### PR TITLE
formatting: check for proto type errors

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -126,9 +126,10 @@ def checkFileContents(file_path):
       printLineError(file_path, line_number, "over-enthusiastic spaces")
     if hasInvalidAngleBracketDirectory(line):
       printLineError(file_path, line_number, "envoy includes should not have angle brackets")
-    for error in PROTOBUF_TYPE_ERRORS:
-      if error in line:
-        printLineError(file_path, line_number, "incorrect protobuf type reference %s" % error)
+    for invalid_construct, valid_construct in PROTOBUF_TYPE_ERRORS.items():
+      if invalid_construct in line:
+        printLineError(file_path, line_number, "incorrect protobuf type reference %s; "
+                       "should be %s" % (invalid_construct, valid_construct))
 
 def fixFileContents(file_path):
   for line in fileinput.input(file_path, inplace=True):
@@ -140,8 +141,8 @@ def fixFileContents(file_path):
       line = line.replace('<', '"').replace(">", '"')
 
     # Fix incorrect protobuf namespace references.
-    for error, replacement in PROTOBUF_TYPE_ERRORS.items():
-      line = line.replace(error, replacement)
+    for invalid_construct, valid_construct in PROTOBUF_TYPE_ERRORS.items():
+      line = line.replace(invalid_construct, valid_construct)
 
     sys.stdout.write(str(line))
 

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -126,6 +126,9 @@ def checkFileContents(file_path):
       printLineError(file_path, line_number, "over-enthusiastic spaces")
     if hasInvalidAngleBracketDirectory(line):
       printLineError(file_path, line_number, "envoy includes should not have angle brackets")
+    for error in PROTOBUF_TYPE_ERRORS:
+      if error in line:
+        printLineError(file_path, line_number, "incorrect protobuf type reference %s" % error)
 
 def fixFileContents(file_path):
   for line in fileinput.input(file_path, inplace=True):


### PR DESCRIPTION
tools/check_format.py was modified in #2969 to automatically fix protobuf type namespace errors in 'fix' mode, but it did not complain about them when run in 'check' mode. This commit fixes the lack of complaints from 'check' mode.

*Risk Level*: Low

*Testing*: introduced errors and ran `tools/check_format.py check` which caught them.

*Docs Changes*: N/A

*Release Notes*: N/A