### PR TITLE
Build: Save build artifact and publish release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,8 @@ jobs:
        - setup_remote_docker
        - run: ci/docker_push.sh
        - run: ci/docker_tag.sh
+       - store_artifacts:
+          path: /tmp/envoy-dist
    asan:
      docker:
        - image: *envoy-build-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
      steps:
        - checkout
        - run: ci/do_circle_ci.sh bazel.release
+       - run: ci/do_circle_ci.sh github_release
        - setup_remote_docker
        - run: ci/docker_push.sh
        - run: ci/docker_tag.sh

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -170,7 +170,7 @@ elif [[ "$1" == "docs" ]]; then
   docs/publish.sh
   exit 0
 elif [[ "$1" == "github_release" ]]; then
-  ./publish_github_release.sh
+  ./ci/publish_github_release.sh
 else
   echo "Invalid do_ci.sh target, see ci/README.md for valid targets."
   exit 1

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -47,8 +47,8 @@ function publish_github_release() {
   chmod +x /usr/local/bin/ghrelease
 
   if [[ -n "${TAG:-}" ]]; then
-      ghrelease release --tag "${TAG:-}" --user taion809 --repo envoy-build-tests --name "${TAG:-}"
-      ghrelease upload --tag "${TAG:-}" --user taion809 --repo envoy-build-tests --name "envoy-linux-amd64" --file "${ENVOY_SRCDIR}/build_release_stripped/envoy"
+      ghrelease release --tag "${TAG:-}" --name "${TAG:-}"
+      ghrelease upload --tag "${TAG:-}" --name "envoy-linux-amd64" --file "${ENVOY_SRCDIR}/build_release_stripped/envoy"
   fi
 }
 
@@ -191,8 +191,22 @@ elif [[ "$1" == "github_release" ]]; then
       exit 0
   fi
 
-  if [[ -z "${GITHUB_TOKEN}" ]]; then
+  if [[ -z "${GITHUB_TOKEN:-}" ]]; then
       echo "environment variable GITHUB_TOKEN unset; cannot continue with publishing."
+      
+      # TODO(taion809): discuss whether or not failing to publish to github warrents failing the build itself
+      exit 0
+  fi
+
+  if [[ -z "${GITHUB_USER:-}" ]]; then
+      echo "environment variable GITHUB_USERNAME unset; cannot continue with publishing."
+      
+      # TODO(taion809): discuss whether or not failing to publish to github warrents failing the build itself
+      exit 0
+  fi
+
+  if [[ -z "${GITHUB_REPO:-}" ]]; then
+      echo "environment variable GITHUB_USERNAME unset; cannot continue with publishing."
       
       # TODO(taion809): discuss whether or not failing to publish to github warrents failing the build itself
       exit 0

--- a/ci/do_circle_ci.sh
+++ b/ci/do_circle_ci.sh
@@ -2,9 +2,11 @@
 
 set -e
 
-# bazel uses jgit internally and the default circle-ci .gitconfig says to
-# convert https://github.com to ssh://git@github.com, which jgit does not support.
-mv ~/.gitconfig ~/.gitconfig_save
+if [[ -f ~/.gitconfig ]]; then
+  # bazel uses jgit internally and the default circle-ci .gitconfig says to
+  # convert https://github.com to ssh://git@github.com, which jgit does not support.
+  mv ~/.gitconfig ~/.gitconfig_save
+fi
 
 export ENVOY_SRCDIR="$(pwd)"
 

--- a/ci/publish_github_release.sh
+++ b/ci/publish_github_release.sh
@@ -24,19 +24,17 @@ if [[ -z "${GITHUB_REPO:-}" ]]; then
     exit 1
 fi
 
-if [[ -n "${CIRCLE_TAG:-}" ]]; then
-    echo "skipping tag events"
+if [[ -z "${CIRCLE_TAG:-}" ]]; then
+    echo "skipping non tag events"
     exit 0
 fi
