### PR TITLE
Move Filesystem::OsSysCalls to Api::OsSysCalls.

### DIFF
--- a/include/envoy/api/BUILD
+++ b/include/envoy/api/BUILD
@@ -16,3 +16,8 @@ envoy_cc_library(
         "//include/envoy/thread:thread_interface",
     ],
 )
+
+envoy_cc_library(
+    name = "os_sys_calls_interface",
+    hdrs = ["os_sys_calls.h"],
+)

--- a/include/envoy/api/os_sys_calls.h
+++ b/include/envoy/api/os_sys_calls.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <string>
+#include <memory>
+
+#include "envoy/common/pure.h"
+
+namespace Envoy {
+namespace Api {
+
+class OsSysCalls {
+public:
+  virtual ~OsSysCalls(){};
+
+  /**
+   * Open file by full_path with given flags and mode.
+   * @return file descriptor.
+   */
+  virtual int open(const std::string& full_path, int flags, int mode) PURE;
+
+  /**
+   * Write num_bytes to fd from buffer.
+   * @return number of bytes written if non negative, otherwise error code.
+   */
+  virtual ssize_t write(int fd, const void* buffer, size_t num_bytes) PURE;
+
+  /**
+   * Release all resources allocated for fd.
+   * @return zero on success, -1 returned otherwise.
+   */
+  virtual int close(int fd) PURE;
+};
+
+typedef std::unique_ptr<OsSysCalls> OsSysCallsPtr;
+
+} // namespace Api
+} // namespace Envoy

--- a/include/envoy/api/os_sys_calls.h
+++ b/include/envoy/api/os_sys_calls.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <string>
 #include <memory>
+#include <string>
 
 #include "envoy/common/pure.h"
 

