### PR TITLE
bazel: better support for temporarily using a local dependency repository

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -22,7 +22,10 @@ As a developer convenience, a [WORKSPACE](https://github.com/envoyproxy/envoy/bl
 version](https://github.com/envoyproxy/envoy/blob/master/bazel/repositories.bzl) of the various Envoy
 dependencies are provided. These are provided as is, they are only suitable for development and
 testing purposes. The specific versions of the Envoy dependencies used in this build may not be
-up-to-date with the latest security patches.
+up-to-date with the latest security patches. You may override the location and/or version of a dependency
+by modifying the corresponding entry in
+[the repository locations file](https://github.com/envoyproxy/envoy/blob/master/bazel/repository_locations.bzl).
+Overrides can be local or remote. See that file for details.
 
 1. Install the latest version of [Bazel](https://bazel.build/versions/master/docs/install.html) in your environment.
 2. Install external dependencies libtool, cmake, and realpath libraries separately.

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -12,7 +12,9 @@ def _repository_impl(name, **kwargs):
     # `existing_rule_keys` contains the names of repositories that have already
     # been defined in the Bazel workspace. By skipping repos with existing keys,
     # users can override dependency versions by using standard Bazel repository
-    # rules in their WORKSPACE files.
+    # rules in their WORKSPACE files. Giving a `local_path` in
+    # `repository_locations.bzl` is the easiest way to override a dependency with
+    # a local checkout.
     existing_rule_keys = native.existing_rules().keys()
     if name in existing_rule_keys:
         # This repository has already been defined, probably because the user
@@ -28,7 +30,29 @@ def _repository_impl(name, **kwargs):
             "Refusing to depend on Git tag %r for external dependency %r: use 'commit' instead."
             % (location["tag"], name))
 
-    if "commit" in location:
+    if "local_path" in location:
+        # local_repository() does not use any parameter besides local_path.
+        # If any are present, warn that they're ignored.
+        if len(location) > 1:
+            other_keys = []
+            for k in location:
+                if k != "local_path":
+                    other_keys.append(k)
+
+            print(("Warning: overriding external dependency %r with repository at local path %r. " +
+                  "The following location specifiers will be ignored: %r") % \
+                  (name, location["local_path"], other_keys))
+
+        # Local repository at given path. Add a BUILD file if requested.
+        if "build_file" in kwargs:
+            native.new_local_repository(
+                name = name,
+                path = location["local_path"])
+        else:
+            native.local_repository(
+                name = name,
+                path = location["local_path"])
+    elif "commit" in location:
         # Git repository at given commit ID. Add a BUILD file if requested.
         if "build_file" in kwargs:
             new_git_repository(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,3 +1,7 @@
+# Use a "local_path" key to build against a local checkout of a repository.
+# The path must be absolute. Other keys are ignored when using a local repository.
+# The current working tree at the given path will be used.
+# DO NOT PUSH a "local_path" override upstream.
 REPOSITORY_LOCATIONS = dict(
     boringssl = dict(
         # Use commits from branch "chromium-stable-with-bazel"

--- a/support/hooks/pre-push
+++ b/support/hooks/pre-push
@@ -47,6 +47,16 @@ do
       exit 1
     fi
 
+    # Check if any commits look like they (likely accidentally) included a
+    # local repository entry in repository_locations.bzl
+    LOCAL_PATH_DEPS=$(git log -p --pickaxe-regex -S "local_path" "$RANGE" -- "bazel/repository_locations.bzl")
+    if [ -n "$LOCAL_PATH_DEPS" ]
+    then
+      echo >&2 "ERROR: The following commit(s) added local dependencies to bazel/repository_locations.bzl"
+      echo >&2 "$LOCAL_PATH_DEPS"
+      exit 1
+    fi
+
     # NOTE: The `tools` directory will be the same relative to the support
     # directory, independent of whether we're in a submodule, so no need to use
     # our `relpath` helper.


### PR DESCRIPTION
*Description*:
I was working with envoy in #2771 and simultaneously with data-plane-api in [this PR](https://github.com/envoyproxy/data-plane-api/pull/532). I didn't want to have to push a new branch to dpapi (sorry, my fingers will eventually fall off from typing that out) and then point bazel at it every time I made a change just to build envoy.

Local repos are supported-ish with the current `git_repository()` rules but bazel does have a `local_repository()` rule for this purpose. This PR adds support for it. Now, as documented, you can stick a `local_path` w/ absolute path in the dep and you'll build against it.

`local_path` is the *only* parameter for `local_repository()`, you can't point at a specific commit or branch; it just uses whatever is currently checked out. I thought this was surprising enough to put a warning in when you mix `local_path` and other parameters.

I tried (like, tried hard) to make local overrides live in a separate gitignored file. Unfortunately, Bazel's load stage is so totally hermetic that I just couldn't make it depend on an untracked file that might not exist. It was sad. Instead, I added a pre-push hook to catch people accidentally committing and pushing local deps. 

Here is an example of the hook output when it doesn't pass:
https://gist.github.com/jsedgwick/19797d74d2a19201faf909127132f5d4

p.s. I learned a little about git's "pickaxe" feature for the hook. It's pretty sweet and you could definitely do some crazy, well, digging if you knew how to use it, which I don't yet. Take a look.

*Risk Level*: Low. Build system stuff. Main risk is that it's easier to push your temporary local pointer, but there's a pre-push hook to try and prevent that. Hook can be bypassed w/ `--no-verify` if necessary.

*Testing*:
I put this together while working on dependent branches in data-plane-api and envoy, and it works. Adding, removing, or changing the path triggers an envoy rebuild. Changing the contents of the local repo triggers an envoy rebuild. All in all, iterative development works.

I manually tested the hook with various scenarios (push w/ no offending commit, push w/ offending commit, etc) and it works as expected. 

*Docs Changes*:
In code, N/A

*Release Notes*:
N/A