### PR TITLE
repo reorg: rename HttpTracerFactory -> TracerFactory

### DIFF
--- a/source/extensions/tracers/dynamic_ot/config.cc
+++ b/source/extensions/tracers/dynamic_ot/config.cc
@@ -14,8 +14,8 @@ namespace Tracers {
 namespace DynamicOt {
 
 Tracing::HttpTracerPtr
-DynamicOpenTracingHttpTracerFactory::createHttpTracer(const Json::Object& json_config,
-                                                      Server::Instance& server) {
+DynamicOpenTracingTracerFactory::createHttpTracer(const Json::Object& json_config,
+                                                  Server::Instance& server) {
   const std::string library = json_config.getString("library");
   const std::string config = json_config.getObject("config")->asJsonString();
   Tracing::DriverPtr dynamic_driver{
@@ -23,15 +23,15 @@ DynamicOpenTracingHttpTracerFactory::createHttpTracer(const Json::Object& json_c
   return std::make_unique<Tracing::HttpTracerImpl>(std::move(dynamic_driver), server.localInfo());
 }
 
-std::string DynamicOpenTracingHttpTracerFactory::name() {
+std::string DynamicOpenTracingTracerFactory::name() {
   return Config::TracerNames::get().DYNAMIC_OT;
 }
 
 /**
- * Static registration for the dynamic opentracing http tracer. @see RegisterFactory.
+ * Static registration for the dynamic opentracing tracer. @see RegisterFactory.
  */
-static Registry::RegisterFactory<DynamicOpenTracingHttpTracerFactory,
-                                 Server::Configuration::HttpTracerFactory>
+static Registry::RegisterFactory<DynamicOpenTracingTracerFactory,
+                                 Server::Configuration::TracerFactory>
     register_;
 
 } // namespace DynamicOt

--- a/source/extensions/tracers/dynamic_ot/config.h
+++ b/source/extensions/tracers/dynamic_ot/config.h
@@ -12,11 +12,11 @@ namespace Tracers {
 namespace DynamicOt {
 
 /**
- * Config registration for the dynamic opentracing tracer. @see HttpTracerFactory.
+ * Config registration for the dynamic opentracing tracer. @see TracerFactory.
  */
-class DynamicOpenTracingHttpTracerFactory : public Server::Configuration::HttpTracerFactory {
+class DynamicOpenTracingTracerFactory : public Server::Configuration::TracerFactory {
 public:
-  // HttpTracerFactory
+  // TracerFactory
   Tracing::HttpTracerPtr createHttpTracer(const Json::Object& json_config,
                                           Server::Instance& server) override;
   std::string name() override;

--- a/source/extensions/tracers/lightstep/config.cc
+++ b/source/extensions/tracers/lightstep/config.cc
@@ -15,8 +15,8 @@ namespace Extensions {
 namespace Tracers {
 namespace Lightstep {
 
-Tracing::HttpTracerPtr LightstepHttpTracerFactory::createHttpTracer(const Json::Object& json_config,
-                                                                    Server::Instance& server) {
+Tracing::HttpTracerPtr LightstepTracerFactory::createHttpTracer(const Json::Object& json_config,
+                                                                Server::Instance& server) {
 
   std::unique_ptr<lightstep::LightStepTracerOptions> opts(new lightstep::LightStepTracerOptions());
   const auto access_token_file =
@@ -31,13 +31,12 @@ Tracing::HttpTracerPtr LightstepHttpTracerFactory::createHttpTracer(const Json::
   return std::make_unique<Tracing::HttpTracerImpl>(std::move(lightstep_driver), server.localInfo());
 }
 
-std::string LightstepHttpTracerFactory::name() { return Config::TracerNames::get().LIGHTSTEP; }
+std::string LightstepTracerFactory::name() { return Config::TracerNames::get().LIGHTSTEP; }
 
 /**
- * Static registration for the lightstep http tracer. @see RegisterFactory.
+ * Static registration for the lightstep tracer. @see RegisterFactory.
  */
-static Registry::RegisterFactory<LightstepHttpTracerFactory,
-                                 Server::Configuration::HttpTracerFactory>
+static Registry::RegisterFactory<LightstepTracerFactory, Server::Configuration::TracerFactory>
     register_;
 
 } // namespace Lightstep

--- a/source/extensions/tracers/lightstep/config.h
+++ b/source/extensions/tracers/lightstep/config.h
@@ -12,11 +12,11 @@ namespace Tracers {
 namespace Lightstep {
 
 /**
- * Config registration for the lightstep tracer. @see HttpTracerFactory.
+ * Config registration for the lightstep tracer. @see TracerFactory.
  */
-class LightstepHttpTracerFactory : public Server::Configuration::HttpTracerFactory {
+class LightstepTracerFactory : public Server::Configuration::TracerFactory {
 public:
-  // HttpTracerFactory
+  // TracerFactory
   Tracing::HttpTracerPtr createHttpTracer(const Json::Object& json_config,
                                           Server::Instance& server) override;
 

--- a/source/extensions/tracers/zipkin/config.cc
+++ b/source/extensions/tracers/zipkin/config.cc
@@ -13,8 +13,8 @@ namespace Extensions {
 namespace Tracers {
 namespace Zipkin {
 
-Tracing::HttpTracerPtr ZipkinHttpTracerFactory::createHttpTracer(const Json::Object& json_config,
-                                                                 Server::Instance& server) {
+Tracing::HttpTracerPtr ZipkinTracerFactory::createHttpTracer(const Json::Object& json_config,
+                                                             Server::Instance& server) {
 
   Envoy::Runtime::RandomGenerator& rand = server.random();
 
@@ -26,12 +26,12 @@ Tracing::HttpTracerPtr ZipkinHttpTracerFactory::createHttpTracer(const Json::Obj
       new Tracing::HttpTracerImpl(std::move(zipkin_driver), server.localInfo()));
 }
 
-std::string ZipkinHttpTracerFactory::name() { return Config::TracerNames::get().ZIPKIN; }
+std::string ZipkinTracerFactory::name() { return Config::TracerNames::get().ZIPKIN; }
 
 /**
- * Static registration for the lightstep http tracer. @see RegisterFactory.
+ * Static registration for the lightstep tracer. @see RegisterFactory.
  */
-static Registry::RegisterFactory<ZipkinHttpTracerFactory, Server::Configuration::HttpTracerFactory>
+static Registry::RegisterFactory<ZipkinTracerFactory, Server::Configuration::TracerFactory>
     register_;
 
 } // namespace Zipkin

--- a/source/extensions/tracers/zipkin/config.h
+++ b/source/extensions/tracers/zipkin/config.h
@@ -10,11 +10,11 @@ namespace Tracers {
 namespace Zipkin {
 
 /**
- * Config registration for the zipkin http tracer. @see HttpTracerFactory.
+ * Config registration for the zipkin tracer. @see TracerFactory.
  */
-class ZipkinHttpTracerFactory : public Server::Configuration::HttpTracerFactory {
+class ZipkinTracerFactory : public Server::Configuration::TracerFactory {
 public:
-  // HttpTracerFactory
+  // TracerFactory
   Tracing::HttpTracerPtr createHttpTracer(const Json::Object& json_config,
                                           Server::Instance& server) override;
   std::string name() override;

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -105,7 +105,7 @@ void MainImpl::initializeTracers(const envoy::config::trace::v2::Tracing& config
       MessageUtil::getJsonObjectFromMessage(configuration.http().config());
 
   // Now see if there is a factory that will accept the config.
-  auto& factory = Config::Utility::getAndCheckFactory<HttpTracerFactory>(type);
+  auto& factory = Config::Utility::getAndCheckFactory<TracerFactory>(type);
   http_tracer_ = factory.createHttpTracer(*driver_config, server);
 }
 

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -30,12 +30,12 @@ namespace Server {
 namespace Configuration {
 
 /**
- * Implemented by each HttpTracer and registered via Registry::registerFactory() or
- * the convenience class RegisterFactory.
+ * Implemented by each Tracer and registered via Registry::registerFactory() or the convenience
+ * class RegisterFactory.
  */
-class HttpTracerFactory {
+class TracerFactory {
 public:
-  virtual ~HttpTracerFactory() {}
+  virtual ~TracerFactory() {}
 
   /**
    * Create a particular HttpTracer implementation. If the implementation is unable to produce an
@@ -49,7 +49,7 @@ public:
                                                   Instance& server) PURE;
 
   /**
-   * Returns the identifying name for a particular implementation of HttpTracer produced by the
+   * Returns the identifying name for a particular implementation of tracer produced by the
    * factory.
    */
   virtual std::string name() PURE;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -202,7 +202,7 @@ void InstanceImpl::initialize(Options& options,
   ENVOY_LOG(info, "  stat_sinks: {}",
             Registry::FactoryRegistry<Configuration::StatsSinkFactory>::allFactoryNames());
   ENVOY_LOG(info, "  tracers: {}",
-            Registry::FactoryRegistry<Configuration::HttpTracerFactory>::allFactoryNames());
+            Registry::FactoryRegistry<Configuration::TracerFactory>::allFactoryNames());
   ENVOY_LOG(info, "  transport_sockets.downstream: {}",
             Registry::FactoryRegistry<
                 Configuration::DownstreamTransportSocketConfigFactory>::allFactoryNames());

--- a/test/extensions/tracers/dynamic_ot/config_test.cc
+++ b/test/extensions/tracers/dynamic_ot/config_test.cc
@@ -33,7 +33,7 @@ TEST(DynamicOtTracerConfigTest, DynamicOpentracingHttpTracer) {
   )EOF",
                                                 TestEnvironment::runfilesDirectory());
   const Json::ObjectSharedPtr valid_json = Json::Factory::loadFromString(valid_config);
-  DynamicOpenTracingHttpTracerFactory factory;
+  DynamicOpenTracingTracerFactory factory;
 
   const Tracing::HttpTracerPtr tracer = factory.createHttpTracer(*valid_json, server);
   EXPECT_NE(nullptr, tracer);

--- a/test/extensions/tracers/lightstep/config_test.cc
+++ b/test/extensions/tracers/lightstep/config_test.cc
@@ -29,7 +29,7 @@ TEST(LightstepTracerConfigTest, LightstepHttpTracer) {
   )EOF";
   Json::ObjectSharedPtr valid_json = Json::Factory::loadFromString(valid_config);
 
-  LightstepHttpTracerFactory factory;
+  LightstepTracerFactory factory;
   Tracing::HttpTracerPtr lightstep_tracer = factory.createHttpTracer(*valid_json, server);
   EXPECT_NE(nullptr, lightstep_tracer);
 }

--- a/test/extensions/tracers/zipkin/config_test.cc
+++ b/test/extensions/tracers/zipkin/config_test.cc
@@ -24,15 +24,15 @@ TEST(ZipkinTracerConfigTest, ZipkinHttpTracer) {
   }
   )EOF";
   Json::ObjectSharedPtr valid_json = Json::Factory::loadFromString(valid_config);
-  ZipkinHttpTracerFactory factory;
+  ZipkinTracerFactory factory;
   Tracing::HttpTracerPtr zipkin_tracer = factory.createHttpTracer(*valid_json, server);
   EXPECT_NE(nullptr, zipkin_tracer);
 }
 
 TEST(ZipkinTracerConfigTest, DoubleRegistrationTest) {
-  EXPECT_THROW_WITH_MESSAGE((Registry::RegisterFactory<ZipkinHttpTracerFactory,
-                                                       Server::Configuration::HttpTracerFactory>()),
-                            EnvoyException, "Double registration for name: 'envoy.zipkin'");
+  EXPECT_THROW_WITH_MESSAGE(
+      (Registry::RegisterFactory<ZipkinTracerFactory, Server::Configuration::TracerFactory>()),
+      EnvoyException, "Double registration for name: 'envoy.zipkin'");
 }
 
 } // namespace Zipkin


### PR DESCRIPTION
Cosmetic only. In the future we will want to create non-HTTP tracers and
the trace drivers themselves are not HTTP specific.

*Risk Level*: Low 
*Testing*: Existing tests
*Docs Changes*: N/A
*Release Notes*: N/A