### PR TITLE
clang-tidy: clean up unused usings.

### DIFF
--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -14,9 +14,7 @@
 #include "gtest/gtest.h"
 
 using testing::NiceMock;
-using testing::Return;
 using testing::ReturnRef;
-using testing::_;
 
 namespace Envoy {
 namespace Router {

--- a/test/common/stats/udp_statsd_test.cc
+++ b/test/common/stats/udp_statsd_test.cc
@@ -14,7 +14,6 @@
 #include "spdlog/spdlog.h"
 
 using testing::NiceMock;
-using testing::ReturnRef;
 
 namespace Envoy {
 namespace Stats {


### PR DESCRIPTION
*Description*: Removed unused using declarations as recommended by ClangTidy.

*Risk Level*: Low

*Testing*: bazel test //test/...

*Docs Changes*: N/A

*Release Notes*: N/A

Signed-off-by: Dan Noé <dpn@google.com>