### PR TITLE
config: latch previous config on empty EDS/RDS update.

### DIFF
--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -234,7 +234,9 @@ public:
   COUNTER(retry_or_shadow_abandoned)                                                               \
   COUNTER(update_attempt)                                                                          \
   COUNTER(update_success)                                                                          \
-  COUNTER(update_failure)
+  COUNTER(update_failure)                                                                          \
+  COUNTER(update_empty)
+
 // clang-format on
 
 /**

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -93,6 +93,12 @@ Router::ConfigConstSharedPtr RdsRouteConfigProviderImpl::config() {
 }
 
 void RdsRouteConfigProviderImpl::onConfigUpdate(const ResourceVector& resources) {
+  if (resources.empty()) {
+    ENVOY_LOG(debug, "Missing RouteConfiguration for {} in onConfigUpdate()", route_config_name_);
+    stats_.update_empty_.inc();
+    runInitializeCallbackIfAny();
+    return;
+  }
   if (resources.size() != 1) {
     throw EnvoyException(fmt::format("Unexpected RDS resource length: {}", resources.size()));
   }

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -60,7 +60,8 @@ private:
  */
 // clang-format off
 #define ALL_RDS_STATS(COUNTER)                                                                     \
-  COUNTER(config_reload)
+  COUNTER(config_reload)                                                                           \
+  COUNTER(update_empty)
 
 // clang-format on
 

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -42,6 +42,12 @@ void EdsClusterImpl::initialize() { subscription_->start({cluster_name_}, *this)
 
 void EdsClusterImpl::onConfigUpdate(const ResourceVector& resources) {
   std::vector<HostSharedPtr> new_hosts;
+  if (resources.empty()) {
+    ENVOY_LOG(debug, "Missing ClusterLoadAssignment for {} in onConfigUpdate()", cluster_name_);
+    info_->stats().update_empty_.inc();
+    runInitializeCallbackIfAny();
+    return;
+  }
   if (resources.size() != 1) {
     throw EnvoyException(fmt::format("Unexpected EDS resource length: {}", resources.size()));
   }

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -478,6 +478,54 @@ TEST_F(RouteConfigProviderManagerImplTest, Basic) {
   EXPECT_EQ(0UL, configured_providers.size());
 }
 
+TEST_F(RouteConfigProviderManagerImplTest, onConfigUpdateEmpty) {
+  std::string config_json = R"EOF(
+    {
+      "cluster": "foo_cluster",
+      "route_config_name": "foo_route_config",
+      "refresh_delay_ms": 1000
+    }
+    )EOF";
+
+  Json::ObjectSharedPtr config = Json::Factory::loadFromString(config_json);
+  envoy::api::v2::filter::Rds rds;
+  Envoy::Config::Utility::translateRdsConfig(*config, rds);
+
+  // Get a RouteConfigProvider. This one should create an entry in the RouteConfigProviderManager.
+  RouteConfigProviderSharedPtr provider = route_config_provider_manager_.getRouteConfigProvider(
+      rds, cm_, store_, "foo_prefix.", init_manager_);
+  init_manager_.initialize();
+  auto& provider_impl = dynamic_cast<RdsRouteConfigProviderImpl&>(*provider.get());
+  EXPECT_CALL(init_manager_.initialized_, ready());
+  provider_impl.onConfigUpdate({});
+  EXPECT_EQ(1UL, store_.counter("foo_prefix.rds.update_empty").value());
+}
+
+TEST_F(RouteConfigProviderManagerImplTest, onConfigUpdateWrongSize) {
+  std::string config_json = R"EOF(
+    {
+      "cluster": "foo_cluster",
+      "route_config_name": "foo_route_config",
+      "refresh_delay_ms": 1000
+    }
+    )EOF";
+
+  Json::ObjectSharedPtr config = Json::Factory::loadFromString(config_json);
+  envoy::api::v2::filter::Rds rds;
+  Envoy::Config::Utility::translateRdsConfig(*config, rds);
+
+  // Get a RouteConfigProvider. This one should create an entry in the RouteConfigProviderManager.
+  RouteConfigProviderSharedPtr provider = route_config_provider_manager_.getRouteConfigProvider(
+      rds, cm_, store_, "foo_prefix.", init_manager_);
+  init_manager_.initialize();
+  auto& provider_impl = dynamic_cast<RdsRouteConfigProviderImpl&>(*provider.get());
+  Protobuf::RepeatedPtrField<envoy::api::v2::RouteConfiguration> route_configs;
+  route_configs.Add();
+  route_configs.Add();
+  EXPECT_THROW_WITH_MESSAGE(provider_impl.onConfigUpdate(route_configs), EnvoyException,
+                            "Unexpected RDS resource length: 2");
+}
+
 } // namespace
 } // namespace Router
 } // namespace Envoy


### PR DESCRIPTION
With ADS or other batched updates, we might not see a cluster/route config in
an EDS/RDS update. There are at least two sane things to do; (1) latch the
previous config (2) provide an empty config for the resource. In this PR, we
opt for (1), this isn't on the happy path so there isn't an obvious choice
either way.

Signed-off-by: Harvey Tuch <htuch@google.com>