### PR TITLE
build: Move non-core (http/tcp) proxy libs out of the common lib and link against main instead

### DIFF
--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -48,13 +48,20 @@ envoy_cc_library(
         "//source/server/config/network:client_ssl_auth_lib",
         "//source/server/config/network:echo_lib",
         "//source/server/config/network:http_connection_manager_lib",
-        "//source/server/config/network:mongo_proxy_lib",
         "//source/server/config/network:ratelimit_lib",
-        "//source/server/config/network:redis_proxy_lib",
         "//source/server/config/network:tcp_proxy_lib",
         "//source/server/config/stats:dog_statsd_lib",
         "//source/server/config/stats:statsd_lib",
         "//source/server/http:health_check_lib",
+    ],
+)
+
+# Non-core HTTP/TCP proxy libraries.
+envoy_cc_library(
+    name = "extra_protocol_proxies_lib",
+    deps = [
+        "//source/server/config/network:mongo_proxy_lib",
+        "//source/server/config/network:redis_proxy_lib",
     ],
 )
 
@@ -63,6 +70,7 @@ envoy_cc_library(
     srcs = ["main.cc"],
     deps = [
         ":envoy_main_common_lib",
+        ":extra_protocol_proxies_lib",
         "//source/server:hot_restart_lib",
         "//source/server:options_lib",
         "//source/server/config/http:lightstep_lib",


### PR DESCRIPTION
@htuch : pursuant to security review

*Description*:
Restructure source/exe/BUILD to move non-core (http and tcp) protocol
libraries into a separate build target which is linked directly against
main so that other consumers of envoy_common_lib don't pull in unwanted
dependencies.

I wasn't sure if this necessitates updating the release notes. It's not a functional change to the reference binary, but may affect the build for those who are not using the stock main.cc.

*Risk Level*: Low

*Testing*: Building all targets and running all tests confirm no link breakage.