### PR TITLE
test fix: count number of configurations tested once.

### DIFF
--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -109,15 +109,13 @@ uint32_t run(const std::string& directory) {
   for (const std::string& filename : TestUtility::listFiles(directory, false)) {
     Server::TestOptionsImpl options(filename, Network::Address::IpVersion::v6);
     ConfigTest test1(options);
-    num_tested++;
-
     // Config flag --config-yaml is only supported for v2 configs.
     envoy::config::bootstrap::v2::Bootstrap bootstrap;
     if (Server::InstanceUtil::loadBootstrapConfig(bootstrap, options) ==
         Server::InstanceUtil::BootstrapVersion::V2) {
       ConfigTest test2(options.asConfigYaml());
-      num_tested++;
     }
+    num_tested++;
   }
   return num_tested;
 }

--- a/test/config_test/example_configs_test.cc
+++ b/test/config_test/example_configs_test.cc
@@ -15,7 +15,7 @@ TEST(ExampleConfigsTest, All) {
   RELEASE_ASSERT(::getcwd(cwd, PATH_MAX) != nullptr);
   RELEASE_ASSERT(::chdir(directory.c_str()) == 0);
 
-  EXPECT_EQ(37UL, ConfigTest::run(directory));
+  EXPECT_EQ(26UL, ConfigTest::run(directory));
   ConfigTest::testMerge();
   ConfigTest::testIncompatibleMerge();
 


### PR DESCRIPTION
*Description*:  When counting the number of configurations tested in ConfigTest::run() v2 configurations ended up getting double counted.

*Risk Level*: Low 

