### PR TITLE
grpc: client integration tests, Grpc::AsyncClientImpl behavior changes.

### DIFF
--- a/source/common/grpc/async_client_impl.cc
+++ b/source/common/grpc/async_client_impl.cc
@@ -97,7 +97,6 @@ void AsyncStreamImpl::onHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
   }
   if (end_stream) {
     trailerResponse(grpc_status, grpc_message);
-    return;
   }
 }
 
@@ -126,7 +125,6 @@ void AsyncStreamImpl::onData(Buffer::Instance& data, bool end_stream) {
     Http::HeaderMapPtr empty_trailers = std::make_unique<Http::HeaderMapImpl>();
     callbacks_.onReceiveTrailingMetadata(std::move(empty_trailers));
     streamError(Status::GrpcStatus::Unknown);
-    return;
   }
 }
 

--- a/source/common/grpc/async_client_impl.cc
+++ b/source/common/grpc/async_client_impl.cc
@@ -97,10 +97,10 @@ void AsyncStreamImpl::onHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
     onTrailers(std::move(headers));
     return;
   }
+  trailers_only_ = false;
 }
 
 void AsyncStreamImpl::onData(Buffer::Instance& data, bool end_stream) {
-  trailers_only_ = false;
   decoded_frames_.clear();
   if (!decoder_.decode(data, decoded_frames_)) {
     streamError(Status::GrpcStatus::Internal);

--- a/source/common/grpc/async_client_impl.h
+++ b/source/common/grpc/async_client_impl.h
@@ -67,6 +67,7 @@ private:
   void streamError(Status::GrpcStatus grpc_status) { streamError(grpc_status, EMPTY_STRING); }
 
   void cleanup();
+  void trailerResponse(Optional<Status::GrpcStatus> grpc_status, const std::string& grpc_message);
 
   Event::Dispatcher* dispatcher_{};
   Http::MessagePtr headers_message_;
@@ -74,7 +75,6 @@ private:
   const Protobuf::MethodDescriptor& service_method_;
   AsyncStreamCallbacks& callbacks_;
   const Optional<std::chrono::milliseconds>& timeout_;
-  bool trailers_only_{true};
   bool http_reset_{};
   Http::AsyncClient::Stream* stream_{};
   Decoder decoder_;

--- a/source/common/grpc/async_client_impl.h
+++ b/source/common/grpc/async_client_impl.h
@@ -68,30 +68,13 @@ private:
 
   void cleanup();
 
-  void closeLocal() {
-    local_closed_ |= true;
-    if (complete()) {
-      cleanup();
-    }
-  }
-
-  void closeRemote() {
-    remote_closed_ |= true;
-    if (complete()) {
-      cleanup();
-    }
-  }
-
-  bool complete() const { return local_closed_ && remote_closed_; }
-
   Event::Dispatcher* dispatcher_{};
   Http::MessagePtr headers_message_;
   AsyncClientImpl& parent_;
   const Protobuf::MethodDescriptor& service_method_;
   AsyncStreamCallbacks& callbacks_;
   const Optional<std::chrono::milliseconds>& timeout_;
-  bool local_closed_{};
-  bool remote_closed_{};
+  bool trailers_only_{true};
   bool http_reset_{};
   Http::AsyncClient::Stream* stream_{};
   Decoder decoder_;

--- a/test/common/grpc/BUILD
+++ b/test/common/grpc/BUILD
@@ -13,16 +13,11 @@ envoy_cc_test(
     name = "async_client_impl_test",
     srcs = ["async_client_impl_test.cc"],
     deps = [
-        "//source/common/common:enum_to_int",
         "//source/common/grpc:async_client_lib",
-        "//source/common/grpc:common_lib",
-        "//test/mocks/buffer:buffer_mocks",
-        "//test/mocks/grpc:grpc_mocks",
         "//test/mocks/http:http_mocks",
         "//test/mocks/tracing:tracing_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/proto:helloworld_proto",
-        "//test/test_common:utility_lib",
     ],
 )
 
@@ -56,6 +51,31 @@ envoy_cc_test(
         "//source/common/http:headers_lib",
         "//test/mocks/upstream:upstream_mocks",
         "//test/proto:helloworld_proto",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "grpc_client_integration_test",
+    srcs = ["grpc_client_integration_test.cc"],
+    deps = [
+        "//source/common/common:enum_to_int",
+        "//source/common/event:dispatcher_lib",
+        "//source/common/grpc:async_client_lib",
+        "//source/common/http/http2:conn_pool_lib",
+        "//source/common/network:connection_lib",
+        "//source/common/network:raw_buffer_socket_lib",
+        "//source/common/stats:stats_lib",
+        "//test/integration:integration_lib",
+        "//test/mocks/grpc:grpc_mocks",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/local_info:local_info_mocks",
+        "//test/mocks/router:router_mocks",
+        "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/tracing:tracing_mocks",
+        "//test/mocks/upstream:upstream_mocks",
+        "//test/proto:helloworld_proto",
+        "//test/test_common:environment_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/common/grpc/async_client_impl_test.cc
+++ b/test/common/grpc/async_client_impl_test.cc
@@ -17,9 +17,9 @@ namespace Envoy {
 namespace Grpc {
 namespace {
 
-class AsyncClientImplTest : public testing::Test {
+class EnvoyAsyncClientImplTest : public testing::Test {
 public:
-  AsyncClientImplTest()
+  EnvoyAsyncClientImplTest()
       : method_descriptor_(helloworld::Greeter::descriptor()->FindMethodByName("SayHello")),
         grpc_client_(new AsyncClientImpl(cm_, "test_cluster")) {
     ON_CALL(cm_, httpAsyncClientForCluster("test_cluster")).WillByDefault(ReturnRef(http_client_));
@@ -33,7 +33,7 @@ public:
 
 // Validate that a failure in the HTTP client returns immediately with status
 // UNAVAILABLE.
-TEST_F(AsyncClientImplTest, StreamHttpStartFail) {
+TEST_F(EnvoyAsyncClientImplTest, StreamHttpStartFail) {
   MockAsyncStreamCallbacks<helloworld::HelloReply> grpc_callbacks;
   ON_CALL(http_client_, start(_, _, false)).WillByDefault(Return(nullptr));
   EXPECT_CALL(grpc_callbacks, onRemoteClose(Status::GrpcStatus::Unavailable, ""));
@@ -43,7 +43,7 @@ TEST_F(AsyncClientImplTest, StreamHttpStartFail) {
 
 // Validate that a failure in the HTTP client returns immediately with status
 // UNAVAILABLE.
-TEST_F(AsyncClientImplTest, RequestHttpStartFail) {
+TEST_F(EnvoyAsyncClientImplTest, RequestHttpStartFail) {
   MockAsyncRequestCallbacks<helloworld::HelloReply> grpc_callbacks;
   ON_CALL(http_client_, start(_, _, true)).WillByDefault(Return(nullptr));
   EXPECT_CALL(grpc_callbacks, onFailure(Status::GrpcStatus::Unavailable, "", _));
@@ -67,7 +67,7 @@ TEST_F(AsyncClientImplTest, RequestHttpStartFail) {
 
 // Validate that a failure to sendHeaders() in the HTTP client returns
 // immediately with status INTERNAL.
-TEST_F(AsyncClientImplTest, StreamHttpSendHeadersFail) {
+TEST_F(EnvoyAsyncClientImplTest, StreamHttpSendHeadersFail) {
   MockAsyncStreamCallbacks<helloworld::HelloReply> grpc_callbacks;
   Http::AsyncClient::StreamCallbacks* http_callbacks;
   Http::MockAsyncClientStream http_stream;
@@ -92,7 +92,7 @@ TEST_F(AsyncClientImplTest, StreamHttpSendHeadersFail) {
 
 // Validate that a failure to sendHeaders() in the HTTP client returns
 // immediately with status INTERNAL.
-TEST_F(AsyncClientImplTest, RequestHttpSendHeadersFail) {
+TEST_F(EnvoyAsyncClientImplTest, RequestHttpSendHeadersFail) {
   MockAsyncRequestCallbacks<helloworld::HelloReply> grpc_callbacks;
   Http::AsyncClient::StreamCallbacks* http_callbacks;
   Http::MockAsyncClientStream http_stream;

--- a/test/common/grpc/async_client_impl_test.cc
+++ b/test/common/grpc/async_client_impl_test.cc
@@ -1,21 +1,14 @@
-#include "common/common/enum_to_int.h"
 #include "common/grpc/async_client_impl.h"
-#include "common/grpc/common.h"
 
-#include "test/mocks/buffer/mocks.h"
-#include "test/mocks/grpc/mocks.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/tracing/mocks.h"
 #include "test/mocks/upstream/mocks.h"
 #include "test/proto/helloworld.pb.h"
-#include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 using testing::Invoke;
-using testing::Mock;
-using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
 using testing::_;
@@ -24,298 +17,23 @@ namespace Envoy {
 namespace Grpc {
 namespace {
 
-const std::string HELLO_REQUEST = "ABC";
-// We expect the 5 byte header to only have a length of 5 indicating the size of the protobuf. The
-// protobuf begins with 0x0a, indicating this is the first field of type string. This is followed
-// by 0x03 for the number of characters and the name ABC set above.
-const char HELLO_REQUEST_DATA[] = "\x00\x00\x00\x00\x05\x0a\x03\x41\x42\x43";
-const size_t HELLO_REQUEST_SIZE = sizeof(HELLO_REQUEST_DATA) - 1;
-
-const std::string HELLO_REPLY = "DEFG";
-const char HELLO_REPLY_DATA[] = "\x00\x00\x00\x00\x06\x0a\x04\x44\x45\x46\x47";
-const size_t HELLO_REPLY_SIZE = sizeof(HELLO_REPLY_DATA) - 1;
-
-MATCHER_P(HelloworldReplyEq, rhs, "") { return arg.message() == rhs; }
-
-typedef std::vector<std::pair<Http::LowerCaseString, std::string>> TestMetadata;
-
-class HelloworldStream : public MockAsyncStreamCallbacks<helloworld::HelloReply> {
+class AsyncClientImplTest : public testing::Test {
 public:
-  HelloworldStream(Http::MockAsyncClientStream* http_stream) : http_stream_(http_stream) {
-    ON_CALL(*http_stream_, reset()).WillByDefault(Invoke([this]() { http_callbacks_->onReset(); }));
-  }
-
-  ~HelloworldStream() { Mock::VerifyAndClear(http_stream_); }
-
-  void sendRequest(bool end_stream = false) {
-    helloworld::HelloRequest request;
-    request.set_name(HELLO_REQUEST);
-
-    EXPECT_CALL(*http_stream_,
-                sendData(BufferStringEqual(std::string(HELLO_REQUEST_DATA, HELLO_REQUEST_SIZE)),
-                         end_stream));
-    grpc_stream_->sendMessage(request, end_stream);
-    Mock::VerifyAndClearExpectations(http_stream_);
-  }
-
-  void sendServerInitialMetadata(TestMetadata& metadata) {
-    Http::HeaderMapPtr reply_headers{new Http::TestHeaderMapImpl{{":status", "200"}}};
-    for (auto& value : metadata) {
-      reply_headers->addReference(value.first, value.second);
-    }
-    EXPECT_CALL(*this, onReceiveInitialMetadata_(HeaderMapEqualRef(reply_headers.get())));
-    http_callbacks_->onHeaders(std::move(reply_headers), false);
-  }
-
-  void sendReply() {
-    Buffer::OwnedImpl reply_buffer(HELLO_REPLY_DATA, HELLO_REPLY_SIZE);
-
-    helloworld::HelloReply reply;
-    reply.set_message(HELLO_REPLY);
-    EXPECT_CALL(*this, onReceiveMessage_(HelloworldReplyEq(HELLO_REPLY)));
-    http_callbacks_->onData(reply_buffer, false);
-  }
-
-  void expectGrpcStatus(Status::GrpcStatus grpc_status,
-                        const std::string& grpc_message = std::string()) {
-    if (grpc_status != Status::GrpcStatus::Ok) {
-      EXPECT_CALL(*http_stream_, reset());
-    }
-    EXPECT_CALL(*this, onRemoteClose(grpc_status, grpc_message))
-        .WillOnce(Invoke([this](Status::GrpcStatus grpc_status, const std::string&) {
-          if (grpc_status != Status::GrpcStatus::Ok) {
-            clearStream();
-          }
-        }));
-  }
-
-  void sendServerTrailers(Status::GrpcStatus grpc_status, const std::string& grpc_message,
-                          TestMetadata metadata, bool trailers_only = false) {
-    auto* reply_trailers =
-        new Http::TestHeaderMapImpl{{"grpc-status", std::to_string(enumToInt(grpc_status))}};
-    if (!grpc_message.empty()) {
-      reply_trailers->addCopy("grpc-message", grpc_message);
-    }
-    if (trailers_only) {
-      reply_trailers->addCopy(":status", "200");
-    }
-    for (const auto& value : metadata) {
-      reply_trailers->addCopy(value.first, value.second);
-    }
-    Http::HeaderMapPtr reply_trailers_ptr{reply_trailers};
-    if (grpc_status == Status::GrpcStatus::Ok) {
-      EXPECT_CALL(*this, onReceiveTrailingMetadata_(HeaderMapEqualRef(reply_trailers)));
-    }
-    expectGrpcStatus(grpc_status, grpc_message);
-    if (trailers_only) {
-      http_callbacks_->onHeaders(std::move(reply_trailers_ptr), true);
-    } else {
-      http_callbacks_->onTrailers(std::move(reply_trailers_ptr));
-    }
-  }
-
-  void closeStream() {
-    EXPECT_CALL(*http_stream_, sendData(BufferStringEqual(""), true));
-    EXPECT_CALL(*http_stream_, reset());
-    grpc_stream_->closeStream();
-    clearStream();
-  }
-
-  void clearStream() { grpc_stream_ = nullptr; }
-
-  Http::AsyncClient::StreamCallbacks* http_callbacks_{};
-  Http::MockAsyncClientStream* http_stream_;
-  AsyncStream* grpc_stream_{};
-};
-
-class HelloworldRequest : public MockAsyncRequestCallbacks<helloworld::HelloReply> {
-public:
-  HelloworldRequest(Http::MockAsyncClientStream* http_stream) : http_stream_(http_stream) {}
-
-  ~HelloworldRequest() { Mock::VerifyAndClear(http_stream_); }
-
-  void sendReply() {
-    Http::HeaderMapPtr reply_headers{new Http::TestHeaderMapImpl{{":status", "200"}}};
-    http_callbacks_->onHeaders(std::move(reply_headers), false);
-
-    Buffer::OwnedImpl reply_buffer(HELLO_REPLY_DATA, HELLO_REPLY_SIZE);
-    helloworld::HelloReply reply;
-    reply.set_message(HELLO_REPLY);
-    http_callbacks_->onData(reply_buffer, false);
-
-    Http::HeaderMapPtr reply_trailers{new Http::TestHeaderMapImpl{{"grpc-status", "0"}}};
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().GRPC_STATUS_CODE, "0"));
-    EXPECT_CALL(*this, onSuccess_(HelloworldReplyEq(HELLO_REPLY), _));
-    EXPECT_CALL(*child_span_, finishSpan());
-    EXPECT_CALL(*http_stream_, reset());
-    http_callbacks_->onTrailers(std::move(reply_trailers));
-  }
-
-  Http::AsyncClient::StreamCallbacks* http_callbacks_{};
-  Http::MockAsyncClientStream* http_stream_;
-  AsyncRequest* grpc_request_{};
-  Tracing::MockSpan* child_span_{new Tracing::MockSpan()};
-};
-
-class GrpcAsyncClientImplTest : public testing::Test {
-public:
-  GrpcAsyncClientImplTest()
+  AsyncClientImplTest()
       : method_descriptor_(helloworld::Greeter::descriptor()->FindMethodByName("SayHello")),
         grpc_client_(new AsyncClientImpl(cm_, "test_cluster")) {
     ON_CALL(cm_, httpAsyncClientForCluster("test_cluster")).WillByDefault(ReturnRef(http_client_));
   }
 
-  ~GrpcAsyncClientImplTest() {
-    for (auto* stream : dangling_streams_) {
-      EXPECT_CALL(*stream, reset());
-    }
-  }
-
-  Http::TestHeaderMapImpl expectedHeaders(const TestMetadata& initial_metadata) const {
-    Http::TestHeaderMapImpl headers{{":method", "POST"},
-                                    {":path", "/helloworld.Greeter/SayHello"},
-                                    {":authority", "test_cluster"},
-                                    {"content-type", "application/grpc"},
-                                    {"te", "trailers"}};
-    for (auto& value : initial_metadata) {
-      headers.addReference(value.first, value.second);
-    }
-
-    return headers;
-  }
-
-  std::unique_ptr<HelloworldRequest> createRequest(const TestMetadata& initial_metadata) {
-    http_streams_.emplace_back(new Http::MockAsyncClientStream());
-    std::unique_ptr<HelloworldRequest> request(new HelloworldRequest(http_streams_.back().get()));
-    EXPECT_CALL(*request, onCreateInitialMetadata(_))
-        .WillOnce(Invoke([&initial_metadata](Http::HeaderMap& headers) {
-          for (auto& value : initial_metadata) {
-            headers.addReference(value.first, value.second);
-          }
-        }));
-    const auto headers = expectedHeaders(initial_metadata);
-    EXPECT_CALL(http_client_, start(_, _, true))
-        .WillOnce(Invoke([&request](Http::AsyncClient::StreamCallbacks& callbacks,
-                                    const Optional<std::chrono::milliseconds>&, bool) {
-          request->http_callbacks_ = &callbacks;
-          return request->http_stream_;
-        }));
-
-    const Http::HeaderMapImpl* active_header_map = nullptr;
-    EXPECT_CALL(*(request->http_stream_), sendHeaders(HeaderMapEqualRef(&headers), _))
-        .WillOnce(Invoke([&active_header_map](Http::HeaderMap& headers, bool) {
-          active_header_map = dynamic_cast<const Http::HeaderMapImpl*>(&headers);
-        }));
-    helloworld::HelloRequest request_msg;
-    request_msg.set_name(HELLO_REQUEST);
-    EXPECT_CALL(
-        *(request->http_stream_),
-        sendData(BufferStringEqual(std::string(HELLO_REQUEST_DATA, HELLO_REQUEST_SIZE)), true));
-
-    Tracing::MockSpan active_span;
-
-    EXPECT_CALL(active_span, spawnChild_(_, "async test_cluster egress", _))
-        .WillOnce(Return(request->child_span_));
-    EXPECT_CALL(*request->child_span_,
-                setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, "test_cluster"));
-    EXPECT_CALL(*request->child_span_,
-                setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY));
-    EXPECT_CALL(*request->child_span_, injectContext(_));
-
-    request->grpc_request_ = grpc_client_->send(*method_descriptor_, request_msg, *request,
-                                                active_span, Optional<std::chrono::milliseconds>());
-    EXPECT_NE(request->grpc_request_, nullptr);
-    // The header map should still be valid after grpc_client_->start() returns, since it is
-    // retained by the HTTP async client for the deferred send.
-    EXPECT_EQ(*active_header_map, headers);
-    return request;
-  }
-
-  std::unique_ptr<HelloworldStream> createStream(TestMetadata& initial_metadata) {
-    http_streams_.emplace_back(new Http::MockAsyncClientStream());
-    std::unique_ptr<HelloworldStream> stream(new HelloworldStream(http_streams_.back().get()));
-    EXPECT_CALL(*stream, onCreateInitialMetadata(_))
-        .WillOnce(Invoke([&initial_metadata](Http::HeaderMap& headers) {
-          for (auto& value : initial_metadata) {
-            headers.addReference(value.first, value.second);
-          }
-        }));
-    const auto headers = expectedHeaders(initial_metadata);
-    EXPECT_CALL(http_client_, start(_, _, false))
-        .WillOnce(Invoke([&stream](Http::AsyncClient::StreamCallbacks& callbacks,
-                                   const Optional<std::chrono::milliseconds>&, bool) {
-          stream->http_callbacks_ = &callbacks;
-          return stream->http_stream_;
-        }));
-    const Http::HeaderMapImpl* active_header_map = nullptr;
-    EXPECT_CALL(*(stream->http_stream_), sendHeaders(HeaderMapEqualRef(&headers), _))
-        .WillOnce(Invoke([&active_header_map](Http::HeaderMap& headers, bool) {
-          active_header_map = dynamic_cast<const Http::HeaderMapImpl*>(&headers);
-        }));
-    stream->grpc_stream_ = grpc_client_->start(*method_descriptor_, *stream);
-    EXPECT_NE(stream->grpc_stream_, nullptr);
-    // The header map should still be valid after grpc_client_->start() returns, since it is
-    // retained by the HTTP async client for the deferred send.
-    EXPECT_EQ(*active_header_map, headers);
-    return stream;
-  }
-
-  void expectResetOn(HelloworldStream* stream) {
-    dangling_streams_.push_back(stream->http_stream_);
-  }
-
-  std::vector<Http::MockAsyncClientStream*> dangling_streams_;
-  std::vector<std::unique_ptr<Http::MockAsyncClientStream>> http_streams_;
   const Protobuf::MethodDescriptor* method_descriptor_;
   NiceMock<Http::MockAsyncClient> http_client_;
   NiceMock<Upstream::MockClusterManager> cm_;
   std::unique_ptr<AsyncClientImpl> grpc_client_;
 };
 
-// Validate that a simple request-reply stream works.
-TEST_F(GrpcAsyncClientImplTest, BasicStream) {
-  TestMetadata empty_metadata;
-  auto stream = createStream(empty_metadata);
-  stream->sendRequest();
-  stream->sendServerInitialMetadata(empty_metadata);
-  stream->sendReply();
-  stream->sendServerTrailers(Status::GrpcStatus::Ok, "", empty_metadata);
-  stream->closeStream();
-}
-
-// Validate that a simple request-reply unary RPC works.
-TEST_F(GrpcAsyncClientImplTest, BasicRequest) {
-  TestMetadata empty_metadata;
-  auto request = createRequest(empty_metadata);
-  request->sendReply();
-}
-
-// Validate that multiple streams work.
-TEST_F(GrpcAsyncClientImplTest, MultiStream) {
-  TestMetadata empty_metadata;
-  auto stream_0 = createStream(empty_metadata);
-  auto stream_1 = createStream(empty_metadata);
-  stream_0->sendRequest();
-  stream_1->sendRequest();
-  stream_0->sendServerInitialMetadata(empty_metadata);
-  stream_0->sendReply();
-  stream_1->sendServerTrailers(Status::GrpcStatus::Unavailable, "", empty_metadata);
-  stream_0->sendServerTrailers(Status::GrpcStatus::Ok, "", empty_metadata);
-  stream_0->closeStream();
-}
-
-// Validate that multiple request-reply unary RPCs works.
-TEST_F(GrpcAsyncClientImplTest, MultiRequest) {
-  TestMetadata empty_metadata;
-  auto request_0 = createRequest(empty_metadata);
-  auto request_1 = createRequest(empty_metadata);
-  request_1->sendReply();
-  request_0->sendReply();
-}
-
 // Validate that a failure in the HTTP client returns immediately with status
 // UNAVAILABLE.
-TEST_F(GrpcAsyncClientImplTest, StreamHttpStartFail) {
+TEST_F(AsyncClientImplTest, StreamHttpStartFail) {
   MockAsyncStreamCallbacks<helloworld::HelloReply> grpc_callbacks;
   ON_CALL(http_client_, start(_, _, false)).WillByDefault(Return(nullptr));
   EXPECT_CALL(grpc_callbacks, onRemoteClose(Status::GrpcStatus::Unavailable, ""));
@@ -325,7 +43,7 @@ TEST_F(GrpcAsyncClientImplTest, StreamHttpStartFail) {
 
 // Validate that a failure in the HTTP client returns immediately with status
 // UNAVAILABLE.
-TEST_F(GrpcAsyncClientImplTest, RequestHttpStartFail) {
+TEST_F(AsyncClientImplTest, RequestHttpStartFail) {
   MockAsyncRequestCallbacks<helloworld::HelloReply> grpc_callbacks;
   ON_CALL(http_client_, start(_, _, true)).WillByDefault(Return(nullptr));
   EXPECT_CALL(grpc_callbacks, onFailure(Status::GrpcStatus::Unavailable, "", _));
@@ -349,7 +67,7 @@ TEST_F(GrpcAsyncClientImplTest, RequestHttpStartFail) {
 
 // Validate that a failure to sendHeaders() in the HTTP client returns
 // immediately with status INTERNAL.
-TEST_F(GrpcAsyncClientImplTest, StreamHttpSendHeadersFail) {
+TEST_F(AsyncClientImplTest, StreamHttpSendHeadersFail) {
   MockAsyncStreamCallbacks<helloworld::HelloReply> grpc_callbacks;
   Http::AsyncClient::StreamCallbacks* http_callbacks;
   Http::MockAsyncClientStream http_stream;
@@ -374,7 +92,7 @@ TEST_F(GrpcAsyncClientImplTest, StreamHttpSendHeadersFail) {
 
 // Validate that a failure to sendHeaders() in the HTTP client returns
 // immediately with status INTERNAL.
-TEST_F(GrpcAsyncClientImplTest, RequestHttpSendHeadersFail) {
+TEST_F(AsyncClientImplTest, RequestHttpSendHeadersFail) {
   MockAsyncRequestCallbacks<helloworld::HelloReply> grpc_callbacks;
   Http::AsyncClient::StreamCallbacks* http_callbacks;
   Http::MockAsyncClientStream http_stream;
@@ -409,236 +127,6 @@ TEST_F(GrpcAsyncClientImplTest, RequestHttpSendHeadersFail) {
   auto* grpc_request = grpc_client_->send(*method_descriptor_, request_msg, grpc_callbacks,
                                           active_span, Optional<std::chrono::milliseconds>());
   EXPECT_EQ(grpc_request, nullptr);
-}
-
-// Validate that a non-200 HTTP status results in the gRPC error as per
-// https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md.
-TEST_F(GrpcAsyncClientImplTest, HttpNon200Status) {
-  for (const auto http_response_status : {400, 401, 403, 404, 429, 431}) {
-    TestMetadata empty_metadata;
-    auto stream = createStream(empty_metadata);
-    Http::HeaderMapPtr reply_headers{
-        new Http::TestHeaderMapImpl{{":status", std::to_string(http_response_status)}}};
-    stream->expectGrpcStatus(Common::httpToGrpcStatus(http_response_status));
-    stream->http_callbacks_->onHeaders(std::move(reply_headers), false);
-  }
-}
-
-// Validate that a non-200 HTTP status results in fallback to grpc-status.
-TEST_F(GrpcAsyncClientImplTest, GrpcStatusFallback) {
-  TestMetadata empty_metadata;
-  auto stream = createStream(empty_metadata);
-  Http::HeaderMapPtr reply_headers{new Http::TestHeaderMapImpl{
-      {":status", "404"},
-      {"grpc-status", std::to_string(enumToInt(Status::GrpcStatus::PermissionDenied))},
-      {"grpc-message", "error message"}}};
-  stream->expectGrpcStatus(Status::GrpcStatus::PermissionDenied, "error message");
-  stream->http_callbacks_->onHeaders(std::move(reply_headers), true);
-}
-
-// Validate that a HTTP-level reset is handled as an INTERNAL gRPC error.
-TEST_F(GrpcAsyncClientImplTest, HttpReset) {
-  TestMetadata empty_metadata;
-  auto stream = createStream(empty_metadata);
-  EXPECT_CALL(*stream, onRemoteClose(Status::GrpcStatus::Internal, ""));
-  stream->http_callbacks_->onReset();
-  stream->clearStream();
-}
-
-// Validate that a reply with bad gRPC framing is handled as an INTERNAL gRPC
-// error.
-TEST_F(GrpcAsyncClientImplTest, BadReplyGrpcFraming) {
-  TestMetadata empty_metadata;
-  auto stream = createStream(empty_metadata);
-  stream->sendRequest();
-  stream->sendServerInitialMetadata(empty_metadata);
-  stream->expectGrpcStatus(Status::GrpcStatus::Internal);
-  Buffer::OwnedImpl reply_buffer("\xde\xad\xbe\xef\x00", 5);
-  stream->http_callbacks_->onData(reply_buffer, false);
-}
-
-// Validate that a reply with bad protobuf is handled as an INTERNAL gRPC error.
-TEST_F(GrpcAsyncClientImplTest, BadReplyProtobuf) {
-  TestMetadata empty_metadata;
-  auto stream = createStream(empty_metadata);
-  stream->sendRequest();
-  stream->sendServerInitialMetadata(empty_metadata);
-  stream->expectGrpcStatus(Status::GrpcStatus::Internal);
-  Buffer::OwnedImpl reply_buffer("\x00\x00\x00\x00\x02\xff\xff", 7);
-  stream->http_callbacks_->onData(reply_buffer, false);
-}
-
-// Validate that an out-of-range gRPC status is handled as an INVALID_CODE gRPC
-// error.
-TEST_F(GrpcAsyncClientImplTest, OutOfRangeGrpcStatus) {
-  TestMetadata empty_metadata;
-  auto stream = createStream(empty_metadata);
-  stream->sendServerInitialMetadata(empty_metadata);
-  stream->sendReply();
-  stream->expectGrpcStatus(Status::GrpcStatus::InvalidCode);
-  Http::HeaderMapPtr reply_trailers{
-      new Http::TestHeaderMapImpl{{"grpc-status", std::to_string(0x1337)}}};
-  stream->http_callbacks_->onTrailers(std::move(reply_trailers));
-}
-
-// Validate that a missing gRPC status is handled as an INTERNAL gRPC error.
-TEST_F(GrpcAsyncClientImplTest, MissingGrpcStatus) {
-  TestMetadata empty_metadata;
-  auto stream = createStream(empty_metadata);
-  stream->sendServerInitialMetadata(empty_metadata);
-  stream->sendReply();
-  stream->expectGrpcStatus(Status::GrpcStatus::Internal);
-  Http::HeaderMapPtr reply_trailers{new Http::TestHeaderMapImpl{}};
-  stream->http_callbacks_->onTrailers(std::move(reply_trailers));
-}
-
-// Validate that a reply terminated without trailers is handled as an INTERNAL
-// gRPC error.
-TEST_F(GrpcAsyncClientImplTest, ReplyNoTrailers) {
-  TestMetadata empty_metadata;
-  auto stream = createStream(empty_metadata);
-  stream->sendRequest();
-  stream->sendServerInitialMetadata(empty_metadata);
-  stream->expectGrpcStatus(Status::GrpcStatus::Internal);
-  Buffer::OwnedImpl reply_buffer(HELLO_REPLY_DATA, HELLO_REPLY_SIZE);
-  helloworld::HelloReply reply;
-  reply.set_message(HELLO_REPLY);
-  stream->http_callbacks_->onData(reply_buffer, true);
-}
-
-// Validate that send client initial metadata works.
-TEST_F(GrpcAsyncClientImplTest, StreamClientInitialMetadata) {
-  TestMetadata initial_metadata = {
-      {Http::LowerCaseString("foo"), "bar"},
-      {Http::LowerCaseString("baz"), "blah"},
-  };
-  auto stream = createStream(initial_metadata);
-  expectResetOn(stream.get());
-}
-
-// Validate that send client initial metadata works.
-TEST_F(GrpcAsyncClientImplTest, RequestClientInitialMetadata) {
-  TestMetadata initial_metadata = {
-      {Http::LowerCaseString("foo"), "bar"},
-      {Http::LowerCaseString("baz"), "blah"},
-  };
-  auto request = createRequest(initial_metadata);
-  dangling_streams_.push_back(request->http_stream_);
-}
-
-// Validate that receiving server initial metadata works.
-TEST_F(GrpcAsyncClientImplTest, ServerInitialMetadata) {
-  TestMetadata empty_metadata;
-  auto stream = createStream(empty_metadata);
-  stream->sendRequest();
-  TestMetadata initial_metadata = {
-      {Http::LowerCaseString("foo"), "bar"},
-      {Http::LowerCaseString("baz"), "blah"},
-  };
-  stream->sendServerInitialMetadata(initial_metadata);
-  expectResetOn(stream.get());
-}
-
-// Validate that receiving server trailing metadata works.
-TEST_F(GrpcAsyncClientImplTest, ServerTrailingMetadata) {
-  TestMetadata empty_metadata;
-  auto stream = createStream(empty_metadata);
-  stream->sendRequest();
-  stream->sendServerInitialMetadata(empty_metadata);
-  stream->sendReply();
-  TestMetadata trailing_metadata = {
-      {Http::LowerCaseString("foo"), "bar"},
-      {Http::LowerCaseString("baz"), "blah"},
-  };
-  stream->sendServerTrailers(Status::GrpcStatus::Ok, "", trailing_metadata);
-  expectResetOn(stream.get());
-}
-
-// Validate that a trailers-only response is handled for streams.
-TEST_F(GrpcAsyncClientImplTest, StreamTrailersOnly) {
-  TestMetadata empty_metadata;
-  auto stream = createStream(empty_metadata);
-  stream->sendServerTrailers(Status::GrpcStatus::Ok, "", empty_metadata, true);
-  stream->closeStream();
-}
-
-// Validate that a trailers-only response is handled for requests, where it is
-// an error.
-TEST_F(GrpcAsyncClientImplTest, RequestTrailersOnly) {
-  TestMetadata empty_metadata;
-  auto request = createRequest(empty_metadata);
-  Http::HeaderMapPtr reply_headers{
-      new Http::TestHeaderMapImpl{{":status", "200"}, {"grpc-status", "0"}}};
-  EXPECT_CALL(*request->child_span_, setTag(Tracing::Tags::get().GRPC_STATUS_CODE, "0"));
-  EXPECT_CALL(*request->child_span_, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
-  EXPECT_CALL(*request, onFailure(Status::Internal, "", _));
-  EXPECT_CALL(*request->child_span_, finishSpan());
-  EXPECT_CALL(*request->http_stream_, reset());
-  request->http_callbacks_->onTrailers(std::move(reply_headers));
-}
-
-// Validate that a trailers RESOURCE_EXHAUSTED reply is handled.
-TEST_F(GrpcAsyncClientImplTest, ResourceExhaustedError) {
-  TestMetadata empty_metadata;
-  auto stream = createStream(empty_metadata);
-  stream->sendServerInitialMetadata(empty_metadata);
-  stream->sendReply();
-  stream->sendServerTrailers(Status::GrpcStatus::ResourceExhausted, "error message",
-                             empty_metadata);
-}
-
-// Validate that we can continue to receive after a local close.
-TEST_F(GrpcAsyncClientImplTest, ReceiveAfterLocalClose) {
-  TestMetadata empty_metadata;
-  auto stream = createStream(empty_metadata);
-  stream->sendRequest(true);
-  stream->sendServerInitialMetadata(empty_metadata);
-  stream->sendReply();
-  EXPECT_CALL(*stream->http_stream_, reset());
-  stream->sendServerTrailers(Status::GrpcStatus::Ok, "", empty_metadata);
-}
-
-// Validate that we can continue to send after a remote close.
-TEST_F(GrpcAsyncClientImplTest, SendAfterRemoteClose) {
-  TestMetadata empty_metadata;
-  auto stream = createStream(empty_metadata);
-  stream->sendServerInitialMetadata(empty_metadata);
-  stream->sendReply();
-  stream->sendServerTrailers(Status::GrpcStatus::Ok, "", empty_metadata);
-  stream->sendRequest();
-  stream->closeStream();
-}
-
-// Validate that reset() doesn't explode on a half-closed stream (local).
-TEST_F(GrpcAsyncClientImplTest, ResetAfterCloseLocal) {
-  TestMetadata empty_metadata;
-  auto stream = createStream(empty_metadata);
-  EXPECT_CALL(*stream->http_stream_, sendData(BufferStringEqual(""), true));
-  stream->grpc_stream_->closeStream();
-  EXPECT_CALL(*stream->http_stream_, reset());
-  stream->grpc_stream_->resetStream();
-  stream->clearStream();
-}
-
-// Validate that reset() doesn't explode on a half-closed stream (remote).
-TEST_F(GrpcAsyncClientImplTest, ResetAfterCloseRemote) {
-  TestMetadata empty_metadata;
-  auto stream = createStream(empty_metadata);
-  stream->sendServerTrailers(Status::GrpcStatus::Ok, "", empty_metadata, true);
-  EXPECT_CALL(*stream->http_stream_, reset());
-  stream->grpc_stream_->resetStream();
-  stream->clearStream();
-}
-
-// Validate that request cancel() works.
-TEST_F(GrpcAsyncClientImplTest, CancelRequest) {
-  TestMetadata empty_metadata;
-  auto request = createRequest(empty_metadata);
-  EXPECT_CALL(*request->child_span_,
-              setTag(Tracing::Tags::get().STATUS, Tracing::Tags::get().CANCELED));
-  EXPECT_CALL(*request->child_span_, finishSpan());
-  EXPECT_CALL(*request->http_stream_, reset());
-  request->grpc_request_->cancel();
 }
 
 } // namespace

--- a/test/common/grpc/grpc_client_integration_test.cc
+++ b/test/common/grpc/grpc_client_integration_test.cc
@@ -1,0 +1,656 @@
+#include "common/common/enum_to_int.h"
+#include "common/event/dispatcher_impl.h"
+#include "common/grpc/async_client_impl.h"
+#include "common/http/async_client_impl.h"
+#include "common/http/http2/conn_pool.h"
+#include "common/network/connection_impl.h"
+#include "common/network/raw_buffer_socket.h"
+#include "common/stats/stats_impl.h"
+
+#include "test/integration/fake_upstream.h"
+#include "test/mocks/grpc/mocks.h"
+#include "test/mocks/http/mocks.h"
+#include "test/mocks/local_info/mocks.h"
+#include "test/mocks/router/mocks.h"
+#include "test/mocks/runtime/mocks.h"
+#include "test/mocks/tracing/mocks.h"
+#include "test/mocks/upstream/mocks.h"
+#include "test/proto/helloworld.pb.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::Invoke;
+using testing::InvokeWithoutArgs;
+using testing::NiceMock;
+using testing::Return;
+using testing::ReturnRef;
+using testing::_;
+
+namespace Envoy {
+namespace Grpc {
+namespace {
+
+const char HELLO_REQUEST[] = "ABC";
+const char HELLO_REPLY[] = "DEFG";
+
+MATCHER_P(HelloworldReplyEq, rhs, "") { return arg.message() == rhs; }
+
+typedef std::vector<std::pair<Http::LowerCaseString, std::string>> TestMetadata;
+
+// Use in EXPECT_CALL(foo, bar(_)).WillExitIfNeeded() to exit dispatcher loop if
+// there are no longer any pending events in DispatcherHelper.
+#define WillExitIfNeeded()                                                                         \
+  WillOnce(InvokeWithoutArgs([this] { dispatcher_helper_.exitDispatcherIfNeeded(); }))
+
+// Utility to assist with keeping track of pending gmock expected events when
+// deferring execution to the dispatcher. The dispatcher can be run using this
+// helper until all pending events are completed.
+class DispatcherHelper {
+public:
+  DispatcherHelper(Event::Dispatcher& dispatcher) : dispatcher_(dispatcher) {}
+
+  void exitDispatcherIfNeeded() {
+    ENVOY_LOG_MISC(debug, "Checking exit with {} events pending", pending_stream_events_);
+    ASSERT(pending_stream_events_ > 0);
+    if (--pending_stream_events_ == 0) {
+      dispatcher_.exit();
+    }
+  }
+
+  void runDispatcher() {
+    if (pending_stream_events_ > 0) {
+      dispatcher_.run(Event::Dispatcher::RunType::Block);
+    }
+  }
+
+  void setStreamEventPending() {
+    ++pending_stream_events_;
+    ENVOY_LOG_MISC(debug, "Set event pending, now {} events pending", pending_stream_events_);
+  }
+
+  uint32_t pending_stream_events_{};
+  Event::Dispatcher& dispatcher_;
+};
+
+// Stream related test utilities.
+class HelloworldStream : public MockAsyncStreamCallbacks<helloworld::HelloReply> {
+public:
+  HelloworldStream(DispatcherHelper& dispatcher_helper) : dispatcher_helper_(dispatcher_helper) {}
+
+  void sendRequest(bool end_stream = false) {
+    helloworld::HelloRequest request_msg;
+    request_msg.set_name(HELLO_REQUEST);
+    grpc_stream_->sendMessage(request_msg, end_stream);
+
+    helloworld::HelloRequest received_msg;
+    fake_stream_->waitForGrpcMessage(dispatcher_helper_.dispatcher_, received_msg);
+    EXPECT_THAT(request_msg, ProtoEq(received_msg));
+  }
+
+  void sendServerInitialMetadata(const TestMetadata& metadata) {
+    Http::HeaderMapPtr reply_headers{new Http::TestHeaderMapImpl{{":status", "200"}}};
+    for (auto& value : metadata) {
+      reply_headers->addReference(value.first, value.second);
+    }
+    EXPECT_CALL(*this, onReceiveInitialMetadata_(_))
+        .WillOnce(Invoke([this, &metadata](const Http::HeaderMap& received_headers) {
+          Http::TestHeaderMapImpl stream_headers(received_headers);
+          for (auto& value : metadata) {
+            EXPECT_EQ(value.second, stream_headers.get_(value.first));
+          }
+          dispatcher_helper_.exitDispatcherIfNeeded();
+        }));
+    dispatcher_helper_.setStreamEventPending();
+    fake_stream_->encodeHeaders(*reply_headers, false);
+  }
+
+  void sendReply() {
+    helloworld::HelloReply reply;
+    reply.set_message(HELLO_REPLY);
+    EXPECT_CALL(*this, onReceiveMessage_(HelloworldReplyEq(HELLO_REPLY))).WillExitIfNeeded();
+    dispatcher_helper_.setStreamEventPending();
+    fake_stream_->sendGrpcMessage<helloworld::HelloReply>(reply);
+  }
+
+  void expectGrpcStatus(Status::GrpcStatus grpc_status) {
+    EXPECT_CALL(*this, onRemoteClose(grpc_status, _)).WillExitIfNeeded();
+    dispatcher_helper_.setStreamEventPending();
+  }
+
+  void sendServerTrailers(Status::GrpcStatus grpc_status, const std::string& grpc_message,
+                          const TestMetadata& metadata, bool trailers_only = false) {
+    Http::TestHeaderMapImpl reply_trailers{{"grpc-status", std::to_string(enumToInt(grpc_status))}};
+    if (!grpc_message.empty()) {
+      reply_trailers.addCopy("grpc-message", grpc_message);
+    }
+    if (trailers_only) {
+      reply_trailers.addCopy(":status", "200");
+    }
+    for (const auto& value : metadata) {
+      reply_trailers.addCopy(value.first, value.second);
+    }
+    (trailers_only ? EXPECT_CALL(*this, onReceiveInitialMetadata_(_))
+                   : EXPECT_CALL(*this, onReceiveTrailingMetadata_(_)))
+        .WillOnce(Invoke([this, &metadata](const Http::HeaderMap& received_headers) {
+          Http::TestHeaderMapImpl stream_headers(received_headers);
+          for (auto& value : metadata) {
+            EXPECT_EQ(value.second, stream_headers.get_(value.first));
+          }
+          dispatcher_helper_.exitDispatcherIfNeeded();
+        }));
+    dispatcher_helper_.setStreamEventPending();
+    expectGrpcStatus(grpc_status);
+    if (trailers_only) {
+      fake_stream_->encodeHeaders(reply_trailers, true);
+    } else {
+      fake_stream_->encodeTrailers(reply_trailers);
+    }
+  }
+
+  void closeStream() {
+    grpc_stream_->closeStream();
+    fake_stream_->waitForEndStream(dispatcher_helper_.dispatcher_);
+  }
+
+  DispatcherHelper& dispatcher_helper_;
+  FakeStream* fake_stream_{};
+  AsyncStream* grpc_stream_{};
+};
+
+// Request related test utilities.
+class HelloworldRequest : public MockAsyncRequestCallbacks<helloworld::HelloReply> {
+public:
+  HelloworldRequest(DispatcherHelper& dispatcher_helper) : dispatcher_helper_(dispatcher_helper) {}
+
+  void sendReply() {
+    fake_stream_->startGrpcStream();
+    helloworld::HelloReply reply;
+    reply.set_message(HELLO_REPLY);
+    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().GRPC_STATUS_CODE, "0"));
+    EXPECT_CALL(*this, onSuccess_(HelloworldReplyEq(HELLO_REPLY), _)).WillExitIfNeeded();
+    EXPECT_CALL(*child_span_, finishSpan());
+    dispatcher_helper_.setStreamEventPending();
+    fake_stream_->sendGrpcMessage(reply);
+    fake_stream_->finishGrpcStream(Grpc::Status::Ok);
+  }
+
+  DispatcherHelper& dispatcher_helper_;
+  FakeStream* fake_stream_{};
+  AsyncRequest* grpc_request_{};
+  Tracing::MockSpan* child_span_{new Tracing::MockSpan()};
+};
+
+// Support paramaterizing over gRPC client type.
+enum class ClientType { EnvoyGrpc, GoogleGrpc };
+
+// Skip tests based on gRPC client type.
+#define SKIP_IF_GRPC_CLIENT(client_type)                                                           \
+  if (std::get<1>(GetParam()) == (client_type)) {                                                  \
+    return;                                                                                        \
+  }
+
+class GrpcClientIntegrationTest
+    : public testing::TestWithParam<std::tuple<Network::Address::IpVersion, ClientType>> {
+public:
+  GrpcClientIntegrationTest()
+      : method_descriptor_(helloworld::Greeter::descriptor()->FindMethodByName("SayHello")),
+        fake_upstream_(
+            new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, std::get<0>(GetParam()))) {
+    switch (std::get<1>(GetParam())) {
+    case ClientType::EnvoyGrpc:
+      grpc_client_ = createAsyncClientImpl();
+      break;
+    case ClientType::GoogleGrpc: {
+      // TODO(htuch): Enable below in PR for Google gRPC C++ client.
+      // envoy::api::v2::GrpcService::GoogleGrpc config;
+      // config.set_target_uri(fake_upstream_->localAddress()->asString());
+      // config.set_stat_prefix("fake_cluster");
+      // grpc_client_ = std::make_unique<GoogleAsyncClientImpl>(dispatcher_, stats_store_, config);
+      NOT_REACHED;
+      break;
+    }
+    }
+    // Setup a test timeout (also needed to maintain an active event in the dispatcher so that
+    // .run() will block until timeout rather than exit immediately).
+    timeout_timer_ = dispatcher_.createTimer([this] {
+      FAIL() << "Test timeout";
+      dispatcher_.exit();
+    });
+    timeout_timer_->enableTimer(std::chrono::milliseconds(10000));
+  }
+
+  void TearDown() override {
+    if (fake_connection_) {
+      fake_connection_->close();
+      fake_connection_->waitForDisconnect();
+    }
+  }
+
+  // Create a Grpc::AsyncClientImpl instance backed by enough fake/mock
+  // infrastructure to initiate a loopback TCP connection to fake_upstream_.
+  AsyncClientPtr createAsyncClientImpl() {
+    client_connection_ = std::make_unique<Network::ClientConnectionImpl>(
+        dispatcher_, fake_upstream_->localAddress(), nullptr,
+        std::make_unique<Network::RawBufferSocket>());
+    EXPECT_CALL(*mock_cluster_info_, name()).WillRepeatedly(ReturnRef("fake_cluster"));
+    EXPECT_CALL(cm_, get(_)).WillRepeatedly(Return(&thread_local_cluster_));
+    EXPECT_CALL(thread_local_cluster_, info()).WillRepeatedly(Return(cluster_info_ptr_));
+    Upstream::MockHost::MockCreateConnectionData connection_data{client_connection_.release(),
+                                                                 host_description_ptr_};
+    EXPECT_CALL(*mock_host_, createConnection_(_)).WillRepeatedly(Return(connection_data));
+    EXPECT_CALL(*mock_host_, cluster()).WillRepeatedly(ReturnRef(*cluster_info_ptr_));
+    EXPECT_CALL(*mock_host_description_, locality()).WillRepeatedly(ReturnRef(host_locality_));
+    http_conn_pool_ = std::make_unique<Http::Http2::ProdConnPoolImpl>(
+        dispatcher_, host_ptr_, Upstream::ResourcePriority::Default);
+    EXPECT_CALL(cm_, httpConnPoolForCluster(_, _, _, _))
+        .WillRepeatedly(Return(http_conn_pool_.get()));
+    http_async_client_ = std::make_unique<Http::AsyncClientImpl>(
+        *cluster_info_ptr_, stats_store_, dispatcher_, local_info_, cm_, runtime_, random_,
+        std::move(shadow_writer_ptr_));
+    EXPECT_CALL(cm_, httpAsyncClientForCluster("fake_cluster"))
+        .WillRepeatedly(ReturnRef(*http_async_client_));
+    return std::make_unique<AsyncClientImpl>(cm_, "fake_cluster");
+  }
+
+  void expectInitialHeaders(FakeStream& fake_stream) {
+    fake_stream.waitForHeadersComplete();
+    Http::TestHeaderMapImpl stream_headers(fake_stream.headers());
+    EXPECT_EQ("POST", stream_headers.get_(":method"));
+    EXPECT_EQ("/helloworld.Greeter/SayHello", stream_headers.get_(":path"));
+    EXPECT_EQ("application/grpc", stream_headers.get_("content-type"));
+    EXPECT_EQ("trailers", stream_headers.get_("te"));
+  }
+
+  std::unique_ptr<HelloworldRequest> createRequest(const TestMetadata& initial_metadata) {
+    auto request = std::make_unique<HelloworldRequest>(dispatcher_helper_);
+    EXPECT_CALL(*request, onCreateInitialMetadata(_))
+        .WillOnce(Invoke([&initial_metadata](Http::HeaderMap& headers) {
+          for (auto& value : initial_metadata) {
+            headers.addReference(value.first, value.second);
+          }
+        }));
+    helloworld::HelloRequest request_msg;
+    request_msg.set_name(HELLO_REQUEST);
+
+    Tracing::MockSpan active_span;
+    EXPECT_CALL(active_span, spawnChild_(_, "async fake_cluster egress", _))
+        .WillOnce(Return(request->child_span_));
+    EXPECT_CALL(*request->child_span_,
+                setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, "fake_cluster"));
+    EXPECT_CALL(*request->child_span_,
+                setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY));
+    EXPECT_CALL(*request->child_span_, injectContext(_));
+
+    request->grpc_request_ = grpc_client_->send(*method_descriptor_, request_msg, *request,
+                                                active_span, Optional<std::chrono::milliseconds>());
+    EXPECT_NE(request->grpc_request_, nullptr);
+
+    if (!fake_connection_) {
+      fake_connection_ = fake_upstream_->waitForHttpConnection(dispatcher_);
+    }
+    fake_streams_.push_back(fake_connection_->waitForNewStream(dispatcher_));
+    auto& fake_stream = *fake_streams_.back();
+    request->fake_stream_ = &fake_stream;
+
+    expectInitialHeaders(fake_stream);
+
+    helloworld::HelloRequest received_msg;
+    fake_stream.waitForGrpcMessage(dispatcher_, received_msg);
+    EXPECT_THAT(request_msg, ProtoEq(received_msg));
+
+    return request;
+  }
+
+  std::unique_ptr<HelloworldStream> createStream(const TestMetadata& initial_metadata) {
+    auto stream = std::make_unique<HelloworldStream>(dispatcher_helper_);
+    EXPECT_CALL(*stream, onCreateInitialMetadata(_))
+        .WillOnce(Invoke([&initial_metadata](Http::HeaderMap& headers) {
+          for (auto& value : initial_metadata) {
+            headers.addReference(value.first, value.second);
+          }
+        }));
+
+    stream->grpc_stream_ = grpc_client_->start(*method_descriptor_, *stream);
+    EXPECT_NE(stream->grpc_stream_, nullptr);
+
+    if (!fake_connection_) {
+      fake_connection_ = fake_upstream_->waitForHttpConnection(dispatcher_);
+    }
+    fake_streams_.push_back(fake_connection_->waitForNewStream(dispatcher_));
+    auto& fake_stream = *fake_streams_.back();
+    stream->fake_stream_ = &fake_stream;
+
+    expectInitialHeaders(fake_stream);
+
+    return stream;
+  }
+
+  FakeHttpConnectionPtr fake_connection_;
+  std::vector<FakeStreamPtr> fake_streams_;
+  const Protobuf::MethodDescriptor* method_descriptor_;
+  Event::DispatcherImpl dispatcher_;
+  DispatcherHelper dispatcher_helper_{dispatcher_};
+  Stats::IsolatedStoreImpl stats_store_;
+  std::unique_ptr<FakeUpstream> fake_upstream_;
+  AsyncClientPtr grpc_client_;
+  Event::TimerPtr timeout_timer_;
+
+  // Fake/mock infrastructure for Grpc::AsyncClientImpl upstream.
+  Upstream::MockClusterManager cm_;
+  Upstream::MockClusterInfo* mock_cluster_info_ = new NiceMock<Upstream::MockClusterInfo>();
+  Upstream::ClusterInfoConstSharedPtr cluster_info_ptr_{mock_cluster_info_};
+  Upstream::MockThreadLocalCluster thread_local_cluster_;
+  NiceMock<LocalInfo::MockLocalInfo> local_info_;
+  Runtime::MockLoader runtime_;
+  NiceMock<Runtime::MockRandomGenerator> random_;
+  Http::AsyncClientPtr http_async_client_;
+  Http::ConnectionPool::InstancePtr http_conn_pool_;
+  envoy::api::v2::Locality host_locality_;
+  Upstream::MockHost* mock_host_ = new NiceMock<Upstream::MockHost>();
+  Upstream::MockHostDescription* mock_host_description_ =
+      new NiceMock<Upstream::MockHostDescription>();
+  Upstream::HostDescriptionConstSharedPtr host_description_ptr_{mock_host_description_};
+  Upstream::HostConstSharedPtr host_ptr_{mock_host_};
+  Router::MockShadowWriter* mock_shadow_writer_ = new Router::MockShadowWriter();
+  Router::ShadowWriterPtr shadow_writer_ptr_{mock_shadow_writer_};
+  Network::ClientConnectionPtr client_connection_;
+};
+
+// Parameterize the loopback test server socket address and gRPC client type.
+INSTANTIATE_TEST_CASE_P(IpVersionsClientType, GrpcClientIntegrationTest,
+                        testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                                         testing::Values(ClientType::EnvoyGrpc /*,
+                                                         ClientType::GoogleGrpc*/)));
+
+// Validate that a simple request-reply stream works.
+TEST_P(GrpcClientIntegrationTest, BasicStream) {
+  const TestMetadata empty_metadata;
+  auto stream = createStream(empty_metadata);
+  stream->sendRequest();
+  stream->sendServerInitialMetadata(empty_metadata);
+  stream->sendReply();
+  stream->sendServerTrailers(Status::GrpcStatus::Ok, "", empty_metadata);
+  stream->closeStream();
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that a simple request-reply unary RPC works.
+TEST_P(GrpcClientIntegrationTest, BasicRequest) {
+  const TestMetadata empty_metadata;
+  auto request = createRequest(empty_metadata);
+  request->sendReply();
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that multiple streams work.
+TEST_P(GrpcClientIntegrationTest, MultiStream) {
+  const TestMetadata empty_metadata;
+  auto stream_0 = createStream(empty_metadata);
+  auto stream_1 = createStream(empty_metadata);
+  stream_0->sendRequest();
+  stream_1->sendRequest();
+  stream_0->sendServerInitialMetadata(empty_metadata);
+  stream_0->sendReply();
+  stream_1->sendServerTrailers(Status::GrpcStatus::Unavailable, "", empty_metadata, true);
+  stream_0->sendServerTrailers(Status::GrpcStatus::Ok, "", empty_metadata);
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that multiple request-reply unary RPCs works.
+TEST_P(GrpcClientIntegrationTest, MultiRequest) {
+  const TestMetadata empty_metadata;
+  auto request_0 = createRequest(empty_metadata);
+  auto request_1 = createRequest(empty_metadata);
+  request_1->sendReply();
+  request_0->sendReply();
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that a non-200 HTTP status results in the expected gRPC error.
+TEST_P(GrpcClientIntegrationTest, HttpNon200Status) {
+  for (const auto http_response_status : {400, 401, 403, 404, 429, 431}) {
+    const TestMetadata empty_metadata;
+    auto stream = createStream(empty_metadata);
+    const Http::TestHeaderMapImpl reply_headers{{":status", std::to_string(http_response_status)}};
+    EXPECT_CALL(*stream, onReceiveInitialMetadata_(_)).WillExitIfNeeded();
+    dispatcher_helper_.setStreamEventPending();
+    // Technically this should be
+    // https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md
+    // as given by Common::httpToGrpcStatus(), but the Google gRPC client treats
+    // this as GrpcStatus::Canceled.
+    stream->expectGrpcStatus(Status::GrpcStatus::Canceled);
+    stream->fake_stream_->encodeHeaders(reply_headers, true);
+    dispatcher_helper_.runDispatcher();
+  }
+}
+
+// Validate that a non-200 HTTP status results in fallback to grpc-status.
+TEST_P(GrpcClientIntegrationTest, GrpcStatusFallback) {
+  const TestMetadata empty_metadata;
+  auto stream = createStream(empty_metadata);
+  const Http::TestHeaderMapImpl reply_headers{
+      {":status", "404"},
+      {"grpc-status", std::to_string(enumToInt(Status::GrpcStatus::PermissionDenied))},
+      {"grpc-message", "error message"}};
+  EXPECT_CALL(*stream, onReceiveInitialMetadata_(_)).WillExitIfNeeded();
+  dispatcher_helper_.setStreamEventPending();
+  stream->expectGrpcStatus(Status::GrpcStatus::PermissionDenied);
+  stream->fake_stream_->encodeHeaders(reply_headers, true);
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that a HTTP-level reset is handled as an INTERNAL gRPC error.
+TEST_P(GrpcClientIntegrationTest, HttpReset) {
+  const TestMetadata empty_metadata;
+  auto stream = createStream(empty_metadata);
+  stream->sendServerInitialMetadata(empty_metadata);
+  dispatcher_helper_.runDispatcher();
+  stream->expectGrpcStatus(Status::GrpcStatus::Internal);
+  stream->fake_stream_->encodeResetStream();
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that a reply with bad gRPC framing (compressed frames with Envoy
+// client) is handled as an INTERNAL gRPC error.
+TEST_P(GrpcClientIntegrationTest, BadReplyGrpcFraming) {
+  // Only testing behavior of Envoy client, since Google client handles
+  // compressed frames.
+  SKIP_IF_GRPC_CLIENT(ClientType::GoogleGrpc);
+  const TestMetadata empty_metadata;
+  auto stream = createStream(empty_metadata);
+  stream->sendRequest();
+  stream->sendServerInitialMetadata(empty_metadata);
+  stream->expectGrpcStatus(Status::GrpcStatus::Internal);
+  Buffer::OwnedImpl reply_buffer("\xde\xad\xbe\xef\x00", 5);
+  stream->fake_stream_->encodeData(reply_buffer, true);
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that a reply with bad protobuf is handled as an INTERNAL gRPC error.
+TEST_P(GrpcClientIntegrationTest, BadReplyProtobuf) {
+  const TestMetadata empty_metadata;
+  auto stream = createStream(empty_metadata);
+  stream->sendRequest();
+  stream->sendServerInitialMetadata(empty_metadata);
+  stream->expectGrpcStatus(Status::GrpcStatus::Internal);
+  Buffer::OwnedImpl reply_buffer("\x00\x00\x00\x00\x02\xff\xff", 7);
+  stream->fake_stream_->encodeData(reply_buffer, true);
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that an out-of-range gRPC status is handled as an INVALID_CODE gRPC
+// error.
+TEST_P(GrpcClientIntegrationTest, OutOfRangeGrpcStatus) {
+  const TestMetadata empty_metadata;
+  auto stream = createStream(empty_metadata);
+  stream->sendServerInitialMetadata(empty_metadata);
+  stream->sendReply();
+  EXPECT_CALL(*stream, onReceiveTrailingMetadata_(_)).WillExitIfNeeded();
+  dispatcher_helper_.setStreamEventPending();
+  stream->expectGrpcStatus(Status::GrpcStatus::InvalidCode);
+  const Http::TestHeaderMapImpl reply_trailers{{"grpc-status", std::to_string(0x1337)}};
+  stream->fake_stream_->encodeTrailers(reply_trailers);
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that a missing gRPC status is handled as an UNKNOWN gRPC error.
+TEST_P(GrpcClientIntegrationTest, MissingGrpcStatus) {
+  const TestMetadata empty_metadata;
+  auto stream = createStream(empty_metadata);
+  stream->sendServerInitialMetadata(empty_metadata);
+  stream->sendReply();
+  EXPECT_CALL(*stream, onReceiveTrailingMetadata_(_)).WillExitIfNeeded();
+  dispatcher_helper_.setStreamEventPending();
+  stream->expectGrpcStatus(Status::GrpcStatus::Unknown);
+  const Http::TestHeaderMapImpl reply_trailers;
+  stream->fake_stream_->encodeTrailers(reply_trailers);
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that a reply terminated without trailers is handled as an UNKNOWN
+// gRPC error.
+TEST_P(GrpcClientIntegrationTest, ReplyNoTrailers) {
+  const TestMetadata empty_metadata;
+  auto stream = createStream(empty_metadata);
+  stream->sendRequest();
+  stream->sendServerInitialMetadata(empty_metadata);
+  helloworld::HelloReply reply;
+  reply.set_message(HELLO_REPLY);
+  EXPECT_CALL(*stream, onReceiveMessage_(HelloworldReplyEq(HELLO_REPLY))).WillExitIfNeeded();
+  dispatcher_helper_.setStreamEventPending();
+  EXPECT_CALL(*stream, onReceiveTrailingMetadata_(_)).WillExitIfNeeded();
+  dispatcher_helper_.setStreamEventPending();
+  stream->expectGrpcStatus(Status::GrpcStatus::Unknown);
+  auto serialized_response = Grpc::Common::serializeBody(reply);
+  stream->fake_stream_->encodeData(*serialized_response, true);
+  stream->fake_stream_->encodeResetStream();
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that send client initial metadata works.
+TEST_P(GrpcClientIntegrationTest, StreamClientInitialMetadata) {
+  const TestMetadata initial_metadata = {
+      {Http::LowerCaseString("foo"), "bar"},
+      {Http::LowerCaseString("baz"), "blah"},
+  };
+  auto stream = createStream(initial_metadata);
+  const TestMetadata empty_metadata;
+  stream->sendServerTrailers(Status::GrpcStatus::Ok, "", empty_metadata, true);
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that send client initial metadata works.
+TEST_P(GrpcClientIntegrationTest, RequestClientInitialMetadata) {
+  const TestMetadata initial_metadata = {
+      {Http::LowerCaseString("foo"), "bar"},
+      {Http::LowerCaseString("baz"), "blah"},
+  };
+  auto request = createRequest(initial_metadata);
+  request->sendReply();
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that receiving server initial metadata works.
+TEST_P(GrpcClientIntegrationTest, ServerInitialMetadata) {
+  const TestMetadata empty_metadata;
+  auto stream = createStream(empty_metadata);
+  stream->sendRequest();
+  const TestMetadata initial_metadata = {
+      {Http::LowerCaseString("foo"), "bar"},
+      {Http::LowerCaseString("baz"), "blah"},
+  };
+  stream->sendServerInitialMetadata(initial_metadata);
+  stream->sendReply();
+  stream->sendServerTrailers(Status::GrpcStatus::Ok, "", empty_metadata);
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that receiving server trailing metadata works.
+TEST_P(GrpcClientIntegrationTest, ServerTrailingMetadata) {
+  const TestMetadata empty_metadata;
+  auto stream = createStream(empty_metadata);
+  stream->sendRequest();
+  stream->sendServerInitialMetadata(empty_metadata);
+  stream->sendReply();
+  const TestMetadata trailing_metadata = {
+      {Http::LowerCaseString("foo"), "bar"},
+      {Http::LowerCaseString("baz"), "blah"},
+  };
+  stream->sendServerTrailers(Status::GrpcStatus::Ok, "", trailing_metadata);
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that a trailers-only response is handled for streams.
+TEST_P(GrpcClientIntegrationTest, StreamTrailersOnly) {
+  const TestMetadata empty_metadata;
+  auto stream = createStream(empty_metadata);
+  stream->sendServerTrailers(Status::GrpcStatus::Ok, "", empty_metadata, true);
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that a trailers-only response is handled for requests, where it is
+// an error.
+TEST_P(GrpcClientIntegrationTest, RequestTrailersOnly) {
+  const TestMetadata empty_metadata;
+  auto request = createRequest(empty_metadata);
+  const Http::TestHeaderMapImpl reply_headers{{":status", "200"}, {"grpc-status", "0"}};
+  EXPECT_CALL(*request->child_span_, setTag(Tracing::Tags::get().GRPC_STATUS_CODE, "0"));
+  EXPECT_CALL(*request->child_span_, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
+  EXPECT_CALL(*request, onFailure(Status::Internal, "", _)).WillExitIfNeeded();
+  dispatcher_helper_.setStreamEventPending();
+  EXPECT_CALL(*request->child_span_, finishSpan());
+  request->fake_stream_->encodeTrailers(reply_headers);
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that a trailers RESOURCE_EXHAUSTED reply is handled.
+TEST_P(GrpcClientIntegrationTest, ResourceExhaustedError) {
+  const TestMetadata empty_metadata;
+  auto stream = createStream(empty_metadata);
+  stream->sendServerInitialMetadata(empty_metadata);
+  stream->sendReply();
+  stream->sendServerTrailers(Status::GrpcStatus::ResourceExhausted, "error message",
+                             empty_metadata);
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that we can continue to receive after a local close.
+TEST_P(GrpcClientIntegrationTest, ReceiveAfterLocalClose) {
+  const TestMetadata empty_metadata;
+  auto stream = createStream(empty_metadata);
+  stream->sendRequest(true);
+  stream->sendServerInitialMetadata(empty_metadata);
+  stream->sendReply();
+  stream->sendServerTrailers(Status::GrpcStatus::Ok, "", empty_metadata);
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that reset() doesn't explode on a half-closed stream (local).
+TEST_P(GrpcClientIntegrationTest, ResetAfterCloseLocal) {
+  const TestMetadata empty_metadata;
+  auto stream = createStream(empty_metadata);
+  stream->grpc_stream_->closeStream();
+  stream->fake_stream_->waitForEndStream(dispatcher_helper_.dispatcher_);
+  stream->grpc_stream_->resetStream();
+  dispatcher_helper_.dispatcher_.run(Event::Dispatcher::RunType::NonBlock);
+  stream->fake_stream_->waitForReset();
+}
+
+// Validate that request cancel() works.
+TEST_P(GrpcClientIntegrationTest, CancelRequest) {
+  const TestMetadata empty_metadata;
+  auto request = createRequest(empty_metadata);
+  EXPECT_CALL(*request->child_span_,
+              setTag(Tracing::Tags::get().STATUS, Tracing::Tags::get().CANCELED));
+  EXPECT_CALL(*request->child_span_, finishSpan());
+  request->grpc_request_->cancel();
+  dispatcher_helper_.dispatcher_.run(Event::Dispatcher::RunType::NonBlock);
+  request->fake_stream_->waitForReset();
+}
+
+} // namespace
+} // namespace Grpc
+} // namespace Envoy

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -30,6 +30,7 @@ using testing::_;
 
 namespace Envoy {
 namespace Http {
+namespace {
 
 class AsyncClientImplTest : public testing::Test {
 public:
@@ -862,5 +863,6 @@ TEST_F(AsyncClientImplTest, WatermarkCallbacks) {
   EXPECT_CALL(stream_callbacks_, onReset());
 }
 
+} // namespace
 } // namespace Http
 } // namespace Envoy

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -65,6 +65,10 @@ public:
   }
   template <class T> void decodeGrpcFrame(T& message) {
     EXPECT_GE(decoded_grpc_frames_.size(), 1);
+    if (decoded_grpc_frames_[0].length_ == 0) {
+      decoded_grpc_frames_.erase(decoded_grpc_frames_.begin());
+      return;
+    }
     Buffer::ZeroCopyInputStreamImpl stream(std::move(decoded_grpc_frames_[0].data_));
     EXPECT_TRUE(decoded_grpc_frames_[0].flags_ == Grpc::GRPC_FH_DEFAULT);
     EXPECT_TRUE(message.ParseFromZeroCopyStream(&stream));


### PR DESCRIPTION
This PR is the next in the series of patches to integrate the Google gRPC client. There are two
parts:

1. The bulk of the existing Grpc::AsyncClientImpl unit tests have been re-expressed as TCP loopback
   integration tests with a FakeUpstream. This allows direct reuse with the Google gRPC client
   libraries, since they are a blackbox that can't be easily mocked internally. The test is also now
   paramaterized by client type, with the Google gRPC implementation elided in this PR.

2. To produce behavioral parity between clients, Grpc::AsyncClientImpl has been modified where its
   behavior differed from the Google gRPC client (which is effectively the gRPC reference
   implementation). Specifically, initial/trailer metadata callbacks, error handling and HTTP ->
   gRPC status mapping behavior have been modified. Remote stream closes, even with OK grpc-status
   now terminate the stream regardless of local stream close behavior.

Testing: Unit/integration tests as described above.
Risk Level: Medium (behavior changes to Grpc::AsyncClientImpl, used for config discovery, rate limiting, access logs and metrics service).

Signed-off-by: Harvey Tuch <htuch@google.com>