### PR TITLE
Checking for cert_chain_file and private_key_file rather than creating them empty

### DIFF
--- a/source/common/config/tls_context_json.cc
+++ b/source/common/config/tls_context_json.cc
@@ -66,10 +66,15 @@ void TlsContextJson::translateCommonTlsContext(
 
 void TlsContextJson::translateTlsCertificate(const Json::Object& json_tls_context,
                                              envoy::api::v2::TlsCertificate& tls_certificate) {
-  tls_certificate.mutable_certificate_chain()->set_filename(
-      json_tls_context.getString("cert_chain_file", ""));
-  tls_certificate.mutable_private_key()->set_filename(
-      json_tls_context.getString("private_key_file", ""));
+  if (json_tls_context.hasObject("cert_chain_file")) {
+    tls_certificate.mutable_certificate_chain()->set_filename(
+        json_tls_context.getString("cert_chain_file", ""));
+  }
+
+  if (json_tls_context.hasObject("private_key_file")) {
+    tls_certificate.mutable_private_key()->set_filename(
+        json_tls_context.getString("private_key_file", ""));
+  }
 }
 
 } // namespace Config


### PR DESCRIPTION
*Title*: 
Checking for cert_chain_file and private_key_file rather than creating them empty

*Description*:
Envoy used to add cert_chain_file and private_key_file even if they are
not present which causes validation errors.

*Risk Level*:
Low

*Testing*:
TBD

*Release Notes*:
generally speaking, the bugfix is minor. But it's blocking my upgrade to 1.5.0 at $work

Fixed #2219

Signed-off-by: Ivan Kruglov <ivan.kruglov@booking.com>