### PR TITLE
test/test_common: fix comment about random seed flag

### DIFF
--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -32,7 +32,7 @@ namespace Envoy {
   }
 
 // Random number generator which logs its seed to stderr.  To repeat a test run with a non-zero seed
-// one can run the test with --test_arg=--gtest_filter=[seed]
+// one can run the test with --test_arg=--gtest_random_seed=[seed]
 class TestRandomGenerator {
 public:
   TestRandomGenerator();


### PR DESCRIPTION
Fix comment to report the actual flag for setting TestRandomGenerator's seed.

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>