### PR TITLE
Upgrade to spdlog 0.16.2.

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -21,9 +21,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/fmtlib/fmt/releases/download/4.0.0/fmt-4.0.0.zip"],
     ),
     com_github_gabime_spdlog = dict(
-        sha256 = "eb5beb4e53f4bfff5b32eb4db8588484bdc15a17b90eeefef3a9fc74fec1d83d",
-        strip_prefix = "spdlog-0.14.0",
-        urls = ["https://github.com/gabime/spdlog/archive/v0.14.0.tar.gz"],
+        sha256 = "2081e5df5e87402398847431e16b87c71dd5c4d632314bb976ace8161f4d32de",
+        strip_prefix = "spdlog-0.16.2",
+        urls = ["https://github.com/gabime/spdlog/archive/v0.16.2.tar.gz"],
     ),
     com_github_gcovr_gcovr = dict(
         commit = "c0d77201039c7b119b18bc7fb991564c602dd75d",


### PR DESCRIPTION
Signed-off-by: Michael Payne <michael@sooper.org>

*dependency*: Upgrade to spdlog 0.16.2

*Description*: spdlog didn't release a 0.15.0 version. This change picks up 0.16.0 plus two bug fixes - [spdlog 0.16.0 release notes](https://github.com/gabime/spdlog/releases/tag/v0.16.0). There is a breaking change but no impacts are seen in tests.

*Risk Level*: Low

*Testing*: `bazel test //test/...` and running across Linux and MacOS hosts for approx. 1 week
