### PR TITLE
http conn man: fix x-envoy-internal regression

### DIFF
--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -140,13 +140,20 @@ public:
   static void sendRedirect(StreamDecoderFilterCallbacks& callbacks, const std::string& new_path,
                            Code response_code);
 
+  struct GetLastAddressFromXffInfo {
+    // Last valid address pulled from the XFF header.
+    Network::Address::InstanceConstSharedPtr address_;
+    // Whether this is the only address in the XFF header.
+    bool single_address_;
+  };
+
   /**
    * Retrieves the last IPv4/IPv6 address in the x-forwarded-for header.
    * @param request_headers supplies the request headers.
-   * @return a valid IPv4 or IPv6 address if one could be parsed, otherwise nullptr.
+   * @return GetLastAddressFromXffInfo information about the last address in the XFF header.
+   *         @see GetLastAddressFromXffInfo for more information.
    */
-  static Network::Address::InstanceConstSharedPtr
-  getLastAddressFromXFF(const Http::HeaderMap& request_headers);
+  static GetLastAddressFromXffInfo getLastAddressFromXFF(const Http::HeaderMap& request_headers);
 };
 
 } // namespace Http

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -130,36 +130,47 @@ TEST(HttpUtility, getLastAddressFromXFF) {
     const std::string second_address = "10.0.0.1";
     TestHeaderMapImpl request_headers{
         {"x-forwarded-for", fmt::format("{0}, {0}, {1}", first_address, second_address)}};
-    EXPECT_EQ(second_address,
-              Utility::getLastAddressFromXFF(request_headers)->ip()->addressAsString());
+    auto ret = Utility::getLastAddressFromXFF(request_headers);
+    EXPECT_EQ(second_address, ret.address_->ip()->addressAsString());
+    EXPECT_FALSE(ret.single_address_);
   }
   {
     TestHeaderMapImpl request_headers{{"x-forwarded-for", ""}};
-    EXPECT_EQ(nullptr, Utility::getLastAddressFromXFF(request_headers));
+    auto ret = Utility::getLastAddressFromXFF(request_headers);
+    EXPECT_EQ(nullptr, ret.address_);
+    EXPECT_FALSE(ret.single_address_);
   }
   {
     TestHeaderMapImpl request_headers{{"x-forwarded-for", ","}};
-    EXPECT_EQ(nullptr, Utility::getLastAddressFromXFF(request_headers));
+    auto ret = Utility::getLastAddressFromXFF(request_headers);
+    EXPECT_EQ(nullptr, ret.address_);
+    EXPECT_FALSE(ret.single_address_);
   }
   {
     TestHeaderMapImpl request_headers{{"x-forwarded-for", ", "}};
-    EXPECT_EQ(nullptr, Utility::getLastAddressFromXFF(request_headers));
+    auto ret = Utility::getLastAddressFromXFF(request_headers);
+    EXPECT_EQ(nullptr, ret.address_);
+    EXPECT_FALSE(ret.single_address_);
   }
   {
     TestHeaderMapImpl request_headers{{"x-forwarded-for", ", bad"}};
-    EXPECT_EQ(nullptr, Utility::getLastAddressFromXFF(request_headers));
+    auto ret = Utility::getLastAddressFromXFF(request_headers);
+    EXPECT_EQ(nullptr, ret.address_);
+    EXPECT_FALSE(ret.single_address_);
   }
   {
     TestHeaderMapImpl request_headers;
-    EXPECT_EQ(nullptr, Utility::getLastAddressFromXFF(request_headers));
+    auto ret = Utility::getLastAddressFromXFF(request_headers);
+    EXPECT_EQ(nullptr, ret.address_);
+    EXPECT_FALSE(ret.single_address_);
   }
