### PR TITLE
Add hash to route local config

### DIFF
--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -233,6 +233,25 @@ class RateLimitPolicy;
 class Config;
 
 /**
+ * Hold both per route config data and its hash.
+ * The hash is calculated at config time. It can be used to detect config change.
+ */
+struct PerFilterConfigAndHash {
+  PerFilterConfigAndHash(const Protobuf::Message& config) : config_(config) {
+    hash_ = MessageUtil::hash(config);
+  }
+  /**
+   * The actual config proto
+   */
+  const Protobuf::Message& config_;
+
+  /**
+   * The hash value of the config data. It can be used to detect changes.
+   */
+  size_t hash_;
+};
+
+/**
  * Virtual host defintion.
  */
 class VirtualHost {
@@ -260,11 +279,11 @@ public:
   virtual const Config& routeConfig() const PURE;
 
   /**
-   * @return const Protobuf::Message* the per-filter config for the given
+   * @return const PerFilterConfigAndHash* the per-filter config for the given
    * filter name configured for this virtual host. If none is present,
    * nullptr is returned.
    */
-  virtual const Protobuf::Message* perFilterConfig(const std::string& name) const PURE;
+  virtual const PerFilterConfigAndHash* perFilterConfig(const std::string& name) const PURE;
 };
 
 /**
@@ -472,12 +491,12 @@ public:
   virtual const PathMatchCriterion& pathMatchCriterion() const PURE;
 
   /**
-   * @return const Protobuf::Message* the per-filter config for the given
+   * @return const PerFilterConfigAndHash* the per-filter config for the given
    * filter name configured for this route entry. Only weighted cluster entries
    * will potentially have these values available. If none is present,
    * nullptr is returned.
    */
-  virtual const Protobuf::Message* perFilterConfig(const std::string& name) const PURE;
+  virtual const PerFilterConfigAndHash* perFilterConfig(const std::string& name) const PURE;
 };
 
 /**
@@ -525,11 +544,11 @@ public:
   virtual const Decorator* decorator() const PURE;
 
   /**
-   * @return const Protobuf::Message* the per-filter config for the given
+   * @return const PerFilterConfigAndHash* the per-filter config for the given
    * filter name configured for this route. If none is present, nullptr is
    * returned.
    */
-  virtual const Protobuf::Message* perFilterConfig(const std::string& name) const PURE;
+  virtual const PerFilterConfigAndHash* perFilterConfig(const std::string& name) const PURE;
 };
 
 typedef std::shared_ptr<const Route> RouteConstSharedPtr;

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -148,7 +148,9 @@ private:
     const Router::RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
     const Router::CorsPolicy* corsPolicy() const override { return nullptr; }
     const Router::Config& routeConfig() const override { return route_configuration_; }
-    const Protobuf::Message* perFilterConfig(const std::string&) const override { return nullptr; }
+    const Router::PerFilterConfigAndHash* perFilterConfig(const std::string&) const override {
+      return nullptr;
+    }
 
     static const NullRateLimitPolicy rate_limit_policy_;
     static const NullConfig route_configuration_;
@@ -203,7 +205,9 @@ private:
       return path_match_criterion_;
     }
 
-    const Protobuf::Message* perFilterConfig(const std::string&) const override { return nullptr; }
+    const Router::PerFilterConfigAndHash* perFilterConfig(const std::string&) const override {
+      return nullptr;
+    }
 
     static const NullRateLimitPolicy rate_limit_policy_;
     static const NullRetryPolicy retry_policy_;
@@ -226,7 +230,9 @@ private:
     const Router::DirectResponseEntry* directResponseEntry() const override { return nullptr; }
     const Router::RouteEntry* routeEntry() const override { return &route_entry_; }
     const Router::Decorator* decorator() const override { return nullptr; }
-    const Protobuf::Message* perFilterConfig(const std::string&) const override { return nullptr; }
+    const Router::PerFilterConfigAndHash* perFilterConfig(const std::string&) const override {
+      return nullptr;
+    }
 
     RouteEntryImpl route_entry_;
   };

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -163,7 +163,7 @@ public:
   MOCK_CONST_METHOD0(rateLimitPolicy, const RateLimitPolicy&());
   MOCK_CONST_METHOD0(corsPolicy, const CorsPolicy*());
   MOCK_CONST_METHOD0(routeConfig, const Config&());
-  MOCK_CONST_METHOD1(perFilterConfig, const Protobuf::Message*(const std::string&));
+  MOCK_CONST_METHOD1(perFilterConfig, const PerFilterConfigAndHash*(const std::string&));
 
   std::string name_{"fake_vhost"};
   testing::NiceMock<MockRateLimitPolicy> rate_limit_policy_;
@@ -233,7 +233,7 @@ public:
   MOCK_CONST_METHOD0(corsPolicy, const CorsPolicy*());
   MOCK_CONST_METHOD0(metadata, const envoy::api::v2::core::Metadata&());
   MOCK_CONST_METHOD0(pathMatchCriterion, const PathMatchCriterion&());
-  MOCK_CONST_METHOD1(perFilterConfig, const Protobuf::Message*(const std::string&));
+  MOCK_CONST_METHOD1(perFilterConfig, const PerFilterConfigAndHash*(const std::string&));
 
   std::string cluster_name_{"fake_cluster"};
   std::multimap<std::string, std::string> opaque_config_;
@@ -270,7 +270,7 @@ public:
   MOCK_CONST_METHOD0(directResponseEntry, const DirectResponseEntry*());
   MOCK_CONST_METHOD0(routeEntry, const RouteEntry*());
   MOCK_CONST_METHOD0(decorator, const Decorator*());
-  MOCK_CONST_METHOD1(perFilterConfig, const Protobuf::Message*(const std::string&));
+  MOCK_CONST_METHOD1(perFilterConfig, const PerFilterConfigAndHash*(const std::string&));
 
   testing::NiceMock<MockRouteEntry> route_entry_;
   testing::NiceMock<MockDecorator> decorator_;


### PR DESCRIPTION

*Description*:
Some filters need to pre-process the per-route-local config data.  If config proto hash can be calculated
at config time, the hash can be used to detect per-route config change.  This is how it can be used:

For each request:

    auto cfg = route()->perFilterConfig("name");
    if (per_thread_map.find(cfg->hash_) == per_thread_map.end()) {
            obj = pre_process(cfg->config_);
            per_thread_map[cfg->hash_] = obj;
    } else {
            obj = per_thread_map[cfg_hash_];
    }

*Risk Level*: Low 

