### PR TITLE
upstream: encapsulate hosts per locality in class, type cleanups.

### DIFF
--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -142,8 +142,8 @@ public:
 
   /**
    * @return const std::vector<HostVector>& list of hosts organized per
-   *         locality. The local locality is the first entry if local() is
-   *         true.
+   *         locality. The local locality is the first entry if
+   *         hasLocalLocality() is true.
    */
   virtual const std::vector<HostVector>& get() const PURE;
 

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -123,21 +123,54 @@ public:
 
 typedef std::shared_ptr<const Host> HostConstSharedPtr;
 
+typedef std::vector<HostSharedPtr> HostVector;
+typedef std::shared_ptr<HostVector> HostVectorSharedPtr;
+typedef std::shared_ptr<const HostVector> HostVectorConstSharedPtr;
+
+/**
+ * Bucket hosts by locality.
+ */
+class HostsPerLocality {
+public:
+  virtual ~HostsPerLocality() {}
+
+  /**
+   * @return bool is local locality one of the locality buckets?
+   */
+  virtual bool hasLocalLocality() const PURE;
+
+  /**
+   * @return const std::vector<HostVector>& list of hosts organized per
+   *         locality. The local locality is the first entry if local() !=
+   *         nullptr.
+   */
+  virtual const std::vector<HostVector>& get() const PURE;
+
+  /**
+   * Clone object with a filter predicate.
+   * @param predicate on Host entries.
+   * @return HostsPerLocalityConstSharedPtr clone of the HostsPerLocality with only
+   *         hosts according to predicate.
+   */
+  virtual std::shared_ptr<const HostsPerLocality>
+  filter(std::function<bool(const Host&)> predicate) const PURE;
+};
+
+typedef std::shared_ptr<HostsPerLocality> HostsPerLocalitySharedPtr;
+typedef std::shared_ptr<const HostsPerLocality> HostsPerLocalityConstSharedPtr;
+
 /**
  * Base host set interface. This contains all of the endpoints for a given LocalityLbEndpoints
  * priority level.
  */
 class HostSet {
 public:
-  typedef std::shared_ptr<const std::vector<HostSharedPtr>> HostVectorConstSharedPtr;
-  typedef std::shared_ptr<const std::vector<std::vector<HostSharedPtr>>> HostListsConstSharedPtr;
-
   virtual ~HostSet() {}
 
   /**
    * @return all hosts that make up the set at the current time.
    */
-  virtual const std::vector<HostSharedPtr>& hosts() const PURE;
+  virtual const HostVector& hosts() const PURE;
 
   /**
    * @return all healthy hosts contained in the set at the current time. NOTE: This set is
@@ -145,21 +178,17 @@ public:
    *         unhealthy and calling healthy() on it will return false. Code should be written to
    *         deal with this case if it matters.
    */
-  virtual const std::vector<HostSharedPtr>& healthyHosts() const PURE;
+  virtual const HostVector& healthyHosts() const PURE;
 
   /**
-   * @return hosts per locality, index 0 is dedicated to local locality hosts.
-   * If there are no hosts in local locality for upstream cluster hostsPerLocality() will @return
-   * empty vector.
-   *
-   * Note, that we sort localities in lexicographic order starting from index 1.
+   * @return hosts per locality.
    */
-  virtual const std::vector<std::vector<HostSharedPtr>>& hostsPerLocality() const PURE;
+  virtual const HostsPerLocality& hostsPerLocality() const PURE;
 
   /**
    * @return same as hostsPerLocality but only contains healthy hosts.
    */
-  virtual const std::vector<std::vector<HostSharedPtr>>& healthyHostsPerLocality() const PURE;
+  virtual const HostsPerLocality& healthyHostsPerLocality() const PURE;
 
   /**
    * Updates the hosts in a given host set.
@@ -172,10 +201,9 @@ public:
    * @param hosts_removed supplies the hosts removed since the last update.
    */
   virtual void updateHosts(HostVectorConstSharedPtr hosts, HostVectorConstSharedPtr healthy_hosts,
-                           HostListsConstSharedPtr hosts_per_locality,
-                           HostListsConstSharedPtr healthy_hosts_per_locality,
-                           const std::vector<HostSharedPtr>& hosts_added,
-                           const std::vector<HostSharedPtr>& hosts_removed) PURE;
+                           HostsPerLocalityConstSharedPtr hosts_per_locality,
+                           HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
+                           const HostVector& hosts_added, const HostVector& hosts_removed) PURE;
 
   /**
    * @return uint32_t the priority of this host set.
@@ -191,8 +219,8 @@ typedef std::unique_ptr<HostSet> HostSetPtr;
  */
 class PrioritySet {
 public:
-  typedef std::function<void(uint32_t priority, const std::vector<HostSharedPtr>& hosts_added,
-                             const std::vector<HostSharedPtr>& hosts_removed)>
+  typedef std::function<void(uint32_t priority, const HostVector& hosts_added,
+                             const HostVector& hosts_removed)>
       MemberUpdateCb;
 
   virtual ~PrioritySet() {}

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -135,14 +135,15 @@ public:
   virtual ~HostsPerLocality() {}
 
   /**
-   * @return bool is local locality one of the locality buckets?
+   * @return bool is local locality one of the locality buckets? If so, the
+   *         local locality will be the first in the get() vector.
    */
   virtual bool hasLocalLocality() const PURE;
 
   /**
    * @return const std::vector<HostVector>& list of hosts organized per
-   *         locality. The local locality is the first entry if local() !=
-   *         nullptr.
+   *         locality. The local locality is the first entry if local() is
+   *         true.
    */
   virtual const std::vector<HostVector>& get() const PURE;
 
@@ -154,6 +155,14 @@ public:
    */
   virtual std::shared_ptr<const HostsPerLocality>
   filter(std::function<bool(const Host&)> predicate) const PURE;
+
+  /**
+   * Clone object.
+   * @return HostsPerLocalityConstSharedPtr clone of the HostsPerLocality.
+   */
+  std::shared_ptr<const HostsPerLocality> clone() const {
+    return filter([](const Host&) { return true; });
+  }
 };
 
 typedef std::shared_ptr<HostsPerLocality> HostsPerLocalitySharedPtr;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -317,13 +317,13 @@ void ClusterManagerImpl::onClusterInit(Cluster& cluster) {
   }
 
   // Now setup for cross-thread updates.
-  cluster.prioritySet().addMemberUpdateCb(
-      [&cluster, this](uint32_t priority, const std::vector<HostSharedPtr>& hosts_added,
-                       const std::vector<HostSharedPtr>& hosts_removed) {
-        // This fires when a cluster is about to have an updated member set. We need to send this
-        // out to all of the thread local configurations.
-        postThreadLocalClusterUpdate(cluster, priority, hosts_added, hosts_removed);
-      });
+  cluster.prioritySet().addMemberUpdateCb([&cluster, this](uint32_t priority,
+                                                           const HostVector& hosts_added,
+                                                           const HostVector& hosts_removed) {
+    // This fires when a cluster is about to have an updated member set. We need to send this
+    // out to all of the thread local configurations.
+    postThreadLocalClusterUpdate(cluster, priority, hosts_added, hosts_removed);
+  });
 
   // Finally, if the cluster has any hosts, post updates cross-thread so the per-thread load
   // balancers are ready.
@@ -331,8 +331,7 @@ void ClusterManagerImpl::onClusterInit(Cluster& cluster) {
     if (host_set->hosts().empty()) {
       continue;
     }
-    postThreadLocalClusterUpdate(cluster, host_set->priority(), host_set->hosts(),
-                                 std::vector<HostSharedPtr>{});
+    postThreadLocalClusterUpdate(cluster, host_set->priority(), host_set->hosts(), HostVector{});
   }
 }
 
@@ -479,19 +478,18 @@ ClusterManagerImpl::httpConnPoolForCluster(const std::string& cluster, ResourceP
   return entry->second->connPool(priority, protocol, context);
 }
 
