### PR TITLE
mac build: force NTP update

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,8 @@ dependencies:
     # Cache homebrew and everything it installs.
     - "/usr/local"
   pre:
+    # Some CircleCI OS X hosts have wonky times. Force a time sync.
+    - sudo ntpdate -vu time.apple.com
     - brew ls --versions coreutils >/dev/null || brew install coreutils
     - brew ls --versions wget >/dev/null || brew install wget
     - brew ls --versions cmake >/dev/null || brew install cmake


### PR DESCRIPTION
Per CircleCI,

> Since we are running macOS inside VMs, the clock might get skewed, and since we constantly reboot and reset the VMs to a saved blank state, the clocks might be getting reset back to when the VM was created.
> You can force an update like this:
> sudo ntpdate -vu time.apple.com
> You can run this at any stage of the build, maybe something super-early like the checkout phase:
> checkout:
>   post:
>     \- sudo ntpdate -vu time.apple.com

The post phase of checkout happens immediately before the pre phase of dependencies, so I put it there. In any event, it happens before bazel starts, so it should solve the clock error we see in builds.