### PR TITLE
logger: macros evaluate logging level before invoking logger

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -208,9 +208,11 @@ protected:
  * Convenience macro to log to a user-specified logger.
  */
 #define ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ...)                                                    \
-  if (static_cast<spdlog::level::level_enum>(Logger::Logger::LEVEL) >= LOGGER.level()) {           \
-    ENVOY_LOG_##LEVEL##_TO_LOGGER(LOGGER, ##__VA_ARGS__);                                          \
-  }
+  do {                                                                                             \
+    if (static_cast<spdlog::level::level_enum>(Logger::Logger::LEVEL) >= LOGGER.level()) {         \
+      ENVOY_LOG_##LEVEL##_TO_LOGGER(LOGGER, ##__VA_ARGS__);                                        \
+    }                                                                                              \
+  } while (0)
 
 /**
  * Convenience macro to get logger.

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -57,6 +57,21 @@ public:
   std::string name() const { return logger_->name(); }
   void setLevel(spdlog::level::level_enum level) const { logger_->set_level(level); }
 
+  /* This is simple mapping between Logger severity levels and spdlog severity levels.
+   * The only reason for this mapping is to go around the fact that spdlog defines level as err
+   * but the method to log at err level is called LOGGER.error not LOGGER.err. All other level are
+   * fine spdlog::info corresponds to LOGGER.info method.
+   */
+  typedef enum {
+    trace = spdlog::level::trace,
+    debug = spdlog::level::debug,
+    info = spdlog::level::info,
+    warn = spdlog::level::warn,
+    error = spdlog::level::err,
+    critical = spdlog::level::critical,
+    off = spdlog::level::off
+  } levels;
+
 private:
   Logger(const std::string& name);
 
@@ -192,7 +207,10 @@ protected:
 /**
  * Convenience macro to log to a user-specified logger.
  */
-#define ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ...) ENVOY_LOG_##LEVEL##_TO_LOGGER(LOGGER, ##__VA_ARGS__)
+#define ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ...)                                                    \
+  if (static_cast<spdlog::level::level_enum>(Logger::Logger::LEVEL) >= LOGGER.level()) {           \
+    ENVOY_LOG_##LEVEL##_TO_LOGGER(LOGGER, ##__VA_ARGS__);                                          \
+  }
 
 /**
  * Convenience macro to get logger.

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -209,7 +209,7 @@ protected:
  */
 #define ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ...)                                                    \
   do {                                                                                             \
-    if (static_cast<spdlog::level::level_enum>(Logger::Logger::LEVEL) >= LOGGER.level()) {         \
+    if (static_cast<spdlog::level::level_enum>(Envoy::Logger::Logger::LEVEL) >= LOGGER.level()) {  \
       ENVOY_LOG_##LEVEL##_TO_LOGGER(LOGGER, ##__VA_ARGS__);                                        \
     }                                                                                              \
   } while (0)

--- a/source/common/http/filter/lua/lua_filter.cc
+++ b/source/common/http/filter/lua/lua_filter.cc
@@ -481,17 +481,23 @@ void Filter::scriptError(const Envoy::Lua::LuaException& e) {
 void Filter::scriptLog(spdlog::level::level_enum level, const char* message) {
   switch (level) {
   case spdlog::level::trace:
-    return ENVOY_LOG(trace, "script log: {}", message);
+    ENVOY_LOG(trace, "script log: {}", message);
+    return;
   case spdlog::level::debug:
-    return ENVOY_LOG(debug, "script log: {}", message);
+    ENVOY_LOG(debug, "script log: {}", message);
+    return;
   case spdlog::level::info:
-    return ENVOY_LOG(info, "script log: {}", message);
+    ENVOY_LOG(info, "script log: {}", message);
+    return;
   case spdlog::level::warn:
-    return ENVOY_LOG(warn, "script log: {}", message);
+    ENVOY_LOG(warn, "script log: {}", message);
+    return;
   case spdlog::level::err:
-    return ENVOY_LOG(error, "script log: {}", message);
+    ENVOY_LOG(error, "script log: {}", message);
+    return;
   case spdlog::level::critical:
-    return ENVOY_LOG(critical, "script log: {}", message);
+    ENVOY_LOG(critical, "script log: {}", message);
+    return;
   case spdlog::level::off:
     NOT_IMPLEMENTED;
   }

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -37,4 +37,24 @@ TEST(Logger, All) {
   // Misc logging with no facility.
   ENVOY_LOG_MISC(info, "fake message");
 }
+
+TEST(Logger, evaluateParams) {
+  auto i = 1;
+
+  // set logger's level to low level.
+  // log message with higher severity and make sure that params were evaluated.
+  GET_MISC_LOGGER().set_level(spdlog::level::info);
+  ENVOY_LOG_MISC(warn, "test message '{}'", i++);
+  ASSERT_THAT(i, testing::Eq(2));
+}
+
+TEST(Logger, doNotEvaluateParams) {
+  auto i = 1;
+
+  // set logger's logging level high and log a message with lower severity
+  // params should not be evaluated.
+  GET_MISC_LOGGER().set_level(spdlog::level::critical);
+  ENVOY_LOG_MISC(error, "test message '{}'", i++);
+  ASSERT_THAT(i, testing::Eq(1));
+}
 } // namespace Envoy

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -39,7 +39,7 @@ TEST(Logger, All) {
 }
 
 TEST(Logger, evaluateParams) {
-  auto i = 1;
+  uint32_t i = 1;
 
   // set logger's level to low level.
   // log message with higher severity and make sure that params were evaluated.
@@ -49,12 +49,28 @@ TEST(Logger, evaluateParams) {
 }
 
 TEST(Logger, doNotEvaluateParams) {
-  auto i = 1;
+  uint32_t i = 1;
 
   // set logger's logging level high and log a message with lower severity
   // params should not be evaluated.
   GET_MISC_LOGGER().set_level(spdlog::level::critical);
   ENVOY_LOG_MISC(error, "test message '{}'", i++);
   ASSERT_THAT(i, testing::Eq(1));
+}
+
+TEST(Logger, logAsStatement) {
+  // Just log as part of if ... statement
+
+  if (true)
+    ENVOY_LOG_MISC(critical, "test message 1");
+  else
+    ENVOY_LOG_MISC(critical, "test message 2");
+
+  // do the same with curly brackets
+  if (true) {
+    ENVOY_LOG_MISC(critical, "test message 3");
+  } else {
+    ENVOY_LOG_MISC(critical, "test message 4");
+  }
 }
 } // namespace Envoy

--- a/test/common/common/utility_speed_test.cc
+++ b/test/common/common/utility_speed_test.cc
@@ -7,8 +7,6 @@
 #include "absl/strings/string_view.h"
 #include "testing/base/public/benchmark.h"
 
-using namespace Envoy;
-
 static const char TextToTrim[] = "\t  the quick brown fox jumps over the lazy dog\n\r\n";
 static size_t TextToTrimLength = sizeof(TextToTrim) - 1;
 

--- a/test/common/common/utility_speed_test.cc
+++ b/test/common/common/utility_speed_test.cc
@@ -7,6 +7,8 @@
 #include "absl/strings/string_view.h"
 #include "testing/base/public/benchmark.h"
 
+using namespace Envoy;
+
 static const char TextToTrim[] = "\t  the quick brown fox jumps over the lazy dog\n\r\n";
 static size_t TextToTrimLength = sizeof(TextToTrim) - 1;
 


### PR DESCRIPTION
Modified main logging macro to compare logger's severity with severity of the message to be logged. If message severity is lower, logger is not called and code passed as params is not evaluated.