### PR TITLE
json: Fix issue converting null yaml into json

### DIFF
--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -307,6 +307,10 @@ void Field::buildRapidJsonDocument(const Field& field, rapidjson::Value& value,
     }
     break;
   }
+  case Type::Null: {
+    value.SetNull();
+    break;
+  }
   default:
     NOT_REACHED;
   }

--- a/test/common/json/json_loader_test.cc
+++ b/test/common/json/json_loader_test.cc
@@ -445,6 +445,13 @@ TEST(JsonLoaderTest, YamlObject) {
   }
 }
 
+TEST(JsonLoaderTest, YamlAsJsonString) {
+  {
+    const Json::ObjectSharedPtr json = Json::Factory::loadFromYamlString("");
+    EXPECT_EQ(json->asJsonString(), "null");
+  }
+}
+
 TEST(JsonLoaderTest, BadYamlException) {
   std::string bad_yaml = R"EOF(
 admin:

--- a/test/common/json/json_loader_test.cc
+++ b/test/common/json/json_loader_test.cc
@@ -446,10 +446,8 @@ TEST(JsonLoaderTest, YamlObject) {
 }
 
 TEST(JsonLoaderTest, YamlAsJsonString) {
-  {
-    const Json::ObjectSharedPtr json = Json::Factory::loadFromYamlString("");
-    EXPECT_EQ(json->asJsonString(), "null");
-  }
+  const Json::ObjectSharedPtr json = Json::Factory::loadFromYamlString("");
+  EXPECT_EQ(json->asJsonString(), "null");
 }
 
 TEST(JsonLoaderTest, BadYamlException) {


### PR DESCRIPTION
When envoy is launched with an empty yaml file through `-c` it blows up with: 
```
2018-03-02_15:39:44.80673 [2018-03-02 15:39:44.806][1][critical][assert] external/envoy/source/common/json/json_loader.cc:311] panic: not reached
2018-03-02_15:39:44.80675 [2018-03-02 15:39:44.806][1][critical][backtrace] bazel-out/k8-opt/bin/external/envoy/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:11
4] Caught Aborted, suspect faulting address 0x4e3800000001
2018-03-02_15:39:44.80698 [2018-03-02 15:39:44.806][1][critical][backtrace] bazel-out/k8-opt/bin/external/envoy/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:90
] Backtrace obj</lib/x86_64-linux-gnu/libc.so.6> thr<0> (use tools/stack_decode.py):
```

This happens because the yaml loader correctly reads the file as a null value but converting this into a rapidjson object fails because the Null type isn't handled. This PR simply adds a switch case that handles this case by returning a null json object. 

*Risk Level*: Low, it makes the json generator more permissive

*Testing*:
Added unit test that verifies that an empty string can be parsed as yaml and converted to a json string. Also verified that envoy doesn't crash when given an empty yaml file:
```
➜  envoy git:(empty-yaml) ✗ bazel-bin/source/exe/envoy-static -c empty.yaml
[2018-03-02 23:11:52.558][2664388][info][main] source/server/server.cc:178] initializing epoch 0 (hot restart version=disabled)
[2018-03-02 23:11:52.572][2664388][critical][main] source/server/server.cc:71] error initializing configuration 'empty.yaml': JSON at lines 0-0 does not conform to schema.
 Invalid schema: #
 Schema violation: type
 Offending document key: #
[2018-03-02 23:11:52.572][2664388][info][main] source/server/server.cc:392] exiting
```