### PR TITLE
make num_ejections consistent in outlier log. changed to numerical value

### DIFF
--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -466,7 +466,7 @@ void EventLoggerImpl::logEject(HostDescriptionConstSharedPtr host, Detector& det
     "\"upstream_url\": \"{}\", " +
     "\"action\": \"eject\", " +
     "\"type\": \"{}\", " +
-    "\"num_ejections\": \"{}\", " +
+    "\"num_ejections\": {}, " +
     "\"enforced\": \"{}\"" +
     "}}\n";
 
@@ -478,7 +478,7 @@ void EventLoggerImpl::logEject(HostDescriptionConstSharedPtr host, Detector& det
     "\"upstream_url\": \"{}\", " +
     "\"action\": \"eject\", " +
     "\"type\": \"{}\", " +
-    "\"num_ejections\": \"{}\", " +
+    "\"num_ejections\": {}, " +
     "\"enforced\": \"{}\", " +
     "\"host_success_rate\": \"{}\", " +
     "\"cluster_average_success_rate\": \"{}\", " +

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -767,7 +767,7 @@ TEST(OutlierDetectionEventLoggerImplTest, All) {
   EXPECT_CALL(*file, write("{\"time\": \"1970-01-01T00:00:00.000Z\", \"secs_since_last_action\": "
                            "\"-1\", \"cluster\": "
                            "\"fake_cluster\", \"upstream_url\": \"10.0.0.1:443\", \"action\": "
-                           "\"eject\", \"type\": \"5xx\", \"num_ejections\": \"0\", "
+                           "\"eject\", \"type\": \"5xx\", \"num_ejections\": 0, "
                            "\"enforced\": \"true\"}\n"))
       .WillOnce(SaveArg<0>(&log1));
   event_logger.logEject(host, detector, EjectionType::Consecutive5xx, true);
@@ -795,7 +795,7 @@ TEST(OutlierDetectionEventLoggerImplTest, All) {
   EXPECT_CALL(*file, write("{\"time\": \"1970-01-01T00:00:00.000Z\", \"secs_since_last_action\": "
                            "\"30\", \"cluster\": "
                            "\"fake_cluster\", \"upstream_url\": \"10.0.0.1:443\", \"action\": "
-                           "\"eject\", \"type\": \"SuccessRate\", \"num_ejections\": \"0\", "
+                           "\"eject\", \"type\": \"SuccessRate\", \"num_ejections\": 0, "
                            "\"enforced\": \"false\", "
                            "\"host_success_rate\": \"-1\", \"cluster_average_success_rate\": "
                            "\"-1\", \"cluster_success_rate_ejection_threshold\": \"-1\""


### PR DESCRIPTION
Signed-off-by: Alok Tiagi <aloktiagi@gmail.com>

outlier detection: make num_ejections numerical to be consistent across logs

Description:
As per issue #2758 num_ejections is not consistent across logs. Its a string for eject action and numerical for uneject. Changing the type to numerical for both.

Risk Level: Low

*Testing*:

Fixes #2758 

