### PR TITLE
Refactoring the load stats test to be more flake-proof

### DIFF
--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -14,13 +14,15 @@ class LoadStatsIntegrationTest : public HttpIntegrationTest,
 public:
   LoadStatsIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
 
-  void addEndpoint(envoy::api::v2::LocalityLbEndpoints& locality_lb_endpoints, uint32_t index) {
+  void addEndpoint(envoy::api::v2::LocalityLbEndpoints& locality_lb_endpoints, uint32_t index,
+                   uint32_t& num_endpoints) {
     auto* socket_address = locality_lb_endpoints.add_lb_endpoints()
                                ->mutable_endpoint()
                                ->mutable_address()
                                ->mutable_socket_address();
     socket_address->set_address(Network::Test::getLoopbackAddressString(GetParam()));
     socket_address->set_port_value(service_upstream_[index]->localAddress()->ip()->port());
+    ++num_endpoints;
   }
 
   // We need to supply the endpoints via EDS to provide locality information for
@@ -29,6 +31,7 @@ public:
                                    const std::vector<uint32_t>& dragon_upstreeams,
                                    const std::vector<uint32_t>& p1_winter_upstreams,
                                    const std::vector<uint32_t>& p1_dragon_upstreams) {
+    uint32_t num_endpoints = 0;
     envoy::api::v2::ClusterLoadAssignment cluster_load_assignment;
     cluster_load_assignment.set_cluster_name("cluster_0");
 
@@ -37,7 +40,7 @@ public:
     winter->mutable_locality()->set_zone("zone_name");
     winter->mutable_locality()->set_sub_zone("winter");
     for (uint32_t index : winter_upstreams) {
-      addEndpoint(*winter, index);
+      addEndpoint(*winter, index, num_endpoints);
     }
 
     auto* dragon = cluster_load_assignment.add_endpoints();
@@ -45,7 +48,7 @@ public:
     dragon->mutable_locality()->set_zone("zone_name");
     dragon->mutable_locality()->set_sub_zone("dragon");
     for (uint32_t index : dragon_upstreeams) {
-      addEndpoint(*dragon, index);
+      addEndpoint(*dragon, index, num_endpoints);
     }
 
     auto* winter_p1 = cluster_load_assignment.add_endpoints();
@@ -54,7 +57,7 @@ public:
     winter_p1->mutable_locality()->set_zone("zone_name");
     winter_p1->mutable_locality()->set_sub_zone("winter");
     for (uint32_t index : p1_winter_upstreams) {
-      addEndpoint(*winter_p1, index);
+      addEndpoint(*winter_p1, index, num_endpoints);
     }
 
     auto* dragon_p1 = cluster_load_assignment.add_endpoints();
@@ -63,7 +66,7 @@ public:
     dragon_p1->mutable_locality()->set_zone("zone_name");
     dragon_p1->mutable_locality()->set_sub_zone("dragon");
     for (uint32_t index : p1_dragon_upstreams) {
-      addEndpoint(*dragon_p1, index);
+      addEndpoint(*dragon_p1, index, num_endpoints);
     }
 
     // Write to file the DiscoveryResponse and trigger inotify watch.
@@ -80,6 +83,11 @@ public:
       std::string path = TestEnvironment::writeStringToFileForTest("eds.update.pb_text",
                                                                    eds_response.DebugString());
       ASSERT_EQ(0, ::rename(path.c_str(), eds_path_.c_str()));
+    }
+    // For every update wait for the update to be processed by Envoy. The nullptr check avoids a
+    // segfault on initial config, where the server is not created yet.
+    if (test_server_) {
+      test_server_->waitForGaugeGe("cluster.cluster_0.membership_total", num_endpoints);
     }
   }
 
@@ -183,13 +191,15 @@ public:
     EXPECT_EQ(response_size_, response_->body().size());
   }
 
