### PR TITLE
router/stats: handle invalid regexes in config

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -8,8 +8,11 @@
 #include <string>
 #include <vector>
 
+#include "envoy/common/exception.h"
+
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_split.h"
+#include "fmt/format.h"
 #include "spdlog/spdlog.h"
 
 namespace Envoy {
@@ -255,6 +258,14 @@ uint32_t Primes::findPrimeLargerThan(uint32_t x) {
     x += 2;
   }
   return x;
+}
+
+std::regex RegexUtil::parseRegex(const std::string& regex, std::regex::flag_type flags) {
+  try {
+    return std::regex(regex, flags);
+  } catch (std::regex_error& e) {
+    throw EnvoyException(fmt::format("Invalid regex '{}': {}", regex, e.what()));
+  }
 }
 
 } // namespace Envoy

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -261,9 +261,11 @@ uint32_t Primes::findPrimeLargerThan(uint32_t x) {
 }
 
 std::regex RegexUtil::parseRegex(const std::string& regex, std::regex::flag_type flags) {
+  // TODO(zuercher): In the future, PGV (https://github.com/lyft/protoc-gen-validate) annotations
+  // may allow us to remove this in favor of direct validation of regular expressions.
   try {
     return std::regex(regex, flags);
-  } catch (std::regex_error& e) {
+  } catch (const std::regex_error& e) {
     throw EnvoyException(fmt::format("Invalid regex '{}': {}", regex, e.what()));
   }
 }

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <regex>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -269,6 +270,22 @@ public:
    * Finds the next prime number larger than x.
    */
   static uint32_t findPrimeLargerThan(uint32_t x);
+};
+
+/**
+ * Utilities for constructing regular expressions.
+ */
+class RegexUtil {
+public:
+  /*
+   * Constructs a std::regex, converting any std::regex_error exception into an EnvoyException.
+   * @param regex std::string containing the regular expression to parse.
+   * @param flags std::regex::flag_type containing parser flags. Defaults to std::regex::optimize.
+   * @return std::regex constructed from regex and flags
+   * @throw EnvoyException if the regex string is invalid.
+   */
+  static std::regex parseRegex(const std::string& regex,
+                               std::regex::flag_type flags = std::regex::optimize);
 };
 
 } // namespace Envoy

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -578,7 +578,7 @@ RegexRouteEntryImpl::RegexRouteEntryImpl(const VirtualHostImpl& vhost,
                                          const envoy::api::v2::Route& route,
                                          Runtime::Loader& loader)
     : RouteEntryImplBase(vhost, route, loader),
-      regex_(std::regex{route.match().regex().c_str(), std::regex::optimize}) {}
+      regex_(RegexUtil::parseRegex(route.match().regex().c_str())) {}
 
 void RegexRouteEntryImpl::finalizeRequestHeaders(
     Http::HeaderMap& headers, const RequestInfo::RequestInfo& request_info) const {
@@ -668,7 +668,7 @@ VirtualHostImpl::VirtualClusterEntry::VirtualClusterEntry(
   }
 
   const std::string pattern = virtual_cluster.pattern();
-  pattern_ = std::regex{pattern, std::regex::optimize};
+  pattern_ = RegexUtil::parseRegex(pattern);
   name_ = virtual_cluster.name();
 }
 

--- a/source/common/router/config_utility.h
+++ b/source/common/router/config_utility.h
@@ -10,6 +10,7 @@
 #include "envoy/upstream/resource_manager.h"
 
 #include "common/common/empty_string.h"
+#include "common/common/utility.h"
 #include "common/config/rds_json.h"
 #include "common/http/headers.h"
 #include "common/http/utility.h"
@@ -31,8 +32,8 @@ public:
     // exact string matching.
     HeaderData(const envoy::api::v2::HeaderMatcher& config)
         : name_(config.name()), value_(config.value()),
