### PR TITLE
admin: add /stats/prometheus handler

### DIFF
--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -166,6 +166,8 @@ private:
                                Buffer::Instance& response);
   Http::Code handlerStats(const std::string& path_and_query, Http::HeaderMap& response_headers,
                           Buffer::Instance& response);
+  Http::Code handlerPrometheusStats(const std::string& path_and_query,
+                                    Http::HeaderMap& response_headers, Buffer::Instance& response);
   Http::Code handlerRuntime(const std::string& path_and_query, Http::HeaderMap& response_headers,
                             Buffer::Instance& response);
 

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -182,6 +182,26 @@ TEST_P(IntegrationAdminTest, Admin) {
   EXPECT_THAT(
       response->body(),
       testing::HasSubstr("envoy_cluster_upstream_cx_active{envoy_cluster_name=\"cluster_0\"} 0\n"));
+
+  response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/stats/prometheus", "",
+                                                downstreamProtocol(), version_);
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_THAT(response->body(),
+              testing::HasSubstr(
+                  "envoy_http_downstream_rq_xx{envoy_response_code_class=\"4\",envoy_http_conn_"
+                  "manager_prefix=\"admin\"} 2\n"));
+  EXPECT_THAT(response->body(), testing::HasSubstr("# TYPE envoy_http_downstream_rq_xx counter\n"));
+  EXPECT_THAT(response->body(),
+              testing::HasSubstr(
+                  "envoy_listener_admin_http_downstream_rq_xx{envoy_response_code_class=\"4\","
+                  "envoy_http_conn_manager_prefix=\"admin\"} 2\n"));
+  EXPECT_THAT(response->body(),
+              testing::HasSubstr("# TYPE envoy_cluster_upstream_cx_active gauge\n"));
+  EXPECT_THAT(
+      response->body(),
+      testing::HasSubstr("envoy_cluster_upstream_cx_active{envoy_cluster_name=\"cluster_0\"} 0\n"));
+
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/clusters", "",
                                                 downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());


### PR DESCRIPTION
admin: add /stats/prometheus handler

This patch adds `/stats/prometheus` handler to print server stats in
prometheus format.

*Risk Level*: Low

*Docs Changes*: 
- https://github.com/envoyproxy/data-plane-api/pull/580

*Release Notes*:
- Add an alternative path `/stats/prometheus` to get server stats in
prometheus format.

Fixes #2182.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>