### PR TITLE
perf: optimize random number generation and populate all 64 bits.

### DIFF
--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -24,26 +24,22 @@ namespace Runtime {
 const size_t RandomGeneratorImpl::UUID_LENGTH = 36;
 
 uint64_t RandomGeneratorImpl::random() {
-  static thread_local uint8_t buffered[2048];
-  static thread_local size_t buffered_idx = sizeof(buffered);
+  const size_t prefetch = 256;
+  static thread_local uint64_t buffered[prefetch];
+  static thread_local size_t buffered_idx = prefetch;
 
-  // Prefetch 2048 bytes of randomness. buffered_idx is initialized to sizeof(buffered),
-  // i.e. out-of-range value, so the buffer will be filled with randomness on the first
-  // call to this function.
-  if (buffered_idx >= sizeof(buffered)) {
-    int rc = RAND_bytes(buffered, sizeof(buffered));
+  // Prefetch 256 * sizeof(uint64_t) bytes of randomness. buffered_idx is initialized to 256,
+  // i.e. out-of-range value, so the buffer will be filled with randomness on the first call
+  // to this function.
+  if (buffered_idx >= prefetch) {
+    int rc = RAND_bytes(reinterpret_cast<uint8_t*>(buffered), sizeof(buffered));
     ASSERT(rc == 1);
     UNREFERENCED_PARAMETER(rc);
     buffered_idx = 0;
   }
 
-  // Consume sizeof(uint64) bytes from the buffer.
-  ASSERT(buffered_idx + sizeof(uint64_t) <= sizeof(buffered));
-  uint64_t rand;
-  std::memcpy(reinterpret_cast<void*>(&rand), &buffered[buffered_idx], sizeof(uint64_t));
-  buffered_idx += sizeof(uint64_t);
-
-  return rand;
+  // Consume uint64_t from the buffer.
+  return buffered[buffered_idx++];
 }
 
 std::string RandomGeneratorImpl::uuid() {

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -2,10 +2,8 @@
 
 #include <dirent.h>
 
-#include <chrono>
 #include <cstdint>
 #include <memory>
-#include <random>
 #include <string>
 #include <unordered_map>
 
@@ -31,19 +29,10 @@ namespace Runtime {
 class RandomGeneratorImpl : public RandomGenerator {
 public:
   // Runtime::RandomGenerator
-  uint64_t random() override { return threadLocalGenerator()(); }
+  uint64_t random() override;
   std::string uuid() override;
 
   static const size_t UUID_LENGTH;
-
-private:
-  static std::ranlux48& threadLocalGenerator() {
-    std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        std::chrono::system_clock::now().time_since_epoch());
-    static thread_local std::ranlux48 generator(now.count() ^ Thread::Thread::currentThreadId());
-
-    return generator;
-  }
 };
 
 /**

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -20,6 +20,26 @@ using testing::ReturnNew;
 namespace Envoy {
 namespace Runtime {
 
+TEST(Random, DISABLED_benchmarkRandom) {
+  Runtime::RandomGeneratorImpl random;
+
+  for (size_t i = 0; i < 100000000; ++i) {
+    random.random();
+  }
+}
+
+TEST(Random, sanityCheckOfUniquenessRandom) {
+  Runtime::RandomGeneratorImpl random;
+  std::set<uint64_t> results;
+  const size_t num_of_results = 1000000;
+
+  for (size_t i = 0; i < num_of_results; ++i) {
+    results.insert(random.random());
+  }
+
+  EXPECT_EQ(num_of_results, results.size());
+}
+
 TEST(UUID, checkLengthOfUUID) {
   RandomGeneratorImpl random;
 

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -23,7 +23,7 @@ namespace Runtime {
 TEST(Random, DISABLED_benchmarkRandom) {
   Runtime::RandomGeneratorImpl random;
 
-  for (size_t i = 0; i < 100000000; ++i) {
+  for (size_t i = 0; i < 1000000000; ++i) {
     random.random();
   }
 }

--- a/test/common/runtime/uuid_util_test.cc
+++ b/test/common/runtime/uuid_util_test.cc
@@ -65,7 +65,7 @@ TEST(UUIDUtilsTest, checkDistribution) {
 TEST(UUIDUtilsTest, DISABLED_benchmark) {
   Runtime::RandomGeneratorImpl random;
 
-  for (int i = 0; i < 10000000; ++i) {
+  for (int i = 0; i < 100000000; ++i) {
     random.uuid();
   }
 }


### PR DESCRIPTION
Before:
Random.benchmarkRandom: 55,713 ms

After:
Random.benchmarkRandom:    800 ms

Fixes #1798.