### PR TITLE
Sanity checking libevent is initialized

### DIFF
--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -36,7 +36,7 @@ DispatcherImpl::DispatcherImpl(Buffer::WatermarkFactoryPtr&& factory)
       deferred_delete_timer_(createTimer([this]() -> void { clearDeferredDeleteList(); })),
       post_timer_(createTimer([this]() -> void { runPostCallbacks(); })),
       current_to_delete_(&to_delete_1_) {
-  ASSERT(Libevent::Global::initialized());
+  RELEASE_ASSERT(Libevent::Global::initialized());
 }
 
 DispatcherImpl::~DispatcherImpl() {}

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -26,13 +26,18 @@ namespace Envoy {
 namespace Event {
 
 DispatcherImpl::DispatcherImpl()
-    : DispatcherImpl(Buffer::WatermarkFactoryPtr{new Buffer::WatermarkBufferFactory}) {}
+    : DispatcherImpl(Buffer::WatermarkFactoryPtr{new Buffer::WatermarkBufferFactory}) {
+  // The dispatcher won't work as expected if libevent hasn't been configured to use threads.
+  ASSERT(Libevent::Global::initialized());
+}
 
 DispatcherImpl::DispatcherImpl(Buffer::WatermarkFactoryPtr&& factory)
     : buffer_factory_(std::move(factory)), base_(event_base_new()),
       deferred_delete_timer_(createTimer([this]() -> void { clearDeferredDeleteList(); })),
       post_timer_(createTimer([this]() -> void { runPostCallbacks(); })),
-      current_to_delete_(&to_delete_1_) {}
+      current_to_delete_(&to_delete_1_) {
+  ASSERT(Libevent::Global::initialized());
+}
 
 DispatcherImpl::~DispatcherImpl() {}
 

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -28,7 +28,7 @@ namespace Event {
 DispatcherImpl::DispatcherImpl()
     : DispatcherImpl(Buffer::WatermarkFactoryPtr{new Buffer::WatermarkBufferFactory}) {
   // The dispatcher won't work as expected if libevent hasn't been configured to use threads.
-  ASSERT(Libevent::Global::initialized());
+  RELEASE_ASSERT(Libevent::Global::initialized());
 }
 
 DispatcherImpl::DispatcherImpl(Buffer::WatermarkFactoryPtr&& factory)

--- a/source/common/event/libevent.cc
+++ b/source/common/event/libevent.cc
@@ -10,16 +10,14 @@ namespace Envoy {
 namespace Event {
 namespace Libevent {
 
-static bool kInitialized = false;
-
-bool Global::initialized() { return kInitialized; }
+bool Global::INITIALIZED = false;
 
 void Global::initialize() {
   evthread_use_pthreads();
 
   // Ignore SIGPIPE and allow errors to propagate through error codes.
   signal(SIGPIPE, SIG_IGN);
-  kInitialized = true;
+  INITIALIZED = true;
 }
 
 } // namespace Libevent

--- a/source/common/event/libevent.cc
+++ b/source/common/event/libevent.cc
@@ -10,14 +10,14 @@ namespace Envoy {
 namespace Event {
 namespace Libevent {
 
-bool Global::is_initialized = false;
+bool Global::initialized_ = false;
 
 void Global::initialize() {
   evthread_use_pthreads();
 
   // Ignore SIGPIPE and allow errors to propagate through error codes.
   signal(SIGPIPE, SIG_IGN);
-  is_initialized = true;
+  initialized_ = true;
 }
 
 } // namespace Libevent

--- a/source/common/event/libevent.cc
+++ b/source/common/event/libevent.cc
@@ -10,11 +10,16 @@ namespace Envoy {
 namespace Event {
 namespace Libevent {
 
+static bool kInitialized = false;
+
+bool Global::initialized() { return kInitialized; }
+
 void Global::initialize() {
   evthread_use_pthreads();
 
   // Ignore SIGPIPE and allow errors to propagate through error codes.
   signal(SIGPIPE, SIG_IGN);
+  kInitialized = true;
 }
 
 } // namespace Libevent

--- a/source/common/event/libevent.cc
+++ b/source/common/event/libevent.cc
@@ -10,14 +10,14 @@ namespace Envoy {
 namespace Event {
 namespace Libevent {
 
-bool Global::INITIALIZED = false;
+bool Global::is_initialized = false;
 
 void Global::initialize() {
   evthread_use_pthreads();
 
   // Ignore SIGPIPE and allow errors to propagate through error codes.
   signal(SIGPIPE, SIG_IGN);
-  INITIALIZED = true;
+  is_initialized = true;
 }
 
 } // namespace Libevent

--- a/source/common/event/libevent.h
+++ b/source/common/event/libevent.h
@@ -31,8 +31,11 @@ namespace Libevent {
  */
 class Global {
 public:
-  // Returns true if initialized() has been called.
-  static bool initialized();
+  // True if initialized() has been called.
+  static bool INITIALIZED;
+
+  static bool initialized() { return INITIALIZED; }
+
   /**
    * Initialize the library globally.
    */

--- a/source/common/event/libevent.h
+++ b/source/common/event/libevent.h
@@ -31,7 +31,7 @@ namespace Libevent {
  */
 class Global {
 public:
-  static bool initialized() { return is_initialized; }
+  static bool initialized() { return initialized_; }
 
   /**
    * Initialize the library globally.
@@ -40,7 +40,7 @@ public:
 
 private:
   // True if initialized() has been called.
-  static bool is_initialized;
+  static bool initialized_;
 };
 
 typedef CSmartPtr<event_base, event_base_free> BasePtr;

--- a/source/common/event/libevent.h
+++ b/source/common/event/libevent.h
@@ -31,15 +31,16 @@ namespace Libevent {
  */
 class Global {
 public:
-  // True if initialized() has been called.
-  static bool INITIALIZED;
-
-  static bool initialized() { return INITIALIZED; }
+  static bool initialized() { return is_initialized; }
 
   /**
    * Initialize the library globally.
    */
   static void initialize();
+
+private:
+  // True if initialized() has been called.
+  static bool is_initialized;
 };
 
 typedef CSmartPtr<event_base, event_base_free> BasePtr;

--- a/source/common/event/libevent.h
+++ b/source/common/event/libevent.h
@@ -31,6 +31,8 @@ namespace Libevent {
  */
 class Global {
 public:
+  // Returns true if initialized() has been called.
+  static bool initialized();
   /**
    * Initialize the library globally.
    */

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -15,6 +15,7 @@
 #include "common/buffer/buffer_impl.h"
 #include "common/common/assert.h"
 #include "common/event/dispatcher_impl.h"
+#include "common/event/libevent.h"
 #include "common/network/connection_impl.h"
 #include "common/network/utility.h"
 #include "common/upstream/upstream_impl.h"
@@ -199,6 +200,7 @@ Network::ClientConnectionPtr BaseIntegrationTest::makeClientConnection(uint32_t 
 
 void BaseIntegrationTest::initialize() {
   RELEASE_ASSERT(!initialized_);
+  RELEASE_ASSERT(Event::Libevent::Global::initialized());
   initialized_ = true;
 
   createUpstreams();


### PR DESCRIPTION
We've had a couple of instances of internal Envoy with custom main or custom tests failing to initialize things properly and causing hard to debug timeouts / tsan warnings.

Adding RELEASE_ASSERTs to hopefully catch this earlier and in a more obvious way.

*Risk Level*: Low
*Testing*: n/a
*Release Notes*: n/a
