### PR TITLE
server admin: Adds an HTML home-page, changing content-type returned by existing handlers to text/plain

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -235,6 +235,7 @@ private:
   HEADER_FUNC(AccessControlExposeHeaders)                                                          \
   HEADER_FUNC(AccessControlMaxAge)                                                                 \
   HEADER_FUNC(Authorization)                                                                       \
+  HEADER_FUNC(CacheControl)                                                                        \
   HEADER_FUNC(ClientTraceId)                                                                       \
   HEADER_FUNC(Connection)                                                                          \
   HEADER_FUNC(ContentLength)                                                                       \

--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -18,9 +18,9 @@ namespace Server {
  * used to add static handlers as in source/server/http/admin.cc and also dynamic handlers as
  * done in the RouteConfigProviderManagerImpl constructor in source/common/router/rds_impl.cc.
  */
-#define MAKE_ADMIN_HANDLER(X)                                                                     \
-  [this](const std::string& url, Http::HeaderMap& header, Buffer::Instance& data) -> Http::Code { \
-    return X(url, header, data);                                                                  \
+#define MAKE_ADMIN_HANDLER(X)                                                                      \
+  [this](const std::string& url, Http::HeaderMap& header, Buffer::Instance& data) -> Http::Code {  \
+    return X(url, header, data);                                                                   \
   }
 
 /**
@@ -37,7 +37,8 @@ public:
    * @return Http::Code the response code.
    */
   typedef std::function<Http::Code(const std::string& url, Http::HeaderMap& header,
-                                   Buffer::Instance& response)> HandlerCb;
+                                   Buffer::Instance& response)>
+      HandlerCb;
 
   /**
    * Add an admin handler.

--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -19,8 +19,9 @@ namespace Server {
  * done in the RouteConfigProviderManagerImpl constructor in source/common/router/rds_impl.cc.
  */
 #define MAKE_ADMIN_HANDLER(X)                                                                      \
-  [this](const std::string& url, Http::HeaderMap& header, Buffer::Instance& data) -> Http::Code {  \
-    return X(url, header, data);                                                                   \
+  [this](const std::string& url, Http::HeaderMap& response_headers, Buffer::Instance& data)        \
+      -> Http::Code {                                                                              \
+    return X(url, response_headers, data);                                                         \
   }
 
 /**

--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -6,6 +6,7 @@
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/pure.h"
 #include "envoy/http/codes.h"
+#include "envoy/http/header_map.h"
 #include "envoy/network/listen_socket.h"
 
 namespace Envoy {
@@ -17,8 +18,10 @@ namespace Server {
  * used to add static handlers as in source/server/http/admin.cc and also dynamic handlers as
  * done in the RouteConfigProviderManagerImpl constructor in source/common/router/rds_impl.cc.
  */
-#define MAKE_ADMIN_HANDLER(X)                                                                      \
-  [this](const std::string& url, Buffer::Instance& data) -> Http::Code { return X(url, data); }
+#define MAKE_ADMIN_HANDLER(X)                                                                     \
+  [this](const std::string& url, Http::HeaderMap& header, Buffer::Instance& data) -> Http::Code { \
+    return X(url, header, data);                                                                  \
+  }
 
 /**
  * Global admin HTTP endpoint for the server.
@@ -33,7 +36,8 @@ public:
    * @param response supplies the buffer to fill in with the response body.
    * @return Http::Code the response code.
    */
-  typedef std::function<Http::Code(const std::string& url, Buffer::Instance& response)> HandlerCb;
+  typedef std::function<Http::Code(const std::string& url, Http::HeaderMap& header,
+                                   Buffer::Instance& response)> HandlerCb;
 
   /**
    * Add an admin handler.

--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -19,10 +19,8 @@ namespace Server {
  * done in the RouteConfigProviderManagerImpl constructor in source/common/router/rds_impl.cc.
  */
 #define MAKE_ADMIN_HANDLER(X)                                                                      \
-  [this](const std::string& url, Http::HeaderMap& response_headers, Buffer::Instance& data)        \
-      -> Http::Code {                                                                              \
-    return X(url, response_headers, data);                                                         \
-  }
+  [this](const std::string& url, Http::HeaderMap& response_headers,                                \
+         Buffer::Instance& data) -> Http::Code { return X(url, response_headers, data); }
 
 /**
  * Global admin HTTP endpoint for the server.

--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -33,6 +33,7 @@ public:
   /**
    * Callback for admin URL handlers.
    * @param url supplies the URL prefix to install the handler for.
+   * @param header enables setting of http headers (eg content-type, cache-control) in the handler.
    * @param response supplies the buffer to fill in with the response body.
    * @return Http::Code the response code.
    */

--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -32,11 +32,12 @@ public:
   /**
    * Callback for admin URL handlers.
    * @param url supplies the URL prefix to install the handler for.
-   * @param header enables setting of http headers (eg content-type, cache-control) in the handler.
+   * @param response_headers enables setting of http headers (eg content-type, cache-control) in the
+   * handler.
    * @param response supplies the buffer to fill in with the response body.
    * @return Http::Code the response code.
    */
-  typedef std::function<Http::Code(const std::string& url, Http::HeaderMap& header,
+  typedef std::function<Http::Code(const std::string& url, Http::HeaderMap& response_headers,
                                    Buffer::Instance& response)>
       HandlerCb;
 

--- a/source/common/html/BUILD
+++ b/source/common/html/BUILD
@@ -1,0 +1,15 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "utility_lib",
+    srcs = ["utility.cc"],
+    hdrs = ["utility.h"],
+)

--- a/source/common/html/BUILD
+++ b/source/common/html/BUILD
@@ -12,4 +12,5 @@ envoy_cc_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
     hdrs = ["utility.h"],
+    external_deps = ["abseil_strings"],
 )

--- a/source/common/html/utility.cc
+++ b/source/common/html/utility.cc
@@ -8,12 +8,8 @@ namespace Envoy {
 namespace Html {
 
 std::string Utility::sanitize(const std::string& text) {
-  return absl::StrReplaceAll(text, {
-        {"&", "&amp;"},
-        {"<", "&lt;"},
-        {">", "&gt;"},
-        {"\"", "&quot;"},
-        {"'", "&#39;"}});
+  return absl::StrReplaceAll(
+      text, {{"&", "&amp;"}, {"<", "&lt;"}, {">", "&gt;"}, {"\"", "&quot;"}, {"'", "&#39;"}});
 }
 
 } // namespace Html

--- a/source/common/html/utility.cc
+++ b/source/common/html/utility.cc
@@ -10,16 +10,28 @@ std::string Utility::sanitize(const std::string& text) {
   std::string buffer;
   for (char ch : text) {
     switch (ch) {
-      case '&':  buffer.append("&amp;");       break;
-      case '\"': buffer.append("&quot;");      break;
-      case '\'': buffer.append("&apos;");      break;
-      case '<':  buffer.append("&lt;");        break;
-      case '>':  buffer.append("&gt;");        break;
-      default:   buffer.append(1, ch);         break;
+    case '&':
+      buffer.append("&amp;");
+      break;
+    case '\"':
+      buffer.append("&quot;");
+      break;
+    case '\'':
+      buffer.append("&apos;");
+      break;
+    case '<':
+      buffer.append("&lt;");
+      break;
+    case '>':
+      buffer.append("&gt;");
+      break;
+    default:
+      buffer.append(1, ch);
+      break;
     }
   }
   return buffer;
 }
 
-}  // namespace Html
-}  // namespace Envoy
+} // namespace Html
+} // namespace Envoy

--- a/source/common/html/utility.cc
+++ b/source/common/html/utility.cc
@@ -2,35 +2,18 @@
 
 #include <string>
 
