### PR TITLE
router: thread metadata_matches through to RouteEntryImplBase

### DIFF
--- a/include/envoy/router/BUILD
+++ b/include/envoy/router/BUILD
@@ -36,9 +36,13 @@ envoy_cc_library(
     hdrs = ["router.h"],
     deps = [
         "//include/envoy/common:optional",
+        "//include/envoy/http:access_log_interface",
         "//include/envoy/http:codec_interface",
         "//include/envoy/http:header_map_interface",
+        "//include/envoy/tracing:http_tracer_interface",
         "//include/envoy/upstream:resource_manager_interface",
+        "//source/common/protobuf",
+        "//source/common/protobuf:utility_lib",
     ],
 )
 

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -229,9 +229,9 @@ public:
                                           const Http::HeaderMap& headers) const PURE;
 };
 
-class MetadataMatch {
+class MetadataMatchCriterion {
 public:
-  virtual ~MetadataMatch() {}
+  virtual ~MetadataMatchCriterion() {}
 
   /*
    * @return const std::string& the name of the metadata key
@@ -244,18 +244,18 @@ public:
   virtual const HashedValue& value() const PURE;
 };
 
-typedef std::shared_ptr<const MetadataMatch> MetadataMatchConstSharedPtr;
+typedef std::shared_ptr<const MetadataMatchCriterion> MetadataMatchCriterionConstSharedPtr;
 
-class MetadataMatches {
+class MetadataMatchCriteria {
 public:
-  virtual ~MetadataMatches() {}
+  virtual ~MetadataMatchCriteria() {}
 
   /*
-   * @return std::vector<MetadataMatchConstSharedPtr>& a vector of
+   * @return std::vector<MetadataMatchCriterionConstSharedPtr>& a vector of
    * metadata to be matched against upstream endpoints when load
    * balancing, sorted lexically by name.
    */
-  virtual const std::vector<MetadataMatchConstSharedPtr>& metadataMatches() const PURE;
+  virtual const std::vector<MetadataMatchCriterionConstSharedPtr>& metadataMatchCriteria() const PURE;
 };
 
 /**
@@ -340,10 +340,10 @@ public:
   virtual bool useWebSocket() const PURE;
 
   /**
-   * @return MetadataMatches* the metadata that a subset load balancer should match when selecting
-   * an upstream host
+   * @return MetadataMatchCriteria* the metadata that a subset load balancer should match when
+   * selecting an upstream host
    */
-  virtual const MetadataMatches* metadataMatches() const PURE;
+  virtual const MetadataMatchCriteria* metadataMatchCriteria() const PURE;
 
   /**
    * @return const std::multimap<std::string, std::string> the opaque configuration associated

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -15,6 +15,9 @@
 #include "envoy/tracing/http_tracer.h"
 #include "envoy/upstream/resource_manager.h"
 
+#include "common/protobuf/protobuf.h"
+#include "common/protobuf/utility.h"
+
 namespace Envoy {
 namespace Router {
 
@@ -226,6 +229,35 @@ public:
                                           const Http::HeaderMap& headers) const PURE;
 };
 
+class MetadataMatch {
+public:
+  virtual ~MetadataMatch() {}
+
+  /*
+   * @return const std::string& the name of the metadata key
+   */
+  virtual const std::string& name() const PURE;
+
+  /*
+   * @return const Envoy::HashedValue& the value for the metadata key
+   */
+  virtual const HashedValue& value() const PURE;
+};
+
+typedef std::shared_ptr<const MetadataMatch> MetadataMatchConstSharedPtr;
+
+class MetadataMatches {
+public:
+  virtual ~MetadataMatches() {}
+
+  /*
+   * @return std::vector<MetadataMatchConstSharedPtr>& a vector of
+   * metadata to be matched against upstream endpoints when load
+   * balancing, sorted lexically by name.
+   */
+  virtual const std::vector<MetadataMatchConstSharedPtr>& metadataMatches() const PURE;
+};
+
 /**
  * An individual resolved route entry.
  */
