### PR TITLE
Add cluster update callbacks

### DIFF
--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -176,11 +176,12 @@ public:
    * in the ClusterManager.
    * The callbacks will be registered in a thread local slot and the callbacks will be executed
    * on the thread that registered them.
+   * To be executed on all threads, Callbacks need to be registered on all threads.
    *
    * @param callbacks are the ClusterUpdateCallbacks to add or remove to the cluster manager.
    */
-  virtual void addClusterUpdateCallbacks(ClusterUpdateCallbacks& callbacks) PURE;
-  virtual void removeClusterUpdateCallbacks(ClusterUpdateCallbacks& callbacks) PURE;
+  virtual void addThreadLocalClusterUpdateCallbacks(ClusterUpdateCallbacks& callbacks) PURE;
+  virtual void removeThreadLocalClusterUpdateCallbacks(ClusterUpdateCallbacks& callbacks) PURE;
 };
 
 typedef std::unique_ptr<ClusterManager> ClusterManagerPtr;

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -23,6 +23,29 @@ namespace Envoy {
 namespace Upstream {
 
 /**
+ * ClusterUpdateCallbacks provide a way to exposes Cluster lifecycle events in the
+ * ClusterManager.
+ */
+class ClusterUpdateCallbacks {
+public:
+  virtual ~ClusterUpdateCallbacks() {}
+
+  /**
+   * onClusterAddOrUpdate is called when a new cluster is added or an existing cluster
+   * is updated in the ClusterManager.
+   * @param cluster is the ThreadLocalCluster that represents the updated
+   * cluster.
+   */
+  virtual void onClusterAddOrUpdate(ThreadLocalCluster& cluster) PURE;
+
+  /**
+   * onClusterRemoval is called when a cluster is removed; the argument is the cluster name.
+   * @param cluster_name is the name of the removed cluster.
+   */
+  virtual void onClusterRemoval(const std::string& cluster_name) PURE;
+};
+
+/**
  * Manages connection pools and load balancing for upstream clusters. The cluster manager is
  * persistent and shared among multiple ongoing requests/connections.
  */
@@ -147,6 +170,17 @@ public:
    * @return std::string the local cluster name, or "" if no local cluster was configured.
    */
   virtual const std::string& localClusterName() const PURE;
+
+  /**
+   * These two methods allow to register and unregister callbacks for cluster lifecycle events
+   * in the ClusterManager.
+   * The callbacks will be registered in a thread local slot and the callbacks will be executed
+   * on the thread that registered them.
+   *
+   * @param callbacks are the ClusterUpdateCallbacks to add or remove to the cluster manager.
+   */
+  virtual void addClusterUpdateCallbacks(ClusterUpdateCallbacks& callbacks) PURE;
+  virtual void removeClusterUpdateCallbacks(ClusterUpdateCallbacks& callbacks) PURE;
 };
 
 typedef std::unique_ptr<ClusterManager> ClusterManagerPtr;

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -46,13 +46,15 @@ public:
 };
 
 /**
- * CallbackRegistration is a RAII wrapper for a ClusterUpdateCallbacks. Deleting
- * the CallbackRegistration will remove the callbacks from ClusterManager in O(1).
+ * ClusterUpdateCallbacksHandle is a RAII wrapper for a ClusterUpdateCallbacks. Deleting
+ * the ClusterUpdateCallbacksHandle will remove the callbacks from ClusterManager in O(1).
  */
-class CallbackRegistration {
+class ClusterUpdateCallbacksHandle {
 public:
-  virtual ~CallbackRegistration() {}
+  virtual ~ClusterUpdateCallbacksHandle() {}
 };
+
+typedef std::unique_ptr<ClusterUpdateCallbacksHandle> ClusterUpdateCallbacksHandlePtr;
 
 /**
  * Manages connection pools and load balancing for upstream clusters. The cluster manager is
@@ -187,10 +189,10 @@ public:
    * To be executed on all threads, Callbacks need to be registered on all threads.
    *
    * @param callbacks are the ClusterUpdateCallbacks to add or remove to the cluster manager.
-   * @return std::unique_ptr<CallbackRegistration> a RAII that needs to be deleted to unregister
-   *                                               the callback.
+   * @return ClusterUpdateCallbacksHandlePtr a RAII that needs to be deleted to
+   * unregister the callback.
    */
-  virtual std::unique_ptr<CallbackRegistration>
+  virtual ClusterUpdateCallbacksHandlePtr
   addThreadLocalClusterUpdateCallbacks(ClusterUpdateCallbacks& callbacks) PURE;
 };
 

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -609,12 +609,12 @@ const std::string ClusterManagerImpl::versionInfo() const {
   return "static";
 }
 
