### PR TITLE
Fix v2 TcpProxy config

### DIFF
--- a/source/server/config/network/tcp_proxy.cc
+++ b/source/server/config/network/tcp_proxy.cc
@@ -37,6 +37,11 @@ NetworkFilterFactoryCb TcpProxyConfigFactory::createFilterFactory(const Json::Ob
   return createFactory(tcp_proxy_config, context);
 }
 
+ProtobufTypes::MessagePtr TcpProxyConfigFactory::createEmptyConfigProto() {
+  return std::unique_ptr<envoy::api::v2::filter::network::TcpProxy>(
+      new envoy::api::v2::filter::network::TcpProxy());
+}
+
 /**
  * Static registration for the tcp_proxy filter. @see RegisterFactory.
  */

--- a/source/server/config/network/tcp_proxy.h
+++ b/source/server/config/network/tcp_proxy.h
@@ -20,6 +20,7 @@ public:
                                                       FactoryContext& context) override;
   NetworkFilterFactoryCb createFilterFactory(const Json::Object& json_config,
                                              FactoryContext& context) override;
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override;
   std::string name() override { return Config::NetworkFilterNames::get().TCP_PROXY; }
 
 private:


### PR DESCRIPTION
*Description*:
Add missing required function for TcpProxy v2 config to work.  Added test to verify.

*Risk Level*: Low

*Testing*: Unit