### PR TITLE
http: make HeaderMap iteration exit early and add reverse iteration

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -358,7 +358,7 @@ public:
    */
   virtual const HeaderEntry* get(const LowerCaseString& key) const PURE;
 
-  // aliases to make iterate() callbacks easier to read
+  // aliases to make iterate() and iterateReverse() callbacks easier to read
   static const bool Continue = true;
   static const bool Break = false;
 
@@ -376,6 +376,13 @@ public:
    * @param context supplies the context that will be passed to the callback.
    */
   virtual void iterate(ConstIterateCb cb, void* context) const PURE;
+
+  /**
+   * Iterate over a constant header map in reverse order.
+   * @param cb supplies the iteration callback.
+   * @param context supplies the context that will be passed to the callback.
+   */
+  virtual void iterateReverse(ConstIterateCb cb, void* context) const PURE;
 
   /**
    * Remove all instances of a header by key.

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -365,7 +365,7 @@ public:
    * Callback when calling iterate() over a const header map.
    * @param header supplies the header entry.
    * @param context supplies the context passed to iterate().
-   * @return true to continue iteration.
+   * @return Iterate::Continue to continue iteration.
    */
   typedef Iterate (*ConstIterateCb)(const HeaderEntry& header, void* context);
 

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -358,12 +358,17 @@ public:
    */
   virtual const HeaderEntry* get(const LowerCaseString& key) const PURE;
 
+  // aliases to make iterate() callbacks easier to read
+  static const bool Continue = true;
+  static const bool Break = false;
+
   /**
    * Callback when calling iterate() over a const header map.
    * @param header supplies the header entry.
    * @param context supplies the context passed to iterate().
+   * @return true to continue iteration.
    */
-  typedef void (*ConstIterateCb)(const HeaderEntry& header, void* context);
+  typedef bool (*ConstIterateCb)(const HeaderEntry& header, void* context);
 
   /**
    * Iterate over a constant header map.

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -359,8 +359,7 @@ public:
   virtual const HeaderEntry* get(const LowerCaseString& key) const PURE;
 
   // aliases to make iterate() and iterateReverse() callbacks easier to read
-  static const bool Continue = true;
-  static const bool Break = false;
+  enum class Iterate { Continue, Break };
 
   /**
    * Callback when calling iterate() over a const header map.
@@ -368,7 +367,7 @@ public:
    * @param context supplies the context passed to iterate().
    * @return true to continue iteration.
    */