-void ClusterManagerImpl::addClusterUpdateCallbacks(ClusterUpdateCallbacks& cb) {
+void ClusterManagerImpl::addThreadLocalClusterUpdateCallbacks(ClusterUpdateCallbacks& cb) {
   ThreadLocalClusterManagerImpl& cluster_manager = tls_->getTyped<ThreadLocalClusterManagerImpl>();
   cluster_manager.update_callbacks_.insert(&cb);
 }
 
-void ClusterManagerImpl::removeClusterUpdateCallbacks(ClusterUpdateCallbacks& cb) {
+void ClusterManagerImpl::removeThreadLocalClusterUpdateCallbacks(ClusterUpdateCallbacks& cb) {
   ThreadLocalClusterManagerImpl& cluster_manager = tls_->getTyped<ThreadLocalClusterManagerImpl>();
   cluster_manager.update_callbacks_.erase(&cb);
 }

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -609,19 +609,19 @@ const std::string ClusterManagerImpl::versionInfo() const {
   return "static";
 }
 
-std::unique_ptr<CallbackRegistration>
+ClusterUpdateCallbacksHandlePtr
 ClusterManagerImpl::addThreadLocalClusterUpdateCallbacks(ClusterUpdateCallbacks& cb) {
   ThreadLocalClusterManagerImpl& cluster_manager = tls_->getTyped<ThreadLocalClusterManagerImpl>();
-  return std::make_unique<CallbackRegistrationImpl>(&cb, cluster_manager.update_callbacks_);
+  return std::make_unique<ClusterUpdateCallbacksHandleImpl>(cb, cluster_manager.update_callbacks_);
 }
 
-ClusterManagerImpl::CallbackRegistrationImpl::CallbackRegistrationImpl(
-    ClusterUpdateCallbacks* cb, std::list<ClusterUpdateCallbacks*>& ll)
+ClusterManagerImpl::ClusterUpdateCallbacksHandleImpl::ClusterUpdateCallbacksHandleImpl(
+    ClusterUpdateCallbacks& cb, std::list<ClusterUpdateCallbacks*>& ll)
     : list(ll) {
-  entry = ll.emplace(ll.begin(), cb);
+  entry = ll.emplace(ll.begin(), &cb);
 }
 
-ClusterManagerImpl::CallbackRegistrationImpl::~CallbackRegistrationImpl() {
+ClusterManagerImpl::ClusterUpdateCallbacksHandleImpl::~ClusterUpdateCallbacksHandleImpl() {
   ASSERT(std::find(list.begin(), list.end(), *entry) != list.end());
   list.erase(entry);
 }

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -419,9 +419,12 @@ void ClusterManagerImpl::createOrUpdateThreadLocalCluster(ClusterData& cluster) 
               ENVOY_LOG(debug, "adding TLS cluster {}", new_cluster->name());
             }
 
-            cluster_manager.thread_local_clusters_[new_cluster->name()].reset(
-                new ThreadLocalClusterManagerImpl::ClusterEntry(cluster_manager, new_cluster,
-                                                                thread_aware_lb_factory));
+            auto thread_local_cluster = new ThreadLocalClusterManagerImpl::ClusterEntry(
+                cluster_manager, new_cluster, thread_aware_lb_factory);
+            cluster_manager.thread_local_clusters_[new_cluster->name()].reset(thread_local_cluster);
+            for (auto* cb : cluster_manager.update_callbacks_) {
+              cb->onClusterAddOrUpdate(*thread_local_cluster);
+            }
           });
 }
 
@@ -442,6 +445,9 @@ bool ClusterManagerImpl::removeCluster(const std::string& cluster_name) {
       ASSERT(cluster_manager.thread_local_clusters_.count(cluster_name) == 1);
       ENVOY_LOG(debug, "removing TLS cluster {}", cluster_name);
       cluster_manager.thread_local_clusters_.erase(cluster_name);
+      for (auto* cb : cluster_manager.update_callbacks_) {
+        cb->onClusterRemoval(cluster_name);
+      }
     });
   }
 
