### PR TITLE
mongo-proxy: handlers for OP_COMMAND and OP_COMMANDREPLY messages

### DIFF
--- a/source/extensions/filters/network/mongo_proxy/codec.h
+++ b/source/extensions/filters/network/mongo_proxy/codec.h
@@ -39,6 +39,12 @@ public:
   virtual int32_t requestId() const PURE;
   virtual int32_t responseTo() const PURE;
   virtual std::string toString(bool full) const PURE;
+
+  // Define some constants used in mongo messages encoding
+  constexpr static uint32_t kMessageHeaderSize = 16;
+  constexpr static uint32_t kInt32Length = 4;
+  constexpr static uint32_t kInt64Length = 8;
+  constexpr static uint32_t kStringPaddingLength = 1;
 };
 
 /**

--- a/source/extensions/filters/network/mongo_proxy/codec.h
+++ b/source/extensions/filters/network/mongo_proxy/codec.h
@@ -41,10 +41,10 @@ public:
   virtual std::string toString(bool full) const PURE;
 
   // Define some constants used in mongo messages encoding
-  constexpr static uint32_t kMessageHeaderSize = 16;
-  constexpr static uint32_t kInt32Length = 4;
-  constexpr static uint32_t kInt64Length = 8;
-  constexpr static uint32_t kStringPaddingLength = 1;
+  constexpr static uint32_t MessageHeaderSize = 16;
+  constexpr static uint32_t Int32Length = 4;
+  constexpr static uint32_t Int64Length = 8;
+  constexpr static uint32_t StringPaddingLength = 1;
 };
 
 /**

--- a/source/extensions/filters/network/mongo_proxy/codec.h
+++ b/source/extensions/filters/network/mongo_proxy/codec.h
@@ -29,7 +29,9 @@ public:
     OP_QUERY = 2004,
     OP_GET_MORE = 2005,
     OP_DELETE = 2006,
-    OP_KILL_CURSORS = 2007
+    OP_KILL_CURSORS = 2007,
+    OP_COMMAND = 2010,
+    OP_COMMANDREPLY = 2011
   };
 
   virtual ~Message(){};
@@ -148,6 +150,35 @@ public:
 
 typedef std::unique_ptr<ReplyMessage> ReplyMessagePtr;
 
+class CommandMessage : public virtual Message {
+public:
+  // CommandMessage accessors
+  virtual bool operator==(const CommandMessage& rhs) const PURE;
+  virtual std::string database() const PURE;
+  virtual void database(std::string database) PURE;
+  virtual std::string commandName() const PURE;
+  virtual void commandName(std::string commandName) PURE;
+  virtual const Bson::Document* metadata() const PURE;
+  virtual void metadata(Bson::DocumentSharedPtr&& metadata) PURE;
+  virtual const Bson::Document* commandArgs() const PURE;
+  virtual void commandArgs(Bson::DocumentSharedPtr&& commandArgs) PURE;
+  virtual const std::list<Bson::DocumentSharedPtr>& inputDocs() const PURE;
+};
+
+typedef std::unique_ptr<CommandMessage> CommandMessagePtr;
+
+class CommandReplyMessage : public virtual Message {
+public:
+  virtual bool operator==(const CommandReplyMessage& rhs) const PURE;
+  virtual const Bson::Document* metadata() const PURE;
+  virtual void metadata(Bson::DocumentSharedPtr&& metadata) PURE;
+  virtual const Bson::Document* commandReply() const PURE;
+  virtual void commandReply(Bson::DocumentSharedPtr&& commandReply) PURE;
+  virtual const std::list<Bson::DocumentSharedPtr>& outputDocs() const PURE;
+};
+
+typedef std::unique_ptr<CommandReplyMessage> CommandReplyMessagePtr;
+
 /**
  * General callbacks for dispatching decoded mongo messages to a sink.
  */
@@ -160,6 +191,8 @@ public:
   virtual void decodeKillCursors(KillCursorsMessagePtr&& message) PURE;
   virtual void decodeQuery(QueryMessagePtr&& message) PURE;
   virtual void decodeReply(ReplyMessagePtr&& message) PURE;
