### PR TITLE
tls: use absl::string_view when calling absl::StrReplaceAll().

### DIFF
--- a/source/common/ssl/ssl_socket.cc
+++ b/source/common/ssl/ssl_socket.cc
@@ -252,7 +252,6 @@ const std::string& SslSocket::urlEncodedPemEncodedPeerCertificate() const {
   absl::string_view pem(reinterpret_cast<const char*>(output), length);
   cached_url_encoded_pem_encoded_peer_certificate_ = absl::StrReplaceAll(
       pem, {{"\n", "%0A"}, {" ", "%20"}, {"+", "%2B"}, {"/", "%2F"}, {"=", "%3D"}});
-  RELEASE_ASSERT(cached_url_encoded_pem_encoded_peer_certificate_.size() >= length);
   return cached_url_encoded_pem_encoded_peer_certificate_;
 }
 

--- a/source/common/ssl/ssl_socket.cc
+++ b/source/common/ssl/ssl_socket.cc
@@ -251,8 +251,7 @@ const std::string& SslSocket::urlEncodedPemEncodedPeerCertificate() const {
   RELEASE_ASSERT(BIO_mem_contents(buf.get(), &output, &length) == 1);
   absl::string_view pem(reinterpret_cast<const char*>(output), length);
   cached_url_encoded_pem_encoded_peer_certificate_ = absl::StrReplaceAll(
-      pem,
-      {{"\n", "%0A"}, {" ", "%20"}, {"+", "%2B"}, {"/", "%2F"}, {"=", "%3D"}});
+      pem, {{"\n", "%0A"}, {" ", "%20"}, {"+", "%2B"}, {"/", "%2F"}, {"=", "%3D"}});
   RELEASE_ASSERT(cached_url_encoded_pem_encoded_peer_certificate_.size() >= length);
   return cached_url_encoded_pem_encoded_peer_certificate_;
 }

--- a/source/common/ssl/ssl_socket.cc
+++ b/source/common/ssl/ssl_socket.cc
@@ -249,11 +249,11 @@ const std::string& SslSocket::urlEncodedPemEncodedPeerCertificate() const {
   const uint8_t* output;
   size_t length;
   RELEASE_ASSERT(BIO_mem_contents(buf.get(), &output, &length) == 1);
-  cached_url_encoded_pem_encoded_peer_certificate_ =
-      std::string(reinterpret_cast<const char*>(output), length);
-  // URL encoding shortcut
-  absl::StrReplaceAll({{"\n", "%0A"}, {" ", "%20"}, {"+", "%2B"}, {"/", "%2F"}, {"=", "%3D"}},
-                      &cached_url_encoded_pem_encoded_peer_certificate_);
+  absl::string_view pem(reinterpret_cast<const char*>(output), length);
+  cached_url_encoded_pem_encoded_peer_certificate_ = absl::StrReplaceAll(
+      pem,
+      {{"\n", "%0A"}, {" ", "%20"}, {"+", "%2B"}, {"/", "%2F"}, {"=", "%3D"}});
+  RELEASE_ASSERT(cached_url_encoded_pem_encoded_peer_certificate_.size() >= length);
   return cached_url_encoded_pem_encoded_peer_certificate_;
 }
 


### PR DESCRIPTION
This change is triggered by Google import, which uses different string type,
and not by any performance issues with existing code.