### PR TITLE
json: remove enable_shared_from_this

### DIFF
--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -37,7 +37,7 @@ namespace {
 class Field;
 typedef std::shared_ptr<Field> FieldSharedPtr;
 
-class Field : public Object, public std::enable_shared_from_this<Field> {
+class Field : public Object {
 public:
   void setLineNumberStart(uint64_t line_number) { line_number_start_ = line_number; }
   void setLineNumberEnd(uint64_t line_number) { line_number_end_ = line_number; }


### PR DESCRIPTION
I was looking at https://github.com/envoyproxy/envoy/issues/1684
and noticed this. I doubt it's related but we should remove it if
not used.

Signed-off-by: Matt Klein <mklein@lyft.com>