### PR TITLE
Add cli flag '--disable-hot-restart'.

### DIFF
--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -137,6 +137,11 @@ public:
    * router/cluster/listener.
    */
   virtual uint64_t maxObjNameLength() PURE;
+
+  /**
+   * @return bool indicating whether the hot restart functionality has been disabled via cli flags.
+   */
+  virtual bool hotRestartDisabled() PURE;
 };
 
 } // namespace Server

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -92,6 +92,8 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_r
                                              " the cluster name)",
                                              false, ENVOY_DEFAULT_MAX_OBJ_NAME_LENGTH, "uint64_t",
                                              cmd);
+  TCLAP::SwitchArg disable_hot_restart("", "disable-hot-restart",
+                                       "Disable hot restart functionality", cmd, false);
 
   cmd.setExceptionHandling(false);
   try {
@@ -169,5 +171,6 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_r
   parent_shutdown_time_ = std::chrono::seconds(parent_shutdown_time_s.getValue());
   max_stats_ = max_stats.getValue();
   max_obj_name_length_ = max_obj_name_len.getValue();
+  hot_restart_disabled_ = disable_hot_restart.getValue();
 }
 } // namespace Envoy

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -46,6 +46,7 @@ public:
   const std::string& serviceZone() override { return service_zone_; }
   uint64_t maxStats() override { return max_stats_; }
   uint64_t maxObjNameLength() override { return max_obj_name_length_; }
+  bool hotRestartDisabled() override { return hot_restart_disabled_; }
 
 private:
   uint64_t base_id_;
@@ -66,6 +67,7 @@ private:
   Server::Mode mode_;
   uint64_t max_stats_;
   uint64_t max_obj_name_length_;
+  bool hot_restart_disabled_;
 };
 
 /**

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -53,6 +53,7 @@ public:
   const std::string& serviceZone() override { return service_zone_; }
   uint64_t maxStats() override { return 16384; }
   uint64_t maxObjNameLength() override { return 60; }
+  bool hotRestartDisabled() override { return false; }
 
 private:
   const std::string config_path_;

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -28,7 +28,9 @@ MockOptions::MockOptions(const std::string& config_path)
   ON_CALL(*this, logPath()).WillByDefault(ReturnRef(log_path_));
   ON_CALL(*this, maxStats()).WillByDefault(Return(1000));
   ON_CALL(*this, maxObjNameLength()).WillByDefault(Return(150));
-  ON_CALL(*this, hotRestartDisabled()).WillByDefault(ReturnPointee(&hot_restart_disabled_));
+  ON_CALL(*this, hotRestartDisabled()).WillByDefault(Invoke([this] {
+    return hot_restart_disabled_;
+  }));
 }
 MockOptions::~MockOptions() {}
 

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -28,6 +28,9 @@ MockOptions::MockOptions(const std::string& config_path)
   ON_CALL(*this, logPath()).WillByDefault(ReturnRef(log_path_));
   ON_CALL(*this, maxStats()).WillByDefault(Return(1000));
   ON_CALL(*this, maxObjNameLength()).WillByDefault(Return(150));
+  ON_CALL(*this, hotRestartDisabled()).WillByDefault(Invoke([this] {
+    return hot_restart_disabled_;
+  }));
 }
 MockOptions::~MockOptions() {}
 

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -28,9 +28,7 @@ MockOptions::MockOptions(const std::string& config_path)
   ON_CALL(*this, logPath()).WillByDefault(ReturnRef(log_path_));
   ON_CALL(*this, maxStats()).WillByDefault(Return(1000));
   ON_CALL(*this, maxObjNameLength()).WillByDefault(Return(150));
-  ON_CALL(*this, hotRestartDisabled()).WillByDefault(Invoke([this] {
-    return hot_restart_disabled_;
-  }));
+  ON_CALL(*this, hotRestartDisabled()).WillByDefault(ReturnPointee(&hot_restart_disabled_));
 }
 MockOptions::~MockOptions() {}
 

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -10,6 +10,7 @@
 using testing::Invoke;
 using testing::Return;
 using testing::ReturnNew;
+using testing::ReturnPointee;
 using testing::ReturnRef;
 using testing::SaveArg;
 using testing::_;
@@ -28,9 +29,7 @@ MockOptions::MockOptions(const std::string& config_path)
   ON_CALL(*this, logPath()).WillByDefault(ReturnRef(log_path_));
   ON_CALL(*this, maxStats()).WillByDefault(Return(1000));
   ON_CALL(*this, maxObjNameLength()).WillByDefault(Return(150));
-  ON_CALL(*this, hotRestartDisabled()).WillByDefault(Invoke([this] {
-    return hot_restart_disabled_;
-  }));
+  ON_CALL(*this, hotRestartDisabled()).WillByDefault(ReturnPointee(&hot_restart_disabled_));
 }
 MockOptions::~MockOptions() {}
 

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -62,6 +62,7 @@ public:
   MOCK_METHOD0(serviceZone, const std::string&());
   MOCK_METHOD0(maxStats, uint64_t());
   MOCK_METHOD0(maxObjNameLength, uint64_t());
+  MOCK_METHOD0(hotRestartDisabled, bool());
 
   std::string config_path_;
   bool v2_config_only_{};
@@ -70,6 +71,7 @@ public:
   std::string service_node_name_;
   std::string service_zone_name_;
   std::string log_path_;
+  bool hot_restart_disabled_{};
 };
 
 class MockAdmin : public Admin {

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -63,7 +63,7 @@ TEST(OptionsImplTest, All) {
       "envoy --mode validate --concurrency 2 -c hello --admin-address-path path --restart-epoch 1 "
       "--local-address-ip-version v6 -l info --service-cluster cluster --service-node node "
       "--service-zone zone --file-flush-interval-msec 9000 --drain-time-s 60 "
-      "--parent-shutdown-time-s 90 --log-path /foo/bar --v2-config-only");
+      "--parent-shutdown-time-s 90 --log-path /foo/bar --v2-config-only --disable-hot-restart");
   EXPECT_EQ(Server::Mode::Validate, options->mode());
   EXPECT_EQ(2U, options->concurrency());
   EXPECT_EQ("hello", options->configPath());
@@ -79,6 +79,7 @@ TEST(OptionsImplTest, All) {
   EXPECT_EQ(std::chrono::milliseconds(9000), options->fileFlushIntervalMsec());
   EXPECT_EQ(std::chrono::seconds(60), options->drainTime());
   EXPECT_EQ(std::chrono::seconds(90), options->parentShutdownTime());
+  EXPECT_EQ(true, options->hotRestartDisabled());
 }
 
 TEST(OptionsImplTest, DefaultParams) {
@@ -88,6 +89,7 @@ TEST(OptionsImplTest, DefaultParams) {
   EXPECT_EQ("", options->adminAddressPath());
   EXPECT_EQ(Network::Address::IpVersion::v4, options->localAddressIpVersion());
   EXPECT_EQ(Server::Mode::Serve, options->mode());
+  EXPECT_EQ(false, options->hotRestartDisabled());
 }
 
 TEST(OptionsImplTest, BadCliOption) {


### PR DESCRIPTION
hot restart: add cli flag to disable hot restart functionality

*Description*:
>This PR attempts to fix #2029 by adding a command line flag to disable hot restart. This can still be accomplished via the currently existing compile flag.

*Risk Level*: Low | Medium | High
>low

*Testing*:
> Unit testing

*Docs Changes*:
> N/A

*Release Notes*:
>TODO

Fixes #2029 

Signed-off-by: Tony Allen <tallen@lyft.com>