### PR TITLE
router: add gateway-error retry-on policy

### DIFF
--- a/RAW_RELEASE_NOTES.md
+++ b/RAW_RELEASE_NOTES.md
@@ -34,3 +34,4 @@ final version.
 * Added support for route matching based on URL query string parameters.
   :ref:`QueryParameterMatcher<envoy_api_msg_QueryParameterMatcher>`
 * Added `/runtime` admin endpoint to read the current runtime values.
+* Added `gateway-error` retry-on policy.

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -93,12 +93,13 @@ class RetryPolicy {
 public:
   // clang-format off
   static const uint32_t RETRY_ON_5XX                     = 0x1;
-  static const uint32_t RETRY_ON_CONNECT_FAILURE         = 0x2;
-  static const uint32_t RETRY_ON_RETRIABLE_4XX           = 0x4;
-  static const uint32_t RETRY_ON_REFUSED_STREAM          = 0x8;
-  static const uint32_t RETRY_ON_GRPC_CANCELLED          = 0x10;
-  static const uint32_t RETRY_ON_GRPC_DEADLINE_EXCEEDED  = 0x20;
-  static const uint32_t RETRY_ON_GRPC_RESOURCE_EXHAUSTED = 0x40;
+  static const uint32_t RETRY_ON_GATEWAY_ERROR           = 0x2;
+  static const uint32_t RETRY_ON_CONNECT_FAILURE         = 0x4;
+  static const uint32_t RETRY_ON_RETRIABLE_4XX           = 0x8;
+  static const uint32_t RETRY_ON_REFUSED_STREAM          = 0x10;
+  static const uint32_t RETRY_ON_GRPC_CANCELLED          = 0x20;
+  static const uint32_t RETRY_ON_GRPC_DEADLINE_EXCEEDED  = 0x40;
+  static const uint32_t RETRY_ON_GRPC_RESOURCE_EXHAUSTED = 0x80;
   // clang-format on
 
   virtual ~RetryPolicy() {}

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -125,6 +125,7 @@ public:
 
   struct {
     const std::string _5xx{"5xx"};
+    const std::string GatewayError{"gateway-error"};
     const std::string ConnectFailure{"connect-failure"};
     const std::string RefusedStream{"refused-stream"};
     const std::string Retriable4xx{"retriable-4xx"};

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -15,9 +15,10 @@
 namespace Envoy {
 namespace Router {
 
-// These are defined in envoy/server/router.h, however during certain cases the compiler is
+// These are defined in envoy/router.h, however during certain cases the compiler is
 // refusing to use the header version so allocate space here.
 const uint32_t RetryPolicy::RETRY_ON_5XX;
+const uint32_t RetryPolicy::RETRY_ON_GATEWAY_ERROR;
 const uint32_t RetryPolicy::RETRY_ON_CONNECT_FAILURE;
 const uint32_t RetryPolicy::RETRY_ON_RETRIABLE_4XX;
 const uint32_t RetryPolicy::RETRY_ON_GRPC_CANCELLED;
@@ -93,6 +94,8 @@ uint32_t RetryStateImpl::parseRetryOn(const std::string& config) {
   for (const std::string& retry_on : retry_on_list) {
     if (retry_on == Http::Headers::get().EnvoyRetryOnValues._5xx) {
       ret |= RetryPolicy::RETRY_ON_5XX;
+    } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.GatewayError) {
+      ret |= RetryPolicy::RETRY_ON_GATEWAY_ERROR;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.ConnectFailure) {
       ret |= RetryPolicy::RETRY_ON_CONNECT_FAILURE;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.Retriable4xx) {
@@ -183,6 +186,12 @@ bool RetryStateImpl::wouldRetry(const Http::HeaderMap* response_headers,
     // into its own type. I.e., RETRY_ON_RESET.
     if (!response_headers ||
         Http::CodeUtility::is5xx(Http::Utility::getResponseStatus(*response_headers))) {
+      return true;
+    }
+  }
+
+  if (retry_on_ & RetryPolicy::RETRY_ON_GATEWAY_ERROR) {
+    if (Http::CodeUtility::isGatewayError(Http::Utility::getResponseStatus(*response_headers))) {
       return true;
     }
   }

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -191,7 +191,7 @@ bool RetryStateImpl::wouldRetry(const Http::HeaderMap* response_headers,
   }
 
   if (retry_on_ & RetryPolicy::RETRY_ON_GATEWAY_ERROR) {
-    if (response_headers != nullptr &&
+    if (!response_headers ||
         Http::CodeUtility::isGatewayError(Http::Utility::getResponseStatus(*response_headers))) {
       return true;
     }

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -191,7 +191,8 @@ bool RetryStateImpl::wouldRetry(const Http::HeaderMap* response_headers,
   }
 
   if (retry_on_ & RetryPolicy::RETRY_ON_GATEWAY_ERROR) {
-    if (Http::CodeUtility::isGatewayError(Http::Utility::getResponseStatus(*response_headers))) {
+    if (response_headers != nullptr &&
+        Http::CodeUtility::isGatewayError(Http::Utility::getResponseStatus(*response_headers))) {
       return true;
     }
   }

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -15,7 +15,7 @@
 namespace Envoy {
 namespace Router {
 
-// These are defined in envoy/router.h, however during certain cases the compiler is
+// These are defined in envoy/router/router.h, however during certain cases the compiler is
 // refusing to use the header version so allocate space here.
 const uint32_t RetryPolicy::RETRY_ON_5XX;
 const uint32_t RetryPolicy::RETRY_ON_GATEWAY_ERROR;

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -1798,7 +1798,7 @@ TEST(RouteMatcherTest, Retry) {
           "retry_policy": {
             "per_try_timeout_ms" : 1000,
             "num_retries": 3,
-            "retry_on": "5xx,connect-failure"
+            "retry_on": "5xx,gateway-error,connect-failure"
           }
         }
       ]
@@ -1849,7 +1849,8 @@ TEST(RouteMatcherTest, Retry) {
                     ->routeEntry()
                     ->retryPolicy()
                     .numRetries());
-  EXPECT_EQ(RetryPolicy::RETRY_ON_CONNECT_FAILURE | RetryPolicy::RETRY_ON_5XX,
+  EXPECT_EQ(RetryPolicy::RETRY_ON_CONNECT_FAILURE | RetryPolicy::RETRY_ON_5XX |
+                RetryPolicy::RETRY_ON_GATEWAY_ERROR,
             config.route(genHeaders("www.lyft.com", "/", "GET"), 0)
                 ->routeEntry()
                 ->retryPolicy()

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -172,6 +172,12 @@ TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemoteReset) {
   Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "gateway-error"}};
   setup(request_headers);
   EXPECT_TRUE(state_->enabled());
+
+  expectTimerCreateAndEnable();
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetry(nullptr, remote_reset_, callback_));
+  EXPECT_CALL(callback_ready_, ready());
+  retry_timer_->callback_();
+
   EXPECT_EQ(RetryStatus::No, state_->shouldRetry(nullptr, remote_reset_, callback_));
 }
 

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -119,6 +119,48 @@ TEST_F(RouterRetryStateImplTest, Policy5xxRemote503Overloaded) {
   EXPECT_EQ(RetryStatus::No, state_->shouldRetry(&response_headers, no_reset_, callback_));
 }
 
+TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemote502) {
+  Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "gateway-error"}};
+  setup(request_headers);
+  EXPECT_TRUE(state_->enabled());
+
+  Http::TestHeaderMapImpl response_headers{{":status", "502"}};
+  expectTimerCreateAndEnable();
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetry(&response_headers, no_reset_, callback_));
+  EXPECT_CALL(callback_ready_, ready());
+  retry_timer_->callback_();
+
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(&response_headers, no_reset_, callback_));
+}
+
+TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemote503) {
+  Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "gateway-error"}};
+  setup(request_headers);
+  EXPECT_TRUE(state_->enabled());
+
+  Http::TestHeaderMapImpl response_headers{{":status", "503"}};
+  expectTimerCreateAndEnable();
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetry(&response_headers, no_reset_, callback_));
+  EXPECT_CALL(callback_ready_, ready());
+  retry_timer_->callback_();
+
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(&response_headers, no_reset_, callback_));
+}
+
+TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemote504) {
+  Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "gateway-error"}};
+  setup(request_headers);
+  EXPECT_TRUE(state_->enabled());
+
+  Http::TestHeaderMapImpl response_headers{{":status", "504"}};
+  expectTimerCreateAndEnable();
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetry(&response_headers, no_reset_, callback_));
+  EXPECT_CALL(callback_ready_, ready());
+  retry_timer_->callback_();
+
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(&response_headers, no_reset_, callback_));
+}
+
 TEST_F(RouterRetryStateImplTest, PolicyGrpcCancelled) {
   Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-grpc-on", "cancelled"}};
   setup(request_headers);

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -161,6 +161,20 @@ TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemote504) {
   EXPECT_EQ(RetryStatus::No, state_->shouldRetry(&response_headers, no_reset_, callback_));
 }
 
+TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorResetOverflow) {
+  Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "gateway-error"}};
+  setup(request_headers);
+  EXPECT_TRUE(state_->enabled());
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(nullptr, overflow_reset_, callback_));
+}
+
+TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemoteReset) {
+  Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "gateway-error"}};
+  setup(request_headers);
+  EXPECT_TRUE(state_->enabled());
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(nullptr, remote_reset_, callback_));
+}
+
 TEST_F(RouterRetryStateImplTest, PolicyGrpcCancelled) {
   Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-grpc-on", "cancelled"}};
   setup(request_headers);


### PR DESCRIPTION
*router: add gateway-error retry-on policy*

*Description*: Add gateway-error (consider 502, 503 and 504 only) as a subset of 5xx retry-on policy.

*Risk Level*: Low

*Testing*: unit test

*Docs Changes*:
- [docs: add gateway-error as one of retry-on policies](https://github.com/envoyproxy/data-plane-api/pull/415)

*Release Notes*: N/A

Fixes #2300