### PR TITLE
redis: add support for georadius read-only commands

### DIFF
--- a/RAW_RELEASE_NOTES.md
+++ b/RAW_RELEASE_NOTES.md
@@ -60,3 +60,4 @@ final version.
 * Added the ability to pass a URL encoded Pem encoded peer certificate in the x-forwarded-client-cert header.
 * Added support for abstract unix domain sockets on linux. The abstract
   namespace can be used by prepending '@' to a socket path.
+* Added `GEORADIUS_RO` and `GEORADIUSBYMEMBER_RO` to the Redis command splitter whitelist.

--- a/source/common/redis/supported_commands.h
+++ b/source/common/redis/supported_commands.h
@@ -16,16 +16,17 @@ struct SupportedCommands {
   static const std::vector<std::string>& simpleCommands() {
     CONSTRUCT_ON_FIRST_USE(
         std::vector<std::string>, "append", "bitcount", "bitfield", "bitpos", "decr", "decrby",
-        "dump", "expire", "expireat", "geoadd", "geodist", "geohash", "geopos", "get", "getbit",
-        "getrange", "getset", "hdel", "hexists", "hget", "hgetall", "hincrby", "hincrbyfloat",
-        "hkeys", "hlen", "hmget", "hmset", "hscan", "hset", "hsetnx", "hstrlen", "hvals", "incr",
-        "incrby", "incrbyfloat", "lindex", "linsert", "llen", "lpop", "lpush", "lpushx", "lrange",
-        "lrem", "lset", "ltrim", "persist", "pexpire", "pexpireat", "psetex", "pttl", "restore",
-        "rpop", "rpush", "rpushx", "sadd", "scard", "set", "setbit", "setex", "setnx", "setrange",
-        "sismember", "smembers", "spop", "srandmember", "srem", "sscan", "strlen", "ttl", "type",
-        "zadd", "zcard", "zcount", "zincrby", "zlexcount", "zrange", "zrangebylex", "zrangebyscore",
-        "zrank", "zrem", "zremrangebylex", "zremrangebyrank", "zremrangebyscore", "zrevrange",
-        "zrevrangebylex", "zrevrangebyscore", "zrevrank", "zscan", "zscore");
+        "dump", "expire", "expireat", "geoadd", "geodist", "geohash", "geopos", "georadius_ro",
+        "georadiusbymember_ro", "get", "getbit", "getrange", "getset", "hdel", "hexists", "hget",
+        "hgetall", "hincrby", "hincrbyfloat", "hkeys", "hlen", "hmget", "hmset", "hscan", "hset",
+        "hsetnx", "hstrlen", "hvals", "incr", "incrby", "incrbyfloat", "lindex", "linsert", "llen",
+        "lpop", "lpush", "lpushx", "lrange", "lrem", "lset", "ltrim", "persist", "pexpire",
+        "pexpireat", "psetex", "pttl", "restore", "rpop", "rpush", "rpushx", "sadd", "scard", "set",
+        "setbit", "setex", "setnx", "setrange", "sismember", "smembers", "spop", "srandmember",
+        "srem", "sscan", "strlen", "ttl", "type", "zadd", "zcard", "zcount", "zincrby", "zlexcount",
+        "zrange", "zrangebylex", "zrangebyscore", "zrank", "zrem", "zremrangebylex",
+        "zremrangebyrank", "zremrangebyscore", "zrevrange", "zrevrangebylex", "zrevrangebyscore",
+        "zrevrank", "zscan", "zscore");
   }
 
   /**


### PR DESCRIPTION
**Description**:
New read-only variants of `GEORADIUS` commands, which are safe to use in all contexts, were recently introduced to Redis. See the [Redis documentation for `GEORADIUS`](https://redis.io/commands/georadius). This PR adds `GEORADIUS_RO` and `GEORADIUSBYMEMBER_RO` to the whitelist.

**Risk Level**:
Low

**Testing**:
Manual testing. Unit tests already test the exhaustive whitelist by iterating over it.

**Release Notes**:
Noted for 1.6.0.

Fixes #2369.

Signed-off-by: Daniel Hochman <danielhochman@users.noreply.github.com>
