### PR TITLE
docs: switch security email

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,5 +165,5 @@ If you want this to be automatic you can set up some aliases:
 
 ```
 git config --add alias.amend "commit -s --amend"
-git config --add alias.commit "commit -s"
+git config --add alias.c "commit -s"
 ```

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ for information on email list usage.
 
 ## Reporting security vulnerabilities
 
-If you've found a vulnerability or a potential vulnerability in Envoy please let us know at
-security@lyft.com. We'll send a confirmation email to acknowledge your report, and we'll send an
+If you've found a vulnerability or a potential vulnerability in Envoy
+please let us know at envoy-security@googlegroups.com. We'll send a
+confirmation email to acknowledge your report, and we'll send an
 additional email when we've identified the issue positively or negatively.
 
 


### PR DESCRIPTION
Also change DCO aliases since you can't alias a built-in command.

Signed-off-by: Matt Klein <mklein@lyft.com>