### PR TITLE
port a bunch of integration tests to using protobufs.

### DIFF
--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -102,13 +102,15 @@ public:
   const std::string RATE_LIMIT = "envoy.rate_limit";
   // Router filter
   const std::string ROUTER = "envoy.router";
+  // Health checking filter
+  const std::string HEALTH_CHECK = "envoy.health_check";
 
   // Converts names from v1 to v2
   const V1Converter v1_converter_;
 
   HttpFilterNameValues()
       : v1_converter_({BUFFER, CORS, DYNAMO, FAULT, GRPC_HTTP1_BRIDGE, GRPC_JSON_TRANSCODER,
-                       GRPC_WEB, IP_TAGGING, RATE_LIMIT, ROUTER}) {}
+                       GRPC_WEB, HEALTH_CHECK, IP_TAGGING, RATE_LIMIT, ROUTER}) {}
 };
 
 typedef ConstSingleton<HttpFilterNameValues> HttpFilterNames;

--- a/source/server/http/health_check.h
+++ b/source/server/http/health_check.h
@@ -17,7 +17,7 @@ class HealthCheckFilterConfig : public NamedHttpFilterConfigFactory {
 public:
   HttpFilterFactoryCb createFilterFactory(const Json::Object& config, const std::string&,
                                           FactoryContext& context) override;
-  std::string name() override { return "health_check"; }
+  std::string name() override { return "envoy.health_check"; }
 };
 
 } // namespace Configuration

--- a/test/config/BUILD
+++ b/test/config/BUILD
@@ -25,5 +25,6 @@ envoy_cc_test_library(
         "//source/common/protobuf:utility_lib",
         "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
+        "//test/test_common:utility_lib",
     ],
 )

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -225,7 +225,7 @@ void ConfigHelper::addConfigModifier(ConfigModifierFunction function) {
 }
 
 void ConfigHelper::addConfigModifier(HttpModifierFunction function) {
-  addConfigModifier([=](envoy::api::v2::Bootstrap&) -> void {
+  addConfigModifier([function, this](envoy::api::v2::Bootstrap&) -> void {
     envoy::api::v2::filter::HttpConnectionManager hcm_config;
     loadHttpConnectionManager(hcm_config);
     function(hcm_config);

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -8,6 +8,9 @@
 #include "api/base.pb.h"
 #include "api/bootstrap.pb.h"
 #include "api/cds.pb.h"
+#include "api/filter/http_connection_manager.pb.h"
+#include "api/protocol.pb.h"
+#include "api/rds.pb.h"
 
 namespace Envoy {
 
@@ -17,19 +20,66 @@ public:
   // and admin connections.
   ConfigHelper(const Network::Address::IpVersion version);
 
-  // Set the upstream ports.  The size of this vector must match the number of socket addresses
-  // across all configured clusters.
-  void setUpstreamPorts(const std::vector<uint32_t>& ports);
+  typedef std::function<void(envoy::api::v2::Bootstrap&)> ConfigModifierFunction;
+  typedef std::function<void(envoy::api::v2::filter::HttpConnectionManager&)> HttpModifierFunction;
+
+  // A string for a basic buffer filter, which can be used with addFilter()
+  static const std::string DEFAULT_BUFFER_FILTER;
+  // a string for a health check filter which can be used with addFilter()
+  static const std::string DEFAULT_HEALTH_CHECK_FILTER;
+
+  // Run the final config modifiers, and then set the upstream ports based on upstream connections.
+  // This is the last operation run on |bootstrap_| before it is handed to Envoy.
+  // Ports are assigned by looping through clusters, hosts, and addresses in the
+  // order they are stored in |bootstrap_|
+  void finalize(const std::vector<uint32_t>& ports);
 
   // Set source_address in the bootstrap bind config.
   void setSourceAddress(const std::string& address_string);
+
+  // Overwrite the first host and route for the primary listener.
+  void setDefaultHostAndRoute(const std::string& host, const std::string& route);
+
+  // Sets byte limits on upstream and downstream connections.
+  void setBufferLimits(uint32_t upstream_buffer_limit, uint32_t downstream_buffer_limit);
+
+  // Add an additional route to the configuration.
+  void addRoute(
+      const std::string& host, const std::string& route, const std::string& cluster,
+      envoy::api::v2::VirtualHost::TlsRequirementType type = envoy::api::v2::VirtualHost::NONE);
+
+  // Add an HTTP filter prior to existing filters.
+  void addFilter(const std::string& filter_yaml);
+
+  // Sets the client codec to the specified type.
+  void setClientCodec(envoy::api::v2::filter::HttpConnectionManager::CodecType type);
+
+  // Allows callers to do their own modification to |bootstrap_| which will be
+  // applied just before ports are modified in finalize().
+  void addConfigModifier(ConfigModifierFunction function);
+
+  // Allows callers to easily modify the HttpConnectionManager configuration.
+  // Mofidiers will be applied just before ports are modified in finalize
+  void addConfigModifier(HttpModifierFunction function);
 
   // Return the bootstrap configuration for hand-off to Envoy.
   const envoy::api::v2::Bootstrap& bootstrap() { return bootstrap_; }
 
 private:
+  // Load the first HCM struct from the first listener into a parsed proto.
+  void loadHttpConnectionManager(envoy::api::v2::filter::HttpConnectionManager& hcm);
+  // Stick the contents of the procided HCM proto and stuff them into the first HCM
+  // struct of the first listener.
+  void storeHttpConnectionManager(const envoy::api::v2::filter::HttpConnectionManager& hcm);
+
   // The bootstrap proto Envoy will start up with.
   envoy::api::v2::Bootstrap bootstrap_;
+
+  // The config modifiers added via addConfigModifier() which will be applied in finalize()
+  std::vector<ConfigModifierFunction> config_modifiers_;
+
+  // A sanity check guard to make sure config is not modified after handing it to Envoy.
+  bool finalized_{false};
 };
 
 } // namespace Envoy

--- a/test/integration/cors_filter_integration_test.cc
+++ b/test/integration/cors_filter_integration_test.cc
@@ -9,21 +9,12 @@ class CorsFilterIntegrationTest : public HttpIntegrationTest,
                                   public testing::TestWithParam<Network::Address::IpVersion> {
 public:
   CorsFilterIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
-  /**
-   * Global initializer for all integration tests.
-   */
-  void SetUp() override {
+
+  void initialize() override {
+    BaseIntegrationTest::initialize();
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
     createTestServer("test/config/integration/server_cors_filter.json", {"http"});
-  }
-
-  /**
-   * Global destructor for all integration tests.
-   */
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
   }
 
 protected:

--- a/test/integration/http2_integration_test.h
+++ b/test/integration/http2_integration_test.h
@@ -9,27 +9,9 @@ class Http2IntegrationTest : public HttpIntegrationTest,
                              public testing::TestWithParam<Network::Address::IpVersion> {
 public:
   Http2IntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP2, GetParam()) {}
-  /**
-   * Initializer for an individual test.
-   */
-  void SetUp() override {
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
-    registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
-    registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
-    createTestServer(
-        "test/config/integration/server_http2.json",
-        {"echo", "http", "http_buffer", "http_with_buffer_limits", "dynamo_with_buffer_limits"});
-  }
 
-  void simultaneousRequest(uint32_t port, int32_t request1_bytes, int32_t request2_bytes);
+  void SetUp() override { setDownstreamProtocol(Http::CodecClient::Type::HTTP2); }
 
-  /**
-   * Destructor for an individual test test.
-   */
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
+  void simultaneousRequest(int32_t request1_bytes, int32_t request2_bytes);
 };
 } // namespace Envoy

--- a/test/integration/http2_upstream_integration_test.h
+++ b/test/integration/http2_upstream_integration_test.h
@@ -10,31 +10,15 @@ class Http2UpstreamIntegrationTest : public HttpIntegrationTest,
 public:
   Http2UpstreamIntegrationTest()
       : HttpIntegrationTest(Http::CodecClient::Type::HTTP2, GetParam()) {}
-  /**
-   * Initializer for an individual test.
-   */
+
   void SetUp() override {
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_));
-    registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_));
-    registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_));
-    registerPort("upstream_3", fake_upstreams_.back()->localAddress()->ip()->port());
-    createTestServer("test/config/integration/server_http2_upstream.json",
-                     {"http", "http_buffer", "http1_buffer", "http_with_buffer_limits"});
+    setDownstreamProtocol(Http::CodecClient::Type::HTTP2);
+    setUpstreamProtocol(FakeHttpConnection::Type::HTTP2);
   }
 
