### PR TITLE
Mpuncel/hot restarter term passthrough

### DIFF
--- a/RAW_RELEASE_NOTES.md
+++ b/RAW_RELEASE_NOTES.md
@@ -66,4 +66,4 @@ final version.
 * Added `GEORADIUS_RO` and `GEORADIUSBYMEMBER_RO` to the Redis command splitter whitelist.
 * Added support for trusting additional hops in the X-Forwarded-For request header.
 * Added setting host header value for http health check request.
-
+* Added SIGTERM propagation to children to hot-restarter.py, which enables using it as a parent of containers.


### PR DESCRIPTION
*Title*: *Enable using hot-restarter.py as a parent of containers by propagating SIGTERM to children*

*Description*:
This PR modifies the way hot-restarter.py handles SIGTERM in order to make it suitable for running as the parent process of containers. It's important to send the SIGTERM along to the container because the envoy process isn't the direct child of hot-restarter.py, and sending SIGKILL to a container runner will leave container state on the host machine.

*Risk Level*: Low | Medium | High
High. If there's an issue with this PR, it could break hot restarting functionality.

*Testing*:
I verified this PR on a linux machine with `hot-restarter.py` configured to launch `runc` containers with envoy processes inside them. SIGTERM properly propagated the signal to `runc` which caused envoy and runc to exit, and left no container state on the machine, verified via `sudo runc list`.

I also verified this PR on MacOS by running `hot-restarter.py` with a "well-behaved" (exiting when it gets a TERM) subprocess, and confirmed that sending a SIGTERM to the `hot-restarter.py` process propagated the TERM to the child and printed the expected output.

I also ran `hot-restarter.py` with a "misbehaving" subprocess (ignores TERM and stays in an infinite loop) and verified that after 30 seconds a SIGKILL was issued, and saw the expected output.

I'm open to writing an integration test to verify all of this functionality, but could use some input from reviewers for how to accomplish this.

*Docs Changes*:
No doc changes, the docs actually already seem to claim that SIGTERM cleanly terminates children, however that seems to not be the actual case (unless SIGKILL is considered clean).

*Release Notes*:
```
* Added SIGTERM propagation to children to hot-restarter.py, which enables using it as a parent of containers.
```
