### PR TITLE
upstream: subsetting load balancer [rough draft]

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -112,7 +112,7 @@ def envoy_api_deps(skip_targets):
     native.git_repository(
         name = "envoy_api",
         remote = REPO_LOCATIONS["envoy_api"],
-        commit = "9be6aff6da46e024af56cce20cb5d5d3184f19c5",
+        commit = "d8ac22d4ff167a1f44229264bfa8d0f9abc3608f",
     )
     api_bind_targets = [
         "address",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,7 +1,7 @@
 REPO_LOCATIONS = {
     "jinja2": "https://github.com/pallets/jinja.git",
     "grpc_transcoding": "https://github.com/grpc-ecosystem/grpc-httpjson-transcoding.git",
-    "envoy_api": "https://github.com/envoyproxy/data-plane-api.git",
+    "envoy_api": "https://github.com/turbinelabs/data-plane-api.git",
     "protobuf" :"https://github.com/htuch/protobuf.git",
     "markupsafe": "https://github.com/pallets/markupsafe.git",
 }

--- a/include/envoy/router/BUILD
+++ b/include/envoy/router/BUILD
@@ -36,9 +36,12 @@ envoy_cc_library(
     hdrs = ["router.h"],
     deps = [
         "//include/envoy/common:optional",
+        "//include/envoy/http:access_log_interface",
         "//include/envoy/http:codec_interface",
         "//include/envoy/http:header_map_interface",
+        "//include/envoy/tracing:http_tracer_interface",
         "//include/envoy/upstream:resource_manager_interface",
+        "//source/common/protobuf",
     ],
 )
 

--- a/include/envoy/upstream/BUILD
+++ b/include/envoy/upstream/BUILD
@@ -54,12 +54,19 @@ envoy_cc_library(
 envoy_cc_library(
     name = "load_balancer_interface",
     hdrs = ["load_balancer.h"],
-    deps = [":upstream_interface"],
+    deps = [
+        ":upstream_interface",
+        "//include/envoy/router:router_interface",
+    ],
 )
 
 envoy_cc_library(
     name = "load_balancer_type_interface",
     hdrs = ["load_balancer_type.h"],
+    external_deps = ["envoy_cds"],
+    deps = [
+        "//source/common/protobuf",
+    ],
 )
 
 envoy_cc_library(

--- a/include/envoy/upstream/load_balancer.h
+++ b/include/envoy/upstream/load_balancer.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "envoy/common/pure.h"
+#include "envoy/router/router.h"
 #include "envoy/upstream/upstream.h"
 
 namespace Envoy {
@@ -21,6 +22,8 @@ public:
    * @return Optional<uint64_t> the optional hash key to use during load balancing.
    */
   virtual Optional<uint64_t> hashKey() const PURE;
+
+  virtual const Router::MetadataMatches* metadataMatches() const PURE;
 
   /**
    * @return const Network::Connection* the incoming connection or nullptr to use during load

--- a/include/envoy/upstream/load_balancer_type.h
+++ b/include/envoy/upstream/load_balancer_type.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
+#include "common/protobuf/protobuf.h"
+
+#include "api/cds.pb.h"
+
 namespace Envoy {
 namespace Upstream {
 
@@ -7,6 +14,25 @@ namespace Upstream {
  * Type of load balancing to perform.
  */
 enum class LoadBalancerType { RoundRobin, LeastRequest, Random, RingHash, OriginalDst };
+
+class LoadBalancerSubsetInfo {
+public:
+  virtual ~LoadBalancerSubsetInfo() {}
+
+  virtual bool isEnabled() const PURE;
+
+  virtual envoy::api::v2::Cluster::LbSubsetConfig::LbSubsetFallbackPolicy
+  fallbackPolicy() const PURE;
+
+  virtual const ProtobufWkt::Struct& defaultSubset() const PURE;
+
+  /*
+   * @return const std:vector<std:vector<std::string>>& a vector of
+   * keys used to define load balancer subsets. The inner vector is
+   * lexically sorted.
+   */
+  virtual const std::vector<std::vector<std::string>>& subsetKeys() const PURE;
+};
 
 } // namespace Upstream
 } // namespace Envoy

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -338,6 +338,8 @@ public:
    * @return a source address to bind to or nullptr if no bind need occur.
    */
   virtual const Network::Address::InstanceConstSharedPtr& sourceAddress() const PURE;
+
+  virtual const LoadBalancerSubsetInfo& lbSubsetInfo() const PURE;
 };
 
 typedef std::shared_ptr<const ClusterInfo> ClusterInfoConstSharedPtr;

--- a/source/common/filter/BUILD
+++ b/source/common/filter/BUILD
@@ -47,6 +47,7 @@ envoy_cc_library(
         "//include/envoy/event:timer_interface",
         "//include/envoy/network:connection_interface",
         "//include/envoy/network:filter_interface",
+        "//include/envoy/router:router_interface",
         "//include/envoy/stats:stats_interface",
         "//include/envoy/stats:stats_macros",
         "//include/envoy/upstream:cluster_manager_interface",

--- a/source/common/filter/tcp_proxy.h
+++ b/source/common/filter/tcp_proxy.h
@@ -101,6 +101,7 @@ public:
 
   // Upstream::LoadBalancerContext
   Optional<uint64_t> hashKey() const override { return {}; }
+  const Router::MetadataMatches* metadataMatches() const override { return nullptr; }
   const Network::Connection* downstreamConnection() const override {
     return &read_callbacks_->connection();
   }

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -146,6 +146,7 @@ private:
     void finalizeRequestHeaders(Http::HeaderMap&,
                                 const Http::AccessLog::RequestInfo&) const override {}
     const Router::HashPolicy* hashPolicy() const override { return nullptr; }
+    const Router::MetadataMatches* metadataMatches() const override { return nullptr; }
     Upstream::ResourcePriority priority() const override {
       return Upstream::ResourcePriority::Default;
     }

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -75,4 +75,34 @@ void MessageUtil::jsonConvert(const Protobuf::Message& source, Protobuf::Message
   MessageUtil::loadFromJson(json, dest);
 }
 
+bool ValueUtil::equal(const ProtobufWkt::Value& v1, const ProtobufWkt::Value& v2) {
+  ProtobufWkt::Value::KindCase kind = v1.kind_case();
+  if (kind != v2.kind_case()) {
+    return false;
+  }
+
+  switch (kind) {
+  case ProtobufWkt::Value::kNullValue:
+    return true;
+
+  case ProtobufWkt::Value::kNumberValue:
+    return v1.number_value() == v2.number_value();
+
+  case ProtobufWkt::Value::kStringValue:
+    return v1.string_value() == v2.string_value();
+
+  case ProtobufWkt::Value::kBoolValue:
+    return v1.bool_value() == v2.bool_value();
+
+  case ProtobufWkt::Value::kStructValue:
+    return ProtobufUtil::MessageDifferencer::Equals(v1.struct_value(), v2.struct_value());
+
+  case ProtobufWkt::Value::kListValue:
+    return ProtobufUtil::MessageDifferencer::Equals(v1.list_value(), v2.list_value());
+
+  default:
+    RELEASE_ASSERT(false);
+  }
+}
+
 } // namespace Envoy

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -110,4 +110,11 @@ public:
   }
 };
 
