### PR TITLE
server: make the --disable-hot-restart flag functional

### DIFF
--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -10,19 +10,13 @@
  * after setting up command line options.
  */
 int main(int argc, char** argv) {
-#ifdef ENVOY_HOT_RESTART
-  constexpr bool enable_hot_restart = true;
-#else
-  constexpr bool enable_hot_restart = false;
-#endif
-
   std::unique_ptr<Envoy::MainCommon> main_common;
 
   // Initialize the server's main context under a try/catch loop and simply return EXIT_FAILURE
   // as needed. Whatever code in the initialization path that fails is expected to log an error
   // message so the user can diagnose.
   try {
-    main_common = std::make_unique<Envoy::MainCommon>(argc, argv, enable_hot_restart);
+    main_common = std::make_unique<Envoy::MainCommon>(argc, argv);
   } catch (const Envoy::NoServingException& e) {
     return EXIT_SUCCESS;
   } catch (const Envoy::MalformedArgvException& e) {

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -98,8 +98,6 @@ std::string MainCommon::hotRestartVersion(uint64_t max_num_stats, uint64_t max_s
     return Server::HotRestartImpl::hotRestartVersion(max_num_stats, max_stat_name_len);
   }
 #else
-  // Hot-restart should not be specified if the support is not compiled in.
-  RELEASE_ASSERT(!hot_restart_enabled);
   UNREFERENCED_PARAMETER(max_num_stats);
   UNREFERENCED_PARAMETER(max_stat_name_len);
 #endif

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -98,6 +98,7 @@ std::string MainCommon::hotRestartVersion(uint64_t max_num_stats, uint64_t max_s
     return Server::HotRestartImpl::hotRestartVersion(max_num_stats, max_stat_name_len);
   }
 #else
+  UNREFERENCED_PARAMETER(hot_restart_enabled);
   UNREFERENCED_PARAMETER(max_num_stats);
   UNREFERENCED_PARAMETER(max_stat_name_len);
 #endif

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -37,7 +37,7 @@ Runtime::LoaderPtr ProdComponentFactory::createRuntime(Server::Instance& server,
   return Server::InstanceUtil::createRuntime(server, config);
 }
 
-MainCommonBase::MainCommonBase(OptionsImpl& options, bool hot_restart) : options_(options) {
+MainCommonBase::MainCommonBase(OptionsImpl& options) : options_(options) {
   ares_library_init(ARES_LIB_INIT_ALL);
   Event::Libevent::Global::initialize();
   RELEASE_ASSERT(Envoy::Server::validateProtoDescriptors());
@@ -45,11 +45,11 @@ MainCommonBase::MainCommonBase(OptionsImpl& options, bool hot_restart) : options
   switch (options_.mode()) {
   case Server::Mode::Serve: {
 #ifdef ENVOY_HOT_RESTART
-    if (hot_restart) {
+    if (!options.hotRestartDisabled()) {
       restarter_.reset(new Server::HotRestartImpl(options_));
     }
 #endif
-    if (!hot_restart) {
+    if (restarter_.get() == nullptr) {
       restarter_.reset(new Server::HotRestartNopImpl());
     }
 
@@ -88,26 +88,22 @@ bool MainCommonBase::run() {
   NOT_REACHED;
 }
 
-MainCommon::MainCommon(int argc, char** argv, bool hot_restart)
-    : options_(computeOptions(argc, argv, hot_restart)), base_(*options_, hot_restart) {}
+MainCommon::MainCommon(int argc, char** argv)
+    : options_(argc, argv, &MainCommon::hotRestartVersion, spdlog::level::info), base_(options_) {}
 
-std::unique_ptr<OptionsImpl> MainCommon::computeOptions(int argc, char** argv, bool hot_restart) {
-  OptionsImpl::HotRestartVersionCb hot_restart_version_cb = [](uint64_t, uint64_t) {
-    return "disabled";
-  };
-
+std::string MainCommon::hotRestartVersion(uint64_t max_num_stats, uint64_t max_stat_name_len,
+                                          bool hot_restart_enabled) {
 #ifdef ENVOY_HOT_RESTART
-  if (hot_restart) {
-    // Enabled by default, except on OS X. Control with "bazel --define=hot_restart=disabled"
-    hot_restart_version_cb = [](uint64_t max_num_stats, uint64_t max_stat_name_len) {
-      return Server::HotRestartImpl::hotRestartVersion(max_num_stats, max_stat_name_len);
-    };
+  if (hot_restart_enabled) {
+    return Server::HotRestartImpl::hotRestartVersion(max_num_stats, max_stat_name_len);
   }
 #else
   // Hot-restart should not be specified if the support is not compiled in.
-  RELEASE_ASSERT(!hot_restart);
+  RELEASE_ASSERT(!hot_restart_enabled);
+  UNREFERENCED_PARAMETER(max_num_stats);
+  UNREFERENCED_PARAMETER(max_stat_name_len);
 #endif
-  return std::make_unique<OptionsImpl>(argc, argv, hot_restart_version_cb, spdlog::level::info);
+  return "disabled";
 }
 
 // Legacy implementation of main_common.
@@ -116,11 +112,7 @@ std::unique_ptr<OptionsImpl> MainCommon::computeOptions(int argc, char** argv, b
 // and MainCommon can be merged. The current theory is that only Google calls this.
 int main_common(OptionsImpl& options) {
   try {
-#if ENVOY_HOT_RESTART
-    MainCommonBase main_common(options, true);
-#else
-    MainCommonBase main_common(options, false);
-#endif
+    MainCommonBase main_common(options);
     return main_common.run() ? EXIT_SUCCESS : EXIT_FAILURE;
   } catch (EnvoyException& e) {
     return EXIT_FAILURE;

--- a/source/exe/main_common.h
+++ b/source/exe/main_common.h
@@ -22,7 +22,7 @@ public:
 
 class MainCommonBase {
 public:
-  MainCommonBase(OptionsImpl& options, bool hot_restart);
+  MainCommonBase(OptionsImpl& options);
   ~MainCommonBase();
 
   bool run();
@@ -39,18 +39,18 @@ protected:
 
 class MainCommon {
 public:
-  MainCommon(int argc, char** argv, bool hot_restart);
+  MainCommon(int argc, char** argv);
   bool run() { return base_.run(); }
 
-private:
-  static std::unique_ptr<Envoy::OptionsImpl> computeOptions(int argc, char** argv,
-                                                            bool hot_restart);
+  static std::string hotRestartVersion(uint64_t max_num_stats, uint64_t max_stat_name_len,
+                                       bool hot_restart_enabled);
 
+private:
 #ifdef ENVOY_HANDLE_SIGNALS
   Envoy::SignalAction handle_sigs;
 #endif
 
-  std::unique_ptr<Envoy::OptionsImpl> options_;
+  Envoy::OptionsImpl options_;
   MainCommonBase base_;
 };
 

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -120,10 +120,12 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_r
     throw MalformedArgvException(message);
   }
 
+  hot_restart_disabled_ = disable_hot_restart.getValue();
   if (hot_restart_version_option.getValue()) {
     std::cerr << hot_restart_version_cb(max_stats.getValue(),
                                         max_obj_name_len.getValue() +
-                                            Stats::RawStatData::maxStatSuffixLength());
+                                            Stats::RawStatData::maxStatSuffixLength(),
+                                        !hot_restart_disabled_);
     throw NoServingException();
   }
 
@@ -171,6 +173,5 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_r
   parent_shutdown_time_ = std::chrono::seconds(parent_shutdown_time_s.getValue());
   max_stats_ = max_stats.getValue();
   max_obj_name_length_ = max_obj_name_len.getValue();
-  hot_restart_disabled_ = disable_hot_restart.getValue();
 }
 } // namespace Envoy

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -15,7 +15,10 @@ namespace Envoy {
  */
 class OptionsImpl : public Server::Options {
 public:
-  typedef std::function<std::string(uint64_t, uint64_t)> HotRestartVersionCb;
+  /**
+   * Parameters are max_num_stats, max_stat_name_len, hot_restart_enabled
+   */
+  typedef std::function<std::string(uint64_t, uint64_t, bool)> HotRestartVersionCb;
 
   /**
    * @throw NoServingException if Envoy has already done everything specified by the argv (e.g.

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -68,7 +68,10 @@ public:
 
   // Adds an argument, assuring that argv remains null-terminated.
   void addArg(const char* arg) {
-    argv_[argv_.size() - 1] = arg;
+    ASSERT(!argv_.empty());
+    size_t last = argv_.size() - 1;
+    ASSERT(argv_[last] == nullptr); // invariant established in ctor, maintained below.
+    argv_[last] = arg;              // guaranteed non-empty
     argv_.push_back(nullptr);
   }
 

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -12,6 +12,7 @@
 #include "server/options_impl.h"
 
 #include "test/test_common/environment.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -32,7 +33,7 @@ TEST(MainCommon, ConstructDestructHotRestartEnabled) {
   std::string config_file = Envoy::TestEnvironment::getCheckedEnvVar("TEST_RUNDIR") +
                             "/test/config/integration/google_com_proxy_port_0.v2.yaml";
   const char* argv[] = {"envoy-static", "-c", config_file.c_str(), "--base-id", "1", nullptr};
-  EXPECT_NO_THROW(MainCommon main_common(ARRAY_SIZE(argv) - 1, const_cast<char**>(argv)));
+  VERBOSE_EXPECT_NO_THROW(MainCommon main_common(ARRAY_SIZE(argv) - 1, const_cast<char**>(argv)));
 }
 
 TEST(MainCommon, ConstructDestructHotRestartDisabled) {
@@ -43,7 +44,7 @@ TEST(MainCommon, ConstructDestructHotRestartDisabled) {
                             "/test/config/integration/google_com_proxy_port_0.v2.yaml";
   const char* argv[] = {"envoy-static",          "-c",   config_file.c_str(), "--base-id", "2",
                         "--disable-hot-restart", nullptr};
-  EXPECT_NO_THROW(MainCommon main_common(ARRAY_SIZE(argv) - 1, const_cast<char**>(argv)));
+  VERBOSE_EXPECT_NO_THROW(MainCommon main_common(ARRAY_SIZE(argv) - 1, const_cast<char**>(argv)));
 }
 
 TEST(MainCommon, LegacyMain) {

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -52,6 +52,8 @@ public:
    */
   static uint32_t computeBaseId() {
     Runtime::RandomGeneratorImpl random_generator_;
+    // Pick a prime number to give more of the 32-bits of entropy to the PID, and the
+    // remainder to the random number.
     const uint32_t four_digit_prime = 7919;
     return getpid() * four_digit_prime + random_generator_.random() % four_digit_prime;
   }
@@ -113,6 +115,9 @@ TEST_F(MainCommonTest, LegacyMain) {
     return_code = EXIT_FAILURE;
   }
   if (return_code == -1) {
+    // Note that Envoy::main_common() will run an event loop if properly configured, which
+    // would hang the test. This is why we don't supply a config file in this testcase;
+    // we just want to make sure we wake up this code in a test.
     return_code = Envoy::main_common(*options);
   }
   EXPECT_EQ(EXIT_FAILURE, return_code);

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -32,7 +32,7 @@ TEST(MainCommon, ConstructDestructHotRestartEnabled) {
   std::string config_file = Envoy::TestEnvironment::getCheckedEnvVar("TEST_RUNDIR") +
                             "/test/config/integration/google_com_proxy_port_0.v2.yaml";
   const char* argv[] = {"envoy-static", "-c", config_file.c_str(), "--base-id", "1", nullptr};
-  MainCommon main_common(ARRAY_SIZE(argv) - 1, const_cast<char**>(argv));
+  EXPECT_NO_THROW(MainCommon main_common(ARRAY_SIZE(argv) - 1, const_cast<char**>(argv)));
 }
 
 TEST(MainCommon, ConstructDestructHotRestartDisabled) {
@@ -43,7 +43,7 @@ TEST(MainCommon, ConstructDestructHotRestartDisabled) {
                             "/test/config/integration/google_com_proxy_port_0.v2.yaml";
   const char* argv[] = {"envoy-static",          "-c",   config_file.c_str(), "--base-id", "2",
                         "--disable-hot-restart", nullptr};
-  MainCommon main_common(ARRAY_SIZE(argv) - 1, const_cast<char**>(argv));
+  EXPECT_NO_THROW(MainCommon main_common(ARRAY_SIZE(argv) - 1, const_cast<char**>(argv)));
 }
 
 TEST(MainCommon, LegacyMain) {

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -25,14 +25,25 @@
 
 namespace Envoy {
 
-TEST(MainCommon, ConstructDestruct) {
+TEST(MainCommon, ConstructDestructHotRestartEnabled) {
   if (!Envoy::TestEnvironment::shouldRunTestForIpVersion(Network::Address::IpVersion::v4)) {
     return;
   }
   std::string config_file = Envoy::TestEnvironment::getCheckedEnvVar("TEST_RUNDIR") +
                             "/test/config/integration/google_com_proxy_port_0.v2.yaml";
-  const char* argv[] = {"envoy-static", "-c", config_file.c_str(), nullptr};
-  MainCommon main_common(3, const_cast<char**>(argv));
+  const char* argv[] = {"envoy-static", "-c", config_file.c_str(), "--base-id", "1", nullptr};
+  MainCommon main_common(ARRAY_SIZE(argv) - 1, const_cast<char**>(argv));
+}
+
+TEST(MainCommon, ConstructDestructHotRestartDisabled) {
+  if (!Envoy::TestEnvironment::shouldRunTestForIpVersion(Network::Address::IpVersion::v4)) {
+    return;
+  }
+  std::string config_file = Envoy::TestEnvironment::getCheckedEnvVar("TEST_RUNDIR") +
+                            "/test/config/integration/google_com_proxy_port_0.v2.yaml";
+  const char* argv[] = {"envoy-static",          "-c",   config_file.c_str(), "--base-id", "2",
+                        "--disable-hot-restart", nullptr};
+  MainCommon main_common(ARRAY_SIZE(argv) - 1, const_cast<char**>(argv));
 }
 
 TEST(MainCommon, LegacyMain) {

--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -247,4 +247,8 @@ fi
 enableHeapCheck
 set -e
 
+start_test disabling hot_restart by command line.
+CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version --disable-hot-restart 2>&1)
+check [ "disabled" = "${CLI_HOT_RESTART_VERSION}" ]
+
 echo "PASS"

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -27,7 +27,7 @@ std::unique_ptr<OptionsImpl> createOptionsImpl(const std::string& args) {
     argv.push_back(s.c_str());
   }
   return std::unique_ptr<OptionsImpl>(new OptionsImpl(argv.size(), const_cast<char**>(&argv[0]),
-                                                      [](uint64_t, uint64_t) { return "1"; },
+                                                      [](uint64_t, uint64_t, bool) { return "1"; },
                                                       spdlog::level::warn));
 }
 

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -87,8 +87,8 @@ std::vector<Network::Address::IpVersion> TestEnvironment::getIpVersionsForTest()
 }
 
 Server::Options& TestEnvironment::getOptions() {
-  static OptionsImpl* options =
-      new OptionsImpl(argc_, argv_, [](uint64_t, uint64_t) { return "1"; }, spdlog::level::err);
+  static OptionsImpl* options = new OptionsImpl(
+      argc_, argv_, [](uint64_t, uint64_t, bool) { return "1"; }, spdlog::level::err);
   return *options;
 }
 


### PR DESCRIPTION
*Description*:
The --disable-hot-restart flag was added to the binary in #2576 by @tonya11en but not hooked up (at my request).  Now that the main_common refactor is in, it's easier to hook it up. This also offers the opportunity for some minor code simplifications.

*Risk Level*: Medium -- this affects the startup path.

*Testing*:
//test/...
added a new subtest to hotrestart_test.sh to cover --disable-hot-restart.  I'd appreciate suggestions though on how to cover the functionality more thoroughly...how should I detect from a test that hot restart is disabled?

*Release Notes*: TBD: I'm not sure if release notes were added already in #2576 -- if not they can be added during this PR review.

*Fixes https://github.com/envoyproxy/envoy/issues/2029 -- actually #2576 claims to fix that but I don't think it really does, since in that PR the switch is a no-op.
