### PR TITLE
router: support more granular weights for weighted clusters

### DIFF
--- a/RAW_RELEASE_NOTES.md
+++ b/RAW_RELEASE_NOTES.md
@@ -43,3 +43,4 @@ final version.
 * Added `gateway-error` retry-on policy.
 * Added support for building envoy with exported symbols
   This change allows scripts loaded with the lua filter to load shared object libraries such as those installed via luarocks.
+* Added support for more granular weighted cluster routing by allowing the total weight to be specified in configuration.

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -71,8 +71,8 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
     ),
     envoy_api = dict(
-        commit = "e7b036e2c625ee615a2ae057ee891b3c7526797e",
-        remote = "https://github.com/turbinelabs/data-plane-api",
+        commit = "5aa0208c3bf0ba35833dc4ac16c73839b032e70a",
+        remote = "https://github.com/envoyproxy/data-plane-api",
     ),
     grpc_httpjson_transcoding = dict(
         commit = "e4f58aa07b9002befa493a0a82e10f2e98b51fc6",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -71,8 +71,8 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
     ),
     envoy_api = dict(
-        commit = "fd1a8c4269910caa2d99bf919c0ad13fb3d70f4f",
-        remote = "https://github.com/envoyproxy/data-plane-api",
+        commit = "e7b036e2c625ee615a2ae057ee891b3c7526797e",
+        remote = "https://github.com/turbinelabs/data-plane-api",
     ),
     grpc_httpjson_transcoding = dict(
         commit = "e4f58aa07b9002befa493a0a82e10f2e98b51fc6",

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -256,6 +256,8 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
   // from the weighted cluster (if any) are merged with and override
   // the criteria from the route.
   if (route.route().cluster_specifier_case() == envoy::api::v2::RouteAction::kWeightedClusters) {
+    ASSERT(total_cluster_weight_ > 0);
+
     uint64_t total_weight = 0UL;
     const std::string& runtime_key_prefix = route.route().weighted_clusters().runtime_key_prefix();
 
@@ -282,10 +284,6 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
                                    std::move(cluster_metadata_match_criteria)));
       weighted_clusters_.emplace_back(std::move(cluster_entry));
       total_weight += weighted_clusters_.back()->clusterWeight();
-    }
-
-    if (total_cluster_weight_ == 0) {
-      throw EnvoyException("total_weight in the weighted_cluster must be greater than 0");
     }
 
     if (total_weight != total_cluster_weight_) {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -215,8 +215,6 @@ void DecoratorImpl::apply(Tracing::Span& span) const {
 
 const std::string& DecoratorImpl::getOperation() const { return operation_; }
 
-const uint64_t RouteEntryImplBase::WeightedClusterEntry::MAX_CLUSTER_WEIGHT = 100UL;
-
 RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
                                        const envoy::api::v2::Route& route, Runtime::Loader& loader)
     : case_sensitive_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(route.match(), case_sensitive, true)),
@@ -233,6 +231,8 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
       path_redirect_(route.redirect().path_redirect()), retry_policy_(route.route()),
       rate_limit_policy_(route.route().rate_limits()), shadow_policy_(route.route()),
       priority_(ConfigUtility::parsePriority(route.route().priority())),
+      total_cluster_weight_(
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(route.route().weighted_clusters(), total_weight, 100UL)),
       request_headers_parser_(HeaderParser::configure(route.route().request_headers_to_add())),
       response_headers_parser_(HeaderParser::configure(route.route().response_headers_to_add(),
                                                        route.route().response_headers_to_remove())),
@@ -284,9 +284,13 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
       total_weight += weighted_clusters_.back()->clusterWeight();
     }
 
-    if (total_weight != WeightedClusterEntry::MAX_CLUSTER_WEIGHT) {
+    if (total_cluster_weight_ == 0) {
+      throw EnvoyException("total_weight in the weighted_cluster must be greater than 0");
+    }
+
+    if (total_weight != total_cluster_weight_) {
       throw EnvoyException(fmt::format("Sum of weights in the weighted_cluster should add up to {}",
-                                       WeightedClusterEntry::MAX_CLUSTER_WEIGHT));
+                                       total_cluster_weight_));
     }
   }
 
@@ -470,7 +474,7 @@ RouteConstSharedPtr RouteEntryImplBase::clusterEntry(const Http::HeaderMap& head
     }
   }
 
-  uint64_t selected_value = random_value % WeightedClusterEntry::MAX_CLUSTER_WEIGHT;
+  uint64_t selected_value = random_value % total_cluster_weight_;
   uint64_t begin = 0UL;
   uint64_t end = 0UL;
 
