### PR TITLE
mongo: implement "drain close" functionality

### DIFF
--- a/docs/configuration/network_filters/mongo_proxy_filter.rst
+++ b/docs/configuration/network_filters/mongo_proxy_filter.rst
@@ -31,9 +31,9 @@ fault
 Fault configuration
 -------------------
 
-Configuration for MongoDB fixed duration delays. Delays are applied to the following MongoDB operations: Query, Insert,
-GetMore, and KillCursors. Once an active delay is in progress, all incoming data up until the timer event fires
-will be a part of the delay.
+Configuration for MongoDB fixed duration delays. Delays are applied to the following MongoDB
+operations: Query, Insert, GetMore, and KillCursors. Once an active delay is in progress, all
+incoming data up until the timer event fires will be a part of the delay.
 
 .. code-block:: json
 
@@ -83,6 +83,7 @@ following statistics:
   op_reply_valid_cursor, Counter, Number of OP_REPLY with a valid cursor
   cx_destroy_local_with_active_rq, Counter, Connections destroyed locally with an active query
   cx_destroy_remote_with_active_rq, Counter, Connections destroyed remotely with an active query
+  cx_drain_close, Counter, Connections gracefully closed on reply boundaries during server drain
 
 Scatter gets
 ^^^^^^^^^^^^

--- a/source/common/mongo/BUILD
+++ b/source/common/mongo/BUILD
@@ -48,6 +48,7 @@ envoy_cc_library(
         "//include/envoy/filesystem:filesystem_interface",
         "//include/envoy/mongo:codec_interface",
         "//include/envoy/network:connection_interface",
+        "//include/envoy/network:drain_decision_interface",
         "//include/envoy/network:filter_interface",
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/stats:stats_interface",

--- a/source/common/mongo/proxy.h
+++ b/source/common/mongo/proxy.h
@@ -11,6 +11,7 @@
 #include "envoy/event/timer.h"
 #include "envoy/mongo/codec.h"
 #include "envoy/network/connection.h"
+#include "envoy/network/drain_decision.h"
 #include "envoy/network/filter.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/stats/stats.h"
@@ -61,7 +62,8 @@ typedef ConstSingleton<MongoRuntimeConfigKeys> MongoRuntimeConfig;
   COUNTER(op_reply_query_failure)                                                                  \
   COUNTER(op_reply_valid_cursor)                                                                   \
   COUNTER(cx_destroy_local_with_active_rq)                                                         \
-  COUNTER(cx_destroy_remote_with_active_rq)
+  COUNTER(cx_destroy_remote_with_active_rq)                                                        \
+  COUNTER(cx_drain_close)
 // clang-format on
 
 /**
@@ -118,7 +120,8 @@ class ProxyFilter : public Network::Filter,
                     Logger::Loggable<Logger::Id::mongo> {
 public:
   ProxyFilter(const std::string& stat_prefix, Stats::Scope& scope, Runtime::Loader& runtime,
-              AccessLogSharedPtr access_log, const FaultConfigSharedPtr& fault_config);
+              AccessLogSharedPtr access_log, const FaultConfigSharedPtr& fault_config,
+              const Network::DrainDecision& drain_decision);
   ~ProxyFilter();
 
   virtual DecoderPtr createDecoder(DecoderCallbacks& callbacks) PURE;
@@ -183,6 +186,7 @@ private:
   Stats::Scope& scope_;
   MongoProxyStats stats_;
   Runtime::Loader& runtime_;
+  const Network::DrainDecision& drain_decision_;
   Buffer::OwnedImpl read_buffer_;
   Buffer::OwnedImpl write_buffer_;
   bool sniffing_{true};

--- a/source/server/config/network/mongo_proxy.cc
+++ b/source/server/config/network/mongo_proxy.cc
@@ -32,7 +32,8 @@ MongoProxyFilterConfigFactory::createFilterFactory(const Json::Object& config,
   return [stat_prefix, &context, access_log,
           fault_config](Network::FilterManager& filter_manager) -> void {
     filter_manager.addFilter(std::make_shared<Mongo::ProdProxyFilter>(
-        stat_prefix, context.scope(), context.runtime(), access_log, fault_config));
+        stat_prefix, context.scope(), context.runtime(), access_log, fault_config,
+        context.drainDecision()));
   };
 }
 

--- a/test/common/mongo/proxy_test.cc
+++ b/test/common/mongo/proxy_test.cc
@@ -70,7 +70,8 @@ public:
   }
 
   void initializeFilter() {
-    filter_.reset(new TestProxyFilter("test.", store_, runtime_, access_log_, fault_config_));
+    filter_.reset(new TestProxyFilter("test.", store_, runtime_, access_log_, fault_config_,
+                                      drain_decision_));
     filter_->initializeReadFilterCallbacks(read_filter_callbacks_);
     filter_->onNewConnection();
   }
@@ -108,6 +109,7 @@ public:
   std::unique_ptr<TestProxyFilter> filter_;
   NiceMock<Network::MockReadFilterCallbacks> read_filter_callbacks_;
   Envoy::AccessLog::MockAccessLogManager log_manager_;
+  NiceMock<Network::MockDrainDecision> drain_decision_;
 };
 
 TEST_F(MongoProxyFilterTest, DelayFaults) {
@@ -402,7 +404,7 @@ TEST_F(MongoProxyFilterTest, DecodeError) {
   EXPECT_EQ(1U, store_.counter("test.decoding_error").value());
 }
 
-TEST_F(MongoProxyFilterTest, ConcurrentQuery) {
+TEST_F(MongoProxyFilterTest, ConcurrentQueryWithDrainClose) {
   initializeFilter();
 
   EXPECT_CALL(*filter_->decoder_, onData(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
@@ -432,10 +434,14 @@ TEST_F(MongoProxyFilterTest, ConcurrentQuery) {
     message->flags(0b11);
     message->cursorId(1);
     message->documents().push_back(Bson::DocumentImpl::create()->addString("hello", "world"));
+    EXPECT_CALL(drain_decision_, drainClose()).WillOnce(Return(true));
+    EXPECT_CALL(read_filter_callbacks_.connection_,
+                close(Network::ConnectionCloseType::FlushWrite));
     filter_->callbacks_->decodeReply(std::move(message));
   }));
   filter_->onWrite(fake_data_);
   EXPECT_EQ(0U, store_.gauge("test.op_query_active").value());
+  EXPECT_EQ(1U, store_.counter("test.cx_drain_close").value());
 }
 
 TEST_F(MongoProxyFilterTest, EmptyActiveQueryList) {


### PR DESCRIPTION
During server drain, we will attempt to gracefully close connections
on reply boundaries to avoid situations where all app connections sever
at the same time because they don't do any connection cycling.

Signed-off-by: Matt Klein <mklein@lyft.com>