### PR TITLE
Add option to create gRPC async client without checking for cluster.

### DIFF
--- a/include/envoy/grpc/async_client_manager.h
+++ b/include/envoy/grpc/async_client_manager.h
@@ -34,12 +34,14 @@ public:
    * will raise an exception on failure.
    * @param grpc_service envoy::api::v2::core::GrpcService configuration.
    * @param scope stats scope.
+   * @param skip_cluster_check if set to true skips checks for cluster presence and being statically
+   * configured.
    * @return AsyncClientFactoryPtr factory for grpc_service.
    * @throws EnvoyException when grpc_service validation fails.
    */
   virtual AsyncClientFactoryPtr
-  factoryForGrpcService(const envoy::api::v2::core::GrpcService& grpc_service,
-                        Stats::Scope& scope) PURE;
+  factoryForGrpcService(const envoy::api::v2::core::GrpcService& grpc_service, Stats::Scope& scope,
+                        bool skip_cluster_check) PURE;
 };
 
 typedef std::unique_ptr<AsyncClientManager> AsyncClientManagerPtr;

--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -190,7 +190,7 @@ Utility::factoryForApiConfigSource(Grpc::AsyncClientManager& async_client_manage
     grpc_service.mutable_envoy_grpc()->set_cluster_name(api_config_source.cluster_names(0));
   }
 
-  return async_client_manager.factoryForGrpcService(grpc_service, scope);
+  return async_client_manager.factoryForGrpcService(grpc_service, scope, false);
 }
 
 } // namespace Config

--- a/source/common/grpc/async_client_impl.cc
+++ b/source/common/grpc/async_client_impl.cc
@@ -60,28 +60,35 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent,
     : parent_(parent), service_method_(service_method), callbacks_(callbacks), timeout_(timeout) {}
 
 void AsyncStreamImpl::initialize(bool buffer_body_for_retry) {
-  auto& http_async_client = parent_.cm_.httpAsyncClientForCluster(parent_.remote_cluster_name_);
-  dispatcher_ = &http_async_client.dispatcher();
-  stream_ = http_async_client.start(*this, absl::optional<std::chrono::milliseconds>(timeout_),
-                                    buffer_body_for_retry);
+  try {
+    auto& http_async_client = parent_.cm_.httpAsyncClientForCluster(parent_.remote_cluster_name_);
+    dispatcher_ = &http_async_client.dispatcher();
+    stream_ = http_async_client.start(*this, absl::optional<std::chrono::milliseconds>(timeout_),
+                                      buffer_body_for_retry);
 
-  if (stream_ == nullptr) {
-    callbacks_.onRemoteClose(Status::GrpcStatus::Unavailable, EMPTY_STRING);
+    if (stream_ == nullptr) {
+      callbacks_.onRemoteClose(Status::GrpcStatus::Unavailable, EMPTY_STRING);
+      http_reset_ = true;
+      return;
+    }
+
+    // TODO(htuch): match Google gRPC base64 encoding behavior for *-bin headers, see
+    // https://github.com/envoyproxy/envoy/pull/2444#discussion_r163914459.
+    headers_message_ =
+        Common::prepareHeaders(parent_.remote_cluster_name_, service_method_.service()->full_name(),
+                               service_method_.name());
+    // Fill service-wide initial metadata.
+    for (const auto& header_value : parent_.initial_metadata_) {
+      headers_message_->headers().addCopy(Http::LowerCaseString(header_value.key()),
+                                          header_value.value());
+    }
+    callbacks_.onCreateInitialMetadata(headers_message_->headers());
+    stream_->sendHeaders(headers_message_->headers(), false);
+  } catch (const EnvoyException&) {
+    stream_ = nullptr;
+    callbacks_.onRemoteClose(Status::GrpcStatus::Unavailable, "Cluster not available");
     http_reset_ = true;
-    return;
   }
-
-  // TODO(htuch): match Google gRPC base64 encoding behavior for *-bin headers, see
-  // https://github.com/envoyproxy/envoy/pull/2444#discussion_r163914459.
-  headers_message_ = Common::prepareHeaders(
-      parent_.remote_cluster_name_, service_method_.service()->full_name(), service_method_.name());
-  // Fill service-wide initial metadata.
-  for (const auto& header_value : parent_.initial_metadata_) {
-    headers_message_->headers().addCopy(Http::LowerCaseString(header_value.key()),
-                                        header_value.value());
-  }
-  callbacks_.onCreateInitialMetadata(headers_message_->headers());
-  stream_->sendHeaders(headers_message_->headers(), false);
 }
 
 // TODO(htuch): match Google gRPC base64 encoding behavior for *-bin headers, see

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -11,7 +11,7 @@ namespace Grpc {
 class AsyncClientFactoryImpl : public AsyncClientFactory {
 public:
   AsyncClientFactoryImpl(Upstream::ClusterManager& cm,
-                         const envoy::api::v2::core::GrpcService& config);
+                         const envoy::api::v2::core::GrpcService& config, bool skip_cluster_check);
 
   AsyncClientPtr create() override;
 
@@ -41,7 +41,8 @@ public:
 
   // Grpc::AsyncClientManager
   AsyncClientFactoryPtr factoryForGrpcService(const envoy::api::v2::core::GrpcService& config,
-                                              Stats::Scope& scope) override;
+                                              Stats::Scope& scope,
+                                              bool skip_cluster_check) override;
 
 private:
   Upstream::ClusterManager& cm_;

--- a/source/common/ratelimit/ratelimit_impl.cc
+++ b/source/common/ratelimit/ratelimit_impl.cc
@@ -83,7 +83,7 @@ GrpcFactoryImpl::GrpcFactoryImpl(const envoy::config::ratelimit::v2::RateLimitSe
       envoy::config::ratelimit::v2::RateLimitServiceConfig::kClusterName) {
     grpc_service.mutable_envoy_grpc()->set_cluster_name(config.cluster_name());
   }
-  async_client_factory_ = async_client_manager.factoryForGrpcService(grpc_service, scope);
+  async_client_factory_ = async_client_manager.factoryForGrpcService(grpc_service, scope, false);
 }
 
 ClientPtr GrpcFactoryImpl::create(const absl::optional<std::chrono::milliseconds>& timeout) {

--- a/source/server/config/access_log/grpc_access_log.cc
+++ b/source/server/config/access_log/grpc_access_log.cc
@@ -28,7 +28,7 @@ AccessLog::InstanceSharedPtr HttpGrpcAccessLogFactory::createAccessLogInstance(
           [&context, grpc_service = proto_config.common_config().grpc_service() ] {
             return std::make_shared<AccessLog::GrpcAccessLogStreamerImpl>(
                 context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
-                    grpc_service, context.scope()),
+                    grpc_service, context.scope(), false),
                 context.threadLocal(), context.localInfo());
           });
 

