### PR TITLE
rds: expose route configuration name through request info

### DIFF
--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -221,6 +221,7 @@ public:
 };
 
 class RateLimitPolicy;
+class Config;
 
 /**
  * Virtual host defintion.
@@ -243,6 +244,11 @@ public:
    * @return const RateLimitPolicy& the rate limit policy for the virtual host.
    */
   virtual const RateLimitPolicy& rateLimitPolicy() const PURE;
+
+  /**
+   * @return const Config& return the router configuration that owns this virtual host.
+   */
+  virtual const Config& routeConfig() const PURE;
 };
 
 /**
@@ -487,6 +493,11 @@ public:
    * (RFC1918) source.
    */
   virtual const std::list<Http::LowerCaseString>& internalOnlyHeaders() const PURE;
+
+  /**
+   * @return const std::string Gets the RouteConfiguration name.
+   */
+  virtual const std::string& name() const PURE;
 };
 
 typedef std::shared_ptr<const Config> ConfigConstSharedPtr;

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -246,7 +246,7 @@ public:
   virtual const RateLimitPolicy& rateLimitPolicy() const PURE;
 
   /**
-   * @return const Config& return the router configuration that owns this virtual host.
+   * @return const Config& the RouteConfiguration that owns this virtual host.
    */
   virtual const Config& routeConfig() const PURE;
 };
@@ -495,7 +495,7 @@ public:
   virtual const std::list<Http::LowerCaseString>& internalOnlyHeaders() const PURE;
 
   /**
-   * @return const std::string Gets the RouteConfiguration name.
+   * @return const std::string the RouteConfiguration name.
    */
   virtual const std::string& name() const PURE;
 };

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -20,8 +20,10 @@ const AsyncStreamImpl::NullRetryPolicy AsyncStreamImpl::RouteEntryImpl::retry_po
 const AsyncStreamImpl::NullShadowPolicy AsyncStreamImpl::RouteEntryImpl::shadow_policy_;
 const AsyncStreamImpl::NullVirtualHost AsyncStreamImpl::RouteEntryImpl::virtual_host_;
 const AsyncStreamImpl::NullRateLimitPolicy AsyncStreamImpl::NullVirtualHost::rate_limit_policy_;
+const AsyncStreamImpl::NullConfig AsyncStreamImpl::NullVirtualHost::route_configuration_;
 const std::multimap<std::string, std::string> AsyncStreamImpl::RouteEntryImpl::opaque_config_;
 const envoy::api::v2::Metadata AsyncStreamImpl::RouteEntryImpl::metadata_;
+const std::list<LowerCaseString> AsyncStreamImpl::NullConfig::internal_only_headers_;
 
 AsyncClientImpl::AsyncClientImpl(const Upstream::ClusterInfo& cluster, Stats::Store& stats_store,
                                  Event::Dispatcher& dispatcher,

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -126,13 +126,29 @@ private:
     const std::string& runtimeKey() const override { return EMPTY_STRING; }
   };
 
+  struct NullConfig : public Router::Config {
+    Router::RouteConstSharedPtr route(const Http::HeaderMap&, uint64_t) const override {
+      return nullptr;
+    }
+
+    const std::list<LowerCaseString>& internalOnlyHeaders() const override {
+      return internal_only_headers_;
+    }
+
+    const std::string& name() const override { return EMPTY_STRING; }
+
+    static const std::list<LowerCaseString> internal_only_headers_;
+  };
+
   struct NullVirtualHost : public Router::VirtualHost {
     // Router::VirtualHost
     const std::string& name() const override { return EMPTY_STRING; }
     const Router::RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
     const Router::CorsPolicy* corsPolicy() const override { return nullptr; }
+    const Router::Config& routeConfig() const override { return route_configuration_; }
 
     static const NullRateLimitPolicy rate_limit_policy_;
+    static const NullConfig route_configuration_;
   };
 
   struct RouteEntryImpl : public Router::RouteEntry {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -687,6 +687,8 @@ VirtualHostImpl::VirtualClusterEntry::VirtualClusterEntry(
   name_ = virtual_cluster.name();
 }
 
+const Config& VirtualHostImpl::routeConfig() const { return global_route_config_; }
+
 const VirtualHostImpl* RouteMatcher::findWildcardVirtualHost(const std::string& host) const {
   // We do a longest wildcard suffix match against the host that's passed in.
   // (e.g. foo-bar.baz.com should match *-bar.baz.com before matching *.baz.com)
@@ -811,7 +813,8 @@ VirtualHostImpl::virtualClusterFromEntries(const Http::HeaderMap& headers) const
 }
 
 ConfigImpl::ConfigImpl(const envoy::api::v2::RouteConfiguration& config, Runtime::Loader& runtime,
-                       Upstream::ClusterManager& cm, bool validate_clusters_default) {
+                       Upstream::ClusterManager& cm, bool validate_clusters_default)
+    : name_(config.name()) {
   route_matcher_.reset(new RouteMatcher(
       config, *this, runtime, cm,
       PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, validate_clusters, validate_clusters_default)));

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -116,6 +116,7 @@ public:
   const CorsPolicy* corsPolicy() const override { return cors_policy_.get(); }
   const std::string& name() const override { return name_; }
   const RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
+  const Config& routeConfig() const override;
 
 private:
   enum class SslRequirements { NONE, EXTERNAL_ONLY, ALL };
@@ -608,11 +609,14 @@ public:
     return internal_only_headers_;
   }
 
