### PR TITLE
deprecation: Indicate that admin mutation GETs are deprecated.

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -5,13 +5,13 @@ As of release 1.3.0, Envoy will follow a
 
 The following features have been DEPRECATED and will be removed in the specified release cycle.
 
-## Version 1.7.0
+## Version 1.7.0 (pending)
 
-* Admin mutations should be sent as POSTs rather than GETs. These will result in an error
-  status code, and will not have their intended effect. Prior to 1.7, GETs can be used for
+* Admin mutations should be sent as POSTs rather than GETs. HTTP GETs will result in an error
+  status code and will not have their intended effect. Prior to 1.7, GETs can be used for
   admin mutations, but a warning is logged.
 
-## Version 1.6.0
+## Version 1.6.0 (March 20, 2018)
 
 * DOWNSTREAM_ADDRESS log formatter is deprecated. Use DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT
   instead.
@@ -25,7 +25,7 @@ The following features have been DEPRECATED and will be removed in the specified
 * `value` and `regex` fields in the `HeaderMatcher` message is deprecated. Use the `exact_match`
   or `regex_match` oneof instead.
 
-## Version 1.5.0
+## Version 1.5.0.0 (Dec 4, 2017)
 
 * The outlier detection `ejections_total` stats counter has been deprecated and not replaced. Monitor
   the individual `ejections_detected_*` counters for the detectors of interest, or
@@ -35,7 +35,7 @@ The following features have been DEPRECATED and will be removed in the specified
 * The outlier detection `ejections_success_rate` stats counter has been deprecated in favour of
   `ejections_detected_success_rate` and `ejections_enforced_success_rate`.
 
-## Version 1.4.0
+## Version 1.4.0 (Aug 24, 2017)
 
 * Config option `statsd_local_udp_port` has been deprecated and has been replaced with
   `statsd_udp_ip_address`.

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -5,7 +5,7 @@ As of release 1.3.0, Envoy will follow a
 
 The following features have been DEPRECATED and will be removed in the specified release cycle.
 
-## Version 1.7.0...
+## Version 1.7.0
 
 * Admin mutations should be sent as POSTs rather than GETs. These will result in an error
   status code, and will not have their intended effect. Prior to 1.7, GETs can be used for

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -5,6 +5,12 @@ As of release 1.3.0, Envoy will follow a
 
 The following features have been DEPRECATED and will be removed in the specified release cycle.
 
+## Version 1.7.0...
+
+* Admin mutations should be sent as POSTs rather than GETs. These will result in an error
+  status code, and will not have their intended effect. Prior to 1.7, GETs can be used for
+  admin mutations, but a warning is logged.
+
 ## Version 1.6.0
 
 * DOWNSTREAM_ADDRESS log formatter is deprecated. Use DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT
@@ -18,11 +24,6 @@ The following features have been DEPRECATED and will be removed in the specified
   matching instead.
 * `value` and `regex` fields in the `HeaderMatcher` message is deprecated. Use the `exact_match`
   or `regex_match` oneof instead.
-
-
-* Admin mutations should be sent as POSTs rather than GETs. Starting in 1.7, these will result
-  in an error status code, and no effect. Prior to 1.7, GETs can be used for admin mutations
-  but will result in a warning.
 
 ## Version 1.5.0
 

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -19,6 +19,11 @@ The following features have been DEPRECATED and will be removed in the specified
 * `value` and `regex` fields in the `HeaderMatcher` message is deprecated. Use the `exact_match`
   or `regex_match` oneof instead.
 
+
+* Admin mutations should be sent as POSTs rather than GETs. Starting in 1.7, these will result
+  in an error status code, and no effect. Prior to 1.7, GETs can be used for admin mutations
+  but will result in a warning.
+
 ## Version 1.5.0
 
 * The outlier detection `ejections_total` stats counter has been deprecated and not replaced. Monitor

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -96,6 +96,8 @@
   to the next development release. E.g., "1.7.0-dev". At the same time, also add a new empty section
   to the [release notes](https://github.com/envoyproxy/data-plane-api/blob/master/docs/root/intro/version_history.rst)
   for the following version. E.g., "1.7.0".
+* Update [DEPRECATED.md](DEPRECATED.md) to remove the '(pending)' comment on the current version,
+  replacing it with the release date. Add a placeholder for the next version.
 
 ## When does a maintainer lose maintainer status
 


### PR DESCRIPTION
Signed-off-by: Joshua Marantz <jmarantz@google.com>

*Description*:
adds a deprecation message.

*Risk Level*: Low 
*Testing*: none
*Docs Changes*: N/A -- the desired state is already docced.
*Release Notes*: https://github.com/envoyproxy/data-plane-api/pull/606
