### PR TITLE
style: drop unnecessary std::move in return statement

### DIFF
--- a/source/common/redis/command_splitter_impl.cc
+++ b/source/common/redis/command_splitter_impl.cc
@@ -56,7 +56,7 @@ SplitRequestPtr SimpleRequest::create(ConnPool::Instance& conn_pool,
     return nullptr;
   }
 
-  return std::move(request_ptr);
+  return request_ptr;
 }
 
 SplitRequestPtr EvalRequest::create(ConnPool::Instance& conn_pool,
@@ -77,7 +77,7 @@ SplitRequestPtr EvalRequest::create(ConnPool::Instance& conn_pool,
     return nullptr;
   }
 
-  return std::move(request_ptr);
+  return request_ptr;
 }
 
 FragmentedRequest::~FragmentedRequest() {

--- a/source/common/redis/conn_pool_impl.cc
+++ b/source/common/redis/conn_pool_impl.cc
@@ -25,7 +25,7 @@ ClientPtr ClientImpl::create(Upstream::HostConstSharedPtr host, Event::Dispatche
   client->connection_->addReadFilter(Network::ReadFilterSharedPtr{new UpstreamReadFilter(*client)});
   client->connection_->connect();
   client->connection_->noDelay(true);
-  return std::move(client);
+  return client;
 }
 
 ClientImpl::ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -41,7 +41,7 @@ ScopePtr ThreadLocalStoreImpl::createScope(const std::string& name) {
   std::unique_ptr<ScopeImpl> new_scope(new ScopeImpl(*this, name));
   std::unique_lock<std::mutex> lock(lock_);
   scopes_.emplace(new_scope.get());
-  return std::move(new_scope);
+  return new_scope;
 }
 
 std::list<GaugeSharedPtr> ThreadLocalStoreImpl::gauges() const {

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -28,13 +28,13 @@ SlotPtr InstanceImpl::allocateSlot() {
     if (slots_[i] == nullptr) {
       std::unique_ptr<SlotImpl> slot(new SlotImpl(*this, i));
       slots_[i] = slot.get();
-      return std::move(slot);
+      return slot;
     }
   }
 
   std::unique_ptr<SlotImpl> slot(new SlotImpl(*this, slots_.size()));
   slots_.push_back(slot.get());
-  return std::move(slot);
+  return slot;
 }
 
 ThreadLocalObjectSharedPtr InstanceImpl::SlotImpl::get() {

--- a/source/common/tracing/zipkin/zipkin_tracer_impl.cc
+++ b/source/common/tracing/zipkin/zipkin_tracer_impl.cc
@@ -126,7 +126,7 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config, Http::HeaderMa
   }
 
   ZipkinSpanPtr active_span(new ZipkinSpan(*new_zipkin_span, tracer));
-  return std::move(active_span);
+  return active_span;
 }
 
 ReporterImpl::ReporterImpl(Driver& driver, Event::Dispatcher& dispatcher,

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -52,7 +52,7 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
       if (host) {
         ENVOY_LOG(debug, "Using existing host {}.", host->address()->asString());
         host->used(true); // Mark as used.
-        return std::move(host);
+        return host;
       }
       // Add a new host
       const Network::Address::Ip* dst_ip = dst_addr.ip();
@@ -80,7 +80,7 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
           });
         }
 
-        return std::move(host);
+        return host;
       } else {
         ENVOY_LOG(debug, "Failed to create host for {}.", dst_addr.asString());
       }

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -63,7 +63,7 @@ LoadBalancerPtr RingHashLoadBalancer::LoadBalancerFactoryImpl::create() {
   lb->per_priority_load_ = per_priority_load_;
   lb->per_priority_state_ = per_priority_state_;
 
-  return std::move(lb);
+  return lb;
 }
 
 HostConstSharedPtr RingHashLoadBalancer::Ring::chooseHost(uint64_t h) const {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -244,7 +244,7 @@ ClusterSharedPtr ClusterImplBase::create(const envoy::api::v2::Cluster& cluster,
 
   new_cluster->setOutlierDetector(Outlier::DetectorImplFactory::createForCluster(
       *new_cluster, cluster, dispatcher, runtime, outlier_event_logger));
-  return std::move(new_cluster);
+  return new_cluster;
 }
 
 ClusterImplBase::ClusterImplBase(const envoy::api::v2::Cluster& cluster,


### PR DESCRIPTION
*Description*:
On returning std::unique_ptr and std::shared_ptr, it seems we don't need rvalue
reference cast. The pointers implements a move constructor with type
conversion, so compilers can use the move constructor. How about dropping these
rvalue reference casts? If this is a common pitfall we can append this in our style guide. 

Since I've just started learning C++, I might mis-understand something, so please just ignore this noise.

refs:

  - http://en.cppreference.com/w/cpp/language/return
  - https://github.com/gcc-mirror/gcc/blob/gcc-7_2_0-release/libstdc%2B%2B-v3/include/bits/unique_ptr.h#L516-L520
  - https://github.com/gcc-mirror/gcc/blob/gcc-7_2_0-release/libstdc%2B%2B-v3/include/bits/shared_ptr.h#L252-L254
  - LLVM libc++ source code

I can't find any related information about this from latest C++11 specification draft.

*Risk Level*: Low

*Testing*:
Existing tests should cover this.

*Docs Changes*:
N/A

*Release Notes*:
N/A
