### PR TITLE
Expand the namespaces of the SINGLETON_MANAGER_REGISTRATION macro.

### DIFF
--- a/include/envoy/singleton/manager.h
+++ b/include/envoy/singleton/manager.h
@@ -42,10 +42,10 @@ public:
  * SINGLETON_MANAGER_REGISTERED_NAME macro to access the name registered with the
  * singleton manager.
  */
-#define SINGLETON_MANAGER_REGISTRATION(NAME)                                                         \
-  static constexpr char NAME##_singleton_name[] = #NAME "_singleton";                                \
-  static Envoy::Registry::RegisterFactory<Envoy::Singleton::RegistrationImpl<NAME##_singleton_name>, \
-                                          Envoy::Singleton::Registration>                            \
+#define SINGLETON_MANAGER_REGISTRATION(NAME)                                                       \
+  static constexpr char NAME##_singleton_name[] = #NAME "_singleton";                              \
+  static Envoy::Registry::RegisterFactory<                                                         \
+      Envoy::Singleton::RegistrationImpl<NAME##_singleton_name>, Envoy::Singleton::Registration>   \
       NAME##_singleton_registered_;
 
 #define SINGLETON_MANAGER_REGISTERED_NAME(NAME) NAME##_singleton_name

--- a/include/envoy/singleton/manager.h
+++ b/include/envoy/singleton/manager.h
@@ -42,10 +42,10 @@ public:
  * SINGLETON_MANAGER_REGISTERED_NAME macro to access the name registered with the
  * singleton manager.
  */
-#define SINGLETON_MANAGER_REGISTRATION(NAME)                                                       \
-  static constexpr char NAME##_singleton_name[] = #NAME "_singleton";                              \
-  static Registry::RegisterFactory<Singleton::RegistrationImpl<NAME##_singleton_name>,             \
-                                   Singleton::Registration>                                        \
+#define SINGLETON_MANAGER_REGISTRATION(NAME)                                                         \
+  static constexpr char NAME##_singleton_name[] = #NAME "_singleton";                                \
+  static Envoy::Registry::RegisterFactory<Envoy::Singleton::RegistrationImpl<NAME##_singleton_name>, \
+                                          Envoy::Singleton::Registration>                            \
       NAME##_singleton_registered_;
 
 #define SINGLETON_MANAGER_REGISTERED_NAME(NAME) NAME##_singleton_name


### PR DESCRIPTION
This allows the use of the macro in build environments that do not allow
"using namespace".

Risk Level: Low
