### PR TITLE
server: Fix assert failure during early shutdown

### DIFF
--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -466,7 +466,9 @@ void ListenerManagerImpl::stopListeners() {
 }
 
 void ListenerManagerImpl::stopWorkers() {
-  ASSERT(workers_started_);
+  if (!workers_started_) {
+    return;
+  }
   for (const auto& worker : workers_) {
     worker->stop();
   }

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -12,12 +12,12 @@
 
 #include "gtest/gtest.h"
 
+using testing::_;
 using testing::InSequence;
 using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
 using testing::Throw;
-using testing::_;
 
 namespace Envoy {
 namespace Server {
@@ -739,6 +739,14 @@ TEST_F(ListenerManagerImplTest, DuplicateAddressDontBind) {
       "error adding listener: 'bar' has duplicate address '0.0.0.0:1234' as existing listener");
 
   EXPECT_CALL(*listener_foo, onDestroy());
+}
+
+TEST_F(ListenerManagerImplTest, EarlyShutdown) {
+  // If stopWorkers is called before the workers are started, it should be a no-op: they should be
+  // neither started nor stopped.
+  EXPECT_CALL(*worker_, start(_)).Times(0);
+  EXPECT_CALL(*worker_, stop()).Times(0);
+  manager_->stopWorkers();
 }
 
 } // namespace Server

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -12,12 +12,12 @@
 
 #include "gtest/gtest.h"
 
-using testing::_;
 using testing::InSequence;
 using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
 using testing::Throw;
+using testing::_;
 
 namespace Envoy {
 namespace Server {


### PR DESCRIPTION
*Description*:
Currently we assert that the workers have been started before stopping
them, but we also avoid starting the workers if we've already received
SIGTERM by that point in initialization. The result is that sending
Envoy a SIGTERM too early leads to an assert failure (in builds with
asserts enabled).

This changes the assert to an early return, so that we simply skip the
calls to both start() and stop() if shutting down early, and adds a test
to cover that case.

*Risk Level*: Low

*Testing*: Unit test

Signed-off-by: Reuven Lazarus <rzl@google.com>