### PR TITLE
Lightstep build fixes from #envoy-dev.

### DIFF
--- a/bazel/external/lightstep.BUILD
+++ b/bazel/external/lightstep.BUILD
@@ -12,8 +12,13 @@ cc_library(
         ":_prefix/include/lightstep_carrier.pb.h",
     ],
     includes = [
-        "_prefix/include",
+        # Note: src/ is listed before _prefix to allow unsandboxed builds.
+        #
+        # Otherwise the compiler will locate included headers in `_prefix`
+        # even though they're properly defined under `src/`, which breaks
+        # strict include checking.
         "src/c++11",
+        "_prefix/include",
     ],
     visibility = ["//visibility:public"],
     deps = ["@protobuf_bzl//:protobuf"],
@@ -37,6 +42,7 @@ genrule(
         ":lightstep_compiler_flags",
         ":protobuf_deps",
         "@protobuf_bzl//:well_known_protos",
+        "@local_config_cc//:toolchain",
     ],
     outs = [
         "_prefix/lib/liblightstep_core_cxx11.a",

--- a/bazel/genrule_repository.bzl
+++ b/bazel/genrule_repository.bzl
@@ -74,6 +74,13 @@ genrule_cc_deps = rule(
     implementation = _genrule_cc_deps,
 )
 
+def _absolute_bin(path):
+  # If the binary path looks like it's relative to the current directory,
+  # transform it to be absolute by appending "${PWD}".
+  if "/" in path and not path.startswith("/"):
+    return '"${PWD}"/%r' % (path,)
+  return '%r' % (path,)
+
 def _genrule_environment(ctx):
   lines = []
 
@@ -98,8 +105,8 @@ def _genrule_environment(ctx):
   lines.append("export CFLAGS=%r" % (" ".join(cc_flags),))
   lines.append("export LDFLAGS=%r" % (" ".join(ld_flags),))
   lines.append("export LIBS=%r" % (" ".join(ld_libs),))
-  lines.append("export CC=%r" % (ctx.var['CC'],))
-  lines.append("export CXX=%r" % (ctx.var['CC'],))
+  lines.append("export CC=%s" % (_absolute_bin(ctx.var['CC']),))
+  lines.append("export CXX=%s" % (_absolute_bin(ctx.var['CC']),))
 
   # Some Autoconf helper binaries leak, which makes ./configure think the
   # system is unable to do anything. Turn off leak checking during part of


### PR DESCRIPTION
* Reorder cc_library includes so unsandboxed builds find correct headers.

* Depend on `@local_config_cc//:toolchain` so MacOS builds with a
  compiler wrapper script can find that script.

* Detect if $CC and $CXX are relative paths, and make them absolute
  before changing to the temporary build directory.