### PR TITLE
format: some clang tidy fixes.

### DIFF
--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -150,7 +150,7 @@ void GrpcMuxImpl::onReceiveMessage(std::unique_ptr<envoy::api::v2::DiscoveryResp
     ENVOY_LOG(warn, "Ignoring unknown type URL {}", type_url);
     return;
   }
-  if (api_state_[type_url].watches_.size() == 0) {
+  if (api_state_[type_url].watches_.empty()) {
     ENVOY_LOG(warn, "Ignoring unwatched type URL {}", type_url);
     return;
   }

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -94,7 +94,7 @@ void DnsResolverImpl::PendingResolution::onAresHostCallback(int status, int time
         address_list.emplace_back(new Address::Ipv6Instance(address));
       }
     }
-    if (address_list.size() > 0) {
+    if (!address_list.empty()) {
       completed_ = true;
     }
   }

--- a/source/server/config/http/ip_tagging.h
+++ b/source/server/config/http/ip_tagging.h
@@ -21,7 +21,7 @@ public:
                                           FactoryContext& context) override;
 
   HttpFilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& proto_config,
-                                                   const std::string& stats_prefix,
+                                                   const std::string& stat_prefix,
                                                    FactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -136,7 +136,7 @@ private:
         const unsigned char* ip_question = question;
         long ip_name_len = name_len;
         std::string encodedCname;
-        if (cname.size() > 0) {
+        if (!cname.empty()) {
           ASSERT_TRUE(cname.size() <= 253);
           hostLookup = cname.c_str();
           encodedCname = TestDnsServerQuery::encodeDnsName(cname);
@@ -159,7 +159,7 @@ private:
         ares_free_string(name);
 
         int answer_size = ips != nullptr ? ips->size() : 0;
-        answer_size += encodedCname.size() > 0 ? 1 : 0;
+        answer_size += !encodedCname.empty() ? 1 : 0;
 
         // The response begins with the intial part of the request
         // (including the question section).
@@ -182,7 +182,7 @@ private:
               ips != nullptr ? ips->size() * (ip_name_len + RRFIXEDSZ + sizeof(in6_addr)) : 0;
         }
         size_t response_cname_len =
-            encodedCname.size() > 0 ? name_len + RRFIXEDSZ + encodedCname.size() + 1 : 0;
+            !encodedCname.empty() ? name_len + RRFIXEDSZ + encodedCname.size() + 1 : 0;
         const uint16_t response_size_n =
             htons(response_base_len + response_ip_rest_len + response_cname_len);
         Buffer::OwnedImpl write_buffer;
@@ -191,7 +191,7 @@ private:
         write_buffer.add(response_base, response_base_len);
 
         // if we have a cname, create a resource record
-        if (encodedCname.size() > 0) {
+        if (!encodedCname.empty()) {
           unsigned char cname_rr_fixed[RRFIXEDSZ];
           DNS_RR_SET_TYPE(cname_rr_fixed, T_CNAME);
           DNS_RR_SET_LEN(cname_rr_fixed, encodedCname.size() + 1);


### PR DESCRIPTION
Signed-off-by: Henna Huang <henna@google.com>

*title*: *Some clang tidy fixes*

*Description*:
Clang-tidy fixes for readability-inconsistent-declaration-parameter-name and
readability-container-size-empty

*Risk Level*: Low 

*Testing*:
N/A

*Docs Changes*:
N/A

*Release Notes*:
N/A