### PR TITLE
build_container: non-root base image fix.

### DIFF
--- a/ci/build_container/build_container_common.sh
+++ b/ci/build_container/build_container_common.sh
@@ -32,3 +32,5 @@ cd /bazel-prebuilt
 for BAZEL_MODE in opt dbg fastbuild; do
   bazel ${BAZEL_OPTIONS} build -c "${BAZEL_MODE}" //bazel/external:all_external
 done
+# Allow access by non-root for building.
+chmod -R a+rX /bazel-prebuilt-root /bazel-prebuilt-output


### PR DESCRIPTION
Part of a fix for non-root invocation of do_ci.sh for regression
introduced in #1682.

Signed-off-by: Harvey Tuch <htuch@google.com>