### PR TITLE
Add "addReference" to buffer. This allows the buffer to store externa…

### DIFF
--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -40,7 +40,7 @@ public:
   virtual void done() PURE;
 
 protected:
-  virtual ~BufferFragment(){};
+  virtual ~BufferFragment() {}
 };
 
 /**
@@ -62,7 +62,7 @@ public:
    * the fragment->data() is no longer needed, fragment->done() is called.
    * @param fragment the externally owned data to add to the buffer.
    */
-  virtual void addBufferFragment(BufferFragment* fragment) PURE;
+  virtual void addBufferFragment(BufferFragment& fragment) PURE;
 
   /**
    * Copy a string into the buffer.

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -22,7 +22,7 @@ struct RawSlice {
  * A callback invoked when the buffer no longer needs an externally owned
  * data. This should be used to free the memory if necessary.
  */
-typedef void(*refReleaseCb)(const void*, size_t, void*);
+typedef void (*refReleaseCb)(const void*, size_t, void*);
 
 /**
  * A basic buffer abstraction.
@@ -47,8 +47,8 @@ public:
    * @param releaseArg optional argument passed to releaseCallback as <arg>.
    * @param size supplies the size of the data.
    */
-  virtual void addReference(
-    const void* data, uint64_t size, refReleaseCb releaseCallback, void* releaseArg) PURE;
+  virtual void addReference(const void* data, uint64_t size, refReleaseCb releaseCallback,
+                            void* releaseArg) PURE;
 
   /**
    * Copy a string into the buffer.

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -20,9 +20,7 @@ struct RawSlice {
 
 /**
  * A wrapper class to facilitate passing in externally owned data to a buffer via addBufferFragment.
- * When the buffer no longer needs the data passed in through a fragment, it calls decRef() on it.
- * Any implementation should ensure that the data() tied to a BufferFragment remains valid as long
- * it has > 0 ref count.
+ * When the buffer no longer needs the data passed in through a fragment, it calls done() on it.
  */
 class BufferFragment {
 public:
@@ -38,14 +36,9 @@ public:
   virtual size_t size() PURE;
 
   /**
-   * Increment the reference count for the data.
+   * Called by a buffer when the refernced data is no longer needed.
    */
-  virtual void incRef() PURE;
-
-  /**
-   * Decrement the reference count for the data.
-   */
-  virtual void decRef() PURE;
+  virtual void done() PURE;
 };
 
 /**

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -26,14 +26,14 @@ class BufferFragment {
 public:
   virtual ~BufferFragment(){};
   /**
-   * @return a pointer to the referenced data.
+   * @return const void* a pointer to the referenced data.
    */
-  virtual const void* data() PURE;
+  virtual const void* data() const PURE;
 
   /**
-   * @return the size of the referenced data.
+   * @return size_t the size of the referenced data.
    */
