### PR TITLE
config: --v2-config-only CLI flag.

### DIFF
--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -65,6 +65,12 @@ public:
   virtual const std::string& configPath() PURE;
 
   /**
+   * @return bool whether the config should only be parsed as v2. If false, when a v2 parse fails,
+   *              a second attempt to parse the config as v1 will be made.
+   */
+  virtual bool v2ConfigOnly() PURE;
+
+  /**
    * @return const std::string& the admin address output file.
    */
   virtual const std::string& adminAddressPath() PURE;

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -67,8 +67,12 @@ void ValidationInstance::initialize(Options& options,
   try {
     MessageUtil::loadFromFile(options.configPath(), bootstrap);
   } catch (const EnvoyException& e) {
-    // TODO(htuch): When v1 is deprecated, make this a warning encouraging config upgrade.
-    ENVOY_LOG(debug, "Unable to initialize config as v2, will retry as v1: {}", e.what());
+    if (options.v2ConfigOnly()) {
+      throw;
+    } else {
+      // TODO(htuch): When v1 is deprecated, make this a warning encouraging config upgrade.
+      ENVOY_LOG(debug, "Unable to initialize config as v2, will retry as v1: {}", e.what());
+    }
   }
   if (!bootstrap.has_admin()) {
     Json::ObjectSharedPtr config_json = Json::Factory::loadFromFile(options.configPath());

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -48,6 +48,7 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_r
                                         std::thread::hardware_concurrency(), "uint32_t", cmd);
   TCLAP::ValueArg<std::string> config_path("c", "config-path", "Path to configuration file", false,
                                            "", "string", cmd);
+  TCLAP::SwitchArg v2_config_only("", "v2-config-only", "parse config as v2 only", cmd, false);
   TCLAP::ValueArg<std::string> admin_address_path("", "admin-address-path", "Admin address path",
                                                   false, "", "string", cmd);
   TCLAP::ValueArg<std::string> local_address_ip_version("", "local-address-ip-version",
@@ -142,6 +143,7 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_r
   base_id_ = base_id.getValue() * 10;
   concurrency_ = concurrency.getValue();
   config_path_ = config_path.getValue();
+  v2_config_only_ = v2_config_only.getValue();
   admin_address_path_ = admin_address_path.getValue();
   log_path_ = log_path.getValue();
   restart_epoch_ = restart_epoch.getValue();

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -23,6 +23,7 @@ public:
   uint64_t baseId() override { return base_id_; }
   uint32_t concurrency() override { return concurrency_; }
   const std::string& configPath() override { return config_path_; }
+  bool v2ConfigOnly() override { return v2_config_only_; }
   const std::string& adminAddressPath() override { return admin_address_path_; }
   Network::Address::IpVersion localAddressIpVersion() override { return local_address_ip_version_; }
   std::chrono::seconds drainTime() override { return drain_time_; }
@@ -42,6 +43,7 @@ private:
   uint64_t base_id_;
   uint32_t concurrency_;
   std::string config_path_;
+  bool v2_config_only_;
   std::string admin_address_path_;
   Network::Address::IpVersion local_address_ip_version_;
   spdlog::level::level_enum log_level_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -161,8 +161,12 @@ void InstanceImpl::initialize(Options& options,
   try {
     MessageUtil::loadFromFile(options.configPath(), bootstrap);
   } catch (const EnvoyException& e) {
-    // TODO(htuch): When v1 is deprecated, make this a warning encouraging config upgrade.
-    ENVOY_LOG(debug, "Unable to initialize config as v2, will retry as v1: {}", e.what());
+    if (options.v2ConfigOnly()) {
+      throw;
+    } else {
+      // TODO(htuch): When v1 is deprecated, make this a warning encouraging config upgrade.
+      ENVOY_LOG(debug, "Unable to initialize config as v2, will retry as v1: {}", e.what());
+    }
   }
   if (!bootstrap.has_admin()) {
     Json::ObjectSharedPtr config_json = Json::Factory::loadFromFile(options.configPath());

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -36,6 +36,7 @@ public:
   uint64_t baseId() override { return 0; }
   uint32_t concurrency() override { return 1; }
   const std::string& configPath() override { return config_path_; }
+  bool v2ConfigOnly() override { return false; }
   const std::string& adminAddressPath() override { return admin_address_path_; }
   Network::Address::IpVersion localAddressIpVersion() override { return local_address_ip_version_; }
   std::chrono::seconds drainTime() override { return std::chrono::seconds(1); }

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -20,7 +20,7 @@ namespace Server {
 MockOptions::MockOptions(const std::string& config_path)
     : config_path_(config_path), admin_address_path_("") {
   ON_CALL(*this, configPath()).WillByDefault(ReturnRef(config_path_));
-  ON_CALL(*this, v2ConfigOnly()).WillByDefault(Return(v2_config_only_));
+  ON_CALL(*this, v2ConfigOnly()).WillByDefault(Invoke([this] { return v2_config_only_; }));
   ON_CALL(*this, adminAddressPath()).WillByDefault(ReturnRef(admin_address_path_));
   ON_CALL(*this, serviceClusterName()).WillByDefault(ReturnRef(service_cluster_name_));
   ON_CALL(*this, serviceNodeName()).WillByDefault(ReturnRef(service_node_name_));

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -20,6 +20,7 @@ namespace Server {
 MockOptions::MockOptions(const std::string& config_path)
     : config_path_(config_path), admin_address_path_("") {
   ON_CALL(*this, configPath()).WillByDefault(ReturnRef(config_path_));
+  ON_CALL(*this, v2ConfigOnly()).WillByDefault(Return(v2_config_only_));
   ON_CALL(*this, adminAddressPath()).WillByDefault(ReturnRef(admin_address_path_));
   ON_CALL(*this, serviceClusterName()).WillByDefault(ReturnRef(service_cluster_name_));
   ON_CALL(*this, serviceNodeName()).WillByDefault(ReturnRef(service_node_name_));

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -63,7 +63,7 @@ public:
   MOCK_METHOD0(maxObjNameLength, uint64_t());
 
   std::string config_path_;
-  bool v2_config_only_;
+  bool v2_config_only_{};
   std::string admin_address_path_;
   std::string service_cluster_name_;
   std::string service_node_name_;

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -46,6 +46,7 @@ public:
   MOCK_METHOD0(baseId, uint64_t());
   MOCK_METHOD0(concurrency, uint32_t());
   MOCK_METHOD0(configPath, const std::string&());
+  MOCK_METHOD0(v2ConfigOnly, bool());
   MOCK_METHOD0(adminAddressPath, const std::string&());
   MOCK_METHOD0(localAddressIpVersion, Network::Address::IpVersion());
   MOCK_METHOD0(drainTime, std::chrono::seconds());
@@ -62,6 +63,7 @@ public:
   MOCK_METHOD0(maxObjNameLength, uint64_t());
 
   std::string config_path_;
+  bool v2_config_only_;
   std::string admin_address_path_;
   std::string service_cluster_name_;
   std::string service_node_name_;

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -41,10 +41,11 @@ TEST(OptionsImplTest, All) {
       "envoy --mode validate --concurrency 2 -c hello --admin-address-path path --restart-epoch 1 "
       "--local-address-ip-version v6 -l info --service-cluster cluster --service-node node "
       "--service-zone zone --file-flush-interval-msec 9000 --drain-time-s 60 "
-      "--parent-shutdown-time-s 90 --log-path /foo/bar");
+      "--parent-shutdown-time-s 90 --log-path /foo/bar --v2-config-only");
   EXPECT_EQ(Server::Mode::Validate, options->mode());
   EXPECT_EQ(2U, options->concurrency());
   EXPECT_EQ("hello", options->configPath());
+  EXPECT_TRUE(options->v2ConfigOnly());
   EXPECT_EQ("path", options->adminAddressPath());
   EXPECT_EQ(Network::Address::IpVersion::v6, options->localAddressIpVersion());
   EXPECT_EQ(1U, options->restartEpoch());


### PR DESCRIPTION
This determines whether the config should only be parsed as v2. If false, when a v2 parse fails,
a second attempt to parse the config as v1 will be made (existing behavior).

This improves the UX when working with v2 configs, as Envoy will fail hard with meaningful messages
rather than attempting to fallback and presenting v1 config errors when a bad v2 config parses as
neither v1 or v2.

When we deprecate v1, this flag will default to true.

Risk Level: Low
Testing: Additional unit tests for server/options.

Signed-off-by: Harvey Tuch <htuch@google.com>