### PR TITLE
stats: Guard regex lookups with substring searches where possible

### DIFF
--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -24,55 +24,60 @@ TagNameValues::TagNameValues() {
   // - Typical * notation will be used to denote an arbitrary set of characters.
 
   // *_rq(_<response_code>)
-  addRegex(RESPONSE_CODE, "_rq(_(\\d{3}))$");
+  addRegex(RESPONSE_CODE, "_rq(_(\\d{3}))$", "_rq_");
 
   // *_rq_(<response_code_class>)xx
-  addRegex(RESPONSE_CODE_CLASS, "_rq_(\\d)xx$");
+  addRegex(RESPONSE_CODE_CLASS, "_rq_(\\d)xx$", "_rq_");
 
   // http.[<stat_prefix>.]dynamodb.table.[<table_name>.]capacity.[<operation_name>.](__partition_id=<last_seven_characters_from_partition_id>)
-  addRegex(DYNAMO_PARTITION_ID, "^http(?=\\.).*?\\.dynamodb\\.table(?=\\.).*?\\."
-                                "capacity(?=\\.).*?(\\.__partition_id=(\\w{7}))"
-                                "$");
+  addRegex(DYNAMO_PARTITION_ID,
+           "^http(?=\\.).*?\\.dynamodb\\.table(?=\\.).*?\\."
+           "capacity(?=\\.).*?(\\.__partition_id=(\\w{7}))$",
+           ".dynamodb.table.");
 
   // http.[<stat_prefix>.]dynamodb.operation.(<operation_name>.)<base_stat> or
   // http.[<stat_prefix>.]dynamodb.table.[<table_name>.]capacity.(<operation_name>.)[<partition_id>]
-  addRegex(DYNAMO_OPERATION, "^http(?=\\.).*?\\.dynamodb.(?:operation|table(?="
-                             "\\.).*?\\.capacity)(\\.(.*?))(?:\\.|$)");
+  addRegex(DYNAMO_OPERATION,
+           "^http(?=\\.).*?\\.dynamodb.(?:operation|table(?="
+           "\\.).*?\\.capacity)(\\.(.*?))(?:\\.|$)",
+           ".dynamodb.");
 
   // mongo.[<stat_prefix>.]collection.[<collection>.]callsite.(<callsite>.)query.<base_stat>
   addRegex(MONGO_CALLSITE,
-           "^mongo(?=\\.).*?\\.collection(?=\\.).*?\\.callsite\\.((.*?)\\.).*?query.\\w+?$");
+           "^mongo(?=\\.).*?\\.collection(?=\\.).*?\\.callsite\\.((.*?)\\.).*?query.\\w+?$",
+           ".collection.");
 
   // http.[<stat_prefix>.]dynamodb.table.(<table_name>.) or
   // http.[<stat_prefix>.]dynamodb.error.(<table_name>.)*
-  addRegex(DYNAMO_TABLE, "^http(?=\\.).*?\\.dynamodb.(?:table|error)\\.((.*?)\\.)");
+  addRegex(DYNAMO_TABLE, "^http(?=\\.).*?\\.dynamodb.(?:table|error)\\.((.*?)\\.)", ".dynamodb");
 
   // mongo.[<stat_prefix>.]collection.(<collection>.)query.<base_stat>
-  addRegex(MONGO_COLLECTION, "^mongo(?=\\.).*?\\.collection\\.((.*?)\\.).*?query.\\w+?$");
+  addRegex(MONGO_COLLECTION, "^mongo(?=\\.).*?\\.collection\\.((.*?)\\.).*?query.\\w+?$",
+           ".collection.");
 
   // mongo.[<stat_prefix>.]cmd.(<cmd>.)<base_stat>
-  addRegex(MONGO_CMD, "^mongo(?=\\.).*?\\.cmd\\.((.*?)\\.)\\w+?$");
+  addRegex(MONGO_CMD, "^mongo(?=\\.).*?\\.cmd\\.((.*?)\\.)\\w+?$", ".cmd.");
 
   // cluster.[<route_target_cluster>.]grpc.[<grpc_service>.](<grpc_method>.)<base_stat>