@@ -479,13 +483,10 @@ RouteConstSharedPtr RouteEntryImplBase::clusterEntry(const Http::HeaderMap& head
   // [0, cluster1_weight), [cluster1_weight, cluster1_weight+cluster2_weight),..
   for (const WeightedClusterEntrySharedPtr& cluster : weighted_clusters_) {
     end = begin + cluster->clusterWeight();
-    if (((selected_value >= begin) && (selected_value < end)) ||
-        (end >= WeightedClusterEntry::MAX_CLUSTER_WEIGHT)) {
-      // end > WeightedClusterEntry::MAX_CLUSTER_WEIGHT : This case can only occur
-      // with Runtimes, when the user specifies invalid weights such that
-      // sum(weights) > WeightedClusterEntry::MAX_CLUSTER_WEIGHT.
-      // In this case, terminate the search and just return the cluster
-      // whose weight cased the overflow
+    if (((selected_value >= begin) && (selected_value < end)) || (end >= total_cluster_weight_)) {
+      // end > total_cluster_weight_: This case can only occur with Runtimes, when the user
+      // specifies invalid weights such that sum(weights) > total_cluster_weight_. In this case,
+      // terminate the search and just return the cluster whose weight caused the overflow.
       return cluster;
     }
     begin = end;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -440,8 +440,6 @@ private:
       return DynamicRouteEntry::metadataMatchCriteria();
     }
 
-    static const uint64_t MAX_CLUSTER_WEIGHT;
-
   private:
     const std::string runtime_key_;
     Runtime::Loader& loader_;
@@ -481,6 +479,7 @@ private:
   std::vector<ConfigUtility::HeaderData> config_headers_;
   std::vector<ConfigUtility::QueryParameterMatcher> config_query_parameters_;
   std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
+  const uint64_t total_cluster_weight_;
   std::unique_ptr<const HashPolicyImpl> hash_policy_;
   MetadataMatchCriteriaImplConstPtr metadata_match_criteria_;
   HeaderParserPtr request_headers_parser_;

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2600,25 +2600,6 @@ TEST(RouteMatcherTest, WeightedClustersMissingClusterList) {
                EnvoyException);
 }
 
-TEST(RouteMatcherTest, WeightedClustersInvalidTotalWeight) {
-  std::string yaml = R"EOF(
-virtual_hosts:
-  - name: www2
-    domains: ["www.lyft.com"]
-    routes:
-      - match: { prefix: "/" }
-        route:
-          weighted_clusters:
-            total_weight: 0
-  )EOF";
-
-  NiceMock<Runtime::MockLoader> runtime;
-  NiceMock<Upstream::MockClusterManager> cm;
-  EXPECT_THROW_WITH_MESSAGE(ConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), runtime, cm, true),
-                            EnvoyException,
-                            "total_weight in the weighted_cluster must be greater than 0");
-}
-
 TEST(RouteMatcherTest, WeightedClustersEmptyClustersList) {
   std::string json = R"EOF(
 {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2379,56 +2379,76 @@ TEST(RouteMatcherTest, ExclusiveWeightedClustersEntryOrDirectResponseEntry) {
 }
 
 TEST(RouteMatcherTest, WeightedClusters) {
-  std::string json = R"EOF(
-{
-  "virtual_hosts": [
-    {
-      "name": "www1",
-      "domains": ["www1.lyft.com"],
-      "routes": [
-        {
-          "prefix": "/",
-          "weighted_clusters": {
-            "clusters" : [
-              { "name" : "cluster1", "weight" : 30 },
-              { "name" : "cluster2", "weight" : 30 },
-              { "name" : "cluster3", "weight" : 40 }
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "name": "www2",
-      "domains": ["www2.lyft.com"],
-      "routes": [
-        {
-          "prefix": "/",
-          "weighted_clusters": {
-            "runtime_key_prefix" : "www2_weights",
-            "clusters" : [
-              { "name" : "cluster1", "weight" : 30 },
-              { "name" : "cluster2", "weight" : 30 },
-              { "name" : "cluster3", "weight" : 40 }
-            ]
-          }
-        }
-      ]
-    }
-  ]
-}
+  std::string yaml = R"EOF(
+virtual_hosts:
+  - name: www1
+    domains: ["www1.lyft.com"]
+    routes:
+      - match: { prefix: "/" }
+        route:
+          weighted_clusters:
+            clusters:
+              - name: cluster1
+                weight: 30
+              - name: cluster2
+                weight: 30
+              - name: cluster3
+                weight: 40
+  - name: www2
+    domains: ["www2.lyft.com"]
+    routes:
+      - match: { prefix: "/" }
+        route:
+          weighted_clusters:
+            clusters:
+              - name: cluster1
+                weight: 2000
+              - name: cluster2
+                weight: 3000
+              - name: cluster3
+                weight: 5000
+            total_weight: 10000
+  - name: www3
+    domains: ["www3.lyft.com"]
+    routes:
+      - match: { prefix: "/" }
+        route:
+          weighted_clusters:
+            runtime_key_prefix: www3_weights
+            clusters:
+              - name: cluster1
+                weight: 30
+              - name: cluster2
+                weight: 30
+              - name: cluster3
+                weight: 40
+  - name: www4
+    domains: ["www4.lyft.com"]
+    routes:
+      - match: { prefix: "/" }
+        route:
+          weighted_clusters:
+            runtime_key_prefix: www4_weights
+            clusters:
+              - name: cluster1
+                weight: 2000
+              - name: cluster2
+                weight: 3000
+              - name: cluster3
+                weight: 5000
+            total_weight: 10000
   )EOF";
 
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
-  ConfigImpl config(parseRouteConfigurationFromJson(json), runtime, cm, true);
+  ConfigImpl config(parseRouteConfigurationFromV2Yaml(yaml), runtime, cm, true);
 
   {
     Http::TestHeaderMapImpl headers = genRedirectHeaders("www1.lyft.com", "/foo", true, true);
     EXPECT_EQ(nullptr, config.route(headers, 0)->directResponseEntry());
   }
 
-  // Weighted Cluster with no runtime
+  // Weighted Cluster with no runtime, default total weight
   {
     Http::TestHeaderMapImpl headers = genHeaders("www1.lyft.com", "/foo", "GET");
     EXPECT_EQ("cluster1", config.route(headers, 115)->routeEntry()->clusterName());
@@ -2447,15 +2467,23 @@ TEST(RouteMatcherTest, WeightedClusters) {
     EXPECT_TRUE(route->includeVirtualHostRateLimits());
   }
 
-  // Weighted Cluster with valid runtime values
+  // Weighted Cluster with no runtime, total weight = 10000
   {
     Http::TestHeaderMapImpl headers = genHeaders("www2.lyft.com", "/foo", "GET");
-    EXPECT_CALL(runtime.snapshot_, featureEnabled("www2", 100, _)).WillRepeatedly(Return(true));
-    EXPECT_CALL(runtime.snapshot_, getInteger("www2_weights.cluster1", 30))
+    EXPECT_EQ("cluster1", config.route(headers, 1150)->routeEntry()->clusterName());
+    EXPECT_EQ("cluster2", config.route(headers, 4500)->routeEntry()->clusterName());
+    EXPECT_EQ("cluster3", config.route(headers, 8900)->routeEntry()->clusterName());
+  }
+
+  // Weighted Cluster with valid runtime values, default total weight
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www3.lyft.com", "/foo", "GET");
+    EXPECT_CALL(runtime.snapshot_, featureEnabled("www3", 100, _)).WillRepeatedly(Return(true));
+    EXPECT_CALL(runtime.snapshot_, getInteger("www3_weights.cluster1", 30))
         .WillRepeatedly(Return(80));
-    EXPECT_CALL(runtime.snapshot_, getInteger("www2_weights.cluster2", 30))
+    EXPECT_CALL(runtime.snapshot_, getInteger("www3_weights.cluster2", 30))
         .WillRepeatedly(Return(10));
-    EXPECT_CALL(runtime.snapshot_, getInteger("www2_weights.cluster3", 40))
+    EXPECT_CALL(runtime.snapshot_, getInteger("www3_weights.cluster3", 40))
         .WillRepeatedly(Return(10));
 
     EXPECT_EQ("cluster1", config.route(headers, 45)->routeEntry()->clusterName());
@@ -2463,23 +2491,55 @@ TEST(RouteMatcherTest, WeightedClusters) {
     EXPECT_EQ("cluster3", config.route(headers, 92)->routeEntry()->clusterName());
   }
 
-  // Weighted Cluster with invalid runtime values
+  // Weighted Cluster with invalid runtime values, default total weight
   {
-    Http::TestHeaderMapImpl headers = genHeaders("www2.lyft.com", "/foo", "GET");
-    EXPECT_CALL(runtime.snapshot_, featureEnabled("www2", 100, _)).WillRepeatedly(Return(true));
-    EXPECT_CALL(runtime.snapshot_, getInteger("www2_weights.cluster1", 30))
+    Http::TestHeaderMapImpl headers = genHeaders("www3.lyft.com", "/foo", "GET");
+    EXPECT_CALL(runtime.snapshot_, featureEnabled("www3", 100, _)).WillRepeatedly(Return(true));
+    EXPECT_CALL(runtime.snapshot_, getInteger("www3_weights.cluster1", 30))
         .WillRepeatedly(Return(10));
 
     // We return an invalid value here, one that is greater than 100
     // Expect any random value > 10 to always land in cluster2.
-    EXPECT_CALL(runtime.snapshot_, getInteger("www2_weights.cluster2", 30))
+    EXPECT_CALL(runtime.snapshot_, getInteger("www3_weights.cluster2", 30))
         .WillRepeatedly(Return(120));
-    EXPECT_CALL(runtime.snapshot_, getInteger("www2_weights.cluster3", 40))
+    EXPECT_CALL(runtime.snapshot_, getInteger("www3_weights.cluster3", 40))
         .WillRepeatedly(Return(10));
 
     EXPECT_EQ("cluster1", config.route(headers, 1005)->routeEntry()->clusterName());
     EXPECT_EQ("cluster2", config.route(headers, 82)->routeEntry()->clusterName());
     EXPECT_EQ("cluster2", config.route(headers, 92)->routeEntry()->clusterName());
+  }
+
+  // Weighted Cluster with runtime values, total weight = 10000
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www4.lyft.com", "/foo", "GET");
+    EXPECT_CALL(runtime.snapshot_, featureEnabled("www4", 100, _)).WillRepeatedly(Return(true));
+    EXPECT_CALL(runtime.snapshot_, getInteger("www4_weights.cluster1", 2000))
+        .WillRepeatedly(Return(8000));
+    EXPECT_CALL(runtime.snapshot_, getInteger("www4_weights.cluster2", 3000))
+        .WillRepeatedly(Return(1000));
+    EXPECT_CALL(runtime.snapshot_, getInteger("www4_weights.cluster3", 5000))
+        .WillRepeatedly(Return(1000));
+
+    EXPECT_EQ("cluster1", config.route(headers, 1150)->routeEntry()->clusterName());
+    EXPECT_EQ("cluster2", config.route(headers, 8100)->routeEntry()->clusterName());
+    EXPECT_EQ("cluster3", config.route(headers, 9200)->routeEntry()->clusterName());
+  }
+
+  // Weighted Cluster with invalid runtime values, total weight = 10000
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www4.lyft.com", "/foo", "GET");
+    EXPECT_CALL(runtime.snapshot_, featureEnabled("www4", 100, _)).WillRepeatedly(Return(true));
+    EXPECT_CALL(runtime.snapshot_, getInteger("www4_weights.cluster1", 2000))
+        .WillRepeatedly(Return(1000));
+    EXPECT_CALL(runtime.snapshot_, getInteger("www4_weights.cluster2", 3000))
+        .WillRepeatedly(Return(12000));
+    EXPECT_CALL(runtime.snapshot_, getInteger("www4_weights.cluster3", 5000))
+        .WillRepeatedly(Return(1000));
+
+    EXPECT_EQ("cluster1", config.route(headers, 500)->routeEntry()->clusterName());
+    EXPECT_EQ("cluster2", config.route(headers, 1500)->routeEntry()->clusterName());
+    EXPECT_EQ("cluster2", config.route(headers, 9999)->routeEntry()->clusterName());
   }
 }
 
@@ -2540,6 +2600,24 @@ TEST(RouteMatcherTest, WeightedClustersMissingClusterList) {
                EnvoyException);
 }
 
+TEST(RouteMatcherTest, WeightedClustersInvalidTotalWeight) {
+  std::string yaml = R"EOF(
+virtual_hosts:
+  - name: www2
+    domains: ["www.lyft.com"]
+    routes:
+      - match: { prefix: "/" }
+        route:
+          weighted_clusters:
+            total_weight: 0
+  )EOF";
+
+  NiceMock<Runtime::MockLoader> runtime;
+  NiceMock<Upstream::MockClusterManager> cm;
+  EXPECT_THROW_WITH_REGEX(ConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), runtime, cm, true),
+                          EnvoyException, "total_weight in the weighted_cluster");
+}
+
 TEST(RouteMatcherTest, WeightedClustersEmptyClustersList) {
   std::string json = R"EOF(
 {
@@ -2568,33 +2646,48 @@ TEST(RouteMatcherTest, WeightedClustersEmptyClustersList) {
 }
 
 TEST(RouteMatcherTest, WeightedClustersSumOFWeightsNotEqualToMax) {
-  std::string json = R"EOF(
-{
-  "virtual_hosts": [
-    {
-      "name": "www2",
-      "domains": ["www.lyft.com"],
-      "routes": [
-        {
-          "prefix": "/",
-          "weighted_clusters": {
-            "clusters" : [
-              { "name" : "cluster1", "weight" : 3 },
-              { "name" : "cluster2", "weight" : 3 },
-              { "name" : "cluster3", "weight" : 3 }
-            ]
-          }
-        }
-      ]
-    }
-  ]
-}
+  std::string yaml = R"EOF(
+virtual_hosts:
+  - name: www2
+    domains: ["www.lyft.com"]
+    routes:
+      - match: { prefix: "/" }
+        route:
+          weighted_clusters:
+            clusters:
+              - name: cluster1
+                weight: 3
+              - name: cluster2
+                weight: 3
+              - name: cluster3
+                weight: 3
   )EOF";
 
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
-  EXPECT_THROW(ConfigImpl(parseRouteConfigurationFromJson(json), runtime, cm, true),
-               EnvoyException);
+  EXPECT_THROW_WITH_REGEX(ConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), runtime, cm, true),
+                          EnvoyException, "should add up to 100");
+
+  yaml = R"EOF(
+virtual_hosts:
+  - name: www2
+    domains: ["www.lyft.com"]
+    routes:
+      - match: { prefix: "/" }
+        route:
+          weighted_clusters:
+            total_weight: 99
+            clusters:
+              - name: cluster1
+                weight: 3
+              - name: cluster2
+                weight: 3
+              - name: cluster3
+                weight: 3
+  )EOF";
+
+  EXPECT_THROW_WITH_REGEX(ConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), runtime, cm, true),
+                          EnvoyException, "should add up to 99");
 }
 
 TEST(RouteMatcherTest, TestWeightedClusterWithMissingWeights) {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2614,8 +2614,9 @@ virtual_hosts:
 
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
-  EXPECT_THROW_WITH_REGEX(ConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), runtime, cm, true),
-                          EnvoyException, "total_weight in the weighted_cluster");
+  EXPECT_THROW_WITH_MESSAGE(ConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), runtime, cm, true),
+                            EnvoyException,
+                            "total_weight in the weighted_cluster must be greater than 0");
 }
 
 TEST(RouteMatcherTest, WeightedClustersEmptyClustersList) {
@@ -2666,7 +2667,8 @@ virtual_hosts:
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
   EXPECT_THROW_WITH_REGEX(ConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), runtime, cm, true),
