### PR TITLE
network: support combined read|write event when connecting.

### DIFF
--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -108,7 +108,6 @@ protected:
 
   void onLowWatermark();
   void onHighWatermark();
-  bool checkConnection();
 
   FilterManagerImpl filter_manager_;
   Address::InstanceConstSharedPtr remote_address_;

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -108,6 +108,7 @@ protected:
 
   void onLowWatermark();
   void onHighWatermark();
+  bool checkConnection();
 
   FilterManagerImpl filter_manager_;
   Address::InstanceConstSharedPtr remote_address_;


### PR DESCRIPTION
This breaks protocols in which servers can send initial data,
because read readiness might be reported during "connected" event.

Fixes #1895.