### PR TITLE
router: refactor ResponseHeaderParser to use AccessLog::RequestInfo and share code with RequestHeaderParser

### DIFF
--- a/RAW_RELEASE_NOTES.md
+++ b/RAW_RELEASE_NOTES.md
@@ -12,3 +12,4 @@ final version.
 * Added transport socket interface to allow custom implementation of transport socket. A transport socket
   provides read and write logic with buffer encryption and decryption. The exising TLS implementation is
   refactored with the interface.
+* Added support for dynamic response header values (`%CLIENT_IP%` and `%PROTOCOL%`).

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -316,8 +316,10 @@ public:
    * adding or removing headers. This should only be called ONCE immediately after receiving an
    * upstream's headers.
    * @param headers supplies the response headers, which may be modified during this call.
+   * @param request_info holds additional information about the request.
    */
-  virtual void finalizeResponseHeaders(Http::HeaderMap& headers) const PURE;
+  virtual void finalizeResponseHeaders(Http::HeaderMap& headers,
+                                       const AccessLog::RequestInfo& request_info) const PURE;
 
   /**
    * @return const HashPolicy* the optional hash policy for the route.

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -147,7 +147,7 @@ private:
     }
     const Router::CorsPolicy* corsPolicy() const override { return nullptr; }
     void finalizeRequestHeaders(Http::HeaderMap&, const AccessLog::RequestInfo&) const override {}
-    void finalizeResponseHeaders(Http::HeaderMap&) const override {}
+    void finalizeResponseHeaders(Http::HeaderMap&, const AccessLog::RequestInfo&) const override {}
     const Router::HashPolicy* hashPolicy() const override { return nullptr; }
     const Router::MetadataMatchCriteria* metadataMatchCriteria() const override { return nullptr; }
     Upstream::ResourcePriority priority() const override {

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -211,7 +211,5 @@ envoy_cc_library(
     hdrs = ["header_formatter.h"],
     deps = [
         "//source/common/access_log:access_log_formatter_lib",
-        "//source/common/config:rds_json_lib",
-        "//source/common/protobuf:utility_lib",
     ],
 )

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -334,10 +334,11 @@ void RouteEntryImplBase::finalizeRequestHeaders(Http::HeaderMap& headers,
   headers.Host()->value(host_rewrite_);
 }
 
-void RouteEntryImplBase::finalizeResponseHeaders(Http::HeaderMap& headers) const {
-  response_headers_parser_->evaluateResponseHeaders(headers);
-  vhost_.responseHeaderParser().evaluateResponseHeaders(headers);
-  vhost_.globalRouteConfig().responseHeaderParser().evaluateResponseHeaders(headers);
+void RouteEntryImplBase::finalizeResponseHeaders(Http::HeaderMap& headers,
+                                                 const AccessLog::RequestInfo& request_info) const {
+  response_headers_parser_->evaluateResponseHeaders(headers, request_info);
+  vhost_.responseHeaderParser().evaluateResponseHeaders(headers, request_info);
+  vhost_.globalRouteConfig().responseHeaderParser().evaluateResponseHeaders(headers, request_info);
 }
 
 Optional<RouteEntryImplBase::RuntimeData>

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -107,8 +107,8 @@ public:
                                           uint64_t random_value) const;
   const VirtualCluster* virtualClusterFromEntries(const Http::HeaderMap& headers) const;
   const ConfigImpl& globalRouteConfig() const { return global_route_config_; }
-  const RequestHeaderParser& requestHeaderParser() const { return *request_headers_parser_; };
-  const ResponseHeaderParser& responseHeaderParser() const { return *response_headers_parser_; };
+  const HeaderParser& requestHeaderParser() const { return *request_headers_parser_; };
+  const HeaderParser& responseHeaderParser() const { return *response_headers_parser_; };
 
   // Router::VirtualHost
   const CorsPolicy* corsPolicy() const override { return cors_policy_.get(); }
@@ -147,8 +147,8 @@ private:
   std::unique_ptr<const CorsPolicyImpl> cors_policy_;
   const ConfigImpl& global_route_config_; // See note in RouteEntryImplBase::clusterEntry() on why
                                           // raw ref to the top level config is currently safe.
-  RequestHeaderParserPtr request_headers_parser_;
-  ResponseHeaderParserPtr response_headers_parser_;
+  HeaderParserPtr request_headers_parser_;
+  HeaderParserPtr response_headers_parser_;
 };
 
 typedef std::shared_ptr<VirtualHostImpl> VirtualHostSharedPtr;
@@ -346,8 +346,8 @@ protected:
 
   RouteConstSharedPtr clusterEntry(const Http::HeaderMap& headers, uint64_t random_value) const;
   void finalizePathHeader(Http::HeaderMap& headers, const std::string& matched_path) const;
-  const RequestHeaderParser& requestHeaderParser() const { return *request_headers_parser_; };
-  const ResponseHeaderParser& responseHeaderParser() const { return *response_headers_parser_; };
+  const HeaderParser& requestHeaderParser() const { return *request_headers_parser_; };
+  const HeaderParser& responseHeaderParser() const { return *response_headers_parser_; };
 
 private:
   struct RuntimeData {
@@ -479,8 +479,8 @@ private:
   std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
   std::unique_ptr<const HashPolicyImpl> hash_policy_;
   MetadataMatchCriteriaImplConstPtr metadata_match_criteria_;
-  RequestHeaderParserPtr request_headers_parser_;
-  ResponseHeaderParserPtr response_headers_parser_;
+  HeaderParserPtr request_headers_parser_;
+  HeaderParserPtr response_headers_parser_;
 
   // TODO(danielhochman): refactor multimap into unordered_map since JSON is unordered map.
   const std::multimap<std::string, std::string> opaque_config_;
@@ -585,8 +585,8 @@ public:
   ConfigImpl(const envoy::api::v2::RouteConfiguration& config, Runtime::Loader& runtime,
              Upstream::ClusterManager& cm, bool validate_clusters_default);
 
-  const RequestHeaderParser& requestHeaderParser() const { return *request_headers_parser_; };
-  const ResponseHeaderParser& responseHeaderParser() const { return *response_headers_parser_; };
+  const HeaderParser& requestHeaderParser() const { return *request_headers_parser_; };
+  const HeaderParser& responseHeaderParser() const { return *response_headers_parser_; };
 
   // Router::Config
   RouteConstSharedPtr route(const Http::HeaderMap& headers, uint64_t random_value) const override {
@@ -600,8 +600,8 @@ public:
 private:
   std::unique_ptr<RouteMatcher> route_matcher_;
   std::list<Http::LowerCaseString> internal_only_headers_;
-  RequestHeaderParserPtr request_headers_parser_;
-  ResponseHeaderParserPtr response_headers_parser_;
+  HeaderParserPtr request_headers_parser_;
+  HeaderParserPtr response_headers_parser_;
 };
 
 /**

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -306,7 +306,8 @@ public:
   const CorsPolicy* corsPolicy() const override { return cors_policy_.get(); }
   void finalizeRequestHeaders(Http::HeaderMap& headers,
                               const AccessLog::RequestInfo& request_info) const override;
-  void finalizeResponseHeaders(Http::HeaderMap& headers) const override;
+  void finalizeResponseHeaders(Http::HeaderMap& headers,
+                               const AccessLog::RequestInfo& request_info) const override;
   const HashPolicy* hashPolicy() const override { return hash_policy_.get(); }
 
   const MetadataMatchCriteria* metadataMatchCriteria() const override {
@@ -369,8 +370,9 @@ private:
                                 const AccessLog::RequestInfo& request_info) const override {
       return parent_->finalizeRequestHeaders(headers, request_info);
     }
-    void finalizeResponseHeaders(Http::HeaderMap& headers) const override {
-      return parent_->finalizeResponseHeaders(headers);
+    void finalizeResponseHeaders(Http::HeaderMap& headers,
+                                 const AccessLog::RequestInfo& request_info) const override {
+      return parent_->finalizeResponseHeaders(headers, request_info);
     }
 
     const CorsPolicy* corsPolicy() const override { return parent_->corsPolicy(); }

--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -20,8 +20,7 @@ RequestInfoHeaderFormatter::RequestInfoHeaderFormatter(const std::string& field_
       return request_info.getDownstreamAddress();
     };
   } else {
-    throw EnvoyException(
-        fmt::format("field '{}' not supported as custom request header", field_name));
+    throw EnvoyException(fmt::format("field '{}' not supported as custom header", field_name));
   }
 }
 

--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -9,7 +9,7 @@
 namespace Envoy {
 namespace Router {
 
-RequestHeaderFormatter::RequestHeaderFormatter(const std::string& field_name, bool append)
+RequestInfoHeaderFormatter::RequestInfoHeaderFormatter(const std::string& field_name, bool append)
     : append_(append) {
   if (field_name == "PROTOCOL") {
     field_extractor_ = [](const Envoy::AccessLog::RequestInfo& request_info) {
@@ -26,7 +26,7 @@ RequestHeaderFormatter::RequestHeaderFormatter(const std::string& field_name, bo
 }
 
 const std::string
-RequestHeaderFormatter::format(const Envoy::AccessLog::RequestInfo& request_info) const {
+RequestInfoHeaderFormatter::format(const Envoy::AccessLog::RequestInfo& request_info) const {
   return field_extractor_(request_info);
 }
 

--- a/source/common/router/header_formatter.h
+++ b/source/common/router/header_formatter.h
@@ -1,12 +1,10 @@
 #pragma once
 
+#include <functional>
+#include <memory>
 #include <string>
 
 #include "envoy/access_log/access_log.h"
-
-#include "common/protobuf/protobuf.h"
-
-#include "api/rds.pb.h"
 
 namespace Envoy {
 namespace Router {

--- a/source/common/router/header_formatter.h
+++ b/source/common/router/header_formatter.h
@@ -32,9 +32,9 @@ typedef std::unique_ptr<HeaderFormatter> HeaderFormatterPtr;
 /**
  * A formatter that expands the request header variable to a value based on info in RequestInfo.
  */
