### PR TITLE
protobuf: s/Protobuf::Empty/ProtobufWkt::Empty/.

### DIFF
--- a/source/server/config/http/empty_http_filter_config.h
+++ b/source/server/config/http/empty_http_filter_config.h
@@ -34,7 +34,7 @@ public:
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return ProtobufTypes::MessagePtr{new Envoy::Protobuf::Empty()};
+    return ProtobufTypes::MessagePtr{new Envoy::ProtobufWkt::Empty()};
   }
 };
 


### PR DESCRIPTION
Needed for Google import, WKTs should be referenced in this namespace.

*Risk Level*: Low
*Testing*: bazel test //test/...

Signed-off-by: Harvey Tuch <htuch@google.com>