### PR TITLE
Refactor async client

### DIFF
--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -52,19 +52,18 @@ public:
     virtual void cancel() PURE;
   };
 
-  typedef std::unique_ptr<Request> RequestPtr;
-
   virtual ~AsyncClient() {}
 
   /**
    * Send an HTTP request asynchronously
-   * @param request the request to send
-   * @param callbacks the callbacks to be notified of request status
+   * @param request the request to send.
+   * @param callbacks the callbacks to be notified of request status.
    * @return a request handle or nullptr if no request could be created. NOTE: In this case
-   *         onFailure() has already been called inline.
+   *         onFailure() has already been called inline. The client owns the request and the
+   *         handle should just be used to cancel.
    */
-  virtual RequestPtr send(MessagePtr&& request, Callbacks& callbacks,
-                          const Optional<std::chrono::milliseconds>& timeout) PURE;
+  virtual Request* send(MessagePtr&& request, Callbacks& callbacks,
+                        const Optional<std::chrono::milliseconds>& timeout) PURE;
 };
 
 typedef std::unique_ptr<AsyncClient> AsyncClientPtr;

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -32,17 +32,11 @@ public:
   virtual const Cluster* get(const std::string& cluster) PURE;
 
   /**
-   * @return whether the cluster manager knows about a particular cluster by name.
-   */
-  virtual bool has(const std::string& cluster) PURE;
-
-  /**
    * Allocate a load balanced HTTP connection pool for a cluster. This is *per-thread* so that
    * callers do not need to worry about per thread synchronization. The load balancing policy that
    * is used is the one defined on the cluster when it was created.
    *
-   * Can return nullptr if there is no host available in the cluster or the cluster name is not
-   * valid.
+   * Can return nullptr if there is no host available in the cluster.
    */
   virtual Http::ConnectionPool::Instance* httpConnPoolForCluster(const std::string& cluster) PURE;
 
@@ -52,15 +46,16 @@ public:
    * load balancing policy that is used is the one defined on the cluster when it was created.
    *
    * Returns both a connection and the host that backs the connection. Both can be nullptr if there
-   * is no host available in the cluster or the cluster name is not valid.
+   * is no host available in the cluster.
    */
   virtual Host::CreateConnectionData tcpConnForCluster(const std::string& cluster) PURE;
 
   /**
-   * Returns a client that can be used to make async HTTP calls against the given cluster.  The
-   * client may be backed by a connection pool or by a multiplexed connection.
+   * Returns a client that can be used to make async HTTP calls against the given cluster. The
+   * client may be backed by a connection pool or by a multiplexed connection. The cluster manager
+   * owns the client.
    */
-  virtual Http::AsyncClientPtr httpAsyncClientForCluster(const std::string& cluster) PURE;
+  virtual Http::AsyncClient& httpAsyncClientForCluster(const std::string& cluster) PURE;
 
   /**
    * Shutdown the cluster prior to destroying connection pools and other thread local data.

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -238,8 +238,7 @@ public:
   virtual ResourceManager& resourceManager() const PURE;
 
   /**
-   * Shutdown the cluster manager prior to destroying connection pools and other thread local
-   * data.
+   * Shutdown the cluster prior to destroying connection pools and other thread local data.
    */
   virtual void shutdown() PURE;
 

