### PR TITLE
Fixing a (macos) test flake

### DIFF
--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -810,7 +810,13 @@ INSTANTIATE_TEST_CASE_P(IpVersions, ReadBufferLimitTest,
 
 TEST_P(ReadBufferLimitTest, NoLimit) { readBufferLimitTest(0, 256 * 1024); }
 
-TEST_P(ReadBufferLimitTest, SomeLimit) { readBufferLimitTest(32 * 1024, 32 * 1024); }
+TEST_P(ReadBufferLimitTest, SomeLimit) {
+  const uint32_t read_buffer_limit = 32 * 1024;
+  // Envoy has soft limits, so as long as the first read is <= read_buffer_limit - 1 it will do a
+  // second read. The effective chunk size is then read_buffer_limit - 1 + MaxReadSize,
+  // which is currently 16384.
+  readBufferLimitTest(read_buffer_limit, read_buffer_limit - 1 + 16384);
+}
 
 class TcpClientConnectionImplTest : public testing::TestWithParam<Address::IpVersion> {};
 INSTANTIATE_TEST_CASE_P(IpVersions, TcpClientConnectionImplTest,


### PR DESCRIPTION
Fixing a test flake where when we did a short read, the next read resulted in a dispatch of "more than the configured buffer limit"

*Risk Level*: Low 
*Testing*: exactly
*Docs Changes*: n/a
*Release Notes*: n/a