### PR TITLE
dns: fix segfault when pipes are used to specify DNS resolvers.

### DIFF
--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -37,6 +37,13 @@ DnsResolverImpl::DnsResolverImpl(
     std::vector<std::string> resolver_addrs;
     resolver_addrs.reserve(resolvers.size());
     for (const auto& resolver : resolvers) {
+      // This should be an IP address (i.e. not a pipe).
+      if (resolver->ip() == nullptr) {
+        ares_destroy(channel_);
+        ares_library_cleanup();
+        throw EnvoyException(
+            fmt::format("DNS resolver '{}' is not an IP address", resolver->asString()));
+      }
       resolver_addrs.push_back(resolver->asString());
     }
     const std::string resolvers_csv = StringUtil::join(resolver_addrs, ",");

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -342,6 +342,15 @@ TEST(DnsImplConstructor, SupportsCustomResolvers) {
   ares_free_data(resolvers);
 }
 
+TEST(DnsImplConstructor, BadCustomResolvers) {
+  Event::DispatcherImpl dispatcher;
+  envoy::api::v2::core::Address pipe_address;
+  pipe_address.mutable_pipe()->set_path("foo");
+  auto pipe_instance = Network::Utility::protobufAddressToAddress(pipe_address);
+  EXPECT_THROW_WITH_MESSAGE(dispatcher.createDnsResolver({pipe_instance}), EnvoyException,
+                            "DNS resolver 'foo' is not an IP address");
+}
+
 class DnsImplTest : public testing::TestWithParam<Address::IpVersion> {
 public:
   void SetUp() override {


### PR DESCRIPTION
This was found via proto fuzzing the server config.

Risk Level: Low
Testing: New dns_impl_test for regression.

Signed-off-by: Harvey Tuch <htuch@google.com>