### PR TITLE
NVLOG to prevent unused var

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -222,6 +222,6 @@ protected:
 #define ENVOY_STREAM_LOG(LEVEL, FORMAT, STREAM, ...)                                               \
   ENVOY_STREAM_LOG_TO_LOGGER(ENVOY_LOGGER(), LEVEL, FORMAT, STREAM, ##__VA_ARGS__)
 
-// TODO(danielhochman): macro(s) for simple logging of structures that support iteration
+// TODO(danielhochman): macros(s)/function(s) for logging structures that support iteration.
 
 } // namespace Envoy

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -222,4 +222,6 @@ protected:
 #define ENVOY_STREAM_LOG(LEVEL, FORMAT, STREAM, ...)                                               \
   ENVOY_STREAM_LOG_TO_LOGGER(ENVOY_LOGGER(), LEVEL, FORMAT, STREAM, ##__VA_ARGS__)
 
+// TODO(danielhochman): macro(s) for simple logging of structures that support iteration
+
 } // namespace Envoy

--- a/source/common/config/grpc_mux_subscription_impl.h
+++ b/source/common/config/grpc_mux_subscription_impl.h
@@ -57,11 +57,11 @@ public:
     version_info_ = version_info;
     ENVOY_LOG(debug, "gRPC config for {} accepted with {} resources", type_url_, resources.size());
 
-  #ifndef NVLOG
+#ifndef NVLOG
     for (const auto resource : typed_resources) {
       ENVOY_LOG(debug, "- {}", resource.DebugString());
     }
-  #endif
+#endif
   }
 
   void onConfigUpdateFailed(const EnvoyException* e) override {

--- a/source/common/config/grpc_mux_subscription_impl.h
+++ b/source/common/config/grpc_mux_subscription_impl.h
@@ -57,11 +57,11 @@ public:
     version_info_ = version_info;
     ENVOY_LOG(debug, "gRPC config for {} accepted with {} resources", type_url_, resources.size());
 
-    #ifndef NVLOG
+  #ifndef NVLOG
     for (const auto resource : typed_resources) {
       ENVOY_LOG(debug, "- {}", resource.DebugString());
     }
-    #endif
+  #endif
   }
 
   void onConfigUpdateFailed(const EnvoyException* e) override {

--- a/source/common/config/grpc_mux_subscription_impl.h
+++ b/source/common/config/grpc_mux_subscription_impl.h
@@ -56,9 +56,12 @@ public:
     stats_.update_attempt_.inc();
     version_info_ = version_info;
     ENVOY_LOG(debug, "gRPC config for {} accepted with {} resources", type_url_, resources.size());
+
+    #ifndef NVLOG
     for (const auto resource : typed_resources) {
       ENVOY_LOG(debug, "- {}", resource.DebugString());
     }
+    #endif
   }
 
   void onConfigUpdateFailed(const EnvoyException* e) override {


### PR DESCRIPTION
clang 5 fails when NVLOG set because `resource` is unused

Signed-off-by: Daniel Hochman <dhochman@lyft.com>