### PR TITLE
router: implement upstream log

### DIFF
--- a/include/envoy/http/conn_pool.h
+++ b/include/envoy/http/conn_pool.h
@@ -70,6 +70,11 @@ public:
   virtual ~Instance() {}
 
   /**
+   * @return Http::Protocol Reports the protocol in use by this connection pool.
+   */
+  virtual Http::Protocol protocol() const PURE;
+
+  /**
    * Called when a connection pool has been drained of pending requests, busy connections, and
    * ready connections.
    */

--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -90,6 +90,7 @@ envoy_cc_library(
     external_deps = [
         "envoy_filter_http_http_connection_manager",
         "envoy_filter_http_fault",
+        "envoy_filter_http_router",
         "envoy_filter_network_mongo_proxy",
     ],
     deps = [

--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -264,5 +264,13 @@ void FilterJson::translateFaultFilter(const Json::Object& config,
   }
 }
 
+void FilterJson::translateRouter(const Json::Object& json_router,
+                                 envoy::api::v2::filter::http::Router& router) {
+  json_router.validateSchema(Json::Schema::ROUTER_HTTP_FILTER_SCHEMA);
+
+  router.mutable_dynamic_stats()->set_value(json_router.getBoolean("dynamic_stats", true));
+  router.set_start_child_span(json_router.getBoolean("start_child_span", false));
+}
+
 } // namespace Config
 } // namespace Envoy

--- a/source/common/config/filter_json.h
+++ b/source/common/config/filter_json.h
@@ -4,6 +4,7 @@
 
 #include "api/filter/http/fault.pb.h"
 #include "api/filter/http/http_connection_manager.pb.h"
+#include "api/filter/http/router.pb.h"
 #include "api/filter/network/mongo_proxy.pb.h"
 
 namespace Envoy {
@@ -56,6 +57,14 @@ public:
    */
   static void translateFaultFilter(const Json::Object& config,
                                    envoy::api::v2::filter::http::HTTPFault& fault);
+
+  /*
+   * Translate a v1 JSON Router object to v2 envoy::api::v2::filter::http::Router.
+   * @param json_router source v1 JSON HTTP router object.
+   * @param router destination v2 envoy::api::v2::filter::http::Router.
+   */
+  static void translateRouter(const Json::Object& json_router,
+                              envoy::api::v2::filter::http::Router& router);
 };
 
 } // namespace Config

--- a/source/common/http/access_log/access_log_impl.h
+++ b/source/common/http/access_log/access_log_impl.h
@@ -136,10 +136,6 @@ private:
   const std::string runtime_key_;
 };
 
-InstanceSharedPtr instanceFromProto(const envoy::api::v2::filter::AccessLog& config,
-                                    Runtime::Loader& runtime,
-                                    Envoy::AccessLog::AccessLogManager& log_manager);
-
 /**
  * Access log factory that reads the configuration from proto.
  */

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -35,6 +35,7 @@ public:
   ~ConnPoolImpl();
 
   // ConnectionPool::Instance
+  Http::Protocol protocol() const override { return Http::Protocol::Http11; }
   void addDrainedCallback(DrainedCb cb) override;
   ConnectionPool::Cancellable* newStream(StreamDecoder& response_decoder,
                                          ConnectionPool::Callbacks& callbacks) override;

--- a/source/common/http/http2/conn_pool.h
+++ b/source/common/http/http2/conn_pool.h
@@ -28,6 +28,7 @@ public:
   ~ConnPoolImpl();
 
   // Http::ConnectionPool::Instance
