### PR TITLE
logger: Add support for setting log pattern.

### DIFF
--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -91,6 +91,11 @@ public:
   virtual spdlog::level::level_enum logLevel() PURE;
 
   /**
+   * @return const std::string& the log format string.
+   */
+  virtual const std::string& logFormat() PURE;
+
+  /**
    * @return const std::string& the log file path.
    */
   virtual const std::string& logPath() PURE;

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -14,9 +14,11 @@ namespace Logger {
 
 #define GENERATE_LOGGER(X) Logger(#X),
 
+std::string Logger::default_log_format = "[%Y-%m-%d %T.%e][%t][%l][%n] %v";
+
 Logger::Logger(const std::string& name) {
   logger_ = std::make_shared<spdlog::logger>(name, Registry::getSink());
-  logger_->set_pattern("[%Y-%m-%d %T.%e][%t][%l][%n] %v");
+  logger_->set_pattern(default_log_format);
   logger_->set_level(spdlog::level::trace);
 
   // Ensure that critical errors, especially ASSERT/PANIC, get flushed
@@ -60,10 +62,12 @@ void LockingStderrOrFileSink::flush() {
 
 spdlog::logger& Registry::getLog(Id id) { return *allLoggers()[static_cast<int>(id)].logger_; }
 
-void Registry::initialize(uint64_t log_level, Thread::BasicLockable& lock) {
+void Registry::initialize(uint64_t log_level, const std::string& log_format,
+                          Thread::BasicLockable& lock) {
   getSink()->setLock(lock);
   for (Logger& logger : allLoggers()) {
     logger.logger_->set_level(static_cast<spdlog::level::level_enum>(log_level));
+    logger.logger_->set_pattern(log_format);
   }
 }
 

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -14,11 +14,11 @@ namespace Logger {
 
 #define GENERATE_LOGGER(X) Logger(#X),
 
-std::string Logger::default_log_format = "[%Y-%m-%d %T.%e][%t][%l][%n] %v";
+const char* Logger::DEFAULT_LOG_FORMAT = "[%Y-%m-%d %T.%e][%t][%l][%n] %v";
 
 Logger::Logger(const std::string& name) {
   logger_ = std::make_shared<spdlog::logger>(name, Registry::getSink());
-  logger_->set_pattern(default_log_format);
+  logger_->set_pattern(DEFAULT_LOG_FORMAT);
   logger_->set_level(spdlog::level::trace);
 
   // Ensure that critical errors, especially ASSERT/PANIC, get flushed

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -72,6 +72,8 @@ public:
     off = spdlog::level::off
   } levels;
 
+  static std::string default_log_format;
+
 private:
   Logger(const std::string& name);
 
@@ -145,7 +147,8 @@ public:
   /**
    * Initialize the logging system from server options.
    */
-  static void initialize(uint64_t log_level, Thread::BasicLockable& lock);
+  static void initialize(uint64_t log_level, const std::string& log_format,
+                         Thread::BasicLockable& lock);
 
   /**
    * @return const std::vector<Logger>& the installed loggers.

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -72,7 +72,7 @@ public:
     off = spdlog::level::off
   } levels;
 
-  static std::string default_log_format;
+  static const char* DEFAULT_LOG_FORMAT;
 
 private:
   Logger(const std::string& name);

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -60,7 +60,7 @@ MainCommonBase::MainCommonBase(OptionsImpl& options) : options_(options) {
     Thread::BasicLockable& log_lock = restarter_->logLock();
     Thread::BasicLockable& access_log_lock = restarter_->accessLogLock();
     auto local_address = Network::Utility::getLocalAddress(options_.localAddressIpVersion());
-    Logger::Registry::initialize(options_.logLevel(), log_lock);
+    Logger::Registry::initialize(options_.logLevel(), options_.logFormat(), log_lock);
 
     stats_store_.reset(new Stats::ThreadLocalStoreImpl(restarter_->statsAllocator()));
     server_.reset(new Server::InstanceImpl(options_, local_address, default_test_hooks_,
@@ -70,7 +70,7 @@ MainCommonBase::MainCommonBase(OptionsImpl& options) : options_(options) {
   }
   case Server::Mode::Validate:
     restarter_.reset(new Server::HotRestartNopImpl());
-    Logger::Registry::initialize(options_.logLevel(), restarter_->logLock());
+    Logger::Registry::initialize(options_.logLevel(), options_.logFormat(), restarter_->logLock());
     break;
   }
 }

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -40,6 +40,12 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_r
       fmt::format("\nDefault is [{}]", spdlog::level::level_names[default_log_level]);
   log_levels_string += "\n[trace] and [debug] are only available on debug builds";
 
+  std::string log_format_string =
+      fmt::format("Log message format in spdlog syntax "
+                  "(see https://github.com/gabime/spdlog/wiki/3.-Custom-formatting)"
+                  "\nDefault is \"{}\"",
+                  Logger::Logger::default_log_format);
+
   TCLAP::CmdLine cmd("envoy", ' ', VersionInfo::version());
   TCLAP::ValueArg<uint32_t> base_id(
       "", "base-id", "base ID so that multiple envoys can run on the same host if needed", false, 0,
@@ -58,6 +64,8 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_r
   TCLAP::ValueArg<std::string> log_level("l", "log-level", log_levels_string, false,
                                          spdlog::level::level_names[default_log_level], "string",
                                          cmd);
+  TCLAP::ValueArg<std::string> log_format("", "log-format", log_format_string, false,
+                                          Logger::Logger::default_log_format, "string", cmd);
   TCLAP::ValueArg<std::string> log_path("", "log-path", "Path to logfile", false, "", "string",
                                         cmd);
   TCLAP::ValueArg<uint32_t> restart_epoch("", "restart-epoch", "hot restart epoch #", false, 0,
@@ -135,6 +143,8 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_r
       log_level_ = static_cast<spdlog::level::level_enum>(i);
     }
   }
+
+  log_format_ = log_format.getValue();
 
   if (mode.getValue() == "serve") {
     mode_ = Server::Mode::Serve;

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -40,11 +40,11 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_r
       fmt::format("\nDefault is [{}]", spdlog::level::level_names[default_log_level]);
   log_levels_string += "\n[trace] and [debug] are only available on debug builds";
 
-  std::string log_format_string =
+  const std::string log_format_string =
       fmt::format("Log message format in spdlog syntax "
                   "(see https://github.com/gabime/spdlog/wiki/3.-Custom-formatting)"
                   "\nDefault is \"{}\"",
-                  Logger::Logger::default_log_format);
+                  Logger::Logger::DEFAULT_LOG_FORMAT);
 
   TCLAP::CmdLine cmd("envoy", ' ', VersionInfo::version());
   TCLAP::ValueArg<uint32_t> base_id(
@@ -65,7 +65,7 @@ OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_r
                                          spdlog::level::level_names[default_log_level], "string",
                                          cmd);
   TCLAP::ValueArg<std::string> log_format("", "log-format", log_format_string, false,
-                                          Logger::Logger::default_log_format, "string", cmd);
+                                          Logger::Logger::DEFAULT_LOG_FORMAT, "string", cmd);
   TCLAP::ValueArg<std::string> log_path("", "log-path", "Path to logfile", false, "", "string",
                                         cmd);
   TCLAP::ValueArg<uint32_t> restart_epoch("", "restart-epoch", "hot restart epoch #", false, 0,

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -39,6 +39,7 @@ public:
   Network::Address::IpVersion localAddressIpVersion() override { return local_address_ip_version_; }
   std::chrono::seconds drainTime() override { return drain_time_; }
   spdlog::level::level_enum logLevel() override { return log_level_; }
+  const std::string& logFormat() override { return log_format_; }
   const std::string& logPath() override { return log_path_; }
   std::chrono::seconds parentShutdownTime() override { return parent_shutdown_time_; }
   uint64_t restartEpoch() override { return restart_epoch_; }
@@ -59,6 +60,7 @@ private:
   std::string admin_address_path_;
   Network::Address::IpVersion local_address_ip_version_;
   spdlog::level::level_enum log_level_;
+  std::string log_format_;
   std::string log_path_;
   uint64_t restart_epoch_;
   std::string service_cluster_;

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -283,7 +283,8 @@ int main(int argc, char** argv) {
   // TODO(mattklein123): Provide a common bazel benchmark wrapper much like we do for normal tests,
   // fuzz, etc.
   Envoy::Thread::MutexBasicLockable lock;
-  Envoy::Logger::Registry::initialize(spdlog::level::warn, lock);
+  Envoy::Logger::Registry::initialize(spdlog::level::warn,
+                                      Envoy::Logger::Logger::default_log_format, lock);
 
   benchmark::Initialize(&argc, argv);
   if (benchmark::ReportUnrecognizedArguments(argc, argv)) {

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -284,7 +284,7 @@ int main(int argc, char** argv) {
   // fuzz, etc.
   Envoy::Thread::MutexBasicLockable lock;
   Envoy::Logger::Registry::initialize(spdlog::level::warn,
-                                      Envoy::Logger::Logger::default_log_format, lock);
+                                      Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock);
 
   benchmark::Initialize(&argc, argv);
   if (benchmark::ReportUnrecognizedArguments(argc, argv)) {

--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -15,7 +15,8 @@ void Runner::setupEnvironment(int argc, char** argv) {
   TestEnvironment::initializeOptions(argc, argv);
 
   static auto* lock = new Thread::MutexBasicLockable();
-  Logger::Registry::initialize(TestEnvironment::getOptions().logLevel(), *lock);
+  Logger::Registry::initialize(TestEnvironment::getOptions().logLevel(),
+                               TestEnvironment::getOptions().logFormat(), *lock);
 }
 
 } // namespace Fuzz

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -41,6 +41,7 @@ public:
   Network::Address::IpVersion localAddressIpVersion() override { return local_address_ip_version_; }
   std::chrono::seconds drainTime() override { return std::chrono::seconds(1); }
   spdlog::level::level_enum logLevel() override { NOT_IMPLEMENTED; }
+  const std::string& logFormat() override { NOT_IMPLEMENTED; }
   std::chrono::seconds parentShutdownTime() override { return std::chrono::seconds(2); }
   const std::string& logPath() override { return log_path_; }
   uint64_t restartEpoch() override { return 0; }

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -53,6 +53,7 @@ public:
   MOCK_METHOD0(localAddressIpVersion, Network::Address::IpVersion());
   MOCK_METHOD0(drainTime, std::chrono::seconds());
   MOCK_METHOD0(logLevel, spdlog::level::level_enum());
+  MOCK_METHOD0(logFormat, const std::string&());
   MOCK_METHOD0(logPath, const std::string&());
   MOCK_METHOD0(parentShutdownTime, std::chrono::seconds());
   MOCK_METHOD0(restartEpoch, uint64_t());

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -62,7 +62,7 @@ TEST(OptionsImplTest, All) {
   std::unique_ptr<OptionsImpl> options = createOptionsImpl(
       "envoy --mode validate --concurrency 2 -c hello --admin-address-path path --restart-epoch 1 "
       "--local-address-ip-version v6 -l info --service-cluster cluster --service-node node "
-      "--service-zone zone --file-flush-interval-msec 9000 --drain-time-s 60 "
+      "--service-zone zone --file-flush-interval-msec 9000 --drain-time-s 60 --log-format [%v] "
       "--parent-shutdown-time-s 90 --log-path /foo/bar --v2-config-only --disable-hot-restart");
   EXPECT_EQ(Server::Mode::Validate, options->mode());
   EXPECT_EQ(2U, options->concurrency());
@@ -72,6 +72,7 @@ TEST(OptionsImplTest, All) {
   EXPECT_EQ(Network::Address::IpVersion::v6, options->localAddressIpVersion());
   EXPECT_EQ(1U, options->restartEpoch());
   EXPECT_EQ(spdlog::level::info, options->logLevel());
+  EXPECT_EQ("[%v]", options->logFormat());
   EXPECT_EQ("/foo/bar", options->logPath());
   EXPECT_EQ("cluster", options->serviceClusterName());
   EXPECT_EQ("node", options->serviceNodeName());

--- a/test/test_runner.h
+++ b/test/test_runner.h
@@ -28,7 +28,8 @@ public:
 
     TestEnvironment::initializeOptions(argc, argv);
     Thread::MutexBasicLockable lock;
-    Logger::Registry::initialize(TestEnvironment::getOptions().logLevel(), lock);
+    Logger::Registry::initialize(TestEnvironment::getOptions().logLevel(),
+                                 TestEnvironment::getOptions().logFormat(), lock);
 
     return RUN_ALL_TESTS();
   }

--- a/test/tools/config_load_check/config_load_check.cc
+++ b/test/tools/config_load_check/config_load_check.cc
@@ -25,7 +25,8 @@ int main(int argc, char* argv[]) {
 
     Envoy::Event::Libevent::Global::initialize();
     Envoy::Thread::MutexBasicLockable lock;
-    Envoy::Logger::Registry::initialize(static_cast<spdlog::level::level_enum>(2), lock);
+    Envoy::Logger::Registry::initialize(static_cast<spdlog::level::level_enum>(2),
+                                        Envoy::Logger::Logger::default_log_format, lock);
 
     const uint32_t num_tested = Envoy::ConfigTest::run(std::string(argv[1]));
     std::cout << fmt::format("Configs tested: {}. ", num_tested);

--- a/test/tools/config_load_check/config_load_check.cc
+++ b/test/tools/config_load_check/config_load_check.cc
@@ -26,7 +26,7 @@ int main(int argc, char* argv[]) {
     Envoy::Event::Libevent::Global::initialize();
     Envoy::Thread::MutexBasicLockable lock;
     Envoy::Logger::Registry::initialize(static_cast<spdlog::level::level_enum>(2),
-                                        Envoy::Logger::Logger::default_log_format, lock);
+                                        Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock);
 
     const uint32_t num_tested = Envoy::ConfigTest::run(std::string(argv[1]));
     std::cout << fmt::format("Configs tested: {}. ", num_tested);


### PR DESCRIPTION
Add a new Envoy command line option `--log-format` to change the log
format from the default at Envoy startup. This allows better
integration of Envoy logs with the logs of the system Envoy is
deployed as a part in.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
Risk Level: Low
