### PR TITLE
test: porting xfcc integration test to v2

### DIFF
--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -219,7 +219,6 @@ public:
 
     if (use_eds_) {
       fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_));
-      ports_.push_back(fake_upstreams_.back()->localAddress()->ip()->port());
     }
   }
 

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -285,7 +285,6 @@ Http2RingHashIntegrationTest::~Http2RingHashIntegrationTest() {
 void Http2RingHashIntegrationTest::createUpstreams() {
   for (int i = 0; i < num_upstreams_; i++) {
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
-    ports_.push_back(fake_upstreams_.back()->localAddress()->ip()->port());
   }
 }
 

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -242,7 +242,7 @@ void HttpIntegrationTest::testRouterHeaderOnlyRequestAndResponse(
     bool close_upstream, ConnectionCreationFunction* create_connection) {
   // This is called multiple times per test in ads_integration_test. Only call
   // initialize() the first time.
-  if (!initialized_) {
+  if (!initialized()) {
     initialize();
   }
   codec_client_ = makeHttpConnection(

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -202,7 +202,6 @@ void BaseIntegrationTest::initialize() {
   initialized_ = true;
 
   createUpstreams();
-
   createEnvoy();
 }
 
@@ -212,11 +211,16 @@ void BaseIntegrationTest::createUpstreams() {
   } else {
     fake_upstreams_.emplace_back(new FakeUpstream(0, upstream_protocol_, version_));
   }
-  ports_.push_back(fake_upstreams_.back()->localAddress()->ip()->port());
 }
 
 void BaseIntegrationTest::createEnvoy() {
-  config_helper_.finalize(ports_);
+  std::vector<uint32_t> ports;
+  for (auto& upstream : fake_upstreams_) {
+    if (upstream->localAddress()->ip()) {
+      ports.push_back(upstream->localAddress()->ip()->port());
+    }
+  }
+  config_helper_.finalize(ports);
 
   ENVOY_LOG_MISC(debug, "Running Envoy with configuration {}",
                  config_helper_.bootstrap().DebugString());

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -117,7 +117,6 @@ public:
   void SetUp();
 
   // Initialize the basic proto configuration, create fake upstreams, and start Envoy.
-  // TODO(alyssawilk) port the rest of the tests to v2 and make initialized_ private.
   virtual void initialize();
   // Set up the fake upstream connections. This is called by initialize() and
   // is virtual to allow subclass overrides.
@@ -159,7 +158,6 @@ protected:
   spdlog::level::level_enum default_log_level_;
   IntegrationTestServerPtr test_server_;
   TestEnvironment::PortMap port_map_;
-  bool initialized_{}; // True if initialized() has been called.
 
   // The named ports for createGeneratedApiTestServer. Used mostly for lookupPort.
   std::vector<std::string> named_ports_{{"default_port"}};
@@ -167,12 +165,15 @@ protected:
   std::vector<uint32_t> ports_;
   // If true, use AutonomousUpstream for fake upstreams.
   bool autonomous_upstream_{false};
+  bool initialized() const { return initialized_; }
 
 private:
   // The codec type for the client-to-Envoy connection
   Http::CodecClient::Type downstream_protocol_{Http::CodecClient::Type::HTTP1};
   // The type for the Envoy-to-backend connection
   FakeHttpConnection::Type upstream_protocol_{FakeHttpConnection::Type::HTTP1};
+  // True if initialized() has been called.
+  bool initialized_{};
 };
 
 } // namespace Envoy

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -161,8 +161,6 @@ protected:
 
   // The named ports for createGeneratedApiTestServer. Used mostly for lookupPort.
   std::vector<std::string> named_ports_{{"default_port"}};
-  // The ports from upstreams created in createUpstreams()
-  std::vector<uint32_t> ports_;
   // If true, use AutonomousUpstream for fake upstreams.
   bool autonomous_upstream_{false};
   bool initialized() const { return initialized_; }

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -93,13 +93,7 @@ public:
 
   void createUpstreams() override {
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_));
-    ports_.push_back(fake_upstreams_.back()->localAddress()->ip()->port());
     load_report_upstream_ = fake_upstreams_.back().get();
-
-    for (uint32_t i = 0; i < upstream_endpoints_; ++i) {
-      fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
-      service_upstream_[i] = fake_upstreams_.back().get();
-    }
   }
 
   void initialize() override {
@@ -129,6 +123,10 @@ public:
     });
     named_ports_ = {"http"};
     HttpIntegrationTest::initialize();
