### PR TITLE
filter: Fix TcpProxy to accept null config object.

### DIFF
--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -125,14 +125,19 @@ TcpProxyStats TcpProxyConfig::generateStats(const std::string& name, Stats::Scop
 void TcpProxy::initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) {
   read_callbacks_ = &callbacks;
   ENVOY_CONN_LOG(debug, "new tcp proxy session", read_callbacks_->connection());
-  config_->stats().downstream_cx_total_.inc();
+
   read_callbacks_->connection().addConnectionCallbacks(downstream_callbacks_);
+  request_info_.downstream_address_ = read_callbacks_->connection().remoteAddress().asString();
+    
+  if (!config_) {
+    return;
+  }
+  config_->stats().downstream_cx_total_.inc();
   read_callbacks_->connection().setConnectionStats(
       {config_->stats().downstream_cx_rx_bytes_total_,
        config_->stats().downstream_cx_rx_bytes_buffered_,
        config_->stats().downstream_cx_tx_bytes_total_,
        config_->stats().downstream_cx_tx_bytes_buffered_, nullptr});
-  request_info_.downstream_address_ = read_callbacks_->connection().remoteAddress().asString();
 }
 
 void TcpProxy::readDisableUpstream(bool disable) {

--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -128,7 +128,7 @@ void TcpProxy::initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callb
 
   read_callbacks_->connection().addConnectionCallbacks(downstream_callbacks_);
   request_info_.downstream_address_ = read_callbacks_->connection().remoteAddress().asString();
-    
+
   if (!config_) {
     return;
   }

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -381,11 +381,10 @@ TEST(TcpProxyConfigTest, AccessLogConfig) {
 
 class TcpProxyNoConfigTest : public testing::Test {
 public:
-  TcpProxyNoConfigTest() {
-  }
+  TcpProxyNoConfigTest() {}
 
-  NiceMock<Network::MockReadFilterCallbacks> filter_callbacks_;  
-  NiceMock<Server::Configuration::MockFactoryContext> factory_context_;  
+  NiceMock<Network::MockReadFilterCallbacks> filter_callbacks_;
+  NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
   std::unique_ptr<TcpProxy> filter_;
 };
 
@@ -395,9 +394,9 @@ TEST_F(TcpProxyNoConfigTest, Initialization) {
 }
 
 TEST_F(TcpProxyNoConfigTest, ReadDisableDownstream) {
-  filter_.reset(new TcpProxy(nullptr, factory_context_.cluster_manager_));    
+  filter_.reset(new TcpProxy(nullptr, factory_context_.cluster_manager_));
   filter_->initializeReadFilterCallbacks(filter_callbacks_);
-  
+
   filter_->readDisableDownstream(true);
 }
 

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -379,6 +379,28 @@ TEST(TcpProxyConfigTest, AccessLogConfig) {
   EXPECT_EQ(2, config_obj.accessLogs().size());
 }
 
+class TcpProxyNoConfigTest : public testing::Test {
+public:
+  TcpProxyNoConfigTest() {
+  }
+
+  NiceMock<Network::MockReadFilterCallbacks> filter_callbacks_;  
+  NiceMock<Server::Configuration::MockFactoryContext> factory_context_;  
+  std::unique_ptr<TcpProxy> filter_;
+};
+
+TEST_F(TcpProxyNoConfigTest, Initialization) {
+  filter_.reset(new TcpProxy(nullptr, factory_context_.cluster_manager_));
+  filter_->initializeReadFilterCallbacks(filter_callbacks_);
+}
+
+TEST_F(TcpProxyNoConfigTest, ReadDisableDownstream) {
+  filter_.reset(new TcpProxy(nullptr, factory_context_.cluster_manager_));    
+  filter_->initializeReadFilterCallbacks(filter_callbacks_);
+  
+  filter_->readDisableDownstream(true);
+}
+
 class TcpProxyTest : public testing::Test {
 public:
   TcpProxyTest() {


### PR DESCRIPTION
*Description*:
TcpProxy is meant to be sub-classed, and checks for null configuration in all necessary places except for one. Added the necessary check so TcpProxy can be re-used in a sub-class.

*Risk Level*: Low

*Testing*:
Added a unit test that crashes with the old code, and passes with the new code.
