### PR TITLE
config: optimize RepeatedPtrUtil::debugString at non-debug log levels.

### DIFF
--- a/source/common/config/grpc_mux_subscription_impl.h
+++ b/source/common/config/grpc_mux_subscription_impl.h
@@ -55,8 +55,10 @@ public:
     stats_.update_attempt_.inc();
     version_info_ = version_info;
     stats_.version_.set(HashUtil::xxHash64(version_info_));
-    ENVOY_LOG(debug, "gRPC config for {} accepted with {} resources: {}", type_url_,
-              resources.size(), RepeatedPtrUtil::debugString(typed_resources));
+    if (ENVOY_LOG_CHECK_LEVEL(debug)) {
+      ENVOY_LOG(debug, "gRPC config for {} accepted with {} resources: {}", type_url_,
+                resources.size(), RepeatedPtrUtil::debugString(typed_resources));
+    }
   }
 
   void onConfigUpdateFailed(const EnvoyException* e) override {


### PR DESCRIPTION
This one was showing up on our flamegraphs.

Risk Level: Low
Testing: bazel build //source/exe/...

Signed-off-by: Harvey Tuch <htuch@google.com>
