### PR TITLE
listener manager: add modifiable status to listeners

### DIFF
--- a/include/envoy/server/listener_manager.h
+++ b/include/envoy/server/listener_manager.h
@@ -132,11 +132,14 @@ public:
    * will be gracefully drained once the new listener is ready to take traffic (e.g. when RDS has
    * been initialized).
    * @param config supplies the configuration proto.
+   * @param modifiable supplies whether the added listener can be updated or removed. If the
+   *        listener is not modifiable, future calls to this function or removeListener() on behalf
+   *        of this listener will return false.
    * @return TRUE if a listener was added or FALSE if the listener was not updated because it is
    *         a duplicate of the existing listener. This routine will throw an EnvoyException if
    *         there is a fundamental error preventing the listener from being added or updated.
    */
-  virtual bool addOrUpdateListener(const envoy::api::v2::Listener& config) PURE;
+  virtual bool addOrUpdateListener(const envoy::api::v2::Listener& config, bool modifiable) PURE;
 
   /**
    * @return std::vector<std::reference_wrapper<Listener>> a list of the currently loaded listeners.

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -46,7 +46,7 @@ void MainImpl::initialize(const envoy::api::v2::Bootstrap& bootstrap, Instance& 
   ENVOY_LOG(info, "loading {} listener(s)", listeners.size());
   for (ssize_t i = 0; i < listeners.size(); i++) {
     ENVOY_LOG(debug, "listener #{}:", i);
-    server.listenerManager().addOrUpdateListener(listeners[i]);
+    server.listenerManager().addOrUpdateListener(listeners[i], false);
   }
 
   if (bootstrap.dynamic_resources().has_lds_config()) {

--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -52,7 +52,7 @@ void LdsApi::onConfigUpdate(const ResourceVector& resources) {
   for (const auto& listener : resources) {
     const std::string listener_name = listener.name();
     listeners_to_remove.erase(listener_name);
-    if (listener_manager_.addOrUpdateListener(listener)) {
+    if (listener_manager_.addOrUpdateListener(listener, true)) {
       ENVOY_LOG(info, "lds: add/update listener '{}'", listener_name);
     } else {
       ENVOY_LOG(debug, "lds: add/update listener '{}' skipped", listener_name);

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -205,7 +205,8 @@ ListenerManagerStats ListenerManagerImpl::generateStats(Stats::Scope& scope) {
                                      POOL_GAUGE_PREFIX(scope, final_prefix))};
 }
 
-bool ListenerManagerImpl::addOrUpdateListener(const envoy::api::v2::Listener& config, bool locked) {
+bool ListenerManagerImpl::addOrUpdateListener(const envoy::api::v2::Listener& config,
+                                              bool modifiable) {
   std::string name;
   if (!config.name().empty()) {
     name = config.name();
@@ -229,7 +230,7 @@ bool ListenerManagerImpl::addOrUpdateListener(const envoy::api::v2::Listener& co
   }
 
   ListenerImplPtr new_listener(
-      new ListenerImpl(config, *this, name, locked, workers_started_, hash));
+      new ListenerImpl(config, *this, name, modifiable, workers_started_, hash));
   ListenerImpl& new_listener_ref = *new_listener;
 
   // We mandate that a listener with the same name must have the same configured address. This

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -71,7 +71,8 @@ ProdListenerComponentFactory::createDrainManager(envoy::api::v2::Listener::Drain
 }
 
 ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, ListenerManagerImpl& parent,
-                           const std::string& name, bool workers_started, uint64_t hash)
+                           const std::string& name, bool modifiable, bool workers_started,
+                           uint64_t hash)
     : parent_(parent),
       // TODO(htuch): Validate not pipe when doing v2.
       address_(
@@ -86,7 +87,7 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, ListenerManag
       use_original_dst_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, use_original_dst, false)),
       per_connection_buffer_limit_bytes_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, per_connection_buffer_limit_bytes, 1024 * 1024)),
-      listener_tag_(parent_.factory_.nextListenerTag()), name_(name),
+      listener_tag_(parent_.factory_.nextListenerTag()), name_(name), modifiable_(modifiable),
       workers_started_(workers_started), hash_(hash),
       local_drain_manager_(parent.factory_.createDrainManager(config.drain_type())) {
   // TODO(htuch): Support multiple filter chains #1280, add constraint to ensure we have at least on
@@ -204,7 +205,7 @@ ListenerManagerStats ListenerManagerImpl::generateStats(Stats::Scope& scope) {
                                      POOL_GAUGE_PREFIX(scope, final_prefix))};
 }
 
-bool ListenerManagerImpl::addOrUpdateListener(const envoy::api::v2::Listener& config) {
+bool ListenerManagerImpl::addOrUpdateListener(const envoy::api::v2::Listener& config, bool locked) {
   std::string name;
   if (!config.name().empty()) {
     name = config.name();
@@ -217,18 +218,18 @@ bool ListenerManagerImpl::addOrUpdateListener(const envoy::api::v2::Listener& co
   auto existing_active_listener = getListenerByName(active_listeners_, name);
   auto existing_warming_listener = getListenerByName(warming_listeners_, name);
 
-  // Do a quick hash check to see if we have a duplicate before going further. This check needs
-  // to be done against both warming and active.
-  // TODO(mattklein123): In v2 move away from hashes and just do an explicit proto equality check.
+  // Do a quick blocked update check before going further. This check needs to be done against both
+  // warming and active.
   if ((existing_warming_listener != warming_listeners_.end() &&
-       (*existing_warming_listener)->hash() == hash) ||
+       (*existing_warming_listener)->blockUpdate(hash)) ||
       (existing_active_listener != active_listeners_.end() &&
-       (*existing_active_listener)->hash() == hash)) {
-    ENVOY_LOG(debug, "duplicate listener '{}'. no add/update", name);
+       (*existing_active_listener)->blockUpdate(hash))) {
+    ENVOY_LOG(debug, "duplicate/locked listener '{}'. no add/update", name);
     return false;
   }
 
-  ListenerImplPtr new_listener(new ListenerImpl(config, *this, name, workers_started_, hash));
+  ListenerImplPtr new_listener(
+      new ListenerImpl(config, *this, name, locked, workers_started_, hash));
   ListenerImpl& new_listener_ref = *new_listener;
 
   // We mandate that a listener with the same name must have the same configured address. This
@@ -455,9 +456,11 @@ bool ListenerManagerImpl::removeListener(const std::string& name) {
 
   auto existing_active_listener = getListenerByName(active_listeners_, name);
   auto existing_warming_listener = getListenerByName(warming_listeners_, name);
-  if (existing_warming_listener == warming_listeners_.end() &&
-      existing_active_listener == active_listeners_.end()) {
-    ENVOY_LOG(debug, "unknown listener '{}'. no remove", name);
+  if ((existing_warming_listener == warming_listeners_.end() ||
+       (*existing_warming_listener)->blockRemove()) &&
+      (existing_active_listener == active_listeners_.end() ||
+       (*existing_active_listener)->blockRemove())) {
+    ENVOY_LOG(debug, "unknown/locked listener '{}'. no remove", name);
     return false;
   }
 
@@ -467,7 +470,7 @@ bool ListenerManagerImpl::removeListener(const std::string& name) {
     warming_listeners_.erase(existing_warming_listener);
   }
 
-  // If there is an active listener
+  // If there is an active listener it needs to be moved to draining.
   if (existing_active_listener != active_listeners_.end()) {
     drainListener(std::move(*existing_active_listener));
     active_listeners_.erase(existing_active_listener);

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -83,7 +83,7 @@ public:
   void onListenerWarmed(ListenerImpl& listener);
 
   // Server::ListenerManager
-  bool addOrUpdateListener(const envoy::api::v2::Listener& config) override;
+  bool addOrUpdateListener(const envoy::api::v2::Listener& config, bool locked) override;
   std::vector<std::reference_wrapper<Listener>> listeners() override;
   uint64_t numConnections() override;
   bool removeListener(const std::string& listener_name) override;
@@ -164,13 +164,20 @@ public:
    * @param config supplies the configuration proto.
    * @param parent supplies the owning manager.
    * @param name supplies the listener name.
+   * @param modifiable supplies whether the listener can be updated or removed.
    * @param workers_started supplies whether the listener is being added before or after workers
    *        have been started. This controls various behavior related to init management.
    * @param hash supplies the hash to use for duplicate checking.
    */
   ListenerImpl(const envoy::api::v2::Listener& config, ListenerManagerImpl& parent,
-               const std::string& name, bool workers_started, uint64_t hash);
+               const std::string& name, bool locked, bool workers_started, uint64_t hash);
   ~ListenerImpl();
