### PR TITLE
build: 'check_format.py check' reports line number

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -140,7 +140,7 @@ def executeCommand(command, error_message, file_path,
       if (e.returncode != 0 and e.returncode != 1):
           print "ERROR: something went wrong while executing: %s" % e.cmd
           sys.exit(1)
-      # In case we can't find line number, call printError at first.
+      # In case we can't find any line numbers, call printError at first.
       printError(error_message + " for file: %s" % (file_path))
       for line in e.output.splitlines():
         for num in regex.findall(line):

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -46,7 +46,7 @@ def checkNamespace(file_path):
 def whitelistedForProtobufDeps(file_path):
   return any(path_segment in file_path for path_segment in GOOGLE_PROTOBUF_WHITELIST)
 
-def findPatternAndPrintError(pattern, file_path, error_message):
+def findSubstringAndPrintError(pattern, file_path, error_message):
   with open(file_path) as f:
     text = f.read()
     if pattern in text:
@@ -62,7 +62,7 @@ def checkProtobufExternalDepsBuild(file_path):
     return True
   message = ("%s has unexpected direct external dependency on protobuf, use "
     "//source/common/protobuf instead." % file_path)
-  return findPatternAndPrintError('"protobuf"', file_path, message)
+  return findSubstringAndPrintError('"protobuf"', file_path, message)
 
 
 def checkProtobufExternalDeps(file_path):
@@ -87,7 +87,7 @@ def isBuildFile(file_path):
 
 def checkFileContents(file_path):
   message = "%s has over-enthusiastic spaces:" % file_path
-  findPatternAndPrintError('.  ', file_path, message)
+  findSubstringAndPrintError('.  ', file_path, message)
 
 
 def fixFileContents(file_path):

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -36,7 +36,7 @@ def checkNamespace(file_path):
   with open(file_path) as f:
     text = f.read()
     if not re.search('^\s*namespace\s+Envoy\s*{', text, re.MULTILINE) and \
-       not re.search('NOLINT\(namespace-envoy\)', text, re.MULTILINE):
+       not 'NOLINT(namespace-envoy)' in text:
       printError("Unable to find Envoy namespace or NOLINT(namespace-envoy) for file: %s" % file_path)
       return False
   return True
@@ -52,13 +52,12 @@ def checkProtobufExternalDepsBuild(file_path):
   pattern = '"protobuf"'
   with open(file_path) as f:
     text = f.read()
-    if re.search(pattern, text, re.MULTILINE):
+    if pattern in text:
       printError(
           "%s has unexpected direct external dependency on protobuf, use "
           "//source/common/protobuf instead." % file_path)
-      regex = re.compile(pattern)
       for i, line in enumerate(text.splitlines()):
-        if regex.search(line):
+        if pattern in line:
           printError("  %s:%s" % (file_path, i + 1))
       return False
     return True
@@ -69,8 +68,7 @@ def checkProtobufExternalDeps(file_path):
     return True
   with open(file_path) as f:
     text = f.read()
-    if re.search('"google/protobuf', text, re.MULTILINE) or re.search(
-        "google::protobuf", text, re.MULTILINE):
+    if '"google/protobuf' in text or "google::protobuf" in text:
       printError(
           "%s has unexpected direct dependency on google.protobuf, use "
           "the definitions in common/protobuf/protobuf.h instead." % file_path)
@@ -86,14 +84,13 @@ def isBuildFile(file_path):
 
 
 def checkFileContents(file_path):
-  pattern = '\.  '
+  pattern = '.  '
   with open(file_path) as f:
     text = f.read()
-    if re.search(pattern, text, re.MULTILINE):
+    if pattern in text:
       printError("%s has over-enthusiastic spaces:" % file_path)
-      regex = re.compile(pattern)
       for i, line in enumerate(text.splitlines()):
-        if regex.search(line):
+        if pattern in line:
           printError("  %s:%s" % (file_path, i + 1))
       return False
   return True

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -46,21 +46,23 @@ def checkNamespace(file_path):
 def whitelistedForProtobufDeps(file_path):
   return any(path_segment in file_path for path_segment in GOOGLE_PROTOBUF_WHITELIST)
 
-def checkProtobufExternalDepsBuild(file_path):
-  if whitelistedForProtobufDeps(file_path):
-    return True
-  pattern = '"protobuf"'
+def findPatternAndPrintError(pattern, file_path, error_message):
   with open(file_path) as f:
     text = f.read()
     if pattern in text:
-      printError(
-          "%s has unexpected direct external dependency on protobuf, use "
-          "//source/common/protobuf instead." % file_path)
+      printError(error_message)
       for i, line in enumerate(text.splitlines()):
         if pattern in line:
           printError("  %s:%s" % (file_path, i + 1))
       return False
     return True
+
+def checkProtobufExternalDepsBuild(file_path):
+  if whitelistedForProtobufDeps(file_path):
+    return True
+  message = ("%s has unexpected direct external dependency on protobuf, use "
+    "//source/common/protobuf instead." % file_path)
+  return findPatternAndPrintError('"protobuf"', file_path, message)
 
 
 def checkProtobufExternalDeps(file_path):
@@ -84,16 +86,8 @@ def isBuildFile(file_path):
 
 
 def checkFileContents(file_path):
-  pattern = '.  '
-  with open(file_path) as f:
-    text = f.read()
-    if pattern in text:
-      printError("%s has over-enthusiastic spaces:" % file_path)
-      for i, line in enumerate(text.splitlines()):
-        if pattern in line:
-          printError("  %s:%s" % (file_path, i + 1))
-      return False
-  return True
+  message = "%s has over-enthusiastic spaces:" % file_path
+  findPatternAndPrintError('.  ', file_path, message)
 
 
 def fixFileContents(file_path):

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -132,7 +132,7 @@ def executeCommand(command, error_message, file_path,
           print "ERROR: something went wrong while executing: %s" % e.cmd
           sys.exit(1)
       # In case we can't find any line numbers, call printError at first.
-      printError(error_message + " for file: %s" % (file_path))
+      printError("%s for file: %s" % (error_message, file_path))
       for line in e.output.splitlines():
         for num in regex.findall(line):
           printError("  %s:%s" % (file_path, num))


### PR DESCRIPTION
*Description*:
Fixes #2298.

Example outputs:

```
$ ./tools/check_format.py check source/common/stats/statsd.cc
ERROR: header_order.py check failed for file: ./source/common/stats/statsd.cc
ERROR:   ./source/common/stats/statsd.cc:3
ERROR:   ./source/common/stats/statsd.cc:9
ERROR:   ./source/common/stats/statsd.cc:12
ERROR: clang-format check failed for file: ./source/common/stats/statsd.cc
ERROR:   ./source/common/stats/statsd.cc:26
ERROR:   ./source/common/stats/statsd.cc:38
ERROR:   ./source/common/stats/statsd.cc:46
ERROR: check format failed. run 'tools/check_format.py fix'
```

```
$ ./tools/check_format.py check source/common/stats/statsd.h
ERROR: ./source/common/stats/statsd.h has over-enthusiastic spaces:
ERROR:   ./source/common/stats/statsd.h:128
ERROR: header_order.py check failed for file: ./source/common/stats/statsd.h
ERROR:   ./source/common/stats/statsd.h:7
ERROR:   ./source/common/stats/statsd.h:12
ERROR: clang-format check failed for file: ./source/common/stats/statsd.h
ERROR:   ./source/common/stats/statsd.h:29
ERROR:   ./source/common/stats/statsd.h:128
ERROR:   ./source/common/stats/statsd.h:146
ERROR: check format failed. run 'tools/check_format.py fix'
```

```
$ ./tools/check_format.py check source/common/stats/BUILD
ERROR: buildifier check failed for file: ./source/common/stats/BUILD
ERROR:   ./source/common/stats/BUILD:16
ERROR:   ./source/common/stats/BUILD:24
ERROR: ./source/common/stats/BUILD has unexpected direct external dependency on protobuf, use //source/common/protobuf instead.
ERROR:   ./source/common/stats/BUILD:24
ERROR: check format failed. run 'tools/check_format.py fix'
```

*Risk Level*:
Low: Small bug fix or small optional feature.

*Testing*:
Manual testing in both macOS and Linux (Ubuntu 16.04.3 LTS).

*Docs Changes*:
N/A

*Release Notes*:
N/A

Fixes #2298.