### PR TITLE
test: fixing some potential test flakes

### DIFF
--- a/source/common/network/raw_buffer_socket.cc
+++ b/source/common/network/raw_buffer_socket.cc
@@ -57,7 +57,8 @@ IoResult RawBufferSocket::doWrite(Buffer::Instance& buffer) {
     int rc = buffer.write(callbacks_->fd());
     ENVOY_CONN_LOG(trace, "write returns: {}", callbacks_->connection(), rc);
     if (rc == -1) {
-      ENVOY_CONN_LOG(trace, "write error: {}", callbacks_->connection(), errno);
+      ENVOY_CONN_LOG(trace, "write error: {} ({})", callbacks_->connection(), errno,
+                     strerror(errno));
       if (errno == EAGAIN) {
         action = PostIoAction::KeepOpen;
       } else {

--- a/test/integration/grpc_json_transcoder_integration_test.cc
+++ b/test/integration/grpc_json_transcoder_integration_test.cc
@@ -282,7 +282,7 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, InvalidJson) {
   //    "INVALID_JSON\n"
   //    "^"
   // If Envoy does a short read of the upstream connection, it may only read part of the
-  // string "INVALID_JSON".  Envoy will note "Unexpected token [whatever substring is read]
+  // string "INVALID_JSON". Envoy will note "Unexpected token [whatever substring is read]
   testTranscoding<bookstore::CreateShelfRequest, bookstore::Shelf>(
       Http::TestHeaderMapImpl{{":method", "POST"}, {":path", "/shelf"}, {":authority", "host"}},
       R"(INVALID_JSON)", {}, {}, Status(),

--- a/test/integration/grpc_json_transcoder_integration_test.cc
+++ b/test/integration/grpc_json_transcoder_integration_test.cc
@@ -281,8 +281,8 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, InvalidJson) {
   // "Unexpected token.\n"
   //    "INVALID_JSON\n"
   //    "^"
-  // But if there's a short read from upstream the full "INVALID_JSON" string
-  // may not be read.
+  // If Envoy does a short read of the upstream connection, it may only read part of the
+  // string "INVALID_JSON".  Envoy will note "Unexpected token [whatever substring is read]
   testTranscoding<bookstore::CreateShelfRequest, bookstore::Shelf>(
       Http::TestHeaderMapImpl{{":method", "POST"}, {":path", "/shelf"}, {":authority", "host"}},
       R"(INVALID_JSON)", {}, {}, Status(),
@@ -301,7 +301,8 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, InvalidJson) {
   //    "Expected : between key:value pair.\n"
   //    "{ \"theme\"  \"Children\" }\n"
   //    "           ^");
-  // But as with INVALID_JSON the full response string may not be read.
+  // But as with INVALID_JSON Envoy may not read the full string from the upstream connection so may
+  // generate its error based on a partial upstream response.
   testTranscoding<bookstore::CreateShelfRequest, bookstore::Shelf>(
       Http::TestHeaderMapImpl{{":method", "POST"}, {":path", "/shelf"}, {":authority", "host"}},
       R"({ "theme"  "Children" })", {}, {}, Status(),

--- a/test/integration/grpc_json_transcoder_integration_test.cc
+++ b/test/integration/grpc_json_transcoder_integration_test.cc
@@ -55,7 +55,7 @@ protected:
                        const std::vector<std::string>& grpc_request_messages,
                        const std::vector<std::string>& grpc_response_messages,
                        const Status& grpc_status, Http::HeaderMap&& response_headers,
-                       const std::string& response_body) {
+                       const std::string& response_body, bool full_response = true) {
     response_.reset(new IntegrationStreamDecoder(*dispatcher_));
 
     codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -126,7 +126,11 @@ protected:
         },
         response_.get());
     if (!response_body.empty()) {
-      EXPECT_EQ(response_body, response_->body());
+      if (full_response) {
+        EXPECT_EQ(response_body, response_->body());
+      } else {
+        EXPECT_TRUE(StringUtil::startsWith(response_->body().c_str(), response_body));
+      }
     }
 
     codec_client_->close();
@@ -273,13 +277,17 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, StreamingPost) {
 }
 
 TEST_P(GrpcJsonTranscoderIntegrationTest, InvalidJson) {
+  // Usually the response would be
+  // "Unexpected token.\n"
+  //    "INVALID_JSON\n"
+  //    "^"
+  // But if there's a short read from upstream the full "INVALID_JSON" string
+  // may not be read.
   testTranscoding<bookstore::CreateShelfRequest, bookstore::Shelf>(
       Http::TestHeaderMapImpl{{":method", "POST"}, {":path", "/shelf"}, {":authority", "host"}},
       R"(INVALID_JSON)", {}, {}, Status(),
       Http::TestHeaderMapImpl{{":status", "400"}, {"content-type", "text/plain"}},
-      "Unexpected token.\n"
-      "INVALID_JSON\n"
-      "^");
+      "Unexpected token.\nI", false);
 
   testTranscoding<bookstore::CreateShelfRequest, bookstore::Shelf>(
       Http::TestHeaderMapImpl{{":method", "POST"}, {":path", "/shelf"}, {":authority", "host"}},
@@ -289,13 +297,16 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, InvalidJson) {
       "\n"
       "^");
 
+  // Usually the response would be
+  //    "Expected : between key:value pair.\n"
+  //    "{ \"theme\"  \"Children\" }\n"
+  //    "           ^");
+  // But as with INVALID_JSON the full response string may not be read.
   testTranscoding<bookstore::CreateShelfRequest, bookstore::Shelf>(
       Http::TestHeaderMapImpl{{":method", "POST"}, {":path", "/shelf"}, {":authority", "host"}},
       R"({ "theme"  "Children" })", {}, {}, Status(),
       Http::TestHeaderMapImpl{{":status", "400"}, {"content-type", "text/plain"}},
-      "Expected : between key:value pair.\n"
-      "{ \"theme\"  \"Children\" }\n"
-      "           ^");
+      "Expected : between key:value pair.\n", false);
 }
 
 } // namespace Envoy

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -236,7 +236,7 @@ void HttpIntegrationTest::testRouterRequestAndResponseWithBody(
   EXPECT_TRUE(upstream_request_->complete());
   EXPECT_EQ(request_size, upstream_request_->bodyLength());
 
-  EXPECT_TRUE(response_->complete());
+  ASSERT_TRUE(response_->complete());
   EXPECT_STREQ("200", response_->headers().Status()->value().c_str());
   EXPECT_EQ(response_size, response_->body().size());
 }