+class ValueUtil {
+public:
+  static std::size_t hash(const ProtobufWkt::Value& value) { return MessageUtil::hash(value); }
+
+  static bool equal(const ProtobufWkt::Value& v1, const ProtobufWkt::Value& v2);
+};
+
 } // namespace Envoy

--- a/source/common/redis/BUILD
+++ b/source/common/redis/BUILD
@@ -41,6 +41,7 @@ envoy_cc_library(
     deps = [
         ":codec_lib",
         "//include/envoy/redis:conn_pool_interface",
+        "//include/envoy/router:router_interface",
         "//include/envoy/thread_local:thread_local_interface",
         "//include/envoy/upstream:cluster_manager_interface",
         "//source/common/buffer:buffer_lib",

--- a/source/common/redis/conn_pool_impl.h
+++ b/source/common/redis/conn_pool_impl.h
@@ -157,6 +157,7 @@ private:
     // TODO(danielhochman): convert to HashUtil::xxHash64 when we have a migration strategy.
     // Upstream::LoadBalancerContext
     Optional<uint64_t> hashKey() const override { return hash_key_; }
+    const Router::MetadataMatches* metadataMatches() const override { return nullptr; }
     const Network::Connection* downstreamConnection() const override { return nullptr; }
 
     const Optional<uint64_t> hash_key_;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -204,6 +204,41 @@ private:
   const Http::LowerCaseString header_name_;
 };
 
+class MetadataMatchImpl : public MetadataMatch {
+public:
+  MetadataMatchImpl(const std::string& name, const ProtobufWkt::Value& value)
+      : name_(name), value_(value), value_hash_(ValueUtil::hash(value)) {}
+
+  const std::string& name() const override { return name_; }
+  const ProtobufWkt::Value& value() const override { return value_; }
+  uint64_t valueHash() const override { return value_hash_; }
+
+private:
+  std::string name_;
+  ProtobufWkt::Value value_;
+  uint64_t value_hash_;
+};
+
+class MetadataMatchesImpl : public MetadataMatches {
+public:
+  MetadataMatchesImpl(const MetadataMatchesImpl* parent,
+                      const ProtobufWkt::Struct& metadata_matches)
+      : metadata_matches_(extractMetadataMatches(parent, metadata_matches)){};
+
+  const std::vector<MetadataMatchConstSharedPtr>& metadataMatches() const override {
+    return metadata_matches_;
+  }
+
+private:
+  static std::vector<MetadataMatchConstSharedPtr>
+  extractMetadataMatches(const MetadataMatchesImpl* parent,
+                         const ProtobufWkt::Struct& metadata_matches);
+
+  const std::vector<MetadataMatchConstSharedPtr> metadata_matches_;
+};
+
+typedef std::unique_ptr<const MetadataMatchesImpl> MetadataMatchesImplConstPtr;
+
 /**
  * Implementation of Decorator that reads from the proto route decorator.
  */
@@ -245,6 +280,7 @@ public:
   void finalizeRequestHeaders(Http::HeaderMap& headers,
                               const Http::AccessLog::RequestInfo& request_info) const override;
   const HashPolicy* hashPolicy() const override { return hash_policy_.get(); }
+  const MetadataMatches* metadataMatches() const override { return metadata_matches_.get(); }
   Upstream::ResourcePriority priority() const override { return priority_; }
   const RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
   const RetryPolicy& retryPolicy() const override { return retry_policy_; }
@@ -305,7 +341,7 @@ private:
     const RetryPolicy& retryPolicy() const override { return parent_->retryPolicy(); }
     const ShadowPolicy& shadowPolicy() const override { return parent_->shadowPolicy(); }
     std::chrono::milliseconds timeout() const override { return parent_->timeout(); }
-
+    const MetadataMatches* metadataMatches() const override { return parent_->metadataMatches(); }
     const VirtualCluster* virtualCluster(const Http::HeaderMap& headers) const override {
       return parent_->virtualCluster(headers);
     }
@@ -335,17 +371,25 @@ private:
    * Route entry implementation for weighted clusters. The RouteEntryImplBase object holds
    * one or more weighted cluster objects, where each object has a back pointer to the parent
    * RouteEntryImplBase object. Almost all functions in this class forward calls back to the
-   * parent, with the exception of clusterName and routeEntry.
+   * parent, with the exception of clusterName, routeEntry, and metadataMatches.
    */
   class WeightedClusterEntry : public DynamicRouteEntry {
   public:
     WeightedClusterEntry(const RouteEntryImplBase* parent, const std::string runtime_key,
-                         Runtime::Loader& loader, const std::string& name, uint64_t weight)
+                         Runtime::Loader& loader, const std::string& name, uint64_t weight,
+                         MetadataMatchesImplConstPtr cluster_metadata_matches)
         : DynamicRouteEntry(parent, name), runtime_key_(runtime_key), loader_(loader),
-          cluster_weight_(weight) {}
+          cluster_weight_(weight), cluster_metadata_matches_(std::move(cluster_metadata_matches)) {}
 
     uint64_t clusterWeight() const {
       return loader_.snapshot().getInteger(runtime_key_, cluster_weight_);
+    }
+
+    const MetadataMatches* metadataMatches() const override {
+      if (cluster_metadata_matches_) {
+        return cluster_metadata_matches_.get();
+      }
+      return DynamicRouteEntry::metadataMatches();
     }
 
     static const uint64_t MAX_CLUSTER_WEIGHT;
@@ -354,6 +398,7 @@ private:
     const std::string runtime_key_;
     Runtime::Loader& loader_;
     const uint64_t cluster_weight_;
+    MetadataMatchesImplConstPtr cluster_metadata_matches_;
   };
 
   typedef std::shared_ptr<WeightedClusterEntry> WeightedClusterEntrySharedPtr;
@@ -387,6 +432,7 @@ private:
   std::vector<ConfigUtility::HeaderData> config_headers_;
   std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
   std::unique_ptr<const HashPolicyImpl> hash_policy_;
+  MetadataMatchesImplConstPtr metadata_matches_;
   std::list<std::pair<Http::LowerCaseString, std::string>> request_headers_to_add_;
   RequestHeaderParserPtr request_headers_parser_;
 

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -134,6 +134,12 @@ public:
     }
     return {};
   }
