### PR TITLE
repo reorg: fix proxy proto namespace

### DIFF
--- a/source/extensions/filters/listener/proxy_protocol/config.cc
+++ b/source/extensions/filters/listener/proxy_protocol/config.cc
@@ -8,8 +8,8 @@
 #include "extensions/filters/listener/proxy_protocol/proxy_protocol.h"
 
 namespace Envoy {
-namespace Filter {
-namespace Listener {
+namespace Extensions {
+namespace ListenerFilters {
 namespace ProxyProtocol {
 
 /**
@@ -42,6 +42,6 @@ static Registry::RegisterFactory<ProxyProtocolConfigFactory,
     registered_;
 
 } // namespace ProxyProtocol
-} // namespace Listener
-} // namespace Filter
+} // namespace ListenerFilters
+} // namespace Extensions
 } // namespace Envoy

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
@@ -18,8 +18,8 @@
 #include "common/network/utility.h"
 
 namespace Envoy {
-namespace Filter {
-namespace Listener {
+namespace Extensions {
+namespace ListenerFilters {
 namespace ProxyProtocol {
 
 Config::Config(Stats::Scope& scope) : stats_{ALL_PROXY_PROTOCOL_STATS(POOL_COUNTER(scope))} {}
@@ -159,6 +159,6 @@ bool Filter::readLine(int fd, std::string& s) {
 }
 
 } // namespace ProxyProtocol
-} // namespace Listener
-} // namespace Filter
+} // namespace ListenerFilters
+} // namespace Extensions
 } // namespace Envoy

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.h
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.h
@@ -7,8 +7,8 @@
 #include "common/common/logger.h"
 
 namespace Envoy {
-namespace Filter {
-namespace Listener {
+namespace Extensions {
+namespace ListenerFilters {
 namespace ProxyProtocol {
 
 /**
@@ -78,6 +78,6 @@ private:
 };
 
 } // namespace ProxyProtocol
-} // namespace Listener
-} // namespace Filter
+} // namespace ListenerFilters
+} // namespace Extensions
 } // namespace Envoy

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -31,8 +31,8 @@ using testing::Return;
 using testing::_;
 
 namespace Envoy {
-namespace Filter {
-namespace Listener {
+namespace Extensions {
+namespace ListenerFilters {
 namespace ProxyProtocol {
 
 // Build again on the basis of the connection_handler_test.cc
@@ -443,6 +443,6 @@ TEST_P(WildcardProxyProtocolTest, BasicV6) {
 }
 
 } // namespace ProxyProtocol
-} // namespace Listener
-} // namespace Filter
+} // namespace ListenerFilters
+} // namespace Extensions
 } // namespace Envoy


### PR DESCRIPTION
Ultimately we should figure out an automated way to enforce this.