### PR TITLE
Checking for existing trusted_ca rather than creating an empty one.

### DIFF
--- a/source/common/config/tls_context_json.cc
+++ b/source/common/config/tls_context_json.cc
@@ -40,7 +40,7 @@ void TlsContextJson::translateCommonTlsContext(
   translateTlsCertificate(json_tls_context, *common_tls_context.mutable_tls_certificates()->Add());
 
   auto* validation_context = common_tls_context.mutable_validation_context();
-  if (validation_context->has_trusted_ca()) {
+  if (json_tls_context.hasObject("ca_cert_file")) {
     validation_context->mutable_trusted_ca()->set_filename(
         json_tls_context.getString("ca_cert_file", ""));
   }

--- a/source/common/config/tls_context_json.cc
+++ b/source/common/config/tls_context_json.cc
@@ -40,8 +40,10 @@ void TlsContextJson::translateCommonTlsContext(
   translateTlsCertificate(json_tls_context, *common_tls_context.mutable_tls_certificates()->Add());
 
   auto* validation_context = common_tls_context.mutable_validation_context();
-  validation_context->mutable_trusted_ca()->set_filename(
-      json_tls_context.getString("ca_cert_file", ""));
+  if (validation_context->has_trusted_ca()) {
+    validation_context->mutable_trusted_ca()->set_filename(
+        json_tls_context.getString("ca_cert_file", ""));
+  }
   if (json_tls_context.hasObject("verify_certificate_hash")) {
     validation_context->add_verify_certificate_hash(
         json_tls_context.getString("verify_certificate_hash"));

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -103,10 +103,14 @@ envoy_cc_test(
 envoy_cc_test(
     name = "lds_api_test",
     srcs = ["lds_api_test.cc"],
+    data = [
+        "//test/config/integration/certs",
+    ],
     deps = [
         "//source/common/config:utility_lib",
         "//source/server:lds_api_lib",
         "//test/mocks/server:server_mocks",
+        "//test/test_common:environment_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -217,7 +217,7 @@ TEST_F(LdsApiTest, Basic) {
   EXPECT_EQ(18068408981723255507U, store_.gauge("listener_manager.lds.version").value());
 }
 
-// Regression test issue #2188 where an empty ca_cert_file field was created and caused and the LDS
+// Regression test issue #2188 where an empty ca_cert_file field was created and caused the LDS
 // update to fail validation.
 TEST_F(LdsApiTest, TlsConfigWithoutCaCert) {
   InSequence s;

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -4,6 +4,7 @@
 #include "server/lds_api.h"
 
 #include "test/mocks/server/mocks.h"
+#include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -214,6 +215,79 @@ TEST_F(LdsApiTest, Basic) {
   EXPECT_EQ(2UL, store_.counter("listener_manager.lds.update_attempt").value());
   EXPECT_EQ(2UL, store_.counter("listener_manager.lds.update_success").value());
   EXPECT_EQ(18068408981723255507U, store_.gauge("listener_manager.lds.version").value());
+}
+
+TEST_F(LdsApiTest, Repro) {
+  InSequence s;
+
+  setup();
+
+  std::string response1_json = R"EOF(
+  {
+    "listeners": [
+    ]
+  }
+  )EOF";
+
+  Http::MessagePtr message(new Http::ResponseMessageImpl(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+  message->body().reset(new Buffer::OwnedImpl(response1_json));
+
+  makeListenersAndExpectCall({});
+  EXPECT_CALL(init_.initialized_, ready());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  callbacks_->onSuccess(std::move(message));
+
+  EXPECT_EQ(Config::Utility::computeHashedVersion(response1_json).first, lds_->versionInfo());
+  expectRequest();
+  interval_timer_->callback_();
+
+  std::string response2_basic = R"EOF(
+  {{
+   "listeners" : [
+         {{
+         "ssl_context" : {{
+            "cipher_suites" : "[ECDHE-RSA-AES256-GCM-SHA384|ECDHE-RSA-AES128-GCM-SHA256]",
+            "cert_chain_file" : "{}",
+            "private_key_file" : "{}"
+         }},
+         "address" : "tcp://0.0.0.0:61001",
+         "name" : "listener-8080",
+         "filters" : [
+            {{
+               "config" : {{
+                  "stat_prefix" : "ingress_tcp-9534127d-306e-49b5-5158-9688cf1cd33b",
+                  "route_config" : {{
+                     "routes" : [
+                        {{
+                           "cluster" : "0-service-cluster"
+                        }}
+                     ]
+                  }}
+               }},
+               "type" : "read",
+               "name" : "tcp_proxy"
+            }}
+         ]
+      }}
+   ]
+  }}
+  )EOF";
+  std::string response2_json =
+      fmt::format(response2_basic,
+                  TestEnvironment::runfilesPath("/test/config/integration/certs/servercert.pem"),
+                  TestEnvironment::runfilesPath("/test/config/integration/certs/serverkey.pem"));
+
+  message.reset(new Http::ResponseMessageImpl(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+  message->body().reset(new Buffer::OwnedImpl(response2_json));
+  makeListenersAndExpectCall({
+      "listener-8080",
+  });
+  expectAdd("listener-8080", true);
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_NO_THROW(callbacks_->onSuccess(std::move(message)));
+  EXPECT_EQ(Config::Utility::computeHashedVersion(response2_json).first, lds_->versionInfo());
 }
 
 TEST_F(LdsApiTest, Failure) {

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -217,7 +217,9 @@ TEST_F(LdsApiTest, Basic) {
   EXPECT_EQ(18068408981723255507U, store_.gauge("listener_manager.lds.version").value());
 }
 
-TEST_F(LdsApiTest, Repro) {
+// Regression test issue #2188 where an empty ca_cert_file field was created and caused and the LDS
+// update to fail validation.
+TEST_F(LdsApiTest, TlsConfigWithoutCaCert) {
   InSequence s;
 
   setup();


### PR DESCRIPTION
*Description*:
Previously, we default added a trusted ca if one was not present, causing validation failures.

*Risk Level*: Low

*Testing*:
LDS repro test which would fail validation prior to the fix.

*Release Notes*:
n/a (minor bugfix)

Fixes  #2188 
