### PR TITLE
added proxy support for build

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -42,6 +42,7 @@ e.g. to use the `envoyproxy/envoy-build-centos` image you can run:
 ```bash
 IMAGE_NAME=envoyproxy/envoy-build-centos ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.dev'
 ```
+In case your setup is behind a proxy, set `http_proxy` and `https_proxy` to the proxy servers before invoking the build.
 
 The Envoy binary can be found in `/tmp/envoy-docker-build/envoy/source/exe/envoy-fastbuild` on the Docker host. You
 can control this by setting `ENVOY_DOCKER_BUILD_DIR` in the environment, e.g. to

--- a/ci/README.md
+++ b/ci/README.md
@@ -42,7 +42,12 @@ e.g. to use the `envoyproxy/envoy-build-centos` image you can run:
 ```bash
 IMAGE_NAME=envoyproxy/envoy-build-centos ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.dev'
 ```
+
 In case your setup is behind a proxy, set `http_proxy` and `https_proxy` to the proxy servers before invoking the build.
+
+```bash
+IMAGE_NAME=envoyproxy/envoy-build-centos http_proxy=http://proxy.foo.com:8080 https_proxy=http://proxy.bar.com:8080 ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.dev'
+```
 
 The Envoy binary can be found in `/tmp/envoy-docker-build/envoy/source/exe/envoy-fastbuild` on the Docker host. You
 can control this by setting `ENVOY_DOCKER_BUILD_DIR` in the environment, e.g. to

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -18,7 +18,7 @@ USER_GROUP=root
 
 mkdir -p "${ENVOY_DOCKER_BUILD_DIR}"
 # Since we specify an explicit hash, docker-run will pull from the remote repo if missing.
-docker run --rm -t -i -e http_proxy=${http_proxy} -e https_proxy=${https_proxy} -e HTTP_PROXY=${http_proxy} -e HTTPS_PROXY=${https_proxy} \
+docker run --rm -t -i -e http_proxy=${http_proxy} -e https_proxy=${https_proxy} \
   -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build \
   -v "$PWD":/source -e NUM_CPUS --cap-add SYS_PTRACE "${IMAGE_NAME}":"${IMAGE_ID}" \
   /bin/bash -lc "groupadd --gid $(id -g) envoygroup && useradd --uid $(id -u) --gid $(id -g) \

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -18,7 +18,8 @@ USER_GROUP=root
 
 mkdir -p "${ENVOY_DOCKER_BUILD_DIR}"
 # Since we specify an explicit hash, docker-run will pull from the remote repo if missing.
-docker run --rm -t -i -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build \
+docker run --rm -t -i -e http_proxy=${http_proxy} -e https_proxy=${https_proxy} -e HTTP_PROXY=${http_proxy} -e HTTPS_PROXY=${https_proxy} \
+  -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build \
   -v "$PWD":/source -e NUM_CPUS --cap-add SYS_PTRACE "${IMAGE_NAME}":"${IMAGE_ID}" \
   /bin/bash -lc "groupadd --gid $(id -g) envoygroup && useradd --uid $(id -u) --gid $(id -g) \
   --no-create-home --home-dir /source envoybuild && su envoybuild -c \"cd source && $*\""


### PR DESCRIPTION
*title*: added support to build in a proxy env


*Description*:

it adds http_proxy env variables which can be used while building the image
user is expected to set http_proxy and https_proxy in the env before running the build command.

*Risk Level*: Low | Medium | High
Low

*Testing*:
tested in a proxy env 
