### PR TITLE
owners: move Roman to emeritus

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -8,7 +8,6 @@
 
 # Committers
 
-* Roman Dzhabarov ([RomanDzhabarov](https://github.com/RomanDzhabarov)) (rdzhabarov@lyft.com)
 * Constance Caramanolis ([ccaraman](https://github.com/ccaraman)) (ccaramanolis@lyft.com)
 * Jose Nino ([junr03](https://github.com/junr03)) (jnino@lyft.com)
 * Dan Noé ([dnoe](https://github.com/dnoe)) (dpn@google.com)
@@ -17,4 +16,5 @@
 
 # Emeritus committers
 
+* Roman Dzhabarov ([RomanDzhabarov](https://github.com/RomanDzhabarov)) (rdzhabarov@lyft.com)
 * Bill Gallagher ([wgallagher](https://github.com/wgallagher)) (bgallagher@lyft.com)


### PR DESCRIPTION
Roman has decided to leave us for bigger and better things.
Thank you Roman for your contributions over the last 2 years.

Signed-off-by: Matt Klein <mklein@lyft.com>