### PR TITLE
Fix the ipv6 hot restart test with curl.7.35.0

### DIFF
--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -72,7 +72,7 @@ do
 
   echo "Checking for match of --hot-restart-version and admin /hot_restart_version"
   ADMIN_ADDRESS_0=$(cat "${ADMIN_ADDRESS_PATH_0}")
-  ADMIN_HOT_RESTART_VERSION=$(curl -s http://${ADMIN_ADDRESS_0}/hot_restart_version)
+  ADMIN_HOT_RESTART_VERSION=$(curl -sg http://${ADMIN_ADDRESS_0}/hot_restart_version)
   CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version 2>&1)
   if [[ "${ADMIN_HOT_RESTART_VERSION}" != "${CLI_HOT_RESTART_VERSION}" ]]; then
       echo "Hot restart version mismatch: ${ADMIN_HOT_RESTART_VERSION} != " \


### PR DESCRIPTION
Signed-off-by: Alyssa Wilk <alyssar@chromium.org>

Description: Stops treating ipv6 addresses as glob with certain versions of curl.

curl "http://[::1]:34871/hot_restart_version"
curl: (3) [globbing] bad range specification in column 9
curl -g "http://[::1]:34871/hot_restart_version"
curl: (7) Failed to connect to ::1 port 34871: Connection refused

*Risk Level*: Low:  test only fix

*Testing*:
Ran the tests both in docker (still pass) and out (now pass) :-P