### PR TITLE
tools: fixing fix format

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -94,7 +94,7 @@ def fixFileContents(file_path):
   for line in fileinput.input(file_path, inplace=True):
     # Strip double space after '.'  This may prove overenthusiastic and need to
     # be restricted to comments and metadata files but works for now.
-    print "%s" % (line.replace('.  ', '. ').rstrip())
+    sys.stdout.write("%s" % (line.replace('.  ', '. ')))
 
 
 def checkFilePath(file_path):


### PR DESCRIPTION
Previously fix format replaced lines with print/rstrip resulting in each line having newlines
Check format did not check that the last line of a file ended in \n

This meant there were files which would pass check_format but get altered by subsequent fix_format runs. Fixing with sys.stdout.write which bypasses newline transformations.

*Risk Level*: n/a (tools)
*Testing*: 
verified whitespace fixing still works, 
verified source/common/upstream/cluster_manager_impl.cc no longer altered at clean checkout.
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Alyssa Wilk <alyssar@chromium.org>

