### PR TITLE
redis: alternate healthcheck

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -71,7 +71,7 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
     ),
     envoy_api = dict(
-        commit = "258bfddfddaad4d6a1da7b4476c98b060d57bcc1",
+        commit = "570d7eaf4db439d67136e95d8fa1628733f86a2b",
         remote = "https://github.com/envoyproxy/data-plane-api",
     ),
     grpc_httpjson_transcoding = dict(

--- a/source/common/config/cds_json.cc
+++ b/source/common/config/cds_json.cc
@@ -53,7 +53,9 @@ void CdsJson::translateHealthCheck(const Json::Object& json_health_check,
     }
   } else {
     ASSERT(hc_type == "redis");
-    health_check.mutable_redis_health_check();
+    auto* redis_health_check = health_check.mutable_redis_health_check();
+    const std::string redis_key = json_health_check.getString("redis_key", "");
+    redis_health_check->set_key(redis_key);
   }
 }
 

--- a/source/common/config/cds_json.cc
+++ b/source/common/config/cds_json.cc
@@ -54,8 +54,9 @@ void CdsJson::translateHealthCheck(const Json::Object& json_health_check,
   } else {
     ASSERT(hc_type == "redis");
     auto* redis_health_check = health_check.mutable_redis_health_check();
-    const std::string redis_key = json_health_check.getString("redis_key", "");
-    redis_health_check->set_key(redis_key);
+    if (json_health_check.hasObject("redis_key")) {
+      redis_health_check->set_key(json_health_check.getString("redis_key"));
+    }
   }
 }
 

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -1429,7 +1429,8 @@ const std::string Json::Schema::CLUSTER_HEALTH_CHECK_SCHEMA(R"EOF(
         "exclusiveMinimum" : true
       },
       "reuse_connection" : {"type" : "boolean"},
-      "service_name" : {"type" : "string"}
+      "service_name" : {"type" : "string"},
+      "redis_key" : {"type" : "string"}
     },
     "required" : ["type", "timeout_ms", "interval_ms", "unhealthy_threshold", "healthy_threshold"],
     "additionalProperties" : false

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -367,7 +367,12 @@ public:
                          Runtime::RandomGenerator& random,
                          Redis::ConnPool::ClientFactory& client_factory);
 
-  static const Redis::RespValue& healthCheckRequest(const std::string& key) {
+  static const Redis::RespValue& pingHealthCheckRequest() {
+    static HealthCheckRequest* request = new HealthCheckRequest();
+    return request->request_;
+  }
+
+  static const Redis::RespValue& existsHealthCheckRequest(const std::string& key) {
     static HealthCheckRequest* request = new HealthCheckRequest(key);
     return request->request_;
   }
@@ -379,7 +384,6 @@ private:
                                          public Network::ConnectionCallbacks {
     RedisActiveHealthCheckSession(RedisHealthCheckerImpl& parent, const HostSharedPtr& host);
     ~RedisActiveHealthCheckSession();
-
     // ActiveHealthCheckSession
     void onInterval() override;
     void onTimeout() override;
@@ -405,8 +409,11 @@ private:
     Redis::ConnPool::PoolRequest* current_request_{};
   };
 
+  enum class Type { Ping, Exists };
+
   struct HealthCheckRequest {
     HealthCheckRequest(const std::string& key);
+    HealthCheckRequest();
 
     Redis::RespValue request_;
   };
@@ -419,6 +426,7 @@ private:
   }
 
   Redis::ConnPool::ClientFactory& client_factory_;
+  Type type_;
   const std::string key_;
 };
 

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -367,8 +367,8 @@ public:
                          Runtime::RandomGenerator& random,
                          Redis::ConnPool::ClientFactory& client_factory);
 
-  static const Redis::RespValue& healthCheckRequest() {
-    static HealthCheckRequest* request = new HealthCheckRequest();
+  static const Redis::RespValue& healthCheckRequest(const std::string& key) {
+    static HealthCheckRequest* request = new HealthCheckRequest(key);
     return request->request_;
   }
 
@@ -406,7 +406,7 @@ private:
   };
 
   struct HealthCheckRequest {
-    HealthCheckRequest();
+    HealthCheckRequest(const std::string& key);
 
     Redis::RespValue request_;
   };
@@ -419,6 +419,7 @@ private:
   }
 
   Redis::ConnPool::ClientFactory& client_factory_;
+  const std::string key_;
 };
 
 /**

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -1413,7 +1413,7 @@ public:
                                                      dispatcher_, runtime_, random_, *this));
   }
 
-    void setupExistsHealthcheck() {
+  void setupExistsHealthcheck() {
     std::string json = R"EOF(
     {
       "type": "redis",
@@ -1503,6 +1503,13 @@ TEST_F(RedisHealthCheckerImplTest, All) {
   response->type(Redis::RespType::SimpleString);
   response->asString() = "PONG";
   pool_callbacks_->onResponse(std::move(response));
+
+  // FOOO
+  Redis::RespValue request;
+  request.type(Redis::RespType::Error);
+  request.asString() = "blah blah blah";
+  // EXPECT_CALL(&pool_callbacks_, onResponse_(PointeesEq(&request)));
+  // FOOO
 
   expectRequestCreate();
   interval_timer_->callback_();


### PR DESCRIPTION
**Description**
Adds EXISTS healthcheck when key is specified in config. This allows the user to fail the healthcheck. See the data-plane changes linked below for more details.

**Risk Level**
Low

**Testing**
Unit, manual

**Docs and API Changes**
https://github.com/envoyproxy/data-plane-api/pull/499