### PR TITLE
host: plumb envoy::api::v2::Locality to HostDescription.

### DIFF
--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -84,9 +84,9 @@ public:
   virtual const HostStats& stats() const PURE;
 
   /**
-   * @return the "zone" of the host (deployment specific). Empty is unknown.
+   * @return the locality of the host (deployment specific). This will be empty if unknown.
    */
-  virtual const std::string& zone() const PURE;
+  virtual const envoy::api::v2::Locality& locality() const PURE;
 };
 
 typedef std::shared_ptr<const HostDescription> HostDescriptionConstSharedPtr;

--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -84,7 +84,8 @@ public:
   virtual const HostStats& stats() const PURE;
 
   /**
-   * @return the locality of the host (deployment specific). This will be empty if unknown.
+   * @return the locality of the host (deployment specific). This will be the default instance if
+   *         unknown.
    */
   virtual const envoy::api::v2::Locality& locality() const PURE;
 };

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -102,7 +102,7 @@ Filter::~Filter() {
 }
 
 const std::string& Filter::upstreamZone(Upstream::HostDescriptionConstSharedPtr upstream_host) {
-  return upstream_host ? upstream_host->zone() : EMPTY_STRING;
+  return upstream_host ? upstream_host->locality().zone() : EMPTY_STRING;
 }
 
 void Filter::chargeUpstreamCode(const Http::HeaderMap& response_headers,

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -58,12 +58,11 @@ void EdsClusterImpl::onConfigUpdate(const ResourceVector& resources) {
                                      cluster_load_assignment.cluster_name()));
   }
   for (const auto& locality_lb_endpoint : cluster_load_assignment.endpoints()) {
-    const std::string& zone = locality_lb_endpoint.locality().zone();
-
     for (const auto& lb_endpoint : locality_lb_endpoint.lb_endpoints()) {
       new_hosts.emplace_back(new HostImpl(
           info_, "", Network::Utility::fromProtoAddress(lb_endpoint.endpoint().address()),
-          lb_endpoint.metadata(), lb_endpoint.load_balancing_weight().value(), zone));
+          lb_endpoint.metadata(), lb_endpoint.load_balancing_weight().value(),
+          locality_lb_endpoint.locality()));
     }
   }
 
