### PR TITLE
tls: support for api::v2::DataSource's new inline_string option

### DIFF
--- a/source/common/ssl/context_config_impl.cc
+++ b/source/common/ssl/context_config_impl.cc
@@ -114,6 +114,10 @@ ServerContextConfigImpl::ServerContextConfigImpl(const envoy::api::v2::Downstrea
               validateAndAppendKey(ret, datasource.inline_bytes());
               break;
             }
+            case envoy::api::v2::DataSource::kInlineString: {
+              validateAndAppendKey(ret, datasource.inline_string());
+              break;
+            }
             default:
               throw EnvoyException(fmt::format("Unexpected DataSource::specifier_case(): {}",
                                                datasource.specifier_case()));

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -248,21 +248,39 @@ TEST_F(SslServerContextImplTicketTest, TicketKeyNone) {
   EXPECT_NO_THROW(loadConfigV2(cfg));
 }
 
-TEST_F(SslServerContextImplTicketTest, TicketKeyInlineSuccess) {
+TEST_F(SslServerContextImplTicketTest, TicketKeyInlineBytesSuccess) {
   envoy::api::v2::DownstreamTlsContext cfg;
   cfg.mutable_session_ticket_keys()->add_keys()->set_inline_bytes(std::string(80, '\0'));
   EXPECT_NO_THROW(loadConfigV2(cfg));
 }
 
-TEST_F(SslServerContextImplTicketTest, TicketKeyInlineFailTooBig) {
+TEST_F(SslServerContextImplTicketTest, TicketKeyInlineStringSuccess) {
+  envoy::api::v2::DownstreamTlsContext cfg;
+  cfg.mutable_session_ticket_keys()->add_keys()->set_inline_string(std::string(80, '\0'));
+  EXPECT_NO_THROW(loadConfigV2(cfg));
+}
+
+TEST_F(SslServerContextImplTicketTest, TicketKeyInlineBytesFailTooBig) {
   envoy::api::v2::DownstreamTlsContext cfg;
   cfg.mutable_session_ticket_keys()->add_keys()->set_inline_bytes(std::string(81, '\0'));
   EXPECT_THROW(loadConfigV2(cfg), EnvoyException);
 }
 
-TEST_F(SslServerContextImplTicketTest, TicketKeyInlineFailTooSmall) {
+TEST_F(SslServerContextImplTicketTest, TicketKeyInlineStringFailTooBig) {
+  envoy::api::v2::DownstreamTlsContext cfg;
+  cfg.mutable_session_ticket_keys()->add_keys()->set_inline_string(std::string(81, '\0'));
+  EXPECT_THROW(loadConfigV2(cfg), EnvoyException);
+}
+
+TEST_F(SslServerContextImplTicketTest, TicketKeyInlineBytesFailTooSmall) {
   envoy::api::v2::DownstreamTlsContext cfg;
   cfg.mutable_session_ticket_keys()->add_keys()->set_inline_bytes(std::string(79, '\0'));
+  EXPECT_THROW(loadConfigV2(cfg), EnvoyException);
+}
+
+TEST_F(SslServerContextImplTicketTest, TicketKeyInlineStringFailTooSmall) {
+  envoy::api::v2::DownstreamTlsContext cfg;
+  cfg.mutable_session_ticket_keys()->add_keys()->set_inline_string(std::string(79, '\0'));
   EXPECT_THROW(loadConfigV2(cfg), EnvoyException);
 }
 


### PR DESCRIPTION
*Description*:
Catching up with the extended `DataSource` definition in data-plane-api

*Risk Level*: Low

*Testing*: Updated unit tests included

*API Changes*: [PR 393](https://github.com/envoyproxy/data-plane-api/pull/393)

Signed-off-by: Brian Pane <bpane@pinterest.com>