### PR TITLE
tls: do not allow flush close if handshake has not completed

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -124,7 +124,7 @@ void ConnectionImpl::close(ConnectionCloseType type) {
 
   uint64_t data_to_write = write_buffer_->length();
   ENVOY_CONN_LOG(debug, "closing data_to_write={} type={}", *this, data_to_write, enumToInt(type));
-  if (data_to_write == 0 || type == ConnectionCloseType::NoFlush) {
+  if (data_to_write == 0 || type == ConnectionCloseType::NoFlush || !canFlushClose()) {
     if (data_to_write > 0) {
       // We aren't going to wait to flush, but try to write as much as we can if there is pending
       // data.

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -92,6 +92,7 @@ protected:
     uint64_t bytes_processed_;
   };
 
+  virtual bool canFlushClose() { return true; }
   virtual void closeSocket(ConnectionEvent close_type);
   void doConnect();
   void raiseEvent(ConnectionEvent event);

--- a/source/common/ssl/connection_impl.h
+++ b/source/common/ssl/connection_impl.h
@@ -42,6 +42,7 @@ private:
   std::string getUriSanFromCertificate(X509* cert);
 
   // Network::ConnectionImpl
+  bool canFlushClose() override { return handshake_complete_; }
   void closeSocket(Network::ConnectionEvent close_type) override;
   IoResult doReadFromSocket() override;
   IoResult doWriteToSocket() override;

--- a/test/common/ssl/connection_impl_test.cc
+++ b/test/common/ssl/connection_impl_test.cc
@@ -327,6 +327,58 @@ TEST_P(SslConnectionImplTest, FailedClientAuthHashVerification) {
            GetParam());
 }
 
+// Make sure that we do not flush code and do an immediate close if we have not completed the
+// handshake.
+TEST_P(SslConnectionImplTest, FlushCloseDuringHandshake) {
+  Stats::IsolatedStoreImpl stats_store;
+  Runtime::MockLoader runtime;
+
+  std::string server_ctx_json = R"EOF(
+  {
+    "cert_chain_file": "{{ test_tmpdir }}/unittestcert.pem",
+    "private_key_file": "{{ test_tmpdir }}/unittestkey.pem",
+    "ca_cert_file": "{{ test_rundir }}/test/common/ssl/test_data/ca_certificates.pem"
+  }
+  )EOF";
+
+  Json::ObjectSharedPtr server_ctx_loader = TestEnvironment::jsonLoadFromString(server_ctx_json);
+  ServerContextConfigImpl server_ctx_config(*server_ctx_loader);
+  ContextManagerImpl manager(runtime);
+  ServerContextPtr server_ctx(manager.createSslServerContext(stats_store, server_ctx_config));
+
+  Event::DispatcherImpl dispatcher;
+  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(GetParam()), true);
+  Network::MockListenerCallbacks callbacks;
+  Network::MockConnectionHandler connection_handler;
+  Network::ListenerPtr listener =
+      dispatcher.createSslListener(connection_handler, *server_ctx, socket, callbacks, stats_store,
+                                   Network::ListenerOptions::listenerOptionsWithBindToPort());
+
+  Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
+      socket.localAddress(), Network::Address::InstanceConstSharedPtr());
+  client_connection->connect();
+  Network::MockConnectionCallbacks client_connection_callbacks;
+  client_connection->addConnectionCallbacks(client_connection_callbacks);
+
+  Network::ConnectionPtr server_connection;
+  Network::MockConnectionCallbacks server_connection_callbacks;
+  EXPECT_CALL(callbacks, onNewConnection_(_))
+      .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
+        server_connection = std::move(conn);
+        server_connection->addConnectionCallbacks(server_connection_callbacks);
+        Buffer::OwnedImpl data("hello");
+        server_connection->write(data);
+        server_connection->close(Network::ConnectionCloseType::FlushWrite);
+      }));
+
+  EXPECT_CALL(server_connection_callbacks, onEvent(Network::ConnectionEvent::LocalClose));
+  EXPECT_CALL(client_connection_callbacks, onEvent(Network::ConnectionEvent::Connected));
+  EXPECT_CALL(client_connection_callbacks, onEvent(Network::ConnectionEvent::RemoteClose))
+      .WillOnce(Invoke([&](Network::ConnectionEvent) -> void { dispatcher.exit(); }));
+
+  dispatcher.run(Event::Dispatcher::RunType::Block);
+}
+
 TEST_P(SslConnectionImplTest, ClientAuthMultipleCAs) {
   Stats::IsolatedStoreImpl stats_store;
   Runtime::MockLoader runtime;


### PR DESCRIPTION
*Description*:
Though we could support flush close if the handshake has not
been completed, it would require larger changes. This PR makes
it so that Envoy does not hang when a flush close is attempted
on a TLS connection that has not completed its handshake.

Fixes https://github.com/envoyproxy/envoy/issues/1928

*Risk Level*: Low 

*Testing*: UT