### PR TITLE
server: change default loglevel to 'info', change some message levels to tune the noise

### DIFF
--- a/source/common/event/dispatched_thread.cc
+++ b/source/common/event/dispatched_thread.cc
@@ -25,11 +25,11 @@ void DispatchedThreadImpl::exit() {
 }
 
 void DispatchedThreadImpl::threadRoutine(Server::GuardDog& guard_dog) {
-  ENVOY_LOG(info, "dispatched thread entering dispatch loop");
+  ENVOY_LOG(debug, "dispatched thread entering dispatch loop");
   auto watchdog = guard_dog.createWatchDog(Thread::Thread::currentThreadId());
   watchdog->startWatchdog(*dispatcher_);
   dispatcher_->run(Dispatcher::RunType::Block);
-  ENVOY_LOG(info, "dispatched thread exited dispatch loop");
+  ENVOY_LOG(debug, "dispatched thread exited dispatch loop");
   guard_dog.stopWatching(watchdog);
 
   watchdog.reset();

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -114,7 +114,7 @@ TcpProxyStats TcpProxyConfig::generateStats(const std::string& name, Stats::Scop
 
 void TcpProxy::initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) {
   read_callbacks_ = &callbacks;
-  ENVOY_CONN_LOG(info, "new tcp proxy session", read_callbacks_->connection());
+  ENVOY_CONN_LOG(debug, "new tcp proxy session", read_callbacks_->connection());
   config_->stats().downstream_cx_total_.inc();
   read_callbacks_->connection().addConnectionCallbacks(downstream_callbacks_);
   read_callbacks_->connection().setConnectionStats(

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -20,7 +20,7 @@ CodecClient::CodecClient(Type type, Network::ClientConnectionPtr&& connection,
   connection_->addConnectionCallbacks(*this);
   connection_->addReadFilter(Network::ReadFilterSharedPtr{new CodecReadFilter(*this)});
 
-  ENVOY_CONN_LOG(info, "connecting", *connection_);
+  ENVOY_CONN_LOG(debug, "connecting", *connection_);
   connection_->connect();
 
   // We just universally set no delay on connections. Theoretically we might at some point want

--- a/source/common/router/rds_subscription.cc
+++ b/source/common/router/rds_subscription.cc
@@ -64,7 +64,7 @@ void RdsSubscription::onFetchFailure(const EnvoyException* e) {
   if (e) {
     ENVOY_LOG(warn, "rds: fetch failure: {}", e->what());
   } else {
-    ENVOY_LOG(info, "rds: fetch failure: network error");
+    ENVOY_LOG(debug, "rds: fetch failure: network error");
   }
 }
 

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -47,14 +47,14 @@ void CdsApiImpl::onConfigUpdate(const ResourceVector& resources) {
     const std::string cluster_name = cluster.name();
     clusters_to_remove.erase(cluster_name);
     if (cm_.addOrUpdatePrimaryCluster(cluster)) {
-      ENVOY_LOG(info, "cds: add/update cluster '{}'", cluster_name);
+      ENVOY_LOG(debug, "cds: add/update cluster '{}'", cluster_name);
     }
   }
 
   for (auto cluster : clusters_to_remove) {
     const std::string cluster_name = cluster.first;
     if (cm_.removePrimaryCluster(cluster_name)) {
-      ENVOY_LOG(info, "cds: remove cluster '{}'", cluster_name);
+      ENVOY_LOG(debug, "cds: remove cluster '{}'", cluster_name);
     }
   }
 

--- a/source/common/upstream/cds_subscription.cc
+++ b/source/common/upstream/cds_subscription.cc
@@ -67,7 +67,7 @@ void CdsSubscription::onFetchFailure(const EnvoyException* e) {
   if (e) {
     ENVOY_LOG(warn, "cds: fetch failure: {}", e->what());
   } else {
-    ENVOY_LOG(info, "cds: fetch failure: network error");
+    ENVOY_LOG(debug, "cds: fetch failure: network error");
   }
 }
 

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -58,7 +58,7 @@ void ClusterManagerInitHelper::addCluster(Cluster& cluster) {
     }
   }
 
-  ENVOY_LOG(info, "cm init: adding: cluster={} primary={} secondary={}", cluster.info()->name(),
+  ENVOY_LOG(debug, "cm init: adding: cluster={} primary={} secondary={}", cluster.info()->name(),
             primary_init_clusters_.size(), secondary_init_clusters_.size());
 }
 
@@ -80,7 +80,7 @@ void ClusterManagerInitHelper::removeCluster(Cluster& cluster) {
   // It is possible that the cluster we are removing has already been initialized, and is not
   // present in the initializer list. If so, this is fine.
   cluster_list->remove(&cluster);
-  ENVOY_LOG(info, "cm init: init complete: cluster={} primary={} secondary={}",
+  ENVOY_LOG(debug, "cm init: init complete: cluster={} primary={} secondary={}",
             cluster.info()->name(), primary_init_clusters_.size(), secondary_init_clusters_.size());
   maybeFinishInitialize();
 }

--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -42,7 +42,7 @@ int main(int argc, char** argv) {
   };
 #endif
 
-  Envoy::OptionsImpl options(argc, argv, hot_restart_version_cb, spdlog::level::warn);
+  Envoy::OptionsImpl options(argc, argv, hot_restart_version_cb, spdlog::level::info);
 
   return Envoy::main_common(options);
 }

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -224,8 +224,8 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     const ProtobufTypes::String& string_name = filters[i].name();
     const auto& proto_config = filters[i];
 
-    ENVOY_LOG(info, "    filter #{}", i);
-    ENVOY_LOG(info, "      name: {}", string_name);
+    ENVOY_LOG(debug, "    filter #{}", i);
+    ENVOY_LOG(debug, "      name: {}", string_name);
 
     const Json::ObjectSharedPtr filter_config =
         MessageUtil::getJsonObjectFromMessage(proto_config.config());

--- a/source/server/config/stats/statsd.cc
+++ b/source/server/config/stats/statsd.cc
@@ -22,13 +22,13 @@ Stats::SinkPtr StatsdSinkFactory::createStatsSink(const Protobuf::Message& confi
   case envoy::api::v2::StatsdSink::kAddress: {
     Network::Address::InstanceConstSharedPtr address =
         Network::Address::resolveProtoAddress(statsd_sink.address());
-    ENVOY_LOG(info, "statsd UDP ip address: {}", address->asString());
+    ENVOY_LOG(debug, "statsd UDP ip address: {}", address->asString());
     return Stats::SinkPtr(
         new Stats::Statsd::UdpStatsdSink(server.threadLocal(), std::move(address)));
     break;
   }
   case envoy::api::v2::StatsdSink::kTcpClusterName:
-    ENVOY_LOG(info, "statsd TCP cluster: {}", statsd_sink.tcp_cluster_name());
+    ENVOY_LOG(debug, "statsd TCP cluster: {}", statsd_sink.tcp_cluster_name());
     return Stats::SinkPtr(new Stats::Statsd::TcpStatsdSink(
         server.localInfo(), statsd_sink.tcp_cluster_name(), server.threadLocal(),
         server.clusterManager(), server.stats()));

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -44,7 +44,7 @@ void MainImpl::initialize(const envoy::api::v2::Bootstrap& bootstrap, Instance& 
   const auto& listeners = bootstrap.static_resources().listeners();
   ENVOY_LOG(info, "loading {} listener(s)", listeners.size());
   for (ssize_t i = 0; i < listeners.size(); i++) {
-    ENVOY_LOG(info, "listener #{}:", i);
+    ENVOY_LOG(debug, "listener #{}:", i);
     server.listenerManager().addOrUpdateListener(listeners[i]);
   }
 

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -55,7 +55,7 @@ void ConnectionHandlerImpl::stopListeners() {
 }
 
 void ConnectionHandlerImpl::ActiveListener::removeConnection(ActiveConnection& connection) {
-  ENVOY_CONN_LOG_TO_LOGGER(parent_.logger_, info, "adding to cleanup list",
+  ENVOY_CONN_LOG_TO_LOGGER(parent_.logger_, debug, "adding to cleanup list",
                            *connection.connection_);
   ActiveConnectionPtr removed = connection.removeFromList(connections_);
   parent_.dispatcher_.deferredDelete(std::move(removed));
@@ -126,7 +126,7 @@ ConnectionHandlerImpl::findListenerByAddress(const Network::Address::Instance& a
 
 void ConnectionHandlerImpl::ActiveListener::onNewConnection(
     Network::ConnectionPtr&& new_connection) {
-  ENVOY_CONN_LOG_TO_LOGGER(parent_.logger_, info, "new connection", *new_connection);
+  ENVOY_CONN_LOG_TO_LOGGER(parent_.logger_, debug, "new connection", *new_connection);
   bool empty_filter_chain = !factory_.createFilterChain(*new_connection);
 
   // If the connection is already closed, we can just let this connection immediately die.
@@ -134,7 +134,7 @@ void ConnectionHandlerImpl::ActiveListener::onNewConnection(
     // Close the connection if the filter chain is empty to avoid leaving open connections
     // with nothing to do.
     if (empty_filter_chain) {
-      ENVOY_CONN_LOG_TO_LOGGER(parent_.logger_, info, "closing connection: no filters",
+      ENVOY_CONN_LOG_TO_LOGGER(parent_.logger_, debug, "closing connection: no filters",
                                *new_connection);
       new_connection->close(Network::ConnectionCloseType::NoFlush);
     } else {

--- a/source/server/drain_manager_impl.cc
+++ b/source/server/drain_manager_impl.cc
@@ -59,7 +59,7 @@ void DrainManagerImpl::startParentShutdownSequence() {
   ASSERT(!parent_shutdown_timer_);
   parent_shutdown_timer_ = server_.dispatcher().createTimer([this]() -> void {
     // Shut down the parent now. It should have already been draining.
-    ENVOY_LOG(warn, "shutting down parent after drain");
+    ENVOY_LOG(info, "shutting down parent after drain");
     server_.hotRestart().terminateParent();
   });
 

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -422,7 +422,7 @@ void HotRestartImpl::onSocketEvent() {
     }
 
     case RpcMessageType::TerminateRequest: {
-      ENVOY_LOG(warn, "shutting down due to child request");
+      ENVOY_LOG(info, "shutting down due to child request");
       kill(getpid(), SIGTERM);
       break;
     }

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -369,7 +369,7 @@ Http::Code AdminImpl::handlerCerts(const std::string&, Buffer::Instance& respons
 
 void AdminFilter::onComplete() {
   std::string path = request_headers_->Path()->value().c_str();
-  ENVOY_STREAM_LOG(info, "request complete: path: {}", *callbacks_, path);
+  ENVOY_STREAM_LOG(debug, "request complete: path: {}", *callbacks_, path);
 
   Buffer::OwnedImpl response;
   Http::Code code = parent_.runCallback(path, response);

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -26,8 +26,8 @@ ProdListenerComponentFactory::createFilterFactoryList_(
     const auto& proto_config = filters[i];
     const ProtobufTypes::String string_type = proto_config.deprecated_v1().type();
     const ProtobufTypes::String string_name = proto_config.name();
-    ENVOY_LOG(info, "  filter #{}:", i);
-    ENVOY_LOG(info, "    name: {}", string_name);
+    ENVOY_LOG(debug, "  filter #{}:", i);
+    ENVOY_LOG(debug, "    name: {}", string_name);
     const Json::ObjectSharedPtr filter_config =
         MessageUtil::getJsonObjectFromMessage(proto_config.config());
 
@@ -58,7 +58,7 @@ ProdListenerComponentFactory::createListenSocket(Network::Address::InstanceConst
   const std::string addr = fmt::format("tcp://{}", address->asString());
   const int fd = server_.hotRestart().duplicateParentListenSocket(addr);
   if (fd != -1) {
-    ENVOY_LOG(info, "obtained socket for address {} from parent", addr);
+    ENVOY_LOG(debug, "obtained socket for address {} from parent", addr);
     return std::make_shared<Network::TcpListenSocket>(fd, address);
   } else {
     return std::make_shared<Network::TcpListenSocket>(address, bind_to_port);
@@ -124,8 +124,8 @@ bool ListenerImpl::drainClose() const {
   return local_drain_manager_->drainClose() || parent_.server_.drainManager().drainClose();
 }
 
-void ListenerImpl::infoLog(const std::string& message) {
-  ENVOY_LOG(info, "{}: name={}, hash={}, address={}", message, name_, hash_, address_->asString());
+void ListenerImpl::debugLog(const std::string& message) {
+  ENVOY_LOG(debug, "{}: name={}, hash={}, address={}", message, name_, hash_, address_->asString());
 }
 
 void ListenerImpl::initialize() {
@@ -216,7 +216,7 @@ bool ListenerManagerImpl::addOrUpdateListener(const envoy::api::v2::Listener& co
   if (existing_warming_listener != warming_listeners_.end()) {
     // In this case we can just replace inline.
     ASSERT(workers_started_);
-    new_listener->infoLog("update warming listener");
+    new_listener->debugLog("update warming listener");
     new_listener->setSocket((*existing_warming_listener)->getSocket());
     *existing_warming_listener = std::move(new_listener);
   } else if (existing_active_listener != active_listeners_.end()) {
@@ -224,10 +224,10 @@ bool ListenerManagerImpl::addOrUpdateListener(const envoy::api::v2::Listener& co
     // have been started or not. Either way we get the socket from the existing listener.
     new_listener->setSocket((*existing_active_listener)->getSocket());
     if (workers_started_) {
-      new_listener->infoLog("add warming listener");
+      new_listener->debugLog("add warming listener");
       warming_listeners_.emplace_back(std::move(new_listener));
     } else {
-      new_listener->infoLog("update active listener");
+      new_listener->debugLog("update active listener");
       *existing_active_listener = std::move(new_listener);
     }
   } else {
@@ -266,10 +266,10 @@ bool ListenerManagerImpl::addOrUpdateListener(const envoy::api::v2::Listener& co
             ? draining_listener_socket
             : factory_.createListenSocket(new_listener->address(), new_listener->bindToPort()));
     if (workers_started_) {
-      new_listener->infoLog("add warming listener");
+      new_listener->debugLog("add warming listener");
       warming_listeners_.emplace_back(std::move(new_listener));
     } else {
-      new_listener->infoLog("add active listener");
+      new_listener->debugLog("add active listener");
       active_listeners_.emplace_back(std::move(new_listener));
     }
 
@@ -307,7 +307,7 @@ void ListenerManagerImpl::drainListener(ListenerImplPtr&& listener) {
   stats_.total_listeners_draining_.set(draining_listeners_.size());
 
   // Tell all workers to stop accepting new connections on this listener.
-  draining_it->listener_->infoLog("draining listener");
+  draining_it->listener_->debugLog("draining listener");
   for (const auto& worker : workers_) {
     worker->stopListener(*draining_it->listener_);
   }
@@ -315,7 +315,7 @@ void ListenerManagerImpl::drainListener(ListenerImplPtr&& listener) {
   // Start the drain sequence which completes when the listener's drain manager has completed
   // draining at whatever the server configured drain times are.
   draining_it->listener_->localDrainManager().startDrainSequence([this, draining_it]() -> void {
-    draining_it->listener_->infoLog("removing listener");
+    draining_it->listener_->debugLog("removing listener");
     for (const auto& worker : workers_) {
       // Once the drain time has completed via the drain manager's timer, we tell the workers to
       // remove the listener.
@@ -325,7 +325,7 @@ void ListenerManagerImpl::drainListener(ListenerImplPtr&& listener) {
         // might still be using its context (stats, etc.).
         server_.dispatcher().post([this, draining_it]() -> void {
           if (--draining_it->workers_pending_removal_ == 0) {
-            draining_it->listener_->infoLog("listener removal complete");
+            draining_it->listener_->debugLog("listener removal complete");
             draining_listeners_.erase(draining_it);
             stats_.total_listeners_draining_.set(draining_listeners_.size());
           }
@@ -395,7 +395,7 @@ void ListenerManagerImpl::onListenerWarmed(ListenerImpl& listener) {
 
   auto existing_active_listener = getListenerByName(active_listeners_, listener.name());
   auto existing_warming_listener = getListenerByName(warming_listeners_, listener.name());
-  (*existing_warming_listener)->infoLog("warm complete. updating active listener");
+  (*existing_warming_listener)->debugLog("warm complete. updating active listener");
   if (existing_active_listener != active_listeners_.end()) {
     drainListener(std::move(*existing_active_listener));
     *existing_active_listener = std::move(*existing_warming_listener);
@@ -429,7 +429,7 @@ bool ListenerManagerImpl::removeListener(const std::string& name) {
 
   // Destroy a warming listener directly.
   if (existing_warming_listener != warming_listeners_.end()) {
-    (*existing_warming_listener)->infoLog("removing warming listener");
+    (*existing_warming_listener)->debugLog("removing warming listener");
     warming_listeners_.erase(existing_warming_listener);
   }
 
@@ -445,7 +445,7 @@ bool ListenerManagerImpl::removeListener(const std::string& name) {
 }
 
 void ListenerManagerImpl::startWorkers(GuardDog& guard_dog) {
-  ENVOY_LOG(warn, "all dependencies initialized. starting workers");
+  ENVOY_LOG(info, "all dependencies initialized. starting workers");
   ASSERT(!workers_started_);
   workers_started_ = true;
   for (const auto& worker : workers_) {

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -185,7 +185,7 @@ public:
   Network::Address::InstanceConstSharedPtr address() const { return address_; }
   const Network::ListenSocketSharedPtr& getSocket() const { return socket_; }
   uint64_t hash() const { return hash_; }
-  void infoLog(const std::string& message);
+  void debugLog(const std::string& message);
   void initialize();
   DrainManager& localDrainManager() const { return *local_drain_manager_; }
   void setSocket(const Network::ListenSocketSharedPtr& socket);

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -300,19 +300,19 @@ RunHelper::RunHelper(Event::Dispatcher& dispatcher, Upstream::ClusterManager& cm
 
   // Setup signals.
   sigterm_ = dispatcher.listenForSignal(SIGTERM, [this, &hot_restart, &dispatcher]() {
-    ENVOY_LOG(info, "caught SIGTERM");
+    ENVOY_LOG(warn, "caught SIGTERM");
     shutdown_ = true;
     hot_restart.terminateParent();
     dispatcher.exit();
   });
 
   sig_usr_1_ = dispatcher.listenForSignal(SIGUSR1, [&access_log_manager]() {
-    ENVOY_LOG(info, "caught SIGUSR1");
+    ENVOY_LOG(warn, "caught SIGUSR1");
     access_log_manager.reopen();
   });
 
   sig_hup_ = dispatcher.listenForSignal(SIGHUP, []() {
-    ENVOY_LOG(info, "caught and eating SIGHUP. See documentation for how to hot restart.");
+    ENVOY_LOG(warn, "caught and eating SIGHUP. See documentation for how to hot restart.");
   });
 
   // Register for cluster manager init notification. We don't start serving worker traffic until
@@ -378,12 +378,12 @@ void InstanceImpl::shutdown() {
 }
 
 void InstanceImpl::shutdownAdmin() {
-  ENVOY_LOG(info, "shutting down admin due to child startup");
+  ENVOY_LOG(warn, "shutting down admin due to child startup");
   stat_flush_timer_.reset();
   handler_->stopListeners();
   admin_->mutable_socket().close();
 
-  ENVOY_LOG(info, "terminating parent process");
+  ENVOY_LOG(warn, "terminating parent process");
   restarter_.terminateParent();
 }
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -88,7 +88,7 @@ Upstream::ClusterManager& InstanceImpl::clusterManager() { return config_->clust
 Tracing::HttpTracer& InstanceImpl::httpTracer() { return config_->httpTracer(); }
 
 void InstanceImpl::drainListeners() {
-  ENVOY_LOG(warn, "closing and draining listeners");
+  ENVOY_LOG(info, "closing and draining listeners");
   listener_manager_->stopListeners();
   drain_manager_->startDrainSequence(nullptr);
 }
@@ -153,7 +153,7 @@ bool InstanceImpl::healthCheckFailed() { return server_stats_->live_.value() == 
 void InstanceImpl::initialize(Options& options,
                               Network::Address::InstanceConstSharedPtr local_address,
                               ComponentFactory& component_factory) {
-  ENVOY_LOG(warn, "initializing epoch {} (hot restart version={})", options.restartEpoch(),
+  ENVOY_LOG(info, "initializing epoch {} (hot restart version={})", options.restartEpoch(),
             restarter_.version());
 
   // Handle configuration that needs to take place prior to the main configuration load.
@@ -192,7 +192,7 @@ void InstanceImpl::initialize(Options& options,
                                    options.serviceClusterName(), options.serviceNodeName()));
 
   Configuration::InitialImpl initial_config(bootstrap);
-  ENVOY_LOG(info, "admin address: {}", initial_config.admin().address()->asString());
+  ENVOY_LOG(debug, "admin address: {}", initial_config.admin().address()->asString());
 
   HotRestart::ShutdownParentAdminInfo info;
   info.original_start_time_ = original_start_time_;
@@ -287,7 +287,7 @@ void InstanceImpl::loadServerFlags(const Optional<std::string>& flags_path) {
 
   ENVOY_LOG(info, "server flags path: {}", flags_path.value());
   if (api_->fileExists(flags_path.value() + "/drain")) {
-    ENVOY_LOG(warn, "starting server in drain mode");
+    ENVOY_LOG(info, "starting server in drain mode");
     failHealthcheck(true);
   }
 }
@@ -300,19 +300,19 @@ RunHelper::RunHelper(Event::Dispatcher& dispatcher, Upstream::ClusterManager& cm
 
   // Setup signals.
   sigterm_ = dispatcher.listenForSignal(SIGTERM, [this, &hot_restart, &dispatcher]() {
-    ENVOY_LOG(warn, "caught SIGTERM");
+    ENVOY_LOG(info, "caught SIGTERM");
     shutdown_ = true;
     hot_restart.terminateParent();
     dispatcher.exit();
   });
 
   sig_usr_1_ = dispatcher.listenForSignal(SIGUSR1, [&access_log_manager]() {
-    ENVOY_LOG(warn, "caught SIGUSR1");
+    ENVOY_LOG(info, "caught SIGUSR1");
     access_log_manager.reopen();
   });
 
   sig_hup_ = dispatcher.listenForSignal(SIGHUP, []() {
-    ENVOY_LOG(warn, "caught and eating SIGHUP. See documentation for how to hot restart.");
+    ENVOY_LOG(info, "caught and eating SIGHUP. See documentation for how to hot restart.");
   });
 
   // Register for cluster manager init notification. We don't start serving worker traffic until
@@ -325,7 +325,7 @@ RunHelper::RunHelper(Event::Dispatcher& dispatcher, Upstream::ClusterManager& cm
       return;
     }
 
-    ENVOY_LOG(warn, "all clusters initialized. initializing init manager");
+    ENVOY_LOG(info, "all clusters initialized. initializing init manager");
     init_manager.initialize([this, workers_start_cb]() {
       if (shutdown_) {
         return;
@@ -341,11 +341,11 @@ void InstanceImpl::run() {
                    [this]() -> void { startWorkers(); });
 
   // Run the main dispatch loop waiting to exit.
-  ENVOY_LOG(warn, "starting main dispatch loop");
+  ENVOY_LOG(info, "starting main dispatch loop");
   auto watchdog = guard_dog_->createWatchDog(Thread::Thread::currentThreadId());
   watchdog->startWatchdog(*dispatcher_);
   dispatcher_->run(Event::Dispatcher::RunType::Block);
-  ENVOY_LOG(warn, "main dispatch loop exited");
+  ENVOY_LOG(info, "main dispatch loop exited");
   guard_dog_->stopWatching(watchdog);
   watchdog.reset();
 
@@ -366,24 +366,24 @@ void InstanceImpl::run() {
   config_->clusterManager().shutdown();
   handler_.reset();
   thread_local_.shutdownThread();
-  ENVOY_LOG(warn, "exiting");
+  ENVOY_LOG(info, "exiting");
   ENVOY_FLUSH_LOG();
 }
 
 Runtime::Loader& InstanceImpl::runtime() { return *runtime_loader_; }
 
 void InstanceImpl::shutdown() {
-  ENVOY_LOG(warn, "shutdown invoked. sending SIGTERM to self");
+  ENVOY_LOG(info, "shutdown invoked. sending SIGTERM to self");
   kill(getpid(), SIGTERM);
 }
 
 void InstanceImpl::shutdownAdmin() {
-  ENVOY_LOG(warn, "shutting down admin due to child startup");
+  ENVOY_LOG(info, "shutting down admin due to child startup");
   stat_flush_timer_.reset();
   handler_->stopListeners();
   admin_->mutable_socket().close();
 
-  ENVOY_LOG(warn, "terminating parent process");
+  ENVOY_LOG(info, "terminating parent process");
   restarter_.terminateParent();
 }
 

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -104,11 +104,11 @@ void WorkerImpl::stopListeners() {
 }
 
 void WorkerImpl::threadRoutine(GuardDog& guard_dog) {
-  ENVOY_LOG(info, "worker entering dispatch loop");
+  ENVOY_LOG(debug, "worker entering dispatch loop");
   auto watchdog = guard_dog.createWatchDog(Thread::Thread::currentThreadId());
   watchdog->startWatchdog(*dispatcher_);
   dispatcher_->run(Event::Dispatcher::RunType::Block);
-  ENVOY_LOG(info, "worker exited dispatch loop");
+  ENVOY_LOG(debug, "worker exited dispatch loop");
   guard_dog.stopWatching(watchdog);
 
   // We must close all active connections before we actually exit the thread. This prevents any


### PR DESCRIPTION
*title*:
 > server: change default loglevel to 'info', change some message levels to tune the noise

*Description*:
> Changes warning messages issued on startup to Info messages.  The messages were only categorized as warnings so they would be emitted by default.  This PR changes the default loglevel to 'info', and adjusted several info messages down to debug, because we want them to be emitted during server operation.  This feature changes the default server behavior.

Fixes https://github.com/envoyproxy/envoy/issues/1854

*Risk Level*: Low
> The biggest risk is that some Info messages may remain that need to be demoted.  However, the Issue has a description of the analysis that was done.  A follow-up for remaining issues will be straightforward.  The biggest risk is that new PRs may introduce new Info messages that should be debug, so the Envoy community needs to be informed of this change.

*Testing*:
> All unit tests and integration tests were run.  Following integration tests, the logs were examined for excessive info messages.  Specifically:

  bazel test //test/integration:all --test_arg="-l info"
  bazel test //test/...

After the integration tests, analyzed the logs to determine whether there was too much noise:

  find . -name '*.log' -exec fgrep \[info\] {} \; >/tmp/info.log
  cut -f4-10 -d\] /tmp/info.log|cut -d\  -f1-2 | grep -v  test/ | sort | uniq -c | sort -n -r

This pipe shows me the sources of messages that come out most frequently in the integration tests. Full results below. I think these seem reasonable but happy to trim further. The remaining high frequency messages all seem to be per server startup or config, not per request.  Details are in a comment in https://github.com/envoyproxy/envoy/issues/1854

*Release Notes*:
 > Default loglevel changed to 'info'

Signed-off-by: Joshua Marantz <jmarantz@google.com>