### PR TITLE
Fix logging of incorrect data in http access logs for response duration.

### DIFF
--- a/source/common/http/access_log/request_info_impl.h
+++ b/source/common/http/access_log/request_info_impl.h
@@ -26,10 +26,10 @@ struct RequestInfoImpl : public RequestInfo {
   }
 
   std::chrono::microseconds responseReceivedDuration() const override {
-    return request_received_duration_;
+    return response_received_duration_;
   }
   void responseReceivedDuration(MonotonicTime time) override {
-    request_received_duration_ =
+    response_received_duration_ =
         std::chrono::duration_cast<std::chrono::microseconds>(time - start_time_monotonic_);
   }
 


### PR DESCRIPTION
Signed-off-by: Greg Greenway <ggreenway@apple.com>