### PR TITLE
ci: forces groupadd to do not fail when group already exists

### DIFF
--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -20,5 +20,5 @@ mkdir -p "${ENVOY_DOCKER_BUILD_DIR}"
 # Since we specify an explicit hash, docker-run will pull from the remote repo if missing.
 docker run --rm -t -i -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build \
   -v "$PWD":/source -e NUM_CPUS --cap-add SYS_PTRACE "${IMAGE_NAME}":"${IMAGE_ID}" \
-  /bin/bash -lc "groupadd --gid $(id -g) envoygroup && useradd --uid $(id -u) --gid $(id -g) \
+  /bin/bash -lc "groupadd --gid $(id -g) -f envoygroup && useradd --uid $(id -u) --gid $(id -g) \
   --no-create-home --home-dir /source envoybuild && su envoybuild -c \"cd source && $*\""


### PR DESCRIPTION
*Description*: This PR fixes #2379 by passing force to docker command. This option causes the command to exit with success status if the specified group already exists.

*Risk Level*: Low

*Testing*: manual OsX

Signed-off-by: Gabriel <gsagula@gmail.com>
