### PR TITLE
build: move to C++14

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -72,9 +72,9 @@ unprefixed, e.g. `as` instead of `x86_64-linux-gnu-as`.
 
 ## Supported compiler versions
 
-Though Envoy has been run in production compiled with GCC 4.9 extensively, we now strongly
-recommend GCC >= 5 due to known issues with std::string thread safety. Clang >= 4.0 is also known
-to work.
+Though Envoy has been run in production compiled with GCC 4.9 extensively, we now require
+GCC >= 5 due to known issues with std::string thread safety and C++14 support. Clang >= 4.0 is also
+known to work.
 
 ## Clang STL debug symbols
 

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -10,7 +10,7 @@ def envoy_copts(repository, test = False):
         "-Wnon-virtual-dtor",
         "-Woverloaded-virtual",
         "-Wold-style-cast",
-        "-std=c++0x",
+        "-std=c++14",
     ] + select({
         # Bazel adds an implicit -DNDEBUG for opt.
         repository + "//bazel:opt_build": [] if test else ["-ggdb3"],

--- a/docs/install/requirements.rst
+++ b/docs/install/requirements.rst
@@ -8,7 +8,7 @@ recent Linux including Ubuntu 16 LTS.
 
 Envoy has the following requirements:
 
-* GCC 4.9+ (for C++11 regex support)
+* GCC 5+ (for C++14 support)
 * `backward <https://github.com/bombela/backward-cpp>`_ (last tested with 1.3)
 * `Bazel <https://github.com/bazelbuild/bazel>`_ (last tested with 0.5.3)
 * `BoringSSL <https://boringssl.googlesource.com/boringssl>`_ (last tested with sha ae9f0616c58bddcbe7a6d80d29d796bee9aaff2e)

--- a/source/common/common/compiler_requirements.h
+++ b/source/common/common/compiler_requirements.h
@@ -1,11 +1,9 @@
 #pragma once
 
-#include <regex>
-
 namespace Envoy {
-#if __cplusplus < 201103L ||                                                                       \
-    (defined(__GLIBCXX__) && (__cplusplus < 201402L) &&                                            \
-     (!defined(_GLIBCXX_REGEX_DFS_QUANTIFIERS_LIMIT) && !defined(_GLIBCXX_REGEX_STATE_LIMIT)))
-#error "Your compiler does not support std::regex properly.  GCC 4.9+ or Clang required."
+
+#if __cplusplus < 201402L
+#error "Your compiler does not support C++14. GCC 5+ or Clang is required."
 #endif
+
 } // Envoy

--- a/source/common/common/macros.h
+++ b/source/common/common/macros.h
@@ -1,6 +1,7 @@
 #pragma once
 
 namespace Envoy {
+
 /**
  * @return the size of a C array.
  */
@@ -37,4 +38,5 @@ namespace Envoy {
 #else // C++11 on gcc 6, and all other cases
 #define FALLTHRU
 #endif
+
 } // Envoy

--- a/source/common/common/macros.h
+++ b/source/common/common/macros.h
@@ -28,7 +28,9 @@ namespace Envoy {
 /**
  * Have a generic fall-through for different versions of C++
  */
-#if __cplusplus >= 201402L // C++14, C++17 and above
+#if __cplusplus >= 201703L // C++17 and above
+#define FALLTHRU [[fallthrough]]
+#elif __cplusplus >= 201402L && __clang_major__ >= 5 // C++14 clang-5
 #define FALLTHRU [[fallthrough]]
 #elif __cplusplus >= 201103L && __GNUC__ >= 7 // C++11 gcc 7
 #define FALLTHRU [[gnu::fallthrough]]


### PR DESCRIPTION
We now require GCC5+ for C++14 support. This will get us R/W mutexes,
heterogeneous containers, make_unique, nd a few other niceties.

Signed-off-by: Matt Klein <mklein@lyft.com>
