### PR TITLE
Revert "Support api config source without cluster names (#2999)"

### DIFF
--- a/source/common/config/subscription_factory.h
+++ b/source/common/config/subscription_factory.h
@@ -52,21 +52,22 @@ public:
     case envoy::api::v2::core::ConfigSource::kApiConfigSource: {
       const envoy::api::v2::core::ApiConfigSource& api_config_source = config.api_config_source();
       Utility::checkApiConfigSourceSubscriptionBackingCluster(cm.clusters(), api_config_source);
+      const std::string& cluster_name = api_config_source.cluster_names()[0];
       switch (api_config_source.api_type()) {
       case envoy::api::v2::core::ApiConfigSource::REST_LEGACY:
         result.reset(rest_legacy_constructor());
         break;
       case envoy::api::v2::core::ApiConfigSource::REST:
         result.reset(new HttpSubscriptionImpl<ResourceType>(
-            node, cm, api_config_source.cluster_names()[0], dispatcher, random,
+            node, cm, cluster_name, dispatcher, random,
             Utility::apiConfigSourceRefreshDelay(api_config_source),
             *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(rest_method), stats));
         break;
       case envoy::api::v2::core::ApiConfigSource::GRPC: {
         result.reset(new GrpcSubscriptionImpl<ResourceType>(
             node,
-            Config::Utility::factoryForGrpcApiConfigSource(cm.grpcAsyncClientManager(),
-                                                           config.api_config_source(), scope)
+            Config::Utility::factoryForApiConfigSource(cm.grpcAsyncClientManager(),
+                                                       config.api_config_source(), scope)
                 ->create(),
             dispatcher, *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(grpc_method),
             stats));

--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -78,67 +78,23 @@ void Utility::checkFilesystemSubscriptionBackingPath(const std::string& path) {
   }
 }
 
-void Utility::checkApiConfigSourceNames(
-    const envoy::api::v2::core::ApiConfigSource& api_config_source) {
-  const bool is_grpc =
-      (api_config_source.api_type() == envoy::api::v2::core::ApiConfigSource::GRPC);
-
-  if (is_grpc) {
-    if (api_config_source.cluster_names().size() != 0) {
-      throw EnvoyException(
-          "envoy::api::v2::core::ConfigSource::GRPC must not have a cluster name specified");
-    }
-    if (api_config_source.grpc_services().size() != 1) {
-      throw EnvoyException(
-          "envoy::api::v2::core::ConfigSource::GRPC must have a single gRPC service specified");
-    }
-  } else {
-    if (api_config_source.grpc_services().size() != 0) {
-      throw EnvoyException("envoy::api::v2::core::ConfigSource, if not of type gRPC, must not have "
-                           "a gRPC service specified");
-    }
-    if (api_config_source.cluster_names().size() != 1) {
-      throw EnvoyException(
-          "envoy::api::v2::core::ConfigSource must have a singleton cluster name specified");
-    }
-  }
-}
-
 void Utility::checkApiConfigSourceSubscriptionBackingCluster(
     const Upstream::ClusterManager::ClusterInfoMap& clusters,
     const envoy::api::v2::core::ApiConfigSource& api_config_source) {
-  Utility::checkApiConfigSourceNames(api_config_source);
+  if (api_config_source.cluster_names().size() != 1) {
+    // TODO(htuch): Add support for multiple clusters, #1170.
+    throw EnvoyException(
+        "envoy::api::v2::core::ConfigSource must have a singleton cluster name specified");
+  }
 
-  const bool is_grpc =
-      (api_config_source.api_type() == envoy::api::v2::core::ApiConfigSource::GRPC);
-
-  // We ought to validate the cluster name if and only if there is a cluster name.
-  if (is_grpc) {
-    // Some ApiConfigSources of type GRPC won't have a cluster name, such as if
-    // they've been configured with google_grpc.
-    if (api_config_source.grpc_services()[0].has_envoy_grpc()) {
-      const std::string& cluster_name =
-          api_config_source.grpc_services()[0].envoy_grpc().cluster_name();
-      const auto& it = clusters.find(cluster_name);
-      if (it == clusters.end() || it->second.get().info()->addedViaApi() ||
-          it->second.get().info()->type() == envoy::api::v2::Cluster::EDS) {
-        throw EnvoyException(fmt::format(
-            "envoy::api::v2::core::ConfigSource must have a statically "
-            "defined non-EDS cluster: '{}' does not exist, was added via api, or is an EDS cluster",
-            cluster_name));
-      }
-    }
-  } else {
-    // All ApiConfigSources of type REST and REST_LEGACY should have cluster_names.
-    const std::string& cluster_name = api_config_source.cluster_names()[0];
-    const auto& it = clusters.find(cluster_name);
-    if (it == clusters.end() || it->second.get().info()->addedViaApi() ||
-        it->second.get().info()->type() == envoy::api::v2::Cluster::EDS) {
-      throw EnvoyException(fmt::format(
-          "envoy::api::v2::core::ConfigSource must have a statically "
-          "defined non-EDS cluster: '{}' does not exist, was added via api, or is an EDS cluster",
-          cluster_name));
-    }
+  const auto& cluster_name = api_config_source.cluster_names()[0];
+  const auto& it = clusters.find(cluster_name);
+  if (it == clusters.end() || it->second.get().info()->addedViaApi() ||
+      it->second.get().info()->type() == envoy::api::v2::Cluster::EDS) {
+    throw EnvoyException(fmt::format(
+        "envoy::api::v2::core::ConfigSource must have a statically "
+        "defined non-EDS cluster: '{}' does not exist, was added via api, or is an EDS cluster",
+        cluster_name));
   }
 }
 
@@ -205,13 +161,36 @@ void Utility::checkObjNameLength(const std::string& error_prefix, const std::str
   }
 }
 
-Grpc::AsyncClientFactoryPtr Utility::factoryForGrpcApiConfigSource(
-    Grpc::AsyncClientManager& async_client_manager,
-    const envoy::api::v2::core::ApiConfigSource& api_config_source, Stats::Scope& scope) {
-  Utility::checkApiConfigSourceNames(api_config_source);
+Grpc::AsyncClientFactoryPtr
+Utility::factoryForApiConfigSource(Grpc::AsyncClientManager& async_client_manager,
+                                   const envoy::api::v2::core::ApiConfigSource& api_config_source,
+                                   Stats::Scope& scope) {
+  ASSERT(api_config_source.api_type() == envoy::api::v2::core::ApiConfigSource::GRPC);
+  envoy::api::v2::core::GrpcService grpc_service;
+  if (api_config_source.cluster_names().empty()) {
+    if (api_config_source.grpc_services().empty()) {
+      throw EnvoyException(
+          fmt::format("Missing gRPC services in envoy::api::v2::core::ApiConfigSource: {}",
+                      api_config_source.DebugString()));
+    }
+    // TODO(htuch): Implement multiple gRPC services.
+    if (api_config_source.grpc_services().size() != 1) {
+      throw EnvoyException(fmt::format("Only singleton gRPC service lists supported in "
+                                       "envoy::api::v2::core::ApiConfigSource: {}",
+                                       api_config_source.DebugString()));
+    }
+    grpc_service.MergeFrom(api_config_source.grpc_services(0));
+  } else {
+    // TODO(htuch): cluster_names is deprecated, remove after 1.6.0.
+    if (api_config_source.cluster_names().size() != 1) {
+      throw EnvoyException(fmt::format("Only singleton cluster name lists supported in "
+                                       "envoy::api::v2::core::ApiConfigSource: {}",
+                                       api_config_source.DebugString()));
+    }
+    grpc_service.mutable_envoy_grpc()->set_cluster_name(api_config_source.cluster_names(0));
+  }
 
-  return async_client_manager.factoryForGrpcService(api_config_source.grpc_services(0), scope,
-                                                    false);
+  return async_client_manager.factoryForGrpcService(grpc_service, scope, false);
 }
 
 } // namespace Config

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -122,15 +122,6 @@ public:
   static void checkFilesystemSubscriptionBackingPath(const std::string& path);
 
   /**
-   * Check the grpc_services and cluster_names for API config sanity. Throws on error.
-   * @param api_config_source the config source to validate.
-   * @throws EnvoyException when an API config has the wrong number of gRPC
-   * services or cluster names, depending on expectations set by its API type.
-   */
-  static void
-  checkApiConfigSourceNames(const envoy::api::v2::core::ApiConfigSource& api_config_source);
-
-  /**
    * Check the validity of a cluster backing an api config source. Throws on error.
    * @param clusters the clusters currently loaded in the cluster manager.
    * @param api_config_source the config source to validate.
@@ -249,9 +240,9 @@ public:
    * @return Grpc::AsyncClientFactoryPtr gRPC async client factory.
    */
   static Grpc::AsyncClientFactoryPtr
-  factoryForGrpcApiConfigSource(Grpc::AsyncClientManager& async_client_manager,
-                                const envoy::api::v2::core::ApiConfigSource& api_config_source,
-                                Stats::Scope& scope);
+  factoryForApiConfigSource(Grpc::AsyncClientManager& async_client_manager,
+                            const envoy::api::v2::core::ApiConfigSource& api_config_source,
+                            Stats::Scope& scope);
 };
 
 } // namespace Config

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -204,7 +204,7 @@ ClusterManagerImpl::ClusterManagerImpl(const envoy::config::bootstrap::v2::Boots
   if (bootstrap.dynamic_resources().has_ads_config()) {
     ads_mux_.reset(new Config::GrpcMuxImpl(
         bootstrap.node(),
-        Config::Utility::factoryForGrpcApiConfigSource(
+        Config::Utility::factoryForApiConfigSource(
             *async_client_manager_, bootstrap.dynamic_resources().ads_config(), stats)
             ->create(),
         main_thread_dispatcher,
@@ -291,12 +291,11 @@ ClusterManagerImpl::ClusterManagerImpl(const envoy::config::bootstrap::v2::Boots
 
   if (cm_config.has_load_stats_config()) {
     const auto& load_stats_config = cm_config.load_stats_config();
-    load_stats_reporter_.reset(
-        new LoadStatsReporter(bootstrap.node(), *this, stats,
-                              Config::Utility::factoryForGrpcApiConfigSource(
-                                  *async_client_manager_, load_stats_config, stats)
-                                  ->create(),
-                              main_thread_dispatcher));
+    load_stats_reporter_.reset(new LoadStatsReporter(
+        bootstrap.node(), *this, stats,
+        Config::Utility::factoryForApiConfigSource(*async_client_manager_, load_stats_config, stats)
+            ->create(),
+        main_thread_dispatcher));
   }
 }
 

--- a/test/common/config/subscription_factory_test.cc
+++ b/test/common/config/subscription_factory_test.cc
@@ -60,122 +60,19 @@ TEST_F(SubscriptionFactoryTest, NoConfigSpecifier) {
       "Missing config source specifier in envoy::api::v2::core::ConfigSource");
 }
 
-TEST_F(SubscriptionFactoryTest, RestClusterEmpty) {
+TEST_F(SubscriptionFactoryTest, WrongClusterNameLength) {
   envoy::api::v2::core::ConfigSource config;
-  Upstream::ClusterManager::ClusterInfoMap cluster_map;
-
   config.mutable_api_config_source()->set_api_type(envoy::api::v2::core::ApiConfigSource::REST);
-
-  EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
+  EXPECT_CALL(cm_, clusters());
   EXPECT_THROW_WITH_MESSAGE(
       subscriptionFromConfigSource(config), EnvoyException,
       "envoy::api::v2::core::ConfigSource must have a singleton cluster name specified");
-}
-
-TEST_F(SubscriptionFactoryTest, GrpcClusterEmpty) {
-  envoy::api::v2::core::ConfigSource config;
-  Upstream::ClusterManager::ClusterInfoMap cluster_map;
-
-  config.mutable_api_config_source()->set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
-
-  EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
-  EXPECT_THROW_WITH_MESSAGE(
-      subscriptionFromConfigSource(config), EnvoyException,
-      "envoy::api::v2::core::ConfigSource::GRPC must have a single gRPC service specified");
-}
-
-TEST_F(SubscriptionFactoryTest, RestClusterSingleton) {
-  envoy::api::v2::core::ConfigSource config;
-  Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  NiceMock<Upstream::MockCluster> cluster;
-
-  config.mutable_api_config_source()->set_api_type(envoy::api::v2::core::ApiConfigSource::REST);
-  config.mutable_api_config_source()->mutable_refresh_delay()->set_seconds(1);
-  config.mutable_api_config_source()->add_cluster_names("static_cluster");
-  cluster_map.emplace("static_cluster", cluster);
-
-  EXPECT_CALL(dispatcher_, createTimer_(_));
-  EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
-  EXPECT_CALL(*cluster.info_, addedViaApi()).WillOnce(Return(false));
-  EXPECT_CALL(*cluster.info_, type()).WillOnce(Return(envoy::api::v2::Cluster::STATIC));
-  subscriptionFromConfigSource(config);
-}
-
-TEST_F(SubscriptionFactoryTest, GrpcClusterSingleton) {
-  envoy::api::v2::core::ConfigSource config;
-  Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  NiceMock<Upstream::MockCluster> cluster;
-
-  config.mutable_api_config_source()->set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
-  config.mutable_api_config_source()->mutable_refresh_delay()->set_seconds(1);
-  config.mutable_api_config_source()->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name(
-      "static_cluster");
-  cluster_map.emplace("static_cluster", cluster);
-
-  envoy::api::v2::core::GrpcService expected_grpc_service;
-  expected_grpc_service.mutable_envoy_grpc()->set_cluster_name("static_cluster");
-
-  EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
-  EXPECT_CALL(cm_, grpcAsyncClientManager()).WillOnce(ReturnRef(cm_.async_client_manager_));
-  EXPECT_CALL(cm_.async_client_manager_,
-              factoryForGrpcService(ProtoEq(expected_grpc_service), _, _))
-      .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&, bool) {
-        auto async_client_factory = std::make_unique<Grpc::MockAsyncClientFactory>();
-        EXPECT_CALL(*async_client_factory, create()).WillOnce(Invoke([] {
-          return std::make_unique<NiceMock<Grpc::MockAsyncClient>>();
-        }));
-        return async_client_factory;
-      }));
-  EXPECT_CALL(*cluster.info_, addedViaApi()).WillOnce(Return(false));
-  EXPECT_CALL(*cluster.info_, type()).WillOnce(Return(envoy::api::v2::Cluster::STATIC));
-  EXPECT_CALL(dispatcher_, createTimer_(_));
-
-  subscriptionFromConfigSource(config);
-}
-
-TEST_F(SubscriptionFactoryTest, RestClusterMultiton) {
-  envoy::api::v2::core::ConfigSource config;
-  Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  NiceMock<Upstream::MockCluster> cluster;
-
-  config.mutable_api_config_source()->set_api_type(envoy::api::v2::core::ApiConfigSource::REST);
-
-  config.mutable_api_config_source()->add_cluster_names("static_cluster_foo");
-  cluster_map.emplace("static_cluster_foo", cluster);
-
-  config.mutable_api_config_source()->add_cluster_names("static_cluster_bar");
-  cluster_map.emplace("static_cluster_bar", cluster);
-
-  EXPECT_CALL(cm_, clusters()).WillRepeatedly(Return(cluster_map));
-  EXPECT_CALL(*cluster.info_, addedViaApi()).WillRepeatedly(Return(false));
-  EXPECT_CALL(*cluster.info_, type()).WillRepeatedly(Return(envoy::api::v2::Cluster::STATIC));
+  config.mutable_api_config_source()->add_cluster_names("foo");
+  config.mutable_api_config_source()->add_cluster_names("bar");
+  EXPECT_CALL(cm_, clusters());
   EXPECT_THROW_WITH_MESSAGE(
       subscriptionFromConfigSource(config), EnvoyException,
       "envoy::api::v2::core::ConfigSource must have a singleton cluster name specified");
-}
-
-TEST_F(SubscriptionFactoryTest, GrpcClusterMultiton) {
-  envoy::api::v2::core::ConfigSource config;
-  Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  NiceMock<Upstream::MockCluster> cluster;
-
-  config.mutable_api_config_source()->set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
-
-  config.mutable_api_config_source()->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name(
-      "static_cluster_foo");
-  cluster_map.emplace("static_cluster_foo", cluster);
-  config.mutable_api_config_source()->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name(
-      "static_cluster_bar");
-  cluster_map.emplace("static_cluster_bar", cluster);
-
-  EXPECT_CALL(cm_, clusters()).WillRepeatedly(Return(cluster_map));
-  EXPECT_CALL(cm_, grpcAsyncClientManager()).WillRepeatedly(ReturnRef(cm_.async_client_manager_));
-  EXPECT_CALL(*cluster.info_, addedViaApi()).WillRepeatedly(Return(false));
-  EXPECT_CALL(*cluster.info_, type()).WillRepeatedly(Return(envoy::api::v2::Cluster::STATIC));
-
-  EXPECT_THROW_WITH_MESSAGE(
-      subscriptionFromConfigSource(config), EnvoyException,
-      "envoy::api::v2::core::ConfigSource::GRPC must have a single gRPC service specified");
 }
 
 TEST_F(SubscriptionFactoryTest, FilesystemSubscription) {
@@ -202,44 +99,44 @@ TEST_F(SubscriptionFactoryTest, LegacySubscription) {
   envoy::api::v2::core::ConfigSource config;
   auto* api_config_source = config.mutable_api_config_source();
   api_config_source->set_api_type(envoy::api::v2::core::ApiConfigSource::REST_LEGACY);
-  api_config_source->add_cluster_names("static_cluster");
+  api_config_source->add_cluster_names("eds_cluster");
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
   Upstream::MockCluster cluster;
-  cluster_map.emplace("static_cluster", cluster);
+  cluster_map.emplace("eds_cluster", cluster);
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
   EXPECT_CALL(cluster, info()).Times(2);
   EXPECT_CALL(*cluster.info_, addedViaApi());
   EXPECT_CALL(*legacy_subscription_, start(_, _));
-  subscriptionFromConfigSource(config)->start({"static_cluster"}, callbacks_);
+  subscriptionFromConfigSource(config)->start({"foo"}, callbacks_);
 }
 
 TEST_F(SubscriptionFactoryTest, HttpSubscription) {
   envoy::api::v2::core::ConfigSource config;
   auto* api_config_source = config.mutable_api_config_source();
   api_config_source->set_api_type(envoy::api::v2::core::ApiConfigSource::REST);
-  api_config_source->add_cluster_names("static_cluster");
+  api_config_source->add_cluster_names("eds_cluster");
   api_config_source->mutable_refresh_delay()->set_seconds(1);
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
   Upstream::MockCluster cluster;
-  cluster_map.emplace("static_cluster", cluster);
+  cluster_map.emplace("eds_cluster", cluster);
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
   EXPECT_CALL(cluster, info()).Times(2);
   EXPECT_CALL(*cluster.info_, addedViaApi());
   EXPECT_CALL(dispatcher_, createTimer_(_));
-  EXPECT_CALL(cm_, httpAsyncClientForCluster("static_cluster"));
+  EXPECT_CALL(cm_, httpAsyncClientForCluster("eds_cluster"));
   EXPECT_CALL(cm_.async_client_, send_(_, _, _))
       .WillOnce(Invoke([this](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
                               const absl::optional<std::chrono::milliseconds>& timeout) {
         UNREFERENCED_PARAMETER(callbacks);
         UNREFERENCED_PARAMETER(timeout);
         EXPECT_EQ("POST", std::string(request->headers().Method()->value().c_str()));
-        EXPECT_EQ("static_cluster", std::string(request->headers().Host()->value().c_str()));
+        EXPECT_EQ("eds_cluster", std::string(request->headers().Host()->value().c_str()));
         EXPECT_EQ("/v2/discovery:endpoints",
                   std::string(request->headers().Path()->value().c_str()));
         return &http_request_;
       }));
   EXPECT_CALL(http_request_, cancel());
-  subscriptionFromConfigSource(config)->start({"static_cluster"}, callbacks_);
+  subscriptionFromConfigSource(config)->start({"foo"}, callbacks_);
 }
 
 // Confirm error when no refresh delay is set (not checked by schema).
@@ -247,29 +144,31 @@ TEST_F(SubscriptionFactoryTest, HttpSubscriptionNoRefreshDelay) {
   envoy::api::v2::core::ConfigSource config;
   auto* api_config_source = config.mutable_api_config_source();
   api_config_source->set_api_type(envoy::api::v2::core::ApiConfigSource::REST);
-  api_config_source->add_cluster_names("static_cluster");
+  api_config_source->add_cluster_names("eds_cluster");
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
   Upstream::MockCluster cluster;
-  cluster_map.emplace("static_cluster", cluster);
+  cluster_map.emplace("eds_cluster", cluster);
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
   EXPECT_CALL(cluster, info()).Times(2);
   EXPECT_CALL(*cluster.info_, addedViaApi());
-  EXPECT_THROW_WITH_MESSAGE(
-      subscriptionFromConfigSource(config)->start({"static_cluster"}, callbacks_), EnvoyException,
-      "refresh_delay is required for REST API configuration sources");
+  EXPECT_THROW_WITH_MESSAGE(subscriptionFromConfigSource(config)->start({"foo"}, callbacks_),
+                            EnvoyException,
+                            "refresh_delay is required for REST API configuration sources");
 }
 
 TEST_F(SubscriptionFactoryTest, GrpcSubscription) {
   envoy::api::v2::core::ConfigSource config;
   auto* api_config_source = config.mutable_api_config_source();
   api_config_source->set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
-  api_config_source->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("static_cluster");
+  api_config_source->add_cluster_names("eds_cluster");
   envoy::api::v2::core::GrpcService expected_grpc_service;
-  expected_grpc_service.mutable_envoy_grpc()->set_cluster_name("static_cluster");
+  expected_grpc_service.mutable_envoy_grpc()->set_cluster_name("eds_cluster");
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
-  NiceMock<Upstream::MockCluster> cluster;
-  cluster_map.emplace("static_cluster", cluster);
+  Upstream::MockCluster cluster;
+  cluster_map.emplace("eds_cluster", cluster);
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
+  EXPECT_CALL(cluster, info()).Times(2);
+  EXPECT_CALL(*cluster.info_, addedViaApi());
   EXPECT_CALL(cm_, grpcAsyncClientManager()).WillOnce(ReturnRef(cm_.async_client_manager_));
   EXPECT_CALL(cm_.async_client_manager_,
               factoryForGrpcService(ProtoEq(expected_grpc_service), _, _))
@@ -282,7 +181,7 @@ TEST_F(SubscriptionFactoryTest, GrpcSubscription) {
       }));
   EXPECT_CALL(dispatcher_, createTimer_(_));
   EXPECT_CALL(callbacks_, onConfigUpdateFailed(_));
-  subscriptionFromConfigSource(config)->start({"static_cluster"}, callbacks_);
+  subscriptionFromConfigSource(config)->start({"foo"}, callbacks_);
 }
 
 INSTANTIATE_TEST_CASE_P(SubscriptionFactoryTestApiConfigSource,
@@ -295,63 +194,51 @@ TEST_P(SubscriptionFactoryTestApiConfigSource, NonExistentCluster) {
   envoy::api::v2::core::ConfigSource config;
   auto* api_config_source = config.mutable_api_config_source();
   api_config_source->set_api_type(GetParam());
-  if (api_config_source->api_type() == envoy::api::v2::core::ApiConfigSource::GRPC) {
-    api_config_source->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name(
-        "static_cluster");
-  } else {
-    api_config_source->add_cluster_names("static_cluster");
-  }
+  api_config_source->add_cluster_names("eds_cluster");
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
-  EXPECT_THROW_WITH_MESSAGE(
-      subscriptionFromConfigSource(config)->start({"static_cluster"}, callbacks_), EnvoyException,
-      "envoy::api::v2::core::ConfigSource must have a statically defined "
-      "non-EDS cluster: 'static_cluster' does not exist, was added via api, or is an EDS cluster");
+  EXPECT_THROW_WITH_MESSAGE(subscriptionFromConfigSource(config)->start({"foo"}, callbacks_),
+                            EnvoyException,
+                            "envoy::api::v2::core::ConfigSource must have a statically defined "
+                            "non-EDS cluster: 'eds_cluster' "
+                            "does not exist, was added via api, or is an EDS cluster");
 }
 
 TEST_P(SubscriptionFactoryTestApiConfigSource, DynamicCluster) {
   envoy::api::v2::core::ConfigSource config;
   auto* api_config_source = config.mutable_api_config_source();
   api_config_source->set_api_type(GetParam());
-  if (api_config_source->api_type() == envoy::api::v2::core::ApiConfigSource::GRPC) {
-    api_config_source->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name(
-        "static_cluster");
-  } else {
-    api_config_source->add_cluster_names("static_cluster");
-  }
+  api_config_source->add_cluster_names("eds_cluster");
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
   Upstream::MockCluster cluster;
-  cluster_map.emplace("static_cluster", cluster);
+  cluster_map.emplace("eds_cluster", cluster);
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
   EXPECT_CALL(cluster, info());
   EXPECT_CALL(*cluster.info_, addedViaApi()).WillOnce(Return(true));
-  EXPECT_THROW_WITH_MESSAGE(
-      subscriptionFromConfigSource(config)->start({"static_cluster"}, callbacks_), EnvoyException,
-      "envoy::api::v2::core::ConfigSource must have a statically defined "
-      "non-EDS cluster: 'static_cluster' does not exist, was added via api, or is an EDS cluster");
+  EXPECT_THROW_WITH_MESSAGE(subscriptionFromConfigSource(config)->start({"foo"}, callbacks_),
+                            EnvoyException,
+                            "envoy::api::v2::core::ConfigSource must have a statically defined "
+                            "non-EDS cluster: 'eds_cluster' "
+                            "does not exist, was added via api, or is an EDS cluster");
 }
 
 TEST_P(SubscriptionFactoryTestApiConfigSource, EDSClusterBackingEDSCluster) {
   envoy::api::v2::core::ConfigSource config;
   auto* api_config_source = config.mutable_api_config_source();
   api_config_source->set_api_type(GetParam());
-  if (api_config_source->api_type() == envoy::api::v2::core::ApiConfigSource::GRPC) {
-    api_config_source->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name(
-        "static_cluster");
-  } else {
-    api_config_source->add_cluster_names("static_cluster");
-  }
+  api_config_source->add_cluster_names("eds_cluster");
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
   Upstream::MockCluster cluster;
-  cluster_map.emplace("static_cluster", cluster);
+  cluster_map.emplace("eds_cluster", cluster);
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
   EXPECT_CALL(cluster, info()).Times(2);
   EXPECT_CALL(*cluster.info_, addedViaApi());
   EXPECT_CALL(*cluster.info_, type()).WillOnce(Return(envoy::api::v2::Cluster::EDS));
-  EXPECT_THROW_WITH_MESSAGE(
-      subscriptionFromConfigSource(config)->start({"static_cluster"}, callbacks_), EnvoyException,
-      "envoy::api::v2::core::ConfigSource must have a statically defined "
-      "non-EDS cluster: 'static_cluster' does not exist, was added via api, or is an EDS cluster");
+  EXPECT_THROW_WITH_MESSAGE(subscriptionFromConfigSource(config)->start({"foo"}, callbacks_),
+                            EnvoyException,
+                            "envoy::api::v2::core::ConfigSource must have a statically defined "
+                            "non-EDS cluster: 'eds_cluster' "
+                            "does not exist, was added via api, or is an EDS cluster");
 }
 
 } // namespace Config

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -138,10 +138,8 @@ public:
                   eds_cluster_config:
                     eds_config:
                       api_config_source:
+                        cluster_names: "eds-cluster"
                         api_type: GRPC
-                        grpc_services:
-                          envoy_grpc:
-                            cluster_name: "eds-cluster"
               )EOF"));
 
       // TODO(zuercher): Make ConfigHelper EDS-aware and get rid of this hack:

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -103,7 +103,7 @@ public:
       // Setup load reporting and corresponding gRPC cluster.
       auto* loadstats_config = bootstrap.mutable_cluster_manager()->mutable_load_stats_config();
       loadstats_config->set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
-      loadstats_config->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("load_report");
+      loadstats_config->add_cluster_names("load_report");
       auto* load_report_cluster = bootstrap.mutable_static_resources()->add_clusters();
       load_report_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
       load_report_cluster->mutable_circuit_breakers()->Clear();


### PR DESCRIPTION
This reverts commit 01e75f937ceb8a4dde6a04334a7dfcdf4c22e7d0.

Discussion on #envoy-users revealed that this is going to break operationally for folks who are
trying to roll forward binaries with the same config, there's no config that can work both
before/after.

Signed-off-by: Harvey Tuch <htuch@google.com>
