### PR TITLE
stats: remove repeated tracing. string in admin tracing stat names

### DIFF
--- a/source/server/http/BUILD
+++ b/source/server/http/BUILD
@@ -49,6 +49,7 @@ envoy_cc_library(
         "//source/common/network:raw_buffer_socket_lib",
         "//source/common/profiler:profiler_lib",
         "//source/common/router:config_lib",
+        "//source/common/stats:stats_lib",
         "//source/common/upstream:host_utility_lib",
         "//source/extensions/access_loggers/file:file_access_log_lib",
         "@envoy_api//envoy/admin/v2:config_dump_cc",

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -685,8 +685,8 @@ AdminImpl::AdminImpl(const std::string& access_log_path, const std::string& prof
     : server_(server), profile_path_(profile_path),
       socket_(new Network::TcpListenSocket(address, nullptr, true)),
       stats_(Http::ConnectionManagerImpl::generateStats("http.admin.", server_.stats())),
-      tracing_stats_(Http::ConnectionManagerImpl::generateTracingStats("http.admin.tracing.",
-                                                                       server_.stats())),
+      tracing_stats_(
+          Http::ConnectionManagerImpl::generateTracingStats("http.admin.", server_.stats())),
       handlers_{
           {"/", "Admin home page", MAKE_ADMIN_HANDLER(handlerAdminHome), false, false},
           {"/certs", "print certs on machine", MAKE_ADMIN_HANDLER(handlerCerts), false, false},

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -686,7 +686,7 @@ AdminImpl::AdminImpl(const std::string& access_log_path, const std::string& prof
       socket_(new Network::TcpListenSocket(address, nullptr, true)),
       stats_(Http::ConnectionManagerImpl::generateStats("http.admin.", server_.stats())),
       tracing_stats_(
-          Http::ConnectionManagerImpl::generateTracingStats("http.admin.", server_.stats())),
+          Http::ConnectionManagerImpl::generateTracingStats("http.admin.", no_op_store_)),
       handlers_{
           {"/", "Admin home page", MAKE_ADMIN_HANDLER(handlerAdminHome), false, false},
           {"/certs", "print certs on machine", MAKE_ADMIN_HANDLER(handlerCerts), false, false},

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -215,7 +215,7 @@ private:
   Network::RawBufferSocketFactory transport_socket_factory_;
   Http::ConnectionManagerStats stats_;
   // Note: this is here to essentially blackhole the tracing stats since they aren't used in the
-  // Admin case, so there's no reason to export them to the sinks.
+  // Admin case.
   Stats::IsolatedStoreImpl no_op_store_;
   Http::ConnectionManagerTracingStats tracing_stats_;
   NullRouteConfigProvider route_config_provider_;

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -23,6 +23,7 @@
 #include "common/http/default_server_string.h"
 #include "common/http/utility.h"
 #include "common/network/raw_buffer_socket.h"
+#include "common/stats/stats_impl.h"
 
 #include "server/http/config_tracker_impl.h"
 
@@ -213,6 +214,9 @@ private:
   Network::SocketPtr socket_;
   Network::RawBufferSocketFactory transport_socket_factory_;
   Http::ConnectionManagerStats stats_;
+  // Note: this is here to essentially blackhole the tracing stats since they aren't used in the
+  // Admin case, so there's no reason to export them to the sinks.
+  Stats::IsolatedStoreImpl no_op_store_;
   Http::ConnectionManagerTracingStats tracing_stats_;
   NullRouteConfigProvider route_config_provider_;
   std::list<UrlHandler> handlers_;

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -369,6 +369,13 @@ TEST_P(AdminInstanceTest, RuntimeModifyNoArguments) {
   EXPECT_TRUE(absl::StartsWith(TestUtility::bufferToString(response), "usage:"));
 }
 
+TEST_P(AdminInstanceTest, TracingStatsDisabled) {
+  const std::string& name = admin_.tracingStats().service_forced_.name();
+  for (Stats::CounterSharedPtr counter : server_.stats().counters()) {
+    EXPECT_NE(counter->name(), name) << "Unexpected tracing stat found in server stats: " << name;
+  }
+}
+
 TEST(PrometheusStatsFormatter, MetricName) {
   std::string raw = "vulture.eats-liver";
   std::string expected = "envoy_vulture_eats_liver";


### PR DESCRIPTION
*Description*: The admin tracing stats were being produced under "admin.tracing.tracing..." as detailed in #3135.  Fixes #3135.

*Risk Level*: Low
*Testing*: Unit tested.
*Docs Changes*: N/A
*Release Notes*: N/A