### PR TITLE
Http filter cleanup after V2 API changes

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -105,8 +105,9 @@ def envoy_api_deps(skip_targets):
     native.git_repository(
         name = "envoy_api",
         remote = REPO_LOCATIONS["envoy_api"],
-        commit = "d4988844024d0bcff4bcd030552eabe3396203fa",
+        commit = "f2c1dc99df64144f76107725bde870dd6827e044",
     )
+
     api_bind_targets = [
         "address",
         "base",
@@ -127,13 +128,40 @@ def envoy_api_deps(skip_targets):
             actual = "@envoy_api//api:" + t + "_cc",
         )
     filter_bind_targets = [
-        "http_connection_manager",
+        "fault",
     ]
     for t in filter_bind_targets:
         native.bind(
             name = "envoy_filter_" + t,
             actual = "@envoy_api//api/filter:" + t + "_cc",
         )
+    http_filter_bind_targets = [
+        "http_connection_manager",
+    	"router",
+    	"buffer",
+    	"transcoder",
+    	"rate_limit",
+    	"ip_tagging",
+    	"health_check",
+    	"fault",
+    ]
+    for t in http_filter_bind_targets:
+        native.bind(
+            name = "envoy_filter_" + t,
+            actual = "@envoy_api//api/filter/http:" + t + "_cc",
+        )
+    network_filter_bind_targets = [
+        "tcp_proxy",
+    	"mongo_proxy",
+    	"redis_proxy",
+    	"rate_limit",
+    	"client_ssl_auth",
+    ]
+    for t in network_filter_bind_targets:
+        native.bind(
+            name = "envoy_filter_" + t,
+            actual = "@envoy_api//api/filter/network:" + t + "_cc",
+        )    
     native.bind(
         name = "http_api_protos",
         actual = "@googleapis//:http_api_protos",

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -137,13 +137,13 @@ def envoy_api_deps(skip_targets):
         )
     http_filter_bind_targets = [
         "http_connection_manager",
-    	"router",
-    	"buffer",
-    	"transcoder",
-    	"rate_limit",
-    	"ip_tagging",
-    	"health_check",
-    	"fault",
+        "router",
+        "buffer",
+        "transcoder",
+        "rate_limit",
+        "ip_tagging",
+        "health_check",
+        "fault",
     ]
     for t in http_filter_bind_targets:
         native.bind(
@@ -152,10 +152,10 @@ def envoy_api_deps(skip_targets):
         )
     network_filter_bind_targets = [
         "tcp_proxy",
-    	"mongo_proxy",
-    	"redis_proxy",
-    	"rate_limit",
-    	"client_ssl_auth",
+        "mongo_proxy",
+        "redis_proxy",
+        "rate_limit",
+        "client_ssl_auth",
     ]
     for t in network_filter_bind_targets:
         native.bind(

--- a/include/envoy/router/route_config_provider_manager.h
+++ b/include/envoy/router/route_config_provider_manager.h
@@ -12,7 +12,7 @@
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/upstream/cluster_manager.h"
 
-#include "api/filter/http_connection_manager.pb.h"
+#include "api/filter/http/http_connection_manager.pb.h"
 
 namespace Envoy {
 namespace Router {
@@ -39,7 +39,7 @@ public:
    * @param init_manager supplies the init manager.
    */
   virtual RouteConfigProviderSharedPtr
-  getRouteConfigProvider(const envoy::api::v2::filter::Rds& rds, Upstream::ClusterManager& cm,
+  getRouteConfigProvider(const envoy::api::v2::filter::http::Rds& rds, Upstream::ClusterManager& cm,
                          Stats::Scope& scope, const std::string& stat_prefix,
                          Init::Manager& init_manager) PURE;
 };

--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -17,13 +17,13 @@ namespace Config {
 namespace {
 
 void translateComparisonFilter(const Json::Object& config,
-                               envoy::api::v2::filter::ComparisonFilter& filter) {
+                               envoy::api::v2::filter::http::ComparisonFilter& filter) {
   const std::string op = config.getString("op");
   if (op == ">=") {
-    filter.set_op(envoy::api::v2::filter::ComparisonFilter::GE);
+    filter.set_op(envoy::api::v2::filter::http::ComparisonFilter::GE);
   } else {
     ASSERT(op == "=");
-    filter.set_op(envoy::api::v2::filter::ComparisonFilter::EQ);
+    filter.set_op(envoy::api::v2::filter::http::ComparisonFilter::EQ);
   }
 
   auto* runtime = filter.mutable_value();
@@ -32,33 +32,33 @@ void translateComparisonFilter(const Json::Object& config,
 }
 
 void translateStatusCodeFilter(const Json::Object& config,
-                               envoy::api::v2::filter::StatusCodeFilter& filter) {
+                               envoy::api::v2::filter::http::StatusCodeFilter& filter) {
   translateComparisonFilter(config, *filter.mutable_comparison());
 }
 
 void translateDurationFilter(const Json::Object& config,
-                             envoy::api::v2::filter::DurationFilter& filter) {
+                             envoy::api::v2::filter::http::DurationFilter& filter) {
   translateComparisonFilter(config, *filter.mutable_comparison());
 }
 
 void translateRuntimeFilter(const Json::Object& config,
-                            envoy::api::v2::filter::RuntimeFilter& filter) {
+                            envoy::api::v2::filter::http::RuntimeFilter& filter) {
   filter.set_runtime_key(config.getString("key"));
 }
 
 void translateRepeatedFilter(
     const Json::Object& config,
-    Protobuf::RepeatedPtrField<envoy::api::v2::filter::AccessLogFilter>& filters) {
+    Protobuf::RepeatedPtrField<envoy::api::v2::filter::http::AccessLogFilter>& filters) {
   for (const auto& json_filter : config.getObjectArray("filters")) {
     FilterJson::translateAccessLogFilter(*json_filter, *filters.Add());
   }
 }
 
-void translateOrFilter(const Json::Object& config, envoy::api::v2::filter::OrFilter& filter) {
+void translateOrFilter(const Json::Object& config, envoy::api::v2::filter::http::OrFilter& filter) {
   translateRepeatedFilter(config, *filter.mutable_filters());
 }
 
-void translateAndFilter(const Json::Object& config, envoy::api::v2::filter::AndFilter& filter) {
+void translateAndFilter(const Json::Object& config, envoy::api::v2::filter::http::AndFilter& filter) {
   translateRepeatedFilter(config, *filter.mutable_filters());
 }
 
@@ -66,7 +66,7 @@ void translateAndFilter(const Json::Object& config, envoy::api::v2::filter::AndF
 
 void FilterJson::translateAccessLogFilter(
     const Json::Object& json_access_log_filter,
-    envoy::api::v2::filter::AccessLogFilter& access_log_filter) {
+    envoy::api::v2::filter::http::AccessLogFilter& access_log_filter) {
   const std::string type = json_access_log_filter.getString("type");
   if (type == "status_code") {
     translateStatusCodeFilter(json_access_log_filter,
@@ -88,8 +88,8 @@ void FilterJson::translateAccessLogFilter(
 }
 
 void FilterJson::translateAccessLog(const Json::Object& json_access_log,
-                                    envoy::api::v2::filter::AccessLog& access_log) {
-  envoy::api::v2::filter::FileAccessLog file_access_log;
+                                    envoy::api::v2::filter::http::AccessLog& access_log) {
+  envoy::api::v2::filter::http::FileAccessLog file_access_log;
 
   JSON_UTIL_SET_STRING(json_access_log, file_access_log, path);
   JSON_UTIL_SET_STRING(json_access_log, file_access_log, format);
@@ -108,11 +108,11 @@ void FilterJson::translateAccessLog(const Json::Object& json_access_log,
 
 void FilterJson::translateHttpConnectionManager(
     const Json::Object& json_http_connection_manager,
-    envoy::api::v2::filter::HttpConnectionManager& http_connection_manager) {
+    envoy::api::v2::filter::http::HttpConnectionManager& http_connection_manager) {
   json_http_connection_manager.validateSchema(Json::Schema::HTTP_CONN_NETWORK_FILTER_SCHEMA);
 
-  envoy::api::v2::filter::HttpConnectionManager::CodecType codec_type{};
-  envoy::api::v2::filter::HttpConnectionManager::CodecType_Parse(
+  envoy::api::v2::filter::http::HttpConnectionManager::CodecType codec_type{};
+  envoy::api::v2::filter::http::HttpConnectionManager::CodecType_Parse(
       StringUtil::toUpper(json_http_connection_manager.getString("codec_type")), &codec_type);
   http_connection_manager.set_codec_type(codec_type);
 
@@ -155,8 +155,8 @@ void FilterJson::translateHttpConnectionManager(
     const auto json_tracing = json_http_connection_manager.getObject("tracing");
     auto* tracing = http_connection_manager.mutable_tracing();
 
-    envoy::api::v2::filter::HttpConnectionManager::Tracing::OperationName operation_name{};
-    envoy::api::v2::filter::HttpConnectionManager::Tracing::OperationName_Parse(
+    envoy::api::v2::filter::http::HttpConnectionManager::Tracing::OperationName operation_name{};
+    envoy::api::v2::filter::http::HttpConnectionManager::Tracing::OperationName_Parse(
         StringUtil::toUpper(json_tracing->getString("operation_name")), &operation_name);
     tracing->set_operation_name(operation_name);
 
@@ -192,8 +192,8 @@ void FilterJson::translateHttpConnectionManager(
   JSON_UTIL_SET_BOOL(json_http_connection_manager, http_connection_manager, use_remote_address);
   JSON_UTIL_SET_BOOL(json_http_connection_manager, http_connection_manager, generate_request_id);
 
-  envoy::api::v2::filter::HttpConnectionManager::ForwardClientCertDetails fcc_details{};
-  envoy::api::v2::filter::HttpConnectionManager::ForwardClientCertDetails_Parse(
+  envoy::api::v2::filter::http::HttpConnectionManager::ForwardClientCertDetails fcc_details{};
+  envoy::api::v2::filter::http::HttpConnectionManager::ForwardClientCertDetails_Parse(
       StringUtil::toUpper(
           json_http_connection_manager.getString("forward_client_cert", "sanitize")),
       &fcc_details);

--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -58,7 +58,8 @@ void translateOrFilter(const Json::Object& config, envoy::api::v2::filter::http:
   translateRepeatedFilter(config, *filter.mutable_filters());
 }
 
-void translateAndFilter(const Json::Object& config, envoy::api::v2::filter::http::AndFilter& filter) {
+void translateAndFilter(const Json::Object& config,
+                        envoy::api::v2::filter::http::AndFilter& filter) {
   translateRepeatedFilter(config, *filter.mutable_filters());
 }
 

--- a/source/common/config/filter_json.h
+++ b/source/common/config/filter_json.h
@@ -10,12 +10,14 @@ namespace Config {
 class FilterJson {
 public:
   /**
-   * Translate a v1 JSON access log filter object to v2 envoy::api::v2::filter::http::AccessLogFilter.
+   * Translate a v1 JSON access log filter object to v2
+   * envoy::api::v2::filter::http::AccessLogFilter.
    * @param json_access_log_filter source v1 JSON access log object.
    * @param access_log_filter destination v2 envoy::api::v2::filter::http::AccessLog.
    */
-  static void translateAccessLogFilter(const Json::Object& json_access_log_filter,
-                                       envoy::api::v2::filter::http::AccessLogFilter& access_log_filter);
+  static void
+  translateAccessLogFilter(const Json::Object& json_access_log_filter,
+                           envoy::api::v2::filter::http::AccessLogFilter& access_log_filter);
 
   /**
    * Translate a v1 JSON access log object to v2 envoy::api::v2::filter::http::AccessLog.
@@ -29,7 +31,8 @@ public:
    * Translate a v1 JSON HTTP connection manager object to v2
    * envoy::api::v2::filter::http::HttpConnectionManager.
    * @param json_http_connection_manager source v1 JSON HTTP connection manager object.
-   * @param http_connection_manager destination v2 envoy::api::v2::filter::http::HttpConnectionManager.
+   * @param http_connection_manager destination v2
+   * envoy::api::v2::filter::http::HttpConnectionManager.
    */
   static void translateHttpConnectionManager(
       const Json::Object& json_http_connection_manager,

--- a/source/common/config/filter_json.h
+++ b/source/common/config/filter_json.h
@@ -2,7 +2,7 @@
 
 #include "envoy/json/json_object.h"
 
-#include "api/filter/http_connection_manager.pb.h"
+#include "api/filter/http/http_connection_manager.pb.h"
 
 namespace Envoy {
 namespace Config {
@@ -10,30 +10,30 @@ namespace Config {
 class FilterJson {
 public:
   /**
-   * Translate a v1 JSON access log filter object to v2 envoy::api::v2::filter::AccessLogFilter.
+   * Translate a v1 JSON access log filter object to v2 envoy::api::v2::filter::http::AccessLogFilter.
    * @param json_access_log_filter source v1 JSON access log object.
-   * @param access_log_filter destination v2 envoy::api::v2::filter::AccessLog.
+   * @param access_log_filter destination v2 envoy::api::v2::filter::http::AccessLog.
    */
   static void translateAccessLogFilter(const Json::Object& json_access_log_filter,
-                                       envoy::api::v2::filter::AccessLogFilter& access_log_filter);
+                                       envoy::api::v2::filter::http::AccessLogFilter& access_log_filter);
 
   /**
-   * Translate a v1 JSON access log object to v2 envoy::api::v2::filter::AccessLog.
+   * Translate a v1 JSON access log object to v2 envoy::api::v2::filter::http::AccessLog.
    * @param json_access_log source v1 JSON access log object.
-   * @param access_log destination v2 envoy::api::v2::filter::AccessLog.
+   * @param access_log destination v2 envoy::api::v2::filter::http::AccessLog.
    */
   static void translateAccessLog(const Json::Object& json_access_log,
-                                 envoy::api::v2::filter::AccessLog& access_log);
+                                 envoy::api::v2::filter::http::AccessLog& access_log);
 
   /**
    * Translate a v1 JSON HTTP connection manager object to v2
-   * envoy::api::v2::filter::HttpConnectionManager.
+   * envoy::api::v2::filter::http::HttpConnectionManager.
    * @param json_http_connection_manager source v1 JSON HTTP connection manager object.
-   * @param http_connection_manager destination v2 envoy::api::v2::filter::HttpConnectionManager.
+   * @param http_connection_manager destination v2 envoy::api::v2::filter::http::HttpConnectionManager.
    */
   static void translateHttpConnectionManager(
       const Json::Object& json_http_connection_manager,
-      envoy::api::v2::filter::HttpConnectionManager& http_connection_manager);
+      envoy::api::v2::filter::http::HttpConnectionManager& http_connection_manager);
 };
 
 } // namespace Config

--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -85,7 +85,7 @@ void Utility::translateCdsConfig(const Json::Object& json_config,
                            *cds_config.mutable_api_config_source());
 }
 
-void Utility::translateRdsConfig(const Json::Object& json_rds, envoy::api::v2::filter::Rds& rds) {
+void Utility::translateRdsConfig(const Json::Object& json_rds, envoy::api::v2::filter::http::Rds& rds) {
   json_rds.validateSchema(Json::Schema::RDS_CONFIGURATION_SCHEMA);
 
   const std::string name = json_rds.getString("route_config_name", "");

--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -85,7 +85,8 @@ void Utility::translateCdsConfig(const Json::Object& json_config,
                            *cds_config.mutable_api_config_source());
 }
 
-void Utility::translateRdsConfig(const Json::Object& json_rds, envoy::api::v2::filter::http::Rds& rds) {
+void Utility::translateRdsConfig(const Json::Object& json_rds,
+                                 envoy::api::v2::filter::http::Rds& rds) {
   json_rds.validateSchema(Json::Schema::RDS_CONFIGURATION_SCHEMA);
 
   const std::string name = json_rds.getString("route_config_name", "");

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -138,7 +138,8 @@ public:
    * @param json_rds source v1 RDS JSON config.
    * @param rds destination v2 RDS envoy::api::v2::filter::http::Rds.
    */
-  static void translateRdsConfig(const Json::Object& json_rds, envoy::api::v2::filter::http::Rds& rds);
+  static void translateRdsConfig(const Json::Object& json_rds,
+                                 envoy::api::v2::filter::http::Rds& rds);
 
   /**
    * Convert a v1 LDS JSON config to v2 LDS envoy::api::v2::ConfigSource.

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -19,7 +19,7 @@
 #include "api/base.pb.h"
 #include "api/cds.pb.h"
 #include "api/eds.pb.h"
-#include "api/filter/http_connection_manager.pb.h"
+#include "api/filter/http/http_connection_manager.pb.h"
 #include "api/lds.pb.h"
 #include "api/rds.pb.h"
 
@@ -134,11 +134,11 @@ public:
                                  envoy::api::v2::ConfigSource& cds_config);
 
   /**
-   * Convert a v1 RDS JSON config to v2 RDS envoy::api::v2::filter::Rds.
+   * Convert a v1 RDS JSON config to v2 RDS envoy::api::v2::filter::http::Rds.
    * @param json_rds source v1 RDS JSON config.
-   * @param rds destination v2 RDS envoy::api::v2::filter::Rds.
+   * @param rds destination v2 RDS envoy::api::v2::filter::http::Rds.
    */
-  static void translateRdsConfig(const Json::Object& json_rds, envoy::api::v2::filter::Rds& rds);
+  static void translateRdsConfig(const Json::Object& json_rds, envoy::api::v2::filter::http::Rds& rds);
 
   /**
    * Convert a v1 LDS JSON config to v2 LDS envoy::api::v2::ConfigSource.

--- a/source/common/http/access_log/access_log_impl.cc
+++ b/source/common/http/access_log/access_log_impl.cc
@@ -112,7 +112,8 @@ OperatorFilter::OperatorFilter(
 OrFilter::OrFilter(const envoy::api::v2::filter::http::OrFilter& config, Runtime::Loader& runtime)
     : OperatorFilter(config.filters(), runtime) {}
 
-AndFilter::AndFilter(const envoy::api::v2::filter::http::AndFilter& config, Runtime::Loader& runtime)
+AndFilter::AndFilter(const envoy::api::v2::filter::http::AndFilter& config,
+                     Runtime::Loader& runtime)
     : OperatorFilter(config.filters(), runtime) {}
 
 bool OrFilter::evaluate(const RequestInfo& info, const HeaderMap& request_headers) {

--- a/source/common/http/access_log/access_log_impl.cc
+++ b/source/common/http/access_log/access_log_impl.cc
@@ -22,7 +22,7 @@ namespace Envoy {
 namespace Http {
 namespace AccessLog {
 
-ComparisonFilter::ComparisonFilter(const envoy::api::v2::filter::ComparisonFilter& config,
+ComparisonFilter::ComparisonFilter(const envoy::api::v2::filter::http::ComparisonFilter& config,
                                    Runtime::Loader& runtime)
     : config_(config), runtime_(runtime) {}
 
@@ -34,31 +34,31 @@ bool ComparisonFilter::compareAgainstValue(uint64_t lhs) {
   }
 
   switch (config_.op()) {
-  case envoy::api::v2::filter::ComparisonFilter::GE:
+  case envoy::api::v2::filter::http::ComparisonFilter::GE:
     return lhs >= value;
-  case envoy::api::v2::filter::ComparisonFilter::EQ:
+  case envoy::api::v2::filter::http::ComparisonFilter::EQ:
     return lhs == value;
   default:
     NOT_REACHED;
   }
 }
 
-FilterPtr FilterFactory::fromProto(const envoy::api::v2::filter::AccessLogFilter& config,
+FilterPtr FilterFactory::fromProto(const envoy::api::v2::filter::http::AccessLogFilter& config,
                                    Runtime::Loader& runtime) {
   switch (config.filter_specifier_case()) {
-  case envoy::api::v2::filter::AccessLogFilter::kStatusCodeFilter:
+  case envoy::api::v2::filter::http::AccessLogFilter::kStatusCodeFilter:
     return FilterPtr{new StatusCodeFilter(config.status_code_filter(), runtime)};
-  case envoy::api::v2::filter::AccessLogFilter::kDurationFilter:
+  case envoy::api::v2::filter::http::AccessLogFilter::kDurationFilter:
     return FilterPtr{new DurationFilter(config.duration_filter(), runtime)};
-  case envoy::api::v2::filter::AccessLogFilter::kNotHealthCheckFilter:
+  case envoy::api::v2::filter::http::AccessLogFilter::kNotHealthCheckFilter:
     return FilterPtr{new NotHealthCheckFilter()};
-  case envoy::api::v2::filter::AccessLogFilter::kTraceableFilter:
+  case envoy::api::v2::filter::http::AccessLogFilter::kTraceableFilter:
     return FilterPtr{new TraceableRequestFilter()};
-  case envoy::api::v2::filter::AccessLogFilter::kRuntimeFilter:
+  case envoy::api::v2::filter::http::AccessLogFilter::kRuntimeFilter:
     return FilterPtr{new RuntimeFilter(config.runtime_filter(), runtime)};
-  case envoy::api::v2::filter::AccessLogFilter::kAndFilter:
+  case envoy::api::v2::filter::http::AccessLogFilter::kAndFilter:
     return FilterPtr{new AndFilter(config.and_filter(), runtime)};
-  case envoy::api::v2::filter::AccessLogFilter::kOrFilter:
+  case envoy::api::v2::filter::http::AccessLogFilter::kOrFilter:
     return FilterPtr{new OrFilter(config.or_filter(), runtime)};
   default:
     NOT_REACHED;
@@ -84,7 +84,7 @@ bool DurationFilter::evaluate(const RequestInfo& info, const HeaderMap&) {
       std::chrono::duration_cast<std::chrono::milliseconds>(info.duration()).count());
 }
 
-RuntimeFilter::RuntimeFilter(const envoy::api::v2::filter::RuntimeFilter& config,
+RuntimeFilter::RuntimeFilter(const envoy::api::v2::filter::http::RuntimeFilter& config,
                              Runtime::Loader& runtime)
     : runtime_(runtime), runtime_key_(config.runtime_key()) {}
 
@@ -102,17 +102,17 @@ bool RuntimeFilter::evaluate(const RequestInfo&, const HeaderMap& request_header
 }
 
 OperatorFilter::OperatorFilter(
-    const Protobuf::RepeatedPtrField<envoy::api::v2::filter::AccessLogFilter>& configs,
+    const Protobuf::RepeatedPtrField<envoy::api::v2::filter::http::AccessLogFilter>& configs,
     Runtime::Loader& runtime) {
   for (const auto& config : configs) {
     filters_.emplace_back(FilterFactory::fromProto(config, runtime));
   }
 }
 
-OrFilter::OrFilter(const envoy::api::v2::filter::OrFilter& config, Runtime::Loader& runtime)
+OrFilter::OrFilter(const envoy::api::v2::filter::http::OrFilter& config, Runtime::Loader& runtime)
     : OperatorFilter(config.filters(), runtime) {}
 
-AndFilter::AndFilter(const envoy::api::v2::filter::AndFilter& config, Runtime::Loader& runtime)
+AndFilter::AndFilter(const envoy::api::v2::filter::http::AndFilter& config, Runtime::Loader& runtime)
     : OperatorFilter(config.filters(), runtime) {}
 
 bool OrFilter::evaluate(const RequestInfo& info, const HeaderMap& request_headers) {
@@ -145,7 +145,7 @@ bool NotHealthCheckFilter::evaluate(const RequestInfo& info, const HeaderMap&) {
   return !info.healthCheck();
 }
 
-InstanceSharedPtr AccessLogFactory::fromProto(const envoy::api::v2::filter::AccessLog& config,
+InstanceSharedPtr AccessLogFactory::fromProto(const envoy::api::v2::filter::http::AccessLog& config,
                                               Server::Configuration::FactoryContext& context) {
   FilterPtr filter;
   if (config.has_filter()) {

--- a/source/common/http/access_log/access_log_impl.h
+++ b/source/common/http/access_log/access_log_impl.h
@@ -25,7 +25,7 @@ public:
   /**
    * Read a filter definition from proto and instantiate a concrete filter class.
    */
-static FilterPtr fromProto(const envoy::api::v2::filter::http::AccessLogFilter& config,
+  static FilterPtr fromProto(const envoy::api::v2::filter::http::AccessLogFilter& config,
                              Runtime::Loader& runtime);
 };
 
@@ -48,7 +48,8 @@ protected:
  */
 class StatusCodeFilter : public ComparisonFilter {
 public:
-  StatusCodeFilter(const envoy::api::v2::filter::http::StatusCodeFilter& config, Runtime::Loader& runtime)
+  StatusCodeFilter(const envoy::api::v2::filter::http::StatusCodeFilter& config,
+                   Runtime::Loader& runtime)
       : ComparisonFilter(config.comparison(), runtime) {}
 
   // Http::AccessLog::Filter
@@ -60,7 +61,8 @@ public:
  */
 class DurationFilter : public ComparisonFilter {
 public:
-  DurationFilter(const envoy::api::v2::filter::http::DurationFilter& config, Runtime::Loader& runtime)
+  DurationFilter(const envoy::api::v2::filter::http::DurationFilter& config,
+                 Runtime::Loader& runtime)
       : ComparisonFilter(config.comparison(), runtime) {}
 
   // Http::AccessLog::Filter
@@ -72,8 +74,9 @@ public:
  */
 class OperatorFilter : public Filter {
 public:
-  OperatorFilter(const Protobuf::RepeatedPtrField<envoy::api::v2::filter::http::AccessLogFilter>& configs,
-                 Runtime::Loader& runtime);
+  OperatorFilter(
+      const Protobuf::RepeatedPtrField<envoy::api::v2::filter::http::AccessLogFilter>& configs,
+      Runtime::Loader& runtime);
 
 protected:
   std::vector<FilterPtr> filters_;
@@ -126,7 +129,8 @@ public:
  */
 class RuntimeFilter : public Filter {
 public:
-  RuntimeFilter(const envoy::api::v2::filter::http::RuntimeFilter& config, Runtime::Loader& runtime);
+  RuntimeFilter(const envoy::api::v2::filter::http::RuntimeFilter& config,
+                Runtime::Loader& runtime);
 
   // Http::AccessLog::Filter
   bool evaluate(const RequestInfo& info, const HeaderMap& request_headers) override;

--- a/source/common/http/access_log/access_log_impl.h
+++ b/source/common/http/access_log/access_log_impl.h
@@ -11,7 +11,7 @@
 
 #include "common/protobuf/protobuf.h"
 
-#include "api/filter/http_connection_manager.pb.h"
+#include "api/filter/http/http_connection_manager.pb.h"
 
 namespace Envoy {
 namespace Http {
@@ -25,7 +25,7 @@ public:
   /**
    * Read a filter definition from proto and instantiate a concrete filter class.
    */
-  static FilterPtr fromProto(const envoy::api::v2::filter::AccessLogFilter& config,
+static FilterPtr fromProto(const envoy::api::v2::filter::http::AccessLogFilter& config,
                              Runtime::Loader& runtime);
 };
 
@@ -34,12 +34,12 @@ public:
  */
 class ComparisonFilter : public Filter {
 protected:
-  ComparisonFilter(const envoy::api::v2::filter::ComparisonFilter& config,
+  ComparisonFilter(const envoy::api::v2::filter::http::ComparisonFilter& config,
                    Runtime::Loader& runtime);
 
   bool compareAgainstValue(uint64_t lhs);
 
-  envoy::api::v2::filter::ComparisonFilter config_;
+  envoy::api::v2::filter::http::ComparisonFilter config_;
   Runtime::Loader& runtime_;
 };
 
@@ -48,7 +48,7 @@ protected:
  */
 class StatusCodeFilter : public ComparisonFilter {
 public:
-  StatusCodeFilter(const envoy::api::v2::filter::StatusCodeFilter& config, Runtime::Loader& runtime)
+  StatusCodeFilter(const envoy::api::v2::filter::http::StatusCodeFilter& config, Runtime::Loader& runtime)
       : ComparisonFilter(config.comparison(), runtime) {}
 
   // Http::AccessLog::Filter
@@ -60,7 +60,7 @@ public:
  */
 class DurationFilter : public ComparisonFilter {
 public:
-  DurationFilter(const envoy::api::v2::filter::DurationFilter& config, Runtime::Loader& runtime)
+  DurationFilter(const envoy::api::v2::filter::http::DurationFilter& config, Runtime::Loader& runtime)
       : ComparisonFilter(config.comparison(), runtime) {}
 
   // Http::AccessLog::Filter
@@ -72,7 +72,7 @@ public:
  */
 class OperatorFilter : public Filter {
 public:
-  OperatorFilter(const Protobuf::RepeatedPtrField<envoy::api::v2::filter::AccessLogFilter>& configs,
+  OperatorFilter(const Protobuf::RepeatedPtrField<envoy::api::v2::filter::http::AccessLogFilter>& configs,
                  Runtime::Loader& runtime);
 
 protected:
@@ -84,7 +84,7 @@ protected:
  */
 class AndFilter : public OperatorFilter {
 public:
-  AndFilter(const envoy::api::v2::filter::AndFilter& config, Runtime::Loader& runtime);
+  AndFilter(const envoy::api::v2::filter::http::AndFilter& config, Runtime::Loader& runtime);
 
   // Http::AccessLog::Filter
   bool evaluate(const RequestInfo& info, const HeaderMap& request_headers) override;
@@ -95,7 +95,7 @@ public:
  */
 class OrFilter : public OperatorFilter {
 public:
-  OrFilter(const envoy::api::v2::filter::OrFilter& config, Runtime::Loader& runtime);
+  OrFilter(const envoy::api::v2::filter::http::OrFilter& config, Runtime::Loader& runtime);
 
   // Http::AccessLog::Filter
   bool evaluate(const RequestInfo& info, const HeaderMap& request_headers) override;
@@ -126,7 +126,7 @@ public:
  */
 class RuntimeFilter : public Filter {
 public:
-  RuntimeFilter(const envoy::api::v2::filter::RuntimeFilter& config, Runtime::Loader& runtime);
+  RuntimeFilter(const envoy::api::v2::filter::http::RuntimeFilter& config, Runtime::Loader& runtime);
 
   // Http::AccessLog::Filter
   bool evaluate(const RequestInfo& info, const HeaderMap& request_headers) override;
@@ -136,7 +136,7 @@ private:
   const std::string runtime_key_;
 };
 
-InstanceSharedPtr instanceFromProto(const envoy::api::v2::filter::AccessLog& config,
+InstanceSharedPtr instanceFromProto(const envoy::api::v2::filter::http::AccessLog& config,
                                     Runtime::Loader& runtime,
                                     Envoy::AccessLog::AccessLogManager& log_manager);
 
@@ -148,7 +148,7 @@ public:
   /**
    * Read a filter definition from proto and instantiate an Instance.
    */
-  static InstanceSharedPtr fromProto(const envoy::api::v2::filter::AccessLog& config,
+  static InstanceSharedPtr fromProto(const envoy::api::v2::filter::http::AccessLog& config,
                                      Server::Configuration::FactoryContext& context);
 };
 

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -18,14 +18,14 @@ namespace Envoy {
 namespace Router {
 
 RouteConfigProviderSharedPtr RouteConfigProviderUtil::create(
-    const envoy::api::v2::filter::HttpConnectionManager& config, Runtime::Loader& runtime,
+    const envoy::api::v2::filter::http::HttpConnectionManager& config, Runtime::Loader& runtime,
     Upstream::ClusterManager& cm, Stats::Scope& scope, const std::string& stat_prefix,
     Init::Manager& init_manager, RouteConfigProviderManager& route_config_provider_manager) {
   switch (config.route_specifier_case()) {
-  case envoy::api::v2::filter::HttpConnectionManager::kRouteConfig:
+  case envoy::api::v2::filter::http::HttpConnectionManager::kRouteConfig:
     return RouteConfigProviderSharedPtr{
         new StaticRouteConfigProviderImpl(config.route_config(), runtime, cm)};
-  case envoy::api::v2::filter::HttpConnectionManager::kRds:
+  case envoy::api::v2::filter::http::HttpConnectionManager::kRds:
     return route_config_provider_manager.getRouteConfigProvider(config.rds(), cm, scope,
                                                                 stat_prefix, init_manager);
   default:
@@ -41,7 +41,7 @@ StaticRouteConfigProviderImpl::StaticRouteConfigProviderImpl(
 // TODO(htuch): If support for multiple clusters is added per #1170 cluster_name_
 // initialization needs to be fixed.
 RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
-    const envoy::api::v2::filter::Rds& rds, const std::string& manager_identifier,
+    const envoy::api::v2::filter::http::Rds& rds, const std::string& manager_identifier,
     Runtime::Loader& runtime, Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
     Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info, Stats::Scope& scope,
     const std::string& stat_prefix, ThreadLocal::SlotAllocator& tls,
@@ -170,7 +170,7 @@ RouteConfigProviderManagerImpl::rdsRouteConfigProviders() {
 };
 
 Router::RouteConfigProviderSharedPtr RouteConfigProviderManagerImpl::getRouteConfigProvider(
-    const envoy::api::v2::filter::Rds& rds, Upstream::ClusterManager& cm, Stats::Scope& scope,
+    const envoy::api::v2::filter::http::Rds& rds, Upstream::ClusterManager& cm, Stats::Scope& scope,
     const std::string& stat_prefix, Init::Manager& init_manager) {
 
   // RdsRouteConfigProviders are unique based on their serialized RDS config.

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -34,9 +34,10 @@ public:
    *         configuration.
    */
   static RouteConfigProviderSharedPtr
-  create(const envoy::api::v2::filter::http::HttpConnectionManager& config, Runtime::Loader& runtime,
-         Upstream::ClusterManager& cm, Stats::Scope& scope, const std::string& stat_prefix,
-         Init::Manager& init_manager, RouteConfigProviderManager& route_config_provider_manager);
+  create(const envoy::api::v2::filter::http::HttpConnectionManager& config,
+         Runtime::Loader& runtime, Upstream::ClusterManager& cm, Stats::Scope& scope,
+         const std::string& stat_prefix, Init::Manager& init_manager,
+         RouteConfigProviderManager& route_config_provider_manager);
 };
 
 /**

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -18,7 +18,7 @@
 #include "common/common/logger.h"
 #include "common/protobuf/utility.h"
 
-#include "api/filter/http_connection_manager.pb.h"
+#include "api/filter/http/http_connection_manager.pb.h"
 #include "api/rds.pb.h"
 
 namespace Envoy {
@@ -34,7 +34,7 @@ public:
    *         configuration.
    */
   static RouteConfigProviderSharedPtr
-  create(const envoy::api::v2::filter::HttpConnectionManager& config, Runtime::Loader& runtime,
+  create(const envoy::api::v2::filter::http::HttpConnectionManager& config, Runtime::Loader& runtime,
          Upstream::ClusterManager& cm, Stats::Scope& scope, const std::string& stat_prefix,
          Init::Manager& init_manager, RouteConfigProviderManager& route_config_provider_manager);
 };
@@ -114,7 +114,7 @@ private:
     ConfigConstSharedPtr config_;
   };
 
-  RdsRouteConfigProviderImpl(const envoy::api::v2::filter::Rds& rds,
+  RdsRouteConfigProviderImpl(const envoy::api::v2::filter::http::Rds& rds,
                              const std::string& manager_identifier, Runtime::Loader& runtime,
                              Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
                              Runtime::RandomGenerator& random,
@@ -155,7 +155,7 @@ public:
   // ServerRouteConfigProviderManager
   std::vector<RdsRouteConfigProviderSharedPtr> rdsRouteConfigProviders() override;
   // RouteConfigProviderManager
-  RouteConfigProviderSharedPtr getRouteConfigProvider(const envoy::api::v2::filter::Rds& rds,
+  RouteConfigProviderSharedPtr getRouteConfigProvider(const envoy::api::v2::filter::http::Rds& rds,
                                                       Upstream::ClusterManager& cm,
                                                       Stats::Scope& scope,
                                                       const std::string& stat_prefix,

--- a/source/common/router/rds_subscription.cc
+++ b/source/common/router/rds_subscription.cc
@@ -12,7 +12,7 @@ namespace Envoy {
 namespace Router {
 
 RdsSubscription::RdsSubscription(Envoy::Config::SubscriptionStats stats,
-                                 const envoy::api::v2::filter::Rds& rds,
+                                 const envoy::api::v2::filter::http::Rds& rds,
                                  Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
                                  Runtime::RandomGenerator& random,
                                  const LocalInfo::LocalInfo& local_info)

--- a/source/common/router/rds_subscription.h
+++ b/source/common/router/rds_subscription.h
@@ -21,9 +21,10 @@ class RdsSubscription : public Http::RestApiFetcher,
                         public Envoy::Config::Subscription<envoy::api::v2::RouteConfiguration>,
                         Logger::Loggable<Logger::Id::upstream> {
 public:
-  RdsSubscription(Envoy::Config::SubscriptionStats stats, const envoy::api::v2::filter::http::Rds& rds,
-                  Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
-                  Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info);
+  RdsSubscription(Envoy::Config::SubscriptionStats stats,
+                  const envoy::api::v2::filter::http::Rds& rds, Upstream::ClusterManager& cm,
+                  Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
+                  const LocalInfo::LocalInfo& local_info);
 
 private:
   // Config::Subscription

--- a/source/common/router/rds_subscription.h
+++ b/source/common/router/rds_subscription.h
@@ -8,7 +8,7 @@
 #include "common/common/assert.h"
 #include "common/http/rest_api_fetcher.h"
 
-#include "api/filter/http_connection_manager.pb.h"
+#include "api/filter/http/http_connection_manager.pb.h"
 
 namespace Envoy {
 namespace Router {
@@ -21,7 +21,7 @@ class RdsSubscription : public Http::RestApiFetcher,
                         public Envoy::Config::Subscription<envoy::api::v2::RouteConfiguration>,
                         Logger::Loggable<Logger::Id::upstream> {
 public:
-  RdsSubscription(Envoy::Config::SubscriptionStats stats, const envoy::api::v2::filter::Rds& rds,
+  RdsSubscription(Envoy::Config::SubscriptionStats stats, const envoy::api::v2::filter::http::Rds& rds,
                   Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
                   Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info);
 

--- a/source/server/config/http/file_access_log.cc
+++ b/source/server/config/http/file_access_log.cc
@@ -9,7 +9,7 @@
 #include "common/http/access_log/access_log_impl.h"
 #include "common/protobuf/protobuf.h"
 
-#include "api/filter/http_connection_manager.pb.h"
+#include "api/filter/http/http_connection_manager.pb.h"
 
 namespace Envoy {
 namespace Server {
@@ -17,7 +17,7 @@ namespace Configuration {
 
 Http::AccessLog::InstanceSharedPtr FileAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, Http::AccessLog::FilterPtr&& filter, FactoryContext& context) {
-  const auto& fal_config = dynamic_cast<const envoy::api::v2::filter::FileAccessLog&>(config);
+  const auto& fal_config = dynamic_cast<const envoy::api::v2::filter::http::FileAccessLog&>(config);
   Http::AccessLog::FormatterPtr formatter;
   if (fal_config.format().empty()) {
     formatter = Http::AccessLog::AccessLogFormatUtils::defaultAccessLogFormatter();
@@ -29,7 +29,7 @@ Http::AccessLog::InstanceSharedPtr FileAccessLogFactory::createAccessLogInstance
 }
 
 ProtobufTypes::MessagePtr FileAccessLogFactory::createEmptyConfigProto() {
-  return ProtobufTypes::MessagePtr{new envoy::api::v2::filter::FileAccessLog()};
+  return ProtobufTypes::MessagePtr{new envoy::api::v2::filter::http::FileAccessLog()};
 }
 
 std::string FileAccessLogFactory::name() const { return Config::AccessLogNames::get().FILE; }

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -38,7 +38,7 @@ SINGLETON_MANAGER_REGISTRATION(route_config_provider_manager);
 namespace {
 
 NetworkFilterFactoryCb createHttpConnectionManagerFilterFactory(
-    const envoy::api::v2::filter::HttpConnectionManager& http_connection_manager,
+    const envoy::api::v2::filter::http::HttpConnectionManager& http_connection_manager,
     FactoryContext& context) {
   std::shared_ptr<Http::TlsCachingDateProviderImpl> date_provider =
       context.singletonManager().getTyped<Http::TlsCachingDateProviderImpl>(
@@ -73,7 +73,7 @@ NetworkFilterFactoryCb createHttpConnectionManagerFilterFactory(
 
 NetworkFilterFactoryCb HttpConnectionManagerFilterConfigFactory::createFilterFactory(
     const Json::Object& json_http_connection_manager, FactoryContext& context) {
-  envoy::api::v2::filter::HttpConnectionManager http_connection_manager;
+  envoy::api::v2::filter::http::HttpConnectionManager http_connection_manager;
   Config::FilterJson::translateHttpConnectionManager(json_http_connection_manager,
                                                      http_connection_manager);
   return createHttpConnectionManagerFilterFactory(http_connection_manager, context);
@@ -82,7 +82,7 @@ NetworkFilterFactoryCb HttpConnectionManagerFilterConfigFactory::createFilterFac
 NetworkFilterFactoryCb HttpConnectionManagerFilterConfigFactory::createFilterFactoryFromProto(
     const Protobuf::Message& config, FactoryContext& context) {
   return createHttpConnectionManagerFilterFactory(
-      dynamic_cast<const envoy::api::v2::filter::HttpConnectionManager&>(config), context);
+      dynamic_cast<const envoy::api::v2::filter::http::HttpConnectionManager&>(config), context);
 }
 
 /**
@@ -111,7 +111,7 @@ HttpConnectionManagerConfigUtility::determineNextProtocol(Network::Connection& c
 }
 
 HttpConnectionManagerConfig::HttpConnectionManagerConfig(
-    const envoy::api::v2::filter::HttpConnectionManager& config, FactoryContext& context,
+    const envoy::api::v2::filter::http::HttpConnectionManager& config, FactoryContext& context,
     Http::DateProvider& date_provider,
     Router::RouteConfigProviderManager& route_config_provider_manager)
     : context_(context), stats_prefix_(fmt::format("http.{}.", config.stat_prefix())),
@@ -133,19 +133,19 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       context_.initManager(), route_config_provider_manager_);
 
   switch (config.forward_client_cert_details()) {
-  case envoy::api::v2::filter::HttpConnectionManager::SANITIZE:
+  case envoy::api::v2::filter::http::HttpConnectionManager::SANITIZE:
     forward_client_cert_ = Http::ForwardClientCertType::Sanitize;
     break;
-  case envoy::api::v2::filter::HttpConnectionManager::FORWARD_ONLY:
+  case envoy::api::v2::filter::http::HttpConnectionManager::FORWARD_ONLY:
     forward_client_cert_ = Http::ForwardClientCertType::ForwardOnly;
     break;
-  case envoy::api::v2::filter::HttpConnectionManager::APPEND_FORWARD:
+  case envoy::api::v2::filter::http::HttpConnectionManager::APPEND_FORWARD:
     forward_client_cert_ = Http::ForwardClientCertType::AppendForward;
     break;
-  case envoy::api::v2::filter::HttpConnectionManager::SANITIZE_SET:
+  case envoy::api::v2::filter::http::HttpConnectionManager::SANITIZE_SET:
     forward_client_cert_ = Http::ForwardClientCertType::SanitizeSet;
     break;
-  case envoy::api::v2::filter::HttpConnectionManager::ALWAYS_FORWARD_ONLY:
+  case envoy::api::v2::filter::http::HttpConnectionManager::ALWAYS_FORWARD_ONLY:
     forward_client_cert_ = Http::ForwardClientCertType::AlwaysForwardOnly;
     break;
   default:
@@ -171,10 +171,10 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     std::vector<Http::LowerCaseString> request_headers_for_tags;
 
     switch (tracing_config.operation_name()) {
-    case envoy::api::v2::filter::HttpConnectionManager::Tracing::INGRESS:
+    case envoy::api::v2::filter::http::HttpConnectionManager::Tracing::INGRESS:
       tracing_operation_name = Tracing::OperationName::Ingress;
       break;
-    case envoy::api::v2::filter::HttpConnectionManager::Tracing::EGRESS:
+    case envoy::api::v2::filter::http::HttpConnectionManager::Tracing::EGRESS:
       tracing_operation_name = Tracing::OperationName::Egress;
       break;
     default:
@@ -206,13 +206,13 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
   }
 
   switch (config.codec_type()) {
-  case envoy::api::v2::filter::HttpConnectionManager::AUTO:
+  case envoy::api::v2::filter::http::HttpConnectionManager::AUTO:
     codec_type_ = CodecType::AUTO;
     break;
-  case envoy::api::v2::filter::HttpConnectionManager::HTTP1:
+  case envoy::api::v2::filter::http::HttpConnectionManager::HTTP1:
     codec_type_ = CodecType::HTTP1;
     break;
-  case envoy::api::v2::filter::HttpConnectionManager::HTTP2:
+  case envoy::api::v2::filter::http::HttpConnectionManager::HTTP2:
     codec_type_ = CodecType::HTTP2;
     break;
   default:

--- a/source/server/config/network/http_connection_manager.h
+++ b/source/server/config/network/http_connection_manager.h
@@ -32,8 +32,8 @@ public:
                                                       FactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return std::unique_ptr<envoy::api::v2::filter::HttpConnectionManager>(
-        new envoy::api::v2::filter::HttpConnectionManager());
+    return std::unique_ptr<envoy::api::v2::filter::http::HttpConnectionManager>(
+        new envoy::api::v2::filter::http::HttpConnectionManager());
   }
   std::string name() override { return Config::NetworkFilterNames::get().HTTP_CONNECTION_MANAGER; }
 };
@@ -59,7 +59,7 @@ class HttpConnectionManagerConfig : Logger::Loggable<Logger::Id::config>,
                                     public Http::FilterChainFactory,
                                     public Http::ConnectionManagerConfig {
 public:
-  HttpConnectionManagerConfig(const envoy::api::v2::filter::HttpConnectionManager& config,
+  HttpConnectionManagerConfig(const envoy::api::v2::filter::http::HttpConnectionManager& config,
                               FactoryContext& context, Http::DateProvider& date_provider,
                               Router::RouteConfigProviderManager& route_config_provider_manager);
 

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -124,7 +124,7 @@ TEST(UtilityTest, ObjNameLength) {
     err_prefix = "Invalid route_config name";
     std::string json = R"EOF({ "route_config_name": ")EOF" + name + R"EOF(", "cluster": "foo"})EOF";
     auto json_object_ptr = Json::Factory::loadFromString(json);
-    envoy::api::v2::filter::Rds rds;
+    envoy::api::v2::filter::http::Rds rds;
     EXPECT_THROW_WITH_MESSAGE(Config::Utility::translateRdsConfig(*json_object_ptr, rds),
                               EnvoyException, err_prefix + err_suffix);
   }

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -30,7 +30,7 @@
 #include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
-#include "api/filter/http_connection_manager.pb.h"
+#include "api/filter/http/http_connection_manager.pb.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -44,8 +44,8 @@ namespace Http {
 namespace AccessLog {
 namespace {
 
-envoy::api::v2::filter::AccessLog parseAccessLogFromJson(const std::string& json_string) {
-  envoy::api::v2::filter::AccessLog access_log;
+envoy::api::v2::filter::http::AccessLog parseAccessLogFromJson(const std::string& json_string) {
+  envoy::api::v2::filter::http::AccessLog access_log;
   auto json_object_ptr = Json::Factory::loadFromString(json_string);
   Config::FilterJson::translateAccessLog(*json_object_ptr, access_log);
   return access_log;
@@ -487,9 +487,9 @@ TEST_F(AccessLogImplTest, multipleOperators) {
 }
 
 TEST_F(AccessLogImplTest, ConfigureFromProto) {
-  envoy::api::v2::filter::AccessLog config;
+  envoy::api::v2::filter::http::AccessLog config;
 
-  envoy::api::v2::filter::FileAccessLog fal_config;
+  envoy::api::v2::filter::http::FileAccessLog fal_config;
   fal_config.set_path("/dev/null");
 
   MessageUtil::jsonConvert(fal_config, *config.mutable_config());
@@ -521,7 +521,7 @@ TEST(AccessLogFilterTest, DurationWithRuntimeKey) {
   NiceMock<Runtime::MockLoader> runtime;
 
   Json::ObjectSharedPtr filter_object = loader->getObject("filter");
-  envoy::api::v2::filter::AccessLogFilter config;
+  envoy::api::v2::filter::http::AccessLogFilter config;
   Config::FilterJson::translateAccessLogFilter(*filter_object, config);
   DurationFilter filter(config.duration_filter(), runtime);
   TestHeaderMapImpl request_headers{{":method", "GET"}, {":path", "/"}};
@@ -555,7 +555,7 @@ TEST(AccessLogFilterTest, StatusCodeWithRuntimeKey) {
   NiceMock<Runtime::MockLoader> runtime;
 
   Json::ObjectSharedPtr filter_object = loader->getObject("filter");
-  envoy::api::v2::filter::AccessLogFilter config;
+  envoy::api::v2::filter::http::AccessLogFilter config;
   Config::FilterJson::translateAccessLogFilter(*filter_object, config);
   StatusCodeFilter filter(config.status_code_filter(), runtime);
 

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -31,9 +31,9 @@ namespace Envoy {
 namespace Router {
 namespace {
 
-envoy::api::v2::filter::HttpConnectionManager
+envoy::api::v2::filter::http::HttpConnectionManager
 parseHttpConnectionManagerFromJson(const std::string& json_string) {
-  envoy::api::v2::filter::HttpConnectionManager http_connection_manager;
+  envoy::api::v2::filter::http::HttpConnectionManager http_connection_manager;
   auto json_object_ptr = Json::Factory::loadFromString(json_string);
   Envoy::Config::FilterJson::translateHttpConnectionManager(*json_object_ptr,
                                                             http_connection_manager);
@@ -428,7 +428,7 @@ TEST_F(RouteConfigProviderManagerImplTest, Basic) {
     )EOF";
 
   Json::ObjectSharedPtr config = Json::Factory::loadFromString(config_json);
-  envoy::api::v2::filter::Rds rds;
+  envoy::api::v2::filter::http::Rds rds;
   Envoy::Config::Utility::translateRdsConfig(*config, rds);
 
   // Get a RouteConfigProvider. This one should create an entry in the RouteConfigProviderManager.
@@ -451,7 +451,7 @@ TEST_F(RouteConfigProviderManagerImplTest, Basic) {
     )EOF";
 
   Json::ObjectSharedPtr config2 = Json::Factory::loadFromString(config_json2);
-  envoy::api::v2::filter::Rds rds2;
+  envoy::api::v2::filter::http::Rds rds2;
   Envoy::Config::Utility::translateRdsConfig(*config2, rds2);
 
   RouteConfigProviderSharedPtr provider3 = route_config_provider_manager_.getRouteConfigProvider(
@@ -493,7 +493,7 @@ TEST_F(RouteConfigProviderManagerImplTest, onConfigUpdateEmpty) {
     )EOF";
 
   Json::ObjectSharedPtr config = Json::Factory::loadFromString(config_json);
-  envoy::api::v2::filter::Rds rds;
+  envoy::api::v2::filter::http::Rds rds;
   Envoy::Config::Utility::translateRdsConfig(*config, rds);
 
   // Get a RouteConfigProvider. This one should create an entry in the RouteConfigProviderManager.
@@ -516,7 +516,7 @@ TEST_F(RouteConfigProviderManagerImplTest, onConfigUpdateWrongSize) {
     )EOF";
 
   Json::ObjectSharedPtr config = Json::Factory::loadFromString(config_json);
-  envoy::api::v2::filter::Rds rds;
+  envoy::api::v2::filter::http::Rds rds;
   Envoy::Config::Utility::translateRdsConfig(*config, rds);
 
   // Get a RouteConfigProvider. This one should create an entry in the RouteConfigProviderManager.

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -193,7 +193,8 @@ void ConfigHelper::addFilter(const std::string& config) {
   storeHttpConnectionManager(hcm_config);
 }
 
-void ConfigHelper::setClientCodec(envoy::api::v2::filter::http::HttpConnectionManager::CodecType type) {
+void ConfigHelper::setClientCodec(
+    envoy::api::v2::filter::http::HttpConnectionManager::CodecType type) {
   RELEASE_ASSERT(!finalized_);
   envoy::api::v2::filter::http::HttpConnectionManager hcm_config;
   loadHttpConnectionManager(hcm_config);
@@ -226,7 +227,8 @@ void ConfigHelper::addSslConfig() {
       TestEnvironment::runfilesPath("/test/config/integration/certs/serverkey.pem"));
 }
 
-void ConfigHelper::loadHttpConnectionManager(envoy::api::v2::filter::http::HttpConnectionManager& hcm) {
+void ConfigHelper::loadHttpConnectionManager(
+    envoy::api::v2::filter::http::HttpConnectionManager& hcm) {
   RELEASE_ASSERT(!finalized_);
   auto* listener = bootstrap_.mutable_static_resources()->mutable_listeners(0);
   auto* filter_chain = listener->mutable_filter_chains(0);

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -8,7 +8,7 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 
-#include "api/filter/http_connection_manager.pb.h"
+#include "api/filter/http/http_connection_manager.pb.h"
 
 namespace Envoy {
 
@@ -127,7 +127,7 @@ void ConfigHelper::setSourceAddress(const std::string& address_string) {
 
 void ConfigHelper::setDefaultHostAndRoute(const std::string& domains, const std::string& prefix) {
   RELEASE_ASSERT(!finalized_);
-  envoy::api::v2::filter::HttpConnectionManager hcm_config;
+  envoy::api::v2::filter::http::HttpConnectionManager hcm_config;
   loadHttpConnectionManager(hcm_config);
 
   auto* virtual_host = hcm_config.mutable_route_config()->mutable_virtual_hosts(0);
@@ -150,9 +150,9 @@ void ConfigHelper::setBufferLimits(uint32_t upstream_buffer_limit,
     cluster->mutable_per_connection_buffer_limit_bytes()->set_value(upstream_buffer_limit);
   }
 
-  envoy::api::v2::filter::HttpConnectionManager hcm_config;
+  envoy::api::v2::filter::http::HttpConnectionManager hcm_config;
   loadHttpConnectionManager(hcm_config);
-  if (hcm_config.codec_type() == envoy::api::v2::filter::HttpConnectionManager::HTTP2) {
+  if (hcm_config.codec_type() == envoy::api::v2::filter::http::HttpConnectionManager::HTTP2) {
     const uint32_t size =
         std::max(downstream_buffer_limit, Http::Http2Settings::MIN_INITIAL_STREAM_WINDOW_SIZE);
     auto* options = hcm_config.mutable_http2_protocol_options();
@@ -165,7 +165,7 @@ void ConfigHelper::addRoute(const std::string& domains, const std::string& prefi
                             const std::string& cluster,
                             envoy::api::v2::VirtualHost::TlsRequirementType type) {
   RELEASE_ASSERT(!finalized_);
-  envoy::api::v2::filter::HttpConnectionManager hcm_config;
+  envoy::api::v2::filter::http::HttpConnectionManager hcm_config;
   loadHttpConnectionManager(hcm_config);
 
   auto* virtual_host = hcm_config.mutable_route_config()->add_virtual_hosts();
@@ -179,7 +179,7 @@ void ConfigHelper::addRoute(const std::string& domains, const std::string& prefi
 
 void ConfigHelper::addFilter(const std::string& config) {
   RELEASE_ASSERT(!finalized_);
-  envoy::api::v2::filter::HttpConnectionManager hcm_config;
+  envoy::api::v2::filter::http::HttpConnectionManager hcm_config;
   loadHttpConnectionManager(hcm_config);
 
   auto* filter_list_back = hcm_config.add_http_filters();
@@ -193,9 +193,9 @@ void ConfigHelper::addFilter(const std::string& config) {
   storeHttpConnectionManager(hcm_config);
 }
 
-void ConfigHelper::setClientCodec(envoy::api::v2::filter::HttpConnectionManager::CodecType type) {
+void ConfigHelper::setClientCodec(envoy::api::v2::filter::http::HttpConnectionManager::CodecType type) {
   RELEASE_ASSERT(!finalized_);
-  envoy::api::v2::filter::HttpConnectionManager hcm_config;
+  envoy::api::v2::filter::http::HttpConnectionManager hcm_config;
   loadHttpConnectionManager(hcm_config);
   hcm_config.set_codec_type(type);
   storeHttpConnectionManager(hcm_config);
@@ -226,7 +226,7 @@ void ConfigHelper::addSslConfig() {
       TestEnvironment::runfilesPath("/test/config/integration/certs/serverkey.pem"));
 }
 
-void ConfigHelper::loadHttpConnectionManager(envoy::api::v2::filter::HttpConnectionManager& hcm) {
+void ConfigHelper::loadHttpConnectionManager(envoy::api::v2::filter::http::HttpConnectionManager& hcm) {
   RELEASE_ASSERT(!finalized_);
   auto* listener = bootstrap_.mutable_static_resources()->mutable_listeners(0);
   auto* filter_chain = listener->mutable_filter_chains(0);
@@ -235,7 +235,7 @@ void ConfigHelper::loadHttpConnectionManager(envoy::api::v2::filter::HttpConnect
 }
 
 void ConfigHelper::storeHttpConnectionManager(
-    const envoy::api::v2::filter::HttpConnectionManager& hcm) {
+    const envoy::api::v2::filter::http::HttpConnectionManager& hcm) {
   RELEASE_ASSERT(!finalized_);
   auto* listener = bootstrap_.mutable_static_resources()->mutable_listeners(0);
   auto* filter_chain = listener->mutable_filter_chains(0);
@@ -251,7 +251,7 @@ void ConfigHelper::addConfigModifier(ConfigModifierFunction function) {
 
 void ConfigHelper::addConfigModifier(HttpModifierFunction function) {
   addConfigModifier([function, this](envoy::api::v2::Bootstrap&) -> void {
-    envoy::api::v2::filter::HttpConnectionManager hcm_config;
+    envoy::api::v2::filter::http::HttpConnectionManager hcm_config;
     loadHttpConnectionManager(hcm_config);
     function(hcm_config);
     storeHttpConnectionManager(hcm_config);

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -8,7 +8,7 @@
 #include "api/base.pb.h"
 #include "api/bootstrap.pb.h"
 #include "api/cds.pb.h"
-#include "api/filter/http_connection_manager.pb.h"
+#include "api/filter/http/http_connection_manager.pb.h"
 #include "api/protocol.pb.h"
 #include "api/rds.pb.h"
 
@@ -21,7 +21,7 @@ public:
   ConfigHelper(const Network::Address::IpVersion version);
 
   typedef std::function<void(envoy::api::v2::Bootstrap&)> ConfigModifierFunction;
-  typedef std::function<void(envoy::api::v2::filter::HttpConnectionManager&)> HttpModifierFunction;
+  typedef std::function<void(envoy::api::v2::filter::http::HttpConnectionManager&)> HttpModifierFunction;
 
   // A string for a basic buffer filter, which can be used with addFilter()
   static const std::string DEFAULT_BUFFER_FILTER;
@@ -52,7 +52,7 @@ public:
   void addFilter(const std::string& filter_yaml);
 
   // Sets the client codec to the specified type.
-  void setClientCodec(envoy::api::v2::filter::HttpConnectionManager::CodecType type);
+  void setClientCodec(envoy::api::v2::filter::http::HttpConnectionManager::CodecType type);
 
   // Add the default SSL configuration.
   void addSslConfig();
@@ -70,10 +70,10 @@ public:
 
 private:
   // Load the first HCM struct from the first listener into a parsed proto.
-  void loadHttpConnectionManager(envoy::api::v2::filter::HttpConnectionManager& hcm);
+  void loadHttpConnectionManager(envoy::api::v2::filter::http::HttpConnectionManager& hcm);
   // Stick the contents of the procided HCM proto and stuff them into the first HCM
   // struct of the first listener.
-  void storeHttpConnectionManager(const envoy::api::v2::filter::HttpConnectionManager& hcm);
+  void storeHttpConnectionManager(const envoy::api::v2::filter::http::HttpConnectionManager& hcm);
 
   // The bootstrap proto Envoy will start up with.
   envoy::api::v2::Bootstrap bootstrap_;

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -21,7 +21,8 @@ public:
   ConfigHelper(const Network::Address::IpVersion version);
 
   typedef std::function<void(envoy::api::v2::Bootstrap&)> ConfigModifierFunction;
-  typedef std::function<void(envoy::api::v2::filter::http::HttpConnectionManager&)> HttpModifierFunction;
+  typedef std::function<void(envoy::api::v2::filter::http::HttpConnectionManager&)>
+      HttpModifierFunction;
 
   // A string for a basic buffer filter, which can be used with addFilter()
   static const std::string DEFAULT_BUFFER_FILTER;

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -333,15 +333,16 @@ void Http2RingHashIntegrationTest::sendMultipleRequests(
 }
 
 TEST_P(Http2RingHashIntegrationTest, CookieRoutingNoCookieNoTtl) {
-  config_helper_.addConfigModifier([&](envoy::api::v2::filter::HttpConnectionManager& hcm) -> void {
-    auto* hash_policy = hcm.mutable_route_config()
-                            ->mutable_virtual_hosts(0)
-                            ->mutable_routes(0)
-                            ->mutable_route()
-                            ->add_hash_policy();
-    auto* cookie = hash_policy->mutable_cookie();
-    cookie->set_name("foo");
-  });
+  config_helper_.addConfigModifier(
+      [&](envoy::api::v2::filter::http::HttpConnectionManager& hcm) -> void {
+        auto* hash_policy = hcm.mutable_route_config()
+                                ->mutable_virtual_hosts(0)
+                                ->mutable_routes(0)
+                                ->mutable_route()
+                                ->add_hash_policy();
+        auto* cookie = hash_policy->mutable_cookie();
+        cookie->set_name("foo");
+      });
 
   // This test is non-deterministic, so make it extremely unlikely that not all
   // upstreams get hit.
@@ -363,16 +364,17 @@ TEST_P(Http2RingHashIntegrationTest, CookieRoutingNoCookieNoTtl) {
 }
 
 TEST_P(Http2RingHashIntegrationTest, CookieRoutingNoCookieWithTtlSet) {
-  config_helper_.addConfigModifier([&](envoy::api::v2::filter::HttpConnectionManager& hcm) -> void {
-    auto* hash_policy = hcm.mutable_route_config()
-                            ->mutable_virtual_hosts(0)
-                            ->mutable_routes(0)
-                            ->mutable_route()
-                            ->add_hash_policy();
-    auto* cookie = hash_policy->mutable_cookie();
-    cookie->set_name("foo");
-    cookie->mutable_ttl()->set_seconds(15);
-  });
+  config_helper_.addConfigModifier(
+      [&](envoy::api::v2::filter::http::HttpConnectionManager& hcm) -> void {
+        auto* hash_policy = hcm.mutable_route_config()
+                                ->mutable_virtual_hosts(0)
+                                ->mutable_routes(0)
+                                ->mutable_route()
+                                ->add_hash_policy();
+        auto* cookie = hash_policy->mutable_cookie();
+        cookie->set_name("foo");
+        cookie->mutable_ttl()->set_seconds(15);
+      });
 
   std::set<std::string> set_cookies;
   sendMultipleRequests(
@@ -391,15 +393,16 @@ TEST_P(Http2RingHashIntegrationTest, CookieRoutingNoCookieWithTtlSet) {
 }
 
 TEST_P(Http2RingHashIntegrationTest, CookieRoutingWithCookieNoTtl) {
-  config_helper_.addConfigModifier([&](envoy::api::v2::filter::HttpConnectionManager& hcm) -> void {
-    auto* hash_policy = hcm.mutable_route_config()
-                            ->mutable_virtual_hosts(0)
-                            ->mutable_routes(0)
-                            ->mutable_route()
-                            ->add_hash_policy();
-    auto* cookie = hash_policy->mutable_cookie();
-    cookie->set_name("foo");
-  });
+  config_helper_.addConfigModifier(
+      [&](envoy::api::v2::filter::http::HttpConnectionManager& hcm) -> void {
+        auto* hash_policy = hcm.mutable_route_config()
+                                ->mutable_virtual_hosts(0)
+                                ->mutable_routes(0)
+                                ->mutable_route()
+                                ->add_hash_policy();
+        auto* cookie = hash_policy->mutable_cookie();
+        cookie->set_name("foo");
+      });
 
   std::set<std::string> served_by;
   sendMultipleRequests(
@@ -419,16 +422,17 @@ TEST_P(Http2RingHashIntegrationTest, CookieRoutingWithCookieNoTtl) {
 }
 
 TEST_P(Http2RingHashIntegrationTest, CookieRoutingWithCookieWithTtlSet) {
-  config_helper_.addConfigModifier([&](envoy::api::v2::filter::HttpConnectionManager& hcm) -> void {
-    auto* hash_policy = hcm.mutable_route_config()
-                            ->mutable_virtual_hosts(0)
-                            ->mutable_routes(0)
-                            ->mutable_route()
-                            ->add_hash_policy();
-    auto* cookie = hash_policy->mutable_cookie();
-    cookie->set_name("foo");
-    cookie->mutable_ttl()->set_seconds(15);
-  });
+  config_helper_.addConfigModifier(
+      [&](envoy::api::v2::filter::http::HttpConnectionManager& hcm) -> void {
+        auto* hash_policy = hcm.mutable_route_config()
+                                ->mutable_virtual_hosts(0)
+                                ->mutable_routes(0)
+                                ->mutable_route()
+                                ->add_hash_policy();
+        auto* cookie = hash_policy->mutable_cookie();
+        cookie->set_name("foo");
+        cookie->mutable_ttl()->set_seconds(15);
+      });
 
   std::set<std::string> served_by;
   sendMultipleRequests(

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -39,19 +39,19 @@ std::string normalizeDate(const std::string& s) {
   return std::regex_replace(s, date_regex, "date: Mon, 01 Jan 2017 00:00:00 GMT");
 }
 
-void setAllowAbsoluteUrl(envoy::api::v2::filter::HttpConnectionManager& hcm) {
+void setAllowAbsoluteUrl(envoy::api::v2::filter::http::HttpConnectionManager& hcm) {
   envoy::api::v2::Http1ProtocolOptions options;
   options.mutable_allow_absolute_url()->set_value(true);
   hcm.mutable_http_protocol_options()->CopyFrom(options);
 };
 
-envoy::api::v2::filter::HttpConnectionManager::CodecType
+envoy::api::v2::filter::http::HttpConnectionManager::CodecType
 typeToCodecType(Http::CodecClient::Type type) {
   switch (type) {
   case Http::CodecClient::Type::HTTP1:
-    return envoy::api::v2::filter::HttpConnectionManager::HTTP1;
+    return envoy::api::v2::filter::http::HttpConnectionManager::HTTP1;
   case Http::CodecClient::Type::HTTP2:
-    return envoy::api::v2::filter::HttpConnectionManager::HTTP2;
+    return envoy::api::v2::filter::http::HttpConnectionManager::HTTP2;
   default:
     RELEASE_ASSERT(0);
   }

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -174,7 +174,7 @@ TEST_P(IntegrationTest, OverlyLongHeaders) { testOverlyLongHeaders(); }
 
 TEST_P(IntegrationTest, UpstreamProtocolError) { testUpstreamProtocolError(); }
 
-void setRouteUsingWebsocket(envoy::api::v2::filter::HttpConnectionManager& hcm) {
+void setRouteUsingWebsocket(envoy::api::v2::filter::http::HttpConnectionManager& hcm) {
   auto route = hcm.mutable_route_config()->mutable_virtual_hosts(0)->add_routes();
   route->mutable_match()->set_prefix("/websocket/test");
   route->mutable_route()->set_prefix_rewrite("/websocket");

--- a/test/integration/ratelimit_integration_test.cc
+++ b/test/integration/ratelimit_integration_test.cc
@@ -38,7 +38,7 @@ public:
       ratelimit_cluster->set_name("ratelimit");
       ratelimit_cluster->mutable_http2_protocol_options();
     });
-    config_helper_.addConfigModifier([](envoy::api::v2::filter::HttpConnectionManager& hcm) {
+    config_helper_.addConfigModifier([](envoy::api::v2::filter::http::HttpConnectionManager& hcm) {
       auto* rate_limit = hcm.mutable_route_config()
                              ->mutable_virtual_hosts(0)
                              ->mutable_routes(0)

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -273,7 +273,7 @@ public:
 
   MOCK_METHOD0(routeConfigProviders, std::vector<RdsRouteConfigProviderSharedPtr>());
   MOCK_METHOD5(getRouteConfigProvider,
-               RouteConfigProviderSharedPtr(const envoy::api::v2::filter::Rds& rds,
+               RouteConfigProviderSharedPtr(const envoy::api::v2::filter::http::Rds& rds,
                                             Upstream::ClusterManager& cm, Stats::Scope& scope,
                                             const std::string& stat_prefix,
                                             Init::Manager& init_manager));

--- a/test/server/config/http/config_test.cc
+++ b/test/server/config/http/config_test.cc
@@ -299,7 +299,7 @@ TEST(AccessLogConfigTest, FileAccessLogTest) {
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
   ASSERT_NE(nullptr, message);
 
-  envoy::api::v2::filter::FileAccessLog file_access_log;
+  envoy::api::v2::filter::http::FileAccessLog file_access_log;
   file_access_log.set_path("/dev/null");
   file_access_log.set_format("%START_TIME%");
   MessageUtil::jsonConvert(file_access_log, *message);

--- a/test/server/config/network/http_connection_manager_test.cc
+++ b/test/server/config/network/http_connection_manager_test.cc
@@ -21,9 +21,9 @@ namespace Server {
 namespace Configuration {
 namespace {
 
-envoy::api::v2::filter::HttpConnectionManager
+envoy::api::v2::filter::http::HttpConnectionManager
 parseHttpConnectionManagerFromJson(const std::string& json_string) {
-  envoy::api::v2::filter::HttpConnectionManager http_connection_manager;
+  envoy::api::v2::filter::http::HttpConnectionManager http_connection_manager;
   auto json_object_ptr = Json::Factory::loadFromString(json_string);
   Config::FilterJson::translateHttpConnectionManager(*json_object_ptr, http_connection_manager);
   return http_connection_manager;


### PR DESCRIPTION
This is the first of the cleanup series for V2 APIs. I wanted to get the code compiling and building before adding new filters. And split this up into smaller PRs.

This PR should be a completely non functional change.
