### PR TITLE
network: change connection address methods to return pointers

### DIFF
--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -149,17 +149,17 @@ public:
   virtual bool readEnabled() const PURE;
 
   /**
-   * @return The address of the remote client.
+   * @return The address of the remote client. Note that this method will never return nullptr.
    */
-  virtual Network::Address::InstanceConstSharedPtr remoteAddress() const PURE;
+  virtual const Network::Address::InstanceConstSharedPtr& remoteAddress() const PURE;
 
   /**
    * @return the local address of the connection. For client connections, this is the origin
    * address. For server connections, this is the local destination address. For server connections
    * it can be different from the proxy address if the downstream connection has been redirected or
-   * the proxy is operating in transparent mode.
+   * the proxy is operating in transparent mode. Note that this method will never return nullptr.
    */
-  virtual Network::Address::InstanceConstSharedPtr localAddress() const PURE;
+  virtual const Network::Address::InstanceConstSharedPtr& localAddress() const PURE;
 
   /**
    * Set the stats to update for various connection state changes. Note that for performance reasons

--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -151,7 +151,7 @@ public:
   /**
    * @return The address of the remote client.
    */
-  virtual const Address::Instance& remoteAddress() const PURE;
+  virtual Network::Address::InstanceConstSharedPtr remoteAddress() const PURE;
 
   /**
    * @return the local address of the connection. For client connections, this is the origin
@@ -159,7 +159,7 @@ public:
    * it can be different from the proxy address if the downstream connection has been redirected or
    * the proxy is operating in transparent mode.
    */
