### PR TITLE
tracing: Make the tracing config available to the router

### DIFF
--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -135,6 +135,11 @@ public:
   virtual Tracing::Span& activeSpan() PURE;
 
   /**
+   * @return tracing configuration.
+   */
+  virtual const Tracing::Config& tracingConfig() PURE;
+
+  /**
    * @return the trusted downstream address for the connection.
    */
   virtual const std::string& downstreamAddress() PURE;

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -69,6 +69,7 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
                                  bool buffer_body_for_retry)
     : parent_(parent), stream_callbacks_(callbacks), stream_id_(parent.config_.random_.random()),
       router_(parent.config_), request_info_(Protocol::Http11),
+      tracing_config_(Tracing::EgressConfig::get()),
       route_(std::make_shared<RouteImpl>(parent_.cluster_.name(), timeout)) {
   if (buffer_body_for_retry) {
     buffered_body_.reset(new Buffer::OwnedImpl());

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -210,6 +210,7 @@ private:
   uint64_t streamId() override { return stream_id_; }
   AccessLog::RequestInfo& requestInfo() override { return request_info_; }
   Tracing::Span& activeSpan() override { return active_span_; }
+  const Tracing::Config& tracingConfig() override { return tracing_config_; }
   const std::string& downstreamAddress() override { return EMPTY_STRING; }
   void continueDecoding() override { NOT_IMPLEMENTED; }
   void addDecodedData(Buffer::Instance&, bool) override { NOT_IMPLEMENTED; }
@@ -229,6 +230,7 @@ private:
   Router::ProdFilter router_;
   AccessLog::RequestInfoImpl request_info_;
   Tracing::NullSpan active_span_;
+  const Tracing::Config& tracing_config_;
   std::shared_ptr<RouteImpl> route_;
   bool local_closed_{};
   bool remote_closed_{};

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1144,6 +1144,8 @@ Tracing::Span& ConnectionManagerImpl::ActiveStreamFilterBase::activeSpan() {
   }
 }
 
+Tracing::Config& ConnectionManagerImpl::ActiveStreamFilterBase::tracingConfig() { return parent_; }
+
 Router::RouteConstSharedPtr ConnectionManagerImpl::ActiveStreamFilterBase::route() {
   if (!parent_.cached_route_.valid()) {
     parent_.cached_route_.value(

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -357,6 +357,7 @@ private:
     uint64_t streamId() override;
     AccessLog::RequestInfo& requestInfo() override;
     Tracing::Span& activeSpan() override;
+    Tracing::Config& tracingConfig() override;
     const std::string& downstreamAddress() override;
 
     ActiveStream& parent_;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -748,7 +748,7 @@ Filter::UpstreamRequest::UpstreamRequest(Filter& parent, Http::ConnectionPool::I
 
   if (parent_.config_.start_child_span_) {
     span_ = parent_.callbacks_->activeSpan().spawnChild(
-        Tracing::EgressConfig::get(), "router " + parent.cluster_->name() + " egress",
+        parent_.callbacks_->tracingConfig(), "router " + parent.cluster_->name() + " egress",
         ProdSystemTimeSource::instance_.currentTime());
     span_->setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY);
   }

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -1921,6 +1921,7 @@ TEST_F(RouterTestChildSpan, BasicFlow) {
   HttpTestUtility::addDefaultHeaders(headers);
   EXPECT_CALL(callbacks_.active_span_, spawnChild_(_, "router fake_cluster egress", _))
       .WillOnce(Return(child_span));
+  EXPECT_CALL(callbacks_, tracingConfig());
   EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY));
   router_.decodeHeaders(headers, true);
 
@@ -1951,6 +1952,7 @@ TEST_F(RouterTestChildSpan, ResetFlow) {
   HttpTestUtility::addDefaultHeaders(headers);
   EXPECT_CALL(callbacks_.active_span_, spawnChild_(_, "router fake_cluster egress", _))
       .WillOnce(Return(child_span));
+  EXPECT_CALL(callbacks_, tracingConfig());
   EXPECT_CALL(*child_span, setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY));
   router_.decodeHeaders(headers, true);
 

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -92,6 +92,7 @@ MockStreamDecoderFilterCallbacks::MockStreamDecoderFilterCallbacks() {
       }));
 
   ON_CALL(*this, activeSpan()).WillByDefault(ReturnRef(active_span_));
+  ON_CALL(*this, tracingConfig()).WillByDefault(ReturnRef(tracing_config_));
 }
 
 MockStreamDecoderFilterCallbacks::~MockStreamDecoderFilterCallbacks() {}
@@ -100,6 +101,7 @@ MockStreamEncoderFilterCallbacks::MockStreamEncoderFilterCallbacks() {
   initializeMockStreamFilterCallbacks(*this);
   ON_CALL(*this, encodingBuffer()).WillByDefault(Invoke(&buffer_, &Buffer::InstancePtr::get));
   ON_CALL(*this, activeSpan()).WillByDefault(ReturnRef(active_span_));
+  ON_CALL(*this, tracingConfig()).WillByDefault(ReturnRef(tracing_config_));
 }
 
 MockStreamEncoderFilterCallbacks::~MockStreamEncoderFilterCallbacks() {}

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -217,6 +217,7 @@ public:
   MOCK_METHOD0(streamId, uint64_t());
   MOCK_METHOD0(requestInfo, AccessLog::RequestInfo&());
   MOCK_METHOD0(activeSpan, Tracing::Span&());
+  MOCK_METHOD0(tracingConfig, Tracing::Config&());
   MOCK_METHOD0(downstreamAddress, const std::string&());
   MOCK_METHOD0(onDecoderFilterAboveWriteBufferHighWatermark, void());
   MOCK_METHOD0(onDecoderFilterBelowWriteBufferLowWatermark, void());
@@ -241,6 +242,7 @@ public:
   Buffer::InstancePtr buffer_;
   std::list<DownstreamWatermarkCallbacks*> callbacks_{};
   testing::NiceMock<Tracing::MockSpan> active_span_;
+  testing::NiceMock<Tracing::MockConfig> tracing_config_;
 };
 
 class MockStreamEncoderFilterCallbacks : public StreamEncoderFilterCallbacks,
@@ -258,6 +260,7 @@ public:
   MOCK_METHOD0(streamId, uint64_t());
   MOCK_METHOD0(requestInfo, AccessLog::RequestInfo&());
   MOCK_METHOD0(activeSpan, Tracing::Span&());
+  MOCK_METHOD0(tracingConfig, Tracing::Config&());
   MOCK_METHOD0(downstreamAddress, const std::string&());
   MOCK_METHOD0(onEncoderFilterAboveWriteBufferHighWatermark, void());
   MOCK_METHOD0(onEncoderFilterBelowWriteBufferLowWatermark, void());
@@ -271,6 +274,7 @@ public:
 
   Buffer::InstancePtr buffer_;
   testing::NiceMock<Tracing::MockSpan> active_span_;
+  testing::NiceMock<Tracing::MockConfig> tracing_config_;
 };
 
 class MockStreamDecoderFilter : public StreamDecoderFilter {


### PR DESCRIPTION
This is required to eventually enable the router to create client spans when proxying an outbound request from a service. Note: the create child span in the router will still not work for the zipkin tracer yet - further changes will be required. 

Signed-off-by: Gary Brown <gary@brownuk.com>