### PR TITLE
macros: ASSERT() enhancements

### DIFF
--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -44,7 +44,6 @@ void OwnedImpl::commit(RawSlice* iovecs, uint64_t num_iovecs) {
   int rc =
       evbuffer_commit_space(buffer_.get(), reinterpret_cast<evbuffer_iovec*>(iovecs), num_iovecs);
   ASSERT(rc == 0);
-  UNREFERENCED_PARAMETER(rc);
 }
 
 void OwnedImpl::copyOut(size_t start, uint64_t size, void* data) const {
@@ -53,18 +52,15 @@ void OwnedImpl::copyOut(size_t start, uint64_t size, void* data) const {
   evbuffer_ptr start_ptr;
   int rc = evbuffer_ptr_set(buffer_.get(), &start_ptr, start, EVBUFFER_PTR_SET);
   ASSERT(rc != -1);
-  UNREFERENCED_PARAMETER(rc);
 
   ev_ssize_t copied = evbuffer_copyout_from(buffer_.get(), &start_ptr, data, size);
   ASSERT(static_cast<uint64_t>(copied) == size);
-  UNREFERENCED_PARAMETER(copied);
 }
 
 void OwnedImpl::drain(uint64_t size) {
   ASSERT(size <= length());
   int rc = evbuffer_drain(buffer_.get(), size);
   ASSERT(rc == 0);
-  UNREFERENCED_PARAMETER(rc);
 }
 
 uint64_t OwnedImpl::getRawSlices(RawSlice* out, uint64_t out_size) const {
@@ -86,7 +82,6 @@ void OwnedImpl::move(Instance& rhs) {
   // abstraction in case we get rid of evbuffer later.
   int rc = evbuffer_add_buffer(buffer_.get(), static_cast<LibEventInstance&>(rhs).buffer().get());
   ASSERT(rc == 0);
-  UNREFERENCED_PARAMETER(rc);
   static_cast<LibEventInstance&>(rhs).postProcess();
 }
 
@@ -95,7 +90,6 @@ void OwnedImpl::move(Instance& rhs, uint64_t length) {
   int rc = evbuffer_remove_buffer(static_cast<LibEventInstance&>(rhs).buffer().get(), buffer_.get(),
                                   length);
   ASSERT(static_cast<uint64_t>(rc) == length);
-  UNREFERENCED_PARAMETER(rc);
   static_cast<LibEventInstance&>(rhs).postProcess();
 }
 

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -20,10 +20,11 @@ namespace Envoy {
 #define ASSERT(X) RELEASE_ASSERT(X)
 #else
 // This non-implementation ensures that its argument is a valid expression that can be statically
-// casted to a bool, but doesn't generate any code, since the argument to sizeof() is not evaluated.
+// casted to a bool, but the expression is never evaluated and will be compiled away.              
 #define ASSERT(X)                                                                                  \
   do {                                                                                             \
-    (void)sizeof(static_cast<bool>(X));                                                            \
+    constexpr bool __assert_dummy_variable = false && static_cast<bool>(X);                        \
+    (void)__assert_dummy_variable;                                                                 \
   } while (false)
 #endif
 

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -8,18 +8,23 @@ namespace Envoy {
  * sinks.
  */
 #define RELEASE_ASSERT(X)                                                                          \
-  {                                                                                                \
+  do {                                                                                             \
     if (!(X)) {                                                                                    \
       ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::assert), critical,    \
                           "assert failure: {}", #X);                                               \
       abort();                                                                                     \
     }                                                                                              \
-  }
+  } while (false)
 
 #ifndef NDEBUG
 #define ASSERT(X) RELEASE_ASSERT(X)
 #else
-#define ASSERT(X)
+// This non-implementation ensures that its argument is a valid expression that can be statically
+// casted to a bool, but doesn't generate any code, since the argument to sizeof() is not evaluated.
+#define ASSERT(X)                                                                                  \
+  do {                                                                                             \
+    (void)sizeof(static_cast<bool>(X));                                                            \
+  } while (false)
 #endif
 
 /**

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -20,7 +20,7 @@ namespace Envoy {
 #define ASSERT(X) RELEASE_ASSERT(X)
 #else
 // This non-implementation ensures that its argument is a valid expression that can be statically
-// casted to a bool, but the expression is never evaluated and will be compiled away.              
+// casted to a bool, but the expression is never evaluated and will be compiled away.
 #define ASSERT(X)                                                                                  \
   do {                                                                                             \
     constexpr bool __assert_dummy_variable = false && static_cast<bool>(X);                        \

--- a/source/common/common/callback_impl.h
+++ b/source/common/common/callback_impl.h
@@ -57,8 +57,10 @@ private:
    * @param handle supplies the callback handle to remove.
    */
   void remove(CallbackHandle* handle) {
-    const auto comp = [handle](const CallbackHolder& holder) -> bool { return handle == &holder; };
-    ASSERT(std::find_if(callbacks_.begin(), callbacks_.end(), comp) != callbacks_.end());
+    ASSERT(std::find_if(callbacks_.begin(), callbacks_.end(),
+                        [handle](const CallbackHolder& holder) -> bool {
+                          return handle == &holder;
+                        }) != callbacks_.end());
     callbacks_.remove_if(
         [handle](const CallbackHolder& holder) -> bool { return handle == &holder; });
   }

--- a/source/common/common/callback_impl.h
+++ b/source/common/common/callback_impl.h
@@ -57,10 +57,8 @@ private:
    * @param handle supplies the callback handle to remove.
    */
   void remove(CallbackHandle* handle) {
-    ASSERT(std::find_if(callbacks_.begin(), callbacks_.end(),
-                        [handle](const CallbackHolder& holder) -> bool {
-                          return handle == &holder;
-                        }) != callbacks_.end());
+    const auto comp = [handle](const CallbackHolder& holder) -> bool { return handle == &holder; };
+    ASSERT(std::find_if(callbacks_.begin(), callbacks_.end(), comp) != callbacks_.end());
     callbacks_.remove_if(
         [handle](const CallbackHolder& holder) -> bool { return handle == &holder; });
   }

--- a/source/common/common/thread.cc
+++ b/source/common/common/thread.cc
@@ -24,7 +24,6 @@ Thread::Thread(std::function<void()> thread_routine) : thread_routine_(thread_ro
                           },
                           this);
   RELEASE_ASSERT(rc == 0);
-  UNREFERENCED_PARAMETER(rc);
 }
 
 int32_t Thread::currentThreadId() {
@@ -42,7 +41,6 @@ int32_t Thread::currentThreadId() {
 void Thread::join() {
   int rc = pthread_join(thread_id_, nullptr);
   RELEASE_ASSERT(rc == 0);
-  UNREFERENCED_PARAMETER(rc);
 }
 
 } // namespace Thread

--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -161,7 +161,6 @@ void FilterJson::translateHttpConnectionManager(
         Protobuf::util::JsonStringToMessage(deprecated_config, filter->mutable_config());
     // JSON schema has already validated that this is a valid JSON object.
     ASSERT(status.ok());
-    UNREFERENCED_PARAMETER(status);
   }
 
   JSON_UTIL_SET_BOOL(json_config, proto_config, add_user_agent);

--- a/source/common/config/lds_json.cc
+++ b/source/common/config/lds_json.cc
@@ -43,7 +43,6 @@ void LdsJson::translateListener(const Json::Object& json_listener,
     const auto status = Protobuf::util::JsonStringToMessage(json_config, filter->mutable_config());
     // JSON schema has already validated that this is a valid JSON object.
     ASSERT(status.ok());
-    UNREFERENCED_PARAMETER(status);
   }
 
   const std::string drain_type = json_listener.getString("drain_type", "default");

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -59,14 +59,13 @@ public:
 
 private:
   void runPostCallbacks();
-#ifndef NDEBUG
+
   // Validate that an operation is thread safe, i.e. it's invoked on the same thread that the
   // dispatcher run loop is executing on. We allow run_tid_ == 0 for tests where we don't invoke
   // run().
   bool isThreadSafe() const {
     return run_tid_ == 0 || run_tid_ == Thread::Thread::currentThreadId();
   }
-#endif
 
   Thread::ThreadId run_tid_{};
   Buffer::WatermarkFactoryPtr buffer_factory_;

--- a/source/common/filesystem/filesystem_impl.cc
+++ b/source/common/filesystem/filesystem_impl.cc
@@ -125,7 +125,6 @@ void FileImpl::doWrite(Buffer::Instance& buffer) {
     for (Buffer::RawSlice& slice : slices) {
       ssize_t rc = os_sys_calls_.write(fd_, slice.mem_, slice.len_);
       ASSERT(rc == static_cast<ssize_t>(slice.len_));
-      UNREFERENCED_PARAMETER(rc);
       stats_.write_completed_.inc();
     }
   }

--- a/source/common/filesystem/inotify/watcher_impl.cc
+++ b/source/common/filesystem/inotify/watcher_impl.cc
@@ -20,7 +20,6 @@ WatcherImpl::WatcherImpl(Event::Dispatcher& dispatcher)
       inotify_event_(dispatcher.createFileEvent(inotify_fd_,
                                                 [this](uint32_t events) -> void {
                                                   ASSERT(events == Event::FileReadyType::Read);
-                                                  UNREFERENCED_PARAMETER(events);
                                                   onInotifyEvent();
                                                 },
                                                 Event::FileTriggerType::Edge,

--- a/source/common/filter/listener/proxy_protocol.cc
+++ b/source/common/filter/listener/proxy_protocol.cc
@@ -32,7 +32,6 @@ Network::FilterStatus Instance::onAccept(Network::ListenerFilterCallbacks& cb) {
       cb.dispatcher().createFileEvent(socket.fd(),
                                       [this](uint32_t events) {
                                         ASSERT(events == Event::FileReadyType::Read);
-                                        UNREFERENCED_PARAMETER(events);
                                         onRead();
                                       },
                                       Event::FileTriggerType::Edge, Event::FileReadyType::Read);

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1381,7 +1381,6 @@ void ConnectionManagerImpl::ActiveStreamDecoderFilter::addDownstreamWatermarkCal
 void ConnectionManagerImpl::ActiveStreamDecoderFilter::removeDownstreamWatermarkCallbacks(
     DownstreamWatermarkCallbacks& watermark_callbacks) {
   ASSERT(parent_.watermark_callbacks_ == &watermark_callbacks);
-  UNREFERENCED_PARAMETER(watermark_callbacks);
   parent_.watermark_callbacks_ = nullptr;
 }
 

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -191,7 +191,6 @@ void ConnectionImpl::StreamImpl::submitTrailers(const HeaderMap& trailers) {
   int rc =
       nghttp2_submit_trailer(parent_.session_, stream_id_, &final_headers[0], final_headers.size());
   ASSERT(rc == 0);
-  UNREFERENCED_PARAMETER(rc);
 }
 
 ssize_t ConnectionImpl::StreamImpl::onDataSourceRead(uint64_t length, uint32_t* data_flags) {
@@ -241,7 +240,6 @@ void ConnectionImpl::ServerStreamImpl::submitHeaders(const std::vector<nghttp2_n
   int rc = nghttp2_submit_response(parent_.session_, stream_id_, &final_headers.data()[0],
                                    final_headers.size(), provider);
   ASSERT(rc == 0);
-  UNREFERENCED_PARAMETER(rc);
 }
 
 void ConnectionImpl::StreamImpl::encodeData(Buffer::Instance& data, bool end_stream) {
@@ -251,7 +249,6 @@ void ConnectionImpl::StreamImpl::encodeData(Buffer::Instance& data, bool end_str
   if (data_deferred_) {
     int rc = nghttp2_session_resume_data(parent_.session_, stream_id_);
     ASSERT(rc == 0);
-    UNREFERENCED_PARAMETER(rc);
 
     data_deferred_ = false;
   }
@@ -286,7 +283,6 @@ void ConnectionImpl::StreamImpl::resetStreamWorker(StreamResetReason reason) {
                                          ? NGHTTP2_REFUSED_STREAM
                                          : NGHTTP2_NO_ERROR);
   ASSERT(rc == 0);
-  UNREFERENCED_PARAMETER(rc);
 }
 
 ConnectionImpl::~ConnectionImpl() { nghttp2_session_del(session_); }
@@ -338,7 +334,6 @@ void ConnectionImpl::goAway() {
                                  nghttp2_session_get_last_proc_stream_id(session_),
                                  NGHTTP2_NO_ERROR, nullptr, 0);
   ASSERT(rc == 0);
-  UNREFERENCED_PARAMETER(rc);
 
   sendPendingFrames();
 }
@@ -346,7 +341,6 @@ void ConnectionImpl::goAway() {
 void ConnectionImpl::shutdownNotice() {
   int rc = nghttp2_submit_shutdown_notice(session_);
   ASSERT(rc == 0);
-  UNREFERENCED_PARAMETER(rc);
 
   sendPendingFrames();
 }
@@ -510,7 +504,6 @@ ssize_t ConnectionImpl::onSend(const uint8_t* data, size_t length) {
 }
 
 int ConnectionImpl::onStreamClose(int32_t stream_id, uint32_t error_code) {
-  UNREFERENCED_PARAMETER(error_code);
 
   StreamImpl* stream = getStream(stream_id);
   if (stream) {
@@ -634,12 +627,10 @@ void ConnectionImpl::sendSettings(const Http2Settings& http2_settings, bool disa
   if (!iv.empty()) {
     int rc = nghttp2_submit_settings(session_, NGHTTP2_FLAG_NONE, &iv[0], iv.size());
     ASSERT(rc == 0);
-    UNREFERENCED_PARAMETER(rc);
   } else {
     // nghttp2_submit_settings need to be called at least once
     int rc = nghttp2_submit_settings(session_, NGHTTP2_FLAG_NONE, 0, 0);
     ASSERT(rc == 0);
-    UNREFERENCED_PARAMETER(rc);
   }
 
   // Increase connection window size up to our default size.
@@ -650,7 +641,6 @@ void ConnectionImpl::sendSettings(const Http2Settings& http2_settings, bool disa
                                           http2_settings.initial_connection_window_size_ -
                                               NGHTTP2_INITIAL_CONNECTION_WINDOW_SIZE);
     ASSERT(rc == 0);
-    UNREFERENCED_PARAMETER(rc);
   }
 }
 
@@ -667,7 +657,6 @@ ConnectionImpl::Http2Callbacks::Http2Callbacks() {
       [](nghttp2_session*, nghttp2_frame* frame, const uint8_t* framehd, size_t length,
          nghttp2_data_source* source, void*) -> int {
         ASSERT(frame->data.padlen == 0);
-        UNREFERENCED_PARAMETER(frame);
         return static_cast<StreamImpl*>(source->ptr)->onDataSourceSend(framehd, length);
       });
 

--- a/source/common/lua/lua.cc
+++ b/source/common/lua/lua.cc
@@ -89,7 +89,6 @@ ThreadLocalState::LuaThreadLocal::LuaThreadLocal(const std::string& code) : stat
   luaL_openlibs(state_.get());
   int rc = luaL_dostring(state_.get(), code.c_str());
   ASSERT(rc == 0);
-  UNREFERENCED_PARAMETER(rc);
 }
 
 } // namespace Lua

--- a/source/common/lua/lua.h
+++ b/source/common/lua/lua.h
@@ -130,7 +130,6 @@ public:
     ENVOY_LOG(debug, "registering new type: {}", typeid(T).name());
     int rc = luaL_newmetatable(state, typeid(T).name());
     ASSERT(rc == 1);
-    UNREFERENCED_PARAMETER(rc);
 
     lua_pushvalue(state, -1);
     lua_setfield(state, -2, "__index");

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -181,7 +181,6 @@ void ConnectionImpl::noDelay(bool enable) {
 #endif
 
   RELEASE_ASSERT(0 == rc);
-  UNREFERENCED_PARAMETER(rc);
 }
 
 uint64_t ConnectionImpl::id() const { return id_; }
@@ -458,7 +457,6 @@ void ConnectionImpl::onWriteReady() {
     socklen_t error_size = sizeof(error);
     int rc = getsockopt(fd(), SOL_SOCKET, SO_ERROR, &error, &error_size);
     ASSERT(0 == rc);
-    UNREFERENCED_PARAMETER(rc);
 
     if (error == 0) {
       ENVOY_CONN_LOG(debug, "connected", *this);

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -41,7 +41,7 @@ DnsResolverImpl::DnsResolverImpl(
     }
     const std::string resolvers_csv = StringUtil::join(resolver_addrs, ",");
     int result = ares_set_servers_ports_csv(channel_, resolvers_csv.c_str());
-    RELEASE_ASSERT(result == ARES_SUCCESS)
+    RELEASE_ASSERT(result == ARES_SUCCESS);
   }
 }
 

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -167,7 +167,6 @@ Address::InstanceConstSharedPtr Utility::getLocalAddress(const Address::IpVersio
 
   int rc = getifaddrs(&ifaddr);
   RELEASE_ASSERT(!rc);
-  UNREFERENCED_PARAMETER(rc);
 
   // man getifaddrs(3)
   for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
@@ -304,7 +303,6 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(int fd) {
 #else
   // TODO(zuercher): determine if connection redirection is possible under OS X (c.f. pfctl and
   // divert), and whether it's possible to find the learn destination address.
-  UNREFERENCED_PARAMETER(fd);
   return nullptr;
 #endif
 }

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -303,6 +303,7 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(int fd) {
 #else
   // TODO(zuercher): determine if connection redirection is possible under OS X (c.f. pfctl and
   // divert), and whether it's possible to find the learn destination address.
+  UNREFERENCED_PARAMETER(fd);
   return nullptr;
 #endif
 }

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -11,7 +11,6 @@ namespace ProtobufPercentHelper {
 
 uint64_t checkAndReturnDefault(uint64_t default_value, uint64_t max_value) {
   ASSERT(default_value <= max_value);
-  UNREFERENCED_PARAMETER(max_value);
   return default_value;
 }
 

--- a/source/common/ratelimit/ratelimit_impl.cc
+++ b/source/common/ratelimit/ratelimit_impl.cc
@@ -68,7 +68,6 @@ void GrpcClientImpl::onSuccess(std::unique_ptr<pb::lyft::ratelimit::RateLimitRes
 void GrpcClientImpl::onFailure(Grpc::Status::GrpcStatus status, const std::string&,
                                Tracing::Span&) {
   ASSERT(status != Grpc::Status::GrpcStatus::Ok);
-  UNREFERENCED_PARAMETER(status);
   callbacks_->complete(LimitStatus::Error);
   callbacks_ = nullptr;
 }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -679,7 +679,6 @@ VirtualHostImpl::VirtualHostImpl(const envoy::api::v2::route::VirtualHost& virtu
       routes_.emplace_back(new PathRouteEntryImpl(*this, route, runtime));
     } else {
       ASSERT(has_regex);
-      UNREFERENCED_PARAMETER(has_regex);
       routes_.emplace_back(new RegexRouteEntryImpl(*this, route, runtime));
     }
 

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -163,7 +163,7 @@ RouteConfigProviderManagerImpl::getRdsRouteConfigProviders() {
     // in the RdsRouteConfigProviderImpl destructor, and the single threaded nature
     // of this code, locking the weak_ptr will not fail.
     RouteConfigProviderSharedPtr provider = element.second.lock();
-    ASSERT(provider)
+    ASSERT(provider);
     ret.push_back(provider);
   }
   return ret;

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -54,7 +54,6 @@ uint64_t RandomGeneratorImpl::random() {
   if (buffered_idx >= prefetch) {
     int rc = RAND_bytes(reinterpret_cast<uint8_t*>(buffered), sizeof(buffered));
     ASSERT(rc == 1);
-    UNREFERENCED_PARAMETER(rc);
     buffered_idx = 0;
   }
 
@@ -89,7 +88,6 @@ std::string RandomGeneratorImpl::uuid() {
   if (buffered_idx + 16 > sizeof(buffered)) {
     int rc = RAND_bytes(buffered, sizeof(buffered));
     ASSERT(rc == 1);
-    UNREFERENCED_PARAMETER(rc);
     buffered_idx = 0;
   }
 

--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -412,7 +412,6 @@ ClientContextImpl::ClientContextImpl(ContextManagerImpl& parent, Stats::Scope& s
     int rc = SSL_CTX_set_alpn_protos(ctx_.get(), &parsed_alpn_protocols_[0],
                                      parsed_alpn_protocols_.size());
     RELEASE_ASSERT(rc == 0);
-    UNREFERENCED_PARAMETER(rc);
   }
 
   server_name_indication_ = config.serverNameIndication();
@@ -424,7 +423,6 @@ bssl::UniquePtr<SSL> ClientContextImpl::newSsl() const {
   if (!server_name_indication_.empty()) {
     int rc = SSL_set_tlsext_host_name(ssl_con.get(), server_name_indication_.c_str());
     RELEASE_ASSERT(rc);
-    UNREFERENCED_PARAMETER(rc);
   }
 
   return ssl_con;
@@ -663,7 +661,6 @@ void ServerContextImpl::updateConnectionContext(SSL* ssl) {
   // TODO(PiotrSikora): add getters to BoringSSL.
   rc = SSL_set1_curves_list(ssl, ecdh_curves_.c_str());
   ASSERT(rc == 1);
-  UNREFERENCED_PARAMETER(rc);
 }
 
 int ServerContextImpl::sessionTicketProcess(SSL*, uint8_t* key_name, uint8_t* iv,
@@ -686,7 +683,6 @@ int ServerContextImpl::sessionTicketProcess(SSL*, uint8_t* key_name, uint8_t* iv
 
     int rc = RAND_bytes(iv, EVP_CIPHER_iv_length(cipher));
     ASSERT(rc);
-    UNREFERENCED_PARAMETER(rc);
 
     // This RELEASE_ASSERT is logically a static_assert, but we can't actually get
     // EVP_CIPHER_key_length(cipher) at compile-time

--- a/source/common/ssl/ssl_socket.cc
+++ b/source/common/ssl/ssl_socket.cc
@@ -136,7 +136,6 @@ void SslSocket::drainErrorQueue() {
     ENVOY_CONN_LOG(debug, "SSL error: {}:{}:{}:{}", callbacks_->connection(), err,
                    ERR_lib_error_string(err), ERR_func_error_string(err),
                    ERR_reason_error_string(err));
-    UNREFERENCED_PARAMETER(err);
   }
   if (saw_error && !saw_counted_error) {
     ctx_.stats().connection_error_.inc();
@@ -207,7 +206,6 @@ void SslSocket::shutdownSsl() {
   if (!shutdown_sent_ && callbacks_->connection().state() != Network::Connection::State::Closed) {
     int rc = SSL_shutdown(ssl_.get());
     ENVOY_CONN_LOG(debug, "SSL shutdown: rc={}", callbacks_->connection(), rc);
-    UNREFERENCED_PARAMETER(rc);
     drainErrorQueue();
     shutdown_sent_ = true;
   }
@@ -334,7 +332,6 @@ std::string SslSocket::getSubjectFromCertificate(X509* cert) const {
   size_t data_len;
   int rc = BIO_mem_contents(buf.get(), &data, &data_len);
   ASSERT(rc == 1);
-  UNREFERENCED_PARAMETER(rc);
   return std::string(reinterpret_cast<const char*>(data), data_len);
 }
 

--- a/source/common/stats/statsd.cc
+++ b/source/common/stats/statsd.cc
@@ -23,7 +23,6 @@ Writer::Writer(Network::Address::InstanceConstSharedPtr address) {
 
   int rc = address->connect(fd_);
   ASSERT(rc != -1);
-  UNREFERENCED_PARAMETER(rc);
 }
 
 Writer::~Writer() {
@@ -113,11 +112,9 @@ TcpStatsdSink::TlsSink::~TlsSink() {
 void TcpStatsdSink::TlsSink::beginFlush(bool expect_empty_buffer) {
   ASSERT(!expect_empty_buffer || buffer_.length() == 0);
   ASSERT(current_slice_mem_ == nullptr);
-  UNREFERENCED_PARAMETER(expect_empty_buffer);
 
   uint64_t num_iovecs = buffer_.reserve(FLUSH_SLICE_SIZE_BYTES, &current_buffer_slice_, 1);
   ASSERT(num_iovecs == 1);
-  UNREFERENCED_PARAMETER(num_iovecs);
 
   ASSERT(current_buffer_slice_.len_ >= FLUSH_SLICE_SIZE_BYTES);
   current_slice_mem_ = reinterpret_cast<char*>(current_buffer_slice_.mem_);
@@ -147,7 +144,6 @@ void TcpStatsdSink::TlsSink::commonFlush(const std::string& name, uint64_t value
   *current_slice_mem_++ = '\n';
 
   ASSERT(static_cast<uint64_t>(current_slice_mem_ - snapped_current) < max_size);
-  UNREFERENCED_PARAMETER(snapped_current);
 }
 
 void TcpStatsdSink::TlsSink::flushCounter(const std::string& name, uint64_t delta) {

--- a/source/common/upstream/cds_subscription.h
+++ b/source/common/upstream/cds_subscription.h
@@ -34,7 +34,6 @@ private:
              Config::SubscriptionCallbacks<envoy::api::v2::Cluster>& callbacks) override {
     // CDS subscribes to all clusters.
     ASSERT(resources.empty());
-    UNREFERENCED_PARAMETER(resources);
     callbacks_ = &callbacks;
     RestApiFetcher::initialize();
   }

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -127,7 +127,6 @@ ZoneAwareLoadBalancerBase::ZoneAwareLoadBalancerBase(
     local_priority_set_member_update_cb_handle_ = local_priority_set_->addMemberUpdateCb(
         [this](uint32_t priority, const HostVector&, const HostVector&) -> void {
           ASSERT(priority == 0);
-          UNREFERENCED_PARAMETER(priority);
           // If the set of local Envoys changes, regenerate routing for P=0 as it does priority
           // based routing.
           regenerateLocalityRoutingStructures();

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -203,7 +203,7 @@ void DetectorImpl::checkHostForUneject(HostSharedPtr host, DetectorHostMonitorIm
   std::chrono::milliseconds base_eject_time =
       std::chrono::milliseconds(runtime_.snapshot().getInteger(
           "outlier_detection.base_ejection_time_ms", config_.baseEjectionTimeMs()));
-  ASSERT(monitor->numEjections() > 0)
+  ASSERT(monitor->numEjections() > 0);
   if ((base_eject_time * monitor->numEjections()) <= (now - monitor->lastEjectionTime().value())) {
     stats_.ejections_active_.dec();
     host->healthFlagClear(Host::HealthFlag::FAILED_OUTLIER_CHECK);

--- a/source/extensions/filters/common/ext_authz/ext_authz_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_impl.cc
@@ -62,7 +62,6 @@ void GrpcClientImpl::onSuccess(std::unique_ptr<envoy::service::auth::v2::CheckRe
 void GrpcClientImpl::onFailure(Grpc::Status::GrpcStatus status, const std::string&,
                                Tracing::Span&) {
   ASSERT(status != Grpc::Status::GrpcStatus::Ok);
-  UNREFERENCED_PARAMETER(status);
   callbacks_->onComplete(CheckStatus::Error);
   callbacks_ = nullptr;
 }

--- a/source/extensions/filters/network/tcp_proxy/tcp_proxy.cc
+++ b/source/extensions/filters/network/tcp_proxy/tcp_proxy.cc
@@ -531,7 +531,6 @@ TcpProxyUpstreamDrainManager::~TcpProxyUpstreamDrainManager() {
     // cancelDrain() should cause that drainer to be removed from drainers_.
     // ASSERT so that we don't end up in an infinite loop.
     ASSERT(drainers_.find(key) == drainers_.end());
-    UNREFERENCED_PARAMETER(key);
   }
 }
 

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -60,7 +60,6 @@ SharedMemory& SharedMemory::initialize(uint32_t stats_set_size, Options& options
   if (options.restartEpoch() == 0) {
     int rc = os_sys_calls.ftruncate(shmem_fd, total_size);
     RELEASE_ASSERT(rc != -1);
-    UNREFERENCED_PARAMETER(rc);
   }
 
   SharedMemory* shmem = reinterpret_cast<SharedMemory*>(
@@ -137,7 +136,6 @@ HotRestartImpl::HotRestartImpl(Options& options)
   // logic killing the entire process tree. We should never exist without our parent.
   int rc = prctl(PR_SET_PDEATHSIG, SIGTERM);
   RELEASE_ASSERT(rc != -1);
-  UNREFERENCED_PARAMETER(rc);
 }
 
 Stats::RawStatData* HotRestartImpl::alloc(const std::string& name) {
@@ -170,7 +168,6 @@ void HotRestartImpl::free(Stats::RawStatData& data) {
   }
   bool key_removed = stats_set_->remove(data.key());
   ASSERT(key_removed);
-  UNREFERENCED_PARAMETER(key_removed);
   memset(&data, 0, Stats::RawStatData::size());
 }
 
@@ -272,7 +269,6 @@ void HotRestartImpl::initialize(Event::Dispatcher& dispatcher, Server::Instance&
       dispatcher.createFileEvent(my_domain_socket_,
                                  [this](uint32_t events) -> void {
                                    ASSERT(events == Event::FileReadyType::Read);
-                                   UNREFERENCED_PARAMETER(events);
                                    onSocketEvent();
                                  },
                                  Event::FileTriggerType::Edge, Event::FileReadyType::Read);
@@ -284,7 +280,6 @@ HotRestartImpl::RpcBase* HotRestartImpl::receiveRpc(bool block) {
   if (block) {
     int rc = fcntl(my_domain_socket_, F_SETFL, 0);
     RELEASE_ASSERT(rc != -1);
-    UNREFERENCED_PARAMETER(rc);
   }
 
   iovec iov[1];
@@ -314,7 +309,6 @@ HotRestartImpl::RpcBase* HotRestartImpl::receiveRpc(bool block) {
   if (block) {
     int rc = fcntl(my_domain_socket_, F_SETFL, O_NONBLOCK);
     RELEASE_ASSERT(rc != -1);
-    UNREFERENCED_PARAMETER(rc);
   }
 
   RpcBase* rpc = reinterpret_cast<RpcBase*>(&rpc_buffer_[0]);
@@ -352,7 +346,6 @@ void HotRestartImpl::sendMessage(sockaddr_un& address, RpcBase& rpc) {
   message.msg_iovlen = 1;
   int rc = sendmsg(my_domain_socket_, &message, 0);
   RELEASE_ASSERT(rc != -1);
-  UNREFERENCED_PARAMETER(rc);
 }
 
 void HotRestartImpl::onGetListenSocket(RpcGetListenSocketRequest& rpc) {
@@ -396,7 +389,6 @@ void HotRestartImpl::onGetListenSocket(RpcGetListenSocketRequest& rpc) {
 
     int rc = sendmsg(my_domain_socket_, &message, 0);
     RELEASE_ASSERT(rc != -1);
-    UNREFERENCED_PARAMETER(rc);
   }
 }
 

--- a/source/server/hot_restart_impl.h
+++ b/source/server/hot_restart_impl.h
@@ -104,7 +104,6 @@ public:
   void unlock() override {
     int rc = pthread_mutex_unlock(&mutex_);
     ASSERT(rc == 0);
-    UNREFERENCED_PARAMETER(rc);
   }
 
 private:

--- a/source/server/http/config_tracker_impl.cc
+++ b/source/server/http/config_tracker_impl.cc
@@ -19,7 +19,6 @@ ConfigTrackerImpl::EntryOwnerImpl::EntryOwnerImpl(const std::shared_ptr<ConfigTr
 ConfigTrackerImpl::EntryOwnerImpl::~EntryOwnerImpl() {
   size_t erased = map_->erase(key_);
   ASSERT(erased == 1);
-  UNREFERENCED_PARAMETER(erased);
 }
 
 } // namespace Server

--- a/source/server/lds_subscription.h
+++ b/source/server/lds_subscription.h
@@ -31,7 +31,6 @@ private:
              Config::SubscriptionCallbacks<envoy::api::v2::Listener>& callbacks) override {
     // LDS subscribes to all clusters.
     ASSERT(resources.empty());
-    UNREFERENCED_PARAMETER(resources);
     callbacks_ = &callbacks;
     RestApiFetcher::initialize();
   }

--- a/test/common/ssl/ssl_socket_test.cc
+++ b/test/common/ssl/ssl_socket_test.cc
@@ -178,7 +178,6 @@ const std::string testUtilV2(const envoy::api::v2::Listener& server_proto,
                                client_session.size(), client_ssl_context);
     int rc = SSL_set_session(client_ssl_socket, client_ssl_session);
     ASSERT(rc == 1);
-    UNREFERENCED_PARAMETER(rc);
     SSL_SESSION_free(client_ssl_session);
   }
 
@@ -222,7 +221,6 @@ const std::string testUtilV2(const envoy::api::v2::Listener& server_proto,
       size_t session_len;
       int rc = SSL_SESSION_to_bytes(client_ssl_session, &session_data, &session_len);
       ASSERT(rc == 1);
-      UNREFERENCED_PARAMETER(rc);
       new_session = std::string(reinterpret_cast<char*>(session_data), session_len);
       OPENSSL_free(session_data);
       server_connection->close(Network::ConnectionCloseType::NoFlush);


### PR DESCRIPTION
*Description*:
This changes the `ASSERT(condition)` macro to put the condition in an unevaluated context if ASSERTS are disabled. Essentially, the `ASSERT()` becomes a static check that its argument is an expression whose value can be statically casted to a bool. This means the condition doesn't just disappear, but the compiler still doesn't emit any code. The biggest benefit of this change is keeping compilation success/failure independent of whether ASSERTS are enabled, which has bitten me a few times. Therefore, I also did a rough and probably incomplete codemod that deletes `UNREFERENCED_PARAMETER()` calls that are no longer necessary.

Further, both `ASSERT()` and `RELEASE_ASSERT()` are now wrapped in `do { ... } while(false)`. In terms of this PR , the main consequence is fixing a couple spots where ASSERT statements don't have semicolons.

*Risk Level*: Low

*Testing*: Local building in opt and dbg. Otherwise, waiting for CI

*Docs Changes*: N/A

*Release Notes*: N/A