### PR TITLE
stats: support default stats tags with fixed value

### DIFF
--- a/RAW_RELEASE_NOTES.md
+++ b/RAW_RELEASE_NOTES.md
@@ -31,3 +31,6 @@ final version.
 xDS the file must exist at configuration time. For cluster based xDS (api\_config\_source, and ADS) the backing cluster must be statically defined and be of non-EDS type.
 * Added support for route matching based on URL query string parameters.
   :ref:`QueryParameterMatcher<envoy_api_msg_QueryParameterMatcher>`
+* Added support for default stats tags with :ref:`fixed tag value
+  <envoy_api_field_TagSpecifier.fixed_value>` which will be added to all metrics.
+  Typical use case is identifying Envoy instances with the tag.

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -71,8 +71,8 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
     ),
     envoy_api = dict(
-        commit = "f268484d221509b175c46cce6c4cc3593a0ede5e",
-        remote = "https://github.com/envoyproxy/data-plane-api",
+        commit = "07b79a51679558d6460fd2785b7206d102869f4d",
+        remote = "https://github.com/taiki45/data-plane-api",
     ),
     grpc_httpjson_transcoding = dict(
         commit = "e4f58aa07b9002befa493a0a82e10f2e98b51fc6",

--- a/include/envoy/stats/stats.h
+++ b/include/envoy/stats/stats.h
@@ -246,6 +246,11 @@ public:
   virtual void setTagExtractors(const std::vector<TagExtractorPtr>& tag_extractor) PURE;
 
   /**
+   * Set the given tags as default tags for all metrics.
+   */
+  virtual void setDefaultTags(const std::vector<Tag>& tags) PURE;
+
+  /**
    * Initialize the store for threading. This will be called once after all worker threads have
    * been initialized. At this point the store can initialize itself for multi-threaded operation.
    */

--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -159,35 +159,62 @@ std::string Utility::resourceName(const ProtobufWkt::Any& resource) {
       fmt::format("Unknown type URL {} in DiscoveryResponse", resource.type_url()));
 }
 
