### PR TITLE
network: deliver onData with end_stream to ReadFilter if possible

### DIFF
--- a/include/envoy/network/filter.h
+++ b/include/envoy/network/filter.h
@@ -81,8 +81,7 @@ public:
   /**
    * Called when data is read on the connection.
    * @param data supplies the read data which may be modified.
-   * @param end_stream supplies whether this is the last byte on the connection. This will only
-   *        be set if the connection has half-close semantics enabled.
+   * @param end_stream supplies whether this is the last byte on the connection.
    * @return status used by the filter manager to manage further filter iteration.
    */
   virtual FilterStatus onData(Buffer::Instance& data, bool end_stream) PURE;

--- a/source/common/filter/echo.cc
+++ b/source/common/filter/echo.cc
@@ -8,9 +8,9 @@
 namespace Envoy {
 namespace Filter {
 
-Network::FilterStatus Echo::onData(Buffer::Instance& data, bool end_stream) {
+Network::FilterStatus Echo::onData(Buffer::Instance& data, bool) {
   ENVOY_CONN_LOG(trace, "echo: got {} bytes", read_callbacks_->connection(), data.length());
-  read_callbacks_->connection().write(data, end_stream);
+  read_callbacks_->connection().write(data, false);
   ASSERT(0 == data.length());
   return Network::FilterStatus::StopIteration;
 }

--- a/source/common/filter/echo.h
+++ b/source/common/filter/echo.h
@@ -13,7 +13,7 @@ namespace Filter {
 class Echo : public Network::ReadFilter, Logger::Loggable<Logger::Id::filter> {
 public:
   // Network::ReadFilter
-  Network::FilterStatus onData(Buffer::Instance& data, bool end_stream) override;
+  Network::FilterStatus onData(Buffer::Instance& data, bool) override;
   Network::FilterStatus onNewConnection() override { return Network::FilterStatus::Continue; }
   void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override {
     read_callbacks_ = &callbacks;

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -432,7 +432,6 @@ void ConnectionImpl::onReadReady() {
   // If this connection doesn't have half-close semantics, translate end_stream into
   // a connection close.
   if ((!enable_half_close_ && result.end_stream_read_)) {
-    result.end_stream_read_ = false;
     result.action_ = PostIoAction::Close;
   }
 

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -201,6 +201,7 @@ public:
         .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
           upstream_connection_ = std::move(conn);
           upstream_connection_->addConnectionCallbacks(upstream_callbacks_);
+          upstream_connection_->addReadFilter(std::make_shared<NiceMock<Network::MockReadFilter>>());
 
           expected_callbacks--;
           if (expected_callbacks == 0) {

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -201,7 +201,8 @@ public:
         .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
           upstream_connection_ = std::move(conn);
           upstream_connection_->addConnectionCallbacks(upstream_callbacks_);
-          upstream_connection_->addReadFilter(std::make_shared<NiceMock<Network::MockReadFilter>>());
+          upstream_connection_->addReadFilter(
+              std::make_shared<NiceMock<Network::MockReadFilter>>());
 
           expected_callbacks--;
           if (expected_callbacks == 0) {

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -245,7 +245,7 @@ private:
       try {
         parent_.codec_->dispatch(data);
       } catch (Http::CodecProtocolException& e) {
-        ASSERT(end_stream);
+        EXPECT_TRUE(end_stream);
         parent_.connection_.close(Network::ConnectionCloseType::NoFlush);
       }
       return Network::FilterStatus::StopIteration;

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -1184,8 +1184,8 @@ void HttpIntegrationTest::testUpstreamProtocolError() {
   // be fixed.
   fake_upstream_connection->waitForData(187);
   fake_upstream_connection->write("bad protocol data!");
-  fake_upstream_connection->waitForDisconnect();
   codec_client_->waitForDisconnect();
+  fake_upstream_connection->waitForDisconnect();
 
   EXPECT_TRUE(response_->complete());
   EXPECT_STREQ("503", response_->headers().Status()->value().c_str());


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <zlizan@google.com>

*Description*:

Read filters doesn't always have control over underlying connections whether it is half-close aware. Deliver onData with end_stream if it is possible.

Split from #2743.

*Risk Level*: Medium

*Testing*:
unit test, integration test

*Docs Changes*:
N/A

*Release Notes*:
N/A