### PR TITLE
readme: delete coverity

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 Envoy is hosted by the [Cloud Native Computing Foundation](https://cncf.io) (CNCF). If you are a company that wants to help shape the evolution of technologies that are container-packaged, dynamically-scheduled and microservices-oriented, consider joining the CNCF. For details about who's involved and how Envoy plays a role, read the CNCF [announcement](https://www.cncf.io/blog/2017/09/13/cncf-hosts-envoy/).
 
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1266/badge)](https://bestpractices.coreinfrastructure.org/projects/1266)
-[![Coverity](https://scan.coverity.com/projects/10180/badge.svg)](https://scan.coverity.com/projects/envoy-proxy)
 
 ## Documentation
 


### PR DESCRIPTION
Coverity scan appears to be no more sadly. Delete for now until we
figure out whether it is coming back and if not what to replace it
with.