+
+  /**
+   * Helper functions to determine whether a listener is blocked for update or remove.
+   */
+  bool blockUpdate(uint64_t new_hash) { return new_hash == hash_ || !modifiable_; }
+  bool blockRemove() { return !modifiable_; }
 
   /**
    * Called when a listener failed to be actually created on a worker.
@@ -184,7 +191,6 @@ public:
 
   Network::Address::InstanceConstSharedPtr address() const { return address_; }
   const Network::ListenSocketSharedPtr& getSocket() const { return socket_; }
-  uint64_t hash() const { return hash_; }
   void debugLog(const std::string& message);
   void initialize();
   DrainManager& localDrainManager() const { return *local_drain_manager_; }
@@ -245,6 +251,7 @@ private:
   const uint32_t per_connection_buffer_limit_bytes_;
   const uint64_t listener_tag_;
   const std::string name_;
+  const bool modifiable_;
   const bool workers_started_;
   const uint64_t hash_;
   InitManagerImpl dynamic_init_manager_;

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -83,7 +83,7 @@ public:
   void onListenerWarmed(ListenerImpl& listener);
 
   // Server::ListenerManager
-  bool addOrUpdateListener(const envoy::api::v2::Listener& config, bool locked) override;
+  bool addOrUpdateListener(const envoy::api::v2::Listener& config, bool modifiable) override;
   std::vector<std::reference_wrapper<Listener>> listeners() override;
   uint64_t numConnections() override;
   bool removeListener(const std::string& listener_name) override;
@@ -170,7 +170,7 @@ public:
    * @param hash supplies the hash to use for duplicate checking.
    */
   ListenerImpl(const envoy::api::v2::Listener& config, ListenerManagerImpl& parent,
-               const std::string& name, bool locked, bool workers_started, uint64_t hash);
+               const std::string& name, bool modifiable, bool workers_started, uint64_t hash);
   ~ListenerImpl();
 
   /**

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -81,7 +81,7 @@ TEST_P(EchoIntegrationTest, AddRemoveListener) {
       [&listener_added_by_worker]() -> void { listener_added_by_worker.setReady(); });
   test_server_->server().dispatcher().post([this, json, &listener_added_by_manager]() -> void {
     EXPECT_TRUE(test_server_->server().listenerManager().addOrUpdateListener(
-        Server::parseListenerFromJson(json)));
+        Server::parseListenerFromJson(json), true));
     listener_added_by_manager.setReady();
   });
   listener_added_by_worker.waitReady();

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -163,7 +163,7 @@ public:
   MockListenerManager();
   ~MockListenerManager();
 
-  MOCK_METHOD1(addOrUpdateListener, bool(const envoy::api::v2::Listener& config));
+  MOCK_METHOD2(addOrUpdateListener, bool(const envoy::api::v2::Listener& config, bool locked));
   MOCK_METHOD0(listeners, std::vector<std::reference_wrapper<Listener>>());
   MOCK_METHOD0(numConnections, uint64_t());
   MOCK_METHOD1(removeListener, bool(const std::string& listener_name));

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -163,7 +163,7 @@ public:
   MockListenerManager();
   ~MockListenerManager();
 
-  MOCK_METHOD2(addOrUpdateListener, bool(const envoy::api::v2::Listener& config, bool locked));
+  MOCK_METHOD2(addOrUpdateListener, bool(const envoy::api::v2::Listener& config, bool modifiable));
   MOCK_METHOD0(listeners, std::vector<std::reference_wrapper<Listener>>());
   MOCK_METHOD0(numConnections, uint64_t());
   MOCK_METHOD1(removeListener, bool(const std::string& listener_name));

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -45,11 +45,12 @@ public:
   }
 
   void expectAdd(const std::string& listener_name, bool updated) {
-    EXPECT_CALL(listener_manager_, addOrUpdateListener(_))
-        .WillOnce(Invoke([listener_name, updated](const envoy::api::v2::Listener& config) -> bool {
-          EXPECT_EQ(listener_name, config.name());
-          return updated;
-        }));
+    EXPECT_CALL(listener_manager_, addOrUpdateListener(_, true))
+        .WillOnce(
+            Invoke([listener_name, updated](const envoy::api::v2::Listener& config, bool) -> bool {
+              EXPECT_EQ(listener_name, config.name());
+              return updated;
+            }));
   }
 
   void expectRequest() {


### PR DESCRIPTION
To match the behavior of the cluster manager, static listeners should
not be modifiable. This creates a large amount of confusion.

*Risk Level*: Low
*Testing*: New UT, also covered by existing unit/integration teests
*Docs Changes*: https://github.com/envoyproxy/data-plane-api/pull/381
*Release Notes*: N/A (this was broken before and I don't think requires a release note)
Fixes https://github.com/envoyproxy/envoy/issues/2234
