### PR TITLE
upstream: add CDS LbSubsetConfig to ClusterInfo

### DIFF
--- a/include/envoy/upstream/BUILD
+++ b/include/envoy/upstream/BUILD
@@ -60,6 +60,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "load_balancer_type_interface",
     hdrs = ["load_balancer_type.h"],
+    external_deps = ["envoy_cds"],
+    deps = [
+        "//source/common/protobuf",
+    ],
 )
 
 envoy_cc_library(

--- a/include/envoy/upstream/load_balancer_type.h
+++ b/include/envoy/upstream/load_balancer_type.h
@@ -16,15 +16,28 @@ namespace Upstream {
  */
 enum class LoadBalancerType { RoundRobin, LeastRequest, Random, RingHash, OriginalDst };
 
+/**
+ * Load Balancer subset configuration.
+ */
 class LoadBalancerSubsetInfo {
 public:
   virtual ~LoadBalancerSubsetInfo() {}
 
+  /**
+   * @return true if load balancer subsets are configured.
+   */
   virtual bool isEnabled() const PURE;
 
+  /**
+   * @return the fallback policy used when route metadata does not match any subset.
+   */
   virtual envoy::api::v2::Cluster::LbSubsetConfig::LbSubsetFallbackPolicy
   fallbackPolicy() const PURE;
 
+  /**
+   * @return a ProtobufWkt::Struct that describes the metadata for a
+   *         host to be included in the default subset.
+   */
   virtual const ProtobufWkt::Struct& defaultSubset() const PURE;
 
   /*

--- a/include/envoy/upstream/load_balancer_type.h
+++ b/include/envoy/upstream/load_balancer_type.h
@@ -1,5 +1,13 @@
 #pragma once
 
+#include <set>
+#include <string>
+#include <vector>
+
+#include "common/protobuf/protobuf.h"
+
+#include "api/cds.pb.h"
+
 namespace Envoy {
 namespace Upstream {
 
@@ -7,6 +15,24 @@ namespace Upstream {
  * Type of load balancing to perform.
  */
 enum class LoadBalancerType { RoundRobin, LeastRequest, Random, RingHash, OriginalDst };
+
+class LoadBalancerSubsetInfo {
+public:
+  virtual ~LoadBalancerSubsetInfo() {}
+
+  virtual bool isEnabled() const PURE;
+
+  virtual envoy::api::v2::Cluster::LbSubsetConfig::LbSubsetFallbackPolicy
+  fallbackPolicy() const PURE;
+
+  virtual const ProtobufWkt::Struct& defaultSubset() const PURE;
+
+  /*
+   * @return const std:vector<std:set<std::string>>& a vector of
+   * sorted keys used to define load balancer subsets.
+   */
+  virtual const std::vector<std::set<std::string>>& subsetKeys() const PURE;
+};
 
 } // namespace Upstream
 } // namespace Envoy

--- a/include/envoy/upstream/load_balancer_type.h
+++ b/include/envoy/upstream/load_balancer_type.h
@@ -24,18 +24,19 @@ public:
   virtual ~LoadBalancerSubsetInfo() {}
 
   /**
-   * @return true if load balancer subsets are configured.
+   * @return bool true if load balancer subsets are configured.
    */
   virtual bool isEnabled() const PURE;
 
   /**
-   * @return the fallback policy used when route metadata does not match any subset.
+   * @return LbSubsetFallbackPolicy the fallback policy used when
+   * route metadata does not match any subset.
    */
   virtual envoy::api::v2::Cluster::LbSubsetConfig::LbSubsetFallbackPolicy
   fallbackPolicy() const PURE;
 
   /**
-   * @return a ProtobufWkt::Struct that describes the metadata for a
+   * @return ProtobufWkt::Struct the struct describing the metadata for a
    *         host to be included in the default subset.
    */
   virtual const ProtobufWkt::Struct& defaultSubset() const PURE;

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -359,6 +359,8 @@ public:
    * @return a source address to bind to or nullptr if no bind need occur.
    */
   virtual const Network::Address::InstanceConstSharedPtr& sourceAddress() const PURE;
+
+  virtual const LoadBalancerSubsetInfo& lbSubsetInfo() const PURE;
 };
 
 typedef std::shared_ptr<const ClusterInfo> ClusterInfoConstSharedPtr;

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -360,6 +360,9 @@ public:
    */
   virtual const Network::Address::InstanceConstSharedPtr& sourceAddress() const PURE;
 
