### PR TITLE
config: add and populate metadata accessor in ClusterInfo

### DIFF
--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -432,7 +432,7 @@ public:
   virtual const LoadBalancerSubsetInfo& lbSubsetInfo() const PURE;
 
   /**
-   * @return the configuration metadata for this cluster.
+   * @return const envoy::api::v2::Metadata& the configuration metadata for this cluster.
    */
   virtual const envoy::api::v2::Metadata& metadata() const PURE;
 };

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -19,6 +19,8 @@
 #include "envoy/upstream/outlier_detection.h"
 #include "envoy/upstream/resource_manager.h"
 
+#include "api/base.pb.h"
+
 namespace Envoy {
 namespace Upstream {
 
@@ -428,6 +430,11 @@ public:
    * @return the configuration for load balancer subsets.
    */
   virtual const LoadBalancerSubsetInfo& lbSubsetInfo() const PURE;
+
+  /**
+   * @return the configuration metadata for this cluster.
+   */
+  virtual const envoy::api::v2::Metadata& metadata() const PURE;
 };
 
 typedef std::shared_ptr<const ClusterInfo> ClusterInfoConstSharedPtr;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -112,7 +112,8 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
       source_address_(getSourceAddress(config, source_address)),
       lb_ring_hash_config_(envoy::api::v2::Cluster::RingHashLbConfig(config.ring_hash_lb_config())),
       ssl_context_manager_(ssl_context_manager), added_via_api_(added_via_api),
-      lb_subset_(LoadBalancerSubsetInfoImpl(config.lb_subset_config())) {
+      lb_subset_(LoadBalancerSubsetInfoImpl(config.lb_subset_config())),
+      metadata_(config.metadata()) {
 
   auto transport_socket = config.transport_socket();
   if (!config.has_transport_socket()) {

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -314,6 +314,7 @@ public:
     return source_address_;
   };
   const LoadBalancerSubsetInfo& lbSubsetInfo() const override { return lb_subset_; }
+  const envoy::api::v2::Metadata& metadata() const override { return metadata_; }
 
   // Server::Configuration::TransportSocketFactoryContext
   Ssl::ContextManager& sslContextManager() override { return ssl_context_manager_; }
@@ -354,6 +355,7 @@ private:
   Ssl::ContextManager& ssl_context_manager_;
   const bool added_via_api_;
   LoadBalancerSubsetInfoImpl lb_subset_;
+  const envoy::api::v2::Metadata metadata_;
 };
 
 /**

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -275,6 +275,7 @@ envoy_cc_test(
         "//include/envoy/api:api_interface",
         "//include/envoy/http:codec_interface",
         "//include/envoy/upstream:cluster_manager_interface",
+        "//source/common/config:metadata_lib",
         "//source/common/event:dispatcher_lib",
         "//source/common/json:config_schemas_lib",
         "//source/common/json:json_loader_lib",

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -707,7 +707,7 @@ TEST(PrioritySet, Extend) {
   }
 }
 
-// Resolve zero hosts, while using health checking.
+// Cluster metadata retrieval.
 TEST(ClusterMetadataTest, Metadata) {
   Stats::IsolatedStoreImpl stats;
   Ssl::MockContextManager ssl_context_manager;
@@ -723,11 +723,10 @@ TEST(ClusterMetadataTest, Metadata) {
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     hosts: [{ socket_address: { address: foo.bar.com, port_value: 443 }}]
+    metadata: { filter_metadata: { com.bar.foo: { baz: test_value } } }
   )EOF";
 
   auto cluster_config = parseClusterFromV2Yaml(yaml);
-  Config::Metadata::mutableMetadataValue(*cluster_config.mutable_metadata(), "com.bar.foo", "baz")
-      .set_string_value("test_value");
   StrictDnsClusterImpl cluster(cluster_config, runtime, stats, ssl_context_manager, dns_resolver,
                                cm, dispatcher, false);
   EXPECT_EQ("test_value",

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -726,9 +726,8 @@ TEST(ClusterMetadataTest, Metadata) {
     metadata: { filter_metadata: { com.bar.foo: { baz: test_value } } }
   )EOF";
 
-  auto cluster_config = parseClusterFromV2Yaml(yaml);
-  StrictDnsClusterImpl cluster(cluster_config, runtime, stats, ssl_context_manager, dns_resolver,
-                               cm, dispatcher, false);
+  StrictDnsClusterImpl cluster(parseClusterFromV2Yaml(yaml), runtime, stats, ssl_context_manager,
+                               dns_resolver, cm, dispatcher, false);
   EXPECT_EQ("test_value",
             Config::Metadata::metadataValue(cluster.info()->metadata(), "com.bar.foo", "baz")
                 .string_value());

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -59,6 +59,7 @@ public:
   MOCK_CONST_METHOD0(loadReportStats, ClusterLoadReportStats&());
   MOCK_CONST_METHOD0(sourceAddress, const Network::Address::InstanceConstSharedPtr&());
   MOCK_CONST_METHOD0(lbSubsetInfo, const LoadBalancerSubsetInfo&());
+  MOCK_CONST_METHOD0(metadata, const envoy::api::v2::Metadata&());
 
   std::string name_{"fake_cluster"};
   Http::Http2Settings http2_settings_{};


### PR DESCRIPTION
*Description*: Made the [cluster metadata field](https://github.com/envoyproxy/data-plane-api/blob/b796da4964af6c332bd7d29ae4f08d0a98bf5352/api/cds.proto#L420) visible in ClusterInfo for access by filters and access logs.

*Risk Level*: Low

*Testing*: Added a small unit test to ensure that the metadata could be populated and extracted from ClusterInfo.

*Docs Changes*: https://github.com/envoyproxy/data-plane-api/pull/408

*Release Notes*: Does this change require release notes?