-class RequestHeaderFormatter : public HeaderFormatter {
+class RequestInfoHeaderFormatter : public HeaderFormatter {
 public:
-  RequestHeaderFormatter(const std::string& field_name, bool append);
+  RequestInfoHeaderFormatter(const std::string& field_name, bool append);
 
   // HeaderFormatter::format
   const std::string format(const Envoy::AccessLog::RequestInfo& request_info) const override;

--- a/source/common/router/header_parser.h
+++ b/source/common/router/header_parser.h
@@ -14,51 +14,36 @@
 namespace Envoy {
 namespace Router {
 
-class HeaderParserBase {
-protected:
-  void addHeaders(Http::HeaderMap& headers, const AccessLog::RequestInfo& request_info) const;
-
-  void
-  setHeadersToAdd(const Protobuf::RepeatedPtrField<envoy::api::v2::HeaderValueOption>& headers);
-
-  std::vector<std::pair<Http::LowerCaseString, HeaderFormatterPtr>> header_formatters_;
-};
-
-class RequestHeaderParser;
-typedef std::unique_ptr<RequestHeaderParser> RequestHeaderParserPtr;
+class HeaderParser;
+typedef std::unique_ptr<HeaderParser> HeaderParserPtr;
 
 /**
- * This class provides request-time generation of upstream request headers. Header configurations
- * are pre-parsed to select between constant values and values based on the evaluation of
+ * HeaderParser manipulates Http::HeaderMap instances. Headers to be added are pre-parsed to select
+ * between a constant value implementation and a dynamic value implementation based on
  * AccessLog::RequestInfo fields.
  */
-class RequestHeaderParser : public HeaderParserBase {
+class HeaderParser {
 public:
-  static RequestHeaderParserPtr
-  parse(const Protobuf::RepeatedPtrField<envoy::api::v2::HeaderValueOption>& headers);
+  /*
+   * @param headers_to_add defines the headers to add during calls to evaluateHeaders
+   * @return HeaderParserPtr a configured HeaderParserPtr
+   */
+  static HeaderParserPtr
+  configure(const Protobuf::RepeatedPtrField<envoy::api::v2::HeaderValueOption>& headers_to_add);
 
-  void evaluateRequestHeaders(Http::HeaderMap& headers,
-                              const AccessLog::RequestInfo& request_info) const;
-};
+  /*
+   * @param headers_to_add defines headers to add during calls to evaluateHeaders
+   * @param headers_to_remove defines headers to remove during calls to evaluateHeaders
+   * @return HeaderParserPtr a configured HeaderParserPtr
+   */
+  static HeaderParserPtr
+  configure(const Protobuf::RepeatedPtrField<envoy::api::v2::HeaderValueOption>& headers_to_add,
+            const Protobuf::RepeatedPtrField<ProtobufTypes::String>& headers_to_remove);
 
-class ResponseHeaderParser;
-typedef std::unique_ptr<ResponseHeaderParser> ResponseHeaderParserPtr;
-
-/**
- * This class provides request-time manipulation of response headers. Header configurations are
- * pre-parsed to select between constant values and values based on the evaluation of
- * AccessLog::RequestInfo fields.
- */
-class ResponseHeaderParser : public HeaderParserBase {
-public:
-  static ResponseHeaderParserPtr
-  parse(const Protobuf::RepeatedPtrField<envoy::api::v2::HeaderValueOption>& headers_to_add,
-        const Protobuf::RepeatedPtrField<ProtobufTypes::String>& headers_to_remove);
-
-  void evaluateResponseHeaders(Http::HeaderMap& headers,
-                               const AccessLog::RequestInfo& request_info) const;
+  void evaluateHeaders(Http::HeaderMap& headers, const AccessLog::RequestInfo& request_info) const;
 
 private:
+  std::vector<std::pair<Http::LowerCaseString, HeaderFormatterPtr>> headers_to_add_;
   std::vector<Http::LowerCaseString> headers_to_remove_;
 };
 

--- a/source/common/router/header_parser.h
+++ b/source/common/router/header_parser.h
@@ -42,6 +42,9 @@ public:
 
   void evaluateHeaders(Http::HeaderMap& headers, const AccessLog::RequestInfo& request_info) const;
 
+protected:
+  HeaderParser() {}
+
 private:
   std::vector<std::pair<Http::LowerCaseString, HeaderFormatterPtr>> headers_to_add_;
   std::vector<Http::LowerCaseString> headers_to_remove_;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -606,7 +606,7 @@ void Filter::onUpstreamHeaders(const uint64_t response_code, Http::HeaderMapPtr&
   // TODO(zuercher): If access to response_headers_to_add (at any level) is ever needed outside
   // Router::Filter we'll need to find a better location for this work. One possibility is to
   // provide finalizeResponseHeaders functions on the Router::Config and VirtualHost interfaces.
-  route_entry_->finalizeResponseHeaders(*headers);
+  route_entry_->finalizeResponseHeaders(*headers, callbacks_->requestInfo());
 
   downstream_response_started_ = true;
   if (end_stream) {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -761,7 +761,7 @@ response_headers_to_remove: ["x-global-remove"]
       Http::TestHeaderMapImpl req_headers = genHeaders("www.lyft.com", "/new_endpoint/foo", "GET");
       const RouteEntry* route = config.route(req_headers, 0)->routeEntry();
       Http::TestHeaderMapImpl headers;
-      route->finalizeResponseHeaders(headers);
+      route->finalizeResponseHeaders(headers, request_info);
       EXPECT_EQ("route-override", headers.get_("x-global-header1"));
       EXPECT_EQ("route-override", headers.get_("x-vhost-header1"));
       EXPECT_EQ("route-new_endpoint", headers.get_("x-route-header"));
@@ -772,7 +772,7 @@ response_headers_to_remove: ["x-global-remove"]
       Http::TestHeaderMapImpl req_headers = genHeaders("www.lyft.com", "/", "GET");
       const RouteEntry* route = config.route(req_headers, 0)->routeEntry();
       Http::TestHeaderMapImpl headers;
-      route->finalizeResponseHeaders(headers);
+      route->finalizeResponseHeaders(headers, request_info);
       EXPECT_EQ("vhost-override", headers.get_("x-global-header1"));
       EXPECT_EQ("vhost1-www2", headers.get_("x-vhost-header1"));
       EXPECT_EQ("route-allpath", headers.get_("x-route-header"));
@@ -783,7 +783,7 @@ response_headers_to_remove: ["x-global-remove"]
       Http::TestHeaderMapImpl req_headers = genHeaders("www-staging.lyft.net", "/foo", "GET");
       const RouteEntry* route = config.route(req_headers, 0)->routeEntry();
       Http::TestHeaderMapImpl headers;
-      route->finalizeResponseHeaders(headers);
+      route->finalizeResponseHeaders(headers, request_info);
       EXPECT_EQ("global1", headers.get_("x-global-header1"));
       EXPECT_EQ("vhost1-www2_staging", headers.get_("x-vhost-header1"));
       EXPECT_EQ("route-allprefix", headers.get_("x-route-header"));
@@ -794,7 +794,7 @@ response_headers_to_remove: ["x-global-remove"]
       Http::TestHeaderMapImpl req_headers = genHeaders("api.lyft.com", "/", "GET");
       const RouteEntry* route = config.route(req_headers, 0)->routeEntry();
       Http::TestHeaderMapImpl headers;
-      route->finalizeResponseHeaders(headers);
+      route->finalizeResponseHeaders(headers, request_info);
       EXPECT_EQ("global1", headers.get_("x-global-header1"));
     }
   }

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -28,37 +28,37 @@ static envoy::api::v2::Route parseRouteFromJson(const std::string& json_string) 
   return route;
 }
 
-TEST(RequestHeaderFormatterTest, TestFormatWithClientIpVariable) {
+TEST(RequestInfoHeaderFormatterTest, TestFormatWithClientIpVariable) {
   NiceMock<Envoy::AccessLog::MockRequestInfo> request_info;
   const std::string downstream_addr = "127.0.0.1";
   ON_CALL(request_info, getDownstreamAddress()).WillByDefault(ReturnRef(downstream_addr));
   const std::string variable = "CLIENT_IP";
-  RequestHeaderFormatter requestHeaderFormatter(variable, false);
-  const std::string formatted_string = requestHeaderFormatter.format(request_info);
+  RequestInfoHeaderFormatter requestInfoHeaderFormatter(variable, false);
+  const std::string formatted_string = requestInfoHeaderFormatter.format(request_info);
   EXPECT_EQ(downstream_addr, formatted_string);
 }
 
-TEST(RequestHeaderFormatterTest, TestFormatWithProtocolVariable) {
+TEST(RequestInfoHeaderFormatterTest, TestFormatWithProtocolVariable) {
   NiceMock<Envoy::AccessLog::MockRequestInfo> request_info;
   Optional<Envoy::Http::Protocol> protocol = Envoy::Http::Protocol::Http11;
   ON_CALL(request_info, protocol()).WillByDefault(ReturnRef(protocol));
   const std::string variable = "PROTOCOL";
-  RequestHeaderFormatter requestHeaderFormatter(variable, false);
-  const std::string formatted_string = requestHeaderFormatter.format(request_info);
+  RequestInfoHeaderFormatter requestInfoHeaderFormatter(variable, false);
+  const std::string formatted_string = requestInfoHeaderFormatter.format(request_info);
   EXPECT_EQ("HTTP/1.1", formatted_string);
 }
 
-TEST(RequestHeaderFormatterTest, WrongVariableToFormat) {
+TEST(RequestInfoHeaderFormatterTest, WrongVariableToFormat) {
   NiceMock<Envoy::AccessLog::MockRequestInfo> request_info;
   const std::string downstream_addr = "127.0.0.1";
   ON_CALL(request_info, getDownstreamAddress()).WillByDefault(ReturnRef(downstream_addr));
   const std::string variable = "INVALID_VARIABLE";
-  EXPECT_THROW_WITH_MESSAGE(RequestHeaderFormatter requestHeaderFormatter(variable, false),
+  EXPECT_THROW_WITH_MESSAGE(RequestInfoHeaderFormatter requestInfoHeaderFormatter(variable, false),
                             EnvoyException,
                             "field 'INVALID_VARIABLE' not supported as custom request header");
 }
 
-TEST(RequestHeaderFormatterTest, WrongFormatOnVariable) {
+TEST(RequestInfoHeaderFormatterTest, WrongFormatOnVariable) {
   const std::string json = R"EOF(
   {
     "prefix": "/new_endpoint",

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -55,7 +55,7 @@ TEST(RequestInfoHeaderFormatterTest, WrongVariableToFormat) {
   const std::string variable = "INVALID_VARIABLE";
   EXPECT_THROW_WITH_MESSAGE(RequestInfoHeaderFormatter requestInfoHeaderFormatter(variable, false),
                             EnvoyException,
-                            "field 'INVALID_VARIABLE' not supported as custom request header");
+                            "field 'INVALID_VARIABLE' not supported as custom header");
 }
 
 TEST(RequestInfoHeaderFormatterTest, WrongFormatOnVariable) {

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -195,7 +195,8 @@ public:
   MOCK_CONST_METHOD0(clusterNotFoundResponseCode, Http::Code());
   MOCK_CONST_METHOD2(finalizeRequestHeaders,
                      void(Http::HeaderMap& headers, const AccessLog::RequestInfo& request_info));
-  MOCK_CONST_METHOD1(finalizeResponseHeaders, void(Http::HeaderMap& headers));
+  MOCK_CONST_METHOD2(finalizeResponseHeaders,
+                     void(Http::HeaderMap& headers, const AccessLog::RequestInfo& request_info));
   MOCK_CONST_METHOD0(hashPolicy, const HashPolicy*());
   MOCK_CONST_METHOD0(metadataMatchCriteria, const Router::MetadataMatchCriteria*());
   MOCK_CONST_METHOD0(priority, Upstream::ResourcePriority());


### PR DESCRIPTION
Provides `%CLIENT_IP%` and `%PROTOCOL%` as valid dynamic response headers as a result of refactoring the `Router::RequestHeaderParser` and `Router::ResponseHeaderParser` into a single class configured as necessary for the actual header processing required. (Adding `request_headers_to_remove` becomes pretty trivial if desired.)

`AccessLog::RequestInfo` is threaded through from `RouteEntry::finalizeResponseHeaders` to `Router::HeaderParser::evaluateHeaders`.

`Router::RequestHeaderFormatter` is renamed `RequestInfoHeaderFormatter`.

Various minor improvements: removes extraneous virtual destructors from header parser, switches storage from list to vector, remove extraneous include directives.

Second step towards #2148.

*Risk Level*: Low

Adds incidental minor feature, but otherwise functionally identical to previous version.

*Testing*:
Existing unit tests cover all changes.

*Docs Changes*:
envoyproxy/data-plane-api#333

*Release Notes*:
Updated raw release notes.
