### PR TITLE
http/2 conn pool: fix crash when there is no primary connection

### DIFF
--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -31,7 +31,11 @@ ConnPoolImpl::~ConnPoolImpl() {
   dispatcher_.clearDeferredDeleteList();
 }
 
-void ConnPoolImpl::ConnPoolImpl::drainConnections() { movePrimaryClientToDraining(); }
+void ConnPoolImpl::ConnPoolImpl::drainConnections() {
+  if (primary_client_ != nullptr) {
+    movePrimaryClientToDraining();
+  }
+}
 
 void ConnPoolImpl::addDrainedCallback(DrainedCb cb) {
   drained_callbacks_.push_back(cb);

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -126,6 +126,9 @@ TEST_F(Http2ConnPoolImplTest, DrainConnections) {
   InSequence s;
   pool_.max_streams_ = 1;
 
+  // Test drain connections call prior to any connections being created.
+  pool_.drainConnections();
+
   expectClientCreate();
   ActiveTestRequest r1(*this, 0);
   EXPECT_CALL(r1.inner_encoder_, encodeHeaders(_, true));


### PR DESCRIPTION
This is a regression from https://github.com/envoyproxy/envoy/pull/2295.

*Risk Level*: Low 
*Testing*: UT
*Docs Changes*: N/A
*Release Notes*: N/A
