### PR TITLE
utility: modified string util class

### DIFF
--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -120,6 +120,9 @@ envoy_cc_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
     hdrs = ["utility.h"],
+    external_deps = [
+        "abseil_strings",
+    ],
     deps = ["//include/envoy/common:time_interface"],
 )
 

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -93,9 +93,9 @@ absl::string_view StringUtil::rtrim(absl::string_view source) {
 
 absl::string_view StringUtil::trim(absl::string_view source) { return ltrim(rtrim(source)); }
 
-bool StringUtil::findToken(absl::string_view source, absl::string_view delimeters,
+bool StringUtil::findToken(absl::string_view source, absl::string_view delimiters,
                            absl::string_view key_token, bool trim_whitespace) {
-  const std::vector<absl::string_view> tokens = splitToken(source, delimeters, trim_whitespace);
+  const std::vector<absl::string_view> tokens = splitToken(source, delimiters, trim_whitespace);
   if (trim_whitespace) {
     for (auto token : tokens) {
       if (key_token == trim(token)) {

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -87,7 +87,7 @@ bool StringUtil::find(absl::string_view source, absl::string_view delimiters,
   if (tokens.empty()) {
     return key_token.empty();
   }
-  
+
   if (trim_whitespace) {
     for (auto token : tokens) {
       if (key_token == trim(token)) {

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -93,13 +93,9 @@ absl::string_view StringUtil::rtrim(absl::string_view source) {
 
 absl::string_view StringUtil::trim(absl::string_view source) { return ltrim(rtrim(source)); }
 
-bool StringUtil::findToken(absl::string_view source, absl::string_view delimiters,
+bool StringUtil::findToken(absl::string_view source, absl::string_view delimeters,
                            absl::string_view key_token, bool trim_whitespace) {
-  const std::vector<absl::string_view> tokens = splitToken(source, delimiters, false);
-  if (tokens.empty()) {
-    return key_token.empty();
-  }
-
+  const std::vector<absl::string_view> tokens = splitToken(source, delimeters, trim_whitespace);
   if (trim_whitespace) {
     for (auto token : tokens) {
       if (key_token == trim(token)) {
@@ -108,7 +104,6 @@ bool StringUtil::findToken(absl::string_view source, absl::string_view delimiter
     }
     return false;
   }
-
   return std::find(tokens.begin(), tokens.end(), key_token) != tokens.end();
 }
 

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -55,7 +55,7 @@ bool DateUtil::timePointValid(MonotonicTime time_point) {
              .count() != 0;
 }
 
-const std::string StringUtil::WhitespaceChars{" \t\f\v\n\r"};
+const char StringUtil::WhitespaceChars[] = " \t\f\v\n\r";
 
 bool StringUtil::atoul(const char* str, uint64_t& out, int base) {
   if (strlen(str) == 0) {

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -84,7 +84,7 @@ absl::string_view StringUtil::ltrim(absl::string_view source) {
 absl::string_view StringUtil::rtrim(absl::string_view source) {
   const absl::string_view::size_type pos = source.find_last_not_of(WhitespaceChars);
   if (pos != absl::string_view::npos) {
-    source.remove_suffix(source.size() - source.find_last_not_of(WhitespaceChars) - 1);
+    source.remove_suffix(source.size() - pos - 1);
   } else {
     source.remove_suffix(source.size());
   }

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -10,6 +10,8 @@
 
 #include "envoy/common/time.h"
 
+#include "absl/strings/string_view.h"
+
 namespace Envoy {
 /**
  * Utility class for formatting dates given a strftime style format string.
@@ -132,16 +134,78 @@ public:
   static uint32_t itoa(char* out, size_t out_len, uint64_t i);
 
   /**
+   * Trim leading whitespace from a string view.
+   * @param source supplies the string view to be trimmed.
+   * @return trimmed string view.
+   */
+  static absl::string_view ltrim(absl::string_view source);
+
+  /**
+   * Trim trailing whitespaces from a string view.
+   * @param source supplies the string view to be trimmed.
+   * @return trimmed string view.
+   */
+  static absl::string_view rtrim(absl::string_view source);
+
+  /**
    * Trim trailing whitespace from a string in place.
+   * @param source supplies the string to be trimmed.
    */
   static void rtrim(std::string& source);
 
   /**
-   * Size-bounded string copying and concatenation
+   * Trim leading and trailing whitespaces from a string view.
+   * @param source supplies the string view to be trimmed.
+   * @return trimmed string view.
    */
-  static size_t strlcpy(char* dst, const char* src, size_t size);
+  static absl::string_view trim(absl::string_view source);
 
   /**
+   * Look up for an exactly token in a delimiter-separated string view.
+   * @param source supplies the delimiter-separated string view.
+   * @param delimiters supplies chars used to split the delimiter-separated string view.
+   * @param token supplies the lookup string view.
+   * @param trim_whitespace remove leading and trailing whitespaces from each of the split
+   * string view instances; default = true.
+   * @return true if found and false otherwise.
+   *
+   * E.g,
+   *
+   * find("A=5; b", "=;", "5")   .. true
+   * find("A=5; b", "=;", "A=5") .. false
+   * find("A=5; b", "=;", "A")   .. true
+   * find("A=5; b", "=;", "b")   .. true
+   */
+  static bool find(absl::string_view source, absl::string_view delimiters, absl::string_view token,
+                   bool trim_whitespace = true);
+
+  /**
+   * Crop characters from a string view starting at the first character of the matched
+   * delimiter string view until the end of the source string view.
+   * @param source supplies the string view to be processed.
+   * @param delimiter supplies the string view that delimits the starting point for deletion.
+   * @param trim_whitespace remove leading and trailing whitespaces from each of the split
+   * string views; default = true.
+   * @return sub-string of the string view if any.
+   */
+  static absl::string_view cropRight(absl::string_view source, absl::string_view delimiters,
+                                     bool trim_whitespace = true);
+
+  /** 
+   * Split a delimiter-separated string view.
+   * @param source supplies the delimiter-separated string view.
+   * @param delimiters supplies chars used to split the delimiter-separated string view.
+   * @param trim_whitespace remove leading and trailing whitespaces from each of the split
+   * string view instances; default = true.
+   * @return true if found and false otherwise.
+   */
+  static std::vector<absl::string_view> splitToken(absl::string_view source,
+                                                   absl::string_view delimiters,
+                                                   bool keep_empty_string = false);
+
+  /**
+   * TODO(gsagula): remove this when all call-sites have been replaced by splitToken().
+   * 
    * Split a string.
    * @param source supplies the string to split.
    * @param split supplies the string to split on.
@@ -152,6 +216,12 @@ public:
   static std::vector<std::string> split(const std::string& source, const std::string& split,
                                         bool keep_empty_string = false);
 
+  
+  /**
+   * Size-bounded string copying and concatenation
+   */
+  static size_t strlcpy(char* dst, const char* src, size_t size);
+  
   /**
    * Join elements of a vector into a string delimited by delimiter.
    * @param source supplies the strings to join.

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -107,10 +107,7 @@ public:
  */
 class StringUtil {
 public:
-  /**
-   * White space chars.
-   */
-  static const std::string WhitespaceChars;
+  static const char WhitespaceChars[];
 
   /**
    * Convert a string to an unsigned long, checking for error.

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -108,6 +108,11 @@ public:
 class StringUtil {
 public:
   /**
+   * White space chars.
+   */
+  static const std::string WhitespaceChars;
+
+  /**
    * Convert a string to an unsigned long, checking for error.
    * @param return TRUE if successful, FALSE otherwise.
    */
@@ -165,15 +170,14 @@ public:
    *
    * E.g,
    *
-   * find("A=5; b", "=;", "5")   . true
-   * find("A=5; b", "=;", "A=5") . false
-   * find("A=5; b", "=;", "A")   . true
-   * find("A=5; b", "=;", "b")   . true
-   * find("", ".", "")           . true (spliting "" with "." returns "" which contains "")
-   * find("", ".", "a")          . false (spliting "" with "." returns "" which doesn't contain "a")
+   * findToken("A=5; b", "=;", "5")   . true
+   * findToken("A=5; b", "=;", "A=5") . false
+   * findToken("A=5; b", "=;", "A")   . true
+   * findToken("A=5; b", "=;", "b")   . true
+   * findToken("A=5", ".", "A=5")     . true
    */
-  static bool find(absl::string_view source, absl::string_view delimiters, absl::string_view token,
-                   bool trim_whitespace = true);
+  static bool findToken(absl::string_view source, absl::string_view delimiters,
+                        absl::string_view token, bool trim_whitespace = true);
 
   /**
    * Crop characters from a string view starting at the first character of the matched
@@ -200,19 +204,6 @@ public:
                                                    bool keep_empty_string = false);
 
   /**
-   * TODO(gsagula): remove this when call-sites have been replaced by splitToken().
-   *
-   * Split a string.
-   * @param source supplies the string to split.
-   * @param split supplies the string to split on.
-   * @param keep_empty_string result contains empty strings if the string starts or ends with
-   * 'split', or if instances of 'split' are adjacent.
-   * @return vector of strings computed after splitting `source` around all instances of `split`.
-   */
-  static std::vector<std::string> split(const std::string& source, const std::string& split,
-                                        bool keep_empty_string = false);
-
-  /**
    * Size-bounded string copying and concatenation
    */
   static size_t strlcpy(char* dst, const char* src, size_t size);
@@ -224,14 +215,6 @@ public:
    * @return string combining elements of `source` with `delimiter` in between each element.
    */
   static std::string join(const std::vector<std::string>& source, const std::string& delimiter);
-
-  /**
-   * Split a string.
-   * @param source supplies the string to split.
-   * @param split supplies the char to split on.
-   * @return vector of strings computed after splitting `source` around all instances of `split`.
-   */
-  static std::vector<std::string> split(const std::string& source, char split);
 
   /**
    * Version of substr() that operates on a start and end index instead of a start index and a

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -148,12 +148,6 @@ public:
   static absl::string_view rtrim(absl::string_view source);
 
   /**
-   * Trim trailing whitespace from a string in place.
-   * @param source supplies the string to be trimmed.
-   */
-  static void rtrim(std::string& source);
-
-  /**
    * Trim leading and trailing whitespaces from a string view.
    * @param source supplies the string view to be trimmed.
    * @return trimmed string view.
@@ -163,18 +157,20 @@ public:
   /**
    * Look up for an exactly token in a delimiter-separated string view.
    * @param source supplies the delimiter-separated string view.
-   * @param delimiters supplies chars used to split the delimiter-separated string view.
+   * @param multi-delimiter supplies chars used to split the delimiter-separated string view.
    * @param token supplies the lookup string view.
    * @param trim_whitespace remove leading and trailing whitespaces from each of the split
-   * string view instances; default = true.
+   * string views; default = true.
    * @return true if found and false otherwise.
    *
    * E.g,
    *
-   * find("A=5; b", "=;", "5")   .. true
-   * find("A=5; b", "=;", "A=5") .. false
-   * find("A=5; b", "=;", "A")   .. true
-   * find("A=5; b", "=;", "b")   .. true
+   * find("A=5; b", "=;", "5")   . true
+   * find("A=5; b", "=;", "A=5") . false
+   * find("A=5; b", "=;", "A")   . true
+   * find("A=5; b", "=;", "b")   . true
+   * find("", ".", "")           . true (spliting "" with "." returns "" which contains "")
+   * find("", ".", "a")          . false (spliting "" with "." returns "" which doesn't contain "a")
    */
   static bool find(absl::string_view source, absl::string_view delimiters, absl::string_view token,
                    bool trim_whitespace = true);
@@ -191,12 +187,12 @@ public:
   static absl::string_view cropRight(absl::string_view source, absl::string_view delimiters,
                                      bool trim_whitespace = true);
 
-  /** 
+  /**
    * Split a delimiter-separated string view.
    * @param source supplies the delimiter-separated string view.
-   * @param delimiters supplies chars used to split the delimiter-separated string view.
-   * @param trim_whitespace remove leading and trailing whitespaces from each of the split
-   * string view instances; default = true.
+   * @param multi-delimiter supplies chars used to split the delimiter-separated string view.
+   * @param keep_empty_string result contains empty strings if the string starts or ends with
+   * 'split', or if instances of 'split' are adjacent; default = false.
    * @return true if found and false otherwise.
    */
   static std::vector<absl::string_view> splitToken(absl::string_view source,
@@ -204,8 +200,8 @@ public:
                                                    bool keep_empty_string = false);
 
   /**
-   * TODO(gsagula): remove this when all call-sites have been replaced by splitToken().
-   * 
+   * TODO(gsagula): remove this when call-sites have been replaced by splitToken().
+   *
    * Split a string.
    * @param source supplies the string to split.
    * @param split supplies the string to split on.
@@ -216,12 +212,11 @@ public:
   static std::vector<std::string> split(const std::string& source, const std::string& split,
                                         bool keep_empty_string = false);
 
-  
   /**
    * Size-bounded string copying and concatenation
    */
   static size_t strlcpy(char* dst, const char* src, size_t size);
-  
+
   /**
    * Join elements of a vector into a string delimited by delimiter.
    * @param source supplies the strings to join.
@@ -277,7 +272,7 @@ public:
    * @param s string.
    * @return std::string s converted to upper case.
    */
-  static std::string toUpper(const std::string& s);
+  static std::string toUpper(absl::string_view s);
 };
 
 } // namespace Envoy

--- a/source/common/config/tls_context_json.cc
+++ b/source/common/config/tls_context_json.cc
@@ -55,12 +55,14 @@ void TlsContextJson::translateCommonTlsContext(
   for (const auto& san : json_tls_context.getStringArray("verify_subject_alt_name", true)) {
     validation_context->add_verify_subject_alt_name(san);
   }
-  for (auto cipher_suite :
-       StringUtil::splitToken(json_tls_context.getString("cipher_suites", ""), ":")) {
+
+  const std::string cipher_suites_str{json_tls_context.getString("cipher_suites", "")};
+  for (auto cipher_suite : StringUtil::splitToken(cipher_suites_str, ":")) {
     common_tls_context.mutable_tls_params()->add_cipher_suites(std::string{cipher_suite});
   }
-  for (auto ecdh_curve :
-       StringUtil::splitToken(json_tls_context.getString("ecdh_curves", ""), ":")) {
+
+  const std::string ecdh_curves_str{json_tls_context.getString("ecdh_curves", "")};
+  for (auto ecdh_curve : StringUtil::splitToken(ecdh_curves_str, ":")) {
     common_tls_context.mutable_tls_params()->add_ecdh_curves(std::string{ecdh_curve});
   }
 }

--- a/source/common/config/tls_context_json.cc
+++ b/source/common/config/tls_context_json.cc
@@ -33,8 +33,8 @@ void TlsContextJson::translateUpstreamTlsContext(
 
 void TlsContextJson::translateCommonTlsContext(
     const Json::Object& json_tls_context, envoy::api::v2::CommonTlsContext& common_tls_context) {
-  for (auto alpn_protocol :
-       StringUtil::splitToken(json_tls_context.getString("alpn_protocols", ""), ",")) {
+  const std::string alpn_protocols_str{json_tls_context.getString("alpn_protocols", "")};
+  for (auto alpn_protocol : StringUtil::splitToken(alpn_protocols_str, ",")) {
     common_tls_context.add_alpn_protocols(std::string{alpn_protocol});
   }
 

--- a/source/common/config/tls_context_json.cc
+++ b/source/common/config/tls_context_json.cc
@@ -33,10 +33,9 @@ void TlsContextJson::translateUpstreamTlsContext(
 
 void TlsContextJson::translateCommonTlsContext(
     const Json::Object& json_tls_context, envoy::api::v2::CommonTlsContext& common_tls_context) {
-  const std::vector<std::string> alpn_protocols =
-      StringUtil::split(json_tls_context.getString("alpn_protocols", ""), ",");
-  for (const auto& alpn_protocol : alpn_protocols) {
-    common_tls_context.add_alpn_protocols(alpn_protocol);
+  for (auto alpn_protocol :
+       StringUtil::splitToken(json_tls_context.getString("alpn_protocols", ""), ",")) {
+    common_tls_context.add_alpn_protocols(std::string{alpn_protocol});
   }
 
   common_tls_context.mutable_deprecated_v1()->set_alt_alpn_protocols(
@@ -56,16 +55,13 @@ void TlsContextJson::translateCommonTlsContext(
   for (const auto& san : json_tls_context.getStringArray("verify_subject_alt_name", true)) {
     validation_context->add_verify_subject_alt_name(san);
   }
-
-  const std::vector<std::string> cipher_suites =
-      StringUtil::split(json_tls_context.getString("cipher_suites", ""), ":");
-  for (const auto& cipher_suite : cipher_suites) {
-    common_tls_context.mutable_tls_params()->add_cipher_suites(cipher_suite);
+  for (auto cipher_suite :
+       StringUtil::splitToken(json_tls_context.getString("cipher_suites", ""), ":")) {
+    common_tls_context.mutable_tls_params()->add_cipher_suites(std::string{cipher_suite});
   }
-  const std::vector<std::string> ecdh_curves =
-      StringUtil::split(json_tls_context.getString("ecdh_curves", ""), ":");
-  for (const auto& ecdh_curve : ecdh_curves) {
-    common_tls_context.mutable_tls_params()->add_ecdh_curves(ecdh_curve);
+  for (auto ecdh_curve :
+       StringUtil::splitToken(json_tls_context.getString("ecdh_curves", ""), ":")) {
+    common_tls_context.mutable_tls_params()->add_ecdh_curves(std::string{ecdh_curve});
   }
 }
 

--- a/source/common/dynamo/dynamo_request_parser.cc
+++ b/source/common/dynamo/dynamo_request_parser.cc
@@ -55,10 +55,9 @@ std::string RequestParser::parseOperation(const Http::HeaderMap& headerMap) {
   const Http::HeaderEntry* x_amz_target = headerMap.get(X_AMZ_TARGET);
   if (x_amz_target) {
     // Normally x-amz-target contains Version.Operation, e.g., DynamoDB_20160101.GetItem
-    std::vector<std::string> version_and_operation =
-        StringUtil::split(x_amz_target->value().c_str(), '.');
+    auto version_and_operation = StringUtil::splitToken(x_amz_target->value().c_str(), ".");
     if (version_and_operation.size() == 2) {
-      operation = version_and_operation[1];
+      operation = std::string{version_and_operation[1]};
     }
   }
 

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -105,12 +105,12 @@ bool Common::resolveServiceAndMethod(const Http::HeaderEntry* path, std::string*
   if (path == nullptr || path->value().c_str() == nullptr) {
     return false;
   }
-  auto parts = StringUtil::splitToken(path->value().c_str(), "/");
+  const auto parts = StringUtil::splitToken(path->value().c_str(), "/");
   if (parts.size() != 2) {
     return false;
   }
-  *service = std::string(parts[0]);
-  *method = std::string(parts[1]);
+  service->assign(parts[0].data(), parts[0].size());
+  method->assign(parts[1].data(), parts[1].size());
   return true;
 }
 

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -105,12 +105,12 @@ bool Common::resolveServiceAndMethod(const Http::HeaderEntry* path, std::string*
   if (path == nullptr || path->value().c_str() == nullptr) {
     return false;
   }
-  std::vector<std::string> parts = StringUtil::split(path->value().c_str(), '/');
+  auto parts = StringUtil::splitToken(path->value().c_str(), "/");
   if (parts.size() != 2) {
     return false;
   }
-  *service = std::move(parts[0]);
-  *method = std::move(parts[1]);
+  *service = std::move(std::string(parts[0]));
+  *method = std::move(std::string(parts[1]));
   return true;
 }
 

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -109,8 +109,10 @@ bool Common::resolveServiceAndMethod(const Http::HeaderEntry* path, std::string*
   if (parts.size() != 2) {
     return false;
   }
-  *service = std::move(std::string(parts[0]));
-  *method = std::move(std::string(parts[1]));
+  std::string service_str{parts[0]};
+  std::string method_str{parts[1]};
+  *service = std::move(service_str);
+  *method = std::move(method_str);
   return true;
 }
 

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -109,10 +109,8 @@ bool Common::resolveServiceAndMethod(const Http::HeaderEntry* path, std::string*
   if (parts.size() != 2) {
     return false;
   }
-  std::string service_str{parts[0]};
-  std::string method_str{parts[1]};
-  *service = std::move(service_str);
-  *method = std::move(method_str);
+  *service = std::string(parts[0]);
+  *method = std::string(parts[1]);
   return true;
 }
 

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -92,7 +92,7 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
         // Find the cookie headers in the request (typically, there's only one).
         if (header.key() == Http::Headers::get().Cookie.get().c_str()) {
           // Split the cookie header into individual cookies.
-          for (const std::string& s : StringUtil::split(std::string{header.value().c_str()}, ';')) {
+          for (auto s : StringUtil::splitToken(header.value().c_str(), ";")) {
             // Find the key part of the cookie (i.e. the name of the cookie).
             size_t first_non_space = s.find_first_not_of(" ");
             size_t equals_index = s.find('=');
@@ -101,18 +101,18 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
               // checking other cookies in this header.
               continue;
             }
-            std::string k = s.substr(first_non_space, equals_index - first_non_space);
+            absl::string_view k = s.substr(first_non_space, equals_index - first_non_space);
             State* state = static_cast<State*>(context);
             // If the key matches, parse the value from the rest of the cookie string.
             if (k == state->key_) {
-              std::string v = s.substr(equals_index + 1, s.size() - 1);
+              absl::string_view v = s.substr(equals_index + 1, s.size() - 1);
 
               // Cookie values may be wrapped in double quotes.
               // https://tools.ietf.org/html/rfc6265#section-4.1.1
               if (v.size() >= 2 && v.back() == '"' && v[0] == '"') {
                 v = v.substr(1, v.size() - 2);
               }
-              state->ret_ = v;
+              state->ret_ = std::string{v};
               return HeaderMap::Iterate::Break;
             }
           }

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -92,7 +92,7 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
         // Find the cookie headers in the request (typically, there's only one).
         if (header.key() == Http::Headers::get().Cookie.get().c_str()) {
           // Split the cookie header into individual cookies.
-          for (auto s : StringUtil::splitToken(header.value().c_str(), ";")) {
+          for (const auto s : StringUtil::splitToken(header.value().c_str(), ";")) {
             // Find the key part of the cookie (i.e. the name of the cookie).
             size_t first_non_space = s.find_first_not_of(" ");
             size_t equals_index = s.find('=');
@@ -101,7 +101,7 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
               // checking other cookies in this header.
               continue;
             }
-            absl::string_view k = s.substr(first_non_space, equals_index - first_non_space);
+            const absl::string_view k = s.substr(first_non_space, equals_index - first_non_space);
             State* state = static_cast<State*>(context);
             // If the key matches, parse the value from the rest of the cookie string.
             if (k == state->key_) {

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -117,6 +117,9 @@ envoy_cc_library(
         "listener_impl.h",
         "proxy_protocol.h",
     ],
+    external_deps = [
+        "abseil_strings",
+    ],
     deps = [
         ":address_lib",
         ":connection_lib",
@@ -171,7 +174,10 @@ envoy_cc_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
     hdrs = ["utility.h"],
-    external_deps = ["envoy_base"],
+    external_deps = [
+        "abseil_strings",
+        "envoy_base",
+    ],
     deps = [
         ":address_lib",
         "//include/envoy/network:connection_interface",

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -117,9 +117,6 @@ envoy_cc_library(
         "listener_impl.h",
         "proxy_protocol.h",
     ],
-    external_deps = [
-        "abseil_strings",
-    ],
     deps = [
         ":address_lib",
         ":connection_lib",

--- a/source/common/network/cidr_range.cc
+++ b/source/common/network/cidr_range.cc
@@ -139,12 +139,12 @@ CidrRange CidrRange::create(const envoy::api::v2::CidrRange& cidr) {
 
 // static
 CidrRange CidrRange::create(const std::string& range) {
-  auto parts = StringUtil::splitToken(range, "/");
+  const auto parts = StringUtil::splitToken(range, "/");
   if (parts.size() == 2) {
     InstanceConstSharedPtr ptr = Utility::parseInternetAddress(std::string{parts[0]});
     if (ptr->type() == Type::Ip) {
       uint64_t length64;
-      std::string part{parts[1]};
+      const std::string part{parts[1]};
       if (StringUtil::atoul(part.c_str(), length64, 10)) {
         if ((ptr->ip()->version() == IpVersion::v6 && length64 <= 128) ||
             (ptr->ip()->version() == IpVersion::v4 && length64 <= 32)) {

--- a/source/common/network/cidr_range.cc
+++ b/source/common/network/cidr_range.cc
@@ -139,12 +139,13 @@ CidrRange CidrRange::create(const envoy::api::v2::CidrRange& cidr) {
 
 // static
 CidrRange CidrRange::create(const std::string& range) {
-  std::vector<std::string> parts = StringUtil::split(range, '/');
+  auto parts = StringUtil::splitToken(range, "/");
   if (parts.size() == 2) {
-    InstanceConstSharedPtr ptr = Utility::parseInternetAddress(parts[0]);
+    InstanceConstSharedPtr ptr = Utility::parseInternetAddress(std::string{parts[0]});
     if (ptr->type() == Type::Ip) {
       uint64_t length64;
-      if (StringUtil::atoul(parts[1].c_str(), length64, 10)) {
+      std::string part{parts[1]};
+      if (StringUtil::atoul(part.c_str(), length64, 10)) {
         if ((ptr->ip()->version() == IpVersion::v6 && length64 <= 128) ||
             (ptr->ip()->version() == IpVersion::v4 && length64 <= 32)) {
           return create(std::move(ptr), static_cast<uint32_t>(length64));

--- a/source/common/network/proxy_protocol.cc
+++ b/source/common/network/proxy_protocol.cc
@@ -87,7 +87,7 @@ void ProxyProtocol::ActiveConnection::onReadWorker() {
     return;
   }
 
-  // If protocol not UNKNOWN, src and dst adresses have to be present.
+  // If protocol not UNKNOWN, src and dst addresses have to be present.
   if (line_parts.size() != 6) {
     throw EnvoyException("failed to read proxy protocol");
   }

--- a/source/common/network/proxy_protocol.cc
+++ b/source/common/network/proxy_protocol.cc
@@ -95,10 +95,11 @@ void ProxyProtocol::ActiveConnection::onReadWorker() {
   Address::IpVersion protocol_version;
   Address::InstanceConstSharedPtr remote_address;
   Address::InstanceConstSharedPtr local_address;
+
+  // TODO(gsagula): parseInternetAddressAndPort() could be modified to take two string_view
+  // arguments, so we can eliminate allocation here.
   if (line_parts[1] == "TCP4") {
     protocol_version = Address::IpVersion::v4;
-    // TODO(gsagula): Utility::parseInternetAddressAndPort() should be refactored to take a
-    // string_view as an argument which would eliminate the need for all this string convertions.
     remote_address = Utility::parseInternetAddressAndPort(std::string{line_parts[2]} + ":" +
                                                           std::string{line_parts[4]});
     local_address = Utility::parseInternetAddressAndPort(std::string{line_parts[3]} + ":" +

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -304,9 +304,9 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(int fd) {
 }
 
 void Utility::parsePortRangeList(absl::string_view string, std::list<PortRange>& list) {
-  auto ranges = StringUtil::splitToken(string, ",");
+  const auto ranges = StringUtil::splitToken(string, ",");
   for (auto s : ranges) {
-    std::string s_string{s};
+    const std::string s_string{s};
     std::stringstream ss(s_string);
     uint32_t min = 0;
     uint32_t max = 0;

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -303,14 +303,15 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(int fd) {
 #endif
 }
 
-void Utility::parsePortRangeList(const std::string& string, std::list<PortRange>& list) {
-  std::vector<std::string> ranges = StringUtil::split(string.c_str(), ',');
-  for (const std::string& s : ranges) {
-    std::stringstream ss(s);
+void Utility::parsePortRangeList(absl::string_view string, std::list<PortRange>& list) {
+  auto ranges = StringUtil::splitToken(string, ",");
+  for (auto s : ranges) {
+    std::string s_string{s};
+    std::stringstream ss(s_string);
     uint32_t min = 0;
     uint32_t max = 0;
 
-    if (s.find('-') != std::string::npos) {
+    if (s.find("-") != std::string::npos) {
       char dash = 0;
       ss >> min;
       ss >> dash;
@@ -321,7 +322,7 @@ void Utility::parsePortRangeList(const std::string& string, std::list<PortRange>
     }
 
     if (s.empty() || (min > 65535) || (max > 65535) || ss.fail() || !ss.eof()) {
-      throw EnvoyException(fmt::format("invalid port number or range '{}'", s));
+      throw EnvoyException(fmt::format("invalid port number or range '{}'", s_string));
     }
 
     list.emplace_back(PortRange(min, max));

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -7,6 +7,7 @@
 #include "envoy/network/connection.h"
 #include "envoy/stats/stats.h"
 
+#include "absl/strings/string_view.h"
 #include "api/address.pb.h"
 
 namespace Envoy {
@@ -176,7 +177,7 @@ public:
    * @param str is the string containing the port numbers and ranges
    * @param list is the list to append the new data structures to
    */
-  static void parsePortRangeList(const std::string& string, std::list<PortRange>& list);
+  static void parsePortRangeList(absl::string_view string, std::list<PortRange>& list);
 
   /**
    * Checks whether a given port number appears in at least one of the port ranges in a list

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -104,6 +104,9 @@ envoy_cc_library(
     name = "retry_state_lib",
     srcs = ["retry_state_impl.cc"],
     hdrs = ["retry_state_impl.h"],
+    external_deps = [
+        "abseil_strings",
+    ],
     deps = [
         "//include/envoy/common:optional",
         "//include/envoy/event:timer_interface",

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -87,10 +87,9 @@ void RetryStateImpl::enableBackoffTimer() {
   retry_timer_->enableTimer(std::chrono::milliseconds(timeout));
 }
 
-uint32_t RetryStateImpl::parseRetryOn(const std::string& config) {
+uint32_t RetryStateImpl::parseRetryOn(absl::string_view config) {
   uint32_t ret = 0;
-  std::vector<std::string> retry_on_list = StringUtil::split(config, ',');
-  for (const std::string& retry_on : retry_on_list) {
+  for (auto retry_on : StringUtil::splitToken(config, ",")) {
     if (retry_on == Http::Headers::get().EnvoyRetryOnValues._5xx) {
       ret |= RetryPolicy::RETRY_ON_5XX;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.ConnectFailure) {
@@ -105,10 +104,9 @@ uint32_t RetryStateImpl::parseRetryOn(const std::string& config) {
   return ret;
 }
 
-uint32_t RetryStateImpl::parseRetryGrpcOn(const std::string& retry_grpc_on_header) {
+uint32_t RetryStateImpl::parseRetryGrpcOn(absl::string_view retry_grpc_on_header) {
   uint32_t ret = 0;
-  std::vector<std::string> retry_on_list = StringUtil::split(retry_grpc_on_header, ',');
-  for (const std::string& retry_on : retry_on_list) {
+  for (auto retry_on : StringUtil::splitToken(retry_grpc_on_header, ",")) {
     if (retry_on == Http::Headers::get().EnvoyRetryOnGrpcValues.Cancelled) {
       ret |= RetryPolicy::RETRY_ON_GRPC_CANCELLED;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnGrpcValues.DeadlineExceeded) {

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -89,7 +89,7 @@ void RetryStateImpl::enableBackoffTimer() {
 
 uint32_t RetryStateImpl::parseRetryOn(absl::string_view config) {
   uint32_t ret = 0;
-  for (auto retry_on : StringUtil::splitToken(config, ",")) {
+  for (const auto retry_on : StringUtil::splitToken(config, ",")) {
     if (retry_on == Http::Headers::get().EnvoyRetryOnValues._5xx) {
       ret |= RetryPolicy::RETRY_ON_5XX;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.ConnectFailure) {
@@ -106,7 +106,7 @@ uint32_t RetryStateImpl::parseRetryOn(absl::string_view config) {
 
 uint32_t RetryStateImpl::parseRetryGrpcOn(absl::string_view retry_grpc_on_header) {
   uint32_t ret = 0;
-  for (auto retry_on : StringUtil::splitToken(retry_grpc_on_header, ",")) {
+  for (const auto retry_on : StringUtil::splitToken(retry_grpc_on_header, ",")) {
     if (retry_on == Http::Headers::get().EnvoyRetryOnGrpcValues.Cancelled) {
       ret |= RetryPolicy::RETRY_ON_GRPC_CANCELLED;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnGrpcValues.DeadlineExceeded) {

--- a/source/common/router/retry_state_impl.h
+++ b/source/common/router/retry_state_impl.h
@@ -11,6 +11,8 @@
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/upstream.h"
 
+#include "absl/strings/string_view.h"
+
 namespace Envoy {
 namespace Router {
 
@@ -25,10 +27,10 @@ public:
                               Upstream::ResourcePriority priority);
   ~RetryStateImpl();
 
-  static uint32_t parseRetryOn(const std::string& config);
+  static uint32_t parseRetryOn(absl::string_view config);
 
   // Returns the RetryPolicy extracted from the x-envoy-retry-grpc-on header.
-  static uint32_t parseRetryGrpcOn(const std::string& retry_grpc_on_header);
+  static uint32_t parseRetryGrpcOn(absl::string_view retry_grpc_on_header);
 
   // Router::RetryState
   bool enabled() override { return retry_on_ != 0; }

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -233,7 +233,7 @@ void SnapshotImpl::walkDirectory(const std::string& path, const std::string& pre
       // Read the file and remove any comments. A comment is a line starting with a '#' character.
       // Comments are useful for placeholder files with no value.
       const std::string text_file{Filesystem::fileReadToEnd(full_path)};
-      auto lines = StringUtil::splitToken(text_file, "\n");
+      const auto lines = StringUtil::splitToken(text_file, "\n");
       for (auto line : lines) {
         if (!line.empty() && line.front() == '#') {
           continue;

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -232,16 +232,18 @@ void SnapshotImpl::walkDirectory(const std::string& path, const std::string& pre
 
       // Read the file and remove any comments. A comment is a line starting with a '#' character.
       // Comments are useful for placeholder files with no value.
-      const std::vector<std::string> lines =
-          StringUtil::split(Filesystem::fileReadToEnd(full_path), "\n");
-      for (const std::string& line : lines) {
-        if (!line.empty() && line.at(0) == '#') {
+      auto text_file{Filesystem::fileReadToEnd(full_path)};
+      auto lines = StringUtil::splitToken(text_file, "\n");
+      for (auto line : lines) {
+        if (!line.empty() && line.front() == '#') {
           continue;
         }
-        entry.string_value_ += line + "\n";
+        if (line == lines.back()) {
+          entry.string_value_.append(std::string(StringUtil::rtrim(line)));
+        } else {
+          entry.string_value_.append(std::string{line} + "\n");
+        }
       }
-
-      entry.string_value_ = std::string(StringUtil::rtrim(entry.string_value_));
 
       // As a perf optimization, attempt to convert the string into an integer. If we don't
       // succeed that's fine.

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -232,14 +232,15 @@ void SnapshotImpl::walkDirectory(const std::string& path, const std::string& pre
 
       // Read the file and remove any comments. A comment is a line starting with a '#' character.
       // Comments are useful for placeholder files with no value.
-      auto text_file{Filesystem::fileReadToEnd(full_path)};
+      const std::string text_file{Filesystem::fileReadToEnd(full_path)};
       auto lines = StringUtil::splitToken(text_file, "\n");
       for (auto line : lines) {
         if (!line.empty() && line.front() == '#') {
           continue;
         }
         if (line == lines.back()) {
-          entry.string_value_.append(std::string(StringUtil::rtrim(line)));
+          absl::string_view trimmed = StringUtil::rtrim(line);
+          entry.string_value_.append(trimmed.data(), trimmed.size());
         } else {
           entry.string_value_.append(std::string{line} + "\n");
         }

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -240,7 +240,8 @@ void SnapshotImpl::walkDirectory(const std::string& path, const std::string& pre
         }
         entry.string_value_ += line + "\n";
       }
-      StringUtil::rtrim(entry.string_value_);
+
+      entry.string_value_ = std::string(StringUtil::rtrim(entry.string_value_));
 
       // As a perf optimization, attempt to convert the string into an integer. If we don't
       // succeed that's fine.

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -234,12 +234,12 @@ void SnapshotImpl::walkDirectory(const std::string& path, const std::string& pre
       // Comments are useful for placeholder files with no value.
       const std::string text_file{Filesystem::fileReadToEnd(full_path)};
       const auto lines = StringUtil::splitToken(text_file, "\n");
-      for (auto line : lines) {
+      for (const auto line : lines) {
         if (!line.empty() && line.front() == '#') {
           continue;
         }
         if (line == lines.back()) {
-          absl::string_view trimmed = StringUtil::rtrim(line);
+          const absl::string_view trimmed = StringUtil::rtrim(line);
           entry.string_value_.append(trimmed.data(), trimmed.size());
         } else {
           entry.string_value_.append(std::string{line} + "\n");

--- a/source/server/config/http/lightstep_http_tracer.cc
+++ b/source/server/config/http/lightstep_http_tracer.cc
@@ -21,8 +21,9 @@ LightstepHttpTracerFactory::createHttpTracer(const Json::Object& json_config,
                                              Upstream::ClusterManager& cluster_manager) {
 
   std::unique_ptr<lightstep::LightStepTracerOptions> opts(new lightstep::LightStepTracerOptions());
-  opts->access_token = std::string(
-      StringUtil::rtrim(server.api().fileReadToEnd(json_config.getString("access_token_file"))));
+  const auto access_token_sv =
+      StringUtil::rtrim(server.api().fileReadToEnd(json_config.getString("access_token_file")));
+  opts->access_token.assign(access_token_sv.data(), access_token_sv.size());
   opts->component_name = server.localInfo().clusterName();
 
   Tracing::DriverPtr lightstep_driver{new Tracing::LightStepDriver{

--- a/source/server/config/http/lightstep_http_tracer.cc
+++ b/source/server/config/http/lightstep_http_tracer.cc
@@ -21,8 +21,8 @@ LightstepHttpTracerFactory::createHttpTracer(const Json::Object& json_config,
                                              Upstream::ClusterManager& cluster_manager) {
 
   std::unique_ptr<lightstep::LightStepTracerOptions> opts(new lightstep::LightStepTracerOptions());
-  opts->access_token = server.api().fileReadToEnd(json_config.getString("access_token_file"));
-  StringUtil::rtrim(opts->access_token);
+  opts->access_token = std::string(
+      StringUtil::rtrim(server.api().fileReadToEnd(json_config.getString("access_token_file"))));
   opts->component_name = server.localInfo().clusterName();
 
   Tracing::DriverPtr lightstep_driver{new Tracing::LightStepDriver{

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -55,6 +55,9 @@ envoy_cc_test(
 envoy_cc_test(
     name = "utility_test",
     srcs = ["utility_test.cc"],
+    external_deps = [
+        "abseil_strings",
+    ],
     deps = ["//source/common/common:utility_lib"],
 )
 

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -58,7 +58,14 @@ TEST(InputConstMemoryStream, All) {
   }
 }
 
-TEST(StringUtil, WhitespaceChars) { EXPECT_EQ(" \t\f\v\n\r", StringUtil::WhitespaceChars); }
+TEST(StringUtil, WhitespaceChars) {
+  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars, ' '));
+  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars, '\t'));
+  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars, '\f'));
+  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars, '\v'));
+  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars, '\n'));
+  EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars, '\r'));
+}
 
 TEST(StringUtil, caseInsensitiveCompare) {
   EXPECT_EQ(0, StringUtil::caseInsensitiveCompare("CONTENT-LENGTH", "content-length"));

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -6,7 +6,6 @@
 #include "common/common/utility.h"
 
 #include "absl/strings/string_view.h"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -235,9 +234,8 @@ TEST(StringUtil, StringViewfind) {
   EXPECT_FALSE(StringUtil::find("abc; type=text", ";=", " "));
   EXPECT_TRUE(StringUtil::find("abc; type=text", ";=", " type", false));
   EXPECT_FALSE(StringUtil::find("hello; world", ".", "hello"));
-  EXPECT_TRUE(StringUtil::find("", "", ""));
-  EXPECT_FALSE(StringUtil::find("", "", " "));
-  EXPECT_FALSE(StringUtil::find(" ", " ", " "));
+  EXPECT_TRUE(StringUtil::find("", ",", ""));
+  EXPECT_FALSE(StringUtil::find("", "", "a"));
   EXPECT_TRUE(StringUtil::find(" ", " ", "", false));
 }
 
@@ -259,8 +257,10 @@ TEST(StringUtil, StringViewSplit) {
     EXPECT_TRUE(std::find(tokens.begin(), tokens.end(), " one ") != tokens.end());
   }
   {
-    auto tokens = StringUtil::splitToken(" one , two , three=five ", ",=", true);
+    auto tokens = StringUtil::splitToken(" one ,  , three=five ", ",=", true);
     EXPECT_EQ(4, tokens.size());
+    EXPECT_TRUE(std::find(tokens.begin(), tokens.end(), " one ") != tokens.end());
+    EXPECT_TRUE(std::find(tokens.begin(), tokens.end(), "  ") != tokens.end());
     EXPECT_TRUE(std::find(tokens.begin(), tokens.end(), " three") != tokens.end());
     EXPECT_TRUE(std::find(tokens.begin(), tokens.end(), "five ") != tokens.end());
   }
@@ -277,7 +277,7 @@ TEST(StringUtil, StringViewSplit) {
     EXPECT_EQ(std_tokens.at(4), sv_tokens.at(4));
     EXPECT_EQ(std_tokens.at(5), sv_tokens.at(5));
     EXPECT_EQ(std_tokens.at(6), sv_tokens.at(6));
-  }  
+  }
   {
     EXPECT_EQ(std::vector<absl::string_view>{"hello"}, StringUtil::splitToken(",hello", ","));
     EXPECT_EQ(std::vector<absl::string_view>{}, StringUtil::splitToken("", ","));
@@ -298,7 +298,7 @@ TEST(StringUtil, StringViewSplit) {
     EXPECT_THAT(std::vector<absl::string_view>({"hello", "world", ""}),
                 ContainerEq(StringUtil::splitToken("hello world ", " ", true)));
     EXPECT_THAT(std::vector<absl::string_view>({"hello", "world"}),
-                ContainerEq(StringUtil::splitToken("hello world", " ", true))); 
+                ContainerEq(StringUtil::splitToken("hello world", " ", true)));
   }
 }
 

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -221,7 +221,8 @@ TEST(StringUtil, StringViewFindToken) {
   EXPECT_FALSE(StringUtil::findToken("hello; world", ".", "hello"));
   EXPECT_TRUE(StringUtil::findToken("", ",", ""));
   EXPECT_FALSE(StringUtil::findToken("", "", "a"));
-  EXPECT_TRUE(StringUtil::findToken(" ", " ", "", false));
+  EXPECT_TRUE(StringUtil::findToken(" ", " ", "", true));
+  EXPECT_FALSE(StringUtil::findToken(" ", " ", "", false));
   EXPECT_TRUE(StringUtil::findToken("A=5", ".", "A=5"));
 }
 

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -98,6 +98,7 @@ envoy_cc_test(
     deps = [
         "//source/common/common:utility_lib",
         "//source/server:options_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -9,6 +9,8 @@
 
 #include "server/options_impl.h"
 
+#include "test/test_common/utility.h"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "spdlog/spdlog.h"
@@ -19,7 +21,7 @@ namespace Envoy {
 // Do the ugly work of turning a std::string into a char** and create an OptionsImpl. Args are
 // separated by a single space: no fancy quoting or escaping.
 std::unique_ptr<OptionsImpl> createOptionsImpl(const std::string& args) {
-  std::vector<std::string> words = StringUtil::split(args, ' ');
+  std::vector<std::string> words = TestUtility::split(args, ' ');
   std::vector<const char*> argv;
   for (const std::string& s : words) {
     argv.push_back(s.c_str());

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -69,12 +69,16 @@ envoy_cc_test_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
     hdrs = ["utility.h"],
-    external_deps = ["envoy_bootstrap"],
+    external_deps = [
+        "envoy_bootstrap",
+        "abseil_strings",
+    ],
     deps = [
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/http:codec_interface",
         "//include/envoy/network:address_interface",
         "//source/common/common:empty_string",
+        "//source/common/common:utility_lib",
         "//source/common/config:bootstrap_json_lib",
         "//source/common/http:header_map_lib",
         "//source/common/json:json_loader_lib",

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -156,6 +156,37 @@ envoy::api::v2::Bootstrap TestUtility::parseBootstrapFromJson(const std::string&
   return bootstrap;
 }
 
+std::vector<std::string> TestUtility::split(const std::string& source, char split) {
+  return TestUtility::split(source, std::string{split});
+}
+
+std::vector<std::string> TestUtility::split(const std::string& source, const std::string& split,
+                                            bool keep_empty_string) {
+  std::vector<std::string> ret;
+  size_t last_index = 0;
+  size_t next_index;
+
+  if (split.empty()) {
+    ret.emplace_back(source);
+    return ret;
+  }
+
+  do {
+    next_index = source.find(split, last_index);
+    if (next_index == std::string::npos) {
+      next_index = source.size();
+    }
+
+    if (next_index != last_index || keep_empty_string) {
+      ret.emplace_back(source.substr(last_index, next_index - last_index));
+    }
+
+    last_index = next_index + split.size();
+  } while (next_index != source.size());
+
+  return ret;
+}
+
 void ConditionalInitializer::setReady() {
   std::unique_lock<std::mutex> lock(mutex_);
   EXPECT_FALSE(ready_);

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -15,6 +15,7 @@
 #include "envoy/http/codec.h"
 
 #include "common/common/empty_string.h"
+#include "common/common/utility.h"
 #include "common/config/bootstrap_json.h"
 #include "common/json/json_loader.h"
 #include "common/network/address_impl.h"
@@ -22,6 +23,7 @@
 
 #include "test/test_common/printers.h"
 
+#include "absl/strings/string_view.h"
 #include "fmt/format.h"
 #include "gtest/gtest.h"
 
@@ -163,27 +165,9 @@ std::vector<std::string> TestUtility::split(const std::string& source, char spli
 std::vector<std::string> TestUtility::split(const std::string& source, const std::string& split,
                                             bool keep_empty_string) {
   std::vector<std::string> ret;
-  size_t last_index = 0;
-  size_t next_index;
-
-  if (split.empty()) {
-    ret.emplace_back(source);
-    return ret;
-  }
-
-  do {
-    next_index = source.find(split, last_index);
-    if (next_index == std::string::npos) {
-      next_index = source.size();
-    }
-
-    if (next_index != last_index || keep_empty_string) {
-      ret.emplace_back(source.substr(last_index, next_index - last_index));
-    }
-
-    last_index = next_index + split.size();
-  } while (next_index != source.size());
-
+  const auto tokens_sv = StringUtil::splitToken(source, split, keep_empty_string);
+  std::transform(tokens_sv.begin(), tokens_sv.end(), std::back_inserter(ret),
+                 [](absl::string_view sv) { return std::string(sv); });
   return ret;
 }
 

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -127,6 +127,25 @@ public:
   }
 
   /**
+   * Split a string.
+   * @param source supplies the string to split.
+   * @param split supplies the char to split on.
+   * @return vector of strings computed after splitting `source` around all instances of `split`.
+   */
+  static std::vector<std::string> split(const std::string& source, char split);
+
+  /**
+   * Split a string.
+   * @param source supplies the string to split.
+   * @param split supplies the string to split on.
+   * @param keep_empty_string result contains empty strings if the string starts or ends with
+   * 'split', or if instances of 'split' are adjacent.
+   * @return vector of strings computed after splitting `source` around all instances of `split`.
+   */
+  static std::vector<std::string> split(const std::string& source, const std::string& split,
+                                        bool keep_empty_string = false);
+
+  /**
    * Compare two RepeatedPtrFields of the same type for equality.
    *
    * @param lhs RepeatedPtrField on LHS.


### PR DESCRIPTION
*Description*:
This PR replaces the old rtrim static member function with a new implementation 
that uses absl::string_view to reduce memory allocation and to increase performance. It also replaces all the call-sites for fully elimination of the older version of rtrim. The same PR adds few new member functions that follows the same design philosophy of the new rtrim. All the improvements made to StringUtil class helps to support #2348 and #2087.

*Risk Level*: High
Few changes where made to internal implementation of proxy_protocol.cc, runtime_impl.cc 
and lightstep_httptracer.cc in order to eliminate the old rtrim function. Even though changes 
are quite simple, it's important to pay close attention when reviewing this PR. 

*Testing*: Unit and manual testing.