### PR TITLE
build: remove custom xcode flags for boringssl

### DIFF
--- a/ci/build_container/build_recipes/boringssl.sh
+++ b/ci/build_container/build_recipes/boringssl.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-# TODO(zuercher): Xcode 9 seems to need this or else boringssl doesn't compile
-if [[ `uname` == "Darwin" ]];
-then
-    export CPPFLAGS="$CPPFLAGS -D_DARWIN_C_SOURCE"
-fi
-
 COMMIT=664e99a6486c293728097c661332f92bf2d847c6  # chromium-63.0.3239.84
 
 git clone https://boringssl.googlesource.com/boringssl


### PR DESCRIPTION
*Description*:
One of the BoringSSL updates we've picked up in the last few months fixed the need for extra flags when compiling BoringSSL in Xcode 9.

*Risk Level*: Low
*Testing*: existing CI is sufficient
*Release Notes*: N/A

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
