### PR TITLE
server: Throw exceptions from OptionsImpl ctor instead of calling exit.

### DIFF
--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -42,7 +42,14 @@ int main(int argc, char** argv) {
   };
 #endif
 
-  Envoy::OptionsImpl options(argc, argv, hot_restart_version_cb, spdlog::level::info);
-
-  return Envoy::main_common(options);
+  std::unique_ptr<Envoy::OptionsImpl> options;
+  try {
+    options = std::make_unique<Envoy::OptionsImpl>(argc, argv, hot_restart_version_cb,
+                                                   spdlog::level::info);
+  } catch (const Envoy::NoServingException& e) {
+    return 0;
+  } catch (const Envoy::MalformedArgvException& e) {
+    return 1;
+  }
+  return Envoy::main_common(*options);
 }

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -93,24 +93,36 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_r
                                              false, ENVOY_DEFAULT_MAX_OBJ_NAME_LENGTH, "uint64_t",
                                              cmd);
 
+  cmd.setExceptionHandling(false);
   try {
     cmd.parse(argc, argv);
   } catch (TCLAP::ArgException& e) {
-    std::cerr << "error: " << e.error() << std::endl;
-    exit(1);
+    try {
+      cmd.getOutput()->failure(cmd, e);
+    } catch (const TCLAP::ExitException&) {
+      // failure() has already written an informative message to stderr, so all that's left to do
+      // is throw our own exception with the original message.
+      throw MalformedArgvException(e.what());
+    }
+  } catch (const TCLAP::ExitException& e) {
+    // parse() throws an ExitException with status 0 after printing the output for --help and
+    // --version.
+    throw NoServingException();
   }
 
   if (max_obj_name_len.getValue() < 60) {
-    std::cerr << "error: the 'max-obj-name-len' value specified (" << max_obj_name_len.getValue()
-              << ") is less than the minimum value of 60" << std::endl;
-    exit(1);
+    const std::string message = fmt::format(
+        "error: the 'max-obj-name-len' value specified ({}) is less than the minimum value of 60",
+        max_obj_name_len.getValue());
+    std::cerr << message << std::endl;
+    throw MalformedArgvException(message);
   }
 
   if (hot_restart_version_option.getValue()) {
     std::cerr << hot_restart_version_cb(max_stats.getValue(),
                                         max_obj_name_len.getValue() +
                                             Stats::RawStatData::maxStatSuffixLength());
-    exit(0);
+    throw NoServingException();
   }
 
   log_level_ = default_log_level;
@@ -125,8 +137,9 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_r
   } else if (mode.getValue() == "validate") {
     mode_ = Server::Mode::Validate;
   } else {
-    std::cerr << "error: unknown mode '" << mode.getValue() << "'" << std::endl;
-    exit(1);
+    const std::string message = fmt::format("error: unknown mode '{}'", mode.getValue());
+    std::cerr << message << std::endl;
+    throw MalformedArgvException(message);
   }
 
   if (local_address_ip_version.getValue() == "v4") {
@@ -134,9 +147,10 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_r
   } else if (local_address_ip_version.getValue() == "v6") {
     local_address_ip_version_ = Network::Address::IpVersion::v6;
   } else {
-    std::cerr << "error: unknown IP address version '" << local_address_ip_version.getValue() << "'"
-              << std::endl;
-    exit(1);
+    const std::string message =
+        fmt::format("error: unknown IP address version '{}'", local_address_ip_version.getValue());
+    std::cerr << message << std::endl;
+    throw MalformedArgvException(message);
   }
 
   // For base ID, scale what the user inputs by 10 so that we have spread for domain sockets.

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -75,7 +75,7 @@ private:
  */
 class NoServingException : public EnvoyException {
 public:
-  NoServingException() : EnvoyException("") {}
+  NoServingException() : EnvoyException("NoServingException") {}
 };
 
 /**

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <string>
 
+#include "envoy/common/exception.h"
 #include "envoy/server/options.h"
 
 #include "spdlog/spdlog.h"
@@ -16,6 +17,13 @@ class OptionsImpl : public Server::Options {
 public:
   typedef std::function<std::string(uint64_t, uint64_t)> HotRestartVersionCb;
 
+  /**
+   * @throw NoServingException if Envoy has already done everything specified by the argv (e.g.
+   *        print the hot restart version) and it's time to exit without serving HTTP traffic. The
+   *        caller should exit(0) after any necessary cleanup.
+   * @throw MalformedArgvException if something is wrong with the arguments (invalid flag or flag
+   *        value). The caller should call exit(1) after any necessary cleanup.
+   */
   OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_restart_version_cb,
               spdlog::level::level_enum default_log_level);
 
