### PR TITLE
Fixing a (downstream) msan failure

### DIFF
--- a/test/common/common/shared_memory_hash_set_test.cc
+++ b/test/common/common/shared_memory_hash_set_test.cc
@@ -32,12 +32,12 @@ protected:
   void SetUp() override {
     options_.capacity = 100;
     options_.num_slots = 67;
-    mem_size_ = SharedMemoryHashSet<TestValue>::numBytes(options_);
-    memory_.reset(new uint8_t[mem_size_]);
+    const uint32_t mem_size = SharedMemoryHashSet<TestValue>::numBytes(options_);
+    memory_.reset(new uint8_t[mem_size]);
+    memset(memory_.get(), 0, mem_size);
   }
 
   SharedMemoryHashSetOptions options_;
-  uint32_t mem_size_;
   std::unique_ptr<uint8_t[]> memory_;
 };
 


### PR DESCRIPTION
When the structure of shared memory is
[100 options slots][control struct] and we try parse it as [99 options][control struct] we end up parsing the control struct from the uninitialized options memory.   Fixed via memset.

*Risk Level*: n/a (test fix)
*Testing*: exactly.
*Release Notes*: n/a