@@ -601,6 +607,16 @@ const std::string ClusterManagerImpl::versionInfo() const {
     return cds_api_->versionInfo();
   }
   return "static";
+}
+
+void ClusterManagerImpl::addClusterUpdateCallbacks(ClusterUpdateCallbacks& cb) {
+  ThreadLocalClusterManagerImpl& cluster_manager = tls_->getTyped<ThreadLocalClusterManagerImpl>();
+  cluster_manager.update_callbacks_.insert(&cb);
+}
+
+void ClusterManagerImpl::removeClusterUpdateCallbacks(ClusterUpdateCallbacks& cb) {
+  ThreadLocalClusterManagerImpl& cluster_manager = tls_->getTyped<ThreadLocalClusterManagerImpl>();
+  cluster_manager.update_callbacks_.erase(&cb);
 }
 
 ClusterManagerImpl::ThreadLocalClusterManagerImpl::ThreadLocalClusterManagerImpl(

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -191,7 +191,7 @@ public:
   const std::string versionInfo() const override;
   const std::string& localClusterName() const override { return local_cluster_name_; }
 
-  std::unique_ptr<CallbackRegistration>
+  ClusterUpdateCallbacksHandlePtr
   addThreadLocalClusterUpdateCallbacks(ClusterUpdateCallbacks&) override;
 
 private:
@@ -288,9 +288,10 @@ private:
     ThreadAwareLoadBalancerPtr thread_aware_lb_;
   };
 
-  struct CallbackRegistrationImpl : public CallbackRegistration {
-    CallbackRegistrationImpl(ClusterUpdateCallbacks* cb, std::list<ClusterUpdateCallbacks*>& ll);
-    ~CallbackRegistrationImpl() override;
+  struct ClusterUpdateCallbacksHandleImpl : public ClusterUpdateCallbacksHandle {
+    ClusterUpdateCallbacksHandleImpl(ClusterUpdateCallbacks& cb,
+                                     std::list<ClusterUpdateCallbacks*>& parent);
+    ~ClusterUpdateCallbacksHandleImpl() override;
 
   private:
     std::list<ClusterUpdateCallbacks*>::iterator entry;

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -191,8 +191,8 @@ public:
   const std::string versionInfo() const override;
   const std::string& localClusterName() const override { return local_cluster_name_; }
 
-  void addClusterUpdateCallbacks(ClusterUpdateCallbacks&) override;
-  void removeClusterUpdateCallbacks(ClusterUpdateCallbacks&) override;
+  void addThreadLocalClusterUpdateCallbacks(ClusterUpdateCallbacks&) override;
+  void removeThreadLocalClusterUpdateCallbacks(ClusterUpdateCallbacks&) override;
 
 private:
   /**

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -191,6 +191,9 @@ public:
   const std::string versionInfo() const override;
   const std::string& localClusterName() const override { return local_cluster_name_; }
 
+  void addClusterUpdateCallbacks(ClusterUpdateCallbacks&) override;
+  void removeClusterUpdateCallbacks(ClusterUpdateCallbacks&) override;
+
 private:
   /**
    * Thread local cached cluster data. Each thread local cluster gets updates from the parent
@@ -260,6 +263,7 @@ private:
     Event::Dispatcher& thread_local_dispatcher_;
     std::unordered_map<std::string, ClusterEntryPtr> thread_local_clusters_;
     std::unordered_map<HostConstSharedPtr, ConnPoolsContainer> host_http_conn_pool_map_;
+    std::set<Envoy::Upstream::ClusterUpdateCallbacks*> update_callbacks_;
     const PrioritySet* local_priority_set_{};
   };
 

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -825,10 +825,14 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
   EXPECT_CALL(initialized, ready());
   cluster_manager_->setInitializedCb([&]() -> void { initialized.ready(); });
 
+  std::unique_ptr<MockClusterUpdateCallbacks> callbacks(new NiceMock<MockClusterUpdateCallbacks>());
+  cluster_manager_->addClusterUpdateCallbacks(*callbacks);
+
   std::shared_ptr<MockCluster> cluster1(new NiceMock<MockCluster>());
   EXPECT_CALL(factory_, clusterFromProto_(_, _, _, _)).WillOnce(Return(cluster1));
   EXPECT_CALL(*cluster1, initializePhase()).Times(0);
   EXPECT_CALL(*cluster1, initialize(_));
+  EXPECT_CALL(*callbacks, onClusterAddOrUpdate(_)).Times(1);
   EXPECT_TRUE(cluster_manager_->addOrUpdateCluster(defaultStaticCluster("fake_cluster")));
   checkStats(1 /*added*/, 0 /*modified*/, 0 /*removed*/, 0 /*active*/, 1 /*warming*/);
   EXPECT_EQ(nullptr, cluster_manager_->get("fake_cluster"));
@@ -854,6 +858,7 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
         // Test inline init.
         initialize_callback();
       }));
