### PR TITLE
data-plane-api: update to 6e3e1a7 and fix namespaces

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -113,7 +113,7 @@ def envoy_api_deps(skip_targets):
     native.git_repository(
         name = "envoy_api",
         remote = REPO_LOCATIONS["envoy_api"],
-        commit = "b085af2c8485ba8525a128f466b1ec9ccf14574e",
+        commit = "6e3e1a784cc583f1fe1a7fd3ed109a8f54e0b1b4",
     )
 
     api_bind_targets = [
@@ -136,6 +136,7 @@ def envoy_api_deps(skip_targets):
             actual = "@envoy_api//api:" + t + "_cc",
         )
     filter_bind_targets = [
+        "accesslog",
         "fault",
     ]
     for t in filter_bind_targets:

--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -17,13 +17,13 @@ namespace Config {
 namespace {
 
 void translateComparisonFilter(const Json::Object& config,
-                               envoy::api::v2::filter::http::ComparisonFilter& filter) {
+                               envoy::api::v2::filter::ComparisonFilter& filter) {
   const std::string op = config.getString("op");
   if (op == ">=") {
-    filter.set_op(envoy::api::v2::filter::http::ComparisonFilter::GE);
+    filter.set_op(envoy::api::v2::filter::ComparisonFilter::GE);
   } else {
     ASSERT(op == "=");
-    filter.set_op(envoy::api::v2::filter::http::ComparisonFilter::EQ);
+    filter.set_op(envoy::api::v2::filter::ComparisonFilter::EQ);
   }
 
   auto* runtime = filter.mutable_value();
@@ -32,34 +32,33 @@ void translateComparisonFilter(const Json::Object& config,
 }
 
 void translateStatusCodeFilter(const Json::Object& config,
-                               envoy::api::v2::filter::http::StatusCodeFilter& filter) {
+                               envoy::api::v2::filter::StatusCodeFilter& filter) {
   translateComparisonFilter(config, *filter.mutable_comparison());
 }
 
 void translateDurationFilter(const Json::Object& config,
-                             envoy::api::v2::filter::http::DurationFilter& filter) {
+                             envoy::api::v2::filter::DurationFilter& filter) {
   translateComparisonFilter(config, *filter.mutable_comparison());
 }
 
 void translateRuntimeFilter(const Json::Object& config,
-                            envoy::api::v2::filter::http::RuntimeFilter& filter) {
+                            envoy::api::v2::filter::RuntimeFilter& filter) {
   filter.set_runtime_key(config.getString("key"));
 }
 
 void translateRepeatedFilter(
     const Json::Object& config,
-    Protobuf::RepeatedPtrField<envoy::api::v2::filter::http::AccessLogFilter>& filters) {
+    Protobuf::RepeatedPtrField<envoy::api::v2::filter::AccessLogFilter>& filters) {
   for (const auto& json_filter : config.getObjectArray("filters")) {
     FilterJson::translateAccessLogFilter(*json_filter, *filters.Add());
   }
 }
 
-void translateOrFilter(const Json::Object& config, envoy::api::v2::filter::http::OrFilter& filter) {
+void translateOrFilter(const Json::Object& config, envoy::api::v2::filter::OrFilter& filter) {
   translateRepeatedFilter(config, *filter.mutable_filters());
 }
 
-void translateAndFilter(const Json::Object& config,
-                        envoy::api::v2::filter::http::AndFilter& filter) {
+void translateAndFilter(const Json::Object& config, envoy::api::v2::filter::AndFilter& filter) {
   translateRepeatedFilter(config, *filter.mutable_filters());
 }
 
@@ -67,7 +66,7 @@ void translateAndFilter(const Json::Object& config,
 
 void FilterJson::translateAccessLogFilter(
     const Json::Object& json_access_log_filter,
-    envoy::api::v2::filter::http::AccessLogFilter& access_log_filter) {
+    envoy::api::v2::filter::AccessLogFilter& access_log_filter) {
   const std::string type = json_access_log_filter.getString("type");
   if (type == "status_code") {
     translateStatusCodeFilter(json_access_log_filter,
@@ -89,8 +88,8 @@ void FilterJson::translateAccessLogFilter(
 }
 
 void FilterJson::translateAccessLog(const Json::Object& json_access_log,
-                                    envoy::api::v2::filter::http::AccessLog& access_log) {
-  envoy::api::v2::filter::http::FileAccessLog file_access_log;
+                                    envoy::api::v2::filter::AccessLog& access_log) {
+  envoy::api::v2::filter::FileAccessLog file_access_log;
 
   JSON_UTIL_SET_STRING(json_access_log, file_access_log, path);
   JSON_UTIL_SET_STRING(json_access_log, file_access_log, format);

--- a/source/common/config/filter_json.h
+++ b/source/common/config/filter_json.h
@@ -11,21 +11,20 @@ class FilterJson {
 public:
   /**
    * Translate a v1 JSON access log filter object to v2
-   * envoy::api::v2::filter::http::AccessLogFilter.
+   * envoy::api::v2::filter::AccessLogFilter.
    * @param json_access_log_filter source v1 JSON access log object.
-   * @param access_log_filter destination v2 envoy::api::v2::filter::http::AccessLog.
+   * @param access_log_filter destination v2 envoy::api::v2::filter::AccessLog.
    */
-  static void
-  translateAccessLogFilter(const Json::Object& json_access_log_filter,
-                           envoy::api::v2::filter::http::AccessLogFilter& access_log_filter);
+  static void translateAccessLogFilter(const Json::Object& json_access_log_filter,
+                                       envoy::api::v2::filter::AccessLogFilter& access_log_filter);
 
   /**
-   * Translate a v1 JSON access log object to v2 envoy::api::v2::filter::http::AccessLog.
+   * Translate a v1 JSON access log object to v2 envoy::api::v2::filter::AccessLog.
    * @param json_access_log source v1 JSON access log object.
-   * @param access_log destination v2 envoy::api::v2::filter::http::AccessLog.
+   * @param access_log destination v2 envoy::api::v2::filter::AccessLog.
    */
   static void translateAccessLog(const Json::Object& json_access_log,
-                                 envoy::api::v2::filter::http::AccessLog& access_log);
+                                 envoy::api::v2::filter::AccessLog& access_log);
 
   /**
    * Translate a v1 JSON HTTP connection manager object to v2

--- a/source/common/http/access_log/access_log_impl.cc
+++ b/source/common/http/access_log/access_log_impl.cc
@@ -22,7 +22,7 @@ namespace Envoy {
 namespace Http {
 namespace AccessLog {
 
-ComparisonFilter::ComparisonFilter(const envoy::api::v2::filter::http::ComparisonFilter& config,
+ComparisonFilter::ComparisonFilter(const envoy::api::v2::filter::ComparisonFilter& config,
                                    Runtime::Loader& runtime)
     : config_(config), runtime_(runtime) {}
 
@@ -34,31 +34,31 @@ bool ComparisonFilter::compareAgainstValue(uint64_t lhs) {
   }
 
   switch (config_.op()) {
-  case envoy::api::v2::filter::http::ComparisonFilter::GE:
+  case envoy::api::v2::filter::ComparisonFilter::GE:
     return lhs >= value;
-  case envoy::api::v2::filter::http::ComparisonFilter::EQ:
+  case envoy::api::v2::filter::ComparisonFilter::EQ:
     return lhs == value;
   default:
     NOT_REACHED;
   }
 }
 
-FilterPtr FilterFactory::fromProto(const envoy::api::v2::filter::http::AccessLogFilter& config,
+FilterPtr FilterFactory::fromProto(const envoy::api::v2::filter::AccessLogFilter& config,
                                    Runtime::Loader& runtime) {
   switch (config.filter_specifier_case()) {
-  case envoy::api::v2::filter::http::AccessLogFilter::kStatusCodeFilter:
+  case envoy::api::v2::filter::AccessLogFilter::kStatusCodeFilter:
     return FilterPtr{new StatusCodeFilter(config.status_code_filter(), runtime)};
-  case envoy::api::v2::filter::http::AccessLogFilter::kDurationFilter:
+  case envoy::api::v2::filter::AccessLogFilter::kDurationFilter:
     return FilterPtr{new DurationFilter(config.duration_filter(), runtime)};
-  case envoy::api::v2::filter::http::AccessLogFilter::kNotHealthCheckFilter:
+  case envoy::api::v2::filter::AccessLogFilter::kNotHealthCheckFilter:
     return FilterPtr{new NotHealthCheckFilter()};
-  case envoy::api::v2::filter::http::AccessLogFilter::kTraceableFilter:
+  case envoy::api::v2::filter::AccessLogFilter::kTraceableFilter:
     return FilterPtr{new TraceableRequestFilter()};
-  case envoy::api::v2::filter::http::AccessLogFilter::kRuntimeFilter:
+  case envoy::api::v2::filter::AccessLogFilter::kRuntimeFilter:
     return FilterPtr{new RuntimeFilter(config.runtime_filter(), runtime)};
-  case envoy::api::v2::filter::http::AccessLogFilter::kAndFilter:
+  case envoy::api::v2::filter::AccessLogFilter::kAndFilter:
     return FilterPtr{new AndFilter(config.and_filter(), runtime)};
-  case envoy::api::v2::filter::http::AccessLogFilter::kOrFilter:
+  case envoy::api::v2::filter::AccessLogFilter::kOrFilter:
     return FilterPtr{new OrFilter(config.or_filter(), runtime)};
   default:
     NOT_REACHED;
@@ -84,7 +84,7 @@ bool DurationFilter::evaluate(const RequestInfo& info, const HeaderMap&) {
       std::chrono::duration_cast<std::chrono::milliseconds>(info.duration()).count());
 }
 
-RuntimeFilter::RuntimeFilter(const envoy::api::v2::filter::http::RuntimeFilter& config,
+RuntimeFilter::RuntimeFilter(const envoy::api::v2::filter::RuntimeFilter& config,
                              Runtime::Loader& runtime)
     : runtime_(runtime), runtime_key_(config.runtime_key()) {}
 
@@ -102,18 +102,17 @@ bool RuntimeFilter::evaluate(const RequestInfo&, const HeaderMap& request_header
 }
 
 OperatorFilter::OperatorFilter(
-    const Protobuf::RepeatedPtrField<envoy::api::v2::filter::http::AccessLogFilter>& configs,
+    const Protobuf::RepeatedPtrField<envoy::api::v2::filter::AccessLogFilter>& configs,
     Runtime::Loader& runtime) {
   for (const auto& config : configs) {
     filters_.emplace_back(FilterFactory::fromProto(config, runtime));
   }
 }
 
-OrFilter::OrFilter(const envoy::api::v2::filter::http::OrFilter& config, Runtime::Loader& runtime)
+OrFilter::OrFilter(const envoy::api::v2::filter::OrFilter& config, Runtime::Loader& runtime)
     : OperatorFilter(config.filters(), runtime) {}
 
-AndFilter::AndFilter(const envoy::api::v2::filter::http::AndFilter& config,
-                     Runtime::Loader& runtime)
+AndFilter::AndFilter(const envoy::api::v2::filter::AndFilter& config, Runtime::Loader& runtime)
     : OperatorFilter(config.filters(), runtime) {}
 
 bool OrFilter::evaluate(const RequestInfo& info, const HeaderMap& request_headers) {
@@ -146,7 +145,7 @@ bool NotHealthCheckFilter::evaluate(const RequestInfo& info, const HeaderMap&) {
   return !info.healthCheck();
 }
 
-InstanceSharedPtr AccessLogFactory::fromProto(const envoy::api::v2::filter::http::AccessLog& config,
+InstanceSharedPtr AccessLogFactory::fromProto(const envoy::api::v2::filter::AccessLog& config,
                                               Server::Configuration::FactoryContext& context) {
   FilterPtr filter;
   if (config.has_filter()) {

--- a/source/common/http/access_log/access_log_impl.h
+++ b/source/common/http/access_log/access_log_impl.h
@@ -25,7 +25,7 @@ public:
   /**
    * Read a filter definition from proto and instantiate a concrete filter class.
    */
-  static FilterPtr fromProto(const envoy::api::v2::filter::http::AccessLogFilter& config,
+  static FilterPtr fromProto(const envoy::api::v2::filter::AccessLogFilter& config,
                              Runtime::Loader& runtime);
 };
 
@@ -34,12 +34,12 @@ public:
  */
 class ComparisonFilter : public Filter {
 protected:
-  ComparisonFilter(const envoy::api::v2::filter::http::ComparisonFilter& config,
+  ComparisonFilter(const envoy::api::v2::filter::ComparisonFilter& config,
                    Runtime::Loader& runtime);
 
   bool compareAgainstValue(uint64_t lhs);
 
-  envoy::api::v2::filter::http::ComparisonFilter config_;
+  envoy::api::v2::filter::ComparisonFilter config_;
   Runtime::Loader& runtime_;
 };
 
@@ -48,8 +48,7 @@ protected:
  */
 class StatusCodeFilter : public ComparisonFilter {
 public:
-  StatusCodeFilter(const envoy::api::v2::filter::http::StatusCodeFilter& config,
-                   Runtime::Loader& runtime)
+  StatusCodeFilter(const envoy::api::v2::filter::StatusCodeFilter& config, Runtime::Loader& runtime)
       : ComparisonFilter(config.comparison(), runtime) {}
 
   // Http::AccessLog::Filter
@@ -61,8 +60,7 @@ public:
  */
 class DurationFilter : public ComparisonFilter {
 public:
-  DurationFilter(const envoy::api::v2::filter::http::DurationFilter& config,
-                 Runtime::Loader& runtime)
+  DurationFilter(const envoy::api::v2::filter::DurationFilter& config, Runtime::Loader& runtime)
       : ComparisonFilter(config.comparison(), runtime) {}
 
   // Http::AccessLog::Filter
@@ -74,9 +72,8 @@ public:
  */
 class OperatorFilter : public Filter {
 public:
-  OperatorFilter(
-      const Protobuf::RepeatedPtrField<envoy::api::v2::filter::http::AccessLogFilter>& configs,
-      Runtime::Loader& runtime);
+  OperatorFilter(const Protobuf::RepeatedPtrField<envoy::api::v2::filter::AccessLogFilter>& configs,
+                 Runtime::Loader& runtime);
 
 protected:
   std::vector<FilterPtr> filters_;
@@ -87,7 +84,7 @@ protected:
  */
 class AndFilter : public OperatorFilter {
 public:
-  AndFilter(const envoy::api::v2::filter::http::AndFilter& config, Runtime::Loader& runtime);
+  AndFilter(const envoy::api::v2::filter::AndFilter& config, Runtime::Loader& runtime);
 
   // Http::AccessLog::Filter
   bool evaluate(const RequestInfo& info, const HeaderMap& request_headers) override;
@@ -98,7 +95,7 @@ public:
  */
 class OrFilter : public OperatorFilter {
 public:
-  OrFilter(const envoy::api::v2::filter::http::OrFilter& config, Runtime::Loader& runtime);
+  OrFilter(const envoy::api::v2::filter::OrFilter& config, Runtime::Loader& runtime);
 
   // Http::AccessLog::Filter
   bool evaluate(const RequestInfo& info, const HeaderMap& request_headers) override;
@@ -129,8 +126,7 @@ public:
  */
 class RuntimeFilter : public Filter {
 public:
-  RuntimeFilter(const envoy::api::v2::filter::http::RuntimeFilter& config,
-                Runtime::Loader& runtime);
+  RuntimeFilter(const envoy::api::v2::filter::RuntimeFilter& config, Runtime::Loader& runtime);
 
   // Http::AccessLog::Filter
   bool evaluate(const RequestInfo& info, const HeaderMap& request_headers) override;
@@ -140,7 +136,7 @@ private:
   const std::string runtime_key_;
 };
 
-InstanceSharedPtr instanceFromProto(const envoy::api::v2::filter::http::AccessLog& config,
+InstanceSharedPtr instanceFromProto(const envoy::api::v2::filter::AccessLog& config,
                                     Runtime::Loader& runtime,
                                     Envoy::AccessLog::AccessLogManager& log_manager);
 
@@ -152,7 +148,7 @@ public:
   /**
    * Read a filter definition from proto and instantiate an Instance.
    */
-  static InstanceSharedPtr fromProto(const envoy::api::v2::filter::http::AccessLog& config,
+  static InstanceSharedPtr fromProto(const envoy::api::v2::filter::AccessLog& config,
                                      Server::Configuration::FactoryContext& context);
 };
 

--- a/source/server/config/http/file_access_log.cc
+++ b/source/server/config/http/file_access_log.cc
@@ -17,7 +17,7 @@ namespace Configuration {
 
 Http::AccessLog::InstanceSharedPtr FileAccessLogFactory::createAccessLogInstance(
     const Protobuf::Message& config, Http::AccessLog::FilterPtr&& filter, FactoryContext& context) {
-  const auto& fal_config = dynamic_cast<const envoy::api::v2::filter::http::FileAccessLog&>(config);
+  const auto& fal_config = dynamic_cast<const envoy::api::v2::filter::FileAccessLog&>(config);
   Http::AccessLog::FormatterPtr formatter;
   if (fal_config.format().empty()) {
     formatter = Http::AccessLog::AccessLogFormatUtils::defaultAccessLogFormatter();
@@ -29,7 +29,7 @@ Http::AccessLog::InstanceSharedPtr FileAccessLogFactory::createAccessLogInstance
 }
 
 ProtobufTypes::MessagePtr FileAccessLogFactory::createEmptyConfigProto() {
-  return ProtobufTypes::MessagePtr{new envoy::api::v2::filter::http::FileAccessLog()};
+  return ProtobufTypes::MessagePtr{new envoy::api::v2::filter::FileAccessLog()};
 }
 
 std::string FileAccessLogFactory::name() const { return Config::AccessLogNames::get().FILE; }

--- a/test/common/http/access_log/access_log_impl_test.cc
+++ b/test/common/http/access_log/access_log_impl_test.cc
@@ -44,8 +44,8 @@ namespace Http {
 namespace AccessLog {
 namespace {
 
-envoy::api::v2::filter::http::AccessLog parseAccessLogFromJson(const std::string& json_string) {
-  envoy::api::v2::filter::http::AccessLog access_log;
+envoy::api::v2::filter::AccessLog parseAccessLogFromJson(const std::string& json_string) {
+  envoy::api::v2::filter::AccessLog access_log;
   auto json_object_ptr = Json::Factory::loadFromString(json_string);
   Config::FilterJson::translateAccessLog(*json_object_ptr, access_log);
   return access_log;
@@ -487,9 +487,9 @@ TEST_F(AccessLogImplTest, multipleOperators) {
 }
 
 TEST_F(AccessLogImplTest, ConfigureFromProto) {
-  envoy::api::v2::filter::http::AccessLog config;
+  envoy::api::v2::filter::AccessLog config;
 
-  envoy::api::v2::filter::http::FileAccessLog fal_config;
+  envoy::api::v2::filter::FileAccessLog fal_config;
   fal_config.set_path("/dev/null");
 
   MessageUtil::jsonConvert(fal_config, *config.mutable_config());
@@ -521,7 +521,7 @@ TEST(AccessLogFilterTest, DurationWithRuntimeKey) {
   NiceMock<Runtime::MockLoader> runtime;
 
   Json::ObjectSharedPtr filter_object = loader->getObject("filter");
-  envoy::api::v2::filter::http::AccessLogFilter config;
+  envoy::api::v2::filter::AccessLogFilter config;
   Config::FilterJson::translateAccessLogFilter(*filter_object, config);
   DurationFilter filter(config.duration_filter(), runtime);
   TestHeaderMapImpl request_headers{{":method", "GET"}, {":path", "/"}};
@@ -555,7 +555,7 @@ TEST(AccessLogFilterTest, StatusCodeWithRuntimeKey) {
   NiceMock<Runtime::MockLoader> runtime;
 
   Json::ObjectSharedPtr filter_object = loader->getObject("filter");
-  envoy::api::v2::filter::http::AccessLogFilter config;
+  envoy::api::v2::filter::AccessLogFilter config;
   Config::FilterJson::translateAccessLogFilter(*filter_object, config);
   StatusCodeFilter filter(config.status_code_filter(), runtime);
 

--- a/test/server/config/http/BUILD
+++ b/test/server/config/http/BUILD
@@ -11,6 +11,7 @@ envoy_package()
 envoy_cc_test(
     name = "config_test",
     srcs = ["config_test.cc"],
+    external_deps = ["envoy_filter_accesslog"],
     deps = [
         "//source/common/config:well_known_names",
         "//source/common/http/access_log:access_log_lib",

--- a/test/server/config/http/config_test.cc
+++ b/test/server/config/http/config_test.cc
@@ -299,7 +299,7 @@ TEST(AccessLogConfigTest, FileAccessLogTest) {
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
   ASSERT_NE(nullptr, message);
 
-  envoy::api::v2::filter::http::FileAccessLog file_access_log;
+  envoy::api::v2::filter::FileAccessLog file_access_log;
   file_access_log.set_path("/dev/null");
   file_access_log.set_format("%START_TIME%");
   MessageUtil::jsonConvert(file_access_log, *message);


### PR DESCRIPTION
Updates the data-plane-api SHA to 6e3e1a7 and changes the namespaces in consuming code to match the package name change for AccessLog and related messages.

Relates to #1927.

Link to [Data Plane PR](https://github.com/envoyproxy/data-plane-api/pull/211).

*Risk Level*: Low
*Testing*: unit tests (no functional change)
*Release Notes*: Note change to data-plane-api.
