### PR TITLE
fix front-proxy example

### DIFF
--- a/examples/front-proxy/docker-compose.yml
+++ b/examples/front-proxy/docker-compose.yml
@@ -3,8 +3,8 @@ services:
 
   front-envoy:
     build:
-      context: ../
-      dockerfile: front-proxy/Dockerfile-frontenvoy
+      context: .
+      dockerfile: Dockerfile-frontenvoy
     volumes:
       - ./front-envoy.yaml:/etc/front-envoy.yaml
     networks:


### PR DESCRIPTION
*Description*:

This fixes the `front-proxy` example's `docker-compose.yml`.

*Risk Level*: Low

*Testing*:

The example doesn't work otherwise.