### PR TITLE
added support for regex route matching

### DIFF
--- a/docs/configuration/http_conn_man/route_config/route.rst
+++ b/docs/configuration/http_conn_man/route_config/route.rst
@@ -11,6 +11,7 @@ next (e.g., redirect, forward, rewrite, etc.).
   {
     "prefix": "...",
     "path": "...",
+    "regex": "...",
     "cluster": "...",
     "cluster_header": "...",
     "weighted_clusters" : "{...}",
@@ -36,12 +37,27 @@ next (e.g., redirect, forward, rewrite, etc.).
 
 prefix
   *(sometimes required, string)* If specified, the route is a prefix rule meaning that the prefix
-  must match the beginning of the :path header. Either *prefix* or *path* must be specified.
+  must match the beginning of the :path header. One of *prefix*, *path*, or *regex* must be specified.
 
 path
   *(sometimes required, string)* If specified, the route is an exact path rule meaning that the path
-  must exactly match the :path header once the query string is removed. Either *prefix* or *path*
-  must be specified.
+  must exactly match the :path header once the query string is removed. One of *prefix*, *path*, or
+  *regex* must be specified.
+
+regex
+  *(sometimes required, string)* If specified, the route is a regular expression rule meaning that the
+  regex must match the :path header once the query string is removed. The entire path (without the
+  query string) must match the regex. The rule will not match if only a subsequence of the :path header
+  matches the regex. The regex grammar is defined `here
+  <http://en.cppreference.com/w/cpp/regex/ecmascript>`_. One of *prefix*, *path*, or
+  *regex* must be specified.
+
+  Examples:
+
+    * The regex */b[io]t* matches the path */bit*
+    * The regex */b[io]t* matches the path */bot*
+    * The regex */b[io]t* does not match the path */bite*
+    * The regex */b[io]t* does not match the path */bit/bot*
 
 .. _config_http_conn_man_route_table_route_cluster:
 
@@ -96,8 +112,9 @@ path_redirect
 
 prefix_rewrite
   *(optional, string)* Indicates that during forwarding, the matched prefix (or path) should be
-  swapped with this value. This option allows application URLs to be rooted at a different path
-  from those exposed at the reverse proxy layer.
+  swapped with this value. When using regex path matching, the entire path (not including
+  the query string) will be swapped with this value. This option allows application URLs to be
+  rooted at a different path from those exposed at the reverse proxy layer.
 
 .. _config_http_conn_man_route_table_route_host_rewrite:
 
@@ -309,8 +326,16 @@ value
 
 regex
   *(optional, boolean)* Specifies whether the header value is a regular
-  expression or not. Defaults to false. The regex grammar used in the value field
-  is defined `here <http://en.cppreference.com/w/cpp/regex/ecmascript>`_.
+  expression or not. Defaults to false. The entire request header value must match the regex. The
+  rule will not match if only a subsequence of the request header value matches the regex. The
+  regex grammar used in the value field is defined
+  `here <http://en.cppreference.com/w/cpp/regex/ecmascript>`_.
+
+  Examples:
+
+    * The regex *\d{3}* matches the value *123*
+    * The regex *\d{3}* does not match the value *1234*
+    * The regex *\d{3}* does not match the value *123.456*
 
 .. attention::
 

--- a/docs/configuration/http_conn_man/route_config/vcluster.rst
+++ b/docs/configuration/http_conn_man/route_config/vcluster.rst
@@ -26,8 +26,8 @@ such that they include network level failures.
   }
 
 pattern
-  *(required, string)* Specifies a regex pattern to use for matching requests. The regex grammar
-  used is defined `here <http://en.cppreference.com/w/cpp/regex/ecmascript>`_.
+  *(required, string)* Specifies a regex pattern to use for matching requests. The entire path of the request
+  must match the regex. The regex grammar used is defined `here <http://en.cppreference.com/w/cpp/regex/ecmascript>`_.
 
 name
   *(required, string)* Specifies the name of the virtual cluster. The virtual cluster name as well
@@ -37,5 +37,11 @@ name
 method
   *(optional, string)* Optionally specifies the HTTP method to match on. For example *GET*, *PUT*,
   etc.
+
+  Examples:
+
+    * The regex */rides/\d+* matches the path */rides/0*
+    * The regex */rides/\d+* matches the path */rides/123*
+    * The regex */rides/\d+* does not match the path */rides/123/456*
 
 Documentation for :ref:`virtual cluser statistics <config_http_filters_router_stats>`.

