### PR TITLE
test: Only fix up IP address for socket addresses.

### DIFF
--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -119,8 +119,10 @@ ConfigHelper::ConfigHelper(const Network::Address::IpVersion version, const std:
 
   for (int i = 0; i < static_resources->clusters_size(); ++i) {
     auto* cluster = static_resources->mutable_clusters(i);
-    auto host_socket_addr = cluster->mutable_hosts(0)->mutable_socket_address();
-    host_socket_addr->set_address(Network::Test::getLoopbackAddressString(version));
+    if (cluster->mutable_hosts(0)->has_socket_address()) {
+      auto host_socket_addr = cluster->mutable_hosts(0)->mutable_socket_address();
+      host_socket_addr->set_address(Network::Test::getLoopbackAddressString(version));
+    }
   }
 }
 


### PR DESCRIPTION
If cluster's host is defined as a unix domain socket ("pipe") setting
an address changes it to a "socket_address" instead. Prevent this by
fixing addresses only if the host is already a "socket_address".

This change allows test configurations to specify clusters using unix
domain sockets. No tests do this currently, but this allows
configuration of gRPC apis (e.g., RDS) without failing on
configuration validation.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
Risk Level: Low