-  virtual size_t size() PURE;
+  virtual size_t size() const PURE;
 
   /**
    * Called by a buffer when the refernced data is no longer needed.

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -24,7 +24,6 @@ struct RawSlice {
  */
 class BufferFragment {
 public:
-  virtual ~BufferFragment(){};
   /**
    * @return const void* a pointer to the referenced data.
    */
@@ -39,6 +38,9 @@ public:
    * Called by a buffer when the refernced data is no longer needed.
    */
   virtual void done() PURE;
+
+protected:
+  virtual ~BufferFragment(){};
 };
 
 /**

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -19,6 +19,12 @@ struct RawSlice {
 };
 
 /**
+ * A callback invoked when the buffer no longer needs an externally owned
+ * data. This should be used to free the memory if necessary.
+ */
+typedef void(*refReleaseCb)(const void*, size_t, void*);
+
+/**
  * A basic buffer abstraction.
  */
 class Instance {
@@ -31,6 +37,18 @@ public:
    * @param size supplies the data size.
    */
   virtual void add(const void* data, uint64_t size) PURE;
+
+  /**
+   * Add externally owned data to the buffer. Nothing is copied.
+   * The memory at <data> must be valid until all data has been read.
+   * <releaseCallback> is called when the memory is no longer needed by the buffer.
+   * @param data supplies a pointer to the externally owned data.
+   * @param releaseCallback a function to be called
+   * @param releaseArg optional argument passed to releaseCallback as <arg>.
+   * @param size supplies the size of the data.
+   */
+  virtual void addReference(
+    const void* data, uint64_t size, refReleaseCb releaseCallback, void* releaseArg) PURE;
 
   /**
    * Copy a string into the buffer.

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -57,7 +57,7 @@ public:
 
   /**
    * Add externally owned data into the buffer. No copying is done. fragment is not owned. When
-   * the fragment->data() is no longer needed, fragment->decRef() is called.
+   * the fragment->data() is no longer needed, fragment->done() is called.
    * @param fragment the externally owned data to add to the buffer.
    */
   virtual void addBufferFragment(BufferFragment* fragment) PURE;

--- a/source/common/buffer/BUILD
+++ b/source/common/buffer/BUILD
@@ -24,6 +24,7 @@ envoy_cc_library(
     hdrs = ["buffer_impl.h"],
     deps = [
         "//include/envoy/buffer:buffer_interface",
+        "//source/common/common:non_copyable",
         "//source/common/event:libevent_lib",
     ],
 )

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -21,6 +21,11 @@ static_assert(offsetof(RawSlice, len_) == offsetof(evbuffer_iovec, iov_len),
 
 void OwnedImpl::add(const void* data, uint64_t size) { evbuffer_add(buffer_.get(), data, size); }
 
+void OwnedImpl::addReference(
+    const void* data, uint64_t size, refReleaseCb releaseCallback, void* releaseArg) {
+  evbuffer_add_reference(buffer_.get(), data, size, releaseCallback, releaseArg);
+}
+
 void OwnedImpl::add(const std::string& data) {
   evbuffer_add(buffer_.get(), data.c_str(), data.size());
 }

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -21,9 +21,11 @@ static_assert(offsetof(RawSlice, len_) == offsetof(evbuffer_iovec, iov_len),
 
 void OwnedImpl::add(const void* data, uint64_t size) { evbuffer_add(buffer_.get(), data, size); }
 
-void OwnedImpl::addReference(const void* data, uint64_t size, refReleaseCb releaseCallback,
-                             void* releaseArg) {
-  evbuffer_add_reference(buffer_.get(), data, size, releaseCallback, releaseArg);
+void OwnedImpl::addBufferFragment(BufferFragment* fragment) {
+  evbuffer_add_reference(
+      buffer_.get(), fragment->data(), fragment->size(),
+      [](const void*, size_t, void* arg) { static_cast<BufferFragment*>(arg)->decRef(); },
+      fragment);
 }
 
 void OwnedImpl::add(const std::string& data) {

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -21,8 +21,8 @@ static_assert(offsetof(RawSlice, len_) == offsetof(evbuffer_iovec, iov_len),
 
 void OwnedImpl::add(const void* data, uint64_t size) { evbuffer_add(buffer_.get(), data, size); }
 
-void OwnedImpl::addReference(
-    const void* data, uint64_t size, refReleaseCb releaseCallback, void* releaseArg) {
+void OwnedImpl::addReference(const void* data, uint64_t size, refReleaseCb releaseCallback,
+                             void* releaseArg) {
   evbuffer_add_reference(buffer_.get(), data, size, releaseCallback, releaseArg);
 }
 

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -24,8 +24,7 @@ void OwnedImpl::add(const void* data, uint64_t size) { evbuffer_add(buffer_.get(
 void OwnedImpl::addBufferFragment(BufferFragment* fragment) {
   evbuffer_add_reference(
       buffer_.get(), fragment->data(), fragment->size(),
-      [](const void*, size_t, void* arg) { static_cast<BufferFragment*>(arg)->decRef(); },
-      fragment);
+      [](const void*, size_t, void* arg) { static_cast<BufferFragment*>(arg)->done(); }, fragment);
 }
 
 void OwnedImpl::add(const std::string& data) {

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -21,10 +21,10 @@ static_assert(offsetof(RawSlice, len_) == offsetof(evbuffer_iovec, iov_len),
 
 void OwnedImpl::add(const void* data, uint64_t size) { evbuffer_add(buffer_.get(), data, size); }
 
-void OwnedImpl::addBufferFragment(BufferFragment* fragment) {
+void OwnedImpl::addBufferFragment(BufferFragment& fragment) {
   evbuffer_add_reference(
-      buffer_.get(), fragment->data(), fragment->size(),
-      [](const void*, size_t, void* arg) { static_cast<BufferFragment*>(arg)->done(); }, fragment);
+      buffer_.get(), fragment.data(), fragment.size(),
+      [](const void*, size_t, void* arg) { static_cast<BufferFragment*>(arg)->done(); }, &fragment);
 }
 
 void OwnedImpl::add(const std::string& data) {

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -33,8 +33,8 @@ public:
 
   // LibEventInstance
   void add(const void* data, uint64_t size) override;
-  void addReference(
-    const void* data, uint64_t size, refReleaseCb releaseCallback, void* releaseArg) override;
+  void addReference(const void* data, uint64_t size, refReleaseCb releaseCallback,
+                    void* releaseArg) override;
   void add(const std::string& data) override;
   void add(const Instance& data) override;
   void commit(RawSlice* iovecs, uint64_t num_iovecs) override;

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -19,13 +19,14 @@ public:
   /**
    * Creates a new wrapper around the externally owned <data> of size <size>.
    * The caller must ensure <data> is valid until releasor() is called, or for the lifetime of the
-   * fragment.
+   * fragment. releasor() is called with <data>, <size> and <this> to allow caller to delete
+   * the fragment object.
    * @param data external data to reference
    * @param size size of data
    * @param releasor a callback function to be called when data is no longer needed.
    */
   BufferFragmentImpl(const void* data, size_t size,
-                     std::function<void(const void*, size_t)> releasor)
+                     std::function<void(const void*, size_t, const BufferFragmentImpl*)> releasor)
       : data_(data), size_(size), releasor_(releasor) {}
 
   const void* data() const override { return data_; }
@@ -33,7 +34,7 @@ public:
 
   void done() override {
     if (releasor_) {
-      releasor_(data_, size_);
+      releasor_(data_, size_, this);
     }
   }
 
@@ -43,7 +44,7 @@ public:
 private:
   const void* const data_;
   size_t size_;
-  std::function<void(const void*, size_t)> releasor_;
+  std::function<void(const void*, size_t, const BufferFragmentImpl*)> releasor_;
 };
 
 class LibEventInstance : public Instance {

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -28,10 +28,8 @@ public:
                      std::function<void(const void*, size_t)> releasor)
       : data_(data), size_(size), releasor_(releasor) {}
 
-  ~BufferFragmentImpl() override {}
-
-  const void* data() override { return data_; }
-  size_t size() override { return size_; }
+  const void* data() const override { return data_; }
+  size_t size() const override { return size_; }
 
   void done() override {
     if (releasor_) {
@@ -43,7 +41,7 @@ public:
   BufferFragmentImpl& operator=(const BufferFragmentImpl&) = delete;
 
 private:
-  const void* data_;
+  const void* const data_;
   size_t size_;
   std::function<void(const void*, size_t)> releasor_;
 };

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -33,6 +33,8 @@ public:
 
   // LibEventInstance
   void add(const void* data, uint64_t size) override;
+  void addReference(
+    const void* data, uint64_t size, refReleaseCb releaseCallback, void* releaseArg) override;
   void add(const std::string& data) override;
   void add(const Instance& data) override;
   void commit(RawSlice* iovecs, uint64_t num_iovecs) override;

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -43,8 +43,8 @@ public:
 
 private:
   const void* const data_;
-  size_t size_;
-  std::function<void(const void*, size_t, const BufferFragmentImpl*)> releasor_;
+  const size_t size_;
+  const std::function<void(const void*, size_t, const BufferFragmentImpl*)> releasor_;
 };
 
 class LibEventInstance : public Instance {

--- a/test/common/buffer/BUILD
+++ b/test/common/buffer/BUILD
@@ -9,6 +9,14 @@ load(
 envoy_package()
 
 envoy_cc_test(
+    name = "owned_impl_test",
+    srcs = ["owned_impl_test.cc"],
+    deps = [
+        "//source/common/buffer:buffer_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "watermark_buffer_test",
     srcs = ["watermark_buffer_test.cc"],
     deps = [

--- a/test/common/buffer/owned_impl_test.cc
+++ b/test/common/buffer/owned_impl_test.cc
@@ -26,10 +26,36 @@ TEST_F(OwnedImplTest, AddBufferFragmentNoCleanup) {
 
 TEST_F(OwnedImplTest, addBufferFragmentWithCleanup) {
   char input[] = "hello world";
-  BufferFragmentImpl frag(input, 11,
-                          [this](const void*, size_t) { release_callback_called_ = true; });
+  BufferFragmentImpl frag(input, 11, [this](const void*, size_t, const BufferFragmentImpl*) {
+    release_callback_called_ = true;
+  });
   Buffer::OwnedImpl buffer;
   buffer.addBufferFragment(&frag);
+  EXPECT_EQ(11, buffer.length());
+
+  buffer.drain(5);
+  EXPECT_EQ(6, buffer.length());
+  EXPECT_FALSE(release_callback_called_);
+
+  buffer.drain(6);
+  EXPECT_EQ(0, buffer.length());
+  EXPECT_TRUE(release_callback_called_);
+}
+
+TEST_F(OwnedImplTest, addBufferFragmentDynamicAllocation) {
+  char input_stack[] = "hello world";
+  char* input = new char[11];
+  std::copy(input_stack, input_stack + 11, input);
+
+  BufferFragmentImpl* frag = new BufferFragmentImpl(
+      input, 11, [this](const void* data, size_t, const BufferFragmentImpl* frag) {
+        release_callback_called_ = true;
+        delete[] static_cast<const char*>(data);
+        delete frag;
+      });
+
+  Buffer::OwnedImpl buffer;
+  buffer.addBufferFragment(frag);
   EXPECT_EQ(11, buffer.length());
 
   buffer.drain(5);

--- a/test/common/buffer/owned_impl_test.cc
+++ b/test/common/buffer/owned_impl_test.cc
@@ -17,7 +17,7 @@ TEST_F(OwnedImplTest, AddBufferFragmentNoCleanup) {
   char input[] = "hello world";
   BufferFragmentImpl frag(input, 11, nullptr);
   Buffer::OwnedImpl buffer;
-  buffer.addBufferFragment(&frag);
+  buffer.addBufferFragment(frag);
   EXPECT_EQ(11, buffer.length());
 
   buffer.drain(11);
@@ -30,7 +30,7 @@ TEST_F(OwnedImplTest, addBufferFragmentWithCleanup) {
     release_callback_called_ = true;
   });
   Buffer::OwnedImpl buffer;
-  buffer.addBufferFragment(&frag);
+  buffer.addBufferFragment(frag);
   EXPECT_EQ(11, buffer.length());
 
   buffer.drain(5);
@@ -55,7 +55,7 @@ TEST_F(OwnedImplTest, addBufferFragmentDynamicAllocation) {
       });
 
   Buffer::OwnedImpl buffer;
-  buffer.addBufferFragment(frag);
+  buffer.addBufferFragment(*frag);
   EXPECT_EQ(11, buffer.length());
 
   buffer.drain(5);

--- a/test/common/buffer/owned_impl_test.cc
+++ b/test/common/buffer/owned_impl_test.cc
@@ -41,35 +41,6 @@ TEST_F(OwnedImplTest, addBufferFragmentWithCleanup) {
   EXPECT_TRUE(release_callback_called_);
 }
 
-TEST_F(OwnedImplTest, AddBufferFragmentTwoBuffers) {
-  char input[] = "hello world";
-  BufferFragmentImpl frag(input, 11,
-                          [this](const void*, size_t) { release_callback_called_ = true; });
-  Buffer::OwnedImpl buffer1;
-  Buffer::OwnedImpl buffer2;
-  buffer1.addBufferFragment(&frag);
-
-  buffer2.addBufferFragment(&frag);
-  frag.incRef();
-
-  EXPECT_EQ(11, buffer1.length());
-  EXPECT_EQ(11, buffer2.length());
-
-  buffer1.drain(5);
-  buffer2.drain(5);
-  EXPECT_EQ(6, buffer1.length());
-  EXPECT_EQ(6, buffer2.length());
-  EXPECT_FALSE(release_callback_called_);
-
-  buffer1.drain(6);
-  EXPECT_EQ(0, buffer1.length());
-  EXPECT_FALSE(release_callback_called_);
-
-  buffer2.drain(6);
-  EXPECT_EQ(0, buffer2.length());
-  EXPECT_TRUE(release_callback_called_);
-}
-
 } // namespace
 } // namespace Buffer
 } // namespace Envoy

--- a/test/common/buffer/owned_impl_test.cc
+++ b/test/common/buffer/owned_impl_test.cc
@@ -1,0 +1,45 @@
+#include "common/buffer/buffer_impl.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Buffer {
+namespace {
+
+class OwnedImplTest : public testing::Test {
+public:
+  OwnedImplTest() {}
+
+  bool release_callback_called_ = false;
+};
+
+TEST_F(OwnedImplTest, AddReferenceNoCleanup) {
+  char input[] = "hello world";
+  Buffer::OwnedImpl buffer;
+  buffer.addReference(input, 11, nullptr, nullptr);
+  EXPECT_EQ(11, buffer.length());
+
+  buffer.drain(11);
+  EXPECT_EQ(0, buffer.length());
+}
+
+TEST_F(OwnedImplTest, AddReferenceWithCleanup) {
+  char input[] = "hello world";
+  Buffer::OwnedImpl buffer;
+  buffer.addReference(input, 11, [](const void*, size_t, void* arg) {
+    (static_cast<OwnedImplTest*>(arg))->release_callback_called_ = true;
+  }, this);
+  EXPECT_EQ(11, buffer.length());
+
+  buffer.drain(5);
+  EXPECT_EQ(6, buffer.length());
+  EXPECT_FALSE(release_callback_called_);
+
+  buffer.drain(6);
+  EXPECT_EQ(0, buffer.length());
+  EXPECT_TRUE(release_callback_called_);
+}
+
+} // namespace
+} // namespace Buffer
+} // namespace Envoy

--- a/test/common/buffer/owned_impl_test.cc
+++ b/test/common/buffer/owned_impl_test.cc
@@ -26,9 +26,11 @@ TEST_F(OwnedImplTest, AddReferenceNoCleanup) {
 TEST_F(OwnedImplTest, AddReferenceWithCleanup) {
   char input[] = "hello world";
   Buffer::OwnedImpl buffer;
-  buffer.addReference(input, 11, [](const void*, size_t, void* arg) {
-    (static_cast<OwnedImplTest*>(arg))->release_callback_called_ = true;
-  }, this);
+  buffer.addReference(input, 11,
+                      [](const void*, size_t, void* arg) {
+                        (static_cast<OwnedImplTest*>(arg))->release_callback_called_ = true;
+                      },
+                      this);
   EXPECT_EQ(11, buffer.length());
 
   buffer.drain(5);


### PR DESCRIPTION
…lly owned data for zero-copy insertion.

Signed-off-by: Shalom Abate <genioshelo@genioshelo.cam.corp.google.com>

*buffer*: *Add "addReference" to buffer for adding externally owned data.*

*Description*:
This PR adds a new method to the Envoy::Buffer::Instance interface as well as it's implementation Envoy::Buffer::OwnedImpl which allows adding externally owned data into a buffer. In a high performance deployment, it may be necessary for filters to avoid copying data into the buffer. This allows a more flexible way to zero-copy into the buffer by just passing in a pointer. The PR also adds a simple unit test for the functionality.

*Risk Level*: Medium

*Testing*:
Unit testing.

*Docs Changes*: N/A

*Release Notes*: N/A

Fixes #2277 