### PR TITLE
Generalizing config overrides via headers

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -225,6 +225,15 @@ private:
   HEADER_FUNC(EnvoyInternalRequest)                                                                \
   HEADER_FUNC(EnvoyMaxRetries)                                                                     \
   HEADER_FUNC(EnvoyOriginalPath)                                                                   \
+  HEADER_FUNC(EnvoyOutlierIntervalMs)                                                              \
+  HEADER_FUNC(EnvoyOutlierBaseEjectionTimeMs)                                                      \
+  HEADER_FUNC(EnvoyOutlierConsecutive5xx)                                                          \
+  HEADER_FUNC(EnvoyOutlierMaxEjectionPercent)                                                      \
+  HEADER_FUNC(EnvoyOutlierSuccessRateMinimumHosts)                                                 \
+  HEADER_FUNC(EnvoyOutlierSuccessRateRequestVolume)                                                \
+  HEADER_FUNC(EnvoyOutlierSuccessRateStdevFactor)                                                  \
+  HEADER_FUNC(EnvoyOutlierEnforcingConsecutive5xx)                                                 \
+  HEADER_FUNC(EnvoyOutlierEnforcingSuccessRate)                                                    \
   HEADER_FUNC(EnvoyOverloaded)                                                                     \
   HEADER_FUNC(EnvoyRetryOn)                                                                        \
   HEADER_FUNC(EnvoyRetryGrpcOn)                                                                    \

--- a/include/envoy/ssl/context_config.h
+++ b/include/envoy/ssl/context_config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -72,6 +73,8 @@ public:
    * Otherwise, ""
    */
   virtual const std::string& serverNameIndication() const PURE;
+
+  typedef std::shared_ptr<const ClientContextConfig> ConstSharedPtr;
 };
 
 class ServerContextConfig : public virtual ContextConfig {
@@ -93,6 +96,8 @@ public:
    * are candidates for decrypting received tickets.
    */
   virtual const std::vector<SessionTicketKey>& sessionTicketKeys() const PURE;
+
+  typedef std::shared_ptr<const ServerContextConfig> ConstSharedPtr;
 };
 
 } // namespace Ssl

--- a/include/envoy/ssl/context_manager.h
+++ b/include/envoy/ssl/context_manager.h
@@ -20,13 +20,13 @@ public:
    * Builds a ClientContext from a ClientContextConfig.
    */
   virtual ClientContextPtr createSslClientContext(Stats::Scope& scope,
-                                                  ClientContextConfig& config) PURE;
+                                                  const ClientContextConfig& config) PURE;
 
   /**
    * Builds a ServerContext from a ServerContextConfig.
    */
   virtual ServerContextPtr createSslServerContext(Stats::Scope& scope,
-                                                  ServerContextConfig& config) PURE;
+                                                  const ServerContextConfig& config) PURE;
 
   /**
    * @return the number of days until the next certificate being managed will expire.

--- a/include/envoy/upstream/BUILD
+++ b/include/envoy/upstream/BUILD
@@ -9,6 +9,19 @@ load(
 envoy_package()
 
 envoy_cc_library(
+    name = "cluster_config_interface",
+    hdrs = ["cluster_config.h"],
+    external_deps = [
+        "envoy_cds",
+    ],
+    deps = [
+        ":load_balancer_type_interface",
+        "//include/envoy/http:codec_interface",
+        "//include/envoy/ssl:context_config_interface",
+    ],
+)
+
+envoy_cc_library(
     name = "cluster_manager_interface",
     hdrs = ["cluster_manager.h"],
     external_deps = [
@@ -92,6 +105,7 @@ envoy_cc_library(
     name = "upstream_interface",
     hdrs = ["upstream.h"],
     deps = [
+        ":cluster_config_interface",
         ":health_check_host_monitor_interface",
         ":load_balancer_type_interface",
         ":resource_manager_interface",

--- a/include/envoy/upstream/cluster_config.h
+++ b/include/envoy/upstream/cluster_config.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include "envoy/common/pure.h"
+#include "envoy/http/codec.h"
+#include "envoy/network/address.h"
+#include "envoy/ssl/context_config.h"
+#include "envoy/upstream/load_balancer_type.h"
+
+namespace Envoy {
+namespace Upstream {
+
+/**
+ * Configuration for an upstream cluster.
+ */
+class ClusterConfig {
+public:
+
+  /**
+   * The configuration for outlier detection for the upstream cluster.
+   */
+  class OutlierDetectionConfig {
+  public:
+    virtual ~OutlierDetectionConfig() {}
+
+    virtual uint64_t intervalMs() const PURE;
+    virtual uint64_t baseEjectionTimeMs() const PURE;
+    virtual uint64_t consecutive5xx() const PURE;
+    virtual uint64_t maxEjectionPercent() const PURE;
+    virtual uint64_t successRateMinimumHosts() const PURE;
+    virtual uint64_t successRateRequestVolume() const PURE;
+    virtual uint64_t successRateStdevFactor() const PURE;
+    virtual uint64_t enforcingConsecutive5xx() const PURE;
+    virtual uint64_t enforcingSuccessRate() const PURE;
+
+    typedef std::shared_ptr<const OutlierDetectionConfig> ConstSharedPtr;
+  };
+
+  class CircuitBreakerConfig {
+  public:
+
+    class Thresholds {
+    public:
+      virtual ~Thresholds() {}
+
+      virtual envoy::api::v2::RoutingPriority priority() const PURE;
+      virtual uint32_t maxConnections() const PURE;
+      virtual uint32_t maxPendingRequests() const PURE;
+      virtual uint32_t maxRequests() const PURE;
+      virtual uint32_t maxRetries() const PURE;
+
+      typedef std::shared_ptr<const Thresholds> ConstSharedPtr;
+    };
+
+  public:
+
+    virtual ~CircuitBreakerConfig() {}
+
+    virtual const std::vector<Thresholds::ConstSharedPtr>& thresholds() const PURE;
+  };
+
+public:
+  virtual ~ClusterConfig() {}
+
+  virtual const std::string& name() const PURE;
+
+  virtual uint64_t maxRequestsPerConnection() const PURE;
+
+  virtual const std::chrono::milliseconds& connectTimeout() const PURE;
+
+  virtual uint32_t perConnectionBufferLimitBytes() const PURE;
+
+  virtual uint64_t features() const PURE;
+
+  virtual const Http::Http2Settings& http2Settings() const PURE;
+
+  virtual const Network::Address::InstanceConstSharedPtr& sourceAddress() const PURE;
+
+  virtual const Ssl::ClientContextConfig::ConstSharedPtr& tlsContextConfig() const PURE;
+
+  virtual LoadBalancerType lbType() const PURE;
+
+  virtual const LoadBalancerSubsetInfo& lbSubsetInfo() const PURE;
+
+  virtual const OutlierDetectionConfig::ConstSharedPtr& outlierDetectionConfig() const PURE;
+
+  virtual const CircuitBreakerConfig& circuitBreakerConfig() const PURE;
+
+  typedef std::shared_ptr<const ClusterConfig> ConstSharedPtr;
+};
+
+} // namespace Upstream
+} // namespace Envoy

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -38,6 +38,15 @@ public:
   const LowerCaseString EnvoyInternalRequest{"x-envoy-internal"};
   const LowerCaseString EnvoyMaxRetries{"x-envoy-max-retries"};
   const LowerCaseString EnvoyOriginalPath{"x-envoy-original-path"};
