### PR TITLE
formatting: reject incorrect protobuf namespaces

### DIFF
--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -285,7 +285,7 @@ Http::Code AdminImpl::handlerConfigDump(absl::string_view, Http::HeaderMap&,
   for (const auto& key_callback_pair : config_tracker_.getCallbacksMap()) {
     ProtobufTypes::MessagePtr message = key_callback_pair.second();
     RELEASE_ASSERT(message);
-    Protobuf::Any any_message;
+    ProtobufWkt::Any any_message;
     any_message.PackFrom(*message);
     config_dump_map[key_callback_pair.first] = any_message;
   }

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -68,6 +68,25 @@ def checkProtobufExternalDepsBuild(file_path):
 def checkProtobufExternalDeps(file_path):
   if whitelistedForProtobufDeps(file_path):
     return True
+  protobuf_type_errors = {
+      # Well-known types should be referenced from the ProtobufWkt namespace.
+      "Protobuf::Any":                    "ProtobufWkt::Any",
+      "Protobuf::Empty":                  "ProtobufWkt::Empty",
+      "Protobuf::ListValue":              "ProtobufWkt:ListValue",
+      "Protobuf::NULL_VALUE":             "ProtobufWkt::NULL_VALUE",
+      "Protobuf::StringValue":            "ProtobufWkt::StringValue",
+      "Protobuf::Struct":                 "ProtobufWkt::Struct",
+      "Protobuf::Value":                  "ProtobufWkt::Value",
+
+      # Maps including strings should use the protobuf string types.
+      "Protobuf::MapPair<std::string":    "Protobuf::MapPair<Envoy::ProtobufTypes::String",
+
+      # Other common mis-namespacing of protobuf types.
+      "ProtobufWkt::Map":                 "Protobuf::Map",
+      "ProtobufWkt::MapPair":             "Protobuf::MapPair",
+      "ProtobufUtil::MessageDifferencer": "Protobuf::util::MessageDifferencer"
+  }
+
   with open(file_path) as f:
     text = f.read()
     if '"google/protobuf' in text or "google::protobuf" in text:
@@ -75,6 +94,10 @@ def checkProtobufExternalDeps(file_path):
           "%s has unexpected direct dependency on google.protobuf, use "
           "the definitions in common/protobuf/protobuf.h instead." % file_path)
       return False
+    for error, replacement in protobuf_type_errors.items():
+      if error in text:
+        printError("%s uses an unexpected protobuf namespace reference; instead of %s, use %s"
+                   % (file_path, error, replacement))
     return True
 
 


### PR DESCRIPTION
Add some checks to the formatting script so that protobuf-related type references use the correct namespaces. This should prevent the need for later fixups like #2963.

*Risk Level*: Low

*Testing*: checked out and ran format script on code from before #2963 and found errors as expected.

*Release Notes*: N/A