### PR TITLE
Updated bazel docs to include latest version

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -6,7 +6,7 @@ To build Envoy with Bazel in a production environment, where the [Envoy
 dependencies](https://www.envoyproxy.io/docs/envoy/latest/install/requirements) are typically
 independently sourced, the following steps should be followed:
 
-1. [Install Bazel](https://bazel.build/versions/master/docs/install.html) in your environment.
+1. Install the latest version of [Bazel](https://bazel.build/versions/master/docs/install.html) in your environment.
 2. Configure, build and/or install the [Envoy dependencies](https://www.envoyproxy.io/docs/envoy/latest/install/requirements).
 3. Configure a Bazel [WORKSPACE](https://bazel.build/versions/master/docs/be/workspace.html)
    to point Bazel at the Envoy dependencies. An example is provided in the CI Docker image


### PR DESCRIPTION
docs: updated bazel docs to include latest version.

Based off of this slack exchange I think putting in a small clarifying change to the install documentation would be helpful.

```
Brian Pane [4:49 PM] 
with a fresh checkout of master, and after removing `~/.cache/bazel`, I’m getting an error when I run `bazel fetch //source/...`: “Not a file: [bazel cache path]/external/bazel_tools/tools/cpp/dummy_toolchain.bzl and referenced by ‘//external:cc_toolchain’.”  Is that expected?


Brian Pane [5:19 PM] 
^ upgrading Bazel from 0.5.3 to 0.8.0 fixed that
```


*Risk Level*: Low

Signed-off-by: Nicholas J nicholas.a.johns5@gmail.com