### PR TITLE
config: avoid spurious empty final discovery request.

### DIFF
--- a/source/common/config/grpc_mux_impl.h
+++ b/source/common/config/grpc_mux_impl.h
@@ -59,7 +59,9 @@ private:
     ~GrpcMuxWatchImpl() override {
       if (inserted_) {
         parent_.api_state_[type_url_].watches_.erase(entry_);
-        parent_.sendDiscoveryRequest(type_url_);
+        if (!resources_.empty()) {
+          parent_.sendDiscoveryRequest(type_url_);
+        }
       }
     }
     std::vector<std::string> resources_;

--- a/test/common/config/grpc_mux_impl_test.cc
+++ b/test/common/config/grpc_mux_impl_test.cc
@@ -80,7 +80,6 @@ TEST_F(GrpcMuxImplTest, MultipleTypeUrlStreams) {
   auto bar_zz_sub = grpc_mux_->subscribe("bar", {"zz"}, callbacks_);
   expectSendMessage("bar", {"z"}, "");
   expectSendMessage("bar", {}, "");
-  expectSendMessage("bar", {}, "");
   expectSendMessage("foo", {}, "");
 }
 
@@ -106,7 +105,6 @@ TEST_F(GrpcMuxImplTest, ResetStream) {
   timer_cb_();
 
   expectSendMessage("baz", {}, "");
-  expectSendMessage("bar", {}, "");
   expectSendMessage("foo", {}, "");
 }
 
@@ -190,8 +188,6 @@ TEST_F(GrpcMuxImplTest, WildcardWatch) {
     expectSendMessage(type_url, {}, "1");
     grpc_mux_->onReceiveMessage(std::move(response));
   }
-
-  expectSendMessage(type_url, {}, "1");
 }
 
 // Validate behavior when watches specify resources (potentially overlapping).


### PR DESCRIPTION
When a subscription is for the empty set, rather than a specific set of services, avoid sending an
empty request when the watch ends.

Testing: UT
Risk Level: Low

Signed-off-by: Harvey Tuch <htuch@google.com>