### PR TITLE
runtime: add getAll accessor to Snapshot to access underlying Entry map

### DIFF
--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -116,7 +116,7 @@ public:
 
   /**
    * Fetch the raw runtime entries map. The map data is safe only for the lifetime of the Snapshot.
-   * @return std::unordered_map<std::string, const Entry*> the raw map of loaded runtime values.
+   * @return std::unordered_map<std::string, const Entry>& the raw map of loaded runtime values.
    */
   virtual const std::unordered_map<std::string, const Entry>& getAll() const PURE;
 };

--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -3,7 +3,9 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
+#include "envoy/common/optional.h"
 #include "envoy/common/pure.h"
 
 namespace Envoy {
@@ -36,6 +38,21 @@ typedef std::unique_ptr<RandomGenerator> RandomGeneratorPtr;
 class Snapshot {
 public:
   virtual ~Snapshot() {}
+
+  /**
+   * The raw data from a single snapshot key.
+   */
+  struct Entry {
+    /**
+     * The raw runtime data.
+     */
+    std::string string_value;
+
+    /**
+     * The possibly parsed integer value from the runtime data.
+     */
+    Optional<uint64_t> uint_value;
+  };
 
   /**
    * Test if a feature is enabled using the built in random generator. This is done by generating
@@ -96,6 +113,12 @@ public:
    * @return uint64_t the runtime value or the default value.
    */
   virtual uint64_t getInteger(const std::string& key, uint64_t default_value) const PURE;
+
+  /**
+   * Fetch the raw runtime entries map.
+   * @return std::unordered_map<std::string, const Entry*> the raw map of loaded runtime values.
+   */
+  virtual std::unordered_map<std::string, const Entry*> getAll() const PURE;
 };
 
 /**

--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -46,12 +46,12 @@ public:
     /**
      * The raw runtime data.
      */
-    std::string string_value;
+    std::string string_value_;
 
     /**
      * The possibly parsed integer value from the runtime data.
      */
-    Optional<uint64_t> uint_value;
+    Optional<uint64_t> uint_value_;
   };
 
   /**
@@ -118,7 +118,7 @@ public:
    * Fetch the raw runtime entries map. The map data is safe only for the lifetime of the Snapshot.
    * @return std::unordered_map<std::string, const Entry*> the raw map of loaded runtime values.
    */
-  virtual std::unordered_map<std::string, const Entry*> getAll() const PURE;
+  virtual const std::unordered_map<std::string, const Entry>& getAll() const PURE;
 };
 
 /**

--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -115,7 +115,7 @@ public:
   virtual uint64_t getInteger(const std::string& key, uint64_t default_value) const PURE;
 
   /**
-   * Fetch the raw runtime entries map.
+   * Fetch the raw runtime entries map. The map data is safe only for the lifetime of the Snapshot.
    * @return std::unordered_map<std::string, const Entry*> the raw map of loaded runtime values.
    */
   virtual std::unordered_map<std::string, const Entry*> getAll() const PURE;

--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -116,7 +116,7 @@ public:
 
   /**
    * Fetch the raw runtime entries map. The map data is safe only for the lifetime of the Snapshot.
-   * @return std::unordered_map<std::string, const Entry>& the raw map of loaded runtime values.
+   * @return const std::unordered_map<std::string, const Entry>& the raw map of loaded values.
    */
   virtual const std::unordered_map<std::string, const Entry>& getAll() const PURE;
 };

