### PR TITLE
fuzz: server config fuzz test.

### DIFF
--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -2,10 +2,15 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_fuzz_test",
     "envoy_cc_test",
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_select_hot_restart",
+)
+load(
+    "//source/extensions:all_extensions.bzl",
+    "envoy_all_extensions",
 )
 
 envoy_package()
@@ -149,6 +154,20 @@ envoy_cc_test(
         "//source/server:listener_socket_option_lib",
         "//test/common/network:socket_option_test_harness",
     ],
+)
+
+envoy_cc_fuzz_test(
+    name = "server_fuzz_test",
+    srcs = ["server_fuzz_test.cc"],
+    corpus = "server_corpus",
+    deps = [
+        "//source/common/thread_local:thread_local_lib",
+        "//source/server:server_lib",
+        "//test/integration:integration_lib",
+        "//test/mocks/server:server_mocks",
+        "//test/mocks/stats:stats_mocks",
+        "//test/test_common:environment_lib",
+    ] + envoy_all_extensions(),
 )
 
 envoy_cc_test(

--- a/test/server/server_corpus/google_com_proxy.v2.pb_text
+++ b/test/server/server_corpus/google_com_proxy.v2.pb_text
@@ -1,0 +1,150 @@
+static_resources {
+  listeners {
+    name: "listener_0"
+    address {
+      socket_address {
+        address: "0.0.0.0"
+        port_value: 10000
+      }
+    }
+    filter_chains {
+      filters {
+        name: "envoy.http_connection_manager"
+        config {
+          fields {
+            key: "http_filters"
+            value {
+              list_value {
+                values {
+                  struct_value {
+                    fields {
+                      key: "name"
+                      value {
+                        string_value: "envoy.router"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          fields {
+            key: "route_config"
+            value {
+              struct_value {
+                fields {
+                  key: "name"
+                  value {
+                    string_value: "local_route"
+                  }
+                }
+                fields {
+                  key: "virtual_hosts"
+                  value {
+                    list_value {
+                      values {
+                        struct_value {
+                          fields {
+                            key: "domains"
+                            value {
+                              list_value {
+                                values {
+                                  string_value: "*"
+                                }
+                              }
+                            }
+                          }
+                          fields {
+                            key: "name"
+                            value {
+                              string_value: "local_service"
+                            }
+                          }
+                          fields {
+                            key: "routes"
+                            value {
+                              list_value {
+                                values {
+                                  struct_value {
+                                    fields {
+                                      key: "match"
+                                      value {
+                                        struct_value {
+                                          fields {
+                                            key: "prefix"
+                                            value {
+                                              string_value: "/"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                    fields {
+                                      key: "route"
+                                      value {
+                                        struct_value {
+                                          fields {
+                                            key: "cluster"
+                                            value {
+                                              string_value: "service_google"
+                                            }
+                                          }
+                                          fields {
+                                            key: "host_rewrite"
+                                            value {
+                                              string_value: "www.google.com"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          fields {
+            key: "stat_prefix"
+            value {
+              string_value: "ingress_http"
+            }
+          }
+        }
+      }
+    }
+  }
+  clusters {
+    name: "service_google"
+    type: LOGICAL_DNS
+    connect_timeout {
+      nanos: 250000000
+    }
+    hosts {
+      socket_address {
+        address: "google.com"
+        port_value: 443
+      }
+    }
+    tls_context {
+      sni: "www.google.com"
+    }
+    dns_lookup_family: V4_ONLY
+  }
+}
+admin {
+  access_log_path: "/tmp/admin_access.log"
+  address {
+    socket_address {
+      address: "127.0.0.1"
+      port_value: 9901
+    }
+  }
+}

--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -1,0 +1,45 @@
+#include <fstream>
+
+#include "common/network/address_impl.h"
+#include "common/thread_local/thread_local_impl.h"
+
+#include "server/server.h"
+#include "server/test_hooks.h"
+
+#include "test/fuzz/fuzz_runner.h"
+#include "test/integration/server.h"
+#include "test/mocks/server/mocks.h"
+#include "test/mocks/stats/mocks.h"
+#include "test/test_common/environment.h"
+
+namespace Envoy {
+namespace Server {
+
+DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v2::Bootstrap& input) {
+  testing::NiceMock<MockOptions> options;
+  DefaultTestHooks hooks;
+  testing::NiceMock<MockHotRestart> restart;
+  Stats::TestIsolatedStoreImpl stats_store;
+  Thread::MutexBasicLockable fakelock;
+  TestComponentFactory component_factory;
+  ThreadLocal::InstanceImpl thread_local_instance;
+
+  {
+    const std::string bootstrap_path = TestEnvironment::temporaryPath("bootstrap.pb_text");
+    std::ofstream bootstrap_file(bootstrap_path);
+    bootstrap_file << input.DebugString();
+    options.config_path_ = bootstrap_path;
+    options.v2_config_only_ = true;
+  }
+
+  try {
+    auto server = std::make_unique<InstanceImpl>(
+        options, std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1"), hooks, restart,
+        stats_store, fakelock, component_factory, thread_local_instance);
+  } catch (const EnvoyException& ex) {
+    ENVOY_LOG_MISC(debug, "Controlled EnvoyException exit: {}", ex.what());
+  }
+}
+
+} // namespace Server
+} // namespace Envoy

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -39,6 +39,16 @@ std::string getOrCreateUnixDomainSocketDirectory() {
   return std::string(test_udsdir);
 }
 
+std::string getTemporaryDirectory() {
+  if (::getenv("TEST_TMPDIR")) {
+    return TestEnvironment::getCheckedEnvVar("TEST_TMPDIR");
+  }
+  if (::getenv("TMPDIR")) {
+    return TestEnvironment::getCheckedEnvVar("TMPDIR");
+  }
+  return "/tmp";
+}
+
 // Allow initializeOptions() to remember CLI args for getOptions().
 int argc_;
 char** argv_;
@@ -93,7 +103,7 @@ Server::Options& TestEnvironment::getOptions() {
 }
 
 const std::string& TestEnvironment::temporaryDirectory() {
-  CONSTRUCT_ON_FIRST_USE(std::string, getCheckedEnvVar("TEST_TMPDIR"));
+  CONSTRUCT_ON_FIRST_USE(std::string, getTemporaryDirectory());
 }
 
 const std::string& TestEnvironment::runfilesDirectory() {

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -2,6 +2,7 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_binary",
     "envoy_package",
     "envoy_py_test_binary",
 )
@@ -21,5 +22,15 @@ envoy_py_test_binary(
     name = "socket_passing",
     srcs = [
         "socket_passing.py",
+    ],
+)
+
+envoy_cc_binary(
+    name = "bootstrap2pb",
+    srcs = ["bootstrap2pb.cc"],
+    deps = [
+        "//source/common/common:assert_lib",
+        "//source/common/protobuf:utility_lib",
+        "@envoy_api//envoy/config/bootstrap/v2:bootstrap_cc",
     ],
 )

--- a/tools/bootstrap2pb.cc
+++ b/tools/bootstrap2pb.cc
@@ -1,0 +1,29 @@
+/**
+ * Utility to convert bootstrap from its YAML/JSON/proto representation to text
+ * proto.
+ *
+ * Usage:
+ *
+ * bootstrap2pb <input YAML/JSON/proto path> <output text proto path>
+ */
+#include <cstdlib>
+#include <fstream>
+
+#include "envoy/config/bootstrap/v2/bootstrap.pb.h"
+
+#include "common/common/assert.h"
+#include "common/protobuf/utility.h"
+
+// NOLINT(namespace-envoy)
+int main(int argc, char** argv) {
+  if (argc != 3) {
+    std::cerr << "Usage: " << argv[0] << " <input YAML/JSON/proto path> <output text text path>"
+              << std::endl;
+    return EXIT_FAILURE;
+  }
+  envoy::config::bootstrap::v2::Bootstrap bootstrap;
+  Envoy::MessageUtil::loadFromFile(argv[1], bootstrap);
+  std::ofstream bootstrap_file(argv[2]);
+  bootstrap_file << bootstrap.DebugString();
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This fuzzes the bootstrap config message with similar infrastructure to
what is used in server_test. So far, we've found 3 bugs with
corresponding PRs.

Also added tools/bootstrap2pb utility, which makes it easy to generate
the text proto input for the fuzzer corpus.

Risk Level: Low
Testing: run under oss-fuzz Docker image, found bugs.

Signed-off-by: Harvey Tuch <htuch@google.com>
