### PR TITLE
Filter out duplicate upstream_rq stats from Prometheus format stats

### DIFF
--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -330,21 +330,32 @@ std::string AdminImpl::formatTagsForPrometheus(const std::vector<Stats::Tag>& ta
   return StringUtil::join(buf, ",");
 }
 
+bool AdminImpl::shouldIncludeForPrometheus(const std::string& name) {
+  // upstream_rq_ stats are broken out by actual status code too, so we drop these to avoid
+  // duplicates
+  const std::regex upstream_rq_regex("upstream_rq_\\dxx$");
+  return !std::regex_search(name, upstream_rq_regex);
+}
+
 void AdminImpl::statsAsPrometheus(const std::list<Stats::CounterSharedPtr>& counters,
                                   const std::list<Stats::GaugeSharedPtr>& gauges,
                                   Buffer::Instance& response) {
   for (const auto& counter : counters) {
-    const std::string tags = formatTagsForPrometheus(counter->tags());
-    const std::string metric_name = sanitizePrometheusName(counter->tagExtractedName());
-    response.add(fmt::format("# TYPE {0} counter\n", metric_name));
-    response.add(fmt::format("{0}{{{1}}} {2}\n", metric_name, tags, counter->value()));
+    if (shouldIncludeForPrometheus(counter->name())) {
+      const std::string tags = formatTagsForPrometheus(counter->tags());
+      const std::string metric_name = sanitizePrometheusName(counter->tagExtractedName());
+      response.add(fmt::format("# TYPE {0} counter\n", metric_name));
+      response.add(fmt::format("{0}{{{1}}} {2}\n", metric_name, tags, counter->value()));
+    }
   }
 
   for (const auto& gauge : gauges) {
-    const std::string tags = formatTagsForPrometheus(gauge->tags());
-    const std::string metric_name = sanitizePrometheusName(gauge->tagExtractedName());
-    response.add(fmt::format("# TYPE {0} gauge\n", metric_name));
-    response.add(fmt::format("{0}{{{1}}} {2}\n", metric_name, tags, gauge->value()));
+    if (shouldIncludeForPrometheus(gauge->name())) {
+      const std::string tags = formatTagsForPrometheus(gauge->tags());
+      const std::string metric_name = sanitizePrometheusName(gauge->tagExtractedName());
+      response.add(fmt::format("# TYPE {0} gauge\n", metric_name));
+      response.add(fmt::format("{0}{{{1}}} {2}\n", metric_name, tags, gauge->value()));
+    }
   }
 }
 

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -119,6 +119,7 @@ private:
                                 Buffer::Instance& response);
   static std::string sanitizePrometheusName(const std::string& name);
   static std::string formatTagsForPrometheus(const std::vector<Stats::Tag>& tags);
+  static bool shouldIncludeForPrometheus(const std::string& name);
 
   /**
    * URL handlers.

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -123,6 +123,14 @@ TEST_P(IntegrationAdminTest, Admin) {
       lookupPort("admin"), "GET", "/stats?format=prometheus", "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_THAT(response->body(),
+              testing::Not(testing::HasSubstr(
+                  "cluster_upstream_rq{envoy_response_code_class=\"5xx\",envoy_cluster_name"
+                  "=\"lds\"} 1\n")));
+  EXPECT_THAT(
+      response->body(),
+      testing::HasSubstr("cluster_upstream_rq{envoy_response_code=\"503\",envoy_cluster_name"
+                         "=\"lds\"} 1\n"));
   EXPECT_THAT(
       response->body(),
       testing::HasSubstr("http_downstream_rq{envoy_response_code_class=\"4xx\",envoy_http_conn_"


### PR DESCRIPTION
upstream_rq stats are broken out by both status code and status code
class. This means that any given status code got included twice in
the same prometheus metric (once with a response_code label, and also
aggregated into a response_code_class label.) As a result you couldn't
run aggregates over the cluster_upstream_rq metric.

This patch simply filters out stats ending upstream_rq_\dxx, which are
the aggregate version, on the assumption that the per specific code
stats are enough. If you need the code_class grouping you can get
Prometheus to add it.

Signed-off-by: Jonathan Oddy <jonathan.oddy@transferwise.com>

A potential fix for: #2141

*Risk Level*: Low

*Testing*:
Updated the integration test for prometheus stats. Test already checks that the response_code_class exists for non upstream_rq metrics, which is unchanged by this patch. Added test to show that upstream_rq broken out by response_code_class is now absent, but by response_code still exists.
