### PR TITLE
logging: log listener name together with the error in LDS onConfigUpdate

### DIFF
--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -56,10 +56,15 @@ void LdsApi::onConfigUpdate(const ResourceVector& resources) {
   for (const auto& listener : resources) {
     const std::string listener_name = listener.name();
     listeners_to_remove.erase(listener_name);
-    if (listener_manager_.addOrUpdateListener(listener, true)) {
-      ENVOY_LOG(info, "lds: add/update listener '{}'", listener_name);
-    } else {
-      ENVOY_LOG(debug, "lds: add/update listener '{}' skipped", listener_name);
+    try {
+      if (listener_manager_.addOrUpdateListener(listener, true)) {
+        ENVOY_LOG(info, "lds: add/update listener '{}'", listener_name);
+      } else {
+        ENVOY_LOG(debug, "lds: add/update listener '{}' skipped", listener_name);
+      }
+    } catch (const EnvoyException& e) {
+      throw EnvoyException(
+          fmt::format("Error adding/updating listener {}: {}", listener_name, e.what()));
     }
   }
 


### PR DESCRIPTION
This wrapper the EnvoyException in LDS to add the erroneous listener name to the exception message. Without it, it's hard to tell which listener is broken.

Before this change:

```
[2018-04-15 20:19:18.760][12883858][warning][upstream] source/common/config/grpc_mux_impl.cc:188] gRPC config for type.googleapis.com/envoy.api.v2.Listener update rejected: Failed to load certificate chain from <inline>
```

After this change:

```
[2018-04-16 07:44:52.239][13348884][warning][upstream] source/common/config/grpc_mux_impl.cc:200] gRPC config for type.googleapis.com/envoy.api.v2.Listener update rejected: Error adding/updating listener some-listener-name: Failed to load certificate chain from <inline>
```

*Risk Level*: Low

*Testing*:
bazel test //test/ executed successfully
```
Executed 7 out of 229 tests: 229 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
```
Manual testing was done, resulting log message posted above.

*Docs Changes*:
probably not required

*Release Notes*:
probably not required?