### PR TITLE
tracing: Define tag constants in common location to consolidate and a…

### DIFF
--- a/source/common/grpc/async_client_impl.h
+++ b/source/common/grpc/async_client_impl.h
@@ -260,12 +260,6 @@ private:
   friend class AsyncClientImpl<RequestType, ResponseType>;
 };
 
-class AsyncClientTracingConfig : public Tracing::EgressConfigImpl {
-public:
-};
-
-typedef ConstSingleton<AsyncClientTracingConfig> TracingConfig;
-
 template <class RequestType, class ResponseType>
 class AsyncRequestImpl : public AsyncRequest,
                          public AsyncStreamImpl<RequestType, ResponseType>,
@@ -278,7 +272,7 @@ public:
       : AsyncStreamImpl<RequestType, ResponseType>(parent, service_method, *this, timeout),
         request_(request), callbacks_(callbacks) {
 
-    current_span_ = parent_span.spawnChild(TracingConfig::get(),
+    current_span_ = parent_span.spawnChild(Tracing::EgressConfig::get(),
                                            "async " + parent.remote_cluster_name_ + " egress",
                                            ProdSystemTimeSource::instance_.currentTime());
     current_span_->setTag(Tracing::Tags::get().UPSTREAM_CLUSTER_NAME, parent.remote_cluster_name_);

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -750,6 +750,7 @@ Filter::UpstreamRequest::UpstreamRequest(Filter& parent, Http::ConnectionPool::I
     span_ = parent_.callbacks_->activeSpan().spawnChild(
         Tracing::EgressConfig::get(), "router " + parent.cluster_->name() + " egress",
         ProdSystemTimeSource::instance_.currentTime());
+    span_->setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY);
   }
 
   request_info_.healthCheck(parent_.callbacks_->requestInfo().healthCheck());

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -27,6 +27,54 @@ struct Decision {
   bool is_tracing;
 };
 
+/**
+ * Tracing tag names.
+ */
+class TracingTagValues {
+public:
+  /* OpenTracing standard tag names. */
+  const std::string COMPONENT = "component";
+  const std::string DB_INSTANCE = "db.instance";
+  const std::string DB_STATEMENT = "db.statement";
+  const std::string DB_USER = "db.user";
+  const std::string DB_TYPE = "db.type";
+  const std::string ERROR = "error";
+  const std::string HTTP_METHOD = "http.method";
+  const std::string HTTP_STATUS_CODE = "http.status_code";
+  const std::string HTTP_URL = "http.url";
+  const std::string MESSAGE_BUS_DESTINATION = "message_bus.destination";
+  const std::string PEER_ADDRESS = "peer.address";
+  const std::string PEER_HOSTNAME = "peer.hostname";
+  const std::string PEER_IPV4 = "peer.ipv4";
+  const std::string PEER_IPV6 = "peer.ipv6";
+  const std::string PEER_PORT = "peer.port";
+  const std::string PEER_SERVICE = "peer.service";
+  const std::string SPAN_KIND = "span.kind";
+
+  /* Non-standard tag names. */
+  const std::string DOWNSTREAM_CLUSTER = "downstream_cluster";
+  const std::string GRPC_STATUS_CODE = "grpc.status_code";
+  const std::string GUID_X_CLIENT_TRACE_ID = "guid:x-client-trace-id";
+  const std::string GUID_X_REQUEST_ID = "guid:x-request-id";
+  const std::string HTTP_PROTOCOL = "http.protocol";
+  const std::string NODE_ID = "node_id";
+  const std::string REQUEST_SIZE = "request_size";
+  const std::string RESPONSE_FLAGS = "response_flags";
+  const std::string RESPONSE_SIZE = "response_size";
+  const std::string STATUS = "status";
+  const std::string UPSTREAM_CLUSTER = "upstream_cluster";
+  const std::string UPSTREAM_CLUSTER_NAME = "upstream_cluster_name";
+  const std::string USER_AGENT = "user_agent";
+  const std::string ZONE = "zone";
+
+  /* Tag values. */
+  const std::string CANCELED = "canceled";
+  const std::string PROXY = "proxy";
+  const std::string TRUE = "true";
+};
+
+typedef ConstSingleton<TracingTagValues> Tags;
+
 class HttpTracerUtility {
 public:
   /**

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -32,7 +32,7 @@ struct Decision {
  */
 class TracingTagValues {
 public:
-  /* OpenTracing standard tag names. */
+  // OpenTracing standard tag names.
   const std::string COMPONENT = "component";
   const std::string DB_INSTANCE = "db.instance";
   const std::string DB_STATEMENT = "db.statement";
@@ -51,7 +51,7 @@ public:
   const std::string PEER_SERVICE = "peer.service";
   const std::string SPAN_KIND = "span.kind";
 
-  /* Non-standard tag names. */
+  // Non-standard tag names.
   const std::string DOWNSTREAM_CLUSTER = "downstream_cluster";
   const std::string GRPC_STATUS_CODE = "grpc.status_code";
   const std::string GUID_X_CLIENT_TRACE_ID = "guid:x-client-trace-id";
@@ -67,7 +67,7 @@ public:
   const std::string USER_AGENT = "user_agent";
   const std::string ZONE = "zone";
 
-  /* Tag values. */
+  // Tag values.
   const std::string CANCELED = "canceled";
   const std::string PROXY = "proxy";
   const std::string TRUE = "true";

--- a/test/common/grpc/async_client_impl_test.cc
+++ b/test/common/grpc/async_client_impl_test.cc
@@ -152,7 +152,7 @@ public:
     http_callbacks_->onData(reply_buffer, false);
 
     Http::HeaderMapPtr reply_trailers{new Http::TestHeaderMapImpl{{"grpc-status", "0"}}};
-    EXPECT_CALL(*child_span_, setTag("grpc.status_code", "0"));
+    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().GRPC_STATUS_CODE, "0"));
     EXPECT_CALL(*this, onSuccess_(HelloworldReplyEq(HELLO_REPLY), _));
     EXPECT_CALL(*child_span_, finishSpan());
     EXPECT_CALL(*http_stream_, reset());
@@ -225,7 +225,10 @@ public:
 
     EXPECT_CALL(active_span, spawnChild_(_, "async test_cluster egress", _))
         .WillOnce(Return(request->child_span_));
-    EXPECT_CALL(*request->child_span_, setTag("upstream_cluster_name", "test_cluster"));
+    EXPECT_CALL(*request->child_span_,
+                setTag(Tracing::Tags::get().UPSTREAM_CLUSTER_NAME, "test_cluster"));
+    EXPECT_CALL(*request->child_span_,
+                setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY));
     EXPECT_CALL(*request->child_span_, injectContext(_));
 
     request->grpc_request_ = grpc_client_->send(*method_descriptor_, request_msg, *request,
@@ -341,9 +344,10 @@ TEST_F(GrpcAsyncClientImplTest, RequestHttpStartFail) {
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
   EXPECT_CALL(active_span, spawnChild_(_, "async test_cluster egress", _))
       .WillOnce(Return(child_span));
-  EXPECT_CALL(*child_span, setTag("upstream_cluster_name", "test_cluster"));
-  EXPECT_CALL(*child_span, setTag("grpc.status_code", "14"));
-  EXPECT_CALL(*child_span, setTag("error", "true"));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER_NAME, "test_cluster"));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().GRPC_STATUS_CODE, "14"));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
   EXPECT_CALL(*child_span, finishSpan());
   EXPECT_CALL(*child_span, injectContext(_)).Times(0);
 
