### PR TITLE
Add DOWNSTREAM_LOCAL_ADDRESS header variable

### DIFF
--- a/RAW_RELEASE_NOTES.md
+++ b/RAW_RELEASE_NOTES.md
@@ -50,3 +50,5 @@ final version.
 * Added support for [Squash microservices debugger](https://github.com/solo-io/squash).
   :ref:`Squash <envoy_api_msg_filter.http.Squash>` allows debugging an incoming request to a microservice in the mesh.
 * Added support for direct responses -- i.e., sending a preconfigured HTTP response without proxying anywhere.
+* Added DOWNSTREAM_LOCAL_ADDRESS, DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT header formatters, and
+  DOWNSTREAM_LOCAL_ADDRESS access log formatter. 

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -235,6 +235,11 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
     field_extractor_ = [](const RequestInfo::RequestInfo& request_info) {
       return request_info.downstreamLocalAddress()->asString();
     };
+  } else if (field_name == "DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT") {
+    field_extractor_ = [](const Envoy::RequestInfo::RequestInfo& request_info) {
+      return RequestInfo::Utility::formatDownstreamAddressNoPort(
+          *request_info.downstreamLocalAddress());
+    };
   } else if (field_name == "DOWNSTREAM_REMOTE_ADDRESS") {
     field_extractor_ = [](const RequestInfo::RequestInfo& request_info) {
       return request_info.downstreamRemoteAddress()->asString();

--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -126,8 +126,7 @@ RequestInfoHeaderFormatter::RequestInfoHeaderFormatter(absl::string_view field_n
       return RequestInfo::Utility::formatDownstreamAddressNoPort(
           *request_info.downstreamRemoteAddress());
     };
-  } else if (field_name == "ORIGINAL_DST" ||
-             field_name == "DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT") {
+  } else if (field_name == "DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT") {
     field_extractor_ = [](const Envoy::RequestInfo::RequestInfo& request_info) {
       return RequestInfo::Utility::formatDownstreamAddressNoPort(
           *request_info.downstreamLocalAddress());

--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -126,6 +126,10 @@ RequestInfoHeaderFormatter::RequestInfoHeaderFormatter(absl::string_view field_n
       return RequestInfo::Utility::formatDownstreamAddressNoPort(
           *request_info.downstreamRemoteAddress());
     };
+  } else if (field_name == "DOWNSTREAM_LOCAL_ADDRESS") {
+    field_extractor_ = [](const RequestInfo::RequestInfo& request_info) {
+      return request_info.downstreamLocalAddress()->asString();
+    };
   } else if (field_name == "DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT") {
     field_extractor_ = [](const Envoy::RequestInfo::RequestInfo& request_info) {
       return RequestInfo::Utility::formatDownstreamAddressNoPort(

--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -126,6 +126,12 @@ RequestInfoHeaderFormatter::RequestInfoHeaderFormatter(absl::string_view field_n
       return RequestInfo::Utility::formatDownstreamAddressNoPort(
           *request_info.downstreamRemoteAddress());
     };
+  } else if (field_name == "ORIGINAL_DST" ||
+             field_name == "DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT") {
+    field_extractor_ = [](const Envoy::RequestInfo::RequestInfo& request_info) {
+      return RequestInfo::Utility::formatDownstreamAddressNoPort(
+          *request_info.downstreamLocalAddress());
+    };
   } else if (field_name.find_first_of("UPSTREAM_METADATA") == 0) {
     field_extractor_ =
         parseUpstreamMetadataField(field_name.substr(STATIC_STRLEN("UPSTREAM_METADATA")));

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -158,6 +158,11 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
   }
 
   {
+    RequestInfoFormatter upstream_format("DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT");
+    EXPECT_EQ("127.0.0.2", upstream_format.format(header, header, request_info));
+  }
+
+  {
     RequestInfoFormatter upstream_format("DOWNSTREAM_ADDRESS");
     EXPECT_EQ("127.0.0.1", upstream_format.format(header, header, request_info));
   }

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -64,10 +64,6 @@ TEST_F(RequestInfoHeaderFormatterTest, TestFormatWithDownstreamRemoteAddressVari
   testFormatting("DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT", "127.0.0.1");
 }
 
-TEST_F(RequestInfoHeaderFormatterTest, TestFormatWithOriginalDstVariable) {
-  testFormatting("ORIGINAL_DST", "127.0.0.2");
-}
-
 TEST_F(RequestInfoHeaderFormatterTest, TestFormatWithDownstreamLocalAddressVariable) {
   testFormatting("DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT", "127.0.0.2");
 }
@@ -261,7 +257,6 @@ TEST(HeaderParserTest, TestParseInternal) {
       {"%%%PROTOCOL%%%", {"%HTTP/1.1%"}, {}},
       {"%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%", {"127.0.0.1"}, {}},
       {"%DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%", {"127.0.0.2"}, {}},
-      {"%ORIGINAL_DST%", {"127.0.0.2"}, {}},
       {"%UPSTREAM_METADATA([\"ns\", \"key\"])%", {"value"}, {}},
       {"[%UPSTREAM_METADATA([\"ns\", \"key\"])%", {"[value"}, {}},
       {"%UPSTREAM_METADATA([\"ns\", \"key\"])%]", {"value]"}, {}},

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -65,6 +65,10 @@ TEST_F(RequestInfoHeaderFormatterTest, TestFormatWithDownstreamRemoteAddressVari
 }
 
 TEST_F(RequestInfoHeaderFormatterTest, TestFormatWithDownstreamLocalAddressVariable) {
+  testFormatting("DOWNSTREAM_LOCAL_ADDRESS", "127.0.0.2:0");
+}
+
+TEST_F(RequestInfoHeaderFormatterTest, TestFormatWithDownstreamLocalAddressWithoutPortVariable) {
   testFormatting("DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT", "127.0.0.2");
 }
 
@@ -256,6 +260,7 @@ TEST(HeaderParserTest, TestParseInternal) {
       {"%PROTOCOL%%%", {"HTTP/1.1%"}, {}},
       {"%%%PROTOCOL%%%", {"%HTTP/1.1%"}, {}},
       {"%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%", {"127.0.0.1"}, {}},
+      {"%DOWNSTREAM_LOCAL_ADDRESS%", {"127.0.0.2:0"}, {}},
       {"%DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%", {"127.0.0.2"}, {}},
       {"%UPSTREAM_METADATA([\"ns\", \"key\"])%", {"value"}, {}},
       {"[%UPSTREAM_METADATA([\"ns\", \"key\"])%", {"[value"}, {}},

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -64,6 +64,14 @@ TEST_F(RequestInfoHeaderFormatterTest, TestFormatWithDownstreamRemoteAddressVari
   testFormatting("DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT", "127.0.0.1");
 }
 
+TEST_F(RequestInfoHeaderFormatterTest, TestFormatWithOriginalDstVariable) {
+  testFormatting("ORIGINAL_DST", "127.0.0.2");
+}
+
+TEST_F(RequestInfoHeaderFormatterTest, TestFormatWithDownstreamLocalAddressVariable) {
+  testFormatting("DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT", "127.0.0.2");
+}
+
 TEST_F(RequestInfoHeaderFormatterTest, TestFormatWithProtocolVariable) {
   NiceMock<Envoy::RequestInfo::MockRequestInfo> request_info;
   Optional<Envoy::Http::Protocol> protocol = Envoy::Http::Protocol::Http11;
@@ -252,6 +260,8 @@ TEST(HeaderParserTest, TestParseInternal) {
       {"%PROTOCOL%%%", {"HTTP/1.1%"}, {}},
       {"%%%PROTOCOL%%%", {"%HTTP/1.1%"}, {}},
       {"%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%", {"127.0.0.1"}, {}},
+      {"%DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%", {"127.0.0.2"}, {}},
+      {"%ORIGINAL_DST%", {"127.0.0.2"}, {}},
       {"%UPSTREAM_METADATA([\"ns\", \"key\"])%", {"value"}, {}},
       {"[%UPSTREAM_METADATA([\"ns\", \"key\"])%", {"[value"}, {}},
       {"%UPSTREAM_METADATA([\"ns\", \"key\"])%]", {"value]"}, {}},


### PR DESCRIPTION
Adds ORIGINAL_DST header variable which is an alias for
DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT.

ORIGINAL_DST is the address that the client initially expected to reach.

Signed-off-by: Mandar U Jog <mjog@google.com>

fixes https://github.com/envoyproxy/envoy/issues/2484