### PR TITLE
Create prebuilt bazel-root and bazel-output dirs.

### DIFF
--- a/ci/build_container/build_container_common.sh
+++ b/ci/build_container/build_container_common.sh
@@ -26,6 +26,7 @@ echo "Building opt deps ${DEPS}"
 "$(dirname "$0")"/build_and_install_deps.sh ${DEPS}
 
 echo "Building Bazel-managed deps (//bazel/external:all_external)"
+mkdir /bazel-prebuilt-root /bazel-prebuilt-output
 BAZEL_OPTIONS="--output_user_root=/bazel-prebuilt-root --output_base=/bazel-prebuilt-output"
 cd /bazel-prebuilt
 for BAZEL_MODE in opt dbg fastbuild; do


### PR DESCRIPTION
Bazel is refusing to Mkdir these directories in the Envoy CI builds. I
don't know how to reproduce it locally, but am hoping it's caused by
Docker version differences and not some deeper issue.