### PR TITLE
Support api config source without cluster names

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -10,16 +10,16 @@ The following features have been DEPRECATED and will be removed in the specified
 * Admin mutations should be sent as POSTs rather than GETs. HTTP GETs will result in an error
   status code and will not have their intended effect. Prior to 1.7, GETs can be used for
   admin mutations, but a warning is logged.
+* Rate limit service configuration via the `cluster_name` field is deprecated. Use `grpc_service`
+  instead.
+* gRPC service configuration via the `cluster_names` field in `ApiConfigSource` is deprecated. Use
+  `grpc_services` instead. Prior to 1.7, a warning is logged.
 
 ## Version 1.6.0 (March 20, 2018)
 
 * DOWNSTREAM_ADDRESS log formatter is deprecated. Use DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT
   instead.
 * CLIENT_IP header formatter is deprecated. Use DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT instead.
-* Rate limit service configuration via the `cluster_name` field is deprecated. Use `grpc_service`
-  instead.
-* gRPC service configuration via the `cluster_names` field in `ApiConfigSource` is deprecated. Use
-  `grpc_services` instead.
 * 'use_original_dst' field in the v2 LDS API is deprecated. Use listener filters and filter chain
   matching instead.
 * `value` and `regex` fields in the `HeaderMatcher` message is deprecated. Use the `exact_match`