+  const std::string& name() const override { return name_; }
+
 private:
   std::unique_ptr<RouteMatcher> route_matcher_;
   std::list<Http::LowerCaseString> internal_only_headers_;
   HeaderParserPtr request_headers_parser_;
   HeaderParserPtr response_headers_parser_;
+  const std::string name_;
 };
 
 /**
@@ -627,8 +631,11 @@ public:
     return internal_only_headers_;
   }
 
+  const std::string& name() const override { return name_; }
+
 private:
   std::list<Http::LowerCaseString> internal_only_headers_;
+  const std::string name_;
 };
 
 } // namespace Router

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -863,6 +863,24 @@ TEST_F(AsyncClientImplTest, WatermarkCallbacks) {
   EXPECT_CALL(stream_callbacks_, onReset());
 }
 
+TEST_F(AsyncClientImplTest, NullRouteConfigTest) {
+  TestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  AsyncClient::Stream* stream =
+      client_.start(stream_callbacks_, Optional<std::chrono::milliseconds>(), false);
+  stream->sendHeaders(headers, false);
+  Http::StreamDecoderFilterCallbacks* filter_callbacks =
+      static_cast<Http::AsyncStreamImpl*>(stream);
+  auto route = filter_callbacks->route();
+  auto route_entry = route->routeEntry();
+  ASSERT_NE(nullptr, route_entry);
+  const auto& route_config = route_entry->virtualHost().routeConfig();
+  EXPECT_EQ("", route_config.name());
+  EXPECT_EQ(0, route_config.internalOnlyHeaders().size());
+  EXPECT_EQ(nullptr, route_config.route(headers, 0));
+  EXPECT_CALL(stream_callbacks_, onReset());
+}
+
 } // namespace
 } // namespace Http
 } // namespace Envoy

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -3756,7 +3756,7 @@ virtual_hosts:
       EnvoyException, "response body size is 4097 bytes; maximum is 4096");
 }
 
-TEST(RouteConfigurationV2, Metadata) {
+TEST(RouteConfigurationV2, RouteConfigGetters) {
   std::string yaml = R"EOF(
 name: foo
 virtual_hosts:
@@ -3778,6 +3778,8 @@ virtual_hosts:
 
   EXPECT_EQ("test_value",
             Envoy::Config::Metadata::metadataValue(metadata, "com.bar.foo", "baz").string_value());
+  EXPECT_EQ("bar", route_entry->virtualHost().name());
+  EXPECT_EQ("foo", route_entry->virtualHost().routeConfig().name());
 }
 
 } // namespace

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -161,6 +161,7 @@ public:
   MOCK_CONST_METHOD0(name, const std::string&());
   MOCK_CONST_METHOD0(rateLimitPolicy, const RateLimitPolicy&());
   MOCK_CONST_METHOD0(corsPolicy, const CorsPolicy*());
+  MOCK_CONST_METHOD0(routeConfig, const Config&());
 
   std::string name_{"fake_vhost"};
   testing::NiceMock<MockRateLimitPolicy> rate_limit_policy_;
@@ -263,6 +264,7 @@ public:
   // Router::Config
   MOCK_CONST_METHOD2(route, RouteConstSharedPtr(const Http::HeaderMap&, uint64_t random_value));
   MOCK_CONST_METHOD0(internalOnlyHeaders, const std::list<Http::LowerCaseString>&());
+  MOCK_CONST_METHOD0(name, const std::string&());
 
   std::shared_ptr<MockRoute> route_;
   std::list<Http::LowerCaseString> internal_only_headers_;


### PR DESCRIPTION
*Description*: To access the route configuration through `RequestInfo`, we needed to store the name in `Router::ConfigImpl`, expose it in the interface, and create an accessor method in the `VirtualHost` interface.

A few things to consider here:
1.  I called one of the accessor methods `routeConfiguration()`, which is difficult to distinguish from the configurations of the individual routes.  I'm open to suggestions for making this clearer.
2.  There is already a method on `VirtualHostImpl` to access `ConfigImpl`.  We could technically promote this to the interface, return a `Config`, and promote any methods that are used on return of `ConfigImpl` to the `Config` interface.  I'm open to moving in that direction, just wanted to hear what folks thought about that.  
3.  This is more of a general question: I'm not sure how universal this need is, but we have found ourselves wanting to pull various names and attributes from the config from within access log implementations.  We are slowly poking more and more holes into the various Envoy objects to get at this information.  Is there interest in refactoring to make all of the config elements that match a particular request available rather than making it available in an ad-hoc way through existing objects?  I should note that our requirements are nearly satisfied in this regard (I'm planning one more PR, and that should be it), so this is more a question of whether we see this as a broadly useful access pattern that warrants a more formal config API.  cc @htuch 

*Risk Level*: Low

*Testing*: Added unit tests for the accessor methods.
