### PR TITLE
grpc: service-wide intial metadata.

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -71,8 +71,8 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
     ),
     envoy_api = dict(
-        commit = "258bfddfddaad4d6a1da7b4476c98b060d57bcc1",
-        remote = "https://github.com/envoyproxy/data-plane-api",
+        commit = "7d60aec93412f65768bb98cec6a9efb39956f197", # DO NOT SUBMIT
+        remote = "https://github.com/htuch/envoy-api",       # DO NOT SUBMIT
     ),
     grpc_httpjson_transcoding = dict(
         commit = "e4f58aa07b9002befa493a0a82e10f2e98b51fc6",

--- a/source/common/grpc/async_client_impl.h
+++ b/source/common/grpc/async_client_impl.h
@@ -14,7 +14,7 @@ class AsyncStreamImpl;
 
 class AsyncClientImpl final : public AsyncClient {
 public:
-  AsyncClientImpl(Upstream::ClusterManager& cm, const std::string& remote_cluster_name);
+  AsyncClientImpl(Upstream::ClusterManager& cm, const envoy::api::v2::core::GrpcService& config);
   ~AsyncClientImpl() override;
 
   // Grpc::AsyncClient
@@ -28,6 +28,7 @@ public:
 private:
   Upstream::ClusterManager& cm_;
   const std::string remote_cluster_name_;
+  const Protobuf::RepeatedPtrField<envoy::api::v2::core::HeaderValue> initial_metadata_;
   std::list<std::unique_ptr<AsyncStreamImpl>> active_streams_;
 
   friend class AsyncRequestImpl;

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -10,15 +10,16 @@ namespace Envoy {
 namespace Grpc {
 
 AsyncClientFactoryImpl::AsyncClientFactoryImpl(Upstream::ClusterManager& cm,
-                                               const std::string& cluster_name)
-    : cm_(cm), cluster_name_(cluster_name) {
+                                               const envoy::api::v2::core::GrpcService& config)
+    : cm_(cm), config_(config) {
+  const std::string& cluster_name = config.envoy_grpc().cluster_name();
   auto clusters = cm_.clusters();
-  const auto& it = clusters.find(cluster_name_);
+  const auto& it = clusters.find(cluster_name);
   if (it == clusters.end()) {
-    throw EnvoyException(fmt::format("Unknown gRPC client cluster '{}'", cluster_name_));
+    throw EnvoyException(fmt::format("Unknown gRPC client cluster '{}'", cluster_name));
   }
   if (it->second.get().info()->addedViaApi()) {
-    throw EnvoyException(fmt::format("gRPC client cluster '{}' is not static", cluster_name_));
+    throw EnvoyException(fmt::format("gRPC client cluster '{}' is not static", cluster_name));
   }
 }
 
@@ -33,14 +34,15 @@ AsyncClientManagerImpl::AsyncClientManagerImpl(Upstream::ClusterManager& cm,
 }
 
 AsyncClientPtr AsyncClientFactoryImpl::create() {
-  return std::make_unique<AsyncClientImpl>(cm_, cluster_name_);
+  return std::make_unique<AsyncClientImpl>(cm_, config_);
 }
 
 GoogleAsyncClientFactoryImpl::GoogleAsyncClientFactoryImpl(
     ThreadLocal::Instance& tls, ThreadLocal::Slot& google_tls_slot, Stats::Scope& scope,
-    const envoy::api::v2::core::GrpcService::GoogleGrpc& config)
+    const envoy::api::v2::core::GrpcService& config)
     : tls_(tls), google_tls_slot_(google_tls_slot),
-      scope_(scope.createScope(fmt::format("grpc.{}.", config.stat_prefix()))), config_(config) {
+      scope_(scope.createScope(fmt::format("grpc.{}.", config.google_grpc().stat_prefix()))),
+      config_(config) {
 #ifndef ENVOY_GOOGLE_GRPC
   UNREFERENCED_PARAMETER(tls_);
   UNREFERENCED_PARAMETER(google_tls_slot_);
@@ -66,10 +68,10 @@ AsyncClientManagerImpl::factoryForGrpcService(const envoy::api::v2::core::GrpcSe
                                               Stats::Scope& scope) {
   switch (grpc_service.target_specifier_case()) {
   case envoy::api::v2::core::GrpcService::kEnvoyGrpc:
-    return std::make_unique<AsyncClientFactoryImpl>(cm_, grpc_service.envoy_grpc().cluster_name());
+    return std::make_unique<AsyncClientFactoryImpl>(cm_, grpc_service);
   case envoy::api::v2::core::GrpcService::kGoogleGrpc:
     return std::make_unique<GoogleAsyncClientFactoryImpl>(tls_, *google_tls_slot_, scope,
-                                                          grpc_service.google_grpc());
+                                                          grpc_service);
   default:
     NOT_REACHED;
   }

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -10,20 +10,21 @@ namespace Grpc {
 
 class AsyncClientFactoryImpl : public AsyncClientFactory {
 public:
-  AsyncClientFactoryImpl(Upstream::ClusterManager& cm, const std::string& cluster_name);
+  AsyncClientFactoryImpl(Upstream::ClusterManager& cm,
+                         const envoy::api::v2::core::GrpcService& config);
 
   AsyncClientPtr create() override;
 
 private:
   Upstream::ClusterManager& cm_;
-  const std::string cluster_name_;
+  const envoy::api::v2::core::GrpcService config_;
 };
 
 class GoogleAsyncClientFactoryImpl : public AsyncClientFactory {
 public:
   GoogleAsyncClientFactoryImpl(ThreadLocal::Instance& tls, ThreadLocal::Slot& google_tls_slot,
                                Stats::Scope& scope,
-                               const envoy::api::v2::core::GrpcService::GoogleGrpc& config);
+                               const envoy::api::v2::core::GrpcService& config);
 
   AsyncClientPtr create() override;
 
@@ -31,7 +32,7 @@ private:
   ThreadLocal::Instance& tls_;
   ThreadLocal::Slot& google_tls_slot_;
   Stats::ScopePtr scope_;
-  const envoy::api::v2::core::GrpcService::GoogleGrpc config_;
+  const envoy::api::v2::core::GrpcService config_;
 };
 
 class AsyncClientManagerImpl : public AsyncClientManager {

--- a/source/common/grpc/google_async_client_impl.h
+++ b/source/common/grpc/google_async_client_impl.h
@@ -152,7 +152,7 @@ class GoogleAsyncClientImpl final : public AsyncClient, Logger::Loggable<Logger:
 public:
   GoogleAsyncClientImpl(Event::Dispatcher& dispatcher, GoogleAsyncClientThreadLocal& tls,
                         GoogleStubFactory& stub_factory, Stats::Scope& scope,
-                        const envoy::api::v2::core::GrpcService::GoogleGrpc& config);
+                        const envoy::api::v2::core::GrpcService& config);
   ~GoogleAsyncClientImpl() override;
 
   // Grpc::AsyncClient
@@ -175,6 +175,7 @@ private:
   std::shared_ptr<GoogleStub> stub_;
   std::list<std::unique_ptr<GoogleAsyncStreamImpl>> active_streams_;
   const std::string stat_prefix_;
+  const Protobuf::RepeatedPtrField<envoy::api::v2::core::HeaderValue> initial_metadata_;
   Stats::Scope& scope_;
   GoogleAsyncClientStats stats_;
 

--- a/test/common/grpc/grpc_client_integration_test.cc
+++ b/test/common/grpc/grpc_client_integration_test.cc
@@ -101,7 +101,7 @@ public:
     EXPECT_CALL(*this, onReceiveInitialMetadata_(_))
         .WillOnce(Invoke([this, &metadata](const Http::HeaderMap& received_headers) {
           Http::TestHeaderMapImpl stream_headers(received_headers);
-          for (auto& value : metadata) {
+          for (const auto& value : metadata) {
             EXPECT_EQ(value.second, stream_headers.get_(value.first));
           }
           dispatcher_helper_.exitDispatcherIfNeeded();
@@ -240,6 +240,14 @@ public:
     }
   }
 
+  void fillServerWideInitialMetadata(envoy::api::v2::core::GrpcService& config) {
+    for (const auto& item : service_wide_initial_metadata_) {
+      auto* header_value = config.add_initial_metadata();
+      header_value->set_key(item.first.get());
+      header_value->set_value(item.second);
+    }
+  }
+
   // Create a Grpc::AsyncClientImpl instance backed by enough fake/mock
   // infrastructure to initiate a loopback TCP connection to fake_upstream_.
   AsyncClientPtr createAsyncClientImpl() {
@@ -265,13 +273,18 @@ public:
         std::move(shadow_writer_ptr_));
     EXPECT_CALL(cm_, httpAsyncClientForCluster(fake_cluster_name_))
         .WillRepeatedly(ReturnRef(*http_async_client_));
-    return std::make_unique<AsyncClientImpl>(cm_, fake_cluster_name_);
+    envoy::api::v2::core::GrpcService config;
+    config.mutable_envoy_grpc()->set_cluster_name(fake_cluster_name_);
+    fillServerWideInitialMetadata(config);
+    return std::make_unique<AsyncClientImpl>(cm_, config);
   }
 
-  virtual envoy::api::v2::core::GrpcService::GoogleGrpc createGoogleGrpcConfig() {
-    envoy::api::v2::core::GrpcService::GoogleGrpc config;
-    config.set_target_uri(fake_upstream_->localAddress()->asString());
-    config.set_stat_prefix("fake_cluster");
+  virtual envoy::api::v2::core::GrpcService createGoogleGrpcConfig() {
+    envoy::api::v2::core::GrpcService config;
+    auto* google_grpc = config.mutable_google_grpc();
+    google_grpc->set_target_uri(fake_upstream_->localAddress()->asString());
+    google_grpc->set_stat_prefix("fake_cluster");
+    fillServerWideInitialMetadata(config);
     return config;
   }
 
@@ -286,20 +299,26 @@ public:
 #endif
   }
 
-  void expectInitialHeaders(FakeStream& fake_stream) {
+  void expectInitialHeaders(FakeStream& fake_stream, const TestMetadata& initial_metadata) {
     fake_stream.waitForHeadersComplete();
     Http::TestHeaderMapImpl stream_headers(fake_stream.headers());
     EXPECT_EQ("POST", stream_headers.get_(":method"));
     EXPECT_EQ("/helloworld.Greeter/SayHello", stream_headers.get_(":path"));
     EXPECT_EQ("application/grpc", stream_headers.get_("content-type"));
     EXPECT_EQ("trailers", stream_headers.get_("te"));
+    for (const auto& value : initial_metadata) {
+      EXPECT_EQ(value.second, stream_headers.get_(value.first));
+    }
+    for (const auto& value : service_wide_initial_metadata_) {
+      EXPECT_EQ(value.second, stream_headers.get_(value.first));
+    }
   }
 
   std::unique_ptr<HelloworldRequest> createRequest(const TestMetadata& initial_metadata) {
     auto request = std::make_unique<HelloworldRequest>(dispatcher_helper_);
     EXPECT_CALL(*request, onCreateInitialMetadata(_))
         .WillOnce(Invoke([&initial_metadata](Http::HeaderMap& headers) {
-          for (auto& value : initial_metadata) {
+          for (const auto& value : initial_metadata) {
             headers.addReference(value.first, value.second);
           }
         }));
@@ -326,7 +345,7 @@ public:
     auto& fake_stream = *fake_streams_.back();
     request->fake_stream_ = &fake_stream;
 
-    expectInitialHeaders(fake_stream);
+    expectInitialHeaders(fake_stream, initial_metadata);
 
     helloworld::HelloRequest received_msg;
     fake_stream.waitForGrpcMessage(dispatcher_, received_msg);
@@ -339,7 +358,7 @@ public:
     auto stream = std::make_unique<HelloworldStream>(dispatcher_helper_);
     EXPECT_CALL(*stream, onCreateInitialMetadata(_))
         .WillOnce(Invoke([&initial_metadata](Http::HeaderMap& headers) {
-          for (auto& value : initial_metadata) {
+          for (const auto& value : initial_metadata) {
             headers.addReference(value.first, value.second);
           }
         }));
@@ -354,7 +373,7 @@ public:
     auto& fake_stream = *fake_streams_.back();
     stream->fake_stream_ = &fake_stream;
 
-    expectInitialHeaders(fake_stream);
+    expectInitialHeaders(fake_stream, initial_metadata);
 
     return stream;
   }
@@ -366,6 +385,7 @@ public:
   DispatcherHelper dispatcher_helper_{dispatcher_};
   Stats::IsolatedStoreImpl stats_store_;
   std::unique_ptr<FakeUpstream> fake_upstream_;
+  TestMetadata service_wide_initial_metadata_;
 #ifdef ENVOY_GOOGLE_GRPC
   std::unique_ptr<GoogleAsyncClientThreadLocal> google_tls_;
 #endif
@@ -578,7 +598,7 @@ TEST_P(GrpcClientIntegrationTest, ReplyNoTrailers) {
   dispatcher_helper_.runDispatcher();
 }
 
-// Validate that send client initial metadata works.
+// Validate that sending client initial metadata works.
 TEST_P(GrpcClientIntegrationTest, StreamClientInitialMetadata) {
   initialize();
   const TestMetadata initial_metadata = {
@@ -590,7 +610,7 @@ TEST_P(GrpcClientIntegrationTest, StreamClientInitialMetadata) {
   dispatcher_helper_.runDispatcher();
 }
 
-// Validate that send client initial metadata works.
+// Validate that sending client initial metadata works.
 TEST_P(GrpcClientIntegrationTest, RequestClientInitialMetadata) {
   initialize();
   const TestMetadata initial_metadata = {
@@ -598,6 +618,16 @@ TEST_P(GrpcClientIntegrationTest, RequestClientInitialMetadata) {
       {Http::LowerCaseString("baz"), "blah"},
   };
   auto request = createRequest(initial_metadata);
+  request->sendReply();
+  dispatcher_helper_.runDispatcher();
+}
+
+// Validate that setting service-wide client initial metadata works.
+TEST_P(GrpcClientIntegrationTest, RequestServiceWideInitialMetadata) {
+  service_wide_initial_metadata_.emplace_back(Http::LowerCaseString("foo"), "bar");
+  service_wide_initial_metadata_.emplace_back(Http::LowerCaseString("baz"), "blah");
+  initialize();
+  auto request = createRequest(empty_metadata_);
   request->sendReply();
   dispatcher_helper_.runDispatcher();
 }
@@ -712,9 +742,10 @@ public:
     mock_cluster_info_->transport_socket_factory_.reset();
   }
 
-  virtual envoy::api::v2::core::GrpcService::GoogleGrpc createGoogleGrpcConfig() override {
+  virtual envoy::api::v2::core::GrpcService createGoogleGrpcConfig() override {
     auto config = GrpcClientIntegrationTest::createGoogleGrpcConfig();
-    auto* ssl_creds = config.mutable_ssl_credentials();
+    auto* google_grpc = config.mutable_google_grpc();
+    auto* ssl_creds = google_grpc->mutable_ssl_credentials();
     ssl_creds->mutable_root_certs()->set_filename(
         TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcacert.pem"));
     if (use_client_cert_) {


### PR DESCRIPTION
Envoy proxy counterpart to
https://github.com/envoyproxy/data-plane-api/pull/500.

Risk Level: Low
Testing: New gRPC client integration tests.
API Changes: https://github.com/envoyproxy/data-plane-api/pull/500.

Signed-off-by: Harvey Tuch <htuch@google.com>