### PR TITLE
http conn pool: rework closeConnections() -> drainConnections()

### DIFF
--- a/include/envoy/http/conn_pool.h
+++ b/include/envoy/http/conn_pool.h
@@ -81,15 +81,19 @@ public:
   typedef std::function<void()> DrainedCb;
 
   /**
-   * Invoke connection pool draining and register a callback that gets called when draining is
-   * complete.
+   * Register a callback that gets called when the connection pool is fully drained. No actual
+   * draining is done. The owner of the connection pool is responsible for not creating any
+   * new streams.
    */
   virtual void addDrainedCallback(DrainedCb cb) PURE;
 
   /**
-   * Close all connections currently owned by the pool.
+   * Actively drain all existing connection pool connections. This method can be used in cases
+   * where the connection pool is not being destroyed, but the caller wishes to make sure that
+   * all new streams take place on a new connection. For example, when a health check failure
+   * occurs.
    */
-  virtual void closeConnections() PURE;
+  virtual void drainConnections() PURE;
 
   /**
    * Create a new stream on the pool.

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -21,19 +21,27 @@ namespace Http {
 namespace Http1 {
 
 ConnPoolImpl::~ConnPoolImpl() {
-  closeConnections();
-
-  // Make sure all clients are destroyed before we are destroyed.
-  dispatcher_.clearDeferredDeleteList();
-}
-
-void ConnPoolImpl::closeConnections() {
   while (!ready_clients_.empty()) {
     ready_clients_.front()->codec_client_->close();
   }
 
   while (!busy_clients_.empty()) {
     busy_clients_.front()->codec_client_->close();
+  }
+
+  // Make sure all clients are destroyed before we are destroyed.
+  dispatcher_.clearDeferredDeleteList();
+}
+
+void ConnPoolImpl::drainConnections() {
+  while (!ready_clients_.empty()) {
+    ready_clients_.front()->codec_client_->close();
+  }
+
+  // We drain busy clients by manually setting remaining requests to 1. Thus, when the next
+  // response completes the client will be destroyed.
+  for (const auto& client : busy_clients_) {
+    client->remaining_requests_ = 1;
   }
 }
 

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -37,7 +37,7 @@ public:
   // ConnectionPool::Instance
   Http::Protocol protocol() const override { return Http::Protocol::Http11; }
   void addDrainedCallback(DrainedCb cb) override;
-  void closeConnections() override;
+  void drainConnections() override;
   ConnectionPool::Cancellable* newStream(StreamDecoder& response_decoder,
                                          ConnectionPool::Callbacks& callbacks) override;
 

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -19,13 +19,6 @@ ConnPoolImpl::ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSha
     : dispatcher_(dispatcher), host_(host), priority_(priority) {}
 
 ConnPoolImpl::~ConnPoolImpl() {
-  closeConnections();
-
-  // Make sure all clients are destroyed before we are destroyed.
-  dispatcher_.clearDeferredDeleteList();
-}
-
-void ConnPoolImpl::ConnPoolImpl::closeConnections() {
   if (primary_client_) {
     primary_client_->client_->close();
   }
@@ -33,7 +26,12 @@ void ConnPoolImpl::ConnPoolImpl::closeConnections() {
   if (draining_client_) {
     draining_client_->client_->close();
   }
+
+  // Make sure all clients are destroyed before we are destroyed.
+  dispatcher_.clearDeferredDeleteList();
 }
+
+void ConnPoolImpl::ConnPoolImpl::drainConnections() { movePrimaryClientToDraining(); }
 
 void ConnPoolImpl::addDrainedCallback(DrainedCb cb) {
   drained_callbacks_.push_back(cb);

--- a/source/common/http/http2/conn_pool.h
+++ b/source/common/http/http2/conn_pool.h
@@ -30,7 +30,7 @@ public:
   // Http::ConnectionPool::Instance
   Http::Protocol protocol() const override { return Http::Protocol::Http2; }
   void addDrainedCallback(DrainedCb cb) override;
-  void closeConnections() override;
+  void drainConnections() override;
   ConnectionPool::Cancellable* newStream(Http::StreamDecoder& response_decoder,
                                          ConnectionPool::Callbacks& callbacks) override;
 

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -621,7 +621,7 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::updateClusterMembership(
 void ClusterManagerImpl::ThreadLocalClusterManagerImpl::onHostHealthFailure(
     const HostSharedPtr& host, ThreadLocal::Slot& tls) {
 
-  // Close all HTTP connection pool connections in the case of a host health failure. If outlier/
+  // Drain all HTTP connection pool connections in the case of a host health failure. If outlier/
   // health is due to ECMP flow hashing issues for example, a new set of connections might do
   // better.
   // TODO(mattklein123): This function is currently very specific, but in the future when we do
@@ -635,7 +635,7 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::onHostHealthFailure(
         continue;
       }
 
-      pool->closeConnections();
+      pool->drainConnections();
     }
   }
 }

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -854,7 +854,7 @@ TEST_F(ClusterManagerImplTest, CloseConnectionsOnHealthFailure) {
   outlier_detector.runCallbacks(test_host);
   health_checker.runCallbacks(test_host, false);
 
-  EXPECT_CALL(*cp1, closeConnections());
+  EXPECT_CALL(*cp1, drainConnections());
   test_host->healthFlagSet(Host::HealthFlag::FAILED_OUTLIER_CHECK);
   outlier_detector.runCallbacks(test_host);
 
@@ -862,8 +862,8 @@ TEST_F(ClusterManagerImplTest, CloseConnectionsOnHealthFailure) {
   EXPECT_CALL(factory_, allocateConnPool_(_)).WillOnce(Return(cp2));
   cluster_manager_->httpConnPoolForCluster("some_cluster", ResourcePriority::High, nullptr);
 
-  EXPECT_CALL(*cp1, closeConnections());
-  EXPECT_CALL(*cp2, closeConnections());
+  EXPECT_CALL(*cp1, drainConnections());
+  EXPECT_CALL(*cp2, drainConnections());
   test_host->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
   health_checker.runCallbacks(test_host, true);
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -445,7 +445,7 @@ public:
   // Http::ConnectionPool::Instance
   MOCK_CONST_METHOD0(protocol, Http::Protocol());
   MOCK_METHOD1(addDrainedCallback, void(DrainedCb cb));
-  MOCK_METHOD0(closeConnections, void());
+  MOCK_METHOD0(drainConnections, void());
   MOCK_METHOD2(newStream, Cancellable*(Http::StreamDecoder& response_decoder,
                                        Http::ConnectionPool::Callbacks& callbacks));
 


### PR DESCRIPTION
This is a follow up from https://github.com/envoyproxy/envoy/pull/2005.
From production usage at Lyft it has become clear that immediately
closing connections on health check failure is too aggressive. During
normal upstream draining when using the x-envoy-immediate-health-check-fail
header, it is possible to close connections while they still have legitimate
draining requests.

This change reworks the functionality to drain but not close existing
connections. This will make it so that *new* streams occur on new connections,
but existing streams are allowed to finish on their existing connections.
This is the behavior we actually wanted in the first place.

*Risk Level*: Low 
*Testing*: UT
*Docs Changes*: N/A
*Release Notes*: N/A
