### PR TITLE
Not registering for early error for HTTP/1 upstream connections

### DIFF
--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -124,6 +124,15 @@ public:
   virtual void readDisable(bool disable) PURE;
 
   /**
+   * Set if Envoy should detect TCP connection close when readDisable(true) is called.
+   * By default, this is true on newly created connections.
+   *
+   * @param should_detect supplies if disconnects should be detected when the connection has been
+   * read disabled
+   */
+  virtual void detectEarlyCloseWhenReadDisabled(bool should_detect) PURE;
+
+  /**
    * @return bool whether reading is enabled on the connection.
    */
   virtual bool readEnabled() const PURE;

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -14,7 +14,9 @@ namespace Http {
 CodecClient::CodecClient(Type type, Network::ClientConnectionPtr&& connection,
                          Upstream::HostDescriptionConstSharedPtr host)
     : type_(type), connection_(std::move(connection)), host_(host) {
-
+  // Make sure upstream connections process data and then the FIN, rather than processing
+  // TCP disconnects immediately.  (see https://github.com/envoyproxy/envoy/issues/1679 for details)
+  connection_->detectEarlyCloseWhenReadDisabled(false);
   connection_->addConnectionCallbacks(*this);
   connection_->addReadFilter(Network::ReadFilterSharedPtr{new CodecReadFilter(*this)});
 

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -245,7 +245,11 @@ void ConnectionImpl::readDisable(bool disable) {
     }
     ASSERT(read_enabled);
     state_ &= ~InternalState::ReadEnabled;
-    file_event_->setEnabled(Event::FileReadyType::Write | Event::FileReadyType::Closed);
+    if (detect_early_close_) {
+      file_event_->setEnabled(Event::FileReadyType::Write | Event::FileReadyType::Closed);
+    } else {
+      file_event_->setEnabled(Event::FileReadyType::Write);
+    }
   } else {
     if (read_disable_count_ > 0) {
       --read_disable_count_;

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -66,6 +66,7 @@ public:
   std::string nextProtocol() const override { return ""; }
   void noDelay(bool enable) override;
   void readDisable(bool disable) override;
+  void detectEarlyCloseWhenReadDisabled(bool value) override { detect_early_close_ = value; }
   bool readEnabled() const override;
   const Address::Instance& remoteAddress() const override { return *remote_address_; }
   const Address::Instance& localAddress() const override { return *local_address_; }
@@ -156,6 +157,7 @@ private:
   uint32_t read_disable_count_{0};
   const bool using_original_dst_;
   bool above_high_watermark_{false};
+  bool detect_early_close_{true};
 };
 
 /**

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -47,6 +47,8 @@ envoy_cc_test(
         "//test/mocks/http:http_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:environment_lib",
+        "//test/test_common:network_utility_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -1,8 +1,10 @@
 #include <memory>
 
 #include "common/buffer/buffer_impl.h"
+#include "common/event/dispatcher_impl.h"
 #include "common/http/codec_client.h"
 #include "common/http/exception.h"
+#include "common/network/listen_socket_impl.h"
 #include "common/network/utility.h"
 #include "common/upstream/upstream_impl.h"
 
@@ -13,6 +15,8 @@
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/network_utility.h"
 #include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
@@ -20,6 +24,7 @@
 #include "gtest/gtest.h"
 
 using testing::Invoke;
+using testing::InvokeWithoutArgs;
 using testing::NiceMock;
 using testing::Pointee;
 using testing::Ref;
@@ -36,6 +41,7 @@ public:
   CodecClientTest() {
     connection_ = new NiceMock<Network::MockClientConnection>();
 
+    EXPECT_CALL(*connection_, detectEarlyCloseWhenReadDisabled(false));
     EXPECT_CALL(*connection_, addConnectionCallbacks(_)).WillOnce(SaveArgAddress(&connection_cb_));
     EXPECT_CALL(*connection_, connect());
     EXPECT_CALL(*connection_, addReadFilter(_))
@@ -166,6 +172,149 @@ TEST_F(CodecClientTest, WatermarkPassthrough) {
   EXPECT_CALL(*codec_, onUnderlyingConnectionBelowWriteBufferLowWatermark());
   connection_cb_->onBelowWriteBufferLowWatermark();
 }
+
+// Test the codec getting input from a real TCP connection.
+class CodecNetworkTest : public testing::TestWithParam<Network::Address::IpVersion> {
+public:
+  CodecNetworkTest() {
+    dispatcher_.reset(new Event::DispatcherImpl);
+    upstream_listener_ =
+        dispatcher_->createListener(connection_handler_, socket_, listener_callbacks_, stats_store_,
+                                    Network::ListenerOptions::listenerOptionsWithBindToPort());
+    Network::ClientConnectionPtr client_connection =
+        dispatcher_->createClientConnection(socket_.localAddress(), source_address_);
+    client_connection_ = client_connection.get();
+    codec_ = new Http::MockClientConnection();
+    client_.reset(new CodecClientForTest(std::move(client_connection), codec_, nullptr, host_));
+    EXPECT_CALL(listener_callbacks_, onNewConnection_(_))
+        .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
+          upstream_connection_ = std::move(conn);
+          upstream_connection_->addConnectionCallbacks(upstream_callbacks_);
+          dispatcher_->exit();
+        }));
+    dispatcher_->run(Event::Dispatcher::RunType::Block);
+  }
+
+  void createNewStream() {
+    Http::StreamDecoder* inner_decoder;
+    EXPECT_CALL(*codec_, newStream(_))
+        .WillOnce(Invoke([&](Http::StreamDecoder& decoder) -> Http::StreamEncoder& {
+          inner_decoder = &decoder;
+          return inner_encoder_;
+        }));
+
+    client_->newStream(outer_decoder_);
+  }
+
+  void close() {
+    client_->close();
+    EXPECT_CALL(upstream_callbacks_, onEvent(Network::ConnectionEvent::RemoteClose))
+        .WillOnce(InvokeWithoutArgs([&]() -> void { dispatcher_->exit(); }));
+    dispatcher_->run(Event::Dispatcher::RunType::Block);
+  }
+
+protected:
+  Event::DispatcherPtr dispatcher_;
+  Network::ListenerPtr upstream_listener_;
+  Network::MockListenerCallbacks listener_callbacks_;
+  Network::MockConnectionHandler connection_handler_;
+  Network::Address::InstanceConstSharedPtr source_address_;
+  Stats::IsolatedStoreImpl stats_store_;
+  Network::TcpListenSocket socket_{Network::Test::getAnyAddress(GetParam()), true};
+  Http::MockClientConnection* codec_;
+  std::unique_ptr<CodecClientForTest> client_;
+  std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
+  Upstream::HostDescriptionConstSharedPtr host_{
+      Upstream::makeTestHostDescription(cluster_, "tcp://127.0.0.1:80")};
+  Network::ConnectionPtr upstream_connection_;
+  testing::NiceMock<Network::MockConnectionCallbacks> upstream_callbacks_;
+  Network::ClientConnection* client_connection_{};
+  NiceMock<Http::MockStreamEncoder> inner_encoder_;
+  NiceMock<Http::MockStreamDecoder> outer_decoder_;
+};
+
+// Send a block of data from upstream, and ensure it is received by the codec.
+TEST_P(CodecNetworkTest, SendData) {
+  createNewStream();
+
+  const std::string full_data = "HTTP/1.1 200 OK\r\ncontent-length: 0\r\n";
+  Buffer::OwnedImpl data(full_data);
+  upstream_connection_->write(data);
+  EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance& data) -> void {
+    EXPECT_EQ(full_data, TestUtility::bufferToString(data));
+    dispatcher_->exit();
+  }));
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
+
+  EXPECT_CALL(inner_encoder_.stream_, resetStream(_));
+  close();
+}
+
+// Send a block of data, and then have upstream close the connection.
+// Make sure that the data is passed on as is the network event.
+TEST_P(CodecNetworkTest, SendHeadersAndClose) {
+  createNewStream();
+
+  // Send some header data.
+  const std::string full_data = "HTTP/1.1 200 OK\r\ncontent-length: 0\r\n";
+  Buffer::OwnedImpl data(full_data);
+  upstream_connection_->write(data);
+  upstream_connection_->close(Network::ConnectionCloseType::FlushWrite);
+  EXPECT_CALL(*codec_, dispatch(_))
+      .Times(2)
+      .WillOnce(Invoke([&](Buffer::Instance& data) -> void {
+        EXPECT_EQ(full_data, TestUtility::bufferToString(data));
+      }))
+      .WillOnce(Invoke([&](Buffer::Instance& data) -> void {
+        EXPECT_EQ("", TestUtility::bufferToString(data));
+      }));
+  // Because the headers are not complete, the disconnect will reset the stream.
+  // Note even if the final \r\n were appended to the header data, enough of the
+  // codec state is mocked out that the data would not be framed and the stream
+  // would not be finished.
+  EXPECT_CALL(inner_encoder_.stream_, resetStream(_)).WillOnce(InvokeWithoutArgs([&]() -> void {
+    for (auto callbacks : inner_encoder_.stream_.callbacks_) {
+      callbacks->onResetStream(StreamResetReason::RemoteReset);
+    }
+    dispatcher_->exit();
+  }));
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
+}
+
+// Mark the stream read disabled, then send a block of data and close the connection.  Ensure the
+// data is drained before the connection close is processed.
+// Regression test for https://github.com/envoyproxy/envoy/issues/1679
+TEST_P(CodecNetworkTest, SendHeadersAndCloseUnderReadDisable) {
+  createNewStream();
+
+  client_connection_->readDisable(true);
+  const std::string full_data = "HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n";
+  Buffer::OwnedImpl data(full_data);
+  upstream_connection_->write(data);
+  upstream_connection_->close(Network::ConnectionCloseType::FlushWrite);
+
+  dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+  client_connection_->readDisable(false);
+
+  EXPECT_CALL(*codec_, dispatch(_))
+      .Times(2)
+      .WillOnce(Invoke([&](Buffer::Instance& data) -> void {
+        EXPECT_EQ(full_data, TestUtility::bufferToString(data));
+      }))
+      .WillOnce(Invoke([&](Buffer::Instance& data) -> void {
+        EXPECT_EQ("", TestUtility::bufferToString(data));
+      }));
+  EXPECT_CALL(inner_encoder_.stream_, resetStream(_)).WillOnce(InvokeWithoutArgs([&]() -> void {
+    for (auto callbacks : inner_encoder_.stream_.callbacks_) {
+      callbacks->onResetStream(StreamResetReason::RemoteReset);
+    }
+    dispatcher_->exit();
+  }));
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
+}
+
+INSTANTIATE_TEST_CASE_P(IpVersions, CodecNetworkTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 } // namespace Http
 } // namespace Envoy

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -289,7 +289,12 @@ TEST_P(ConnectionImplTest, ReadDisable) {
   disconnect(false);
 }
 
-TEST_P(ConnectionImplTest, CloseOnNormalReadDisable) {
+TEST_P(ConnectionImplTest, EarlyCloseOnReadDisabledConnection) {
+#ifdef __APPLE__
+  // On our current OSX build, the client connection does not get the early
+  // close notification and instead gets the close after reading the FIN.
+  return;
+#endif
   setUpBasicConnection();
   connect();
 

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -58,6 +58,7 @@ public:
   MOCK_CONST_METHOD0(nextProtocol, std::string());
   MOCK_METHOD1(noDelay, void(bool enable));
   MOCK_METHOD1(readDisable, void(bool disable));
+  MOCK_METHOD1(detectEarlyCloseWhenReadDisabled, void(bool));
   MOCK_CONST_METHOD0(readEnabled, bool());
   MOCK_CONST_METHOD0(remoteAddress, const Address::Instance&());
   MOCK_CONST_METHOD0(localAddress, const Address::Instance&());
@@ -93,6 +94,7 @@ public:
   MOCK_CONST_METHOD0(nextProtocol, std::string());
   MOCK_METHOD1(noDelay, void(bool enable));
   MOCK_METHOD1(readDisable, void(bool disable));
+  MOCK_METHOD1(detectEarlyCloseWhenReadDisabled, void(bool));
   MOCK_CONST_METHOD0(readEnabled, bool());
   MOCK_CONST_METHOD0(remoteAddress, const Address::Instance&());
   MOCK_CONST_METHOD0(localAddress, const Address::Instance&());


### PR DESCRIPTION
This solves the problem where an HTTP upstream connection which is readDisable()d can process the FIN before processing the underlying data

fixes #1679