### PR TITLE
WIP bots: initial config for probot/stale

### DIFF
--- a/stale.yml
+++ b/stale.yml
@@ -1,0 +1,54 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 7
+
+# Number of days of inactivity before a stale Issue or Pull Request is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - [help+wanted]
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This pull request has been automatically marked as stale because it has not had
+  activity in the last 7 days. It will be closed if no further activity occurs. Please
+  feel free to give a status update now, ping for review, or re-open when it's ready.
+  Thank you for your contributions!
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 1
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+issues:
+  daysUntilStale: 30
+  markComment: >
+    This issue has been automatically marked as stale because it has not had activity in the
+    last 30 days. It will be closed unless it is tagged "help wanted" or other activity
+    occurs. Thank you for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed

--- a/stale.yml
+++ b/stale.yml
@@ -9,7 +9,7 @@ daysUntilClose: 7
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
-  - [help+wanted]
+  - []
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false
@@ -32,22 +32,22 @@ markComment: >
 #   Your comment here.
 
 # Comment to post when closing a stale Issue or Pull Request.
-closeComment: >
+#closeComment: >
 #   Your comment here.
 
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 1
 
 # Limit to only `issues` or `pulls`
-# only: issues
+only: pulls
 
 # Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
-issues:
-  daysUntilStale: 30
-  markComment: >
-    This issue has been automatically marked as stale because it has not had activity in the
-    last 30 days. It will be closed unless it is tagged "help wanted" or other activity
-    occurs. Thank you for your contributions.
+#issues:
+#  daysUntilStale: 30
+#  markComment: >
+#    This issue has been automatically marked as stale because it has not had activity in the
+#    last 30 days. It will be closed unless it is tagged "help wanted" or other activity
+#    occurs. Thank you for your contributions.
 
 # issues:
 #   exemptLabels:


### PR DESCRIPTION
This will currently result in 
-PRs getting flagged as stale after 7d, and closed after 14
-Issues not tagged with "help wanted" being flagged as stale after 30d and closed after 37.

WIP because we probably shouldn't submit until we've flagged the 3 pages of not-assigned not-help-wanted issues with help wanted, which I'm happy to do once we've done some bikeshedding
(is:issue is:open -label:"help wanted" no:assignee)

Happy to change time scales, turn off staleness for one or the other.  Suggest away!

I'm also mildly concerned that the + in help wanted will be incorrect and we'll have to untag a ton of bugs as stale.  I've limited tags per run to 1 and I'll turn it up on a day when I'm around to minimize that.  We can up the limit when we get busy enough we need to flag more frequently :-)

*Testing*: I wish
*Docs Changes*: Nope
*Release Notes*: n/a
Part of #2797

@envoyproxy/maintainers 