### PR TITLE
build: update rules_go and data-plane-api

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,5 +14,3 @@ load("@com_lyft_protoc_gen_validate//bazel:go_proto_library.bzl", "go_proto_repo
 go_proto_repositories(shared=0)
 go_rules_dependencies()
 go_register_toolchains()
-load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
-proto_register_toolchains()

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -79,7 +79,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/grpc-ecosystem/grpc-httpjson-transcoding",
     ),
     io_bazel_rules_go = dict(
-        commit = "4374be38e9a75ff5957c3922adb155d32086fe14",
+        commit = "0.9.0",
         remote = "https://github.com/bazelbuild/rules_go",
     ),
     # I'd love to name this `com_github_google_subpar`, but something in the Subpar


### PR DESCRIPTION
*title*: build: update rules_go and data-plane-api

*Description*:
This updates rules_go to 0.9.0 in order to bring in
https://github.com/bazelbuild/rules_go/commit/812c172b921cafaa27a58bba2d2cd37ace296b88
which is necessary in order to build envoy from behind a proxy.

Updating data-plane-api is necessary in order to to update the version
of protoc-gen-validate to a version that includes https://github.com/lyft/protoc-gen-validate/commit/3204975f8145b7d187081b7034060012ae838d17

*Risk Level*: Low
This only modifies build dependencies. Only risk I can imagine is incompatible protos being brought in by data-plane-api, but I'd imagine code review in that repo would have prevented that. 

*Testing*:

Ran the tests on OS X. I also successfully built `//source/exe:envoy-static` on Centos 7 behind a proxy (after specifying HTTP(S)_PROXY) in order to verify that this fixes https://github.com/envoyproxy/envoy/issues/2578. 

*Docs Changes*:
n/a

*Release Notes*:
n/a

[Optional Fixes #Issue]
This should address https://github.com/envoyproxy/envoy/issues/2578
