### PR TITLE
test: pretty printing IPs in test

### DIFF
--- a/test/common/event/BUILD
+++ b/test/common/event/BUILD
@@ -27,6 +27,7 @@ envoy_cc_test(
         "//source/common/event:dispatcher_lib",
         "//test/mocks:common_lib",
         "//test/test_common:environment_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 

--- a/test/common/event/file_event_impl_test.cc
+++ b/test/common/event/file_event_impl_test.cc
@@ -6,6 +6,7 @@
 
 #include "test/mocks/common.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -34,7 +35,8 @@ protected:
 class FileEventImplActivateTest : public testing::TestWithParam<Network::Address::IpVersion> {};
 
 INSTANTIATE_TEST_CASE_P(IpVersions, FileEventImplActivateTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(FileEventImplActivateTest, Activate) {
   int fd;

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -427,7 +427,8 @@ TEST_P(CodecNetworkTest, SendHeadersAndCloseUnderReadDisable) {
 }
 
 INSTANTIATE_TEST_CASE_P(IpVersions, CodecNetworkTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 } // namespace Http
 } // namespace Envoy

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -68,6 +68,7 @@ envoy_cc_test(
         "//test/mocks/network:network_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 
@@ -116,6 +117,7 @@ envoy_cc_test(
         "//test/mocks/network:network_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 
@@ -132,6 +134,7 @@ envoy_cc_test(
         "//test/mocks/server:server_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -105,7 +105,8 @@ void testSocketBindAndConnect(Network::Address::IpVersion ip_version, bool v6onl
 
 class AddressImplSocketTest : public testing::TestWithParam<IpVersion> {};
 INSTANTIATE_TEST_CASE_P(IpVersions, AddressImplSocketTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(AddressImplSocketTest, SocketBindAndConnect) {
   // Test listening on and connecting to an unused port with an IP loopback address.

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -66,7 +66,8 @@ TEST(ConnectionImplUtility, updateBufferStats) {
 
 class ConnectionImplDeathTest : public testing::TestWithParam<Address::IpVersion> {};
 INSTANTIATE_TEST_CASE_P(IpVersions, ConnectionImplDeathTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(ConnectionImplDeathTest, BadFd) {
   Event::DispatcherImpl dispatcher;
@@ -175,7 +176,8 @@ protected:
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, ConnectionImplTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(ConnectionImplTest, CloseDuringConnectCallback) {
   setUpBasicConnection();
@@ -1214,7 +1216,8 @@ public:
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, ReadBufferLimitTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(ReadBufferLimitTest, NoLimit) { readBufferLimitTest(0, 256 * 1024); }
 
@@ -1228,7 +1231,8 @@ TEST_P(ReadBufferLimitTest, SomeLimit) {
 
 class TcpClientConnectionImplTest : public testing::TestWithParam<Address::IpVersion> {};
 INSTANTIATE_TEST_CASE_P(IpVersions, TcpClientConnectionImplTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(TcpClientConnectionImplTest, BadConnectNotConnRefused) {
   Event::DispatcherImpl dispatcher;

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -24,6 +24,7 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 #include "test/test_common/printers.h"
+#include "test/test_common/utility.h"
 
 #include "ares.h"
 #include "ares_dns.h"
@@ -389,7 +390,8 @@ static bool hasAddress(const std::list<Address::InstanceConstSharedPtr>& results
 
 // Parameterize the DNS test server socket address.
 INSTANTIATE_TEST_CASE_P(IpVersions, DnsImplTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 // Validate that when DnsResolverImpl is destructed with outstanding requests,
 // that we don't invoke any callbacks. This is a regression test from
@@ -668,7 +670,8 @@ protected:
 
 // Parameterize the DNS test server socket address.
 INSTANTIATE_TEST_CASE_P(IpVersions, DnsImplZeroTimeoutTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 // Validate that timeouts result in an empty callback.
 TEST_P(DnsImplZeroTimeoutTest, Timeout) {

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -6,6 +6,7 @@
 #include "test/mocks/network/mocks.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -22,7 +23,8 @@ protected:
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, ListenSocketImplTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(ListenSocketImplTest, BindSpecificPort) {
   // Pick a free port.

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -7,6 +7,7 @@
 #include "test/mocks/server/mocks.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
+#include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -54,7 +55,8 @@ static void errorCallbackTest(Address::IpVersion version) {
 
 class ListenerImplDeathTest : public testing::TestWithParam<Address::IpVersion> {};
 INSTANTIATE_TEST_CASE_P(IpVersions, ListenerImplDeathTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(ListenerImplDeathTest, ErrorCallback) {
   EXPECT_DEATH(errorCallbackTest(GetParam()), ".*listener accept failure.*");
@@ -81,7 +83,8 @@ protected:
   const Address::InstanceConstSharedPtr alt_address_;
 };
 INSTANTIATE_TEST_CASE_P(IpVersions, ListenerImplTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(ListenerImplTest, UseActualDst) {
   Stats::IsolatedStoreImpl stats_store;

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -122,7 +122,8 @@ TEST(NetworkUtility, ParseInternetAddressAndPort) {
 class NetworkUtilityGetLocalAddress : public testing::TestWithParam<Address::IpVersion> {};
 
 INSTANTIATE_TEST_CASE_P(IpVersions, NetworkUtilityGetLocalAddress,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(NetworkUtilityGetLocalAddress, GetLocalAddress) {
   EXPECT_NE(nullptr, Utility::getLocalAddress(GetParam()));

--- a/test/common/ssl/BUILD
+++ b/test/common/ssl/BUILD
@@ -38,6 +38,7 @@ envoy_cc_test(
         "//test/mocks/stats:stats_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 

--- a/test/common/ssl/ssl_socket_test.cc
+++ b/test/common/ssl/ssl_socket_test.cc
@@ -23,6 +23,7 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 #include "test/test_common/printers.h"
+#include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -260,7 +261,8 @@ class SslSocketTest : public SslCertsTest,
                       public testing::WithParamInterface<Network::Address::IpVersion> {};
 
 INSTANTIATE_TEST_CASE_P(IpVersions, SslSocketTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(SslSocketTest, GetCertDigest) {
   std::string client_ctx_json = R"EOF(
@@ -2216,7 +2218,8 @@ public:
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, SslReadBufferLimitTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(SslReadBufferLimitTest, NoLimit) {
   readBufferLimitTest(0, 256 * 1024, 256 * 1024, 1, false);

--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -66,6 +66,7 @@ envoy_cc_test(
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 

--- a/test/common/stats/udp_statsd_test.cc
+++ b/test/common/stats/udp_statsd_test.cc
@@ -8,6 +8,7 @@
 #include "test/mocks/thread_local/mocks.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
+#include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -26,7 +27,8 @@ public:
 
 class UdpStatsdSinkTest : public testing::TestWithParam<Network::Address::IpVersion> {};
 INSTANTIATE_TEST_CASE_P(IpVersions, UdpStatsdSinkTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(UdpStatsdSinkTest, InitWithIpAddress) {
   NiceMock<ThreadLocal::MockInstance> tls_;
@@ -63,7 +65,8 @@ TEST_P(UdpStatsdSinkTest, InitWithIpAddress) {
 
 class UdpStatsdSinkWithTagsTest : public testing::TestWithParam<Network::Address::IpVersion> {};
 INSTANTIATE_TEST_CASE_P(IpVersions, UdpStatsdSinkWithTagsTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(UdpStatsdSinkWithTagsTest, InitWithIpAddress) {
   NiceMock<ThreadLocal::MockInstance> tls_;

--- a/test/extensions/filters/listener/proxy_protocol/BUILD
+++ b/test/extensions/filters/listener/proxy_protocol/BUILD
@@ -25,5 +25,6 @@ envoy_cc_test(
         "//test/mocks/server:server_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
+        "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -20,6 +20,7 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 #include "test/test_common/printers.h"
+#include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -141,7 +142,8 @@ public:
 
 // Parameterize the listener socket address version.
 INSTANTIATE_TEST_CASE_P(IpVersions, ProxyProtocolTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(ProxyProtocolTest, Basic) {
   connect();
@@ -414,7 +416,8 @@ public:
 
 // Parameterize the listener socket address version.
 INSTANTIATE_TEST_CASE_P(IpVersions, WildcardProxyProtocolTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(WildcardProxyProtocolTest, Basic) {
   connect();

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -121,6 +121,7 @@ envoy_cc_test(
     deps = [
         ":http_integration_lib",
         "//source/common/protobuf",
+        "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/filter/network/http_connection_manager/v2:http_connection_manager_cc",
     ],
 )
@@ -152,6 +153,7 @@ envoy_cc_test(
     ],
     deps = [
         ":http_integration_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 
@@ -177,6 +179,7 @@ envoy_cc_test(
     deps = [
         ":http_integration_lib",
         "//source/common/decompressor:decompressor_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 
@@ -207,6 +210,7 @@ envoy_cc_test(
     data = [
         "//test/config/integration:server.json",
         "//test/config/integration:server_config_files",
+        "//test/test_common:utility_lib",
     ],
     deps = [
         ":http_integration_lib",
@@ -345,6 +349,7 @@ envoy_cc_test(
         ":integration_lib",
         "//source/extensions/filters/network/echo:config",
         "//test/server:utility_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 
@@ -354,6 +359,7 @@ envoy_cc_test(
     deps = [
         ":integration_lib",
         "//test/test_common:network_utility_lib",
+        "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/bootstrap/v2:bootstrap_cc",
         "@envoy_api//envoy/config/metrics/v2:stats_cc",
     ],
@@ -366,6 +372,7 @@ envoy_cc_test(
         ":http_integration_lib",
         "//source/common/config:resources_lib",
         "//test/test_common:network_utility_lib",
+        "//test/test_common:utility_lib",
         "@envoy_api//envoy/api/v2:eds_cc",
     ],
 )
@@ -396,6 +403,7 @@ envoy_cc_test(
         "//source/common/config:well_known_names",
         "//source/common/http:codec_client_lib",
         "//source/extensions/filters/listener/proxy_protocol:config",
+        "//test/test_common:utility_lib",
     ],
 )
 
@@ -431,6 +439,7 @@ envoy_cc_test(
         "//source/common/ssl:context_config_lib",
         "//source/common/ssl:context_lib",
         "//test/mocks/runtime:runtime_mocks",
+        "//test/test_common:utility_lib",
     ],
 )
 
@@ -449,6 +458,7 @@ envoy_cc_test(
         "//source/common/ssl:context_lib",
         "//source/extensions/filters/network/tcp_proxy:config",
         "//test/mocks/runtime:runtime_mocks",
+        "//test/test_common:utility_lib",
     ],
 )
 
@@ -475,6 +485,7 @@ envoy_cc_test(
     data = ["//test/config/integration:server_xds_files"],
     deps = [
         ":http_integration_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 

--- a/test/integration/cors_filter_integration_test.cc
+++ b/test/integration/cors_filter_integration_test.cc
@@ -1,5 +1,6 @@
 #include "test/integration/http_integration.h"
 #include "test/mocks/http/mocks.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -90,7 +91,8 @@ protected:
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, CorsFilterIntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(CorsFilterIntegrationTest, TestVHostConfigSuccess) {
   testPreflight(

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -1,6 +1,7 @@
 #include "test/integration/integration.h"
 #include "test/integration/utility.h"
 #include "test/server/utility.h"
+#include "test/test_common/utility.h"
 
 namespace Envoy {
 
@@ -42,7 +43,8 @@ public:
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, EchoIntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(EchoIntegrationTest, Hello) {
   Buffer::OwnedImpl buffer("hello");

--- a/test/integration/grpc_json_transcoder_integration_test.cc
+++ b/test/integration/grpc_json_transcoder_integration_test.cc
@@ -6,6 +6,7 @@
 #include "test/integration/http_integration.h"
 #include "test/mocks/http/mocks.h"
 #include "test/proto/bookstore.pb.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -140,7 +141,8 @@ protected:
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, GrpcJsonTranscoderIntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(GrpcJsonTranscoderIntegrationTest, UnaryPost) {
   testTranscoding<bookstore::CreateShelfRequest, bookstore::Shelf>(

--- a/test/integration/gzip_filter_integration_test.cc
+++ b/test/integration/gzip_filter_integration_test.cc
@@ -1,6 +1,7 @@
 #include "common/decompressor/zlib_decompressor_impl.h"
 
 #include "test/integration/http_integration.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -80,7 +81,8 @@ public:
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, GzipIntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 /**
  * Exercises gzip compression with default configuration.

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -7,6 +7,7 @@
 
 #include "test/integration/http_integration.h"
 #include "test/test_common/network_utility.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -345,7 +346,8 @@ protected:
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, HeaderIntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 // Validate that downstream request headers are passed upstream and upstream response headers are
 // passed downstream.

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -17,7 +17,8 @@ using ::testing::MatchesRegex;
 namespace Envoy {
 
 INSTANTIATE_TEST_CASE_P(IpVersions, Http2IntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(Http2IntegrationTest, RouterNotFound) { testRouterNotFound(); }
 
@@ -394,7 +395,8 @@ void Http2RingHashIntegrationTest::createUpstreams() {
 }
 
 INSTANTIATE_TEST_CASE_P(IpVersions, Http2RingHashIntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 void Http2RingHashIntegrationTest::sendMultipleRequests(
     int request_bytes, Http::TestHeaderMapImpl headers,

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -13,7 +13,8 @@
 namespace Envoy {
 
 INSTANTIATE_TEST_CASE_P(IpVersions, Http2UpstreamIntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(Http2UpstreamIntegrationTest, RouterNotFound) { testRouterNotFound(); }
 

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -6,6 +6,7 @@
 #include "common/json/json_loader.h"
 
 #include "test/integration/utility.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 #include "spdlog/spdlog.h"
@@ -13,7 +14,8 @@
 namespace Envoy {
 
 INSTANTIATE_TEST_CASE_P(IpVersions, IntegrationAdminTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(IntegrationAdminTest, HealthCheck) {
   initialize();

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -15,7 +15,8 @@
 namespace Envoy {
 
 INSTANTIATE_TEST_CASE_P(IpVersions, IntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(IntegrationTest, RouterNotFound) { testRouterNotFound(); }
 

--- a/test/integration/legacy_json_integration_test.cc
+++ b/test/integration/legacy_json_integration_test.cc
@@ -1,5 +1,6 @@
 #include "test/integration/integration.h"
 #include "test/mocks/runtime/mocks.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -70,5 +71,6 @@ TEST_P(LegacyJsonIntegrationTest, TestServerGrpcJsonTranscoder) {
 }
 
 INSTANTIATE_TEST_CASE_P(IpVersions, LegacyJsonIntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 } // namespace Envoy

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -7,6 +7,7 @@
 
 #include "test/integration/http_integration.h"
 #include "test/test_common/network_utility.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -315,7 +316,8 @@ public:
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, LoadStatsIntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 // Validate the load reports for successful requests as cluster membership
 // changes.

--- a/test/integration/lua_integration_test.cc
+++ b/test/integration/lua_integration_test.cc
@@ -1,4 +1,5 @@
 #include "test/integration/http_integration.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -81,7 +82,8 @@ public:
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, LuaIntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 // Basic request and response.
 TEST_P(LuaIntegrationTest, RequestAndResponse) {

--- a/test/integration/proxy_proto_integration_test.cc
+++ b/test/integration/proxy_proto_integration_test.cc
@@ -4,6 +4,7 @@
 
 #include "test/test_common/network_utility.h"
 #include "test/test_common/printers.h"
+#include "test/test_common/utility.h"
 
 #include "fmt/format.h"
 #include "gtest/gtest.h"
@@ -11,7 +12,8 @@
 namespace Envoy {
 
 INSTANTIATE_TEST_CASE_P(IpVersions, ProxyProtoIntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(ProxyProtoIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {

--- a/test/integration/squash_filter_integration_test.cc
+++ b/test/integration/squash_filter_integration_test.cc
@@ -109,7 +109,8 @@ const std::string SquashFilterIntegrationTest::SQUASH_CREATE_DEFAULT =
     "\"status\":{\"state\":\"none\"}}";
 
 INSTANTIATE_TEST_CASE_P(IpVersions, SquashFilterIntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(SquashFilterIntegrationTest, TestHappyPath) {
   sendDebugRequest(codec_client_);

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -10,6 +10,7 @@
 
 #include "test/integration/ssl_utility.h"
 #include "test/test_common/network_utility.h"
+#include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -76,7 +77,8 @@ void SslIntegrationTest::checkStats() {
 }
 
 INSTANTIATE_TEST_CASE_P(IpVersions, SslIntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(SslIntegrationTest, RouterRequestAndResponseWithGiantBodyBuffer) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -3,6 +3,7 @@
 
 #include "test/integration/integration.h"
 #include "test/test_common/network_utility.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -23,7 +24,8 @@ public:
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, StatsIntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(StatsIntegrationTest, WithDefaultConfig) {
   initialize();

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -20,7 +20,8 @@ namespace Envoy {
 namespace {
 
 INSTANTIATE_TEST_CASE_P(IpVersions, TcpProxyIntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 void TcpProxyIntegrationTest::initialize() {
   config_helper_.renameListener("tcp_proxy");

--- a/test/integration/xds_integration_test.cc
+++ b/test/integration/xds_integration_test.cc
@@ -1,12 +1,12 @@
 #include "test/integration/http_integration.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
 namespace Envoy {
 namespace {
 
-// This is a minimal litmus test for the v2 xDS APIs. TODO(htuch): Convert all integration tests to
-// be parameterized with v2 configs.
+// This is a minimal litmus test for the v2 xDS APIs.
 class XdsIntegrationTest : public HttpIntegrationTest,
                            public testing::TestWithParam<Network::Address::IpVersion> {
 public:
@@ -29,7 +29,8 @@ public:
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, XdsIntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(XdsIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
   testRouterRequestAndResponseWithBody(1024, 512, false);

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -163,7 +163,8 @@ void XfccIntegrationTest::testRequestAndResponseWithXfccHeader(std::string previ
 }
 
 INSTANTIATE_TEST_CASE_P(IpVersions, XfccIntegrationTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(XfccIntegrationTest, MtlsForwardOnly) {
   fcc_ = envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager::

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -162,6 +162,7 @@ envoy_cc_test(
         "//test/integration:integration_lib",
         "//test/mocks/server:server_mocks",
         "//test/mocks/stats:stats_mocks",
+        "//test/test_common:utility_lib",
     ],
 )
 

--- a/test/server/config/stats/config_test.cc
+++ b/test/server/config/stats/config_test.cc
@@ -47,7 +47,8 @@ TEST(StatsConfigTest, ValidTcpStatsd) {
 
 class StatsConfigLoopbackTest : public testing::TestWithParam<Network::Address::IpVersion> {};
 INSTANTIATE_TEST_CASE_P(IpVersions, StatsConfigLoopbackTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(StatsConfigLoopbackTest, ValidUdpIpStatsd) {
   const std::string name = Config::StatsSinkNames::get().STATSD;
@@ -83,7 +84,8 @@ TEST(StatsdConfigTest, ValidateFail) {
 
 class DogStatsdConfigLoopbackTest : public testing::TestWithParam<Network::Address::IpVersion> {};
 INSTANTIATE_TEST_CASE_P(IpVersions, DogStatsdConfigLoopbackTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(DogStatsdConfigLoopbackTest, ValidUdpIp) {
   const std::string name = Config::StatsSinkNames::get().DOG_STATSD;

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -48,7 +48,8 @@ public:
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, AdminFilterTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(AdminFilterTest, HeaderOnly) {
   EXPECT_CALL(callbacks_, encodeHeaders_(_, false));
@@ -91,7 +92,8 @@ public:
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, AdminInstanceTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 // Can only get code coverage of AdminImpl::handlerCpuProfiler stopProfiler with
 // a real profiler linked in (successful call to startProfiler). startProfiler
 // requies tcmalloc.

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -8,6 +8,7 @@
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -119,7 +120,8 @@ protected:
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, ServerInstanceImplTest,
-                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 TEST_P(ServerInstanceImplTest, V2ConfigOnly) {
   options_.service_cluster_name_ = "some_cluster_name";

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -231,7 +231,7 @@ public:
     return message;
   }
 
-  // Allows pretty printed test names for TEST_P using TestEnvironment::getIpVersionsForTest()
+  // Allows pretty printed test names for TEST_P using TestEnvironment::getIpVersionsForTest().
   //
   // Tests using this will be of the form IpVersions/SslSocketTest.HalfClose/IPv4
   // instead of IpVersions/SslSocketTest.HalfClose/1

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -230,6 +230,15 @@ public:
     MessageUtil::loadFromYaml(yaml, message);
     return message;
   }
+
+  // Allows pretty printed test names for TEST_P using TestEnvironment::getIpVersionsForTest()
+  //
+  // Tests using this will be of the form IpVersions/SslSocketTest.HalfClose/IPv4
+  // instead of IpVersions/SslSocketTest.HalfClose/1
+  static std::string
+  ipTestParamsToString(const testing::TestParamInfo<Network::Address::IpVersion>& params) {
+    return params.param == Network::Address::IpVersion::v4 ? "IPv4" : "IPv6";
+  }
 };
 
 /**


### PR DESCRIPTION
Changing our tests from being of the form
 IpVersions/SslSocketTest.HalfClose/1
to
 IpVersions/SslSocketTest.HalfClose/IPv4

*Risk Level*: Low
*Testing*: n/a (manually looked at test output)
*Docs Changes*: n/a
*Release Notes*: n/a