### PR TITLE
utility: remove absl::strings_internal::memcasecmp usage (#2700)

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -134,7 +134,7 @@ bool StringUtil::caseCompare(absl::string_view lhs, absl::string_view rhs) {
   if (rhs.size() != lhs.size()) {
     return false;
   }
-  return absl::StartsWithIgnoreCase(rhs.data(), lhs.data());
+  return absl::StartsWithIgnoreCase(rhs, lhs);
 }
 
 absl::string_view StringUtil::cropRight(absl::string_view source, absl::string_view delimiter) {

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -14,7 +14,7 @@
 #include "common/common/hash.h"
 
 #include "absl/strings/ascii.h"
-#include "absl/strings/internal/memutil.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "spdlog/spdlog.h"
@@ -134,7 +134,7 @@ bool StringUtil::caseCompare(absl::string_view lhs, absl::string_view rhs) {
   if (rhs.size() != lhs.size()) {
     return false;
   }
-  return absl::strings_internal::memcasecmp(rhs.data(), lhs.data(), rhs.size()) == 0;
+  return absl::StartsWithIgnoreCase(rhs.data(), lhs.data());
 }
 
 absl::string_view StringUtil::cropRight(absl::string_view source, absl::string_view delimiter) {


### PR DESCRIPTION
*title*: Remove absl::strings_internal usage in utility

*Description*:
Replace use of absl::strings_internal::memcasecmp() in utility with absl::StartsWithIgnoreCase. This removes dependency on Abseil's internals and is inline with [the Abseil Compatibility Guidelines.](https://abseil.io/about/compatibility).

*Risk Level*: Low 

*Testing*: Ran unit tests
`bazel test //test/common/common:utility_test`
> Linux version 4.4.0-116-generic (buildd@lgw01-amd64-021) (gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.9) )

*Docs Changes*:N/A

*Release Notes*: N/A

Fixes #2700
