### PR TITLE
util: Convert file-system write to take an absl::string_view.

### DIFF
--- a/include/envoy/filesystem/filesystem.h
+++ b/include/envoy/filesystem/filesystem.h
@@ -7,6 +7,8 @@
 
 #include "envoy/common/pure.h"
 
+#include "absl/strings/string_view.h"
+
 namespace Envoy {
 namespace Filesystem {
 
@@ -20,7 +22,7 @@ public:
   /**
    * Write data to the file.
    */
-  virtual void write(const std::string& data) PURE;
+  virtual void write(absl::string_view) PURE;
 
   /**
    * Reopen the file.

--- a/source/common/filesystem/filesystem_impl.cc
+++ b/source/common/filesystem/filesystem_impl.cc
@@ -199,7 +199,7 @@ void FileImpl::flush() {
   doWrite(about_to_write_buffer_);
 }
 
-void FileImpl::write(const std::string& data) {
+void FileImpl::write(absl::string_view data) {
   std::lock_guard<std::mutex> lock(write_lock_);
 
   if (flush_thread_ == nullptr) {
@@ -208,7 +208,7 @@ void FileImpl::write(const std::string& data) {
 
   stats_.write_buffered_.inc();
   stats_.write_total_buffered_.add(data.length());
-  flush_buffer_.add(data);
+  flush_buffer_.add(data.data(), data.size());
   if (flush_buffer_.length() > MIN_FLUSH_SIZE) {
     flush_event_.notify_one();
   }

--- a/source/common/filesystem/filesystem_impl.h
+++ b/source/common/filesystem/filesystem_impl.h
@@ -70,7 +70,7 @@ public:
   ~FileImpl();
 
   // Filesystem::File
-  void write(const std::string& data) override;
+  void write(absl::string_view data) override;
 
   /**
    * Filesystem::File

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -209,7 +209,7 @@ public:
   Http::TestHeaderMapImpl response_headers_;
   TestRequestInfo request_info_;
   std::shared_ptr<Filesystem::MockFile> file_;
-  Filesystem::StringViewSaver output_;
+  StringViewSaver output_;
 
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Envoy::AccessLog::MockAccessLogManager> log_manager_;

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -209,7 +209,7 @@ public:
   Http::TestHeaderMapImpl response_headers_;
   TestRequestInfo request_info_;
   std::shared_ptr<Filesystem::MockFile> file_;
-  std::string output_;
+  Filesystem::StringViewSaver output_;
 
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Envoy::AccessLog::MockAccessLogManager> log_manager_;

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -80,7 +80,8 @@ public:
 
     if (upstream_log) {
       ON_CALL(*context_.access_log_manager_.file_, write(_))
-          .WillByDefault(Invoke([&](const std::string& data) { output_.push_back(data); }));
+          .WillByDefault(
+              Invoke([&](absl::string_view data) { output_.push_back(std::string(data)); }));
 
       envoy::config::filter::accesslog::v2::AccessLog* current_upstream_log =
           router_proto.add_upstream_log();

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -762,23 +762,25 @@ TEST(OutlierDetectionEventLoggerImplTest, All) {
   EXPECT_CALL(log_manager, createAccessLog("foo")).WillOnce(Return(file));
   EventLoggerImpl event_logger(log_manager, "foo", time_source, monotonic_time_source);
 
-  std::string log1;
+  Filesystem::StringViewSaver log1;
   EXPECT_CALL(host->outlier_detector_, lastUnejectionTime()).WillOnce(ReturnRef(monotonic_time));
-  EXPECT_CALL(*file, write("{\"time\": \"1970-01-01T00:00:00.000Z\", \"secs_since_last_action\": "
-                           "\"-1\", \"cluster\": "
-                           "\"fake_cluster\", \"upstream_url\": \"10.0.0.1:443\", \"action\": "
-                           "\"eject\", \"type\": \"5xx\", \"num_ejections\": 0, "
-                           "\"enforced\": \"true\"}\n"))
+  EXPECT_CALL(*file, write(absl::string_view(
+                         "{\"time\": \"1970-01-01T00:00:00.000Z\", \"secs_since_last_action\": "
+                         "\"-1\", \"cluster\": "
+                         "\"fake_cluster\", \"upstream_url\": \"10.0.0.1:443\", \"action\": "
+                         "\"eject\", \"type\": \"5xx\", \"num_ejections\": 0, "
+                         "\"enforced\": \"true\"}\n")))
       .WillOnce(SaveArg<0>(&log1));
   event_logger.logEject(host, detector, EjectionType::Consecutive5xx, true);
   Json::Factory::loadFromString(log1);
 
-  std::string log2;
+  Filesystem::StringViewSaver log2;
   EXPECT_CALL(host->outlier_detector_, lastEjectionTime()).WillOnce(ReturnRef(monotonic_time));
-  EXPECT_CALL(*file, write("{\"time\": \"1970-01-01T00:00:00.000Z\", \"secs_since_last_action\": "
-                           "\"-1\", \"cluster\": \"fake_cluster\", "
-                           "\"upstream_url\": \"10.0.0.1:443\", \"action\": \"uneject\", "
-                           "\"num_ejections\": 0}\n"))
+  EXPECT_CALL(*file, write(absl::string_view(
+                         "{\"time\": \"1970-01-01T00:00:00.000Z\", \"secs_since_last_action\": "
+                         "\"-1\", \"cluster\": \"fake_cluster\", "
+                         "\"upstream_url\": \"10.0.0.1:443\", \"action\": \"uneject\", "
+                         "\"num_ejections\": 0}\n")))
       .WillOnce(SaveArg<0>(&log2));
   event_logger.logUneject(host);
   Json::Factory::loadFromString(log2);
@@ -787,29 +789,31 @@ TEST(OutlierDetectionEventLoggerImplTest, All) {
   time = (time_source.currentTime() - std::chrono::seconds(30));
   monotonic_time = (monotonic_time_source.currentTime() - std::chrono::seconds(30));
 
-  std::string log3;
+  Filesystem::StringViewSaver log3;
   EXPECT_CALL(host->outlier_detector_, lastUnejectionTime()).WillOnce(ReturnRef(monotonic_time));
   EXPECT_CALL(host->outlier_detector_, successRate()).WillOnce(Return(-1));
   EXPECT_CALL(detector, successRateAverage()).WillOnce(Return(-1));
   EXPECT_CALL(detector, successRateEjectionThreshold()).WillOnce(Return(-1));
-  EXPECT_CALL(*file, write("{\"time\": \"1970-01-01T00:00:00.000Z\", \"secs_since_last_action\": "
-                           "\"30\", \"cluster\": "
-                           "\"fake_cluster\", \"upstream_url\": \"10.0.0.1:443\", \"action\": "
-                           "\"eject\", \"type\": \"SuccessRate\", \"num_ejections\": 0, "
-                           "\"enforced\": \"false\", "
-                           "\"host_success_rate\": \"-1\", \"cluster_average_success_rate\": "
-                           "\"-1\", \"cluster_success_rate_ejection_threshold\": \"-1\""
-                           "}\n"))
+  EXPECT_CALL(*file, write(absl::string_view(
+                         "{\"time\": \"1970-01-01T00:00:00.000Z\", \"secs_since_last_action\": "
+                         "\"30\", \"cluster\": "
+                         "\"fake_cluster\", \"upstream_url\": \"10.0.0.1:443\", \"action\": "
+                         "\"eject\", \"type\": \"SuccessRate\", \"num_ejections\": 0, "
+                         "\"enforced\": \"false\", "
+                         "\"host_success_rate\": \"-1\", \"cluster_average_success_rate\": "
+                         "\"-1\", \"cluster_success_rate_ejection_threshold\": \"-1\""
+                         "}\n")))
       .WillOnce(SaveArg<0>(&log3));
   event_logger.logEject(host, detector, EjectionType::SuccessRate, false);
   Json::Factory::loadFromString(log3);
 
-  std::string log4;
+  Filesystem::StringViewSaver log4;
   EXPECT_CALL(host->outlier_detector_, lastEjectionTime()).WillOnce(ReturnRef(monotonic_time));
-  EXPECT_CALL(*file, write("{\"time\": \"1970-01-01T00:00:00.000Z\", \"secs_since_last_action\": "
-                           "\"30\", \"cluster\": \"fake_cluster\", "
-                           "\"upstream_url\": \"10.0.0.1:443\", \"action\": \"uneject\", "
-                           "\"num_ejections\": 0}\n"))
+  EXPECT_CALL(*file, write(absl::string_view(
+                         "{\"time\": \"1970-01-01T00:00:00.000Z\", \"secs_since_last_action\": "
+                         "\"30\", \"cluster\": \"fake_cluster\", "
+                         "\"upstream_url\": \"10.0.0.1:443\", \"action\": \"uneject\", "
+                         "\"num_ejections\": 0}\n")))
       .WillOnce(SaveArg<0>(&log4));
   event_logger.logUneject(host);
   Json::Factory::loadFromString(log4);

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -762,7 +762,7 @@ TEST(OutlierDetectionEventLoggerImplTest, All) {
   EXPECT_CALL(log_manager, createAccessLog("foo")).WillOnce(Return(file));
   EventLoggerImpl event_logger(log_manager, "foo", time_source, monotonic_time_source);
 
-  Filesystem::StringViewSaver log1;
+  StringViewSaver log1;
   EXPECT_CALL(host->outlier_detector_, lastUnejectionTime()).WillOnce(ReturnRef(monotonic_time));
   EXPECT_CALL(*file, write(absl::string_view(
                          "{\"time\": \"1970-01-01T00:00:00.000Z\", \"secs_since_last_action\": "
@@ -774,7 +774,7 @@ TEST(OutlierDetectionEventLoggerImplTest, All) {
   event_logger.logEject(host, detector, EjectionType::Consecutive5xx, true);
   Json::Factory::loadFromString(log1);
 
-  Filesystem::StringViewSaver log2;
+  StringViewSaver log2;
   EXPECT_CALL(host->outlier_detector_, lastEjectionTime()).WillOnce(ReturnRef(monotonic_time));
   EXPECT_CALL(*file, write(absl::string_view(
                          "{\"time\": \"1970-01-01T00:00:00.000Z\", \"secs_since_last_action\": "
@@ -789,7 +789,7 @@ TEST(OutlierDetectionEventLoggerImplTest, All) {
   time = (time_source.currentTime() - std::chrono::seconds(30));
   monotonic_time = (monotonic_time_source.currentTime() - std::chrono::seconds(30));
 
-  Filesystem::StringViewSaver log3;
+  StringViewSaver log3;
   EXPECT_CALL(host->outlier_detector_, lastUnejectionTime()).WillOnce(ReturnRef(monotonic_time));
   EXPECT_CALL(host->outlier_detector_, successRate()).WillOnce(Return(-1));
   EXPECT_CALL(detector, successRateAverage()).WillOnce(Return(-1));
@@ -807,7 +807,7 @@ TEST(OutlierDetectionEventLoggerImplTest, All) {
   event_logger.logEject(host, detector, EjectionType::SuccessRate, false);
   Json::Factory::loadFromString(log3);
 
-  Filesystem::StringViewSaver log4;
+  StringViewSaver log4;
   EXPECT_CALL(host->outlier_detector_, lastEjectionTime()).WillOnce(ReturnRef(monotonic_time));
   EXPECT_CALL(*file, write(absl::string_view(
                          "{\"time\": \"1970-01-01T00:00:00.000Z\", \"secs_since_last_action\": "

--- a/test/extensions/filters/network/tcp_proxy/tcp_proxy_test.cc
+++ b/test/extensions/filters/network/tcp_proxy/tcp_proxy_test.cc
@@ -470,7 +470,7 @@ public:
   Network::ReadFilterSharedPtr upstream_read_filter_;
   std::vector<NiceMock<Event::MockTimer>*> connect_timers_;
   std::unique_ptr<TcpProxyFilter> filter_;
-  Filesystem::StringViewSaver access_log_data_;
+  StringViewSaver access_log_data_;
   Network::Address::InstanceConstSharedPtr upstream_local_address_;
   Network::Address::InstanceConstSharedPtr upstream_remote_address_;
 };

--- a/test/extensions/filters/network/tcp_proxy/tcp_proxy_test.cc
+++ b/test/extensions/filters/network/tcp_proxy/tcp_proxy_test.cc
@@ -470,7 +470,7 @@ public:
   Network::ReadFilterSharedPtr upstream_read_filter_;
   std::vector<NiceMock<Event::MockTimer>*> connect_timers_;
   std::unique_ptr<TcpProxyFilter> filter_;
-  std::string access_log_data_;
+  Filesystem::StringViewSaver access_log_data_;
   Network::Address::InstanceConstSharedPtr upstream_local_address_;
   Network::Address::InstanceConstSharedPtr upstream_remote_address_;
 };
@@ -711,14 +711,14 @@ TEST_F(TcpProxyTest, UpstreamConnectTimeout) {
                     .value());
 
   filter_.reset();
-  EXPECT_EQ(access_log_data_, "UF");
+  EXPECT_EQ("UF", access_log_data_);
 }
 
 TEST_F(TcpProxyTest, NoHost) {
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   setup(0, accessLogConfig("%RESPONSE_FLAGS%"));
   filter_.reset();
-  EXPECT_EQ(access_log_data_, "UH");
+  EXPECT_EQ("UH", access_log_data_);
 }
 
 TEST_F(TcpProxyTest, WithMetadataMatch) {
@@ -776,7 +776,7 @@ TEST_F(TcpProxyTest, UpstreamConnectFailure) {
                     .value());
 
   filter_.reset();
-  EXPECT_EQ(access_log_data_, "UF");
+  EXPECT_EQ("UF", access_log_data_);
 }
 
 TEST_F(TcpProxyTest, UpstreamConnectionLimit) {
@@ -796,7 +796,7 @@ TEST_F(TcpProxyTest, UpstreamConnectionLimit) {
                     .value());
 
   filter_.reset();
-  EXPECT_EQ(access_log_data_, "UO");
+  EXPECT_EQ("UO", access_log_data_);
 }
 
 // Tests that the idle timer closes both connections, and gets updated when either
@@ -862,14 +862,14 @@ TEST_F(TcpProxyTest, IdleTimerDisabledUpstreamClose) {
 TEST_F(TcpProxyTest, AccessLogUpstreamHost) {
   setup(1, accessLogConfig("%UPSTREAM_HOST% %UPSTREAM_CLUSTER%"));
   filter_.reset();
-  EXPECT_EQ(access_log_data_, "127.0.0.1:80 fake_cluster");
+  EXPECT_EQ("127.0.0.1:80 fake_cluster", access_log_data_);
 }
 
 // Test that access log field %UPSTREAM_LOCAL_ADDRESS% is correctly logged.
 TEST_F(TcpProxyTest, AccessLogUpstreamLocalAddress) {
   setup(1, accessLogConfig("%UPSTREAM_LOCAL_ADDRESS%"));
   filter_.reset();
-  EXPECT_EQ(access_log_data_, "2.2.2.2:50000");
+  EXPECT_EQ("2.2.2.2:50000", access_log_data_);
 }
 
 // Test that access log fields %DOWNSTREAM_ADDRESS% and %DOWNSTREAM_LOCAL_ADDRESS% are correctly
@@ -881,7 +881,7 @@ TEST_F(TcpProxyTest, AccessLogDownstreamAddress) {
       Network::Utility::resolveUrl("tcp://1.1.1.1:40000");
   setup(1, accessLogConfig("%DOWNSTREAM_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS%"));
   filter_.reset();
-  EXPECT_EQ(access_log_data_, "1.1.1.1 1.1.1.2:20000");
+  EXPECT_EQ("1.1.1.1 1.1.1.2:20000", access_log_data_);
 }
 
 // Test that access log fields %BYTES_RECEIVED%, %BYTES_SENT%, %START_TIME%, %DURATION% are

--- a/test/extensions/filters/network/tcp_proxy/tcp_proxy_test.cc
+++ b/test/extensions/filters/network/tcp_proxy/tcp_proxy_test.cc
@@ -711,14 +711,14 @@ TEST_F(TcpProxyTest, UpstreamConnectTimeout) {
                     .value());
 
   filter_.reset();
-  EXPECT_EQ("UF", access_log_data_);
+  EXPECT_EQ(access_log_data_, "UF");
 }
 
 TEST_F(TcpProxyTest, NoHost) {
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   setup(0, accessLogConfig("%RESPONSE_FLAGS%"));
   filter_.reset();
-  EXPECT_EQ("UH", access_log_data_);
+  EXPECT_EQ(access_log_data_, "UH");
 }
 
 TEST_F(TcpProxyTest, WithMetadataMatch) {
@@ -776,7 +776,7 @@ TEST_F(TcpProxyTest, UpstreamConnectFailure) {
                     .value());
 
   filter_.reset();
-  EXPECT_EQ("UF", access_log_data_);
+  EXPECT_EQ(access_log_data_, "UF");
 }
 
 TEST_F(TcpProxyTest, UpstreamConnectionLimit) {
@@ -796,7 +796,7 @@ TEST_F(TcpProxyTest, UpstreamConnectionLimit) {
                     .value());
 
   filter_.reset();
-  EXPECT_EQ("UO", access_log_data_);
+  EXPECT_EQ(access_log_data_, "UO");
 }
 
 // Tests that the idle timer closes both connections, and gets updated when either
@@ -862,14 +862,14 @@ TEST_F(TcpProxyTest, IdleTimerDisabledUpstreamClose) {
 TEST_F(TcpProxyTest, AccessLogUpstreamHost) {
   setup(1, accessLogConfig("%UPSTREAM_HOST% %UPSTREAM_CLUSTER%"));
   filter_.reset();
-  EXPECT_EQ("127.0.0.1:80 fake_cluster", access_log_data_);
+  EXPECT_EQ(access_log_data_, "127.0.0.1:80 fake_cluster");
 }
 
 // Test that access log field %UPSTREAM_LOCAL_ADDRESS% is correctly logged.
 TEST_F(TcpProxyTest, AccessLogUpstreamLocalAddress) {
   setup(1, accessLogConfig("%UPSTREAM_LOCAL_ADDRESS%"));
   filter_.reset();
-  EXPECT_EQ("2.2.2.2:50000", access_log_data_);
+  EXPECT_EQ(access_log_data_, "2.2.2.2:50000");
 }
 
 // Test that access log fields %DOWNSTREAM_ADDRESS% and %DOWNSTREAM_LOCAL_ADDRESS% are correctly
@@ -881,7 +881,7 @@ TEST_F(TcpProxyTest, AccessLogDownstreamAddress) {
       Network::Utility::resolveUrl("tcp://1.1.1.1:40000");
   setup(1, accessLogConfig("%DOWNSTREAM_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS%"));
   filter_.reset();
-  EXPECT_EQ("1.1.1.1 1.1.1.2:20000", access_log_data_);
+  EXPECT_EQ(access_log_data_, "1.1.1.1 1.1.1.2:20000");
 }
 
 // Test that access log fields %BYTES_RECEIVED%, %BYTES_SENT%, %START_TIME%, %DURATION% are

--- a/test/mocks/common.h
+++ b/test/mocks/common.h
@@ -2,6 +2,7 @@
 
 #include "envoy/common/time.h"
 
+#include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
 
 namespace Envoy {
@@ -44,4 +45,27 @@ public:
 
   MOCK_METHOD0(currentTime, MonotonicTime());
 };
+
+// Captures absl::string_view parameters into temp strings, for use
+// with gmock's SaveArg<n>. Providing an absl::string_view compiles,
+// but fails because by the time you examine the saved value, its
+// backing store will go out of scope.
+class StringViewSaver {
+public:
+  void operator=(absl::string_view view) { value_ = std::string(view); }
+  const std::string& value() const { return value_; }
+  operator std::string() const { return value_; }
+
+private:
+  std::string value_;
+};
+
+inline bool operator==(const char* str, const StringViewSaver& saver) {
+  return saver.value() == str;
+}
+
+inline bool operator==(const StringViewSaver& saver, const char* str) {
+  return saver.value() == str;
+}
+
 } // namespace Envoy

--- a/test/mocks/filesystem/mocks.h
+++ b/test/mocks/filesystem/mocks.h
@@ -42,6 +42,10 @@ inline bool operator==(const char* str, const StringViewSaver& saver) {
   return saver.value() == str;
 }
 
+inline bool operator==(const StringViewSaver& saver, const char* str) {
+  return saver.value() == str;
+}
+
 class MockWatcher : public Watcher {
 public:
   MockWatcher();

--- a/test/mocks/filesystem/mocks.h
+++ b/test/mocks/filesystem/mocks.h
@@ -19,10 +19,28 @@ public:
   ~MockFile();
 
   // Filesystem::File
-  MOCK_METHOD1(write, void(const std::string& data));
+  MOCK_METHOD1(write, void(absl::string_view data));
   MOCK_METHOD0(reopen, void());
   MOCK_METHOD0(flush, void());
 };
+
+// Captures absl::string_view parameters into temp strings, for use
+// with gmock's SaveArg<n>. Providing an absl::string_view compiles,
+// but fails because by the time you examine the saved value, its
+// backing store will go out of scope.
+class StringViewSaver {
+public:
+  void operator=(absl::string_view view) { value_ = std::string(view); }
+  const std::string& value() const { return value_; }
+  operator std::string() const { return value_; }
+
+private:
+  std::string value_;
+};
+
+inline bool operator==(const char* str, const StringViewSaver& saver) {
+  return saver.value() == str;
+}
 
 class MockWatcher : public Watcher {
 public:

--- a/test/mocks/filesystem/mocks.h
+++ b/test/mocks/filesystem/mocks.h
@@ -24,28 +24,6 @@ public:
   MOCK_METHOD0(flush, void());
 };
 
-// Captures absl::string_view parameters into temp strings, for use
-// with gmock's SaveArg<n>. Providing an absl::string_view compiles,
-// but fails because by the time you examine the saved value, its
-// backing store will go out of scope.
-class StringViewSaver {
-public:
-  void operator=(absl::string_view view) { value_ = std::string(view); }
-  const std::string& value() const { return value_; }
-  operator std::string() const { return value_; }
-
-private:
-  std::string value_;
-};
-
-inline bool operator==(const char* str, const StringViewSaver& saver) {
-  return saver.value() == str;
-}
-
-inline bool operator==(const StringViewSaver& saver, const char* str) {
-  return saver.value() == str;
-}
-
 class MockWatcher : public Watcher {
 public:
   MockWatcher();


### PR DESCRIPTION
Signed-off-by: Joshua Marantz <jmarantz@google.com>

*Description*: Ultimately writing a file requires only a byte pointer and size; the pointer doesn't necessarily require a std::string object, which you don't necessarily always have one writing one. This PR eliminates potential extra conversions in the writing path.

One side-effect is that mocking is a little messier: you need to explicitly construct an absl::string_view from an expected static string constants to allow the object matchers to work.  You also need to use the new Filesystem::StringViewSaver object when saving arguments with SaveArg<n> in test mocks.

*Risk Level*: Low

*Testing*: //test/...

*Release Notes*: N/A
