### PR TITLE
Porting the SSL test to use protos

### DIFF
--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -54,6 +54,9 @@ public:
   // Sets the client codec to the specified type.
   void setClientCodec(envoy::api::v2::filter::HttpConnectionManager::CodecType type);
 
+  // Add the default SSL configuration.
+  void addSslConfig();
+
   // Allows callers to do their own modification to |bootstrap_| which will be
   // applied just before ports are modified in finalize().
   void addConfigModifier(ConfigModifierFunction function);

--- a/test/integration/ssl_integration_test.h
+++ b/test/integration/ssl_integration_test.h
@@ -15,34 +15,11 @@ using testing::NiceMock;
 namespace Envoy {
 namespace Ssl {
 
-class MockRuntimeIntegrationTestServer : public IntegrationTestServer {
-public:
-  static IntegrationTestServerPtr create(const std::string& config_path,
-                                         Network::Address::IpVersion version) {
-    IntegrationTestServerPtr server{new MockRuntimeIntegrationTestServer(config_path)};
-    server->start(version);
-    return server;
-  }
-
-  // Server::ComponentFactory
-  Runtime::LoaderPtr createRuntime(Server::Instance&, Server::Configuration::Initial&) override {
-    runtime_ = new NiceMock<Runtime::MockLoader>();
-    return Runtime::LoaderPtr{runtime_};
-  }
-
-  Runtime::MockLoader* runtime_;
-
-private:
-  MockRuntimeIntegrationTestServer(const std::string& config_path)
-      : IntegrationTestServer(config_path) {}
-};
-
 class SslIntegrationTest : public HttpIntegrationTest,
                            public testing::TestWithParam<Network::Address::IpVersion> {
 public:
   SslIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
 
-  // Use old style configuration for now.
   void initialize() override;
 
   void TearDown() override;

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -117,7 +117,7 @@ void XfccIntegrationTest::startTestServerWithXfccConfig(std::string fcc, std::st
   param_map["set_current_client_cert_details"] = sccd;
   std::string config = TestEnvironment::temporaryFileSubstitute(
       "test/config/integration/server_xfcc.json", param_map, port_map_, version_);
-  test_server_ = Ssl::MockRuntimeIntegrationTestServer::create(config, version_);
+  test_server_ = IntegrationTestServer::create(config, version_);
   registerTestServerPorts({"ssl", "plain"});
 }
 

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -212,9 +212,11 @@ void TestEnvironment::exec(const std::vector<std::string>& args) {
 std::string TestEnvironment::writeStringToFileForTest(const std::string& filename,
                                                       const std::string& contents) {
   const std::string out_path = TestEnvironment::temporaryPath(filename);
+  RELEASE_ASSERT(::system(("mkdir -p $(dirname " + out_path + ")").c_str()) == 0);
   unlink(out_path.c_str());
   {
     std::ofstream out_file(out_path);
+    RELEASE_ASSERT(!out_file.fail());
     out_file << contents;
   }
   return out_path;


### PR DESCRIPTION
Includes changes to use the real runtime libraries now that we have better file utilities.

If you don't object I'm going to claim this
Fixes #1162
As I think it's the last major feature to not have utilities.  We can file a follow-up issue to move the rest of the test over, or leave some on json until we stop supporting v1 config.  I think we're at a point where I'd encourage folks to add their own dynamic config rather than creating new json files though.