### PR TITLE
Cluster lazy loading

### DIFF
--- a/include/envoy/upstream/BUILD
+++ b/include/envoy/upstream/BUILD
@@ -14,6 +14,26 @@ envoy_cc_library(
     deps = [
         ":load_balancer_interface",
         ":thread_local_cluster_interface",
+        ":lazy_loader_interface",
+        ":upstream_interface",
+        "//include/envoy/access_log:access_log_interface",
+        "//include/envoy/config:grpc_mux_interface",
+        "//include/envoy/grpc:async_client_manager_interface",
+        "//include/envoy/http:async_client_interface",
+        "//include/envoy/http:conn_pool_interface",
+        "//include/envoy/local_info:local_info_interface",
+        "//include/envoy/runtime:runtime_interface",
+        "@envoy_api//envoy/api/v2:cds_cc",
+        "@envoy_api//envoy/config/bootstrap/v2:bootstrap_cc",
+    ],
+)
+
+envoy_cc_library(
+    name = "lazy_loader_interface",
+    hdrs = ["lazy_loader.h"],
+    deps = [
+        ":load_balancer_interface",
+        ":thread_local_cluster_interface",
         ":upstream_interface",
         "//include/envoy/access_log:access_log_interface",
         "//include/envoy/config:grpc_mux_interface",

--- a/include/envoy/upstream/lazy_loader.h
+++ b/include/envoy/upstream/lazy_loader.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "envoy/access_log/access_log.h"
+#include "envoy/api/v2/cds.pb.h"
+#include "envoy/config/bootstrap/v2/bootstrap.pb.h"
+#include "envoy/config/grpc_mux.h"
+#include "envoy/grpc/async_client_manager.h"
+#include "envoy/http/async_client.h"
+#include "envoy/http/conn_pool.h"
+#include "envoy/local_info/local_info.h"
+#include "envoy/runtime/runtime.h"
+#include "envoy/upstream/load_balancer.h"
+#include "envoy/upstream/thread_local_cluster.h"
+#include "envoy/upstream/upstream.h"
+
+namespace Envoy {
+namespace Upstream {
+
+/**
+ * Lazy loading is only available when using CDS, bootstrap with static clusters will not support
+ * lazy loading.
+ */
+class LazyLoader {
+public:
+  virtual ~LazyLoader() {}
+
+  virtual void loadCluster(const std::string& cluster) PURE;
+};
+
+}
+}

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -377,6 +377,8 @@ public:
    */
   virtual bool addedViaApi() const PURE;
 
+  virtual bool addedLazily() const PURE;
+
   /**
    * @return the connect timeout for upstream hosts that belong to this cluster.
    */

--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -284,6 +284,7 @@ envoy_cc_library(
         ":utility_lib",
         "//include/envoy/config:subscription_interface",
         "//include/envoy/upstream:cluster_manager_interface",
+        "//source/common/upstream:cds_subscription_lib",
         "//source/common/filesystem:filesystem_lib",
         "//source/common/protobuf",
         "@envoy_api//envoy/api/v2/core:base_cc",

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -51,8 +51,14 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "cluster_manager_lib",
-    srcs = ["cluster_manager_impl.cc"],
-    hdrs = ["cluster_manager_impl.h"],
+    srcs = [
+        "cluster_manager_impl.cc",
+        "lazy_loader_impl.cc",
+    ],
+    hdrs = [
+        "cluster_manager_impl.h",
+        "lazy_loader_impl.h"
+    ],
     deps = [
         ":cds_api_lib",
         ":load_balancer_lib",
@@ -67,6 +73,7 @@ envoy_cc_library(
         "//include/envoy/ssl:context_manager_interface",
         "//include/envoy/thread_local:thread_local_interface",
         "//include/envoy/upstream:cluster_manager_interface",
+        "//include/envoy/upstream:lazy_loader_interface",
         "//source/common/common:enum_to_int",
         "//source/common/common:utility_lib",
         "//source/common/config:cds_json_lib",

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -27,6 +27,7 @@
 #include "common/protobuf/utility.h"
 #include "common/router/shadow_writer_impl.h"
 #include "common/upstream/cds_api_impl.h"
+#include "common/upstream/lazy_loader_impl.h"
 #include "common/upstream/load_balancer_impl.h"
 #include "common/upstream/maglev_lb.h"
 #include "common/upstream/original_dst_cluster.h"
@@ -201,14 +202,14 @@ ClusterManagerImpl::ClusterManagerImpl(const envoy::config::bootstrap::v2::Boots
   for (const auto& cluster : bootstrap.static_resources().clusters()) {
     // First load all the primary clusters.
     if (cluster.type() != envoy::api::v2::Cluster::EDS) {
-      loadCluster(cluster, false);
+      loadCluster(cluster, false, false);
     }
   }
 
   for (const auto& cluster : bootstrap.static_resources().clusters()) {
     // Now load all the secondary clusters.
     if (cluster.type() == envoy::api::v2::Cluster::EDS) {
-      loadCluster(cluster, false);
+      loadCluster(cluster, false, false);
     }
   }
 
@@ -299,6 +300,11 @@ ClusterManagerImpl::ClusterManagerImpl(const envoy::config::bootstrap::v2::Boots
             ->create(),
         primary_dispatcher));
   }
+
+  // Lazy loading requires CDS
+  if (bootstrap.dynamic_resources().has_cds_config()) {
+    lazy_loader_.reset(new LazyLoaderImpl(bootstrap, local_info, primary_dispatcher, random, *this, stats));
+  }
 }
 
 ClusterManagerStats ClusterManagerImpl::generateStats(Stats::Scope& scope) {
@@ -337,6 +343,10 @@ void ClusterManagerImpl::onClusterInit(Cluster& cluster) {
 }
 
 bool ClusterManagerImpl::addOrUpdatePrimaryCluster(const envoy::api::v2::Cluster& cluster) {
+  return addOrUpdatePrimaryCluster(cluster, false);
+}
+
+bool ClusterManagerImpl::addOrUpdatePrimaryCluster(const envoy::api::v2::Cluster& cluster, bool added_lazily) {
   // First we need to see if this new config is new or an update to an existing dynamic cluster.
   // We don't allow updates to statically configured clusters in the main configuration.
   const std::string cluster_name = cluster.name();
@@ -351,7 +361,7 @@ bool ClusterManagerImpl::addOrUpdatePrimaryCluster(const envoy::api::v2::Cluster
     init_helper_.removeCluster(*existing_cluster->second.cluster_);
   }
 
-  loadCluster(cluster, true);
+  loadCluster(cluster, true, added_lazily);
   auto& primary_cluster_entry = primary_clusters_.at(cluster_name);
   ENVOY_LOG(info, "add/update cluster {}", cluster_name);
   tls_->runOnAllThreads(
@@ -369,9 +379,13 @@ bool ClusterManagerImpl::addOrUpdatePrimaryCluster(const envoy::api::v2::Cluster
               ENVOY_LOG(debug, "adding TLS cluster {}", new_cluster->name());
             }
 
-            cluster_manager.thread_local_clusters_[new_cluster->name()].reset(
+            auto thread_local_cluster =
                 new ThreadLocalClusterManagerImpl::ClusterEntry(cluster_manager, new_cluster,
-                                                                thread_aware_lb_factory));
+                                                                thread_aware_lb_factory);
+            cluster_manager.thread_local_clusters_[new_cluster->name()].reset(thread_local_cluster);
+            for (auto *cb : cluster_manager.update_callbacks_) {
+              cb->onClusterAddOrUpdate(*thread_local_cluster);
+            }
           });
 
   init_helper_.addCluster(*primary_cluster_entry.cluster_);
@@ -396,14 +410,17 @@ bool ClusterManagerImpl::removePrimaryCluster(const std::string& cluster_name) {
     ASSERT(cluster_manager.thread_local_clusters_.count(cluster_name) == 1);
     ENVOY_LOG(debug, "removing TLS cluster {}", cluster_name);
     cluster_manager.thread_local_clusters_.erase(cluster_name);
+    for (auto *cb : cluster_manager.update_callbacks_) {
+      cb->onClusterRemoval(cluster_name);
+    }
   });
 
   return true;
 }
 
-void ClusterManagerImpl::loadCluster(const envoy::api::v2::Cluster& cluster, bool added_via_api) {
+void ClusterManagerImpl::loadCluster(const envoy::api::v2::Cluster& cluster, bool added_via_api, bool added_lazily) {
   ClusterSharedPtr new_cluster =
-      factory_.clusterFromProto(cluster, *this, outlier_event_logger_, added_via_api);
+      factory_.clusterFromProto(cluster, *this, outlier_event_logger_, added_via_api, added_lazily);
 
   if (!added_via_api) {
     if (primary_clusters_.find(new_cluster->info()->name()) != primary_clusters_.end()) {
@@ -434,7 +451,7 @@ void ClusterManagerImpl::loadCluster(const envoy::api::v2::Cluster& cluster, boo
   size_t num_erased = primary_clusters_.erase(primary_cluster_reference.info()->name());
   auto cluster_entry_it = primary_clusters_
                               .emplace(primary_cluster_reference.info()->name(),
-                                       PrimaryClusterData{MessageUtil::hash(cluster), added_via_api,
+                                       PrimaryClusterData{MessageUtil::hash(cluster), added_via_api, added_lazily,
                                                           std::move(new_cluster)})
                               .first;
 
@@ -546,6 +563,16 @@ const std::string ClusterManagerImpl::versionInfo() const {
     return cds_api_->versionInfo();
   }
   return "static";
+}
+
+void ClusterManagerImpl::addClusterUpdateCallbacks(ClusterUpdateCallbacks& cb) {
+  ThreadLocalClusterManagerImpl& cluster_manager = tls_->getTyped<ThreadLocalClusterManagerImpl>();
+  cluster_manager.update_callbacks_.insert(&cb);
+}
+
+void ClusterManagerImpl::removeClusterUpdateCallbacks(ClusterUpdateCallbacks& cb) {
+  ThreadLocalClusterManagerImpl& cluster_manager = tls_->getTyped<ThreadLocalClusterManagerImpl>();
+  cluster_manager.update_callbacks_.erase(&cb);
 }
 
 ClusterManagerImpl::ThreadLocalClusterManagerImpl::ThreadLocalClusterManagerImpl(
@@ -805,10 +832,10 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
 
 ClusterSharedPtr ProdClusterManagerFactory::clusterFromProto(
     const envoy::api::v2::Cluster& cluster, ClusterManager& cm,
-    Outlier::EventLoggerSharedPtr outlier_event_logger, bool added_via_api) {
+    Outlier::EventLoggerSharedPtr outlier_event_logger, bool added_via_api, bool added_lazily) {
   return ClusterImplBase::create(cluster, cm, stats_, tls_, dns_resolver_, ssl_context_manager_,
                                  runtime_, random_, primary_dispatcher_, local_info_,
-                                 outlier_event_logger, added_via_api);
+                                 outlier_event_logger, added_via_api, added_lazily);
 }
 
 CdsApiPtr

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -21,9 +21,9 @@ EdsClusterImpl::EdsClusterImpl(const envoy::api::v2::Cluster& cluster, Runtime::
                                Stats::Store& stats, Ssl::ContextManager& ssl_context_manager,
                                const LocalInfo::LocalInfo& local_info, ClusterManager& cm,
                                Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
-                               bool added_via_api)
+                               bool added_via_api, bool added_lazily)
     : BaseDynamicClusterImpl(cluster, cm.sourceAddress(), runtime, stats, ssl_context_manager,
-                             added_via_api),
+                             added_via_api, added_lazily),
       cm_(cm), local_info_(local_info),
       cluster_name_(cluster.eds_cluster_config().service_name().empty()
                         ? cluster.name()

--- a/source/common/upstream/eds.h
+++ b/source/common/upstream/eds.h
@@ -20,7 +20,7 @@ public:
                  Stats::Store& stats, Ssl::ContextManager& ssl_context_manager,
                  const LocalInfo::LocalInfo& local_info, ClusterManager& cm,
                  Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
-                 bool added_via_api);
+                 bool added_via_api, bool added_lazily);
 
   const std::string versionInfo() const { return subscription_->versionInfo(); }
 

--- a/source/common/upstream/lazy_loader_impl.cc
+++ b/source/common/upstream/lazy_loader_impl.cc
@@ -1,0 +1,68 @@
+#include "common/upstream/lazy_loader_impl.h"
+
+#include "envoy/config/bootstrap/v2/bootstrap.pb.h"
+#include "envoy/upstream/lazy_loader.h"
+#include "envoy/event/dispatcher.h"
+
+#include "common/config/subscription_factory.h"
+#include "common/config/utility.h"
+#include "common/config/grpc_mux_impl.h"
+
+
+namespace Envoy {
+namespace Upstream {
+
+
+LazyLoaderImpl::LazyLoaderImpl(const envoy::config::bootstrap::v2::Bootstrap& bootstrap,
+                               const LocalInfo::LocalInfo& local_info,
+                               Event::Dispatcher& primary_dispatcher,
+                               Runtime::RandomGenerator& random,
+                               ClusterManagerImpl& cm,
+                               Stats::Store& stats) :
+                                 primary_dispatcher_(primary_dispatcher),
+                                 cluster_manager_(cm) {
+  ASSERT(bootstrap.dynamic_resources().has_cds_config());
+  if (bootstrap.dynamic_resources().has_ads_config()) {
+    // Create an ADS stream for the lazy loader. We can not reuse the cluster manager ADS stream.
+    ads_mux_.reset(new Config::GrpcMuxImpl(
+        bootstrap.node(),
+        Config::Utility::factoryForApiConfigSource(
+            cluster_manager_.grpcAsyncClientManager(), bootstrap.dynamic_resources().ads_config(), stats)
+            ->create(),
+        primary_dispatcher,
+        *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
+            "envoy.service.discovery.v2.AggregatedDiscoveryService.StreamAggregatedResources")));
+  } else {
+    ads_mux_.reset(&cluster_manager_.adsMux());
+  }
+
+  if (bootstrap.dynamic_resources().deprecated_v1().has_sds_config()) {
+    eds_config_.value(bootstrap.dynamic_resources().deprecated_v1().sds_config());
+  }
+
+  subscription_ =
+      Config::SubscriptionFactory::cdsSubscriptionFromConfigSource(
+          bootstrap.dynamic_resources().cds_config(), eds_config_, local_info, primary_dispatcher,
+          cluster_manager_, random, stats, *ads_mux_.get());
+
+  subscription_->start({}, *this);
+};
+
+void LazyLoaderImpl::loadCluster(const std::string& cluster) {
+  subscription_->updateResources({cluster});
+}
+
+void LazyLoaderImpl::onConfigUpdate(const ResourceVector& resources) {
+  primary_dispatcher_.post([this, resources]() -> void {
+    for (auto r : resources) {
+      cluster_manager_.addOrUpdatePrimaryCluster(r, true);
+    }
+  });
+}
+void LazyLoaderImpl::onConfigUpdateFailed(const EnvoyException* e) {
+  ENVOY_LOG(warn, "gRPC update failed for lazy loader: {}", e->what());
+}
+
+} // namespace Upstream
+} // namespace Envoy
+

--- a/source/common/upstream/lazy_loader_impl.h
+++ b/source/common/upstream/lazy_loader_impl.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "envoy/config/bootstrap/v2/bootstrap.pb.h"
+#include "envoy/upstream/lazy_loader.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/config/subscription.h"
+
+#include "common/config/grpc_mux_impl.h"
+#include "common/upstream/cluster_manager_impl.h"
+
+namespace Envoy {
+namespace Upstream {
+
+class LazyLoaderImpl : public LazyLoader, Config::SubscriptionCallbacks<envoy::api::v2::Cluster>, Logger::Loggable<Logger::Id::upstream> {
+public:
+  LazyLoaderImpl(const envoy::config::bootstrap::v2::Bootstrap& bootstrap,
+                 const LocalInfo::LocalInfo& local_info,
+                 Event::Dispatcher& primary_dispatcher,
+                 Runtime::RandomGenerator& random,
+                 ClusterManagerImpl& cluster_manager,
+                 Stats::Store& statsconst);
+
+  void loadCluster(const std::string& cluster) override;
+
+  // From Config::SubscriptionCallbacks
+  void onConfigUpdate(const ResourceVector& resources) override;
+  void onConfigUpdateFailed(const EnvoyException* e) override;
+  std::string resourceName(const ProtobufWkt::Any& resource) override {
+    return MessageUtil::anyConvert<envoy::api::v2::Cluster>(resource).name();
+  }
+
+private:
+  Optional<envoy::api::v2::core::ConfigSource> eds_config_;
+  Config::GrpcMuxPtr ads_mux_;
+  std::unique_ptr<Config::Subscription<envoy::api::v2::Cluster>> subscription_;
+  Event::Dispatcher& primary_dispatcher_;
+  ClusterManagerImpl& cluster_manager_;
+
+};
+
+} // namespace Upstream
+} // namespace Envoy

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -20,9 +20,9 @@ LogicalDnsCluster::LogicalDnsCluster(const envoy::api::v2::Cluster& cluster,
                                      Ssl::ContextManager& ssl_context_manager,
                                      Network::DnsResolverSharedPtr dns_resolver,
                                      ThreadLocal::SlotAllocator& tls, ClusterManager& cm,
-                                     Event::Dispatcher& dispatcher, bool added_via_api)
+                                     Event::Dispatcher& dispatcher, bool added_via_api, bool added_lazily)
     : ClusterImplBase(cluster, cm.sourceAddress(), runtime, stats, ssl_context_manager,
-                      added_via_api),
+                      added_via_api, added_lazily),
       dns_resolver_(dns_resolver),
       dns_refresh_rate_ms_(
           std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(cluster, dns_refresh_rate, 5000))),

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -31,7 +31,7 @@ public:
   LogicalDnsCluster(const envoy::api::v2::Cluster& cluster, Runtime::Loader& runtime,
                     Stats::Store& stats, Ssl::ContextManager& ssl_context_manager,
                     Network::DnsResolverSharedPtr dns_resolver, ThreadLocal::SlotAllocator& tls,
-                    ClusterManager& cm, Event::Dispatcher& dispatcher, bool added_via_api);
+                    ClusterManager& cm, Event::Dispatcher& dispatcher, bool added_via_api, bool added_lazily);
 
   ~LogicalDnsCluster();
 

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -94,9 +94,9 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
 OriginalDstCluster::OriginalDstCluster(const envoy::api::v2::Cluster& config,
                                        Runtime::Loader& runtime, Stats::Store& stats,
                                        Ssl::ContextManager& ssl_context_manager, ClusterManager& cm,
-                                       Event::Dispatcher& dispatcher, bool added_via_api)
+                                       Event::Dispatcher& dispatcher, bool added_via_api, bool added_lazily)
     : ClusterImplBase(config, cm.sourceAddress(), runtime, stats, ssl_context_manager,
-                      added_via_api),
+                      added_via_api, added_lazily),
       dispatcher_(dispatcher), cleanup_interval_ms_(std::chrono::milliseconds(
                                    PROTOBUF_GET_MS_OR_DEFAULT(config, cleanup_interval, 5000))),
       cleanup_timer_(dispatcher.createTimer([this]() -> void { cleanup(); })) {

--- a/source/common/upstream/original_dst_cluster.h
+++ b/source/common/upstream/original_dst_cluster.h
@@ -24,7 +24,7 @@ class OriginalDstCluster : public ClusterImplBase {
 public:
   OriginalDstCluster(const envoy::api::v2::Cluster& config, Runtime::Loader& runtime,
                      Stats::Store& stats, Ssl::ContextManager& ssl_context_manager,
-                     ClusterManager& cm, Event::Dispatcher& dispatcher, bool added_via_api);
+                     ClusterManager& cm, Event::Dispatcher& dispatcher, bool added_via_api, bool added_lazily);
 
   // Upstream::Cluster
   InitializePhase initializePhase() const override { return InitializePhase::Primary; }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -296,13 +296,15 @@ public:
   ClusterInfoImpl(const envoy::api::v2::Cluster& config,
                   const Network::Address::InstanceConstSharedPtr source_address,
                   Runtime::Loader& runtime, Stats::Store& stats,
-                  Ssl::ContextManager& ssl_context_manager, bool added_via_api);
+                  Ssl::ContextManager& ssl_context_manager, bool added_via_api,
+                  bool added_lazily_);
 
   static ClusterStats generateStats(Stats::Scope& scope);
   static ClusterLoadReportStats generateLoadReportStats(Stats::Scope& scope);
 
   // Upstream::ClusterInfo
   bool addedViaApi() const override { return added_via_api_; }
