### PR TITLE
Fix the gzip filter to use ProtobufTypes::String.

### DIFF
--- a/source/common/http/filter/gzip_filter.cc
+++ b/source/common/http/filter/gzip_filter.cc
@@ -76,8 +76,8 @@ Compressor::ZlibCompressorImpl::CompressionStrategy GzipFilterConfig::compressio
   }
 }
 
-StringUtil::CaseUnorderedSet
-GzipFilterConfig::contentTypeSet(const Protobuf::RepeatedPtrField<std::string>& types) {
+StringUtil::CaseUnorderedSet GzipFilterConfig::contentTypeSet(
+    const Protobuf::RepeatedPtrField<Envoy::ProtobufTypes::String>& types) {
   return types.empty() ? StringUtil::CaseUnorderedSet(defaultContentEncoding().begin(),
                                                       defaultContentEncoding().end())
                        : StringUtil::CaseUnorderedSet(types.cbegin(), types.cend());


### PR DESCRIPTION
gzip: update gzip filter to use String compatibility.

*Description*: gzip uses std::string where it should use Protobuf::String for compatibility with those not using std::string.

*Risk Level*: Low 

*Testing*: Tested with standard bazel test ...