### PR TITLE
Upstream: Add shell-command health checks.

### DIFF
--- a/docs/configuration/cluster_manager/cluster_hc.rst
+++ b/docs/configuration/cluster_manager/cluster_hc.rst
@@ -19,13 +19,14 @@ Health checking
     "send": [],
     "receive": [],
     "interval_jitter_ms": "...",
+    "command": [],
     "service_name": "..."
   }
 
 type
   *(required, string)* The type of health checking to perform. Currently supported types are
-  *http*, *redis*, and *tcp*. See the :ref:`architecture overview <arch_overview_health_checking>`
-  for more information.
+  *http*, *redis*, *tcp*, and *shell_command*. See the
+  :ref:`architecture overview <arch_overview_health_checking>` for more information.
 
 timeout_ms
   *(required, integer)* The time in milliseconds to wait for a health check response. If the
@@ -73,6 +74,26 @@ receive
 interval_jitter_ms
   *(optional, integer)* An optional jitter amount in millseconds. If specified, during every
   internal Envoy will add 0 to *interval_jitter_ms* milliseconds to the wait time.
+
+command
+  *(sometimes required, array)* This parameter is required if the type is *shell_command*. It
+  specifies the command name and arguments to execute for the health check.  An exit code
+  of zero means success, any other exit code, or exiting by signal, is a failure. '{' and '}' are
+  considered special characters, but the literal can be inserted with '{{' and '}}',
+  respectively. The following will be substituted in these strings:
+
+  *{address}*
+    *1.2.3.4:80* for IPv4, *[1234:5678::9]:443* for IPv6
+
+  *{ip}*
+    *1.2.3.4* for IPv4, *1234:5678::9* for IPv6
+
+  *{port}*
+    The port number
+
+  *{hostname}*
+    The hostname, if specified, or the value of *{ip}* if the hostname is not specified.
+
 
 .. _config_cluster_manager_cluster_hc_service_name:
 

