### PR TITLE
clang-tidy: performance oriented fixes.

### DIFF
--- a/source/common/router/header_parser.cc
+++ b/source/common/router/header_parser.cc
@@ -46,7 +46,7 @@ HeaderParserPtr HeaderParser::configure(
     const Protobuf::RepeatedPtrField<ProtobufTypes::String>& headers_to_remove) {
   HeaderParserPtr header_parser = configure(headers_to_add);
 
-  for (const std::string& header : headers_to_remove) {
+  for (const auto& header : headers_to_remove) {
     header_parser->headers_to_remove_.emplace_back(header);
   }
 

--- a/source/common/stats/statsd.cc
+++ b/source/common/stats/statsd.cc
@@ -39,7 +39,7 @@ void Writer::write(const std::string& message) {
 
 UdpStatsdSink::UdpStatsdSink(ThreadLocal::SlotAllocator& tls,
                              Network::Address::InstanceConstSharedPtr address, const bool use_tag)
-    : tls_(tls.allocateSlot()), server_address_(address), use_tag_(use_tag) {
+    : tls_(tls.allocateSlot()), server_address_(std::move(address)), use_tag_(use_tag) {
   tls_->set([this](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
     return std::make_shared<Writer>(this->server_address_);
   });
@@ -79,6 +79,7 @@ const std::string UdpStatsdSink::buildTagStr(const std::vector<Tag>& tags) {
   }
 
   std::vector<std::string> tag_strings;
+  tag_strings.reserve(tags.size());
   for (const Tag& tag : tags) {
     tag_strings.emplace_back(tag.name_ + ":" + tag.value_);
   }

--- a/source/common/stats/statsd.h
+++ b/source/common/stats/statsd.h
@@ -42,7 +42,8 @@ public:
   UdpStatsdSink(ThreadLocal::SlotAllocator& tls, Network::Address::InstanceConstSharedPtr address,
                 const bool use_tag);
   // For testing.
-  UdpStatsdSink(ThreadLocal::SlotAllocator& tls, std::shared_ptr<Writer> writer, const bool use_tag)
+  UdpStatsdSink(ThreadLocal::SlotAllocator& tls, const std::shared_ptr<Writer>& writer,
+                const bool use_tag)
       : tls_(tls.allocateSlot()), use_tag_(use_tag) {
     tls_->set(
         [writer](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr { return writer; });


### PR DESCRIPTION
Several simple changes recommended by ClangTidy for performance reasons.
The change in header_parser.cc removes an explicit copy that likely only
exist in our deployment because of protobuf string quirks, but should do
no harm in any case.

*Risk level*: low

*Testing*: bazel test //test/...

*Docs Changes*: N/A

*Release Notes*: N/A

Signed-off-by: Dan Noé <dpn@google.com>