### PR TITLE
ssl: fix ASSERT when wrong number of certs/hashes in config.

### DIFF
--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -425,6 +425,9 @@ ServerContextImpl::ServerContextImpl(ContextManagerImpl& parent, const std::stri
     : ContextImpl(parent, scope, config), listener_name_(listener_name),
       server_names_(server_names), skip_context_update_(skip_context_update), runtime_(runtime),
       session_ticket_keys_(config.sessionTicketKeys()) {
+  if (config.certChain().empty()) {
+    throw EnvoyException("Server TlsCertificates must have a certificate specified");
+  }
   SSL_CTX_set_select_certificate_cb(
       ctx_.get(), [](const SSL_CLIENT_HELLO* client_hello) -> ssl_select_cert_result_t {
         ContextImpl* context_impl = static_cast<ContextImpl*>(

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -354,7 +354,7 @@ TEST(ClientContextConfigImplTest, MultipleTlsCertificates) {
 // Multiple TLS certificates are not yet supported, but one is expected for
 // server.
 // TODO(PiotrSikora): Support multiple TLS certificates.
-TEST(ServerContextConfigImplTicketTest, MultipleTlsCertificates) {
+TEST(ServerContextConfigImplTest, MultipleTlsCertificates) {
   envoy::api::v2::auth::DownstreamTlsContext tls_context;
   EXPECT_THROW_WITH_MESSAGE(ServerContextConfigImpl client_context_config(tls_context),
                             EnvoyException,
@@ -364,6 +364,20 @@ TEST(ServerContextConfigImplTicketTest, MultipleTlsCertificates) {
   EXPECT_THROW_WITH_MESSAGE(ServerContextConfigImpl client_context_config(tls_context),
                             EnvoyException,
                             "A single TLS certificate is required for server contexts");
+}
+
+// TlsCertificate messages must have a cert for servers.
+TEST(ServerContextImplTest, TlsCertificateNonEmpty) {
+  envoy::api::v2::auth::DownstreamTlsContext tls_context;
+  tls_context.mutable_common_tls_context()->add_tls_certificates();
+  ServerContextConfigImpl client_context_config(tls_context);
+  Runtime::MockLoader runtime;
+  ContextManagerImpl manager(runtime);
+  Stats::IsolatedStoreImpl store;
+  EXPECT_THROW_WITH_MESSAGE(ServerContextPtr server_ctx(manager.createSslServerContext(
+                                "", {}, store, client_context_config, true)),
+                            EnvoyException,
+                            "Server TlsCertificates must have a certificate specified");
 }
 
 } // namespace Ssl

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -325,5 +325,46 @@ TEST_F(SslServerContextImplTicketTest, CRLWithNoCA) {
                           "^Failed to load CRL from .* without trusted CA certificates$");
 }
 
+// Multiple certificate hashes are not yet supported.
+// TODO(htuch): Support multiple hashes.
+TEST(ClientContextConfigImplTest, MultipleValidationHashes) {
+  envoy::api::v2::auth::UpstreamTlsContext tls_context;
+  tls_context.mutable_common_tls_context()
+      ->mutable_validation_context()
+      ->add_verify_certificate_hash();
+  tls_context.mutable_common_tls_context()
+      ->mutable_validation_context()
+      ->add_verify_certificate_hash();
+  EXPECT_THROW_WITH_MESSAGE(ClientContextConfigImpl client_context_config(tls_context),
+                            EnvoyException,
+                            "Multiple TLS certificate verification hashes are not supported");
+}
+
+// Multiple TLS certificates are not yet supported.
+// TODO(PiotrSikora): Support multiple TLS certificates.
+TEST(ClientContextConfigImplTest, MultipleTlsCertificates) {
+  envoy::api::v2::auth::UpstreamTlsContext tls_context;
+  tls_context.mutable_common_tls_context()->add_tls_certificates();
+  tls_context.mutable_common_tls_context()->add_tls_certificates();
+  EXPECT_THROW_WITH_MESSAGE(ClientContextConfigImpl client_context_config(tls_context),
+                            EnvoyException,
+                            "Multiple TLS certificates are not supported for client contexts");
+}
+
+// Multiple TLS certificates are not yet supported, but one is expected for
+// server.
+// TODO(PiotrSikora): Support multiple TLS certificates.
+TEST(ServerContextConfigImplTicketTest, MultipleTlsCertificates) {
+  envoy::api::v2::auth::DownstreamTlsContext tls_context;
+  EXPECT_THROW_WITH_MESSAGE(ServerContextConfigImpl client_context_config(tls_context),
+                            EnvoyException,
+                            "A single TLS certificate is required for server contexts");
+  tls_context.mutable_common_tls_context()->add_tls_certificates();
+  tls_context.mutable_common_tls_context()->add_tls_certificates();
+  EXPECT_THROW_WITH_MESSAGE(ServerContextConfigImpl client_context_config(tls_context),
+                            EnvoyException,
+                            "A single TLS certificate is required for server contexts");
+}
+
 } // namespace Ssl
 } // namespace Envoy


### PR DESCRIPTION
This was found via proto fuzzing the server config.

Risk Level: Low
Testing: New context_impl_tests for regression.

Signed-off-by: Harvey Tuch <htuch@google.com>