### PR TITLE
[wip] traffic splitting for tcp proxy

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -60,8 +60,8 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
     ),
     envoy_api = dict(
-        commit = "c73aac33c9d9f07dfc2d93e09b110a2269bb0632",
-        remote = "https://github.com/envoyproxy/data-plane-api",
+        commit = "5ba17fd40cd872c59ef00eae673c792b255a9bbc",
+        remote = "https://github.com/rshriram/envoy-api",
     ),
     grpc_httpjson_transcoding = dict(
         commit = "e4f58aa07b9002befa493a0a82e10f2e98b51fc6",

--- a/source/common/filter/BUILD
+++ b/source/common/filter/BUILD
@@ -42,6 +42,7 @@ envoy_cc_library(
     srcs = ["tcp_proxy.cc"],
     hdrs = ["tcp_proxy.h"],
     external_deps = [
+        "envoy_rds",
         "envoy_filter_network_tcp_proxy",
     ],
     deps = [
@@ -52,6 +53,7 @@ envoy_cc_library(
         "//include/envoy/network:connection_interface",
         "//include/envoy/network:filter_interface",
         "//include/envoy/router:router_interface",
+        "//include/envoy/runtime:runtime_interface",
         "//include/envoy/server:filter_config_interface",
         "//include/envoy/stats:stats_interface",
         "//include/envoy/stats:stats_macros",
@@ -66,5 +68,6 @@ envoy_cc_library(
         "//source/common/network:cidr_range_lib",
         "//source/common/network:filter_lib",
         "//source/common/network:utility_lib",
+        "//source/common/protobuf:utility_lib",
     ],
 )


### PR DESCRIPTION
Signed-off-by: Shriram Rajagopalan <shriram@us.ibm.com>

*title*: Traffic splitting for TCP Proxy

*Description*:
Introduces HTTP router style weighted routing for TCP proxy. 

ps: I have not tried to refactor code from http/router and other route_entry interfaces (mostly because I was lazy). 
pps: There is a problem here: weighted routing is tied to each route. However, TCP proxy's route selection is in deprecated mode. And filter chain match is not implemented yet. For the moment, I just stuck the weighted clusters under the deprecated_v1 config.

*Risk Level*: Medium

*Testing*: TODO

[optional *Release Notes*:]
Traffic splitting support for TCP proxy.