### PR TITLE
fix filter manager crash

### DIFF
--- a/source/common/network/filter_manager.h
+++ b/source/common/network/filter_manager.h
@@ -61,9 +61,9 @@ private:
 
   Connection& connection_;
   BufferSource& buffer_source_;
+  Upstream::HostDescriptionPtr host_description_;
   std::list<ActiveReadFilterPtr> upstream_filters_;
   std::list<WriteFilterPtr> downstream_filters_;
-  Upstream::HostDescriptionPtr host_description_;
 };
 
 } // Network


### PR DESCRIPTION
upstream host needs to be available during filter destructors since filters
might use it for accessing stats, etc.
