### PR TITLE
lc_trie_test: Initialize address port in lc_trie_test

### DIFF
--- a/test/common/network/lc_trie_test.cc
+++ b/test/common/network/lc_trie_test.cc
@@ -326,6 +326,7 @@ TEST_F(LcTrieTest, ExceedingAllocatedTrieNodesException) {
     sockaddr_in addr4;
     addr4.sin_family = AF_INET;
     addr4.sin_addr.s_addr = ip_address;
+    addr4.sin_port = 0;
     Address::InstanceConstSharedPtr address = std::make_shared<Address::Ipv4Instance>(&addr4);
     large_vector_cidr[i] = Address::CidrRange::create(address, 32);
   }


### PR DESCRIPTION
Signed-off-by: Henna Huang <henna@google.com>

*title*: *Initialize address port in lc_trie_test*

*Description*:
When running the lc_trie_test, saw warning MemorySanitizer: use-of-uninitialized-value. This causes the test to fail in google's build environment.

*Risk Level*: Low 

*Testing*:
lc_trie_test passes with this fix.

*Docs Changes*:
N/A

*Release Notes*:
N/A
