### PR TITLE
tracing: Delegate envoy tracing decision to tracer to determine if should override sampling

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -39,7 +39,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/grpc/grpc.git",
     ),
     io_opentracing_cpp = dict(
-        commit = "f3c1f42601d13504c68e2bc81c60604f0de055dd",
+        commit = "b40d8817d309f5bb434eda804a841cecf4a396c2",
         remote = "https://github.com/opentracing/opentracing-cpp",
     ),
     com_lightstep_tracer_cpp = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -39,7 +39,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/grpc/grpc.git",
     ),
     io_opentracing_cpp = dict(
-        commit = "b40d8817d309f5bb434eda804a841cecf4a396c2",
+        commit = "f6be24043e00baa2a25e0c1bb8793433d44ecc8b",
         remote = "https://github.com/opentracing/opentracing-cpp",
     ),
     com_lightstep_tracer_cpp = dict(

--- a/include/envoy/tracing/http_tracer.h
+++ b/include/envoy/tracing/http_tracer.h
@@ -13,17 +13,28 @@ namespace Tracing {
 
 enum class OperationName { Ingress, Egress };
 
+/**
+ * The reasons why trace sampling may or may not be performed.
+ */
 enum class Reason {
+  // Not sampled based on supplied request id.
   NotTraceableRequestId,
+  // Not sampled due to being a health check.
   HealthCheck,
+  // Sampling enabled.
   Sampling,
+  // Sampling forced by the service.
   ServiceForced,
+  // Sampling forced by the client.
   ClientForced,
 };
 
+/**
+ * The decision regarding whether traces should be sampled, and the reason for it.
+ */
 struct Decision {
   Reason reason;
-  bool is_tracing;
+  bool traced;
 };
 
 /**
@@ -102,7 +113,7 @@ public:
    */
   virtual SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
                             const std::string& operation_name, SystemTime start_time,
-                            const Tracing::Decision& tracing_decision) PURE;
+                            const Tracing::Decision tracing_decision) PURE;
 };
 
 typedef std::unique_ptr<Driver> DriverPtr;
@@ -117,7 +128,7 @@ public:
 
   virtual SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
                             const RequestInfo::RequestInfo& request_info,
-                            const Tracing::Decision& tracing_decision) PURE;
+                            const Tracing::Decision tracing_decision) PURE;
 };
 
 typedef std::unique_ptr<HttpTracer> HttpTracerPtr;

--- a/include/envoy/tracing/http_tracer.h
+++ b/include/envoy/tracing/http_tracer.h
@@ -13,6 +13,19 @@ namespace Tracing {
 
 enum class OperationName { Ingress, Egress };
 
+enum class Reason {
+  NotTraceableRequestId,
+  HealthCheck,
+  Sampling,
+  ServiceForced,
+  ClientForced,
+};
+
+struct Decision {
+  Reason reason;
+  bool is_tracing;
+};
+
 /**
  * Tracing configuration, it carries additional data needed to populate the span.
  */
@@ -88,7 +101,8 @@ public:
    * Start driver specific span.
    */
   virtual SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
-                            const std::string& operation_name, SystemTime start_time) PURE;
+                            const std::string& operation_name, SystemTime start_time,
+                            const Tracing::Decision& tracing_decision) PURE;
 };
 
 typedef std::unique_ptr<Driver> DriverPtr;
@@ -102,7 +116,8 @@ public:
   virtual ~HttpTracer() {}
 
   virtual SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
