### PR TITLE
network: fix sporadic test failures related to Network::ConnectionImpl

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -422,8 +422,8 @@ void ConnectionImpl::onReadReady() {
   uint64_t new_buffer_size = read_buffer_.length();
   updateReadBufferStats(result.bytes_processed_, new_buffer_size);
   if (result.bytes_processed_ != 0) {
-    // Connection close on OS X may produce a spurious read event with
-    // no data. Skip onRead if no bytes were processed.
+    // Skip onRead if no bytes were processed. For instance, if the connection was closed without
+    // producing more data.
     onRead(new_buffer_size);
   }
 

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -421,7 +421,11 @@ void ConnectionImpl::onReadReady() {
   IoResult result = transport_socket_->doRead(read_buffer_);
   uint64_t new_buffer_size = read_buffer_.length();
   updateReadBufferStats(result.bytes_processed_, new_buffer_size);
-  onRead(new_buffer_size);
+  if (result.bytes_processed_ != 0) {
+    // Connection close on OS X may produce a spurious read event with
+    // no data. Skip onRead if no bytes were processed.
+    onRead(new_buffer_size);
+  }
 
   // The read callback may have already closed the connection.
   if (result.action_ == PostIoAction::Close) {

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -581,7 +581,7 @@ TEST_P(ConnectionImplTest, ReadOnCloseTest) {
   setUpBasicConnection();
   connect();
 
-  // Close without flush will immediately invokes this callback.
+  // Close without flush immediately invokes this callback.
   EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::LocalClose));
 
   const int buffer_size = 32;


### PR DESCRIPTION
*Description*:

Fixes non-determinism in setup of `test/common/http:codec_client_test` (similar to changes previously made to `test/common/network:connection_impl_test`). Doing that uncovered a reliable test failure as describe in #2271, which is resolved by not invoking the connection read filter's onData callback if no data was processed on a read event.

*Risk Level*: Medium -- relatively low-level change, coverage shows that even without the new test both paths of the onData guard were followed

*Testing*:
Flakey test no longer fails after 1000 runs (where before ~50 were sufficient). Added direct test of change in ConnectionImpl.

Fixes #2271