### PR TITLE
data-plane-api: bump SHA to 4fa7c16.

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -60,7 +60,7 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
     ),
     envoy_api = dict(
-        commit = "ddf6b6206148fd2342172642cf56451316bc870d",
+        commit = "4fa7c1607b42f8d4c585f5484e3cadd809352284",
         remote = "https://github.com/envoyproxy/data-plane-api",
     ),
     grpc_httpjson_transcoding = dict(

--- a/source/server/config/stats/statsd.cc
+++ b/source/server/config/stats/statsd.cc
@@ -9,7 +9,7 @@
 #include "common/stats/statsd.h"
 
 #include "api/bootstrap.pb.h"
-#include "api/bootstrap.pb.validate.h"
+#include "api/stats.pb.validate.h"
 
 namespace Envoy {
 namespace Server {


### PR DESCRIPTION
This picks up some recent changes to address validation and the DogStatsD sink proto.

Testing: bazel test //test/...
Risk Level: Low

Signed-off-by: Harvey Tuch <htuch@google.com>