### PR TITLE
tools: reformat find_related_envoy_files.py

### DIFF
--- a/tools/find_related_envoy_files.py
+++ b/tools/find_related_envoy_files.py
@@ -39,46 +39,46 @@ fname = sys.argv[1].replace("/" + INTERFACE_REAL_ROOT + "/",
 # is trouble.
 envoy_index = fname.rfind(ENVOY_ROOT)
 if envoy_index == -1:
-    sys.exit(0)
+  sys.exit(0)
 envoy_index += len(ENVOY_ROOT)
 absolute_location = fname[0:envoy_index]  # "/path/to/gitroot/envoy/"
 path = fname[envoy_index:]
 path_elements = path.split("/")
 if len(path_elements) < 3:
-    sys.exit(0)
+  sys.exit(0)
 leaf = path_elements[len(path_elements) - 1]
 dot = leaf.rfind(".")
 if dot == -1 or dot == len(leaf) - 1:
-    sys.exit(0)
+  sys.exit(0)
 ext = leaf[dot:]
 
 # Transforms the input filename based on some transformation rules. Nothing
 # is emitted if the input path or extension does not match the expected pattern,
 # or if the file doesn't exist.
 def emit(source_path, dest_path, source_ending, dest_ending):
-    if fname.endswith(source_ending) and path.startswith(source_path + "/"):
-        path_len = len(path) - len(source_path) - len(source_ending)
-        new_path = absolute_location + dest_path + \
-          path[len(source_path):-len(source_ending)] + dest_ending
-        if os.path.isfile(new_path):
-            print(new_path)
+  if fname.endswith(source_ending) and path.startswith(source_path + "/"):
+    path_len = len(path) - len(source_path) - len(source_ending)
+    new_path = (absolute_location + dest_path +
+                path[len(source_path):-len(source_ending)] + dest_ending)
+    if os.path.isfile(new_path):
+      print(new_path)
 
 # Depending on which type of file is passed into the script: test, cc,
 # h, or interface, emit any related ones in cyclic order.
 root = path_elements[0]
 if root == TEST_ROOT:
-    emit("test/common", INTERFACE_REAL_ROOT, "_impl_test.cc", ".h")
-    emit(TEST_ROOT, SOURCE_ROOT, "_test.cc", ".cc")
-    emit(TEST_ROOT, SOURCE_ROOT, "_test.cc", ".h")
+  emit("test/common", INTERFACE_REAL_ROOT, "_impl_test.cc", ".h")
+  emit(TEST_ROOT, SOURCE_ROOT, "_test.cc", ".cc")
+  emit(TEST_ROOT, SOURCE_ROOT, "_test.cc", ".h")
 elif root == SOURCE_ROOT and ext == ".cc":
-    emit(SOURCE_ROOT, SOURCE_ROOT, ".cc", ".h")
-    emit(SOURCE_ROOT, TEST_ROOT, ".cc", "_test.cc")
-    emit("source/common", INTERFACE_REAL_ROOT, "_impl.cc", ".h")
+  emit(SOURCE_ROOT, SOURCE_ROOT, ".cc", ".h")
+  emit(SOURCE_ROOT, TEST_ROOT, ".cc", "_test.cc")
+  emit("source/common", INTERFACE_REAL_ROOT, "_impl.cc", ".h")
 elif root == SOURCE_ROOT and ext == ".h":
-    emit(SOURCE_ROOT, TEST_ROOT, ".h", "_test.cc")
-    emit("source/common", INTERFACE_REAL_ROOT, "_impl.h", ".h")
-    emit(SOURCE_ROOT, SOURCE_ROOT, ".h", ".cc")
+  emit(SOURCE_ROOT, TEST_ROOT, ".h", "_test.cc")
+  emit("source/common", INTERFACE_REAL_ROOT, "_impl.h", ".h")
+  emit(SOURCE_ROOT, SOURCE_ROOT, ".h", ".cc")
 elif root == INTERFACE_SYNTHETIC_ROOT:
-    emit(INTERFACE_SYNTHETIC_ROOT, "source/common", ".h", "_impl.cc")
-    emit(INTERFACE_SYNTHETIC_ROOT, "source/common", ".h", "_impl.h")
-    emit(INTERFACE_SYNTHETIC_ROOT, "test/common", ".h", "_impl_test.cc")
+  emit(INTERFACE_SYNTHETIC_ROOT, "source/common", ".h", "_impl.cc")
+  emit(INTERFACE_SYNTHETIC_ROOT, "source/common", ".h", "_impl.h")
+  emit(INTERFACE_SYNTHETIC_ROOT, "test/common", ".h", "_impl_test.cc")


### PR DESCRIPTION
*Description*: I wrote this originally on a Mac where my Emacs python settings were not what we usually use.  This just corrects indentation.

*Risk Level*: Low

*Testing*: ran the python script on a few files to make sure the logic still works.

*Docs Changes*: N/A

*Release Notes*: N/A