### PR TITLE
macos build: make $(CC) absolute in lightstep build

### DIFF
--- a/bazel/external/lightstep.genrule_cmd
+++ b/bazel/external/lightstep.genrule_cmd
@@ -6,6 +6,13 @@
 cat "$(location :lightstep_compiler_flags)"
 source "$(location :lightstep_compiler_flags)"
 
+if [[ `uname` == "Darwin" ]]; then
+   # OSX CROSSTOOL CC is a relative path, force it to be absolute to be independent of working
+   # directory). Must use CC make variable ($(CC) not $${CC}) or the substitution does not take.
+   export CC="$${PWD}/$(CC)"
+   export CXX="$${PWD}/$(CC)"
+fi
+
 CONFIGURE="$${PWD}/$(location :configure)"
 PROTOC="$${PWD}/$(location @protobuf_bzl//:protoc)"
 PROTOBUF_SRC="$${PWD}/external/protobuf_bzl/src/"


### PR DESCRIPTION
Fixes the macos build. If anyone has any tips on how to compute the absolute path of the crosstool wrapper script in genrule_repository.bzl, it would be better to do it there (because this way requires doing it for every library that doesn't use bazel for its build).

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>