### PR TITLE
build image: Install openssl in the centos build image.

### DIFF
--- a/ci/build_container/build_container_centos.sh
+++ b/ci/build_container/build_container_centos.sh
@@ -8,7 +8,7 @@ curl -L -o /etc/yum.repos.d/alonid-llvm-5.0.0-epel-7.repo \
   https://copr.fedorainfracloud.org/coprs/alonid/llvm-5.0.0/repo/epel-7/alonid-llvm-5.0.0-epel-7.repo
 
 # dependencies for bazel and build_recipes
-yum install -y java-1.8.0-openjdk-devel unzip which \
+yum install -y java-1.8.0-openjdk-devel unzip which openssl rpm-build \
                cmake3 devtoolset-4-gcc-c++ git golang libtool make patch rsync wget \
                clang-5.0.0 devtoolset-4-libatomic-devel llvm-5.0.0 python-virtualenv
 yum clean all


### PR DESCRIPTION
The openssl CLI tool is needed for tests.

Also, for good measure, install rpm-build, because it is likely that someone
compiling on centos will want to package the results in rpm format.

Fixes #2425

Signed-off-by: Greg Greenway <ggreenway@apple.com>

*Risk Level*: Low

*Testing*: Manually built the image, and built "bazel.release" in that image