-
-TAG=$(git describe --abbrev=0 --tags)
 
 wget https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2 -O /tmp/ghrelease.tar.bz2
 tar -xvjpf /tmp/ghrelease.tar.bz2 -C /tmp
 cp /tmp/bin/linux/amd64/github-release /usr/local/bin/ghrelease
 chmod +x /usr/local/bin/ghrelease
 
-if [[ -n "${TAG:-}" ]]; then
-    ghrelease release --tag "${TAG:-}" --name "${TAG:-}"
-    ghrelease upload --tag "${TAG:-}" --name "envoy-linux-amd64" --file "${ENVOY_SRCDIR}/build_release_stripped/envoy"
+if [[ -n "${CIRCLE_TAG:-}" ]]; then
+    ghrelease release --tag "${CIRCLE_TAG:-}" --name "${CIRCLE_TAG:-}"
+    ghrelease upload --tag "${CIRCLE_TAG:-}" --name "envoy-linux-amd64" --file "${ENVOY_SRCDIR}/build_release_stripped/envoy"
 fi

--- a/ci/publish_github_release.sh
+++ b/ci/publish_github_release.sh
@@ -11,23 +11,17 @@ fi
 
 if [[ -z "${GITHUB_TOKEN:-}" ]]; then
     echo "environment variable GITHUB_TOKEN unset; cannot continue with publishing."
-    
-    # TODO(taion809): discuss whether or not failing to publish to github warrents failing the build itself
-    exit 0
+    exit 1
 fi
 
 if [[ -z "${GITHUB_USER:-}" ]]; then
-    echo "environment variable GITHUB_USERNAME unset; cannot continue with publishing."
-    
-    # TODO(taion809): discuss whether or not failing to publish to github warrents failing the build itself
-    exit 0
+    echo "environment variable GITHUB_USER unset; cannot continue with publishing."
+    exit 1
 fi
 
 if [[ -z "${GITHUB_REPO:-}" ]]; then
-    echo "environment variable GITHUB_USERNAME unset; cannot continue with publishing."
-    
-    # TODO(taion809): discuss whether or not failing to publish to github warrents failing the build itself
-    exit 0
+    echo "environment variable GITHUB_REPO unset; cannot continue with publishing."
+    exit 1
 fi
 
 if [[ -n "${CIRCLE_TAG:-}" ]]; then

--- a/ci/publish_github_release.sh
+++ b/ci/publish_github_release.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# NOTE: please do not set trace mode (-x)
+# as it will leak credentials in the logs.
+set -e
+
+if [[ ! -f "${ENVOY_SRCDIR}/build_release_stripped/envoy" ]]; then
+    echo "could not locate envoy binary at path: ${ENVOY_SRCDIR}/build_release_stripped/envoy"
+    exit 1
+fi
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+    echo "environment variable GITHUB_TOKEN unset; cannot continue with publishing."
+    
+    # TODO(taion809): discuss whether or not failing to publish to github warrents failing the build itself
+    exit 0
+fi
+
+if [[ -z "${GITHUB_USER:-}" ]]; then
+    echo "environment variable GITHUB_USERNAME unset; cannot continue with publishing."
+    
+    # TODO(taion809): discuss whether or not failing to publish to github warrents failing the build itself
+    exit 0
+fi
+
+if [[ -z "${GITHUB_REPO:-}" ]]; then
+    echo "environment variable GITHUB_USERNAME unset; cannot continue with publishing."
+    
+    # TODO(taion809): discuss whether or not failing to publish to github warrents failing the build itself
+    exit 0
+fi
+
+if [[ -n "${CIRCLE_TAG:-}" ]]; then
+    echo "skipping tag events"
+    exit 0
+fi
+
+TAG=$(git describe --abbrev=0 --tags)
+
+wget https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2 -O /tmp/ghrelease.tar.bz2
+tar -xvjpf /tmp/ghrelease.tar.bz2 -C /tmp
+cp /tmp/bin/linux/amd64/github-release /usr/local/bin/ghrelease
+chmod +x /usr/local/bin/ghrelease
+
+if [[ -n "${TAG:-}" ]]; then
+    ghrelease release --tag "${TAG:-}" --name "${TAG:-}"
+    ghrelease upload --tag "${TAG:-}" --name "envoy-linux-amd64" --file "${ENVOY_SRCDIR}/build_release_stripped/envoy"
+fi

