### PR TITLE
Revert "logger: macros evaluate logging level before invoking logger …

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -57,21 +57,6 @@ public:
   std::string name() const { return logger_->name(); }
   void setLevel(spdlog::level::level_enum level) const { logger_->set_level(level); }
 
-  /* This is simple mapping between Logger severity levels and spdlog severity levels.
-   * The only reason for this mapping is to go around the fact that spdlog defines level as err
-   * but the method to log at err level is called LOGGER.error not LOGGER.err. All other level are
-   * fine spdlog::info corresponds to LOGGER.info method.
-   */
-  typedef enum {
-    trace = spdlog::level::trace,
-    debug = spdlog::level::debug,
-    info = spdlog::level::info,
-    warn = spdlog::level::warn,
-    error = spdlog::level::err,
-    critical = spdlog::level::critical,
-    off = spdlog::level::off
-  } levels;
-
 private:
   Logger(const std::string& name);
 
@@ -207,12 +192,7 @@ protected:
 /**
  * Convenience macro to log to a user-specified logger.
  */
-#define ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ...)                                                    \
-  do {                                                                                             \
-    if (static_cast<spdlog::level::level_enum>(Envoy::Logger::Logger::LEVEL) >= LOGGER.level()) {  \
-      ENVOY_LOG_##LEVEL##_TO_LOGGER(LOGGER, ##__VA_ARGS__);                                        \
-    }                                                                                              \
-  } while (0)
+#define ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ...) ENVOY_LOG_##LEVEL##_TO_LOGGER(LOGGER, ##__VA_ARGS__)
 
 /**
  * Convenience macro to get logger.

--- a/source/common/http/filter/lua/lua_filter.cc
+++ b/source/common/http/filter/lua/lua_filter.cc
@@ -481,23 +481,17 @@ void Filter::scriptError(const Envoy::Lua::LuaException& e) {
 void Filter::scriptLog(spdlog::level::level_enum level, const char* message) {
   switch (level) {
   case spdlog::level::trace:
-    ENVOY_LOG(trace, "script log: {}", message);
-    return;
+    return ENVOY_LOG(trace, "script log: {}", message);
   case spdlog::level::debug:
-    ENVOY_LOG(debug, "script log: {}", message);
-    return;
+    return ENVOY_LOG(debug, "script log: {}", message);
   case spdlog::level::info:
-    ENVOY_LOG(info, "script log: {}", message);
-    return;
+    return ENVOY_LOG(info, "script log: {}", message);
   case spdlog::level::warn:
-    ENVOY_LOG(warn, "script log: {}", message);
-    return;
+    return ENVOY_LOG(warn, "script log: {}", message);
   case spdlog::level::err:
-    ENVOY_LOG(error, "script log: {}", message);
-    return;
+    return ENVOY_LOG(error, "script log: {}", message);
   case spdlog::level::critical:
-    ENVOY_LOG(critical, "script log: {}", message);
-    return;
+    return ENVOY_LOG(critical, "script log: {}", message);
   case spdlog::level::off:
     NOT_IMPLEMENTED;
   }

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -37,40 +37,4 @@ TEST(Logger, All) {
   // Misc logging with no facility.
   ENVOY_LOG_MISC(info, "fake message");
 }
-
-TEST(Logger, evaluateParams) {
-  uint32_t i = 1;
-
-  // set logger's level to low level.
-  // log message with higher severity and make sure that params were evaluated.
-  GET_MISC_LOGGER().set_level(spdlog::level::info);
-  ENVOY_LOG_MISC(warn, "test message '{}'", i++);
-  ASSERT_THAT(i, testing::Eq(2));
-}
-
-TEST(Logger, doNotEvaluateParams) {
-  uint32_t i = 1;
-
-  // set logger's logging level high and log a message with lower severity
-  // params should not be evaluated.
-  GET_MISC_LOGGER().set_level(spdlog::level::critical);
-  ENVOY_LOG_MISC(error, "test message '{}'", i++);
-  ASSERT_THAT(i, testing::Eq(1));
-}
-
-TEST(Logger, logAsStatement) {
-  // Just log as part of if ... statement
-
-  if (true)
-    ENVOY_LOG_MISC(critical, "test message 1");
-  else
-    ENVOY_LOG_MISC(critical, "test message 2");
-
-  // do the same with curly brackets
-  if (true) {
-    ENVOY_LOG_MISC(critical, "test message 3");
-  } else {
-    ENVOY_LOG_MISC(critical, "test message 4");
-  }
-}
 } // namespace Envoy


### PR DESCRIPTION
…(#2676)"

This reverts commit 807809281759993026f41112994566db01685004.

Signed-off-by: Lita Cho <lcho@lyft.com>

*revert*: *logger: macros evaluate logging level before invoking logger (#2676)*

*Description*: Revert https://github.com/envoyproxy/envoy/pull/2676
*Risk Level*: Low 
*Testing*: N/A
