### PR TITLE
lua: Fix compile error on GCC 6.2

### DIFF
--- a/source/common/lua/lua.h
+++ b/source/common/lua/lua.h
@@ -235,7 +235,7 @@ public:
    */
   void reset() {
     unref();
-    object_ = {};
+    object_ = std::pair<T*, lua_State*>{};
     ref_ = LUA_NOREF;
   }
 


### PR DESCRIPTION
Fix compile error on GCC 6.2 by specifying the ambiguous type explicitly.

This change fixes this error:

/source/common/lua/lua.h:238:13: error: ambiguous overload for 'operator=' (operand types are 'std::pair<Envoy::Http::Filter::Lua::HeaderMapIterator*, lua_State*>' and '<brace-enclosed initializer list>')
     object_ = {};
     ~~~~~~~~^~~~

Risk Level: Low
Testing: Successful build with GCC 6.2.0

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
