### PR TITLE
upstream: fix bug in load stats reporting when local locality is miss…

### DIFF
--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -109,21 +109,29 @@ void EdsClusterImpl::updateHostsPerLocality(HostSet& host_set, HostVector& new_h
     const Locality local_locality(local_info_.node().locality());
     ENVOY_LOG(trace, "Local locality: {}", local_info_.node().locality().DebugString());
 
+    // We use std::map to guarantee a stable ordering for zone aware routing.
     std::map<Locality, HostVector> hosts_per_locality;
 
     for (const HostSharedPtr& host : *current_hosts_copy) {
       hosts_per_locality[Locality(host->locality())].push_back(host);
     }
 
-    const bool local = !local_locality.empty() &&
-                       hosts_per_locality.find(local_locality) != hosts_per_locality.end();
+    // Do we have hosts for the local locality?
+    const bool non_empty_local_locality =
+        !local_locality.empty() &&
+        hosts_per_locality.find(local_locality) != hosts_per_locality.end();
 
-    if (local) {
+    // As per HostsPerLocality::get(), the per_locality vector must have the
+    // local locality hosts first if non_empty_local_locality.
+    if (non_empty_local_locality) {
       per_locality.push_back(hosts_per_locality[local_locality]);
     }
 
+    // After the local locality hosts (if any), we place the remaining locality
+    // host groups in lexicographic order. This provides a stable ordering for
+    // zone aware routing.
     for (auto& entry : hosts_per_locality) {
-      if (!local || local_locality != entry.first) {
+      if (!non_empty_local_locality || local_locality != entry.first) {
         per_locality.push_back(entry.second);
       }
     }

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -108,27 +108,28 @@ void EdsClusterImpl::updateHostsPerLocality(HostSet& host_set, HostVector& new_h
     // If local locality is not defined then skip populating per locality hosts.
     const Locality local_locality(local_info_.node().locality());
     ENVOY_LOG(trace, "Local locality: {}", local_info_.node().locality().DebugString());
-    if (!local_locality.empty()) {
-      std::map<Locality, HostVector> hosts_per_locality;
 
-      for (const HostSharedPtr& host : *current_hosts_copy) {
-        hosts_per_locality[Locality(host->locality())].push_back(host);
-      }
+    std::map<Locality, HostVector> hosts_per_locality;
 
-      // Populate per_locality hosts only if upstream cluster has hosts in the same locality.
-      if (hosts_per_locality.find(local_locality) != hosts_per_locality.end()) {
-        per_locality.push_back(hosts_per_locality[local_locality]);
+    for (const HostSharedPtr& host : *current_hosts_copy) {
+      hosts_per_locality[Locality(host->locality())].push_back(host);
+    }
 
-        for (auto& entry : hosts_per_locality) {
-          if (local_locality != entry.first) {
-            per_locality.push_back(entry.second);
-          }
-        }
+    const bool local = !local_locality.empty() &&
+                       hosts_per_locality.find(local_locality) != hosts_per_locality.end();
+
+    if (local) {
+      per_locality.push_back(hosts_per_locality[local_locality]);
+    }
+
+    for (auto& entry : hosts_per_locality) {
+      if (!local || local_locality != entry.first) {
+        per_locality.push_back(entry.second);
       }
     }
 
     auto per_locality_shared =
-        std::make_shared<HostsPerLocalityImpl>(std::move(per_locality), !per_locality.empty());
+        std::make_shared<HostsPerLocalityImpl>(std::move(per_locality), local);
 
     host_set.updateHosts(current_hosts_copy, createHealthyHostList(*current_hosts_copy),
                          per_locality_shared, createHealthyHostLists(*per_locality_shared),

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -137,7 +137,7 @@ void EdsClusterImpl::updateHostsPerLocality(HostSet& host_set, HostVector& new_h
     }
 
     auto per_locality_shared =
-        std::make_shared<HostsPerLocalityImpl>(std::move(per_locality), local);
+        std::make_shared<HostsPerLocalityImpl>(std::move(per_locality), non_empty_local_locality);
 
     host_set.updateHosts(current_hosts_copy, createHealthyHostList(*current_hosts_copy),
                          per_locality_shared, createHealthyHostLists(*per_locality_shared),

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -228,9 +228,13 @@ void ZoneAwareLoadBalancerBase::resizePerPriorityState() {
 bool ZoneAwareLoadBalancerBase::earlyExitNonLocalityRouting() {
   // We only do locality routing for P=0.
   HostSet& host_set = *priority_set_.hostSetsPerPriority()[0];
+  if (host_set.healthyHostsPerLocality().get().size() < 2) {
+    return true;
+  }
+
   if (!host_set.healthyHostsPerLocality().hasLocalLocality() ||
-      host_set.healthyHostsPerLocality().get().size() < 2 ||
       host_set.healthyHostsPerLocality().get()[0].empty()) {
+    stats_.lb_local_cluster_not_ok_.inc();
     return true;
   }
 

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -232,6 +232,8 @@ bool ZoneAwareLoadBalancerBase::earlyExitNonLocalityRouting() {
     return true;
   }
 
+  // lb_local_cluster_not_ok is bumped for "Local host set is not set or it is
+  // panic mode for local cluster".
   if (!host_set.healthyHostsPerLocality().hasLocalLocality() ||
       host_set.healthyHostsPerLocality().get()[0].empty()) {
     stats_.lb_local_cluster_not_ok_.inc();

--- a/source/common/upstream/load_stats_reporter.cc
+++ b/source/common/upstream/load_stats_reporter.cc
@@ -50,6 +50,7 @@ void LoadStatsReporter::sendLoadStatsRequest() {
     auto* cluster_stats = request_.add_cluster_stats();
     cluster_stats->set_cluster_name(cluster_name);
     for (auto& host_set : cluster.prioritySet().hostSetsPerPriority()) {
+      ENVOY_LOG(trace, "Load report locality count {}", host_set->hostsPerLocality().get().size());
       for (auto& hosts : host_set->hostsPerLocality().get()) {
         ASSERT(hosts.size() > 0);
         uint64_t rq_success = 0;

--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -90,8 +90,10 @@ inline HostDescriptionConstSharedPtr makeTestHostDescription(ClusterInfoConstSha
       envoy::api::v2::Locality().default_instance())};
 }
 
-inline HostsPerLocalitySharedPtr makeHostsPerLocality(std::vector<HostVector>&& locality_hosts) {
-  return std::make_shared<HostsPerLocalityImpl>(std::move(locality_hosts), !locality_hosts.empty());
+inline HostsPerLocalitySharedPtr makeHostsPerLocality(std::vector<HostVector>&& locality_hosts,
+                                                      bool force_no_local_locality = false) {
+  return std::make_shared<HostsPerLocalityImpl>(
+      std::move(locality_hosts), !force_no_local_locality && !locality_hosts.empty());
 }
 
 } // namespace

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -77,6 +77,7 @@ public:
     decoded_grpc_frames_.erase(decoded_grpc_frames_.begin());
   }
   template <class T> void waitForGrpcMessage(Event::Dispatcher& client_dispatcher, T& message) {
+    ENVOY_LOG(debug, "Waiting for gRPC message...");
     if (!decoded_grpc_frames_.empty()) {
       decodeGrpcFrame(message);
       return;
@@ -94,6 +95,7 @@ public:
       }
     }
     decodeGrpcFrame(message);
+    ENVOY_LOG(debug, "Received gRPC message: {}", message.DebugString());
   }
 
   // Http::StreamDecoder


### PR DESCRIPTION
…ing.

Previously, when an EDS assignment had no hosts in the local locality
for a cluster, load reports were not created, since we lost track of
hosts per locality.

In this patch, we now track hosts per locality regardless of the
presence of hosts in the local locality.

Another related change is that we also now bump the
lb_local_cluster_not_ok stat when bypassing zone aware routing due to no
hosts being present in the local locality.

Risk Level: Low
Tests: Additional load stats reporter and zone aware routing tests.

Signed-off-by: Harvey Tuch <htuch@google.com>