### PR TITLE
websockets: connection should support subset load balancer metadata

### DIFF
--- a/source/common/http/websocket/ws_handler_impl.h
+++ b/source/common/http/websocket/ws_handler_impl.h
@@ -30,6 +30,11 @@ public:
                 Upstream::ClusterManager& cluster_manager,
                 Network::ReadFilterCallbacks* read_callbacks);
 
+  // Upstream::LoadBalancerContext
+  const Router::MetadataMatchCriteria* metadataMatchCriteria() const override {
+    return route_entry_.metadataMatchCriteria();
+  }
+
 protected:
   // Filter::TcpProxy
   const std::string& getUpstreamCluster() override { return route_entry_.clusterName(); }


### PR DESCRIPTION
*Description*:
Enabling subset load balancing with metadata for websocket connections.

Currently http and tcp_proxy support SLB, but websocket connections do not. This just brings websockets in line with the http and tcp_proxy behavior.

*Risk Level*: Low

*Testing*:
Added unit test

*Docs Changes*:
not needed

*Release Notes*:
not needed

@ggreenway 

Signed-off-by: Bjoern Metzdorf <bmetzdorf@apple.com>