+  bool addedLazily() const override { return added_lazily_; }
   const envoy::api::v2::Cluster::CommonLbConfig& lbConfig() const override {
     return common_lb_config_;
   }
@@ -371,6 +373,7 @@ private:
   Optional<envoy::api::v2::Cluster::RingHashLbConfig> lb_ring_hash_config_;
   Ssl::ContextManager& ssl_context_manager_;
   const bool added_via_api_;
+  const bool added_lazily_;
   LoadBalancerSubsetInfoImpl lb_subset_;
   const envoy::api::v2::core::Metadata metadata_;
   const envoy::api::v2::Cluster::CommonLbConfig common_lb_config_;
@@ -389,7 +392,7 @@ public:
                                  Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                                  const LocalInfo::LocalInfo& local_info,
                                  Outlier::EventLoggerSharedPtr outlier_event_logger,
-                                 bool added_via_api);
+                                 bool added_via_api, bool added_lazily);
   // From Upstream::Cluster
   virtual PrioritySet& prioritySet() override { return priority_set_; }
   virtual const PrioritySet& prioritySet() const override { return priority_set_; }
@@ -418,7 +421,7 @@ protected:
   ClusterImplBase(const envoy::api::v2::Cluster& cluster,
                   const Network::Address::InstanceConstSharedPtr source_address,
                   Runtime::Loader& runtime, Stats::Store& stats,
-                  Ssl::ContextManager& ssl_context_manager, bool added_via_api);
+                  Ssl::ContextManager& ssl_context_manager, bool added_via_api, bool added_lazily);
 
   static HostVectorConstSharedPtr createHealthyHostList(const HostVector& hosts);
   static HostsPerLocalityConstSharedPtr createHealthyHostLists(const HostsPerLocality& hosts);
