### PR TITLE
router: correct cluster name for ads in routes

### DIFF
--- a/include/envoy/router/rds.h
+++ b/include/envoy/router/rds.h
@@ -51,10 +51,10 @@ public:
   virtual const std::string& routeConfigName() const PURE;
 
   /**
-   * @return const std::string& the configuration of the cluster the RdsRouteConfigProvider is
+   * @return const std::string& the configuration of service the RdsRouteConfigProvider is
    * issuing RDS requests to.
    */
-  virtual const std::string& clusterConfig() const PURE;
+  virtual const std::string& configSource() const PURE;
 };
 
 typedef std::shared_ptr<RouteConfigProvider> RouteConfigProviderSharedPtr;

--- a/include/envoy/router/rds.h
+++ b/include/envoy/router/rds.h
@@ -51,10 +51,10 @@ public:
   virtual const std::string& routeConfigName() const PURE;
 
   /**
-   * @return const std::string& the name of the cluster the RdsRouteConfigProvider is issuing RDS
-   * requests to.
+   * @return const std::string& the configuration of the cluster the RdsRouteConfigProvider is
+   * issuing RDS requests to.
    */
-  virtual const std::string& clusterName() const PURE;
+  virtual const std::string& clusterConfig() const PURE;
 };
 
 typedef std::shared_ptr<RouteConfigProvider> RouteConfigProviderSharedPtr;

--- a/include/envoy/router/rds.h
+++ b/include/envoy/router/rds.h
@@ -51,7 +51,7 @@ public:
   virtual const std::string& routeConfigName() const PURE;
 
   /**
-   * @return const std::string& the configuration of service the RdsRouteConfigProvider is
+   * @return const std::string& the configuration of the service the RdsRouteConfigProvider is
    * issuing RDS requests to.
    */
   virtual const std::string& configSource() const PURE;

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -59,17 +59,25 @@ void MessageUtil::loadFromFile(const std::string& path, Protobuf::Message& messa
   }
 }
 
