### PR TITLE
test: automatically registering integration ports from listener names

### DIFF
--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -299,7 +299,7 @@ void ConfigHelper::addSslConfig() {
       TestEnvironment::runfilesPath("/test/config/integration/certs/serverkey.pem"));
 }
 
-void ConfigHelper::renameListener(const char* name) {
+void ConfigHelper::renameListener(const std::string& name) {
   auto* static_resources = bootstrap_.mutable_static_resources();
   if (static_resources->listeners_size() > 0) {
     static_resources->mutable_listeners(0)->set_name(name);

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -299,6 +299,13 @@ void ConfigHelper::addSslConfig() {
       TestEnvironment::runfilesPath("/test/config/integration/certs/serverkey.pem"));
 }
 
+void ConfigHelper::renameListener(const char* name) {
+  auto* static_resources = bootstrap_.mutable_static_resources();
+  if (static_resources->listeners_size() > 0) {
+    static_resources->mutable_listeners(0)->set_name(name);
+  }
+}
+
 envoy::api::v2::listener::Filter* ConfigHelper::getFilterFromListener() {
   RELEASE_ASSERT(!finalized_);
   if (bootstrap_.mutable_static_resources()->listeners_size() == 0) {

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -84,7 +84,7 @@ public:
   void addSslConfig();
 
   // Renames the first listener to the name specified.
-  void renameListener(const char* name);
+  void renameListener(const std::string& name);
 
   // Allows callers to do their own modification to |bootstrap_| which will be
   // applied just before ports are modified in finalize().

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -83,6 +83,9 @@ public:
   // Add the default SSL configuration.
   void addSslConfig();
 
+  // Renames the first listener to the name specified.
+  void renameListener(const char* name);
+
   // Allows callers to do their own modification to |bootstrap_| which will be
   // applied just before ports are modified in finalize().
   void addConfigModifier(ConfigModifierFunction function);

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -30,10 +30,7 @@ public:
   /**
    * Initializer for an individual test.
    */
-  void SetUp() override {
-    named_ports_ = {{"echo"}};
-    BaseIntegrationTest::initialize();
-  }
+  void SetUp() override { BaseIntegrationTest::initialize(); }
 
   /**
    *  Destructor for an individual test.
@@ -51,7 +48,7 @@ TEST_P(EchoIntegrationTest, Hello) {
   Buffer::OwnedImpl buffer("hello");
   std::string response;
   RawConnectionDriver connection(
-      lookupPort("echo"), buffer,
+      lookupPort("listener_0"), buffer,
       [&](Network::ClientConnection&, const Buffer::Instance& data) -> void {
         response.append(TestUtility::bufferToString(data));
         connection.close();

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -160,7 +160,13 @@ HttpIntegrationTest::HttpIntegrationTest(Http::CodecClient::Type downstream_prot
                                          Network::Address::IpVersion version,
                                          const std::string& config)
     : BaseIntegrationTest(version, config), downstream_protocol_(downstream_protocol) {
-  named_ports_ = {{"http"}};
+  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v2::Bootstrap& bootstrap) -> void {
+    auto static_resources = bootstrap.mutable_static_resources();
+    // Legacy integration tests expect the default listener to be named "http" for lookupPort calls.
+    if (static_resources->listeners_size() > 0) {
+      static_resources->mutable_listeners(0)->set_name("http");
+    }
+  });
   config_helper_.setClientCodec(typeToCodecType(downstream_protocol_));
 }
 
@@ -928,14 +934,10 @@ void HttpIntegrationTest::testEquivalent(const std::string& request) {
     auto* old_listener = static_resources->mutable_listeners(0);
     auto* cloned_listener = static_resources->add_listeners();
     cloned_listener->CopyFrom(*old_listener);
-    cloned_listener->set_name("listener2");
+    old_listener->set_name("http_forward");
   });
   // Set the first listener to allow absoute URLs.
   config_helper_.addConfigModifier(&setAllowAbsoluteUrl);
-  // Make sure both listeners can be reached.
-  // TODO(alyssar) in a follow-up, instead have these named ports pulled automatically from the
-  // listener names.
-  named_ports_ = {"http_forward", "http"};
   initialize();
 
   Buffer::OwnedImpl buffer1(request);

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -160,13 +160,8 @@ HttpIntegrationTest::HttpIntegrationTest(Http::CodecClient::Type downstream_prot
                                          Network::Address::IpVersion version,
                                          const std::string& config)
     : BaseIntegrationTest(version, config), downstream_protocol_(downstream_protocol) {
-  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v2::Bootstrap& bootstrap) -> void {
-    auto static_resources = bootstrap.mutable_static_resources();
-    // Legacy integration tests expect the default listener to be named "http" for lookupPort calls.
-    if (static_resources->listeners_size() > 0) {
-      static_resources->mutable_listeners(0)->set_name("http");
-    }
-  });
+  // Legacy integration tests expect the default listener to be named "http" for lookupPort calls.
+  config_helper_.renameListener("http");
   config_helper_.setClientCodec(typeToCodecType(downstream_protocol_));
 }
 

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -232,7 +232,7 @@ void BaseIntegrationTest::createEnvoy() {
       "bootstrap.json", MessageUtil::getJsonStringFromMessage(config_helper_.bootstrap()));
 
   std::vector<std::string> named_ports;
-  const auto static_resources = config_helper_.bootstrap().static_resources();
+  const auto& static_resources = config_helper_.bootstrap().static_resources();
   for (int i = 0; i < static_resources.listeners_size(); ++i) {
     named_ports.push_back(static_resources.listeners(i).name());
   }

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -230,7 +230,13 @@ void BaseIntegrationTest::createEnvoy() {
 
   const std::string bootstrap_path = TestEnvironment::writeStringToFileForTest(
       "bootstrap.json", MessageUtil::getJsonStringFromMessage(config_helper_.bootstrap()));
-  createGeneratedApiTestServer(bootstrap_path, named_ports_);
+
+  std::vector<std::string> named_ports;
+  auto static_resources = config_helper_.bootstrap().static_resources();
+  for (int i = 0; i < static_resources.listeners_size(); ++i) {
+    named_ports.push_back(static_resources.listeners(i).name());
+  }
+  createGeneratedApiTestServer(bootstrap_path, named_ports);
 }
 
 void BaseIntegrationTest::setUpstreamProtocol(FakeHttpConnection::Type protocol) {

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -232,7 +232,7 @@ void BaseIntegrationTest::createEnvoy() {
       "bootstrap.json", MessageUtil::getJsonStringFromMessage(config_helper_.bootstrap()));
 
   std::vector<std::string> named_ports;
-  auto static_resources = config_helper_.bootstrap().static_resources();
+  const auto static_resources = config_helper_.bootstrap().static_resources();
   for (int i = 0; i < static_resources.listeners_size(); ++i) {
     named_ports.push_back(static_resources.listeners(i).name());
   }

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -161,10 +161,10 @@ protected:
   std::vector<std::unique_ptr<FakeUpstream>> fake_upstreams_;
   spdlog::level::level_enum default_log_level_;
   IntegrationTestServerPtr test_server_;
+  // A map of keys to port names. Generally the names are pulled from the v2 listener name
+  // but if a listener is created via ADS, it will be from whatever key is used with registerPort.
   TestEnvironment::PortMap port_map_;
 
-  // The named ports for createGeneratedApiTestServer. Used mostly for lookupPort.
-  std::vector<std::string> named_ports_{{"default_port"}};
   // If true, use AutonomousUpstream for fake upstreams.
   bool autonomous_upstream_{false};
 

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -129,7 +129,6 @@ public:
       auto* eds_cluster_config = cluster_0->mutable_eds_cluster_config();
       eds_cluster_config->mutable_eds_config()->set_path(eds_path_);
     });
-    named_ports_ = {"http"};
     HttpIntegrationTest::initialize();
     for (uint32_t i = 0; i < upstream_endpoints_; ++i) {
       fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -23,6 +23,14 @@ namespace {
 INSTANTIATE_TEST_CASE_P(IpVersions, TcpProxyIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
+void TcpProxyIntegrationTest::initialize() {
+  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v2::Bootstrap& bootstrap) -> void {
+    auto static_resources = bootstrap.mutable_static_resources();
+    static_resources->mutable_listeners(0)->set_name("tcp_proxy");
+  });
+  BaseIntegrationTest::initialize();
+}
+
 // Test upstream writing before downstream downstream does.
 TEST_P(TcpProxyIntegrationTest, TcpProxyUpstreamWritesFirst) {
   initialize();

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -24,10 +24,7 @@ INSTANTIATE_TEST_CASE_P(IpVersions, TcpProxyIntegrationTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 void TcpProxyIntegrationTest::initialize() {
-  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v2::Bootstrap& bootstrap) -> void {
-    auto static_resources = bootstrap.mutable_static_resources();
-    static_resources->mutable_listeners(0)->set_name("tcp_proxy");
-  });
+  config_helper_.renameListener("tcp_proxy");
   BaseIntegrationTest::initialize();
 }
 

--- a/test/integration/tcp_proxy_integration_test.h
+++ b/test/integration/tcp_proxy_integration_test.h
@@ -14,10 +14,7 @@ class TcpProxyIntegrationTest : public BaseIntegrationTest,
 public:
   TcpProxyIntegrationTest() : BaseIntegrationTest(GetParam(), ConfigHelper::TCP_PROXY_CONFIG) {}
 
-  void initialize() override {
-    named_ports_ = {{"tcp_proxy"}};
-    BaseIntegrationTest::initialize();
-  }
+  void initialize() override;
 
   void TearDown() override {
     test_server_.reset();


### PR DESCRIPTION
*Risk Level*: Low (test only)
*Testing*: integration tests still pass
*Docs Changes*: n/a
*Release Notes*: n/a

