### PR TITLE
ci: fix image container build

### DIFF
--- a/ci/build_container/build_container_ubuntu.sh
+++ b/ci/build_container/build_container_ubuntu.sh
@@ -22,5 +22,5 @@ rm -rf /var/lib/apt/lists/*
 # virtualenv
 pip install virtualenv
 
-EXPECTED_CXX_VERSION="g++ (Ubuntu 5.4.0-6ubuntu1~16.04.5) 5.4.0 20160609" ./build_container_common.sh
+EXPECTED_CXX_VERSION="g++ (Ubuntu 5.4.0-6ubuntu1~16.04.6) 5.4.0 20160609" ./build_container_common.sh
 


### PR DESCRIPTION
```
Unexpected compiler version: g++ (Ubuntu 5.4.0-6ubuntu1~16.04.6) 5.4.0 20160609
The command '/bin/sh -c ./build_container_ubuntu.sh' returned a non-zero code: 1
Exited with code 1
```