### PR TITLE
access_logs: minor string fix and return code checking

### DIFF
--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -362,8 +362,9 @@ std::string MetadataFormatter::format(const envoy::api::v2::core::Metadata& meta
     }
     data = &val;
   }
-  std::string json;
-  Protobuf::util::MessageToJsonString(*data, &json);
+  ProtobufTypes::String json;
+  const auto status = Protobuf::util::MessageToJsonString(*data, &json);
+  RELEASE_ASSERT(status.ok());
   if (max_length_ && json.length() > max_length_.value()) {
     return json.substr(0, max_length_.value());
   }

--- a/test/common/request_info/request_info_impl_test.cc
+++ b/test/common/request_info/request_info_impl_test.cc
@@ -155,7 +155,7 @@ TEST(RequestInfoImplTest, DynamicMetadataTest) {
   EXPECT_EQ("test_value",
             Config::Metadata::metadataValue(request_info.dynamicMetadata(), "com.test", "test_key")
                 .string_value());
-  std::string json;
+  ProtobufTypes::String json;
   const auto test_struct = request_info.dynamicMetadata().filter_metadata().at("com.test");
   const auto status = Protobuf::util::MessageToJsonString(test_struct, &json);
   EXPECT_TRUE(status.ok());


### PR DESCRIPTION
*Description*:
The protobuf string types were missing from a few instantiations and a call to the message->json conversion method wasn't checking its return code.

*Risk Level*: Low

*Testing*: Unit tests already exist for these methods.