### PR TITLE
Add automake dependency.

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -34,6 +34,7 @@ On Ubuntu, run the following commands:
  apt-get install cmake
  apt-get install realpath
  apt-get install clang-format-5.0
+ apt-get install automake
 ```
 
 On Fedora (maybe also other red hat distros), run the following:


### PR DESCRIPTION
Signed-off-by: Randy Smith <rdsmith@google.com>

*title*: Add automake to list of dependencies in quick start bazel Ubuntu dependencies.



*Description*:
For at least some Ubuntu distributions (including the one I was using) automake is 
not an automatically included dependency and needs to be added before envoy will build. 
This CL adds that dependency to the quick start documentation.

*Risk Level*: Low

*Testing*: None, just a developer doc change.

*Docs Changes*: N/A

*Release Notes*: N/A

