### PR TITLE
always use randomly generated stream id

### DIFF
--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -447,13 +447,6 @@ public:
    * router.
    */
   virtual const std::list<Http::LowerCaseString>& responseHeadersToRemove() const PURE;
-
-  /**
-   * Return whether the configuration makes use of runtime or not. Callers can use this to
-   * determine whether they should use a fast or slow source of randomness when calling route
-   * functions.
-   */
-  virtual bool usesRuntime() const PURE;
 };
 
 typedef std::shared_ptr<const Config> ConfigConstSharedPtr;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -346,8 +346,7 @@ void ConnectionManagerImpl::chargeTracingStats(const Tracing::Reason& tracing_re
 ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connection_manager)
     : connection_manager_(connection_manager),
       snapped_route_config_(connection_manager.config_.routeConfigProvider().config()),
-      stream_id_(ConnectionManagerUtility::generateStreamId(*snapped_route_config_,
-                                                            connection_manager.random_generator_)),
+      stream_id_(connection_manager.random_generator_.random()),
       request_timer_(new Stats::Timespan(connection_manager_.stats_.named_.downstream_rq_time_)),
       request_info_(connection_manager_.codec_->protocol()) {
   connection_manager_.stats_.named_.downstream_rq_total_.inc();

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -16,18 +16,6 @@
 namespace Envoy {
 namespace Http {
 
-std::atomic<uint64_t> ConnectionManagerUtility::next_stream_id_(0);
-
-uint64_t ConnectionManagerUtility::generateStreamId(const Router::Config& route_table,
-                                                    Runtime::RandomGenerator& random_generator) {
-  // See the comment for next_stream_id_ in conn_manager_utility.h for why we do this.
-  if (route_table.usesRuntime()) {
-    return random_generator.random();
-  } else {
-    return ++next_stream_id_;
-  }
-}
-
 void ConnectionManagerUtility::mutateRequestHeaders(
     Http::HeaderMap& request_headers, Protocol protocol, Network::Connection& connection,
     ConnectionManagerConfig& config, const Router::Config& route_config,

--- a/source/common/http/conn_manager_utility.h
+++ b/source/common/http/conn_manager_utility.h
@@ -16,9 +16,6 @@ namespace Http {
  */
 class ConnectionManagerUtility {
 public:
-  static uint64_t generateStreamId(const Router::Config& route_table,
-                                   Runtime::RandomGenerator& random_generator);
-
   static void mutateRequestHeaders(Http::HeaderMap& request_headers, Protocol protocol,
                                    Network::Connection& connection, ConnectionManagerConfig& config,
                                    const Router::Config& route_config,
@@ -33,11 +30,6 @@ private:
   static void mutateXfccRequestHeader(Http::HeaderMap& request_headers,
                                       Network::Connection& connection,
                                       ConnectionManagerConfig& config);
-
-  // NOTE: This is used for stable randomness in the case where the route table does not use any
-  //       runtime rules. If runtime rules are used, we use true randomness which is slower but
-  //       provides behavior that most consumers would expect.
-  static std::atomic<uint64_t> next_stream_id_;
 };
 
 } // namespace Http

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -644,16 +644,6 @@ VirtualHostImpl::VirtualHostImpl(const envoy::api::v2::VirtualHost& virtual_host
   }
 }
 
-bool VirtualHostImpl::usesRuntime() const {
-  bool uses = false;
-  for (const RouteEntryImplBaseConstSharedPtr& route : routes_) {
-    // Currently a base runtime rule as well as a shadow rule can use runtime.
-    uses |= (route->usesRuntime() || !route->shadowPolicy().runtimeKey().empty());
-  }
-
-  return uses;
-}
-
 VirtualHostImpl::VirtualClusterEntry::VirtualClusterEntry(
     const envoy::api::v2::VirtualCluster& virtual_cluster) {
   if (virtual_cluster.method() != envoy::api::v2::RequestMethod::METHOD_UNSPECIFIED) {
@@ -691,8 +681,6 @@ RouteMatcher::RouteMatcher(const envoy::api::v2::RouteConfiguration& route_confi
   for (const auto& virtual_host_config : route_config.virtual_hosts()) {
     VirtualHostSharedPtr virtual_host(new VirtualHostImpl(virtual_host_config, global_route_config,
                                                           runtime, cm, validate_clusters));
-    uses_runtime_ |= virtual_host->usesRuntime();
-
     for (const std::string& domain : virtual_host_config.domains()) {
       if ("*" == domain) {
         if (default_virtual_host_) {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -103,7 +103,6 @@ public:
 
   RouteConstSharedPtr getRouteFromEntries(const Http::HeaderMap& headers,
                                           uint64_t random_value) const;
-  bool usesRuntime() const;
   const VirtualCluster* virtualClusterFromEntries(const Http::HeaderMap& headers) const;
   const std::list<std::pair<Http::LowerCaseString, std::string>>& requestHeadersToAdd() const {
     return request_headers_to_add_;
@@ -292,7 +291,6 @@ public:
                      Runtime::Loader& loader);
 
   bool isRedirect() const { return !host_redirect_.empty() || !path_redirect_.empty(); }
-  bool usesRuntime() const { return runtime_.valid(); }
 
   bool matchRoute(const Http::HeaderMap& headers, uint64_t random_value) const;
   void validateClusters(Upstream::ClusterManager& cm) const;
@@ -543,7 +541,6 @@ public:
                Upstream::ClusterManager& cm, bool validate_clusters);
 
   RouteConstSharedPtr route(const Http::HeaderMap& headers, uint64_t random_value) const;
-  bool usesRuntime() const { return uses_runtime_; }
 
 private:
   const VirtualHostImpl* findVirtualHost(const Http::HeaderMap& headers) const;
@@ -562,7 +559,6 @@ private:
   std::map<int64_t, std::unordered_map<std::string, VirtualHostSharedPtr>, std::greater<int64_t>>
       wildcard_virtual_host_suffixes_;
   VirtualHostSharedPtr default_virtual_host_;
-  bool uses_runtime_{};
 };
 
 /**
@@ -597,8 +593,6 @@ public:
     return response_headers_to_remove_;
   }
 
-  bool usesRuntime() const override { return route_matcher_->usesRuntime(); }
-
 private:
   std::unique_ptr<RouteMatcher> route_matcher_;
   std::list<Http::LowerCaseString> internal_only_headers_;
@@ -628,8 +622,6 @@ public:
   const std::list<Http::LowerCaseString>& responseHeadersToRemove() const override {
     return response_headers_to_remove_;
   }
-
-  bool usesRuntime() const override { return false; }
 
 private:
   std::list<Http::LowerCaseString> internal_only_headers_;

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -48,17 +48,6 @@ public:
   std::string empty_node_{""};
 };
 
-TEST_F(ConnectionManagerUtilityTest, generateStreamId) {
-  InSequence s;
-
-  EXPECT_CALL(route_config_, usesRuntime()).WillOnce(Return(false));
-  ConnectionManagerUtility::generateStreamId(route_config_, random_);
-
-  EXPECT_CALL(route_config_, usesRuntime()).WillOnce(Return(true));
-  EXPECT_CALL(random_, random()).WillOnce(Return(5));
-  EXPECT_EQ(5UL, ConnectionManagerUtility::generateStreamId(route_config_, random_));
-}
-
 TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWhenNotLocalHostRemoteAddress) {
   Network::Address::Ipv4Instance not_local_host_remote_address("12.12.12.12");
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -218,8 +218,6 @@ TEST(RouteMatcherTest, TestRoutes) {
   NiceMock<Envoy::Http::AccessLog::MockRequestInfo> request_info;
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
 
-  EXPECT_FALSE(config.usesRuntime());
-
   // Base routing testing.
   EXPECT_EQ("instant-server",
             config.route(genHeaders("api.lyft.com", "/", "GET"), 0)->routeEntry()->clusterName());
@@ -640,8 +638,6 @@ TEST(RouteMatcherTest, Priority) {
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
 
-  EXPECT_FALSE(config.usesRuntime());
-
   EXPECT_EQ(Upstream::ResourcePriority::High,
             config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)->routeEntry()->priority());
   EXPECT_EQ(Upstream::ResourcePriority::Default,
@@ -757,8 +753,6 @@ TEST(RouteMatcherTest, HeaderMatchedRouting) {
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
 
-  EXPECT_FALSE(config.usesRuntime());
-
   {
     EXPECT_EQ("local_service_without_headers",
               config.route(genHeaders("www.lyft.com", "/", "GET"), 0)->routeEntry()->clusterName());
@@ -849,7 +843,6 @@ public:
   ConfigImpl& config() {
     if (config_ == nullptr) {
       config_ = std::unique_ptr<ConfigImpl>{new ConfigImpl(route_config_, runtime_, cm_, true)};
-      EXPECT_FALSE(config_->usesRuntime());
     }
     return *config_;
   }
@@ -1137,8 +1130,6 @@ TEST(RouteMatcherTest, ClusterHeader) {
   NiceMock<Envoy::Http::AccessLog::MockRequestInfo> request_info;
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
 
-  EXPECT_FALSE(config.usesRuntime());
-
   EXPECT_EQ(
       "some_cluster",
       config.route(genHeaders("some_cluster", "/foo", "GET"), 0)->routeEntry()->clusterName());
@@ -1194,8 +1185,6 @@ TEST(RouteMatcherTest, ContentType) {
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
 
-  EXPECT_FALSE(config.usesRuntime());
-
   {
     EXPECT_EQ("local_service",
               config.route(genHeaders("www.lyft.com", "/", "GET"), 0)->routeEntry()->clusterName());
@@ -1247,8 +1236,6 @@ TEST(RouteMatcherTest, Runtime) {
   ON_CALL(runtime, snapshot()).WillByDefault(ReturnRef(snapshot));
 
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
-
-  EXPECT_TRUE(config.usesRuntime());
 
   EXPECT_CALL(snapshot, featureEnabled("some_key", 50, 10)).WillOnce(Return(true));
   EXPECT_EQ("something_else",
@@ -1403,8 +1390,6 @@ TEST(RouteMatcherTest, Shadow) {
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
 
-  EXPECT_TRUE(config.usesRuntime());
-
   EXPECT_EQ("some_cluster", config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)
                                 ->routeEntry()
                                 ->shadowPolicy()
@@ -1470,8 +1455,6 @@ TEST(RouteMatcherTest, Retry) {
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
-
-  EXPECT_FALSE(config.usesRuntime());
 
   EXPECT_EQ(std::chrono::milliseconds(0),
             config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)
@@ -1555,8 +1538,6 @@ TEST(RouteMatcherTest, GrpcRetry) {
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
-
-  EXPECT_FALSE(config.usesRuntime());
 
   EXPECT_EQ(std::chrono::milliseconds(0),
             config.route(genHeaders("www.lyft.com", "/foo", "GET"), 0)
@@ -1739,8 +1720,6 @@ TEST(RouteMatcherTest, Redirect) {
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
-
-  EXPECT_FALSE(config.usesRuntime());
 
   EXPECT_EQ(nullptr, config.route(genRedirectHeaders("www.foo.com", "/foo", true, true), 0));
 
@@ -2162,7 +2141,6 @@ TEST(NullConfigImplTest, All) {
   EXPECT_EQ(0UL, config.internalOnlyHeaders().size());
   EXPECT_EQ(0UL, config.responseHeadersToAdd().size());
   EXPECT_EQ(0UL, config.responseHeadersToRemove().size());
-  EXPECT_FALSE(config.usesRuntime());
 }
 
 TEST(BadHttpRouteConfigurationsTest, BadRouteConfig) {
@@ -2638,8 +2616,6 @@ TEST(RouterMatcherTest, Decorator) {
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
-
-  EXPECT_FALSE(config.usesRuntime());
 
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -259,7 +259,6 @@ public:
   MOCK_CONST_METHOD0(responseHeadersToAdd,
                      const std::list<std::pair<Http::LowerCaseString, std::string>>&());
   MOCK_CONST_METHOD0(responseHeadersToRemove, const std::list<Http::LowerCaseString>&());
-  MOCK_CONST_METHOD0(usesRuntime, bool());
 
   std::shared_ptr<MockRoute> route_;
   std::list<Http::LowerCaseString> internal_only_headers_;


### PR DESCRIPTION
#1812 fixed the perf issues with random number generation. We no longer have to rely on monotonically increasing stream IDs for perf reasons. Switch to always using randomly generated stream IDs.

Signed-off-by: Shriram Rajagopalan <shriram@us.ibm.com>