--- a/source/server/config/http/ext_authz.cc
+++ b/source/server/config/http/ext_authz.cc
@@ -25,8 +25,8 @@ HttpFilterFactoryCb ExtAuthzFilterConfig::createFilter(
   return [ grpc_service = proto_config.grpc_service(), &context, filter_config,
            timeout_ms ](Http::FilterChainFactoryCallbacks & callbacks) {
     auto async_client_factory =
-        context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(grpc_service,
-                                                                                context.scope());
+        context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
+            grpc_service, context.scope(), false);
     auto client = std::make_unique<Envoy::ExtAuthz::GrpcClientImpl>(
         async_client_factory->create(), std::chrono::milliseconds(timeout_ms));
     callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterSharedPtr{

--- a/source/server/config/network/ext_authz.cc
+++ b/source/server/config/network/ext_authz.cc
@@ -28,8 +28,8 @@ NetworkFilterFactoryCb ExtAuthzConfigFactory::createFilter(
       ->void {
 
     auto async_client_factory =
-        context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(grpc_service,
-                                                                                context.scope());
+        context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
+            grpc_service, context.scope(), false);
 
     auto client = std::make_unique<Envoy::ExtAuthz::GrpcClientImpl>(
         async_client_factory->create(), std::chrono::milliseconds(timeout_ms));

--- a/source/server/config/stats/metrics_service.cc
+++ b/source/server/config/stats/metrics_service.cc
@@ -25,8 +25,8 @@ Stats::SinkPtr MetricsServiceSinkFactory::createStatsSink(const Protobuf::Messag
 
   std::shared_ptr<Stats::Metrics::GrpcMetricsStreamer> grpc_metrics_streamer =
       std::make_shared<Stats::Metrics::GrpcMetricsStreamerImpl>(
-          server.clusterManager().grpcAsyncClientManager().factoryForGrpcService(grpc_service,
-                                                                                 server.stats()),
+          server.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
+              grpc_service, server.stats(), false),
           server.threadLocal(), server.localInfo());
 
   return Stats::SinkPtr(

--- a/test/common/config/subscription_factory_test.cc
+++ b/test/common/config/subscription_factory_test.cc
@@ -170,8 +170,9 @@ TEST_F(SubscriptionFactoryTest, GrpcSubscription) {
   EXPECT_CALL(cluster, info()).Times(2);
   EXPECT_CALL(*cluster.info_, addedViaApi());
   EXPECT_CALL(cm_, grpcAsyncClientManager()).WillOnce(ReturnRef(cm_.async_client_manager_));
-  EXPECT_CALL(cm_.async_client_manager_, factoryForGrpcService(ProtoEq(expected_grpc_service), _))
-      .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&) {
+  EXPECT_CALL(cm_.async_client_manager_,
+              factoryForGrpcService(ProtoEq(expected_grpc_service), _, _))
+      .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&, bool) {
         auto async_client_factory = std::make_unique<Grpc::MockAsyncClientFactory>();
         EXPECT_CALL(*async_client_factory, create()).WillOnce(Invoke([] {
           return std::make_unique<NiceMock<Grpc::MockAsyncClient>>();

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -24,6 +24,7 @@ using testing::AtLeast;
 using testing::Ref;
 using testing::Return;
 using testing::ReturnRef;
+using testing::_;
 
 namespace Envoy {
 namespace Config {
@@ -272,7 +273,7 @@ TEST(UtilityTest, FactoryForApiConfigSource) {
     envoy::api::v2::core::GrpcService expected_grpc_service;
     expected_grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
     EXPECT_CALL(async_client_manager,
-                factoryForGrpcService(ProtoEq(expected_grpc_service), Ref(scope)));
+                factoryForGrpcService(ProtoEq(expected_grpc_service), Ref(scope), _));
     Utility::factoryForApiConfigSource(async_client_manager, api_config_source, scope);
   }
 
@@ -281,7 +282,7 @@ TEST(UtilityTest, FactoryForApiConfigSource) {
     api_config_source.set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
     api_config_source.add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("foo");
     EXPECT_CALL(async_client_manager,
-                factoryForGrpcService(ProtoEq(api_config_source.grpc_services(0)), Ref(scope)));
+                factoryForGrpcService(ProtoEq(api_config_source.grpc_services(0)), Ref(scope), _));
     Utility::factoryForApiConfigSource(async_client_manager, api_config_source, scope);
   }
 }

--- a/test/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/common/ratelimit/ratelimit_impl_test.cc
@@ -126,8 +126,8 @@ TEST(RateLimitGrpcFactoryTest, Create) {
   Grpc::MockAsyncClientManager async_client_manager;
   Stats::MockStore scope;
   EXPECT_CALL(async_client_manager,
-              factoryForGrpcService(ProtoEq(config.grpc_service()), Ref(scope)))
-      .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&) {
+              factoryForGrpcService(ProtoEq(config.grpc_service()), Ref(scope), _))
+      .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&, bool) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
   GrpcFactoryImpl factory(config, async_client_manager, scope);
@@ -143,8 +143,8 @@ TEST(RateLimitGrpcFactoryTest, CreateLegacy) {
   envoy::api::v2::core::GrpcService expected_grpc_service;
   expected_grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
   EXPECT_CALL(async_client_manager,
-              factoryForGrpcService(ProtoEq(expected_grpc_service), Ref(scope)))
-      .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&) {
+              factoryForGrpcService(ProtoEq(expected_grpc_service), Ref(scope), _))
+      .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&, bool) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
   GrpcFactoryImpl factory(config, async_client_manager, scope);

--- a/test/mocks/grpc/mocks.h
+++ b/test/mocks/grpc/mocks.h
@@ -82,9 +82,9 @@ public:
   MockAsyncClientManager();
   ~MockAsyncClientManager();
 
-  MOCK_METHOD2(factoryForGrpcService,
+  MOCK_METHOD3(factoryForGrpcService,
                AsyncClientFactoryPtr(const envoy::api::v2::core::GrpcService& grpc_service,
-                                     Stats::Scope& scope));
+                                     Stats::Scope& scope, bool skip_cluster_check));
 };
 
 } // namespace Grpc

--- a/test/server/config/access_log/config_test.cc
+++ b/test/server/config/access_log/config_test.cc
@@ -27,8 +27,8 @@ public:
     message_ = factory_->createEmptyConfigProto();
     ASSERT_NE(nullptr, message_);
 
-    EXPECT_CALL(context_.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _))
-        .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&) {
+    EXPECT_CALL(context_.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
+        .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&, bool) {
           return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
         }));
 

