### PR TITLE
config: remove unreferenced include directive

### DIFF
--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -225,7 +225,6 @@ envoy_cc_library(
     hdrs = ["metadata.h"],
     deps = [
         "//source/common/protobuf",
-        "//source/common/singleton:const_singleton",
         "@envoy_api//envoy/api/v2/core:base_cc",
     ],
 )

--- a/source/common/config/metadata.h
+++ b/source/common/config/metadata.h
@@ -5,7 +5,6 @@
 #include "envoy/api/v2/core/base.pb.h"
 
 #include "common/protobuf/protobuf.h"
-#include "common/singleton/const_singleton.h"
 
 namespace Envoy {
 namespace Config {


### PR DESCRIPTION
*Description*:

1. Remove the `#include "common/singleton/const_singleton.h"` directive
   from `source/common/config/metadata.h`.
2. Remove the associated library dependency from `common/config/BUILD`.

These seem to be remains from the times when `MetadataEnvoyLbKeys` used
to be defined in `source/common/config/metadata.h`.
See commit 1d330b5a4535a483daaa5dfd71306a8bf21b2d3a.

Signed-off-by: Tal Nordan <tal.nordan@solo.io>

*Risk Level*: Low
*Testing*: `//test/...`
*Docs Changes*: N/A
*Release Notes*: N/A