### PR TITLE
*: update URLs

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -6,7 +6,7 @@ To get started building Envoy locally, see the [Bazel quick start](https://githu
 
 Below is a list of additional documentation to aid the development process:
 
-- [General build and installation documentation](https://envoyproxy.github.io/envoy/install/install.html)
+- [General build and installation documentation](https://www.envoyproxy.io/docs/envoy/latest/install/install)
 
 - [Building and testing Envoy with Bazel](https://github.com/envoyproxy/envoy/blob/master/bazel/README.md)
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -33,7 +33,7 @@ privacy concerns, sanitize the data prior to sharing the tarball/pasting.
 *Admin and Stats Output*:
 >Include the admin output for the following endpoints: /stats, 
 /clusters, /routes, /server_info. For more information, refer to the 
-[admin endpoint documentation.](https://envoyproxy.github.io/envoy/operations/admin.html)
+[admin endpoint documentation.](https://www.envoyproxy.io/docs/envoy/latest/operations/admin)
 
 >**Note**: If there are privacy concerns, sanitize the data prior to
 sharing.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Envoy Logo](https://github.com/envoyproxy/artwork/blob/master/PNG/Envoy_Logo_Final_PANTONE.png)
 
-[C++ L7 proxy and communication bus](https://envoyproxy.github.io/)
+[C++ L7 proxy and communication bus](https://www.envoyproxy.io/)
 
 Envoy is hosted by the [Cloud Native Computing Foundation](https://cncf.io) (CNCF). If you are a company that wants to help shape the evolution of technologies that are container-packaged, dynamically-scheduled and microservices-oriented, consider joining the CNCF. For details about who's involved and how Envoy plays a role, read the CNCF [announcement](https://www.cncf.io/blog/2017/09/13/cncf-hosts-envoy/).
 
@@ -9,7 +9,7 @@ Envoy is hosted by the [Cloud Native Computing Foundation](https://cncf.io) (CNC
 
 ## Documentation
 
-* [Official documentation](https://envoyproxy.github.io).
+* [Official documentation](https://www.envoyproxy.io/).
 * Watch [a video overview of Envoy](https://www.youtube.com/watch?v=RVZX4CwKhGE)
 ([transcript](https://www.microservices.com/talks/lyfts-envoy-monolith-service-mesh-matt-klein/))
 to find out more about the origin story and design philosophy of Envoy.

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -3,11 +3,11 @@
 ## Production environments
 
 To build Envoy with Bazel in a production environment, where the [Envoy
-dependencies](https://envoyproxy.github.io/envoy/install/requirements.html) are typically
+dependencies](https://www.envoyproxy.io/docs/envoy/latest/install/requirements) are typically
 independently sourced, the following steps should be followed:
 
 1. [Install Bazel](https://bazel.build/versions/master/docs/install.html) in your environment.
-2. Configure, build and/or install the [Envoy dependencies](https://envoyproxy.github.io/envoy/install/requirements.html).
+2. Configure, build and/or install the [Envoy dependencies](https://www.envoyproxy.io/docs/envoy/latest/install/requirements).
 3. Configure a Bazel [WORKSPACE](https://bazel.build/versions/master/docs/be/workspace.html)
    to point Bazel at the Envoy dependencies. An example is provided in the CI Docker image
    [WORKSPACE](https://github.com/envoyproxy/envoy/blob/master/ci/WORKSPACE) and corresponding

--- a/examples/front-proxy/README.md
+++ b/examples/front-proxy/README.md
@@ -1,2 +1,2 @@
 To learn about this sandbox and for instructions on how to run it please head over
-to the [envoy docs](https://envoyproxy.github.io/envoy/install/sandboxes/front_proxy.html)
+to the [envoy docs](https://www.envoyproxy.io/docs/envoy/latest/install/sandboxes/front_proxy)

--- a/examples/grpc-bridge/README.md
+++ b/examples/grpc-bridge/README.md
@@ -1,2 +1,2 @@
 To learn about this sandbox and for instructions on how to run it please head over
-to the [envoy docs](https://envoyproxy.github.io/envoy/install/sandboxes/grpc_bridge.html)
+to the [envoy docs](https://www.envoyproxy.io/docs/envoy/latest/install/sandboxes/grpc_bridge)

--- a/examples/jaeger-tracing/README.md
+++ b/examples/jaeger-tracing/README.md
@@ -1,2 +1,2 @@
 To learn about this sandbox and for instructions on how to run it please head over
-to the [envoy docs](https://envoyproxy.github.io/envoy/install/sandboxes/jaeger_tracing.html)
+to the [envoy docs](https://www.envoyproxy.io/docs/envoy/latest/install/sandboxes/jaeger_tracing)

--- a/examples/zipkin-tracing/README.md
+++ b/examples/zipkin-tracing/README.md
@@ -1,2 +1,2 @@
 To learn about this sandbox and for instructions on how to run it please head over
-to the [envoy docs](https://envoyproxy.github.io/envoy/install/sandboxes/zipkin_tracing.html)
+to the [envoy docs](https://www.envoyproxy.io/docs/envoy/latest/install/sandboxes/zipkin_tracing)


### PR DESCRIPTION
https://envoyproxy.github.io/ -> https://www.envoyproxy.io/

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>

*Description*:
updates links to the new docs site

*Risk Level*: Low 

*Testing*:
Clink the URL and ensure it's not a 404
