### PR TITLE
http: guard against multiple 100 responses

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -461,7 +461,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
     // and sends the 100-Continue directly to the encoder.
     chargeStats(continueHeader());
     response_encoder_->encode100ContinueHeaders(continueHeader());
-    // Remove the Expect header so it won't be handled again downstream.
+    // Remove the Expect header so it won't be handled again upstream.
     request_headers_->removeExpect();
   }
 

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -406,6 +406,9 @@ int ConnectionImpl::onFrameReceived(const nghttp2_frame* frame) {
             // supports. Even if this is valid HTTP (something like 103 early hints) fail here
             // rather than trying to push unexpected headers through the Envoy pipeline as that
             // will likely result in Envoy crashing.
+            // It would be cleaner to reset the stream rather than reset the/ entire connection but
+            // it's also slightly more dangerous so currently we err on the side of safety.
+            stats_.too_many_header_frames_.inc();
             throw CodecProtocolException("Unexpected 'trailers' with no end stream.");
           } else {
             stream->decoder_->decodeTrailers(std::move(stream->headers_));

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -401,8 +401,15 @@ int ConnectionImpl::onFrameReceived(const nghttp2_frame* frame) {
       // if local is not complete.
       if (!stream->deferred_reset_.valid()) {
         if (!stream->waiting_for_non_informational_headers_) {
-          ASSERT(stream->remote_end_stream_);
-          stream->decoder_->decodeTrailers(std::move(stream->headers_));
+          if (!stream->remote_end_stream_) {
+            // This indicates we have received more headers frames than Envoy
+            // supports. Even if this is valid HTTP (something like 103 early hints) fail here
+            // rather than trying to push unexpected headers through the Envoy pipeline as that
+            // will likely result in Envoy crashing.
+            throw CodecProtocolException("Unexpected 'trailers' with no end stream.");
+          } else {
+            stream->decoder_->decodeTrailers(std::move(stream->headers_));
+          }
         } else {
           ASSERT(!nghttp2_session_check_server_session(session_));
           stream->waiting_for_non_informational_headers_ = false;

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -41,7 +41,7 @@ const std::string CLIENT_MAGIC_PREFIX = "PRI * HTTP/2";
   COUNTER(tx_reset)                                                                                \
   COUNTER(header_overflow)                                                                         \
   COUNTER(trailers)                                                                                \
-  COUNTER(headers_cb_no_stream)                                                                   \
+  COUNTER(headers_cb_no_stream)                                                                    \
   COUNTER(too_many_header_frames)
 // clang-format on
 

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -41,7 +41,8 @@ const std::string CLIENT_MAGIC_PREFIX = "PRI * HTTP/2";
   COUNTER(tx_reset)                                                                                \
   COUNTER(header_overflow)                                                                         \
   COUNTER(trailers)                                                                                \
-  COUNTER(headers_cb_no_stream)
+  COUNTER(headers_cb_no_stream)                                                                   \
+  COUNTER(too_many_header_frames)
 // clang-format on
 
 /**

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -243,7 +243,7 @@ public:
   const Optional<std::string>& userAgent() override { return user_agent_; }
   const TracingConnectionManagerConfig* tracingConfig() override { return tracing_config_.get(); }
   ConnectionManagerListenerStats& listenerStats() override { return listener_stats_; }
-  bool proxy100Continue() const override { return false; }
+  bool proxy100Continue() const override { return proxy_100_continue_; }
 
   NiceMock<Tracing::MockHttpTracer> tracer_;
   NiceMock<Runtime::MockLoader> runtime_;
@@ -278,6 +278,7 @@ public:
   bool streaming_filter_{false};
   Stats::IsolatedStoreImpl fake_listener_stats_;
   ConnectionManagerListenerStats listener_stats_;
+  bool proxy_100_continue_ = false;
 
   // TODO(mattklein123): Not all tests have been converted over to better setup. Convert the rest.
   MockStreamEncoder response_encoder_;
@@ -348,6 +349,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderOnlyRequestAndResponse) {
 }
 
 TEST_F(HttpConnectionManagerImplTest, 100ContinueResponse) {
+  proxy_100_continue_ = true;
   setup(false, "envoy-custom-server", false);
 
   // Store the basic request encoder during filter chain setup.
@@ -400,7 +402,32 @@ TEST_F(HttpConnectionManagerImplTest, 100ContinueResponse) {
   EXPECT_EQ(1U, listener_stats_.downstream_rq_2xx_.value());
 }
 
+TEST_F(HttpConnectionManagerImplTest, 100ContinueResponseWithEncoderFiltersProxyingDisabled) {
+  proxy_100_continue_ = false;
+  setup(false, "envoy-custom-server", false);
+  setUpEncoderAndDecoder();
+  sendReqestHeadersAndData();
+
+  // Akin to 100ContinueResponseWithEncoderFilters below, but with
+  // proxy_100_continue_ false. Verify the filters do not get the 100 continue
+  // headers.
+  EXPECT_CALL(*encoder_filters_[0], encode100ContinueHeaders(_)).Times(0);
+  EXPECT_CALL(*encoder_filters_[1], encode100ContinueHeaders(_)).Times(0);
+  EXPECT_CALL(response_encoder_, encode100ContinueHeaders(_)).Times(0);
+  HeaderMapPtr continue_headers{new TestHeaderMapImpl{{":status", "100"}}};
+  decoder_filters_[0]->callbacks_->encode100ContinueHeaders(std::move(continue_headers));
+
+  EXPECT_CALL(*encoder_filters_[0], encodeHeaders(_, false))
+      .WillOnce(Return(FilterHeadersStatus::Continue));
+  EXPECT_CALL(*encoder_filters_[1], encodeHeaders(_, false))
+      .WillOnce(Return(FilterHeadersStatus::Continue));
+  EXPECT_CALL(response_encoder_, encodeHeaders(_, false));
+  HeaderMapPtr response_headers{new TestHeaderMapImpl{{":status", "200"}}};
+  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), false);
+}
+
 TEST_F(HttpConnectionManagerImplTest, 100ContinueResponseWithEncoderFilters) {
+  proxy_100_continue_ = true;
   setup(false, "envoy-custom-server", false);
   setUpEncoderAndDecoder();
   sendReqestHeadersAndData();
@@ -423,6 +450,7 @@ TEST_F(HttpConnectionManagerImplTest, 100ContinueResponseWithEncoderFilters) {
 }
 
 TEST_F(HttpConnectionManagerImplTest, PauseResume100Continue) {
+  proxy_100_continue_ = true;
   setup(false, "envoy-custom-server", false);
   setUpEncoderAndDecoder();
   sendReqestHeadersAndData();

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -188,6 +188,25 @@ TEST_P(Http2CodecImplTest, InvalidRepeatContinue) {
   EXPECT_THROW(response_encoder_->encodeHeaders(continue_headers, true), CodecProtocolException);
 };
 
+TEST_P(Http2CodecImplTest, Invalid103) {
+  initialize();
+
+  TestHeaderMapImpl request_headers;
+  HttpTestUtility::addDefaultHeaders(request_headers);
+  EXPECT_CALL(request_decoder_, decodeHeaders_(_, true));
+  request_encoder_->encodeHeaders(request_headers, true);
+
+  TestHeaderMapImpl continue_headers{{":status", "100"}};
+  EXPECT_CALL(response_decoder_, decode100ContinueHeaders_(_));
+  response_encoder_->encode100ContinueHeaders(continue_headers);
+
+  TestHeaderMapImpl early_hint_headers{{":status", "103"}};
+  EXPECT_CALL(response_decoder_, decodeHeaders_(_, false));
+  response_encoder_->encodeHeaders(early_hint_headers, false);
+
+  EXPECT_THROW(response_encoder_->encodeHeaders(early_hint_headers, false), CodecProtocolException);
+};
+
 TEST_P(Http2CodecImplTest, RefusedStreamReset) {
   initialize();
 

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -204,7 +204,9 @@ TEST_P(Http2CodecImplTest, Invalid103) {
   EXPECT_CALL(response_decoder_, decodeHeaders_(_, false));
   response_encoder_->encodeHeaders(early_hint_headers, false);
 
-  EXPECT_THROW(response_encoder_->encodeHeaders(early_hint_headers, false), CodecProtocolException);
+  EXPECT_THROW_WITH_MESSAGE(response_encoder_->encodeHeaders(early_hint_headers, false),
+                            CodecProtocolException, "Unexpected 'trailers' with no end stream.");
+  EXPECT_EQ(1, stats_store_.counter("http2.too_many_header_frames").value());
 };
 
 TEST_P(Http2CodecImplTest, RefusedStreamReset) {

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -106,7 +106,13 @@ TEST_P(Http2IntegrationTest, Retry) { testRetry(); }
 
 TEST_P(Http2IntegrationTest, EnvoyHandling100Continue) { testEnvoyHandling100Continue(); }
 
-TEST_P(Http2IntegrationTest, EnvoyProxying100Continue) { testEnvoyProxying100Continue(); }
+TEST_P(Http2IntegrationTest, EnvoyHandlingDuplicate100Continue) {
+  testEnvoyHandling100Continue(true);
+}
+
+TEST_P(Http2IntegrationTest, EnvoyProxyingEarly100Continue) { testEnvoyProxying100Continue(true); }
+
+TEST_P(Http2IntegrationTest, EnvoyProxyingLate100Continue) { testEnvoyProxying100Continue(false); }
 
 TEST_P(Http2IntegrationTest, RetryHittingBufferLimit) { testRetryHittingBufferLimit(); }
 

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -90,7 +90,17 @@ TEST_P(Http2UpstreamIntegrationTest, Retry) { testRetry(); }
 
 TEST_P(Http2UpstreamIntegrationTest, EnvoyHandling100Continue) { testEnvoyHandling100Continue(); }
 
-TEST_P(Http2UpstreamIntegrationTest, EnvoyProxying100Continue) { testEnvoyProxying100Continue(); }
+TEST_P(Http2UpstreamIntegrationTest, EnvoyHandlingDuplicate100Continue) {
+  testEnvoyHandling100Continue(true);
+}
+
+TEST_P(Http2UpstreamIntegrationTest, EnvoyProxyingEarly100Continue) {
+  testEnvoyProxying100Continue(true);
+}
+
+TEST_P(Http2UpstreamIntegrationTest, EnvoyProxyingLate100Continue) {
+  testEnvoyProxying100Continue(false);
+}
 
 TEST_P(Http2UpstreamIntegrationTest, RetryHittingBufferLimit) { testRetryHittingBufferLimit(); }
 

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -741,32 +741,42 @@ void HttpIntegrationTest::testHittingEncoderFilterLimit() {
   EXPECT_STREQ("500", response_->headers().Status()->value().c_str());
 }
 
-void HttpIntegrationTest::testEnvoyHandling100Continue() {
+void HttpIntegrationTest::testEnvoyHandling100Continue(bool additional_continue_from_upstream) {
   initialize();
-
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  codec_client_->makeHeaderOnlyRequest(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                               {":path", "/dynamo/url"},
-                                                               {":scheme", "http"},
-                                                               {":authority", "host"},
-                                                               {"expect", "100-continue"}},
-                                       *response_);
-  waitForNextUpstreamRequest();
+  request_encoder_ =
+      &codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
+                                                           {":path", "/dynamo/url"},
+                                                           {":scheme", "http"},
+                                                           {":authority", "host"},
+                                                           {"expect", "100-continue"}},
+                                   *response_);
+  fake_upstream_connection_ = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
+  // The continue headers should arrive immediately.
+  response_->waitForContinueHeaders();
+  upstream_request_ = fake_upstream_connection_->waitForNewStream(*dispatcher_);
+  codec_client_->sendData(*request_encoder_, 10, true);
+  upstream_request_->waitForEndStream(*dispatcher_);
+  if (additional_continue_from_upstream) {
+    // Make sure if upstream sends an 100-Continue Envoy doesn't send its own and proxy the one
+    // from upstream!
+    upstream_request_->encode100ContinueHeaders(Http::TestHeaderMapImpl{{":status", "100"}});
+  }
+  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeData(12, true);
 
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, true);
   response_->waitForEndStream();
   ASSERT_TRUE(response_->complete());
   ASSERT(response_->continue_headers() != nullptr);
   EXPECT_STREQ("100", response_->continue_headers()->Status()->value().c_str());
-
   EXPECT_STREQ("200", response_->headers().Status()->value().c_str());
 }
 
-void HttpIntegrationTest::testEnvoyProxying100Continue(bool with_encoder_filter) {
+void HttpIntegrationTest::testEnvoyProxying100Continue(bool continue_before_upstream_complete,
+                                                       bool with_encoder_filter) {
   if (with_encoder_filter) {
-    // Because 100-continue only affects encoder filters, make sure it plays well
-    // with one.
+    // Because 100-continue only affects encoder filters, make sure it plays well with one.
     config_helper_.addFilter("name: envoy.cors");
     config_helper_.addConfigModifier(
         [&](envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager& hcm)
@@ -787,16 +797,34 @@ void HttpIntegrationTest::testEnvoyProxying100Continue(bool with_encoder_filter)
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
+  request_encoder_ =
+      &codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "GET"},
+                                                           {":path", "/dynamo/url"},
+                                                           {":scheme", "http"},
+                                                           {":authority", "host"},
+                                                           {"expect", "100-continue"}},
+                                   *response_);
 
-  codec_client_->makeHeaderOnlyRequest(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                               {":path", "/dynamo/url"},
-                                                               {":scheme", "http"},
-                                                               {":authority", "host"},
-                                                               {"expect", "100-continue"}},
-                                       *response_);
-  waitForNextUpstreamRequest();
+  // Wait for the request headers to be received upstream.
+  fake_upstream_connection_ = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
+  upstream_request_ = fake_upstream_connection_->waitForNewStream(*dispatcher_);
 
-  upstream_request_->encode100ContinueHeaders(Http::TestHeaderMapImpl{{":status", "100"}});
+  if (continue_before_upstream_complete) {
+    // This case tests sending on 100-Continue headers before the client has sent all the
+    // request data.
+    upstream_request_->encode100ContinueHeaders(Http::TestHeaderMapImpl{{":status", "100"}});
+    response_->waitForContinueHeaders();
+  }
+  // Send all of the request data and wait for it to be received upstream.
+  codec_client_->sendData(*request_encoder_, 10, true);
+  upstream_request_->waitForEndStream(*dispatcher_);
+
+  if (!continue_before_upstream_complete) {
+    // This case tests forwarding 100-Continue after the client has sent all data.
+    upstream_request_->encode100ContinueHeaders(Http::TestHeaderMapImpl{{":status", "100"}});
+    response_->waitForContinueHeaders();
+  }
+  // Now send the rest of the response.
   upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, true);
   response_->waitForEndStream();
   EXPECT_TRUE(response_->complete());

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -152,8 +152,9 @@ protected:
   void testGrpcRetry();
   void testHittingDecoderFilterLimit();
   void testHittingEncoderFilterLimit();
-  void testEnvoyHandling100Continue();
-  void testEnvoyProxying100Continue(bool with_encoder_filter = false);
+  void testEnvoyHandling100Continue(bool additional_continue_from_upstream = false);
+  void testEnvoyProxying100Continue(bool continue_before_upstream_complete = false,
+                                    bool with_encoder_filter = false);
 
   // HTTP/2 client tests.
   void testDownstreamResetBeforeResponseComplete();

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -32,6 +32,7 @@ public:
   const Http::HeaderMap* continue_headers() { return continue_headers_.get(); }
   const Http::HeaderMap& headers() { return *headers_; }
   const Http::HeaderMapPtr& trailers() { return trailers_; }
+  void waitForContinueHeaders();
   void waitForHeaders();
   void waitForBodyData(uint64_t size);
   void waitForEndStream();
@@ -58,6 +59,7 @@ private:
   std::string body_;
   uint64_t body_data_waiting_length_{};
   bool waiting_for_reset_{};
+  bool waiting_for_continue_headers_{};
   bool waiting_for_headers_{};
   bool saw_reset_{};
   Http::StreamResetReason reset_reason_{};

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -115,10 +115,18 @@ TEST_P(IntegrationTest, Retry) { testRetry(); }
 
 TEST_P(IntegrationTest, EnvoyHandling100Continue) { testEnvoyHandling100Continue(); }
 
-TEST_P(IntegrationTest, EnvoyProxying100Continue) { testEnvoyProxying100Continue(); }
+TEST_P(IntegrationTest, EnvoyHandlingDuplicate100Continues) { testEnvoyHandling100Continue(true); }
 
-TEST_P(IntegrationTest, EnvoyProxying100ContinueWithEncoderFilter) {
-  testEnvoyProxying100Continue(true);
+TEST_P(IntegrationTest, EnvoyProxyingEarly100Continue) { testEnvoyProxying100Continue(true); }
+
+TEST_P(IntegrationTest, EnvoyProxyingLate100Continue) { testEnvoyProxying100Continue(false); }
+
+TEST_P(IntegrationTest, EnvoyProxyingEarly100ContinueWithEncoderFilter) {
+  testEnvoyProxying100Continue(true, true);
+}
+
+TEST_P(IntegrationTest, EnvoyProxyingLate100ContinueWithEncoderFilter) {
+  testEnvoyProxying100Continue(false, true);
 }
 
 TEST_P(IntegrationTest, TwoRequests) { testTwoRequests(); }


### PR DESCRIPTION
*Description*:
If not proxying 100-Continue, swallow 100-continues.
Also handle the case of multiple continues headers "cleanly" by resetting the stream, rather than crashing.  Support for responses with multiple headers, such as 103 (early hint) can be added when there's a need.

*Risk Level*: Medium (on top of a high risk feature)
*Testing*: Lots and lots of extended integration tests.
*Docs Changes*: https://github.com/envoyproxy/data-plane-api/pull/492
*Release Notes*: 100-continue support already docced.
Fixes #2563