### PR TITLE
router: fix crash when no host during retry delay timeout and alt res…

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -501,7 +501,7 @@ void Filter::onUpstreamReset(UpstreamResetType type,
     // starting response, we treat this as an error. We only get non-5xx when
     // timeout_response_code_ is used for code above, where this member can
     // assume values such as 204 (NoContent).
-    if (!Http::CodeUtility::is5xx(enumToInt(code))) {
+    if (upstream_host != nullptr && !Http::CodeUtility::is5xx(enumToInt(code))) {
       upstream_host->stats().rq_error_.inc();
     }
     sendLocalReply(code, body, dropped);


### PR DESCRIPTION
…ponse

I think this is a small regression from the load stats change.

*Risk Level*: Low 

*Testing*: UT