+  Http::Protocol protocol() const override { return Http::Protocol::Http2; }
   void addDrainedCallback(DrainedCb cb) override;
   ConnectionPool::Cancellable* newStream(Http::StreamDecoder& response_decoder,
                                          ConnectionPool::Callbacks& callbacks) override;

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -123,6 +123,7 @@ envoy_cc_library(
     name = "router_lib",
     srcs = ["router.cc"],
     hdrs = ["router.h"],
+    external_deps = ["envoy_filter_http_router"],
     deps = [
         ":config_lib",
         ":retry_state_lib",
@@ -136,6 +137,7 @@ envoy_cc_library(
         "//include/envoy/local_info:local_info_interface",
         "//include/envoy/router:shadow_writer_interface",
         "//include/envoy/runtime:runtime_interface",
+        "//include/envoy/server:filter_config_interface",
         "//include/envoy/stats:stats_interface",
         "//include/envoy/stats:stats_macros",
         "//include/envoy/upstream:cluster_manager_interface",
@@ -154,6 +156,8 @@ envoy_cc_library(
         "//source/common/http:headers_lib",
         "//source/common/http:message_lib",
         "//source/common/http:utility_lib",
+        "//source/common/http/access_log:access_log_lib",
+        "//source/common/http/access_log:request_info_lib",
         "//source/common/tracing:http_tracer_lib",
     ],
 )

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -398,6 +398,9 @@ void Filter::onRequestComplete() {
 
   // Possible that we got an immediate reset.
   if (upstream_request_) {
+    // Nominally how long it took to send the request.
+    upstream_request_->request_info_.requestReceivedDuration(downstream_request_complete_time_);
+
     // Even if we got an immediate reset, we could still shadow, but that is a riskier change and
     // seems unnecessary right now.
     maybeDoShadowing();
@@ -548,12 +551,12 @@ void Filter::handleNon5xxResponseHeaders(const Http::HeaderMap& headers, bool en
   }
 }
 
-void Filter::onUpstreamHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
+void Filter::onUpstreamHeaders(const uint64_t response_code, Http::HeaderMapPtr&& headers,
+                               bool end_stream) {
   ENVOY_STREAM_LOG(debug, "upstream headers complete: end_stream={}", *callbacks_, end_stream);
   ASSERT(!downstream_response_started_);
 
-  upstream_request_->upstream_host_->outlierDetector().putHttpResponseCode(
-      Http::Utility::getResponseStatus(*headers));
+  upstream_request_->upstream_host_->outlierDetector().putHttpResponseCode(response_code);
 
   if (headers->EnvoyImmediateHealthCheckFail() != nullptr) {
     upstream_request_->upstream_host_->healthChecker().setUnhealthy();
@@ -566,9 +569,8 @@ void Filter::onUpstreamHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
     // upstream_request_.
     const auto upstream_host = upstream_request_->upstream_host_;
     if (retry_status == RetryStatus::Yes && setupRetry(end_stream)) {
-      Http::CodeUtility::chargeBasicResponseStat(
-          cluster_->statsScope(), "retry.",
-          static_cast<Http::Code>(Http::Utility::getResponseStatus(*headers)));
+      Http::CodeUtility::chargeBasicResponseStat(cluster_->statsScope(), "retry.",
+                                                 static_cast<Http::Code>(response_code));
       upstream_host->stats().rq_error_.inc();
       return;
     } else if (retry_status == RetryStatus::NoOverflow) {
@@ -588,12 +590,12 @@ void Filter::onUpstreamHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
         response_received_time - downstream_request_complete_time_);
     headers->insertEnvoyUpstreamServiceTime().value(ms.count());
     callbacks_->requestInfo().responseReceivedDuration(response_received_time);
+    upstream_request_->request_info_.responseReceivedDuration(response_received_time);
   }
 
   upstream_request_->upstream_canary_ =
       (headers->EnvoyUpstreamCanary() && headers->EnvoyUpstreamCanary()->value() == "true") ||
       upstream_request_->upstream_host_->canary();
-  const uint64_t response_code = Http::Utility::getResponseStatus(*headers);
   chargeUpstreamCode(response_code, *headers, upstream_request_->upstream_host_, false);
   if (!Http::CodeUtility::is5xx(response_code)) {
     handleNon5xxResponseHeaders(*headers, end_stream);
@@ -739,14 +741,16 @@ void Filter::doRetry() {
 
 Filter::UpstreamRequest::UpstreamRequest(Filter& parent, Http::ConnectionPool::Instance& pool)
     : parent_(parent), conn_pool_(pool), grpc_rq_success_deferred_(false),
-      calling_encode_headers_(false), upstream_canary_(false), encode_complete_(false),
-      encode_trailers_(false) {
+      request_info_(pool.protocol()), calling_encode_headers_(false), upstream_canary_(false),
+      encode_complete_(false), encode_trailers_(false) {
 
   if (parent_.config_.start_child_span_) {
     span_ = parent_.callbacks_->activeSpan().spawnChild(
         Tracing::EgressConfig::get(), "router " + parent.cluster_->name() + " egress",
         ProdSystemTimeSource::instance_.currentTime());
   }
+
+  request_info_.healthCheck(parent_.callbacks_->requestInfo().healthCheck());
 }
 
 Filter::UpstreamRequest::~UpstreamRequest() {
@@ -759,13 +763,21 @@ Filter::UpstreamRequest::~UpstreamRequest() {
     per_try_timeout_->disableTimer();
   }
   clearRequestEncoder();
+
+  for (const auto& upstream_log : parent_.config_.upstream_logs_) {
+    upstream_log->log(parent_.downstream_headers_, upstream_headers_, request_info_);
+  }
 }
 
 void Filter::UpstreamRequest::decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
-  parent_.onUpstreamHeaders(std::move(headers), end_stream);
+  upstream_headers_ = headers.get();
+  const uint64_t response_code = Http::Utility::getResponseStatus(*headers);
+  request_info_.response_code_.value(static_cast<uint32_t>(response_code));
+  parent_.onUpstreamHeaders(response_code, std::move(headers), end_stream);
 }
 
 void Filter::UpstreamRequest::decodeData(Buffer::Instance& data, bool end_stream) {
+  request_info_.bytes_received_ += data.length();
   parent_.onUpstreamData(data, end_stream);
 }
 
@@ -802,6 +814,7 @@ void Filter::UpstreamRequest::encodeData(Buffer::Instance& data, bool end_stream
     buffered_request_body_->move(data);
   } else {
     ENVOY_STREAM_LOG(trace, "proxying {} bytes", *parent_.callbacks_, data.length());
+    request_info_.bytes_sent_ += data.length();
     request_encoder_->encodeData(data, end_stream);
   }
 }
@@ -822,6 +835,7 @@ void Filter::UpstreamRequest::encodeTrailers(const Http::HeaderMap& trailers) {
 void Filter::UpstreamRequest::onResetStream(Http::StreamResetReason reason) {
   clearRequestEncoder();
   if (!calling_encode_headers_) {
+    request_info_.setResponseFlag(parent_.streamResetReasonToResponseFlag(reason));
     parent_.onUpstreamReset(UpstreamResetType::Reset, Optional<Http::StreamResetReason>(reason));
   } else {
     deferred_reset_reason_ = reason;
@@ -859,6 +873,7 @@ void Filter::UpstreamRequest::onPerTryTimeout() {
     upstream_host_->stats().rq_timeout_.inc();
   }
   resetStream();
+  request_info_.setResponseFlag(Http::AccessLog::ResponseFlag::UpstreamRequestTimeout);
   parent_.onUpstreamReset(UpstreamResetType::PerTryTimeout,
                           Optional<Http::StreamResetReason>(Http::StreamResetReason::LocalReset));
 }
@@ -910,6 +925,7 @@ void Filter::UpstreamRequest::onPoolReady(Http::StreamEncoder& request_encoder,
     onResetStream(deferred_reset_reason_.value());
   } else {
     if (buffered_request_body_) {
+      request_info_.bytes_sent_ += buffered_request_body_->length();
       request_encoder.encodeData(*buffered_request_body_, encode_complete_ && !encode_trailers_);
     }
 

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -103,9 +103,7 @@ public:
                      PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, dynamic_stats, true),
                      config.start_child_span()) {
     for (const auto& upstream_log : config.upstream_log()) {
-      Http::AccessLog::InstanceSharedPtr current_upstream_log =
-          Http::AccessLog::AccessLogFactory::fromProto(upstream_log, context);
-      upstream_logs_.push_back(current_upstream_log);
+      upstream_logs_.push_back(Http::AccessLog::AccessLogFactory::fromProto(upstream_log, context));
     }
   }
 

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -12,6 +12,7 @@
 #include "envoy/local_info/local_info.h"
 #include "envoy/router/shadow_writer.h"
 #include "envoy/runtime/runtime.h"
+#include "envoy/server/filter_config.h"
 #include "envoy/stats/stats_macros.h"
 #include "envoy/upstream/cluster_manager.h"
 
@@ -19,7 +20,11 @@
 #include "common/common/hash.h"
 #include "common/common/hex.h"
 #include "common/common/logger.h"
+#include "common/http/access_log/access_log_impl.h"
+#include "common/http/access_log/request_info_impl.h"
 #include "common/http/utility.h"
+
+#include "api/filter/http/router.pb.h"
 
 namespace Envoy {
 namespace Router {
@@ -91,6 +96,19 @@ public:
         emit_dynamic_stats_(emit_dynamic_stats), start_child_span_(start_child_span),
         shadow_writer_(std::move(shadow_writer)) {}
 
+  FilterConfig(const std::string& stat_prefix, Server::Configuration::FactoryContext& context,
+               ShadowWriterPtr&& shadow_writer, const envoy::api::v2::filter::http::Router& config)
+      : FilterConfig(stat_prefix, context.localInfo(), context.scope(), context.clusterManager(),
+                     context.runtime(), context.random(), std::move(shadow_writer),
+                     PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, dynamic_stats, true),
+                     config.start_child_span()) {
+    for (const auto& upstream_log : config.upstream_log()) {
+      Http::AccessLog::InstanceSharedPtr current_upstream_log =
+          Http::AccessLog::AccessLogFactory::fromProto(upstream_log, context);
+      upstream_logs_.push_back(current_upstream_log);
+    }
+  }
+
   ShadowWriter& shadowWriter() { return *shadow_writer_; }
 
   Stats::Scope& scope_;
@@ -101,6 +119,7 @@ public:
   FilterStats stats_;
   const bool emit_dynamic_stats_;
   const bool start_child_span_;
+  std::list<Http::AccessLog::InstanceSharedPtr> upstream_logs_;
 
 private:
   ShadowWriterPtr shadow_writer_;
@@ -194,6 +213,7 @@ private:
     void onPerTryTimeout();
 
     void onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host) {
+      request_info_.onUpstreamHostSelected(host);
       upstream_host_ = host;
       parent_.callbacks_->requestInfo().onUpstreamHostSelected(host);
     }
@@ -249,6 +269,8 @@ private:
     Upstream::HostDescriptionConstSharedPtr upstream_host_;
     DownstreamWatermarkManager downstream_watermark_manager_{*this};
     Tracing::SpanPtr span_;
+    Http::AccessLog::RequestInfoImpl request_info_;
+    Http::HeaderMap* upstream_headers_{};
 
     bool calling_encode_headers_ : 1;
     bool upstream_canary_ : 1;
@@ -279,7 +301,7 @@ private:
   void maybeDoShadowing();
   void onRequestComplete();
   void onResponseTimeout();
-  void onUpstreamHeaders(Http::HeaderMapPtr&& headers, bool end_stream);
+  void onUpstreamHeaders(uint64_t response_code, Http::HeaderMapPtr&& headers, bool end_stream);
   void onUpstreamData(Buffer::Instance& data, bool end_stream);
   void onUpstreamTrailers(Http::HeaderMapPtr&& trailers);
   void onUpstreamComplete();

--- a/source/server/config/http/BUILD
+++ b/source/server/config/http/BUILD
@@ -151,9 +151,11 @@ envoy_cc_library(
     name = "router_lib",
     srcs = ["router.cc"],
     hdrs = ["router.h"],
+    external_deps = ["envoy_filter_http_router"],
     deps = [
         "//include/envoy/registry",
         "//include/envoy/server:filter_config_interface",
+        "//source/common/config:filter_json_lib",
         "//source/common/config:well_known_names",
         "//source/common/json:config_schemas_lib",
         "//source/common/router:router_lib",

--- a/source/server/config/http/router.cc
+++ b/source/server/config/http/router.cc
@@ -4,29 +4,46 @@
 
 #include "envoy/registry/registry.h"
 
+#include "common/config/filter_json.h"
 #include "common/json/config_schemas.h"
 #include "common/router/router.h"
 #include "common/router/shadow_writer_impl.h"
+
+#include "api/filter/http/router.pb.h"
 
 namespace Envoy {
 namespace Server {
 namespace Configuration {
 
-HttpFilterFactoryCb RouterFilterConfig::createFilterFactory(const Json::Object& json_config,
-                                                            const std::string& stat_prefix,
-                                                            FactoryContext& context) {
-  json_config.validateSchema(Json::Schema::ROUTER_HTTP_FILTER_SCHEMA);
+namespace {
 
+HttpFilterFactoryCb createRouterFilterFactory(const envoy::api::v2::filter::http::Router& router,
+                                              const std::string& stat_prefix,
+                                              FactoryContext& context) {
   Router::FilterConfigSharedPtr config(new Router::FilterConfig(
-      stat_prefix, context.localInfo(), context.scope(), context.clusterManager(),
-      context.runtime(), context.random(),
-      Router::ShadowWriterPtr{new Router::ShadowWriterImpl(context.clusterManager())},
-      json_config.getBoolean("dynamic_stats", true),
-      json_config.getBoolean("start_child_span", false)));
+      stat_prefix, context,
+      Router::ShadowWriterPtr{new Router::ShadowWriterImpl(context.clusterManager())}, router));
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<Router::ProdFilter>(*config));
   };
+}
+
+} // namespace
+
+HttpFilterFactoryCb RouterFilterConfig::createFilterFactory(const Json::Object& json_config,
+                                                            const std::string& stat_prefix,
+                                                            FactoryContext& context) {
+  envoy::api::v2::filter::http::Router router;
+  Config::FilterJson::translateRouter(json_config, router);
+
+  return createRouterFilterFactory(router, stat_prefix, context);
+}
+
+HttpFilterFactoryCb RouterFilterConfig::createFilterFactoryFromProto(
+    const Protobuf::Message& config, const std::string& stat_prefix, FactoryContext& context) {
+  return createRouterFilterFactory(
+      dynamic_cast<const envoy::api::v2::filter::http::Router&>(config), stat_prefix, context);
 }
 
 /**

--- a/source/server/config/http/router.cc
+++ b/source/server/config/http/router.cc
@@ -9,8 +9,6 @@
 #include "common/router/router.h"
 #include "common/router/shadow_writer_impl.h"
 
-#include "api/filter/http/router.pb.h"
-
 namespace Envoy {
 namespace Server {
 namespace Configuration {

--- a/source/server/config/http/router.h
+++ b/source/server/config/http/router.h
@@ -5,6 +5,7 @@
 #include "envoy/server/filter_config.h"
 
 #include "common/config/well_known_names.h"
+#include "common/protobuf/protobuf.h"
 
 namespace Envoy {
 namespace Server {
@@ -18,6 +19,11 @@ public:
   HttpFilterFactoryCb createFilterFactory(const Json::Object& json_config,
                                           const std::string& stat_prefix,
                                           FactoryContext& context) override;
+
+  HttpFilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& config,
+                                                   const std::string& stat_prefix,
+                                                   FactoryContext& context) override;
+
   std::string name() override { return Config::HttpFilterNames::get().ROUTER; }
 };
 

--- a/source/server/config/http/router.h
+++ b/source/server/config/http/router.h
@@ -27,8 +27,7 @@ public:
                                                    FactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return std::unique_ptr<envoy::api::v2::filter::http::Router>(
-        new envoy::api::v2::filter::http::Router());
+    return ProtobufTypes::MessagePtr{new envoy::api::v2::filter::http::Router()};
   }
 
   std::string name() override { return Config::HttpFilterNames::get().ROUTER; }

--- a/source/server/config/http/router.h
+++ b/source/server/config/http/router.h
@@ -7,6 +7,8 @@
 #include "common/config/well_known_names.h"
 #include "common/protobuf/protobuf.h"
 
+#include "api/filter/http/router.pb.h"
+
 namespace Envoy {
 namespace Server {
 namespace Configuration {
@@ -23,6 +25,11 @@ public:
   HttpFilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& config,
                                                    const std::string& stat_prefix,
                                                    FactoryContext& context) override;
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::unique_ptr<envoy::api::v2::filter::http::Router>(
+        new envoy::api::v2::filter::http::Router());
+  }
 
   std::string name() override { return Config::HttpFilterNames::get().ROUTER; }
 };

--- a/test/common/config/BUILD
+++ b/test/common/config/BUILD
@@ -162,3 +162,11 @@ envoy_cc_test(
         "//test/test_common:utility_lib",
     ],
 )
+
+envoy_cc_test(
+    name = "filter_json_test",
+    srcs = ["filter_json_test.cc"],
+    deps = [
+        "//source/common/config:filter_json_lib",
+    ],
+)

--- a/test/common/config/filter_json_test.cc
+++ b/test/common/config/filter_json_test.cc
@@ -1,0 +1,41 @@
+#include "common/config/filter_json.h"
+#include "common/json/json_loader.h"
+
+#include "api/filter/http/router.pb.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Config {
+namespace {
+
+envoy::api::v2::filter::http::Router parseRouterFromJson(const std::string& json_string) {
+  envoy::api::v2::filter::http::Router router;
+  auto json_object_ptr = Json::Factory::loadFromString(json_string);
+  Config::FilterJson::translateRouter(*json_object_ptr, router);
+  return router;
+}
+
+} // namespace
+
+TEST(FilterJsonTest, TranslateRouter) {
+  std::string json_string = R"EOF(
+    {
+      "dynamic_stats": false,
+      "start_child_span": true
+    }
+  )EOF";
+
+  auto router = parseRouterFromJson(json_string);
+  EXPECT_FALSE(router.dynamic_stats().value());
+  EXPECT_TRUE(router.start_child_span());
+}
+
+TEST(FilterJsonTest, TranslateRouterDefaults) {
+  std::string json_string = "{}";
+  auto router = parseRouterFromJson(json_string);
+  EXPECT_TRUE(router.dynamic_stats().value());
+  EXPECT_FALSE(router.start_child_span());
+}
+
+} // namespace Config
+} // namespace Envoy

--- a/test/common/json/config_schemas_test.cc
+++ b/test/common/json/config_schemas_test.cc
@@ -22,7 +22,7 @@ std::vector<std::string> generateTestInputs() {
 
   std::string test_path = TestEnvironment::temporaryDirectory() + "/config_schemas_test";
   auto file_list = TestUtility::listFiles(test_path, false);
-  EXPECT_EQ(17, file_list.size());
+  EXPECT_EQ(19, file_list.size());
   return file_list;
 }
 
@@ -37,6 +37,8 @@ TEST_P(ConfigSchemasTest, CheckValidationExpectation) {
     schema = Schema::LISTENER_SCHEMA;
   } else if (schema_name == "HTTP_CONN_NETWORK_FILTER_SCHEMA") {
     schema = Schema::HTTP_CONN_NETWORK_FILTER_SCHEMA;
+  } else if (schema_name == "ROUTER_HTTP_FILTER_SCHEMA") {
+    schema = Schema::ROUTER_HTTP_FILTER_SCHEMA;
   } else if (schema_name == "ROUTE_CONFIGURATION_SCHEMA") {
     schema = Schema::ROUTE_CONFIGURATION_SCHEMA;
   } else if (schema_name == "ROUTE_ENTRY_CONFIGURATION_SCHEMA") {

--- a/test/common/json/config_schemas_test_data/test_http_router_schema.py
+++ b/test/common/json/config_schemas_test_data/test_http_router_schema.py
@@ -1,0 +1,21 @@
+from util import get_blob
+from util import true, false
+
+ROUTER_HTTP_FILTER_BLOB = {
+    "dynamic_stats": true
+}
+
+def test(writer):
+    writer.write_test_file(
+        'Valid',
+        schema='ROUTER_HTTP_FILTER_SCHEMA',
+        data=get_blob(ROUTER_HTTP_FILTER_BLOB),
+        throws=False,
+    )
+
+    writer.write_test_file(
+        'ValidDynamicStatsMissing',
+        schema='ROUTER_HTTP_FILTER_SCHEMA',
+        data={},
+        throws=False,
+    )

--- a/test/common/json/config_schemas_test_data/test_http_router_schema.py
+++ b/test/common/json/config_schemas_test_data/test_http_router_schema.py
@@ -14,7 +14,7 @@ def test(writer):
     )
 
     writer.write_test_file(
-        'ValidDynamicStatsMissing',
+        'ValidDefaults',
         schema='ROUTER_HTTP_FILTER_SCHEMA',
         data={},
         throws=False,

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -95,6 +95,34 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "router_upstream_log_test",
+    srcs = ["router_upstream_log_test.cc"],
+    external_deps = ["envoy_filter_http_router"],
+    deps = [
+        "//include/envoy/common:optional",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/config:filter_json_lib",
+        "//source/common/network:utility_lib",
+        "//source/common/router:router_lib",
+        "//source/common/upstream:upstream_includes",
+        "//source/common/upstream:upstream_lib",
+        "//source/server/config/http:file_access_log_lib",
+        "//test/common/http:common_lib",
+        "//test/mocks/access_log:access_log_mocks",
+        "//test/mocks/filesystem:filesystem_mocks",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/local_info:local_info_mocks",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/router:router_mocks",
+        "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/server:server_mocks",
+        "//test/mocks/ssl:ssl_mocks",
+        "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "shadow_writer_impl_test",
     srcs = ["shadow_writer_impl_test.cc"],
     deps = [

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -1,0 +1,253 @@
+#include "envoy/common/optional.h"
+
+#include "common/config/filter_json.h"
+#include "common/router/router.h"
+#include "common/upstream/upstream_impl.h"
+
+#include "test/common/http/common.h"
+#include "test/mocks/access_log/mocks.h"
+#include "test/mocks/filesystem/mocks.h"
+#include "test/mocks/http/mocks.h"
+#include "test/mocks/local_info/mocks.h"
+#include "test/mocks/network/mocks.h"
+#include "test/mocks/router/mocks.h"
+#include "test/mocks/runtime/mocks.h"
+#include "test/mocks/server/mocks.h"
+#include "test/mocks/upstream/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::Invoke;
+using testing::NiceMock;
+using testing::Return;
+using testing::ReturnRef;
+using testing::_;
+
+namespace Envoy {
+namespace Router {
+namespace {
+
+Optional<envoy::api::v2::filter::AccessLog> testUpstreamLog() {
+  // Custom format without timestamps or durations.
+  const std::string json_string = R"EOF(
+  {
+    "path": "/dev/null",
+    "format": "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL% %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %REQ(:AUTHORITY)% %UPSTREAM_HOST% %RESP(X-UPSTREAM-HEADER)%\n"
+  }
+  )EOF";
+
+  auto json_object_ptr = Json::Factory::loadFromString(json_string);
+
+  envoy::api::v2::filter::AccessLog upstream_log;
+  Envoy::Config::FilterJson::translateAccessLog(*json_object_ptr, upstream_log);
+
+  return Optional<envoy::api::v2::filter::AccessLog>(upstream_log);
+}
+
+} // namespace
+
+class TestFilter : public Filter {
+public:
+  using Filter::Filter;
+
+  // Filter
+  RetryStatePtr createRetryState(const RetryPolicy&, Http::HeaderMap&, const Upstream::ClusterInfo&,
+                                 Runtime::Loader&, Runtime::RandomGenerator&, Event::Dispatcher&,
+                                 Upstream::ResourcePriority) override {
+    EXPECT_EQ(nullptr, retry_state_);
+    retry_state_ = new NiceMock<MockRetryState>();
+    return RetryStatePtr{retry_state_};
+  }
+
+  const Network::Connection* downstreamConnection() const override {
+    return &downstream_connection_;
+  }
+
+  NiceMock<Network::MockConnection> downstream_connection_;
+  MockRetryState* retry_state_{};
+};
+
+class RouterUpstreamLogTest : public testing::Test {
+public:
+  RouterUpstreamLogTest() {}
+
+  void init(Optional<envoy::api::v2::filter::AccessLog> upstream_log) {
+    envoy::api::v2::filter::http::Router router_proto;
+
+    if (upstream_log.valid()) {
+      ON_CALL(*context_.access_log_manager_.file_, write(_))
+          .WillByDefault(Invoke([&](const std::string& data) { output_.push_back(data); }));
+
+      envoy::api::v2::filter::AccessLog* current_upstream_log = router_proto.add_upstream_log();
+      current_upstream_log->CopyFrom(upstream_log.value());
+    }
+
+    config_.reset(new FilterConfig("prefix", context_, ShadowWriterPtr(new MockShadowWriter()),
+                                   router_proto));
+    router_.reset(new TestFilter(*config_));
+    router_->setDecoderFilterCallbacks(callbacks_);
+
+    upstream_locality_.set_zone("to_az");
+
+    ON_CALL(*context_.cluster_manager_.conn_pool_.host_, address())
+        .WillByDefault(Return(host_address_));
+    ON_CALL(*context_.cluster_manager_.conn_pool_.host_, locality())
+        .WillByDefault(ReturnRef(upstream_locality_));
+    ON_CALL(router_->downstream_connection_, localAddress())
+        .WillByDefault(ReturnRef(*host_address_));
+    ON_CALL(router_->downstream_connection_, remoteAddress())
+        .WillByDefault(ReturnRef(*remote_address_));
+  }
+
+  void expectResponseTimerCreate() {
+    response_timeout_ = new Event::MockTimer(&callbacks_.dispatcher_);
+    EXPECT_CALL(*response_timeout_, enableTimer(_));
+    EXPECT_CALL(*response_timeout_, disableTimer());
+  }
+
+  void expectPerTryTimerCreate() {
+    per_try_timeout_ = new Event::MockTimer(&callbacks_.dispatcher_);
+    EXPECT_CALL(*per_try_timeout_, enableTimer(_));
+    EXPECT_CALL(*per_try_timeout_, disableTimer());
+  }
+
+  void
+  run(uint64_t response_code,
+      const std::initializer_list<std::pair<std::string, std::string>>& request_headers_init,
+      const std::initializer_list<std::pair<std::string, std::string>>& response_headers_init) {
+    NiceMock<Http::MockStreamEncoder> encoder;
+    Http::StreamDecoder* response_decoder = nullptr;
+
+    EXPECT_CALL(context_.cluster_manager_.conn_pool_, newStream(_, _))
+        .WillOnce(Invoke(
+            [&](Http::StreamDecoder& decoder,
+                Http::ConnectionPool::Callbacks& callbacks) -> Http::ConnectionPool::Cancellable* {
+              response_decoder = &decoder;
+              callbacks.onPoolReady(encoder, context_.cluster_manager_.conn_pool_.host_);
+              return nullptr;
+            }));
+    expectResponseTimerCreate();
+
+    Http::TestHeaderMapImpl headers(request_headers_init);
+    HttpTestUtility::addDefaultHeaders(headers);
+    router_->decodeHeaders(headers, true);
+
+    EXPECT_CALL(*router_->retry_state_, shouldRetry(_, _, _)).WillOnce(Return(RetryStatus::No));
+
+    Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl(response_headers_init));
+    response_headers->insertStatus().value(response_code);
+
+    EXPECT_CALL(context_.cluster_manager_.conn_pool_.host_->outlier_detector_,
+                putHttpResponseCode(response_code));
+    response_decoder->decodeHeaders(std::move(response_headers), true);
+  }
+
+  void run() { run(200, {}, {}); }
+
+  void runWithRetry() {
+    NiceMock<Http::MockStreamEncoder> encoder1;
+    Http::StreamDecoder* response_decoder = nullptr;
+    EXPECT_CALL(context_.cluster_manager_.conn_pool_, newStream(_, _))
+        .WillOnce(Invoke(
+            [&](Http::StreamDecoder& decoder,
+                Http::ConnectionPool::Callbacks& callbacks) -> Http::ConnectionPool::Cancellable* {
+              response_decoder = &decoder;
+              callbacks.onPoolReady(encoder1, context_.cluster_manager_.conn_pool_.host_);
+              return nullptr;
+            }));
+    expectResponseTimerCreate();
+    expectPerTryTimerCreate();
+
+    Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"},
+                                    {"x-envoy-internal", "true"},
+                                    {"x-envoy-upstream-rq-per-try-timeout-ms", "5"}};
+    HttpTestUtility::addDefaultHeaders(headers);
+    router_->decodeHeaders(headers, true);
+
+    router_->retry_state_->expectRetry();
+    EXPECT_CALL(context_.cluster_manager_.conn_pool_.host_->outlier_detector_,
+                putHttpResponseCode(504));
+    per_try_timeout_->callback_();
+
+    // We expect this reset to kick off a new request.
+    NiceMock<Http::MockStreamEncoder> encoder2;
+    EXPECT_CALL(context_.cluster_manager_.conn_pool_, newStream(_, _))
+        .WillOnce(Invoke(
+            [&](Http::StreamDecoder& decoder,
+                Http::ConnectionPool::Callbacks& callbacks) -> Http::ConnectionPool::Cancellable* {
+              response_decoder = &decoder;
+              callbacks.onPoolReady(encoder2, context_.cluster_manager_.conn_pool_.host_);
+              return nullptr;
+            }));
+    expectPerTryTimerCreate();
+    router_->retry_state_->callback_();
+
+    // Normal response.
+    EXPECT_CALL(*router_->retry_state_, shouldRetry(_, _, _)).WillOnce(Return(RetryStatus::No));
+    Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
+    EXPECT_CALL(context_.cluster_manager_.conn_pool_.host_->outlier_detector_,
+                putHttpResponseCode(200));
+    response_decoder->decodeHeaders(std::move(response_headers), true);
+  }
+
+  std::vector<std::string> output_;
+
+  NiceMock<Server::Configuration::MockFactoryContext> context_;
+
+  envoy::api::v2::Locality upstream_locality_;
+  Network::Address::InstanceConstSharedPtr host_address_{
+      Network::Utility::resolveUrl("tcp://10.0.0.5:9211")};
+  Network::Address::InstanceConstSharedPtr remote_address_{
+      Network::Utility::parseInternetAddressAndPort("1.2.3.4:80")};
+  Event::MockTimer* response_timeout_{};
+  Event::MockTimer* per_try_timeout_{};
+
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks_;
+  std::shared_ptr<FilterConfig> config_;
+  std::shared_ptr<TestFilter> router_;
+};
+
+TEST_F(RouterUpstreamLogTest, NoLogConfigured) {
+  init({});
+  run();
+
+  EXPECT_TRUE(output_.empty());
+}
+
+TEST_F(RouterUpstreamLogTest, LogSingleTry) {
+  init(testUpstreamLog());
+  run();
+
+  EXPECT_EQ(output_.size(), 1U);
+  EXPECT_EQ(output_.front(), "GET / HTTP/1.0 200 - 0 0 host 10.0.0.5:9211 -\n");
+}
+
+TEST_F(RouterUpstreamLogTest, LogRetries) {
+  init(testUpstreamLog());
+  runWithRetry();
+
+  EXPECT_EQ(output_.size(), 2U);
+  EXPECT_EQ(output_.front(), "GET / HTTP/1.0 0 UT 0 0 host 10.0.0.5:9211 -\n");
+  EXPECT_EQ(output_.back(), "GET / HTTP/1.0 200 - 0 0 host 10.0.0.5:9211 -\n");
+}
+
+TEST_F(RouterUpstreamLogTest, LogFailure) {
+  init(testUpstreamLog());
+  run(503, {}, {});
+
+  EXPECT_EQ(output_.size(), 1U);
+  EXPECT_EQ(output_.front(), "GET / HTTP/1.0 503 - 0 0 host 10.0.0.5:9211 -\n");
+}
+
+TEST_F(RouterUpstreamLogTest, LogHeaders) {
+  init(testUpstreamLog());
+  run(200, {{"x-envoy-original-path", "/foo"}}, {{"x-upstream-header", "abcdef"}});
+
+  EXPECT_EQ(output_.size(), 1U);
+  EXPECT_EQ(output_.front(), "GET /foo HTTP/1.0 200 - 0 0 host 10.0.0.5:9211 abcdef\n");
+}
+
+} // namespace Router
+} // namespace Envoy

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -486,6 +486,7 @@ public:
   ~MockInstance();
 
   // Http::ConnectionPool::Instance
+  MOCK_CONST_METHOD0(protocol, Http::Protocol());
   MOCK_METHOD1(addDrainedCallback, void(DrainedCb cb));
   MOCK_METHOD2(newStream, Cancellable*(Http::StreamDecoder& response_decoder,
                                        Http::ConnectionPool::Callbacks& callbacks));

--- a/test/server/config/http/BUILD
+++ b/test/server/config/http/BUILD
@@ -17,6 +17,7 @@ envoy_cc_test(
         "//source/common/http/access_log:access_log_lib",
         "//source/common/protobuf",
         "//source/common/protobuf:utility_lib",
+        "//source/common/router:router_lib",
         "//source/server/config/http:buffer_lib",
         "//source/server/config/http:dynamo_lib",
         "//source/server/config/http:fault_lib",

--- a/test/server/config/http/config_test.cc
+++ b/test/server/config/http/config_test.cc
@@ -2,10 +2,12 @@
 
 #include "envoy/registry/registry.h"
 
+#include "common/config/filter_json.h"
 #include "common/config/well_known_names.h"
 #include "common/http/access_log/access_log_impl.h"
 #include "common/protobuf/protobuf.h"
 #include "common/protobuf/utility.h"
+#include "common/router/router.h"
 
 #include "server/config/http/buffer.h"
 #include "server/config/http/dynamo.h"
@@ -23,9 +25,11 @@
 #include "test/mocks/server/mocks.h"
 #include "test/test_common/utility.h"
 
+#include "api/filter/http/router.pb.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
 using testing::_;
@@ -242,6 +246,18 @@ TEST(HttpFilterConfigTest, BadRouterFilterConfig) {
   NiceMock<MockFactoryContext> context;
   RouterFilterConfig factory;
   EXPECT_THROW(factory.createFilterFactory(*json_config, "stats", context), Json::Exception);
+}
+
+TEST(HttpFilterConigTest, RouterV2Filter) {
+  envoy::api::v2::filter::http::Router router_config;
+  router_config.mutable_dynamic_stats()->set_value(true);
+
+  NiceMock<MockFactoryContext> context;
+  RouterFilterConfig factory;
+  HttpFilterFactoryCb cb = factory.createFilterFactoryFromProto(router_config, "stats", context);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
+  cb(filter_callback);
 }
 
 TEST(HttpFilterConfigTest, IpTaggingFilter) {


### PR DESCRIPTION
*Description*:

Adds support for the `upstream_log` field of the v2 API's `Router` HTTP filter. The upstream log reuses the existing access log code for configuring and generating logs. The feature is enabled by adding the appropriate log file configuration to the Router object in the v2 API only. 

Closes #1927.

API Change: envoyproxy/data-plane-api#211

*Risk Level*: Medium -- adds code to a heavily used filter.

*Testing*:
Unit tests to verify that logs are generated when expected and disabled by default.
Additional manual testing with parallel requests.

*Release Notes*:
Note that api.http.filter.Router upstream_log configuration point is available for use.