-  addRegex(GRPC_BRIDGE_METHOD, "^cluster(?=\\.).*?\\.grpc(?=\\.).*\\.((.*?)\\.)\\w+?$");
+  addRegex(GRPC_BRIDGE_METHOD, "^cluster(?=\\.).*?\\.grpc(?=\\.).*\\.((.*?)\\.)\\w+?$", ".grpc.");
 
   // http.[<stat_prefix>.]user_agent.(<user_agent>.)<base_stat>
-  addRegex(HTTP_USER_AGENT, "^http(?=\\.).*?\\.user_agent\\.((.*?)\\.)\\w+?$");
+  addRegex(HTTP_USER_AGENT, "^http(?=\\.).*?\\.user_agent\\.((.*?)\\.)\\w+?$", ".user_agent.");
 
   // vhost.[<virtual host name>.]vcluster.(<virtual_cluster_name>.)<base_stat>
-  addRegex(VIRTUAL_CLUSTER, "^vhost(?=\\.).*?\\.vcluster\\.((.*?)\\.)\\w+?$");
+  addRegex(VIRTUAL_CLUSTER, "^vhost(?=\\.).*?\\.vcluster\\.((.*?)\\.)\\w+?$", ".vcluster.");
 
   // http.[<stat_prefix>.]fault.(<downstream_cluster>.)<base_stat>
-  addRegex(FAULT_DOWNSTREAM_CLUSTER, "^http(?=\\.).*?\\.fault\\.((.*?)\\.)\\w+?$");
+  addRegex(FAULT_DOWNSTREAM_CLUSTER, "^http(?=\\.).*?\\.fault\\.((.*?)\\.)\\w+?$", ".fault.");
 
   // listener.[<address>.]ssl.cipher.(<cipher>)
   addRegex(SSL_CIPHER, "^listener(?=\\.).*?\\.ssl\\.cipher(\\.(.*?))$");
 
   // cluster.[<cluster_name>.]ssl.ciphers.(<cipher>)
-  addRegex(SSL_CIPHER_SUITE, "^cluster(?=\\.).*?\\.ssl\\.ciphers(\\.(.*?))$");
+  addRegex(SSL_CIPHER_SUITE, "^cluster(?=\\.).*?\\.ssl\\.ciphers(\\.(.*?))$", "ssl.ciphers");
 
   // cluster.[<route_target_cluster>.]grpc.(<grpc_service>.)*
-  addRegex(GRPC_BRIDGE_SERVICE, "^cluster(?=\\.).*?\\.grpc\\.((.*?)\\.)");
+  addRegex(GRPC_BRIDGE_SERVICE, "^cluster(?=\\.).*?\\.grpc\\.((.*?)\\.)", "grpc");
 
   // tcp.(<stat_prefix>.)<base_stat>
   addRegex(TCP_PREFIX, "^tcp\\.((.*?)\\.)\\w+?$");
