### PR TITLE
config: don't require client certificates when using TLS.

### DIFF
--- a/configs/google_com_proxy.json
+++ b/configs/google_com_proxy.json
@@ -40,8 +40,11 @@
             "type": "logical_dns",
             "lb_type": "round_robin",
             "hosts": [{
-                "url": "tcp://google.com:80"
-            }]
+                "url": "tcp://google.com:443"
+            }],
+            "ssl_context": {
+                "sni": "www.google.com"
+            }
         }]
     }
 }

--- a/configs/google_com_proxy.v2.yaml
+++ b/configs/google_com_proxy.v2.yaml
@@ -30,4 +30,5 @@ static_resources:
     connect_timeout: 0.25s
     type: LOGICAL_DNS
     lb_policy: ROUND_ROBIN
-    hosts: [{ socket_address: { address: google.com, port_value: 80 }}]
+    hosts: [{ socket_address: { address: google.com, port_value: 443 }}]
+    tls_context: { sni: www.google.com }

--- a/configs/google_com_proxy.yaml
+++ b/configs/google_com_proxy.yaml
@@ -28,4 +28,5 @@ cluster_manager:
     connect_timeout_ms: 250
     type: logical_dns
     lb_type: round_robin
-    hosts: [{ url: tcp://google.com:80 }]
+    hosts: [{ url: tcp://google.com:443 }]
+    ssl_context: { sni: www.google.com }

--- a/source/common/ssl/context_config_impl.cc
+++ b/source/common/ssl/context_config_impl.cc
@@ -39,12 +39,12 @@ ContextConfigImpl::ContextConfigImpl(const envoy::api::v2::CommonTlsContext& con
       ecdh_curves_(StringUtil::nonEmptyStringOrDefault(
           RepeatedPtrUtil::join(config.tls_params().ecdh_curves(), ":"), DEFAULT_ECDH_CURVES)),
       ca_cert_file_(config.validation_context().trusted_ca().filename()),
-      cert_chain_file_(config.tls_certificates().size()
-                           ? config.tls_certificates()[0].certificate_chain().filename()
-                           : ""),
-      private_key_file_(config.tls_certificates().size()
-                            ? config.tls_certificates()[0].private_key().filename()
-                            : ""),
+      cert_chain_file_(config.tls_certificates().empty()
+                           ? ""
+                           : config.tls_certificates()[0].certificate_chain().filename()),
+      private_key_file_(config.tls_certificates().empty()
+                            ? ""
+                            : config.tls_certificates()[0].private_key().filename()),
       verify_subject_alt_name_list_(config.validation_context().verify_subject_alt_name().begin(),
                                     config.validation_context().verify_subject_alt_name().end()),
       verify_certificate_hash_(config.validation_context().verify_certificate_hash().empty()
@@ -52,7 +52,7 @@ ContextConfigImpl::ContextConfigImpl(const envoy::api::v2::CommonTlsContext& con
                                    : config.validation_context().verify_certificate_hash()[0]) {
   // TODO(htuch): Support multiple hashes.
   ASSERT(config.validation_context().verify_certificate_hash().size() <= 1);
-  if (config.tls_certificates().size()) {
+  if (!config.tls_certificates().empty()) {
     // TODO(htuch): Support inline cert material delivery.
     ASSERT(config.tls_certificates()[0].certificate_chain().specifier_case() ==
            envoy::api::v2::DataSource::kFilename);

--- a/source/common/ssl/context_config_impl.cc
+++ b/source/common/ssl/context_config_impl.cc
@@ -39,8 +39,12 @@ ContextConfigImpl::ContextConfigImpl(const envoy::api::v2::CommonTlsContext& con
       ecdh_curves_(StringUtil::nonEmptyStringOrDefault(
           RepeatedPtrUtil::join(config.tls_params().ecdh_curves(), ":"), DEFAULT_ECDH_CURVES)),
       ca_cert_file_(config.validation_context().trusted_ca().filename()),
-      cert_chain_file_(config.tls_certificates()[0].certificate_chain().filename()),
-      private_key_file_(config.tls_certificates()[0].private_key().filename()),
+      cert_chain_file_(config.tls_certificates().size()
+                           ? config.tls_certificates()[0].certificate_chain().filename()
+                           : ""),
+      private_key_file_(config.tls_certificates().size()
+                            ? config.tls_certificates()[0].private_key().filename()
+                            : ""),
       verify_subject_alt_name_list_(config.validation_context().verify_subject_alt_name().begin(),
                                     config.validation_context().verify_subject_alt_name().end()),
       verify_certificate_hash_(config.validation_context().verify_certificate_hash().empty()
@@ -48,17 +52,20 @@ ContextConfigImpl::ContextConfigImpl(const envoy::api::v2::CommonTlsContext& con
                                    : config.validation_context().verify_certificate_hash()[0]) {
   // TODO(htuch): Support multiple hashes.
   ASSERT(config.validation_context().verify_certificate_hash().size() <= 1);
-  // TODO(PiotrSikora): Support multiple TLS certificates.
-  ASSERT(config.tls_certificates().size() == 1);
-  // TODO(htuch): Support inline cert material delivery.
-  ASSERT(config.tls_certificates()[0].certificate_chain().specifier_case() ==
-         envoy::api::v2::DataSource::kFilename);
-  ASSERT(config.tls_certificates()[0].private_key().specifier_case() ==
-         envoy::api::v2::DataSource::kFilename);
+  if (config.tls_certificates().size()) {
+    // TODO(htuch): Support inline cert material delivery.
+    ASSERT(config.tls_certificates()[0].certificate_chain().specifier_case() ==
+           envoy::api::v2::DataSource::kFilename);
+    ASSERT(config.tls_certificates()[0].private_key().specifier_case() ==
+           envoy::api::v2::DataSource::kFilename);
+  }
 }
 
 ClientContextConfigImpl::ClientContextConfigImpl(const envoy::api::v2::UpstreamTlsContext& config)
-    : ContextConfigImpl(config.common_tls_context()), server_name_indication_(config.sni()) {}
+    : ContextConfigImpl(config.common_tls_context()), server_name_indication_(config.sni()) {
+  // TODO(PiotrSikora): Support multiple TLS certificates.
+  ASSERT(config.common_tls_context().tls_certificates().size() <= 1);
+}
 
 ClientContextConfigImpl::ClientContextConfigImpl(const Json::Object& config)
     : ClientContextConfigImpl([&config] {
@@ -70,7 +77,10 @@ ClientContextConfigImpl::ClientContextConfigImpl(const Json::Object& config)
 ServerContextConfigImpl::ServerContextConfigImpl(const envoy::api::v2::DownstreamTlsContext& config)
     : ContextConfigImpl(config.common_tls_context()),
       require_client_certificate_(
-          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, require_client_certificate, false)) {}
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, require_client_certificate, false)) {
+  // TODO(PiotrSikora): Support multiple TLS certificates.
+  ASSERT(config.common_tls_context().tls_certificates().size() == 1);
+}
 
 ServerContextConfigImpl::ServerContextConfigImpl(const Json::Object& config)
     : ServerContextConfigImpl([&config] {


### PR DESCRIPTION
Broken in commit b0d8095d0cd3c63667997124b9e8cee70d52f743.

Fixes #1604.