### PR TITLE
WIP server: resolve tsan failure due to main_common refactor

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -63,6 +63,10 @@
   NiceMock for mocks whose behavior is not the focus of a test.
 * There are probably a few other things missing from this list. We will add them as they
   are brought to our attention.
+* [Thread
+  annotations](https://github.com/abseil/abseil-cpp/blob/master/absl/base/thread_annotations.h),
+  such as `GUARDED_BY`, should be used for shared state guarded by
+  locks/mutexes.
 
 # Error handling
 

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -110,6 +110,12 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "thread_annotations",
+    hdrs = ["thread_annotations.h"],
+    external_deps = ["abseil_base"],
+)
+
+envoy_cc_library(
     name = "thread_lib",
     srcs = ["thread.cc"],
     hdrs = ["thread.h"],

--- a/source/common/common/thread_annotations.h
+++ b/source/common/common/thread_annotations.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// NOLINT(namespace-envoy)
+
+#include "absl/base/thread_annotations.h"
+
+#ifdef __APPLE__
+#undef THREAD_ANNOTATION_ATTRIBUTE__
+// See #2571, we get problematic warnings on Clang + OS X.
+#define THREAD_ANNOTATION_ATTRIBUTE__(x) // no-op
+#endif

--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -85,6 +85,7 @@ envoy_cc_library(
         "//include/envoy/thread_local:thread_local_interface",
         "//source/common/common:empty_string",
         "//source/common/common:linked_object",
+        "//source/common/common:thread_annotations",
         "//source/common/common:thread_lib",
         "//source/common/tracing:http_tracer_lib",
     ],

--- a/source/common/grpc/google_async_client_impl.h
+++ b/source/common/grpc/google_async_client_impl.h
@@ -8,6 +8,7 @@
 
 #include "common/common/linked_object.h"
 #include "common/common/thread.h"
+#include "common/common/thread_annotations.h"
 #include "common/tracing/http_tracer_impl.h"
 
 #include "grpc++/generic/generic_stub.h"
@@ -289,7 +290,8 @@ private:
   uint32_t inflight_tags_{};
   // Queue of completed (op, ok) passed from completionThread() to
   // handleOpCompletion().
-  std::deque<std::pair<GoogleAsyncTag::Operation, bool>> completed_ops_;
+  std::deque<std::pair<GoogleAsyncTag::Operation, bool>>
+      completed_ops_ GUARDED_BY(completed_ops_lock_);
   std::mutex completed_ops_lock_;
 
   friend class GoogleAsyncClientImpl;

--- a/source/exe/main_common.h
+++ b/source/exe/main_common.h
@@ -31,6 +31,7 @@ protected:
   Envoy::OptionsImpl& options_;
   ProdComponentFactory component_factory_;
   DefaultTestHooks default_test_hooks_;
+  Network::Address::InstanceConstSharedPtr local_address_;
   std::unique_ptr<ThreadLocal::InstanceImpl> tls_;
   std::unique_ptr<Server::HotRestart> restarter_;
   std::unique_ptr<Stats::ThreadLocalStoreImpl> stats_store_;

--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -91,7 +91,7 @@ do
   echo "Checking for match of --hot-restart-version and admin /hot_restart_version"
   ADMIN_ADDRESS_0=$(cat "${ADMIN_ADDRESS_PATH_0}")
   ADMIN_HOT_RESTART_VERSION=$(curl -sg http://${ADMIN_ADDRESS_0}/hot_restart_version)
-  CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version 2>&1)
+  CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version --base-id "${BASE_ID}" 2>&1)
   if [[ "${ADMIN_HOT_RESTART_VERSION}" != "${CLI_HOT_RESTART_VERSION}" ]]; then
       echo "Hot restart version mismatch: ${ADMIN_HOT_RESTART_VERSION} != " \
            "${CLI_HOT_RESTART_VERSION}"
@@ -99,7 +99,7 @@ do
   fi
 
   echo "Checking max-obj-name-len"
-  CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version --max-obj-name-len 1234 2>&1)
+  CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version --max-obj-name-len 1234 --base-id "${BASE_ID}" 2>&1)
   if [[ "${ADMIN_HOT_RESTART_VERSION}" = "${CLI_HOT_RESTART_VERSION}" ]]; then
       echo "Hot restart version match when it should mismatch: ${ADMIN_HOT_RESTART_VERSION} == " \
            "${CLI_HOT_RESTART_VERSION}"
@@ -107,7 +107,7 @@ do
   fi
 
   echo "Checking max-stats"
-  CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version --max-stats 12345 2>&1)
+  CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version --max-stats 12345 --base-id "${BASE_ID}" 2>&1)
   if [[ "${ADMIN_HOT_RESTART_VERSION}" = "${CLI_HOT_RESTART_VERSION}" ]]; then
       echo "Hot restart version match when it should mismatch: ${ADMIN_HOT_RESTART_VERSION} == " \
            "${CLI_HOT_RESTART_VERSION}"
@@ -177,7 +177,7 @@ set +e
 disableHeapCheck
 
 echo "Launching envoy with no parameters. Check the exit value is 1"
-${ENVOY_BIN}
+${ENVOY_BIN} --base_id "${BASE_ID}"
 EXIT_CODE=$?
 # The test should fail if the Envoy binary exits with anything other than 1.
 if [[ $EXIT_CODE -ne 1 ]]; then


### PR DESCRIPTION
*Description*:
Replace the call to ```Logger::Registry::initialize(options_.logLevel(), log_lock);``` which had been removed in the earlier refactor, and resulted in the logger being functional but not thread-safe, hence tsan errors.

Note that this incorporates #2609 to allow parallel testing of test/integration:hotrestart_test.

Also note that this branch incorporates #2568 but not the rollback of it in #2613 so it can't be merged as is, but it's probably easier to review this way.

*Risk Level*: Medium

*Testing*:
bazel test --compilation_mode=dbg --config=tsan test/integration:hotrestart_test --runs_per_test=100

*Release Notes*: n/a
