### PR TITLE
health_check: add header matching to health check http filter

### DIFF
--- a/api/envoy/config/filter/http/health_check/v2/health_check.proto
+++ b/api/envoy/config/filter/http/health_check/v2/health_check.proto
@@ -32,7 +32,6 @@ message HealthCheck {
   // must be healthy in order for the filter to return a 200.
   map<string, envoy.type.Percent> cluster_min_healthy_percentages = 4;
 
-  // [#not-implemented-hide:]
   // Specifies a set of health check request headers to match on. The health check filter will
   // check a request’s headers against all the specified headers. To specify the health check
   // endpoint, set the ``:path`` header to match on. Note that if the

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -24,6 +24,10 @@ Version history
   <envoy_api_field_core.HealthCheck.unhealthy_edge_interval>`, :ref:`unhealthy to healthy
   <envoy_api_field_core.HealthCheck.healthy_edge_interval>` and for subsequent checks on
   :ref:`unhealthy hosts <envoy_api_field_core.HealthCheck.unhealthy_interval>`.
+* health check http filter: added
+  :ref:`generic header matching <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.headers>`
+  to trigger health check response. Deprecated the
+  :ref:`endpoint option <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.endpoint>`.
 * listeners: added :ref:`tcp_fast_open_queue_length <envoy_api_field_Listener.tcp_fast_open_queue_length>` option.
 * health check: added support for :ref:`custom health check <envoy_api_field_core.HealthCheck.custom_health_check>`.
 * http: added the ability to pass DNS type Subject Alternative Names of the client certificate in the

--- a/source/extensions/filters/http/health_check/BUILD
+++ b/source/extensions/filters/http/health_check/BUILD
@@ -27,6 +27,7 @@ envoy_cc_library(
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",
         "//source/common/protobuf:utility_lib",
+        "//source/common/router:config_utility_lib",
         "@envoy_api//envoy/config/filter/http/health_check/v2:health_check_cc",
     ],
 )
@@ -39,6 +40,7 @@ envoy_cc_library(
         "//include/envoy/registry",
         "//include/envoy/server:filter_config_interface",
         "//source/common/config:filter_json_lib",
+        "//source/common/router:config_utility_lib",
         "//source/extensions/filters/http:well_known_names",
         "//source/extensions/filters/http/health_check:health_check_lib",
     ],

--- a/source/extensions/filters/http/health_check/config.cc
+++ b/source/extensions/filters/http/health_check/config.cc
@@ -3,6 +3,8 @@
 #include "envoy/registry/registry.h"
 
 #include "common/config/filter_json.h"
+#include "common/http/headers.h"
+#include "common/router/config_utility.h"
 
 #include "extensions/filters/http/health_check/health_check.h"
 
@@ -15,11 +17,29 @@ Server::Configuration::HttpFilterFactoryCb HealthCheckFilterConfig::createFilter
     const envoy::config::filter::http::health_check::v2::HealthCheck& proto_config,
     const std::string&, Server::Configuration::FactoryContext& context) {
   ASSERT(proto_config.has_pass_through_mode());
-  ASSERT(!proto_config.endpoint().empty());
 
   const bool pass_through_mode = proto_config.pass_through_mode().value();
   const int64_t cache_time_ms = PROTOBUF_GET_MS_OR_DEFAULT(proto_config, cache_time, 0);
   const std::string hc_endpoint = proto_config.endpoint();
+
+  auto header_match_data = std::make_shared<std::vector<Router::ConfigUtility::HeaderData>>();
+
+  bool endpoint_set = !proto_config.endpoint().empty();
+
+  if (endpoint_set) {
+    envoy::api::v2::route::HeaderMatcher matcher;
+    matcher.set_name(Http::Headers::get().Path.get());
+    matcher.set_exact_match(proto_config.endpoint());
+    header_match_data->emplace_back(matcher);
+  }
+
+  for (const envoy::api::v2::route::HeaderMatcher& matcher : proto_config.headers()) {
+    Router::ConfigUtility::HeaderData single_header_match(matcher);
+    // Ignore the any path header matchers if the endpoint field has been set.
+    if (!endpoint_set || !(single_header_match.name_ == Http::Headers::get().Path)) {
+      header_match_data->push_back(std::move(single_header_match));
+    }
+  }
 
   if (!pass_through_mode && cache_time_ms) {
     throw EnvoyException("cache_time_ms must not be set when path_through_mode is disabled");
@@ -40,10 +60,11 @@ Server::Configuration::HttpFilterFactoryCb HealthCheckFilterConfig::createFilter
     cluster_min_healthy_percentages = std::move(cluster_to_percentage);
   }
 
-  return [&context, pass_through_mode, cache_manager, hc_endpoint,
+  return [&context, pass_through_mode, cache_manager, header_match_data,
           cluster_min_healthy_percentages](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<HealthCheckFilter>(
-        context, pass_through_mode, cache_manager, hc_endpoint, cluster_min_healthy_percentages));
+    callbacks.addStreamFilter(std::make_shared<HealthCheckFilter>(context, pass_through_mode,
+                                                                  cache_manager, header_match_data,
+                                                                  cluster_min_healthy_percentages));
 
   };
 }

--- a/source/extensions/filters/http/health_check/health_check.cc
+++ b/source/extensions/filters/http/health_check/health_check.cc
@@ -34,7 +34,7 @@ void HealthCheckCacheManager::onTimer() {
 
 Http::FilterHeadersStatus HealthCheckFilter::decodeHeaders(Http::HeaderMap& headers,
                                                            bool end_stream) {
-  if (headers.Path()->value() == endpoint_.c_str()) {
+  if (Router::ConfigUtility::matchHeaders(headers, *header_match_data_)) {
     health_check_request_ = true;
     callbacks_->requestInfo().healthCheck(true);
 

--- a/source/extensions/filters/http/health_check/health_check.h
+++ b/source/extensions/filters/http/health_check/health_check.h
@@ -9,6 +9,8 @@
 #include "envoy/http/filter.h"
 #include "envoy/server/filter_config.h"
 
+#include "common/router/config_utility.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -52,11 +54,14 @@ typedef std::shared_ptr<const ClusterMinHealthyPercentages>
  */
 class HealthCheckFilter : public Http::StreamFilter {
 public:
-  HealthCheckFilter(Server::Configuration::FactoryContext& context, bool pass_through_mode,
-                    HealthCheckCacheManagerSharedPtr cache_manager, const std::string& endpoint,
-                    ClusterMinHealthyPercentagesConstSharedPtr cluster_min_healthy_percentages)
+  HealthCheckFilter(
+      Server::Configuration::FactoryContext& context, bool pass_through_mode,
+      HealthCheckCacheManagerSharedPtr cache_manager,
+      std::shared_ptr<std::vector<Router::ConfigUtility::HeaderData>> header_match_data,
+      ClusterMinHealthyPercentagesConstSharedPtr cluster_min_healthy_percentages)
       : context_(context), pass_through_mode_(pass_through_mode), cache_manager_(cache_manager),
-        endpoint_(endpoint), cluster_min_healthy_percentages_(cluster_min_healthy_percentages) {}
+        header_match_data_(std::move(header_match_data)),
+        cluster_min_healthy_percentages_(cluster_min_healthy_percentages) {}
 
   // Http::StreamFilterBase
   void onDestroy() override {}
@@ -91,7 +96,7 @@ private:
   bool health_check_request_{};
   bool pass_through_mode_{};
   HealthCheckCacheManagerSharedPtr cache_manager_;
-  const std::string endpoint_;
+  const std::shared_ptr<std::vector<Router::ConfigUtility::HeaderData>> header_match_data_;
   ClusterMinHealthyPercentagesConstSharedPtr cluster_min_healthy_percentages_;
 };
 

--- a/test/extensions/filters/http/health_check/BUILD
+++ b/test/extensions/filters/http/health_check/BUILD
@@ -30,5 +30,6 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/health_check:config",
         "//test/mocks/server:server_mocks",
+        "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/filters/http/health_check/health_check_test.cc
+++ b/test/extensions/filters/http/health_check/health_check_test.cc
@@ -44,7 +44,12 @@ public:
   void prepareFilter(
       bool pass_through,
       ClusterMinHealthyPercentagesConstSharedPtr cluster_min_healthy_percentages = nullptr) {
-    filter_.reset(new HealthCheckFilter(context_, pass_through, cache_manager_, "/healthcheck",
+    header_data_ = std::make_shared<std::vector<Router::ConfigUtility::HeaderData>>();
+    envoy::api::v2::route::HeaderMatcher matcher;
+    matcher.set_name(":path");
+    matcher.set_exact_match("/healthcheck");
+    header_data_->emplace_back(matcher);
+    filter_.reset(new HealthCheckFilter(context_, pass_through, cache_manager_, header_data_,
                                         cluster_min_healthy_percentages));
     filter_->setDecoderFilterCallbacks(callbacks_);
   }
@@ -57,6 +62,7 @@ public:
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks_;
   Http::TestHeaderMapImpl request_headers_;
   Http::TestHeaderMapImpl request_headers_no_hc_;
+  std::shared_ptr<std::vector<Router::ConfigUtility::HeaderData>> header_data_;
 
   class MockHealthCheckCluster : public NiceMock<Upstream::MockThreadLocalCluster> {
   public:


### PR DESCRIPTION
*Description*: Implements the header matching mechanism that was added to the API in #3097 .  

*Risk Level*: Low

*Testing*: Unit tests were added for the new configuration options.

*Docs Changes*: #3097.

*Release Notes*: added release note.