### PR TITLE
decompressor_lib: implemented decompressor interface

### DIFF
--- a/include/envoy/decompressor/BUILD
+++ b/include/envoy/decompressor/BUILD
@@ -1,0 +1,17 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "decompressor_interface",
+    hdrs = ["decompressor.h"],
+    deps = [
+        "//include/envoy/buffer:buffer_interface",
+    ],
+)

--- a/include/envoy/decompressor/decompressor.h
+++ b/include/envoy/decompressor/decompressor.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "envoy/buffer/buffer.h"
+
+namespace Envoy {
+namespace Decompressor {
+
+/**
+ * Allows decompressing data.
+ */
+class Decompressor {
+public:
+  virtual ~Decompressor() {}
+
+  /**
+   * Decompresses data from one buffer into another buffer.
+   * @param input_buffer supplies the buffer with compressed data.
+   * @param output_buffer supplies the buffer to output decompressed data.
+   */
+  virtual void decompress(const Buffer::Instance& input_buffer,
+                          Buffer::Instance& output_buffer) PURE;
+};
+
+} // namespace Decompressor
+} // namespace Envoy

--- a/source/common/compressor/zlib_compressor_impl.cc
+++ b/source/common/compressor/zlib_compressor_impl.cc
@@ -54,7 +54,7 @@ void ZlibCompressorImpl::compress(const Buffer::Instance& input_buffer,
 bool ZlibCompressorImpl::deflateNext(int8_t flush_state) {
   const int result = deflate(zstream_ptr_.get(), static_cast<int>(flush_state));
   if (result == Z_BUF_ERROR && zstream_ptr_->avail_in == 0) {
-    return false; // This means that zlib needs more input, so stop here
+    return false; // This means that zlib needs more input, so stop here.
   }
 
   RELEASE_ASSERT(result == Z_OK);

--- a/source/common/compressor/zlib_compressor_impl.cc
+++ b/source/common/compressor/zlib_compressor_impl.cc
@@ -7,7 +7,7 @@
 namespace Envoy {
 namespace Compressor {
 
-ZlibCompressorImpl::ZlibCompressorImpl() : ZlibCompressorImpl(4096){};
+ZlibCompressorImpl::ZlibCompressorImpl() : ZlibCompressorImpl(4096) {}
 
 ZlibCompressorImpl::ZlibCompressorImpl(uint64_t chunk_size)
     : chunk_size_{chunk_size}, initialized_{false}, chunk_char_ptr_(new unsigned char[chunk_size]),

--- a/source/common/compressor/zlib_compressor_impl.cc
+++ b/source/common/compressor/zlib_compressor_impl.cc
@@ -23,11 +23,10 @@ ZlibCompressorImpl::ZlibCompressorImpl(uint64_t chunk_size)
 }
 
 void ZlibCompressorImpl::init(CompressionLevel comp_level, CompressionStrategy comp_strategy,
-                              int8_t window_bits, uint8_t memory_level = 8) {
+                              int64_t window_bits, uint64_t memory_level = 8) {
   ASSERT(initialized_ == false);
-  const int result = deflateInit2(zstream_ptr_.get(), static_cast<int>(comp_level), Z_DEFLATED,
-                                  static_cast<int>(window_bits), static_cast<int>(memory_level),
-                                  static_cast<int>(comp_strategy));
+  const int result = deflateInit2(zstream_ptr_.get(), static_cast<int64_t>(comp_level), Z_DEFLATED,
+                                  window_bits, memory_level, static_cast<uint64_t>(comp_strategy));
   RELEASE_ASSERT(result >= 0);
   initialized_ = true;
 }
@@ -51,8 +50,8 @@ void ZlibCompressorImpl::compress(const Buffer::Instance& input_buffer,
   }
 }
 
-bool ZlibCompressorImpl::deflateNext(int8_t flush_state) {
-  const int result = deflate(zstream_ptr_.get(), static_cast<int>(flush_state));
+bool ZlibCompressorImpl::deflateNext(int64_t flush_state) {
+  const int result = deflate(zstream_ptr_.get(), flush_state);
   if (result == Z_BUF_ERROR && zstream_ptr_->avail_in == 0) {
     return false; // This means that zlib needs more input, so stop here.
   }
@@ -61,7 +60,7 @@ bool ZlibCompressorImpl::deflateNext(int8_t flush_state) {
   return true;
 }
 
-void ZlibCompressorImpl::process(Buffer::Instance& output_buffer, int8_t flush_state) {
+void ZlibCompressorImpl::process(Buffer::Instance& output_buffer, int64_t flush_state) {
   while (deflateNext(flush_state)) {
     if (zstream_ptr_->avail_out == 0) {
       updateOutput(output_buffer);

--- a/source/common/compressor/zlib_compressor_impl.h
+++ b/source/common/compressor/zlib_compressor_impl.h
@@ -17,7 +17,7 @@ public:
   /**
    * Constructor that allows setting the size of compressor's output buffer. It
    * should be called whenever a buffer size different than the 4096 bytes, normally set by the
-   * default constructor, is desired. If memory is avaiable and it makes sense to output large
+   * default constructor, is desired. If memory is available and it makes sense to output large
    * chunks of compressed data, zlib documentation suggests buffers sizes on the order of 128K or
    * 256K bytes. @see http://zlib.net/zlib_how.html
    * @param chunk_size amount of memory reserved for the compressor output.

--- a/source/common/compressor/zlib_compressor_impl.h
+++ b/source/common/compressor/zlib_compressor_impl.h
@@ -80,9 +80,7 @@ public:
    */
   uint64_t checksum();
 
-  /**
-   * Implements Envoy::Compressor.
-   */
+  // Compressor
   void compress(const Buffer::Instance& input_buffer, Buffer::Instance& output_buffer) override;
 
 private:
@@ -90,10 +88,10 @@ private:
   void process(Buffer::Instance& output_buffer, int64_t flush_state);
   void updateOutput(Buffer::Instance& output_buffer);
 
-  const uint64_t chunk_;
+  const uint64_t chunk_size_;
   bool initialized_;
 
-  std::unique_ptr<unsigned char[]> output_char_ptr_;
+  std::unique_ptr<unsigned char[]> chunk_char_ptr_;
   std::unique_ptr<z_stream, std::function<void(z_stream*)>> zstream_ptr_;
 };
 

--- a/source/common/compressor/zlib_compressor_impl.h
+++ b/source/common/compressor/zlib_compressor_impl.h
@@ -13,6 +13,11 @@ namespace Compressor {
 class ZlibCompressorImpl : public Compressor {
 public:
   ZlibCompressorImpl();
+
+  /**
+   * Sets buffer size for feeding data to the compressor routines.
+   * @param chunk amount of memory reserved for the compressor output.
+   */
   ZlibCompressorImpl(uint64_t chunk);
 
   /**
@@ -62,12 +67,12 @@ public:
   void flush(Buffer::Instance& output_buffer);
 
   /**
-   * Returns adler checksum
+   * Returns adler checksum.
    */
   uint64_t checksum();
 
   /**
-   * Implements Envoy::Compressor
+   * Implements Envoy::Compressor.
    */
   void compress(const Buffer::Instance& input_buffer, Buffer::Instance& output_buffer) override;
 
@@ -75,8 +80,10 @@ private:
   bool deflateNext(int8_t flush_state);
   void process(Buffer::Instance& output_buffer, int8_t flush_state);
   void updateOutput(Buffer::Instance& output_buffer);
+
   uint64_t chunk_;
   bool initialized_;
+
   std::unique_ptr<unsigned char[]> output_char_ptr_;
   std::unique_ptr<z_stream, std::function<void(z_stream*)>> zstream_ptr_;
 };

--- a/source/common/compressor/zlib_compressor_impl.h
+++ b/source/common/compressor/zlib_compressor_impl.h
@@ -60,14 +60,17 @@ public:
             uint8_t memory_level);
 
   /**
-   * Flush must be called usually when stream is over. It will compress any remaining
-   * input data in the compressor and flush it to the output buffer.
+   * Flush should be called when no more data needs to be compressed. It will compress
+   * any remaining input available in the compressor and flush the compressed data to the output
+   * buffer. Note that forcing flush frequently degrades the compression ratio, so this should only
+   * be called when necessary.
    * @param output_buffer supplies the buffer to output compressed data.
    */
   void flush(Buffer::Instance& output_buffer);
 
   /**
-   * Returns adler checksum.
+   * @return uint64_t CRC-32 if a gzip stream is being written or Adler-32 for other compression
+   * types.
    */
   uint64_t checksum();
 

--- a/source/common/compressor/zlib_compressor_impl.h
+++ b/source/common/compressor/zlib_compressor_impl.h
@@ -47,8 +47,8 @@ public:
   };
 
   /**
-   * Init must be called in order to initialize the compressor. It should be always called before
-   * calling compress.
+   * Init must be called in order to initialize the compressor. Once compressor is initialized, it
+   * cannot be initialized again. Init should run before compressing any data.
    * @param level @see CompressionLevel enum
    * @param strategy @see CompressionStrategy enum
    * @param window_bits sets the size of the history buffer. Larger values result in better

--- a/source/common/decompressor/BUILD
+++ b/source/common/decompressor/BUILD
@@ -1,0 +1,21 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "decompressor_lib",
+    srcs = ["zlib_decompressor_impl.cc"],
+    hdrs = ["zlib_decompressor_impl.h"],
+    external_deps = ["zlib"],
+    deps = [
+        "//include/envoy/decompressor:decompressor_interface",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:assert_lib",
+    ],
+)

--- a/source/common/decompressor/zlib_decompressor_impl.cc
+++ b/source/common/decompressor/zlib_decompressor_impl.cc
@@ -1,0 +1,67 @@
+#include "common/decompressor/zlib_decompressor_impl.h"
+
+#include "envoy/common/exception.h"
+
+#include "common/common/assert.h"
+
+namespace Envoy {
+namespace Decompressor {
+
+ZlibDecompressorImpl::ZlibDecompressorImpl() : ZlibDecompressorImpl(4096){};
+
+ZlibDecompressorImpl::ZlibDecompressorImpl(uint64_t chunk_size)
+    : chunk_{chunk_size}, initialized_{false}, output_char_ptr_(new unsigned char[chunk_size]),
+      zstream_ptr_(new z_stream(), [](z_stream* z) {
+        inflateEnd(z);
+        delete z;
+      }) {
+  zstream_ptr_->zalloc = Z_NULL;
+  zstream_ptr_->zfree = Z_NULL;
+  zstream_ptr_->opaque = Z_NULL;
+  zstream_ptr_->avail_out = chunk_;
+  zstream_ptr_->next_out = output_char_ptr_.get();
+}
+
+void ZlibDecompressorImpl::init(int8_t window_bits) {
+  ASSERT(initialized_ == false);
+  const int result = inflateInit2(zstream_ptr_.get(), static_cast<int>(window_bits));
+  RELEASE_ASSERT(result >= 0);
+  initialized_ = true;
+}
+
+uint64_t ZlibDecompressorImpl::checksum() { return zstream_ptr_->adler; }
+
+void ZlibDecompressorImpl::decompress(const Buffer::Instance& input_buffer,
+                                      Buffer::Instance& output_buffer) {
+  const uint64_t num_slices = input_buffer.getRawSlices(nullptr, 0);
+  Buffer::RawSlice slices[num_slices];
+  input_buffer.getRawSlices(slices, num_slices);
+
+  for (const Buffer::RawSlice& input_slice : slices) {
+    zstream_ptr_->avail_in = input_slice.len_;
+    zstream_ptr_->next_in = static_cast<Bytef*>(input_slice.mem_);
+    while (inflateNext()) {
+      if (zstream_ptr_->avail_out == 0) {
+        output_buffer.add(static_cast<void*>(output_char_ptr_.get()),
+                          chunk_ - zstream_ptr_->avail_out);
+        output_char_ptr_.reset(new unsigned char[chunk_]);
+        zstream_ptr_->avail_out = chunk_;
+        zstream_ptr_->next_out = output_char_ptr_.get();
+      }
+    }
+  }
+  output_buffer.add(static_cast<void*>(output_char_ptr_.get()), chunk_ - zstream_ptr_->avail_out);
+}
+
+bool ZlibDecompressorImpl::inflateNext() {
+  const int result = inflate(zstream_ptr_.get(), Z_NO_FLUSH);
+  if (result == Z_BUF_ERROR && zstream_ptr_->avail_in == 0) {
+    return false;
+  }
+
+  RELEASE_ASSERT(result == Z_OK);
+  return true;
+}
+
+} // namespace Decompressor
+} // namespace Envoy

--- a/source/common/decompressor/zlib_decompressor_impl.cc
+++ b/source/common/decompressor/zlib_decompressor_impl.cc
@@ -50,13 +50,14 @@ void ZlibDecompressorImpl::decompress(const Buffer::Instance& input_buffer,
       }
     }
   }
+
   output_buffer.add(static_cast<void*>(output_char_ptr_.get()), chunk_ - zstream_ptr_->avail_out);
 }
 
 bool ZlibDecompressorImpl::inflateNext() {
   const int result = inflate(zstream_ptr_.get(), Z_NO_FLUSH);
   if (result == Z_BUF_ERROR && zstream_ptr_->avail_in == 0) {
-    return false;
+    return false; // This means that zlib needs more input, so stop here.
   }
 
   RELEASE_ASSERT(result == Z_OK);

--- a/source/common/decompressor/zlib_decompressor_impl.cc
+++ b/source/common/decompressor/zlib_decompressor_impl.cc
@@ -22,9 +22,9 @@ ZlibDecompressorImpl::ZlibDecompressorImpl(uint64_t chunk_size)
   zstream_ptr_->next_out = output_char_ptr_.get();
 }
 
-void ZlibDecompressorImpl::init(int8_t window_bits) {
+void ZlibDecompressorImpl::init(int64_t window_bits) {
   ASSERT(initialized_ == false);
-  const int result = inflateInit2(zstream_ptr_.get(), static_cast<int>(window_bits));
+  const int result = inflateInit2(zstream_ptr_.get(), window_bits);
   RELEASE_ASSERT(result >= 0);
   initialized_ = true;
 }
@@ -51,7 +51,10 @@ void ZlibDecompressorImpl::decompress(const Buffer::Instance& input_buffer,
     }
   }
 
-  output_buffer.add(static_cast<void*>(output_char_ptr_.get()), chunk_ - zstream_ptr_->avail_out);
+  const uint64_t n_output{chunk_ - zstream_ptr_->avail_out};
+  if (n_output > 0) {
+    output_buffer.add(static_cast<void*>(output_char_ptr_.get()), n_output);
+  }
 }
 
 bool ZlibDecompressorImpl::inflateNext() {

--- a/source/common/decompressor/zlib_decompressor_impl.cc
+++ b/source/common/decompressor/zlib_decompressor_impl.cc
@@ -7,10 +7,10 @@
 namespace Envoy {
 namespace Decompressor {
 
-ZlibDecompressorImpl::ZlibDecompressorImpl() : ZlibDecompressorImpl(4096){};
+ZlibDecompressorImpl::ZlibDecompressorImpl() : ZlibDecompressorImpl(4096) {}
 
 ZlibDecompressorImpl::ZlibDecompressorImpl(uint64_t chunk_size)
-    : chunk_{chunk_size}, initialized_{false}, output_char_ptr_(new unsigned char[chunk_size]),
+    : chunk_size_{chunk_size}, initialized_{false}, chunk_char_ptr_(new unsigned char[chunk_size]),
       zstream_ptr_(new z_stream(), [](z_stream* z) {
         inflateEnd(z);
         delete z;
@@ -18,8 +18,8 @@ ZlibDecompressorImpl::ZlibDecompressorImpl(uint64_t chunk_size)
   zstream_ptr_->zalloc = Z_NULL;
   zstream_ptr_->zfree = Z_NULL;
   zstream_ptr_->opaque = Z_NULL;
-  zstream_ptr_->avail_out = chunk_;
-  zstream_ptr_->next_out = output_char_ptr_.get();
+  zstream_ptr_->avail_out = chunk_size_;
+  zstream_ptr_->next_out = chunk_char_ptr_.get();
 }
 
 void ZlibDecompressorImpl::init(int64_t window_bits) {
@@ -42,18 +42,18 @@ void ZlibDecompressorImpl::decompress(const Buffer::Instance& input_buffer,
     zstream_ptr_->next_in = static_cast<Bytef*>(input_slice.mem_);
     while (inflateNext()) {
       if (zstream_ptr_->avail_out == 0) {
-        output_buffer.add(static_cast<void*>(output_char_ptr_.get()),
-                          chunk_ - zstream_ptr_->avail_out);
-        output_char_ptr_.reset(new unsigned char[chunk_]);
-        zstream_ptr_->avail_out = chunk_;
-        zstream_ptr_->next_out = output_char_ptr_.get();
+        output_buffer.add(static_cast<void*>(chunk_char_ptr_.get()),
+                          chunk_size_ - zstream_ptr_->avail_out);
+        chunk_char_ptr_.reset(new unsigned char[chunk_size_]);
+        zstream_ptr_->avail_out = chunk_size_;
+        zstream_ptr_->next_out = chunk_char_ptr_.get();
       }
     }
   }
 
-  const uint64_t n_output{chunk_ - zstream_ptr_->avail_out};
+  const uint64_t n_output{chunk_size_ - zstream_ptr_->avail_out};
   if (n_output > 0) {
-    output_buffer.add(static_cast<void*>(output_char_ptr_.get()), n_output);
+    output_buffer.add(static_cast<void*>(chunk_char_ptr_.get()), n_output);
   }
 }
 

--- a/source/common/decompressor/zlib_decompressor_impl.h
+++ b/source/common/decompressor/zlib_decompressor_impl.h
@@ -40,18 +40,16 @@ public:
    */
   uint64_t checksum();
 
-  /**
-   * Implements Envoy::Decompressor.
-   */
+  // Decompressor
   void decompress(const Buffer::Instance& input_buffer, Buffer::Instance& output_buffer) override;
 
 private:
   bool inflateNext();
 
-  uint64_t chunk_;
+  uint64_t chunk_size_;
   bool initialized_;
 
-  std::unique_ptr<unsigned char[]> output_char_ptr_;
+  std::unique_ptr<unsigned char[]> chunk_char_ptr_;
   std::unique_ptr<z_stream, std::function<void(z_stream*)>> zstream_ptr_;
 };
 

--- a/source/common/decompressor/zlib_decompressor_impl.h
+++ b/source/common/decompressor/zlib_decompressor_impl.h
@@ -21,15 +21,16 @@ public:
   ZlibDecompressorImpl(uint64_t chunk_size);
 
   /**
-   * Init must be called in order to initialize the decompressor. It should be called before calling
-   * decompress.
+   * Init must be called in order to initialize the decompressor. Once decompressor is initialized,
+   * it cannot be initialized again. Init should run before decompressing any data.
    * @param window_bits sets the size of the history buffer. It must be greater than or equal to
    * the window_bits value provided when data was compressed (zlib manual).
    */
   void init(int8_t window_bits);
 
   /**
-   * Returns adler checksum.
+   * @return uint64_t CRC-32 if a gzip stream is being written or Adler-32 for other compression
+   * types.
    */
   uint64_t checksum();
 

--- a/source/common/decompressor/zlib_decompressor_impl.h
+++ b/source/common/decompressor/zlib_decompressor_impl.h
@@ -17,7 +17,7 @@ public:
   /**
    * Constructor that allows setting the size of decompressor's output buffer. It
    * should be called whenever a buffer size different than the 4096 bytes, normally set by the
-   * default constructor, is desired. If memory is avaiable and it makes sense to output large
+   * default constructor, is desired. If memory is available and it makes sense to output large
    * chunks of compressed data, zlib documentation suggests buffers sizes on the order of 128K or
    * 256K bytes. @see http://zlib.net/zlib_how.html
    * @param chunk_size amount of memory reserved for the decompressor output.

--- a/source/common/decompressor/zlib_decompressor_impl.h
+++ b/source/common/decompressor/zlib_decompressor_impl.h
@@ -13,30 +13,37 @@ namespace Decompressor {
 class ZlibDecompressorImpl : public Decompressor {
 public:
   ZlibDecompressorImpl();
+
+  /**
+   * Sets buffer size for feeding data to the decompressor routines.
+   * @param chunk amount of memory reserved for the compressor output.
+   */
   ZlibDecompressorImpl(uint64_t chunk_size);
 
   /**
-   * Init must be called in order to initialize the decompressor and it should be always invoked
-   * before calling decompress.
+   * Init must be called in order to initialize the decompressor. It should be called before calling
+   * decompress.
    * @param window_bits sets the size of the history buffer. It must be greater than or equal to
    * the window_bits value provided when data was compressed (zlib manual).
    */
   void init(int8_t window_bits);
 
   /**
-   * Returns adler checksum
+   * Returns adler checksum.
    */
   uint64_t checksum();
 
   /**
-   * Implements Envoy::Decompressor
+   * Implements Envoy::Decompressor.
    */
   void decompress(const Buffer::Instance& input_buffer, Buffer::Instance& output_buffer) override;
 
 private:
   bool inflateNext();
+
   uint64_t chunk_;
   bool initialized_;
+
   std::unique_ptr<unsigned char[]> output_char_ptr_;
   std::unique_ptr<z_stream, std::function<void(z_stream*)>> zstream_ptr_;
 };

--- a/source/common/decompressor/zlib_decompressor_impl.h
+++ b/source/common/decompressor/zlib_decompressor_impl.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "envoy/decompressor/decompressor.h"
+
+#include "zlib.h"
+
+namespace Envoy {
+namespace Decompressor {
+
+/**
+ * Implementation of decompressor's interface.
+ */
+class ZlibDecompressorImpl : public Decompressor {
+public:
+  ZlibDecompressorImpl();
+  ZlibDecompressorImpl(uint64_t chunk_size);
+
+  /**
+   * Init must be called in order to initialize the decompressor and it should be always invoked
+   * before calling decompress.
+   * @param window_bits sets the size of the history buffer. It must be greater than or equal to
+   * the window_bits value provided when data was compressed (zlib manual).
+   */
+  void init(int8_t window_bits);
+
+  /**
+   * Returns adler checksum
+   */
+  uint64_t checksum();
+
+  /**
+   * Implements Envoy::Decompressor
+   */
+  void decompress(const Buffer::Instance& input_buffer, Buffer::Instance& output_buffer) override;
+
+private:
+  bool inflateNext();
+  uint64_t chunk_;
+  bool initialized_;
+  std::unique_ptr<unsigned char[]> output_char_ptr_;
+  std::unique_ptr<z_stream, std::function<void(z_stream*)>> zstream_ptr_;
+};
+
+} // namespace Decompressor
+} // namespace Envoy

--- a/source/common/decompressor/zlib_decompressor_impl.h
+++ b/source/common/decompressor/zlib_decompressor_impl.h
@@ -15,8 +15,12 @@ public:
   ZlibDecompressorImpl();
 
   /**
-   * Sets buffer size for feeding data to the decompressor routines.
-   * @param chunk amount of memory reserved for the compressor output.
+   * Constructor that allows setting the size of decompressor's output buffer. It
+   * should be called whenever a buffer size different than the 4096 bytes, normally set by the
+   * default constructor, is desired. If memory is avaiable and it makes sense to output large
+   * chunks of compressed data, zlib documentation suggests buffers sizes on the order of 128K or
+   * 256K bytes. @see http://zlib.net/zlib_how.html
+   * @param chunk_size amount of memory reserved for the decompressor output.
    */
   ZlibDecompressorImpl(uint64_t chunk_size);
 
@@ -26,10 +30,12 @@ public:
    * @param window_bits sets the size of the history buffer. It must be greater than or equal to
    * the window_bits value provided when data was compressed (zlib manual).
    */
-  void init(int8_t window_bits);
+  void init(int64_t window_bits);
 
   /**
-   * @return uint64_t CRC-32 if a gzip stream is being written or Adler-32 for other compression
+   * It returns the checksum of all output produced so far. Decompressor's checksum at the end of
+   * the stream has to match compressor's checksum produced at the end of the compression.
+   * @return uint64_t CRC-32 if a gzip stream is being read or Adler-32 for other compression
    * types.
    */
   uint64_t checksum();

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -24,6 +24,7 @@ envoy_cc_library(
     name = "envoy_common_lib",
     deps = [
         "//source/common/compressor:compressor_lib",
+        "//source/common/decompressor:decompressor_lib",
         "//source/common/event:libevent_lib",
         "//source/common/network:utility_lib",
         "//source/common/stats:stats_lib",

--- a/test/common/compressor/zlib_compressor_impl_test.cc
+++ b/test/common/compressor/zlib_compressor_impl_test.cc
@@ -34,7 +34,7 @@ protected:
     Buffer::OwnedImpl input_buffer;
     Buffer::OwnedImpl output_buffer;
     ZlibCompressorImpl compressor;
-    TestUtility::feedBufferWithRandomCharecters(input_buffer, 100);
+    TestUtility::feedBufferWithRandomCharacters(input_buffer, 100);
     compressor.compress(input_buffer, output_buffer);
   }
 };
@@ -55,7 +55,7 @@ TEST_F(ZlibCompressorImplTest, CompressWithSmallChunkMemory) {
                   memory_level);
 
   for (uint64_t i = 0; i < 50; i++) {
-    TestUtility::feedBufferWithRandomCharecters(input_buffer, 4796);
+    TestUtility::feedBufferWithRandomCharacters(input_buffer, 4796);
     compressor.compress(input_buffer, output_buffer);
     input_buffer.drain(4796);
     ASSERT_EQ(0, input_buffer.length());
@@ -93,7 +93,7 @@ TEST_F(ZlibCompressorImplTest, CompressFlushAndCompressMore) {
                   memory_level);
 
   for (uint64_t i = 0; i < 50; i++) {
-    TestUtility::feedBufferWithRandomCharecters(input_buffer, 4796);
+    TestUtility::feedBufferWithRandomCharacters(input_buffer, 4796);
     compressor.compress(input_buffer, temp_buffer);
     input_buffer.drain(4796);
     ASSERT_EQ(0, input_buffer.length());
@@ -107,7 +107,7 @@ TEST_F(ZlibCompressorImplTest, CompressFlushAndCompressMore) {
   output_buffer.move(temp_buffer);
   ASSERT_EQ(0, temp_buffer.length());
 
-  TestUtility::feedBufferWithRandomCharecters(input_buffer, 4796);
+  TestUtility::feedBufferWithRandomCharacters(input_buffer, 4796);
   compressor.compress(input_buffer, temp_buffer);
   input_buffer.drain(4796);
   output_buffer.move(temp_buffer);

--- a/test/common/compressor/zlib_compressor_impl_test.cc
+++ b/test/common/compressor/zlib_compressor_impl_test.cc
@@ -48,8 +48,6 @@ TEST_F(ZlibCompressorImplDeathTest, CompressorTestDeath) {
 }
 
 TEST_F(ZlibCompressorImplTest, CallingChecksum) {
-  const uint64_t expected_checksum{3587466910};
-
   Buffer::OwnedImpl compressor_input_buffer;
   Buffer::OwnedImpl compressor_output_buffer;
 
@@ -65,7 +63,7 @@ TEST_F(ZlibCompressorImplTest, CallingChecksum) {
   compressor.compress(compressor_input_buffer, compressor_output_buffer);
   compressor.flush(compressor_output_buffer);
   compressor_input_buffer.drain(4096);
-  EXPECT_EQ(expected_checksum, compressor.checksum());
+  EXPECT_TRUE(compressor.checksum() > 0);
 }
 
 TEST_F(ZlibCompressorImplTest, CompressWithReducedInternalMemory) {

--- a/test/common/decompressor/BUILD
+++ b/test/common/decompressor/BUILD
@@ -9,12 +9,13 @@ load(
 envoy_package()
 
 envoy_cc_test(
-    name = "compressor_test",
-    srcs = ["zlib_compressor_impl_test.cc"],
+    name = "decompressor_test",
+    srcs = ["zlib_decompressor_impl_test.cc"],
     deps = [
         "//source/common/common:assert_lib",
         "//source/common/common:hex_lib",
         "//source/common/compressor:compressor_lib",
+        "//source/common/decompressor:decompressor_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/common/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/common/decompressor/zlib_decompressor_impl_test.cc
@@ -55,7 +55,7 @@ TEST_F(ZlibDecompressorImplTest, CompressAndDecompress) {
 
   std::string original_text{};
   for (uint64_t i = 0; i < 20; ++i) {
-    TestUtility::feedBufferWithRandomCharacters(compressor_input_buffer, default_input_size * i);
+    TestUtility::feedBufferWithRandomCharacters(compressor_input_buffer, default_input_size * i, i);
     compressor.compress(compressor_input_buffer, compressor_output_buffer);
     original_text.append(TestUtility::bufferToString(compressor_input_buffer));
     compressor_input_buffer.drain(default_input_size * i);
@@ -89,7 +89,7 @@ TEST_F(ZlibDecompressorImplTest, DecompressWithReducedInternalMemory) {
 
   std::string original_text{};
   for (uint64_t i = 0; i < 20; ++i) {
-    TestUtility::feedBufferWithRandomCharacters(input_buffer, default_input_size * i);
+    TestUtility::feedBufferWithRandomCharacters(input_buffer, default_input_size * i, i);
     compressor.compress(input_buffer, output_buffer);
     original_text.append(TestUtility::bufferToString(input_buffer));
     input_buffer.drain(default_input_size * i);
@@ -105,7 +105,7 @@ TEST_F(ZlibDecompressorImplTest, DecompressWithReducedInternalMemory) {
 
   ASSERT_EQ(compressor.checksum(), decompressor.checksum());
   ASSERT_EQ(original_text.length(), decompressed_text.length());
-  ASSERT_EQ(original_text, decompressed_text);
+  EXPECT_EQ(original_text, decompressed_text);
 }
 
 TEST_F(ZlibDecompressorImplTest, CompressDecompressWithUncommonParams) {
@@ -118,7 +118,7 @@ TEST_F(ZlibDecompressorImplTest, CompressDecompressWithUncommonParams) {
 
   std::string original_text{};
   for (uint64_t i = 0; i < 20; ++i) {
-    TestUtility::feedBufferWithRandomCharacters(input_buffer, default_input_size * i);
+    TestUtility::feedBufferWithRandomCharacters(input_buffer, default_input_size * i, i);
     compressor.compress(input_buffer, output_buffer);
     original_text.append(TestUtility::bufferToString(input_buffer));
     input_buffer.drain(default_input_size * i);

--- a/test/common/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/common/decompressor/zlib_decompressor_impl_test.cc
@@ -1,9 +1,4 @@
-#include <string>
-
-#include "envoy/common/exception.h"
-
 #include "common/buffer/buffer_impl.h"
-#include "common/common/assert.h"
 #include "common/common/hex.h"
 #include "common/compressor/zlib_compressor_impl.h"
 #include "common/decompressor/zlib_decompressor_impl.h"
@@ -39,11 +34,18 @@ protected:
   }
 };
 
+/**
+ * Exercises death by passing bad initialization params or by calling
+ * decompress before init.
+ */
 TEST_F(ZlibDecompressorImplDeathTest, DecompressorTestDeath) {
   EXPECT_DEATH(decompressorBadInitTestHelper(100), std::string{"assert failure: result >= 0"});
   EXPECT_DEATH(unitializedDecompressorTestHelper(), std::string{"assert failure: result == Z_OK"});
 }
 
+/**
+ * Exercises decompressor's checksum by calling it before init or decompress.
+ */
 TEST_F(ZlibDecompressorImplTest, CallingChecksum) {
   Buffer::OwnedImpl compressor_input_buffer;
   Buffer::OwnedImpl compressor_output_buffer;
@@ -72,6 +74,10 @@ TEST_F(ZlibDecompressorImplTest, CallingChecksum) {
   EXPECT_EQ(compressor.checksum(), decompressor.checksum());
 }
 
+/**
+ * Exercises compression and decompression by compressing some data, decompressing it and then
+ * comparing compressor's input/checksum with decompressor's output/checksum.
+ */
 TEST_F(ZlibDecompressorImplTest, CompressAndDecompress) {
   Buffer::OwnedImpl compressor_input_buffer;
   Buffer::OwnedImpl compressor_output_buffer;
@@ -106,7 +112,10 @@ TEST_F(ZlibDecompressorImplTest, CompressAndDecompress) {
   EXPECT_EQ(original_text, decompressed_text);
 }
 
-TEST_F(ZlibDecompressorImplTest, DecompressWithReducedInternalMemory) {
+/**
+ * Exercises decompression with a very small output buffer.
+ */
+TEST_F(ZlibDecompressorImplTest, DecompressWithSmallOutputBuffer) {
   Buffer::OwnedImpl input_buffer;
   Buffer::OwnedImpl output_buffer;
 
@@ -136,6 +145,9 @@ TEST_F(ZlibDecompressorImplTest, DecompressWithReducedInternalMemory) {
   EXPECT_EQ(original_text, decompressed_text);
 }
 
+/**
+ * Exercises decompression with other supported zlib initialization params.
+ */
 TEST_F(ZlibDecompressorImplTest, CompressDecompressWithUncommonParams) {
   Buffer::OwnedImpl input_buffer;
   Buffer::OwnedImpl output_buffer;

--- a/test/common/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/common/decompressor/zlib_decompressor_impl_test.cc
@@ -1,0 +1,110 @@
+#include <string>
+
+#include "envoy/common/exception.h"
+
+#include "common/buffer/buffer_impl.h"
+#include "common/common/assert.h"
+#include "common/common/hex.h"
+#include "common/compressor/zlib_compressor_impl.h"
+#include "common/decompressor/zlib_decompressor_impl.h"
+
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Decompressor {
+namespace {
+
+class ZlibDecompressorImplTest : public testing::Test {
+protected:
+  static const int8_t gzip_window_bits{31};
+  static const int8_t memory_level{8};
+};
+
+class ZlibDecompressorImplDeathTest : public ZlibDecompressorImplTest {
+protected:
+  static void decompressorBadInitTestHelper(int8_t window_bits) {
+    ZlibDecompressorImpl decompressor;
+    decompressor.init(window_bits);
+  }
+
+  static void unitializedDecompressorTestHelper() {
+    Buffer::OwnedImpl input_buffer;
+    Buffer::OwnedImpl ouput_buffer;
+    ZlibDecompressorImpl decompressor;
+    TestUtility::feedBufferWithRandomCharecters(input_buffer, 4796);
+    decompressor.decompress(input_buffer, ouput_buffer);
+  }
+};
+
+TEST_F(ZlibDecompressorImplDeathTest, DecompressorTestDeath) {
+  EXPECT_DEATH(decompressorBadInitTestHelper(100), std::string{"assert failure: result >= 0"});
+  EXPECT_DEATH(unitializedDecompressorTestHelper(), std::string{"assert failure: result == Z_OK"});
+}
+
+TEST_F(ZlibDecompressorImplTest, CompressDecompressSymetricTesting) {
+  Buffer::OwnedImpl input_buffer;
+  Buffer::OwnedImpl output_buffer;
+
+  Envoy::Compressor::ZlibCompressorImpl compressor;
+  compressor.init(Envoy::Compressor::ZlibCompressorImpl::CompressionLevel::Standard,
+                  Envoy::Compressor::ZlibCompressorImpl::CompressionStrategy::Standard,
+                  gzip_window_bits, memory_level);
+
+  std::string original_text{};
+  for (uint64_t i = 0; i < 50; ++i) {
+    TestUtility::feedBufferWithRandomCharecters(input_buffer, 4796);
+    compressor.compress(input_buffer, output_buffer);
+    original_text.append(TestUtility::bufferToString(input_buffer));
+    input_buffer.drain(4796);
+  }
+
+  compressor.flush(output_buffer);
+
+  ZlibDecompressorImpl decompressor;
+  decompressor.init(gzip_window_bits);
+  ASSERT_EQ(0, input_buffer.length());
+  decompressor.decompress(output_buffer, input_buffer);
+
+  std::string decompressed_text{TestUtility::bufferToString(input_buffer)};
+
+  ASSERT_EQ(decompressor.checksum(), compressor.checksum());
+  ASSERT_EQ(original_text.length(), decompressed_text.length());
+  ASSERT_EQ(original_text, decompressed_text);
+}
+
+TEST_F(ZlibDecompressorImplTest, CompressWithSmallChunkMemmory) {
+  Buffer::OwnedImpl input_buffer;
+  Buffer::OwnedImpl output_buffer;
+
+  Envoy::Compressor::ZlibCompressorImpl compressor;
+  compressor.init(Envoy::Compressor::ZlibCompressorImpl::CompressionLevel::Standard,
+                  Envoy::Compressor::ZlibCompressorImpl::CompressionStrategy::Standard,
+                  gzip_window_bits, memory_level);
+
+  std::string original_text{};
+  for (uint64_t i = 0; i < 50; ++i) {
+    TestUtility::feedBufferWithRandomCharecters(input_buffer, 4796);
+    compressor.compress(input_buffer, output_buffer);
+    original_text.append(TestUtility::bufferToString(input_buffer));
+    input_buffer.drain(4796);
+  }
+
+  compressor.flush(output_buffer);
+
+  ZlibDecompressorImpl decompressor(768);
+  decompressor.init(gzip_window_bits);
+  ASSERT_EQ(0, input_buffer.length());
+  decompressor.decompress(output_buffer, input_buffer);
+
+  std::string decompressed_text{TestUtility::bufferToString(input_buffer)};
+
+  ASSERT_EQ(decompressor.checksum(), compressor.checksum());
+  ASSERT_EQ(original_text.length(), decompressed_text.length());
+  ASSERT_EQ(original_text, decompressed_text);
+}
+
+} // namespace
+} // namespace Decompressor
+} // namespace Envoy

--- a/test/common/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/common/decompressor/zlib_decompressor_impl_test.cc
@@ -45,8 +45,6 @@ TEST_F(ZlibDecompressorImplDeathTest, DecompressorTestDeath) {
 }
 
 TEST_F(ZlibDecompressorImplTest, CallingChecksum) {
-  const uint64_t expected_checksum{3587466910};
-
   Buffer::OwnedImpl compressor_input_buffer;
   Buffer::OwnedImpl compressor_output_buffer;
 
@@ -62,7 +60,7 @@ TEST_F(ZlibDecompressorImplTest, CallingChecksum) {
   compressor.compress(compressor_input_buffer, compressor_output_buffer);
   compressor.flush(compressor_output_buffer);
   compressor_input_buffer.drain(4096);
-  ASSERT_EQ(expected_checksum, compressor.checksum());
+  ASSERT_TRUE(compressor.checksum() > 0);
 
   ZlibDecompressorImpl decompressor;
   decompressor.init(gzip_window_bits);
@@ -71,7 +69,7 @@ TEST_F(ZlibDecompressorImplTest, CallingChecksum) {
   // compressor_output_buffer becomes decompressor input param.
   // compressor_input_buffer is re-used as decompressor output since it is empty.
   decompressor.decompress(compressor_output_buffer, compressor_input_buffer);
-  EXPECT_EQ(expected_checksum, decompressor.checksum());
+  EXPECT_EQ(compressor.checksum(), decompressor.checksum());
 }
 
 TEST_F(ZlibDecompressorImplTest, CompressAndDecompress) {

--- a/test/common/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/common/decompressor/zlib_decompressor_impl_test.cc
@@ -33,7 +33,7 @@ protected:
     Buffer::OwnedImpl input_buffer;
     Buffer::OwnedImpl ouput_buffer;
     ZlibDecompressorImpl decompressor;
-    TestUtility::feedBufferWithRandomCharecters(input_buffer, 4796);
+    TestUtility::feedBufferWithRandomCharacters(input_buffer, 100);
     decompressor.decompress(input_buffer, ouput_buffer);
   }
 };
@@ -54,7 +54,7 @@ TEST_F(ZlibDecompressorImplTest, CompressDecompressSymetricTesting) {
 
   std::string original_text{};
   for (uint64_t i = 0; i < 50; ++i) {
-    TestUtility::feedBufferWithRandomCharecters(input_buffer, 4796);
+    TestUtility::feedBufferWithRandomCharacters(input_buffer, 4796);
     compressor.compress(input_buffer, output_buffer);
     original_text.append(TestUtility::bufferToString(input_buffer));
     input_buffer.drain(4796);
@@ -85,7 +85,7 @@ TEST_F(ZlibDecompressorImplTest, CompressWithSmallChunkMemmory) {
 
   std::string original_text{};
   for (uint64_t i = 0; i < 50; ++i) {
-    TestUtility::feedBufferWithRandomCharecters(input_buffer, 4796);
+    TestUtility::feedBufferWithRandomCharacters(input_buffer, 4796);
     compressor.compress(input_buffer, output_buffer);
     original_text.append(TestUtility::bufferToString(input_buffer));
     input_buffer.drain(4796);

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -80,14 +80,14 @@ std::string TestUtility::bufferToString(const Buffer::Instance& buffer) {
   return output;
 }
 
-void TestUtility::feedBufferWithRandomCharacters(Buffer::Instance& buffer, uint64_t n_bytes) {
-  std::string const chars = "abcdefghijklmnaoqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
-  std::random_device rd;
-  std::mt19937 generate(rd());
-  std::uniform_int_distribution<> distribute(1, chars.length() - 1);
+void TestUtility::feedBufferWithRandomCharacters(Buffer::Instance& buffer, uint64_t n_bytes,
+                                                 uint64_t seed) {
+  std::string const sample = "Neque porro quisquam est qui dolorem ipsum..";
+  std::mt19937 generate(seed);
+  std::uniform_int_distribution<> distribute(1, sample.length() - 1);
   std::string str{};
   for (uint64_t n = 0; n < n_bytes; ++n) {
-    str += chars.at(distribute(generate));
+    str += sample.at(distribute(generate));
   }
   buffer.add(str);
 }

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -80,7 +80,7 @@ std::string TestUtility::bufferToString(const Buffer::Instance& buffer) {
   return output;
 }
 
-void TestUtility::feedBufferWithRandomCharecters(Buffer::Instance& buffer, uint64_t n_bytes) {
+void TestUtility::feedBufferWithRandomCharacters(Buffer::Instance& buffer, uint64_t n_bytes) {
   std::string const chars = "abcdefghijklmnaoqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
   std::random_device rd;
   std::mt19937 generate(rd());

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -80,13 +80,13 @@ std::string TestUtility::bufferToString(const Buffer::Instance& buffer) {
   return output;
 }
 
-void TestUtility::feedBufferWithRandomCharacters(Buffer::Instance& buffer, uint64_t n_bytes,
+void TestUtility::feedBufferWithRandomCharacters(Buffer::Instance& buffer, uint64_t n_char,
                                                  uint64_t seed) {
-  std::string const sample = "Neque porro quisquam est qui dolorem ipsum..";
+  const std::string sample = "Neque porro quisquam est qui dolorem ipsum..";
   std::mt19937 generate(seed);
   std::uniform_int_distribution<> distribute(1, sample.length() - 1);
   std::string str{};
-  for (uint64_t n = 0; n < n_bytes; ++n) {
+  for (uint64_t n = 0; n < n_char; ++n) {
     str += sample.at(distribute(generate));
   }
   buffer.add(str);

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -80,6 +80,18 @@ std::string TestUtility::bufferToString(const Buffer::Instance& buffer) {
   return output;
 }
 
+void TestUtility::feedBufferWithRandomCharecters(Buffer::Instance& buffer, uint64_t n_bytes) {
+  std::string const chars = "abcdefghijklmnaoqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+  std::random_device rd;
+  std::mt19937 generate(rd());
+  std::uniform_int_distribution<> distribute(1, chars.length() - 1);
+  std::string str{};
+  for (uint64_t n = 0; n < n_bytes; ++n) {
+    str += chars.at(distribute(generate));
+  }
+  buffer.add(str);
+}
+
 Stats::CounterSharedPtr TestUtility::findCounter(Stats::Store& store, const std::string& name) {
   for (auto counter : store.counters()) {
     if (counter->name() == name) {

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -68,7 +68,7 @@ public:
   /**
    * Feed a buffer with random characters.
    * @param buffer supplies the buffer to be fed.
-   * @param n_bytes amount of bytes that should be add to the supplied buffer.
+   * @param n_bytes amount of bytes that should be added to the supplied buffer.
    */
   static void feedBufferWithRandomCharacters(Buffer::Instance& buffer, uint64_t n_bytes);
 

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -69,7 +69,7 @@ public:
    * Feed a buffer with random characters.
    * @param buffer supplies the buffer to be fed.
    * @param n_char number of characters that should be added to the supplied buffer.
-   * @param seed seeds pseudo-random number genarator (dafault = 0).
+   * @param seed seeds pseudo-random number genarator (default = 0).
    */
   static void feedBufferWithRandomCharacters(Buffer::Instance& buffer, uint64_t n_char,
                                              uint64_t seed = 0);

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -70,7 +70,7 @@ public:
    * @param buffer supplies the buffer to be fed.
    * @param n_bytes amount of bytes that should be add to the supplied buffer.
    */
-  static void feedBufferWithRandomCharecters(Buffer::Instance& buffer, uint64_t n_bytes);
+  static void feedBufferWithRandomCharacters(Buffer::Instance& buffer, uint64_t n_bytes);
 
   /**
    * Find a counter in a stats store.

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -68,10 +68,10 @@ public:
   /**
    * Feed a buffer with random characters.
    * @param buffer supplies the buffer to be fed.
-   * @param n_bytes amount of bytes that should be added to the supplied buffer.
-   * @param seed sets random number genarator seed (dafault = 0).
+   * @param n_char number of characters that should be added to the supplied buffer.
+   * @param seed seeds pseudo-random number genarator (dafault = 0).
    */
-  static void feedBufferWithRandomCharacters(Buffer::Instance& buffer, uint64_t n_bytes,
+  static void feedBufferWithRandomCharacters(Buffer::Instance& buffer, uint64_t n_char,
                                              uint64_t seed = 0);
 
   /**

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -69,8 +69,10 @@ public:
    * Feed a buffer with random characters.
    * @param buffer supplies the buffer to be fed.
    * @param n_bytes amount of bytes that should be added to the supplied buffer.
+   * @param seed sets random number genarator seed (dafault = 0).
    */
-  static void feedBufferWithRandomCharacters(Buffer::Instance& buffer, uint64_t n_bytes);
+  static void feedBufferWithRandomCharacters(Buffer::Instance& buffer, uint64_t n_bytes,
+                                             uint64_t seed = 0);
 
   /**
    * Find a counter in a stats store.

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -66,6 +66,13 @@ public:
   static std::string bufferToString(const Buffer::Instance& buffer);
 
   /**
+   * Feed a buffer with random characters.
+   * @param buffer supplies the buffer to be fed.
+   * @param n_bytes amount of bytes that should be add to the supplied buffer.
+   */
+  static void feedBufferWithRandomCharecters(Buffer::Instance& buffer, uint64_t n_bytes);
+
+  /**
    * Find a counter in a stats store.
    * @param store supplies the stats store.
    * @param name supplies the name to search for.


### PR DESCRIPTION
Signed-off-by: Gabriel <gsagula@gmail.com>

*Description*:

This PR implements decompressor interface, modifies the currently compressor implementation and also includes symmetric testing. Current compressor implementation has an issue when output buffer is completely moved. This has been fixed by changing the way that memory is allocated internally by the compressor and also how compressed data is add to the output buffer. Member function `finish`  has been renamed to "flush" which better describes the behaviour. Member function `checksum` has been added to compressor to facilitate tests at this point. Decompressor interface has been implemented to allow symmetric testing. Symmetric testing has been added to assert that both compressor and decompressor work properly.

*Risk Level*: Low (libraries are not being used and it has good testing coverage)
 
*Testing*: Unit