### PR TITLE
access_loggers/http_grpc: add request method and support additional headers config

### DIFF
--- a/source/extensions/access_loggers/http_grpc/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/http_grpc/grpc_access_log_impl.cc
@@ -274,6 +274,13 @@ void HttpGrpcAccessLog::log(const Http::HeaderMap* request_headers,
   }
   request_properties->set_request_headers_bytes(request_headers->byteSize());
   request_properties->set_request_body_bytes(request_info.bytesReceived());
+  if (request_headers->Method() != nullptr) {
+    envoy::api::v2::core::RequestMethod method =
+        envoy::api::v2::core::RequestMethod::METHOD_UNSPECIFIED;
+    envoy::api::v2::core::RequestMethod_Parse(
+        std::string(request_headers->Method()->value().c_str()), &method);
+    request_properties->set_request_method(method);
+  }
 
   // HTTP response properties.
   // TODO(mattklein123): Populate custom response headers.

--- a/source/extensions/access_loggers/http_grpc/grpc_access_log_impl.h
+++ b/source/extensions/access_loggers/http_grpc/grpc_access_log_impl.h
@@ -129,8 +129,8 @@ private:
   AccessLog::FilterPtr filter_;
   const envoy::config::accesslog::v2::HttpGrpcAccessLogConfig config_;
   GrpcAccessLogStreamerSharedPtr grpc_access_log_streamer_;
-  std::vector<Http::LowerCaseString> request_headers_to_log_{};
-  std::vector<Http::LowerCaseString> response_headers_to_log_{};
+  std::vector<Http::LowerCaseString> request_headers_to_log_;
+  std::vector<Http::LowerCaseString> response_headers_to_log_;
 };
 
 } // namespace HttpGrpc

--- a/source/extensions/access_loggers/http_grpc/grpc_access_log_impl.h
+++ b/source/extensions/access_loggers/http_grpc/grpc_access_log_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <vector>
 
 #include "envoy/access_log/access_log.h"
 #include "envoy/config/accesslog/v2/als.pb.h"
@@ -128,6 +129,8 @@ private:
   AccessLog::FilterPtr filter_;
   const envoy::config::accesslog::v2::HttpGrpcAccessLogConfig config_;
   GrpcAccessLogStreamerSharedPtr grpc_access_log_streamer_;
+  std::vector<Http::LowerCaseString> request_headers_to_log_{};
+  std::vector<Http::LowerCaseString> response_headers_to_log_{};
 };
 
 } // namespace HttpGrpc

