### PR TITLE
server: fix SharedMemoryHashSet removal problem and make sanityCheck catch such issues

### DIFF
--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -174,7 +174,6 @@ envoy_cc_library(
     ],
     deps = [
         ":assert_lib",
-        ":hash_lib",
         ":logger_lib",
     ],
 )

--- a/source/common/common/shared_memory_hash_set.h
+++ b/source/common/common/shared_memory_hash_set.h
@@ -220,7 +220,7 @@ public:
     const uint32_t slot = computeSlot(key);
     uint32_t* next = nullptr;
     for (uint32_t* cptr = &slots_[slot]; *cptr != Sentinal; cptr = next) {
-      uint32_t cell_index = *cptr;
+      const uint32_t cell_index = *cptr;
       Cell& cell = getCell(cell_index);
       if (cell.value.key() == key) {
         // Splice current cell out of slot-chain.
@@ -283,7 +283,7 @@ private:
     }
 
     // Initialize the free-cell list.
-    uint32_t last_cell = options.capacity - 1;
+    const uint32_t last_cell = options.capacity - 1;
     for (uint32_t cell_index = 0; cell_index < last_cell; ++cell_index) {
       Cell& cell = getCell(cell_index);
       cell.next_cell = cell_index + 1;

--- a/source/common/common/shared_memory_hash_set.h
+++ b/source/common/common/shared_memory_hash_set.h
@@ -141,15 +141,15 @@ public:
     }
 
     uint32_t num_free_entries = 0;
+    uint32_t expected_free_entries = control_->options.capacity - control_->size;
     for (uint32_t cell_index = control_->free_cell_index; cell_index != Sentinal;
          cell_index = getCell(cell_index).next_cell) {
       ++num_free_entries;
-      if (num_free_entries > control_->options.capacity) {
-        // Don't infinite-loop with a corruption, but break immediately.
+      if (num_free_entries > expected_free_entries) {
+        // Don't infinite-loop with a corruption; break when we see there's a problem.
         break;
       }
     }
-    uint32_t expected_free_entries = control_->options.capacity - control_->size;
     if (num_free_entries != expected_free_entries) {
       ENVOY_LOG(error, "SharedMemoryHashSet has wrong number of free entries: {}, expected {}",
                 num_free_entries, expected_free_entries);

--- a/source/common/stats/BUILD
+++ b/source/common/stats/BUILD
@@ -21,6 +21,7 @@ envoy_cc_library(
         "//include/envoy/server:options_interface",
         "//include/envoy/stats:stats_interface",
         "//source/common/common:assert_lib",
+        "//source/common/common:hash_lib",
         "//source/common/common:utility_lib",
         "//source/common/config:well_known_names",
         "//source/common/protobuf",

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -134,6 +134,7 @@ struct RawStatData {
    * Returns true if object is in use.
    */
   bool initialized() { return name_[0] != '\0'; }
+
   /**
    * Returns the name as a string_view. This is required by SharedMemoryHashSet.
    */

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -16,6 +16,7 @@
 #include "envoy/stats/stats.h"
 
 #include "common/common/assert.h"
+#include "common/common/hash.h"
 #include "common/protobuf/protobuf.h"
 
 #include "absl/strings/string_view.h"
@@ -120,15 +121,19 @@ struct RawStatData {
   /**
    * Initializes this object to have the specified key,
    * a refcount of 1, and all other values zero. This is required by
-   * SharedMemoryHashSet
+   * SharedMemoryHashSet.
    */
   void initialize(absl::string_view key);
+
+  /**
+   * Returns a hash of the key. This is required by SharedMemoryHashSet.
+   */
+  static uint64_t hash(absl::string_view key) { return HashUtil::xxHash64(key); }
 
   /**
    * Returns true if object is in use.
    */
   bool initialized() { return name_[0] != '\0'; }
-
   /**
    * Returns the name as a string_view. This is required by SharedMemoryHashSet.
    */

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -76,5 +76,8 @@ envoy_cc_test(
 envoy_cc_test(
     name = "shared_memory_hash_set_test",
     srcs = ["shared_memory_hash_set_test.cc"],
-    deps = ["//source/common/common:shared_memory_hash_set_lib"],
+    deps = [
+        "//source/common/common:hash_lib",
+        "//source/common/common:shared_memory_hash_set_lib",
+    ],
 )

--- a/test/common/common/shared_memory_hash_set_test.cc
+++ b/test/common/common/shared_memory_hash_set_test.cc
@@ -79,13 +79,13 @@ TEST_F(SharedMemoryHashSetTest, putRemove) {
   setUp<TestValue>();
   {
     SharedMemoryHashSet<TestValue> hash_set1(options_, true, memory_.get());
-    ASSERT_TRUE(hash_set1.sanityCheck());
+    hash_set1.sanityCheck();
     EXPECT_EQ(0, hash_set1.size());
     EXPECT_EQ(nullptr, hash_set1.get("no such key"));
     ValueCreatedPair vc = hash_set1.insert("good key");
     EXPECT_TRUE(vc.second);
     vc.first->number = 12345;
-    ASSERT_TRUE(hash_set1.sanityCheck());
+    hash_set1.sanityCheck();
     EXPECT_EQ(1, hash_set1.size());
     EXPECT_EQ(12345, hash_set1.get("good key")->number);
     EXPECT_EQ(nullptr, hash_set1.get("no such key"));
@@ -104,9 +104,9 @@ TEST_F(SharedMemoryHashSetTest, putRemove) {
     EXPECT_EQ(nullptr, hash_set2.get("no such key"));
     EXPECT_EQ(6789, hash_set2.get("good key")->number) << hash_set2.toString();
     EXPECT_FALSE(hash_set2.remove("no such key"));
-    ASSERT_TRUE(hash_set2.sanityCheck());
+    hash_set2.sanityCheck();
     EXPECT_TRUE(hash_set2.remove("good key"));
-    ASSERT_TRUE(hash_set2.sanityCheck());
+    hash_set2.sanityCheck();
     EXPECT_EQ(nullptr, hash_set2.get("good key"));
     EXPECT_EQ(0, hash_set2.size());
   }
@@ -125,7 +125,7 @@ TEST_F(SharedMemoryHashSetTest, tooManyValues) {
     ASSERT_NE(nullptr, value);
     value->number = i;
   }
-  ASSERT_TRUE(hash_set1.sanityCheck());
+  hash_set1.sanityCheck();
   EXPECT_EQ(options_.capacity, hash_set1.size());
 
   for (uint32_t i = 0; i < options_.capacity; ++i) {
@@ -133,18 +133,18 @@ TEST_F(SharedMemoryHashSetTest, tooManyValues) {
     ASSERT_NE(nullptr, value);
     EXPECT_EQ(i, value->number);
   }
-  ASSERT_TRUE(hash_set1.sanityCheck());
+  hash_set1.sanityCheck();
 
   // We can't fit one more value.
   EXPECT_EQ(nullptr, hash_set1.insert(keys[options_.capacity]).first);
-  ASSERT_TRUE(hash_set1.sanityCheck());
+  hash_set1.sanityCheck();
   EXPECT_EQ(options_.capacity, hash_set1.size());
 
   // Now remove everything one by one.
   for (uint32_t i = 0; i < options_.capacity; ++i) {
     EXPECT_TRUE(hash_set1.remove(keys[i]));
   }
-  ASSERT_TRUE(hash_set1.sanityCheck());
+  hash_set1.sanityCheck();
   EXPECT_EQ(0, hash_set1.size());
 
   // Now we can put in that last key we weren't able to before.
@@ -153,7 +153,7 @@ TEST_F(SharedMemoryHashSetTest, tooManyValues) {
   value->number = 314519;
   EXPECT_EQ(1, hash_set1.size());
   EXPECT_EQ(314519, hash_set1.get(keys[options_.capacity])->number);
-  ASSERT_TRUE(hash_set1.sanityCheck());
+  hash_set1.sanityCheck();
 }
 
 TEST_F(SharedMemoryHashSetTest, severalKeysZeroHash) {
@@ -163,11 +163,18 @@ TEST_F(SharedMemoryHashSetTest, severalKeysZeroHash) {
   hash_set1.insert("two").first->number = 2;
   hash_set1.insert("three").first->number = 3;
   EXPECT_TRUE(hash_set1.remove("two"));
-  ASSERT_TRUE(hash_set1.sanityCheck());
+  hash_set1.sanityCheck();
   hash_set1.insert("four").first->number = 4;
-  ASSERT_TRUE(hash_set1.sanityCheck());
+  hash_set1.sanityCheck();
   EXPECT_FALSE(hash_set1.remove("two"));
-  ASSERT_TRUE(hash_set1.sanityCheck());
+  hash_set1.sanityCheck();
+}
+
+TEST_F(SharedMemoryHashSetTest, sanityCheckZeroedMemory) {
+  setUp<TestValueZeroHash>();
+  SharedMemoryHashSet<TestValueZeroHash> hash_set1(options_, true, memory_.get());
+  memset(memory_.get(), 0, hash_set1.numBytes());
+  EXPECT_DEATH(hash_set1.sanityCheck(), "");
 }
 
 } // namespace Envoy

--- a/test/common/common/shared_memory_hash_set_test.cc
+++ b/test/common/common/shared_memory_hash_set_test.cc
@@ -1,5 +1,3 @@
-#include "common/common/shared_memory_hash_set.h"
-
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
@@ -7,6 +5,7 @@
 #include <string>
 
 #include "common/common/hash.h"
+#include "common/common/shared_memory_hash_set.h"
 
 #include "absl/strings/string_view.h"
 #include "fmt/format.h"
@@ -38,16 +37,12 @@ protected:
 
   // TestValue that uses a real hash function.
   struct TestValue : public TestValueBase {
-    static uint64_t hash(absl::string_view key) {
-      return HashUtil::xxHash64(key);
-    }
+    static uint64_t hash(absl::string_view key) { return HashUtil::xxHash64(key); }
   };
-
 
   typedef SharedMemoryHashSet<TestValue>::ValueCreatedPair ValueCreatedPair;
 
-  template<class TestValueClass>
-  void setUp() {
+  template <class TestValueClass> void setUp() {
     options_.capacity = 100;
     options_.num_slots = 5;
     const uint32_t mem_size = SharedMemoryHashSet<TestValueClass>::numBytes(options_);

--- a/test/common/common/shared_memory_hash_set_test.cc
+++ b/test/common/common/shared_memory_hash_set_test.cc
@@ -170,7 +170,7 @@ TEST_F(SharedMemoryHashSetTest, severalKeysZeroHash) {
   hash_set1.sanityCheck();
 }
 
-TEST_F(SharedMemoryHashSetTest, sanityCheckZeroedMemory) {
+TEST_F(SharedMemoryHashSetTest, sanityCheckZeroedMemoryDeathTest) {
   setUp<TestValueZeroHash>();
   SharedMemoryHashSet<TestValueZeroHash> hash_set1(options_, true, memory_.get());
   memset(memory_.get(), 0, hash_set1.numBytes());

--- a/test/common/common/shared_memory_hash_set_test.cc
+++ b/test/common/common/shared_memory_hash_set_test.cc
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <cstdint>
+#include <cstdio>
 #include <memory>
 #include <string>
 
@@ -22,6 +23,7 @@ protected:
       name[xfer] = '\0';
     }
     static size_t size() { return sizeof(TestValue); }
+    static uint64_t hash(absl::string_view /* key */) { return 0; }
 
     int64_t number;
     char name[256];
@@ -31,7 +33,7 @@ protected:
 
   void SetUp() override {
     options_.capacity = 100;
-    options_.num_slots = 67;
+    options_.num_slots = 5;
     const uint32_t mem_size = SharedMemoryHashSet<TestValue>::numBytes(options_);
     memory_.reset(new uint8_t[mem_size]);
     memset(memory_.get(), 0, mem_size);
@@ -64,13 +66,13 @@ TEST_F(SharedMemoryHashSetTest, initAndAttach) {
 TEST_F(SharedMemoryHashSetTest, putRemove) {
   {
     SharedMemoryHashSet<TestValue> hash_set1(options_, true, memory_.get());
-    EXPECT_TRUE(hash_set1.sanityCheck());
+    ASSERT_TRUE(hash_set1.sanityCheck());
     EXPECT_EQ(0, hash_set1.size());
     EXPECT_EQ(nullptr, hash_set1.get("no such key"));
     ValueCreatedPair vc = hash_set1.insert("good key");
     EXPECT_TRUE(vc.second);
     vc.first->number = 12345;
-    EXPECT_TRUE(hash_set1.sanityCheck());
+    ASSERT_TRUE(hash_set1.sanityCheck());
     EXPECT_EQ(1, hash_set1.size());
     EXPECT_EQ(12345, hash_set1.get("good key")->number);
     EXPECT_EQ(nullptr, hash_set1.get("no such key"));
@@ -85,12 +87,13 @@ TEST_F(SharedMemoryHashSetTest, putRemove) {
   {
     // Now init a new hash-map with the same memory.
     SharedMemoryHashSet<TestValue> hash_set2(options_, false, memory_.get());
-    ;
     EXPECT_EQ(1, hash_set2.size());
     EXPECT_EQ(nullptr, hash_set2.get("no such key"));
     EXPECT_EQ(6789, hash_set2.get("good key")->number) << hash_set2.toString();
     EXPECT_FALSE(hash_set2.remove("no such key"));
+    ASSERT_TRUE(hash_set2.sanityCheck());
     EXPECT_TRUE(hash_set2.remove("good key"));
+    ASSERT_TRUE(hash_set2.sanityCheck());
     EXPECT_EQ(nullptr, hash_set2.get("good key"));
     EXPECT_EQ(0, hash_set2.size());
   }
@@ -108,7 +111,7 @@ TEST_F(SharedMemoryHashSetTest, tooManyValues) {
     ASSERT_NE(nullptr, value);
     value->number = i;
   }
-  EXPECT_TRUE(hash_set1.sanityCheck());
+  ASSERT_TRUE(hash_set1.sanityCheck());
   EXPECT_EQ(options_.capacity, hash_set1.size());
 
   for (uint32_t i = 0; i < options_.capacity; ++i) {
@@ -116,18 +119,18 @@ TEST_F(SharedMemoryHashSetTest, tooManyValues) {
     ASSERT_NE(nullptr, value);
     EXPECT_EQ(i, value->number);
   }
-  EXPECT_TRUE(hash_set1.sanityCheck());
+  ASSERT_TRUE(hash_set1.sanityCheck());
 
   // We can't fit one more value.
   EXPECT_EQ(nullptr, hash_set1.insert(keys[options_.capacity]).first);
-  EXPECT_TRUE(hash_set1.sanityCheck()) << hash_set1.toString();
+  ASSERT_TRUE(hash_set1.sanityCheck());
   EXPECT_EQ(options_.capacity, hash_set1.size());
 
   // Now remove everything one by one.
   for (uint32_t i = 0; i < options_.capacity; ++i) {
     EXPECT_TRUE(hash_set1.remove(keys[i]));
   }
-  EXPECT_TRUE(hash_set1.sanityCheck());
+  ASSERT_TRUE(hash_set1.sanityCheck());
   EXPECT_EQ(0, hash_set1.size());
 
   // Now we can put in that last key we weren't able to before.
@@ -136,7 +139,20 @@ TEST_F(SharedMemoryHashSetTest, tooManyValues) {
   value->number = 314519;
   EXPECT_EQ(1, hash_set1.size());
   EXPECT_EQ(314519, hash_set1.get(keys[options_.capacity])->number);
-  EXPECT_TRUE(hash_set1.sanityCheck());
+  ASSERT_TRUE(hash_set1.sanityCheck());
+}
+
+TEST_F(SharedMemoryHashSetTest, severalKeys) {
+  SharedMemoryHashSet<TestValue> hash_set1(options_, true, memory_.get());
+  hash_set1.insert("one").first->number = 1;
+  hash_set1.insert("two").first->number = 2;
+  hash_set1.insert("three").first->number = 3;
+  EXPECT_TRUE(hash_set1.remove("two"));
+  ASSERT_TRUE(hash_set1.sanityCheck());
+  hash_set1.insert("four").first->number = 4;
+  ASSERT_TRUE(hash_set1.sanityCheck());
+  EXPECT_FALSE(hash_set1.remove("two"));
+  ASSERT_TRUE(hash_set1.sanityCheck());
 }
 
 } // namespace Envoy


### PR DESCRIPTION
*Description*: the remove() method did not leave the free-list in a coherent state.
This was triggered by tests, but not detected, because sanityCheck() did not verify the coherence of the free-list.

*Risk Level*: Low

*Testing*:
//test/...

Fixes https://github.com/envoyproxy/envoy/issues/2407