-          regex_pattern_(value_, std::regex::optimize),
-          is_regex_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, regex, false)) {}
+          is_regex_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, regex, false)),
+          regex_pattern_(is_regex_ ? RegexUtil::parseRegex(value_) : std::regex()) {}
     HeaderData(const Json::Object& config)
         : HeaderData([&config] {
             envoy::api::v2::HeaderMatcher header_matcher;
@@ -42,8 +43,8 @@ public:
 
     const Http::LowerCaseString name_;
     const std::string value_;
-    const std::regex regex_pattern_;
     const bool is_regex_;
+    const std::regex regex_pattern_;
   };
 
   // A QueryParameterMatcher specifies one "name" or "name=value" element
@@ -53,8 +54,8 @@ public:
   public:
     QueryParameterMatcher(const envoy::api::v2::QueryParameterMatcher& config)
         : name_(config.name()), value_(config.value()),
-          regex_pattern_(value_, std::regex::optimize),
-          is_regex_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, regex, false)) {}
+          is_regex_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, regex, false)),
+          regex_pattern_(is_regex_ ? RegexUtil::parseRegex(value_) : std::regex()) {}
 
     /**
      * Check if the query parameters for a request contain a match for this
@@ -67,8 +68,8 @@ public:
   private:
     const std::string name_;
     const std::string value_;
-    const std::regex regex_pattern_;
     const bool is_regex_;
+    const std::regex regex_pattern_;
   };
 
   /**

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -62,7 +62,7 @@ std::string Utility::sanitizeStatsName(const std::string& name) {
 }
 
 TagExtractorImpl::TagExtractorImpl(const std::string& name, const std::string& regex)
-    : name_(name), regex_(regex) {}
+    : name_(name), regex_(RegexUtil::parseRegex(regex)) {}
 
 TagExtractorPtr TagExtractorImpl::createTagExtractor(const std::string& name,
                                                      const std::string& regex) {

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -58,7 +58,10 @@ envoy_cc_test(
     external_deps = [
         "abseil_strings",
     ],
-    deps = ["//source/common/common:utility_lib"],
+    deps = [
+        "//source/common/common:utility_lib",
+        "//test/test_common:utility_lib",
+    ],
 )
 
 envoy_cc_test(

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -3,7 +3,11 @@
 #include <string>
 #include <vector>
 
+#include "envoy/common/exception.h"
+
 #include "common/common/utility.h"
+
+#include "test/test_common/utility.h"
 
 #include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
@@ -286,6 +290,22 @@ TEST(Primes, findPrimeLargerThan) {
   EXPECT_EQ(67, Primes::findPrimeLargerThan(62));
   EXPECT_EQ(107, Primes::findPrimeLargerThan(103));
   EXPECT_EQ(10007, Primes::findPrimeLargerThan(9991));
+}
+
+TEST(RegexUtil, parseRegex) {
+  EXPECT_THROW_WITH_REGEX(RegexUtil::parseRegex("(+invalid)"), EnvoyException,
+                          "Invalid regex '\\(\\+invalid\\)': .+");
+
+  {
+    std::regex regex = RegexUtil::parseRegex("x*");
+    EXPECT_NE(0, regex.flags() & std::regex::optimize);
+  }
+
+  {
+    std::regex regex = RegexUtil::parseRegex("x*", std::regex::icase);
+    EXPECT_NE(0, regex.flags() & std::regex::icase);
+    EXPECT_EQ(0, regex.flags() & std::regex::optimize);
+  }
 }
 
 } // namespace Envoy

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -508,7 +508,7 @@ virtual_hosts:
 
   EXPECT_THROW_WITH_REGEX(
       ConfigImpl(parseRouteConfigurationFromV2Yaml(invalid_virtual_cluster), runtime, cm, true),
-      EnvoyException, "Invalid regex '\\^/\\(\\+invalid)\\':");
+      EnvoyException, "Invalid regex '\\^/\\(\\+invalid\\)':");
 }
 
 // Validates behavior of request_headers_to_add at router, vhost, and route levels.

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -476,6 +476,41 @@ TEST(RouteMatcherTest, TestRoutes) {
   }
 }
 
+TEST(RouteMatcherTest, TestRoutesWithInvalidRegex) {
+  std::string invalid_route = R"EOF(
+virtual_hosts:
+  - name: regex
+    domains: ["*"]
+    routes:
+      - match: { regex: "/(+invalid)" }
+        route: { cluster: "regex" }
+  )EOF";
+
+  std::string invalid_virtual_cluster = R"EOF(
+virtual_hosts:
+  - name: regex
+    domains: ["*"]
+    routes:
+      - match: { prefix: "/" }
+        route: { cluster: "regex" }
+    virtual_clusters:
+      - pattern: "^/(+invalid)"
+        name: "invalid"
+  )EOF";
+
+  NiceMock<Runtime::MockLoader> runtime;
+  NiceMock<Upstream::MockClusterManager> cm;
+  NiceMock<Envoy::RequestInfo::MockRequestInfo> request_info;
+
+  EXPECT_THROW_WITH_REGEX(
+      ConfigImpl(parseRouteConfigurationFromV2Yaml(invalid_route), runtime, cm, true),
+      EnvoyException, "Invalid regex '/\\(\\+invalid\\)':");
+
+  EXPECT_THROW_WITH_REGEX(
+      ConfigImpl(parseRouteConfigurationFromV2Yaml(invalid_virtual_cluster), runtime, cm, true),
+      EnvoyException, "Invalid regex '\\^/\\(\\+invalid)\\':");
+}
+
 // Validates behavior of request_headers_to_add at router, vhost, and route levels.
 TEST(RouteMatcherTest, TestAddRemoveRequestHeaders) {
   std::string json = R"EOF(
@@ -995,6 +1030,46 @@ TEST(RouteMatcherTest, HeaderMatchedRouting) {
   }
 }
 
+// Verify the fixes for https://github.com/envoyproxy/envoy/issues/2406
+TEST(RouteMatcherTest, InvalidHeaderMatchedRoutingConfig) {
+  std::string value_with_regex_chars = R"EOF(
+virtual_hosts:
+  - name: local_service
+    domains: ["*"]
+    routes:
+      - match:
+          prefix: "/"
+          headers:
+            - name: test_header
+              value: "(+not a regex)"
+        route: { cluster: "local_service" }
+  )EOF";
+
+  std::string invalid_regex = R"EOF(
+virtual_hosts:
+  - name: local_service
+    domains: ["*"]
+    routes:
+      - match:
+          prefix: "/"
+          headers:
+            - name: test_header
+              value: "(+invalid regex)"
+              regex: true
+        route: { cluster: "local_service" }
+  )EOF";
+
+  NiceMock<Runtime::MockLoader> runtime;
+  NiceMock<Upstream::MockClusterManager> cm;
+
+  EXPECT_NO_THROW(
+      ConfigImpl(parseRouteConfigurationFromV2Yaml(value_with_regex_chars), runtime, cm, true));
+
+  EXPECT_THROW_WITH_REGEX(
+      ConfigImpl(parseRouteConfigurationFromV2Yaml(invalid_regex), runtime, cm, true),
+      EnvoyException, "Invalid regex");
+}
+
 TEST(RouteMatcherTest, QueryParamMatchedRouting) {
   std::string json = R"EOF(
 {
@@ -1086,6 +1161,46 @@ TEST(RouteMatcherTest, QueryParamMatchedRouting) {
     EXPECT_EQ("local_service_with_multiple_query_parameters",
               config.route(headers, 0)->routeEntry()->clusterName());
   }
+}
+
+// Verify the fixes for https://github.com/envoyproxy/envoy/issues/2406
+TEST(RouteMatcherTest, InvalidQueryParamMatchedRoutingConfig) {
+  std::string value_with_regex_chars = R"EOF(
+virtual_hosts:
+  - name: local_service
+    domains: ["*"]
+    routes:
+      - match:
+          prefix: "/"
+          query_parameters:
+            - name: test_param
+              value: "(+not a regex)"
+        route: { cluster: "local_service" }
+  )EOF";
+
+  std::string invalid_regex = R"EOF(
+virtual_hosts:
+  - name: local_service
+    domains: ["*"]
+    routes:
+      - match:
+          prefix: "/"
+          query_parameters:
+            - name: test_param
+              value: "(+invalid regex)"
+              regex: true
+        route: { cluster: "local_service" }
+  )EOF";
+
+  NiceMock<Runtime::MockLoader> runtime;
+  NiceMock<Upstream::MockClusterManager> cm;
+
+  EXPECT_NO_THROW(
+      ConfigImpl(parseRouteConfigurationFromV2Yaml(value_with_regex_chars), runtime, cm, true));
+
+  EXPECT_THROW_WITH_REGEX(
+      ConfigImpl(parseRouteConfigurationFromV2Yaml(invalid_regex), runtime, cm, true),
+      EnvoyException, "Invalid regex");
 }
 
 class RouterMatcherHashPolicyTest : public testing::Test {

--- a/test/common/stats/stats_impl_test.cc
+++ b/test/common/stats/stats_impl_test.cc
@@ -110,6 +110,11 @@ TEST(TagExtractorTest, EmptyName) {
                             EnvoyException, "tag_name cannot be empty");
 }
 
+TEST(TagExtractorTest, BadRegex) {
+  EXPECT_THROW_WITH_REGEX(TagExtractorImpl::createTagExtractor("cluster_name", "+invalid"),
+                          EnvoyException, "Invalid regex '\\+invalid':");
+}
+
 class DefaultTagRegexTester {
 public:
   DefaultTagRegexTester() {


### PR DESCRIPTION
*Description*:
The Envoy API accepts regular expressions for several configuration options. If an invalid regular expression is provided, STL throws `std::regex_error`, which is uncaught and causes the sudden termination of Envoy. Replace use of the `std::regex(std::string)` constructor with calls to a new utility `RegexUtil::parseRegex()` which converts the `std::regex_error` into an `EnvoyException`, allowing the invalid configuration to be handled gracefully.

*Risk Level*: Low

*Testing*:
Unit tests for behavior or new utility function and testing of invalid regular expressions in configuration.

*Release Notes*: N/A

*Fixes*: #2406

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
