### PR TITLE
connection.h: Fix comment.

### DIFF
--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -227,7 +227,7 @@ class ClientConnection : public virtual Connection {
 public:
   /**
    * Connect to a remote host. Errors or connection events are reported via the event callback
-   * registered via setConnectionEventCb().
+   * registered via addConnectionCallbacks().
    */
   virtual void connect() PURE;
 };


### PR DESCRIPTION
setConnectionEventCb() does not exist any more, and
addConnectionCallbacks() seems like the more general replacement.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
Risk Level: Low