--- a/source/common/common/linked_object.h
+++ b/source/common/common/linked_object.h
@@ -19,6 +19,11 @@ public:
   }
 
   /**
+   * @return whether the object is currently inserted into a list.
+   */
+  bool inserted() { return inserted_; }
+
+  /**
    * Move a linked item between 2 lists.
    * @param list1 supplies the first list.
    * @param list2 supplies the second list.

--- a/source/common/filter/auth/client_ssl.h
+++ b/source/common/filter/auth/client_ssl.h
@@ -78,13 +78,6 @@ public:
   void onFailure(Http::AsyncClient::FailureReason reason) override;
 
 private:
-  struct ActiveRequest {
-    Http::AsyncClientPtr client_;
-    Http::AsyncClient::RequestPtr request_;
-  };
-
-  typedef std::unique_ptr<ActiveRequest> ActiveRequestPtr;
-
   static GlobalStats generateStats(Stats::Store& store, const std::string& prefix);
   AllowedPrincipalsPtr parseAuthResponse(Http::Message& message);
   void refreshPrincipals();
@@ -94,7 +87,6 @@ private:
   uint32_t tls_slot_;
   Upstream::ClusterManager& cm_;
   const std::string auth_api_cluster_;
-  ActiveRequestPtr active_request_;
   Event::TimerPtr interval_timer_;
   Network::IpWhiteList ip_white_list_;
   GlobalStats stats_;

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -16,7 +16,7 @@ TcpProxyConfig::TcpProxyConfig(const Json::Object& config,
                                Upstream::ClusterManager& cluster_manager, Stats::Store& stats_store)
     : cluster_name_(config.getString("cluster")),
       stats_(generateStats(config.getString("stat_prefix"), stats_store)) {
-  if (!cluster_manager.has(cluster_name_)) {
+  if (!cluster_manager.get(cluster_name_)) {
     throw EnvoyException(fmt::format("tcp proxy: unknown cluster '{}'", cluster_name_));
   }
 }

--- a/source/common/grpc/rpc_channel_impl.h
+++ b/source/common/grpc/rpc_channel_impl.h
@@ -62,8 +62,7 @@ private:
 
   Upstream::ClusterManager& cm_;
   const std::string cluster_;
-  Http::AsyncClientPtr client_;
-  Http::AsyncClient::RequestPtr http_request_;
+  Http::AsyncClient::Request* http_request_{};
   const proto::MethodDescriptor* grpc_method_{};
   proto::Message* grpc_response_{};
   RpcChannelCallbacks& callbacks_;

--- a/source/common/ratelimit/ratelimit_impl.cc
+++ b/source/common/ratelimit/ratelimit_impl.cc
@@ -60,7 +60,7 @@ void GrpcClientImpl::onFailure(const Optional<uint64_t>&, const std::string&) {
 GrpcFactoryImpl::GrpcFactoryImpl(const Json::Object& config, Upstream::ClusterManager& cm,
                                  Stats::Store& stats_store)
     : cluster_name_(config.getString("cluster_name")), cm_(cm), stats_store_(stats_store) {
-  if (!cm_.has(cluster_name_)) {
+  if (!cm_.get(cluster_name_)) {
     throw EnvoyException(fmt::format("unknown rate limit service cluster '{}'", cluster_name_));
   }
 }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -194,7 +194,7 @@ VirtualHost::VirtualHost(const Json::Object& virtual_host, Runtime::Loader& runt
     }
 
     if (!routes_.back()->isRedirect()) {
-      if (!cm.has(routes_.back()->clusterName())) {
+      if (!cm.get(routes_.back()->clusterName())) {
         throw EnvoyException(
             fmt::format("route: unknown cluster '{}'", routes_.back()->clusterName()));
       }

--- a/source/common/stats/statsd.cc
+++ b/source/common/stats/statsd.cc
@@ -60,7 +60,7 @@ TcpStatsdSink::TcpStatsdSink(const std::string& stat_cluster, const std::string&
     : stat_cluster_(stat_cluster), stat_host_(stat_host), cluster_name_(cluster_name), tls_(tls),
       tls_slot_(tls.allocateSlot()), cluster_manager_(cluster_manager) {
 
-  if (!cluster_manager.has(cluster_name)) {
+  if (!cluster_manager.get(cluster_name)) {
     throw EnvoyException(fmt::format("unknown TCP statsd upstream cluster: {}", cluster_name));
   }
 

--- a/source/common/upstream/sds.h
+++ b/source/common/upstream/sds.h
@@ -54,8 +54,7 @@ private:
   const std::string service_name_;
   Runtime::RandomGenerator& random_;
   Event::TimerPtr refresh_timer_;
-  Http::AsyncClientPtr client_;
-  Http::AsyncClient::RequestPtr active_request_;
+  Http::AsyncClient::Request* active_request_{};
   uint64_t pending_health_checks_{};
 };
 

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -82,9 +82,9 @@ void MainImpl::initializeTracers(const Json::Object& tracing_configuration_) {
           StringUtil::rtrim(access_token);
 
           http_tracer_->addSink(Tracing::HttpSinkPtr{new Tracing::LightStepSink(
-              sink.getObject("config"), *cluster_manager_, server_.threadLocal(), "",
-              server_.stats(), server_.random(), server_.options().serviceClusterName(),
-              server_.options().serviceNodeName(), access_token)});
+              sink.getObject("config"), *cluster_manager_, "", server_.stats(), server_.random(),
+              server_.options().serviceClusterName(), server_.options().serviceNodeName(),
+              access_token)});
         } else {
           throw EnvoyException(fmt::format("Unsupported sink type: '{}'", type));
         }

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -25,7 +25,7 @@ TEST(TcpProxyConfigTest, NoCluster) {
 
   Json::StringLoader config(json);
   NiceMock<Upstream::MockClusterManager> cluster_manager;
-  EXPECT_CALL(cluster_manager, has("fake_cluster")).WillOnce(Return(false));
+  EXPECT_CALL(cluster_manager, get("fake_cluster")).WillOnce(Return(nullptr));
   EXPECT_THROW(TcpProxyConfig(config, cluster_manager, cluster_manager.cluster_.stats_store_),
                EnvoyException);
 }
@@ -41,7 +41,6 @@ public:
     )EOF";
 
     Json::StringLoader config(json);
-    EXPECT_CALL(cluster_manager_, has("fake_cluster")).WillOnce(Return(true));
     config_.reset(
         new TcpProxyConfig(config, cluster_manager_, cluster_manager_.cluster_.stats_store_));
   }

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -6,6 +6,7 @@
 #include "test/mocks/common.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/stats/mocks.h"
+#include "test/mocks/upstream/mocks.h"
 
 using testing::_;
 using testing::ByRef;
@@ -15,9 +16,12 @@ using testing::Ref;
 
 namespace Http {
 
-class AsyncClientImplTest : public testing::Test {
+class AsyncClientImplTest : public testing::Test, public AsyncClientConnPoolFactory {
 public:
   AsyncClientImplTest() { HttpTestUtility::addDefaultHeaders(message_->headers()); }
+
+  // Http::AsyncClientConnPoolFactory
+  Http::ConnectionPool::Instance* connPool() override { return &conn_pool_; }
 
   MessagePtr message_{new RequestMessageImpl()};
   MockAsyncClientCallbacks callbacks_;
@@ -27,6 +31,7 @@ public:
   NiceMock<Stats::MockStore> stats_store_;
   NiceMock<Event::MockTimer>* timer_;
   NiceMock<Event::MockDispatcher> dispatcher_;
+  NiceMock<Upstream::MockCluster> cluster_;
 };
 
 TEST_F(AsyncClientImplTest, Basic) {
@@ -45,9 +50,8 @@ TEST_F(AsyncClientImplTest, Basic) {
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(&data), true));
   EXPECT_CALL(callbacks_, onSuccess_(_));
 
-  AsyncClientImpl client(conn_pool_, "fake_cluster", stats_store_, dispatcher_);
-  AsyncClient::RequestPtr request =
-      client.send(std::move(message_), callbacks_, Optional<std::chrono::milliseconds>());
+  AsyncClientImpl client(cluster_, *this, stats_store_, dispatcher_);
+  client.send(std::move(message_), callbacks_, Optional<std::chrono::milliseconds>());
 
   EXPECT_CALL(stats_store_, counter("cluster.fake_cluster.upstream_rq_2xx"));
   EXPECT_CALL(stats_store_, counter("cluster.fake_cluster.upstream_rq_200"));
@@ -59,6 +63,53 @@ TEST_F(AsyncClientImplTest, Basic) {
 
   HeaderMapPtr response_headers(new HeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
+  response_decoder_->decodeData(data, true);
+}
+
+TEST_F(AsyncClientImplTest, MultipleRequests) {
+  // Send request 1
+  message_->body(Buffer::InstancePtr{new Buffer::OwnedImpl("test body")});
+  Buffer::Instance& data = *message_->body();
+
+  EXPECT_CALL(conn_pool_, newStream(_, _))
+      .WillOnce(Invoke([&](StreamDecoder& decoder, ConnectionPool::Callbacks& callbacks)
+                           -> ConnectionPool::Cancellable* {
+                             callbacks.onPoolReady(stream_encoder_, conn_pool_.host_);
+                             response_decoder_ = &decoder;
+                             return nullptr;
+                           }));
+
+  EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(ByRef(message_->headers())), false));
+  EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(&data), true));
+
+  AsyncClientImpl client(cluster_, *this, stats_store_, dispatcher_);
+  client.send(std::move(message_), callbacks_, Optional<std::chrono::milliseconds>());
+
+  // Send request 2.
+  MessagePtr message2{new RequestMessageImpl()};
+  HttpTestUtility::addDefaultHeaders(message2->headers());
+  NiceMock<MockStreamEncoder> stream_encoder2;
+  StreamDecoder* response_decoder2{};
+  MockAsyncClientCallbacks callbacks2;
+  EXPECT_CALL(conn_pool_, newStream(_, _))
+      .WillOnce(Invoke([&](StreamDecoder& decoder, ConnectionPool::Callbacks& callbacks)
+                           -> ConnectionPool::Cancellable* {
+                             callbacks.onPoolReady(stream_encoder2, conn_pool_.host_);
+                             response_decoder2 = &decoder;
+                             return nullptr;
+                           }));
+  EXPECT_CALL(stream_encoder2, encodeHeaders(HeaderMapEqualRef(ByRef(message2->headers())), true));
+  client.send(std::move(message2), callbacks2, Optional<std::chrono::milliseconds>());
+
+  // Finish request 2.
+  HeaderMapPtr response_headers2(new HeaderMapImpl{{":status", "503"}});
+  EXPECT_CALL(callbacks2, onSuccess_(_));
+  response_decoder2->decodeHeaders(std::move(response_headers2), true);
+
+  // Finish request 1.
+  HeaderMapPtr response_headers(new HeaderMapImpl{{":status", "200"}});
+  response_decoder_->decodeHeaders(std::move(response_headers), false);
+  EXPECT_CALL(callbacks_, onSuccess_(_));
   response_decoder_->decodeData(data, true);
 }
 
@@ -78,9 +129,8 @@ TEST_F(AsyncClientImplTest, Trailers) {
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(&data), true));
   EXPECT_CALL(callbacks_, onSuccess_(_));
 
-  AsyncClientImpl client(conn_pool_, "fake_cluster", stats_store_, dispatcher_);
-  AsyncClient::RequestPtr request =
-      client.send(std::move(message_), callbacks_, Optional<std::chrono::milliseconds>());
+  AsyncClientImpl client(cluster_, *this, stats_store_, dispatcher_);
+  client.send(std::move(message_), callbacks_, Optional<std::chrono::milliseconds>());
   HeaderMapPtr response_headers(new HeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
   response_decoder_->decodeData(data, false);
@@ -103,9 +153,8 @@ TEST_F(AsyncClientImplTest, FailRequest) {
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(ByRef(message_->headers())), true));
   EXPECT_CALL(callbacks_, onFailure(Http::AsyncClient::FailureReason::Reset));
 
-  AsyncClientImpl client(conn_pool_, "fake_cluster", stats_store_, dispatcher_);
-  AsyncClient::RequestPtr request =
-      client.send(std::move(message_), callbacks_, Optional<std::chrono::milliseconds>());
+  AsyncClientImpl client(cluster_, *this, stats_store_, dispatcher_);
+  client.send(std::move(message_), callbacks_, Optional<std::chrono::milliseconds>());
   stream_encoder_.getStream().resetStream(StreamResetReason::RemoteReset);
 }
 
@@ -120,8 +169,8 @@ TEST_F(AsyncClientImplTest, CancelRequest) {
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(ByRef(message_->headers())), true));
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
 
-  AsyncClientImpl client(conn_pool_, "fake_cluster", stats_store_, dispatcher_);
-  AsyncClient::RequestPtr request =
+  AsyncClientImpl client(cluster_, *this, stats_store_, dispatcher_);
+  AsyncClient::Request* request =
       client.send(std::move(message_), callbacks_, Optional<std::chrono::milliseconds>());
   request->cancel();
 }
@@ -141,7 +190,7 @@ TEST_F(AsyncClientImplTest, PoolFailure) {
       }));
 
   EXPECT_CALL(callbacks_, onFailure(Http::AsyncClient::FailureReason::Reset));
-  AsyncClientImpl client(conn_pool_, "fake_cluster", stats_store_, dispatcher_);
+  AsyncClientImpl client(cluster_, *this, stats_store_, dispatcher_);
   EXPECT_EQ(nullptr,
             client.send(std::move(message_), callbacks_, Optional<std::chrono::milliseconds>()));
 }
@@ -151,7 +200,6 @@ TEST_F(AsyncClientImplTest, RequestTimeout) {
   EXPECT_CALL(stats_store_, counter("cluster.fake_cluster.upstream_rq_504"));
   EXPECT_CALL(stats_store_, counter("cluster.fake_cluster.internal.upstream_rq_5xx"));
   EXPECT_CALL(stats_store_, counter("cluster.fake_cluster.internal.upstream_rq_504"));
-  EXPECT_CALL(stats_store_, counter("cluster.fake_cluster.upstream_rq_timeout"));
   EXPECT_CALL(conn_pool_, newStream(_, _))
       .WillOnce(Invoke([&](StreamDecoder&, ConnectionPool::Callbacks& callbacks)
                            -> ConnectionPool::Cancellable* {
@@ -164,10 +212,11 @@ TEST_F(AsyncClientImplTest, RequestTimeout) {
   timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
   EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(40)));
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
-  AsyncClientImpl client(conn_pool_, "fake_cluster", stats_store_, dispatcher_);
-  AsyncClient::RequestPtr request =
-      client.send(std::move(message_), callbacks_, std::chrono::milliseconds(40));
+  AsyncClientImpl client(cluster_, *this, stats_store_, dispatcher_);
+  client.send(std::move(message_), callbacks_, std::chrono::milliseconds(40));
   timer_->callback_();
+
+  EXPECT_EQ(1UL, cluster_.stats_store_.counter("cluster.fake_cluster.upstream_rq_timeout").value());
 }
 
 TEST_F(AsyncClientImplTest, DisableTimer) {
@@ -183,8 +232,8 @@ TEST_F(AsyncClientImplTest, DisableTimer) {
   EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(200)));
   EXPECT_CALL(*timer_, disableTimer());
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
-  AsyncClientImpl client(conn_pool_, "fake_cluster", stats_store_, dispatcher_);
-  AsyncClient::RequestPtr request =
+  AsyncClientImpl client(cluster_, *this, stats_store_, dispatcher_);
+  AsyncClient::Request* request =
       client.send(std::move(message_), callbacks_, std::chrono::milliseconds(200));
   request->cancel();
 }

--- a/test/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/common/ratelimit/ratelimit_impl_test.cc
@@ -112,7 +112,7 @@ TEST(RateLimitGrpcFactoryTest, NoCluster) {
   Upstream::MockClusterManager cm;
   Stats::IsolatedStoreImpl stats_store;
 
-  EXPECT_CALL(cm, has("foo")).WillOnce(Return(false));
+  EXPECT_CALL(cm, get("foo")).WillOnce(Return(nullptr));
   EXPECT_THROW(GrpcFactoryImpl(config, cm, stats_store), EnvoyException);
 }
 
@@ -127,7 +127,7 @@ TEST(RateLimitGrpcFactoryTest, Create) {
   Upstream::MockClusterManager cm;
   Stats::IsolatedStoreImpl stats_store;
 
-  EXPECT_CALL(cm, has("foo")).WillOnce(Return(true));
+  EXPECT_CALL(cm, get("foo"));
   GrpcFactoryImpl factory(config, cm, stats_store);
   factory.create(Optional<std::chrono::milliseconds>());
 }

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -146,7 +146,6 @@ TEST(RouteMatcherTest, TestRoutes) {
   Json::StringLoader loader(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
-  ON_CALL(cm, has(_)).WillByDefault(Return(true));
   ConfigImpl config(loader, runtime, cm);
 
   // Base routing testing.
@@ -351,7 +350,6 @@ TEST(RouteMatcherTest, ContentType) {
   Json::StringLoader loader(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
-  ON_CALL(cm, has(_)).WillByDefault(Return(true));
   ConfigImpl config(loader, runtime, cm);
 
   {
@@ -403,7 +401,6 @@ TEST(RouteMatcherTest, Runtime) {
   NiceMock<Upstream::MockClusterManager> cm;
   Runtime::MockSnapshot snapshot;
 
-  ON_CALL(cm, has(_)).WillByDefault(Return(true));
   ON_CALL(runtime, snapshot()).WillByDefault(ReturnRef(snapshot));
 
   ConfigImpl config(loader, runtime, cm);
@@ -445,7 +442,6 @@ TEST(RouteMatcherTest, RateLimit) {
   Json::StringLoader loader(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
-  ON_CALL(cm, has(_)).WillByDefault(Return(true));
   ConfigImpl config(loader, runtime, cm);
 
   EXPECT_TRUE(config.routeForRequest(genHeaders("www.lyft.com", "/foo", "GET"), 0)
@@ -492,7 +488,6 @@ TEST(RouteMatcherTest, Retry) {
   Json::StringLoader loader(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
-  ON_CALL(cm, has(_)).WillByDefault(Return(true));
   ConfigImpl config(loader, runtime, cm);
 
   EXPECT_EQ(1U, config.routeForRequest(genHeaders("www.lyft.com", "/foo", "GET"), 0)
@@ -619,7 +614,6 @@ TEST(RouteMatcherTest, Redirect) {
   Json::StringLoader loader(json);
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
-  ON_CALL(cm, has(StrNe(""))).WillByDefault(Return(true));
   ConfigImpl config(loader, runtime, cm);
 
   EXPECT_EQ(nullptr,

--- a/test/common/stats/statsd_test.cc
+++ b/test/common/stats/statsd_test.cc
@@ -16,7 +16,7 @@ namespace Statsd {
 class TcpStatsdSinkTest : public testing::Test {
 public:
   TcpStatsdSinkTest() {
-    EXPECT_CALL(cluster_manager_, has(_)).WillOnce(Return(true));
+    EXPECT_CALL(cluster_manager_, get("statsd"));
     sink_.reset(new TcpStatsdSink("cluster", "host", "statsd", tls_, cluster_manager_));
   }
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -281,9 +281,9 @@ public:
   MOCK_METHOD0(onRequestDestroy, void());
 
   // Http::AsyncClient
-  RequestPtr send(MessagePtr&& request, Callbacks& callbacks,
-                  const Optional<std::chrono::milliseconds>& timeout) override {
-    return RequestPtr{send_(request, callbacks, timeout)};
+  Request* send(MessagePtr&& request, Callbacks& callbacks,
+                const Optional<std::chrono::milliseconds>& timeout) override {
+    return send_(request, callbacks, timeout);
   }
 
   MOCK_METHOD3(send_, Request*(MessagePtr& request, Callbacks& callbacks,

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -66,22 +66,18 @@ public:
     return {Network::ClientConnectionPtr{data.connection_}, data.host_};
   }
 
-  Http::AsyncClientPtr httpAsyncClientForCluster(const std::string& cluster) override {
-    return Http::AsyncClientPtr{httpAsyncClientForCluster_(cluster)};
-  }
-
   // Upstream::ClusterManager
   MOCK_METHOD1(setInitializedCb, void(std::function<void()>));
   MOCK_METHOD0(clusters, std::unordered_map<std::string, ConstClusterPtr>());
   MOCK_METHOD1(get, const Cluster*(const std::string& cluster));
-  MOCK_METHOD1(has, bool(const std::string& cluster));
   MOCK_METHOD1(httpConnPoolForCluster, Http::ConnectionPool::Instance*(const std::string& cluster));
   MOCK_METHOD1(tcpConnForCluster_, MockHost::MockCreateConnectionData(const std::string& cluster));
-  MOCK_METHOD1(httpAsyncClientForCluster_, Http::AsyncClient*(const std::string& cluster));
+  MOCK_METHOD1(httpAsyncClientForCluster, Http::AsyncClient&(const std::string& cluster));
   MOCK_METHOD0(shutdown, void());
 
   NiceMock<Http::ConnectionPool::MockInstance> conn_pool_;
   NiceMock<MockCluster> cluster_;
+  NiceMock<Http::MockAsyncClient> async_client_;
 };
 
 class MockHealthChecker : public HealthChecker {


### PR DESCRIPTION
This change refactors async client so that it is owned by the cluster
manager. Now users can just send requests and fire and forget if they
don't need to cancel. This makes a lot of the consumers much simpler.
The fire and forget functionality will be used for router request
shadowing (similar to the HTTP tracer).
