### PR TITLE
ci build image: disable centos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 references:
   envoy-build-image: &envoy-build-image
-    envoyproxy/envoy-build:d5865073be7f665c42c00bb733e64012fd4ab22f
+    envoyproxy/envoy-build:52f6880ffbf761c9b809fc3ac208900956ff16b4
 
 version: 2
 jobs:

--- a/ci/build_container/docker_push.sh
+++ b/ci/build_container/docker_push.sh
@@ -27,9 +27,8 @@ then
         cd ci/build_container
         docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
-        # TODO(mattklein123): centos has been removed because the version of cmake is too old to
-        #                     build now. Someone who cares about centos needs to come back and fix
-        #                     this.
+        # centos has been removed because the version of cmake is too old to build now. Someone who
+        # cares about centos needs to come back and fix this.
         for distro in ubuntu
         do
             echo "Updating envoyproxy/envoy-build-${distro} image"

--- a/ci/build_container/docker_push.sh
+++ b/ci/build_container/docker_push.sh
@@ -27,7 +27,10 @@ then
         cd ci/build_container
         docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
-        for distro in ubuntu centos
+        # TODO(mattklein123): centos has been removed because the version of cmake is too old to
+        #                     build now. Someone who cares about centos needs to come back and fix
+        #                     this.
+        for distro in ubuntu
         do
             echo "Updating envoyproxy/envoy-build-${distro} image"
             LINUX_DISTRO=$distro ./docker_build.sh


### PR DESCRIPTION
The CentOS build image no longer builds because the cmake version is
too old. This change disables it. Someone that cares will need to come
and fix it.
