### PR TITLE
ci: add delay to reduce likelihood of GH <-> CircleCI sync issues.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
      resource_class: xlarge
      working_directory: /source
      steps:
+       - run: sleep 30 # workaround GH sync issue
        - checkout
        - run: ci/do_circle_ci.sh bazel.release
        - setup_remote_docker
@@ -21,6 +22,7 @@ jobs:
      resource_class: xlarge
      working_directory: /source
      steps:
+       - run: sleep 30 # workaround GH sync issue
        - checkout
        - run: ci/do_circle_ci.sh bazel.asan
    tsan:
@@ -34,6 +36,7 @@ jobs:
    ipv6_tests:
      machine: true
      steps:
+     - run: sleep 30 # workaround GH sync issue
      - checkout
      - run:
          name: enable ipv6
@@ -54,6 +57,7 @@ jobs:
      resource_class: xlarge
      working_directory: /source
      steps:
+       - run: sleep 30 # workaround GH sync issue
        - checkout
        - run: ci/do_circle_ci.sh bazel.coverage
        - run: ci/coverage_publish.sh
@@ -65,6 +69,7 @@ jobs:
      resource_class: small
      working_directory: /source
      steps:
+       - run: sleep 30 # workaround GH sync issue
        - checkout
        - run: ci/do_circle_ci.sh check_format
    build_image:
@@ -75,6 +80,7 @@ jobs:
            NUM_CPUS: 8
      resource_class: xlarge
      steps:
+       - run: sleep 30 # workaround GH sync issue
        - checkout
        - setup_remote_docker
        - run: ci/build_container/docker_push.sh
@@ -84,6 +90,7 @@ jobs:
      resource_class: xlarge
      working_directory: /source
      steps:
+       - run: sleep 30 # workaround GH sync issue
        - checkout
        - add_ssh_keys
        - run: ci/do_circle_ci.sh docs
@@ -92,6 +99,7 @@ jobs:
        xcode: "9.3.0"
      steps:
        - run: sudo ntpdate -vu time.apple.com
+       - run: sleep 30 # workaround GH sync issue
        - checkout
        - run: ci/mac_ci_setup.sh
        - run: ci/mac_ci_steps.sh


### PR DESCRIPTION
This is specifically about the missing SHA messages we routinely in CI failures.

Signed-off-by: Harvey Tuch <htuch@google.com>