### PR TITLE
load balancer: implement Maglev algorithm and benchmarks

### DIFF
--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -11,10 +11,14 @@ namespace Envoy {
 class HashUtil {
 public:
   /**
-   * Return 64-bit hash with seed of 0 from the xxHash algorithm.
+   * Return 64-bit hash from the xxHash algorithm.
+   * @param input supplies the string view to hash.
+   * @param seed supplies the hash seed which defaults to 0.
    * See https://github.com/Cyan4973/xxHash for details.
    */
-  static uint64_t xxHash64(absl::string_view input) { return XXH64(input.data(), input.size(), 0); }
+  static uint64_t xxHash64(absl::string_view input, uint64_t seed = 0) {
+    return XXH64(input.data(), input.size(), seed);
+  }
 
   /**
    * TODO(gsagula): extend xxHash to handle case-insensitive.

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -218,6 +218,15 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "maglev_lb_lib",
+    srcs = ["maglev_lb.cc"],
+    hdrs = ["maglev_lb.h"],
+    deps = [
+        ":load_balancer_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "ring_hash_lb_lib",
     srcs = ["ring_hash_lb.cc"],
     hdrs = ["ring_hash_lb.h"],

--- a/source/common/upstream/maglev_lb.cc
+++ b/source/common/upstream/maglev_lb.cc
@@ -1,0 +1,45 @@
+#include "common/upstream/maglev_lb.h"
+
+namespace Envoy {
+namespace Upstream {
+
+MaglevTable::MaglevTable(const HostVector& hosts) {
+  // Implementation of pseudocode listing 1 in the paper (see header file for more info).
+  std::vector<TableBuildEntry> table_build_entries;
+  table_build_entries.reserve(hosts.size());
+  for (const auto& host : hosts) {
+    const std::string& address = host->address()->asString();
+    table_build_entries.emplace_back(HashUtil::xxHash64(address) % TableSize,
+                                     (HashUtil::xxHash64(address, 1) % (TableSize - 1)) + 1);
+  }
+
+  table_.resize(TableSize);
+  uint64_t table_index = 0;
+  while (true) {
+    for (uint64_t i = 0; i < hosts.size(); i++) {
+      uint64_t c = permutation(table_build_entries[i]);
+      while (table_[c] != nullptr) {
+        table_build_entries[i].next_++;
+        c = permutation(table_build_entries[i]);
+      }
+
+      table_[c] = hosts[i];
+      table_build_entries[i].next_++;
+      table_index++;
+      if (table_index == TableSize) {
+        return;
+      }
+    }
+  }
+}
+
+HostConstSharedPtr MaglevTable::chooseHost(LoadBalancerContext* context) {
+  return table_[context->computeHashKey().value() % TableSize];
+}
+
+uint64_t MaglevTable::permutation(const TableBuildEntry& entry) {
+  return (entry.offset_ + (entry.skip_ * entry.next_)) % TableSize;
+}
+
+} // namespace Upstream
+} // namespace Envoy

--- a/source/common/upstream/maglev_lb.h
+++ b/source/common/upstream/maglev_lb.h
@@ -11,11 +11,12 @@ namespace Upstream {
  * section 3.4. Specifically, the algorithm shown in pseudocode listening 1 is implemented
  * with a fixed table size of 65537. This is the recommended table size in section 5.3.
  */
-class MaglevTable {
+class MaglevTable : public LoadBalancer {
 public:
   MaglevTable(const HostVector& hosts);
 
-  HostConstSharedPtr chooseHost(LoadBalancerContext* context);
+  // Upstream::LoadBalancer
+  HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
 
 private:
   struct TableBuildEntry {

--- a/source/common/upstream/maglev_lb.h
+++ b/source/common/upstream/maglev_lb.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "common/upstream/load_balancer_impl.h"
+
+namespace Envoy {
+namespace Upstream {
+
+/**
+ * This is an implementation of Maglev consistent hashing as described in:
+ * https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/44824.pdf
+ * section 3.4. Specifically, the algorithm shown in pseudocode listening 1 is implemented
+ * with a fixed table size of 65537. This is the recommended table size in section 5.3.
+ */
+class MaglevTable {
+public:
+  MaglevTable(const HostVector& hosts);
+
+  HostConstSharedPtr chooseHost(LoadBalancerContext* context);
+
+private:
+  struct TableBuildEntry {
+    TableBuildEntry(uint64_t offset, uint64_t skip) : offset_(offset), skip_(skip) {}
+
+    const uint64_t offset_;
+    const uint64_t skip_;
+    uint64_t next_{};
+  };
+
+  uint64_t permutation(const TableBuildEntry& entry);
+
+  // Recommended table size in section 5.3 of the paper.
+  static const uint64_t TableSize = 65537;
+  HostVector table_;
+};
+
+} // namespace Upstream
+} // namespace Envoy

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -241,6 +241,7 @@ envoy_cc_binary(
         "benchmark",
     ],
     deps = [
+        "//source/common/upstream:maglev_lb_lib",
         "//source/common/upstream:ring_hash_lb_lib",
         "//source/common/upstream:upstream_lib",
         "//test/common/upstream:utility_lib",

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -1,4 +1,5 @@
 #include "common/runtime/runtime_impl.h"
+#include "common/upstream/maglev_lb.h"
 #include "common/upstream/ring_hash_lb.h"
 #include "common/upstream/upstream_impl.h"
 
@@ -9,10 +10,11 @@
 
 namespace Envoy {
 namespace Upstream {
+namespace {
 
-class RingHashTester {
+class BaseTester {
 public:
-  RingHashTester(uint64_t num_hosts, uint64_t min_ring_size) {
+  BaseTester(uint64_t num_hosts) {
     HostSet& host_set = priority_set_.getOrCreateHostSet(0);
 
     HostVector hosts;
@@ -22,15 +24,21 @@ public:
     }
     HostVectorConstSharedPtr updated_hosts{new HostVector(hosts)};
     host_set.updateHosts(updated_hosts, updated_hosts, nullptr, nullptr, hosts, {});
+  }
 
+  PrioritySetImpl priority_set_;
+  std::shared_ptr<MockClusterInfo> info_{new NiceMock<MockClusterInfo>()};
+};
+
+class RingHashTester : public BaseTester {
+public:
+  RingHashTester(uint64_t num_hosts, uint64_t min_ring_size) : BaseTester(num_hosts) {
     config_.value(envoy::api::v2::Cluster::RingHashLbConfig());
     config_.value().mutable_minimum_ring_size()->set_value(min_ring_size);
     ring_hash_lb_.reset(new RingHashLoadBalancer{priority_set_, stats_, runtime_, random_, config_,
                                                  common_config_});
   }
 
-  PrioritySetImpl priority_set_;
-  std::shared_ptr<MockClusterInfo> info_{new NiceMock<MockClusterInfo>()};
   Stats::IsolatedStoreImpl stats_store_;
   ClusterStats stats_{ClusterInfoImpl::generateStats(stats_store_)};
   NiceMock<Runtime::MockLoader> runtime_;
@@ -40,7 +48,7 @@ public:
   envoy::api::v2::Cluster::CommonLbConfig common_config_;
 };
 
-static void BM_RingHashLoadBalancerBuildRing(benchmark::State& state) {
+void BM_RingHashLoadBalancerBuildRing(benchmark::State& state) {
   for (auto _ : state) {
     state.PauseTiming();
     const uint64_t num_hosts = state.range(0);
@@ -61,6 +69,21 @@ BENCHMARK(BM_RingHashLoadBalancerBuildRing)
     ->Args({500, 256000})
     ->Unit(benchmark::kMillisecond);
 
+void BM_MaglevLoadBalancerBuildTable(benchmark::State& state) {
+  for (auto _ : state) {
+    state.PauseTiming();
+    const uint64_t num_hosts = state.range(0);
+    BaseTester tester(num_hosts);
+    state.ResumeTiming();
+    MaglevTable table(tester.priority_set_.getOrCreateHostSet(0).hosts());
+  }
+}
+BENCHMARK(BM_MaglevLoadBalancerBuildTable)
+    ->Arg(100)
+    ->Arg(200)
+    ->Arg(500)
+    ->Unit(benchmark::kMillisecond);
+
 class TestLoadBalancerContext : public LoadBalancerContext {
 public:
   // Upstream::LoadBalancerContext
@@ -71,7 +94,27 @@ public:
   Optional<uint64_t> hash_key_;
 };
 
-static void BM_RingHashLoadBalancerChooseHost(benchmark::State& state) {
+void computeHitStats(benchmark::State& state,
+                     const std::unordered_map<std::string, uint64_t>& hit_counter) {
+  double mean = 0;
+  for (const auto& pair : hit_counter) {
+    mean += pair.second;
+  }
+  mean /= hit_counter.size();
+
+  double variance = 0;
+  for (const auto& pair : hit_counter) {
+    variance += std::pow(pair.second - mean, 2);
+  }
+  variance /= hit_counter.size();
+  const double stddev = std::sqrt(variance);
+
+  state.counters["mean_hits"] = mean;
+  state.counters["stddev_hits"] = stddev;
+  state.counters["relative_stddev_hits"] = (stddev / mean);
+}
+
+void BM_RingHashLoadBalancerChooseHost(benchmark::State& state) {
   for (auto _ : state) {
     // Do not time the creation of the ring.
     state.PauseTiming();
@@ -87,7 +130,9 @@ static void BM_RingHashLoadBalancerChooseHost(benchmark::State& state) {
 
     // Note: To a certain extent this is benchmarking the performance of xxhash as well as
     // std::unordered_map. However, it should be roughly equivalent to the work done when
-    // comparing to different hashing algorithms such as Maglev.
+    // comparing different hashing algorithms.
+    // TODO(mattklein123): When Maglev is a real load balancer, further share code with the
+    //                     other test.
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       context.hash_key_.value(
           HashUtil::xxHash64(absl::string_view(reinterpret_cast<const char*>(&i), sizeof(i))));
@@ -96,22 +141,7 @@ static void BM_RingHashLoadBalancerChooseHost(benchmark::State& state) {
 
     // Do not time computation of mean, standard deviation, and relative standard deviation.
     state.PauseTiming();
-    double mean = 0;
-    for (const auto& pair : hit_counter) {
-      mean += pair.second;
-    }
-    mean /= hit_counter.size();
-
-    double variance = 0;
-    for (const auto& pair : hit_counter) {
-      variance += std::pow(pair.second - mean, 2);
-    }
-    variance /= hit_counter.size();
-    const double stddev = std::sqrt(variance);
-
-    state.counters["mean_hits"] = mean;
-    state.counters["stddev_hits"] = stddev;
-    state.counters["relative_stddev_hits"] = (stddev / mean);
+    computeHitStats(state, hit_counter);
     state.ResumeTiming();
   }
 }
@@ -124,6 +154,40 @@ BENCHMARK(BM_RingHashLoadBalancerChooseHost)
     ->Args({500, 256000, 100000})
     ->Unit(benchmark::kMillisecond);
 
+void BM_MaglevLoadBalancerChooseHost(benchmark::State& state) {
+  for (auto _ : state) {
+    // Do not time the creation of the table.
+    state.PauseTiming();
+    const uint64_t num_hosts = state.range(0);
+    const uint64_t keys_to_simulate = state.range(1);
+    BaseTester tester(num_hosts);
+    MaglevTable table(tester.priority_set_.getOrCreateHostSet(0).hosts());
+    std::unordered_map<std::string, uint64_t> hit_counter;
+    TestLoadBalancerContext context;
+    state.ResumeTiming();
+
+    // Note: To a certain extent this is benchmarking the performance of xxhash as well as
+    // std::unordered_map. However, it should be roughly equivalent to the work done when
+    // comparing different hashing algorithms.
+    for (uint64_t i = 0; i < keys_to_simulate; i++) {
+      context.hash_key_.value(
+          HashUtil::xxHash64(absl::string_view(reinterpret_cast<const char*>(&i), sizeof(i))));
+      hit_counter[table.chooseHost(&context)->address()->asString()] += 1;
+    }
+
+    // Do not time computation of mean, standard deviation, and relative standard deviation.
+    state.PauseTiming();
+    computeHitStats(state, hit_counter);
+    state.ResumeTiming();
+  }
+}
+BENCHMARK(BM_MaglevLoadBalancerChooseHost)
+    ->Args({100, 100000})
+    ->Args({200, 100000})
+    ->Args({500, 100000})
+    ->Unit(benchmark::kMillisecond);
+
+} // namespace
 } // namespace Upstream
 } // namespace Envoy
 

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -202,7 +202,8 @@ void BM_RingHashLoadBalancerHostLoss(benchmark::State& state) {
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       context.hash_key_.value(
           HashUtil::xxHash64(absl::string_view(reinterpret_cast<const char*>(&i), sizeof(i))));
-      hosts.push_back(lb->chooseHost(&context));;
+      hosts.push_back(lb->chooseHost(&context));
+      ;
     }
 
     RingHashTester tester2(num_hosts - hosts_to_lose, min_ring_size);
@@ -212,7 +213,8 @@ void BM_RingHashLoadBalancerHostLoss(benchmark::State& state) {
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       context.hash_key_.value(
           HashUtil::xxHash64(absl::string_view(reinterpret_cast<const char*>(&i), sizeof(i))));
-      hosts2.push_back(lb->chooseHost(&context));;
+      hosts2.push_back(lb->chooseHost(&context));
+      ;
     }
 
     ASSERT(hosts.size() == hosts2.size());
@@ -224,9 +226,9 @@ void BM_RingHashLoadBalancerHostLoss(benchmark::State& state) {
     }
 
     state.counters["percent_different"] =
-      (static_cast<double>(num_different_hosts) / hosts.size()) * 100;
+        (static_cast<double>(num_different_hosts) / hosts.size()) * 100;
     state.counters["host_loss_over_N_optimal"] =
-      (static_cast<double>(hosts_to_lose) / num_hosts) * 100;
+        (static_cast<double>(hosts_to_lose) / num_hosts) * 100;
   }
 }
 BENCHMARK(BM_RingHashLoadBalancerHostLoss)
@@ -248,7 +250,8 @@ void BM_MaglevLoadBalancerHostLoss(benchmark::State& state) {
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       context.hash_key_.value(
           HashUtil::xxHash64(absl::string_view(reinterpret_cast<const char*>(&i), sizeof(i))));
-      hosts.push_back(table.chooseHost(&context));;
+      hosts.push_back(table.chooseHost(&context));
+      ;
     }
 
     BaseTester tester2(num_hosts - hosts_to_lose);
@@ -257,7 +260,8 @@ void BM_MaglevLoadBalancerHostLoss(benchmark::State& state) {
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       context.hash_key_.value(
           HashUtil::xxHash64(absl::string_view(reinterpret_cast<const char*>(&i), sizeof(i))));
-      hosts2.push_back(table2.chooseHost(&context));;
+      hosts2.push_back(table2.chooseHost(&context));
+      ;
     }
 
     ASSERT(hosts.size() == hosts2.size());
@@ -269,9 +273,9 @@ void BM_MaglevLoadBalancerHostLoss(benchmark::State& state) {
     }
 
     state.counters["percent_different"] =
-      (static_cast<double>(num_different_hosts) / hosts.size()) * 100;
+        (static_cast<double>(num_different_hosts) / hosts.size()) * 100;
     state.counters["host_loss_over_N_optimal"] =
-      (static_cast<double>(hosts_to_lose) / num_hosts) * 100;
+        (static_cast<double>(hosts_to_lose) / num_hosts) * 100;
   }
 }
 BENCHMARK(BM_MaglevLoadBalancerHostLoss)
@@ -279,7 +283,6 @@ BENCHMARK(BM_MaglevLoadBalancerHostLoss)
     ->Args({500, 2, 10000})
     ->Args({500, 3, 10000})
     ->Unit(benchmark::kMillisecond);
-
 
 } // namespace
 } // namespace Upstream


### PR DESCRIPTION
This commit implements the Maglev consistent hash algorithm and a benchmark
around it to compare it to RingHash. This is not a full load balancer implementation
but it is enough to get an idea of the rough relative performance. The one
missing piece of data is a test/simulation of how many keys move when a host
is removed. The number of moved keys will be higher with Maglev than with Ketama.

*Risk Level*: None
*Testing*: Benchmark only
*Docs Changes*: N/A
*Release Notes*: N/A (will document when we add the feature)