### PR TITLE
Fix weird protobuf string issue with ternary operator.

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -121,7 +121,8 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
       per_connection_buffer_limit_bytes_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, per_connection_buffer_limit_bytes, 1024 * 1024)),
       stats_scope_(stats.createScope(fmt::format(
-          "cluster.{}.", config.alt_stat_name().empty() ? name_ : config.alt_stat_name()))),
+          "cluster.{}.",
+          config.alt_stat_name().empty() ? name_ : std::string(config.alt_stat_name())))),
       stats_(generateStats(*stats_scope_)),
       load_report_stats_(generateLoadReportStats(load_report_stats_store_)),
       features_(parseFeatures(config)),

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -352,7 +352,7 @@ private:
   static uint64_t parseFeatures(const envoy::api::v2::Cluster& config);
 
   Runtime::Loader& runtime_;
-  const Envoy::ProtobufTypes::String name_;
+  const std::string name_;
   const envoy::api::v2::Cluster::DiscoveryType type_;
   const uint64_t max_requests_per_connection_;
   const std::chrono::milliseconds connect_timeout_;


### PR DESCRIPTION
The previous fix in https://github.com/envoyproxy/envoy/pull/2648/
causes 29 tests to segfault when run with internal string variant (but
works fine externally). This version of the fix works fine, all tests
pass with all protobuf versions. But why?

Testing: bazel test //test/...
and the: blaze equivalent internally.

Signed-off-by: Dan Noé <dpn@google.com>