### PR TITLE
[WIP] early draft for #1780 : x509 verify in route

### DIFF
--- a/include/envoy/http/access_log.h
+++ b/include/envoy/http/access_log.h
@@ -145,6 +145,13 @@ public:
    * Get the downstream address.
    */
   virtual const std::string& getDownstreamAddress() const PURE;
+
+  // cert info for request
+  virtual const Optional<std::vector<std::string> >& subjectAltNames() const PURE;
+  virtual void subjectAltNames(const std::vector<std::string> > sans) const PURE;
+
+  virtual const Optional<std::string>& certificateHash() const PURE;
+  virtual void certificateHash(const std::string& hash) const PURE;
 };
 
 /**

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -317,6 +317,10 @@ public:
    * @return bool true if the virtual host rate limits should be included.
    */
   virtual bool includeVirtualHostRateLimits() const PURE;
+
+  // route cert verify configs
+  virtual const std::vector<std::string>& verifySubjectAltNameList() const PURE;
+  virtual const std::vector<std::string>& verifyCertificateHashList() const PURE;
 };
 
 /**

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -556,6 +556,11 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
 
   // Set the trusted address for the connection by taking the last address in XFF.
   request_info_.downstream_address_ = Utility::getLastAddressFromXFF(*request_headers_);
+
+  // attach ssl info if available
+  if (nullptr != ssl()) {
+  }
+
   decodeHeaders(nullptr, *request_headers_, end_stream);
 }
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -221,6 +221,15 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 
   // A route entry matches for the request.
   route_entry_ = route_->routeEntry();
+
+  // TODO:
+  // 1. check subjectAltName from callbacks_->requestInfo() and route_entry_
+  // 2. check cert hash from callbacks_->requestInfo() and route_entry_
+  // 3. maybe add stats here
+  if (false) {
+    Http::Utility::sendLocalReply(...);
+  }
+
   Upstream::ThreadLocalCluster* cluster = config_.cm_.get(route_entry_->clusterName());
   if (!cluster) {
     config_.stats_.no_cluster_.inc();


### PR DESCRIPTION
very early **DRAFT**, based on discussion in #1780 and my wild guess.

don't even compile yet.

i am planning to:
1. add request cert info fields to *RequestInfo*
2. duplicate *verify_certificate_hash/verify_subject_alt_name* configs in *RouteEntry*
3. copy cert info from SSL connection to *RequestInfo* in *ActiveStream::decodeHeaders*
4. check *RequestInfo* against *RouteEntry* in *Router::Filter::decodeHeaders*