### PR TITLE
proxy protocol: parse UNKNOWN protocol (#1728)

### DIFF
--- a/source/common/network/proxy_protocol.cc
+++ b/source/common/network/proxy_protocol.cc
@@ -75,21 +75,21 @@ void ProxyProtocol::ActiveConnection::onReadWorker() {
   }
 
   if (line_parts[1] == "UNKNOWN") {
-    // at this point we know it's a proxy protocol line, so we can remove it from the socket
-    // and continue
+    // At this point we know it's a proxy protocol line, so we can remove it from the socket
+    // and continue.
     Address::InstanceConstSharedPtr local_address = Envoy::Network::Address::addressFromFd(fd_);
     Address::InstanceConstSharedPtr remote_address;
-    // we don't know the remote address
+    // The remote address not known.
     if (local_address->ip()->version() == Address::IpVersion::v4) {
       remote_address = std::make_shared<Address::Ipv4Instance>(Address::Ipv4Instance("0.0.0.0"));
     } else {
       remote_address = std::make_shared<Address::Ipv6Instance>(Address::Ipv6Instance("::"));
     }
-    reconnect(remote_address, local_address);
+    finishConnection(remote_address, local_address);
     return;
   }
 
-  // if protocol not UNKNOWN, src and dst adresses have to be present
+  // If protocol not UNKNOWN, src and dst adresses have to be present.
   if (line_parts.size() != 6) {
     throw EnvoyException("failed to read proxy protocol");
   }
@@ -125,11 +125,11 @@ void ProxyProtocol::ActiveConnection::onReadWorker() {
     throw EnvoyException("failed to read proxy protocol");
   }
 
-  reconnect(remote_address, local_address);
+  finishConnection(remote_address, local_address);
 }
 
-void ProxyProtocol::ActiveConnection::reconnect(Address::InstanceConstSharedPtr remote_address,
-                                                Address::InstanceConstSharedPtr local_address) {
+void ProxyProtocol::ActiveConnection::finishConnection(
+    Address::InstanceConstSharedPtr remote_address, Address::InstanceConstSharedPtr local_address) {
 
   ListenerImpl& listener = listener_;
   int fd = fd_;

--- a/source/common/network/proxy_protocol.h
+++ b/source/common/network/proxy_protocol.h
@@ -58,8 +58,8 @@ public:
     /**
      * Helper function that replaces the current connection with the specified one.
      */
-    void reconnect(Address::InstanceConstSharedPtr remote_address,
-                   Address::InstanceConstSharedPtr local_address);
+    void finishConnection(Address::InstanceConstSharedPtr remote_address,
+                          Address::InstanceConstSharedPtr local_address);
 
     ProxyProtocol& parent_;
     int fd_;

--- a/source/common/network/proxy_protocol.h
+++ b/source/common/network/proxy_protocol.h
@@ -55,6 +55,12 @@ public:
     bool readLine(int fd, std::string& s);
     void close();
 
+    /**
+     * Helper function that replaces the current connection with the specified one.
+     */
+    void reconnect(Address::InstanceConstSharedPtr remote_address,
+                   Address::InstanceConstSharedPtr local_address);
+
     ProxyProtocol& parent_;
     int fd_;
     ListenerImpl& listener_;

--- a/test/integration/proxy_proto_integration_test.cc
+++ b/test/integration/proxy_proto_integration_test.cc
@@ -33,4 +33,26 @@ TEST_P(ProxyProtoIntegrationTest, RouterRequestAndResponseWithBodyNoBufferV6) {
   testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
 }
 
+TEST_P(ProxyProtoIntegrationTest, RouterProxyUnknownRequestAndResponseWithBodyNoBuffer) {
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    auto conn = makeClientConnection(lookupPort("http"));
+    Buffer::OwnedImpl buf("PROXY UNKNOWN\r\n");
+    conn->write(buf);
+    return conn;
+  };
+
+  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
+}
+
+TEST_P(ProxyProtoIntegrationTest, RouterProxyUnknownLongRequestAndResponseWithBodyNoBuffer) {
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    auto conn = makeClientConnection(lookupPort("http"));
+    Buffer::OwnedImpl buf("PROXY UNKNOWN 1:2:3::4 FE00:: 65535 1234\r\n");
+    conn->write(buf);
+    return conn;
+  };
+
+  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
+}
+
 } // namespace Envoy


### PR DESCRIPTION
Ignore any parameters sent on the PROXY line when the procotol is
UNKNOWN and accept the connection with current settings.

As per protocol spec:

If the announced transport protocol is "UNKNOWN", then the receiver
knows that the sender speaks the correct PROXY protocol with
the appropriate version, and SHOULD accept the connection and use
the real connection's parameters as if there were no PROXY protocol

*Risk Level*: Low

*Testing*:
Added unit tests for accepting proxy UNKNOWN line with and without additional parameters.header on the wire.

Signed-off-by: Filip Andres <filip@andresovi.net>