### PR TITLE
bazel: fix protobuf UBSAN errors

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -13,8 +13,9 @@ build:asan --define tcmalloc=disabled
 build:asan --build_tag_filters=-no_asan
 build:asan --test_tag_filters=-no_asan
 build:asan --define signal_trace=disabled
+build:asan --copt -DADDRESS_SANITIZER=1
 
-# Clang 5.0 ASAN
+# Clang 5.0 ASAN/UBSAN
 build:clang-asan --define ENVOY_CONFIG_ASAN=1
 build:clang-asan --copt -D__SANITIZE_ADDRESS__
 build:clang-asan --copt -fsanitize=address,undefined
@@ -27,6 +28,7 @@ build:clang-asan --define tcmalloc=disabled
 build:clang-asan --build_tag_filters=-no_asan
 build:clang-asan --test_tag_filters=-no_asan
 build:clang-asan --define signal_trace=disabled
+build:clang-asan --copt -DADDRESS_SANITIZER=1
 build:clang-asan --test_env=ASAN_SYMBOLIZER_PATH
 
 # Clang 5.0 TSAN


### PR DESCRIPTION
*Description*:
The google-protobuf library, by default, uses unaligned reads on x86.
Those happen to work on that CPU architecture, but their behavior is
undefined in C/C++, so UBSAN (which runs along with ASAN in the CI
ASAN tests) treats them as an error.

Defining `ADDRESS_SANITIZER=1` causes the protobuf library to use
a portable alternative to the unaligned reads.

*Risk Level*: Low

*Testing*: I tested this change with PR [2429](https://github.com/envoyproxy/envoy/pull/2429), where it fixed the ASAN test failure.

*Docs Changes*: N/A

*Release Notes*: N/A

Signed-off-by: Brian Pane <bpane@pinterest.com>
