### PR TITLE
#2620 Allow to Set Hash and By in Client Cert Details

### DIFF
--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -210,8 +210,8 @@ void FilterJson::translateHttpConnectionManager(
           StringUtil::toUpper(json_config.getString("forward_client_cert", "sanitize")),
           &fcc_details);
   proto_config.set_forward_client_cert_details(fcc_details);
-    proto_config.mutable_set_current_client_cert_details()->mutable_by()->set_value(true);
-    proto_config.mutable_set_current_client_cert_details()->mutable_hash()->set_value(true);
+  proto_config.mutable_set_current_client_cert_details()->mutable_by()->set_value(true);
+  proto_config.mutable_set_current_client_cert_details()->mutable_hash()->set_value(true);
   for (const std::string& detail :
        json_config.getStringArray("set_current_client_cert_details", true)) {
     if (detail == "By") {

--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -210,9 +210,16 @@ void FilterJson::translateHttpConnectionManager(
           StringUtil::toUpper(json_config.getString("forward_client_cert", "sanitize")),
           &fcc_details);
   proto_config.set_forward_client_cert_details(fcc_details);
-
+    proto_config.mutable_set_current_client_cert_details()->mutable_by()->set_value(true);
+    proto_config.mutable_set_current_client_cert_details()->mutable_hash()->set_value(true);
   for (const std::string& detail :
        json_config.getStringArray("set_current_client_cert_details", true)) {
+    if (detail == "By") {
+      proto_config.mutable_set_current_client_cert_details()->mutable_by()->set_value(false);
+    }
+    if (detail == "Hash") {
+      proto_config.mutable_set_current_client_cert_details()->mutable_hash()->set_value(false);
+    }
     if (detail == "Subject") {
       proto_config.mutable_set_current_client_cert_details()->mutable_subject()->set_value(true);
     } else {

--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -212,6 +212,7 @@ void FilterJson::translateHttpConnectionManager(
   proto_config.set_forward_client_cert_details(fcc_details);
   proto_config.mutable_set_current_client_cert_details()->mutable_by()->set_value(true);
   proto_config.mutable_set_current_client_cert_details()->mutable_hash()->set_value(true);
+  proto_config.mutable_set_current_client_cert_details()->mutable_san()->set_value(true);
   for (const std::string& detail :
        json_config.getStringArray("set_current_client_cert_details", true)) {
     if (detail == "By") {
@@ -222,9 +223,7 @@ void FilterJson::translateHttpConnectionManager(
     }
     if (detail == "Subject") {
       proto_config.mutable_set_current_client_cert_details()->mutable_subject()->set_value(true);
-    } else {
-      ASSERT(detail == "SAN");
-      proto_config.mutable_set_current_client_cert_details()->mutable_san()->set_value(true);
+      proto_config.mutable_set_current_client_cert_details()->mutable_san()->set_value(false);
     }
   }
 }

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -162,7 +162,7 @@ enum class ForwardClientCertType {
  * Configuration for the fields of the client cert, used for populating the current client cert
  * information to the next hop.
  */
-enum class ClientCertDetailsType { Cert, Subject, SAN };
+enum class ClientCertDetailsType { Cert, Subject, SAN, By, Hash };
 
 /**
  * Abstract configuration for the connection manager.

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -208,13 +208,13 @@ void ConnectionManagerUtility::mutateXfccRequestHeader(Http::HeaderMap& request_
         if (!uri_san_local_cert.empty()) {
           client_cert_details.push_back("By=" + uri_san_local_cert);
         }
-      break;
+        break;
       case Http::ClientCertDetailsType::Hash:
         const std::string cert_digest = connection.ssl()->sha256PeerCertificateDigest();
         if (!cert_digest.empty()) {
           client_cert_details.push_back("Hash=" + cert_digest);
         }
-      break;
+        break;
       case Http::ClientCertDetailsType::Subject:
         // The "Subject" key still exists even if the subject is empty.
         client_cert_details.push_back("Subject=\"" + connection.ssl()->subjectPeerCertificate() +

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -204,31 +204,44 @@ void ConnectionManagerUtility::mutateXfccRequestHeader(Http::HeaderMap& request_
     for (const auto& detail : config.setCurrentClientCertDetails()) {
       switch (detail) {
       case Http::ClientCertDetailsType::By:
-        const std::string uri_san_local_cert = connection.ssl()->uriSanLocalCertificate();
-        if (!uri_san_local_cert.empty()) {
-          client_cert_details.push_back("By=" + uri_san_local_cert);
+        {
+          const std::string uri_san_local_cert = connection.ssl()->uriSanLocalCertificate();
+          if (!uri_san_local_cert.empty()) {
+            client_cert_details.push_back("By=" + uri_san_local_cert);
+          }
         }
         break;
       case Http::ClientCertDetailsType::Hash:
-        const std::string cert_digest = connection.ssl()->sha256PeerCertificateDigest();
-        if (!cert_digest.empty()) {
-          client_cert_details.push_back("Hash=" + cert_digest);
+        {
+          const std::string cert_digest = connection.ssl()->sha256PeerCertificateDigest();
+          if (!cert_digest.empty()) {
+            client_cert_details.push_back("Hash=" + cert_digest);
+          }
         }
+
         break;
       case Http::ClientCertDetailsType::Subject:
-        // The "Subject" key still exists even if the subject is empty.
-        client_cert_details.push_back("Subject=\"" + connection.ssl()->subjectPeerCertificate() +
-                                      "\"");
+        {
+          // The "Subject" key still exists even if the subject is empty.
+          client_cert_details.push_back("Subject=\"" + connection.ssl()->subjectPeerCertificate() +
+                                        "\"");
+        }
+
         break;
       case Http::ClientCertDetailsType::SAN:
-        // Currently, we only support a single SAN field with URI type.
-        // The "SAN" key still exists even if the SAN is empty.
-        client_cert_details.push_back("SAN=" + connection.ssl()->uriSanPeerCertificate());
+        {
+          // Currently, we only support a single SAN field with URI type.
+          // The "SAN" key still exists even if the SAN is empty.
+          client_cert_details.push_back("SAN=" + connection.ssl()->uriSanPeerCertificate());
+        }
         break;
+
       case Http::ClientCertDetailsType::Cert:
-        const std::string peer_cert = connection.ssl()->urlEncodedPemEncodedPeerCertificate();
-        if (!peer_cert.empty()) {
-          client_cert_details.push_back("Cert=\"" + peer_cert + "\"");
+        {
+          const std::string peer_cert = connection.ssl()->urlEncodedPemEncodedPeerCertificate();
+          if (!peer_cert.empty()) {
+            client_cert_details.push_back("Cert=\"" + peer_cert + "\"");
+          }
         }
         break;
       }

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -201,16 +201,20 @@ void ConnectionManagerUtility::mutateXfccRequestHeader(Http::HeaderMap& request_
   // the XFCC header.
   if (config.forwardClientCert() == Http::ForwardClientCertType::AppendForward ||
       config.forwardClientCert() == Http::ForwardClientCertType::SanitizeSet) {
-    const std::string uri_san_local_cert = connection.ssl()->uriSanLocalCertificate();
-    if (!uri_san_local_cert.empty()) {
-      client_cert_details.push_back("By=" + uri_san_local_cert);
-    }
-    const std::string cert_digest = connection.ssl()->sha256PeerCertificateDigest();
-    if (!cert_digest.empty()) {
-      client_cert_details.push_back("Hash=" + cert_digest);
-    }
     for (const auto& detail : config.setCurrentClientCertDetails()) {
       switch (detail) {
+      case Http::ClientCertDetailsType::By:
+        const std::string uri_san_local_cert = connection.ssl()->uriSanLocalCertificate();
+        if (!uri_san_local_cert.empty()) {
+          client_cert_details.push_back("By=" + uri_san_local_cert);
+        }
+      break;
+      case Http::ClientCertDetailsType::Hash:
+        const std::string cert_digest = connection.ssl()->sha256PeerCertificateDigest();
+        if (!cert_digest.empty()) {
+          client_cert_details.push_back("Hash=" + cert_digest);
+        }
+      break;
       case Http::ClientCertDetailsType::Subject:
         // The "Subject" key still exists even if the subject is empty.
         client_cert_details.push_back("Subject=\"" + connection.ssl()->subjectPeerCertificate() +

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -354,7 +354,7 @@ const std::string Json::Schema::HTTP_CONN_NETWORK_FILTER_SCHEMA(R"EOF(
           "uniqueItems": true,
           "items" : {
               "type" : "string",
-              "enum" : ["Subject", "SAN"]
+              "enum" : ["Subject", "SAN", "By", "Hash"]
           }
       },
       "generate_request_id" : {"type" : "boolean"}


### PR DESCRIPTION
Signed-off-by: Robert Tindell <tim.tindell@gmail.com>

*Title*: *XFCC set_current_client_details: Allow to set "Hash" and "By"*

*Description*:
>When using Envoy for client-cert proxy authentication, it would be useful to be able to specify whether to set or not to set the Hash and the By field. This could be facilitated using the set_current_client_details configuration. 
 
*Example Use Case*:

>We have a backend application that cannot parse parts of the XFCC header, rather you can only set the name of the header that contains the CN.  The use of x-forwarded-client-cert in this case would be as the username. The Hash would make adding users to the application difficult as the hash would need to be known by the backend application.

*Proposed Solution*:

>The proposed solution would be to add "Hash" and "By" to the settable cert details with set_current_client_details configuration. Both of these configurations would be set to True by Default. Example:
```
{
  "subject": "{...}",
  "san": "{...}",
  "hash": "{...}",
  "by": "{...}"
}
```
| Name    | Type         | Description                                                             | Default |
|----------|------------|-------------------------------------------------------|-------|
| subject  | BoolValue | Whether to forward the subject of the client cert  | false |
| san        | BoolValue | Whether to forward the SAN of the client cert      | false |
| hash      | BoolValue | Whether to forward the Hash of the client cert     | true  |
| by          |BoolValue  | Whether to forward the By of the client cert         | true  |
