### PR TITLE
stats: add prometheus formatted stats in the admin endpoint

### DIFF
--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -301,7 +301,9 @@ Http::Code AdminImpl::handlerStats(const std::string& url, Buffer::Instance& res
     const std::string format_key = params.begin()->first;
     const std::string format_value = params.begin()->second;
     if (format_key == "format" && format_value == "json") {
-      response.add(statsAsJson(all_stats));
+      response.add(AdminImpl::statsAsJson(all_stats));
+    } else if (format_key == "format" && format_value == "prometheus") {
+      AdminImpl::statsAsPrometheus(server_.stats().counters(), server_.stats().gauges(), response);
     } else {
       response.add("usage: /stats?format=json \n");
       response.add("\n");
@@ -309,6 +311,31 @@ Http::Code AdminImpl::handlerStats(const std::string& url, Buffer::Instance& res
     }
   }
   return rc;
+}
+
+std::string AdminImpl::formatTagsForPrometheus(const std::vector<Stats::Tag>& tags) {
+  std::vector<std::string> buf;
+  for (const Stats::Tag& tag : tags) {
+    buf.push_back(fmt::format("{}={}", tag.name_, tag.value_));
+  }
+  return StringUtil::join(buf, ",");
+}
+
+void AdminImpl::statsAsPrometheus(const std::list<Stats::CounterSharedPtr>& counters,
+                                  const std::list<Stats::GaugeSharedPtr>& gauges,
+                                  Buffer::Instance& response) {
+  for (const auto& counter : counters) {
+    const std::string tags = AdminImpl::formatTagsForPrometheus(counter->tags());
+    response.add(fmt::format("# TYPE {0} counter\n", counter->tagExtractedName()));
+    response.add(
+        fmt::format("{0}{{{1}}} {2}\n", counter->tagExtractedName(), tags, counter->value()));
+  }
+
+  for (const auto& gauge : gauges) {
+    const std::string tags = AdminImpl::formatTagsForPrometheus(gauge->tags());
+    response.add(fmt::format("# TYPE {0} gauge\n", gauge->tagExtractedName()));
+    response.add(fmt::format("{0}{{{1}}} {2}\n", gauge->tagExtractedName(), tags, gauge->value()));
+  }
 }
 
 std::string AdminImpl::statsAsJson(const std::map<std::string, uint64_t>& all_stats) {

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -113,7 +113,11 @@ private:
   void addOutlierInfo(const std::string& cluster_name,
                       const Upstream::Outlier::Detector* outlier_detector,
                       Buffer::Instance& response);
-  std::string statsAsJson(const std::map<std::string, uint64_t>& all_stats);
+  static std::string statsAsJson(const std::map<std::string, uint64_t>& all_stats);
+  static void statsAsPrometheus(const std::list<Stats::CounterSharedPtr>& counters,
+                                const std::list<Stats::GaugeSharedPtr>& gauges,
+                                Buffer::Instance& response);
+  static std::string formatTagsForPrometheus(const std::vector<Stats::Tag>& tags);
 
   /**
    * URL handlers.

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -119,6 +119,18 @@ TEST_P(IntegrationAdminTest, Admin) {
   Json::ObjectSharedPtr statsjson = Json::Factory::loadFromString(response->body());
   EXPECT_TRUE(statsjson->hasObject("stats"));
 
+  response = IntegrationUtil::makeSingleRequest(
+      lookupPort("admin"), "GET", "/stats?format=prometheus", "", downstreamProtocol(), version_);
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_THAT(response->body(),
+              testing::HasSubstr("http.downstream_rq{envoy.response_code_class=4xx,envoy.http_conn_"
+                                 "manager_prefix=admin} 4\n"));
+  EXPECT_THAT(response->body(), testing::HasSubstr("# TYPE http.downstream_rq counter\n"));
+  EXPECT_THAT(response->body(),
+              testing::HasSubstr("cluster.upstream_cx_active{envoy.cluster_name=cds} 0\n"));
+  EXPECT_THAT(response->body(), testing::HasSubstr("# TYPE cluster.upstream_cx_active gauge\n"));
+
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/clusters", "",
                                                 downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());


### PR DESCRIPTION
*Description*: Adding /metric endpoint that returns prometheus formatted stats described [here](https://prometheus.io/docs/instrumenting/exposition_formats/). This endpoint only handles counters and gauges.

Part of https://github.com/envoyproxy/envoy/issues/1947

*Risk Level*: Low 

*Testing*: integration tests

Signed-off-by: Lita Cho <lcho@lyft.com>