### PR TITLE
ci: fixed strip envoy artifact implementation

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -22,8 +22,7 @@ function bazel_release_binary_build() {
   mkdir -p "${ENVOY_SRCDIR}"/build_release
   cp -f "${ENVOY_DELIVERY_DIR}"/envoy "${ENVOY_SRCDIR}"/build_release
   mkdir -p "${ENVOY_SRCDIR}"/build_release_stripped
-  cp -f "${ENVOY_DELIVERY_DIR}"/envoy "${ENVOY_SRCDIR}"/build_release_stripped
-  strip "${ENVOY_SRCDIR}"/build_release_stripped/envoy
+  strip "${ENVOY_DELIVERY_DIR}"/envoy -o "${ENVOY_SRCDIR}"/build_release_stripped/envoy
 }
 
 function bazel_debug_binary_build() {


### PR DESCRIPTION
When stripping the envoy artifact, was getting `Permission denied`:

```
INFO: From Executing genrule //source/exe:envoy-static_stamped:
Writing c534f5a4c429de4c6d43d3766e26df4011507283 truncated to c534f5a4c429de4c6d43d3766e26df40 at offset 0x2ac in bazel-out/local-opt/genfiles/source/exe/envoy-static.stamped
Target //source/exe:envoy-static.stamped up-to-date:
  bazel-genfiles/source/exe/envoy-static.stamped
INFO: Elapsed time: 1439.266s, Critical Path: 253.51s
INFO: Build completed successfully, 542 total actions
Copying release binary for image build...
strip: unable to copy file '/source/build_release_stripped/envoy'; reason: Permission denied
```

This was because the `envoy` artifact being copied into the `build_release_stripped/` directory was of mode `-r-xr-xr-x` and `strip` was unable to replace it as it was readonly. A simply fix for this is not copying the artifact with `cp` but rather, `strip` to `the build_release_stripped/` directory instead.