### PR TITLE
admin: move '/routes' handler implementation from rds_impl to admin_impl

### DIFF
--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -40,13 +40,14 @@ public:
 
   /**
    * Gets a factory by name. If the name isn't found in the registry, returns nullptr.
+   * Optionally, downcast from the registry type, with the usual caveats about downcasting.
    */
-  static Base* getFactory(const std::string& name) {
+  template <class T = Base> static T* getFactory(const std::string& name) {
     auto it = factories().find(name);
     if (it == factories().end()) {
       return nullptr;
     }
-    return it->second;
+    return dynamic_cast<T*>(it->second);
   }
 
 private:

--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -94,6 +94,22 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "server_context_interface",
+    hdrs = ["server_context.h"],
+    deps = [
+        "//include/envoy/access_log:access_log_interface",
+        "//include/envoy/init:init_interface",
+        "//include/envoy/local_info:local_info_interface",
+        "//include/envoy/ratelimit:ratelimit_interface",
+        "//include/envoy/runtime:runtime_interface",
+        "//include/envoy/singleton:manager_interface",
+        "//include/envoy/thread_local:thread_local_interface",
+        "//include/envoy/tracing:http_tracer_interface",
+        "//include/envoy/upstream:cluster_manager_interface",
+    ],
+)
+
+envoy_cc_library(
     name = "worker_interface",
     hdrs = ["worker.h"],
     deps = [
@@ -115,18 +131,12 @@ envoy_cc_library(
     hdrs = ["filter_config.h"],
     deps = [
         ":admin_interface",
+        ":server_context_interface",
         "//include/envoy/access_log:access_log_interface",
         "//include/envoy/http:filter_interface",
         "//include/envoy/init:init_interface",
         "//include/envoy/json:json_object_interface",
-        "//include/envoy/local_info:local_info_interface",
         "//include/envoy/network:drain_decision_interface",
-        "//include/envoy/ratelimit:ratelimit_interface",
-        "//include/envoy/runtime:runtime_interface",
-        "//include/envoy/singleton:manager_interface",
-        "//include/envoy/thread_local:thread_local_interface",
-        "//include/envoy/tracing:http_tracer_interface",
-        "//include/envoy/upstream:cluster_manager_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:macros",
         "//source/common/protobuf",

--- a/include/envoy/server/instance.h
+++ b/include/envoy/server/instance.h
@@ -13,9 +13,11 @@
 #include "envoy/runtime/runtime.h"
 #include "envoy/server/admin.h"
 #include "envoy/server/drain_manager.h"
+#include "envoy/server/filter_config.h"
 #include "envoy/server/hot_restart.h"
 #include "envoy/server/listener_manager.h"
 #include "envoy/server/options.h"
+#include "envoy/server/server_context.h"
 #include "envoy/ssl/context_manager.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/tracing/http_tracer.h"
@@ -27,7 +29,7 @@ namespace Server {
 /**
  * An instance of the running server.
  */
-class Instance {
+class Instance : public ServerContext {
 public:
   virtual ~Instance() {}
 

--- a/include/envoy/server/listener_manager.h
+++ b/include/envoy/server/listener_manager.h
@@ -47,7 +47,7 @@ public:
    */
   virtual std::vector<Configuration::ListenerFilterFactoryCb> createListenerFilterFactoryList(
       const Protobuf::RepeatedPtrField<envoy::api::v2::listener::ListenerFilter>& filters,
-      Configuration::ListenerFactoryContext& context) PURE;
+      Configuration::FactoryContext& context) PURE;
 
   /**
    * @return DrainManagerPtr a new drain manager.

--- a/include/envoy/server/server_context.h
+++ b/include/envoy/server/server_context.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "envoy/access_log/access_log.h"
+#include "envoy/init/init.h"
+#include "envoy/ratelimit/ratelimit.h"
+#include "envoy/runtime/runtime.h"
+#include "envoy/server/admin.h"
+#include "envoy/singleton/manager.h"
+#include "envoy/thread_local/thread_local.h"
+#include "envoy/tracing/http_tracer.h"
+#include "envoy/upstream/cluster_manager.h"
+
+namespace Envoy {
+namespace Server {
+
+/*
+ * ServerContext provides controlled, limited access to server resources
+ * For example usage, see subclass FactoryContext and how it is used by the
+ * filter system
+ */
+class ServerContext {
+public:
+  virtual ~ServerContext() {}
+
+  /**
+   * @return AccessLogManager for use by the entire server.
+   */
+  virtual AccessLog::AccessLogManager& accessLogManager() PURE;
+
+  /**
+   * @return Upstream::ClusterManager& singleton for use by the entire server.
+   */
+  virtual Upstream::ClusterManager& clusterManager() PURE;
+
+  /**
+   * @return Event::Dispatcher& the main thread's dispatcher. This dispatcher should be used
+   *         for all singleton processing.
+   */
+  virtual Event::Dispatcher& dispatcher() PURE;
+
+  /**
+   * @return whether external healthchecks are currently failed or not.
+   */
+  virtual bool healthCheckFailed() PURE;
+
+  /**
+   * @return the server-wide http tracer.
+   */
+  virtual Tracing::HttpTracer& httpTracer() PURE;
+
+  /**
+   * @return the server's init manager. This can be used for extensions that need to initialize
+   *         after cluster manager init but before the server starts listening. All extensions
+   *         should register themselves during configuration load. initialize() will be called on
+   *         each registered target after cluster manager init but before the server starts
+   *         listening. Once all targets have initialized and invoked their callbacks, the server
+   *         will start listening.
+   */
+  virtual Init::Manager& initManager() PURE;
+
+  /**
+   * @return information about the local environment the server is running in.
+   */
+  virtual const LocalInfo::LocalInfo& localInfo() PURE;
+
+  /**
+   * @return RandomGenerator& the random generator for the server.
+   */
+  virtual Envoy::Runtime::RandomGenerator& random() PURE;
+
+  /**
+   * @return a new ratelimit client. The implementation depends on the configuration of the server.
+   */
+  virtual RateLimit::ClientPtr
+  rateLimitClient(const Optional<std::chrono::milliseconds>& timeout) PURE;
+
+  /**
+   * @return Runtime::Loader& the singleton runtime loader for the server.
+   */
+  virtual Envoy::Runtime::Loader& runtime() PURE;
+
+  /**
+   * @return Singleton::Manager& the server-wide singleton manager.
+   */
+  virtual Singleton::Manager& singletonManager() PURE;
+
+  /**
+   * @return ThreadLocal::SlotAllocator& the thread local storage engine for the server. This is
+   *         used to allow runtime lockless updates to configuration, etc. across multiple threads.
+   */
+  virtual ThreadLocal::SlotAllocator& threadLocal() PURE;
+
+  /**
+   * @return Server::Admin& the server's global admin HTTP endpoint.
+   */
+  virtual Server::Admin& admin() PURE;
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/include/envoy/singleton/manager.h
+++ b/include/envoy/singleton/manager.h
@@ -63,6 +63,17 @@ public:
   virtual ~Manager() {}
 
   /**
+   * Get a singleton and create it if it does not exist.
+   * @param name supplies the singleton name. Must be registered via RegistrationImpl.
+   * @param cb supplies the singleton creation callback. This will only be called if the
+   *        singleton does not already exist. NOTE: The manager only stores a weak pointer. This
+   *        allows a singleton to be cleaned up if it is not needed any more. All code that uses
+   *        singletons must store the shared_ptr for as long as the singleton is needed.
+   * @return InstancePtr the singleton.
+   */
+  virtual InstanceSharedPtr get(const std::string& name, SingletonFactoryCb) PURE;
+
+  /**
    * This is a helper on top of get() that casts the object stored to the specified type. Since the
    * manager only stores pointers to the base interface, dynamic_cast provides some level of
    * protection via RTTI.
@@ -72,15 +83,18 @@ public:
   }
 
   /**
-   * Get a singleton and create it if it does not exist.
+   * Get a singleton and return nullptr if it does not exist.
    * @param name supplies the singleton name. Must be registered via RegistrationImpl.
-   * @param singleton supplies the singleton creation callback. This will only be called if the
-   *        singleton does not already exist. NOTE: The manager only stores a weak pointer. This
-   *        allows a singleton to be cleaned up if it is not needed any more. All code that uses
-   *        singletons must store the shared_ptr for as long as the singleton is needed.
    * @return InstancePtr the singleton.
    */
-  virtual InstanceSharedPtr get(const std::string& name, SingletonFactoryCb) PURE;
+  virtual InstanceSharedPtr tryGet(const std::string& name) PURE;
+
+  /**
+   * Helper for tryGet() that dynamic_casts and returns a pointer of the requested type
+   */
+  template <class T> std::shared_ptr<T> tryGetTyped(const std::string& name) {
+    return std::dynamic_pointer_cast<T>(tryGet(name));
+  }
 };
 
 typedef std::unique_ptr<Manager> ManagerPtr;

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -152,8 +152,6 @@ public:
                                  Runtime::RandomGenerator& random,
                                  const LocalInfo::LocalInfo& local_info,
                                  ThreadLocal::SlotAllocator& tls, Server::Admin& admin);
-  ~RouteConfigProviderManagerImpl();
-
   // ServerRouteConfigProviderManager
   std::vector<RdsRouteConfigProviderSharedPtr> rdsRouteConfigProviders() override;
   // RouteConfigProviderManager

--- a/source/common/singleton/manager_impl.cc
+++ b/source/common/singleton/manager_impl.cc
@@ -9,18 +9,22 @@ namespace Envoy {
 namespace Singleton {
 
 InstanceSharedPtr ManagerImpl::get(const std::string& name, SingletonFactoryCb cb) {
+  auto singleton = tryGet(name);
+  if (!singleton) {
+    singleton = cb();
+    singletons_[name] = singleton;
+  }
+
+  return singleton;
+}
+
+InstanceSharedPtr ManagerImpl::tryGet(const std::string& name) {
   ASSERT(run_tid_ == Thread::Thread::currentThreadId());
   if (nullptr == Registry::FactoryRegistry<Registration>::getFactory(name)) {
     PANIC(fmt::format("invalid singleton name '{}'. Make sure it is registered.", name));
   }
 
-  if (nullptr == singletons_[name].lock()) {
-    InstanceSharedPtr singleton = cb();
-    singletons_[name] = singleton;
-    return singleton;
-  } else {
-    return singletons_[name].lock();
-  }
+  return singletons_[name].lock();
 }
 
 } // namespace Singleton

--- a/source/common/singleton/manager_impl.h
+++ b/source/common/singleton/manager_impl.h
@@ -21,6 +21,8 @@ public:
   // Singleton::Manager
   InstanceSharedPtr get(const std::string& name, SingletonFactoryCb cb) override;
 
+  InstanceSharedPtr tryGet(const std::string& name) override;
+
 private:
   std::unordered_map<std::string, std::weak_ptr<Instance>> singletons_;
   Thread::ThreadId run_tid_{};

--- a/source/server/config/listener/original_dst.cc
+++ b/source/server/config/listener/original_dst.cc
@@ -17,7 +17,7 @@ class OriginalDstConfigFactory : public NamedListenerFilterConfigFactory {
 public:
   // NamedListenerFilterConfigFactory
   ListenerFilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message&,
-                                                       ListenerFactoryContext&) override {
+                                                       FactoryContext&) override {
     return [](Network::ListenerFilterManager& filter_manager) -> void {
       filter_manager.addAcceptFilter(std::make_unique<Filter::Listener::OriginalDst>());
     };

--- a/source/server/config/listener/proxy_protocol.cc
+++ b/source/server/config/listener/proxy_protocol.cc
@@ -17,7 +17,7 @@ class ProxyProtocolConfigFactory : public NamedListenerFilterConfigFactory {
 public:
   // NamedListenerFilterConfigFactory
   ListenerFilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message&,
-                                                       ListenerFactoryContext& context) override {
+                                                       FactoryContext& context) override {
     Filter::Listener::ProxyProtocol::ConfigSharedPtr config(
         new Filter::Listener::ProxyProtocol::Config(context.scope()));
     return [config](Network::ListenerFilterManager& filter_manager) -> void {

--- a/source/server/config/network/http_connection_manager.cc
+++ b/source/server/config/network/http_connection_manager.cc
@@ -85,6 +85,13 @@ NetworkFilterFactoryCb HttpConnectionManagerFilterConfigFactory::createFilterFac
       context);
 }
 
+std::shared_ptr<Router::ServerRouteConfigProviderManager>
+HttpConnectionManagerFilterConfigFactory::getServerRouteConfigProviderManager(
+    ServerContext& context) {
+  return context.singletonManager().tryGetTyped<Router::ServerRouteConfigProviderManager>(
+      SINGLETON_MANAGER_REGISTERED_NAME(route_config_provider_manager));
+}
+
 /**
  * Static registration for the HTTP connection manager filter.
  */

--- a/source/server/config/network/http_connection_manager.h
+++ b/source/server/config/network/http_connection_manager.h
@@ -9,6 +9,7 @@
 #include "envoy/http/filter.h"
 #include "envoy/router/route_config_provider_manager.h"
 #include "envoy/server/filter_config.h"
+#include "envoy/server/server_context.h"
 
 #include "common/common/logger.h"
 #include "common/config/well_known_names.h"
@@ -37,6 +38,9 @@ public:
         new envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager());
   }
   std::string name() override { return Config::NetworkFilterNames::get().HTTP_CONNECTION_MANAGER; }
+
+  virtual std::shared_ptr<Router::ServerRouteConfigProviderManager>
+  getServerRouteConfigProviderManager(ServerContext& context);
 
 private:
   NetworkFilterFactoryCb createFilter(

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -96,7 +96,7 @@ public:
   }
   std::vector<Configuration::ListenerFilterFactoryCb> createListenerFilterFactoryList(
       const Protobuf::RepeatedPtrField<envoy::api::v2::listener::ListenerFilter>& filters,
-      Configuration::ListenerFactoryContext& context) override {
+      Configuration::FactoryContext& context) override {
     return ProdListenerComponentFactory::createListenerFilterFactoryList_(filters, context);
   }
   Network::SocketSharedPtr createListenSocket(Network::Address::InstanceConstSharedPtr,

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -9,6 +9,7 @@
 
 #include "envoy/http/filter.h"
 #include "envoy/network/listen_socket.h"
+#include "envoy/router/rds.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/server/admin.h"
 #include "envoy/server/instance.h"

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -160,6 +160,8 @@ private:
   Http::Code handlerMain(const std::string& path, Buffer::Instance& response);
   Http::Code handlerQuitQuitQuit(const std::string& path_and_query,
                                  Http::HeaderMap& response_headers, Buffer::Instance& response);
+  Http::Code handlerRoutes(const std::string& path_and_query, Http::HeaderMap& response_headers,
+                           Buffer::Instance& response) const;
   Http::Code handlerResetCounters(const std::string& path_and_query,
                                   Http::HeaderMap& response_headers, Buffer::Instance& response);
   Http::Code handlerServerInfo(const std::string& path_and_query, Http::HeaderMap& response_headers,
@@ -168,6 +170,11 @@ private:
                           Buffer::Instance& response);
   Http::Code handlerRuntime(const std::string& path_and_query, Http::HeaderMap& response_headers,
                             Buffer::Instance& response);
+
+  // Helper for handlerRoutes
+  Http::Code
+  handlerRoutesLoop(Buffer::Instance& response,
+                    const std::vector<Router::RdsRouteConfigProviderSharedPtr> providers) const;
 
   class AdminListener : public Network::ListenerConfig {
   public:

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -51,7 +51,7 @@ ProdListenerComponentFactory::createNetworkFilterFactoryList_(
 std::vector<Configuration::ListenerFilterFactoryCb>
 ProdListenerComponentFactory::createListenerFilterFactoryList_(
     const Protobuf::RepeatedPtrField<envoy::api::v2::listener::ListenerFilter>& filters,
-    Configuration::ListenerFactoryContext& context) {
+    Configuration::FactoryContext& context) {
   std::vector<Configuration::ListenerFilterFactoryCb> ret;
   for (ssize_t i = 0; i < filters.size(); i++) {
     const auto& proto_config = filters[i];

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -35,7 +35,7 @@ public:
    */
   static std::vector<Configuration::ListenerFilterFactoryCb> createListenerFilterFactoryList_(
       const Protobuf::RepeatedPtrField<envoy::api::v2::listener::ListenerFilter>& filters,
-      Configuration::ListenerFactoryContext& context);
+      Configuration::FactoryContext& context);
 
   // Server::ListenerComponentFactory
   std::vector<Configuration::NetworkFilterFactoryCb> createNetworkFilterFactoryList(
@@ -45,7 +45,7 @@ public:
   }
   std::vector<Configuration::ListenerFilterFactoryCb> createListenerFilterFactoryList(
       const Protobuf::RepeatedPtrField<envoy::api::v2::listener::ListenerFilter>& filters,
-      Configuration::ListenerFactoryContext& context) override {
+      Configuration::FactoryContext& context) override {
     return createListenerFilterFactoryList_(filters, context);
   }
 
@@ -166,7 +166,7 @@ private:
  * Maps proto config to runtime config for a listener with a network filter chain.
  */
 class ListenerImpl : public Network::ListenerConfig,
-                     public Configuration::ListenerFactoryContext,
+                     public Configuration::FactoryContext,
                      public Network::DrainDecision,
                      public Network::FilterChainFactory,
                      public Configuration::TransportSocketFactoryContext,
@@ -224,7 +224,7 @@ public:
   uint64_t listenerTag() const override { return listener_tag_; }
   const std::string& name() const override { return name_; }
 
-  // Server::Configuration::ListenerFactoryContext
+  // Server::Configuration::FactoryContext
   AccessLog::AccessLogManager& accessLogManager() override {
     return parent_.server_.accessLogManager();
   }

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -51,10 +51,8 @@ public:
     route_config_provider_manager_.reset(new RouteConfigProviderManagerImpl(
         runtime_, dispatcher_, random_, local_info_, tls_, admin_));
   }
-  ~RdsImplTest() {
-    EXPECT_CALL(admin_, removeHandler("/routes"));
-    tls_.shutdownThread();
-  }
+
+  ~RdsImplTest() { tls_.shutdownThread(); }
 
   void setup() {
     const std::string config_json = R"EOF(
@@ -512,10 +510,8 @@ public:
     route_config_provider_manager_.reset(new RouteConfigProviderManagerImpl(
         runtime_, dispatcher_, random_, local_info_, tls_, admin_));
   }
-  ~RouteConfigProviderManagerImplTest() {
-    EXPECT_CALL(admin_, removeHandler("/routes"));
-    tls_.shutdownThread();
-  }
+
+  ~RouteConfigProviderManagerImplTest() { tls_.shutdownThread(); }
 
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Upstream::MockClusterManager> cm_;

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -44,10 +44,6 @@ parseHttpConnectionManagerFromJson(const std::string& json_string) {
 class RdsImplTest : public testing::Test {
 public:
   RdsImplTest() : request_(&cm_.async_client_) {
-    EXPECT_CALL(admin_,
-                addHandler("/routes", "print out currently loaded dynamic HTTP route tables", _,
-                           true, false))
-        .WillOnce(DoAll(SaveArg<2>(&handler_callback_), Return(true)));
     route_config_provider_manager_.reset(new RouteConfigProviderManagerImpl(
         runtime_, dispatcher_, random_, local_info_, tls_, admin_));
   }
@@ -119,7 +115,6 @@ public:
   RouteConfigProviderSharedPtr rds_;
   Event::MockTimer* interval_timer_{};
   Http::AsyncClient::Callbacks* callbacks_{};
-  Server::Admin::HandlerCb handler_callback_;
 };
 
 TEST_F(RdsImplTest, RdsAndStatic) {
@@ -209,31 +204,7 @@ TEST_F(RdsImplTest, Basic) {
 
   // Make sure the initial empty route table works.
   EXPECT_EQ(nullptr, rds_->config()->route(Http::TestHeaderMapImpl{{":authority", "foo"}}, 0));
-
-  // Test Admin /routes handler. There should be no route table to dump.
-  const std::string& routes_expected_output_no_routes = R"EOF([
-{
-"version_info": "",
-"route_config_name": "foo_route_config",
-"config_source": {
- "api_config_source": {
-  "cluster_names": [
-   "foo_cluster"
-  ],
-  "refresh_delay": "1s"
- }
-}
-,
-"route_table_dump": {}
-
-}
-]
-)EOF";
   EXPECT_EQ("", rds_->versionInfo());
-  Http::HeaderMapImpl header_map;
-  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes", header_map, data));
-  EXPECT_EQ(routes_expected_output_no_routes, TestUtility::bufferToString(data));
-  data.drain(data.length());
   EXPECT_EQ(0UL, store_.gauge("foo.rds.foo_route_config.version").value());
 
   // Initial request.
@@ -252,32 +223,6 @@ TEST_F(RdsImplTest, Basic) {
   callbacks_->onSuccess(std::move(message));
   EXPECT_EQ(nullptr, rds_->config()->route(Http::TestHeaderMapImpl{{":authority", "foo"}}, 0));
 
-  // Test Admin /routes handler. Now we should have an empty route table, with exception of name.
-  const std::string routes_expected_output_only_name = R"EOF([
-{
-"version_info": "hash_15ed54077da94d8b",
-"route_config_name": "foo_route_config",
-"config_source": {
- "api_config_source": {
-  "cluster_names": [
-   "foo_cluster"
-  ],
-  "refresh_delay": "1s"
- }
-}
-,
-"route_table_dump": {
- "name": "foo_route_config"
-}
-
-}
-]
-)EOF";
-
-  EXPECT_EQ("hash_15ed54077da94d8b", rds_->versionInfo());
-  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes", header_map, data));
-  EXPECT_EQ(routes_expected_output_only_name, TestUtility::bufferToString(data));
-  data.drain(data.length());
   EXPECT_EQ(1580011435426663819U, store_.gauge("foo.rds.foo_route_config.version").value());
 
   expectRequest();
@@ -291,12 +236,6 @@ TEST_F(RdsImplTest, Basic) {
   EXPECT_CALL(*interval_timer_, enableTimer(_));
   callbacks_->onSuccess(std::move(message));
   EXPECT_EQ(nullptr, rds_->config()->route(Http::TestHeaderMapImpl{{":authority", "foo"}}, 0));
-
-  // Test Admin /routes handler. The route table should not change.
-  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes", header_map, data));
-  EXPECT_EQ(routes_expected_output_only_name, TestUtility::bufferToString(data));
-  data.drain(data.length());
-  EXPECT_EQ(1580011435426663819U, store_.gauge("foo.rds.foo_route_config.version").value());
 
   expectRequest();
   interval_timer_->callback_();
@@ -340,82 +279,6 @@ TEST_F(RdsImplTest, Basic) {
                        ->route(Http::TestHeaderMapImpl{{":authority", "foo"}, {":path", "/foo"}}, 0)
                        ->routeEntry()
                        ->clusterName());
-
-  // Test Admin /routes handler. The route table should now have the information given in
-  // response2_json.
-  const std::string routes_expected_output_full_table = R"EOF([
-{
-"version_info": "hash_7a3f97b327d08382",
-"route_config_name": "foo_route_config",
-"config_source": {
- "api_config_source": {
-  "cluster_names": [
-   "foo_cluster"
-  ],
-  "refresh_delay": "1s"
- }
-}
-,
-"route_table_dump": {
- "name": "foo_route_config",
- "virtual_hosts": [
-  {
-   "name": "local_service",
-   "domains": [
-    "*"
-   ],
-   "routes": [
-    {
-     "match": {
-      "prefix": "/foo"
-     },
-     "route": {
-      "cluster_header": ":authority"
-     }
-    },
-    {
-     "match": {
-      "prefix": "/bar"
-     },
-     "route": {
-      "cluster": "bar"
-     }
-    }
-   ]
-  }
- ]
-}
-
-}
-]
-)EOF";
-
-  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes", header_map, data));
-  EXPECT_EQ(routes_expected_output_full_table, TestUtility::bufferToString(data));
-  data.drain(data.length());
-  EXPECT_EQ(8808926191882896258U, store_.gauge("foo.rds.foo_route_config.version").value());
-
-  // Test that we get the same dump if we specify the route name.
-  EXPECT_EQ(Http::Code::OK,
-            handler_callback_("/routes?route_config_name=foo_route_config", header_map, data));
-  EXPECT_EQ(routes_expected_output_full_table, TestUtility::bufferToString(data));
-  data.drain(data.length());
-
-  // Test that we get an emtpy response if the name does not match.
-  EXPECT_EQ(Http::Code::OK,
-            handler_callback_("/routes?route_config_name=does_not_exist", header_map, data));
-  EXPECT_EQ("[\n]\n", TestUtility::bufferToString(data));
-  data.drain(data.length());
-
-  const std::string routes_expected_output_usage = R"EOF({
-    "general_usage": "/routes (dump all dynamic HTTP route tables).",
-    "specify_name_usage": "/routes?route_config_name=<name> (dump all dynamic HTTP route tables with the <name> if any)."
-})EOF";
-
-  // Test that we get the help text if we use the command in an invalid ways.
-  EXPECT_EQ(Http::Code::NotFound, handler_callback_("/routes?bad_param", header_map, data));
-  EXPECT_EQ(routes_expected_output_usage, TestUtility::bufferToString(data));
-  data.drain(data.length());
 
   // Old config use count should be 1 now.
   EXPECT_EQ(1, config.use_count());
@@ -503,10 +366,6 @@ public:
   }
 
   RouteConfigProviderManagerImplTest() {
-    EXPECT_CALL(admin_,
-                addHandler("/routes", "print out currently loaded dynamic HTTP route tables", _,
-                           true, false))
-        .WillOnce(DoAll(SaveArg<2>(&handler_callback_), Return(true)));
     route_config_provider_manager_.reset(new RouteConfigProviderManagerImpl(
         runtime_, dispatcher_, random_, local_info_, tls_, admin_));
   }
@@ -523,7 +382,6 @@ public:
   NiceMock<Init::MockManager> init_manager_;
   NiceMock<Server::MockAdmin> admin_;
   envoy::config::filter::network::http_connection_manager::v2::Rds rds_;
-  Server::Admin::HandlerCb handler_callback_;
   std::unique_ptr<RouteConfigProviderManagerImpl> route_config_provider_manager_;
   RouteConfigProviderSharedPtr provider_;
 };
@@ -574,46 +432,6 @@ TEST_F(RouteConfigProviderManagerImplTest, Basic) {
   EXPECT_EQ(2UL, configured_providers.size());
   EXPECT_EQ(3UL, provider_.use_count());
   EXPECT_EQ(2UL, provider3.use_count());
-
-  const std::string routes_expected_output = R"EOF([
-{
-"version_info": "",
-"route_config_name": "foo_route_config",
-"config_source": {
- "api_config_source": {
-  "cluster_names": [
-   "bar_cluster"
-  ],
-  "refresh_delay": "1s"
- }
-}
-,
-"route_table_dump": {}
-
-}
-,{
-"version_info": "",
-"route_config_name": "foo_route_config",
-"config_source": {
- "api_config_source": {
-  "cluster_names": [
-   "foo_cluster"
-  ],
-  "refresh_delay": "1s"
- }
-}
-,
-"route_table_dump": {}
-
-}
-]
-)EOF";
-
-  // Test Admin /routes handler.
-  Http::HeaderMapImpl header_map;
-  EXPECT_EQ(Http::Code::OK, handler_callback_("/routes", header_map, data));
-  EXPECT_EQ(routes_expected_output, TestUtility::bufferToString(data));
-  data.drain(data.length());
 
   provider_.reset();
   provider2.reset();

--- a/test/common/singleton/manager_impl_test.cc
+++ b/test/common/singleton/manager_impl_test.cc
@@ -41,5 +41,18 @@ TEST(SingletonManagerImplTest, Basic) {
   singleton.reset();
 }
 
+TEST(SingletonManagerImplTest, TryGet) {
+  ManagerImpl manager;
+
+  auto singleton = std::make_shared<TestSingleton>();
+  EXPECT_EQ(nullptr, manager.tryGet("test_singleton"));
+  EXPECT_EQ(singleton, manager.get("test_singleton", [singleton] { return singleton; }));
+  EXPECT_EQ(singleton, manager.tryGet("test_singleton"));
+  EXPECT_EQ(singleton, manager.tryGetTyped<TestSingleton>("test_singleton"));
+
+  EXPECT_CALL(*singleton, onDestroy());
+  singleton.reset();
+}
+
 } // namespace Singleton
 } // namespace Envoy

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -60,7 +60,7 @@ public:
     ON_CALL(component_factory_, createListenerFilterFactoryList(_, _))
         .WillByDefault(Invoke(
             [&](const Protobuf::RepeatedPtrField<envoy::api::v2::listener::ListenerFilter>& filters,
-                Server::Configuration::ListenerFactoryContext& context)
+                Server::Configuration::FactoryContext& context)
                 -> std::vector<Server::Configuration::ListenerFilterFactoryCb> {
               return Server::ProdListenerComponentFactory::createListenerFilterFactoryList_(
                   filters, context);

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -142,9 +142,6 @@ MockFactoryContext::~MockFactoryContext() {}
 MockTransportSocketFactoryContext::MockTransportSocketFactoryContext() {}
 MockTransportSocketFactoryContext::~MockTransportSocketFactoryContext() {}
 
-MockListenerFactoryContext::MockListenerFactoryContext() {}
-MockListenerFactoryContext::~MockListenerFactoryContext() {}
-
 } // namespace Configuration
 } // namespace Server
 } // namespace Envoy

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -164,7 +164,7 @@ public:
   MOCK_METHOD2(createListenerFilterFactoryList,
                std::vector<Configuration::ListenerFilterFactoryCb>(
                    const Protobuf::RepeatedPtrField<envoy::api::v2::listener::ListenerFilter>&,
-                   Configuration::ListenerFactoryContext& context));
+                   Configuration::FactoryContext& context));
   MOCK_METHOD2(createListenSocket,
                Network::SocketSharedPtr(Network::Address::InstanceConstSharedPtr address,
                                         bool bind_to_port));
