### PR TITLE
docs: clarifying the merge process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,8 +114,9 @@ maximize the chances of your PR being merged.
 * If there is a question on who should review a PR please discuss in Slack.
 * Anyone is welcome to review any PR that they want, whether they are a maintainer or not.
 * Please **clean up the commit message** before merging. By default, GitHub fills the squash merge
-  commit message with every individual commit from the PR. Generally, we want a commit message
-  that is roughly equal to the original PR title and description.
+  commit message with every individual commit from the PR. Generally, the maintainer doing the merge
+  should overwrite these with the original PR title and description (cleaning it up if necessary)
+  while preserving the PR author's final DCO sign-off.
 * If a PR includes a deprecation/breaking change, notification should be sent to the
   [envoy-announce](https://groups.google.com/forum/#!forum/envoy-announce) email list.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ maximize the chances of your PR being merged.
 * Anyone is welcome to review any PR that they want, whether they are a maintainer or not.
 * Please **clean up the commit message** before merging. By default, GitHub fills the squash merge
   commit message with every individual commit from the PR. Generally, the maintainer doing the merge
-  should overwrite these with the original PR title and description (cleaning it up if necessary)
+  should overwrite these with the original PR title and body (cleaning it up if necessary)
   while preserving the PR author's final DCO sign-off.
 * If a PR includes a deprecation/breaking change, notification should be sent to the
   [envoy-announce](https://groups.google.com/forum/#!forum/envoy-announce) email list.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,9 +113,10 @@ maximize the chances of your PR being merged.
   organization specific shortcuts into the code.
 * If there is a question on who should review a PR please discuss in Slack.
 * Anyone is welcome to review any PR that they want, whether they are a maintainer or not.
-* Please **clean up the commit message** before merging. By default, GitHub fills the squash merge
-  commit message with every individual commit from the PR. Generally, the maintainer doing the merge
-  should overwrite these with the original PR title and body (cleaning it up if necessary)
+* Please **clean up the title and body** before merging. By default, GitHub fills the squash merge
+  title with the original title, and the commit body with every individual commit from the PR.
+  The maintainer doing the merge should make sure the title follows the guidelines above and should
+  overwrite the body with the original extended description from the PR (cleaning it up if necessary)
   while preserving the PR author's final DCO sign-off.
 * If a PR includes a deprecation/breaking change, notification should be sent to the
   [envoy-announce](https://groups.google.com/forum/#!forum/envoy-announce) email list.


### PR DESCRIPTION
Documenting that the merge should retain DCO, as discussed on #2600 

*Risk Level*: n/a
*Testing*: n/a
*Release Notes*: n/a
