### PR TITLE
config: hints for using v4 dns to avoid 503 (#2478)

### DIFF
--- a/configs/google_com_proxy.v2.yaml
+++ b/configs/google_com_proxy.v2.yaml
@@ -28,6 +28,9 @@ static_resources:
   - name: service_google
     connect_timeout: 0.25s
     type: LOGICAL_DNS
+    # uncomment the following line if your environment don't have v6 network
+    # or envoy may try to talk to v6 endpoint and you will get 503 error
+    # dns_lookup_family: V4_ONLY
     lb_policy: ROUND_ROBIN
     hosts: [{ socket_address: { address: google.com, port_value: 443 }}]
     tls_context: { sni: www.google.com }

--- a/configs/google_com_proxy.v2.yaml
+++ b/configs/google_com_proxy.v2.yaml
@@ -28,8 +28,7 @@ static_resources:
   - name: service_google
     connect_timeout: 0.25s
     type: LOGICAL_DNS
-    # uncomment the following line if your environment don't have v6 network
-    # or envoy may try to talk to v6 endpoint and you will get 503 error
+    # Uncomment the following line if your environment doesn't have v6 network access or Envoy may try to talk to a v6 endpoint which will result in a 503 error.
     # dns_lookup_family: V4_ONLY
     lb_policy: ROUND_ROBIN
     hosts: [{ socket_address: { address: google.com, port_value: 443 }}]


### PR DESCRIPTION
Add a YAML comment to the config file that might help someone who encounters v4/v6 dns problem in the future.

## Risk Level

Low, fixing sample config

## Testing

manual testing.

Environment: a machine don't have ipv6 network but can resolve v6 address of google

### before

```
$ curl -i http://127.0.0.1:10000
HTTP/1.1 503 Service Unavailable
content-length: 57
content-type: text/plain
date: Wed, 31 Jan 2018 03:23:39 GMT
server: envoy

upstream connect error or disconnect/reset before headers
```

### uncomment `dns_lookup_family: V4_ONLY`

```
$ curl -i http://127.0.0.1:10000
HTTP/1.1 200 OK
date: Wed, 31 Jan 2018 03:27:02 GMT
expires: -1
cache-control: private, max-age=0
content-type: text/html; charset=ISO-8859-1
...
```

## fix

#2478 
