### PR TITLE
build: fix build break in #2790.

### DIFF
--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -929,7 +929,7 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLogWithInvalidRequest) {
   EXPECT_CALL(*handler, log(_, _, _))
       .WillOnce(Invoke(
           [](const HeaderMap*, const HeaderMap*, const RequestInfo::RequestInfo& request_info) {
-            EXPECT_TRUE(request_info.responseCode().valid());
+            EXPECT_TRUE(request_info.responseCode());
             EXPECT_EQ(request_info.responseCode().value(), uint32_t(400));
             EXPECT_NE(nullptr, request_info.downstreamLocalAddress());
             EXPECT_NE(nullptr, request_info.downstreamRemoteAddress());


### PR DESCRIPTION
Some absl::optional changes missed due to not being merged with #2688.

Signed-off-by: Harvey Tuch <htuch@google.com>