### PR TITLE
config check tool: initialize logger and libevent.

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -54,7 +54,7 @@ Envoy compiles and passes tests with the version of clang installed by XCode 8.3
 Apple LLVM version 8.1.0 (clang-802.0.42).
 
 3. Install Golang on your machine. This is required as part of building [BoringSSL](https://boringssl.googlesource.com/boringssl/+/HEAD/BUILDING.md)
-and also for [Buildifer](https://github.com/bazelbuild/buildtools) which is used for formatting bazel BUILD files. 
+and also for [Buildifer](https://github.com/bazelbuild/buildtools) which is used for formatting bazel BUILD files.
 4. `go get github.com/bazelbuild/buildtools/buildifier` to install buildifier
 5. `bazel fetch //source/...` to fetch and build all external dependencies. This may take some time.
 6. `bazel build //source/exe:envoy-static` from the Envoy source directory.

--- a/test/config_test/BUILD
+++ b/test/config_test/BUILD
@@ -35,6 +35,7 @@ envoy_cc_test_library(
     deps = [
         "//source/common/protobuf:utility_lib",
         "//source/server:configuration_lib",
+        "//source/server/config_validation:server_lib",
         "//test/integration:integration_lib",
         "//test/mocks/server:server_mocks",
         "//test/mocks/ssl:ssl_mocks",

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -5,8 +5,8 @@
 
 #include "common/common/fmt.h"
 #include "common/protobuf/utility.h"
-#include "common/upstream/cluster_manager_impl.h"
 
+#include "server/config_validation/server.h"
 #include "server/configuration_impl.h"
 
 #include "test/integration/server.h"
@@ -41,7 +41,7 @@ public:
     Server::Configuration::InitialImpl initial_config(bootstrap);
     Server::Configuration::MainImpl main_config;
 
-    cluster_manager_factory_.reset(new Upstream::ProdClusterManagerFactory(
+    cluster_manager_factory_.reset(new Upstream::ValidationClusterManagerFactory(
         server_.runtime(), server_.stats(), server_.threadLocal(), server_.random(),
         server_.dnsResolver(), ssl_context_manager_, server_.dispatcher(), server_.localInfo()));
 

--- a/test/tools/config_load_check/BUILD
+++ b/test/tools/config_load_check/BUILD
@@ -18,5 +18,10 @@ envoy_cc_test_library(
 envoy_cc_binary(
     name = "config_load_check_tool",
     testonly = 1,
-    deps = [":config_load_check_lib"],
+    deps = [
+        ":config_load_check_lib",
+        "//source/common/common:logger_lib",
+        "//source/common/common:thread_lib",
+        "//source/common/event:libevent_lib",
+    ],
 )

--- a/test/tools/config_load_check/config_load_check.cc
+++ b/test/tools/config_load_check/config_load_check.cc
@@ -24,8 +24,8 @@ int main(int argc, char* argv[]) {
   try {
 
     Envoy::Event::Libevent::Global::initialize();
-    static auto* lock = new Envoy::Thread::MutexBasicLockable();
-    Envoy::Logger::Registry::initialize(static_cast<spdlog::level::level_enum>(2), *lock);
+    Envoy::Thread::MutexBasicLockable lock;
+    Envoy::Logger::Registry::initialize(static_cast<spdlog::level::level_enum>(2), lock);
 
     const uint32_t num_tested = Envoy::ConfigTest::run(std::string(argv[1]));
     std::cout << fmt::format("Configs tested: {}. ", num_tested);

--- a/test/tools/config_load_check/config_load_check.cc
+++ b/test/tools/config_load_check/config_load_check.cc
@@ -4,6 +4,9 @@
 #include <string>
 
 #include "common/common/fmt.h"
+#include "common/common/logger.h"
+#include "common/common/thread.h"
+#include "common/event/libevent.h"
 
 #include "test/config_test/config_test.h"
 
@@ -19,6 +22,11 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
   try {
+
+    Envoy::Event::Libevent::Global::initialize();
+    static auto* lock = new Envoy::Thread::MutexBasicLockable();
+    Envoy::Logger::Registry::initialize(static_cast<spdlog::level::level_enum>(2), *lock);
+
     const uint32_t num_tested = Envoy::ConfigTest::run(std::string(argv[1]));
     std::cout << fmt::format("Configs tested: {}. ", num_tested);
     if (testing::Test::HasFailure()) {


### PR DESCRIPTION
Signed-off-by: Constance Caramanolis <ccaramanolis@lyft.com>

*Description*: The config check tool didn't initialize Logger and Libevent  and would seg fault when running it. 
This doesn't cause an issue for test cases, because test runner initializes both. 

*Risk Level*: Low  - Manually ran the binary. 
