### PR TITLE
ci: use YAML references to define the build-image sha once

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,3 @@
-# TODO(mattklein123): See if there is a way to put build SHA into a variable.
-# In the meantime, it's required to edit the SHA in this file as well as envoy_build_sha.sh.
-
 references:
   envoy-build-image: &envoy-build-image
     envoyproxy/envoy-build:516cdcd55326648978f8db1fe3a774ec759f5a13

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,15 @@
 # TODO(mattklein123): See if there is a way to put build SHA into a variable.
 # In the meantime, it's required to edit the SHA in this file as well as envoy_build_sha.sh.
 
+references:
+  envoy-build-image: &envoy-build-image
+    envoyproxy/envoy-build:516cdcd55326648978f8db1fe3a774ec759f5a13
+
 version: 2
 jobs:
    release:
      docker:
-       - image: envoyproxy/envoy-build:516cdcd55326648978f8db1fe3a774ec759f5a13
+       - image: *envoy-build-image
      resource_class: xlarge
      working_directory: /source
      steps:
@@ -16,7 +20,7 @@ jobs:
        - run: ci/docker_tag.sh
    asan:
      docker:
-       - image: envoyproxy/envoy-build:516cdcd55326648978f8db1fe3a774ec759f5a13
+       - image: *envoy-build-image
      resource_class: xlarge
      working_directory: /source
      steps:
@@ -24,7 +28,7 @@ jobs:
        - run: ci/do_circle_ci.sh bazel.asan
    tsan:
      docker:
-       - image: envoyproxy/envoy-build:516cdcd55326648978f8db1fe3a774ec759f5a13
+       - image: *envoy-build-image
      resource_class: xlarge
      working_directory: /source
      steps:
@@ -32,7 +36,7 @@ jobs:
        - run: ci/do_circle_ci.sh bazel.tsan
    coverage:
      docker:
-       - image: envoyproxy/envoy-build:516cdcd55326648978f8db1fe3a774ec759f5a13
+       - image: *envoy-build-image
      resource_class: xlarge
      working_directory: /source
      steps:
@@ -43,7 +47,7 @@ jobs:
            path: /build/envoy/generated/coverage
    format:
      docker:
-       - image: envoyproxy/envoy-build:516cdcd55326648978f8db1fe3a774ec759f5a13
+       - image: *envoy-build-image
      resource_class: small
      working_directory: /source
      steps:


### PR DESCRIPTION
Removes duplication of the build-image SHA in `.circleci/config.yml`

Signed-off-by: Gordon Syme <gordonsyme@gmail.com>