@@ -80,7 +79,7 @@ void EdsClusterImpl::onConfigUpdate(const ResourceVector& resources) {
       std::map<std::string, std::vector<HostSharedPtr>> hosts_per_zone;
 
       for (const HostSharedPtr& host : *current_hosts_copy) {
-        hosts_per_zone[host->zone()].push_back(host);
+        hosts_per_zone[host->locality().zone()].push_back(host);
       }
 
       // Populate per_zone hosts only if upstream cluster has hosts in the same zone.

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -50,7 +50,8 @@ private:
   struct LogicalHost : public HostImpl {
     LogicalHost(ClusterInfoConstSharedPtr cluster, const std::string& hostname,
                 Network::Address::InstanceConstSharedPtr address, LogicalDnsCluster& parent)
-        : HostImpl(cluster, hostname, address, envoy::api::v2::Metadata::default_instance(), 1, ""),
+        : HostImpl(cluster, hostname, address, envoy::api::v2::Metadata::default_instance(), 1,
+                   envoy::api::v2::Locality()),
           parent_(parent) {}
 
     // Upstream::Host
@@ -79,7 +80,9 @@ private:
     const HostStats& stats() const override { return logical_host_->stats(); }
     const std::string& hostname() const override { return logical_host_->hostname(); }
     Network::Address::InstanceConstSharedPtr address() const override { return address_; }
-    const std::string& zone() const override { return EMPTY_STRING; }
+    const envoy::api::v2::Locality& locality() const override {
+      return envoy::api::v2::Locality().default_instance();
+    }
 
     Network::Address::InstanceConstSharedPtr address_;
     HostConstSharedPtr logical_host_;

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -51,7 +51,7 @@ private:
     LogicalHost(ClusterInfoConstSharedPtr cluster, const std::string& hostname,
                 Network::Address::InstanceConstSharedPtr address, LogicalDnsCluster& parent)
         : HostImpl(cluster, hostname, address, envoy::api::v2::Metadata::default_instance(), 1,
-                   envoy::api::v2::Locality()),
+                   envoy::api::v2::Locality().default_instance()),
           parent_(parent) {}
 
     // Upstream::Host

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -62,7 +62,8 @@ OriginalDstCluster::LoadBalancer::chooseHost(const LoadBalancerContext* context)
             Network::Utility::copyInternetAddressAndPort(*dst_ip));
         // Create a host we can use immediately.
         host.reset(new HostImpl(info_, info_->name() + dst_addr.asString(), std::move(host_ip_port),
-                                envoy::api::v2::Metadata::default_instance(), 1, ""));
+                                envoy::api::v2::Metadata::default_instance(), 1,
+                                envoy::api::v2::Locality()));
 
         ENVOY_LOG(debug, "Created host {}.", host->address()->asString());
         // Add the new host to the map.  We just failed to find it in

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -63,7 +63,7 @@ OriginalDstCluster::LoadBalancer::chooseHost(const LoadBalancerContext* context)
         // Create a host we can use immediately.
         host.reset(new HostImpl(info_, info_->name() + dst_addr.asString(), std::move(host_ip_port),
                                 envoy::api::v2::Metadata::default_instance(), 1,
-                                envoy::api::v2::Locality()));
+                                envoy::api::v2::Locality().default_instance()));
 
         ENVOY_LOG(debug, "Created host {}.", host->address()->asString());
         // Add the new host to the map.  We just failed to find it in

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -335,9 +335,10 @@ StaticClusterImpl::StaticClusterImpl(const envoy::api::v2::Cluster& cluster,
                       added_via_api) {
   HostVectorSharedPtr new_hosts(new std::vector<HostSharedPtr>());
   for (const auto& host : cluster.hosts()) {
-    new_hosts->emplace_back(HostSharedPtr{
-        new HostImpl(info_, "", Network::Utility::fromProtoAddress(host),
-                     envoy::api::v2::Metadata::default_instance(), 1, envoy::api::v2::Locality())});
+    new_hosts->emplace_back(
+        HostSharedPtr{new HostImpl(info_, "", Network::Utility::fromProtoAddress(host),
+                                   envoy::api::v2::Metadata::default_instance(), 1,
+                                   envoy::api::v2::Locality().default_instance())});
   }
 
   updateHosts(new_hosts, createHealthyHostList(*new_hosts), empty_host_lists_, empty_host_lists_,
@@ -511,9 +512,10 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
           // a new address that has port in it. We need to both support IPv6 as well as potentially
           // move port handling into the DNS interface itself, which would work better for SRV.
           ASSERT(address != nullptr);
-          new_hosts.emplace_back(new HostImpl(
-              parent_.info_, dns_address_, Network::Utility::getAddressWithPort(*address, port_),
-              envoy::api::v2::Metadata::default_instance(), 1, envoy::api::v2::Locality()));
+          new_hosts.emplace_back(new HostImpl(parent_.info_, dns_address_,
+                                              Network::Utility::getAddressWithPort(*address, port_),
+                                              envoy::api::v2::Metadata::default_instance(), 1,
+                                              envoy::api::v2::Locality().default_instance()));
         }
 
         std::vector<HostSharedPtr> hosts_added;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -335,9 +335,9 @@ StaticClusterImpl::StaticClusterImpl(const envoy::api::v2::Cluster& cluster,
                       added_via_api) {
   HostVectorSharedPtr new_hosts(new std::vector<HostSharedPtr>());
   for (const auto& host : cluster.hosts()) {
-    new_hosts->emplace_back(
-        HostSharedPtr{new HostImpl(info_, "", Network::Utility::fromProtoAddress(host),
-                                   envoy::api::v2::Metadata::default_instance(), 1, "")});
+    new_hosts->emplace_back(HostSharedPtr{
+        new HostImpl(info_, "", Network::Utility::fromProtoAddress(host),
+                     envoy::api::v2::Metadata::default_instance(), 1, envoy::api::v2::Locality())});
   }
 
   updateHosts(new_hosts, createHealthyHostList(*new_hosts), empty_host_lists_, empty_host_lists_,
@@ -511,9 +511,9 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
           // a new address that has port in it. We need to both support IPv6 as well as potentially
           // move port handling into the DNS interface itself, which would work better for SRV.
           ASSERT(address != nullptr);
-          new_hosts.emplace_back(new HostImpl(parent_.info_, dns_address_,
-                                              Network::Utility::getAddressWithPort(*address, port_),
-                                              envoy::api::v2::Metadata::default_instance(), 1, ""));
+          new_hosts.emplace_back(new HostImpl(
+              parent_.info_, dns_address_, Network::Utility::getAddressWithPort(*address, port_),
+              envoy::api::v2::Metadata::default_instance(), 1, envoy::api::v2::Locality()));
         }
 
         std::vector<HostSharedPtr> hosts_added;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -51,13 +51,15 @@ class HostDescriptionImpl : virtual public HostDescription {
 public:
   HostDescriptionImpl(ClusterInfoConstSharedPtr cluster, const std::string& hostname,
                       Network::Address::InstanceConstSharedPtr dest_address,
-                      const envoy::api::v2::Metadata& metadata, const std::string& zone)
+                      const envoy::api::v2::Metadata& metadata,
+                      const envoy::api::v2::Locality& locality)
       : cluster_(cluster), hostname_(hostname), address_(dest_address),
         canary_(Config::Metadata::metadataValue(metadata, Config::MetadataFilters::get().ENVOY_LB,
                                                 Config::MetadataEnvoyLbKeys::get().CANARY)
                     .bool_value()),
-        metadata_(metadata),
-        zone_(zone), stats_{ALL_HOST_STATS(POOL_COUNTER(stats_store_), POOL_GAUGE(stats_store_))} {}
+        metadata_(metadata), locality_(locality), stats_{ALL_HOST_STATS(POOL_COUNTER(stats_store_),
+                                                                        POOL_GAUGE(stats_store_))} {
+  }
 
   // Upstream::HostDescription
   bool canary() const override { return canary_; }
@@ -84,7 +86,7 @@ public:
   const HostStats& stats() const override { return stats_; }
   const std::string& hostname() const override { return hostname_; }
   Network::Address::InstanceConstSharedPtr address() const override { return address_; }
-  const std::string& zone() const override { return zone_; }
+  const envoy::api::v2::Locality& locality() const override { return locality_; }
 
 protected:
   ClusterInfoConstSharedPtr cluster_;
@@ -92,7 +94,7 @@ protected:
   Network::Address::InstanceConstSharedPtr address_;
   const bool canary_;
   const envoy::api::v2::Metadata metadata_;
-  const std::string zone_;
+  const envoy::api::v2::Locality locality_;
   Stats::IsolatedStoreImpl stats_store_;
   HostStats stats_;
   Outlier::DetectorHostMonitorPtr outlier_detector_;
@@ -109,8 +111,8 @@ public:
   HostImpl(ClusterInfoConstSharedPtr cluster, const std::string& hostname,
            Network::Address::InstanceConstSharedPtr address,
            const envoy::api::v2::Metadata& metadata, uint32_t initial_weight,
-           const std::string& zone)
-      : HostDescriptionImpl(cluster, hostname, address, metadata, zone), used_(true) {
+           const envoy::api::v2::Locality& locality)
+      : HostDescriptionImpl(cluster, hostname, address, metadata, locality), used_(true) {
     weight(initial_weight);
   }
 

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -164,8 +164,12 @@ Http::Code AdminImpl::handlerClusters(const std::string&, Buffer::Instance& resp
                                Upstream::HostUtility::healthFlagsToString(*host)));
       response.add(fmt::format("{}::{}::weight::{}\n", cluster.second.get().info()->name(),
                                host->address()->asString(), host->weight()));
+      response.add(fmt::format("{}::{}::region::{}\n", cluster.second.get().info()->name(),
+                               host->address()->asString(), host->locality().region()));
       response.add(fmt::format("{}::{}::zone::{}\n", cluster.second.get().info()->name(),
-                               host->address()->asString(), host->zone()));
+                               host->address()->asString(), host->locality().zone()));
+      response.add(fmt::format("{}::{}::sub_zone::{}\n", cluster.second.get().info()->name(),
+                               host->address()->asString(), host->locality().sub_zone()));
       response.add(fmt::format("{}::{}::canary::{}\n", cluster.second.get().info()->name(),
                                host->address()->asString(), host->canary()));
       response.add(fmt::format("{}::{}::success_rate::{}\n", cluster.second.get().info()->name(),

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -42,7 +42,7 @@ public:
     message_->headers().insertHost().value(std::string("host"));
     message_->headers().insertPath().value(std::string("/"));
     ON_CALL(*cm_.conn_pool_.host_, locality())
-        .WillByDefault(ReturnRefOfCopy(envoy::api::v2::Locality()));
+        .WillByDefault(ReturnRef(envoy::api::v2::Locality().default_instance()));
   }
 
   void expectSuccess(uint64_t code) {

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -41,7 +41,8 @@ public:
     message_->headers().insertMethod().value(std::string("GET"));
     message_->headers().insertHost().value(std::string("host"));
     message_->headers().insertPath().value(std::string("/"));
-    ON_CALL(*cm_.conn_pool_.host_, zone()).WillByDefault(ReturnRefOfCopy(local_info_.zoneName()));
+    ON_CALL(*cm_.conn_pool_.host_, locality())
+        .WillByDefault(ReturnRefOfCopy(envoy::api::v2::Locality()));
   }
 
   void expectSuccess(uint64_t code) {

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -682,10 +682,11 @@ TEST_F(HttpConnectionManagerImplTest, WebSocketPrefixRewrite) {
   Upstream::MockHost::MockCreateConnectionData conn_info;
 
   conn_info.connection_ = upstream_connection_;
-  conn_info.host_description_.reset(new Upstream::HostImpl(
-      cluster_manager_.thread_local_cluster_.cluster_.info_, "newhost",
-      Network::Utility::resolveUrl("tcp://127.0.0.1:80"),
-      envoy::api::v2::Metadata::default_instance(), 1, envoy::api::v2::Locality()));
+  conn_info.host_description_.reset(
+      new Upstream::HostImpl(cluster_manager_.thread_local_cluster_.cluster_.info_, "newhost",
+                             Network::Utility::resolveUrl("tcp://127.0.0.1:80"),
+                             envoy::api::v2::Metadata::default_instance(), 1,
+                             envoy::api::v2::Locality().default_instance()));
   EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster", _)).WillOnce(Return(conn_info));
 
   ON_CALL(route_config_provider_.route_config_->route_->route_entry_, useWebSocket())

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -682,10 +682,10 @@ TEST_F(HttpConnectionManagerImplTest, WebSocketPrefixRewrite) {
   Upstream::MockHost::MockCreateConnectionData conn_info;
 
   conn_info.connection_ = upstream_connection_;
-  conn_info.host_description_.reset(
-      new Upstream::HostImpl(cluster_manager_.thread_local_cluster_.cluster_.info_, "newhost",
-                             Network::Utility::resolveUrl("tcp://127.0.0.1:80"),
-                             envoy::api::v2::Metadata::default_instance(), 1, ""));
+  conn_info.host_description_.reset(new Upstream::HostImpl(
+      cluster_manager_.thread_local_cluster_.cluster_.info_, "newhost",
+      Network::Utility::resolveUrl("tcp://127.0.0.1:80"),
+      envoy::api::v2::Metadata::default_instance(), 1, envoy::api::v2::Locality()));
   EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster", _)).WillOnce(Return(conn_info));
 
   ON_CALL(route_config_provider_.route_config_->route_->route_entry_, useWebSocket())

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -54,9 +54,10 @@ public:
                 ShadowWriterPtr{shadow_writer_}, true),
         router_(config_) {
     router_.setDecoderFilterCallbacks(callbacks_);
+    upstream_locality_.set_zone("to_az");
 
     ON_CALL(*cm_.conn_pool_.host_, address()).WillByDefault(Return(host_address_));
-    ON_CALL(*cm_.conn_pool_.host_, zone()).WillByDefault(ReturnRef(upstream_zone_));
+    ON_CALL(*cm_.conn_pool_.host_, locality()).WillByDefault(ReturnRef(upstream_locality_));
   }
 
   void expectResponseTimerCreate() {
@@ -71,7 +72,7 @@ public:
     EXPECT_CALL(*per_try_timeout_, disableTimer());
   }
 
-  std::string upstream_zone_{"to_az"};
+  envoy::api::v2::Locality upstream_locality_;
   Stats::IsolatedStoreImpl stats_store_;
   NiceMock<Upstream::MockClusterManager> cm_;
   NiceMock<Runtime::MockLoader> runtime_;

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -23,8 +23,11 @@ namespace Upstream {
 static HostSharedPtr newTestHost(Upstream::ClusterInfoConstSharedPtr cluster,
                                  const std::string& url, uint32_t weight = 1,
                                  const std::string& zone = "") {
+  envoy::api::v2::Locality locality;
+  locality.set_zone(zone);
   return HostSharedPtr{new HostImpl(cluster, "", Network::Utility::resolveUrl(url),
-                                    envoy::api::v2::Metadata::default_instance(), weight, zone)};
+                                    envoy::api::v2::Metadata::default_instance(), weight,
+                                    locality)};
 }
 
 /**
@@ -67,7 +70,7 @@ public:
     std::map<std::string, uint32_t> hits;
     for (uint32_t i = 0; i < total_number_of_requests; ++i) {
       HostSharedPtr from_host = selectOriginatingHost(*originating_hosts);
-      uint32_t from_zone = atoi(from_host->zone().c_str());
+      uint32_t from_zone = atoi(from_host->locality().zone().c_str());
 
       // Populate host set for upstream cluster.
       HostListsSharedPtr per_zone_upstream(new std::vector<std::vector<HostSharedPtr>>());

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -197,7 +197,9 @@ TEST_F(LogicalDnsClusterTest, Basic) {
   EXPECT_EQ(&cluster_->hosts()[0]->cluster(), &data.host_description_->cluster());
   EXPECT_EQ(&cluster_->hosts()[0]->stats(), &data.host_description_->stats());
   EXPECT_EQ("127.0.0.1:443", data.host_description_->address()->asString());
-  EXPECT_EQ("", data.host_description_->zone());
+  EXPECT_EQ("", data.host_description_->locality().region());
+  EXPECT_EQ("", data.host_description_->locality().zone());
+  EXPECT_EQ("", data.host_description_->locality().sub_zone());
   EXPECT_EQ("foo.bar.com", data.host_description_->hostname());
   data.host_description_->outlierDetector().putHttpResponseCode(200);
   data.host_description_->healthChecker().setUnhealthy();

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -161,7 +161,7 @@ TEST_F(SdsTest, NoHealthChecker) {
 
   HostSharedPtr canary_host = findHost("10.0.16.43");
   EXPECT_TRUE(canary_host->canary());
-  EXPECT_EQ("us-east-1d", canary_host->zone());
+  EXPECT_EQ("us-east-1d", canary_host->locality().zone());
   EXPECT_EQ(40U, canary_host->weight());
   EXPECT_EQ(90UL, cluster_->info()->stats().max_host_weight_.value());
 
@@ -181,7 +181,7 @@ TEST_F(SdsTest, NoHealthChecker) {
   EXPECT_EQ(13UL, cluster_->hosts().size());
   EXPECT_EQ(canary_host, findHost("10.0.16.43"));
   EXPECT_TRUE(canary_host->canary());
-  EXPECT_EQ("us-east-1d", canary_host->zone());
+  EXPECT_EQ("us-east-1d", canary_host->locality().zone());
   EXPECT_EQ(50U, canary_host->weight());
   EXPECT_EQ(50UL, cluster_->info()->stats().max_host_weight_.value());
   EXPECT_EQ(3UL, cluster_->healthyHostsPerZone().size());

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -262,7 +262,7 @@ TEST(HostImplTest, HostCluster) {
   EXPECT_EQ(cluster.info_.get(), &host->cluster());
   EXPECT_EQ("", host->hostname());
   EXPECT_FALSE(host->canary());
-  EXPECT_EQ("", host->zone());
+  EXPECT_EQ("", host->locality().zone());
 }
 
 TEST(HostImplTest, Weight) {
@@ -281,18 +281,24 @@ TEST(HostImplTest, Weight) {
   EXPECT_EQ(100U, host->weight());
 }
 
-TEST(HostImplTest, HostameCanaryAndZone) {
+TEST(HostImplTest, HostameCanaryAndLocality) {
   MockCluster cluster;
   envoy::api::v2::Metadata metadata;
   Config::Metadata::mutableMetadataValue(metadata, Config::MetadataFilters::get().ENVOY_LB,
                                          Config::MetadataEnvoyLbKeys::get().CANARY)
       .set_bool_value(true);
+  envoy::api::v2::Locality locality;
+  locality.set_region("oceania");
+  locality.set_zone("hello");
+  locality.set_sub_zone("world");
   HostImpl host(cluster.info_, "lyft.com", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"),
-                metadata, 1, "hello");
+                metadata, 1, locality);
   EXPECT_EQ(cluster.info_.get(), &host.cluster());
   EXPECT_EQ("lyft.com", host.hostname());
   EXPECT_TRUE(host.canary());
-  EXPECT_EQ("hello", host.zone());
+  EXPECT_EQ("oceania", host.locality().region());
+  EXPECT_EQ("hello", host.locality().zone());
+  EXPECT_EQ("world", host.locality().sub_zone());
 }
 
 TEST(StaticClusterImplTest, EmptyHostname) {

--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -75,7 +75,7 @@ inline HostDescriptionConstSharedPtr makeTestHostDescription(ClusterInfoConstSha
                                                              const std::string& url) {
   return HostDescriptionConstSharedPtr{new HostDescriptionImpl(
       cluster, "", Network::Utility::resolveUrl(url), envoy::api::v2::Metadata::default_instance(),
-      envoy::api::v2::Locality())};
+      envoy::api::v2::Locality().default_instance())};
 }
 
 } // namespace

--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -67,14 +67,15 @@ parseSdsClusterFromJson(const std::string& json_string,
 inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
                                   uint32_t weight = 1) {
   return HostSharedPtr{new HostImpl(cluster, "", Network::Utility::resolveUrl(url),
-                                    envoy::api::v2::Metadata::default_instance(), weight, "")};
+                                    envoy::api::v2::Metadata::default_instance(), weight,
+                                    envoy::api::v2::Locality())};
 }
 
 inline HostDescriptionConstSharedPtr makeTestHostDescription(ClusterInfoConstSharedPtr cluster,
                                                              const std::string& url) {
-  return HostDescriptionConstSharedPtr{
-      new HostDescriptionImpl(cluster, "", Network::Utility::resolveUrl(url),
-                              envoy::api::v2::Metadata::default_instance(), "")};
+  return HostDescriptionConstSharedPtr{new HostDescriptionImpl(
+      cluster, "", Network::Utility::resolveUrl(url), envoy::api::v2::Metadata::default_instance(),
+      envoy::api::v2::Locality())};
 }
 
 } // namespace

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -82,7 +82,7 @@ public:
   MOCK_CONST_METHOD0(healthChecker, HealthCheckHostMonitor&());
   MOCK_CONST_METHOD0(hostname, const std::string&());
   MOCK_CONST_METHOD0(stats, HostStats&());
-  MOCK_CONST_METHOD0(zone, const std::string&());
+  MOCK_CONST_METHOD0(locality, const envoy::api::v2::Locality&());
 
   std::string hostname_;
   Network::Address::InstanceConstSharedPtr address_;
@@ -137,7 +137,7 @@ public:
   MOCK_METHOD1(weight, void(uint32_t new_weight));
   MOCK_CONST_METHOD0(used, bool());
   MOCK_METHOD1(used, void(bool new_used));
-  MOCK_CONST_METHOD0(zone, const std::string&());
+  MOCK_CONST_METHOD0(locality, const envoy::api::v2::Locality&());
 
   testing::NiceMock<MockClusterInfo> cluster_;
   testing::NiceMock<Outlier::MockDetectorHostMonitor> outlier_detector_;


### PR DESCRIPTION
Generalizes existing zone support.

Fixes #1750.

Signed-off-by: Harvey Tuch <htuch@google.com>