+  const LowerCaseString EnvoyOutlierIntervalMs{"x-envoy-outlier-interval_ms"};
+  const LowerCaseString EnvoyOutlierBaseEjectionTimeMs{"x-envoy-outlier-base-ejection-time_ms"};
+  const LowerCaseString EnvoyOutlierConsecutive5xx{"x-envoy-outlier-consecutive-5xx"};
+  const LowerCaseString EnvoyOutlierMaxEjectionPercent{"x-envoy-outlier-max-ejection-percent"};
+  const LowerCaseString EnvoyOutlierSuccessRateMinimumHosts{"x-envoy-outlier-success-rate-minimum-hosts"};
+  const LowerCaseString EnvoyOutlierSuccessRateRequestVolume{"x-envoy-outlier-success-rate-request-volume"};
+  const LowerCaseString EnvoyOutlierSuccessRateStdevFactor{"x-envoy-outlier-success-rate-stdev-factor"};
+  const LowerCaseString EnvoyOutlierEnforcingConsecutive5xx{"x-envoy-outlier-enforcing-consecutive-5xx"};
+  const LowerCaseString EnvoyOutlierEnforcingSuccessRate{"x-envoy-outlier-enforcing-success-rate"};
   const LowerCaseString EnvoyOverloaded{"x-envoy-overloaded"};
   const LowerCaseString EnvoyRetryOn{"x-envoy-retry-on"};
   const LowerCaseString EnvoyRetryGrpcOn{"x-envoy-retry-grpc-on"};

--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -27,7 +27,7 @@ int ContextImpl::sslContextIndex() {
   }());
 }
 
