### PR TITLE
grpc-json: no buffering at end_stream or non-gRPC response

### DIFF
--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -48,6 +48,17 @@ bool Common::hasGrpcContentType(const Http::HeaderMap& headers) {
   return false;
 }
 
+bool Common::isGrpcResponseHeader(const Http::HeaderMap& headers, bool end_stream) {
+  if (end_stream) {
+    // Trailers-only response, only grpc-status is required.
+    return headers.GrpcStatus() != nullptr;
+  }
+  if (Http::Utility::getResponseStatus(headers) != enumToInt(Http::Code::OK)) {
+    return false;
+  }
+  return hasGrpcContentType(headers);
+}
+
 void Common::chargeStat(const Upstream::ClusterInfo& cluster, const std::string& protocol,
                         const std::string& grpc_service, const std::string& grpc_method,
                         const Http::HeaderEntry* grpc_status) {

--- a/source/common/grpc/common.h
+++ b/source/common/grpc/common.h
@@ -28,6 +28,7 @@ class Common {
 public:
   /**
    * @param headers the headers to parse.
+   * @param bool indicating wether the header is at end_stream.
    * @return bool indicating whether content-type is gRPC.
    */
   static bool hasGrpcContentType(const Http::HeaderMap& headers);

--- a/source/common/grpc/common.h
+++ b/source/common/grpc/common.h
@@ -33,6 +33,12 @@ public:
   static bool hasGrpcContentType(const Http::HeaderMap& headers);
 
   /**
+   * @param headers the headers to parse.
+   * @return bool indicating whether the header is a gRPC reseponse header
+   */
+  static bool isGrpcResponseHeader(const Http::HeaderMap& headers, bool end_stream);
+
+  /**
    * Returns the GrpcStatus code from a given set of trailers, if present.
    * @param trailers the trailers to parse.
    * @return Optional<Status::GrpcStatus> the parsed status code or InvalidCode if no valid status

--- a/source/common/grpc/common.h
+++ b/source/common/grpc/common.h
@@ -28,13 +28,13 @@ class Common {
 public:
   /**
    * @param headers the headers to parse.
-   * @param bool indicating wether the header is at end_stream.
    * @return bool indicating whether content-type is gRPC.
    */
   static bool hasGrpcContentType(const Http::HeaderMap& headers);
 
   /**
    * @param headers the headers to parse.
+   * @param bool indicating wether the header is at end_stream.
    * @return bool indicating whether the header is a gRPC reseponse header
    */
   static bool isGrpcResponseHeader(const Http::HeaderMap& headers, bool end_stream);

--- a/source/common/grpc/json_transcoder_filter.cc
+++ b/source/common/grpc/json_transcoder_filter.cc
@@ -73,11 +73,11 @@ private:
 };
 
 bool isGrpcResponse(const Http::HeaderMap& headers) {
-  if (strcmp("200", headers.Status()->value().c_str()) != 0) {
+  if (Http::Utility::getResponseStatus(headers) != 200) {
     return false;
   }
   return headers.ContentType() &&
-         Http::Headers::get().ContentTypeValues.Grpc == headers.ContentType()->value().c_str();
+         headers.ContentType()->value() == Http::Headers::get().ContentTypeValues.Grpc.c_str();
 }
 
 } // namespace

--- a/source/common/grpc/json_transcoder_filter.cc
+++ b/source/common/grpc/json_transcoder_filter.cc
@@ -72,14 +72,6 @@ private:
   std::unique_ptr<TranscoderInputStream> response_stream_;
 };
 
