### PR TITLE
Fixes to Dockerhub release tagging

### DIFF
--- a/ci/do_circle_ci.sh
+++ b/ci/do_circle_ci.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+if [ -n "$CIRCLE_TAG" ]
+then
+  echo 'Ignoring build for git tag event'
+  exit 0
+fi
+
 # bazel uses jgit internally and the default circle-ci .gitconfig says to
 # convert https://github.com to ssh://git@github.com, which jgit does not support.
 mv ~/.gitconfig ~/.gitconfig_save

--- a/ci/docker_tag.sh
+++ b/ci/docker_tag.sh
@@ -6,6 +6,16 @@ set -e
 
 if [ -n "$CIRCLE_TAG" ]
 then
+   # TODO(mattklein123): Currently we are doing this push in the context of the release job which
+   # happens inside of our build image. We should switch to using Circle caching so each of these
+   # are discrete jobs that work with the binary. All of these commands run on a remote docker
+   # server also so we have to temporarily install docker here.
+   # https://circleci.com/docs/2.0/building-docker-images/
+   VER="17.03.0-ce"
+   curl -L -o /tmp/docker-"$VER".tgz https://get.docker.com/builds/Linux/x86_64/docker-"$VER".tgz
+   tar -xz -C /tmp -f /tmp/docker-"$VER".tgz
+   mv /tmp/docker/* /usr/bin
+
    docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
    docker pull lyft/envoy:"$CIRCLE_SHA1"


### PR DESCRIPTION
This is a follow up to https://github.com/envoyproxy/envoy/pull/1768

* Resolves missing `docker` command by installing Docker in tag script ([CI failure](https://circleci.com/gh/envoyproxy/envoy/1212))
* Skips unnecessary build/test on tag events