### PR TITLE
Upgrade to http-parser 2.8.0.

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -51,7 +51,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/google/googleapis",
     ),
     com_github_nodejs_http_parser = dict(
-        commit = "feae95a3a69f111bc1897b9048d9acbc290992f9",  # v2.7.1
+        commit = "dd74753cf5cf8944438d6f49ddf46f9659993dfb",  # v2.8.0
         remote = "https://github.com/nodejs/http-parser",
     ),
     com_github_pallets_jinja = dict(

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -904,10 +904,10 @@ void HttpIntegrationTest::testInvalidCharacterInFirstline() {
   EXPECT_EQ("HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\nconnection: close\r\n\r\n", response);
 }
 
-void HttpIntegrationTest::testLowVersion() {
+void HttpIntegrationTest::testInvalidVersion() {
   initialize();
   std::string response;
-  sendRawHttpAndWaitForResponse(lookupPort("http"), "GET / HTTP/0.8\r\nHost: host\r\n\r\n",
+  sendRawHttpAndWaitForResponse(lookupPort("http"), "GET / HTTP/1.01\r\nHost: host\r\n\r\n",
                                 &response);
   EXPECT_EQ("HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\nconnection: close\r\n\r\n", response);
 }

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -129,7 +129,7 @@ protected:
   void testBadFirstline();
   void testMissingDelimiter();
   void testInvalidCharacterInFirstline();
-  void testLowVersion();
+  void testInvalidVersion();
   void testHttp10Request();
   void testNoHost();
   void testUpstreamProtocolError();

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -172,7 +172,7 @@ TEST_P(IntegrationTest, MissingDelimiter) { testMissingDelimiter(); }
 
 TEST_P(IntegrationTest, InvalidCharacterInFirstline) { testInvalidCharacterInFirstline(); }
 
-TEST_P(IntegrationTest, LowVersion) { testLowVersion(); }
+TEST_P(IntegrationTest, InvalidVersion) { testInvalidVersion(); }
 
 TEST_P(IntegrationTest, Http10Request) { testHttp10Request(); }
 


### PR DESCRIPTION
Signed-off-by: Michael Payne <michael@sooper.org>

*dependency*: Upgrade to http-parser 2.8.0.

*Description*: http-parser doesn't provide a changelog. The commits between releases are [here](https://github.com/nodejs/http-parser/compare/v2.7.1...master).  The biggest change is how http-parser parses HTTP version numbers. The code now adheres to the RFC which says the major and minor version is a single digit. Previously Envoy would test a low HTTP version number of 0.8 which would fail as expected as http-parser would reject major version numbers below 1 (even though technically 0.9 is a valid HTTP version). It was confirmed on Twitter ([thread](https://twitter.com/hartley/status/970064722048372736)) with @indutny that with the new change 0.8 is considered valid.  In addition to this dependency change we change the test to test for an invalid version.

*Risk Level*: Medium. Changes to HTTP version parsing. Shouldn't affect Envoy with regular 1.1 requests however 0.8 is now considered valid as per HTTP RFC.

*Testing*: `bazel test //test/...` and running on local instances for 1+ weeks.

*Docs Changes*: None required.
