### PR TITLE
server: Move Listener to Network::ListenerConfig.

### DIFF
--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -6,6 +6,7 @@
 
 #include "envoy/common/exception.h"
 #include "envoy/network/connection.h"
+#include "envoy/ssl/context.h"
 
 namespace Envoy {
 namespace Network {
@@ -36,6 +37,71 @@ struct ListenerOptions {
             .use_original_dst_ = false,
             .per_connection_buffer_limit_bytes_ = 0};
   }
+};
+
+/**
+ * A configuration for an individual listener.
+ */
+class ListenerConfig {
+public:
+  virtual ~ListenerConfig() {}
+
+  /**
+   * @return FilterChainFactory& the factory for setting up the filter chain on a new
+   *         connection.
+   */
+  virtual FilterChainFactory& filterChainFactory() PURE;
+
+  /**
+   * @return ListenSocket& the actual listen socket. The address of this socket may be
+   *         different from configured if for example the configured address binds to port zero.
+   */
+  virtual ListenSocket& socket() PURE;
+
+  /**
+   * @return Ssl::ServerContext* the default SSL context.
+   */
+  virtual Ssl::ServerContext* defaultSslContext() PURE;
+
+  /**
+   * @return bool whether to use the PROXY Protocol V1
+   * (http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt)
+   */
+  virtual bool useProxyProto() PURE;
+
+  /**
+   * @return bool specifies whether the listener should actually listen on the port.
+   *         A listener that doesn't listen on a port can only receive connections
+   *         redirected from other listeners.
+   */
+  virtual bool bindToPort() PURE;
+
+  /**
+   * @return bool if a connection was redirected to this listener address using iptables,
+   *         allow the listener to hand it off to the listener associated to the original address
+   */
+  virtual bool useOriginalDst() PURE;
+
+  /**
+   * @return uint32_t providing a soft limit on size of the listener's new connection read and write
+   *         buffers.
+   */
+  virtual uint32_t perConnectionBufferLimitBytes() PURE;
+
+  /**
+   * @return Stats::Scope& the stats scope to use for all listener specific stats.
+   */
+  virtual Stats::Scope& listenerScope() PURE;
+
+  /**
+   * @return uint64_t the tag the listener should use for connection handler tracking.
+   */
+  virtual uint64_t listenerTag() PURE;
+
+  /**
+   * @return const std::string& the listener's name.
+   */
+  virtual const std::string& name() const PURE;
 };
 
 /**

--- a/include/envoy/server/listener_manager.h
+++ b/include/envoy/server/listener_manager.h
@@ -2,10 +2,10 @@
 
 #include "envoy/network/filter.h"
 #include "envoy/network/listen_socket.h"
+#include "envoy/network/listener.h"
 #include "envoy/server/drain_manager.h"
 #include "envoy/server/filter_config.h"
 #include "envoy/server/guarddog.h"
-#include "envoy/ssl/context.h"
 
 #include "common/protobuf/protobuf.h"
 
@@ -53,71 +53,6 @@ public:
 };
 
 /**
- * A configuration for an individual listener.
- */
-class Listener {
-public:
-  virtual ~Listener() {}
-
-  /**
-   * @return Network::FilterChainFactory& the factory for setting up the filter chain on a new
-   *         connection.
-   */
-  virtual Network::FilterChainFactory& filterChainFactory() PURE;
-
-  /**
-   * @return Network::ListenSocket& the actual listen socket. The address of this socket may be
-   *         different from configured if for example the configured address binds to port zero.
-   */
-  virtual Network::ListenSocket& socket() PURE;
-
-  /**
-   * @return Ssl::ServerContext* the default SSL context.
-   */
-  virtual Ssl::ServerContext* defaultSslContext() PURE;
-
-  /**
-   * @return bool whether to use the PROXY Protocol V1
-   * (http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt)
-   */
-  virtual bool useProxyProto() PURE;
-
-  /**
-   * @return bool specifies whether the listener should actually listen on the port.
-   *         A listener that doesn't listen on a port can only receive connections
-   *         redirected from other listeners.
-   */
-  virtual bool bindToPort() PURE;
-
-  /**
-   * @return bool if a connection was redirected to this listener address using iptables,
-   *         allow the listener to hand it off to the listener associated to the original address
-   */
-  virtual bool useOriginalDst() PURE;
-
-  /**
-   * @return uint32_t providing a soft limit on size of the listener's new connection read and write
-   *         buffers.
-   */
-  virtual uint32_t perConnectionBufferLimitBytes() PURE;
-
-  /**
-   * @return Stats::Scope& the stats scope to use for all listener specific stats.
-   */
-  virtual Stats::Scope& listenerScope() PURE;
-
-  /**
-   * @return uint64_t the tag the listener should use for connection handler tracking.
-   */
-  virtual uint64_t listenerTag() PURE;
-
-  /**
-   * @return const std::string& the listener's name.
-   */
-  virtual const std::string& name() const PURE;
-};
-
-/**
  * A manager for all listeners and all threaded connection handling workers.
  */
 class ListenerManager {
@@ -142,11 +77,11 @@ public:
   virtual bool addOrUpdateListener(const envoy::api::v2::Listener& config, bool modifiable) PURE;
 
   /**
-   * @return std::vector<std::reference_wrapper<Listener>> a list of the currently loaded listeners.
-   * Note that this routine returns references to the existing listeners. The references are only
-   * valid in the context of the current call stack and should not be stored.
+   * @return std::vector<std::reference_wrapper<Network::ListenerConfig>> a list of the currently
+   * loaded listeners. Note that this routine returns references to the existing listeners. The
+   * references are only valid in the context of the current call stack and should not be stored.
    */
-  virtual std::vector<std::reference_wrapper<Listener>> listeners() PURE;
+  virtual std::vector<std::reference_wrapper<Network::ListenerConfig>> listeners() PURE;
 
   /**
    * @return uint64_t the total number of connections owned by all listeners across all workers.

--- a/include/envoy/server/worker.h
+++ b/include/envoy/server/worker.h
@@ -28,7 +28,8 @@ public:
    * @param completion supplies the completion to call when the listener has been added (or not) on
    *                   the worker.
    */
-  virtual void addListener(Listener& listener, AddListenerCompletion completion) PURE;
+  virtual void addListener(Network::ListenerConfig& listener,
+                           AddListenerCompletion completion) PURE;
 
   /**
    * @return uint64_t the number of connections across all listeners that the worker owns.
@@ -52,7 +53,8 @@ public:
    * @param completion supplies the completion to be called when the listener has been removed.
    *        This completion is called on the worker thread. No locking is performed by the worker.
    */
-  virtual void removeListener(Listener& listener, std::function<void()> completion) PURE;
+  virtual void removeListener(Network::ListenerConfig& listener,
+                              std::function<void()> completion) PURE;
 
   /**
    * Stop a listener from accepting new connections. This is used for server draining.
@@ -61,7 +63,7 @@ public:
    * all connections are gone. This would allow us to remove the listener more quickly depending on
    * drain speed.
    */
-  virtual void stopListener(Listener& listener) PURE;
+  virtual void stopListener(Network::ListenerConfig& listener) PURE;
 
   /**
    * Stop all listeners from accepting new connections. This is used for server draining.

--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -46,7 +46,8 @@ void LdsApi::onConfigUpdate(const ResourceVector& resources) {
     MessageUtil::validate(listener);
   }
   // We need to keep track of which listeners we might need to remove.
-  std::unordered_map<std::string, std::reference_wrapper<Listener>> listeners_to_remove;
+  std::unordered_map<std::string, std::reference_wrapper<Network::ListenerConfig>>
+      listeners_to_remove;
   for (const auto& listener : listener_manager_.listeners()) {
     listeners_to_remove.emplace(listener.get().name(), listener);
   }

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -389,8 +389,8 @@ ListenerManagerImpl::getListenerByName(ListenerList& listeners, const std::strin
   return ret;
 }
 
-std::vector<std::reference_wrapper<Listener>> ListenerManagerImpl::listeners() {
-  std::vector<std::reference_wrapper<Listener>> ret;
+std::vector<std::reference_wrapper<Network::ListenerConfig>> ListenerManagerImpl::listeners() {
+  std::vector<std::reference_wrapper<Network::ListenerConfig>> ret;
   ret.reserve(active_listeners_.size());
   for (const auto& listener : active_listeners_) {
     ret.push_back(*listener);

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -84,7 +84,7 @@ public:
 
   // Server::ListenerManager
   bool addOrUpdateListener(const envoy::api::v2::Listener& config, bool modifiable) override;
-  std::vector<std::reference_wrapper<Listener>> listeners() override;
+  std::vector<std::reference_wrapper<Network::ListenerConfig>> listeners() override;
   uint64_t numConnections() override;
   bool removeListener(const std::string& listener_name) override;
   void startWorkers(GuardDog& guard_dog) override;
@@ -153,7 +153,7 @@ private:
 /**
  * Maps proto config to runtime config for a listener with a network filter chain.
  */
-class ListenerImpl : public Listener,
+class ListenerImpl : public Network::ListenerConfig,
                      public Configuration::FactoryContext,
                      public Network::DrainDecision,
                      public Network::FilterChainFactory,
@@ -196,7 +196,7 @@ public:
   DrainManager& localDrainManager() const { return *local_drain_manager_; }
   void setSocket(const Network::ListenSocketSharedPtr& socket);
 
-  // Server::Listener
+  // Network::ListenerConfig
   Network::FilterChainFactory& filterChainFactory() override { return *this; }
   Network::ListenSocket& socket() override { return *socket_; }
   bool bindToPort() override { return bind_to_port_; }

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -27,7 +27,7 @@ WorkerImpl::WorkerImpl(ThreadLocal::Instance& tls, TestHooks& hooks,
   tls_.registerThread(*dispatcher_, false);
 }
 
-void WorkerImpl::addListener(Listener& listener, AddListenerCompletion completion) {
+void WorkerImpl::addListener(Network::ListenerConfig& listener, AddListenerCompletion completion) {
   // All listener additions happen via post. However, we must deal with the case where the listener
   // can not be created on the worker. There is a race condition where 2 processes can successfully
   // bind to an address, but then fail to listen() with EADDRINUSE. During initial startup, we want
@@ -42,7 +42,7 @@ void WorkerImpl::addListener(Listener& listener, AddListenerCompletion completio
   });
 }
 
-void WorkerImpl::addListenerWorker(Listener& listener) {
+void WorkerImpl::addListenerWorker(Network::ListenerConfig& listener) {
   const Network::ListenerOptions listener_options = {.bind_to_port_ = listener.bindToPort(),
                                                      .use_proxy_proto_ = listener.useProxyProto(),
                                                      .use_original_dst_ = listener.useOriginalDst(),
@@ -68,7 +68,8 @@ uint64_t WorkerImpl::numConnections() {
   return ret;
 }
 
-void WorkerImpl::removeListener(Listener& listener, std::function<void()> completion) {
+void WorkerImpl::removeListener(Network::ListenerConfig& listener,
+                                std::function<void()> completion) {
   ASSERT(thread_);
   const uint64_t listener_tag = listener.listenerTag();
   dispatcher_->post([this, listener_tag, completion]() -> void {
@@ -92,7 +93,7 @@ void WorkerImpl::stop() {
   }
 }
 
-void WorkerImpl::stopListener(Listener& listener) {
+void WorkerImpl::stopListener(Network::ListenerConfig& listener) {
   ASSERT(thread_);
   const uint64_t listener_tag = listener.listenerTag();
   dispatcher_->post([this, listener_tag]() -> void { handler_->stopListeners(listener_tag); });

--- a/source/server/worker_impl.h
+++ b/source/server/worker_impl.h
@@ -41,16 +41,16 @@ public:
              Network::ConnectionHandlerPtr handler);
 
   // Server::Worker
-  void addListener(Listener& listener, AddListenerCompletion completion) override;
+  void addListener(Network::ListenerConfig& listener, AddListenerCompletion completion) override;
   uint64_t numConnections() override;
-  void removeListener(Listener& listener, std::function<void()> completion) override;
+  void removeListener(Network::ListenerConfig& listener, std::function<void()> completion) override;
   void start(GuardDog& guard_dog) override;
   void stop() override;
-  void stopListener(Listener& listener) override;
+  void stopListener(Network::ListenerConfig& listener) override;
   void stopListeners() override;
 
 private:
-  void addListenerWorker(Listener& listener);
+  void addListenerWorker(Network::ListenerConfig& listener);
   void threadRoutine(GuardDog& guard_dog);
 
   ThreadLocal::Instance& tls_;

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -22,6 +22,14 @@ using testing::_;
 namespace Envoy {
 namespace Network {
 
+MockListenerConfig::MockListenerConfig() {
+  ON_CALL(*this, filterChainFactory()).WillByDefault(ReturnRef(filter_chain_factory_));
+  ON_CALL(*this, socket()).WillByDefault(ReturnRef(socket_));
+  ON_CALL(*this, listenerScope()).WillByDefault(ReturnRef(scope_));
+  ON_CALL(*this, name()).WillByDefault(ReturnRef(name_));
+}
+MockListenerConfig::~MockListenerConfig() {}
+
 MockConnectionCallbacks::MockConnectionCallbacks() {}
 MockConnectionCallbacks::~MockConnectionCallbacks() {}
 

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -9,6 +9,8 @@
 #include "envoy/network/filter.h"
 #include "envoy/network/transport_socket.h"
 
+#include "common/stats/stats_impl.h"
+
 #include "test/mocks/event/mocks.h"
 #include "test/test_common/printers.h"
 
@@ -224,6 +226,28 @@ public:
   MOCK_METHOD0(close, void());
 
   Address::InstanceConstSharedPtr local_address_;
+};
+
+class MockListenerConfig : public ListenerConfig {
+public:
+  MockListenerConfig();
+  ~MockListenerConfig();
+
+  MOCK_METHOD0(filterChainFactory, FilterChainFactory&());
+  MOCK_METHOD0(socket, ListenSocket&());
+  MOCK_METHOD0(defaultSslContext, Ssl::ServerContext*());
+  MOCK_METHOD0(useProxyProto, bool());
+  MOCK_METHOD0(bindToPort, bool());
+  MOCK_METHOD0(useOriginalDst, bool());
+  MOCK_METHOD0(perConnectionBufferLimitBytes, uint32_t());
+  MOCK_METHOD0(listenerScope, Stats::Scope&());
+  MOCK_METHOD0(listenerTag, uint64_t());
+  MOCK_CONST_METHOD0(name, const std::string&());
+
+  testing::NiceMock<MockFilterChainFactory> filter_chain_factory_;
+  testing::NiceMock<MockListenSocket> socket_;
+  Stats::IsolatedStoreImpl scope_;
+  std::string name_;
 };
 
 class MockListener : public Listener {

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -59,29 +59,23 @@ MockListenerComponentFactory::~MockListenerComponentFactory() {}
 MockListenerManager::MockListenerManager() {}
 MockListenerManager::~MockListenerManager() {}
 
-MockListener::MockListener() {
-  ON_CALL(*this, filterChainFactory()).WillByDefault(ReturnRef(filter_chain_factory_));
-  ON_CALL(*this, socket()).WillByDefault(ReturnRef(socket_));
-  ON_CALL(*this, listenerScope()).WillByDefault(ReturnRef(scope_));
-  ON_CALL(*this, name()).WillByDefault(ReturnRef(name_));
-}
-MockListener::~MockListener() {}
-
 MockWorkerFactory::MockWorkerFactory() {}
 MockWorkerFactory::~MockWorkerFactory() {}
 
 MockWorker::MockWorker() {
   ON_CALL(*this, addListener(_, _))
-      .WillByDefault(Invoke([this](Listener&, AddListenerCompletion completion) -> void {
-        EXPECT_EQ(nullptr, add_listener_completion_);
-        add_listener_completion_ = completion;
-      }));
+      .WillByDefault(
+          Invoke([this](Network::ListenerConfig&, AddListenerCompletion completion) -> void {
+            EXPECT_EQ(nullptr, add_listener_completion_);
+            add_listener_completion_ = completion;
+          }));
 
   ON_CALL(*this, removeListener(_, _))
-      .WillByDefault(Invoke([this](Listener&, std::function<void()> completion) -> void {
-        EXPECT_EQ(nullptr, remove_listener_completion_);
-        remove_listener_completion_ = completion;
-      }));
+      .WillByDefault(
+          Invoke([this](Network::ListenerConfig&, std::function<void()> completion) -> void {
+            EXPECT_EQ(nullptr, remove_listener_completion_);
+            remove_listener_completion_ = completion;
+          }));
 }
 MockWorker::~MockWorker() {}
 

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -165,34 +165,12 @@ public:
   ~MockListenerManager();
 
   MOCK_METHOD2(addOrUpdateListener, bool(const envoy::api::v2::Listener& config, bool modifiable));
-  MOCK_METHOD0(listeners, std::vector<std::reference_wrapper<Listener>>());
+  MOCK_METHOD0(listeners, std::vector<std::reference_wrapper<Network::ListenerConfig>>());
   MOCK_METHOD0(numConnections, uint64_t());
   MOCK_METHOD1(removeListener, bool(const std::string& listener_name));
   MOCK_METHOD1(startWorkers, void(GuardDog& guard_dog));
   MOCK_METHOD0(stopListeners, void());
   MOCK_METHOD0(stopWorkers, void());
-};
-
-class MockListener : public Listener {
-public:
-  MockListener();
-  ~MockListener();
-
-  MOCK_METHOD0(filterChainFactory, Network::FilterChainFactory&());
-  MOCK_METHOD0(socket, Network::ListenSocket&());
-  MOCK_METHOD0(defaultSslContext, Ssl::ServerContext*());
-  MOCK_METHOD0(useProxyProto, bool());
-  MOCK_METHOD0(bindToPort, bool());
-  MOCK_METHOD0(useOriginalDst, bool());
-  MOCK_METHOD0(perConnectionBufferLimitBytes, uint32_t());
-  MOCK_METHOD0(listenerScope, Stats::Scope&());
-  MOCK_METHOD0(listenerTag, uint64_t());
-  MOCK_CONST_METHOD0(name, const std::string&());
-
-  testing::NiceMock<Network::MockFilterChainFactory> filter_chain_factory_;
-  testing::NiceMock<Network::MockListenSocket> socket_;
-  Stats::IsolatedStoreImpl scope_;
-  std::string name_;
 };
 
 class MockWorkerFactory : public WorkerFactory {
@@ -224,12 +202,14 @@ public:
   }
 
   // Server::Worker
-  MOCK_METHOD2(addListener, void(Listener& listener, AddListenerCompletion completion));
+  MOCK_METHOD2(addListener,
+               void(Network::ListenerConfig& listener, AddListenerCompletion completion));
   MOCK_METHOD0(numConnections, uint64_t());
-  MOCK_METHOD2(removeListener, void(Listener& listener, std::function<void()> completion));
+  MOCK_METHOD2(removeListener,
+               void(Network::ListenerConfig& listener, std::function<void()> completion));
   MOCK_METHOD1(start, void(GuardDog& guard_dog));
   MOCK_METHOD0(stop, void());
-  MOCK_METHOD1(stopListener, void(Listener& listener));
+  MOCK_METHOD1(stopListener, void(Network::ListenerConfig& listener));
   MOCK_METHOD0(stopListeners, void());
 
   AddListenerCompletion add_listener_completion_;

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -80,7 +80,7 @@ public:
   }
 
   void makeListenersAndExpectCall(const std::vector<std::string>& listener_names) {
-    std::vector<std::reference_wrapper<Listener>> refs;
+    std::vector<std::reference_wrapper<Network::ListenerConfig>> refs;
     listeners_.clear();
     for (const auto& name : listener_names) {
       listeners_.emplace_back();
@@ -104,7 +104,7 @@ public:
   Http::AsyncClient::Callbacks* callbacks_{};
 
 private:
-  std::list<NiceMock<MockListener>> listeners_;
+  std::list<NiceMock<Network::MockListenerConfig>> listeners_;
 };
 
 // Negative test for protoc-gen-validate constraints.

--- a/test/server/worker_impl_test.cc
+++ b/test/server/worker_impl_test.cc
@@ -44,7 +44,7 @@ TEST_F(WorkerImplTest, BasicFlow) {
 
   // Before a worker is started adding a listener will be posted and will get added when the
   // thread starts running.
-  NiceMock<MockListener> listener;
+  NiceMock<Network::MockListenerConfig> listener;
   ON_CALL(listener, listenerTag()).WillByDefault(Return(1));
   EXPECT_CALL(*handler_, addListener(_, _, _, 1, _))
       .WillOnce(InvokeWithoutArgs([current_thread_id]() -> void {
@@ -59,7 +59,7 @@ TEST_F(WorkerImplTest, BasicFlow) {
   ci.waitReady();
 
   // After a worker is started adding/stopping/removing a listener happens on the worker thread.
-  NiceMock<MockListener> listener2;
+  NiceMock<Network::MockListenerConfig> listener2;
   ON_CALL(listener2, listenerTag()).WillByDefault(Return(2));
   EXPECT_CALL(*handler_, addListener(_, _, _, 2, _))
       .WillOnce(InvokeWithoutArgs([current_thread_id]() -> void {
@@ -90,7 +90,7 @@ TEST_F(WorkerImplTest, BasicFlow) {
   ci.waitReady();
 
   // Now test adding and removing a listener without stopping it first.
-  NiceMock<MockListener> listener3;
+  NiceMock<Network::MockListenerConfig> listener3;
   ON_CALL(listener3, listenerTag()).WillByDefault(Return(3));
   EXPECT_CALL(*handler_, addListener(_, _, _, 3, _))
       .WillOnce(InvokeWithoutArgs([current_thread_id]() -> void {
@@ -116,7 +116,7 @@ TEST_F(WorkerImplTest, BasicFlow) {
 TEST_F(WorkerImplTest, ListenerException) {
   InSequence s;
 
-  NiceMock<MockListener> listener;
+  NiceMock<Network::MockListenerConfig> listener;
   ON_CALL(listener, listenerTag()).WillByDefault(Return(1));
   EXPECT_CALL(*handler_, addListener(_, _, _, 1, _))
       .WillOnce(Throw(Network::CreateListenerException("failed")));


### PR DESCRIPTION
Moving Server::Listener to Network::ListenerConfig helps avoid
dependency from Network namespace to Server namespace in following
changes.

Risk Level: Low
Requested-by: Matt Klein <mklein@lyft.com>
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
