### PR TITLE
listener: log errno when setsockopt fails

### DIFF
--- a/source/common/network/socket_option_impl.cc
+++ b/source/common/network/socket_option_impl.cc
@@ -16,7 +16,7 @@ bool SocketOptionImpl::setOption(Socket& socket, Socket::SocketState state) cons
         setIpSocketOption(socket, ENVOY_SOCKET_IP_TRANSPARENT, ENVOY_SOCKET_IPV6_TRANSPARENT,
                           &should_transparent, sizeof(should_transparent));
     if (error != 0) {
-      ENVOY_LOG(warn, "Setting IP_TRANSPARENT on listener socket failed: {}", strerror(error));
+      ENVOY_LOG(warn, "Setting IP_TRANSPARENT on listener socket failed: {}", strerror(errno));
       return false;
     }
   }
@@ -28,7 +28,7 @@ bool SocketOptionImpl::setOption(Socket& socket, Socket::SocketState state) cons
           setIpSocketOption(socket, ENVOY_SOCKET_IP_FREEBIND, ENVOY_SOCKET_IPV6_FREEBIND,
                             &should_freebind, sizeof(should_freebind));
       if (error != 0) {
-        ENVOY_LOG(warn, "Setting IP_FREEBIND on listener socket failed: {}", strerror(error));
+        ENVOY_LOG(warn, "Setting IP_FREEBIND on listener socket failed: {}", strerror(errno));
         return false;
       }
     }

--- a/source/common/network/socket_option_impl.cc
+++ b/source/common/network/socket_option_impl.cc
@@ -69,7 +69,8 @@ int SocketOptionImpl::setIpSocketOption(Socket& socket, SocketOptionName ipv4_op
   if (ip->version() == Network::Address::IpVersion::v4) {
     if (!ipv4_optname) {
       ENVOY_LOG(warn, "Unsupported IPv4 socket option");
-      return ENOTSUP;
+      errno = ENOTSUP;
+      return -1;
     }
     return os_syscalls.setsockopt(socket.fd(), IPPROTO_IP, ipv4_optname.value(), optval, optlen);
   }
@@ -84,7 +85,8 @@ int SocketOptionImpl::setIpSocketOption(Socket& socket, SocketOptionName ipv4_op
     return os_syscalls.setsockopt(socket.fd(), IPPROTO_IP, ipv4_optname.value(), optval, optlen);
   }
   ENVOY_LOG(warn, "Unsupported IPv6 socket option");
-  return ENOTSUP;
+  errno = ENOTSUP;
+  return -1;
 }
 
 } // namespace Network

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -159,6 +159,7 @@ envoy_cc_test(
         "//source/common/network:socket_option_lib",
         "//test/mocks/api:api_mocks",
         "//test/mocks/network:network_mocks",
+        "//test/test_common:logging_lib",
         "//test/test_common:threadsafe_singleton_injector_lib",
     ],
 )

--- a/test/common/network/socket_option_impl_test.cc
+++ b/test/common/network/socket_option_impl_test.cc
@@ -43,18 +43,18 @@ TEST_F(SocketOptionImplTest, SetOptionEmptyNop) {
 TEST_F(SocketOptionImplTest, SetOptionTransparentFailure) {
   SocketOptionImpl socket_option{true, {}};
   EXPECT_FALSE(socket_option.setOption(socket_, Socket::SocketState::PreBind));
-  EXPECT_LOG_CONTAINS("warning",
-                      "Failed to set IP socket option on non-IP socket",
-                      EXPECT_EQ(EOPNOTSUPP, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0)));
-    }
+  EXPECT_LOG_CONTAINS(
+      "warning", "Failed to set IP socket option on non-IP socket",
+      EXPECT_EQ(EOPNOTSUPP, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0)));
+}
 
 // We fail to set the option when the underlying setsockopt syscall fails.
 TEST_F(SocketOptionImplTest, SetOptionFreebindFailure) {
   SocketOptionImpl socket_option{{}, true};
   EXPECT_FALSE(socket_option.setOption(socket_, Socket::SocketState::PreBind));
-  EXPECT_LOG_CONTAINS("warning",
-                      "Failed to set IP socket option on non-IP socket",
-                      EXPECT_EQ(EOPNOTSUPP, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0)));
+  EXPECT_LOG_CONTAINS(
+      "warning", "Failed to set IP socket option on non-IP socket",
+      EXPECT_EQ(EOPNOTSUPP, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0)));
 }
 
 // The happy path for setOption(); IP_TRANSPARENT is set to true.
@@ -150,9 +150,9 @@ TEST_F(SocketOptionImplTest, V4EmptyOptionNames) {
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
   EXPECT_EQ(-1, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0));
   EXPECT_EQ(ENOTSUP, errno);
-  EXPECT_LOG_CONTAINS("warning",
-                      "Unsupported IPv4 socket option",
-                      EXPECT_EQ(-1, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0)));
+  EXPECT_LOG_CONTAINS(
+      "warning", "Unsupported IPv4 socket option",
+      EXPECT_EQ(-1, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0)));
 }
 
 // If a platform doesn't suppport IPv4 and IPv6 socket option variants for an IPv4 address, we fail
@@ -163,9 +163,9 @@ TEST_F(SocketOptionImplTest, V6EmptyOptionNames) {
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
   EXPECT_EQ(-1, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0));
   EXPECT_EQ(ENOTSUP, errno);
