### PR TITLE
Add a --config-yaml flag to pass the full bootstrap to Envoy

### DIFF
--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -70,6 +70,12 @@ public:
   virtual const std::string& configPath() PURE;
 
   /**
+   * @return const std::string& an inline YAML bootstrap config that merges
+   *                            into the config loaded in configPath().
+   */
+  virtual const std::string& configYaml() PURE;
+
+  /**
    * @return bool whether the config should only be parsed as v2. If false, when a v2 parse fails,
    *              a second attempt to parse the config as v1 will be made.
    */

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -163,6 +163,12 @@ public:
     validate(message);
   }
 
+  template <class MessageType>
+  static void loadFromYamlAndValidate(const std::string& yaml, MessageType& message) {
+    loadFromYaml(yaml, message);
+    validate(message);
+  }
+
   /**
    * Downcast and validate protoc-gen-validate constraints on a given protobuf.
    * Note the corresponding `.pb.validate.h` for the message has to be included in the source file

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -65,7 +65,7 @@ void ValidationInstance::initialize(Options& options,
   // be ready to serve, then the config has passed validation.
   // Handle configuration that needs to take place prior to the main configuration load.
   envoy::config::bootstrap::v2::Bootstrap bootstrap;
-  InstanceUtil::loadBootstrapConfig(bootstrap, options.configPath(), options.v2ConfigOnly());
+  InstanceUtil::loadBootstrapConfig(bootstrap, options);
 
   Config::Utility::createTagProducer(bootstrap);
 

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -48,6 +48,9 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_r
                                         std::thread::hardware_concurrency(), "uint32_t", cmd);
   TCLAP::ValueArg<std::string> config_path("c", "config-path", "Path to configuration file", false,
                                            "", "string", cmd);
+  TCLAP::ValueArg<std::string> config_yaml(
+      "", "config-yaml", "Inline YAML configuration, merges with the contents of --config-path",
+      false, "", "string", cmd);
   TCLAP::SwitchArg v2_config_only("", "v2-config-only", "parse config as v2 only", cmd, false);
   TCLAP::ValueArg<std::string> admin_address_path("", "admin-address-path", "Admin address path",
                                                   false, "", "string", cmd);
@@ -163,6 +166,7 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_r
   base_id_ = base_id.getValue() * 10;
   concurrency_ = concurrency.getValue();
   config_path_ = config_path.getValue();
+  config_yaml_ = config_yaml.getValue();
   v2_config_only_ = v2_config_only.getValue();
   admin_address_path_ = admin_address_path.getValue();
   log_path_ = log_path.getValue();

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -34,6 +34,7 @@ public:
   uint64_t baseId() override { return base_id_; }
   uint32_t concurrency() override { return concurrency_; }
   const std::string& configPath() override { return config_path_; }
+  const std::string& configYaml() override { return config_yaml_; }
   bool v2ConfigOnly() override { return v2_config_only_; }
   const std::string& adminAddressPath() override { return admin_address_path_; }
   Network::Address::IpVersion localAddressIpVersion() override { return local_address_ip_version_; }
@@ -55,6 +56,7 @@ private:
   uint64_t base_id_;
   uint32_t concurrency_;
   std::string config_path_;
+  std::string config_yaml_;
   bool v2_config_only_;
   std::string admin_address_path_;
   Network::Address::IpVersion local_address_ip_version_;

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -95,6 +95,7 @@ public:
    * @param bootstrap supplies the bootstrap to fill.
    * @param config_path supplies the config path.
    * @param v2_only supplies whether to attempt v1 fallback.
+   * @return BootstrapVersion to indicate which version of the API was parsed.
    */
   static BootstrapVersion loadBootstrapConfig(envoy::config::bootstrap::v2::Bootstrap& bootstrap,
                                               Options& options);

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -73,6 +73,8 @@ public:
  */
 class InstanceUtil : Logger::Loggable<Logger::Id::main> {
 public:
+  enum class BootstrapVersion { V1, V2 };
+
   /**
    * Default implementation of runtime loader creation used in the real server and in most
    * integration tests where a mock runtime is not needed.
@@ -94,8 +96,8 @@ public:
    * @param config_path supplies the config path.
    * @param v2_only supplies whether to attempt v1 fallback.
    */
-  static void loadBootstrapConfig(envoy::config::bootstrap::v2::Bootstrap& bootstrap,
-                                  const std::string& config_path, bool v2_only);
+  static BootstrapVersion loadBootstrapConfig(envoy::config::bootstrap::v2::Bootstrap& bootstrap,
+                                              Options& options);
 };
 
 /**

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -85,6 +85,15 @@ public:
   Runtime::RandomGeneratorImpl random_;
 };
 
+void test_merge() {
+  const std::string overlay = "static_resources: { clusters: [{name: 'foo'}]}";
+  Server::TestOptionsImpl options("google_com_proxy.v2.yaml", overlay,
+                                  Network::Address::IpVersion::v6);
+  envoy::config::bootstrap::v2::Bootstrap bootstrap;
+  Server::InstanceUtil::loadBootstrapConfig(bootstrap, options);
+  EXPECT_EQ(2, bootstrap.static_resources().clusters_size());
+}
+
 uint32_t run(const std::string& directory) {
   // Change working directory, otherwise we won't be able to read files using relative paths.
   char cwd[PATH_MAX];
@@ -104,6 +113,9 @@ uint32_t run(const std::string& directory) {
       num_tested++;
     }
   }
+
+  test_merge();
+
   // Return to the original working directory, otherwise "bazel.coverage" breaks (...but why?).
   RELEASE_ASSERT(::chdir(cwd) == 0);
   return num_tested;

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -85,7 +85,7 @@ public:
   Runtime::RandomGeneratorImpl random_;
 };
 
-void test_merge() {
+void testMerge() {
   const std::string overlay = "static_resources: { clusters: [{name: 'foo'}]}";
   Server::TestOptionsImpl options("google_com_proxy.v2.yaml", overlay,
                                   Network::Address::IpVersion::v6);
@@ -95,10 +95,6 @@ void test_merge() {
 }
 
 uint32_t run(const std::string& directory) {
-  // Change working directory, otherwise we won't be able to read files using relative paths.
-  char cwd[PATH_MAX];
-  RELEASE_ASSERT(::getcwd(cwd, PATH_MAX) != nullptr);
-  RELEASE_ASSERT(::chdir(directory.c_str()) == 0);
   uint32_t num_tested = 0;
   for (const std::string& filename : TestUtility::listFiles(directory, false)) {
     Server::TestOptionsImpl options(filename, Network::Address::IpVersion::v6);
@@ -113,11 +109,6 @@ uint32_t run(const std::string& directory) {
       num_tested++;
     }
   }
-
-  test_merge();
-
-  // Return to the original working directory, otherwise "bazel.coverage" breaks (...but why?).
-  RELEASE_ASSERT(::chdir(cwd) == 0);
   return num_tested;
 }
 

--- a/test/config_test/config_test.h
+++ b/test/config_test/config_test.h
@@ -18,5 +18,10 @@ uint32_t run(const std::string& path);
  */
 void testMerge();
 
