### PR TITLE
validation server: add ValidationDispatcher to the ValidationAsyncClient

### DIFF
--- a/source/server/config_validation/BUILD
+++ b/source/server/config_validation/BUILD
@@ -31,6 +31,7 @@ envoy_cc_library(
     srcs = ["async_client.cc"],
     hdrs = ["async_client.h"],
     deps = [
+        ":dispatcher_lib",
         "//include/envoy/http:async_client_interface",
         "//include/envoy/http:message_interface",
         "//source/common/common:assert_lib",

--- a/source/server/config_validation/async_client.h
+++ b/source/server/config_validation/async_client.h
@@ -7,6 +7,8 @@
 
 #include "common/common/assert.h"
 
+#include "server/config_validation/dispatcher.h"
+
 namespace Envoy {
 namespace Http {
 
@@ -23,7 +25,10 @@ public:
   AsyncClient::Stream* start(StreamCallbacks& callbacks,
                              const Optional<std::chrono::milliseconds>& timeout,
                              bool buffer_body_for_retry) override;
-  Event::Dispatcher& dispatcher() override { NOT_IMPLEMENTED; }
+  Event::Dispatcher& dispatcher() override { return dispatcher_; }
+
+private:
+  Event::ValidationDispatcher dispatcher_;
 };
 
 } // namespace Http


### PR DESCRIPTION
Signed-off-by: Jose Nino <jnino@lyft.com>

validation server: add ValidationDispatcher to the ValidationAsyncClient

*Description*: if people want to run the server on validate mode with xDS V2, e.g RDS with GRPC, the validation server will crash because the grpc mux initialization requires a dispatcher ref when initializing the AsyncStream. Right now the call for a dispatcher is not implemented in the ValidationAsyncClient. This PR adds a ValidationDispatcher instance to the ValidationAsyncClient.

*Risk Level*: Low.

*Testing*: ran the server in validation mode against a config that required V2 GRPC RDS successfully.
