### PR TITLE
ci: use ubuntu:16.04

### DIFF
--- a/ci/Dockerfile-envoy-image
+++ b/ci/Dockerfile-envoy-image
@@ -1,3 +1,3 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 ADD build_release_stripped/envoy /usr/local/bin/envoy


### PR DESCRIPTION
*title*: ci: use ubuntu:16.04

*Description*:
To use ubuntu:16.04 instead of ubuntu:14.04 for ci image.

*Risk Level*: Low

*Testing*:
manual testing

*Docs Changes*:
N/A

Fixes #2374

Signed-off-by: Dhi Aurrahman <dio@hooq.tv>