### PR TITLE
grpc-json: use gRPC status to HTTP status code mapping

### DIFF
--- a/source/common/grpc/json_transcoder_filter.cc
+++ b/source/common/grpc/json_transcoder_filter.cc
@@ -290,10 +290,19 @@ Http::FilterHeadersStatus JsonTranscoderFilter::encodeHeaders(Http::HeaderMap& h
   }
 
   response_headers_ = &headers;
+
+  if (end_stream) {
+    // In gRPC wire protocol, headers frame with end_stream is a trailers-only response.
+    // The return value from encodeTrailers is ignored since it is always continue.
+    encodeTrailers(headers);
+    return Http::FilterHeadersStatus::Continue;
+  }
+
   headers.insertContentType().value().setReference(Http::Headers::get().ContentTypeValues.Json);
-  if (!method_->server_streaming() && !end_stream) {
+  if (!method_->server_streaming()) {
     return Http::FilterHeadersStatus::StopIteration;
   }
+
   return Http::FilterHeadersStatus::Continue;
 }
 
@@ -338,13 +347,12 @@ Http::FilterTrailersStatus JsonTranscoderFilter::encodeTrailers(Http::HeaderMap&
     return Http::FilterTrailersStatus::Continue;
   }
 
-  const Http::HeaderEntry* grpc_status_header = trailers.GrpcStatus();
-  if (grpc_status_header) {
-    uint64_t grpc_status_code;
-    if (!StringUtil::atoul(grpc_status_header->value().c_str(), grpc_status_code)) {
-      response_headers_->Status()->value(enumToInt(Http::Code::ServiceUnavailable));
-    }
-    response_headers_->insertGrpcStatus().value(*grpc_status_header);
+  Optional<Status::GrpcStatus> grpc_status = Common::getGrpcStatus(trailers);
+  if (!grpc_status.valid() || grpc_status.value() == Status::GrpcStatus::InvalidCode) {
+    response_headers_->Status()->value(enumToInt(Http::Code::ServiceUnavailable));
+  } else {
+    response_headers_->Status()->value(Common::grpcToHttpStatus(grpc_status.value()));
+    response_headers_->insertGrpcStatus().value(enumToInt(grpc_status.value()));
   }
 
   const Http::HeaderEntry* grpc_message_header = trailers.GrpcMessage();

--- a/source/common/grpc/json_transcoder_filter.cc
+++ b/source/common/grpc/json_transcoder_filter.cc
@@ -347,7 +347,7 @@ Http::FilterTrailersStatus JsonTranscoderFilter::encodeTrailers(Http::HeaderMap&
     return Http::FilterTrailersStatus::Continue;
   }
 
-  Optional<Status::GrpcStatus> grpc_status = Common::getGrpcStatus(trailers);
+  const Optional<Status::GrpcStatus> grpc_status = Common::getGrpcStatus(trailers);
   if (!grpc_status.valid() || grpc_status.value() == Status::GrpcStatus::InvalidCode) {
     response_headers_->Status()->value(enumToInt(Http::Code::ServiceUnavailable));
   } else {

--- a/test/integration/grpc_json_transcoder_integration_test.cc
+++ b/test/integration/grpc_json_transcoder_integration_test.cc
@@ -163,7 +163,7 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, UnaryGetError) {
           {":method", "GET"}, {":path", "/shelves/100?"}, {":authority", "host"}},
       "", {"shelf: 100"}, {}, Status(Code::NOT_FOUND, "Shelf 100 Not Found"),
       Http::TestHeaderMapImpl{
-          {":status", "200"}, {"grpc-status", "5"}, {"grpc-message", "Shelf 100 Not Found"}},
+          {":status", "404"}, {"grpc-status", "5"}, {"grpc-message", "Shelf 100 Not Found"}},
       "");
 }
 


### PR DESCRIPTION
*Description*:
Previously the while the `grpc-status` is propagated, the HTTP status code was blindly set to 200, this PR change it to use gRPC status to HTTP status code mapping.

Fixes #2006 

*Risk Level*: Low

*Testing*:
a integration test covers this.

*Release Notes*:
Note the gRRPC JSON transcoder filter behavior is now return HTTP status mapped from grpc-status.
