### PR TITLE
CI: Move to envoyproxy Dockerhub

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -3,18 +3,18 @@
 Two flavors of Envoy Docker images, based on Ubuntu and Alpine Linux, are built.
 
 ## Ubuntu envoy image
-The Ubuntu based Envoy Docker image at [`lyft/envoy-build:<hash>`](https://hub.docker.com/r/lyft/envoy-build/) is used for Travis CI checks,
+The Ubuntu based Envoy Docker image at [`envoyproxy/envoy-build:<hash>`](https://hub.docker.com/r/envoyproxy/envoy-build/) is used for Travis CI checks,
 where `<hash>` is specified in [`envoy_build_sha.sh`](https://github.com/envoyproxy/envoy/blob/master/ci/envoy_build_sha.sh). Developers
-may work with `lyft/envoy-build:latest` to provide a self-contained environment for building Envoy binaries and
+may work with `envoyproxy/envoy-build:latest` to provide a self-contained environment for building Envoy binaries and
 running tests that reflects the latest built Ubuntu Envoy image. Moreover, the Docker image
-at [`lyft/envoy:<hash>`](https://hub.docker.com/r/lyft/envoy/) is an image that has an Envoy binary at `/usr/local/bin/envoy`. The `<hash>`
-corresponds to the master commit at which the binary was compiled. Lastly, `lyft/envoy:latest` contains an Envoy
+at [`envoyproxy/envoy:<hash>`](https://hub.docker.com/r/envoyproxy/envoy/) is an image that has an Envoy binary at `/usr/local/bin/envoy`. The `<hash>`
+corresponds to the master commit at which the binary was compiled. Lastly, `envoyproxy/envoy:latest` contains an Envoy
 binary built from the latest tip of master that passed tests.
 
 ## Alpine envoy image
 
 Minimal images based on Alpine Linux allow for quicker deployment of Envoy. Two Alpine based images are built,
-one with an Envoy binary with debug (`lyft/envoy-alpine-debug`) symbols and one stripped of them (`lyft/envoy-alpine`).
+one with an Envoy binary with debug (`envoyproxy/envoy-alpine-debug`) symbols and one stripped of them (`envoyproxy/envoy-alpine`).
 Both images are pushed with two different tags: `<hash>` and `latest`. Parallel to the Ubuntu images above, `<hash>` corresponds to the
 master commit at which the binary was compiled, and `latest` corresponds to a binary built from the latest tip of master that passed tests.
 
@@ -22,9 +22,9 @@ master commit at which the binary was compiled, and `latest` corresponds to a bi
 
 Currently there are three build images:
 
-* `lyft/envoy-build` &mdash; alias to `lyft/envoy-build-ubuntu`.
-* `lyft/envoy-build-ubuntu` &mdash; based on Ubuntu 16.04 (Xenial) which uses the GCC 5.4 compiler.
-* `lyft/envoy-build-centos` &mdash; based on CentOS 7 which uses the GCC 5.3.1 compiler (devtoolset-4).
+* `envoyproxy/envoy-build` &mdash; alias to `envoyproxy/envoy-build-ubuntu`.
+* `envoyproxy/envoy-build-ubuntu` &mdash; based on Ubuntu 16.04 (Xenial) which uses the GCC 5.4 compiler.
+* `envoyproxy/envoy-build-centos` &mdash; based on CentOS 7 which uses the GCC 5.3.1 compiler (devtoolset-4).
 
 We also install and use the clang-5.0 compiler for some sanitizing runs.
 
@@ -36,11 +36,11 @@ An example basic invocation to build a developer version of the Envoy static bin
 ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.dev'
 ```
 
-The build image defaults to `lyft/envoy-build-ubuntu`, but you can choose build image by setting `IMAGE_NAME` in the environment,
-e.g. to use the `lyft/envoy-build-centos` image you can run:
+The build image defaults to `envoyproxy/envoy-build-ubuntu`, but you can choose build image by setting `IMAGE_NAME` in the environment,
+e.g. to use the `envoyproxy/envoy-build-centos` image you can run:
 
 ```bash
-IMAGE_NAME=lyft/envoy-build-centos ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.dev'
+IMAGE_NAME=envoyproxy/envoy-build-centos ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.dev'
 ```
 
 The Envoy binary can be found in `/tmp/envoy-docker-build/envoy/source/exe/envoy-fastbuild` on the Docker host. You
@@ -95,11 +95,11 @@ DISTRO=ubuntu
 cd ci/build_container
 LINUX_DISTRO="${DISTRO}" CIRCLE_SHA1=my_tag ./docker_build.sh  # Wait patiently for quite some time
 cd ../..
-IMAGE_NAME="lyft/envoy-build-${DISTRO}" IMAGE_ID=my_tag ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.whatever'
+IMAGE_NAME="envoyproxy/envoy-build-${DISTRO}" IMAGE_ID=my_tag ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.whatever'
 ```
 
-This build the Ubuntu based `lyft/envoy-build-ubuntu` image, and the final call will run against your local copy of the build image.
-To build the CentOS based `lyft/envoy-build-ubuntu-centos` image, change `DISTRO` above to *centos*.
+This build the Ubuntu based `envoyproxy/envoy-build-ubuntu` image, and the final call will run against your local copy of the build image.
+To build the CentOS based `envoyproxy/envoy-build-ubuntu-centos` image, change `DISTRO` above to *centos*.
 
 # MacOS Build Flow
 
@@ -117,7 +117,7 @@ Coverity Scan static analysis is not run within Envoy CI. However, Envoy can be 
 submitted for analysis. A Coverity Scan Envoy project token must be generated from the
 [Coverity Project Settings](https://scan.coverity.com/projects/envoy-proxy?tab=project_settings).
 Only a Coverity Project Administrator can create a token. With this token, running
-`ci/do_coverity_local.sh` will use the Ubuntu based `lyft/envoy-build-ubuntu` image to build the
+`ci/do_coverity_local.sh` will use the Ubuntu based `envoyproxy/envoy-build-ubuntu` image to build the
 Envoy static binary with the Coverity Scan tool chain. This process generates an artifact,
 envoy-coverity-output.tgz, that is uploaded to Coverity for static analysis.
 

--- a/ci/build_container/README.md
+++ b/ci/build_container/README.md
@@ -1,6 +1,6 @@
 Envoy's CI has a build run called `build_image`. On a commit to master, `ci/build_container/docker_push.sh`
-checks if the commit has changed the `ci/build_container` directory. If there are changes, CI builds a new `lyft/envoy-build`
-image. The image is pushed to [dockerhub](https://hub.docker.com/r/lyft/envoy-build/tags/) under `latest` and under the commit sha.
+checks if the commit has changed the `ci/build_container` directory. If there are changes, CI builds a new `envoyproxy/envoy-build`
+image. The image is pushed to [dockerhub](https://hub.docker.com/r/envoyproxy/envoy-build/tags/) under `latest` and under the commit sha.
 
 After the PR that changes `ci/build_container` has been merged, and the new image gets pushed,
 a second PR is needed to update `ci/envoy_build_sha.sh`. In order to pull the new tagged version of

--- a/ci/build_container/docker_build.sh
+++ b/ci/build_container/docker_build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 [[ -z "${LINUX_DISTRO}" ]] && LINUX_DISTRO="ubuntu"
-[[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME="lyft/envoy-build-${LINUX_DISTRO}"
+[[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME=envoyproxy/envoy-build-"${LINUX_DISTRO}"
 
 # We need //bazel/... and WORKSPACE for the build, but it's not in ci/build_container. Using Docker
 # relative path workaround from https://github.com/docker/docker/issues/2745#issuecomment-253230025

--- a/ci/build_container/docker_build.sh
+++ b/ci/build_container/docker_build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 [[ -z "${LINUX_DISTRO}" ]] && LINUX_DISTRO="ubuntu"
-[[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME=envoyproxy/envoy-build-"${LINUX_DISTRO}"
+[[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME=lyft/envoy-build-"${LINUX_DISTRO}"
 
 # We need //bazel/... and WORKSPACE for the build, but it's not in ci/build_container. Using Docker
 # relative path workaround from https://github.com/docker/docker/issues/2745#issuecomment-253230025

--- a/ci/build_container/docker_push.sh
+++ b/ci/build_container/docker_push.sh
@@ -29,19 +29,19 @@ then
 
         for distro in ubuntu centos
         do
-            echo "Updating lyft/envoy-build-${distro} image"
+            echo "Updating envoyproxy/envoy-build-${distro} image"
             LINUX_DISTRO=$distro ./docker_build.sh
-            docker push lyft/envoy-build-${distro}:$CIRCLE_SHA1
-            docker tag lyft/envoy-build-${distro}:$CIRCLE_SHA1 lyft/envoy-build-${distro}:latest
-            docker push lyft/envoy-build-${distro}:latest
+            docker push envoyproxy/envoy-build-"${distro}":"$CIRCLE_SHA1"
+            docker tag envoyproxy/envoy-build-"${distro}":"$CIRCLE_SHA1" envoyproxy/envoy-build-"${distro}":latest
+            docker push envoyproxy/envoy-build-"${distro}":latest
 
             if [ "$distro" == "ubuntu" ]
             then
-                echo "Updating lyft/envoy-build image"
-                docker tag lyft/envoy-build-${distro}:$CIRCLE_SHA1 lyft/envoy-build:$CIRCLE_SHA1
-                docker push lyft/envoy-build:$CIRCLE_SHA1
-                docker tag lyft/envoy-build:$CIRCLE_SHA1 lyft/envoy-build:latest
-                docker push lyft/envoy-build:latest
+                echo "Updating envoyproxy/envoy-build image"
+                docker tag envoyproxy/envoy-build-"${distro}":"$CIRCLE_SHA1" envoyproxy/envoy-build:"$CIRCLE_SHA1"
+                docker push envoyproxy/envoy-build:"$CIRCLE_SHA1"
+                docker tag envoyproxy/envoy-build:"$CIRCLE_SHA1" envoyproxy/envoy-build:latest
+                docker push envoyproxy/envoy-build:latest
             fi
         done
     else

--- a/ci/ci_steps.sh
+++ b/ci/ci_steps.sh
@@ -21,5 +21,5 @@ trap finish EXIT
 echo "disk space at beginning of build:"
 df -h
 
-docker run -t -i -v "$ENVOY_BUILD_DIR":/build -v $TRAVIS_BUILD_DIR:/source \
-  lyft/envoy-build:$ENVOY_BUILD_SHA /bin/bash -c "cd /source && ci/do_ci.sh $TEST_TYPE"
+docker run -t -i -v "$ENVOY_BUILD_DIR":/build -v "$TRAVIS_BUILD_DIR":/source \
+  envoyproxy/envoy-build:"$ENVOY_BUILD_SHA" /bin/bash -c "cd /source && ci/do_ci.sh $TEST_TYPE"

--- a/ci/ci_steps.sh
+++ b/ci/ci_steps.sh
@@ -22,4 +22,4 @@ echo "disk space at beginning of build:"
 df -h
 
 docker run -t -i -v "$ENVOY_BUILD_DIR":/build -v "$TRAVIS_BUILD_DIR":/source \
-  envoyproxy/envoy-build:"$ENVOY_BUILD_SHA" /bin/bash -c "cd /source && ci/do_ci.sh $TEST_TYPE"
+  lyft/envoy-build:"$ENVOY_BUILD_SHA" /bin/bash -c "cd /source && ci/do_ci.sh $TEST_TYPE"

--- a/ci/docker_push.sh
+++ b/ci/docker_push.sh
@@ -25,21 +25,21 @@ then
    tar -xz -C /tmp -f /tmp/docker-"$VER".tgz
    mv /tmp/docker/* /usr/bin
 
-   docker build -f ci/Dockerfile-envoy-image -t lyft/envoy:latest .
+   docker build -f ci/Dockerfile-envoy-image -t envoyproxy/envoy:latest .
    docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
-   docker push lyft/envoy:latest
-   docker tag lyft/envoy:latest lyft/envoy:"$CIRCLE_SHA1"
-   docker push lyft/envoy:"$CIRCLE_SHA1"
+   docker push envoyproxy/envoy:latest
+   docker tag envoyproxy/envoy:latest envoyproxy/envoy:"$CIRCLE_SHA1"
+   docker push envoyproxy/envoy:"$CIRCLE_SHA1"
 
-   docker build -f ci/Dockerfile-envoy-alpine -t lyft/envoy-alpine:latest .
-   docker tag lyft/envoy-alpine:latest lyft/envoy-alpine:"$CIRCLE_SHA1"
-   docker push lyft/envoy-alpine:"$CIRCLE_SHA1"
-   docker push lyft/envoy-alpine:latest
+   docker build -f ci/Dockerfile-envoy-alpine -t envoyproxy/envoy-alpine:latest .
+   docker tag envoyproxy/envoy-alpine:latest envoyproxy/envoy-alpine:"$CIRCLE_SHA1"
+   docker push envoyproxy/envoy-alpine:"$CIRCLE_SHA1"
+   docker push envoyproxy/envoy-alpine:latest
 
-   docker build -f ci/Dockerfile-envoy-alpine-debug -t lyft/envoy-alpine-debug:latest .
-   docker tag lyft/envoy-alpine-debug:latest lyft/envoy-alpine-debug:"$CIRCLE_SHA1"
-   docker push lyft/envoy-alpine-debug:"$CIRCLE_SHA1"
-   docker push lyft/envoy-alpine-debug:latest
+   docker build -f ci/Dockerfile-envoy-alpine-debug -t envoyproxy/envoy-alpine-debug:latest .
+   docker tag envoyproxy/envoy-alpine-debug:latest envoyproxy/envoy-alpine-debug:"$CIRCLE_SHA1"
+   docker push envoyproxy/envoy-alpine-debug:"$CIRCLE_SHA1"
+   docker push envoyproxy/envoy-alpine-debug:latest
 
    # This script tests the docker examples.
    # TODO(mattklein123): This almost always times out on Travis. Do not run for now until we

--- a/ci/docker_tag.sh
+++ b/ci/docker_tag.sh
@@ -18,17 +18,17 @@ then
 
    docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
-   docker pull lyft/envoy:"$CIRCLE_SHA1"
-   docker tag lyft/envoy:"$CIRCLE_SHA1" lyft/envoy:"$CIRCLE_TAG"
-   docker push lyft/envoy:"$CIRCLE_TAG"
+   docker pull envoyproxy/envoy:"$CIRCLE_SHA1"
+   docker tag envoyproxy/envoy:"$CIRCLE_SHA1" envoyproxy/envoy:"$CIRCLE_TAG"
+   docker push envoyproxy/envoy:"$CIRCLE_TAG"
 
-   docker pull lyft/envoy-alpine:"$CIRCLE_SHA1"
-   docker tag lyft/envoy-alpine:"$CIRCLE_SHA1" lyft/envoy-alpine:"$CIRCLE_TAG"
-   docker push lyft/envoy-alpine:"$CIRCLE_TAG"
+   docker pull envoyproxy/envoy-alpine:"$CIRCLE_SHA1"
+   docker tag envoyproxy/envoy-alpine:"$CIRCLE_SHA1" envoyproxy/envoy-alpine:"$CIRCLE_TAG"
+   docker push envoyproxy/envoy-alpine:"$CIRCLE_TAG"
 
-   docker pull lyft/envoy-alpine-debug:"$CIRCLE_SHA1"
-   docker tag lyft/envoy-alpine-debug:"$CIRCLE_SHA1" lyft/envoy-alpine-debug:"$CIRCLE_TAG"
-   docker push lyft/envoy-alpine-debug:"$CIRCLE_TAG"
+   docker pull envoyproxy/envoy-alpine-debug:"$CIRCLE_SHA1"
+   docker tag envoyproxy/envoy-alpine-debug:"$CIRCLE_SHA1" envoyproxy/envoy-alpine-debug:"$CIRCLE_TAG"
+   docker push envoyproxy/envoy-alpine-debug:"$CIRCLE_TAG"
 else
    echo 'Ignoring non-tag event for docker tag.'
 fi

--- a/ci/envoy_build_sha.sh
+++ b/ci/envoy_build_sha.sh
@@ -1,2 +1,2 @@
-ENVOY_BUILD_SHA=$(grep lyft/envoy-build .circleci/config.yml | sed -e 's#.*lyft/envoy-build:\(.*\)#\1#' | uniq)
+ENVOY_BUILD_SHA=$(grep envoyproxy/envoy-build .circleci/config.yml | sed -e 's#.*envoyproxy/envoy-build:\(.*\)#\1#' | uniq)
 [[ $(wc -l <<< "${ENVOY_BUILD_SHA}" | awk '{$1=$1};1') == 1 ]] || (echo ".circleci/config.yml hashes are inconsistent!" && exit 1)

--- a/ci/envoy_build_sha.sh
+++ b/ci/envoy_build_sha.sh
@@ -1,2 +1,2 @@
-ENVOY_BUILD_SHA=$(grep envoyproxy/envoy-build .circleci/config.yml | sed -e 's#.*envoyproxy/envoy-build:\(.*\)#\1#' | uniq)
+ENVOY_BUILD_SHA=$(grep lyft/envoy-build .circleci/config.yml | sed -e 's#.*lyft/envoy-build:\(.*\)#\1#' | uniq)
 [[ $(wc -l <<< "${ENVOY_BUILD_SHA}" | awk '{$1=$1};1') == 1 ]] || (echo ".circleci/config.yml hashes are inconsistent!" && exit 1)

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -13,7 +13,7 @@ else
 	USER_GROUP=$(id -g)
 fi
 
-[[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME="lyft/envoy-build-ubuntu"
+[[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME="envoyproxy/envoy-build-ubuntu"
 # The IMAGE_ID defaults to the CI hash but can be set to an arbitrary image ID (found with 'docker
 # images').
 [[ -z "${IMAGE_ID}" ]] && IMAGE_ID="${ENVOY_BUILD_SHA}"

--- a/examples/front-proxy/Dockerfile-frontenvoy
+++ b/examples/front-proxy/Dockerfile-frontenvoy
@@ -1,4 +1,4 @@
-FROM lyft/envoy:latest
+FROM envoyproxy/envoy:latest
 
 RUN apt-get update && apt-get -q install -y \
     curl

--- a/examples/front-proxy/Dockerfile-service
+++ b/examples/front-proxy/Dockerfile-service
@@ -1,4 +1,4 @@
-FROM lyft/envoy:latest
+FROM envoyproxy/envoy:latest
 
 RUN apt-get update && apt-get -q install -y \
     curl \

--- a/examples/grpc-bridge/Dockerfile-grpc
+++ b/examples/grpc-bridge/Dockerfile-grpc
@@ -1,4 +1,4 @@
-FROM lyft/envoy:latest
+FROM envoyproxy/envoy:latest
 
 RUN mkdir /var/log/envoy/
 COPY ./bin/service /usr/local/bin/srv

--- a/examples/grpc-bridge/Dockerfile-python
+++ b/examples/grpc-bridge/Dockerfile-python
@@ -1,4 +1,4 @@
-FROM lyft/envoy:latest
+FROM envoyproxy/envoy:latest
 
 RUN apt-get update
 RUN apt-get -q install -y python-dev \


### PR DESCRIPTION
**NOTE**: This does not include the updates to the Docker image [used by CircleCI](https://github.com/envoyproxy/envoy/blob/master/.circleci/config.yml#L8) since that'll probably break all the tests until the Dockerhub account is created. 
@mattklein123 lmk when that's ready and I'll add a followup commit to change that build image.

Fixes https://github.com/envoyproxy/envoy/issues/1957

Signed-off-by: bndw <benjamindwoodward@gmail.com>