-ContextImpl::ContextImpl(ContextManagerImpl& parent, Stats::Scope& scope, ContextConfig& config)
+ContextImpl::ContextImpl(ContextManagerImpl& parent, Stats::Scope& scope, const ContextConfig& config)
     : parent_(parent), ctx_(SSL_CTX_new(TLS_method())), scope_(scope),
       stats_(generateStats(scope)) {
   RELEASE_ASSERT(ctx_);
@@ -331,7 +331,7 @@ bssl::UniquePtr<X509> ContextImpl::loadCert(const std::string& cert_file) {
 };
 
 ClientContextImpl::ClientContextImpl(ContextManagerImpl& parent, Stats::Scope& scope,
-                                     ClientContextConfig& config)
+                                     const ClientContextConfig& config)
     : ContextImpl(parent, scope, config) {
   if (!parsed_alpn_protocols_.empty()) {
     int rc = SSL_CTX_set_alpn_protos(ctx_.get(), &parsed_alpn_protocols_[0],
@@ -356,7 +356,7 @@ bssl::UniquePtr<SSL> ClientContextImpl::newSsl() const {
 }
 
 ServerContextImpl::ServerContextImpl(ContextManagerImpl& parent, Stats::Scope& scope,
-                                     ServerContextConfig& config, Runtime::Loader& runtime)
+                                     const ServerContextConfig& config, Runtime::Loader& runtime)
     : ContextImpl(parent, scope, config), runtime_(runtime),
       session_ticket_keys_(config.sessionTicketKeys()) {
   if (!config.caCertFile().empty()) {

--- a/source/common/ssl/context_impl.h
+++ b/source/common/ssl/context_impl.h
@@ -77,7 +77,7 @@ public:
   std::string getCertChainInformation() override;
 
 protected:
-  ContextImpl(ContextManagerImpl& parent, Stats::Scope& scope, ContextConfig& config);
+  ContextImpl(ContextManagerImpl& parent, Stats::Scope& scope, const ContextConfig& config);
 
   /**
    * The global SSL-library index used for storing a pointer to the context
@@ -123,7 +123,7 @@ protected:
 
 class ClientContextImpl : public ContextImpl, public ClientContext {
 public:
-  ClientContextImpl(ContextManagerImpl& parent, Stats::Scope& scope, ClientContextConfig& config);
+  ClientContextImpl(ContextManagerImpl& parent, Stats::Scope& scope, const ClientContextConfig& config);
 
   bssl::UniquePtr<SSL> newSsl() const override;
 
@@ -133,7 +133,7 @@ private:
 
 class ServerContextImpl : public ContextImpl, public ServerContext {
 public:
-  ServerContextImpl(ContextManagerImpl& parent, Stats::Scope& scope, ServerContextConfig& config,
+  ServerContextImpl(ContextManagerImpl& parent, Stats::Scope& scope, const ServerContextConfig& config,
                     Runtime::Loader& runtime);
 
 private:

--- a/source/common/ssl/context_manager_impl.cc
+++ b/source/common/ssl/context_manager_impl.cc
@@ -21,7 +21,7 @@ void ContextManagerImpl::releaseContext(Context* context) {
 }
 
 ClientContextPtr ContextManagerImpl::createSslClientContext(Stats::Scope& scope,
-                                                            ClientContextConfig& config) {
+                                                            const ClientContextConfig& config) {
 
   ClientContextPtr context(new ClientContextImpl(*this, scope, config));
   std::unique_lock<std::mutex> lock(contexts_lock_);
@@ -30,7 +30,7 @@ ClientContextPtr ContextManagerImpl::createSslClientContext(Stats::Scope& scope,
 }
 
 ServerContextPtr ContextManagerImpl::createSslServerContext(Stats::Scope& scope,
-                                                            ServerContextConfig& config) {
+                                                            const ServerContextConfig& config) {
   ServerContextPtr context(new ServerContextImpl(*this, scope, config, runtime_));
   std::unique_lock<std::mutex> lock(contexts_lock_);
   contexts_.emplace_back(context.get());

--- a/source/common/ssl/context_manager_impl.h
+++ b/source/common/ssl/context_manager_impl.h
@@ -31,9 +31,9 @@ public:
 
   // Ssl::ContextManager
   Ssl::ClientContextPtr createSslClientContext(Stats::Scope& scope,
-                                               ClientContextConfig& config) override;
+                                               const ClientContextConfig& config) override;
   Ssl::ServerContextPtr createSslServerContext(Stats::Scope& scope,
-                                               ServerContextConfig& config) override;
+                                               const ServerContextConfig& config) override;
   size_t daysUntilFirstCertExpires() override;
   void iterateContexts(std::function<void(Context&)> callback) override;
 

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -46,6 +46,26 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "cluster_config_lib",
+    srcs = [
+        "cluster_config_impl.cc",
+    ],
+    hdrs = [
+        "cluster_config_impl.h",
+        "overridable_cluster_config.h",
+    ],
+    external_deps = ["envoy_base"],
+    deps = [
+        ":cds_api_lib",
+        ":load_balancer_lib",
+        "//include/envoy/upstream:cluster_config_interface",
+        "//source/common/http:utility_lib",
+        "//source/common/network:resolver_lib",
+        "//source/common/ssl:context_config_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "cluster_manager_lib",
     srcs = ["cluster_manager_impl.cc"],
     hdrs = ["cluster_manager_impl.h"],
@@ -317,6 +337,7 @@ envoy_cc_library(
     hdrs = ["upstream_impl.h"],
     external_deps = ["envoy_base"],
     deps = [
+        ":cluster_config_lib",
         ":load_balancer_lib",
         ":outlier_detection_lib",
         ":resource_manager_lib",

--- a/source/common/upstream/cluster_config_impl.cc
+++ b/source/common/upstream/cluster_config_impl.cc
@@ -1,0 +1,128 @@
+#include "common/upstream/cluster_config_impl.h"
+
+#include <fmt/format.h>
+
+#include "common/common/assert.h"
+#include "common/http/utility.h"
+#include "common/network/resolver_impl.h"
+#include "common/protobuf/utility.h"
+#include "common/ssl/context_config_impl.h"
+
+#include "envoy/upstream/upstream.h"
+
+namespace Envoy {
+namespace Upstream {
+
+namespace {
+
+static Network::Address::InstanceConstSharedPtr
+toSourceAddress(const envoy::api::v2::Cluster& config) {
+  if (config.upstream_bind_config().has_source_address()) {
+    return Network::Address::resolveProtoSocketAddress(
+        config.upstream_bind_config().source_address());
+  }
+  return nullptr;
+}
+
+static Ssl::ClientContextConfig::ConstSharedPtr
+toTlsContext(const envoy::api::v2::Cluster& config) {
+  if (config.has_tls_context()) {
+    return std::make_shared<Ssl::ClientContextConfigImpl>(config.tls_context());
+  }
+  return nullptr;
+}
+
+static uint64_t parseFeatures(const envoy::api::v2::Cluster& config) {
+  uint64_t features = 0;
+  if (config.has_http2_protocol_options()) {
+    features |= ClusterInfo::Features::HTTP2;
+  }
+  return features;
+}
+
+static LoadBalancerType toLbType(const envoy::api::v2::Cluster& config) {
+  switch (config.lb_policy()) {
+    case envoy::api::v2::Cluster::ROUND_ROBIN:
+      return LoadBalancerType::RoundRobin;
+    case envoy::api::v2::Cluster::LEAST_REQUEST:
+      return LoadBalancerType::LeastRequest;
+    case envoy::api::v2::Cluster::RANDOM:
+      return LoadBalancerType::Random;
+    case envoy::api::v2::Cluster::RING_HASH:
+      return LoadBalancerType::RingHash;
+    case envoy::api::v2::Cluster::ORIGINAL_DST_LB:
+      if (config.type() != envoy::api::v2::Cluster::ORIGINAL_DST) {
+        throw EnvoyException(fmt::format(
+            "cluster: LB type 'original_dst_lb' may only be used with cluser type 'original_dst'"));
+      }
+      return LoadBalancerType::OriginalDst;
+    default:
+      NOT_REACHED;
+  }
+}
+
+
+static ClusterConfig::OutlierDetectionConfig* toOutlierDetectionConfig(const envoy::api::v2::Cluster& config) {
+  if (config.has_outlier_detection()) {
+    return new ClusterConfigImpl::OutlierDetectionConfigImpl(config.outlier_detection());
+  }
+  return nullptr;
+}
+} // namespace
+
+ClusterConfigImpl::CircuitBreakerConfigImpl::ThresholdsImpl::ThresholdsImpl(const envoy::api::v2::CircuitBreakers_Thresholds& config)
+: priority_(config.priority()),
+  max_connections_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, max_connections, 1024)),
+  max_pending_requests_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, max_pending_requests, 1024)),
+  max_requests_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, max_requests, 1024)),
+  max_retries_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, max_retries, 3)) {
+}
+
+ClusterConfigImpl::CircuitBreakerConfigImpl::CircuitBreakerConfigImpl(const envoy::api::v2::CircuitBreakers& config)
+: thresholds_(static_cast<std::vector<Thresholds::ConstSharedPtr>::size_type>(config.thresholds_size())) {
+  const auto& thresholds = config.thresholds();
+  for (auto it = thresholds.begin(); it != thresholds.end(); ++it) {
+    thresholds_.push_back(std::make_shared<ClusterConfigImpl::CircuitBreakerConfigImpl::ThresholdsImpl>(*it));
+  }
+}
+
+ClusterConfigImpl::OutlierDetectionConfigImpl::OutlierDetectionConfigImpl(const envoy::api::v2::Cluster::OutlierDetection& config)
+    : interval_ms_(static_cast<uint64_t>(PROTOBUF_GET_MS_OR_DEFAULT(config, interval, 10000))),
+      base_ejection_time_ms_(
+          static_cast<uint64_t>(PROTOBUF_GET_MS_OR_DEFAULT(config, base_ejection_time, 30000))),
+      consecutive_5xx_(
+          static_cast<uint64_t>(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, consecutive_5xx, 5))),
+      max_ejection_percent_(
+          static_cast<uint64_t>(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, max_ejection_percent, 10))),
+      success_rate_minimum_hosts_(static_cast<uint64_t>(
+                                      PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, success_rate_minimum_hosts, 5))),
+      success_rate_request_volume_(static_cast<uint64_t>(
+                                       PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, success_rate_request_volume, 100))),
+      success_rate_stdev_factor_(static_cast<uint64_t>(
+                                     PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, success_rate_stdev_factor, 1900))),
+      enforcing_consecutive_5xx_(static_cast<uint64_t>(
+                                     PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, enforcing_consecutive_5xx, 100))),
+      enforcing_success_rate_(static_cast<uint64_t>(
+                                  PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, enforcing_success_rate, 100))) {}
+
+ClusterConfigImpl::ClusterConfigImpl(const envoy::api::v2::Cluster& config)
+: name_(config.name()),
+  max_requests_per_connection_(
+      PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, max_requests_per_connection, 0)),
+  connect_timeout_(
+      std::chrono::milliseconds(PROTOBUF_GET_MS_REQUIRED(config, connect_timeout))),
+  per_connection_buffer_limit_bytes_(
+      PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, per_connection_buffer_limit_bytes, 1024 * 1024)),
+  features_(parseFeatures(config)),
+  http2_settings_(Http::Utility::parseHttp2Settings(config.http2_protocol_options())),
+  source_address_(toSourceAddress(config)),
+  tls_context_config_(toTlsContext(config)),
+  lb_type_(toLbType(config)),
+  lb_subset_info_(config.lb_subset_config()),
+  outlier_detection_config_(toOutlierDetectionConfig(config)),
+  circuit_breaker_config_(config.circuit_breakers()) {
+  printf("NM: ClusterConfigImpl created\n");
+}
+
+} // namespace Upstream
+} // namespace Envoy

--- a/source/common/upstream/cluster_config_impl.h
+++ b/source/common/upstream/cluster_config_impl.h
@@ -1,0 +1,175 @@
+#pragma once
+
+#include <chrono>
+#include <string>
+
+#include "common/upstream/load_balancer_impl.h"
+
+#include "envoy/upstream/cluster_config.h"
+#include "envoy/network/address.h"
+#include "envoy/upstream/load_balancer_type.h"
+
+#include "external/envoy_api/api/cds.pb.h"
+
+namespace Envoy {
+namespace Upstream {
+
+class ClusterConfigImpl : public ClusterConfig {
+public:
+
+  ClusterConfigImpl(const envoy::api::v2::Cluster& cluster);
+  virtual ~ClusterConfigImpl() {}
+
+  const std::string& name() const override {
+    return name_;
+  }
+
+  uint64_t maxRequestsPerConnection() const override {
+    return max_requests_per_connection_;
+  }
+
+  const std::chrono::milliseconds& connectTimeout() const override {
+    return connect_timeout_;
+  }
+
+  uint32_t perConnectionBufferLimitBytes() const override {
+    return per_connection_buffer_limit_bytes_;
+  }
+
+  uint64_t features() const override {
+    return features_;
+  }
+
+  const Http::Http2Settings& http2Settings() const override {
+    return http2_settings_;
+  }
+
+  const Network::Address::InstanceConstSharedPtr& sourceAddress() const override {
+    return source_address_;
+  }
+
+  const Ssl::ClientContextConfig::ConstSharedPtr& tlsContextConfig() const override {
+    return tls_context_config_;
+  }
+
+  LoadBalancerType lbType() const override {
+    return lb_type_;
+  }
+
+  const LoadBalancerSubsetInfoImpl& lbSubsetInfo() const override {
+    return lb_subset_info_;
+  }
+
+  const OutlierDetectionConfig::ConstSharedPtr& outlierDetectionConfig() const override {
+    return outlier_detection_config_;
+  }
+
+  const CircuitBreakerConfig& circuitBreakerConfig() const override {
+    return circuit_breaker_config_;
+  }
+
+public:
+
+  /**
+   * Configuration for the outlier detection.
+   */
+  class OutlierDetectionConfigImpl : public OutlierDetectionConfig {
+   public:
+    OutlierDetectionConfigImpl(const envoy::api::v2::Cluster::OutlierDetection& config);
+    virtual ~OutlierDetectionConfigImpl() {}
+
+    uint64_t intervalMs() const override { return interval_ms_; }
+    uint64_t baseEjectionTimeMs() const override { return base_ejection_time_ms_; }
+    uint64_t consecutive5xx() const override { return consecutive_5xx_; }
+    uint64_t maxEjectionPercent() const override { return max_ejection_percent_; }
+    uint64_t successRateMinimumHosts() const override { return success_rate_minimum_hosts_; }
+    uint64_t successRateRequestVolume() const override { return success_rate_request_volume_; }
+    uint64_t successRateStdevFactor() const override { return success_rate_stdev_factor_; }
+    uint64_t enforcingConsecutive5xx() const override { return enforcing_consecutive_5xx_; }
+    uint64_t enforcingSuccessRate() const override { return enforcing_success_rate_; }
+
+   private:
+    const uint64_t interval_ms_;
+    const uint64_t base_ejection_time_ms_;
+    const uint64_t consecutive_5xx_;
+    const uint64_t max_ejection_percent_;
+    const uint64_t success_rate_minimum_hosts_;
+    const uint64_t success_rate_request_volume_;
+    const uint64_t success_rate_stdev_factor_;
+    const uint64_t enforcing_consecutive_5xx_;
+    const uint64_t enforcing_success_rate_;
+  };
+
+  class CircuitBreakerConfigImpl : public CircuitBreakerConfig {
+  public:
+    CircuitBreakerConfigImpl(const envoy::api::v2::CircuitBreakers& config);
+    virtual ~CircuitBreakerConfigImpl() {}
+
+    const std::vector<Thresholds::ConstSharedPtr>& thresholds() const override {
+      return thresholds_;
+    }
+
+  public:
+
+    class ThresholdsImpl : public Thresholds {
+    public:
+      ThresholdsImpl(const envoy::api::v2::CircuitBreakers_Thresholds& config);
+      virtual ~ThresholdsImpl() {}
+
+      envoy::api::v2::RoutingPriority priority() const override {
+        return priority_;
+      }
+
+      uint32_t maxConnections() const override {
+        return max_connections_;
+      }
+      uint32_t maxPendingRequests() const override {
+        return max_pending_requests_;
+      }
+
+      uint32_t maxRequests() const override {
+        return max_requests_;
+      }
+
+      uint32_t maxRetries() const override {
+        return max_retries_;
+      }
+
+    private:
+
+      envoy::api::v2::RoutingPriority priority_;
+      uint32_t max_connections_;
+      uint32_t max_pending_requests_;
+      uint32_t max_requests_;
+      uint32_t max_retries_;
+    };
+
+  private:
+
+    std::vector<Thresholds::ConstSharedPtr> thresholds_;
+  };
+
+private:
+
+  const std::string name_;
+  const uint64_t max_requests_per_connection_;
+  const std::chrono::milliseconds connect_timeout_;
+  const uint32_t per_connection_buffer_limit_bytes_;
+  const uint64_t features_;
+  const Http::Http2Settings http2_settings_;
+  const Network::Address::InstanceConstSharedPtr source_address_;
+
+  const Ssl::ClientContextConfig::ConstSharedPtr tls_context_config_;
+  const LoadBalancerType lb_type_;
+
+  // TODO(nmittler): This currently references an underlying proto message.
+  const LoadBalancerSubsetInfoImpl lb_subset_info_;
+
+  const OutlierDetectionConfig::ConstSharedPtr outlier_detection_config_;
+
+  const CircuitBreakerConfigImpl circuit_breaker_config_;
+};
+
+
+} // namespace Upstream
+} // namespace Envoy

--- a/source/common/upstream/overridable_cluster_config.h
+++ b/source/common/upstream/overridable_cluster_config.h
@@ -1,0 +1,210 @@
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include "common/common/utility.h"
+#include "envoy/http/header_map.h"
+#include "envoy/upstream/cluster_config.h"
+
+namespace Envoy {
+namespace Upstream {
+
+#define OVERRIDE_CLUSTER_PROP_WITH_HEADER(propertyName, headerMethodName) \
+    {                                                                     \
+      const Http::HeaderEntry* entry = headers.headerMethodName();        \
+      uint64_t value;                                                     \
+      if (entry && StringUtil::atoul(entry->value().c_str(), value)) {    \
+        propertyName(value);                                              \
+      }                                                                   \
+    }
+
+// A macro for defining the override methods.
+#define OVERRIDABLE_CLUSTER_PROP_UINT64(propertyName, fieldIndex) \
+  private:                                                        \
+    uint64_t propertyName##_;                                     \
+  public:                                                         \
+    uint64_t propertyName() const override {                      \
+      if (isFieldSet(fieldIndex)) {                               \
+        return propertyName##_;                                   \
+      }                                                           \
+      return delegate().propertyName();                           \
+    }                                                             \
+    void propertyName(uint64_t value) {                           \
+      setField(fieldIndex);                                       \
+      propertyName##_ = value;                                    \
+    }                                                             \
+    void clear##propertyName() {                                  \
+      clearField(fieldIndex);                                     \
+    }
+
+class OverridableClusterConfig : public virtual ClusterConfig {
+public:
+
+  class OverridingOutlierDetectionConfig : public OutlierDetectionConfig {
+    // Give the parent class full access.
+    friend class OverridableClusterConfig;
+
+  public:
+    OverridingOutlierDetectionConfig(OverridableClusterConfig* parent)
+        : parent_(parent),
+          bit_field_(0) {}
+
+    virtual ~OverridingOutlierDetectionConfig() {}
+
+    OVERRIDABLE_CLUSTER_PROP_UINT64(intervalMs, 0)
+    OVERRIDABLE_CLUSTER_PROP_UINT64(baseEjectionTimeMs, 1)
+    OVERRIDABLE_CLUSTER_PROP_UINT64(consecutive5xx, 2)
+    OVERRIDABLE_CLUSTER_PROP_UINT64(maxEjectionPercent, 3)
+    OVERRIDABLE_CLUSTER_PROP_UINT64(successRateMinimumHosts, 4)
+    OVERRIDABLE_CLUSTER_PROP_UINT64(successRateRequestVolume, 5)
+    OVERRIDABLE_CLUSTER_PROP_UINT64(successRateStdevFactor, 6)
+    OVERRIDABLE_CLUSTER_PROP_UINT64(enforcingConsecutive5xx, 7)
+    OVERRIDABLE_CLUSTER_PROP_UINT64(enforcingSuccessRate, 8)
+
+    typedef std::shared_ptr<OverridingOutlierDetectionConfig> SharedPtr;
+
+  private:
+
+    void overrideWithHeaders(const Http::HeaderMap& headers) {
+      OVERRIDE_CLUSTER_PROP_WITH_HEADER(intervalMs, EnvoyOutlierIntervalMs)
+      OVERRIDE_CLUSTER_PROP_WITH_HEADER(baseEjectionTimeMs, EnvoyOutlierBaseEjectionTimeMs)
+      OVERRIDE_CLUSTER_PROP_WITH_HEADER(consecutive5xx, EnvoyOutlierConsecutive5xx)
+      OVERRIDE_CLUSTER_PROP_WITH_HEADER(maxEjectionPercent, EnvoyOutlierMaxEjectionPercent)
+      OVERRIDE_CLUSTER_PROP_WITH_HEADER(successRateMinimumHosts, EnvoyOutlierSuccessRateMinimumHosts)
+      OVERRIDE_CLUSTER_PROP_WITH_HEADER(successRateRequestVolume, EnvoyOutlierSuccessRateRequestVolume)
+      OVERRIDE_CLUSTER_PROP_WITH_HEADER(successRateStdevFactor, EnvoyOutlierSuccessRateStdevFactor)
+      OVERRIDE_CLUSTER_PROP_WITH_HEADER(enforcingConsecutive5xx, EnvoyOutlierEnforcingConsecutive5xx)
+      OVERRIDE_CLUSTER_PROP_WITH_HEADER(enforcingSuccessRate, EnvoyOutlierEnforcingSuccessRate)
+    }
+
+    void clear() {
+      bit_field_ = 0;
+    }
+
+    const OutlierDetectionConfig& delegate() const {
+      return *parent_->delegate_->outlierDetectionConfig();
+    }
+
+    bool isFieldSet(int fieldIndex) const {
+      return (bit_field_ & (1 << fieldIndex)) != 0;
+    }
+
+    void setField(int fieldIndex) {
+      bit_field_ |= (1 << fieldIndex);
+    }
+
+    void clearField(int fieldIndex) {
+      bit_field_ &= ~(1 << fieldIndex);
+    }
+
+  private:
+
+    const OverridableClusterConfig* parent_;
+    uint32_t bit_field_;
+  };
+
+public:
+
+  OverridableClusterConfig(const ClusterConfig::ConstSharedPtr& delegate)
+  : delegate_(delegate) {
+
+    if (delegate_->outlierDetectionConfig() != nullptr) {
+      overridable_outlier_detection_config_ = std::make_shared<OverridingOutlierDetectionConfig>(this);
+      outlier_detection_config_ = std::static_pointer_cast<OutlierDetectionConfig>(overridable_outlier_detection_config_);
+    }
+  }
+
+  virtual ~OverridableClusterConfig() {
+  }
+
+  const std::string& name() const override {
+    return delegate_->name();
+  }
+
+  uint64_t maxRequestsPerConnection() const override {
+    return delegate_->maxRequestsPerConnection();
+  }
+
+  const std::chrono::milliseconds& connectTimeout() const override {
+    return delegate_->connectTimeout();
+  }
+
+  uint32_t perConnectionBufferLimitBytes() const override {
+    return delegate_->perConnectionBufferLimitBytes();
+  }
+
+  uint64_t features() const override {
+    return delegate_->features();
+  }
+
+  const Http::Http2Settings& http2Settings() const override {
+    return delegate_->http2Settings();
+  }
+
+  const Network::Address::InstanceConstSharedPtr& sourceAddress() const override {
+    if (source_address_ != nullptr) {
+      return source_address_;
+    }
+    return delegate_->sourceAddress();
+  }
+
+  void sourceAddress(const Network::Address::InstanceConstSharedPtr sourceAddress) {
+    source_address_ = sourceAddress;
+  }
+
+  const Ssl::ClientContextConfig::ConstSharedPtr& tlsContextConfig() const override {
+    return delegate_->tlsContextConfig();
+  }
+
+  LoadBalancerType lbType() const override {
+    return delegate_->lbType();
+  }
+
+  const LoadBalancerSubsetInfo& lbSubsetInfo() const override {
+    return delegate_->lbSubsetInfo();
+  }
+
+  const OutlierDetectionConfig::ConstSharedPtr& outlierDetectionConfig() const override {
+    return outlier_detection_config_;
+  }
+
+  OverridingOutlierDetectionConfig::SharedPtr& overridableOutlierDetectionConfig() {
+    return overridable_outlier_detection_config_;
+  }
+
+  const CircuitBreakerConfig& circuitBreakerConfig() const override {
+    return delegate_->circuitBreakerConfig();
+  }
+
+  void clearOverrides() {
+    if (hasOutlierDetectionConfig()) {
+      overridable_outlier_detection_config_->clear();
+    }
+  }
+
+  void overrideWithHeaders(const Http::HeaderMap& headers) {
+    if (hasOutlierDetectionConfig()) {
+      overridable_outlier_detection_config_->overrideWithHeaders(headers);
+    }
+  }
+
+private:
+
+  bool hasOutlierDetectionConfig() const {
+    return overridable_outlier_detection_config_ != nullptr;
+  }
+
+private:
+
+  const ClusterConfig::ConstSharedPtr delegate_;
+  Network::Address::InstanceConstSharedPtr source_address_;
+
+  OutlierDetectionConfig::ConstSharedPtr outlier_detection_config_;
+  OverridingOutlierDetectionConfig::SharedPtr overridable_outlier_detection_config_;
+};
+
+}  // namespace Upstream
+}  // namespace Envoy
+

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -35,15 +35,18 @@ public:
 
     envoy::api::v2::Bootstrap bootstrap;
     try {
+      printf("NM: calling loadFromFile\n");
       MessageUtil::loadFromFile(file_path, bootstrap);
     } catch (const EnvoyException& e) {
       // TODO(htuch): When v1 is deprecated, make this a warning encouraging config upgrade.
       Json::ObjectSharedPtr config_json = Json::Factory::loadFromFile(file_path);
       bootstrap = TestUtility::parseBootstrapFromJson(config_json->asJsonString());
     }
