### PR TITLE
config: support for DiscoveryResponse nonces in gRPC Subscription.

### DIFF
--- a/source/common/config/ads_subscription_impl.h
+++ b/source/common/config/ads_subscription_impl.h
@@ -38,6 +38,7 @@ public:
 
   void updateResources(const std::vector<std::string>& resources) override {
     watch_ = ads_api_.subscribe(type_url_, resources, *this);
+    stats_.update_attempt_.inc();
   }
 
   const std::string versionInfo() const override { NOT_IMPLEMENTED; }

--- a/source/common/config/filesystem_subscription_impl.h
+++ b/source/common/config/filesystem_subscription_impl.h
@@ -45,6 +45,8 @@ public:
   void updateResources(const std::vector<std::string>& resources) override {
     // We report all discovered resources in the watched file.
     UNREFERENCED_PARAMETER(resources);
+    // Bump stats for consistence behavior with other xDS.
+    stats_.update_attempt_.inc();
   }
 
   const std::string versionInfo() const override { return version_info_; }

--- a/source/common/config/grpc_subscription_impl.h
+++ b/source/common/config/grpc_subscription_impl.h
@@ -58,8 +58,10 @@ public:
 
   void sendDiscoveryRequest() {
     if (stream_ == nullptr) {
+      ENVOY_LOG(trace, "Unable to sendDiscoveryRequest() on null stream");
       return;
     }
+    ENVOY_LOG(trace, "sendDiscoveryRequest: {}", request_.DebugString());
     stream_->sendMessage(request_, false);
   }
 
@@ -79,6 +81,7 @@ public:
                                                                        resources.end());
     request_.mutable_resource_names()->Swap(&resources_vector);
     sendDiscoveryRequest();
+    stats_.update_attempt_.inc();
   }
 
   const std::string versionInfo() const override { return request_.version_info(); }
@@ -107,6 +110,7 @@ public:
     // This effectively ACK/NACKs the accepted configuration.
     ENVOY_LOG(debug, "Sending version update: {}", message->version_info());
     stats_.update_attempt_.inc();
+    request_.set_response_nonce(message->nonce());
     sendDiscoveryRequest();
   }
 

