### PR TITLE
tracing: Cancel active tracing requests upon destruction.

### DIFF
--- a/source/common/tracing/lightstep_tracer_impl.h
+++ b/source/common/tracing/lightstep_tracer_impl.h
@@ -58,6 +58,8 @@ private:
   public:
     explicit LightStepTransporter(LightStepDriver& driver);
 
+    ~LightStepTransporter();
+
     // lightstep::AsyncTransporter
     void Send(const Protobuf::Message& request, Protobuf::Message& response,
               lightstep::AsyncTransporter::Callback& callback) override;
@@ -67,6 +69,7 @@ private:
     void onFailure(Http::AsyncClient::FailureReason) override;
 
   private:
+    Http::AsyncClient::Request* active_request_ = nullptr;
     lightstep::AsyncTransporter::Callback* active_callback_ = nullptr;
     Protobuf::Message* active_response_ = nullptr;
     LightStepDriver& driver_;

--- a/test/common/tracing/lightstep_tracer_impl_test.cc
+++ b/test/common/tracing/lightstep_tracer_impl_test.cc
@@ -329,14 +329,9 @@ TEST_F(LightStepDriverTest, CancelRequestOnDestruction) {
 
   EXPECT_CALL(cm_.async_client_, send_(_, _, timeout))
       .WillOnce(
-          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
+          Invoke([&](Http::MessagePtr& /*message*/, Http::AsyncClient::Callbacks& callbacks,
                      const Optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
-
-            EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
-                         message->headers().Path()->value().c_str());
-            EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
-            EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
 
             return &request;
           }));
@@ -348,7 +343,7 @@ TEST_F(LightStepDriverTest, CancelRequestOnDestruction) {
   SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_, start_time_);
   span->finishSpan();
 
-  EXPECT_CALL(request, cancel()).Times(1);
+  EXPECT_CALL(request, cancel());
 
   driver_.reset();
 }


### PR DESCRIPTION
Signed-off-by: Ryan Burn <ryan.burn@gmail.com>

*Description*:
When a LightStepTransporter gets destroyed, any active requests it has must be cancelled; otherwise callbacks will be invoked on a destructed object.

*Risk Level*: Low

*Testing*:
Added a unit test to verify described behavior.

Fixes #2257
