### PR TITLE
sigHandler define for power

### DIFF
--- a/source/exe/signal_action.cc
+++ b/source/exe/signal_action.cc
@@ -18,11 +18,12 @@ void SignalAction::sigHandler(int sig, siginfo_t* info, void* context) {
     error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[REG_RIP]);
 #elif defined(__APPLE__) && defined(__x86_64__)
     error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext->__ss.__rip);
+#elif defined(__powerpc__)
+    error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext.regs->nip);
 #else
 #warning "Please enable and test PC retrieval code for your arch in signal_action.cc"
 // x86 Classic: reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[REG_EIP]);
 // ARM: reinterpret_cast<void*>(ucontext->uc_mcontext.arm_pc);
-// PPC: reinterpret_cast<void*>(ucontext->uc_mcontext.regs->nip);
 #endif
   }
 


### PR DESCRIPTION
Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>

*main*: *sigHandler define for power*

*Description*:
This enables PC retrieval for Power platforms.

*Risk Level*: Low | Medium | High
Low: This won't break anything for current envoy users since it's for Power (`__powerpc__`).

*Testing*:
This has been manually tested by including envoy in istio builds (versions 0.4 and 0.7.1 were tested).

*Docs Changes*:
N/A at this time

*Release Notes*:
N/A
