### PR TITLE
cluster: alt_stat_name functionality for clusters

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -71,7 +71,7 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
     ),
     envoy_api = dict(
-        commit = "4e533f22baced334c4aba68fb60c5fc439f0fe9c",
+        commit = "258bfddfddaad4d6a1da7b4476c98b060d57bcc1",
         remote = "https://github.com/envoyproxy/data-plane-api",
     ),
     grpc_httpjson_transcoding = dict(

--- a/source/common/config/cds_json.cc
+++ b/source/common/config/cds_json.cc
@@ -102,7 +102,9 @@ void CdsJson::translateCluster(const Json::Object& json_cluster,
   const std::string name = json_cluster.getString("name");
   Utility::checkObjNameLength("Invalid cluster name", name);
   cluster.set_name(name);
-
+  if (json_cluster.hasObject("alt_stat_name")) {
+    cluster.set_alt_stat_name(json_cluster.getString("alt_stat_name"));
+  }
   const std::string string_type = json_cluster.getString("type");
   auto set_dns_hosts = [&json_cluster, &cluster] {
     const auto hosts = json_cluster.getObjectArray("hosts");

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -1477,6 +1477,9 @@ const std::string Json::Schema::CLUSTER_SCHEMA(R"EOF(
         "type" : "string",
         "minLength" : 1
       },
+      "alt_stat_name" : {
+        "type" : "string"
+      },
       "type" : {
         "type" : "string",
         "enum" : ["static", "strict_dns", "logical_dns", "sds", "original_dst"]

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -120,7 +120,7 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
           std::chrono::milliseconds(PROTOBUF_GET_MS_REQUIRED(config, connect_timeout))),
       per_connection_buffer_limit_bytes_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, per_connection_buffer_limit_bytes, 1024 * 1024)),
-      stats_scope_(stats.createScope(fmt::format("cluster.{}.", name_))),
+      stats_scope_(stats.createScope(fmt::format("cluster.{}.", config.alt_stat_name().empty() ? name_ : config.alt_stat_name()))),
       stats_(generateStats(*stats_scope_)),
       load_report_stats_(generateLoadReportStats(load_report_stats_store_)),
       features_(parseFeatures(config)),


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*: Adds optional alternate stat name functionality while emitting stats.
*Risk Level*: Low
*Testing*: Added a test case for verification
*Docs Changes*: [Data Plane PR](https://github.com/envoyproxy/data-plane-api/pull/484)]
*Release Notes*: Updated
