### PR TITLE
testing: make factory registries support injection

### DIFF
--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -58,12 +58,13 @@ public:
   }
 
   /**
-   * Remove a factory by name.
+   * Remove a factory by name. This method should only be used for testing purposes.
+   * @param name is the name of the factory to remove.
    */
-  static void unregisterFactory(Base& factory) {
-    auto result = factories().erase(factory.name());
+  static void removeFactoryForTest(const std::string& name) {
+    auto result = factories().erase(name);
     if (result == 0) {
-      throw EnvoyException(fmt::format("No registration for name: '{}'", factory.name()));
+      throw EnvoyException(fmt::format("No registration for name: '{}'", name));
     }
   }
 
@@ -94,17 +95,12 @@ public:
   /**
    * Contructor that registers an instance of the factory with the FactoryRegistry.
    */
-  RegisterFactory() { FactoryRegistry<Base>::registerFactory(instance_); }
-
-  /**
-   * Destructor that removes an instance of the factory from the FactoryRegistry.
-   */
-  ~RegisterFactory() { FactoryRegistry<Base>::unregisterFactory(instance_); }
-
-  T& testGetFactory() { return instance_; }
+  RegisterFactory() {
+    FactoryRegistry<Base>::registerFactory(instance_);
+  }
 
 private:
-  T instance_;
+  T instance_ {};
 };
 
 } // namespace Registry

--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -11,6 +11,9 @@
 namespace Envoy {
 namespace Registry {
 
+// Forward declaration of test class for friend declaration below.
+template <typename T> class InjectFactory;
+
 /**
  * General registry for implementation factories. The registry is templated by the Base class that a
  * set of factories conforms to.
@@ -48,7 +51,7 @@ public:
 
 private:
   // Allow factory injection only in tests.
-  template <typename T> friend class InjectFactory;
+  friend class InjectFactory<Base>;
 
   /**
    * Replaces a factory by name. This method should only be used for testing purposes.

--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -37,8 +37,8 @@ public:
 
   /**
    * Replaces a factory by name. This method should only be used for testing purposes.
-   * @param factory is the factory to inject
-   * @return Base* a pointer to the previously registered value
+   * @param factory is the factory to inject.
+   * @return Base* a pointer to the previously registered value.
    */
   static Base* replaceFactoryForTest(Base& factory) {
     auto displaced = getFactory(factory.name());

--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -95,12 +95,10 @@ public:
   /**
    * Contructor that registers an instance of the factory with the FactoryRegistry.
    */
-  RegisterFactory() {
-    FactoryRegistry<Base>::registerFactory(instance_);
-  }
+  RegisterFactory() { FactoryRegistry<Base>::registerFactory(instance_); }
 
 private:
-  T instance_ {};
+  T instance_{};
 };
 
 } // namespace Registry

--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -36,17 +36,6 @@ public:
   }
 
   /**
-   * Replaces a factory by name. This method should only be used for testing purposes.
-   * @param factory is the factory to inject.
-   * @return Base* a pointer to the previously registered value.
-   */
-  static Base* replaceFactoryForTest(Base& factory) {
-    auto displaced = getFactory(factory.name());
-    factories().emplace(std::make_pair(factory.name(), &factory));
-    return displaced;
-  }
-
-  /**
    * Gets a factory by name.  If the name isn't found in the registry, returns nullptr.
    */
   static Base* getFactory(const std::string& name) {
@@ -55,6 +44,21 @@ public:
       return nullptr;
     }
     return it->second;
+  }
+
+private:
+  // Allow factory injection only in tests.
+  template <typename T> friend class InjectFactory;
+
+  /**
+   * Replaces a factory by name. This method should only be used for testing purposes.
+   * @param factory is the factory to inject.
+   * @return Base* a pointer to the previously registered value.
+   */
+  static Base* replaceFactoryForTest(Base& factory) {
+    auto displaced = getFactory(factory.name());
+    factories().emplace(std::make_pair(factory.name(), &factory));
+    return displaced;
   }
 
   /**
@@ -68,7 +72,6 @@ public:
     }
   }
 
-private:
   /**
    * Gets the current map of factory implementations.
    */

--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -36,6 +36,17 @@ public:
   }
 
   /**
+   * Replaces a factory by name. This method should only be used for testing purposes.
+   * @param factory is the factory to inject
+   * @return Base* a pointer to the previously registered value
+   */
+  static Base* replaceFactoryForTest(Base& factory) {
+    auto displaced = getFactory(factory.name());
+    factories().emplace(std::make_pair(factory.name(), &factory));
+    return displaced;
+  }
+
+  /**
    * Gets a factory by name.  If the name isn't found in the registry, returns nullptr.
    */
   static Base* getFactory(const std::string& name) {

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -147,6 +147,7 @@ envoy_cc_test(
         "//source/common/protobuf",
         "//test/mocks/network:network_mocks",
         "//test/test_common:environment_lib",
+        "//test/test_common:registry_lib",
     ],
 )
 