+/**
+ * Test --config-yaml overlay merge fails with v1.
+ */
+void testIncompatibleMerge();
+
 } // namespace ConfigTest
 } // namespace Envoy

--- a/test/config_test/config_test.h
+++ b/test/config_test/config_test.h
@@ -13,5 +13,10 @@ namespace ConfigTest {
  */
 uint32_t run(const std::string& path);
 
+/**
+ * Test --config-yaml overlay merge.
+ */
+void testMerge();
+
 } // namespace ConfigTest
 } // namespace Envoy

--- a/test/config_test/example_configs_test.cc
+++ b/test/config_test/example_configs_test.cc
@@ -8,6 +8,6 @@ namespace Envoy {
 TEST(ExampleConfigsTest, All) {
   TestEnvironment::exec(
       {TestEnvironment::runfilesPath("test/config_test/example_configs_test_setup.sh")});
-  EXPECT_EQ(26UL, ConfigTest::run(TestEnvironment::temporaryDirectory() + "/test/config_test"));
+  EXPECT_EQ(37UL, ConfigTest::run(TestEnvironment::temporaryDirectory() + "/test/config_test"));
 }
 } // namespace Envoy

--- a/test/config_test/example_configs_test.cc
+++ b/test/config_test/example_configs_test.cc
@@ -17,6 +17,7 @@ TEST(ExampleConfigsTest, All) {
 
   EXPECT_EQ(37UL, ConfigTest::run(directory));
   ConfigTest::testMerge();
+  ConfigTest::testIncompatibleMerge();
 
   // Return to the original working directory, otherwise "bazel.coverage" breaks (...but why?).
   RELEASE_ASSERT(::chdir(cwd) == 0);

--- a/test/config_test/example_configs_test.cc
+++ b/test/config_test/example_configs_test.cc
@@ -8,6 +8,17 @@ namespace Envoy {
 TEST(ExampleConfigsTest, All) {
   TestEnvironment::exec(
       {TestEnvironment::runfilesPath("test/config_test/example_configs_test_setup.sh")});
-  EXPECT_EQ(37UL, ConfigTest::run(TestEnvironment::temporaryDirectory() + "/test/config_test"));
+
+  // Change working directory, otherwise we won't be able to read files using relative paths.
+  char cwd[PATH_MAX];
+  const std::string& directory = TestEnvironment::temporaryDirectory() + "/test/config_test";
+  RELEASE_ASSERT(::getcwd(cwd, PATH_MAX) != nullptr);
+  RELEASE_ASSERT(::chdir(directory.c_str()) == 0);
+
+  EXPECT_EQ(37UL, ConfigTest::run(directory));
+  ConfigTest::testMerge();
+
+  // Return to the original working directory, otherwise "bazel.coverage" breaks (...but why?).
+  RELEASE_ASSERT(::chdir(cwd) == 0);
 }
 } // namespace Envoy

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -4,6 +4,7 @@
 
 #include "envoy/http/header_map.h"
 
+#include "common/filesystem/filesystem_impl.h"
 #include "common/local_info/local_info_impl.h"
 #include "common/network/utility.h"
 #include "common/stats/thread_local_store.h"
@@ -99,4 +100,9 @@ void IntegrationTestServer::threadRoutine(const Network::Address::IpVersion vers
   server_.reset();
   stat_store_ = nullptr;
 }
+
+Server::TestOptionsImpl Server::TestOptionsImpl::asConfigYaml() {
+  return TestOptionsImpl("", Filesystem::fileReadToEnd(config_path_), local_address_ip_version_);
+}
+
 } // namespace Envoy

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -28,7 +28,7 @@ namespace Server {
 class TestOptionsImpl : public Options {
 public:
   TestOptionsImpl(const std::string& config_path, Network::Address::IpVersion ip_version)
-      : config_path_(config_path), config_yaml_(""), local_address_ip_version_(ip_version),
+      : config_path_(config_path), local_address_ip_version_(ip_version),
         service_cluster_name_("cluster_name"), service_node_name_("node_name"),
         service_zone_("zone_name") {}
   TestOptionsImpl(const std::string& config_path, const std::string& config_yaml,

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -28,7 +28,12 @@ namespace Server {
 class TestOptionsImpl : public Options {
 public:
   TestOptionsImpl(const std::string& config_path, Network::Address::IpVersion ip_version)
-      : config_path_(config_path), local_address_ip_version_(ip_version),
+      : config_path_(config_path), config_yaml_(""), local_address_ip_version_(ip_version),
+        service_cluster_name_("cluster_name"), service_node_name_("node_name"),
+        service_zone_("zone_name") {}
+  TestOptionsImpl(const std::string& config_path, const std::string& config_yaml,
+                  Network::Address::IpVersion ip_version)
+      : config_path_(config_path), config_yaml_(config_yaml), local_address_ip_version_(ip_version),
         service_cluster_name_("cluster_name"), service_node_name_("node_name"),
         service_zone_("zone_name") {}
 
@@ -36,6 +41,7 @@ public:
   uint64_t baseId() override { return 0; }
   uint32_t concurrency() override { return 1; }
   const std::string& configPath() override { return config_path_; }
+  const std::string& configYaml() override { return config_yaml_; }
   bool v2ConfigOnly() override { return false; }
   const std::string& adminAddressPath() override { return admin_address_path_; }
   Network::Address::IpVersion localAddressIpVersion() override { return local_address_ip_version_; }
@@ -55,8 +61,12 @@ public:
   uint64_t maxObjNameLength() override { return 60; }
   bool hotRestartDisabled() override { return false; }
 
+  // asConfigYaml returns a new config that empties the configPath() and populates configYaml()
+  Server::TestOptionsImpl asConfigYaml();
+
 private:
   const std::string config_path_;
+  const std::string config_yaml_;
   const std::string admin_address_path_;
   const Network::Address::IpVersion local_address_ip_version_;
   const std::string service_cluster_name_;

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -21,6 +21,7 @@ namespace Server {
 MockOptions::MockOptions(const std::string& config_path)
     : config_path_(config_path), admin_address_path_("") {
   ON_CALL(*this, configPath()).WillByDefault(ReturnRef(config_path_));
+  ON_CALL(*this, configYaml()).WillByDefault(ReturnRef(""));
   ON_CALL(*this, v2ConfigOnly()).WillByDefault(Invoke([this] { return v2_config_only_; }));
   ON_CALL(*this, adminAddressPath()).WillByDefault(ReturnRef(admin_address_path_));
   ON_CALL(*this, serviceClusterName()).WillByDefault(ReturnRef(service_cluster_name_));

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -19,9 +19,9 @@ namespace Envoy {
 namespace Server {
 
 MockOptions::MockOptions(const std::string& config_path)
-    : config_path_(config_path), admin_address_path_("") {
+    : config_path_(config_path), config_yaml_(""), admin_address_path_("") {
   ON_CALL(*this, configPath()).WillByDefault(ReturnRef(config_path_));
-  ON_CALL(*this, configYaml()).WillByDefault(ReturnRef(""));
+  ON_CALL(*this, configYaml()).WillByDefault(ReturnRef(config_yaml_));
   ON_CALL(*this, v2ConfigOnly()).WillByDefault(Invoke([this] { return v2_config_only_; }));
   ON_CALL(*this, adminAddressPath()).WillByDefault(ReturnRef(admin_address_path_));
   ON_CALL(*this, serviceClusterName()).WillByDefault(ReturnRef(service_cluster_name_));

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -18,8 +18,7 @@ using testing::_;
 namespace Envoy {
 namespace Server {
 
-MockOptions::MockOptions(const std::string& config_path)
-    : config_path_(config_path), config_yaml_(""), admin_address_path_("") {
+MockOptions::MockOptions(const std::string& config_path) : config_path_(config_path) {
   ON_CALL(*this, configPath()).WillByDefault(ReturnRef(config_path_));
   ON_CALL(*this, configYaml()).WillByDefault(ReturnRef(config_yaml_));
   ON_CALL(*this, v2ConfigOnly()).WillByDefault(Invoke([this] { return v2_config_only_; }));

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -48,6 +48,7 @@ public:
   MOCK_METHOD0(baseId, uint64_t());
   MOCK_METHOD0(concurrency, uint32_t());
   MOCK_METHOD0(configPath, const std::string&());
+  MOCK_METHOD0(configYaml, const std::string&());
   MOCK_METHOD0(v2ConfigOnly, bool());
   MOCK_METHOD0(adminAddressPath, const std::string&());
   MOCK_METHOD0(localAddressIpVersion, Network::Address::IpVersion());

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -67,6 +67,7 @@ public:
   MOCK_METHOD0(hotRestartDisabled, bool());
 
   std::string config_path_;
+  std::string config_yaml_;
   bool v2_config_only_{};
   std::string admin_address_path_;
   std::string service_cluster_name_;


### PR DESCRIPTION
This removes the need to package a config file with the Envoy binary.

Risk Level: Low

Testing: Unit tests
