### PR TITLE
router: add x-envoy-overloaded header

### DIFF
--- a/docs/configuration/http_filters/router_filter.rst
+++ b/docs/configuration/http_filters/router_filter.rst
@@ -225,6 +225,17 @@ for the next health check interval. The host can become healthy again via standa
 checks. See the :ref:`health checking overview <arch_overview_health_checking>` for more
 information.
 
+.. _config_http_filters_router_x-envoy-overloaded:
+
+x-envoy-overloaded
+^^^^^^^^^^^^^^^^^^
+
+If this header is set by upstream, Envoy will not retry. Currently the value of the header is not
+looked at, only its presence. Additionally, Envoy will set this header on the downstream response
+if a request was dropped due to either :ref:`maintenance mode
+<config_http_filters_router_runtime_maintenance_mode>` or upstream :ref:`circuit breaking
+<arch_overview_circuit_break>`.
+
 .. _config_http_filters_router_stats:
 
 Statistics

--- a/docs/intro/arch_overview/circuit_breaking.rst
+++ b/docs/intro/arch_overview/circuit_breaking.rst
@@ -25,10 +25,14 @@ configure and code each application independently. Envoy supports various types 
 * **Cluster maximum active retries**: The maximum number of retries that can be outstanding to all
   hosts in a cluster at any given time. In general we recommend aggressively circuit breaking
   retries so that retries for sporadic failures are allowed but the overall retry volume cannot
-  explode and cause large scale cascading failure. If this circuit breaker overflows the 
+  explode and cause large scale cascading failure. If this circuit breaker overflows the
   :ref:`upstream_rq_retry_overflow <config_cluster_manager_cluster_stats>` counter for the cluster
   will increment.
 
 Each circuit breaking limit is :ref:`configurable <config_cluster_manager_cluster_circuit_breakers>`
 and tracked on a per upstream cluster and per priority basis. This allows different components of
 the distributed system to be tuned independently and have different limits.
+
+Note that circuit breaking will cause the :ref:`x-envoy-overloaded
+<config_http_filters_router_x-envoy-overloaded>` header to be set by the router filter in the
+case of HTTP requests.

--- a/docs/intro/arch_overview/http_routing.rst
+++ b/docs/intro/arch_overview/http_routing.rst
@@ -76,6 +76,9 @@ headers <config_http_filters_router_headers>`. The following configurations are 
   requirements. For example, network failure, all 5xx response codes, idempotent 4xx response codes,
   etc.
 
+Note that retries may be disabled depending on the contents of the :ref:`x-envoy-overloaded
+<config_http_filters_router_x-envoy-overloaded>`.
+
 .. _arch_overview_http_routing_priority:
 
 Priority routing

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -224,6 +224,7 @@ private:
   HEADER_FUNC(EnvoyInternalRequest)                                                                \
   HEADER_FUNC(EnvoyMaxRetries)                                                                     \
   HEADER_FUNC(EnvoyOriginalPath)                                                                   \
+  HEADER_FUNC(EnvoyOverloaded)                                                                     \
   HEADER_FUNC(EnvoyRetryOn)                                                                        \
   HEADER_FUNC(EnvoyRetryGrpcOn)                                                                    \
   HEADER_FUNC(EnvoyUpstreamAltStatName)                                                            \

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -38,6 +38,7 @@ public:
   const LowerCaseString EnvoyInternalRequest{"x-envoy-internal"};
   const LowerCaseString EnvoyMaxRetries{"x-envoy-max-retries"};
   const LowerCaseString EnvoyOriginalPath{"x-envoy-original-path"};
+  const LowerCaseString EnvoyOverloaded{"x-envoy-overloaded"};
   const LowerCaseString EnvoyRetryOn{"x-envoy-retry-on"};
   const LowerCaseString EnvoyRetryGrpcOn{"x-envoy-retry-grpc-on"};
   const LowerCaseString EnvoyUpstreamAltStatName{"x-envoy-upstream-alt-stat-name"};
@@ -106,6 +107,10 @@ public:
   struct {
     const std::string True{"true"};
   } EnvoyInternalRequestValues;
+
+  struct {
+    const std::string True{"true"};
+  } EnvoyOverloadedValues;
 
   struct {
     const std::string _5xx{"5xx"};

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -168,7 +168,7 @@ RetryStatus RetryStateImpl::shouldRetry(const Http::HeaderMap* response_headers,
 bool RetryStateImpl::wouldRetry(const Http::HeaderMap* response_headers,
                                 const Optional<Http::StreamResetReason>& reset_reason) {
   // We never retry if the overloaded header is set.
-  if (response_headers && response_headers->EnvoyOverloaded() != nullptr) {
+  if (response_headers != nullptr && response_headers->EnvoyOverloaded() != nullptr) {
     return false;
   }
 

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -256,6 +256,7 @@ private:
   // Called immediately after a non-5xx header is received from upstream, performs stats accounting
   // and handle difference between gRPC and non-gRPC requests.
   void handleNon5xxResponseHeaders(const Http::HeaderMap& headers, bool end_stream);
+  void sendLocalReply(Http::Code code, const std::string& body, bool overloaded);
 
   FilterConfig& config_;
   Http::StreamDecoderFilterCallbacks* callbacks_{};

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -180,8 +180,10 @@ TEST_F(RouterTest, PoolFailureOverflow) {
         return nullptr;
       }));
 
-  Http::TestHeaderMapImpl response_headers{
-      {":status", "503"}, {"content-length", "57"}, {"content-type", "text/plain"}};
+  Http::TestHeaderMapImpl response_headers{{":status", "503"},
+                                           {"content-length", "57"},
+                                           {"content-type", "text/plain"},
+                                           {"x-envoy-overloaded", "true"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
   EXPECT_CALL(callbacks_.request_info_,
@@ -283,8 +285,10 @@ TEST_F(RouterTest, NoHost) {
 TEST_F(RouterTest, MaintenanceMode) {
   EXPECT_CALL(*cm_.thread_local_cluster_.cluster_.info_, maintenanceMode()).WillOnce(Return(true));
 
-  Http::TestHeaderMapImpl response_headers{
-      {":status", "503"}, {"content-length", "16"}, {"content-type", "text/plain"}};
+  Http::TestHeaderMapImpl response_headers{{":status", "503"},
+                                           {"content-length", "16"},
+                                           {"content-type", "text/plain"},
+                                           {"x-envoy-overloaded", "true"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
   EXPECT_CALL(callbacks_.request_info_,


### PR DESCRIPTION
This change reduces retry explosion:
1) Retry is never performed if local circuit breaking occurred.
2) If traffic was dropped (circuit breaking or maintenance mode),
   Envoy will set an x-envoy-overloaded header. (Right now it is
   set to "true" which has no real meaning. We might define more
   values in the future).
3) Envoy will not retry if it sees the x-envoy-overloaded header
   set by upstream. Of course this header can be propagated
   downstream by the caller if desired and application other than
   Envoy can set this header. However, even in the Envoy <-> Envoy
   single hop case this can reduce retry explosion when under
   duress.

One downside of this change is that a single bad upstream might
create a situation in which retries do not happen that might
otherwise succeed. In general, it seems better to err on the side
of less retries and bad single hosts should be ejected via proper
outlier detection policies.

Signed-off-by: Matt Klein <mklein@lyft.com>