### PR TITLE
Passing priority sets to loadbalancers (still unused for picking)

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -610,43 +610,40 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(
                          parent.parent_.local_info_, parent.parent_, parent.parent_.runtime_,
                          parent.parent_.random_,
                          Router::ShadowWriterPtr{new Router::ShadowWriterImpl(parent.parent_)}) {
-
-  // TODO(alyssawilk) make lb priority-set aware in a follow-up patch.
-  HostSet& host_set = priority_set_.getOrCreateHostSet(0);
-  HostSet* local_host_set = nullptr;
-  if (parent.local_priority_set_) {
-    local_host_set = parent.local_priority_set_->hostSetsPerPriority()[0].get();
-  }
+  priority_set_.getOrCreateHostSet(0);
 
   if (cluster->lbSubsetInfo().isEnabled()) {
-    lb_.reset(new SubsetLoadBalancer(cluster->lbType(), host_set, local_host_set, cluster->stats(),
-                                     parent.parent_.runtime_, parent.parent_.random_,
-                                     cluster->lbSubsetInfo(), cluster->lbRingHashConfig()));
+    lb_.reset(new SubsetLoadBalancer(cluster->lbType(), priority_set_, parent_.local_priority_set_,
+                                     cluster->stats(), parent.parent_.runtime_,
+                                     parent.parent_.random_, cluster->lbSubsetInfo(),
+                                     cluster->lbRingHashConfig()));
   } else {
     switch (cluster->lbType()) {
     case LoadBalancerType::LeastRequest: {
-      lb_.reset(new LeastRequestLoadBalancer(host_set, local_host_set, cluster->stats(),
-                                             parent.parent_.runtime_, parent.parent_.random_));
+      lb_.reset(new LeastRequestLoadBalancer(priority_set_, parent_.local_priority_set_,
+                                             cluster->stats(), parent.parent_.runtime_,
+                                             parent.parent_.random_));
       break;
     }
     case LoadBalancerType::Random: {
-      lb_.reset(new RandomLoadBalancer(host_set, local_host_set, cluster->stats(),
+      lb_.reset(new RandomLoadBalancer(priority_set_, parent_.local_priority_set_, cluster->stats(),
                                        parent.parent_.runtime_, parent.parent_.random_));
       break;
     }
     case LoadBalancerType::RoundRobin: {
-      lb_.reset(new RoundRobinLoadBalancer(host_set, local_host_set, cluster->stats(),
-                                           parent.parent_.runtime_, parent.parent_.random_));
+      lb_.reset(new RoundRobinLoadBalancer(priority_set_, parent_.local_priority_set_,
+                                           cluster->stats(), parent.parent_.runtime_,
+                                           parent.parent_.random_));
       break;
     }
     case LoadBalancerType::RingHash: {
-      lb_.reset(new RingHashLoadBalancer(host_set, cluster->stats(), parent.parent_.runtime_,
+      lb_.reset(new RingHashLoadBalancer(priority_set_, cluster->stats(), parent.parent_.runtime_,
                                          parent.parent_.random_, cluster->lbRingHashConfig()));
       break;
     }
     case LoadBalancerType::OriginalDst: {
       lb_.reset(new OriginalDstCluster::LoadBalancer(
-          host_set, parent.parent_.primary_clusters_.at(cluster->name()).cluster_));
+          priority_set_, parent.parent_.primary_clusters_.at(cluster->name()).cluster_));
       break;
     }
     }

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -31,8 +31,8 @@ public:
  */
 class LoadBalancerBase {
 protected:
-  LoadBalancerBase(const HostSet& host_set, const HostSet* local_host_set, ClusterStats& stats,
-                   Runtime::Loader& runtime, Runtime::RandomGenerator& random);
+  LoadBalancerBase(const PrioritySet& priority_set, const PrioritySet* local_priority_set,
+                   ClusterStats& stats, Runtime::Loader& runtime, Runtime::RandomGenerator& random);
   ~LoadBalancerBase();
 
   /**
@@ -43,6 +43,10 @@ protected:
   ClusterStats& stats_;
   Runtime::Loader& runtime_;
   Runtime::RandomGenerator& random_;
+
+  // TODO(alyssawilk) make load balancers priority-aware and remove.
+protected:
+  const HostSet& host_set_;
 
 private:
   enum class LocalityRoutingState { NoLocalityRouting, LocalityDirect, LocalityResidual };
@@ -72,7 +76,6 @@ private:
    */
   void regenerateLocalityRoutingStructures();
 
-  const HostSet& host_set_;
   const HostSet* local_host_set_;
   uint64_t local_percent_to_route_{};
   LocalityRoutingState locality_routing_state_{LocalityRoutingState::NoLocalityRouting};
@@ -85,10 +88,10 @@ private:
  */
 class RoundRobinLoadBalancer : public LoadBalancer, LoadBalancerBase {
 public:
-  RoundRobinLoadBalancer(const HostSet& host_set, const HostSet* local_host_set_,
+  RoundRobinLoadBalancer(const PrioritySet& priority_set, const PrioritySet* local_priority_set,
                          ClusterStats& stats, Runtime::Loader& runtime,
                          Runtime::RandomGenerator& random)
-      : LoadBalancerBase(host_set, local_host_set_, stats, runtime, random) {}
+      : LoadBalancerBase(priority_set, local_priority_set, stats, runtime, random) {}
 
   // Upstream::LoadBalancer
   HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
@@ -112,7 +115,7 @@ private:
  */
 class LeastRequestLoadBalancer : public LoadBalancer, LoadBalancerBase {
 public:
-  LeastRequestLoadBalancer(const HostSet& host_set, const HostSet* local_host_set_,
+  LeastRequestLoadBalancer(const PrioritySet& priority_set, const PrioritySet* local_priority_set,
                            ClusterStats& stats, Runtime::Loader& runtime,
                            Runtime::RandomGenerator& random);
 
@@ -129,9 +132,10 @@ private:
  */
 class RandomLoadBalancer : public LoadBalancer, LoadBalancerBase {
 public:
-  RandomLoadBalancer(const HostSet& host_set, const HostSet* local_host_set, ClusterStats& stats,
-                     Runtime::Loader& runtime, Runtime::RandomGenerator& random)
-      : LoadBalancerBase(host_set, local_host_set, stats, runtime, random) {}
+  RandomLoadBalancer(const PrioritySet& priority_set, const PrioritySet* local_priority_set,
+                     ClusterStats& stats, Runtime::Loader& runtime,
+                     Runtime::RandomGenerator& random)
+      : LoadBalancerBase(priority_set, local_priority_set, stats, runtime, random) {}
 
   // Upstream::LoadBalancer
   HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -19,12 +19,12 @@ namespace Upstream {
 // OriginalDstCluster::LoadBalancer is never configured with any other type of cluster,
 // and throws an exception otherwise.
 
-OriginalDstCluster::LoadBalancer::LoadBalancer(HostSet& host_set, ClusterSharedPtr& parent)
-    : host_set_(host_set), parent_(std::static_pointer_cast<OriginalDstCluster>(parent)),
+OriginalDstCluster::LoadBalancer::LoadBalancer(PrioritySet& priority_set, ClusterSharedPtr& parent)
+    : priority_set_(priority_set), parent_(std::static_pointer_cast<OriginalDstCluster>(parent)),
       info_(parent->info()) {
-  // host_set_ is initially empty.
-  host_set_.addMemberUpdateCb([this](uint32_t, const std::vector<HostSharedPtr>& hosts_added,
-                                     const std::vector<HostSharedPtr>& hosts_removed) -> void {
+  // priority_set_ is initially empty.
+  priority_set_.addMemberUpdateCb([this](uint32_t, const std::vector<HostSharedPtr>& hosts_added,
+                                         const std::vector<HostSharedPtr>& hosts_removed) -> void {
     // Update the hosts map
     for (const HostSharedPtr& host : hosts_removed) {
       ENVOY_LOG(debug, "Removing host {}.", host->address()->asString());

--- a/source/common/upstream/original_dst_cluster.h
+++ b/source/common/upstream/original_dst_cluster.h
@@ -42,7 +42,7 @@ public:
    */
   class LoadBalancer : public Upstream::LoadBalancer {
   public:
-    LoadBalancer(HostSet& host_set, ClusterSharedPtr& parent);
+    LoadBalancer(PrioritySet& priority_set, ClusterSharedPtr& parent);
 
     // Upstream::LoadBalancer
     HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
@@ -91,7 +91,7 @@ public:
       std::unordered_multimap<std::string, HostSharedPtr> map_;
     };
 
-    HostSet& host_set_;                        // Thread local host set.
+    PrioritySet& priority_set_;                // Thread local priority set.
     std::weak_ptr<OriginalDstCluster> parent_; // Primary cluster managed by the main thread.
     ClusterInfoConstSharedPtr info_;
     HostMap host_map_;

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -11,10 +11,11 @@ namespace Envoy {
 namespace Upstream {
 
 RingHashLoadBalancer::RingHashLoadBalancer(
-    HostSet& host_set, ClusterStats& stats, Runtime::Loader& runtime,
+    PrioritySet& priority_set, ClusterStats& stats, Runtime::Loader& runtime,
     Runtime::RandomGenerator& random,
     const Optional<envoy::api::v2::Cluster::RingHashLbConfig>& config)
-    : host_set_(host_set), stats_(stats), runtime_(runtime), random_(random), config_(config) {
+    : host_set_(*priority_set.hostSetsPerPriority()[0]), stats_(stats), runtime_(runtime),
+      random_(random), config_(config) {
   host_set_.addMemberUpdateCb([this](uint32_t, const std::vector<HostSharedPtr>&,
                                      const std::vector<HostSharedPtr>&) -> void { refresh(); });
 

--- a/source/common/upstream/ring_hash_lb.h
+++ b/source/common/upstream/ring_hash_lb.h
@@ -22,7 +22,7 @@ namespace Upstream {
  */
 class RingHashLoadBalancer : public LoadBalancer, Logger::Loggable<Logger::Id::upstream> {
 public:
-  RingHashLoadBalancer(HostSet& host_set, ClusterStats& stats, Runtime::Loader& runtime,
+  RingHashLoadBalancer(PrioritySet& priority_set, ClusterStats& stats, Runtime::Loader& runtime,
                        Runtime::RandomGenerator& random,
                        const Optional<envoy::api::v2::Cluster::RingHashLbConfig>& config);
 

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -231,8 +231,6 @@ typedef std::unique_ptr<HostSetImpl> HostSetImplPtr;
 
 class PrioritySetImpl : public PrioritySet {
 public:
-  PrioritySetImpl();
-
   // From PrioritySet
   Common::CallbackHandle* addMemberUpdateCb(MemberUpdateCb callback) const override {
     return member_update_cb_helper_.add(callback);
@@ -244,12 +242,18 @@ public:
   // Get the host set for this priority level, creating it if necessary.
   HostSet& getOrCreateHostSet(uint32_t priority);
 
+protected:
+  // Allows subclasses of PrioritySetImpl to create their own type of HostSet.
+  virtual HostSetPtr createHostSet(uint32_t priority) {
+    return HostSetPtr{new HostSetImpl(priority)};
+  }
+
 private:
   virtual void runUpdateCallbacks(uint32_t priority, const std::vector<HostSharedPtr>& hosts_added,
                                   const std::vector<HostSharedPtr>& hosts_removed) {
     member_update_cb_helper_.runCallbacks(priority, hosts_added, hosts_removed);
   }
-  // This vector will always have at lest one member, for priority level 0.
+  // This vector will generally have at least one member, for priority level 0.
   // It will expand as host sets are added but currently does not shrink to
   // avoid any potential lifetime issues.
   std::vector<std::unique_ptr<HostSet>> host_sets_;

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -330,7 +330,7 @@ TEST_F(EdsTest, EndpointHostsPerPriority) {
   EXPECT_EQ(4, cluster_->prioritySet().hostSetsPerPriority()[3]->hosts().size());
 }
 
-// Set up an EDS config with multiple priorities and localitie and make sure
+// Set up an EDS config with multiple priorities and localities and make sure
 // they are loaded and reloaded as expected.
 TEST_F(EdsTest, PriorityAndLocality) {
   Protobuf::RepeatedPtrField<envoy::api::v2::ClusterLoadAssignment> resources;

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -659,6 +659,7 @@ TEST(StaticClusterImplTest, SourceAddressPriority) {
 // Test creating and extending a priority set.
 TEST(PrioritySet, Extend) {
   PrioritySetImpl priority_set;
+  priority_set.getOrCreateHostSet(0);
 
   uint32_t changes = 0;
   uint32_t last_priority = 0;


### PR DESCRIPTION
This change just passes priority sets to the load balancers instead of host sets.
This required implementing priority subsets for the subset LB, which made it a large enough change without actually using the new priorities for any of the load balancers.

The next step for #1929 

*Risk Level*: Medium
This includes removing the default constructor for priority sets to allow sub-classing for the PrioritySubset.  Both places where priority sets are used in the code default-create as the LB code still assumes priority 0 exists.

*Testing*:
Existing tests pass.
One unit test for the new subset lb code not causing harm with priority = 1
More tests will come in the next PR, where we actually use non-zero priority levels.

No release notes for this one, since it's a no-op for functionality.  I'll add release notes where I add LB supprt.