--- a/source/common/runtime/BUILD
+++ b/source/common/runtime/BUILD
@@ -15,7 +15,6 @@ envoy_cc_library(
     external_deps = ["ssl"],
     deps = [
         "//include/envoy/api:os_sys_calls_interface",
-        "//include/envoy/common:optional",
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/stats:stats_interface",

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -192,7 +192,7 @@ std::unordered_map<std::string, const Snapshot::Entry*> SnapshotImpl::getAll() c
   std::unordered_map<std::string, const Snapshot::Entry*> entries;
   entries.reserve(values_.size());
 
-  for (auto& kv : values_) {
+  for (const auto& kv : values_) {
     entries[kv.first] = &kv.second;
   }
 

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -249,6 +249,8 @@ void SnapshotImpl::walkDirectory(const std::string& path, const std::string& pre
         entry.uint_value_.value(converted);
       }
 
+      // Separate erase/insert calls required due to the value type being constant; this prevents
+      // the use of the [] operator. Can leverage insert_or_assign in C++17 in the future.
       values_.erase(full_prefix);
       values_.insert({full_prefix, entry});
     }

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -175,28 +175,21 @@ const std::string& SnapshotImpl::get(const std::string& key) const {
   if (entry == values_.end()) {
     return EMPTY_STRING;
   } else {
-    return entry->second.string_value;
+    return entry->second.string_value_;
   }
 }
 
 uint64_t SnapshotImpl::getInteger(const std::string& key, uint64_t default_value) const {
   auto entry = values_.find(key);
-  if (entry == values_.end() || !entry->second.uint_value.valid()) {
+  if (entry == values_.end() || !entry->second.uint_value_.valid()) {
     return default_value;
   } else {
-    return entry->second.uint_value.value();
+    return entry->second.uint_value_.value();
   }
 }
 
-std::unordered_map<std::string, const Snapshot::Entry*> SnapshotImpl::getAll() const {
-  std::unordered_map<std::string, const Snapshot::Entry*> entries;
-  entries.reserve(values_.size());
-
-  for (const auto& kv : values_) {
-    entries[kv.first] = &kv.second;
-  }
-
-  return entries;
+const std::unordered_map<std::string, const Snapshot::Entry>& SnapshotImpl::getAll() const {
+  return values_;
 }
 
 void SnapshotImpl::walkDirectory(const std::string& path, const std::string& prefix) {
@@ -245,18 +238,19 @@ void SnapshotImpl::walkDirectory(const std::string& path, const std::string& pre
         if (!line.empty() && line.at(0) == '#') {
           continue;
         }
-        entry.string_value += line + "\n";
+        entry.string_value_ += line + "\n";
       }
-      StringUtil::rtrim(entry.string_value);
+      StringUtil::rtrim(entry.string_value_);
 
       // As a perf optimization, attempt to convert the string into an integer. If we don't
       // succeed that's fine.
       uint64_t converted;
-      if (StringUtil::atoul(entry.string_value.c_str(), converted)) {
-        entry.uint_value.value(converted);
+      if (StringUtil::atoul(entry.string_value_.c_str(), converted)) {
+        entry.uint_value_.value(converted);
       }
 
-      values_[full_prefix] = entry;
+      values_.erase(full_prefix);
+      values_.insert({full_prefix, entry});
     }
   }
 }

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -90,7 +90,7 @@ public:
 
   const std::string& get(const std::string& key) const override;
   uint64_t getInteger(const std::string&, uint64_t default_value) const override;
-  std::unordered_map<std::string, const Snapshot::Entry*> getAll() const override;
+  const std::unordered_map<std::string, const Snapshot::Entry>& getAll() const override;
 
 private:
   struct Directory {
@@ -108,7 +108,7 @@ private:
 
   void walkDirectory(const std::string& path, const std::string& prefix);
 
-  std::unordered_map<std::string, Entry> values_;
+  std::unordered_map<std::string, const Entry> values_;
   RandomGenerator& generator_;
   Api::OsSysCalls& os_sys_calls_;
 };
@@ -185,11 +185,12 @@ private:
       return default_value;
     }
 
-    std::unordered_map<std::string, const Snapshot::Entry*> getAll() const override {
-      return std::unordered_map<std::string, const Snapshot::Entry*>();
+    const std::unordered_map<std::string, const Snapshot::Entry>& getAll() const override {
+      return values_;
     }
 
     RandomGenerator& generator_;
+    std::unordered_map<std::string, const Snapshot::Entry> values_;
   };
 
   NullSnapshotImpl snapshot_;

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -186,8 +186,7 @@ private:
     }
 
     std::unordered_map<std::string, const Snapshot::Entry*> getAll() const override {
-      std::unordered_map<std::string, const Snapshot::Entry*> entries;
-      return entries;
+      return std::unordered_map<std::string, const Snapshot::Entry*>();
     }
 
     RandomGenerator& generator_;

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -9,7 +9,6 @@
 
 #include "envoy/api/os_sys_calls.h"
 #include "envoy/common/exception.h"
-#include "envoy/common/optional.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/stats/stats_macros.h"
 #include "envoy/thread_local/thread_local.h"
@@ -91,6 +90,7 @@ public:
 
   const std::string& get(const std::string& key) const override;
   uint64_t getInteger(const std::string&, uint64_t default_value) const override;
+  std::unordered_map<std::string, const Snapshot::Entry*> getAll() const override;
 
 private:
   struct Directory {
@@ -104,11 +104,6 @@ private:
     ~Directory() { closedir(dir_); }
 
     DIR* dir_;
-  };
-
-  struct Entry {
-    std::string string_value_;
-    Optional<uint64_t> uint_value_;
   };
 
   void walkDirectory(const std::string& path, const std::string& prefix);
@@ -188,6 +183,11 @@ private:
 
     uint64_t getInteger(const std::string&, uint64_t default_value) const override {
       return default_value;
+    }
+
+    std::unordered_map<std::string, const Snapshot::Entry*> getAll() const override {
+      std::unordered_map<std::string, const Snapshot::Entry*> entries;
+      return entries;
     }
 
     RandomGenerator& generator_;

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -142,19 +142,19 @@ TEST_F(RuntimeImplTest, GetAll) {
 
   auto entry = values.find("file1");
   EXPECT_FALSE(entry == values.end());
-  EXPECT_EQ("hello override", entry->second->string_value);
-  EXPECT_FALSE(entry->second->uint_value.valid());
+  EXPECT_EQ("hello override", entry->second.string_value_);
+  EXPECT_FALSE(entry->second.uint_value_.valid());
 
   entry = values.find("file2");
   EXPECT_FALSE(entry == values.end());
-  EXPECT_EQ("world", entry->second->string_value);
-  EXPECT_FALSE(entry->second->uint_value.valid());
+  EXPECT_EQ("world", entry->second.string_value_);
+  EXPECT_FALSE(entry->second.uint_value_.valid());
 
   entry = values.find("file3");
   EXPECT_FALSE(entry == values.end());
-  EXPECT_EQ("2", entry->second->string_value);
-  EXPECT_TRUE(entry->second->uint_value.valid());
-  EXPECT_EQ(2UL, entry->second->uint_value.value());
+  EXPECT_EQ("2", entry->second.string_value_);
+  EXPECT_TRUE(entry->second.uint_value_.valid());
+  EXPECT_EQ(2UL, entry->second.uint_value_.value());
 
   entry = values.find("invalid");
   EXPECT_TRUE(entry == values.end());

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -134,6 +134,32 @@ TEST_F(RuntimeImplTest, All) {
   EXPECT_EQ("hello override", loader->snapshot().get("file1"));
 }
 
+TEST_F(RuntimeImplTest, GetAll) {
+  setup();
+  run("test/common/runtime/test_data/current", "envoy_override");
+
+  auto values = loader->snapshot().getAll();
+
+  auto entry = values.find("file1");
+  EXPECT_FALSE(entry == values.end());
+  EXPECT_EQ("hello override", entry->second->string_value);
+  EXPECT_FALSE(entry->second->uint_value.valid());
+
+  entry = values.find("file2");
+  EXPECT_FALSE(entry == values.end());
+  EXPECT_EQ("world", entry->second->string_value);
+  EXPECT_FALSE(entry->second->uint_value.valid());
+
+  entry = values.find("file3");
+  EXPECT_FALSE(entry == values.end());
+  EXPECT_EQ("2", entry->second->string_value);
+  EXPECT_TRUE(entry->second->uint_value.valid());
+  EXPECT_EQ(2UL, entry->second->uint_value.value());
+
+  entry = values.find("invalid");
+  EXPECT_TRUE(entry == values.end());
+}
+
 TEST_F(RuntimeImplTest, BadDirectory) {
   setup();
   run("/baddir", "/baddir");
@@ -160,6 +186,7 @@ TEST(NullRuntimeImplTest, All) {
   EXPECT_EQ(1UL, loader.snapshot().getInteger("foo", 1));
   EXPECT_CALL(generator, random()).WillOnce(Return(49));
   EXPECT_TRUE(loader.snapshot().featureEnabled("foo", 50));
+  EXPECT_TRUE(loader.snapshot().getAll().empty());
 }
 
 } // namespace Runtime

--- a/test/mocks/runtime/BUILD
+++ b/test/mocks/runtime/BUILD
@@ -13,6 +13,7 @@ envoy_cc_mock(
     srcs = ["mocks.cc"],
     hdrs = ["mocks.h"],
     deps = [
+        "//include/envoy/common:optional",
         "//include/envoy/runtime:runtime_interface",
         "//test/mocks:common_lib",
     ],

--- a/test/mocks/runtime/mocks.h
+++ b/test/mocks/runtime/mocks.h
@@ -34,7 +34,7 @@ public:
                                           uint64_t random_value, uint16_t num_buckets));
   MOCK_CONST_METHOD1(get, const std::string&(const std::string& key));
   MOCK_CONST_METHOD2(getInteger, uint64_t(const std::string& key, uint64_t default_value));
-  MOCK_CONST_METHOD0(getAll, std::unordered_map<std::string, const Snapshot::Entry*>());
+  MOCK_CONST_METHOD0(getAll, const std::unordered_map<std::string, const Snapshot::Entry>&());
 };
 
 class MockLoader : public Loader {

--- a/test/mocks/runtime/mocks.h
+++ b/test/mocks/runtime/mocks.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include <unordered_map>
 
 #include "envoy/runtime/runtime.h"
 
@@ -33,6 +34,7 @@ public:
                                           uint64_t random_value, uint16_t num_buckets));
   MOCK_CONST_METHOD1(get, const std::string&(const std::string& key));
   MOCK_CONST_METHOD2(getInteger, uint64_t(const std::string& key, uint64_t default_value));
+  MOCK_CONST_METHOD0(getAll, std::unordered_map<std::string, const Snapshot::Entry*>());
 };
 
 class MockLoader : public Loader {


### PR DESCRIPTION
This patch adds a `getAll` accessor to the underlying entries map in the `Runtime::Snapshot`. This will be used in the forthcoming `/runtime` admin endpoint (#514).

*Risk Level*: Low (new unused feature)
*Testing*: Unit
*Docs Changes*: N/A (will be added when the admin endpoint is created)
*Release Notes*: N/A (likewise)
