### PR TITLE
Use Envoy::ProtobufTypes::String instead of std::string.

### DIFF
--- a/source/common/ext_authz/ext_authz_impl.cc
+++ b/source/common/ext_authz/ext_authz_impl.cc
@@ -144,8 +144,10 @@ void CreateCheckRequest::setHttpRequest(
   auto mutable_headers = httpreq.mutable_headers();
   headers.iterate(
       [](const Envoy::Http::HeaderEntry& e, void* ctx) {
-        Envoy::Protobuf::Map<::std::string, ::std::string>* mutable_headers =
-            static_cast<Envoy::Protobuf::Map<::std::string, ::std::string>*>(ctx);
+        Envoy::Protobuf::Map<Envoy::ProtobufTypes::String, Envoy::ProtobufTypes::String>*
+            mutable_headers = static_cast<
+                Envoy::Protobuf::Map<Envoy::ProtobufTypes::String, Envoy::ProtobufTypes::String>*>(
+                ctx);
         (*mutable_headers)[e.key().getString()] = e.value().getString();
         return Envoy::Http::HeaderMap::Iterate::Continue;
       },


### PR DESCRIPTION
Signed-off-by: Trevor Schroeder <trevors@google.com>
authz: string isn't always std::string so use the portable type.

Site-local string classes may not be std::string, so use the compatibility layer.

Risk Level: Low

Tested by running all bazel tests.