### PR TITLE
listen_socket: Remove default value from virtual function parameter.

### DIFF
--- a/include/envoy/network/listen_socket.h
+++ b/include/envoy/network/listen_socket.h
@@ -96,7 +96,7 @@ public:
    *        actually different when passing restored as 'true'.
    */
   virtual void setLocalAddress(const Address::InstanceConstSharedPtr& local_address,
-                               bool restored = false) PURE;
+                               bool restored) PURE;
 
   /**
    * Set the remote address of the socket.

--- a/source/common/filter/listener/proxy_protocol.cc
+++ b/source/common/filter/listener/proxy_protocol.cc
@@ -110,7 +110,7 @@ void Instance::onReadWorker() {
       throw EnvoyException("failed to read proxy protocol");
     }
 
-    socket.setLocalAddress(local_address);
+    socket.setLocalAddress(local_address, false);
     socket.setRemoteAddress(remote_address);
   }
 

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -579,7 +579,7 @@ void ClientConnectionImpl::connect() {
   // The local address can only be retrieved for IP connections. Other
   // types, such as UDS, don't have a notion of a local address.
   if (socket_->remoteAddress()->type() == Address::Type::Ip) {
-    socket_->setLocalAddress(Address::addressFromFd(fd()));
+    socket_->setLocalAddress(Address::addressFromFd(fd()), false);
   }
 }
 


### PR DESCRIPTION
We should not have default parameter values on virtual functions, but
this one slipped through.

Fixes: eb02089b03 ("Listener: Add listener filters. (#2346)")
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
Risk Level: Low
