### PR TITLE
grpc-json: fix unit test response headers

### DIFF
--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -258,12 +258,10 @@ TEST_F(GrpcJsonTranscoderFilterTest, NoTranscoding) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_trailers));
 
   Http::TestHeaderMapImpl response_headers{{"content-type", "application/grpc"},
-                                           {":status", "200"},
-                                           {":path", "/grpc.service/UnknownGrpcMethod"}};
+                                           {":status", "200"}};
 
   Http::TestHeaderMapImpl expected_response_headers{{"content-type", "application/grpc"},
-                                                    {":status", "200"},
-                                                    {":path", "/grpc.service/UnknownGrpcMethod"}};
+                                                    {":status", "200"}};
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(response_headers, false));
   EXPECT_EQ(expected_response_headers, response_headers);


### PR DESCRIPTION
Risk Level: Low
Testing: `bazel test //test/extensions/filters/http/grpc_json_transcoder:json_transcoder_filter_test`
Docs Changes: N/A
Release Notes: N/A