### PR TITLE
Cleanup from variable stat size

### DIFF
--- a/docs/operations/cli.rst
+++ b/docs/operations/cli.rst
@@ -116,3 +116,12 @@ following are the command line options that Envoy supports.
   *(optional)* The time in seconds that Envoy will wait before shutting down the parent process
   during a hot restart. See the :ref:`hot restart overview <arch_overview_hot_restart>` for more
   information. Defaults to 900 seconds (15 minutes).
+
+.. option:: --max-stat-name-len <uint64_t>
+
+  *(optional)* The maximum name length (in bytes) for a stat.  Instances of Envoy must have the
+  same value for this option in order to hot-restart. Defaults to 127.
+
+.. option:: --max-stats <uint64_t>
+  *(optional)* The maximum number of stats that can be shared between hot-restarts. Instances of
+  Envoy must have the same value for this option in order to hot-restart. Defaults to 16384.

--- a/docs/operations/cli.rst
+++ b/docs/operations/cli.rst
@@ -119,9 +119,11 @@ following are the command line options that Envoy supports.
 
 .. option:: --max-stat-name-len <uint64_t>
 
-  *(optional)* The maximum name length (in bytes) for a stat.  Instances of Envoy must have the
-  same value for this option in order to hot-restart. Defaults to 127.
+  *(optional)* The maximum name length (in bytes) for a stat. This setting affects the output
+  of :option:`--hot-restart-version`; the same value must be used to hot restart. Defaults to 127.
 
 .. option:: --max-stats <uint64_t>
-  *(optional)* The maximum number of stats that can be shared between hot-restarts. Instances of
-  Envoy must have the same value for this option in order to hot-restart. Defaults to 16384.
+
+  *(optional)* The maximum number of stats that can be shared between hot-restarts. This setting
+  affects the output of :option:`--hot-restart-version`; the same value must be used to hot
+  restart. Defaults to 16384.

--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -65,6 +65,35 @@ do
   kill -SIGHUP ${FIRST_SERVER_PID}
   sleep 3
 
+  # The heapchecker outputs some data to stderr on every execution.  This gets intermingled
+  # with the output from --hot-restart-version, so disable the heap-checker for these runs.
+  SAVED_HEAPCHECK=${HEAPCHECK}
+  unset HEAPCHECK
+
+  ADMIN_ADDRESS_0=`cat ${ADMIN_ADDRESS_PATH_0}`
+  ADMIN_HOT_RESTART_VERSION=`curl http://${ADMIN_ADDRESS_0}/hot_restart_version 2>/dev/null`
+  CLI_HOT_RESTART_VERSION=`${ENVOY_BIN} --hot-restart-version 2>&1`
+  if [ "${ADMIN_HOT_RESTART_VERSION}" != "${CLI_HOT_RESTART_VERSION}" ]; then
+      echo "Hot restart version mismatch: ${ADMIN_HOT_RESTART_VERSION} != ${CLI_HOT_RESTART_VERSION}"
+      exit 2
+  fi
+
+  echo "Checking max-stat-name-len"
+  CLI_HOT_RESTART_VERSION=`${ENVOY_BIN} --hot-restart-version --max-stat-name-len 1234 2>&1`
+  if [ "${ADMIN_HOT_RESTART_VERSION}" = "${CLI_HOT_RESTART_VERSION}" ]; then
+      echo "Hot restart version match when it should mismatch: ${ADMIN_HOT_RESTART_VERSION} != ${CLI_HOT_RESTART_VERSION}"
+      exit 2
+  fi
+
+  echo "Checking max-stats"
+  CLI_HOT_RESTART_VERSION=`${ENVOY_BIN} --hot-restart-version --max-stats 12345 2>&1`
+  if [ "${ADMIN_HOT_RESTART_VERSION}" = "${CLI_HOT_RESTART_VERSION}" ]; then
+      echo "Hot restart version match when it should mismatch: ${ADMIN_HOT_RESTART_VERSION} != ${CLI_HOT_RESTART_VERSION}"
+      exit 2
+  fi
+
+  HEAPCHECK=${SAVED_HEAPCHECK}
+
   echo "Starting epoch 1"
   ADMIN_ADDRESS_PATH_1="${TEST_TMPDIR}"/admin.1."${TEST_INDEX}".address
   "${ENVOY_BIN}" -c "${UPDATED_HOT_RESTART_JSON}" \

--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -70,25 +70,29 @@ do
   SAVED_HEAPCHECK=${HEAPCHECK}
   unset HEAPCHECK
 
