### PR TITLE
stats: universal tag support with cli option

### DIFF
--- a/RAW_RELEASE_NOTES.md
+++ b/RAW_RELEASE_NOTES.md
@@ -25,3 +25,5 @@ final version.
 * Added idle timeout to TCP proxy.
 * Added support for dynamic headers generated from upstream host endpoint metadata
   (`UPSTREAM_METADATA(...)`).
+* Added universal tag support, the tags which will be added to all metrics. The tags can be specified
+  with commandline argument. :ref:`Command line options doc<operations_cli>`.

--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -87,6 +87,7 @@ envoy_cc_library(
     hdrs = ["options.h"],
     deps = [
         "//include/envoy/network:address_interface",
+        "//include/envoy/stats:stats_interface",
     ],
 )
 

--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -6,6 +6,7 @@
 
 #include "envoy/common/pure.h"
 #include "envoy/network/address.h"
+#include "envoy/stats/stats.h"
 
 #include "spdlog/spdlog.h"
 
@@ -126,6 +127,11 @@ public:
    * @return const std::string& the server's zone.
    */
   virtual const std::string& serviceZone() PURE;
+
+  /**
+   * @return const std::vector<Stats::Tag> default stats tags.
+   */
+  virtual const std::vector<Stats::Tag> statsTags() PURE;
 
   /**
    * @return uint64_t the maximum number of stats gauges and counters.

--- a/include/envoy/stats/stats.h
+++ b/include/envoy/stats/stats.h
@@ -246,6 +246,11 @@ public:
   virtual void setTagExtractors(const std::vector<TagExtractorPtr>& tag_extractor) PURE;
 
   /**
+   * Set the given tags as default tags for all metrics.
+   */
+  virtual void setDefaultTags(const std::vector<Tag> tags) PURE;
+
+  /**
    * Initialize the store for threading. This will be called once after all worker threads have
    * been initialized. At this point the store can initialize itself for multi-threaded operation.
    */

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -87,6 +87,8 @@ void ThreadLocalStoreImpl::releaseScopeCrossThread(ScopeImpl* scope) {
 }
 
 std::string ThreadLocalStoreImpl::getTagsForName(const std::string& name, std::vector<Tag>& tags) {
+  tags.insert(tags.end(), default_tags_.begin(), default_tags_.end());
+
   std::string tag_extracted_name = name;
   if (tag_extractors_ != nullptr) {
     for (const TagExtractorPtr& tag_extractor : *tag_extractors_) {

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -70,6 +70,7 @@ public:
   void setTagExtractors(const std::vector<TagExtractorPtr>& tag_extractors) override {
     tag_extractors_ = &tag_extractors;
   }
+  void setDefaultTags(const std::vector<Tag> tags) override { default_tags_ = tags; }
   void initializeThreading(Event::Dispatcher& main_thread_dispatcher,
                            ThreadLocal::Instance& tls) override;
   void shutdownThreading() override;
@@ -122,6 +123,7 @@ private:
   ScopePtr default_scope_;
   std::list<std::reference_wrapper<Sink>> timer_sinks_;
   const std::vector<TagExtractorPtr>* tag_extractors_{};
+  std::vector<Tag> default_tags_{};
   std::atomic<bool> shutting_down_{};
   Counter& num_last_resort_stats_;
   HeapRawStatDataAllocator heap_allocator_;

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -148,6 +148,7 @@ envoy_cc_library(
     deps = [
         "//include/envoy/network:address_interface",
         "//include/envoy/server:options_interface",
+        "//include/envoy/stats:stats_interface",
         "//source/common/common:macros",
         "//source/common/common:version_lib",
         "//source/common/stats:stats_lib",

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -44,6 +44,7 @@ public:
   const std::string& serviceClusterName() override { return service_cluster_; }
   const std::string& serviceNodeName() override { return service_node_; }
   const std::string& serviceZone() override { return service_zone_; }
+  const std::vector<Stats::Tag> statsTags() override { return stats_tags_; }
   uint64_t maxStats() override { return max_stats_; }
   uint64_t maxObjNameLength() override { return max_obj_name_length_; }
 
@@ -60,6 +61,7 @@ private:
   std::string service_cluster_;
   std::string service_node_;
   std::string service_zone_;
+  std::vector<Stats::Tag> stats_tags_;
   std::chrono::milliseconds file_flush_interval_msec_;
   std::chrono::seconds drain_time_;
   std::chrono::seconds parent_shutdown_time_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -192,6 +192,8 @@ void InstanceImpl::initialize(Options& options,
   // stats.
   tag_extractors_ = Config::Utility::createTagExtractors(bootstrap);
   stats_store_.setTagExtractors(tag_extractors_);
+  default_tags_ = options.statsTags();
+  stats_store_.setDefaultTags(default_tags_);
 
   server_stats_.reset(
       new ServerStats{ALL_SERVER_STATS(POOL_GAUGE_PREFIX(stats_store_, "server."))});

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -178,6 +178,7 @@ private:
   time_t original_start_time_;
   Stats::StoreRoot& stats_store_;
   std::vector<Stats::TagExtractorPtr> tag_extractors_;
+  std::vector<Stats::Tag> default_tags_;
   std::unique_ptr<ServerStats> server_stats_;
   ThreadLocal::Instance& thread_local_;
   Api::ApiPtr api_;

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -228,6 +228,7 @@ envoy_cc_test_library(
         "//include/envoy/server:configuration_interface",
         "//include/envoy/server:hot_restart_interface",
         "//include/envoy/server:options_interface",
+        "//include/envoy/stats:stats_interface",
         "//source/common/api:api_lib",
         "//source/common/buffer:buffer_lib",
         "//source/common/buffer:zero_copy_input_stream_lib",

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "envoy/server/options.h"
+#include "envoy/stats/stats.h"
 
 #include "common/common/assert.h"
 #include "common/common/logger.h"
@@ -51,6 +52,7 @@ public:
   const std::string& serviceClusterName() override { return service_cluster_name_; }
   const std::string& serviceNodeName() override { return service_node_name_; }
   const std::string& serviceZone() override { return service_zone_; }
+  const std::vector<Stats::Tag> statsTags() override { return stats_tags_; }
   uint64_t maxStats() override { return 16384; }
   uint64_t maxObjNameLength() override { return 60; }
 
@@ -61,6 +63,7 @@ private:
   const std::string service_cluster_name_;
   const std::string service_node_name_;
   const std::string service_zone_;
+  const std::vector<Stats::Tag> stats_tags_;
   const std::string log_path_;
 };
 
@@ -166,6 +169,7 @@ public:
   // Stats::StoreRoot
   void addSink(Sink&) override {}
   void setTagExtractors(const std::vector<TagExtractorPtr>&) override {}
+  void setDefaultTags(const std::vector<Tag>) override {}
   void initializeThreading(Event::Dispatcher&, ThreadLocal::Instance&) override {}
   void shutdownThreading() override {}
 

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -22,6 +22,7 @@ envoy_cc_mock(
         "//include/envoy/server:options_interface",
         "//include/envoy/server:worker_interface",
         "//include/envoy/ssl:context_manager_interface",
+        "//include/envoy/stats:stats_interface",
         "//source/common/singleton:manager_impl_lib",
         "//source/common/ssl:context_lib",
         "//source/common/stats:stats_lib",

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -25,6 +25,7 @@ MockOptions::MockOptions(const std::string& config_path)
   ON_CALL(*this, serviceClusterName()).WillByDefault(ReturnRef(service_cluster_name_));
   ON_CALL(*this, serviceNodeName()).WillByDefault(ReturnRef(service_node_name_));
   ON_CALL(*this, serviceZone()).WillByDefault(ReturnRef(service_zone_name_));
+  ON_CALL(*this, statsTags()).WillByDefault(Return(stats_tags_));
   ON_CALL(*this, logPath()).WillByDefault(ReturnRef(log_path_));
   ON_CALL(*this, maxStats()).WillByDefault(Return(1000));
   ON_CALL(*this, maxObjNameLength()).WillByDefault(Return(150));

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -13,6 +13,7 @@
 #include "envoy/server/options.h"
 #include "envoy/server/worker.h"
 #include "envoy/ssl/context_manager.h"
+#include "envoy/stats/stats.h"
 
 #include "common/ssl/context_manager_impl.h"
 #include "common/stats/stats_impl.h"
@@ -59,6 +60,7 @@ public:
   MOCK_METHOD0(serviceClusterName, const std::string&());
   MOCK_METHOD0(serviceNodeName, const std::string&());
   MOCK_METHOD0(serviceZone, const std::string&());
+  MOCK_METHOD0(statsTags, const std::vector<Stats::Tag>());
   MOCK_METHOD0(maxStats, uint64_t());
   MOCK_METHOD0(maxObjNameLength, uint64_t());
 
@@ -68,6 +70,7 @@ public:
   std::string service_cluster_name_;
   std::string service_node_name_;
   std::string service_zone_name_;
+  std::vector<Stats::Tag> stats_tags_;
   std::string log_path_;
 };
 

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -97,6 +97,7 @@ envoy_cc_test(
     deps = [
         "//source/common/common:utility_lib",
         "//source/server:options_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 


### PR DESCRIPTION
*Description*:
Support [universal tag](https://github.com/envoyproxy/envoy/issues/1975), the tags which will be added to all metrics. The main use case is to distinguish each Envoy instance by the the tag. This universal tag accepts arbitrary pairs of tag name and tag value.
The tags will be specified with commandline argument `--stats-tag`. The argument can be specified multiple times so that users can add multiple tags.

The original issue is https://github.com/envoyproxy/envoy/issues/1975.

*Risk Level*:
Medium - New features that are not enabled by default.

*Testing*:
unit test, manual testing with statsd_exporter v0.5.0 and Prometheus v2.0.0.

*Docs Changes*:
https://github.com/envoyproxy/data-plane-api/pull/361

*Release Notes*:
Added.

Fixes https://github.com/envoyproxy/envoy/issues/1975

*API Changes*:
N/A