+  /**
+   * @return the configuration for load balancer subsets.
+   */
   virtual const LoadBalancerSubsetInfo& lbSubsetInfo() const PURE;
 };
 

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -278,6 +278,7 @@ envoy_cc_library(
     hdrs = ["upstream_impl.h"],
     external_deps = ["envoy_base"],
     deps = [
+        ":load_balancer_lib",
         ":outlier_detection_lib",
         ":resource_manager_lib",
         "//include/envoy/event:timer_interface",

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -137,6 +137,9 @@ public:
   HostConstSharedPtr chooseHost(const LoadBalancerContext* context) override;
 };
 
+/**
+ * Implementation of LoadBalancerSubsetInfo.
+ */
 class LoadBalancerSubsetInfoImpl : public LoadBalancerSubsetInfo {
 public:
   LoadBalancerSubsetInfoImpl(const envoy::api::v2::Cluster::LbSubsetConfig& subset_config)
@@ -151,14 +154,12 @@ public:
     }
   }
 
+  // Upstream::LoadBalancerSubsetInfo
   bool isEnabled() const override { return enabled_; }
-
   envoy::api::v2::Cluster::LbSubsetConfig::LbSubsetFallbackPolicy fallbackPolicy() const override {
     return fallback_policy_;
   }
-
   const ProtobufWkt::Struct& defaultSubset() const override { return default_subset_; }
