### PR TITLE
CluserInfo: Use Envoy::ProtobufTypes:String.

### DIFF
--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -352,7 +352,7 @@ private:
   static uint64_t parseFeatures(const envoy::api::v2::Cluster& config);
 
   Runtime::Loader& runtime_;
-  const std::string name_;
+  const Envoy::ProtobufTypes::String name_;
   const envoy::api::v2::Cluster::DiscoveryType type_;
   const uint64_t max_requests_per_connection_;
   const std::chrono::milliseconds connect_timeout_;


### PR DESCRIPTION
Due to mismatch between internal and external string types used by
protobuf the compiler was unable to deduce the type of this expression
used in ClusterInfoImpl constructor:

config.alt_stat_name().empty() ? name_ : config.alt_stat_name()

Make name_ an Envoy::ProtobufTypes:String to fix.

*Testing*: `bazel test //test/...`

Signed-off-by: Dan Noé <dpn@google.com>
