### PR TITLE
http/2: disable push via settings

### DIFF
--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -231,7 +231,7 @@ protected:
   StreamImpl* getStream(int32_t stream_id);
   int saveHeader(const nghttp2_frame* frame, HeaderString&& name, HeaderString&& value);
   void sendPendingFrames();
-  void sendSettings(const Http2Settings& http2_settings);
+  void sendSettings(const Http2Settings& http2_settings, bool disable_push);
 
   static Http2Callbacks http2_callbacks_;
   static Http2Options http2_options_;


### PR DESCRIPTION
We don't currently handle push promise frames so disable them in
client settings. nghttp2 will fail a connection where remote ignores
this setting to protect us. Unfortunately there is no great way to
test this change explicitly without doing a ton more work so I'm
suggesting we rely on our existing integration tests to make sure things
are fundamentally OK. This change will be unwound when we fully support
push promise proxy.

Fixes https://github.com/envoyproxy/envoy/issues/1693

Signed-off-by: Matt Klein <mklein@lyft.com>