### PR TITLE
build: better workaround for travis ipv6 issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: shell
 sudo: required
 dist: trusty
-group: deprecated-2017Q4
 
 services:
   - docker
@@ -13,6 +12,9 @@ matrix:
   fast_finish: true
 env:
   - TEST_TYPE=bazel.ipv6_tests
+before_script:
+  # TODO(zuercher): remove this workaround for https://github.com/travis-ci/travis-ci/issues/8891
+  - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
 script: ./ci/ci_steps.sh
 
 branches:


### PR DESCRIPTION
Force ipv6 to be enabled rather than depending on deprecated functionality.

*Risk Level*: Low - minor CI change
*Release Notes*: N/A

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>

