### PR TITLE
connection: Add TCP_FASTOPEN listener option (continuation)

### DIFF
--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -154,8 +154,8 @@ envoy_cc_test(
 )
 
 envoy_cc_test_library(
-    name = "socket_option_test_harness",
-    srcs = ["socket_option_test_harness.h"],
+    name = "socket_option_test",
+    srcs = ["socket_option_test.h"],
     deps = [
         "//source/common/network:address_lib",
         "//source/common/network:socket_option_lib",
@@ -171,7 +171,7 @@ envoy_cc_test(
     name = "socket_option_impl_test",
     srcs = ["socket_option_impl_test.cc"],
     deps = [
-        ":socket_option_test_harness",
+        ":socket_option_test",
     ],
 )
 

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -111,8 +111,10 @@ TEST_P(ListenerImplTest, SetListeningSocketOptionsError) {
   std::shared_ptr<MockSocketOption> option = std::make_shared<MockSocketOption>();
   socket.addOption(option);
   EXPECT_CALL(*option, setOption(_, Socket::SocketState::Listening)).WillOnce(Return(false));
-  EXPECT_THROW(TestListenerImpl(dispatcher, socket, listener_callbacks, true, false),
-               CreateListenerException);
+  EXPECT_THROW_WITH_MESSAGE(TestListenerImpl(dispatcher, socket, listener_callbacks, true, false),
+                            CreateListenerException,
+                            fmt::format("cannot set post-listen socket option on socket: {}",
+                                        socket.localAddress()->asString()));
 }
 
 TEST_P(ListenerImplTest, UseActualDst) {

--- a/test/common/network/socket_option_impl_test.cc
+++ b/test/common/network/socket_option_impl_test.cc
@@ -1,10 +1,10 @@
-#include "test/common/network/socket_option_test_harness.h"
+#include "test/common/network/socket_option_test.h"
 
 namespace Envoy {
 namespace Network {
 namespace {
 
-class SocketOptionImplTest : public SocketOptionTestHarness {};
+class SocketOptionImplTest : public SocketOptionTest {};
 
 // We fail to set the option if the socket FD is bad.
 TEST_F(SocketOptionImplTest, BadFd) {

--- a/test/common/network/socket_option_test.h
+++ b/test/common/network/socket_option_test.h
@@ -17,9 +17,9 @@ namespace Envoy {
 namespace Network {
 namespace {
 
-class SocketOptionTestHarness : public testing::Test {
+class SocketOptionTest : public testing::Test {
 public:
-  SocketOptionTestHarness() { socket_.local_address_.reset(); }
+  SocketOptionTest() { socket_.local_address_.reset(); }
 
   NiceMock<MockListenSocket> socket_;
   Api::MockOsSysCalls os_sys_calls_;

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -152,7 +152,7 @@ envoy_cc_test(
     srcs = ["listener_socket_option_impl_test.cc"],
     deps = [
         "//source/server:listener_socket_option_lib",
-        "//test/common/network:socket_option_test_harness",
+        "//test/common/network:socket_option_test",
     ],
 )
 

--- a/test/server/listener_socket_option_impl_test.cc
+++ b/test/server/listener_socket_option_impl_test.cc
@@ -1,17 +1,17 @@
 #include "server/listener_socket_option_impl.h"
 
-#include "test/common/network/socket_option_test_harness.h"
+#include "test/common/network/socket_option_test.h"
 
 namespace Envoy {
 namespace Server {
 
-class ListenerSocketOptionImplTest : public Network::SocketOptionTestHarness {
+class ListenerSocketOptionImplTest : public Network::SocketOptionTest {
 public:
   void testSetSocketOptionSuccess(ListenerSocketOptionImpl& socket_option, int socket_level,
                                   Network::SocketOptionName option_name, int option_val,
                                   const std::set<Network::Socket::SocketState>& when) {
-    Network::SocketOptionTestHarness::testSetSocketOptionSuccess(socket_option, socket_level,
-                                                                 option_name, option_val, when);
+    Network::SocketOptionTest::testSetSocketOptionSuccess(socket_option, socket_level, option_name,
+                                                          option_val, when);
   }
 };
 


### PR DESCRIPTION
This is addressing the last unaddressed comments from #2793

*Done* here:

https://github.com/envoyproxy/envoy/pull/2793#discussion-diff-182437803R20
Rename socket_option_test_harness to socket_option_test

https://github.com/envoyproxy/envoy/pull/2793#discussion-diff-181290693R15
Tested with `if 0` on both Linux and macOS. All tests still pass.

https://github.com/envoyproxy/envoy/pull/2793#discussion-diff-181290864R114
Changed to EXPECT_THROW_WITH_MESSAGE


Still *TODO*:

missing test coverage
https://github.com/envoyproxy/envoy/pull/2793#discussion-diff-182258992R43

setTcpSocketOption
https://github.com/envoyproxy/envoy/pull/2793#discussion-diff-179304507R44

@htuch @ggreenway 