### PR TITLE
ci: enable ipv6 tests on cirlceci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,23 @@ jobs:
      steps:
        - checkout
        - run: ci/do_circle_ci.sh bazel.tsan
+   ipv6_tests:
+     machine: true
+     steps:
+     - checkout
+     - run:
+         name: enable ipv6
+         command: |
+           cat <<'EOF' | sudo tee /etc/docker/daemon.json
+           {
+             "ipv6": true,
+             "fixed-cidr-v6": "2001:db8:1::/64"
+           }
+           EOF
+
+           sudo service docker restart
+     - run: ./ci/do_circle_ci_ipv6_tests.sh
+
    coverage:
      docker:
        - image: *envoy-build-image
@@ -89,6 +106,7 @@ workflows:
               only: /^v.*/
       - asan
       - tsan
+      - ipv6_tests
       - coverage
       - format
       - build_image

--- a/ci/do_circle_ci_ipv6_tests.sh
+++ b/ci/do_circle_ci_ipv6_tests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+. ./ci/envoy_build_sha.sh
+
+export ENVOY_SRCDIR="$(pwd)"
+
+export ENVOY_BUILD_DIR=/tmp/envoy-docker
+
+export TEST_TYPE="bazel.ipv6_tests"
+
+function finish {
+  echo "disk space at end of build:"
+  df -h
+}
+trap finish EXIT
+
+echo "disk space at beginning of build:"
+df -h
+
+docker run -t -i -v "$ENVOY_BUILD_DIR":/build -v "$ENVOY_SRCDIR":/source \
+  envoyproxy/envoy-build:"$ENVOY_BUILD_SHA" /bin/bash -c "cd /source && ci/do_ci.sh $TEST_TYPE"
+


### PR DESCRIPTION
Use CircleCI machine executor where docker can be configured to enable IPv6.