-  EXPECT_LOG_CONTAINS("warning",
-                      "Unsupported IPv6 socket option",
-                      EXPECT_EQ(-1, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0)));
+  EXPECT_LOG_CONTAINS(
+      "warning", "Unsupported IPv6 socket option",
+      EXPECT_EQ(-1, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0)));
 }
 
 // If a platform suppports IPv4 socket option variant for an IPv4 address,

--- a/test/common/network/socket_option_impl_test.cc
+++ b/test/common/network/socket_option_impl_test.cc
@@ -45,7 +45,7 @@ TEST_F(SocketOptionImplTest, SetOptionTransparentFailure) {
   EXPECT_FALSE(socket_option.setOption(socket_, Socket::SocketState::PreBind));
   EXPECT_LOG_CONTAINS(
       "warning", "Failed to set IP socket option on non-IP socket",
-      EXPECT_EQ(EOPNOTSUPP, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0)));
+      EXPECT_EQ(ENOTSUP, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0)));
 }
 
 // We fail to set the option when the underlying setsockopt syscall fails.
@@ -54,7 +54,7 @@ TEST_F(SocketOptionImplTest, SetOptionFreebindFailure) {
   EXPECT_FALSE(socket_option.setOption(socket_, Socket::SocketState::PreBind));
   EXPECT_LOG_CONTAINS(
       "warning", "Failed to set IP socket option on non-IP socket",
-      EXPECT_EQ(EOPNOTSUPP, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0)));
+      EXPECT_EQ(ENOTSUP, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0)));
 }
 
 // The happy path for setOption(); IP_TRANSPARENT is set to true.

--- a/test/common/network/socket_option_impl_test.cc
+++ b/test/common/network/socket_option_impl_test.cc
@@ -3,6 +3,7 @@
 
 #include "test/mocks/api/mocks.h"
 #include "test/mocks/network/mocks.h"
+#include "test/test_common/logging.h"
 #include "test/test_common/threadsafe_singleton_injector.h"
 
 #include "gtest/gtest.h"
@@ -42,12 +43,18 @@ TEST_F(SocketOptionImplTest, SetOptionEmptyNop) {
 TEST_F(SocketOptionImplTest, SetOptionTransparentFailure) {
   SocketOptionImpl socket_option{true, {}};
   EXPECT_FALSE(socket_option.setOption(socket_, Socket::SocketState::PreBind));
-}
+  EXPECT_LOG_CONTAINS("warning",
+                      "Failed to set IP socket option on non-IP socket",
+                      EXPECT_EQ(EOPNOTSUPP, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0)));
+    }
 
 // We fail to set the option when the underlying setsockopt syscall fails.
 TEST_F(SocketOptionImplTest, SetOptionFreebindFailure) {
   SocketOptionImpl socket_option{{}, true};
   EXPECT_FALSE(socket_option.setOption(socket_, Socket::SocketState::PreBind));
+  EXPECT_LOG_CONTAINS("warning",
+                      "Failed to set IP socket option on non-IP socket",
+                      EXPECT_EQ(EOPNOTSUPP, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0)));
 }
 
 // The happy path for setOption(); IP_TRANSPARENT is set to true.
@@ -143,6 +150,9 @@ TEST_F(SocketOptionImplTest, V4EmptyOptionNames) {
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
   EXPECT_EQ(-1, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0));
   EXPECT_EQ(ENOTSUP, errno);
+  EXPECT_LOG_CONTAINS("warning",
+                      "Unsupported IPv4 socket option",
+                      EXPECT_EQ(-1, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0)));
 }
 
 // If a platform doesn't suppport IPv4 and IPv6 socket option variants for an IPv4 address, we fail
@@ -153,6 +163,9 @@ TEST_F(SocketOptionImplTest, V6EmptyOptionNames) {
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
   EXPECT_EQ(-1, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0));
   EXPECT_EQ(ENOTSUP, errno);
+  EXPECT_LOG_CONTAINS("warning",
+                      "Unsupported IPv6 socket option",
+                      EXPECT_EQ(-1, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0)));
 }
 
 // If a platform suppports IPv4 socket option variant for an IPv4 address,

--- a/test/common/network/socket_option_impl_test.cc
+++ b/test/common/network/socket_option_impl_test.cc
@@ -141,7 +141,8 @@ TEST_F(SocketOptionImplTest, V4EmptyOptionNames) {
   Address::Ipv4Instance address("1.2.3.4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
-  EXPECT_EQ(ENOTSUP, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0));
+  EXPECT_EQ(-1, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0));
+  EXPECT_EQ(ENOTSUP, errno);
 }
 
 // If a platform doesn't suppport IPv4 and IPv6 socket option variants for an IPv4 address, we fail
@@ -150,7 +151,8 @@ TEST_F(SocketOptionImplTest, V6EmptyOptionNames) {
   Address::Ipv6Instance address("::1:2:3:4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
-  EXPECT_EQ(ENOTSUP, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0));
+  EXPECT_EQ(-1, SocketOptionImpl::setIpSocketOption(socket_, {}, {}, nullptr, 0));
+  EXPECT_EQ(ENOTSUP, errno);
 }
 
 // If a platform suppports IPv4 socket option variant for an IPv4 address,


### PR DESCRIPTION
listener: log errno when setsockopt fails

If -1 is passed to the strerror the warning is shown as ENOTSUP.
In the case that the operation should be supported but we are talking
to a non-existent socket, we want ENOTSOCK to be returned.

Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

*Risk Level*: 
Low: Correct logging bug

*Docs Changes*:
N/A

*Release Notes*:
TODO:

Fixes: #2986
