### PR TITLE
Upgrade to yaml-cpp to 0.6.1.

### DIFF
--- a/ci/build_container/build_recipes/yaml-cpp.sh
+++ b/ci/build_container/build_recipes/yaml-cpp.sh
@@ -2,13 +2,11 @@
 
 set -e
 
-# Using a pinned commit rather than release version to avoid taking the Boost
-# dependency present in last release.
-COMMIT=e2818c423e5058a02f46ce2e519a82742a8ccac9  # 2017-07-25
+VERSION=0.6.1
 
-git clone https://github.com/jbeder/yaml-cpp
-cd yaml-cpp
-git reset --hard "$COMMIT"
+wget -O yaml-cpp-"$VERSION".tar.gz https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-"$VERSION".tar.gz
+tar xf yaml-cpp-"$VERSION".tar.gz
+cd yaml-cpp-yaml-cpp-"$VERSION"
 cmake -DCMAKE_INSTALL_PREFIX:PATH="$THIRDPARTY_BUILD" \
   -DCMAKE_CXX_FLAGS:STRING="${CXXFLAGS} ${CPPFLAGS}" \
   -DCMAKE_C_FLAGS:STRING="${CFLAGS} ${CPPFLAGS}" \


### PR DESCRIPTION
Signed-off-by: Michael Payne <michael@sooper.org>

*dependency*: Upgrade to yaml-cpp to 0.6.1.

*Description*: minor release [update](https://github.com/jbeder/yaml-cpp/releases/tag/yaml-cpp-0.6.1) to yaml-cpp which removes dependency on Boost and requires C++ 11. We can now use a standard release and remove pulling specific commit.

*Risk Level*: Low

*Testing*: `bazel test //test/...` and running on local instances for 1+ weeks.
