### PR TITLE
build: fix cares with latest automake on OS X

### DIFF
--- a/ci/build_container/build_recipes/cares.sh
+++ b/ci/build_container/build_recipes/cares.sh
@@ -5,9 +5,10 @@ set -e
 VERSION=cares-1_14_0
 
 # cares is fussy over whether -D appears inside CFLAGS vs. CPPFLAGS, oss-fuzz
-# sets CFLAGS with -D, so we need to impedance match here.
-CPPFLAGS="$(for f in $CXXFLAGS; do if [[ $f =~ -D.* ]]; then echo $f; fi; done)"
-CFLAGS="$(for f in $CXXFLAGS; do if [[ ! $f =~ -D.* ]]; then echo $f; fi; done)"
+# sets CFLAGS with -D, so we need to impedance match here. In turn, OS X automake
+# is fussy about newlines in CFLAGS/CPPFLAGS, so translate them into spaces.
+CPPFLAGS="$(for f in $CXXFLAGS; do if [[ $f =~ -D.* ]]; then echo $f; fi; done | tr '\n' ' ')"
+CFLAGS="$(for f in $CXXFLAGS; do if [[ ! $f =~ -D.* ]]; then echo $f; fi; done | tr '\n' ' ')"
 
 wget -O c-ares-"$VERSION".tar.gz https://github.com/c-ares/c-ares/archive/"$VERSION".tar.gz
 tar xf c-ares-"$VERSION".tar.gz

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -21,7 +21,7 @@ if ! brew update; then
     exit 1
 fi
 
-DEPS="coreutils wget cmake libtool go bazel"
+DEPS="automake bazel cmake coreutils go libtool wget"
 for DEP in ${DEPS}
 do
     is_installed "${DEP}" || install "${DEP}"


### PR DESCRIPTION
The current homebrew version of automake on OS X is 1.16 and it fails to build c-ares due to newlines that are introduced into CFLAGS in cares.sh. This change converts the newlines to spaces.

*Risk Level*: Low - minor build change
*Testing*: existing tests are sufficient
*Release Notes*: N/A

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
