### PR TITLE
ci: save space during docker push

### DIFF
--- a/ci/docker_push.sh
+++ b/ci/docker_push.sh
@@ -15,15 +15,14 @@ do
 done
 if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$want_push" == "true" ]
 then
-   # this is needed to verify the example images
    docker build -f ci/Dockerfile-envoy-image -t lyft/envoy:latest .
-   # verify the Alpine build even when we're not pushing it
-   make -C ci/build_alpine_container
-
    docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
    docker push lyft/envoy:latest
    docker tag lyft/envoy:latest lyft/envoy:$TRAVIS_COMMIT
    docker push lyft/envoy:$TRAVIS_COMMIT
+   docker rmi $(docker images -a -q)
+
+   make -C ci/build_alpine_container
    docker tag lyft/envoy-alpine:latest lyft/envoy-alpine:$TRAVIS_COMMIT
    docker push lyft/envoy-alpine:$TRAVIS_COMMIT
    docker push lyft/envoy-alpine:latest


### PR DESCRIPTION
This is yet another workaround for lack of disk space but should allow
us to limp around for a while longer.