### PR TITLE
tools: Export check_format.py

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -12,6 +12,9 @@ exports_files([
     "gen_git_sha.sh",
     "git_sha_rewriter.py",
     "stack_decode.py",
+    "check_format.py",
+    "header_order.py",
+    "envoy_build_fixer.py",
 ])
 
 envoy_py_test_binary(


### PR DESCRIPTION
Export check_format.py and it's dependencies so that projects depending on Envoy can use it.

This is useful for filter projects that import Envoy as a http archive or git repository rather than
a git submodule.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
Risk Level: Low
