### PR TITLE
TcpProxy: Enable use of outlier detector

### DIFF
--- a/include/envoy/upstream/outlier_detection.h
+++ b/include/envoy/upstream/outlier_detection.h
@@ -21,6 +21,17 @@ typedef std::shared_ptr<const HostDescription> HostDescriptionConstSharedPtr;
 namespace Outlier {
 
 /**
+ * Non-HTTP result of requests/operations.
+ */
+enum class Result {
+  SUCCESS,        // Successfully established a connection or completed a request.
+  TIMEOUT,        // Timed out while connecting or executing a request.
+  CONNECT_FAILED, // Remote host rejected the connection.
+  REQUEST_FAILED, // Request was not completed successfully.
+  SERVER_FAILURE, // The server indicated it cannot process a request.
+};
+
+/**
  * Monitor for per host data. Proxy filters should send pertinent data when available.
  */
 class DetectorHostMonitor {
@@ -36,6 +47,11 @@ public:
    * Add an HTTP response code for a host.
    */
   virtual void putHttpResponseCode(uint64_t code) PURE;
+
+  /**
+   * Add a non-HTTP result for a host.
+   */
+  virtual void putResult(Result result) PURE;
 
   /**
    * Add a response time for a host (in this case response time is generic and might be used for

--- a/include/envoy/upstream/outlier_detection.h
+++ b/include/envoy/upstream/outlier_detection.h
@@ -27,6 +27,10 @@ enum class Result {
   SUCCESS,        // Successfully established a connection or completed a request.
   TIMEOUT,        // Timed out while connecting or executing a request.
   CONNECT_FAILED, // Remote host rejected the connection.
+
+  // The entries below only make sense when Envoy understands requests/responses for the
+  // protocol being proxied.  They do not make sense for TcpProxy, for example.
+
   REQUEST_FAILED, // Request was not completed successfully.
   SERVER_FAILURE, // The server indicated it cannot process a request.
 };

--- a/source/common/redis/BUILD
+++ b/source/common/redis/BUILD
@@ -47,8 +47,6 @@ envoy_cc_library(
         "//include/envoy/upstream:cluster_manager_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
-        "//source/common/common:enum_to_int",
-        "//source/common/http:codes_lib",
         "//source/common/network:filter_lib",
         "//source/common/protobuf:utility_lib",
     ],

--- a/source/common/redis/conn_pool_impl.cc
+++ b/source/common/redis/conn_pool_impl.cc
@@ -6,8 +6,6 @@
 #include <vector>
 
 #include "common/common/assert.h"
-#include "common/common/enum_to_int.h"
-#include "common/http/codes.h"
 
 namespace Envoy {
 namespace Redis {
@@ -72,7 +70,7 @@ PoolRequest* ClientImpl::makeRequest(const RespValue& request, PoolCallbacks& ca
 }
 
 void ClientImpl::onConnectOrOpTimeout() {
-  host_->outlierDetector().putHttpResponseCode(enumToInt(Http::Code::GatewayTimeout));
+  host_->outlierDetector().putResult(Upstream::Outlier::Result::TIMEOUT);
   if (connected_) {
     host_->cluster().stats().upstream_rq_timeout_.inc();
   } else {
@@ -86,7 +84,7 @@ void ClientImpl::onData(Buffer::Instance& data) {
   try {
     decoder_->decode(data);
   } catch (ProtocolError&) {
-    host_->outlierDetector().putHttpResponseCode(enumToInt(Http::Code::InternalServerError));
+    host_->outlierDetector().putResult(Upstream::Outlier::Result::REQUEST_FAILED);
     host_->cluster().stats().upstream_cx_protocol_error_.inc();
     connection_->close(Network::ConnectionCloseType::NoFlush);
   }
@@ -98,7 +96,7 @@ void ClientImpl::onEvent(Network::ConnectionEvent event) {
     if (!pending_requests_.empty()) {
       host_->cluster().stats().upstream_cx_destroy_with_active_rq_.inc();
       if (event == Network::ConnectionEvent::RemoteClose) {
-        host_->outlierDetector().putHttpResponseCode(enumToInt(Http::Code::ServiceUnavailable));
+        host_->outlierDetector().putResult(Upstream::Outlier::Result::SERVER_FAILURE);
         host_->cluster().stats().upstream_cx_destroy_remote_with_active_rq_.inc();
       }
       if (event == Network::ConnectionEvent::LocalClose) {
@@ -147,7 +145,7 @@ void ClientImpl::onRespValue(RespValuePtr&& value) {
     connect_or_op_timer_->enableTimer(config_.opTimeout());
   }
 
-  host_->outlierDetector().putHttpResponseCode(enumToInt(Http::Code::OK));
+  host_->outlierDetector().putResult(Upstream::Outlier::Result::SUCCESS);
 }
 
 ClientImpl::PendingRequest::PendingRequest(ClientImpl& parent, PoolCallbacks& callbacks)

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -9,6 +9,7 @@
 #include "envoy/event/dispatcher.h"
 
 #include "common/common/assert.h"
+#include "common/common/enum_to_int.h"
 #include "common/common/utility.h"
 #include "common/http/codes.h"
 #include "common/protobuf/utility.h"
@@ -73,6 +74,30 @@ void DetectorHostMonitorImpl::putHttpResponseCode(uint64_t response_code) {
     consecutive_5xx_ = 0;
     consecutive_gateway_failure_ = 0;
   }
+}
+
+void DetectorHostMonitorImpl::putResult(Result result) {
+  Http::Code http_code = Http::Code::InternalServerError;
+
+  switch (result) {
+  case Result::SUCCESS:
+    http_code = Http::Code::OK;
+    break;
+  case Result::TIMEOUT:
+    http_code = Http::Code::GatewayTimeout;
+    break;
+  case Result::CONNECT_FAILED:
+    http_code = Http::Code::ServiceUnavailable;
+    break;
+  case Result::REQUEST_FAILED:
+    http_code = Http::Code::InternalServerError;
+    break;
+  case Result::SERVER_FAILURE:
+    http_code = Http::Code::ServiceUnavailable;
+    break;
+  }
+
+  putHttpResponseCode(enumToInt(http_code));
 }
 
 DetectorConfig::DetectorConfig(const envoy::api::v2::Cluster::OutlierDetection& config)

--- a/source/common/upstream/outlier_detection_impl.h
+++ b/source/common/upstream/outlier_detection_impl.h
@@ -29,6 +29,7 @@ public:
   // Upstream::Outlier::DetectorHostMonitor
   uint32_t numEjections() override { return 0; }
   void putHttpResponseCode(uint64_t) override {}
+  void putResult(Result) override {}
   void putResponseTime(std::chrono::milliseconds) override {}
   const Optional<MonotonicTime>& lastEjectionTime() override { return time_; }
   const Optional<MonotonicTime>& lastUnejectionTime() override { return time_; }
@@ -120,6 +121,7 @@ public:
   // Upstream::Outlier::DetectorHostMonitor
   uint32_t numEjections() override { return num_ejections_; }
   void putHttpResponseCode(uint64_t response_code) override;
+  void putResult(Result result) override;
   void putResponseTime(std::chrono::milliseconds) override {}
   const Optional<MonotonicTime>& lastEjectionTime() override { return last_ejection_time_; }
   const Optional<MonotonicTime>& lastUnejectionTime() override { return last_unejection_time_; }

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -24,6 +24,7 @@ public:
 
   MOCK_METHOD0(numEjections, uint32_t());
   MOCK_METHOD1(putHttpResponseCode, void(uint64_t code));
+  MOCK_METHOD1(putResult, void(Result result));
   MOCK_METHOD1(putResponseTime, void(std::chrono::milliseconds time));
   MOCK_METHOD0(lastEjectionTime, const Optional<MonotonicTime>&());
   MOCK_METHOD0(lastUnejectionTime, const Optional<MonotonicTime>&());


### PR DESCRIPTION

*Description*:
Make TcpProxy feed appropriate events to any configured outlier detector.

Add non-HTTP interface to outlier detector, and convert redis filter to
use it.

*Risk Level*: Low

*Testing*: Unit