### PR TITLE
logger: macros evaluate logging level before invoking logger 

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -208,9 +208,11 @@ protected:
  * Convenience macro to log to a user-specified logger.
  */
 #define ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ...)                                                    \
-  if (static_cast<spdlog::level::level_enum>(Logger::Logger::LEVEL) >= LOGGER.level()) {           \
-    ENVOY_LOG_##LEVEL##_TO_LOGGER(LOGGER, ##__VA_ARGS__);                                          \
-  }
+  do {                                                                                             \
+    if (static_cast<spdlog::level::level_enum>(Logger::Logger::LEVEL) >= LOGGER.level()) {         \
+      ENVOY_LOG_##LEVEL##_TO_LOGGER(LOGGER, ##__VA_ARGS__);                                        \
+    }                                                                                              \
+  } while (0)
 
 /**
  * Convenience macro to get logger.

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -57,6 +57,21 @@ public:
   std::string name() const { return logger_->name(); }
   void setLevel(spdlog::level::level_enum level) const { logger_->set_level(level); }
 
+  /* This is simple mapping between Logger severity levels and spdlog severity levels.
+   * The only reason for this mapping is to go around the fact that spdlog defines level as err
+   * but the method to log at err level is called LOGGER.error not LOGGER.err. All other level are
+   * fine spdlog::info corresponds to LOGGER.info method.
+   */
+  typedef enum {
+    trace = spdlog::level::trace,
+    debug = spdlog::level::debug,
+    info = spdlog::level::info,
+    warn = spdlog::level::warn,
+    error = spdlog::level::err,
+    critical = spdlog::level::critical,
+    off = spdlog::level::off
+  } levels;
+
 private:
   Logger(const std::string& name);
 
@@ -192,7 +207,10 @@ protected:
 /**
  * Convenience macro to log to a user-specified logger.
  */
