### PR TITLE
tools: exclude Bazel .cache from check_format.py.

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 
 EXCLUDED_PREFIXES = ("./generated/", "./thirdparty/", "./build", "./.git/",
-                     "./bazel-", "./bazel/external")
+                     "./bazel-", "./bazel/external", "./.cache")
 SUFFIXES = (".cc", ".h", "BUILD", ".md", ".rst")
 DOCS_SUFFIX = (".md", ".rst")
 


### PR DESCRIPTION
Signed-off-by: Harvey Tuch <htuch@google.com>