### PR TITLE
bug: fix formatting in prometheus stats

### DIFF
--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -313,10 +313,17 @@ Http::Code AdminImpl::handlerStats(const std::string& url, Buffer::Instance& res
   return rc;
 }
 
+std::string AdminImpl::sanitizePrometheusName(const std::string& name) {
+  std::string stats_name = name;
+  std::replace(stats_name.begin(), stats_name.end(), '.', '_');
+  return stats_name;
+}
+
 std::string AdminImpl::formatTagsForPrometheus(const std::vector<Stats::Tag>& tags) {
   std::vector<std::string> buf;
   for (const Stats::Tag& tag : tags) {
-    buf.push_back(fmt::format("{}={}", tag.name_, tag.value_));
+    buf.push_back(fmt::format("{}=\"{}\"", sanitizePrometheusName(tag.name_),
+                              sanitizePrometheusName(tag.value_)));
   }
   return StringUtil::join(buf, ",");
 }
@@ -325,16 +332,17 @@ void AdminImpl::statsAsPrometheus(const std::list<Stats::CounterSharedPtr>& coun
                                   const std::list<Stats::GaugeSharedPtr>& gauges,
                                   Buffer::Instance& response) {
   for (const auto& counter : counters) {
-    const std::string tags = AdminImpl::formatTagsForPrometheus(counter->tags());
-    response.add(fmt::format("# TYPE {0} counter\n", counter->tagExtractedName()));
-    response.add(
-        fmt::format("{0}{{{1}}} {2}\n", counter->tagExtractedName(), tags, counter->value()));
+    const std::string tags = formatTagsForPrometheus(counter->tags());
+    const std::string metric_name = sanitizePrometheusName(counter->tagExtractedName());
+    response.add(fmt::format("# TYPE {0} counter\n", metric_name));
+    response.add(fmt::format("{0}{{{1}}} {2}\n", metric_name, tags, counter->value()));
   }
 
   for (const auto& gauge : gauges) {
-    const std::string tags = AdminImpl::formatTagsForPrometheus(gauge->tags());
-    response.add(fmt::format("# TYPE {0} gauge\n", gauge->tagExtractedName()));
-    response.add(fmt::format("{0}{{{1}}} {2}\n", gauge->tagExtractedName(), tags, gauge->value()));
+    const std::string tags = formatTagsForPrometheus(gauge->tags());
+    const std::string metric_name = sanitizePrometheusName(gauge->tagExtractedName());
+    response.add(fmt::format("# TYPE {0} gauge\n", metric_name));
+    response.add(fmt::format("{0}{{{1}}} {2}\n", metric_name, tags, gauge->value()));
   }
 }
 

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -117,6 +117,7 @@ private:
   static void statsAsPrometheus(const std::list<Stats::CounterSharedPtr>& counters,
                                 const std::list<Stats::GaugeSharedPtr>& gauges,
                                 Buffer::Instance& response);
+  static std::string sanitizePrometheusName(const std::string& name);
   static std::string formatTagsForPrometheus(const std::vector<Stats::Tag>& tags);
 
   /**

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -123,17 +123,18 @@ TEST_P(IntegrationAdminTest, Admin) {
       lookupPort("admin"), "GET", "/stats?format=prometheus", "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_THAT(
+      response->body(),
+      testing::HasSubstr("http_downstream_rq{envoy_response_code_class=\"4xx\",envoy_http_conn_"
+                         "manager_prefix=\"admin\"} 2\n"));
+  EXPECT_THAT(response->body(), testing::HasSubstr("# TYPE http_downstream_rq counter\n"));
+  EXPECT_THAT(
+      response->body(),
+      testing::HasSubstr("listener_admin_http_downstream_rq{envoy_response_code_class=\"4xx\","
+                         "envoy_http_conn_manager_prefix=\"admin\"} 2\n"));
+  EXPECT_THAT(response->body(), testing::HasSubstr("# TYPE cluster_upstream_cx_active gauge\n"));
   EXPECT_THAT(response->body(),
-              testing::HasSubstr("http.downstream_rq{envoy.response_code_class=4xx,envoy.http_conn_"
-                                 "manager_prefix=admin} 2\n"));
-  EXPECT_THAT(response->body(),
-              testing::HasSubstr("listener.admin.http.downstream_rq{envoy.response_code_class=4xx,"
-                                 "envoy.http_conn_manager_prefix=admin} 2\n"));
-  EXPECT_THAT(response->body(), testing::HasSubstr("# TYPE http.downstream_rq counter\n"));
-  EXPECT_THAT(response->body(),
-              testing::HasSubstr("cluster.upstream_cx_active{envoy.cluster_name=cds} 0\n"));
-  EXPECT_THAT(response->body(), testing::HasSubstr("# TYPE cluster.upstream_cx_active gauge\n"));
-
+              testing::HasSubstr("cluster_upstream_cx_active{envoy_cluster_name=\"cds\"} 0\n"));
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/clusters", "",
                                                 downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());


### PR DESCRIPTION
Signed-off-by: Lita Cho <lcho@lyft.com>

*Description*: 

Fixes https://github.com/envoyproxy/envoy/issues/2118

The admin endpoint is currently sending stats with `.` in them and was not adding quotes to label values. This PR fixes that

*Risk Level*: Low

*Testing*: integration and unit test