### PR TITLE
build: fix do_ci.sh for non-root Linux execution.

### DIFF
--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -4,14 +4,11 @@ set -e
 
 . ci/envoy_build_sha.sh
 
-# When running docker on a Mac, root user permissions are required.
-if [[ "$OSTYPE" == "darwin"* ]]; then
-	USER=root
-	USER_GROUP=root
-else
-	USER=$(id -u)
-	USER_GROUP=$(id -g)
-fi
+# We run as root and later drop permissions. This is requried to setup the USER
+# in useradd below, which is need for correct Python execution in the Docker
+# environment.
+USER=root
+USER_GROUP=root
 
 [[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME="envoyproxy/envoy-build-ubuntu"
 # The IMAGE_ID defaults to the CI hash but can be set to an arbitrary image ID (found with 'docker
@@ -23,4 +20,5 @@ mkdir -p "${ENVOY_DOCKER_BUILD_DIR}"
 # Since we specify an explicit hash, docker-run will pull from the remote repo if missing.
 docker run --rm -t -i -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build \
   -v "$PWD":/source -e NUM_CPUS --cap-add SYS_PTRACE "${IMAGE_NAME}":"${IMAGE_ID}" \
-  /bin/bash -lc "cd source && $*"
+  /bin/bash -lc "groupadd --gid $(id -g) envoygroup && useradd --uid $(id -u) --gid $(id -g) \
+  --no-create-home --home-dir /source envoybuild && su envoybuild -c \"cd source && $*\""


### PR DESCRIPTION
Subpar uses Python, which doesn't like it when we don't have
PYTHONUSERBASE (hidden by Bazel hermeticity) set or getpwuid()
resolution to user (missing in /etc/passwd). This is a workaround based
on https://github.com/JonathonReinhart/scuba/issues/11 to get build
happening on Linux when non-root.

Signed-off-by: Harvey Tuch <htuch@google.com>