--- a/include/envoy/event/BUILD
+++ b/include/envoy/event/BUILD
@@ -19,6 +19,7 @@ envoy_cc_library(
     deps = [
         ":deferred_deletable",
         ":file_event_interface",
+        ":process_interface",
         ":signal_interface",
         ":timer_interface",
         "//include/envoy/filesystem:filesystem_interface",
@@ -33,6 +34,11 @@ envoy_cc_library(
 envoy_cc_library(
     name = "file_event_interface",
     hdrs = ["file_event.h"],
+)
+
+envoy_cc_library(
+    name = "process_interface",
+    hdrs = ["process.h"],
 )
 
 envoy_cc_library(

--- a/include/envoy/event/process.h
+++ b/include/envoy/event/process.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <functional>
+
+namespace Envoy {
+namespace Event {
+
+/**
+ * Callback invoked when a child is terminated.
+ * @param zero_exit_code True if the process exited with a zero exit code, false
+ *    if the process exited with non-zero status or was killed because of a signal.
+ */
+typedef std::function<void(bool zero_exit_code)> ProcessTerminationCb;
+
+/**
+ * An abstract child process. Free the object to kill the process before completion.
+ * Freeing the object after the process termination callback has run has no effect.
+ */
+class ChildProcess {
+public:
+  virtual ~ChildProcess() {}
+};
+
+typedef std::unique_ptr<ChildProcess> ChildProcessPtr;
+
+} // namespace Event
+} // namespace Envoy

--- a/source/common/config/cds_json.cc
+++ b/source/common/config/cds_json.cc
@@ -40,6 +40,11 @@ void CdsJson::translateHealthCheck(const Json::Object& json_health_check,
       const std::string hex_string = entry->getString("binary");
       tcp_health_check->mutable_receive()->Add()->set_text(hex_string);
     }
+  } else if (hc_type == "shell_command") {
+    auto* shell_command_health_check = health_check.mutable_shell_command_health_check();
+    for (const std::string& str : json_health_check.getStringArray("command")) {
+      shell_command_health_check->add_command(str);
+    }
   } else {
     ASSERT(hc_type == "redis");
     health_check.mutable_redis_health_check();

--- a/source/common/filesystem/filesystem_impl.cc
+++ b/source/common/filesystem/filesystem_impl.cc
@@ -79,7 +79,7 @@ FileImpl::FileImpl(const std::string& path, Event::Dispatcher& dispatcher,
 }
 
 void FileImpl::open() {
-  fd_ = os_sys_calls_.open(path_.c_str(), O_RDWR | O_APPEND | O_CREAT,
+  fd_ = os_sys_calls_.open(path_.c_str(), O_RDWR | O_APPEND | O_CREAT | O_CLOEXEC,
                            S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 
   if (-1 == fd_) {

--- a/source/common/filesystem/inotify/watcher_impl.cc
+++ b/source/common/filesystem/inotify/watcher_impl.cc
@@ -17,7 +17,7 @@ namespace Envoy {
 namespace Filesystem {
 
 WatcherImpl::WatcherImpl(Event::Dispatcher& dispatcher)
-    : inotify_fd_(inotify_init1(IN_NONBLOCK)),
+    : inotify_fd_(inotify_init1(IN_NONBLOCK | IN_CLOEXEC)),
       inotify_event_(dispatcher.createFileEvent(inotify_fd_,
                                                 [this](uint32_t events) -> void {
                                                   ASSERT(events == Event::FileReadyType::Read);

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -1309,7 +1309,7 @@ const std::string Json::Schema::CLUSTER_HEALTH_CHECK_SCHEMA(R"EOF(
     "properties" : {
       "type" : {
         "type" : "string",
-        "enum" : ["http", "redis", "tcp"]
+        "enum" : ["http", "redis", "tcp", "shell_command"]
       },
       "timeout_ms" : {
         "type" : "integer",
@@ -1345,7 +1345,14 @@ const std::string Json::Schema::CLUSTER_HEALTH_CHECK_SCHEMA(R"EOF(
         "minimum" : 0,
         "exclusiveMinimum" : true
       },
-      "service_name" : {"type" : "string"}
+      "service_name" : {"type" : "string"},
+      "command" : {
+        "type" : "array",
+        "items" : {
+          "type" : "string"
+        },
+        "minItems" : 1
+      }
     },
     "required" : ["type", "timeout_ms", "interval_ms", "unhealthy_threshold", "healthy_threshold"],
     "additionalProperties" : false

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -88,6 +88,8 @@ int InstanceBase::socketFromSocketType(SocketType socketType) const {
   int flags = SOCK_NONBLOCK;
 #endif
 
+  flags |= SOCK_CLOEXEC;
+
   if (socketType == SocketType::Stream) {
     flags |= SOCK_STREAM;
   } else {

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -92,8 +92,8 @@ ListenerImpl::ListenerImpl(Network::ConnectionHandler& conn_handler,
       proxy_protocol_(scope), options_(listener_options), listener_(nullptr) {
 
   if (options_.bind_to_port_) {
-    listener_.reset(
-        evconnlistener_new(&dispatcher_.base(), listenCallback, this, 0, -1, socket.fd()));
+    listener_.reset(evconnlistener_new(&dispatcher_.base(), listenCallback, this,
+                                       LEV_OPT_CLOSE_ON_EXEC, -1, socket.fd()));
 
     if (!listener_) {
       throw CreateListenerException(

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -136,7 +136,7 @@ void HotRestartImpl::free(Stats::RawStatData& data) {
 int HotRestartImpl::bindDomainSocket(uint64_t id) {
   // This actually creates the socket and binds it. We use the socket in datagram mode so we can
   // easily read single messages.
-  int fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK, 0);
+  int fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
   sockaddr_un address = createDomainSocketAddress(id);
   int rc = bind(fd, reinterpret_cast<sockaddr*>(&address), sizeof(address));
   if (rc != 0) {

--- a/test/common/event/BUILD
+++ b/test/common/event/BUILD
@@ -15,6 +15,7 @@ envoy_cc_test(
         "//source/common/event:dispatcher_includes",
         "//source/common/event:dispatcher_lib",
         "//test/mocks:common_lib",
+        "//test/mocks/event:event_mocks",
     ],
 )
 

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -1,13 +1,23 @@
+#include <fcntl.h>
+
 #include <functional>
 
 #include "common/event/dispatcher_impl.h"
 
 #include "test/mocks/common.h"
+#include "test/mocks/event/mocks.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using testing::Eq;
 using testing::InSequence;
+using testing::NiceMock;
+using testing::Not;
+using testing::Return;
+using testing::SetArgReferee;
+using testing::StrEq;
+using testing::_;
 
 namespace Envoy {
 namespace Event {
@@ -49,6 +59,277 @@ TEST(DispatcherImplTest, DeferredDelete) {
 
   EXPECT_CALL(watcher3, ready());
   dispatcher.clearDeferredDeleteList();
+}
+
+// Test that the basic fork()/exec() works, and that PATH is searched for
+// the binary
+TEST(DispatcherImplTest, runProcess) {
+  DispatcherImpl dispatcher;
+  ChildProcessPtr child;
+  TimerPtr timer;
+  bool run_succeeded = false;
+  dispatcher.post([&]() {
+    child = dispatcher.runProcess({"true"}, [&](bool zero_exit_code) {
+      run_succeeded = zero_exit_code;
+      dispatcher.exit();
+    });
+  });
+  dispatcher.run(Dispatcher::RunType::Block);
+  EXPECT_TRUE(run_succeeded);
+
+  run_succeeded = false;
+  dispatcher.post([&]() {
+    child = dispatcher.runProcess({"false"}, [&](bool zero_exit_code) {
+      run_succeeded = !zero_exit_code;
+      dispatcher.exit();
+    });
+  });
+  dispatcher.run(Dispatcher::RunType::Block);
+  EXPECT_TRUE(run_succeeded);
+
+  run_succeeded = false;
+  dispatcher.post([&]() {
+    child = dispatcher.runProcess({"sh", "-c", "while true; do sleep 1; done"}, [&](bool) {
+      // Infinite loop, so we should never get here
+      run_succeeded = false;
+      dispatcher.exit();
+    });
+
+    timer = dispatcher.createTimer([&]() {
+      child.reset();
+      dispatcher.exit();
+      run_succeeded = true;
+    });
+    timer->enableTimer(std::chrono::milliseconds(5));
+  });
+  dispatcher.run(Dispatcher::RunType::Block);
+  EXPECT_TRUE(run_succeeded);
+}
+
+class DispatcherChildManagerTest : public testing::Test {
+public:
+  DispatcherChildManagerTest()
+      : os_sys_calls_(new NiceMock<MockOsSysCalls>), child_manager_(OsSysCallsPtr(os_sys_calls_)) {}
+
+  // Make fork return a value indicating this is the child process
+  void setupChild() { EXPECT_CALL(*os_sys_calls_, fork()).WillOnce(Return(0)); }
+
+  // Make fork return a value indicating this is the parent process.
+  // Returns the child pid
+  pid_t setupParent(pid_t pid) {
+    EXPECT_CALL(*os_sys_calls_, fork()).WillOnce(Return(pid));
+    return pid;
+  }
+
+  pid_t setupParent() { return setupParent(10); }
+
+  NiceMock<MockOsSysCalls>* os_sys_calls_;
+  ChildManager child_manager_;
+};
+
+TEST_F(DispatcherChildManagerTest, ForkParent) {
+  const pid_t pid = setupParent();
+  ChildProcessPtr child = child_manager_.run({"foo"}, [](bool) {});
+  EXPECT_TRUE(child_manager_.watched(pid));
+  EXPECT_EQ(1, child_manager_.numWatched());
+}
+
+TEST_F(DispatcherChildManagerTest, ForkChild) {
+  InSequence s;
+  setupChild();
+  EXPECT_CALL(*os_sys_calls_, open(StrEq("/dev/null"), O_RDWR)).WillOnce(Return(10));
+  EXPECT_CALL(*os_sys_calls_, dup2(10, STDIN_FILENO));
+  EXPECT_CALL(*os_sys_calls_, dup2(10, STDOUT_FILENO));
+  EXPECT_CALL(*os_sys_calls_, dup2(10, STDERR_FILENO));
+  EXPECT_CALL(*os_sys_calls_, execvp_(_, _));
+
+  // Mock-execvp doesn't really execvp (obviously), so the call returns.
+  // Any return from execvp is treated as a failure and results in a
+  // call to _exit.
+  EXPECT_CALL(*os_sys_calls_, _exit(Not(Eq(0))));
+
+  child_manager_.run({"process_name"}, [](bool) {});
+}
+
+TEST_F(DispatcherChildManagerTest, ForkError) {
+  EXPECT_CALL(*os_sys_calls_, fork()).WillOnce(Return(-1));
+  EXPECT_THROW({ child_manager_.run({"process_name"}, [](bool) {}); }, EnvoyException);
+}
+
+TEST_F(DispatcherChildManagerTest, ExecMissingProcessName) {
+  EXPECT_THROW({ child_manager_.run({}, [](bool) {}); }, EnvoyException);
+}
+
+TEST_F(DispatcherChildManagerTest, ExecEmptyProcessName) {
+  EXPECT_THROW({ child_manager_.run({""}, [](bool) {}); }, EnvoyException);
+}
+
+TEST_F(DispatcherChildManagerTest, ExecArgsNone) {
+  const char* process_name = "process_name";
+  setupChild();
+  EXPECT_CALL(*os_sys_calls_, execvp_(StrEq(process_name), ElementsAre(StrEq(process_name))));
+  child_manager_.run({process_name}, [](bool) {});
+}
+
+TEST_F(DispatcherChildManagerTest, ExecArgsNoneProcessContainsSlash) {
+  const char* process_name = "/a/path/to/process";
+  setupChild();
+  EXPECT_CALL(*os_sys_calls_, execvp_(StrEq(process_name), ElementsAre(StrEq(process_name))));
+  child_manager_.run({process_name}, [](bool) {});
+}
+
+TEST_F(DispatcherChildManagerTest, ExecArgsMultiple) {
+  const char* process_name = "process_name";
+  const std::vector<std::string> args = {process_name, "arg1", "arg2", "arg3"};
+  setupChild();
+  EXPECT_CALL(*os_sys_calls_,
+              execvp_(StrEq(process_name), ElementsAre(StrEq(process_name), StrEq("arg1"),
+                                                       StrEq("arg2"), StrEq("arg3"))));
+  child_manager_.run(args, [](bool) {});
+}
+
+struct ProcessCompletionCase {
+  OsSysCalls::WaitpidStatus waitpid_status;
+  bool expect_zero_exit;
+  bool expect_callback_called;
+};
+
+class DispatcherChildManagerProcessCompletionTest
+    : public DispatcherChildManagerTest,
+      public testing::WithParamInterface<ProcessCompletionCase> {};
+
+TEST_P(DispatcherChildManagerProcessCompletionTest, ProcessCompletionStatus) {
+  const pid_t pid = setupParent();
+
+  bool callback_run = false;
+  bool zero_exit_code = false;
+  ChildProcessPtr child = child_manager_.run({"sh"}, [&](bool zero_exit_code_param) {
+    callback_run = true;
+    zero_exit_code = zero_exit_code_param;
+  });
+  EXPECT_CALL(*os_sys_calls_, waitpid(-1, _, _))
+      .WillOnce(DoAll(SetArgReferee<1>(GetParam().waitpid_status), Return(pid)))
+      .WillOnce(Return(-1));
+  child_manager_.onSigChld();
+  EXPECT_EQ(GetParam().expect_callback_called, callback_run);
+  EXPECT_EQ(GetParam().expect_zero_exit, zero_exit_code);
+}
+
+static const ProcessCompletionCase processCompletionCases[] = {
+    {{false, true, 0}, true, true},    // exited with 0
+    {{false, true, 1}, false, true},   // exited non-zero
+    {{false, true, -1}, false, true},  // exited negative non-zero
+    {{true, false, 0}, false, true},   // signalled
+    {{false, false, 0}, false, false}, // process didn't complete
+};
+
+INSTANTIATE_TEST_CASE_P(Cases, DispatcherChildManagerProcessCompletionTest,
+                        testing::ValuesIn(processCompletionCases));
+
+TEST_F(DispatcherChildManagerTest, WaitpidMultiple) {
+  OsSysCalls::WaitpidStatus status1;
+  status1.exited_ = true;
+  status1.exit_status_ = 0;
+  status1.signalled_ = false;
+
+  OsSysCalls::WaitpidStatus status2;
+  status2.exited_ = true;
+  status2.exit_status_ = 1;
+  status2.signalled_ = false;
+
+  bool callback_run1 = false;
+  bool callback_run2 = false;
+  bool zero1 = false;
+  bool zero2 = false;
+
+  const pid_t pid1 = setupParent();
+  ChildProcessPtr child1 = child_manager_.run({"sh"}, [&](bool zero_exit) {
+    callback_run1 = true;
+    zero1 = zero_exit;
+  });
+
+  const pid_t pid2 = setupParent(pid1 + 1);
+  ChildProcessPtr child2 = child_manager_.run({"sh"}, [&](bool zero_exit) {
+    callback_run2 = true;
+    zero2 = zero_exit;
+  });
+
+  EXPECT_CALL(*os_sys_calls_, waitpid(-1, _, _))
+      .WillOnce(DoAll(SetArgReferee<1>(status1), Return(pid1)))
+      .WillOnce(DoAll(SetArgReferee<1>(status2), Return(pid2)))
+      .WillOnce(Return(-1));
+
+  child_manager_.onSigChld();
+  EXPECT_TRUE(callback_run1);
+  EXPECT_TRUE(callback_run2);
+  EXPECT_TRUE(zero1);
+  EXPECT_FALSE(zero2);
+}
+
+TEST_F(DispatcherChildManagerTest, UnwatchedSigChld) {
+  const pid_t pid = setupParent();
+  OsSysCalls::WaitpidStatus status;
+  status.exited_ = true;
+  status.exit_status_ = 0;
+  status.signalled_ = false;
+
+  bool callback_run = false;
+  ChildProcessPtr child = child_manager_.run({"sh"}, [&](bool) { callback_run = true; });
+  EXPECT_CALL(*os_sys_calls_, waitpid(-1, _, _))
+      .WillOnce(DoAll(SetArgReferee<1>(status), Return(pid + 1)))
+      .WillOnce(Return(-1));
+  EXPECT_EQ(1, child_manager_.numWatched());
+  child_manager_.onSigChld();
+  EXPECT_FALSE(callback_run);
+  EXPECT_EQ(1, child_manager_.numWatched());
+}
+
+TEST_F(DispatcherChildManagerTest, Cancellation) {
+  const pid_t pid = setupParent();
+  OsSysCalls::WaitpidStatus status;
+  status.exited_ = true;
+  status.exit_status_ = 0;
+  status.signalled_ = false;
+
+  bool callback_run = false;
+  ChildProcessPtr child = child_manager_.run({"sh"}, [&](bool) { callback_run = true; });
+
+  EXPECT_CALL(*os_sys_calls_, kill(pid, SIGTERM));
+  EXPECT_TRUE(child_manager_.watched(pid));
+  child.reset();
+  EXPECT_FALSE(child_manager_.watched(pid));
+
+  EXPECT_CALL(*os_sys_calls_, waitpid(-1, _, _))
+      .WillOnce(DoAll(SetArgReferee<1>(status), Return(pid)))
+      .WillOnce(Return(-1));
+  child_manager_.onSigChld();
+  EXPECT_FALSE(callback_run);
+}
+
+TEST_F(DispatcherChildManagerTest, StaleCancellation) {
+  const pid_t pid = setupParent();
+  OsSysCalls::WaitpidStatus status;
+  status.exited_ = true;
+  status.exit_status_ = 0;
+  status.signalled_ = false;
+
+  ChildProcessPtr child1 = child_manager_.run({"sh"}, [&](bool) {});
+  EXPECT_CALL(*os_sys_calls_, waitpid(-1, _, _))
+      .WillOnce(DoAll(SetArgReferee<1>(status), Return(pid)))
+      .WillOnce(Return(-1));
+  EXPECT_TRUE(child_manager_.watched(pid));
+  child_manager_.onSigChld();
+  EXPECT_FALSE(child_manager_.watched(pid));
+
+  const pid_t pid2 = setupParent(pid);
+  ASSERT_EQ(pid, pid2); // Test doesn't work if these don't match
+  ChildProcessPtr child2 = child_manager_.run({"sh"}, [&](bool) {});
+
+  EXPECT_CALL(*os_sys_calls_, kill(_, _)).Times(0);
+  child1.reset();
+
+  EXPECT_CALL(*os_sys_calls_, kill(_, _)).Times(1);
+  child2.reset();
 }
 
 } // namespace Event

--- a/test/common/json/config_schemas_test.cc
+++ b/test/common/json/config_schemas_test.cc
@@ -22,7 +22,7 @@ std::vector<std::string> generateTestInputs() {
 
   std::string test_path = TestEnvironment::temporaryDirectory() + "/config_schemas_test";
   auto file_list = TestUtility::listFiles(test_path, false);
-  EXPECT_EQ(17, file_list.size());
+  EXPECT_EQ(19, file_list.size());
   return file_list;
 }
 
@@ -43,6 +43,8 @@ TEST_P(ConfigSchemasTest, CheckValidationExpectation) {
     schema = Schema::ROUTE_ENTRY_CONFIGURATION_SCHEMA;
   } else if (schema_name == "CLUSTER_SCHEMA") {
     schema = Schema::CLUSTER_SCHEMA;
+  } else if (schema_name == "CLUSTER_HEALTH_CHECK_SCHEMA") {
+    schema = Schema::CLUSTER_HEALTH_CHECK_SCHEMA;
   } else if (schema_name == "TOP_LEVEL_CONFIG_SCHEMA") {
     schema = Schema::TOP_LEVEL_CONFIG_SCHEMA;
   } else {

--- a/test/common/json/config_schemas_test_data/test_cluster_schema.py
+++ b/test/common/json/config_schemas_test_data/test_cluster_schema.py
@@ -16,7 +16,8 @@ CLUSTER_BLOB = {
         "unhealthy_threshold": 2, 
         "healthy_threshold": 2, 
         "path": "/healthcheck", 
-        "service_name": "foo"
+        "service_name": "foo",
+        "command": ["commandname", "--someoption"]
     }, 
     "outlier_detection": {}
 }
@@ -36,6 +37,24 @@ def test(writer):
     writer.write_test_file(
         'UnsupportedFeature',
         schema='CLUSTER_SCHEMA',
+        data=blob,
+        throws=True,
+    )
+
+    blob = get_blob(CLUSTER_BLOB)['health_check']
+    blob['command'] = list()
+    writer.write_test_file(
+        'CommandMinimumListLength',
+        schema='CLUSTER_HEALTH_CHECK_SCHEMA',
+        data=blob,
+        throws=True,
+    )
+
+    blob = get_blob(CLUSTER_BLOB)['health_check']
+    blob['command'] = ['mycommand', 1]
+    writer.write_test_file(
+        'CommandElementType',
+        schema='CLUSTER_HEALTH_CHECK_SCHEMA',
         data=blob,
         throws=True,
     )

--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -64,11 +64,17 @@ parseSdsClusterFromJson(const std::string& json_string,
   return cluster;
 }
 
-inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
-                                  uint32_t weight = 1) {
-  return HostSharedPtr{new HostImpl(cluster, "", Network::Utility::resolveUrl(url),
+inline HostSharedPtr makeNamedTestHost(ClusterInfoConstSharedPtr cluster,
+                                       const std::string& hostname, const std::string& url,
+                                       uint32_t weight = 1) {
+  return HostSharedPtr{new HostImpl(cluster, hostname, Network::Utility::resolveUrl(url),
                                     envoy::api::v2::Metadata::default_instance(), weight,
                                     envoy::api::v2::Locality())};
+}
+
+inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
+                                  uint32_t weight = 1) {
+  return makeNamedTestHost(cluster, "", url, weight);
 }
 
 inline HostDescriptionConstSharedPtr makeTestHostDescription(ClusterInfoConstSharedPtr cluster,

--- a/test/mocks/event/mocks.cc
+++ b/test/mocks/event/mocks.cc
@@ -47,5 +47,21 @@ MockSignalEvent::~MockSignalEvent() {}
 MockFileEvent::MockFileEvent() {}
 MockFileEvent::~MockFileEvent() {}
 
+MockOsSysCalls::MockOsSysCalls() {}
+MockOsSysCalls::~MockOsSysCalls() {}
+
+int MockOsSysCalls::execvp(const char* file, char* const argv[]) {
+  std::vector<const char*> args;
+
+  // Convert to something that gtest matchers can easily operate on
+  for (size_t i = 0; argv[i] != nullptr; i++) {
+    args.push_back(argv[i]);
+  }
+  return execvp_(file, args);
+}
+
+MockChildProcess::MockChildProcess() {}
+MockChildProcess::~MockChildProcess() { destructor(); }
+
 } // namespace Event
 } // namespace Envoy

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -78,6 +78,11 @@ public:
     return SignalEventPtr{listenForSignal_(signal_num, cb)};
   }
 
+  ChildProcessPtr runProcess(const std::vector<std::string>& args,
+                             ProcessTerminationCb cb) override {
+    return ChildProcessPtr{runProcess_(args, cb)};
+  }
+
   // Event::Dispatcher
   MOCK_METHOD0(clearDeferredDeleteList, void());
   MOCK_METHOD2(createClientConnection_,
@@ -107,6 +112,8 @@ public:
   MOCK_METHOD1(deferredDelete_, void(DeferredDeletablePtr& to_delete));
   MOCK_METHOD0(exit, void());
   MOCK_METHOD2(listenForSignal_, SignalEvent*(int signal_num, SignalCb cb));
+  MOCK_METHOD2(runProcess_,
+               ChildProcess*(const std::vector<std::string>& args, ProcessTerminationCb cb));
   MOCK_METHOD1(post, void(std::function<void()> callback));
   MOCK_METHOD1(run, void(RunType type));
   Buffer::WatermarkFactory& getWatermarkFactory() override { return *buffer_factory_; }
@@ -144,6 +151,31 @@ public:
 
   MOCK_METHOD1(activate, void(uint32_t events));
   MOCK_METHOD1(setEnabled, void(uint32_t events));
+};
+
+class MockOsSysCalls : public OsSysCalls {
+public:
+  MockOsSysCalls();
+  ~MockOsSysCalls();
+
+  int execvp(const char* file, char* const argv[]) override;
+
+  MOCK_METHOD0(fork, pid_t());
+  MOCK_METHOD2(execvp_, int(const char* file, const std::vector<const char*>& args));
+  MOCK_METHOD3(waitpid, pid_t(pid_t pid, OsSysCalls::WaitpidStatus& status, int options));
+  MOCK_METHOD2(kill, int(pid_t pid, int sig));
+  MOCK_METHOD1(_exit, void(int status));
+  MOCK_METHOD2(open, int(const char* pathname, int flags));
+  MOCK_METHOD2(dup2, int(int oldfd, int newfd));
+  MOCK_METHOD1(close, int(int fd));
+};
+
+class MockChildProcess : public ChildProcess {
+public:
+  MockChildProcess();
+  ~MockChildProcess();
+
+  MOCK_METHOD0(destructor, void());
 };
 
 } // namespace Event


### PR DESCRIPTION
This is useful when using tcp_proxy, but more intelligent health
checks are needed than can be provided by sending/receiving a fixed
set of bytes.

Signed-off-by: Greg Greenway <ggreenway@apple.com>