### PR TITLE
listener_manager: mark log parameter unreferenced

### DIFF
--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -126,6 +126,7 @@ bool ListenerImpl::drainClose() const {
 }
 
 void ListenerImpl::debugLog(const std::string& message) {
+  UNREFERENCED_PARAMETER(message);
   ENVOY_LOG(debug, "{}: name={}, hash={}, address={}", message, name_, hash_, address_->asString());
 }
 


### PR DESCRIPTION
Signed-off-by: Mike Schore <mike.schore@gmail.com>

*Description*:
Minor bugfix for when log statement gets compiled out.

*Risk Level*: Low

*Testing*: Builds
