### PR TITLE
Revert "config: optimize RepeatedPtrUtil::debugString at non-debug lo…

### DIFF
--- a/source/common/config/grpc_mux_subscription_impl.h
+++ b/source/common/config/grpc_mux_subscription_impl.h
@@ -55,10 +55,8 @@ public:
     stats_.update_attempt_.inc();
     version_info_ = version_info;
     stats_.version_.set(HashUtil::xxHash64(version_info_));
-    if (ENVOY_LOG_CHECK_LEVEL(debug)) {
-      ENVOY_LOG(debug, "gRPC config for {} accepted with {} resources: {}", type_url_,
-                resources.size(), RepeatedPtrUtil::debugString(typed_resources));
-    }
+    ENVOY_LOG(debug, "gRPC config for {} accepted with {} resources: {}", type_url_,
+              resources.size(), RepeatedPtrUtil::debugString(typed_resources));
   }
 
   void onConfigUpdateFailed(const EnvoyException* e) override {


### PR DESCRIPTION
…g levels. (#2984)"

This reverts commit 48743154a35f5751796d39ebceb615453abac8de.

As pointed out by @alyssawilk, this doesn't make sense given #2751. I
think the profile that motivated this must have been created before
the Google import included #2751.

Signed-off-by: Harvey Tuch <htuch@google.com>
