### PR TITLE
Some clang tidy fixes from Google weekly import

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -534,11 +534,11 @@ void ConnectionImpl::updateWriteBufferStats(uint64_t num_written, uint64_t new_s
                                            connection_stats_->write_current_);
 }
 
-ClientConnectionImpl::ClientConnectionImpl(
-    Event::Dispatcher& dispatcher, Address::InstanceConstSharedPtr address,
-    const Network::Address::InstanceConstSharedPtr source_address)
-    : ConnectionImpl(dispatcher, address->socket(Address::SocketType::Stream), address, nullptr,
-                     source_address, false, false) {}
+ClientConnectionImpl::ClientConnectionImpl(Event::Dispatcher& dispatcher,
+                                           const Address::InstanceConstSharedPtr remote_address,
+                                           const Address::InstanceConstSharedPtr source_address)
+    : ConnectionImpl(dispatcher, remote_address->socket(Address::SocketType::Stream),
+                     remote_address, nullptr, source_address, false, false) {}
 
 } // namespace Network
 } // namespace Envoy

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -535,8 +535,8 @@ void ConnectionImpl::updateWriteBufferStats(uint64_t num_written, uint64_t new_s
 }
 
 ClientConnectionImpl::ClientConnectionImpl(Event::Dispatcher& dispatcher,
-                                           const Address::InstanceConstSharedPtr remote_address,
-                                           const Address::InstanceConstSharedPtr source_address)
+                                           const Address::InstanceConstSharedPtr& remote_address,
+                                           const Address::InstanceConstSharedPtr& source_address)
     : ConnectionImpl(dispatcher, remote_address->socket(Address::SocketType::Stream),
                      remote_address, nullptr, source_address, false, false) {}
 

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -172,8 +172,8 @@ private:
 class ClientConnectionImpl : public ConnectionImpl, virtual public ClientConnection {
 public:
   ClientConnectionImpl(Event::Dispatcher& dispatcher,
-                       const Address::InstanceConstSharedPtr remote_address,
-                       const Address::InstanceConstSharedPtr source_address);
+                       const Address::InstanceConstSharedPtr& remote_address,
+                       const Address::InstanceConstSharedPtr& source_address);
 
   // Network::ClientConnection
   void connect() override { doConnect(); }

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -172,7 +172,7 @@ private:
 class ClientConnectionImpl : public ConnectionImpl, virtual public ClientConnection {
 public:
   ClientConnectionImpl(Event::Dispatcher& dispatcher,
-                       Address::InstanceConstSharedPtr remote_address,
+                       const Address::InstanceConstSharedPtr remote_address,
                        const Address::InstanceConstSharedPtr source_address);
 
   // Network::ClientConnection

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -20,7 +20,7 @@ const HostSet* bestAvailable(const PrioritySet* priority_set) {
   }
   // This is used for LoadBalancerBase priority_set_ and local_priority_set_
   // which are guaranteed to have at least one host set.
-  ASSERT(priority_set->hostSetsPerPriority().size() > 0);
+  ASSERT(!priority_set->hostSetsPerPriority().empty());
 
   for (auto& host_set : priority_set->hostSetsPerPriority()) {
     if (!host_set->healthyHosts().empty()) {
@@ -54,7 +54,7 @@ ZoneAwareLoadBalancerBase::ZoneAwareLoadBalancerBase(const PrioritySet& priority
                                                      Runtime::RandomGenerator& random)
     : LoadBalancerBase(priority_set, stats, runtime, random),
       local_priority_set_(local_priority_set) {
-  ASSERT(priority_set.hostSetsPerPriority().size() > 0);
+  ASSERT(!priority_set.hostSetsPerPriority().empty());
   resizePerPriorityState();
   priority_set_.addMemberUpdateCb([this](uint32_t priority, const std::vector<HostSharedPtr>&,
                                          const std::vector<HostSharedPtr>&) -> void {

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -125,7 +125,7 @@ public:
   // Finalize the config and spin up an Envoy instance.
   virtual void createEnvoy();
   // sets upstream_protocol_ and alters the upstream protocol in the config_helper_
-  void setUpstreamProtocol(FakeHttpConnection::Type type);
+  void setUpstreamProtocol(FakeHttpConnection::Type protocol);
 
   FakeHttpConnection::Type upstreamProtocol() const { return upstream_protocol_; }
 

--- a/test/mocks/request_info/mocks.cc
+++ b/test/mocks/request_info/mocks.cc
@@ -7,7 +7,6 @@
 
 using testing::Return;
 using testing::ReturnRef;
-using testing::_;
 
 namespace Envoy {
 namespace RequestInfo {


### PR DESCRIPTION
Signed-off-by: Henna Huang <henna@google.com>

*title*: *Some clang tidy fixes from Google weekly import*

*Description*: Clang tidy fixes
  - remove unused using
  - match header and function definition parameter names
  - s/size() > 0/empty()
  - const Address::InstanceConstSharedPtr

*Risk Level*: Low

*Testing*: no additional tests added

*Docs Changes*: none

*Release Notes*: none