### PR TITLE
bazel: bump com_github_lightstep_lightstep_tracer_cpp version.

### DIFF
--- a/bazel/external/BUILD
+++ b/bazel/external/BUILD
@@ -5,7 +5,7 @@ cc_library(
     srcs = [":empty.cc"],
     deps = [
         "@io_opentracing_cpp//:opentracing",
-        "@com_github_lightstep_lightstep_tracer_cpp//:lightstep_tracer",
+        "@com_lightstep_tracer_cpp//:lightstep_tracer",
         "@com_google_googletest//:gtest",
     ],
 )

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -238,7 +238,7 @@ def envoy_dependencies(path = "@envoy_deps//", skip_targets = []):
     _com_github_gabime_spdlog()
     _com_github_gcovr_gcovr()
     _io_opentracing_cpp()
-    _com_github_lightstep_lightstep_tracer_cpp()
+    _com_lightstep_tracer_cpp()
     _com_github_nodejs_http_parser()
     _com_github_tencent_rapidjson()
     _com_google_googletest()
@@ -319,15 +319,15 @@ def _io_opentracing_cpp():
         actual = "@io_opentracing_cpp//:opentracing",
     )
 
-def _com_github_lightstep_lightstep_tracer_cpp():
-    _repository_impl("com_github_lightstep_lightstep_tracer_cpp")
+def _com_lightstep_tracer_cpp():
+    _repository_impl("com_lightstep_tracer_cpp")
     _repository_impl(
         name = "lightstep_vendored_googleapis",
-        build_file = "@com_github_lightstep_lightstep_tracer_cpp//:lightstep-tracer-common/third_party/googleapis/BUILD",
+        build_file = "@com_lightstep_tracer_cpp//:lightstep-tracer-common/third_party/googleapis/BUILD",
     )
     native.bind(
         name = "lightstep",
-        actual = "@com_github_lightstep_lightstep_tracer_cpp//:lightstep_tracer",
+        actual = "@com_lightstep_tracer_cpp//:lightstep_tracer",
     )
 
 def _com_github_tencent_rapidjson():

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -33,7 +33,7 @@ REPOSITORY_LOCATIONS = dict(
         commit = "e57161e2a4bd1f9d3a8d3edf23185f033bb45f17",
         remote = "https://github.com/opentracing/opentracing-cpp", # v1.2.0
     ),
-    com_github_lightstep_lightstep_tracer_cpp = dict(
+    com_lightstep_tracer_cpp = dict(
         # This picks up a commit after v0.6.0 (d4501f84de2d149da2a7a56c545a1c40f214db3f) that fixes
         # a Clang build issue.
         # TODO(htuch): Switch back to regular versioned releases at next release.

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -34,8 +34,11 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/opentracing/opentracing-cpp", # v1.2.0
     ),
     com_github_lightstep_lightstep_tracer_cpp = dict(
-        commit = "deb5284395075028c3e5b4eab1416fe1e597bdb7",
-        remote = "https://github.com/lightstep/lightstep-tracer-cpp", # v0.6.0
+        # This picks up a commit after v0.6.0 (d4501f84de2d149da2a7a56c545a1c40f214db3f) that fixes
+        # a Clang build issue.
+        # TODO(htuch): Switch back to regular versioned releases at next release.
+        commit = "1c63a24bd7f4e71ccae0d807afd699c3d49307df",
+        remote = "https://github.com/lightstep/lightstep-tracer-cpp", # v0.6.0+
     ),
     lightstep_vendored_googleapis = dict(
         commit = "d6f78d948c53f3b400bb46996eb3084359914f9b",


### PR DESCRIPTION
This allows us to pick up
https://github.com/lightstep/lightstep-tracer-cpp/commit/d4501f84de2d149da2a7a56c545a1c40f214db3f,
which fixes a Google internal build issue with Clang.

*Risk Level*: Low
*Testing*: bazel test //test/...

Signed-off-by: Harvey Tuch <htuch@google.com>