### PR TITLE
Upgrade to spdlog 0.16.3, c-ares 1.14.0, nghttp2 1.31.0.

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -26,9 +26,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/fmtlib/fmt/releases/download/4.0.0/fmt-4.0.0.zip"],
     ),
     com_github_gabime_spdlog = dict(
-        sha256 = "2081e5df5e87402398847431e16b87c71dd5c4d632314bb976ace8161f4d32de",
-        strip_prefix = "spdlog-0.16.2",
-        urls = ["https://github.com/gabime/spdlog/archive/v0.16.2.tar.gz"],
+        sha256 = "b88d7be261d9089c817fc8cee6c000d69f349b357828e4c7f66985bc5d5360b8",
+        strip_prefix = "spdlog-0.16.3",
+        urls = ["https://github.com/gabime/spdlog/archive/v0.16.3.tar.gz"],
     ),
     com_github_gcovr_gcovr = dict(
         commit = "c0d77201039c7b119b18bc7fb991564c602dd75d",

--- a/ci/build_container/build_recipes/cares.sh
+++ b/ci/build_container/build_recipes/cares.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION=cares-1_13_0
+VERSION=cares-1_14_0
 
 # cares is fussy over whether -D appears inside CFLAGS vs. CPPFLAGS, oss-fuzz
 # sets CFLAGS with -D, so we need to impedance match here.

--- a/ci/build_container/build_recipes/nghttp2.sh
+++ b/ci/build_container/build_recipes/nghttp2.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION=1.30.0
+VERSION=1.31.0
 
 wget -O nghttp2-"$VERSION".tar.gz https://github.com/nghttp2/nghttp2/releases/download/v"$VERSION"/nghttp2-"$VERSION".tar.gz
 tar xf nghttp2-"$VERSION".tar.gz


### PR DESCRIPTION
Signed-off-by: Michael Payne <michael@sooper.org>

*dependency*: Upgrade to spdlog 0.16.3, c-ares 1.14.0, nghttp2 1.31.0.

*Description*: Minor updates to spdlog ([release notes](https://github.com/gabime/spdlog/releases/tag/v0.16.3)), c-ares ([release notes](https://c-ares.haxx.se/changelog.html#1_14_0)) and nghttp2 ([release notes](https://github.com/nghttp2/nghttp2/releases/tag/v1.31.0)).

*Risk Level*: Low

*Testing*: `bazel test //test/...` and running on local instances for 1+ weeks.

*Docs Changes*: None required.
