### PR TITLE
example/configs: remove "type"

### DIFF
--- a/configs/envoy_double_proxy.template.json
+++ b/configs/envoy_double_proxy.template.json
@@ -14,7 +14,6 @@
     {% endif -%}
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "auto",
@@ -57,18 +56,18 @@
           ]
         },
         "filters": [
-          { "type": "both", "name": "health_check",
+          { "name": "health_check",
             "config": {
               "pass_through_mode": false, "endpoint": "/healthcheck"
             }
           },
-          { "type": "decoder", "name": "buffer",
+          { "name": "buffer",
             "config": {
               "max_request_bytes": 5242880,
               "max_request_time_s": 120
             }
           },
-          { "type": "decoder", "name": "router", "config": {} }
+          { "name": "router", "config": {} }
         ]
       }
     }]

--- a/configs/envoy_front_proxy.template.json
+++ b/configs/envoy_front_proxy.template.json
@@ -22,7 +22,6 @@
     {% endif -%}
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "auto",
@@ -50,24 +49,24 @@
         {% endif -%}
         "route_config": {% include kwargs['router_file'] %},
         "filters": [
-          { "type": "both", "name": "health_check",
+          { "name": "health_check",
             "config": {
               "pass_through_mode": false, "endpoint": "/healthcheck"
             }
           },
-          { "type": "decoder", "name": "buffer",
+          { "name": "buffer",
             "config": {
               "max_request_bytes": 5242880,
               "max_request_time_s": 120
             }
           },
-          { "type": "decoder", "name": "rate_limit",
+          { "name": "rate_limit",
             "config" : {
               "domain": "envoy_front",
               "request_type": "external"
             }
           },
-          { "type": "decoder", "name": "router", "config": {} }
+          { "name": "router", "config": {} }
         ]
       }
     }]

--- a/configs/envoy_service_to_service.template.json
+++ b/configs/envoy_service_to_service.template.json
@@ -6,7 +6,6 @@
   "address": "{{ address }}",
   "filters": [
   {
-    "type": "read",
     "name": "http_connection_manager",
     "config": {
       "codec_type": "auto",
@@ -69,18 +68,18 @@
         ]
       },
       "filters": [
-        { "type": "both", "name": "health_check",
+        { "name": "health_check",
           "config": {
             "pass_through_mode": true, "cache_time_ms": 2500, "endpoint": "/healthcheck"
            }
         },
-        { "type": "decoder", "name": "buffer",
+        { "name": "buffer",
           "config": {
             "max_request_bytes": 5242880,
             "max_request_time_s": 120
           }
         },
-        { "type": "decoder", "name": "router", "config": {} }
+        { "name": "router", "config": {} }
       ]
     }
   }]
@@ -94,7 +93,6 @@
     "address": "tcp://127.0.0.1:9001",
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "auto",
@@ -150,13 +148,13 @@
           ]
         },
         "filters": [
-          {"type": "decoder", "name": "rate_limit",
+          {"name": "rate_limit",
             "config": {
               "domain": "envoy_service_to_service"
             }
           },
-          {"type": "both", "name": "grpc_http1_bridge", "config": {}},
-          {"type": "decoder", "name": "router", "config": {}}
+          {"name": "grpc_http1_bridge", "config": {}},
+          {"name": "router", "config": {}}
         ]
       }
     }]
@@ -166,7 +164,6 @@
     "address": "tcp://127.0.0.1:9002",
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "auto",
@@ -192,13 +189,13 @@
           "route_config_name": "9002_http_conn_man"
         },
         "filters": [
-          {"type": "decoder", "name": "rate_limit",
+          {"name": "rate_limit",
             "config": {
               "domain": "envoy_service_to_service"
             }
           },
-          {"type": "both", "name": "grpc_http1_bridge", "config": {}},
-          {"type": "decoder", "name": "router", "config": {}}
+          {"name": "grpc_http1_bridge", "config": {}},
+          {"name": "router", "config": {}}
         ]
       }
     }]