-#define ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ...) ENVOY_LOG_##LEVEL##_TO_LOGGER(LOGGER, ##__VA_ARGS__)
+#define ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ...)                                                    \
+  if (static_cast<spdlog::level::level_enum>(Logger::Logger::LEVEL) >= LOGGER.level()) {           \
+    ENVOY_LOG_##LEVEL##_TO_LOGGER(LOGGER, ##__VA_ARGS__);                                          \
+  }
 
 /**
  * Convenience macro to get logger.

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -209,7 +209,7 @@ protected:
  */
 #define ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ...)                                                    \
   do {                                                                                             \
-    if (static_cast<spdlog::level::level_enum>(Logger::Logger::LEVEL) >= LOGGER.level()) {         \
+    if (static_cast<spdlog::level::level_enum>(Envoy::Logger::Logger::LEVEL) >= LOGGER.level()) {  \
       ENVOY_LOG_##LEVEL##_TO_LOGGER(LOGGER, ##__VA_ARGS__);                                        \
     }                                                                                              \
   } while (0)

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -191,28 +191,32 @@ protected:
  * Base logging macros. It is expected that users will use the convenience macros below rather than
  * invoke these directly.
  */
+// Compare levels before invoking logger
+#define ENVOY_LOG_COMP_AND_LOG(LOGGER, LEVEL, ...)                                                 \
+  do {                                                                                             \
+    if (static_cast<spdlog::level::level_enum>(Envoy::Logger::Logger::LEVEL) >= LOGGER.level()) {  \
+      LOGGER.LEVEL(LOG_PREFIX __VA_ARGS__);                                                        \
+    }                                                                                              \
+  } while (0)
+
 #ifdef NVLOG
 #define ENVOY_LOG_trace_TO_LOGGER(LOGGER, ...)
 #define ENVOY_LOG_debug_TO_LOGGER(LOGGER, ...)
 #else
-#define ENVOY_LOG_trace_TO_LOGGER(LOGGER, ...) LOGGER.trace(LOG_PREFIX __VA_ARGS__)
-#define ENVOY_LOG_debug_TO_LOGGER(LOGGER, ...) LOGGER.debug(LOG_PREFIX __VA_ARGS__)
+#define ENVOY_LOG_trace_TO_LOGGER(LOGGER, ...) ENVOY_LOG_COMP_AND_LOG(LOGGER, trace, ##__VA_ARGS__)
+#define ENVOY_LOG_debug_TO_LOGGER(LOGGER, ...) ENVOY_LOG_COMP_AND_LOG(LOGGER, debug, ##__VA_ARGS__)
 #endif
 
-#define ENVOY_LOG_info_TO_LOGGER(LOGGER, ...) LOGGER.info(LOG_PREFIX __VA_ARGS__)
-#define ENVOY_LOG_warn_TO_LOGGER(LOGGER, ...) LOGGER.warn(LOG_PREFIX __VA_ARGS__)
-#define ENVOY_LOG_error_TO_LOGGER(LOGGER, ...) LOGGER.error(LOG_PREFIX __VA_ARGS__)
-#define ENVOY_LOG_critical_TO_LOGGER(LOGGER, ...) LOGGER.critical(LOG_PREFIX __VA_ARGS__)
+#define ENVOY_LOG_info_TO_LOGGER(LOGGER, ...) ENVOY_LOG_COMP_AND_LOG(LOGGER, info, ##__VA_ARGS__)
+#define ENVOY_LOG_warn_TO_LOGGER(LOGGER, ...) ENVOY_LOG_COMP_AND_LOG(LOGGER, warn, ##__VA_ARGS__)
+#define ENVOY_LOG_error_TO_LOGGER(LOGGER, ...) ENVOY_LOG_COMP_AND_LOG(LOGGER, error, ##__VA_ARGS__)
+#define ENVOY_LOG_critical_TO_LOGGER(LOGGER, ...)                                                  \
+  ENVOY_LOG_COMP_AND_LOG(LOGGER, critical, ##__VA_ARGS__)
 
 /**
  * Convenience macro to log to a user-specified logger.
  */
-#define ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ...)                                                    \
-  do {                                                                                             \
-    if (static_cast<spdlog::level::level_enum>(Envoy::Logger::Logger::LEVEL) >= LOGGER.level()) {  \
-      ENVOY_LOG_##LEVEL##_TO_LOGGER(LOGGER, ##__VA_ARGS__);                                        \
-    }                                                                                              \
-  } while (0)
+#define ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ...) ENVOY_LOG_##LEVEL##_TO_LOGGER(LOGGER, ##__VA_ARGS__)
 
 /**
  * Convenience macro to get logger.

--- a/source/common/http/filter/lua/lua_filter.cc
+++ b/source/common/http/filter/lua/lua_filter.cc
@@ -481,17 +481,23 @@ void Filter::scriptError(const Envoy::Lua::LuaException& e) {
 void Filter::scriptLog(spdlog::level::level_enum level, const char* message) {
   switch (level) {
   case spdlog::level::trace:
-    return ENVOY_LOG(trace, "script log: {}", message);
+    ENVOY_LOG(trace, "script log: {}", message);
+    return;
   case spdlog::level::debug:
-    return ENVOY_LOG(debug, "script log: {}", message);
+    ENVOY_LOG(debug, "script log: {}", message);
+    return;
   case spdlog::level::info:
-    return ENVOY_LOG(info, "script log: {}", message);
+    ENVOY_LOG(info, "script log: {}", message);
+    return;
   case spdlog::level::warn:
-    return ENVOY_LOG(warn, "script log: {}", message);
+    ENVOY_LOG(warn, "script log: {}", message);
+    return;
   case spdlog::level::err:
-    return ENVOY_LOG(error, "script log: {}", message);
+    ENVOY_LOG(error, "script log: {}", message);
+    return;
   case spdlog::level::critical:
-    return ENVOY_LOG(critical, "script log: {}", message);
+    ENVOY_LOG(critical, "script log: {}", message);
+    return;
   case spdlog::level::off:
     NOT_IMPLEMENTED;
   }

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -37,4 +37,24 @@ TEST(Logger, All) {
   // Misc logging with no facility.
   ENVOY_LOG_MISC(info, "fake message");
 }
+
+TEST(Logger, evaluateParams) {
+  auto i = 1;
+
+  // set logger's level to low level.
+  // log message with higher severity and make sure that params were evaluated.
+  GET_MISC_LOGGER().set_level(spdlog::level::info);
+  ENVOY_LOG_MISC(warn, "test message '{}'", i++);
+  ASSERT_THAT(i, testing::Eq(2));
+}
+
+TEST(Logger, doNotEvaluateParams) {
+  auto i = 1;
+
+  // set logger's logging level high and log a message with lower severity
+  // params should not be evaluated.
+  GET_MISC_LOGGER().set_level(spdlog::level::critical);
+  ENVOY_LOG_MISC(error, "test message '{}'", i++);
+  ASSERT_THAT(i, testing::Eq(1));
+}
 } // namespace Envoy

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -39,7 +39,7 @@ TEST(Logger, All) {
 }
 
 TEST(Logger, evaluateParams) {
-  auto i = 1;
+  uint32_t i = 1;
 
   // set logger's level to low level.
   // log message with higher severity and make sure that params were evaluated.
@@ -49,12 +49,28 @@ TEST(Logger, evaluateParams) {
 }
 
 TEST(Logger, doNotEvaluateParams) {
-  auto i = 1;
+  uint32_t i = 1;
 
   // set logger's logging level high and log a message with lower severity
   // params should not be evaluated.
   GET_MISC_LOGGER().set_level(spdlog::level::critical);
   ENVOY_LOG_MISC(error, "test message '{}'", i++);
   ASSERT_THAT(i, testing::Eq(1));
+}
+
+TEST(Logger, logAsStatement) {
+  // Just log as part of if ... statement
+
+  if (true)
+    ENVOY_LOG_MISC(critical, "test message 1");
+  else
+    ENVOY_LOG_MISC(critical, "test message 2");
+
+  // do the same with curly brackets
+  if (true) {
+    ENVOY_LOG_MISC(critical, "test message 3");
+  } else {
+    ENVOY_LOG_MISC(critical, "test message 4");
+  }
 }
 } // namespace Envoy

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -45,7 +45,7 @@ TEST(Logger, evaluateParams) {
   // log message with higher severity and make sure that params were evaluated.
   GET_MISC_LOGGER().set_level(spdlog::level::info);
   ENVOY_LOG_MISC(warn, "test message '{}'", i++);
-  ASSERT_THAT(i, testing::Eq(2));
+  EXPECT_THAT(i, testing::Eq(2));
 }
 
 TEST(Logger, doNotEvaluateParams) {
@@ -55,7 +55,7 @@ TEST(Logger, doNotEvaluateParams) {
   // params should not be evaluated.
   GET_MISC_LOGGER().set_level(spdlog::level::critical);
   ENVOY_LOG_MISC(error, "test message '{}'", i++);
-  ASSERT_THAT(i, testing::Eq(1));
+  EXPECT_THAT(i, testing::Eq(1));
 }
 
 TEST(Logger, logAsStatement) {
@@ -72,8 +72,8 @@ TEST(Logger, logAsStatement) {
   else
     ENVOY_LOG_MISC(critical, "test message 2 '{}'", j++);
 
-  ASSERT_THAT(i, testing::Eq(1));
-  ASSERT_THAT(j, testing::Eq(1));
+  EXPECT_THAT(i, testing::Eq(1));
+  EXPECT_THAT(j, testing::Eq(1));
 
   // do the same with curly brackets
   if (true) {
@@ -82,8 +82,8 @@ TEST(Logger, logAsStatement) {
     ENVOY_LOG_MISC(critical, "test message 4 '{}'", j++);
   }
 
-  ASSERT_THAT(i, testing::Eq(1));
-  ASSERT_THAT(j, testing::Eq(1));
+  EXPECT_THAT(i, testing::Eq(1));
+  EXPECT_THAT(j, testing::Eq(1));
 }
 
 #ifdef NVLOG
@@ -92,10 +92,10 @@ TEST(Logger, doNotExpandTraceAndDebug) {
 
   // The following two macros should be expanded to no-op if NVLOG compile flag is defined.
   ENVOY_LOG_TO_LOGGER(nonExistingLogger, trace, "test message 5 '{}'", i++);
-  ASSERT_THAT(i, testing::Eq(1));
+  EXPECT_THAT(i, testing::Eq(1));
 
   ENVOY_LOG_TO_LOGGER(nonExistingLogger, debug, "test message 6 '{}'", i++);
-  ASSERT_THAT(i, testing::Eq(1));
+  EXPECT_THAT(i, testing::Eq(1));
 }
 #endif /* NVLOG */
 } // namespace Envoy

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -73,4 +73,12 @@ TEST(Logger, logAsStatement) {
     ENVOY_LOG_MISC(critical, "test message 4");
   }
 }
