### PR TITLE
Refactoring Cluster to own a HostSet rather than implementing HostSet

### DIFF
--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -378,8 +378,10 @@ typedef std::shared_ptr<const ClusterInfo> ClusterInfoConstSharedPtr;
  * An upstream cluster (group of hosts). This class is the "primary" singleton cluster used amongst
  * all forwarding threads/workers. Individual HostSets are used on the workers themselves.
  */
-class Cluster : public virtual HostSet {
+class Cluster {
 public:
+  virtual ~Cluster() {}
+
   enum class InitializePhase { Primary, Secondary };
 
   /**
@@ -412,6 +414,22 @@ public:
    * resolution is complete.
    */
   virtual void setInitializedCb(std::function<void()> callback) PURE;
+
+  /**
+   * @return the HostSet of the primary hosts.
+   *
+   * This is the set of the hosts which should receive all traffic for the
+   * cluster as long as the primary hosts remain healthy.
+   */
+  virtual HostSet& primaryHosts() PURE;
+
+  /**
+   * @return the const HostSet of the primary hosts.
+   *
+   * This is the set of the hosts which should receive all traffic for the
+   * cluster as long as the primary hosts remain healthy.
+   */
+  virtual const HostSet& primaryHosts() const PURE;
 };
 
 typedef std::shared_ptr<Cluster> ClusterSharedPtr;

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -61,10 +61,11 @@ HealthCheckerImplBase::HealthCheckerImplBase(const Cluster& cluster,
       stats_(generateStats(cluster.info()->statsScope())), runtime_(runtime), random_(random),
       interval_(PROTOBUF_GET_MS_REQUIRED(config, interval)),
       interval_jitter_(PROTOBUF_GET_MS_OR_DEFAULT(config, interval_jitter, 0)) {
-  cluster_.addMemberUpdateCb([this](const std::vector<HostSharedPtr>& hosts_added,
-                                    const std::vector<HostSharedPtr>& hosts_removed) -> void {
-    onClusterMemberUpdate(hosts_added, hosts_removed);
-  });
+  cluster_.primaryHosts().addMemberUpdateCb(
+      [this](const std::vector<HostSharedPtr>& hosts_added,
+             const std::vector<HostSharedPtr>& hosts_removed) -> void {
+        onClusterMemberUpdate(hosts_added, hosts_removed);
+      });
 }
 
 void HealthCheckerImplBase::decHealthy() {
@@ -178,7 +179,7 @@ void HealthCheckerImplBase::setUnhealthyCrossThread(const HostSharedPtr& host) {
   });
 }
 
-void HealthCheckerImplBase::start() { addHosts(cluster_.hosts()); }
+void HealthCheckerImplBase::start() { addHosts(cluster_.primaryHosts().hosts()); }
 
 HealthCheckerImplBase::ActiveHealthCheckSession::ActiveHealthCheckSession(
     HealthCheckerImplBase& parent, HostSharedPtr host)

--- a/source/common/upstream/load_stats_reporter.cc
+++ b/source/common/upstream/load_stats_reporter.cc
@@ -60,7 +60,7 @@ void LoadStatsReporter::sendLoadStatsRequest() {
     auto& cluster = it->second.get();
     auto* cluster_stats = request_.add_cluster_stats();
     cluster_stats->set_cluster_name(cluster_name);
-    for (auto& hosts : cluster.hostsPerLocality()) {
+    for (auto& hosts : cluster.primaryHosts().hostsPerLocality()) {
       auto* locality_stats = cluster_stats->add_upstream_locality_stats();
       ASSERT(hosts.size() > 0);
       locality_stats->mutable_locality()->MergeFrom(hosts[0]->locality());
@@ -113,7 +113,7 @@ void LoadStatsReporter::onReceiveMessage(
       continue;
     }
     auto& cluster = it->second.get();
-    for (auto host : cluster.hosts()) {
+    for (auto host : cluster.primaryHosts().hosts()) {
       host->stats().rq_success_.latch();
       host->stats().rq_error_.latch();
     }

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -112,8 +112,8 @@ void LogicalDnsCluster::startResolve() {
             }
             HostVectorSharedPtr new_hosts(new std::vector<HostSharedPtr>());
             new_hosts->emplace_back(logical_host_);
-            updateHosts(new_hosts, createHealthyHostList(*new_hosts), empty_host_lists_,
-                        empty_host_lists_, *new_hosts, {});
+            primaryHosts().updateHosts(new_hosts, createHealthyHostList(*new_hosts),
+                                       empty_host_lists_, empty_host_lists_, *new_hosts, {});
           }
         }
 

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -105,16 +105,16 @@ OriginalDstCluster::OriginalDstCluster(const envoy::api::v2::Cluster& config,
 }
 
 void OriginalDstCluster::addHost(HostSharedPtr& host) {
-  HostVectorSharedPtr new_hosts(new std::vector<HostSharedPtr>(hosts()));
+  HostVectorSharedPtr new_hosts(new std::vector<HostSharedPtr>(primaryHosts().hosts()));
   new_hosts->emplace_back(host);
-  updateHosts(new_hosts, createHealthyHostList(*new_hosts), empty_host_lists_, empty_host_lists_,
-              {std::move(host)}, {});
+  primaryHosts().updateHosts(new_hosts, createHealthyHostList(*new_hosts), empty_host_lists_,
+                             empty_host_lists_, {std::move(host)}, {});
 }
 
 void OriginalDstCluster::cleanup() {
   HostVectorSharedPtr new_hosts(new std::vector<HostSharedPtr>);
   std::vector<HostSharedPtr> to_be_removed;
-  const auto& host_set = hosts();
+  const auto& host_set = primaryHosts().hosts();
 
   ENVOY_LOG(debug, "Cleaning up stale original dst hosts.");
   for (const HostSharedPtr& host : host_set) {
@@ -129,8 +129,8 @@ void OriginalDstCluster::cleanup() {
   }
 
   if (to_be_removed.size() > 0) {
-    updateHosts(new_hosts, createHealthyHostList(*new_hosts), empty_host_lists_, empty_host_lists_,
-                {}, to_be_removed);
+    primaryHosts().updateHosts(new_hosts, createHealthyHostList(*new_hosts), empty_host_lists_,
+                               empty_host_lists_, {}, to_be_removed);
   }
 
   cleanup_timer_->enableTimer(cleanup_interval_ms_);

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -158,7 +158,7 @@ Http::Code AdminImpl::handlerClusters(const std::string&, Buffer::Instance& resp
     response.add(fmt::format("{}::added_via_api::{}\n", cluster.second.get().info()->name(),
                              cluster.second.get().info()->addedViaApi()));
 
-    for (auto& host : cluster.second.get().hosts()) {
+    for (auto& host : cluster.second.get().primaryHosts().hosts()) {
       std::map<std::string, uint64_t> all_stats;
       for (const Stats::CounterSharedPtr& counter : host->counters()) {
         all_stats[counter->name()] = counter->value();

--- a/test/common/redis/conn_pool_impl_test.cc
+++ b/test/common/redis/conn_pool_impl_test.cc
@@ -418,7 +418,7 @@ TEST_F(RedisConnPoolImplTest, HostRemove) {
   EXPECT_EQ(&active_request2, request2);
 
   EXPECT_CALL(*client2, close());
-  cm_.thread_local_cluster_.cluster_.runCallbacks({}, {host2});
+  cm_.thread_local_cluster_.cluster_.primary_hosts_.runCallbacks({}, {host2});
 
   EXPECT_CALL(*client1, close());
   tls_.shutdownThread();
@@ -428,7 +428,7 @@ TEST_F(RedisConnPoolImplTest, DeleteFollowedByClusterUpdateCallback) {
   conn_pool_.reset();
 
   std::shared_ptr<Upstream::Host> host(new Upstream::MockHost());
-  cm_.thread_local_cluster_.cluster_.runCallbacks({}, {host});
+  cm_.thread_local_cluster_.cluster_.primary_hosts_.runCallbacks({}, {host});
 }
 
 TEST_F(RedisConnPoolImplTest, NoHost) {

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -143,7 +143,7 @@ TEST_F(EdsTest, EndpointMetadata) {
   EXPECT_NO_THROW(cluster_->onConfigUpdate(resources));
   EXPECT_TRUE(initialized);
 
-  auto& hosts = cluster_->hosts();
+  auto& hosts = cluster_->primaryHosts().hosts();
   EXPECT_EQ(hosts.size(), 2);
   EXPECT_EQ(hosts[0]->metadata().filter_metadata_size(), 2);
   EXPECT_EQ(Config::Metadata::metadataValue(hosts[0]->metadata(),
@@ -194,7 +194,7 @@ TEST_F(EdsTest, EndpointLocality) {
   EXPECT_NO_THROW(cluster_->onConfigUpdate(resources));
   EXPECT_TRUE(initialized);
 
-  const auto& hosts = cluster_->hosts();
+  const auto& hosts = cluster_->primaryHosts().hosts();
   EXPECT_EQ(hosts.size(), 2);
   for (int i = 0; i < 2; ++i) {
     const auto& locality = hosts[i]->locality();
@@ -237,34 +237,34 @@ TEST_F(EdsTest, EndpointHostsPerLocality) {
   EXPECT_NO_THROW(cluster_->onConfigUpdate(resources));
   EXPECT_TRUE(initialized);
 
-  EXPECT_EQ(2, cluster_->hostsPerLocality().size());
-  EXPECT_EQ(1, cluster_->hostsPerLocality()[0].size());
+  EXPECT_EQ(2, cluster_->primaryHosts().hostsPerLocality().size());
+  EXPECT_EQ(1, cluster_->primaryHosts().hostsPerLocality()[0].size());
   EXPECT_EQ(Locality("", "us-east-1a", ""),
-            Locality(cluster_->hostsPerLocality()[0][0]->locality()));
-  EXPECT_EQ(2, cluster_->hostsPerLocality()[1].size());
+            Locality(cluster_->primaryHosts().hostsPerLocality()[0][0]->locality()));
+  EXPECT_EQ(2, cluster_->primaryHosts().hostsPerLocality()[1].size());
   EXPECT_EQ(Locality("oceania", "koala", "ingsoc"),
-            Locality(cluster_->hostsPerLocality()[1][0]->locality()));
+            Locality(cluster_->primaryHosts().hostsPerLocality()[1][0]->locality()));
   EXPECT_EQ(Locality("oceania", "koala", "ingsoc"),
-            Locality(cluster_->hostsPerLocality()[1][1]->locality()));
+            Locality(cluster_->primaryHosts().hostsPerLocality()[1][1]->locality()));
 
   add_hosts_to_locality("oceania", "koala", "eucalyptus", 3);
   add_hosts_to_locality("general", "koala", "ingsoc", 5);
 
   EXPECT_NO_THROW(cluster_->onConfigUpdate(resources));
 
-  EXPECT_EQ(4, cluster_->hostsPerLocality().size());
-  EXPECT_EQ(1, cluster_->hostsPerLocality()[0].size());
+  EXPECT_EQ(4, cluster_->primaryHosts().hostsPerLocality().size());
+  EXPECT_EQ(1, cluster_->primaryHosts().hostsPerLocality()[0].size());
   EXPECT_EQ(Locality("", "us-east-1a", ""),
-            Locality(cluster_->hostsPerLocality()[0][0]->locality()));
-  EXPECT_EQ(5, cluster_->hostsPerLocality()[1].size());
+            Locality(cluster_->primaryHosts().hostsPerLocality()[0][0]->locality()));
+  EXPECT_EQ(5, cluster_->primaryHosts().hostsPerLocality()[1].size());
   EXPECT_EQ(Locality("general", "koala", "ingsoc"),
-            Locality(cluster_->hostsPerLocality()[1][0]->locality()));
-  EXPECT_EQ(3, cluster_->hostsPerLocality()[2].size());
+            Locality(cluster_->primaryHosts().hostsPerLocality()[1][0]->locality()));
+  EXPECT_EQ(3, cluster_->primaryHosts().hostsPerLocality()[2].size());
   EXPECT_EQ(Locality("oceania", "koala", "eucalyptus"),
-            Locality(cluster_->hostsPerLocality()[2][0]->locality()));
-  EXPECT_EQ(2, cluster_->hostsPerLocality()[3].size());
+            Locality(cluster_->primaryHosts().hostsPerLocality()[2][0]->locality()));
+  EXPECT_EQ(2, cluster_->primaryHosts().hostsPerLocality()[3].size());
   EXPECT_EQ(Locality("oceania", "koala", "ingsoc"),
-            Locality(cluster_->hostsPerLocality()[3][0]->locality()));
+            Locality(cluster_->primaryHosts().hostsPerLocality()[3][0]->locality()));
 }
 
 } // namespace Upstream

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -56,16 +56,16 @@ public:
            std::vector<uint32_t> healthy_destination_cluster) {
     local_host_set_ = new HostSetImpl();
     // TODO(mattklein123): make load balancer per originating cluster host.
-    RandomLoadBalancer lb(cluster_, local_host_set_, stats_, runtime_, random_);
+    RandomLoadBalancer lb(cluster_.primary_hosts_, local_host_set_, stats_, runtime_, random_);
 
     HostListsSharedPtr upstream_per_zone_hosts = generateHostsPerZone(healthy_destination_cluster);
     HostListsSharedPtr local_per_zone_hosts = generateHostsPerZone(originating_cluster);
 
     HostVectorSharedPtr originating_hosts = generateHostList(originating_cluster);
     HostVectorSharedPtr healthy_destination = generateHostList(healthy_destination_cluster);
-    cluster_.healthy_hosts_ = *healthy_destination;
+    cluster_.primary_hosts_.healthy_hosts_ = *healthy_destination;
     HostVectorSharedPtr all_destination = generateHostList(all_destination_cluster);
-    cluster_.hosts_ = *all_destination;
+    cluster_.primary_hosts_.hosts_ = *all_destination;
 
     std::map<std::string, uint32_t> hits;
     for (uint32_t i = 0; i < total_number_of_requests; ++i) {
@@ -82,8 +82,8 @@ public:
 
         per_zone_upstream->push_back((*upstream_per_zone_hosts)[zone]);
       }
-      cluster_.hosts_per_locality_ = *per_zone_upstream;
-      cluster_.healthy_hosts_per_locality_ = *per_zone_upstream;
+      cluster_.primary_hosts_.hosts_per_locality_ = *per_zone_upstream;
+      cluster_.primary_hosts_.healthy_hosts_per_locality_ = *per_zone_upstream;
 
       // Populate host set for originating cluster.
       HostListsSharedPtr per_zone_local(new std::vector<std::vector<HostSharedPtr>>());

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -34,7 +34,7 @@ public:
     cluster_.reset(new LogicalDnsCluster(parseClusterFromJson(json), runtime_, stats_store_,
                                          ssl_context_manager_, dns_resolver_, tls_, cm, dispatcher_,
                                          false));
-    cluster_->addMemberUpdateCb(
+    cluster_->primaryHosts().addMemberUpdateCb(
         [&](const std::vector<HostSharedPtr>&, const std::vector<HostSharedPtr>&) -> void {
           membership_updated_.ready();
         });
@@ -127,10 +127,10 @@ TEST_P(LogicalDnsParamTest, ImmediateResolve) {
         return nullptr;
       }));
   setup(json);
-  EXPECT_EQ(1UL, cluster_->hosts().size());
-  EXPECT_EQ(1UL, cluster_->healthyHosts().size());
-  EXPECT_EQ("foo.bar.com", cluster_->hosts()[0]->hostname());
-  cluster_->hosts()[0]->healthChecker().setUnhealthy();
+  EXPECT_EQ(1UL, cluster_->primaryHosts().hosts().size());
+  EXPECT_EQ(1UL, cluster_->primaryHosts().healthyHosts().size());
+  EXPECT_EQ("foo.bar.com", cluster_->primaryHosts().hosts()[0]->hostname());
+  cluster_->primaryHosts().hosts()[0]->healthChecker().setUnhealthy();
   tls_.shutdownThread();
 }
 
@@ -168,12 +168,12 @@ TEST_F(LogicalDnsClusterTest, Basic) {
   EXPECT_CALL(*resolve_timer_, enableTimer(std::chrono::milliseconds(4000)));
   dns_callback_(TestUtility::makeDnsResponse({"127.0.0.1", "127.0.0.2"}));
 
-  EXPECT_EQ(1UL, cluster_->hosts().size());
-  EXPECT_EQ(1UL, cluster_->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster_->hostsPerLocality().size());
-  EXPECT_EQ(0UL, cluster_->healthyHostsPerLocality().size());
-  EXPECT_EQ(cluster_->hosts()[0], cluster_->healthyHosts()[0]);
-  HostSharedPtr logical_host = cluster_->hosts()[0];
+  EXPECT_EQ(1UL, cluster_->primaryHosts().hosts().size());
+  EXPECT_EQ(1UL, cluster_->primaryHosts().healthyHosts().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().hostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().healthyHostsPerLocality().size());
+  EXPECT_EQ(cluster_->primaryHosts().hosts()[0], cluster_->primaryHosts().healthyHosts()[0]);
+  HostSharedPtr logical_host = cluster_->primaryHosts().hosts()[0];
 
   EXPECT_CALL(dispatcher_, createClientConnection_(
                                PointeesEq(Network::Utility::resolveUrl("tcp://127.0.0.1:443")), _))
@@ -188,14 +188,14 @@ TEST_F(LogicalDnsClusterTest, Basic) {
   EXPECT_CALL(*resolve_timer_, enableTimer(_));
   dns_callback_(TestUtility::makeDnsResponse({"127.0.0.1", "127.0.0.2", "127.0.0.3"}));
 
-  EXPECT_EQ(logical_host, cluster_->hosts()[0]);
+  EXPECT_EQ(logical_host, cluster_->primaryHosts().hosts()[0]);
   EXPECT_CALL(dispatcher_, createClientConnection_(
                                PointeesEq(Network::Utility::resolveUrl("tcp://127.0.0.1:443")), _))
       .WillOnce(Return(new NiceMock<Network::MockClientConnection>()));
   Host::CreateConnectionData data = logical_host->createConnection(dispatcher_);
   EXPECT_FALSE(data.host_description_->canary());
-  EXPECT_EQ(&cluster_->hosts()[0]->cluster(), &data.host_description_->cluster());
-  EXPECT_EQ(&cluster_->hosts()[0]->stats(), &data.host_description_->stats());
+  EXPECT_EQ(&cluster_->primaryHosts().hosts()[0]->cluster(), &data.host_description_->cluster());
+  EXPECT_EQ(&cluster_->primaryHosts().hosts()[0]->stats(), &data.host_description_->stats());
   EXPECT_EQ("127.0.0.1:443", data.host_description_->address()->asString());
   EXPECT_EQ("", data.host_description_->locality().region());
   EXPECT_EQ("", data.host_description_->locality().zone());
@@ -211,7 +211,7 @@ TEST_F(LogicalDnsClusterTest, Basic) {
   EXPECT_CALL(*resolve_timer_, enableTimer(_));
   dns_callback_(TestUtility::makeDnsResponse({"127.0.0.3", "127.0.0.1", "127.0.0.2"}));
 
-  EXPECT_EQ(logical_host, cluster_->hosts()[0]);
+  EXPECT_EQ(logical_host, cluster_->primaryHosts().hosts()[0]);
   EXPECT_CALL(dispatcher_, createClientConnection_(
                                PointeesEq(Network::Utility::resolveUrl("tcp://127.0.0.3:443")), _))
       .WillOnce(Return(new NiceMock<Network::MockClientConnection>()));
@@ -224,7 +224,7 @@ TEST_F(LogicalDnsClusterTest, Basic) {
   EXPECT_CALL(*resolve_timer_, enableTimer(_));
   dns_callback_({});
 
-  EXPECT_EQ(logical_host, cluster_->hosts()[0]);
+  EXPECT_EQ(logical_host, cluster_->primaryHosts().hosts()[0]);
   EXPECT_CALL(dispatcher_, createClientConnection_(
                                PointeesEq(Network::Utility::resolveUrl("tcp://127.0.0.3:443")), _))
       .WillOnce(Return(new NiceMock<Network::MockClientConnection>()));

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -55,7 +55,7 @@ public:
     NiceMock<MockClusterManager> cm;
     cluster_.reset(new OriginalDstCluster(parseClusterFromJson(json), runtime_, stats_store_,
                                           ssl_context_manager_, cm, dispatcher_, false));
-    cluster_->addMemberUpdateCb(
+    cluster_->primaryHosts().addMemberUpdateCb(
         [&](const std::vector<HostSharedPtr>&, const std::vector<HostSharedPtr>&) -> void {
           membership_updated_.ready();
         });
@@ -116,8 +116,8 @@ TEST_F(OriginalDstClusterTest, CleanupInterval) {
   EXPECT_CALL(*cleanup_timer_, enableTimer(std::chrono::milliseconds(1000)));
   setup(json);
 
-  EXPECT_EQ(0UL, cluster_->hosts().size());
-  EXPECT_EQ(0UL, cluster_->healthyHosts().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().hosts().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().healthyHosts().size());
 }
 
 TEST_F(OriginalDstClusterTest, NoContext) {
@@ -135,15 +135,15 @@ TEST_F(OriginalDstClusterTest, NoContext) {
   EXPECT_CALL(*cleanup_timer_, enableTimer(_));
   setup(json);
 
-  EXPECT_EQ(0UL, cluster_->hosts().size());
-  EXPECT_EQ(0UL, cluster_->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster_->hostsPerLocality().size());
-  EXPECT_EQ(0UL, cluster_->healthyHostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().hosts().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().healthyHosts().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().hostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().healthyHostsPerLocality().size());
 
   // No downstream connection => no host.
   {
     TestLoadBalancerContext lb_context(nullptr);
-    OriginalDstCluster::LoadBalancer lb(*cluster_, cluster_);
+    OriginalDstCluster::LoadBalancer lb(cluster_->primaryHosts(), cluster_);
     EXPECT_CALL(dispatcher_, post(_)).Times(0);
     HostConstSharedPtr host = lb.chooseHost(&lb_context);
     EXPECT_EQ(host, nullptr);
@@ -158,7 +158,7 @@ TEST_F(OriginalDstClusterTest, NoContext) {
     // First argument is normally the reference to the ThreadLocalCluster's HostSet, but in these
     // tests we do not have the thread local clusters, so we pass a reference to the HostSet of the
     // primary cluster.  The implementation handles both cases the same.
-    OriginalDstCluster::LoadBalancer lb(*cluster_, cluster_);
+    OriginalDstCluster::LoadBalancer lb(cluster_->primaryHosts(), cluster_);
     EXPECT_CALL(dispatcher_, post(_)).Times(0);
     HostConstSharedPtr host = lb.chooseHost(&lb_context);
     EXPECT_EQ(host, nullptr);
@@ -172,7 +172,7 @@ TEST_F(OriginalDstClusterTest, NoContext) {
     EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
     EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
 
-    OriginalDstCluster::LoadBalancer lb(*cluster_, cluster_);
+    OriginalDstCluster::LoadBalancer lb(cluster_->primaryHosts(), cluster_);
     EXPECT_CALL(dispatcher_, post(_)).Times(0);
     HostConstSharedPtr host = lb.chooseHost(&lb_context);
     EXPECT_EQ(host, nullptr);
@@ -193,10 +193,10 @@ TEST_F(OriginalDstClusterTest, Membership) {
   EXPECT_CALL(*cleanup_timer_, enableTimer(_));
   setup(json);
 
-  EXPECT_EQ(0UL, cluster_->hosts().size());
-  EXPECT_EQ(0UL, cluster_->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster_->hostsPerLocality().size());
-  EXPECT_EQ(0UL, cluster_->healthyHostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().hosts().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().healthyHosts().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().hostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().healthyHostsPerLocality().size());
 
   EXPECT_CALL(membership_updated_, ready());
 
@@ -208,46 +208,46 @@ TEST_F(OriginalDstClusterTest, Membership) {
   EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
   EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
 
-  OriginalDstCluster::LoadBalancer lb(*cluster_, cluster_);
+  OriginalDstCluster::LoadBalancer lb(cluster_->primaryHosts(), cluster_);
   Event::PostCb post_cb;
   EXPECT_CALL(dispatcher_, post(_)).WillOnce(SaveArg<0>(&post_cb));
   HostConstSharedPtr host = lb.chooseHost(&lb_context);
   post_cb();
-  auto cluster_hosts = cluster_->hosts();
+  auto cluster_hosts = cluster_->primaryHosts().hosts();
 
   ASSERT_NE(host, nullptr);
   EXPECT_EQ(local_address, *host->address());
 
-  EXPECT_EQ(1UL, cluster_->hosts().size());
-  EXPECT_EQ(1UL, cluster_->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster_->hostsPerLocality().size());
-  EXPECT_EQ(0UL, cluster_->healthyHostsPerLocality().size());
+  EXPECT_EQ(1UL, cluster_->primaryHosts().hosts().size());
+  EXPECT_EQ(1UL, cluster_->primaryHosts().healthyHosts().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().hostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().healthyHostsPerLocality().size());
 
-  EXPECT_EQ(host, cluster_->hosts()[0]);
-  EXPECT_EQ(local_address, *cluster_->hosts()[0]->address());
+  EXPECT_EQ(host, cluster_->primaryHosts().hosts()[0]);
+  EXPECT_EQ(local_address, *cluster_->primaryHosts().hosts()[0]->address());
 
   // Same host is returned on the 2nd call
   HostConstSharedPtr host2 = lb.chooseHost(&lb_context);
   EXPECT_EQ(host2, host);
 
   // Make host time out, no membership changes happen on the first timeout.
-  ASSERT_EQ(1UL, cluster_->hosts().size());
-  EXPECT_EQ(true, cluster_->hosts()[0]->used());
+  ASSERT_EQ(1UL, cluster_->primaryHosts().hosts().size());
+  EXPECT_EQ(true, cluster_->primaryHosts().hosts()[0]->used());
   EXPECT_CALL(*cleanup_timer_, enableTimer(_));
   cleanup_timer_->callback_();
-  EXPECT_EQ(cluster_hosts, cluster_->hosts()); // hosts vector remains the same
+  EXPECT_EQ(cluster_hosts, cluster_->primaryHosts().hosts()); // hosts vector remains the same
 
   // host gets removed on the 2nd timeout.
-  ASSERT_EQ(1UL, cluster_->hosts().size());
-  EXPECT_EQ(false, cluster_->hosts()[0]->used());
+  ASSERT_EQ(1UL, cluster_->primaryHosts().hosts().size());
+  EXPECT_EQ(false, cluster_->primaryHosts().hosts()[0]->used());
 
   EXPECT_CALL(*cleanup_timer_, enableTimer(_));
   EXPECT_CALL(membership_updated_, ready());
   cleanup_timer_->callback_();
-  EXPECT_NE(cluster_hosts, cluster_->hosts()); // hosts vector changes
+  EXPECT_NE(cluster_hosts, cluster_->primaryHosts().hosts()); // hosts vector changes
 
-  EXPECT_EQ(0UL, cluster_->hosts().size());
-  cluster_hosts = cluster_->hosts();
+  EXPECT_EQ(0UL, cluster_->primaryHosts().hosts().size());
+  cluster_hosts = cluster_->primaryHosts().hosts();
 
   // New host gets created
   EXPECT_CALL(membership_updated_, ready());
@@ -256,10 +256,10 @@ TEST_F(OriginalDstClusterTest, Membership) {
   post_cb();
   EXPECT_NE(host3, nullptr);
   EXPECT_NE(host3, host);
-  EXPECT_NE(cluster_hosts, cluster_->hosts()); // hosts vector changes
+  EXPECT_NE(cluster_hosts, cluster_->primaryHosts().hosts()); // hosts vector changes
 
-  EXPECT_EQ(1UL, cluster_->hosts().size());
-  EXPECT_EQ(host3, cluster_->hosts()[0]);
+  EXPECT_EQ(1UL, cluster_->primaryHosts().hosts().size());
+  EXPECT_EQ(host3, cluster_->primaryHosts().hosts()[0]);
 }
 
 TEST_F(OriginalDstClusterTest, Membership2) {
@@ -276,10 +276,10 @@ TEST_F(OriginalDstClusterTest, Membership2) {
   EXPECT_CALL(*cleanup_timer_, enableTimer(_));
   setup(json);
 
-  EXPECT_EQ(0UL, cluster_->hosts().size());
-  EXPECT_EQ(0UL, cluster_->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster_->hostsPerLocality().size());
-  EXPECT_EQ(0UL, cluster_->healthyHostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().hosts().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().healthyHosts().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().hostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().healthyHostsPerLocality().size());
 
   // Host gets the local address of the downstream connection.
 
@@ -295,7 +295,7 @@ TEST_F(OriginalDstClusterTest, Membership2) {
   EXPECT_CALL(connection2, localAddress()).WillRepeatedly(ReturnRef(local_address2));
   EXPECT_CALL(connection2, usingOriginalDst()).WillRepeatedly(Return(true));
 
-  OriginalDstCluster::LoadBalancer lb(*cluster_, cluster_);
+  OriginalDstCluster::LoadBalancer lb(cluster_->primaryHosts(), cluster_);
 
   EXPECT_CALL(membership_updated_, ready());
   Event::PostCb post_cb;
@@ -312,38 +312,38 @@ TEST_F(OriginalDstClusterTest, Membership2) {
   ASSERT_NE(host2, nullptr);
   EXPECT_EQ(local_address2, *host2->address());
 
-  EXPECT_EQ(2UL, cluster_->hosts().size());
-  EXPECT_EQ(2UL, cluster_->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster_->hostsPerLocality().size());
-  EXPECT_EQ(0UL, cluster_->healthyHostsPerLocality().size());
+  EXPECT_EQ(2UL, cluster_->primaryHosts().hosts().size());
+  EXPECT_EQ(2UL, cluster_->primaryHosts().healthyHosts().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().hostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().healthyHostsPerLocality().size());
 
-  EXPECT_EQ(host1, cluster_->hosts()[0]);
-  EXPECT_EQ(local_address1, *cluster_->hosts()[0]->address());
+  EXPECT_EQ(host1, cluster_->primaryHosts().hosts()[0]);
+  EXPECT_EQ(local_address1, *cluster_->primaryHosts().hosts()[0]->address());
 
-  EXPECT_EQ(host2, cluster_->hosts()[1]);
-  EXPECT_EQ(local_address2, *cluster_->hosts()[1]->address());
+  EXPECT_EQ(host2, cluster_->primaryHosts().hosts()[1]);
+  EXPECT_EQ(local_address2, *cluster_->primaryHosts().hosts()[1]->address());
 
-  auto cluster_hosts = cluster_->hosts();
+  auto cluster_hosts = cluster_->primaryHosts().hosts();
 
   // Make hosts time out, no membership changes happen on the first timeout.
-  ASSERT_EQ(2UL, cluster_->hosts().size());
-  EXPECT_EQ(true, cluster_->hosts()[0]->used());
-  EXPECT_EQ(true, cluster_->hosts()[1]->used());
+  ASSERT_EQ(2UL, cluster_->primaryHosts().hosts().size());
+  EXPECT_EQ(true, cluster_->primaryHosts().hosts()[0]->used());
+  EXPECT_EQ(true, cluster_->primaryHosts().hosts()[1]->used());
   EXPECT_CALL(*cleanup_timer_, enableTimer(_));
   cleanup_timer_->callback_();
-  EXPECT_EQ(cluster_hosts, cluster_->hosts()); // hosts vector remains the same
+  EXPECT_EQ(cluster_hosts, cluster_->primaryHosts().hosts()); // hosts vector remains the same
 
   // both hosts get removed on the 2nd timeout.
-  ASSERT_EQ(2UL, cluster_->hosts().size());
-  EXPECT_EQ(false, cluster_->hosts()[0]->used());
-  EXPECT_EQ(false, cluster_->hosts()[1]->used());
+  ASSERT_EQ(2UL, cluster_->primaryHosts().hosts().size());
+  EXPECT_EQ(false, cluster_->primaryHosts().hosts()[0]->used());
+  EXPECT_EQ(false, cluster_->primaryHosts().hosts()[1]->used());
 
   EXPECT_CALL(*cleanup_timer_, enableTimer(_));
   EXPECT_CALL(membership_updated_, ready());
   cleanup_timer_->callback_();
-  EXPECT_NE(cluster_hosts, cluster_->hosts()); // hosts vector changes
+  EXPECT_NE(cluster_hosts, cluster_->primaryHosts().hosts()); // hosts vector changes
 
-  EXPECT_EQ(0UL, cluster_->hosts().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().hosts().size());
 }
 
 TEST_F(OriginalDstClusterTest, Connection) {
@@ -360,10 +360,10 @@ TEST_F(OriginalDstClusterTest, Connection) {
   EXPECT_CALL(*cleanup_timer_, enableTimer(_));
   setup(json);
 
-  EXPECT_EQ(0UL, cluster_->hosts().size());
-  EXPECT_EQ(0UL, cluster_->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster_->hostsPerLocality().size());
-  EXPECT_EQ(0UL, cluster_->healthyHostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().hosts().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().healthyHosts().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().hostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->primaryHosts().healthyHostsPerLocality().size());
 
   EXPECT_CALL(membership_updated_, ready());
 
@@ -374,7 +374,7 @@ TEST_F(OriginalDstClusterTest, Connection) {
   EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
   EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
 
-  OriginalDstCluster::LoadBalancer lb(*cluster_, cluster_);
+  OriginalDstCluster::LoadBalancer lb(cluster_->primaryHosts(), cluster_);
   Event::PostCb post_cb;
   EXPECT_CALL(dispatcher_, post(_)).WillOnce(SaveArg<0>(&post_cb));
   HostConstSharedPtr host = lb.chooseHost(&lb_context);
@@ -402,11 +402,13 @@ TEST_F(OriginalDstClusterTest, MultipleClusters) {
   setup(json);
 
   HostSetImpl second;
-  cluster_->addMemberUpdateCb([&](const std::vector<HostSharedPtr>& added,
-                                  const std::vector<HostSharedPtr>& removed) -> void {
+  cluster_->primaryHosts().addMemberUpdateCb([&](const std::vector<HostSharedPtr>& added,
+                                                 const std::vector<HostSharedPtr>& removed)
+                                                 -> void {
     // Update second hostset accordingly;
-    HostVectorSharedPtr new_hosts(new std::vector<HostSharedPtr>(cluster_->hosts()));
-    HostVectorSharedPtr healthy_hosts(new std::vector<HostSharedPtr>(cluster_->hosts()));
+    HostVectorSharedPtr new_hosts(new std::vector<HostSharedPtr>(cluster_->primaryHosts().hosts()));
+    HostVectorSharedPtr healthy_hosts(
+        new std::vector<HostSharedPtr>(cluster_->primaryHosts().hosts()));
     const HostListsConstSharedPtr empty_host_lists{new std::vector<std::vector<HostSharedPtr>>()};
 
     second.updateHosts(new_hosts, healthy_hosts, empty_host_lists, empty_host_lists, added,
@@ -422,7 +424,7 @@ TEST_F(OriginalDstClusterTest, MultipleClusters) {
   EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
   EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
 
-  OriginalDstCluster::LoadBalancer lb1(*cluster_, cluster_);
+  OriginalDstCluster::LoadBalancer lb1(cluster_->primaryHosts(), cluster_);
   OriginalDstCluster::LoadBalancer lb2(second, cluster_);
   Event::PostCb post_cb;
   EXPECT_CALL(dispatcher_, post(_)).WillOnce(SaveArg<0>(&post_cb));
@@ -431,11 +433,11 @@ TEST_F(OriginalDstClusterTest, MultipleClusters) {
   ASSERT_NE(host, nullptr);
   EXPECT_EQ(local_address, *host->address());
 
-  EXPECT_EQ(1UL, cluster_->hosts().size());
+  EXPECT_EQ(1UL, cluster_->primaryHosts().hosts().size());
   // Check that lb2 also gets updated
   EXPECT_EQ(1UL, second.hosts().size());
 
-  EXPECT_EQ(host, cluster_->hosts()[0]);
+  EXPECT_EQ(host, cluster_->primaryHosts().hosts()[0]);
   EXPECT_EQ(host, second.hosts()[0]);
 }
 

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -38,27 +38,28 @@ public:
   RingHashLoadBalancerTest() : stats_(ClusterInfoImpl::generateStats(stats_store_)) {}
 
   NiceMock<MockCluster> cluster_;
+  NiceMock<MockHostSet>& primary_hosts_ = cluster_.primary_hosts_;
   Stats::IsolatedStoreImpl stats_store_;
   ClusterStats stats_;
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Runtime::MockRandomGenerator> random_;
-  RingHashLoadBalancer lb_{cluster_, stats_, runtime_, random_};
+  RingHashLoadBalancer lb_{primary_hosts_, stats_, runtime_, random_};
 };
 
 TEST_F(RingHashLoadBalancerTest, NoHost) { EXPECT_EQ(nullptr, lb_.chooseHost(nullptr)); };
 
 TEST_F(RingHashLoadBalancerTest, Basic) {
-  cluster_.hosts_ = {makeTestHost(cluster_.info_, "tcp://127.0.0.1:80"),
-                     makeTestHost(cluster_.info_, "tcp://127.0.0.1:81"),
-                     makeTestHost(cluster_.info_, "tcp://127.0.0.1:82"),
-                     makeTestHost(cluster_.info_, "tcp://127.0.0.1:83"),
-                     makeTestHost(cluster_.info_, "tcp://127.0.0.1:84"),
-                     makeTestHost(cluster_.info_, "tcp://127.0.0.1:85")};
-  cluster_.healthy_hosts_ = cluster_.hosts_;
+  primary_hosts_.hosts_ = {makeTestHost(cluster_.info_, "tcp://127.0.0.1:80"),
+                           makeTestHost(cluster_.info_, "tcp://127.0.0.1:81"),
+                           makeTestHost(cluster_.info_, "tcp://127.0.0.1:82"),
+                           makeTestHost(cluster_.info_, "tcp://127.0.0.1:83"),
+                           makeTestHost(cluster_.info_, "tcp://127.0.0.1:84"),
+                           makeTestHost(cluster_.info_, "tcp://127.0.0.1:85")};
+  primary_hosts_.healthy_hosts_ = primary_hosts_.hosts_;
 
   ON_CALL(runtime_.snapshot_, getInteger("upstream.ring_hash.min_ring_size", _))
       .WillByDefault(Return(12));
-  cluster_.runCallbacks({}, {});
+  primary_hosts_.runCallbacks({}, {});
 
   // This is the hash ring built using the default hash (probably murmur2) on GCC 5.4.
   // TODO(mattklein123): Compile in and use murmur3 or city so we know exactly
@@ -77,41 +78,41 @@ TEST_F(RingHashLoadBalancerTest, Basic) {
   // ring hash: host=127.0.0.1:80 hash=17613279263364193813
   {
     TestLoadBalancerContext context(0);
-    EXPECT_EQ(cluster_.hosts_[5], lb_.chooseHost(&context));
+    EXPECT_EQ(primary_hosts_.hosts_[5], lb_.chooseHost(&context));
   }
   {
     TestLoadBalancerContext context(std::numeric_limits<uint64_t>::max());
-    EXPECT_EQ(cluster_.hosts_[5], lb_.chooseHost(&context));
+    EXPECT_EQ(primary_hosts_.hosts_[5], lb_.chooseHost(&context));
   }
   {
     TestLoadBalancerContext context(1358027074129602068);
-    EXPECT_EQ(cluster_.hosts_[5], lb_.chooseHost(&context));
+    EXPECT_EQ(primary_hosts_.hosts_[5], lb_.chooseHost(&context));
   }
   {
     TestLoadBalancerContext context(1358027074129602069);
-    EXPECT_EQ(cluster_.hosts_[3], lb_.chooseHost(&context));
+    EXPECT_EQ(primary_hosts_.hosts_[3], lb_.chooseHost(&context));
   }
   {
     EXPECT_CALL(random_, random()).WillOnce(Return(10150910876324007730UL));
-    EXPECT_EQ(cluster_.hosts_[2], lb_.chooseHost(nullptr));
+    EXPECT_EQ(primary_hosts_.hosts_[2], lb_.chooseHost(nullptr));
   }
   EXPECT_EQ(0UL, stats_.lb_healthy_panic_.value());
 
-  cluster_.healthy_hosts_.clear();
-  cluster_.runCallbacks({}, {});
+  primary_hosts_.healthy_hosts_.clear();
+  primary_hosts_.runCallbacks({}, {});
   {
     TestLoadBalancerContext context(0);
-    EXPECT_EQ(cluster_.hosts_[5], lb_.chooseHost(&context));
+    EXPECT_EQ(primary_hosts_.hosts_[5], lb_.chooseHost(&context));
   }
   EXPECT_EQ(1UL, stats_.lb_healthy_panic_.value());
 }
 
 TEST_F(RingHashLoadBalancerTest, UnevenHosts) {
-  cluster_.hosts_ = {makeTestHost(cluster_.info_, "tcp://127.0.0.1:80"),
-                     makeTestHost(cluster_.info_, "tcp://127.0.0.1:81")};
+  primary_hosts_.hosts_ = {makeTestHost(cluster_.info_, "tcp://127.0.0.1:80"),
+                           makeTestHost(cluster_.info_, "tcp://127.0.0.1:81")};
   ON_CALL(runtime_.snapshot_, getInteger("upstream.ring_hash.min_ring_size", _))
       .WillByDefault(Return(3));
-  cluster_.runCallbacks({}, {});
+  primary_hosts_.runCallbacks({}, {});
 
   // This is the hash ring built using the default hash (probably murmur2) on GCC 5.4.
   // TODO(mattklein123): Compile in and use murmur3 or city so we know exactly
@@ -122,12 +123,12 @@ TEST_F(RingHashLoadBalancerTest, UnevenHosts) {
   // ring hash: host=127.0.0.1:80 hash=17613279263364193813
   {
     TestLoadBalancerContext context(0);
-    EXPECT_EQ(cluster_.hosts_[1], lb_.chooseHost(&context));
+    EXPECT_EQ(primary_hosts_.hosts_[1], lb_.chooseHost(&context));
   }
 
-  cluster_.hosts_ = {makeTestHost(cluster_.info_, "tcp://127.0.0.1:81"),
-                     makeTestHost(cluster_.info_, "tcp://127.0.0.1:82")};
-  cluster_.runCallbacks({}, {});
+  primary_hosts_.hosts_ = {makeTestHost(cluster_.info_, "tcp://127.0.0.1:81"),
+                           makeTestHost(cluster_.info_, "tcp://127.0.0.1:82")};
+  primary_hosts_.runCallbacks({}, {});
 
   // This is the hash ring built using the default hash (probably murmur2) on GCC 5.4.
   // TODO(mattklein123): Compile in and use murmur3 or city so we know exactly
@@ -138,7 +139,7 @@ TEST_F(RingHashLoadBalancerTest, UnevenHosts) {
   // ring hash: host=127.0.0.1:82 hash=10150910876324007731
   {
     TestLoadBalancerContext context(0);
-    EXPECT_EQ(cluster_.hosts_[0], lb_.chooseHost(&context));
+    EXPECT_EQ(primary_hosts_.hosts_[0], lb_.chooseHost(&context));
   }
 }
 
@@ -176,13 +177,14 @@ TEST_F(DISABLED_RingHashLoadBalancerTest, DetermineSpread) {
   // TODO(danielhochman): add support for more hosts if necessary with another loop for subnet
   ASSERT_LT(num_hosts, 256);
   for (uint64_t i = 0; i < num_hosts; i++) {
-    cluster_.hosts_.push_back(makeTestHost(cluster_.info_, fmt::format("tcp://10.0.0.{}:6379", i)));
+    primary_hosts_.hosts_.push_back(
+        makeTestHost(cluster_.info_, fmt::format("tcp://10.0.0.{}:6379", i)));
   }
-  cluster_.healthy_hosts_ = cluster_.hosts_;
+  primary_hosts_.healthy_hosts_ = primary_hosts_.hosts_;
 
   ON_CALL(runtime_.snapshot_, getInteger("upstream.ring_hash.min_ring_size", _))
       .WillByDefault(Return(min_ring_size));
-  cluster_.runCallbacks({}, {});
+  primary_hosts_.runCallbacks({}, {});
 
   for (uint64_t i = 0; i < keys_to_simulate; i++) {
     TestLoadBalancerContext context(std::hash<std::string>()(fmt::format("{}", i)));

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -95,15 +95,20 @@ MockClusterInfo::MockClusterInfo()
 
 MockClusterInfo::~MockClusterInfo() {}
 
-MockCluster::MockCluster() {
+MockHostSet::MockHostSet() {
   ON_CALL(*this, addMemberUpdateCb(_))
-      .WillByDefault(Invoke([this](MemberUpdateCb cb) -> Common::CallbackHandle* {
+      .WillByDefault(Invoke([this](HostSet::MemberUpdateCb cb) -> Common::CallbackHandle* {
         return member_update_cb_helper_.add(cb);
       }));
   ON_CALL(*this, hosts()).WillByDefault(ReturnRef(hosts_));
   ON_CALL(*this, healthyHosts()).WillByDefault(ReturnRef(healthy_hosts_));
   ON_CALL(*this, hostsPerLocality()).WillByDefault(ReturnRef(hosts_per_locality_));
   ON_CALL(*this, healthyHostsPerLocality()).WillByDefault(ReturnRef(healthy_hosts_per_locality_));
+}
+
+MockCluster::MockCluster() {
+  ON_CALL(*this, primaryHosts()).WillByDefault(ReturnRef(primary_hosts_));
+  ON_CALL(testing::Const(*this), primaryHosts()).WillByDefault(ReturnRef(primary_hosts_));
   ON_CALL(*this, info()).WillByDefault(Return(info_));
   ON_CALL(*this, setInitializedCb(_))
       .WillByDefault(Invoke([this](std::function<void()> callback) -> void {
@@ -119,7 +124,7 @@ MockLoadBalancer::MockLoadBalancer() { ON_CALL(*this, chooseHost(_)).WillByDefau
 MockLoadBalancer::~MockLoadBalancer() {}
 
 MockThreadLocalCluster::MockThreadLocalCluster() {
-  ON_CALL(*this, hostSet()).WillByDefault(ReturnRef(cluster_));
+  ON_CALL(*this, hostSet()).WillByDefault(ReturnRef(cluster_.primary_hosts_));
   ON_CALL(*this, info()).WillByDefault(Return(cluster_.info_));
   ON_CALL(*this, loadBalancer()).WillByDefault(ReturnRef(lb_));
 }

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -26,10 +26,9 @@ using testing::NiceMock;
 namespace Envoy {
 namespace Upstream {
 
-class MockCluster : public Cluster {
+class MockHostSet : public HostSet {
 public:
-  MockCluster();
-  ~MockCluster();
+  MockHostSet();
 
   void runCallbacks(const std::vector<HostSharedPtr> added,
                     const std::vector<HostSharedPtr> removed) {
@@ -43,6 +42,19 @@ public:
   MOCK_CONST_METHOD0(hostsPerLocality, const std::vector<std::vector<HostSharedPtr>>&());
   MOCK_CONST_METHOD0(healthyHostsPerLocality, const std::vector<std::vector<HostSharedPtr>>&());
 
+  std::vector<HostSharedPtr> hosts_;
+  std::vector<HostSharedPtr> healthy_hosts_;
+  std::vector<std::vector<HostSharedPtr>> hosts_per_locality_;
+  std::vector<std::vector<HostSharedPtr>> healthy_hosts_per_locality_;
+  Common::CallbackManager<const std::vector<HostSharedPtr>&, const std::vector<HostSharedPtr>&>
+      member_update_cb_helper_;
+};
+
+class MockCluster : public Cluster {
+public:
+  MockCluster();
+  ~MockCluster();
+
   // Upstream::Cluster
   MOCK_CONST_METHOD0(info, ClusterInfoConstSharedPtr());
   MOCK_CONST_METHOD0(outlierDetector, const Outlier::Detector*());
@@ -50,16 +62,13 @@ public:
   MOCK_CONST_METHOD0(initializePhase, InitializePhase());
   MOCK_METHOD1(setInitializedCb, void(std::function<void()>));
   MOCK_CONST_METHOD0(sourceAddress, const Network::Address::InstanceConstSharedPtr&());
+  MOCK_METHOD0(primaryHosts, HostSet&());
+  MOCK_CONST_METHOD0(primaryHosts, const HostSet&());
 
-  std::vector<HostSharedPtr> hosts_;
-  std::vector<HostSharedPtr> healthy_hosts_;
-  std::vector<std::vector<HostSharedPtr>> hosts_per_locality_;
-  std::vector<std::vector<HostSharedPtr>> healthy_hosts_per_locality_;
-  Common::CallbackManager<const std::vector<HostSharedPtr>&, const std::vector<HostSharedPtr>&>
-      member_update_cb_helper_;
   std::shared_ptr<MockClusterInfo> info_{new NiceMock<MockClusterInfo>()};
   std::function<void()> initialize_callback_;
   Network::Address::InstanceConstSharedPtr source_address_;
+  NiceMock<MockHostSet> primary_hosts_;
 };
 
 class MockLoadBalancer : public LoadBalancer {


### PR DESCRIPTION
*Description*:
Refactoring Cluster to own a HostSet rather than implementing HostSet
This is prep-work for #1354 - logically a cluster will have a primary HostSet and a failover HostSet and it can't very well do that with an inheritance relationship.

*Alternatives considered*
Having HostSetImpl have a failover_ set.  and a healthy_failover set.  And then failover_by_locality_ and healthy_failover_by_locality_ and updater functions for both and no, really, we should probably have two host sets.

*Risk Level*: Low to Medium 
Fairly large refactor but there's no functional change expected, and the main code change is to how ClusterImplBase gets its stats updated.

*Testing*:
Refactor: simply ran existing tests.
Verified that without the changes to the ClusterImplBase constructor that tests failed (stats are checked in at least load_stats_integration_test)