### PR TITLE
redis: fix pipeline timeout logic

### DIFF
--- a/test/common/redis/conn_pool_impl_test.cc
+++ b/test/common/redis/conn_pool_impl_test.cc
@@ -106,7 +106,6 @@ TEST_F(RedisClientImplTest, Basic) {
   RespValue request2;
   MockPoolCallbacks callbacks2;
   EXPECT_CALL(*encoder_, encode(Ref(request2), _));
-  EXPECT_CALL(*connect_or_op_timer_, enableTimer(_));
   PoolRequest* handle2 = client_->makeRequest(request2, callbacks2);
   EXPECT_NE(nullptr, handle2);
 
@@ -120,6 +119,7 @@ TEST_F(RedisClientImplTest, Basic) {
     InSequence s;
     RespValuePtr response1(new RespValue());
     EXPECT_CALL(callbacks1, onResponse_(Ref(response1)));
+    EXPECT_CALL(*connect_or_op_timer_, enableTimer(_));
     EXPECT_CALL(host_->outlier_detector_, putHttpResponseCode(200));
     callbacks_->onRespValue(std::move(response1));
 
@@ -152,7 +152,6 @@ TEST_F(RedisClientImplTest, Cancel) {
   RespValue request2;
   MockPoolCallbacks callbacks2;
   EXPECT_CALL(*encoder_, encode(Ref(request2), _));
-  EXPECT_CALL(*connect_or_op_timer_, enableTimer(_));
   PoolRequest* handle2 = client_->makeRequest(request2, callbacks2);
   EXPECT_NE(nullptr, handle2);
 
@@ -164,6 +163,7 @@ TEST_F(RedisClientImplTest, Cancel) {
 
     RespValuePtr response1(new RespValue());
     EXPECT_CALL(callbacks1, onResponse_(_)).Times(0);
+    EXPECT_CALL(*connect_or_op_timer_, enableTimer(_));
     EXPECT_CALL(host_->outlier_detector_, putHttpResponseCode(200));
     callbacks_->onRespValue(std::move(response1));
 


### PR DESCRIPTION
When using Redis pipelines, this ensures that we only boost the timeout when first command is written to the connection (`makeRequest`).

We also reset the timeout whenever we receive a response (`onRespValue`) to give Redis time to respond to each operation with the full op timeout. 

Before we would boost the timeout on each incoming command even if the connection was going to timeout with no response on the first command. This resulted in long-tail timeouts well beyond the configured op timeout.