+  EXPECT_CALL(*callbacks, onClusterAddOrUpdate(_)).Times(1);
   EXPECT_TRUE(cluster_manager_->addOrUpdateCluster(update_cluster));
 
   EXPECT_EQ(cluster2->info_, cluster_manager_->get("fake_cluster")->info());
@@ -866,6 +871,7 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
   // Now remove it. This should drain the connection pool.
   Http::ConnectionPool::Instance::DrainedCb drained_cb;
   EXPECT_CALL(*cp, addDrainedCallback(_)).WillOnce(SaveArg<0>(&drained_cb));
+  EXPECT_CALL(*callbacks, onClusterRemoval(_)).Times(1);
   EXPECT_TRUE(cluster_manager_->removeCluster("fake_cluster"));
   EXPECT_EQ(nullptr, cluster_manager_->get("fake_cluster"));
   EXPECT_EQ(0UL, cluster_manager_->clusters().size());
@@ -879,6 +885,7 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
 
   EXPECT_TRUE(Mock::VerifyAndClearExpectations(cluster1.get()));
   EXPECT_TRUE(Mock::VerifyAndClearExpectations(cluster2.get()));
+  EXPECT_TRUE(Mock::VerifyAndClearExpectations(callbacks.get()));
 }
 
 TEST_F(ClusterManagerImplTest, addOrUpdateClusterStaticExists) {

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -826,7 +826,7 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
   cluster_manager_->setInitializedCb([&]() -> void { initialized.ready(); });
 
   std::unique_ptr<MockClusterUpdateCallbacks> callbacks(new NiceMock<MockClusterUpdateCallbacks>());
-  std::unique_ptr<CallbackRegistration> cb =
+  ClusterUpdateCallbacksHandlePtr cb =
       cluster_manager_->addThreadLocalClusterUpdateCallbacks(*callbacks);
 
   std::shared_ptr<MockCluster> cluster1(new NiceMock<MockCluster>());

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -826,7 +826,8 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
   cluster_manager_->setInitializedCb([&]() -> void { initialized.ready(); });
 
   std::unique_ptr<MockClusterUpdateCallbacks> callbacks(new NiceMock<MockClusterUpdateCallbacks>());
-  cluster_manager_->addThreadLocalClusterUpdateCallbacks(*callbacks);
+  std::unique_ptr<CallbackRegistration> cb =
+      cluster_manager_->addThreadLocalClusterUpdateCallbacks(*callbacks);
 
   std::shared_ptr<MockCluster> cluster1(new NiceMock<MockCluster>());
   EXPECT_CALL(factory_, clusterFromProto_(_, _, _, _)).WillOnce(Return(cluster1));

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -826,7 +826,7 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
   cluster_manager_->setInitializedCb([&]() -> void { initialized.ready(); });
 
   std::unique_ptr<MockClusterUpdateCallbacks> callbacks(new NiceMock<MockClusterUpdateCallbacks>());
-  cluster_manager_->addClusterUpdateCallbacks(*callbacks);
+  cluster_manager_->addThreadLocalClusterUpdateCallbacks(*callbacks);
 
   std::shared_ptr<MockCluster> cluster1(new NiceMock<MockCluster>());
   EXPECT_CALL(factory_, clusterFromProto_(_, _, _, _)).WillOnce(Return(cluster1));

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -113,5 +113,9 @@ MockCdsApi::MockCdsApi() {
 
 MockCdsApi::~MockCdsApi() {}
 
+MockClusterUpdateCallbacks::MockClusterUpdateCallbacks() {}
+
+MockClusterUpdateCallbacks::~MockClusterUpdateCallbacks() {}
+
 } // namespace Upstream
 } // namespace Envoy

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -161,8 +161,8 @@ public:
   MOCK_METHOD0(grpcAsyncClientManager, Grpc::AsyncClientManager&());
   MOCK_CONST_METHOD0(versionInfo, const std::string());
   MOCK_CONST_METHOD0(localClusterName, const std::string&());