@@ -404,10 +408,11 @@ TEST_F(GrpcAsyncClientImplTest, RequestHttpSendHeadersFail) {
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
   EXPECT_CALL(active_span, spawnChild_(_, "async test_cluster egress", _))
       .WillOnce(Return(child_span));
-  EXPECT_CALL(*child_span, setTag("upstream_cluster_name", "test_cluster"));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER_NAME, "test_cluster"));
   EXPECT_CALL(*child_span, injectContext(_));
-  EXPECT_CALL(*child_span, setTag("grpc.status_code", "13"));
-  EXPECT_CALL(*child_span, setTag("error", "true"));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().GRPC_STATUS_CODE, "13"));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
   EXPECT_CALL(*child_span, finishSpan());
 
   auto* grpc_request = grpc_client_->send(*method_descriptor_, request_msg, grpc_callbacks,
@@ -573,8 +578,8 @@ TEST_F(GrpcAsyncClientImplTest, RequestTrailersOnly) {
   auto request = createRequest(empty_metadata);
   Http::HeaderMapPtr reply_headers{
       new Http::TestHeaderMapImpl{{":status", "200"}, {"grpc-status", "0"}}};
-  EXPECT_CALL(*request->child_span_, setTag("grpc.status_code", "0"));
-  EXPECT_CALL(*request->child_span_, setTag("error", "true"));
+  EXPECT_CALL(*request->child_span_, setTag(Tracing::Tags::get().GRPC_STATUS_CODE, "0"));
+  EXPECT_CALL(*request->child_span_, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
   EXPECT_CALL(*request, onFailure(Status::Internal, "", _));
   EXPECT_CALL(*request->child_span_, finishSpan());
   EXPECT_CALL(*request->http_stream_, reset());
@@ -638,7 +643,8 @@ TEST_F(GrpcAsyncClientImplTest, ResetAfterCloseRemote) {
 TEST_F(GrpcAsyncClientImplTest, CancelRequest) {
   TestMetadata empty_metadata;
   auto request = createRequest(empty_metadata);
-  EXPECT_CALL(*request->child_span_, setTag("status", "canceled"));
+  EXPECT_CALL(*request->child_span_,
+              setTag(Tracing::Tags::get().STATUS, Tracing::Tags::get().CANCELED));
   EXPECT_CALL(*request->child_span_, finishSpan());
   EXPECT_CALL(*request->http_stream_, reset());
   request->grpc_request_->cancel();

--- a/test/common/grpc/async_client_impl_test.cc
+++ b/test/common/grpc/async_client_impl_test.cc
@@ -26,12 +26,6 @@ template class AsyncStreamImpl<helloworld::HelloRequest, helloworld::HelloReply>
 
 namespace {
 
-TEST(AsyncClientTracingConfigTest, All) {
-  AsyncClientTracingConfig config;
-  EXPECT_EQ(Tracing::OperationName::Egress, config.operationName());
-  EXPECT_TRUE(config.requestHeadersForTags().empty());
-}
-
 const std::string HELLO_REQUEST = "ABC";
 // We expect the 5 byte header to only have a length of 5 indicating the size of the protobuf. The
 // protobuf begins with 0x0a, indicating this is the first field of type string. This is followed

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -1921,6 +1921,7 @@ TEST_F(RouterTestChildSpan, BasicFlow) {
   HttpTestUtility::addDefaultHeaders(headers);
   EXPECT_CALL(callbacks_.active_span_, spawnChild_(_, "router fake_cluster egress", _))
       .WillOnce(Return(child_span));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY));
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});
@@ -1950,6 +1951,7 @@ TEST_F(RouterTestChildSpan, ResetFlow) {
   HttpTestUtility::addDefaultHeaders(headers);
   EXPECT_CALL(callbacks_.active_span_, spawnChild_(_, "router fake_cluster egress", _))
       .WillOnce(Return(child_span));
+  EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY));
   router_.decodeHeaders(headers, true);
 
   Http::HeaderMapPtr response_headers(new Http::TestHeaderMapImpl{{":status", "200"}});

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -254,9 +254,9 @@ TEST(HttpConnManFinalizerImpl, OriginalAndLongPath) {
   EXPECT_CALL(request_info, responseCode()).WillRepeatedly(ReturnRef(response_code));
 
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
-  EXPECT_CALL(*span, setTag("http.url", path_prefix + expected_path));
-  EXPECT_CALL(*span, setTag("http.method", "GET"));
-  EXPECT_CALL(*span, setTag("http.protocol", "HTTP/2"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_URL, path_prefix + expected_path));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_METHOD, "GET"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_PROTOCOL, "HTTP/2"));
 
   NiceMock<MockConfig> config;
   HttpTracerUtility::finalizeSpan(*span, &request_headers, request_info, config);
@@ -272,12 +272,12 @@ TEST(HttpConnManFinalizerImpl, NullRequestHeaders) {
   EXPECT_CALL(request_info, responseCode()).WillRepeatedly(ReturnRef(response_code));
   EXPECT_CALL(request_info, upstreamHost()).WillOnce(Return(nullptr));
 
-  EXPECT_CALL(*span, setTag("http.status_code", "0"));
-  EXPECT_CALL(*span, setTag("error", "true"));
-  EXPECT_CALL(*span, setTag("response_size", "11"));
-  EXPECT_CALL(*span, setTag("response_flags", "-"));
-  EXPECT_CALL(*span, setTag("request_size", "10"));
-  EXPECT_CALL(*span, setTag("upstream_cluster", _)).Times(0);
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_STATUS_CODE, "0"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().RESPONSE_SIZE, "11"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "-"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().REQUEST_SIZE, "10"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, _)).Times(0);
 
   NiceMock<MockConfig> config;
   HttpTracerUtility::finalizeSpan(*span, nullptr, request_info, config);