--- a/source/common/config/subscription_factory.h
+++ b/source/common/config/subscription_factory.h
@@ -52,22 +52,21 @@ public:
     case envoy::api::v2::core::ConfigSource::kApiConfigSource: {
       const envoy::api::v2::core::ApiConfigSource& api_config_source = config.api_config_source();
       Utility::checkApiConfigSourceSubscriptionBackingCluster(cm.clusters(), api_config_source);
-      const std::string& cluster_name = api_config_source.cluster_names()[0];
       switch (api_config_source.api_type()) {
       case envoy::api::v2::core::ApiConfigSource::REST_LEGACY:
         result.reset(rest_legacy_constructor());
         break;
       case envoy::api::v2::core::ApiConfigSource::REST:
         result.reset(new HttpSubscriptionImpl<ResourceType>(
-            node, cm, cluster_name, dispatcher, random,
+            node, cm, api_config_source.cluster_names()[0], dispatcher, random,
             Utility::apiConfigSourceRefreshDelay(api_config_source),
             *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(rest_method), stats));
         break;
       case envoy::api::v2::core::ApiConfigSource::GRPC: {
         result.reset(new GrpcSubscriptionImpl<ResourceType>(
             node,
-            Config::Utility::factoryForApiConfigSource(cm.grpcAsyncClientManager(),
-                                                       config.api_config_source(), scope)
+            Config::Utility::factoryForGrpcApiConfigSource(cm.grpcAsyncClientManager(),
+                                                           config.api_config_source(), scope)
                 ->create(),
             dispatcher, *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(grpc_method),
             stats));

--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -78,16 +78,43 @@ void Utility::checkFilesystemSubscriptionBackingPath(const std::string& path) {
   }
 }
 
-void Utility::checkApiConfigSourceSubscriptionBackingCluster(
-    const Upstream::ClusterManager::ClusterInfoMap& clusters,
+void Utility::checkApiConfigSourceNames(
     const envoy::api::v2::core::ApiConfigSource& api_config_source) {
-  if (api_config_source.cluster_names().size() != 1) {
-    // TODO(htuch): Add support for multiple clusters, #1170.
-    throw EnvoyException(
-        "envoy::api::v2::core::ConfigSource must have a singleton cluster name specified");
+  const bool is_grpc =
+      (api_config_source.api_type() == envoy::api::v2::core::ApiConfigSource::GRPC);
+
+  if (api_config_source.cluster_names().size() == 0 &&
+      api_config_source.grpc_services().size() == 0) {
+    throw EnvoyException("API configs must have either a gRPC service or a cluster name defined");
   }
 
-  const auto& cluster_name = api_config_source.cluster_names()[0];
+  if (is_grpc) {
+    if (api_config_source.cluster_names().size() != 0) {
+      ENVOY_LOG_MISC(warn, "Setting a cluster name for API config source type "
+                           "envoy::api::v2::core::ConfigSource::GRPC is deprecated");
+    }
+    if (api_config_source.cluster_names().size() > 1) {
+      throw EnvoyException(
+          "envoy::api::v2::core::ConfigSource must have a singleton cluster name specified");
+    }
+    if (api_config_source.grpc_services().size() > 1) {
+      throw EnvoyException(
+          "envoy::api::v2::core::ConfigSource::GRPC must have a single gRPC service specified");
+    }
+  } else {
+    if (api_config_source.grpc_services().size() != 0) {
+      throw EnvoyException("envoy::api::v2::core::ConfigSource, if not of type gRPC, must not have "
+                           "a gRPC service specified");
+    }
+    if (api_config_source.cluster_names().size() != 1) {
+      throw EnvoyException(
+          "envoy::api::v2::core::ConfigSource must have a singleton cluster name specified");
+    }
+  }
+}
+
+void Utility::validateClusterName(const Upstream::ClusterManager::ClusterInfoMap& clusters,
+                                  const std::string& cluster_name) {
   const auto& it = clusters.find(cluster_name);
   if (it == clusters.end() || it->second.get().info()->addedViaApi() ||
       it->second.get().info()->type() == envoy::api::v2::Cluster::EDS) {
@@ -96,6 +123,31 @@ void Utility::checkApiConfigSourceSubscriptionBackingCluster(
         "defined non-EDS cluster: '{}' does not exist, was added via api, or is an EDS cluster",
         cluster_name));
   }
+}
+
+void Utility::checkApiConfigSourceSubscriptionBackingCluster(
+    const Upstream::ClusterManager::ClusterInfoMap& clusters,
+    const envoy::api::v2::core::ApiConfigSource& api_config_source) {
+  Utility::checkApiConfigSourceNames(api_config_source);
+
+  const bool is_grpc =
+      (api_config_source.api_type() == envoy::api::v2::core::ApiConfigSource::GRPC);
+
+  if (!api_config_source.cluster_names().empty()) {
+    // All API configs of type REST and REST_LEGACY should have cluster names.
+    // Additionally, some gRPC API configs might have a cluster name set instead
+    // of an envoy gRPC.
+    Utility::validateClusterName(clusters, api_config_source.cluster_names()[0]);
+  } else if (is_grpc) {
+    // Some ApiConfigSources of type GRPC won't have a cluster name, such as if
+    // they've been configured with google_grpc.
+    if (api_config_source.grpc_services()[0].has_envoy_grpc()) {
+      // If an Envoy gRPC exists, we take its cluster name.
+      Utility::validateClusterName(
+          clusters, api_config_source.grpc_services()[0].envoy_grpc().cluster_name());
+    }
+  }
+  // Otherwise, there is no cluster name to validate.
 }
 
 std::chrono::milliseconds Utility::apiConfigSourceRefreshDelay(
@@ -161,36 +213,13 @@ void Utility::checkObjNameLength(const std::string& error_prefix, const std::str
   }
 }
 
-Grpc::AsyncClientFactoryPtr
-Utility::factoryForApiConfigSource(Grpc::AsyncClientManager& async_client_manager,
-                                   const envoy::api::v2::core::ApiConfigSource& api_config_source,
-                                   Stats::Scope& scope) {
-  ASSERT(api_config_source.api_type() == envoy::api::v2::core::ApiConfigSource::GRPC);
-  envoy::api::v2::core::GrpcService grpc_service;
-  if (api_config_source.cluster_names().empty()) {
-    if (api_config_source.grpc_services().empty()) {
-      throw EnvoyException(
-          fmt::format("Missing gRPC services in envoy::api::v2::core::ApiConfigSource: {}",
-                      api_config_source.DebugString()));
-    }
-    // TODO(htuch): Implement multiple gRPC services.
-    if (api_config_source.grpc_services().size() != 1) {
-      throw EnvoyException(fmt::format("Only singleton gRPC service lists supported in "
-                                       "envoy::api::v2::core::ApiConfigSource: {}",
-                                       api_config_source.DebugString()));
-    }
-    grpc_service.MergeFrom(api_config_source.grpc_services(0));
-  } else {
-    // TODO(htuch): cluster_names is deprecated, remove after 1.6.0.
-    if (api_config_source.cluster_names().size() != 1) {
-      throw EnvoyException(fmt::format("Only singleton cluster name lists supported in "
-                                       "envoy::api::v2::core::ApiConfigSource: {}",
-                                       api_config_source.DebugString()));
-    }
-    grpc_service.mutable_envoy_grpc()->set_cluster_name(api_config_source.cluster_names(0));
-  }
+Grpc::AsyncClientFactoryPtr Utility::factoryForGrpcApiConfigSource(
+    Grpc::AsyncClientManager& async_client_manager,
+    const envoy::api::v2::core::ApiConfigSource& api_config_source, Stats::Scope& scope) {
+  Utility::checkApiConfigSourceNames(api_config_source);
 
-  return async_client_manager.factoryForGrpcService(grpc_service, scope, false);
+  return async_client_manager.factoryForGrpcService(api_config_source.grpc_services(0), scope,
+                                                    false);
 }
 
 } // namespace Config

--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -218,8 +218,14 @@ Grpc::AsyncClientFactoryPtr Utility::factoryForGrpcApiConfigSource(
     const envoy::api::v2::core::ApiConfigSource& api_config_source, Stats::Scope& scope) {
   Utility::checkApiConfigSourceNames(api_config_source);
 
-  return async_client_manager.factoryForGrpcService(api_config_source.grpc_services(0), scope,
-                                                    false);
+  envoy::api::v2::core::GrpcService grpc_service;
+  if (api_config_source.cluster_names().empty()) {
+    grpc_service.MergeFrom(api_config_source.grpc_services(0));
+  } else {
+    grpc_service.mutable_envoy_grpc()->set_cluster_name(api_config_source.cluster_names(0));
+  }
+
+  return async_client_manager.factoryForGrpcService(grpc_service, scope, false);
 }
 
 } // namespace Config

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -122,9 +122,28 @@ public:
   static void checkFilesystemSubscriptionBackingPath(const std::string& path);
 
   /**
+   * Check the grpc_services and cluster_names for API config sanity. Throws on error.
+   * @param api_config_source the config source to validate.
+   * @throws EnvoyException when an API config has the wrong number of gRPC
+   * services or cluster names, depending on expectations set by its API type.
+   */
+  static void
+  checkApiConfigSourceNames(const envoy::api::v2::core::ApiConfigSource& api_config_source);
+
+  /**
    * Check the validity of a cluster backing an api config source. Throws on error.
    * @param clusters the clusters currently loaded in the cluster manager.
    * @param api_config_source the config source to validate.
+   * @throws EnvoyException when an API config doesn't have a statically defined non-EDS cluster.
+   */
+  static void validateClusterName(const Upstream::ClusterManager::ClusterInfoMap& clusters,
+                                  const std::string& cluster_name);
+
+  /**
+   * Potentially calls Utility::validateClusterName, if a cluster name can be found.
+   * @param clusters the clusters currently loaded in the cluster manager.
+   * @param api_config_source the config source to validate.
+   * @throws EnvoyException when an API config doesn't have a statically defined non-EDS cluster.
    */
   static void checkApiConfigSourceSubscriptionBackingCluster(
       const Upstream::ClusterManager::ClusterInfoMap& clusters,
@@ -240,9 +259,9 @@ public:
    * @return Grpc::AsyncClientFactoryPtr gRPC async client factory.
    */
   static Grpc::AsyncClientFactoryPtr
-  factoryForApiConfigSource(Grpc::AsyncClientManager& async_client_manager,
-                            const envoy::api::v2::core::ApiConfigSource& api_config_source,
-                            Stats::Scope& scope);
+  factoryForGrpcApiConfigSource(Grpc::AsyncClientManager& async_client_manager,
+                                const envoy::api::v2::core::ApiConfigSource& api_config_source,
+                                Stats::Scope& scope);
 };
 
 } // namespace Config

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -204,7 +204,7 @@ ClusterManagerImpl::ClusterManagerImpl(const envoy::config::bootstrap::v2::Boots
   if (bootstrap.dynamic_resources().has_ads_config()) {
     ads_mux_.reset(new Config::GrpcMuxImpl(
         bootstrap.node(),
-        Config::Utility::factoryForApiConfigSource(
+        Config::Utility::factoryForGrpcApiConfigSource(
             *async_client_manager_, bootstrap.dynamic_resources().ads_config(), stats)
             ->create(),
         main_thread_dispatcher,
@@ -291,11 +291,12 @@ ClusterManagerImpl::ClusterManagerImpl(const envoy::config::bootstrap::v2::Boots
 
   if (cm_config.has_load_stats_config()) {
     const auto& load_stats_config = cm_config.load_stats_config();
-    load_stats_reporter_.reset(new LoadStatsReporter(
-        bootstrap.node(), *this, stats,
-        Config::Utility::factoryForApiConfigSource(*async_client_manager_, load_stats_config, stats)
-            ->create(),
-        main_thread_dispatcher));
+    load_stats_reporter_.reset(
+        new LoadStatsReporter(bootstrap.node(), *this, stats,
+                              Config::Utility::factoryForGrpcApiConfigSource(
+                                  *async_client_manager_, load_stats_config, stats)
+                                  ->create(),
+                              main_thread_dispatcher));
   }
 }
 

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -188,19 +188,99 @@ TEST(UtilityTest, CheckFilesystemSubscriptionBackingPath) {
   Utility::checkFilesystemSubscriptionBackingPath(test_path);
 }
 
-TEST(UtilityTest, CheckApiConfigSourceSubscriptionBackingCluster) {
+// TEST(UtilityTest, FactoryForGrpcApiConfigSource) should catch misconfigured
+// API configs along the dimension of ApiConfigSource type.
+TEST(UtilityTest, FactoryForGrpcApiConfigSource) {
+  Grpc::MockAsyncClientManager async_client_manager;
+  Stats::MockStore scope;
+
+  {
+    envoy::api::v2::core::ApiConfigSource api_config_source;
+    api_config_source.set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
+    EXPECT_THROW_WITH_REGEX(
+        Utility::factoryForGrpcApiConfigSource(async_client_manager, api_config_source, scope),
+        EnvoyException, "API configs must have either a gRPC service or a cluster name defined");
+  }
+
+  {
+    envoy::api::v2::core::ApiConfigSource api_config_source;
+    api_config_source.set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
+    api_config_source.add_grpc_services();
+    api_config_source.add_grpc_services();
+    EXPECT_THROW_WITH_REGEX(
+        Utility::factoryForGrpcApiConfigSource(async_client_manager, api_config_source, scope),
+        EnvoyException,
+        "envoy::api::v2::core::ConfigSource::GRPC must have a single gRPC service specified");
+  }
+
+  {
+    envoy::api::v2::core::ApiConfigSource api_config_source;
+    api_config_source.set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
+    api_config_source.add_cluster_names();
+    api_config_source.add_cluster_names();
+    // this also logs a warning for setting REST cluster names for a gRPC API config.
+    EXPECT_THROW_WITH_REGEX(
+        Utility::factoryForGrpcApiConfigSource(async_client_manager, api_config_source, scope),
+        EnvoyException,
+        "envoy::api::v2::core::ConfigSource must have a singleton cluster name specified");
+  }
+
+  {
+    envoy::api::v2::core::ApiConfigSource api_config_source;
+    api_config_source.set_api_type(envoy::api::v2::core::ApiConfigSource::REST);
+    api_config_source.add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("foo");
+    // this also logs a warning for configuring gRPC clusters for a REST API config.
+    EXPECT_THROW_WITH_REGEX(
+        Utility::factoryForGrpcApiConfigSource(async_client_manager, api_config_source, scope),
+        EnvoyException,
+        "envoy::api::v2::core::ConfigSource, if not of type gRPC, must not have a gRPC service "
+        "specified");
+  }
+
+  {
+    envoy::api::v2::core::ApiConfigSource api_config_source;
+    api_config_source.set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
+    api_config_source.add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("foo");
+    envoy::api::v2::core::GrpcService expected_grpc_service;
+    expected_grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
+    EXPECT_CALL(async_client_manager,
+                factoryForGrpcService(ProtoEq(expected_grpc_service), Ref(scope), _));
+    Utility::factoryForGrpcApiConfigSource(async_client_manager, api_config_source, scope);
+  }
+
+  {
+    envoy::api::v2::core::ApiConfigSource api_config_source;
+    api_config_source.set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
+    api_config_source.add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("foo");
+    EXPECT_CALL(async_client_manager,
+                factoryForGrpcService(ProtoEq(api_config_source.grpc_services(0)), Ref(scope), _));
+    Utility::factoryForGrpcApiConfigSource(async_client_manager, api_config_source, scope);
+  }
+}
+
+TEST(CheckApiConfigSourceSubscriptionBackingClusterTest, GrpcClusterTestAcrossTypes) {
   envoy::api::v2::core::ConfigSource config;
   auto* api_config_source = config.mutable_api_config_source();
-  api_config_source->add_cluster_names("foo_cluster");
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
 
-  // Non-existent cluster.
+  // API of type GRPC
+  api_config_source->set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
+  api_config_source->add_cluster_names("foo_cluster");
+
+  // GRPC cluster without GRPC services.
   EXPECT_THROW_WITH_MESSAGE(
       Utility::checkApiConfigSourceSubscriptionBackingCluster(cluster_map, *api_config_source),
       EnvoyException,
       "envoy::api::v2::core::ConfigSource must have a statically defined non-EDS cluster: "
-      "'foo_cluster' "
-      "does not exist, was added via api, or is an EDS cluster");
+      "'foo_cluster' does not exist, was added via api, or is an EDS cluster");
+
+  // Non-existent cluster.
+  api_config_source->add_grpc_services();
+  EXPECT_THROW_WITH_MESSAGE(
+      Utility::checkApiConfigSourceSubscriptionBackingCluster(cluster_map, *api_config_source),
+      EnvoyException,
+      "envoy::api::v2::core::ConfigSource must have a statically defined non-EDS cluster: "
+      "'foo_cluster' does not exist, was added via api, or is an EDS cluster");
 
   // Dynamic Cluster.
   Upstream::MockCluster cluster;
@@ -211,8 +291,7 @@ TEST(UtilityTest, CheckApiConfigSourceSubscriptionBackingCluster) {
       Utility::checkApiConfigSourceSubscriptionBackingCluster(cluster_map, *api_config_source),
       EnvoyException,
       "envoy::api::v2::core::ConfigSource must have a statically defined non-EDS cluster: "
-      "'foo_cluster' "
-      "does not exist, was added via api, or is an EDS cluster");
+      "'foo_cluster' does not exist, was added via api, or is an EDS cluster");
 
   // EDS Cluster backing EDS Cluster.
   EXPECT_CALL(cluster, info()).Times(2);
@@ -222,8 +301,7 @@ TEST(UtilityTest, CheckApiConfigSourceSubscriptionBackingCluster) {
       Utility::checkApiConfigSourceSubscriptionBackingCluster(cluster_map, *api_config_source),
       EnvoyException,
       "envoy::api::v2::core::ConfigSource must have a statically defined non-EDS cluster: "
-      "'foo_cluster' "
-      "does not exist, was added via api, or is an EDS cluster");
+      "'foo_cluster' does not exist, was added via api, or is an EDS cluster");
 
   // All ok.
   EXPECT_CALL(cluster, info()).Times(2);
@@ -232,59 +310,46 @@ TEST(UtilityTest, CheckApiConfigSourceSubscriptionBackingCluster) {
   Utility::checkApiConfigSourceSubscriptionBackingCluster(cluster_map, *api_config_source);
 }
 
-TEST(UtilityTest, FactoryForApiConfigSource) {
-  Grpc::MockAsyncClientManager async_client_manager;
-  Stats::MockStore scope;
+TEST(CheckApiConfigSourceSubscriptionBackingClusterTest, RestClusterTestAcrossTypes) {
+  envoy::api::v2::core::ConfigSource config;
+  auto* api_config_source = config.mutable_api_config_source();
+  Upstream::ClusterManager::ClusterInfoMap cluster_map;
+  api_config_source->set_api_type(envoy::api::v2::core::ApiConfigSource::REST);
 
-  {
-    envoy::api::v2::core::ApiConfigSource api_config_source;
-    api_config_source.set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
-    EXPECT_THROW_WITH_REGEX(
-        Utility::factoryForApiConfigSource(async_client_manager, api_config_source, scope),
-        EnvoyException, "Missing gRPC services in envoy::api::v2::core::ApiConfigSource:");
-  }
+  // Non-existent cluster.
+  api_config_source->add_cluster_names("foo_cluster");
+  EXPECT_THROW_WITH_MESSAGE(
+      Utility::checkApiConfigSourceSubscriptionBackingCluster(cluster_map, *api_config_source),
+      EnvoyException,
+      "envoy::api::v2::core::ConfigSource must have a statically defined non-EDS cluster: "
+      "'foo_cluster' does not exist, was added via api, or is an EDS cluster");
 
-  {
-    envoy::api::v2::core::ApiConfigSource api_config_source;
-    api_config_source.set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
-    api_config_source.add_grpc_services();
-    api_config_source.add_grpc_services();
-    EXPECT_THROW_WITH_REGEX(
-        Utility::factoryForApiConfigSource(async_client_manager, api_config_source, scope),
-        EnvoyException,
-        "Only singleton gRPC service lists supported in envoy::api::v2::core::ApiConfigSource:");
-  }
+  // Dynamic Cluster.
+  Upstream::MockCluster cluster;
+  cluster_map.emplace("foo_cluster", cluster);
+  EXPECT_CALL(cluster, info());
+  EXPECT_CALL(*cluster.info_, addedViaApi()).WillOnce(Return(true));
+  EXPECT_THROW_WITH_MESSAGE(
+      Utility::checkApiConfigSourceSubscriptionBackingCluster(cluster_map, *api_config_source),
+      EnvoyException,
+      "envoy::api::v2::core::ConfigSource must have a statically defined non-EDS cluster: "
+      "'foo_cluster' does not exist, was added via api, or is an EDS cluster");
 
-  {
-    envoy::api::v2::core::ApiConfigSource api_config_source;
-    api_config_source.set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
-    api_config_source.add_cluster_names();
-    api_config_source.add_cluster_names();
-    EXPECT_THROW_WITH_REGEX(
-        Utility::factoryForApiConfigSource(async_client_manager, api_config_source, scope),
-        EnvoyException,
-        "Only singleton cluster name lists supported in envoy::api::v2::core::ApiConfigSource:");
-  }
+  // EDS Cluster backing EDS Cluster.
+  EXPECT_CALL(cluster, info()).Times(2);
+  EXPECT_CALL(*cluster.info_, addedViaApi());
+  EXPECT_CALL(*cluster.info_, type()).WillOnce(Return(envoy::api::v2::Cluster::EDS));
+  EXPECT_THROW_WITH_MESSAGE(
+      Utility::checkApiConfigSourceSubscriptionBackingCluster(cluster_map, *api_config_source),
+      EnvoyException,
+      "envoy::api::v2::core::ConfigSource must have a statically defined non-EDS cluster: "
+      "'foo_cluster' does not exist, was added via api, or is an EDS cluster");
 
-  {
-    envoy::api::v2::core::ApiConfigSource api_config_source;
-    api_config_source.set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
-    api_config_source.add_cluster_names("foo");
-    envoy::api::v2::core::GrpcService expected_grpc_service;
-    expected_grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
-    EXPECT_CALL(async_client_manager,
-                factoryForGrpcService(ProtoEq(expected_grpc_service), Ref(scope), _));
-    Utility::factoryForApiConfigSource(async_client_manager, api_config_source, scope);
-  }
-
-  {
-    envoy::api::v2::core::ApiConfigSource api_config_source;
-    api_config_source.set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
-    api_config_source.add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("foo");
-    EXPECT_CALL(async_client_manager,
-                factoryForGrpcService(ProtoEq(api_config_source.grpc_services(0)), Ref(scope), _));
-    Utility::factoryForApiConfigSource(async_client_manager, api_config_source, scope);
-  }
+  // All ok.
+  EXPECT_CALL(cluster, info()).Times(2);
+  EXPECT_CALL(*cluster.info_, addedViaApi());
+  EXPECT_CALL(*cluster.info_, type());
+  Utility::checkApiConfigSourceSubscriptionBackingCluster(cluster_map, *api_config_source);
 }
 
 } // namespace Config

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -191,7 +191,7 @@ TEST(UtilityTest, CheckFilesystemSubscriptionBackingPath) {
 // TEST(UtilityTest, FactoryForGrpcApiConfigSource) should catch misconfigured
 // API configs along the dimension of ApiConfigSource type.
 TEST(UtilityTest, FactoryForGrpcApiConfigSource) {
-  Grpc::MockAsyncClientManager async_client_manager;
+  NiceMock<Grpc::MockAsyncClientManager> async_client_manager;
   Stats::MockStore scope;
 
   {
@@ -211,6 +211,15 @@ TEST(UtilityTest, FactoryForGrpcApiConfigSource) {
         Utility::factoryForGrpcApiConfigSource(async_client_manager, api_config_source, scope),
         EnvoyException,
         "envoy::api::v2::core::ConfigSource::GRPC must have a single gRPC service specified");
+  }
+
+  {
+    envoy::api::v2::core::ApiConfigSource api_config_source;
+    api_config_source.set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
+    api_config_source.add_cluster_names();
+    // this also logs a warning for setting REST cluster names for a gRPC API config.
+    EXPECT_NO_THROW(
+        Utility::factoryForGrpcApiConfigSource(async_client_manager, api_config_source, scope));
   }
 
   {

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -138,8 +138,10 @@ public:
                   eds_cluster_config:
                     eds_config:
                       api_config_source:
-                        cluster_names: "eds-cluster"
                         api_type: GRPC
+                        grpc_services:
+                          envoy_grpc:
+                            cluster_name: "eds-cluster"
               )EOF"));
 
       // TODO(zuercher): Make ConfigHelper EDS-aware and get rid of this hack:

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -103,7 +103,7 @@ public:
       // Setup load reporting and corresponding gRPC cluster.
       auto* loadstats_config = bootstrap.mutable_cluster_manager()->mutable_load_stats_config();
       loadstats_config->set_api_type(envoy::api::v2::core::ApiConfigSource::GRPC);
-      loadstats_config->add_cluster_names("load_report");
+      loadstats_config->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("load_report");
       auto* load_report_cluster = bootstrap.mutable_static_resources()->add_clusters();
       load_report_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
       load_report_cluster->mutable_circuit_breakers()->Clear();


### PR DESCRIPTION
This reverts #3063, which reverted #3030, which reverted #3018, which reverted #2999. Therefore this PR is similar to #2999, except that
 -  REST/gRPC config mismatch errors now warn instead of throwing an error. Hopefully this solves the issue for users who were unable to roll forward their binaries while keeping the same config.
 -  a related issue where API configs of type GRPC were implicitly assumed to have a `grpc_services` field set is now fixed. (see 32dae12.) Support for GRPC configs with `cluster_names` set instead of  `grpc_services` will extend through release 1.7.0.

Changelist for #2999:

To support the deprecation of cluster_names in the api_config_source (#2860), I
- added a more verbose error in utility.cc for GRPC api_config_sources with any named clusters
- hunted down places in tests where api_config_source.cluster_names()[0] was implicitly used (assuming that API would be GRPC and would have cluster names).
- renamed factoryForApiConfigSource to factoryForGrpcApiConfigSource, as it already implicitly returns a Grpc::AsyncClientFactoryPtr, and gave a more verbose error for when the user passes a config with cluster_names set.
- separated out checkApiConfigSourceSubscriptionBackingCluster into checkApiConfigSourceNames, which does the gRPC services v. cluster names validation, and checkApiConfigSourceSubscriptionBackingCluster, which actually validates the cluster name against the clusters map.
- more completely covered the tests for the branching cases for non-gRPC API configs which happened to have grpc services defined.

Risk Level: Low

Testing: bazel test test/... all passed.

Fixed #2680
Fixed #2902

Signed-off-by: James Buckland jbuckland@google.com

