### PR TITLE
config: add sample config in text proto format.

### DIFF
--- a/configs/BUILD
+++ b/configs/BUILD
@@ -14,6 +14,7 @@ envoy_py_test_binary(
     srcs = ["configgen.py"],
     data = glob([
         "*.json",
+        "*.pb_text",
         "*.yaml",
     ]),
     external_deps = ["jinja2"],

--- a/configs/configgen.py
+++ b/configs/configgen.py
@@ -114,5 +114,5 @@ generate_config(SCRIPT_DIR, 'envoy_service_to_service.template.json',
                 external_virtual_hosts=external_virtual_hosts,
                 mongos_servers=mongos_servers)
 
-for google_ext in ['json', 'yaml', 'v2.yaml']:
+for google_ext in ['json', 'yaml', 'v2.yaml', 'v2.pb_text']:
   shutil.copy(os.path.join(SCRIPT_DIR, 'google_com_proxy.%s' % google_ext), OUT_DIR)

--- a/configs/configgen.sh
+++ b/configs/configgen.sh
@@ -12,4 +12,4 @@ mkdir -p "$OUT_DIR"
 cp $* "$OUT_DIR"
 
 # tar is having issues with -C for some reason so just cd into OUT_DIR.
-(cd "$OUT_DIR"; tar -cvf example_configs.tar *.json *.yaml)
+(cd "$OUT_DIR"; tar -cvf example_configs.tar *.json *.pb_text *.yaml)

--- a/configs/google_com_proxy.v2.pb_text
+++ b/configs/google_com_proxy.v2.pb_text
@@ -1,0 +1,159 @@
+admin {
+  access_log_path: "/tmp/admin_access.log"
+  address {
+    socket_address {
+      address: "127.0.0.1"
+      port_value: 9901
+    }
+  }
+}
+
+static_resources {
+  listeners {
+    name: "listener_0"
+    address {
+      socket_address {
+        address: "127.0.0.1"
+        port_value: 10000
+      }
+    }
+    filter_chains {
+      filters {
+        name: "envoy.http_connection_manager"
+        config {
+          fields {
+            key: "stat_prefix"
+            value {
+              string_value: "ingress_http"
+            }
+          }
+          fields {
+            key: "codec_type"
+            value {
+              string_value: "AUTO"
+            }
+          }
+          fields {
+            key: "route_config"
+            value {
+              struct_value {
+                fields {
+                  key: "name"
+                  value {
+                    string_value: "local_route"
+                  }
+                }
+                fields {
+                  key: "virtual_hosts"
+                  value {
+                    struct_value {
+                      fields {
+                        key: "name"
+                        value {
+                          string_value: "local_service"
+                        }
+                      }
+                      fields {
+                        key: "domains"
+                        value {
+                          list_value {
+                            values {
+                              string_value: "*"
+                            }
+                          }
+                        }
+                      }
+                      fields {
+                        key: "routes"
+                        value {
+                          struct_value {
+                            fields {
+                              key: "match"
+                              value {
+                                struct_value {
+                                  fields {
+                                    key: "prefix"
+                                    value {
+                                      string_value: "/"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                            fields {
+                              key: "route"
+                              value {
+                                struct_value {
+                                  fields {
+                                    key: "host_rewrite"
+                                    value {
+                                      string_value: "www.google.com"
+                                    }
+                                  }
+                                  fields {
+                                    key: "cluster"
+                                    value {
+                                      string_value: "service_google"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          fields {
+            key: "http_filters"
+            value {
+              struct_value {
+                fields {
+                  key: "name"
+                  value {
+                    string_value: "envoy.router"
+                  }
+                }
+                fields {
+                  key: "config"
+                  value {
+                    struct_value {
+                      fields {
+                        key: "deprecated_v1"
+                        value {
+                          bool_value: true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  clusters {
+    name: "service_google"
+    connect_timeout {
+      nanos: 250000000
+    }
+    type: LOGICAL_DNS
+    lb_policy: ROUND_ROBIN
+    hosts {
+      socket_address {
+        address: "www.google.com"
+        port_value: 443
+      }
+    }
+    tls_context {
+      sni: "www.google.com"
+    }
+  }
+}

--- a/test/config_test/example_configs_test.cc
+++ b/test/config_test/example_configs_test.cc
@@ -8,6 +8,6 @@ namespace Envoy {
 TEST(ExampleConfigsTest, All) {
   TestEnvironment::exec(
       {TestEnvironment::runfilesPath("test/config_test/example_configs_test_setup.sh")});
-  EXPECT_EQ(16UL, ConfigTest::run(TestEnvironment::temporaryDirectory() + "/test/config_test"));
+  EXPECT_EQ(17UL, ConfigTest::run(TestEnvironment::temporaryDirectory() + "/test/config_test"));
 }
 } // namespace Envoy

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -40,7 +40,8 @@ TEST_P(ValidationServerTest, Validate) {
 INSTANTIATE_TEST_CASE_P(ValidConfigs, ValidationServerTest,
                         ::testing::Values("front-envoy.json", "google_com_proxy.json",
                                           "google_com_proxy.yaml", "google_com_proxy.v2.yaml",
-                                          "s2s-grpc-envoy.json", "service-envoy.json"));
+                                          "google_com_proxy.v2.pb_text", "s2s-grpc-envoy.json",
+                                          "service-envoy.json"));
 
 } // namespace Server
 } // namespace Envoy


### PR DESCRIPTION
Support for parsing configs in the text proto was added in commit
ca8572eb6c3337b01dc4c493cd6a4d3c27373ff7, but there were no tests
or examples that verified that this feature really works.