-bool isGrpcResponse(const Http::HeaderMap& headers) {
-  if (Http::Utility::getResponseStatus(headers) != 200) {
-    return false;
-  }
-  return headers.ContentType() &&
-         headers.ContentType()->value() == Http::Headers::get().ContentTypeValues.Grpc.c_str();
-}
-
 } // namespace
 
 JsonTranscoderConfig::JsonTranscoderConfig(
@@ -305,7 +297,7 @@ void JsonTranscoderFilter::setDecoderFilterCallbacks(
 
 Http::FilterHeadersStatus JsonTranscoderFilter::encodeHeaders(Http::HeaderMap& headers,
                                                               bool end_stream) {
-  if (!isGrpcResponse(headers)) {
+  if (!Common::isGrpcResponseHeader(headers, end_stream)) {
     error_ = true;
   }
 

--- a/source/common/grpc/json_transcoder_filter.cc
+++ b/source/common/grpc/json_transcoder_filter.cc
@@ -1,6 +1,5 @@
 #include "common/grpc/json_transcoder_filter.h"
 
-
 #include "envoy/common/exception.h"
 #include "envoy/http/filter.h"
 

--- a/source/common/grpc/json_transcoder_filter.cc
+++ b/source/common/grpc/json_transcoder_filter.cc
@@ -1,6 +1,5 @@
 #include "common/grpc/json_transcoder_filter.h"
 
-#include <common/http/headers.h>
 
 #include "envoy/common/exception.h"
 #include "envoy/http/filter.h"

--- a/test/common/grpc/common_test.cc
+++ b/test/common/grpc/common_test.cc
@@ -148,11 +148,13 @@ TEST(GrpcCommonTest, IsGrpcResponseHeader) {
   EXPECT_TRUE(Common::isGrpcResponseHeader(grpc_status_only, true));
   EXPECT_FALSE(Common::isGrpcResponseHeader(grpc_status_only, false));
 
-  Http::TestHeaderMapImpl grpc_response_header{{":status", "200"}, {"content-type", "application/grpc"}};
+  Http::TestHeaderMapImpl grpc_response_header{{":status", "200"},
+                                               {"content-type", "application/grpc"}};
   EXPECT_FALSE(Common::isGrpcResponseHeader(grpc_response_header, true));
   EXPECT_TRUE(Common::isGrpcResponseHeader(grpc_response_header, false));
 
-  Http::TestHeaderMapImpl json_response_header{{":status", "200"}, {"content-type", "application/json"}};
+  Http::TestHeaderMapImpl json_response_header{{":status", "200"},
+                                               {"content-type", "application/json"}};
   EXPECT_FALSE(Common::isGrpcResponseHeader(json_response_header, true));
   EXPECT_FALSE(Common::isGrpcResponseHeader(json_response_header, false));
 }

--- a/test/common/grpc/common_test.cc
+++ b/test/common/grpc/common_test.cc
@@ -143,5 +143,19 @@ TEST(GrpcCommonTest, HasGrpcContentType) {
   EXPECT_FALSE(isGrpcContentType("application/grpc-web+foo"));
 }
 
+TEST(GrpcCommonTest, IsGrpcResponseHeader) {
+  Http::TestHeaderMapImpl grpc_status_only{{":status", "500"}, {"grpc-status", "14"}};
+  EXPECT_TRUE(Common::isGrpcResponseHeader(grpc_status_only, true));
+  EXPECT_FALSE(Common::isGrpcResponseHeader(grpc_status_only, false));
+
+  Http::TestHeaderMapImpl grpc_response_header{{":status", "200"}, {"content-type", "application/grpc"}};
+  EXPECT_FALSE(Common::isGrpcResponseHeader(grpc_response_header, true));
+  EXPECT_TRUE(Common::isGrpcResponseHeader(grpc_response_header, false));
+
+  Http::TestHeaderMapImpl json_response_header{{":status", "200"}, {"content-type", "application/json"}};
+  EXPECT_FALSE(Common::isGrpcResponseHeader(json_response_header, true));
+  EXPECT_FALSE(Common::isGrpcResponseHeader(json_response_header, false));
+}
+
 } // namespace Grpc
 } // namespace Envoy


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <zlizan@google.com>

*Description*:
Make gRPC-JSON transcoder not buffering response at end_stream or non-gRPC response.

*Risk Level*: Low

*Testing*:
unit test

*Docs Changes*:
N/A

*Release Notes*:
N/A

Fixes #2275 
