### PR TITLE
lc trie: increase test code coverage

### DIFF
--- a/source/common/network/lc_trie.h
+++ b/source/common/network/lc_trie.h
@@ -213,7 +213,6 @@ private:
       // LcNode uses the last 20 bits to store either the index into ip_prefixes_ or trie_.
       // In theory, the trie_ should only need twice the amount of entries of CIDR ranges.
       // To prevent index out of bounds issues, only support a maximum of (2^19) CIDR ranges.
-      // TODO(ccaraman): Add a test case for this.
       if (tag_data.size() > MAXIMUM_CIDR_RANGE_ENTRIES) {
         throw EnvoyException(fmt::format("The input vector has '{0}' CIDR ranges entires. LC-Trie "
                                          "can only support '{1}' CIDR ranges.",
@@ -370,7 +369,6 @@ private:
         // LC-Trie. If while building the trie the position that is being set exceeds the maximum
         // number of supported trie_ entries, throw an Envoy Exception instead of letting an
         // out_of_range exception be thrown.
-        // TODO(ccaraman): Add a test case.
         if (position > maximum_trie_node_size) {
           throw EnvoyException(fmt::format("The number of internal nodes required for the LC-Trie "
                                            "exceeded the maximum number of "

--- a/source/common/network/lc_trie.h
+++ b/source/common/network/lc_trie.h
@@ -367,14 +367,15 @@ private:
       if (n == 1) {
         // There is no way to predictably determine the number of trie nodes required to build a
         // LC-Trie. If while building the trie the position that is being set exceeds the maximum
-        // number of supported trie_ entries, throw an Envoy Exception instead of letting an
-        // out_of_range exception be thrown.
-        if (position > maximum_trie_node_size) {
-          throw EnvoyException(fmt::format("The number of internal nodes required for the LC-Trie "
-                                           "exceeded the maximum number of "
-                                           "supported nodes. Number of internal nodes required: "
-                                           "'{0}'. Maximum number of supported nodes: '{1}'.",
-                                           position, maximum_trie_node_size));
+        // number of supported trie_ entries, throw an Envoy Exception.
+        if (position >= maximum_trie_node_size) {
+          // Adding 1 to the position to count how many nodes are trying to be set.
+          throw EnvoyException(
+              fmt::format("The number of internal nodes required for the LC-Trie "
+                          "exceeded the maximum number of "
+                          "supported nodes. Minimum number of internal nodes required: "
+                          "'{0}'. Maximum number of supported nodes: '{1}'.",
+                          (position + 1), maximum_trie_node_size));
         }
 
         trie_[position].address_ = first;

--- a/source/common/network/lc_trie.h
+++ b/source/common/network/lc_trie.h
@@ -376,6 +376,7 @@ private:
                                            "'{0}'. Maximum number of supported nodes: '{1}'.",
                                            position, maximum_trie_node_size));
         }
+
         trie_[position].address_ = first;
         return;
       }

--- a/test/common/network/lc_trie_test.cc
+++ b/test/common/network/lc_trie_test.cc
@@ -333,10 +333,11 @@ TEST_F(LcTrieTest, ExceedingAllocatedTrieNodesException) {
   std::pair<std::string, std::vector<Address::CidrRange>> ip_tag =
       std::make_pair("bad_tag", large_vector_cidr);
   std::vector<std::pair<std::string, std::vector<Address::CidrRange>>> ip_tags_input{ip_tag};
-  EXPECT_THROW_WITH_MESSAGE(new LcTrie(ip_tags_input, 0.01, 16), EnvoyException,
-                            "The number of internal nodes required for the LC-Trie exceeded the "
-                            "maximum number of supported nodes. Number of internal nodes required: "
-                            "'3048577'. Maximum number of supported nodes: '3048576'.");
+  EXPECT_THROW_WITH_MESSAGE(
+      new LcTrie(ip_tags_input, 0.01, 16), EnvoyException,
+      "The number of internal nodes required for the LC-Trie exceeded the "
+      "maximum number of supported nodes. Minimum number of internal nodes required: "
+      "'3048577'. Maximum number of supported nodes: '3048576'.");
 }
 
 } // namespace LcTrie

--- a/test/common/network/lc_trie_test.cc
+++ b/test/common/network/lc_trie_test.cc
@@ -262,7 +262,7 @@ TEST_F(LcTrieTest, NestedPrefixes) {
       {"2001:db8::/96", "2001:db8::8000/97"}, // tag_3
       {"2001:db8::ffff/128"},                 // tag_4
       {"2001:db8:1::/48"},                    // tag_5
-      {"2001:db8:1::/48"}                     // tag_6
+      {"2001:db8:1::/128", "2001:db8:1::/48"} // tag_6
   };
   setup(cidr_range_strings);
 
@@ -299,6 +299,44 @@ TEST_F(LcTrieTest, NestedPrefixesWithCatchAll) {
 
   };
   expectIPAndTags(test_case);
+}
+
+// Test the trie can only support 2^19 Cidr Entries.
+TEST_F(LcTrieTest, MaximumEntriesException) {
+  Address::CidrRange cidr_entry = Address::CidrRange::create("1.2.3.4/32");
+  std::vector<Address::CidrRange> large_vector_cidr(((1 << 19) + 1), cidr_entry);
+
+  std::pair<std::string, std::vector<Address::CidrRange>> ip_tag =
+      std::make_pair("bad_tag", large_vector_cidr);
+  std::vector<std::pair<std::string, std::vector<Address::CidrRange>>> ip_tags_input{ip_tag};
+  EXPECT_THROW_WITH_MESSAGE(new LcTrie(ip_tags_input), EnvoyException,
+                            "The input vector has '524289' CIDR ranges entires. LC-Trie can only "
+                            "support '524288' CIDR ranges.");
+}
+
+// Test the exception will be thrown when the maximum allocated trie nodes are being set.
+TEST_F(LcTrieTest, ExceedingAllocatedTrieNodesException) {
+  std::vector<Address::CidrRange> large_vector_cidr((1 << 19));
+
+  // The CIDR ranges have to be unique as to force getting towards the higher range of nodes
+  // inserted in the trie.
+  uint32_t ip_address = 1u;
+  for (int i = 0; i < (1 << 19); i++) {
+    ip_address++;
+    sockaddr_in addr4;
+    addr4.sin_family = AF_INET;
+    addr4.sin_addr.s_addr = ip_address;
+    Address::InstanceConstSharedPtr address = std::make_shared<Address::Ipv4Instance>(&addr4);
+    large_vector_cidr[i] = Address::CidrRange::create(address, 32);
+  }
+
+  std::pair<std::string, std::vector<Address::CidrRange>> ip_tag =
+      std::make_pair("bad_tag", large_vector_cidr);
+  std::vector<std::pair<std::string, std::vector<Address::CidrRange>>> ip_tags_input{ip_tag};
+  EXPECT_THROW_WITH_MESSAGE(new LcTrie(ip_tags_input, 0.01, 16), EnvoyException,
+                            "The number of internal nodes required for the LC-Trie exceeded the "
+                            "maximum number of supported nodes. Number of internal nodes required: "
+                            "'3048577'. Maximum number of supported nodes: '3048576'.");
 }
 
 } // namespace LcTrie


### PR DESCRIPTION
Signed-off-by: Constance Caramanolis <ccaramanolis@lyft.com>
*Description*: Add tests to get coverage for the three areas highlighted in [coverage report](https://s3.amazonaws.com/lyft-envoy/coverage/report-master/coverage.bazel-out_k8-dbg_bin_source_common_network__virtual_includes_lc_trie_lib_common_network_lc_trie.h.html)

*Risk Level*: Low  - Only test changes. Code changes were removing old TODO's.
*Testing*: Added two new test cases for the large input vectors cases and modify a nested prefix to fully cover the compare method.