### PR TITLE
base64: add base64url support

### DIFF
--- a/source/common/common/base64.cc
+++ b/source/common/common/base64.cc
@@ -6,12 +6,15 @@
 #include "common/common/empty_string.h"
 
 namespace Envoy {
-static constexpr char CHAR_TABLE[] =
+namespace {
+
+// clang-format off
+constexpr char CHAR_TABLE[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 // Conversion table is taken from
 // https://opensource.apple.com/source/QuickTimeStreamingServer/QuickTimeStreamingServer-452/CommonUtilitiesLib/base64.c
-static const unsigned char REVERSE_LOOKUP_TABLE[256] = {
+constexpr unsigned char REVERSE_LOOKUP_TABLE[256] = {
     64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
     64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63,
     52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64, 64, 0,  1,  2,  3,  4,  5,  6,
@@ -24,116 +27,147 @@ static const unsigned char REVERSE_LOOKUP_TABLE[256] = {
     64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
     64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64};
 
-std::string Base64::decode(const std::string& input) {
-  if (input.length() % 4 || input.empty()) {
-    return EMPTY_STRING;
+constexpr char URL_CHAR_TABLE[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+constexpr unsigned char URL_REVERSE_LOOKUP_TABLE[256] = {
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64,
+    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64, 64, 0,  1,  2,  3,  4,  5,  6,
+    7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64, 63,
+    64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
+    49, 50, 51, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64};
+// clang-format on
+
+inline bool decodeBase(const uint8_t cur_char, uint64_t pos, std::string& ret,
+                       const unsigned char* const reverse_lookup_table) {
+  const unsigned char c = reverse_lookup_table[static_cast<uint32_t>(cur_char)];
+  if (c == 64) {
+    // Invalid character
+    return false;
   }
 
-  // First position of "valid" padding character.
-  uint64_t first_padding_index = input.length();
-  int max_length = input.length() / 4 * 3;
-  // At most last two chars can be '='.
-  if (input[input.length() - 1] == '=') {
-    max_length--;
-    first_padding_index = input.length() - 1;
-    if (input[input.length() - 2] == '=') {
-      max_length--;
-      first_padding_index = input.length() - 2;
-    }
+  switch (pos % 4) {
+  case 0:
+    ret.push_back(c << 2);
+    break;
+  case 1:
+    ret.back() |= c >> 4;
+    ret.push_back(c << 4);
+    break;
+  case 2:
+    ret.back() |= c >> 2;
+    ret.push_back(c << 6);
+    break;
+  case 3:
+    ret.back() |= c;
+    break;
   }
-  std::string result;
-  result.reserve(max_length);
-
-  uint64_t bytes_left = input.length();
-  uint64_t cur_read = 0;
-
-  // Read input string by group of 4 chars, length of input string must be divided evenly by 4.
-  // Decode 4 chars 6 bits each into 3 chars 8 bits each.
-  while (bytes_left > 0) {
-    // Take first 6 bits from 1st converted char and first 2 bits from 2nd converted char,
-    // make 8 bits char from it.
-    // Use conversion table to map char to decoded value (value is between 0 and 63 inclusive for a
-    // valid character).
-    const unsigned char a = REVERSE_LOOKUP_TABLE[static_cast<uint32_t>(input[cur_read])];
-    const unsigned char b = REVERSE_LOOKUP_TABLE[static_cast<uint32_t>(input[cur_read + 1])];
-    if (a == 64 || b == 64) {
-      // Input contains an invalid character.
-      return EMPTY_STRING;
-    }
-    result.push_back(a << 2 | b >> 4);
-    const unsigned char c = REVERSE_LOOKUP_TABLE[static_cast<uint32_t>(input[cur_read + 2])];
-
-    // Decoded value 64 means invalid character unless we already know it is a valid padding.
-    // If so, following characters are all padding.
-    // Also we should check there are no unused bits.
-    if (c == 64) {
-      if (first_padding_index != cur_read + 2) {
-        // Input contains an invalid character.
-        return EMPTY_STRING;
-      } else if (b & 0b1111) {
-        // There are unused bits at tail.
-        return EMPTY_STRING;
-      } else {
-        return result;
-      }
-    }
-    // Take last 4 bits from 2nd converted char and 4 first bits from 3rd converted char.
-    result.push_back(b << 4 | c >> 2);
-
-    const unsigned char d = REVERSE_LOOKUP_TABLE[static_cast<uint32_t>(input[cur_read + 3])];
-    if (d == 64) {
-      if (first_padding_index != cur_read + 3) {
-        // Input contains an invalid character.
-        return EMPTY_STRING;
-      } else if (c & 0b11) {
-        // There are unused bits at tail.
-        return EMPTY_STRING;
-      } else {
-        return result;
-      }
-    }
-    // Take last 2 bits from 3rd converted char and all(6) bits from 4th converted char.
-    result.push_back(c << 6 | d);
-
-    cur_read += 4;
-    bytes_left -= 4;
-  }
-
-  return result;
+  return true;
 }
 
-void Base64::encodeBase(const uint8_t cur_char, uint64_t pos, uint8_t& next_c, std::string& ret) {
+inline bool decodeLast(const uint8_t cur_char, uint64_t pos, std::string& ret,
+                       const unsigned char* const reverse_lookup_table) {
+  const unsigned char c = reverse_lookup_table[static_cast<uint32_t>(cur_char)];
+  if (c == 64) {
+    // Invalid character
+    return false;
+  }
+
+  switch (pos % 4) {
+  case 0:
+    return false;
+  case 1:
+    ret.back() |= c >> 4;
+    return (c & 0b1111) == 0;
+  case 2:
+    ret.back() |= c >> 2;
+    return (c & 0b11) == 0;
+  case 3:
+    ret.back() |= c;
+    break;
+  }
+  return true;
+}
+
+inline void encodeBase(const uint8_t cur_char, uint64_t pos, uint8_t& next_c, std::string& ret,
+                       const char* const char_table) {
   switch (pos % 3) {
   case 0:
-    ret.push_back(CHAR_TABLE[cur_char >> 2]);
+    ret.push_back(char_table[cur_char >> 2]);
     next_c = (cur_char & 0x03) << 4;
     break;
   case 1:
-    ret.push_back(CHAR_TABLE[next_c | (cur_char >> 4)]);
+    ret.push_back(char_table[next_c | (cur_char >> 4)]);
     next_c = (cur_char & 0x0f) << 2;
     break;
   case 2:
-    ret.push_back(CHAR_TABLE[next_c | (cur_char >> 6)]);
-    ret.push_back(CHAR_TABLE[cur_char & 0x3f]);
+    ret.push_back(char_table[next_c | (cur_char >> 6)]);
+    ret.push_back(char_table[cur_char & 0x3f]);
     next_c = 0;
     break;
   }
 }
 
-void Base64::encodeLast(uint64_t pos, uint8_t last_char, std::string& ret) {
+inline void encodeLast(uint64_t pos, uint8_t last_char, std::string& ret,
+                       const char* const char_table, bool add_padding) {
   switch (pos % 3) {
   case 1:
-    ret.push_back(CHAR_TABLE[last_char]);
-    ret.push_back('=');
-    ret.push_back('=');
+    ret.push_back(char_table[last_char]);
+    if (add_padding) {
+      ret.push_back('=');
+      ret.push_back('=');
+    }
     break;
   case 2:
-    ret.push_back(CHAR_TABLE[last_char]);
-    ret.push_back('=');
+    ret.push_back(char_table[last_char]);
+    if (add_padding) {
+      ret.push_back('=');
+    }
     break;
   default:
     break;
   }
+}
+
+} // namespace
+
+std::string Base64::decode(const std::string& input) {
+  if (input.length() % 4 || input.empty()) {
+    return EMPTY_STRING;
+  }
+
+  // Last position before "valid" padding character.
+  uint64_t last = input.length() - 1;
+  size_t max_length = input.length() / 4 * 3;
+  // At most last two chars can be '='.
+  if (input[input.length() - 1] == '=') {
+    max_length--;
+    last = input.length() - 2;
+    if (input[input.length() - 2] == '=') {
+      max_length--;
+      last = input.length() - 3;
+    }
+  }
+
+  std::string ret;
+  ret.reserve(max_length);
+  for (uint64_t i = 0; i < last; ++i) {
+    if (!decodeBase(input[i], i, ret, REVERSE_LOOKUP_TABLE)) {
+      return EMPTY_STRING;
+    }
+  }
+
+  if (!decodeLast(input[last], last, ret, REVERSE_LOOKUP_TABLE)) {
+    return EMPTY_STRING;
+  }
+
+  return ret;
 }
 
 std::string Base64::encode(const Buffer::Instance& buffer, uint64_t length) {
@@ -151,7 +185,7 @@ std::string Base64::encode(const Buffer::Instance& buffer, uint64_t length) {
     const uint8_t* slice_mem = static_cast<const uint8_t*>(slice.mem_);
 
     for (uint64_t i = 0; i < slice.len_ && j < length; ++i, ++j) {
-      encodeBase(slice_mem[i], j, next_c, ret);
+      encodeBase(slice_mem[i], j, next_c, ret, CHAR_TABLE);
     }
 
     if (j == length) {
@@ -159,7 +193,7 @@ std::string Base64::encode(const Buffer::Instance& buffer, uint64_t length) {
     }
   }
 
-  encodeLast(j, next_c, ret);
+  encodeLast(j, next_c, ret, CHAR_TABLE, true);
 
   return ret;
 }
@@ -173,11 +207,51 @@ std::string Base64::encode(const char* input, uint64_t length) {
   uint8_t next_c = 0;
 
   for (uint64_t i = 0; i < length; ++i) {
-    encodeBase(input[i], pos++, next_c, ret);
+    encodeBase(input[i], pos++, next_c, ret, CHAR_TABLE);
   }
 
-  encodeLast(pos, next_c, ret);
+  encodeLast(pos, next_c, ret, CHAR_TABLE, true);
 
   return ret;
 }
+
+std::string Base64Url::decode(const std::string& input) {
+  if (input.empty()) {
+    return EMPTY_STRING;
+  }
+
+  std::string ret;
+  ret.reserve(input.length() / 4 * 3 + 3);
+
+  uint64_t last = input.length() - 1;
+  for (uint64_t i = 0; i < last; ++i) {
+    if (!decodeBase(input[i], i, ret, URL_REVERSE_LOOKUP_TABLE)) {
+      return EMPTY_STRING;
+    }
+  }
+
+  if (!decodeLast(input[last], last, ret, URL_REVERSE_LOOKUP_TABLE)) {
+    return EMPTY_STRING;
+  }
+
+  return ret;
+}
+
+std::string Base64Url::encode(const char* input, uint64_t length) {
+  uint64_t output_length = (length + 2) / 3 * 4;
+  std::string ret;
+  ret.reserve(output_length);
+
+  uint64_t pos = 0;
+  uint8_t next_c = 0;
+
+  for (uint64_t i = 0; i < length; ++i) {
+    encodeBase(input[i], pos++, next_c, ret, URL_CHAR_TABLE);
+  }
+
+  encodeLast(pos, next_c, ret, URL_CHAR_TABLE, false);
+
+  return ret;
+}
+
 } // namespace Envoy

--- a/source/common/common/base64.cc
+++ b/source/common/common/base64.cc
@@ -27,6 +27,8 @@ constexpr unsigned char REVERSE_LOOKUP_TABLE[256] = {
     64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
     64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64};
 
+// The base64url tables are copied from above and modified based on table in
+// https://tools.ietf.org/html/rfc4648#section-5
 constexpr char URL_CHAR_TABLE[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 

--- a/source/common/common/base64.h
+++ b/source/common/common/base64.h
@@ -6,6 +6,11 @@
 #include "envoy/buffer/buffer.h"
 
 namespace Envoy {
+
+/**
+ * A utility class to support base64 encoding, which is defined in RFC4648 Section 4.
+ * See https://tools.ietf.org/html/rfc4648#section-4
+ */
 class Base64 {
 public:
   /**
@@ -23,7 +28,7 @@ public:
   static std::string encode(const char* input, uint64_t length);
 
   /**
-   * Base64 decode an input string.
+   * Base64 decode an input string. Padding is required.
    * @param input supplies the input to decode.
    *
    * Note, decoded string may contain '\0' at any position, it should be treated as a sequence of
@@ -32,6 +37,10 @@ public:
   static std::string decode(const std::string& input);
 };
 
+/**
+ * A utility class to support base64url encoding, which is defined in RFC4648 Section 5.
+ * See https://tools.ietf.org/html/rfc4648#section-5
+ */
 class Base64Url {
 public:
   /**
@@ -42,7 +51,7 @@ public:
   static std::string encode(const char* input, uint64_t length);
 
   /**
-   * Base64url decode an input string.
+   * Base64url decode an input string. Padding must not be included in the input.
    * @param input supplies the input to decode.
    *
    * Note, decoded string may contain '\0' at any position, it should be treated as a sequence of

--- a/source/common/common/base64.h
+++ b/source/common/common/base64.h
@@ -30,17 +30,25 @@ public:
    * bytes.
    */
   static std::string decode(const std::string& input);
-
-private:
-  /**
-   * Helper method for encoding. This is used to encode all of the characters from the input string.
-   */
-  static void encodeBase(const uint8_t cur_char, uint64_t pos, uint8_t& next_c, std::string& ret);
-
-  /**
-   * Encode last characters. It appends '=' chars to the ret if input
-   * string length is not divisible by 3.
-   */
-  static void encodeLast(uint64_t pos, uint8_t last_char, std::string& ret);
 };
+
+class Base64Url {
+public:
+  /**
+   * Base64url encode an input char buffer with a given length.
+   * @param input char array to encode.
+   * @param length of the input array.
+   */
+  static std::string encode(const char* input, uint64_t length);
+
+  /**
+   * Base64url decode an input string.
+   * @param input supplies the input to decode.
+   *
+   * Note, decoded string may contain '\0' at any position, it should be treated as a sequence of
+   * bytes.
+   */
+  static std::string decode(const std::string& input);
+};
+
 } // namespace Envoy

--- a/test/common/common/base64_test.cc
+++ b/test/common/common/base64_test.cc
@@ -159,8 +159,8 @@ TEST(Base64UrlTest, DecodeFailure) {
   EXPECT_EQ("", Base64Url::decode("Zg.."));
   EXPECT_EQ("", Base64Url::decode("..Zg"));
   EXPECT_EQ("", Base64Url::decode("A==="));
-  EXPECT_EQ("", Base64Url::decode("Zh"));   // 011001 100001 <- unused bit at tail
-  EXPECT_EQ("", Base64Url::decode("Zm9"));  // 011001 100110 111101 <- unused bit at tail
+  EXPECT_EQ("", Base64Url::decode("Zh"));  // 011001 100001 <- unused bit at tail
+  EXPECT_EQ("", Base64Url::decode("Zm9")); // 011001 100110 111101 <- unused bit at tail
   EXPECT_EQ("", Base64Url::decode("A"));
 }
 } // namespace Envoy

--- a/test/common/common/base64_test.cc
+++ b/test/common/common/base64_test.cc
@@ -108,4 +108,59 @@ TEST(Base64Test, BinaryBufferEncode) {
   EXPECT_EQ("AAECAwgKCQCqvA==", Base64::encode(buffer, 10));
   EXPECT_EQ("AAECAwgKCQCqvN4=", Base64::encode(buffer, 30));
 }
+
+TEST(Base64UrlTest, EncodeString) {
+  EXPECT_EQ("", Base64Url::encode("", 0));
+  EXPECT_EQ("AAA", Base64Url::encode("\0\0", 2));
+  EXPECT_EQ("Zm9v", Base64Url::encode("foo", 3));
+  EXPECT_EQ("Zm8", Base64Url::encode("fo", 2));
+}
+
+TEST(Base64UrlTest, Decode) {
+  EXPECT_EQ("", Base64Url::decode(""));
+  EXPECT_EQ("foo", Base64Url::decode("Zm9v"));
+  EXPECT_EQ("fo", Base64Url::decode("Zm8"));
+  EXPECT_EQ("f", Base64Url::decode("Zg"));
+  EXPECT_EQ("foobar", Base64Url::decode("Zm9vYmFy"));
+  EXPECT_EQ("foob", Base64Url::decode("Zm9vYg"));
+
+  {
+    const char* test_string = "\0\1\2\3\b\n\t";
+    EXPECT_FALSE(memcmp(test_string, Base64Url::decode("AAECAwgKCQ").data(), 7));
+  }
+
+  {
+    const char* test_string = "\0\0\0\0als;jkopqitu[\0opbjlcxnb35g]b[\xaa\b\n";
+    EXPECT_FALSE(
+        memcmp(test_string, Base64Url::decode(Base64Url::encode(test_string, 36)).data(), 36));
+  }
+
+  {
+    const char* test_string = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    std::string decoded = Base64Url::decode(test_string);
+    EXPECT_EQ(test_string, Base64Url::encode(decoded.c_str(), decoded.length()));
+  }
+
+  {
+    const char* url_test_string =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    const char* test_string = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    EXPECT_EQ(Base64Url::decode(url_test_string), Base64::decode(test_string));
+  }
+}
+
+TEST(Base64UrlTest, DecodeFailure) {
+  EXPECT_EQ("", Base64Url::decode("==Zg"));
+  EXPECT_EQ("", Base64Url::decode("=Zm8"));
+  EXPECT_EQ("", Base64Url::decode("Zm=8"));
+  EXPECT_EQ("", Base64Url::decode("Zg=A"));
+  EXPECT_EQ("", Base64Url::decode("Zh==")); // 011001 100001 <- unused bit at tail
+  EXPECT_EQ("", Base64Url::decode("Zm9=")); // 011001 100110 111101 <- unused bit at tail
+  EXPECT_EQ("", Base64Url::decode("Zg.."));
+  EXPECT_EQ("", Base64Url::decode("..Zg"));
+  EXPECT_EQ("", Base64Url::decode("A==="));
+  EXPECT_EQ("", Base64Url::decode("Zh"));   // 011001 100001 <- unused bit at tail
+  EXPECT_EQ("", Base64Url::decode("Zm9"));  // 011001 100110 111101 <- unused bit at tail
+  EXPECT_EQ("", Base64Url::decode("A"));
+}
 } // namespace Envoy


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <zlizan@google.com>

*Description*:
Add [base64url](https://tools.ietf.org/html/rfc4648#section-5) support in common utils, this is a dependency of JWT #2514 support.
*Risk Level*: Low
*Testing*: unit test
*Docs Changes*: N/A
*Release Notes*: N/A