### PR TITLE
ci: add python-sphinx to lyft/envoy-build.

### DIFF
--- a/ci/build_container/build_container_ubuntu.sh
+++ b/ci/build_container/build_container_ubuntu.sh
@@ -5,7 +5,7 @@ set -e
 # Setup basic requirements and install them.
 apt-get update
 apt-get install -y wget software-properties-common make cmake git python python-pip \
-  bc libtool automake zip time golang g++ gdb strace
+  bc libtool automake zip time golang g++ gdb strace python-sphinx
 # clang head (currently 5.0)
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main"


### PR DESCRIPTION
Needed by data-plane-api repo (and main envoy eventually) to be able to build both Bazel and sphinx
in a single image.

Signed-off-by: Harvey Tuch <htuch@google.com>