@@ -87,7 +92,7 @@ TagNameValues::TagNameValues() {
   addRegex(CLUSTER_NAME, "^cluster\\.((.*?)\\.)");
 
   // http.(<stat_prefix>.)* or listener.[<address>.]http.(<stat_prefix>.)*
-  addRegex(HTTP_CONN_MANAGER_PREFIX, "^(?:|listener(?=\\.).*?\\.)http\\.((.*?)\\.)");
+  addRegex(HTTP_CONN_MANAGER_PREFIX, "^(?:|listener(?=\\.).*?\\.)http\\.((.*?)\\.)", "http.");
 
   // listener.(<address>.)*
   addRegex(LISTENER_ADDRESS,
@@ -100,8 +105,9 @@ TagNameValues::TagNameValues() {
   addRegex(MONGO_PREFIX, "^mongo\\.((.*?)\\.)");
 }
 
-void TagNameValues::addRegex(const std::string& name, const std::string& regex) {
-  descriptor_vec_.emplace_back(Descriptor(name, regex));
+void TagNameValues::addRegex(const std::string& name, const std::string& regex,
+                             const std::string& substr) {
+  descriptor_vec_.emplace_back(Descriptor(name, regex, substr));
 }
 
 } // namespace Config

--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -92,7 +92,7 @@ TagNameValues::TagNameValues() {
   addRegex(CLUSTER_NAME, "^cluster\\.((.*?)\\.)");
 
   // listener.[<address>.]http.(<stat_prefix>.)*
-  addRegex(HTTP_CONN_MANAGER_PREFIX, "^(?:|listener(?=\\.).*?\\.)http\\.((.*?)\\.)", ".http.");
+  addRegex(HTTP_CONN_MANAGER_PREFIX, "^listener(?=\\.).*?\\.http\\.((.*?)\\.)", ".http.");
 
   // http.(<stat_prefix>.)*
   addRegex(HTTP_CONN_MANAGER_PREFIX, "^http\\.((.*?)\\.)");

--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -49,7 +49,7 @@ TagNameValues::TagNameValues() {
 
   // http.[<stat_prefix>.]dynamodb.table.(<table_name>.) or
   // http.[<stat_prefix>.]dynamodb.error.(<table_name>.)*
-  addRegex(DYNAMO_TABLE, "^http(?=\\.).*?\\.dynamodb.(?:table|error)\\.((.*?)\\.)", ".dynamodb");
+  addRegex(DYNAMO_TABLE, "^http(?=\\.).*?\\.dynamodb.(?:table|error)\\.((.*?)\\.)", ".dynamodb.");
 
   // mongo.[<stat_prefix>.]collection.(<collection>.)query.<base_stat>
   addRegex(MONGO_COLLECTION, "^mongo(?=\\.).*?\\.collection\\.((.*?)\\.).*?query.\\w+?$",
@@ -74,10 +74,10 @@ TagNameValues::TagNameValues() {
   addRegex(SSL_CIPHER, "^listener(?=\\.).*?\\.ssl\\.cipher(\\.(.*?))$");
 
   // cluster.[<cluster_name>.]ssl.ciphers.(<cipher>)
-  addRegex(SSL_CIPHER_SUITE, "^cluster(?=\\.).*?\\.ssl\\.ciphers(\\.(.*?))$", "ssl.ciphers");
+  addRegex(SSL_CIPHER_SUITE, "^cluster(?=\\.).*?\\.ssl\\.ciphers(\\.(.*?))$", ".ssl.ciphers.");
 
   // cluster.[<route_target_cluster>.]grpc.(<grpc_service>.)*
-  addRegex(GRPC_BRIDGE_SERVICE, "^cluster(?=\\.).*?\\.grpc\\.((.*?)\\.)", "grpc");
+  addRegex(GRPC_BRIDGE_SERVICE, "^cluster(?=\\.).*?\\.grpc\\.((.*?)\\.)", ".grpc.");
 
   // tcp.(<stat_prefix>.)<base_stat>
   addRegex(TCP_PREFIX, "^tcp\\.((.*?)\\.)\\w+?$");
@@ -91,8 +91,11 @@ TagNameValues::TagNameValues() {
   // cluster.(<cluster_name>.)*
   addRegex(CLUSTER_NAME, "^cluster\\.((.*?)\\.)");
 
-  // http.(<stat_prefix>.)* or listener.[<address>.]http.(<stat_prefix>.)*
-  addRegex(HTTP_CONN_MANAGER_PREFIX, "^(?:|listener(?=\\.).*?\\.)http\\.((.*?)\\.)", "http.");
+  // listener.[<address>.]http.(<stat_prefix>.)*
+  addRegex(HTTP_CONN_MANAGER_PREFIX, "^(?:|listener(?=\\.).*?\\.)http\\.((.*?)\\.)", ".http.");
+
+  // http.(<stat_prefix>.)*
+  addRegex(HTTP_CONN_MANAGER_PREFIX, "^http\\.((.*?)\\.)");
 
   // listener.(<address>.)*
   addRegex(LISTENER_ADDRESS,

--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -230,9 +230,11 @@ public:
    * tags, such as "_rq_(\\d)xx$", will probably stay as regexes.
    */
   struct Descriptor {
-    Descriptor(const std::string& name, const std::string& regex) : name_(name), regex_(regex) {}
+    Descriptor(const std::string& name, const std::string& regex, const std::string& substr = "")
+        : name_(name), regex_(regex), substr_(substr) {}
     const std::string name_;
     const std::string regex_;
+    const std::string substr_;
   };
 
   // Cluster name tag
@@ -289,7 +291,7 @@ public:
   const std::vector<Descriptor>& descriptorVec() const { return descriptor_vec_; }
 
 private:
-  void addRegex(const std::string& name, const std::string& regex);
+  void addRegex(const std::string& name, const std::string& regex, const std::string& substr = "");
 
   // Collection of tag descriptors.
   std::vector<Descriptor> descriptor_vec_;

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -69,8 +69,9 @@ std::string Utility::sanitizeStatsName(const std::string& name) {
   return stats_name;
 }
 
-TagExtractorImpl::TagExtractorImpl(const std::string& name, const std::string& regex)
-    : name_(name), prefix_(std::string(extractRegexPrefix(regex))),
+TagExtractorImpl::TagExtractorImpl(const std::string& name, const std::string& regex,
+                                   const std::string& substr)
+    : name_(name), prefix_(std::string(extractRegexPrefix(regex))), substr_(substr),
       regex_(RegexUtil::parseRegex(regex)) {}
 
 std::string TagExtractorImpl::extractRegexPrefix(absl::string_view regex) {
@@ -93,7 +94,8 @@ std::string TagExtractorImpl::extractRegexPrefix(absl::string_view regex) {
 }
 
 TagExtractorPtr TagExtractorImpl::createTagExtractor(const std::string& name,
-                                                     const std::string& regex) {
+                                                     const std::string& regex,
+                                                     const std::string& substr) {
 
   if (name.empty()) {
     throw EnvoyException("tag_name cannot be empty");
@@ -103,11 +105,14 @@ TagExtractorPtr TagExtractorImpl::createTagExtractor(const std::string& name,
     throw EnvoyException(fmt::format(
         "No regex specified for tag specifier and no default regex for name: '{}'", name));
   }
-  return TagExtractorPtr{new TagExtractorImpl(name, regex)};
+  return TagExtractorPtr{new TagExtractorImpl(name, regex, substr)};
 }
 
 bool TagExtractorImpl::extractTag(const std::string& stat_name, std::vector<Tag>& tags,
                                   IntervalSet<size_t>& remove_characters) const {
+  if (!substr_.empty() && stat_name.find(substr_) == std::string::npos) {
+    return false;
+  }
 
   PERF_OPERATION(perf);
   std::smatch match;
@@ -181,7 +186,8 @@ int TagProducerImpl::addExtractorsMatching(absl::string_view name) {
   int num_found = 0;
   for (const auto& desc : Config::TagNames::get().descriptorVec()) {
     if (desc.name_ == name) {
-      addExtractor(Stats::TagExtractorImpl::createTagExtractor(desc.name_, desc.regex_));
+      addExtractor(
+          Stats::TagExtractorImpl::createTagExtractor(desc.name_, desc.regex_, desc.substr_));
       ++num_found;
     }
   }
@@ -241,7 +247,8 @@ TagProducerImpl::addDefaultExtractors(const envoy::config::metrics::v2::StatsCon
   if (!config.has_use_all_default_tags() || config.use_all_default_tags().value()) {
     for (const auto& desc : Config::TagNames::get().descriptorVec()) {
       names.emplace(desc.name_);
-      addExtractor(Stats::TagExtractorImpl::createTagExtractor(desc.name_, desc.regex_));
+      addExtractor(
+          Stats::TagExtractorImpl::createTagExtractor(desc.name_, desc.regex_, desc.substr_));
     }
   }
   return names;

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -110,11 +110,13 @@ TagExtractorPtr TagExtractorImpl::createTagExtractor(const std::string& name,
 
 bool TagExtractorImpl::extractTag(const std::string& stat_name, std::vector<Tag>& tags,
                                   IntervalSet<size_t>& remove_characters) const {
+  PERF_OPERATION(perf);
+
   if (!substr_.empty() && stat_name.find(substr_) == std::string::npos) {
+    PERF_RECORD(perf, "re-skip-substr", name_);
     return false;
   }
 
-  PERF_OPERATION(perf);
   std::smatch match;
   // The regex must match and contain one or more subexpressions (all after the first are ignored).
   if (std::regex_search(stat_name, match, regex_) && match.size() > 1) {

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -108,11 +108,15 @@ TagExtractorPtr TagExtractorImpl::createTagExtractor(const std::string& name,
   return TagExtractorPtr{new TagExtractorImpl(name, regex, substr)};
 }
 
+bool TagExtractorImpl::substrMismatch(const std::string& stat_name) const {
+  return !substr_.empty() && stat_name.find(substr_) == std::string::npos;
+}
+
 bool TagExtractorImpl::extractTag(const std::string& stat_name, std::vector<Tag>& tags,
                                   IntervalSet<size_t>& remove_characters) const {
   PERF_OPERATION(perf);
 
-  if (!substr_.empty() && stat_name.find(substr_) == std::string::npos) {
+  if (substrMismatch(stat_name)) {
     PERF_RECORD(perf, "re-skip-substr", name_);
     return false;
   }

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -193,11 +193,6 @@ int TagProducerImpl::addExtractorsMatching(absl::string_view name) {
       ++num_found;
     }
   }
-  // TODO(jmarantz): Changing the default tag regexes so that more than one regex can
-  // yield the same tag, on the theory that this will reduce regex backtracking. At the
-  // moment, this doesn't happen, so this flow isn't well tested. When we start exploiting
-  // this, and it's tested, we can simply remove this assert.
-  ASSERT(num_found <= 1);
   return num_found;
 }
 

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -34,9 +34,11 @@ public:
    * @param regex regex expression.
    * @return TagExtractorPtr newly constructed TagExtractor.
    */
-  static TagExtractorPtr createTagExtractor(const std::string& name, const std::string& regex);
+  static TagExtractorPtr createTagExtractor(const std::string& name, const std::string& regex,
+                                            const std::string& substr = "");
 
-  TagExtractorImpl(const std::string& name, const std::string& regex);
+  TagExtractorImpl(const std::string& name, const std::string& regex,
+                   const std::string& substr = "");
   std::string name() const override { return name_; }
   bool extractTag(const std::string& tag_extracted_name, std::vector<Tag>& tags,
                   IntervalSet<size_t>& remove_characters) const override;
@@ -53,6 +55,7 @@ private:
 
   const std::string name_;
   const std::string prefix_;
+  const std::string substr_;
   const std::regex regex_;
 };
 

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -44,6 +44,13 @@ public:
                   IntervalSet<size_t>& remove_characters) const override;
   absl::string_view prefixToken() const override { return prefix_; }
 
+  /**
+   * @param stat_name The stat name
+   * @return bool indicates whether tag extraction should be skipped for this stat_name due
+   * to a subdstring mismatch.
+   */
+  bool substrMismatch(const std::string& stat_name) const;
+
 private:
   /**
    * Examines a regex string, looking for the pattern: ^alphanumerics_with_underscores\.

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -50,7 +50,7 @@ public:
   /**
    * @param stat_name The stat name
    * @return bool indicates whether tag extraction should be skipped for this stat_name due
-   * to a subdstring mismatch.
+   * to a substring mismatch.
    */
   bool substrMismatch(const std::string& stat_name) const;
 

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -32,6 +32,9 @@ public:
    * Creates a tag extractor from the regex provided. name and regex must be non-empty.
    * @param name name for tag extractor.
    * @param regex regex expression.
+   * @param substr a substring that -- if provided -- must be present in a stat name
+   *               in order to match the regex. This is an optional performance tweak
+   *               to avoid large numbers of failed regex lookups.
    * @return TagExtractorPtr newly constructed TagExtractor.
    */
   static TagExtractorPtr createTagExtractor(const std::string& name, const std::string& regex,

--- a/test/common/stats/stats_impl_test.cc
+++ b/test/common/stats/stats_impl_test.cc
@@ -111,6 +111,18 @@ TEST(TagExtractorTest, SingleSubexpression) {
   EXPECT_EQ("listner_port", tags.at(0).name_);
 }
 
+TEST(TagExtractorTest, substrMismatch) {
+  TagExtractorImpl tag_extractor("listner_port", "^listener\\.(\\d+?\\.)\\.foo\\.", ".foo.");
+  EXPECT_TRUE(tag_extractor.substrMismatch("listener.80.downstream_cx_total"));
+  EXPECT_FALSE(tag_extractor.substrMismatch("listener.80.downstream_cx_total.foo.bar"));
+}
+
+TEST(TagExtractorTest, noSubstrMismatch) {
+  TagExtractorImpl tag_extractor("listner_port", "^listener\\.(\\d+?\\.)\\.foo\\.");
+  EXPECT_FALSE(tag_extractor.substrMismatch("listener.80.downstream_cx_total"));
+  EXPECT_FALSE(tag_extractor.substrMismatch("listener.80.downstream_cx_total.foo.bar"));
+}
+
 TEST(TagExtractorTest, EmptyName) {
   EXPECT_THROW_WITH_MESSAGE(TagExtractorImpl::createTagExtractor("", "^listener\\.(\\d+?\\.)"),
                             EnvoyException, "tag_name cannot be empty");


### PR DESCRIPTION
Annotate addRegex calls with expected substrings.  It is significantly faster to search a candidate stat for these substrings prior to running regex analysis.  This change speeds up 10k case from 8 seconds to 3.5 sec.

Before:
```
Duration(us)  # Calls  Mean(ns)  StdDev(ns)  Min(ns)  Max(ns)  Category  Description                   
     1198153   680000      1761      1408.5     1126  1052984  re-miss   envoy.grpc_bridge_method      
     1184283   680000      1741     1409.55     1119  1048041  re-miss   cipher_suite                  
     1179557   680000      1734     579.372     1112   121057  re-miss   envoy.grpc_bridge_service     
      686269   680127      1009     562.467      483    75670  re-miss   envoy.response_code_class     
      665593   680147       978     411.618      490    79632  re-miss   envoy.response_code           
      616527   680031       906     418.034      517    85152  re-miss   envoy.http_conn_manager_prefix
      451858   680000       664     1333.08      583  1034655  re-match  envoy.cluster_name            
         226      106      2135     999.719      971     9424  re-miss   envoy.dynamo_partition_id     
         215      106      2036     1121.43      915    11952  re-miss   envoy.http_user_agent         
         212      106      2003     580.828      958     3485  re-miss   envoy.dynamo_operation        
         205      106      1935     551.338      928     3387  re-miss   envoy.dyanmo_table            
         202      106      1906     546.486      923     3352  re-miss   envoy.fault_downstream_cluster
          83      116       723     324.772      466     2208  re-match  envoy.http_conn_manager_prefix
          33       14      2373     282.729     2020     2852  re-miss   envoy.ssl_cipher              
          21       20      1056     260.687      651     1439  re-match  envoy.response_code_class     
          16        9      1784     342.155     1515     2663  re-miss   envoy.listener_address        
           4        5       845     347.121      657     1464  re-match  envoy.listener_address        
```

After:
```
Duration(us)  # Calls  Mean(ns)  StdDev(ns)  Min(ns)  Max(ns)  Category        Description                   
      457801   680000       673     859.183      561   198777  re-match        envoy.cluster_name            
      158922   150042      1059     1317.31      707   193774  re-miss         envoy.response_code           
      158747   150022      1058      1240.3      732   202819  re-miss         envoy.response_code_class     
       44221   530105        83     1593.54       33  1140472  re-skip-substr  envoy.response_code           
       42209   680000        62     323.569       41   180224  re-skip-substr  cipher_suite                  
       37968   680000        55     278.834       35   152175  re-skip-substr  envoy.grpc_bridge_method      
       37254   680000        54     346.805       35   172786  re-skip-substr  envoy.grpc_bridge_service     
       35105   530105        66     294.315       30   120865  re-skip-substr  envoy.response_code_class     
          68      116       591     426.393      417     2952  re-match        envoy.http_conn_manager_prefix
          39       14      2803     2468.54     1517    10385  re-miss         envoy.ssl_cipher              
          17       20       890     198.915      622     1182  re-match        envoy.response_code_class     
          10        9      1215     236.915     1005     1785  re-miss         envoy.listener_address        
           6      106        65     22.9534       41      234  re-skip-substr  envoy.dynamo_partition_id     
           6      106        65      14.675       47      143  re-skip-substr  envoy.dynamo_operation        
           6      106        62     13.1069       42      154  re-skip-substr  envoy.fault_downstream_cluster
           6      106        61      12.603       43      124  re-skip-substr  envoy.http_user_agent         
           5      106        49     11.6811       32      130  re-skip-substr  envoy.dyanmo_table            
           4        5       824     309.373      661     1376  re-match        envoy.listener_address        
           0        4        73     21.8689       53      103  re-skip-substr  envoy.http_conn_manager_prefix
```


*Description*:
Allows explicit specification of a required substring, which can be quickly scanned for in an input string before applying regexes.

*Risk Level*: Medium - mis-specifying these can lead to broken tag processing

*Testing*:
//test/...

*Release Notes*: N/A
