### PR TITLE
build: Disable compiler warning maybe-initialized.

### DIFF
--- a/bazel/cc_wrapper.py
+++ b/bazel/cc_wrapper.py
@@ -67,13 +67,16 @@ def main():
 
   # Add compiler-specific options
   if "clang" in compiler:
+    # This ensures that STL symbols are included.
+    # See https://github.com/envoyproxy/envoy/issues/1341
     argv.append("-fno-limit-debug-info")
 
-  if "gcc" in compiler:
+  if "gcc" in compiler or "g++" in compiler:
     # -Wmaybe-initialized is warning about many uses of absl::optional. Disable
     # to prevent build breakage. This option does not exist in clang, so setting
     # it in clang builds causes a build error because of unknown command line
     # flag.
+    # See https://github.com/envoyproxy/envoy/issues/2987
     argv.append("-Wno-maybe-uninitialized")
 
   os.execv(compiler, [compiler] + argv)

--- a/bazel/cc_wrapper.py
+++ b/bazel/cc_wrapper.py
@@ -64,6 +64,18 @@ def main():
         argv.append(arg)
   else:
     argv = sys.argv[1:]
+
+  # Add compiler-specific options
+  if "clang" in compiler:
+    argv.append("-fno-limit-debug-info")
+
+  if "gcc" in compiler:
+    # -Wmaybe-initialized is warning about many uses of absl::optional. Disable
+    # to prevent build breakage. This option does not exist in clang, so setting
+    # it in clang builds causes a build error because of unknown command line
+    # flag.
+    argv.append("-Wno-maybe-uninitialized")
+
   os.execv(compiler, [compiler] + argv)
 
 

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -12,11 +12,6 @@ def envoy_copts(repository, test = False):
         "-Wnon-virtual-dtor",
         "-Woverloaded-virtual",
         "-Wold-style-cast",
-
-        # -Wmaybe-initialized is warning about many uses of absl::optional. Disable
-        # to prevent build breakage.
-        "-Wno-maybe-uninitialized",
-
         "-std=c++14",
     ] + select({
         # Bazel adds an implicit -DNDEBUG for opt.

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -12,6 +12,11 @@ def envoy_copts(repository, test = False):
         "-Wnon-virtual-dtor",
         "-Woverloaded-virtual",
         "-Wold-style-cast",
+
+        # -Wmaybe-initialized is warning about many uses of absl::optional. Disable
+        # to prevent build breakage.
+        "-Wno-maybe-uninitialized",
+
         "-std=c++14",
     ] + select({
         # Bazel adds an implicit -DNDEBUG for opt.


### PR DESCRIPTION
This is causing warnings in some uses of absl::optional.

Fixes #2987
Fixes #1341

Signed-off-by: Greg Greenway <ggreenway@apple.com>

*Risk Level*: Low

*Testing*: Compiled https://github.com/envoyproxy/envoy/pull/2793 with this change, verified that build was fixed.