### PR TITLE
deps: bump data-plane-api to 5055a88, fix PGV fallout.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,11 @@
 workspace(name = "envoy")
 
+git_repository(
+    name = "io_bazel_rules_go",
+    remote = "https://github.com/bazelbuild/rules_go.git",
+    commit = "4374be38e9a75ff5957c3922adb155d32086fe14",
+)
+
 load("//bazel:repositories.bzl", "envoy_dependencies")
 load("//bazel:cc_configure.bzl", "cc_configure")
 
@@ -8,3 +14,11 @@ cc_configure()
 
 load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
 api_dependencies()
+
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@com_lyft_protoc_gen_validate//bazel:go_proto_library.bzl", "go_proto_repositories")
+go_proto_repositories(shared=0)
+go_rules_dependencies()
+go_register_toolchains()
+load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
+proto_register_toolchains()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,11 +1,5 @@
 workspace(name = "envoy")
 
-git_repository(
-    name = "io_bazel_rules_go",
-    remote = "https://github.com/bazelbuild/rules_go.git",
-    commit = "4374be38e9a75ff5957c3922adb155d32086fe14",
-)
-
 load("//bazel:repositories.bzl", "envoy_dependencies")
 load("//bazel:cc_configure.bzl", "cc_configure")
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -185,14 +185,10 @@ def _envoy_api_deps():
         native.bind(
             name = "envoy_filter_network_" + t,
             actual = "@envoy_api//api/filter/network:" + t + "_cc",
-        )    
+        )
     native.bind(
         name = "http_api_protos",
         actual = "@googleapis//:http_api_protos",
-    )
-    native.bind(
-        name = "http_api_protos_lib",
-        actual = "@googleapis//:http_api_protos_lib",
     )
 
 def envoy_dependencies(path = "@envoy_deps//", skip_targets = []):

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -60,7 +60,7 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
     ),
     envoy_api = dict(
-        commit = "011c8f5ec0f9cc653389629711da08226acc13bb",
+        commit = "5055a888929d6aca545bff0159ab937ee40532f3",
         remote = "https://github.com/envoyproxy/data-plane-api",
     ),
     grpc_httpjson_transcoding = dict(

--- a/ci/WORKSPACE
+++ b/ci/WORKSPACE
@@ -17,3 +17,11 @@ cc_configure()
 
 load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
 api_dependencies()
+
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@com_lyft_protoc_gen_validate//bazel:go_proto_library.bzl", "go_proto_repositories")
+go_proto_repositories(shared=0)
+go_rules_dependencies()
+go_register_toolchains()
+load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
+proto_register_toolchains()

--- a/ci/WORKSPACE.filter.example
+++ b/ci/WORKSPACE.filter.example
@@ -16,3 +16,11 @@ cc_configure()
 
 load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
 api_dependencies()
+
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@com_lyft_protoc_gen_validate//bazel:go_proto_library.bzl", "go_proto_repositories")
+go_proto_repositories(shared=0)
+go_rules_dependencies()
+go_register_toolchains()
+load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
+proto_register_toolchains()

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -19,8 +19,7 @@ envoy_proto_library(
 envoy_proto_library(
     name = "bookstore_proto",
     srcs = [":bookstore.proto"],
-    external_deps = ["http_api_protos_lib"],
-    deps = ["//source/common/protobuf:wkt_protos"],
+    external_deps = ["http_api_protos", "well_known_protos"],
 )
 
 envoy_proto_descriptor(

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -19,7 +19,10 @@ envoy_proto_library(
 envoy_proto_library(
     name = "bookstore_proto",
     srcs = [":bookstore.proto"],
-    external_deps = ["http_api_protos", "well_known_protos"],
+    external_deps = [
+        "http_api_protos",
+        "well_known_protos",
+    ],
 )
 
 envoy_proto_descriptor(


### PR DESCRIPTION
* Need to add Go deps for PGV to all WORKSPACEs. This is a PITA, but we don't have much choice until
  recursive WORKSPACEs arrive in later Bazel versions. Setting up io_bazel_rules_go involves a bunch
  of dependent load/macro invocations that can't be turned into a macro in a .bzl (at least from a
  brief shot at doing this).

* Switch envoy_proto_library back to protobuf.bzl cc_proto_library, to avoid horrible conflicts
  where things like http_api_protos were being built under both native cc_proto_library and
  protobuf.bzl variant with PGV, making Bazel unhappy with conflicting file paths.

Signed-off-by: Harvey Tuch <htuch@google.com>

*Risk Level*: Low

*Testing*: bazel test //test/...