### PR TITLE
Make the total number of stats in shared memory, and the maximum length

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -243,6 +243,15 @@ bazel build --copt=-DNVLOG //source/exe:envoy-static
 Hot restart can be disabled in any build by specifying `--define=hot_restart=disabled`
 on the Bazel command line.
 
+## Stats Tunables
+
+The default maximum number of stats in shared memory, and the default maximum length of a stat name,
+can be overriden at compile-time by defining `ENVOY_DEFAULT_MAX_STATS` and `ENVOY_DEFAULT_MAX_STAT_NAME_LENGTH`,
+respectively, to the desired value.  For example:
+```
+bazel build --copts=-DENVOY_DEFAULT_MAX_STATS=32768 //source/exe:envoy-static
+```
+
 
 # Release builds
 

--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -120,6 +120,16 @@ public:
    * @return const std::string& the server's zone.
    */
   virtual const std::string& serviceZone() PURE;
+
+  /**
+   * @return uint64_t the maximum number of stats gauges and counters.
+   */
+  virtual uint64_t maxStats() PURE;
+
+  /**
+   * @return uint64_t the maximum name length of a stat.
+   */
+  virtual uint64_t maxStatNameLength() PURE;
 };
 
 } // namespace Server

--- a/source/common/dynamo/dynamo_utility.cc
+++ b/source/common/dynamo/dynamo_utility.cc
@@ -19,7 +19,7 @@ std::string Utility::buildPartitionStatString(const std::string& stat_prefix,
                   partition_id.substr(partition_id.size() - 7, partition_id.size()));
 
   // Calculate how many characters are available for the table prefix.
-  size_t remaining_size = Stats::RawStatData::MAX_NAME_SIZE - stats_partition_postfix.size();
+  size_t remaining_size = Stats::RawStatData::maxNameLength() - stats_partition_postfix.size();
 
   std::string stats_table_prefix = fmt::format("{}table.{}", stat_prefix, table_name);
   // Truncate the table prefix if the current string is too large.

