### PR TITLE
fix: broken compilation on ubuntu 17.10

### DIFF
--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "envoy/common/pure.h"
 


### PR DESCRIPTION
*Description*:
commit 45a126da430232dc0ebc65d56cbfe0b525196452 broke complication on my machine (ubuntu 17.10, gcc (Ubuntu 7.2.0-8ubuntu3.2) 7.2.0. This adds a missing include to make envoy compile.

*Risk Level*: Low

