### PR TITLE
runtime: explicitly include <vector>

### DIFF
--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "envoy/common/pure.h"
 


### PR DESCRIPTION
`runtime.h` explicitly uses `std::vector`, but doesn't directly include the header.  Without this the build fails on Ubuntu Bionic with GCC 7.3 for me:

```
ERROR: /home/bobby/mac/envoy/source/common/runtime/BUILD:11:1: C++ compilation of rule '//source/common/runtime:runtime_lib' failed (Exit 1)
In file included from bazel-out/k8-fastbuild/bin/source/common/runtime/_virtual_includes/runtime_lib/common/runtime/runtime_impl.h:12:0,
                 from source/common/runtime/runtime_impl.cc:1:
bazel-out/k8-fastbuild/bin/include/envoy/runtime/_virtual_includes/runtime_interface/envoy/runtime/runtime.h:144:22: error: 'vector' in namespace 'std' does not name a template type
   virtual const std::vector<OverrideLayerConstPtr>& getLayers() const PURE;
                      ^~~~~~
In file included from source/common/runtime/runtime_impl.cc:1:0:
bazel-out/k8-fastbuild/bin/source/common/runtime/_virtual_includes/runtime_lib/common/runtime/runtime_impl.h:74:45: error: 'const std::vector<std::unique_ptr<const Envoy::Runtime::Snapshot::OverrideLayer> >& Envoy::Runtime::SnapshotImpl::getLayers() const' marked 'override', but does not override
   const std::vector<OverrideLayerConstPtr>& getLayers() const override;
                                             ^~~~~~~~~
Target //source/exe:envoy-static failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 304.470s, Critical Path: 29.83s
FAILED: Build did NOT complete successfully
```

*Risk Level*: Low

*Testing*: Unit tests pass