### PR TITLE
config: fix unnecessary log lines on remote close

### DIFF
--- a/docs/root/configuration/cluster_manager/cds.rst
+++ b/docs/root/configuration/cluster_manager/cds.rst
@@ -27,5 +27,5 @@ CDS has a statistics tree rooted at *cluster_manager.cds.* with the following st
   config_reload, Counter, Total API fetches that resulted in a config reload due to a different config
   update_attempt, Counter, Total API fetches attempted
   update_success, Counter, Total API fetches completed successfully
-  update_failure, Counter, Total API fetches that failed (either network or schema errors)
+  update_failure, Counter, Total API fetches that failed because of schema errors
   version, Gauge, Hash of the contents from the last successful API fetch

--- a/docs/root/configuration/overview/v2_overview.rst
+++ b/docs/root/configuration/overview/v2_overview.rst
@@ -510,6 +510,21 @@ to
 with the effect that the LDS stream will be directed to *some_ads_cluster* over
 the shared ADS channel.
 
+.. _config_overview_v2_mgmt_con_issues:
+
+Management Server Unreachability
+--------------------------------
+
+Some times because of network related issues, Envoy instance may loose connectivity with the 
+management server. Envoy will latch on to the previous configuration while actively retrying 
+in the background to reestablish the connection with the management server. 
+
+Envoy logs the fact that it is not able to establish a connection with the management server 
+every time it attempts a connection.
+
+:ref:`upstream_cx_connect_fail <config_cluster_manager_cluster_stats>` a cluster level statistic
+of the cluster pointing to management server would indicate this behavior.
+
 .. _config_overview_v2_status:
 
 Status

--- a/docs/root/configuration/overview/v2_overview.rst
+++ b/docs/root/configuration/overview/v2_overview.rst
@@ -515,15 +515,15 @@ the shared ADS channel.
 Management Server Unreachability
 --------------------------------
 
-Some times because of network related issues, Envoy instance may loose connectivity with the 
-management server. Envoy will latch on to the previous configuration while actively retrying 
-in the background to reestablish the connection with the management server. 
+When Envoy instance looses connectivity with the management server, Envoy will latch on to
+the previous configuration while actively retrying in the background to reestablish the 
+connection with the management server. 
 
-Envoy logs the fact that it is not able to establish a connection with the management server 
+Envoy debug logs the fact that it is not able to establish a connection with the management server 
 every time it attempts a connection.
 
 :ref:`upstream_cx_connect_fail <config_cluster_manager_cluster_stats>` a cluster level statistic
-of the cluster pointing to management server would indicate this behavior.
+of the cluster pointing to management server provides a signal for monitoring this behavior.
 
 .. _config_overview_v2_status:
 

--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -216,7 +216,7 @@ void GrpcMuxImpl::onReceiveTrailingMetadata(Http::HeaderMapPtr&& metadata) {
 void GrpcMuxImpl::onRemoteClose(Grpc::Status::GrpcStatus status, const std::string& message) {
   ENVOY_LOG(warn, "gRPC config stream closed: {}, {}", status, message);
   stream_ = nullptr;
-  handleFailure();
+  setRetryTimer();
 }
 
 } // namespace Config

--- a/test/common/config/grpc_mux_impl_test.cc
+++ b/test/common/config/grpc_mux_impl_test.cc
@@ -111,7 +111,6 @@ TEST_F(GrpcMuxImplTest, ResetStream) {
   expectSendMessage("baz", {"z"}, "");
   grpc_mux_->start();
 
-  EXPECT_CALL(callbacks_, onConfigUpdateFailed(_)).Times(3);
   EXPECT_CALL(*timer_, enableTimer(_));
   grpc_mux_->onRemoteClose(Grpc::Status::GrpcStatus::Canceled, "");
   EXPECT_CALL(*async_client_, start(_, _)).WillOnce(Return(&async_stream_));

--- a/test/common/config/grpc_subscription_impl_test.cc
+++ b/test/common/config/grpc_subscription_impl_test.cc
@@ -35,14 +35,13 @@ TEST_F(GrpcSubscriptionImplTest, RemoteStreamClose) {
   Http::HeaderMapPtr trailers{new Http::TestHeaderMapImpl{}};
   subscription_->grpcMux().onReceiveTrailingMetadata(std::move(trailers));
   EXPECT_CALL(*timer_, enableTimer(_));
-  EXPECT_CALL(callbacks_, onConfigUpdateFailed(_));
   subscription_->grpcMux().onRemoteClose(Grpc::Status::GrpcStatus::Canceled, "");
-  verifyStats(2, 0, 0, 1, 0);
+  verifyStats(1, 0, 0, 0, 0);
   // Retry and succeed.
   EXPECT_CALL(*async_client_, start(_, _)).WillOnce(Return(&async_stream_));
   expectSendMessage({"cluster0", "cluster1"}, "");
   timer_cb_();
-  verifyStats(2, 0, 0, 1, 0);
+  verifyStats(1, 0, 0, 0, 0);
 }
 
 // Validate that When the management server gets multiple requests for the same version, it can


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*:
only call setRetryTimer instead of handleFailure on remote close
*Risk Level*: Low
*Testing*: Automated tests
*Docs Changes*: NA
*Release Notes*: NA

Fixes https://github.com/envoyproxy/envoy/issues/3024
