### PR TITLE
ci: force checkout the filter example specified commit

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -86,7 +86,7 @@ then
 fi
 
 # This is the hash on https://github.com/envoyproxy/envoy-filter-example.git we pin to.
-(cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout 59a7fe50c1e13e9d18005c76224fdafdec31de74)
+(cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout -f 59a7fe50c1e13e9d18005c76224fdafdec31de74)
 cp -f "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/WORKSPACE
 
 # Also setup some space for building Envoy standalone.


### PR DESCRIPTION
A later stage in the script modifies WORKSPACE in the filter-example directory;
if this directory persists between builds, this may cause the checkout of
a particular commit to fail due to modified local workspace.

Signed-off-by: Greg Greenway <ggreenway@apple.com>

*Risk Level*: Low

*Testing*: Manually tested in broken scenario