### PR TITLE
fix OS X build

### DIFF
--- a/source/common/common/byte_order.h
+++ b/source/common/common/byte_order.h
@@ -1,17 +1,18 @@
 #pragma once
 
+// NOLINT(namespace-envoy)
+
 #ifdef __APPLE__
+
 #include <libkern/OSByteOrder.h>
 
-#endif
-
-namespace Envoy {
-
-#ifdef __APPLE__
 #define htole32(x) OSSwapHostToLittleInt32((x))
 #define htole64(x) OSSwapHostToLittleInt64((x))
 #define le32toh(x) OSSwapLittleToHostInt32((x))
 #define le64toh(x) OSSwapLittleToHostInt64((x))
-#endif
 
-} // Envoy
+#else
+
+#include <endian.h>
+
+#endif

--- a/source/common/mongo/bson_impl.cc
+++ b/source/common/mongo/bson_impl.cc
@@ -1,7 +1,5 @@
 #include "common/mongo/bson_impl.h"
 
-#include <endian.h>
-
 #include <cstdint>
 #include <sstream>
 #include <string>

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -5,6 +5,7 @@ load(
     "envoy_cc_test",
     "envoy_cc_test_library",
     "envoy_package",
+    "envoy_select_hot_restart",
 )
 
 envoy_package()
@@ -56,7 +57,7 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "hot_restart_impl_test",
-    srcs = ["hot_restart_impl_test.cc"],
+    srcs = envoy_select_hot_restart(["hot_restart_impl_test.cc"]),
     deps = [
         "//source/server:hot_restart_lib",
         "//test/mocks/server:server_mocks",


### PR DESCRIPTION
Two changes:

1. As discussed on #envoy-osx-dev, `<endian>` doesn't exist on OS X.  Fixed byte_order.h to properly include it when not OS X, and fixed bson_impl.cc to not know about endian.h.
2. The new hot_restart test needs to only be run on systems that `envoy_select_hot_restart`. Like not attempting to run on OS X.

ps. byte_order.h had a completely unused `namespace Envoy` wrapping the macros. I ditched it because it's correct.