@@ -294,12 +294,12 @@ TEST(HttpConnManFinalizerImpl, UpstreamClusterTagSet) {
   EXPECT_CALL(request_info, responseCode()).WillRepeatedly(ReturnRef(response_code));
   EXPECT_CALL(request_info, upstreamHost()).Times(2);
 
-  EXPECT_CALL(*span, setTag("upstream_cluster", "my_upstream_cluster"));
-  EXPECT_CALL(*span, setTag("http.status_code", "0"));
-  EXPECT_CALL(*span, setTag("error", "true"));
-  EXPECT_CALL(*span, setTag("response_size", "11"));
-  EXPECT_CALL(*span, setTag("response_flags", "-"));
-  EXPECT_CALL(*span, setTag("request_size", "10"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, "my_upstream_cluster"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_STATUS_CODE, "0"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().RESPONSE_SIZE, "11"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "-"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().REQUEST_SIZE, "10"));
 
   NiceMock<MockConfig> config;
   HttpTracerUtility::finalizeSpan(*span, nullptr, request_info, config);
@@ -320,24 +320,24 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
   const std::string service_node = "i-453";
 
   // Check that span is populated correctly.
-  EXPECT_CALL(*span, setTag("guid:x-request-id", "id"));
-  EXPECT_CALL(*span, setTag("http.url", "https:///test"));
-  EXPECT_CALL(*span, setTag("http.method", "GET"));
-  EXPECT_CALL(*span, setTag("user_agent", "-"));
-  EXPECT_CALL(*span, setTag("http.protocol", "HTTP/1.0"));
-  EXPECT_CALL(*span, setTag("downstream_cluster", "-"));
-  EXPECT_CALL(*span, setTag("request_size", "10"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().GUID_X_REQUEST_ID, "id"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_URL, "https:///test"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_METHOD, "GET"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().USER_AGENT, "-"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_PROTOCOL, "HTTP/1.0"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().DOWNSTREAM_CLUSTER, "-"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().REQUEST_SIZE, "10"));
 
   Optional<uint32_t> response_code;
   EXPECT_CALL(request_info, responseCode()).WillRepeatedly(ReturnRef(response_code));
   EXPECT_CALL(request_info, bytesSent()).WillOnce(Return(100));
   EXPECT_CALL(request_info, upstreamHost()).WillOnce(Return(nullptr));
 
-  EXPECT_CALL(*span, setTag("http.status_code", "0"));
-  EXPECT_CALL(*span, setTag("error", "true"));
-  EXPECT_CALL(*span, setTag("response_size", "100"));
-  EXPECT_CALL(*span, setTag("response_flags", "-"));
-  EXPECT_CALL(*span, setTag("upstream_cluster", _)).Times(0);
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_STATUS_CODE, "0"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().RESPONSE_SIZE, "100"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "-"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, _)).Times(0);
 
   NiceMock<MockConfig> config;
   HttpTracerUtility::finalizeSpan(*span, &request_headers, request_info, config);