--- a/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
@@ -112,13 +112,17 @@ public:
 
 class HttpGrpcAccessLogTest : public testing::Test {
 public:
-  HttpGrpcAccessLogTest() {
+  void init() {
     ON_CALL(*filter_, evaluate(_, _)).WillByDefault(Return(true));
     config_.mutable_common_config()->set_log_name("hello_log");
     access_log_.reset(new HttpGrpcAccessLog(AccessLog::FilterPtr{filter_}, config_, streamer_));
   }
 
   void expectLog(const std::string& expected_request_msg_yaml) {
+    if (access_log_ == nullptr) {
+      init();
+    }
+
     envoy::service::accesslog::v2::StreamAccessLogsMessage expected_request_msg;
     MessageUtil::loadFromYaml(expected_request_msg_yaml, expected_request_msg);
     EXPECT_CALL(*streamer_, send(_, "hello_log"))
@@ -298,7 +302,7 @@ http_logs:
     request_info.start_time_ = SystemTime(1h);
 
     Http::TestHeaderMapImpl request_headers{
-        {":method", "WHACK-A-DOO"},
+        {":method", "WHACKADOO"},
     };
 
     expectLog(R"EOF(
@@ -320,6 +324,69 @@ http_logs:
     response: {}
 )EOF");
     access_log_->log(nullptr, nullptr, request_info);
+  }
+}
+
+// Test HTTP log marshalling with additional headers.
+TEST_F(HttpGrpcAccessLogTest, MarshallingAdditionalHeaders) {
+  InSequence s;
+
+  config_.add_additional_request_headers_to_log("X-Custom-Request");
+  config_.add_additional_request_headers_to_log("x-envoy-max-retries");
+
+  config_.add_additional_response_headers_to_log("X-Custom-Response");
+  config_.add_additional_response_headers_to_log("x-envoy-immediate-health-check-fail");
+  init();
+
+  {
+    NiceMock<RequestInfo::MockRequestInfo> request_info;
+    request_info.host_ = nullptr;
+    request_info.start_time_ = SystemTime(1h);
+
+    Http::TestHeaderMapImpl request_headers{
+        {":scheme", "scheme_value"},
+        {":authority", "authority_value"},
+        {":path", "path_value"},
+        {":method", "POST"},
+        {"x-envoy-max-retries", "3"}, // test inline header not otherwise logged
+        {"x-custom-request", "custom_value"},
+    };
+    Http::TestHeaderMapImpl response_headers{
+        {":status", "200"},
+        {"x-envoy-immediate-health-check-fail", "true"}, // test inline header not otherwise logged
+        {"x-custom-response", "custom_value"},
+    };
+
+    expectLog(R"EOF(
+http_logs:
+  log_entry:
+    common_properties:
+      downstream_remote_address:
+        socket_address:
+          address: "127.0.0.1"
+          port_value: 0
+      downstream_local_address:
+        socket_address:
+          address: "127.0.0.2"
+          port_value: 0
+      start_time:
+        seconds: 3600
+    request:
+      scheme: "scheme_value"
+      authority: "authority_value"
+      path: "path_value"
+      request_method: "POST"
+      request_headers_bytes: 118
+      request_headers:
+        "X-Custom-Request": "custom_value"
+        "x-envoy-max-retries": "3"
+    response:
+      response_headers_bytes: 78
+      response_headers:
+        "X-Custom-Response": "custom_value"
+        "x-envoy-immediate-health-check-fail": "true"
+)EOF");
+    access_log_->log(&request_headers, &response_headers, request_info);
   }
 }
 

--- a/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
@@ -332,10 +332,14 @@ TEST_F(HttpGrpcAccessLogTest, MarshallingAdditionalHeaders) {
   InSequence s;
 
   config_.add_additional_request_headers_to_log("X-Custom-Request");
-  config_.add_additional_request_headers_to_log("x-envoy-max-retries");
+  config_.add_additional_request_headers_to_log("X-Custom-Empty");
+  config_.add_additional_request_headers_to_log("X-Envoy-Max-Retries");
+  config_.add_additional_request_headers_to_log("X-Envoy-Force-Trace");
 
   config_.add_additional_response_headers_to_log("X-Custom-Response");
-  config_.add_additional_response_headers_to_log("x-envoy-immediate-health-check-fail");
+  config_.add_additional_response_headers_to_log("X-Custom-Empty");
+  config_.add_additional_response_headers_to_log("X-Envoy-Immediate-Health-Check-Fail");
+  config_.add_additional_response_headers_to_log("X-Envoy-Upstream-Service-Time");
   init();
 
   {
@@ -350,11 +354,13 @@ TEST_F(HttpGrpcAccessLogTest, MarshallingAdditionalHeaders) {
         {":method", "POST"},
         {"x-envoy-max-retries", "3"}, // test inline header not otherwise logged
         {"x-custom-request", "custom_value"},
+        {"x-custom-empty", ""},
     };
     Http::TestHeaderMapImpl response_headers{
         {":status", "200"},
         {"x-envoy-immediate-health-check-fail", "true"}, // test inline header not otherwise logged
         {"x-custom-response", "custom_value"},
+        {"x-custom-empty", ""},
     };
 
     expectLog(R"EOF(
@@ -376,14 +382,16 @@ http_logs:
       authority: "authority_value"
       path: "path_value"
       request_method: "POST"
-      request_headers_bytes: 118
+      request_headers_bytes: 132
       request_headers:
-        "X-Custom-Request": "custom_value"
+        "x-custom-request": "custom_value"
+        "x-custom-empty": ""
         "x-envoy-max-retries": "3"
     response:
-      response_headers_bytes: 78
+      response_headers_bytes: 92
       response_headers:
-        "X-Custom-Response": "custom_value"
+        "x-custom-response": "custom_value"
+        "x-custom-empty": ""
         "x-envoy-immediate-health-check-fail": "true"
 )EOF");
     access_log_->log(&request_headers, &response_headers, request_info);

--- a/test/extensions/access_loggers/http_grpc/grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/http_grpc/grpc_access_log_integration_test.cc
@@ -118,6 +118,7 @@ http_logs:
       authority: host
       path: /notfound
       request_headers_bytes: 122
+      request_method: GET
     response:
       response_code:
         value: 404
@@ -140,6 +141,7 @@ http_logs:
       authority: host
       path: /notfound
       request_headers_bytes: 122
+      request_method: GET
     response:
       response_code:
         value: 404
@@ -186,6 +188,7 @@ http_logs:
       authority: host
       path: /notfound
       request_headers_bytes: 122
+      request_method: GET
     response:
       response_code:
         value: 404


### PR DESCRIPTION
*Description*:
Fills the in the `request_method` field of the `HTTPRequestProperties` contained by `HTTPAccessLogEntry`. Similarly, if the `HttpGrpcAccessLogConfig` specifies `additional_request_headers_to_add` or `additional_response_headers_to_add`, the matching headers are added the `HTTPRequestProperties.request_headers` and `HTTPResponseProperties.response_headers` fields.

*Risk Level*: Low
*Testing*: unit and integration tests
*Docs Changes*: n/a
*Release Notes*: n/a
Related: #743 

Signed-off-by: Stephan Zuercher \<stephan@turbinelabs.io\>