### PR TITLE
ensure the inotify fd is valid

### DIFF
--- a/source/common/filesystem/inotify/watcher_impl.cc
+++ b/source/common/filesystem/inotify/watcher_impl.cc
@@ -23,7 +23,9 @@ WatcherImpl::WatcherImpl(Event::Dispatcher& dispatcher)
                                                   onInotifyEvent();
                                                 },
                                                 Event::FileTriggerType::Edge,
-                                                Event::FileReadyType::Read)) {}
+                                                Event::FileReadyType::Read)) {
+  RELEASE_ASSERT(inotify_fd_ >= 0);
+}
 
 WatcherImpl::~WatcherImpl() { close(inotify_fd_); }
 


### PR DESCRIPTION
this could happen for example if the user hits a limit on the number of file
descriptor

*title*: filesystem/intoify: ensure the inotify fd is valid. throw an exception otherwise

*Description*:

Fixes behavior of initialization when `intofiy_init1` returns an error, e.g. because the no of file descriptor limit is reached. Without the patch the following stacktrace is printed (another exception not being caught bug per [this convo](https://envoyproxy.slack.com/archives/C78M4KW76/p1522704993000283))
```
   2018-04-03T12:19:44.93-0400 [PROXY/0] ERR terminate called after throwing an instance of 'Envoy::EnvoyException'                                           
   2018-04-03T12:19:44.93-0400 [PROXY/0] ERR   what():  unable to add filesystem watch for file /etc/cf-assets/envoy_config/listeners.yaml: Bad file descriptor
   2018-04-03T12:19:44.93-0400 [PROXY/0] ERR [2018-04-03 16:19:44.939][57][critical][backtrace] bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:114] Caught Aborted, suspect faulting address 0x39
   2018-04-03T12:19:44.94-0400 [PROXY/0] ERR [2018-04-03 16:19:44.939][57][critical][backtrace] bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:90] Backtrace obj</lib/x86_64-linux-gnu/libc.so.6> thr<0> (use tools/stack_decode.py):
   2018-04-03T12:19:44.94-0400 [PROXY/0] ERR [2018-04-03 16:19:44.939][57][critical][backtrace] bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:107] thr<0> #0 0x7ffb8528cc37
   2018-04-03T12:19:44.94-0400 [PROXY/0] ERR [2018-04-03 16:19:44.939][57][critical][backtrace] bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:107] thr<0> #1 0x7ffb85290027
   2018-04-03T12:19:44.94-0400 [PROXY/0] ERR [2018-04-03 16:19:44.939][57][critical][backtrace] bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:99] thr<0> obj</etc/cf-assets/envoy/envoy>
   2018-04-03T12:19:44.94-0400 [PROXY/0] ERR [2018-04-03 16:19:44.939][57][critical][backtrace] bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:107] thr<0> #2 0x13cc48c
```

With the patch the following is printed on stderr
```
   2018-04-03T12:15:50.46-0400 [PROXY/2] ERR [2018-04-03 16:15:50.462][58][critical][main] source/server/server.cc:72] error initializing configuration '/etc/cf-assets/envoy_config/envoy.yaml': unable to initialize filesystem watcher: Too many open files

```

*Risk Level*: Low

*Testing*: manual testing

*Docs Changes*: None

*Release Notes*: Not sure if this is necessary
