### PR TITLE
Add sanitization of decorator-operation header

### DIFF
--- a/docs/configuration/http_conn_man/header_sanitizing.rst
+++ b/docs/configuration/http_conn_man/header_sanitizing.rst
@@ -12,6 +12,7 @@ depends on the :ref:`use_remote_address <config_http_conn_man_use_remote_address
 
 Envoy will potentially sanitize the following headers:
 
+* :ref:`x-envoy-decorator-operation <config_http_filters_router_x-envoy-decorator-operation>`
 * :ref:`x-envoy-downstream-service-cluster
   <config_http_conn_man_headers_downstream-service-cluster>`
 * :ref:`x-envoy-downstream-service-node <config_http_conn_man_headers_downstream-service-node>`

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -68,6 +68,7 @@ void ConnectionManagerUtility::mutateRequestHeaders(
         Headers::get().EnvoyInternalRequestValues.True);
   } else {
     if (edge_request) {
+      request_headers.removeEnvoyDecoratorOperation();
       request_headers.removeEnvoyDownstreamServiceCluster();
       request_headers.removeEnvoyDownstreamServiceNode();
     }

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -313,7 +313,8 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
 
   route_config_.internal_only_headers_.push_back(LowerCaseString("custom_header"));
 
-  TestHeaderMapImpl headers{{"x-envoy-downstream-service-cluster", "foo"},
+  TestHeaderMapImpl headers{{"x-envoy-decorator-operation", "foo"},
+                            {"x-envoy-downstream-service-cluster", "foo"},
                             {"x-envoy-retry-on", "foo"},
                             {"x-envoy-retry-grpc-on", "foo"},
                             {"x-envoy-max-retries", "foo"},
@@ -326,6 +327,7 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
                                                  route_config_, random_, runtime_, local_info_);
   EXPECT_EQ("50.0.0.1", headers.get_("x-envoy-external-address"));
   EXPECT_FALSE(headers.has("x-envoy-internal"));
+  EXPECT_FALSE(headers.has("x-envoy-decorator-operation"));
   EXPECT_FALSE(headers.has("x-envoy-downstream-service-cluster"));
   EXPECT_FALSE(headers.has("x-envoy-retry-on"));
   EXPECT_FALSE(headers.has("x-envoy-retry-grpc-on"));


### PR DESCRIPTION
Fixes #1889

Side note - when trying to build locally based off current master, I got an error:

> ENVOY_SRCDIR=/source
INFO: $TEST_TMPDIR defined: output root default is '/build/tmp'.
Error: failed to set timestamp on '/build/tmp/_bazel_bazel/install/697791709cf5cd5dd10a151e49e24677': (error: 1): Operation not permitted

I had to revert the envoy-build-sha to `8839608c2f4b0d7c8311361ee5c8785e543d517a`.

Signed-off-by: Gary Brown <gary@brownuk.com>