-  MOCK_METHOD1(addClusterUpdateCallbacks, void(ClusterUpdateCallbacks& callbacks));
-  MOCK_METHOD1(removeClusterUpdateCallbacks, void(ClusterUpdateCallbacks& callbacks));
+  MOCK_METHOD1(addThreadLocalClusterUpdateCallbacks, void(ClusterUpdateCallbacks& callbacks));
+  MOCK_METHOD1(removeThreadLocalClusterUpdateCallbacks, void(ClusterUpdateCallbacks& callbacks));
 
   NiceMock<Http::ConnectionPool::MockInstance> conn_pool_;
   NiceMock<Http::MockAsyncClient> async_client_;

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -161,8 +161,8 @@ public:
   MOCK_METHOD0(grpcAsyncClientManager, Grpc::AsyncClientManager&());
   MOCK_CONST_METHOD0(versionInfo, const std::string());
   MOCK_CONST_METHOD0(localClusterName, const std::string&());
-  MOCK_METHOD1(addThreadLocalClusterUpdateCallbacks, void(ClusterUpdateCallbacks& callbacks));
-  MOCK_METHOD1(removeThreadLocalClusterUpdateCallbacks, void(ClusterUpdateCallbacks& callbacks));
+  MOCK_METHOD1(addThreadLocalClusterUpdateCallbacks,
+               std::unique_ptr<CallbackRegistration>(ClusterUpdateCallbacks& callbacks));
 
   NiceMock<Http::ConnectionPool::MockInstance> conn_pool_;
   NiceMock<Http::MockAsyncClient> async_client_;

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -162,7 +162,7 @@ public:
   MOCK_CONST_METHOD0(versionInfo, const std::string());
   MOCK_CONST_METHOD0(localClusterName, const std::string&());
   MOCK_METHOD1(addThreadLocalClusterUpdateCallbacks,
-               std::unique_ptr<CallbackRegistration>(ClusterUpdateCallbacks& callbacks));
+               std::unique_ptr<ClusterUpdateCallbacksHandle>(ClusterUpdateCallbacks& callbacks));
 
   NiceMock<Http::ConnectionPool::MockInstance> conn_pool_;
   NiceMock<Http::MockAsyncClient> async_client_;

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -161,6 +161,8 @@ public:
   MOCK_METHOD0(grpcAsyncClientManager, Grpc::AsyncClientManager&());
   MOCK_CONST_METHOD0(versionInfo, const std::string());
   MOCK_CONST_METHOD0(localClusterName, const std::string&());
+  MOCK_METHOD1(addClusterUpdateCallbacks, void(ClusterUpdateCallbacks& callbacks));
+  MOCK_METHOD1(removeClusterUpdateCallbacks, void(ClusterUpdateCallbacks& callbacks));
 
   NiceMock<Http::ConnectionPool::MockInstance> conn_pool_;
   NiceMock<Http::MockAsyncClient> async_client_;
@@ -198,6 +200,15 @@ public:
   MOCK_CONST_METHOD0(versionInfo, const std::string());
 
   std::function<void()> initialized_callback_;
+};
+
+class MockClusterUpdateCallbacks : public ClusterUpdateCallbacks {
+public:
+  MockClusterUpdateCallbacks();
+  ~MockClusterUpdateCallbacks();
+
+  MOCK_METHOD1(onClusterAddOrUpdate, void(ThreadLocalCluster& cluster));
+  MOCK_METHOD1(onClusterRemoval, void(const std::string& cluster_name));
 };
 
 } // namespace Upstream


### PR DESCRIPTION
This change allows filters to subscribe to Cluster lifecycle events.

Risk Level: Low