### PR TITLE
http: fixing 100-continue behavior

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -461,6 +461,8 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
     // and sends the 100-Continue directly to the encoder.
     chargeStats(continueHeader());
     response_encoder_->encode100ContinueHeaders(continueHeader());
+    // Remove the Expect header so it won't be handled again downstream.
+    request_headers_->removeExpect();
   }
 
   connection_manager_.user_agent_.initializeFromHeaders(

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -753,6 +753,8 @@ void HttpIntegrationTest::testEnvoyHandling100Continue() {
                                        *response_);
   waitForNextUpstreamRequest();
 
+  // Verify the Expect header is stripped.
+  EXPECT_TRUE(upstream_request_->headers().get(Http::Headers::get().Expect) == nullptr);
   upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, true);
   response_->waitForEndStream();
   ASSERT_TRUE(response_->complete());


### PR DESCRIPTION
Restoring the previous behavior where Envoy strips the Expect header when seeing expect: 100-continue

*Risk Level*: Low
*Testing*: integration test
*Docs Changes*: n/a
*Release Notes*: n/a