### PR TITLE
build: Google gRPC C++ library as an external dependency.

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -36,3 +36,8 @@ config_setting(
     name = "disable_hot_restart",
     values = {"define": "hot_restart=disabled"},
 )
+
+config_setting(
+    name = "disable_google_grpc",
+    values = {"define": "google_grpc=disabled"},
+)

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -243,9 +243,9 @@ remove log statements of lower importance during compilation to enhance performa
 bazel build --copt=-DNVLOG //source/exe:envoy-static
 ```
 
-## Disabling optional featuers
+## Disabling optional features
 
-The following optional featuers can be disabled on the Bazel build command-line:
+The following optional features can be disabled on the Bazel build command-line:
 
 * Hot restart with `--define hot_restart=disabled`
 * Google C++ gRPC client with `--define google_grpc=disabled`

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -243,10 +243,13 @@ remove log statements of lower importance during compilation to enhance performa
 bazel build --copt=-DNVLOG //source/exe:envoy-static
 ```
 
-## Hot Restart
+## Disabling optional featuers
 
-Hot restart can be disabled in any build by specifying `--define=hot_restart=disabled`
-on the Bazel command line.
+The following optional featuers can be disabled on the Bazel build command-line:
+
+* Hot restart with `--define hot_restart=disabled`
+* Google C++ gRPC client with `--define google_grpc=disabled`
+* Backtracing on signals with `--define signal_trace=disabled`
 
 ## Stats Tunables
 

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -28,7 +28,8 @@ def envoy_copts(repository, test = False):
         # TCLAP command line parser needs this to support int64_t/uint64_t
         "@bazel_tools//tools/osx:darwin": ["-DHAVE_LONG_LONG"],
         "//conditions:default": [],
-    }) + envoy_select_hot_restart(["-DENVOY_HOT_RESTART"], repository)
+    }) + envoy_select_hot_restart(["-DENVOY_HOT_RESTART"], repository) + \
+        envoy_select_google_grpc(["-DENVOY_GOOGLE_GRPC"], repository)
 
 # Compute the final linkopts based on various options.
 def envoy_linkopts():
@@ -359,5 +360,12 @@ def envoy_select_hot_restart(xs, repository = ""):
     return select({
         repository + "//bazel:disable_hot_restart": [],
         "@bazel_tools//tools/osx:darwin": [],
+        "//conditions:default": xs,
+    })
+
+# Selects the given values if Google gRPC is enabled in the current build.
+def envoy_select_google_grpc(xs, repository = ""):
+    return select({
+        repository + "//bazel:disable_google_grpc": [],
         "//conditions:default": xs,
     })

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -242,6 +242,7 @@ def envoy_dependencies(path = "@envoy_deps//", skip_targets = []):
     _com_github_gcovr_gcovr()
     _io_opentracing_cpp()
     _com_lightstep_tracer_cpp()
+    _com_github_grpc_grpc()
     _com_github_nodejs_http_parser()
     _com_github_tencent_rapidjson()
     _com_google_googletest()
@@ -386,4 +387,26 @@ def _com_google_protobuf():
     native.bind(
         name = "protoc",
         actual = "@com_google_protobuf_cc//:protoc",
+    )
+
+def _com_github_grpc_grpc():
+    _repository_impl("com_github_grpc_grpc")
+
+    # Rebind some stuff to match what the gRPC Bazel is expecting.
+    native.bind(
+      name = "protobuf_headers",
+      actual = "@com_google_protobuf//:protobuf_headers",
+    )
+    native.bind(
+      name = "libssl",
+      actual = "//external:ssl",
+    )
+    native.bind(
+      name = "cares",
+      actual = "//external:ares",
+    )
+
+    native.bind(
+      name = "grpc",
+      actual = "@com_github_grpc_grpc//:grpc++"
     )

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -29,6 +29,10 @@ REPOSITORY_LOCATIONS = dict(
         commit = "c0d77201039c7b119b18bc7fb991564c602dd75d",
         remote = "https://github.com/gcovr/gcovr",
     ),
+    com_github_grpc_grpc = dict(
+        commit = "f526a2164f9c1eb816eea420f7201b8dfa278a8f", # v1.8.3
+        remote = "https://github.com/grpc/grpc.git",
+    ),
     io_opentracing_cpp = dict(
         commit = "e57161e2a4bd1f9d3a8d3edf23185f033bb45f17",
         remote = "https://github.com/opentracing/opentracing-cpp", # v1.2.0

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -72,4 +72,5 @@ cc_library(
         "thirdparty_build/include/zconf.h",
         "thirdparty_build/include/zlib.h",
     ],
+    includes = ["thirdparty_build/include"],
 )

--- a/test/common/grpc/BUILD
+++ b/test/common/grpc/BUILD
@@ -59,6 +59,12 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "google_grpc_test",
+    srcs = ["google_grpc_test.cc"],
+    external_deps = ["grpc"],
+)
+
+envoy_cc_test(
     name = "grpc_web_filter_test",
     srcs = ["grpc_web_filter_test.cc"],
     deps = [

--- a/test/common/grpc/BUILD
+++ b/test/common/grpc/BUILD
@@ -4,6 +4,7 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",
     "envoy_package",
+    "envoy_select_google_grpc",
 )
 
 envoy_package()
@@ -60,7 +61,7 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "google_grpc_test",
-    srcs = ["google_grpc_test.cc"],
+    srcs = envoy_select_google_grpc(["google_grpc_test.cc"]),
     external_deps = ["grpc"],
 )
 

--- a/test/common/grpc/google_grpc_test.cc
+++ b/test/common/grpc/google_grpc_test.cc
@@ -1,0 +1,17 @@
+#include "grpc++/channel.h"
+#include "grpc++/grpc++.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Grpc {
+namespace {
+
+// Validate we can include/link some basic Google gRPC C++ library objects.
+TEST(GoogleGrpc, All) {
+  std::shared_ptr<grpc::ChannelCredentials> creds = grpc::InsecureChannelCredentials();
+  CreateChannel("1.2.3.4:5678", creds);
+}
+
+} // namespace
+} // namespace Grpc
+} // namespace Envoy


### PR DESCRIPTION
This is needed for upcoming integration with xDS and other gRPC clients, where the option to use
Google gRPC or the in-built Envoy client will be made available.

Signed-off-by: Harvey Tuch <htuch@google.com>