@@ -278,7 +278,7 @@ void HttpIntegrationTest::testRouterNotFound() {
 
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
       lookupPort("http"), "GET", "/notfound", "", downstream_protocol_, version_);
-  EXPECT_TRUE(response->complete());
+  ASSERT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 }
 
@@ -289,7 +289,7 @@ void HttpIntegrationTest::testRouterNotFoundWithBody() {
 
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
       lookupPort("http"), "POST", "/notfound", "foo", downstream_protocol_, version_);
-  EXPECT_TRUE(response->complete());
+  ASSERT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 }
 
@@ -302,7 +302,7 @@ void HttpIntegrationTest::testRouterClusterNotFound404() {
 
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
       lookupPort("http"), "GET", "/unknown", "", downstream_protocol_, version_, "foo.com");
-  EXPECT_TRUE(response->complete());
+  ASSERT_TRUE(response->complete());
   EXPECT_STREQ("404", response->headers().Status()->value().c_str());
 }
 
@@ -315,7 +315,7 @@ void HttpIntegrationTest::testRouterClusterNotFound503() {
 
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
       lookupPort("http"), "GET", "/unknown", "", downstream_protocol_, version_, "foo.com");
-  EXPECT_TRUE(response->complete());
+  ASSERT_TRUE(response->complete());
   EXPECT_STREQ("503", response->headers().Status()->value().c_str());
 }
 
@@ -328,7 +328,7 @@ void HttpIntegrationTest::testRouterRedirect() {
 
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
       lookupPort("http"), "GET", "/foo", "", downstream_protocol_, version_, "www.redirect.com");
-  EXPECT_TRUE(response->complete());
+  ASSERT_TRUE(response->complete());
   EXPECT_STREQ("301", response->headers().Status()->value().c_str());
   EXPECT_STREQ("https://www.redirect.com/foo",
                response->headers().get(Http::Headers::get().Location)->value().c_str());
@@ -365,7 +365,7 @@ void HttpIntegrationTest::testRouterDirectResponse() {
 
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
       lookupPort("http"), "GET", "/", "", downstream_protocol_, version_, "direct.example.com");
-  EXPECT_TRUE(response->complete());
+  ASSERT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   EXPECT_STREQ("example-value", response->headers()
                                     .get(Envoy::Http::LowerCaseString("x-additional-header"))
@@ -706,7 +706,7 @@ void HttpIntegrationTest::testHittingDecoderFilterLimit() {
                                      1024 * 65, *response_);
 
   response_->waitForEndStream();
-  EXPECT_TRUE(response_->complete());
+  ASSERT_TRUE(response_->complete());
   EXPECT_STREQ("413", response_->headers().Status()->value().c_str());
 }
 
