### PR TITLE
Support for gRPC accesslog unauthorized respose flag.

### DIFF
--- a/include/envoy/request_info/request_info.h
+++ b/include/envoy/request_info/request_info.h
@@ -43,10 +43,10 @@ enum ResponseFlag {
   FaultInjected = 0x400,
   // Request was ratelimited locally by rate limit filter.
   RateLimited = 0x800,
-  // Request was unauthorized.
-  Unauthorized = 0x1000,
+  // Request was unauthorized by external authorization service.
+  UnauthorizedExternalService = 0x1000,
   // ATTENTION: MAKE SURE THIS REMAINS EQUAL TO THE LAST FLAG.
-  LastFlag = Unauthorized
+  LastFlag = UnauthorizedExternalService
 };
 
 /**

--- a/source/common/access_log/grpc_access_log_impl.cc
+++ b/source/common/access_log/grpc_access_log_impl.cc
@@ -120,6 +120,12 @@ void HttpGrpcAccessLog::responseFlagsToAccessLogResponseFlags(
   if (request_info.getResponseFlag(RequestInfo::ResponseFlag::RateLimited)) {
     common_access_log.mutable_response_flags()->set_rate_limited(true);
   }
+
+  if (request_info.getResponseFlag(RequestInfo::ResponseFlag::UnauthorizedExternalService)) {
+    common_access_log.mutable_response_flags()->mutable_unauthorized_details()->set_reason(
+        envoy::config::filter::accesslog::v2::ResponseFlags_Unauthorized_Reason::
+            ResponseFlags_Unauthorized_Reason_EXTERNAL_SERVICE);
+  }
 }
 
 void HttpGrpcAccessLog::log(const Http::HeaderMap* request_headers,

--- a/source/common/http/filter/ext_authz.cc
+++ b/source/common/http/filter/ext_authz.cc
@@ -111,7 +111,8 @@ void Filter::onComplete(Envoy::ExtAuthz::CheckStatus status) {
       (status == CheckStatus::Error && !config_->failureModeAllow())) {
     Http::HeaderMapPtr response_headers{new HeaderMapImpl(*getDeniedHeader())};
     callbacks_->encodeHeaders(std::move(response_headers), true);
-    callbacks_->requestInfo().setResponseFlag(Envoy::RequestInfo::ResponseFlag::Unauthorized);
+    callbacks_->requestInfo().setResponseFlag(
+        Envoy::RequestInfo::ResponseFlag::UnauthorizedExternalService);
   } else {
     // We can get completion inline, so only call continue if that isn't happening.
     if (!initiating_call_) {

--- a/source/common/request_info/utility.cc
+++ b/source/common/request_info/utility.cc
@@ -18,7 +18,7 @@ const std::string ResponseFlagUtils::NO_ROUTE_FOUND = "NR";
 const std::string ResponseFlagUtils::DELAY_INJECTED = "DI";
 const std::string ResponseFlagUtils::FAULT_INJECTED = "FI";
 const std::string ResponseFlagUtils::RATE_LIMITED = "RL";
-const std::string ResponseFlagUtils::UNAUTHORIZED = "UA";
+const std::string ResponseFlagUtils::UNAUTHORIZED_EXTERNAL_SERVICE = "UAEX";
 
 void ResponseFlagUtils::appendString(std::string& result, const std::string& append) {
   if (result.empty()) {
@@ -81,8 +81,8 @@ const std::string ResponseFlagUtils::toShortString(const RequestInfo& request_in
     appendString(result, RATE_LIMITED);
   }
 
-  if (request_info.getResponseFlag(ResponseFlag::Unauthorized)) {
-    appendString(result, UNAUTHORIZED);
+  if (request_info.getResponseFlag(ResponseFlag::UnauthorizedExternalService)) {
+    appendString(result, UNAUTHORIZED_EXTERNAL_SERVICE);
   }
 
   return result.empty() ? NONE : result;

--- a/source/common/request_info/utility.h
+++ b/source/common/request_info/utility.h
@@ -32,7 +32,7 @@ private:
   const static std::string DELAY_INJECTED;
   const static std::string FAULT_INJECTED;
   const static std::string RATE_LIMITED;
-  const static std::string UNAUTHORIZED;
+  const static std::string UNAUTHORIZED_EXTERNAL_SERVICE;
 };
 
 /**

--- a/test/common/access_log/grpc_access_log_impl_test.cc
+++ b/test/common/access_log/grpc_access_log_impl_test.cc
@@ -307,6 +307,9 @@ TEST(responseFlagsToAccessLogResponseFlagsTest, All) {
   common_access_log_expected.mutable_response_flags()->set_delay_injected(true);
   common_access_log_expected.mutable_response_flags()->set_fault_injected(true);
   common_access_log_expected.mutable_response_flags()->set_rate_limited(true);
+  common_access_log_expected.mutable_response_flags()->mutable_unauthorized_details()->set_reason(
+      envoy::config::filter::accesslog::v2::ResponseFlags_Unauthorized_Reason::
+          ResponseFlags_Unauthorized_Reason_EXTERNAL_SERVICE);
 
   EXPECT_EQ(common_access_log_expected.DebugString(), common_access_log.DebugString());
 }

--- a/test/common/http/filter/ext_authz_test.cc
+++ b/test/common/http/filter/ext_authz_test.cc
@@ -151,7 +151,7 @@ TEST_P(HttpExtAuthzFilterParamTest, OkResponse) {
 
   EXPECT_CALL(filter_callbacks_, continueDecoding());
   EXPECT_CALL(filter_callbacks_.request_info_,
-              setResponseFlag(Envoy::RequestInfo::ResponseFlag::Unauthorized))
+              setResponseFlag(Envoy::RequestInfo::ResponseFlag::UnauthorizedExternalService))
       .Times(0);
   request_callbacks_->onComplete(Envoy::ExtAuthz::CheckStatus::OK);
 
@@ -198,7 +198,7 @@ TEST_P(HttpExtAuthzFilterParamTest, DeniedResponse) {
   EXPECT_CALL(filter_callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
   EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
   EXPECT_CALL(filter_callbacks_.request_info_,
-              setResponseFlag(Envoy::RequestInfo::ResponseFlag::Unauthorized));
+              setResponseFlag(Envoy::RequestInfo::ResponseFlag::UnauthorizedExternalService));
   request_callbacks_->onComplete(Envoy::ExtAuthz::CheckStatus::Denied);
 
   EXPECT_EQ(

--- a/test/common/request_info/utility_test.cc
+++ b/test/common/request_info/utility_test.cc
@@ -29,7 +29,7 @@ TEST(ResponseFlagUtilsTest, toShortStringConversion) {
       std::make_pair(ResponseFlag::DelayInjected, "DI"),
       std::make_pair(ResponseFlag::FaultInjected, "FI"),
       std::make_pair(ResponseFlag::RateLimited, "RL"),
-      std::make_pair(ResponseFlag::Unauthorized, "UA"),
+      std::make_pair(ResponseFlag::UnauthorizedExternalService, "UAEX"),
   };
 
   for (const auto& test_case : expected) {


### PR DESCRIPTION
*title*: Add support for response flag unauthorized (by external service) in gRPC access log.
Adding support for gRPC access log support for response flag Unauthorized. 
Here we are adding support for https://github.com/envoyproxy/data-plane-api/pull/505

*Risk Level*: Low
Small optional feature.

*Testing*:
Added UT's.

*Docs Changes*: N/A

Signed-off-by: Saurabh Mohan <saurabh+github@tigera.io>
