### PR TITLE
Minor patch to tools/check_format.py to fix #2391 .

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -177,8 +177,7 @@ if __name__ == "__main__":
   if os.path.isfile(target_path):
     checkFormat("./" + target_path)
   else:
-    os.chdir(target_path)
-    os.path.walk(".", checkFormatVisitor, None)
+    os.path.walk(target_path, checkFormatVisitor, None)
 
   if found_error:
     print "ERROR: check format failed. run 'tools/check_format.py fix'"


### PR DESCRIPTION
*Description*:
Fixes #2391  .
Reason for Issue : 
If a directory is passed to the script , current directory is changed and relative path is used .
When /tools/header.py is called with relative path  it couldn't find the file .

Fix : fixed by using absolute path instead of changing directory and using relative path .

*Risk Level*: 
 Small bug fix for tooling

*Testing*:
Tested with this one-liner(./tools/check_format.py check source/common/stats) and seems to work fine 

*Docs Changes*:
N/A

*Release Notes*:
Now directories can also be passed as an argument to /tools/check_format.py .

[Optional Fixes #Issue]

