### PR TITLE
Tech Debt: Upgrade bazel go rule from 0.9 to 0.10.1

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -84,7 +84,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/grpc-ecosystem/grpc-httpjson-transcoding",
     ),
     io_bazel_rules_go = dict(
-        commit = "0.9.0",
+        commit = "0.10.1",
         remote = "https://github.com/bazelbuild/rules_go",
     ),
     # I'd love to name this `com_github_google_subpar`, but something in the Subpar


### PR DESCRIPTION
Description:
The current bazel go rule is 0.9 which targets go1.9.2.  This changes the go bazel rule to 0.10.1 which targets 1.10.

Signed-off-by: Nicholas Johns <nicholas.a.johns5@gmail.com>

*Risk Level*: Low 
*Testing*: Manually fetched and compiled (no issues)
