### PR TITLE
router: Add clusterMetadata RouteEntry interface and implementation.

### DIFF
--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -362,6 +362,12 @@ public:
   virtual const std::string& clusterName() const PURE;
 
   /**
+   * @return const envoy::api::v2::core::Metadata& metadata related to the cluster referenced by
+   * clusterName.
+   */
+  virtual const envoy::api::v2::core::Metadata& clusterMetadata() const PURE;
+
+  /**
    * Returns the HTTP status code to use when configured cluster is not found.
    * @return Http::Code to use when configured cluster is not found.
    */

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -198,6 +198,7 @@ private:
     bool useWebSocket() const override { return false; }
     bool includeVirtualHostRateLimits() const override { return true; }
     const envoy::api::v2::core::Metadata& metadata() const override { return metadata_; }
+    const envoy::api::v2::core::Metadata& clusterMetadata() const override { return metadata_; }
     const Router::PathMatchCriterion& pathMatchCriterion() const override {
       return path_match_criterion_;
     }

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -345,6 +345,9 @@ public:
   }
   bool includeVirtualHostRateLimits() const override { return include_vh_rate_limits_; }
   const envoy::api::v2::core::Metadata& metadata() const override { return metadata_; }
+  const envoy::api::v2::core::Metadata& clusterMetadata() const override {
+    return cluster_metadata_;
+  }
   const PathMatchCriterion& pathMatchCriterion() const override { return *this; }
 
   // Router::DirectResponseEntry
@@ -421,6 +424,9 @@ private:
       return parent_->includeVirtualHostRateLimits();
     }
     const envoy::api::v2::core::Metadata& metadata() const override { return parent_->metadata(); }
+    const envoy::api::v2::core::Metadata& clusterMetadata() const override {
+      return parent_->clusterMetadata();
+    }
     const PathMatchCriterion& pathMatchCriterion() const override {
       return parent_->pathMatchCriterion();
     }
@@ -458,6 +464,10 @@ private:
       return DynamicRouteEntry::metadataMatchCriteria();
     }
 
+    const envoy::api::v2::core::Metadata& clusterMetadata() const override {
+      return cluster_metadata_;
+    }
+
     void finalizeRequestHeaders(Http::HeaderMap& headers,
                                 const RequestInfo::RequestInfo& request_info) const override {
       request_headers_parser_->evaluateHeaders(headers, request_info);
@@ -476,6 +486,7 @@ private:
     MetadataMatchCriteriaImplConstPtr cluster_metadata_match_criteria_;
     HeaderParserPtr request_headers_parser_;
     HeaderParserPtr response_headers_parser_;
+    envoy::api::v2::core::Metadata cluster_metadata_;
   };
 
   typedef std::shared_ptr<WeightedClusterEntry> WeightedClusterEntrySharedPtr;
@@ -520,6 +531,7 @@ private:
   HeaderParserPtr request_headers_parser_;
   HeaderParserPtr response_headers_parser_;
   envoy::api::v2::core::Metadata metadata_;
+  envoy::api::v2::core::Metadata cluster_metadata_;
 
   // TODO(danielhochman): refactor multimap into unordered_map since JSON is unordered map.
   const std::multimap<std::string, std::string> opaque_config_;

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -75,6 +75,7 @@ MockRouteEntry::MockRouteEntry() {
   ON_CALL(*this, includeVirtualHostRateLimits()).WillByDefault(Return(true));
   ON_CALL(*this, pathMatchCriterion()).WillByDefault(ReturnRef(path_match_criterion_));
   ON_CALL(*this, metadata()).WillByDefault(ReturnRef(metadata_));
+  ON_CALL(*this, clusterMetadata()).WillByDefault(ReturnRef(cluster_metadata_));
 }
 
 MockRouteEntry::~MockRouteEntry() {}

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -231,6 +231,7 @@ public:
   MOCK_CONST_METHOD0(includeVirtualHostRateLimits, bool());
   MOCK_CONST_METHOD0(corsPolicy, const CorsPolicy*());
   MOCK_CONST_METHOD0(metadata, const envoy::api::v2::core::Metadata&());
+  MOCK_CONST_METHOD0(clusterMetadata, const envoy::api::v2::core::Metadata&());
   MOCK_CONST_METHOD0(pathMatchCriterion, const PathMatchCriterion&());
 
   std::string cluster_name_{"fake_cluster"};
@@ -245,6 +246,7 @@ public:
   TestCorsPolicy cors_policy_;
   testing::NiceMock<MockPathMatchCriterion> path_match_criterion_;
   envoy::api::v2::core::Metadata metadata_;
+  envoy::api::v2::core::Metadata cluster_metadata_;
 };
 
 class MockDecorator : public Decorator {


### PR DESCRIPTION
This adds cluster_metadata to route entry so that a filter can get metadata that is specific to the 
cluster chosen for routing. A "cluster_metadata" field was added to the RouteAction configuration (see
link to the data plane PR)
*Risk Level*: Low/Medium

*Testing*:
Added a unit test to config_impl_test.cc

*Docs Changes*:
original data pr:
https://github.com/envoyproxy/data-plane-api/pull/598
final pr that unhides docs:
https://github.com/envoyproxy/data-plane-api/pull/607

*Release Notes*:
https://github.com/envoyproxy/data-plane-api/pull/607

Fixes envoyproxy/envoy#2851

*API Changes*:
https://github.com/envoyproxy/data-plane-api/pull/598
