### PR TITLE
health_check: `scheme` header for gRPC HC requests

### DIFF
--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -121,6 +121,7 @@ envoy_cc_library(
         "//source/common/network:filter_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/redis:conn_pool_lib",
+        "//source/common/router:router_lib",
         "@envoy_api//envoy/api/v2/core:health_check_cc",
     ],
 )

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -24,6 +24,7 @@
 #include "common/http/utility.h"
 #include "common/protobuf/utility.h"
 #include "common/redis/conn_pool_impl.h"
+#include "common/router/router.h"
 #include "common/upstream/host_utility.h"
 
 namespace Envoy {
@@ -723,6 +724,7 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::onInterval() {
       parent_.service_method_.name());
   headers_message->headers().insertUserAgent().value().setReference(
       Http::Headers::get().UserAgentValues.EnvoyHealthChecker);
+  Router::FilterUtility::setUpstreamScheme(headers_message->headers(), *parent_.cluster_.info());
 
   request_encoder_->encodeHeaders(headers_message->headers(), false);
 

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -1819,6 +1819,9 @@ TEST_F(GrpcHealthCheckerImplTest, Success) {
         EXPECT_EQ(Http::Headers::get().ContentTypeValues.Grpc,
                   headers.ContentType()->value().c_str());
         EXPECT_EQ(std::string("/grpc.health.v1.Health/Check"), headers.Path()->value().c_str());
+        EXPECT_EQ(Http::Headers::get().SchemeValues.Http, headers.Scheme()->value().c_str());
+        EXPECT_TRUE(headers.Method());
+        EXPECT_TRUE(headers.Host());
       }));
   EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeData(_, true))
       .WillOnce(Invoke([&](Buffer::Instance& data, bool) {

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -1820,8 +1820,8 @@ TEST_F(GrpcHealthCheckerImplTest, Success) {
                   headers.ContentType()->value().c_str());
         EXPECT_EQ(std::string("/grpc.health.v1.Health/Check"), headers.Path()->value().c_str());
         EXPECT_EQ(Http::Headers::get().SchemeValues.Http, headers.Scheme()->value().c_str());
-        EXPECT_TRUE(headers.Method());
-        EXPECT_TRUE(headers.Host());
+        EXPECT_NE(nullptr, headers.Method());
+        EXPECT_NE(nullptr, headers.Host());
       }));
   EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeData(_, true))
       .WillOnce(Invoke([&](Buffer::Instance& data, bool) {


### PR DESCRIPTION
*Description*:
Fixes #2583. Add required `scheme` header to gRPC health check requests.

*Risk Level*: Low
Small bug fix or small optional feature.

*Testing*:
Unit tests should cover this.

*Docs Changes*:
N/A

*Release Notes*:
N/A

Fixes #2583