### PR TITLE
Fix bazel build against release 0.6.0 for Ubuntu.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 jobs:
    release:
      docker:
-       - image: lyft/envoy-build:7480d2a53726b6389380d741f8a7e7b74a990133
+       - image: lyft/envoy-build:8839608c2f4b0d7c8311361ee5c8785e543d517a
      resource_class: xlarge
      working_directory: /source
      steps:
@@ -15,7 +15,7 @@ jobs:
        - run: ci/docker_push.sh
    asan:
      docker:
-       - image: lyft/envoy-build:7480d2a53726b6389380d741f8a7e7b74a990133
+       - image: lyft/envoy-build:8839608c2f4b0d7c8311361ee5c8785e543d517a
      resource_class: xlarge
      working_directory: /source
      steps:
@@ -23,7 +23,7 @@ jobs:
        - run: ci/do_circle_ci.sh bazel.asan
    tsan:
      docker:
-       - image: lyft/envoy-build:7480d2a53726b6389380d741f8a7e7b74a990133
+       - image: lyft/envoy-build:8839608c2f4b0d7c8311361ee5c8785e543d517a
      resource_class: xlarge
      working_directory: /source
      steps:
@@ -31,7 +31,7 @@ jobs:
        - run: ci/do_circle_ci.sh bazel.tsan
    coverage:
      docker:
-       - image: lyft/envoy-build:7480d2a53726b6389380d741f8a7e7b74a990133
+       - image: lyft/envoy-build:8839608c2f4b0d7c8311361ee5c8785e543d517a
      resource_class: xlarge
      working_directory: /source
      steps:
@@ -40,7 +40,7 @@ jobs:
        - run: ci/coverage_publish.sh
    format:
      docker:
-       - image: lyft/envoy-build:7480d2a53726b6389380d741f8a7e7b74a990133
+       - image: lyft/envoy-build:8839608c2f4b0d7c8311361ee5c8785e543d517a
      resource_class: small
      working_directory: /source
      steps:

--- a/bazel/cc_configure.bzl
+++ b/bazel/cc_configure.bzl
@@ -4,7 +4,7 @@
 # * https://github.com/bazelbuild/bazel/issues/2840
 # * (and potentially) https://github.com/bazelbuild/bazel/issues/2805
 #
-# See cc_configure.bzl.diff for the changes made in this fork.
+# See cc_configure.bzl.diff for the changes made in this fork against bazel release 0.6.0.
 
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
@@ -27,6 +27,8 @@ load("//bazel:lib_cc_configure.bzl", "get_cpu_value")
 
 def _impl(repository_ctx):
   repository_ctx.file("tools/cpp/empty.cc", "int main() {}")
+  repository_ctx.symlink(
+      Label("@bazel_tools//tools/cpp:dummy_toolchain.bzl"), "dummy_toolchain.bzl")
   cpu_value = get_cpu_value(repository_ctx)
   if cpu_value == "freebsd":
     fail("freebsd support needs to be added to the Envoy Bazel cc_configure.bzl fork")

--- a/bazel/cc_configure.bzl.diff
+++ b/bazel/cc_configure.bzl.diff
@@ -1,7 +1,7 @@
-diff --git a/../../bazel/tools/cpp/cc_configure.bzl b/./cc_configure.bzl
-index 79fb8ba65..6ffed9ba3 100644
+diff --git a/../../bazel/tools/cpp/cc_configure.bzl b/cc_configure.bzl
+index 9d6d29fc8..3d0c9e551 100644
 --- a/../../bazel/tools/cpp/cc_configure.bzl
-+++ b/./cc_configure.bzl
++++ b/cc_configure.bzl
 @@ -1,3 +1,11 @@
 +# This file was imported from https://github.com/bazelbuild/bazel at 7b85122. We apply a number of
 +# local modifications to deal with known issues in Bazel 0.5.2:
@@ -9,12 +9,12 @@ index 79fb8ba65..6ffed9ba3 100644
 +# * https://github.com/bazelbuild/bazel/issues/2840
 +# * (and potentially) https://github.com/bazelbuild/bazel/issues/2805
 +#
-+# See cc_configure.bzl.diff for the changes made in this fork.
++# See cc_configure.bzl.diff for the changes made in this fork against bazel release 0.6.0.
 +
  # Copyright 2016 The Bazel Authors. All rights reserved.
  #
  # Licensed under the Apache License, Version 2.0 (the "License");
-@@ -13,23 +21,18 @@
+@@ -13,25 +21,20 @@
  # limitations under the License.
  """Rules for configuring the C++ toolchain (experimental)."""
  
@@ -29,6 +29,8 @@ index 79fb8ba65..6ffed9ba3 100644
  
  def _impl(repository_ctx):
 +  repository_ctx.file("tools/cpp/empty.cc", "int main() {}")
+   repository_ctx.symlink(
+       Label("@bazel_tools//tools/cpp:dummy_toolchain.bzl"), "dummy_toolchain.bzl")
    cpu_value = get_cpu_value(repository_ctx)
    if cpu_value == "freebsd":
 -    # This is defaulting to the static crosstool, we should eventually
@@ -45,7 +47,12 @@ index 79fb8ba65..6ffed9ba3 100644
    elif cpu_value == "darwin":
      configure_osx_toolchain(repository_ctx)
    else:
-@@ -55,6 +58,7 @@ cc_autoconf = repository_rule(
+@@ -53,15 +56,15 @@ cc_autoconf = repository_rule(
+         "BAZEL_VC",
+         "BAZEL_VS",
+         "CC",
+-        "CC_CONFIGURE_DEBUG",
+         "CC_TOOLCHAIN_NAME",
          "CPLUS_INCLUDE_PATH",
          "CUDA_COMPUTE_CAPABILITIES",
          "CUDA_PATH",
@@ -53,3 +60,8 @@ index 79fb8ba65..6ffed9ba3 100644
          "HOMEBREW_RUBY_PATH",
          "NO_WHOLE_ARCHIVE_OPTION",
          "USE_DYNAMIC_CRT",
+-        "USE_MSVC_WRAPPER",
++        "NO_MSVC_WRAPPER",
+         "SYSTEMROOT",
+         "VS90COMNTOOLS",
+         "VS100COMNTOOLS",

--- a/ci/envoy_build_sha.sh
+++ b/ci/envoy_build_sha.sh
@@ -1,3 +1,3 @@
 # If you edit the SHA here you must also edit the SHA in .circleci/config.yml.
 
-ENVOY_BUILD_SHA=7480d2a53726b6389380d741f8a7e7b74a990133
+ENVOY_BUILD_SHA=8839608c2f4b0d7c8311361ee5c8785e543d517a


### PR DESCRIPTION
Fixed bazel 0.6.0 release issue stemming from a missing symlink.  Not sure if other build targets will have issues.