-  ADMIN_ADDRESS_0=`cat ${ADMIN_ADDRESS_PATH_0}`
-  ADMIN_HOT_RESTART_VERSION=`curl http://${ADMIN_ADDRESS_0}/hot_restart_version 2>/dev/null`
-  CLI_HOT_RESTART_VERSION=`${ENVOY_BIN} --hot-restart-version 2>&1`
-  if [ "${ADMIN_HOT_RESTART_VERSION}" != "${CLI_HOT_RESTART_VERSION}" ]; then
-      echo "Hot restart version mismatch: ${ADMIN_HOT_RESTART_VERSION} != ${CLI_HOT_RESTART_VERSION}"
+  echo "Checking for match of --hot-restart-version and admin /hot_restart_version"
+  ADMIN_ADDRESS_0=$(cat ${ADMIN_ADDRESS_PATH_0})
+  ADMIN_HOT_RESTART_VERSION=$(curl -s http://${ADMIN_ADDRESS_0}/hot_restart_version)
+  CLI_HOT_RESTART_VERSION=$(${ENVOY_BIN} --hot-restart-version 2>&1)
+  if [[ "${ADMIN_HOT_RESTART_VERSION}" != "${CLI_HOT_RESTART_VERSION}" ]]; then
+      echo "Hot restart version mismatch: ${ADMIN_HOT_RESTART_VERSION} != " \
+           "${CLI_HOT_RESTART_VERSION}"
       exit 2
   fi
 
   echo "Checking max-stat-name-len"
-  CLI_HOT_RESTART_VERSION=`${ENVOY_BIN} --hot-restart-version --max-stat-name-len 1234 2>&1`
-  if [ "${ADMIN_HOT_RESTART_VERSION}" = "${CLI_HOT_RESTART_VERSION}" ]; then
-      echo "Hot restart version match when it should mismatch: ${ADMIN_HOT_RESTART_VERSION} != ${CLI_HOT_RESTART_VERSION}"
+  CLI_HOT_RESTART_VERSION=$(${ENVOY_BIN} --hot-restart-version --max-stat-name-len 1234 2>&1)
+  if [[ "${ADMIN_HOT_RESTART_VERSION}" = "${CLI_HOT_RESTART_VERSION}" ]]; then
+      echo "Hot restart version match when it should mismatch: ${ADMIN_HOT_RESTART_VERSION} == " \
+           "${CLI_HOT_RESTART_VERSION}"
       exit 2
   fi
 
   echo "Checking max-stats"
-  CLI_HOT_RESTART_VERSION=`${ENVOY_BIN} --hot-restart-version --max-stats 12345 2>&1`
-  if [ "${ADMIN_HOT_RESTART_VERSION}" = "${CLI_HOT_RESTART_VERSION}" ]; then
-      echo "Hot restart version match when it should mismatch: ${ADMIN_HOT_RESTART_VERSION} != ${CLI_HOT_RESTART_VERSION}"
+  CLI_HOT_RESTART_VERSION=$(${ENVOY_BIN} --hot-restart-version --max-stats 12345 2>&1)
+  if [[ "${ADMIN_HOT_RESTART_VERSION}" = "${CLI_HOT_RESTART_VERSION}" ]]; then
+      echo "Hot restart version match when it should mismatch: ${ADMIN_HOT_RESTART_VERSION} == " \
+           "${CLI_HOT_RESTART_VERSION}"
       exit 2
   fi
 

--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -71,9 +71,9 @@ do
   unset HEAPCHECK
 
   echo "Checking for match of --hot-restart-version and admin /hot_restart_version"
-  ADMIN_ADDRESS_0=$(cat ${ADMIN_ADDRESS_PATH_0})
+  ADMIN_ADDRESS_0=$(cat "${ADMIN_ADDRESS_PATH_0}")
   ADMIN_HOT_RESTART_VERSION=$(curl -s http://${ADMIN_ADDRESS_0}/hot_restart_version)
-  CLI_HOT_RESTART_VERSION=$(${ENVOY_BIN} --hot-restart-version 2>&1)
+  CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version 2>&1)
   if [[ "${ADMIN_HOT_RESTART_VERSION}" != "${CLI_HOT_RESTART_VERSION}" ]]; then
       echo "Hot restart version mismatch: ${ADMIN_HOT_RESTART_VERSION} != " \
            "${CLI_HOT_RESTART_VERSION}"
@@ -81,7 +81,7 @@ do
   fi
 
   echo "Checking max-stat-name-len"
-  CLI_HOT_RESTART_VERSION=$(${ENVOY_BIN} --hot-restart-version --max-stat-name-len 1234 2>&1)
+  CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version --max-stat-name-len 1234 2>&1)
   if [[ "${ADMIN_HOT_RESTART_VERSION}" = "${CLI_HOT_RESTART_VERSION}" ]]; then
       echo "Hot restart version match when it should mismatch: ${ADMIN_HOT_RESTART_VERSION} == " \
            "${CLI_HOT_RESTART_VERSION}"
@@ -89,7 +89,7 @@ do
   fi
 
   echo "Checking max-stats"
-  CLI_HOT_RESTART_VERSION=$(${ENVOY_BIN} --hot-restart-version --max-stats 12345 2>&1)
+  CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version --max-stats 12345 2>&1)
   if [[ "${ADMIN_HOT_RESTART_VERSION}" = "${CLI_HOT_RESTART_VERSION}" ]]; then
       echo "Hot restart version match when it should mismatch: ${ADMIN_HOT_RESTART_VERSION} == " \
            "${CLI_HOT_RESTART_VERSION}"

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -103,6 +103,7 @@ public:
     EXPECT_CALL(options_, maxStats()).WillRepeatedly(Return(num_stats_));
     EXPECT_CALL(options_, maxStatNameLength()).WillRepeatedly(Return(name_len_));
     setup();
+    EXPECT_EQ(name_len_, Stats::RawStatData::maxNameLength());
   }
 
   static const uint64_t num_stats_ = 8;


### PR DESCRIPTION
- Add an integration test that verifies the the results of --hot-restart-version and
  the corresponding value on the admin endpoint match
- Documentation for CLI flags
- Add additional check to unittest that got lost yesterday

Signed-off-by: Greg Greenway <ggreenway@apple.com>