### PR TITLE
docs: clarify possible values of 'priority' field in circuit breaker runtime configuration

### DIFF
--- a/docs/configuration/cluster_manager/cluster_circuit_breakers.rst
+++ b/docs/configuration/cluster_manager/cluster_circuit_breakers.rst
@@ -69,5 +69,5 @@ Runtime
 All four circuit breaking settings are runtime configurable for all defined priorities based on cluster
 name. They follow the following naming scheme ``circuit_breakers.<cluster_name>.<priority>.<setting>``.
 ``cluster_name`` is the name field in each cluster's configuration, which is set in the envoy
-:ref:`config file <config_cluster_manager_cluster_name>`. Available runtime settings will override
-settings set in the envoy config file.
+:ref:`config file <config_cluster_manager_cluster_name>`. ``priority`` here is in numeric form:
+default - 0, high - 1. Available runtime settings will override settings set in the envoy config file.


### PR DESCRIPTION
Hi. Please consider this pull request. Ideally, it would be nice to make envoy consistent with naming priorities (i.e., use default/high instead of 1/0). But looking into the code, I don't see an easy way how to achieve this without breaking compatibility.