### PR TITLE
server: shutdown stats threading during server initialization exception

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -71,8 +71,8 @@ InstanceImpl::InstanceImpl(Options& options, Network::Address::InstanceConstShar
     ENVOY_LOG(critical, "error initializing configuration '{}': {}", options.configPath(),
               e.what());
     thread_local_.shutdownGlobalThreading();
-    thread_local_.shutdownThread();
     stats_store_.shutdownThreading();
+    thread_local_.shutdownThread();
     throw;
   }
 }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -70,9 +70,14 @@ InstanceImpl::InstanceImpl(Options& options, Network::Address::InstanceConstShar
   } catch (const EnvoyException& e) {
     ENVOY_LOG(critical, "error initializing configuration '{}': {}", options.configPath(),
               e.what());
+
+    // Invoke shutdown methods called in run().
     thread_local_.shutdownGlobalThreading();
     stats_store_.shutdownThreading();
     thread_local_.shutdownThread();
+
+    // Invoke the shutdown method called in the deconstructor.
+    restarter_.shutdown();
     throw;
   }
 }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -76,7 +76,7 @@ InstanceImpl::InstanceImpl(Options& options, Network::Address::InstanceConstShar
     stats_store_.shutdownThreading();
     thread_local_.shutdownThread();
 
-    // Invoke the shutdown method called in the deconstructor.
+    // Invoke the shutdown method called in the destructor.
     restarter_.shutdown();
     throw;
   }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -72,6 +72,7 @@ InstanceImpl::InstanceImpl(Options& options, Network::Address::InstanceConstShar
               e.what());
     thread_local_.shutdownGlobalThreading();
     thread_local_.shutdownThread();
+    stats_store_.shutdownThreading();
     throw;
   }
 }

--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -153,4 +153,23 @@ do
   TEST_INDEX=$((TEST_INDEX+1))
 done
 
+# set -e forces the script to exit on non-zero exit codes. Set +e makes it easier to
+# catch the non-zero exit code.
+set +e
+# The heapchecker outputs some data to stderr on every execution.  This gets intermingled
+# with the output from --hot-restart-version, so disable the heap-checker for these runs.
+SAVED_HEAPCHECK=${HEAPCHECK}
+unset HEAPCHECK
+
+echo "Launching envoy with no parameters. Check the exit value is 1"
+${ENVOY_BIN}
+EXIT_CODE=$?
+# The test should fail if the Envoy binary exits with anything other than 1.
+if [[ $EXIT_CODE -ne 1 ]]; then
+    echo "Envoy exited with code: ${EXIT_CODE}"
+    exit 1
+fi
+HEAPCHECK=${SAVED_HEAPCHECK}
+set -e
+
 echo "PASS"

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -224,5 +224,17 @@ TEST_P(ServerInstanceImplTest, LogToFileError) {
     EXPECT_THAT(e.what(), HasSubstr("Failed to open log-file"));
   }
 }
+
+TEST_P(ServerInstanceImplTest, NoOptionsPassed) {
+  try {
+    server_.reset(new InstanceImpl(
+        options_,
+        Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("127.0.0.1")),
+        hooks_, restart_, stats_store_, fakelock_, component_factory_, thread_local_));
+    FAIL();
+  } catch (const EnvoyException& e) {
+    EXPECT_THAT(e.what(), HasSubstr("unable to read file:"));
+  }
+}
 } // namespace Server
 } // namespace Envoy

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -226,15 +226,12 @@ TEST_P(ServerInstanceImplTest, LogToFileError) {
 }
 
 TEST_P(ServerInstanceImplTest, NoOptionsPassed) {
-  try {
-    server_.reset(new InstanceImpl(
-        options_,
-        Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("127.0.0.1")),
-        hooks_, restart_, stats_store_, fakelock_, component_factory_, thread_local_));
-    FAIL();
-  } catch (const EnvoyException& e) {
-    EXPECT_THAT(e.what(), HasSubstr("unable to read file:"));
-  }
+  EXPECT_THROW_WITH_MESSAGE(
+      server_.reset(new InstanceImpl(
+          options_,
+          Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("127.0.0.1")),
+          hooks_, restart_, stats_store_, fakelock_, component_factory_, thread_local_)),
+      EnvoyException, "unable to read file: ")
 }
 } // namespace Server
 } // namespace Envoy


### PR DESCRIPTION
*Description*: When an exception is thrown in server initialization, the stats store did not set the shutdown variable to true.  This bug was exposed with https://github.com/envoyproxy/envoy/pull/2157 which now throws during server init. 

Repro: run the envoy binary with no parameters. 
Current behavior: Crash with the call stack below
Expected behavior: Binary exits. 

Call Stack
```
#1  0x000000000054e26f in Envoy::Stats::ThreadLocalStoreImpl::releaseScopeCrossThread (this=0x7ffdd269cca0, scope=scope@entry=0x21ba180) at external/envoy/source/common/stats/thread_local_store.cc:85
#2  0x000000000054e385 in Envoy::Stats::ThreadLocalStoreImpl::ScopeImpl::~ScopeImpl (this=0x21ba180, __in_chrg=<optimized out>) at external/envoy/source/common/stats/thread_local_store.cc:122
#3  0x000000000054e751 in Envoy::Stats::ThreadLocalStoreImpl::ScopeImpl::~ScopeImpl (this=0x21ba180, __in_chrg=<optimized out>) at external/envoy/source/common/stats/thread_local_store.cc:122
#4  0x000000000054e034 in operator() (this=<optimized out>, __ptr=<optimized out>) at /usr/include/c++/5/bits/unique_ptr.h:76
#5  reset (__p=<optimized out>, this=0x7ffdd269cd20) at /usr/include/c++/5/bits/unique_ptr.h:344
#6  Envoy::Stats::ThreadLocalStoreImpl::~ThreadLocalStoreImpl (this=0x7ffdd269cca0, __in_chrg=<optimized out>) at external/envoy/source/common/stats/thread_local_store.cc:20
#7  0x000000000046b00d in Envoy::main_common (options=...) at external/envoy/source/exe/main_common.cc:85
#8  0x000000000040b012 in main (argc=<optimized out>, argv=<optimized out>) at external/envoy/source/exe/main.cc:47
```

*Risk Level*: Low
*Testing*: Unit Test + Manually run the envoy binary 

Signed-off-by: Constance Caramanolis <ccaramanolis@lyft.com>

