### PR TITLE
Add tests to cover HTTP health checker callbacks

### DIFF
--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -627,13 +627,8 @@ TEST_F(HttpHealthCheckerImplTest, StreamReachesWatermarkDuringCheck) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
 
-  for (auto* callback : test_sessions_[0]->request_encoder_.stream_.callbacks_) {
-    callback->onAboveWriteBufferHighWatermark();
-  }
-
-  for (auto* callback : test_sessions_[0]->request_encoder_.stream_.callbacks_) {
-    callback->onBelowWriteBufferLowWatermark();
-  }
+  test_sessions_[0]->request_encoder_.stream_.runHighWatermarkCallbacks();
+  test_sessions_[0]->request_encoder_.stream_.runLowWatermarkCallbacks();
 
   respond(0, "200", true);
   EXPECT_TRUE(cluster_->hosts_[0]->healthy());

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -614,6 +614,31 @@ TEST_F(HttpHealthCheckerImplTest, RemoteCloseBetweenChecks) {
   EXPECT_TRUE(cluster_->hosts_[0]->healthy());
 }
 
+TEST_F(HttpHealthCheckerImplTest, ReachesWatermarkDuringCheck) {
+  setupNoServiceValidationHC();
+  EXPECT_CALL(*this, onHostStatus(_, false));
+
+  cluster_->hosts_ = {makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectStreamCreate(0);
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+
+  for (auto* callback : test_sessions_[0]->request_encoder_.stream_.callbacks_) {
+    callback->onAboveWriteBufferHighWatermark();
+  }
+
+  for (auto* callback : test_sessions_[0]->request_encoder_.stream_.callbacks_) {
+    callback->onBelowWriteBufferLowWatermark();
+  }
+
+  respond(0, "200", true);
+  EXPECT_TRUE(cluster_->hosts_[0]->healthy());
+}
+
 TEST(TcpHealthCheckMatcher, loadJsonBytes) {
   {
     Protobuf::RepeatedPtrField<envoy::api::v2::HealthCheck::Payload> repeated_payload;

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -647,13 +647,8 @@ TEST_F(HttpHealthCheckerImplTest, ConnectionReachesWatermarkDuringCheck) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
 
-  for (auto* callback : test_sessions_[0]->client_connection_->callbacks_) {
-    callback->onAboveWriteBufferHighWatermark();
-  }
-
-  for (auto* callback : test_sessions_[0]->client_connection_->callbacks_) {
-    callback->onBelowWriteBufferLowWatermark();
-  }
+  test_sessions_[0]->client_connection_->runHighWatermarkCallbacks();
+  test_sessions_[0]->client_connection_->runLowWatermarkCallbacks();
 
   respond(0, "200", true);
   EXPECT_TRUE(cluster_->hosts_[0]->healthy());

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -164,6 +164,18 @@ public:
   MOCK_METHOD0(bufferLimit, uint32_t());
 
   std::list<StreamCallbacks*> callbacks_{};
+
+  void runHighWatermarkCallbacks() {
+    for (auto* callback : callbacks_) {
+      callback->onAboveWriteBufferHighWatermark();
+    }
+  }
+
+  void runLowWatermarkCallbacks() {
+    for (auto* callback : callbacks_) {
+      callback->onBelowWriteBufferLowWatermark();
+    }
+  }
 };
 
 class MockStreamEncoder : public StreamEncoder {

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -42,6 +42,18 @@ void MockConnectionBase::raiseEvent(Network::ConnectionEvent event) {
   }
 }
 
+void MockConnectionBase::runHighWatermarkCallbacks() {
+  for (auto* callback : callbacks_) {
+    callback->onAboveWriteBufferHighWatermark();
+  }
+}
+
+void MockConnectionBase::runLowWatermarkCallbacks() {
+  for (auto* callback : callbacks_) {
+    callback->onBelowWriteBufferLowWatermark();
+  }
+}
+
 template <class T> static void initializeMockConnection(T& connection) {
   ON_CALL(connection, dispatcher()).WillByDefault(ReturnRef(connection.dispatcher_));
   ON_CALL(connection, readEnabled()).WillByDefault(ReturnPointee(&connection.read_enabled_));

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -30,6 +30,8 @@ public:
 class MockConnectionBase {
 public:
   void raiseEvent(Network::ConnectionEvent event);
+  void runHighWatermarkCallbacks();
+  void runLowWatermarkCallbacks();
 
   static uint64_t next_id_;
 
@@ -108,19 +110,6 @@ public:
 
   // Network::ClientConnection
   MOCK_METHOD0(connect, void());
-
-  // helper methods for testing
-  void runHighWatermarkCallbacks() {
-    for (auto* callback : callbacks_) {
-      callback->onAboveWriteBufferHighWatermark();
-    }
-  }
-
-  void runLowWatermarkCallbacks() {
-    for (auto* callback : callbacks_) {
-      callback->onBelowWriteBufferLowWatermark();
-    }
-  }
 };
 
 class MockActiveDnsQuery : public ActiveDnsQuery {

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -108,6 +108,19 @@ public:
 
   // Network::ClientConnection
   MOCK_METHOD0(connect, void());
+
+  // helper methods for testing
+  void runHighWatermarkCallbacks() {
+    for (auto* callback : callbacks_) {
+      callback->onAboveWriteBufferHighWatermark();
+    }
+  }
+
+  void runLowWatermarkCallbacks() {
+    for (auto* callback : callbacks_) {
+      callback->onBelowWriteBufferLowWatermark();
+    }
+  }
 };
 
 class MockActiveDnsQuery : public ActiveDnsQuery {


### PR DESCRIPTION
The methods under test are no-ops, but are not covered by any existing tests. Add some simple sanity checks to make sure that the callbacks don't blow anything up if high water marks are reached.