+
+#ifdef NVLOG
+TEST(Logger, doNotExpandTraceAndDebug) {
+  // The following two macros should not be expanded to no-op if NVLOG compile flag is defined.
+  ENVOY_LOG_TO_LOGGER(nonExistingLogger, trace, "test message 5");
+  ENVOY_LOG_TO_LOGGER(nonExistingLogger, debug, "test message 6");
+}
+#endif /* NVLOG */
 } // namespace Envoy

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -41,8 +41,8 @@ TEST(Logger, All) {
 TEST(Logger, evaluateParams) {
   uint32_t i = 1;
 
-  // set logger's level to low level.
-  // log message with higher severity and make sure that params were evaluated.
+  // Set logger's level to low level.
+  // Log message with higher severity and make sure that params were evaluated.
   GET_MISC_LOGGER().set_level(spdlog::level::info);
   ENVOY_LOG_MISC(warn, "test message '{}'", i++);
   EXPECT_THAT(i, testing::Eq(2));
@@ -51,7 +51,7 @@ TEST(Logger, evaluateParams) {
 TEST(Logger, doNotEvaluateParams) {
   uint32_t i = 1;
 
-  // set logger's logging level high and log a message with lower severity
+  // Set logger's logging level high and log a message with lower severity
   // params should not be evaluated.
   GET_MISC_LOGGER().set_level(spdlog::level::critical);
   ENVOY_LOG_MISC(error, "test message '{}'", i++);
@@ -62,7 +62,7 @@ TEST(Logger, logAsStatement) {
   // Just log as part of if ... statement
   uint32_t i = 1, j = 1;
 
-  // set logger's logging level to high
+  // Set logger's logging level to high
   GET_MISC_LOGGER().set_level(spdlog::level::critical);
 
   // Make sure that if statement inside of LOGGER macro does not catch trailing
@@ -75,7 +75,7 @@ TEST(Logger, logAsStatement) {
   EXPECT_THAT(i, testing::Eq(1));
   EXPECT_THAT(j, testing::Eq(1));
 
-  // do the same with curly brackets
+  // Do the same with curly brackets
   if (true) {
     ENVOY_LOG_MISC(warn, "test message 3 '{}'", i++);
   } else {

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -60,25 +60,42 @@ TEST(Logger, doNotEvaluateParams) {
 
 TEST(Logger, logAsStatement) {
   // Just log as part of if ... statement
+  uint32_t i = 1, j = 1;
 
+  // set logger's logging level to high
+  GET_MISC_LOGGER().set_level(spdlog::level::critical);
+
+  // Make sure that if statement inside of LOGGER macro does not catch trailing
+  // else ....
   if (true)
-    ENVOY_LOG_MISC(critical, "test message 1");
+    ENVOY_LOG_MISC(warn, "test message 1 '{}'", i++);
   else
-    ENVOY_LOG_MISC(critical, "test message 2");
+    ENVOY_LOG_MISC(critical, "test message 2 '{}'", j++);
+
+  ASSERT_THAT(i, testing::Eq(1));
+  ASSERT_THAT(j, testing::Eq(1));
 
   // do the same with curly brackets
   if (true) {
-    ENVOY_LOG_MISC(critical, "test message 3");
+    ENVOY_LOG_MISC(warn, "test message 3 '{}'", i++);
   } else {
-    ENVOY_LOG_MISC(critical, "test message 4");
+    ENVOY_LOG_MISC(critical, "test message 4 '{}'", j++);
   }
+
+  ASSERT_THAT(i, testing::Eq(1));
+  ASSERT_THAT(j, testing::Eq(1));
 }
 
 #ifdef NVLOG
 TEST(Logger, doNotExpandTraceAndDebug) {
-  // The following two macros should not be expanded to no-op if NVLOG compile flag is defined.
-  ENVOY_LOG_TO_LOGGER(nonExistingLogger, trace, "test message 5");
-  ENVOY_LOG_TO_LOGGER(nonExistingLogger, debug, "test message 6");
+  uint32_t i = 1;
+
+  // The following two macros should be expanded to no-op if NVLOG compile flag is defined.
+  ENVOY_LOG_TO_LOGGER(nonExistingLogger, trace, "test message 5 '{}'", i++);
+  ASSERT_THAT(i, testing::Eq(1));
+
+  ENVOY_LOG_TO_LOGGER(nonExistingLogger, debug, "test message 6 '{}'", i++);
+  ASSERT_THAT(i, testing::Eq(1));
 }
 #endif /* NVLOG */
 } // namespace Envoy

--- a/test/common/common/utility_speed_test.cc
+++ b/test/common/common/utility_speed_test.cc
@@ -7,8 +7,6 @@
 #include "absl/strings/string_view.h"
 #include "testing/base/public/benchmark.h"
 
-using namespace Envoy;
-
 static const char TextToTrim[] = "\t  the quick brown fox jumps over the lazy dog\n\r\n";
 static size_t TextToTrimLength = sizeof(TextToTrim) - 1;
 

--- a/test/common/common/utility_speed_test.cc
+++ b/test/common/common/utility_speed_test.cc
@@ -7,6 +7,8 @@
 #include "absl/strings/string_view.h"
 #include "testing/base/public/benchmark.h"
 
+using namespace Envoy;
+
 static const char TextToTrim[] = "\t  the quick brown fox jumps over the lazy dog\n\r\n";
 static size_t TextToTrimLength = sizeof(TextToTrim) - 1;
 


### PR DESCRIPTION
Description: logger's current severity level is checked before calling logger's API. This avoids evaluating parameters passed to the logger when message severity is lower than logger's setting. Before this change, params were evaluated even when the message was later on dropped by logger. This addresses  issue #2330. First PR #2676 was reverted because code did not compile when NVLOG compile flag was enabled. This has been fixed and test for this case has been added.

Risk Level: Medium. This is simple fix, but the code is extensively used across the project.

Testing: unit tests: added 3 tests to test/common/common/log_macros_test.cc. Added test to makes sure that code compiles when NVLOG is defined.

Docs Changes: N/A

Release Notes: N/A