### PR TITLE
cds: allow v1 config to define api_type in the json-schema

### DIFF
--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -1131,6 +1131,10 @@ const std::string Json::Schema::CLUSTER_MANAGER_SCHEMA(R"EOF(
             "type" : "integer",
             "minimum" : 0,
             "exclusiveMinimum" : true
+          },
+          "api_type" : {
+            "type" : "string",
+            "enum" : ["REST_LEGACY", "REST", "GRPC"]
           }
         },
         "required" : ["cluster"],


### PR DESCRIPTION
cds: allow v1 config to define api_type in the json-schema

*Description*: https://github.com/envoyproxy/envoy/pull/1583 enabled v1 bootstrap configs to define the api type of the management server. This PR adds that constraint to the CDS definition schema.

*Risk Level*: Low

*Testing*: existing utility tests test the translation; existing tests test that a v2 grpc cds server can be used.