### PR TITLE
support multiple trusted proxies when processing XFF

### DIFF
--- a/RAW_RELEASE_NOTES.md
+++ b/RAW_RELEASE_NOTES.md
@@ -58,3 +58,4 @@ final version.
 * Added the ability to pass a URL encoded Pem encoded peer certificate in the x-forwarded-client-cert header.
 * Added support for abstract unix domain sockets on linux. The abstract
   namespace can be used by prepending '@' to a socket path.
+* Added support for trusting additional hops in the X-Forwarded-For request header.

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -71,7 +71,7 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
     ),
     envoy_api = dict(
-        commit = "4e533f22baced334c4aba68fb60c5fc439f0fe9c",
+        commit = "a0b91dc1a099a14c0da242217bd5ad99c0e1fb6d",
         remote = "https://github.com/envoyproxy/data-plane-api",
     ),
     grpc_httpjson_transcoding = dict(

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -245,6 +245,12 @@ public:
   virtual bool useRemoteAddress() PURE;
 
   /**
+   * @return uint32_t the number of trusted proxy hops in front of this Envoy instance, for
+   *         the purposes of XFF processing.
+   */
+  virtual uint32_t xffNumTrustedHops() const PURE;
+
+  /**
    * @return ForwardClientCertType the configuration of how to forward the client cert information.
    */
   virtual ForwardClientCertType forwardClientCert() PURE;

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -50,17 +50,15 @@ Network::Address::InstanceConstSharedPtr ConnectionManagerUtility::mutateRequest
   // our peer to have already properly set XFF, etc.
   Network::Address::InstanceConstSharedPtr final_remote_address;
   bool single_xff_address;
-  auto xff_num_trusted_hops = config.xffNumTrustedHops();
+  uint32_t xff_num_trusted_hops = config.xffNumTrustedHops();
   if (config.useRemoteAddress()) {
     single_xff_address = request_headers.ForwardedFor() == nullptr;
     // If there are any trusted proxies in front of this Envoy instance (as indicated by
     // the xff_num_trusted_hops configuration option), get the trusted client address
-    // from the XFF.
+    // from the XFF before we append to XFF.
     if (xff_num_trusted_hops > 0) {
-      auto ret = Utility::getLastAddressFromXFF(request_headers, xff_num_trusted_hops - 1);
-      if (ret.address_ != nullptr) {
-        final_remote_address = ret.address_;
-      }
+      final_remote_address =
+          Utility::getLastAddressFromXFF(request_headers, xff_num_trusted_hops - 1).address_;
     }
     // If there aren't any trusted proxies in front of this Envoy instance, or there
     // are but they didn't populate XFF properly, the trusted client address is the

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -50,7 +50,7 @@ Network::Address::InstanceConstSharedPtr ConnectionManagerUtility::mutateRequest
   // our peer to have already properly set XFF, etc.
   Network::Address::InstanceConstSharedPtr final_remote_address;
   bool single_xff_address;
-  uint32_t xff_num_trusted_hops = config.xffNumTrustedHops();
+  const uint32_t xff_num_trusted_hops = config.xffNumTrustedHops();
   if (config.useRemoteAddress()) {
     single_xff_address = request_headers.ForwardedFor() == nullptr;
     // If there are any trusted proxies in front of this Envoy instance (as indicated by

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -155,9 +155,9 @@ Network::Address::InstanceConstSharedPtr ConnectionManagerUtility::mutateRequest
 
   // If we are an external request, AND we are "using remote address" (see above), we set
   // x-envoy-external-address since this is our first ingress point into the trusted network.
-  if (edge_request && connection.remoteAddress()->type() == Network::Address::Type::Ip) {
+  if (edge_request && final_remote_address->type() == Network::Address::Type::Ip) {
     request_headers.insertEnvoyExternalAddress().value(
-        connection.remoteAddress()->ip()->addressAsString());
+        final_remote_address->ip()->addressAsString());
   }
 
   // Generate x-request-id for all edge requests, or if there is none.

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -143,7 +143,8 @@ public:
    * @return GetLastAddressFromXffInfo information about the last address in the XFF header.
    *         @see GetLastAddressFromXffInfo for more information.
    */
-  static GetLastAddressFromXffInfo getLastAddressFromXFF(const Http::HeaderMap& request_headers);
+  static GetLastAddressFromXffInfo getLastAddressFromXFF(const Http::HeaderMap& request_headers,
+                                                         uint32_t num_to_skip = 0);
 
   /**
    * Get the string for the given http protocol.

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -140,6 +140,8 @@ public:
   /**
    * Retrieves the last IPv4/IPv6 address in the x-forwarded-for header.
    * @param request_headers supplies the request headers.
+   * @param num_to_skip specifies the number of addresses at the end of the XFF header
+   *        to ignore when identifying the "last" address.
    * @return GetLastAddressFromXffInfo information about the last address in the XFF header.
    *         @see GetLastAddressFromXffInfo for more information.
    */

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -120,6 +120,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       tracing_stats_(
           Http::ConnectionManagerImpl::generateTracingStats(stats_prefix_, context_.scope())),
       use_remote_address_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, use_remote_address, false)),
+      xff_num_trusted_hops_(config.xff_num_trusted_hops()),
       route_config_provider_manager_(route_config_provider_manager),
       http2_settings_(Http::Utility::parseHttp2Settings(config.http2_protocol_options())),
       http1_settings_(Http::Utility::parseHttp1Settings(config.http_protocol_options())),

--- a/source/server/config/network/http_connection_manager.h
+++ b/source/server/config/network/http_connection_manager.h
@@ -90,6 +90,7 @@ public:
   Http::ConnectionManagerStats& stats() override { return stats_; }
   Http::ConnectionManagerTracingStats& tracingStats() override { return tracing_stats_; }
   bool useRemoteAddress() override { return use_remote_address_; }
+  uint32_t xffNumTrustedHops() const override { return xff_num_trusted_hops_; }
   Http::ForwardClientCertType forwardClientCert() override { return forward_client_cert_; }
   const std::vector<Http::ClientCertDetailsType>& setCurrentClientCertDetails() const override {
     return set_current_client_cert_details_;
@@ -114,6 +115,7 @@ private:
   Http::ConnectionManagerStats stats_;
   Http::ConnectionManagerTracingStats tracing_stats_;
   const bool use_remote_address_{};
+  const uint32_t xff_num_trusted_hops_;
   Http::ForwardClientCertType forward_client_cert_;
   std::vector<Http::ClientCertDetailsType> set_current_client_cert_details_;
   Router::RouteConfigProviderManager& route_config_provider_manager_;

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -76,6 +76,7 @@ public:
   Http::ConnectionManagerStats& stats() override { return stats_; }
   Http::ConnectionManagerTracingStats& tracingStats() override { return tracing_stats_; }
   bool useRemoteAddress() override { return true; }
+  uint32_t xffNumTrustedHops() const override { return 0; }
   Http::ForwardClientCertType forwardClientCert() override {
     return Http::ForwardClientCertType::Sanitize;
   }

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -235,6 +235,7 @@ public:
   ConnectionManagerStats& stats() override { return stats_; }
   ConnectionManagerTracingStats& tracingStats() override { return tracing_stats_; }
   bool useRemoteAddress() override { return use_remote_address_; }
+  uint32_t xffNumTrustedHops() const override { return 0; }
   Http::ForwardClientCertType forwardClientCert() override { return forward_client_cert_; }
   const std::vector<Http::ClientCertDetailsType>& setCurrentClientCertDetails() const override {
     return set_current_client_cert_details_;

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -96,6 +96,26 @@ TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWhenLocalHostRemoteAddress)
   EXPECT_EQ(local_address.ip()->addressAsString(), headers.get_(Headers::get().ForwardedFor));
 }
 
+// Verify that we trust Nth address from XFF when using remote address with xff_num_trusted_hops.
+TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWithXFFTrustedHops) {
+  connection_.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("203.0.113.128");
+  ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
+  ON_CALL(config_, xffNumTrustedHops()).WillByDefault(Return(1));
+  TestHeaderMapImpl headers{{"x-forwarded-for", "198.51.100.1"}};
+  EXPECT_EQ((MutateRequestRet{"198.51.100.1:0", false}),
+            callMutateRequestHeaders(headers, Protocol::Http2));
+}
+
+// Verify that xff_num_trusted_hops works when not using remote address.
+TEST_F(ConnectionManagerUtilityTest, UseXFFTrustedHopsWithoutRemoteAddress) {
+  connection_.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1");
+  ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(false));
+  ON_CALL(config_, xffNumTrustedHops()).WillByDefault(Return(1));
+  TestHeaderMapImpl headers{{"x-forwarded-for", "198.51.100.2, 198.51.100.1"}};
+  EXPECT_EQ((MutateRequestRet{"198.51.100.2:0", false}),
+            callMutateRequestHeaders(headers, Protocol::Http2));
+}
+
 // Verify that we don't set user agent when it is already set.
 TEST_F(ConnectionManagerUtilityTest, UserAgentDontSet) {
   connection_.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1");

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -104,6 +104,7 @@ TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWithXFFTrustedHops) {
   TestHeaderMapImpl headers{{"x-forwarded-for", "198.51.100.1"}};
   EXPECT_EQ((MutateRequestRet{"198.51.100.1:0", false}),
             callMutateRequestHeaders(headers, Protocol::Http2));
+  EXPECT_EQ(headers.EnvoyExternalAddress()->value(), "198.51.100.1");
 }
 
 // Verify that xff_num_trusted_hops works when not using remote address.
