### PR TITLE
ssl: fix handshake hang that manifested on OS X.

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -275,6 +275,13 @@ void ConnectionImpl::raiseEvent(ConnectionEvent event) {
     // connected events.
     callback->onEvent(event);
   }
+  // We may have pending data in the write buffer on transport handshake
+  // completion, which may also have completed in the context of onReadReady(),
+  // where no check of the write buffer is made. Provide an opportunity to flush
+  // here. If connection write is not ready, this is harmless.
+  if (event == ConnectionEvent::Connected && write_buffer_->length() > 0) {
+    onWriteReady();
+  }
 }
 
 bool ConnectionImpl::readEnabled() const { return read_enabled_; }

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -270,17 +270,17 @@ void ConnectionImpl::readDisable(bool disable) {
 }
 
 void ConnectionImpl::raiseEvent(ConnectionEvent event) {
-  for (ConnectionCallbacks* callback : callbacks_) {
-    // TODO(mattklein123): If we close while raising a connected event we should not raise further
-    // connected events.
-    callback->onEvent(event);
-  }
   // We may have pending data in the write buffer on transport handshake
   // completion, which may also have completed in the context of onReadReady(),
   // where no check of the write buffer is made. Provide an opportunity to flush
   // here. If connection write is not ready, this is harmless.
   if (event == ConnectionEvent::Connected && write_buffer_->length() > 0) {
     onWriteReady();
+  }
+  for (ConnectionCallbacks* callback : callbacks_) {
+    // TODO(mattklein123): If we close while raising a connected event we should not raise further
+    // connected events.
+    callback->onEvent(event);
   }
 }
 

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -270,17 +270,19 @@ void ConnectionImpl::readDisable(bool disable) {
 }
 
 void ConnectionImpl::raiseEvent(ConnectionEvent event) {
-  // We may have pending data in the write buffer on transport handshake
-  // completion, which may also have completed in the context of onReadReady(),
-  // where no check of the write buffer is made. Provide an opportunity to flush
-  // here. If connection write is not ready, this is harmless.
-  if (event == ConnectionEvent::Connected && write_buffer_->length() > 0) {
-    onWriteReady();
-  }
   for (ConnectionCallbacks* callback : callbacks_) {
     // TODO(mattklein123): If we close while raising a connected event we should not raise further
     // connected events.
     callback->onEvent(event);
+  }
+  // We may have pending data in the write buffer on transport handshake
+  // completion, which may also have completed in the context of onReadReady(),
+  // where no check of the write buffer is made. Provide an opportunity to flush
+  // here. If connection write is not ready, this is harmless. We should only do
+  // this if we're still open (the above callbacks may have closed).
+  if (state() == State::Open && event == ConnectionEvent::Connected &&
+      write_buffer_->length() > 0) {
+    onWriteReady();
   }
 }
 

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1137,7 +1137,7 @@ TEST_F(MockTransportConnectionImplTest, WriteReadyOnConnected) {
   Buffer::OwnedImpl buffer(val);
   EXPECT_CALL(*file_event_, activate(Event::FileReadyType::Write)).WillOnce(Invoke(file_ready_cb_));
   EXPECT_CALL(*transport_socket_, doWrite(BufferStringEqual(val), false))
-      .WillOnce(Return(IoResult{PostIoAction::KeepOpen, 100, false}));
+      .WillOnce(Return(IoResult{PostIoAction::KeepOpen, 0, false}));
   connection_->write(buffer, false);
 
   // A read event happens, resulting in handshake completion and

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -842,6 +842,10 @@ public:
     EXPECT_CALL(dispatcher_, createFileEvent_(0, _, _, _))
         .WillOnce(DoAll(SaveArg<1>(&file_ready_cb_), Return(file_event_)));
     transport_socket_ = new NiceMock<MockTransportSocket>;
+    EXPECT_CALL(*transport_socket_, setTransportSocketCallbacks(_))
+        .WillOnce(Invoke([this](TransportSocketCallbacks& callbacks) {
+          transport_socket_callbacks_ = &callbacks;
+        }));
     connection_.reset(
         new ConnectionImpl(dispatcher_, std::make_unique<ConnectionSocketImpl>(0, nullptr, nullptr),
                            TransportSocketPtr(transport_socket_), true));
@@ -861,9 +865,10 @@ public:
   std::unique_ptr<ConnectionImpl> connection_;
   Event::MockDispatcher dispatcher_;
   NiceMock<MockConnectionCallbacks> callbacks_;
-  NiceMock<MockTransportSocket>* transport_socket_;
+  MockTransportSocket* transport_socket_;
   Event::MockFileEvent* file_event_;
   Event::FileReadyCb file_ready_cb_;
+  TransportSocketCallbacks* transport_socket_callbacks_;
 };
 
 // Test that BytesSentCb is invoked at the correct times
