### PR TITLE
Making fix format more pedantic to be merciful to maintainers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ maximize the chances of your PR being merged.
 
 The sign-off is a simple line at the end of the explanation for the
 patch, which certifies that you wrote it or otherwise have the right to
-pass it on as an open-source patch.  The rules are pretty simple: if you
+pass it on as an open-source patch. The rules are pretty simple: if you
 can certify the below (from
 [developercertificate.org](http://developercertificate.org/)):
 

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -23,7 +23,7 @@ The following features have been DEPRECATED and will be removed in the specified
 * Config option `http_codec_options` has been deprecated and has been replaced with `http2_settings`.
 * The following log macros have been deprecated: `log_trace`, `log_debug`, `conn_log`,
   `conn_log_info`, `conn_log_debug`, `conn_log_trace`, `stream_log`, `stream_log_info`,
-  `stream_log_debug`, `stream_log_trace`.  For replacements, please see
+  `stream_log_debug`, `stream_log_trace`. For replacements, please see
   [logger.h](https://github.com/envoyproxy/envoy/blob/master/source/common/common/logger.h).
 * The connectionId() and ssl() callbacks of StreamFilterCallbacks have been deprecated and
   replaced with a more general connection() callback, which, when not returning a nullptr, can be

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 *Description*:
 >Describe the issue. Please be detailed. If a feature request, please
-describe the desired behaviour, what scenario it enables and how it 
+describe the desired behaviour, what scenario it enables and how it
 would be used.
 
 [optional *Relevant Links*:]
@@ -22,17 +22,17 @@ the bug, for example: Envoy should not crash, the expected value isn't
 returned, etc.
 
 *Repro steps*:
-> Include sample requests, environment, etc. All data and inputs 
+> Include sample requests, environment, etc. All data and inputs
 required to reproduce the bug.
 
 >**Note**: The [Envoy_collect tool](https://github.com/envoyproxy/envoy/blob/master/tools/envoy_collect/README.md)
-gathers a tarball with debug logs, config and the following admin 
+gathers a tarball with debug logs, config and the following admin
 endpoints: /stats, /clusters and /server_info. Please note if there are
-privacy concerns, sanitize the data prior to sharing the tarball/pasting. 
+privacy concerns, sanitize the data prior to sharing the tarball/pasting.
 
 *Admin and Stats Output*:
->Include the admin output for the following endpoints: /stats, 
-/clusters, /routes, /server_info. For more information, refer to the 
+>Include the admin output for the following endpoints: /stats,
+/clusters, /routes, /server_info. For more information, refer to the
 [admin endpoint documentation.](https://www.envoyproxy.io/docs/envoy/latest/operations/admin)
 
 >**Note**: If there are privacy concerns, sanitize the data prior to

--- a/STYLE.md
+++ b/STYLE.md
@@ -25,16 +25,16 @@
   * `typedef std::shared_ptr<Bar> BarSharedPtr;`
   * `typedef std::shared_ptr<const Blah> BlahConstSharedPtr;`
   * Regular pointers (e.g. `int* foo`) should not be type aliased.
-* If move semantics are intended, prefer specifying function arguments with `&&`. 
+* If move semantics are intended, prefer specifying function arguments with `&&`.
   E.g., `void onHeaders(Http::HeaderMapPtr&& headers, ...)`. The rationale for this is that it
   forces the caller to specify `std::move(...)` or pass a temporary and makes the intention at
   the callsite clear. Otherwise, it's difficult to tell if a const reference is actually being
   passed to the called function. This is true even for `std::unique_ptr`.
 * Prefer `unique_ptr` over `shared_ptr` wherever possible. `unique_ptr` makes ownership in
-  production code easier to reason about. Note that this creates some test oddities where 
+  production code easier to reason about. Note that this creates some test oddities where
   production code requires a `unique_ptr` but the test must still have access to the memory
   the production code is using (mock or otherwise). In these cases it is acceptable to allocate
-  raw memory in a test and return it to the production code with the expectation that the 
+  raw memory in a test and return it to the production code with the expectation that the
   production code will hold it in a `unique_ptr` and free it. Envoy uses the factory pattern
   quite a bit for these cases. (Search the code for "factory").
 * The Google C++ style guide points out that [non-PoD static and global variables are forbidden](https://google.github.io/styleguide/cppguide.html#Static_and_Global_Variables).
@@ -55,7 +55,7 @@
 * If a method that must be defined outside the `test` directory is intended to be called only
   from test code then it should have a name that ends in `ForTest()` such as `aMethodForTest()`.
   In most cases tests can and should be structured so this is not necessary.
-* Tests default to StrictMock so will fail if hitting unexpected warnings.  Feel free to use
+* Tests default to StrictMock so will fail if hitting unexpected warnings. Feel free to use
   NiceMock for mocks whose behavior is not the focus of a test.
 * There are probably a few other things missing from this list. We will add them as they
   are brought to our attention.

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -25,7 +25,7 @@ testing purposes. The specific versions of the Envoy dependencies used in this b
 up-to-date with the latest security patches.
 
 1. Install the latest version of [Bazel](https://bazel.build/versions/master/docs/install.html) in your environment.
-2.  Install external dependencies libtool, cmake, and realpath libraries separately.
+2. Install external dependencies libtool, cmake, and realpath libraries separately.
 On Ubuntu, run the following commands:
 ```
  apt-get install libtool
@@ -52,7 +52,7 @@ brew install automake
 Envoy compiles and passes tests with the version of clang installed by XCode 8.3.3:
 Apple LLVM version 8.1.0 (clang-802.0.42).
 
-3.  Install Golang on your machine. This is required as part of building [BoringSSL](https://boringssl.googlesource.com/boringssl/+/HEAD/BUILDING.md)
+3. Install Golang on your machine. This is required as part of building [BoringSSL](https://boringssl.googlesource.com/boringssl/+/HEAD/BUILDING.md)
 and also for [Buildifer](https://github.com/bazelbuild/buildtools) which is used for formatting bazel BUILD files.
 4. `bazel fetch //source/...` to fetch and build all external dependencies. This may take some time.
 5. `bazel build //source/exe:envoy-static` from the Envoy source directory.
@@ -155,9 +155,9 @@ bazel test //test/common/http:async_client_impl_test --strategy=TestRunner=stand
 # Stack trace symbol resolution
 
 Envoy can produce backtraces on demand and from assertions and other fatal
-actions like segfaults.  The stack traces written in the log or to stderr contain
-addresses rather than resolved symbols.  The `tools/stack_decode.py` script exists
-to process the output and do symbol resolution to make the stack traces useful.  Any
+actions like segfaults. The stack traces written in the log or to stderr contain
+addresses rather than resolved symbols. The `tools/stack_decode.py` script exists
+to process the output and do symbol resolution to make the stack traces useful. Any
 log lines not relevant to the backtrace capability are passed through the script unchanged
 (it acts like a filter).
 
@@ -178,9 +178,9 @@ You will need to use either a `dbg` build type or the `opt` build type to get sy
 information in the binaries.
 
 By default main.cc will install signal handlers to print backtraces at the
-location where a fatal signal occurred.  The signal handler will re-raise the
+location where a fatal signal occurred. The signal handler will re-raise the
 fatal signal with the default handler so a core file will still be dumped after
-the stack trace is logged.  To inhibit this behavior use
+the stack trace is logged. To inhibit this behavior use
 `--define=signal_trace=disabled` on the Bazel command line. No signal handlers will
 be installed.
 
@@ -254,7 +254,7 @@ The default maximum number of stats in shared memory, and the default
 maximum length of a cluster/route config/listener name, can be
 overriden at compile-time by defining `ENVOY_DEFAULT_MAX_STATS` and
 `ENVOY_DEFAULT_MAX_OBJ_NAME_LENGTH`, respectively, to the desired
-value.  For example:
+value. For example:
 
 ```
 bazel build --copts=-DENVOY_DEFAULT_MAX_STATS=32768 --copts=-DENVOY_DEFAULT_MAX_OBJ_NAME_LENGTH=150 //source/exe:envoy-static

--- a/configs/original-dst-cluster/README.md
+++ b/configs/original-dst-cluster/README.md
@@ -2,7 +2,7 @@
 
 An original destination cluster forwards requests to the same destination
 the request was going to before being redirected to Envoy using an
-iptables REDIRECT rule.  `proxy_config.json` contains an example Envoy
+iptables REDIRECT rule. `proxy_config.json` contains an example Envoy
 configuration demonstrating the use of an original destination
 cluster. `netns_setup.sh` and `netns_cleanup.sh` are provided as
 examples for setting up and cleaning up, respectively, a network
@@ -21,7 +21,7 @@ the traffic matches `173.194.222.0/24` :
 
 ```
 sudo ./configs/original-dst-cluster/netns_setup.sh ns1 173.194.222.0/24
-``` 
+```
 
 # Building and running Envoy
 
@@ -71,6 +71,6 @@ the setup before:
 
 ```
 sudo ./configs/original-dst-cluster/netns_cleanup.sh ns1 173.194.222.0/24
-``` 
+```
 
 Finally, stop Envoy with `^C`.

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,7 +1,7 @@
 # Writing new tests
 
 The Envoy integration test framework is designed to make it simple to test downstream-Envoy-upstream
-communication.  In the common case, one
+communication. In the common case, one
 
 - Sends a request from downstream through Envoy
 - Verifies the request is received upstream, and possibly inspects elements of the headers or body
@@ -23,7 +23,7 @@ Http::TestHeaderMapImpl request_headers{{":method", "GET"},
                                         {":scheme", "http"},
                                         {":authority", "host"}};
 
-// Send the request headers from the client, wait until they are received upstream.  When they
+// Send the request headers from the client, wait until they are received upstream. When they
 // are received, send the default response headers from upstream and wait until they are
 // received at by client
 sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
@@ -38,9 +38,9 @@ EXPECT_EQ(0U, response_->body().size());
 ```
 
 Once you have the basic end-to-end test, it is fairly straight forward to modify it to test more
-interesting corner cases.   There are existing tests which send requests with bodies, have
+interesting corner cases. There are existing tests which send requests with bodies, have
 downstream or upstream disconnect or time out, send multiple simultaneous requests on the same
-connection, etc.  Given that many of the disconnect/timeout cases are covered, a common case for
+connection, etc. Given that many of the disconnect/timeout cases are covered, a common case for
 testing is covering a newly added configuration option.
 
 Most of Envoy's tests have been migrated from using [`json flatfiles`](../config/integration/) to
@@ -60,10 +60,10 @@ or
 config_helper_.addFilter(ConfigHelper::DEFAULT_BUFFER_FILTER);
 ```
 
-For other edits which are less likely reusable, one can add config modifiers.  Config modifiers
-allow arbitrary modification of Envoy’s configuration just before Envoy is brought up.  One can add
+For other edits which are less likely reusable, one can add config modifiers. Config modifiers
+allow arbitrary modification of Envoy’s configuration just before Envoy is brought up. One can add
 a config modifier to alter the bootstrap proto, one which affects the first `HttpConnectionManager`
-object in the config, or mix and match.  Config modifiers are operated on in the order they are
+object in the config, or mix and match. Config modifiers are operated on in the order they are
 added, so one could, for example, modify the default `HttpConnectionManager`, duplicate the listening
 config, and then change the first `HttpConnectionManager` to be different from the second.
 
@@ -95,7 +95,7 @@ cluster:
     });
 ```
 
-In addition to the existing test framework, which allows for carefully timed interaction and ordering of events between downstream, Envoy, and Upstream, there is now an “autonomous” framework which simplifies the common case where the timing is not essential (or bidirectional streaming is desired).  When AutonomousUpstream is used, by setting `autonomous_upstream_ = true` before `initialize()`, upstream will by default create AutonomousHttpConnections for each incoming connection and AutonomousStreams for each incoming stream.  By default, the streams will respond to each complete request with “200 OK” and 10 bytes of payload, but this behavior can be altered by setting various request headers, as documented in [`autonomous_upstream.h`](autonomous_upstream.h)
+In addition to the existing test framework, which allows for carefully timed interaction and ordering of events between downstream, Envoy, and Upstream, there is now an “autonomous” framework which simplifies the common case where the timing is not essential (or bidirectional streaming is desired). When AutonomousUpstream is used, by setting `autonomous_upstream_ = true` before `initialize()`, upstream will by default create AutonomousHttpConnections for each incoming connection and AutonomousStreams for each incoming stream. By default, the streams will respond to each complete request with “200 OK” and 10 bytes of payload, but this behavior can be altered by setting various request headers, as documented in [`autonomous_upstream.h`](autonomous_upstream.h)
 
 # Extending the test framework
 
@@ -103,6 +103,6 @@ The Envoy integration test framework is most definitely a work in progress.
 When encountering features which do not exist (actions for the autonomous
 backend, testing new sections of configuration) please use your best judgement
 if the changes will be needed by one specific test file, or will be likely
-reused in other integration tests.  If it's likely be reused, please add the
-appropriate functions to existing utilities or add new test utilities.  If it's
+reused in other integration tests. If it's likely be reused, please add the
+appropriate functions to existing utilities or add new test utilities. If it's
 likely a one-off change, it can be scoped to the existing test file.

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -9,7 +9,8 @@ import sys
 
 EXCLUDED_PREFIXES = ("./generated/", "./thirdparty/", "./build", "./.git/",
                      "./bazel-", "./bazel/external")
-SUFFIXES = (".cc", ".h", "BUILD")
+SUFFIXES = (".cc", ".h", "BUILD", ".md", ".rst")
+DOCS_SUFFIX = (".md", ".rst")
 
 # Files in these paths can make reference to protobuf stuff directly
 GOOGLE_PROTOBUF_WHITELIST = ('ci/prebuilt', 'source/common/protobuf')
@@ -104,6 +105,9 @@ def checkFilePath(file_path):
     checkProtobufExternalDepsBuild(file_path)
     return
   checkFileContents(file_path)
+
+  if file_path.endswith(DOCS_SUFFIX):
+    return
   checkNamespace(file_path)
   checkProtobufExternalDeps(file_path)
   command = ("%s %s | diff -q %s - > /dev/null" % (HEADER_ORDER_PATH, file_path,
@@ -124,6 +128,8 @@ def fixFilePath(file_path):
       printError("buildifier rewrite failed for file: %s" % file_path)
     return
   fixFileContents(file_path)
+  if file_path.endswith(DOCS_SUFFIX):
+    return
   if not checkNamespace(file_path) or not checkProtobufExternalDepsBuild(
       file_path) or not checkProtobufExternalDeps(file_path):
     printError("This cannot be automatically corrected. Please fix by hand.")


### PR DESCRIPTION
Adding .md and .rst to whitespace checking in [check/fix]_format

*Risk Level*: 
risk to envoy: none (docs and tools change only) 
low risk of alienating any passionate developers on the other side of the double space wars :-P

*Testing*:
nope!

*Docs Changes*:
Lots of them!

*Release Notes*:
None for this patch, but release notes will now be protected from the dreaded double-space.

[Optional Fixes #Issue]
Fixes whitespace, according to most maintainers.

[Optional *API Changes*:]
Nope, but I'll make the same change over there, until we have shared scripts.

[Optional *Deprecated*:]
The concept of ".  "

Signed-off-by: Alyssa Wilk <alyssar@chromium.org>
who is possibly overly punchy on very little sleep.