### PR TITLE
load balancer: thread metadata matches through LoadBalancerContext

### DIFF
--- a/include/envoy/upstream/BUILD
+++ b/include/envoy/upstream/BUILD
@@ -54,7 +54,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "load_balancer_interface",
     hdrs = ["load_balancer.h"],
-    deps = [":upstream_interface"],
+    deps = [
+        ":upstream_interface",
+        "//include/envoy/router:router_interface",
+    ],
 )
 
 envoy_cc_library(

--- a/include/envoy/upstream/load_balancer.h
+++ b/include/envoy/upstream/load_balancer.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "envoy/common/pure.h"
+#include "envoy/router/router.h"
 #include "envoy/upstream/upstream.h"
 
 namespace Envoy {
@@ -21,6 +22,12 @@ public:
    * @return Optional<uint64_t> the optional hash key to use during load balancing.
    */
   virtual Optional<uint64_t> hashKey() const PURE;
+
+  /**
+   * @return Router::MetadataMatchCriteria* metadata for use in selecting a subset of hosts
+   *         during load balancing.
+   */
+  virtual const Router::MetadataMatchCriteria* metadataMatchCriteria() const PURE;
 
   /**
    * @return const Network::Connection* the incoming connection or nullptr to use during load

--- a/source/common/filter/BUILD
+++ b/source/common/filter/BUILD
@@ -47,6 +47,7 @@ envoy_cc_library(
         "//include/envoy/event:timer_interface",
         "//include/envoy/network:connection_interface",
         "//include/envoy/network:filter_interface",
+        "//include/envoy/router:router_interface",
         "//include/envoy/stats:stats_interface",
         "//include/envoy/stats:stats_macros",
         "//include/envoy/stats:timespan",

--- a/source/common/filter/tcp_proxy.h
+++ b/source/common/filter/tcp_proxy.h
@@ -102,6 +102,7 @@ public:
 
   // Upstream::LoadBalancerContext
   Optional<uint64_t> hashKey() const override { return {}; }
+  const Router::MetadataMatchCriteria* metadataMatchCriteria() const override { return nullptr; }
   const Network::Connection* downstreamConnection() const override {
     return &read_callbacks_->connection();
   }

--- a/source/common/redis/BUILD
+++ b/source/common/redis/BUILD
@@ -41,6 +41,7 @@ envoy_cc_library(
     deps = [
         ":codec_lib",
         "//include/envoy/redis:conn_pool_interface",
+        "//include/envoy/router:router_interface",
         "//include/envoy/thread_local:thread_local_interface",
         "//include/envoy/upstream:cluster_manager_interface",
         "//source/common/buffer:buffer_lib",

--- a/source/common/redis/conn_pool_impl.h
+++ b/source/common/redis/conn_pool_impl.h
@@ -157,6 +157,7 @@ private:
     // TODO(danielhochman): convert to HashUtil::xxHash64 when we have a migration strategy.
     // Upstream::LoadBalancerContext
     Optional<uint64_t> hashKey() const override { return hash_key_; }
+    const Router::MetadataMatchCriteria* metadataMatchCriteria() const override { return nullptr; }
     const Network::Connection* downstreamConnection() const override { return nullptr; }
 
     const Optional<uint64_t> hash_key_;

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1,5 +1,6 @@
 #include "common/router/config_impl.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <map>
@@ -136,6 +137,37 @@ Optional<uint64_t> HashPolicyImpl::generateHash(const std::string& downstream_ad
   return hash;
 }
 
+std::vector<MetadataMatchCriterionConstSharedPtr>
+MetadataMatchCriteriaImpl::extractMetadataMatchCriteria(const MetadataMatchCriteriaImpl* parent,
+                                                        const ProtobufWkt::Struct& matches) {
+  std::vector<MetadataMatchCriterionConstSharedPtr> v;
+  std::unordered_map<std::string, std::size_t> existing;
+
+  if (parent) {
+    for (const auto& it : parent->metadata_match_criteria_) {
+      existing.emplace(it->name(), v.size());
+      v.emplace_back(it);
+    }
+  }
+
+  // Add values from matches, replacing key/values copied from parent.
+  for (const auto it : matches.fields()) {
+    const auto index_it = existing.find(it.first);
+    if (index_it != existing.end()) {
+      v[index_it->second] = std::make_shared<MetadataMatchCriterionImpl>(it.first, it.second);
+    } else {
+      v.emplace_back(std::make_shared<MetadataMatchCriterionImpl>(it.first, it.second));
+    }
+  }
+
+  std::sort(
+      v.begin(), v.end(),
+      [](const MetadataMatchCriterionConstSharedPtr& a,
+         const MetadataMatchCriterionConstSharedPtr& b) -> bool { return a->name() < b->name(); });
+
+  return v;
+}
+
 DecoratorImpl::DecoratorImpl(const envoy::api::v2::Decorator& decorator)
     : operation_(decorator.operation()) {}
 
@@ -163,6 +195,14 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
       priority_(ConfigUtility::parsePriority(route.route().priority())),
       request_headers_parser_(RequestHeaderParser::parse(route.route().request_headers_to_add())),
       opaque_config_(parseOpaqueConfig(route)), decorator_(parseDecorator(route)) {
+  if (route.route().has_metadata_match()) {
+    const auto filter_it = route.route().metadata_match().filter_metadata().find(
+        Envoy::Config::MetadataFilters::get().ENVOY_LB);
+    if (filter_it != route.route().metadata_match().filter_metadata().end()) {
+      metadata_match_criteria_.reset(new MetadataMatchCriteriaImpl(nullptr, filter_it->second));
+    }
+  }
+
   // If this is a weighted_cluster, we create N internal route entries
   // (called WeightedClusterEntry), such that each object is a simple
   // single cluster, pointing back to the parent.
@@ -172,9 +212,21 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
 
     for (const auto& cluster : route.route().weighted_clusters().clusters()) {
       const std::string& cluster_name = cluster.name();
+
+      MetadataMatchCriteriaImplConstPtr cluster_metadata_match_criteria;
+      if (cluster.has_metadata_match()) {
+        const auto filter_it = cluster.metadata_match().filter_metadata().find(
+            Envoy::Config::MetadataFilters::get().ENVOY_LB);
+        if (filter_it != cluster.metadata_match().filter_metadata().end()) {
+          cluster_metadata_match_criteria.reset(
+              new MetadataMatchCriteriaImpl(metadata_match_criteria_.get(), filter_it->second));
+        }
+      }
+
       std::unique_ptr<WeightedClusterEntry> cluster_entry(
           new WeightedClusterEntry(this, runtime_key_prefix + "." + cluster_name, loader_,
-                                   cluster_name, PROTOBUF_GET_WRAPPED_REQUIRED(cluster, weight)));
+                                   cluster_name, PROTOBUF_GET_WRAPPED_REQUIRED(cluster, weight),
+                                   std::move(cluster_metadata_match_criteria)));
       weighted_clusters_.emplace_back(std::move(cluster_entry));
       total_weight += weighted_clusters_.back()->clusterWeight();
     }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -141,16 +141,20 @@ std::vector<MetadataMatchCriterionConstSharedPtr>
 MetadataMatchCriteriaImpl::extractMetadataMatchCriteria(const MetadataMatchCriteriaImpl* parent,
                                                         const ProtobufWkt::Struct& matches) {
   std::vector<MetadataMatchCriterionConstSharedPtr> v;
+
+  // Track locations of each name (from the parent) in v to make it
+  // easier to replace them when the same name exists in matches.
   std::unordered_map<std::string, std::size_t> existing;
 
   if (parent) {
     for (const auto& it : parent->metadata_match_criteria_) {
+      // v.size() is the index of the emplaced name.
       existing.emplace(it->name(), v.size());
       v.emplace_back(it);
     }
   }
 
-  // Add values from matches, replacing key/values copied from parent.
+  // Add values from matches, replacing name/values copied from parent.
   for (const auto it : matches.fields()) {
     const auto index_it = existing.find(it.first);
     if (index_it != existing.end()) {
@@ -160,6 +164,8 @@ MetadataMatchCriteriaImpl::extractMetadataMatchCriteria(const MetadataMatchCrite
     }
   }
 
+  // Sort criteria by name to speed matching in the subset load balancer.
+  // See source/docs/subset_load_balancer.md.
   std::sort(
       v.begin(), v.end(),
       [](const MetadataMatchCriterionConstSharedPtr& a,
@@ -199,7 +205,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
     const auto filter_it = route.route().metadata_match().filter_metadata().find(
         Envoy::Config::MetadataFilters::get().ENVOY_LB);
     if (filter_it != route.route().metadata_match().filter_metadata().end()) {
-      metadata_match_criteria_.reset(new MetadataMatchCriteriaImpl(nullptr, filter_it->second));
+      metadata_match_criteria_.reset(new MetadataMatchCriteriaImpl(filter_it->second));
     }
   }
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -226,8 +226,12 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
         const auto filter_it = cluster.metadata_match().filter_metadata().find(
             Envoy::Config::MetadataFilters::get().ENVOY_LB);
         if (filter_it != cluster.metadata_match().filter_metadata().end()) {
-          cluster_metadata_match_criteria =
-              metadata_match_criteria_->mergeMatchCriteria(filter_it->second);
+          if (metadata_match_criteria_) {
+            cluster_metadata_match_criteria =
+                metadata_match_criteria_->mergeMatchCriteria(filter_it->second);
+          } else {
+            cluster_metadata_match_criteria.reset(new MetadataMatchCriteriaImpl(filter_it->second));
+          }
         }
       }
 

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -229,6 +229,14 @@ private:
 
 class MetadataMatchCriteriaImpl : public MetadataMatchCriteria {
 public:
+  MetadataMatchCriteriaImpl(const ProtobufWkt::Struct& metadata_matches)
+      : MetadataMatchCriteriaImpl(nullptr, metadata_matches){};
+
+  /**
+   * Constructs a new MetadataMatchCriteriaImpl, merging existing
+   * metadata criteria from a parent. Metadata from the
+   * ProtobufWkt::Struct override those from the parent.
+   */
   MetadataMatchCriteriaImpl(const MetadataMatchCriteriaImpl* parent,
                             const ProtobufWkt::Struct& metadata_matches)
       : metadata_match_criteria_(extractMetadataMatchCriteria(parent, metadata_matches)){};

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -214,6 +214,39 @@ private:
   std::vector<HashMethodPtr> hash_impls_;
 };
 
+class MetadataMatchCriterionImpl : public MetadataMatchCriterion {
+public:
+  MetadataMatchCriterionImpl(const std::string& name, const HashedValue& value)
+      : name_(name), value_(value) {}
+
+  const std::string& name() const override { return name_; }
+  const HashedValue& value() const override { return value_; }
+
+private:
+  const std::string name_;
+  const HashedValue value_;
+};
+
+class MetadataMatchCriteriaImpl : public MetadataMatchCriteria {
+public:
+  MetadataMatchCriteriaImpl(const MetadataMatchCriteriaImpl* parent,
+                            const ProtobufWkt::Struct& metadata_matches)
+      : metadata_match_criteria_(extractMetadataMatchCriteria(parent, metadata_matches)){};
+
+  const std::vector<MetadataMatchCriterionConstSharedPtr>& metadataMatchCriteria() const override {
+    return metadata_match_criteria_;
+  }
+
+private:
+  static std::vector<MetadataMatchCriterionConstSharedPtr>
+  extractMetadataMatchCriteria(const MetadataMatchCriteriaImpl* parent,
+                               const ProtobufWkt::Struct& metadata_matches);
+
+  const std::vector<MetadataMatchCriterionConstSharedPtr> metadata_match_criteria_;
+};
+
+typedef std::unique_ptr<const MetadataMatchCriteriaImpl> MetadataMatchCriteriaImplConstPtr;
+
 /**
  * Implementation of Decorator that reads from the proto route decorator.
  */
@@ -255,7 +288,10 @@ public:
   void finalizeRequestHeaders(Http::HeaderMap& headers,
                               const Http::AccessLog::RequestInfo& request_info) const override;
   const HashPolicy* hashPolicy() const override { return hash_policy_.get(); }
-  const MetadataMatchCriteria* metadataMatchCriteria() const override { return nullptr; }
+
+  const MetadataMatchCriteria* metadataMatchCriteria() const override {
+    return metadata_match_criteria_.get();
+  }
   Upstream::ResourcePriority priority() const override { return priority_; }
   const RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
   const RetryPolicy& retryPolicy() const override { return retry_policy_; }
@@ -316,7 +352,9 @@ private:
     const RetryPolicy& retryPolicy() const override { return parent_->retryPolicy(); }
     const ShadowPolicy& shadowPolicy() const override { return parent_->shadowPolicy(); }
     std::chrono::milliseconds timeout() const override { return parent_->timeout(); }
-    const MetadataMatchCriteria* metadataMatchCriteria() const override { return nullptr; }
+    const MetadataMatchCriteria* metadataMatchCriteria() const override {
+      return parent_->metadataMatchCriteria();
+    }
 
     const VirtualCluster* virtualCluster(const Http::HeaderMap& headers) const override {
       return parent_->virtualCluster(headers);
@@ -347,17 +385,26 @@ private:
    * Route entry implementation for weighted clusters. The RouteEntryImplBase object holds
    * one or more weighted cluster objects, where each object has a back pointer to the parent
    * RouteEntryImplBase object. Almost all functions in this class forward calls back to the
-   * parent, with the exception of clusterName and routeEntry.
+   * parent, with the exception of clusterName, routeEntry, and metadataMatchCriteria.
    */
   class WeightedClusterEntry : public DynamicRouteEntry {
   public:
     WeightedClusterEntry(const RouteEntryImplBase* parent, const std::string runtime_key,
-                         Runtime::Loader& loader, const std::string& name, uint64_t weight)
+                         Runtime::Loader& loader, const std::string& name, uint64_t weight,
+                         MetadataMatchCriteriaImplConstPtr cluster_metadata_match_criteria)
         : DynamicRouteEntry(parent, name), runtime_key_(runtime_key), loader_(loader),
-          cluster_weight_(weight) {}
+          cluster_weight_(weight),
+          cluster_metadata_match_criteria_(std::move(cluster_metadata_match_criteria)) {}
 
     uint64_t clusterWeight() const {
       return loader_.snapshot().getInteger(runtime_key_, cluster_weight_);
+    }
+
+    const MetadataMatchCriteria* metadataMatchCriteria() const override {
+      if (cluster_metadata_match_criteria_) {
+        return cluster_metadata_match_criteria_.get();
+      }
+      return DynamicRouteEntry::metadataMatchCriteria();
     }
 
     static const uint64_t MAX_CLUSTER_WEIGHT;
@@ -366,6 +413,7 @@ private:
     const std::string runtime_key_;
     Runtime::Loader& loader_;
     const uint64_t cluster_weight_;
+    MetadataMatchCriteriaImplConstPtr cluster_metadata_match_criteria_;
   };
 
   typedef std::shared_ptr<WeightedClusterEntry> WeightedClusterEntrySharedPtr;
@@ -399,6 +447,7 @@ private:
   std::vector<ConfigUtility::HeaderData> config_headers_;
   std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
   std::unique_ptr<const HashPolicyImpl> hash_policy_;
+  MetadataMatchCriteriaImplConstPtr metadata_match_criteria_;
   std::list<std::pair<Http::LowerCaseString, std::string>> request_headers_to_add_;
   RequestHeaderParserPtr request_headers_parser_;
 

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -134,6 +134,12 @@ public:
     }
     return {};
   }