+  virtual void decodeCommand(CommandMessagePtr&& message) PURE;
+  virtual void decodeCommandReply(CommandReplyMessagePtr&& message) PURE;
 };
 
 /**
@@ -186,6 +219,8 @@ public:
   virtual void encodeKillCursors(const KillCursorsMessage& message) PURE;
   virtual void encodeQuery(const QueryMessage& message) PURE;
   virtual void encodeReply(const ReplyMessage& message) PURE;
+  virtual void encodeCommand(const CommandMessage& message) PURE;
+  virtual void encodeCommandReply(const CommandReplyMessage& message) PURE;
 };
 
 } // namespace MongoProxy

--- a/source/extensions/filters/network/mongo_proxy/codec.h
+++ b/source/extensions/filters/network/mongo_proxy/codec.h
@@ -169,6 +169,7 @@ public:
   virtual const Bson::Document* commandArgs() const PURE;
   virtual void commandArgs(Bson::DocumentSharedPtr&& commandArgs) PURE;
   virtual const std::list<Bson::DocumentSharedPtr>& inputDocs() const PURE;
+  virtual std::list<Bson::DocumentSharedPtr>& inputDocs() PURE;
 };
 
 typedef std::unique_ptr<CommandMessage> CommandMessagePtr;
@@ -181,6 +182,7 @@ public:
   virtual const Bson::Document* commandReply() const PURE;
   virtual void commandReply(Bson::DocumentSharedPtr&& commandReply) PURE;
   virtual const std::list<Bson::DocumentSharedPtr>& outputDocs() const PURE;
+  virtual std::list<Bson::DocumentSharedPtr>& outputDocs() PURE;
 };
 
 typedef std::unique_ptr<CommandReplyMessage> CommandReplyMessagePtr;

--- a/source/extensions/filters/network/mongo_proxy/codec.h
+++ b/source/extensions/filters/network/mongo_proxy/codec.h
@@ -152,7 +152,7 @@ typedef std::unique_ptr<ReplyMessage> ReplyMessagePtr;
 
 class CommandMessage : public virtual Message {
 public:
-  // CommandMessage accessors
+  // CommandMessage accessors.
   virtual bool operator==(const CommandMessage& rhs) const PURE;
   virtual std::string database() const PURE;
   virtual void database(std::string database) PURE;

--- a/source/extensions/filters/network/mongo_proxy/codec_impl.cc
+++ b/source/extensions/filters/network/mongo_proxy/codec_impl.cc
@@ -520,8 +520,7 @@ void EncoderImpl::encodeQuery(const QueryMessage& message) {
 
 void EncoderImpl::encodeReply(const ReplyMessage& message) {
   // https://docs.mongodb.org/manual/reference/mongodb-wire-protocol/#op-reply
-  int32_t total_size =
-      Message::MessageHeaderSize + 3 * Message::Int32Length + Message::Int64Length;
+  int32_t total_size = Message::MessageHeaderSize + 3 * Message::Int32Length + Message::Int64Length;
   for (const Bson::DocumentSharedPtr& document : message.documents()) {
     total_size += document->byteSize();
   }

--- a/source/extensions/filters/network/mongo_proxy/codec_impl.h
+++ b/source/extensions/filters/network/mongo_proxy/codec_impl.h
@@ -211,6 +211,7 @@ public:
     command_args_ = std::move(command_args);
   }
   const std::list<Bson::DocumentSharedPtr>& inputDocs() const override { return input_docs_; }
+  std::list<Bson::DocumentSharedPtr>& inputDocs() override { return input_docs_; }
 
 private:
   std::string database_;
@@ -240,6 +241,7 @@ public:
     command_reply_ = std::move(command_reply);
   }
   const std::list<Bson::DocumentSharedPtr>& outputDocs() const override { return output_docs_; }
+  std::list<Bson::DocumentSharedPtr>& outputDocs() override { return output_docs_; }
 
 private:
   Bson::DocumentSharedPtr metadata_;

--- a/source/extensions/filters/network/mongo_proxy/codec_impl.h
+++ b/source/extensions/filters/network/mongo_proxy/codec_impl.h
@@ -187,64 +187,64 @@ private:
   std::list<Bson::DocumentSharedPtr> documents_;
 };
 
-// OP_COMMAND message
+// OP_COMMAND message.
 class CommandMessageImpl : public MessageImpl,
                            public CommandMessage,
                            Logger::Loggable<Logger::Id::mongo> {
 public:
   using MessageImpl::MessageImpl;
 
-  // MessageImpl
+  // MessageImpl.
   void fromBuffer(uint32_t message_length, Buffer::Instance& data) override;
   std::string toString(bool full) const override;
 
-  // CommandMessageImpl accessors
+  // CommandMessageImpl accessors.
   bool operator==(const CommandMessage& rhs) const override;
   std::string database() const override { return database_; }
   void database(std::string database) override { database_ = database; }
-  std::string commandName() const override { return commandName_; }
-  void commandName(std::string commandName) override { commandName_ = commandName; }
+  std::string commandName() const override { return command_name_; }
+  void commandName(std::string command_name) override { command_name_ = command_name; }
   const Bson::Document* metadata() const override { return metadata_.get(); }
   void metadata(Bson::DocumentSharedPtr&& metadata) override { metadata_ = std::move(metadata); }
-  const Bson::Document* commandArgs() const override { return commandArgs_.get(); }
-  void commandArgs(Bson::DocumentSharedPtr&& commandArgs) override {
-    commandArgs_ = std::move(commandArgs);
+  const Bson::Document* commandArgs() const override { return command_args_.get(); }
+  void commandArgs(Bson::DocumentSharedPtr&& command_args) override {
+    command_args_ = std::move(command_args);
   }
-  const std::list<Bson::DocumentSharedPtr>& inputDocs() const override { return inputDocs_; }
+  const std::list<Bson::DocumentSharedPtr>& inputDocs() const override { return input_docs_; }
 
 private:
   std::string database_;
-  std::string commandName_;
+  std::string command_name_;
   Bson::DocumentSharedPtr metadata_;
-  Bson::DocumentSharedPtr commandArgs_;
-  std::list<Bson::DocumentSharedPtr> inputDocs_;
+  Bson::DocumentSharedPtr command_args_;
+  std::list<Bson::DocumentSharedPtr> input_docs_;
 };
 
-// OP_COMMANDREPLY
+// OP_COMMANDREPLY message.
 class CommandReplyMessageImpl : public MessageImpl,
                                 public CommandReplyMessage,
                                 Logger::Loggable<Logger::Id::mongo> {
 public:
   using MessageImpl::MessageImpl;
 
-  // MessageImpl
+  // MessageImpl.
   void fromBuffer(uint32_t message_length, Buffer::Instance& data) override;
   std::string toString(bool full) const override;
 
-  // CommandMessageImpl accessors
+  // CommandMessageReplyImpl accessors.
   bool operator==(const CommandReplyMessage& rhs) const override;
   const Bson::Document* metadata() const override { return metadata_.get(); }
   void metadata(Bson::DocumentSharedPtr&& metadata) override { metadata_ = std::move(metadata); }
-  const Bson::Document* commandReply() const override { return commandReply_.get(); }
-  void commandReply(Bson::DocumentSharedPtr&& commandReply) override {
-    commandReply_ = std::move(commandReply);
+  const Bson::Document* commandReply() const override { return command_reply_.get(); }
+  void commandReply(Bson::DocumentSharedPtr&& command_reply) override {
+    command_reply_ = std::move(command_reply);
   }
-  const std::list<Bson::DocumentSharedPtr>& outputDocs() const override { return outputDocs_; }
+  const std::list<Bson::DocumentSharedPtr>& outputDocs() const override { return output_docs_; }
 
 private:
   Bson::DocumentSharedPtr metadata_;
-  Bson::DocumentSharedPtr commandReply_;
-  std::list<Bson::DocumentSharedPtr> outputDocs_;
+  Bson::DocumentSharedPtr command_reply_;
+  std::list<Bson::DocumentSharedPtr> output_docs_;
 };
 
 class DecoderImpl : public Decoder, Logger::Loggable<Logger::Id::mongo> {

--- a/source/extensions/filters/network/mongo_proxy/codec_impl.h
+++ b/source/extensions/filters/network/mongo_proxy/codec_impl.h
@@ -187,6 +187,66 @@ private:
   std::list<Bson::DocumentSharedPtr> documents_;
 };
 
+// OP_COMMAND message
+class CommandMessageImpl : public MessageImpl,
+                           public CommandMessage,
+                           Logger::Loggable<Logger::Id::mongo> {
+public:
+  using MessageImpl::MessageImpl;
+
+  // MessageImpl
+  void fromBuffer(uint32_t message_length, Buffer::Instance& data) override;
+  std::string toString(bool full) const override;
+
+  // CommandMessageImpl accessors
+  bool operator==(const CommandMessage& rhs) const override;
+  std::string database() const override { return database_; }
+  void database(std::string database) override { database_ = database; }
+  std::string commandName() const override { return commandName_; }
+  void commandName(std::string commandName) override { commandName_ = commandName; }
+  const Bson::Document* metadata() const override { return metadata_.get(); }
+  void metadata(Bson::DocumentSharedPtr&& metadata) override { metadata_ = std::move(metadata); }
+  const Bson::Document* commandArgs() const override { return commandArgs_.get(); }
+  void commandArgs(Bson::DocumentSharedPtr&& commandArgs) override {
+    commandArgs_ = std::move(commandArgs);
+  }
+  const std::list<Bson::DocumentSharedPtr>& inputDocs() const override { return inputDocs_; }
+
+private:
+  std::string database_;
+  std::string commandName_;
+  Bson::DocumentSharedPtr metadata_;
+  Bson::DocumentSharedPtr commandArgs_;
+  std::list<Bson::DocumentSharedPtr> inputDocs_;
+};
+
+// OP_COMMANDREPLY
+class CommandReplyMessageImpl : public MessageImpl,
+                                public CommandReplyMessage,
+                                Logger::Loggable<Logger::Id::mongo> {
+public:
+  using MessageImpl::MessageImpl;
+
+  // MessageImpl
+  void fromBuffer(uint32_t message_length, Buffer::Instance& data) override;
+  std::string toString(bool full) const override;
+
+  // CommandMessageImpl accessors
+  bool operator==(const CommandReplyMessage& rhs) const override;
+  const Bson::Document* metadata() const override { return metadata_.get(); }
+  void metadata(Bson::DocumentSharedPtr&& metadata) override { metadata_ = std::move(metadata); }
+  const Bson::Document* commandReply() const override { return commandReply_.get(); }
+  void commandReply(Bson::DocumentSharedPtr&& commandReply) override {
+    commandReply_ = std::move(commandReply);
+  }
+  const std::list<Bson::DocumentSharedPtr>& outputDocs() const override { return outputDocs_; }
+
+private:
+  Bson::DocumentSharedPtr metadata_;
+  Bson::DocumentSharedPtr commandReply_;
+  std::list<Bson::DocumentSharedPtr> outputDocs_;
+};
+
 class DecoderImpl : public Decoder, Logger::Loggable<Logger::Id::mongo> {
 public:
   DecoderImpl(DecoderCallbacks& callbacks) : callbacks_(callbacks) {}
@@ -210,6 +270,8 @@ public:
   void encodeKillCursors(const KillCursorsMessage& message) override;
   void encodeQuery(const QueryMessage& message) override;
   void encodeReply(const ReplyMessage& message) override;
+  void encodeCommand(const CommandMessage& message) override;
+  void encodeCommandReply(const CommandReplyMessage& message) override;
 
 private:
   void encodeCommonHeader(int32_t total_size, const Message& message, Message::OpCode op);

--- a/source/extensions/filters/network/mongo_proxy/proxy.cc
+++ b/source/extensions/filters/network/mongo_proxy/proxy.cc
@@ -207,6 +207,22 @@ void ProxyFilter::decodeReply(ReplyMessagePtr&& message) {
   }
 }
 
+void ProxyFilter::decodeCommand(CommandMessagePtr&& message) {
+  tryInjectDelay();
+
+  stats_.op_command_.inc();
+  logMessage(*message, true);
+  ENVOY_LOG(debug, "decoded COMMAND: {}", message->toString(true));
+}
+
+void ProxyFilter::decodeCommandReply(CommandReplyMessagePtr&& message) {
+  tryInjectDelay();
+
+  stats_.op_command_reply_.inc();
+  logMessage(*message, true);
+  ENVOY_LOG(debug, "decoded COMMANDREPLY: {}", message->toString(true));
+}
+
 void ProxyFilter::onDrainClose() {
   read_callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
 }

--- a/source/extensions/filters/network/mongo_proxy/proxy.h
+++ b/source/extensions/filters/network/mongo_proxy/proxy.h
@@ -68,7 +68,9 @@ typedef ConstSingleton<MongoRuntimeConfigKeys> MongoRuntimeConfig;
   COUNTER(op_reply_valid_cursor)                                                                   \
   COUNTER(cx_destroy_local_with_active_rq)                                                         \
   COUNTER(cx_destroy_remote_with_active_rq)                                                        \
-  COUNTER(cx_drain_close)
+  COUNTER(cx_drain_close)                                                                          \
+  COUNTER(op_command)                                                                              \
+  COUNTER(op_command_reply)
 // clang-format on
 
 /**
@@ -145,6 +147,8 @@ public:
   void decodeKillCursors(KillCursorsMessagePtr&& message) override;
   void decodeQuery(QueryMessagePtr&& message) override;
   void decodeReply(ReplyMessagePtr&& message) override;
+  void decodeCommand(CommandMessagePtr&& message) override;
+  void decodeCommandReply(CommandReplyMessagePtr&& message) override;
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;

--- a/test/extensions/filters/network/mongo_proxy/codec_impl_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/codec_impl_test.cc
@@ -341,6 +341,41 @@ TEST_F(MongoCodecImplTest, QueryToStringWithEscape) {
   EXPECT_NO_THROW(Json::Factory::loadFromString(query.toString(false)));
 }
 
+TEST_F(MongoCodecImplTest, CommandEqual) {
+  {
+    CommandMessageImpl m1(0, 0);
+    CommandMessageImpl m2(1, 1);
+    EXPECT_FALSE(m1 == m2);
+  }
+
+  // Trigger fail on comparing metadata.
+  {
+    CommandMessageImpl m1(0, 0);
+    m1.metadata(Bson::DocumentImpl::create()->addString("hello", "world"));
+    CommandMessageImpl m2(1, 1);
+    m2.metadata(Bson::DocumentImpl::create()->addString("world", "hello"));
+    EXPECT_FALSE(m1 == m2);
+  }
+
+  // Trigger fail on comparing commandArgs.
+  {
+    CommandMessageImpl m1(0, 0);
+    m1.commandArgs(Bson::DocumentImpl::create()->addString("hello", "world"));
+    CommandMessageImpl m2(1, 1);
+    m2.commandArgs(Bson::DocumentImpl::create()->addString("world", "hello"));
+    EXPECT_FALSE(m1 == m2);
+  }
+
+  // Trigger fail on comparing inputDocs.
+  {
+    CommandMessageImpl m1(0, 0);
+    m1.inputDocs().push_back(Bson::DocumentImpl::create()->addString("hello", "world"));
+    CommandMessageImpl m2(1, 1);
+    m2.inputDocs().push_back(Bson::DocumentImpl::create()->addString("world", "hello"));
+    EXPECT_FALSE(m1 == m2);
+  }
+}
+
 TEST_F(MongoCodecImplTest, Command) {
   CommandMessageImpl command(15, 25);
 
@@ -348,6 +383,7 @@ TEST_F(MongoCodecImplTest, Command) {
   command.commandName(std::string("Test command name"));
   command.metadata(Bson::DocumentImpl::create());
   command.commandArgs(Bson::DocumentImpl::create());
+  command.inputDocs().push_back(Bson::DocumentImpl::create()->addString("world", "hello"));
 
   EXPECT_NO_THROW(Json::Factory::loadFromString(command.toString(true)));
   EXPECT_NO_THROW(Json::Factory::loadFromString(command.toString(false)));
@@ -357,11 +393,46 @@ TEST_F(MongoCodecImplTest, Command) {
   decoder_.onData(output_);
 }
 
+TEST_F(MongoCodecImplTest, CommandReplyEqual) {
+  {
+    CommandReplyMessageImpl m1(0, 0);
+    CommandReplyMessageImpl m2(1, 1);
+    EXPECT_FALSE(m1 == m2);
+  }
+
+  // Trigger fail on comparing metadata.
+  {
+    CommandReplyMessageImpl m1(0, 0);
+    m1.metadata(Bson::DocumentImpl::create()->addString("hello", "world"));
+    CommandReplyMessageImpl m2(1, 1);
+    m2.metadata(Bson::DocumentImpl::create()->addString("world", "hello"));
+    EXPECT_FALSE(m1 == m2);
+  }
+
+  // Trigger fail on comparing commandReply.
+  {
+    CommandReplyMessageImpl m1(0, 0);
+    m1.commandReply(Bson::DocumentImpl::create()->addString("hello", "world"));
+    CommandReplyMessageImpl m2(1, 1);
+    m2.commandReply(Bson::DocumentImpl::create()->addString("world", "hello"));
+    EXPECT_FALSE(m1 == m2);
+  }
+
+  // Trigger fail on comparing outputDocs.
+  {
+    CommandReplyMessageImpl m1(0, 0);
+    m1.outputDocs().push_back(Bson::DocumentImpl::create()->addString("hello", "world"));
+    CommandReplyMessageImpl m2(1, 1);
+    m2.outputDocs().push_back(Bson::DocumentImpl::create()->addString("world", "hello"));
+    EXPECT_FALSE(m1 == m2);
+  }
+}
 TEST_F(MongoCodecImplTest, CommandReply) {
   CommandReplyMessageImpl commandReply(16, 26);
 
   commandReply.metadata(Bson::DocumentImpl::create());
   commandReply.commandReply(Bson::DocumentImpl::create());
+  commandReply.outputDocs().push_back(Bson::DocumentImpl::create()->addString("world", "hello"));
 
   EXPECT_NO_THROW(Json::Factory::loadFromString(commandReply.toString(true)));
   EXPECT_NO_THROW(Json::Factory::loadFromString(commandReply.toString(false)));

--- a/test/extensions/filters/network/mongo_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/proxy_test.cc
@@ -265,10 +265,30 @@ TEST_F(MongoProxyFilterTest, Stats) {
   }));
   filter_->onData(fake_data_, false);
 
+  EXPECT_CALL(*filter_->decoder_, onData(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    CommandMessagePtr message(new CommandMessageImpl(0, 0));
+    message->database(std::string("Test database"));
+    message->commandName(std::string("Test command name"));
+    message->metadata(Bson::DocumentImpl::create());
+    message->commandArgs(Bson::DocumentImpl::create());
+    filter_->callbacks_->decodeCommand(std::move(message));
+  }));
+  filter_->onData(fake_data_, false);
+
+  EXPECT_CALL(*filter_->decoder_, onData(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    CommandReplyMessagePtr message(new CommandReplyMessageImpl(0, 0));
+    message->metadata(Bson::DocumentImpl::create());
+    message->commandReply(Bson::DocumentImpl::create());
+    filter_->callbacks_->decodeCommandReply(std::move(message));
+  }));
+  filter_->onData(fake_data_, false);
+
   EXPECT_EQ(1U, store_.counter("test.op_get_more").value());
   EXPECT_EQ(1U, store_.counter("test.op_insert").value());
   EXPECT_EQ(1U, store_.counter("test.op_kill_cursors").value());
   EXPECT_EQ(0U, store_.counter("test.delays_injected").value());
+  EXPECT_EQ(1U, store_.counter("test.op_command").value());
+  EXPECT_EQ(1U, store_.counter("test.op_command_reply").value());
 }
 
 TEST_F(MongoProxyFilterTest, CommandStats) {


### PR DESCRIPTION
Description: mongo-proxy filter was missing parsers for OP_COMMAND and OP_COMMANDREPLY messages as described in #2745. Classes handling those messages were added to mongo-proxy filter along with decoder's callbacks and encoder routines.

Risk Level: Low.

Testing: Added few unit tests to test decoding from wire format, to test decoder's callbacks and to test updating proxy stats.

Docs Changes: Yes - update Mongo statistics table.

Release Notes: Yes - add support for OP_COMMAND and OPCOMMANDREPLY messages.

Fixes: #2745 