### PR TITLE
server: If init fails, return 1 from main_common instead of calling exit(1).

### DIFF
--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -88,6 +88,7 @@ int main_common(OptionsImpl& options) {
                                 access_log_lock, component_factory, tls);
     server.run();
   } catch (const EnvoyException& e) {
+    ares_library_cleanup();
     return 1;
   }
   ares_library_cleanup();

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -83,9 +83,13 @@ int main_common(OptionsImpl& options) {
   DefaultTestHooks default_test_hooks;
   ThreadLocal::InstanceImpl tls;
   Stats::ThreadLocalStoreImpl stats_store(stats_allocator);
-  Server::InstanceImpl server(options, local_address, default_test_hooks, *restarter, stats_store,
-                              access_log_lock, component_factory, tls);
-  server.run();
+  try {
+    Server::InstanceImpl server(options, local_address, default_test_hooks, *restarter, stats_store,
+                                access_log_lock, component_factory, tls);
+    server.run();
+  } catch (const EnvoyException& e) {
+    return 1;
+  }
   ares_library_cleanup();
   return 0;
 }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -71,7 +71,7 @@ InstanceImpl::InstanceImpl(Options& options, Network::Address::InstanceConstShar
               e.what());
     thread_local_.shutdownGlobalThreading();
     thread_local_.shutdownThread();
-    exit(1);
+    throw;
   }
 }
 

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -110,6 +110,9 @@ private:
  */
 class InstanceImpl : Logger::Loggable<Logger::Id::main>, public Instance {
 public:
+  /**
+   * @throw EnvoyException if initialization fails.
+   */
   InstanceImpl(Options& options, Network::Address::InstanceConstSharedPtr local_address,
                TestHooks& hooks, HotRestart& restarter, Stats::StoreRoot& store,
                Thread::BasicLockable& access_log_lock, ComponentFactory& component_factory,

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -11,6 +11,7 @@
 
 #include "gtest/gtest.h"
 
+using testing::HasSubstr;
 using testing::InSequence;
 using testing::Property;
 using testing::SaveArg;
@@ -107,9 +108,13 @@ protected:
   }
 
   void TearDown() override {
-    server_->threadLocal().shutdownGlobalThreading();
-    server_->clusterManager().shutdown();
-    server_->threadLocal().shutdownThread();
+    // If the config is bad, the InstanceImpl ctor threw an exception, so server_ wasn't set. For
+    // those tests, skip the shutdown steps.
+    if (server_ != nullptr) {
+      server_->threadLocal().shutdownGlobalThreading();
+      server_->clusterManager().shutdown();
+      server_->threadLocal().shutdownThread();
+    }
   }
 
   Network::Address::IpVersion version_;
@@ -123,21 +128,19 @@ protected:
   std::unique_ptr<InstanceImpl> server_;
 };
 
-class ServerInstanceImplDeathTest : public ServerInstanceImplTest {
-  void TearDown() override { thread_local_.shutdownGlobalThreading(); }
-};
-
 INSTANTIATE_TEST_CASE_P(IpVersions, ServerInstanceImplTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
-INSTANTIATE_TEST_CASE_P(IpVersionsDeath, ServerInstanceImplDeathTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
-
-TEST_P(ServerInstanceImplDeathTest, V2ConfigOnly) {
+TEST_P(ServerInstanceImplTest, V2ConfigOnly) {
   options_.service_cluster_name_ = "some_cluster_name";
   options_.service_node_name_ = "some_node_name";
   options_.v2_config_only_ = true;
-  EXPECT_DEATH(initialize(std::string()), ".*Unable to parse JSON as proto.*");
+  try {
+    initialize(std::string());
+    FAIL();
+  } catch (const EnvoyException& e) {
+    EXPECT_THAT(e.what(), HasSubstr("Unable to parse JSON as proto"));
+  }
 }
 
 TEST_P(ServerInstanceImplTest, V1ConfigFallback) {
@@ -199,11 +202,16 @@ TEST_P(ServerInstanceImplTest, LogToFile) {
   EXPECT_TRUE(log.find("LogToFile second test string") != std::string::npos);
 }
 
-TEST_P(ServerInstanceImplDeathTest, LogToFileError) {
+TEST_P(ServerInstanceImplTest, LogToFileError) {
   options_.log_path_ = "/this/path/does/not/exist";
   options_.service_cluster_name_ = "some_cluster_name";
   options_.service_node_name_ = "some_node_name";
-  EXPECT_DEATH(initialize(std::string()), ".*Failed to open log-file.*");
+  try {
+    initialize(std::string());
+    FAIL();
+  } catch (const EnvoyException& e) {
+    EXPECT_THAT(e.what(), HasSubstr("Failed to open log-file"));
+  }
 }
 } // namespace Server
 } // namespace Envoy


### PR DESCRIPTION
*Description*:
This change takes the `exit(1)` out of the Server::InstanceImpl constructor, and replaces it with a `return 1` from main_common by way of an `EnvoyException` from the constructor. The reason is that at Google we have some cleanup work to do after main_common returns (whether success or failure). If it calls exit() instead of returning, we never get the chance.

*Risk Level*: Low

*Testing*:
Updated unit tests to verify the exception is thrown in case of bad config. As a nice side benefit, we don't need death tests for those cases anymore.

*Docs Changes*:
N/A

*Release Notes*:
N/A

Signed-off-by: Reuven Lazarus <rzl@google.com>