### PR TITLE
routing: enable routing on query arg match (#2120)

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -67,7 +67,7 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
     ),
     envoy_api = dict(
-        commit = "3deffbd132b40fa544137902fdf83bec7442a87f",
+        commit = "05384e069b3ea910b04d1ee267aa4fc0fdf15103",
         remote = "https://github.com/envoyproxy/data-plane-api",
     ),
     grpc_httpjson_transcoding = dict(

--- a/source/common/config/rds_json.cc
+++ b/source/common/config/rds_json.cc
@@ -95,9 +95,9 @@ void RdsJson::translateHeaderMatcher(const Json::Object& json_header_matcher,
   JSON_UTIL_SET_BOOL(json_header_matcher, header_matcher, regex);
 }
 
-void RdsJson::translateQueryParameterMatcher(const Json::Object& json_query_parameter_matcher,
-                                             envoy::api::v2::QueryParameterMatcher&
-                                             query_parameter_matcher) {
+void RdsJson::translateQueryParameterMatcher(
+    const Json::Object& json_query_parameter_matcher,
+    envoy::api::v2::QueryParameterMatcher& query_parameter_matcher) {
   json_query_parameter_matcher.validateSchema(Json::Schema::QUERY_PARAMETER_CONFIGURATION_SCHEMA);
   JSON_UTIL_SET_STRING(json_query_parameter_matcher, query_parameter_matcher, name);
   JSON_UTIL_SET_STRING(json_query_parameter_matcher, query_parameter_matcher, value);
@@ -221,7 +221,7 @@ void RdsJson::translateRoute(const Json::Object& json_route, envoy::api::v2::Rou
   }
 
   for (const auto json_query_parameter_matcher :
-           json_route.getObjectArray("query_parameters", true)) {
+       json_route.getObjectArray("query_parameters", true)) {
     auto* query_parameter_matcher = match->mutable_query_parameters()->Add();
     translateQueryParameterMatcher(*json_query_parameter_matcher, *query_parameter_matcher);
   }

--- a/source/common/config/rds_json.cc
+++ b/source/common/config/rds_json.cc
@@ -95,6 +95,15 @@ void RdsJson::translateHeaderMatcher(const Json::Object& json_header_matcher,
   JSON_UTIL_SET_BOOL(json_header_matcher, header_matcher, regex);
 }
 
+void RdsJson::translateQueryParameterMatcher(const Json::Object& json_query_parameter_matcher,
+                                             envoy::api::v2::QueryParameterMatcher&
+                                             query_parameter_matcher) {
+  json_query_parameter_matcher.validateSchema(Json::Schema::QUERY_PARAMETER_CONFIGURATION_SCHEMA);
+  JSON_UTIL_SET_STRING(json_query_parameter_matcher, query_parameter_matcher, name);
+  JSON_UTIL_SET_STRING(json_query_parameter_matcher, query_parameter_matcher, value);
+  JSON_UTIL_SET_BOOL(json_query_parameter_matcher, query_parameter_matcher, regex);
+}
+
 void RdsJson::translateRouteConfiguration(const Json::Object& json_route_config,
                                           envoy::api::v2::RouteConfiguration& route_config) {
   json_route_config.validateSchema(Json::Schema::ROUTE_CONFIGURATION_SCHEMA);
@@ -209,6 +218,12 @@ void RdsJson::translateRoute(const Json::Object& json_route, envoy::api::v2::Rou
   for (const auto json_header_matcher : json_route.getObjectArray("headers", true)) {
     auto* header_matcher = match->mutable_headers()->Add();
     translateHeaderMatcher(*json_header_matcher, *header_matcher);
+  }
+
+  for (const auto json_query_parameter_matcher :
+           json_route.getObjectArray("query_parameters", true)) {
+    auto* query_parameter_matcher = match->mutable_query_parameters()->Add();
+    translateQueryParameterMatcher(*json_query_parameter_matcher, *query_parameter_matcher);
   }
 
   bool has_redirect = false;

--- a/source/common/config/rds_json.h
+++ b/source/common/config/rds_json.h
@@ -53,9 +53,9 @@ public:
    * @param json_query_parameter_matcher source v1 JSON query parameter matcher object.
    * @param query_parameter_matcher destination v2 envoy::api::v2::QueryParameterMatcher.
    */
-  static void translateQueryParameterMatcher(const Json::Object& json_query_parameter_matcher,
-                                             envoy::api::v2::QueryParameterMatcher&
-                                             query_parameter_matcher);
+  static void
+  translateQueryParameterMatcher(const Json::Object& json_query_parameter_matcher,
+                                 envoy::api::v2::QueryParameterMatcher& query_parameter_matcher);
 
   /**
    * Translate a v1 JSON route configuration object to v2 envoy::api::v2::RouteConfiguration.

--- a/source/common/config/rds_json.h
+++ b/source/common/config/rds_json.h
@@ -49,6 +49,15 @@ public:
                                      envoy::api::v2::HeaderMatcher& header_matcher);
 
   /**
+   * Translate a v1 JSON header matcher object to v2 envoy::api::v2::QueryParameterMatcher.
+   * @param json_query_parameter_matcher source v1 JSON query parameter matcher object.
+   * @param query_parameter_matcher destination v2 envoy::api::v2::QueryParameterMatcher.
+   */
+  static void translateQueryParameterMatcher(const Json::Object& json_query_parameter_matcher,
+                                             envoy::api::v2::QueryParameterMatcher&
+                                             query_parameter_matcher);
+
+  /**
    * Translate a v1 JSON route configuration object to v2 envoy::api::v2::RouteConfiguration.
    * @param json_route_config source v1 JSON route configuration object.
    * @param route_config destination v2 envoy::api::v2::RouteConfiguration.

--- a/source/common/config/rds_json.h
+++ b/source/common/config/rds_json.h
@@ -49,7 +49,7 @@ public:
                                      envoy::api::v2::HeaderMatcher& header_matcher);
 
   /**
-   * Translate a v1 JSON header matcher object to v2 envoy::api::v2::QueryParameterMatcher.
+   * Translate a v1 JSON query parameter matcher object to v2 envoy::api::v2::QueryParameterMatcher.
    * @param json_query_parameter_matcher source v1 JSON query parameter matcher object.
    * @param query_parameter_matcher destination v2 envoy::api::v2::QueryParameterMatcher.
    */

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -57,14 +57,14 @@ Utility::QueryParams Utility::parseQueryString(const std::string& url) {
     if (end == std::string::npos) {
       end = url.size();
     }
-    auto param = StringUtil::subspan(url, start, end);
+    absl::string_view param(url.c_str() + start, end - start);
 
     size_t equal = param.find('=');
     if (equal != std::string::npos) {
-      params.emplace(StringUtil::subspan(param, 0, equal),
-                     StringUtil::subspan(param, equal + 1, param.length()));
+      params.emplace(StringUtil::subspan(url, start, start + equal),
+                     StringUtil::subspan(url, start + equal + 1, end));
     } else {
-      params.emplace(param, "");
+      params.emplace(StringUtil::subspan(url, start, end), "");
     }
 
     start = end + 1;

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -57,13 +57,14 @@ Utility::QueryParams Utility::parseQueryString(const std::string& url) {
     if (end == std::string::npos) {
       end = url.size();
     }
+    auto param = StringUtil::subspan(url, start, end);
 
-    size_t equal = url.find('=', start);
+    size_t equal = param.find('=');
     if (equal != std::string::npos) {
-      params.emplace(StringUtil::subspan(url, start, equal),
-                     StringUtil::subspan(url, equal + 1, end));
+      params.emplace(StringUtil::subspan(param, 0, equal),
+                     StringUtil::subspan(param, equal + 1, param.length()));
     } else {
-      params.emplace(StringUtil::subspan(url, start, end), "");
+      params.emplace(param, "");
     }
 
     start = end + 1;

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -59,7 +59,7 @@ Utility::QueryParams Utility::parseQueryString(const std::string& url) {
     }
     absl::string_view param(url.c_str() + start, end - start);
 
-    size_t equal = param.find('=');
+    const size_t equal = param.find('=');
     if (equal != std::string::npos) {
       params.emplace(StringUtil::subspan(url, start, start + equal),
                      StringUtil::subspan(url, start + equal + 1, end));

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -721,6 +721,13 @@ const std::string Json::Schema::ROUTE_ENTRY_CONFIGURATION_SCHEMA(R"EOF(
           "type" : "object"
         }
       },
+      "query_parameters": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object"
+        }
+      },
       "rate_limits" : {"type" : "array"},
       "include_vh_rate_limits" : {"type" : "boolean"},
       "hash_policy" : {
@@ -781,6 +788,20 @@ const std::string Json::Schema::ROUTE_ENTRY_CONFIGURATION_SCHEMA(R"EOF(
   )EOF");
 
 const std::string Json::Schema::HEADER_DATA_CONFIGURATION_SCHEMA(R"EOF(
+  {
+    "$schema" : "http://json-schema.org/schema#",
+    "type" : "object",
+    "properties" : {
+      "name" : {"type" : "string"},
+      "value" : {"type" : "string"},
+      "regex" : {"type" : "boolean"}
+    },
+    "required" : ["name"],
+    "additionalProperties" : false
+  }
+  )EOF");
+
+const std::string Json::Schema::QUERY_PARAMETER_CONFIGURATION_SCHEMA(R"EOF(
   {
     "$schema" : "http://json-schema.org/schema#",
     "type" : "object",

--- a/source/common/json/config_schemas.h
+++ b/source/common/json/config_schemas.h
@@ -33,6 +33,7 @@ public:
   static const std::string HTTP_RATE_LIMITS_CONFIGURATION_SCHEMA;
   static const std::string RDS_CONFIGURATION_SCHEMA;
   static const std::string HEADER_DATA_CONFIGURATION_SCHEMA;
+  static const std::string QUERY_PARAMETER_CONFIGURATION_SCHEMA;
 
   // HTTP Filter Schemas
   static const std::string BUFFER_HTTP_FILTER_SCHEMA;

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -291,6 +291,10 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
     config_headers_.push_back(header_map);
   }
 
+  for (const auto& query_parameter : route.match().query_parameters()) {
+    config_query_parameters_.push_back(query_parameter);
+  }
+
   if (!route.route().hash_policy().empty()) {
     hash_policy_.reset(new HashPolicyImpl(route.route().hash_policy()));
   }
@@ -315,6 +319,11 @@ bool RouteEntryImplBase::matchRoute(const Http::HeaderMap& headers, uint64_t ran
   }
 
   matches &= ConfigUtility::matchHeaders(headers, config_headers_);
+  if (config_query_parameters_.size() != 0) {
+    Http::Utility::QueryParams query_parameters =
+        Http::Utility::parseQueryString(headers.Path()->value().c_str());
+    matches &= ConfigUtility::matchQueryParams(query_parameters, config_query_parameters_);
+  }
 
   return matches;
 }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -319,7 +319,7 @@ bool RouteEntryImplBase::matchRoute(const Http::HeaderMap& headers, uint64_t ran
   }
 
   matches &= ConfigUtility::matchHeaders(headers, config_headers_);
-  if (config_query_parameters_.size() != 0) {
+  if (!config_query_parameters_.empty()) {
     Http::Utility::QueryParams query_parameters =
         Http::Utility::parseQueryString(headers.Path()->value().c_str());
     matches &= ConfigUtility::matchQueryParams(query_parameters, config_query_parameters_);

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -476,6 +476,7 @@ private:
   const ShadowPolicyImpl shadow_policy_;
   const Upstream::ResourcePriority priority_;
   std::vector<ConfigUtility::HeaderData> config_headers_;
+  std::vector<ConfigUtility::QueryParameterMatcher> config_query_parameters_;
   std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
   std::unique_ptr<const HashPolicyImpl> hash_policy_;
   MetadataMatchCriteriaImplConstPtr metadata_match_criteria_;

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -45,6 +45,28 @@ bool ConfigUtility::matchHeaders(const Http::HeaderMap& request_headers,
   return matches;
 }
 
+bool ConfigUtility::matchQueryParams(const Http::Utility::QueryParams& query_params,
+                                     const std::vector<QueryParameterMatcher>& config_query_params) {
+  bool matches = true;
+  for (const auto& config_query_param : config_query_params) {
+    auto query_param = query_params.find(config_query_param.name_);
+    if (query_param == query_params.end()) {
+      matches &= false;
+    } else if (config_query_param.is_regex_) {
+      matches &= std::regex_match(query_param->second, config_query_param.regex_pattern_);
+    } else if (config_query_param.value_.length() == 0) {
+      matches &= true;
+    } else {
+      matches &= (config_query_param.value_ == query_param->second);
+    }
+    if (!matches) {
+      break;
+    }
+  }
+
+  return matches;
+}
+
 Http::Code ConfigUtility::parseRedirectResponseCode(
     const envoy::api::v2::RedirectAction::RedirectResponseCode& code) {
   switch (code) {

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -45,8 +45,9 @@ bool ConfigUtility::matchHeaders(const Http::HeaderMap& request_headers,
   return matches;
 }
 
-bool ConfigUtility::matchQueryParams(const Http::Utility::QueryParams& query_params,
-                                     const std::vector<QueryParameterMatcher>& config_query_params) {
+bool ConfigUtility::matchQueryParams(
+    const Http::Utility::QueryParams& query_params,
+    const std::vector<QueryParameterMatcher>& config_query_params) {
   bool matches = true;
   for (const auto& config_query_param : config_query_params) {
     auto query_param = query_params.find(config_query_param.name_);

--- a/source/common/router/config_utility.h
+++ b/source/common/router/config_utility.h
@@ -11,6 +11,7 @@
 #include "common/common/empty_string.h"
 #include "common/config/rds_json.h"
 #include "common/http/headers.h"
+#include "common/http/utility.h"
 #include "common/protobuf/utility.h"
 
 #include "api/rds.pb.h"
@@ -44,6 +45,21 @@ public:
     const bool is_regex_;
   };
 
+  // A QueryParameterMatcher specifies one "name" or "name=value" element
+  // to match in a request's query string. It is the optimized, runtime
+  // equivalent of the QueryParameterMatcher proto in the RDS v2 API.
+  struct QueryParameterMatcher {
+    QueryParameterMatcher(const envoy::api::v2::QueryParameterMatcher& config)
+        : name_(config.name()), value_(config.value()),
+          regex_pattern_(value_, std::regex::optimize),
+          is_regex_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, regex, false)) {}
+
+    const std::string name_;
+    const std::string value_;
+    const std::regex regex_pattern_;
+    const bool is_regex_;
+  };
+
   /**
    * @return the resource priority parsed from proto.
    */
@@ -58,6 +74,16 @@ public:
    */
   static bool matchHeaders(const Http::HeaderMap& request_headers,
                            const std::vector<HeaderData>& config_headers);
+
+  /**
+   * See if the query parameters specified in the config are present in a request.
+   * @param query_params supplies the query parameters from the request's query string.
+   * @param config_params supplies the list of configured query param conditions on which to match.
+   * @return bool true if all the query params (and values) in the config_params are found in the
+   *         query_params
+   */
+  static bool matchQueryParams(const Http::Utility::QueryParams& query_params,
+                               const std::vector<QueryParameterMatcher>& config_query_params);
 
   /**
    * Returns the redirect HTTP Status Code enum parsed from proto.

--- a/source/common/router/config_utility.h
+++ b/source/common/router/config_utility.h
@@ -48,12 +48,22 @@ public:
   // A QueryParameterMatcher specifies one "name" or "name=value" element
   // to match in a request's query string. It is the optimized, runtime
   // equivalent of the QueryParameterMatcher proto in the RDS v2 API.
-  struct QueryParameterMatcher {
+  class QueryParameterMatcher {
+  public:
     QueryParameterMatcher(const envoy::api::v2::QueryParameterMatcher& config)
         : name_(config.name()), value_(config.value()),
           regex_pattern_(value_, std::regex::optimize),
           is_regex_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, regex, false)) {}
 
+    /**
+     * Check if the query parameters for a request contain a match for this
+     * QueryParameterMatcher.
+     * @param request_query_params supplies the parsed query parameters from a request.
+     * @return bool true if a match for this QueryParameterMatcher exists in request_query_params.
+     */
+    bool matches(const Http::Utility::QueryParams& request_query_params) const;
+
+  private:
     const std::string name_;
     const std::string value_;
     const std::regex regex_pattern_;


### PR DESCRIPTION
Signed-off-by: Brian Pane <bpane@pinterest.com>

*Description*:
This change support route selection based on request query string parameters,
implementing the API changes in data-plane-api commit [05384e0](https://github.com/envoyproxy/data-plane-api/commit/05384e069b3ea910b04d1ee267aa4fc0fdf15103).

*Risk Level*: Medium

*Testing*:
New unit tests are included in this PR.
