### PR TITLE
grpc-web: suppress content-length header from grpc-web requests

### DIFF
--- a/source/common/grpc/grpc_web_filter.cc
+++ b/source/common/grpc/grpc_web_filter.cc
@@ -46,6 +46,10 @@ Http::FilterHeadersStatus GrpcWebFilter::decodeHeaders(Http::HeaderMap& headers,
   }
   is_grpc_web_request_ = true;
 
+  // Remove content-length header since it represents http1.1 payload size, not the sum of the h2
+  // DATA frame payload lengths. https://http2.github.io/http2-spec/#malformed This effectively
+  // switches to chunked encoding which is the default for h2
+  headers.removeContentLength();
   setupStatTracking(headers);
 
   if (content_type != nullptr &&

--- a/test/common/grpc/grpc_web_filter_test.cc
+++ b/test/common/grpc/grpc_web_filter_test.cc
@@ -16,12 +16,12 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using testing::_;
 using testing::Combine;
 using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
 using testing::Values;
+using testing::_;
 
 namespace Envoy {
 namespace Grpc {


### PR DESCRIPTION
grpc-web: suppress content-length header from web requests

*Description*:
When using envoy in a tiered deployment, with a grpc-web filter on the downstream envoy, requests to upstream envoys fail over http2 when a content-length header is present, since the underlying nghttp2 library strictly adheres to the [http2 spec](https://http2.github.io/http2-spec/#malformed). This header is usually passed up from browsers, but reflects the total http1.1 payload size, not the total DATA frame sizes.

*Risk Level*: Low

*Testing*:
A simple unit test was added to verify that content-length headers are suppressed.

*Release Notes*:
N/A

Fixes https://github.com/envoyproxy/envoy/issues/2942