@@ -785,60 +785,45 @@ void HttpIntegrationTest::testTwoRequests() {
 void HttpIntegrationTest::testBadFirstline() {
   initialize();
   std::string response;
-  sendRawHttpAndWaitForResponse("hello", &response);
+  sendRawHttpAndWaitForResponse(lookupPort("http"), "hello", &response);
   EXPECT_EQ("HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\nconnection: close\r\n\r\n", response);
 }
 
 void HttpIntegrationTest::testMissingDelimiter() {
   initialize();
   std::string response;
-  sendRawHttpAndWaitForResponse("GET / HTTP/1.1\r\nHost: host\r\nfoo bar\r\n\r\n", &response);
+  sendRawHttpAndWaitForResponse(lookupPort("http"),
+                                "GET / HTTP/1.1\r\nHost: host\r\nfoo bar\r\n\r\n", &response);
   EXPECT_EQ("HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\nconnection: close\r\n\r\n", response);
 }
 
 void HttpIntegrationTest::testInvalidCharacterInFirstline() {
   initialize();
   std::string response;
-  sendRawHttpAndWaitForResponse("GE(T / HTTP/1.1\r\nHost: host\r\n\r\n", &response);
+  sendRawHttpAndWaitForResponse(lookupPort("http"), "GE(T / HTTP/1.1\r\nHost: host\r\n\r\n",
+                                &response);
   EXPECT_EQ("HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\nconnection: close\r\n\r\n", response);
 }
 
 void HttpIntegrationTest::testLowVersion() {
   initialize();
   std::string response;
-  sendRawHttpAndWaitForResponse("GET / HTTP/0.8\r\nHost: host\r\n\r\n", &response);
+  sendRawHttpAndWaitForResponse(lookupPort("http"), "GET / HTTP/0.8\r\nHost: host\r\n\r\n",
+                                &response);
   EXPECT_EQ("HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\nconnection: close\r\n\r\n", response);
 }
 
 void HttpIntegrationTest::testHttp10Request() {
   initialize();
-  Buffer::OwnedImpl buffer("GET / HTTP/1.0\r\n\r\n");
   std::string response;
-  RawConnectionDriver connection(
-      lookupPort("http"), buffer,
-      [&](Network::ClientConnection& client, const Buffer::Instance& data) -> void {
-        response.append(TestUtility::bufferToString(data));
-        client.close(Network::ConnectionCloseType::NoFlush);
-      },
-      version_);
-
-  connection.run();
+  sendRawHttpAndWaitForResponse(lookupPort("http"), "GET / HTTP/1.0\r\n\r\n", &response, true);
   EXPECT_TRUE(response.find("HTTP/1.1 426 Upgrade Required\r\n") == 0);
 }
 
 void HttpIntegrationTest::testNoHost() {
   initialize();
-  Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n\r\n");
   std::string response;
-  RawConnectionDriver connection(
-      lookupPort("http"), buffer,
-      [&](Network::ClientConnection& client, const Buffer::Instance& data) -> void {
-        response.append(TestUtility::bufferToString(data));
-        client.close(Network::ConnectionCloseType::NoFlush);
-      },
-      version_);
-
-  connection.run();
+  sendRawHttpAndWaitForResponse(lookupPort("http"), "GET / HTTP/1.1\r\n\r\n", &response, true);
   EXPECT_TRUE(response.find("HTTP/1.1 400 Bad Request\r\n") == 0);
 }
 
@@ -851,17 +836,10 @@ void HttpIntegrationTest::testAbsolutePath() {
   config_helper_.addConfigModifier(&setAllowAbsoluteUrl);
 
   initialize();
-  Buffer::OwnedImpl buffer("GET http://www.redirect.com HTTP/1.1\r\nHost: host\r\n\r\n");
   std::string response;
-  RawConnectionDriver connection(
-      lookupPort("http"), buffer,
-      [&](Network::ClientConnection& client, const Buffer::Instance& data) -> void {
-        response.append(TestUtility::bufferToString(data));
-        client.close(Network::ConnectionCloseType::NoFlush);
-      },
-      version_);
-
-  connection.run();
+  sendRawHttpAndWaitForResponse(lookupPort("http"),
+                                "GET http://www.redirect.com HTTP/1.1\r\nHost: host\r\n\r\n",
+                                &response, true);
   EXPECT_FALSE(response.find("HTTP/1.1 404 Not Found\r\n") == 0);
 }
 
@@ -873,17 +851,10 @@ void HttpIntegrationTest::testAbsolutePathWithPort() {
                           envoy::api::v2::route::VirtualHost::ALL);
   config_helper_.addConfigModifier(&setAllowAbsoluteUrl);
   initialize();
-  Buffer::OwnedImpl buffer("GET http://www.namewithport.com:1234 HTTP/1.1\r\nHost: host\r\n\r\n");
   std::string response;
-  RawConnectionDriver connection(
-      lookupPort("http"), buffer,
-      [&](Network::ClientConnection& client, const Buffer::Instance& data) -> void {
-        response.append(TestUtility::bufferToString(data));
-        client.close(Network::ConnectionCloseType::NoFlush);
-      },
-      version_);
-
-  connection.run();
+  sendRawHttpAndWaitForResponse(
+      lookupPort("http"), "GET http://www.namewithport.com:1234 HTTP/1.1\r\nHost: host\r\n\r\n",
+      &response, true);
   EXPECT_FALSE(response.find("HTTP/1.1 404 Not Found\r\n") == 0);
 }
 
