### PR TITLE
add envoy-build-centos

### DIFF
--- a/ci/build_container_centos/Dockerfile
+++ b/ci/build_container_centos/Dockerfile
@@ -1,0 +1,7 @@
+FROM centos/devtoolset-6-toolchain-centos7
+
+COPY ./build_container.sh ./build_and_install_deps.sh ./target_recipes.bzl ./recipe_wrapper.sh ./Makefile /
+COPY ./build_recipes/*.sh /build_recipes/
+
+USER root
+RUN cd / && ./build_container.sh

--- a/ci/build_container_centos/build_container.sh
+++ b/ci/build_container_centos/build_container.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+
+# dependencies for bazel and build_recipes
+yum install -y java-1.8.0-openjdk-devel unzip which \
+               cmake git golang libtool make patch rsync wget
+yum clean all
+
+# latest bazel installer
+BAZEL_VERSION=$(curl -s https://api.github.com/repos/bazelbuild/bazel/releases/latest |
+                  python -c "import json, sys; print json.load(sys.stdin)['tag_name']")
+BAZEL_INSTALLER=bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
+curl -OL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/${BAZEL_INSTALLER} \
+  && chmod ug+x ./${BAZEL_INSTALLER} && ./${BAZEL_INSTALLER} && rm ./${BAZEL_INSTALLER}
+
+# no suitable clang-format-5.0 for centos, so we also omit buildifier/virtualenv here.
+# we can use lyft/envoy-build image for format/docs.
+
+# GCC for everything.
+export CC=gcc
+export CXX=g++
+CXX_VERSION="$(${CXX} --version | grep ^g++)"
+if [[ "${CXX_VERSION}" != "g++ (GCC) 6.2.1 20160916 (Red Hat 6.2.1-3)" ]]; then
+  echo "Unexpected compiler version: ${CXX_VERSION}"
+  exit 1
+fi
+
+export THIRDPARTY_DEPS=/tmp
+export THIRDPARTY_SRC=/thirdparty
+DEPS=$(python <(cat target_recipes.bzl; \
+  echo "print ' '.join(\"${THIRDPARTY_DEPS}/%s.dep\" % r for r in set(TARGET_RECIPES.values()))"))
+
+# TODO(htuch): We build twice as a workaround for https://github.com/google/protobuf/issues/3322.
+# Fix this. This will be gone real soon now.
+export THIRDPARTY_BUILD=/thirdparty_build
+export CPPFLAGS="-DNDEBUG"
+echo "Building opt deps ${DEPS}"
+"$(dirname "$0")"/build_and_install_deps.sh ${DEPS}

--- a/ci/build_container_centos/docker_build.sh
+++ b/ci/build_container_centos/docker_build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Using Docker relative path workaround from
+# https://github.com/docker/docker/issues/2745#issuecomment-253230025
+tar cf - -C ../build_container . \
+         -C ../../bazel target_recipes.bzl \
+         -C ../ci/build_container_centos . | \
+    docker build --no-cache --rm -t lyft/envoy-build-centos:$TRAVIS_COMMIT -

--- a/ci/build_container_centos/docker_push.sh
+++ b/ci/build_container_centos/docker_push.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Do not ever set -x here, it is a security hazard as it will place the credentials below in the
+# Travis logs.
+set -e
+
+# push the envoy image on merge to master
+want_push='false'
+for branch in "master"
+do
+   if [ "$TRAVIS_BRANCH" == "$branch" ]
+   then
+       want_push='true'
+   fi
+done
+if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$want_push" == "true" ]
+then
+    if [[ $(git diff HEAD^ ci/build_container_centos/) ]]; then
+        echo "There are changes in the ci/build_container_centos directory"
+        echo "Updating lyft/envoy-build-centos image"
+        cd ci/build_container_centos
+        ./docker_build.sh
+        docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+        docker push lyft/envoy-build-centos:$TRAVIS_COMMIT
+        docker tag lyft/envoy-build-centos:$TRAVIS_COMMIT lyft/envoy-build-centos:latest
+        docker push lyft/envoy-build-centos:latest
+    else
+        echo "The ci/build_container_centos directory has not changed"
+    fi
+else
+    echo 'Ignoring PR branch for docker push.'
+fi

--- a/ci/ci_steps.sh
+++ b/ci/ci_steps.sh
@@ -29,10 +29,12 @@ then
   exit 0
 elif [ "$TEST_TYPE" == "build_image" ]
 then
-  # The script builds lyft/envoy-build and pushes that image when ci/build_container
+  # The script builds lyft/envoy-build{-centos} and pushes that image when ci/build_container
   # has changed on a push to master.
   echo "lyft/envoy-build pushing..."
   ./ci/build_container/docker_push.sh
+  echo "lyft/envoy-build-centos pushing..."
+  ./ci/build_container_centos/docker_push.sh
 else
   docker run -t -i -v "$ENVOY_BUILD_DIR":/build -v $TRAVIS_BUILD_DIR:/source \
     lyft/envoy-build:$ENVOY_BUILD_SHA /bin/bash -c "cd /source && ci/do_ci.sh $TEST_TYPE"


### PR DESCRIPTION
envoy-build based on centos/devtoolset-6-toolchain-centos7

no clang-format since there is not binary rpm for centos.

also omit bulidifier and pip, we can use lyft/envoy-build for that. 