### PR TITLE
Revert "mongo: implement "drain close" functionality"

### DIFF
--- a/docs/configuration/network_filters/mongo_proxy_filter.rst
+++ b/docs/configuration/network_filters/mongo_proxy_filter.rst
@@ -31,9 +31,9 @@ fault
 Fault configuration
 -------------------
 
-Configuration for MongoDB fixed duration delays. Delays are applied to the following MongoDB
-operations: Query, Insert, GetMore, and KillCursors. Once an active delay is in progress, all
-incoming data up until the timer event fires will be a part of the delay.
+Configuration for MongoDB fixed duration delays. Delays are applied to the following MongoDB operations: Query, Insert,
+GetMore, and KillCursors. Once an active delay is in progress, all incoming data up until the timer event fires
+will be a part of the delay.
 
 .. code-block:: json
 
@@ -83,7 +83,6 @@ following statistics:
   op_reply_valid_cursor, Counter, Number of OP_REPLY with a valid cursor
   cx_destroy_local_with_active_rq, Counter, Connections destroyed locally with an active query
   cx_destroy_remote_with_active_rq, Counter, Connections destroyed remotely with an active query
-  cx_drain_close, Counter, Connections gracefully closed on reply boundaries during server drain
 
 Scatter gets
 ^^^^^^^^^^^^

--- a/source/common/mongo/BUILD
+++ b/source/common/mongo/BUILD
@@ -48,7 +48,6 @@ envoy_cc_library(
         "//include/envoy/filesystem:filesystem_interface",
         "//include/envoy/mongo:codec_interface",
         "//include/envoy/network:connection_interface",
-        "//include/envoy/network:drain_decision_interface",
         "//include/envoy/network:filter_interface",
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/stats:stats_interface",

--- a/source/common/mongo/proxy.cc
+++ b/source/common/mongo/proxy.cc
@@ -38,11 +38,9 @@ void AccessLog::logMessage(const Message& message, bool full,
 
 ProxyFilter::ProxyFilter(const std::string& stat_prefix, Stats::Scope& scope,
                          Runtime::Loader& runtime, AccessLogSharedPtr access_log,
-                         const FaultConfigSharedPtr& fault_config,
-                         const Network::DrainDecision& drain_decision)
+                         const FaultConfigSharedPtr& fault_config)
     : stat_prefix_(stat_prefix), scope_(scope), stats_(generateStats(stat_prefix, scope)),
-      runtime_(runtime), drain_decision_(drain_decision), access_log_(access_log),
-      fault_config_(fault_config) {
+      runtime_(runtime), access_log_(access_log), fault_config_(fault_config) {
   if (!runtime_.snapshot().featureEnabled(MongoRuntimeConfig::get().ConnectionLoggingEnabled,
                                           100)) {
     // If we are not logging at the connection level, just release the shared pointer so that we
@@ -183,12 +181,6 @@ void ProxyFilter::decodeReply(ReplyMessagePtr&& message) {
 
     active_query_list_.erase(i);
     break;
-  }
-
-  if (active_query_list_.empty() && drain_decision_.drainClose()) {
-    ENVOY_LOG(debug, "drain closing mongo connection");
-    stats_.cx_drain_close_.inc();
-    read_callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
   }
 }
 

--- a/source/common/mongo/proxy.h
+++ b/source/common/mongo/proxy.h
@@ -11,7 +11,6 @@
 #include "envoy/event/timer.h"
 #include "envoy/mongo/codec.h"
 #include "envoy/network/connection.h"
-#include "envoy/network/drain_decision.h"
 #include "envoy/network/filter.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/stats/stats.h"
@@ -62,8 +61,7 @@ typedef ConstSingleton<MongoRuntimeConfigKeys> MongoRuntimeConfig;
   COUNTER(op_reply_query_failure)                                                                  \
   COUNTER(op_reply_valid_cursor)                                                                   \
   COUNTER(cx_destroy_local_with_active_rq)                                                         \
-  COUNTER(cx_destroy_remote_with_active_rq)                                                        \
-  COUNTER(cx_drain_close)
+  COUNTER(cx_destroy_remote_with_active_rq)
 // clang-format on
 
 /**
@@ -120,8 +118,7 @@ class ProxyFilter : public Network::Filter,
                     Logger::Loggable<Logger::Id::mongo> {
 public:
   ProxyFilter(const std::string& stat_prefix, Stats::Scope& scope, Runtime::Loader& runtime,
-              AccessLogSharedPtr access_log, const FaultConfigSharedPtr& fault_config,
-              const Network::DrainDecision& drain_decision);
+              AccessLogSharedPtr access_log, const FaultConfigSharedPtr& fault_config);
   ~ProxyFilter();
 
   virtual DecoderPtr createDecoder(DecoderCallbacks& callbacks) PURE;
@@ -186,7 +183,6 @@ private:
   Stats::Scope& scope_;
   MongoProxyStats stats_;
   Runtime::Loader& runtime_;
-  const Network::DrainDecision& drain_decision_;
   Buffer::OwnedImpl read_buffer_;
   Buffer::OwnedImpl write_buffer_;
   bool sniffing_{true};

--- a/source/server/config/network/mongo_proxy.cc
+++ b/source/server/config/network/mongo_proxy.cc
@@ -32,8 +32,7 @@ MongoProxyFilterConfigFactory::createFilterFactory(const Json::Object& config,
   return [stat_prefix, &context, access_log,
           fault_config](Network::FilterManager& filter_manager) -> void {
     filter_manager.addFilter(std::make_shared<Mongo::ProdProxyFilter>(
-        stat_prefix, context.scope(), context.runtime(), access_log, fault_config,
-        context.drainDecision()));
+        stat_prefix, context.scope(), context.runtime(), access_log, fault_config));
   };
 }
 


### PR DESCRIPTION
Reverts envoyproxy/envoy#1910

There are interactions with the the L4 filter manager here and TCP proxy that are broken.
I need to spend more time with this so am reverting.