@@ -342,6 +342,7 @@ public:
   MOCK_METHOD0(admin, Server::Admin&());
   MOCK_METHOD0(listenerScope, Stats::Scope&());
   MOCK_CONST_METHOD0(listenerMetadata, const envoy::api::v2::core::Metadata&());
+  MOCK_METHOD1(setListenSocketOptions, void(const Network::Socket::OptionsSharedPtr&));
 
   testing::NiceMock<AccessLog::MockAccessLogManager> access_log_manager_;
   testing::NiceMock<Upstream::MockClusterManager> cluster_manager_;
@@ -366,14 +367,6 @@ public:
 
   MOCK_METHOD0(sslContextManager, Ssl::ContextManager&());
   MOCK_CONST_METHOD0(statsScope, Stats::Scope&());
-};
-
-class MockListenerFactoryContext : public MockFactoryContext {
-public:
-  MockListenerFactoryContext();
-  ~MockListenerFactoryContext();
-
-  MOCK_METHOD1(setListenSocketOptions, void(const Network::Socket::OptionsSharedPtr&));
 };
 
 } // namespace Configuration

--- a/test/server/http/BUILD
+++ b/test/server/http/BUILD
@@ -22,6 +22,7 @@ envoy_cc_test(
         "//test/mocks/server:server_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
+        "//test/test_common:registry_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -15,6 +15,7 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 #include "test/test_common/printers.h"
+#include "test/test_common/registry.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -273,6 +274,100 @@ TEST_P(AdminInstanceTest, RuntimeBadFormat) {
   EXPECT_EQ(Http::Code::BadRequest,
             admin_.runCallback("/runtime?format=foo", header_map, response));
   EXPECT_EQ("usage: /runtime?format=json\n", TestUtility::bufferToString(response));
+}
+
+class MockHttpConnectionManagerFilterConfigFactory
+    : public Configuration::HttpConnectionManagerFilterConfigFactory {
+public:
+  MOCK_METHOD1(getServerRouteConfigProviderManager,
+               std::shared_ptr<Router::ServerRouteConfigProviderManager>(ServerContext&));
+};
+
+class MockRdsRouteConfigProvider : public Router::RdsRouteConfigProvider {
+public:
+  MOCK_METHOD0(config, Router::ConfigConstSharedPtr());
+  MOCK_CONST_METHOD0(versionInfo, const std::string());
+  // RdsRouteConfigProvider
+  MOCK_CONST_METHOD0(configAsJson, std::string());
+  MOCK_CONST_METHOD0(routeConfigName, const std::string&());
+  MOCK_CONST_METHOD0(configSource, const std::string&());
+};
+
+class MockRouteConfigProviderManager : public Router::ServerRouteConfigProviderManager {
+public:
+  // RouteConfigProviderManager
+  MOCK_METHOD5(getRouteConfigProvider,
+               Router::RouteConfigProviderSharedPtr(
+                   const envoy::config::filter::network::http_connection_manager::v2::Rds&,
+                   Upstream::ClusterManager&, Stats::Scope&, const std::string&, Init::Manager&));
+  // ServerRouteConfigProviderManager
+  MOCK_METHOD0(rdsRouteConfigProviders, std::vector<Router::RdsRouteConfigProviderSharedPtr>());
+};
+
+TEST_P(AdminInstanceTest, Routes) {
+  MockHttpConnectionManagerFilterConfigFactory factory;
+  Registry::InjectFactory<Configuration::NamedNetworkFilterConfigFactory> inject_factory{factory};
+
+  auto provider_manager = std::make_shared<NiceMock<MockRouteConfigProviderManager>>();
+  auto provider = std::make_shared<NiceMock<MockRdsRouteConfigProvider>>();
+  EXPECT_CALL(factory, getServerRouteConfigProviderManager(_))
+      .WillRepeatedly(testing::Return(provider_manager));
+
+  const std::string& routes_expected_output_empty = R"EOF([
+]
+)EOF";
+
+  Buffer::OwnedImpl data;
+  Http::HeaderMapImpl header_map;
+  EXPECT_EQ(Http::Code::OK, admin_.runCallback("/routes", header_map, data));
+  EXPECT_EQ(routes_expected_output_empty, TestUtility::bufferToString(data));
+  data.drain(data.length());
+
+  const std::string& routes_expected_output_table = R"EOF([
+{
+"version_info": "foo_version",
+"route_config_name": "foo_route_config_name",
+"config_source": "foo_config_source",
+"route_table_dump": {}
+}
+]
+)EOF";
+
+  EXPECT_CALL(*provider_manager, rdsRouteConfigProviders())
+      .WillRepeatedly(
+          testing::Return(std::vector<Router::RdsRouteConfigProviderSharedPtr>{provider}));
+  EXPECT_CALL(*provider, versionInfo()).WillRepeatedly(testing::Return("foo_version"));
+  EXPECT_CALL(*provider, configAsJson()).WillRepeatedly(testing::Return("{}"));
+  const std::string route_config_name = "foo_route_config_name";
+  EXPECT_CALL(*provider, routeConfigName()).WillRepeatedly(testing::ReturnRef(route_config_name));
+  const std::string config_source = "\"foo_config_source\"";
+  EXPECT_CALL(*provider, configSource()).WillRepeatedly(testing::ReturnRef(config_source));
+
+  EXPECT_EQ(Http::Code::OK, admin_.runCallback("/routes", header_map, data));
+  EXPECT_EQ(routes_expected_output_table, TestUtility::bufferToString(data));
+  data.drain(data.length());
+
+  // Test that we get the same dump if we specify the route name.
+  EXPECT_EQ(Http::Code::OK, admin_.runCallback("/routes?route_config_name=foo_route_config_name",
+                                               header_map, data));
+  EXPECT_EQ(routes_expected_output_table, TestUtility::bufferToString(data));
+  data.drain(data.length());
+
+  // Test that we get an empty response if the name does not match.
+  EXPECT_EQ(Http::Code::OK,
+            admin_.runCallback("/routes?route_config_name=does_not_exist", header_map, data));
+  EXPECT_EQ("[\n]\n", TestUtility::bufferToString(data));
+  data.drain(data.length());
+
+  const std::string routes_expected_output_usage = R"EOF({
+    "general_usage": "/routes (dump all dynamic HTTP route tables).",
+    "specify_name_usage": "/routes?route_config_name=<name> (dump all dynamic HTTP route tables with the <name> if any)."
+})EOF";
+
+  // Test that we get the help text if we use the command in an invalid ways.
+  EXPECT_EQ(Http::Code::NotFound, admin_.runCallback("/routes?bad_param", header_map, data));
+  EXPECT_EQ(routes_expected_output_usage, TestUtility::bufferToString(data));
+  data.drain(data.length());
 }
 
 TEST(PrometheusStatsFormatter, MetricName) {

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -111,7 +111,7 @@ public:
     ON_CALL(listener_factory_, createListenerFilterFactoryList(_, _))
         .WillByDefault(Invoke(
             [](const Protobuf::RepeatedPtrField<envoy::api::v2::listener::ListenerFilter>& filters,
-               Configuration::ListenerFactoryContext& context)
+               Configuration::FactoryContext& context)
                 -> std::vector<Configuration::ListenerFilterFactoryCb> {
               return ProdListenerComponentFactory::createListenerFilterFactoryList_(filters,
                                                                                     context);
@@ -1272,7 +1272,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstTestFilter) {
     // NamedListenerFilterConfigFactory
     Configuration::ListenerFilterFactoryCb
     createFilterFactoryFromProto(const Protobuf::Message&,
-                                 Configuration::ListenerFactoryContext& context) override {
+                                 Configuration::FactoryContext& context) override {
       EXPECT_CALL(*options_, setOptions(_)).WillOnce(Invoke([](Network::Socket& socket) -> bool {
         fd = socket.fd();
         return true;
@@ -1347,7 +1347,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstTestFilterOptionFail) 
     // NamedListenerFilterConfigFactory
     Configuration::ListenerFilterFactoryCb
     createFilterFactoryFromProto(const Protobuf::Message&,
-                                 Configuration::ListenerFactoryContext& context) override {
+                                 Configuration::FactoryContext& context) override {
       EXPECT_CALL(*options_, setOptions(_)).WillOnce(Return(false));
       context.setListenSocketOptions(options_);
       return [](Network::ListenerFilterManager& filter_manager) -> void {


### PR DESCRIPTION
*Description*:
This PR is setup for a solution to #2421. For that issue, the admin will have to aggregate config information from multiple xDS consumers. There, the model of adding admin interfaces via `addHandler` breaks down - there is no single source from which to add the handler. Since the route configs are necessary for the aggregated config, I decided to relocate the `/routes` implementation as a guinea pig for decoupling admin functionality from xDS functionality.*

This commit stack contains a few refactors, none of which I'm tied to but were the path of least resistance to getting the config objects available within `AdminImpl`.** LMK if you feel there are better ways.

I noticed that `FactoryContext` contained the bulk of `Server::Instance`'s interface, so I split the context more cleanly between "server context" and "additional context for listeners" so that `AdminImpl` can pass its `Server::Instance` reference as a context to the connection manager. As a result, what is now called `FactoryContext`should probably be called `ListenerContext` but that's an orthogonal refactor.

Note the difference between the old `RdsImplTest` and the new `AdminTest`. The relocated tests now test the admin functionality they purport to (i.e. how the configs are filtered and spat out) and don't rely on rds impl details.

Anywho, I will start building the current config endpoint on top of this.

Below, 'FWIW' means 'it's not worth very much;' I just like to start discussions as a way to learn this project. The below opinions are not meant to be assertive or authoritative but rather food for [my] thought.

\* FWIW, this means there are no longer any external users of `Admin::addHandler/removeHandler`. I'd be in favor of making those private without a new compelling case for dynamism, but I don't care. That the `/routes` handler has to do sanitation is a bit of a warning sign against anyone adding an admin route anywhere. IMO: admin handlers, especially those that modify, should interact with server components through established interfaces, not vice versa.

** FWIW, I think the backflips required to get the `RouteConfigProviderManager` into `AdminImpl` showcase the fragility of a proliferation of singletons, but that's a separate conversation. IMO, the `HttpConnectionManager` and `RouteConfigProviderManager` and other such singletons should be owned by the Server, unless they need to be shared outside the single Server object..

*Risk Level*: Low - no functional production changes

*Testing*: Unit, local testing of /routes endpoint