### PR TITLE
metrics: populate metric type and time stamp in Metric Service

### DIFF
--- a/source/common/stats/grpc_metrics_service_impl.h
+++ b/source/common/stats/grpc_metrics_service_impl.h
@@ -117,16 +117,22 @@ public:
 
   void flushCounter(const Counter& counter, uint64_t) override {
     io::prometheus::client::MetricFamily* metrics_family = message_.add_envoy_metrics();
+    io::prometheus::client::MetricType counter_type = io::prometheus::client::MetricType::COUNTER;
+    metrics_family->set_type(counter_type);
     metrics_family->set_name(counter.name());
     auto* metric = metrics_family->add_metric();
+    metric->set_timestamp_ms(std::chrono::system_clock::now().time_since_epoch().count());
     auto* counter_metric = metric->mutable_counter();
     counter_metric->set_value(counter.value());
   }
 
   void flushGauge(const Gauge& gauge, uint64_t value) override {
     io::prometheus::client::MetricFamily* metrics_family = message_.add_envoy_metrics();
+    io::prometheus::client::MetricType gauge_type = io::prometheus::client::MetricType::GAUGE;
+    metrics_family->set_type(gauge_type);
     metrics_family->set_name(gauge.name());
     auto* metric = metrics_family->add_metric();
+    metric->set_timestamp_ms(std::chrono::system_clock::now().time_since_epoch().count());
     auto* gauage_metric = metric->mutable_gauge();
     gauage_metric->set_value(value);
   }

--- a/source/common/stats/grpc_metrics_service_impl.h
+++ b/source/common/stats/grpc_metrics_service_impl.h
@@ -117,8 +117,7 @@ public:
 
   void flushCounter(const Counter& counter, uint64_t) override {
     io::prometheus::client::MetricFamily* metrics_family = message_.add_envoy_metrics();
-    io::prometheus::client::MetricType counter_type = io::prometheus::client::MetricType::COUNTER;
-    metrics_family->set_type(counter_type);
+    metrics_family->set_type(io::prometheus::client::MetricType::COUNTER);
     metrics_family->set_name(counter.name());
     auto* metric = metrics_family->add_metric();
     metric->set_timestamp_ms(std::chrono::system_clock::now().time_since_epoch().count());
@@ -128,8 +127,7 @@ public:
 
   void flushGauge(const Gauge& gauge, uint64_t value) override {
     io::prometheus::client::MetricFamily* metrics_family = message_.add_envoy_metrics();
-    io::prometheus::client::MetricType gauge_type = io::prometheus::client::MetricType::GAUGE;
-    metrics_family->set_type(gauge_type);
+    metrics_family->set_type(io::prometheus::client::MetricType::GAUGE);
     metrics_family->set_name(gauge.name());
     auto* metric = metrics_family->add_metric();
     metric->set_timestamp_ms(std::chrono::system_clock::now().time_since_epoch().count());

--- a/test/integration/metrics_service_integration_test.cc
+++ b/test/integration/metrics_service_integration_test.cc
@@ -65,12 +65,12 @@ public:
     bool known_gauge_exists = false;
     for (::io::prometheus::client::MetricFamily metrics_family : envoy_metrics) {
       if (metrics_family.name() == "cluster.metrics_service.membership_change" &&
-          metrics_family.metric(0).has_counter()) {
+          metrics_family.type() == ::io::prometheus::client::MetricType::COUNTER) {
         known_counter_exists = true;
         EXPECT_EQ(1, metrics_family.metric(0).counter().value());
       }
       if (metrics_family.name() == "cluster.metrics_service.membership_total" &&
-          metrics_family.metric(0).has_gauge()) {
+          metrics_family.type() == ::io::prometheus::client::MetricType::GAUGE) {
         known_gauge_exists = true;
         EXPECT_EQ(1, metrics_family.metric(0).gauge().value());
       }

--- a/test/integration/metrics_service_integration_test.cc
+++ b/test/integration/metrics_service_integration_test.cc
@@ -74,6 +74,7 @@ public:
         known_gauge_exists = true;
         EXPECT_EQ(1, metrics_family.metric(0).gauge().value());
       }
+      ASSERT(metrics_family.metric(0).has_timestamp_ms());
       if (known_counter_exists && known_gauge_exists) {
         break;
       }


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*:
Metric Service does not populate the type and timestamp. It is easier to check the `type` in `MetricFamily` rather than checking `has_counter()` and `has_gauge()`. Also the time stamp field is not populated.

*Risk Level*: Low
*Testing*: Integration test upated
*Docs Changes*: N/A
*Release Notes*: N/A