--- a/test/common/config/BUILD
+++ b/test/common/config/BUILD
@@ -58,6 +58,7 @@ envoy_cc_test_library(
     external_deps = ["envoy_eds"],
     deps = [
         ":subscription_test_harness",
+        "//source/common/common:hash_lib",
         "//source/common/config:grpc_subscription_lib",
         "//test/mocks/config:config_mocks",
         "//test/mocks/event:event_mocks",

--- a/test/common/config/filesystem_subscription_test_harness.h
+++ b/test/common/config/filesystem_subscription_test_harness.h
@@ -38,7 +38,7 @@ public:
   }
 
   void updateResources(const std::vector<std::string>& cluster_names) override {
-    UNREFERENCED_PARAMETER(cluster_names);
+    subscription_.updateResources(cluster_names);
   }
 
   void updateFile(const std::string json, bool run_dispatcher = true) {

--- a/test/common/config/grpc_subscription_impl_test.cc
+++ b/test/common/config/grpc_subscription_impl_test.cc
@@ -25,7 +25,7 @@ TEST_F(GrpcSubscriptionImplTest, StreamCreationFailure) {
   EXPECT_CALL(*async_client_, start(_, _)).WillOnce(Return(&async_stream_));
   expectSendMessage({"cluster2"}, "");
   timer_cb_();
-  verifyStats(2, 0, 0, 1);
+  verifyStats(3, 0, 0, 1);
 }
 
 // Validate that the client can recover from a remote stream closure via retry.
@@ -43,6 +43,30 @@ TEST_F(GrpcSubscriptionImplTest, RemoteStreamClose) {
   expectSendMessage({"cluster0", "cluster1"}, "");
   timer_cb_();
   verifyStats(2, 0, 0, 1);
+}
+
+// Validate that When the management server gets multiple requests for the same version, it can
+// ignore later ones. This allows the nonce to be used.
+TEST_F(GrpcSubscriptionImplTest, RepeatedNonce) {
+  startSubscription({"cluster0", "cluster1"});
+  verifyStats(1, 0, 0, 0);
+  // First with the initial, empty version update to "0".
+  expectSendMessage({"cluster2"}, "");
+  updateResources({"cluster2"});
+  verifyStats(2, 0, 0, 0);
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", false);
+  verifyStats(3, 0, 1, 0);
+  deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
+  verifyStats(4, 1, 1, 0);
+  // Now with version "0" update to "1".
+  expectSendMessage({"cluster3"}, "0");
+  updateResources({"cluster3"});
+  verifyStats(5, 1, 1, 0);
+  deliverConfigUpdate({"cluster2"}, "1", false);
+  verifyStats(6, 1, 2, 0);
+  Mock::VerifyAndClearExpectations(&async_stream_);
+  deliverConfigUpdate({"cluster2"}, "1", true);
+  verifyStats(7, 2, 2, 0);
 }
 
 } // namespace

--- a/test/common/config/grpc_subscription_test_harness.h
+++ b/test/common/config/grpc_subscription_test_harness.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common/common/hash.h"
 #include "common/config/grpc_subscription_impl.h"
 
 #include "test/common/config/subscription_test_harness.h"
@@ -52,12 +53,14 @@ public:
     if (!version.empty()) {
       expected_request.set_version_info(version);
     }
+    expected_request.set_response_nonce(last_response_nonce_);
     EXPECT_CALL(async_stream_, sendMessage(ProtoEq(expected_request), false));
   }
 
   void startSubscription(const std::vector<std::string>& cluster_names) override {
     EXPECT_CALL(*async_client_, start(_, _)).WillOnce(Return(&async_stream_));
-    expectSendMessage(cluster_names, "");
+    last_cluster_names_ = cluster_names;
+    expectSendMessage(last_cluster_names_, "");
     subscription_->start(cluster_names, callbacks_);
     // These are just there to add coverage to the null implementations of these
     // callbacks.
@@ -72,6 +75,8 @@ public:
     std::unique_ptr<envoy::api::v2::DiscoveryResponse> response(
         new envoy::api::v2::DiscoveryResponse());
     response->set_version_info(version);
+    last_response_nonce_ = std::to_string(HashUtil::xxHash64(version));
+    response->set_nonce(last_response_nonce_);
     Protobuf::RepeatedPtrField<envoy::api::v2::ClusterLoadAssignment> typed_resources;
     for (const auto& cluster : cluster_names) {
       envoy::api::v2::ClusterLoadAssignment* load_assignment = typed_resources.Add();
@@ -81,10 +86,10 @@ public:
     EXPECT_CALL(callbacks_, onConfigUpdate(RepeatedProtoEq(typed_resources)))
         .WillOnce(ThrowOnRejectedConfig(accept));
     if (accept) {
-      expectSendMessage(cluster_names, version);
+      expectSendMessage(last_cluster_names_, version);
       version_ = version;
     } else {
-      expectSendMessage(cluster_names, version_);
+      expectSendMessage(last_cluster_names_, version_);
       EXPECT_CALL(callbacks_, onConfigUpdateFailed(_));
     }
     subscription_->onReceiveMessage(std::move(response));
@@ -94,6 +99,7 @@ public:
 
   void updateResources(const std::vector<std::string>& cluster_names) override {
     subscription_->updateResources(cluster_names);
+    last_cluster_names_ = cluster_names;
   }
 
   std::string version_;
@@ -107,6 +113,8 @@ public:
   Config::MockSubscriptionCallbacks<envoy::api::v2::ClusterLoadAssignment> callbacks_;
   Grpc::MockAsyncStream<envoy::api::v2::DiscoveryRequest> async_stream_;
   std::unique_ptr<GrpcEdsSubscriptionImpl> subscription_;
+  std::string last_response_nonce_;
+  std::vector<std::string> last_cluster_names_;
 };
 
 // TODO(danielhochman): test with RDS and ensure version_info is same as what API returned

--- a/test/common/config/subscription_impl_test.cc
+++ b/test/common/config/subscription_impl_test.cc
@@ -117,6 +117,7 @@ TEST_P(SubscriptionImplTest, UpdateResources) {
   verifyStats(2, 1, 0, 0);
   expectSendMessage({"cluster2"}, "0");
   updateResources({"cluster2"});
+  verifyStats(3, 1, 0, 0);
 }
 
 } // namespace


### PR DESCRIPTION
Also a bonus fix to the attempt stats in Subscriptions and related tests.