### PR TITLE
config: Convert tcp_proxy to v2 config.

### DIFF
--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -93,6 +93,7 @@ envoy_cc_library(
         "envoy_filter_http_fault",
         "envoy_filter_http_router",
         "envoy_filter_network_mongo_proxy",
+        "envoy_filter_network_tcp_proxy",
     ],
     deps = [
         ":json_utility_lib",
@@ -104,6 +105,7 @@ envoy_cc_library(
         "//source/common/common:utility_lib",
         "//source/common/config:well_known_names",
         "//source/common/json:config_schemas_lib",
+        "//source/common/network:cidr_range_lib",
         "//source/common/protobuf",
         "//source/common/protobuf:utility_lib",
     ],

--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
     deps = [
         "//include/envoy/json:json_object_interface",
         "//source/common/common:assert_lib",
+        "//source/common/network:cidr_range_lib",
         "//source/common/network:utility_lib",
     ],
 )
@@ -96,6 +97,7 @@ envoy_cc_library(
         "envoy_filter_network_tcp_proxy",
     ],
     deps = [
+        ":address_json_lib",
         ":json_utility_lib",
         ":protocol_json_lib",
         ":rds_json_lib",
@@ -105,7 +107,6 @@ envoy_cc_library(
         "//source/common/common:utility_lib",
         "//source/common/config:well_known_names",
         "//source/common/json:config_schemas_lib",
-        "//source/common/network:cidr_range_lib",
         "//source/common/protobuf",
         "//source/common/protobuf:utility_lib",
     ],

--- a/source/common/config/address_json.cc
+++ b/source/common/config/address_json.cc
@@ -1,6 +1,7 @@
 #include "common/config/address_json.h"
 
 #include "common/common/assert.h"
+#include "common/network/cidr_range.h"
 #include "common/network/utility.h"
 
 namespace Envoy {
@@ -30,6 +31,20 @@ void AddressJson::translateAddress(const std::string& json_address, bool url, bo
   }
   address.mutable_socket_address()->set_address(Network::Utility::hostFromTcpUrl(json_address));
   address.mutable_socket_address()->set_port_value(Network::Utility::portFromTcpUrl(json_address));
+}
+
+void AddressJson::translateCidrRangeList(
+    const std::vector<std::string>& json_ip_list,
+    Protobuf::RepeatedPtrField<envoy::api::v2::CidrRange>& range_list) {
+  for (const std::string& source_ip : json_ip_list) {
+    Network::Address::CidrRange cidr(Network::Address::CidrRange::create(source_ip));
+    if (!cidr.isValid()) {
+      throw EnvoyException(fmt::format("Invalid cidr entry: {}", source_ip));
+    }
+    envoy::api::v2::CidrRange* v2_cidr = range_list.Add();
+    v2_cidr->set_address_prefix(cidr.ip()->addressAsString());
+    v2_cidr->mutable_prefix_len()->set_value(cidr.length());
+  }
 }
 
 } // namespace Config

--- a/source/common/config/address_json.h
+++ b/source/common/config/address_json.h
@@ -2,6 +2,8 @@
 
 #include "envoy/json/json_object.h"
 
+#include "common/protobuf/protobuf.h"
+
 #include "api/address.pb.h"
 
 namespace Envoy {
@@ -19,6 +21,16 @@ public:
    */
   static void translateAddress(const std::string& json_address, bool url, bool resolved,
                                envoy::api::v2::Address& address);
+
+  /**
+   * Translate a v1 JSON array of IP ranges to v2
+   * Protobuf::RepeatedPtrField<envoy::api::v2::CidrRange>.
+   * @param json_ip_list List of IP ranges, such as "1.1.1.1/24"
+   * @param range_list destination
+   */
+  static void
+  translateCidrRangeList(const std::vector<std::string>& json_ip_list,
+                         Protobuf::RepeatedPtrField<envoy::api::v2::CidrRange>& range_list);
 };
 
 } // namespace Config

--- a/source/common/config/filter_json.h
+++ b/source/common/config/filter_json.h
@@ -7,6 +7,7 @@
 #include "api/filter/http/http_connection_manager.pb.h"
 #include "api/filter/http/router.pb.h"
 #include "api/filter/network/mongo_proxy.pb.h"
