### PR TITLE
stats: add support for custom prefixes 

### DIFF
--- a/source/extensions/stat_sinks/common/statsd/statsd.cc
+++ b/source/extensions/stat_sinks/common/statsd/statsd.cc
@@ -125,8 +125,9 @@ void TcpStatsdSink::TlsSink::beginFlush(bool expect_empty_buffer) {
 
 void TcpStatsdSink::TlsSink::commonFlush(const std::string& name, uint64_t value, char stat_type) {
   ASSERT(current_slice_mem_ != nullptr);
-  // 34 > 4 (postfix chars, e.g., "|ms\n") + 30 for number (bigger than it will ever be)
-  const uint32_t max_size = name.size() + parent_.getPrefix().size() + 34;
+  // 36 > 1 ("." after prefix) + 1 (":" after name) + 4 (postfix chars, e.g., "|ms\n") + 30 for
+  // number (bigger than it will ever be)
+  const uint32_t max_size = name.size() + parent_.getPrefix().size() + 36;
   if (current_buffer_slice_.len_ - usedBuffer() < max_size) {
     endFlush(false);
     beginFlush(false);
@@ -138,8 +139,7 @@ void TcpStatsdSink::TlsSink::commonFlush(const std::string& name, uint64_t value
   const char* snapped_current = current_slice_mem_;
   memcpy(current_slice_mem_, parent_.getPrefix().c_str(), parent_.getPrefix().size());
   current_slice_mem_ += parent_.getPrefix().size();
-  *current_slice_mem_ = '.';
-  current_slice_mem_ += 1;
+  *current_slice_mem_++ = '.';
   memcpy(current_slice_mem_, name.c_str(), name.size());
   current_slice_mem_ += name.size();
   *current_slice_mem_++ = ':';

--- a/source/extensions/stat_sinks/common/statsd/statsd.cc
+++ b/source/extensions/stat_sinks/common/statsd/statsd.cc
@@ -58,8 +58,8 @@ void UdpStatsdSink::flushCounter(const Stats::Counter& counter, uint64_t delta) 
 }
 
 void UdpStatsdSink::flushGauge(const Stats::Gauge& gauge, uint64_t value) {
-  const std::string message(fmt::format("{}.{}:{}|g{}", prefix, getName(gauge), value,
-                                        buildTagStr(gauge.tags())));
+  const std::string message(
+      fmt::format("{}.{}:{}|g{}", prefix, getName(gauge), value, buildTagStr(gauge.tags())));
   tls_->getTyped<Writer>().write(message);
 }
 

--- a/source/extensions/stat_sinks/common/statsd/statsd.cc
+++ b/source/extensions/stat_sinks/common/statsd/statsd.cc
@@ -125,8 +125,8 @@ void TcpStatsdSink::TlsSink::beginFlush(bool expect_empty_buffer) {
 
 void TcpStatsdSink::TlsSink::commonFlush(const std::string& name, uint64_t value, char stat_type) {
   ASSERT(current_slice_mem_ != nullptr);
-  // 34 >  4 (random chars) + 30 for number (bigger than it will ever be)
-  const uint32_t max_size = name.size() + parent_.getPrefix().size() + 40;
+  // 34 > 4 (postfix chars, e.g., "|ms\n") + 30 for number (bigger than it will ever be)
+  const uint32_t max_size = name.size() + parent_.getPrefix().size() + 34;
   if (current_buffer_slice_.len_ - usedBuffer() < max_size) {
     endFlush(false);
     beginFlush(false);

--- a/source/extensions/stat_sinks/common/statsd/statsd.cc
+++ b/source/extensions/stat_sinks/common/statsd/statsd.cc
@@ -125,8 +125,8 @@ void TcpStatsdSink::TlsSink::beginFlush(bool expect_empty_buffer) {
 
 void TcpStatsdSink::TlsSink::commonFlush(const std::string& name, uint64_t value, char stat_type) {
   ASSERT(current_slice_mem_ != nullptr);
-  // 40 > 6 (prefix_) + 4 (random chars) + 30 for number (bigger than it will ever be)
-  const uint32_t max_size = name.size() + 40;
+  // 34 >  4 (random chars) + 30 for number (bigger than it will ever be)
+  const uint32_t max_size = name.size() + parent_.getPrefix().size() + 40;
   if (current_buffer_slice_.len_ - usedBuffer() < max_size) {
     endFlush(false);
     beginFlush(false);

--- a/source/extensions/stat_sinks/common/statsd/statsd.h
+++ b/source/extensions/stat_sinks/common/statsd/statsd.h
@@ -61,7 +61,7 @@ public:
   // Called in unit test to validate writer construction and address.
   int getFdForTests() { return tls_->getTyped<Writer>().getFdForTests(); }
   bool getUseTagForTest() { return use_tag_; }
-  const std::string getPrefix() { return prefix_; }
+  const std::string& getPrefix() { return prefix_; }
 
 private:
   const std::string getName(const Stats::Metric& metric);
@@ -102,7 +102,7 @@ public:
                                                  std::chrono::milliseconds(value));
   }
 
-  const std::string getPrefix() { return prefix_; }
+  const std::string& getPrefix() { return prefix_; }
 
 private:
   struct TlsSink : public ThreadLocal::ThreadLocalObject, public Network::ConnectionCallbacks {

--- a/source/extensions/stat_sinks/common/statsd/statsd.h
+++ b/source/extensions/stat_sinks/common/statsd/statsd.h
@@ -14,6 +14,7 @@ namespace StatSinks {
 namespace Common {
 namespace Statsd {
 
+static const std::string DEFAULT_PREFIX = "envoy";
 /**
  * This is a simple UDP localhost writer for statsd messages.
  */
@@ -38,13 +39,16 @@ private:
 class UdpStatsdSink : public Stats::Sink {
 public:
   UdpStatsdSink(ThreadLocal::SlotAllocator& tls, Network::Address::InstanceConstSharedPtr address,
-                const bool use_tag);
+                const bool use_tag, const std::string _prefix = DEFAULT_PREFIX);
   // For testing.
   UdpStatsdSink(ThreadLocal::SlotAllocator& tls, const std::shared_ptr<Writer>& writer,
-                const bool use_tag)
+                const bool use_tag, const std::string _prefix = DEFAULT_PREFIX)
       : tls_(tls.allocateSlot()), use_tag_(use_tag) {
     tls_->set(
         [writer](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr { return writer; });
+    if (_prefix.size() != 0) {
+      prefix = _prefix;
+    }
   }
 
   // Stats::Sink
@@ -57,6 +61,7 @@ public:
   // Called in unit test to validate writer construction and address.
   int getFdForTests() { return tls_->getTyped<Writer>().getFdForTests(); }
   bool getUseTagForTest() { return use_tag_; }
+  std::string getPrefix() { return prefix; }
 
 private:
   const std::string getName(const Stats::Metric& metric);
@@ -65,6 +70,8 @@ private:
   ThreadLocal::SlotPtr tls_;
   Network::Address::InstanceConstSharedPtr server_address_;
   const bool use_tag_;
+  // Prefix for all flushed stats.
+  std::string prefix;
 };
 
 /**
@@ -74,7 +81,7 @@ class TcpStatsdSink : public Stats::Sink {
 public:
   TcpStatsdSink(const LocalInfo::LocalInfo& local_info, const std::string& cluster_name,
                 ThreadLocal::SlotAllocator& tls, Upstream::ClusterManager& cluster_manager,
-                Stats::Scope& scope);
+                Stats::Scope& scope, std::string _prefix = DEFAULT_PREFIX);
 
   // Stats::Sink
   void beginFlush() override { tls_->getTyped<TlsSink>().beginFlush(true); }
@@ -94,6 +101,8 @@ public:
     tls_->getTyped<TlsSink>().onTimespanComplete(histogram.name(),
                                                  std::chrono::milliseconds(value));
   }
+
+  std::string getPrefix() { return prefix; }
 
 private:
   struct TlsSink : public ThreadLocal::ThreadLocalObject, public Network::ConnectionCallbacks {
@@ -130,7 +139,7 @@ private:
   static constexpr uint32_t FLUSH_SLICE_SIZE_BYTES = (1024 * 16);
 
   // Prefix for all flushed stats.
-  static char STAT_PREFIX[];
+  std::string prefix;
 
   Upstream::ClusterInfoConstSharedPtr cluster_info_;
   ThreadLocal::SlotPtr tls_;

--- a/source/extensions/stat_sinks/common/statsd/statsd.h
+++ b/source/extensions/stat_sinks/common/statsd/statsd.h
@@ -61,7 +61,7 @@ public:
   // Called in unit test to validate writer construction and address.
   int getFdForTests() { return tls_->getTyped<Writer>().getFdForTests(); }
   bool getUseTagForTest() { return use_tag_; }
-  const std::string& getPrefix() { return prefix_; }
+  const std::string getPrefix() { return prefix_; }
 
 private:
   const std::string getName(const Stats::Metric& metric);
@@ -71,7 +71,7 @@ private:
   Network::Address::InstanceConstSharedPtr server_address_;
   const bool use_tag_;
   // Prefix for all flushed stats.
-  const std::string& prefix_;
+  const std::string prefix_;
 };
 
 /**
@@ -102,7 +102,7 @@ public:
                                                  std::chrono::milliseconds(value));
   }
 
-  std::string getPrefix() { return prefix_; }
+  const std::string getPrefix() { return prefix_; }
 
 private:
   struct TlsSink : public ThreadLocal::ThreadLocalObject, public Network::ConnectionCallbacks {
@@ -139,7 +139,7 @@ private:
   static constexpr uint32_t FLUSH_SLICE_SIZE_BYTES = (1024 * 16);
 
   // Prefix for all flushed stats.
-  const std::string& prefix_;
+  const std::string prefix_;
 
   Upstream::ClusterInfoConstSharedPtr cluster_info_;
   ThreadLocal::SlotPtr tls_;

--- a/source/extensions/stat_sinks/statsd/config.cc
+++ b/source/extensions/stat_sinks/statsd/config.cc
@@ -25,13 +25,13 @@ Stats::SinkPtr StatsdSinkFactory::createStatsSink(const Protobuf::Message& confi
         Network::Address::resolveProtoAddress(statsd_sink.address());
     ENVOY_LOG(debug, "statsd UDP ip address: {}", address->asString());
     return std::make_unique<Common::Statsd::UdpStatsdSink>(server.threadLocal(), std::move(address),
-                                                           false);
+                                                           false, statsd_sink.prefix());
   }
   case envoy::config::metrics::v2::StatsdSink::kTcpClusterName:
     ENVOY_LOG(debug, "statsd TCP cluster: {}", statsd_sink.tcp_cluster_name());
     return std::make_unique<Common::Statsd::TcpStatsdSink>(
         server.localInfo(), statsd_sink.tcp_cluster_name(), server.threadLocal(),
-        server.clusterManager(), server.stats());
+        server.clusterManager(), server.stats(), statsd_sink.prefix());
   default:
     // Verified by schema.
     NOT_REACHED;

--- a/test/extensions/stats_sinks/statsd/config_test.cc
+++ b/test/extensions/stats_sinks/statsd/config_test.cc
@@ -46,7 +46,7 @@ TEST(StatsConfigTest, ValidTcpStatsd) {
 }
 
 TEST(StatsConfigTest, UdpSinkDefaultPrefix) {
-  const std::string name = Config::StatsSinkNames::get().STATSD;
+  const std::string name = StatsSinkNames::get().STATSD;
   auto defaultPrefix = Common::Statsd::getDefaultPrefix();
 
   envoy::config::metrics::v2::StatsdSink sink_config;
@@ -71,7 +71,7 @@ TEST(StatsConfigTest, UdpSinkDefaultPrefix) {
 }
 
 TEST(StatsConfigTest, UdpSinkCustomPrefix) {
-  const std::string name = Config::StatsSinkNames::get().STATSD;
+  const std::string name = StatsSinkNames::get().STATSD;
   const std::string customPrefix = "prefix.test";
 
   envoy::config::metrics::v2::StatsdSink sink_config;
@@ -97,7 +97,7 @@ TEST(StatsConfigTest, UdpSinkCustomPrefix) {
 }
 
 TEST(StatsConfigTest, TcpSinkDefaultPrefix) {
-  const std::string name = Config::StatsSinkNames::get().STATSD;
+  const std::string name = StatsSinkNames::get().STATSD;
 
   envoy::config::metrics::v2::StatsdSink sink_config;
   auto defaultPrefix = Common::Statsd::getDefaultPrefix();
@@ -118,7 +118,7 @@ TEST(StatsConfigTest, TcpSinkDefaultPrefix) {
 }
 
 TEST(StatsConfigTest, TcpSinkCustomPrefix) {
-  const std::string name = Config::StatsSinkNames::get().STATSD;
+  const std::string name = StatsSinkNames::get().STATSD;
 
   envoy::config::metrics::v2::StatsdSink sink_config;
   std::string prefix = "prefixTest";

--- a/test/extensions/stats_sinks/statsd/config_test.cc
+++ b/test/extensions/stats_sinks/statsd/config_test.cc
@@ -67,7 +67,7 @@ TEST(StatsConfigTest, UdpSinkDefaultPrefix) {
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
   EXPECT_NE(sink, nullptr);
   EXPECT_NE(dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get()), nullptr);
-  EXPECT_EQ(dynamic_cast<common::Statsd::UdpStatsdSink*>(sink.get())->getPrefix(), defaultPrefix);
+  EXPECT_EQ(dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get())->getPrefix(), defaultPrefix);
 }
 
 TEST(StatsConfigTest, UdpSinkCustomPrefix) {
@@ -93,7 +93,7 @@ TEST(StatsConfigTest, UdpSinkCustomPrefix) {
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
   EXPECT_NE(sink, nullptr);
   EXPECT_NE(dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get()), nullptr);
-  EXPECT_EQ(dynamic_cast<common::Statsd::UdpStatsdSink*>(sink.get())->getPrefix(), customPrefix);
+  EXPECT_EQ(dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get())->getPrefix(), customPrefix);
 }
 
 TEST(StatsConfigTest, TcpSinkDefaultPrefix) {

--- a/test/extensions/stats_sinks/statsd/config_test.cc
+++ b/test/extensions/stats_sinks/statsd/config_test.cc
@@ -47,7 +47,7 @@ TEST(StatsConfigTest, ValidTcpStatsd) {
 
 TEST(StatsConfigTest, UdpSinkDefaultPrefix) {
   const std::string name = Config::StatsSinkNames::get().STATSD;
-  auto defaultPrefix = Common::Statsd::DEFAULT_PREFIX;
+  auto defaultPrefix = Common::Statsd::getDefaultPrefix();
 
   envoy::config::metrics::v2::StatsdSink sink_config;
   envoy::api::v2::core::Address& address = *sink_config.mutable_address();
@@ -100,7 +100,7 @@ TEST(StatsConfigTest, TcpSinkDefaultPrefix) {
   const std::string name = Config::StatsSinkNames::get().STATSD;
 
   envoy::config::metrics::v2::StatsdSink sink_config;
-  auto defaultPrefix = Common::Statsd::DEFAULT_PREFIX;
+  auto defaultPrefix = Common::Statsd::getDefaultPrefix();
   sink_config.set_tcp_cluster_name("fake_cluster");
 
   Server::Configuration::StatsSinkFactory* factory =

--- a/test/extensions/stats_sinks/statsd/config_test.cc
+++ b/test/extensions/stats_sinks/statsd/config_test.cc
@@ -65,9 +65,11 @@ TEST(StatsConfigTest, UdpSinkDefaultPrefix) {
 
   NiceMock<Server::MockInstance> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
-  EXPECT_NE(sink, nullptr);
-  EXPECT_NE(dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get()), nullptr);
-  EXPECT_EQ(dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get())->getPrefix(), defaultPrefix);
+  ASSERT_NE(sink, nullptr);
+
+  auto udp_sink = dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get());
+  ASSERT_NE(udp_sink, nullptr);
+  EXPECT_EQ(udp_sink->getPrefix(), defaultPrefix);
 }
 
 TEST(StatsConfigTest, UdpSinkCustomPrefix) {
@@ -91,9 +93,11 @@ TEST(StatsConfigTest, UdpSinkCustomPrefix) {
 
   NiceMock<Server::MockInstance> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
-  EXPECT_NE(sink, nullptr);
-  EXPECT_NE(dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get()), nullptr);
-  EXPECT_EQ(dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get())->getPrefix(), customPrefix);
+  ASSERT_NE(sink, nullptr);
+
+  auto udp_sink = dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get());
+  ASSERT_NE(udp_sink, nullptr);
+  EXPECT_EQ(udp_sink->getPrefix(), customPrefix);
 }
 
 TEST(StatsConfigTest, TcpSinkDefaultPrefix) {
@@ -112,9 +116,11 @@ TEST(StatsConfigTest, TcpSinkDefaultPrefix) {
 
   NiceMock<Server::MockInstance> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
-  EXPECT_NE(sink, nullptr);
-  EXPECT_NE(dynamic_cast<Common::Statsd::TcpStatsdSink*>(sink.get()), nullptr);
-  EXPECT_EQ(dynamic_cast<Common::Statsd::TcpStatsdSink*>(sink.get())->getPrefix(), defaultPrefix);
+  ASSERT_NE(sink, nullptr);
+
+  auto tcp_sink = dynamic_cast<Common::Statsd::TcpStatsdSink*>(sink.get());
+  ASSERT_NE(tcp_sink, nullptr);
+  EXPECT_EQ(tcp_sink->getPrefix(), defaultPrefix);
 }
 
 TEST(StatsConfigTest, TcpSinkCustomPrefix) {
@@ -135,9 +141,11 @@ TEST(StatsConfigTest, TcpSinkCustomPrefix) {
 
   NiceMock<Server::MockInstance> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
-  EXPECT_NE(sink, nullptr);
-  EXPECT_NE(dynamic_cast<Common::Statsd::TcpStatsdSink*>(sink.get()), nullptr);
-  EXPECT_EQ(dynamic_cast<Common::Statsd::TcpStatsdSink*>(sink.get())->getPrefix(), prefix);
+  ASSERT_NE(sink, nullptr);
+
+  auto tcp_sink = dynamic_cast<Common::Statsd::TcpStatsdSink*>(sink.get());
+  ASSERT_NE(tcp_sink, nullptr);
+  EXPECT_EQ(tcp_sink->getPrefix(), prefix);
 }
 
 class StatsConfigLoopbackTest : public testing::TestWithParam<Network::Address::IpVersion> {};


### PR DESCRIPTION
stats: Add support for specifying a custom prefix 

*Description*:
This PR adds support for specifying custom prefixes for StatsdSinks.

*Testing*:
Ran unit tests locally and added the following unit tests:
  - config_test.cc:UdpSinkCustomPrefix
  - config_test.cc:UdpSinkDefaultPrefix
  - config_test.cc:TcpSinkCustomPrefix
  - config_test.cc:TcpSinkDefaultPrefix

*Release Notes*: TODO(?)

*Fixes #2897*

[Data Plane PR](https://github.com/envoyproxy/data-plane-api/pull/604)

*TODO*
- revert changes to repository_locations.bzl
