### PR TITLE
ssl: make *ContextConfig const everywhere

### DIFF
--- a/include/envoy/ssl/context_manager.h
+++ b/include/envoy/ssl/context_manager.h
@@ -20,7 +20,7 @@ public:
    * Builds a ClientContext from a ClientContextConfig.
    */
   virtual ClientContextPtr createSslClientContext(Stats::Scope& scope,
-                                                  ClientContextConfig& config) PURE;
+                                                  const ClientContextConfig& config) PURE;
 
   /**
    * Builds a ServerContext from a ServerContextConfig.
@@ -29,7 +29,8 @@ public:
    */
   virtual ServerContextPtr createSslServerContext(const std::string& listener_name,
                                                   const std::vector<std::string>& server_names,
-                                                  Stats::Scope& scope, ServerContextConfig& config,
+                                                  Stats::Scope& scope,
+                                                  const ServerContextConfig& config,
                                                   bool skip_context_update) PURE;
 
   /**

--- a/source/common/ssl/context_config_impl.h
+++ b/source/common/ssl/context_config_impl.h
@@ -54,8 +54,8 @@ private:
 
 class ClientContextConfigImpl : public ContextConfigImpl, public ClientContextConfig {
 public:
-  ClientContextConfigImpl(const envoy::api::v2::UpstreamTlsContext& config);
-  ClientContextConfigImpl(const Json::Object& config);
+  explicit ClientContextConfigImpl(const envoy::api::v2::UpstreamTlsContext& config);
+  explicit ClientContextConfigImpl(const Json::Object& config);
 
   // Ssl::ClientContextConfig
   const std::string& serverNameIndication() const override { return server_name_indication_; }
@@ -66,8 +66,8 @@ private:
 
 class ServerContextConfigImpl : public ContextConfigImpl, public ServerContextConfig {
 public:
-  ServerContextConfigImpl(const envoy::api::v2::DownstreamTlsContext& config);
-  ServerContextConfigImpl(const Json::Object& config);
+  explicit ServerContextConfigImpl(const envoy::api::v2::DownstreamTlsContext& config);
+  explicit ServerContextConfigImpl(const Json::Object& config);
 
   // Ssl::ServerContextConfig
   bool requireClientCertificate() const override { return require_client_certificate_; }

--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -27,7 +27,8 @@ int ContextImpl::sslContextIndex() {
   }());
 }
 
-ContextImpl::ContextImpl(ContextManagerImpl& parent, Stats::Scope& scope, ContextConfig& config)
+ContextImpl::ContextImpl(ContextManagerImpl& parent, Stats::Scope& scope,
+                         const ContextConfig& config)
     : parent_(parent), ctx_(SSL_CTX_new(TLS_method())), scope_(scope), stats_(generateStats(scope)),
       min_protocol_version_(config.minProtocolVersion()),
       max_protocol_version_(config.maxProtocolVersion()), ecdh_curves_(config.ecdhCurves()) {
@@ -336,7 +337,7 @@ bssl::UniquePtr<X509> ContextImpl::loadCert(const std::string& cert_file) {
 };
 
 ClientContextImpl::ClientContextImpl(ContextManagerImpl& parent, Stats::Scope& scope,
-                                     ClientContextConfig& config)
+                                     const ClientContextConfig& config)
     : ContextImpl(parent, scope, config) {
   if (!parsed_alpn_protocols_.empty()) {
     int rc = SSL_CTX_set_alpn_protos(ctx_.get(), &parsed_alpn_protocols_[0],
@@ -362,7 +363,7 @@ bssl::UniquePtr<SSL> ClientContextImpl::newSsl() const {
 
 ServerContextImpl::ServerContextImpl(ContextManagerImpl& parent, const std::string& listener_name,
                                      const std::vector<std::string>& server_names,
-                                     Stats::Scope& scope, ServerContextConfig& config,
+                                     Stats::Scope& scope, const ServerContextConfig& config,
                                      bool skip_context_update, Runtime::Loader& runtime)
     : ContextImpl(parent, scope, config), listener_name_(listener_name),
       server_names_(server_names), skip_context_update_(skip_context_update), runtime_(runtime),

--- a/source/common/ssl/context_impl.h
+++ b/source/common/ssl/context_impl.h
@@ -76,7 +76,7 @@ public:
   std::string getCertChainInformation() const override;
 
 protected:
-  ContextImpl(ContextManagerImpl& parent, Stats::Scope& scope, ContextConfig& config);
+  ContextImpl(ContextManagerImpl& parent, Stats::Scope& scope, const ContextConfig& config);
 
   /**
    * The global SSL-library index used for storing a pointer to the context
@@ -125,7 +125,8 @@ protected:
 
 class ClientContextImpl : public ContextImpl, public ClientContext {
 public:
-  ClientContextImpl(ContextManagerImpl& parent, Stats::Scope& scope, ClientContextConfig& config);
+  ClientContextImpl(ContextManagerImpl& parent, Stats::Scope& scope,
+                    const ClientContextConfig& config);
   ~ClientContextImpl() { parent_.releaseClientContext(this); }
 
   bssl::UniquePtr<SSL> newSsl() const override;
@@ -138,7 +139,7 @@ class ServerContextImpl : public ContextImpl, public ServerContext {
 public:
   ServerContextImpl(ContextManagerImpl& parent, const std::string& listener_name,
                     const std::vector<std::string>& server_names, Stats::Scope& scope,
-                    ServerContextConfig& config, bool skip_context_update,
+                    const ServerContextConfig& config, bool skip_context_update,
                     Runtime::Loader& runtime);
   ~ServerContextImpl() { parent_.releaseServerContext(this, listener_name_, server_names_); }
 

--- a/source/common/ssl/context_manager_impl.cc
+++ b/source/common/ssl/context_manager_impl.cc
@@ -57,7 +57,7 @@ void ContextManagerImpl::releaseServerContext(ServerContext* context,
 }
 
 ClientContextPtr ContextManagerImpl::createSslClientContext(Stats::Scope& scope,
-                                                            ClientContextConfig& config) {
+                                                            const ClientContextConfig& config) {
   ClientContextPtr context(new ClientContextImpl(*this, scope, config));
   std::unique_lock<std::shared_timed_mutex> lock(contexts_lock_);
   contexts_.emplace_back(context.get());
@@ -70,7 +70,7 @@ bool ContextManagerImpl::isWildcardServerName(const std::string& name) {
 
 ServerContextPtr ContextManagerImpl::createSslServerContext(
     const std::string& listener_name, const std::vector<std::string>& server_names,
-    Stats::Scope& scope, ServerContextConfig& config, bool skip_context_update) {
+    Stats::Scope& scope, const ServerContextConfig& config, bool skip_context_update) {
   ServerContextPtr context(new ServerContextImpl(*this, listener_name, server_names, scope, config,
                                                  skip_context_update, runtime_));
   std::unique_lock<std::shared_timed_mutex> lock(contexts_lock_);

--- a/source/common/ssl/context_manager_impl.h
+++ b/source/common/ssl/context_manager_impl.h
@@ -34,10 +34,11 @@ public:
 
   // Ssl::ContextManager
   Ssl::ClientContextPtr createSslClientContext(Stats::Scope& scope,
-                                               ClientContextConfig& config) override;
+                                               const ClientContextConfig& config) override;
   Ssl::ServerContextPtr createSslServerContext(const std::string& listener_name,
                                                const std::vector<std::string>& server_names,
-                                               Stats::Scope& scope, ServerContextConfig& config,
+                                               Stats::Scope& scope,
+                                               const ServerContextConfig& config,
                                                bool skip_context_update) override;
   Ssl::ServerContext* findSslServerContext(const std::string& listener_name,
                                            const std::string& server_name) const override;

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -20,24 +20,24 @@ public:
   ~MockContextManager();
 
   ClientContextPtr createSslClientContext(Stats::Scope& scope,
-                                          ClientContextConfig& config) override {
+                                          const ClientContextConfig& config) override {
     return ClientContextPtr{createSslClientContext_(scope, config)};
   }
 
   ServerContextPtr createSslServerContext(const std::string& listener_name,
                                           const std::vector<std::string>& server_names,
-                                          Stats::Scope& scope, ServerContextConfig& config,
+                                          Stats::Scope& scope, const ServerContextConfig& config,
                                           bool skip_context_update) override {
     return ServerContextPtr{
         createSslServerContext_(listener_name, server_names, scope, config, skip_context_update)};
   }
 
   MOCK_METHOD2(createSslClientContext_,
-               ClientContext*(Stats::Scope& scope, ClientContextConfig& config));
+               ClientContext*(Stats::Scope& scope, const ClientContextConfig& config));
   MOCK_METHOD5(createSslServerContext_,
                ServerContext*(const std::string& listener_name,
                               const std::vector<std::string>& server_names, Stats::Scope& stats,
-                              ServerContextConfig& config, bool skip_context_update));
+                              const ServerContextConfig& config, bool skip_context_update));
   MOCK_CONST_METHOD2(findSslServerContext, ServerContext*(const std::string&, const std::string&));
   MOCK_CONST_METHOD0(daysUntilFirstCertExpires, size_t());
   MOCK_METHOD1(iterateContexts, void(std::function<void(const Context&)> callback));


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <zlizan@google.com>

*Description*:
Make ContextConfigs const since it is actually used as const.
Also marked ContextConfigImpl constructors explicit to disallow implicit conversion.

*Risk Level*: Low

*Testing*: unit test, integration test

*Docs Changes*:
N/A

*Release Notes*:
N/A