### PR TITLE
grpc/json transcoder: fix bad assert

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/config.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/config.cc
@@ -16,9 +16,6 @@ namespace GrpcJsonTranscoder {
 Server::Configuration::HttpFilterFactoryCb GrpcJsonTranscoderFilterConfig::createFilter(
     const envoy::config::filter::http::transcoder::v2::GrpcJsonTranscoder& proto_config,
     const std::string&, Server::Configuration::FactoryContext&) {
-  ASSERT(!(proto_config.proto_descriptor().empty() && proto_config.proto_descriptor_bin().empty()));
-  ASSERT(proto_config.services_size() > 0);
-
   JsonTranscoderConfigSharedPtr filter_config =
       std::make_shared<JsonTranscoderConfig>(proto_config);
 

--- a/source/extensions/filters/http/grpc_json_transcoder/config.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/config.cc
@@ -16,7 +16,7 @@ namespace GrpcJsonTranscoder {
 Server::Configuration::HttpFilterFactoryCb GrpcJsonTranscoderFilterConfig::createFilter(
     const envoy::config::filter::http::transcoder::v2::GrpcJsonTranscoder& proto_config,
     const std::string&, Server::Configuration::FactoryContext&) {
-  ASSERT(!proto_config.proto_descriptor().empty());
+  ASSERT(!(proto_config.proto_descriptor().empty() && proto_config.proto_descriptor_bin().empty()));
   ASSERT(proto_config.services_size() > 0);
 
   JsonTranscoderConfigSharedPtr filter_config =


### PR DESCRIPTION
there is a buggy ASSERT in the grpc-json transcoder filter
if the proto config for the filter uses an inlined `proto_descriptor_bin` instead of a file reference `proto_descriptor`, this assert will fail

this PR fixes the ASSERT to allow the use of `proto_descriptor_bin`