### PR TITLE
tracing: Enable service version to be specified on command line and r…

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -112,7 +112,7 @@ def envoy_api_deps(skip_targets):
     native.git_repository(
         name = "envoy_api",
         remote = REPO_LOCATIONS["envoy_api"],
-        commit = "9be6aff6da46e024af56cce20cb5d5d3184f19c5",
+        commit = "3e5037feccd94a118fb136ebc73410aeb2930c4d",
     )
     api_bind_targets = [
         "address",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,7 +1,7 @@
 REPO_LOCATIONS = {
     "jinja2": "https://github.com/pallets/jinja.git",
     "grpc_transcoding": "https://github.com/grpc-ecosystem/grpc-httpjson-transcoding.git",
-    "envoy_api": "https://github.com/envoyproxy/data-plane-api.git",
+    "envoy_api": "https://github.com/objectiser/envoy-api.git",
     "protobuf" :"https://github.com/htuch/protobuf.git",
     "markupsafe": "https://github.com/pallets/markupsafe.git",
 }

--- a/include/envoy/local_info/local_info.h
+++ b/include/envoy/local_info/local_info.h
@@ -33,6 +33,11 @@ public:
   virtual const std::string clusterName() const PURE;
 
   /**
+   * Human readable service version. E.g., "1".
+   */
+  virtual const std::string serviceVersion() const PURE;
+
+  /**
    * Human readable individual node name. E.g., "i-123456".
    */
   virtual const std::string nodeName() const PURE;

--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -112,6 +112,11 @@ public:
   virtual const std::string& serviceClusterName() PURE;
 
   /**
+   * @return const std::string& the server's cluster.
+   */
+  virtual const std::string& serviceVersion() PURE;
+
+  /**
    * @return const std::string& the server's node identification.
    */
   virtual const std::string& serviceNodeName() PURE;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -556,6 +556,9 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
       if (cached_route_.value() && cached_route_.value()->decorator()) {
         cached_route_.value()->decorator()->apply(*active_span_);
       }
+      if (!connection_manager_.local_info_.serviceVersion().empty()) {
+        active_span_->setTag("version", connection_manager_.local_info_.serviceVersion());
+      }
       active_span_->injectContext(*request_headers_);
     }
   }

