### PR TITLE
config: catch all exceptions from YAML parser

### DIFF
--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -745,14 +745,13 @@ ObjectSharedPtr Factory::loadFromYamlString(const std::string& yaml) {
     throw EnvoyException(e.what());
   } catch (YAML::BadConversion& e) {
     throw EnvoyException(e.what());
-  } catch (...) {
+  } catch (std::exception& e) {
     // There is a potentially wide space of exceptions thrown by the YAML parser,
     // and enumerating them all may be difficult. Envoy doesn't work well with
     // unhandled exceptions, so we capture them and record the exception name in
     // the Envoy Exception text.
     std::exception_ptr p = std::current_exception();
-    throw EnvoyException(std::string("Unexpected YAML exception: ") +
-                         p.__cxa_exception_type()->name());
+    throw EnvoyException(std::string("Unexpected YAML exception: ") + e.what());
   }
 }
 

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -746,19 +746,10 @@ ObjectSharedPtr Factory::loadFromYamlString(const std::string& yaml) {
   } catch (YAML::BadConversion& e) {
     throw EnvoyException(e.what());
   } catch (...) {
-    // When testing, I found this triggered when attempt to parse the
-    // contents of test/config/integration/server_ads.yaml, yielding
-    // this message:
-    //     Unexpected YAML exception:
-    //     N4YAML18TypedBadConversionINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE
-    // While this particular exception is now handled above, it
-    // appears that there's no complete list of exceptions that can be
-    // thrown in this YAML parser. The rest of Envoy doesn't deal well with
-    // unexpected exceptions, due to complex interlock between
-    // structures during construction. Constructing a Server::InstanceImpl requires
-    // an already-constructed Stats::ThreadLocalStoreImpl. But an uncaught exception thrown
-    // between their construction causes an assert in
-    // ThreadLocalStoreImpl's destructor.
+    // There is a potentially wide space of exceptions thrown by the YAML parser,
+    // and enumerating them all may be difficult. Envoy doesn't work well with
+    // unhandled exceptions, so we capture them and record the exception name in
+    // the Envoy Exception text.
     std::exception_ptr p = std::current_exception();
     throw EnvoyException(std::string("Unexpected YAML exception: ") +
                          p.__cxa_exception_type()->name());

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -753,12 +753,10 @@ ObjectSharedPtr Factory::loadFromYamlString(const std::string& yaml) {
     //     N4YAML18TypedBadConversionINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE
     // While this particular exception is now handled above, it
     // appears that there's no complete list of exceptions that can be
-    // thrown in JSON.  The rest of Envoy doesn't deal well with
+    // thrown in this YAML parser. The rest of Envoy doesn't deal well with
     // unexpected exceptions, due to complex interlock between
-    // structures during construction.  In particular,
-    // Server::InstanceImpl and Stats::ThreadLocalStoreImpl.  You need
-    // to construct a Stats::ThreadLocalStoreImpl before constructing
-    // a Server::InstanceImpl, but an uncaught exception thrown
+    // structures during construction. Constructing a Server::InstanceImpl requires
+    // an already-constructed Stats::ThreadLocalStoreImpl. But an uncaught exception thrown
     // between their construction causes an assert in
     // ThreadLocalStoreImpl's destructor.
     std::exception_ptr p = std::current_exception();

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -750,7 +750,7 @@ ObjectSharedPtr Factory::loadFromYamlString(const std::string& yaml) {
     // and enumerating them all may be difficult. Envoy doesn't work well with
     // unhandled exceptions, so we capture them and record the exception name in
     // the Envoy Exception text.
-    throw EnvoyException(fmt::format("Unexpected YAML exception: {}", + e.what()));
+    throw EnvoyException(fmt::format("Unexpected YAML exception: {}", +e.what()));
   }
 }
 

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -750,8 +750,7 @@ ObjectSharedPtr Factory::loadFromYamlString(const std::string& yaml) {
     // and enumerating them all may be difficult. Envoy doesn't work well with
     // unhandled exceptions, so we capture them and record the exception name in
     // the Envoy Exception text.
-    std::exception_ptr p = std::current_exception();
-    throw EnvoyException(std::string("Unexpected YAML exception: ") + e.what());
+    throw EnvoyException(fmt::format("Unexpected YAML exception: {}", + e.what()));
   }
 }
 

--- a/test/common/json/json_loader_test.cc
+++ b/test/common/json/json_loader_test.cc
@@ -481,8 +481,7 @@ admin:
     exception_text = e.what();
   }
   EXPECT_TRUE(exception_caught);
-  EXPECT_TRUE(exception_text.find("bad conversion") != std::string::npos)
-      << exception_text;
+  EXPECT_TRUE(exception_text.find("bad conversion") != std::string::npos) << exception_text;
 }
 
 } // namespace Json