-void ClusterManagerImpl::postThreadLocalClusterUpdate(
-    const Cluster& primary_cluster, uint32_t priority,
-    const std::vector<HostSharedPtr>& hosts_added,
-    const std::vector<HostSharedPtr>& hosts_removed) {
+void ClusterManagerImpl::postThreadLocalClusterUpdate(const Cluster& primary_cluster,
+                                                      uint32_t priority,
+                                                      const HostVector& hosts_added,
+                                                      const HostVector& hosts_removed) {
   const auto& host_set = primary_cluster.prioritySet().hostSetsPerPriority()[priority];
 
-  HostVectorConstSharedPtr hosts_copy(new std::vector<HostSharedPtr>(host_set->hosts()));
-  HostVectorConstSharedPtr healthy_hosts_copy(
-      new std::vector<HostSharedPtr>(host_set->healthyHosts()));
-  HostListsConstSharedPtr hosts_per_locality_copy(
-      new std::vector<std::vector<HostSharedPtr>>(host_set->hostsPerLocality()));
-  HostListsConstSharedPtr healthy_hosts_per_locality_copy(
-      new std::vector<std::vector<HostSharedPtr>>(host_set->healthyHostsPerLocality()));
+  HostVectorConstSharedPtr hosts_copy(new HostVector(host_set->hosts()));
+  HostVectorConstSharedPtr healthy_hosts_copy(new HostVector(host_set->healthyHosts()));
+  HostsPerLocalityConstSharedPtr hosts_per_locality_copy =
+      host_set->hostsPerLocality().filter([](const Host&) { return true; });
+  HostsPerLocalityConstSharedPtr healthy_hosts_per_locality_copy =
+      host_set->healthyHostsPerLocality().filter([](const Host&) { return true; });
 
   tls_->runOnAllThreads([
     this, name = primary_cluster.info()->name(), priority, hosts_copy, healthy_hosts_copy,
@@ -591,8 +589,7 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::~ThreadLocalClusterManagerImp
   thread_local_clusters_.clear();
 }
 
-void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainConnPools(
-    const std::vector<HostSharedPtr>& hosts) {
+void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainConnPools(const HostVector& hosts) {
   for (const HostSharedPtr& host : hosts) {
     auto container = host_http_conn_pool_map_.find(host);
     if (container != host_http_conn_pool_map_.end()) {
@@ -629,10 +626,9 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainConnPools(
 
 void ClusterManagerImpl::ThreadLocalClusterManagerImpl::updateClusterMembership(
     const std::string& name, uint32_t priority, HostVectorConstSharedPtr hosts,
-    HostVectorConstSharedPtr healthy_hosts, HostListsConstSharedPtr hosts_per_locality,
-    HostListsConstSharedPtr healthy_hosts_per_locality,
-    const std::vector<HostSharedPtr>& hosts_added, const std::vector<HostSharedPtr>& hosts_removed,
-    ThreadLocal::Slot& tls) {
+    HostVectorConstSharedPtr healthy_hosts, HostsPerLocalityConstSharedPtr hosts_per_locality,
+    HostsPerLocalityConstSharedPtr healthy_hosts_per_locality, const HostVector& hosts_added,
+    const HostVector& hosts_removed, ThreadLocal::Slot& tls) {
 
   ThreadLocalClusterManagerImpl& config = tls.getTyped<ThreadLocalClusterManagerImpl>();
 
@@ -723,13 +719,13 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(
     }
   }
 
-  priority_set_.addMemberUpdateCb([this](uint32_t, const std::vector<HostSharedPtr>&,
-                                         const std::vector<HostSharedPtr>& hosts_removed) -> void {
-    // We need to go through and purge any connection pools for hosts that got deleted.
-    // Even if two hosts actually point to the same address this will be safe, since if a
-    // host is readded it will be a different physical HostSharedPtr.
-    parent_.drainConnPools(hosts_removed);
-  });
+  priority_set_.addMemberUpdateCb(
+      [this](uint32_t, const HostVector&, const HostVector& hosts_removed) -> void {
+        // We need to go through and purge any connection pools for hosts that got deleted.
+        // Even if two hosts actually point to the same address this will be safe, since if a
+        // host is readded it will be a different physical HostSharedPtr.
+        parent_.drainConnPools(hosts_removed);
+      });
 }
 
 ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::~ClusterEntry() {

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -486,10 +486,9 @@ void ClusterManagerImpl::postThreadLocalClusterUpdate(const Cluster& primary_clu
 
   HostVectorConstSharedPtr hosts_copy(new HostVector(host_set->hosts()));
   HostVectorConstSharedPtr healthy_hosts_copy(new HostVector(host_set->healthyHosts()));
-  HostsPerLocalityConstSharedPtr hosts_per_locality_copy =
-      host_set->hostsPerLocality().filter([](const Host&) { return true; });
+  HostsPerLocalityConstSharedPtr hosts_per_locality_copy = host_set->hostsPerLocality().clone();
   HostsPerLocalityConstSharedPtr healthy_hosts_per_locality_copy =
-      host_set->healthyHostsPerLocality().filter([](const Host&) { return true; });
+      host_set->healthyHostsPerLocality().clone();
 
   tls_->runOnAllThreads([
     this, name = primary_cluster.info()->name(), priority, hosts_copy, healthy_hosts_copy,

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -242,16 +242,15 @@ private:
     ThreadLocalClusterManagerImpl(ClusterManagerImpl& parent, Event::Dispatcher& dispatcher,
                                   const Optional<std::string>& local_cluster_name);
     ~ThreadLocalClusterManagerImpl();
-    void drainConnPools(const std::vector<HostSharedPtr>& hosts);
+    void drainConnPools(const HostVector& hosts);
     void drainConnPools(HostSharedPtr old_host, ConnPoolsContainer& container);
     static void updateClusterMembership(const std::string& name, uint32_t priority,
                                         HostVectorConstSharedPtr hosts,
                                         HostVectorConstSharedPtr healthy_hosts,
-                                        HostListsConstSharedPtr hosts_per_locality,
-                                        HostListsConstSharedPtr healthy_hosts_per_locality,
-                                        const std::vector<HostSharedPtr>& hosts_added,
-                                        const std::vector<HostSharedPtr>& hosts_removed,
-                                        ThreadLocal::Slot& tls);
+                                        HostsPerLocalityConstSharedPtr hosts_per_locality,
+                                        HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
+                                        const HostVector& hosts_added,
+                                        const HostVector& hosts_removed, ThreadLocal::Slot& tls);
     static void onHostHealthFailure(const HostSharedPtr& host, ThreadLocal::Slot& tls);
 
     ClusterManagerImpl& parent_;
@@ -284,8 +283,7 @@ private:
   void loadCluster(const envoy::api::v2::Cluster& cluster, bool added_via_api);
   void onClusterInit(Cluster& cluster);
   void postThreadLocalClusterUpdate(const Cluster& cluster, uint32_t priority,
-                                    const std::vector<HostSharedPtr>& hosts_added,
-                                    const std::vector<HostSharedPtr>& hosts_removed);
+                                    const HostVector& hosts_added, const HostVector& hosts_removed);
   void postThreadLocalHealthFailure(const HostSharedPtr& host);
 
   ClusterManagerFactory& factory_;

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -45,7 +45,7 @@ EdsClusterImpl::EdsClusterImpl(const envoy::api::v2::Cluster& cluster, Runtime::
 void EdsClusterImpl::startPreInit() { subscription_->start({cluster_name_}, *this); }
 
 void EdsClusterImpl::onConfigUpdate(const ResourceVector& resources) {
-  typedef std::unique_ptr<std::vector<HostSharedPtr>> HostListPtr;
+  typedef std::unique_ptr<HostVector> HostListPtr;
   std::vector<HostListPtr> new_hosts(1);
   if (resources.empty()) {
     ENVOY_LOG(debug, "Missing ClusterLoadAssignment for {} in onConfigUpdate()", cluster_name_);
@@ -73,7 +73,7 @@ void EdsClusterImpl::onConfigUpdate(const ResourceVector& resources) {
       new_hosts.resize(priority + 1);
     }
     if (new_hosts[priority] == nullptr) {
-      new_hosts[priority] = HostListPtr{new std::vector<HostSharedPtr>};
+      new_hosts[priority] = HostListPtr{new HostVector};
     }
     for (const auto& lb_endpoint : locality_lb_endpoint.lb_endpoints()) {
       new_hosts[priority]->emplace_back(new HostImpl(
@@ -94,23 +94,22 @@ void EdsClusterImpl::onConfigUpdate(const ResourceVector& resources) {
   onPreInitComplete();
 }
 
-void EdsClusterImpl::updateHostsPerLocality(HostSet& host_set,
-                                            std::vector<HostSharedPtr>& new_hosts) {
-  HostVectorSharedPtr current_hosts_copy(new std::vector<HostSharedPtr>(host_set.hosts()));
+void EdsClusterImpl::updateHostsPerLocality(HostSet& host_set, HostVector& new_hosts) {
+  HostVectorSharedPtr current_hosts_copy(new HostVector(host_set.hosts()));
 
-  std::vector<HostSharedPtr> hosts_added;
-  std::vector<HostSharedPtr> hosts_removed;
+  HostVector hosts_added;
+  HostVector hosts_removed;
   if (updateDynamicHostList(new_hosts, *current_hosts_copy, hosts_added, hosts_removed,
                             health_checker_ != nullptr)) {
     ENVOY_LOG(debug, "EDS hosts changed for cluster: {} ({}) priority {}", info_->name(),
               host_set.hosts().size(), host_set.priority());
-    HostListsSharedPtr per_locality(new std::vector<std::vector<HostSharedPtr>>());
+    std::vector<HostVector> per_locality;
 
     // If local locality is not defined then skip populating per locality hosts.
     const Locality local_locality(local_info_.node().locality());
     ENVOY_LOG(trace, "Local locality: {}", local_info_.node().locality().DebugString());
     if (!local_locality.empty()) {
-      std::map<Locality, std::vector<HostSharedPtr>> hosts_per_locality;
+      std::map<Locality, HostVector> hosts_per_locality;
 
       for (const HostSharedPtr& host : *current_hosts_copy) {
         hosts_per_locality[Locality(host->locality())].push_back(host);
@@ -118,19 +117,21 @@ void EdsClusterImpl::updateHostsPerLocality(HostSet& host_set,
 
       // Populate per_locality hosts only if upstream cluster has hosts in the same locality.
       if (hosts_per_locality.find(local_locality) != hosts_per_locality.end()) {
-        per_locality->push_back(hosts_per_locality[local_locality]);
+        per_locality.push_back(hosts_per_locality[local_locality]);
 
         for (auto& entry : hosts_per_locality) {
           if (local_locality != entry.first) {
-            per_locality->push_back(entry.second);
+            per_locality.push_back(entry.second);
           }
         }
       }
     }
 
+    auto per_locality_shared = std::make_shared<HostsPerLocalityImpl>(std::move(per_locality));
+
     host_set.updateHosts(current_hosts_copy, createHealthyHostList(*current_hosts_copy),
-                         per_locality, createHealthyHostLists(*per_locality), hosts_added,
-                         hosts_removed);
+                         per_locality_shared, createHealthyHostLists(*per_locality_shared),
+                         hosts_added, hosts_removed);
   }
 }
 

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -127,7 +127,8 @@ void EdsClusterImpl::updateHostsPerLocality(HostSet& host_set, HostVector& new_h
       }
     }
 
-    auto per_locality_shared = std::make_shared<HostsPerLocalityImpl>(std::move(per_locality));
+    auto per_locality_shared =
+        std::make_shared<HostsPerLocalityImpl>(std::move(per_locality), !per_locality.empty());
 
     host_set.updateHosts(current_hosts_copy, createHealthyHostList(*current_hosts_copy),
                          per_locality_shared, createHealthyHostLists(*per_locality_shared),

--- a/source/common/upstream/eds.h
+++ b/source/common/upstream/eds.h
@@ -32,7 +32,7 @@ public:
   void onConfigUpdateFailed(const EnvoyException* e) override;
 
 private:
-  void updateHostsPerLocality(HostSet& host_set, std::vector<HostSharedPtr>& new_hosts);
+  void updateHostsPerLocality(HostSet& host_set, HostVector& new_hosts);
 
   // ClusterImplBase
   void startPreInit() override;

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -72,8 +72,7 @@ HealthCheckerImplBase::HealthCheckerImplBase(const Cluster& cluster,
       interval_(PROTOBUF_GET_MS_REQUIRED(config, interval)),
       interval_jitter_(PROTOBUF_GET_MS_OR_DEFAULT(config, interval_jitter, 0)) {
   cluster_.prioritySet().addMemberUpdateCb(
-      [this](uint32_t, const std::vector<HostSharedPtr>& hosts_added,
-             const std::vector<HostSharedPtr>& hosts_removed) -> void {
+      [this](uint32_t, const HostVector& hosts_added, const HostVector& hosts_removed) -> void {
         onClusterMemberUpdate(hosts_added, hosts_removed);
       });
 }
@@ -120,7 +119,7 @@ std::chrono::milliseconds HealthCheckerImplBase::interval() const {
   return std::chrono::milliseconds(final_ms);
 }
 
-void HealthCheckerImplBase::addHosts(const std::vector<HostSharedPtr>& hosts) {
+void HealthCheckerImplBase::addHosts(const HostVector& hosts) {
   for (const HostSharedPtr& host : hosts) {
     active_sessions_[host] = makeSession(host);
     host->setHealthChecker(
@@ -129,8 +128,8 @@ void HealthCheckerImplBase::addHosts(const std::vector<HostSharedPtr>& hosts) {
   }
 }
 
-void HealthCheckerImplBase::onClusterMemberUpdate(const std::vector<HostSharedPtr>& hosts_added,
-                                                  const std::vector<HostSharedPtr>& hosts_removed) {
+void HealthCheckerImplBase::onClusterMemberUpdate(const HostVector& hosts_added,
+                                                  const HostVector& hosts_removed) {
   addHosts(hosts_added);
   for (const HostSharedPtr& host : hosts_removed) {
     auto session_iter = active_sessions_.find(host);

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -143,13 +143,12 @@ private:
     std::weak_ptr<Host> host_;
   };
 
-  void addHosts(const std::vector<HostSharedPtr>& hosts);
+  void addHosts(const HostVector& hosts);
   void decHealthy();
   HealthCheckerStats generateStats(Stats::Scope& scope);
   void incHealthy();
   std::chrono::milliseconds interval() const;
-  void onClusterMemberUpdate(const std::vector<HostSharedPtr>& hosts_added,
-                             const std::vector<HostSharedPtr>& hosts_removed);
+  void onClusterMemberUpdate(const HostVector& hosts_added, const HostVector& hosts_removed);
   void refreshHealthyStat();
   void runCallbacks(HostSharedPtr host, bool changed_state);
   void setUnhealthyCrossThread(const HostSharedPtr& host);

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -70,7 +70,7 @@ protected:
   /**
    * Pick the host list to use, doing zone aware routing when the hosts are sufficiently healthy.
    */
-  const std::vector<HostSharedPtr>& hostsToUse();
+  const HostVector& hostsToUse();
 
 private:
   enum class LocalityRoutingState {
@@ -98,16 +98,14 @@ private:
    * Try to select upstream hosts from the same locality.
    * @param host_set the last host set returned by chooseHostSet()
    */
-  const std::vector<HostSharedPtr>& tryChooseLocalLocalityHosts(const HostSet& host_set);
+  const HostVector& tryChooseLocalLocalityHosts(const HostSet& host_set);
 
   /**
    * @return (number of hosts in a given locality)/(total number of hosts) in ret param.
    * The result is stored as integer number and scaled by 10000 multiplier for better precision.
    * Caller is responsible for allocation/de-allocation of ret.
    */
-  void
-  calculateLocalityPercentage(const std::vector<std::vector<HostSharedPtr>>& hosts_per_locality,
-                              uint64_t* ret);
+  void calculateLocalityPercentage(const HostsPerLocality& hosts_per_locality, uint64_t* ret);
 
   /**
    * Regenerate locality aware routing structures for fast decisions on upstream locality selection.

--- a/source/common/upstream/load_stats_reporter.cc
+++ b/source/common/upstream/load_stats_reporter.cc
@@ -50,7 +50,7 @@ void LoadStatsReporter::sendLoadStatsRequest() {
     auto* cluster_stats = request_.add_cluster_stats();
     cluster_stats->set_cluster_name(cluster_name);
     for (auto& host_set : cluster.prioritySet().hostSetsPerPriority()) {
-      for (auto& hosts : host_set->hostsPerLocality()) {
+      for (auto& hosts : host_set->hostsPerLocality().get()) {
         ASSERT(hosts.size() > 0);
         uint64_t rq_success = 0;
         uint64_t rq_error = 0;

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -107,13 +107,14 @@ void LogicalDnsCluster::startResolve() {
                   new LogicalHost(info_, hostname_, Network::Utility::getIpv6AnyAddress(), *this));
               break;
             }
-            HostVectorSharedPtr new_hosts(new std::vector<HostSharedPtr>());
+            HostVectorSharedPtr new_hosts(new HostVector());
             new_hosts->emplace_back(logical_host_);
             // Given the current config, only EDS clusters support multiple priorities.
             ASSERT(priority_set_.hostSetsPerPriority().size() == 1);
             auto& first_host_set = priority_set_.getOrCreateHostSet(0);
             first_host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts),
-                                       empty_host_lists_, empty_host_lists_, *new_hosts, {});
+                                       HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(),
+                                       *new_hosts, {});
           }
         }
 

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -163,8 +163,7 @@ void DetectorImpl::initialize(const Cluster& cluster) {
     }
   }
   cluster.prioritySet().addMemberUpdateCb(
-      [this](uint32_t, const std::vector<HostSharedPtr>& hosts_added,
-             const std::vector<HostSharedPtr>& hosts_removed) -> void {
+      [this](uint32_t, const HostVector& hosts_added, const HostVector& hosts_removed) -> void {
         for (const HostSharedPtr& host : hosts_added) {
           addHostMonitor(host);
         }

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -26,8 +26,8 @@ void RingHashLoadBalancer::initialize() {
   // I will look into doing this in a follow up. Doing everything using a background thread heavily
   // complicated initialization as the load balancer would need its own initialized callback. I
   // think the synchronous/asynchronous split is probably the best option.
-  priority_set_.addMemberUpdateCb([this](uint32_t, const std::vector<HostSharedPtr>&,
-                                         const std::vector<HostSharedPtr>&) -> void { refresh(); });
+  priority_set_.addMemberUpdateCb(
+      [this](uint32_t, const HostVector&, const HostVector&) -> void { refresh(); });
 
   refresh();
 }
@@ -104,7 +104,7 @@ HostConstSharedPtr RingHashLoadBalancer::Ring::chooseHost(uint64_t h) const {
 }
 
 RingHashLoadBalancer::Ring::Ring(const Optional<envoy::api::v2::Cluster::RingHashLbConfig>& config,
-                                 const std::vector<HostSharedPtr>& hosts) {
+                                 const HostVector& hosts) {
   ENVOY_LOG(trace, "ring hash: building ring");
   if (hosts.empty()) {
     return;

--- a/source/common/upstream/ring_hash_lb.h
+++ b/source/common/upstream/ring_hash_lb.h
@@ -44,7 +44,7 @@ private:
 
   struct Ring {
     Ring(const Optional<envoy::api::v2::Cluster::RingHashLbConfig>& config,
-         const std::vector<HostSharedPtr>& hosts);
+         const HostVector& hosts);
     HostConstSharedPtr chooseHost(uint64_t hash) const;
 
     std::vector<RingEntry> ring_;

--- a/source/common/upstream/subset_lb.h
+++ b/source/common/upstream/subset_lb.h
@@ -38,8 +38,8 @@ private:
     HostSubsetImpl(const HostSet& original_host_set)
         : HostSetImpl(original_host_set.priority()), original_host_set_(original_host_set) {}
 
-    void update(const std::vector<HostSharedPtr>& hosts_added,
-                const std::vector<HostSharedPtr>& hosts_removed, HostPredicate predicate);
+    void update(const HostVector& hosts_added, const HostVector& hosts_removed,
+                HostPredicate predicate);
 
     void triggerCallbacks() { HostSetImpl::runUpdateCallbacks({}, {}); }
     bool empty() { return hosts().empty(); }
@@ -53,8 +53,8 @@ private:
   public:
     PrioritySubsetImpl(const SubsetLoadBalancer& subset_lb, HostPredicate predicate);
 
-    void update(uint32_t priority, const std::vector<HostSharedPtr>& hosts_added,
-                const std::vector<HostSharedPtr>& hosts_removed, HostPredicate predicate);
+    void update(uint32_t priority, const HostVector& hosts_added, const HostVector& hosts_removed,
+                HostPredicate predicate);
 
     bool empty() { return empty_; }
 
@@ -106,13 +106,11 @@ private:
   };
 
   // Called by HostSet::MemberUpdateCb
-  void update(uint32_t priority, const std::vector<HostSharedPtr>& hosts_added,
-              const std::vector<HostSharedPtr>& hosts_removed);
+  void update(uint32_t priority, const HostVector& hosts_added, const HostVector& hosts_removed);
 
-  void updateFallbackSubset(uint32_t priority, const std::vector<HostSharedPtr>& hosts_added,
-                            const std::vector<HostSharedPtr>& hosts_removed);
-  void processSubsets(const std::vector<HostSharedPtr>& hosts_added,
-                      const std::vector<HostSharedPtr>& hosts_removed,
+  void updateFallbackSubset(uint32_t priority, const HostVector& hosts_added,
+                            const HostVector& hosts_removed);
+  void processSubsets(const HostVector& hosts_added, const HostVector& hosts_removed,
                       std::function<void(LbSubsetEntryPtr, HostPredicate, bool)> cb);
 
   HostConstSharedPtr tryChooseHostFromContext(LoadBalancerContext* context, bool& host_chosen);

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -411,8 +411,7 @@ void ClusterImplBase::reloadHealthyHosts() {
 
   for (auto& host_set : prioritySet().hostSetsPerPriority()) {
     HostVectorConstSharedPtr hosts_copy(new HostVector(host_set->hosts()));
-    HostsPerLocalityConstSharedPtr hosts_per_locality_copy =
-        host_set->hostsPerLocality().filter([](const Host&) { return true; });
+    HostsPerLocalityConstSharedPtr hosts_per_locality_copy = host_set->hostsPerLocality().clone();
     host_set->updateHosts(hosts_copy, createHealthyHostList(host_set->hosts()),
                           hosts_per_locality_copy,
                           createHealthyHostLists(host_set->hostsPerLocality()), {}, {});

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -68,13 +68,31 @@ HostImpl::createConnection(Event::Dispatcher& dispatcher, const ClusterInfo& clu
 
 void HostImpl::weight(uint32_t new_weight) { weight_ = std::max(1U, std::min(128U, new_weight)); }
 
+HostsPerLocalityConstSharedPtr
+HostsPerLocalityImpl::filter(std::function<bool(const Host&)> predicate) const {
+  auto* filtered_clone = new HostsPerLocalityImpl();
+  HostsPerLocalityConstSharedPtr shared_filtered_clone{filtered_clone};
+
+  filtered_clone->local_ = local_;
+  for (const auto& hosts_locality : hosts_per_locality_) {
+    HostVector current_locality_hosts;
+    for (const auto& host : hosts_locality) {
+      if (predicate(*host)) {
+        current_locality_hosts.emplace_back(host);
+      }
+    }
+    filtered_clone->hosts_per_locality_.push_back(std::move(current_locality_hosts));
+  }
+
+  return shared_filtered_clone;
+}
+
 HostSet& PrioritySetImpl::getOrCreateHostSet(uint32_t priority) {
   if (host_sets_.size() < priority + 1) {
     for (size_t i = host_sets_.size(); i <= priority; ++i) {
       HostSetImplPtr host_set = createHostSet(i);
-      host_set->addMemberUpdateCb([this](uint32_t priority,
-                                         const std::vector<HostSharedPtr>& hosts_added,
-                                         const std::vector<HostSharedPtr>& hosts_removed) {
+      host_set->addMemberUpdateCb([this](uint32_t priority, const HostVector& hosts_added,
+                                         const HostVector& hosts_removed) {
         runUpdateCallbacks(priority, hosts_added, hosts_removed);
       });
       host_sets_.push_back(std::move(host_set));
@@ -167,9 +185,6 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
   }
 }
 
-const HostListsConstSharedPtr ClusterImplBase::empty_host_lists_{
-    new std::vector<std::vector<HostSharedPtr>>()};
-
 ClusterSharedPtr ClusterImplBase::create(const envoy::api::v2::Cluster& cluster, ClusterManager& cm,
                                          Stats::Store& stats, ThreadLocal::Instance& tls,
                                          Network::DnsResolverSharedPtr dns_resolver,
@@ -259,26 +274,25 @@ ClusterImplBase::ClusterImplBase(const envoy::api::v2::Cluster& cluster,
   // Create the default (empty) priority set before registering callbacks to
   // avoid getting an update the first time it is accessed.
   priority_set_.getOrCreateHostSet(0);
-  priority_set_.addMemberUpdateCb([this](uint32_t, const std::vector<HostSharedPtr>& hosts_added,
-                                         const std::vector<HostSharedPtr>& hosts_removed) {
-    if (!hosts_added.empty() || !hosts_removed.empty()) {
-      info_->stats().membership_change_.inc();
-    }
+  priority_set_.addMemberUpdateCb(
+      [this](uint32_t, const HostVector& hosts_added, const HostVector& hosts_removed) {
+        if (!hosts_added.empty() || !hosts_removed.empty()) {
+          info_->stats().membership_change_.inc();
+        }
 
-    uint32_t healthy_hosts = 0;
-    uint32_t hosts = 0;
-    for (const auto& host_set : prioritySet().hostSetsPerPriority()) {
-      hosts += host_set->hosts().size();
-      healthy_hosts += host_set->healthyHosts().size();
-    }
-    info_->stats().membership_total_.set(hosts);
-    info_->stats().membership_healthy_.set(healthy_hosts);
-  });
+        uint32_t healthy_hosts = 0;
+        uint32_t hosts = 0;
+        for (const auto& host_set : prioritySet().hostSetsPerPriority()) {
+          hosts += host_set->hosts().size();
+          healthy_hosts += host_set->healthyHosts().size();
+        }
+        info_->stats().membership_total_.set(hosts);
+        info_->stats().membership_healthy_.set(healthy_hosts);
+      });
 }
 
-HostVectorConstSharedPtr
-ClusterImplBase::createHealthyHostList(const std::vector<HostSharedPtr>& hosts) {
-  HostVectorSharedPtr healthy_list(new std::vector<HostSharedPtr>());
+HostVectorConstSharedPtr ClusterImplBase::createHealthyHostList(const HostVector& hosts) {
+  HostVectorSharedPtr healthy_list(new HostVector());
   for (const auto& host : hosts) {
     if (host->healthy()) {
       healthy_list->emplace_back(host);
@@ -288,21 +302,9 @@ ClusterImplBase::createHealthyHostList(const std::vector<HostSharedPtr>& hosts) 
   return healthy_list;
 }
 
-HostListsConstSharedPtr
-ClusterImplBase::createHealthyHostLists(const std::vector<std::vector<HostSharedPtr>>& hosts) {
-  HostListsSharedPtr healthy_list(new std::vector<std::vector<HostSharedPtr>>());
-
-  for (const auto& hosts_zone : hosts) {
-    std::vector<HostSharedPtr> current_zone_hosts;
-    for (const auto& host : hosts_zone) {
-      if (host->healthy()) {
-        current_zone_hosts.emplace_back(host);
-      }
-    }
-    healthy_list->push_back(std::move(current_zone_hosts));
-  }
-
-  return healthy_list;
+HostsPerLocalityConstSharedPtr
+ClusterImplBase::createHealthyHostLists(const HostsPerLocality& hosts) {
+  return hosts.filter([](const Host& host) { return host.healthy(); });
 }
 
 bool ClusterInfoImpl::maintenanceMode() const {
@@ -408,9 +410,9 @@ void ClusterImplBase::reloadHealthyHosts() {
   }
 
   for (auto& host_set : prioritySet().hostSetsPerPriority()) {
-    HostVectorConstSharedPtr hosts_copy(new std::vector<HostSharedPtr>(host_set->hosts()));
-    HostListsConstSharedPtr hosts_per_locality_copy(
-        new std::vector<std::vector<HostSharedPtr>>(host_set->hostsPerLocality()));
+    HostVectorConstSharedPtr hosts_copy(new HostVector(host_set->hosts()));
+    HostsPerLocalityConstSharedPtr hosts_per_locality_copy =
+        host_set->hostsPerLocality().filter([](const Host&) { return true; });
     host_set->updateHosts(hosts_copy, createHealthyHostList(host_set->hosts()),
                           hosts_per_locality_copy,
                           createHealthyHostLists(host_set->hostsPerLocality()), {}, {});
@@ -473,7 +475,7 @@ StaticClusterImpl::StaticClusterImpl(const envoy::api::v2::Cluster& cluster,
                                      bool added_via_api)
     : ClusterImplBase(cluster, cm.sourceAddress(), runtime, stats, ssl_context_manager,
                       added_via_api),
-      initial_hosts_(new std::vector<HostSharedPtr>()) {
+      initial_hosts_(new HostVector()) {
 
   for (const auto& host : cluster.hosts()) {
     initial_hosts_->emplace_back(
@@ -496,17 +498,17 @@ void StaticClusterImpl::startPreInit() {
   ASSERT(priority_set_.hostSetsPerPriority().size() == 1);
   auto& first_host_set = priority_set_.getOrCreateHostSet(0);
   first_host_set.updateHosts(initial_hosts_, createHealthyHostList(*initial_hosts_),
-                             empty_host_lists_, empty_host_lists_, *initial_hosts_, {});
+                             HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(),
+                             *initial_hosts_, {});
   initial_hosts_ = nullptr;
 
   onPreInitComplete();
 }
 
-bool BaseDynamicClusterImpl::updateDynamicHostList(const std::vector<HostSharedPtr>& new_hosts,
-                                                   std::vector<HostSharedPtr>& current_hosts,
-                                                   std::vector<HostSharedPtr>& hosts_added,
-                                                   std::vector<HostSharedPtr>& hosts_removed,
-                                                   bool depend_on_hc) {
+bool BaseDynamicClusterImpl::updateDynamicHostList(const HostVector& new_hosts,
+                                                   HostVector& current_hosts,
+                                                   HostVector& hosts_added,
+                                                   HostVector& hosts_removed, bool depend_on_hc) {
   uint64_t max_host_weight = 1;
 
   // Go through and see if the list we have is different from what we just got. If it is, we
@@ -515,7 +517,7 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(const std::vector<HostSharedP
   // duplicates here. It's possible for DNS to return the same address multiple times, and a bad
   // SDS implementation could do the same thing.
   std::unordered_set<std::string> host_addresses;
-  std::vector<HostSharedPtr> final_hosts;
+  HostVector final_hosts;
   for (const HostSharedPtr& host : new_hosts) {
     if (host_addresses.count(host->address()->asString())) {
       continue;
@@ -624,10 +626,10 @@ void StrictDnsClusterImpl::startPreInit() {
   }
 }
 
-void StrictDnsClusterImpl::updateAllHosts(const std::vector<HostSharedPtr>& hosts_added,
-                                          const std::vector<HostSharedPtr>& hosts_removed) {
+void StrictDnsClusterImpl::updateAllHosts(const HostVector& hosts_added,
+                                          const HostVector& hosts_removed) {
   // At this point we know that we are different so make a new host list and notify.
-  HostVectorSharedPtr new_hosts(new std::vector<HostSharedPtr>());
+  HostVectorSharedPtr new_hosts(new HostVector());
   for (const ResolveTargetPtr& target : resolve_targets_) {
     for (const HostSharedPtr& host : target->hosts_) {
       new_hosts->emplace_back(host);
@@ -637,8 +639,9 @@ void StrictDnsClusterImpl::updateAllHosts(const std::vector<HostSharedPtr>& host
   // Given the current config, only EDS clusters support multiple priorities.
   ASSERT(priority_set_.hostSetsPerPriority().size() == 1);
   auto& first_host_set = priority_set_.getOrCreateHostSet(0);
-  first_host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts), empty_host_lists_,
-                             empty_host_lists_, hosts_added, hosts_removed);
+  first_host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts),
+                             HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(),
+                             hosts_added, hosts_removed);
 }
 
 StrictDnsClusterImpl::ResolveTarget::ResolveTarget(StrictDnsClusterImpl& parent,
@@ -665,7 +668,7 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
         ENVOY_LOG(debug, "async DNS resolution complete for {}", dns_address_);
         parent_.info_->stats().update_success_.inc();
 
-        std::vector<HostSharedPtr> new_hosts;
+        HostVector new_hosts;
         for (const Network::Address::InstanceConstSharedPtr& address : address_list) {
           // TODO(mattklein123): Currently the DNS interface does not consider port. We need to make
           // a new address that has port in it. We need to both support IPv6 as well as potentially
@@ -677,8 +680,8 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
                                               envoy::api::v2::Locality().default_instance()));
         }
 
-        std::vector<HostSharedPtr> hosts_added;
-        std::vector<HostSharedPtr> hosts_removed;
+        HostVector hosts_added;
+        HostVector hosts_removed;
         if (parent_.updateDynamicHostList(new_hosts, hosts_, hosts_added, hosts_removed, false)) {
           ENVOY_LOG(debug, "DNS hosts have changed for {}", dns_address_);
           parent_.updateAllHosts(hosts_added, hosts_removed);

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -166,10 +166,38 @@ private:
   std::atomic<bool> used_;
 };
 
-typedef std::shared_ptr<std::vector<HostSharedPtr>> HostVectorSharedPtr;
-typedef std::shared_ptr<const std::vector<HostSharedPtr>> HostVectorConstSharedPtr;
-typedef std::shared_ptr<std::vector<std::vector<HostSharedPtr>>> HostListsSharedPtr;
-typedef std::shared_ptr<const std::vector<std::vector<HostSharedPtr>>> HostListsConstSharedPtr;
+class HostsPerLocalityImpl : public HostsPerLocality {
+public:
+  HostsPerLocalityImpl() : HostsPerLocalityImpl(false) {}
+
+  HostsPerLocalityImpl(bool has_local_locality)
+      : HostsPerLocalityImpl(has_local_locality ? std::vector<HostVector>({{}})
+                                                : std::vector<HostVector>()) {}
+
+  HostsPerLocalityImpl(std::vector<HostVector>&& locality_hosts)
+      : HostsPerLocalityImpl(std::move(locality_hosts), !locality_hosts.empty()) {}
+
+  HostsPerLocalityImpl(std::vector<HostVector>&& locality_hosts, bool has_local_locality)
+      : local_(has_local_locality), hosts_per_locality_(std::move(locality_hosts)) {
+    ASSERT(!has_local_locality || !hosts_per_locality_.empty());
+  }
+
+  bool hasLocalLocality() const override { return local_; }
+  const std::vector<HostVector>& get() const override { return hosts_per_locality_; }
+  HostsPerLocalityConstSharedPtr filter(std::function<bool(const Host&)> predicate) const override;
+
+  // The const shared pointer for the empty HostsPerLocalityImpl.
+  static HostsPerLocalityConstSharedPtr empty() {
+    static HostsPerLocalityConstSharedPtr empty = std::make_shared<HostsPerLocalityImpl>();
+    return empty;
+  }
+
+private:
+  // Does an entry exist for the local locality?
+  bool local_{};
+  // The first entry is for local hosts in the local locality.
+  std::vector<HostVector> hosts_per_locality_;
+};
 
 /**
  * A class for management of the set of hosts for a given priority level.
@@ -177,16 +205,12 @@ typedef std::shared_ptr<const std::vector<std::vector<HostSharedPtr>>> HostLists
 class HostSetImpl : public HostSet {
 public:
   HostSetImpl(uint32_t priority)
-      : priority_(priority), hosts_(new std::vector<HostSharedPtr>()),
-        healthy_hosts_(new std::vector<HostSharedPtr>()),
-        hosts_per_locality_(new std::vector<std::vector<HostSharedPtr>>()),
-        healthy_hosts_per_locality_(new std::vector<std::vector<HostSharedPtr>>()) {}
+      : priority_(priority), hosts_(new HostVector()), healthy_hosts_(new HostVector()) {}
 
   void updateHosts(HostVectorConstSharedPtr hosts, HostVectorConstSharedPtr healthy_hosts,
-                   HostListsConstSharedPtr hosts_per_locality,
-                   HostListsConstSharedPtr healthy_hosts_per_locality,
-                   const std::vector<HostSharedPtr>& hosts_added,
-                   const std::vector<HostSharedPtr>& hosts_removed) override {
+                   HostsPerLocalityConstSharedPtr hosts_per_locality,
+                   HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
+                   const HostVector& hosts_added, const HostVector& hosts_removed) override {
     hosts_ = std::move(hosts);
     healthy_hosts_ = std::move(healthy_hosts);
     hosts_per_locality_ = std::move(hosts_per_locality);
@@ -199,27 +223,24 @@ public:
    * @param callback supplies the callback to invoke.
    * @return Common::CallbackHandle* the callback handle.
    */
-  typedef std::function<void(uint32_t priority, const std::vector<HostSharedPtr>& hosts_added,
-                             const std::vector<HostSharedPtr>& hosts_removed)>
+  typedef std::function<void(uint32_t priority, const HostVector& hosts_added,
+                             const HostVector& hosts_removed)>
       MemberUpdateCb;
   Common::CallbackHandle* addMemberUpdateCb(MemberUpdateCb callback) const {
     return member_update_cb_helper_.add(callback);
   }
 
   // Upstream::HostSet
-  const std::vector<HostSharedPtr>& hosts() const override { return *hosts_; }
-  const std::vector<HostSharedPtr>& healthyHosts() const override { return *healthy_hosts_; }
-  const std::vector<std::vector<HostSharedPtr>>& hostsPerLocality() const override {
-    return *hosts_per_locality_;
-  }
-  const std::vector<std::vector<HostSharedPtr>>& healthyHostsPerLocality() const override {
+  const HostVector& hosts() const override { return *hosts_; }
+  const HostVector& healthyHosts() const override { return *healthy_hosts_; }
+  const HostsPerLocality& hostsPerLocality() const override { return *hosts_per_locality_; }
+  const HostsPerLocality& healthyHostsPerLocality() const override {
     return *healthy_hosts_per_locality_;
   }
   uint32_t priority() const override { return priority_; }
 
 protected:
-  virtual void runUpdateCallbacks(const std::vector<HostSharedPtr>& hosts_added,
-                                  const std::vector<HostSharedPtr>& hosts_removed) {
+  virtual void runUpdateCallbacks(const HostVector& hosts_added, const HostVector& hosts_removed) {
     member_update_cb_helper_.runCallbacks(priority_, hosts_added, hosts_removed);
   }
 
@@ -227,11 +248,10 @@ private:
   uint32_t priority_;
   HostVectorConstSharedPtr hosts_;
   HostVectorConstSharedPtr healthy_hosts_;
-  HostListsConstSharedPtr hosts_per_locality_;
-  HostListsConstSharedPtr healthy_hosts_per_locality_;
+  HostsPerLocalityConstSharedPtr hosts_per_locality_{HostsPerLocalityImpl::empty()};
+  HostsPerLocalityConstSharedPtr healthy_hosts_per_locality_{HostsPerLocalityImpl::empty()};
   // TODO(mattklein123): Remove mutable.
-  mutable Common::CallbackManager<uint32_t, const std::vector<HostSharedPtr>&,
-                                  const std::vector<HostSharedPtr>&>
+  mutable Common::CallbackManager<uint32_t, const HostVector&, const HostVector&>
       member_update_cb_helper_;
 };
 
@@ -261,8 +281,8 @@ protected:
   }
 
 private:
-  virtual void runUpdateCallbacks(uint32_t priority, const std::vector<HostSharedPtr>& hosts_added,
-                                  const std::vector<HostSharedPtr>& hosts_removed) {
+  virtual void runUpdateCallbacks(uint32_t priority, const HostVector& hosts_added,
+                                  const HostVector& hosts_removed) {
     member_update_cb_helper_.runCallbacks(priority, hosts_added, hosts_removed);
   }
   // This vector will generally have at least one member, for priority level 0.
@@ -270,8 +290,7 @@ private:
   // avoid any potential lifetime issues.
   std::vector<std::unique_ptr<HostSet>> host_sets_;
   // TODO(mattklein123): Remove mutable.
-  mutable Common::CallbackManager<uint32_t, const std::vector<HostSharedPtr>&,
-                                  const std::vector<HostSharedPtr>&>
+  mutable Common::CallbackManager<uint32_t, const HostVector&, const HostVector&>
       member_update_cb_helper_;
 };
 
@@ -404,9 +423,8 @@ protected:
                   Runtime::Loader& runtime, Stats::Store& stats,
                   Ssl::ContextManager& ssl_context_manager, bool added_via_api);
 
-  static HostVectorConstSharedPtr createHealthyHostList(const std::vector<HostSharedPtr>& hosts);
-  static HostListsConstSharedPtr
-  createHealthyHostLists(const std::vector<std::vector<HostSharedPtr>>& hosts);
+  static HostVectorConstSharedPtr createHealthyHostList(const HostVector& hosts);
+  static HostsPerLocalityConstSharedPtr createHealthyHostLists(const HostsPerLocality& hosts);
 
   /**
    * Overridden by every concrete cluster. The cluster should do whatever pre-init is needed. E.g.,
@@ -419,8 +437,6 @@ protected:
    * over and determines if there is an initial health check pass needed, etc.
    */
   void onPreInitComplete();
-
-  static const HostListsConstSharedPtr empty_host_lists_;
 
   Runtime::Loader& runtime_;
   ClusterInfoConstSharedPtr
@@ -468,10 +484,8 @@ class BaseDynamicClusterImpl : public ClusterImplBase {
 protected:
   using ClusterImplBase::ClusterImplBase;
 
-  bool updateDynamicHostList(const std::vector<HostSharedPtr>& new_hosts,
-                             std::vector<HostSharedPtr>& current_hosts,
-                             std::vector<HostSharedPtr>& hosts_added,
-                             std::vector<HostSharedPtr>& hosts_removed, bool depend_on_hc);
+  bool updateDynamicHostList(const HostVector& new_hosts, HostVector& current_hosts,
+                             HostVector& hosts_added, HostVector& hosts_removed, bool depend_on_hc);
 };
 
 /**
@@ -500,13 +514,12 @@ private:
     std::string dns_address_;
     uint32_t port_;
     Event::TimerPtr resolve_timer_;
-    std::vector<HostSharedPtr> hosts_;
+    HostVector hosts_;
   };
 
   typedef std::unique_ptr<ResolveTarget> ResolveTargetPtr;
 
-  void updateAllHosts(const std::vector<HostSharedPtr>& hosts_added,
-                      const std::vector<HostSharedPtr>& hosts_removed);
+  void updateAllHosts(const HostVector& hosts_added, const HostVector& hosts_removed);
 
   // ClusterImplBase
   void startPreInit() override;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -168,14 +168,7 @@ private:
 
 class HostsPerLocalityImpl : public HostsPerLocality {
 public:
-  HostsPerLocalityImpl() : HostsPerLocalityImpl(false) {}
-
-  HostsPerLocalityImpl(bool has_local_locality)
-      : HostsPerLocalityImpl(has_local_locality ? std::vector<HostVector>({{}})
-                                                : std::vector<HostVector>()) {}
-
-  HostsPerLocalityImpl(std::vector<HostVector>&& locality_hosts)
-      : HostsPerLocalityImpl(std::move(locality_hosts), !locality_hosts.empty()) {}
+  HostsPerLocalityImpl() : HostsPerLocalityImpl({}, false) {}
 
   HostsPerLocalityImpl(std::vector<HostVector>&& locality_hosts, bool has_local_locality)
       : local_(has_local_locality), hosts_per_locality_(std::move(locality_hosts)) {

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -122,6 +122,7 @@ envoy_cc_test(
     name = "load_balancer_simulation_test",
     srcs = ["load_balancer_simulation_test.cc"],
     deps = [
+        ":utility_lib",
         "//source/common/network:utility_lib",
         "//source/common/runtime:runtime_lib",
         "//source/common/upstream:load_balancer_lib",

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -742,8 +742,7 @@ TEST_F(ClusterManagerImplTest, DynamicRemoveWithLocalCluster) {
   // Add another update callback on foo so we make sure callbacks keep working.
   ReadyWatcher membership_updated;
   foo->prioritySet().addMemberUpdateCb(
-      [&membership_updated](uint32_t, const std::vector<HostSharedPtr>&,
-                            const std::vector<HostSharedPtr>&) -> void {
+      [&membership_updated](uint32_t, const HostVector&, const HostVector&) -> void {
         membership_updated.ready();
       });
 

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -267,14 +267,14 @@ TEST_F(EdsTest, EndpointHostsPerLocality) {
 
   {
     auto& hosts_per_locality = cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality();
-    EXPECT_EQ(2, hosts_per_locality.size());
-    EXPECT_EQ(1, hosts_per_locality[0].size());
-    EXPECT_EQ(Locality("", "us-east-1a", ""), Locality(hosts_per_locality[0][0]->locality()));
-    EXPECT_EQ(2, hosts_per_locality[1].size());
+    EXPECT_EQ(2, hosts_per_locality.get().size());
+    EXPECT_EQ(1, hosts_per_locality.get()[0].size());
+    EXPECT_EQ(Locality("", "us-east-1a", ""), Locality(hosts_per_locality.get()[0][0]->locality()));
+    EXPECT_EQ(2, hosts_per_locality.get()[1].size());
     EXPECT_EQ(Locality("oceania", "koala", "ingsoc"),
-              Locality(hosts_per_locality[1][0]->locality()));
+              Locality(hosts_per_locality.get()[1][0]->locality()));
     EXPECT_EQ(Locality("oceania", "koala", "ingsoc"),
-              Locality(hosts_per_locality[1][1]->locality()));
+              Locality(hosts_per_locality.get()[1][1]->locality()));
   }
 
   add_hosts_to_locality("oceania", "koala", "eucalyptus", 3);
@@ -284,18 +284,18 @@ TEST_F(EdsTest, EndpointHostsPerLocality) {
 
   {
     auto& hosts_per_locality = cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality();
-    EXPECT_EQ(4, hosts_per_locality.size());
-    EXPECT_EQ(1, hosts_per_locality[0].size());
-    EXPECT_EQ(Locality("", "us-east-1a", ""), Locality(hosts_per_locality[0][0]->locality()));
-    EXPECT_EQ(5, hosts_per_locality[1].size());
+    EXPECT_EQ(4, hosts_per_locality.get().size());
+    EXPECT_EQ(1, hosts_per_locality.get()[0].size());
+    EXPECT_EQ(Locality("", "us-east-1a", ""), Locality(hosts_per_locality.get()[0][0]->locality()));
+    EXPECT_EQ(5, hosts_per_locality.get()[1].size());
     EXPECT_EQ(Locality("general", "koala", "ingsoc"),
-              Locality(hosts_per_locality[1][0]->locality()));
-    EXPECT_EQ(3, hosts_per_locality[2].size());
+              Locality(hosts_per_locality.get()[1][0]->locality()));
+    EXPECT_EQ(3, hosts_per_locality.get()[2].size());
     EXPECT_EQ(Locality("oceania", "koala", "eucalyptus"),
-              Locality(hosts_per_locality[2][0]->locality()));
-    EXPECT_EQ(2, hosts_per_locality[3].size());
+              Locality(hosts_per_locality.get()[2][0]->locality()));
+    EXPECT_EQ(2, hosts_per_locality.get()[3].size());
     EXPECT_EQ(Locality("oceania", "koala", "ingsoc"),
-              Locality(hosts_per_locality[3][0]->locality()));
+              Locality(hosts_per_locality.get()[3][0]->locality()));
   }
 }
 
@@ -435,20 +435,21 @@ TEST_F(EdsTest, PriorityAndLocality) {
   {
     auto& first_hosts_per_locality =
         cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality();
-    EXPECT_EQ(2, first_hosts_per_locality.size());
-    EXPECT_EQ(1, first_hosts_per_locality[0].size());
-    EXPECT_EQ(Locality("", "us-east-1a", ""), Locality(first_hosts_per_locality[0][0]->locality()));
-    EXPECT_EQ(2, first_hosts_per_locality[1].size());
+    EXPECT_EQ(2, first_hosts_per_locality.get().size());
+    EXPECT_EQ(1, first_hosts_per_locality.get()[0].size());
+    EXPECT_EQ(Locality("", "us-east-1a", ""),
+              Locality(first_hosts_per_locality.get()[0][0]->locality()));
+    EXPECT_EQ(2, first_hosts_per_locality.get()[1].size());
     EXPECT_EQ(Locality("oceania", "koala", "ingsoc"),
-              Locality(first_hosts_per_locality[1][0]->locality()));
+              Locality(first_hosts_per_locality.get()[1][0]->locality()));
     EXPECT_EQ(Locality("oceania", "koala", "ingsoc"),
-              Locality(first_hosts_per_locality[1][1]->locality()));
+              Locality(first_hosts_per_locality.get()[1][1]->locality()));
 
     auto& second_hosts_per_locality =
         cluster_->prioritySet().hostSetsPerPriority()[1]->hostsPerLocality();
-    ASSERT_EQ(2, second_hosts_per_locality.size());
-    EXPECT_EQ(8, second_hosts_per_locality[0].size());
-    EXPECT_EQ(2, second_hosts_per_locality[1].size());
+    ASSERT_EQ(2, second_hosts_per_locality.get().size());
+    EXPECT_EQ(8, second_hosts_per_locality.get()[0].size());
+    EXPECT_EQ(2, second_hosts_per_locality.get()[1].size());
   }
 
   // Add one more locality to both priority 0 and priority 1.
@@ -460,27 +461,29 @@ TEST_F(EdsTest, PriorityAndLocality) {
   {
     auto& first_hosts_per_locality =
         cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality();
-    EXPECT_EQ(3, first_hosts_per_locality.size());
-    EXPECT_EQ(1, first_hosts_per_locality[0].size());
-    EXPECT_EQ(Locality("", "us-east-1a", ""), Locality(first_hosts_per_locality[0][0]->locality()));
-    EXPECT_EQ(3, first_hosts_per_locality[1].size());
+    EXPECT_EQ(3, first_hosts_per_locality.get().size());
+    EXPECT_EQ(1, first_hosts_per_locality.get()[0].size());
+    EXPECT_EQ(Locality("", "us-east-1a", ""),
+              Locality(first_hosts_per_locality.get()[0][0]->locality()));
+    EXPECT_EQ(3, first_hosts_per_locality.get()[1].size());
     EXPECT_EQ(Locality("oceania", "koala", "eucalyptus"),
-              Locality(first_hosts_per_locality[1][0]->locality()));
-    EXPECT_EQ(2, first_hosts_per_locality[2].size());
+              Locality(first_hosts_per_locality.get()[1][0]->locality()));
+    EXPECT_EQ(2, first_hosts_per_locality.get()[2].size());
     EXPECT_EQ(Locality("oceania", "koala", "ingsoc"),
-              Locality(first_hosts_per_locality[2][0]->locality()));
+              Locality(first_hosts_per_locality.get()[2][0]->locality()));
 
     auto& second_hosts_per_locality =
         cluster_->prioritySet().hostSetsPerPriority()[1]->hostsPerLocality();
-    EXPECT_EQ(3, second_hosts_per_locality.size());
-    EXPECT_EQ(8, second_hosts_per_locality[0].size());
+    EXPECT_EQ(3, second_hosts_per_locality.get().size());
+    EXPECT_EQ(8, second_hosts_per_locality.get()[0].size());
     EXPECT_EQ(Locality("", "us-east-1a", ""),
-              Locality(second_hosts_per_locality[0][0]->locality()));
-    EXPECT_EQ(2, second_hosts_per_locality[1].size());
-    EXPECT_EQ(Locality("foo", "bar", "eep"), Locality(second_hosts_per_locality[1][0]->locality()));
-    EXPECT_EQ(5, second_hosts_per_locality[2].size());
+              Locality(second_hosts_per_locality.get()[0][0]->locality()));
+    EXPECT_EQ(2, second_hosts_per_locality.get()[1].size());
+    EXPECT_EQ(Locality("foo", "bar", "eep"),
+              Locality(second_hosts_per_locality.get()[1][0]->locality()));
+    EXPECT_EQ(5, second_hosts_per_locality.get()[2].size());
     EXPECT_EQ(Locality("general", "koala", "ingsoc"),
-              Locality(second_hosts_per_locality[2][0]->locality()));
+              Locality(second_hosts_per_locality.get()[2][0]->locality()));
   }
 }
 

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -728,7 +728,7 @@ TEST_F(HttpHealthCheckerImplTest, DynamicAddAndRemove) {
   cluster_->prioritySet().getMockHostSet(0)->runCallbacks(
       {cluster_->prioritySet().getMockHostSet(0)->hosts_.back()}, {});
 
-  std::vector<HostSharedPtr> removed{cluster_->prioritySet().getMockHostSet(0)->hosts_.back()};
+  HostVector removed{cluster_->prioritySet().getMockHostSet(0)->hosts_.back()};
   cluster_->prioritySet().getMockHostSet(0)->hosts_.clear();
   EXPECT_CALL(*test_sessions_[0]->client_connection_, close(_));
   cluster_->prioritySet().getMockHostSet(0)->runCallbacks({}, removed);
@@ -1103,7 +1103,7 @@ TEST_F(TcpHealthCheckerImplTest, Timeout) {
 
   connection_->raiseEvent(Network::ConnectionEvent::Connected);
 
-  std::vector<HostSharedPtr> removed{cluster_->prioritySet().getMockHostSet(0)->hosts_.back()};
+  HostVector removed{cluster_->prioritySet().getMockHostSet(0)->hosts_.back()};
   cluster_->prioritySet().getMockHostSet(0)->hosts_.clear();
   EXPECT_CALL(*connection_, close(_));
   cluster_->prioritySet().getMockHostSet(0)->runCallbacks({}, removed);
@@ -1254,8 +1254,7 @@ TEST_F(TcpHealthCheckerImplTest, PassiveFailureCrossThreadRemoveHostRace) {
 
   // Remove before the cross thread event comes in.
   EXPECT_CALL(*connection_, close(_));
-  std::vector<HostSharedPtr> old_hosts =
-      std::move(cluster_->prioritySet().getMockHostSet(0)->hosts_);
+  HostVector old_hosts = std::move(cluster_->prioritySet().getMockHostSet(0)->hosts_);
   cluster_->prioritySet().getMockHostSet(0)->runCallbacks({}, old_hosts);
   post_cb();
 
@@ -2088,7 +2087,7 @@ TEST_F(GrpcHealthCheckerImplTest, DynamicAddAndRemove) {
   cluster_->prioritySet().getMockHostSet(0)->runCallbacks(
       {cluster_->prioritySet().getMockHostSet(0)->hosts_.back()}, {});
 
-  std::vector<HostSharedPtr> removed{cluster_->prioritySet().getMockHostSet(0)->hosts_.back()};
+  HostVector removed{cluster_->prioritySet().getMockHostSet(0)->hosts_.back()};
   cluster_->prioritySet().getMockHostSet(0)->hosts_.clear();
   EXPECT_CALL(*test_sessions_[0]->client_connection_, close(_));
   cluster_->prioritySet().getMockHostSet(0)->runCallbacks({}, removed);

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -8,6 +8,7 @@
 #include "common/upstream/load_balancer_impl.h"
 #include "common/upstream/upstream_impl.h"
 
+#include "test/common/upstream/utility.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/mocks.h"
 
@@ -58,8 +59,9 @@ public:
     // TODO(mattklein123): make load balancer per originating cluster host.
     RandomLoadBalancer lb(priority_set_, local_priority_set_, stats_, runtime_, random_);
 
-    HostListsSharedPtr upstream_per_zone_hosts = generateHostsPerZone(healthy_destination_cluster);
-    HostListsSharedPtr local_per_zone_hosts = generateHostsPerZone(originating_cluster);
+    HostsPerLocalitySharedPtr upstream_per_zone_hosts =
+        generateHostsPerZone(healthy_destination_cluster);
+    HostsPerLocalitySharedPtr local_per_zone_hosts = generateHostsPerZone(originating_cluster);
 
     HostVectorSharedPtr originating_hosts = generateHostList(originating_cluster);
     HostVectorSharedPtr healthy_destination = generateHostList(healthy_destination_cluster);
@@ -73,31 +75,33 @@ public:
       uint32_t from_zone = atoi(from_host->locality().zone().c_str());
 
       // Populate host set for upstream cluster.
-      HostListsSharedPtr per_zone_upstream(new std::vector<std::vector<HostSharedPtr>>());
-      per_zone_upstream->push_back((*upstream_per_zone_hosts)[from_zone]);
-      for (size_t zone = 0; zone < upstream_per_zone_hosts->size(); ++zone) {
+      std::vector<HostVector> per_zone_upstream;
+      per_zone_upstream.push_back(upstream_per_zone_hosts->get()[from_zone]);
+      for (size_t zone = 0; zone < upstream_per_zone_hosts->get().size(); ++zone) {
         if (zone == from_zone) {
           continue;
         }
 
-        per_zone_upstream->push_back((*upstream_per_zone_hosts)[zone]);
+        per_zone_upstream.push_back(upstream_per_zone_hosts->get()[zone]);
       }
-      host_set_.hosts_per_locality_ = *per_zone_upstream;
-      host_set_.healthy_hosts_per_locality_ = *per_zone_upstream;
+      auto per_zone_upstream_shared = makeHostsPerLocality(std::move(per_zone_upstream));
+      host_set_.hosts_per_locality_ = per_zone_upstream_shared;
+      host_set_.healthy_hosts_per_locality_ = per_zone_upstream_shared;
 
       // Populate host set for originating cluster.
-      HostListsSharedPtr per_zone_local(new std::vector<std::vector<HostSharedPtr>>());
-      per_zone_local->push_back((*local_per_zone_hosts)[from_zone]);
-      for (size_t zone = 0; zone < local_per_zone_hosts->size(); ++zone) {
+      std::vector<HostVector> per_zone_local;
+      per_zone_local.push_back(local_per_zone_hosts->get()[from_zone]);
+      for (size_t zone = 0; zone < local_per_zone_hosts->get().size(); ++zone) {
         if (zone == from_zone) {
           continue;
         }
 
-        per_zone_local->push_back((*local_per_zone_hosts)[zone]);
+        per_zone_local.push_back(local_per_zone_hosts->get()[zone]);
       }
-      local_priority_set_->getOrCreateHostSet(0).updateHosts(originating_hosts, originating_hosts,
-                                                             per_zone_local, per_zone_local,
-                                                             empty_vector_, empty_vector_);
+      auto per_zone_local_shared = makeHostsPerLocality(std::move(per_zone_local));
+      local_priority_set_->getOrCreateHostSet(0).updateHosts(
+          originating_hosts, originating_hosts, per_zone_local_shared, per_zone_local_shared,
+          empty_vector_, empty_vector_);
 
       HostConstSharedPtr selected = lb.chooseHost(nullptr);
       hits[selected->address()->asString()]++;
@@ -112,7 +116,7 @@ public:
     }
   }
 
-  HostSharedPtr selectOriginatingHost(const std::vector<HostSharedPtr>& hosts) {
+  HostSharedPtr selectOriginatingHost(const HostVector& hosts) {
     // Originating cluster should have roughly the same per host request distribution.
     return hosts[random_.random() % hosts.size()];
   }
@@ -122,7 +126,7 @@ public:
    * @param hosts number of hosts per zone.
    */
   HostVectorSharedPtr generateHostList(const std::vector<uint32_t>& hosts) {
-    HostVectorSharedPtr ret(new std::vector<HostSharedPtr>());
+    HostVectorSharedPtr ret(new HostVector());
     for (size_t i = 0; i < hosts.size(); ++i) {
       const std::string zone = std::to_string(i);
       for (uint32_t j = 0; j < hosts[i]; ++j) {
@@ -138,25 +142,25 @@ public:
    * Generate hosts by zone.
    * @param hosts number of hosts per zone.
    */
-  HostListsSharedPtr generateHostsPerZone(const std::vector<uint32_t>& hosts) {
-    HostListsSharedPtr ret(new std::vector<std::vector<HostSharedPtr>>());
+  HostsPerLocalitySharedPtr generateHostsPerZone(const std::vector<uint32_t>& hosts) {
+    std::vector<HostVector> ret;
     for (size_t i = 0; i < hosts.size(); ++i) {
       const std::string zone = std::to_string(i);
-      std::vector<HostSharedPtr> zone_hosts;
+      HostVector zone_hosts;
 
       for (uint32_t j = 0; j < hosts[i]; ++j) {
         const std::string url = fmt::format("tcp://host.{}.{}:80", i, j);
         zone_hosts.push_back(newTestHost(info_, url, 1, zone));
       }
 
-      ret->push_back(std::move(zone_hosts));
+      ret.push_back(std::move(zone_hosts));
     }
 
-    return ret;
+    return makeHostsPerLocality(std::move(ret));
   };
 
   const uint32_t total_number_of_requests = 1000000;
-  std::vector<HostSharedPtr> empty_vector_;
+  HostVector empty_vector_;
 
   PrioritySetImpl* local_priority_set_;
   NiceMock<MockPrioritySet> priority_set_;

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -35,8 +35,9 @@ public:
                                          ssl_context_manager_, dns_resolver_, tls_, cm, dispatcher_,
                                          false));
     cluster_->prioritySet().addMemberUpdateCb(
-        [&](uint32_t, const std::vector<HostSharedPtr>&,
-            const std::vector<HostSharedPtr>&) -> void { membership_updated_.ready(); });
+        [&](uint32_t, const HostVector&, const HostVector&) -> void {
+          membership_updated_.ready();
+        });
     cluster_->initialize([&]() -> void { initialized_.ready(); });
   }
 
@@ -171,9 +172,10 @@ TEST_F(LogicalDnsClusterTest, Basic) {
 
   EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().size());
-  EXPECT_EQ(0UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get().size());
+  EXPECT_EQ(
+      0UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
   EXPECT_EQ(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0],
             cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts()[0]);
   HostSharedPtr logical_host = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0];

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -56,8 +56,9 @@ public:
     cluster_.reset(new OriginalDstCluster(parseClusterFromJson(json), runtime_, stats_store_,
                                           ssl_context_manager_, cm, dispatcher_, false));
     cluster_->prioritySet().addMemberUpdateCb(
-        [&](uint32_t, const std::vector<HostSharedPtr>&,
-            const std::vector<HostSharedPtr>&) -> void { membership_updated_.ready(); });
+        [&](uint32_t, const HostVector&, const HostVector&) -> void {
+          membership_updated_.ready();
+        });
     cluster_->initialize([&]() -> void { initialized_.ready(); });
   }
 
@@ -136,9 +137,10 @@ TEST_F(OriginalDstClusterTest, NoContext) {
 
   EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().size());
-  EXPECT_EQ(0UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get().size());
+  EXPECT_EQ(
+      0UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
 
   // No downstream connection => no host.
   {
@@ -194,9 +196,10 @@ TEST_F(OriginalDstClusterTest, Membership) {
 
   EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().size());
-  EXPECT_EQ(0UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get().size());
+  EXPECT_EQ(
+      0UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
 
   EXPECT_CALL(membership_updated_, ready());
 
@@ -219,9 +222,10 @@ TEST_F(OriginalDstClusterTest, Membership) {
 
   EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().size());
-  EXPECT_EQ(0UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get().size());
+  EXPECT_EQ(
+      0UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
 
   EXPECT_EQ(host, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]);
   EXPECT_EQ(*connection.local_address_,
@@ -283,9 +287,10 @@ TEST_F(OriginalDstClusterTest, Membership2) {
 
   EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().size());
-  EXPECT_EQ(0UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get().size());
+  EXPECT_EQ(
+      0UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
 
   // Host gets the local address of the downstream connection.
 
@@ -318,9 +323,10 @@ TEST_F(OriginalDstClusterTest, Membership2) {
 
   EXPECT_EQ(2UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(2UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().size());
-  EXPECT_EQ(0UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get().size());
+  EXPECT_EQ(
+      0UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
 
   EXPECT_EQ(host1, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]);
   EXPECT_EQ(*connection1.local_address_,
@@ -372,9 +378,10 @@ TEST_F(OriginalDstClusterTest, Connection) {
 
   EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().size());
-  EXPECT_EQ(0UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get().size());
+  EXPECT_EQ(
+      0UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
 
   EXPECT_CALL(membership_updated_, ready());
 
@@ -412,18 +419,18 @@ TEST_F(OriginalDstClusterTest, MultipleClusters) {
   setup(json);
 
   PrioritySetImpl second;
-  cluster_->prioritySet().addMemberUpdateCb([&](uint32_t, const std::vector<HostSharedPtr>& added,
-                                                const std::vector<HostSharedPtr>& removed) -> void {
-    // Update second hostset accordingly;
-    HostVectorSharedPtr new_hosts(
-        new std::vector<HostSharedPtr>(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
-    HostVectorSharedPtr healthy_hosts(
-        new std::vector<HostSharedPtr>(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
-    const HostListsConstSharedPtr empty_host_lists{new std::vector<std::vector<HostSharedPtr>>()};
+  cluster_->prioritySet().addMemberUpdateCb(
+      [&](uint32_t, const HostVector& added, const HostVector& removed) -> void {
+        // Update second hostset accordingly;
+        HostVectorSharedPtr new_hosts(
+            new HostVector(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
+        HostVectorSharedPtr healthy_hosts(
+            new HostVector(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
+        const HostsPerLocalityConstSharedPtr empty_hosts_per_locality{new HostsPerLocalityImpl()};
 
-    second.getOrCreateHostSet(0).updateHosts(new_hosts, healthy_hosts, empty_host_lists,
-                                             empty_host_lists, added, removed);
-  });
+        second.getOrCreateHostSet(0).updateHosts(new_hosts, healthy_hosts, empty_hosts_per_locality,
+                                                 empty_hosts_per_locality, added, removed);
+      });
 
   EXPECT_CALL(membership_updated_, ready());
 

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -140,9 +140,7 @@ TEST_F(SdsTest, NoHealthChecker) {
   setupRequest();
 
   cluster_->prioritySet().addMemberUpdateCb(
-      [&](uint32_t, const std::vector<HostSharedPtr>&, const std::vector<HostSharedPtr>&) -> void {
-        membership_updated_.ready();
-      });
+      [&](uint32_t, const HostVector&, const HostVector&) -> void { membership_updated_.ready(); });
   cluster_->initialize([&]() -> void { membership_updated_.ready(); });
 
   Http::MessagePtr message(new Http::ResponseMessageImpl(
@@ -157,14 +155,18 @@ TEST_F(SdsTest, NoHealthChecker) {
   EXPECT_EQ(13UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(13UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
   EXPECT_EQ(13UL, cluster_->info()->stats().membership_healthy_.value());
-  EXPECT_EQ(3UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
-  EXPECT_EQ(4UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[0].size());
-  EXPECT_EQ(5UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[1].size());
-  EXPECT_EQ(4UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[2].size());
+  EXPECT_EQ(
+      3UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
+  EXPECT_EQ(
+      4UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[0].size());
+  EXPECT_EQ(
+      5UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[1].size());
+  EXPECT_EQ(
+      4UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[2].size());
   EXPECT_EQ(6860994315024339285U, cluster_->info()->stats().version_.value());
 
   // Hosts in SDS and static clusters should have empty hostname
@@ -195,14 +197,18 @@ TEST_F(SdsTest, NoHealthChecker) {
   EXPECT_EQ("us-east-1d", canary_host->locality().zone());
   EXPECT_EQ(50U, canary_host->weight());
   EXPECT_EQ(50UL, cluster_->info()->stats().max_host_weight_.value());
-  EXPECT_EQ(3UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
-  EXPECT_EQ(4UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[0].size());
-  EXPECT_EQ(5UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[1].size());
-  EXPECT_EQ(4UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[2].size());
+  EXPECT_EQ(
+      3UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
+  EXPECT_EQ(
+      4UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[0].size());
+  EXPECT_EQ(
+      5UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[1].size());
+  EXPECT_EQ(
+      4UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[2].size());
   EXPECT_EQ(3250177750903005831U, cluster_->info()->stats().version_.value());
 
   // Now test the failure case, our cluster size should not change.
@@ -214,14 +220,18 @@ TEST_F(SdsTest, NoHealthChecker) {
   EXPECT_EQ(13UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(50U, canary_host->weight());
   EXPECT_EQ(50UL, cluster_->info()->stats().max_host_weight_.value());
-  EXPECT_EQ(3UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
-  EXPECT_EQ(4UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[0].size());
-  EXPECT_EQ(5UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[1].size());
-  EXPECT_EQ(4UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[2].size());
+  EXPECT_EQ(
+      3UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
+  EXPECT_EQ(
+      4UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[0].size());
+  EXPECT_EQ(
+      5UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[1].size());
+  EXPECT_EQ(
+      4UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[2].size());
 
   // 503 response.
   setupRequest();
@@ -235,14 +245,18 @@ TEST_F(SdsTest, NoHealthChecker) {
   EXPECT_EQ(13UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(50U, canary_host->weight());
   EXPECT_EQ(50UL, cluster_->info()->stats().max_host_weight_.value());
-  EXPECT_EQ(3UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
-  EXPECT_EQ(4UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[0].size());
-  EXPECT_EQ(5UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[1].size());
-  EXPECT_EQ(4UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[2].size());
+  EXPECT_EQ(
+      3UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
+  EXPECT_EQ(
+      4UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[0].size());
+  EXPECT_EQ(
+      5UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[1].size());
+  EXPECT_EQ(
+      4UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[2].size());
   EXPECT_EQ(3250177750903005831U, cluster_->info()->stats().version_.value());
 }
 
@@ -271,15 +285,19 @@ TEST_F(SdsTest, HealthChecker) {
   EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
   EXPECT_EQ(0UL, cluster_->info()->stats().membership_healthy_.value());
   EXPECT_EQ(0UL, numHealthy());
-  EXPECT_EQ(3UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
-  EXPECT_EQ(3UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().size());
-  EXPECT_EQ(0UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[0].size());
-  EXPECT_EQ(0UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[1].size());
-  EXPECT_EQ(0UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[2].size());
+  EXPECT_EQ(
+      3UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
+  EXPECT_EQ(3UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get().size());
+  EXPECT_EQ(
+      0UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[0].size());
+  EXPECT_EQ(
+      0UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[1].size());
+  EXPECT_EQ(
+      0UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[2].size());
   EXPECT_EQ(6860994315024339285U, cluster_->info()->stats().version_.value());
 
   // Now run through and make all the hosts healthy except for the first one. Because we are
@@ -293,14 +311,18 @@ TEST_F(SdsTest, HealthChecker) {
 
   EXPECT_EQ(0UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
   EXPECT_EQ(0UL, cluster_->info()->stats().membership_healthy_.value());
-  EXPECT_EQ(3UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
-  EXPECT_EQ(0UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[0].size());
-  EXPECT_EQ(0UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[1].size());
-  EXPECT_EQ(0UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[2].size());
+  EXPECT_EQ(
+      3UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
+  EXPECT_EQ(
+      0UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[0].size());
+  EXPECT_EQ(
+      0UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[1].size());
+  EXPECT_EQ(
+      0UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[2].size());
 
   // Do the last one now which should fire the initialized event. It should also cause a healthy
   // host recalculation and unblock health updates.
@@ -311,14 +333,18 @@ TEST_F(SdsTest, HealthChecker) {
   EXPECT_EQ("hash_5f3725fa79001155", cluster_->versionInfo());
   EXPECT_EQ(13UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
   EXPECT_EQ(13UL, cluster_->info()->stats().membership_healthy_.value());
-  EXPECT_EQ(3UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
-  EXPECT_EQ(4UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[0].size());
-  EXPECT_EQ(5UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[1].size());
-  EXPECT_EQ(4UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[2].size());
+  EXPECT_EQ(
+      3UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
+  EXPECT_EQ(
+      4UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[0].size());
+  EXPECT_EQ(
+      5UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[1].size());
+  EXPECT_EQ(
+      4UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[2].size());
   EXPECT_EQ(6860994315024339285U, cluster_->info()->stats().version_.value());
 
   // Now we will remove some hosts, but since they are all healthy, they shouldn't actually be gone.
@@ -336,14 +362,18 @@ TEST_F(SdsTest, HealthChecker) {
   EXPECT_EQ(13UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
   EXPECT_EQ(13UL, cluster_->info()->stats().membership_healthy_.value());
   EXPECT_EQ(13UL, numHealthy());
-  EXPECT_EQ(3UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
-  EXPECT_EQ(4UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[0].size());
-  EXPECT_EQ(5UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[1].size());
-  EXPECT_EQ(4UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[2].size());
+  EXPECT_EQ(
+      3UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
+  EXPECT_EQ(
+      4UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[0].size());
+  EXPECT_EQ(
+      5UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[1].size());
+  EXPECT_EQ(
+      4UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[2].size());
   EXPECT_EQ(4145707046791707664U, cluster_->info()->stats().version_.value());
 
   // Now set one of the removed hosts to unhealthy, and return the same query again, this should
@@ -362,14 +392,18 @@ TEST_F(SdsTest, HealthChecker) {
   EXPECT_EQ(12UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
   EXPECT_EQ(12UL, cluster_->info()->stats().membership_healthy_.value());
   EXPECT_EQ(12UL, numHealthy());
-  EXPECT_EQ(3UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
-  EXPECT_EQ(3UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[0].size());
-  EXPECT_EQ(5UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[1].size());
-  EXPECT_EQ(4UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[2].size());
+  EXPECT_EQ(
+      3UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
+  EXPECT_EQ(
+      3UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[0].size());
+  EXPECT_EQ(
+      5UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[1].size());
+  EXPECT_EQ(
+      4UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[2].size());
   EXPECT_EQ(4145707046791707664U, cluster_->info()->stats().version_.value());
 
   // Now add back one of the hosts that was previously missing but we still have and make sure
@@ -387,14 +421,18 @@ TEST_F(SdsTest, HealthChecker) {
   EXPECT_EQ(12UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
   EXPECT_EQ(12UL, cluster_->info()->stats().membership_healthy_.value());
   EXPECT_EQ(12UL, numHealthy());
-  EXPECT_EQ(3UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
-  EXPECT_EQ(3UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[0].size());
-  EXPECT_EQ(5UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[1].size());
-  EXPECT_EQ(4UL,
-            cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality()[2].size());
+  EXPECT_EQ(
+      3UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
+  EXPECT_EQ(
+      3UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[0].size());
+  EXPECT_EQ(
+      5UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[1].size());
+  EXPECT_EQ(
+      4UL,
+      cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get()[2].size());
   EXPECT_EQ(13400729244851125029U, cluster_->info()->stats().version_.value());
 }
 

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -35,7 +35,7 @@ namespace Envoy {
 namespace Upstream {
 namespace {
 
-std::list<std::string> hostListToAddresses(const std::vector<HostSharedPtr>& hosts) {
+std::list<std::string> hostListToAddresses(const HostVector& hosts) {
   std::list<std::string> addresses;
   for (const HostSharedPtr& host : hosts) {
     addresses.push_back(host->address()->asString());
@@ -242,9 +242,7 @@ TEST(StrictDnsClusterImplTest, Basic) {
 
   ReadyWatcher membership_updated;
   cluster.prioritySet().addMemberUpdateCb(
-      [&](uint32_t, const std::vector<HostSharedPtr>&, const std::vector<HostSharedPtr>&) -> void {
-        membership_updated.ready();
-      });
+      [&](uint32_t, const HostVector&, const HostVector&) -> void { membership_updated.ready(); });
 
   cluster.initialize([] {});
 
@@ -291,8 +289,9 @@ TEST(StrictDnsClusterImplTest, Basic) {
       ContainerEq(hostListToAddresses(cluster.prioritySet().hostSetsPerPriority()[0]->hosts())));
 
   EXPECT_EQ(2UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().size());
-  EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get().size());
+  EXPECT_EQ(0UL,
+            cluster.prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
 
   for (const HostSharedPtr& host : cluster.prioritySet().hostSetsPerPriority()[0]->hosts()) {
     EXPECT_EQ(cluster.info().get(), &host->cluster());
@@ -563,8 +562,9 @@ TEST(StaticClusterImplTest, UrlConfig) {
       std::list<std::string>({"10.0.0.1:11001", "10.0.0.2:11002"}),
       ContainerEq(hostListToAddresses(cluster.prioritySet().hostSetsPerPriority()[0]->hosts())));
   EXPECT_EQ(2UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
-  EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().size());
-  EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().size());
+  EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get().size());
+  EXPECT_EQ(0UL,
+            cluster.prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
   cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[0]->healthChecker().setUnhealthy();
 }
 
@@ -664,8 +664,8 @@ TEST(PrioritySet, Extend) {
 
   uint32_t changes = 0;
   uint32_t last_priority = 0;
-  priority_set.addMemberUpdateCb([&](uint32_t priority, const std::vector<HostSharedPtr>&,
-                                     const std::vector<HostSharedPtr>&) -> void { // fIXME
+  priority_set.addMemberUpdateCb([&](uint32_t priority, const HostVector&,
+                                     const HostVector&) -> void { // fIXME
     last_priority = priority;
     ++changes;
   });
@@ -688,11 +688,10 @@ TEST(PrioritySet, Extend) {
 
   // Now add hosts for priority 1, and ensure they're added and subscribers are notified.
   std::shared_ptr<MockClusterInfo> info{new NiceMock<MockClusterInfo>()};
-  HostVectorSharedPtr hosts(
-      new std::vector<HostSharedPtr>({makeTestHost(info, "tcp://127.0.0.1:80")}));
-  HostListsSharedPtr hosts_per_locality(new std::vector<std::vector<HostSharedPtr>>({}));
-  std::vector<HostSharedPtr> hosts_added{hosts->front()};
-  std::vector<HostSharedPtr> hosts_removed{};
+  HostVectorSharedPtr hosts(new HostVector({makeTestHost(info, "tcp://127.0.0.1:80")}));
+  HostsPerLocalitySharedPtr hosts_per_locality = std::make_shared<HostsPerLocalityImpl>();
+  HostVector hosts_added{hosts->front()};
+  HostVector hosts_removed{};
 
   priority_set.hostSetsPerPriority()[1]->updateHosts(
       hosts, hosts, hosts_per_locality, hosts_per_locality, hosts_added, hosts_removed);
@@ -731,6 +730,82 @@ TEST(ClusterMetadataTest, Metadata) {
   EXPECT_EQ("test_value",
             Config::Metadata::metadataValue(cluster.info()->metadata(), "com.bar.foo", "baz")
                 .string_value());
+}
+
+// Validate empty singleton for HostsPerLocalityImpl.
+TEST(HostsPerLocalityImpl, Empty) {
+  EXPECT_FALSE(HostsPerLocalityImpl::empty()->hasLocalLocality());
+  EXPECT_EQ(0, HostsPerLocalityImpl::empty()->get().size());
+}
+
+// Validate HostsPerLocalityImpl constructors.
+TEST(HostsPerLocalityImpl, Cons) {
+  {
+    const HostsPerLocalityImpl hosts_per_locality;
+    EXPECT_FALSE(hosts_per_locality.hasLocalLocality());
+    EXPECT_EQ(0, hosts_per_locality.get().size());
+  }
+
+  {
+    const HostsPerLocalityImpl hosts_per_locality(false);
+    EXPECT_FALSE(hosts_per_locality.hasLocalLocality());
+    EXPECT_EQ(0, hosts_per_locality.get().size());
+  }
+
+  {
+    const HostsPerLocalityImpl hosts_per_locality(true);
+    EXPECT_TRUE(hosts_per_locality.hasLocalLocality());
+    EXPECT_EQ(1, hosts_per_locality.get().size());
+    EXPECT_TRUE(hosts_per_locality.get()[0].empty());
+  }
+
+  MockCluster cluster;
+  HostSharedPtr host_0 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);
+  HostSharedPtr host_1 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);
+
+  {
+    std::vector<HostVector> locality_hosts = {{host_0}, {host_1}};
+    const auto locality_hosts_copy = locality_hosts;
+    const HostsPerLocalityImpl hosts_per_locality(std::move(locality_hosts));
+    EXPECT_TRUE(hosts_per_locality.hasLocalLocality());
+    EXPECT_EQ(locality_hosts_copy, hosts_per_locality.get());
+  }
+
+  {
+    std::vector<HostVector> locality_hosts = {{host_0}, {host_1}};
+    const auto locality_hosts_copy = locality_hosts;
+    const HostsPerLocalityImpl hosts_per_locality(std::move(locality_hosts), false);
+    EXPECT_FALSE(hosts_per_locality.hasLocalLocality());
+    EXPECT_EQ(locality_hosts_copy, hosts_per_locality.get());
+  }
+}
+
+TEST(HostsPerLocalityImpl, Filter) {
+  MockCluster cluster;
+  HostSharedPtr host_0 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);
+  HostSharedPtr host_1 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);
+
+  {
+    std::vector<HostVector> locality_hosts = {{host_0}, {host_1}};
+    const auto filtered =
+        HostsPerLocalityImpl(std::move(locality_hosts), false).filter([&host_0](const Host& host) {
+          return &host == host_0.get();
+        });
+    EXPECT_FALSE(filtered->hasLocalLocality());
+    const std::vector<HostVector> expected_locality_hosts = {{host_0}, {}};
+    EXPECT_EQ(expected_locality_hosts, filtered->get());
+  }
+
+  {
+    std::vector<HostVector> locality_hosts = {{host_0}, {host_1}};
+    auto filtered =
+        HostsPerLocalityImpl(std::move(locality_hosts), true).filter([&host_1](const Host& host) {
+          return &host == host_1.get();
+        });
+    EXPECT_TRUE(filtered->hasLocalLocality());
+    const std::vector<HostVector> expected_locality_hosts = {{}, {host_1}};
+    EXPECT_EQ(expected_locality_hosts, filtered->get());
+  }
 }
 
 } // namespace

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -746,19 +746,6 @@ TEST(HostsPerLocalityImpl, Cons) {
     EXPECT_EQ(0, hosts_per_locality.get().size());
   }
 
-  {
-    const HostsPerLocalityImpl hosts_per_locality(false);
-    EXPECT_FALSE(hosts_per_locality.hasLocalLocality());
-    EXPECT_EQ(0, hosts_per_locality.get().size());
-  }
-
-  {
-    const HostsPerLocalityImpl hosts_per_locality(true);
-    EXPECT_TRUE(hosts_per_locality.hasLocalLocality());
-    EXPECT_EQ(1, hosts_per_locality.get().size());
-    EXPECT_TRUE(hosts_per_locality.get()[0].empty());
-  }
-
   MockCluster cluster;
   HostSharedPtr host_0 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);
   HostSharedPtr host_1 = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);
@@ -766,7 +753,7 @@ TEST(HostsPerLocalityImpl, Cons) {
   {
     std::vector<HostVector> locality_hosts = {{host_0}, {host_1}};
     const auto locality_hosts_copy = locality_hosts;
-    const HostsPerLocalityImpl hosts_per_locality(std::move(locality_hosts));
+    const HostsPerLocalityImpl hosts_per_locality(std::move(locality_hosts), true);
     EXPECT_TRUE(hosts_per_locality.hasLocalLocality());
     EXPECT_EQ(locality_hosts_copy, hosts_per_locality.get());
   }

--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -90,6 +90,10 @@ inline HostDescriptionConstSharedPtr makeTestHostDescription(ClusterInfoConstSha
       envoy::api::v2::Locality().default_instance())};
 }
 
+inline HostsPerLocalitySharedPtr makeHostsPerLocality(std::vector<HostVector>&& locality_hosts) {
+  return std::make_shared<HostsPerLocalityImpl>(std::move(locality_hosts));
+}
+
 } // namespace
 } // namespace Upstream
 } // namespace Envoy

--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -91,7 +91,7 @@ inline HostDescriptionConstSharedPtr makeTestHostDescription(ClusterInfoConstSha
 }
 
 inline HostsPerLocalitySharedPtr makeHostsPerLocality(std::vector<HostVector>&& locality_hosts) {
-  return std::make_shared<HostsPerLocalityImpl>(std::move(locality_hosts));
+  return std::make_shared<HostsPerLocalityImpl>(std::move(locality_hosts), !locality_hosts.empty());
 }
 
 } // namespace

--- a/test/mocks/upstream/BUILD
+++ b/test/mocks/upstream/BUILD
@@ -45,6 +45,7 @@ envoy_cc_mock(
         "//include/envoy/upstream:health_checker_interface",
         "//include/envoy/upstream:load_balancer_interface",
         "//include/envoy/upstream:upstream_interface",
+        "//source/common/upstream:upstream_lib",
         "//test/mocks/config:config_mocks",
         "//test/mocks/grpc:grpc_mocks",
         "//test/mocks/http:http_mocks",

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -55,8 +55,8 @@ public:
 
   HostVector hosts_;
   HostVector healthy_hosts_;
-  HostsPerLocalitySharedPtr hosts_per_locality_{new HostsPerLocalityImpl(true)};
-  HostsPerLocalitySharedPtr healthy_hosts_per_locality_{new HostsPerLocalityImpl(true)};
+  HostsPerLocalitySharedPtr hosts_per_locality_{new HostsPerLocalityImpl()};
+  HostsPerLocalitySharedPtr healthy_hosts_per_locality_{new HostsPerLocalityImpl()};
   Common::CallbackManager<uint32_t, const HostVector&, const HostVector&> member_update_cb_helper_;
   uint32_t priority_{};
 };

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -12,6 +12,7 @@
 #include "envoy/upstream/upstream.h"
 
 #include "common/common/callback_impl.h"
+#include "common/upstream/upstream_impl.h"
 
 #include "test/mocks/config/mocks.h"
 #include "test/mocks/grpc/mocks.h"
@@ -32,8 +33,7 @@ class MockHostSet : public HostSet {
 public:
   MockHostSet(uint32_t priority = 0);
 
-  void runCallbacks(const std::vector<HostSharedPtr> added,
-                    const std::vector<HostSharedPtr> removed) {
+  void runCallbacks(const HostVector added, const HostVector removed) {
     member_update_cb_helper_.runCallbacks(priority(), added, removed);
   }
 
@@ -42,28 +42,22 @@ public:
   }
 
   // Upstream::HostSet
-  MOCK_CONST_METHOD0(hosts, const std::vector<HostSharedPtr>&());
-  MOCK_CONST_METHOD0(healthyHosts, const std::vector<HostSharedPtr>&());
-  MOCK_CONST_METHOD0(hostsPerLocality, const std::vector<std::vector<HostSharedPtr>>&());
-  MOCK_CONST_METHOD0(healthyHostsPerLocality, const std::vector<std::vector<HostSharedPtr>>&());
-  MOCK_METHOD6(
-      updateHosts,
-      void(
-          std::shared_ptr<const std::vector<HostSharedPtr>> hosts,
-          std::shared_ptr<const std::vector<HostSharedPtr>> healthy_hosts,
-          std::shared_ptr<const std::vector<std::vector<HostSharedPtr>>> hosts_per_locality,
-          std::shared_ptr<const std::vector<std::vector<HostSharedPtr>>> healthy_hosts_per_locality,
-          const std::vector<HostSharedPtr>& hosts_added,
-          const std::vector<HostSharedPtr>& hosts_removed));
+  MOCK_CONST_METHOD0(hosts, const HostVector&());
+  MOCK_CONST_METHOD0(healthyHosts, const HostVector&());
+  MOCK_CONST_METHOD0(hostsPerLocality, const HostsPerLocality&());
+  MOCK_CONST_METHOD0(healthyHostsPerLocality, const HostsPerLocality&());
+  MOCK_METHOD6(updateHosts, void(std::shared_ptr<const HostVector> hosts,
+                                 std::shared_ptr<const HostVector> healthy_hosts,
+                                 HostsPerLocalityConstSharedPtr hosts_per_locality,
+                                 HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
+                                 const HostVector& hosts_added, const HostVector& hosts_removed));
   MOCK_CONST_METHOD0(priority, uint32_t());
 
-  std::vector<HostSharedPtr> hosts_;
-  std::vector<HostSharedPtr> healthy_hosts_;
-  std::vector<std::vector<HostSharedPtr>> hosts_per_locality_;
-  std::vector<std::vector<HostSharedPtr>> healthy_hosts_per_locality_;
-  Common::CallbackManager<uint32_t, const std::vector<HostSharedPtr>&,
-                          const std::vector<HostSharedPtr>&>
-      member_update_cb_helper_;
+  HostVector hosts_;
+  HostVector healthy_hosts_;
+  HostsPerLocalitySharedPtr hosts_per_locality_{new HostsPerLocalityImpl(true)};
+  HostsPerLocalitySharedPtr healthy_hosts_per_locality_{new HostsPerLocalityImpl(true)};
+  Common::CallbackManager<uint32_t, const HostVector&, const HostVector&> member_update_cb_helper_;
   uint32_t priority_{};
 };
 
@@ -73,8 +67,8 @@ public:
   ~MockPrioritySet() {}
 
   HostSet& getHostSet(uint32_t priority);
-  void runUpdateCallbacks(uint32_t priority, const std::vector<HostSharedPtr>& hosts_added,
-                          const std::vector<HostSharedPtr>& hosts_removed);
+  void runUpdateCallbacks(uint32_t priority, const HostVector& hosts_added,
+                          const HostVector& hosts_removed);
 
   MOCK_CONST_METHOD1(addMemberUpdateCb, Common::CallbackHandle*(MemberUpdateCb callback));
   MOCK_CONST_METHOD0(hostSetsPerPriority, const std::vector<HostSetPtr>&());
@@ -86,9 +80,7 @@ public:
   }
 
   std::vector<HostSetPtr> host_sets_;
-  Common::CallbackManager<uint32_t, const std::vector<HostSharedPtr>&,
-                          const std::vector<HostSharedPtr>&>
-      member_update_cb_helper_;
+  Common::CallbackManager<uint32_t, const HostVector&, const HostVector&> member_update_cb_helper_;
 };
 
 class MockCluster : public Cluster {


### PR DESCRIPTION
Rather than pass a std::vector<std::vector<HostSharedPtr>> around to
represent the hosts grouped by locality, switch to a first class object,
HostsPerLocality.

This has the advantage that we can independently flag whether or not the
local locality is present, which is needed to correct a bug in load
reporting where we fail to report for clusters where there are no local
hosts. The bug fix will be in a following PR.

The HostsPerLocality internal representation and API is fairly similar
to what we have today, a list with the first locality local (if it
exists). This has the advantage of minimizing churn and being largely
compatible with the existing zone aware LB. The interface is immutable
however, which reduces the amount of reliance code has on the internal
representation.

There's a lot of renaming in this PR as a result of some new typedefs;
best review strategy is to move quickly through that and search for
"HostsPerLocality" and "hosts_per_locality" for the interesting bits (in
particular in load_balancer_impl.cc and upstream[_impl].{h,cc}).

Risk Level: Low
Testing: New UTs for HostsPerLocalityImpl.

Signed-off-by: Harvey Tuch <htuch@google.com>