### PR TITLE
upstream: Adding std::move calls to fix several clang-tidy issues.

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -520,8 +520,8 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::updateClusterMembership(
 
   ASSERT(config.thread_local_clusters_.find(name) != config.thread_local_clusters_.end());
   config.thread_local_clusters_[name]->host_set_.updateHosts(
-      hosts, healthy_hosts, hosts_per_locality, healthy_hosts_per_locality, hosts_added,
-      hosts_removed);
+      std::move(hosts), std::move(healthy_hosts), std::move(hosts_per_locality),
+      std::move(healthy_hosts_per_locality), hosts_added, hosts_removed);
 }
 
 ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -8,6 +8,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "envoy/event/timer.h"
@@ -181,10 +182,10 @@ public:
                    HostListsConstSharedPtr healthy_hosts_per_locality,
                    const std::vector<HostSharedPtr>& hosts_added,
                    const std::vector<HostSharedPtr>& hosts_removed) {
-    hosts_ = hosts;
-    healthy_hosts_ = healthy_hosts;
-    hosts_per_locality_ = hosts_per_locality;
-    healthy_hosts_per_locality_ = healthy_hosts_per_locality;
+    hosts_ = std::move(hosts);
+    healthy_hosts_ = std::move(healthy_hosts);
+    hosts_per_locality_ = std::move(hosts_per_locality);
+    healthy_hosts_per_locality_ = std::move(healthy_hosts_per_locality);
     runUpdateCallbacks(hosts_added, hosts_removed);
   }
 


### PR DESCRIPTION
Signed-off-by: James Synge <jamessynge@google.com>