+#include "absl/strings/str_replace.h"
+
 namespace Envoy {
 namespace Html {
 
-/* static */
 std::string Utility::sanitize(const std::string& text) {
-  std::string buffer;
-  for (char ch : text) {
-    switch (ch) {
-    case '&':
-      buffer.append("&amp;");
-      break;
-    case '\"':
-      buffer.append("&quot;");
-      break;
-    case '\'':
-      buffer.append("&apos;");
-      break;
-    case '<':
-      buffer.append("&lt;");
-      break;
-    case '>':
-      buffer.append("&gt;");
-      break;
-    default:
-      buffer.append(1, ch);
-      break;
-    }
-  }
-  return buffer;
+  return absl::StrReplaceAll(text, {
+        {"&", "&amp;"},
+        {"<", "&lt;"},
+        {">", "&gt;"},
+        {"\"", "&quot;"},
+        {"'", "&#39;"}});
 }
 
 } // namespace Html

--- a/source/common/html/utility.cc
+++ b/source/common/html/utility.cc
@@ -1,0 +1,25 @@
+#include "common/html/utility.h"
+
+#include <string>
+
+namespace Envoy {
+namespace Html {
+
+/* static */
+std::string Utility::sanitize(const std::string& text) {
+  std::string buffer;
+  for (char ch : text) {
+    switch (ch) {
+      case '&':  buffer.append("&amp;");       break;
+      case '\"': buffer.append("&quot;");      break;
+      case '\'': buffer.append("&apos;");      break;
+      case '<':  buffer.append("&lt;");        break;
+      case '>':  buffer.append("&gt;");        break;
+      default:   buffer.append(1, ch);         break;
+    }
+  }
+  return buffer;
+}
+
+}  // namespace Html
+}  // namespace Envoy

--- a/source/common/html/utility.h
+++ b/source/common/html/utility.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+
+namespace Envoy {
+namespace Html {
+
+/**
+ * General HTML utilities.
+ */
+class Utility {
+ public:
+  /**
+   * Sanitizes arbitrary text so it can be included in HTML.
+   * @param text arbitrary text to be escaped for safe inclusion in HTML.
+   */
+  static std::string sanitize(const std::string& text);
+};
+
+}  // namespace Html
+}  // namespace Envoy

--- a/source/common/html/utility.h
+++ b/source/common/html/utility.h
@@ -9,7 +9,7 @@ namespace Html {
  * General HTML utilities.
  */
 class Utility {
- public:
+public:
   /**
    * Sanitizes arbitrary text so it can be included in HTML.
    * @param text arbitrary text to be escaped for safe inclusion in HTML.
@@ -17,5 +17,5 @@ class Utility {
   static std::string sanitize(const std::string& text);
 };
 
-}  // namespace Html
-}  // namespace Envoy
+} // namespace Html
+} // namespace Envoy

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -24,6 +24,7 @@ public:
   const LowerCaseString AccessControlMaxAge{"access-control-max-age"};
   const LowerCaseString AccessControlAllowCredentials{"access-control-allow-credentials"};
   const LowerCaseString Authorization{"authorization"};
+  const LowerCaseString CacheControl{"cache-control"};
   const LowerCaseString ClientTraceId{"x-client-trace-id"};
   const LowerCaseString Connection{"connection"};
   const LowerCaseString ContentLength{"content-length"};
@@ -82,6 +83,7 @@ public:
   const LowerCaseString XB3ParentSpanId{"x-b3-parentspanid"};
   const LowerCaseString XB3Sampled{"x-b3-sampled"};
   const LowerCaseString XB3Flags{"x-b3-flags"};
+  const LowerCaseString XContentTypeOptions{"x-content-type-options"};
 
   struct {
     const std::string Close{"close"};

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -100,7 +100,7 @@ public:
 
   struct {
     const std::string Text{"text/plain"};
-    const std::string TextUtf8{"text/plain; charset=UTF-8"};  // TODO(jmarantz): fold this into Text
+    const std::string TextUtf8{"text/plain; charset=UTF-8"}; // TODO(jmarantz): fold this into Text
     const std::string Html{"text/html; charset=UTF-8"};
     const std::string Grpc{"application/grpc"};
     const std::string GrpcWeb{"application/grpc-web"};

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -95,7 +95,13 @@ public:
   } UpgradeValues;
 
   struct {
+    const std::string NoCacheMaxAge0{"no-cache, max-age=0"};
+  } CacheControlValues;
+
+  struct {
     const std::string Text{"text/plain"};
+    const std::string TextUtf8{"text/plain; charset=UTF-8"};  // TODO(jmarantz): fold this into Text
+    const std::string Html{"text/html; charset=UTF-8"};
     const std::string Grpc{"application/grpc"};
     const std::string GrpcWeb{"application/grpc-web"};
     const std::string GrpcWebProto{"application/grpc-web+proto"};
@@ -160,6 +166,10 @@ public:
   struct {
     const std::string Trailers{"trailers"};
   } TEValues;
+
+  struct {
+    const std::string Nosniff{"nosniff"};
+  } XContentTypeOptionValues;
 
   struct {
     const std::string True{"true"};

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -205,8 +205,8 @@ Router::RouteConfigProviderSharedPtr RouteConfigProviderManagerImpl::getRouteCon
   return new_provider;
 };
 
-Http::Code RouteConfigProviderManagerImpl::handlerRoutes(const std::string& url,
-                                                         Buffer::Instance& response) {
+Http::Code RouteConfigProviderManagerImpl::handlerRoutes(
+    const std::string& url, Http::HeaderMap&, Buffer::Instance& response) {
   Http::Utility::QueryParams query_params = Http::Utility::parseQueryString(url);
   // If there are no query params, print out all the configured route tables.
   if (query_params.size() == 0) {

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -205,8 +205,8 @@ Router::RouteConfigProviderSharedPtr RouteConfigProviderManagerImpl::getRouteCon
   return new_provider;
 };
 
-Http::Code RouteConfigProviderManagerImpl::handlerRoutes(
-    const std::string& url, Http::HeaderMap&, Buffer::Instance& response) {
+Http::Code RouteConfigProviderManagerImpl::handlerRoutes(const std::string& url, Http::HeaderMap&,
+                                                         Buffer::Instance& response) {
   Http::Utility::QueryParams query_params = Http::Utility::parseQueryString(url);
   // If there are no query params, print out all the configured route tables.
   if (query_params.size() == 0) {

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -166,11 +166,13 @@ private:
    * The handler used in the Admin /routes endpoint. This handler is used to
    * populate the response Buffer::Instance with information about the currently
    * loaded dynamic HTTP Route Tables.
-   * @param url supplies the url sent to the Admin endpoint.
+   * @param path_and_query supplies the url path and query-params sent to the Admin endpoint.
+   * @param response_headers enables setting of http headers (eg content-type, cache-control) in
+   * the handler.
    * @param response supplies the buffer to fill with information.
    * @return Http::Code OK if the endpoint can parse and operate on the url, NotFound otherwise.
    */
-  Http::Code handlerRoutes(const std::string& url, Http::HeaderMap& response_headers,
+  Http::Code handlerRoutes(const std::string& path_and_query, Http::HeaderMap& response_headers,
                            Buffer::Instance& response);
 
   /**

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -170,7 +170,7 @@ private:
    * @param response supplies the buffer to fill with information.
    * @return Http::Code OK if the endpoint can parse and operate on the url, NotFound otherwise.
    */
-  Http::Code handlerRoutes(const std::string& url, Http::HeaderMap& headers,
+  Http::Code handlerRoutes(const std::string& url, Http::HeaderMap& response_headers,
                            Buffer::Instance& response);
 
   /**

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -170,7 +170,8 @@ private:
    * @param response supplies the buffer to fill with information.
    * @return Http::Code OK if the endpoint can parse and operate on the url, NotFound otherwise.
    */
-  Http::Code handlerRoutes(const std::string& url, Buffer::Instance& response);
+  Http::Code handlerRoutes(const std::string& url, Http::HeaderMap& headers,
+                           Buffer::Instance& response);
 
   /**
    * Helper function used by handlerRoutes. The function loops through the providers

--- a/source/server/http/BUILD
+++ b/source/server/http/BUILD
@@ -33,6 +33,7 @@ envoy_cc_library(
         "//source/common/common:macros",
         "//source/common/common:utility_lib",
         "//source/common/common:version_includes",
+        "//source/common/html:utility_lib",
         "//source/common/http:codes_lib",
         "//source/common/http:conn_manager_lib",
         "//source/common/http:date_provider_lib",

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -53,12 +53,12 @@ namespace {
 
 /**
  * Favicon base64 image was harvested by screen-capturing the favicon from a Chrome tab
- * while visiting https://www.envoyproxy.io/.  The resulting PNG was translated to base64
+ * while visiting https://www.envoyproxy.io/. The resulting PNG was translated to base64
  * by dropping it into https://www.base64-image.de/ and then pasting the resulting string
  * below.
  *
  * The actual favicon source for that, https://www.envoyproxy.io/img/favicon.ico is nicer
- * because it's transparent, but is also 67646 bytes, which is annoying to inline.  We could
+ * because it's transparent, but is also 67646 bytes, which is annoying to inline. We could
  * just reference that rather than inlining it, but then the favicon won't work when visiting
  * the admin page from a network that can't see the internet.
  */

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1,4 +1,5 @@
 #include "server/http/admin.h"
+
 #include <cstdint>
 #include <fstream>
 #include <string>
@@ -620,13 +621,13 @@ bool AdminImpl::addHandler(const std::string& prefix, const std::string& help_te
                            HandlerCb callback, bool removable) {
   // Sanitize prefix and help_text to ensure no XSS can be injected, as
   // we are injecting these strings into HTML that runs in a domain that
-  // can mutate Envoy server state.  Also rule out some characters that
+  // can mutate Envoy server state. Also rule out some characters that
   // make no sense as part of a URL path: ? and :.
   //
   // TODO(jmarantz): replace with absl definitive absl implementation
   std::string::size_type pos = prefix.find_first_of("&\"'<>?:");
   if (pos != std::string::npos) {
-    ENVOY_LOG(error, "filter \"{}\" contains invalid character '{}'" , prefix[pos]);
+    ENVOY_LOG(error, "filter \"{}\" contains invalid character '{}'", prefix[pos]);
     return false;
   }
 

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -64,7 +64,8 @@ const char kEnvoyFavicon[] =
     "ErkJggg==";
 
 const char kAdminHtmlStart[] = R"(
-    <head>
+<head>
+  <title>Envoy Admin</title>
   <link rel='shortcut icon' type='image/png' href='@FAVICON@'/>
   <style>
     .home-table {

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -496,7 +496,8 @@ void AdminFilter::onComplete() {
   }
   // Default to 'no-cache' if unset, but not 'no-store' which may break the 'back button.
   if (header_map->CacheControl() == nullptr) {
-    header_map->insertCacheControl().value().setReference(headers.CacheControlValues.NoCacheMaxAge0);
+    header_map->insertCacheControl().value().setReference(
+        headers.CacheControlValues.NoCacheMaxAge0);
   }
 
   // Under no circumstance should browsers sniff content-type.

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1,5 +1,4 @@
 #include "server/http/admin.h"
-
 #include <cstdint>
 #include <fstream>
 #include <string>
@@ -20,6 +19,7 @@
 #include "common/common/enum_to_int.h"
 #include "common/common/utility.h"
 #include "common/common/version.h"
+#include "common/html/utility.h"
 #include "common/http/codes.h"
 #include "common/http/header_map_impl.h"
 #include "common/http/headers.h"
@@ -142,7 +142,8 @@ void AdminImpl::addCircuitSettings(const std::string& cluster_name, const std::s
                            resource_manager.retries().max()));
 }
 
-Http::Code AdminImpl::handlerClusters(const std::string&, Buffer::Instance& response) {
+Http::Code AdminImpl::handlerClusters(const std::string&, Http::HeaderMap&,
+                                      Buffer::Instance& response) {
   response.add(fmt::format("version_info::{}\n", server_.clusterManager().versionInfo()));
 
   for (auto& cluster : server_.clusterManager().clusters()) {
@@ -198,7 +199,8 @@ Http::Code AdminImpl::handlerClusters(const std::string&, Buffer::Instance& resp
   return Http::Code::OK;
 }
 
-Http::Code AdminImpl::handlerCpuProfiler(const std::string& url, Buffer::Instance& response) {
+Http::Code AdminImpl::handlerCpuProfiler(const std::string& url, Http::HeaderMap&,
+                                         Buffer::Instance& response) {
   Http::Utility::QueryParams query_params = Http::Utility::parseQueryString(url);
   if (query_params.size() != 1 || query_params.begin()->first != "enable" ||
       (query_params.begin()->second != "y" && query_params.begin()->second != "n")) {
@@ -221,24 +223,28 @@ Http::Code AdminImpl::handlerCpuProfiler(const std::string& url, Buffer::Instanc
   return Http::Code::OK;
 }
 
-Http::Code AdminImpl::handlerHealthcheckFail(const std::string&, Buffer::Instance& response) {
+Http::Code AdminImpl::handlerHealthcheckFail(const std::string&, Http::HeaderMap&,
+                                             Buffer::Instance& response) {
   server_.failHealthcheck(true);
   response.add("OK\n");
   return Http::Code::OK;
 }
 
-Http::Code AdminImpl::handlerHealthcheckOk(const std::string&, Buffer::Instance& response) {
+Http::Code AdminImpl::handlerHealthcheckOk(const std::string&, Http::HeaderMap&,
+                                           Buffer::Instance& response) {
   server_.failHealthcheck(false);
   response.add("OK\n");
   return Http::Code::OK;
 }
 
-Http::Code AdminImpl::handlerHotRestartVersion(const std::string&, Buffer::Instance& response) {
+Http::Code AdminImpl::handlerHotRestartVersion(const std::string&, Http::HeaderMap&,
+                                               Buffer::Instance& response) {
   response.add(server_.hotRestart().version());
   return Http::Code::OK;
 }
 
-Http::Code AdminImpl::handlerLogging(const std::string& url, Buffer::Instance& response) {
+Http::Code AdminImpl::handlerLogging(const std::string& url, Http::HeaderMap&,
+                                     Buffer::Instance& response) {
   Http::Utility::QueryParams query_params = Http::Utility::parseQueryString(url);
 
   Http::Code rc = Http::Code::OK;
@@ -263,7 +269,8 @@ Http::Code AdminImpl::handlerLogging(const std::string& url, Buffer::Instance& r
   return rc;
 }
 
-Http::Code AdminImpl::handlerResetCounters(const std::string&, Buffer::Instance& response) {
+Http::Code AdminImpl::handlerResetCounters(const std::string&, Http::HeaderMap&,
+                                           Buffer::Instance& response) {
   for (const Stats::CounterSharedPtr& counter : server_.stats().counters()) {
     counter->reset();
   }
@@ -272,7 +279,8 @@ Http::Code AdminImpl::handlerResetCounters(const std::string&, Buffer::Instance&
   return Http::Code::OK;
 }
 
-Http::Code AdminImpl::handlerServerInfo(const std::string&, Buffer::Instance& response) {
+Http::Code AdminImpl::handlerServerInfo(const std::string&, Http::HeaderMap&,
+                                        Buffer::Instance& response) {
   time_t current_time = time(nullptr);
   response.add(fmt::format("envoy {} {} {} {} {}\n", VersionInfo::version(),
                            server_.healthCheckFailed() ? "draining" : "live",
@@ -282,7 +290,8 @@ Http::Code AdminImpl::handlerServerInfo(const std::string&, Buffer::Instance& re
   return Http::Code::OK;
 }
 
-Http::Code AdminImpl::handlerStats(const std::string& url, Buffer::Instance& response) {
+Http::Code AdminImpl::handlerStats(const std::string& url, Http::HeaderMap&,
+                                   Buffer::Instance& response) {
   // We currently don't support timers locally (only via statsd) so just group all the counters
   // and gauges together, alpha sort them, and spit them out.
   Http::Code rc = Http::Code::OK;
@@ -379,13 +388,15 @@ std::string AdminImpl::statsAsJson(const std::map<std::string, uint64_t>& all_st
   return strbuf.GetString();
 }
 
-Http::Code AdminImpl::handlerQuitQuitQuit(const std::string&, Buffer::Instance& response) {
+Http::Code AdminImpl::handlerQuitQuitQuit(const std::string&, Http::HeaderMap&,
+                                          Buffer::Instance& response) {
   server_.shutdown();
   response.add("OK\n");
   return Http::Code::OK;
 }
 
-Http::Code AdminImpl::handlerListenerInfo(const std::string&, Buffer::Instance& response) {
+Http::Code AdminImpl::handlerListenerInfo(const std::string&, Http::HeaderMap&,
+                                          Buffer::Instance& response) {
   std::list<std::string> listeners;
   for (auto listener : server_.listenerManager().listeners()) {
     listeners.push_back(listener.get().socket().localAddress()->asString());
@@ -394,7 +405,8 @@ Http::Code AdminImpl::handlerListenerInfo(const std::string&, Buffer::Instance& 
   return Http::Code::OK;
 }
 
-Http::Code AdminImpl::handlerCerts(const std::string&, Buffer::Instance& response) {
+Http::Code AdminImpl::handlerCerts(const std::string&, Http::HeaderMap&,
+                                   Buffer::Instance& response) {
   // This set is used to track distinct certificates. We may have multiple listeners, upstreams, etc
   // using the same cert.
   std::unordered_set<std::string> context_info_set;
@@ -417,11 +429,21 @@ void AdminFilter::onComplete() {
   ENVOY_STREAM_LOG(debug, "request complete: path: {}", *callbacks_, path);
 
   Buffer::OwnedImpl response;
-  Http::Code code = parent_.runCallback(path, response);
-
-  Http::HeaderMapPtr headers{
-      new Http::HeaderMapImpl{{Http::Headers::get().Status, std::to_string(enumToInt(code))}}};
-  callbacks_->encodeHeaders(std::move(headers), response.length() == 0);
+  Http::HeaderMapPtr header_map{new Http::HeaderMapImpl};
+  Http::Code code = parent_.runCallback(path, *header_map, response);
+  const auto& headers = Http::Headers::get();
+  header_map->addReferenceKey(headers.Status, std::to_string(enumToInt(code)));
+  if (header_map->ContentType() == nullptr) {
+    // Default to text-plain if unset.
+    header_map->addReferenceKey(headers.ContentType, "text/plain; charset=UTF-8");
+  }
+  // Default to 'no-cache' if unset, but not 'no-store' which may break the 'back button.
+  if (header_map->CacheControl() == nullptr) {
+    header_map->addReferenceKey(headers.CacheControl, "no-cache, max-age=0");
+  }
+  // Under no circumstance should browsers sniff content-type.
+  header_map->addReferenceKey(headers.XContentTypeOptions, "nosniff");
+  callbacks_->encodeHeaders(std::move(header_map), response.length() == 0);
 
   if (response.length() > 0) {
     callbacks_->encodeData(response, true);
@@ -441,27 +463,50 @@ AdminImpl::AdminImpl(const std::string& access_log_path, const std::string& prof
       tracing_stats_(Http::ConnectionManagerImpl::generateTracingStats("http.admin.tracing.",
                                                                        server_.stats())),
       handlers_{
+          {"/", "Admin home page", MAKE_ADMIN_HANDLER(handlerAdminHome), false},
           {"/certs", "print certs on machine", MAKE_ADMIN_HANDLER(handlerCerts), false},
           {"/clusters", "upstream cluster status", MAKE_ADMIN_HANDLER(handlerClusters), false},
           {"/cpuprofiler", "enable/disable the CPU profiler",
-           MAKE_ADMIN_HANDLER(handlerCpuProfiler), false},
+                MAKE_ADMIN_HANDLER(handlerCpuProfiler), false},
           {"/healthcheck/fail", "cause the server to fail health checks",
-           MAKE_ADMIN_HANDLER(handlerHealthcheckFail), false},
+                MAKE_ADMIN_HANDLER(handlerHealthcheckFail), false},
           {"/healthcheck/ok", "cause the server to pass health checks",
-           MAKE_ADMIN_HANDLER(handlerHealthcheckOk), false},
+                MAKE_ADMIN_HANDLER(handlerHealthcheckOk), false},
           {"/hot_restart_version", "print the hot restart compatability version",
-           MAKE_ADMIN_HANDLER(handlerHotRestartVersion), false},
+                MAKE_ADMIN_HANDLER(handlerHotRestartVersion), false},
           {"/logging", "query/change logging levels", MAKE_ADMIN_HANDLER(handlerLogging), false},
           {"/quitquitquit", "exit the server", MAKE_ADMIN_HANDLER(handlerQuitQuitQuit), false},
           {"/reset_counters", "reset all counters to zero",
-           MAKE_ADMIN_HANDLER(handlerResetCounters), false},
+                MAKE_ADMIN_HANDLER(handlerResetCounters), false},
           {"/server_info", "print server version/status information",
-           MAKE_ADMIN_HANDLER(handlerServerInfo), false},
+                MAKE_ADMIN_HANDLER(handlerServerInfo), false},
           {"/stats", "print server stats", MAKE_ADMIN_HANDLER(handlerStats), false},
           {"/listeners", "print listener addresses", MAKE_ADMIN_HANDLER(handlerListenerInfo),
-           false}},
+                false}},
       listener_stats_(
           Http::ConnectionManagerImpl::generateListenerStats("http.admin.", listener_scope)) {
+        /*
+  addHandler("/", "Admin home page", MAKE_ADMIN_HANDLER(handlerAdminHome), false);
+  addHandler("/certs", "print certs on machine", MAKE_ADMIN_HANDLER(handlerCerts), false);
+  addHandler("/clusters", "upstream cluster status", MAKE_ADMIN_HANDLER(handlerClusters), false);
+  addHandler("/cpuprofiler", "enable/disable the CPU profiler",
+             MAKE_ADMIN_HANDLER(handlerCpuProfiler), false);
+  addHandler("/healthcheck/fail", "cause the server to fail health checks",
+             MAKE_ADMIN_HANDLER(handlerHealthcheckFail), false);
+  addHandler("/healthcheck/ok", "cause the server to pass health checks",
+             MAKE_ADMIN_HANDLER(handlerHealthcheckOk), false);
+  addHandler("/hot_restart_version", "print the hot restart compatibility version",
+             MAKE_ADMIN_HANDLER(handlerHotRestartVersion), false);
+  addHandler("/logging", "query/change logging levels", MAKE_ADMIN_HANDLER(handlerLogging), false);
+  addHandler("/quitquitquit", "exit the server", MAKE_ADMIN_HANDLER(handlerQuitQuitQuit), false);
+  addHandler("/reset_counters", "reset all counters to zero",
+             MAKE_ADMIN_HANDLER(handlerResetCounters), false);
+  addHandler("/server_info", "print server version/status information",
+             MAKE_ADMIN_HANDLER(handlerServerInfo), false);
+  addHandler("/stats", "print server stats", MAKE_ADMIN_HANDLER(handlerStats), false);
+  addHandler("/listeners", "print listener addresses",
+             MAKE_ADMIN_HANDLER(handlerListenerInfo), false);;
+        */
 
   if (!address_out_path.empty()) {
     std::ofstream address_out_file(address_out_path);
@@ -496,20 +541,27 @@ void AdminImpl::createFilterChain(Http::FilterChainFactoryCallbacks& callbacks) 
   callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterSharedPtr{new AdminFilter(*this)});
 }
 
-Http::Code AdminImpl::runCallback(const std::string& path, Buffer::Instance& response) {
+Http::Code AdminImpl::runCallback(const std::string& path_and_query, Http::HeaderMap& header_map,
+                                  Buffer::Instance& response) {
   Http::Code code = Http::Code::OK;
   bool found_handler = false;
+
+  std::string::size_type query_index = path_and_query.find('?');
+  if (query_index == std::string::npos) {
+    query_index = path_and_query.size();
+  }
+
   for (const UrlHandler& handler : handlers_) {
-    if (path.find(handler.prefix_) == 0) {
-      code = handler.handler_(path, response);
+    if (path_and_query.compare(0, query_index, handler.prefix_) == 0) {
+      code = handler.handler_(path_and_query, header_map, response);
       found_handler = true;
       break;
     }
   }
 
   if (!found_handler) {
-    code = Http::Code::NotFound;
-    response.add("envoy admin commands:\n");
+    header_map.addReferenceKey(Http::Headers::get().ContentType, "text/plain; charset=UTF-8");
+    response.add("invalid path. admin commands are:\n");
 
     // Prefix order is used during searching, but for printing do them in alpha order.
     std::map<std::string, const UrlHandler*> sorted_handlers;
@@ -520,9 +572,66 @@ Http::Code AdminImpl::runCallback(const std::string& path, Buffer::Instance& res
     for (auto handler : sorted_handlers) {
       response.add(fmt::format("  {}: {}\n", handler.first, handler.second->help_text_));
     }
+    code = Http::Code::NotFound;
   }
 
   return code;
+}
+
+Http::Code AdminImpl::handlerAdminHome(const std::string&, Http::HeaderMap& header_map,
+                                       Buffer::Instance& response) {
+  header_map.addReferenceKey(Http::Headers::get().ContentType, "text/html; charset=UTF-8");
+
+  // Prefix order is used during searching, but for printing do them in alpha order.
+  std::map<std::string, const UrlHandler*> sorted_handlers;
+  for (const UrlHandler& handler : handlers_) {
+    sorted_handlers[handler.prefix_] = &handler;
+  }
+
+  response.add(R"(
+<head>
+  <link rel='shortcut icon' type='image/png' href='https://www.envoyproxy.io/img/favicon.ico'/>
+  <style>
+    .home-table {
+      font-family: sans-serif;
+      font-size: medium;
+      border-collapse: collapse;
+    }
+
+    .home-row:nth-child(even) {
+      background-color: #dddddd;
+    }
+
+    .home-data {
+      border: 1px solid #dddddd;
+      text-align: left;
+      padding: 8px;
+    }
+  </style>
+</head>
+<body>
+  <table class='home-table'>
+    <thead>
+      <th class='home-data'>Command</th>
+      <th class='home-data'>Description</th>
+     </thead>
+     <tbody>
+)");
+
+  for (auto handler : sorted_handlers) {
+    // Handlers are all specified by statically above, and are thus trusted and do
+    // not require escaping.
+    response.add(fmt::format("<tr class='home-row'><td class='home-data'><a href='{}'>{}</a></td>"
+                             "<td class='home-data'>{}</td></tr>\n",
+                             handler.first, handler.first,
+                             Html::Utility::sanitize(handler.second->help_text_)));
+  }
+  response.add(R"(
+    </tbody>
+  </table>
+</body>
+)");
+  return Http::Code::OK;
 }
 
 const Network::Address::Instance& AdminImpl::localAddress() {
@@ -531,6 +640,18 @@ const Network::Address::Instance& AdminImpl::localAddress() {
 
 bool AdminImpl::addHandler(const std::string& prefix, const std::string& help_text,
                            HandlerCb callback, bool removable) {
+  // Sanitize prefix and help_text to ensure no XSS can be injected, as
+  // we are injecting these strings into HTML that runs in a domain that
+  // can mutate Envoy server state.  Also rule out some characters that
+  // make no sense as part of a URL path: ? and :.
+  //
+  // TODO(jmarantz): replace with absl definitive absl implementation
+  std::string::size_type pos = prefix.find_first_of("&\"'<>?:");
+  if (pos != std::string::npos) {
+    ENVOY_LOG(error, "filter \"{}\" contains invalid character '{}'" , prefix[pos]);
+    return false;
+  }
+
   auto it = std::find_if(handlers_.cbegin(), handlers_.cend(),
                          [&prefix](const UrlHandler& entry) { return prefix == entry.prefix_; });
   if (it == handlers_.end()) {

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -5,8 +5,6 @@
 #include <string>
 #include <unordered_set>
 
-#include "absl/strings/str_replace.h"
-
 #include "envoy/filesystem/filesystem.h"
 #include "envoy/server/hot_restart.h"
 #include "envoy/server/instance.h"
@@ -33,6 +31,7 @@
 #include "common/router/config_impl.h"
 #include "common/upstream/host_utility.h"
 
+#include "absl/strings/str_replace.h"
 #include "fmt/format.h"
 
 // TODO(mattklein123): Switch to JSON interface methods and remove rapidjson dependency.
@@ -100,7 +99,7 @@ const char kAdminHtmlEnd[] = R"(
 </body>
 )";
 
-}  // namespace
+} // namespace
 
 AdminFilter::AdminFilter(AdminImpl& parent) : parent_(parent) {}
 

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -508,7 +508,7 @@ void AdminFilter::onComplete() {
     // Default to text-plain if unset.
     header_map->insertContentType().value().setReference(headers.ContentTypeValues.TextUtf8);
   }
-  // Default to 'no-cache' if unset, but not 'no-store' which may break the 'back button.
+  // Default to 'no-cache' if unset, but not 'no-store' which may break the back button.
   if (header_map->CacheControl() == nullptr) {
     header_map->insertCacheControl().value().setReference(
         headers.CacheControlValues.NoCacheMaxAge0);
@@ -612,6 +612,8 @@ Http::Code AdminImpl::runCallback(const std::string& path_and_query,
   }
 
   if (!found_handler) {
+    // Extra space is emitted below to have "invalid path." be a separate sentence in the
+    // 404 output from "admin commands are:" in handlerHelp.
     response.add("invalid path. ");
     handlerHelp(path_and_query, response_headers, response);
     code = Http::Code::NotFound;
@@ -630,7 +632,7 @@ Http::Code AdminImpl::handlerHelp(const std::string&, Http::HeaderMap&,
     sorted_handlers[handler.prefix_] = &handler;
   }
 
-  for (auto handler : sorted_handlers) {
+  for (const auto handler : sorted_handlers) {
     response.add(fmt::format("  {}: {}\n", handler.first, handler.second->help_text_));
   }
   return Http::Code::OK;
@@ -648,7 +650,7 @@ Http::Code AdminImpl::handlerAdminHome(const std::string&, Http::HeaderMap& resp
   }
 
   response.add(absl::StrReplaceAll(AdminHtmlStart, {{"@FAVICON@", EnvoyFavicon}}));
-  for (auto handler : sorted_handlers) {
+  for (const auto handler : sorted_handlers) {
     // Handlers are all specified by statically above, and are thus trusted and do
     // not require escaping.
     response.add(fmt::format("<tr class='home-row'><td class='home-data'><a href='{}'>{}</a></td>"

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -467,46 +467,24 @@ AdminImpl::AdminImpl(const std::string& access_log_path, const std::string& prof
           {"/certs", "print certs on machine", MAKE_ADMIN_HANDLER(handlerCerts), false},
           {"/clusters", "upstream cluster status", MAKE_ADMIN_HANDLER(handlerClusters), false},
           {"/cpuprofiler", "enable/disable the CPU profiler",
-                MAKE_ADMIN_HANDLER(handlerCpuProfiler), false},
+           MAKE_ADMIN_HANDLER(handlerCpuProfiler), false},
           {"/healthcheck/fail", "cause the server to fail health checks",
-                MAKE_ADMIN_HANDLER(handlerHealthcheckFail), false},
+           MAKE_ADMIN_HANDLER(handlerHealthcheckFail), false},
           {"/healthcheck/ok", "cause the server to pass health checks",
-                MAKE_ADMIN_HANDLER(handlerHealthcheckOk), false},
+           MAKE_ADMIN_HANDLER(handlerHealthcheckOk), false},
           {"/hot_restart_version", "print the hot restart compatability version",
-                MAKE_ADMIN_HANDLER(handlerHotRestartVersion), false},
+           MAKE_ADMIN_HANDLER(handlerHotRestartVersion), false},
           {"/logging", "query/change logging levels", MAKE_ADMIN_HANDLER(handlerLogging), false},
           {"/quitquitquit", "exit the server", MAKE_ADMIN_HANDLER(handlerQuitQuitQuit), false},
           {"/reset_counters", "reset all counters to zero",
-                MAKE_ADMIN_HANDLER(handlerResetCounters), false},
+           MAKE_ADMIN_HANDLER(handlerResetCounters), false},
           {"/server_info", "print server version/status information",
-                MAKE_ADMIN_HANDLER(handlerServerInfo), false},
+           MAKE_ADMIN_HANDLER(handlerServerInfo), false},
           {"/stats", "print server stats", MAKE_ADMIN_HANDLER(handlerStats), false},
           {"/listeners", "print listener addresses", MAKE_ADMIN_HANDLER(handlerListenerInfo),
-                false}},
+           false}},
       listener_stats_(
           Http::ConnectionManagerImpl::generateListenerStats("http.admin.", listener_scope)) {
-        /*
-  addHandler("/", "Admin home page", MAKE_ADMIN_HANDLER(handlerAdminHome), false);
-  addHandler("/certs", "print certs on machine", MAKE_ADMIN_HANDLER(handlerCerts), false);
-  addHandler("/clusters", "upstream cluster status", MAKE_ADMIN_HANDLER(handlerClusters), false);
-  addHandler("/cpuprofiler", "enable/disable the CPU profiler",
-             MAKE_ADMIN_HANDLER(handlerCpuProfiler), false);
-  addHandler("/healthcheck/fail", "cause the server to fail health checks",
-             MAKE_ADMIN_HANDLER(handlerHealthcheckFail), false);
-  addHandler("/healthcheck/ok", "cause the server to pass health checks",
-             MAKE_ADMIN_HANDLER(handlerHealthcheckOk), false);
-  addHandler("/hot_restart_version", "print the hot restart compatibility version",
-             MAKE_ADMIN_HANDLER(handlerHotRestartVersion), false);
-  addHandler("/logging", "query/change logging levels", MAKE_ADMIN_HANDLER(handlerLogging), false);
-  addHandler("/quitquitquit", "exit the server", MAKE_ADMIN_HANDLER(handlerQuitQuitQuit), false);
-  addHandler("/reset_counters", "reset all counters to zero",
-             MAKE_ADMIN_HANDLER(handlerResetCounters), false);
-  addHandler("/server_info", "print server version/status information",
-             MAKE_ADMIN_HANDLER(handlerServerInfo), false);
-  addHandler("/stats", "print server stats", MAKE_ADMIN_HANDLER(handlerStats), false);
-  addHandler("/listeners", "print listener addresses",
-             MAKE_ADMIN_HANDLER(handlerListenerInfo), false);;
-        */
 
   if (!address_out_path.empty()) {
     std::ofstream address_out_file(address_out_path);

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -35,7 +35,8 @@ public:
             const std::string& address_out_path, Network::Address::InstanceConstSharedPtr address,
             Server::Instance& server, Stats::Scope& listener_scope);
 
-  Http::Code runCallback(const std::string& path, Buffer::Instance& response);
+  Http::Code runCallback(const std::string& path_and_query, Http::HeaderMap& headers,
+                         Buffer::Instance& response);
   const Network::ListenSocket& socket() override { return *socket_; }
   Network::ListenSocket& mutable_socket() { return *socket_; }
 
@@ -124,18 +125,33 @@ private:
   /**
    * URL handlers.
    */
-  Http::Code handlerCerts(const std::string& url, Buffer::Instance& response);
-  Http::Code handlerClusters(const std::string& url, Buffer::Instance& response);
-  Http::Code handlerCpuProfiler(const std::string& url, Buffer::Instance& response);
-  Http::Code handlerHealthcheckFail(const std::string& url, Buffer::Instance& response);
-  Http::Code handlerHealthcheckOk(const std::string& url, Buffer::Instance& response);
-  Http::Code handlerHotRestartVersion(const std::string& url, Buffer::Instance& response);
-  Http::Code handlerLogging(const std::string& url, Buffer::Instance& response);
-  Http::Code handlerResetCounters(const std::string& url, Buffer::Instance& response);
-  Http::Code handlerServerInfo(const std::string& url, Buffer::Instance& response);
-  Http::Code handlerStats(const std::string& url, Buffer::Instance& response);
-  Http::Code handlerQuitQuitQuit(const std::string& url, Buffer::Instance& response);
-  Http::Code handlerListenerInfo(const std::string& url, Buffer::Instance& response);
+  Http::Code handlerAdminHome(const std::string& url, Http::HeaderMap& headers,
+                              Buffer::Instance& response);
+  Http::Code handlerCerts(const std::string& url, Http::HeaderMap& headers,
+                          Buffer::Instance& response);
+  Http::Code handlerClusters(const std::string& url, Http::HeaderMap& headers,
+                             Buffer::Instance& response);
+  Http::Code handlerCpuProfiler(const std::string& url, Http::HeaderMap& headers,
+                                Buffer::Instance& response);
+  Http::Code handlerHealthcheckFail(const std::string& url, Http::HeaderMap& headers,
+                                    Buffer::Instance& response);
+  Http::Code handlerHealthcheckOk(const std::string& url, Http::HeaderMap& headers,
+                                  Buffer::Instance& response);
+  Http::Code handlerHotRestartVersion(const std::string& url, Http::HeaderMap& headers,
+                                      Buffer::Instance& response);
+  Http::Code handlerListenerInfo(const std::string& url, Http::HeaderMap& headers,
+                                 Buffer::Instance& response);
+  Http::Code handlerLogging(const std::string& url, Http::HeaderMap& headers,
+                            Buffer::Instance& response);
+  Http::Code handlerMain(const std::string& path, Buffer::Instance& response);
+  Http::Code handlerQuitQuitQuit(const std::string& url, Http::HeaderMap& headers,
+                                 Buffer::Instance& response);
+  Http::Code handlerResetCounters(const std::string& url, Http::HeaderMap& headers,
+                                  Buffer::Instance& response);
+  Http::Code handlerServerInfo(const std::string& url, Http::HeaderMap& headers,
+                               Buffer::Instance& response);
+  Http::Code handlerStats(const std::string& url, Http::HeaderMap& headers,
+                          Buffer::Instance& response);
 
   Server::Instance& server_;
   std::list<AccessLog::InstanceSharedPtr> access_logs_;

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -179,8 +179,8 @@ public:
   void onDestroy() override {}
 
   // Http::StreamDecoderFilter
-  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap& response_headers, bool end_stream)
-      override;
+  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap& response_headers,
+                                          bool end_stream) override;
   Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override;
   Http::FilterTrailersStatus decodeTrailers(Http::HeaderMap& trailers) override;
   void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override {

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -35,7 +35,7 @@ public:
             const std::string& address_out_path, Network::Address::InstanceConstSharedPtr address,
             Server::Instance& server, Stats::Scope& listener_scope);
 
-  Http::Code runCallback(const std::string& path_and_query, Http::HeaderMap& headers,
+  Http::Code runCallback(const std::string& path_and_query, Http::HeaderMap& response_headers,
                          Buffer::Instance& response);
   const Network::ListenSocket& socket() override { return *socket_; }
   Network::ListenSocket& mutable_socket() { return *socket_; }
@@ -125,32 +125,32 @@ private:
   /**
    * URL handlers.
    */
-  Http::Code handlerAdminHome(const std::string& url, Http::HeaderMap& headers,
+  Http::Code handlerAdminHome(const std::string& url, Http::HeaderMap& response_headers,
                               Buffer::Instance& response);
-  Http::Code handlerCerts(const std::string& url, Http::HeaderMap& headers,
+  Http::Code handlerCerts(const std::string& url, Http::HeaderMap& response_headers,
                           Buffer::Instance& response);
-  Http::Code handlerClusters(const std::string& url, Http::HeaderMap& headers,
+  Http::Code handlerClusters(const std::string& url, Http::HeaderMap& response_headers,
                              Buffer::Instance& response);
-  Http::Code handlerCpuProfiler(const std::string& url, Http::HeaderMap& headers,
+  Http::Code handlerCpuProfiler(const std::string& url, Http::HeaderMap& response_headers,
                                 Buffer::Instance& response);
-  Http::Code handlerHealthcheckFail(const std::string& url, Http::HeaderMap& headers,
+  Http::Code handlerHealthcheckFail(const std::string& url, Http::HeaderMap& response_headers,
                                     Buffer::Instance& response);
-  Http::Code handlerHealthcheckOk(const std::string& url, Http::HeaderMap& headers,
+  Http::Code handlerHealthcheckOk(const std::string& url, Http::HeaderMap& response_headers,
                                   Buffer::Instance& response);
-  Http::Code handlerHotRestartVersion(const std::string& url, Http::HeaderMap& headers,
+  Http::Code handlerHotRestartVersion(const std::string& url, Http::HeaderMap& response_headers,
                                       Buffer::Instance& response);
-  Http::Code handlerListenerInfo(const std::string& url, Http::HeaderMap& headers,
+  Http::Code handlerListenerInfo(const std::string& url, Http::HeaderMap& response_headers,
                                  Buffer::Instance& response);
-  Http::Code handlerLogging(const std::string& url, Http::HeaderMap& headers,
+  Http::Code handlerLogging(const std::string& url, Http::HeaderMap& response_headers,
                             Buffer::Instance& response);
   Http::Code handlerMain(const std::string& path, Buffer::Instance& response);
-  Http::Code handlerQuitQuitQuit(const std::string& url, Http::HeaderMap& headers,
+  Http::Code handlerQuitQuitQuit(const std::string& url, Http::HeaderMap& response_headers,
                                  Buffer::Instance& response);
-  Http::Code handlerResetCounters(const std::string& url, Http::HeaderMap& headers,
+  Http::Code handlerResetCounters(const std::string& url, Http::HeaderMap& response_headers,
                                   Buffer::Instance& response);
-  Http::Code handlerServerInfo(const std::string& url, Http::HeaderMap& headers,
+  Http::Code handlerServerInfo(const std::string& url, Http::HeaderMap& response_headers,
                                Buffer::Instance& response);
-  Http::Code handlerStats(const std::string& url, Http::HeaderMap& headers,
+  Http::Code handlerStats(const std::string& url, Http::HeaderMap& response_headers,
                           Buffer::Instance& response);
 
   Server::Instance& server_;
@@ -179,7 +179,8 @@ public:
   void onDestroy() override {}
 
   // Http::StreamDecoderFilter
-  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap& headers, bool end_stream) override;
+  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap& response_headers, bool end_stream)
+      override;
   Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override;
   Http::FilterTrailersStatus decodeTrailers(Http::HeaderMap& trailers) override;
   void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override {

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -125,32 +125,35 @@ private:
   /**
    * URL handlers.
    */
-  Http::Code handlerAdminHome(const std::string& url, Http::HeaderMap& response_headers,
+  Http::Code handlerAdminHome(const std::string& path_and_query, Http::HeaderMap& response_headers,
                               Buffer::Instance& response);
-  Http::Code handlerCerts(const std::string& url, Http::HeaderMap& response_headers,
+  Http::Code handlerCerts(const std::string& path_and_query, Http::HeaderMap& response_headers,
                           Buffer::Instance& response);
-  Http::Code handlerClusters(const std::string& url, Http::HeaderMap& response_headers,
+  Http::Code handlerClusters(const std::string& path_and_query, Http::HeaderMap& response_headers,
                              Buffer::Instance& response);
-  Http::Code handlerCpuProfiler(const std::string& url, Http::HeaderMap& response_headers,
-                                Buffer::Instance& response);
-  Http::Code handlerHealthcheckFail(const std::string& url, Http::HeaderMap& response_headers,
-                                    Buffer::Instance& response);
-  Http::Code handlerHealthcheckOk(const std::string& url, Http::HeaderMap& response_headers,
-                                  Buffer::Instance& response);
-  Http::Code handlerHotRestartVersion(const std::string& url, Http::HeaderMap& response_headers,
+  Http::Code handlerCpuProfiler(const std::string& path_and_query,
+                                Http::HeaderMap& response_headers, Buffer::Instance& response);
+  Http::Code handlerHealthcheckFail(const std::string& path_and_query,
+                                    Http::HeaderMap& response_headers, Buffer::Instance& response);
+  Http::Code handlerHealthcheckOk(const std::string& path_and_query,
+                                  Http::HeaderMap& response_headers, Buffer::Instance& response);
+  Http::Code handlerHelp(const std::string& path_and_query, Http::HeaderMap& response_headers,
+                         Buffer::Instance& response);
+  Http::Code handlerHotRestartVersion(const std::string& path_and_query,
+                                      Http::HeaderMap& response_headers,
                                       Buffer::Instance& response);
-  Http::Code handlerListenerInfo(const std::string& url, Http::HeaderMap& response_headers,
-                                 Buffer::Instance& response);
-  Http::Code handlerLogging(const std::string& url, Http::HeaderMap& response_headers,
+  Http::Code handlerListenerInfo(const std::string& path_and_query,
+                                 Http::HeaderMap& response_headers, Buffer::Instance& response);
+  Http::Code handlerLogging(const std::string& path_and_query, Http::HeaderMap& response_headers,
                             Buffer::Instance& response);
   Http::Code handlerMain(const std::string& path, Buffer::Instance& response);
-  Http::Code handlerQuitQuitQuit(const std::string& url, Http::HeaderMap& response_headers,
-                                 Buffer::Instance& response);
-  Http::Code handlerResetCounters(const std::string& url, Http::HeaderMap& response_headers,
-                                  Buffer::Instance& response);
-  Http::Code handlerServerInfo(const std::string& url, Http::HeaderMap& response_headers,
+  Http::Code handlerQuitQuitQuit(const std::string& path_and_query,
+                                 Http::HeaderMap& response_headers, Buffer::Instance& response);
+  Http::Code handlerResetCounters(const std::string& path_and_query,
+                                  Http::HeaderMap& response_headers, Buffer::Instance& response);
+  Http::Code handlerServerInfo(const std::string& path_and_query, Http::HeaderMap& response_headers,
                                Buffer::Instance& response);
-  Http::Code handlerStats(const std::string& url, Http::HeaderMap& response_headers,
+  Http::Code handlerStats(const std::string& path_and_query, Http::HeaderMap& response_headers,
                           Buffer::Instance& response);
 
   Server::Instance& server_;

--- a/test/common/html/BUILD
+++ b/test/common/html/BUILD
@@ -1,0 +1,17 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_test",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_test(
+    name = "utility_test",
+    srcs = ["utility_test.cc"],
+    deps = [
+        "//source/common/html:utility_lib",
+    ],
+)

--- a/test/common/html/utility_test.cc
+++ b/test/common/html/utility_test.cc
@@ -11,5 +11,5 @@ TEST(HttpUtility, sanitizeHtml) {
   EXPECT_EQ("&lt;script&gt;", Utility::sanitize("<script>"));
 }
 
-} // namespace Http
+} // namespace Html
 } // namespace Envoy

--- a/test/common/html/utility_test.cc
+++ b/test/common/html/utility_test.cc
@@ -5,7 +5,7 @@
 namespace Envoy {
 namespace Html {
 
-TEST(HttpUtility, sanitizeHtml) {
+TEST(HttpUtility, SanitizeHtml) {
   EXPECT_EQ("simple text, no cares/worries", Utility::sanitize("simple text, no cares/worries"));
   EXPECT_EQ("a&amp;b", Utility::sanitize("a&b"));
   EXPECT_EQ("&lt;script&gt;", Utility::sanitize("<script>"));

--- a/test/common/html/utility_test.cc
+++ b/test/common/html/utility_test.cc
@@ -1,0 +1,15 @@
+#include "common/html/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Html {
+
+TEST(HttpUtility, sanitizeHtml) {
+  EXPECT_EQ("simple text, no cares/worries", Utility::sanitize("simple text, no cares/worries"));
+  EXPECT_EQ("a&amp;b", Utility::sanitize("a&b"));
+  EXPECT_EQ("&lt;script&gt;", Utility::sanitize("<script>"));
+}
+
+} // namespace Http
+} // namespace Envoy

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -330,14 +330,14 @@ TEST_F(RdsImplTest, Basic) {
   EXPECT_EQ(8808926191882896258U, store_.gauge("foo.rds.foo_route_config.version").value());
 
   // Test that we get the same dump if we specify the route name.
-  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes?route_config_name=foo_route_config",
-                                              header_map, data));
+  EXPECT_EQ(Http::Code::OK,
+            handler_callback_("/routes?route_config_name=foo_route_config", header_map, data));
   EXPECT_EQ(routes_expected_output_full_table, TestUtility::bufferToString(data));
   data.drain(data.length());
 
   // Test that we get an emtpy response if the name does not match.
-  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes?route_config_name=does_not_exist",
-                                              header_map, data));
+  EXPECT_EQ(Http::Code::OK,
+            handler_callback_("/routes?route_config_name=does_not_exist", header_map, data));
   EXPECT_EQ("[\n]\n", TestUtility::bufferToString(data));
   data.drain(data.length());
 

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -212,7 +212,8 @@ TEST_F(RdsImplTest, Basic) {
 ]
 )EOF";
   EXPECT_EQ("", rds_->versionInfo());
-  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes", data));
+  Http::HeaderMapImpl header_map;
+  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes", header_map, data));
   EXPECT_EQ(routes_expected_output_no_routes, TestUtility::bufferToString(data));
   data.drain(data.length());
   EXPECT_EQ(0UL, store_.gauge("foo.rds.foo_route_config.version").value());
@@ -245,7 +246,7 @@ TEST_F(RdsImplTest, Basic) {
 )EOF";
 
   EXPECT_EQ("hash_15ed54077da94d8b", rds_->versionInfo());
-  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes", data));
+  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes", header_map, data));
   EXPECT_EQ(routes_expected_output_only_name, TestUtility::bufferToString(data));
   data.drain(data.length());
   EXPECT_EQ(1580011435426663819U, store_.gauge("foo.rds.foo_route_config.version").value());
@@ -263,7 +264,7 @@ TEST_F(RdsImplTest, Basic) {
   EXPECT_EQ(nullptr, rds_->config()->route(Http::TestHeaderMapImpl{{":authority", "foo"}}, 0));
 
   // Test Admin /routes handler. The route table should not change.
-  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes", data));
+  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes", header_map, data));
   EXPECT_EQ(routes_expected_output_only_name, TestUtility::bufferToString(data));
   data.drain(data.length());
   EXPECT_EQ(1580011435426663819U, store_.gauge("foo.rds.foo_route_config.version").value());
@@ -323,18 +324,20 @@ TEST_F(RdsImplTest, Basic) {
 ]
 )EOF";
 
-  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes", data));
+  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes", header_map, data));
   EXPECT_EQ(routes_expected_output_full_table, TestUtility::bufferToString(data));
   data.drain(data.length());
   EXPECT_EQ(8808926191882896258U, store_.gauge("foo.rds.foo_route_config.version").value());
 
   // Test that we get the same dump if we specify the route name.
-  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes?route_config_name=foo_route_config", data));
+  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes?route_config_name=foo_route_config",
+                                              header_map, data));
   EXPECT_EQ(routes_expected_output_full_table, TestUtility::bufferToString(data));
   data.drain(data.length());
 
   // Test that we get an emtpy response if the name does not match.
-  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes?route_config_name=does_not_exist", data));
+  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes?route_config_name=does_not_exist",
+                                              header_map, data));
   EXPECT_EQ("[\n]\n", TestUtility::bufferToString(data));
   data.drain(data.length());
 
@@ -344,7 +347,7 @@ TEST_F(RdsImplTest, Basic) {
 })EOF";
 
   // Test that we get the help text if we use the command in an invalid ways.
-  EXPECT_EQ(Http::Code::NotFound, handler_callback_("/routes?bad_param", data));
+  EXPECT_EQ(Http::Code::NotFound, handler_callback_("/routes?bad_param", header_map, data));
   EXPECT_EQ(routes_expected_output_usage, TestUtility::bufferToString(data));
   data.drain(data.length());
 
@@ -510,7 +513,8 @@ TEST_F(RouteConfigProviderManagerImplTest, Basic) {
 )EOF";
 
   // Test Admin /routes handler.
-  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes", data));
+  Http::HeaderMapImpl header_map;
+  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes", header_map, data));
   EXPECT_EQ(routes_expected_output, TestUtility::bufferToString(data));
   data.drain(data.length());
 

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -100,28 +100,50 @@ TEST_P(IntegrationAdminTest, AdminLogging) {
   }
 }
 
+namespace {
+
+const char* ContentType(const BufferingStreamDecoderPtr& response) {
+  const Http::HeaderEntry* entry = response->headers().ContentType();
+  if (entry == nullptr) {
+    return "(null)";
+  }
+  return entry->value().c_str();
+}
+
+}  // namespace
+
 TEST_P(IntegrationAdminTest, Admin) {
   initialize();
 
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("admin"), "GET", "/", "", downstreamProtocol(), version_);
+      lookupPort("admin"), "GET", "/notfound", "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
+  EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
+
+  response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/", "",
+                                                downstreamProtocol(), version_);
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_STREQ("text/html; charset=UTF-8", ContentType(response));
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/server_info", "",
                                                 downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/stats", "",
                                                 downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/stats?format=blah",
                                                 "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
+  EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/stats?format=json",
                                                 "", downstreamProtocol(), version_);
@@ -129,6 +151,7 @@ TEST_P(IntegrationAdminTest, Admin) {
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   Json::ObjectSharedPtr statsjson = Json::Factory::loadFromString(response->body());
   EXPECT_TRUE(statsjson->hasObject("stats"));
+  EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
 
   response = IntegrationUtil::makeSingleRequest(
       lookupPort("admin"), "GET", "/stats?format=prometheus", "", downstreamProtocol(), version_);
@@ -154,31 +177,37 @@ TEST_P(IntegrationAdminTest, Admin) {
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   EXPECT_THAT(response->body(), testing::HasSubstr("added_via_api"));
   EXPECT_THAT(response->body(), testing::HasSubstr("version_info::static\n"));
+  EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/cpuprofiler", "",
                                                 downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("400", response->headers().Status()->value().c_str());
+  EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/hot_restart_version",
                                                 "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/reset_counters", "",
                                                 downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/certs", "",
                                                 downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/listeners", "",
                                                 downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
 
   Json::ObjectSharedPtr json = Json::Factory::loadFromString(response->body());
   std::vector<Json::ObjectSharedPtr> listener_info = json->asObjectArray();

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -207,7 +207,7 @@ TEST_P(IntegrationAdminTest, Admin) {
                                                 downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
-  EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
+  EXPECT_STREQ("application/json", ContentType(response));
 
   Json::ObjectSharedPtr json = Json::Factory::loadFromString(response->body());
   std::vector<Json::ObjectSharedPtr> listener_info = json->asObjectArray();

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -110,7 +110,7 @@ const char* ContentType(const BufferingStreamDecoderPtr& response) {
   return entry->value().c_str();
 }
 
-}  // namespace
+} // namespace
 
 TEST_P(IntegrationAdminTest, Admin) {
   initialize();

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -120,12 +120,23 @@ TEST_P(IntegrationAdminTest, Admin) {
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
   EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
+  EXPECT_NE(std::string::npos, response->body().find("invalid path. admin commands are:"))
+      << response->body();
+
+  response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/help", "",
+                                                downstreamProtocol(), version_);
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
+  EXPECT_NE(std::string::npos, response->body().find("admin commands are:")) << response->body();
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/", "",
                                                 downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   EXPECT_STREQ("text/html; charset=UTF-8", ContentType(response));
+  EXPECT_NE(std::string::npos, response->body().find("<title>Envoy Admin</title>"))
+      << response->body();
 
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/server_info", "",
                                                 downstreamProtocol(), version_);

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -151,7 +151,7 @@ TEST_P(IntegrationAdminTest, Admin) {
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   Json::ObjectSharedPtr statsjson = Json::Factory::loadFromString(response->body());
   EXPECT_TRUE(statsjson->hasObject("stats"));
-  EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
+  EXPECT_STREQ("application/json", ContentType(response));
 
   response = IntegrationUtil::makeSingleRequest(
       lookupPort("admin"), "GET", "/stats?format=prometheus", "", downstreamProtocol(), version_);


### PR DESCRIPTION
Having an HTML page with live links on HOST:admin_port/ makes the list of commands easier to find and visit from a browser.

Make the admin HandlerCb pass through a headers reference so handlers
can optionally set the content-type and/or cache-control, changing the
defaults to text/plain and no-cache, respectively.

Added sanitization of both the prefix string and the help text, which
need to be safely injected into the HTML doc.

Added some styling and a reference to the existing Envoy favicon as
well.

Added some tests and several test-variants to existing tests.

Note: this changes the dispatch mechanism in the admin handlers from prefix-based to exact-matches of the non-query part of the URL path.

Risk Level: Low

Testing: Ran all integration and unit tests.  Added new unit and integration tests for new functionality and code.

Docs Changes: N/A; none made; not sure if any are required.  Please let me know in the PR if there is a suitable doc to be editing for this.

Fixes https://github.com/envoyproxy/envoy/issues/2246

Signed-off-by: Joshua Marantz <jmarantz@google.com>
