### PR TITLE
mongo: add runtime feature flag for drain close behavior

### DIFF
--- a/docs/configuration/network_filters/mongo_proxy_filter.rst
+++ b/docs/configuration/network_filters/mongo_proxy_filter.rst
@@ -179,6 +179,10 @@ mongo.logging_enabled
   % of messages that will be logged. Defaults to 100. If less than 100, queries may be logged
   without replies, etc.
 
+mongo.mongo.drain_close_enabled
+  % of connections that will be drain closed if the server is draining and would otherwise
+  attempt a drain close. Defaults to 100.
+
 mongo.fault.fixed_delay.percent
   Probability of an eligible MongoDB operation to be affected by
   the injected fault when there is no active fault.

--- a/source/common/mongo/proxy.cc
+++ b/source/common/mongo/proxy.cc
@@ -185,7 +185,8 @@ void ProxyFilter::decodeReply(ReplyMessagePtr&& message) {
     break;
   }
 
-  if (active_query_list_.empty() && drain_decision_.drainClose()) {
+  if (active_query_list_.empty() && drain_decision_.drainClose() &&
+      runtime_.snapshot().featureEnabled(MongoRuntimeConfig::get().DrainCloseEnabled, 100)) {
     ENVOY_LOG(debug, "drain closing mongo connection");
     stats_.cx_drain_close_.inc();
 

--- a/source/common/mongo/proxy.h
+++ b/source/common/mongo/proxy.h
@@ -36,6 +36,7 @@ public:
   const std::string LoggingEnabled{"mongo.logging_enabled"};
   const std::string ProxyEnabled{"mongo.proxy_enabled"};
   const std::string ConnectionLoggingEnabled{"mongo.connection_logging_enabled"};
+  const std::string DrainCloseEnabled{"mongo.drain_close_enabled"};
 };
 
 typedef ConstSingleton<MongoRuntimeConfigKeys> MongoRuntimeConfig;

--- a/test/common/mongo/proxy_test.cc
+++ b/test/common/mongo/proxy_test.cc
@@ -430,6 +430,8 @@ TEST_F(MongoProxyFilterTest, ConcurrentQueryWithDrainClose) {
     message->flags(0b11);
     message->cursorId(1);
     message->documents().push_back(Bson::DocumentImpl::create()->addString("hello", "world"));
+    ON_CALL(runtime_.snapshot_, featureEnabled("mongo.drain_close_enabled", 100))
+        .WillByDefault(Return(true));
     EXPECT_CALL(drain_decision_, drainClose()).WillOnce(Return(true));
     drain_timer = new Event::MockTimer(&read_filter_callbacks_.connection_.dispatcher_);
     EXPECT_CALL(*drain_timer, enableTimer(std::chrono::milliseconds(0)));


### PR DESCRIPTION
*Description*:
There are some issues in Lyft's environment related to this feature.
I need to do further work on draining in general but that is going
to take me several days. This is a short term fix and seems fine to
have this control here in either case.

Note that I will add better documentation on draining as an overall
topic when I do the draining follow ups.

*Risk Level*: Low 

*Testing*: UT only