### PR TITLE
fixing a test flake by ignoring the backend connection data/disconnect

### DIFF
--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -600,28 +600,28 @@ void HttpIntegrationTest::testRetryHittingBufferLimit() {
 // Test hitting the dynamo filter with too many request bytes to buffer.  Ensure the connection
 // manager sends a 413.
 void HttpIntegrationTest::testHittingDecoderFilterLimit() {
-  executeActions(
-      {[&]() -> void {
-         codec_client_ = makeHttpConnection(lookupPort("dynamo_with_buffer_limits"));
-       },
-       [&]() -> void {
-         // Envoy will likely connect and proxy some unspecified amount of data before
-         // hitting the buffer limit and disconnecting.  Ignore this if it happens.
-         fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
-         codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                                    {":path", "/dynamo/url"},
-                                                                    {":scheme", "http"},
-                                                                    {":authority", "host"},
-                                                                    {"x-forwarded-for", "10.0.0.1"},
-                                                                    {"x-envoy-retry-on", "5xx"}},
-                                            1024 * 65, *response_);
-       },
-       [&]() -> void {
-         response_->waitForEndStream();
-         EXPECT_TRUE(response_->complete());
-         EXPECT_STREQ("413", response_->headers().Status()->value().c_str());
-       },
-       [&]() -> void { cleanupUpstreamAndDownstream(); }});
+  executeActions({[&]() -> void {
+                    codec_client_ = makeHttpConnection(lookupPort("dynamo_with_buffer_limits"));
+                  },
+                  [&]() -> void {
+                    // Envoy will likely connect and proxy some unspecified amount of data before
+                    // hitting the buffer limit and disconnecting.  Ignore this if it happens.
+                    fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
+                    codec_client_->makeRequestWithBody(
+                        Http::TestHeaderMapImpl{{":method", "POST"},
+                                                {":path", "/dynamo/url"},
+                                                {":scheme", "http"},
+                                                {":authority", "host"},
+                                                {"x-forwarded-for", "10.0.0.1"},
+                                                {"x-envoy-retry-on", "5xx"}},
+                        1024 * 65, *response_);
+                  },
+                  [&]() -> void {
+                    response_->waitForEndStream();
+                    EXPECT_TRUE(response_->complete());
+                    EXPECT_STREQ("413", response_->headers().Status()->value().c_str());
+                  },
+                  [&]() -> void { cleanupUpstreamAndDownstream(); }});
 }
 
 // Test hitting the dynamo filter with too many response bytes to buffer.  Given the request headers


### PR DESCRIPTION
Fixes #1685

I do believe there's an inherent race in the end to end tests wherein any time a client sends headers, Envoy could establish the upstream connection before waitForHttpConnection.  I suspect it's only a problem with large-body tests where we send the headers and body together.  I started on the longer fix where we kill the assertion that the connection is parented_ in onEvent and instead queue events to be dispatch on set_parented, but that turns out to not work for this case since by the time the events are processed we've picked up the disconnect and it caused some other ASSERT failure so I went with the simple fix here.