-std::vector<Stats::TagExtractorPtr>
-Utility::createTagExtractors(const envoy::api::v2::Bootstrap& bootstrap) {
-  std::vector<Stats::TagExtractorPtr> tag_extractors;
-
-  // Ensure no tag names are repeated.
+void Utility::detectTagNameConflict(const envoy::api::v2::Bootstrap& bootstrap) {
   std::unordered_set<std::string> names;
-  auto add_tag = [&names, &tag_extractors](const std::string& name, const std::string& regex) {
+
+  if (!bootstrap.stats_config().has_use_all_default_tags() ||
+      bootstrap.stats_config().use_all_default_tags().value()) {
+    for (const std::pair<std::string, std::string>& default_tag :
+         TagNames::get().name_regex_pairs_) {
+      names.emplace(default_tag.first);
+    }
+  }
+
+  for (const envoy::api::v2::TagSpecifier& tag_specifier : bootstrap.stats_config().stats_tags()) {
+    const std::string name = tag_specifier.tag_name();
     if (!names.emplace(name).second) {
       throw EnvoyException(fmt::format("Tag name '{}' specified twice.", name));
     }
+  }
+}
 
-    tag_extractors.emplace_back(Stats::TagExtractorImpl::createTagExtractor(name, regex));
-  };
+std::vector<Stats::TagExtractorPtr>
+Utility::createTagExtractors(const envoy::api::v2::Bootstrap& bootstrap) {
+  std::vector<Stats::TagExtractorPtr> tag_extractors;
 
   // Add defaults.
   if (!bootstrap.stats_config().has_use_all_default_tags() ||
       bootstrap.stats_config().use_all_default_tags().value()) {
     for (const std::pair<std::string, std::string>& default_tag :
          TagNames::get().name_regex_pairs_) {
-      add_tag(default_tag.first, default_tag.second);
+      tag_extractors.emplace_back(
+          Stats::TagExtractorImpl::createTagExtractor(default_tag.first, default_tag.second));
     }
   }
 
   // Add custom tags.
   for (const envoy::api::v2::TagSpecifier& tag_specifier : bootstrap.stats_config().stats_tags()) {
-    add_tag(tag_specifier.tag_name(), tag_specifier.regex());
+    // If no tag value are found, fallback to default regex to keep backward compatibility.
+    if (tag_specifier.tag_value_case() == envoy::api::v2::TagSpecifier::TAG_VALUE_NOT_SET ||
+        tag_specifier.tag_value_case() == envoy::api::v2::TagSpecifier::kRegex) {
+      tag_extractors.emplace_back(Stats::TagExtractorImpl::createTagExtractor(
+          tag_specifier.tag_name(), tag_specifier.regex()));
+    }
   }
 
   return tag_extractors;
+}
+
+std::vector<Stats::Tag> Utility::createTags(const envoy::api::v2::Bootstrap& bootstrap) {
+  std::vector<Stats::Tag> tags;
+
+  for (const envoy::api::v2::TagSpecifier& tag_specifier : bootstrap.stats_config().stats_tags()) {
+    if (tag_specifier.tag_value_case() == envoy::api::v2::TagSpecifier::kFixedValue) {
+      tags.emplace_back(Stats::Tag{tag_specifier.tag_name(), tag_specifier.fixed_value()});
+    }
+  }
+
+  return tags;
 }
 
 void Utility::checkObjNameLength(const std::string& error_prefix, const std::string& name) {

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -230,6 +230,15 @@ public:
   static std::string resourceName(const ProtobufWkt::Any& resource);
 
   /**
+   * Envoy can have both pre-defined tag names in well_known_names and user
+   * provided tag names through bootstrap configuration. Check the confilict of
+   * all the tag names to avoid unexpected tag name overwriting. If found a
+   * confilict, throw an exception.
+   * @param bootstrap bootstrap proto.
+   */
+  static void detectTagNameConflict(const envoy::api::v2::Bootstrap& bootstrap);
+
+  /**
    * Creates the set of stats tag extractors requested by the config and transfers ownership to the
    * caller.
    * @param bootstrap bootstrap proto.
@@ -237,6 +246,13 @@ public:
    */
   static std::vector<Stats::TagExtractorPtr>
   createTagExtractors(const envoy::api::v2::Bootstrap& bootstrap);
+
+  /**
+   * Creates the set of tags if TagSpecifiers have "fixed_value" field. The
+   * tags will use as default tags. In other words, the tags will be added into
+   * all metrics.
+   */
+  static std::vector<Stats::Tag> createTags(const envoy::api::v2::Bootstrap& bootstrap);
 
   /**
    * Check user supplied name in RDS/CDS/LDS for sanity.

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -87,6 +87,10 @@ void ThreadLocalStoreImpl::releaseScopeCrossThread(ScopeImpl* scope) {
 }
 
 std::string ThreadLocalStoreImpl::getTagsForName(const std::string& name, std::vector<Tag>& tags) {
+  if (default_tags_ != nullptr) {
+    tags.insert(tags.end(), default_tags_->begin(), default_tags_->end());
+  }
+
   std::string tag_extracted_name = name;
   if (tag_extractors_ != nullptr) {
     for (const TagExtractorPtr& tag_extractor : *tag_extractors_) {

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -70,6 +70,7 @@ public:
   void setTagExtractors(const std::vector<TagExtractorPtr>& tag_extractors) override {
     tag_extractors_ = &tag_extractors;
   }
+  void setDefaultTags(const std::vector<Tag>& tags) override { default_tags_ = &tags; }
   void initializeThreading(Event::Dispatcher& main_thread_dispatcher,
                            ThreadLocal::Instance& tls) override;
   void shutdownThreading() override;
@@ -122,6 +123,7 @@ private:
   ScopePtr default_scope_;
   std::list<std::reference_wrapper<Sink>> timer_sinks_;
   const std::vector<TagExtractorPtr>* tag_extractors_{};
+  const std::vector<Tag>* default_tags_{};
   std::atomic<bool> shutting_down_{};
   Counter& num_last_resort_stats_;
   HeapRawStatDataAllocator heap_allocator_;

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -67,7 +67,9 @@ void ValidationInstance::initialize(Options& options,
   envoy::api::v2::Bootstrap bootstrap;
   InstanceUtil::loadBootstrapConfig(bootstrap, options.configPath(), options.v2ConfigOnly());
 
+  Config::Utility::detectTagNameConflict(bootstrap);
   tag_extractors_ = Config::Utility::createTagExtractors(bootstrap);
+  Config::Utility::createTags(bootstrap);
 
   bootstrap.mutable_node()->set_build_version(VersionInfo::version());
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -192,6 +192,8 @@ void InstanceImpl::initialize(Options& options,
   // stats.
   tag_extractors_ = Config::Utility::createTagExtractors(bootstrap);
   stats_store_.setTagExtractors(tag_extractors_);
+  default_tags_ = Config::Utility::createTags(bootstrap);
+  stats_store_.setDefaultTags(default_tags_);
 
   server_stats_.reset(
       new ServerStats{ALL_SERVER_STATS(POOL_GAUGE_PREFIX(stats_store_, "server."))});

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -178,6 +178,7 @@ private:
   time_t original_start_time_;
   Stats::StoreRoot& stats_store_;
   std::vector<Stats::TagExtractorPtr> tag_extractors_;
+  std::vector<Stats::Tag> default_tags_;
   std::unique_ptr<ServerStats> server_stats_;
   ThreadLocal::Instance& thread_local_;
   Api::ApiPtr api_;

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -81,6 +81,31 @@ TEST(UtilityTest, TranslateApiConfigSource) {
   EXPECT_EQ("test_grpc_cluster", api_config_source_grpc.cluster_names(0));
 }
 
+TEST(UtilityTest, DetectTagNameConflict) {
+  envoy::api::v2::Bootstrap bootstrap;
+  auto& stats_config = *bootstrap.mutable_stats_config();
+
+  // Should pass there were no conflict.
+  auto& tag_specifier1 = *stats_config.mutable_stats_tags()->Add();
+  tag_specifier1.set_tag_name("test.x");
+  Utility::detectTagNameConflict(bootstrap);
+
+  // Should raise an error when duplicate tag names are specified.
+  auto& tag_specifier2 = *stats_config.mutable_stats_tags()->Add();
+  tag_specifier2.set_tag_name("test.x");
+  EXPECT_THROW_WITH_MESSAGE(Utility::detectTagNameConflict(bootstrap), EnvoyException,
+                            fmt::format("Tag name '{}' specified twice.", "test.x"));
+
+  // Also should raise an error When user defined tag name conflicts with Envoy's default tag names.
+  stats_config.clear_stats_tags();
+  stats_config.mutable_use_all_default_tags()->set_value(true);
+  auto& tag_specifier_with_dup = *stats_config.mutable_stats_tags()->Add();
+  tag_specifier_with_dup.set_tag_name(TagNames::get().CLUSTER_NAME);
+  EXPECT_THROW_WITH_MESSAGE(
+      Utility::detectTagNameConflict(bootstrap), EnvoyException,
+      fmt::format("Tag name '{}' specified twice.", TagNames::get().CLUSTER_NAME));
+}
+
 TEST(UtilityTest, GetTagExtractorsFromBootstrap) {
   envoy::api::v2::Bootstrap bootstrap;
   const auto& tag_names = TagNames::get();
@@ -100,11 +125,8 @@ TEST(UtilityTest, GetTagExtractorsFromBootstrap) {
   tag_extractors = Utility::createTagExtractors(bootstrap);
   EXPECT_EQ(tag_names.name_regex_pairs_.size(), tag_extractors.size());
 
-  // Create a duplicate name by adding a default name with all the defaults enabled.
   auto& custom_tag_extractor = *stats_config.mutable_stats_tags()->Add();
   custom_tag_extractor.set_tag_name(tag_names.CLUSTER_NAME);
-  EXPECT_THROW_WITH_MESSAGE(Utility::createTagExtractors(bootstrap), EnvoyException,
-                            fmt::format("Tag name '{}' specified twice.", tag_names.CLUSTER_NAME));
 
   // Remove the defaults and ensure the manually added default gets the correct regex.
   stats_config.mutable_use_all_default_tags()->set_value(false);
@@ -148,6 +170,28 @@ TEST(UtilityTest, GetTagExtractorsFromBootstrap) {
   EXPECT_THROW_WITH_MESSAGE(
       Utility::createTagExtractors(bootstrap), EnvoyException,
       "No regex specified for tag specifier and no default regex for name: 'test_extractor'");
+}
+
+TEST(UtilityTest, GetDefaultTagsFromBootstrap) {
+  envoy::api::v2::Bootstrap bootstrap;
+  auto& stats_config = *bootstrap.mutable_stats_config();
+
+  // Default configuration should produce empty tags.
+  std::vector<Stats::Tag> tags = Utility::createTags(bootstrap);
+  EXPECT_EQ(0, tags.size());
+
+  // Should ignore tag_specifiers which has empty tag_value.
+  auto& tag_specifier = *stats_config.mutable_stats_tags()->Add();
+  tag_specifier.set_tag_name("test.service_cluster");
+  tags = Utility::createTags(bootstrap);
+  EXPECT_EQ(0, tags.size());
+
+  // Should build Stats::Tag when given TagSpecifier has fixed_value.
+  tag_specifier.set_fixed_value("test_cluster");
+  tags = Utility::createTags(bootstrap);
+  EXPECT_EQ(1, tags.size());
+  EXPECT_EQ("test.service_cluster", tags[0].name_);
+  EXPECT_EQ("test_cluster", tags[0].value_);
 }
 
 TEST(UtilityTest, ObjNameLength) {

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -323,6 +323,19 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "stats_integration_test",
+    srcs = ["stats_integration_test.cc"],
+    external_deps = [
+        "envoy_bootstrap",
+        "envoy_stats",
+    ],
+    deps = [
+        ":integration_lib",
+        "//test/test_common:network_utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "load_stats_integration_test",
     srcs = ["load_stats_integration_test.cc"],
     external_deps = ["envoy_eds"],

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -166,6 +166,7 @@ public:
   // Stats::StoreRoot
   void addSink(Sink&) override {}
   void setTagExtractors(const std::vector<TagExtractorPtr>&) override {}
+  void setDefaultTags(const std::vector<Tag>&) override {}
   void initializeThreading(Event::Dispatcher&, ThreadLocal::Instance&) override {}
   void shutdownThreading() override {}
 

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -1,0 +1,90 @@
+#include "test/integration/integration.h"
+#include "test/test_common/network_utility.h"
+
+#include "api/bootstrap.pb.h"
+#include "api/stats.pb.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace {
+
+class StatsIntegrationTest : public BaseIntegrationTest,
+                             public testing::TestWithParam<Network::Address::IpVersion> {
+public:
+  StatsIntegrationTest() : BaseIntegrationTest(GetParam()) {}
+
+  void TearDown() override {
+    test_server_.reset();
+    fake_upstreams_.clear();
+  }
+
+  void initialize() override { BaseIntegrationTest::initialize(); }
+};
+
+INSTANTIATE_TEST_CASE_P(IpVersions, StatsIntegrationTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(StatsIntegrationTest, WithDefaultConfig) {
+  initialize();
+
+  auto live = test_server_->gauge("server.live");
+  EXPECT_EQ(live->value(), 1);
+  EXPECT_EQ(live->tags().size(), 0);
+}
+
+TEST_P(StatsIntegrationTest, WithDefaultTags) {
+  initialize();
+
+  auto cx_active = test_server_->gauge("listener.127.0.0.1_0.downstream_cx_active");
+  EXPECT_EQ(cx_active->tags().size(), 1);
+  EXPECT_EQ(cx_active->tags()[0].name_, "envoy.listener_address");
+  EXPECT_EQ(cx_active->tags()[0].value_, "127.0.0.1_0");
+}
+
+TEST_P(StatsIntegrationTest, WithEmptyTagValue) {
+  config_helper_.addConfigModifier([&](envoy::api::v2::Bootstrap& bootstrap) -> void {
+    bootstrap.mutable_stats_config()->mutable_use_all_default_tags()->set_value(false);
+    auto tag_specifier = bootstrap.mutable_stats_config()->mutable_stats_tags()->Add();
+    tag_specifier->set_tag_name("envoy.listener_address");
+  });
+  initialize();
+
+  auto cx_active = test_server_->gauge("listener.127.0.0.1_0.downstream_cx_active");
+  EXPECT_EQ(cx_active->tags().size(), 1);
+  EXPECT_EQ(cx_active->tags()[0].name_, "envoy.listener_address");
+  EXPECT_EQ(cx_active->tags()[0].value_, "127.0.0.1_0");
+}
+
+TEST_P(StatsIntegrationTest, WithTagSpecifierWithRegex) {
+  config_helper_.addConfigModifier([&](envoy::api::v2::Bootstrap& bootstrap) -> void {
+    bootstrap.mutable_stats_config()->mutable_use_all_default_tags()->set_value(false);
+    auto tag_specifier = bootstrap.mutable_stats_config()->mutable_stats_tags()->Add();
+    tag_specifier->set_tag_name("my_listener_address");
+    tag_specifier->set_regex(
+        "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)");
+  });
+  initialize();
+
+  auto cx_active = test_server_->gauge("listener.127.0.0.1_0.downstream_cx_active");
+  EXPECT_EQ(cx_active->tags().size(), 1);
+  EXPECT_EQ(cx_active->tags()[0].name_, "my_listener_address");
+  EXPECT_EQ(cx_active->tags()[0].value_, "127.0.0.1_0");
+}
+
+TEST_P(StatsIntegrationTest, WithTagSpecifierWithFixedValue) {
+  config_helper_.addConfigModifier([&](envoy::api::v2::Bootstrap& bootstrap) -> void {
+    auto tag_specifier = bootstrap.mutable_stats_config()->mutable_stats_tags()->Add();
+    tag_specifier->set_tag_name("test.x");
+    tag_specifier->set_fixed_value("xxx");
+  });
+  initialize();
+
+  auto live = test_server_->gauge("server.live");
+  EXPECT_EQ(live->value(), 1);
+  EXPECT_EQ(live->tags().size(), 1);
+  EXPECT_EQ(live->tags()[0].name_, "test.x");
+  EXPECT_EQ(live->tags()[0].value_, "xxx");
+}
+
+} // namespace
+} // namespace Envoy


### PR DESCRIPTION
*Description*:
Support default stats tag which will be added to all metrics. Typical use case is
identifying Envoy instances with the tag.

The previous disscussions were:

a. we don't use environment variable extraction due to configuration inconsistency. ref: https://github.com/envoyproxy/envoy/issues/1975#issuecomment-353415481
b. we don't add any more ad-hoc CLI flag. ref:  https://github.com/envoyproxy/envoy/pull/2264#pullrequestreview-85432283
c. generic override CLI flag can be implemented to overwrite this fixed tag value option but not in this PR. ref: https://github.com/envoyproxy/envoy/pull/2264#issuecomment-353892333

So just implement fixed stats tag value option and leave CLI override feature to https://github.com/envoyproxy/envoy/issues/2269.

*Risk Level*: Medium
New features that are not enabled by default.

*Testing*:
unit test and integration test should cover this. Also munally tested with with statsd_exporter v0.5.0 and Prometheus v2.0.0.

*Docs Changes*:
https://github.com/envoyproxy/data-plane-api/pull/416

*Release Notes*:
Added.

*API Changes*:
https://github.com/envoyproxy/data-plane-api/pull/416

Fixes #1975