--- a/source/common/stats/BUILD
+++ b/source/common/stats/BUILD
@@ -14,6 +14,7 @@ envoy_cc_library(
     hdrs = ["stats_impl.h"],
     deps = [
         "//include/envoy/common:time_interface",
+        "//include/envoy/server:options_interface",
         "//include/envoy/stats:stats_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:utility_lib",

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -63,7 +63,9 @@ struct RawStatData {
    * Returns the maximum length of the name of a stat.  This length
    * does not include a trailing NULL-terminator.
    */
-  static size_t maxNameLength() { return getMaxNameLength(DEFAULT_MAX_NAME_SIZE); }
+  static size_t maxNameLength() {
+    return initializeAndGetMutableMaxNameLength(DEFAULT_MAX_NAME_SIZE);
+  }
 
   /**
    * size in bytes of name_
@@ -102,7 +104,7 @@ struct RawStatData {
 private:
   static const size_t DEFAULT_MAX_NAME_SIZE = 127;
 
-  static size_t& getMaxNameLength(size_t configured_size);
+  static size_t& initializeAndGetMutableMaxNameLength(size_t configured_size);
 };
 
 /**

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -10,6 +10,7 @@
 #include <unordered_map>
 
 #include "envoy/common/time.h"
+#include "envoy/server/options.h"
 #include "envoy/stats/stats.h"
 
 #include "common/common/assert.h"
@@ -20,17 +21,65 @@ namespace Stats {
 /**
  * This structure is the backing memory for both CounterImpl and GaugeImpl. It is designed so that
  * it can be allocated from shared memory if needed.
+ *
+ * @note Due to name_ being variable size, sizeof(RawStatData) probably isn't useful.  Use
+ * RawStatData::size() instead.
  */
 struct RawStatData {
   struct Flags {
     static const uint8_t Used = 0x1;
   };
 
-  static const size_t MAX_NAME_SIZE = 127;
+  /**
+   * Due to the flexible-array-length of name_, c-style allocation
+   * and initialization are neccessary.
+   */
+  RawStatData() = delete;
+  ~RawStatData() = delete;
 
-  RawStatData() { memset(name_, 0, sizeof(name_)); }
+  /**
+   * Configure static settings.  This MUST be called
+   * before any other static or instance methods.
+   */
+  static void configure(Server::Options& options);
+
+  /**
+   * Allow tests to re-configure this value after it has been set.
+   * This is unsafe in a non-test context.
+   */
+  static void configureForTestsOnly(Server::Options& options);
+
+  /**
+   * Returns the maximum length of the name of a stat.  This length
+   * does not include a trailing NULL-terminator.
+   */
+  static size_t maxNameLength() { return getMaxNameLength(DEFAULT_MAX_NAME_SIZE); }
+
+  /**
+   * size in bytes of name_
+   */
+  static size_t nameSize() { return maxNameLength() + 1; }
+
+  /**
+   * Returns the size of this struct, accounting for the length of name_
+   * and padding for alignment.
+   */
+  static size_t size();
+
+  /**
+   * Initializes this object to have the specified name,
+   * a refcount of 1, and all other values zero.
+   */
   void initialize(const std::string& name);
+
+  /**
+   * Returns true if object is in use.
+   */
   bool initialized() { return name_[0] != '\0'; }
+
+  /**
+   * Returns true if this matches name, truncated to maxNameLength().
+   */
   bool matches(const std::string& name);
 
   std::atomic<uint64_t> value_;
@@ -38,7 +87,12 @@ struct RawStatData {
   std::atomic<uint16_t> flags_;
   std::atomic<uint16_t> ref_count_;
   std::atomic<uint32_t> unused_;
-  char name_[MAX_NAME_SIZE + 1];
+  char name_[];
+
+private:
+  static const size_t DEFAULT_MAX_NAME_SIZE = 127;
+
+  static size_t& getMaxNameLength(size_t configured_size);
 };
 
 /**

--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -32,12 +32,17 @@ int main(int argc, char** argv) {
 
 #ifdef ENVOY_HOT_RESTART
   // Enabled by default, except on OS X. Control with "bazel --define=hot_restart=disabled"
-  const std::string shared_mem_version = Envoy::Server::SharedMemory::version();
+  const Envoy::OptionsImpl::HotRestartVersionCB hot_restart_version_cb =
+      [](uint64_t max_num_stats, uint64_t max_stat_name_len) {
+        return Envoy::Server::SharedMemory::version(max_num_stats, max_stat_name_len);
+      };
 #else
-  const std::string shared_mem_version = "disabled";
+  const Envoy::OptionsImpl::HotRestartVersionCB hot_restart_version_cb = [](uint64_t, uint64_t) {
+    return "disabled";
+  };
 #endif
 
-  Envoy::OptionsImpl options(argc, argv, shared_mem_version, spdlog::level::warn);
+  Envoy::OptionsImpl options(argc, argv, hot_restart_version_cb, spdlog::level::warn);
 
   return Envoy::main_common(options);
 }

--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -32,7 +32,7 @@ int main(int argc, char** argv) {
 
 #ifdef ENVOY_HOT_RESTART
   // Enabled by default, except on OS X. Control with "bazel --define=hot_restart=disabled"
-  const Envoy::OptionsImpl::HotRestartVersionCB hot_restart_version_cb =
+  const Envoy::OptionsImpl::HotRestartVersionCb hot_restart_version_cb =
       [](uint64_t max_num_stats, uint64_t max_stat_name_len) {
         return Envoy::Server::SharedMemory::version(max_num_stats, max_stat_name_len);
       };

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -40,6 +40,8 @@ public:
 } // namespace Server
 
 int main_common(OptionsImpl& options) {
+  Stats::RawStatData::configure(options);
+
 #ifdef ENVOY_HOT_RESTART
   Api::OsSysCallsImpl os_sys_calls_impl;
   std::unique_ptr<Server::HotRestartImpl> restarter;

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -53,7 +53,7 @@ SharedMemory& SharedMemory::initialize(Options& options, Api::OsSysCalls& os_sys
   SharedMemory* shmem = reinterpret_cast<SharedMemory*>(
       os_sys_calls.mmap(nullptr, total_size, PROT_READ | PROT_WRITE, MAP_SHARED, shmem_fd, 0));
   RELEASE_ASSERT(shmem != MAP_FAILED);
-  RELEASE_ASSERT((reinterpret_cast<uintptr_t>(shmem) % alignof(shmem)) == 0);
+  RELEASE_ASSERT((reinterpret_cast<uintptr_t>(shmem) % alignof(decltype(shmem))) == 0);
 
   if (options.restartEpoch() == 0) {
     shmem->size_ = total_size;

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -12,16 +12,22 @@
 #include "spdlog/spdlog.h"
 #include "tclap/CmdLine.h"
 
+// Can be overridden at compile time
 #ifndef ENVOY_DEFAULT_MAX_STATS
 #define ENVOY_DEFAULT_MAX_STATS 16384
 #endif
 
+// Can be overridden at compile time
 #ifndef ENVOY_DEFAULT_MAX_STAT_NAME_LENGTH
 #define ENVOY_DEFAULT_MAX_STAT_NAME_LENGTH 127
 #endif
 
+#if ENVOY_DEFAULT_MAX_STAT_NAME_LENGTH < 127
+#error "ENVOY_DEFAULT_MAX_STAT_NAME_LENGTH must be >= 127"
+#endif
+
 namespace Envoy {
-OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCB& hot_restart_version_cb,
+OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_restart_version_cb,
                          spdlog::level::level_enum default_log_level) {
   std::string log_levels_string = "Log levels: ";
   for (size_t i = 0; i < ARRAY_SIZE(spdlog::level::level_names); i++) {
@@ -84,6 +90,12 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCB& hot_r
     cmd.parse(argc, argv);
   } catch (TCLAP::ArgException& e) {
     std::cerr << "error: " << e.error() << std::endl;
+    exit(1);
+  }
+
+  if (max_stat_name_len.getValue() < 127) {
+    std::cerr << "error: the 'max-stat-name-len' value specified (" << max_stat_name_len.getValue()
+              << ") is less than the minimum value of 127" << std::endl;
     exit(1);
   }
 

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -14,7 +14,9 @@ namespace Envoy {
  */
 class OptionsImpl : public Server::Options {
 public:
-  OptionsImpl(int argc, char** argv, const std::string& hot_restart_version,
+  typedef std::function<std::string(uint64_t, uint64_t)> HotRestartVersionCB;
+
+  OptionsImpl(int argc, char** argv, const HotRestartVersionCB& hot_restart_version_cb,
               spdlog::level::level_enum default_log_level);
 
   // Server::Options
@@ -33,6 +35,8 @@ public:
   const std::string& serviceClusterName() override { return service_cluster_; }
   const std::string& serviceNodeName() override { return service_node_; }
   const std::string& serviceZone() override { return service_zone_; }
+  uint64_t maxStats() override { return max_stats_; }
+  uint64_t maxStatNameLength() override { return max_stat_name_length_; }
 
 private:
   uint64_t base_id_;
@@ -50,5 +54,7 @@ private:
   std::chrono::seconds drain_time_;
   std::chrono::seconds parent_shutdown_time_;
   Server::Mode mode_;
+  uint64_t max_stats_;
+  uint64_t max_stat_name_length_;
 };
 } // namespace Envoy

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -14,9 +14,9 @@ namespace Envoy {
  */
 class OptionsImpl : public Server::Options {
 public:
-  typedef std::function<std::string(uint64_t, uint64_t)> HotRestartVersionCB;
+  typedef std::function<std::string(uint64_t, uint64_t)> HotRestartVersionCb;
 
-  OptionsImpl(int argc, char** argv, const HotRestartVersionCB& hot_restart_version_cb,
+  OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_restart_version_cb,
               spdlog::level::level_enum default_log_level);
 
   // Server::Options

--- a/test/common/dynamo/dynamo_utility_test.cc
+++ b/test/common/dynamo/dynamo_utility_test.cc
@@ -22,7 +22,7 @@ TEST(DynamoUtility, PartitionIdStatString) {
     std::string expected_stat_string =
         "stat.prefix.table.locations.capacity.GetItem.__partition_id=c5883ca";
     EXPECT_EQ(expected_stat_string, partition_stat_string);
-    EXPECT_TRUE(partition_stat_string.size() <= Stats::RawStatData::MAX_NAME_SIZE);
+    EXPECT_TRUE(partition_stat_string.size() <= Stats::RawStatData::maxNameLength());
   }
 
   {
@@ -37,7 +37,7 @@ TEST(DynamoUtility, PartitionIdStatString) {
                                        "partition-test-iad-mytest-rea.capacity.GetItem.__partition_"
                                        "id=c5883ca";
     EXPECT_EQ(expected_stat_string, partition_stat_string);
-    EXPECT_TRUE(partition_stat_string.size() == Stats::RawStatData::MAX_NAME_SIZE);
+    EXPECT_TRUE(partition_stat_string.size() == Stats::RawStatData::maxNameLength());
   }
   {
     std::string stat_prefix = "http.egress_dynamodb_iad.dynamodb.";
@@ -52,7 +52,7 @@ TEST(DynamoUtility, PartitionIdStatString) {
                                        "id=c5883ca";
 
     EXPECT_EQ(expected_stat_string, partition_stat_string);
-    EXPECT_TRUE(partition_stat_string.size() == Stats::RawStatData::MAX_NAME_SIZE);
+    EXPECT_TRUE(partition_stat_string.size() == Stats::RawStatData::maxNameLength());
   }
 }
 

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -50,6 +50,8 @@ public:
   const std::string& serviceClusterName() override { return service_cluster_name_; }
   const std::string& serviceNodeName() override { return service_node_name_; }
   const std::string& serviceZone() override { return service_zone_; }
+  uint64_t maxStats() override { return 16384; }
+  uint64_t maxStatNameLength() override { return 127; }
 
 private:
   const std::string config_path_;

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -26,7 +26,7 @@ MockOptions::MockOptions(const std::string& config_path)
   ON_CALL(*this, serviceZone()).WillByDefault(ReturnRef(service_zone_name_));
   ON_CALL(*this, logPath()).WillByDefault(ReturnRef(log_path_));
   ON_CALL(*this, maxStats()).WillByDefault(Return(1000));
-  ON_CALL(*this, maxStatNameLength()).WillByDefault(Return(64));
+  ON_CALL(*this, maxStatNameLength()).WillByDefault(Return(150));
 }
 MockOptions::~MockOptions() {}
 

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -25,6 +25,8 @@ MockOptions::MockOptions(const std::string& config_path)
   ON_CALL(*this, serviceNodeName()).WillByDefault(ReturnRef(service_node_name_));
   ON_CALL(*this, serviceZone()).WillByDefault(ReturnRef(service_zone_name_));
   ON_CALL(*this, logPath()).WillByDefault(ReturnRef(log_path_));
+  ON_CALL(*this, maxStats()).WillByDefault(Return(1000));
+  ON_CALL(*this, maxStatNameLength()).WillByDefault(Return(64));
 }
 MockOptions::~MockOptions() {}
 

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -58,6 +58,8 @@ public:
   MOCK_METHOD0(serviceClusterName, const std::string&());
   MOCK_METHOD0(serviceNodeName, const std::string&());
   MOCK_METHOD0(serviceZone, const std::string&());
+  MOCK_METHOD0(maxStats, uint64_t());
+  MOCK_METHOD0(maxStatNameLength, uint64_t());
 
   std::string config_path_;
   std::string admin_address_path_;

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -92,6 +92,13 @@ public:
     setup();
   }
 
+  void TearDown() {
+    // Configure it back so that later tests don't get the wonky values
+    // used here
+    NiceMock<MockOptions> default_options;
+    Stats::RawStatData::configureForTestsOnly(default_options);
+  }
+
   static const uint64_t num_stats_ = 8;
   const uint64_t name_len_;
 };

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -101,7 +101,7 @@ TEST_P(HotRestartImplAlignmentTest, objectAlignment) {
   std::set<Stats::RawStatData*> used;
   for (uint64_t i = 0; i < num_stats_; i++) {
     Stats::RawStatData* stat = hot_restart_->alloc(fmt::format("stat {}", i));
-    EXPECT_TRUE((reinterpret_cast<uintptr_t>(stat) % alignof(*stat)) == 0);
+    EXPECT_TRUE((reinterpret_cast<uintptr_t>(stat) % alignof(decltype(*stat))) == 0);
     EXPECT_TRUE(used.find(stat) == used.end());
     used.insert(stat);
   }

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -14,40 +14,49 @@ using testing::_;
 namespace Envoy {
 namespace Server {
 
-TEST(HotRestartImplTest, alloc) {
-  Api::MockOsSysCalls os_sys_calls;
-  NiceMock<MockOptions> options;
-  std::vector<uint8_t> buffer;
+class HotRestartImplTest : public testing::Test {
+public:
+  void setup() {
+    EXPECT_CALL(os_sys_calls_, shmUnlink(_));
+    EXPECT_CALL(os_sys_calls_, shmOpen(_, _, _));
+    EXPECT_CALL(os_sys_calls_, ftruncate(_, _)).WillOnce(WithArg<1>(Invoke([this](off_t size) {
+      buffer_.resize(size);
+      return 0;
+    })));
+    EXPECT_CALL(os_sys_calls_, mmap(_, _, _, _, _, _)).WillOnce(InvokeWithoutArgs([this]() {
+      return buffer_.data();
+    }));
+    EXPECT_CALL(os_sys_calls_, bind(_, _, _));
 
-  EXPECT_CALL(os_sys_calls, shmUnlink(_));
-  EXPECT_CALL(os_sys_calls, shmOpen(_, _, _));
-  EXPECT_CALL(os_sys_calls, ftruncate(_, _)).WillOnce(WithArg<1>(Invoke([&buffer](off_t size) {
-    buffer.resize(size);
-    return 0;
-  })));
-  EXPECT_CALL(os_sys_calls, mmap(_, _, _, _, _, _)).WillOnce(InvokeWithoutArgs([&buffer]() {
-    return buffer.data();
-  }));
-  EXPECT_CALL(os_sys_calls, bind(_, _, _));
+    // Test we match the correct stat with empty-slots before, after, or both.
+    hot_restart_.reset(new HotRestartImpl(options_, os_sys_calls_));
+    hot_restart_->drainParentListeners();
+  }
 
-  // Test we match the correct stat with empty-slots before, after, or both.
-  HotRestartImpl hot_restart1(options, os_sys_calls);
-  hot_restart1.drainParentListeners();
-  Stats::RawStatData* stat1 = hot_restart1.alloc("stat1");
-  Stats::RawStatData* stat2 = hot_restart1.alloc("stat2");
-  Stats::RawStatData* stat3 = hot_restart1.alloc("stat3");
-  Stats::RawStatData* stat4 = hot_restart1.alloc("stat4");
-  Stats::RawStatData* stat5 = hot_restart1.alloc("stat5");
-  hot_restart1.free(*stat2);
-  hot_restart1.free(*stat4);
+  Api::MockOsSysCalls os_sys_calls_;
+  NiceMock<MockOptions> options_;
+  std::vector<uint8_t> buffer_;
+  std::unique_ptr<HotRestartImpl> hot_restart_;
+};
+
+TEST_F(HotRestartImplTest, crossAlloc) {
+  setup();
+
+  Stats::RawStatData* stat1 = hot_restart_->alloc("stat1");
+  Stats::RawStatData* stat2 = hot_restart_->alloc("stat2");
+  Stats::RawStatData* stat3 = hot_restart_->alloc("stat3");
+  Stats::RawStatData* stat4 = hot_restart_->alloc("stat4");
+  Stats::RawStatData* stat5 = hot_restart_->alloc("stat5");
+  hot_restart_->free(*stat2);
+  hot_restart_->free(*stat4);
   stat2 = nullptr;
   stat4 = nullptr;
 
-  EXPECT_CALL(options, restartEpoch()).WillRepeatedly(Return(1));
-  EXPECT_CALL(os_sys_calls, shmOpen(_, _, _));
-  EXPECT_CALL(os_sys_calls, mmap(_, _, _, _, _, _)).WillOnce(Return(buffer.data()));
-  EXPECT_CALL(os_sys_calls, bind(_, _, _));
-  HotRestartImpl hot_restart2(options, os_sys_calls);
+  EXPECT_CALL(options_, restartEpoch()).WillRepeatedly(Return(1));
+  EXPECT_CALL(os_sys_calls_, shmOpen(_, _, _));
+  EXPECT_CALL(os_sys_calls_, mmap(_, _, _, _, _, _)).WillOnce(Return(buffer_.data()));
+  EXPECT_CALL(os_sys_calls_, bind(_, _, _));
+  HotRestartImpl hot_restart2(options_, os_sys_calls_);
   Stats::RawStatData* stat1_prime = hot_restart2.alloc("stat1");
   Stats::RawStatData* stat3_prime = hot_restart2.alloc("stat3");
   Stats::RawStatData* stat5_prime = hot_restart2.alloc("stat5");
@@ -55,6 +64,109 @@ TEST(HotRestartImplTest, alloc) {
   EXPECT_EQ(stat3, stat3_prime);
   EXPECT_EQ(stat5, stat5_prime);
 }
+
+TEST_F(HotRestartImplTest, allocFail) {
+  EXPECT_CALL(options_, maxStats()).WillRepeatedly(Return(2));
+  setup();
+
+  Stats::RawStatData* s1 = hot_restart_->alloc("1");
+  Stats::RawStatData* s2 = hot_restart_->alloc("2");
+  Stats::RawStatData* s3 = hot_restart_->alloc("3");
+  EXPECT_NE(s1, nullptr);
+  EXPECT_NE(s2, nullptr);
+  EXPECT_EQ(s3, nullptr);
+}
+
+// Because the shared memory is managed manually, make sure it meets
+// basic requirements:
+//   - Objects are correctly aligned so that std::atomic works properly
+//   - Objects don't overlap
+class HotRestartImplAlignmentTest : public HotRestartImplTest,
+                                    public testing::WithParamInterface<uint64_t> {
+public:
+  HotRestartImplAlignmentTest() : name_len_(8 + GetParam()) {
+    EXPECT_CALL(options_, maxStats()).WillRepeatedly(Return(num_stats_));
+    EXPECT_CALL(options_, maxStatNameLength()).WillRepeatedly(Return(name_len_));
+    Stats::RawStatData::configureForTestsOnly(options_);
+    EXPECT_EQ(name_len_, Stats::RawStatData::maxNameLength());
+    setup();
+  }
+
+  static const uint64_t num_stats_ = 8;
+  const uint64_t name_len_;
+};
+
+TEST_P(HotRestartImplAlignmentTest, objectAlignment) {
+
+  std::set<Stats::RawStatData*> used;
+  for (uint64_t i = 0; i < num_stats_; i++) {
+    Stats::RawStatData* stat = hot_restart_->alloc(fmt::format("stat {}", i));
+    EXPECT_TRUE((reinterpret_cast<uintptr_t>(stat) % alignof(*stat)) == 0);
+    EXPECT_TRUE(used.find(stat) == used.end());
+    used.insert(stat);
+  }
+}
+
+TEST_P(HotRestartImplAlignmentTest, objectOverlap) {
+  // Iterate through all stats forwards and backwards, writing to all fields, then read them back to
+  // make sure that writing to an adjacent stat didn't overwrite
+  struct TestStat {
+    Stats::RawStatData* stat_;
+    std::string name_;
+    uint64_t index_;
+  };
+  std::vector<TestStat> stats;
+  for (uint64_t i = 0; i < num_stats_; i++) {
+    std::string name = fmt::format("{}zzzzzzzzzzzzzzzzzzzzzzzzzzzz", i)
+                           .substr(0, Stats::RawStatData::maxNameLength());
+    TestStat ts;
+    ts.stat_ = hot_restart_->alloc(name);
+    ts.name_ = ts.stat_->name_;
+    ts.index_ = i;
+
+    // If this isn't true then the hard coded part of the name isn't long enough to make the test
+    // valid.
+    EXPECT_EQ(ts.name_.size(), Stats::RawStatData::maxNameLength());
+
+    stats.push_back(ts);
+  }
+
+  auto write = [](TestStat& ts) {
+    ts.stat_->value_ = ts.index_;
+    ts.stat_->pending_increment_ = ts.index_;
+    ts.stat_->flags_ = ts.index_;
+    ts.stat_->ref_count_ = ts.index_;
+    ts.stat_->unused_ = ts.index_;
+  };
+
+  auto verify = [](TestStat& ts) {
+    EXPECT_TRUE(ts.stat_->matches(ts.name_));
+    EXPECT_EQ(ts.stat_->value_, ts.index_);
+    EXPECT_EQ(ts.stat_->pending_increment_, ts.index_);
+    EXPECT_EQ(ts.stat_->flags_, ts.index_);
+    EXPECT_EQ(ts.stat_->ref_count_, ts.index_);
+    EXPECT_EQ(ts.stat_->unused_, ts.index_);
+  };
+
+  for (TestStat& ts : stats) {
+    write(ts);
+  }
+
+  for (TestStat& ts : stats) {
+    verify(ts);
+  }
+
+  for (auto it = stats.rbegin(); it != stats.rend(); ++it) {
+    write(*it);
+  }
+
+  for (auto it = stats.rbegin(); it != stats.rend(); ++it) {
+    verify(*it);
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(HotRestartImplAlignmentTest, HotRestartImplAlignmentTest,
+                        testing::Range(0UL, alignof(Stats::RawStatData) + 1));
 
 } // namespace Server
 } // namespace Envoy

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -19,8 +19,9 @@ std::unique_ptr<OptionsImpl> createOptionsImpl(const std::string& args) {
   for (const std::string& s : words) {
     argv.push_back(s.c_str());
   }
-  return std::unique_ptr<OptionsImpl>(
-      new OptionsImpl(argv.size(), const_cast<char**>(&argv[0]), "1", spdlog::level::warn));
+  return std::unique_ptr<OptionsImpl>(new OptionsImpl(argv.size(), const_cast<char**>(&argv[0]),
+                                                      [](uint64_t, uint64_t) { return "1"; },
+                                                      spdlog::level::warn));
 }
 
 TEST(OptionsImplDeathTest, HotRestartVersion) {

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -71,4 +71,9 @@ TEST(OptionsImplTest, BadCliOption) {
   EXPECT_DEATH(createOptionsImpl("envoy -c hello --local-address-ip-version foo"),
                "error: unknown IP address version 'foo'");
 }
+
+TEST(OptionsImplTest, BadStatNameLenOption) {
+  EXPECT_DEATH(createOptionsImpl("envoy --max-stat-name-len 1"),
+               "error: the 'max-stat-name-len' value specified");
+}
 } // namespace Envoy

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -87,7 +87,8 @@ std::vector<Network::Address::IpVersion> TestEnvironment::getIpVersionsForTest()
 }
 
 Server::Options& TestEnvironment::getOptions() {
-  static OptionsImpl* options = new OptionsImpl(argc_, argv_, "1", spdlog::level::err);
+  static OptionsImpl* options =
+      new OptionsImpl(argc_, argv_, [](uint64_t, uint64_t) { return "1"; }, spdlog::level::err);
   return *options;
 }
 


### PR DESCRIPTION
of a stat name, configurable at compile-time and run-time.

fixes #1761

Signed-off-by: Greg Greenway <ggreenway@apple.com>