--- a/test/server/config/http/config_test.cc
+++ b/test/server/config/http/config_test.cc
@@ -464,8 +464,8 @@ TEST(HttpExtAuthzConfigTest, ExtAuthzCorrectProto) {
   NiceMock<MockFactoryContext> context;
   ExtAuthzFilterConfig factory;
 
-  EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _))
-      .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&) {
+  EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
+      .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&, bool) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
   HttpFilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);

--- a/test/server/config/network/config_test.cc
+++ b/test/server/config/network/config_test.cc
@@ -420,8 +420,8 @@ TEST(NetworkFilterConfigTest, ExtAuthzCorrectProto) {
   NiceMock<MockFactoryContext> context;
   ExtAuthzConfigFactory factory;
 
-  EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _))
-      .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&) {
+  EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
+      .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&, bool) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
   NetworkFilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, context);


### PR DESCRIPTION
*title*: *Add option to create a async gRPC client which defers cluster check*
*Description*:
In issue https://github.com/envoyproxy/envoy/issues/2785 we discussed adding an option s.t when creating a gRPC client the check for the presence of the cluster is skipped.
This PR adds the boolean to be enable it.
As it will now be possible that the underlying cluster is not there I also added a check in the gRPC client implementation that if `httpAsyncClientForCluster` throws an exception then the session will be closed with status `Unavailable`. 

*Risk Level*: Low 
Low: Default behavior is not changed.

*Testing*:
Added corresponding UT's

*Note*: I know the repo is getting re-org'd and the merge won't happen. But I wanted to get the PR up so that we can get agreement that the implemented logic is what we want.

Signed-off-by: Saurabh Mohan <saurabh+github@tigera.io>
