### PR TITLE
Few small fixes to allow envoy to compile on ARM32

### DIFF
--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -15,7 +15,7 @@ namespace Buffer {
  */
 struct RawSlice {
   void* mem_;
-  uint64_t len_;
+  size_t len_;
 };
 
 /**

--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 #include <memory>
 
 #include "envoy/buffer/buffer.h"
@@ -197,7 +198,7 @@ struct Http2Settings {
   // initial value from HTTP/2 spec, same as NGHTTP2_DEFAULT_HEADER_TABLE_SIZE from nghttp2
   static const uint32_t DEFAULT_HPACK_TABLE_SIZE = (1 << 12);
   // no maximum from HTTP/2 spec, use unsigned 32-bit maximum
-  static const uint32_t MAX_HPACK_TABLE_SIZE = (1UL << 32) - 1;
+  static const uint32_t MAX_HPACK_TABLE_SIZE = std::numeric_limits<uint32_t>::max();
 
   // TODO(jwfang): make this 0, the HTTP/2 spec minimum
   static const uint32_t MIN_MAX_CONCURRENT_STREAMS = 1;

--- a/source/common/mongo/bson_impl.cc
+++ b/source/common/mongo/bson_impl.cc
@@ -1,5 +1,7 @@
 #include "common/mongo/bson_impl.h"
 
+#include <endian.h>
+
 #include <cstdint>
 #include <sstream>
 #include <string>

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -24,9 +24,9 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const std::string& hot_restart_v
   log_levels_string += "\n[trace] and [debug] are only available on debug builds";
 
   TCLAP::CmdLine cmd("envoy", ' ', VersionInfo::version());
-  TCLAP::ValueArg<uint64_t> base_id(
+  TCLAP::ValueArg<uint32_t> base_id(
       "", "base-id", "base ID so that multiple envoys can run on the same host if needed", false, 0,
-      "uint64_t", cmd);
+      "uint32_t", cmd);
   TCLAP::ValueArg<uint32_t> concurrency("", "concurrency", "# of worker threads to run", false,
                                         std::thread::hardware_concurrency(), "uint32_t", cmd);
   TCLAP::ValueArg<std::string> config_path("c", "config-path", "Path to configuration file", false,
@@ -42,8 +42,8 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const std::string& hot_restart_v
                                          cmd);
   TCLAP::ValueArg<std::string> log_path("", "log-path", "Path to logfile", false, "", "string",
                                         cmd);
-  TCLAP::ValueArg<uint64_t> restart_epoch("", "restart-epoch", "hot restart epoch #", false, 0,
-                                          "uint64_t", cmd);
+  TCLAP::ValueArg<uint32_t> restart_epoch("", "restart-epoch", "hot restart epoch #", false, 0,
+                                          "uint32_t", cmd);
   TCLAP::SwitchArg hot_restart_version_option("", "hot-restart-version",
                                               "hot restart compatability version", cmd);
   TCLAP::ValueArg<std::string> service_cluster("", "service-cluster", "Cluster name", false, "",
@@ -52,14 +52,14 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const std::string& hot_restart_v
                                             cmd);
   TCLAP::ValueArg<std::string> service_zone("", "service-zone", "Zone name", false, "", "string",
                                             cmd);
-  TCLAP::ValueArg<uint64_t> file_flush_interval_msec("", "file-flush-interval-msec",
+  TCLAP::ValueArg<uint32_t> file_flush_interval_msec("", "file-flush-interval-msec",
                                                      "Interval for log flushing in msec", false,
-                                                     10000, "uint64_t", cmd);
-  TCLAP::ValueArg<uint64_t> drain_time_s("", "drain-time-s", "Hot restart drain time in seconds",
-                                         false, 600, "uint64_t", cmd);
-  TCLAP::ValueArg<uint64_t> parent_shutdown_time_s("", "parent-shutdown-time-s",
+                                                     10000, "uint32_t", cmd);
+  TCLAP::ValueArg<uint32_t> drain_time_s("", "drain-time-s", "Hot restart drain time in seconds",
+                                         false, 600, "uint32_t", cmd);
+  TCLAP::ValueArg<uint32_t> parent_shutdown_time_s("", "parent-shutdown-time-s",
                                                    "Hot restart parent shutdown time in seconds",
-                                                   false, 900, "uint64_t", cmd);
+                                                   false, 900, "uint32_t", cmd);
   TCLAP::ValueArg<std::string> mode("", "mode",
                                     "One of 'serve' (default; validate configs and then serve "
                                     "traffic normally) or 'validate' (validate configs and exit).",


### PR DESCRIPTION
Tested compilation for rasbperry pi and android (the 'endian' change is
required for android NDK - recent androids can compile with 64 bit).

(moved from PR #1781 due to git squashing/DCO issues)

Signed-off-by: Costin Manolache <costin@google.com>