### PR TITLE
grpc: detemplatize Grpc::AsyncClient.

### DIFF
--- a/include/envoy/grpc/async_client.h
+++ b/include/envoy/grpc/async_client.h
@@ -29,7 +29,7 @@ public:
 /**
  * An in-flight gRPC stream.
  */
-template <class RequestType> class AsyncStream {
+class AsyncStream {
 public:
   virtual ~AsyncStream() {}
 
@@ -40,7 +40,7 @@ public:
    *                   object, but callbacks may still be received until the stream is closed
    *                   remotely.
    */
-  virtual void sendMessage(const RequestType& request, bool end_stream) PURE;
+  virtual void sendMessage(const Protobuf::Message& request, bool end_stream) PURE;
 
   /**
    * Close the stream locally and send an empty DATA frame to the remote. No further methods may be
@@ -56,7 +56,7 @@ public:
   virtual void resetStream() PURE;
 };
 
-template <class ResponseType> class AsyncRequestCallbacks {
+class AsyncRequestCallbacks {
 public:
   virtual ~AsyncRequestCallbacks() {}
 
@@ -67,11 +67,18 @@ public:
   virtual void onCreateInitialMetadata(Http::HeaderMap& metadata) PURE;
 
   /**
+   * Factory for empty response messages.
+   * @return ProtobufTypes::MessagePtr a Protobuf::Message with the response
+   *         type for the request.
+   */
+  virtual ProtobufTypes::MessagePtr createEmptyResponse() PURE;
+
+  /**
    * Called when the async gRPC request succeeds. No further callbacks will be invoked.
    * @param response the gRPC response.
    * @param span a tracing span to fill with extra tags.
    */
-  virtual void onSuccess(std::unique_ptr<ResponseType>&& response, Tracing::Span& span) PURE;
+  virtual void onSuccess(ProtobufTypes::MessagePtr&& response, Tracing::Span& span) PURE;
 
   /**
    * Called when the async gRPC request fails. No further callbacks will be invoked.
@@ -83,6 +90,20 @@ public:
                          Tracing::Span& span) PURE;
 };
 
+// Templatized variant of AsyncRequestCallbacks.
+template <class ResponseType> class TypedAsyncRequestCallbacks : public AsyncRequestCallbacks {
+public:
+  ProtobufTypes::MessagePtr createEmptyResponse() override {
+    return std::make_unique<ResponseType>();
+  }
+
+  virtual void onSuccess(std::unique_ptr<ResponseType>&& response, Tracing::Span& span) PURE;
+
+  void onSuccess(ProtobufTypes::MessagePtr&& response, Tracing::Span& span) override {
+    onSuccess(std::unique_ptr<ResponseType>(dynamic_cast<ResponseType*>(response.release())), span);
+  }
+};
+
 /**
  * Notifies caller of async gRPC stream status.
  * Note the gRPC stream is full-duplex, even if the local to remote stream has been ended by
@@ -90,9 +111,16 @@ public:
  * to local stream is closed (onRemoteClose), and vice versa. Once the stream is closed remotely, no
  * further callbacks will be invoked.
  */
-template <class ResponseType> class AsyncStreamCallbacks {
+class AsyncStreamCallbacks {
 public:
   virtual ~AsyncStreamCallbacks() {}
+
+  /**
+   * Factory for empty response messages.
+   * @return ProtobufTypes::MessagePtr a Protobuf::Message with the response
+   *          type for the stream.
+   */
+  virtual ProtobufTypes::MessagePtr createEmptyResponse() PURE;
 
   /**
    * Called when populating the headers to send with initial metadata.
@@ -110,7 +138,7 @@ public:
    * Called when an async gRPC message is received.
    * @param response the gRPC message.
    */
-  virtual void onReceiveMessage(std::unique_ptr<ResponseType>&& message) PURE;
+  virtual void onReceiveMessage(ProtobufTypes::MessagePtr&& message) PURE;
 
   /**
    * Called when trailing metadata is recevied.
@@ -129,11 +157,25 @@ public:
   virtual void onRemoteClose(Status::GrpcStatus status, const std::string& message) PURE;
 };
 
+// Templatized variant of AsyncStreamCallbacks.
+template <class ResponseType> class TypedAsyncStreamCallbacks : public AsyncStreamCallbacks {
+public:
+  ProtobufTypes::MessagePtr createEmptyResponse() override {
+    return std::make_unique<ResponseType>();
+  }
+
+  virtual void onReceiveMessage(std::unique_ptr<ResponseType>&& message) PURE;
+
+  void onReceiveMessage(ProtobufTypes::MessagePtr&& message) override {
+    onReceiveMessage(std::unique_ptr<ResponseType>(dynamic_cast<ResponseType*>(message.release())));
+  }
+};
+
 /**
  * Supports sending gRPC requests and receiving responses asynchronously. This can be used to
  * implement either plain gRPC or streaming gRPC calls.
  */
-template <class RequestType, class ResponseType> class AsyncClient {
+class AsyncClient {
 public:
   virtual ~AsyncClient() {}
 
@@ -149,8 +191,7 @@ public:
    *         handle should just be used to cancel.
    */
   virtual AsyncRequest* send(const Protobuf::MethodDescriptor& service_method,
-                             const RequestType& request,
-                             AsyncRequestCallbacks<ResponseType>& callbacks,
+                             const Protobuf::Message& request, AsyncRequestCallbacks& callbacks,
                              Tracing::Span& parent_span,
                              const Optional<std::chrono::milliseconds>& timeout) PURE;
 
@@ -165,9 +206,11 @@ public:
    *         closeStream() is invoked by the caller to notify the client that the stream resources
    *         may be reclaimed.
    */
-  virtual AsyncStream<RequestType>* start(const Protobuf::MethodDescriptor& service_method,
-                                          AsyncStreamCallbacks<ResponseType>& callbacks) PURE;
+  virtual AsyncStream* start(const Protobuf::MethodDescriptor& service_method,
+                             AsyncStreamCallbacks& callbacks) PURE;
 };
+
+typedef std::unique_ptr<AsyncClient> AsyncClientPtr;
 
 } // namespace Grpc
 } // namespace Envoy

--- a/include/envoy/grpc/async_client.h
+++ b/include/envoy/grpc/async_client.h
@@ -78,7 +78,7 @@ public:
    * @param response the gRPC response.
    * @param span a tracing span to fill with extra tags.
    */
-  virtual void onSuccess(ProtobufTypes::MessagePtr&& response, Tracing::Span& span) PURE;
+  virtual void onSuccessUntyped(ProtobufTypes::MessagePtr&& response, Tracing::Span& span) PURE;
 
   /**
    * Called when the async gRPC request fails. No further callbacks will be invoked.
@@ -93,15 +93,13 @@ public:
 // Templatized variant of AsyncRequestCallbacks.
 template <class ResponseType> class TypedAsyncRequestCallbacks : public AsyncRequestCallbacks {
 public:
-  using AsyncRequestCallbacks::onSuccess;
-
   ProtobufTypes::MessagePtr createEmptyResponse() override {
     return std::make_unique<ResponseType>();
   }
 
   virtual void onSuccess(std::unique_ptr<ResponseType>&& response, Tracing::Span& span) PURE;
 
-  void onSuccess(ProtobufTypes::MessagePtr&& response, Tracing::Span& span) override {
+  void onSuccessUntyped(ProtobufTypes::MessagePtr&& response, Tracing::Span& span) override {
     onSuccess(std::unique_ptr<ResponseType>(dynamic_cast<ResponseType*>(response.release())), span);
   }
 };
@@ -140,7 +138,7 @@ public:
    * Called when an async gRPC message is received.
    * @param response the gRPC message.
    */
-  virtual void onReceiveMessage(ProtobufTypes::MessagePtr&& message) PURE;
+  virtual void onReceiveMessageUntyped(ProtobufTypes::MessagePtr&& message) PURE;
 
   /**
    * Called when trailing metadata is recevied.
@@ -162,15 +160,13 @@ public:
 // Templatized variant of AsyncStreamCallbacks.
 template <class ResponseType> class TypedAsyncStreamCallbacks : public AsyncStreamCallbacks {
 public:
-  using AsyncStreamCallbacks::onReceiveMessage;
-
   ProtobufTypes::MessagePtr createEmptyResponse() override {
     return std::make_unique<ResponseType>();
   }
 
   virtual void onReceiveMessage(std::unique_ptr<ResponseType>&& message) PURE;
 
-  void onReceiveMessage(ProtobufTypes::MessagePtr&& message) override {
+  void onReceiveMessageUntyped(ProtobufTypes::MessagePtr&& message) override {
     onReceiveMessage(std::unique_ptr<ResponseType>(dynamic_cast<ResponseType*>(message.release())));
   }
 };

--- a/include/envoy/grpc/async_client.h
+++ b/include/envoy/grpc/async_client.h
@@ -93,6 +93,8 @@ public:
 // Templatized variant of AsyncRequestCallbacks.
 template <class ResponseType> class TypedAsyncRequestCallbacks : public AsyncRequestCallbacks {
 public:
+  using AsyncRequestCallbacks::onSuccess;
+
   ProtobufTypes::MessagePtr createEmptyResponse() override {
     return std::make_unique<ResponseType>();
   }
@@ -160,6 +162,8 @@ public:
 // Templatized variant of AsyncStreamCallbacks.
 template <class ResponseType> class TypedAsyncStreamCallbacks : public AsyncStreamCallbacks {
 public:
+  using AsyncStreamCallbacks::onReceiveMessage;
+
   ProtobufTypes::MessagePtr createEmptyResponse() override {
     return std::make_unique<ResponseType>();
   }

--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -8,12 +8,9 @@
 namespace Envoy {
 namespace Config {
 
-GrpcMuxImpl::GrpcMuxImpl(
-    const envoy::api::v2::Node& node,
-    std::unique_ptr<
-        Grpc::AsyncClient<envoy::api::v2::DiscoveryRequest, envoy::api::v2::DiscoveryResponse>>
-        async_client,
-    Event::Dispatcher& dispatcher, const Protobuf::MethodDescriptor& service_method)
+GrpcMuxImpl::GrpcMuxImpl(const envoy::api::v2::Node& node, Grpc::AsyncClientPtr async_client,
+                         Event::Dispatcher& dispatcher,
+                         const Protobuf::MethodDescriptor& service_method)
     : node_(node), async_client_(std::move(async_client)), service_method_(service_method) {
   retry_timer_ = dispatcher.createTimer([this]() -> void { establishNewStream(); });
 }
@@ -23,11 +20,7 @@ GrpcMuxImpl::GrpcMuxImpl(const envoy::api::v2::Node& node,
                          const std::string& remote_cluster_name, Event::Dispatcher& dispatcher,
                          const Protobuf::MethodDescriptor& service_method)
     : GrpcMuxImpl(node,
-                  std::unique_ptr<Grpc::AsyncClientImpl<envoy::api::v2::DiscoveryRequest,
-                                                        envoy::api::v2::DiscoveryResponse>>(
-                      new Grpc::AsyncClientImpl<envoy::api::v2::DiscoveryRequest,
-                                                envoy::api::v2::DiscoveryResponse>(
-                          cluster_manager, remote_cluster_name)),
+                  std::make_unique<Grpc::AsyncClientImpl>(cluster_manager, remote_cluster_name),
                   dispatcher, service_method) {}
 
 GrpcMuxImpl::~GrpcMuxImpl() {

--- a/source/common/config/grpc_mux_impl.h
+++ b/source/common/config/grpc_mux_impl.h
@@ -19,16 +19,13 @@ namespace Config {
  * ADS API implementation that fetches via gRPC.
  */
 class GrpcMuxImpl : public GrpcMux,
-                    Grpc::AsyncStreamCallbacks<envoy::api::v2::DiscoveryResponse>,
+                    Grpc::TypedAsyncStreamCallbacks<envoy::api::v2::DiscoveryResponse>,
                     Logger::Loggable<Logger::Id::upstream> {
 public:
   GrpcMuxImpl(const envoy::api::v2::Node& node, Upstream::ClusterManager& cluster_manager,
               const std::string& remote_cluster_name, Event::Dispatcher& dispatcher,
               const Protobuf::MethodDescriptor& service_method);
-  GrpcMuxImpl(const envoy::api::v2::Node& node,
-              std::unique_ptr<Grpc::AsyncClient<envoy::api::v2::DiscoveryRequest,
-                                                envoy::api::v2::DiscoveryResponse>>
-                  async_client,
+  GrpcMuxImpl(const envoy::api::v2::Node& node, Grpc::AsyncClientPtr async_client,
               Event::Dispatcher& dispatcher, const Protobuf::MethodDescriptor& service_method);
   ~GrpcMuxImpl();
 
@@ -91,10 +88,8 @@ private:
   };
 
   envoy::api::v2::Node node_;
-  std::unique_ptr<
-      Grpc::AsyncClient<envoy::api::v2::DiscoveryRequest, envoy::api::v2::DiscoveryResponse>>
-      async_client_;
-  Grpc::AsyncStream<envoy::api::v2::DiscoveryRequest>* stream_{};
+  Grpc::AsyncClientPtr async_client_;
+  Grpc::AsyncStream* stream_{};
   const Protobuf::MethodDescriptor& service_method_;
   std::unordered_map<std::string, ApiState> api_state_;
   // Envoy's dependendency ordering.

--- a/source/common/config/grpc_subscription_impl.h
+++ b/source/common/config/grpc_subscription_impl.h
@@ -17,19 +17,10 @@ public:
   GrpcSubscriptionImpl(const envoy::api::v2::Node& node, Upstream::ClusterManager& cm,
                        const std::string& remote_cluster_name, Event::Dispatcher& dispatcher,
                        const Protobuf::MethodDescriptor& service_method, SubscriptionStats stats)
-      : GrpcSubscriptionImpl(
-            node,
-            std::unique_ptr<Grpc::AsyncClientImpl<envoy::api::v2::DiscoveryRequest,
-                                                  envoy::api::v2::DiscoveryResponse>>(
-                new Grpc::AsyncClientImpl<envoy::api::v2::DiscoveryRequest,
-                                          envoy::api::v2::DiscoveryResponse>(cm,
-                                                                             remote_cluster_name)),
-            dispatcher, service_method, stats) {}
+      : GrpcSubscriptionImpl(node, std::make_unique<Grpc::AsyncClientImpl>(cm, remote_cluster_name),
+                             dispatcher, service_method, stats) {}
 
-  GrpcSubscriptionImpl(const envoy::api::v2::Node& node,
-                       std::unique_ptr<Grpc::AsyncClient<envoy::api::v2::DiscoveryRequest,
-                                                         envoy::api::v2::DiscoveryResponse>>
-                           async_client,
+  GrpcSubscriptionImpl(const envoy::api::v2::Node& node, Grpc::AsyncClientPtr async_client,
                        Event::Dispatcher& dispatcher,
                        const Protobuf::MethodDescriptor& service_method, SubscriptionStats stats)
       : grpc_mux_(node, std::move(async_client), dispatcher, service_method),

--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -10,6 +10,7 @@ envoy_package()
 
 envoy_cc_library(
     name = "async_client_lib",
+    srcs = ["async_client_impl.cc"],
     hdrs = ["async_client_impl.h"],
     deps = [
         ":codec_lib",

--- a/source/common/grpc/async_client_impl.cc
+++ b/source/common/grpc/async_client_impl.cc
@@ -1,0 +1,252 @@
+#include "common/grpc/async_client_impl.h"
+
+#include "common/buffer/zero_copy_input_stream_impl.h"
+#include "common/common/enum_to_int.h"
+#include "common/common/utility.h"
+#include "common/grpc/common.h"
+#include "common/http/header_map_impl.h"
+#include "common/http/utility.h"
+
+namespace Envoy {
+namespace Grpc {
+
+AsyncClientImpl::AsyncClientImpl(Upstream::ClusterManager& cm,
+                                 const std::string& remote_cluster_name)
+    : cm_(cm), remote_cluster_name_(remote_cluster_name) {}
+
+AsyncClientImpl::~AsyncClientImpl() {
+  while (!active_streams_.empty()) {
+    active_streams_.front()->resetStream();
+  }
+}
+
+AsyncRequest* AsyncClientImpl::send(const Protobuf::MethodDescriptor& service_method,
+                                    const Protobuf::Message& request,
+                                    AsyncRequestCallbacks& callbacks, Tracing::Span& parent_span,
+                                    const Optional<std::chrono::milliseconds>& timeout) {
+  auto* const async_request =
+      new AsyncRequestImpl(*this, service_method, request, callbacks, parent_span, timeout);
+  std::unique_ptr<AsyncStreamImpl> grpc_stream{async_request};
+
+  grpc_stream->initialize(true);
+  if (grpc_stream->hasResetStream()) {
+    return nullptr;
+  }
+
+  grpc_stream->moveIntoList(std::move(grpc_stream), active_streams_);
+  return async_request;
+}
+
+AsyncStream* AsyncClientImpl::start(const Protobuf::MethodDescriptor& service_method,
+                                    AsyncStreamCallbacks& callbacks) {
+  const Optional<std::chrono::milliseconds> no_timeout;
+  std::unique_ptr<AsyncStreamImpl> grpc_stream{
+      new AsyncStreamImpl(*this, service_method, callbacks, no_timeout)};
+
+  grpc_stream->initialize(false);
+  if (grpc_stream->hasResetStream()) {
+    return nullptr;
+  }
+
+  grpc_stream->moveIntoList(std::move(grpc_stream), active_streams_);
+  return active_streams_.front().get();
+}
+
+AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent,
+                                 const Protobuf::MethodDescriptor& service_method,
+                                 AsyncStreamCallbacks& callbacks,
+                                 const Optional<std::chrono::milliseconds>& timeout)
+    : parent_(parent), service_method_(service_method), callbacks_(callbacks), timeout_(timeout) {}
+
+void AsyncStreamImpl::initialize(bool buffer_body_for_retry) {
+  auto& http_async_client = parent_.cm_.httpAsyncClientForCluster(parent_.remote_cluster_name_);
+  dispatcher_ = &http_async_client.dispatcher();
+  stream_ = http_async_client.start(*this, Optional<std::chrono::milliseconds>(timeout_),
+                                    buffer_body_for_retry);
+
+  if (stream_ == nullptr) {
+    callbacks_.onRemoteClose(Status::GrpcStatus::Unavailable, EMPTY_STRING);
+    http_reset_ = true;
+    return;
+  }
+
+  headers_message_ = Common::prepareHeaders(
+      parent_.remote_cluster_name_, service_method_.service()->full_name(), service_method_.name());
+  callbacks_.onCreateInitialMetadata(headers_message_->headers());
+  stream_->sendHeaders(headers_message_->headers(), false);
+}
+
+void AsyncStreamImpl::onHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
+  ASSERT(!remote_closed_);
+  const auto http_response_status = Http::Utility::getResponseStatus(*headers);
+  if (http_response_status != enumToInt(Http::Code::OK)) {
+    // https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md requires that
+    // grpc-status be used if available.
+    if (end_stream && Common::getGrpcStatus(*headers).valid()) {
+      onTrailers(std::move(headers));
+      return;
+    }
+    streamError(Common::httpToGrpcStatus(http_response_status));
+    return;
+  }
+  if (end_stream) {
+    onTrailers(std::move(headers));
+    return;
+  }
+  callbacks_.onReceiveInitialMetadata(std::move(headers));
+}
+
+void AsyncStreamImpl::onData(Buffer::Instance& data, bool end_stream) {
+  ASSERT(!remote_closed_);
+  if (end_stream) {
+    streamError(Status::GrpcStatus::Internal);
+    return;
+  }
+
+  decoded_frames_.clear();
+  if (!decoder_.decode(data, decoded_frames_)) {
+    streamError(Status::GrpcStatus::Internal);
+    return;
+  }
+
+  for (auto& frame : decoded_frames_) {
+    ProtobufTypes::MessagePtr response = callbacks_.createEmptyResponse();
+    // TODO(htuch): Need to add support for compressed responses as well here.
+    if (frame.length_ > 0) {
+      Buffer::ZeroCopyInputStreamImpl stream(std::move(frame.data_));
+
+      if (frame.flags_ != GRPC_FH_DEFAULT || !response->ParseFromZeroCopyStream(&stream)) {
+        streamError(Status::GrpcStatus::Internal);
+        return;
+      }
+    }
+    callbacks_.onReceiveMessage(std::move(response));
+  }
+}
+
+void AsyncStreamImpl::onTrailers(Http::HeaderMapPtr&& trailers) {
+  ASSERT(!remote_closed_);
+
+  const Optional<Status::GrpcStatus> grpc_status = Common::getGrpcStatus(*trailers);
+  if (!grpc_status.valid()) {
+    streamError(Status::GrpcStatus::Internal);
+    return;
+  }
+  if (grpc_status.value() != Status::GrpcStatus::Ok) {
+    const std::string grpc_message = Common::getGrpcMessage(*trailers);
+    streamError(grpc_status.value(), grpc_message);
+    return;
+  }
+  callbacks_.onReceiveTrailingMetadata(std::move(trailers));
+  callbacks_.onRemoteClose(Status::GrpcStatus::Ok, EMPTY_STRING);
+  closeRemote();
+}
+
+void AsyncStreamImpl::onReset() {
+  if (http_reset_) {
+    return;
+  }
+
+  http_reset_ = true;
+  streamError(Status::GrpcStatus::Internal);
+}
+
+void AsyncStreamImpl::sendMessage(const Protobuf::Message& request, bool end_stream) {
+  stream_->sendData(*Common::serializeBody(request), end_stream);
+  if (end_stream) {
+    closeLocal();
+  }
+}
+
+void AsyncStreamImpl::closeStream() {
+  Buffer::OwnedImpl empty_buffer;
+  stream_->sendData(empty_buffer, true);
+  closeLocal();
+}
+
+void AsyncStreamImpl::resetStream() {
+  // Both closeLocal() and closeRemote() might self-destruct the object. We don't use these below
+  // to avoid sequencing issues.
+  local_closed_ |= true;
+  remote_closed_ |= true;
+  cleanup();
+}
+
+void AsyncStreamImpl::cleanup() {
+  if (!http_reset_) {
+    http_reset_ = true;
+    stream_->reset();
+  }
+
+  // This will destroy us, but only do so if we are actually in a list. This does not happen in
+  // the immediate failure case.
+  if (LinkedObject<AsyncStreamImpl>::inserted()) {
+    dispatcher_->deferredDelete(
+        LinkedObject<AsyncStreamImpl>::removeFromList(parent_.active_streams_));
+  }
+}
+
+AsyncRequestImpl::AsyncRequestImpl(AsyncClientImpl& parent,
+                                   const Protobuf::MethodDescriptor& service_method,
+                                   const Protobuf::Message& request,
+                                   AsyncRequestCallbacks& callbacks, Tracing::Span& parent_span,
+                                   const Optional<std::chrono::milliseconds>& timeout)
+    : AsyncStreamImpl(parent, service_method, *this, timeout), request_(request),
+      callbacks_(callbacks) {
+
+  current_span_ = parent_span.spawnChild(Tracing::EgressConfig::get(),
+                                         "async " + parent.remote_cluster_name_ + " egress",
+                                         ProdSystemTimeSource::instance_.currentTime());
+  current_span_->setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, parent.remote_cluster_name_);
+  current_span_->setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY);
+}
+
+void AsyncRequestImpl::initialize(bool buffer_body_for_retry) {
+  AsyncStreamImpl::initialize(buffer_body_for_retry);
+  if (this->hasResetStream()) {
+    return;
+  }
+  this->sendMessage(request_, true);
+}
+
+void AsyncRequestImpl::cancel() {
+  current_span_->setTag(Tracing::Tags::get().STATUS, Tracing::Tags::get().CANCELED);
+  current_span_->finishSpan();
+  this->resetStream();
+}
+
+ProtobufTypes::MessagePtr AsyncRequestImpl::createEmptyResponse() {
+  return callbacks_.createEmptyResponse();
+}
+
+void AsyncRequestImpl::onCreateInitialMetadata(Http::HeaderMap& metadata) {
+  current_span_->injectContext(metadata);
+  callbacks_.onCreateInitialMetadata(metadata);
+}
+
+void AsyncRequestImpl::onReceiveInitialMetadata(Http::HeaderMapPtr&&) {}
+
+void AsyncRequestImpl::onReceiveMessage(ProtobufTypes::MessagePtr&& message) {
+  response_ = std::move(message);
+}
+
+void AsyncRequestImpl::onReceiveTrailingMetadata(Http::HeaderMapPtr&&) {}
+
+void AsyncRequestImpl::onRemoteClose(Grpc::Status::GrpcStatus status, const std::string& message) {
+  current_span_->setTag(Tracing::Tags::get().GRPC_STATUS_CODE, std::to_string(status));
+
+  if (status != Grpc::Status::GrpcStatus::Ok) {
+    current_span_->setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE);
+    callbacks_.onFailure(status, message, *current_span_);
+  } else if (response_ == nullptr) {
+    current_span_->setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE);
+    callbacks_.onFailure(Status::Internal, EMPTY_STRING, *current_span_);
+  } else {
+    callbacks_.onSuccess(std::move(response_), *current_span_);
+  }
+
+  current_span_->finishSpan();
+}
+
+} // namespace Grpc
+} // namespace Envoy

--- a/source/common/grpc/async_client_impl.cc
+++ b/source/common/grpc/async_client_impl.cc
@@ -120,7 +120,7 @@ void AsyncStreamImpl::onData(Buffer::Instance& data, bool end_stream) {
         return;
       }
     }
