### PR TITLE
TcpProxy: Add configurable connect retries

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -56,7 +56,7 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
     ),
     envoy_api = dict(
-        commit = "ae685c66fcb47a49b2b3d6ef41881b1ef664fbb5",
+        commit = "12c3240c5e3354358e53b58df558ae78468f219f",
         remote = "https://github.com/envoyproxy/data-plane-api",
     ),
     grpc_httpjson_transcoding = dict(

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -195,6 +195,7 @@ public:
   COUNTER  (upstream_cx_http2_total)                                                               \
   COUNTER  (upstream_cx_connect_fail)                                                              \
   COUNTER  (upstream_cx_connect_timeout)                                                           \
+  COUNTER  (upstream_cx_connect_attempts_exceeded)                                                 \
   COUNTER  (upstream_cx_overflow)                                                                  \
   HISTOGRAM(upstream_cx_connect_ms)                                                                \
   HISTOGRAM(upstream_cx_length_ms)                                                                 \

--- a/source/common/filter/tcp_proxy.h
+++ b/source/common/filter/tcp_proxy.h
@@ -68,6 +68,7 @@ public:
 
   const TcpProxyStats& stats() { return stats_; }
   const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() { return access_logs_; }
+  uint32_t maxConnectAttempts() const { return max_connect_attempts_; }
 
 private:
   struct Route {
@@ -85,6 +86,7 @@ private:
   std::vector<Route> routes_;
   const TcpProxyStats stats_;
   std::vector<AccessLog::InstanceSharedPtr> access_logs_;
+  const uint32_t max_connect_attempts_;
 };
 
 typedef std::shared_ptr<TcpProxyConfig> TcpProxyConfigSharedPtr;
@@ -155,26 +157,19 @@ protected:
     return config_->getRouteFromEntries(read_callbacks_->connection());
   }
 
-  virtual void onInitFailure() {
+  virtual void onInitFailure(Http::Code) {
     read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
-  }
-
-  virtual void onConnectTimeoutError() {
-    read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
-  }
-
-  virtual void onConnectionFailure() {
-    read_callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
   }
 
   virtual void onConnectionSuccess() {}
-  virtual void onUpstreamHostReady() {}
 
   Network::FilterStatus initializeUpstreamConnection();
   void onConnectTimeout();
   void onDownstreamEvent(Network::ConnectionEvent event);
   void onUpstreamData(Buffer::Instance& data);
   void onUpstreamEvent(Network::ConnectionEvent event);
+  void finalizeUpstreamConnectionStats();
+  void closeUpstreamConnection();
 
   TcpProxyConfigSharedPtr config_;
   Upstream::ClusterManager& cluster_manager_;
@@ -187,6 +182,7 @@ protected:
   std::shared_ptr<UpstreamCallbacks> upstream_callbacks_; // shared_ptr required for passing as a
                                                           // read filter.
   AccessLog::RequestInfoImpl request_info_;
+  uint32_t connect_attempts_{};
 };
 
 } // Filter

--- a/source/common/filter/tcp_proxy.h
+++ b/source/common/filter/tcp_proxy.h
@@ -152,12 +152,19 @@ protected:
     bool on_high_watermark_called_{false};
   };
 
+  enum class UpstreamFailureReason {
+    CONNECT_FAILED,
+    NO_HEALTHY_UPSTREAM,
+    RESOURCE_LIMIT_EXCEEDED,
+    NO_ROUTE,
+  };
+
   // Callbacks for different error and success states during connection establishment
   virtual const std::string& getUpstreamCluster() {
     return config_->getRouteFromEntries(read_callbacks_->connection());
   }
 