@@ -896,18 +867,11 @@ void HttpIntegrationTest::testAbsolutePathWithoutPort() {
                           envoy::api::v2::route::VirtualHost::ALL);
   config_helper_.addConfigModifier(&setAllowAbsoluteUrl);
   initialize();
-  Buffer::OwnedImpl buffer("GET http://www.namewithport.com HTTP/1.1\r\nHost: host\r\n\r\n");
   std::string response;
-  RawConnectionDriver connection(
-      lookupPort("http"), buffer,
-      [&](Network::ClientConnection& client, const Buffer::Instance& data) -> void {
-        response.append(TestUtility::bufferToString(data));
-        client.close(Network::ConnectionCloseType::NoFlush);
-      },
-      version_);
-
-  connection.run();
-  EXPECT_TRUE(response.find("HTTP/1.1 404 Not Found\r\n") == 0);
+  sendRawHttpAndWaitForResponse(lookupPort("http"),
+                                "GET http://www.namewithport.com HTTP/1.1\r\nHost: host\r\n\r\n",
+                                &response, true);
+  EXPECT_TRUE(response.find("HTTP/1.1 404 Not Found\r\n") == 0) << response;
 }
 
 void HttpIntegrationTest::testAllowAbsoluteSameRelative() {
@@ -933,51 +897,26 @@ void HttpIntegrationTest::testEquivalent(const std::string& request) {
   // Set the first listener to allow absoute URLs.
   config_helper_.addConfigModifier(&setAllowAbsoluteUrl);
   // Make sure both listeners can be reached.
-  // TODO(alyssar) in a follow-up, instead have these named ports pulled automatically from the
+  // TODO(alyssawilk) in a follow-up, instead have these named ports pulled automatically from the
   // listener names.
   named_ports_ = {"http_forward", "http"};
   initialize();
 
-  Buffer::OwnedImpl buffer1(request);
   std::string response1;
-  RawConnectionDriver connection1(
-      lookupPort("http"), buffer1,
-      [&](Network::ClientConnection& client, const Buffer::Instance& data) -> void {
-        response1.append(TestUtility::bufferToString(data));
-        client.close(Network::ConnectionCloseType::NoFlush);
-      },
-      version_);
+  sendRawHttpAndWaitForResponse(lookupPort("http"), request.c_str(), &response1, true);
 
-  connection1.run();
-
-  Buffer::OwnedImpl buffer2(request);
   std::string response2;
-  RawConnectionDriver connection2(
-      lookupPort("http_forward"), buffer2,
-      [&](Network::ClientConnection& client, const Buffer::Instance& data) -> void {
-        response2.append(TestUtility::bufferToString(data));
-        client.close(Network::ConnectionCloseType::NoFlush);
-      },
-      version_);
-
-  connection2.run();
+  sendRawHttpAndWaitForResponse(lookupPort("http_forward"), request.c_str(), &response2, true);
 
   EXPECT_EQ(normalizeDate(response1), normalizeDate(response2));
 }
 
 void HttpIntegrationTest::testBadPath() {
   initialize();
-  Buffer::OwnedImpl buffer("GET http://api.lyft.com HTTP/1.1\r\nHost: host\r\n\r\n");
   std::string response;
-  RawConnectionDriver connection(
-      lookupPort("http"), buffer,
-      [&](Network::ClientConnection& client, const Buffer::Instance& data) -> void {
-        response.append(TestUtility::bufferToString(data));
-        client.close(Network::ConnectionCloseType::NoFlush);
-      },
-      version_);
-
-  connection.run();
+  sendRawHttpAndWaitForResponse(lookupPort("http"),
+                                "GET http://api.lyft.com HTTP/1.1\r\nHost: host\r\n\r\n", &response,
+                                true);
   EXPECT_TRUE(response.find("HTTP/1.1 404 Not Found\r\n") == 0);
 }
 

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -310,13 +310,17 @@ void BaseIntegrationTest::createTestServer(const std::string& json_path,
   registerTestServerPorts(port_names);
 }
 
-void BaseIntegrationTest::sendRawHttpAndWaitForResponse(const char* raw_http,
-                                                        std::string* response) {
+void BaseIntegrationTest::sendRawHttpAndWaitForResponse(int port, const char* raw_http,
+                                                        std::string* response,
+                                                        bool disconnect_after_headers_complete) {
   Buffer::OwnedImpl buffer(raw_http);
   RawConnectionDriver connection(
-      lookupPort("http"), buffer,
-      [&](Network::ClientConnection&, const Buffer::Instance& data) -> void {
+      port, buffer,
+      [&](Network::ClientConnection& client, const Buffer::Instance& data) -> void {
         response->append(TestUtility::bufferToString(data));
+        if (disconnect_after_headers_complete && response->find("\r\n\r\n") != std::string::npos) {
+          client.close(Network::ConnectionCloseType::NoFlush);
+        }
       },
       version_);
 

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -146,7 +146,19 @@ public:
   Api::ApiPtr api_;
   MockBufferFactory* mock_buffer_factory_; // Will point to the dispatcher's factory.
   Event::DispatcherPtr dispatcher_;
-  void sendRawHttpAndWaitForResponse(const char* http, std::string* response);
+
+  /* Open a connection to Envoy, send a series of bytes, and return the
+   * response. This function will continue reading response bytes until Envoy
+   * closes the connection (as a part of error handling) or (if configured true)
+   * the complete headers are read.
+   *
+   * @param port the port to connect to.
+   * @param raw_http the data to send.
+   * @param response the response data will be sent here
+   * @param if the connection should be terminated onece '\r\n\r\n' has been read.
+   * */
+  void sendRawHttpAndWaitForResponse(int port, const char* raw_http, std::string* response,
+                                     bool disconnect_after_headers_complete = false);
 
 protected:
   bool initialized() const { return initialized_; }

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -147,7 +147,8 @@ public:
   MockBufferFactory* mock_buffer_factory_; // Will point to the dispatcher's factory.
   Event::DispatcherPtr dispatcher_;
 
-  /* Open a connection to Envoy, send a series of bytes, and return the
+  /**
+   * Open a connection to Envoy, send a series of bytes, and return the
    * response. This function will continue reading response bytes until Envoy
    * closes the connection (as a part of error handling) or (if configured true)
    * the complete headers are read.
@@ -156,7 +157,7 @@ public:
    * @param raw_http the data to send.
    * @param response the response data will be sent here
    * @param if the connection should be terminated onece '\r\n\r\n' has been read.
-   * */
+   **/
   void sendRawHttpAndWaitForResponse(int port, const char* raw_http, std::string* response,
                                      bool disconnect_after_headers_complete = false);
 

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -242,10 +242,10 @@ public:
     upstream_request_->encodeData(response_size_, true);
     response_->waitForEndStream();
 
-    EXPECT_TRUE(upstream_request_->complete());
+    ASSERT_TRUE(upstream_request_->complete());
     EXPECT_EQ(request_size_, upstream_request_->bodyLength());
 
-    EXPECT_TRUE(response_->complete());
+    ASSERT_TRUE(response_->complete());
     EXPECT_STREQ(std::to_string(response_code).c_str(),
                  response_->headers().Status()->value().c_str());
     EXPECT_EQ(response_size_, response_->body().size());
@@ -472,7 +472,7 @@ TEST_P(LoadStatsIntegrationTest, Dropped) {
   // This should count as dropped, since we trigger circuit breaking.
   initiateClientConnection();
   response_->waitForEndStream();
-  EXPECT_TRUE(response_->complete());
+  ASSERT_TRUE(response_->complete());
   EXPECT_STREQ("503", response_->headers().Status()->value().c_str());
   cleanupUpstreamConnection();
 


### PR DESCRIPTION
Fixing a bunch of test flakes triggered by short writes.
Sadly these weren't the flakes I was looking for.    

Also changing a bunch of timeouts from segfaults (response not complete) to assert-fails (other tests run) and updating a TODO to the right Alyssa variant.

*Risk Level*: Low  (I did tweak an Envoy log to enhance debug logging.  )
*Testing*: almost test-only PR
*Docs Changes*: n/a
*Release Notes*: n/a (the log is not user impacting)