-    callbacks_.onReceiveMessage(std::move(response));
+    callbacks_.onReceiveMessageUntyped(std::move(response));
   }
 }
 
@@ -226,7 +226,7 @@ void AsyncRequestImpl::onCreateInitialMetadata(Http::HeaderMap& metadata) {
 
 void AsyncRequestImpl::onReceiveInitialMetadata(Http::HeaderMapPtr&&) {}
 
-void AsyncRequestImpl::onReceiveMessage(ProtobufTypes::MessagePtr&& message) {
+void AsyncRequestImpl::onReceiveMessageUntyped(ProtobufTypes::MessagePtr&& message) {
   response_ = std::move(message);
 }
 
@@ -242,7 +242,7 @@ void AsyncRequestImpl::onRemoteClose(Grpc::Status::GrpcStatus status, const std:
     current_span_->setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE);
     callbacks_.onFailure(Status::Internal, EMPTY_STRING, *current_span_);
   } else {
-    callbacks_.onSuccess(std::move(response_), *current_span_);
+    callbacks_.onSuccessUntyped(std::move(response_), *current_span_);
   }
 
   current_span_->finishSpan();

--- a/source/common/grpc/async_client_impl.h
+++ b/source/common/grpc/async_client_impl.h
@@ -117,7 +117,7 @@ private:
   ProtobufTypes::MessagePtr createEmptyResponse() override;
   void onCreateInitialMetadata(Http::HeaderMap& metadata) override;
   void onReceiveInitialMetadata(Http::HeaderMapPtr&&) override;
-  void onReceiveMessage(ProtobufTypes::MessagePtr&& message) override;
+  void onReceiveMessageUntyped(ProtobufTypes::MessagePtr&& message) override;
   void onReceiveTrailingMetadata(Http::HeaderMapPtr&&) override;
   void onRemoteClose(Grpc::Status::GrpcStatus status, const std::string& message) override;
 

--- a/source/common/grpc/async_client_impl.h
+++ b/source/common/grpc/async_client_impl.h
@@ -2,205 +2,59 @@
 
 #include "envoy/grpc/async_client.h"
 
-#include "common/buffer/zero_copy_input_stream_impl.h"
-#include "common/common/enum_to_int.h"
 #include "common/common/linked_object.h"
-#include "common/common/utility.h"
 #include "common/grpc/codec.h"
-#include "common/grpc/common.h"
 #include "common/http/async_client_impl.h"
-#include "common/http/header_map_impl.h"
-#include "common/http/utility.h"
 
 namespace Envoy {
 namespace Grpc {
 
-template <class RequestType, class ResponseType> class AsyncStreamImpl;
-template <class RequestType, class ResponseType> class AsyncRequestImpl;
+class AsyncRequestImpl;
+class AsyncStreamImpl;
 
-template <class RequestType, class ResponseType>
-class AsyncClientImpl final : public AsyncClient<RequestType, ResponseType> {
+class AsyncClientImpl final : public AsyncClient {
 public:
-  AsyncClientImpl(Upstream::ClusterManager& cm, const std::string& remote_cluster_name)
-      : cm_(cm), remote_cluster_name_(remote_cluster_name) {}
-
-  ~AsyncClientImpl() override {
-    while (!active_streams_.empty()) {
-      active_streams_.front()->resetStream();
-    }
-  }
+  AsyncClientImpl(Upstream::ClusterManager& cm, const std::string& remote_cluster_name);
+  ~AsyncClientImpl() override;
 
   // Grpc::AsyncClient
-  AsyncRequest* send(const Protobuf::MethodDescriptor& service_method, const RequestType& request,
-                     AsyncRequestCallbacks<ResponseType>& callbacks, Tracing::Span& parent_span,
-                     const Optional<std::chrono::milliseconds>& timeout) override {
-    auto* const async_request = new AsyncRequestImpl<RequestType, ResponseType>(
-        *this, service_method, request, callbacks, parent_span, timeout);
-    std::unique_ptr<AsyncStreamImpl<RequestType, ResponseType>> grpc_stream{async_request};
-
-    grpc_stream->initialize(true);
-    if (grpc_stream->hasResetStream()) {
-      return nullptr;
-    }
-
-    grpc_stream->moveIntoList(std::move(grpc_stream), active_streams_);
-    return async_request;
-  }
-
-  AsyncStream<RequestType>* start(const Protobuf::MethodDescriptor& service_method,
-                                  AsyncStreamCallbacks<ResponseType>& callbacks) override {
-    const Optional<std::chrono::milliseconds> no_timeout;
-    std::unique_ptr<AsyncStreamImpl<RequestType, ResponseType>> grpc_stream{
-        new AsyncStreamImpl<RequestType, ResponseType>(*this, service_method, callbacks,
-                                                       no_timeout)};
-
-    grpc_stream->initialize(false);
-    if (grpc_stream->hasResetStream()) {
-      return nullptr;
-    }
-
-    grpc_stream->moveIntoList(std::move(grpc_stream), active_streams_);
-    return active_streams_.front().get();
-  }
+  AsyncRequest* send(const Protobuf::MethodDescriptor& service_method,
+                     const Protobuf::Message& request, AsyncRequestCallbacks& callbacks,
+                     Tracing::Span& parent_span,
+                     const Optional<std::chrono::milliseconds>& timeout) override;
+  AsyncStream* start(const Protobuf::MethodDescriptor& service_method,
+                     AsyncStreamCallbacks& callbacks) override;
 
 private:
   Upstream::ClusterManager& cm_;
   const std::string remote_cluster_name_;
-  std::list<std::unique_ptr<AsyncStreamImpl<RequestType, ResponseType>>> active_streams_;
+  std::list<std::unique_ptr<AsyncStreamImpl>> active_streams_;
 
-  friend class AsyncRequestImpl<RequestType, ResponseType>;
-  friend class AsyncStreamImpl<RequestType, ResponseType>;
+  friend class AsyncRequestImpl;
+  friend class AsyncStreamImpl;
 };
 
-template <class RequestType, class ResponseType>
-class AsyncStreamImpl : public AsyncStream<RequestType>,
+class AsyncStreamImpl : public AsyncStream,
                         Http::AsyncClient::StreamCallbacks,
                         public Event::DeferredDeletable,
-                        LinkedObject<AsyncStreamImpl<RequestType, ResponseType>> {
+                        LinkedObject<AsyncStreamImpl> {
 public:
-  AsyncStreamImpl(AsyncClientImpl<RequestType, ResponseType>& parent,
-                  const Protobuf::MethodDescriptor& service_method,
-                  AsyncStreamCallbacks<ResponseType>& callbacks,
-                  const Optional<std::chrono::milliseconds>& timeout)
-      : parent_(parent), service_method_(service_method), callbacks_(callbacks), timeout_(timeout) {
-  }
+  AsyncStreamImpl(AsyncClientImpl& parent, const Protobuf::MethodDescriptor& service_method,
+                  AsyncStreamCallbacks& callbacks,
+                  const Optional<std::chrono::milliseconds>& timeout);
 
-  virtual void initialize(bool buffer_body_for_retry) {
-    auto& http_async_client = parent_.cm_.httpAsyncClientForCluster(parent_.remote_cluster_name_);
-    dispatcher_ = &http_async_client.dispatcher();
-    stream_ = http_async_client.start(*this, Optional<std::chrono::milliseconds>(timeout_),
-                                      buffer_body_for_retry);
-
-    if (stream_ == nullptr) {
-      callbacks_.onRemoteClose(Status::GrpcStatus::Unavailable, EMPTY_STRING);
-      http_reset_ = true;
-      return;
-    }
-
-    headers_message_ =
-        Common::prepareHeaders(parent_.remote_cluster_name_, service_method_.service()->full_name(),
-                               service_method_.name());
-    callbacks_.onCreateInitialMetadata(headers_message_->headers());
-    stream_->sendHeaders(headers_message_->headers(), false);
-  }
+  virtual void initialize(bool buffer_body_for_retry);
 
   // Http::AsyncClient::StreamCallbacks
-  void onHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override {
-    ASSERT(!remote_closed_);
-    const auto http_response_status = Http::Utility::getResponseStatus(*headers);
-    if (http_response_status != enumToInt(Http::Code::OK)) {
-      // https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md requires that
-      // grpc-status be used if available.
-      if (end_stream && Common::getGrpcStatus(*headers).valid()) {
-        onTrailers(std::move(headers));
-        return;
-      }
-      streamError(Common::httpToGrpcStatus(http_response_status));
-      return;
-    }
-    if (end_stream) {
-      onTrailers(std::move(headers));
-      return;
-    }
-    callbacks_.onReceiveInitialMetadata(std::move(headers));
-  }
-
-  void onData(Buffer::Instance& data, bool end_stream) override {
-    ASSERT(!remote_closed_);
-    if (end_stream) {
-      streamError(Status::GrpcStatus::Internal);
-      return;
-    }
-
-    decoded_frames_.clear();
-    if (!decoder_.decode(data, decoded_frames_)) {
-      streamError(Status::GrpcStatus::Internal);
-      return;
-    }
-
-    for (auto& frame : decoded_frames_) {
-      std::unique_ptr<ResponseType> response(new ResponseType());
-      // TODO(htuch): Need to add support for compressed responses as well here.
-      if (frame.length_ > 0) {
-        Buffer::ZeroCopyInputStreamImpl stream(std::move(frame.data_));
-
-        if (frame.flags_ != GRPC_FH_DEFAULT || !response->ParseFromZeroCopyStream(&stream)) {
-          streamError(Status::GrpcStatus::Internal);
-          return;
-        }
-      }
-      callbacks_.onReceiveMessage(std::move(response));
-    }
-  }
-
-  void onTrailers(Http::HeaderMapPtr&& trailers) override {
-    ASSERT(!remote_closed_);
-
-    const Optional<Status::GrpcStatus> grpc_status = Common::getGrpcStatus(*trailers);
-    if (!grpc_status.valid()) {
-      streamError(Status::GrpcStatus::Internal);
-      return;
-    }
-    if (grpc_status.value() != Status::GrpcStatus::Ok) {
-      const std::string grpc_message = Common::getGrpcMessage(*trailers);
-      streamError(grpc_status.value(), grpc_message);
-      return;
-    }
-    callbacks_.onReceiveTrailingMetadata(std::move(trailers));
-    callbacks_.onRemoteClose(Status::GrpcStatus::Ok, EMPTY_STRING);
-    closeRemote();
-  }
-
-  void onReset() override {
-    if (http_reset_) {
-      return;
-    }
-
-    http_reset_ = true;
-    streamError(Status::GrpcStatus::Internal);
-  }
+  void onHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override;
+  void onData(Buffer::Instance& data, bool end_stream) override;
+  void onTrailers(Http::HeaderMapPtr&& trailers) override;
+  void onReset() override;
 
   // Grpc::AsyncStream
-  void sendMessage(const RequestType& request, bool end_stream) override {
-    stream_->sendData(*Common::serializeBody(request), end_stream);
-    if (end_stream) {
-      closeLocal();
-    }
-  }
-
-  void closeStream() override {
-    Buffer::OwnedImpl empty_buffer;
-    stream_->sendData(empty_buffer, true);
-    closeLocal();
-  }
-
-  void resetStream() override {
-    // Both closeLocal() and closeRemote() might self-destruct the object. We don't use these below
-    // to avoid sequencing issues.
-    local_closed_ |= true;
-    remote_closed_ |= true;
-    cleanup();
-  }
+  void sendMessage(const Protobuf::Message& request, bool end_stream) override;
+  void closeStream() override;
+  void resetStream() override;
 
   bool hasResetStream() const { return http_reset_; }
 
@@ -212,20 +66,7 @@ private:
 
   void streamError(Status::GrpcStatus grpc_status) { streamError(grpc_status, EMPTY_STRING); }
 
-  void cleanup() {
-    if (!http_reset_) {
-      http_reset_ = true;
-      stream_->reset();
-    }
-
-    // This will destroy us, but only do so if we are actually in a list. This does not happen in
-    // the immediate failure case.
-    if (LinkedObject<AsyncStreamImpl<RequestType, ResponseType>>::inserted()) {
-      dispatcher_->deferredDelete(
-          LinkedObject<AsyncStreamImpl<RequestType, ResponseType>>::removeFromList(
-              parent_.active_streams_));
-    }
-  }
+  void cleanup();
 
   void closeLocal() {
     local_closed_ |= true;
@@ -245,9 +86,9 @@ private:
 
   Event::Dispatcher* dispatcher_{};
   Http::MessagePtr headers_message_;
-  AsyncClientImpl<RequestType, ResponseType>& parent_;
+  AsyncClientImpl& parent_;
   const Protobuf::MethodDescriptor& service_method_;
-  AsyncStreamCallbacks<ResponseType>& callbacks_;
+  AsyncStreamCallbacks& callbacks_;
   const Optional<std::chrono::milliseconds>& timeout_;
   bool local_closed_{};
   bool remote_closed_{};
@@ -257,78 +98,33 @@ private:
   // This is a member to avoid reallocation on every onData().
   std::vector<Frame> decoded_frames_;
 
-  friend class AsyncClientImpl<RequestType, ResponseType>;
+  friend class AsyncClientImpl;
 };
 
-template <class RequestType, class ResponseType>
-class AsyncRequestImpl : public AsyncRequest,
-                         public AsyncStreamImpl<RequestType, ResponseType>,
-                         AsyncStreamCallbacks<ResponseType> {
+class AsyncRequestImpl : public AsyncRequest, public AsyncStreamImpl, AsyncStreamCallbacks {
 public:
-  AsyncRequestImpl(AsyncClientImpl<RequestType, ResponseType>& parent,
-                   const Protobuf::MethodDescriptor& service_method, const RequestType& request,
-                   AsyncRequestCallbacks<ResponseType>& callbacks, Tracing::Span& parent_span,
-                   const Optional<std::chrono::milliseconds>& timeout)
-      : AsyncStreamImpl<RequestType, ResponseType>(parent, service_method, *this, timeout),
-        request_(request), callbacks_(callbacks) {
+  AsyncRequestImpl(AsyncClientImpl& parent, const Protobuf::MethodDescriptor& service_method,
+                   const Protobuf::Message& request, AsyncRequestCallbacks& callbacks,
+                   Tracing::Span& parent_span, const Optional<std::chrono::milliseconds>& timeout);
 
-    current_span_ = parent_span.spawnChild(Tracing::EgressConfig::get(),
-                                           "async " + parent.remote_cluster_name_ + " egress",
-                                           ProdSystemTimeSource::instance_.currentTime());
-    current_span_->setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, parent.remote_cluster_name_);
-    current_span_->setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY);
-  }
-
-  void initialize(bool buffer_body_for_retry) override {
-    AsyncStreamImpl<RequestType, ResponseType>::initialize(buffer_body_for_retry);
-    if (this->hasResetStream()) {
-      return;
-    }
-    this->sendMessage(request_, true);
-  }
+  void initialize(bool buffer_body_for_retry) override;
 
   // Grpc::AsyncRequest
-  void cancel() override {
-    current_span_->setTag(Tracing::Tags::get().STATUS, Tracing::Tags::get().CANCELED);
-    current_span_->finishSpan();
-    this->resetStream();
-  }
+  void cancel() override;
 
 private:
   // Grpc::AsyncStreamCallbacks
-  void onCreateInitialMetadata(Http::HeaderMap& metadata) override {
-    current_span_->injectContext(metadata);
-    callbacks_.onCreateInitialMetadata(metadata);
-  }
+  ProtobufTypes::MessagePtr createEmptyResponse() override;
+  void onCreateInitialMetadata(Http::HeaderMap& metadata) override;
+  void onReceiveInitialMetadata(Http::HeaderMapPtr&&) override;
+  void onReceiveMessage(ProtobufTypes::MessagePtr&& message) override;
+  void onReceiveTrailingMetadata(Http::HeaderMapPtr&&) override;
+  void onRemoteClose(Grpc::Status::GrpcStatus status, const std::string& message) override;
 
-  void onReceiveInitialMetadata(Http::HeaderMapPtr&&) override {}
-
-  void onReceiveMessage(std::unique_ptr<ResponseType>&& message) override {
-    response_ = std::move(message);
-  }
-
-  void onReceiveTrailingMetadata(Http::HeaderMapPtr&&) override {}
-
-  void onRemoteClose(Grpc::Status::GrpcStatus status, const std::string& message) override {
-    current_span_->setTag(Tracing::Tags::get().GRPC_STATUS_CODE, std::to_string(status));
-
-    if (status != Grpc::Status::GrpcStatus::Ok) {
-      current_span_->setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE);
-      callbacks_.onFailure(status, message, *current_span_);
-    } else if (response_ == nullptr) {
-      current_span_->setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE);
-      callbacks_.onFailure(Status::Internal, EMPTY_STRING, *current_span_);
-    } else {
-      callbacks_.onSuccess(std::move(response_), *current_span_);
-    }
-
-    current_span_->finishSpan();
-  }
-
-  const RequestType& request_;
-  AsyncRequestCallbacks<ResponseType>& callbacks_;
+  const Protobuf::Message& request_;
+  AsyncRequestCallbacks& callbacks_;
   Tracing::SpanPtr current_span_;
-  std::unique_ptr<ResponseType> response_;
+  ProtobufTypes::MessagePtr response_;
 };
 
 } // namespace Grpc

--- a/source/common/ratelimit/ratelimit_impl.cc
+++ b/source/common/ratelimit/ratelimit_impl.cc
@@ -14,7 +14,7 @@
 namespace Envoy {
 namespace RateLimit {
 
-GrpcClientImpl::GrpcClientImpl(RateLimitAsyncClientPtr&& async_client,
+GrpcClientImpl::GrpcClientImpl(Grpc::AsyncClientPtr&& async_client,
                                const Optional<std::chrono::milliseconds>& timeout)
     : service_method_(*Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
           "pb.lyft.ratelimit.RateLimitService.ShouldRateLimit")),
@@ -85,11 +85,8 @@ GrpcFactoryImpl::GrpcFactoryImpl(const envoy::api::v2::RateLimitServiceConfig& c
 }
 
 ClientPtr GrpcFactoryImpl::create(const Optional<std::chrono::milliseconds>& timeout) {
-  return ClientPtr{new GrpcClientImpl(
-      RateLimitAsyncClientPtr{
-          new Grpc::AsyncClientImpl<pb::lyft::ratelimit::RateLimitRequest,
-                                    pb::lyft::ratelimit::RateLimitResponse>(cm_, cluster_name_)},
-      timeout)};
+  return std::make_unique<GrpcClientImpl>(
+      std::make_unique<Grpc::AsyncClientImpl>(cm_, cluster_name_), timeout);
 }
 
 } // namespace RateLimit

--- a/source/common/ratelimit/ratelimit_impl.h
+++ b/source/common/ratelimit/ratelimit_impl.h
@@ -19,12 +19,8 @@
 namespace Envoy {
 namespace RateLimit {
 
-typedef Grpc::AsyncClient<pb::lyft::ratelimit::RateLimitRequest,
-                          pb::lyft::ratelimit::RateLimitResponse>
-    RateLimitAsyncClient;
-typedef std::unique_ptr<RateLimitAsyncClient> RateLimitAsyncClientPtr;
-
-typedef Grpc::AsyncRequestCallbacks<pb::lyft::ratelimit::RateLimitResponse> RateLimitAsyncCallbacks;
+typedef Grpc::TypedAsyncRequestCallbacks<pb::lyft::ratelimit::RateLimitResponse>
+    RateLimitAsyncCallbacks;
 
 struct ConstantValues {
   const std::string TraceStatus = "ratelimit_status";
@@ -39,7 +35,7 @@ typedef ConstSingleton<ConstantValues> Constants;
 // one today).
 class GrpcClientImpl : public Client, public RateLimitAsyncCallbacks {
 public:
-  GrpcClientImpl(RateLimitAsyncClientPtr&& async_client,
+  GrpcClientImpl(Grpc::AsyncClientPtr&& async_client,
                  const Optional<std::chrono::milliseconds>& timeout);
   ~GrpcClientImpl();
 
@@ -60,7 +56,7 @@ public:
 
 private:
   const Protobuf::MethodDescriptor& service_method_;
-  RateLimitAsyncClientPtr async_client_;
+  Grpc::AsyncClientPtr async_client_;
   Grpc::AsyncRequest* request_{};
   Optional<std::chrono::milliseconds> timeout_;
   RequestCallbacks* callbacks_{};

--- a/source/common/upstream/load_stats_reporter.cc
+++ b/source/common/upstream/load_stats_reporter.cc
@@ -7,7 +7,7 @@ namespace Upstream {
 
 LoadStatsReporter::LoadStatsReporter(const envoy::api::v2::Node& node,
                                      ClusterManager& cluster_manager, Stats::Scope& scope,
-                                     LoadStatsAsyncClientPtr async_client,
+                                     Grpc::AsyncClientPtr async_client,
                                      Event::Dispatcher& dispatcher)
     : cm_(cluster_manager), stats_{ALL_LOAD_REPORTER_STATS(
                                 POOL_COUNTER_PREFIX(scope, "load_reporter."))},
@@ -26,9 +26,7 @@ LoadStatsReporter::LoadStatsReporter(const envoy::api::v2::Node& node,
                                      Event::Dispatcher& dispatcher)
     : LoadStatsReporter(
           node, cluster_manager, scope,
-          LoadStatsAsyncClientPtr(new Grpc::AsyncClientImpl<envoy::api::v2::LoadStatsRequest,
-                                                            envoy::api::v2::LoadStatsResponse>(
-              cluster_manager, remote_cluster_name)),
+          std::make_unique<Grpc::AsyncClientImpl>(cluster_manager, remote_cluster_name),
           dispatcher) {}
 
 void LoadStatsReporter::setRetryTimer() {

--- a/source/common/upstream/load_stats_reporter.h
+++ b/source/common/upstream/load_stats_reporter.h
@@ -29,21 +29,17 @@ struct LoadReporterStats {
   ALL_LOAD_REPORTER_STATS(GENERATE_COUNTER_STRUCT)
 };
 
-typedef Grpc::AsyncClient<envoy::api::v2::LoadStatsRequest, envoy::api::v2::LoadStatsResponse>
-    LoadStatsAsyncClient;
-typedef std::unique_ptr<LoadStatsAsyncClient> LoadStatsAsyncClientPtr;
-
-class LoadStatsReporter : Grpc::AsyncStreamCallbacks<envoy::api::v2::LoadStatsResponse>,
+class LoadStatsReporter : Grpc::TypedAsyncStreamCallbacks<envoy::api::v2::LoadStatsResponse>,
                           Logger::Loggable<Logger::Id::upstream> {
 public:
   LoadStatsReporter(const envoy::api::v2::Node& node, ClusterManager& cluster_manager,
-                    Stats::Scope& scope, LoadStatsAsyncClientPtr async_client,
+                    Stats::Scope& scope, Grpc::AsyncClientPtr async_client,
                     Event::Dispatcher& dispatcher);
   LoadStatsReporter(const envoy::api::v2::Node& node, ClusterManager& cluster_manager,
                     Stats::Scope& scope, const std::string& remote_cluster_name,
                     Event::Dispatcher& dispatcher);
 
-  // Grpc::AsyncStreamCallbacks
+  // Grpc::TypedAsyncStreamCallbacks
   void onCreateInitialMetadata(Http::HeaderMap& metadata) override;
   void onReceiveInitialMetadata(Http::HeaderMapPtr&& metadata) override;
   void onReceiveMessage(std::unique_ptr<envoy::api::v2::LoadStatsResponse>&& message) override;
@@ -62,8 +58,8 @@ private:
 
   ClusterManager& cm_;
   LoadReporterStats stats_;
-  LoadStatsAsyncClientPtr async_client_;
-  Grpc::AsyncStream<envoy::api::v2::LoadStatsRequest>* stream_{};
+  Grpc::AsyncClientPtr async_client_;
+  Grpc::AsyncStream* stream_{};
   const Protobuf::MethodDescriptor& service_method_;
   Event::TimerPtr retry_timer_;
   Event::TimerPtr response_timer_;

--- a/source/server/config/access_log/grpc_access_log.cc
+++ b/source/server/config/access_log/grpc_access_log.cc
@@ -22,11 +22,8 @@ public:
       : cluster_manager_(cluster_manager), cluster_name_(cluster_name) {}
 
   // AccessLog::GrpcAccessLogClientFactory
-  AccessLog::GrpcAccessLogClientPtr create() override {
-    return std::make_unique<
-        Grpc::AsyncClientImpl<envoy::api::v2::filter::accesslog::StreamAccessLogsMessage,
-                              envoy::api::v2::filter::accesslog::StreamAccessLogsResponse>>(
-        cluster_manager_, cluster_name_);
+  Grpc::AsyncClientPtr create() override {
+    return std::make_unique<Grpc::AsyncClientImpl>(cluster_manager_, cluster_name_);
   };
 
   Upstream::ClusterManager& cluster_manager_;

--- a/source/server/config/stats/metrics_service.cc
+++ b/source/server/config/stats/metrics_service.cc
@@ -23,10 +23,8 @@ public:
       : cluster_manager_(cluster_manager), cluster_name_(cluster_name) {}
 
   // Metrics::GrpcMetricsServiceClientPtr
-  Stats::Metrics::GrpcMetricsServiceClientPtr create() override {
-    return std::make_unique<Grpc::AsyncClientImpl<envoy::api::v2::StreamMetricsMessage,
-                                                  envoy::api::v2::StreamMetricsResponse>>(
-        cluster_manager_, cluster_name_);
+  Grpc::AsyncClientPtr create() override {
+    return std::make_unique<Grpc::AsyncClientImpl>(cluster_manager_, cluster_name_);
   };
 
   Upstream::ClusterManager& cluster_manager_;

--- a/test/common/config/grpc_mux_impl_test.cc
+++ b/test/common/config/grpc_mux_impl_test.cc
@@ -23,24 +23,19 @@ namespace Envoy {
 namespace Config {
 namespace {
 
-typedef Grpc::MockAsyncClient<envoy::api::v2::DiscoveryRequest, envoy::api::v2::DiscoveryResponse>
-    SubscriptionMockAsyncClient;
-
 // We test some mux specific stuff below, other unit test coverage for singleton use of GrpcMuxImpl
 // is provided in [grpc_]subscription_impl_test.cc.
 class GrpcMuxImplTest : public testing::Test {
 public:
-  GrpcMuxImplTest()
-      : async_client_(new SubscriptionMockAsyncClient()), timer_(new Event::MockTimer()) {
+  GrpcMuxImplTest() : async_client_(new Grpc::MockAsyncClient()), timer_(new Event::MockTimer()) {
     EXPECT_CALL(dispatcher_, createTimer_(_)).WillOnce(Invoke([this](Event::TimerCb timer_cb) {
       timer_cb_ = timer_cb;
       return timer_;
     }));
-    grpc_mux_.reset(
-        new GrpcMuxImpl(envoy::api::v2::Node(),
-                        std::unique_ptr<SubscriptionMockAsyncClient>(async_client_), dispatcher_,
-                        *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
-                            "envoy.api.v2.AggregatedDiscoveryService.StreamAggregatedResources")));
+    grpc_mux_.reset(new GrpcMuxImpl(
+        envoy::api::v2::Node(), std::unique_ptr<Grpc::MockAsyncClient>(async_client_), dispatcher_,
+        *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
+            "envoy.api.v2.AggregatedDiscoveryService.StreamAggregatedResources")));
   }
 
   void expectSendMessage(const std::string& type_url,
@@ -61,10 +56,10 @@ public:
 
   envoy::api::v2::Node node_;
   NiceMock<Event::MockDispatcher> dispatcher_;
-  SubscriptionMockAsyncClient* async_client_;
+  Grpc::MockAsyncClient* async_client_;
   Event::MockTimer* timer_;
   Event::TimerCb timer_cb_;
-  Grpc::MockAsyncStream<envoy::api::v2::DiscoveryRequest> async_stream_;
+  Grpc::MockAsyncStream async_stream_;
   std::unique_ptr<GrpcMuxImpl> grpc_mux_;
   MockGrpcMuxCallbacks callbacks_;
 };

--- a/test/common/grpc/BUILD
+++ b/test/common/grpc/BUILD
@@ -13,7 +13,9 @@ envoy_cc_test(
     name = "async_client_impl_test",
     srcs = ["async_client_impl_test.cc"],
     deps = [
+        "//source/common/common:enum_to_int",
         "//source/common/grpc:async_client_lib",
+        "//source/common/grpc:common_lib",
         "//test/mocks/buffer:buffer_mocks",
         "//test/mocks/grpc:grpc_mocks",
         "//test/mocks/http:http_mocks",

--- a/test/common/grpc/async_client_impl_test.cc
+++ b/test/common/grpc/async_client_impl_test.cc
@@ -1,4 +1,6 @@
+#include "common/common/enum_to_int.h"
 #include "common/grpc/async_client_impl.h"
+#include "common/grpc/common.h"
 
 #include "test/mocks/buffer/mocks.h"
 #include "test/mocks/grpc/mocks.h"
@@ -20,10 +22,6 @@ using testing::_;
 
 namespace Envoy {
 namespace Grpc {
-
-template class AsyncClientImpl<helloworld::HelloRequest, helloworld::HelloReply>;
-template class AsyncStreamImpl<helloworld::HelloRequest, helloworld::HelloReply>;
-
 namespace {
 
 const std::string HELLO_REQUEST = "ABC";
@@ -127,7 +125,7 @@ public:
 
   Http::AsyncClient::StreamCallbacks* http_callbacks_{};
   Http::MockAsyncClientStream* http_stream_;
-  AsyncStream<helloworld::HelloRequest>* grpc_stream_{};
+  AsyncStream* grpc_stream_{};
 };
 
 class HelloworldRequest : public MockAsyncRequestCallbacks<helloworld::HelloReply> {
@@ -163,8 +161,7 @@ class GrpcAsyncClientImplTest : public testing::Test {
 public:
   GrpcAsyncClientImplTest()
       : method_descriptor_(helloworld::Greeter::descriptor()->FindMethodByName("SayHello")),
-        grpc_client_(new AsyncClientImpl<helloworld::HelloRequest, helloworld::HelloReply>(
-            cm_, "test_cluster")) {
+        grpc_client_(new AsyncClientImpl(cm_, "test_cluster")) {
     ON_CALL(cm_, httpAsyncClientForCluster("test_cluster")).WillByDefault(ReturnRef(http_client_));
   }
 
@@ -272,7 +269,7 @@ public:
   const Protobuf::MethodDescriptor* method_descriptor_;
   NiceMock<Http::MockAsyncClient> http_client_;
   NiceMock<Upstream::MockClusterManager> cm_;
-  std::unique_ptr<AsyncClientImpl<helloworld::HelloRequest, helloworld::HelloReply>> grpc_client_;
+  std::unique_ptr<AsyncClientImpl> grpc_client_;
 };
 
 // Validate that a simple request-reply stream works.

--- a/test/common/upstream/load_stats_reporter_test.cc
+++ b/test/common/upstream/load_stats_reporter_test.cc
@@ -21,14 +21,11 @@ using testing::_;
 namespace Envoy {
 namespace Upstream {
 
-typedef Grpc::MockAsyncClient<envoy::api::v2::LoadStatsRequest, envoy::api::v2::LoadStatsResponse>
-    LoadStatsMockAsyncClient;
-
 class LoadStatsReporterTest : public testing::Test {
 public:
   LoadStatsReporterTest()
       : retry_timer_(new Event::MockTimer()), response_timer_(new Event::MockTimer()),
-        async_client_(new LoadStatsMockAsyncClient()) {
+        async_client_(new Grpc::MockAsyncClient()) {
     node_.set_id("foo");
   }
 
@@ -43,7 +40,7 @@ public:
       return response_timer_;
     }));
     load_stats_reporter_.reset(new LoadStatsReporter(
-        node_, cm_, stats_store_, LoadStatsAsyncClientPtr(async_client_), dispatcher_));
+        node_, cm_, stats_store_, Grpc::AsyncClientPtr(async_client_), dispatcher_));
   }
 
   void expectSendMessage(const std::vector<envoy::api::v2::ClusterStats>& expected_cluster_stats) {
@@ -74,8 +71,8 @@ public:
   Event::TimerCb retry_timer_cb_;
   Event::MockTimer* response_timer_;
   Event::TimerCb response_timer_cb_;
-  Grpc::MockAsyncStream<envoy::api::v2::LoadStatsRequest> async_stream_;
-  LoadStatsMockAsyncClient* async_client_;
+  Grpc::MockAsyncStream async_stream_;
+  Grpc::MockAsyncClient* async_client_;
 };
 
 // Validate that stream creation results in a timer based retry.

--- a/test/mocks/grpc/mocks.h
+++ b/test/mocks/grpc/mocks.h
@@ -18,15 +18,15 @@ public:
   MOCK_METHOD0(cancel, void());
 };
 
-template <class RequestType> class MockAsyncStream : public AsyncStream<RequestType> {
+class MockAsyncStream : public AsyncStream {
 public:
-  MOCK_METHOD2_T(sendMessage, void(const RequestType& request, bool end_stream));
+  MOCK_METHOD2_T(sendMessage, void(const Protobuf::Message& request, bool end_stream));
   MOCK_METHOD0_T(closeStream, void());
   MOCK_METHOD0_T(resetStream, void());
 };
 
 template <class ResponseType>
-class MockAsyncRequestCallbacks : public AsyncRequestCallbacks<ResponseType> {
+class MockAsyncRequestCallbacks : public TypedAsyncRequestCallbacks<ResponseType> {
 public:
   void onSuccess(std::unique_ptr<ResponseType>&& response, Tracing::Span& span) {
     onSuccess_(*response, span);
@@ -39,7 +39,7 @@ public:
 };
 
 template <class ResponseType>
-class MockAsyncStreamCallbacks : public AsyncStreamCallbacks<ResponseType> {
+class MockAsyncStreamCallbacks : public TypedAsyncStreamCallbacks<ResponseType> {
 public:
   void onReceiveInitialMetadata(Http::HeaderMapPtr&& metadata) {
     onReceiveInitialMetadata_(*metadata);
@@ -58,16 +58,14 @@ public:
   MOCK_METHOD2_T(onRemoteClose, void(Status::GrpcStatus status, const std::string& message));
 };
 
-template <class RequestType, class ResponseType>
-class MockAsyncClient : public AsyncClient<RequestType, ResponseType> {
+class MockAsyncClient : public AsyncClient {
 public:
   MOCK_METHOD5_T(send, AsyncRequest*(const Protobuf::MethodDescriptor& service_method,
-                                     const RequestType& request,
-                                     AsyncRequestCallbacks<ResponseType>& callbacks,
-                                     Tracing::Span& parent_span,
+                                     const Protobuf::Message& request,
+                                     AsyncRequestCallbacks& callbacks, Tracing::Span& parent_span,
                                      const Optional<std::chrono::milliseconds>& timeout));
-  MOCK_METHOD2_T(start, AsyncStream<RequestType>*(const Protobuf::MethodDescriptor& service_method,
-                                                  AsyncStreamCallbacks<ResponseType>& callbacks));
+  MOCK_METHOD2_T(start, AsyncStream*(const Protobuf::MethodDescriptor& service_method,
+                                     AsyncStreamCallbacks& callbacks));
 };
 
 } // namespace Grpc

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -121,7 +121,7 @@ public:
    * @return bool indicating whether the protos are equal. Type name and string serialization are
    *         used for equality testing.
    */
-  template <class ProtoType> static bool protoEqual(const ProtoType& lhs, const ProtoType& rhs) {
+  static bool protoEqual(const Protobuf::Message& lhs, const Protobuf::Message& rhs) {
     return lhs.GetTypeName() == rhs.GetTypeName() &&
            lhs.SerializeAsString() == rhs.SerializeAsString();
   }


### PR DESCRIPTION
In order to support a singleton gRPC manager (managing TLS state,
connection pools for the Google gRPC client, etc.), this PR removes the
use of templating in Grpc::AsyncClient and its related interfaces.

We initially used templates as they were an easy way to propagate type
information. However, we can avoid using them by taking advantage of the
Protobuf::Message superclass interface. There is some convenience in
using templating for the request/stream callbacks, adapter template
classes are provided to make this possible.

Risk Level: Low
Testing: No new tests, this is purely refactoring.

Signed-off-by: Harvey Tuch <htuch@google.com>