### PR TITLE
admin: surface version info string to the /clusters endpoint

### DIFF
--- a/RAW_RELEASE_NOTES.md
+++ b/RAW_RELEASE_NOTES.md
@@ -8,5 +8,3 @@ will make it substantially easier for the releaser to "linkify" all of the relea
 final version.
 
 ## 1.6.0
-
-* Added `version info` string to the `/clusters` admin endpoint.

--- a/RAW_RELEASE_NOTES.md
+++ b/RAW_RELEASE_NOTES.md
@@ -8,3 +8,5 @@ will make it substantially easier for the releaser to "linkify" all of the relea
 final version.
 
 ## 1.6.0
+
+* Added `versionInfo` string to the `/clusters` admin endpoint.

--- a/RAW_RELEASE_NOTES.md
+++ b/RAW_RELEASE_NOTES.md
@@ -9,4 +9,4 @@ final version.
 
 ## 1.6.0
 
-* Added `versionInfo` string to the `/clusters` admin endpoint.
+* Added `version info` string to the `/clusters` admin endpoint.

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -126,6 +126,14 @@ public:
    * @return GrpcMux& ADS API provider referencee.
    */
   virtual Config::GrpcMux& adsMux() PURE;
+
+  /**
+   * Return the current version info string for dynamic clusters, if CDS is setup.
+   *
+   * @return std::string the current version info string for dynamic clusters,
+   *                     or EMPTY_STRING if CDS is not in use.
+   */
+  virtual const std::string versionInfo() const PURE;
 };
 
 typedef std::unique_ptr<ClusterManager> ClusterManagerPtr;

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -131,7 +131,7 @@ public:
    * Return the current version info string for dynamic clusters, if CDS is setup.
    *
    * @return std::string the current version info string for dynamic clusters,
-   *                     or EMPTY_STRING if CDS is not in use.
+   *                     or "static" if CDS is not in use.
    */
   virtual const std::string versionInfo() const PURE;
 };

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -476,6 +476,13 @@ Http::AsyncClient& ClusterManagerImpl::httpAsyncClientForCluster(const std::stri
   }
 }
 
+const std::string ClusterManagerImpl::versionInfo() const {
+  if (cds_api_) {
+    return cds_api_->versionInfo();
+  }
+  return "static";
+}
+
 ClusterManagerImpl::ThreadLocalClusterManagerImpl::ThreadLocalClusterManagerImpl(
     ClusterManagerImpl& parent, Event::Dispatcher& dispatcher,
     const Optional<std::string>& local_cluster_name)

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -174,6 +174,8 @@ public:
 
   Config::GrpcMux& adsMux() override { return *ads_mux_; }
 
+  const std::string versionInfo() const override;
+
 private:
   /**
    * Thread local cached cluster data. Each thread local cluster gets updates from the parent

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -143,6 +143,8 @@ void AdminImpl::addCircuitSettings(const std::string& cluster_name, const std::s
 }
 
 Http::Code AdminImpl::handlerClusters(const std::string&, Buffer::Instance& response) {
+  response.add(fmt::format("version_info::{}\n", server_.clusterManager().versionInfo()));
+
   for (auto& cluster : server_.clusterManager().clusters()) {
     addOutlierInfo(cluster.second.get().info()->name(), cluster.second.get().outlierDetector(),
                    response);

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -140,6 +140,7 @@ TEST_P(IntegrationAdminTest, Admin) {
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   EXPECT_THAT(response->body(), testing::HasSubstr("added_via_api"));
+  EXPECT_THAT(response->body(), testing::HasSubstr("version_info::\n"));
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/cpuprofiler", "",
                                                 downstreamProtocol(), version_);

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -161,6 +161,7 @@ public:
   MOCK_METHOD0(shutdown, void());
   MOCK_CONST_METHOD0(sourceAddress, const Network::Address::InstanceConstSharedPtr&());
   MOCK_METHOD0(adsMux, Config::GrpcMux&());
+  MOCK_CONST_METHOD0(versionInfo, const std::string());
 
   NiceMock<Http::ConnectionPool::MockInstance> conn_pool_;
   NiceMock<Http::MockAsyncClient> async_client_;


### PR DESCRIPTION
Signed-off-by: Jose Nino <jnino@lyft.com>

admin: surface version info string to the /clusters endpoint

*Description*: surface the cds version info string in the `/clusters` admin endpoint.

*Risk Level*: Low

*Testing*: ensured string presence in the endpoint's output. Added unit tests to the ClusterManager to test the `versionInfo` function added.

*Release Notes*: added release notes.

*Docs Changes*: https://github.com/envoyproxy/data-plane-api/pull/310