@@ -114,6 +115,7 @@ TEST_F(ConnectionManagerUtilityTest, UseXFFTrustedHopsWithoutRemoteAddress) {
   TestHeaderMapImpl headers{{"x-forwarded-for", "198.51.100.2, 198.51.100.1"}};
   EXPECT_EQ((MutateRequestRet{"198.51.100.2:0", false}),
             callMutateRequestHeaders(headers, Protocol::Http2));
+  EXPECT_EQ(headers.EnvoyExternalAddress(), nullptr);
 }
 
 // Verify that we don't set user agent when it is already set.

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -129,8 +129,7 @@ TEST(HttpUtility, getLastAddressFromXFF) {
     const std::string first_address = "192.0.2.10";
     const std::string second_address = "192.0.2.1";
     const std::string third_address = "10.0.0.1";
-    TestHeaderMapImpl request_headers{
-        {"x-forwarded-for", first_address + ", " + second_address + ", " + third_address}};
+    TestHeaderMapImpl request_headers{{"x-forwarded-for", "192.0.2.10, 192.0.2.1, 10.0.0.1"}};
     auto ret = Utility::getLastAddressFromXFF(request_headers);
     EXPECT_EQ(third_address, ret.address_->ip()->addressAsString());
     EXPECT_FALSE(ret.single_address_);

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -130,8 +130,7 @@ TEST(HttpUtility, getLastAddressFromXFF) {
     const std::string second_address = "192.0.2.1";
     const std::string third_address = "10.0.0.1";
     TestHeaderMapImpl request_headers{
-        {"x-forwarded-for",
-         fmt::format("{0}, {1}, {2}", first_address, second_address, third_address)}};
+        {"x-forwarded-for", first_address + ", " + second_address + ", " + third_address}};
     auto ret = Utility::getLastAddressFromXFF(request_headers);
     EXPECT_EQ(third_address, ret.address_->ip()->addressAsString());
     EXPECT_FALSE(ret.single_address_);

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -126,12 +126,23 @@ TEST(HttpUtility, parseHttp2Settings) {
 
 TEST(HttpUtility, getLastAddressFromXFF) {
   {
-    const std::string first_address = "34.0.0.1";
-    const std::string second_address = "10.0.0.1";
+    const std::string first_address = "192.0.2.10";
+    const std::string second_address = "192.0.2.1";
+    const std::string third_address = "10.0.0.1";
     TestHeaderMapImpl request_headers{
-        {"x-forwarded-for", fmt::format("{0}, {0}, {1}", first_address, second_address)}};
+        {"x-forwarded-for",
+         fmt::format("{0}, {1}, {2}", first_address, second_address, third_address)}};
     auto ret = Utility::getLastAddressFromXFF(request_headers);
+    EXPECT_EQ(third_address, ret.address_->ip()->addressAsString());
+    EXPECT_FALSE(ret.single_address_);
+    ret = Utility::getLastAddressFromXFF(request_headers, 1);
     EXPECT_EQ(second_address, ret.address_->ip()->addressAsString());
+    EXPECT_FALSE(ret.single_address_);
+    ret = Utility::getLastAddressFromXFF(request_headers, 2);
+    EXPECT_EQ(first_address, ret.address_->ip()->addressAsString());
+    EXPECT_FALSE(ret.single_address_);
+    ret = Utility::getLastAddressFromXFF(request_headers, 3);
+    EXPECT_EQ(nullptr, ret.address_);
     EXPECT_FALSE(ret.single_address_);
   }
   {

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -53,6 +53,7 @@ public:
   MOCK_METHOD0(stats, ConnectionManagerStats&());
   MOCK_METHOD0(tracingStats, ConnectionManagerTracingStats&());
   MOCK_METHOD0(useRemoteAddress, bool());
+  MOCK_CONST_METHOD0(xffNumTrustedHops, uint32_t());
   MOCK_METHOD0(forwardClientCert, Http::ForwardClientCertType());
   MOCK_CONST_METHOD0(setCurrentClientCertDetails,
                      const std::vector<Http::ClientCertDetailsType>&());


### PR DESCRIPTION
*Description*:
If the [xff_num_trusted_hops](https://github.com/envoyproxy/data-plane-api/commit/2bf5d617042e52b7f4f834f87792f1638bfa7bbc) config option is set to a number greater than zero, trust the specified number of additional addresses at the end of the `X-Forwarded-For` request header.

*Risk Level*: High
(because this change interacts with the internal/external request security model)

*Testing*: New test cases included

*Docs Changes*: [#479](https://github.com/envoyproxy/data-plane-api/pull/479)

*Release Notes*: Included 

*Fixes*: #2503 

*API Changes*: [#459](https://github.com/envoyproxy/data-plane-api/pull/459)

Signed-off-by: Brian Pane <bpane@pinterest.com>
