### PR TITLE
lua: change log level from warn to info for lua function not found cases

### DIFF
--- a/source/common/lua/lua.cc
+++ b/source/common/lua/lua.cc
@@ -71,7 +71,7 @@ uint64_t ThreadLocalState::registerGlobal(const std::string& global) {
     if (lua_isfunction(tls.state_.get(), -1)) {
       tls.global_slots_.push_back(luaL_ref(tls.state_.get(), LUA_REGISTRYINDEX));
     } else {
-      ENVOY_LOG(warn, "no '{}' global found in script", global);
+      ENVOY_LOG(info, "definition for '{}' not found in script", global);
       lua_pop(tls.state_.get(), 1);
       tls.global_slots_.push_back(LUA_REFNIL);
     }

--- a/source/common/lua/lua.h
+++ b/source/common/lua/lua.h
@@ -127,7 +127,7 @@ public:
 
     // Register the type by creating a new metatable, setting __index to itself, and then
     // performing the register.
-    ENVOY_LOG(info, "registering new type: {}", typeid(T).name());
+    ENVOY_LOG(debug, "registering new type: {}", typeid(T).name());
     int rc = luaL_newmetatable(state, typeid(T).name());
     ASSERT(rc == 1);
     UNREFERENCED_PARAMETER(rc);


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>

*Description*: Changes the log level to info if `envoy_response` function is not found
*Risk Level*: Low
*Testing*: Manual
*Docs Changes*: N/A
*Release Notes*: N/A

