### PR TITLE
ci: fix ubuntu version in EXPECTED_CXX_VERSION

### DIFF
--- a/ci/build_container/build_container_ubuntu.sh
+++ b/ci/build_container/build_container_ubuntu.sh
@@ -22,5 +22,5 @@ rm -rf /var/lib/apt/lists/*
 # virtualenv
 pip install virtualenv
 
-EXPECTED_CXX_VERSION="g++ (Ubuntu 5.4.0-6ubuntu1~16.04.6) 5.4.0 20160609" ./build_container_common.sh
+EXPECTED_CXX_VERSION="g++ (Ubuntu 5.4.0-6ubuntu1~16.04.9) 5.4.0 20160609" ./build_container_common.sh
 


### PR DESCRIPTION
I believe the ubuntu:xenial docker image was recently updated. The version of g++ in use is the same, but contains the OS version and so the build_image CI build is failing because the expected compiler version is wrong.

*Risk Level*: Low (build fix)
*Testing*: CI
*Release Notes*: n/a

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
