### PR TITLE
config: v1 routes must include redirect or cluster

### DIFF
--- a/source/common/config/rds_json.cc
+++ b/source/common/config/rds_json.cc
@@ -221,11 +221,16 @@ void RdsJson::translateRoute(const Json::Object& json_route, envoy::api::v2::Rou
       throw EnvoyException("Redirect route entries must not have WebSockets set");
     }
   }
-  if (json_route.hasObject("cluster") || json_route.hasObject("cluster_header") ||
-      json_route.hasObject("weighted_clusters")) {
-    if (has_redirect) {
-      throw EnvoyException("routes must be either redirects or cluster targets");
-    }
+  const bool has_cluster = json_route.hasObject("cluster") ||
+                           json_route.hasObject("cluster_header") ||
+                           json_route.hasObject("weighted_clusters");
+
+  if (has_cluster && has_redirect) {
+    throw EnvoyException("routes must be either redirects or cluster targets");
+  } else if (!has_cluster && !has_redirect) {
+    throw EnvoyException(
+        "routes must have redirect or one of cluster/cluster_header/weighted_clusters");
+  } else if (has_cluster) {
     auto* action = route.mutable_route();
 
     if (json_route.hasObject("cluster")) {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2613,6 +2613,31 @@ TEST(BadHttpRouteConfigurationsTest, BadRouteEntryConfigMissingPathSpecifier) {
                             EnvoyException, "routes must specify one of prefix/path/regex");
 }
 
+TEST(BadHttpRouteConfigurationsTest, BadRouteEntryConfigNoRedirectNoClusters) {
+  std::string json = R"EOF(
+  {
+    "virtual_hosts": [
+      {
+        "name": "www2",
+        "domains": ["*"],
+        "routes": [
+          {
+            "prefix": "/api"
+          }
+        ]
+      }
+    ]
+  }
+  )EOF";
+
+  NiceMock<Runtime::MockLoader> runtime;
+  NiceMock<Upstream::MockClusterManager> cm;
+
+  EXPECT_THROW_WITH_MESSAGE(
+      ConfigImpl(parseRouteConfigurationFromJson(json), runtime, cm, true), EnvoyException,
+      "routes must have redirect or one of cluster/cluster_header/weighted_clusters")
+}
+
 TEST(RouteMatcherTest, TestOpaqueConfig) {
   std::string json = R"EOF(
 {


### PR DESCRIPTION
This is a bugfix to disallow 'bridge to nowhere' v1 route configurations, as described by the docs.[1] This prevents an outage case where operator error results in a route definition which matches traffic but does not route it, just returning 404s to the client.

The v2 API is not vulnerable to this error because of the Protobuf `oneof` constraint applied to (`RouteAction`|`RedirectAction`), the `RouteAction` `cluster_specifier` constraint, and the required `host_redirect`/`path_redirect` fields in `RedirectAction`.

**Risk level**: Low
This is a breaking change for v1 route configs, but I don't think there are any valid reasons to have a bridge to nowhere route config.

**Testing**: unit test

[1]: "If the route is not a redirect (host_redirect and/or path_redirect is not specified), one of cluster, cluster_header, or weighted_clusters must be specified."