### PR TITLE
thread_local: add dispatcher() method to ThreadLocal::Instance.

### DIFF
--- a/include/envoy/thread_local/thread_local.h
+++ b/include/envoy/thread_local/thread_local.h
@@ -99,6 +99,11 @@ public:
    * called on the thread that is shutting down.
    */
   virtual void shutdownThread() PURE;
+
+  /**
+   * @return Event::Dispatcher& the thread local dispatcher.
+   */
+  virtual Event::Dispatcher& dispatcher() PURE;
 };
 
 } // namespace ThreadLocal

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -52,6 +52,8 @@ void InstanceImpl::registerThread(Event::Dispatcher& dispatcher, bool main_threa
     ASSERT(!containsReference(registered_threads_, dispatcher));
     registered_threads_.push_back(dispatcher);
   }
+
+  dispatcher.post([&dispatcher] { thread_local_data_.dispatcher_ = &dispatcher; });
 }
 
 void InstanceImpl::removeSlot(SlotImpl& slot) {
@@ -146,6 +148,11 @@ void InstanceImpl::shutdownThread() {
     it->reset();
   }
   thread_local_data_.data_.clear();
+}
+
+Event::Dispatcher& InstanceImpl::dispatcher() {
+  ASSERT(thread_local_data_.dispatcher_ != nullptr);
+  return *thread_local_data_.dispatcher_;
 }
 
 } // namespace ThreadLocal

--- a/source/common/thread_local/thread_local_impl.h
+++ b/source/common/thread_local/thread_local_impl.h
@@ -25,6 +25,7 @@ public:
   void registerThread(Event::Dispatcher& dispatcher, bool main_thread) override;
   void shutdownGlobalThreading() override;
   void shutdownThread() override;
+  Event::Dispatcher& dispatcher() override;
 
 private:
   struct SlotImpl : public Slot {
@@ -41,6 +42,7 @@ private:
   };
 
   struct ThreadLocalData {
+    Event::Dispatcher* dispatcher_{};
     std::vector<ThreadLocalObjectSharedPtr> data_;
   };
 

--- a/test/common/thread_local/BUILD
+++ b/test/common/thread_local/BUILD
@@ -12,6 +12,7 @@ envoy_cc_test(
     name = "thread_local_impl_test",
     srcs = ["thread_local_impl_test.cc"],
     deps = [
+        "//source/common/event:dispatcher_lib",
         "//source/common/thread_local:thread_local_lib",
         "//test/mocks/event:event_mocks",
     ],

--- a/test/common/thread_local/thread_local_impl_test.cc
+++ b/test/common/thread_local/thread_local_impl_test.cc
@@ -82,8 +82,8 @@ TEST_F(ThreadLocalInstanceImplTest, All) {
   tls_.shutdownThread();
 }
 
-// Validate ThreadLocal::InstanceImpl's dispacher() behavior.
-TEST(ThreadLocalInstanceImplThreadedTest, All) {
+// Validate ThreadLocal::InstanceImpl's dispatcher() behavior.
+TEST(ThreadLocalInstanceImplDispatcherTest, Dispatcher) {
   InstanceImpl tls;
   Event::DispatcherImpl main_dispatcher;
   Event::DispatcherImpl thread_dispatcher;

--- a/test/common/thread_local/thread_local_impl_test.cc
+++ b/test/common/thread_local/thread_local_impl_test.cc
@@ -1,3 +1,4 @@
+#include "common/event/dispatcher_impl.h"
 #include "common/thread_local/thread_local_impl.h"
 
 #include "test/mocks/event/mocks.h"
@@ -22,7 +23,9 @@ public:
 class ThreadLocalInstanceImplTest : public testing::Test {
 public:
   ThreadLocalInstanceImplTest() {
+    EXPECT_CALL(main_dispatcher_, post(_));
     tls_.registerThread(main_dispatcher_, true);
+    EXPECT_CALL(thread_dispatcher_, post(_));
     tls_.registerThread(thread_dispatcher_, false);
   }
 
@@ -77,6 +80,35 @@ TEST_F(ThreadLocalInstanceImplTest, All) {
   EXPECT_CALL(object_ref4, onDestroy());
   EXPECT_CALL(object_ref3, onDestroy());
   tls_.shutdownThread();
+}
+
+// Validate ThreadLocal::InstanceImpl's dispacher() behavior.
+TEST(ThreadLocalInstanceImplThreadedTest, All) {
+  InstanceImpl tls;
+  Event::DispatcherImpl main_dispatcher;
+  Event::DispatcherImpl thread_dispatcher;
+
+  tls.registerThread(main_dispatcher, true);
+  tls.registerThread(thread_dispatcher, false);
+
+  // Ensure that the dispatcher update in tls posted during the above registerThread happens.
+  main_dispatcher.run(Event::Dispatcher::RunType::NonBlock);
+  // Verify we have the expected dispatcher for the main thread.
+  EXPECT_EQ(&main_dispatcher, &tls.dispatcher());
+
+  Thread::Thread([&thread_dispatcher, &tls]() {
+    // Ensure that the dispatcher update in tls posted during the above registerThread happens.
+    thread_dispatcher.run(Event::Dispatcher::RunType::NonBlock);
+    // Verify we have the expected dispatcher for the new thread thread.
+    EXPECT_EQ(&thread_dispatcher, &tls.dispatcher());
+  })
+      .join();
+
+  // Verify we still have the expected dispatcher for the main thread.
+  EXPECT_EQ(&main_dispatcher, &tls.dispatcher());
+
+  tls.shutdownGlobalThreading();
+  tls.shutdownThread();
 }
 
 } // namespace ThreadLocal

--- a/test/mocks/thread_local/mocks.h
+++ b/test/mocks/thread_local/mocks.h
@@ -24,6 +24,7 @@ public:
   MOCK_METHOD2(registerThread, void(Event::Dispatcher& dispatcher, bool main_thread));
   MOCK_METHOD0(shutdownGlobalThreading, void());
   MOCK_METHOD0(shutdownThread, void());
+  MOCK_METHOD0(dispatcher, Event::Dispatcher&());
 
   SlotPtr allocateSlot_() { return SlotPtr{new SlotImpl(*this, current_slot_++)}; }
   void runOnAllThreads_(Event::PostCb cb) { cb(); }


### PR DESCRIPTION
This is a convenience for obtaining the dispatcher of the current thread without having to setup an
explicit TLS slot to capture/access it. This was useful when working on the Google C++ gRPC library
integration.

*Risk Level*: Low
*Testing*: Unit test.

Signed-off-by: Harvey Tuch <htuch@google.com>