--- a/test/common/json/json_loader_test.cc
+++ b/test/common/json/json_loader_test.cc
@@ -465,6 +465,8 @@ admin:
   }
   EXPECT_TRUE(exception_caught);
   EXPECT_TRUE(exception_text.find("bad conversion") != std::string::npos) << exception_text;
+  EXPECT_TRUE(exception_text.find("Unexpected YAML exception") == std::string::npos)
+      << exception_text;
 }
 
 } // namespace Json

--- a/test/common/json/json_loader_test.cc
+++ b/test/common/json/json_loader_test.cc
@@ -447,12 +447,6 @@ TEST(JsonLoaderTest, YamlObject) {
 
 TEST(JsonLoaderTest, BadYamlException) {
   std::string bad_yaml = R"EOF(
-dynamic_resources:
-  lds_config: {ads: {}}
-  cds_config: {ads: {}}
-  ads_config:
-    api_type: GRPC
-    cluster_name: [ads_cluster]
 static_resources:
   clusters:
   - name: ads_cluster

--- a/test/common/json/json_loader_test.cc
+++ b/test/common/json/json_loader_test.cc
@@ -455,18 +455,10 @@ admin:
       port_value: 0
 )EOF";
 
-  bool exception_caught = false;
-  std::string exception_text;
-  try {
-    const Json::ObjectSharedPtr json = Json::Factory::loadFromYamlString(bad_yaml);
-  } catch (const EnvoyException& e) {
-    exception_caught = true;
-    exception_text = e.what();
-  }
-  EXPECT_TRUE(exception_caught);
-  EXPECT_TRUE(exception_text.find("bad conversion") != std::string::npos) << exception_text;
-  EXPECT_TRUE(exception_text.find("Unexpected YAML exception") == std::string::npos)
-      << exception_text;
+  EXPECT_THROW_WITH_REGEX(Json::Factory::loadFromYamlString(bad_yaml), EnvoyException,
+                            "bad conversion");
+  EXPECT_THROW_WITHOUT_REGEX(Json::Factory::loadFromYamlString(bad_yaml), EnvoyException,
+                            "Unexpected YAML exception");
 }
 
 } // namespace Json

--- a/test/common/json/json_loader_test.cc
+++ b/test/common/json/json_loader_test.cc
@@ -447,17 +447,6 @@ TEST(JsonLoaderTest, YamlObject) {
 
 TEST(JsonLoaderTest, BadYamlException) {
   std::string bad_yaml = R"EOF(
-static_resources:
-  clusters:
-  - name: ads_cluster
-    connect_timeout: { seconds: 5 }
-    type: STATIC
-    hosts:
-    - socket_address:
-        address: {{ ntop_ip_loopback_address }}
-        port_value: {{ ads_upstream }}
-    lb_policy: ROUND_ROBIN
-    http2_protocol_options: {}
 admin:
   access_log_path: /dev/null
   address:

--- a/test/common/json/json_loader_test.cc
+++ b/test/common/json/json_loader_test.cc
@@ -456,9 +456,9 @@ admin:
 )EOF";
 
   EXPECT_THROW_WITH_REGEX(Json::Factory::loadFromYamlString(bad_yaml), EnvoyException,
-                            "bad conversion");
+                          "bad conversion");
   EXPECT_THROW_WITHOUT_REGEX(Json::Factory::loadFromYamlString(bad_yaml), EnvoyException,
-                            "Unexpected YAML exception");
+                             "Unexpected YAML exception");
 }
 
 } // namespace Json

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -43,6 +43,14 @@ namespace Envoy {
     EXPECT_THAT(e.what(), ::testing::ContainsRegex(regex_str));                                    \
   }
 
+#define EXPECT_THROW_WITHOUT_REGEX(statement, expected_exception, regex_str)                       \
+  try {                                                                                            \
+    statement;                                                                                     \
+    ADD_FAILURE() << "Exception should take place. It did not.";                                   \
+  } catch (expected_exception & e) {                                                               \
+    EXPECT_THAT(e.what(), ::testing::Not(::testing::ContainsRegex(regex_str)));                    \
+  }
+
 #define VERBOSE_EXPECT_NO_THROW(statement)                                                         \
   try {                                                                                            \
     statement;                                                                                     \


### PR DESCRIPTION
*Description*:
YAML can throw a fairly wide variety of exceptions.  Unhandled exceptions are not handled well by the Envoy codebase in general, e.g. ThreadLocalStoreImpl will assert-fail if it's destructed right after it's constructed, which can happen with an exception.

*Risk Level*: Low

*Testing*:
//test/...
New unit test to cover type-conversion exception.
