### PR TITLE
test: avoid taking reference to temporary in access_log mocks.

### DIFF
--- a/test/mocks/access_log/mocks.h
+++ b/test/mocks/access_log/mocks.h
@@ -64,8 +64,8 @@ public:
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_{
       new testing::NiceMock<Upstream::MockHostDescription>()};
   SystemTime start_time_;
-  std::chrono::microseconds request_received_duration_;
-  std::chrono::microseconds response_received_duration_;
+  Optional<std::chrono::microseconds> request_received_duration_;
+  Optional<std::chrono::microseconds> response_received_duration_;
 };
 
 } // namespace AccessLog


### PR DESCRIPTION
This showed up during the Google import.

Risk Level: Low
Testing: bazel test //test/...

Signed-off-by: Harvey Tuch <htuch@google.com>