### PR TITLE
Comment fix for ConfigUtility::matchHeaders

### DIFF
--- a/source/common/router/config_utility.h
+++ b/source/common/router/config_utility.h
@@ -53,7 +53,7 @@ public:
    * See if the headers specified in the config are present in a request.
    * @param request_headers supplies the headers from the request.
    * @param config_headers supplies the list of configured header conditions on which to match.
-   * @return true if all the headers (and values) in the config_headers are found in the
+   * @return bool true if all the headers (and values) in the config_headers are found in the
    *         request_headers
    */
   static bool matchHeaders(const Http::HeaderMap& request_headers,

--- a/source/common/router/config_utility.h
+++ b/source/common/router/config_utility.h
@@ -50,14 +50,14 @@ public:
   static Upstream::ResourcePriority parsePriority(const envoy::api::v2::RoutingPriority& priority);
 
   /**
-   * See if the specified headers are present in the request headers.
-   * @param headers supplies the list of headers to match
-   * @param request_headers supplies the list of request headers to compare against search_list
+   * See if the headers specified in the config are present in a request.
+   * @param request_headers supplies the headers from the request.
+   * @param request_headers supplies the list of configured header conditions on which to match.
    * @return true all the headers (and values) in the search_list set are found in the
    * request_headers
    */
-  static bool matchHeaders(const Http::HeaderMap& headers,
-                           const std::vector<HeaderData>& request_headers);
+  static bool matchHeaders(const Http::HeaderMap& request_headers,
+                           const std::vector<HeaderData>& config_headers);
 
   /**
    * Returns the redirect HTTP Status Code enum parsed from proto.

--- a/source/common/router/config_utility.h
+++ b/source/common/router/config_utility.h
@@ -52,9 +52,9 @@ public:
   /**
    * See if the headers specified in the config are present in a request.
    * @param request_headers supplies the headers from the request.
-   * @param request_headers supplies the list of configured header conditions on which to match.
-   * @return true all the headers (and values) in the search_list set are found in the
-   * request_headers
+   * @param config_headers supplies the list of configured header conditions on which to match.
+   * @return true if all the headers (and values) in the config_headers are found in the
+   *         request_headers
    */
   static bool matchHeaders(const Http::HeaderMap& request_headers,
                            const std::vector<HeaderData>& config_headers);


### PR DESCRIPTION
*Description*:
This diff changes the parameter names in the declaration of `ConfigUtility::matchHeaders` and the corresponding comment to more clearly reflect what the method does.

*Risk Level*: Low

*Testing*:
I compiled Envoy and ran the unit tests

*Docs Changes*:
N/A

Signed-off-by: Brian Pane <bpane@pinterest.com>