### PR TITLE
upstream: EDS load reporter.

### DIFF
--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -17,7 +17,8 @@ namespace Upstream {
  * All per host stats. @see stats_macros.h
  *
  * {rq_success, rq_error} have specific semantics driven by the needs of EDS load reporting. See
- * envoy.api.v2.UpstreamLocalityStats for the definitions of success/error.
+ * envoy.api.v2.UpstreamLocalityStats for the definitions of success/error. These are latched by
+ * LoadStatsReporter, independent of the normal stats sink flushing.
  */
 // clang-format off
 #define ALL_HOST_STATS(COUNTER, GAUGE)                                                             \

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -241,7 +241,8 @@ public:
 
 /**
  * All cluster load report stats. These are only use for EDS load reporting and not sent to the
- * stats sink. See envoy.api.v2.ClusterStats for the definition of upstream_rq_dropped.
+ * stats sink. See envoy.api.v2.ClusterStats for the definition of upstream_rq_dropped. These are
+ * latched by LoadStatsReporter, independent of the normal stats sink flushing.
  */
 // clang-format off
 #define ALL_CLUSTER_LOAD_REPORT_STATS(COUNTER)                                                     \

--- a/source/common/config/grpc_mux_subscription_impl.h
+++ b/source/common/config/grpc_mux_subscription_impl.h
@@ -56,13 +56,8 @@ public:
     stats_.update_attempt_.inc();
     version_info_ = version_info;
     stats_.version_.set(HashUtil::xxHash64(version_info_));
-    ENVOY_LOG(debug, "gRPC config for {} accepted with {} resources", type_url_, resources.size());
-
-#ifndef NVLOG
-    for (const auto resource : typed_resources) {
-      ENVOY_LOG(debug, "- {}", resource.DebugString());
-    }
-#endif
+    ENVOY_LOG(debug, "gRPC config for {} accepted with {} resources: {}", type_url_,
+              resources.size(), RepeatedPtrUtil::debugString(typed_resources));
   }
 
   void onConfigUpdateFailed(const EnvoyException* e) override {

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -46,6 +46,18 @@ public:
                           const std::string& delimiter) {
     return StringUtil::join(std::vector<std::string>(source.begin(), source.end()), delimiter);
   }