-}
-
-TEST(HttpUtility, OneAddressInXFF) {
-  const std::string first_address = "34.0.0.1";
-  TestHeaderMapImpl request_headers{{"x-forwarded-for", first_address}};
-  EXPECT_EQ(first_address,
-            Utility::getLastAddressFromXFF(request_headers)->ip()->addressAsString());
+  {
+    const std::string first_address = "34.0.0.1";
+    TestHeaderMapImpl request_headers{{"x-forwarded-for", first_address}};
+    auto ret = Utility::getLastAddressFromXFF(request_headers);
+    EXPECT_EQ(first_address, ret.address_->ip()->addressAsString());
+    EXPECT_TRUE(ret.single_address_);
+  }
 }
 
 TEST(HttpUtility, TestParseCookie) {

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -1011,7 +1011,7 @@ void HttpIntegrationTest::testUpstreamProtocolError() {
   FakeRawConnectionPtr fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection();
   // TODO(mattklein123): Waiting for exact amount of data is a hack. This needs to
   // be fixed.
-  fake_upstream_connection->waitForData(211);
+  fake_upstream_connection->waitForData(187);
   fake_upstream_connection->write("bad protocol data!");
   fake_upstream_connection->waitForDisconnect();
   codec_client_->waitForDisconnect();

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -204,10 +204,10 @@ TEST_P(IntegrationTest, WebSocketConnectionDownstreamDisconnect) {
   tcp_client = makeTcpConnection(lookupPort("http"));
   // Send websocket upgrade request
   // The request path gets rewritten from /websocket/test to /websocket.
-  // The size of headers received by the destination is 252 bytes.
+  // The size of headers received by the destination is 228 bytes.
   tcp_client->write(upgrade_req_str);
   fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection();
-  const std::string data = fake_upstream_connection->waitForData(252);
+  const std::string data = fake_upstream_connection->waitForData(228);
   // In HTTP1, the transfer-length is defined by use of the "chunked" transfer-coding, even if
   // content-length header is present. No body websocket upgrade request send to upstream has
   // content-length header and has no transfer-encoding header.
@@ -218,15 +218,15 @@ TEST_P(IntegrationTest, WebSocketConnectionDownstreamDisconnect) {
   tcp_client->waitForData(upgrade_resp_str);
   // Standard TCP proxy semantics post upgrade
   tcp_client->write("hello");
-  // datalen = 252 + strlen(hello)
-  fake_upstream_connection->waitForData(257);
+  // datalen = 228 + strlen(hello)
+  fake_upstream_connection->waitForData(233);
   fake_upstream_connection->write("world");
   tcp_client->waitForData(upgrade_resp_str + "world");
   tcp_client->write("bye!");
   // downstream disconnect
   tcp_client->close();
-  // datalen = 252 + strlen(hello) + strlen(bye!)
-  fake_upstream_connection->waitForData(261);
+  // datalen = 228 + strlen(hello) + strlen(bye!)
+  fake_upstream_connection->waitForData(237);
   fake_upstream_connection->waitForDisconnect();
 }
 
@@ -247,8 +247,8 @@ TEST_P(IntegrationTest, WebSocketConnectionUpstreamDisconnect) {
   tcp_client->write(upgrade_req_str);
   fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection();
   // The request path gets rewritten from /websocket/test to /websocket.
-  // The size of headers received by the destination is 252 bytes.
-  const std::string data = fake_upstream_connection->waitForData(252);
+  // The size of headers received by the destination is 228 bytes.
+  const std::string data = fake_upstream_connection->waitForData(228);
   // In HTTP1, the transfer-length is defined by use of the "chunked" transfer-coding, even if
   // content-length header is present. No body websocket upgrade request send to upstream has
   // content-length header and has no transfer-encoding header.
@@ -259,8 +259,8 @@ TEST_P(IntegrationTest, WebSocketConnectionUpstreamDisconnect) {
   tcp_client->waitForData(upgrade_resp_str);
   // Standard TCP proxy semantics post upgrade
   tcp_client->write("hello");
-  // datalen = 252 + strlen(hello)
-  fake_upstream_connection->waitForData(257);
+  // datalen = 228 + strlen(hello)
+  fake_upstream_connection->waitForData(233);
   fake_upstream_connection->write("world");
   // upstream disconnect
   fake_upstream_connection->close();


### PR DESCRIPTION
This fixes a regression from https://github.com/envoyproxy/envoy/pull/2217.
In that PR, we refactored calculation of downstream address to use real
addresses and not strings. As part of that change, I broke some behavior
that people were depending on. Primarily that x-envoy-internal is based on:
1) XFF is present (either via use_remote_address or in request headers).
2) XFF contains a single address after any appending from use_remote_address.
3) The address is valid.

In all other cases the request is not considered internal. The above algorithm
is IMO not optimal in many ways, but it's how the code has worked for a long
time and Lyft (and possibly) others are depending on it, so we can't change it.

This change restores the old behavior. It reverts changes to integration tests
for checking for bytes, as well as does a substantial cleanup to the connection
manager utility tests since they were a mess. It also adds some new tests to
specifically cover certain cases.

In the future I think we will want to add additional inference modes for
determining internal requests, but for now, we need to keep the old behavior.

*Risk Level*: Medium (Hopefully not more broken than before, but still risky change)
*Testing*: Unit/integration (note reverted integration tests from previous commit which
actually caught this issue.
*Documentation*: N/A
*Release notes*: N/A