@@ -306,6 +338,12 @@ public:
    * @return bool true if this route should use WebSockets.
    */
   virtual bool useWebSocket() const PURE;
+
+  /**
+   * @return MetadataMatches* the metadata that a subset load balancer should match when selecting
+   * an upstream host
+   */
+  virtual const MetadataMatches* metadataMatches() const PURE;
 
   /**
    * @return const std::multimap<std::string, std::string> the opaque configuration associated

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -255,7 +255,8 @@ public:
    * metadata to be matched against upstream endpoints when load
    * balancing, sorted lexically by name.
    */
-  virtual const std::vector<MetadataMatchCriterionConstSharedPtr>& metadataMatchCriteria() const PURE;
+  virtual const std::vector<MetadataMatchCriterionConstSharedPtr>&
+  metadataMatchCriteria() const PURE;
 };
 
 /**

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -146,7 +146,7 @@ private:
     void finalizeRequestHeaders(Http::HeaderMap&,
                                 const Http::AccessLog::RequestInfo&) const override {}
     const Router::HashPolicy* hashPolicy() const override { return nullptr; }
-    const Router::MetadataMatches* metadataMatches() const override { return nullptr; }
+    const Router::MetadataMatchCriteria* metadataMatchCriteria() const override { return nullptr; }
     Upstream::ResourcePriority priority() const override {
       return Upstream::ResourcePriority::Default;
     }

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -146,6 +146,7 @@ private:
     void finalizeRequestHeaders(Http::HeaderMap&,
                                 const Http::AccessLog::RequestInfo&) const override {}
     const Router::HashPolicy* hashPolicy() const override { return nullptr; }
+    const Router::MetadataMatches* metadataMatches() const override { return nullptr; }
     Upstream::ResourcePriority priority() const override {
       return Upstream::ResourcePriority::Default;
     }

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -75,4 +75,61 @@ void MessageUtil::jsonConvert(const Protobuf::Message& source, Protobuf::Message
   MessageUtil::loadFromJson(json, dest);
 }
 
+bool ValueUtil::equal(const ProtobufWkt::Value& v1, const ProtobufWkt::Value& v2) {
+  ProtobufWkt::Value::KindCase kind = v1.kind_case();
+  if (kind != v2.kind_case()) {
+    return false;
+  }
+
+  switch (kind) {
+  case ProtobufWkt::Value::kNullValue:
+    return true;
+
+  case ProtobufWkt::Value::kNumberValue:
+    return v1.number_value() == v2.number_value();
+
+  case ProtobufWkt::Value::kStringValue:
+    return v1.string_value() == v2.string_value();
+
+  case ProtobufWkt::Value::kBoolValue:
+    return v1.bool_value() == v2.bool_value();
+
+  case ProtobufWkt::Value::kStructValue: {
+    const ProtobufWkt::Struct& s1 = v1.struct_value();
+    const ProtobufWkt::Struct& s2 = v2.struct_value();
+    if (s1.fields_size() != s2.fields_size()) {
+      return false;
+    }
+    for (const auto& it1 : s1.fields()) {
+      const auto& it2 = s2.fields().find(it1.first);
+      if (it2 == s2.fields().end()) {
+        return false;
+      }
+
+      if (!equal(it1.second, it2->second)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  case ProtobufWkt::Value::kListValue: {
+    const ProtobufWkt::ListValue& l1 = v1.list_value();
+    const ProtobufWkt::ListValue& l2 = v2.list_value();
+    if (l1.values_size() != l2.values_size()) {
+      return false;
+    }
+    for (int i = 0; i < l1.values_size(); i++) {
+      if (!equal(l1.values(i), l2.values(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  default:
+    RELEASE_ASSERT(false);
+  }
+}
+
 } // namespace Envoy

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -128,7 +128,7 @@ bool ValueUtil::equal(const ProtobufWkt::Value& v1, const ProtobufWkt::Value& v2
   }
 
   default:
-    RELEASE_ASSERT(false);
+    NOT_REACHED;
   }
 }
 

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -110,4 +110,48 @@ public:
   }
 };
 
+class ValueUtil {
+public:
+  static std::size_t hash(const ProtobufWkt::Value& value) { return MessageUtil::hash(value); }
+
+  /**
+   * Compare two ProtobufWkt::Values for equality.
+   * @param v1 message of type type.googleapis.com/google.protobuf.Value
+   * @param v2 message of type type.googleapis.com/google.protobuf.Value
+   * @return true if v1 and v2 are identical
+   */
+  static bool equal(const ProtobufWkt::Value& v1, const ProtobufWkt::Value& v2);
+};
+
+/**
+ * HashedValue is a wrapper around ProtobufWkt::Value that computes
+ * and stores a hash code for the Value at construction.
+ */
+class HashedValue {
+public:
+  HashedValue(const ProtobufWkt::Value& value) : value_(value), hash_(ValueUtil::hash(value)){};
+  HashedValue(const HashedValue& v) : value_(v.value_), hash_(v.hash_){};
+
+  const ProtobufWkt::Value& value() const { return value_; }
+  std::size_t hash() const { return hash_; }
+
+  bool operator==(const HashedValue& rhs) const {
+    return hash_ == rhs.hash_ && ValueUtil::equal(value_, rhs.value_);
+  }
+
+  bool operator!=(const HashedValue& rhs) const { return !(*this == rhs); }
+
+private:
+  const ProtobufWkt::Value value_;
+  const std::size_t hash_;
+};
+
 } // namespace Envoy
