### PR TITLE
ssl: avoid reaching into BoringSSL

### DIFF
--- a/test/common/ssl/ssl_socket_test.cc
+++ b/test/common/ssl/ssl_socket_test.cc
@@ -217,7 +217,7 @@ const std::string testUtilV2(const envoy::api::v2::Listener& server_proto,
         EXPECT_EQ(expected_protocol_version, SSL_get_version(client_ssl_socket));
       }
       SSL_SESSION* client_ssl_session = SSL_get_session(client_ssl_socket);
-      EXPECT_FALSE(client_ssl_session->not_resumable);
+      EXPECT_TRUE(SSL_SESSION_is_resumable(client_ssl_session));
       uint8_t* session_data;
       size_t session_len;
       int rc = SSL_SESSION_to_bytes(client_ssl_session, &session_data, &session_len);
@@ -998,7 +998,7 @@ void testTicketSessionResumption(const std::string& server_ctx_json1,
       .WillOnce(Invoke([&](Network::ConnectionEvent) -> void {
         Ssl::SslSocket* ssl_socket = dynamic_cast<Ssl::SslSocket*>(client_connection->ssl());
         ssl_session = SSL_get1_session(ssl_socket->rawSslForTest());
-        EXPECT_FALSE(ssl_session->not_resumable);
+        EXPECT_TRUE(SSL_SESSION_is_resumable(ssl_session));
         client_connection->close(Network::ConnectionCloseType::NoFlush);
         server_connection->close(Network::ConnectionCloseType::NoFlush);
         dispatcher.exit();
@@ -1335,7 +1335,7 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
       .WillOnce(Invoke([&](Network::ConnectionEvent) -> void {
         Ssl::SslSocket* ssl_socket = dynamic_cast<Ssl::SslSocket*>(client_connection->ssl());
         ssl_session = SSL_get1_session(ssl_socket->rawSslForTest());
-        EXPECT_FALSE(ssl_session->not_resumable);
+        EXPECT_TRUE(SSL_SESSION_is_resumable(ssl_session));
         server_connection->close(Network::ConnectionCloseType::NoFlush);
         client_connection->close(Network::ConnectionCloseType::NoFlush);
         dispatcher.exit();


### PR DESCRIPTION
ssl: avoid reaching into BoringSSL

Rather than reaching into not_resumable, there's the
SSL_SESSION_is_resumable API. (This is so a future revision of BoringSSL
can hide the SSL_SESSION struct and make it C++.)

*Risk Level*: Low (test only)

*Testing*: I ran the test in Google's copy of the tree.

*Docs Changes*: N/A

*Release Notes*: N/A