### PR TITLE
Rename SharedMemoryHashSet to BlockMemoryHashSet

### DIFF
--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -179,8 +179,8 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "shared_memory_hash_set_lib",
-    hdrs = ["shared_memory_hash_set.h"],
+    name = "block_memory_hash_set_lib",
+    hdrs = ["block_memory_hash_set.h"],
     deps = [
         ":assert_lib",
         ":logger_lib",

--- a/source/common/common/block_memory_hash_set.h
+++ b/source/common/common/block_memory_hash_set.h
@@ -15,18 +15,18 @@
 namespace Envoy {
 
 /**
- * Initialization parameters for SharedMemoryHashSet. The options are duplicated
+ * Initialization parameters for BlockMemoryHashSet. The options are duplicated
  * to the control-block after init, to aid with sanity checking when attaching
  * an existing memory segment.
  */
-struct SharedMemoryHashSetOptions {
+struct BlockMemoryHashSetOptions {
   std::string toString() const {
     return fmt::format("capacity={}, num_slots={}", capacity, num_slots);
   }
-  bool operator==(const SharedMemoryHashSetOptions& that) const {
+  bool operator==(const BlockMemoryHashSetOptions& that) const {
     return capacity == that.capacity && num_slots == that.num_slots;
   }
-  bool operator!=(const SharedMemoryHashSetOptions& that) const { return !(*this == that); }
+  bool operator!=(const BlockMemoryHashSetOptions& that) const { return !(*this == that); }
 
   uint32_t capacity;  // how many values can be stored.
   uint32_t num_slots; // determines speed of hash vs size efficiency.
@@ -45,7 +45,7 @@ struct SharedMemoryHashSetOptions {
  * term storage, but not across machine architectures, as it doesn't
  * use network byte order for storing ints.
  */
-template <class Value> class SharedMemoryHashSet : public Logger::Loggable<Logger::Id::config> {
+template <class Value> class BlockMemoryHashSet : public Logger::Loggable<Logger::Id::config> {
 public:
   /**
    * Sentinal used for next_cell links to indicate end-of-list.
@@ -66,13 +66,13 @@ public:
    * Note that no locking of any kind is done by this class; this must be done at the
    * call-site to support concurrent access.
    */
-  SharedMemoryHashSet(const SharedMemoryHashSetOptions& options, bool init, uint8_t* memory)
+  BlockMemoryHashSet(const BlockMemoryHashSetOptions& options, bool init, uint8_t* memory)
       : cells_(nullptr), control_(nullptr), slots_(nullptr) {
     mapMemorySegments(options, memory);
     if (init) {
       initialize(options);
     } else if (!attach(options)) {
-      throw EnvoyException("SharedMemoryHashSet: Incompatible memory block");
+      throw EnvoyException("BlockMemoryHashSet: Incompatible memory block");
     }
   }
 
@@ -82,7 +82,7 @@ public:
    * backing-store (eg) in shared memory, which we do after
    * constructing the object with the desired sizing.
    */
-  static uint32_t numBytes(const SharedMemoryHashSetOptions& options) {
+  static uint32_t numBytes(const BlockMemoryHashSetOptions& options) {
     uint32_t size =
         cellOffset(options.capacity) + sizeof(Control) + options.num_slots * sizeof(uint32_t);
     return align(size);
@@ -93,7 +93,7 @@ public:
   /**
    * Returns the options structure that was used to construct the set.
    */
-  const SharedMemoryHashSetOptions& options() const { return control_->options; }
+  const BlockMemoryHashSetOptions& options() const { return control_->options; }
 
   /** Examines the data structures to see if they are sane, assert-failing on any trouble. */
   void sanityCheck() {
@@ -221,14 +221,14 @@ public:
   }
 
 private:
-  friend class SharedMemoryHashSetTest;
+  friend class BlockMemoryHashSetTest;
 
   /**
    * Initializes a hash-map on raw memory. No expectations are made about the state of the memory
    * coming in.
    * @param memory
    */
-  void initialize(const SharedMemoryHashSetOptions& options) {
+  void initialize(const BlockMemoryHashSetOptions& options) {
     control_->hash_signature = Value::hash(signatureStringToHash());
     control_->num_bytes = numBytes(options);
     control_->options = options;
@@ -254,14 +254,14 @@ private:
    * sanity check to make sure the options copied to the provided memory match, and also
    * that the slot, cell, and key-string structures look sane.
    */
-  bool attach(const SharedMemoryHashSetOptions& options) {
+  bool attach(const BlockMemoryHashSetOptions& options) {
     if (numBytes(options) != control_->num_bytes) {
-      ENVOY_LOG(error, "SharedMemoryHashSet unexpected memory size {} != {}", numBytes(options),
+      ENVOY_LOG(error, "BlockMemoryHashSet unexpected memory size {} != {}", numBytes(options),
                 control_->num_bytes);
       return false;
     }
     if (Value::hash(signatureStringToHash()) != control_->hash_signature) {
-      ENVOY_LOG(error, "SharedMemoryHashSet hash signature mismatch.");
+      ENVOY_LOG(error, "BlockMemoryHashSet hash signature mismatch.");
       return false;
     }
     sanityCheck();
@@ -290,11 +290,11 @@ private:
    * Represents control-values for the hash-table.
    */
   struct Control {
-    SharedMemoryHashSetOptions options; // Options established at map construction time.
-    uint64_t hash_signature;            // Hash of a constant signature string.
-    uint32_t num_bytes;                 // Bytes allocated on behalf of the map.
-    uint32_t size;                      // Number of values currently stored.
-    uint32_t free_cell_index;           // Offset of first free cell.
+    BlockMemoryHashSetOptions options; // Options established at map construction time.
+    uint64_t hash_signature;           // Hash of a constant signature string.
+    uint32_t num_bytes;                // Bytes allocated on behalf of the map.
+    uint32_t size;                     // Number of values currently stored.
+    uint32_t free_cell_index;          // Offset of first free cell.
   };
 
   /**
@@ -341,7 +341,7 @@ private:
   }
 
   /** Maps out the segments of shared memory for us to work with. */
-  void mapMemorySegments(const SharedMemoryHashSetOptions& options, uint8_t* memory) {
+  void mapMemorySegments(const BlockMemoryHashSetOptions& options, uint8_t* memory) {
     // Note that we are not examining or mutating memory here, just looking at the pointer,
     // so we don't need to hold any locks.
     cells_ = reinterpret_cast<Cell*>(memory); // First because Value may need to be aligned.

--- a/source/common/common/block_memory_hash_set.h
+++ b/source/common/common/block_memory_hash_set.h
@@ -58,7 +58,7 @@ public:
   /**
    * Constructs a map control structure given a set of options, which cannot be changed.
    * @param options describes the parameters comtrolling set layout.
-   * @param init true if the shared-memory should be initialized on construction. If false,
+   * @param init true if the memory should be initialized on construction. If false,
    *             the data in the table will be sanity checked, and an exception thrown if
    *             it is incoherent or mismatches the passed-in options.
    * @param memory the memory buffer for the set data.
@@ -79,7 +79,7 @@ public:
   /**
    * Returns the numbers of byte required for the hash-table, based on
    * the control structure. This must be used to allocate the
-   * backing-store (eg) in shared memory, which we do after
+   * backing-store (eg) in memory, which we do after
    * constructing the object with the desired sizing.
    */
   static uint32_t numBytes(const BlockMemoryHashSetOptions& options) {
@@ -250,7 +250,7 @@ private:
   }
 
   /**
-   * Attempts to attach to an existing shared memory segment. Does a (relatively) quick
+   * Attempts to attach to an existing memory segment. Does a (relatively) quick
    * sanity check to make sure the options copied to the provided memory match, and also
    * that the slot, cell, and key-string structures look sane.
    */
@@ -340,7 +340,7 @@ private:
     return *reinterpret_cast<Cell*>(ptr);
   }
 
-  /** Maps out the segments of shared memory for us to work with. */
+  /** Maps out the segments of memory for us to work with. */
   void mapMemorySegments(const BlockMemoryHashSetOptions& options, uint8_t* memory) {
     // Note that we are not examining or mutating memory here, just looking at the pointer,
     // so we don't need to hold any locks.
@@ -351,7 +351,7 @@ private:
     slots_ = reinterpret_cast<uint32_t*>(memory);
   }
 
-  // Pointers into shared memory. Cells go first, because Value may need a more aggressive
+  // Pointers into memory. Cells go first, because Value may need a more aggressive
   // aligmnment.
   Cell* cells_;
   Control* control_;

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -217,19 +217,19 @@ struct RawStatData {
 
   /**
    * Returns the size of this struct, accounting for the length of name_
-   * and padding for alignment. This is required by SharedMemoryHashSet.
+   * and padding for alignment. This is required by BlockMemoryHashSet.
    */
   static size_t size();
 
   /**
    * Initializes this object to have the specified key,
    * a refcount of 1, and all other values zero. This is required by
-   * SharedMemoryHashSet.
+   * BlockMemoryHashSet.
    */
   void initialize(absl::string_view key);
 
   /**
-   * Returns a hash of the key. This is required by SharedMemoryHashSet.
+   * Returns a hash of the key. This is required by BlockMemoryHashSet.
    */
   static uint64_t hash(absl::string_view key) { return HashUtil::xxHash64(key); }
 
@@ -239,7 +239,7 @@ struct RawStatData {
   bool initialized() { return name_[0] != '\0'; }
 
   /**
-   * Returns the name as a string_view. This is required by SharedMemoryHashSet.
+   * Returns the name as a string_view. This is required by BlockMemoryHashSet.
    */
   absl::string_view key() const {
     return absl::string_view(name_, strnlen(name_, maxNameLength()));

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -116,7 +116,7 @@ envoy_cc_library(
         "//include/envoy/server:options_interface",
         "//source/common/api:os_sys_calls_lib",
         "//source/common/common:assert_lib",
-        "//source/common/common:shared_memory_hash_set_lib",
+        "//source/common/common:block_memory_hash_set_lib",
         "//source/common/common:utility_lib",
         "//source/common/network:utility_lib",
         "//source/common/stats:stats_lib",

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -119,7 +119,7 @@ HotRestartImpl::HotRestartImpl(Options& options)
       log_lock_(shmem_.log_lock_), access_log_lock_(shmem_.access_log_lock_),
       stat_lock_(shmem_.stat_lock_), init_lock_(shmem_.init_lock_) {
   {
-    // We must hold the stat lock when attaching to an existing shared-memory segment
+    // We must hold the stat lock when attaching to an existing memory segment
     // because it might be actively written to while we sanityCheck it.
     std::unique_lock<Thread::BasicLockable> lock(stat_lock_);
     stats_set_.reset(new RawStatDataSet(stats_set_options_, options.restartEpoch() == 0,

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -27,8 +27,8 @@ namespace Server {
 // from working. Operations code can then cope with this and do a full restart.
 const uint64_t SharedMemory::VERSION = 9;
 
-static SharedMemoryHashSetOptions sharedMemHashOptions(uint64_t max_stats) {
-  SharedMemoryHashSetOptions hash_set_options;
+static BlockMemoryHashSetOptions blockMemHashOptions(uint64_t max_stats) {
+  BlockMemoryHashSetOptions hash_set_options;
   hash_set_options.capacity = max_stats;
 
   // https://stackoverflow.com/questions/3980117/hash-table-why-size-should-be-prime
@@ -43,7 +43,7 @@ SharedMemory& SharedMemory::initialize(uint32_t stats_set_size, Options& options
   const uint64_t total_size = sizeof(SharedMemory) + stats_set_size;
 
   int flags = O_RDWR;
-  const std::string shmem_name = fmt::format("/envoy_shared_memory_{}", options.baseId());
+  const std::string shmem_name = fmt::format("/envoy_block_memory_{}", options.baseId());
   if (options.restartEpoch() == 0) {
     flags |= O_CREAT | O_EXCL;
 
@@ -114,7 +114,7 @@ std::string SharedMemory::version(size_t max_num_stats, size_t max_stat_name_len
 }
 
 HotRestartImpl::HotRestartImpl(Options& options)
-    : options_(options), stats_set_options_(sharedMemHashOptions(options.maxStats())),
+    : options_(options), stats_set_options_(blockMemHashOptions(options.maxStats())),
       shmem_(SharedMemory::initialize(RawStatDataSet::numBytes(stats_set_options_), options)),
       log_lock_(shmem_.log_lock_), access_log_lock_(shmem_.access_log_lock_),
       stat_lock_(shmem_.stat_lock_), init_lock_(shmem_.init_lock_) {
@@ -150,7 +150,7 @@ Stats::RawStatData* HotRestartImpl::alloc(const std::string& name) {
   if (data == nullptr) {
     return nullptr;
   }
-  // For new entries (value-created.second==true), SharedMemoryHashSet calls Value::initialize()
+  // For new entries (value-created.second==true), BlockMemoryHashSet calls Value::initialize()
   // automatically, but on recycled entries (value-created.second==false) we need to bump the
   // ref-count.
   if (!value_created.second) {
@@ -478,7 +478,7 @@ std::string HotRestartImpl::version() {
 // Called from envoy --hot-restart-version -- needs to instantiate a RawStatDataSet so it
 // can generate the version string.
 std::string HotRestartImpl::hotRestartVersion(size_t max_num_stats, size_t max_stat_name_len) {
-  const SharedMemoryHashSetOptions options = sharedMemHashOptions(max_num_stats);
+  const BlockMemoryHashSetOptions options = blockMemHashOptions(max_num_stats);
   const size_t bytes = RawStatDataSet::numBytes(options);
   std::unique_ptr<uint8_t[]> mem_buffer_for_dry_run_(new uint8_t[bytes]);
   RawStatDataSet stats_set(options, true /* init */, mem_buffer_for_dry_run_.get());

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -43,7 +43,7 @@ SharedMemory& SharedMemory::initialize(uint32_t stats_set_size, Options& options
   const uint64_t total_size = sizeof(SharedMemory) + stats_set_size;
 
   int flags = O_RDWR;
-  const std::string shmem_name = fmt::format("/envoy_block_memory_{}", options.baseId());
+  const std::string shmem_name = fmt::format("/envoy_shared_memory_{}", options.baseId());
   if (options.restartEpoch() == 0) {
     flags |= O_CREAT | O_EXCL;
 

--- a/source/server/hot_restart_impl.h
+++ b/source/server/hot_restart_impl.h
@@ -12,13 +12,13 @@
 #include "envoy/server/options.h"
 
 #include "common/common/assert.h"
-#include "common/common/shared_memory_hash_set.h"
+#include "common/common/block_memory_hash_set.h"
 #include "common/stats/stats_impl.h"
 
 namespace Envoy {
 namespace Server {
 
-typedef SharedMemoryHashSet<Stats::RawStatData> RawStatDataSet;
+typedef BlockMemoryHashSet<Stats::RawStatData> RawStatDataSet;
 
 /**
  * Shared memory segment. This structure is laid directly into shared memory and is used amongst
@@ -64,7 +64,7 @@ private:
   pthread_mutex_t access_log_lock_;
   pthread_mutex_t stat_lock_;
   pthread_mutex_t init_lock_;
-  alignas(SharedMemoryHashSet<Stats::RawStatData>) uint8_t stats_set_data_[];
+  alignas(BlockMemoryHashSet<Stats::RawStatData>) uint8_t stats_set_data_[];
 
   friend class HotRestartImpl;
 };
@@ -207,7 +207,7 @@ private:
                                    RawStatDataSet& stats_set);
 
   Options& options_;
-  SharedMemoryHashSetOptions stats_set_options_;
+  BlockMemoryHashSetOptions stats_set_options_;
   SharedMemory& shmem_;
   std::unique_ptr<RawStatDataSet> stats_set_;
   ProcessSharedMutex log_lock_;

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -115,11 +115,11 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
-    name = "shared_memory_hash_set_test",
-    srcs = ["shared_memory_hash_set_test.cc"],
+    name = "block_memory_hash_set_test",
+    srcs = ["block_memory_hash_set_test.cc"],
     deps = [
+        "//source/common/common:block_memory_hash_set_lib",
         "//source/common/common:hash_lib",
-        "//source/common/common:shared_memory_hash_set_lib",
     ],
 )
 


### PR DESCRIPTION
Signed-off-by: James Buckland <jbuckland@google.com>

*Title*: Rename SharedMemoryHashSet to BlockMemoryHashSet

*Description*: The class currently named SharedMemoryHashSet has no specific bias towards shared or non-shared memory, instead accepts a pointer to the buffer in memory for the set data. 

For context, a solution for https://github.com/envoyproxy/envoy/issues/2453 could use this hash set to implement reference counting across scopes. It would not necessarily need to run in shared memory.

*Risk Level*: Low

*Testing*: N/A - no behavior change.

*Docs Changes*: N/A, this is not user-facing.

*Release Notes*: N/A