@@ -209,7 +206,6 @@
     "address": "{{ mapping['address'] }}",
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "auto",
@@ -254,9 +250,9 @@
         },
         "filters": [
           {% if mapping['name'] in ['dynamodb_iad', 'dynamodb_legacy'] %}
-            { "type": "both", "name": "http_dynamo_filter", "config": {}},
+          { "name": "http_dynamo_filter", "config": {}},
           {% endif %}
-          { "type": "decoder", "name": "router", "config": {} }
+          { "name": "router", "config": {} }
         ]
       }
     }]
@@ -269,7 +265,6 @@
     "filters": [
     {% if value.get('ratelimit', False) %}
     {
-      "type": "read",
       "name": "ratelimit",
       "config": {
         "stat_prefix": "{{ key }}",
@@ -279,7 +274,6 @@
     },
     {% endif %}
     {
-      "type": "both",
       "name": "mongo_proxy",
       "config": {
         "stat_prefix": "{{ key }}",
@@ -287,7 +281,6 @@
       }
     },
     {
-      "type": "read",
       "name": "tcp_proxy",
       "config": {
         "stat_prefix": "mongo_{{ key }}",

--- a/configs/google_com_proxy.json
+++ b/configs/google_com_proxy.json
@@ -2,7 +2,6 @@
     "listeners": [{
         "address": "tcp://127.0.0.1:10000",
         "filters": [{
-            "type": "read",
             "name": "http_connection_manager",
             "config": {
                 "codec_type": "auto",
@@ -22,7 +21,6 @@
                     }]
                 },
                 "filters": [{
-                    "type": "decoder",
                     "name": "router",
                     "config": {}
                 }]

--- a/configs/original-dst-cluster/proxy_config.json
+++ b/configs/original-dst-cluster/proxy_config.json
@@ -3,7 +3,6 @@
         "address": "tcp://0.0.0.0:10000",
         "use_original_dst": true,
         "filters": [{
-            "type": "read",
             "name": "http_connection_manager",
             "config": {
                 "codec_type": "auto",
@@ -22,7 +21,6 @@
                     }]
                 },
                 "filters": [{
-                    "type": "decoder",
                     "name": "router",
                     "config": {}
                 }]

--- a/examples/front-proxy/front-envoy.json
+++ b/examples/front-proxy/front-envoy.json
@@ -4,7 +4,6 @@
       "address": "tcp://0.0.0.0:80",
       "filters": [
         {
-          "type": "read",
           "name": "http_connection_manager",
           "config": {
             "codec_type": "auto",
@@ -32,7 +31,6 @@
             },
             "filters": [
               {
-                "type": "decoder",
                 "name": "router",
                 "config": {}
               }

--- a/examples/front-proxy/service-envoy.json
+++ b/examples/front-proxy/service-envoy.json
@@ -4,7 +4,6 @@
       "address": "tcp://0.0.0.0:80",
       "filters": [
         {
-          "type": "read",
           "name": "http_connection_manager",
           "config": {
             "codec_type": "auto",
@@ -26,7 +25,6 @@
             },
             "filters": [
               {
-                "type": "decoder",
                 "name": "router",
                 "config": {}
               }

--- a/examples/grpc-bridge/config/s2s-grpc-envoy.json
+++ b/examples/grpc-bridge/config/s2s-grpc-envoy.json
@@ -4,7 +4,6 @@
       "address": "tcp://0.0.0.0:9211",
       "filters": [
         {
-          "type": "read",
           "name": "http_connection_manager",
           "config": {
             "codec_type": "auto",
@@ -31,7 +30,6 @@
             },
             "filters": [
               {
-                "type": "decoder",
                 "name": "router",
                 "config": {}
               }

--- a/examples/grpc-bridge/config/s2s-python-envoy.json
+++ b/examples/grpc-bridge/config/s2s-python-envoy.json
@@ -4,7 +4,6 @@
       "address": "tcp://127.0.0.1:9001",
       "filters": [
         {
-          "type": "read",
           "name": "http_connection_manager",
           "config": {
             "codec_type": "auto",
@@ -35,12 +34,10 @@
             },
             "filters": [
               {
-                "type": "both",
                 "name": "grpc_http1_bridge",
                 "config": {}
               },
               {
-                "type": "decoder",
                 "name": "router",
                 "config": {}
               }

--- a/examples/jaeger-tracing/front-envoy-jaeger.json
+++ b/examples/jaeger-tracing/front-envoy-jaeger.json
@@ -4,7 +4,6 @@
       "address": "tcp://0.0.0.0:80",
       "filters": [
         {
-          "type": "read",
           "name": "http_connection_manager",
           "config": {
             "tracing": {
@@ -31,7 +30,6 @@
             },
             "filters": [
               {
-                "type": "decoder",
                 "name": "router",
                 "config": {}
               }

--- a/examples/jaeger-tracing/service1-envoy-jaeger.json
+++ b/examples/jaeger-tracing/service1-envoy-jaeger.json
@@ -4,7 +4,6 @@
       "address": "tcp://0.0.0.0:80",
       "filters": [
         {
-          "type": "read",
           "name": "http_connection_manager",
           "config": {
             "tracing": {
@@ -31,7 +30,6 @@
             },
             "filters": [
               {
-                "type": "decoder",
                 "name": "router",
                 "config": {}
               }
@@ -44,7 +42,6 @@
       "address": "tcp://0.0.0.0:9000",
       "filters": [
         {
-          "type": "read",
           "name": "http_connection_manager",
           "config": {
             "tracing": {
@@ -72,7 +69,6 @@
             },
             "filters": [
               {
-                "type": "decoder",
                 "name": "router",
                 "config": {}
               }

--- a/examples/jaeger-tracing/service2-envoy-jaeger.json
+++ b/examples/jaeger-tracing/service2-envoy-jaeger.json
@@ -4,7 +4,6 @@
       "address": "tcp://0.0.0.0:80",
       "filters": [
         {
-          "type": "read",
           "name": "http_connection_manager",
           "config": {
             "tracing": {
@@ -32,7 +31,6 @@
             },
             "filters": [
               {
-                "type": "decoder",
                 "name": "router",
                 "config": {}
               }

--- a/examples/zipkin-tracing/front-envoy-zipkin.json
+++ b/examples/zipkin-tracing/front-envoy-zipkin.json
@@ -4,7 +4,6 @@
       "address": "tcp://0.0.0.0:80",
       "filters": [
         {
-          "type": "read",
           "name": "http_connection_manager",
           "config": {
             "generate_request_id": true,
@@ -32,7 +31,6 @@
             },
             "filters": [
               {
-                "type": "decoder",
                 "name": "router",
                 "config": {}
               }

--- a/examples/zipkin-tracing/service1-envoy-zipkin.json
+++ b/examples/zipkin-tracing/service1-envoy-zipkin.json
@@ -4,7 +4,6 @@
       "address": "tcp://0.0.0.0:80",
       "filters": [
         {
-          "type": "read",
           "name": "http_connection_manager",
           "config": {
             "tracing": {
@@ -31,7 +30,6 @@
             },
             "filters": [
               {
-                "type": "decoder",
                 "name": "router",
                 "config": {}
               }
@@ -44,7 +42,6 @@
       "address": "tcp://0.0.0.0:9000",
       "filters": [
         {
-          "type": "read",
           "name": "http_connection_manager",
           "config": {
             "tracing": {
@@ -72,7 +69,6 @@
             },
             "filters": [
               {
-                "type": "decoder",
                 "name": "router",
                 "config": {}
               }

--- a/examples/zipkin-tracing/service2-envoy-zipkin.json
+++ b/examples/zipkin-tracing/service2-envoy-zipkin.json
@@ -4,7 +4,6 @@
       "address": "tcp://0.0.0.0:80",
       "filters": [
         {
-          "type": "read",
           "name": "http_connection_manager",
           "config": {
             "tracing": {
@@ -32,7 +31,6 @@
             },
             "filters": [
               {
-                "type": "decoder",
                 "name": "router",
                 "config": {}
               }

--- a/test/common/json/config_schemas_test_data/test_http_conn_network_filter_schema.py
+++ b/test/common/json/config_schemas_test_data/test_http_conn_network_filter_schema.py
@@ -63,12 +63,10 @@ HTTP_CONN_NETWORK_FILTER_BLOB = {
                 "endpoint": "/healthcheck",
                 "pass_through_mode": false
             },
-            "type": "both",
             "name": "health_check"
         },
         {
             "config": {},
-            "type": "decoder",
             "name": "router"
         }
     ],

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -65,7 +65,7 @@ public:
       "codec_type": "auto",
       "stat_prefix": "foo",
       "filters": [
-        { "type": "both", "name": "http_dynamo_filter", "config": {} }
+        { "name": "http_dynamo_filter", "config": {} }
       ]
     }
     )EOF";
@@ -122,7 +122,7 @@ TEST_F(RdsImplTest, RdsAndStatic) {
       "codec_type": "auto",
       "stat_prefix": "foo",
       "filters": [
-        { "type": "both", "name": "http_dynamo_filter", "config": {} }
+        { "name": "http_dynamo_filter", "config": {} }
       ]
     }
     )EOF";
@@ -143,7 +143,7 @@ TEST_F(RdsImplTest, LocalInfoNotDefined) {
       "codec_type": "auto",
       "stat_prefix": "foo",
       "filters": [
-        { "type": "both", "name": "http_dynamo_filter", "config": {} }
+        { "name": "http_dynamo_filter", "config": {} }
       ]
     }
     )EOF";
@@ -166,7 +166,7 @@ TEST_F(RdsImplTest, UnknownCluster) {
       "codec_type": "auto",
       "stat_prefix": "foo",
       "filters": [
-        { "type": "both", "name": "http_dynamo_filter", "config": {} }
+        { "name": "http_dynamo_filter", "config": {} }
       ]
     }
     )EOF";

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -51,7 +51,7 @@ TEST_P(EchoIntegrationTest, AddRemoveListener) {
     "name": "new_listener",
     "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
-      { "type": "read", "name": "echo", "config": {} }
+      { "name": "echo", "config": {} }
     ]
   }
   )EOF",

--- a/test/server/config/network/http_connection_manager_test.cc
+++ b/test/server/config/network/http_connection_manager_test.cc
@@ -59,8 +59,7 @@ TEST_F(HttpConnectionManagerConfigTest, InvalidFilterName) {
       ]
     },
     "filters": [
-      { "type": "encoder", "name": "foo", "config": {}
-      }
+      { "name": "foo", "config": {} }
     ]
   }
   )EOF";
@@ -97,7 +96,7 @@ TEST_F(HttpConnectionManagerConfigTest, MiscConfig) {
       "request_headers_for_tags": [ "foo" ]
     },
     "filters": [
-      { "type": "both", "name": "http_dynamo_filter", "config": {} }
+      { "name": "http_dynamo_filter", "config": {} }
     ]
   }
   )EOF";
@@ -132,7 +131,7 @@ TEST_F(HttpConnectionManagerConfigTest, SingleDateProvider) {
       ]
     },
     "filters": [
-      { "type": "both", "name": "http_dynamo_filter", "config": {} }
+      { "name": "http_dynamo_filter", "config": {} }
     ]
   }
   )EOF";


### PR DESCRIPTION
This further cleans up filter types. I left "type" in the old v1 integration
test configs so we still have coverage there that the config doesn't blow up.

Signed-off-by: Matt Klein <mklein@lyft.com>