-  void bidirectionalStreaming(uint32_t port, uint32_t bytes);
-  void simultaneousRequest(uint32_t port, uint32_t request1_bytes, uint32_t request2_bytes,
+  void bidirectionalStreaming(uint32_t bytes);
+  void simultaneousRequest(uint32_t request1_bytes, uint32_t request2_bytes,
                            uint32_t response1_bytes, uint32_t response2_bytes);
-  void manySimultaneousRequests(uint32_t port, uint32_t request_bytes, uint32_t response_bytes);
-
-  /**
-   * Destructor for an individual test.
-   */
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
+  void manySimultaneousRequests(uint32_t request_bytes, uint32_t response_bytes);
 };
 } // namespace Envoy

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -151,7 +151,6 @@ void HttpIntegrationTest::TearDown() {
 
 void HttpIntegrationTest::initialize() {
   BaseIntegrationTest::initialize();
-
   createUpstreams();
 
   config_helper_.finalize(ports_);
@@ -178,8 +177,8 @@ HttpIntegrationTest::makeHttpConnection(Network::ClientConnectionPtr&& conn) {
   std::shared_ptr<Upstream::MockClusterInfo> cluster{new NiceMock<Upstream::MockClusterInfo>()};
   Upstream::HostDescriptionConstSharedPtr host_description{Upstream::makeTestHostDescription(
       cluster, fmt::format("tcp://{}:80", Network::Test::getLoopbackAddressUrlString(version_)))};
-  return IntegrationCodecClientPtr{new IntegrationCodecClient(*dispatcher_, std::move(conn),
-                                                              host_description, downstream_protocol_)};
+  return IntegrationCodecClientPtr{new IntegrationCodecClient(
+      *dispatcher_, std::move(conn), host_description, downstream_protocol_)};
 }
 
 HttpIntegrationTest::HttpIntegrationTest(Http::CodecClient::Type downstream_protocol,

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -15,6 +15,7 @@
 #include "common/buffer/buffer_impl.h"
 #include "common/network/connection_impl.h"
 #include "common/network/utility.h"
+#include "common/protobuf/utility.h"
 #include "common/upstream/upstream_impl.h"
 
 #include "test/common/upstream/utility.h"
@@ -37,6 +38,25 @@ std::string normalizeDate(const std::string& s) {
   const std::regex date_regex("date:[^\r]+");
   return std::regex_replace(s, date_regex, "date: Mon, 01 Jan 2017 00:00:00 GMT");
 }
+
+void setAllowAbsoluteUrl(envoy::api::v2::filter::HttpConnectionManager& hcm) {
+  envoy::api::v2::Http1ProtocolOptions options;
+  options.mutable_allow_absolute_url()->set_value(true);
+  hcm.mutable_http_protocol_options()->CopyFrom(options);
+};
+
+envoy::api::v2::filter::HttpConnectionManager::CodecType
+typeToCodecType(Http::CodecClient::Type type) {
+  switch (type) {
+  case Http::CodecClient::Type::HTTP1:
+    return envoy::api::v2::filter::HttpConnectionManager::HTTP1;
+  case Http::CodecClient::Type::HTTP2:
+    return envoy::api::v2::filter::HttpConnectionManager::HTTP2;
+  default:
+    RELEASE_ASSERT(0);
+  }
+}
+
 } // namespace
 
 IntegrationCodecClient::IntegrationCodecClient(
@@ -120,6 +140,35 @@ void IntegrationCodecClient::ConnectionCallbacks::onEvent(Network::ConnectionEve
   }
 }
 
+void HttpIntegrationTest::SetUp() {
+  config_helper_.setClientCodec(typeToCodecType(downstream_protocol_));
+}
+
+void HttpIntegrationTest::TearDown() {
+  test_server_.reset();
+  fake_upstreams_.clear();
+}
+
+void HttpIntegrationTest::initialize() {
+  BaseIntegrationTest::initialize();
+
+  createUpstreams();
+
+  config_helper_.finalize(ports_);
+
+  ENVOY_LOG_MISC(debug, "Running Envoy with configuration {}",
+                 config_helper_.bootstrap().DebugString());
+
+  const std::string bootstrap_path = TestEnvironment::writeStringToFileForTest(
+      "bootstrap.json", MessageUtil::getJsonStringFromMessage(config_helper_.bootstrap()));
+  createGeneratedApiTestServer(bootstrap_path, named_ports_);
+}
+
+void HttpIntegrationTest::createUpstreams() {
+  fake_upstreams_.emplace_back(new FakeUpstream(0, upstream_protocol_, version_));
+  ports_.push_back(fake_upstreams_.back()->localAddress()->ip()->port());
+}
+
 IntegrationCodecClientPtr HttpIntegrationTest::makeHttpConnection(uint32_t port) {
   return makeHttpConnection(makeClientConnection(port));
 }
@@ -130,12 +179,30 @@ HttpIntegrationTest::makeHttpConnection(Network::ClientConnectionPtr&& conn) {
   Upstream::HostDescriptionConstSharedPtr host_description{Upstream::makeTestHostDescription(
       cluster, fmt::format("tcp://{}:80", Network::Test::getLoopbackAddressUrlString(version_)))};
   return IntegrationCodecClientPtr{new IntegrationCodecClient(*dispatcher_, std::move(conn),
-                                                              host_description, client_protocol_)};
+                                                              host_description, downstream_protocol_)};
 }
 
