### PR TITLE
server: fix segfault when cluster manager throws during init.

### DIFF
--- a/include/envoy/server/configuration.h
+++ b/include/envoy/server/configuration.h
@@ -49,9 +49,10 @@ public:
   virtual ~Main() {}
 
   /**
-   * @return Upstream::ClusterManager& singleton for use by the entire server.
+   * @return Upstream::ClusterManager* singleton for use by the entire server.
+   *         This will be nullptr if the cluster managed has not initialized yet.
    */
-  virtual Upstream::ClusterManager& clusterManager() PURE;
+  virtual Upstream::ClusterManager* clusterManager() PURE;
 
   /**
    * @return Tracing::HttpTracer& singleton for use by the entire server.

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -96,7 +96,9 @@ void ValidationInstance::shutdown() {
   // do an abbreviated shutdown here since there's less to clean up -- for example, no workers to
   // exit.
   thread_local_.shutdownGlobalThreading();
-  config_->clusterManager().shutdown();
+  if (config_ != nullptr && config_->clusterManager() != nullptr) {
+    config_->clusterManager()->shutdown();
+  }
   thread_local_.shutdownThread();
 }
 

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -59,7 +59,7 @@ public:
   // Server::Instance
   Admin& admin() override { return admin_; }
   Api::Api& api() override { return *api_; }
-  Upstream::ClusterManager& clusterManager() override { return config_->clusterManager(); }
+  Upstream::ClusterManager& clusterManager() override { return *config_->clusterManager(); }
   Ssl::ContextManager& sslContextManager() override { return *ssl_context_manager_; }
   Event::Dispatcher& dispatcher() override { return *dispatcher_; }
   Network::DnsResolverSharedPtr dnsResolver() override { return dns_resolver_; }

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -123,7 +123,7 @@ public:
                   Upstream::ClusterManagerFactory& cluster_manager_factory);
 
   // Server::Configuration::Main
-  Upstream::ClusterManager& clusterManager() override { return *cluster_manager_; }
+  Upstream::ClusterManager* clusterManager() override { return cluster_manager_.get(); }
   Tracing::HttpTracer& httpTracer() override { return *http_tracer_; }
   RateLimit::ClientFactory& rateLimitClientFactory() override { return *ratelimit_client_factory_; }
   std::list<Stats::SinkPtr>& statsSinks() override { return stats_sinks_; }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -84,7 +84,7 @@ InstanceImpl::~InstanceImpl() {
   file_logger_.reset();
 }
 
-Upstream::ClusterManager& InstanceImpl::clusterManager() { return config_->clusterManager(); }
+Upstream::ClusterManager& InstanceImpl::clusterManager() { return *config_->clusterManager(); }
 
 Tracing::HttpTracer& InstanceImpl::httpTracer() { return config_->httpTracer(); }
 
@@ -417,8 +417,8 @@ void InstanceImpl::terminate() {
     flushStats();
   }
 
-  if (config_.get() != nullptr) {
-    config_->clusterManager().shutdown();
+  if (config_.get() != nullptr && config_->clusterManager() != nullptr) {
+    config_->clusterManager()->shutdown();
   }
   handler_.reset();
   thread_local_.shutdownThread();

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -46,7 +46,7 @@ public:
         server_.dnsResolver(), ssl_context_manager_, server_.dispatcher(), server_.localInfo()));
 
     ON_CALL(server_, clusterManager()).WillByDefault(Invoke([&]() -> Upstream::ClusterManager& {
-      return main_config.clusterManager();
+      return *main_config.clusterManager();
     }));
     ON_CALL(server_, listenerManager()).WillByDefault(ReturnRef(listener_manager_));
     ON_CALL(component_factory_, createNetworkFilterFactoryList(_, _))

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -318,7 +318,7 @@ public:
   MockMain() : MockMain(0, 0, 0, 0) {}
   MockMain(int wd_miss, int wd_megamiss, int wd_kill, int wd_multikill);
 
-  MOCK_METHOD0(clusterManager, Upstream::ClusterManager&());
+  MOCK_METHOD0(clusterManager, Upstream::ClusterManager*());
   MOCK_METHOD0(httpTracer, Tracing::HttpTracer&());
   MOCK_METHOD0(rateLimitClientFactory, RateLimit::ClientFactory&());
   MOCK_METHOD0(statsSinks, std::list<Stats::SinkPtr>&());

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -155,6 +155,7 @@ envoy_cc_test(
     name = "server_test",
     srcs = ["server_test.cc"],
     data = [
+        ":cluster_dupe_bootstrap.yaml",
         ":empty_bootstrap.yaml",
         ":node_bootstrap.yaml",
         "//test/config/integration:server.json",

--- a/test/server/cluster_dupe_bootstrap.yaml
+++ b/test/server/cluster_dupe_bootstrap.yaml
@@ -1,0 +1,12 @@
+admin:
+  access_log_path: /dev/null
+  address:
+    socket_address:
+      address: {{ ntop_ip_loopback_address }}
+      port_value: 0
+static_resources:
+  clusters:
+  - name: service_google
+    connect_timeout: 0.25s
+  - name: service_google
+    connect_timeout: 0.25s

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -118,9 +118,9 @@ TEST_F(ConfigurationImplTest, SetUpstreamClusterPerConnectionBufferLimit) {
   MainImpl config;
   config.initialize(bootstrap, server_, cluster_manager_factory_);
 
-  ASSERT_EQ(1U, config.clusterManager().clusters().count("test_cluster"));
+  ASSERT_EQ(1U, config.clusterManager()->clusters().count("test_cluster"));
   EXPECT_EQ(8192U, config.clusterManager()
-                       .clusters()
+                       ->clusters()
                        .find("test_cluster")
                        ->second.get()
                        .info()

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -172,6 +172,13 @@ TEST_P(ServerInstanceImplTest, BootstrapNodeWithOptionsOverride) {
   EXPECT_EQ(VersionInfo::version(), server_->localInfo().node().build_version());
 }
 
+// Regression test for segfault when server initialization fails prior to
+// ClusterManager initialization.
+TEST_P(ServerInstanceImplTest, BootstrapClusterManagerInitializationFail) {
+  EXPECT_THROW_WITH_MESSAGE(initialize("test/server/cluster_dupe_bootstrap.yaml"), EnvoyException,
+                            "cluster manager: duplicate cluster 'service_google'");
+}
+
 // Negative test for protoc-gen-validate constraints.
 TEST_P(ServerInstanceImplTest, ValidateFail) {
   options_.service_cluster_name_ = "some_cluster_name";


### PR DESCRIPTION
This was found via proto fuzzing the server config.

Risk Level: Low
Testing: New server_test for regression.

Signed-off-by: Harvey Tuch <htuch@google.com>