### PR TITLE
bazel: fix bug in compiler flag selection.

### DIFF
--- a/bazel/cc_wrapper.py
+++ b/bazel/cc_wrapper.py
@@ -70,8 +70,7 @@ def main():
     # This ensures that STL symbols are included.
     # See https://github.com/envoyproxy/envoy/issues/1341
     argv.append("-fno-limit-debug-info")
-
-  if "gcc" in compiler or "g++" in compiler:
+  else:
     # -Wmaybe-initialized is warning about many uses of absl::optional. Disable
     # to prevent build breakage. This option does not exist in clang, so setting
     # it in clang builds causes a build error because of unknown command line

--- a/bazel/cc_wrapper.py
+++ b/bazel/cc_wrapper.py
@@ -70,7 +70,7 @@ def main():
     # This ensures that STL symbols are included.
     # See https://github.com/envoyproxy/envoy/issues/1341
     argv.append("-fno-limit-debug-info")
-  else:
+  elif "gcc" in compiler or "g++" in compiler:
     # -Wmaybe-initialized is warning about many uses of absl::optional. Disable
     # to prevent build breakage. This option does not exist in clang, so setting
     # it in clang builds causes a build error because of unknown command line


### PR DESCRIPTION
See https://github.com/google/oss-fuzz/issues/1337.

Risk Level: Low.
Test: CI builds.

Signed-off-by: Harvey Tuch <htuch@google.com>
