### PR TITLE
Fix EXPECT_TRUE(string.find(...)) usage

### DIFF
--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -191,7 +191,8 @@ TEST_P(AdminInstanceTest, EscapeHelpTextWithPunctuation) {
   Buffer::OwnedImpl response;
   EXPECT_EQ(Http::Code::OK, admin_.runCallback("/", header_map, response));
   Http::HeaderString& content_type = header_map.ContentType()->value();
-  EXPECT_TRUE(content_type.find("text/html")) << content_type.c_str();
+  EXPECT_THAT(content_type, testing::HasSubstr("text/html"))
+      << content_type.c_str();
   EXPECT_EQ(-1, response.search(planets.data(), planets.size(), 0));
   const std::string escaped_planets = "jupiter&gt;saturn&gt;mars";
   EXPECT_NE(-1, response.search(escaped_planets.data(), escaped_planets.size(), 0));


### PR DESCRIPTION
`EXPECT_TRUE(haystack.find(needle))` looks like it means 'verify `haystack` contains `needle`' but it actually executes 'verify `haystack` does not begin with `needle`'.

*Risk Level*: Low

*Testing*: none

*Docs Changes*: N/A

*Release Notes*: N/A