### PR TITLE
Docs: Add basic UDP roadmap

### DIFF
--- a/docs/udp-proposal.md
+++ b/docs/udp-proposal.md
@@ -1,0 +1,16 @@
+# UDP Roadmap
+
+## General
+
+[Main Github Issue](https://github.com/envoyproxy/envoy/issues/492)
+[Detailed Design Doc](https://docs.google.com/document/d/1G9IVq7F7Onwinsl6EYzGsdzAGvVbo2FGfcPt35ItIx8)
+
+## Roadmap
+
+- [ ] General API refactoring (Ex. less file-descriptor hardcoding)
+- [ ] UDP listener
+- [ ] UDP "session manager"
+- [ ] Basic UDP proxying sessions (proxy -> host)
+- [ ] Advanced UDP proxying features (timeouts, filters, etc.)
+- [ ] Network filters (need a use-case)
+- [ ] Clear documentation with configuration and developer walkthroughs of UDP features


### PR DESCRIPTION
*title*: docs: add basic UDP roadmap

*Description*:
This is a basic set of steps that Alyssa helped me summarize for how we should tackle UDP support. The bulk of the discussion remains in the Google doc to allow for continual comments.

*Risk Level*: Low: doc proposal

*Testing*:
N/A , documentation only

*Docs Changes*:
N/A

*Release Notes*:
N/A

Related #492