### PR TITLE
link to the email address for security issue reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Meeting minutes are here: https://goo.gl/5Cergb
 ## Reporting security vulnerabilities
 
 If you've found a vulnerability or a potential vulnerability in Envoy please let us know at
-[envoy-security](https://groups.google.com/forum/#!forum/envoy-security). We'll send a confirmation
+[envoy-security](mailto:envoy-security@googlegroups.com). We'll send a confirmation
 email to acknowledge your report, and we'll send an additional email when we've identified the issue
 positively or negatively.
 


### PR DESCRIPTION
*Description*:
Previously, the "envoy-security" link in the top-level README.md went to the Google group page, which doesn't show the email address to nonmembers. This PR changes the link to a mailto.

*Risk Level*: Low

*Testing*: I viewed Github's rendering of README.md in my fork and verified that clicking the envoy-security link brought up the browser's configured email handler.

*Docs Changes*: N/A

*Release Notes*: N/A

Signed-off-by: Brian Pane <bpane@pinterest.com>