### PR TITLE
Change .travis.yml's language: minimal to shell.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: minimal
+language: shell
 sudo: required
 
 services:


### PR DESCRIPTION
There is no `minimal` language and due to travis-ci/travis-ci#4895, it will fallback to `ruby`. `shell` should serve our usecase

Signed-off-by: bndw <benjamindwoodward@gmail.com>