### PR TITLE
Add header match to http health check filter

### DIFF
--- a/api/envoy/config/filter/http/health_check/v2/BUILD
+++ b/api/envoy/config/filter/http/health_check/v2/BUILD
@@ -6,6 +6,7 @@ api_proto_library(
     name = "health_check",
     srcs = ["health_check.proto"],
     deps = [
+        "//envoy/api/v2/route",
         "//envoy/type:percent",
     ],
 )
@@ -14,6 +15,7 @@ api_go_proto_library(
     name = "health_check",
     proto = ":health_check",
     deps = [
+        "//envoy/api/v2/route:route_go_proto",
         "//envoy/type:percent_go_proto",
     ],
 )

--- a/api/envoy/config/filter/http/health_check/v2/health_check.proto
+++ b/api/envoy/config/filter/http/health_check/v2/health_check.proto
@@ -6,6 +6,7 @@ option go_package = "v2";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "envoy/api/v2/route/route.proto";
 import "envoy/type/percent.proto";
 
 import "validate/validate.proto";
@@ -20,7 +21,7 @@ message HealthCheck {
 
   // Specifies the incoming HTTP endpoint that should be considered the
   // health check endpoint. For example */healthcheck*.
-  string endpoint = 2 [(validate.rules).string.min_bytes = 1];
+  string endpoint = 2 [(validate.rules).string.min_bytes = 1, deprecated = true];
 
   // If operating in pass through mode, the amount of time in milliseconds
   // that the filter should cache the upstream response.
@@ -30,4 +31,12 @@ message HealthCheck {
   // names and the minimum percentage of servers in each of those clusters that
   // must be healthy in order for the filter to return a 200.
   map<string, envoy.type.Percent> cluster_min_healthy_percentages = 4;
+
+  // [#not-implemented-hide:]
+  // Specifies a set of health check request headers to match on. The health check filter will
+  // check a request’s headers against all the specified headers. To specify the health check
+  // endpoint, set the ``:path`` header to match on. Note that if the
+  // :ref:`endpoint <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.endpoint>`
+  // field is set, it will overwrite any ``:path`` header to match.
+  repeated envoy.api.v2.route.HeaderMatcher headers = 5;
 }


### PR DESCRIPTION
Signed-off-by: Henna Huang <henna@google.com>

*title*: *Add header match to the http health check filter*

*Description*:
Add a header match field to the Http health check filter. This allows filtering health check requests not only on endpoint, but also request headers. Implementation will happen in a follow-up PR by @mrice32. 

Copy of https://github.com/envoyproxy/data-plane-api/pull/617 

*Risk Level*: Low 

*Testing*: n/a

*Docs Changes*: description added with [#not-implemented-hide:]

*Release Notes*: Will add in follow up PR.

[Optional *Deprecated*:] Will add in follow up PR.