+  const Router::MetadataMatchCriteria* metadataMatchCriteria() const override {
+    if (route_entry_) {
+      return route_entry_->metadataMatchCriteria();
+    }
+    return nullptr;
+  }
   const Network::Connection* downstreamConnection() const override {
     return callbacks_->connection();
   }

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4,7 +4,9 @@
 #include <memory>
 #include <string>
 
+#include "common/config/metadata.h"
 #include "common/config/rds_json.h"
+#include "common/config/well_known_names.h"
 #include "common/http/header_map_impl.h"
 #include "common/http/headers.h"
 #include "common/json/json_loader.h"
@@ -2558,9 +2560,9 @@ TEST(CustomRequestHeadersTest, AddNewHeader) {
               {
                 "key": "x-client-ip",
                 "value": "%CLIENT_IP%"
-              }  
+              }
             ]
-          }  
+          }
         ]
       }
     ],
@@ -2633,6 +2635,197 @@ TEST(CustomRequestHeadersTest, CustomHeaderWrongFormat) {
       ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true), EnvoyException,
       "Incorrect header configuration. Expected variable format %<variable_name>%, actual format "
       "%CLIENT_IP");
+}
+
+TEST(MetadataMatchCriteriaImpl, Create) {
+  auto v1 = ProtobufWkt::Value();
+  v1.set_string_value("v1");
+  auto v2 = ProtobufWkt::Value();
+  v2.set_number_value(2.0);
+  auto v3 = ProtobufWkt::Value();
+  v3.set_bool_value(true);
+
+  auto metadata_struct = ProtobufWkt::Struct();
+  auto mutable_fields = metadata_struct.mutable_fields();
+  mutable_fields->insert({"a", v1});
+  mutable_fields->insert({"b", v2});
+  mutable_fields->insert({"c", v3});
+
+  auto matches = MetadataMatchCriteriaImpl(nullptr, metadata_struct);
+
+  EXPECT_EQ(matches.metadataMatchCriteria().size(), 3);
+  auto it = matches.metadataMatchCriteria().begin();
+  EXPECT_EQ((*it)->name(), std::string("a"));
+  EXPECT_EQ((*it)->value().value().string_value(), std::string("v1"));
+  it++;
+
+  EXPECT_EQ((*it)->name(), std::string("b"));
+  EXPECT_EQ((*it)->value().value().number_value(), 2.0);
+  it++;
+
+  EXPECT_EQ((*it)->name(), std::string("c"));
+  EXPECT_EQ((*it)->value().value().bool_value(), true);
+}
+
+TEST(MetadataMatchCriteriaImpl, CreateWithParent) {
+  auto pv1 = ProtobufWkt::Value();
+  pv1.set_string_value("v1");
+  auto pv2 = ProtobufWkt::Value();
+  pv2.set_number_value(2.0);
+  auto pv3 = ProtobufWkt::Value();
+  pv3.set_bool_value(true);
+
+  auto parent_struct = ProtobufWkt::Struct();
+  auto parent_fields = parent_struct.mutable_fields();
+  parent_fields->insert({"a", pv1});
+  parent_fields->insert({"b", pv2});
+  parent_fields->insert({"c", pv3});
+
+  auto parent_matches = MetadataMatchCriteriaImpl(nullptr, parent_struct);
+
+  auto v1 = ProtobufWkt::Value();
+  v1.set_string_value("override1");
+  auto v2 = ProtobufWkt::Value();
+  v2.set_string_value("v2");
+  auto v3 = ProtobufWkt::Value();
+  v3.set_string_value("override3");
+
+  auto metadata_struct = ProtobufWkt::Struct();
+  auto mutable_fields = metadata_struct.mutable_fields();
+  mutable_fields->insert({"a", v1});
+  mutable_fields->insert({"b++", v2});
+  mutable_fields->insert({"c", v3});
+
+  auto matches = MetadataMatchCriteriaImpl(&parent_matches, metadata_struct);
+
+  EXPECT_EQ(matches.metadataMatchCriteria().size(), 4);
+  auto it = matches.metadataMatchCriteria().begin();
+  EXPECT_EQ((*it)->name(), std::string("a"));
+  EXPECT_EQ((*it)->value().value().string_value(), std::string("override1"));
+  it++;
+
+  EXPECT_EQ((*it)->name(), std::string("b"));
+  EXPECT_EQ((*it)->value().value().number_value(), 2.0);
+  it++;
+
+  EXPECT_EQ((*it)->name(), std::string("b++"));
+  EXPECT_EQ((*it)->value().value().string_value(), "v2");
+  it++;
+
+  EXPECT_EQ((*it)->name(), std::string("c"));
+  EXPECT_EQ((*it)->value().value().string_value(), std::string("override3"));
+}
+
+TEST(RoutEntryMetadataMatchTest, ParsesMetadata) {
+  auto route_config = envoy::api::v2::RouteConfiguration();
+  auto* vhost = route_config.add_virtual_hosts();
+  vhost->set_name("vhost");
+  vhost->add_domains("www.lyft.com");
+
+  // route provides metadata matches combined from RouteAction and WeightedCluster
+  auto* route = vhost->add_routes();
+  route->mutable_match()->set_prefix("/both");
+  auto* route_action = route->mutable_route();
+  auto* weighted_cluster = route_action->mutable_weighted_clusters()->add_clusters();
+  weighted_cluster->set_name("www1");
+  weighted_cluster->mutable_weight()->set_value(100);
+  Envoy::Config::Metadata::mutableMetadataValue(*weighted_cluster->mutable_metadata_match(),
+                                                Envoy::Config::MetadataFilters::get().ENVOY_LB,
+                                                "r1_wc_key")
+      .set_string_value("r1_wc_value");
+  Envoy::Config::Metadata::mutableMetadataValue(*route_action->mutable_metadata_match(),
+                                                Envoy::Config::MetadataFilters::get().ENVOY_LB,
+                                                "r1_key")
+      .set_string_value("r1_value");
+
+  // route provides metadata matches from WeightedCluster only
+  route = vhost->add_routes();
+  route->mutable_match()->set_prefix("/cluster-only");
+  route_action = route->mutable_route();
+  weighted_cluster = route_action->mutable_weighted_clusters()->add_clusters();
+  weighted_cluster->set_name("www2");
+  weighted_cluster->mutable_weight()->set_value(100);
+  Envoy::Config::Metadata::mutableMetadataValue(*weighted_cluster->mutable_metadata_match(),
+                                                Envoy::Config::MetadataFilters::get().ENVOY_LB,
+                                                "r2_wc_key")
+      .set_string_value("r2_wc_value");
+
+  // route provides metadata matches from RouteAction only
+  route = vhost->add_routes();
+  route->mutable_match()->set_prefix("/route-only");
+  route_action = route->mutable_route();
+  route_action->set_cluster("www3");
+  Envoy::Config::Metadata::mutableMetadataValue(*route_action->mutable_metadata_match(),
+                                                Envoy::Config::MetadataFilters::get().ENVOY_LB,
+                                                "r3_key")
+      .set_string_value("r3_value");
+
+  // route provides metadata matches from RouteAction (but WeightedCluster exists)
+  route = vhost->add_routes();
+  route->mutable_match()->set_prefix("/cluster-passthrough");
+  route_action = route->mutable_route();
+  weighted_cluster = route_action->mutable_weighted_clusters()->add_clusters();
+  weighted_cluster->set_name("www4");
+  weighted_cluster->mutable_weight()->set_value(100);
+  Envoy::Config::Metadata::mutableMetadataValue(*route_action->mutable_metadata_match(),
+                                                Envoy::Config::MetadataFilters::get().ENVOY_LB,
+                                                "r4_key")
+      .set_string_value("r4_value");
+
+  NiceMock<Runtime::MockLoader> runtime;
+  NiceMock<Upstream::MockClusterManager> cm;
+  ConfigImpl config(route_config, runtime, cm, true);
+
+  {
+    Http::TestHeaderMapImpl headers = genRedirectHeaders("www.lyft.com", "/both", true, true);
+    EXPECT_EQ(nullptr, config.route(headers, 0)->redirectEntry());
+
+    auto* route_entry = config.route(headers, 0)->routeEntry();
+    EXPECT_EQ("www1", route_entry->clusterName());
+    auto* matches = route_entry->metadataMatchCriteria();
+    EXPECT_NE(matches, nullptr);
+    EXPECT_EQ(matches->metadataMatchCriteria().size(), 2);
+    EXPECT_EQ(matches->metadataMatchCriteria().at(0)->name(), std::string("r1_key"));
+    EXPECT_EQ(matches->metadataMatchCriteria().at(1)->name(), std::string("r1_wc_key"));
+  }
+
+  {
+    Http::TestHeaderMapImpl headers =
+        genRedirectHeaders("www.lyft.com", "/cluster-only", true, true);
+    EXPECT_EQ(nullptr, config.route(headers, 0)->redirectEntry());
+
+    auto* route_entry = config.route(headers, 0)->routeEntry();
+    EXPECT_EQ("www2", route_entry->clusterName());
+    auto* matches = route_entry->metadataMatchCriteria();
+    EXPECT_NE(matches, nullptr);
+    EXPECT_EQ(matches->metadataMatchCriteria().size(), 1);
+    EXPECT_EQ(matches->metadataMatchCriteria().at(0)->name(), std::string("r2_wc_key"));
+  }
+
+  {
+    Http::TestHeaderMapImpl headers = genRedirectHeaders("www.lyft.com", "/route-only", true, true);
+    EXPECT_EQ(nullptr, config.route(headers, 0)->redirectEntry());
+
+    auto* route_entry = config.route(headers, 0)->routeEntry();
+    EXPECT_EQ("www3", route_entry->clusterName());
+    auto* matches = route_entry->metadataMatchCriteria();
+    EXPECT_NE(matches, nullptr);
+    EXPECT_EQ(matches->metadataMatchCriteria().size(), 1);
+    EXPECT_EQ(matches->metadataMatchCriteria().at(0)->name(), std::string("r3_key"));
+  }
+
+  {
+    Http::TestHeaderMapImpl headers =
+        genRedirectHeaders("www.lyft.com", "/cluster-passthrough", true, true);
+    EXPECT_EQ(nullptr, config.route(headers, 0)->redirectEntry());
+
+    auto* route_entry = config.route(headers, 0)->routeEntry();
+    EXPECT_EQ("www4", route_entry->clusterName());
+    auto* matches = route_entry->metadataMatchCriteria();
+    EXPECT_NE(matches, nullptr);
+    EXPECT_EQ(matches->metadataMatchCriteria().size(), 1);
+    EXPECT_EQ(matches->metadataMatchCriteria().at(0)->name(), std::string("r4_key"));
+  }
 }
 
 } // namespace

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2655,15 +2655,15 @@ TEST(MetadataMatchCriteriaImpl, Create) {
 
   EXPECT_EQ(matches.metadataMatchCriteria().size(), 3);
   auto it = matches.metadataMatchCriteria().begin();
-  EXPECT_EQ((*it)->name(), std::string("a"));
-  EXPECT_EQ((*it)->value().value().string_value(), std::string("v1"));
+  EXPECT_EQ((*it)->name(), "a");
+  EXPECT_EQ((*it)->value().value().string_value(), "v1");
   it++;
 
-  EXPECT_EQ((*it)->name(), std::string("b"));
+  EXPECT_EQ((*it)->name(), "b");
   EXPECT_EQ((*it)->value().value().number_value(), 2.0);
   it++;
 
-  EXPECT_EQ((*it)->name(), std::string("c"));
+  EXPECT_EQ((*it)->name(), "c");
   EXPECT_EQ((*it)->value().value().bool_value(), true);
 }
 
