### PR TITLE
[WIP] RFC: Pluggable transport security

### DIFF
--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -69,16 +69,16 @@ enum class ConnectionCloseType {
  * An abstract raw connection. Free the connection or call close() to disconnect.
  */
 class Connection : public Event::DeferredDeletable, public FilterManager {
- public:
+public:
   enum class State { Open, Closing, Closed };
 
   struct ConnectionStats {
-    Stats::Counter &read_total_;
-    Stats::Gauge &read_current_;
-    Stats::Counter &write_total_;
-    Stats::Gauge &write_current_;
+    Stats::Counter& read_total_;
+    Stats::Gauge& read_current_;
+    Stats::Counter& write_total_;
+    Stats::Gauge& write_current_;
     // Counter* as this is an optional counter.  Bind errors will not be tracked if this is nullptr.
-    Stats::Counter *bind_errors_;
+    Stats::Counter* bind_errors_;
   };
 
   virtual ~Connection() {}
@@ -86,7 +86,7 @@ class Connection : public Event::DeferredDeletable, public FilterManager {
   /**
    * Register callbacks that fire when connection events occur.
    */
-  virtual void addConnectionCallbacks(ConnectionCallbacks &cb) PURE;
+  virtual void addConnectionCallbacks(ConnectionCallbacks& cb) PURE;
 
   /**
    * Close the connection.
@@ -96,7 +96,7 @@ class Connection : public Event::DeferredDeletable, public FilterManager {
   /**
    * @return Event::Dispatcher& the dispatcher backing this connection.
    */
-  virtual Event::Dispatcher &dispatcher() PURE;
+  virtual Event::Dispatcher& dispatcher() PURE;
 
   /**
    * @return uint64_t the unique local ID of this connection.
@@ -140,7 +140,7 @@ class Connection : public Event::DeferredDeletable, public FilterManager {
   /**
    * @return The address of the remote client.
    */
-  virtual const Address::Instance &remoteAddress() const PURE;
+  virtual const Address::Instance& remoteAddress() const PURE;
 
   /**
    * @return the local address of the connection. For client connections, this is the origin
@@ -148,24 +148,24 @@ class Connection : public Event::DeferredDeletable, public FilterManager {
    * it can be different from the proxy address if the downstream connection has been redirected or
    * the proxy is operating in transparent mode.
    */
-  virtual const Address::Instance &localAddress() const PURE;
+  virtual const Address::Instance& localAddress() const PURE;
 
   /**
    * Set the stats to update for various connection state changes. Note that for performance reasons
    * these stats are eventually consistent and may not always accurately represent the connection
    * state at any given point in time.
    */
-  virtual void setConnectionStats(const ConnectionStats &stats) PURE;
+  virtual void setConnectionStats(const ConnectionStats& stats) PURE;
 
   /**
    * @return the SSL connection data if this is an SSL connection, or nullptr if it is not.
    */
-  virtual Ssl::Connection *ssl() PURE;
+  virtual Ssl::Connection* ssl() PURE;
 
   /**
    * @return the const SSL connection data if this is an SSL connection, or nullptr if it is not.
    */
-  virtual const Ssl::Connection *ssl() const PURE;
+  virtual const Ssl::Connection* ssl() const PURE;
 
   /**
    * @return State the current state of the connection.
@@ -176,7 +176,7 @@ class Connection : public Event::DeferredDeletable, public FilterManager {
    * Write data to the connection. Will iterate through downstream filters with the buffer if any
    * are installed.
    */
-  virtual void write(Buffer::Instance &data) PURE;
+  virtual void write(Buffer::Instance& data) PURE;
 
   /**
    * Set a soft limit on the size of buffers for the connection.
@@ -216,7 +216,7 @@ class Connection : public Event::DeferredDeletable, public FilterManager {
 
 class TransportSecurityCallbacks {
 public:
-  virtual ~TransportSecurityCallbacks() {};
+  virtual ~TransportSecurityCallbacks(){};
 
   virtual const Connection& connection() const PURE;
 
@@ -236,13 +236,13 @@ public:
 typedef std::unique_ptr<Connection> ConnectionPtr;
 
 class TransportSecurity {
- public:
+public:
   virtual ~TransportSecurity() {}
   virtual std::string nextProtocol() const PURE;
   virtual Connection::IoResult doReadFromSocket() PURE;
   virtual Connection::IoResult doWriteToSocket() PURE;
   virtual void onConnected() PURE;
-  virtual void closeSocket(Network::ConnectionEvent) {};
+  virtual void closeSocket(Network::ConnectionEvent){};
 };
 
 typedef std::unique_ptr<TransportSecurity> SecureLayerPtr;

--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -214,9 +214,9 @@ class Connection : public Event::DeferredDeletable, public FilterManager {
   };
 };
 
-class SecureLayerCallbacks {
+class TransportSecurityCallbacks {
 public:
-  virtual ~SecureLayerCallbacks() {};
+  virtual ~TransportSecurityCallbacks() {};
 
   virtual const Connection& connection() const PURE;
 
@@ -235,9 +235,9 @@ public:
 
 typedef std::unique_ptr<Connection> ConnectionPtr;
 
-class SecureLayer {
+class TransportSecurity {
  public:
-  virtual ~SecureLayer() {}
+  virtual ~TransportSecurity() {}
   virtual std::string nextProtocol() const PURE;
   virtual Connection::IoResult doReadFromSocket() PURE;
   virtual Connection::IoResult doWriteToSocket() PURE;
@@ -245,7 +245,7 @@ class SecureLayer {
   virtual void closeSocket(Network::ConnectionEvent) {};
 };
 
-typedef std::unique_ptr<SecureLayer> SecureLayerPtr;
+typedef std::unique_ptr<TransportSecurity> SecureLayerPtr;
 
 typedef std::function<SecureLayerPtr()> SecureLayerFactoryCb;
 

--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -220,8 +220,6 @@ public:
 
   virtual uint64_t id() const PURE;
 
-  virtual void closeSocket(ConnectionEvent close_type) PURE;
-
   virtual void raiseEvent(ConnectionEvent event) PURE;
 
   virtual bool shouldDrainReadBuffer() PURE;
@@ -243,6 +241,7 @@ class SecureLayer {
   virtual Connection::IoResult doReadFromSocket() PURE;
   virtual Connection::IoResult doWriteToSocket() PURE;
   virtual void onConnected() PURE;
+  virtual void closeSocket(Network::ConnectionEvent close_type) {};
 };
 
 typedef std::unique_ptr<SecureLayer> SecureLayerPtr;

--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -247,7 +247,7 @@ public:
 
 typedef std::unique_ptr<TransportSecurity> TransportSecurityPtr;
 
-typedef std::function<TransportSecurityPtr()> TransportSecurityFactoryCb;
+typedef std::function<TransportSecurityPtr(TransportSecurityCallbacks&)> TransportSecurityFactoryCb;
 
 /**
  * Connections capable of outbound connects.

--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -245,9 +245,9 @@ public:
   virtual void closeSocket(Network::ConnectionEvent){};
 };
 
-typedef std::unique_ptr<TransportSecurity> SecureLayerPtr;
+typedef std::unique_ptr<TransportSecurity> TransportSecurityPtr;
 
-typedef std::function<SecureLayerPtr()> SecureLayerFactoryCb;
+typedef std::function<TransportSecurityPtr()> TransportSecurityFactoryCb;
 
 /**
  * Connections capable of outbound connects.

--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -69,16 +69,16 @@ enum class ConnectionCloseType {
  * An abstract raw connection. Free the connection or call close() to disconnect.
  */
 class Connection : public Event::DeferredDeletable, public FilterManager {
-public:
+ public:
   enum class State { Open, Closing, Closed };
 
   struct ConnectionStats {
-    Stats::Counter& read_total_;
-    Stats::Gauge& read_current_;
-    Stats::Counter& write_total_;
-    Stats::Gauge& write_current_;
+    Stats::Counter &read_total_;
+    Stats::Gauge &read_current_;
+    Stats::Counter &write_total_;
+    Stats::Gauge &write_current_;
     // Counter* as this is an optional counter.  Bind errors will not be tracked if this is nullptr.
-    Stats::Counter* bind_errors_;
+    Stats::Counter *bind_errors_;
   };
 
   virtual ~Connection() {}
@@ -86,7 +86,7 @@ public:
   /**
    * Register callbacks that fire when connection events occur.
    */
-  virtual void addConnectionCallbacks(ConnectionCallbacks& cb) PURE;
+  virtual void addConnectionCallbacks(ConnectionCallbacks &cb) PURE;
 
   /**
    * Close the connection.
@@ -96,7 +96,7 @@ public:
   /**
    * @return Event::Dispatcher& the dispatcher backing this connection.
    */
-  virtual Event::Dispatcher& dispatcher() PURE;
+  virtual Event::Dispatcher &dispatcher() PURE;
 
   /**
    * @return uint64_t the unique local ID of this connection.
@@ -140,7 +140,7 @@ public:
   /**
    * @return The address of the remote client.
    */
-  virtual const Address::Instance& remoteAddress() const PURE;
+  virtual const Address::Instance &remoteAddress() const PURE;
 
   /**
    * @return the local address of the connection. For client connections, this is the origin
@@ -148,24 +148,24 @@ public:
    * it can be different from the proxy address if the downstream connection has been redirected or
    * the proxy is operating in transparent mode.
    */
-  virtual const Address::Instance& localAddress() const PURE;
+  virtual const Address::Instance &localAddress() const PURE;
 
   /**
    * Set the stats to update for various connection state changes. Note that for performance reasons
    * these stats are eventually consistent and may not always accurately represent the connection
    * state at any given point in time.
    */
-  virtual void setConnectionStats(const ConnectionStats& stats) PURE;
+  virtual void setConnectionStats(const ConnectionStats &stats) PURE;
 
   /**
    * @return the SSL connection data if this is an SSL connection, or nullptr if it is not.
    */
-  virtual Ssl::Connection* ssl() PURE;
+  virtual Ssl::Connection *ssl() PURE;
 
   /**
    * @return the const SSL connection data if this is an SSL connection, or nullptr if it is not.
    */
-  virtual const Ssl::Connection* ssl() const PURE;
+  virtual const Ssl::Connection *ssl() const PURE;
 
   /**
    * @return State the current state of the connection.
@@ -176,7 +176,7 @@ public:
    * Write data to the connection. Will iterate through downstream filters with the buffer if any
    * are installed.
    */
-  virtual void write(Buffer::Instance& data) PURE;
+  virtual void write(Buffer::Instance &data) PURE;
 
   /**
    * Set a soft limit on the size of buffers for the connection.
@@ -205,9 +205,47 @@ public:
    * @return boolean telling if the connection is currently above the high watermark.
    */
   virtual bool aboveHighWatermark() const PURE;
+
+  enum class PostIoAction { Close, KeepOpen };
+
+  struct IoResult {
+    PostIoAction action_;
+    uint64_t bytes_processed_;
+  };
+};
+
+class SecureLayerCallbacks {
+public:
+  virtual ~SecureLayerCallbacks() {};
+
+  virtual uint64_t id() const PURE;
+
+  virtual void closeSocket(ConnectionEvent close_type) PURE;
+
+  virtual void raiseEvent(ConnectionEvent event) PURE;
+
+  virtual bool shouldDrainReadBuffer() PURE;
+
+  virtual void setReadBufferReady() PURE;
+
+  virtual int fd() PURE;
+
+  virtual Buffer::Instance& readBuffer() PURE;
+
+  virtual Buffer::Instance& writeBuffer() PURE;
 };
 
 typedef std::unique_ptr<Connection> ConnectionPtr;
+
+class SecureLayer {
+ public:
+  virtual ~SecureLayer() {}
+  virtual Connection::IoResult doReadFromSocket() PURE;
+  virtual Connection::IoResult doWriteToSocket() PURE;
+  virtual void onConnected() PURE;
+};
+
+typedef std::unique_ptr<SecureLayer> SecureLayerPtr;
 
 /**
  * Connections capable of outbound connects.

--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -218,7 +218,7 @@ class SecureLayerCallbacks {
 public:
   virtual ~SecureLayerCallbacks() {};
 
-  virtual uint64_t id() const PURE;
+  virtual const Connection& connection() const PURE;
 
   virtual void raiseEvent(ConnectionEvent event) PURE;
 
@@ -238,13 +238,16 @@ typedef std::unique_ptr<Connection> ConnectionPtr;
 class SecureLayer {
  public:
   virtual ~SecureLayer() {}
+  virtual std::string nextProtocol() const PURE;
   virtual Connection::IoResult doReadFromSocket() PURE;
   virtual Connection::IoResult doWriteToSocket() PURE;
   virtual void onConnected() PURE;
-  virtual void closeSocket(Network::ConnectionEvent close_type) {};
+  virtual void closeSocket(Network::ConnectionEvent) {};
 };
 
 typedef std::unique_ptr<SecureLayer> SecureLayerPtr;
+
+typedef std::function<SecureLayerPtr()> SecureLayerFactoryCb;
 
 /**
  * Connections capable of outbound connects.

--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -121,6 +121,7 @@ envoy_cc_library(
         "//include/envoy/ratelimit:ratelimit_interface",
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/singleton:manager_interface",
+        "//include/envoy/ssl:context_manager_interface",
         "//include/envoy/thread_local:thread_local_interface",
         "//include/envoy/tracing:http_tracer_interface",
         "//include/envoy/upstream:cluster_manager_interface",
@@ -141,6 +142,16 @@ envoy_cc_library(
         "//include/envoy/network:filter_interface",
         "//include/envoy/network:listen_socket_interface",
         "//include/envoy/ssl:context_interface",
+        "//source/common/protobuf",
+    ],
+)
+
+envoy_cc_library(
+    name = "transport_security_config_interface",
+    hdrs = ["transport_security_config.h"],
+    deps = [
+        ":filter_config_interface",
+        "//include/envoy/network:connection_interface",
         "//source/common/protobuf",
     ],
 )

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -12,6 +12,7 @@
 #include "envoy/runtime/runtime.h"
 #include "envoy/server/admin.h"
 #include "envoy/singleton/manager.h"
+#include "envoy/ssl/context_manager.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/tracing/http_tracer.h"
 #include "envoy/upstream/cluster_manager.h"
@@ -48,6 +49,8 @@ public:
    *         for all singleton processing.
    */
   virtual Event::Dispatcher& dispatcher() PURE;
+
+  virtual Ssl::ContextManager& sslContextManager() PURE;
 
   /**
    * @return const Network::DrainDecision& a drain decision that filters can use to determine if

--- a/include/envoy/server/transport_security_config.h
+++ b/include/envoy/server/transport_security_config.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "envoy/network/connection.h"
+#include "envoy/server/filter_config.h"
+#include "common/protobuf/protobuf.h"
+
+namespace Envoy {
+namespace Server {
+namespace Configuration {
+
+typedef std::function<Network::TransportSecurityPtr(Network::TransportSecurityCallbacks&)> TransportSecurityFactoryCb;
+
+class NamedTransportSecurityConfigFactory {
+ public:
+  virtual ~NamedTransportSecurityConfigFactory() {}
+
+  virtual TransportSecurityFactoryCb createClientTransportSecurityFactory(
+      const Protobuf::Message& config,
+      FactoryContext& context) PURE;
+  virtual TransportSecurityFactoryCb createServerTransportSecurityFactory(
+      const Protobuf::Message& config,
+      FactoryContext& context) PURE;
+
+  virtual ProtobufTypes::MessagePtr createEmptyClientConfigProto() PURE;
+  virtual ProtobufTypes::MessagePtr createEmptyServerConfigProto() PURE;
+  virtual std::string name() PURE;
+};
+
+}
+}
+}

--- a/include/envoy/server/transport_security_config.h
+++ b/include/envoy/server/transport_security_config.h
@@ -8,16 +8,14 @@ namespace Envoy {
 namespace Server {
 namespace Configuration {
 
-typedef std::function<Network::TransportSecurityPtr(Network::TransportSecurityCallbacks&)> TransportSecurityFactoryCb;
-
 class NamedTransportSecurityConfigFactory {
  public:
   virtual ~NamedTransportSecurityConfigFactory() {}
 
-  virtual TransportSecurityFactoryCb createClientTransportSecurityFactory(
+  virtual Network::TransportSecurityFactoryCb createClientTransportSecurityFactory(
       const Protobuf::Message& config,
       FactoryContext& context) PURE;
-  virtual TransportSecurityFactoryCb createServerTransportSecurityFactory(
+  virtual Network::TransportSecurityFactoryCb createServerTransportSecurityFactory(
       const Protobuf::Message& config,
       FactoryContext& context) PURE;
 

--- a/include/envoy/ssl/context.h
+++ b/include/envoy/ssl/context.h
@@ -35,9 +35,11 @@ public:
 
 class ClientContext : public virtual Context {};
 typedef std::unique_ptr<ClientContext> ClientContextPtr;
+typedef std::shared_ptr<ClientContext> ClientContextSharedPtr;
 
 class ServerContext : public virtual Context {};
 typedef std::unique_ptr<ServerContext> ServerContextPtr;
+typedef std::shared_ptr<ServerContext> ServerContextSharedPtr;
 
 } // namespace Ssl
 } // namespace Envoy

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -45,6 +45,8 @@ envoy_cc_library(
         "//include/envoy/event:timer_interface",
         "//include/envoy/network:connection_interface",
         "//include/envoy/network:filter_interface",
+        "//include/envoy/registry",
+        "//include/envoy/server:transport_security_config_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/buffer:watermark_buffer_lib",
         "//source/common/common:assert_lib",

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -58,13 +58,13 @@ ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
                                Address::InstanceConstSharedPtr remote_address,
                                Address::InstanceConstSharedPtr local_address,
                                Address::InstanceConstSharedPtr bind_to_address,
-                               bool using_original_dst, bool connected)
+                               bool using_original_dst, bool connected, SecureLayerPtr secure_layer)
     : filter_manager_(*this, *this), remote_address_(remote_address), local_address_(local_address),
       write_buffer_(
           dispatcher.getWatermarkFactory().create([this]() -> void { this->onLowWatermark(); },
                                                   [this]() -> void { this->onHighWatermark(); })),
       dispatcher_(dispatcher), fd_(fd), id_(++next_global_id_),
-      using_original_dst_(using_original_dst) {
+      using_original_dst_(using_original_dst), secure_layer_(std::move(secure_layer)) {
 
   // Treat the lack of a valid fd (which in practice only happens if we run out of FDs) as an OOM
   // condition and just crash.
@@ -93,6 +93,15 @@ ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
       file_event_->activate(Event::FileReadyType::Write);
     }
   }
+}
+
+ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
+                               Address::InstanceConstSharedPtr remote_address,
+                               Address::InstanceConstSharedPtr local_address,
+                               Address::InstanceConstSharedPtr bind_to_address,
+                               bool using_original_dst, bool connected)
+    : ConnectionImpl(dispatcher, fd, remote_address, local_address, bind_to_address,
+                     using_original_dst, connected, SecureLayerPtr{new Plaintext(*this)}) {
 }
 
 ConnectionImpl::~ConnectionImpl() {
@@ -397,39 +406,7 @@ void ConnectionImpl::onFileEvent(uint32_t events) {
 }
 
 ConnectionImpl::IoResult ConnectionImpl::doReadFromSocket() {
-  PostIoAction action = PostIoAction::KeepOpen;
-  uint64_t bytes_read = 0;
-  do {
-    // 16K read is arbitrary. IIRC, libevent will currently clamp this to 4K. libevent will also
-    // use an ioctl() before every read to figure out how much data there is to read.
-    //
-    // TODO(mattklein123) PERF: Tune the read size and figure out a way of getting rid of the
-    // ioctl(). The extra syscall is not worth it.
-    int rc = read_buffer_.read(fd_, 16384);
-    ENVOY_CONN_LOG(trace, "read returns: {}", *this, rc);
-
-    // Remote close. Might need to raise data before raising close.
-    if (rc == 0) {
-      action = PostIoAction::Close;
-      break;
-    } else if (rc == -1) {
-      // Remote error (might be no data).
-      ENVOY_CONN_LOG(trace, "read error: {}", *this, errno);
-      if (errno != EAGAIN) {
-        action = PostIoAction::Close;
-      }
-
-      break;
-    } else {
-      bytes_read += rc;
-      if (shouldDrainReadBuffer()) {
-        setReadBufferReady();
-        break;
-      }
-    }
-  } while (true);
-
-  return {action, bytes_read};
+  return secure_layer_->doReadFromSocket();
 }
 
 void ConnectionImpl::onReadReady() {
@@ -450,33 +427,10 @@ void ConnectionImpl::onReadReady() {
 }
 
 ConnectionImpl::IoResult ConnectionImpl::doWriteToSocket() {
-  PostIoAction action;
-  uint64_t bytes_written = 0;
-  do {
-    if (write_buffer_->length() == 0) {
-      action = PostIoAction::KeepOpen;
-      break;
-    }
-    int rc = write_buffer_->write(fd_);
-    ENVOY_CONN_LOG(trace, "write returns: {}", *this, rc);
-    if (rc == -1) {
-      ENVOY_CONN_LOG(trace, "write error: {}", *this, errno);
-      if (errno == EAGAIN) {
-        action = PostIoAction::KeepOpen;
-      } else {
-        action = PostIoAction::Close;
-      }
-
-      break;
-    } else {
-      bytes_written += rc;
-    }
-  } while (true);
-
-  return {action, bytes_written};
+  return secure_layer_->doWriteToSocket();
 }
 
-void ConnectionImpl::onConnected() { raiseEvent(ConnectionEvent::Connected); }
+void ConnectionImpl::onConnected() { secure_layer_->onConnected(); }
 
 void ConnectionImpl::onWriteReady() {
   ENVOY_CONN_LOG(trace, "write ready", *this);
@@ -569,6 +523,76 @@ ClientConnectionImpl::ClientConnectionImpl(
     const Network::Address::InstanceConstSharedPtr source_address)
     : ConnectionImpl(dispatcher, address->socket(Address::SocketType::Stream), address,
                      getNullLocalAddress(*address), source_address, false, false) {}
+
+
+Plaintext::Plaintext(SecureLayerCallbacks& callbacks) : callbacks_(callbacks) {}
+
+void Plaintext::onConnected() {
+  callbacks_.raiseEvent(ConnectionEvent::Connected);
+}
+
+Connection::IoResult Plaintext::doReadFromSocket() {
+  Connection::PostIoAction action = Connection::PostIoAction::KeepOpen;
+  uint64_t bytes_read = 0;
+  do {
+    // 16K read is arbitrary. IIRC, libevent will currently clamp this to 4K. libevent will also
+    // use an ioctl() before every read to figure out how much data there is to read.
+    //
+    // TODO(mattklein123) PERF: Tune the read size and figure out a way of getting rid of the
+    // ioctl(). The extra syscall is not worth it.
+    int rc = callbacks_.readBuffer().read(callbacks_.fd(), 16384);
+    ENVOY_CONN_LOG(trace, "read returns: {}", callbacks_, rc);
+
+    // Remote close. Might need to raise data before raising close.
+    if (rc == 0) {
+      action = Connection::PostIoAction::Close;
+      break;
+    } else if (rc == -1) {
+      // Remote error (might be no data).
+      ENVOY_CONN_LOG(trace, "read error: {}", callbacks_, errno);
+      if (errno != EAGAIN) {
+        action = Connection::PostIoAction::Close;
+      }
+
+      break;
+    } else {
+      bytes_read += rc;
+      if (callbacks_.shouldDrainReadBuffer()) {
+        callbacks_.setReadBufferReady();
+        break;
+      }
+    }
+  } while (true);
+
+  return {action, bytes_read};
+}
+
+Connection::IoResult Plaintext::doWriteToSocket() {
+  Connection::PostIoAction action;
+  uint64_t bytes_written = 0;
+  do {
+    if (callbacks_.writeBuffer().length() == 0) {
+      action = Connection::PostIoAction::KeepOpen;
+      break;
+    }
+    int rc = callbacks_.writeBuffer().write(callbacks_.fd());
+    ENVOY_CONN_LOG(trace, "write returns: {}", callbacks_, rc);
+    if (rc == -1) {
+      ENVOY_CONN_LOG(trace, "write error: {}", callbacks_, errno);
+      if (errno == EAGAIN) {
+        action = Connection::PostIoAction::KeepOpen;
+      } else {
+        action = Connection::PostIoAction::Close;
+      }
+
+      break;
+    } else {
+      bytes_written += rc;
+    }
+  } while (true);
+
+  return {action, bytes_written};
+}
 
 } // namespace Network
 } // namespace Envoy

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -102,10 +102,8 @@ ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
                                Address::InstanceConstSharedPtr bind_to_address,
                                bool using_original_dst, bool connected)
     : ConnectionImpl(dispatcher, fd, remote_address, local_address, bind_to_address,
-                     using_original_dst, connected, [&]() -> SecureLayerPtr {
-      return SecureLayerPtr{new Plaintext(*this)};
-    }) {
-}
+                     using_original_dst, connected,
+                     [&]() -> SecureLayerPtr { return SecureLayerPtr{new Plaintext(*this)}; }) {}
 
 ConnectionImpl::~ConnectionImpl() {
   ASSERT(fd_ == -1);
@@ -529,12 +527,9 @@ ClientConnectionImpl::ClientConnectionImpl(
     : ConnectionImpl(dispatcher, address->socket(Address::SocketType::Stream), address,
                      getNullLocalAddress(*address), source_address, false, false) {}
 
-
 Plaintext::Plaintext(TransportSecurityCallbacks& callbacks) : callbacks_(callbacks) {}
 
-void Plaintext::onConnected() {
-  callbacks_.raiseEvent(ConnectionEvent::Connected);
-}
+void Plaintext::onConnected() { callbacks_.raiseEvent(ConnectionEvent::Connected); }
 
 Connection::IoResult Plaintext::doReadFromSocket() {
   Connection::PostIoAction action = Connection::PostIoAction::KeepOpen;

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -530,7 +530,7 @@ ClientConnectionImpl::ClientConnectionImpl(
                      getNullLocalAddress(*address), source_address, false, false) {}
 
 
-Plaintext::Plaintext(SecureLayerCallbacks& callbacks) : callbacks_(callbacks) {}
+Plaintext::Plaintext(TransportSecurityCallbacks& callbacks) : callbacks_(callbacks) {}
 
 void Plaintext::onConnected() {
   callbacks_.raiseEvent(ConnectionEvent::Connected);

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -161,6 +161,8 @@ Connection::State ConnectionImpl::state() const {
 }
 
 void ConnectionImpl::closeSocket(ConnectionEvent close_type) {
+  secure_layer_->closeSocket(close_type);
+
   if (fd_ == -1) {
     return;
   }

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -41,7 +41,7 @@ public:
  * Implementation of Network::Connection.
  */
 class ConnectionImpl : public virtual Connection,
-                       public virtual SecureLayerCallbacks,
+                       public virtual TransportSecurityCallbacks,
                        public BufferSource,
                        protected Logger::Loggable<Logger::Id::connection> {
 public:
@@ -91,7 +91,7 @@ public:
   Buffer::Instance& getReadBuffer() override { return read_buffer_; }
   Buffer::Instance& getWriteBuffer() override { return *current_write_buffer_; }
 
-  // Network::SecureLayerCallbacks
+  // Network::TransportSecurityCallbacks
   const Connection& connection() const override { return *this; }
   void raiseEvent(ConnectionEvent event) override;
   // Should the read buffer be drained?
@@ -179,10 +179,10 @@ public:
   void connect() override { doConnect(); }
 };
 
-class Plaintext : public SecureLayer,
+class Plaintext : public TransportSecurity,
                   protected Logger::Loggable<Logger::Id::connection> {
 public:
-  explicit Plaintext(SecureLayerCallbacks& callbacks);
+  explicit Plaintext(TransportSecurityCallbacks& callbacks);
 
   std::string nextProtocol() const override {
     return "";
@@ -191,7 +191,7 @@ public:
   Connection::IoResult doWriteToSocket() override;
   void onConnected() override;
 private:
-  SecureLayerCallbacks& callbacks_;
+  TransportSecurityCallbacks& callbacks_;
 };
 
 } // namespace Network

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -92,7 +92,6 @@ public:
   Buffer::Instance& getWriteBuffer() override { return *current_write_buffer_; }
 
   // Network::SecureLayerCallbacks
-  virtual void closeSocket(ConnectionEvent close_type) override;
   virtual void raiseEvent(ConnectionEvent event) override;
   // Should the read buffer be drained?
   virtual bool shouldDrainReadBuffer() override {
@@ -110,6 +109,7 @@ public:
  protected:
   void doConnect();
 
+  virtual void closeSocket(ConnectionEvent close_type);
   void onLowWatermark();
   void onHighWatermark();
 

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -49,7 +49,7 @@ public:
                  Address::InstanceConstSharedPtr remote_address,
                  Address::InstanceConstSharedPtr local_address,
                  Address::InstanceConstSharedPtr bind_to_address, bool using_original_dst,
-                 bool connected, TransportSecurityFactoryCb secure_layer_factory);
+                 bool connected, TransportSecurityFactoryCb transport_security_factory);
 
   ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
                  Address::InstanceConstSharedPtr remote_address,
@@ -70,7 +70,7 @@ public:
   void close(ConnectionCloseType type) override;
   Event::Dispatcher& dispatcher() override;
   uint64_t id() const override;
-  std::string nextProtocol() const override { return secure_layer_->nextProtocol(); }
+  std::string nextProtocol() const override { return transport_security_->nextProtocol(); }
   void noDelay(bool enable) override;
   void readDisable(bool disable) override;
   void detectEarlyCloseWhenReadDisabled(bool value) override { detect_early_close_ = value; }
@@ -78,9 +78,9 @@ public:
   const Address::Instance& remoteAddress() const override { return *remote_address_; }
   const Address::Instance& localAddress() const override { return *local_address_; }
   void setConnectionStats(const ConnectionStats& stats) override;
-  Ssl::Connection* ssl() override { return dynamic_cast<Ssl::Connection*>(secure_layer_.get()); }
+  Ssl::Connection* ssl() override { return dynamic_cast<Ssl::Connection*>(transport_security_.get()); }
   const Ssl::Connection* ssl() const override {
-    return dynamic_cast<const Ssl::Connection*>(secure_layer_.get());
+    return dynamic_cast<const Ssl::Connection*>(transport_security_.get());
   }
   State state() const override;
   void write(Buffer::Instance& data) override;
@@ -166,7 +166,7 @@ private:
   const bool using_original_dst_;
   bool above_high_watermark_{false};
   bool detect_early_close_{true};
-  TransportSecurityPtr secure_layer_;
+  TransportSecurityPtr transport_security_;
 };
 
 /**

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -79,7 +79,9 @@ public:
   const Address::Instance& localAddress() const override { return *local_address_; }
   void setConnectionStats(const ConnectionStats& stats) override;
   Ssl::Connection* ssl() override { return dynamic_cast<Ssl::Connection*>(secure_layer_.get()); }
-  const Ssl::Connection* ssl() const override { return dynamic_cast<const Ssl::Connection*>(secure_layer_.get()); }
+  const Ssl::Connection* ssl() const override {
+    return dynamic_cast<const Ssl::Connection*>(secure_layer_.get());
+  }
   State state() const override;
   void write(Buffer::Instance& data) override;
   void setBufferLimits(uint32_t limit) override;
@@ -107,7 +109,8 @@ public:
   int fd() override { return fd_; }
   Buffer::Instance& readBuffer() override { return read_buffer_; }
   Buffer::Instance& writeBuffer() override { return *write_buffer_; }
- protected:
+
+protected:
   void doConnect();
 
   virtual void closeSocket(ConnectionEvent close_type);
@@ -179,17 +182,15 @@ public:
   void connect() override { doConnect(); }
 };
 
-class Plaintext : public TransportSecurity,
-                  protected Logger::Loggable<Logger::Id::connection> {
+class Plaintext : public TransportSecurity, protected Logger::Loggable<Logger::Id::connection> {
 public:
   explicit Plaintext(TransportSecurityCallbacks& callbacks);
 
-  std::string nextProtocol() const override {
-    return "";
-  }
+  std::string nextProtocol() const override { return ""; }
   Connection::IoResult doReadFromSocket() override;
   Connection::IoResult doWriteToSocket() override;
   void onConnected() override;
+
 private:
   TransportSecurityCallbacks& callbacks_;
 };

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -49,7 +49,7 @@ public:
                  Address::InstanceConstSharedPtr remote_address,
                  Address::InstanceConstSharedPtr local_address,
                  Address::InstanceConstSharedPtr bind_to_address, bool using_original_dst,
-                 bool connected, SecureLayerFactoryCb secure_layer_factory);
+                 bool connected, TransportSecurityFactoryCb secure_layer_factory);
 
   ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
                  Address::InstanceConstSharedPtr remote_address,
@@ -166,7 +166,7 @@ private:
   const bool using_original_dst_;
   bool above_high_watermark_{false};
   bool detect_early_close_{true};
-  SecureLayerPtr secure_layer_;
+  TransportSecurityPtr secure_layer_;
 };
 
 /**

--- a/source/common/ssl/BUILD
+++ b/source/common/ssl/BUILD
@@ -15,6 +15,9 @@ envoy_cc_library(
     external_deps = ["ssl"],
     deps = [
         ":context_lib",
+        ":context_config_lib",
+        "//include/envoy/registry",
+        "//include/envoy/server:transport_security_config_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:empty_string",
         "//source/common/common:hex_lib",

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -36,47 +36,32 @@ ConnectionImpl::ConnectionImpl(Event::DispatcherImpl& dispatcher, int fd,
                                bool using_original_dst, bool connected, Context& ctx,
                                InitialState state)
     : Network::ConnectionImpl(dispatcher, fd, remote_address, local_address, bind_to_address,
-                              using_original_dst, connected),
-      ctx_(dynamic_cast<Ssl::ContextImpl&>(ctx)), ssl_(ctx_.newSsl()) {
-  BIO* bio = BIO_new_socket(fd, 0);
-  SSL_set_bio(ssl_.get(), bio, bio);
-
-  SSL_set_mode(ssl_.get(), SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
-  if (state == InitialState::Client) {
-    SSL_set_connect_state(ssl_.get());
-  } else {
-    ASSERT(state == InitialState::Server);
-    SSL_set_accept_state(ssl_.get());
-  }
+                              using_original_dst, connected,
+                              [&]() -> Network::SecureLayerPtr {
+                                return Network::SecureLayerPtr{new Tls(*this, ctx, static_cast<Tls::InitialState>(state))};
+                              }) {
 }
 
-ConnectionImpl::~ConnectionImpl() {
-  // Filters may care about whether this connection is an SSL connection or not in their
-  // destructors for stat reasons. We destroy the filters here vs. the base class destructors
-  // to make sure they have the chance to still inspect SSL specific data via virtual functions.
-  filter_manager_.destroyFilters();
-}
-
-Network::ConnectionImpl::IoResult ConnectionImpl::doReadFromSocket() {
+Network::Connection::IoResult Tls::doReadFromSocket() {
   if (!handshake_complete_) {
-    PostIoAction action = doHandshake();
-    if (action == PostIoAction::Close || !handshake_complete_) {
+    Network::Connection::PostIoAction action = doHandshake();
+    if (action == Network::Connection::PostIoAction::Close || !handshake_complete_) {
       return {action, 0};
     }
   }
 
   bool keep_reading = true;
-  PostIoAction action = PostIoAction::KeepOpen;
+  Network::Connection::PostIoAction action = Network::Connection::PostIoAction::KeepOpen;
   uint64_t bytes_read = 0;
   while (keep_reading) {
     // We use 2 slices here so that we can use the remainder of an existing buffer chain element
     // if there is extra space. 16K read is arbitrary and can be tuned later.
     Buffer::RawSlice slices[2];
     uint64_t slices_to_commit = 0;
-    uint64_t num_slices = read_buffer_.reserve(16384, slices, 2);
+    uint64_t num_slices = callbacks_.readBuffer().reserve(16384, slices, 2);
     for (uint64_t i = 0; i < num_slices; i++) {
       int rc = SSL_read(ssl_.get(), slices[i].mem_, slices[i].len_);
-      ENVOY_CONN_LOG(trace, "ssl read returns: {}", *this, rc);
+      ENVOY_CONN_LOG(trace, "ssl read returns: {}", callbacks_.connection(), rc);
       if (rc > 0) {
         slices[i].len_ = rc;
         slices_to_commit++;
@@ -91,7 +76,7 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doReadFromSocket() {
         // Renegotiation has started. We don't handle renegotiation so just fall through.
         default:
           drainErrorQueue();
-          action = PostIoAction::Close;
+          action = Network::Connection::PostIoAction::Close;
           break;
         }
 
@@ -100,9 +85,9 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doReadFromSocket() {
     }
 
     if (slices_to_commit > 0) {
-      read_buffer_.commit(slices, slices_to_commit);
-      if (shouldDrainReadBuffer()) {
-        setReadBufferReady();
+      callbacks_.readBuffer().commit(slices, slices_to_commit);
+      if (callbacks_.shouldDrainReadBuffer()) {
+        callbacks_.setReadBufferReady();
         keep_reading = false;
       }
     }
@@ -111,32 +96,33 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doReadFromSocket() {
   return {action, bytes_read};
 }
 
-Network::ConnectionImpl::PostIoAction ConnectionImpl::doHandshake() {
+Network::Connection::PostIoAction Tls::doHandshake() {
   ASSERT(!handshake_complete_);
   int rc = SSL_do_handshake(ssl_.get());
   if (rc == 1) {
-    ENVOY_CONN_LOG(debug, "handshake complete", *this);
+    ENVOY_CONN_LOG(debug, "handshake complete", callbacks_.connection());
     handshake_complete_ = true;
     ctx_.logHandshake(ssl_.get());
-    raiseEvent(Network::ConnectionEvent::Connected);
+    callbacks_.raiseEvent(Network::ConnectionEvent::Connected);
 
     // It's possible that we closed during the handshake callback.
-    return state() == State::Open ? PostIoAction::KeepOpen : PostIoAction::Close;
+    return callbacks_.connection().state() == Network::Connection::State::Open ?
+           Network::Connection::PostIoAction::KeepOpen : Network::Connection::PostIoAction::Close;
   } else {
     int err = SSL_get_error(ssl_.get(), rc);
-    ENVOY_CONN_LOG(debug, "handshake error: {}", *this, err);
+    ENVOY_CONN_LOG(debug, "handshake error: {}", callbacks_.connection(), err);
     switch (err) {
     case SSL_ERROR_WANT_READ:
     case SSL_ERROR_WANT_WRITE:
-      return PostIoAction::KeepOpen;
+      return Network::Connection::PostIoAction::KeepOpen;
     default:
       drainErrorQueue();
-      return PostIoAction::Close;
+      return Network::Connection::PostIoAction::Close;
     }
   }
 }
 
-void ConnectionImpl::drainErrorQueue() {
+void Tls::drainErrorQueue() {
   bool saw_error = false;
   bool saw_counted_error = false;
   while (uint64_t err = ERR_get_error()) {
@@ -150,7 +136,7 @@ void ConnectionImpl::drainErrorQueue() {
     }
     saw_error = true;
 
-    ENVOY_CONN_LOG(debug, "SSL error: {}:{}:{}:{}", *this, err, ERR_lib_error_string(err),
+    ENVOY_CONN_LOG(debug, "SSL error: {}:{}:{}:{}", callbacks_.connection(), err, ERR_lib_error_string(err),
                    ERR_func_error_string(err), ERR_reason_error_string(err));
     UNREFERENCED_PARAMETER(err);
   }
@@ -159,15 +145,15 @@ void ConnectionImpl::drainErrorQueue() {
   }
 }
 
-Network::ConnectionImpl::IoResult ConnectionImpl::doWriteToSocket() {
+Network::Connection::IoResult Tls::doWriteToSocket() {
   if (!handshake_complete_) {
-    PostIoAction action = doHandshake();
-    if (action == PostIoAction::Close || !handshake_complete_) {
+    Network::Connection::PostIoAction action = doHandshake();
+    if (action == Network::Connection::PostIoAction::Close || !handshake_complete_) {
       return {action, 0};
     }
   }
 
-  uint64_t original_buffer_length = write_buffer_->length();
+  uint64_t original_buffer_length = callbacks_.writeBuffer().length();
   uint64_t total_bytes_written = 0;
   bool keep_writing = true;
   while ((original_buffer_length != total_bytes_written) && keep_writing) {
@@ -178,7 +164,7 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doWriteToSocket() {
     // of iterations of this loop, either by pure iterations, bytes written, etc.
     const uint64_t MAX_SLICES = 32;
     Buffer::RawSlice slices[MAX_SLICES];
-    uint64_t num_slices = write_buffer_->getRawSlices(slices, MAX_SLICES);
+    uint64_t num_slices = callbacks_.writeBuffer().getRawSlices(slices, MAX_SLICES);
 
     uint64_t inner_bytes_written = 0;
     for (uint64_t i = 0; (i < num_slices) && (original_buffer_length != total_bytes_written); i++) {
@@ -189,7 +175,7 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doWriteToSocket() {
       // particular chain to increase in size. So as long as we start writing where we left off we
       // are guaranteed to call SSL_write() with the same parameters.
       int rc = SSL_write(ssl_.get(), slices[i].mem_, slices[i].len_);
-      ENVOY_CONN_LOG(trace, "ssl write returns: {}", *this, rc);
+      ENVOY_CONN_LOG(trace, "ssl write returns: {}", callbacks_.connection(), rc);
       if (rc > 0) {
         inner_bytes_written += rc;
         total_bytes_written += rc;
@@ -203,7 +189,7 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doWriteToSocket() {
         // Renegotiation has started. We don't handle renegotiation so just fall through.
         default:
           drainErrorQueue();
-          return {PostIoAction::Close, total_bytes_written};
+          return {Network::Connection::PostIoAction::Close, total_bytes_written};
         }
 
         break;
@@ -213,21 +199,19 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doWriteToSocket() {
     // Draining must be done within the inner loop, otherwise we will keep getting the same slices
     // at the beginning of the buffer.
     if (inner_bytes_written > 0) {
-      write_buffer_->drain(inner_bytes_written);
+      callbacks_.writeBuffer().drain(inner_bytes_written);
     }
   }
 
-  return {PostIoAction::KeepOpen, total_bytes_written};
+  return {Network::Connection::PostIoAction::KeepOpen, total_bytes_written};
 }
 
-void ConnectionImpl::onConnected() { ASSERT(!handshake_complete_); }
-
-bool ConnectionImpl::peerCertificatePresented() {
+bool Tls::peerCertificatePresented() {
   bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
   return cert != nullptr;
 }
 
-std::string ConnectionImpl::uriSanLocalCertificate() {
+std::string Tls::uriSanLocalCertificate() {
   // The cert object is not owned.
   X509* cert = SSL_get_certificate(ssl_.get());
   if (!cert) {
@@ -236,7 +220,7 @@ std::string ConnectionImpl::uriSanLocalCertificate() {
   return getUriSanFromCertificate(cert);
 }
 
-std::string ConnectionImpl::sha256PeerCertificateDigest() {
+std::string Tls::sha256PeerCertificateDigest() {
   bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
   if (!cert) {
     return "";
@@ -249,7 +233,7 @@ std::string ConnectionImpl::sha256PeerCertificateDigest() {
   return Hex::encode(computed_hash);
 }
 
-std::string ConnectionImpl::subjectPeerCertificate() {
+std::string Tls::subjectPeerCertificate() {
   bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
   if (!cert) {
     return "";
@@ -269,7 +253,7 @@ std::string ConnectionImpl::subjectPeerCertificate() {
   return std::string(reinterpret_cast<const char*>(data), data_len);
 }
 
-std::string ConnectionImpl::uriSanPeerCertificate() {
+std::string Tls::uriSanPeerCertificate() {
   bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
   if (!cert) {
     return "";
@@ -277,7 +261,7 @@ std::string ConnectionImpl::uriSanPeerCertificate() {
   return getUriSanFromCertificate(cert.get());
 }
 
-std::string ConnectionImpl::getUriSanFromCertificate(X509* cert) {
+std::string Tls::getUriSanFromCertificate(X509* cert) {
   STACK_OF(GENERAL_NAME)* altnames = static_cast<STACK_OF(GENERAL_NAME)*>(
       X509_get_ext_d2i(cert, NID_subject_alt_name, nullptr, nullptr));
 
@@ -314,21 +298,7 @@ ClientConnectionImpl::ClientConnectionImpl(Event::DispatcherImpl& dispatcher, Co
 
 void ClientConnectionImpl::connect() { doConnect(); }
 
-void ConnectionImpl::closeSocket(Network::ConnectionEvent close_type) {
-  if (handshake_complete_ && state() != State::Closed) {
-    // Attempt to send a shutdown before closing the socket. It's possible this won't go out if
-    // there is no room on the socket. We can extend the state machine to handle this at some point
-    // if needed.
-    int rc = SSL_shutdown(ssl_.get());
-    ENVOY_CONN_LOG(debug, "SSL shutdown: rc={}", *this, rc);
-    UNREFERENCED_PARAMETER(rc);
-    drainErrorQueue();
-  }
-
-  Network::ConnectionImpl::closeSocket(close_type);
-}
-
-std::string ConnectionImpl::nextProtocol() const {
+std::string Tls::nextProtocol() const {
   const unsigned char* proto;
   unsigned int proto_len;
   SSL_get0_alpn_selected(ssl_.get(), &proto, &proto_len);
@@ -350,5 +320,20 @@ Tls::Tls(Network::SecureLayerCallbacks &callbacks, Context &ctx, InitialState st
   }
 }
 
+void Tls::onConnected() {
+  ASSERT(!handshake_complete_);
+}
+
+void Tls::closeSocket(Network::ConnectionEvent) {
+  if (handshake_complete_ && callbacks_.connection().state() != Network::Connection::State::Closed) {
+    // Attempt to send a shutdown before closing the socket. It's possible this won't go out if
+    // there is no room on the socket. We can extend the state machine to handle this at some point
+    // if needed.
+    int rc = SSL_shutdown(ssl_.get());
+    ENVOY_CONN_LOG(debug, "SSL shutdown: rc={}", callbacks_.connection(), rc);
+    UNREFERENCED_PARAMETER(rc);
+    drainErrorQueue();
+  }
+}
 } // namespace Ssl
 } // namespace Envoy

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -305,7 +305,7 @@ std::string Tls::nextProtocol() const {
   return std::string(reinterpret_cast<const char*>(proto), proto_len);
 }
 
-Tls::Tls(Network::SecureLayerCallbacks &callbacks, Context &ctx, InitialState state)
+Tls::Tls(Network::TransportSecurityCallbacks &callbacks, Context &ctx, InitialState state)
     : callbacks_(callbacks),
       ctx_(dynamic_cast<Ssl::ContextImpl&>(ctx)), ssl_(ctx_.newSsl()) {
   BIO* bio = BIO_new_socket(callbacks.fd(), 0);

--- a/source/common/ssl/connection_impl.h
+++ b/source/common/ssl/connection_impl.h
@@ -32,15 +32,15 @@ public:
   void connect() override;
 };
 
-class Tls : public Network::SecureLayer,
+class Tls : public Network::TransportSecurity,
             public Connection,
             protected Logger::Loggable<Logger::Id::connection> {
  public:
   enum class InitialState { Client, Server };
 
-  Tls(Network::SecureLayerCallbacks& callbacks, Context& ctx, InitialState state);
+  Tls(Network::TransportSecurityCallbacks& callbacks, Context& ctx, InitialState state);
 
-  // Network::SecureLayer
+  // Network::TransportSecurity
   std::string nextProtocol() const override;
   Network::Connection::IoResult doReadFromSocket() override;
   Network::Connection::IoResult doWriteToSocket() override;
@@ -61,7 +61,7 @@ class Tls : public Network::SecureLayer,
   void drainErrorQueue();
   std::string getUriSanFromCertificate(X509* cert);
 
-  Network::SecureLayerCallbacks& callbacks_;
+  Network::TransportSecurityCallbacks& callbacks_;
   ContextImpl& ctx_;
   bssl::UniquePtr<SSL> ssl_;
   bool handshake_complete_{};

--- a/source/common/ssl/connection_impl.h
+++ b/source/common/ssl/connection_impl.h
@@ -35,7 +35,7 @@ public:
 class Tls : public Network::TransportSecurity,
             public Connection,
             protected Logger::Loggable<Logger::Id::connection> {
- public:
+public:
   enum class InitialState { Client, Server };
 
   Tls(Network::TransportSecurityCallbacks& callbacks, Context& ctx, InitialState state);
@@ -56,7 +56,7 @@ class Tls : public Network::TransportSecurity,
 
   SSL* rawSslForTest() { return ssl_.get(); }
 
- private:
+private:
   Network::Connection::PostIoAction doHandshake();
   void drainErrorQueue();
   std::string getUriSanFromCertificate(X509* cert);

--- a/source/common/ssl/connection_impl.h
+++ b/source/common/ssl/connection_impl.h
@@ -62,5 +62,27 @@ public:
   void connect() override;
 };
 
+class Tls : public Network::SecureLayer,
+            public Connection,
+            protected Logger::Loggable<Logger::Id::connection> {
+ public:
+  enum class InitialState { Client, Server };
+
+  explicit Tls(Network::SecureLayerCallbacks& callbacks, Context& ctx, InitialState state);
+
+  // Network::SecureLayer
+  virtual Network::Connection::IoResult doReadFromSocket() override;
+  virtual Network::Connection::IoResult doWriteToSocket() override;
+  virtual void onConnected() override;
+
+  // Ssl::Connection
+
+ private:
+  Network::SecureLayerCallbacks& callbacks_;
+  ContextImpl& ctx_;
+  bssl::UniquePtr<SSL> ssl_;
+  bool handshake_complete_{};
+};
+
 } // namespace Ssl
 } // namespace Envoy

--- a/source/common/ssl/context_config_impl.cc
+++ b/source/common/ssl/context_config_impl.cc
@@ -150,5 +150,6 @@ void ServerContextConfigImpl::validateAndAppendKey(
   ASSERT(key_data.begin() + pos == key_data.end());
 }
 
+
 } // namespace Ssl
 } // namespace Envoy

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -208,6 +208,7 @@ public:
   }
   Upstream::ClusterManager& clusterManager() override { return parent_.server_.clusterManager(); }
   Event::Dispatcher& dispatcher() override { return parent_.server_.dispatcher(); }
+  Ssl::ContextManager& sslContextManager() override { return parent_.server_.sslContextManager(); }
   Network::DrainDecision& drainDecision() override { return *this; }
   bool healthCheckFailed() override { return parent_.server_.healthCheckFailed(); }
   Tracing::HttpTracer& httpTracer() override { return parent_.server_.httpTracer(); }


### PR DESCRIPTION
Early prototype of the interface for transport security and registry. Context for https://github.com/envoyproxy/data-plane-api/pull/189

- [ ] Better class / method naming
- [ ] Better header structure
- [ ] Comments
- [ ] Using registry in dispatcher, etc.

 @mattklein123 @htuch @alyssawilk 