### PR TITLE
const fixes for PR 2190

### DIFF
--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -149,7 +149,7 @@ TEST_F(LdsApiTest, Basic) {
 
   setup();
 
-  std::string response1_json = R"EOF(
+  const std::string response1_json = R"EOF(
   {
     "listeners": [
     {
@@ -182,7 +182,7 @@ TEST_F(LdsApiTest, Basic) {
   expectRequest();
   interval_timer_->callback_();
 
-  std::string response2_json = R"EOF(
+  const std::string response2_json = R"EOF(
   {
     "listeners": [
     {
@@ -221,7 +221,7 @@ TEST_F(LdsApiTest, Failure) {
 
   setup();
 
-  std::string response_json = R"EOF(
+  const std::string response_json = R"EOF(
   {
     "listeners" : {}
   }


### PR DESCRIPTION
Marking some test strings const

*Testing*: n/a
*Release Notes*: n/a

