### PR TITLE
Fix a couple Coverity code quality warnings (uninitialized fields, buffer overwrites, etc)

### DIFF
--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -14,8 +14,8 @@ namespace Buffer {
  * A raw memory data slice including location and length.
  */
 struct RawSlice {
-  void* mem_;
-  size_t len_;
+  void* mem_ = nullptr;
+  size_t len_ = 0;
 };
 
 /**

--- a/source/common/filesystem/inotify/watcher_impl.cc
+++ b/source/common/filesystem/inotify/watcher_impl.cc
@@ -52,14 +52,16 @@ void WatcherImpl::addWatch(const std::string& path, uint32_t events, OnChangedCb
 
 void WatcherImpl::onInotifyEvent() {
   while (true) {
-    char buffer[sizeof(inotify_event) + NAME_MAX + 1];
+    uint8_t buffer[sizeof(inotify_event) + NAME_MAX + 1];
     ssize_t rc = read(inotify_fd_, &buffer, sizeof(buffer));
     if (rc == -1 && errno == EAGAIN) {
       return;
     }
+    RELEASE_ASSERT(rc >= 0);
 
-    ssize_t index = 0;
-    while (index < rc) {
+    const size_t event_count = rc;
+    size_t index = 0;
+    while (index < event_count) {
       inotify_event* file_event = reinterpret_cast<inotify_event*>(&buffer[index]);
       ASSERT(callback_map_.count(file_event->wd) == 1);
 

--- a/source/common/http/filter/cors_filter.cc
+++ b/source/common/http/filter/cors_filter.cc
@@ -10,7 +10,7 @@
 namespace Envoy {
 namespace Http {
 
-CorsFilter::CorsFilter() : is_cors_request_(false) {}
+CorsFilter::CorsFilter() : policies_({{nullptr, nullptr}}), is_cors_request_(false) {}
 
 // This handles the CORS preflight request as described in #6.2
 // https://www.w3.org/TR/cors/

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -172,8 +172,8 @@ private:
   static void buildRapidJsonDocument(const Field& field, rapidjson::Value& value,
                                      rapidjson::Document::AllocatorType& allocator);
 
-  uint64_t line_number_start_;
-  uint64_t line_number_end_;
+  uint64_t line_number_start_ = 0;
+  uint64_t line_number_end_ = 0;
   const Type type_;
   Value value_;
 };

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -85,7 +85,7 @@ std::string RandomGeneratorImpl::uuid() {
   static thread_local uint8_t buffered[2048];
   static thread_local size_t buffered_idx = sizeof(buffered);
 
-  if (buffered_idx >= sizeof(buffered)) {
+  if (buffered_idx + 16 > sizeof(buffered)) {
     int rc = RAND_bytes(buffered, sizeof(buffered));
     ASSERT(rc == 1);
     UNREFERENCED_PARAMETER(rc);


### PR DESCRIPTION
As far as I can tell none of these are security relevant, but it's nice to trim off a chunk of the Coverity warnings list.