### PR TITLE
test: Allow filters before http connection manager.

### DIFF
--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -107,8 +107,8 @@ private:
       const envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager&
           hcm);
 
-  // Snags the first filter from the first filter chain from the first listener.
-  envoy::api::v2::listener::Filter* getFilterFromListener();
+  // Finds the filter named 'name' from the first filter chain from the first listener.
+  envoy::api::v2::listener::Filter* getFilterFromListener(const std::string& name);
 
   // The bootstrap proto Envoy will start up with.
   envoy::config::bootstrap::v2::Bootstrap bootstrap_;


### PR DESCRIPTION
Integration tests assume the http connection manager is the first
filter. Relax this and allow other filters appear before the http
connection manager.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
Risk Level: Low
