### PR TITLE
access_log_formatter: timezone fix

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -26,7 +26,7 @@ std::string DateFormatter::fromTime(const SystemTime& time) const {
 
 std::string DateFormatter::fromTime(time_t time) const {
   tm current_tm;
-  localtime_r(&time, &current_tm);
+  gmtime_r(&time, &current_tm);
 
   std::array<char, 1024> buf;
   strftime(&buf[0], buf.size(), format_string_.c_str(), &current_tm);
@@ -267,7 +267,7 @@ std::string AccessLogDateTimeFormatter::fromTime(const SystemTime& time) {
       cached_time.epoch_time_seconds != epoch_time_seconds) {
     time_t time = static_cast<time_t>(epoch_time_seconds.count());
     tm date_time;
-    localtime_r(&time, &date_time);
+    gmtime_r(&time, &date_time);
     cached_time.formatted_time_length =
         strftime(cached_time.formatted_time, sizeof(cached_time.formatted_time), DefaultDateFormat,
                  &date_time);

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -26,7 +26,7 @@ std::string DateFormatter::fromTime(const SystemTime& time) const {
 
 std::string DateFormatter::fromTime(time_t time) const {
   tm current_tm;
-  gmtime_r(&time, &current_tm);
+  localtime_r(&time, &current_tm);
 
   std::array<char, 1024> buf;
   strftime(&buf[0], buf.size(), format_string_.c_str(), &current_tm);
@@ -267,7 +267,7 @@ std::string AccessLogDateTimeFormatter::fromTime(const SystemTime& time) {
       cached_time.epoch_time_seconds != epoch_time_seconds) {
     time_t time = static_cast<time_t>(epoch_time_seconds.count());
     tm date_time;
-    gmtime_r(&time, &date_time);
+    localtime_r(&time, &date_time);
     cached_time.formatted_time_length =
         strftime(cached_time.formatted_time, sizeof(cached_time.formatted_time), DefaultDateFormat,
                  &date_time);

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -362,7 +362,12 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
     EXPECT_CALL(request_info, startTime()).WillRepeatedly(Return(time));
     FormatterImpl formatter(format);
 
-    EXPECT_EQ("2018/03/28|1522280158|bad_format|2018-03-28T23:35:58.000Z",
+    // Needed to take into account the behavior in non-GMT timezones.
+    struct tm time_val;
+    gmtime_r(&test_epoch, &time_val);
+    time_t expected_time_t = mktime(&time_val);
+
+    EXPECT_EQ(fmt::format("2018/03/28|{}|bad_format|2018-03-28T23:35:58.000Z", expected_time_t),
               formatter.format(request_header, response_header, request_info));
   }
 }


### PR DESCRIPTION
*Description*:
A little background - we noticed that [this expect case](https://github.com/envoyproxy/envoy/blob/master/test/common/access_log/access_log_formatter_test.cc#L365) fails when we run it internally.  This is because the test expects that a `time_t` passed into the `fromTime()` method will show up exactly in the format in place of a `%s`.  Because `gmtime_r` is used to convert to `struct tm`, but `strftime` uses `mktime` (which reverses the `localtime_r` conversion, not `gmtime_r`) to convert back to `time_t` in the case of a `%s`.  This causes us to see an 8 hour difference in the timestamps in this test when we run internally.  I think there are a few solutions here:

1.  Move to using `localtime_r` as is done in this PR.
2.  Modify the expectations of `fromTime()` to incorporate this behavior, and update the test to take the time zone into account.

I'm curious what others think, and I'm open to other suggestions as to how to fix this issue.

*Risk Level*: Low
