### PR TITLE
Revert "configs: Google example remove dns_lookup_family (#2844)"

### DIFF
--- a/configs/google_com_proxy.v2.yaml
+++ b/configs/google_com_proxy.v2.yaml
@@ -27,6 +27,8 @@ static_resources:
   - name: service_google
     connect_timeout: 0.25s
     type: LOGICAL_DNS
+    # Comment out the following line to test on v6 networks
+    dns_lookup_family: V4_ONLY
     lb_policy: ROUND_ROBIN
     hosts: [{ socket_address: { address: google.com, port_value: 443 }}]
     tls_context: { sni: www.google.com }


### PR DESCRIPTION
This reverts commit 2c78cde82a85a2630d51f9a6c42e872209ee5bea.

This is still an issue per https://github.com/envoyproxy/envoy/issues/2853