### PR TITLE
redis: disable outlier events when healthchecking

### DIFF
--- a/include/envoy/redis/conn_pool.h
+++ b/include/envoy/redis/conn_pool.h
@@ -84,6 +84,12 @@ public:
    *         all operations use the same timeout.
    */
   virtual std::chrono::milliseconds opTimeout() const PURE;
+
+  /**
+   * @return bool the healthcheck pool can disable outlier events even if the cluster has it
+   * enabled.
+   */
+  virtual bool disableOutlierEvents() const PURE;
 };
 
 /**

--- a/include/envoy/redis/conn_pool.h
+++ b/include/envoy/redis/conn_pool.h
@@ -86,8 +86,9 @@ public:
   virtual std::chrono::milliseconds opTimeout() const PURE;
 
   /**
-   * @return bool disable outlier events even if the cluster has it enabled, useful for the
-   * healthcheck pool.
+   * @return bool disable outlier events even if the cluster has it enabled. This is used by the
+   * healthchecker's connection pool to avoid double counting active healthcheck operations as
+   * passive healthcheck operations.
    */
   virtual bool disableOutlierEvents() const PURE;
 };

--- a/include/envoy/redis/conn_pool.h
+++ b/include/envoy/redis/conn_pool.h
@@ -86,8 +86,8 @@ public:
   virtual std::chrono::milliseconds opTimeout() const PURE;
 
   /**
-   * @return bool disable outlier events even if the cluster has it enabled, useful for the
-   * healthcheck pool.
+   * @return bool the healthcheck pool can disable outlier events even if the cluster has it
+   * enabled.
    */
   virtual bool disableOutlierEvents() const PURE;
 };

--- a/include/envoy/redis/conn_pool.h
+++ b/include/envoy/redis/conn_pool.h
@@ -86,8 +86,8 @@ public:
   virtual std::chrono::milliseconds opTimeout() const PURE;
 
   /**
-   * @return bool the healthcheck pool can disable outlier events even if the cluster has it
-   * enabled.
+   * @return bool disable outlier events even if the cluster has it enabled, useful for the
+   * healthcheck pool.
    */
   virtual bool disableOutlierEvents() const PURE;
 };