-
   const std::vector<std::set<std::string>>& subsetKeys() const override { return subset_keys_; }
 
 private:

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -143,11 +143,11 @@ public:
 class LoadBalancerSubsetInfoImpl : public LoadBalancerSubsetInfo {
 public:
   LoadBalancerSubsetInfoImpl(const envoy::api::v2::Cluster::LbSubsetConfig& subset_config)
-      : enabled_(subset_config.subset_selectors_size() != 0),
+      : enabled_(!subset_config.subset_selectors().empty()),
         fallback_policy_(subset_config.fallback_policy()),
         default_subset_(subset_config.default_subset()) {
-    for (auto subset : subset_config.subset_selectors()) {
-      if (subset.keys_size() > 0) {
+    for (const auto& subset : subset_config.subset_selectors()) {
+      if (!subset.keys().empty()) {
         subset_keys_.emplace_back(
             std::set<std::string>(subset.keys().begin(), subset.keys().end()));
       }
@@ -163,9 +163,9 @@ public:
   const std::vector<std::set<std::string>>& subsetKeys() const override { return subset_keys_; }
 
 private:
-  bool enabled_;
-  envoy::api::v2::Cluster::LbSubsetConfig::LbSubsetFallbackPolicy fallback_policy_;
-  ProtobufWkt::Struct default_subset_;
+  const bool enabled_;
+  const envoy::api::v2::Cluster::LbSubsetConfig::LbSubsetFallbackPolicy fallback_policy_;
+  const ProtobufWkt::Struct default_subset_;
   std::vector<std::set<std::string>> subset_keys_;
 };
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -92,7 +92,8 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
       http2_settings_(Http::Utility::parseHttp2Settings(config.http2_protocol_options())),
       resource_managers_(config, runtime, name_),
       maintenance_mode_runtime_key_(fmt::format("upstream.maintenance_mode.{}", name_)),
-      source_address_(getSourceAddress(config, source_address)), added_via_api_(added_via_api) {
+      source_address_(getSourceAddress(config, source_address)), added_via_api_(added_via_api),
+      lb_subset_(LoadBalancerSubsetInfoImpl(config.lb_subset_config())) {
   ssl_ctx_ = nullptr;
   if (config.has_tls_context()) {
     Ssl::ClientContextConfigImpl context_config(config.tls_context());

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -28,6 +28,7 @@
 #include "common/config/metadata.h"
 #include "common/config/well_known_names.h"
 #include "common/stats/stats_impl.h"
+#include "common/upstream/load_balancer_impl.h"
 #include "common/upstream/outlier_detection_impl.h"
 #include "common/upstream/resource_manager_impl.h"
 
@@ -253,6 +254,7 @@ public:
   const Network::Address::InstanceConstSharedPtr& sourceAddress() const override {
     return source_address_;
   };
+  const LoadBalancerSubsetInfo& lbSubsetInfo() const override { return lb_subset_; }
 
 private:
   struct ResourceManagers {
@@ -286,6 +288,7 @@ private:
   const Network::Address::InstanceConstSharedPtr source_address_;
   LoadBalancerType lb_type_;
   const bool added_via_api_;
+  LoadBalancerSubsetInfoImpl lb_subset_;
 };
 
 /**

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -577,13 +577,11 @@ TEST(LoadBalancerSubsetInfoImplTest, SubsetConfig) {
   auto subset_value = ProtobufWkt::Value();
   subset_value.set_string_value("the value");
 
-  auto subset_selector = envoy::api::v2::Cluster::LbSubsetConfig::LbSubsetSelector();
-  subset_selector.add_keys("selector_key");
-
   auto subset_config = envoy::api::v2::Cluster::LbSubsetConfig::default_instance();
   subset_config.set_fallback_policy(envoy::api::v2::Cluster::LbSubsetConfig::DEFAULT_SUBSET);
   subset_config.mutable_default_subset()->mutable_fields()->insert({"key", subset_value});
-  subset_config.mutable_subset_selectors()->Add()->CopyFrom(subset_selector);
+  auto subset_selector = subset_config.mutable_subset_selectors()->Add();
+  subset_selector->add_keys("selector_key");
 
   auto subset_info = LoadBalancerSubsetInfoImpl(subset_config);
 

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -1,6 +1,8 @@
 #include <cstdint>
 #include <memory>
+#include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "common/network/utility.h"
@@ -559,6 +561,40 @@ TEST_F(RandomLoadBalancerTest, Normal) {
   EXPECT_CALL(random_, random()).WillOnce(Return(2)).WillOnce(Return(3));
   EXPECT_EQ(cluster_.healthy_hosts_[0], lb_.chooseHost(nullptr));
   EXPECT_EQ(cluster_.healthy_hosts_[1], lb_.chooseHost(nullptr));
+}
+
+TEST(LoadBalancerSubsetInfoImplTest, DefaultConfigIsDiabled) {
+  auto subset_info =
+      LoadBalancerSubsetInfoImpl(envoy::api::v2::Cluster::LbSubsetConfig::default_instance());
+
+  EXPECT_FALSE(subset_info.isEnabled());
+  EXPECT_TRUE(subset_info.fallbackPolicy() == envoy::api::v2::Cluster::LbSubsetConfig::NO_FALLBACK);
+  EXPECT_EQ(subset_info.defaultSubset().fields_size(), 0);
+  EXPECT_EQ(subset_info.subsetKeys().size(), 0);
+}
+
+TEST(LoadBalancerSubsetInfoImplTest, SubsetConfig) {
+  auto subset_value = ProtobufWkt::Value();
+  subset_value.set_string_value("the value");
+
+  auto subset_selector = envoy::api::v2::Cluster::LbSubsetConfig::LbSubsetSelector();
+  subset_selector.add_keys("selector_key");
+
+  auto subset_config = envoy::api::v2::Cluster::LbSubsetConfig::default_instance();
+  subset_config.set_fallback_policy(envoy::api::v2::Cluster::LbSubsetConfig::DEFAULT_SUBSET);
+  subset_config.mutable_default_subset()->mutable_fields()->insert({"key", subset_value});
+  subset_config.mutable_subset_selectors()->Add()->CopyFrom(subset_selector);
+
+  auto subset_info = LoadBalancerSubsetInfoImpl(subset_config);
+
+  EXPECT_TRUE(subset_info.isEnabled());
+  EXPECT_TRUE(subset_info.fallbackPolicy() ==
+              envoy::api::v2::Cluster::LbSubsetConfig::DEFAULT_SUBSET);
+  EXPECT_EQ(subset_info.defaultSubset().fields_size(), 1);
+  EXPECT_EQ(subset_info.defaultSubset().fields().at("key").string_value(),
+            std::string("the value"));
+  EXPECT_EQ(subset_info.subsetKeys().size(), 1);
+  EXPECT_EQ(subset_info.subsetKeys()[0], std::set<std::string>({"selector_key"}));
 }
 
 } // namespace Upstream

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -19,6 +19,21 @@ using testing::NiceMock;
 namespace Envoy {
 namespace Upstream {
 
+class MockLoadBalancerSubsetInfo : public LoadBalancerSubsetInfo {
+public:
+  MockLoadBalancerSubsetInfo();
+  ~MockLoadBalancerSubsetInfo();
+
+  // Upstream::LoadBalancerSubsetInfo
+  MOCK_CONST_METHOD0(isEnabled, bool());
+  MOCK_CONST_METHOD0(fallbackPolicy,
+                     envoy::api::v2::Cluster::LbSubsetConfig::LbSubsetFallbackPolicy());
+  MOCK_CONST_METHOD0(defaultSubset, const ProtobufWkt::Struct&());
+  MOCK_CONST_METHOD0(subsetKeys, const std::vector<std::set<std::string>>&());
+
+  std::vector<std::set<std::string>> subset_keys_;
+};
+
 class MockClusterInfo : public ClusterInfo {
 public:
   MockClusterInfo();
@@ -40,6 +55,7 @@ public:
   MOCK_CONST_METHOD0(statsScope, Stats::Scope&());
   MOCK_CONST_METHOD0(loadReportStats, ClusterLoadReportStats&());
   MOCK_CONST_METHOD0(sourceAddress, const Network::Address::InstanceConstSharedPtr&());
+  MOCK_CONST_METHOD0(lbSubsetInfo, const LoadBalancerSubsetInfo&());
 
   std::string name_{"fake_cluster"};
   Http::Http2Settings http2_settings_{};
@@ -52,6 +68,7 @@ public:
   std::unique_ptr<Upstream::ResourceManager> resource_manager_;
   Network::Address::InstanceConstSharedPtr source_address_;
   LoadBalancerType lb_type_{LoadBalancerType::RoundRobin};
+  NiceMock<MockLoadBalancerSubsetInfo> lb_subset_;
 };
 
 } // namespace Upstream

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -61,6 +61,16 @@ MockHost::MockHost() {
 
 MockHost::~MockHost() {}
 
+MockLoadBalancerSubsetInfo::MockLoadBalancerSubsetInfo() {
+  ON_CALL(*this, isEnabled()).WillByDefault(Return(false));
+  ON_CALL(*this, fallbackPolicy())
+      .WillByDefault(Return(envoy::api::v2::Cluster::LbSubsetConfig::ANY_ENDPOINT));
+  ON_CALL(*this, defaultSubset()).WillByDefault(ReturnRef(ProtobufWkt::Struct::default_instance()));
+  ON_CALL(*this, subsetKeys()).WillByDefault(ReturnRef(subset_keys_));
+}
+
+MockLoadBalancerSubsetInfo::~MockLoadBalancerSubsetInfo() {}
+
 MockClusterInfo::MockClusterInfo()
     : stats_(ClusterInfoImpl::generateStats(stats_store_)),
       load_report_stats_(ClusterInfoImpl::generateLoadReportStats(load_report_stats_store_)),
@@ -80,6 +90,7 @@ MockClusterInfo::MockClusterInfo()
           [this](ResourcePriority) -> Upstream::ResourceManager& { return *resource_manager_; }));
   ON_CALL(*this, lbType()).WillByDefault(ReturnPointee(&lb_type_));
   ON_CALL(*this, sourceAddress()).WillByDefault(ReturnRef(source_address_));
+  ON_CALL(*this, lbSubsetInfo()).WillByDefault(ReturnRef(lb_subset_));
 }
 
 MockClusterInfo::~MockClusterInfo() {}


### PR DESCRIPTION
Second PR split out of #1735.

This one adds the LbSubsetConfig data from the CDS Cluster message to the existing ClusterInfo class.