### PR TITLE
build: check format fix functionality

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -68,6 +68,7 @@ def checkProtobufExternalDeps(file_path):
       return False
     return True
 
+
 def isBuildFile(file_path):
   basename = os.path.basename(file_path)
   if basename in {"BUILD", "BUILD.bazel"} or basename.endswith(".BUILD"):

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -68,12 +68,9 @@ def checkProtobufExternalDeps(file_path):
       return False
     return True
 
-
 def isBuildFile(file_path):
   basename = os.path.basename(file_path)
-  if basename in ["BUILD", "BUILD.bazel"]:
-    return True
-  if basename.endswith(".BUILD"):
+  if basename in {"BUILD", "BUILD.bazel"} or basename.endswith(".BUILD"):
     return True
   return False
 
@@ -101,7 +98,7 @@ def checkFilePath(file_path):
 
 
 def fixFilePath(file_path):
-  if os.path.basename(file_path) == "BUILD":
+  if isBuildFile(file_path):
     if os.system("%s %s %s" % (ENVOY_BUILD_FIXER_PATH, file_path, file_path)) != 0:
       printError("envoy_build_fixer rewrite failed for file: %s" % file_path)
     if os.system("%s -mode=fix %s" % (BUILDIFIER_PATH, file_path)) != 0:


### PR DESCRIPTION
This function was used in `checkFilePath` but not `fixFilePath`.

Signed-off-by: Daniel Hochman <danielhochman@users.noreply.github.com>