### PR TITLE
examples/front-proxy: base dockerfile on alpine

### DIFF
--- a/examples/front-proxy/Dockerfile-service
+++ b/examples/front-proxy/Dockerfile-service
@@ -1,15 +1,8 @@
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy-alpine:latest
 
-RUN apt-get update && apt-get -q install -y \
-    curl \
-    software-properties-common \
-    python-software-properties
-RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get update && apt-get -q install -y \
-    python3 \
-    python3-pip
+RUN apk update && apk add python3 bash
 RUN python3 --version && pip3 --version
-RUN pip3 install -q Flask==0.11.1
+RUN pip3 install -q Flask==0.11.1 requests==2.18.4
 RUN mkdir /code
 ADD ./service.py /code
 ADD ./start_service.sh /usr/local/bin/start_service.sh

--- a/examples/front-proxy/start_service.sh
+++ b/examples/front-proxy/start_service.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 python3 /code/service.py &
 envoy -c /etc/service-envoy.yaml --service-cluster service${SERVICE_NAME}


### PR DESCRIPTION
Previously, the example wouldn't build due to the wrong version of
python being used.

Rather than go through the pain of installing a modern version of python
on ubuntu:14.04, this patch just bases examples dockerfile on the envoy
alpine image which includes the necessary version of python3 by default.

Fixes #2262.

*Risk Level*: Low

*Release Notes*: N/A

*Release Notes*: N/A