### PR TITLE
router: Support range based header matching for request routing.

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -16,6 +16,8 @@ The following features have been DEPRECATED and will be removed in the specified
   `grpc_services` instead.
 * 'use_original_dst' field in the v2 LDS API is deprecated. Use listener filters and filter chain
   matching instead.
+* `value` and `regex` fields in the `HeaderMatcher` message is deprecated. Use the `exact_match`
+  or `regex_match` oneof instead.
 
 ## Version 1.5.0
 

--- a/RAW_RELEASE_NOTES.md
+++ b/RAW_RELEASE_NOTES.md
@@ -76,3 +76,4 @@ final version.
 * Added support for stripping query string for redirects.
 * Added support for specifying a metadata matcher for upstream clusters in the tcp filter
 * Added support for listening on UNIX domain sockets.
+* Added support for range based header matching for request routing.

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -79,6 +79,20 @@ bool StringUtil::atoul(const char* str, uint64_t& out, int base) {
   }
 }
 
+bool StringUtil::atol(const char* str, int64_t& out, int base) {
+  if (strlen(str) == 0) {
+    return false;
+  }
+
+  char* end_ptr;
+  out = strtol(str, &end_ptr, base);
+  if (*end_ptr != '\0' || ((out == LONG_MAX || out == LONG_MIN) && errno == ERANGE)) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
 absl::string_view StringUtil::ltrim(absl::string_view source) {
   const absl::string_view::size_type pos = source.find_first_not_of(WhitespaceChars);
   if (pos != absl::string_view::npos) {

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -71,6 +71,7 @@ bool StringUtil::atoul(const char* str, uint64_t& out, int base) {
   }
 
   char* end_ptr;
+  errno = 0;
   out = strtoul(str, &end_ptr, base);
   if (*end_ptr != '\0' || (out == ULONG_MAX && errno == ERANGE)) {
     return false;
@@ -85,6 +86,7 @@ bool StringUtil::atol(const char* str, int64_t& out, int base) {
   }
 
   char* end_ptr;
+  errno = 0;
   out = strtol(str, &end_ptr, base);
   if (*end_ptr != '\0' || ((out == LONG_MAX || out == LONG_MIN) && errno == ERANGE)) {
     return false;

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -123,6 +123,12 @@ public:
   static bool atoul(const char* str, uint64_t& out, int base = 10);
 
   /**
+   * Convert a string to a long, checking for error.
+   * @param return TRUE if successful, FALSE otherwise.
+   */
+  static bool atol(const char* str, int64_t& out, int base = 10);
+
+  /**
    * Perform a case insensitive compare of 2 strings.
    * @param lhs supplies string 1.
    * @param rhs supplies string 2.

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -118,13 +118,13 @@ public:
 
   /**
    * Convert a string to an unsigned long, checking for error.
-   * @param return TRUE if successful, FALSE otherwise.
+   * @param return true if successful, false otherwise.
    */
   static bool atoul(const char* str, uint64_t& out, int base = 10);
 
   /**
    * Convert a string to a long, checking for error.
-   * @param return TRUE if successful, FALSE otherwise.
+   * @param return true if successful, false otherwise.
    */
   static bool atol(const char* str, int64_t& out, int base = 10);
 

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -795,7 +795,14 @@ const std::string Json::Schema::HEADER_DATA_CONFIGURATION_SCHEMA(R"EOF(
     "properties" : {
       "name" : {"type" : "string"},
       "value" : {"type" : "string"},
-      "regex" : {"type" : "boolean"}
+      "regex" : {"type" : "boolean"},
+      "range_match" : {
+        "type" : "object",
+        "properties" : {
+          "start" : {"type" : "integer"},
+          "end" : {"type" : "integer"}
+        }
+      }
     },
     "required" : ["name"],
     "additionalProperties" : false

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -10,6 +10,55 @@
 namespace Envoy {
 namespace Router {
 
+// HeaderMatcher will consist of one of the below two options:
+// 1.value (string) and regex (bool)
+//   An empty header value allows for matching to be only based on header presence.
+//   Regex is an opt-in. Unless explicitly mentioned, the header values will be used for
+//   exact string matching.
+//   This is now deprecated.
+// 2.header_match_specifier which can be any one of exact_match, regex_match or range_match.
+//   Absence of these options implies empty header value match based on header presence.
+//   a.exact_match: value will be used for exact string matching.
+//   b.regex_match: Match will succeed if header value matches the value specified here.
+//   c.range_match: Match will succeed if header value lies within the range specified
+//     here, using half open interval semantics [start,end).
+ConfigUtility::HeaderData::HeaderData(const envoy::api::v2::route::HeaderMatcher& config)
+    : name_(config.name()) {
+  switch (config.header_match_specifier_case()) {
+  case envoy::api::v2::route::HeaderMatcher::kExactMatch:
+    header_match_type_ = HeaderMatchType::Value;
+    value_ = config.exact_match();
+    break;
+  case envoy::api::v2::route::HeaderMatcher::kRegexMatch:
+    header_match_type_ = HeaderMatchType::Regex;
+    regex_pattern_ = RegexUtil::parseRegex(config.regex_match());
+    break;
+  case envoy::api::v2::route::HeaderMatcher::kRangeMatch:
+    header_match_type_ = HeaderMatchType::Range;
+    range_.set_start(config.range_match().start());
+    range_.set_end(config.range_match().end());
+    break;
+  case envoy::api::v2::route::HeaderMatcher::HEADER_MATCH_SPECIFIER_NOT_SET:
+    FALLTHRU;
+  default:
+    if (PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, regex, false)) {
+      header_match_type_ = HeaderMatchType::Regex;
+      regex_pattern_ = RegexUtil::parseRegex(config.value());
+    } else {
+      header_match_type_ = HeaderMatchType::Value;
+      value_ = config.value();
+    }
+    break;
+  }
+}
+
+ConfigUtility::HeaderData::HeaderData(const Json::Object& config)
+    : HeaderData([&config] {
+        envoy::api::v2::route::HeaderMatcher header_matcher;
+        Envoy::Config::RdsJson::translateHeaderMatcher(config, header_matcher);
+        return header_matcher;
+      }()) {}
+
 bool ConfigUtility::QueryParameterMatcher::matches(
     const Http::Utility::QueryParams& request_query_params) const {
   auto query_param = request_query_params.find(name_);

--- a/source/common/router/config_utility.h
+++ b/source/common/router/config_utility.h
@@ -30,18 +30,18 @@ public:
   enum class HeaderMatchType { Value, Regex, Range };
 
   struct HeaderData {
-    // HeaderMatcher will consist of one of the below two options :
-    // 1) value (string) and regex (bool)
-    // An empty header value allows for matching to be only based on header presence.
-    // Regex is an opt-in. Unless explicitly mentioned, the header values will be used for
-    // exact string matching.
-    // This is now deprecated.
-    // 2) header_match_specifier which can be any one of exact_match, regex_match or range_match.
-    // Absence of these options implies empty header value  => match based on header presence.
-    // exact_match value will be used for exact string matching.
-    // regex_match : Match will succeed if header value matches the value specified in regex_match.
-    // range_match : Match will succeed if header value lies within the range specified in this
-    // field, using half open interval semantics [start,end)
+    // HeaderMatcher will consist of one of the below two options:
+    // 1.value (string) and regex (bool)
+    //   An empty header value allows for matching to be only based on header presence.
+    //   Regex is an opt-in. Unless explicitly mentioned, the header values will be used for
+    //   exact string matching.
+    //   This is now deprecated.
+    // 2.header_match_specifier which can be any one of exact_match, regex_match or range_match.
+    //   Absence of these options implies empty header value match based on header presence.
+    //   a.exact_match: value will be used for exact string matching.
+    //   b.regex_match: Match will succeed if header value matches the value specified here.
+    //   c.range_match: Match will succeed if header value lies within the range specified
+    //     here, using half open interval semantics [start,end).
     HeaderData(const envoy::api::v2::route::HeaderMatcher& config) : name_(config.name()) {
       switch (config.header_match_specifier_case()) {
       case envoy::api::v2::route::HeaderMatcher::kExactMatch:
@@ -58,6 +58,7 @@ public:
         range_.set_end(config.range_match().end());
         break;
       case envoy::api::v2::route::HeaderMatcher::HEADER_MATCH_SPECIFIER_NOT_SET:
+        FALLTHRU;
       default:
         if (PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, regex, false)) {
           header_match_type_ = HeaderMatchType::Regex;

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -33,6 +33,12 @@ TEST(StringUtil, atoul) {
 
   EXPECT_TRUE(StringUtil::atoul("00789", out));
   EXPECT_EQ(789U, out);
+
+  // Verify subsequent call to atoul succeeds after the first one
+  // failed due to errno ERANGE
+  EXPECT_FALSE(StringUtil::atoul("18446744073709551616", out));
+  EXPECT_TRUE(StringUtil::atoul("18446744073709551615", out));
+  EXPECT_EQ(18446744073709551615U, out);
 }
 
 TEST(StringUtil, atol) {

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -59,7 +59,7 @@ TEST(StringUtil, atol) {
 
   // INT64_MIN
   EXPECT_TRUE(StringUtil::atol("-9223372036854775808", out));
-  EXPECT_EQ(-9223372036854775808, out);
+  EXPECT_EQ(INT64_MIN, out);
 }
 
 TEST(DateUtil, All) {

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -35,6 +35,33 @@ TEST(StringUtil, atoul) {
   EXPECT_EQ(789U, out);
 }
 
+TEST(StringUtil, atol) {
+  int64_t out;
+  EXPECT_FALSE(StringUtil::atol("-123b", out));
+  EXPECT_FALSE(StringUtil::atol("", out));
+  EXPECT_FALSE(StringUtil::atol("b123", out));
+
+  EXPECT_TRUE(StringUtil::atol("123", out));
+  EXPECT_EQ(123, out);
+  EXPECT_TRUE(StringUtil::atol("-123", out));
+  EXPECT_EQ(-123, out);
+  EXPECT_TRUE(StringUtil::atol("+123", out));
+  EXPECT_EQ(123, out);
+
+  EXPECT_TRUE(StringUtil::atol("  456", out));
+  EXPECT_EQ(456, out);
+
+  EXPECT_TRUE(StringUtil::atol("00789", out));
+  EXPECT_EQ(789, out);
+
+  // INT64_MAX + 1
+  EXPECT_FALSE(StringUtil::atol("9223372036854775808", out));
+
+  // INT64_MIN
+  EXPECT_TRUE(StringUtil::atol("-9223372036854775808", out));
+  EXPECT_EQ(-9223372036854775808, out);
+}
+
 TEST(DateUtil, All) {
   EXPECT_FALSE(DateUtil::timePointValid(SystemTime()));
   EXPECT_TRUE(DateUtil::timePointValid(std::chrono::system_clock::now()));

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4014,8 +4014,8 @@ virtual_hosts:
           headers:
             - name: test_header_range
               range_match:
-                 start: 1
-                 end: 10
+                 start: -9223372036854775808
+                 end: -10
         route:
           cluster: local_service_with_header_range_test1
       - match:
@@ -4034,10 +4034,26 @@ virtual_hosts:
           headers:
             - name: test_header_range
               range_match:
-                 start: -9223372036854775808
-                 end: -10
+                 start: 1
+                 end: 10
         route:
           cluster: local_service_with_header_range_test3
+      - match:
+          prefix: "/"
+          headers:
+            - name: test_header_range
+              range_match:
+                 start: 9223372036854775801
+                 end: 9223372036854775807
+        route:
+          cluster: local_service_with_header_range_test4
+      - match:
+          prefix: "/"
+          headers:
+            - name: test_header_range
+              exact_match: "9223372036854775807"
+        route:
+          cluster: local_service_with_header_range_test5
       - match:
           prefix: "/"
         route:
@@ -4090,7 +4106,7 @@ virtual_hosts:
   }
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
-    headers.addCopy("test_header_range", "9");
+    headers.addCopy("test_header_range", "-9223372036854775808");
     EXPECT_EQ("local_service_with_header_range_test1",
               config.route(headers, 0)->routeEntry()->clusterName());
   }
@@ -4103,6 +4119,18 @@ virtual_hosts:
   }
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+    headers.addCopy("test_header_range", "9");
+    EXPECT_EQ("local_service_with_header_range_test3",
+              config.route(headers, 0)->routeEntry()->clusterName());
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+    headers.addCopy("test_header_range", "9223372036854775807");
+    EXPECT_EQ("local_service_with_header_range_test5",
+              config.route(headers, 0)->routeEntry()->clusterName());
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
     headers.addCopy("test_header_multiple_range", "-9");
     EXPECT_EQ("local_service_without_headers",
               config.route(headers, 0)->routeEntry()->clusterName());
@@ -4111,12 +4139,6 @@ virtual_hosts:
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
     headers.addCopy("test_header_range", "19");
     EXPECT_EQ("local_service_without_headers",
-              config.route(headers, 0)->routeEntry()->clusterName());
-  }
-  {
-    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
-    headers.addCopy("test_header_range", "-9223372036854775808");
-    EXPECT_EQ("local_service_with_header_range_test3",
               config.route(headers, 0)->routeEntry()->clusterName());
   }
 }

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -975,6 +975,13 @@ TEST(RouteMatcherTest, HeaderMatchedRouting) {
         },
         {
           "prefix": "/",
+          "cluster": "local_service_with_header_range",
+          "headers" : [
+            {"name": "test_header_range", "range_match": {"start" : 1, "end" : 10}}
+          ]
+        },
+        {
+          "prefix": "/",
           "cluster": "local_service_without_headers"
         }
       ]
@@ -1030,6 +1037,20 @@ TEST(RouteMatcherTest, HeaderMatchedRouting) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
     headers.addCopy("test_header_pattern", "customer=test-1223");
+    EXPECT_EQ("local_service_without_headers",
+              config.route(headers, 0)->routeEntry()->clusterName());
+  }
+
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+    headers.addCopy("test_header_range", "9");
+    EXPECT_EQ("local_service_with_header_range",
+              config.route(headers, 0)->routeEntry()->clusterName());
+  }
+
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+    headers.addCopy("test_header_range", "19");
     EXPECT_EQ("local_service_without_headers",
               config.route(headers, 0)->routeEntry()->clusterName());
   }
@@ -3945,6 +3966,160 @@ virtual_hosts:
   }
 }
 
+TEST(RouteMatcherTest, HeaderMatchedRoutingV2) {
+  std::string yaml = R"EOF(
+name: foo
+virtual_hosts:
+  - name: local_service
+    domains: ["*"]
+    routes:
+      - match:
+          prefix: "/"
+          headers:
+            - name: test_header
+              exact_match: test
+        route:
+          cluster: local_service_with_headers
+      - match:
+          prefix: "/"
+          headers:
+            - name: test_header_multiple1
+              exact_match: test1
+            - name: test_header_multiple2
+              exact_match: test2
+        route:
+          cluster: local_service_with_multiple_headers
+      - match:
+          prefix: "/"
+          headers:
+            - name: test_header_presence
+        route:
+          cluster: local_service_with_empty_headers
+      - match:
+          prefix: "/"
+          headers:
+            - name: test_header_pattern
+              regex_match: "^user=test-\\d+$"
+        route:
+          cluster: local_service_with_header_pattern_set_regex
+      - match:
+          prefix: "/"
+          headers:
+            - name: test_header_pattern
+              exact_match: "^customer=test-\\d+$"
+        route:
+          cluster: local_service_with_header_pattern_unset_regex
+      - match:
+          prefix: "/"
+          headers:
+            - name: test_header_range
+              range_match:
+                 start: 1
+                 end: 10
+        route:
+          cluster: local_service_with_header_range_test1
+      - match:
+          prefix: "/"
+          headers:
+            - name: test_header_multiple_range
+              range_match:
+                 start: -10
+                 end: 1
+            - name: test_header_multiple_exact
+              exact_match: test
+        route:
+          cluster: local_service_with_header_range_test2
+      - match:
+          prefix: "/"
+          headers:
+            - name: test_header_range
+              range_match:
+                 start: -9223372036854775808
+                 end: -10
+        route:
+          cluster: local_service_with_header_range_test3
+      - match:
+          prefix: "/"
+        route:
+          cluster: local_service_without_headers
+  )EOF";
+
+  NiceMock<Runtime::MockLoader> runtime;
+  NiceMock<Upstream::MockClusterManager> cm;
+  ConfigImpl config(parseRouteConfigurationFromV2Yaml(yaml), runtime, cm, true);
+
+  {
+    EXPECT_EQ("local_service_without_headers",
+              config.route(genHeaders("www.lyft.com", "/", "GET"), 0)->routeEntry()->clusterName());
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+    headers.addCopy("test_header", "test");
+    EXPECT_EQ("local_service_with_headers", config.route(headers, 0)->routeEntry()->clusterName());
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+    headers.addCopy("test_header_multiple1", "test1");
+    headers.addCopy("test_header_multiple2", "test2");
+    EXPECT_EQ("local_service_with_multiple_headers",
+              config.route(headers, 0)->routeEntry()->clusterName());
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+    headers.addCopy("non_existent_header", "foo");
+    EXPECT_EQ("local_service_without_headers",
+              config.route(headers, 0)->routeEntry()->clusterName());
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+    headers.addCopy("test_header_presence", "test");
+    EXPECT_EQ("local_service_with_empty_headers",
+              config.route(headers, 0)->routeEntry()->clusterName());
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+    headers.addCopy("test_header_pattern", "user=test-1223");
+    EXPECT_EQ("local_service_with_header_pattern_set_regex",
+              config.route(headers, 0)->routeEntry()->clusterName());
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+    headers.addCopy("test_header_pattern", "customer=test-1223");
+    EXPECT_EQ("local_service_without_headers",
+              config.route(headers, 0)->routeEntry()->clusterName());
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+    headers.addCopy("test_header_range", "9");
+    EXPECT_EQ("local_service_with_header_range_test1",
+              config.route(headers, 0)->routeEntry()->clusterName());
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+    headers.addCopy("test_header_multiple_range", "-9");
+    headers.addCopy("test_header_multiple_exact", "test");
+    EXPECT_EQ("local_service_with_header_range_test2",
+              config.route(headers, 0)->routeEntry()->clusterName());
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+    headers.addCopy("test_header_multiple_range", "-9");
+    EXPECT_EQ("local_service_without_headers",
+              config.route(headers, 0)->routeEntry()->clusterName());
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+    headers.addCopy("test_header_range", "19");
+    EXPECT_EQ("local_service_without_headers",
+              config.route(headers, 0)->routeEntry()->clusterName());
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/", "GET");
+    headers.addCopy("test_header_range", "-9223372036854775808");
+    EXPECT_EQ("local_service_with_header_range_test3",
+              config.route(headers, 0)->routeEntry()->clusterName());
+  }
+}
 } // namespace
 } // namespace Router
 } // namespace Envoy


### PR DESCRIPTION

 *title*: *router: Support range based header matching for request routing.*

*Description*:
Add range support for route match. Match will succeed if the header value lies in the specified range, following the half open interval semantics [start,end). This implements the new header match specifier oneof added in HeaderMatcher.
 This only applies to integer header values.

 v1 config: If range_match JSON object is present in the route config, perform range check.
 v2 config: Route match is performed based on the oneof specifier in HeaderMatcher: exact_match or regex_match or range_match.
 If none of these match specifiers are present, matching will be based on header presence.
 HeaderMatcher value and regex fields will be deprecated.

*Risk Level*: Low

*Testing*:
 Testcase RouteMatcherTest::HeaderMatchedRouting tests range_match config specified with existing config options like value and regex.
 HeaderMatchedRoutingV2 testcase tests the route matching with the new header match specifier (oneof) options: exact_match, regex_match, range_match.

*Docs Changes*:
[Data Plane PR](https://github.com/envoyproxy/data-plane-api/pull/475)]

*Release Notes*: done.

[Optional *Deprecated*:] 
>HeaderMatcher value and regex fields are deprecated.