@@ -2700,20 +2700,20 @@ TEST(MetadataMatchCriteriaImpl, Merge) {
 
   EXPECT_EQ(matches->metadataMatchCriteria().size(), 4);
   auto it = matches->metadataMatchCriteria().begin();
-  EXPECT_EQ((*it)->name(), std::string("a"));
-  EXPECT_EQ((*it)->value().value().string_value(), std::string("override1"));
+  EXPECT_EQ((*it)->name(), "a");
+  EXPECT_EQ((*it)->value().value().string_value(), "override1");
   it++;
 
-  EXPECT_EQ((*it)->name(), std::string("b"));
+  EXPECT_EQ((*it)->name(), "b");
   EXPECT_EQ((*it)->value().value().number_value(), 2.0);
   it++;
 
-  EXPECT_EQ((*it)->name(), std::string("b++"));
+  EXPECT_EQ((*it)->name(), "b++");
   EXPECT_EQ((*it)->value().value().string_value(), "v2");
   it++;
 
-  EXPECT_EQ((*it)->name(), std::string("c"));
-  EXPECT_EQ((*it)->value().value().string_value(), std::string("override3"));
+  EXPECT_EQ((*it)->name(), "c");
+  EXPECT_EQ((*it)->value().value().string_value(), "override3");
 }
 
 TEST(RoutEntryMetadataMatchTest, ParsesMetadata) {
@@ -2785,8 +2785,8 @@ TEST(RoutEntryMetadataMatchTest, ParsesMetadata) {
     auto* matches = route_entry->metadataMatchCriteria();
     EXPECT_NE(matches, nullptr);
     EXPECT_EQ(matches->metadataMatchCriteria().size(), 2);
-    EXPECT_EQ(matches->metadataMatchCriteria().at(0)->name(), std::string("r1_key"));
-    EXPECT_EQ(matches->metadataMatchCriteria().at(1)->name(), std::string("r1_wc_key"));
+    EXPECT_EQ(matches->metadataMatchCriteria().at(0)->name(), "r1_key");
+    EXPECT_EQ(matches->metadataMatchCriteria().at(1)->name(), "r1_wc_key");
   }
 
   {
@@ -2799,7 +2799,7 @@ TEST(RoutEntryMetadataMatchTest, ParsesMetadata) {
     auto* matches = route_entry->metadataMatchCriteria();
     EXPECT_NE(matches, nullptr);
     EXPECT_EQ(matches->metadataMatchCriteria().size(), 1);
-    EXPECT_EQ(matches->metadataMatchCriteria().at(0)->name(), std::string("r2_wc_key"));
+    EXPECT_EQ(matches->metadataMatchCriteria().at(0)->name(), "r2_wc_key");
   }
 
   {
@@ -2811,7 +2811,7 @@ TEST(RoutEntryMetadataMatchTest, ParsesMetadata) {
     auto* matches = route_entry->metadataMatchCriteria();
     EXPECT_NE(matches, nullptr);
     EXPECT_EQ(matches->metadataMatchCriteria().size(), 1);
-    EXPECT_EQ(matches->metadataMatchCriteria().at(0)->name(), std::string("r3_key"));
+    EXPECT_EQ(matches->metadataMatchCriteria().at(0)->name(), "r3_key");
   }
 
   {
@@ -2824,7 +2824,7 @@ TEST(RoutEntryMetadataMatchTest, ParsesMetadata) {
     auto* matches = route_entry->metadataMatchCriteria();
     EXPECT_NE(matches, nullptr);
     EXPECT_EQ(matches->metadataMatchCriteria().size(), 1);
-    EXPECT_EQ(matches->metadataMatchCriteria().at(0)->name(), std::string("r4_key"));
+    EXPECT_EQ(matches->metadataMatchCriteria().at(0)->name(), "r4_key");
   }
 }
 

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2651,7 +2651,7 @@ TEST(MetadataMatchCriteriaImpl, Create) {
   mutable_fields->insert({"b", v2});
   mutable_fields->insert({"c", v3});
 
-  auto matches = MetadataMatchCriteriaImpl(nullptr, metadata_struct);
+  auto matches = MetadataMatchCriteriaImpl(metadata_struct);
 
   EXPECT_EQ(matches.metadataMatchCriteria().size(), 3);
   auto it = matches.metadataMatchCriteria().begin();
@@ -2667,7 +2667,7 @@ TEST(MetadataMatchCriteriaImpl, Create) {
   EXPECT_EQ((*it)->value().value().bool_value(), true);
 }
 
-TEST(MetadataMatchCriteriaImpl, CreateWithParent) {
+TEST(MetadataMatchCriteriaImpl, Merge) {
   auto pv1 = ProtobufWkt::Value();
   pv1.set_string_value("v1");
   auto pv2 = ProtobufWkt::Value();
@@ -2681,7 +2681,7 @@ TEST(MetadataMatchCriteriaImpl, CreateWithParent) {
   parent_fields->insert({"b", pv2});
   parent_fields->insert({"c", pv3});
 
-  auto parent_matches = MetadataMatchCriteriaImpl(nullptr, parent_struct);
+  auto parent_matches = MetadataMatchCriteriaImpl(parent_struct);
 
   auto v1 = ProtobufWkt::Value();
   v1.set_string_value("override1");
@@ -2696,10 +2696,10 @@ TEST(MetadataMatchCriteriaImpl, CreateWithParent) {
   mutable_fields->insert({"b++", v2});
   mutable_fields->insert({"c", v3});
 
-  auto matches = MetadataMatchCriteriaImpl(&parent_matches, metadata_struct);
+  MetadataMatchCriteriaImplConstPtr matches = parent_matches.mergeMatchCriteria(metadata_struct);
 
-  EXPECT_EQ(matches.metadataMatchCriteria().size(), 4);
-  auto it = matches.metadataMatchCriteria().begin();
+  EXPECT_EQ(matches->metadataMatchCriteria().size(), 4);
+  auto it = matches->metadataMatchCriteria().begin();
   EXPECT_EQ((*it)->name(), std::string("a"));
   EXPECT_EQ((*it)->value().value().string_value(), std::string("override1"));
   it++;

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -213,6 +213,52 @@ TEST_F(RouterTest, HashPolicyNoHash) {
   EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
 }
 
+TEST_F(RouterTest, MetadataMatchCriteria) {
+  MockMetadataMatchCriteria matches;
+
+  ON_CALL(callbacks_.route_->route_entry_, metadataMatchCriteria())
+      .WillByDefault(Return(&callbacks_.route_->route_entry_.metadata_matches_criteria_));
+  EXPECT_CALL(cm_, httpConnPoolForCluster(_, _, _))
+      .WillOnce(
+          Invoke([&](const std::string&, Upstream::ResourcePriority,
+                     Upstream::LoadBalancerContext* context) -> Http::ConnectionPool::Instance* {
+            EXPECT_EQ(context->metadataMatchCriteria(),
+                      &callbacks_.route_->route_entry_.metadata_matches_criteria_);
+            return &cm_.conn_pool_;
+          }));
+  EXPECT_CALL(cm_.conn_pool_, newStream(_, _)).WillOnce(Return(&cancellable_));
+  expectResponseTimerCreate();
+
+  Http::TestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  router_.decodeHeaders(headers, true);
+
+  // When the router filter gets reset we should cancel the pool request.
+  EXPECT_CALL(cancellable_, cancel());
+  router_.onDestroy();
+}
+
+TEST_F(RouterTest, NoMetadataMatchCriteria) {
+  ON_CALL(callbacks_.route_->route_entry_, metadataMatchCriteria()).WillByDefault(Return(nullptr));
+  EXPECT_CALL(cm_, httpConnPoolForCluster(_, _, _))
+      .WillOnce(
+          Invoke([&](const std::string&, Upstream::ResourcePriority,
+                     Upstream::LoadBalancerContext* context) -> Http::ConnectionPool::Instance* {
+            EXPECT_EQ(context->metadataMatchCriteria(), nullptr);
+            return &cm_.conn_pool_;
+          }));
+  EXPECT_CALL(cm_.conn_pool_, newStream(_, _)).WillOnce(Return(&cancellable_));
+  expectResponseTimerCreate();
+
+  Http::TestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  router_.decodeHeaders(headers, true);
+
+  // When the router filter gets reset we should cancel the pool request.
+  EXPECT_CALL(cancellable_, cancel());
+  router_.onDestroy();
+}
+
 TEST_F(RouterTest, CancelBeforeBoundToPool) {
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _)).WillOnce(Return(&cancellable_));
   expectResponseTimerCreate();

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -38,6 +38,7 @@ public:
   // Upstream::LoadBalancerContext
   Optional<uint64_t> hashKey() const override { return 0; }
   const Network::Connection* downstreamConnection() const override { return connection_; }
+  const Router::MetadataMatchCriteria* metadataMatchCriteria() const override { return nullptr; }
 
   Optional<uint64_t> hash_key_;
   const Network::Connection* connection_;

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -1,6 +1,8 @@
 #include <cstdint>
 #include <string>
 
+#include "envoy/router/router.h"
+
 #include "common/network/utility.h"
 #include "common/upstream/ring_hash_lb.h"
 #include "common/upstream/upstream_impl.h"
@@ -25,6 +27,7 @@ public:
 
   // Upstream::LoadBalancerContext
   Optional<uint64_t> hashKey() const override { return hash_key_; }
+  const Router::MetadataMatchCriteria* metadataMatchCriteria() const override { return nullptr; }
   const Network::Connection* downstreamConnection() const override { return nullptr; }
 
   Optional<uint64_t> hash_key_;

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -52,6 +52,9 @@ MockVirtualHost::~MockVirtualHost() {}
 MockHashPolicy::MockHashPolicy() {}
 MockHashPolicy::~MockHashPolicy() {}
 
+MockMetadataMatchCriteria::MockMetadataMatchCriteria() {}
+MockMetadataMatchCriteria::~MockMetadataMatchCriteria() {}
+
 MockRouteEntry::MockRouteEntry() {
   ON_CALL(*this, clusterName()).WillByDefault(ReturnRef(cluster_name_));
   ON_CALL(*this, opaqueConfig()).WillByDefault(ReturnRef(opaque_config_));

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -173,6 +173,16 @@ public:
                                                       const Http::HeaderMap& headers));
 };
 
+class MockMetadataMatchCriteria : public MetadataMatchCriteria {
+public:
+  MockMetadataMatchCriteria();
+  ~MockMetadataMatchCriteria();
+
+  // Router::MetadataMatchCriteria
+  MOCK_CONST_METHOD0(metadataMatchCriteria,
+                     const std::vector<MetadataMatchCriterionConstSharedPtr>&());
+};
+
 class MockRouteEntry : public RouteEntry {
 public:
   MockRouteEntry();
@@ -207,6 +217,7 @@ public:
   TestShadowPolicy shadow_policy_;
   testing::NiceMock<MockVirtualHost> virtual_host_;
   MockHashPolicy hash_policy_;
+  MockMetadataMatchCriteria metadata_matches_criteria_;
   TestCorsPolicy cors_policy_;
 };
 


### PR DESCRIPTION
3rd of 4 reviews split out from #1735.

Router::MetadataMatchCriteria is implemented. Instances of the implementation are created when a route's RouteAction has an "envoy.lb" section in metadata_match values. These are merged with additional "envoy.lb" metadata_match values from the WeightedCluster, if any. In the event of a collision, the WeightedCluster keys take precedence.

The LoadBalancerContext interface is modified to allow MetadataMatchCriteria to be accessed by load balancers. Router::Filter's implementation of the LoadBalancerContext is updated to return the selected route's criteria, if any.