--- a/ci/publish_github_release.sh
+++ b/ci/publish_github_release.sh
@@ -4,6 +4,11 @@
 # as it will leak credentials in the logs.
 set -e
 
+if [[ -z "${CIRCLE_TAG:-}" ]]; then
+    echo "skipping non tag events"
+    exit 0
+fi
+
 if [[ ! -f "${ENVOY_SRCDIR}/build_release_stripped/envoy" ]]; then
     echo "could not locate envoy binary at path: ${ENVOY_SRCDIR}/build_release_stripped/envoy"
     exit 1
@@ -22,11 +27,6 @@ fi
 if [[ -z "${GITHUB_REPO:-}" ]]; then
     echo "environment variable GITHUB_REPO unset; cannot continue with publishing."
     exit 1
-fi
-
-if [[ -z "${CIRCLE_TAG:-}" ]]; then
-    echo "skipping non tag events"
-    exit 0
 fi
 
 wget https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2 -O /tmp/ghrelease.tar.bz2

--- a/ci/publish_github_release.sh
+++ b/ci/publish_github_release.sh
@@ -34,5 +34,4 @@ tar -xvjpf /tmp/ghrelease.tar.bz2 -C /tmp
 cp /tmp/bin/linux/amd64/github-release /usr/local/bin/ghrelease
 chmod +x /usr/local/bin/ghrelease
 
-ghrelease release --tag "${CIRCLE_TAG:-}" --name "${CIRCLE_TAG:-}"
 ghrelease upload --tag "${CIRCLE_TAG:-}" --name "envoy-linux-amd64" --file "${ENVOY_SRCDIR}/build_release_stripped/envoy"

--- a/ci/publish_github_release.sh
+++ b/ci/publish_github_release.sh
@@ -34,7 +34,5 @@ tar -xvjpf /tmp/ghrelease.tar.bz2 -C /tmp
 cp /tmp/bin/linux/amd64/github-release /usr/local/bin/ghrelease
 chmod +x /usr/local/bin/ghrelease
 
-if [[ -n "${CIRCLE_TAG:-}" ]]; then
-    ghrelease release --tag "${CIRCLE_TAG:-}" --name "${CIRCLE_TAG:-}"
-    ghrelease upload --tag "${CIRCLE_TAG:-}" --name "envoy-linux-amd64" --file "${ENVOY_SRCDIR}/build_release_stripped/envoy"
-fi
+ghrelease release --tag "${CIRCLE_TAG:-}" --name "${CIRCLE_TAG:-}"
+ghrelease upload --tag "${CIRCLE_TAG:-}" --name "envoy-linux-amd64" --file "${ENVOY_SRCDIR}/build_release_stripped/envoy"


### PR DESCRIPTION
Description:
This pull request saves the release binary to
circleci artifacts.  Additionally adds a release
script to create and publish a github release with
the linux binary attached to the github release as an asset.

A CNCF member will need to:
  - create a github token with repo access to cut releases and upload artifacts
  - Add the following environment variables to the circleci envoy project
    - GITHUB_TOKEN
    - GITHUB_USER
    - GITHUB_REPO

Risk Level: low

Testing:
I manually tested using this github repo:
https://github.com/taion809/envoy-build-tests

fixes #2095

Signed-off-by: Nicholas Johns <nicholas.a.johns5@gmail.com>
