### PR TITLE
gzip filter: add missing FALLTHRU

### DIFF
--- a/source/common/compressor/zlib_compressor_impl.cc
+++ b/source/common/compressor/zlib_compressor_impl.cc
@@ -60,6 +60,7 @@ bool ZlibCompressorImpl::deflateNext(int64_t flush_state) {
       RELEASE_ASSERT(result == Z_STREAM_END);
       return false;
     }
+    FALLTHRU;
   default:
     if (result == Z_BUF_ERROR && zstream_ptr_->avail_in == 0) {
       return false; // This means that zlib needs more input, so stop here.


### PR DESCRIPTION
*Description*: This was causing a compiler warning internally.  I'm assuming the fallthrough behavior was intended here, but I'm not familiar with the gzip filter.

*Risk Level*: Low

*Testing*: N/A - no behavior change.

*Release Notes*: N/A