@@ -462,7 +465,7 @@ class StaticClusterImpl : public ClusterImplBase {
 public:
   StaticClusterImpl(const envoy::api::v2::Cluster& cluster, Runtime::Loader& runtime,
                     Stats::Store& stats, Ssl::ContextManager& ssl_context_manager,
-                    ClusterManager& cm, bool added_via_api);
+                    ClusterManager& cm, bool added_via_api, bool added_lazily);
 
   // Upstream::Cluster
   InitializePhase initializePhase() const override { return InitializePhase::Primary; }
@@ -494,7 +497,7 @@ public:
   StrictDnsClusterImpl(const envoy::api::v2::Cluster& cluster, Runtime::Loader& runtime,
                        Stats::Store& stats, Ssl::ContextManager& ssl_context_manager,
                        Network::DnsResolverSharedPtr dns_resolver, ClusterManager& cm,
-                       Event::Dispatcher& dispatcher, bool added_via_api);
+                       Event::Dispatcher& dispatcher, bool added_via_api, bool added_lazily);
 
   // Upstream::Cluster
   InitializePhase initializePhase() const override { return InitializePhase::Primary; }


### PR DESCRIPTION
Lazy loading

This PR addresses #2500 for cluster lazy loading. Key design points are:

- Exposes a new LazyLoader type that is owned by cluster manager.
- LazyLoader allows the user to request for a specific cluster config.
- LazyLoader is only available is there is a dynamic CDS config.
- It will own its own separate XDS stream to not interfere with ClusterManager.
- Callbacks can be added to ClusterManager to be notified of clusters updates or removal.

Missing in this initial PR. guidance requested:

- At the moment there is no mechanism to deactivate the feature and avoid the extra XDS stream per envoy.
- Tests.
- I do not know if this PR should include a filter in source/common/http/filter/. Should I include one or let users implement their own using custom filters. Example implementation: https://gist.github.com/nt/e97410fd29583a340c4bb8ab4c41d9b8

Risk Level: Medium (new feature)
