### PR TITLE
logger: removed NVLOG compile flag

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -240,12 +240,7 @@ bazel test -c dbg --config=clang-tsan //test/...
 
 ## Log Verbosity
 
-By default, log verbosity is controlled at runtime in all builds. However, it may be desirable to
-remove log statements of lower importance during compilation to enhance performance. To remove
-`trace` and `debug` log statements during compilation define `NVLOG`:
-```
-bazel build --copt=-DNVLOG //source/exe:envoy-static
-```
+Log verbosity is controlled at runtime in all builds. 
 
 ## Disabling optional features
 

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -191,32 +191,24 @@ protected:
  * Base logging macros. It is expected that users will use the convenience macros below rather than
  * invoke these directly.
  */
+
+#define ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)                                                        \
+  (static_cast<spdlog::level::level_enum>(Envoy::Logger::Logger::LEVEL) >= LOGGER.level())
+
 // Compare levels before invoking logger
 #define ENVOY_LOG_COMP_AND_LOG(LOGGER, LEVEL, ...)                                                 \
   do {                                                                                             \
-    if (static_cast<spdlog::level::level_enum>(Envoy::Logger::Logger::LEVEL) >= LOGGER.level()) {  \
+    if (ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                                                     \
       LOGGER.LEVEL(LOG_PREFIX __VA_ARGS__);                                                        \
     }                                                                                              \
   } while (0)
 
-#ifdef NVLOG
-#define ENVOY_LOG_trace_TO_LOGGER(LOGGER, ...)
-#define ENVOY_LOG_debug_TO_LOGGER(LOGGER, ...)
-#else
-#define ENVOY_LOG_trace_TO_LOGGER(LOGGER, ...) ENVOY_LOG_COMP_AND_LOG(LOGGER, trace, ##__VA_ARGS__)
-#define ENVOY_LOG_debug_TO_LOGGER(LOGGER, ...) ENVOY_LOG_COMP_AND_LOG(LOGGER, debug, ##__VA_ARGS__)
-#endif
-
-#define ENVOY_LOG_info_TO_LOGGER(LOGGER, ...) ENVOY_LOG_COMP_AND_LOG(LOGGER, info, ##__VA_ARGS__)
-#define ENVOY_LOG_warn_TO_LOGGER(LOGGER, ...) ENVOY_LOG_COMP_AND_LOG(LOGGER, warn, ##__VA_ARGS__)
-#define ENVOY_LOG_error_TO_LOGGER(LOGGER, ...) ENVOY_LOG_COMP_AND_LOG(LOGGER, error, ##__VA_ARGS__)
-#define ENVOY_LOG_critical_TO_LOGGER(LOGGER, ...)                                                  \
-  ENVOY_LOG_COMP_AND_LOG(LOGGER, critical, ##__VA_ARGS__)
+#define ENVOY_LOG_CHECK_LEVEL(LEVEL) ENVOY_LOG_COMP_LEVEL(ENVOY_LOGGER(), LEVEL)
 
 /**
  * Convenience macro to log to a user-specified logger.
  */
-#define ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ...) ENVOY_LOG_##LEVEL##_TO_LOGGER(LOGGER, ##__VA_ARGS__)
+#define ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ...) ENVOY_LOG_COMP_AND_LOG(LOGGER, LEVEL, ##__VA_ARGS__)
 
 /**
  * Convenience macro to get logger.

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -207,6 +207,9 @@ protected:
 
 /**
  * Convenience macro to log to a user-specified logger.
+ * Maps directly to ENVOY_LOG_COMP_AND_LOG - it could contain macro logic itself, without
+ * redirection, but left in case various implementations are required in the future (based on log
+ * level for example).
  */
 #define ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ...) ENVOY_LOG_COMP_AND_LOG(LOGGER, LEVEL, ##__VA_ARGS__)
 

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -87,15 +87,15 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
 }
 
 void AsyncStreamImpl::encodeHeaders(HeaderMapPtr&& headers, bool end_stream) {
-#ifndef NVLOG
-  ENVOY_LOG(debug, "async http request response headers (end_stream={}):", end_stream);
-  headers->iterate(
-      [](const HeaderEntry& header, void*) -> HeaderMap::Iterate {
-        ENVOY_LOG(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());
-        return HeaderMap::Iterate::Continue;
-      },
-      nullptr);
-#endif
+  if (ENVOY_LOG_CHECK_LEVEL(debug)) {
+    ENVOY_LOG(debug, "async http request response headers (end_stream={}):", end_stream);
+    headers->iterate(
+        [](const HeaderEntry& header, void*) -> HeaderMap::Iterate {
+          ENVOY_LOG(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());
+          return HeaderMap::Iterate::Continue;
+        },
+        nullptr);
+  }
   ASSERT(!remote_closed_);
   stream_callbacks_.onHeaders(std::move(headers), end_stream);
   closeRemote(end_stream);
@@ -110,15 +110,15 @@ void AsyncStreamImpl::encodeData(Buffer::Instance& data, bool end_stream) {
 }
 
 void AsyncStreamImpl::encodeTrailers(HeaderMapPtr&& trailers) {
-#ifndef NVLOG
-  ENVOY_LOG(debug, "async http request response trailers:");
-  trailers->iterate(
-      [](const HeaderEntry& header, void*) -> HeaderMap::Iterate {
-        ENVOY_LOG(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());
-        return HeaderMap::Iterate::Continue;
-      },
-      nullptr);
-#endif
+  if (ENVOY_LOG_CHECK_LEVEL(debug)) {
+    ENVOY_LOG(debug, "async http request response trailers:");
+    trailers->iterate(
+        [](const HeaderEntry& header, void*) -> HeaderMap::Iterate {
+          ENVOY_LOG(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());
+          return HeaderMap::Iterate::Continue;
+        },
+        nullptr);
+  }
   ASSERT(!remote_closed_);
   stream_callbacks_.onTrailers(std::move(trailers));
   closeRemote(true);

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -290,16 +290,16 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
   do_shadowing_ = FilterUtility::shouldShadow(route_entry_->shadowPolicy(), config_.runtime_,
                                               callbacks_->streamId());
 
-#ifndef NVLOG
-  headers.iterate(
-      [](const Http::HeaderEntry& header, void* context) -> Http::HeaderMap::Iterate {
-        ENVOY_STREAM_LOG(debug, "  '{}':'{}'",
-                         *static_cast<Http::StreamDecoderFilterCallbacks*>(context),
-                         header.key().c_str(), header.value().c_str());
-        return Http::HeaderMap::Iterate::Continue;
-      },
-      callbacks_);
-#endif
+  if (ENVOY_LOG_CHECK_LEVEL(debug)) {
+    headers.iterate(
+        [](const Http::HeaderEntry& header, void* context) -> Http::HeaderMap::Iterate {
+          ENVOY_STREAM_LOG(debug, "  '{}':'{}'",
+                           *static_cast<Http::StreamDecoderFilterCallbacks*>(context),
+                           header.key().c_str(), header.value().c_str());
+          return Http::HeaderMap::Iterate::Continue;
+        },
+        callbacks_);
+  }
 
   // Do a common header check. We make sure that all outgoing requests have all HTTP/2 headers.
   // These get stripped by HTTP/1 codec where applicable.

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -891,10 +891,6 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::logHealthCheckStatus(
     grpc_status_message = fmt::format("{}", grpc_status);
   }
 
-  // The following can be compiled out when defining NVLOG.
-  // TODO(mattklein123): Refactor this to make this less ugly.
-  UNREFERENCED_PARAMETER(service_status);
-  UNREFERENCED_PARAMETER(grpc_status_message);
   ENVOY_CONN_LOG(debug, "hc grpc_status={} service_status={} health_flags={}", *client_,
                  grpc_status_message, service_status, HostUtility::healthFlagsToString(*host_));
 }

--- a/source/common/upstream/maglev_lb.cc
+++ b/source/common/upstream/maglev_lb.cc
@@ -37,11 +37,11 @@ MaglevTable::MaglevTable(const HostVector& hosts, uint64_t table_size) : table_s
       table_build_entries[i].next_++;
       table_index++;
       if (table_index == table_size_) {
-#ifndef NVLOG
-        for (uint64_t i = 0; i < table_.size(); i++) {
-          ENVOY_LOG(trace, "maglev: i={} host={}", i, table_[i]->address()->asString());
+        if (ENVOY_LOG_CHECK_LEVEL(trace)) {
+          for (uint64_t i = 0; i < table_.size(); i++) {
+            ENVOY_LOG(trace, "maglev: i={} host={}", i, table_[i]->address()->asString());
+          }
         }
-#endif
         return;
       }
     }

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -125,11 +125,13 @@ RingHashLoadBalancer::Ring::Ring(
   std::sort(ring_.begin(), ring_.end(), [](const RingEntry& lhs, const RingEntry& rhs) -> bool {
     return lhs.hash_ < rhs.hash_;
   });
-#ifndef NVLOG
-  for (auto entry : ring_) {
-    ENVOY_LOG(trace, "ring hash: host={} hash={}", entry.host_->address()->asString(), entry.hash_);
+
+  if (ENVOY_LOG_CHECK_LEVEL(trace)) {
+    for (auto entry : ring_) {
+      ENVOY_LOG(trace, "ring hash: host={} hash={}", entry.host_->address()->asString(),
+                entry.hash_);
+    }
   }
-#endif
 }
 
 } // namespace Upstream

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -12,13 +12,7 @@ namespace Envoy {
 namespace Server {
 
 ConnectionHandlerImpl::ConnectionHandlerImpl(spdlog::logger& logger, Event::Dispatcher& dispatcher)
-    :
-#ifndef NVLOG
-      logger_(logger),
-#endif
-      dispatcher_(dispatcher) {
-  UNREFERENCED_PARAMETER(logger);
-}
+    : logger_(logger), dispatcher_(dispatcher) {}
 
 void ConnectionHandlerImpl::addListener(Network::ListenerConfig& config) {
   ActiveListenerPtr l(new ActiveListener(*this, config));

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -160,9 +160,7 @@ private:
 
   static ListenerStats generateStats(Stats::Scope& scope);
 
-#ifndef NVLOG
   spdlog::logger& logger_;
-#endif
   Event::Dispatcher& dispatcher_;
   std::list<std::pair<Network::Address::InstanceConstSharedPtr, ActiveListenerPtr>> listeners_;
   std::atomic<uint64_t> num_connections_{};

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -86,16 +86,29 @@ TEST(Logger, logAsStatement) {
   EXPECT_THAT(j, testing::Eq(1));
 }
 
-#ifdef NVLOG
-TEST(Logger, doNotExpandTraceAndDebug) {
-  uint32_t i = 1;
+TEST(Logger, checkLoggerLevel) {
+  class logTestClass : public Logger::Loggable<Logger::Id::misc> {
+  public:
+    void setLevel(const spdlog::level::level_enum level) { ENVOY_LOGGER().set_level(level); }
+    uint32_t executeAtTraceLevel() {
+      if (ENVOY_LOG_CHECK_LEVEL(trace)) {
+        //  Logger's level was at least trace
+        return 1;
+      } else {
+        // Logger's evel was higher than trace
+        return 2;
+      };
+    }
+  };
 
-  // The following two macros should be expanded to no-op if NVLOG compile flag is defined.
-  ENVOY_LOG_TO_LOGGER(nonExistingLogger, trace, "test message 5 '{}'", i++);
-  EXPECT_THAT(i, testing::Eq(1));
+  logTestClass testObj;
 
-  ENVOY_LOG_TO_LOGGER(nonExistingLogger, debug, "test message 6 '{}'", i++);
-  EXPECT_THAT(i, testing::Eq(1));
+  // Set Loggers severity low
+  testObj.setLevel(spdlog::level::trace);
+  EXPECT_THAT(testObj.executeAtTraceLevel(), testing::Eq(1));
+
+  testObj.setLevel(spdlog::level::info);
+  EXPECT_THAT(testObj.executeAtTraceLevel(), testing::Eq(2));
 }
-#endif /* NVLOG */
+
 } // namespace Envoy

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -95,7 +95,7 @@ TEST(Logger, checkLoggerLevel) {
         //  Logger's level was at least trace
         return 1;
       } else {
-        // Logger's evel was higher than trace
+        // Logger's level was higher than trace
         return 2;
       };
     }


### PR DESCRIPTION
Description: logger's trace and debug statements were compiled out when NVLOG flag was defined. This was done for performance reasons. #2751 introduced run-time logger's level check before invoking logging routines, but still compiled out trace and debug logging statements. This change, as per #2854, uses run-time logger's level checks for all levels, including trace and debug. NVLOG flag is not used in the code any more.

Risk Level: Low.

Testing: Added unit test to test new macro comparing logging levels.

Docs Changes: Yes - all logger levels can be configured in run-time now: trace, debug, info, warn, error and critical.

Release Notes: Yes - trace and debug log levels are used in all releases.