### PR TITLE
ci: force previous version of travis distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: shell
 sudo: required
+dist: trusty
+group: deprecated-2017Q4
 
 services:
   - docker


### PR DESCRIPTION
Travis CI builds are failing due to IPv6 errors. Using Travis' instructions for downgrading to the previous image to see if that resolves the problem temporarily.

*Risk Level*: Low

*Testing*: N/A

*Release Notes*: N/A
