### PR TITLE
stats: Configure default max_obj_name_length at compile time

### DIFF
--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -23,6 +23,15 @@
 
 #include "absl/strings/string_view.h"
 
+// Can be overridden at compile time
+#ifndef ENVOY_DEFAULT_MAX_OBJ_NAME_LENGTH
+#define ENVOY_DEFAULT_MAX_OBJ_NAME_LENGTH 60
+#endif
+
+#if ENVOY_DEFAULT_MAX_OBJ_NAME_LENGTH < 60
+#error "ENVOY_DEFAULT_MAX_OBJ_NAME_LENGTH must be >= 60"
+#endif
+
 namespace Envoy {
 namespace Stats {
 
@@ -265,7 +274,7 @@ private:
   // If you want to increase the max user supplied name length, use the compiler
   // option ENVOY_DEFAULT_MAX_OBJ_NAME_LENGTH or the CLI option
   // max-obj-name-len
-  static const size_t DEFAULT_MAX_OBJ_NAME_LENGTH = 60;
+  static const size_t DEFAULT_MAX_OBJ_NAME_LENGTH = ENVOY_DEFAULT_MAX_OBJ_NAME_LENGTH;
   static const size_t MAX_STAT_SUFFIX_LENGTH = 67;
 
   static size_t& initializeAndGetMutableMaxObjNameLength(size_t configured_size);

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -18,17 +18,6 @@
 #define ENVOY_DEFAULT_MAX_STATS 16384
 #endif
 
-// Can be overridden at compile time
-// See comment in common/stat/stat_impl.h for rationale behind
-// this constant.
-#ifndef ENVOY_DEFAULT_MAX_OBJ_NAME_LENGTH
-#define ENVOY_DEFAULT_MAX_OBJ_NAME_LENGTH 60
-#endif
-
-#if ENVOY_DEFAULT_MAX_OBJ_NAME_LENGTH < 60
-#error "ENVOY_DEFAULT_MAX_OBJ_NAME_LENGTH must be >= 60"
-#endif
-
 namespace Envoy {
 OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_restart_version_cb,
                          spdlog::level::level_enum default_log_level) {


### PR DESCRIPTION
stats: Configure default max_obj_name_length at compile time

DEFAULT_MAX_OBJ_NAME_LENGTH was still hard-coded to 60.
Set it to ENVOY_DEFAULT_MAX_OBJ_NAME_LENGTH to make it configurable
at compile time.

Signed-off-by: Romain Lenglet <romain@covalent.io>
Risk Level: Low