### PR TITLE
stats: envoy prometheus endpoint fails promlint #2597

### DIFF
--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -249,10 +249,11 @@ public:
   /**
    * Extracts counters and gauges and relevant tags, appending them to
    * the response buffer after sanitizing the metric / label names.
+   * @return int64_t total number of metric types inserted in response.
    */
-  static void statsAsPrometheus(const std::list<Stats::CounterSharedPtr>& counters,
-                                const std::list<Stats::GaugeSharedPtr>& gauges,
-                                Buffer::Instance& response);
+  static uint64_t statsAsPrometheus(const std::list<Stats::CounterSharedPtr>& counters,
+                                    const std::list<Stats::GaugeSharedPtr>& gauges,
+                                    Buffer::Instance& response);
   /**
    * Format the given tags, returning a string as a comma-separated list
    * of <tag_name>="<tag_value>" pairs.

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -249,7 +249,7 @@ public:
   /**
    * Extracts counters and gauges and relevant tags, appending them to
    * the response buffer after sanitizing the metric / label names.
-   * @return int64_t total number of metric types inserted in response.
+   * @return uint64_t total number of metric types inserted in response.
    */
   static uint64_t statsAsPrometheus(const std::list<Stats::CounterSharedPtr>& counters,
                                     const std::list<Stats::GaugeSharedPtr>& gauges,

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -310,8 +310,8 @@ TEST(PrometheusStatsFormatter, MetricNameCollison) {
     Stats::Tag tag = {"a.tag-name", "a.tag-value"};
     cluster_tags.push_back(tag);
     Stats::RawStatData* data = alloc.alloc(name);
-    Stats::CounterSharedPtr c(
-        new Stats::CounterImpl(*data, alloc, std::string(name), std::move(cluster_tags)));
+    Stats::CounterSharedPtr c = std::make_shared<Stats::CounterImpl>(*data, alloc, std::move(name),
+                                                                     std::move(cluster_tags));
     counters.push_back(c);
   }
 
@@ -321,8 +321,8 @@ TEST(PrometheusStatsFormatter, MetricNameCollison) {
     Stats::Tag tag = {"another_tag_name", "another_tag-value"};
     cluster_tags.push_back(tag);
     Stats::RawStatData* data = alloc.alloc(name);
-    Stats::CounterSharedPtr c(
-        new Stats::CounterImpl(*data, alloc, std::string(name), std::move(cluster_tags)));
+    Stats::CounterSharedPtr c = std::make_shared<Stats::CounterImpl>(*data, alloc, std::move(name),
+                                                                     std::move(cluster_tags));
     counters.push_back(c);
   }
 
@@ -332,8 +332,8 @@ TEST(PrometheusStatsFormatter, MetricNameCollison) {
     Stats::Tag tag = {"another_tag_name_3", "another_tag_3-value"};
     cluster_tags.push_back(tag);
     Stats::RawStatData* data = alloc.alloc(name);
-    Stats::GaugeSharedPtr g(
-        new Stats::GaugeImpl(*data, alloc, std::string(name), std::move(cluster_tags)));
+    Stats::GaugeSharedPtr g =
+        std::make_shared<Stats::GaugeImpl>(*data, alloc, std::move(name), std::move(cluster_tags));
     gauges.push_back(g);
   }
 
@@ -343,8 +343,8 @@ TEST(PrometheusStatsFormatter, MetricNameCollison) {
     Stats::Tag tag = {"another_tag_name_4", "another_tag_4-value"};
     cluster_tags.push_back(tag);
     Stats::RawStatData* data = alloc.alloc(name);
-    Stats::GaugeSharedPtr g(
-        new Stats::GaugeImpl(*data, alloc, std::string(name), std::move(cluster_tags)));
+    Stats::GaugeSharedPtr g =
+        std::make_shared<Stats::GaugeImpl>(*data, alloc, std::move(name), std::move(cluster_tags));
     gauges.push_back(g);
   }
 
@@ -368,8 +368,8 @@ TEST(PrometheusStatsFormatter, UniqueMetricName) {
     Stats::Tag tag = {"a.tag-name", "a.tag-value"};
     cluster_tags.push_back(tag);
     Stats::RawStatData* data = alloc.alloc(name);
-    Stats::CounterSharedPtr c(
-        new Stats::CounterImpl(*data, alloc, std::string(name), std::move(cluster_tags)));
+    Stats::CounterSharedPtr c = std::make_shared<Stats::CounterImpl>(*data, alloc, std::move(name),
+                                                                     std::move(cluster_tags));
     counters.push_back(c);
   }
 
@@ -379,8 +379,8 @@ TEST(PrometheusStatsFormatter, UniqueMetricName) {
     Stats::Tag tag = {"another_tag_name", "another_tag-value"};
     cluster_tags.push_back(tag);
     Stats::RawStatData* data = alloc.alloc(name);
-    Stats::CounterSharedPtr c(
-        new Stats::CounterImpl(*data, alloc, std::string(name), std::move(cluster_tags)));
+    Stats::CounterSharedPtr c = std::make_shared<Stats::CounterImpl>(*data, alloc, std::move(name),
+                                                                     std::move(cluster_tags));
     counters.push_back(c);
   }
 
@@ -390,8 +390,8 @@ TEST(PrometheusStatsFormatter, UniqueMetricName) {
     Stats::Tag tag = {"another_tag_name_3", "another_tag_3-value"};
     cluster_tags.push_back(tag);
     Stats::RawStatData* data = alloc.alloc(name);
-    Stats::GaugeSharedPtr g(
-        new Stats::GaugeImpl(*data, alloc, std::string(name), std::move(cluster_tags)));
+    Stats::GaugeSharedPtr g =
+        std::make_shared<Stats::GaugeImpl>(*data, alloc, std::move(name), std::move(cluster_tags));
     gauges.push_back(g);
   }
 
@@ -401,8 +401,8 @@ TEST(PrometheusStatsFormatter, UniqueMetricName) {
     Stats::Tag tag = {"another_tag_name_4", "another_tag_4-value"};
     cluster_tags.push_back(tag);
     Stats::RawStatData* data = alloc.alloc(name);
-    Stats::GaugeSharedPtr g(
-        new Stats::GaugeImpl(*data, alloc, std::string(name), std::move(cluster_tags)));
+    Stats::GaugeSharedPtr g =
+        std::make_shared<Stats::GaugeImpl>(*data, alloc, std::move(name), std::move(cluster_tags));
     gauges.push_back(g);
   }
 

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -7,6 +7,7 @@
 #include "common/http/message_impl.h"
 #include "common/json/json_loader.h"
 #include "common/profiler/profiler.h"
+#include "common/stats/stats_impl.h"
 
 #include "server/http/admin.h"
 
@@ -291,6 +292,122 @@ TEST(PrometheusStatsFormatter, FormattedTags) {
   std::string expected = "a_tag_name=\"a.tag-value\",another_tag_name=\"another_tag-value\"";
   auto actual = PrometheusStatsFormatter::formattedTags(tags);
   EXPECT_EQ(expected, actual);
+}
+
+TEST(PrometheusStatsFormatter, MetricNameCollison) {
+
+  // Create two counters and two gauges with each pair having the same name,
+  // but having different tag names and values.
+  //`statsAsPrometheus()` should return two implying it found two unique stat names
+
+  Stats::HeapRawStatDataAllocator alloc;
+  std::list<Stats::CounterSharedPtr> counters;
+  std::list<Stats::GaugeSharedPtr> gauges;
+
+  {
+    std::string name = "cluster.test_cluster_1.upstream_cx_total";
+    std::vector<Stats::Tag> cluster_tags;
+    Stats::Tag tag = {"a.tag-name", "a.tag-value"};
+    cluster_tags.push_back(tag);
+    Stats::RawStatData* data = alloc.alloc(name);
+    Stats::CounterSharedPtr c(
+        new Stats::CounterImpl(*data, alloc, std::string(name), std::move(cluster_tags)));
+    counters.push_back(c);
+  }
+
+  {
+    std::string name = "cluster.test_cluster_1.upstream_cx_total";
+    std::vector<Stats::Tag> cluster_tags;
+    Stats::Tag tag = {"another_tag_name", "another_tag-value"};
+    cluster_tags.push_back(tag);
+    Stats::RawStatData* data = alloc.alloc(name);
+    Stats::CounterSharedPtr c(
+        new Stats::CounterImpl(*data, alloc, std::string(name), std::move(cluster_tags)));
+    counters.push_back(c);
+  }
+
+  {
+    std::vector<Stats::Tag> cluster_tags;
+    std::string name = "cluster.test_cluster_2.upstream_cx_total";
+    Stats::Tag tag = {"another_tag_name_3", "another_tag_3-value"};
+    cluster_tags.push_back(tag);
+    Stats::RawStatData* data = alloc.alloc(name);
+    Stats::GaugeSharedPtr g(
+        new Stats::GaugeImpl(*data, alloc, std::string(name), std::move(cluster_tags)));
+    gauges.push_back(g);
+  }
+
+  {
+    std::vector<Stats::Tag> cluster_tags;
+    std::string name = "cluster.test_cluster_2.upstream_cx_total";
+    Stats::Tag tag = {"another_tag_name_4", "another_tag_4-value"};
+    cluster_tags.push_back(tag);
+    Stats::RawStatData* data = alloc.alloc(name);
+    Stats::GaugeSharedPtr g(
+        new Stats::GaugeImpl(*data, alloc, std::string(name), std::move(cluster_tags)));
+    gauges.push_back(g);
+  }
+
+  Buffer::OwnedImpl response;
+  EXPECT_EQ(2UL, PrometheusStatsFormatter::statsAsPrometheus(counters, gauges, response));
+}
+
+TEST(PrometheusStatsFormatter, UniqueMetricName) {
+
+  // Create two counters and two gauges, all with unique names.
+  // statsAsPrometheus() should return four implying it found
+  // four unique stat names.
+
+  Stats::HeapRawStatDataAllocator alloc;
+  std::list<Stats::CounterSharedPtr> counters;
+  std::list<Stats::GaugeSharedPtr> gauges;
+
+  {
+    std::string name = "cluster.test_cluster_1.upstream_cx_total";
+    std::vector<Stats::Tag> cluster_tags;
+    Stats::Tag tag = {"a.tag-name", "a.tag-value"};
+    cluster_tags.push_back(tag);
+    Stats::RawStatData* data = alloc.alloc(name);
+    Stats::CounterSharedPtr c(
+        new Stats::CounterImpl(*data, alloc, std::string(name), std::move(cluster_tags)));
+    counters.push_back(c);
+  }
+
+  {
+    std::string name = "cluster.test_cluster_2.upstream_cx_total";
+    std::vector<Stats::Tag> cluster_tags;
+    Stats::Tag tag = {"another_tag_name", "another_tag-value"};
+    cluster_tags.push_back(tag);
+    Stats::RawStatData* data = alloc.alloc(name);
+    Stats::CounterSharedPtr c(
+        new Stats::CounterImpl(*data, alloc, std::string(name), std::move(cluster_tags)));
+    counters.push_back(c);
+  }
+
+  {
+    std::vector<Stats::Tag> cluster_tags;
+    std::string name = "cluster.test_cluster_3.upstream_cx_total";
+    Stats::Tag tag = {"another_tag_name_3", "another_tag_3-value"};
+    cluster_tags.push_back(tag);
+    Stats::RawStatData* data = alloc.alloc(name);
+    Stats::GaugeSharedPtr g(
+        new Stats::GaugeImpl(*data, alloc, std::string(name), std::move(cluster_tags)));
+    gauges.push_back(g);
+  }
+
+  {
+    std::vector<Stats::Tag> cluster_tags;
+    std::string name = "cluster.test_cluster_4.upstream_cx_total";
+    Stats::Tag tag = {"another_tag_name_4", "another_tag_4-value"};
+    cluster_tags.push_back(tag);
+    Stats::RawStatData* data = alloc.alloc(name);
+    Stats::GaugeSharedPtr g(
+        new Stats::GaugeImpl(*data, alloc, std::string(name), std::move(cluster_tags)));
+    gauges.push_back(g);
+  }
+
+  Buffer::OwnedImpl response;
+  EXPECT_EQ(4UL, PrometheusStatsFormatter::statsAsPrometheus(counters, gauges, response));
 }
 
 } // namespace Server


### PR DESCRIPTION
Description: Fixes #2597"

The admin endpoint of envoy when queried as a prometheus endpoint fails promlint.
Promlint is a sanity check tool offered by Prometheus to check the correctness
of a prometheus endpoint.

following issues were fixed
-fixed issue with metric type being printed twice
-added unit test as well

Risk Level: Low