### PR TITLE
build: Add compile-time check that correct glibc ABI is set for c++11-conforming std::string.

### DIFF
--- a/source/common/common/compiler_requirements.h
+++ b/source/common/common/compiler_requirements.h
@@ -6,4 +6,15 @@ namespace Envoy {
 #error "Your compiler does not support C++14. GCC 5+ or Clang is required."
 #endif
 
+// See:
+//   https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
+//   https://bugzilla.redhat.com/show_bug.cgi?id=1546704
+#if defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI != 1 &&                              \
+    !defined(ENVOY_IGNORE_GLIBCXX_USE_CXX11_ABI_ERROR)
+#error "Your toolchain has set _GLIBCXX_USE_CXX11_ABI to a value that uses a std::string "         \
+  "implementation that is not thread-safe. This may cause rare and difficult-to-debug errors "     \
+  "if std::string is passed between threads in any way. If you accept this risk, you may define "  \
+  "ENVOY_IGNORE_GLIBCXX_USE_CXX11_ABI_ERROR=1 in your build."
+#endif
+
 } // Envoy


### PR DESCRIPTION
This detects the failure noted in #3005 

Signed-off-by: Greg Greenway <ggreenway@apple.com>

*Risk Level*: Low

*Testing*: Tested that compilation fails in centos image, passes in ubuntu image