### PR TITLE
upstream: switch dropped stats accounting from host to cluster.

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -112,7 +112,7 @@ def envoy_api_deps(skip_targets):
     native.git_repository(
         name = "envoy_api",
         remote = REPO_LOCATIONS["envoy_api"],
-        commit = "daec5667480396201b3593593da1a38471a1ff11",
+        commit = "67ceb6429aca38aecd722494baa0e499dadd3caf",
     )
     api_bind_targets = [
         "address",

--- a/docs/operations/admin.rst
+++ b/docs/operations/admin.rst
@@ -40,6 +40,8 @@ modify different aspects of the server.
       cx_connect_fail, Counter, Total connection failures
       rq_total, Counter, Total requests
       rq_timeout, Counter, Total timed out requests
+      rq_success, Counter, Total requests with non-5xx responses
+      rq_error, Counter, Total requests with 5xx responses
       rq_active, Gauge, Total active requests
       healthy, String, The health status of the host. See below
       weight, Integer, Load balancing weight (1-100)

--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -16,8 +16,8 @@ namespace Upstream {
 /**
  * All per host stats. @see stats_macros.h
  *
- * {rq_success, rq_error, rq_dropped} have specific semantics driven by the needs of EDS load
- * reporting. See envoy.api.v2.UpstreamLocalityStats for the definitions of success/error/dropped.
+ * {rq_success, rq_error} have specific semantics driven by the needs of EDS load reporting. See
+ * envoy.api.v2.UpstreamLocalityStats for the definitions of success/error.
  */
 // clang-format off
 #define ALL_HOST_STATS(COUNTER, GAUGE)                                                             \
@@ -28,7 +28,6 @@ namespace Upstream {
   COUNTER(rq_timeout)                                                                              \
   COUNTER(rq_success)                                                                              \
   COUNTER(rq_error)                                                                                \
-  COUNTER(rq_dropped)                                                                              \
   GAUGE  (rq_active)
 // clang-format on
 

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -237,7 +237,15 @@ public:
   COUNTER  (update_failure)                                                                        \
   COUNTER  (update_empty)                                                                          \
   GAUGE    (version)
+// clang-format on
 
+/**
+ * All cluster load report stats. These are only use for EDS load reporting and not sent to the
+ * stats sink. See envoy.api.v2.ClusterStats for the definition of upstream_rq_dropped.
+ */
+// clang-format off
+#define ALL_CLUSTER_LOAD_REPORT_STATS(COUNTER)                                                     \
+  COUNTER (upstream_rq_dropped)
 // clang-format on
 
 /**
@@ -245,6 +253,13 @@ public:
  */
 struct ClusterStats {
   ALL_CLUSTER_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT)
+};
+
+/**
+ * Struct definition for all cluster load report stats. @see stats_macros.h
+ */
+struct ClusterLoadReportStats {
+  ALL_CLUSTER_LOAD_REPORT_STATS(GENERATE_COUNTER_STRUCT)
 };
 
 /**
@@ -332,6 +347,11 @@ public:
    *         stats that will be freed when the cluster is removed.
    */
   virtual Stats::Scope& statsScope() const PURE;
+
+  /**
+   * @return ClusterLoadReportStats& strongly named load report stats for this cluster.
+   */
+  virtual ClusterLoadReportStats& loadReportStats() const PURE;
 
   /**
    * Returns an optional source address for upstream connections to bind to.

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -156,12 +156,11 @@ void Filter::chargeUpstreamCode(uint64_t response_status_code,
       Http::CodeUtility::chargeResponseStat(info);
     }
 
-    if (upstream_host) {
-      if (dropped) {
-        upstream_host->stats().rq_dropped_.inc();
-      } else if (Http::CodeUtility::is5xx(response_status_code)) {
-        upstream_host->stats().rq_error_.inc();
-      }
+    if (dropped) {
+      cluster_->loadReportStats().upstream_rq_dropped_.inc();
+    }
+    if (upstream_host && Http::CodeUtility::is5xx(response_status_code)) {
+      upstream_host->stats().rq_error_.inc();
     }
   }
 }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -70,6 +70,10 @@ ClusterStats ClusterInfoImpl::generateStats(Stats::Scope& scope) {
   return {ALL_CLUSTER_STATS(POOL_COUNTER(scope), POOL_GAUGE(scope), POOL_HISTOGRAM(scope))};
 }
 
+ClusterLoadReportStats ClusterInfoImpl::generateLoadReportStats(Stats::Scope& scope) {
+  return {ALL_CLUSTER_LOAD_REPORT_STATS(POOL_COUNTER(scope))};
+}
+
 ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
                                  const Network::Address::InstanceConstSharedPtr source_address,
                                  Runtime::Loader& runtime, Stats::Store& stats,
@@ -82,7 +86,9 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
       per_connection_buffer_limit_bytes_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, per_connection_buffer_limit_bytes, 1024 * 1024)),
       stats_scope_(stats.createScope(fmt::format("cluster.{}.", name_))),
-      stats_(generateStats(*stats_scope_)), features_(parseFeatures(config)),
+      stats_(generateStats(*stats_scope_)),
+      load_report_stats_(generateLoadReportStats(load_report_stats_store_)),
+      features_(parseFeatures(config)),
       http2_settings_(Http::Utility::parseHttp2Settings(config.http2_protocol_options())),
       resource_managers_(config, runtime, name_),
       maintenance_mode_runtime_key_(fmt::format("upstream.maintenance_mode.{}", name_)),

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -231,6 +231,7 @@ public:
                   Ssl::ContextManager& ssl_context_manager, bool added_via_api);
 
   static ClusterStats generateStats(Stats::Scope& scope);
+  static ClusterLoadReportStats generateLoadReportStats(Stats::Scope& scope);
 
   // Upstream::ClusterInfo
   bool addedViaApi() const override { return added_via_api_; }
@@ -248,6 +249,7 @@ public:
   Ssl::ClientContext* sslContext() const override { return ssl_ctx_.get(); }
   ClusterStats& stats() const override { return stats_; }
   Stats::Scope& statsScope() const override { return *stats_scope_; }
+  ClusterLoadReportStats& loadReportStats() const override { return load_report_stats_; }
   const Network::Address::InstanceConstSharedPtr& sourceAddress() const override {
     return source_address_;
   };
@@ -274,6 +276,8 @@ private:
   const uint32_t per_connection_buffer_limit_bytes_;
   Stats::ScopePtr stats_scope_;
   mutable ClusterStats stats_;
+  Stats::IsolatedStoreImpl load_report_stats_store_;
+  mutable ClusterLoadReportStats load_report_stats_;
   Ssl::ClientContextPtr ssl_ctx_;
   const uint64_t features_;
   const Http::Http2Settings http2_settings_;

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -38,6 +38,7 @@ public:
   MOCK_CONST_METHOD0(sslContext, Ssl::ClientContext*());
   MOCK_CONST_METHOD0(stats, ClusterStats&());
   MOCK_CONST_METHOD0(statsScope, Stats::Scope&());
+  MOCK_CONST_METHOD0(loadReportStats, ClusterLoadReportStats&());
   MOCK_CONST_METHOD0(sourceAddress, const Network::Address::InstanceConstSharedPtr&());
 
   std::string name_{"fake_cluster"};
@@ -45,6 +46,8 @@ public:
   uint64_t max_requests_per_connection_{};
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
   ClusterStats stats_;
+  NiceMock<Stats::MockIsolatedStatsStore> load_report_stats_store_;
+  ClusterLoadReportStats load_report_stats_;
   NiceMock<Runtime::MockLoader> runtime_;
   std::unique_ptr<Upstream::ResourceManager> resource_manager_;
   Network::Address::InstanceConstSharedPtr source_address_;

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -63,6 +63,7 @@ MockHost::~MockHost() {}
 
 MockClusterInfo::MockClusterInfo()
     : stats_(ClusterInfoImpl::generateStats(stats_store_)),
+      load_report_stats_(ClusterInfoImpl::generateLoadReportStats(load_report_stats_store_)),
       resource_manager_(new Upstream::ResourceManagerImpl(runtime_, "fake_key", 1, 1024, 1024, 1)) {
 
   ON_CALL(*this, connectTimeout()).WillByDefault(Return(std::chrono::milliseconds(1)));
@@ -72,6 +73,7 @@ MockClusterInfo::MockClusterInfo()
       .WillByDefault(ReturnPointee(&max_requests_per_connection_));
   ON_CALL(*this, stats()).WillByDefault(ReturnRef(stats_));
   ON_CALL(*this, statsScope()).WillByDefault(ReturnRef(stats_store_));
+  ON_CALL(*this, loadReportStats()).WillByDefault(ReturnRef(load_report_stats_));
   ON_CALL(*this, sourceAddress()).WillByDefault(ReturnRef(source_address_));
   ON_CALL(*this, resourceManager(_))
       .WillByDefault(Invoke(


### PR DESCRIPTION
It makes no sense to attribute dropped requests to the host (or locality), since the drop decision is
made at the cluster level, prior to host picking. Instead, introduced a parallel concept of cluster
stats, load report stats, that don't get sent to sinks and can be latched independently of the stats
flush period.

As a bonus, bumped data-plane-api SHA to bring in corresponding EDS load report proto changes.

Signed-off-by: Harvey Tuch <htuch@google.com>