### PR TITLE
stats: metric/tag name fix for Prometheus

### DIFF
--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -75,6 +75,9 @@ std::vector<std::pair<std::string, std::string>> TagNameValues::getRegexMapping(
   // listener.[<address>.]ssl.cipher.(<cipher>)
   name_regex_pairs.push_back({SSL_CIPHER, "^listener(?=\\.).*?\\.ssl\\.cipher(\\.(.*?))$"});
 
+  // cluster.[<cluster_name>.]ssl.ciphers.(<cipher>)
+  name_regex_pairs.push_back({SSL_CIPHER_SUITE, "^cluster(?=\\.).*?\\.ssl\\.ciphers(\\.(.*?))$"});
+
   // cluster.[<route_target_cluster>.]grpc.(<grpc_service>.)*
   name_regex_pairs.push_back({GRPC_BRIDGE_SERVICE, "^cluster(?=\\.).*?\\.grpc\\.((.*?)\\.)"});
 

--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -207,7 +207,7 @@ public:
   // SSL cipher for a connection
   const std::string SSL_CIPHER = "envoy.ssl_cipher";
   // SSL cipher suite
-  const std::string SSL_CIPHER_SUITE  = "cipher_suite";
+  const std::string SSL_CIPHER_SUITE = "cipher_suite";
   // Stats prefix for the Client SSL Auth network filter
   const std::string CLIENTSSL_PREFIX = "envoy.clientssl_prefix";
   // Stats prefix for the Mongo Proxy network filter

--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -206,6 +206,8 @@ public:
   const std::string HTTP_USER_AGENT = "envoy.http_user_agent";
   // SSL cipher for a connection
   const std::string SSL_CIPHER = "envoy.ssl_cipher";
+  // SSL cipher suite
+  const std::string SSL_CIPHER_SUITE  = "cipher_suite";
   // Stats prefix for the Client SSL Auth network filter
   const std::string CLIENTSSL_PREFIX = "envoy.clientssl_prefix";
   // Stats prefix for the Mongo Proxy network filter

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -385,7 +385,8 @@ Http::Code AdminImpl::handlerStats(const std::string& url, Http::HeaderMap& resp
           Http::Headers::get().ContentTypeValues.Json);
       response.add(AdminImpl::statsAsJson(all_stats));
     } else if (format_key == "format" && format_value == "prometheus") {
-      PrometheusStatsFormatter::statsAsPrometheus(server_.stats().counters(), server_.stats().gauges(), response);
+      PrometheusStatsFormatter::statsAsPrometheus(server_.stats().counters(),
+                                                  server_.stats().gauges(), response);
     } else {
       response.add("usage: /stats?format=json \n");
       response.add("\n");
@@ -395,7 +396,8 @@ Http::Code AdminImpl::handlerStats(const std::string& url, Http::HeaderMap& resp
   return rc;
 }
 
-std::string PrometheusStatsFormatter::sanitizePrometheusName(const std::string& name, const bool strict) {
+std::string PrometheusStatsFormatter::sanitizePrometheusName(const std::string& name,
+                                                             const bool strict) {
   std::string stats_name = name;
   std::replace(stats_name.begin(), stats_name.end(), '.', '_');
   if (strict) {
@@ -420,8 +422,8 @@ std::string PrometheusStatsFormatter::prometheusMetricName(const std::string& ex
 }
 
 void PrometheusStatsFormatter::statsAsPrometheus(const std::list<Stats::CounterSharedPtr>& counters,
-                                  const std::list<Stats::GaugeSharedPtr>& gauges,
-                                  Buffer::Instance& response) {
+                                                 const std::list<Stats::GaugeSharedPtr>& gauges,
+                                                 Buffer::Instance& response) {
   for (const auto& counter : counters) {
     const std::string tags = formatTagsForPrometheus(counter->tags());
     const std::string metric_name = prometheusMetricName(counter->tagExtractedName());

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -396,44 +396,41 @@ Http::Code AdminImpl::handlerStats(const std::string& url, Http::HeaderMap& resp
   return rc;
 }
 
-std::string PrometheusStatsFormatter::sanitizePrometheusName(const std::string& name,
-                                                             const bool strict) {
+std::string PrometheusStatsFormatter::sanitizeName(const std::string& name) {
   std::string stats_name = name;
   std::replace(stats_name.begin(), stats_name.end(), '.', '_');
-  if (strict) {
-    std::replace(stats_name.begin(), stats_name.end(), '-', '_');
-  }
+  std::replace(stats_name.begin(), stats_name.end(), '-', '_');
   return stats_name;
 }
 
-std::string PrometheusStatsFormatter::formatTagsForPrometheus(const std::vector<Stats::Tag>& tags) {
+std::string PrometheusStatsFormatter::formattedTags(const std::vector<Stats::Tag>& tags) {
   std::vector<std::string> buf;
   for (const Stats::Tag& tag : tags) {
-    buf.push_back(fmt::format("{}=\"{}\"", sanitizePrometheusName(tag.name_, true),
-                              sanitizePrometheusName(tag.value_, false)));
+    buf.push_back(fmt::format("{}=\"{}\"", sanitizeName(tag.name_), tag.value_));
   }
   return StringUtil::join(buf, ",");
 }
 
-std::string PrometheusStatsFormatter::prometheusMetricName(const std::string& extractedName) {
+std::string PrometheusStatsFormatter::metricName(const std::string& extractedName) {
   // Add namespacing prefix to avoid conflicts, as per best practice:
   // https://prometheus.io/docs/practices/naming/#metric-names
-  return fmt::format("envoy_{0}", sanitizePrometheusName(extractedName, true));
+  // Also, naming conventions on https://prometheus.io/docs/concepts/data_model/
+  return fmt::format("envoy_{0}", sanitizeName(extractedName));
 }
 
 void PrometheusStatsFormatter::statsAsPrometheus(const std::list<Stats::CounterSharedPtr>& counters,
                                                  const std::list<Stats::GaugeSharedPtr>& gauges,
                                                  Buffer::Instance& response) {
   for (const auto& counter : counters) {
-    const std::string tags = formatTagsForPrometheus(counter->tags());
-    const std::string metric_name = prometheusMetricName(counter->tagExtractedName());
+    const std::string tags = formattedTags(counter->tags());
+    const std::string metric_name = metricName(counter->tagExtractedName());
     response.add(fmt::format("# TYPE {0} counter\n", metric_name));
     response.add(fmt::format("{0}{{{1}}} {2}\n", metric_name, tags, counter->value()));
   }
 
   for (const auto& gauge : gauges) {
-    const std::string tags = formatTagsForPrometheus(gauge->tags());
-    const std::string metric_name = prometheusMetricName(gauge->tagExtractedName());
+    const std::string tags = formattedTags(gauge->tags());
+    const std::string metric_name = metricName(gauge->tagExtractedName());
     response.add(fmt::format("# TYPE {0} gauge\n", metric_name));
     response.add(fmt::format("{0}{{{1}}} {2}\n", metric_name, tags, gauge->value()));
   }

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -201,5 +201,17 @@ private:
   Http::HeaderMap* request_headers_{};
 };
 
+class PrometheusStatsFormatter {
+public:
+  static void statsAsPrometheus(const std::list<Stats::CounterSharedPtr>& counters,
+                                const std::list<Stats::GaugeSharedPtr>& gauges,
+                                Buffer::Instance& response);
+  static std::string formatTagsForPrometheus(const std::vector<Stats::Tag>& tags);
+  static std::string prometheusMetricName(const std::string& extractedName);
+private:
+  static std::string sanitizePrometheusName(const std::string& name);
+};
+
+
 } // namespace Server
 } // namespace Envoy

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -115,12 +115,6 @@ private:
                       const Upstream::Outlier::Detector* outlier_detector,
                       Buffer::Instance& response);
   static std::string statsAsJson(const std::map<std::string, uint64_t>& all_stats);
-  static void statsAsPrometheus(const std::list<Stats::CounterSharedPtr>& counters,
-                                const std::list<Stats::GaugeSharedPtr>& gauges,
-                                Buffer::Instance& response);
-  static std::string sanitizePrometheusName(const std::string& name);
-  static std::string formatTagsForPrometheus(const std::vector<Stats::Tag>& tags);
-  static std::string prometheusMetricName(const std::string& extractedName);
 
   /**
    * URL handlers.
@@ -209,7 +203,7 @@ public:
   static std::string formatTagsForPrometheus(const std::vector<Stats::Tag>& tags);
   static std::string prometheusMetricName(const std::string& extractedName);
 private:
-  static std::string sanitizePrometheusName(const std::string& name);
+  static std::string sanitizePrometheusName(const std::string& name, const bool strict);
 };
 
 

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -195,16 +195,35 @@ private:
   Http::HeaderMap* request_headers_{};
 };
 
+/**
+ * Formatter for metric/labels exported to Prometheus.
+ *
+ * See: https://prometheus.io/docs/concepts/data_model
+ */
 class PrometheusStatsFormatter {
 public:
+  /**
+   * Extracts counters and gauges and relevant tags, appending them to
+   * the response buffer after sanitizing the metric / label names.
+   */
   static void statsAsPrometheus(const std::list<Stats::CounterSharedPtr>& counters,
                                 const std::list<Stats::GaugeSharedPtr>& gauges,
                                 Buffer::Instance& response);
-  static std::string formatTagsForPrometheus(const std::vector<Stats::Tag>& tags);
-  static std::string prometheusMetricName(const std::string& extractedName);
+  /**
+   * Format the given tags, returning a string as a comma-separated list
+   * of <tag_name>="<tag_value>" pairs.
+   */
+  static std::string formattedTags(const std::vector<Stats::Tag>& tags);
+  /**
+   * Format the given metric name, prefixed with "envoy_".
+   */
+  static std::string metricName(const std::string& extractedName);
 
 private:
-  static std::string sanitizePrometheusName(const std::string& name, const bool strict);
+  /**
+   * Take a string and sanitize it according to Prometheus conventions.
+   */
+  static std::string sanitizeName(const std::string& name);
 };
 
 } // namespace Server

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -202,10 +202,10 @@ public:
                                 Buffer::Instance& response);
   static std::string formatTagsForPrometheus(const std::vector<Stats::Tag>& tags);
   static std::string prometheusMetricName(const std::string& extractedName);
+
 private:
   static std::string sanitizePrometheusName(const std::string& name, const bool strict);
 };
-
 
 } // namespace Server
 } // namespace Envoy

--- a/test/common/stats/stats_impl_test.cc
+++ b/test/common/stats/stats_impl_test.cc
@@ -195,8 +195,8 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
   cipher_suite.name_ = tag_names.SSL_CIPHER_SUITE;
   cipher_suite.value_ = "ECDHE-RSA-AES128-GCM-SHA256";
 
-  regex_tester.testRegex("cluster.ratelimit.ssl.ciphers.ECDHE-RSA-AES128-GCM-SHA256", "cluster.ssl.ciphers",
-                         {cluster_tag, cipher_suite});
+  regex_tester.testRegex("cluster.ratelimit.ssl.ciphers.ECDHE-RSA-AES128-GCM-SHA256",
+                         "cluster.ssl.ciphers", {cluster_tag, cipher_suite});
 
   // ipv6 non-loopback (for alphabetical chars)
   listener_address.value_ = "[2001_0db8_85a3_0000_0000_8a2e_0370_7334]_3543";

--- a/test/common/stats/stats_impl_test.cc
+++ b/test/common/stats/stats_impl_test.cc
@@ -190,6 +190,14 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
   regex_tester.testRegex("listener.[__1]_0.ssl.cipher.AES256-SHA", "listener.ssl.cipher",
                          {listener_address, cipher_name});
 
+  // Cipher suite
+  Tag cipher_suite;
+  cipher_suite.name_ = tag_names.SSL_CIPHER_SUITE;
+  cipher_suite.value_ = "ECDHE-RSA-AES128-GCM-SHA256";
+
+  regex_tester.testRegex("cluster.ratelimit.ssl.ciphers.ECDHE-RSA-AES128-GCM-SHA256", "cluster.ssl.ciphers",
+                         {cluster_tag, cipher_suite});
+
   // ipv6 non-loopback (for alphabetical chars)
   listener_address.value_ = "[2001_0db8_85a3_0000_0000_8a2e_0370_7334]_3543";
   regex_tester.testRegex(

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -185,5 +185,23 @@ TEST_P(AdminInstanceTest, EscapeHelpTextWithPunctuation) {
   EXPECT_NE(-1, response.search(kEscapedPlanets.data(), kEscapedPlanets.size(), 0));
 }
 
+TEST(PrometheusStatsFormatter, PrometheusMetricName) {
+  std::string raw = "vulture.eats-liver";
+  std::string expected = "envoy_vulture_eats-liver";
+  auto actual = PrometheusStatsFormatter::prometheusMetricName(raw);
+  EXPECT_EQ(expected, actual);
+}
+
+TEST(PrometheusStatsFormatter, FormatTagsForPrometheus) {
+  std::vector<Stats::Tag> tags;
+  Stats::Tag tag1 = {"a.tag-name", "a.tag-value"};
+  Stats::Tag tag2 = {"another_tag_name", "another_tag-value"};
+  tags.push_back(tag1);
+  tags.push_back(tag2);
+  std::string expected = "a_tag-name=\"a_tag-value\",another_tag_name=\"another_tag-value\"";
+  auto actual = PrometheusStatsFormatter::formatTagsForPrometheus(tags);
+  EXPECT_EQ(expected, actual);
+}
+
 } // namespace Server
 } // namespace Envoy

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -187,7 +187,7 @@ TEST_P(AdminInstanceTest, EscapeHelpTextWithPunctuation) {
 
 TEST(PrometheusStatsFormatter, PrometheusMetricName) {
   std::string raw = "vulture.eats-liver";
-  std::string expected = "envoy_vulture_eats-liver";
+  std::string expected = "envoy_vulture_eats_liver";
   auto actual = PrometheusStatsFormatter::prometheusMetricName(raw);
   EXPECT_EQ(expected, actual);
 }
@@ -198,7 +198,7 @@ TEST(PrometheusStatsFormatter, FormatTagsForPrometheus) {
   Stats::Tag tag2 = {"another_tag_name", "another_tag-value"};
   tags.push_back(tag1);
   tags.push_back(tag2);
-  std::string expected = "a_tag-name=\"a_tag-value\",another_tag_name=\"another_tag-value\"";
+  std::string expected = "a_tag_name=\"a_tag-value\",another_tag_name=\"another_tag-value\"";
   auto actual = PrometheusStatsFormatter::formatTagsForPrometheus(tags);
   EXPECT_EQ(expected, actual);
 }

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -185,21 +185,21 @@ TEST_P(AdminInstanceTest, EscapeHelpTextWithPunctuation) {
   EXPECT_NE(-1, response.search(kEscapedPlanets.data(), kEscapedPlanets.size(), 0));
 }
 
-TEST(PrometheusStatsFormatter, PrometheusMetricName) {
+TEST(PrometheusStatsFormatter, MetricName) {
   std::string raw = "vulture.eats-liver";
   std::string expected = "envoy_vulture_eats_liver";
-  auto actual = PrometheusStatsFormatter::prometheusMetricName(raw);
+  auto actual = PrometheusStatsFormatter::metricName(raw);
   EXPECT_EQ(expected, actual);
 }
 
-TEST(PrometheusStatsFormatter, FormatTagsForPrometheus) {
+TEST(PrometheusStatsFormatter, FormattedTags) {
   std::vector<Stats::Tag> tags;
   Stats::Tag tag1 = {"a.tag-name", "a.tag-value"};
   Stats::Tag tag2 = {"another_tag_name", "another_tag-value"};
   tags.push_back(tag1);
   tags.push_back(tag2);
-  std::string expected = "a_tag_name=\"a_tag-value\",another_tag_name=\"another_tag-value\"";
-  auto actual = PrometheusStatsFormatter::formatTagsForPrometheus(tags);
+  std::string expected = "a_tag_name=\"a.tag-value\",another_tag_name=\"another_tag-value\"";
+  auto actual = PrometheusStatsFormatter::formattedTags(tags);
   EXPECT_EQ(expected, actual);
 }
 


### PR DESCRIPTION
*Description*
The Prometheus metrics formatter only sanitizes '.', but leaves other
non supported chars like '-'.  A case where this may appear is on cipher
suites as reported in #2263.

The change adds a second replace for '-' (rather than a regex to avoid
the perf. hit, same reason for not matching on all [^a-Z0-9_] chars.)
The replacement is only applied to metric and tag names, not tag
values.

As a result of this change, the current formatting would change from:

```
# TYPE envoy_cluster_ssl_ciphers_ECDHE-RSA-AES128-GCM-SHA256 counter
envoy_cluster_ssl_ciphers_ECDHE-RSA-AES128-GCM-SHA256{envoy_cluster_name="local_service"} 8
```

to

```
# TYPE envoy_cluster_ssl_ciphers_ECDHE-RSA-AES128-GCM-SHA256 counter
envoy_cluster_ssl_ciphers_ECDHE_RSA_AES128_GCM_SHA256{envoy_cluster_name="local_service"} 8
```

Fixing the general case for any metric/tag name that includes '-'. 

Following the suggestion on the original issue, the cipher suite is also moved to a label instead.  The specific example above results in:

```
# TYPE envoy_cluster_ssl_ciphers_ECDHE-RSA-AES128-GCM-SHA256 counter
envoy_cluster_ssl_ciphers{envoy_cluster_name="local_service", cipher_suite="ECDHE-RSA-AES128-GCM-SHA256"} 8
```

*Risk Level*: Low

*Testing*:

Updated unit/integration rests, + new unit tests.

There is a set of unit tests that can verify the sanitization of metrics
names when exported to Prometheus.  These rely on the default set of
metrics for a fresh server which, incidentally, doesn't include metrics
with some prohibited characters. #2263 reports one of these cases, '-'.
An integration test falls in a similar case.

A fix for #2263 is trivial, but adding a regression test is not.  The
root reason is that the affected method is private in AdminImpl, so the
only way of hitting the right code path is to add excessive complexity
as both unit/integration versions would require configuration that is
known to generate metrics with '-', etc.

This PR makes a preliminary refactor on admin.cc, moving all code
involved in formatting metrics for Prometheus to its own class where
methods can be made public (instead of polluting AdminImpl's API.) A
later improvement could also refactor the JSON formatter to a separate
class and introduce a strategy pattern for formatters.  This requires a
shuffling a bit more code so I preferred to take a single step here.

*Docs Changes*:
N/A

*Release Notes*:
N/A

*Fixes issue*
#2263 