### PR TITLE
fix compatibility with data-plane-api commit fc64085

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -67,7 +67,7 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
     ),
     envoy_api = dict(
-        commit = "aa73175ddf5e229dd4d97a019e5312ba1263d252",
+        commit = "fc640851ea3b4cdcc50d0e4a7cd1dbfc4d7449bb",
         remote = "https://github.com/envoyproxy/data-plane-api",
     ),
     grpc_httpjson_transcoding = dict(

--- a/source/common/ssl/context_config_impl.cc
+++ b/source/common/ssl/context_config_impl.cc
@@ -110,8 +110,8 @@ ServerContextConfigImpl::ServerContextConfigImpl(const envoy::api::v2::Downstrea
               validateAndAppendKey(ret, Filesystem::fileReadToEnd(datasource.filename()));
               break;
             }
-            case envoy::api::v2::DataSource::kInline: {
-              validateAndAppendKey(ret, datasource.inline_());
+            case envoy::api::v2::DataSource::kInlineBytes: {
+              validateAndAppendKey(ret, datasource.inline_bytes());
               break;
             }
             default:

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -250,19 +250,19 @@ TEST_F(SslServerContextImplTicketTest, TicketKeyNone) {
 
 TEST_F(SslServerContextImplTicketTest, TicketKeyInlineSuccess) {
   envoy::api::v2::DownstreamTlsContext cfg;
-  cfg.mutable_session_ticket_keys()->add_keys()->set_inline_(std::string(80, '\0'));
+  cfg.mutable_session_ticket_keys()->add_keys()->set_inline_bytes(std::string(80, '\0'));
   EXPECT_NO_THROW(loadConfigV2(cfg));
 }
 
 TEST_F(SslServerContextImplTicketTest, TicketKeyInlineFailTooBig) {
   envoy::api::v2::DownstreamTlsContext cfg;
-  cfg.mutable_session_ticket_keys()->add_keys()->set_inline_(std::string(81, '\0'));
+  cfg.mutable_session_ticket_keys()->add_keys()->set_inline_bytes(std::string(81, '\0'));
   EXPECT_THROW(loadConfigV2(cfg), EnvoyException);
 }
 
 TEST_F(SslServerContextImplTicketTest, TicketKeyInlineFailTooSmall) {
   envoy::api::v2::DownstreamTlsContext cfg;
-  cfg.mutable_session_ticket_keys()->add_keys()->set_inline_(std::string(79, '\0'));
+  cfg.mutable_session_ticket_keys()->add_keys()->set_inline_bytes(std::string(79, '\0'));
   EXPECT_THROW(loadConfigV2(cfg), EnvoyException);
 }
 


### PR DESCRIPTION
*Description*

data-plane-api commit fc64085 changed an existing field name, so
this PR updates the Envoy code correspondingly in order to avoid
surprising anybody who needs to pick up any subsequent changes to
data-plane-api.

*Related Issues*: #2315 

*Risk Level*: Low

*Testing*:
Ran the Envoy regression tests

*API Changes*:
https://github.com/envoyproxy/data-plane-api/pull/393

Signed-off-by: Brian Pane <bpane@pinterest.com>

