### PR TITLE
accesslog: add access log header filter

### DIFF
--- a/api/envoy/config/filter/accesslog/v2/accesslog.proto
+++ b/api/envoy/config/filter/accesslog/v2/accesslog.proto
@@ -333,7 +333,7 @@ message AccessLogFilter {
     // Or filter.
     OrFilter or_filter = 7;
 
-    // [#not-implemented-hide:] Header filter.
+    // Header filter.
     HeaderFilter header_filter = 8;
   }
 }
@@ -418,7 +418,7 @@ message OrFilter {
   repeated AccessLogFilter filters = 2 [(validate.rules).repeated .min_items = 2];
 }
 
-// [#not-implemented-hide:] Filters requests based on the presence or value of a request header.
+// Filters requests based on the presence or value of a request header.
 message HeaderFilter {
   // Only requests with a header which matches the specified HeaderMatcher will pass the filter
   // check.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -6,6 +6,8 @@ Version history
 
 * access log: ability to format START_TIME
 * access log: added DYNAMIC_METADATA :ref:`access log formatter <config_access_log_format>`.
+* access log: added :ref:`HeaderFilter <envoy_api_msg_config.filter.accesslog.v2.HeaderFilter>`
+  to filter logs based on request headers
 * admin: added :http:get:`/config_dump` for dumping current configs
 * admin: added :http:get:`/stats/prometheus` as an alternative endpoint for getting stats in prometheus format.
 * admin: added :ref:`/runtime_modify endpoint <operations_admin_interface_runtime_modify>` to add or change runtime values

--- a/source/common/access_log/BUILD
+++ b/source/common/access_log/BUILD
@@ -50,6 +50,7 @@ envoy_cc_library(
         "//source/common/http:header_map_lib",
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",
+        "//source/common/router:config_utility_lib",
         "//source/common/runtime:uuid_util_lib",
         "//source/common/tracing:http_tracer_lib",
     ],

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -11,6 +11,7 @@
 #include "envoy/server/access_log_config.h"
 
 #include "common/protobuf/protobuf.h"
+#include "common/router/config_utility.h"
 
 namespace Envoy {
 namespace AccessLog {
@@ -148,6 +149,21 @@ private:
   const std::string runtime_key_;
   const envoy::type::FractionalPercent percent_;
   const bool use_independent_randomness_;
+};
+
+/**
+ * Filter requests based on its headers.
+ */
+class HeaderFilter : public Filter {
+public:
+  HeaderFilter(const envoy::config::filter::accesslog::v2::HeaderFilter& config);
+
+  // AccessLog::Filter
+  bool evaluate(const RequestInfo::RequestInfo& info,
+                const Http::HeaderMap& request_headers) override;
+
+private:
+  std::vector<Router::ConfigUtility::HeaderData> header_data_;
 };
 
 /**

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -753,6 +753,131 @@ config:
   log->log(&request_headers_, &response_headers_, request_info_);
 }
 
+TEST_F(AccessLogImplTest, HeaderPresence) {
+  const std::string yaml = R"EOF(
+name: envoy.file_access_log
+filter:
+  header_filter:
+    header:
+      name: test-header
+config:
+  path: /dev/null
+  )EOF";
+
+  InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV2Yaml(yaml), context_);
+
+  EXPECT_CALL(*file_, write(_)).Times(0);
+  log->log(&request_headers_, &response_headers_, request_info_);
+
+  request_headers_.addCopy("test-header", "present");
+  EXPECT_CALL(*file_, write(_));
+  log->log(&request_headers_, &response_headers_, request_info_);
+}
+
+TEST_F(AccessLogImplTest, HeaderExactMatch) {
+  const std::string yaml = R"EOF(
+name: envoy.file_access_log
+filter:
+  header_filter:
+    header:
+      name: test-header
+      exact_match: exact-match-value
+
+config:
+  path: /dev/null
+  )EOF";
+
+  InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV2Yaml(yaml), context_);
+
+  EXPECT_CALL(*file_, write(_)).Times(0);
+  log->log(&request_headers_, &response_headers_, request_info_);
+
+  request_headers_.addCopy("test-header", "exact-match-value");
+  EXPECT_CALL(*file_, write(_));
+  log->log(&request_headers_, &response_headers_, request_info_);
+
+  request_headers_.remove("test-header");
+  request_headers_.addCopy("test-header", "not-exact-match-value");
+  EXPECT_CALL(*file_, write(_)).Times(0);
+  log->log(&request_headers_, &response_headers_, request_info_);
+}
+
+TEST_F(AccessLogImplTest, HeaderRegexMatch) {
+  const std::string yaml = R"EOF(
+name: envoy.file_access_log
+filter:
+  header_filter:
+    header:
+      name: test-header
+      regex_match: \d{3}
+config:
+  path: /dev/null
+  )EOF";
+
+  InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV2Yaml(yaml), context_);
+
+  EXPECT_CALL(*file_, write(_)).Times(0);
+  log->log(&request_headers_, &response_headers_, request_info_);
+
+  request_headers_.addCopy("test-header", "123");
+  EXPECT_CALL(*file_, write(_));
+  log->log(&request_headers_, &response_headers_, request_info_);
+
+  request_headers_.remove("test-header");
+  request_headers_.addCopy("test-header", "1234");
+  EXPECT_CALL(*file_, write(_)).Times(0);
+  log->log(&request_headers_, &response_headers_, request_info_);
+
+  request_headers_.remove("test-header");
+  request_headers_.addCopy("test-header", "123.456");
+  EXPECT_CALL(*file_, write(_)).Times(0);
+  log->log(&request_headers_, &response_headers_, request_info_);
+}
+
+TEST_F(AccessLogImplTest, HeaderRangeMatch) {
+  const std::string yaml = R"EOF(
+name: envoy.file_access_log
+filter:
+  header_filter:
+    header:
+      name: test-header
+      range_match:
+        start: -10
+        end: 0
+config:
+  path: /dev/null
+  )EOF";
+
+  InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV2Yaml(yaml), context_);
+
+  EXPECT_CALL(*file_, write(_)).Times(0);
+  log->log(&request_headers_, &response_headers_, request_info_);
+
+  request_headers_.addCopy("test-header", "-1");
+  EXPECT_CALL(*file_, write(_));
+  log->log(&request_headers_, &response_headers_, request_info_);
+
+  request_headers_.remove("test-header");
+  request_headers_.addCopy("test-header", "0");
+  EXPECT_CALL(*file_, write(_)).Times(0);
+  log->log(&request_headers_, &response_headers_, request_info_);
+
+  request_headers_.remove("test-header");
+  request_headers_.addCopy("test-header", "somestring");
+  EXPECT_CALL(*file_, write(_)).Times(0);
+  log->log(&request_headers_, &response_headers_, request_info_);
+
+  request_headers_.remove("test-header");
+  request_headers_.addCopy("test-header", "10.9");
+  EXPECT_CALL(*file_, write(_)).Times(0);
+  log->log(&request_headers_, &response_headers_, request_info_);
+
+  request_headers_.remove("test-header");
+  request_headers_.addCopy("test-header", "-1somestring");
+  EXPECT_CALL(*file_, write(_)).Times(0);
+  log->log(&request_headers_, &response_headers_, request_info_);
+}
+
 } // namespace
 } // namespace AccessLog
 } // namespace Envoy

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -219,6 +219,8 @@ void TestHeaderMapImpl::addCopy(const std::string& key, const std::string& value
   addCopy(LowerCaseString(key), value);
 }
 
+void TestHeaderMapImpl::remove(const std::string& key) { remove(LowerCaseString(key)); }
+
 std::string TestHeaderMapImpl::get_(const std::string& key) { return get_(LowerCaseString(key)); }
 
 std::string TestHeaderMapImpl::get_(const LowerCaseString& key) {

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -297,7 +297,9 @@ public:
   }
 
   using HeaderMapImpl::addCopy;
+  using HeaderMapImpl::remove;
   void addCopy(const std::string& key, const std::string& value);
+  void remove(const std::string& key);
   std::string get_(const std::string& key);
   std::string get_(const LowerCaseString& key);
   bool has(const std::string& key);


### PR DESCRIPTION
*Title*: accesslog: add access log header filter

*Description*:
Adds HeaderFilter, which allows access log filtering based on
a request's headers. This filter can be added to an access log via config.

*Risk Level*: Low

*Testing*: unit testing, manual testing

*Docs Changes*:
data-plane-api PR: https://github.com/envoyproxy/data-plane-api/pull/616
see [version_history](https://github.com/envoyproxy/envoy/compare/master...kevintchan:header-filter?expand=1#diff-d8d3e33358b55e6c0466dd1bb5f40c79)

*Release Notes*:
see [version_history](https://github.com/envoyproxy/envoy/compare/master...kevintchan:header-filter?expand=1#diff-d8d3e33358b55e6c0466dd1bb5f40c79)

*Fixes* envoyproxy/envoy#2544

Signed-off-by: Kevin Chan <kchan@evernote.com>