-  void sendLoadStatsResponse(const std::vector<std::string>& clusters, uint32_t secs) {
+  void requestLoadStatsResponse(const std::vector<std::string>& clusters, uint32_t secs) {
     envoy::api::v2::LoadStatsResponse loadstats_response;
     loadstats_response.mutable_load_reporting_interval()->set_seconds(secs);
     for (const auto& cluster : clusters) {
       loadstats_response.add_clusters(cluster);
     }
     loadstats_stream_->sendGrpcMessage(loadstats_response);
+    // Wait until the request has been received by Envoy.
+    test_server_->waitForCounterGe("load_reporter.requests", ++load_requests_);
   }
 
   envoy::api::v2::UpstreamLocalityStats localityStats(const std::string& sub_zone, uint64_t success,
@@ -236,6 +246,7 @@ public:
   FakeUpstream* service_upstream_[upstream_endpoints_]{};
   std::string eds_path_;
   uint32_t eds_version_{};
+  uint32_t load_requests_{};
 
   const uint64_t request_size_ = 1024;
   const uint64_t response_size_ = 512;
@@ -255,11 +266,9 @@ TEST_P(LoadStatsIntegrationTest, Success) {
 
   // Simple 50%/50% split between dragon/winter localities. Also include an
   // unknown cluster to exercise the handling of this case.
-  sendLoadStatsResponse({"cluster_0", "cluster_1"}, 1);
-  test_server_->waitForCounterGe("load_reporter.requests", 1);
+  requestLoadStatsResponse({"cluster_0", "cluster_1"}, 1);
 
   updateClusterLoadAssignment({0}, {1}, {3}, {});
-  test_server_->waitForGaugeGe("cluster.cluster_0.membership_total", 3);
 
   for (uint32_t i = 0; i < 4; ++i) {
     sendAndReceiveUpstream(i % 2);
@@ -275,8 +284,7 @@ TEST_P(LoadStatsIntegrationTest, Success) {
 
   // 33%/67% split between dragon/winter primary localities.
   updateClusterLoadAssignment({0}, {1, 2}, {}, {4});
-  sendLoadStatsResponse({"cluster_0"}, 1);
-  test_server_->waitForGaugeGe("cluster.cluster_0.membership_total", 4);
+  requestLoadStatsResponse({"cluster_0"}, 1);
 
   for (uint32_t i = 0; i < 6; ++i) {
     sendAndReceiveUpstream((i + 1) % 3);
@@ -293,8 +301,7 @@ TEST_P(LoadStatsIntegrationTest, Success) {
   // 100% winter locality.
   updateClusterLoadAssignment({}, {}, {}, {});
   updateClusterLoadAssignment({1}, {}, {}, {});
-  sendLoadStatsResponse({"cluster_0"}, 1);
-  test_server_->waitForCounterGe("load_reporter.requests", 3);
+  requestLoadStatsResponse({"cluster_0"}, 1);
 
   for (uint32_t i = 0; i < 1; ++i) {
     sendAndReceiveUpstream(1);
@@ -307,11 +314,9 @@ TEST_P(LoadStatsIntegrationTest, Success) {
   EXPECT_EQ(0, test_server_->counter("load_reporter.errors")->value());
 
   // A LoadStatsResponse arrives before the expiration of the reporting interval.
-  sendLoadStatsResponse({"cluster_0"}, 1);
-  test_server_->waitForCounterGe("load_reporter.requests", 4);
+  requestLoadStatsResponse({"cluster_0"}, 1);
   sendAndReceiveUpstream(1);
-  sendLoadStatsResponse({"cluster_0"}, 1);
-  test_server_->waitForCounterGe("load_reporter.requests", 5);
+  requestLoadStatsResponse({"cluster_0"}, 1);
   sendAndReceiveUpstream(1);
   sendAndReceiveUpstream(1);
 
@@ -332,11 +337,8 @@ TEST_P(LoadStatsIntegrationTest, Error) {
   waitForLoadStatsRequest({});
   loadstats_stream_->startGrpcStream();
 
-  sendLoadStatsResponse({"cluster_0"}, 1);
-  test_server_->waitForCounterGe("load_reporter.requests", 1);
-
+  requestLoadStatsResponse({"cluster_0"}, 1);
   updateClusterLoadAssignment({0}, {}, {}, {});
-  test_server_->waitForGaugeGe("cluster.cluster_0.membership_total", 1);
 
   // This should count as an error since 5xx.
   sendAndReceiveUpstream(0, 503);
@@ -361,11 +363,9 @@ TEST_P(LoadStatsIntegrationTest, InProgress) {
   waitForLoadStatsRequest({});
   loadstats_stream_->startGrpcStream();
 
-  sendLoadStatsResponse({"cluster_0"}, 1);
-  test_server_->waitForCounterGe("load_reporter.requests", 1);
+  requestLoadStatsResponse({"cluster_0"}, 1);
 
   updateClusterLoadAssignment({0}, {}, {}, {});
-  test_server_->waitForGaugeGe("cluster.cluster_0.membership_total", 1);
 
   initiateClientConnection();
 
@@ -394,11 +394,9 @@ TEST_P(LoadStatsIntegrationTest, Dropped) {
   waitForLoadStatsRequest({});
   loadstats_stream_->startGrpcStream();
 
-  sendLoadStatsResponse({"cluster_0"}, 1);
-  test_server_->waitForCounterGe("load_reporter.requests", 1);
+  requestLoadStatsResponse({"cluster_0"}, 1);
 
   updateClusterLoadAssignment({0}, {}, {}, {});
-  test_server_->waitForGaugeGe("cluster.cluster_0.membership_total", 1);
 
   // This should count as dropped, since we trigger circuit breaking.
   initiateClientConnection();


### PR DESCRIPTION
Moving the synchronization counter checks into the functions and tracking counter values to avoid races.

This fixes the missing "test_server_->waitForCounterGe("load_reporter.requests", 2);" and futureproofs.

*Risk Level*: n/a (test only)
*Release Notes*: n/a