### PR TITLE
Make some ssl cert functions const

### DIFF
--- a/include/envoy/ssl/connection.h
+++ b/include/envoy/ssl/connection.h
@@ -17,7 +17,7 @@ public:
   /**
    * @return whether the peer certificate is presented.
    **/
-  virtual bool peerCertificatePresented() PURE;
+  virtual bool peerCertificatePresented() const PURE;
 
   /**
    * @return the URI in the SAN feld of the local certificate. Returns "" if there is no local
@@ -35,7 +35,7 @@ public:
    * @return the subject field of the peer certificate in RFC 2253 format. Returns "" if there is
    *         no peer certificate, or no subject.
    **/
-  virtual std::string subjectPeerCertificate() PURE;
+  virtual std::string subjectPeerCertificate() const PURE;
 
   /**
    * @return the URI in the SAN field of the peer certificate. Returns "" if there is no peer

--- a/source/common/ssl/connection_impl.cc
+++ b/source/common/ssl/connection_impl.cc
@@ -222,7 +222,7 @@ Network::ConnectionImpl::IoResult ConnectionImpl::doWriteToSocket() {
 
 void ConnectionImpl::onConnected() { ASSERT(!handshake_complete_); }
 
-bool ConnectionImpl::peerCertificatePresented() {
+bool ConnectionImpl::peerCertificatePresented() const {
   bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
   return cert != nullptr;
 }
@@ -249,7 +249,7 @@ std::string ConnectionImpl::sha256PeerCertificateDigest() {
   return Hex::encode(computed_hash);
 }
 
-std::string ConnectionImpl::subjectPeerCertificate() {
+std::string ConnectionImpl::subjectPeerCertificate() const {
   bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
   if (!cert) {
     return "";

--- a/source/common/ssl/connection_impl.h
+++ b/source/common/ssl/connection_impl.h
@@ -28,10 +28,10 @@ public:
   const Ssl::Connection* ssl() const override { return this; }
 
   // Ssl::Connection
-  bool peerCertificatePresented() override;
+  bool peerCertificatePresented() const override;
   std::string uriSanLocalCertificate() override;
   std::string sha256PeerCertificateDigest() override;
-  std::string subjectPeerCertificate() override;
+  std::string subjectPeerCertificate() const override;
   std::string uriSanPeerCertificate() override;
 
   SSL* rawSslForTest() { return ssl_.get(); }

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -42,10 +42,10 @@ public:
   MockConnection();
   ~MockConnection();
 
-  MOCK_METHOD0(peerCertificatePresented, bool());
+  MOCK_CONST_METHOD0(peerCertificatePresented, bool());
   MOCK_METHOD0(uriSanLocalCertificate, std::string());
   MOCK_METHOD0(sha256PeerCertificateDigest, std::string());
-  MOCK_METHOD0(subjectPeerCertificate, std::string());
+  MOCK_CONST_METHOD0(subjectPeerCertificate, std::string());
   MOCK_METHOD0(uriSanPeerCertificate, std::string());
 };
 


### PR DESCRIPTION
Make peerCertificatePresented and subjectPeerCertificate functions const. They should not change any data, and them not being const is erroring my build of a filter with ```error: passing 'const Envoy::Ssl::Connection' as 'this' argument discards qualifiers```