-  virtual void onInitFailure(Http::Code) {
+  virtual void onInitFailure(UpstreamFailureReason) {
     read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
   }
 

--- a/source/common/http/websocket/ws_handler_impl.cc
+++ b/source/common/http/websocket/ws_handler_impl.cc
@@ -20,44 +20,22 @@ WsHandlerImpl::WsHandlerImpl(HeaderMap& request_headers, const AccessLog::Reques
     : Filter::TcpProxy(nullptr, cluster_manager), request_headers_(request_headers),
       request_info_(request_info), route_entry_(route_entry), ws_callbacks_(callbacks) {
 
-  read_callbacks_ = read_callbacks;
-  read_callbacks_->connection().addConnectionCallbacks(downstream_callbacks_);
+  initializeReadFilterCallbacks(*read_callbacks);
 }
 
-void WsHandlerImpl::onInitFailure() {
-  HeaderMapImpl headers{
-      {Headers::get().Status, std::to_string(enumToInt(Code::ServiceUnavailable))}};
+void WsHandlerImpl::onInitFailure(Code failure_reason) {
+  HeaderMapImpl headers{{Headers::get().Status, std::to_string(enumToInt(failure_reason))}};
   ws_callbacks_.sendHeadersOnlyResponse(headers);
 }
 
-void WsHandlerImpl::onUpstreamHostReady() {
+void WsHandlerImpl::onConnectionSuccess() {
   // path and host rewrites
   route_entry_.finalizeRequestHeaders(request_headers_, request_info_);
   // for auto host rewrite
   if (route_entry_.autoHostRewrite() && !read_callbacks_->upstreamHost()->hostname().empty()) {
     request_headers_.Host()->value(read_callbacks_->upstreamHost()->hostname());
   }
-}
 
-void WsHandlerImpl::onConnectTimeoutError() {
-  HeaderMapImpl headers{{Headers::get().Status, std::to_string(enumToInt(Code::GatewayTimeout))}};
-  ws_callbacks_.sendHeadersOnlyResponse(headers);
-}
-
-void WsHandlerImpl::onConnectionFailure() {
-  // We send a 503 response if the upstream refuses to accept connections
-  // (i.e. non-null connect_timeout_timer). If the upstream closes connection
-  // after the starting data transfer, we close and flush the connection as
-  // in TCP proxy.
-  if (connect_timeout_timer_) {
-    HeaderMapImpl headers{{Headers::get().Status, std::to_string(enumToInt(Code::GatewayTimeout))}};
-    ws_callbacks_.sendHeadersOnlyResponse(headers);
-  } else {
-    read_callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
-  }
-}
-
-void WsHandlerImpl::onConnectionSuccess() {
   // Wrap upstream connection in HTTP Connection, so that we can
   // re-use the HTTP1 codec to send upgrade headers to upstream
   // host.

--- a/source/common/http/websocket/ws_handler_impl.cc
+++ b/source/common/http/websocket/ws_handler_impl.cc
@@ -24,7 +24,7 @@ WsHandlerImpl::WsHandlerImpl(HeaderMap& request_headers, const AccessLog::Reques
 }
 
 void WsHandlerImpl::onInitFailure(UpstreamFailureReason failure_reason) {
-  Code http_code;
+  Code http_code = Code::InternalServerError;
   switch (failure_reason) {
   case UpstreamFailureReason::CONNECT_FAILED:
     http_code = Code::GatewayTimeout;

--- a/source/common/http/websocket/ws_handler_impl.h
+++ b/source/common/http/websocket/ws_handler_impl.h
@@ -34,10 +34,7 @@ protected:
   // Filter::TcpProxy
   const std::string& getUpstreamCluster() override { return route_entry_.clusterName(); }
 
-  void onInitFailure() override;
-  void onUpstreamHostReady() override;
-  void onConnectTimeoutError() override;
-  void onConnectionFailure() override;
+  void onInitFailure(Http::Code failure_reason) override;
   void onConnectionSuccess() override;
 
 private:

--- a/source/common/http/websocket/ws_handler_impl.h
+++ b/source/common/http/websocket/ws_handler_impl.h
@@ -33,8 +33,7 @@ public:
 protected:
   // Filter::TcpProxy
   const std::string& getUpstreamCluster() override { return route_entry_.clusterName(); }
-
-  void onInitFailure(Http::Code failure_reason) override;
+  void onInitFailure(UpstreamFailureReason failure_reason) override;
   void onConnectionSuccess() override;
 
 private:

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -407,167 +407,255 @@ public:
         .WillByDefault(SaveArg<0>(&access_log_data_));
   }
 
-  void configure(const std::string& accessLogJson) {
-    std::string json = R"EOF(
-    {{
-      "stat_prefix": "name",
-      "route_config": {{
-        "routes": [
-          {{
-            "cluster": "fake_cluster"
-          }}
-        ]
-      }},
-      "access_log": [
-        {}
-      ]
-    }}
-    )EOF";
-
-    Json::ObjectSharedPtr config = Json::Factory::loadFromString(fmt::format(json, accessLogJson));
-    config_.reset(new TcpProxyConfig(constructTcpProxyConfigFromJson(*config, factory_context_)));
+  void configure(const envoy::api::v2::filter::network::TcpProxy& config) {
+    config_.reset(new TcpProxyConfig(config, factory_context_));
   }
 
-  void setup(bool return_connection, const std::string& accessLogJson) {
-    configure(accessLogJson);
-    if (return_connection) {
-      connect_timer_ = new NiceMock<Event::MockTimer>(&filter_callbacks_.connection_.dispatcher_);
-      EXPECT_CALL(*connect_timer_, enableTimer(_));
+  envoy::api::v2::filter::network::TcpProxy defaultConfig() {
+    envoy::api::v2::filter::network::TcpProxy config;
+    config.set_stat_prefix("name");
+    auto* route = config.mutable_deprecated_v1()->mutable_routes()->Add();
+    route->set_cluster("fake_cluster");
 
-      upstream_local_address_ = Network::Utility::resolveUrl("tcp://2.2.2.2:50000");
-      upstream_connection_ = new NiceMock<Network::MockClientConnection>();
-      ON_CALL(*upstream_connection_, localAddress())
-          .WillByDefault(ReturnPointee(upstream_local_address_));
-      Upstream::MockHost::MockCreateConnectionData conn_info;
-      conn_info.connection_ = upstream_connection_;
-      conn_info.host_description_ = Upstream::makeTestHost(
-          factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_,
-          "tcp://127.0.0.1:80");
+    return config;
+  }
+
+  // Return the default config, plus one file access log with the specified format
+  envoy::api::v2::filter::network::TcpProxy accessLogConfig(const std::string access_log_format) {
+    envoy::api::v2::filter::network::TcpProxy config = defaultConfig();
+    envoy::api::v2::filter::AccessLog* access_log = config.mutable_access_log()->Add();
+    access_log->set_name(Config::AccessLogNames::get().FILE);
+    envoy::api::v2::filter::FileAccessLog file_access_log;
+    file_access_log.set_path("unused");
+    file_access_log.set_format(access_log_format);
+    MessageUtil::jsonConvert(file_access_log, *access_log->mutable_config());
+
+    return config;
+  }
+
+  void setupAndExpectUpstreamConnect() {}
+
+  void setup(uint32_t connections, const envoy::api::v2::filter::network::TcpProxy& config) {
+    configure(config);
+    upstream_local_address_ = Network::Utility::resolveUrl("tcp://2.2.2.2:50000");
+    if (connections >= 1) {
+      {
+        testing::InSequence sequence;
+        for (uint32_t i = 0; i < connections; i++) {
+          connect_timers_.push_back(
+              new NiceMock<Event::MockTimer>(&filter_callbacks_.connection_.dispatcher_));
+          EXPECT_CALL(*connect_timers_.at(i), enableTimer(_));
+        }
+      }
+
+      for (uint32_t i = 0; i < connections; i++) {
+        upstream_connections_.push_back(new NiceMock<Network::MockClientConnection>());
+        conn_infos_.push_back(Upstream::MockHost::MockCreateConnectionData());
+        conn_infos_.at(i).connection_ = upstream_connections_.back();
+        conn_infos_.at(i).host_description_ = Upstream::makeTestHost(
+            factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_,
+            "tcp://127.0.0.1:80");
+
+        ON_CALL(*upstream_connections_.at(i), localAddress())
+            .WillByDefault(ReturnPointee(upstream_local_address_));
+        EXPECT_CALL(*upstream_connections_.at(i), addReadFilter(_))
+            .WillOnce(SaveArg<0>(&upstream_read_filter_));
+        EXPECT_CALL(*upstream_connections_.at(i), dispatcher())
+            .WillRepeatedly(ReturnRef(filter_callbacks_.connection_.dispatcher_));
+      }
+    }
+
+    {
+      testing::InSequence sequence;
+      for (uint32_t i = 0; i < connections; i++) {
+        EXPECT_CALL(factory_context_.cluster_manager_, tcpConnForCluster_("fake_cluster", _))
+            .WillOnce(Return(conn_infos_.at(i)))
+            .RetiresOnSaturation();
+      }
       EXPECT_CALL(factory_context_.cluster_manager_, tcpConnForCluster_("fake_cluster", _))
-          .WillOnce(Return(conn_info));
-      EXPECT_CALL(*upstream_connection_, addReadFilter(_))
-          .WillOnce(SaveArg<0>(&upstream_read_filter_));
-    } else {
-      Upstream::MockHost::MockCreateConnectionData conn_info;
-      EXPECT_CALL(factory_context_.cluster_manager_, tcpConnForCluster_("fake_cluster", _))
-          .WillOnce(Return(conn_info));
+          .WillRepeatedly(Return(Upstream::MockHost::MockCreateConnectionData()));
     }
 
     filter_.reset(new TcpProxy(config_, factory_context_.cluster_manager_));
+    EXPECT_CALL(filter_callbacks_.connection_, readDisable(true));
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
-    EXPECT_EQ(return_connection ? Network::FilterStatus::Continue
-                                : Network::FilterStatus::StopIteration,
+    EXPECT_EQ(connections >= 1 ? Network::FilterStatus::Continue
+                               : Network::FilterStatus::StopIteration,
               filter_->onNewConnection());
 
     EXPECT_EQ(Optional<uint64_t>(), filter_->computeHashKey());
     EXPECT_EQ(&filter_callbacks_.connection_, filter_->downstreamConnection());
   }
 
-  void setup(bool return_connection) { setup(return_connection, std::string()); }
+  void setup(uint32_t connections) { setup(connections, defaultConfig()); }
+
+  void raiseEventUpstreamConnected(uint32_t conn_index) {
+    EXPECT_CALL(*connect_timers_.at(conn_index), disableTimer());
+    EXPECT_CALL(filter_callbacks_.connection_, readDisable(false));
+    upstream_connections_.at(conn_index)->raiseEvent(Network::ConnectionEvent::Connected);
+  }
 
   TcpProxyConfigSharedPtr config_;
   NiceMock<Network::MockReadFilterCallbacks> filter_callbacks_;
   NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
-  NiceMock<Network::MockClientConnection>* upstream_connection_{};
+  std::vector<NiceMock<Network::MockClientConnection>*> upstream_connections_{};
+  std::vector<Upstream::MockHost::MockCreateConnectionData> conn_infos_;
   Network::ReadFilterSharedPtr upstream_read_filter_;
-  NiceMock<Event::MockTimer>* connect_timer_{};
+  std::vector<NiceMock<Event::MockTimer>*> connect_timers_;
   std::unique_ptr<TcpProxy> filter_;
   std::string access_log_data_;
   Network::Address::InstanceConstSharedPtr upstream_local_address_;
 };
 
 TEST_F(TcpProxyTest, UpstreamDisconnect) {
-  setup(true);
+  setup(1);
 
   Buffer::OwnedImpl buffer("hello");
-  EXPECT_CALL(*upstream_connection_, write(BufferEqual(&buffer)));
+  EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer)));
   filter_->onData(buffer);
 
-  EXPECT_CALL(*connect_timer_, disableTimer());
-  upstream_connection_->raiseEvent(Network::ConnectionEvent::Connected);
+  raiseEventUpstreamConnected(0);
 
   Buffer::OwnedImpl response("world");
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response)));
   upstream_read_filter_->onData(response);
 
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
-  upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
+}
+
+// Test that reconnect is attempted after a connect failure
+TEST_F(TcpProxyTest, ConnectAttemptsUpstreamFail) {
+  envoy::api::v2::filter::network::TcpProxy config = defaultConfig();
+  config.mutable_max_connect_attempts()->set_value(2);
+  setup(2, config);
+
+  EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
+  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  raiseEventUpstreamConnected(1);
+
+  EXPECT_EQ(0U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
+                    .counter("upstream_cx_connect_attempts_exceeded")
+                    .value());
+}
+
+// Test that reconnect is attempted after a connect timeout
+TEST_F(TcpProxyTest, ConnectAttemptsUpstreamTimeout) {
+  envoy::api::v2::filter::network::TcpProxy config = defaultConfig();
+  config.mutable_max_connect_attempts()->set_value(2);
+  setup(2, config);
+
+  EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
+  connect_timers_.at(0)->callback_();
+  raiseEventUpstreamConnected(1);
+
+  EXPECT_EQ(0U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
+                    .counter("upstream_cx_connect_attempts_exceeded")
+                    .value());
+}
+
+// Test that only the configured number of connect attempts occur
+TEST_F(TcpProxyTest, ConnectAttemptsLimit) {
+  envoy::api::v2::filter::network::TcpProxy config = defaultConfig();
+  config.mutable_max_connect_attempts()->set_value(3);
+  setup(3, config);
+
+  {
+    testing::InSequence sequence;
+    EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
+    EXPECT_CALL(*upstream_connections_.at(1), close(Network::ConnectionCloseType::NoFlush));
+    EXPECT_CALL(*upstream_connections_.at(2), close(Network::ConnectionCloseType::NoFlush));
+    EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
+  }
+
+  // Try both failure modes
+  connect_timers_.at(0)->callback_();
+  upstream_connections_.at(1)->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  upstream_connections_.at(2)->raiseEvent(Network::ConnectionEvent::RemoteClose);
+
+  EXPECT_EQ(1U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
+                    .counter("upstream_cx_connect_timeout")
+                    .value());
+  EXPECT_EQ(2U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
+                    .counter("upstream_cx_connect_fail")
+                    .value());
+  EXPECT_EQ(1U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
+                    .counter("upstream_cx_connect_attempts_exceeded")
+                    .value());
+  EXPECT_EQ(0U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
+                    .counter("upstream_cx_overflow")
+                    .value());
+  EXPECT_EQ(0U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
+                    .counter("upstream_cx_no_successful_host")
+                    .value());
 }
 
 TEST_F(TcpProxyTest, UpstreamDisconnectDownstreamFlowControl) {
-  setup(true);
+  setup(1);
 
   Buffer::OwnedImpl buffer("hello");
-  EXPECT_CALL(*upstream_connection_, write(BufferEqual(&buffer)));
+  EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer)));
   filter_->onData(buffer);
 
