### PR TITLE
ci: allowed to create users with duplicate in run_envoy_docker script

### DIFF
--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -21,5 +21,5 @@ mkdir -p "${ENVOY_DOCKER_BUILD_DIR}"
 docker run --rm -t -i -e http_proxy=${http_proxy} -e https_proxy=${https_proxy} \
   -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build \
   -v "$PWD":/source -e NUM_CPUS --cap-add SYS_PTRACE "${IMAGE_NAME}":"${IMAGE_ID}" \
-  /bin/bash -lc "groupadd --gid $(id -g) -f envoygroup && useradd --uid $(id -u) --gid $(id -g) \
+  /bin/bash -lc "groupadd --gid $(id -g) -f envoygroup && useradd -o --uid $(id -u) --gid $(id -g) \
   --no-create-home --home-dir /source envoybuild && su envoybuild -c \"cd source && $*\""


### PR DESCRIPTION
Description: This PR fixes #2379 (Linux) by passing --non-unique to docker command. This option allows creating duplicated users.

Risk Level: Low

Testing: manual OSx, Linux

Signed-off-by: Gabriel gsagula@gmail.com