### PR TITLE
grpc-web: returns bad request when a client half close the request without base64 padding.

### DIFF
--- a/source/common/grpc/grpc_web_filter.h
+++ b/source/common/grpc/grpc_web_filter.h
@@ -25,7 +25,7 @@ public:
 
   // Implements StreamDecoderFilter.
   Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap&, bool) override;
-  Http::FilterDataStatus decodeData(Buffer::Instance&, bool) override;
+  Http::FilterDataStatus decodeData(Buffer::Instance&, bool end_stream) override;
   Http::FilterTrailersStatus decodeTrailers(Http::HeaderMap&) override {
     return Http::FilterTrailersStatus::Continue;
   }


### PR DESCRIPTION
Returns bad request when a client half close the gRPC-Web request without base64 padding. Base64 padding is mandatory for gRPC-Web whenever a peer need to flush the message over the wire.
Without this fix, a gRPC-Web request without proper padding may keep hanging, as the server is waiting for additional data to decode.

Signed-off-by: Feng Li <fengli@google.com>