### PR TITLE
grpc: update to 1.10.0

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -39,7 +39,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/gcovr/gcovr",
     ),
     com_github_grpc_grpc = dict(
-        commit = "04ecc18e3a5b8de5bb7ffa20700364ad88dc16f9", # v1.9.0-pre3
+        commit = "474c5950686e3962bd339c93d27e369bf64f568f", # v1.10.0
         remote = "https://github.com/grpc/grpc.git",
     ),
     io_opentracing_cpp = dict(


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <zlizan@google.com>

*Description*:
Update gRPC dependency to 1.10.0

*Risk Level*: Low as low usage of Google gRPC
*Testing*: unit test, integration
*Docs Changes*: N/A
*Release Notes*: N/A
