### PR TITLE
Trim whitespace when checking ci docker SHAs are consistent

### DIFF
--- a/ci/envoy_build_sha.sh
+++ b/ci/envoy_build_sha.sh
@@ -1,2 +1,2 @@
 ENVOY_BUILD_SHA=$(grep lyft/envoy-build .circleci/config.yml | sed -e 's#.*lyft/envoy-build:\(.*\)#\1#' | uniq)
-[[ $(wc -l <<< "${ENVOY_BUILD_SHA}") == 1 ]] || (echo ".circleci/config.yml hashes are inconsistent!" && exit 1)
+[[ $(wc -l <<< "${ENVOY_BUILD_SHA}" | awk '{$1=$1};1') == 1 ]] || (echo ".circleci/config.yml hashes are inconsistent!" && exit 1)


### PR DESCRIPTION
On Mac 10.12.6 using ZSH the check to verify all Docker image used by for CI were consistent was failing even when they were. Trimming all whitespace made the equality check work correctly.

Signed-off-by: Patrick Auld <Patrick@PatrickAuld.com>