+
+namespace std {
+// Inject an implementation of std::hash for Envoy::HashedValue into the std namespace.
+template <> struct hash<Envoy::HashedValue> {
+  std::size_t operator()(Envoy::HashedValue const& v) const { return v.hash(); }
+};
+
+} // namespace std

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -255,6 +255,7 @@ public:
   void finalizeRequestHeaders(Http::HeaderMap& headers,
                               const Http::AccessLog::RequestInfo& request_info) const override;
   const HashPolicy* hashPolicy() const override { return hash_policy_.get(); }
+  const MetadataMatches* metadataMatches() const override { return nullptr; }
   Upstream::ResourcePriority priority() const override { return priority_; }
   const RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
   const RetryPolicy& retryPolicy() const override { return retry_policy_; }
@@ -315,6 +316,7 @@ private:
     const RetryPolicy& retryPolicy() const override { return parent_->retryPolicy(); }
     const ShadowPolicy& shadowPolicy() const override { return parent_->shadowPolicy(); }
     std::chrono::milliseconds timeout() const override { return parent_->timeout(); }
+    const MetadataMatches* metadataMatches() const override { return nullptr; }
 
     const VirtualCluster* virtualCluster(const Http::HeaderMap& headers) const override {
       return parent_->virtualCluster(headers);

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -255,7 +255,7 @@ public:
   void finalizeRequestHeaders(Http::HeaderMap& headers,
                               const Http::AccessLog::RequestInfo& request_info) const override;
   const HashPolicy* hashPolicy() const override { return hash_policy_.get(); }
-  const MetadataMatches* metadataMatches() const override { return nullptr; }
+  const MetadataMatchCriteria* metadataMatchCriteria() const override { return nullptr; }
   Upstream::ResourcePriority priority() const override { return priority_; }
   const RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
   const RetryPolicy& retryPolicy() const override { return retry_policy_; }
@@ -316,7 +316,7 @@ private:
     const RetryPolicy& retryPolicy() const override { return parent_->retryPolicy(); }
     const ShadowPolicy& shadowPolicy() const override { return parent_->shadowPolicy(); }
     std::chrono::milliseconds timeout() const override { return parent_->timeout(); }
-    const MetadataMatches* metadataMatches() const override { return nullptr; }
+    const MetadataMatchCriteria* metadataMatchCriteria() const override { return nullptr; }
 
     const VirtualCluster* virtualCluster(const Http::HeaderMap& headers) const override {
       return parent_->virtualCluster(headers);

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1,3 +1,5 @@
+#include <unordered_set>
+
 #include "common/protobuf/protobuf.h"
 #include "common/protobuf/utility.h"
 
@@ -49,6 +51,130 @@ TEST(UtilityTest, LoadTextProtoFromFile_Failure) {
   EXPECT_THROW_WITH_MESSAGE(MessageUtil::loadFromFile(filename, proto_from_file), EnvoyException,
                             "Unable to parse file \"" + filename +
                                 "\" as a text protobuf (type envoy.api.v2.Bootstrap)");
+}
+
+TEST(UtilityTest, ValueUtilEqual_NullValues) {
+  ProtobufWkt::Value v1, v2;
+  v1.set_null_value(ProtobufWkt::NULL_VALUE);
+  v2.set_null_value(ProtobufWkt::NULL_VALUE);
+
+  ProtobufWkt::Value other;
+  other.set_string_value("s");
+
+  EXPECT_TRUE(ValueUtil::equal(v1, v2));
+  EXPECT_FALSE(ValueUtil::equal(v1, other));
+}
+
+TEST(UtilityTest, ValueUtilEqual_StringValues) {
+  ProtobufWkt::Value v1, v2, v3;
+  v1.set_string_value("s");
+  v2.set_string_value("s");
+  v3.set_string_value("not_s");
+
+  EXPECT_TRUE(ValueUtil::equal(v1, v2));
+  EXPECT_FALSE(ValueUtil::equal(v1, v3));
+}
+
+TEST(UtilityTest, ValueUtilEqual_NumberValues) {
+  ProtobufWkt::Value v1, v2, v3;
+  v1.set_number_value(1.0);
+  v2.set_number_value(1.0);
+  v3.set_number_value(100.0);
+
+  EXPECT_TRUE(ValueUtil::equal(v1, v2));
+  EXPECT_FALSE(ValueUtil::equal(v1, v3));
+}
+
+TEST(UtilityTest, ValueUtilEqual_BoolValues) {
+  ProtobufWkt::Value v1, v2, v3;
+  v1.set_bool_value(true);
+  v2.set_bool_value(true);
+  v3.set_bool_value(false);
+
+  EXPECT_TRUE(ValueUtil::equal(v1, v2));
+  EXPECT_FALSE(ValueUtil::equal(v1, v3));
+}
+
+TEST(UtilityTest, ValueUtilEqual_StructValues) {
+  ProtobufWkt::Value string_val1, string_val2, bool_val;
+
+  string_val1.set_string_value("s1");
+  string_val2.set_string_value("s2");
+  bool_val.set_bool_value(true);
+
+  ProtobufWkt::Value v1, v2, v3, v4;
+  v1.mutable_struct_value()->mutable_fields()->insert({"f1", string_val1});
+  v1.mutable_struct_value()->mutable_fields()->insert({"f2", bool_val});
+
+  v2.mutable_struct_value()->mutable_fields()->insert({"f1", string_val1});
+  v2.mutable_struct_value()->mutable_fields()->insert({"f2", bool_val});
+
+  v3.mutable_struct_value()->mutable_fields()->insert({"f1", string_val2});
+  v3.mutable_struct_value()->mutable_fields()->insert({"f2", bool_val});
+
+  v4.mutable_struct_value()->mutable_fields()->insert({"f1", string_val1});
+
+  EXPECT_TRUE(ValueUtil::equal(v1, v2));
+  EXPECT_FALSE(ValueUtil::equal(v1, v3));
+  EXPECT_FALSE(ValueUtil::equal(v1, v4));
+}
+
+TEST(UtilityTest, ValueUtilEqual_ListValues) {
+  ProtobufWkt::Value v1, v2, v3, v4;
+  v1.mutable_list_value()->add_values()->set_string_value("s");
+  v1.mutable_list_value()->add_values()->set_bool_value(true);
+
+  v2.mutable_list_value()->add_values()->set_string_value("s");
+  v2.mutable_list_value()->add_values()->set_bool_value(true);
+
+  v3.mutable_list_value()->add_values()->set_bool_value(true);
+  v3.mutable_list_value()->add_values()->set_string_value("s");
+
+  v4.mutable_list_value()->add_values()->set_string_value("s");
+
+  EXPECT_TRUE(ValueUtil::equal(v1, v2));
+  EXPECT_FALSE(ValueUtil::equal(v1, v3));
+  EXPECT_FALSE(ValueUtil::equal(v1, v4));
+}
+
+TEST(UtilityTest, ValueUtilHash) {
+  ProtobufWkt::Value v;
+  v.set_string_value("s1");
+
+  EXPECT_NE(ValueUtil::hash(v), 0);
+}
+
+TEST(UtilityTest, HashedValue) {
+  ProtobufWkt::Value v1, v2, v3;
+  v1.set_string_value("s");
+  v2.set_string_value("s");
+  v3.set_string_value("not_s");
+
+  HashedValue hv1(v1), hv2(v2), hv3(v3);
+
+  EXPECT_EQ(hv1, hv2);
+  EXPECT_NE(hv1, hv3);
+
+  HashedValue copy(hv1);
+  EXPECT_EQ(hv1, copy);
+}
+
+TEST(UtilityTest, HashedValueStdHash) {
+  ProtobufWkt::Value v1, v2, v3;
+  v1.set_string_value("s");
+  v2.set_string_value("s");
+  v3.set_string_value("not_s");
+
+  HashedValue hv1(v1), hv2(v2), hv3(v3);
+
+  std::unordered_set<HashedValue> set;
+  set.emplace(hv1);
+  set.emplace(hv2);
+  set.emplace(hv3);
+
+  EXPECT_EQ(set.size(), 2); // hv1 == hv2
+  EXPECT_NE(set.find(hv1), set.end());
+  EXPECT_NE(set.find(hv3), set.end());
 }
 
 } // namespace Envoy

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -184,6 +184,7 @@ public:
                      void(Http::HeaderMap& headers,
                           const Http::AccessLog::RequestInfo& request_info));
   MOCK_CONST_METHOD0(hashPolicy, const HashPolicy*());
