### PR TITLE
Bazel: add define flag for exporting symbols

### DIFF
--- a/RAW_RELEASE_NOTES.md
+++ b/RAW_RELEASE_NOTES.md
@@ -36,3 +36,5 @@ final version.
   :ref:`QueryParameterMatcher<envoy_api_msg_QueryParameterMatcher>`
 * Added `/runtime` admin endpoint to read the current runtime values.
 * Added `gateway-error` retry-on policy.
+* Added support for building envoy with exported symbols
+  This change allows scripts loaded with the lua filter to load shared object libraries such as those installed via luarocks.

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -46,3 +46,8 @@ cc_proto_library(
     name = "grpc_health_proto",
     deps = ["@com_github_grpc_grpc//src/proto/grpc/health/v1:_health_proto_only"],
 )
+
+config_setting(
+    name = "enable_exported_symbols",
+    values = {"define": "exported_symbols=enabled"},
+)

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -251,6 +251,13 @@ The following optional features can be disabled on the Bazel build command-line:
 * Google C++ gRPC client with `--define google_grpc=disabled`
 * Backtracing on signals with `--define signal_trace=disabled`
 
+## Enabling optional features
+
+The following optional features can be enabled on the Bazel build command-line:
+
+* Exported symbols during linking with `--define exported_symbols=enabled`.
+  This is useful in cases where you have a lua script that loads shared object libraries, such as those installed via luarocks.
+
 ## Stats Tunables
 
 The default maximum number of stats in shared memory, and the default

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -60,7 +60,7 @@ def envoy_linkopts():
             "-static-libstdc++",
             "-static-libgcc",
         ],
-    })
+    }) + envoy_select_exported_symbols(["-Wl,-E"])
 
 # Compute the test linkopts based on various options.
 def envoy_test_linkopts():
@@ -169,7 +169,11 @@ def envoy_cc_binary(name,
                     repository = "",
                     stamped = False,
                     deps = [],
-                    linkopts = envoy_linkopts()):
+                    linkopts = []):
+
+    if not linkopts:
+        linkopts = envoy_linkopts()
+
     # Implicit .stamped targets to obtain builds with the (truncated) git SHA1.
     if stamped:
         _git_stamped_genrule(repository, name)
@@ -370,4 +374,11 @@ def envoy_select_google_grpc(xs, repository = ""):
     return select({
         repository + "//bazel:disable_google_grpc": [],
         "//conditions:default": xs,
+    })
+
+# Select the given values if exporting is enabled in the current build.
+def envoy_select_exported_symbols(xs):
+    return select({
+        "@envoy//bazel:enable_exported_symbols": xs,
+        "//conditions:default": [],
     })


### PR DESCRIPTION
Bazel: add define flag for exporting symbols

*Description*:
The current problem with lua is that it is unable to use external
libraries such as lrexlib installed via luarocks.

The solution is to export the symbols needed by those libraries.

*Risk Level*: Low

*Testing*:
I tested this manually.  Here is an example lua script and envoy configuration.

```json
{
    "listeners": [
      {
        "address": "tcp://0.0.0.0:5555",
        "filters": [
          {
            "name": "http_connection_manager", 
            "config": {
              "codec_type": "auto", 
              "add_user_agent": true, 
              "use_remote_address": true,
              "idle_timeout_s": 840,
              "stat_prefix": "frontrouter",
              "route_config": {
                "virtual_hosts": [
                  {
                    "name": "backend",
                    "domains": ["*"],
                    "routes": [
                      {
                        "prefix": "",
                        "cluster": "echoer-backend",
                        "auto_host_rewrite": false
                      }
                    ]
                  }
                ]
              }, 
              "filters": [
                  {
                    "name": "lua",
                    "config": {
                        "inline_code": "dofile(\"script.lua\")"
                    }
                  },
                {
                  "name": "router", 
                  "config": {}
                }
              ]
            }
          }
        ]
      }
    ], 
    "cluster_manager": {
      "clusters": [
        {
          "name": "echoer-backend",
          "connect_timeout_ms": 250,
          "type": "static",
          "lb_type": "round_robin",
          "hosts": [
            {
              "url": "tcp://127.0.0.1:3000"
            }
          ]
        }
      ]
    }
  }
```

```lua
function envoy_on_request(request)
    local rex = require "rex_pcre"
    headers = request:headers()
    referrerHeader = headers:get("Referrer")

    if referrerHeader ~= nil then
        match = rex.match(referrerHeader, '^\\/search\\?.*category=.*')
        request:logInfo("Match: "..match)
    end
end

function envoy_on_response(response)
end
```

*Docs Changes*:
https://github.com/envoyproxy/data-plane-api/pull/405

Fixes issue #2251

Signed-off-by: Nicholas J <nicholas.a.johns5@gmail.com>