@@ -1120,6 +1125,33 @@ TEST_F(MockTransportConnectionImplTest, WriteEndStreamStopIteration) {
       .WillOnce(Return(FilterStatus::Continue));
   EXPECT_CALL(*file_event_, activate(Event::FileReadyType::Write));
   connection_->write(buffer, true);
+}
+
+// Validate that when the transport signals ConnectionEvent::Connected, that we
+// check for pending write buffer content.
+TEST_F(MockTransportConnectionImplTest, WriteReadyOnConnected) {
+  InSequence s;
+
+  // Queue up some data in write buffer, simulating what happens in SSL handshake.
+  const std::string val("some data");
+  Buffer::OwnedImpl buffer(val);
+  EXPECT_CALL(*file_event_, activate(Event::FileReadyType::Write)).WillOnce(Invoke(file_ready_cb_));
+  EXPECT_CALL(*transport_socket_, doWrite(BufferStringEqual(val), false))
+      .WillOnce(Return(IoResult{PostIoAction::KeepOpen, 100, false}));
+  connection_->write(buffer, false);
+
+  // A read event happens, resulting in handshake completion and
+  // raiseEvent(Network::ConnectionEvent::Connected). Since we have data queued
+  // in the write buffer, we should see a doWrite with this data.
+  EXPECT_CALL(*transport_socket_, doRead(_)).WillOnce(InvokeWithoutArgs([this] {
+    transport_socket_callbacks_->raiseEvent(Network::ConnectionEvent::Connected);
+    return IoResult{PostIoAction::KeepOpen, 100, false};
+  }));
+  EXPECT_CALL(*transport_socket_, doWrite(BufferStringEqual(val), false))
+      .WillOnce(Return(IoResult{PostIoAction::KeepOpen, 100, false}));
+  EXPECT_CALL(*transport_socket_, doWrite(_, true))
+      .WillOnce(Return(IoResult{PostIoAction::KeepOpen, 0, true}));
+  file_ready_cb_(Event::FileReadyType::Read);
 }
 
 class ReadBufferLimitTest : public ConnectionImplTest {

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1145,13 +1145,13 @@ TEST_F(MockTransportConnectionImplTest, WriteReadyOnConnected) {
   // in the write buffer, we should see a doWrite with this data.
   EXPECT_CALL(*transport_socket_, doRead(_)).WillOnce(InvokeWithoutArgs([this] {
     transport_socket_callbacks_->raiseEvent(Network::ConnectionEvent::Connected);
-    return IoResult{PostIoAction::KeepOpen, 100, false};
+    return IoResult{PostIoAction::KeepOpen, 0, false};
   }));
   EXPECT_CALL(*transport_socket_, doWrite(BufferStringEqual(val), false))
-      .WillOnce(Return(IoResult{PostIoAction::KeepOpen, 100, false}));
+      .WillOnce(Return(IoResult{PostIoAction::KeepOpen, 0, false}));
+  file_ready_cb_(Event::FileReadyType::Read);
   EXPECT_CALL(*transport_socket_, doWrite(_, true))
       .WillOnce(Return(IoResult{PostIoAction::KeepOpen, 0, true}));
-  file_ready_cb_(Event::FileReadyType::Read);
 }
 
 class ReadBufferLimitTest : public ConnectionImplTest {


### PR DESCRIPTION
When a handshake completed in transport socket doRead(), we didn't check
to see if there were any pending bytes in the write buffer in
Network::ConnectionImpl. This showed up in #2598, where
ads_integration_test would hang while waiting for the server to connect
to the fake management upstream.

Risk Level: Medium (messing around with connection handshaking can do
bad things).
Testing: Additional unit test for ConnectionImpl changes. Validated
ads_integration_test now passes on OS X.

Signed-off-by: Harvey Tuch <htuch@google.com>