+    for (uint32_t i = 0; i < upstream_endpoints_; ++i) {
+      fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
+      service_upstream_[i] = fake_upstreams_.back().get();
+    }
   }
 
   void initiateClientConnection() {

--- a/test/integration/lua_integration_test.cc
+++ b/test/integration/lua_integration_test.cc
@@ -12,9 +12,7 @@ public:
   void createUpstreams() override {
     HttpIntegrationTest::createUpstreams();
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
-    ports_.push_back(fake_upstreams_.back()->localAddress()->ip()->port());
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
-    ports_.push_back(fake_upstreams_.back()->localAddress()->ip()->port());
   }
 
   void initializeFilter(const std::string& filter_config) {

--- a/test/integration/ratelimit_integration_test.cc
+++ b/test/integration/ratelimit_integration_test.cc
@@ -21,7 +21,6 @@ public:
   void createUpstreams() override {
     HttpIntegrationTest::createUpstreams();
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_));
-    ports_.push_back(fake_upstreams_.back()->localAddress()->ip()->port());
   }
 
   void initialize() override {

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -12,6 +12,7 @@
 #include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
+#include "api/filter/network/http_connection_manager.pb.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "integration.h"
@@ -20,21 +21,6 @@
 
 namespace Envoy {
 namespace Xfcc {
-
-void XfccIntegrationTest::initialize() {
-  initialized_ = true;
-  runtime_.reset(new NiceMock<Runtime::MockLoader>());
-  context_manager_.reset(new Ssl::ContextManagerImpl(*runtime_));
-  upstream_ssl_ctx_ = createUpstreamSslContext();
-  fake_upstreams_.emplace_back(
-      new FakeUpstream(upstream_ssl_ctx_.get(), 0, FakeHttpConnection::Type::HTTP1, version_));
-  registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
-  fake_upstreams_.emplace_back(
-      new FakeUpstream(upstream_ssl_ctx_.get(), 0, FakeHttpConnection::Type::HTTP1, version_));
-  registerPort("upstream_1", fake_upstreams_.back()->localAddress()->ip()->port());
-  client_tls_ssl_ctx_ = createClientSslContext(false);
-  client_mtls_ssl_ctx_ = createClientSslContext(true);
-}
 
 void XfccIntegrationTest::TearDown() {
   test_server_.reset();
@@ -91,39 +77,54 @@ Ssl::ServerContextPtr XfccIntegrationTest::createUpstreamSslContext() {
 Network::ClientConnectionPtr XfccIntegrationTest::makeClientConnection() {
   Network::Address::InstanceConstSharedPtr address =
       Network::Utility::resolveUrl("tcp://" + Network::Test::getLoopbackAddressUrlString(version_) +
-                                   ":" + std::to_string(lookupPort("plain")));
+                                   ":" + std::to_string(lookupPort("http")));
   return dispatcher_->createClientConnection(address, Network::Address::InstanceConstSharedPtr());
-}
-
-Network::ClientConnectionPtr XfccIntegrationTest::makeTlsClientConnection() {
-  Network::Address::InstanceConstSharedPtr address =
-      Network::Utility::resolveUrl("tcp://" + Network::Test::getLoopbackAddressUrlString(version_) +
-                                   ":" + std::to_string(lookupPort("ssl")));
-  return dispatcher_->createSslClientConnection(*client_tls_ssl_ctx_, address,
-                                                Network::Address::InstanceConstSharedPtr());
 }
 
 Network::ClientConnectionPtr XfccIntegrationTest::makeMtlsClientConnection() {
   Network::Address::InstanceConstSharedPtr address =
       Network::Utility::resolveUrl("tcp://" + Network::Test::getLoopbackAddressUrlString(version_) +
-                                   ":" + std::to_string(lookupPort("ssl")));
+                                   ":" + std::to_string(lookupPort("http")));
   return dispatcher_->createSslClientConnection(*client_mtls_ssl_ctx_, address,
                                                 Network::Address::InstanceConstSharedPtr());
 }
 
-void XfccIntegrationTest::startTestServerWithXfccConfig(std::string fcc, std::string sccd) {
-  TestEnvironment::ParamMap param_map;
-  param_map["forward_client_cert"] = fcc;
-  param_map["set_current_client_cert_details"] = sccd;
-  std::string config = TestEnvironment::temporaryFileSubstitute(
-      "test/config/integration/server_xfcc.json", param_map, port_map_, version_);
-  test_server_ = IntegrationTestServer::create(config, version_);
-  registerTestServerPorts({"ssl", "plain"});
+void XfccIntegrationTest::createUpstreams() {
+  upstream_ssl_ctx_ = createUpstreamSslContext();
+  fake_upstreams_.emplace_back(
+      new FakeUpstream(upstream_ssl_ctx_.get(), 0, FakeHttpConnection::Type::HTTP1, version_));
+  ports_.push_back(fake_upstreams_.back()->localAddress()->ip()->port());
 }
 
-void XfccIntegrationTest::testRequestAndResponseWithXfccHeader(Network::ClientConnectionPtr&& conn,
-                                                               std::string previous_xfcc,
+void XfccIntegrationTest::initialize() {
+  config_helper_.addConfigModifier(
+      [&](envoy::api::v2::filter::network::HttpConnectionManager& hcm) -> void {
+        hcm.set_forward_client_cert_details(fcc_);
+        hcm.mutable_set_current_client_cert_details()->CopyFrom(sccd_);
+      });
+
+  config_helper_.addConfigModifier([&](envoy::api::v2::Bootstrap& bootstrap) -> void {
+    auto context = bootstrap.mutable_static_resources()->mutable_clusters(0)->mutable_tls_context();
+    auto* validation_context = context->mutable_common_tls_context()->mutable_validation_context();
+    validation_context->mutable_trusted_ca()->set_filename(
+        TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcacert.pem"));
+    validation_context->add_verify_subject_alt_name("foo.lyft.com");
+  });
+
+  if (tls_) {
+    config_helper_.addSslConfig();
+  }
+
+  runtime_.reset(new NiceMock<Runtime::MockLoader>());
+  context_manager_.reset(new Ssl::ContextManagerImpl(*runtime_));
+  client_tls_ssl_ctx_ = createClientSslContext(false);
+  client_mtls_ssl_ctx_ = createClientSslContext(true);
+  HttpIntegrationTest::initialize();
+}
+
+void XfccIntegrationTest::testRequestAndResponseWithXfccHeader(std::string previous_xfcc,
                                                                std::string expected_xfcc) {
+  Network::ClientConnectionPtr conn = tls_ ? makeMtlsClientConnection() : makeClientConnection();
   Http::TestHeaderMapImpl header_map;
   if (previous_xfcc.empty()) {
     header_map = Http::TestHeaderMapImpl{{":method", "GET"},
@@ -159,84 +160,104 @@ INSTANTIATE_TEST_CASE_P(IpVersions, XfccIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(XfccIntegrationTest, MtlsForwardOnly) {
-  startTestServerWithXfccConfig("forward_only", "");
-  testRequestAndResponseWithXfccHeader(makeMtlsClientConnection(), previous_xfcc_, previous_xfcc_);
+  fcc_ = envoy::api::v2::filter::network::HttpConnectionManager::FORWARD_ONLY;
+  initialize();
+  testRequestAndResponseWithXfccHeader(previous_xfcc_, previous_xfcc_);
 }
 
 TEST_P(XfccIntegrationTest, MtlsAlwaysForwardOnly) {
-  startTestServerWithXfccConfig("always_forward_only", "");
-  testRequestAndResponseWithXfccHeader(makeMtlsClientConnection(), previous_xfcc_, previous_xfcc_);
+  fcc_ = envoy::api::v2::filter::network::HttpConnectionManager::ALWAYS_FORWARD_ONLY;
+  initialize();
+  testRequestAndResponseWithXfccHeader(previous_xfcc_, previous_xfcc_);
 }
 
 TEST_P(XfccIntegrationTest, MtlsSanitize) {
-  startTestServerWithXfccConfig("sanitize", "");
-  testRequestAndResponseWithXfccHeader(makeMtlsClientConnection(), previous_xfcc_, "");
+  fcc_ = envoy::api::v2::filter::network::HttpConnectionManager::SANITIZE;
+  initialize();
+  testRequestAndResponseWithXfccHeader(previous_xfcc_, "");
 }
 
 TEST_P(XfccIntegrationTest, MtlsSanitizeSetSubjectSan) {
-  startTestServerWithXfccConfig("sanitize_set", "\"Subject\", \"SAN\"");
-  testRequestAndResponseWithXfccHeader(makeMtlsClientConnection(), previous_xfcc_,
-                                       current_xfcc_by_hash_ + ";" + client_subject_ + ";" +
-                                           client_san_);
+  fcc_ = envoy::api::v2::filter::network::HttpConnectionManager::SANITIZE_SET;
+  sccd_.mutable_subject()->set_value(true);
+  sccd_.mutable_san()->set_value(true);
+  initialize();
+  testRequestAndResponseWithXfccHeader(previous_xfcc_, current_xfcc_by_hash_ + ";" +
+                                                           client_subject_ + ";" + client_san_);
 }
 
 TEST_P(XfccIntegrationTest, MtlsAppendForward) {
-  startTestServerWithXfccConfig("append_forward", "");
-  testRequestAndResponseWithXfccHeader(makeMtlsClientConnection(), previous_xfcc_,
+  fcc_ = envoy::api::v2::filter::network::HttpConnectionManager::APPEND_FORWARD;
+  initialize();
+  testRequestAndResponseWithXfccHeader(previous_xfcc_,
                                        previous_xfcc_ + "," + current_xfcc_by_hash_);
 }
 
 TEST_P(XfccIntegrationTest, MtlsAppendForwardSubject) {
-  startTestServerWithXfccConfig("append_forward", "\"Subject\"");
-  testRequestAndResponseWithXfccHeader(makeMtlsClientConnection(), previous_xfcc_,
-                                       previous_xfcc_ + "," + current_xfcc_by_hash_ + ";" +
-                                           client_subject_);
+  fcc_ = envoy::api::v2::filter::network::HttpConnectionManager::APPEND_FORWARD;
+  sccd_.mutable_subject()->set_value(true);
+  initialize();
+  testRequestAndResponseWithXfccHeader(
+      previous_xfcc_, previous_xfcc_ + "," + current_xfcc_by_hash_ + ";" + client_subject_);
 }
 
 TEST_P(XfccIntegrationTest, MtlsAppendForwardSan) {
-  startTestServerWithXfccConfig("append_forward", "\"SAN\"");
-  testRequestAndResponseWithXfccHeader(makeMtlsClientConnection(), previous_xfcc_,
-                                       previous_xfcc_ + "," + current_xfcc_by_hash_ + ";" +
-                                           client_san_);
+  fcc_ = envoy::api::v2::filter::network::HttpConnectionManager::APPEND_FORWARD;
+  sccd_.mutable_san()->set_value(true);
+  initialize();
+  testRequestAndResponseWithXfccHeader(
+      previous_xfcc_, previous_xfcc_ + "," + current_xfcc_by_hash_ + ";" + client_san_);
 }
 
 TEST_P(XfccIntegrationTest, MtlsAppendForwardSubjectSan) {
-  startTestServerWithXfccConfig("append_forward", "\"Subject\", \"SAN\"");
-  testRequestAndResponseWithXfccHeader(makeMtlsClientConnection(), previous_xfcc_,
-                                       previous_xfcc_ + "," + current_xfcc_by_hash_ + ";" +
-                                           client_subject_ + ";" + client_san_);
+  fcc_ = envoy::api::v2::filter::network::HttpConnectionManager::APPEND_FORWARD;
+  sccd_.mutable_subject()->set_value(true);
+  sccd_.mutable_san()->set_value(true);
+  initialize();
+  testRequestAndResponseWithXfccHeader(previous_xfcc_, previous_xfcc_ + "," +
+                                                           current_xfcc_by_hash_ + ";" +
+                                                           client_subject_ + ";" + client_san_);
 }
 
 TEST_P(XfccIntegrationTest, MtlsAppendForwardSanPreviousXfccHeaderEmpty) {
-  startTestServerWithXfccConfig("append_forward", "\"SAN\"");
-  testRequestAndResponseWithXfccHeader(makeMtlsClientConnection(), "",
-                                       current_xfcc_by_hash_ + ";" + client_san_);
+  fcc_ = envoy::api::v2::filter::network::HttpConnectionManager::APPEND_FORWARD;
+  sccd_.mutable_san()->set_value(true);
+  initialize();
+  testRequestAndResponseWithXfccHeader("", current_xfcc_by_hash_ + ";" + client_san_);
 }
 
 TEST_P(XfccIntegrationTest, TlsAlwaysForwardOnly) {
   // The always_forward_only works regardless of whether the connection is TLS/mTLS.
-  startTestServerWithXfccConfig("always_forward_only", "");
-  testRequestAndResponseWithXfccHeader(makeClientConnection(), previous_xfcc_, previous_xfcc_);
+  fcc_ = envoy::api::v2::filter::network::HttpConnectionManager::ALWAYS_FORWARD_ONLY;
+  tls_ = false;
+  initialize();
+  testRequestAndResponseWithXfccHeader(previous_xfcc_, previous_xfcc_);
 }
 
 TEST_P(XfccIntegrationTest, TlsEnforceSanitize) {
   // The forward_only, append_forward and sanitize_set options are not effective when the connection
   // is not using Mtls.
-  startTestServerWithXfccConfig("forward_only", "");
-  testRequestAndResponseWithXfccHeader(makeClientConnection(), previous_xfcc_, "");
+  fcc_ = envoy::api::v2::filter::network::HttpConnectionManager::FORWARD_ONLY;
+  tls_ = false;
+  initialize();
+  testRequestAndResponseWithXfccHeader(previous_xfcc_, "");
 }
 
 TEST_P(XfccIntegrationTest, NonTlsAlwaysForwardOnly) {
   // The always_forward_only works regardless of whether the connection is TLS/mTLS.
-  startTestServerWithXfccConfig("always_forward_only", "");
-  testRequestAndResponseWithXfccHeader(makeClientConnection(), previous_xfcc_, previous_xfcc_);
+  fcc_ = envoy::api::v2::filter::network::HttpConnectionManager::ALWAYS_FORWARD_ONLY;
+  tls_ = false;
+  initialize();
+  testRequestAndResponseWithXfccHeader(previous_xfcc_, previous_xfcc_);
 }
 
 TEST_P(XfccIntegrationTest, NonTlsEnforceSanitize) {
   // The forward_only, append_forward and sanitize_set options are not effective when the connection
   // is not using Mtls.
-  startTestServerWithXfccConfig("forward_only", "");
-  testRequestAndResponseWithXfccHeader(makeClientConnection(), previous_xfcc_, "");
+  fcc_ = envoy::api::v2::filter::network::HttpConnectionManager::FORWARD_ONLY;
+  tls_ = false;
+  initialize();
+  testRequestAndResponseWithXfccHeader(previous_xfcc_, "");
 }
 
 TEST_P(XfccIntegrationTest, TagExtractedNameGenerationTest) {
@@ -248,7 +269,8 @@ TEST_P(XfccIntegrationTest, TagExtractedNameGenerationTest) {
   // the printout needs to be copied from each test parameterization and pasted into the respective
   // case in the switch statement below.
 
-  startTestServerWithXfccConfig("forward_only", "");
+  fcc_ = envoy::api::v2::filter::network::HttpConnectionManager::FORWARD_ONLY;
+  initialize();
 
   // Commented sample code to regenerate the map literals used below in the test log if necessary:
 

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -93,7 +93,6 @@ void XfccIntegrationTest::createUpstreams() {
   upstream_ssl_ctx_ = createUpstreamSslContext();
   fake_upstreams_.emplace_back(
       new FakeUpstream(upstream_ssl_ctx_.get(), 0, FakeHttpConnection::Type::HTTP1, version_));
-  ports_.push_back(fake_upstreams_.back()->localAddress()->ip()->port());
 }
 
 void XfccIntegrationTest::initialize() {

--- a/test/integration/xfcc_integration_test.h
+++ b/test/integration/xfcc_integration_test.h
@@ -32,8 +32,8 @@ public:
   XfccIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
 
   void initialize() override;
+  void createUpstreams() override;
 
-  void SetUp() override { initialize(); }
   void TearDown() override;
 
   Ssl::ServerContextPtr createUpstreamSslContext();
@@ -41,9 +41,10 @@ public:
   Network::ClientConnectionPtr makeClientConnection();
   Network::ClientConnectionPtr makeTlsClientConnection();
   Network::ClientConnectionPtr makeMtlsClientConnection();
-  void testRequestAndResponseWithXfccHeader(Network::ClientConnectionPtr&& conn,
-                                            std::string privous_xfcc, std::string expected_xfcc);
-  void startTestServerWithXfccConfig(std::string config, std::string content);
+  void testRequestAndResponseWithXfccHeader(std::string privous_xfcc, std::string expected_xfcc);
+  envoy::api::v2::filter::network::HttpConnectionManager::ForwardClientCertDetails fcc_;
+  envoy::api::v2::filter::network::HttpConnectionManager::SetCurrentClientCertDetails sccd_;
+  bool tls_ = true;
 
 private:
   std::unique_ptr<Runtime::Loader> runtime_;


### PR DESCRIPTION
This is the last (external) test to move over, so making initialized_ private.

YAY!!

*Risk Level*: Low (test only) 
*Testing*: the ported tests pass :-)
*Release Notes*: n/a