### PR TITLE
registry: fix FactoryRegistry::replaceFactoryForTest()

### DIFF
--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -59,8 +59,15 @@ private:
    * @return Base* a pointer to the previously registered value.
    */
   static Base* replaceFactoryForTest(Base& factory) {
-    auto displaced = getFactory(factory.name());
-    factories().emplace(std::make_pair(factory.name(), &factory));
+    auto it = factories().find(factory.name());
+    Base* displaced = nullptr;
+    if (it != factories().end()) {
+      displaced = it->second;
+      factories().erase(it);
+    }
+
+    factories().emplace(factory.name(), &factory);
+    RELEASE_ASSERT(getFactory(factory.name()) == &factory);
     return displaced;
   }
 


### PR DESCRIPTION
*Description*:
This patch fixes a pretty common mistake with `unordered_map` and friends - `emplace` and `insert` *do not overwrite an existing value*. They return it. Facepalm. 

Also removes extraneous `std::make_pair` from the `emplace` call. The point of `emplace` is to forward args to the ctor.

Side note: C++17 introduces `insert_or_assign`

*Risk Level*: Low - code path is only exercised in tests

*Testing*: Current user (common/network:resolver_test) still passes. A new test exposed this bug and is in another PR, which I will link to once it's up. That test fails without this fix

*Docs Changes*: N/A

*Release Notes*: N/A