### PR TITLE
Recover the OT context header from the B3 headers if not propagated

### DIFF
--- a/source/common/tracing/zipkin/span_context.h
+++ b/source/common/tracing/zipkin/span_context.h
@@ -20,6 +20,17 @@ public:
   SpanContext() : trace_id_(0), id_(0), parent_id_(0), is_initialized_(false) {}
 
   /**
+   * Constructor that creates a context object from the supplied trace, span
+   * and parent ids.
+   *
+   * @param trace_id The trace id.
+   * @param id The span id.
+   * @param parent_id The parent id.
+   */
+  SpanContext(const uint64_t trace_id, const uint64_t id, const uint64_t parent_id)
+      : trace_id_(trace_id), id_(id), parent_id_(parent_id), is_initialized_(true) {}
+
+  /**
    * Constructor that creates a context object from the given Zipkin span object.
    *
    * @param span The Zipkin span used to initialize a SpanContext object.

--- a/source/common/tracing/zipkin/zipkin_tracer_impl.cc
+++ b/source/common/tracing/zipkin/zipkin_tracer_impl.cc
@@ -109,17 +109,17 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config, Http::HeaderMa
     new_zipkin_span =
         tracer.startSpan(config, request_headers.Host()->value().c_str(), start_time, context);
   } else if (request_headers.XB3TraceId() && request_headers.XB3SpanId()) {
-    uint64_t traceId(0);
-    uint64_t spanId(0);
-    uint64_t parentId(0);
-    if (!StringUtil::atoul(request_headers.XB3TraceId()->value().c_str(), traceId, 16) ||
-        !StringUtil::atoul(request_headers.XB3SpanId()->value().c_str(), spanId, 16) ||
+    uint64_t trace_id(0);
+    uint64_t span_id(0);
+    uint64_t parent_id(0);
+    if (!StringUtil::atoul(request_headers.XB3TraceId()->value().c_str(), trace_id, 16) ||
+        !StringUtil::atoul(request_headers.XB3SpanId()->value().c_str(), span_id, 16) ||
         (request_headers.XB3ParentSpanId() &&
-         !StringUtil::atoul(request_headers.XB3ParentSpanId()->value().c_str(), parentId, 16))) {
+         !StringUtil::atoul(request_headers.XB3ParentSpanId()->value().c_str(), parent_id, 16))) {
       return Tracing::SpanPtr(new Tracing::NullSpan());
     }
 
-    SpanContext context(traceId, spanId, parentId);
+    SpanContext context(trace_id, span_id, parent_id);
 
     new_zipkin_span =
         tracer.startSpan(config, request_headers.Host()->value().c_str(), start_time, context);

--- a/source/common/tracing/zipkin/zipkin_tracer_impl.cc
+++ b/source/common/tracing/zipkin/zipkin_tracer_impl.cc
@@ -107,6 +107,20 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config, Http::HeaderMa
 
     new_zipkin_span =
         tracer.startSpan(config, request_headers.Host()->value().c_str(), start_time, context);
+
+  } else if (request_headers.XB3TraceId() && request_headers.XB3SpanId()) {
+    uint64_t parentId(0);
+    if (request_headers.XB3ParentSpanId()) {
+      parentId = std::stoull(request_headers.XB3ParentSpanId()->value().c_str(), nullptr, 16);
+    }
+
+    SpanContext context(std::stoull(request_headers.XB3TraceId()->value().c_str(), nullptr, 16),
+                        std::stoull(request_headers.XB3SpanId()->value().c_str(), nullptr, 16),
+                        parentId);
+
+    new_zipkin_span =
+        tracer.startSpan(config, request_headers.Host()->value().c_str(), start_time, context);
+
   } else {
     // Create a root Zipkin span. No context was found in the headers.
     new_zipkin_span = tracer.startSpan(config, request_headers.Host()->value().c_str(), start_time);

--- a/source/common/tracing/zipkin/zipkin_tracer_impl.cc
+++ b/source/common/tracing/zipkin/zipkin_tracer_impl.cc
@@ -112,19 +112,10 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config, Http::HeaderMa
     uint64_t traceId(0);
     uint64_t spanId(0);
     uint64_t parentId(0);
-    if (!StringUtil::atoul(request_headers.XB3TraceId()->value().c_str(), traceId, 16)) {
-      throw EnvoyException(fmt::format("invalid hex string for XB3TraceId '{}'",
-                                       request_headers.XB3TraceId()->value().c_str()));
-    }
-    if (!StringUtil::atoul(request_headers.XB3SpanId()->value().c_str(), spanId, 16)) {
-      throw EnvoyException(fmt::format("invalid hex string for XB3SpanId '{}'",
-                                       request_headers.XB3SpanId()->value().c_str()));
-    }
-    if (request_headers.XB3ParentSpanId()) {
-      if (!StringUtil::atoul(request_headers.XB3ParentSpanId()->value().c_str(), parentId, 16)) {
-        throw EnvoyException(fmt::format("invalid hex string for XB3ParentSpanId '{}'",
-                                         request_headers.XB3ParentSpanId()->value().c_str()));
-      }
+    if (!StringUtil::atoul(request_headers.XB3TraceId()->value().c_str(), traceId, 16)
+        || !StringUtil::atoul(request_headers.XB3SpanId()->value().c_str(), spanId, 16)
+        || (request_headers.XB3ParentSpanId() && !StringUtil::atoul(request_headers.XB3ParentSpanId()->value().c_str(), parentId, 16))) {
+      return nullptr;
     }
 
     SpanContext context(traceId, spanId, parentId);

--- a/source/common/tracing/zipkin/zipkin_tracer_impl.cc
+++ b/source/common/tracing/zipkin/zipkin_tracer_impl.cc
@@ -112,10 +112,11 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config, Http::HeaderMa
     uint64_t traceId(0);
     uint64_t spanId(0);
     uint64_t parentId(0);
-    if (!StringUtil::atoul(request_headers.XB3TraceId()->value().c_str(), traceId, 16)
-        || !StringUtil::atoul(request_headers.XB3SpanId()->value().c_str(), spanId, 16)
-        || (request_headers.XB3ParentSpanId() && !StringUtil::atoul(request_headers.XB3ParentSpanId()->value().c_str(), parentId, 16))) {
-      return nullptr;
+    if (!StringUtil::atoul(request_headers.XB3TraceId()->value().c_str(), traceId, 16) ||
+        !StringUtil::atoul(request_headers.XB3SpanId()->value().c_str(), spanId, 16) ||
+        (request_headers.XB3ParentSpanId() &&
+         !StringUtil::atoul(request_headers.XB3ParentSpanId()->value().c_str(), parentId, 16))) {
+      return Tracing::SpanPtr(new Tracing::NullSpan());
     }
 
     SpanContext context(traceId, spanId, parentId);

--- a/test/common/tracing/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/common/tracing/zipkin/zipkin_tracer_impl_test.cc
@@ -398,8 +398,7 @@ TEST_F(ZipkinDriverTest, ZipkinSpanContextFromInvalidTraceIdB3HeadersTest) {
   request_headers_.insertXB3SpanId().value(Hex::uint64ToHex(Util::generateRandom64()));
   request_headers_.insertXB3ParentSpanId().value(Hex::uint64ToHex(Util::generateRandom64()));
 
-  EXPECT_THROW(driver_->startSpan(config_, request_headers_, operation_name_, start_time_),
-               EnvoyException);
+  EXPECT_EQ(nullptr, driver_->startSpan(config_, request_headers_, operation_name_, start_time_));
 }
 
 TEST_F(ZipkinDriverTest, ZipkinSpanContextFromInvalidSpanIdB3HeadersTest) {
@@ -409,8 +408,7 @@ TEST_F(ZipkinDriverTest, ZipkinSpanContextFromInvalidSpanIdB3HeadersTest) {
   request_headers_.insertXB3SpanId().value(std::string("xyz"));
   request_headers_.insertXB3ParentSpanId().value(Hex::uint64ToHex(Util::generateRandom64()));
 
-  EXPECT_THROW(driver_->startSpan(config_, request_headers_, operation_name_, start_time_),
-               EnvoyException);
+  EXPECT_EQ(nullptr, driver_->startSpan(config_, request_headers_, operation_name_, start_time_));
 }
 
 TEST_F(ZipkinDriverTest, ZipkinSpanContextFromInvalidParentIdB3HeadersTest) {
@@ -420,8 +418,7 @@ TEST_F(ZipkinDriverTest, ZipkinSpanContextFromInvalidParentIdB3HeadersTest) {
   request_headers_.insertXB3SpanId().value(Hex::uint64ToHex(Util::generateRandom64()));
   request_headers_.insertXB3ParentSpanId().value(std::string("xyz"));
 
-  EXPECT_THROW(driver_->startSpan(config_, request_headers_, operation_name_, start_time_),
-               EnvoyException);
+  EXPECT_EQ(nullptr, driver_->startSpan(config_, request_headers_, operation_name_, start_time_));
 }
 } // namespace Zipkin
 } // namespace Envoy

--- a/test/common/tracing/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/common/tracing/zipkin/zipkin_tracer_impl_test.cc
@@ -390,5 +390,38 @@ TEST_F(ZipkinDriverTest, ZipkinSpanContextFromB3HeadersTest) {
   EXPECT_EQ(span_id, zipkin_span->span().idAsHexString());
   EXPECT_EQ(parent_id, zipkin_span->span().parentIdAsHexString());
 }
+
+TEST_F(ZipkinDriverTest, ZipkinSpanContextFromInvalidTraceIdB3HeadersTest) {
+  setupValidDriver();
+
+  request_headers_.insertXB3TraceId().value(std::string("xyz"));
+  request_headers_.insertXB3SpanId().value(Hex::uint64ToHex(Util::generateRandom64()));
+  request_headers_.insertXB3ParentSpanId().value(Hex::uint64ToHex(Util::generateRandom64()));
+
+  EXPECT_THROW(driver_->startSpan(config_, request_headers_, operation_name_, start_time_),
+               EnvoyException);
+}
+
+TEST_F(ZipkinDriverTest, ZipkinSpanContextFromInvalidSpanIdB3HeadersTest) {
+  setupValidDriver();
+
+  request_headers_.insertXB3TraceId().value(Hex::uint64ToHex(Util::generateRandom64()));
+  request_headers_.insertXB3SpanId().value(std::string("xyz"));
+  request_headers_.insertXB3ParentSpanId().value(Hex::uint64ToHex(Util::generateRandom64()));
+
+  EXPECT_THROW(driver_->startSpan(config_, request_headers_, operation_name_, start_time_),
+               EnvoyException);
+}
+
+TEST_F(ZipkinDriverTest, ZipkinSpanContextFromInvalidParentIdB3HeadersTest) {
+  setupValidDriver();
+
+  request_headers_.insertXB3TraceId().value(Hex::uint64ToHex(Util::generateRandom64()));
+  request_headers_.insertXB3SpanId().value(Hex::uint64ToHex(Util::generateRandom64()));
+  request_headers_.insertXB3ParentSpanId().value(std::string("xyz"));
+
+  EXPECT_THROW(driver_->startSpan(config_, request_headers_, operation_name_, start_time_),
+               EnvoyException);
+}
 } // namespace Zipkin
 } // namespace Envoy

--- a/test/common/tracing/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/common/tracing/zipkin/zipkin_tracer_impl_test.cc
@@ -344,5 +344,51 @@ TEST_F(ZipkinDriverTest, ZipkinSpanTest) {
   EXPECT_EQ("key3", zipkin_zipkin_span3.binaryAnnotations()[0].key());
   EXPECT_EQ("value3", zipkin_zipkin_span3.binaryAnnotations()[0].value());
 }
+
+TEST_F(ZipkinDriverTest, ZipkinSpanContextFromOtSpanContextHeaderTest) {
+  setupValidDriver();
+
+  const std::string trace_id = Hex::uint64ToHex(Util::generateRandom64());
+  const std::string span_id = Hex::uint64ToHex(Util::generateRandom64());
+  const std::string parent_id = Hex::uint64ToHex(Util::generateRandom64());
+  const std::string context =
+      trace_id + ";" + span_id + ";" + parent_id + ";" + ZipkinCoreConstants::get().CLIENT_SEND;
+
+  request_headers_.insertOtSpanContext().value(context);
+
+  // New span will have an SR annotation - so its span and parent ids will be
+  // the same as the supplied span context (i.e. shared context)
+  Tracing::SpanPtr span =
+      driver_->startSpan(config_, request_headers_, operation_name_, start_time_);
+
+  ZipkinSpanPtr zipkin_span(dynamic_cast<ZipkinSpan*>(span.release()));
+
+  EXPECT_EQ(trace_id, zipkin_span->span().traceIdAsHexString());
+  EXPECT_EQ(span_id, zipkin_span->span().idAsHexString());
+  EXPECT_EQ(parent_id, zipkin_span->span().parentIdAsHexString());
+}
+
+TEST_F(ZipkinDriverTest, ZipkinSpanContextFromB3HeadersTest) {
+  setupValidDriver();
+
+  const std::string trace_id = Hex::uint64ToHex(Util::generateRandom64());
+  const std::string span_id = Hex::uint64ToHex(Util::generateRandom64());
+  const std::string parent_id = Hex::uint64ToHex(Util::generateRandom64());
+
+  request_headers_.insertXB3TraceId().value(trace_id);
+  request_headers_.insertXB3SpanId().value(span_id);
+  request_headers_.insertXB3ParentSpanId().value(parent_id);
+
+  // New span will have an SR annotation - so its span and parent ids will be
+  // the same as the supplied span context (i.e. shared context)
+  Tracing::SpanPtr span =
+      driver_->startSpan(config_, request_headers_, operation_name_, start_time_);
+
+  ZipkinSpanPtr zipkin_span(dynamic_cast<ZipkinSpan*>(span.release()));
+
+  EXPECT_EQ(trace_id, zipkin_span->span().traceIdAsHexString());
+  EXPECT_EQ(span_id, zipkin_span->span().idAsHexString());
+  EXPECT_EQ(parent_id, zipkin_span->span().parentIdAsHexString());
+}
 } // namespace Zipkin
 } // namespace Envoy

--- a/test/common/tracing/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/common/tracing/zipkin/zipkin_tracer_impl_test.cc
@@ -398,7 +398,9 @@ TEST_F(ZipkinDriverTest, ZipkinSpanContextFromInvalidTraceIdB3HeadersTest) {
   request_headers_.insertXB3SpanId().value(Hex::uint64ToHex(Util::generateRandom64()));
   request_headers_.insertXB3ParentSpanId().value(Hex::uint64ToHex(Util::generateRandom64()));
 
-  EXPECT_EQ(nullptr, driver_->startSpan(config_, request_headers_, operation_name_, start_time_));
+  Tracing::SpanPtr span =
+      driver_->startSpan(config_, request_headers_, operation_name_, start_time_);
+  EXPECT_NE(nullptr, dynamic_cast<Tracing::NullSpan*>(span.get()));
 }
 
 TEST_F(ZipkinDriverTest, ZipkinSpanContextFromInvalidSpanIdB3HeadersTest) {
@@ -408,7 +410,9 @@ TEST_F(ZipkinDriverTest, ZipkinSpanContextFromInvalidSpanIdB3HeadersTest) {
   request_headers_.insertXB3SpanId().value(std::string("xyz"));
   request_headers_.insertXB3ParentSpanId().value(Hex::uint64ToHex(Util::generateRandom64()));
 
-  EXPECT_EQ(nullptr, driver_->startSpan(config_, request_headers_, operation_name_, start_time_));
+  Tracing::SpanPtr span =
+      driver_->startSpan(config_, request_headers_, operation_name_, start_time_);
+  EXPECT_NE(nullptr, dynamic_cast<Tracing::NullSpan*>(span.get()));
 }
 
 TEST_F(ZipkinDriverTest, ZipkinSpanContextFromInvalidParentIdB3HeadersTest) {
@@ -418,7 +422,9 @@ TEST_F(ZipkinDriverTest, ZipkinSpanContextFromInvalidParentIdB3HeadersTest) {
   request_headers_.insertXB3SpanId().value(Hex::uint64ToHex(Util::generateRandom64()));
   request_headers_.insertXB3ParentSpanId().value(std::string("xyz"));
 
-  EXPECT_EQ(nullptr, driver_->startSpan(config_, request_headers_, operation_name_, start_time_));
+  Tracing::SpanPtr span =
+      driver_->startSpan(config_, request_headers_, operation_name_, start_time_);
+  EXPECT_NE(nullptr, dynamic_cast<Tracing::NullSpan*>(span.get()));
 }
 } // namespace Zipkin
 } // namespace Envoy


### PR DESCRIPTION
Resolves #1364 

This fixes the issue by detecting that the OtSpanContext header has not been propagated, but the B3 headers have - and therefore will use those values instead.

This means that when an application is only concerned with propagating the span context, they only need to propagate the OtSpanContext header (not the B3 headers) - which is also supported prior to this PR. However if they wish to use a B3 compatible tracer to augment the tracing information within their application, then this tracer would only need to propagate the B3 headers to any outbound (Egress) connections.

So this will simplify the manual propagation case - only one header to propagate, while still allowing more complex tracing requirements to be addressed.

If this change is acceptable, then we may want to consider removing the B3 header propagation from the docs and examples, and instead have a section discussing the case where the application can enhance the default tracing information by using a suitable tracer directly?