### PR TITLE
protobuf: add comment to MessageUtil to include .pb.validate.h

### DIFF
--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -118,6 +118,8 @@ public:
 
   /**
    * Validate protoc-gen-validate constraints on a given protobuf.
+   * Note the corresponding `.pb.validate.h` for the message has to be included in the source file
+   * of caller.
    * @param message message to validate.
    * @throw ProtoValidationException if the message does not satisfy its type constraints.
    */
@@ -136,6 +138,8 @@ public:
 
   /**
    * Downcast and validate protoc-gen-validate constraints on a given protobuf.
+   * Note the corresponding `.pb.validate.h` for the message has to be included in the source file
+   * of caller.
    * @param message const Protobuf::Message& to downcast and validate.
    * @return const MessageType& the concrete message type downcasted to on success.
    * @throw ProtoValidationException if the message does not satisfy its type constraints.


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <zlizan@google.com>

add comment to MessageUtil to include .pb.validate.h

*Description*:
Tiny fix to the comment, it took me a while to find the header include dependency since it is templated.

*Risk Level*: Low

*Testing*:
N/A

*Docs Changes*:
N/A

*Release Notes*:
N/A