### PR TITLE
Check for non NULL active_span_ before usage in conn_manager_impl

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -917,7 +917,7 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
       // For Egress (outbound) response, if a decorator operation name has been provided, it
       // should be used to override the active span's operation.
       if (resp_operation_override) {
-        if (!resp_operation_override->value().empty()) {
+        if (!resp_operation_override->value().empty() && active_span_) {
           active_span_->setOperation(resp_operation_override->value().c_str());
         }
         // Remove header so not propagated to service.


### PR DESCRIPTION
**Check for non NULL active_span_ before usage in conn_manager_impl**

Addresses [Envoy coredumps with random_sampling enabled](https://github.com/envoyproxy/envoy/issues/2710)

Fixes #2710.

Signed-off-by: Mandar U Jog <mjog@google.com>