-  EXPECT_CALL(*connect_timer_, disableTimer());
-  upstream_connection_->raiseEvent(Network::ConnectionEvent::Connected);
+  raiseEventUpstreamConnected(0);
 
   Buffer::OwnedImpl response("world");
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response)));
   upstream_read_filter_->onData(response);
 
-  EXPECT_CALL(*upstream_connection_, readDisable(true));
+  EXPECT_CALL(*upstream_connections_.at(0), readDisable(true));
   filter_callbacks_.connection_.runHighWatermarkCallbacks();
 
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
-  upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
 
   filter_callbacks_.connection_.runLowWatermarkCallbacks();
 }
 
 TEST_F(TcpProxyTest, DownstreamDisconnectRemote) {
-  setup(true);
+  setup(1);
 
   Buffer::OwnedImpl buffer("hello");
-  EXPECT_CALL(*upstream_connection_, write(BufferEqual(&buffer)));
+  EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer)));
   filter_->onData(buffer);
 
-  EXPECT_CALL(*connect_timer_, disableTimer());
-  upstream_connection_->raiseEvent(Network::ConnectionEvent::Connected);
+  raiseEventUpstreamConnected(0);
 
   Buffer::OwnedImpl response("world");
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response)));
   upstream_read_filter_->onData(response);
 
