### PR TITLE
mongo: implement drain close

### DIFF
--- a/docs/configuration/network_filters/mongo_proxy_filter.rst
+++ b/docs/configuration/network_filters/mongo_proxy_filter.rst
@@ -31,9 +31,9 @@ fault
 Fault configuration
 -------------------
 
-Configuration for MongoDB fixed duration delays. Delays are applied to the following MongoDB operations: Query, Insert,
-GetMore, and KillCursors. Once an active delay is in progress, all incoming data up until the timer event fires
-will be a part of the delay.
+Configuration for MongoDB fixed duration delays. Delays are applied to the following MongoDB
+operations: Query, Insert, GetMore, and KillCursors. Once an active delay is in progress, all
+incoming data up until the timer event fires will be a part of the delay.
 
 .. code-block:: json
 
@@ -83,6 +83,7 @@ following statistics:
   op_reply_valid_cursor, Counter, Number of OP_REPLY with a valid cursor
   cx_destroy_local_with_active_rq, Counter, Connections destroyed locally with an active query
   cx_destroy_remote_with_active_rq, Counter, Connections destroyed remotely with an active query
+  cx_drain_close, Counter, Connections gracefully closed on reply boundaries during server drain
 
 Scatter gets
 ^^^^^^^^^^^^

--- a/source/common/mongo/BUILD
+++ b/source/common/mongo/BUILD
@@ -48,6 +48,7 @@ envoy_cc_library(
         "//include/envoy/filesystem:filesystem_interface",
         "//include/envoy/mongo:codec_interface",
         "//include/envoy/network:connection_interface",
+        "//include/envoy/network:drain_decision_interface",
         "//include/envoy/network:filter_interface",
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/stats:stats_interface",

--- a/source/server/config/network/mongo_proxy.cc
+++ b/source/server/config/network/mongo_proxy.cc
@@ -32,7 +32,8 @@ MongoProxyFilterConfigFactory::createFilterFactory(const Json::Object& config,
   return [stat_prefix, &context, access_log,
           fault_config](Network::FilterManager& filter_manager) -> void {
     filter_manager.addFilter(std::make_shared<Mongo::ProdProxyFilter>(
-        stat_prefix, context.scope(), context.runtime(), access_log, fault_config));
+        stat_prefix, context.scope(), context.runtime(), access_log, fault_config,
+        context.drainDecision()));
   };
 }
 

--- a/test/common/mongo/proxy_test.cc
+++ b/test/common/mongo/proxy_test.cc
@@ -70,7 +70,8 @@ public:
   }
 
   void initializeFilter() {
-    filter_.reset(new TestProxyFilter("test.", store_, runtime_, access_log_, fault_config_));
+    filter_.reset(new TestProxyFilter("test.", store_, runtime_, access_log_, fault_config_,
+                                      drain_decision_));
     filter_->initializeReadFilterCallbacks(read_filter_callbacks_);
     filter_->onNewConnection();
   }
@@ -108,6 +109,7 @@ public:
   std::unique_ptr<TestProxyFilter> filter_;
   NiceMock<Network::MockReadFilterCallbacks> read_filter_callbacks_;
   Envoy::AccessLog::MockAccessLogManager log_manager_;
+  NiceMock<Network::MockDrainDecision> drain_decision_;
 };
 
 TEST_F(MongoProxyFilterTest, DelayFaults) {
@@ -402,7 +404,7 @@ TEST_F(MongoProxyFilterTest, DecodeError) {
   EXPECT_EQ(1U, store_.counter("test.decoding_error").value());
 }
 
-TEST_F(MongoProxyFilterTest, ConcurrentQuery) {
+TEST_F(MongoProxyFilterTest, ConcurrentQueryWithDrainClose) {
   initializeFilter();
 
   EXPECT_CALL(*filter_->decoder_, onData(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
@@ -421,6 +423,7 @@ TEST_F(MongoProxyFilterTest, ConcurrentQuery) {
   filter_->onData(fake_data_);
   EXPECT_EQ(2U, store_.gauge("test.op_query_active").value());
 
+  Event::MockTimer* drain_timer = nullptr;
   EXPECT_CALL(*filter_->decoder_, onData(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
     ReplyMessagePtr message(new ReplyMessageImpl(0, 1));
     message->flags(0b11);
@@ -432,10 +435,19 @@ TEST_F(MongoProxyFilterTest, ConcurrentQuery) {
     message->flags(0b11);
     message->cursorId(1);
     message->documents().push_back(Bson::DocumentImpl::create()->addString("hello", "world"));
+    EXPECT_CALL(drain_decision_, drainClose()).WillOnce(Return(true));
+    drain_timer = new Event::MockTimer(&read_filter_callbacks_.connection_.dispatcher_);
+    EXPECT_CALL(*drain_timer, enableTimer(std::chrono::milliseconds(0)));
     filter_->callbacks_->decodeReply(std::move(message));
   }));
   filter_->onWrite(fake_data_);
+
+  EXPECT_CALL(read_filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
+  EXPECT_CALL(*drain_timer, disableTimer());
+  drain_timer->callback_();
+
   EXPECT_EQ(0U, store_.gauge("test.op_query_active").value());
+  EXPECT_EQ(1U, store_.counter("test.cx_drain_close").value());
 }
 
 TEST_F(MongoProxyFilterTest, EmptyActiveQueryList) {


### PR DESCRIPTION
This is take two for #1910. The initial solution was incorrect
as it closed the connection during the write flush path. I put
a TODO into the code as I think we can have a better / more
general solution here but this will work for now.

Signed-off-by: Matt Klein <mklein@lyft.com>