+
+  template <class ProtoType>
+  static std::string debugString(const Protobuf::RepeatedPtrField<ProtoType>& source) {
+    if (source.empty()) {
+      return "[]";
+    }
+    return std::accumulate(std::next(source.begin()), source.end(), "[" + source[0].DebugString(),
+                           [](std::string debug_string, const Protobuf::Message& message) {
+                             return debug_string + ", " + message.DebugString();
+                           }) +
+           "]";
+  }
 };
 
 class MessageUtil {

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <numeric>
+
 #include "envoy/common/exception.h"
 #include "envoy/json/json_object.h"
 

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -53,6 +53,7 @@ envoy_cc_library(
     deps = [
         ":cds_api_lib",
         ":load_balancer_lib",
+        ":load_stats_reporter_lib",
         ":ring_hash_lb_lib",
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/http:codes_interface",
@@ -126,6 +127,20 @@ envoy_cc_library(
         "//include/envoy/upstream:load_balancer_interface",
         "//include/envoy/upstream:upstream_interface",
         "//source/common/common:assert_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "load_stats_reporter_lib",
+    srcs = ["load_stats_reporter.cc"],
+    hdrs = ["load_stats_reporter.h"],
+    external_deps = ["envoy_eds"],
+    deps = [
+        "//include/envoy/event:dispatcher_interface",
+        "//include/envoy/stats:stats_macros",
+        "//include/envoy/upstream:cluster_manager_interface",
+        "//source/common/common:logger_lib",
+        "//source/common/grpc:async_client_lib",
     ],
 )
 

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -237,6 +237,17 @@ ClusterManagerImpl::ClusterManagerImpl(const envoy::api::v2::Bootstrap& bootstra
 
   init_helper_.onStaticLoadComplete();
   ads_mux_->start();
+
+  if (cm_config.has_load_stats_config()) {
+    const auto& load_stats_config = cm_config.load_stats_config();
+    if (load_stats_config.cluster_name().size() != 1) {
+      // TODO(htuch): Add support for multiple clusters, #1170.
+      throw EnvoyException(
+          "envoy::api::v2::ApiConfigSource must have a singleton cluster name specified");
+    }
+    load_stats_reporter_.reset(new LoadStatsReporter(
+        bootstrap.node(), *this, stats, load_stats_config.cluster_name()[0], primary_dispatcher));
+  }
 }
 
 ClusterManagerStats ClusterManagerImpl::generateStats(Stats::Scope& scope) {

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -18,6 +18,7 @@
 
 #include "common/config/grpc_mux_impl.h"
 #include "common/http/async_client_impl.h"
+#include "common/upstream/load_stats_reporter.h"
 #include "common/upstream/upstream_impl.h"
 
 #include "api/bootstrap.pb.h"
@@ -248,6 +249,7 @@ private:
   ClusterManagerStats cm_stats_;
   ClusterManagerInitHelper init_helper_;
   Config::GrpcMuxPtr ads_mux_;
+  LoadStatsReporterPtr load_stats_reporter_;
 };
 
 } // namespace Upstream

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -76,6 +76,7 @@ void EdsClusterImpl::onConfigUpdate(const ResourceVector& resources) {
 
     // If local locality is not defined then skip populating per locality hosts.
     const Locality local_locality(local_info_.node().locality());
+    ENVOY_LOG(trace, "Local locality: {}", local_info_.node().locality().DebugString());
     if (!local_locality.empty()) {
       std::map<Locality, std::vector<HostSharedPtr>> hosts_per_locality;
 

--- a/source/common/upstream/load_stats_reporter.cc
+++ b/source/common/upstream/load_stats_reporter.cc
@@ -1,0 +1,137 @@
+#include "common/upstream/load_stats_reporter.h"
+
+#include "common/protobuf/protobuf.h"
+
+namespace Envoy {
+namespace Upstream {
+
+LoadStatsReporter::LoadStatsReporter(const envoy::api::v2::Node& node,
+                                     ClusterManager& cluster_manager, Stats::Scope& scope,
+                                     LoadStatsAsyncClientPtr async_client,
+                                     Event::Dispatcher& dispatcher)
+    : cm_(cluster_manager), stats_{ALL_LOAD_REPORTER_STATS(
+                                POOL_COUNTER_PREFIX(scope, "load_reporter."))},
+      async_client_(std::move(async_client)),
+      service_method_(*Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
+          "envoy.api.v2.EndpointDiscoveryService.StreamLoadStats")) {
+  request_.mutable_node()->MergeFrom(node);
+  retry_timer_ = dispatcher.createTimer([this]() -> void { establishNewStream(); });
+  response_timer_ = dispatcher.createTimer([this]() -> void { sendLoadStatsRequest(); });
+  establishNewStream();
+}
+
+LoadStatsReporter::LoadStatsReporter(const envoy::api::v2::Node& node,
+                                     ClusterManager& cluster_manager, Stats::Scope& scope,
+                                     const std::string& remote_cluster_name,
+                                     Event::Dispatcher& dispatcher)
+    : LoadStatsReporter(
+          node, cluster_manager, scope,
+          LoadStatsAsyncClientPtr(new Grpc::AsyncClientImpl<envoy::api::v2::LoadStatsRequest,
+                                                            envoy::api::v2::LoadStatsResponse>(
+              cluster_manager, remote_cluster_name)),
+          dispatcher) {}
+
+void LoadStatsReporter::setRetryTimer() {
+  retry_timer_->enableTimer(std::chrono::milliseconds(RETRY_DELAY_MS));
+}
+
+void LoadStatsReporter::establishNewStream() {
+  ENVOY_LOG(debug, "Establishing new gRPC bidi stream for {}", service_method_.DebugString());
+  stream_ = async_client_->start(service_method_, *this);
+  if (stream_ == nullptr) {
+    ENVOY_LOG(warn, "Unable to establish new stream");
+    handleFailure();
+    return;
+  }
+
+  request_.mutable_cluster_stats()->Clear();
+  sendLoadStatsRequest();
+}
+
+void LoadStatsReporter::sendLoadStatsRequest() {
+  request_.mutable_cluster_stats()->Clear();
+  for (const std::string& cluster_name : clusters_) {
+    auto it = cm_.clusters().find(cluster_name);
+    if (it == cm_.clusters().end()) {
+      ENVOY_LOG(debug, "Cluster {} does not exist", cluster_name);
+      continue;
+    }
+    auto& cluster = it->second.get();
+    auto* cluster_stats = request_.add_cluster_stats();
+    cluster_stats->set_cluster_name(cluster_name);
+    for (auto& hosts : cluster.hostsPerLocality()) {
+      auto* locality_stats = cluster_stats->add_upstream_locality_stats();
+      ASSERT(hosts.size() > 0);
+      locality_stats->mutable_locality()->MergeFrom(hosts[0]->locality());
+      uint64_t rq_success = 0;
+      uint64_t rq_error = 0;
+      uint64_t rq_active = 0;
+      for (auto host : hosts) {
+        rq_success += host->stats().rq_success_.latch();
+        rq_error += host->stats().rq_error_.latch();
+        rq_active += host->stats().rq_active_.value();
+      }
+      locality_stats->set_total_successful_requests(rq_success);
+      locality_stats->set_total_error_requests(rq_error);
+      locality_stats->set_total_requests_in_progress(rq_active);
+    }
+    cluster_stats->set_total_dropped_requests(
+        cluster.info()->loadReportStats().upstream_rq_dropped_.latch());
+  }
+
+  ENVOY_LOG(trace, "Sending LoadStatsRequest: {}", request_.DebugString());
+  stream_->sendMessage(request_, false);
+  stats_.responses_.inc();
+}
+
+void LoadStatsReporter::handleFailure() {
+  ENVOY_LOG(warn, "Load reporter stats stream/connection failure, will retry in {} ms.",
+            RETRY_DELAY_MS);
+  stats_.errors_.inc();
+  setRetryTimer();
+}
+
+void LoadStatsReporter::onCreateInitialMetadata(Http::HeaderMap& metadata) {
+  UNREFERENCED_PARAMETER(metadata);
+}
+
+void LoadStatsReporter::onReceiveInitialMetadata(Http::HeaderMapPtr&& metadata) {
+  UNREFERENCED_PARAMETER(metadata);
+}
+
+void LoadStatsReporter::onReceiveMessage(
+    std::unique_ptr<envoy::api::v2::LoadStatsResponse>&& message) {
+  ENVOY_LOG(debug, "New load report epoch: {}", message->DebugString());
+  clusters_.clear();
+  // Reset stats for all hosts in clusters we are tracking.
+  for (const std::string& cluster_name : message->clusters()) {
+    clusters_.emplace_back(cluster_name);
+    auto it = cm_.clusters().find(cluster_name);
+    if (it == cm_.clusters().end()) {
+      continue;
+    }
+    auto& cluster = it->second.get();
+    for (auto host : cluster.hosts()) {
+      host->stats().rq_success_.latch();
+      host->stats().rq_error_.latch();
+    }
+    cluster.info()->loadReportStats().upstream_rq_dropped_.latch();
+  }
+  stats_.requests_.inc();
+  response_timer_->enableTimer(std::chrono::milliseconds(
+      Protobuf::util::TimeUtil::DurationToMilliseconds(message->load_reporting_interval())));
+}
+
+void LoadStatsReporter::onReceiveTrailingMetadata(Http::HeaderMapPtr&& metadata) {
+  UNREFERENCED_PARAMETER(metadata);
+}
+
+void LoadStatsReporter::onRemoteClose(Grpc::Status::GrpcStatus status, const std::string& message) {
+  ENVOY_LOG(warn, "gRPC config stream closed: {}, {}", status, message);
+  response_timer_->disableTimer();
+  stream_ = nullptr;
+  handleFailure();
+}
+
+} // namespace Upstream
+} // namespace Envoy

--- a/source/common/upstream/load_stats_reporter.cc
+++ b/source/common/upstream/load_stats_reporter.cc
@@ -51,8 +51,9 @@ void LoadStatsReporter::establishNewStream() {
 void LoadStatsReporter::sendLoadStatsRequest() {
   request_.mutable_cluster_stats()->Clear();
   for (const std::string& cluster_name : clusters_) {
-    auto it = cm_.clusters().find(cluster_name);
-    if (it == cm_.clusters().end()) {
+    auto cluster_info_map = cm_.clusters();
+    auto it = cluster_info_map.find(cluster_name);
+    if (it == cluster_info_map.end()) {
       ENVOY_LOG(debug, "Cluster {} does not exist", cluster_name);
       continue;
     }
@@ -106,8 +107,9 @@ void LoadStatsReporter::onReceiveMessage(
   // Reset stats for all hosts in clusters we are tracking.
   for (const std::string& cluster_name : message->clusters()) {
     clusters_.emplace_back(cluster_name);
-    auto it = cm_.clusters().find(cluster_name);
-    if (it == cm_.clusters().end()) {
+    auto cluster_info_map = cm_.clusters();
+    auto it = cluster_info_map.find(cluster_name);
+    if (it == cluster_info_map.end()) {
       continue;
     }
     auto& cluster = it->second.get();

--- a/source/common/upstream/load_stats_reporter.h
+++ b/source/common/upstream/load_stats_reporter.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "envoy/event/dispatcher.h"
+#include "envoy/stats/stats_macros.h"
+#include "envoy/upstream/cluster_manager.h"
+
+#include "common/common/logger.h"
+#include "common/grpc/async_client_impl.h"
+
+#include "api/eds.pb.h"
+
+namespace Envoy {
+namespace Upstream {
+
+/**
+ * All load reporter stats. @see stats_macros.h
+ */
+// clang-format off
+#define ALL_LOAD_REPORTER_STATS(COUNTER)                                                           \
+  COUNTER(requests)                                                                                \
+  COUNTER(responses)                                                                               \
+  COUNTER(errors)
+// clang-format on
+
+/**
+ * Struct definition for all load reporter stats. @see stats_macros.h
+ */
+struct LoadReporterStats {
+  ALL_LOAD_REPORTER_STATS(GENERATE_COUNTER_STRUCT)
+};
+
+typedef Grpc::AsyncClient<envoy::api::v2::LoadStatsRequest, envoy::api::v2::LoadStatsResponse>
+    LoadStatsAsyncClient;
+typedef std::unique_ptr<LoadStatsAsyncClient> LoadStatsAsyncClientPtr;
+
+class LoadStatsReporter : Grpc::AsyncStreamCallbacks<envoy::api::v2::LoadStatsResponse>,
+                          Logger::Loggable<Logger::Id::upstream> {
+public:
+  LoadStatsReporter(const envoy::api::v2::Node& node, ClusterManager& cluster_manager,
+                    Stats::Scope& scope, LoadStatsAsyncClientPtr async_client,
+                    Event::Dispatcher& dispatcher);
+  LoadStatsReporter(const envoy::api::v2::Node& node, ClusterManager& cluster_manager,
+                    Stats::Scope& scope, const std::string& remote_cluster_name,
+                    Event::Dispatcher& dispatcher);
+
+  // Grpc::AsyncStreamCallbacks
+  void onCreateInitialMetadata(Http::HeaderMap& metadata) override;
+  void onReceiveInitialMetadata(Http::HeaderMapPtr&& metadata) override;
+  void onReceiveMessage(std::unique_ptr<envoy::api::v2::LoadStatsResponse>&& message) override;
+  void onReceiveTrailingMetadata(Http::HeaderMapPtr&& metadata) override;
+  void onRemoteClose(Grpc::Status::GrpcStatus status, const std::string& message) override;
+
+  // TODO(htuch): Make this configurable or some static.
+  const uint32_t RETRY_DELAY_MS = 5000;
+
+private:
+  void setRetryTimer();
+  void establishNewStream();
+  void sendLoadStatsRequest();
+  void handleFailure();
+
+  ClusterManager& cm_;
+  LoadReporterStats stats_;
+  LoadStatsAsyncClientPtr async_client_;
+  Grpc::AsyncStream<envoy::api::v2::LoadStatsRequest>* stream_{};
+  const Protobuf::MethodDescriptor& service_method_;
+  Event::TimerPtr retry_timer_;
+  Event::TimerPtr response_timer_;
+  envoy::api::v2::LoadStatsRequest request_;
+  std::vector<std::string> clusters_;
+};
+
+typedef std::unique_ptr<LoadStatsReporter> LoadStatsReporterPtr;
+
+} // namespace Upstream
+} // namespace Envoy

--- a/test/common/config/filesystem_subscription_test_harness.h
+++ b/test/common/config/filesystem_subscription_test_harness.h
@@ -57,8 +57,8 @@ public:
     UNREFERENCED_PARAMETER(version);
   }
 
-  void deliverConfigUpdate(const std::vector<std::string> cluster_names, const std::string& version,
-                           bool accept) override {
+  void deliverConfigUpdate(const std::vector<std::string>& cluster_names,
+                           const std::string& version, bool accept) override {
     std::string file_json = "{\"versionInfo\":\"" + version + "\",\"resources\":[";
     for (const auto& cluster : cluster_names) {
       file_json += "{\"@type\":\"type.googleapis.com/"

--- a/test/common/config/grpc_subscription_test_harness.h
+++ b/test/common/config/grpc_subscription_test_harness.h
@@ -74,8 +74,8 @@ public:
     subscription_->grpcMux().onCreateInitialMetadata(request_headers);
   }
 
-  void deliverConfigUpdate(const std::vector<std::string> cluster_names, const std::string& version,
-                           bool accept) override {
+  void deliverConfigUpdate(const std::vector<std::string>& cluster_names,
+                           const std::string& version, bool accept) override {
     std::unique_ptr<envoy::api::v2::DiscoveryResponse> response(
         new envoy::api::v2::DiscoveryResponse());
     response->set_version_info(version);

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -92,8 +92,8 @@ public:
     timer_cb_();
   }
 
-  void deliverConfigUpdate(const std::vector<std::string> cluster_names, const std::string& version,
-                           bool accept) override {
+  void deliverConfigUpdate(const std::vector<std::string>& cluster_names,
+                           const std::string& version, bool accept) override {
     std::string response_json = "{\"version_info\":\"" + version + "\",\"resources\":[";
     for (const auto& cluster : cluster_names) {
       response_json += "{\"@type\":\"type.googleapis.com/"

--- a/test/common/config/subscription_test_harness.h
+++ b/test/common/config/subscription_test_harness.h
@@ -46,7 +46,7 @@ public:
    * @param version version_info to provide in the response.
    * @param accept will the onConfigUpdate() callback accept the response?
    */
-  virtual void deliverConfigUpdate(const std::vector<std::string> cluster_names,
+  virtual void deliverConfigUpdate(const std::vector<std::string>& cluster_names,
                                    const std::string& version, bool accept) PURE;
 
   virtual void verifyStats(uint32_t attempt, uint32_t success, uint32_t rejected, uint32_t failure,

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -128,6 +128,20 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "load_stats_reporter_test",
+    srcs = ["load_stats_reporter_test.cc"],
+    external_deps = ["envoy_eds"],
+    deps = [
+        "//source/common/stats:stats_lib",
+        "//source/common/upstream:load_stats_reporter_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/grpc:grpc_mocks",
+        "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "logical_dns_cluster_test",
     srcs = ["logical_dns_cluster_test.cc"],
     deps = [

--- a/test/common/upstream/load_stats_reporter_test.cc
+++ b/test/common/upstream/load_stats_reporter_test.cc
@@ -1,0 +1,105 @@
+#include "common/stats/stats_impl.h"
+#include "common/upstream/load_stats_reporter.h"
+
+#include "test/mocks/event/mocks.h"
+#include "test/mocks/grpc/mocks.h"
+#include "test/mocks/upstream/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "api/eds.pb.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::InSequence;
+using testing::Invoke;
+using testing::NiceMock;
+using testing::Return;
+using testing::_;
+
+// The tests in this file provide just coverage over some corner cases in error handling. The test
+// for the happy path for LoadStatsReporter is provided in //test/integration:load_stats_reporter.
+namespace Envoy {
+namespace Upstream {
+
+typedef Grpc::MockAsyncClient<envoy::api::v2::LoadStatsRequest, envoy::api::v2::LoadStatsResponse>
+    LoadStatsMockAsyncClient;
+
+class LoadStatsReporterTest : public testing::Test {
+public:
+  LoadStatsReporterTest()
+      : retry_timer_(new Event::MockTimer()), response_timer_(new Event::MockTimer()),
+        async_client_(new LoadStatsMockAsyncClient()) {
+    node_.set_id("foo");
+  }
+
+  void createLoadStatsReporter() {
+    InSequence s;
+    EXPECT_CALL(dispatcher_, createTimer_(_)).WillOnce(Invoke([this](Event::TimerCb timer_cb) {
+      retry_timer_cb_ = timer_cb;
+      return retry_timer_;
+    }));
+    EXPECT_CALL(dispatcher_, createTimer_(_)).WillOnce(Invoke([this](Event::TimerCb timer_cb) {
+      response_timer_cb_ = timer_cb;
+      return response_timer_;
+    }));
+    load_stats_reporter_.reset(new LoadStatsReporter(
+        node_, cm_, stats_store_, LoadStatsAsyncClientPtr(async_client_), dispatcher_));
+  }
+
+  void expectSendMessage(const std::vector<envoy::api::v2::ClusterStats>& expected_cluster_stats) {
+    envoy::api::v2::LoadStatsRequest expected_request;
+    expected_request.mutable_node()->MergeFrom(node_);
+    std::copy(expected_cluster_stats.begin(), expected_cluster_stats.end(),
+              Protobuf::RepeatedPtrFieldBackInserter(expected_request.mutable_cluster_stats()));
+    EXPECT_CALL(async_stream_, sendMessage(ProtoEq(expected_request), false));
+  }
+
+  void deliverLoadStatsResponse(const std::vector<std::string>& cluster_names) {
+    std::unique_ptr<envoy::api::v2::LoadStatsResponse> response(
+        new envoy::api::v2::LoadStatsResponse());
+    response->mutable_load_reporting_interval()->set_seconds(42);
+    std::copy(cluster_names.begin(), cluster_names.end(),
+              Protobuf::RepeatedPtrFieldBackInserter(response->mutable_clusters()));
+
+    EXPECT_CALL(*response_timer_, enableTimer(std::chrono::milliseconds(42000)));
+    load_stats_reporter_->onReceiveMessage(std::move(response));
+  }
+
+  envoy::api::v2::Node node_;
+  NiceMock<Upstream::MockClusterManager> cm_;
+  Event::MockDispatcher dispatcher_;
+  Stats::IsolatedStoreImpl stats_store_;
+  std::unique_ptr<LoadStatsReporter> load_stats_reporter_;
+  Event::MockTimer* retry_timer_;
+  Event::TimerCb retry_timer_cb_;
+  Event::MockTimer* response_timer_;
+  Event::TimerCb response_timer_cb_;
+  Grpc::MockAsyncStream<envoy::api::v2::LoadStatsRequest> async_stream_;
+  LoadStatsMockAsyncClient* async_client_;
+};
+
+// Validate that stream creation results in a timer based retry.
+TEST_F(LoadStatsReporterTest, StreamCreationFailure) {
+  EXPECT_CALL(*async_client_, start(_, _)).WillOnce(Return(nullptr));
+  EXPECT_CALL(*retry_timer_, enableTimer(_));
+  createLoadStatsReporter();
+  EXPECT_CALL(*async_client_, start(_, _)).WillOnce(Return(&async_stream_));
+  expectSendMessage({});
+  retry_timer_cb_();
+}
+
+// Validate that the client can recover from a remote stream closure via retry.
+TEST_F(LoadStatsReporterTest, RemoteStreamClose) {
+  EXPECT_CALL(*async_client_, start(_, _)).WillOnce(Return(&async_stream_));
+  expectSendMessage({});
+  createLoadStatsReporter();
+  EXPECT_CALL(*response_timer_, disableTimer());
+  EXPECT_CALL(*retry_timer_, enableTimer(_));
+  load_stats_reporter_->onRemoteClose(Grpc::Status::GrpcStatus::Canceled, "");
+  EXPECT_CALL(*async_client_, start(_, _)).WillOnce(Return(&async_stream_));
+  expectSendMessage({});
+  retry_timer_cb_();
+}
+
+} // namespace Upstream
+} // namespace Envoy

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -306,6 +306,17 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "load_stats_integration_test",
+    srcs = ["load_stats_integration_test.cc"],
+    external_deps = ["envoy_eds"],
+    deps = [
+        ":http_integration_lib",
+        "//source/common/config:resources_lib",
+        "//test/test_common:network_utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "proxy_proto_integration_test",
     srcs = [
         "proxy_proto_integration_test.cc",

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -60,6 +60,7 @@ public:
   template <class T> void sendGrpcMessage(const T& message) {
     auto serialized_response = Grpc::Common::serializeBody(message);
     encodeData(*serialized_response, false);
+    ENVOY_LOG(debug, "Sent gRPC message: {}", message.DebugString());
   }
   template <class T> void decodeGrpcFrame(T& message) {
     EXPECT_GE(decoded_grpc_frames_.size(), 1);

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -1,0 +1,384 @@
+#include "common/config/resources.h"
+
+#include "test/integration/http_integration.h"
+#include "test/test_common/network_utility.h"
+
+#include "api/eds.pb.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace {
+
+class LoadStatsIntegrationTest : public HttpIntegrationTest,
+                                 public testing::TestWithParam<Network::Address::IpVersion> {
+public:
+  LoadStatsIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
+
+  void addEndpoint(envoy::api::v2::LocalityLbEndpoints& locality_lb_endpoints, uint32_t index) {
+    auto* socket_address = locality_lb_endpoints.add_lb_endpoints()
+                               ->mutable_endpoint()
+                               ->mutable_address()
+                               ->mutable_socket_address();
+    socket_address->set_address(Network::Test::getLoopbackAddressString(GetParam()));
+    socket_address->set_port_value(service_upstream_[index]->localAddress()->ip()->port());
+  }
+
+  // We need to supply the endpoints via EDS to provide locality information for
+  // load reporting. Use a filesystem delivery to simplify test mechanics.
+  void updateClusterLoadAssignment(const std::vector<uint32_t>& winter_upstreams,
+                                   const std::vector<uint32_t>& dragon_upstreeams) {
+    envoy::api::v2::ClusterLoadAssignment cluster_load_assignment;
+    cluster_load_assignment.set_cluster_name("cluster_0");
+
+    auto* winter = cluster_load_assignment.add_endpoints();
+    winter->mutable_locality()->set_region("some_region");
+    winter->mutable_locality()->set_zone("zone_name");
+    winter->mutable_locality()->set_sub_zone("winter");
+    for (uint32_t index : winter_upstreams) {
+      addEndpoint(*winter, index);
+    }
+
+    auto* dragon = cluster_load_assignment.add_endpoints();
+    dragon->mutable_locality()->set_region("some_region");
+    dragon->mutable_locality()->set_zone("zone_name");
+    dragon->mutable_locality()->set_sub_zone("dragon");
+    for (uint32_t index : dragon_upstreeams) {
+      addEndpoint(*dragon, index);
+    }
+
+    // Write to file the DiscoveryResponse and trigger inotify watch.
+    envoy::api::v2::DiscoveryResponse eds_response;
+    eds_response.set_version_info(std::to_string(eds_version_++));
+    eds_response.set_type_url(Config::TypeUrl::get().ClusterLoadAssignment);
+    eds_response.add_resources()->PackFrom(cluster_load_assignment);
+    // Past the initial write, need move semantics to trigger inotify move event that the
+    // FilesystemSubscriptionImpl is subscribed to.
+    if (eds_path_.empty()) {
+      eds_path_ =
+          TestEnvironment::writeStringToFileForTest("eds.pb_text", eds_response.DebugString());
+    } else {
+      std::string path = TestEnvironment::writeStringToFileForTest("eds.update.pb_text",
+                                                                   eds_response.DebugString());
+      ASSERT_EQ(0, ::rename(path.c_str(), eds_path_.c_str()));
+    }
+  }
+
+  void createUpstreams() override {
+    fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_));
+    ports_.push_back(fake_upstreams_.back()->localAddress()->ip()->port());
+    load_report_upstream_ = fake_upstreams_.back().get();
+
+    for (uint32_t i = 0; i < upstream_endpoints_; ++i) {
+      fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
+      service_upstream_[i] = fake_upstreams_.back().get();
+      // service_upstream_[i]->set_allow_unexpected_disconnects(true);
+    }
+  }
+
+  void initialize() override {
+    updateClusterLoadAssignment({}, {});
+    config_helper_.addConfigModifier([this](envoy::api::v2::Bootstrap& bootstrap) {
+      // Setup load reporting and corresponding gRPC cluster.
+      auto* loadstats_config = bootstrap.mutable_cluster_manager()->mutable_load_stats_config();
+      loadstats_config->set_api_type(envoy::api::v2::ApiConfigSource::GRPC);
+      loadstats_config->add_cluster_name("load_report");
+      auto* load_report_cluster = bootstrap.mutable_static_resources()->add_clusters();
+      load_report_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+      load_report_cluster->mutable_circuit_breakers()->Clear();
+      load_report_cluster->set_name("load_report");
+      load_report_cluster->mutable_http2_protocol_options();
+      // Put ourselves in a locality that will be used in
+      // updateClusterLoadAssignment()
+      auto* locality = bootstrap.mutable_node()->mutable_locality();
+      locality->set_region("some_region");
+      locality->set_zone("zone_name");
+      locality->set_sub_zone("winter");
+      // Switch predefined cluster_0 to EDS filesystem sourcing.
+      auto* cluster_0 = bootstrap.mutable_static_resources()->mutable_clusters(0);
+      cluster_0->mutable_hosts()->Clear();
+      cluster_0->set_type(envoy::api::v2::Cluster::EDS);
+      auto* eds_cluster_config = cluster_0->mutable_eds_cluster_config();
+      eds_cluster_config->mutable_eds_config()->set_path(eds_path_);
+    });
+    named_ports_ = {"http"};
+    HttpIntegrationTest::initialize();
+  }
+
+  void initiateClientConnection() {
+    auto conn = makeClientConnection(lookupPort("http"));
+    codec_client_ = makeHttpConnection(std::move(conn));
+    Http::TestHeaderMapImpl headers{{":method", "POST"},       {":path", "/test/long/url"},
+                                    {":scheme", "http"},       {":authority", "host"},
+                                    {"x-lyft-user-id", "123"}, {"x-forwarded-for", "10.0.0.1"}};
+    response_.reset(new IntegrationStreamDecoder(*dispatcher_));
+    codec_client_->makeRequestWithBody(headers, request_size_, *response_);
+  }
+
+  void waitForLoadStatsStream() {
+    fake_loadstats_connection_ = load_report_upstream_->waitForHttpConnection(*dispatcher_);
+    loadstats_stream_ = fake_loadstats_connection_->waitForNewStream();
+  }
+
+  void waitForLoadStatsRequest(
+      const std::vector<envoy::api::v2::UpstreamLocalityStats>& expected_locality_stats,
+      uint64_t dropped = 0) {
+    envoy::api::v2::LoadStatsRequest loadstats_request;
+    loadstats_stream_->waitForGrpcMessage(*dispatcher_, loadstats_request);
+    EXPECT_STREQ("POST", loadstats_stream_->headers().Method()->value().c_str());
+    EXPECT_STREQ("/envoy.api.v2.EndpointDiscoveryService/StreamLoadStats",
+                 loadstats_stream_->headers().Path()->value().c_str());
+    EXPECT_STREQ("application/grpc", loadstats_stream_->headers().ContentType()->value().c_str());
+
+    Protobuf::RepeatedPtrField<envoy::api::v2::ClusterStats> expected_cluster_stats;
+    if (!expected_locality_stats.empty()) {
+      auto* cluster_stats = expected_cluster_stats.Add();
+      cluster_stats->set_cluster_name("cluster_0");
+      if (dropped > 0) {
+        cluster_stats->set_total_dropped_requests(dropped);
+      }
+      std::copy(
+          expected_locality_stats.begin(), expected_locality_stats.end(),
+          Protobuf::RepeatedPtrFieldBackInserter(cluster_stats->mutable_upstream_locality_stats()));
+    }
+    EXPECT_TRUE(TestUtility::assertRepeatedPtrFieldEqual(expected_cluster_stats,
+                                                         loadstats_request.cluster_stats()));
+  }
+
+  void waitForUpstreamResponse(uint32_t endpoint_index, uint32_t response_code = 200) {
+    fake_upstream_connection_ =
+        service_upstream_[endpoint_index]->waitForHttpConnection(*dispatcher_);
+    upstream_request_ = fake_upstream_connection_->waitForNewStream();
+    upstream_request_->waitForEndStream(*dispatcher_);
+
+    upstream_request_->encodeHeaders(
+        Http::TestHeaderMapImpl{{":status", std::to_string(response_code)}}, false);
+    upstream_request_->encodeData(response_size_, true);
+    response_->waitForEndStream();
+
+    EXPECT_TRUE(upstream_request_->complete());
+    EXPECT_EQ(request_size_, upstream_request_->bodyLength());
+
+    EXPECT_TRUE(response_->complete());
+    EXPECT_STREQ(std::to_string(response_code).c_str(),
+                 response_->headers().Status()->value().c_str());
+    EXPECT_EQ(response_size_, response_->body().size());
+  }
+
+  void sendLoadStatsResponse(const std::vector<std::string>& clusters, uint32_t secs) {
+    envoy::api::v2::LoadStatsResponse loadstats_response;
+    loadstats_response.mutable_load_reporting_interval()->set_seconds(secs);
+    for (const auto& cluster : clusters) {
+      loadstats_response.add_clusters(cluster);
+    }
+    loadstats_stream_->sendGrpcMessage(loadstats_response);
+  }
+
+  envoy::api::v2::UpstreamLocalityStats localityStats(const std::string& sub_zone, uint64_t success,
+                                                      uint64_t error, uint64_t active) {
+    envoy::api::v2::UpstreamLocalityStats locality_stats;
+    auto* locality = locality_stats.mutable_locality();
+    locality->set_region("some_region");
+    locality->set_zone("zone_name");
+    locality->set_sub_zone(sub_zone);
+    locality_stats.set_total_successful_requests(success);
+    locality_stats.set_total_error_requests(error);
+    locality_stats.set_total_requests_in_progress(active);
+    return locality_stats;
+  }
+
+  void cleanupUpstreamConnection() {
+    codec_client_->close();
+    if (fake_upstream_connection_ != nullptr) {
+      fake_upstream_connection_->close();
+      fake_upstream_connection_->waitForDisconnect();
+    }
+  }
+
+  void cleanupLoadStatsConnection() {
+    if (fake_loadstats_connection_ != nullptr) {
+      fake_loadstats_connection_->close();
+      fake_loadstats_connection_->waitForDisconnect();
+    }
+  }
+
+  static constexpr uint32_t upstream_endpoints_ = 3;
+
+  FakeHttpConnectionPtr fake_loadstats_connection_;
+  FakeStreamPtr loadstats_stream_;
+  FakeUpstream* load_report_upstream_{};
+  FakeUpstream* service_upstream_[upstream_endpoints_]{};
+  std::string eds_path_;
+  uint32_t eds_version_{};
+
+  const uint64_t request_size_ = 1024;
+  const uint64_t response_size_ = 512;
+};
+
+INSTANTIATE_TEST_CASE_P(IpVersions, LoadStatsIntegrationTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+// Validate the load reports for successful requests as cluster membership
+// changes.
+TEST_P(LoadStatsIntegrationTest, Success) {
+  initialize();
+
+  waitForLoadStatsStream();
+  waitForLoadStatsRequest({});
+  loadstats_stream_->startGrpcStream();
+
+  // Simple 50%/50% split between dragon/winter localities. Also include an
+  // unknown cluster to exercise the handling of this case.
+  sendLoadStatsResponse({"cluster_0", "cluster_1"}, 1);
+  test_server_->waitForCounterGe("load_reporter.requests", 1);
+
+  updateClusterLoadAssignment({0}, {1});
+  test_server_->waitForGaugeGe("cluster.cluster_0.membership_total", 2);
+
+  for (uint32_t i = 0; i < 4; ++i) {
+    initiateClientConnection();
+    waitForUpstreamResponse(i % 2);
+    cleanupUpstreamConnection();
+  }
+
+  waitForLoadStatsRequest({localityStats("winter", 2, 0, 0), localityStats("dragon", 2, 0, 0)});
+
+  EXPECT_EQ(1, test_server_->counter("load_reporter.requests")->value());
+  EXPECT_EQ(2, test_server_->counter("load_reporter.responses")->value());
+  EXPECT_EQ(0, test_server_->counter("load_reporter.errors")->value());
+
+  // 33%/67% split between dragon/winter localities.
+  updateClusterLoadAssignment({0}, {1, 2});
+  sendLoadStatsResponse({"cluster_0"}, 1);
+  test_server_->waitForGaugeGe("cluster.cluster_0.membership_total", 3);
+
+  for (uint32_t i = 0; i < 6; ++i) {
+    initiateClientConnection();
+    waitForUpstreamResponse((i + 1) % 3);
+    cleanupUpstreamConnection();
+  }
+
+  waitForLoadStatsRequest({localityStats("winter", 2, 0, 0), localityStats("dragon", 4, 0, 0)});
+
+  EXPECT_EQ(2, test_server_->counter("load_reporter.requests")->value());
+  EXPECT_EQ(3, test_server_->counter("load_reporter.responses")->value());
+  EXPECT_EQ(0, test_server_->counter("load_reporter.errors")->value());
+
+  // 100% winter locality.
+  updateClusterLoadAssignment({}, {});
+  updateClusterLoadAssignment({1}, {});
+  sendLoadStatsResponse({"cluster_0"}, 1);
+  test_server_->waitForCounterGe("load_reporter.requests", 3);
+
+  for (uint32_t i = 0; i < 1; ++i) {
+    initiateClientConnection();
+    waitForUpstreamResponse(1);
+    cleanupUpstreamConnection();
+  }
+
+  waitForLoadStatsRequest({localityStats("winter", 1, 0, 0)});
+
+  EXPECT_EQ(3, test_server_->counter("load_reporter.requests")->value());
+  EXPECT_EQ(4, test_server_->counter("load_reporter.responses")->value());
+  EXPECT_EQ(0, test_server_->counter("load_reporter.errors")->value());
+
+  cleanupLoadStatsConnection();
+}
+
+// Validate the load reports for successful/error requests make sense.
+TEST_P(LoadStatsIntegrationTest, Error) {
+  initialize();
+
+  waitForLoadStatsStream();
+  waitForLoadStatsRequest({});
+  loadstats_stream_->startGrpcStream();
+
+  sendLoadStatsResponse({"cluster_0"}, 1);
+  test_server_->waitForCounterGe("load_reporter.requests", 1);
+
+  updateClusterLoadAssignment({0}, {});
+  test_server_->waitForGaugeGe("cluster.cluster_0.membership_total", 1);
+
+  // This should count as an error since 5xx.
+  initiateClientConnection();
+  waitForUpstreamResponse(0, 503);
+  cleanupUpstreamConnection();
+
+  // This should count as "success" since non-5xx.
+  initiateClientConnection();
+  waitForUpstreamResponse(0, 404);
+  cleanupUpstreamConnection();
+
+  waitForLoadStatsRequest({localityStats("winter", 1, 1, 0)});
+
+  EXPECT_EQ(1, test_server_->counter("load_reporter.requests")->value());
+  EXPECT_EQ(2, test_server_->counter("load_reporter.responses")->value());
+  EXPECT_EQ(0, test_server_->counter("load_reporter.errors")->value());
+
+  cleanupLoadStatsConnection();
+}
+
+// Validate the load reports for in-progress make sense.
+TEST_P(LoadStatsIntegrationTest, InProgress) {
+  initialize();
+
+  waitForLoadStatsStream();
+  waitForLoadStatsRequest({});
+  loadstats_stream_->startGrpcStream();
+
+  sendLoadStatsResponse({"cluster_0"}, 1);
+  test_server_->waitForCounterGe("load_reporter.requests", 1);
+
+  updateClusterLoadAssignment({0}, {});
+  test_server_->waitForGaugeGe("cluster.cluster_0.membership_total", 1);
+
+  initiateClientConnection();
+
+  waitForLoadStatsRequest({localityStats("winter", 0, 0, 1)});
+
+  waitForUpstreamResponse(0, 503);
+  cleanupUpstreamConnection();
+
+  EXPECT_EQ(1, test_server_->counter("load_reporter.requests")->value());
+  EXPECT_EQ(2, test_server_->counter("load_reporter.responses")->value());
+  EXPECT_EQ(0, test_server_->counter("load_reporter.errors")->value());
+
+  cleanupLoadStatsConnection();
+}
+
+// Validate the load reports for dropped requests make sense.
+TEST_P(LoadStatsIntegrationTest, Dropped) {
+  config_helper_.addConfigModifier([](envoy::api::v2::Bootstrap& bootstrap) {
+    auto* cluster_0 = bootstrap.mutable_static_resources()->mutable_clusters(0);
+    auto* thresholds = cluster_0->mutable_circuit_breakers()->add_thresholds();
+    thresholds->mutable_max_pending_requests()->set_value(0);
+  });
+  initialize();
+
+  waitForLoadStatsStream();
+  waitForLoadStatsRequest({});
+  loadstats_stream_->startGrpcStream();
+
+  sendLoadStatsResponse({"cluster_0"}, 1);
+  test_server_->waitForCounterGe("load_reporter.requests", 1);
+
+  updateClusterLoadAssignment({0}, {});
+  test_server_->waitForGaugeGe("cluster.cluster_0.membership_total", 1);
+
+  // This should count as dropped, since we trigger circuit breaking.
+  initiateClientConnection();
+  response_->waitForEndStream();
+  EXPECT_TRUE(response_->complete());
+  EXPECT_STREQ("503", response_->headers().Status()->value().c_str());
+  cleanupUpstreamConnection();
+
+  waitForLoadStatsRequest({localityStats("winter", 0, 0, 0)}, 1);
+
+  EXPECT_EQ(1, test_server_->counter("load_reporter.requests")->value());
+  EXPECT_EQ(2, test_server_->counter("load_reporter.responses")->value());
+  EXPECT_EQ(0, test_server_->counter("load_reporter.errors")->value());
+
+  cleanupLoadStatsConnection();
+}
+
+} // namespace
+} // namespace Envoy

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -22,6 +22,10 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using testing::AssertionFailure;
+using testing::AssertionResult;
+using testing::AssertionSuccess;
+
 namespace Envoy {
 #define EXPECT_THROW_WITH_MESSAGE(statement, expected_exception, message)                          \
   try {                                                                                            \
@@ -101,9 +105,45 @@ public:
    * @return bool indicating whether the protos are equal. Type name and string serialization are
    *         used for equality testing.
    */
-  template <class ProtoType> static bool protoEqual(ProtoType lhs, ProtoType rhs) {
+  template <class ProtoType> static bool protoEqual(const ProtoType& lhs, const ProtoType& rhs) {
     return lhs.GetTypeName() == rhs.GetTypeName() &&
            lhs.SerializeAsString() == rhs.SerializeAsString();
+  }
+
+  /**
+   * Compare two RepeatedPtrFields of the same type for equality.
+   *
+   * @param lhs RepeatedPtrField on LHS.
+   * @param rhs RepeatedPtrField on RHS.
+   * @return bool indicating whether the RepeatedPtrField are equal. TestUtility::protoEqual() is
+   *              used for individual element testing.
+   */
+  template <class ProtoType>
+  static bool repeatedPtrFieldEqual(const Protobuf::RepeatedPtrField<ProtoType>& lhs,
+                                    const Protobuf::RepeatedPtrField<ProtoType>& rhs) {
+    if (lhs.size() != rhs.size()) {
+      return false;
+    }
+
+    for (int i = 0; i < lhs.size(); ++i) {
+      if (!TestUtility::protoEqual(lhs[i], rhs[i])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  template <class ProtoType>
+  static AssertionResult
+  assertRepeatedPtrFieldEqual(const Protobuf::RepeatedPtrField<ProtoType>& lhs,
+                              const Protobuf::RepeatedPtrField<ProtoType>& rhs) {
+    if (!repeatedPtrFieldEqual(lhs, rhs)) {
+      return AssertionFailure() << RepeatedPtrUtil::debugString(lhs) << " does not match "
+                                << RepeatedPtrUtil::debugString(rhs);
+    }
+
+    return AssertionSuccess();
   }
 
   /**
@@ -196,18 +236,6 @@ public:
 
 MATCHER_P(ProtoEq, rhs, "") { return TestUtility::protoEqual(arg, rhs); }
 
-MATCHER_P(RepeatedProtoEq, rhs, "") {
-  if (arg.size() != rhs.size()) {
-    return false;
-  }
-
-  for (int i = 0; i < arg.size(); ++i) {
-    if (!TestUtility::protoEqual(arg[i], rhs[i])) {
-      return false;
-    }
-  }
-
-  return true;
-}
+MATCHER_P(RepeatedProtoEq, rhs, "") { return TestUtility::repeatedPtrFieldEqual(arg, rhs); }
 
 } // Envoy


### PR DESCRIPTION
This patch introduces the LoadStatsReporter for the envoy.api.v2.StreamLoadStats streaming RPC. See
https://github.com/envoyproxy/data-plane-api/blob/67ceb6429aca38aecd722494baa0e499dadd3caf/api/eds.proto#L28
for a description of how the load report protocol works. If configured, a connection is made to the
management server at cluster manager initialization time. Once a load report request is received,
Envoy will report back the observed load in the specified clusters over the specified interval.

Only support for basic metrics at the locality/cluster level are provided, later work will handled
multi-dimensional LB stats.

Signed-off-by: Harvey Tuch <htuch@google.com>