### PR TITLE
Added a namespace to Prometheus format stats.

### DIFF
--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -330,19 +330,23 @@ std::string AdminImpl::formatTagsForPrometheus(const std::vector<Stats::Tag>& ta
   return StringUtil::join(buf, ",");
 }
 
+std::string AdminImpl::prometheusMetricName(const std::string& extractedName) {
+  return fmt::format("envoy_{0}", sanitizePrometheusName(extractedName));
+}
+
 void AdminImpl::statsAsPrometheus(const std::list<Stats::CounterSharedPtr>& counters,
                                   const std::list<Stats::GaugeSharedPtr>& gauges,
                                   Buffer::Instance& response) {
   for (const auto& counter : counters) {
     const std::string tags = formatTagsForPrometheus(counter->tags());
-    const std::string metric_name = sanitizePrometheusName(counter->tagExtractedName());
+    const std::string metric_name = prometheusMetricName(counter->tagExtractedName());
     response.add(fmt::format("# TYPE {0} counter\n", metric_name));
     response.add(fmt::format("{0}{{{1}}} {2}\n", metric_name, tags, counter->value()));
   }
 
   for (const auto& gauge : gauges) {
     const std::string tags = formatTagsForPrometheus(gauge->tags());
-    const std::string metric_name = sanitizePrometheusName(gauge->tagExtractedName());
+    const std::string metric_name = prometheusMetricName(gauge->tagExtractedName());
     response.add(fmt::format("# TYPE {0} gauge\n", metric_name));
     response.add(fmt::format("{0}{{{1}}} {2}\n", metric_name, tags, gauge->value()));
   }

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -331,6 +331,8 @@ std::string AdminImpl::formatTagsForPrometheus(const std::vector<Stats::Tag>& ta
 }
 
 std::string AdminImpl::prometheusMetricName(const std::string& extractedName) {
+  // Add namespacing prefix to avoid conflicts, as per best practice:
+  // https://prometheus.io/docs/practices/naming/#metric-names
   return fmt::format("envoy_{0}", sanitizePrometheusName(extractedName));
 }
 

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -119,6 +119,7 @@ private:
                                 Buffer::Instance& response);
   static std::string sanitizePrometheusName(const std::string& name);
   static std::string formatTagsForPrometheus(const std::vector<Stats::Tag>& tags);
+  static std::string prometheusMetricName(const std::string& extractedName);
 
   /**
    * URL handlers.

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -123,18 +123,20 @@ TEST_P(IntegrationAdminTest, Admin) {
       lookupPort("admin"), "GET", "/stats?format=prometheus", "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
-  EXPECT_THAT(
-      response->body(),
-      testing::HasSubstr("http_downstream_rq{envoy_response_code_class=\"4xx\",envoy_http_conn_"
-                         "manager_prefix=\"admin\"} 2\n"));
-  EXPECT_THAT(response->body(), testing::HasSubstr("# TYPE http_downstream_rq counter\n"));
-  EXPECT_THAT(
-      response->body(),
-      testing::HasSubstr("listener_admin_http_downstream_rq{envoy_response_code_class=\"4xx\","
-                         "envoy_http_conn_manager_prefix=\"admin\"} 2\n"));
-  EXPECT_THAT(response->body(), testing::HasSubstr("# TYPE cluster_upstream_cx_active gauge\n"));
   EXPECT_THAT(response->body(),
-              testing::HasSubstr("cluster_upstream_cx_active{envoy_cluster_name=\"cds\"} 0\n"));
+              testing::HasSubstr(
+                  "envoy_http_downstream_rq{envoy_response_code_class=\"4xx\",envoy_http_conn_"
+                  "manager_prefix=\"admin\"} 2\n"));
+  EXPECT_THAT(response->body(), testing::HasSubstr("# TYPE envoy_http_downstream_rq counter\n"));
+  EXPECT_THAT(response->body(),
+              testing::HasSubstr(
+                  "envoy_listener_admin_http_downstream_rq{envoy_response_code_class=\"4xx\","
+                  "envoy_http_conn_manager_prefix=\"admin\"} 2\n"));
+  EXPECT_THAT(response->body(),
+              testing::HasSubstr("# TYPE envoy_cluster_upstream_cx_active gauge\n"));
+  EXPECT_THAT(
+      response->body(),
+      testing::HasSubstr("envoy_cluster_upstream_cx_active{envoy_cluster_name=\"cds\"} 0\n"));
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/clusters", "",
                                                 downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());


### PR DESCRIPTION
*Description*:

Prometheus best practice is to namespace metrics with the application
name to avoid collisions (it also makes it obvious what metrics are
for what application!) This patch adds envoy_ to the start of all stats
when the stats output format is prometheus.

*Risk Level*: Low