--- a/source/common/config/rds_json.cc
+++ b/source/common/config/rds_json.cc
@@ -156,14 +156,19 @@ void RdsJson::translateRoute(const Json::Object& json_route, envoy::api::v2::Rou
 
   auto* match = route.mutable_match();
 
+  // This is a trick to do a three-way XOR.
+  if ((json_route.hasObject("prefix") + json_route.hasObject("path") +
+       json_route.hasObject("regex")) != 1) {
+    throw EnvoyException("routes must specify one of prefix/path/regex");
+  }
+
   if (json_route.hasObject("prefix")) {
     match->set_prefix(json_route.getString("prefix"));
-  }
-  if (json_route.hasObject("path")) {
-    if (json_route.hasObject("prefix")) {
-      throw EnvoyException("routes must specify either prefix or path");
-    }
+  } else if (json_route.hasObject("path")) {
     match->set_path(json_route.getString("path"));
+  } else {
+    ASSERT(json_route.hasObject("regex"));
+    match->set_regex(json_route.getString("regex"));
   }
 
   JSON_UTIL_SET_BOOL(json_route, *match, case_sensitive);

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -71,6 +71,10 @@ Utility::QueryParams Utility::parseQueryString(const std::string& url) {
   return params;
 }
 
+const char* Utility::findQueryStringStart(const HeaderString& path) {
+  return std::find(path.c_str(), path.c_str() + path.size(), '?');
+}
+
 std::string Utility::parseCookieValue(const HeaderMap& headers, const std::string& key) {
 
   struct State {

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -42,6 +42,14 @@ public:
   static QueryParams parseQueryString(const std::string& url);
 
   /**
+   * Finds the start of the query string in a path
+   * @param path supplies a HeaderString& to search for the query string
+   * @return const char* a pointer to the beginning of the query string, or the end of the
+   *         path if there is no query
+   */
+  static const char* findQueryStringStart(const HeaderString& path);
+
+  /**
    * Parse a particular value out of a cookie
    * @param headers supplies the headers to get the cookie from.
    * @param key the key for the particular cookie value to return

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -637,6 +637,7 @@ const std::string Json::Schema::ROUTE_ENTRY_CONFIGURATION_SCHEMA(R"EOF(
     "properties" : {
       "prefix" : {"type" : "string"},
       "path" : {"type" : "string"},
+      "regex" : {"type" : "string"},
       "cluster" : {"type" : "string"},
       "cluster_header" : {"type" : "string"},
       "weighted_clusters": {"$ref" : "#/definitions/weighted_clusters"},

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -359,7 +359,7 @@ RouteConstSharedPtr PathRouteEntryImpl::matches(const Http::HeaderMap& headers,
                                                 uint64_t random_value) const {
   if (RouteEntryImplBase::matchRoute(headers, random_value)) {
     const Http::HeaderString& path = headers.Path()->value();
-    const char* query_string_start = strchr(path.c_str(), '?');
+    const char* query_string_start = Http::Utility::findQueryStringStart(path);
     size_t compare_length = path.size();
     if (query_string_start != nullptr) {
       compare_length = query_string_start - path.c_str();
@@ -380,6 +380,34 @@ RouteConstSharedPtr PathRouteEntryImpl::matches(const Http::HeaderMap& headers,
     }
   }
 
+  return nullptr;
+}
+
+RegexRouteEntryImpl::RegexRouteEntryImpl(const VirtualHostImpl& vhost,
+                                         const envoy::api::v2::Route& route,
+                                         Runtime::Loader& loader)
+    : RouteEntryImplBase(vhost, route, loader),
+      regex_(std::regex{route.match().regex(), std::regex::optimize}) {}
+
+void RegexRouteEntryImpl::finalizeRequestHeaders(Http::HeaderMap& headers) const {
+  RouteEntryImplBase::finalizeRequestHeaders(headers);
+
+  const Http::HeaderString& path = headers.Path()->value();
+  const char* query_string_start = Http::Utility::findQueryStringStart(path);
+  ASSERT(std::regex_match(path.c_str(), query_string_start, regex_));
+  std::string matched_path(path.c_str(), query_string_start);
+  finalizePathHeader(headers, matched_path);
+}
+
+RouteConstSharedPtr RegexRouteEntryImpl::matches(const Http::HeaderMap& headers,
+                                                 uint64_t random_value) const {
+  if (RouteEntryImplBase::matchRoute(headers, random_value)) {
+    const Http::HeaderString& path = headers.Path()->value();
+    const char* query_string_start = Http::Utility::findQueryStringStart(path);
+    if (std::regex_match(path.c_str(), query_string_start, regex_)) {
+      return clusterEntry(headers, random_value);
+    }
+  }
   return nullptr;
 }
 
@@ -411,12 +439,16 @@ VirtualHostImpl::VirtualHostImpl(const envoy::api::v2::VirtualHost& virtual_host
     const bool has_prefix =
         route.match().path_specifier_case() == envoy::api::v2::RouteMatch::kPrefix;
     const bool has_path = route.match().path_specifier_case() == envoy::api::v2::RouteMatch::kPath;
+    const bool has_regex =
+        route.match().path_specifier_case() == envoy::api::v2::RouteMatch::kRegex;
     if (has_prefix) {
       routes_.emplace_back(new PrefixRouteEntryImpl(*this, route, runtime));
-    } else {
-      ASSERT(has_path);
-      UNREFERENCED_PARAMETER(has_path);
+    } else if (has_path) {
       routes_.emplace_back(new PathRouteEntryImpl(*this, route, runtime));
+    } else {
+      ASSERT(has_regex);
+      UNREFERENCED_PARAMETER(has_regex);
+      routes_.emplace_back(new RegexRouteEntryImpl(*this, route, runtime));
     }
 
     if (validate_clusters) {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -374,6 +374,24 @@ private:
 };
 
 /**
+ * Route entry implementation for regular expression match routing.
+ */
+class RegexRouteEntryImpl : public RouteEntryImplBase {
+public:
+  RegexRouteEntryImpl(const VirtualHostImpl& vhost, const envoy::api::v2::Route& route,
+                      Runtime::Loader& loader);
+
+  // Router::RouteEntry
+  void finalizeRequestHeaders(Http::HeaderMap& headers) const override;
+
+  // Router::Matchable
+  RouteConstSharedPtr matches(const Http::HeaderMap& headers, uint64_t random_value) const override;
+
+private:
+  const std::regex regex_;
+};
+
+/**
  * Wraps the route configuration which matches an incoming request headers to a backend cluster.
  * This is split out mainly to help with unit testing.
  */


### PR DESCRIPTION
In addition to prefix matching and path matching, regex matching is now supported for route matching. Like before, a list of routes will be tested in order against incoming requests. The first route that matches will be used, whether it is a prefix, path, or regex.

- implemented RegexRouteEntryImpl
- added regex to route entry JSON schema
- added unit testing for regex route matching
- updated documentation

Fixes #1425  