@@ -59,4 +67,23 @@ private:
   uint64_t max_stats_;
   uint64_t max_obj_name_length_;
 };
+
+/**
+ * Thrown when an OptionsImpl was not constructed because all of Envoy's work is done (for example,
+ * it was started with --help and it's already printed a help message) so all that's left to do is
+ * exit successfully.
+ */
+class NoServingException : public EnvoyException {
+public:
+  NoServingException() : EnvoyException("") {}
+};
+
+/**
+ * Thrown when an OptionsImpl was not constructed because the argv was invalid.
+ */
+class MalformedArgvException : public EnvoyException {
+public:
+  MalformedArgvException(const std::string& what) : EnvoyException(what) {}
+};
+
 } // namespace Envoy

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -3,12 +3,17 @@
 #include <string>
 #include <vector>
 
+#include "envoy/common/exception.h"
+
 #include "common/common/utility.h"
 
 #include "server/options_impl.h"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "spdlog/spdlog.h"
+
+using testing::HasSubstr;
 
 namespace Envoy {
 // Do the ugly work of turning a std::string into a char** and create an OptionsImpl. Args are
@@ -24,16 +29,31 @@ std::unique_ptr<OptionsImpl> createOptionsImpl(const std::string& args) {
                                                       spdlog::level::warn));
 }
 
-TEST(OptionsImplDeathTest, HotRestartVersion) {
-  EXPECT_EXIT(createOptionsImpl("envoy --hot-restart-version"), testing::ExitedWithCode(0), "");
+TEST(OptionsImplTest, HotRestartVersion) {
+  try {
+    createOptionsImpl("envoy --hot-restart-version");
+    FAIL();
+  } catch (const NoServingException& e) {
+    SUCCEED();
+  }
 }
 
-TEST(OptionsImplDeathTest, InvalidMode) {
-  EXPECT_EXIT(createOptionsImpl("envoy --mode bogus"), testing::ExitedWithCode(1), "bogus");
+TEST(OptionsImplTest, InvalidMode) {
+  try {
+    createOptionsImpl("envoy --mode bogus");
+    FAIL();
+  } catch (const MalformedArgvException& e) {
+    EXPECT_THAT(e.what(), HasSubstr("bogus"));
+  }
 }
 
-TEST(OptionsImplDeathTest, InvalidCommandLine) {
-  EXPECT_EXIT(createOptionsImpl("envoy ---blah"), testing::ExitedWithCode(1), "PARSE ERROR");
+TEST(OptionsImplTest, InvalidCommandLine) {
+  try {
+    createOptionsImpl("envoy --blah");
+    FAIL();
+  } catch (const MalformedArgvException& e) {
+    EXPECT_THAT(e.what(), HasSubstr("Couldn't find match for argument"));
+  }
 }
 
 TEST(OptionsImplTest, All) {
@@ -69,12 +89,20 @@ TEST(OptionsImplTest, DefaultParams) {
 }
 
 TEST(OptionsImplTest, BadCliOption) {
-  EXPECT_DEATH(createOptionsImpl("envoy -c hello --local-address-ip-version foo"),
-               "error: unknown IP address version 'foo'");
+  try {
+    createOptionsImpl("envoy -c hello --local-address-ip-version foo");
+    FAIL();
+  } catch (const MalformedArgvException& e) {
+    EXPECT_THAT(e.what(), HasSubstr("error: unknown IP address version 'foo'"));
+  }
 }
 
 TEST(OptionsImplTest, BadObjNameLenOption) {
-  EXPECT_DEATH(createOptionsImpl("envoy --max-obj-name-len 1"),
-               "error: the 'max-obj-name-len' value specified");
+  try {
+    createOptionsImpl("envoy --max-obj-name-len 1");
+    FAIL();
+  } catch (const MalformedArgvException& e) {
+    EXPECT_THAT(e.what(), HasSubstr("'max-obj-name-len' value specified"));
+  }
 }
 } // namespace Envoy


### PR DESCRIPTION
This is a logical continuation to #2157. The `OptionsImpl` constructor used to call `exit(0)` when the `argv` was e.g. `"envoy --hot-restart-version"` (which prints a message and exits) or `exit(1)` when it was malformed. With this change, the constructor throws exceptions in those cases instead.

The exceptions are caught in `main()`, which returns 0 or 1 accordingly. Envoy users who write their own `main()` will want to do the same when they construct `OptionsImpl` (after doing any necessary cleanup work), so this is a more significant developer-facing API change than #2157 was.

*Risk Level*: Medium

*Testing*:
Updated unit tests to verify the exception is thrown. As a nice side benefit, we don't need death tests for those cases anymore.

*Docs Changes*:
N/A

*Release Notes*:
N/A

Signed-off-by: Reuven Lazarus <rzl@google.com>