+    printf("NM: creating initial_config\n");
     Server::Configuration::InitialImpl initial_config(bootstrap);
     Server::Configuration::MainImpl main_config;
 
+    printf("NM: resetting cluster_manager_factory\n");
     cluster_manager_factory_.reset(new Upstream::ProdClusterManagerFactory(
         server_.runtime(), server_.stats(), server_.threadLocal(), server_.random(),
         server_.dnsResolver(), ssl_context_manager_, server_.dispatcher(), server_.localInfo()));
@@ -60,6 +63,7 @@ public:
         }));
 
     try {
+      printf("NM: main_config.initialize\n");
       main_config.initialize(bootstrap, server_, *cluster_manager_factory_);
     } catch (const EnvoyException& ex) {
       ADD_FAILURE() << fmt::format("'{}' config failed. Error: {}", file_path, ex.what());
@@ -81,6 +85,7 @@ public:
 uint32_t run(const std::string& directory) {
   uint32_t num_tested = 0;
   for (const std::string& filename : TestUtility::listFiles(directory, true)) {
+    printf("NM: loading config file %s\n", filename.c_str());
     ConfigTest config(filename);
     num_tested++;
   }

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -20,19 +20,19 @@ public:
   ~MockContextManager();
 
   ClientContextPtr createSslClientContext(Stats::Scope& scope,
-                                          ClientContextConfig& config) override {
+                                          const ClientContextConfig& config) override {
     return ClientContextPtr{createSslClientContext_(scope, config)};
   }
 
   ServerContextPtr createSslServerContext(Stats::Scope& scope,
-                                          ServerContextConfig& config) override {
+                                          const ServerContextConfig& config) override {
     return ServerContextPtr{createSslServerContext_(scope, config)};
   }
 
   MOCK_METHOD2(createSslClientContext_,
-               ClientContext*(Stats::Scope& scope, ClientContextConfig& config));
+               ClientContext*(Stats::Scope& scope, const ClientContextConfig& config));
   MOCK_METHOD2(createSslServerContext_,
-               ServerContext*(Stats::Scope& stats, ServerContextConfig& config));
+               ServerContext*(Stats::Scope& stats, const ServerContextConfig& config));
   MOCK_METHOD0(daysUntilFirstCertExpires, size_t());
   MOCK_METHOD1(iterateContexts, void(std::function<void(Context&)> callback));
 };

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -19,6 +19,32 @@ using testing::NiceMock;
 namespace Envoy {
 namespace Upstream {
 
+class MockCircuitBreakerConfig : public ClusterInfo::CircuitBreakerConfig {
+public:
+  MockCircuitBreakerConfig();
+  ~MockCircuitBreakerConfig();
+
+  // Upstream::ClusterInfo::CircuitBreakerConfig
+  MOCK_CONST_METHOD0(thresholds, const std::vector<Thresholds::ConstSharedPtr>&());
+};
+
+class MockOutlierDetectionConfig : public ClusterInfo::OutlierDetectionConfig {
+public:
+  MockOutlierDetectionConfig();
+  ~MockOutlierDetectionConfig();
+
+  // Upstream::ClusterInfo::OutlierDetectionConfig
+  MOCK_CONST_METHOD0(intervalMs, uint64_t());
+  MOCK_CONST_METHOD0(baseEjectionTimeMs, uint64_t());
+  MOCK_CONST_METHOD0(consecutive5xx, uint64_t());
+  MOCK_CONST_METHOD0(maxEjectionPercent, uint64_t());
+  MOCK_CONST_METHOD0(successRateMinimumHosts, uint64_t());
+  MOCK_CONST_METHOD0(successRateRequestVolume, uint64_t());
+  MOCK_CONST_METHOD0(successRateStdevFactor, uint64_t());
+  MOCK_CONST_METHOD0(enforcingConsecutive5xx, uint64_t());
+  MOCK_CONST_METHOD0(enforcingSuccessRate, uint64_t());
+};
+
 class MockLoadBalancerSubsetInfo : public LoadBalancerSubsetInfo {
 public:
   MockLoadBalancerSubsetInfo();
@@ -41,7 +67,7 @@ public:
 
   // Upstream::ClusterInfo
   MOCK_CONST_METHOD0(addedViaApi, bool());
-  MOCK_CONST_METHOD0(connectTimeout, std::chrono::milliseconds());
+  MOCK_CONST_METHOD0(connectTimeout, const std::chrono::milliseconds&());
   MOCK_CONST_METHOD0(perConnectionBufferLimitBytes, uint32_t());
   MOCK_CONST_METHOD0(features, uint64_t());
   MOCK_CONST_METHOD0(http2Settings, const Http::Http2Settings&());
@@ -51,13 +77,18 @@ public:
   MOCK_CONST_METHOD0(name, const std::string&());
   MOCK_CONST_METHOD1(resourceManager, ResourceManager&(ResourcePriority priority));
   MOCK_CONST_METHOD0(sslContext, Ssl::ClientContext*());
+  MOCK_CONST_METHOD0(tlsContextConfig, const Ssl::ClientContextConfig::ConstSharedPtr&());
   MOCK_CONST_METHOD0(stats, ClusterStats&());
   MOCK_CONST_METHOD0(statsScope, Stats::Scope&());
   MOCK_CONST_METHOD0(loadReportStats, ClusterLoadReportStats&());
   MOCK_CONST_METHOD0(sourceAddress, const Network::Address::InstanceConstSharedPtr&());
   MOCK_CONST_METHOD0(lbSubsetInfo, const LoadBalancerSubsetInfo&());
+  MOCK_CONST_METHOD0(outlierDetectionConfig, const OutlierDetectionConfig::ConstSharedPtr&());
+  MOCK_CONST_METHOD0(circuitBreakerConfig, const CircuitBreakerConfig&());
+  MOCK_METHOD1_T(overrideWithHeaders, void(const Http::HeaderMap& headers));
 
   std::string name_{"fake_cluster"};
+  std::chrono::milliseconds connection_timeout_;
   Http::Http2Settings http2_settings_{};
   uint64_t max_requests_per_connection_{};
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
@@ -69,6 +100,8 @@ public:
   Network::Address::InstanceConstSharedPtr source_address_;
   LoadBalancerType lb_type_{LoadBalancerType::RoundRobin};
   NiceMock<MockLoadBalancerSubsetInfo> lb_subset_;
+  OutlierDetectionConfig::ConstSharedPtr outlier_detection_config_;
+  NiceMock<MockCircuitBreakerConfig> circuit_breaker_config_;
 };
 
 } // namespace Upstream

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -61,6 +61,22 @@ MockHost::MockHost() {
 
 MockHost::~MockHost() {}
 
+MockCircuitBreakerConfig::MockCircuitBreakerConfig() {
+  // TODO(nmittler):
+}
+
+MockCircuitBreakerConfig::~MockCircuitBreakerConfig() {
+  // TODO(nmittler):
+}
+
+MockOutlierDetectionConfig::MockOutlierDetectionConfig() {
+  // TODO(nmittler):
+}
+
+MockOutlierDetectionConfig::~MockOutlierDetectionConfig() {
+  // TODO(nmittler):
+}
+
 MockLoadBalancerSubsetInfo::MockLoadBalancerSubsetInfo() {
   ON_CALL(*this, isEnabled()).WillByDefault(Return(false));
   ON_CALL(*this, fallbackPolicy())
@@ -72,11 +88,12 @@ MockLoadBalancerSubsetInfo::MockLoadBalancerSubsetInfo() {
 MockLoadBalancerSubsetInfo::~MockLoadBalancerSubsetInfo() {}
 
 MockClusterInfo::MockClusterInfo()
-    : stats_(ClusterInfoImpl::generateStats(stats_store_)),
+    : connection_timeout_(1),
+      stats_(ClusterInfoImpl::generateStats(stats_store_)),
       load_report_stats_(ClusterInfoImpl::generateLoadReportStats(load_report_stats_store_)),
       resource_manager_(new Upstream::ResourceManagerImpl(runtime_, "fake_key", 1, 1024, 1024, 1)) {
 
-  ON_CALL(*this, connectTimeout()).WillByDefault(Return(std::chrono::milliseconds(1)));
+  ON_CALL(*this, connectTimeout()).WillByDefault(ReturnRef(connection_timeout_));
   ON_CALL(*this, name()).WillByDefault(ReturnRef(name_));
   ON_CALL(*this, http2Settings()).WillByDefault(ReturnRef(http2_settings_));
   ON_CALL(*this, maxRequestsPerConnection())
@@ -90,7 +107,8 @@ MockClusterInfo::MockClusterInfo()
           [this](ResourcePriority) -> Upstream::ResourceManager& { return *resource_manager_; }));
   ON_CALL(*this, lbType()).WillByDefault(ReturnPointee(&lb_type_));
   ON_CALL(*this, sourceAddress()).WillByDefault(ReturnRef(source_address_));
-  ON_CALL(*this, lbSubsetInfo()).WillByDefault(ReturnRef(lb_subset_));
+  ON_CALL(*this, outlierDetectionConfig()).WillByDefault(ReturnRef(outlier_detection_config_));
+  ON_CALL(*this, circuitBreakerConfig()).WillByDefault(ReturnRef(circuit_breaker_config_));
 }
 
 MockClusterInfo::~MockClusterInfo() {}


### PR DESCRIPTION
Istio currently supports overriding a few elements of configuration via http headers (https://envoyproxy.github.io/envoy/configuration/http_filters/router_filter.html#http-headers).

This PR is a work in progress.  It proposes a more general approach for supporting these overrides in a way that is more transparent from the application code.

The basic idea is to convert the cluster configuration early on from protobuf to a new type ClusterConfig(Impl). ClusterInfo then has been made to extend OverridingClusterConfig which supports overriding config values with headers. All of the application code will start to use ClusterConfig, rather than the protobuf class so that the overridden values are always available.