### PR TITLE
Logging: Fix 'error' log-level.

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -172,7 +172,7 @@ protected:
 
 #define ENVOY_LOG_info_TO_LOGGER(LOGGER, ...) LOGGER.info(LOG_PREFIX __VA_ARGS__)
 #define ENVOY_LOG_warn_TO_LOGGER(LOGGER, ...) LOGGER.warn(LOG_PREFIX __VA_ARGS__)
-#define ENVOY_LOG_err_TO_LOGGER(LOGGER, ...) LOGGER.err(LOG_PREFIX __VA_ARGS__)
+#define ENVOY_LOG_error_TO_LOGGER(LOGGER, ...) LOGGER.error(LOG_PREFIX __VA_ARGS__)
 #define ENVOY_LOG_critical_TO_LOGGER(LOGGER, ...) LOGGER.critical(LOG_PREFIX __VA_ARGS__)
 
 /**

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -16,6 +16,9 @@ public:
   void logMessage() {
     ENVOY_LOG(trace, "fake message");
     ENVOY_LOG(debug, "fake message");
+    ENVOY_LOG(warn, "fake message");
+    ENVOY_LOG(error, "fake message");
+    ENVOY_LOG(critical, "fake message");
     ENVOY_CONN_LOG(info, "fake message", connection_);
     ENVOY_STREAM_LOG(info, "fake message", stream_);
   }


### PR DESCRIPTION
There is no 'err' log-level, however there are no uses of err/error
in the codebase so it went unnoticed.

Signed-off-by: Greg Greenway <ggreenway@apple.com>