### PR TITLE
admin: fix JSON output for /routes endpoint

### DIFF
--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -202,18 +202,6 @@ Router::RouteConfigProviderSharedPtr RouteConfigProviderManagerImpl::getRouteCon
   return new_provider;
 };
 
-void RouteConfigProviderManagerImpl::addRouteInfo(const RdsRouteConfigProvider& provider,
-                                                  Buffer::Instance& response) {
-  // TODO(junr03): change this to proto with JSON transcoding when #1522 is done.
-  response.add("{\n");
-  response.add(fmt::format("\"version_info\": \"{}\",\n", provider.versionInfo()));
-  response.add(fmt::format("\"route_config_name\": \"{}\",\n", provider.routeConfigName()));
-  response.add(fmt::format("\"cluster_name\": \"{}\",\n", provider.clusterName()));
-  response.add("\"route_table_dump\": ");
-  response.add(fmt::format("{}\n", provider.configAsJson()));
-  response.add("}\n");
-}
-
 Http::Code RouteConfigProviderManagerImpl::handlerRoutes(const std::string& url,
                                                          Buffer::Instance& response) {
   Http::Utility::QueryParams query_params = Http::Utility::parseQueryString(url);
@@ -253,7 +241,13 @@ Http::Code RouteConfigProviderManagerImpl::handlerRoutesLoop(
     } else {
       first_item = false;
     }
-    addRouteInfo(*provider, response);
+    response.add("{\n");
+    response.add(fmt::format("\"version_info\": \"{}\",\n", provider->versionInfo()));
+    response.add(fmt::format("\"route_config_name\": \"{}\",\n", provider->routeConfigName()));
+    response.add(fmt::format("\"cluster_name\": \"{}\",\n", provider->clusterName()));
+    response.add("\"route_table_dump\": ");
+    response.add(fmt::format("{}\n", provider->configAsJson()));
+    response.add("}\n");
   }
   response.add("]\n");
   return Http::Code::OK;

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -215,7 +215,7 @@ Http::Code RouteConfigProviderManagerImpl::handlerRoutes(const std::string& url,
   if (query_params.size() == 1 && it != query_params.end()) {
     // Create a vector with all the providers that have the queried route_config_name.
     std::vector<RdsRouteConfigProviderSharedPtr> selected_providers;
-    for (const auto provider : rdsRouteConfigProviders()) {
+    for (const auto& provider : rdsRouteConfigProviders()) {
       if (provider->routeConfigName() == it->second) {
         selected_providers.push_back(provider);
       }

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -206,10 +206,10 @@ void RouteConfigProviderManagerImpl::addRouteInfo(const RdsRouteConfigProvider& 
                                                   Buffer::Instance& response) {
   // TODO(junr03): change this to proto with JSON transcoding when #1522 is done.
   response.add("{\n");
-  response.add(fmt::format("    \"version_info\": \"{}\",\n", provider.versionInfo()));
-  response.add(fmt::format("    \"route_config_name\": \"{}\",\n", provider.routeConfigName()));
-  response.add(fmt::format("    \"cluster_name\": \"{}\",\n", provider.clusterName()));
-  response.add("    \"route_table_dump\": ");
+  response.add(fmt::format("\"version_info\": \"{}\",\n", provider.versionInfo()));
+  response.add(fmt::format("\"route_config_name\": \"{}\",\n", provider.routeConfigName()));
+  response.add(fmt::format("\"cluster_name\": \"{}\",\n", provider.clusterName()));
+  response.add("\"route_table_dump\": ");
   response.add(fmt::format("{}\n", provider.configAsJson()));
   response.add("}\n");
 }
@@ -219,21 +219,20 @@ Http::Code RouteConfigProviderManagerImpl::handlerRoutes(const std::string& url,
   Http::Utility::QueryParams query_params = Http::Utility::parseQueryString(url);
   // If there are no query params, print out all the configured route tables.
   if (query_params.size() == 0) {
-    for (const auto& provider : rdsRouteConfigProviders()) {
-      addRouteInfo(*provider, response);
-    }
-    return Http::Code::OK;
+    return handlerRoutesLoop(response, rdsRouteConfigProviders());
   }
 
   // If there are query params, make sure it is only the route_config_name param.
   const auto it = query_params.find("route_config_name");
   if (query_params.size() == 1 && it != query_params.end()) {
-    for (const auto& provider : rdsRouteConfigProviders()) {
+    // Create a vector with all the providers that have the queried route_config_name.
+    std::vector<RdsRouteConfigProviderSharedPtr> selected_providers;
+    for (const auto provider : rdsRouteConfigProviders()) {
       if (provider->routeConfigName() == it->second) {
-        addRouteInfo(*provider, response);
+        selected_providers.push_back(provider);
       }
     }
-    return Http::Code::OK;
+    return handlerRoutesLoop(response, selected_providers);
   }
   response.add("{\n");
   response.add("    \"general_usage\": \"/routes (dump all dynamic HTTP route tables).\",\n");
@@ -244,5 +243,20 @@ Http::Code RouteConfigProviderManagerImpl::handlerRoutes(const std::string& url,
   return Http::Code::NotFound;
 }
 
+Http::Code RouteConfigProviderManagerImpl::handlerRoutesLoop(
+    Buffer::Instance& response, const std::vector<RdsRouteConfigProviderSharedPtr> providers) {
+  bool first_item = true;
+  response.add("[\n");
+  for (const auto& provider : providers) {
+    if (!first_item) {
+      response.add(",");
+    } else {
+      first_item = false;
+    }
+    addRouteInfo(*provider, response);
+  }
+  response.add("]\n");
+  return Http::Code::OK;
+}
 } // namespace Router
 } // namespace Envoy

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -179,6 +179,16 @@ private:
    */
   Http::Code handlerRoutes(const std::string& url, Buffer::Instance& response);
 
+  /**
+   * Helper function used by handlerRoutes. The function loops through the providers
+   * and adds them to the response.
+   * @param response supplies the buffer to fill with information.
+   * @param providers supplies the vector of providers to add to the response.
+   * @return Http::Code OK.
+   */
+  Http::Code handlerRoutesLoop(Buffer::Instance& response,
+                               const std::vector<RdsRouteConfigProviderSharedPtr> providers);
+
   std::unordered_map<std::string, std::weak_ptr<RdsRouteConfigProviderImpl>>
       route_config_providers_;
   Runtime::Loader& runtime_;

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -163,13 +163,6 @@ public:
 
 private:
   /**
-   * Add the RdsRouteConfigProvider information to the buffer.
-   * @param provider supplies the Provider to extract information from.
-   * @param response supplies the buffer to fill with information.
-   */
-  void addRouteInfo(const RdsRouteConfigProvider& provider, Buffer::Instance& response);
-
-  /**
    * The handler used in the Admin /routes endpoint. This handler is used to
    * populate the response Buffer::Instance with information about the currently
    * loaded dynamic HTTP Route Tables.


### PR DESCRIPTION
Signed-off-by: Jose Nino <jnino@lyft.com>

admin: fix JSON output for /routes endpoint

*Description*: fix output of the `/routes` admin endpoint. Previously, the output with more
than one provider was incorrect JSON.

*Risk Level*: Low 

*Testing*: updated unit tests in order to verify correct output.