@@ -362,14 +362,14 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
   const std::string service_node = "i-453";
 
   // Check that span is populated correctly.
-  EXPECT_CALL(*span, setTag("guid:x-request-id", "id"));
-  EXPECT_CALL(*span, setTag("http.url", "http://api/test"));
-  EXPECT_CALL(*span, setTag("http.method", "GET"));
-  EXPECT_CALL(*span, setTag("user_agent", "agent"));
-  EXPECT_CALL(*span, setTag("http.protocol", "HTTP/1.0"));
-  EXPECT_CALL(*span, setTag("downstream_cluster", "downstream_cluster"));
-  EXPECT_CALL(*span, setTag("request_size", "10"));
-  EXPECT_CALL(*span, setTag("guid:x-client-trace-id", "client_trace_id"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().GUID_X_REQUEST_ID, "id"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_URL, "http://api/test"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_METHOD, "GET"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().USER_AGENT, "agent"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_PROTOCOL, "HTTP/1.0"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().DOWNSTREAM_CLUSTER, "downstream_cluster"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().REQUEST_SIZE, "10"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().GUID_X_CLIENT_TRACE_ID, "client_trace_id"));
 
   // Check that span has tags from custom headers.
   request_headers.addCopy(Http::LowerCaseString("aa"), "a");
