### PR TITLE
server: functional backtraces for OS X

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -4,7 +4,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/abseil/abseil-cpp",
     ),
     com_github_bombela_backward = dict(
-        commit = "cd1c4bd9e48afe812a0e996d335298c455afcd92",  # v1.3
+        commit = "44ae9609e860e3428cd057f7052e505b4819eb84",  # osx support
         remote = "https://github.com/bombela/backward-cpp",
     ),
     com_github_cyan4973_xxhash = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -4,7 +4,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/abseil/abseil-cpp",
     ),
     com_github_bombela_backward = dict(
-        commit = "44ae9609e860e3428cd057f7052e505b4819eb84",  # osx support
+        commit = "44ae9609e860e3428cd057f7052e505b4819eb84",  # 2018-02-06
         remote = "https://github.com/bombela/backward-cpp",
     ),
     com_github_cyan4973_xxhash = dict(


### PR DESCRIPTION
*Description*:
bombela/backward-cpp now has some support for backtraces on OS X. Bump backward-cpp to a revision that contains the change. Modify stack trace output on OS X since addr2line (via homebrew's binutils package) doesn't seem to be able to resolve addresses from the stack trace (or lldb for that matter). Instead, print as much information as possible directly in the stack trace (which is equivalent to lldb's output given bazelbuild/bazel#2537).

*Risk Level*: Low 

*Testing*:
Manually tested stack traces by forcing division by zero.

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
