### PR TITLE
ci: yet another api_mirror.sh fix.

### DIFF
--- a/ci/api_mirror.sh
+++ b/ci/api_mirror.sh
@@ -42,7 +42,6 @@ then
     git -C "$CHECKOUT_DIR" add .
     git -C "$CHECKOUT_DIR" commit -m "$QUALIFIED_COMMIT_MSG"
   done
-  git worktree remove --force "$API_WORKING_DIR"
 
   echo "Pushing..."
   git -C "$CHECKOUT_DIR" push origin master


### PR DESCRIPTION
Looks like the version of git on CircleCI doesn't support "git workspace remove". This doesn't
matter in CI anyway, since state is ephemeral.

Signed-off-by: Harvey Tuch <htuch@google.com>