### PR TITLE
tls: initialize main thread dispatcher explicitly.

### DIFF
--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -48,12 +48,12 @@ void InstanceImpl::registerThread(Event::Dispatcher& dispatcher, bool main_threa
 
   if (main_thread) {
     main_thread_dispatcher_ = &dispatcher;
+    thread_local_data_.dispatcher_ = &dispatcher;
   } else {
     ASSERT(!containsReference(registered_threads_, dispatcher));
     registered_threads_.push_back(dispatcher);
+    dispatcher.post([&dispatcher] { thread_local_data_.dispatcher_ = &dispatcher; });
   }
-
-  dispatcher.post([&dispatcher] { thread_local_data_.dispatcher_ = &dispatcher; });
 }
 
 void InstanceImpl::removeSlot(SlotImpl& slot) {

--- a/test/common/thread_local/thread_local_impl_test.cc
+++ b/test/common/thread_local/thread_local_impl_test.cc
@@ -23,8 +23,8 @@ public:
 class ThreadLocalInstanceImplTest : public testing::Test {
 public:
   ThreadLocalInstanceImplTest() {
-    EXPECT_CALL(main_dispatcher_, post(_));
     tls_.registerThread(main_dispatcher_, true);
+    EXPECT_EQ(&main_dispatcher_, &tls_.dispatcher());
     EXPECT_CALL(thread_dispatcher_, post(_));
     tls_.registerThread(thread_dispatcher_, false);
   }


### PR DESCRIPTION
Waiting for first dispatch loop is too late for ADS use with Google gRPC client.

Testing: ADS integration test with Google gRPC client, existing tests.
Risk Level: Low

Signed-off-by: Harvey Tuch <htuch@google.com>