-HttpIntegrationTest::HttpIntegrationTest(Http::CodecClient::Type client_protocol,
+HttpIntegrationTest::HttpIntegrationTest(Http::CodecClient::Type downstream_protocol,
                                          Network::Address::IpVersion version)
-    : BaseIntegrationTest(version), client_protocol_(client_protocol) {}
+    : BaseIntegrationTest(version), downstream_protocol_(downstream_protocol) {}
+
+void HttpIntegrationTest::setDownstreamProtocol(Http::CodecClient::Type downstream_protocol) {
+  downstream_protocol_ = downstream_protocol;
+  config_helper_.setClientCodec(typeToCodecType(downstream_protocol_));
+}
+
+void HttpIntegrationTest::setUpstreamProtocol(FakeHttpConnection::Type protocol) {
+  upstream_protocol_ = protocol;
+  if (upstream_protocol_ == FakeHttpConnection::Type::HTTP2) {
+    config_helper_.addConfigModifier([&](envoy::api::v2::Bootstrap& bootstrap) -> void {
+      RELEASE_ASSERT(bootstrap.mutable_static_resources()->clusters_size() == 1);
+      auto* cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
+      cluster->mutable_http2_protocol_options();
+    });
+  } else {
+    RELEASE_ASSERT(protocol == FakeHttpConnection::Type::HTTP1);
+  }
+}
 
 void HttpIntegrationTest::sendRequestAndWaitForResponse(Http::TestHeaderMapImpl& request_headers,
                                                         uint32_t request_body_size,
@@ -177,24 +244,26 @@ void HttpIntegrationTest::waitForNextUpstreamRequest() {
   upstream_request_->waitForEndStream(*dispatcher_);
 }
 
-void HttpIntegrationTest::testRouterRequestAndResponseWithBody(Network::ClientConnectionPtr&& conn,
-                                                               uint64_t request_size,
-                                                               uint64_t response_size,
-                                                               bool big_header) {
-  executeActions({[&]() -> void { codec_client_ = makeHttpConnection(std::move(conn)); },
-
-                  [&]() -> void {
-                    Http::TestHeaderMapImpl request_headers{
-                        {":method", "POST"},       {":path", "/test/long/url"},
-                        {":scheme", "http"},       {":authority", "host"},
-                        {"x-lyft-user-id", "123"}, {"x-forwarded-for", "10.0.0.1"}};
-                    if (big_header) {
-                      request_headers.addCopy("big", std::string(4096, 'a'));
-                    }
-                    sendRequestAndWaitForResponse(request_headers, request_size,
-                                                  default_response_headers_, response_size);
-                  },
-                  [&]() -> void { cleanupUpstreamAndDownstream(); }});
+void HttpIntegrationTest::testRouterRequestAndResponseWithBody(
+    uint64_t request_size, uint64_t response_size, bool big_header,
+    ConnectionCreationFunction* create_connection) {
+  executeActions(
+      {[&]() -> void {
+         codec_client_ =
+             makeHttpConnection(create_connection ? ((*create_connection)())
+                                                  : makeClientConnection((lookupPort("http"))));
+       },
+       [&]() -> void {
+         Http::TestHeaderMapImpl request_headers{
+             {":method", "POST"},    {":path", "/test/long/url"}, {":scheme", "http"},
+             {":authority", "host"}, {"x-lyft-user-id", "123"},   {"x-forwarded-for", "10.0.0.1"}};
+         if (big_header) {
+           request_headers.addCopy("big", std::string(4096, 'a'));
+         }
+         sendRequestAndWaitForResponse(request_headers, request_size, default_response_headers_,
+                                       response_size);
+       },
+       [&]() -> void { cleanupUpstreamAndDownstream(); }});
 
   EXPECT_TRUE(upstream_request_->complete());
   EXPECT_EQ(request_size, upstream_request_->bodyLength());
@@ -205,9 +274,12 @@ void HttpIntegrationTest::testRouterRequestAndResponseWithBody(Network::ClientCo
 }
 
 void HttpIntegrationTest::testRouterHeaderOnlyRequestAndResponse(
-    Network::ClientConnectionPtr&& conn, bool close_upstream) {
-
-  executeActions({[&]() -> void { codec_client_ = makeHttpConnection(std::move(conn)); },
+    bool close_upstream, ConnectionCreationFunction* create_connection) {
+  executeActions({[&]() -> void {
+                    codec_client_ = makeHttpConnection(
+                        create_connection ? ((*create_connection)())
+                                          : makeClientConnection((lookupPort("http"))));
+                  },
                   [&]() -> void {
                     Http::TestHeaderMapImpl request_headers{{":method", "GET"},
                                                             {":path", "/test/long/url"},
@@ -237,30 +309,46 @@ void HttpIntegrationTest::testRouterHeaderOnlyRequestAndResponse(
   EXPECT_EQ(0U, response_->body().size());
 }
 
+// Change the default route to be restrictive, and send a request to an alternate route.
 void HttpIntegrationTest::testRouterNotFound() {
+  config_helper_.setDefaultHostAndRoute("foo.com", "/found");
+  initialize();
+
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("http"), "GET", "/notfound", "", client_protocol_, version_);
+      lookupPort("http"), "GET", "/notfound", "", downstream_protocol_, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 }
 
-void HttpIntegrationTest::testRouterNotFoundWithBody(uint32_t port) {
+// Change the default route to be restrictive, and send a POST to an alternate route.
+void HttpIntegrationTest::testRouterNotFoundWithBody() {
+  config_helper_.setDefaultHostAndRoute("foo.com", "/found");
+  initialize();
+
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      port, "POST", "/notfound", "foo", client_protocol_, version_);
+      lookupPort("http"), "POST", "/notfound", "foo", downstream_protocol_, version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 }
 
+// Add a route which redirects HTTP to HTTPS, and verify Envoy sends a 301
 void HttpIntegrationTest::testRouterRedirect() {
+  config_helper_.addRoute("www.redirect.com", "/", "cluster_0", envoy::api::v2::VirtualHost::ALL);
+  initialize();
+
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("http"), "GET", "/foo", "", client_protocol_, version_, "www.redirect.com");
+      lookupPort("http"), "GET", "/foo", "", downstream_protocol_, version_, "www.redirect.com");
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("301", response->headers().Status()->value().c_str());
   EXPECT_STREQ("https://www.redirect.com/foo",
                response->headers().get(Http::Headers::get().Location)->value().c_str());
 }
 
+// Add a health check filter and verify correct behavior when draining.
 void HttpIntegrationTest::testDrainClose() {
+  config_helper_.addFilter(ConfigHelper::DEFAULT_HEALTH_CHECK_FILTER);
+  initialize();
+
   test_server_->drainManager().draining_ = true;
 
   executeActions({[&]() -> void { codec_client_ = makeHttpConnection(lookupPort("http")); },
@@ -277,17 +365,16 @@ void HttpIntegrationTest::testDrainClose() {
 
   EXPECT_TRUE(response_->complete());
   EXPECT_STREQ("200", response_->headers().Status()->value().c_str());
-  if (client_protocol_ == Http::CodecClient::Type::HTTP2) {
+  if (downstream_protocol_ == Http::CodecClient::Type::HTTP2) {
     EXPECT_TRUE(codec_client_->sawGoAway());
   }
 
   test_server_->drainManager().draining_ = false;
 }
 
-void HttpIntegrationTest::testRouterUpstreamDisconnectBeforeRequestComplete(
-    Network::ClientConnectionPtr&& conn) {
+void HttpIntegrationTest::testRouterUpstreamDisconnectBeforeRequestComplete() {
   std::list<std::function<void()>> actions = {
-      [&]() -> void { codec_client_ = makeHttpConnection(std::move(conn)); },
+      [&]() -> void { codec_client_ = makeHttpConnection(lookupPort("http")); },
       [&]() -> void {
         codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "GET"},
                                                             {":path", "/test/long/url"},
@@ -304,7 +391,7 @@ void HttpIntegrationTest::testRouterUpstreamDisconnectBeforeRequestComplete(
       [&]() -> void { fake_upstream_connection_->waitForDisconnect(); },
       [&]() -> void { response_->waitForEndStream(); }};
 
-  if (client_protocol_ == Http::CodecClient::Type::HTTP1) {
+  if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
     actions.push_back([&]() -> void { codec_client_->waitForDisconnect(); });
   } else {
     actions.push_back([&]() -> void { codec_client_->close(); });
@@ -321,9 +408,13 @@ void HttpIntegrationTest::testRouterUpstreamDisconnectBeforeRequestComplete(
 }
 
 void HttpIntegrationTest::testRouterUpstreamDisconnectBeforeResponseComplete(
-    Network::ClientConnectionPtr&& conn) {
+    ConnectionCreationFunction* create_connection) {
   std::list<std::function<void()>> actions = {
-      [&]() -> void { codec_client_ = makeHttpConnection(std::move(conn)); },
+      [&]() -> void {
+        codec_client_ =
+            makeHttpConnection(create_connection ? ((*create_connection)())
+                                                 : makeClientConnection((lookupPort("http"))));
+      },
       [&]() -> void {
         codec_client_->makeHeaderOnlyRequest(Http::TestHeaderMapImpl{{":method", "GET"},
                                                                      {":path", "/test/long/url"},
@@ -338,7 +429,7 @@ void HttpIntegrationTest::testRouterUpstreamDisconnectBeforeResponseComplete(
       [&]() -> void { fake_upstream_connection_->close(); },
       [&]() -> void { fake_upstream_connection_->waitForDisconnect(); }};
 
-  if (client_protocol_ == Http::CodecClient::Type::HTTP1) {
+  if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
     actions.push_back([&]() -> void { codec_client_->waitForDisconnect(); });
   } else {
     actions.push_back([&]() -> void { response_->waitForReset(); });
@@ -356,9 +447,13 @@ void HttpIntegrationTest::testRouterUpstreamDisconnectBeforeResponseComplete(
 }
 
 void HttpIntegrationTest::testRouterDownstreamDisconnectBeforeRequestComplete(
-    Network::ClientConnectionPtr&& conn) {
+    ConnectionCreationFunction* create_connection) {
   std::list<std::function<void()>> actions = {
-      [&]() -> void { codec_client_ = makeHttpConnection(std::move(conn)); },
+      [&]() -> void {
+        codec_client_ =
+            makeHttpConnection(create_connection ? ((*create_connection)())
+                                                 : makeClientConnection((lookupPort("http"))));
+      },
       [&]() -> void {
         codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "GET"},
                                                             {":path", "/test/long/url"},
@@ -373,7 +468,7 @@ void HttpIntegrationTest::testRouterDownstreamDisconnectBeforeRequestComplete(
       [&]() -> void { upstream_request_->waitForHeadersComplete(); },
       [&]() -> void { codec_client_->close(); }};
 
-  if (fake_upstreams_[0]->httpType() == FakeHttpConnection::Type::HTTP1) {
+  if (upstream_protocol_ == FakeHttpConnection::Type::HTTP1) {
     actions.push_back([&]() -> void { fake_upstream_connection_->waitForDisconnect(); });
   } else {
     actions.push_back([&]() -> void { upstream_request_->waitForReset(); });
@@ -390,9 +485,13 @@ void HttpIntegrationTest::testRouterDownstreamDisconnectBeforeRequestComplete(
 }
 
 void HttpIntegrationTest::testRouterDownstreamDisconnectBeforeResponseComplete(
-    Network::ClientConnectionPtr&& conn) {
+    ConnectionCreationFunction* create_connection) {
   std::list<std::function<void()>> actions = {
-      [&]() -> void { codec_client_ = makeHttpConnection(std::move(conn)); },
+      [&]() -> void {
+        codec_client_ =
+            makeHttpConnection(create_connection ? ((*create_connection)())
+                                                 : makeClientConnection((lookupPort("http"))));
+      },
       [&]() -> void {
         codec_client_->makeHeaderOnlyRequest(Http::TestHeaderMapImpl{{":method", "GET"},
                                                                      {":path", "/test/long/url"},
@@ -408,7 +507,7 @@ void HttpIntegrationTest::testRouterDownstreamDisconnectBeforeResponseComplete(
       [&]() -> void { response_->waitForBodyData(512); },
       [&]() -> void { codec_client_->close(); }};
 
-  if (fake_upstreams_[0]->httpType() == FakeHttpConnection::Type::HTTP1) {
+  if (upstream_protocol_ == FakeHttpConnection::Type::HTTP1) {
     actions.push_back([&]() -> void { fake_upstream_connection_->waitForDisconnect(); });
   } else {
     actions.push_back([&]() -> void { upstream_request_->waitForReset(); });
@@ -426,10 +525,9 @@ void HttpIntegrationTest::testRouterDownstreamDisconnectBeforeResponseComplete(
   EXPECT_EQ(512U, response_->body().size());
 }
 
-void HttpIntegrationTest::testRouterUpstreamResponseBeforeRequestComplete(
-    Network::ClientConnectionPtr&& conn) {
+void HttpIntegrationTest::testRouterUpstreamResponseBeforeRequestComplete() {
   std::list<std::function<void()>> actions = {
-      [&]() -> void { codec_client_ = makeHttpConnection(std::move(conn)); },
+      [&]() -> void { codec_client_ = makeHttpConnection(lookupPort("http")); },
       [&]() -> void {
         codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "GET"},
                                                             {":path", "/test/long/url"},
@@ -448,7 +546,7 @@ void HttpIntegrationTest::testRouterUpstreamResponseBeforeRequestComplete(
       },
       [&]() -> void { response_->waitForEndStream(); }};
 
-  if (fake_upstreams_[0]->httpType() == FakeHttpConnection::Type::HTTP1) {
+  if (upstream_protocol_ == FakeHttpConnection::Type::HTTP1) {
     actions.push_back([&]() -> void { fake_upstream_connection_->waitForDisconnect(); });
   } else {
     actions.push_back([&]() -> void { upstream_request_->waitForReset(); });
@@ -456,7 +554,7 @@ void HttpIntegrationTest::testRouterUpstreamResponseBeforeRequestComplete(
     actions.push_back([&]() -> void { fake_upstream_connection_->waitForDisconnect(); });
   }
 
-  if (client_protocol_ == Http::CodecClient::Type::HTTP1) {
+  if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
     actions.push_back([&]() -> void { codec_client_->waitForDisconnect(); });
   } else {
     actions.push_back([&]() -> void { codec_client_->close(); });
@@ -571,8 +669,10 @@ void HttpIntegrationTest::testGrpcRetry() {
 // Very similar set-up to testRetry but with a 16k request the request will not
 // be buffered and the 503 will be returned to the user.
 void HttpIntegrationTest::testRetryHittingBufferLimit() {
+  config_helper_.setBufferLimits(1024, 1024); // Set buffer limits upstream and downstream.
+
   executeActions(
-      {[&]() -> void { codec_client_ = makeHttpConnection(lookupPort("http_with_buffer_limits")); },
+      {[&]() -> void { codec_client_ = makeHttpConnection(lookupPort("http")); },
        [&]() -> void {
          codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
                                                                     {":path", "/test/long/url"},
@@ -600,10 +700,11 @@ void HttpIntegrationTest::testRetryHittingBufferLimit() {
 // Test hitting the dynamo filter with too many request bytes to buffer.  Ensure the connection
 // manager sends a 413.
 void HttpIntegrationTest::testHittingDecoderFilterLimit() {
+  config_helper_.addFilter("{ name: envoy.http_dynamo_filter, config: { deprecated_v1: true } }");
+  config_helper_.setBufferLimits(1024, 1024);
+
   executeActions(
-      {[&]() -> void {
-         codec_client_ = makeHttpConnection(lookupPort("dynamo_with_buffer_limits"));
-       },
+      {[&]() -> void { codec_client_ = makeHttpConnection(lookupPort("http")); },
        [&]() -> void {
          codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
                                                                     {":path", "/dynamo/url"},
@@ -627,10 +728,11 @@ void HttpIntegrationTest::testHittingDecoderFilterLimit() {
 // Test hitting the dynamo filter with too many response bytes to buffer.  Given the request headers
 // are sent on early, the stream/connection will be reset.
 void HttpIntegrationTest::testHittingEncoderFilterLimit() {
+  config_helper_.addFilter("{ name: envoy.http_dynamo_filter, config: { deprecated_v1: true } }");
+  config_helper_.setBufferLimits(1024, 1024);
+
   executeActions(
-      {[&]() -> void {
-         codec_client_ = makeHttpConnection(lookupPort("dynamo_with_buffer_limits"));
-       },
+      {[&]() -> void { codec_client_ = makeHttpConnection(lookupPort("http")); },
        [&]() -> void {
          auto downstream_request =
              &codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "GET"},
@@ -650,7 +752,7 @@ void HttpIntegrationTest::testHittingEncoderFilterLimit() {
          upstream_request_->encodeData(1024 * 65, false);
        },
        [&]() -> void {
-         if (client_protocol_ == Http::CodecClient::Type::HTTP2) {
+         if (downstream_protocol_ == Http::CodecClient::Type::HTTP2) {
            response_->waitForReset();
          } else {
            response_->waitForEndStream();
@@ -716,30 +818,35 @@ void HttpIntegrationTest::testTwoRequests() {
 }
 
 void HttpIntegrationTest::testBadFirstline() {
+  initialize();
   std::string response;
   sendRawHttpAndWaitForResponse("hello", &response);
   EXPECT_EQ("HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\nconnection: close\r\n\r\n", response);
 }
 
 void HttpIntegrationTest::testMissingDelimiter() {
+  initialize();
   std::string response;
   sendRawHttpAndWaitForResponse("GET / HTTP/1.1\r\nHost: host\r\nfoo bar\r\n\r\n", &response);
   EXPECT_EQ("HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\nconnection: close\r\n\r\n", response);
 }
 
 void HttpIntegrationTest::testInvalidCharacterInFirstline() {
+  initialize();
   std::string response;
   sendRawHttpAndWaitForResponse("GE(T / HTTP/1.1\r\nHost: host\r\n\r\n", &response);
   EXPECT_EQ("HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\nconnection: close\r\n\r\n", response);
 }
 
 void HttpIntegrationTest::testLowVersion() {
+  initialize();
   std::string response;
   sendRawHttpAndWaitForResponse("GET / HTTP/0.8\r\nHost: host\r\n\r\n", &response);
   EXPECT_EQ("HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\nconnection: close\r\n\r\n", response);
 }
 
 void HttpIntegrationTest::testHttp10Request() {
+  initialize();
   Buffer::OwnedImpl buffer("GET / HTTP/1.0\r\n\r\n");
   std::string response;
   RawConnectionDriver connection(
@@ -755,6 +862,7 @@ void HttpIntegrationTest::testHttp10Request() {
 }
 
 void HttpIntegrationTest::testNoHost() {
+  initialize();
   Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n\r\n");
   std::string response;
   RawConnectionDriver connection(
@@ -770,10 +878,16 @@ void HttpIntegrationTest::testNoHost() {
 }
 
 void HttpIntegrationTest::testAbsolutePath() {
+  // Configure www.redirect.com to send a redirect, and ensure the redirect is
+  // encountered via absolute URL.
+  config_helper_.addRoute("www.redirect.com", "/", "cluster_0", envoy::api::v2::VirtualHost::ALL);
+  config_helper_.addConfigModifier(&setAllowAbsoluteUrl);
+
+  initialize();
   Buffer::OwnedImpl buffer("GET http://www.redirect.com HTTP/1.1\r\nHost: host\r\n\r\n");
   std::string response;
   RawConnectionDriver connection(
-      lookupPort("http_forward"), buffer,
+      lookupPort("http"), buffer,
       [&](Network::ClientConnection& client, const Buffer::Instance& data) -> void {
         response.append(TestUtility::bufferToString(data));
         client.close(Network::ConnectionCloseType::NoFlush);
@@ -785,10 +899,16 @@ void HttpIntegrationTest::testAbsolutePath() {
 }
 
 void HttpIntegrationTest::testAbsolutePathWithPort() {
+  // Configure www.namewithport.com:1234 to send a redirect, and ensure the redirect is
+  // encountered via absolute URL with a port.
+  config_helper_.addRoute("www.namewithport.com:1234", "/", "cluster_0",
+                          envoy::api::v2::VirtualHost::ALL);
+  config_helper_.addConfigModifier(&setAllowAbsoluteUrl);
+  initialize();
   Buffer::OwnedImpl buffer("GET http://www.namewithport.com:1234 HTTP/1.1\r\nHost: host\r\n\r\n");
   std::string response;
   RawConnectionDriver connection(
-      lookupPort("http_forward"), buffer,
+      lookupPort("http"), buffer,
       [&](Network::ClientConnection& client, const Buffer::Instance& data) -> void {
         response.append(TestUtility::bufferToString(data));
         client.close(Network::ConnectionCloseType::NoFlush);
@@ -800,10 +920,17 @@ void HttpIntegrationTest::testAbsolutePathWithPort() {
 }
 
 void HttpIntegrationTest::testAbsolutePathWithoutPort() {
+  // Add a restrictive default match, to avoid the request hitting the * / catchall.
+  config_helper_.setDefaultHostAndRoute("foo.com", "/found");
+  // Set a matcher for namewithport:1234 and verify http://namewithport does not match
+  config_helper_.addRoute("www.namewithport.com:1234", "/", "cluster_0",
+                          envoy::api::v2::VirtualHost::ALL);
+  config_helper_.addConfigModifier(&setAllowAbsoluteUrl);
+  initialize();
   Buffer::OwnedImpl buffer("GET http://www.namewithport.com HTTP/1.1\r\nHost: host\r\n\r\n");
   std::string response;
   RawConnectionDriver connection(
-      lookupPort("http_forward"), buffer,
+      lookupPort("http"), buffer,
       [&](Network::ClientConnection& client, const Buffer::Instance& data) -> void {
         response.append(TestUtility::bufferToString(data));
         client.close(Network::ConnectionCloseType::NoFlush);
@@ -815,6 +942,7 @@ void HttpIntegrationTest::testAbsolutePathWithoutPort() {
 }
 
 void HttpIntegrationTest::testAllowAbsoluteSameRelative() {
+  // TODO(mattwoodyard) run this test.
   // Ensure that relative urls behave the same with allow_absolute_url enabled and without
   testEquivalent("GET /foo/bar HTTP/1.1\r\nHost: host\r\n\r\n");
 }
@@ -825,6 +953,22 @@ void HttpIntegrationTest::testConnect() {
 }
 
 void HttpIntegrationTest::testEquivalent(const std::string& request) {
+  config_helper_.addConfigModifier([&](envoy::api::v2::Bootstrap& bootstrap) -> void {
+    // Clone the whole listener.
+    auto static_resources = bootstrap.mutable_static_resources();
+    auto* old_listener = static_resources->mutable_listeners(0);
+    auto* cloned_listener = static_resources->add_listeners();
+    cloned_listener->CopyFrom(*old_listener);
+    cloned_listener->set_name("listener2");
+  });
+  // Set the first listener to allow absoute URLs.
+  config_helper_.addConfigModifier(&setAllowAbsoluteUrl);
+  // Make sure both listeners can be reached.
+  // TODO(alyssar) in a follow-up, instead have these named ports pulled automatically from the
+  // listener names.
+  named_ports_ = {"http_forward", "http"};
+  initialize();
+
   Buffer::OwnedImpl buffer1(request);
   std::string response1;
   RawConnectionDriver connection1(
@@ -853,6 +997,7 @@ void HttpIntegrationTest::testEquivalent(const std::string& request) {
 }
 
 void HttpIntegrationTest::testBadPath() {
+  initialize();
   Buffer::OwnedImpl buffer("GET http://api.lyft.com HTTP/1.1\r\nHost: host\r\n\r\n");
   std::string response;
   RawConnectionDriver connection(
@@ -893,7 +1038,7 @@ void HttpIntegrationTest::testInvalidContentLength() {
                                                 *response_);
                   },
                   [&]() -> void {
-                    if (client_protocol_ == Http::CodecClient::Type::HTTP1) {
+                    if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
                       codec_client_->waitForDisconnect();
                     } else {
                       response_->waitForReset();
@@ -901,7 +1046,7 @@ void HttpIntegrationTest::testInvalidContentLength() {
                     }
                   }});
 
-  if (client_protocol_ == Http::CodecClient::Type::HTTP1) {
+  if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
     ASSERT_TRUE(response_->complete());
     EXPECT_STREQ("400", response_->headers().Status()->value().c_str());
   } else {
@@ -920,7 +1065,7 @@ void HttpIntegrationTest::testMultipleContentLengths() {
                                                 *response_);
                   },
                   [&]() -> void {
-                    if (client_protocol_ == Http::CodecClient::Type::HTTP1) {
+                    if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
                       codec_client_->waitForDisconnect();
                     } else {
                       response_->waitForReset();
@@ -928,7 +1073,7 @@ void HttpIntegrationTest::testMultipleContentLengths() {
                     }
                   }});
 
-  if (client_protocol_ == Http::CodecClient::Type::HTTP1) {
+  if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
     ASSERT_TRUE(response_->complete());
     EXPECT_STREQ("400", response_->headers().Status()->value().c_str());
   } else {
@@ -1001,7 +1146,7 @@ void HttpIntegrationTest::testDownstreamResetBeforeResponseComplete() {
       [&]() -> void { response_->waitForBodyData(512); },
       [&]() -> void { codec_client_->sendReset(*request_encoder_); }};
 
-  if (fake_upstreams_[0]->httpType() == FakeHttpConnection::Type::HTTP1) {
+  if (upstream_protocol_ == FakeHttpConnection::Type::HTTP1) {
     actions.push_back([&]() -> void { fake_upstream_connection_->waitForDisconnect(); });
   } else {
     actions.push_back([&]() -> void { upstream_request_->waitForReset(); });
@@ -1021,10 +1166,11 @@ void HttpIntegrationTest::testDownstreamResetBeforeResponseComplete() {
 }
 
 void HttpIntegrationTest::testTrailers(uint64_t request_size, uint64_t response_size) {
+  config_helper_.addFilter(ConfigHelper::DEFAULT_BUFFER_FILTER);
   Http::TestHeaderMapImpl request_trailers{{"request1", "trailer1"}, {"request2", "trailer2"}};
   Http::TestHeaderMapImpl response_trailers{{"response1", "trailer1"}, {"response2", "trailer2"}};
   executeActions(
-      {[&]() -> void { codec_client_ = makeHttpConnection(lookupPort("http_buffer")); },
+      {[&]() -> void { codec_client_ = makeHttpConnection(lookupPort("http")); },
        [&]() -> void {
          request_encoder_ =
              &codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -111,10 +111,20 @@ struct ApiFilesystemConfig {
 class BaseIntegrationTest : Logger::Loggable<Logger::Id::testing> {
 public:
   BaseIntegrationTest(Network::Address::IpVersion version);
+  virtual ~BaseIntegrationTest() {}
+
+  virtual void initialize() {
+    RELEASE_ASSERT(!initialized_);
+    initialized_ = true;
+  }
+
   /**
    * Integration tests are composed of a sequence of actions which are run via this routine.
    */
   void executeActions(std::list<std::function<void()>> actions) {
+    if (!initialized_) {
+      initialize();
+    }
     for (const std::function<void()>& action : actions) {
       action();
     }
@@ -149,6 +159,7 @@ protected:
   spdlog::level::level_enum default_log_level_;
   IntegrationTestServerPtr test_server_;
   TestEnvironment::PortMap port_map_;
+  bool initialized_{}; // True if initialized() has been called.
 };
 
 } // namespace Envoy

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -17,57 +17,57 @@ INSTANTIATE_TEST_CASE_P(IpVersions, IntegrationAdminTest,
 
 TEST_P(IntegrationAdminTest, HealthCheck) {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("http"), "GET", "/healthcheck", "", client_protocol_, version_);
+      lookupPort("http"), "GET", "/healthcheck", "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/healthcheck/fail", "",
-                                                client_protocol_, version_);
+                                                downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("http"), "GET", "/healthcheck", "",
-                                                client_protocol_, version_);
+                                                downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("503", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/healthcheck/ok", "",
-                                                client_protocol_, version_);
+                                                downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("http"), "GET", "/healthcheck", "",
-                                                client_protocol_, version_);
+                                                downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("http_buffer"), "GET", "/healthcheck",
-                                                "", client_protocol_, version_);
+                                                "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 }
 
 TEST_P(IntegrationAdminTest, AdminLogging) {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "GET", "/logging", "", client_protocol_, version_);
+      lookupPort("admin"), "GET", "/logging", "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 
   // Bad level
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/logging?level=blah",
-                                                "", client_protocol_, version_);
+                                                "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 
   // Bad logger
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/logging?blah=info",
-                                                "", client_protocol_, version_);
+                                                "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 
   // This is going to stomp over custom log levels that are set on the command line.
   response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "GET", "/logging?level=warning", "", client_protocol_, version_);
+      lookupPort("admin"), "GET", "/logging?level=warning", "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   for (const Logger::Logger& logger : Logger::Registry::loggers()) {
@@ -75,7 +75,7 @@ TEST_P(IntegrationAdminTest, AdminLogging) {
   }
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/logging?assert=trace",
-                                                "", client_protocol_, version_);
+                                                "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   EXPECT_EQ(spdlog::level::trace, Logger::Registry::getLog(Logger::Id::assert).level());
@@ -83,7 +83,7 @@ TEST_P(IntegrationAdminTest, AdminLogging) {
   const char* level_name = spdlog::level::level_names[default_log_level_];
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET",
                                                 fmt::format("/logging?level={}", level_name), "",
-                                                client_protocol_, version_);
+                                                downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   for (const Logger::Logger& logger : Logger::Registry::loggers()) {
@@ -93,47 +93,47 @@ TEST_P(IntegrationAdminTest, AdminLogging) {
 
 TEST_P(IntegrationAdminTest, Admin) {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "GET", "/", "", client_protocol_, version_);
+      lookupPort("admin"), "GET", "/", "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/server_info", "",
-                                                client_protocol_, version_);
+                                                downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/stats", "",
-                                                client_protocol_, version_);
+                                                downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/clusters", "",
-                                                client_protocol_, version_);
+                                                downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/cpuprofiler", "",
-                                                client_protocol_, version_);
+                                                downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("400", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/hot_restart_version",
-                                                "", client_protocol_, version_);
+                                                "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/reset_counters", "",
-                                                client_protocol_, version_);
+                                                downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/certs", "",
-                                                client_protocol_, version_);
+                                                downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/listeners", "",
-                                                client_protocol_, version_);
+                                                downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
@@ -154,12 +154,12 @@ TEST_P(IntegrationAdminTest, Admin) {
 
 TEST_P(IntegrationAdminTest, AdminCpuProfilerStart) {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "GET", "/cpuprofiler?enable=y", "", client_protocol_, version_);
+      lookupPort("admin"), "GET", "/cpuprofiler?enable=y", "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/cpuprofiler?enable=n",
-                                                "", client_protocol_, version_);
+                                                "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 }

--- a/test/integration/integration_test.h
+++ b/test/integration/integration_test.h
@@ -9,26 +9,5 @@ class IntegrationTest : public HttpIntegrationTest,
                         public testing::TestWithParam<Network::Address::IpVersion> {
 public:
   IntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
-  /**
-   * Initializer for an individual test.
-   */
-  void SetUp() override {
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
-    registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
-    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
-    registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
-    createTestServer("test/config/integration/server.json",
-                     {"http", "http_forward", "http_with_buffer_limits",
-                      "dynamo_with_buffer_limits", "bridge_with_buffer_limits", "http_buffer",
-                      "tcp_proxy", "rds"});
-  }
-
-  /**
-   *  Destructor for an individual test.
-   */
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
 };
 } // namespace Envoy

--- a/test/integration/proxy_proto_integration_test.h
+++ b/test/integration/proxy_proto_integration_test.h
@@ -14,21 +14,12 @@ class ProxyProtoIntegrationTest : public HttpIntegrationTest,
                                   public testing::TestWithParam<Network::Address::IpVersion> {
 public:
   ProxyProtoIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
-  /**
-   * Initializer for an individual test.
-   */
-  void SetUp() override {
+
+  void initialize() override {
+    BaseIntegrationTest::initialize();
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
     createTestServer("test/config/integration/server_proxy_proto.json", {"http"});
-  }
-
-  /**
-   * Destructor for an individual test.
-   */
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
   }
 };
 } // namespace Envoy

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -21,7 +21,9 @@ using testing::Return;
 namespace Envoy {
 namespace Ssl {
 
-void SslIntegrationTest::SetUp() {
+void SslIntegrationTest::initialize() {
+  BaseIntegrationTest::initialize();
+
   runtime_.reset(new NiceMock<Runtime::MockLoader>());
   context_manager_.reset(new ContextManagerImpl(*runtime_));
   upstream_ssl_ctx_ = createUpstreamSslContext();
@@ -99,68 +101,99 @@ INSTANTIATE_TEST_CASE_P(IpVersions, SslIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(SslIntegrationTest, RouterRequestAndResponseWithGiantBodyBuffer) {
-  testRouterRequestAndResponseWithBody(makeSslClientConnection(false, false), 16 * 1024 * 1024,
-                                       16 * 1024 * 1024, false);
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection(false, false);
+  };
+  testRouterRequestAndResponseWithBody(16 * 1024 * 1024, 16 * 1024 * 1024, false, &creator);
   checkStats();
 }
 
 TEST_P(SslIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
-  testRouterRequestAndResponseWithBody(makeSslClientConnection(false, false), 1024, 512, false);
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection(false, false);
+  };
+  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
   checkStats();
 }
 
 TEST_P(SslIntegrationTest, RouterRequestAndResponseWithBodyNoBufferHttp2) {
-  client_protocol_ = Http::CodecClient::Type::HTTP2;
-  testRouterRequestAndResponseWithBody(makeSslClientConnection(true, false), 1024, 512, false);
+  setDownstreamProtocol(Http::CodecClient::Type::HTTP2);
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection(true, false);
+  };
+  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
   checkStats();
 }
 
 TEST_P(SslIntegrationTest, RouterRequestAndResponseWithBodyNoBufferVierfySAN) {
-  testRouterRequestAndResponseWithBody(makeSslClientConnection(false, true), 1024, 512, false);
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection(false, true);
+  };
+  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
   checkStats();
 }
 
 TEST_P(SslIntegrationTest, RouterRequestAndResponseWithBodyNoBufferHttp2VerifySAN) {
-  client_protocol_ = Http::CodecClient::Type::HTTP2;
-  testRouterRequestAndResponseWithBody(makeSslClientConnection(true, true), 1024, 512, false);
+  setDownstreamProtocol(Http::CodecClient::Type::HTTP2);
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection(true, true);
+  };
+  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
   checkStats();
 }
 
 TEST_P(SslIntegrationTest, RouterHeaderOnlyRequestAndResponse) {
-  testRouterHeaderOnlyRequestAndResponse(makeSslClientConnection(false, false), true);
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection(false, false);
+  };
+  testRouterHeaderOnlyRequestAndResponse(true, &creator);
   checkStats();
 }
 
 TEST_P(SslIntegrationTest, RouterUpstreamDisconnectBeforeResponseComplete) {
-  testRouterUpstreamDisconnectBeforeResponseComplete(makeSslClientConnection(false, false));
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection(false, false);
+  };
+  testRouterUpstreamDisconnectBeforeResponseComplete(&creator);
   checkStats();
 }
 
 TEST_P(SslIntegrationTest, RouterDownstreamDisconnectBeforeRequestComplete) {
-  testRouterDownstreamDisconnectBeforeRequestComplete(makeSslClientConnection(false, false));
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection(false, false);
+  };
+  testRouterDownstreamDisconnectBeforeRequestComplete(&creator);
   checkStats();
 }
 
 TEST_P(SslIntegrationTest, RouterDownstreamDisconnectBeforeResponseComplete) {
-  testRouterDownstreamDisconnectBeforeResponseComplete(makeSslClientConnection(false, false));
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection(false, false);
+  };
+  testRouterDownstreamDisconnectBeforeResponseComplete(&creator);
   checkStats();
 }
 
 // This test must be here vs integration_admin_test so that it tests a server with loaded certs.
 TEST_P(SslIntegrationTest, AdminCertEndpoint) {
+  initialize();
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "GET", "/certs", "", client_protocol_, version_);
+      lookupPort("admin"), "GET", "/certs", "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 }
 
 TEST_P(SslIntegrationTest, AltAlpn) {
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection(true, false);
+  };
+  initialize();
   // Connect with ALPN, but we should end up using HTTP/1.
   MockRuntimeIntegrationTestServer* server =
       dynamic_cast<MockRuntimeIntegrationTestServer*>(test_server_.get());
   ON_CALL(server->runtime_->snapshot_, featureEnabled("ssl.alt_alpn", 0))
       .WillByDefault(Return(true));
-  testRouterRequestAndResponseWithBody(makeSslClientConnection(true, false), 1024, 512, false);
+  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
   checkStats();
 }
 

--- a/test/integration/ssl_integration_test.h
+++ b/test/integration/ssl_integration_test.h
@@ -41,16 +41,13 @@ class SslIntegrationTest : public HttpIntegrationTest,
                            public testing::TestWithParam<Network::Address::IpVersion> {
 public:
   SslIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
-  /**
-   * Initializer for an individual test.
-   */
-  void SetUp() override;
 
-  /**
-   * Destructor for an individual test.
-   */
+  // Use old style configuration for now.
+  void initialize() override;
+
   void TearDown() override;
 
+  Network::ClientConnectionPtr makeSslConn() { return makeSslClientConnection(false, false); }
   Network::ClientConnectionPtr makeSslClientConnection(bool alpn, bool san);
   ServerContextPtr createUpstreamSslContext();
   void checkStats();

--- a/test/integration/uds_integration_test.cc
+++ b/test/integration/uds_integration_test.cc
@@ -10,22 +10,23 @@ INSTANTIATE_TEST_CASE_P(IpVersions, UdsIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(UdsIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
-  testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http")), 1024, 512, false);
+  testRouterRequestAndResponseWithBody(1024, 512, false);
 }
 
 TEST_P(UdsIntegrationTest, RouterHeaderOnlyRequestAndResponse) {
-  testRouterHeaderOnlyRequestAndResponse(makeClientConnection(lookupPort("http")), true);
+  testRouterHeaderOnlyRequestAndResponse(true);
 }
 
 TEST_P(UdsIntegrationTest, RouterUpstreamDisconnectBeforeResponseComplete) {
-  testRouterUpstreamDisconnectBeforeResponseComplete(makeClientConnection(lookupPort("http")));
+  testRouterUpstreamDisconnectBeforeResponseComplete();
 }
 
 TEST_P(UdsIntegrationTest, RouterDownstreamDisconnectBeforeRequestComplete) {
-  testRouterDownstreamDisconnectBeforeRequestComplete(makeClientConnection(lookupPort("http")));
+  testRouterDownstreamDisconnectBeforeRequestComplete();
 }
 
 TEST_P(UdsIntegrationTest, RouterDownstreamDisconnectBeforeResponseComplete) {
-  testRouterDownstreamDisconnectBeforeResponseComplete(makeClientConnection(lookupPort("http")));
+  testRouterDownstreamDisconnectBeforeResponseComplete();
 }
+
 } // namespace Envoy

--- a/test/integration/xds_integration_test.cc
+++ b/test/integration/xds_integration_test.cc
@@ -12,7 +12,8 @@ class XdsIntegrationTest : public HttpIntegrationTest,
 public:
   XdsIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP2, GetParam()) {}
 
-  void SetUp() override {
+  void initialize() override {
+    BaseIntegrationTest::initialize();
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_));
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
     createApiTestServer(
@@ -25,18 +26,13 @@ public:
         },
         {"http"});
   }
-
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, XdsIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(XdsIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
-  testRouterRequestAndResponseWithBody(makeClientConnection(lookupPort("http")), 1024, 512, false);
+  testRouterRequestAndResponseWithBody(1024, 512, false);
 }
 
 } // namespace

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -21,7 +21,8 @@
 namespace Envoy {
 namespace Xfcc {
 
-void XfccIntegrationTest::SetUp() {
+void XfccIntegrationTest::initialize() {
+  BaseIntegrationTest::initialize();
   runtime_.reset(new NiceMock<Runtime::MockLoader>());
   context_manager_.reset(new Ssl::ContextManagerImpl(*runtime_));
   upstream_ssl_ctx_ = createUpstreamSslContext();

--- a/test/integration/xfcc_integration_test.h
+++ b/test/integration/xfcc_integration_test.h
@@ -30,13 +30,10 @@ public:
   const std::string client_san_ = "SAN=spiffe://lyft.com/frontend-team";
 
   XfccIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
-  /**
-   * Initializer for an individual test.
-   */
-  void SetUp() override;
-  /**
-   * Destructor for an individual test.
-   */
+
+  void initialize() override;
+
+  void SetUp() override { initialize(); }
   void TearDown() override;
 
   Ssl::ServerContextPtr createUpstreamSslContext();

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -169,6 +169,7 @@ const uint32_t Http2Settings::DEFAULT_HPACK_TABLE_SIZE;
 const uint32_t Http2Settings::DEFAULT_MAX_CONCURRENT_STREAMS;
 const uint32_t Http2Settings::DEFAULT_INITIAL_STREAM_WINDOW_SIZE;
 const uint32_t Http2Settings::DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE;
+const uint32_t Http2Settings::MIN_INITIAL_STREAM_WINDOW_SIZE;
 
 TestHeaderMapImpl::TestHeaderMapImpl() : HeaderMapImpl() {}
 


### PR DESCRIPTION
This includes adding many utilities to ConfigHelper to fairly easily edit the bootstrap config.

This ports
integration_test,
http2_integration_test,
http2_upstream_integration_test,
uds_integration_test,
to using editable protos rather than flatfiles.

I think I should probably port over at least ssl_integration_test and writing the necessary TLS utils before closing off  #1162