@@ -390,11 +390,11 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
       .WillByDefault(Return(true));
   EXPECT_CALL(request_info, upstreamHost()).WillOnce(Return(nullptr));
 
-  EXPECT_CALL(*span, setTag("error", "true"));
-  EXPECT_CALL(*span, setTag("http.status_code", "503"));
-  EXPECT_CALL(*span, setTag("response_size", "100"));
-  EXPECT_CALL(*span, setTag("response_flags", "UT"));
-  EXPECT_CALL(*span, setTag("upstream_cluster", _)).Times(0);
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_STATUS_CODE, "503"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().RESPONSE_SIZE, "100"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "UT"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, _)).Times(0);
 
   HttpTracerUtility::finalizeSpan(*span, &request_headers, request_info, config);
 }
@@ -454,7 +454,7 @@ TEST_F(HttpTracerImplTest, BasicFunctionalityNodeSet) {
   EXPECT_CALL(*driver_, startSpan_(_, _, operation_name, request_info_.start_time_))
       .WillOnce(Return(span));
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
-  EXPECT_CALL(*span, setTag("node_id", "node_name"));
+  EXPECT_CALL(*span, setTag(Tracing::Tags::get().NODE_ID, "node_name"));
 
   tracer_->startSpan(config_, request_headers_, request_info_);
 }


### PR DESCRIPTION
…void inconsistent usage

A couple of things to consider:

- currently the constants are defined in http_tracer_impl.h, but most of them are not http specific, so may be better to define in a tracer.h?

- there seems to be duplicate upstream cluster tags

- currently the ratelimit_impl.h has its own constants used for tags - perhaps these should also be consolidated

- class AsyncClientTracingConfig may no longer be required

Also taken the opportunity to add the OpenTracing standard 'component' tag to the created spans - this was because in some examples where tracing is also captured from the services, it could be useful to distinguish between the spans created in the proxy.

*Risk Level*: Low 

Testing*: Added new tag (component) to relevant tests, updated to use constants

*Docs Changes*: None

*Release Notes*: None

Signed-off-by: Gary Brown <gary@brownuk.com>
