### PR TITLE
Allow custom link options for envoy_cc_binary

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -170,7 +170,8 @@ def envoy_cc_binary(name,
                     visibility = None,
                     repository = "",
                     stamped = False,
-                    deps = []):
+                    deps = [],
+                    linkopts = envoy_linkopts()):
     # Implicit .stamped targets to obtain builds with the (truncated) git SHA1.
     if stamped:
         _git_stamped_genrule(repository, name)
@@ -180,7 +181,7 @@ def envoy_cc_binary(name,
         srcs = srcs,
         data = data,
         copts = envoy_copts(repository),
-        linkopts = envoy_linkopts(),
+        linkopts = linkopts,
         testonly = testonly,
         linkstatic = 1,
         visibility = visibility,


### PR DESCRIPTION
*build: custom link options*: *Modify envoy build definition to allow linking with non-standard libraries*

*Description*:
Exposing linkopts parameter for envoy_cc_binary allows linking envoy with non-standard libraries. This comes handy when extending envoy, e.g. through custom filters.

*Risk Level*: Low

*Testing*:
I am leveraging this new capability in my project (a custom filter).
Relying on standard tests to ensure that nothing is broken when the value for linkopts is not specified.
