### PR TITLE
build: gperftools-2.6.3

### DIFF
--- a/bazel/EXTERNAL_DEPS.md
+++ b/bazel/EXTERNAL_DEPS.md
@@ -3,12 +3,11 @@
 This is the preferred style of adding dependencies that use Bazel for their
 build process.
 
-1. Specify name and version in [external documentation](https://github.com/envoyproxy/data-plane-api/blob/master/docs/root/install/requirements.rst).
-2. Define a new Bazel repository in [`bazel/repositories.bzl`](repositories.bzl),
+1. Define a new Bazel repository in [`bazel/repositories.bzl`](repositories.bzl),
    in the `envoy_dependencies()` function.
-5. Reference your new external dependency in some `envoy_cc_library` via the
+2. Reference your new external dependency in some `envoy_cc_library` via the
    `external_deps` attribute.
-6. `bazel test //test/...`
+3. `bazel test //test/...`
 
 # Adding external dependencies to Envoy (genrule repository)
 
@@ -20,17 +19,16 @@ The shell script is executed by Bash, with a few Bazel-specific extensions.
 See the [Bazel docs for "genrule"](https://docs.bazel.build/versions/master/be/general.html#genrule)
 for details on Bazel's shell extensions.
 
-1. Specify name and version in [external documentation](https://github.com/envoyproxy/data-plane-api/blob/master/docs/root/install/requirements.rst).
-2. Add a BUILD file in [`bazel/external/`](external/), using a `genrule` target
+1. Add a BUILD file in [`bazel/external/`](external/), using a `genrule` target
    to build the dependency. Please do not add BUILD logic that replaces the
    dependency's upstream build tooling.
 2. Define a new Bazel repository in [`bazel/repositories.bzl`](repositories.bzl),
    in the `envoy_dependencies()` function. The repository may use `genrule_repository`
    from [`bazel/genrule_repository.bzl`](genrule_repository.bzl) to place large
    genrule shell commands into a separate file.
-5. Reference your new external dependency in some `envoy_cc_library` via Y in the
+3. Reference your new external dependency in some `envoy_cc_library` via Y in the
    `external_deps` attribute.
-6. `bazel test //test/...`
+4. `bazel test //test/...`
 
 Dependencies between external libraries can use the standard Bazel dependency
 resolution logic, using the `$(location)` shell extension to resolve paths
@@ -43,18 +41,16 @@ an example.
 This is the older style of adding dependencies. It uses shell scripts to build
 and install dependencies into a shared directory prefix.
 
-1. Specify name and version in [external documentation](https://github.com/envoyproxy/data-plane-api/blob/master/docs/root/install/requirements.rst).
-2. Add a build recipe X in [`ci/build_container/build_recipes`](../ci/build_container/build_recipes)
+1. Add a build recipe X in [`ci/build_container/build_recipes`](../ci/build_container/build_recipes)
    for developer-local and CI external dependency build flows.
-3. Add a build target Y in [`ci/prebuilt/BUILD`](../ci/prebuilt/BUILD) to consume the headers and
+2. Add a build target Y in [`ci/prebuilt/BUILD`](../ci/prebuilt/BUILD) to consume the headers and
    libraries produced by the build recipe X.
-4. Add a map from target Y to build recipe X in [`target_recipes.bzl`](target_recipes.bzl).
-5. Reference your new external dependency in some `envoy_cc_library` via Y in the `external_deps`
+3. Add a map from target Y to build recipe X in [`target_recipes.bzl`](target_recipes.bzl).
+4. Reference your new external dependency in some `envoy_cc_library` via Y in the `external_deps`
    attribute.
-6. `bazel test //test/...`
+5. `bazel test //test/...`
 
 # Updating an external dependency version
 
-1. Specify the new version in [external documentation](https://github.com/envoyproxy/data-plane-api/blob/master/docs/root/install/requirements.rst).
-2. Update the build recipe in [`ci/build_container/build_recipes`](../ci/build_container/build_recipes).
-3. `bazel test //test/...`
+1. Update the build recipe in [`ci/build_container/build_recipes`](../ci/build_container/build_recipes).
+2. `bazel test //test/...`

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -39,9 +39,6 @@ def envoy_linkopts():
         # The file could should contain the current git SHA (or enough placeholder data to allow
         # it to be rewritten by tools/git_sha_rewriter.py).
         "@bazel_tools//tools/osx:darwin": [
-            # TODO(zuercher): should be able to remove this after the next gperftools release after
-            # 2.6.1 (see discussion at https://github.com/gperftools/gperftools/issues/901)
-            "-Wl,-U,___lsan_ignore_object",
             # See note here: http://luajit.org/install.html
             "-pagezero_size 10000", "-image_base 100000000",
         ],
@@ -68,9 +65,6 @@ def envoy_linkopts():
 def envoy_test_linkopts():
     return select({
         "@bazel_tools//tools/osx:darwin": [
-            # TODO(zuercher): should be able to remove this after the next gperftools release after
-            # 2.6.1 (see discussion at https://github.com/gperftools/gperftools/issues/901)
-            "-Wl,-U,___lsan_ignore_object",
             # See note here: http://luajit.org/install.html
             "-pagezero_size 10000", "-image_base 100000000",
         ],

--- a/ci/build_container/build_recipes/gperftools.sh
+++ b/ci/build_container/build_recipes/gperftools.sh
@@ -2,17 +2,11 @@
 
 set -e
 
-VERSION=2.6.1
+VERSION=2.6.3
 
 wget -O gperftools-"$VERSION".tar.gz https://github.com/gperftools/gperftools/releases/download/gperftools-"$VERSION"/gperftools-"$VERSION".tar.gz
 tar xf gperftools-"$VERSION".tar.gz
 cd gperftools-"$VERSION"
-
-# TODO(zuercher): Remove this workaround for https://github.com/gperftools/gperftools/issues/910
-if [[ `uname` == "Darwin" ]];
-then
-  export CPPFLAGS="$CPPFLAGS -D_XOPEN_SOURCE=500 -D_DARWIN_C_SOURCE"
-fi
 
 LDFLAGS="-lpthread" ./configure --prefix="$THIRDPARTY_BUILD" --enable-shared=no --enable-frame-pointers --disable-libunwind
 make V=1 install


### PR DESCRIPTION
gperftools 2.6.3 contains fixes for MacOS builds (gperftools/gperftools#901, gperftools/gperftools#910, and gperftools/gperftools#942) that allow us to remove some Mac-only workaround in the build.

Removed references to the requirements documentation. (The file was deleted in envoyproxy/data-plane-api#318.)

*Risk Level*: Low

*Testing*: Builds and passes tests.

*Release Notes*: N/A