### PR TITLE
async client: restore ability to retry unary calls

### DIFF
--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -147,12 +147,17 @@ public:
    * @param callbacks the callbacks to be notified of stream status.
    * @param timeout supplies the stream timeout, measured since when the frame with end_stream
    *        flag is sent until when the first frame is received.
+   * @param buffer_body_for_retry specifies whether the streamed body will be buffered so that
+   *        it can be retried. In general, this should be set to false for a true stream. However,
+   *        streaming is also used in certain cases such as gRPC unary calls, where retry can
+   *        still be useful.
    * @return a stream handle or nullptr if no stream could be started. NOTE: In this case
    *         onResetStream() has already been called inline. The client owns the stream and
    *         the handle can be used to send more messages or close the stream.
    */
   virtual Stream* start(StreamCallbacks& callbacks,
-                        const Optional<std::chrono::milliseconds>& timeout) PURE;
+                        const Optional<std::chrono::milliseconds>& timeout,
+                        bool buffer_body_for_retry) PURE;
 
   /**
    * @return Event::Dispatcher& the dispatcher backing this client.

--- a/source/server/config_validation/async_client.cc
+++ b/source/server/config_validation/async_client.cc
@@ -8,8 +8,8 @@ AsyncClient::Request* ValidationAsyncClient::send(MessagePtr&&, Callbacks&,
   return nullptr;
 }
 
-AsyncClient::Stream* ValidationAsyncClient::start(StreamCallbacks&,
-                                                  const Optional<std::chrono::milliseconds>&) {
+AsyncClient::Stream*
+ValidationAsyncClient::start(StreamCallbacks&, const Optional<std::chrono::milliseconds>&, bool) {
   return nullptr;
 }
 

--- a/source/server/config_validation/async_client.h
+++ b/source/server/config_validation/async_client.h
@@ -18,9 +18,11 @@ namespace Http {
 class ValidationAsyncClient : public AsyncClient {
 public:
   // Http::AsyncClient
-  AsyncClient::Request* send(MessagePtr&&, Callbacks&,
-                             const Optional<std::chrono::milliseconds>&) override;
-  AsyncClient::Stream* start(StreamCallbacks&, const Optional<std::chrono::milliseconds>&) override;
+  AsyncClient::Request* send(MessagePtr&& request, Callbacks& callbacks,
+                             const Optional<std::chrono::milliseconds>& timeout) override;
+  AsyncClient::Stream* start(StreamCallbacks& callbacks,
+                             const Optional<std::chrono::milliseconds>& timeout,
+                             bool buffer_body_for_retry) override;
   Event::Dispatcher& dispatcher() override { NOT_IMPLEMENTED; }
 };
 

--- a/test/common/config/subscription_factory_test.cc
+++ b/test/common/config/subscription_factory_test.cc
@@ -116,7 +116,7 @@ TEST_F(SubscriptionFactoryTest, GrpcSubscription) {
   EXPECT_CALL(dispatcher_, createTimer_(_));
   EXPECT_CALL(cm_, httpAsyncClientForCluster("eds_cluster"));
   NiceMock<Http::MockAsyncClientStream> stream;
-  EXPECT_CALL(cm_.async_client_, start(_, _)).WillOnce(Return(&stream));
+  EXPECT_CALL(cm_.async_client_, start(_, _, false)).WillOnce(Return(&stream));
   Http::TestHeaderMapImpl headers{
       {":method", "POST"},
       {":path", "/envoy.api.v2.EndpointDiscoveryService/StreamEndpoints"},

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -391,8 +391,9 @@ public:
   MOCK_METHOD3(send_, Request*(MessagePtr& request, Callbacks& callbacks,
                                const Optional<std::chrono::milliseconds>& timeout));
 
-  MOCK_METHOD2(start, Stream*(StreamCallbacks& callbacks,
-                              const Optional<std::chrono::milliseconds>& timeout));
+  MOCK_METHOD3(start, Stream*(StreamCallbacks& callbacks,
+                              const Optional<std::chrono::milliseconds>& timeout,
+                              bool buffer_body_for_retry));
 
   MOCK_METHOD0(dispatcher, Event::Dispatcher&());
 

--- a/test/server/config_validation/async_client_test.cc
+++ b/test/server/config_validation/async_client_test.cc
@@ -18,7 +18,7 @@ TEST(ValidationAsyncClientTest, MockedMethods) {
   ValidationAsyncClient client;
   EXPECT_EQ(nullptr,
             client.send(std::move(message), callbacks, Optional<std::chrono::milliseconds>()));
-  EXPECT_EQ(nullptr, client.start(stream_callbacks, Optional<std::chrono::milliseconds>()));
+  EXPECT_EQ(nullptr, client.start(stream_callbacks, Optional<std::chrono::milliseconds>(), false));
 }
 
 } // namespace Http

--- a/test/server/config_validation/cluster_manager_test.cc
+++ b/test/server/config_validation/cluster_manager_test.cc
@@ -44,7 +44,7 @@ TEST(ValidationClusterManagerTest, MockedMethods) {
 
   Http::AsyncClient& client = cluster_manager->httpAsyncClientForCluster("cluster");
   Http::MockAsyncClientStreamCallbacks stream_callbacks;
-  EXPECT_EQ(nullptr, client.start(stream_callbacks, Optional<std::chrono::milliseconds>()));
+  EXPECT_EQ(nullptr, client.start(stream_callbacks, Optional<std::chrono::milliseconds>(), false));
 }
 
 } // namespace Upstream


### PR DESCRIPTION
When we converted to the new gRPC async client we lost the ability
to retry unary requests because all gRPC requests use an underlying
streaming HTTP async client. This change allows buffering to be
configured on an HTTP async client stream, which then allows it
to be used during retries.

Signed-off-by: Matt Klein <mklein@lyft.com>