### PR TITLE
bug_fix_gzip: skip compression when accept-encoding in not present in the request headers

### DIFF
--- a/source/common/http/filter/gzip_filter.cc
+++ b/source/common/http/filter/gzip_filter.cc
@@ -189,7 +189,7 @@ bool GzipFilter::isAcceptEncodingAllowed(HeaderMap& headers) const {
     // if neither identity nor gzip codings are present, we return the wildcard.
     return is_wildcard;
   }
-
+  // if no accept-encoding header is present, return false.
   return false;
 }
 

--- a/source/common/http/filter/gzip_filter.cc
+++ b/source/common/http/filter/gzip_filter.cc
@@ -186,10 +186,10 @@ bool GzipFilter::isAcceptEncodingAllowed(HeaderMap& headers) const {
         is_wildcard = !StringUtil::caseCompare(q_value, ZeroQvalueString);
       }
     }
-    // if neither identity nor gzip codings are present, we return the wildcard.
+    // If neither identity nor gzip codings are present, we return the wildcard.
     return is_wildcard;
   }
-  // if no accept-encoding header is present, return false.
+  // If no accept-encoding header is present, return false.
   return false;
 }
 

--- a/source/common/http/filter/gzip_filter.cc
+++ b/source/common/http/filter/gzip_filter.cc
@@ -190,7 +190,7 @@ bool GzipFilter::isAcceptEncodingAllowed(HeaderMap& headers) const {
     return is_wildcard;
   }
 
-  return true;
+  return false;
 }
 
 bool GzipFilter::isContentTypeAllowed(HeaderMap& headers) const {

--- a/test/common/http/filter/gzip_filter_test.cc
+++ b/test/common/http/filter/gzip_filter_test.cc
@@ -193,7 +193,7 @@ TEST_F(GzipFilterTest, isAcceptEncodingAllowed) {
   }
   {
     TestHeaderMapImpl headers = {};
-    EXPECT_TRUE(isAcceptEncodingAllowed(headers));
+    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
   }
   {
     TestHeaderMapImpl headers = {{"accept-encoding", "identity, *;q=0"}};


### PR DESCRIPTION
*Description*: This PR fixes https://github.com/envoyproxy/envoy/issues/2855. Before this change, gzip filter was compressing content even when `accept-encoding` was not present in the request headers.
  
*Risk Level*: Low

*Testing*: unit test

Signed-off-by: Gabriel <gsagula@gmail.com>