--- a/include/envoy/filesystem/filesystem.h
+++ b/include/envoy/filesystem/filesystem.h
@@ -10,31 +10,6 @@
 namespace Envoy {
 namespace Filesystem {
 
-class OsSysCalls {
-public:
-  virtual ~OsSysCalls(){};
-
-  /**
-   * Open file by full_path with given flags and mode.
-   * @return file descriptor.
-   */
-  virtual int open(const std::string& full_path, int flags, int mode) PURE;
-
-  /**
-   * Write num_bytes to fd from buffer.
-   * @return number of bytes written if non negative, otherwise error code.
-   */
-  virtual ssize_t write(int fd, const void* buffer, size_t num_bytes) PURE;
-
-  /**
-   * Release all resources allocated for fd.
-   * @return zero on success, -1 returned otherwise.
-   */
-  virtual int close(int fd) PURE;
-};
-
-typedef std::unique_ptr<OsSysCalls> OsSysCallsPtr;
-
 /**
  * Abstraction for a file on disk.
  */

--- a/source/common/api/BUILD
+++ b/source/common/api/BUILD
@@ -14,7 +14,17 @@ envoy_cc_library(
     hdrs = ["api_impl.h"],
     deps = [
         "//include/envoy/api:api_interface",
+        "//source/common/api:os_sys_calls_lib",
         "//source/common/event:dispatcher_lib",
         "//source/common/filesystem:filesystem_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "os_sys_calls_lib",
+    srcs = ["os_sys_calls_impl.cc"],
+    hdrs = ["os_sys_calls_impl.h"],
+    deps = [
+        "//include/envoy/api:os_sys_calls_interface",
     ],
 )

--- a/source/common/api/api_impl.cc
+++ b/source/common/api/api_impl.cc
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <string>
 
+#include "common/api/os_sys_calls_impl.h"
 #include "common/event/dispatcher_impl.h"
 #include "common/filesystem/filesystem_impl.h"
 
@@ -14,8 +15,7 @@ Event::DispatcherPtr Impl::allocateDispatcher() {
 }
 
 Impl::Impl(std::chrono::milliseconds file_flush_interval_msec)
-    : os_sys_calls_(new Filesystem::OsSysCallsImpl()),
-      file_flush_interval_msec_(file_flush_interval_msec) {}
+    : os_sys_calls_(new OsSysCallsImpl()), file_flush_interval_msec_(file_flush_interval_msec) {}
 
 Filesystem::FileSharedPtr Impl::createFile(const std::string& path, Event::Dispatcher& dispatcher,
                                            Thread::BasicLockable& lock, Stats::Store& stats_store) {

--- a/source/common/api/api_impl.h
+++ b/source/common/api/api_impl.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "envoy/api/api.h"
+#include "envoy/api/os_sys_calls.h"
 #include "envoy/filesystem/filesystem.h"
 
 namespace Envoy {
@@ -25,7 +26,7 @@ public:
   std::string fileReadToEnd(const std::string& path) override;
 
 private:
-  Filesystem::OsSysCallsPtr os_sys_calls_;
+  OsSysCallsPtr os_sys_calls_;
   std::chrono::milliseconds file_flush_interval_msec_;
 };
 

--- a/source/common/api/os_sys_calls_impl.cc
+++ b/source/common/api/os_sys_calls_impl.cc
@@ -1,0 +1,21 @@
+#include "common/api/os_sys_calls_impl.h"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace Envoy {
+namespace Api {
+
+int OsSysCallsImpl::open(const std::string& full_path, int flags, int mode) {
+  return ::open(full_path.c_str(), flags, mode);
+}
+
+int OsSysCallsImpl::close(int fd) { return ::close(fd); }
+
+ssize_t OsSysCallsImpl::write(int fd, const void* buffer, size_t num_bytes) {
+  return ::write(fd, buffer, num_bytes);
+}
+
+} // namespace Api
+} // namespace Envoy

--- a/source/common/api/os_sys_calls_impl.h
+++ b/source/common/api/os_sys_calls_impl.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "envoy/api/os_sys_calls.h"
+
+namespace Envoy {
+namespace Api {
+
+class OsSysCallsImpl : public OsSysCalls {
+public:
+  // Api::OsSysCalls
+  int open(const std::string& full_path, int flags, int mode) override;
+  ssize_t write(int fd, const void* buffer, size_t num_bytes) override;
+  int close(int fd) override;
+};
+
+} // namespace Api
+} // namespace Envoy

--- a/source/common/filesystem/BUILD
+++ b/source/common/filesystem/BUILD
@@ -13,6 +13,7 @@ envoy_cc_library(
     srcs = ["filesystem_impl.cc"],
     hdrs = ["filesystem_impl.h"],
     deps = [
+        "//include/envoy/api:os_sys_calls_interface",
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/filesystem:filesystem_interface",
         "//source/common/buffer:buffer_lib",

--- a/source/common/filesystem/filesystem_impl.cc
+++ b/source/common/filesystem/filesystem_impl.cc
@@ -1,8 +1,6 @@
 #include "common/filesystem/filesystem_impl.h"
 
 #include <dirent.h>
-#include <fcntl.h>
-#include <unistd.h>
 
 #include <chrono>
 #include <cstdint>
@@ -54,19 +52,9 @@ std::string fileReadToEnd(const std::string& path) {
   return file_string.str();
 }
 
-int OsSysCallsImpl::open(const std::string& full_path, int flags, int mode) {
-  return ::open(full_path.c_str(), flags, mode);
-}
-
-int OsSysCallsImpl::close(int fd) { return ::close(fd); }
-
-ssize_t OsSysCallsImpl::write(int fd, const void* buffer, size_t num_bytes) {
-  return ::write(fd, buffer, num_bytes);
-}
-
 FileImpl::FileImpl(const std::string& path, Event::Dispatcher& dispatcher,
-                   Thread::BasicLockable& lock, OsSysCalls& os_sys_calls, Stats::Store& stats_store,
-                   std::chrono::milliseconds flush_interval_msec)
+                   Thread::BasicLockable& lock, Api::OsSysCalls& os_sys_calls,
+                   Stats::Store& stats_store, std::chrono::milliseconds flush_interval_msec)
     : path_(path), file_lock_(lock), flush_timer_(dispatcher.createTimer([this]() -> void {
         stats_.flushed_by_timer_.inc();
         flush_event_.notify_one();

--- a/source/common/filesystem/filesystem_impl.h
+++ b/source/common/filesystem/filesystem_impl.h
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <string>
 
+#include "envoy/api/os_sys_calls.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/filesystem/filesystem.h"
 #include "envoy/stats/stats_macros.h"
@@ -46,14 +47,6 @@ bool directoryExists(const std::string& path);
  */
 std::string fileReadToEnd(const std::string& path);
 
-class OsSysCallsImpl : public OsSysCalls {
-public:
-  // Filesystem::OsSysCalls
-  int open(const std::string& full_path, int flags, int mode) override;
-  ssize_t write(int fd, const void* buffer, size_t num_bytes) override;
-  int close(int fd) override;
-};
-
 /**
  * This is a file implementation geared for writing out access logs. It turn out that in certain
  * cases even if a standard file is opened with O_NONBLOCK, the kernel can still block when writing.
@@ -64,7 +57,7 @@ public:
 class FileImpl : public File {
 public:
   FileImpl(const std::string& path, Event::Dispatcher& dispatcher, Thread::BasicLockable& lock,
-           OsSysCalls& osSysCalls, Stats::Store& stats_store,
+           Api::OsSysCalls& osSysCalls, Stats::Store& stats_store,
            std::chrono::milliseconds flush_interval_msec);
   ~FileImpl();
 
@@ -123,7 +116,7 @@ private:
                                             // continue to fill. This buffer is then used for the
                                             // final write to disk.
   Event::TimerPtr flush_timer_;
-  OsSysCalls& os_sys_calls_;
+  Api::OsSysCalls& os_sys_calls_;
   const std::chrono::milliseconds flush_interval_msec_; // Time interval buffer gets flushed no
                                                         // matter if it reached the MIN_FLUSH_SIZE
                                                         // or not.

--- a/test/common/filesystem/BUILD
+++ b/test/common/filesystem/BUILD
@@ -12,11 +12,13 @@ envoy_cc_test(
     name = "filesystem_impl_test",
     srcs = ["filesystem_impl_test.cc"],
     deps = [
+        "//source/common/api:os_sys_calls_lib",
         "//source/common/common:thread_lib",
         "//source/common/event:dispatcher_includes",
         "//source/common/event:dispatcher_lib",
         "//source/common/filesystem:filesystem_lib",
         "//source/common/stats:stats_lib",
+        "//test/mocks/api:api_mocks",
         "//test/mocks/event:event_mocks",
         "//test/mocks/filesystem:filesystem_mocks",
         "//test/test_common:environment_lib",

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -1,11 +1,13 @@
 #include <chrono>
 #include <string>
 
+#include "common/api/os_sys_calls_impl.h"
 #include "common/common/thread.h"
 #include "common/event/dispatcher_impl.h"
 #include "common/filesystem/filesystem_impl.h"
 #include "common/stats/stats_impl.h"
 
+#include "test/mocks/api/mocks.h"
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/filesystem/mocks.h"
 #include "test/test_common/environment.h"
@@ -28,7 +30,7 @@ TEST(FileSystemImpl, BadFile) {
   Event::MockDispatcher dispatcher;
   Thread::MutexBasicLockable lock;
   Stats::IsolatedStoreImpl store;
-  Filesystem::OsSysCallsImpl os_sys_calls;
+  Api::OsSysCallsImpl os_sys_calls;
   EXPECT_CALL(dispatcher, createTimer_(_));
   EXPECT_THROW(Filesystem::FileImpl("", dispatcher, lock, os_sys_calls, store,
                                     std::chrono::milliseconds(10000)),
@@ -65,7 +67,7 @@ TEST(FileSystemImpl, flushToLogFilePeriodically) {
 
   Thread::MutexBasicLockable mutex;
   Stats::IsolatedStoreImpl stats_store;
-  NiceMock<Filesystem::MockOsSysCalls> os_sys_calls;
+  NiceMock<Api::MockOsSysCalls> os_sys_calls;
 
   EXPECT_CALL(os_sys_calls, open_(_, _, _)).WillOnce(Return(5));
   Filesystem::FileImpl file("", dispatcher, mutex, os_sys_calls, stats_store,
@@ -118,7 +120,7 @@ TEST(FileSystemImpl, flushToLogFileOnDemand) {
 
   Thread::MutexBasicLockable mutex;
   Stats::IsolatedStoreImpl stats_store;
-  NiceMock<Filesystem::MockOsSysCalls> os_sys_calls;
+  NiceMock<Api::MockOsSysCalls> os_sys_calls;
 
   EXPECT_CALL(os_sys_calls, open_(_, _, _)).WillOnce(Return(5));
   Filesystem::FileImpl file("", dispatcher, mutex, os_sys_calls, stats_store,
@@ -191,7 +193,7 @@ TEST(FileSystemImpl, reopenFile) {
 
   Thread::MutexBasicLockable mutex;
   Stats::IsolatedStoreImpl stats_store;
-  NiceMock<Filesystem::MockOsSysCalls> os_sys_calls;
+  NiceMock<Api::MockOsSysCalls> os_sys_calls;
 
   Sequence sq;
   EXPECT_CALL(os_sys_calls, open_(_, _, _)).InSequence(sq).WillOnce(Return(5));
@@ -251,7 +253,7 @@ TEST(FilesystemImpl, reopenThrows) {
 
   Thread::MutexBasicLockable mutex;
   Stats::IsolatedStoreImpl stats_store;
-  NiceMock<Filesystem::MockOsSysCalls> os_sys_calls;
+  NiceMock<Api::MockOsSysCalls> os_sys_calls;
 
   EXPECT_CALL(os_sys_calls, write_(_, _, _))
       .WillRepeatedly(Invoke([](int fd, const void* buffer, size_t num_bytes) -> ssize_t {
@@ -298,7 +300,7 @@ TEST(FilesystemImpl, bigDataChunkShouldBeFlushedWithoutTimer) {
   NiceMock<Event::MockDispatcher> dispatcher;
   Thread::MutexBasicLockable mutex;
   Stats::IsolatedStoreImpl stats_store;
-  NiceMock<Filesystem::MockOsSysCalls> os_sys_calls;
+  NiceMock<Api::MockOsSysCalls> os_sys_calls;
 
   Filesystem::FileImpl file("", dispatcher, mutex, os_sys_calls, stats_store,
                             std::chrono::milliseconds(40));

--- a/test/mocks/api/BUILD
+++ b/test/mocks/api/BUILD
@@ -14,6 +14,7 @@ envoy_cc_mock(
     hdrs = ["mocks.h"],
     deps = [
         "//include/envoy/api:api_interface",
+        "//include/envoy/api:os_sys_calls_interface",
         "//test/mocks/filesystem:filesystem_mocks",
     ],
 )

--- a/test/mocks/api/mocks.cc
+++ b/test/mocks/api/mocks.cc
@@ -13,5 +13,29 @@ MockApi::MockApi() { ON_CALL(*this, createFile(_, _, _, _)).WillByDefault(Return
 
 MockApi::~MockApi() {}
 
+MockOsSysCalls::MockOsSysCalls() { num_writes_ = num_open_ = 0; }
+
+MockOsSysCalls::~MockOsSysCalls() {}
+
+int MockOsSysCalls::open(const std::string& full_path, int flags, int mode) {
+  std::unique_lock<Thread::BasicLockable> lock(open_mutex_);
+
+  int result = open_(full_path, flags, mode);
+  num_open_++;
+  open_event_.notify_one();
+
+  return result;
+}
+
+ssize_t MockOsSysCalls::write(int fd, const void* buffer, size_t num_bytes) {
+  std::unique_lock<Thread::BasicLockable> lock(write_mutex_);
+
+  ssize_t result = write_(fd, buffer, num_bytes);
+  num_writes_++;
+  write_event_.notify_one();
+
+  return result;
+}
+
 } // namespace Api
 } // namespace Envoy

--- a/test/mocks/api/mocks.h
+++ b/test/mocks/api/mocks.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "envoy/api/api.h"
+#include "envoy/api/os_sys_calls.h"
 #include "envoy/event/dispatcher.h"
 
 #include "test/mocks/filesystem/mocks.h"
@@ -31,6 +32,27 @@ public:
   MOCK_METHOD1(fileReadToEnd, std::string(const std::string& path));
 
   std::shared_ptr<Filesystem::MockFile> file_{new Filesystem::MockFile()};
+};
+
+class MockOsSysCalls : public OsSysCalls {
+public:
+  MockOsSysCalls();
+  ~MockOsSysCalls();
+
+  // Filesystem::OsSysCalls
+  ssize_t write(int fd, const void* buffer, size_t num_bytes) override;
+  int open(const std::string& full_path, int flags, int mode) override;
+  MOCK_METHOD1(close, int(int));
+
+  MOCK_METHOD3(open_, int(const std::string& full_path, int flags, int mode));
+  MOCK_METHOD3(write_, ssize_t(int, const void*, size_t));
+
+  size_t num_writes_;
+  size_t num_open_;
+  Thread::MutexBasicLockable write_mutex_;
+  Thread::MutexBasicLockable open_mutex_;
+  std::condition_variable_any write_event_;
+  std::condition_variable_any open_event_;
 };
 
 } // namespace Api

--- a/test/mocks/filesystem/mocks.cc
+++ b/test/mocks/filesystem/mocks.cc
@@ -5,30 +5,6 @@
 namespace Envoy {
 namespace Filesystem {
 
-MockOsSysCalls::MockOsSysCalls() { num_writes_ = num_open_ = 0; }
-
-MockOsSysCalls::~MockOsSysCalls() {}
-
-int MockOsSysCalls::open(const std::string& full_path, int flags, int mode) {
-  std::unique_lock<Thread::BasicLockable> lock(open_mutex_);
-
-  int result = open_(full_path, flags, mode);
-  num_open_++;
-  open_event_.notify_one();
-
-  return result;
-}
-
-ssize_t MockOsSysCalls::write(int fd, const void* buffer, size_t num_bytes) {
-  std::unique_lock<Thread::BasicLockable> lock(write_mutex_);
-
-  ssize_t result = write_(fd, buffer, num_bytes);
-  num_writes_++;
-  write_event_.notify_one();
-
-  return result;
-}
-
 MockFile::MockFile() {}
 MockFile::~MockFile() {}
 

--- a/test/mocks/filesystem/mocks.h
+++ b/test/mocks/filesystem/mocks.h
@@ -13,27 +13,6 @@
 namespace Envoy {
 namespace Filesystem {
 
-class MockOsSysCalls : public OsSysCalls {
-public:
-  MockOsSysCalls();
-  ~MockOsSysCalls();
-
-  // Filesystem::OsSysCalls
-  ssize_t write(int fd, const void* buffer, size_t num_bytes) override;
-  int open(const std::string& full_path, int flags, int mode) override;
-  MOCK_METHOD1(close, int(int));
-
-  MOCK_METHOD3(open_, int(const std::string& full_path, int flags, int mode));
-  MOCK_METHOD3(write_, ssize_t(int, const void*, size_t));
-
-  size_t num_writes_;
-  size_t num_open_;
-  Thread::MutexBasicLockable write_mutex_;
-  Thread::MutexBasicLockable open_mutex_;
-  std::condition_variable_any write_event_;
-  std::condition_variable_any open_event_;
-};
-
 class MockFile : public File {
 public:
   MockFile();


### PR DESCRIPTION
This makes it appopriate to use the OsSysCalls abstraction
in other areas of the code-base, such as hot-restart.

Signed-off-by: Greg Greenway <ggreenway@apple.com>