+#include "api/filter/network/tcp_proxy.pb.h"
 
 namespace Envoy {
 namespace Config {
@@ -75,6 +76,14 @@ public:
    */
   static void translateBufferFilter(const Json::Object& json_buffer,
                                     envoy::api::v2::filter::http::Buffer& buffer);
+
+  /**
+   * Translate a v1 JSON TCP proxy filter object to a v2 envoy::api::v2::filter::network::TcpProxy.
+   * @param json_tcp_proxy source v1 JSON TCP proxy object.
+   * @param tcp_proxy destination v2 envoy::api::v2::filter::network::TcpProxy.
+   */
+  static void translateTcpProxy(const Json::Object& json_tcp_proxy,
+                                envoy::api::v2::filter::network::TcpProxy& tcp_proxy);
 };
 
 } // namespace Config

--- a/source/common/filter/BUILD
+++ b/source/common/filter/BUILD
@@ -41,6 +41,9 @@ envoy_cc_library(
     name = "tcp_proxy_lib",
     srcs = ["tcp_proxy.cc"],
     hdrs = ["tcp_proxy.h"],
+    external_deps = [
+        "envoy_filter_network_tcp_proxy",
+    ],
     deps = [
         "//include/envoy/access_log:access_log_interface",
         "//include/envoy/buffer:buffer_interface",
@@ -60,9 +63,6 @@ envoy_cc_library(
         "//source/common/common:assert_lib",
         "//source/common/common:empty_string",
         "//source/common/common:logger_lib",
-        "//source/common/config:filter_json_lib",
-        "//source/common/json:config_schemas_lib",
-        "//source/common/json:json_loader_lib",
         "//source/common/network:cidr_range_lib",
         "//source/common/network:filter_lib",
         "//source/common/network:utility_lib",

--- a/source/common/filter/tcp_proxy.h
+++ b/source/common/filter/tcp_proxy.h
@@ -17,10 +17,11 @@
 
 #include "common/access_log/request_info_impl.h"
 #include "common/common/logger.h"
-#include "common/json/json_loader.h"
 #include "common/network/cidr_range.h"
 #include "common/network/filter_impl.h"
 #include "common/network/utility.h"
+
+#include "api/filter/network/tcp_proxy.pb.h"
 
 namespace Envoy {
 namespace Filter {
@@ -52,7 +53,8 @@ struct TcpProxyStats {
  */
 class TcpProxyConfig {
 public:
-  TcpProxyConfig(const Json::Object& config, Server::Configuration::FactoryContext& context);
+  TcpProxyConfig(const envoy::api::v2::filter::network::TcpProxy& config,
+                 Server::Configuration::FactoryContext& context);
 
   /**
    * Find out which cluster an upstream connection should be opened to based on the
@@ -69,7 +71,7 @@ public:
 
 private:
   struct Route {
-    Route(const Json::Object& config);
+    Route(const envoy::api::v2::filter::network::TcpProxy::DeprecatedV1::TCPRoute& config);
 
     Network::Address::IpList source_ips_;
     Network::PortRangeList source_port_ranges_;

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -23,6 +23,9 @@ envoy_cc_library(
     name = "cidr_range_lib",
     srcs = ["cidr_range.cc"],
     hdrs = ["cidr_range.h"],
+    external_deps = [
+        "envoy_address",
+    ],
     deps = [
         ":address_lib",
         ":utility_lib",

--- a/source/common/network/cidr_range.h
+++ b/source/common/network/cidr_range.h
@@ -6,6 +6,10 @@
 #include "envoy/json/json_object.h"
 #include "envoy/network/address.h"
 
+#include "common/protobuf/protobuf.h"
+
+#include "api/address.pb.h"
+
 namespace Envoy {
 namespace Network {
 namespace Address {
@@ -37,6 +41,11 @@ public:
    * @return true if the ranges are identical.
    */
   bool operator==(const CidrRange& other) const;
+
+  /**
+   * @return Ip address data IFF length >= 0, otherwise nullptr.
+   */
+  const Ip* ip() const;
 
   /**
    * @return Ipv4 address data IFF length >= 0 and version() == IpVersion::v4, otherwise nullptr.
@@ -100,6 +109,11 @@ public:
   static CidrRange create(const std::string& range);
 
   /**
+   * Constructs a CidrRange from envoy::api::v2::CidrRange.
+   */
+  static CidrRange create(const envoy::api::v2::CidrRange& cidr);
+
+  /**
    * Given an IP address and a length of high order bits to keep, returns an address
    * where those high order bits are unmodified, and the remaining bits are all zero.
    * length_io is reduced to be at most 32 for IPv4 address and at most 128 for IPv6
@@ -127,6 +141,7 @@ class IpList {
 public:
   IpList(const std::vector<std::string>& subnets);
   IpList(const Json::Object& config, const std::string& member_name);
+  IpList(const Protobuf::RepeatedPtrField<envoy::api::v2::CidrRange>& cidrs);
   IpList(){};
 
   bool contains(const Instance& address) const;

--- a/source/common/network/cidr_range.h
+++ b/source/common/network/cidr_range.h
@@ -48,27 +48,12 @@ public:
   const Ip* ip() const;
 
   /**
-   * @return Ipv4 address data IFF length >= 0 and version() == IpVersion::v4, otherwise nullptr.
-   */
-  const Ipv4* ipv4() const;
-
-  /**
-   * @return Ipv6 address data IFF length >= 0 and version() == IpVersion::v6, otherwise nullptr.
-   */
-  const Ipv6* ipv6() const;
-
-  /**
    * TODO(jamessynge) Consider making this Optional<int> length, or modifying the create() methods
    *                  below to return Optional<CidrRange> (the latter is probably better).
    * @return the number of bits of the address that are included in the mask. -1 if uninitialized
    *         or invalid, else in the range 0 to 32 for IPv4, and 0 to 128 for IPv6.
    */
   int length() const;
-
-  /**
-   * @return the version of IP address.
-   */
-  IpVersion version() const;
 
   /**
    * @return true if the address argument is in the range of this object, false if not, including

--- a/source/server/config/network/BUILD
+++ b/source/server/config/network/BUILD
@@ -117,9 +117,13 @@ envoy_cc_library(
     name = "tcp_proxy_lib",
     srcs = ["tcp_proxy.cc"],
     hdrs = ["tcp_proxy.h"],
+    external_deps = [
+        "envoy_filter_network_tcp_proxy",
+    ],
     deps = [
         "//include/envoy/registry",
         "//include/envoy/server:filter_config_interface",
+        "//source/common/config:filter_json_lib",
         "//source/common/config:well_known_names",
         "//source/common/filter:tcp_proxy_lib",
     ],

--- a/source/server/config/network/tcp_proxy.cc
+++ b/source/server/config/network/tcp_proxy.cc
@@ -5,19 +5,36 @@
 #include "envoy/network/connection.h"
 #include "envoy/registry/registry.h"
 
+#include "common/config/filter_json.h"
 #include "common/filter/tcp_proxy.h"
 
 namespace Envoy {
 namespace Server {
 namespace Configuration {
 
-NetworkFilterFactoryCb TcpProxyConfigFactory::createFilterFactory(const Json::Object& config,
-                                                                  FactoryContext& context) {
+NetworkFilterFactoryCb
+TcpProxyConfigFactory::createFactory(const envoy::api::v2::filter::network::TcpProxy& config,
+                                     FactoryContext& context) {
   Filter::TcpProxyConfigSharedPtr filter_config(new Filter::TcpProxyConfig(config, context));
   return [filter_config, &context](Network::FilterManager& filter_manager) -> void {
     filter_manager.addReadFilter(Network::ReadFilterSharedPtr{
         new Filter::TcpProxy(filter_config, context.clusterManager())});
   };
+}
+
+NetworkFilterFactoryCb
+TcpProxyConfigFactory::createFilterFactoryFromProto(const Protobuf::Message& config,
+                                                    FactoryContext& context) {
+  return createFactory(dynamic_cast<const envoy::api::v2::filter::network::TcpProxy&>(config),
+                       context);
+}
+
+NetworkFilterFactoryCb TcpProxyConfigFactory::createFilterFactory(const Json::Object& json_config,
+                                                                  FactoryContext& context) {
+  envoy::api::v2::filter::network::TcpProxy tcp_proxy_config;
+  Config::FilterJson::translateTcpProxy(json_config, tcp_proxy_config);
+
+  return createFactory(tcp_proxy_config, context);
 }
 
 /**

--- a/source/server/config/network/tcp_proxy.h
+++ b/source/server/config/network/tcp_proxy.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <string>
-
 #include "envoy/server/filter_config.h"
 
 #include "common/config/well_known_names.h"
+
+#include "api/filter/network/tcp_proxy.pb.h"
 
 namespace Envoy {
 namespace Server {
@@ -16,9 +16,15 @@ namespace Configuration {
 class TcpProxyConfigFactory : public NamedNetworkFilterConfigFactory {
 public:
   // NamedNetworkFilterConfigFactory
-  NetworkFilterFactoryCb createFilterFactory(const Json::Object& config,
+  NetworkFilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& config,
+                                                      FactoryContext& context) override;
+  NetworkFilterFactoryCb createFilterFactory(const Json::Object& json_config,
                                              FactoryContext& context) override;
   std::string name() override { return Config::NetworkFilterNames::get().TCP_PROXY; }
+
+private:
+  NetworkFilterFactoryCb createFactory(const envoy::api::v2::filter::network::TcpProxy& config,
+                                       FactoryContext& context);
 };
 
 } // namespace Configuration

--- a/test/common/filter/BUILD
+++ b/test/common/filter/BUILD
@@ -28,6 +28,7 @@ envoy_cc_test(
     srcs = ["tcp_proxy_test.cc"],
     deps = [
         "//source/common/buffer:buffer_lib",
+        "//source/common/config:filter_json_lib",
         "//source/common/event:dispatcher_lib",
         "//source/common/filter:tcp_proxy_lib",
         "//source/common/network:address_lib",

--- a/test/common/network/cidr_range_test.cc
+++ b/test/common/network/cidr_range_test.cc
@@ -97,7 +97,7 @@ TEST(IsInRange, Various) {
     EXPECT_TRUE(rng.isValid());
     EXPECT_EQ(rng.asString(), "0.0.0.0/0");
     EXPECT_EQ(rng.length(), 0);
-    EXPECT_EQ(rng.version(), IpVersion::v4);
+    EXPECT_EQ(rng.ip()->version(), IpVersion::v4);
     EXPECT_TRUE(rng.isInRange(Ipv4Instance("10.255.255.255")));
     EXPECT_TRUE(rng.isInRange(Ipv4Instance("9.255.255.255")));
     EXPECT_TRUE(rng.isInRange(Ipv4Instance("0.0.0.0")));
@@ -110,7 +110,7 @@ TEST(IsInRange, Various) {
     EXPECT_TRUE(rng.isValid());
     EXPECT_EQ(rng.asString(), "10.192.0.0/10");
     EXPECT_EQ(rng.length(), 10);
-    EXPECT_EQ(rng.version(), IpVersion::v4);
+    EXPECT_EQ(rng.ip()->version(), IpVersion::v4);
     EXPECT_TRUE(rng.isInRange(Ipv4Instance("10.255.255.255")));
     EXPECT_FALSE(rng.isInRange(Ipv4Instance("9.255.255.255")));
     EXPECT_FALSE(rng.isInRange(Ipv4Instance("0.0.0.0")));
@@ -122,7 +122,7 @@ TEST(IsInRange, Various) {
     EXPECT_TRUE(rng.isValid());
     EXPECT_EQ(rng.asString(), "::/0");
     EXPECT_EQ(rng.length(), 0);
-    EXPECT_EQ(rng.version(), IpVersion::v6);
+    EXPECT_EQ(rng.ip()->version(), IpVersion::v6);
     EXPECT_TRUE(rng.isInRange(Ipv6Instance("::")));
     EXPECT_TRUE(rng.isInRange(Ipv6Instance("::1")));
     EXPECT_TRUE(rng.isInRange(Ipv6Instance("2001::")));
@@ -135,7 +135,7 @@ TEST(IsInRange, Various) {
     EXPECT_TRUE(rng.isValid());
     EXPECT_EQ(rng.asString(), "::1/128");
     EXPECT_EQ(rng.length(), 128);
-    EXPECT_EQ(rng.version(), IpVersion::v6);
+    EXPECT_EQ(rng.ip()->version(), IpVersion::v6);
     EXPECT_TRUE(rng.isInRange(Ipv6Instance("::1")));
     EXPECT_FALSE(rng.isInRange(Ipv6Instance("::")));
     EXPECT_FALSE(rng.isInRange(Ipv6Instance("2001::")));
@@ -147,7 +147,7 @@ TEST(IsInRange, Various) {
     EXPECT_TRUE(rng.isValid());
     EXPECT_EQ(rng.asString(), "2001:abcd:ef01:2345::/64");
     EXPECT_EQ(rng.length(), 64);
-    EXPECT_EQ(rng.version(), IpVersion::v6);
+    EXPECT_EQ(rng.ip()->version(), IpVersion::v6);
     EXPECT_TRUE(rng.isInRange(Ipv6Instance("2001:abcd:ef01:2345::1")));
     EXPECT_TRUE(rng.isInRange(Ipv6Instance("2001:abcd:ef01:2345::")));
     EXPECT_FALSE(rng.isInRange(Ipv6Instance("2001::")));
@@ -161,7 +161,7 @@ TEST(IsInRange, Various) {
     EXPECT_TRUE(rng.isValid());
     EXPECT_EQ(rng.asString(), "2001:abcd:ef01:2340::/60");
     EXPECT_EQ(rng.length(), 60);
-    EXPECT_EQ(rng.version(), IpVersion::v6);
+    EXPECT_EQ(rng.ip()->version(), IpVersion::v6);
     EXPECT_TRUE(rng.isInRange(Ipv6Instance("2001:abcd:ef01:2345::")));
     EXPECT_TRUE(rng.isInRange(Ipv6Instance("2001:abcd:ef01:2340::")));
     EXPECT_FALSE(rng.isInRange(Ipv6Instance("2001:abcd:ef01:2330::")));
@@ -212,9 +212,7 @@ TEST(CidrRangeTest, OperatorIsEqual) {
 
 TEST(CidrRangeTest, InvalidCidrRange) {
   CidrRange rng1 = CidrRange::create("foo");
-  EXPECT_EQ(nullptr, rng1.ipv4());
-  EXPECT_EQ(nullptr, rng1.ipv6());
-  EXPECT_EQ(IpVersion::v4, rng1.version());
+  EXPECT_EQ(nullptr, rng1.ip());
   EXPECT_EQ("/-1", rng1.asString());
   // Not equal due to invalid CidrRange.
   EXPECT_FALSE(rng1 == rng1);
@@ -228,7 +226,7 @@ TEST(Ipv4CidrRangeTest, InstanceConstSharedPtrAndLengthCtor) {
   CidrRange rng(CidrRange::create(ptr, 31)); // Copy ctor.
   EXPECT_TRUE(rng.isValid());
   EXPECT_EQ(rng.length(), 31);
-  EXPECT_EQ(rng.version(), IpVersion::v4);
+  EXPECT_EQ(rng.ip()->version(), IpVersion::v4);
   EXPECT_EQ(rng.asString(), "1.2.3.4/31");
   EXPECT_FALSE(rng.isInRange(Ipv4Instance("1.2.3.3")));
   EXPECT_TRUE(rng.isInRange(Ipv4Instance("1.2.3.4")));
@@ -249,7 +247,7 @@ TEST(Ipv4CidrRangeTest, StringAndLengthCtor) {
   EXPECT_TRUE(rng.isValid());
   EXPECT_EQ(rng.asString(), "1.2.3.4/31");
   EXPECT_EQ(rng.length(), 31);
-  EXPECT_EQ(rng.version(), IpVersion::v4);
+  EXPECT_EQ(rng.ip()->version(), IpVersion::v4);
   EXPECT_FALSE(rng.isInRange(Ipv4Instance("1.2.3.3")));
   EXPECT_TRUE(rng.isInRange(Ipv4Instance("1.2.3.4")));
   EXPECT_TRUE(rng.isInRange(Ipv4Instance("1.2.3.5")));
@@ -266,7 +264,7 @@ TEST(Ipv4CidrRangeTest, StringCtor) {
   EXPECT_TRUE(rng.isValid());
   EXPECT_EQ(rng.asString(), "1.2.3.4/31");
   EXPECT_EQ(rng.length(), 31);
-  EXPECT_EQ(rng.version(), IpVersion::v4);
+  EXPECT_EQ(rng.ip()->version(), IpVersion::v4);
   EXPECT_FALSE(rng.isInRange(Ipv4Instance("1.2.3.3")));
   EXPECT_TRUE(rng.isInRange(Ipv4Instance("1.2.3.4")));
   EXPECT_TRUE(rng.isInRange(Ipv4Instance("1.2.3.5")));
@@ -289,7 +287,7 @@ TEST(Ipv4CidrRangeTest, BigRange) {
   EXPECT_TRUE(rng.isValid());
   EXPECT_EQ(rng.asString(), "10.0.0.0/8");
   EXPECT_EQ(rng.length(), 8);
-  EXPECT_EQ(rng.version(), IpVersion::v4);
+  EXPECT_EQ(rng.ip()->version(), IpVersion::v4);
   EXPECT_FALSE(rng.isInRange(Ipv4Instance("9.255.255.255")));
   std::string addr;
   for (int i = 0; i < 256; ++i) {
@@ -306,7 +304,7 @@ TEST(Ipv6CidrRange, InstanceConstSharedPtrAndLengthCtor) {
   CidrRange rng(CidrRange::create(ptr, 127)); // Copy ctor.
   EXPECT_TRUE(rng.isValid());
   EXPECT_EQ(rng.length(), 127);
-  EXPECT_EQ(rng.version(), IpVersion::v6);
+  EXPECT_EQ(rng.ip()->version(), IpVersion::v6);
   EXPECT_EQ(rng.asString(), "abcd::344/127");
   EXPECT_FALSE(rng.isInRange(Ipv6Instance("abcd::343")));
   EXPECT_TRUE(rng.isInRange(Ipv6Instance("abcd::344")));
@@ -327,7 +325,7 @@ TEST(Ipv6CidrRange, StringAndLengthCtor) {
   EXPECT_TRUE(rng.isValid());
   EXPECT_EQ(rng.asString(), "ff::ffc0/122");
   EXPECT_EQ(rng.length(), 122);
-  EXPECT_EQ(rng.version(), IpVersion::v6);
+  EXPECT_EQ(rng.ip()->version(), IpVersion::v6);
   EXPECT_FALSE(rng.isInRange(Ipv6Instance("ff::ffbf")));
   EXPECT_TRUE(rng.isInRange(Ipv6Instance("ff::ffc0")));
   EXPECT_TRUE(rng.isInRange(Ipv6Instance("ff::ffff")));
@@ -344,7 +342,7 @@ TEST(Ipv6CidrRange, StringCtor) {
   EXPECT_TRUE(rng.isValid());
   EXPECT_EQ(rng.asString(), "ff::fc00/118");
   EXPECT_EQ(rng.length(), 118);
-  EXPECT_EQ(rng.version(), IpVersion::v6);
+  EXPECT_EQ(rng.ip()->version(), IpVersion::v6);
   EXPECT_FALSE(rng.isInRange(Ipv6Instance("ff::fbff")));
   EXPECT_TRUE(rng.isInRange(Ipv6Instance("ff::fc00")));
   EXPECT_TRUE(rng.isInRange(Ipv6Instance("ff::ffff")));
@@ -368,7 +366,7 @@ TEST(Ipv6CidrRange, BigRange) {
   EXPECT_TRUE(rng.isValid());
   EXPECT_EQ(rng.asString(), "2001:db8:85a3::/64");
   EXPECT_EQ(rng.length(), 64);
-  EXPECT_EQ(rng.version(), IpVersion::v6);
+  EXPECT_EQ(rng.ip()->version(), IpVersion::v6);
   EXPECT_FALSE(rng.isInRange(Ipv6Instance("2001:0db8:85a2:ffff:ffff:ffff:ffff:ffff")));
   std::string addr;
   for (char c : std::string("0123456789abcdef")) {

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -127,22 +127,11 @@ TEST_F(NetworkFilterManagerTest, RateLimitAndTcpProxy) {
   manager.addReadFilter(ReadFilterSharedPtr{
       new RateLimit::TcpFilter::Instance(rl_config, RateLimit::ClientPtr{rl_client})});
 
-  std::string tcp_proxy_json = R"EOF(
-    {
-      "stat_prefix": "name",
-      "route_config": {
-        "routes": [
-          {
-            "cluster": "fake_cluster"
-          }
-        ]
-      }
-    }
-    )EOF";
-
-  Json::ObjectSharedPtr tcp_proxy_config_loader = Json::Factory::loadFromString(tcp_proxy_json);
+  envoy::api::v2::filter::network::TcpProxy tcp_proxy;
+  tcp_proxy.set_stat_prefix("name");
+  tcp_proxy.set_cluster("fake_cluster");
   Envoy::Filter::TcpProxyConfigSharedPtr tcp_proxy_config(
-      new Envoy::Filter::TcpProxyConfig(*tcp_proxy_config_loader, factory_context));
+      new Envoy::Filter::TcpProxyConfig(tcp_proxy, factory_context));
   manager.addReadFilter(ReadFilterSharedPtr{
       new Envoy::Filter::TcpProxy(tcp_proxy_config, factory_context.cluster_manager_)});
 


### PR DESCRIPTION
Signed-off-by: Greg Greenway <ggreenway@apple.com>

*title*: *Convert tcp_proxy to v2 config*

*Description*:
Convert tcp_proxy to natively use v2 config.  Added v1-->v2 translation.

*Risk Level*: Low

*Testing*: unit test