+  const Router::MetadataMatches* metadataMatches() const override {
+    if (route_entry_) {
+      return route_entry_->metadataMatches();
+    }
+    return nullptr;
+  }
   const Network::Connection* downstreamConnection() const override {
     return callbacks_->connection();
   }

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -54,6 +54,7 @@ envoy_cc_library(
         ":cds_api_lib",
         ":load_balancer_lib",
         ":ring_hash_lb_lib",
+        ":subset_lb_lib",
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/http:codes_interface",
         "//include/envoy/local_info:local_info_interface",
@@ -241,6 +242,26 @@ envoy_cc_library(
         "//source/common/json:config_schemas_lib",
         "//source/common/json:json_loader_lib",
         "//source/common/protobuf",
+        "//source/common/router:router_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "subset_lb_lib",
+    srcs = ["subset_lb.cc"],
+    hdrs = ["subset_lb.h"],
+    deps = [
+        ":load_balancer_lib",
+        ":ring_hash_lb_lib",
+        ":upstream_lib",
+        "//include/envoy/runtime:runtime_interface",
+        "//include/envoy/upstream:load_balancer_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/common:logger_lib",
+        "//source/common/config:metadata_lib",
+        "//source/common/config:well_known_names",
+        "//source/common/protobuf",
+        "//source/common/protobuf:utility_lib",
     ],
 )
 
@@ -296,5 +317,6 @@ envoy_cc_library(
         "//source/common/config:metadata_lib",
         "//source/common/config:well_known_names",
         "//source/common/stats:stats_lib",
+        "//source/common/upstream:load_balancer_lib",
     ],
 )

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -26,6 +26,7 @@
 #include "common/upstream/load_balancer_impl.h"
 #include "common/upstream/original_dst_cluster.h"
 #include "common/upstream/ring_hash_lb.h"
+#include "common/upstream/subset_lb.h"
 
 #include "fmt/format.h"
 
