### PR TITLE
grpc access log: fix crash when downstream addresses not set

### DIFF
--- a/source/common/access_log/grpc_access_log_impl.cc
+++ b/source/common/access_log/grpc_access_log_impl.cc
@@ -150,12 +150,17 @@ void HttpGrpcAccessLog::log(const Http::HeaderMap* request_headers,
   // TODO(mattklein123): Populate time_to_first_downstream_tx_byte field.
   // TODO(mattklein123): Populate metadata field and wire up to filters.
   auto* common_properties = log_entry->mutable_common_properties();
-  Network::Utility::addressToProtobufAddress(
-      *request_info.downstreamRemoteAddress(),
-      *common_properties->mutable_downstream_remote_address());
-  Network::Utility::addressToProtobufAddress(
-      *request_info.downstreamLocalAddress(),
-      *common_properties->mutable_downstream_local_address());
+
+  if (request_info.downstreamRemoteAddress() != nullptr) {
+    Network::Utility::addressToProtobufAddress(
+        *request_info.downstreamRemoteAddress(),
+        *common_properties->mutable_downstream_remote_address());
+  }
+  if (request_info.downstreamLocalAddress() != nullptr) {
+    Network::Utility::addressToProtobufAddress(
+        *request_info.downstreamLocalAddress(),
+        *common_properties->mutable_downstream_local_address());
+  }
   common_properties->mutable_start_time()->MergeFrom(
       Protobuf::util::TimeUtil::MicrosecondsToTimestamp(
           std::chrono::duration_cast<std::chrono::microseconds>(

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -500,6 +500,9 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
     state_.saw_connection_close_ = true;
   }
 
+  // TODO(mattklein123): We should set downstream_local_address_ and downstream_remote_address_
+  // as early as possible in this function since there are various places where we can return and
+  // still log before we get here.
   request_info_.downstream_local_address_ =
       connection_manager_.read_callbacks_->connection().localAddress();
   request_info_.downstream_remote_address_ = ConnectionManagerUtility::mutateRequestHeaders(

--- a/test/common/access_log/grpc_access_log_impl_test.cc
+++ b/test/common/access_log/grpc_access_log_impl_test.cc
@@ -167,6 +167,30 @@ http_logs:
 
   {
     NiceMock<RequestInfo::MockRequestInfo> request_info;
+    request_info.host_ = nullptr;
+    request_info.start_time_ = SystemTime(1h);
+    request_info.duration_ = 2ms;
+    request_info.downstream_local_address_ = nullptr;
+    request_info.downstream_remote_address_ = nullptr;
+    request_info.protocol_ = Http::Protocol::Http2;
+    expectLog(R"EOF(
+http_logs:
+  log_entry:
+    common_properties:
+      start_time:
+        seconds: 3600
+      time_to_last_downstream_tx_byte:
+        nanos: 2000000
+    protocol_version: HTTP2
+    request: {}
+    response: {}
+
+)EOF");
+    access_log_->log(nullptr, nullptr, request_info);
+  }
+
+  {
+    NiceMock<RequestInfo::MockRequestInfo> request_info;
     request_info.start_time_ = SystemTime(1h);
     request_info.request_received_duration_ = 2ms;
     request_info.response_received_duration_ = 4ms;


### PR DESCRIPTION
*Risk Level*: Low 
*Testing*:  Unit
*Docs Changes*: N/A
*Release Notes*: N/A