-                            const RequestInfo::RequestInfo& request_info) PURE;
+                            const RequestInfo::RequestInfo& request_info,
+                            const Tracing::Decision& tracing_decision) PURE;
 };
 
 typedef std::unique_ptr<HttpTracer> HttpTracerPtr;

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -74,7 +74,7 @@ bool TraceableRequestFilter::evaluate(const RequestInfo::RequestInfo& info,
                                       const Http::HeaderMap& request_headers) {
   Tracing::Decision decision = Tracing::HttpTracerUtility::isTracing(info, request_headers);
 
-  return decision.is_tracing && decision.reason == Tracing::Reason::ServiceForced;
+  return decision.traced && decision.reason == Tracing::Reason::ServiceForced;
 }
 
 bool StatusCodeFilter::evaluate(const RequestInfo::RequestInfo& info, const Http::HeaderMap&) {

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -607,11 +607,12 @@ void ConnectionManagerImpl::ActiveStream::traceRequest() {
   ConnectionManagerImpl::chargeTracingStats(tracing_decision.reason,
                                             connection_manager_.config_.tracingStats());
 
-  if (!tracing_decision.is_tracing) {
+  active_span_ = connection_manager_.tracer_.startSpan(*this, *request_headers_, request_info_,
+                                                       tracing_decision);
+
+  if (!active_span_) {
     return;
   }
-
-  active_span_ = connection_manager_.tracer_.startSpan(*this, *request_headers_, request_info_);
 
   // TODO: Need to investigate the following code based on the cached route, as may
   // be broken in the case a filter changes the route.

--- a/source/common/tracing/dynamic_opentracing_driver_impl.h
+++ b/source/common/tracing/dynamic_opentracing_driver_impl.h
@@ -32,6 +32,9 @@ public:
     return OpenTracingDriver::PropagationMode::TracerNative;
   }
 
+protected:
+  bool useTagForSamplingDecision() override { return true; }
+
 private:
   opentracing::DynamicTracingLibraryHandle library_handle_;
   std::shared_ptr<opentracing::Tracer> tracer_;

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -168,7 +168,8 @@ HttpTracerImpl::HttpTracerImpl(DriverPtr&& driver, const LocalInfo::LocalInfo& l
     : driver_(std::move(driver)), local_info_(local_info) {}
 
 SpanPtr HttpTracerImpl::startSpan(const Config& config, Http::HeaderMap& request_headers,
-                                  const RequestInfo::RequestInfo& request_info) {
+                                  const RequestInfo::RequestInfo& request_info,
+                                  const Tracing::Decision& tracing_decision) {
   std::string span_name = HttpTracerUtility::toString(config.operationName());
 
   if (config.operationName() == OperationName::Egress) {
@@ -176,8 +177,8 @@ SpanPtr HttpTracerImpl::startSpan(const Config& config, Http::HeaderMap& request
     span_name.append(request_headers.Host()->value().c_str());
   }
 
-  SpanPtr active_span =
-      driver_->startSpan(config, request_headers, span_name, request_info.startTime());
+  SpanPtr active_span = driver_->startSpan(config, request_headers, span_name,
+                                           request_info.startTime(), tracing_decision);
   if (active_span) {
     active_span->setTag(Tracing::Tags::get().COMPONENT, Tracing::Tags::get().PROXY);
     active_span->setTag(Tracing::Tags::get().NODE_ID, local_info_.nodeName());

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -169,7 +169,7 @@ HttpTracerImpl::HttpTracerImpl(DriverPtr&& driver, const LocalInfo::LocalInfo& l
 
 SpanPtr HttpTracerImpl::startSpan(const Config& config, Http::HeaderMap& request_headers,
                                   const RequestInfo::RequestInfo& request_info,
-                                  const Tracing::Decision& tracing_decision) {
+                                  const Tracing::Decision tracing_decision) {
   std::string span_name = HttpTracerUtility::toString(config.operationName());
 
   if (config.operationName() == OperationName::Egress) {

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -14,19 +14,6 @@
 namespace Envoy {
 namespace Tracing {
 
-enum class Reason {
-  NotTraceableRequestId,
-  HealthCheck,
-  Sampling,
-  ServiceForced,
-  ClientForced,
-};
-
-struct Decision {
-  Reason reason;
-  bool is_tracing;
-};
-
 /**
  * Tracing tag names.
  */
@@ -143,7 +130,8 @@ public:
 class HttpNullTracer : public HttpTracer {
 public:
   // Tracing::HttpTracer
-  SpanPtr startSpan(const Config&, Http::HeaderMap&, const RequestInfo::RequestInfo&) override {
+  SpanPtr startSpan(const Config&, Http::HeaderMap&, const RequestInfo::RequestInfo&,
+                    const Tracing::Decision&) override {
     return SpanPtr{new NullSpan()};
   }
 };
@@ -154,7 +142,8 @@ public:
 
   // Tracing::HttpTracer
   SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
-                    const RequestInfo::RequestInfo& request_info) override;
+                    const RequestInfo::RequestInfo& request_info,
+                    const Tracing::Decision& tracing_decision) override;
 
 private:
   DriverPtr driver_;

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -131,7 +131,7 @@ class HttpNullTracer : public HttpTracer {
 public:
   // Tracing::HttpTracer
   SpanPtr startSpan(const Config&, Http::HeaderMap&, const RequestInfo::RequestInfo&,
-                    const Tracing::Decision&) override {
+                    const Tracing::Decision) override {
     return SpanPtr{new NullSpan()};
   }
 };
@@ -143,7 +143,7 @@ public:
   // Tracing::HttpTracer
   SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
                     const RequestInfo::RequestInfo& request_info,
-                    const Tracing::Decision& tracing_decision) override;
+                    const Tracing::Decision tracing_decision) override;
 
 private:
   DriverPtr driver_;

--- a/source/common/tracing/lightstep_tracer_impl.h
+++ b/source/common/tracing/lightstep_tracer_impl.h
@@ -61,6 +61,9 @@ public:
   opentracing::Tracer& tracer() override;
   PropagationMode propagationMode() const override { return propagation_mode_; }
 
+protected:
+  bool useTagForSamplingDecision() override { return false; }
+
 private:
   class LightStepTransporter : public lightstep::AsyncTransporter, Http::AsyncClient::Callbacks {
   public:

--- a/source/common/tracing/opentracing_driver_impl.cc
+++ b/source/common/tracing/opentracing_driver_impl.cc
@@ -174,7 +174,7 @@ SpanPtr OpenTracingDriver::startSpan(const Config&, Http::HeaderMap& request_hea
   opentracing::ChildOf(parent_span_ctx.get()).Apply(options);
   opentracing::StartTimestamp(start_time).Apply(options);
   if (!tracing_decision.traced) {
-    opentracing::SetTag(OpenTracingTags::get().SAMPLING_PRIORITY, 0).Apply(options);
+    opentracing::SetTag(opentracing::ext::sampling_priority, 0).Apply(options);
   }
   active_span = tracer.StartSpanWithOptions(operation_name, options);
   RELEASE_ASSERT(active_span != nullptr);

--- a/source/common/tracing/opentracing_driver_impl.cc
+++ b/source/common/tracing/opentracing_driver_impl.cc
@@ -129,10 +129,10 @@ OpenTracingDriver::OpenTracingDriver(Stats::Store& stats)
 
 SpanPtr OpenTracingDriver::startSpan(const Config&, Http::HeaderMap& request_headers,
                                      const std::string& operation_name, SystemTime start_time,
-                                     const Tracing::Decision& tracing_decision) {
+                                     const Tracing::Decision tracing_decision) {
   // If tracing decision is no, and sampling decision is not communicated via tags, then
   // return a null span to indicate that tracing is not being performed.
-  if (!tracing_decision.is_tracing && !useTagForSamplingDecision()) {
+  if (!tracing_decision.traced && !useTagForSamplingDecision()) {
     return nullptr;
   }
   const PropagationMode propagation_mode = this->propagationMode();
@@ -173,7 +173,7 @@ SpanPtr OpenTracingDriver::startSpan(const Config&, Http::HeaderMap& request_hea
   opentracing::StartSpanOptions options;
   opentracing::ChildOf(parent_span_ctx.get()).Apply(options);
   opentracing::StartTimestamp(start_time).Apply(options);
-  if (!tracing_decision.is_tracing) {
+  if (!tracing_decision.traced) {
     opentracing::SetTag(OpenTracingTags::get().SAMPLING_PRIORITY, 0).Apply(options);
   }
   active_span = tracer.StartSpanWithOptions(operation_name, options);

--- a/source/common/tracing/opentracing_driver_impl.cc
+++ b/source/common/tracing/opentracing_driver_impl.cc
@@ -171,10 +171,11 @@ SpanPtr OpenTracingDriver::startSpan(const Config&, Http::HeaderMap& request_hea
     }
   }
   opentracing::StartSpanOptions options;
-  opentracing::ChildOf(parent_span_ctx.get()).Apply(options);
-  opentracing::StartTimestamp(start_time).Apply(options);
+  options.references.emplace_back(opentracing::SpanReferenceType::ChildOfRef,
+                                  parent_span_ctx.get());
+  options.start_system_timestamp = start_time;
   if (!tracing_decision.traced) {
-    opentracing::SetTag(opentracing::ext::sampling_priority, 0).Apply(options);
+    options.tags.emplace_back(opentracing::ext::sampling_priority, 0);
   }
   active_span = tracer.StartSpanWithOptions(operation_name, options);
   RELEASE_ASSERT(active_span != nullptr);

--- a/source/common/tracing/opentracing_driver_impl.h
+++ b/source/common/tracing/opentracing_driver_impl.h
@@ -8,16 +8,10 @@
 #include "common/singleton/const_singleton.h"
 
 #include "opentracing/tracer.h"
+#include "opentracing/ext/tags.h"
 
 namespace Envoy {
 namespace Tracing {
-
-class OpenTracingTagValues {
-public:
-  const std::string SAMPLING_PRIORITY = "sampling.priority";
-};
-
-typedef ConstSingleton<OpenTracingTagValues> OpenTracingTags;
 
 #define OPENTRACING_TRACER_STATS(COUNTER)                                                          \
   COUNTER(span_context_extraction_error)                                                           \

--- a/source/common/tracing/opentracing_driver_impl.h
+++ b/source/common/tracing/opentracing_driver_impl.h
@@ -58,7 +58,7 @@ public:
   // Tracer::TracingDriver
   SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
                     const std::string& operation_name, SystemTime start_time,
-                    const Tracing::Decision& tracing_decision) override;
+                    const Tracing::Decision tracing_decision) override;
 
   virtual opentracing::Tracer& tracer() PURE;
 

--- a/source/common/tracing/opentracing_driver_impl.h
+++ b/source/common/tracing/opentracing_driver_impl.h
@@ -7,8 +7,8 @@
 #include "common/common/logger.h"
 #include "common/singleton/const_singleton.h"
 
-#include "opentracing/tracer.h"
 #include "opentracing/ext/tags.h"
+#include "opentracing/tracer.h"
 
 namespace Envoy {
 namespace Tracing {

--- a/source/common/tracing/zipkin/zipkin_tracer_impl.cc
+++ b/source/common/tracing/zipkin/zipkin_tracer_impl.cc
@@ -77,7 +77,7 @@ Driver::Driver(const Json::Object& config, Upstream::ClusterManager& cluster_man
 
 Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config, Http::HeaderMap& request_headers,
                                    const std::string&, SystemTime start_time,
-                                   const Tracing::Decision& tracing_decision) {
+                                   const Tracing::Decision tracing_decision) {
   Tracer& tracer = *tls_->getTyped<TlsTracer>().tracer_;
   SpanPtr new_zipkin_span;
   bool sampled(true);
@@ -88,7 +88,7 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config, Http::HeaderMa
     absl::string_view xb3_sampled = request_headers.XB3Sampled()->value().getStringView();
     sampled = xb3_sampled == ZipkinCoreConstants::get().SAMPLED || xb3_sampled == "true";
   } else {
-    sampled = tracing_decision.is_tracing;
+    sampled = tracing_decision.traced;
   }
 
   if (request_headers.XB3TraceId() && request_headers.XB3SpanId()) {

--- a/source/common/tracing/zipkin/zipkin_tracer_impl.cc
+++ b/source/common/tracing/zipkin/zipkin_tracer_impl.cc
@@ -76,7 +76,8 @@ Driver::Driver(const Json::Object& config, Upstream::ClusterManager& cluster_man
 }
 
 Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config, Http::HeaderMap& request_headers,
-                                   const std::string&, SystemTime start_time) {
+                                   const std::string&, SystemTime start_time,
+                                   const Tracing::Decision& tracing_decision) {
   Tracer& tracer = *tls_->getTyped<TlsTracer>().tracer_;
   SpanPtr new_zipkin_span;
   bool sampled(true);
@@ -86,6 +87,8 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config, Http::HeaderMa
     // zipkin tracers may still use that value, although should be 0 or 1.
     absl::string_view xb3_sampled = request_headers.XB3Sampled()->value().getStringView();
     sampled = xb3_sampled == ZipkinCoreConstants::get().SAMPLED || xb3_sampled == "true";
+  } else {
+    sampled = tracing_decision.is_tracing;
   }
 
   if (request_headers.XB3TraceId() && request_headers.XB3SpanId()) {

--- a/source/common/tracing/zipkin/zipkin_tracer_impl.h
+++ b/source/common/tracing/zipkin/zipkin_tracer_impl.h
@@ -100,7 +100,7 @@ public:
    */
   Tracing::SpanPtr startSpan(const Tracing::Config&, Http::HeaderMap& request_headers,
                              const std::string&, SystemTime start_time,
-                             const Tracing::Decision& tracing_decision) override;
+                             const Tracing::Decision tracing_decision) override;
 
   // Getters to return the ZipkinDriver's key members.
   Upstream::ClusterManager& clusterManager() { return cm_; }

--- a/source/common/tracing/zipkin/zipkin_tracer_impl.h
+++ b/source/common/tracing/zipkin/zipkin_tracer_impl.h
@@ -99,7 +99,8 @@ public:
    * ("ingress" or "egress") passed by the caller.
    */
   Tracing::SpanPtr startSpan(const Tracing::Config&, Http::HeaderMap& request_headers,
-                             const std::string&, SystemTime start_time) override;
+                             const std::string&, SystemTime start_time,
+                             const Tracing::Decision& tracing_decision) override;
 
   // Getters to return the ZipkinDriver's key members.
   Upstream::ClusterManager& clusterManager() { return cm_; }

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -517,13 +517,14 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlow) {
   setup(false, "");
 
   NiceMock<Tracing::MockSpan>* span = new NiceMock<Tracing::MockSpan>();
-  EXPECT_CALL(tracer_, startSpan_(_, _, _))
-      .WillOnce(Invoke([&](const Tracing::Config& config, const HeaderMap&,
-                           const RequestInfo::RequestInfo&) -> Tracing::Span* {
-        EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
+  EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
+      .WillOnce(
+          Invoke([&](const Tracing::Config& config, const HeaderMap&,
+                     const RequestInfo::RequestInfo&, const Tracing::Decision&) -> Tracing::Span* {
+            EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
 
-        return span;
-      }));
+            return span;
+          }));
   // No decorator.
   EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator())
       .WillRepeatedly(Return(nullptr));
@@ -583,13 +584,14 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   setup(false, "");
 
   NiceMock<Tracing::MockSpan>* span = new NiceMock<Tracing::MockSpan>();
-  EXPECT_CALL(tracer_, startSpan_(_, _, _))
-      .WillOnce(Invoke([&](const Tracing::Config& config, const HeaderMap&,
-                           const RequestInfo::RequestInfo&) -> Tracing::Span* {
-        EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
+  EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
+      .WillOnce(
+          Invoke([&](const Tracing::Config& config, const HeaderMap&,
+                     const RequestInfo::RequestInfo&, const Tracing::Decision&) -> Tracing::Span* {
+            EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
 
-        return span;
-      }));
+            return span;
+          }));
   route_config_provider_.route_config_->route_->decorator_.operation_ = "testOp";
   EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(4);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
@@ -644,13 +646,14 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   setup(false, "");
 
   NiceMock<Tracing::MockSpan>* span = new NiceMock<Tracing::MockSpan>();
-  EXPECT_CALL(tracer_, startSpan_(_, _, _))
-      .WillOnce(Invoke([&](const Tracing::Config& config, const HeaderMap&,
-                           const RequestInfo::RequestInfo&) -> Tracing::Span* {
-        EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
+  EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
+      .WillOnce(
+          Invoke([&](const Tracing::Config& config, const HeaderMap&,
+                     const RequestInfo::RequestInfo&, const Tracing::Decision&) -> Tracing::Span* {
+            EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
 
-        return span;
-      }));
+            return span;
+          }));
   route_config_provider_.route_config_->route_->decorator_.operation_ = "initOp";
   EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(4);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
@@ -710,13 +713,14 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
       {Tracing::OperationName::Egress, {LowerCaseString(":method")}}));
 
   NiceMock<Tracing::MockSpan>* span = new NiceMock<Tracing::MockSpan>();
-  EXPECT_CALL(tracer_, startSpan_(_, _, _))
-      .WillOnce(Invoke([&](const Tracing::Config& config, const HeaderMap&,
-                           const RequestInfo::RequestInfo&) -> Tracing::Span* {
-        EXPECT_EQ(Tracing::OperationName::Egress, config.operationName());
+  EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
+      .WillOnce(
+          Invoke([&](const Tracing::Config& config, const HeaderMap&,
+                     const RequestInfo::RequestInfo&, const Tracing::Decision&) -> Tracing::Span* {
+            EXPECT_EQ(Tracing::OperationName::Egress, config.operationName());
 
-        return span;
-      }));
+            return span;
+          }));
   route_config_provider_.route_config_->route_->decorator_.operation_ = "testOp";
   EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(4);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
@@ -776,13 +780,14 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
       {Tracing::OperationName::Egress, {LowerCaseString(":method")}}));
 
   NiceMock<Tracing::MockSpan>* span = new NiceMock<Tracing::MockSpan>();
-  EXPECT_CALL(tracer_, startSpan_(_, _, _))
-      .WillOnce(Invoke([&](const Tracing::Config& config, const HeaderMap&,
-                           const RequestInfo::RequestInfo&) -> Tracing::Span* {
-        EXPECT_EQ(Tracing::OperationName::Egress, config.operationName());
+  EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
+      .WillOnce(
+          Invoke([&](const Tracing::Config& config, const HeaderMap&,
+                     const RequestInfo::RequestInfo&, const Tracing::Decision&) -> Tracing::Span* {
+            EXPECT_EQ(Tracing::OperationName::Egress, config.operationName());
 
-        return span;
-      }));
+            return span;
+          }));
   route_config_provider_.route_config_->route_->decorator_.operation_ = "initOp";
   EXPECT_CALL(*route_config_provider_.route_config_->route_, decorator()).Times(4);
   EXPECT_CALL(route_config_provider_.route_config_->route_->decorator_, apply(_))
@@ -959,7 +964,7 @@ TEST_F(HttpConnectionManagerImplTest, DoNotStartSpanIfTracingIsNotEnabled) {
   // Disable tracing.
   tracing_config_.reset();
 
-  EXPECT_CALL(tracer_, startSpan_(_, _, _)).Times(0);
+  EXPECT_CALL(tracer_, startSpan_(_, _, _, _)).Times(0);
   ON_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))
       .WillByDefault(Return(true));
 
@@ -997,7 +1002,7 @@ TEST_F(HttpConnectionManagerImplTest, StartSpanOnlyHealthCheckRequest) {
 
   NiceMock<Tracing::MockSpan>* span = new NiceMock<Tracing::MockSpan>();
 
-  EXPECT_CALL(tracer_, startSpan_(_, _, _)).WillOnce(Return(span));
+  EXPECT_CALL(tracer_, startSpan_(_, _, _, _)).WillOnce(Return(span));
   EXPECT_CALL(*span, finishSpan()).Times(0);
 
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.global_enabled", 100, _))

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -520,7 +520,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlow) {
   EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
       .WillOnce(
           Invoke([&](const Tracing::Config& config, const HeaderMap&,
-                     const RequestInfo::RequestInfo&, const Tracing::Decision&) -> Tracing::Span* {
+                     const RequestInfo::RequestInfo&, const Tracing::Decision) -> Tracing::Span* {
             EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
 
             return span;
@@ -587,7 +587,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
       .WillOnce(
           Invoke([&](const Tracing::Config& config, const HeaderMap&,
-                     const RequestInfo::RequestInfo&, const Tracing::Decision&) -> Tracing::Span* {
+                     const RequestInfo::RequestInfo&, const Tracing::Decision) -> Tracing::Span* {
             EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
 
             return span;
@@ -649,7 +649,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
       .WillOnce(
           Invoke([&](const Tracing::Config& config, const HeaderMap&,
-                     const RequestInfo::RequestInfo&, const Tracing::Decision&) -> Tracing::Span* {
+                     const RequestInfo::RequestInfo&, const Tracing::Decision) -> Tracing::Span* {
             EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
 
             return span;
@@ -716,7 +716,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
       .WillOnce(
           Invoke([&](const Tracing::Config& config, const HeaderMap&,
-                     const RequestInfo::RequestInfo&, const Tracing::Decision&) -> Tracing::Span* {
+                     const RequestInfo::RequestInfo&, const Tracing::Decision) -> Tracing::Span* {
             EXPECT_EQ(Tracing::OperationName::Egress, config.operationName());
 
             return span;
@@ -783,7 +783,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   EXPECT_CALL(tracer_, startSpan_(_, _, _, _))
       .WillOnce(
           Invoke([&](const Tracing::Config& config, const HeaderMap&,
-                     const RequestInfo::RequestInfo&, const Tracing::Decision&) -> Tracing::Span* {
+                     const RequestInfo::RequestInfo&, const Tracing::Decision) -> Tracing::Span* {
             EXPECT_EQ(Tracing::OperationName::Egress, config.operationName());
 
             return span;

--- a/test/common/tracing/dynamic_opentracing_driver_impl_test.cc
+++ b/test/common/tracing/dynamic_opentracing_driver_impl_test.cc
@@ -70,7 +70,8 @@ TEST_F(DynamicOpenTracingDriverTest, InitializeDriver) {
 TEST_F(DynamicOpenTracingDriverTest, FlushSpans) {
   setupValidDriver();
 
-  SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_, start_time_);
+  SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_, start_time_,
+                                          {Reason::Sampling, true});
   first_span->finishSpan();
   driver_->tracer().Close();
 

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -411,7 +411,8 @@ TEST(HttpNullTracerTest, BasicFunctionality) {
   RequestInfo::MockRequestInfo request_info;
   Http::TestHeaderMapImpl request_headers;
 
-  SpanPtr span_ptr = null_tracer.startSpan(config, request_headers, request_info);
+  SpanPtr span_ptr =
+      null_tracer.startSpan(config, request_headers, request_info, {Reason::Sampling, true});
   EXPECT_TRUE(dynamic_cast<NullSpan*>(span_ptr.get()) != nullptr);
 
   span_ptr->setOperation("foo");
@@ -441,9 +442,9 @@ TEST_F(HttpTracerImplTest, BasicFunctionalityNullSpan) {
   EXPECT_CALL(config_, operationName()).Times(2);
   EXPECT_CALL(request_info_, startTime());
   const std::string operation_name = "ingress";
-  EXPECT_CALL(*driver_, startSpan_(_, _, operation_name, request_info_.start_time_))
+  EXPECT_CALL(*driver_, startSpan_(_, _, operation_name, request_info_.start_time_, _))
       .WillOnce(Return(nullptr));
-  tracer_->startSpan(config_, request_headers_, request_info_);
+  tracer_->startSpan(config_, request_headers_, request_info_, {Reason::Sampling, true});
 }
 
 TEST_F(HttpTracerImplTest, BasicFunctionalityNodeSet) {
@@ -453,12 +454,12 @@ TEST_F(HttpTracerImplTest, BasicFunctionalityNodeSet) {
 
   NiceMock<MockSpan>* span = new NiceMock<MockSpan>();
   const std::string operation_name = "egress test";
-  EXPECT_CALL(*driver_, startSpan_(_, _, operation_name, request_info_.start_time_))
+  EXPECT_CALL(*driver_, startSpan_(_, _, operation_name, request_info_.start_time_, _))
       .WillOnce(Return(span));
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(*span, setTag(Tracing::Tags::get().NODE_ID, "node_name"));
 
-  tracer_->startSpan(config_, request_headers_, request_info_);
+  tracer_->startSpan(config_, request_headers_, request_info_, {Reason::Sampling, true});
 }
 
 } // namespace Tracing

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -185,7 +185,7 @@ TEST(HttpTracerUtilityTest, IsTracing) {
 
     Decision result = HttpTracerUtility::isTracing(request_info, forced_header);
     EXPECT_EQ(Reason::ServiceForced, result.reason);
-    EXPECT_TRUE(result.is_tracing);
+    EXPECT_TRUE(result.traced);
   }
 
   // Sample traced.
@@ -194,7 +194,7 @@ TEST(HttpTracerUtilityTest, IsTracing) {
 
     Decision result = HttpTracerUtility::isTracing(request_info, sampled_header);
     EXPECT_EQ(Reason::Sampling, result.reason);
-    EXPECT_TRUE(result.is_tracing);
+    EXPECT_TRUE(result.traced);
   }
 
   // HC request.
@@ -204,7 +204,7 @@ TEST(HttpTracerUtilityTest, IsTracing) {
 
     Decision result = HttpTracerUtility::isTracing(request_info, traceable_header_hc);
     EXPECT_EQ(Reason::HealthCheck, result.reason);
-    EXPECT_FALSE(result.is_tracing);
+    EXPECT_FALSE(result.traced);
   }
 
   // Client traced.
@@ -213,7 +213,7 @@ TEST(HttpTracerUtilityTest, IsTracing) {
 
     Decision result = HttpTracerUtility::isTracing(request_info, client_header);
     EXPECT_EQ(Reason::ClientForced, result.reason);
-    EXPECT_TRUE(result.is_tracing);
+    EXPECT_TRUE(result.traced);
   }
 
   // No request id.
@@ -222,7 +222,7 @@ TEST(HttpTracerUtilityTest, IsTracing) {
     EXPECT_CALL(request_info, healthCheck()).WillOnce(Return(false));
     Decision result = HttpTracerUtility::isTracing(request_info, headers);
     EXPECT_EQ(Reason::NotTraceableRequestId, result.reason);
-    EXPECT_FALSE(result.is_tracing);
+    EXPECT_FALSE(result.traced);
   }
 
   // Broken request id.
@@ -231,7 +231,7 @@ TEST(HttpTracerUtilityTest, IsTracing) {
     EXPECT_CALL(request_info, healthCheck()).WillOnce(Return(false));
     Decision result = HttpTracerUtility::isTracing(request_info, headers);
     EXPECT_EQ(Reason::NotTraceableRequestId, result.reason);
-    EXPECT_FALSE(result.is_tracing);
+    EXPECT_FALSE(result.traced);
   }
 }
 

--- a/test/common/tracing/opentracing_driver_impl_test.cc
+++ b/test/common/tracing/opentracing_driver_impl_test.cc
@@ -98,7 +98,7 @@ TEST_F(OpenTracingDriverTest, TagSamplingFalse) {
   first_span->finishSpan();
 
   const std::unordered_map<std::string, opentracing::Value> expected_tags = {
-      {OpenTracingTags::get().SAMPLING_PRIORITY, 0}};
+      {opentracing::ext::sampling_priority, 0}};
 
   EXPECT_EQ(1, driver_->recorder().spans().size());
   EXPECT_EQ(expected_tags, driver_->recorder().top().tags);

--- a/test/common/tracing/opentracing_driver_impl_test.cc
+++ b/test/common/tracing/opentracing_driver_impl_test.cc
@@ -18,8 +18,9 @@ class TestDriver : public OpenTracingDriver {
 public:
   TestDriver(OpenTracingDriver::PropagationMode propagation_mode,
              const opentracing::mocktracer::PropagationOptions& propagation_options,
-             Stats::Store& stats)
-      : OpenTracingDriver{stats}, propagation_mode_{propagation_mode} {
+             Stats::Store& stats, bool useTagForSamplingDecision)
+      : OpenTracingDriver{stats}, propagation_mode_{propagation_mode},
+        useTagForSamplingDecision_(useTagForSamplingDecision) {
     opentracing::mocktracer::MockTracerOptions options;
     auto recorder = new opentracing::mocktracer::InMemoryRecorder{};
     recorder_ = recorder;
@@ -35,19 +36,24 @@ public:
 
   PropagationMode propagationMode() const override { return propagation_mode_; }
 
+protected:
+  bool useTagForSamplingDecision() override { return useTagForSamplingDecision_; }
+
 private:
   const OpenTracingDriver::PropagationMode propagation_mode_;
   const opentracing::mocktracer::InMemoryRecorder* recorder_;
   std::shared_ptr<opentracing::mocktracer::MockTracer> tracer_;
+  bool useTagForSamplingDecision_;
 };
 
 class OpenTracingDriverTest : public Test {
 public:
-  void
-  setupValidDriver(OpenTracingDriver::PropagationMode propagation_mode =
-                       OpenTracingDriver::PropagationMode::SingleHeader,
-                   const opentracing::mocktracer::PropagationOptions& propagation_options = {}) {
-    driver_.reset(new TestDriver{propagation_mode, propagation_options, stats_});
+  void setupValidDriver(OpenTracingDriver::PropagationMode propagation_mode =
+                            OpenTracingDriver::PropagationMode::SingleHeader,
+                        const opentracing::mocktracer::PropagationOptions& propagation_options = {},
+                        const bool useTagForSamplingDecision = false) {
+    driver_.reset(
+        new TestDriver{propagation_mode, propagation_options, stats_, useTagForSamplingDecision});
   }
 
   const std::string operation_name_{"test"};
@@ -65,12 +71,34 @@ public:
 TEST_F(OpenTracingDriverTest, FlushSpanWithTag) {
   setupValidDriver();
 
-  SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_, start_time_);
+  SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_, start_time_,
+                                          {Reason::Sampling, true});
   first_span->setTag("abc", "123");
   first_span->finishSpan();
 
   const std::unordered_map<std::string, opentracing::Value> expected_tags = {
       {"abc", std::string{"123"}}};
+
+  EXPECT_EQ(1, driver_->recorder().spans().size());
+  EXPECT_EQ(expected_tags, driver_->recorder().top().tags);
+}
+
+TEST_F(OpenTracingDriverTest, NoSpanSamplingFalse) {
+  setupValidDriver(OpenTracingDriver::PropagationMode::SingleHeader, {}, false);
+
+  EXPECT_EQ(nullptr, driver_->startSpan(config_, request_headers_, operation_name_, start_time_,
+                                        {Reason::Sampling, false}));
+}
+
+TEST_F(OpenTracingDriverTest, TagSamplingFalse) {
+  setupValidDriver(OpenTracingDriver::PropagationMode::TracerNative, {}, true);
+
+  SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_, start_time_,
+                                          {Reason::Sampling, false});
+  first_span->finishSpan();
+
+  const std::unordered_map<std::string, opentracing::Value> expected_tags = {
+      {OpenTracingTags::get().SAMPLING_PRIORITY, 0}};
 
   EXPECT_EQ(1, driver_->recorder().spans().size());
   EXPECT_EQ(expected_tags, driver_->recorder().top().tags);
@@ -84,7 +112,8 @@ TEST_F(OpenTracingDriverTest, InjectFailure) {
     propagation_options.inject_error_code = std::make_error_code(std::errc::bad_message);
     setupValidDriver(propagation_mode, propagation_options);
 
-    SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_, start_time_);
+    SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_, start_time_,
+                                      {Reason::Sampling, true});
 
     const auto span_context_injection_error_count =
         stats_.counter("tracing.opentracing.span_context_injection_error").value();
@@ -101,10 +130,12 @@ TEST_F(OpenTracingDriverTest, ExtractWithUnindexedHeader) {
   propagation_options.propagation_key = "unindexed-header";
   setupValidDriver(OpenTracingDriver::PropagationMode::TracerNative, propagation_options);
 
-  SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_, start_time_);
+  SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_, start_time_,
+                                          {Reason::Sampling, true});
   first_span->injectContext(request_headers_);
 
-  SpanPtr second_span = driver_->startSpan(config_, request_headers_, operation_name_, start_time_);
+  SpanPtr second_span = driver_->startSpan(config_, request_headers_, operation_name_, start_time_,
+                                           {Reason::Sampling, true});
   second_span->finishSpan();
   first_span->finishSpan();
 

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -47,12 +47,14 @@ public:
   ~MockHttpTracer();
 
   SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
-                    const RequestInfo::RequestInfo& request_info) override {
-    return SpanPtr{startSpan_(config, request_headers, request_info)};
+                    const RequestInfo::RequestInfo& request_info,
+                    const Tracing::Decision& tracing_decision) override {
+    return SpanPtr{startSpan_(config, request_headers, request_info, tracing_decision)};
   }
 
-  MOCK_METHOD3(startSpan_, Span*(const Config& config, Http::HeaderMap& request_headers,
-                                 const RequestInfo::RequestInfo& request_info));
+  MOCK_METHOD4(startSpan_, Span*(const Config& config, Http::HeaderMap& request_headers,
+                                 const RequestInfo::RequestInfo& request_info,
+                                 const Tracing::Decision& tracing_decision));
 };
 
 class MockDriver : public Driver {
@@ -61,12 +63,15 @@ public:
   ~MockDriver();
 
   SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
-                    const std::string& operation_name, SystemTime start_time) override {
-    return SpanPtr{startSpan_(config, request_headers, operation_name, start_time)};
+                    const std::string& operation_name, SystemTime start_time,
+                    const Tracing::Decision& tracing_decision) override {
+    return SpanPtr{
+        startSpan_(config, request_headers, operation_name, start_time, tracing_decision)};
   }
 
-  MOCK_METHOD4(startSpan_, Span*(const Config& config, Http::HeaderMap& request_headers,
-                                 const std::string& operation_name, SystemTime start_time));
+  MOCK_METHOD5(startSpan_, Span*(const Config& config, Http::HeaderMap& request_headers,
+                                 const std::string& operation_name, SystemTime start_time,
+                                 const Tracing::Decision& tracing_decision));
 };
 
 } // namespace Tracing

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -48,13 +48,13 @@ public:
 
   SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
                     const RequestInfo::RequestInfo& request_info,
-                    const Tracing::Decision& tracing_decision) override {
+                    const Tracing::Decision tracing_decision) override {
     return SpanPtr{startSpan_(config, request_headers, request_info, tracing_decision)};
   }
 
   MOCK_METHOD4(startSpan_, Span*(const Config& config, Http::HeaderMap& request_headers,
                                  const RequestInfo::RequestInfo& request_info,
-                                 const Tracing::Decision& tracing_decision));
+                                 const Tracing::Decision tracing_decision));
 };
 
 class MockDriver : public Driver {
@@ -64,14 +64,14 @@ public:
 
   SpanPtr startSpan(const Config& config, Http::HeaderMap& request_headers,
                     const std::string& operation_name, SystemTime start_time,
-                    const Tracing::Decision& tracing_decision) override {
+                    const Tracing::Decision tracing_decision) override {
     return SpanPtr{
         startSpan_(config, request_headers, operation_name, start_time, tracing_decision)};
   }
 
   MOCK_METHOD5(startSpan_, Span*(const Config& config, Http::HeaderMap& request_headers,
                                  const std::string& operation_name, SystemTime start_time,
-                                 const Tracing::Decision& tracing_decision));
+                                 const Tracing::Decision tracing_decision));
 };
 
 } // namespace Tracing


### PR DESCRIPTION
The sampling decision is currently used to determine whether a span should be created/started. The decision is propagated to downstream services via the `x-trace-id` header.

The problem is that, if the `x-trace-id` is not propagated along with other trace context (e.g. the service does not propagate it due to using a zipkin compatible tracer in the service that does not know about this header), then the decision is lost in the downstream service and it will make its own sampling decision. This will lead to inconsistent fragmented traces.

The other problem is that any B3-sampled header received with a request will be ignored by the local sampling decision.

This PR deals with the situation by delegating the envoy proxy's tracing (sampling) decision down to the tracers themselves. There are essentially three tracers, which handle the decision in different ways:

1) LightStep - this tracer only creates/starts a span if the tracing decision indicates it should - otherwise no span is created - as now. It is the responsibility of any proxied services to propagate the `x-trace-id` to ensure that decision is passed to downstream services.

2) Zipkin - this tracer propagates its own sampling decision via the `X-B3-Sampled` header. If that header is not present, such as when creating the root span or it hasn't been propagated with the trace context, then the proxy's tracing (sampling) decision will be used to set the `X-B3-Sampled` header which will subsequently be passed to downstream services.

3) Other OpenTracing compatible tracers - the only way to influence the sampling of a trace instance in the OpenTracing standard is through the use of the `sampling.priority` tag - so in this situation if the proxy sampling decision is false, the `sampling.priority` tag will be set to 0 when creating the span. It is then the tracer's responsibility to use or ignore that *hint*.

*Risk Level*: Medium

*Testing*: unit tests

*Docs Changes*:
none

*Release Notes*:
This change delegates the sampling decision to the tracer, which may have additional context that needs to be taken into account when determining the actual sampling state. If no such state already exists for a trace instance, then the sampling decision supplied by the Envoy proxy will be used.