@@ -530,33 +531,38 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(
                          parent.parent_.local_info_, parent.parent_, parent.parent_.runtime_,
                          parent.parent_.random_,
                          Router::ShadowWriterPtr{new Router::ShadowWriterImpl(parent.parent_)}) {
-
-  switch (cluster->lbType()) {
-  case LoadBalancerType::LeastRequest: {
-    lb_.reset(new LeastRequestLoadBalancer(host_set_, parent.local_host_set_, cluster->stats(),
+  if (cluster->lbSubsetInfo().isEnabled() && cluster->lbType() != LoadBalancerType::OriginalDst) {
+    lb_.reset(new SubsetLoadBalancer(cluster->lbType(), host_set_, parent.local_host_set_,
+                                     cluster->stats(), parent.parent_.runtime_,
+                                     parent.parent_.random_, cluster->lbSubsetInfo()));
+  } else {
+    switch (cluster->lbType()) {
+    case LoadBalancerType::LeastRequest: {
+      lb_.reset(new LeastRequestLoadBalancer(host_set_, parent.local_host_set_, cluster->stats(),
+                                             parent.parent_.runtime_, parent.parent_.random_));
+      break;
+    }
+    case LoadBalancerType::Random: {
+      lb_.reset(new RandomLoadBalancer(host_set_, parent.local_host_set_, cluster->stats(),
+                                       parent.parent_.runtime_, parent.parent_.random_));
+      break;
+    }
+    case LoadBalancerType::RoundRobin: {
+      lb_.reset(new RoundRobinLoadBalancer(host_set_, parent.local_host_set_, cluster->stats(),
                                            parent.parent_.runtime_, parent.parent_.random_));
-    break;
-  }
-  case LoadBalancerType::Random: {
-    lb_.reset(new RandomLoadBalancer(host_set_, parent.local_host_set_, cluster->stats(),
-                                     parent.parent_.runtime_, parent.parent_.random_));
-    break;
-  }
-  case LoadBalancerType::RoundRobin: {
-    lb_.reset(new RoundRobinLoadBalancer(host_set_, parent.local_host_set_, cluster->stats(),
-                                         parent.parent_.runtime_, parent.parent_.random_));
-    break;
-  }
-  case LoadBalancerType::RingHash: {
-    lb_.reset(new RingHashLoadBalancer(host_set_, cluster->stats(), parent.parent_.runtime_,
-                                       parent.parent_.random_));
-    break;
-  }
-  case LoadBalancerType::OriginalDst: {
-    lb_.reset(new OriginalDstCluster::LoadBalancer(
-        host_set_, parent.parent_.primary_clusters_.at(cluster->name()).cluster_));
-    break;
-  }
+      break;
+    }
+    case LoadBalancerType::RingHash: {
+      lb_.reset(new RingHashLoadBalancer(host_set_, cluster->stats(), parent.parent_.runtime_,
+                                         parent.parent_.random_));
+      break;
+    }
+    case LoadBalancerType::OriginalDst: {
+      lb_.reset(new OriginalDstCluster::LoadBalancer(
+          host_set_, parent.parent_.primary_clusters_.at(cluster->name()).cluster_));
+      break;
+    }
+    }
   }
 
   host_set_.addMemberUpdateCb([this](const std::vector<HostSharedPtr>&,

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -7,6 +7,8 @@
 #include "envoy/upstream/load_balancer.h"
 #include "envoy/upstream/upstream.h"
 
+#include "api/cds.pb.h"
+
 namespace Envoy {
 namespace Upstream {
 
@@ -131,6 +133,42 @@ public:
 
   // Upstream::LoadBalancer
   HostConstSharedPtr chooseHost(const LoadBalancerContext* context) override;
+};
+
+class LoadBalancerSubsetInfoImpl : public LoadBalancerSubsetInfo {
+public:
+  LoadBalancerSubsetInfoImpl(const envoy::api::v2::Cluster::LbSubsetConfig& subset_config)
+      : enabled_(subset_config.subset_keys_size() != 0),
+        fallback_policy_(subset_config.fallback_policy()),
+        default_subset_(subset_config.default_subset()) {
+    for (auto subset : subset_config.subset_keys()) {
+      if (subset.keys_size() > 0) {
+        std::vector<std::string> v;
+        for (auto key : subset.keys()) {
+          v.push_back(key);
+        }
+
+        std::sort(v.begin(), v.end());
+        subset_keys_.push_back(v);
+      }
+    }
+  }
+
+  bool isEnabled() const override { return enabled_; }
+
+  envoy::api::v2::Cluster::LbSubsetConfig::LbSubsetFallbackPolicy fallbackPolicy() const override {
+    return fallback_policy_;
+  }
+
+  const ProtobufWkt::Struct& defaultSubset() const override { return default_subset_; }
+
+  const std::vector<std::vector<std::string>>& subsetKeys() const override { return subset_keys_; }
+
+private:
+  bool enabled_;
+  envoy::api::v2::Cluster::LbSubsetConfig::LbSubsetFallbackPolicy fallback_policy_;
+  ProtobufWkt::Struct default_subset_;
+  std::vector<std::vector<std::string>> subset_keys_;
 };
 
 } // namespace Upstream

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -1,0 +1,450 @@
+#include "common/upstream/subset_lb.h"
+
+#include <unordered_set>
+
+#include "envoy/runtime/runtime.h"
+
+#include "common/common/assert.h"
+#include "common/config/metadata.h"
+#include "common/config/well_known_names.h"
+#include "common/protobuf/utility.h"
+#include "common/upstream/load_balancer_impl.h"
+#include "common/upstream/ring_hash_lb.h"
+
+namespace Envoy {
+namespace Upstream {
+
+const HostSetImpl SubsetLoadBalancer::empty_host_set_;
+
+SubsetLoadBalancer::SubsetLoadBalancer(LoadBalancerType lb_type, HostSet& host_set,
+                                       const HostSet* local_host_set, ClusterStats& stats,
+                                       Runtime::Loader& runtime, Runtime::RandomGenerator& random,
+                                       const LoadBalancerSubsetInfo& subsets)
+    : lb_type_(lb_type), stats_(stats), runtime_(runtime), random_(random),
+      fallback_policy_(subsets.fallbackPolicy()), default_subset_(subsets.defaultSubset()),
+      subset_keys_(subsets.subsetKeys()), original_host_set_(host_set),
+      original_local_host_set_(local_host_set) {
+  RELEASE_ASSERT(subsets.isEnabled());
+
+  if (default_subset_.fields_size() == 0) {
+    // All hosts will match, so don't bother checking.
+    fallback_policy_ = envoy::api::v2::Cluster::LbSubsetConfig::ANY_ENDPOINT;
+  }
+
+  if (subsets.fallbackPolicy() == envoy::api::v2::Cluster::LbSubsetConfig::ANY_ENDPOINT) {
+    // Create a load balancer based on the unfiltered host sets.
+    default_host_subset_.reset(
+        new Subset(host_set, local_host_set ? *local_host_set : empty_host_set_));
+    default_host_subset_->lb_.reset(newLoadBalancer(default_host_subset_));
+  }
+
+  // Create filtered default subset (if necessary) and other subsets based on current hosts.
+  update(host_set.hosts(), {}, false);
+
+  // Configure future updates.
+  host_set.addMemberUpdateCb([this](const std::vector<HostSharedPtr>& hosts_added,
+                                    const std::vector<HostSharedPtr>& hosts_removed) -> void {
+    update(hosts_added, hosts_removed, false);
+  });
+
+  if (local_host_set) {
+    update(local_host_set->hosts(), {}, true);
+    local_host_set->addMemberUpdateCb(
+        [this](const std::vector<HostSharedPtr>& hosts_added,
+               const std::vector<HostSharedPtr>& hosts_removed) -> void {
+          update(hosts_added, hosts_removed, true);
+        });
+  }
+}
+
+HostConstSharedPtr SubsetLoadBalancer::chooseHost(const LoadBalancerContext* context) {
+  if (context) {
+    const Router::MetadataMatches* matches = context->metadataMatches();
+    if (matches) {
+      // Route has metadata_matches defined, see if we have a matching subset.
+      SubsetPtr subset = findSubset(matches);
+      if (subset != nullptr && subset->lb_ != nullptr) {
+        return subset->lb_->chooseHost(context);
+      }
+    }
+  }
+
+  if (default_host_subset_ == nullptr || default_host_subset_->lb_ == nullptr) {
+    return nullptr;
+  }
+
+  return default_host_subset_->lb_->chooseHost(context);
+}
+
+// Iterates over the given metadata matches (which must be lexically
+// sorted by key) and find a matching SubsetPtr, if any.
+SubsetLoadBalancer::SubsetPtr
+SubsetLoadBalancer::findSubset(const Router::MetadataMatches* matches) {
+  SubsetPtr subset;
+  int order = INT_MAX;
+
+  LbSubsetMap* subsets = &subsets_;
+  for (const auto& it : matches->metadataMatches()) {
+    const auto& subset_it = subsets->find(it->name());
+    if (subset_it == subsets->end()) {
+      // No subsets with this key (at this level in the hierachy).
+      return nullptr;
+    }
+
+    const ValueSubsetMap& vs_map = subset_it->second;
+    const auto& vs_it = vs_map.find(Value(it->value(), it->valueHash()));
+    if (vs_it == vs_map.end()) {
+      // No subsets with this value.
+      return nullptr;
+    }
+
+    const LbSubsetEntryPtr& entry = vs_it->second;
+    if (entry->host_subset_ != nullptr && entry->order_ < order) {
+      // Found a matching subset that came earlier in the subset
+      // definitions than any previous found subset.
+      subset = entry->host_subset_;
+      order = entry->order_;
+      if (order == 0) {
+        // short circuit: not going to find an earlier match
+        return subset;
+      }
+    }
+
+    subsets = &entry->children_;
+  }
+
+  return subset;
+}
+
+// Given the addition and/or removal of hosts, update all subsets to
+// match, creating new subsets as necessary.
+void SubsetLoadBalancer::update(const std::vector<HostSharedPtr>& hosts_added,
+                                const std::vector<HostSharedPtr>& hosts_removed, bool local) {
+  RELEASE_ASSERT(!local || original_local_host_set_);
+
+  if (fallback_policy_ == envoy::api::v2::Cluster::LbSubsetConfig::DEFAULT_SUBSET) {
+    if (default_host_subset_ == nullptr) {
+      // First update: create the default host subset
+      default_host_subset_ = newSubset(
+          std::bind(&SubsetLoadBalancer::hostMatchesDefaultSubset, this, std::placeholders::_1));
+      default_host_subset_->lb_.reset(newLoadBalancer(default_host_subset_));
+    } else {
+      // Filter out added hosts that don't match the default subset
+      std::vector<HostSharedPtr> subset_hosts_added;
+      for (const auto& it : hosts_added) {
+        if (hostMatchesDefaultSubset(it)) {
+          subset_hosts_added.emplace_back(it);
+        }
+      }
+
+      if (!subset_hosts_added.empty() || !hosts_removed.empty()) {
+        if (local) {
+          default_host_subset_->local_host_set_.update(subset_hosts_added, hosts_removed);
+        } else {
+          default_host_subset_->host_set_.update(subset_hosts_added, hosts_removed);
+        }
+      }
+    }
+  }
+
+  std::unordered_set<SubsetPtr> subsets_created;
+  std::unordered_map<SubsetPtr, std::vector<HostSharedPtr>> subset_hosts_added;
+  std::unordered_map<SubsetPtr, std::vector<HostSharedPtr>> subset_hosts_removed;
+
+  SubsetMetadata kvs;
+  for (const auto& host_it : hosts_added) {
+    int createOrder = 0;
+    for (const auto& keys_it : subset_keys_) {
+      if (extractSubsetMetadata(keys_it, host_it, &kvs)) {
+        LbSubsetEntryPtr entry = findOrCreateSubset(subsets_, kvs, 0, createOrder);
+        if (entry->host_subset_->lb_ == nullptr) {
+          subsets_created.emplace(entry->host_subset_);
+        } else {
+          subset_hosts_added[entry->host_subset_].emplace_back(host_it);
+        }
+      }
+      createOrder++;
+    }
+  }
+
+  for (const auto& host_it : hosts_removed) {
+    for (const auto& keys_it : subset_keys_) {
+      if (extractSubsetMetadata(keys_it, host_it, &kvs)) {
+        LbSubsetEntryPtr entry = findOrCreateSubset(subsets_, kvs, 0, -1);
+        if (entry->host_subset_->lb_ == nullptr) {
+          // newly created subset, ignore removals
+          continue;
+        }
+
+        subset_hosts_removed[entry->host_subset_].emplace_back(host_it);
+      }
+    }
+  }
+
+  for (const auto& added_it : subset_hosts_added) {
+    HostSubsetImpl& host_subset =
+        local ? added_it.first->local_host_set_ : added_it.first->host_set_;
+
+    const auto& removed_it = subset_hosts_removed.find(added_it.first);
+    if (removed_it != subset_hosts_removed.end()) {
+      host_subset.update(added_it.second, removed_it->second);
+      subset_hosts_removed.erase(removed_it);
+    } else {
+      host_subset.update(added_it.second, {});
+    }
+  }
+
+  for (const auto& removed_it : subset_hosts_added) {
+    if (local) {
+      removed_it.first->local_host_set_.update({}, removed_it.second);
+    } else {
+      removed_it.first->host_set_.update({}, removed_it.second);
+    }
+  }
+
+  for (const auto& it : subsets_created) {
+    it->lb_.reset(newLoadBalancer(it));
+  }
+}
+
+bool SubsetLoadBalancer::hostMatchesDefaultSubset(const HostSharedPtr& host) {
+  const envoy::api::v2::Metadata& host_metadata = host->metadata();
+
+  for (const auto& it : default_subset_.fields()) {
+    const ProtobufWkt::Value& host_value = Config::Metadata::metadataValue(
+        host_metadata, Config::MetadataFilters::get().ENVOY_LB, it.first);
+
+    if (!ValueUtil::equal(host_value, it.second)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool SubsetLoadBalancer::hostMatches(const SubsetMetadata& kvs, const HostSharedPtr& host) {
+  const envoy::api::v2::Metadata& host_metadata = host->metadata();
+
+  for (const auto& it : kvs) {
+    const ProtobufWkt::Value& host_value = Config::Metadata::metadataValue(
+        host_metadata, Config::MetadataFilters::get().ENVOY_LB, it.first);
+
+    if (!ValueUtil::equal(host_value, it.second)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// Iterates over subset_keys looking up values from the given host's
+// metadata. Each key-value pair is appended to kvs. Returns true if
+// the host has a value for each key. The kvs vector is cleared before
+// use.
+bool SubsetLoadBalancer::extractSubsetMetadata(const std::vector<std::string>& subset_keys,
+                                               const HostSharedPtr& host, SubsetMetadata* kvs) {
+  ASSERT(kvs != nullptr);
+  kvs->clear();
+
+  const envoy::api::v2::Metadata& metadata = host->metadata();
+  const auto& filter_it = metadata.filter_metadata().find(Config::MetadataFilters::get().ENVOY_LB);
+  if (filter_it == metadata.filter_metadata().end()) {
+    return false;
+  }
+
+  const auto& fields = filter_it->second.fields();
+  for (const auto key : subset_keys) {
+    const auto it = fields.find(key);
+    if (it == fields.end()) {
+      break;
+    }
+    kvs->emplace_back(std::pair<std::string, ProtobufWkt::Value>(key, it->second));
+  }
+
+  return kvs->size() == subset_keys.size();
+}
+
+// Given a vector of key-values (from extractSubsetMetadata),
+// recursively finds the matching LbSubsetEntryPtr.  If it does not
+// exist and createOrder >= 0, create the new subset.
+SubsetLoadBalancer::LbSubsetEntryPtr
+SubsetLoadBalancer::findOrCreateSubset(LbSubsetMap& subsets, const SubsetMetadata& kvs, size_t idx,
+                                       const int createOrder) {
+  const std::string& name = kvs[idx].first;
+  const ProtobufWkt::Value& pb_value = kvs[idx].second;
+  const Value value(pb_value);
+
+  const auto& kv_it = subsets.find(name);
+  if (kv_it != subsets.end()) {
+    ValueSubsetMap& value_subset_map = kv_it->second;
+    const auto vs_it = value_subset_map.find(value);
+    if (vs_it != value_subset_map.end()) {
+      LbSubsetEntryPtr entry = vs_it->second;
+      idx++;
+      if (idx == kvs.size()) {
+        if (entry->host_subset_ == nullptr) {
+          // More specific nested subsets may exist, but this one does not.
+          if (createOrder < 0) {
+            return nullptr;
+          }
+          entry->host_subset_ = newSubset(
+              std::bind(&SubsetLoadBalancer::hostMatches, this, kvs, std::placeholders::_1));
+        }
+        return entry;
+      }
+
+      return findOrCreateSubset(entry->children_, kvs, idx, createOrder);
+    }
+  }
+
+  // not found, but don't want creation
+  if (createOrder < 0) {
+    return nullptr;
+  }
+
+  LbSubsetEntryPtr entry(new LbSubsetEntry());
+  if (kv_it != subsets.end()) {
+    ValueSubsetMap& value_subset_map = kv_it->second;
+    value_subset_map.emplace(value, entry);
+  } else {
+    ValueSubsetMap value_subset_map = {{value, entry}};
+    subsets.emplace(name, value_subset_map);
+  }
+
+  idx++;
+  if (idx == kvs.size()) {
+    entry->host_subset_ =
+        newSubset(std::bind(&SubsetLoadBalancer::hostMatches, this, kvs, std::placeholders::_1));
+    entry->order_ = createOrder;
+    return entry;
+  }
+
+  return findOrCreateSubset(entry->children_, kvs, idx, createOrder);
+}
+
+// Create a new Subset from the current HostSets, filtering hosts with
+// the given predicate.
+SubsetLoadBalancer::SubsetPtr
+SubsetLoadBalancer::newSubset(std::function<bool(const HostSharedPtr&)> predicate) {
+  std::vector<HostSharedPtr> hosts;
+  for (const auto& it : original_host_set_.hosts()) {
+    if (predicate(it)) {
+      hosts.emplace_back(it);
+    }
+  }
+
+  SubsetPtr subset;
+  std::vector<HostSharedPtr> local_hosts;
+  if (original_local_host_set_) {
+    for (const auto& it : original_local_host_set_->hosts()) {
+      if (predicate(it)) {
+        local_hosts.emplace_back(it);
+      }
+    }
+
+    subset.reset(new Subset(original_host_set_, *original_local_host_set_));
+  } else {
+    subset.reset(new Subset(original_host_set_, empty_host_set_));
+  }
+
+  subset->host_set_.update(hosts, {});
+  subset->local_host_set_.update(local_hosts, {});
+  return subset;
+}
+
+LoadBalancer* SubsetLoadBalancer::newLoadBalancer(const SubsetPtr& subset) {
+  const HostSet* local_host_set = nullptr;
+  if (original_local_host_set_ != nullptr) {
+    local_host_set = &subset->local_host_set_;
+  }
+
+  switch (lb_type_) {
+  case LoadBalancerType::LeastRequest:
+    return new LeastRequestLoadBalancer(subset->host_set_, local_host_set, stats_, runtime_,
+                                        random_);
+
+  case LoadBalancerType::Random:
+    return new RandomLoadBalancer(subset->host_set_, local_host_set, stats_, runtime_, random_);
+
+  case LoadBalancerType::RoundRobin:
+    return new RoundRobinLoadBalancer(subset->host_set_, local_host_set, stats_, runtime_, random_);
+
+  case LoadBalancerType::RingHash:
+    return new RingHashLoadBalancer(subset->host_set_, stats_, runtime_, random_);
+
+  case LoadBalancerType::OriginalDst:
+    RELEASE_ASSERT(false);
+  }
+}
+
+// Find the index in which the original HostSet's hostsPerZone vector
+// contains the given host.
+int SubsetLoadBalancer::HostSubsetImpl::findZoneIndex(const HostSharedPtr& host) {
+  int idx = 0;
+  for (const auto zone_it : original_host_set_.hostsPerZone()) {
+    for (const auto it : zone_it) {
+      if (it == host) {
+        return idx;
+      }
+    }
+    idx++;
+  }
+
+  return -1;
+}
+
+// Given hosts_added and hosts_removed, update the underlying
+// HostSet. The hosts_added Hosts must be filtered to match hosts that
+// belong in this subset. The hosts_removed Hosts are ignored if they
+// are not currently a member of this subset.
+void SubsetLoadBalancer::HostSubsetImpl::update(const std::vector<HostSharedPtr>& hosts_added,
+                                                const std::vector<HostSharedPtr>& hosts_removed) {
+  for (const auto it : hosts_added) {
+    int zone_index = findZoneIndex(it);
+    host_to_zone_.emplace(it, zone_index);
+  }
+
+  bool removed = false;
+  for (const auto it : hosts_removed) {
+    const auto host_it = host_to_zone_.find(it);
+    if (host_it != host_to_zone_.end()) {
+      host_to_zone_.erase(host_it);
+      removed = true;
+    }
+  }
+
+  if (hosts_added.empty() && !removed) {
+    return;
+  }
+
+  HostVectorSharedPtr hosts(new std::vector<HostSharedPtr>());
+  HostVectorSharedPtr healthy_hosts(new std::vector<HostSharedPtr>());
+  HostListsSharedPtr hosts_per_zone(new std::vector<std::vector<HostSharedPtr>>());
+  HostListsSharedPtr healthy_hosts_per_zone(new std::vector<std::vector<HostSharedPtr>>());
+
+  for (const auto it : host_to_zone_) {
+    hosts->emplace_back(it.first);
+    if (it.first->healthy()) {
+      healthy_hosts->emplace_back(it.first);
+    }
+
+    int index = it.second;
+    if (index >= 0) {
+      if (hosts_per_zone->size() <= static_cast<size_t>(index)) {
+        hosts_per_zone->resize(index + 1);
+        healthy_hosts_per_zone->resize(index + 1);
+      }
+
+      hosts_per_zone->at(index).emplace_back(it.first);
+      if (it.first->healthy()) {
+        healthy_hosts_per_zone->at(index).emplace_back(it.first);
+      }
+    }
+  }
+
+  HostSetImpl::updateHosts(hosts, healthy_hosts, hosts_per_zone, healthy_hosts_per_zone,
+                           hosts_added, hosts_removed);
+}
+
+} // namespace Upstream
+} // namespace Envoy

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -375,6 +375,8 @@ LoadBalancer* SubsetLoadBalancer::newLoadBalancer(const SubsetPtr& subset) {
   case LoadBalancerType::OriginalDst:
     RELEASE_ASSERT(false);
   }
+
+  NOT_REACHED;
 }
 
 // Find the index in which the original HostSet's hostsPerZone vector

--- a/source/common/upstream/subset_lb.h
+++ b/source/common/upstream/subset_lb.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+
+#include "envoy/runtime/runtime.h"
+#include "envoy/upstream/load_balancer.h"
+
+#include "common/protobuf/protobuf.h"
+#include "common/protobuf/utility.h"
+#include "common/upstream/upstream_impl.h"
+
+namespace Envoy {
+namespace Upstream {
+
+class SubsetLoadBalancer : public LoadBalancer, Logger::Loggable<Logger::Id::upstream> {
+public:
+  SubsetLoadBalancer(LoadBalancerType lb_type, HostSet& host_set, const HostSet* local_host_set,
+                     ClusterStats& stats, Runtime::Loader& runtime,
+                     Runtime::RandomGenerator& random, const LoadBalancerSubsetInfo& subsets);
+
+  // Upstream::LoadBalancer
+  HostConstSharedPtr chooseHost(const LoadBalancerContext* context) override;
+
+private:
+  LoadBalancerType lb_type_;
+  ClusterStats& stats_;
+  Runtime::Loader& runtime_;
+  Runtime::RandomGenerator& random_;
+
+  envoy::api::v2::Cluster::LbSubsetConfig::LbSubsetFallbackPolicy fallback_policy_;
+  ProtobufWkt::Struct default_subset_;
+  std::vector<std::vector<std::string>> subset_keys_;
+
+  const HostSet& original_host_set_;
+  const HostSet* original_local_host_set_;
+
+  // Represents a subset of an original HostSet.
+  class HostSubsetImpl : public HostSetImpl {
+  public:
+    HostSubsetImpl(const HostSet& original_host_set)
+        : HostSetImpl(), original_host_set_(original_host_set) {}
+
+    void update(const std::vector<HostSharedPtr>& hosts_added,
+                const std::vector<HostSharedPtr>& hosts_removed);
+
+    int findZoneIndex(const HostSharedPtr& host);
+
+    const HostSet& original_host_set_;
+    std::unordered_map<HostSharedPtr, int> host_to_zone_;
+  };
+
+  // Subset maintains a LoadBalancer and HostSubsetImpls for a
+  // subset's filtered hosts and filtered local hosts.
+  class Subset {
+  public:
+    Subset(const HostSet& original_host_set, const HostSet& original_local_host_set)
+        : host_set_(HostSubsetImpl(original_host_set)),
+          local_host_set_(HostSubsetImpl(original_local_host_set)) {}
+
+    HostSubsetImpl host_set_;
+    HostSubsetImpl local_host_set_;
+    LoadBalancerPtr lb_;
+  };
+  typedef std::shared_ptr<Subset> SubsetPtr;
+
+  SubsetPtr default_host_subset_;
+
+  class Value {
+  public:
+    Value(const ProtobufWkt::Value& value, uint64_t value_hash)
+        : value_(value), value_hash_(value_hash) {}
+
+    Value(const ProtobufWkt::Value& value) : Value(value, ValueUtil::hash(value)) {}
+
+    bool operator==(const Value& rhs) const {
+      return value_hash_ == rhs.value_hash_ && ValueUtil::equal(value_, rhs.value_);
+    }
+
+    ProtobufWkt::Value value_;
+    uint64_t value_hash_;
+  };
+
+  struct ValueHash {
+    std::size_t operator()(Value const& v) const { return v.value_hash_; }
+  };
+
+  class LbSubsetEntry;
+  typedef std::shared_ptr<LbSubsetEntry> LbSubsetEntryPtr;
+
+  typedef std::unordered_map<Value, LbSubsetEntryPtr, ValueHash> ValueSubsetMap;
+  typedef std::unordered_map<std::string, ValueSubsetMap> LbSubsetMap;
+
+  typedef std::vector<std::pair<std::string, ProtobufWkt::Value>> SubsetMetadata;
+
+  // Entry in the subset hierarchy.
+  class LbSubsetEntry {
+  public:
+    LbSubsetEntry() {}
+
+    LbSubsetMap children_;
+
+    // Match exists at this level
+    SubsetPtr host_subset_;
+
+    // Original order of the matching subset_keys entry.
+    int order_;
+  };
+
+  // Forms a trie-like structure. Requires lexically sorted Host and Route metadata.
+  LbSubsetMap subsets_;
+
+  void update(const std::vector<HostSharedPtr>& hosts_added,
+              const std::vector<HostSharedPtr>& hosts_removed, bool local);
+
+  bool hostMatchesDefaultSubset(const HostSharedPtr& host);
+  bool hostMatches(const SubsetMetadata& kvs, const HostSharedPtr& host);
+
+  SubsetPtr findSubset(const Router::MetadataMatches* matches);
+
+  LbSubsetEntryPtr findOrCreateSubset(LbSubsetMap& subsets, const SubsetMetadata& kvs, size_t idx,
+                                      const int createOrder);
+
+  SubsetPtr newSubset(std::function<bool(const HostSharedPtr&)> predicate);
+
+  bool extractSubsetMetadata(const std::vector<std::string>& subset_keys, const HostSharedPtr& host,
+                             SubsetMetadata* kvs);
+
+  LoadBalancer* newLoadBalancer(const SubsetPtr& subset);
+
+  static const HostSetImpl empty_host_set_;
+};
+
+} // namespace Upstream
+} // namespace Envoy

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -86,7 +86,8 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
       http2_settings_(Http::Utility::parseHttp2Settings(config.http2_protocol_options())),
       resource_managers_(config, runtime, name_),
       maintenance_mode_runtime_key_(fmt::format("upstream.maintenance_mode.{}", name_)),
-      source_address_(getSourceAddress(config, source_address)), added_via_api_(added_via_api) {
+      source_address_(getSourceAddress(config, source_address)), added_via_api_(added_via_api),
+      lb_subset_(LoadBalancerSubsetInfoImpl(config.lb_subset_config())) {
   ssl_ctx_ = nullptr;
   if (config.has_tls_context()) {
     Ssl::ClientContextConfigImpl context_config(config.tls_context());

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -27,6 +27,7 @@
 #include "common/config/metadata.h"
 #include "common/config/well_known_names.h"
 #include "common/stats/stats_impl.h"
+#include "common/upstream/load_balancer_impl.h"
 #include "common/upstream/outlier_detection_impl.h"
 #include "common/upstream/resource_manager_impl.h"
 
@@ -233,6 +234,7 @@ public:
   const Network::Address::InstanceConstSharedPtr& sourceAddress() const override {
     return source_address_;
   };
+  const LoadBalancerSubsetInfo& lbSubsetInfo() const override { return lb_subset_; }
 
 private:
   struct ResourceManagers {
@@ -264,6 +266,7 @@ private:
   const Network::Address::InstanceConstSharedPtr source_address_;
   LoadBalancerType lb_type_;
   const bool added_via_api_;
+  LoadBalancerSubsetInfoImpl lb_subset_;
 };
 
 /**

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -201,7 +201,7 @@ envoy_cc_test(
     }),
     deps = [
         ":utility_lib",
-	"//include/envoy/router:router_interface",
+        "//include/envoy/router:router_interface",
         "//source/common/network:utility_lib",
         "//source/common/upstream:ring_hash_lb_lib",
         "//source/common/upstream:upstream_includes",

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -201,6 +201,7 @@ envoy_cc_test(
     }),
     deps = [
         ":utility_lib",
+	"//include/envoy/router:router_interface",
         "//source/common/network:utility_lib",
         "//source/common/upstream:ring_hash_lb_lib",
         "//source/common/upstream:upstream_includes",

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -38,6 +38,7 @@ public:
   // Upstream::LoadBalancerContext
   Optional<uint64_t> hashKey() const override { return 0; }
   const Network::Connection* downstreamConnection() const override { return connection_; }
+  const Router::MetadataMatches* metadataMatches() const override { return nullptr; }
 
   Optional<uint64_t> hash_key_;
   const Network::Connection* connection_;

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -1,6 +1,8 @@
 #include <cstdint>
 #include <string>
 
+#include "envoy/router/router.h"
+
 #include "common/network/utility.h"
 #include "common/upstream/ring_hash_lb.h"
 #include "common/upstream/upstream_impl.h"
@@ -25,6 +27,7 @@ public:
 
   // Upstream::LoadBalancerContext
   Optional<uint64_t> hashKey() const override { return hash_key_; }
+  const Router::MetadataMatches* metadataMatches() const override { return nullptr; }
   const Network::Connection* downstreamConnection() const override { return nullptr; }
 
   Optional<uint64_t> hash_key_;

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -183,6 +183,7 @@ public:
                      void(Http::HeaderMap& headers,
                           const Http::AccessLog::RequestInfo& request_info));
   MOCK_CONST_METHOD0(hashPolicy, const HashPolicy*());
+  MOCK_CONST_METHOD0(metadataMatches, const MetadataMatches*());
   MOCK_CONST_METHOD0(priority, Upstream::ResourcePriority());
   MOCK_CONST_METHOD0(rateLimitPolicy, const RateLimitPolicy&());
   MOCK_CONST_METHOD0(retryPolicy, const RetryPolicy&());

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -19,6 +19,21 @@ using testing::NiceMock;
 namespace Envoy {
 namespace Upstream {
 
+class MockLoadBalancerSubsetInfo : public LoadBalancerSubsetInfo {
+public:
+  MockLoadBalancerSubsetInfo();
+  ~MockLoadBalancerSubsetInfo();
+
+  // Upstream::LoadBalancerSubsetInfo
+  MOCK_CONST_METHOD0(isEnabled, bool());
+  MOCK_CONST_METHOD0(fallbackPolicy,
+                     envoy::api::v2::Cluster::LbSubsetConfig::LbSubsetFallbackPolicy());
+  MOCK_CONST_METHOD0(defaultSubset, const ProtobufWkt::Struct&());
+  MOCK_CONST_METHOD0(subsetKeys, const std::vector<std::vector<std::string>>&());
+
+  std::vector<std::vector<std::string>> subset_keys_;
+};
+
 class MockClusterInfo : public ClusterInfo {
 public:
   MockClusterInfo();
@@ -39,6 +54,7 @@ public:
   MOCK_CONST_METHOD0(stats, ClusterStats&());
   MOCK_CONST_METHOD0(statsScope, Stats::Scope&());
   MOCK_CONST_METHOD0(sourceAddress, const Network::Address::InstanceConstSharedPtr&());
+  MOCK_CONST_METHOD0(lbSubsetInfo, const LoadBalancerSubsetInfo&());
 
   std::string name_{"fake_cluster"};
   Http::Http2Settings http2_settings_{};
@@ -49,6 +65,7 @@ public:
   std::unique_ptr<Upstream::ResourceManager> resource_manager_;
   Network::Address::InstanceConstSharedPtr source_address_;
   LoadBalancerType lb_type_{LoadBalancerType::RoundRobin};
+  NiceMock<MockLoadBalancerSubsetInfo> lb_subset_;
 };
 
 } // namespace Upstream

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -63,7 +63,8 @@ MockHost::~MockHost() {}
 
 MockLoadBalancerSubsetInfo::MockLoadBalancerSubsetInfo() {
   ON_CALL(*this, isEnabled()).WillByDefault(Return(false));
-  ON_CALL(*this, fallbackPolicy()).WillByDefault(Return(envoy::api::v2::Cluster::LbSubsetConfig::ANY_ENDPOINT));
+  ON_CALL(*this, fallbackPolicy())
+      .WillByDefault(Return(envoy::api::v2::Cluster::LbSubsetConfig::ANY_ENDPOINT));
   ON_CALL(*this, defaultSubset()).WillByDefault(ReturnRef(ProtobufWkt::Struct::default_instance()));
   ON_CALL(*this, subsetKeys()).WillByDefault(ReturnRef(subset_keys_));
 }

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -61,6 +61,15 @@ MockHost::MockHost() {
 
 MockHost::~MockHost() {}
 
+MockLoadBalancerSubsetInfo::MockLoadBalancerSubsetInfo() {
+  ON_CALL(*this, isEnabled()).WillByDefault(Return(false));
+  ON_CALL(*this, fallbackPolicy()).WillByDefault(Return(envoy::api::v2::Cluster::LbSubsetConfig::ANY_ENDPOINT));
+  ON_CALL(*this, defaultSubset()).WillByDefault(ReturnRef(ProtobufWkt::Struct::default_instance()));
+  ON_CALL(*this, subsetKeys()).WillByDefault(ReturnRef(subset_keys_));
+}
+
+MockLoadBalancerSubsetInfo::~MockLoadBalancerSubsetInfo() {}
+
 MockClusterInfo::MockClusterInfo()
     : stats_(ClusterInfoImpl::generateStats(stats_store_)),
       resource_manager_(new Upstream::ResourceManagerImpl(runtime_, "fake_key", 1, 1024, 1024, 1)) {
@@ -78,6 +87,7 @@ MockClusterInfo::MockClusterInfo()
           [this](ResourcePriority) -> Upstream::ResourceManager& { return *resource_manager_; }));
   ON_CALL(*this, lbType()).WillByDefault(ReturnPointee(&lb_type_));
   ON_CALL(*this, sourceAddress()).WillByDefault(ReturnRef(source_address_));
+  ON_CALL(*this, lbSubsetInfo()).WillByDefault(ReturnRef(lb_subset_));
 }
 
 MockClusterInfo::~MockClusterInfo() {}


### PR DESCRIPTION
As requested in envoyproxy/data-plane-api#173, here's a rough draft the implementation of the subsetting load balancer.

The load balancer's chooseHost is implemented as follows:
1. If the LoadBalancerContext contains no metadata to match, skip to 6.
2. Otherwise, for each entry in the metadata do a pair of unordered map lookups for the name and value.
3. If both lookups succeed, we see if there is a load balancer defined. If so, we have a match and we remember the match if it's creation order is smaller than any previous match. Match or not, we continue the metadata iteration.
4. If either lookup fails or we reach the end of the metadata, there are no further matching subsets, so return the best found, if any.
5. If a subset is found, we invoke it's load balancer with the LoadBalancerContext and return.
6. Otherwise, we implement the fallback policy.

Metadata values are stored as a ProtobufWkt::Value and corresponding hash value. I reused the existing protobuf hash utility function and it seems expensive, so I took care not to compute any hash in the load balancing path.

The load balancer produces subsets by watching the original HostSet(s) for updates. Each subset has its own pair for HostSetImpl objects which represent filtered copies of the `host_set` and `local_host_set` originally passed to the load balancer.

Presuming the other PR is approved, this PR has a bunch of known deficiencies that I will address:
1. It needs tests and additional comments.
2. ValueUtil::equal (for ProtobufWkt::Value comparison) should operate recursively on list and struct values.
3. MetadataMatches is in the Router namespace -- it should probably find another home to simplify dependencies.
4. I think there's an opportunity to have MetadataMatches return a set instead of a vector -- the load balancer depends on the matches being sorted and using a set with a custom Compare operator should make it possible to put that requirement into the code rather than just documenting it.
5. Similarly the LoadBalancer depends on using the same hash algorithmin Upstream::MetadataMatchImpl, so it probably makes sense to introduce a small class that wraps a ProtobufWkt::Value and its hash and to use that in both places.