### PR TITLE
upstream: locality weighted maglev load balancing.

### DIFF
--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -238,6 +238,7 @@ envoy_cc_library(
     hdrs = ["maglev_lb.h"],
     deps = [
         ":thread_aware_lb_lib",
+        ":upstream_lib",
     ],
 )
 

--- a/source/common/upstream/maglev_lb.cc
+++ b/source/common/upstream/maglev_lb.cc
@@ -3,38 +3,60 @@
 namespace Envoy {
 namespace Upstream {
 
-MaglevTable::MaglevTable(const HostVector& hosts, uint64_t table_size) : table_size_(table_size) {
+MaglevTable::MaglevTable(const HostsPerLocality& hosts_per_locality,
+                         const LocalityWeightsConstSharedPtr& locality_weights, uint64_t table_size)
+    : table_size_(table_size) {
   // TODO(mattklein123): The Maglev table must have a size that is a prime number for the algorithm
   // to work. Currently, the table size is not user configurable. In the future, if the table size
   // is made user configurable, we will need proper error checking that the user cannot configure a
   // size that is not prime (the result is going to be an infinite loop with some inputs which is
   // not good!).
   ASSERT(Primes::isPrime(table_size));
-  if (hosts.empty()) {
-    return;
-  }
+
+  // Compute host weight combined with locality weight where applicable.
+  const auto effective_weight = [&locality_weights](uint32_t host_weight,
+                                                    uint32_t locality_index) -> uint32_t {
+    if (locality_weights == nullptr || locality_weights->empty()) {
+      return host_weight;
+    } else {
+      return host_weight * (*locality_weights)[locality_index];
+    }
+  };
 
   // Compute maximum host weight. If this is zero, we are doing unweighted Maglev.
   uint32_t max_host_weight = 0;
-  for (const auto& host : hosts) {
-    max_host_weight = std::max(host->weight(), max_host_weight);
+  uint32_t total_hosts = 0;
+  for (uint32_t i = 0; i < hosts_per_locality.get().size(); ++i) {
+    for (const auto& host : hosts_per_locality.get()[i]) {
+      max_host_weight =
+          effective_weight(std::max(effective_weight(host->weight(), i), max_host_weight), i);
+      ++total_hosts;
+    }
+  }
+
+  // We can't do anything sensible with no hosts.
+  if (total_hosts == 0) {
+    return;
   }
 
   // Implementation of pseudocode listing 1 in the paper (see header file for more info).
   std::vector<TableBuildEntry> table_build_entries;
-  table_build_entries.reserve(hosts.size());
-  for (const auto& host : hosts) {
-    const std::string& address = host->address()->asString();
-    table_build_entries.emplace_back(HashUtil::xxHash64(address) % table_size_,
-                                     (HashUtil::xxHash64(address, 1) % (table_size_ - 1)) + 1,
-                                     max_host_weight > 0 ? host->weight() : 0);
+  table_build_entries.reserve(total_hosts);
+  for (uint32_t i = 0; i < hosts_per_locality.get().size(); ++i) {
+    for (const auto& host : hosts_per_locality.get()[i]) {
+      const std::string& address = host->address()->asString();
+      table_build_entries.emplace_back(host, HashUtil::xxHash64(address) % table_size_,
+                                       (HashUtil::xxHash64(address, 1) % (table_size_ - 1)) + 1,
+                                       max_host_weight > 0 ? effective_weight(host->weight(), i)
+                                                           : 0);
+    }
   }
 
   table_.resize(table_size_);
   uint64_t table_index = 0;
   uint32_t iteration = 1;
   while (true) {
-    for (uint64_t i = 0; i < hosts.size(); i++) {
+    for (uint64_t i = 0; i < table_build_entries.size(); i++) {
       TableBuildEntry& entry = table_build_entries[i];
       // Only consider weight if we are doing weighted Maglev.
       if (max_host_weight > 0) {
@@ -54,7 +76,7 @@ MaglevTable::MaglevTable(const HostVector& hosts, uint64_t table_size) : table_s
         c = permutation(entry);
       }
 
-      table_[c] = hosts[i];
+      table_[c] = entry.host_;
       entry.next_++;
       table_index++;
       if (table_index == table_size_) {

--- a/source/common/upstream/maglev_lb.cc
+++ b/source/common/upstream/maglev_lb.cc
@@ -28,8 +28,7 @@ MaglevTable::MaglevTable(const HostsPerLocality& hosts_per_locality,
   uint32_t total_hosts = 0;
   for (uint32_t i = 0; i < hosts_per_locality.get().size(); ++i) {
     for (const auto& host : hosts_per_locality.get()[i]) {
-      max_host_weight =
-          effective_weight(std::max(effective_weight(host->weight(), i), max_host_weight), i);
+      max_host_weight = std::max(effective_weight(host->weight(), i), max_host_weight);
       ++total_hosts;
     }
   }

--- a/source/common/upstream/thread_aware_lb_impl.h
+++ b/source/common/upstream/thread_aware_lb_impl.h
@@ -73,7 +73,7 @@ private:
     std::shared_ptr<std::vector<uint32_t>> per_priority_load_;
   };
 
-  virtual HashingLoadBalancerSharedPtr createLoadBalancer(const HostVector& hosts) PURE;
+  virtual HashingLoadBalancerSharedPtr createLoadBalancer(const HostSet& host_set) PURE;
   void refresh();
 
   std::shared_ptr<LoadBalancerFactoryImpl> factory_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -154,7 +154,11 @@ private:
 
 class HostsPerLocalityImpl : public HostsPerLocality {
 public:
-  HostsPerLocalityImpl() : HostsPerLocalityImpl({}, false) {}
+  HostsPerLocalityImpl() : HostsPerLocalityImpl(std::vector<HostVector>(), false) {}
+
+  // Single locality constructor
+  HostsPerLocalityImpl(const HostVector& hosts, bool has_local_locality = false)
+      : HostsPerLocalityImpl(std::vector<HostVector>({hosts}), has_local_locality) {}
 
   HostsPerLocalityImpl(std::vector<HostVector>&& locality_hosts, bool has_local_locality)
       : local_(has_local_locality), hosts_per_locality_(std::move(locality_hosts)) {

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -87,7 +87,8 @@ void BM_MaglevLoadBalancerBuildTable(benchmark::State& state) {
     const uint64_t num_hosts = state.range(0);
     BaseTester tester(num_hosts);
     state.ResumeTiming();
-    MaglevTable table(tester.priority_set_.getOrCreateHostSet(0).hosts());
+    MaglevTable table(HostsPerLocalityImpl(tester.priority_set_.getOrCreateHostSet(0).hosts()),
+                      nullptr);
   }
 }
 BENCHMARK(BM_MaglevLoadBalancerBuildTable)
@@ -172,7 +173,8 @@ void BM_MaglevLoadBalancerChooseHost(benchmark::State& state) {
     const uint64_t num_hosts = state.range(0);
     const uint64_t keys_to_simulate = state.range(1);
     BaseTester tester(num_hosts);
-    MaglevTable table(tester.priority_set_.getOrCreateHostSet(0).hosts());
+    MaglevTable table(HostsPerLocalityImpl(tester.priority_set_.getOrCreateHostSet(0).hosts()),
+                      nullptr);
     std::unordered_map<std::string, uint64_t> hit_counter;
     state.ResumeTiming();
 
@@ -248,14 +250,16 @@ void BM_MaglevLoadBalancerHostLoss(benchmark::State& state) {
     const uint64_t keys_to_simulate = state.range(2);
 
     BaseTester tester(num_hosts);
-    MaglevTable table(tester.priority_set_.getOrCreateHostSet(0).hosts());
+    MaglevTable table(HostsPerLocalityImpl(tester.priority_set_.getOrCreateHostSet(0).hosts()),
+                      nullptr);
     std::vector<HostConstSharedPtr> hosts;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       hosts.push_back(table.chooseHost(hashInt(i)));
     }
 
     BaseTester tester2(num_hosts - hosts_to_lose);
-    MaglevTable table2(tester2.priority_set_.getOrCreateHostSet(0).hosts());
+    MaglevTable table2(HostsPerLocalityImpl(tester2.priority_set_.getOrCreateHostSet(0).hosts()),
+                       nullptr);
     std::vector<HostConstSharedPtr> hosts2;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       hosts2.push_back(table2.chooseHost(hashInt(i)));
@@ -290,14 +294,16 @@ void BM_MaglevLoadBalancerWeighted(benchmark::State& state) {
     const uint64_t keys_to_simulate = state.range(4);
 
     BaseTester tester(num_hosts, weighted_subset_percent, before_weight);
-    MaglevTable table(tester.priority_set_.getOrCreateHostSet(0).hosts());
+    MaglevTable table(HostsPerLocalityImpl(tester.priority_set_.getOrCreateHostSet(0).hosts()),
+                      nullptr);
     std::vector<HostConstSharedPtr> hosts;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       hosts.push_back(table.chooseHost(hashInt(i)));
     }
 
     BaseTester tester2(num_hosts, weighted_subset_percent, after_weight);
-    MaglevTable table2(tester2.priority_set_.getOrCreateHostSet(0).hosts());
+    MaglevTable table2(HostsPerLocalityImpl(tester2.priority_set_.getOrCreateHostSet(0).hosts()),
+                       nullptr);
     std::vector<HostConstSharedPtr> hosts2;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       hosts2.push_back(table2.chooseHost(hashInt(i)));

--- a/test/common/upstream/maglev_lb_test.cc
+++ b/test/common/upstream/maglev_lb_test.cc
@@ -107,5 +107,125 @@ TEST_F(MaglevLoadBalancerTest, Weighted) {
   }
 }
 
+// Locality weighted sanity test when localities have the same weights (no
+// different to Weighted above).
+TEST_F(MaglevLoadBalancerTest, LocalityWeightedSameLocalityWeights) {
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", 1),
+                      makeTestHost(info_, "tcp://127.0.0.1:91", 2)};
+  host_set_.healthy_hosts_ = host_set_.hosts_;
+  host_set_.hosts_per_locality_ =
+      makeHostsPerLocality({{host_set_.hosts_[0]}, {host_set_.hosts_[1]}});
+  host_set_.healthy_hosts_per_locality_ = host_set_.hosts_per_locality_;
+  LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{1, 1}};
+  host_set_.locality_weights_ = locality_weights;
+  host_set_.runCallbacks({}, {});
+  init(17);
+  // maglev: i=0 host=127.0.0.1:91
+  // maglev: i=1 host=127.0.0.1:90
+  // maglev: i=2 host=127.0.0.1:90
+  // maglev: i=3 host=127.0.0.1:91
+  // maglev: i=4 host=127.0.0.1:90
+  // maglev: i=5 host=127.0.0.1:91
+  // maglev: i=6 host=127.0.0.1:91
+  // maglev: i=7 host=127.0.0.1:90
+  // maglev: i=8 host=127.0.0.1:91
+  // maglev: i=9 host=127.0.0.1:91
+  // maglev: i=10 host=127.0.0.1:91
+  // maglev: i=11 host=127.0.0.1:91
+  // maglev: i=12 host=127.0.0.1:91
+  // maglev: i=13 host=127.0.0.1:90
+  // maglev: i=14 host=127.0.0.1:91
+  // maglev: i=15 host=127.0.0.1:90
+  // maglev: i=16 host=127.0.0.1:91
+  LoadBalancerPtr lb = lb_->factory()->create();
+  const std::vector<uint32_t> expected_assignments{1, 0, 0, 1, 0, 1, 1, 0, 1,
+                                                   1, 1, 1, 1, 0, 1, 0, 1};
+  for (uint32_t i = 0; i < 3 * expected_assignments.size(); ++i) {
+    TestLoadBalancerContext context(i);
+    EXPECT_EQ(host_set_.hosts_[expected_assignments[i % expected_assignments.size()]],
+              lb->chooseHost(&context));
+  }
+}
+
+// Locality weighted sanity test when localities have different weights (we
+// invert the Weighted effective weights).
+TEST_F(MaglevLoadBalancerTest, LocalityWeightedDifferentLocalityWeights) {
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", 1),
+                      makeTestHost(info_, "tcp://127.0.0.1:91", 2)};
+  host_set_.healthy_hosts_ = host_set_.hosts_;
+  host_set_.hosts_per_locality_ =
+      makeHostsPerLocality({{host_set_.hosts_[0]}, {host_set_.hosts_[1]}});
+  host_set_.healthy_hosts_per_locality_ = host_set_.hosts_per_locality_;
+  LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{8, 2}};
+  host_set_.locality_weights_ = locality_weights;
+  host_set_.runCallbacks({}, {});
+  init(17);
+  // maglev: i=0 host=127.0.0.1:91
+  // maglev: i=1 host=127.0.0.1:90
+  // maglev: i=2 host=127.0.0.1:90
+  // maglev: i=3 host=127.0.0.1:91
+  // maglev: i=4 host=127.0.0.1:90
+  // maglev: i=5 host=127.0.0.1:90
+  // maglev: i=6 host=127.0.0.1:91
+  // maglev: i=7 host=127.0.0.1:90
+  // maglev: i=8 host=127.0.0.1:90
+  // maglev: i=9 host=127.0.0.1:91
+  // maglev: i=10 host=127.0.0.1:90
+  // maglev: i=11 host=127.0.0.1:91
+  // maglev: i=12 host=127.0.0.1:91
+  // maglev: i=13 host=127.0.0.1:90
+  // maglev: i=14 host=127.0.0.1:90
+  // maglev: i=15 host=127.0.0.1:90
+  // maglev: i=16 host=127.0.0.1:90
+  LoadBalancerPtr lb = lb_->factory()->create();
+  const std::vector<uint32_t> expected_assignments{1, 0, 0, 1, 0, 0, 1, 0, 0,
+                                                   1, 0, 1, 1, 0, 0, 0, 0};
+  for (uint32_t i = 0; i < 3 * expected_assignments.size(); ++i) {
+    TestLoadBalancerContext context(i);
+    EXPECT_EQ(host_set_.hosts_[expected_assignments[i % expected_assignments.size()]],
+              lb->chooseHost(&context));
+  }
+}
+
+// Validate that when we are in global panic and have localities, we get sane
+// results (fall back to non-healthy hosts).
+TEST_F(MaglevLoadBalancerTest, LocalityWeightedGlobalPanic) {
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", 1),
+                      makeTestHost(info_, "tcp://127.0.0.1:91", 2)};
+  host_set_.healthy_hosts_ = {};
+  host_set_.hosts_per_locality_ =
+      makeHostsPerLocality({{host_set_.hosts_[0]}, {host_set_.hosts_[1]}});
+  host_set_.healthy_hosts_per_locality_ = makeHostsPerLocality({{}, {}});
+  LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{1, 1}};
+  host_set_.locality_weights_ = locality_weights;
+  host_set_.runCallbacks({}, {});
+  init(17);
+  // maglev: i=0 host=127.0.0.1:91
+  // maglev: i=1 host=127.0.0.1:90
+  // maglev: i=2 host=127.0.0.1:90
+  // maglev: i=3 host=127.0.0.1:91
+  // maglev: i=4 host=127.0.0.1:90
+  // maglev: i=5 host=127.0.0.1:91
+  // maglev: i=6 host=127.0.0.1:91
+  // maglev: i=7 host=127.0.0.1:90
+  // maglev: i=8 host=127.0.0.1:91
+  // maglev: i=9 host=127.0.0.1:91
+  // maglev: i=10 host=127.0.0.1:91
+  // maglev: i=11 host=127.0.0.1:91
+  // maglev: i=12 host=127.0.0.1:91
+  // maglev: i=13 host=127.0.0.1:90
+  // maglev: i=14 host=127.0.0.1:91
+  // maglev: i=15 host=127.0.0.1:90
+  // maglev: i=16 host=127.0.0.1:91
+  LoadBalancerPtr lb = lb_->factory()->create();
+  const std::vector<uint32_t> expected_assignments{1, 0, 0, 1, 0, 1, 1, 0, 1,
+                                                   1, 1, 1, 1, 0, 1, 0, 1};
+  for (uint32_t i = 0; i < 3 * expected_assignments.size(); ++i) {
+    TestLoadBalancerContext context(i);
+    EXPECT_EQ(host_set_.hosts_[expected_assignments[i % expected_assignments.size()]],
+              lb->chooseHost(&context));
+  }
+}
+
 } // namespace Upstream
 } // namespace Envoy

--- a/test/common/upstream/maglev_lb_test.cc
+++ b/test/common/upstream/maglev_lb_test.cc
@@ -165,21 +165,21 @@ TEST_F(MaglevLoadBalancerTest, LocalityWeightedDifferentLocalityWeights) {
   // maglev: i=2 host=127.0.0.1:90
   // maglev: i=3 host=127.0.0.1:91
   // maglev: i=4 host=127.0.0.1:90
-  // maglev: i=5 host=127.0.0.1:90
+  // maglev: i=5 host=127.0.0.1:91
   // maglev: i=6 host=127.0.0.1:91
   // maglev: i=7 host=127.0.0.1:90
   // maglev: i=8 host=127.0.0.1:90
   // maglev: i=9 host=127.0.0.1:91
   // maglev: i=10 host=127.0.0.1:90
   // maglev: i=11 host=127.0.0.1:91
-  // maglev: i=12 host=127.0.0.1:91
+  // maglev: i=12 host=127.0.0.1:90
   // maglev: i=13 host=127.0.0.1:90
   // maglev: i=14 host=127.0.0.1:90
   // maglev: i=15 host=127.0.0.1:90
   // maglev: i=16 host=127.0.0.1:90
   LoadBalancerPtr lb = lb_->factory()->create();
-  const std::vector<uint32_t> expected_assignments{1, 0, 0, 1, 0, 0, 1, 0, 0,
-                                                   1, 0, 1, 1, 0, 0, 0, 0};
+  const std::vector<uint32_t> expected_assignments{1, 0, 0, 1, 0, 1, 1, 0, 0,
+                                                   1, 0, 1, 0, 0, 0, 0, 0};
   for (uint32_t i = 0; i < 3 * expected_assignments.size(); ++i) {
     TestLoadBalancerContext context(i);
     EXPECT_EQ(host_set_.hosts_[expected_assignments[i % expected_assignments.size()]],


### PR DESCRIPTION
This follows up from #2982 and adds the ability to weight at the locality level when performing
Maglev LB. Unlike the non-affinity case, we don't do a two level LB (pick locality, pick host), but
use a single Maglev table. This reduces memory cost when there are few localities relative to hosts,
at the expense of reduced granularity. Ring hash LB is explicitly not supported for weighted,
locality or otherwise.

Fixes #2725.

Risk Level: Low.
Testing: Additional unit tests for locality weighted in maglev_lb_test.

Signed-off-by: Harvey Tuch <htuch@google.com>