-  virtual const Address::Instance& localAddress() const PURE;
+  virtual Network::Address::InstanceConstSharedPtr localAddress() const PURE;
 
   /**
    * Set the stats to update for various connection state changes. Note that for performance reasons

--- a/source/common/filter/auth/client_ssl.cc
+++ b/source/common/filter/auth/client_ssl.cc
@@ -103,7 +103,7 @@ void Instance::onEvent(Network::ConnectionEvent event) {
   }
 
   ASSERT(read_callbacks_->connection().ssl());
-  if (config_->ipWhiteList().contains(read_callbacks_->connection().remoteAddress())) {
+  if (config_->ipWhiteList().contains(*read_callbacks_->connection().remoteAddress())) {
     config_->stats().auth_ip_white_list_.inc();
     read_callbacks_->continueReading();
     return;

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -49,10 +49,10 @@ void ConnectionManagerUtility::mutateRequestHeaders(
   // peer. Cases where we don't "use remote address" include trusted double proxy where we expect
   // our peer to have already properly set XFF, etc.
   if (config.useRemoteAddress()) {
-    if (Network::Utility::isLoopbackAddress(connection.remoteAddress())) {
+    if (Network::Utility::isLoopbackAddress(*connection.remoteAddress())) {
       Utility::appendXff(request_headers, config.localAddress());
     } else {
-      Utility::appendXff(request_headers, connection.remoteAddress());
+      Utility::appendXff(request_headers, *connection.remoteAddress());
     }
     request_headers.insertForwardedProto().value().setReference(
         connection.ssl() ? Headers::get().SchemeValues.Https : Headers::get().SchemeValues.Http);
@@ -115,9 +115,9 @@ void ConnectionManagerUtility::mutateRequestHeaders(
 
   // If we are an external request, AND we are "using remote address" (see above), we set
   // x-envoy-external-address since this is our first ingress point into the trusted network.
-  if (edge_request && connection.remoteAddress().type() == Network::Address::Type::Ip) {
+  if (edge_request && connection.remoteAddress()->type() == Network::Address::Type::Ip) {
     request_headers.insertEnvoyExternalAddress().value(
-        connection.remoteAddress().ip()->addressAsString());
+        connection.remoteAddress()->ip()->addressAsString());
   }
 
   // Generate x-request-id for all edge requests, or if there is none.

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -78,8 +78,8 @@ public:
   void readDisable(bool disable) override;
   void detectEarlyCloseWhenReadDisabled(bool value) override { detect_early_close_ = value; }
   bool readEnabled() const override;
-  const Address::Instance& remoteAddress() const override { return *remote_address_; }
-  const Address::Instance& localAddress() const override { return *local_address_; }
+  Address::InstanceConstSharedPtr remoteAddress() const override { return remote_address_; }
+  Address::InstanceConstSharedPtr localAddress() const override { return local_address_; }
   void setConnectionStats(const ConnectionStats& stats) override;
   Ssl::Connection* ssl() override { return nullptr; }
   const Ssl::Connection* ssl() const override { return nullptr; }

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -78,8 +78,8 @@ public:
   void readDisable(bool disable) override;
   void detectEarlyCloseWhenReadDisabled(bool value) override { detect_early_close_ = value; }
   bool readEnabled() const override;
-  Address::InstanceConstSharedPtr remoteAddress() const override { return remote_address_; }
-  Address::InstanceConstSharedPtr localAddress() const override { return local_address_; }
+  const Address::InstanceConstSharedPtr& remoteAddress() const override { return remote_address_; }
+  const Address::InstanceConstSharedPtr& localAddress() const override { return local_address_; }
   void setConnectionStats(const ConnectionStats& stats) override;
   Ssl::Connection* ssl() override { return nullptr; }
   const Ssl::Connection* ssl() const override { return nullptr; }

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -183,8 +183,8 @@ public:
     // connections can receive different cookies if they race on requests.
     std::string value;
     const Network::Connection* conn = downstreamConnection();
-    // need to check for null conn if this is ever used by Http::AsyncClient in the fiture
-    value = conn->remoteAddress().asString() + conn->localAddress().asString();
+    // Need to check for null conn if this is ever used by Http::AsyncClient in the future.
+    value = conn->remoteAddress()->asString() + conn->localAddress()->asString();
 
     const std::string cookie_value = Hex::uint64ToHex(HashUtil::xxHash64(value));
     downstream_set_cookies_.emplace_back(

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -45,7 +45,7 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
     // The local address of the downstream connection is the original destination address,
     // if usingOriginalDst() returns 'true'.
     if (connection && connection->usingOriginalDst()) {
-      const Network::Address::Instance& dst_addr = connection->localAddress();
+      const Network::Address::Instance& dst_addr = *connection->localAddress();
 
       // Check if a host with the destination address is already in the host set.
       HostSharedPtr host = host_map_.find(dst_addr);

--- a/test/common/filter/auth/client_ssl_test.cc
+++ b/test/common/filter/auth/client_ssl_test.cc
@@ -155,8 +155,8 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   // Create a new filter for an SSL connection, with no backing auth data yet.
   createAuthFilter();
   ON_CALL(filter_callbacks_.connection_, ssl()).WillByDefault(Return(&ssl_));
-  Network::Address::Ipv4Instance remote_address("192.168.1.1");
-  EXPECT_CALL(filter_callbacks_.connection_, remoteAddress()).WillOnce(ReturnRef(remote_address));
+  EXPECT_CALL(filter_callbacks_.connection_, remoteAddress())
+      .WillOnce(Return(std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1")));
   EXPECT_CALL(ssl_, sha256PeerCertificateDigest()).WillOnce(Return("digest"));
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_EQ(Network::FilterStatus::StopIteration, instance_->onNewConnection());
@@ -174,7 +174,8 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
 
   // Create a new filter for an SSL connection with an authorized cert.
   createAuthFilter();
-  EXPECT_CALL(filter_callbacks_.connection_, remoteAddress()).WillOnce(ReturnRef(remote_address));
+  EXPECT_CALL(filter_callbacks_.connection_, remoteAddress())
+      .WillOnce(Return(std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1")));
   EXPECT_CALL(ssl_, sha256PeerCertificateDigest())
       .WillOnce(Return("1b7d42ef0025ad89c1c911d6c10d7e86a4cb7c5863b2980abcbad1895f8b5314"));
   EXPECT_EQ(Network::FilterStatus::StopIteration, instance_->onNewConnection());
@@ -186,8 +187,8 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
 
   // White list case.
   createAuthFilter();
-  Network::Address::Ipv4Instance remote_address2("1.2.3.4");
-  EXPECT_CALL(filter_callbacks_.connection_, remoteAddress()).WillOnce(ReturnRef(remote_address2));
+  EXPECT_CALL(filter_callbacks_.connection_, remoteAddress())
+      .WillOnce(Return(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4")));
   EXPECT_EQ(Network::FilterStatus::StopIteration, instance_->onNewConnection());
   EXPECT_CALL(filter_callbacks_, continueReading());
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::Connected);
@@ -197,8 +198,8 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
 
   // IPv6 White list case.
   createAuthFilter();
-  Network::Address::Ipv6Instance remote_address3("2001:abcd::1");
-  EXPECT_CALL(filter_callbacks_.connection_, remoteAddress()).WillOnce(ReturnRef(remote_address3));
+  EXPECT_CALL(filter_callbacks_.connection_, remoteAddress())
+      .WillOnce(Return(std::make_shared<Network::Address::Ipv6Instance>("2001:abcd::1")));
   EXPECT_EQ(Network::FilterStatus::StopIteration, instance_->onNewConnection());
   EXPECT_CALL(filter_callbacks_, continueReading());
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::Connected);

--- a/test/common/filter/auth/client_ssl_test.cc
+++ b/test/common/filter/auth/client_ssl_test.cc
@@ -25,6 +25,7 @@ using testing::Invoke;
 using testing::Return;
 using testing::ReturnNew;
 using testing::ReturnRef;
+using testing::ReturnRefOfCopy;
 using testing::WithArg;
 using testing::_;
 
@@ -156,7 +157,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   createAuthFilter();
   ON_CALL(filter_callbacks_.connection_, ssl()).WillByDefault(Return(&ssl_));
   EXPECT_CALL(filter_callbacks_.connection_, remoteAddress())
-      .WillOnce(Return(std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1")));
+      .WillOnce(ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1")));
   EXPECT_CALL(ssl_, sha256PeerCertificateDigest()).WillOnce(Return("digest"));
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_EQ(Network::FilterStatus::StopIteration, instance_->onNewConnection());
@@ -175,7 +176,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   // Create a new filter for an SSL connection with an authorized cert.
   createAuthFilter();
   EXPECT_CALL(filter_callbacks_.connection_, remoteAddress())
-      .WillOnce(Return(std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1")));
+      .WillOnce(ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1")));
   EXPECT_CALL(ssl_, sha256PeerCertificateDigest())
       .WillOnce(Return("1b7d42ef0025ad89c1c911d6c10d7e86a4cb7c5863b2980abcbad1895f8b5314"));
   EXPECT_EQ(Network::FilterStatus::StopIteration, instance_->onNewConnection());
@@ -188,7 +189,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   // White list case.
   createAuthFilter();
   EXPECT_CALL(filter_callbacks_.connection_, remoteAddress())
-      .WillOnce(Return(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4")));
+      .WillOnce(ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4")));
   EXPECT_EQ(Network::FilterStatus::StopIteration, instance_->onNewConnection());
   EXPECT_CALL(filter_callbacks_, continueReading());
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::Connected);
@@ -199,7 +200,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   // IPv6 White list case.
   createAuthFilter();
   EXPECT_CALL(filter_callbacks_.connection_, remoteAddress())
-      .WillOnce(Return(std::make_shared<Network::Address::Ipv6Instance>("2001:abcd::1")));
+      .WillOnce(ReturnRefOfCopy(std::make_shared<Network::Address::Ipv6Instance>("2001:abcd::1")));
   EXPECT_EQ(Network::FilterStatus::StopIteration, instance_->onNewConnection());
   EXPECT_CALL(filter_callbacks_, continueReading());
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::Connected);

--- a/test/common/filter/auth/client_ssl_test.cc
+++ b/test/common/filter/auth/client_ssl_test.cc
@@ -25,7 +25,6 @@ using testing::Invoke;
 using testing::Return;
 using testing::ReturnNew;
 using testing::ReturnRef;
-using testing::ReturnRefOfCopy;
 using testing::WithArg;
 using testing::_;
 
@@ -156,8 +155,8 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   // Create a new filter for an SSL connection, with no backing auth data yet.
   createAuthFilter();
   ON_CALL(filter_callbacks_.connection_, ssl()).WillByDefault(Return(&ssl_));
-  EXPECT_CALL(filter_callbacks_.connection_, remoteAddress())
-      .WillOnce(ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1")));
+  filter_callbacks_.connection_.remote_address_ =
+      std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1");
   EXPECT_CALL(ssl_, sha256PeerCertificateDigest()).WillOnce(Return("digest"));
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_EQ(Network::FilterStatus::StopIteration, instance_->onNewConnection());
@@ -175,8 +174,8 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
 
   // Create a new filter for an SSL connection with an authorized cert.
   createAuthFilter();
-  EXPECT_CALL(filter_callbacks_.connection_, remoteAddress())
-      .WillOnce(ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1")));
+  filter_callbacks_.connection_.remote_address_ =
+      std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1");
   EXPECT_CALL(ssl_, sha256PeerCertificateDigest())
       .WillOnce(Return("1b7d42ef0025ad89c1c911d6c10d7e86a4cb7c5863b2980abcbad1895f8b5314"));
   EXPECT_EQ(Network::FilterStatus::StopIteration, instance_->onNewConnection());
@@ -188,8 +187,8 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
 
   // White list case.
   createAuthFilter();
-  EXPECT_CALL(filter_callbacks_.connection_, remoteAddress())
-      .WillOnce(ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4")));
+  filter_callbacks_.connection_.remote_address_ =
+      std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4");
   EXPECT_EQ(Network::FilterStatus::StopIteration, instance_->onNewConnection());
   EXPECT_CALL(filter_callbacks_, continueReading());
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::Connected);
@@ -199,8 +198,8 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
 
   // IPv6 White list case.
   createAuthFilter();
-  EXPECT_CALL(filter_callbacks_.connection_, remoteAddress())
-      .WillOnce(ReturnRefOfCopy(std::make_shared<Network::Address::Ipv6Instance>("2001:abcd::1")));
+  filter_callbacks_.connection_.remote_address_ =
+      std::make_shared<Network::Address::Ipv6Instance>("2001:abcd::1");
   EXPECT_EQ(Network::FilterStatus::StopIteration, instance_->onNewConnection());
   EXPECT_CALL(filter_callbacks_, continueReading());
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::Connected);

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -26,6 +26,7 @@ using testing::NiceMock;
 using testing::Return;
 using testing::ReturnPointee;
 using testing::ReturnRef;
+using testing::ReturnRefOfCopy;
 using testing::SaveArg;
 using testing::_;
 
@@ -160,7 +161,8 @@ TEST(TcpProxyConfigTest, Routes) {
     // hit route with destination_ip (10.10.10.10/32)
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("10.10.10.10")));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("10.10.10.10")));
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
@@ -168,9 +170,11 @@ TEST(TcpProxyConfigTest, Routes) {
     // fall-through
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("10.10.10.11")));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("10.10.10.11")));
     EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
@@ -178,7 +182,8 @@ TEST(TcpProxyConfigTest, Routes) {
     // hit route with destination_ip (10.10.11.0/24)
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("10.10.11.11")));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("10.10.11.11")));
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
@@ -186,9 +191,11 @@ TEST(TcpProxyConfigTest, Routes) {
     // fall-through
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("10.10.12.12")));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("10.10.12.12")));
     EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
@@ -196,7 +203,8 @@ TEST(TcpProxyConfigTest, Routes) {
     // hit route with destination_ip (10.11.0.0/16)
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("10.11.11.11")));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("10.11.11.11")));
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
@@ -204,9 +212,11 @@ TEST(TcpProxyConfigTest, Routes) {
     // fall-through
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("10.12.12.12")));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("10.12.12.12")));
     EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
@@ -214,7 +224,8 @@ TEST(TcpProxyConfigTest, Routes) {
     // hit route with destination_ip (11.0.0.0/8)
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("11.11.11.11")));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("11.11.11.11")));
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
@@ -222,9 +233,11 @@ TEST(TcpProxyConfigTest, Routes) {
     // fall-through
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("12.12.12.12")));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("12.12.12.12")));
     EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
@@ -233,7 +246,7 @@ TEST(TcpProxyConfigTest, Routes) {
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
         .WillRepeatedly(
-            Return(std::make_shared<Network::Address::Ipv4Instance>("128.255.255.255")));
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("128.255.255.255")));
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
@@ -241,7 +254,8 @@ TEST(TcpProxyConfigTest, Routes) {
     // hit route with destination port range
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 12345)));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 12345)));
     EXPECT_EQ(std::string("with_destination_ports"), config_obj.getRouteFromEntries(connection));
   }
 
@@ -249,9 +263,11 @@ TEST(TcpProxyConfigTest, Routes) {
     // fall through
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 23456)));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 23456)));
     EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
@@ -259,9 +275,11 @@ TEST(TcpProxyConfigTest, Routes) {
     // hit route with source port range
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 23456)));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 23456)));
     EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0", 23459)));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0", 23459)));
     EXPECT_EQ(std::string("with_source_ports"), config_obj.getRouteFromEntries(connection));
   }
 
@@ -269,9 +287,11 @@ TEST(TcpProxyConfigTest, Routes) {
     // fall through
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 23456)));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 23456)));
     EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0", 23458)));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0", 23458)));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
@@ -280,10 +300,10 @@ TEST(TcpProxyConfigTest, Routes) {
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
         .WillRepeatedly(
-            Return(std::make_shared<Network::Address::Ipv4Instance>("10.0.0.0", 10000)));
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("10.0.0.0", 10000)));
     EXPECT_CALL(connection, remoteAddress())
         .WillRepeatedly(
-            Return(std::make_shared<Network::Address::Ipv4Instance>("20.0.0.0", 20000)));
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("20.0.0.0", 20000)));
     EXPECT_EQ(std::string("with_everything"), config_obj.getRouteFromEntries(connection));
   }
 
@@ -292,10 +312,10 @@ TEST(TcpProxyConfigTest, Routes) {
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
         .WillRepeatedly(
-            Return(std::make_shared<Network::Address::Ipv4Instance>("10.0.0.0", 10000)));
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("10.0.0.0", 10000)));
     EXPECT_CALL(connection, remoteAddress())
         .WillRepeatedly(
-            Return(std::make_shared<Network::Address::Ipv4Instance>("30.0.0.0", 20000)));
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("30.0.0.0", 20000)));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
@@ -303,7 +323,7 @@ TEST(TcpProxyConfigTest, Routes) {
     // hit route with destination_ip (::1/128)
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv6Instance>("::1")));
+        .WillRepeatedly(ReturnRefOfCopy(std::make_shared<Network::Address::Ipv6Instance>("::1")));
     EXPECT_EQ(std::string("with_v6_destination"), config_obj.getRouteFromEntries(connection));
   }
 
@@ -312,7 +332,7 @@ TEST(TcpProxyConfigTest, Routes) {
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
         .WillRepeatedly(
-            Return(std::make_shared<Network::Address::Ipv6Instance>("2001:abcd:0:0:1::")));
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv6Instance>("2001:abcd:0:0:1::")));
     EXPECT_EQ(std::string("with_v6_destination"), config_obj.getRouteFromEntries(connection));
   }
 
@@ -321,10 +341,10 @@ TEST(TcpProxyConfigTest, Routes) {
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
         .WillRepeatedly(
-            Return(std::make_shared<Network::Address::Ipv6Instance>("2002:0:0:0:0:0::1")));
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv6Instance>("2002:0:0:0:0:0::1")));
     EXPECT_CALL(connection, remoteAddress())
         .WillRepeatedly(
-            Return(std::make_shared<Network::Address::Ipv6Instance>("2003:0:0:0:0::5")));
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv6Instance>("2003:0:0:0:0::5")));
     EXPECT_EQ(std::string("with_v6_source_and_destination"),
               config_obj.getRouteFromEntries(connection));
   }
@@ -333,9 +353,10 @@ TEST(TcpProxyConfigTest, Routes) {
     // fall through
     NiceMock<Network::MockConnection> connection;
     EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv6Instance>("2004::")));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv6Instance>("2004::")));
     EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv6Instance>("::")));
+        .WillRepeatedly(ReturnRefOfCopy(std::make_shared<Network::Address::Ipv6Instance>("::")));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 }
@@ -467,7 +488,7 @@ public:
                 factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_));
         ON_CALL(*upstream_hosts_.at(i), address()).WillByDefault(Return(upstream_remote_address_));
         ON_CALL(*upstream_connections_.at(i), localAddress())
-            .WillByDefault(Return(upstream_local_address_));
+            .WillByDefault(ReturnRef(upstream_local_address_));
         EXPECT_CALL(*upstream_connections_.at(i), addReadFilter(_))
             .WillOnce(SaveArg<0>(&upstream_read_filter_));
         EXPECT_CALL(*upstream_connections_.at(i), dispatcher())
@@ -824,7 +845,8 @@ TEST_F(TcpProxyTest, AccessLogUpstreamLocalAddress) {
 TEST_F(TcpProxyTest, AccessLogDownstreamAddress) {
   Network::Address::InstanceConstSharedPtr downstream_address =
       Network::Utility::resolveUrl("tcp://1.1.1.1:40000");
-  ON_CALL(filter_callbacks_.connection_, remoteAddress()).WillByDefault(Return(downstream_address));
+  ON_CALL(filter_callbacks_.connection_, remoteAddress())
+      .WillByDefault(ReturnRef(downstream_address));
   setup(1, accessLogConfig("%DOWNSTREAM_ADDRESS%"));
   filter_.reset();
   EXPECT_EQ(access_log_data_, "1.1.1.1:40000");
@@ -894,7 +916,8 @@ TEST_F(TcpProxyRoutingTest, NonRoutableConnection) {
 
   // Port 10000 is outside the specified destination port range.
   EXPECT_CALL(connection_, localAddress())
-      .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 10000)));
+      .WillRepeatedly(
+          ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 10000)));
 
   // Expect filter to stop iteration and close connection.
   EXPECT_CALL(connection_, close(Network::ConnectionCloseType::NoFlush));
@@ -912,7 +935,8 @@ TEST_F(TcpProxyRoutingTest, RoutableConnection) {
 
   // Port 9999 is within the specified destination port range.
   EXPECT_CALL(connection_, localAddress())
-      .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 9999)));
+      .WillRepeatedly(
+          ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 9999)));
 
   // Expect filter to try to open a connection to specified cluster.
   EXPECT_CALL(factory_context_.cluster_manager_, tcpConnForCluster_("fake_cluster", _));

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -26,7 +26,6 @@ using testing::NiceMock;
 using testing::Return;
 using testing::ReturnPointee;
 using testing::ReturnRef;
-using testing::ReturnRefOfCopy;
 using testing::SaveArg;
 using testing::_;
 
@@ -160,191 +159,141 @@ TEST(TcpProxyConfigTest, Routes) {
   {
     // hit route with destination_ip (10.10.10.10/32)
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("10.10.10.10")));
+    connection.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.10.10.10");
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall-through
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("10.10.10.11")));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
+    connection.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.10.10.11");
+    connection.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0");
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip (10.10.11.0/24)
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("10.10.11.11")));
+    connection.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.10.11.11");
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall-through
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("10.10.12.12")));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
+    connection.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.10.12.12");
+    connection.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0");
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip (10.11.0.0/16)
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("10.11.11.11")));
+    connection.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.11.11.11");
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall-through
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("10.12.12.12")));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
+    connection.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.12.12.12");
+    connection.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0");
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip (11.0.0.0/8)
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("11.11.11.11")));
+    connection.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("11.11.11.11");
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall-through
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("12.12.12.12")));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
+    connection.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("12.12.12.12");
+    connection.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0");
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip (128.0.0.0/8)
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("128.255.255.255")));
+    connection.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("128.255.255.255");
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination port range
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 12345)));
+    connection.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 12345);
     EXPECT_EQ(std::string("with_destination_ports"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall through
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 23456)));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
+    connection.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 23456);
+    connection.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0");
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with source port range
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 23456)));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0", 23459)));
+    connection.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 23456);
+    connection.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0", 23459);
     EXPECT_EQ(std::string("with_source_ports"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall through
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 23456)));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0", 23458)));
+    connection.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 23456);
+    connection.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0", 23458);
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit the route with all criterias present
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("10.0.0.0", 10000)));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("20.0.0.0", 20000)));
+    connection.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.0", 10000);
+    connection.remote_address_ =
+        std::make_shared<Network::Address::Ipv4Instance>("20.0.0.0", 20000);
     EXPECT_EQ(std::string("with_everything"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall through
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("10.0.0.0", 10000)));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("30.0.0.0", 20000)));
+    connection.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.0", 10000);
+    connection.remote_address_ =
+        std::make_shared<Network::Address::Ipv4Instance>("30.0.0.0", 20000);
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip (::1/128)
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::make_shared<Network::Address::Ipv6Instance>("::1")));
+    connection.local_address_ = std::make_shared<Network::Address::Ipv6Instance>("::1");
     EXPECT_EQ(std::string("with_v6_destination"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip (2001:abcd/64")
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv6Instance>("2001:abcd:0:0:1::")));
+    connection.local_address_ =
+        std::make_shared<Network::Address::Ipv6Instance>("2001:abcd:0:0:1::");
     EXPECT_EQ(std::string("with_v6_destination"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip ("2002::/32") and source_ip ("2003::/64")
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv6Instance>("2002:0:0:0:0:0::1")));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv6Instance>("2003:0:0:0:0::5")));
+    connection.local_address_ =
+        std::make_shared<Network::Address::Ipv6Instance>("2002:0:0:0:0:0::1");
+    connection.remote_address_ =
+        std::make_shared<Network::Address::Ipv6Instance>("2003:0:0:0:0::5");
     EXPECT_EQ(std::string("with_v6_source_and_destination"),
               config_obj.getRouteFromEntries(connection));
   }
@@ -352,11 +301,8 @@ TEST(TcpProxyConfigTest, Routes) {
   {
     // fall through
     NiceMock<Network::MockConnection> connection;
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::Ipv6Instance>("2004::")));
-    EXPECT_CALL(connection, remoteAddress())
-        .WillRepeatedly(ReturnRefOfCopy(std::make_shared<Network::Address::Ipv6Instance>("::")));
+    connection.local_address_ = std::make_shared<Network::Address::Ipv6Instance>("2004::");
+    connection.remote_address_ = std::make_shared<Network::Address::Ipv6Instance>("::");
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 }
@@ -915,9 +861,7 @@ TEST_F(TcpProxyRoutingTest, NonRoutableConnection) {
   setup();
 
   // Port 10000 is outside the specified destination port range.
-  EXPECT_CALL(connection_, localAddress())
-      .WillRepeatedly(
-          ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 10000)));
+  connection_.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 10000);
 
   // Expect filter to stop iteration and close connection.
   EXPECT_CALL(connection_, close(Network::ConnectionCloseType::NoFlush));
@@ -934,9 +878,7 @@ TEST_F(TcpProxyRoutingTest, RoutableConnection) {
   setup();
 
   // Port 9999 is within the specified destination port range.
-  EXPECT_CALL(connection_, localAddress())
-      .WillRepeatedly(
-          ReturnRefOfCopy(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 9999)));
+  connection_.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 9999);
 
   // Expect filter to try to open a connection to specified cluster.
   EXPECT_CALL(factory_context_.cluster_manager_, tcpConnForCluster_("fake_cluster", _));

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -433,8 +433,7 @@ public:
             .WillByDefault(ReturnPointee(
                 factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_));
         ON_CALL(*upstream_hosts_.at(i), address()).WillByDefault(Return(upstream_remote_address_));
-        ON_CALL(*upstream_connections_.at(i), localAddress())
-            .WillByDefault(ReturnRef(upstream_local_address_));
+        upstream_connections_.at(i)->local_address_ = upstream_local_address_;
         EXPECT_CALL(*upstream_connections_.at(i), addReadFilter(_))
             .WillOnce(SaveArg<0>(&upstream_read_filter_));
         EXPECT_CALL(*upstream_connections_.at(i), dispatcher())
@@ -789,10 +788,8 @@ TEST_F(TcpProxyTest, AccessLogUpstreamLocalAddress) {
 
 // Test that access log field %DOWNSTREAM_ADDRESS% is correctly logged.
 TEST_F(TcpProxyTest, AccessLogDownstreamAddress) {
-  Network::Address::InstanceConstSharedPtr downstream_address =
+  filter_callbacks_.connection_.remote_address_ =
       Network::Utility::resolveUrl("tcp://1.1.1.1:40000");
-  ON_CALL(filter_callbacks_.connection_, remoteAddress())
-      .WillByDefault(ReturnRef(downstream_address));
   setup(1, accessLogConfig("%DOWNSTREAM_ADDRESS%"));
   filter_.reset();
   EXPECT_EQ(access_log_data_, "1.1.1.1:40000");

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -159,164 +159,172 @@ TEST(TcpProxyConfigTest, Routes) {
   {
     // hit route with destination_ip (10.10.10.10/32)
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv4Instance local_address("10.10.10.10");
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("10.10.10.10")));
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall-through
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv4Instance local_address("10.10.10.11");
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
-    Network::Address::Ipv4Instance remote_address("0.0.0.0");
-    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("10.10.10.11")));
+    EXPECT_CALL(connection, remoteAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip (10.10.11.0/24)
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv4Instance local_address("10.10.11.11");
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("10.10.11.11")));
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall-through
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv4Instance local_address("10.10.12.12");
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
-    Network::Address::Ipv4Instance remote_address("0.0.0.0");
-    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("10.10.12.12")));
+    EXPECT_CALL(connection, remoteAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip (10.11.0.0/16)
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv4Instance local_address("10.11.11.11");
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("10.11.11.11")));
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall-through
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv4Instance local_address("10.12.12.12");
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
-    Network::Address::Ipv4Instance remote_address("0.0.0.0");
-    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("10.12.12.12")));
+    EXPECT_CALL(connection, remoteAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip (11.0.0.0/8)
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv4Instance local_address("11.11.11.11");
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("11.11.11.11")));
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall-through
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv4Instance local_address("12.12.12.12");
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
-    Network::Address::Ipv4Instance remote_address("0.0.0.0");
-    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("12.12.12.12")));
+    EXPECT_CALL(connection, remoteAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip (128.0.0.0/8)
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv4Instance local_address("128.255.255.255");
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(
+            Return(std::make_shared<Network::Address::Ipv4Instance>("128.255.255.255")));
     EXPECT_EQ(std::string("with_destination_ip_list"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination port range
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv4Instance local_address("1.2.3.4", 12345);
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 12345)));
     EXPECT_EQ(std::string("with_destination_ports"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall through
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv4Instance local_address("1.2.3.4", 23456);
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
-    Network::Address::Ipv4Instance remote_address("0.0.0.0");
-    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 23456)));
+    EXPECT_CALL(connection, remoteAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with source port range
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv4Instance local_address("1.2.3.4", 23456);
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
-    Network::Address::Ipv4Instance remote_address("0.0.0.0", 23459);
-    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 23456)));
+    EXPECT_CALL(connection, remoteAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0", 23459)));
     EXPECT_EQ(std::string("with_source_ports"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall through
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv4Instance local_address("1.2.3.4", 23456);
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
-    Network::Address::Ipv4Instance remote_address("0.0.0.0", 23458);
-    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 23456)));
+    EXPECT_CALL(connection, remoteAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0", 23458)));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit the route with all criterias present
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv4Instance local_address("10.0.0.0", 10000);
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
-    Network::Address::Ipv4Instance remote_address("20.0.0.0", 20000);
-    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(
+            Return(std::make_shared<Network::Address::Ipv4Instance>("10.0.0.0", 10000)));
+    EXPECT_CALL(connection, remoteAddress())
+        .WillRepeatedly(
+            Return(std::make_shared<Network::Address::Ipv4Instance>("20.0.0.0", 20000)));
     EXPECT_EQ(std::string("with_everything"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // fall through
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv4Instance local_address("10.0.0.0", 10000);
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
-    Network::Address::Ipv4Instance remote_address("30.0.0.0", 20000);
-    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(
+            Return(std::make_shared<Network::Address::Ipv4Instance>("10.0.0.0", 10000)));
+    EXPECT_CALL(connection, remoteAddress())
+        .WillRepeatedly(
+            Return(std::make_shared<Network::Address::Ipv4Instance>("30.0.0.0", 20000)));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip (::1/128)
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv6Instance local_address("::1");
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv6Instance>("::1")));
     EXPECT_EQ(std::string("with_v6_destination"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip (2001:abcd/64")
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv6Instance local_address("2001:abcd:0:0:1::");
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(
+            Return(std::make_shared<Network::Address::Ipv6Instance>("2001:abcd:0:0:1::")));
     EXPECT_EQ(std::string("with_v6_destination"), config_obj.getRouteFromEntries(connection));
   }
 
   {
     // hit route with destination_ip ("2002::/32") and source_ip ("2003::/64")
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv6Instance local_address("2002:0:0:0:0:0::1");
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
-    Network::Address::Ipv6Instance remote_address("2003:0:0:0:0::5");
-    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(
+            Return(std::make_shared<Network::Address::Ipv6Instance>("2002:0:0:0:0:0::1")));
+    EXPECT_CALL(connection, remoteAddress())
+        .WillRepeatedly(
+            Return(std::make_shared<Network::Address::Ipv6Instance>("2003:0:0:0:0::5")));
     EXPECT_EQ(std::string("with_v6_source_and_destination"),
               config_obj.getRouteFromEntries(connection));
   }
@@ -324,10 +332,10 @@ TEST(TcpProxyConfigTest, Routes) {
   {
     // fall through
     NiceMock<Network::MockConnection> connection;
-    Network::Address::Ipv6Instance local_address("2004::");
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
-    Network::Address::Ipv6Instance remote_address("::");
-    EXPECT_CALL(connection, remoteAddress()).WillRepeatedly(ReturnRef(remote_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv6Instance>("2004::")));
+    EXPECT_CALL(connection, remoteAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv6Instance>("::")));
     EXPECT_EQ(std::string("catch_all"), config_obj.getRouteFromEntries(connection));
   }
 }
@@ -459,7 +467,7 @@ public:
                 factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_));
         ON_CALL(*upstream_hosts_.at(i), address()).WillByDefault(Return(upstream_remote_address_));
         ON_CALL(*upstream_connections_.at(i), localAddress())
-            .WillByDefault(ReturnPointee(upstream_local_address_));
+            .WillByDefault(Return(upstream_local_address_));
         EXPECT_CALL(*upstream_connections_.at(i), addReadFilter(_))
             .WillOnce(SaveArg<0>(&upstream_read_filter_));
         EXPECT_CALL(*upstream_connections_.at(i), dispatcher())
@@ -816,8 +824,7 @@ TEST_F(TcpProxyTest, AccessLogUpstreamLocalAddress) {
 TEST_F(TcpProxyTest, AccessLogDownstreamAddress) {
   Network::Address::InstanceConstSharedPtr downstream_address =
       Network::Utility::resolveUrl("tcp://1.1.1.1:40000");
-  ON_CALL(filter_callbacks_.connection_, remoteAddress())
-      .WillByDefault(ReturnPointee(downstream_address));
+  ON_CALL(filter_callbacks_.connection_, remoteAddress()).WillByDefault(Return(downstream_address));
   setup(1, accessLogConfig("%DOWNSTREAM_ADDRESS%"));
   filter_.reset();
   EXPECT_EQ(access_log_data_, "1.1.1.1:40000");
@@ -885,11 +892,11 @@ TEST_F(TcpProxyRoutingTest, NonRoutableConnection) {
 
   setup();
 
-  // port 10000 is outside the specified destination port range
-  Network::Address::Ipv4Instance local_address("1.2.3.4", 10000);
-  EXPECT_CALL(connection_, localAddress()).WillRepeatedly(ReturnRef(local_address));
+  // Port 10000 is outside the specified destination port range.
+  EXPECT_CALL(connection_, localAddress())
+      .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 10000)));
 
-  // Expect filter to stop iteration and close connection
+  // Expect filter to stop iteration and close connection.
   EXPECT_CALL(connection_, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
 
@@ -903,11 +910,11 @@ TEST_F(TcpProxyRoutingTest, RoutableConnection) {
 
   setup();
 
-  // port 9999 is within the specified destination port range
-  Network::Address::Ipv4Instance local_address("1.2.3.4", 9999);
-  EXPECT_CALL(connection_, localAddress()).WillRepeatedly(ReturnRef(local_address));
+  // Port 9999 is within the specified destination port range.
+  EXPECT_CALL(connection_, localAddress())
+      .WillRepeatedly(Return(std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 9999)));
 
-  // Expect filter to try to open a connection to specified cluster
+  // Expect filter to try to open a connection to specified cluster.
   EXPECT_CALL(factory_context_.cluster_manager_, tcpConnForCluster_("fake_cluster", _));
 
   filter_->onNewConnection();

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -26,7 +26,6 @@ using testing::NiceMock;
 using testing::Ref;
 using testing::Return;
 using testing::ReturnRef;
-using testing::ReturnRefOfCopy;
 using testing::_;
 
 namespace Envoy {

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -95,7 +95,8 @@ public:
     ON_CALL(filter_callbacks_.connection_, ssl()).WillByDefault(Return(ssl_connection_.get()));
     ON_CALL(Const(filter_callbacks_.connection_), ssl())
         .WillByDefault(Return(ssl_connection_.get()));
-    ON_CALL(filter_callbacks_.connection_, remoteAddress()).WillByDefault(Return(remote_address_));
+    ON_CALL(filter_callbacks_.connection_, remoteAddress())
+        .WillByDefault(ReturnRef(remote_address_));
     conn_manager_.reset(new ConnectionManagerImpl(*this, drain_close_, random_, tracer_, runtime_,
                                                   local_info_, cluster_manager_));
     conn_manager_->initializeReadFilterCallbacks(filter_callbacks_);

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -95,8 +95,7 @@ public:
     ON_CALL(filter_callbacks_.connection_, ssl()).WillByDefault(Return(ssl_connection_.get()));
     ON_CALL(Const(filter_callbacks_.connection_), ssl())
         .WillByDefault(Return(ssl_connection_.get()));
-    ON_CALL(filter_callbacks_.connection_, remoteAddress())
-        .WillByDefault(ReturnRef(remote_address_));
+    ON_CALL(filter_callbacks_.connection_, remoteAddress()).WillByDefault(Return(remote_address_));
     conn_manager_.reset(new ConnectionManagerImpl(*this, drain_close_, random_, tracer_, runtime_,
                                                   local_info_, cluster_manager_));
     conn_manager_->initializeReadFilterCallbacks(filter_callbacks_);
@@ -257,7 +256,8 @@ public:
   std::unique_ptr<ConnectionManagerImpl> conn_manager_;
   std::string server_name_;
   Network::Address::Ipv4Instance local_address_{"127.0.0.1"};
-  Network::Address::Ipv4Instance remote_address_{"0.0.0.0"};
+  Network::Address::InstanceConstSharedPtr remote_address_{
+      std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")};
   bool use_remote_address_{true};
   Http::ForwardClientCertType forward_client_cert_{Http::ForwardClientCertType::Sanitize};
   std::vector<Http::ClientCertDetailsType> set_current_client_cert_details_;

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -95,8 +95,8 @@ public:
     ON_CALL(filter_callbacks_.connection_, ssl()).WillByDefault(Return(ssl_connection_.get()));
     ON_CALL(Const(filter_callbacks_.connection_), ssl())
         .WillByDefault(Return(ssl_connection_.get()));
-    ON_CALL(filter_callbacks_.connection_, remoteAddress())
-        .WillByDefault(ReturnRef(remote_address_));
+    filter_callbacks_.connection_.remote_address_ =
+        std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0");
     conn_manager_.reset(new ConnectionManagerImpl(*this, drain_close_, random_, tracer_, runtime_,
                                                   local_info_, cluster_manager_));
     conn_manager_->initializeReadFilterCallbacks(filter_callbacks_);
@@ -257,8 +257,6 @@ public:
   std::unique_ptr<ConnectionManagerImpl> conn_manager_;
   std::string server_name_;
   Network::Address::Ipv4Instance local_address_{"127.0.0.1"};
-  Network::Address::InstanceConstSharedPtr remote_address_{
-      std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0")};
   bool use_remote_address_{true};
   Http::ForwardClientCertType forward_client_cert_{Http::ForwardClientCertType::Sanitize};
   std::vector<Http::ClientCertDetailsType> set_current_client_cert_details_;

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -49,25 +49,25 @@ public:
 };
 
 TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWhenNotLocalHostRemoteAddress) {
-  Network::Address::Ipv4Instance not_local_host_remote_address("12.12.12.12");
+  auto not_local_host_remote_address =
+      std::make_shared<Network::Address::Ipv4Instance>("12.12.12.12");
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
-  EXPECT_CALL(connection_, remoteAddress())
-      .WillRepeatedly(ReturnRef(not_local_host_remote_address));
+  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(Return(not_local_host_remote_address));
 
   TestHeaderMapImpl headers{};
   ConnectionManagerUtility::mutateRequestHeaders(headers, Protocol::Http2, connection_, config_,
                                                  route_config_, random_, runtime_, local_info_);
 
   EXPECT_TRUE(headers.has(Headers::get().ForwardedFor));
-  EXPECT_EQ(not_local_host_remote_address.ip()->addressAsString(),
+  EXPECT_EQ(not_local_host_remote_address->ip()->addressAsString(),
             headers.get_(Headers::get().ForwardedFor));
 }
 
 TEST_F(ConnectionManagerUtilityTest, UseLocalAddressWhenLocalHostRemoteAddress) {
-  Network::Address::Ipv4Instance local_host_remote_address("127.0.0.1");
+  auto local_host_remote_address = std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1");
   Network::Address::Ipv4Instance local_address("10.3.2.1");
 
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(local_host_remote_address));
+  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(Return(local_host_remote_address));
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
   EXPECT_CALL(config_, localAddress()).WillRepeatedly(ReturnRef(local_address));
 
@@ -80,10 +80,10 @@ TEST_F(ConnectionManagerUtilityTest, UseLocalAddressWhenLocalHostRemoteAddress) 
 }
 
 TEST_F(ConnectionManagerUtilityTest, UserAgentDontSet) {
-  Network::Address::Ipv4Instance internal_remote_address("10.0.0.1");
+  auto internal_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
 
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
+  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(Return(internal_remote_address));
 
   TestHeaderMapImpl headers{{"user-agent", "foo"}};
   ConnectionManagerUtility::mutateRequestHeaders(headers, Protocol::Http2, connection_, config_,
@@ -96,10 +96,10 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentDontSet) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, UserAgentSetWhenIncomingEmpty) {
-  Network::Address::Ipv4Instance internal_remote_address("10.0.0.1");
+  auto internal_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
 
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
+  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(Return(internal_remote_address));
 
   user_agent_.value("bar");
   TestHeaderMapImpl headers{{"user-agent", ""}, {"x-envoy-downstream-service-cluster", "foo"}};
@@ -147,10 +147,10 @@ TEST_F(ConnectionManagerUtilityTest, InternalServiceForceTrace) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, EdgeRequestRegenerateRequestIdAndWipeDownstream) {
-  Network::Address::Ipv4Instance external_remote_address("34.0.0.1");
+  auto external_remote_address = std::make_shared<Network::Address::Ipv4Instance>("34.0.0.1");
 
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
-  ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRef(external_remote_address));
+  ON_CALL(connection_, remoteAddress()).WillByDefault(Return(external_remote_address));
   ON_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
       .WillByDefault(Return(true));
 
@@ -222,10 +222,10 @@ TEST_F(ConnectionManagerUtilityTest, ExternalRequestPreserveRequestIdAndDownstre
 }
 
 TEST_F(ConnectionManagerUtilityTest, UserAgentSetIncomingUserAgent) {
-  Network::Address::Ipv4Instance internal_remote_address("10.0.0.1");
+  auto internal_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
 
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
+  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(Return(internal_remote_address));
 
   user_agent_.value("bar");
   TestHeaderMapImpl headers{{"user-agent", "foo"}, {"x-envoy-downstream-service-cluster", "foo"}};
@@ -240,10 +240,10 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentSetIncomingUserAgent) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, UserAgentSetNoIncomingUserAgent) {
-  Network::Address::Ipv4Instance internal_remote_address("10.0.0.1");
+  auto internal_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
 
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
+  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(Return(internal_remote_address));
 
   user_agent_.value("bar");
   TestHeaderMapImpl headers{};
@@ -281,9 +281,9 @@ TEST_F(ConnectionManagerUtilityTest, RequestIdGeneratedWhenItsNotPresent) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, DoNotOverrideRequestIdIfPresentWhenInternalRequest) {
-  Network::Address::Ipv4Instance local_remote_address("10.0.0.1");
+  auto local_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
   EXPECT_CALL(config_, useRemoteAddress()).WillOnce(Return(true));
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(local_remote_address));
+  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(Return(local_remote_address));
 
   TestHeaderMapImpl headers{{"x-request-id", "original_request_id"}};
   EXPECT_CALL(random_, uuid()).Times(0);
@@ -294,8 +294,8 @@ TEST_F(ConnectionManagerUtilityTest, DoNotOverrideRequestIdIfPresentWhenInternal
 }
 
 TEST_F(ConnectionManagerUtilityTest, OverrideRequestIdForExternalRequests) {
-  Network::Address::Ipv4Instance external_ip("134.2.2.11");
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(external_ip));
+  auto external_ip = std::make_shared<Network::Address::Ipv4Instance>("134.2.2.11");
+  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(Return(external_ip));
   TestHeaderMapImpl headers{{"x-request-id", "original"}};
 
   EXPECT_CALL(random_, uuid()).WillOnce(Return("override"));
@@ -307,8 +307,8 @@ TEST_F(ConnectionManagerUtilityTest, OverrideRequestIdForExternalRequests) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
-  Network::Address::Ipv4Instance external_ip("50.0.0.1");
-  ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRef(external_ip));
+  auto external_ip = std::make_shared<Network::Address::Ipv4Instance>("50.0.0.1");
+  ON_CALL(connection_, remoteAddress()).WillByDefault(Return(external_ip));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
 
   route_config_.internal_only_headers_.push_back(LowerCaseString("custom_header"));
@@ -340,8 +340,8 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestDontUseRemote) {
-  Network::Address::Ipv4Instance external_ip("60.0.0.1");
-  ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRef(external_ip));
+  auto external_ip = std::make_shared<Network::Address::Ipv4Instance>("60.0.0.1");
+  ON_CALL(connection_, remoteAddress()).WillByDefault(Return(external_ip));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(false));
 
   TestHeaderMapImpl headers{{"x-envoy-external-address", "60.0.0.1"},
@@ -354,8 +354,8 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestDontUseRemote
 }
 
 TEST_F(ConnectionManagerUtilityTest, ExternalAddressInternalRequestUseRemote) {
-  Network::Address::Ipv4Instance local_remote_address("10.0.0.1");
-  ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRef(local_remote_address));
+  auto local_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
+  ON_CALL(connection_, remoteAddress()).WillByDefault(Return(local_remote_address));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
 
   TestHeaderMapImpl headers{{"x-envoy-external-address", "60.0.0.1"},

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -49,26 +49,22 @@ public:
 };
 
 TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWhenNotLocalHostRemoteAddress) {
-  auto not_local_host_remote_address =
-      std::make_shared<Network::Address::Ipv4Instance>("12.12.12.12");
+  connection_.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("12.12.12.12");
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
-  EXPECT_CALL(connection_, remoteAddress())
-      .WillRepeatedly(ReturnRef(not_local_host_remote_address));
 
   TestHeaderMapImpl headers{};
   ConnectionManagerUtility::mutateRequestHeaders(headers, Protocol::Http2, connection_, config_,
                                                  route_config_, random_, runtime_, local_info_);
 
   EXPECT_TRUE(headers.has(Headers::get().ForwardedFor));
-  EXPECT_EQ(not_local_host_remote_address->ip()->addressAsString(),
+  EXPECT_EQ(connection_.remote_address_->ip()->addressAsString(),
             headers.get_(Headers::get().ForwardedFor));
 }
 
 TEST_F(ConnectionManagerUtilityTest, UseLocalAddressWhenLocalHostRemoteAddress) {
-  auto local_host_remote_address = std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1");
+  connection_.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1");
   Network::Address::Ipv4Instance local_address("10.3.2.1");
 
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(local_host_remote_address));
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
   EXPECT_CALL(config_, localAddress()).WillRepeatedly(ReturnRef(local_address));
 
@@ -81,10 +77,9 @@ TEST_F(ConnectionManagerUtilityTest, UseLocalAddressWhenLocalHostRemoteAddress) 
 }
 
 TEST_F(ConnectionManagerUtilityTest, UserAgentDontSet) {
-  auto internal_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
+  connection_.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
 
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
 
   TestHeaderMapImpl headers{{"user-agent", "foo"}};
   ConnectionManagerUtility::mutateRequestHeaders(headers, Protocol::Http2, connection_, config_,
@@ -97,10 +92,9 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentDontSet) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, UserAgentSetWhenIncomingEmpty) {
-  auto internal_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
+  connection_.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
 
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
 
   user_agent_.value("bar");
   TestHeaderMapImpl headers{{"user-agent", ""}, {"x-envoy-downstream-service-cluster", "foo"}};
@@ -148,10 +142,9 @@ TEST_F(ConnectionManagerUtilityTest, InternalServiceForceTrace) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, EdgeRequestRegenerateRequestIdAndWipeDownstream) {
-  auto external_remote_address = std::make_shared<Network::Address::Ipv4Instance>("34.0.0.1");
+  connection_.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("34.0.0.1");
 
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
-  ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRef(external_remote_address));
   ON_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
       .WillByDefault(Return(true));
 
@@ -223,10 +216,9 @@ TEST_F(ConnectionManagerUtilityTest, ExternalRequestPreserveRequestIdAndDownstre
 }
 
 TEST_F(ConnectionManagerUtilityTest, UserAgentSetIncomingUserAgent) {
-  auto internal_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
+  connection_.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
 
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
 
   user_agent_.value("bar");
   TestHeaderMapImpl headers{{"user-agent", "foo"}, {"x-envoy-downstream-service-cluster", "foo"}};
@@ -241,10 +233,9 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentSetIncomingUserAgent) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, UserAgentSetNoIncomingUserAgent) {
-  auto internal_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
+  connection_.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
 
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
 
   user_agent_.value("bar");
   TestHeaderMapImpl headers{};
@@ -282,9 +273,8 @@ TEST_F(ConnectionManagerUtilityTest, RequestIdGeneratedWhenItsNotPresent) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, DoNotOverrideRequestIdIfPresentWhenInternalRequest) {
-  auto local_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
+  connection_.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
   EXPECT_CALL(config_, useRemoteAddress()).WillOnce(Return(true));
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(local_remote_address));
 
   TestHeaderMapImpl headers{{"x-request-id", "original_request_id"}};
   EXPECT_CALL(random_, uuid()).Times(0);
@@ -295,8 +285,7 @@ TEST_F(ConnectionManagerUtilityTest, DoNotOverrideRequestIdIfPresentWhenInternal
 }
 
 TEST_F(ConnectionManagerUtilityTest, OverrideRequestIdForExternalRequests) {
-  auto external_ip = std::make_shared<Network::Address::Ipv4Instance>("134.2.2.11");
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(external_ip));
+  connection_.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("134.2.2.11");
   TestHeaderMapImpl headers{{"x-request-id", "original"}};
 
   EXPECT_CALL(random_, uuid()).WillOnce(Return("override"));
@@ -308,8 +297,7 @@ TEST_F(ConnectionManagerUtilityTest, OverrideRequestIdForExternalRequests) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
-  auto external_ip = std::make_shared<Network::Address::Ipv4Instance>("50.0.0.1");
-  ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRef(external_ip));
+  connection_.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("50.0.0.1");
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
 
   route_config_.internal_only_headers_.push_back(LowerCaseString("custom_header"));
@@ -341,8 +329,7 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
 }
 
 TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestDontUseRemote) {
-  auto external_ip = std::make_shared<Network::Address::Ipv4Instance>("60.0.0.1");
-  ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRef(external_ip));
+  connection_.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("60.0.0.1");
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(false));
 
   TestHeaderMapImpl headers{{"x-envoy-external-address", "60.0.0.1"},
@@ -355,8 +342,7 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestDontUseRemote
 }
 
 TEST_F(ConnectionManagerUtilityTest, ExternalAddressInternalRequestUseRemote) {
-  auto local_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
-  ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRef(local_remote_address));
+  connection_.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
 
   TestHeaderMapImpl headers{{"x-envoy-external-address", "60.0.0.1"},

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -52,7 +52,8 @@ TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWhenNotLocalHostRemoteAddre
   auto not_local_host_remote_address =
       std::make_shared<Network::Address::Ipv4Instance>("12.12.12.12");
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(Return(not_local_host_remote_address));
+  EXPECT_CALL(connection_, remoteAddress())
+      .WillRepeatedly(ReturnRef(not_local_host_remote_address));
 
   TestHeaderMapImpl headers{};
   ConnectionManagerUtility::mutateRequestHeaders(headers, Protocol::Http2, connection_, config_,
@@ -67,7 +68,7 @@ TEST_F(ConnectionManagerUtilityTest, UseLocalAddressWhenLocalHostRemoteAddress) 
   auto local_host_remote_address = std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1");
   Network::Address::Ipv4Instance local_address("10.3.2.1");
 
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(Return(local_host_remote_address));
+  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(local_host_remote_address));
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
   EXPECT_CALL(config_, localAddress()).WillRepeatedly(ReturnRef(local_address));
 
@@ -83,7 +84,7 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentDontSet) {
   auto internal_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
 
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(Return(internal_remote_address));
+  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
 
   TestHeaderMapImpl headers{{"user-agent", "foo"}};
   ConnectionManagerUtility::mutateRequestHeaders(headers, Protocol::Http2, connection_, config_,
@@ -99,7 +100,7 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentSetWhenIncomingEmpty) {
   auto internal_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
 
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(Return(internal_remote_address));
+  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
 
   user_agent_.value("bar");
   TestHeaderMapImpl headers{{"user-agent", ""}, {"x-envoy-downstream-service-cluster", "foo"}};
@@ -150,7 +151,7 @@ TEST_F(ConnectionManagerUtilityTest, EdgeRequestRegenerateRequestIdAndWipeDownst
   auto external_remote_address = std::make_shared<Network::Address::Ipv4Instance>("34.0.0.1");
 
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
-  ON_CALL(connection_, remoteAddress()).WillByDefault(Return(external_remote_address));
+  ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRef(external_remote_address));
   ON_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
       .WillByDefault(Return(true));
 
@@ -225,7 +226,7 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentSetIncomingUserAgent) {
   auto internal_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
 
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(Return(internal_remote_address));
+  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
 
   user_agent_.value("bar");
   TestHeaderMapImpl headers{{"user-agent", "foo"}, {"x-envoy-downstream-service-cluster", "foo"}};
@@ -243,7 +244,7 @@ TEST_F(ConnectionManagerUtilityTest, UserAgentSetNoIncomingUserAgent) {
   auto internal_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
 
   EXPECT_CALL(config_, useRemoteAddress()).WillRepeatedly(Return(true));
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(Return(internal_remote_address));
+  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(internal_remote_address));
 
   user_agent_.value("bar");
   TestHeaderMapImpl headers{};
@@ -283,7 +284,7 @@ TEST_F(ConnectionManagerUtilityTest, RequestIdGeneratedWhenItsNotPresent) {
 TEST_F(ConnectionManagerUtilityTest, DoNotOverrideRequestIdIfPresentWhenInternalRequest) {
   auto local_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
   EXPECT_CALL(config_, useRemoteAddress()).WillOnce(Return(true));
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(Return(local_remote_address));
+  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(local_remote_address));
 
   TestHeaderMapImpl headers{{"x-request-id", "original_request_id"}};
   EXPECT_CALL(random_, uuid()).Times(0);
@@ -295,7 +296,7 @@ TEST_F(ConnectionManagerUtilityTest, DoNotOverrideRequestIdIfPresentWhenInternal
 
 TEST_F(ConnectionManagerUtilityTest, OverrideRequestIdForExternalRequests) {
   auto external_ip = std::make_shared<Network::Address::Ipv4Instance>("134.2.2.11");
-  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(Return(external_ip));
+  EXPECT_CALL(connection_, remoteAddress()).WillRepeatedly(ReturnRef(external_ip));
   TestHeaderMapImpl headers{{"x-request-id", "original"}};
 
   EXPECT_CALL(random_, uuid()).WillOnce(Return("override"));
@@ -308,7 +309,7 @@ TEST_F(ConnectionManagerUtilityTest, OverrideRequestIdForExternalRequests) {
 
 TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
   auto external_ip = std::make_shared<Network::Address::Ipv4Instance>("50.0.0.1");
-  ON_CALL(connection_, remoteAddress()).WillByDefault(Return(external_ip));
+  ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRef(external_ip));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
 
   route_config_.internal_only_headers_.push_back(LowerCaseString("custom_header"));
@@ -341,7 +342,7 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
 
 TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestDontUseRemote) {
   auto external_ip = std::make_shared<Network::Address::Ipv4Instance>("60.0.0.1");
-  ON_CALL(connection_, remoteAddress()).WillByDefault(Return(external_ip));
+  ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRef(external_ip));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(false));
 
   TestHeaderMapImpl headers{{"x-envoy-external-address", "60.0.0.1"},
@@ -355,7 +356,7 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestDontUseRemote
 
 TEST_F(ConnectionManagerUtilityTest, ExternalAddressInternalRequestUseRemote) {
   auto local_remote_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");
-  ON_CALL(connection_, remoteAddress()).WillByDefault(Return(local_remote_address));
+  ON_CALL(connection_, remoteAddress()).WillByDefault(ReturnRef(local_remote_address));
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
 
   TestHeaderMapImpl headers{{"x-envoy-external-address", "60.0.0.1"},

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -544,7 +544,7 @@ TEST_P(ConnectionImplTest, BindTest) {
   }
   setUpBasicConnection();
   connect();
-  EXPECT_EQ(address_string, server_connection_->remoteAddress().ip()->addressAsString());
+  EXPECT_EQ(address_string, server_connection_->remoteAddress()->ip()->addressAsString());
 
   disconnect(true);
 }

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -126,7 +126,7 @@ TEST_P(ListenerImplTest, NormalRedirect) {
   EXPECT_CALL(listenerDst, newConnection(_, _, _, _));
   EXPECT_CALL(listener_callbacks2, onNewConnection_(_))
       .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
-        EXPECT_EQ(*alt_address_, conn->localAddress());
+        EXPECT_EQ(*alt_address_, *conn->localAddress());
         client_connection->close(ConnectionCloseType::NoFlush);
         conn->close(ConnectionCloseType::NoFlush);
         dispatcher.exit();
@@ -167,8 +167,8 @@ TEST_P(ListenerImplTest, FallbackToWildcardListener) {
   EXPECT_CALL(listenerDst, newConnection(_, _, _, _));
   EXPECT_CALL(listener_callbacks2, onNewConnection_(_))
       .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
-        EXPECT_EQ(*alt_address_, conn->localAddress());
-        EXPECT_FALSE(*socketDst.localAddress() == conn->localAddress());
+        EXPECT_EQ(*alt_address_, *conn->localAddress());
+        EXPECT_FALSE(*socketDst.localAddress() == *conn->localAddress());
         client_connection->close(ConnectionCloseType::NoFlush);
         conn->close(ConnectionCloseType::NoFlush);
         dispatcher.exit();
@@ -205,7 +205,7 @@ TEST_P(ListenerImplTest, WildcardListenerWithOriginalDst) {
   EXPECT_CALL(listener, newConnection(_, _, _, _));
   EXPECT_CALL(listener_callbacks, onNewConnection_(_))
       .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
-        EXPECT_EQ(conn->localAddress(), *alt_address_);
+        EXPECT_EQ(*conn->localAddress(), *alt_address_);
         client_connection->close(ConnectionCloseType::NoFlush);
         conn->close(ConnectionCloseType::NoFlush);
         dispatcher.exit();
@@ -242,7 +242,7 @@ TEST_P(ListenerImplTest, WildcardListenerNoOriginalDst) {
   EXPECT_CALL(listener, newConnection(_, _, _, _));
   EXPECT_CALL(listener_callbacks, onNewConnection_(_))
       .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
-        EXPECT_EQ(conn->localAddress(), *local_dst_address);
+        EXPECT_EQ(*conn->localAddress(), *local_dst_address);
         client_connection->close(ConnectionCloseType::NoFlush);
         conn->close(ConnectionCloseType::NoFlush);
         dispatcher.exit();
@@ -282,7 +282,7 @@ TEST_P(ListenerImplTest, UseActualDst) {
   EXPECT_CALL(listenerDst, newConnection(_, _, _, _)).Times(0);
   EXPECT_CALL(listener_callbacks1, onNewConnection_(_))
       .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
-        EXPECT_EQ(conn->localAddress(), *socket.localAddress());
+        EXPECT_EQ(*conn->localAddress(), *socket.localAddress());
         client_connection->close(ConnectionCloseType::NoFlush);
         conn->close(ConnectionCloseType::NoFlush);
         dispatcher.exit();
@@ -318,7 +318,7 @@ TEST_P(ListenerImplTest, WildcardListenerUseActualDst) {
   EXPECT_CALL(listener, newConnection(_, _, _, _)).Times(1);
   EXPECT_CALL(listener_callbacks, onNewConnection_(_))
       .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
-        EXPECT_EQ(conn->localAddress(), *local_dst_address);
+        EXPECT_EQ(*conn->localAddress(), *local_dst_address);
         client_connection->close(ConnectionCloseType::NoFlush);
         conn->close(ConnectionCloseType::NoFlush);
         dispatcher.exit();

--- a/test/common/network/proxy_protocol_test.cc
+++ b/test/common/network/proxy_protocol_test.cc
@@ -110,7 +110,7 @@ TEST_P(ProxyProtocolTest, Basic) {
   EXPECT_CALL(*read_filter_, onNewConnection());
   EXPECT_CALL(*read_filter_, onData(_))
       .WillOnce(Invoke([&](Buffer::Instance& buffer) -> FilterStatus {
-        EXPECT_EQ(server_connection_->remoteAddress().ip()->addressAsString(), "1.2.3.4");
+        EXPECT_EQ(server_connection_->remoteAddress()->ip()->addressAsString(), "1.2.3.4");
 
         EXPECT_EQ(TestUtility::bufferToString(buffer), "more data");
         buffer.drain(9);
@@ -129,7 +129,7 @@ TEST_P(ProxyProtocolTest, BasicV6) {
   EXPECT_CALL(*read_filter_, onNewConnection());
   EXPECT_CALL(*read_filter_, onData(_))
       .WillOnce(Invoke([&](Buffer::Instance& buffer) -> FilterStatus {
-        EXPECT_EQ(server_connection_->remoteAddress().ip()->addressAsString(), "1:2:3::4");
+        EXPECT_EQ(server_connection_->remoteAddress()->ip()->addressAsString(), "1:2:3::4");
 
         EXPECT_EQ(TestUtility::bufferToString(buffer), "more data");
         buffer.drain(9);
@@ -153,7 +153,7 @@ TEST_P(ProxyProtocolTest, Fragmented) {
 
   disconnect();
 
-  EXPECT_EQ(server_connection_->remoteAddress().ip()->addressAsString(), "254.254.254.254");
+  EXPECT_EQ(server_connection_->remoteAddress()->ip()->addressAsString(), "254.254.254.254");
 }
 
 TEST_P(ProxyProtocolTest, PartialRead) {
@@ -172,7 +172,7 @@ TEST_P(ProxyProtocolTest, PartialRead) {
 
   disconnect();
 
-  EXPECT_EQ(server_connection_->remoteAddress().ip()->addressAsString(), "254.254.254.254");
+  EXPECT_EQ(server_connection_->remoteAddress()->ip()->addressAsString(), "254.254.254.254");
 }
 
 TEST_P(ProxyProtocolTest, MalformedProxyLine) {
@@ -352,8 +352,8 @@ TEST_P(WildcardProxyProtocolTest, Basic) {
   EXPECT_CALL(*read_filter_, onNewConnection());
   EXPECT_CALL(*read_filter_, onData(_))
       .WillOnce(Invoke([&](Buffer::Instance& buffer) -> FilterStatus {
-        EXPECT_EQ(server_connection_->remoteAddress().asString(), "1.2.3.4:65535");
-        EXPECT_EQ(server_connection_->localAddress().asString(), "254.254.254.254:1234");
+        EXPECT_EQ(server_connection_->remoteAddress()->asString(), "1.2.3.4:65535");
+        EXPECT_EQ(server_connection_->localAddress()->asString(), "254.254.254.254:1234");
 
         EXPECT_EQ(TestUtility::bufferToString(buffer), "more data");
         buffer.drain(9);
@@ -370,8 +370,8 @@ TEST_P(WildcardProxyProtocolTest, BasicV6) {
   EXPECT_CALL(*read_filter_, onNewConnection());
   EXPECT_CALL(*read_filter_, onData(_))
       .WillOnce(Invoke([&](Buffer::Instance& buffer) -> FilterStatus {
-        EXPECT_EQ(server_connection_->remoteAddress().asString(), "[1:2:3::4]:65535");
-        EXPECT_EQ(server_connection_->localAddress().asString(), "[5:6::7:8]:1234");
+        EXPECT_EQ(server_connection_->remoteAddress()->asString(), "[1:2:3::4]:65535");
+        EXPECT_EQ(server_connection_->localAddress()->asString(), "[5:6::7:8]:1234");
 
         EXPECT_EQ(TestUtility::bufferToString(buffer), "more data");
         buffer.drain(9);

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -68,8 +68,9 @@ public:
 
     ON_CALL(*cm_.conn_pool_.host_, address()).WillByDefault(Return(host_address_));
     ON_CALL(*cm_.conn_pool_.host_, locality()).WillByDefault(ReturnRef(upstream_locality_));
-    ON_CALL(router_.downstream_connection_, localAddress()).WillByDefault(Return(host_address_));
-    ON_CALL(router_.downstream_connection_, remoteAddress()).WillByDefault(Return(remote_address_));
+    ON_CALL(router_.downstream_connection_, localAddress()).WillByDefault(ReturnRef(host_address_));
+    ON_CALL(router_.downstream_connection_, remoteAddress())
+        .WillByDefault(ReturnRef(remote_address_));
   }
 
   void expectResponseTimerCreate() {

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -68,9 +68,9 @@ public:
 
     ON_CALL(*cm_.conn_pool_.host_, address()).WillByDefault(Return(host_address_));
     ON_CALL(*cm_.conn_pool_.host_, locality()).WillByDefault(ReturnRef(upstream_locality_));
-    ON_CALL(router_.downstream_connection_, localAddress()).WillByDefault(ReturnRef(host_address_));
-    ON_CALL(router_.downstream_connection_, remoteAddress())
-        .WillByDefault(ReturnRef(remote_address_));
+    router_.downstream_connection_.local_address_ = host_address_;
+    router_.downstream_connection_.remote_address_ =
+        Network::Utility::parseInternetAddressAndPort("1.2.3.4:80");
   }
 
   void expectResponseTimerCreate() {
@@ -115,8 +115,6 @@ public:
   Event::MockTimer* per_try_timeout_{};
   Network::Address::InstanceConstSharedPtr host_address_{
       Network::Utility::resolveUrl("tcp://10.0.0.5:9211")};
-  Network::Address::InstanceConstSharedPtr remote_address_{
-      Network::Utility::parseInternetAddressAndPort("1.2.3.4:80")};
 };
 
 class RouterTest : public RouterTestBase {

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -68,10 +68,8 @@ public:
 
     ON_CALL(*cm_.conn_pool_.host_, address()).WillByDefault(Return(host_address_));
     ON_CALL(*cm_.conn_pool_.host_, locality()).WillByDefault(ReturnRef(upstream_locality_));
-    ON_CALL(router_.downstream_connection_, localAddress())
-        .WillByDefault(ReturnRef(*host_address_));
-    ON_CALL(router_.downstream_connection_, remoteAddress())
-        .WillByDefault(ReturnRef(*remote_address_));
+    ON_CALL(router_.downstream_connection_, localAddress()).WillByDefault(Return(host_address_));
+    ON_CALL(router_.downstream_connection_, remoteAddress()).WillByDefault(Return(remote_address_));
   }
 
   void expectResponseTimerCreate() {

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -96,9 +96,10 @@ public:
         .WillByDefault(Return(host_address_));
     ON_CALL(*context_.cluster_manager_.conn_pool_.host_, locality())
         .WillByDefault(ReturnRef(upstream_locality_));
-    ON_CALL(router_->downstream_connection_, localAddress()).WillByDefault(Return(host_address_));
+    ON_CALL(router_->downstream_connection_, localAddress())
+        .WillByDefault(ReturnRef(host_address_));
     ON_CALL(router_->downstream_connection_, remoteAddress())
-        .WillByDefault(Return(remote_address_));
+        .WillByDefault(ReturnRef(remote_address_));
   }
 
   void expectResponseTimerCreate() {

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -96,10 +96,9 @@ public:
         .WillByDefault(Return(host_address_));
     ON_CALL(*context_.cluster_manager_.conn_pool_.host_, locality())
         .WillByDefault(ReturnRef(upstream_locality_));
-    ON_CALL(router_->downstream_connection_, localAddress())
-        .WillByDefault(ReturnRef(host_address_));
-    ON_CALL(router_->downstream_connection_, remoteAddress())
-        .WillByDefault(ReturnRef(remote_address_));
+    router_->downstream_connection_.local_address_ = host_address_;
+    router_->downstream_connection_.remote_address_ =
+        Network::Utility::parseInternetAddressAndPort("1.2.3.4:80");
   }
 
   void expectResponseTimerCreate() {
@@ -200,8 +199,6 @@ public:
   envoy::api::v2::Locality upstream_locality_;
   Network::Address::InstanceConstSharedPtr host_address_{
       Network::Utility::resolveUrl("tcp://10.0.0.5:9211")};
-  Network::Address::InstanceConstSharedPtr remote_address_{
-      Network::Utility::parseInternetAddressAndPort("1.2.3.4:80")};
   Event::MockTimer* response_timeout_{};
   Event::MockTimer* per_try_timeout_{};
 

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -96,10 +96,9 @@ public:
         .WillByDefault(Return(host_address_));
     ON_CALL(*context_.cluster_manager_.conn_pool_.host_, locality())
         .WillByDefault(ReturnRef(upstream_locality_));
-    ON_CALL(router_->downstream_connection_, localAddress())
-        .WillByDefault(ReturnRef(*host_address_));
+    ON_CALL(router_->downstream_connection_, localAddress()).WillByDefault(Return(host_address_));
     ON_CALL(router_->downstream_connection_, remoteAddress())
-        .WillByDefault(ReturnRef(*remote_address_));
+        .WillByDefault(Return(remote_address_));
   }
 
   void expectResponseTimerCreate() {

--- a/test/common/ssl/ssl_socket_test.cc
+++ b/test/common/ssl/ssl_socket_test.cc
@@ -1798,7 +1798,7 @@ TEST_P(SslReadBufferLimitTest, TestBind) {
       .WillOnce(Invoke([&](Network::ConnectionEvent) -> void { dispatcher_->exit(); }));
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 
-  EXPECT_EQ(address_string, server_connection_->remoteAddress().ip()->addressAsString());
+  EXPECT_EQ(address_string, server_connection_->remoteAddress()->ip()->addressAsString());
 
   disconnect();
 }

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -24,6 +24,7 @@ using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
+using testing::ReturnRefOfCopy;
 using testing::SaveArg;
 using testing::_;
 
@@ -169,7 +170,8 @@ TEST_F(OriginalDstClusterTest, NoContext) {
     NiceMock<Network::MockConnection> connection;
     TestLoadBalancerContext lb_context(&connection);
     EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(Return(std::make_shared<Network::Address::PipeInstance>("unix://foo")));
+        .WillRepeatedly(
+            ReturnRefOfCopy(std::make_shared<Network::Address::PipeInstance>("unix://foo")));
     EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
 
     OriginalDstCluster::LoadBalancer lb(cluster_->prioritySet(), cluster_);
@@ -206,7 +208,7 @@ TEST_F(OriginalDstClusterTest, Membership) {
   NiceMock<Network::MockConnection> connection;
   TestLoadBalancerContext lb_context(&connection);
   auto local_address = std::make_shared<Network::Address::Ipv4Instance>("10.10.11.11");
-  EXPECT_CALL(connection, localAddress()).WillRepeatedly(Return(local_address));
+  EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
   EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
 
   OriginalDstCluster::LoadBalancer lb(cluster_->prioritySet(), cluster_);
@@ -294,13 +296,13 @@ TEST_F(OriginalDstClusterTest, Membership2) {
   NiceMock<Network::MockConnection> connection1;
   TestLoadBalancerContext lb_context1(&connection1);
   auto local_address1 = std::make_shared<Network::Address::Ipv4Instance>("10.10.11.11");
-  EXPECT_CALL(connection1, localAddress()).WillRepeatedly(Return(local_address1));
+  EXPECT_CALL(connection1, localAddress()).WillRepeatedly(ReturnRef(local_address1));
   EXPECT_CALL(connection1, usingOriginalDst()).WillRepeatedly(Return(true));
 
   NiceMock<Network::MockConnection> connection2;
   TestLoadBalancerContext lb_context2(&connection2);
   auto local_address2 = std::make_shared<Network::Address::Ipv4Instance>("10.10.11.12");
-  EXPECT_CALL(connection2, localAddress()).WillRepeatedly(Return(local_address2));
+  EXPECT_CALL(connection2, localAddress()).WillRepeatedly(ReturnRef(local_address2));
   EXPECT_CALL(connection2, usingOriginalDst()).WillRepeatedly(Return(true));
 
   OriginalDstCluster::LoadBalancer lb(cluster_->prioritySet(), cluster_);
@@ -386,7 +388,7 @@ TEST_F(OriginalDstClusterTest, Connection) {
   NiceMock<Network::MockConnection> connection;
   TestLoadBalancerContext lb_context(&connection);
   auto local_address = std::make_shared<Network::Address::Ipv6Instance>("FD00::1");
-  EXPECT_CALL(connection, localAddress()).WillRepeatedly(Return(local_address));
+  EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
   EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
 
   OriginalDstCluster::LoadBalancer lb(cluster_->prioritySet(), cluster_);
@@ -436,7 +438,7 @@ TEST_F(OriginalDstClusterTest, MultipleClusters) {
   NiceMock<Network::MockConnection> connection;
   TestLoadBalancerContext lb_context(&connection);
   auto local_address = std::make_shared<Network::Address::Ipv6Instance>("FD00::1");
-  EXPECT_CALL(connection, localAddress()).WillRepeatedly(Return(local_address));
+  EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
   EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
 
   OriginalDstCluster::LoadBalancer lb1(cluster_->prioritySet(), cluster_);

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -24,7 +24,6 @@ using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
-using testing::ReturnRefOfCopy;
 using testing::SaveArg;
 using testing::_;
 
@@ -169,9 +168,7 @@ TEST_F(OriginalDstClusterTest, NoContext) {
   {
     NiceMock<Network::MockConnection> connection;
     TestLoadBalancerContext lb_context(&connection);
-    EXPECT_CALL(connection, localAddress())
-        .WillRepeatedly(
-            ReturnRefOfCopy(std::make_shared<Network::Address::PipeInstance>("unix://foo")));
+    connection.local_address_ = std::make_shared<Network::Address::PipeInstance>("unix://foo");
     EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
 
     OriginalDstCluster::LoadBalancer lb(cluster_->prioritySet(), cluster_);
@@ -207,8 +204,7 @@ TEST_F(OriginalDstClusterTest, Membership) {
 
   NiceMock<Network::MockConnection> connection;
   TestLoadBalancerContext lb_context(&connection);
-  auto local_address = std::make_shared<Network::Address::Ipv4Instance>("10.10.11.11");
-  EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+  connection.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.10.11.11");
   EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
 
   OriginalDstCluster::LoadBalancer lb(cluster_->prioritySet(), cluster_);
@@ -219,7 +215,7 @@ TEST_F(OriginalDstClusterTest, Membership) {
   auto cluster_hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
 
   ASSERT_NE(host, nullptr);
-  EXPECT_EQ(*local_address, *host->address());
+  EXPECT_EQ(*connection.local_address_, *host->address());
 
   EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -228,7 +224,7 @@ TEST_F(OriginalDstClusterTest, Membership) {
             cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
 
   EXPECT_EQ(host, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]);
-  EXPECT_EQ(*local_address,
+  EXPECT_EQ(*connection.local_address_,
             *cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]->address());
 
   // Same host is returned on the 2nd call
@@ -295,14 +291,12 @@ TEST_F(OriginalDstClusterTest, Membership2) {
 
   NiceMock<Network::MockConnection> connection1;
   TestLoadBalancerContext lb_context1(&connection1);
-  auto local_address1 = std::make_shared<Network::Address::Ipv4Instance>("10.10.11.11");
-  EXPECT_CALL(connection1, localAddress()).WillRepeatedly(ReturnRef(local_address1));
+  connection1.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.10.11.11");
   EXPECT_CALL(connection1, usingOriginalDst()).WillRepeatedly(Return(true));
 
   NiceMock<Network::MockConnection> connection2;
   TestLoadBalancerContext lb_context2(&connection2);
-  auto local_address2 = std::make_shared<Network::Address::Ipv4Instance>("10.10.11.12");
-  EXPECT_CALL(connection2, localAddress()).WillRepeatedly(ReturnRef(local_address2));
+  connection2.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.10.11.12");
   EXPECT_CALL(connection2, usingOriginalDst()).WillRepeatedly(Return(true));
 
   OriginalDstCluster::LoadBalancer lb(cluster_->prioritySet(), cluster_);
@@ -313,14 +307,14 @@ TEST_F(OriginalDstClusterTest, Membership2) {
   HostConstSharedPtr host1 = lb.chooseHost(&lb_context1);
   post_cb();
   ASSERT_NE(host1, nullptr);
-  EXPECT_EQ(*local_address1, *host1->address());
+  EXPECT_EQ(*connection1.local_address_, *host1->address());
 
   EXPECT_CALL(membership_updated_, ready());
   EXPECT_CALL(dispatcher_, post(_)).WillOnce(SaveArg<0>(&post_cb));
   HostConstSharedPtr host2 = lb.chooseHost(&lb_context2);
   post_cb();
   ASSERT_NE(host2, nullptr);
-  EXPECT_EQ(*local_address2, *host2->address());
+  EXPECT_EQ(*connection2.local_address_, *host2->address());
 
   EXPECT_EQ(2UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(2UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -329,11 +323,11 @@ TEST_F(OriginalDstClusterTest, Membership2) {
             cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
 
   EXPECT_EQ(host1, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]);
-  EXPECT_EQ(*local_address1,
+  EXPECT_EQ(*connection1.local_address_,
             *cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]->address());
 
   EXPECT_EQ(host2, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[1]);
-  EXPECT_EQ(*local_address2,
+  EXPECT_EQ(*connection2.local_address_,
             *cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[1]->address());
 
   auto cluster_hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
@@ -387,8 +381,7 @@ TEST_F(OriginalDstClusterTest, Connection) {
   // Connection to the host is made to the downstream connection's local address.
   NiceMock<Network::MockConnection> connection;
   TestLoadBalancerContext lb_context(&connection);
-  auto local_address = std::make_shared<Network::Address::Ipv6Instance>("FD00::1");
-  EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+  connection.local_address_ = std::make_shared<Network::Address::Ipv6Instance>("FD00::1");
   EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
 
   OriginalDstCluster::LoadBalancer lb(cluster_->prioritySet(), cluster_);
@@ -397,9 +390,9 @@ TEST_F(OriginalDstClusterTest, Connection) {
   HostConstSharedPtr host = lb.chooseHost(&lb_context);
   post_cb();
   ASSERT_NE(host, nullptr);
-  EXPECT_EQ(*local_address, *host->address());
+  EXPECT_EQ(*connection.local_address_, *host->address());
 
-  EXPECT_CALL(dispatcher_, createClientConnection_(PointeesEq(local_address), _))
+  EXPECT_CALL(dispatcher_, createClientConnection_(PointeesEq(connection.local_address_), _))
       .WillOnce(Return(new NiceMock<Network::MockClientConnection>()));
   host->createConnection(dispatcher_);
 }
@@ -437,8 +430,7 @@ TEST_F(OriginalDstClusterTest, MultipleClusters) {
   // Connection to the host is made to the downstream connection's local address.
   NiceMock<Network::MockConnection> connection;
   TestLoadBalancerContext lb_context(&connection);
-  auto local_address = std::make_shared<Network::Address::Ipv6Instance>("FD00::1");
-  EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+  connection.local_address_ = std::make_shared<Network::Address::Ipv6Instance>("FD00::1");
   EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
 
   OriginalDstCluster::LoadBalancer lb1(cluster_->prioritySet(), cluster_);
@@ -448,7 +440,7 @@ TEST_F(OriginalDstClusterTest, MultipleClusters) {
   HostConstSharedPtr host = lb1.chooseHost(&lb_context);
   post_cb();
   ASSERT_NE(host, nullptr);
-  EXPECT_EQ(*local_address, *host->address());
+  EXPECT_EQ(*connection.local_address_, *host->address());
 
   EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   // Check that lb2 also gets updated

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -168,8 +168,8 @@ TEST_F(OriginalDstClusterTest, NoContext) {
   {
     NiceMock<Network::MockConnection> connection;
     TestLoadBalancerContext lb_context(&connection);
-    Network::Address::PipeInstance local_address("unix://foo");
-    EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+    EXPECT_CALL(connection, localAddress())
+        .WillRepeatedly(Return(std::make_shared<Network::Address::PipeInstance>("unix://foo")));
     EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
 
     OriginalDstCluster::LoadBalancer lb(cluster_->prioritySet(), cluster_);
@@ -205,8 +205,8 @@ TEST_F(OriginalDstClusterTest, Membership) {
 
   NiceMock<Network::MockConnection> connection;
   TestLoadBalancerContext lb_context(&connection);
-  Network::Address::Ipv4Instance local_address("10.10.11.11");
-  EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+  auto local_address = std::make_shared<Network::Address::Ipv4Instance>("10.10.11.11");
+  EXPECT_CALL(connection, localAddress()).WillRepeatedly(Return(local_address));
   EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
 
   OriginalDstCluster::LoadBalancer lb(cluster_->prioritySet(), cluster_);
@@ -217,7 +217,7 @@ TEST_F(OriginalDstClusterTest, Membership) {
   auto cluster_hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
 
   ASSERT_NE(host, nullptr);
-  EXPECT_EQ(local_address, *host->address());
+  EXPECT_EQ(*local_address, *host->address());
 
   EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -226,7 +226,7 @@ TEST_F(OriginalDstClusterTest, Membership) {
             cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
 
   EXPECT_EQ(host, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]);
-  EXPECT_EQ(local_address,
+  EXPECT_EQ(*local_address,
             *cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]->address());
 
   // Same host is returned on the 2nd call
@@ -293,14 +293,14 @@ TEST_F(OriginalDstClusterTest, Membership2) {
 
   NiceMock<Network::MockConnection> connection1;
   TestLoadBalancerContext lb_context1(&connection1);
-  Network::Address::Ipv4Instance local_address1("10.10.11.11");
-  EXPECT_CALL(connection1, localAddress()).WillRepeatedly(ReturnRef(local_address1));
+  auto local_address1 = std::make_shared<Network::Address::Ipv4Instance>("10.10.11.11");
+  EXPECT_CALL(connection1, localAddress()).WillRepeatedly(Return(local_address1));
   EXPECT_CALL(connection1, usingOriginalDst()).WillRepeatedly(Return(true));
 
   NiceMock<Network::MockConnection> connection2;
   TestLoadBalancerContext lb_context2(&connection2);
-  Network::Address::Ipv4Instance local_address2("10.10.11.12");
-  EXPECT_CALL(connection2, localAddress()).WillRepeatedly(ReturnRef(local_address2));
+  auto local_address2 = std::make_shared<Network::Address::Ipv4Instance>("10.10.11.12");
+  EXPECT_CALL(connection2, localAddress()).WillRepeatedly(Return(local_address2));
   EXPECT_CALL(connection2, usingOriginalDst()).WillRepeatedly(Return(true));
 
   OriginalDstCluster::LoadBalancer lb(cluster_->prioritySet(), cluster_);
@@ -311,14 +311,14 @@ TEST_F(OriginalDstClusterTest, Membership2) {
   HostConstSharedPtr host1 = lb.chooseHost(&lb_context1);
   post_cb();
   ASSERT_NE(host1, nullptr);
-  EXPECT_EQ(local_address1, *host1->address());
+  EXPECT_EQ(*local_address1, *host1->address());
 
   EXPECT_CALL(membership_updated_, ready());
   EXPECT_CALL(dispatcher_, post(_)).WillOnce(SaveArg<0>(&post_cb));
   HostConstSharedPtr host2 = lb.chooseHost(&lb_context2);
   post_cb();
   ASSERT_NE(host2, nullptr);
-  EXPECT_EQ(local_address2, *host2->address());
+  EXPECT_EQ(*local_address2, *host2->address());
 
   EXPECT_EQ(2UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(2UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -327,11 +327,11 @@ TEST_F(OriginalDstClusterTest, Membership2) {
             cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
 
   EXPECT_EQ(host1, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]);
-  EXPECT_EQ(local_address1,
+  EXPECT_EQ(*local_address1,
             *cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]->address());
 
   EXPECT_EQ(host2, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[1]);
-  EXPECT_EQ(local_address2,
+  EXPECT_EQ(*local_address2,
             *cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[1]->address());
 
   auto cluster_hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
@@ -385,8 +385,8 @@ TEST_F(OriginalDstClusterTest, Connection) {
   // Connection to the host is made to the downstream connection's local address.
   NiceMock<Network::MockConnection> connection;
   TestLoadBalancerContext lb_context(&connection);
-  Network::Address::Ipv6Instance local_address("FD00::1");
-  EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+  auto local_address = std::make_shared<Network::Address::Ipv6Instance>("FD00::1");
+  EXPECT_CALL(connection, localAddress()).WillRepeatedly(Return(local_address));
   EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
 
   OriginalDstCluster::LoadBalancer lb(cluster_->prioritySet(), cluster_);
@@ -395,9 +395,9 @@ TEST_F(OriginalDstClusterTest, Connection) {
   HostConstSharedPtr host = lb.chooseHost(&lb_context);
   post_cb();
   ASSERT_NE(host, nullptr);
-  EXPECT_EQ(local_address, *host->address());
+  EXPECT_EQ(*local_address, *host->address());
 
-  EXPECT_CALL(dispatcher_, createClientConnection_(PointeesEq(&local_address), _))
+  EXPECT_CALL(dispatcher_, createClientConnection_(PointeesEq(local_address), _))
       .WillOnce(Return(new NiceMock<Network::MockClientConnection>()));
   host->createConnection(dispatcher_);
 }
@@ -435,8 +435,8 @@ TEST_F(OriginalDstClusterTest, MultipleClusters) {
   // Connection to the host is made to the downstream connection's local address.
   NiceMock<Network::MockConnection> connection;
   TestLoadBalancerContext lb_context(&connection);
-  Network::Address::Ipv6Instance local_address("FD00::1");
-  EXPECT_CALL(connection, localAddress()).WillRepeatedly(ReturnRef(local_address));
+  auto local_address = std::make_shared<Network::Address::Ipv6Instance>("FD00::1");
+  EXPECT_CALL(connection, localAddress()).WillRepeatedly(Return(local_address));
   EXPECT_CALL(connection, usingOriginalDst()).WillRepeatedly(Return(true));
 
   OriginalDstCluster::LoadBalancer lb1(cluster_->prioritySet(), cluster_);
@@ -446,7 +446,7 @@ TEST_F(OriginalDstClusterTest, MultipleClusters) {
   HostConstSharedPtr host = lb1.chooseHost(&lb_context);
   post_cb();
   ASSERT_NE(host, nullptr);
-  EXPECT_EQ(local_address, *host->address());
+  EXPECT_EQ(*local_address, *host->address());
 
   EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   // Check that lb2 also gets updated

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -55,7 +55,7 @@ void FakeStream::encodeHeaders(const Http::HeaderMapImpl& headers, bool end_stre
       new Http::HeaderMapImpl(static_cast<const Http::HeaderMap&>(headers)));
   if (add_served_by_header_) {
     headers_copy->addCopy(Http::LowerCaseString("x-served-by"),
-                          parent_.connection().localAddress().asString());
+                          parent_.connection().localAddress()->asString());
   }
   parent_.connection().dispatcher().post([this, headers_copy, end_stream]() -> void {
     encoder_.encodeHeaders(*headers_copy, end_stream);

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -291,7 +291,7 @@ TEST_P(IntegrationTest, TestBind) {
 
   fake_upstream_connection_ = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
   std::string address =
-      fake_upstream_connection_->connection().remoteAddress().ip()->addressAsString();
+      fake_upstream_connection_->connection().remoteAddress()->ip()->addressAsString();
   EXPECT_EQ(address, address_string);
   upstream_request_ = fake_upstream_connection_->waitForNewStream(*dispatcher_);
   upstream_request_->waitForEndStream(*dispatcher_);

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -74,8 +74,8 @@ template <class T> static void initializeMockConnection(T& connection) {
   ON_CALL(connection, close(_)).WillByDefault(Invoke([&connection](ConnectionCloseType) -> void {
     connection.raiseEvent(Network::ConnectionEvent::LocalClose);
   }));
-  ON_CALL(connection, remoteAddress()).WillByDefault(ReturnPointee(connection.remote_address_));
-  ON_CALL(connection, localAddress()).WillByDefault(ReturnPointee(connection.local_address_));
+  ON_CALL(connection, remoteAddress()).WillByDefault(ReturnPointee(&connection.remote_address_));
+  ON_CALL(connection, localAddress()).WillByDefault(ReturnPointee(&connection.local_address_));
   ON_CALL(connection, id()).WillByDefault(Return(connection.next_id_));
   ON_CALL(connection, state()).WillByDefault(ReturnPointee(&connection.state_));
 

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -74,8 +74,8 @@ template <class T> static void initializeMockConnection(T& connection) {
   ON_CALL(connection, close(_)).WillByDefault(Invoke([&connection](ConnectionCloseType) -> void {
     connection.raiseEvent(Network::ConnectionEvent::LocalClose);
   }));
-  ON_CALL(connection, remoteAddress()).WillByDefault(ReturnPointee(&connection.remote_address_));
-  ON_CALL(connection, localAddress()).WillByDefault(ReturnPointee(&connection.local_address_));
+  ON_CALL(connection, remoteAddress()).WillByDefault(ReturnRef(connection.remote_address_));
+  ON_CALL(connection, localAddress()).WillByDefault(ReturnRef(connection.local_address_));
   ON_CALL(connection, id()).WillByDefault(Return(connection.next_id_));
   ON_CALL(connection, state()).WillByDefault(ReturnPointee(&connection.state_));
 

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -67,8 +67,8 @@ public:
   MOCK_METHOD1(readDisable, void(bool disable));
   MOCK_METHOD1(detectEarlyCloseWhenReadDisabled, void(bool));
   MOCK_CONST_METHOD0(readEnabled, bool());
-  MOCK_CONST_METHOD0(remoteAddress, const Address::Instance&());
-  MOCK_CONST_METHOD0(localAddress, const Address::Instance&());
+  MOCK_CONST_METHOD0(remoteAddress, Address::InstanceConstSharedPtr());
+  MOCK_CONST_METHOD0(localAddress, Address::InstanceConstSharedPtr());
   MOCK_METHOD1(setConnectionStats, void(const ConnectionStats& stats));
   MOCK_METHOD0(ssl, Ssl::Connection*());
   MOCK_CONST_METHOD0(ssl, const Ssl::Connection*());
@@ -104,8 +104,8 @@ public:
   MOCK_METHOD1(readDisable, void(bool disable));
   MOCK_METHOD1(detectEarlyCloseWhenReadDisabled, void(bool));
   MOCK_CONST_METHOD0(readEnabled, bool());
-  MOCK_CONST_METHOD0(remoteAddress, const Address::Instance&());
-  MOCK_CONST_METHOD0(localAddress, const Address::Instance&());
+  MOCK_CONST_METHOD0(remoteAddress, Address::InstanceConstSharedPtr());
+  MOCK_CONST_METHOD0(localAddress, Address::InstanceConstSharedPtr());
   MOCK_METHOD1(setConnectionStats, void(const ConnectionStats& stats));
   MOCK_METHOD0(ssl, Ssl::Connection*());
   MOCK_CONST_METHOD0(ssl, const Ssl::Connection*());

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -67,8 +67,8 @@ public:
   MOCK_METHOD1(readDisable, void(bool disable));
   MOCK_METHOD1(detectEarlyCloseWhenReadDisabled, void(bool));
   MOCK_CONST_METHOD0(readEnabled, bool());
-  MOCK_CONST_METHOD0(remoteAddress, Address::InstanceConstSharedPtr());
-  MOCK_CONST_METHOD0(localAddress, Address::InstanceConstSharedPtr());
+  MOCK_CONST_METHOD0(remoteAddress, const Address::InstanceConstSharedPtr&());
+  MOCK_CONST_METHOD0(localAddress, const Address::InstanceConstSharedPtr&());
   MOCK_METHOD1(setConnectionStats, void(const ConnectionStats& stats));
   MOCK_METHOD0(ssl, Ssl::Connection*());
   MOCK_CONST_METHOD0(ssl, const Ssl::Connection*());
@@ -104,8 +104,8 @@ public:
   MOCK_METHOD1(readDisable, void(bool disable));
   MOCK_METHOD1(detectEarlyCloseWhenReadDisabled, void(bool));
   MOCK_CONST_METHOD0(readEnabled, bool());
-  MOCK_CONST_METHOD0(remoteAddress, Address::InstanceConstSharedPtr());
-  MOCK_CONST_METHOD0(localAddress, Address::InstanceConstSharedPtr());
+  MOCK_CONST_METHOD0(remoteAddress, const Address::InstanceConstSharedPtr&());
+  MOCK_CONST_METHOD0(localAddress, const Address::InstanceConstSharedPtr&());
   MOCK_METHOD1(setConnectionStats, void(const ConnectionStats& stats));
   MOCK_METHOD0(ssl, Ssl::Connection*());
   MOCK_CONST_METHOD0(ssl, const Ssl::Connection*());

--- a/tools/path_fix.sh
+++ b/tools/path_fix.sh
@@ -7,14 +7,14 @@
 #
 # NOTE: This implementation is far from perfect and will need to be refined to cover all cases.
 
+set -e
+
 $* 2>&1 |
   while IFS= read -r LINE
   do
     if [[ "${LINE}" =~ [[:space:]]*([^:[:space:]]+):[[:digit:]]+:[[:digit:]]+: ]]; then
       REAL_PATH=$(readlink -f "${BASH_REMATCH[1]}")
-      if [[ $? == 0 ]]; then
-        LINE=${LINE//${BASH_REMATCH[1]}/${REAL_PATH}}
-      fi
+      LINE=${LINE//${BASH_REMATCH[1]}/${REAL_PATH}}
     fi
     echo "${LINE}"
   done

--- a/tools/path_fix.sh
+++ b/tools/path_fix.sh
@@ -7,14 +7,14 @@
 #
 # NOTE: This implementation is far from perfect and will need to be refined to cover all cases.
 
-set -e
-
 $* 2>&1 |
   while IFS= read -r LINE
   do
     if [[ "${LINE}" =~ [[:space:]]*([^:[:space:]]+):[[:digit:]]+:[[:digit:]]+: ]]; then
       REAL_PATH=$(readlink -f "${BASH_REMATCH[1]}")
-      LINE=${LINE//${BASH_REMATCH[1]}/${REAL_PATH}}
+      if [[ $? == 0 ]]; then
+        LINE=${LINE//${BASH_REMATCH[1]}/${REAL_PATH}}
+      fi
     fi
     echo "${LINE}"
   done


### PR DESCRIPTION
This is a cleanup needed for further access log work. There is no
functional change.

*Risk Level*: Low 
*Testing*: Existing tests
*Docs Changes*: N/A
*Release Notes*: N/A