### PR TITLE
bazel: Remove dead link from EXTERANL_DEPS.md

### DIFF
--- a/bazel/EXTERNAL_DEPS.md
+++ b/bazel/EXTERNAL_DEPS.md
@@ -32,9 +32,7 @@ for details on Bazel's shell extensions.
 
 Dependencies between external libraries can use the standard Bazel dependency
 resolution logic, using the `$(location)` shell extension to resolve paths
-to binaries, libraries, headers, etc. See
-[`bazel/external/lightstep.genrule_cmd`](external/lightstep.genrule_cmd) for
-an example.
+to binaries, libraries, headers, etc.
 
 # Adding external dependencies to Envoy (build recipe)
 


### PR DESCRIPTION
*Description*:
Found a dead link in one of the readmes, this just deletes it since I couldn't immediately see another working example. If one exists, I'd be happy to point the readme to that instead.

*Risk Level*: None
Internal documentation change

*Testing*:
n/a

*Docs Changes*:
n/a

*Release Notes*:
n/a
