### PR TITLE
Upgrade to nghttp2 1.29.0

### DIFF
--- a/ci/build_container/build_recipes/nghttp2.sh
+++ b/ci/build_container/build_recipes/nghttp2.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION=1.28.0
+VERSION=1.29.0
 
 wget -O nghttp2-"$VERSION".tar.gz https://github.com/nghttp2/nghttp2/releases/download/v"$VERSION"/nghttp2-"$VERSION".tar.gz
 tar xf nghttp2-"$VERSION".tar.gz


### PR DESCRIPTION
Signed-off-by: Michael Payne <michael@sooper.org>

*dependency*: Upgrade to nghttp2 1.29.0

*Description*: small change to nghttp2 lib - [Use NGHTTP2_REFUSED_STREAM for streams which are closed by GOAWAY](https://github.com/nghttp2/nghttp2/pull/1077). Would be good to have our h2 experts review.

*Risk Level*: Low

*Testing*: `bazel test //test/...`
