### PR TITLE
hot-restarter.py: revert SIGCHLD handler to force kill instead of term

### DIFF
--- a/restarter/hot-restarter.py
+++ b/restarter/hot-restarter.py
@@ -139,8 +139,12 @@ def sigchld_handler(signum, frame):
       kill_all_and_exit = True
 
   if kill_all_and_exit:
-    print "Due to abnormal exit, terminating all child processes and exiting"
-    term_all_children()
+    print "Due to abnormal exit, force killing all child processes and exiting"
+
+    # First uninstall the SIGCHLD handler so that we don't get called again.
+    signal.signal(signal.SIGCHLD, signal.SIG_DFL)
+
+    force_kill_all_children()
 
   # Our last child died, so we have no purpose. Exit.
   if not pid_list:


### PR DESCRIPTION
PR: #2596 changed the behavior of the SIGTERM and SIGCHLD handlers to
attempt to allow child processes to exit gracefully before force killing
them. This PR reverts the behavior of the SIGCHLD handler back to force
killing children if a child exits uncleanly. This should allow the
supervisor of the python process (e.g. runit) to restart envoy with a
shorter delay (whereas an attempt at graceful TERM might delay up to
TERM_WAIT_SECONDS).

Note: If the child process of hot-restarter.py is a container framework
(e.g. runc), the force kill might result in container state being
leaked. This should hopefully be a rare occurrence.

Signed-off-by: Michael Puncel <mpuncel@squareup.com>

*title*: *Revert SIGCHLD handler in hot-restarter.py to force killing children instead of attempting graceful shutdown*

*Description*:
Reverts the behavior of the hot-restarter.py
*Risk Level*: Low | Medium | High
Low

*Testing*:
I ran hot-restarter.py manually with /usr/bin/false and saw it print that it was sending a TERM
ran it with `/usr/bin/true` and saw that it exited cleanly without terminating children


*Docs Changes*:
no docs changes

*Release Notes*:
no release notes
