### PR TITLE
Docker: Improve Published Docker Images

### DIFF
--- a/ci/Dockerfile-envoy-alpine
+++ b/ci/Dockerfile-envoy-alpine
@@ -14,4 +14,4 @@ ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
 EXPOSE 10000
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD [ "/usr/local/bin/envoy", "--v2-config-only", "-l", "${loglevel}", "-c", "/etc/envoy/envoy.yaml" ]
+CMD /usr/local/bin/envoy --v2-config-only -l $loglevel -c /etc/envoy/envoy.yaml

--- a/ci/Dockerfile-envoy-alpine
+++ b/ci/Dockerfile-envoy-alpine
@@ -1,3 +1,17 @@
 FROM frolvlad/alpine-glibc
 
-ADD build_release_stripped/envoy /usr/local/bin/envoy
+ENV loglevel=info
+
+RUN apk upgrade --update-cache \
+    && apk add dumb-init \
+    && rm -rf /var/cache/apk/*
+
+RUN mkdir -p /etc/envoy
+
+ADD build_release/envoy /usr/local/bin/envoy
+ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
+
+EXPOSE 10000
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD [ "/usr/local/bin/envoy", "--v2-config-only", "-l", "${loglevel}", "-c", "/etc/envoy/envoy.yaml" ]

--- a/ci/Dockerfile-envoy-alpine
+++ b/ci/Dockerfile-envoy-alpine
@@ -8,7 +8,7 @@ RUN apk upgrade --update-cache \
 
 RUN mkdir -p /etc/envoy
 
-ADD build_release/envoy /usr/local/bin/envoy
+ADD build_release_stripped/envoy /usr/local/bin/envoy
 ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
 
 EXPOSE 10000

--- a/ci/Dockerfile-envoy-alpine-debug
+++ b/ci/Dockerfile-envoy-alpine-debug
@@ -1,3 +1,17 @@
 FROM frolvlad/alpine-glibc
 
-ADD build_release/envoy /usr/local/bin/envoy
+ENV loglevel=info
+
+RUN apk upgrade --update-cache \
+    && apk add dumb-init \
+    && rm -rf /var/cache/apk/*
+
+RUN mkdir -p /etc/envoy
+
+ADD build_release_stripped/envoy /usr/local/bin/envoy
+ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
+
+EXPOSE 10000
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD [ "/usr/local/bin/envoy", "--v2-config-only", "-l", "${loglevel}", "-c", "/etc/envoy/envoy.yaml" ]

--- a/ci/Dockerfile-envoy-alpine-debug
+++ b/ci/Dockerfile-envoy-alpine-debug
@@ -8,7 +8,7 @@ RUN apk upgrade --update-cache \
 
 RUN mkdir -p /etc/envoy
 
-ADD build_release_stripped/envoy /usr/local/bin/envoy
+ADD build_release/envoy /usr/local/bin/envoy
 ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
 
 EXPOSE 10000

--- a/ci/Dockerfile-envoy-alpine-debug
+++ b/ci/Dockerfile-envoy-alpine-debug
@@ -14,4 +14,4 @@ ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
 EXPOSE 10000
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD [ "/usr/local/bin/envoy", "--v2-config-only", "-l", "${loglevel}", "-c", "/etc/envoy/envoy.yaml" ]
+CMD /usr/local/bin/envoy --v2-config-only -l $loglevel -c /etc/envoy/envoy.yaml

--- a/ci/Dockerfile-envoy-image
+++ b/ci/Dockerfile-envoy-image
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-ARG diversion=1.2.1
+ARG dumbinit_version=1.2.1
 ENV loglevel=info
 
 RUN apt-get update \
@@ -12,8 +12,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 
-RUN wget https://github.com/Yelp/dumb-init/releases/download/v${diversion}/dumb-init_${diversion}_amd64.deb \
-    && dpkg -i dumb-init_${diversion}_amd64.deb
+RUN wget https://github.com/Yelp/dumb-init/releases/download/v${dumbinit_version}/dumb-init_${dumbinit_version}_amd64.deb \
+    && dpkg -i dumb-init_${dumbinit_version}_amd64.deb
 
 RUN mkdir -p /etc/envoy
 

--- a/ci/Dockerfile-envoy-image
+++ b/ci/Dockerfile-envoy-image
@@ -23,4 +23,4 @@ ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
 EXPOSE 10000
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD [ "/usr/local/bin/envoy", "--v2-config-only", "-l", "${loglevel}", "-c", "/etc/envoy/envoy.yaml" ]
+CMD /usr/local/bin/envoy --v2-config-only -l $loglevel -c /etc/envoy/envoy.yaml

--- a/ci/Dockerfile-envoy-image
+++ b/ci/Dockerfile-envoy-image
@@ -1,3 +1,26 @@
 FROM ubuntu:16.04
 
+ARG diversion=1.2.1
+ENV loglevel=info
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y wget ca-certificates \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /tmp/* /var/tmp/* \
+    && rm -rf /var/lib/apt/lists/*
+
+
+RUN wget https://github.com/Yelp/dumb-init/releases/download/v${diversion}/dumb-init_${diversion}_amd64.deb \
+    && dpkg -i dumb-init_${diversion}_amd64.deb
+
+RUN mkdir -p /etc/envoy
+
 ADD build_release_stripped/envoy /usr/local/bin/envoy
+ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
+
+EXPOSE 10000
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD [ "/usr/local/bin/envoy", "--v2-config-only", "-l", "${loglevel}", "-c", "/etc/envoy/envoy.yaml" ]


### PR DESCRIPTION
*title*: Improve Published Docker Images
This is an initial update to the docker images that are created
and published to hub.dockerhub.com.

The purpose is to provide users with an image that can be ready
to run from the moment they issue docker pull.

ref: #2805 

Signed-off-by: Nicholas Johns <nicholas.a.johns5@gmail.com>
