### PR TITLE
listener_impl: Use make_shared for shared parameter.

### DIFF
--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -139,7 +139,7 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, ListenerManag
   ASSERT(config.filter_chains().size() >= 1);
 
   // Add listen socket options from the config.
-  addListenSocketOption(std::make_unique<ListenerSocketOption>(config));
+  addListenSocketOption(std::make_shared<ListenerSocketOption>(config));
 
   if (!config.listener_filters().empty()) {
     listener_filter_factories_ =

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -254,12 +254,12 @@ TEST_P(ConnectionImplTest, SocketOptions) {
 
   read_filter_.reset(new NiceMock<MockReadFilter>());
 
-  auto option = std::make_unique<MockSocketOption>();
+  auto option = std::make_shared<MockSocketOption>();
 
   EXPECT_CALL(*option, setOption(_, Network::Socket::SocketState::PreBind)).WillOnce(Return(true));
   EXPECT_CALL(listener_callbacks_, onAccept_(_, _))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& socket, bool) -> void {
-        socket->addOption(std::move(option));
+        socket->addOption(option);
         Network::ConnectionPtr new_connection = dispatcher_->createServerConnection(
             std::move(socket), Network::Test::createRawBufferSocket());
         listener_callbacks_.onNewConnection(std::move(new_connection));
@@ -302,12 +302,12 @@ TEST_P(ConnectionImplTest, SocketOptionsFailureTest) {
 
   read_filter_.reset(new NiceMock<MockReadFilter>());
 
-  auto option = std::make_unique<MockSocketOption>();
+  auto option = std::make_shared<MockSocketOption>();
 
   EXPECT_CALL(*option, setOption(_, Network::Socket::SocketState::PreBind)).WillOnce(Return(false));
   EXPECT_CALL(listener_callbacks_, onAccept_(_, _))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& socket, bool) -> void {
-        socket->addOption(std::move(option));
+        socket->addOption(option);
         Network::ConnectionPtr new_connection = dispatcher_->createServerConnection(
             std::move(socket), Network::Test::createRawBufferSocket());
         listener_callbacks_.onNewConnection(std::move(new_connection));


### PR DESCRIPTION
Even if using make_unique() is correct for a shared_ptr parameter, it
is misleading. Use make_shared instead(). Avoid std::move in tests for
the same reason.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
Risk Level: Low