-  typedef bool (*ConstIterateCb)(const HeaderEntry& header, void* context);
+  typedef Iterate (*ConstIterateCb)(const HeaderEntry& header, void* context);
 
   /**
    * Iterate over a constant header map.

--- a/source/common/grpc/grpc_web_filter.cc
+++ b/source/common/grpc/grpc_web_filter.cc
@@ -175,12 +175,13 @@ Http::FilterTrailersStatus GrpcWebFilter::encodeTrailers(Http::HeaderMap& traile
   // Trailers in the trailers frame are separated by CRLFs.
   Buffer::OwnedImpl temp;
   trailers.iterate(
-      [](const Http::HeaderEntry& header, void* context) -> void {
+      [](const Http::HeaderEntry& header, void* context) -> bool {
         Buffer::Instance* temp = static_cast<Buffer::Instance*>(context);
         temp->add(header.key().c_str(), header.key().size());
         temp->add(":");
         temp->add(header.value().c_str(), header.value().size());
         temp->add("\r\n");
+        return Http::HeaderMap::Continue;
       },
       &temp);
   Buffer::OwnedImpl buffer;

--- a/source/common/grpc/grpc_web_filter.cc
+++ b/source/common/grpc/grpc_web_filter.cc
@@ -175,13 +175,13 @@ Http::FilterTrailersStatus GrpcWebFilter::encodeTrailers(Http::HeaderMap& traile
   // Trailers in the trailers frame are separated by CRLFs.
   Buffer::OwnedImpl temp;
   trailers.iterate(
-      [](const Http::HeaderEntry& header, void* context) -> bool {
+      [](const Http::HeaderEntry& header, void* context) -> Http::HeaderMap::Iterate {
         Buffer::Instance* temp = static_cast<Buffer::Instance*>(context);
         temp->add(header.key().c_str(), header.key().size());
         temp->add(":");
         temp->add(header.value().c_str(), header.value().size());
         temp->add("\r\n");
-        return Http::HeaderMap::Continue;
+        return Http::HeaderMap::Iterate::Continue;
       },
       &temp);
   Buffer::OwnedImpl buffer;

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -76,8 +76,9 @@ void AsyncStreamImpl::encodeHeaders(HeaderMapPtr&& headers, bool end_stream) {
 #ifndef NVLOG
   ENVOY_LOG(debug, "async http request response headers (end_stream={}):", end_stream);
   headers->iterate(
-      [](const HeaderEntry& header, void*) -> void {
+      [](const HeaderEntry& header, void*) -> bool {
         ENVOY_LOG(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());
+        return HeaderMap::Continue;
       },
       nullptr);
 #endif
@@ -98,8 +99,9 @@ void AsyncStreamImpl::encodeTrailers(HeaderMapPtr&& trailers) {
 #ifndef NVLOG
   ENVOY_LOG(debug, "async http request response trailers:");
   trailers->iterate(
-      [](const HeaderEntry& header, void*) -> void {
+      [](const HeaderEntry& header, void*) -> bool {
         ENVOY_LOG(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());
+        return HeaderMap::Continue;
       },
       nullptr);
 #endif

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -76,9 +76,9 @@ void AsyncStreamImpl::encodeHeaders(HeaderMapPtr&& headers, bool end_stream) {
 #ifndef NVLOG
   ENVOY_LOG(debug, "async http request response headers (end_stream={}):", end_stream);
   headers->iterate(
-      [](const HeaderEntry& header, void*) -> bool {
+      [](const HeaderEntry& header, void*) -> HeaderMap::Iterate {
         ENVOY_LOG(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());
-        return HeaderMap::Continue;
+        return HeaderMap::Iterate::Continue;
       },
       nullptr);
 #endif
@@ -99,9 +99,9 @@ void AsyncStreamImpl::encodeTrailers(HeaderMapPtr&& trailers) {
 #ifndef NVLOG
   ENVOY_LOG(debug, "async http request response trailers:");
   trailers->iterate(
-      [](const HeaderEntry& header, void*) -> bool {
+      [](const HeaderEntry& header, void*) -> HeaderMap::Iterate {
         ENVOY_LOG(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());
-        return HeaderMap::Continue;
+        return HeaderMap::Iterate::Continue;
       },
       nullptr);
 #endif

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -440,9 +440,10 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
   ENVOY_STREAM_LOG(debug, "request headers complete (end_stream={}):", *this, end_stream);
 #ifndef NVLOG
   request_headers_->iterate(
-      [](const HeaderEntry& header, void* context) -> void {
+      [](const HeaderEntry& header, void* context) -> bool {
         ENVOY_STREAM_LOG(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
                          header.key().c_str(), header.value().c_str());
+        return HeaderMap::Continue;
       },
       this);
 #endif
@@ -791,9 +792,10 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
                    end_stream && continue_data_entry == encoder_filters_.end());
 #ifndef NVLOG
   headers.iterate(
-      [](const HeaderEntry& header, void* context) -> void {
+      [](const HeaderEntry& header, void* context) -> bool {
         ENVOY_STREAM_LOG(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
                          header.key().c_str(), header.value().c_str());
+        return HeaderMap::Continue;
       },
       this);
 #endif
@@ -874,9 +876,10 @@ void ConnectionManagerImpl::ActiveStream::encodeTrailers(ActiveStreamEncoderFilt
   ENVOY_STREAM_LOG(debug, "encoding trailers via codec", *this);
 #ifndef NVLOG
   trailers.iterate(
-      [](const HeaderEntry& header, void* context) -> void {
+      [](const HeaderEntry& header, void* context) -> bool {
         ENVOY_STREAM_LOG(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
                          header.key().c_str(), header.value().c_str());
+        return HeaderMap::Continue;
       },
       this);
 #endif

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -440,10 +440,10 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
   ENVOY_STREAM_LOG(debug, "request headers complete (end_stream={}):", *this, end_stream);
 #ifndef NVLOG
   request_headers_->iterate(
-      [](const HeaderEntry& header, void* context) -> bool {
+      [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {
         ENVOY_STREAM_LOG(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
                          header.key().c_str(), header.value().c_str());
-        return HeaderMap::Continue;
+        return HeaderMap::Iterate::Continue;
       },
       this);
 #endif
@@ -792,10 +792,10 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
                    end_stream && continue_data_entry == encoder_filters_.end());
 #ifndef NVLOG
   headers.iterate(
-      [](const HeaderEntry& header, void* context) -> bool {
+      [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {
         ENVOY_STREAM_LOG(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
                          header.key().c_str(), header.value().c_str());
-        return HeaderMap::Continue;
+        return HeaderMap::Iterate::Continue;
       },
       this);
 #endif
@@ -876,10 +876,10 @@ void ConnectionManagerImpl::ActiveStream::encodeTrailers(ActiveStreamEncoderFilt
   ENVOY_STREAM_LOG(debug, "encoding trailers via codec", *this);
 #ifndef NVLOG
   trailers.iterate(
-      [](const HeaderEntry& header, void* context) -> bool {
+      [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {
         ENVOY_STREAM_LOG(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
                          header.key().c_str(), header.value().c_str());
-        return HeaderMap::Continue;
+        return HeaderMap::Iterate::Continue;
       },
       this);
 #endif

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -385,8 +385,7 @@ const HeaderEntry* HeaderMapImpl::get(const LowerCaseString& key) const {
 
 void HeaderMapImpl::iterate(ConstIterateCb cb, void* context) const {
   for (const HeaderEntryImpl& header : headers_) {
-    const HeaderMap::Iterate result = cb(header, context);
-    if (result == HeaderMap::Iterate::Break) {
+    if (cb(header, context) == HeaderMap::Iterate::Break) {
       break;
     }
   }
@@ -394,8 +393,7 @@ void HeaderMapImpl::iterate(ConstIterateCb cb, void* context) const {
 
 void HeaderMapImpl::iterateReverse(ConstIterateCb cb, void* context) const {
   for (auto it = headers_.rbegin(); it != headers_.rend(); it++) {
-    const HeaderMap::Iterate result = cb(*it, context);
-    if (result == HeaderMap::Iterate::Break) {
+    if (cb(*it, context) == HeaderMap::Iterate::Break) {
       break;
     }
   }

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -392,6 +392,15 @@ void HeaderMapImpl::iterate(ConstIterateCb cb, void* context) const {
   }
 }
 
+void HeaderMapImpl::iterateReverse(ConstIterateCb cb, void* context) const {
+  for (auto it = headers_.rbegin(); it != headers_.rend(); it++) {
+    const bool result = cb(*it, context);
+    if (result == HeaderMap::Break) {
+      break;
+    }
+  }
+}
+
 void HeaderMapImpl::remove(const LowerCaseString& key) {
   StaticLookupEntry::EntryCb cb = ConstSingleton<StaticLookupTable>::get().find(key.get().c_str());
   if (cb) {

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -259,7 +259,7 @@ HeaderMapImpl::HeaderMapImpl() { memset(&inline_headers_, 0, sizeof(inline_heade
 
 HeaderMapImpl::HeaderMapImpl(const HeaderMap& rhs) : HeaderMapImpl() {
   rhs.iterate(
-      [](const HeaderEntry& header, void* context) -> bool {
+      [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {
         // TODO(mattklein123) PERF: Avoid copying here is not necessary.
         HeaderString key_string;
         key_string.setCopy(header.key().c_str(), header.key().size());
@@ -268,7 +268,7 @@ HeaderMapImpl::HeaderMapImpl(const HeaderMap& rhs) : HeaderMapImpl() {
 
         static_cast<HeaderMapImpl*>(context)->addViaMove(std::move(key_string),
                                                          std::move(value_string));
-        return HeaderMap::Continue;
+        return HeaderMap::Iterate::Continue;
       },
       this);
 }
@@ -385,8 +385,8 @@ const HeaderEntry* HeaderMapImpl::get(const LowerCaseString& key) const {
 
 void HeaderMapImpl::iterate(ConstIterateCb cb, void* context) const {
   for (const HeaderEntryImpl& header : headers_) {
-    const bool result = cb(header, context);
-    if (result == HeaderMap::Break) {
+    const HeaderMap::Iterate result = cb(header, context);
+    if (result == HeaderMap::Iterate::Break) {
       break;
     }
   }
@@ -394,8 +394,8 @@ void HeaderMapImpl::iterate(ConstIterateCb cb, void* context) const {
 
 void HeaderMapImpl::iterateReverse(ConstIterateCb cb, void* context) const {
   for (auto it = headers_.rbegin(); it != headers_.rend(); it++) {
-    const bool result = cb(*it, context);
-    if (result == HeaderMap::Break) {
+    const HeaderMap::Iterate result = cb(*it, context);
+    if (result == HeaderMap::Iterate::Break) {
       break;
     }
   }

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -63,6 +63,7 @@ public:
   uint64_t byteSize() const override;
   const HeaderEntry* get(const LowerCaseString& key) const override;
   void iterate(ConstIterateCb cb, void* context) const override;
+  void iterateReverse(ConstIterateCb cb, void* context) const override;
   void remove(const LowerCaseString& key) override;
   size_t size() const override { return headers_.size(); }
 

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -39,7 +39,7 @@ void StreamEncoderImpl::encodeHeader(const char* key, uint32_t key_size, const c
 void StreamEncoderImpl::encodeHeaders(const HeaderMap& headers, bool end_stream) {
   bool saw_content_length = false;
   headers.iterate(
-      [](const HeaderEntry& header, void* context) -> bool {
+      [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {
         const char* key_to_use = header.key().c_str();
         uint32_t key_size_to_use = header.key().size();
         // Translate :authority -> host so that upper layers do not need to deal with this.
@@ -50,12 +50,12 @@ void StreamEncoderImpl::encodeHeaders(const HeaderMap& headers, bool end_stream)
 
         // Skip all headers starting with ':' that make it here.
         if (key_to_use[0] == ':') {
-          return HeaderMap::Continue;
+          return HeaderMap::Iterate::Continue;
         }
 
         static_cast<StreamEncoderImpl*>(context)->encodeHeader(
             key_to_use, key_size_to_use, header.value().c_str(), header.value().size());
-        return HeaderMap::Continue;
+        return HeaderMap::Iterate::Continue;
       },
       this);
 

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -39,7 +39,7 @@ void StreamEncoderImpl::encodeHeader(const char* key, uint32_t key_size, const c
 void StreamEncoderImpl::encodeHeaders(const HeaderMap& headers, bool end_stream) {
   bool saw_content_length = false;
   headers.iterate(
-      [](const HeaderEntry& header, void* context) -> void {
+      [](const HeaderEntry& header, void* context) -> bool {
         const char* key_to_use = header.key().c_str();
         uint32_t key_size_to_use = header.key().size();
         // Translate :authority -> host so that upper layers do not need to deal with this.
@@ -50,11 +50,12 @@ void StreamEncoderImpl::encodeHeaders(const HeaderMap& headers, bool end_stream)
 
         // Skip all headers starting with ':' that make it here.
         if (key_to_use[0] == ':') {
-          return;
+          return HeaderMap::Continue;
         }
 
         static_cast<StreamEncoderImpl*>(context)->encodeHeader(
             key_to_use, key_size_to_use, header.value().c_str(), header.value().size());
+        return HeaderMap::Continue;
       },
       this);
 

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -81,22 +81,22 @@ void ConnectionImpl::StreamImpl::buildHeaders(std::vector<nghttp2_nv>& final_hea
   // layers understand that we do two passes here to build the final header list to encode.
   final_headers.reserve(headers.size());
   headers.iterate(
-      [](const HeaderEntry& header, void* context) -> bool {
+      [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {
         std::vector<nghttp2_nv>* final_headers = static_cast<std::vector<nghttp2_nv>*>(context);
         if (header.key().c_str()[0] == ':') {
           insertHeader(*final_headers, header);
         }
-        return HeaderMap::Continue;
+        return HeaderMap::Iterate::Continue;
       },
       &final_headers);
 
   headers.iterate(
-      [](const HeaderEntry& header, void* context) -> bool {
+      [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {
         std::vector<nghttp2_nv>* final_headers = static_cast<std::vector<nghttp2_nv>*>(context);
         if (header.key().c_str()[0] != ':') {
           insertHeader(*final_headers, header);
         }
-        return HeaderMap::Continue;
+        return HeaderMap::Iterate::Continue;
       },
       &final_headers);
 }

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -81,20 +81,22 @@ void ConnectionImpl::StreamImpl::buildHeaders(std::vector<nghttp2_nv>& final_hea
   // layers understand that we do two passes here to build the final header list to encode.
   final_headers.reserve(headers.size());
   headers.iterate(
-      [](const HeaderEntry& header, void* context) -> void {
+      [](const HeaderEntry& header, void* context) -> bool {
         std::vector<nghttp2_nv>* final_headers = static_cast<std::vector<nghttp2_nv>*>(context);
         if (header.key().c_str()[0] == ':') {
           insertHeader(*final_headers, header);
         }
+        return HeaderMap::Continue;
       },
       &final_headers);
 
   headers.iterate(
-      [](const HeaderEntry& header, void* context) -> void {
+      [](const HeaderEntry& header, void* context) -> bool {
         std::vector<nghttp2_nv>* final_headers = static_cast<std::vector<nghttp2_nv>*>(context);
         if (header.key().c_str()[0] != ':') {
           insertHeader(*final_headers, header);
         }
+        return HeaderMap::Continue;
       },
       &final_headers);
 }

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -86,7 +86,7 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
   state.key_ = key;
 
   headers.iterateReverse(
-      [](const HeaderEntry& header, void* context) -> bool {
+      [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {
         // Find the cookie headers in the request (typically, there's only one).
         if (header.key() == Http::Headers::get().Cookie.get().c_str()) {
           // Split the cookie header into individual cookies.
@@ -111,11 +111,11 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
                 v = v.substr(1, v.size() - 2);
               }
               state->ret_ = v;
-              return HeaderMap::Break;
+              return HeaderMap::Iterate::Break;
             }
           }
         }
-        return HeaderMap::Continue;
+        return HeaderMap::Iterate::Continue;
       },
       &state);
 

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -85,7 +85,7 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
   State state;
   state.key_ = key;
 
-  headers.iterate(
+  headers.iterateReverse(
       [](const HeaderEntry& header, void* context) -> bool {
         // Find the cookie headers in the request (typically, there's only one).
         if (header.key() == Http::Headers::get().Cookie.get().c_str()) {
@@ -111,7 +111,7 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
                 v = v.substr(1, v.size() - 2);
               }
               state->ret_ = v;
-              return HeaderMap::Continue;
+              return HeaderMap::Break;
             }
           }
         }

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -86,7 +86,7 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
   state.key_ = key;
 
   headers.iterate(
-      [](const HeaderEntry& header, void* context) -> void {
+      [](const HeaderEntry& header, void* context) -> bool {
         // Find the cookie headers in the request (typically, there's only one).
         if (header.key() == Http::Headers::get().Cookie.get().c_str()) {
           // Split the cookie header into individual cookies.
@@ -111,10 +111,11 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
                 v = v.substr(1, v.size() - 2);
               }
               state->ret_ = v;
-              return;
+              return HeaderMap::Continue;
             }
           }
         }
+        return HeaderMap::Continue;
       },
       &state);
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -279,11 +279,11 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 
 #ifndef NVLOG
   headers.iterate(
-      [](const Http::HeaderEntry& header, void* context) -> bool {
+      [](const Http::HeaderEntry& header, void* context) -> Http::HeaderMap::Iterate {
         ENVOY_STREAM_LOG(debug, "  '{}':'{}'",
                          *static_cast<Http::StreamDecoderFilterCallbacks*>(context),
                          header.key().c_str(), header.value().c_str());
-        return Http::HeaderMap::Continue;
+        return Http::HeaderMap::Iterate::Continue;
       },
       callbacks_);
 #endif

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -279,10 +279,11 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 
 #ifndef NVLOG
   headers.iterate(
-      [](const Http::HeaderEntry& header, void* context) -> void {
+      [](const Http::HeaderEntry& header, void* context) -> bool {
         ENVOY_STREAM_LOG(debug, "  '{}':'{}'",
                          *static_cast<Http::StreamDecoderFilterCallbacks*>(context),
                          header.key().c_str(), header.value().c_str());
+        return Http::HeaderMap::Continue;
       },
       callbacks_);
 #endif

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -415,9 +415,9 @@ TEST(HeaderMapImplTest, Iterate) {
   EXPECT_CALL(cb, Call("foo", "bar"));
   EXPECT_CALL(cb, Call("world", "hello"));
   headers.iterate(
-      [](const Http::HeaderEntry& header, void* cb_v) -> bool {
+      [](const Http::HeaderEntry& header, void* cb_v) -> HeaderMap::Iterate {
         static_cast<MockCb*>(cb_v)->Call(header.key().c_str(), header.value().c_str());
-        return HeaderMap::Continue;
+        return HeaderMap::Iterate::Continue;
       },
       &cb);
 }
@@ -435,12 +435,12 @@ TEST(HeaderMapImplTest, IterateReverse) {
   EXPECT_CALL(cb, Call("foo", "bar"));
   // no "hello"
   headers.iterateReverse(
-      [](const Http::HeaderEntry& header, void* cb_v) -> bool {
+      [](const Http::HeaderEntry& header, void* cb_v) -> HeaderMap::Iterate {
         static_cast<MockCb*>(cb_v)->Call(header.key().c_str(), header.value().c_str());
         if (0 != strcmp("foo", header.key().c_str())) {
-          return HeaderMap::Continue;
+          return HeaderMap::Iterate::Continue;
         } else {
-          return HeaderMap::Break;
+          return HeaderMap::Iterate::Break;
         }
       },
       &cb);

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -437,7 +437,7 @@ TEST(HeaderMapImplTest, IterateReverse) {
   headers.iterateReverse(
       [](const Http::HeaderEntry& header, void* cb_v) -> HeaderMap::Iterate {
         static_cast<MockCb*>(cb_v)->Call(header.key().c_str(), header.value().c_str());
-        if (0 != strcmp("foo", header.key().c_str())) {
+        if ("foo" != std::string{header.key().c_str()}) {
           return HeaderMap::Iterate::Continue;
         } else {
           return HeaderMap::Iterate::Break;

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -422,5 +422,29 @@ TEST(HeaderMapImplTest, Iterate) {
       &cb);
 }
 
+TEST(HeaderMapImplTest, IterateReverse) {
+  TestHeaderMapImpl headers;
+  headers.addCopy("hello", "world");
+  headers.addCopy("foo", "bar");
+  headers.addCopy("world", "hello");
+
+  typedef testing::MockFunction<void(const std::string&, const std::string&)> MockCb;
+  MockCb cb;
+
+  EXPECT_CALL(cb, Call("world", "hello"));
+  EXPECT_CALL(cb, Call("foo", "bar"));
+  // no "hello"
+  headers.iterateReverse(
+      [](const Http::HeaderEntry& header, void* cb_v) -> bool {
+        static_cast<MockCb*>(cb_v)->Call(header.key().c_str(), header.value().c_str());
+        if (0 != strcmp("foo", header.key().c_str())) {
+          return HeaderMap::Continue;
+        } else {
+          return HeaderMap::Break;
+        }
+      },
+      &cb);
+}
+
 } // namespace Http
 } // namespace Envoy

--- a/test/integration/grpc_json_transcoder_integration_test.cc
+++ b/test/integration/grpc_json_transcoder_integration_test.cc
@@ -110,10 +110,11 @@ protected:
     response_->waitForEndStream();
     EXPECT_TRUE(response_->complete());
     response_headers.iterate(
-        [](const Http::HeaderEntry& entry, void* context) -> void {
+        [](const Http::HeaderEntry& entry, void* context) -> bool {
           IntegrationStreamDecoder* response = static_cast<IntegrationStreamDecoder*>(context);
           Http::LowerCaseString lower_key{entry.key().c_str()};
           EXPECT_STREQ(entry.value().c_str(), response->headers().get(lower_key)->value().c_str());
+          return Http::HeaderMap::Continue;
         },
         response_.get());
     if (!response_body.empty()) {

--- a/test/integration/grpc_json_transcoder_integration_test.cc
+++ b/test/integration/grpc_json_transcoder_integration_test.cc
@@ -110,7 +110,7 @@ protected:
     response_->waitForEndStream();
     EXPECT_TRUE(response_->complete());
     response_headers.iterate(
-        [](const Http::HeaderEntry& entry, void* context) -> HeaderMap::Iterate {
+        [](const Http::HeaderEntry& entry, void* context) -> Http::HeaderMap::Iterate {
           IntegrationStreamDecoder* response = static_cast<IntegrationStreamDecoder*>(context);
           Http::LowerCaseString lower_key{entry.key().c_str()};
           EXPECT_STREQ(entry.value().c_str(), response->headers().get(lower_key)->value().c_str());

--- a/test/integration/grpc_json_transcoder_integration_test.cc
+++ b/test/integration/grpc_json_transcoder_integration_test.cc
@@ -110,11 +110,11 @@ protected:
     response_->waitForEndStream();
     EXPECT_TRUE(response_->complete());
     response_headers.iterate(
-        [](const Http::HeaderEntry& entry, void* context) -> bool {
+        [](const Http::HeaderEntry& entry, void* context) -> HeaderMap::Iterate {
           IntegrationStreamDecoder* response = static_cast<IntegrationStreamDecoder*>(context);
           Http::LowerCaseString lower_key{entry.key().c_str()};
           EXPECT_STREQ(entry.value().c_str(), response->headers().get(lower_key)->value().c_str());
-          return Http::HeaderMap::Continue;
+          return Http::HeaderMap::Iterate::Continue;
         },
         response_.get());
     if (!response_body.empty()) {

--- a/test/test_common/printers.cc
+++ b/test/test_common/printers.cc
@@ -12,10 +12,10 @@ namespace Envoy {
 namespace Http {
 void PrintTo(const HeaderMapImpl& headers, std::ostream* os) {
   headers.iterate(
-      [](const HeaderEntry& header, void* context) -> bool {
+      [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {
         std::ostream* os = static_cast<std::ostream*>(context);
         *os << "{'" << header.key().c_str() << "','" << header.value().c_str() << "'}";
-        return HeaderMap::Continue;
+        return HeaderMap::Iterate::Continue;
       },
       os);
 }

--- a/test/test_common/printers.cc
+++ b/test/test_common/printers.cc
@@ -12,9 +12,10 @@ namespace Envoy {
 namespace Http {
 void PrintTo(const HeaderMapImpl& headers, std::ostream* os) {
   headers.iterate(
-      [](const HeaderEntry& header, void* context) -> void {
+      [](const HeaderEntry& header, void* context) -> bool {
         std::ostream* os = static_cast<std::ostream*>(context);
         *os << "{'" << header.key().c_str() << "','" << header.value().c_str() << "'}";
+        return HeaderMap::Continue;
       },
       os);
 }


### PR DESCRIPTION
This is useful when it's possible to end iteration before scanning all headers, such as searching for a the first of a particular header. Reverse iteration is useful for searching for the last of a particular header, and is used to reduce the number of headers processed when parsing out a cookie value.