--- a/test/common/network/resolver_impl_test.cc
+++ b/test/common/network/resolver_impl_test.cc
@@ -107,7 +107,7 @@ TEST(ResolverTest, NonStandardResolver) {
   TestResolver test_resolver;
   test_resolver.addMapping("foo", "1.2.3.4");
   test_resolver.addMapping("bar", "4.3.2.1");
-  InjectFactory<TestResolver, Resolver> register_resolver(test_resolver);
+  InjectFactory<Resolver> register_resolver(test_resolver);
 
   {
     envoy::api::v2::Address address;

--- a/test/common/network/resolver_impl_test.cc
+++ b/test/common/network/resolver_impl_test.cc
@@ -12,6 +12,7 @@
 
 #include "test/mocks/network/mocks.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/registry.h"
 #include "test/test_common/utility.h"
 
 #include "api/address.pb.h"
@@ -103,12 +104,10 @@ private:
 };
 
 TEST(ResolverTest, NonStandardResolver) {
-  // TODO(akonradi) Use singleton override instead of adding and removing
-  // resolvers for this test once issue #1808 is resolved.
-  Registry::RegisterFactory<TestResolver, Resolver> register_resolver;
-  auto& test_resolver = register_resolver.testGetFactory();
+  TestResolver test_resolver;
   test_resolver.addMapping("foo", "1.2.3.4");
   test_resolver.addMapping("bar", "4.3.2.1");
+  InjectFactory<TestResolver, Resolver> register_resolver(test_resolver);
 
   {
     envoy::api::v2::Address address;

--- a/test/common/network/resolver_impl_test.cc
+++ b/test/common/network/resolver_impl_test.cc
@@ -107,7 +107,7 @@ TEST(ResolverTest, NonStandardResolver) {
   TestResolver test_resolver;
   test_resolver.addMapping("foo", "1.2.3.4");
   test_resolver.addMapping("bar", "4.3.2.1");
-  InjectFactory<Resolver> register_resolver(test_resolver);
+  Registry::InjectFactory<Resolver> register_resolver(test_resolver);
 
   {
     envoy::api::v2::Address address;

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -57,6 +57,14 @@ envoy_cc_library(
 )
 
 envoy_cc_test_library(
+    name = "registry_lib",
+    hdrs = ["registry.h"],
+    deps = [
+        "//include/envoy/registry",
+    ],
+)
+
+envoy_cc_test_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
     hdrs = ["utility.h"],

--- a/test/test_common/registry.h
+++ b/test/test_common/registry.h
@@ -9,9 +9,9 @@ namespace Envoy {
  * of a factory for testing purposes. It will restore the original value, if any, when it goes
  * out of scope.
  */
-template <class T, class Base> class InjectFactory {
+template <class Base> class InjectFactory {
 public:
-  InjectFactory(T& instance) : instance_(instance) {
+  InjectFactory(Base& instance) : instance_(instance) {
     displaced_ = Registry::FactoryRegistry<Base>::replaceFactoryForTest(instance_);
   }
 
@@ -25,7 +25,7 @@ public:
   }
 
 private:
-  T& instance_;
+  Base& instance_;
   Base* displaced_{};
 };
 

--- a/test/test_common/registry.h
+++ b/test/test_common/registry.h
@@ -3,6 +3,7 @@
 #include "gtest/gtest.h"
 
 namespace Envoy {
+namespace Registry {
 
 /**
  * Factory registration template for tests. This can be used to inject a mock or dummy version
@@ -29,4 +30,5 @@ private:
   Base* displaced_{};
 };
 
+} // namespace Registry
 } // namespace Envoy

--- a/test/test_common/registry.h
+++ b/test/test_common/registry.h
@@ -1,0 +1,31 @@
+#include "envoy/registry/registry.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+
+/**
+ * Factory registration template for tests. This can be used to inject a mock or dummy version
+ * of a factory for testing purposes. It will restore the original value, if any, when it goes
+ * out of scope.
+ */
+template <class T, class Base> class InjectFactory {
+public:
+  InjectFactory(T& instance) : instance_(instance) {
+    displaced_ = Registry::FactoryRegistry<Base>::replaceFactoryForTest(instance_);
+  }
+
+  ~InjectFactory() {
+    if (displaced_) {
+      auto injected = Registry::FactoryRegistry<Base>::replaceFactoryForTest(*displaced_);
+      EXPECT_EQ(injected, &instance_);
+    } else {
+      Registry::FactoryRegistry<Base>::unregisterFactory(instance_);
+    }
+  }
+private:
+  T& instance_;
+  Base* displaced_ {};
+};
+
+} // namespace Envoy

--- a/test/test_common/registry.h
+++ b/test/test_common/registry.h
@@ -20,7 +20,7 @@ public:
       auto injected = Registry::FactoryRegistry<Base>::replaceFactoryForTest(*displaced_);
       EXPECT_EQ(injected, &instance_);
     } else {
-      Registry::FactoryRegistry<Base>::unregisterFactory(instance_);
+      Registry::FactoryRegistry<Base>::removeFactoryForTest(instance_.name());
     }
   }
 private:

--- a/test/test_common/registry.h
+++ b/test/test_common/registry.h
@@ -23,9 +23,10 @@ public:
       Registry::FactoryRegistry<Base>::removeFactoryForTest(instance_.name());
     }
   }
+
 private:
   T& instance_;
-  Base* displaced_ {};
+  Base* displaced_{};
 };
 
 } // namespace Envoy


### PR DESCRIPTION
*Description*:
Allows factories to be injected into registries for testing purpoes. 

Tangentially related to #1808

*Risk Level*: Low

*Testing*:
Ran the unit tests