### PR TITLE
test: fix typo, replace `counter` with `gauge`

### DIFF
--- a/test/common/stats/udp_statsd_test.cc
+++ b/test/common/stats/udp_statsd_test.cc
@@ -39,7 +39,7 @@ TEST_P(UdpStatsdSinkTest, InitWithIpAddress) {
   sink.flushCounter(counter, 1);
 
   NiceMock<MockGauge> gauge;
-  counter.name_ = "test_gauge";
+  gauge.name_ = "test_gauge";
   sink.flushGauge(gauge, 1);
 
   NiceMock<MockHistogram> timer;


### PR DESCRIPTION
Actually we want to use `gauge` here.

Signed-off-by: Taiki Ono <taiks.4559@gmail.com>

*title*: *fix typo in udp_statsd_test*

*Description*:

Fix typo in variable names in test.

*Risk Level*: Low

*Testing*:

unit test