+  MOCK_CONST_METHOD0(metadataMatches, const Router::MetadataMatches*());
   MOCK_CONST_METHOD0(priority, Upstream::ResourcePriority());
   MOCK_CONST_METHOD0(rateLimitPolicy, const RateLimitPolicy&());
   MOCK_CONST_METHOD0(retryPolicy, const RetryPolicy&());

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -184,7 +184,7 @@ public:
                      void(Http::HeaderMap& headers,
                           const Http::AccessLog::RequestInfo& request_info));
   MOCK_CONST_METHOD0(hashPolicy, const HashPolicy*());
-  MOCK_CONST_METHOD0(metadataMatches, const Router::MetadataMatches*());
+  MOCK_CONST_METHOD0(metadataMatchCriteria, const Router::MetadataMatchCriteria*());
   MOCK_CONST_METHOD0(priority, Upstream::ResourcePriority());
   MOCK_CONST_METHOD0(rateLimitPolicy, const RateLimitPolicy&());
   MOCK_CONST_METHOD0(retryPolicy, const RetryPolicy&());


### PR DESCRIPTION
First review split off of #1735.

This provides the interface used retrieve the RouteAction `metadata_match` fields, but leaves them unimlemented for now. It also provides protobuf utilities that are used to implement using values from `metadata_match` in STL maps.