--- a/source/common/redis/conn_pool_impl.cc
+++ b/source/common/redis/conn_pool_impl.cc
@@ -70,7 +70,7 @@ PoolRequest* ClientImpl::makeRequest(const RespValue& request, PoolCallbacks& ca
 }
 
 void ClientImpl::onConnectOrOpTimeout() {
-  host_->outlierDetector().putResult(Upstream::Outlier::Result::TIMEOUT);
+  putOutlierEvent(Upstream::Outlier::Result::TIMEOUT);
   if (connected_) {
     host_->cluster().stats().upstream_rq_timeout_.inc();
   } else {
@@ -84,9 +84,15 @@ void ClientImpl::onData(Buffer::Instance& data) {
   try {
     decoder_->decode(data);
   } catch (ProtocolError&) {
-    host_->outlierDetector().putResult(Upstream::Outlier::Result::REQUEST_FAILED);
+    putOutlierEvent(Upstream::Outlier::Result::REQUEST_FAILED);
     host_->cluster().stats().upstream_cx_protocol_error_.inc();
     connection_->close(Network::ConnectionCloseType::NoFlush);
+  }
+}
+
+void ClientImpl::putOutlierEvent(Upstream::Outlier::Result result) {
+  if (!config_.disableOutlierEvents()) {
+    host_->outlierDetector().putResult(result);
   }
 }
 
@@ -96,7 +102,7 @@ void ClientImpl::onEvent(Network::ConnectionEvent event) {
     if (!pending_requests_.empty()) {
       host_->cluster().stats().upstream_cx_destroy_with_active_rq_.inc();
       if (event == Network::ConnectionEvent::RemoteClose) {
-        host_->outlierDetector().putResult(Upstream::Outlier::Result::SERVER_FAILURE);
+        putOutlierEvent(Upstream::Outlier::Result::SERVER_FAILURE);
         host_->cluster().stats().upstream_cx_destroy_remote_with_active_rq_.inc();
       }
       if (event == Network::ConnectionEvent::LocalClose) {
@@ -145,7 +151,7 @@ void ClientImpl::onRespValue(RespValuePtr&& value) {
     connect_or_op_timer_->enableTimer(config_.opTimeout());
   }
 
-  host_->outlierDetector().putResult(Upstream::Outlier::Result::SUCCESS);
+  putOutlierEvent(Upstream::Outlier::Result::SUCCESS);
 }
 
 ClientImpl::PendingRequest::PendingRequest(ClientImpl& parent, PoolCallbacks& callbacks)

--- a/source/common/redis/conn_pool_impl.h
+++ b/source/common/redis/conn_pool_impl.h
@@ -30,6 +30,7 @@ class ConfigImpl : public Config {
 public:
   ConfigImpl(const envoy::api::v2::filter::network::RedisProxy::ConnPoolSettings& config);
 
+  bool disableOutlierEvents() const override { return false; }
   std::chrono::milliseconds opTimeout() const override { return op_timeout_; }
 
 private:

--- a/source/common/redis/conn_pool_impl.h
+++ b/source/common/redis/conn_pool_impl.h
@@ -81,6 +81,7 @@ private:
              DecoderFactory& decoder_factory, const Config& config);
   void onConnectOrOpTimeout();
   void onData(Buffer::Instance& data);
+  void putOutlierDetectorCode(Http::Code code);
 
   // Redis::DecoderCallbacks
   void onRespValue(RespValuePtr&& value) override;

--- a/source/common/redis/conn_pool_impl.h
+++ b/source/common/redis/conn_pool_impl.h
@@ -81,7 +81,6 @@ private:
              DecoderFactory& decoder_factory, const Config& config);
   void onConnectOrOpTimeout();
   void onData(Buffer::Instance& data);
-  void putOutlierDetectorCode(Http::Code code);
 
   // Redis::DecoderCallbacks
   void onRespValue(RespValuePtr&& value) override;

--- a/source/common/redis/conn_pool_impl.h
+++ b/source/common/redis/conn_pool_impl.h
@@ -81,6 +81,7 @@ private:
              DecoderFactory& decoder_factory, const Config& config);
   void onConnectOrOpTimeout();
   void onData(Buffer::Instance& data);
+  void putOutlierEvent(Upstream::Outlier::Result result);
 
   // Redis::DecoderCallbacks
   void onRespValue(RespValuePtr&& value) override;

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -381,6 +381,7 @@ private:
     void onTimeout() override;
 
     // Redis::ConnPool::Config
+    bool disableOutlierEvents() const override { return true; }
     std::chrono::milliseconds opTimeout() const override {
       // Allow the main HC infra to control timeout.
       return parent_.timeout_ * 2;

--- a/test/common/redis/conn_pool_impl_test.cc
+++ b/test/common/redis/conn_pool_impl_test.cc
@@ -58,8 +58,8 @@ public:
     finishSetup();
   }
 
-  void setup(Config* config) {
-    config_.reset(config);
+  void setup(std::unique_ptr<Config>&& config) {
+    config_ = std::move(config);
     finishSetup();
   }
 
@@ -296,7 +296,7 @@ class ConfigOutlierDisabled : public Config {
 TEST_F(RedisClientImplTest, OutlierDisabled) {
   InSequence s;
 
-  setup(new ConfigOutlierDisabled());
+  setup(std::make_unique<ConfigOutlierDisabled>());
 
   RespValue request1;
   MockPoolCallbacks callbacks1;

--- a/test/common/redis/conn_pool_impl_test.cc
+++ b/test/common/redis/conn_pool_impl_test.cc
@@ -368,44 +368,6 @@ TEST(RedisClientFactoryImplTest, Basic) {
   client->close();
 }
 
-// TEST(RedisClientFactoryImplTest, OutlierDisabled) {
-//   ClientFactoryImpl factory;
-//   Upstream::MockHost::MockCreateConnectionData conn_info;
-//   conn_info.connection_ = new NiceMock<Network::MockClientConnection>();
-//   std::shared_ptr<Upstream::MockHost> host(new NiceMock<Upstream::MockHost>());
-//   EXPECT_CALL(*host, createConnection_(_)).WillOnce(Return(conn_info));
-//   NiceMock<Event::MockDispatcher> dispatcher;
-//   ConfigOutlierDisabled config;
-//   ClientPtr client = factory.create(host, dispatcher, config);
-//   client->
-
-//   //   InSequence s;
-
-//   // setup();
-
-//   // NiceMock<Network::MockConnectionCallbacks> connection_callbacks;
-//   // client_->addConnectionCallbacks(connection_callbacks);
-
-//   // RespValue request1;
-//   // MockPoolCallbacks callbacks1;
-//   // EXPECT_CALL(*encoder_, encode(Ref(request1), _));
-//   // PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
-//   // EXPECT_NE(nullptr, handle1);
-
-//   // onConnected();
-
-//   // EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::SERVER_FAILURE));
-//   // EXPECT_CALL(callbacks1, onFailure());
-//   // EXPECT_CALL(*connect_or_op_timer_, disableTimer());
-//   // EXPECT_CALL(connection_callbacks, onEvent(Network::ConnectionEvent::RemoteClose));
-//   // upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
-
-//   // EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_destroy_with_active_rq_.value());
-//   // EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_destroy_remote_with_active_rq_.value());
-
-//   client->close();
-// }
-
 class RedisConnPoolImplTest : public testing::Test, public ClientFactory {
 public:
   RedisConnPoolImplTest() {

--- a/test/common/redis/conn_pool_impl_test.cc
+++ b/test/common/redis/conn_pool_impl_test.cc
@@ -304,8 +304,7 @@ TEST_F(RedisClientImplTest, OutlierDisabled) {
   PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
   EXPECT_NE(nullptr, handle1);
 
-  EXPECT_CALL(host_->outlier_detector_, putResult(Upstream::Outlier::Result::SERVER_FAILURE))
-      .Times(0);
+  EXPECT_CALL(host_->outlier_detector_, putResult(_)).Times(0);
   EXPECT_CALL(callbacks1, onFailure());
   EXPECT_CALL(*connect_or_op_timer_, disableTimer());
   upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);


### PR DESCRIPTION
**Description**
Disable outlier events when doing active healthchecking on Redis. Outlier events should only fire for client operations.

**Risk Level**
Low

**Testing**
UT