-                          EnvoyException, "should add up to 100");
+                          EnvoyException,
+                          "Sum of weights in the weighted_cluster should add up to 100");
 
   yaml = R"EOF(
 virtual_hosts:
@@ -2687,7 +2689,8 @@ virtual_hosts:
   )EOF";
 
   EXPECT_THROW_WITH_REGEX(ConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), runtime, cm, true),
-                          EnvoyException, "should add up to 99");
+                          EnvoyException,
+                          "Sum of weights in the weighted_cluster should add up to 99");
 }
 
 TEST(RouteMatcherTest, TestWeightedClusterWithMissingWeights) {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2666,9 +2666,9 @@ virtual_hosts:
 
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Upstream::MockClusterManager> cm;
-  EXPECT_THROW_WITH_REGEX(ConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), runtime, cm, true),
-                          EnvoyException,
-                          "Sum of weights in the weighted_cluster should add up to 100");
+  EXPECT_THROW_WITH_MESSAGE(ConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), runtime, cm, true),
+                            EnvoyException,
+                            "Sum of weights in the weighted_cluster should add up to 100");
 
   yaml = R"EOF(
 virtual_hosts:
@@ -2688,9 +2688,9 @@ virtual_hosts:
                 weight: 3
   )EOF";
 
-  EXPECT_THROW_WITH_REGEX(ConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), runtime, cm, true),
-                          EnvoyException,
-                          "Sum of weights in the weighted_cluster should add up to 99");
+  EXPECT_THROW_WITH_MESSAGE(ConfigImpl(parseRouteConfigurationFromV2Yaml(yaml), runtime, cm, true),
+                            EnvoyException,
+                            "Sum of weights in the weighted_cluster should add up to 99");
 }
 
 TEST(RouteMatcherTest, TestWeightedClusterWithMissingWeights) {


### PR DESCRIPTION
*Description*:
Modifies RouteEntryImplBase to allow the total weight of weighted clusters to be specified by the configuration. The total weight defaults to 100, so existing configurations continue to work as before. If the total weight is overridden, more granular distribution of requests across weighted clusters is possible.

*Risk Level*: Low

*Testing*:
Unit tests for configuration handling and routing.

*Doc/API Changes*: envoyproxy/data-plane-api#431

*Release Notes*: updated

*Fixes*: #2253
