### PR TITLE
admin: fix admin listener stats to use proper scope

### DIFF
--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -442,7 +442,7 @@ AdminImpl::AdminImpl(const std::string& access_log_path, const std::string& prof
           {"/listeners", "print listener addresses", MAKE_ADMIN_HANDLER(handlerListenerInfo),
            false}},
       listener_stats_(
-          Http::ConnectionManagerImpl::generateListenerStats("http.admin.", server_.stats())) {
+          Http::ConnectionManagerImpl::generateListenerStats("listener.admin.", server_.stats())) {
 
   if (!address_out_path.empty()) {
     std::ofstream address_out_file(address_out_path);

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -415,7 +415,8 @@ AdminImpl::NullRouteConfigProvider::NullRouteConfigProvider()
 
 AdminImpl::AdminImpl(const std::string& access_log_path, const std::string& profile_path,
                      const std::string& address_out_path,
-                     Network::Address::InstanceConstSharedPtr address, Server::Instance& server)
+                     Network::Address::InstanceConstSharedPtr address, Server::Instance& server,
+                     Stats::Scope& listener_scope)
     : server_(server), profile_path_(profile_path),
       socket_(new Network::TcpListenSocket(address, true)),
       stats_(Http::ConnectionManagerImpl::generateStats("http.admin.", server_.stats())),
@@ -442,7 +443,7 @@ AdminImpl::AdminImpl(const std::string& access_log_path, const std::string& prof
           {"/listeners", "print listener addresses", MAKE_ADMIN_HANDLER(handlerListenerInfo),
            false}},
       listener_stats_(
-          Http::ConnectionManagerImpl::generateListenerStats("listener.admin.", server_.stats())) {
+          Http::ConnectionManagerImpl::generateListenerStats("http.admin.", listener_scope)) {
 
   if (!address_out_path.empty()) {
     std::ofstream address_out_file(address_out_path);

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -33,7 +33,7 @@ class AdminImpl : public Admin,
 public:
   AdminImpl(const std::string& access_log_path, const std::string& profiler_path,
             const std::string& address_out_path, Network::Address::InstanceConstSharedPtr address,
-            Server::Instance& server);
+            Server::Instance& server, Stats::Scope& listener_scope);
 
   Http::Code runCallback(const std::string& path, Buffer::Instance& response);
   const Network::ListenSocket& socket() override { return *socket_; }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -202,11 +202,11 @@ void InstanceImpl::initialize(Options& options,
   info.original_start_time_ = original_start_time_;
   restarter_.shutdownParentAdmin(info);
   original_start_time_ = info.original_start_time_;
+  admin_scope_ = stats_store_.createScope("listener.admin.");
   admin_.reset(new AdminImpl(initial_config.admin().accessLogPath(),
                              initial_config.admin().profilePath(), options.adminAddressPath(),
-                             initial_config.admin().address(), *this));
+                             initial_config.admin().address(), *this, *admin_scope_));
 
-  admin_scope_ = stats_store_.createScope("listener.admin.");
   handler_->addListener(*admin_, admin_->mutable_socket(), *admin_scope_, 0,
                         Network::ListenerOptions::listenerOptionsWithBindToPort());
 

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -125,7 +125,10 @@ TEST_P(IntegrationAdminTest, Admin) {
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   EXPECT_THAT(response->body(),
               testing::HasSubstr("http.downstream_rq{envoy.response_code_class=4xx,envoy.http_conn_"
-                                 "manager_prefix=admin} 4\n"));
+                                 "manager_prefix=admin} 2\n"));
+  EXPECT_THAT(response->body(),
+              testing::HasSubstr("listener.admin.http.downstream_rq{envoy.response_code_class=4xx,"
+                                 "envoy.http_conn_manager_prefix=admin} 2\n"));
   EXPECT_THAT(response->body(), testing::HasSubstr("# TYPE http.downstream_rq counter\n"));
   EXPECT_THAT(response->body(),
               testing::HasSubstr("cluster.upstream_cx_active{envoy.cluster_name=cds} 0\n"));


### PR DESCRIPTION
*Description*:  Previously, the HTTP *xx stats were being double counted for the admin endpoint because the same stats prefix is being used under the same scope for both the HTTP stats and the per listener HTTP stats. The fix passes the admin listener scope to Admin Impl and uses that scope for aggregating the stas.

Fixes #2123 

*Risk Level*: Low

*Testing*: Fix the integration admin tests to check for 2 4xx hits in the HTTP stats and 2 4xx hits in the per listener admin stats.

Signed-off-by: Constance Caramanolis <ccaramanolis@lyft.com>
