### PR TITLE
address_impl: Return an Ipv4Instance for v4-mapped v6 addresses.

### DIFF
--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -36,7 +36,7 @@ Address::InstanceConstSharedPtr addressFromSockAddr(const sockaddr_storage& ss, 
     ASSERT(AF_INET6 == sin6->sin6_family);
     if (!v6only && IN6_IS_ADDR_V4MAPPED(&sin6->sin6_addr)) {
 #ifndef s6_addr32
-#if defined(__APPLE__) && defined(__MACH__)
+#ifdef __APPLE__
 #define s6_addr32 __u6_addr.__u6_addr32
 #endif
 #endif

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -34,7 +34,20 @@ Address::InstanceConstSharedPtr addressFromSockAddr(const sockaddr_storage& ss, 
     RELEASE_ASSERT(ss_len == 0 || ss_len == sizeof(sockaddr_in6));
     const struct sockaddr_in6* sin6 = reinterpret_cast<const struct sockaddr_in6*>(&ss);
     ASSERT(AF_INET6 == sin6->sin6_family);
-    return std::make_shared<Address::Ipv6Instance>(*sin6, v6only);
+    if (!v6only && IN6_IS_ADDR_V4MAPPED(&sin6->sin6_addr)) {
+#ifndef s6_addr32
+#if defined(__APPLE__) && defined(__MACH__)
+#define s6_addr32 __u6_addr.__u6_addr32
+#endif
+#endif
+      struct sockaddr_in sin = {.sin_family = AF_INET,
+                                .sin_port = sin6->sin6_port,
+                                .sin_addr = {.s_addr = sin6->sin6_addr.s6_addr32[3]},
+                                .sin_zero = {}};
+      return std::make_shared<Address::Ipv4Instance>(&sin);
+    } else {
+      return std::make_shared<Address::Ipv6Instance>(*sin6, v6only);
+    }
   }
   case AF_UNIX: {
     const struct sockaddr_un* sun = reinterpret_cast<const struct sockaddr_un*>(&ss);

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -319,6 +319,14 @@ TEST(AddressFromSockAddr, IPv6) {
   EXPECT_DEATH(addressFromSockAddr(ss, sizeof(sockaddr_in6) + 1), "ss_len");
 
   EXPECT_EQ("[1:23::ef]:32000", addressFromSockAddr(ss, sizeof(sockaddr_in6))->asString());
+
+  // Test that IPv4-mapped IPv6 address is returned as an Ipv4Instance when 'v6only' parameter is
+  // 'false', but not otherwise.
+  EXPECT_EQ(1, inet_pton(AF_INET6, "::ffff:192.0.2.128", &sin6.sin6_addr));
+  EXPECT_EQ(IpVersion::v4, addressFromSockAddr(ss, sizeof(sockaddr_in6), false)->ip()->version());
+  EXPECT_EQ("192.0.2.128:32000", addressFromSockAddr(ss, sizeof(sockaddr_in6), false)->asString());
+  EXPECT_EQ(IpVersion::v6, addressFromSockAddr(ss, sizeof(sockaddr_in6), true)->ip()->version());
+  EXPECT_EQ("[::ffff:192.0.2.128]:32000", addressFromSockAddr(ss, sizeof(sockaddr_in6), true)->asString());
 }
 
 TEST(AddressFromSockAddr, Pipe) {

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -326,7 +326,8 @@ TEST(AddressFromSockAddr, IPv6) {
   EXPECT_EQ(IpVersion::v4, addressFromSockAddr(ss, sizeof(sockaddr_in6), false)->ip()->version());
   EXPECT_EQ("192.0.2.128:32000", addressFromSockAddr(ss, sizeof(sockaddr_in6), false)->asString());
   EXPECT_EQ(IpVersion::v6, addressFromSockAddr(ss, sizeof(sockaddr_in6), true)->ip()->version());
-  EXPECT_EQ("[::ffff:192.0.2.128]:32000", addressFromSockAddr(ss, sizeof(sockaddr_in6), true)->asString());
+  EXPECT_EQ("[::ffff:192.0.2.128]:32000",
+            addressFromSockAddr(ss, sizeof(sockaddr_in6), true)->asString());
 }
 
 TEST(AddressFromSockAddr, Pipe) {


### PR DESCRIPTION
Recognize v6-mapped v4 addresses and use IPv4 address
instances to represent them so that rest of Envoy can treat v4 connections
the same regardless if they were received from a v6 or a v4 socket.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
