### PR TITLE
tcp filter: Allow referencing dynamic clusters in v1 config

### DIFF
--- a/source/common/filter/tcp_proxy.cc
+++ b/source/common/filter/tcp_proxy.cc
@@ -60,10 +60,6 @@ TcpProxyConfig::TcpProxyConfig(
   if (config.has_deprecated_v1()) {
     for (const envoy::config::filter::network::tcp_proxy::v2::TcpProxy::DeprecatedV1::TCPRoute&
              route_desc : config.deprecated_v1().routes()) {
-      if (!context.clusterManager().get(route_desc.cluster())) {
-        throw EnvoyException(
-            fmt::format("tcp proxy: unknown cluster '{}' in TCP route", route_desc.cluster()));
-      }
       routes_.emplace_back(Route(route_desc));
     }
   }

--- a/test/common/filter/tcp_proxy_test.cc
+++ b/test/common/filter/tcp_proxy_test.cc
@@ -53,26 +53,6 @@ TEST(TcpProxyConfigTest, NoRouteConfig) {
   EXPECT_THROW(constructTcpProxyConfigFromJson(*config, factory_context), EnvoyException);
 }
 
-TEST(TcpProxyConfigTest, NoCluster) {
-  std::string json = R"EOF(
-    {
-      "stat_prefix": "name",
-      "route_config": {
-        "routes": [
-          {
-            "cluster": "fake_cluster"
-          }
-        ]
-      }
-    }
-    )EOF";
-
-  Json::ObjectSharedPtr config = Json::Factory::loadFromString(json);
-  NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  EXPECT_CALL(factory_context.cluster_manager_, get("fake_cluster")).WillOnce(Return(nullptr));
-  EXPECT_THROW(constructTcpProxyConfigFromJson(*config, factory_context), EnvoyException);
-}
-
 TEST(TcpProxyConfigTest, BadTcpProxyConfig) {
   std::string json_string = R"EOF(
   {


### PR DESCRIPTION
This removes the validation code that ensures that any cluster referenced in the tcp filter config is known when the config is applied. Removing this allows users to specify a cluster that is not known at the time but will be made available later on through CDS. 

*Risk Level*: Low
This is already possible to do with the v2 config (as the validation was not applied in that case), so the behavior should already be battle tested. This does open up the possibility for people misconfiguring their  static config (e.g. a typo when trying to reference a static cluster), although it will not break existing configs.

*Testing*:
None: the code path that this enables is already exercised when using the v2 config, so the existing test cases should cover this

Fixes issue https://github.com/envoyproxy/envoy/issues/2075

cc @ggreenway 