-std::string MessageUtil::getJsonStringFromMessage(const Protobuf::Message& message) {
+std::string MessageUtil::getJsonStringFromMessage(const Protobuf::Message& message,
+                                                  const bool pretty_print) {
   Protobuf::util::JsonPrintOptions json_options;
   // By default, proto field names are converted to camelCase when the message is converted to JSON.
   // Setting this option makes debugging easier because it keeps field names consistent in JSON
   // printouts.
   json_options.preserve_proto_field_names = true;
+  if (pretty_print) {
+    json_options.add_whitespace = true;
+  }
   ProtobufTypes::String json;
   const auto status = Protobuf::util::MessageToJsonString(message, &json, json_options);
   // This should always succeed unless something crash-worthy such as out-of-memory.
   RELEASE_ASSERT(status.ok());
   return json;
+}
+
+std::string MessageUtil::getJsonStringFromMessage(const Protobuf::Message& message) {
+  return getJsonStringFromMessage(message, false);
 }
 
 void MessageUtil::jsonConvert(const Protobuf::Message& source, Protobuf::Message& dest) {

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -76,10 +76,6 @@ std::string MessageUtil::getJsonStringFromMessage(const Protobuf::Message& messa
   return json;
 }
 
-std::string MessageUtil::getJsonStringFromMessage(const Protobuf::Message& message) {
-  return getJsonStringFromMessage(message, false);
-}
-
 void MessageUtil::jsonConvert(const Protobuf::Message& source, Protobuf::Message& dest) {
   // TODO(htuch): Consolidate with the inflight cleanups here.
   Protobuf::util::JsonOptions json_options;

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -178,18 +178,11 @@ public:
   /**
    * Extract JSON as string from a google.protobuf.Message.
    * @param message message of type type.googleapis.com/google.protobuf.Message.
-   * @return std::string of JSON object.
-   */
-  static std::string getJsonStringFromMessage(const Protobuf::Message& message);
-
-  /**
-   * Extract JSON as string from a google.protobuf.Message.
-   * @param message message of type type.googleapis.com/google.protobuf.Message.
    * @param pretty_print whether the returned JSON should be formatted.
    * @return std::string of formatted JSON object.
    */
   static std::string getJsonStringFromMessage(const Protobuf::Message& message,
-                                              const bool pretty_print);
+                                              const bool pretty_print = false);
 
   /**
    * Extract JSON object from a google.protobuf.Message.

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -183,6 +183,15 @@ public:
   static std::string getJsonStringFromMessage(const Protobuf::Message& message);
 
   /**
+   * Extract JSON as string from a google.protobuf.Message.
+   * @param message message of type type.googleapis.com/google.protobuf.Message.
+   * @param pretty_print whether the returned JSON should be formatted.
+   * @return std::string of formatted JSON object.
+   */
+  static std::string getJsonStringFromMessage(const Protobuf::Message& message,
+                                              const bool pretty_print);
+
+  /**
    * Extract JSON object from a google.protobuf.Message.
    * @param message message of type type.googleapis.com/google.protobuf.Message.
    * @return Json::ObjectSharedPtr of JSON object or nullptr if unable to extract.

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -181,7 +181,7 @@ public:
    * @param pretty_print whether the returned JSON should be formatted.
    * @return std::string of formatted JSON object.
    */
-  static std::string getJsonStringFromMessage(Protobuf::Message& message,
+  static std::string getJsonStringFromMessage(const Protobuf::Message& message,
                                               bool pretty_print = false);
 
   /**

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -181,8 +181,8 @@ public:
    * @param pretty_print whether the returned JSON should be formatted.
    * @return std::string of formatted JSON object.
    */
-  static std::string getJsonStringFromMessage(const Protobuf::Message& message,
-                                              const bool pretty_print = false);
+  static std::string getJsonStringFromMessage(Protobuf::Message& message,
+                                              bool pretty_print = false);
 
   /**
    * Extract JSON object from a google.protobuf.Message.

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -76,7 +76,7 @@ RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
   if (rds.has_config_source()) {
     config_source_ = MessageUtil::getJsonStringFromMessage(rds.config_source(), true);
   } else {
-    config_source_ = "NO_CONFIG_SOURCE";
+    config_source_ = "{}";
   }
 }
 

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -74,7 +74,7 @@ RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
   // local filesystem. If the subscription happens via local filesystem (e.g xds_integration_test),
   // then there is no actual RDS server, and hence no RDS cluster name.
   if (rds.has_config_source()) {
-    config_source_ = MessageUtil::getJsonStringFromMessage(rds.config_source());
+    config_source_ = MessageUtil::getJsonStringFromMessage(rds.config_source(), true);
   } else {
     config_source_ = "NOT_USING_CLUSTER";
   }

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -75,6 +75,8 @@ RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
   // then there is no actual RDS server, and hence no RDS cluster name.
   if (rds.has_config_source() && rds.config_source().has_api_config_source()) {
     cluster_name_ = rds.config_source().api_config_source().cluster_names()[0];
+  } else if (rds.has_config_source() && rds.config_source().has_ads()) {
+    cluster_name_ = "ADS_CLUSTER";
   } else {
     cluster_name_ = "NOT_USING_CLUSTER";
   }

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -73,10 +73,12 @@ RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
   // In V2 we use a Subscription model where the fetch can happen via gRPC, REST, or
   // local filesystem. If the subscription happens via local filesystem (e.g xds_integration_test),
   // then there is no actual RDS server, and hence no RDS cluster name.
-  if (rds.has_config_source() && (rds.config_source().has_api_config_source() || rds.config_source().has_ads())) {
-    cluster_name_ = MessageUtil::getJsonStringFromMessage(rds.config_source().api_config_source());
+  if (rds.has_config_source() &&
+      (rds.config_source().has_api_config_source() || rds.config_source().has_ads())) {
+    cluster_config_ =
+        MessageUtil::getJsonStringFromMessage(rds.config_source().api_config_source());
   } else {
-    cluster_name_ = "NOT_USING_CLUSTER";
+    cluster_config_ = "NOT_USING_CLUSTER";
   }
 }
 
@@ -247,7 +249,7 @@ Http::Code RouteConfigProviderManagerImpl::handlerRoutesLoop(
     response.add("{\n");
     response.add(fmt::format("\"version_info\": \"{}\",\n", provider->versionInfo()));
     response.add(fmt::format("\"route_config_name\": \"{}\",\n", provider->routeConfigName()));
-    response.add(fmt::format("\"cluster_config\": {},\n", provider->clusterName()));
+    response.add(fmt::format("\"cluster_config\": {},\n", provider->clusterConfig()));
     response.add("\"route_table_dump\": ");
     response.add(fmt::format("{}\n", provider->configAsJson()));
     response.add("}\n");

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -76,7 +76,7 @@ RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
   if (rds.has_config_source()) {
     config_source_ = MessageUtil::getJsonStringFromMessage(rds.config_source(), true);
   } else {
-    config_source_ = "NOT_USING_CLUSTER";
+    config_source_ = "NO_CONFIG_SOURCE";
   }
 }
 

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -73,10 +73,8 @@ RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
   // In V2 we use a Subscription model where the fetch can happen via gRPC, REST, or
   // local filesystem. If the subscription happens via local filesystem (e.g xds_integration_test),
   // then there is no actual RDS server, and hence no RDS cluster name.
-  if (rds.has_config_source() && rds.config_source().has_api_config_source()) {
-    cluster_name_ = rds.config_source().api_config_source().cluster_names()[0];
-  } else if (rds.has_config_source() && rds.config_source().has_ads()) {
-    cluster_name_ = "ADS_CLUSTER";
+  if (rds.has_config_source() && (rds.config_source().has_api_config_source() || rds.config_source().has_ads())) {
+    cluster_name_ = MessageUtil::getJsonStringFromMessage(rds.config_source().api_config_source());
   } else {
     cluster_name_ = "NOT_USING_CLUSTER";
   }
@@ -249,7 +247,7 @@ Http::Code RouteConfigProviderManagerImpl::handlerRoutesLoop(
     response.add("{\n");
     response.add(fmt::format("\"version_info\": \"{}\",\n", provider->versionInfo()));
     response.add(fmt::format("\"route_config_name\": \"{}\",\n", provider->routeConfigName()));
-    response.add(fmt::format("\"cluster_name\": \"{}\",\n", provider->clusterName()));
+    response.add(fmt::format("\"cluster_config\": {},\n", provider->clusterName()));
     response.add("\"route_table_dump\": ");
     response.add(fmt::format("{}\n", provider->configAsJson()));
     response.add("}\n");

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -73,12 +73,10 @@ RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
   // In V2 we use a Subscription model where the fetch can happen via gRPC, REST, or
   // local filesystem. If the subscription happens via local filesystem (e.g xds_integration_test),
   // then there is no actual RDS server, and hence no RDS cluster name.
-  if (rds.has_config_source() &&
-      (rds.config_source().has_api_config_source() || rds.config_source().has_ads())) {
-    cluster_config_ =
-        MessageUtil::getJsonStringFromMessage(rds.config_source().api_config_source());
+  if (rds.has_config_source()) {
+    config_source_ = MessageUtil::getJsonStringFromMessage(rds.config_source());
   } else {
-    cluster_config_ = "NOT_USING_CLUSTER";
+    config_source_ = "NOT_USING_CLUSTER";
   }
 }
 
@@ -249,7 +247,7 @@ Http::Code RouteConfigProviderManagerImpl::handlerRoutesLoop(
     response.add("{\n");
     response.add(fmt::format("\"version_info\": \"{}\",\n", provider->versionInfo()));
     response.add(fmt::format("\"route_config_name\": \"{}\",\n", provider->routeConfigName()));
-    response.add(fmt::format("\"cluster_config\": {},\n", provider->clusterConfig()));
+    response.add(fmt::format("\"config_source\": {},\n", provider->configSource()));
     response.add("\"route_table_dump\": ");
     response.add(fmt::format("{}\n", provider->configAsJson()));
     response.add("}\n");

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -69,15 +69,7 @@ RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
       },
       "envoy.api.v2.RouteDiscoveryService.FetchRoutes",
       "envoy.api.v2.RouteDiscoveryService.StreamRoutes");
-
-  // In V2 we use a Subscription model where the fetch can happen via gRPC, REST, or
-  // local filesystem. If the subscription happens via local filesystem (e.g xds_integration_test),
-  // then there is no actual RDS server, and hence no RDS cluster name.
-  if (rds.has_config_source()) {
-    config_source_ = MessageUtil::getJsonStringFromMessage(rds.config_source(), true);
-  } else {
-    config_source_ = "{}";
-  }
+  config_source_ = MessageUtil::getJsonStringFromMessage(rds.config_source(), true);
 }
 
 RdsRouteConfigProviderImpl::~RdsRouteConfigProviderImpl() {

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -101,7 +101,7 @@ public:
     return MessageUtil::getJsonStringFromMessage(route_config_proto_);
   }
   const std::string& routeConfigName() const override { return route_config_name_; }
-  const std::string& clusterName() const override { return cluster_name_; }
+  const std::string& clusterConfig() const override { return cluster_config_; }
   const std::string versionInfo() const override { return subscription_->versionInfo(); }
 
   // Config::SubscriptionCallbacks
@@ -130,7 +130,7 @@ private:
   Upstream::ClusterManager& cm_;
   std::unique_ptr<Envoy::Config::Subscription<envoy::api::v2::RouteConfiguration>> subscription_;
   ThreadLocal::SlotPtr tls_;
-  std::string cluster_name_;
+  std::string cluster_config_;
   const std::string route_config_name_;
   bool initialized_{};
   uint64_t last_config_hash_{};

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -101,7 +101,7 @@ public:
     return MessageUtil::getJsonStringFromMessage(route_config_proto_);
   }
   const std::string& routeConfigName() const override { return route_config_name_; }
-  const std::string& clusterConfig() const override { return cluster_config_; }
+  const std::string& configSource() const override { return config_source_; }
   const std::string versionInfo() const override { return subscription_->versionInfo(); }
 
   // Config::SubscriptionCallbacks
@@ -130,7 +130,7 @@ private:
   Upstream::ClusterManager& cm_;
   std::unique_ptr<Envoy::Config::Subscription<envoy::api::v2::RouteConfiguration>> subscription_;
   ThreadLocal::SlotPtr tls_;
-  std::string cluster_config_;
+  std::string config_source_;
   const std::string route_config_name_;
   bool initialized_{};
   uint64_t last_config_hash_{};

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -98,7 +98,7 @@ public:
 
   // Router::RdsRouteConfigProvider
   std::string configAsJson() const override {
-    return MessageUtil::getJsonStringFromMessage(route_config_proto_);
+    return MessageUtil::getJsonStringFromMessage(route_config_proto_, true);
   }
   const std::string& routeConfigName() const override { return route_config_name_; }
   const std::string& configSource() const override { return config_source_; }

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -215,7 +215,7 @@ TEST_F(RdsImplTest, Basic) {
 {
 "version_info": "",
 "route_config_name": "foo_route_config",
-"cluster_name": "foo_cluster",
+"cluster_config": {"cluster_names":["foo_cluster"],"refresh_delay":"1s"},
 "route_table_dump": {}
 }
 ]
@@ -248,7 +248,7 @@ TEST_F(RdsImplTest, Basic) {
 {
 "version_info": "hash_15ed54077da94d8b",
 "route_config_name": "foo_route_config",
-"cluster_name": "foo_cluster",
+"cluster_config": {"cluster_names":["foo_cluster"],"refresh_delay":"1s"},
 "route_table_dump": {"name":"foo_route_config"}
 }
 ]
@@ -327,7 +327,7 @@ TEST_F(RdsImplTest, Basic) {
 {
 "version_info": "hash_7a3f97b327d08382",
 "route_config_name": "foo_route_config",
-"cluster_name": "foo_cluster",
+"cluster_config": {"cluster_names":["foo_cluster"],"refresh_delay":"1s"},
 "route_table_dump": {"name":"foo_route_config","virtual_hosts":[{"name":"local_service","domains":["*"],"routes":[{"match":{"prefix":"/foo"},"route":{"cluster_header":":authority"}},{"match":{"prefix":"/bar"},"route":{"cluster":"bar"}}]}]}
 }
 ]
@@ -524,13 +524,13 @@ TEST_F(RouteConfigProviderManagerImplTest, Basic) {
 {
 "version_info": "",
 "route_config_name": "foo_route_config",
-"cluster_name": "bar_cluster",
+"cluster_config": {"cluster_names":["bar_cluster"],"refresh_delay":"1s"},
 "route_table_dump": {}
 }
 ,{
 "version_info": "",
 "route_config_name": "foo_route_config",
-"cluster_name": "foo_cluster",
+"cluster_config": {"cluster_names":["foo_cluster"],"refresh_delay":"1s"},
 "route_table_dump": {}
 }
 ]

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -215,7 +215,7 @@ TEST_F(RdsImplTest, Basic) {
 {
 "version_info": "",
 "route_config_name": "foo_route_config",
-"cluster_config": {"cluster_names":["foo_cluster"],"refresh_delay":"1s"},
+"config_source": {"api_config_source":{"cluster_names":["foo_cluster"],"refresh_delay":"1s"}},
 "route_table_dump": {}
 }
 ]
@@ -248,7 +248,7 @@ TEST_F(RdsImplTest, Basic) {
 {
 "version_info": "hash_15ed54077da94d8b",
 "route_config_name": "foo_route_config",
-"cluster_config": {"cluster_names":["foo_cluster"],"refresh_delay":"1s"},
+"config_source": {"api_config_source":{"cluster_names":["foo_cluster"],"refresh_delay":"1s"}},
 "route_table_dump": {"name":"foo_route_config"}
 }
 ]
@@ -327,7 +327,7 @@ TEST_F(RdsImplTest, Basic) {
 {
 "version_info": "hash_7a3f97b327d08382",
 "route_config_name": "foo_route_config",
-"cluster_config": {"cluster_names":["foo_cluster"],"refresh_delay":"1s"},
+"config_source": {"api_config_source":{"cluster_names":["foo_cluster"],"refresh_delay":"1s"}},
 "route_table_dump": {"name":"foo_route_config","virtual_hosts":[{"name":"local_service","domains":["*"],"routes":[{"match":{"prefix":"/foo"},"route":{"cluster_header":":authority"}},{"match":{"prefix":"/bar"},"route":{"cluster":"bar"}}]}]}
 }
 ]
@@ -524,13 +524,13 @@ TEST_F(RouteConfigProviderManagerImplTest, Basic) {
 {
 "version_info": "",
 "route_config_name": "foo_route_config",
-"cluster_config": {"cluster_names":["bar_cluster"],"refresh_delay":"1s"},
+"config_source": {"api_config_source":{"cluster_names":["bar_cluster"],"refresh_delay":"1s"}},
 "route_table_dump": {}
 }
 ,{
 "version_info": "",
 "route_config_name": "foo_route_config",
-"cluster_config": {"cluster_names":["foo_cluster"],"refresh_delay":"1s"},
+"config_source": {"api_config_source":{"cluster_names":["foo_cluster"],"refresh_delay":"1s"}},
 "route_table_dump": {}
 }
 ]

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -215,8 +215,17 @@ TEST_F(RdsImplTest, Basic) {
 {
 "version_info": "",
 "route_config_name": "foo_route_config",
-"config_source": {"api_config_source":{"cluster_names":["foo_cluster"],"refresh_delay":"1s"}},
+"config_source": {
+ "api_config_source": {
+  "cluster_names": [
+   "foo_cluster"
+  ],
+  "refresh_delay": "1s"
+ }
+}
+,
 "route_table_dump": {}
+
 }
 ]
 )EOF";
@@ -248,8 +257,19 @@ TEST_F(RdsImplTest, Basic) {
 {
 "version_info": "hash_15ed54077da94d8b",
 "route_config_name": "foo_route_config",
-"config_source": {"api_config_source":{"cluster_names":["foo_cluster"],"refresh_delay":"1s"}},
-"route_table_dump": {"name":"foo_route_config"}
+"config_source": {
+ "api_config_source": {
+  "cluster_names": [
+   "foo_cluster"
+  ],
+  "refresh_delay": "1s"
+ }
+}
+,
+"route_table_dump": {
+ "name": "foo_route_config"
+}
+
 }
 ]
 )EOF";
@@ -327,8 +347,45 @@ TEST_F(RdsImplTest, Basic) {
 {
 "version_info": "hash_7a3f97b327d08382",
 "route_config_name": "foo_route_config",
-"config_source": {"api_config_source":{"cluster_names":["foo_cluster"],"refresh_delay":"1s"}},
-"route_table_dump": {"name":"foo_route_config","virtual_hosts":[{"name":"local_service","domains":["*"],"routes":[{"match":{"prefix":"/foo"},"route":{"cluster_header":":authority"}},{"match":{"prefix":"/bar"},"route":{"cluster":"bar"}}]}]}
+"config_source": {
+ "api_config_source": {
+  "cluster_names": [
+   "foo_cluster"
+  ],
+  "refresh_delay": "1s"
+ }
+}
+,
+"route_table_dump": {
+ "name": "foo_route_config",
+ "virtual_hosts": [
+  {
+   "name": "local_service",
+   "domains": [
+    "*"
+   ],
+   "routes": [
+    {
+     "match": {
+      "prefix": "/foo"
+     },
+     "route": {
+      "cluster_header": ":authority"
+     }
+    },
+    {
+     "match": {
+      "prefix": "/bar"
+     },
+     "route": {
+      "cluster": "bar"
+     }
+    }
+   ]
+  }
+ ]
+}
+
 }
 ]
 )EOF";
@@ -524,14 +581,32 @@ TEST_F(RouteConfigProviderManagerImplTest, Basic) {
 {
 "version_info": "",
 "route_config_name": "foo_route_config",
-"config_source": {"api_config_source":{"cluster_names":["bar_cluster"],"refresh_delay":"1s"}},
+"config_source": {
+ "api_config_source": {
+  "cluster_names": [
+   "bar_cluster"
+  ],
+  "refresh_delay": "1s"
+ }
+}
+,
 "route_table_dump": {}
+
 }
 ,{
 "version_info": "",
 "route_config_name": "foo_route_config",
-"config_source": {"api_config_source":{"cluster_names":["foo_cluster"],"refresh_delay":"1s"}},
+"config_source": {
+ "api_config_source": {
+  "cluster_names": [
+   "foo_cluster"
+  ],
+  "refresh_delay": "1s"
+ }
+}
+,
 "route_table_dump": {}
+
 }
 ]
 )EOF";


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
Fix Cluster name for ADS configured RDS in routes

*Description*:
When admin/routes displays the route table, configured with RDS, it shows the cluster name as `"NOT_USING_CLUSTER"`. Fixed it to display `"ADS_CLUSTER"`

*Risk Level*: Low 
*Testing*: Manual
*Docs Changes*: N/A
*Release Notes*: N/A