-  EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
 TEST_F(TcpProxyTest, DownstreamDisconnectLocal) {
-  setup(true);
+  setup(1);
 
   Buffer::OwnedImpl buffer("hello");
-  EXPECT_CALL(*upstream_connection_, write(BufferEqual(&buffer)));
+  EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer)));
   filter_->onData(buffer);
 
-  EXPECT_CALL(*connect_timer_, disableTimer());
-  upstream_connection_->raiseEvent(Network::ConnectionEvent::Connected);
+  raiseEventUpstreamConnected(0);
 
   Buffer::OwnedImpl response("world");
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response)));
   upstream_read_filter_->onData(response);
 
-  EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::LocalClose);
 }
 
 TEST_F(TcpProxyTest, UpstreamConnectTimeout) {
-  setup(true, R"EOF(
-      {
-        "path": "unused",
-        "format": "%RESPONSE_FLAGS%"
-      }
-    )EOF");
+  setup(1, accessLogConfig("%RESPONSE_FLAGS%"));
 
   Buffer::OwnedImpl buffer("hello");
-  EXPECT_CALL(*upstream_connection_, write(BufferEqual(&buffer)));
+  EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer)));
   filter_->onData(buffer);
 
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
-  EXPECT_CALL(*upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
-  connect_timer_->callback_();
+  EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
+  connect_timers_.at(0)->callback_();
   EXPECT_EQ(1U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
                     .counter("upstream_cx_connect_timeout")
                     .value());
@@ -578,18 +666,13 @@ TEST_F(TcpProxyTest, UpstreamConnectTimeout) {
 
 TEST_F(TcpProxyTest, NoHost) {
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
-  setup(false, R"EOF(
-      {
-        "path": "unused",
-        "format": "%RESPONSE_FLAGS%"
-      }
-    )EOF");
+  setup(0, accessLogConfig("%RESPONSE_FLAGS%"));
   filter_.reset();
   EXPECT_EQ(access_log_data_, "UH");
 }
 
 TEST_F(TcpProxyTest, DisconnectBeforeData) {
-  configure("");
+  configure(defaultConfig());
   filter_.reset(new TcpProxy(config_, factory_context_.cluster_manager_));
   filter_->initializeReadFilterCallbacks(filter_callbacks_);
 
@@ -597,20 +680,14 @@ TEST_F(TcpProxyTest, DisconnectBeforeData) {
 }
 
 TEST_F(TcpProxyTest, UpstreamConnectFailure) {
-  setup(true, R"EOF(
-      {
-        "path": "unused",
-        "format": "%RESPONSE_FLAGS%"
-      }
-    )EOF");
+  setup(1, accessLogConfig("%RESPONSE_FLAGS%"));
 
   Buffer::OwnedImpl buffer("hello");
-  EXPECT_CALL(*upstream_connection_, write(BufferEqual(&buffer)));
   filter_->onData(buffer);
 
-  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
-  EXPECT_CALL(*connect_timer_, disableTimer());
-  upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(*connect_timers_.at(0), disableTimer());
+  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_EQ(1U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
                     .counter("upstream_cx_connect_fail")
                     .value());
@@ -620,12 +697,7 @@ TEST_F(TcpProxyTest, UpstreamConnectFailure) {
 }
 
 TEST_F(TcpProxyTest, UpstreamConnectionLimit) {
-  configure(R"EOF(
-      {
-        "path": "unused",
-        "format": "%RESPONSE_FLAGS%"
-      }
-    )EOF");
+  configure(accessLogConfig("%RESPONSE_FLAGS%"));
   factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->resource_manager_.reset(
       new Upstream::ResourceManagerImpl(factory_context_.runtime_loader_, "fake_key", 0, 0, 0, 0));
 
@@ -646,24 +718,14 @@ TEST_F(TcpProxyTest, UpstreamConnectionLimit) {
 
 // Test that access log fields %UPSTREAM_HOST% and %UPSTREAM_CLUSTER% are correctly logged.
 TEST_F(TcpProxyTest, AccessLogUpstreamHost) {
-  setup(true, R"EOF(
-      {
-        "path": "unused",
-        "format": "%UPSTREAM_HOST% %UPSTREAM_CLUSTER%"
-      }
-    )EOF");
+  setup(1, accessLogConfig("%UPSTREAM_HOST% %UPSTREAM_CLUSTER%"));
   filter_.reset();
   EXPECT_EQ(access_log_data_, "127.0.0.1:80 fake_cluster");
 }
 
 // Test that access log field %UPSTREAM_LOCAL_ADDRESS% is correctly logged.
 TEST_F(TcpProxyTest, AccessLogUpstreamLocalAddress) {
-  setup(true, R"EOF(
-      {
-        "path": "unused",
-        "format": "%UPSTREAM_LOCAL_ADDRESS%"
-      }
-    )EOF");
+  setup(1, accessLogConfig("%UPSTREAM_LOCAL_ADDRESS%"));
   filter_.reset();
   EXPECT_EQ(access_log_data_, "2.2.2.2:50000");
 }
@@ -674,12 +736,7 @@ TEST_F(TcpProxyTest, AccessLogDownstreamAddress) {
       Network::Utility::resolveUrl("tcp://1.1.1.1:40000");
   ON_CALL(filter_callbacks_.connection_, remoteAddress())
       .WillByDefault(ReturnPointee(downstream_address));
-  setup(true, R"EOF(
-      {
-        "path": "unused",
-        "format": "%DOWNSTREAM_ADDRESS%"
-      }
-    )EOF");
+  setup(1, accessLogConfig("%DOWNSTREAM_ADDRESS%"));
   filter_.reset();
   EXPECT_EQ(access_log_data_, "1.1.1.1:40000");
 }
@@ -687,21 +744,17 @@ TEST_F(TcpProxyTest, AccessLogDownstreamAddress) {
 // Test that access log fields %BYTES_RECEIVED%, %BYTES_SENT%, %START_TIME%, %DURATION% are
 // all correctly logged.
 TEST_F(TcpProxyTest, AccessLogBytesRxTxDuration) {
-  setup(true, R"EOF(
-      {
-        "path": "unused",
-        "format": "bytesreceived=%BYTES_RECEIVED% bytessent=%BYTES_SENT% datetime=%START_TIME% nonzeronum=%DURATION%"
-      }
-    )EOF");
+  setup(1, accessLogConfig("bytesreceived=%BYTES_RECEIVED% bytessent=%BYTES_SENT% "
+                           "datetime=%START_TIME% nonzeronum=%DURATION%"));
 
-  upstream_connection_->raiseEvent(Network::ConnectionEvent::Connected);
+  raiseEventUpstreamConnected(0);
   Buffer::OwnedImpl buffer("a");
   filter_->onData(buffer);
   Buffer::OwnedImpl response("bb");
   upstream_read_filter_->onData(response);
 
   std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
   filter_.reset();
 
   EXPECT_THAT(access_log_data_,

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -1073,6 +1073,7 @@ TEST_F(HttpConnectionManagerImplTest, WebSocketPrefixAndAutoHostRewrite) {
 
   Buffer::OwnedImpl fake_input("1234");
   conn_manager_->onData(fake_input);
+  upstream_connection->raiseEvent(Network::ConnectionEvent::Connected);
 
   // rewritten authority header when auto_host_rewrite is true
   EXPECT_STREQ("newhost", raw_header_ptr->Host()->value().c_str());


### PR DESCRIPTION
If the TcpProxy fails to connect to an upstream, retry with a new LB pick, up to a configurable number of times.

*API Changes*: https://github.com/envoyproxy/data-plane-api/pull/248

*Risk Level*: Medium

*Testing*: Unit
