### PR TITLE
configs: Change IP address of admin server in Google example to 127.0.0.1

### DIFF
--- a/configs/google_com_proxy.v2.yaml
+++ b/configs/google_com_proxy.v2.yaml
@@ -1,7 +1,7 @@
 admin:
   access_log_path: /tmp/admin_access.log
   address:
-    socket_address: { address: 0.0.0.0, port_value: 9901 }
+    socket_address: { address: 127.0.0.1, port_value: 9901 }
 
 static_resources:
   listeners:


### PR DESCRIPTION
Signed-off-by: Francis Upton IV <francisu@gmail.com>

*Risk Level*: Low

*Testing*:
Ran the example using this file.

*Docs Changes*:
https://github.com/envoyproxy/data-plane-api/pull/548

*Release Notes*:
NA