### PR TITLE
CI: Publish tags to Dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ jobs:
        - run: ci/do_circle_ci.sh bazel.release
        - setup_remote_docker
        - run: ci/docker_push.sh
+       - deploy:
+           command: ci/docker_tag.sh
    asan:
      docker:
        - image: lyft/envoy-build:7480d2a53726b6389380d741f8a7e7b74a990133
@@ -79,7 +81,10 @@ workflows:
   version: 2
   all:
     jobs:
-      - release
+      - release:
+          filters:
+            tags:
+              only: /^v.*/
       - asan
       - tsan
       - coverage

--- a/ci/docker_push.sh
+++ b/ci/docker_push.sh
@@ -13,7 +13,7 @@ do
        want_push='true'
    fi
 done
-if [ -z "$CIRCLE_PULL_REQUEST" ] && [ "$want_push" == "true" ]
+if [ -z "$CIRCLE_PULL_REQUEST" ] && [ -z "$CIRCLE_TAG" ] && [ "$want_push" == "true" ]
 then
    # TODO(mattklein123): Currently we are doing this push in the context of the release job which
    # happens inside of our build image. We should switch to using Circle caching so each of these

--- a/ci/docker_tag.sh
+++ b/ci/docker_tag.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Do not ever set -x here, it is a security hazard as it will place the credentials below in the
+# Travis logs.
+set -e
+
+if [ -n "$CIRCLE_TAG" ]
+then
+   docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+
+   docker pull lyft/envoy:"$CIRCLE_SHA1"
+   docker tag lyft/envoy:"$CIRCLE_SHA1" lyft/envoy:"$CIRCLE_TAG"
+   docker push lyft/envoy:"$CIRCLE_TAG"
+
+   docker pull lyft/envoy-alpine:"$CIRCLE_SHA1"
+   docker tag lyft/envoy-alpine:"$CIRCLE_SHA1" lyft/envoy-alpine:"$CIRCLE_TAG"
+   docker push lyft/envoy-alpine:"$CIRCLE_TAG"
+
+   docker pull lyft/envoy-alpine-debug:"$CIRCLE_SHA1"
+   docker tag lyft/envoy-alpine-debug:"$CIRCLE_SHA1" lyft/envoy-alpine-debug:"$CIRCLE_TAG"
+   docker push lyft/envoy-alpine-debug:"$CIRCLE_TAG"
+else
+   echo 'Ignoring non-tag event for docker tag.'
+fi


### PR DESCRIPTION
Creates a tag in Dockerhub for git tags. Unfortunately, I'm not sure how to test this and it may require an update to `.circleci/config.yml` to explicitly set the `build_image` job to run on tags.

Implements https://github.com/envoyproxy/envoy/issues/1742