--- a/source/common/local_info/local_info_impl.h
+++ b/source/common/local_info/local_info_impl.h
@@ -11,13 +11,16 @@ class LocalInfoImpl : public LocalInfo {
 public:
   LocalInfoImpl(const envoy::api::v2::Node& node, Network::Address::InstanceConstSharedPtr address,
                 const std::string zone_name, const std::string cluster_name,
-                const std::string node_name)
+                const std::string service_version, const std::string node_name)
       : node_(node), address_(address) {
     if (!zone_name.empty()) {
       node_.mutable_locality()->set_zone(zone_name);
     }
     if (!cluster_name.empty()) {
       node_.set_cluster(cluster_name);
+    }
+    if (!service_version.empty()) {
+      node_.set_version(service_version);
     }
     if (!node_name.empty()) {
       node_.set_id(node_name);
@@ -30,6 +33,7 @@ public:
   Network::Address::InstanceConstSharedPtr address() const override { return address_; }
   const std::string zoneName() const override { return node_.locality().zone(); }
   const std::string clusterName() const override { return node_.cluster(); }
+  const std::string serviceVersion() const override { return node_.version(); }
   const std::string nodeName() const override { return node_.id(); }
   const envoy::api::v2::Node& node() const override { return node_; }
 

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -75,9 +75,9 @@ void ValidationInstance::initialize(Options& options,
   }
   bootstrap.mutable_node()->set_build_version(VersionInfo::version());
 
-  local_info_.reset(
-      new LocalInfo::LocalInfoImpl(bootstrap.node(), local_address, options.serviceZone(),
-                                   options.serviceClusterName(), options.serviceNodeName()));
+  local_info_.reset(new LocalInfo::LocalInfoImpl(
+      bootstrap.node(), local_address, options.serviceZone(), options.serviceClusterName(),
+      options.serviceVersion(), options.serviceNodeName()));
 
   Configuration::InitialImpl initial_config(bootstrap);
   thread_local_.registerThread(*dispatcher_, true);

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -48,6 +48,8 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const std::string& hot_restart_v
                                               "hot restart compatability version", cmd);
   TCLAP::ValueArg<std::string> service_cluster("", "service-cluster", "Cluster name", false, "",
                                                "string", cmd);
+  TCLAP::ValueArg<std::string> service_version("", "service-version", "Service version", false, "",
+                                               "string", cmd);
   TCLAP::ValueArg<std::string> service_node("", "service-node", "Node name", false, "", "string",
                                             cmd);
   TCLAP::ValueArg<std::string> service_zone("", "service-zone", "Zone name", false, "", "string",
@@ -111,6 +113,7 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const std::string& hot_restart_v
   log_path_ = log_path.getValue();
   restart_epoch_ = restart_epoch.getValue();
   service_cluster_ = service_cluster.getValue();
+  service_version_ = service_version.getValue();
   service_node_ = service_node.getValue();
   service_zone_ = service_zone.getValue();
   file_flush_interval_msec_ = std::chrono::milliseconds(file_flush_interval_msec.getValue());

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -31,6 +31,7 @@ public:
   Server::Mode mode() const override { return mode_; }
   std::chrono::milliseconds fileFlushIntervalMsec() override { return file_flush_interval_msec_; }
   const std::string& serviceClusterName() override { return service_cluster_; }
+  const std::string& serviceVersion() override { return service_version_; }
   const std::string& serviceNodeName() override { return service_node_; }
   const std::string& serviceZone() override { return service_zone_; }
 
@@ -44,6 +45,7 @@ private:
   std::string log_path_;
   uint64_t restart_epoch_;
   std::string service_cluster_;
+  std::string service_version_;
   std::string service_node_;
   std::string service_zone_;
   std::chrono::milliseconds file_flush_interval_msec_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -177,9 +177,9 @@ void InstanceImpl::initialize(Options& options,
   }
   bootstrap.mutable_node()->set_build_version(VersionInfo::version());
 
-  local_info_.reset(
-      new LocalInfo::LocalInfoImpl(bootstrap.node(), local_address, options.serviceZone(),
-                                   options.serviceClusterName(), options.serviceNodeName()));
+  local_info_.reset(new LocalInfo::LocalInfoImpl(
+      bootstrap.node(), local_address, options.serviceZone(), options.serviceClusterName(),
+      options.serviceVersion(), options.serviceNodeName()));
 
   Configuration::InitialImpl initial_config(bootstrap);
   ENVOY_LOG(info, "admin address: {}", initial_config.admin().address()->asString());

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -375,6 +375,8 @@ TEST_F(HttpConnectionManagerImplTest, InvalidPathWithDualFilter) {
 TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlow) {
   setup(false, "");
 
+  EXPECT_CALL(local_info_, serviceVersion()).WillRepeatedly(Return("v1"));
+
   NiceMock<Tracing::MockSpan>* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(tracer_, startSpan_(_, _, _))
       .WillOnce(Invoke([&](const Tracing::Config& config, const HeaderMap&,
@@ -395,6 +397,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlow) {
   EXPECT_CALL(*span, setTag(":method", "GET"));
   // Verify if the activeSpan interface returns reference to the current span.
   EXPECT_CALL(*span, setTag("service-cluster", "scoobydoo"));
+  EXPECT_CALL(*span, setTag("version", "v1"));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
       .WillOnce(Return(true));
 

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -48,6 +48,7 @@ public:
   }
   Mode mode() const override { return Mode::Serve; }
   const std::string& serviceClusterName() override { return service_cluster_name_; }
+  const std::string& serviceVersion() override { return service_version_; }
   const std::string& serviceNodeName() override { return service_node_name_; }
   const std::string& serviceZone() override { return service_zone_; }
 
@@ -56,6 +57,7 @@ private:
   const std::string admin_address_path_;
   const Network::Address::IpVersion local_address_ip_version_;
   const std::string service_cluster_name_;
+  const std::string service_version_;
   const std::string service_node_name_;
   const std::string service_zone_;
   const std::string log_path_;

--- a/test/mocks/local_info/mocks.h
+++ b/test/mocks/local_info/mocks.h
@@ -17,6 +17,7 @@ public:
   MOCK_CONST_METHOD0(address, Network::Address::InstanceConstSharedPtr());
   MOCK_CONST_METHOD0(zoneName, const std::string());
   MOCK_CONST_METHOD0(clusterName, const std::string());
+  MOCK_CONST_METHOD0(serviceVersion, const std::string());
   MOCK_CONST_METHOD0(nodeName, const std::string());
   MOCK_CONST_METHOD0(node, envoy::api::v2::Node&());
 

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -22,6 +22,7 @@ MockOptions::MockOptions(const std::string& config_path)
   ON_CALL(*this, configPath()).WillByDefault(ReturnRef(config_path_));
   ON_CALL(*this, adminAddressPath()).WillByDefault(ReturnRef(admin_address_path_));
   ON_CALL(*this, serviceClusterName()).WillByDefault(ReturnRef(service_cluster_name_));
+  ON_CALL(*this, serviceVersion()).WillByDefault(ReturnRef(service_version_));
   ON_CALL(*this, serviceNodeName()).WillByDefault(ReturnRef(service_node_name_));
   ON_CALL(*this, serviceZone()).WillByDefault(ReturnRef(service_zone_name_));
   ON_CALL(*this, logPath()).WillByDefault(ReturnRef(log_path_));

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -56,12 +56,14 @@ public:
   MOCK_METHOD0(fileFlushIntervalMsec, std::chrono::milliseconds());
   MOCK_CONST_METHOD0(mode, Mode());
   MOCK_METHOD0(serviceClusterName, const std::string&());
+  MOCK_METHOD0(serviceVersion, const std::string&());
   MOCK_METHOD0(serviceNodeName, const std::string&());
   MOCK_METHOD0(serviceZone, const std::string&());
 
   std::string config_path_;
   std::string admin_address_path_;
   std::string service_cluster_name_;
+  std::string service_version_;
   std::string service_node_name_;
   std::string service_zone_name_;
   std::string log_path_;

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -39,6 +39,7 @@ TEST(OptionsImplTest, All) {
   std::unique_ptr<OptionsImpl> options = createOptionsImpl(
       "envoy --mode validate --concurrency 2 -c hello --admin-address-path path --restart-epoch 1 "
       "--local-address-ip-version v6 -l info --service-cluster cluster --service-node node "
+      "--service version v1 "
       "--service-zone zone --file-flush-interval-msec 9000 --drain-time-s 60 "
       "--parent-shutdown-time-s 90 --log-path /foo/bar");
   EXPECT_EQ(Server::Mode::Validate, options->mode());
@@ -50,6 +51,7 @@ TEST(OptionsImplTest, All) {
   EXPECT_EQ(spdlog::level::info, options->logLevel());
   EXPECT_EQ("/foo/bar", options->logPath());
   EXPECT_EQ("cluster", options->serviceClusterName());
+  EXPECT_EQ("v1", options->serviceVersion());
   EXPECT_EQ("node", options->serviceNodeName());
   EXPECT_EQ("zone", options->serviceZone());
   EXPECT_EQ(std::chrono::milliseconds(9000), options->fileFlushIntervalMsec());

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -149,11 +149,13 @@ TEST_P(ServerInstanceImplTest, BootstrapNode) {
 // Validate server localInfo() from bootstrap Node with CLI overrides.
 TEST_P(ServerInstanceImplTest, BootstrapNodeWithOptionsOverride) {
   options_.service_cluster_name_ = "some_cluster_name";
+  options_.service_version_ = "some_service_version";
   options_.service_node_name_ = "some_node_name";
   options_.service_zone_name_ = "some_zone_name";
   initialize("test/server/node_bootstrap.yaml");
   EXPECT_EQ("some_zone_name", server_->localInfo().zoneName());
   EXPECT_EQ("some_cluster_name", server_->localInfo().clusterName());
+  EXPECT_EQ("some_service_version", server_->localInfo().serviceVersion());
   EXPECT_EQ("some_node_name", server_->localInfo().nodeName());
   EXPECT_EQ("bootstrap_sub_zone", server_->localInfo().node().locality().sub_zone());
   EXPECT_EQ(VersionInfo::version(), server_->localInfo().node().build_version());


### PR DESCRIPTION
…ecorded in tracing spans

Signed-off-by: Gary Brown <gary@brownuk.com>

**DO NOT MERGE**

This PR is dependent upon https://github.com/envoyproxy/data-plane-api/pull/187 - which is based off the current commit used by the Envoy proxy (https://github.com/envoyproxy/data-plane-api/commit/9be6aff6da46e024af56cce20cb5d5d3184f19c5), as the proxy does not build with the most recent commit in the data-plane-api. So for review purposes this PR is using my own fork of the data-plane-api repo.