### PR TITLE
Call c_str for regex ctor to resolve local string compat issues.

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -422,7 +422,7 @@ RegexRouteEntryImpl::RegexRouteEntryImpl(const VirtualHostImpl& vhost,
                                          const envoy::api::v2::Route& route,
                                          Runtime::Loader& loader)
     : RouteEntryImplBase(vhost, route, loader),
-      regex_(std::regex{route.match().regex(), std::regex::optimize}) {}
+      regex_(std::regex{route.match().regex().c_str(), std::regex::optimize}) {}
 
 void RegexRouteEntryImpl::finalizeRequestHeaders(Http::HeaderMap& headers) const {
   RouteEntryImplBase::finalizeRequestHeaders(headers);


### PR DESCRIPTION
Resolve any incompatibilities between std::string and local string (versa_string in this case) by instead passing c_str() to std::regex ctor.

@htuch 