### PR TITLE
Fix issue with Envoy not reference counting across scopes under not-hot restart

### DIFF
--- a/source/common/stats/BUILD
+++ b/source/common/stats/BUILD
@@ -17,6 +17,7 @@ envoy_cc_library(
         "//include/envoy/server:options_interface",
         "//include/envoy/stats:stats_interface",
         "//source/common/common:assert_lib",
+        "//source/common/common:block_memory_hash_set_lib",
         "//source/common/common:hash_lib",
         "//source/common/common:perf_annotation_lib",
         "//source/common/common:utility_lib",

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -35,6 +35,15 @@ bool regexStartsWithDot(absl::string_view regex) {
 
 } // namespace
 
+BlockMemoryHashSetOptions blockMemHashOptions(uint64_t max_stats) {
+  BlockMemoryHashSetOptions hash_set_options;
+  hash_set_options.capacity = max_stats;
+
+  // https://stackoverflow.com/questions/3980117/hash-table-why-size-should-be-prime
+  hash_set_options.num_slots = Primes::findPrimeLargerThan(hash_set_options.capacity / 2);
+  return hash_set_options;
+}
+
 size_t RawStatData::size() {
   // Normally the compiler would do this, but because name_ is a flexible-array-length
   // element, the compiler can't. RawStatData is put into an array in HotRestartImpl, so

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -17,6 +17,7 @@
 #include "envoy/stats/stats.h"
 
 #include "common/common/assert.h"
+#include "common/common/block_memory_hash_set.h"
 #include "common/common/hash.h"
 #include "common/common/utility.h"
 #include "common/protobuf/protobuf.h"
@@ -25,6 +26,8 @@
 
 namespace Envoy {
 namespace Stats {
+
+typedef BlockMemoryHashSet<Stats::RawStatData> RawStatDataSet;
 
 class TagExtractorImpl : public TagExtractor {
 public:
@@ -370,12 +373,43 @@ public:
 };
 
 /**
- * Implementation of RawStatDataAllocator that just allocates a new structure in memory and returns
- * it.
+ * Implementation of RawStatDataAllocator which accepts a block of (potentially shared) memory.
+ */
+class BlockRawStatDataAllocator : public RawStatDataAllocator {
+public:
+  /**
+   * Creates a RawStatDataAllocator with an underlying MemoryHashMap to track stat names. Optionally
+   * works with shared memory, as in HotRestartImpl. Thread-safe but requires a lock as argument.
+   * @param options initialization parameters for BlockMemoryHashSet
+   * @param init true if the shared-memory should be initialized on construction. See the
+   * BlockMemoryHashSet constructor.
+   * @param memory the memory buffer for the set data.
+   * @param stat_lock a lock for thread safety.
+   * @return BlockRawStatDataAllocator newly constructed BlockRawStatDataAllocator.
+   */
+  BlockRawStatDataAllocator(const BlockMemoryHashSetOptions& options, bool init, uint8_t* memory,
+                            Thread::BasicLockable& stat_lock)
+      : stat_lock_(stat_lock) {
+    stats_set_ = std::make_unique<RawStatDataSet>(options, init, memory);
+  }
+
+  RawStatData* alloc(const std::string& name);
+  void free(RawStatData& data);
+  std::string version() { return stats_set_->version(); }
+
+private:
+  std::unique_ptr<RawStatDataSet> stats_set_;
+  // We must hold the stat lock when attaching to an existing memory segment
+  // because it might be actively written to while we sanityCheck it.
+  Thread::BasicLockable& stat_lock_;
+};
+
+/**
+ * Heap-based implementation of RawStatDataAllocator that just allocates a new structure in memory
+ * and returns it.
  */
 class HeapRawStatDataAllocator : public RawStatDataAllocator {
 public:
-  // RawStatDataAllocator
   RawStatData* alloc(const std::string& name) override;
   void free(RawStatData& data) override;
 };

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -29,6 +29,8 @@ namespace Stats {
 
 typedef BlockMemoryHashSet<Stats::RawStatData> RawStatDataSet;
 
+BlockMemoryHashSetOptions blockMemHashOptions(uint64_t max_stats);
+
 class TagExtractorImpl : public TagExtractor {
 public:
   /**

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -53,7 +53,7 @@ MainCommonBase::MainCommonBase(OptionsImpl& options) : options_(options) {
     }
 #endif
     if (restarter_.get() == nullptr) {
-      restarter_.reset(new Server::HotRestartNopImpl());
+      restarter_.reset(new Server::HotRestartNopImpl(options_));
     }
 
     tls_.reset(new ThreadLocal::InstanceImpl);
@@ -69,7 +69,7 @@ MainCommonBase::MainCommonBase(OptionsImpl& options) : options_(options) {
     break;
   }
   case Server::Mode::Validate:
-    restarter_.reset(new Server::HotRestartNopImpl());
+    restarter_.reset(new Server::HotRestartNopImpl(options_));
     Logger::Registry::initialize(options_.logLevel(), options_.logFormat(), restarter_->logLock());
     break;
   }

--- a/source/extensions/filters/http/dynamo/dynamo_utility.cc
+++ b/source/extensions/filters/http/dynamo/dynamo_utility.cc
@@ -9,6 +9,8 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Dynamo {
 
+uint64_t Utility::exampleMaxNameLength() { return 127; }
+
 std::string Utility::buildPartitionStatString(const std::string& stat_prefix,
                                               const std::string& table_name,
                                               const std::string& operation,
@@ -19,7 +21,7 @@ std::string Utility::buildPartitionStatString(const std::string& stat_prefix,
                   partition_id.substr(partition_id.size() - 7, partition_id.size()));
 
   // Calculate how many characters are available for the table prefix.
-  size_t remaining_size = Stats::RawStatData::maxNameLength() - stats_partition_postfix.size();
+  size_t remaining_size = Utility::exampleMaxNameLength() - stats_partition_postfix.size();
 
   std::string stats_table_prefix = fmt::format("{}table.{}", stat_prefix, table_name);
   // Truncate the table prefix if the current string is too large.

--- a/source/extensions/filters/http/dynamo/dynamo_utility.h
+++ b/source/extensions/filters/http/dynamo/dynamo_utility.h
@@ -9,6 +9,15 @@ namespace Dynamo {
 
 class Utility {
 public:
+  // returns example max name length, 127. This number is easily mutable in the
+  // outside world, and depending on it makes this test fragile. Thus, the examples
+  // in dynamo_utility_test are hard-coded to make sure
+  //   `locations-sandbox-partition-test-iad-mytest-really-long-name`
+  // becomes
+  //   `locations-sandbox-partition-test-iad-mytest-rea`
+
+  static uint64_t exampleMaxNameLength();
+
   /**
    * Creates the partition id stats string.
    * The stats format is

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -128,6 +128,7 @@ envoy_cc_library(
     hdrs = ["hot_restart_nop_impl.h"],
     deps = [
         "//include/envoy/server:hot_restart_interface",
+        "//source/server:hot_restart_lib",
     ],
 )
 

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -17,6 +17,7 @@
 #include "common/common/fmt.h"
 #include "common/common/utility.h"
 #include "common/network/utility.h"
+#include "common/stats/stats_impl.h"
 
 #include "absl/strings/string_view.h"
 
@@ -27,7 +28,7 @@ namespace Server {
 // from working. Operations code can then cope with this and do a full restart.
 const uint64_t SharedMemory::VERSION = 9;
 
-static BlockMemoryHashSetOptions blockMemHashOptions(uint64_t max_stats) {
+BlockMemoryHashSetOptions blockMemHashOptions(uint64_t max_stats) {
   BlockMemoryHashSetOptions hash_set_options;
   hash_set_options.capacity = max_stats;
 
@@ -84,8 +85,8 @@ SharedMemory& SharedMemory::initialize(uint32_t stats_set_size, Options& options
   }
 
   // Stats::RawStatData must be naturally aligned for atomics to work properly.
-  RELEASE_ASSERT((reinterpret_cast<uintptr_t>(shmem->stats_set_data_) % alignof(RawStatDataSet)) ==
-                 0);
+  RELEASE_ASSERT(
+      (reinterpret_cast<uintptr_t>(shmem->stats_set_data_) % alignof(Stats::RawStatDataSet)) == 0);
 
   // Here we catch the case where a new Envoy starts up when the current Envoy has not yet fully
   // initialized. The startup logic is quite complicated, and it's not worth trying to handle this
@@ -115,15 +116,13 @@ std::string SharedMemory::version(size_t max_num_stats, size_t max_stat_name_len
 
 HotRestartImpl::HotRestartImpl(Options& options)
     : options_(options), stats_set_options_(blockMemHashOptions(options.maxStats())),
-      shmem_(SharedMemory::initialize(RawStatDataSet::numBytes(stats_set_options_), options)),
+      shmem_(
+          SharedMemory::initialize(Stats::RawStatDataSet::numBytes(stats_set_options_), options)),
       log_lock_(shmem_.log_lock_), access_log_lock_(shmem_.access_log_lock_),
       stat_lock_(shmem_.stat_lock_), init_lock_(shmem_.init_lock_) {
   {
-    // We must hold the stat lock when attaching to an existing memory segment
-    // because it might be actively written to while we sanityCheck it.
-    std::unique_lock<Thread::BasicLockable> lock(stat_lock_);
-    stats_set_.reset(new RawStatDataSet(stats_set_options_, options.restartEpoch() == 0,
-                                        shmem_.stats_set_data_));
+    stats_allocator_ = std::make_unique<Stats::BlockRawStatDataAllocator>(
+        stats_set_options_, options.restartEpoch() == 0, shmem_.stats_set_data_, stat_lock_);
   }
   my_domain_socket_ = bindDomainSocket(options.restartEpoch());
   child_address_ = createDomainSocketAddress((options.restartEpoch() + 1));
@@ -136,39 +135,6 @@ HotRestartImpl::HotRestartImpl(Options& options)
   // logic killing the entire process tree. We should never exist without our parent.
   int rc = prctl(PR_SET_PDEATHSIG, SIGTERM);
   RELEASE_ASSERT(rc != -1);
-}
-
-Stats::RawStatData* HotRestartImpl::alloc(const std::string& name) {
-  // Try to find the existing slot in shared memory, otherwise allocate a new one.
-  std::unique_lock<Thread::BasicLockable> lock(stat_lock_);
-  absl::string_view key = name;
-  if (key.size() > Stats::RawStatData::maxNameLength()) {
-    key.remove_suffix(key.size() - Stats::RawStatData::maxNameLength());
-  }
-  auto value_created = stats_set_->insert(key);
-  Stats::RawStatData* data = value_created.first;
-  if (data == nullptr) {
-    return nullptr;
-  }
-  // For new entries (value-created.second==true), BlockMemoryHashSet calls Value::initialize()
-  // automatically, but on recycled entries (value-created.second==false) we need to bump the
-  // ref-count.
-  if (!value_created.second) {
-    ++data->ref_count_;
-  }
-  return data;
-}
-
-void HotRestartImpl::free(Stats::RawStatData& data) {
-  // We must hold the lock since the reference decrement can race with an initialize above.
-  std::unique_lock<Thread::BasicLockable> lock(stat_lock_);
-  ASSERT(data.ref_count_ > 0);
-  if (--data.ref_count_ > 0) {
-    return;
-  }
-  bool key_removed = stats_set_->remove(data.key());
-  ASSERT(key_removed);
-  memset(&data, 0, Stats::RawStatData::size());
 }
 
 int HotRestartImpl::bindDomainSocket(uint64_t id) {
@@ -472,23 +438,25 @@ void HotRestartImpl::terminateParent() {
 void HotRestartImpl::shutdown() { socket_event_.reset(); }
 
 std::string HotRestartImpl::version() {
-  return versionHelper(shmem_.maxStats(), Stats::RawStatData::maxNameLength(), *stats_set_);
+  return versionHelper(shmem_.maxStats(), Stats::RawStatData::maxNameLength(),
+                       stats_allocator_->version());
 }
 
 // Called from envoy --hot-restart-version -- needs to instantiate a RawStatDataSet so it
 // can generate the version string.
 std::string HotRestartImpl::hotRestartVersion(size_t max_num_stats, size_t max_stat_name_len) {
   const BlockMemoryHashSetOptions options = blockMemHashOptions(max_num_stats);
-  const size_t bytes = RawStatDataSet::numBytes(options);
+  const size_t bytes = Stats::RawStatDataSet::numBytes(options);
   std::unique_ptr<uint8_t[]> mem_buffer_for_dry_run_(new uint8_t[bytes]);
-  RawStatDataSet stats_set(options, true /* init */, mem_buffer_for_dry_run_.get());
+  Stats::RawStatDataSet stats_set(options, true /* init */, mem_buffer_for_dry_run_.get());
+  auto stats_set_version = stats_set.version();
 
-  return versionHelper(max_num_stats, max_stat_name_len, stats_set);
+  return versionHelper(max_num_stats, max_stat_name_len, stats_set_version);
 }
 
 std::string HotRestartImpl::versionHelper(size_t max_num_stats, size_t max_stat_name_len,
-                                          RawStatDataSet& stats_set) {
-  return SharedMemory::version(max_num_stats, max_stat_name_len) + "." + stats_set.version();
+                                          std::string stats_set_version) {
+  return SharedMemory::version(max_num_stats, max_stat_name_len) + "." + stats_set_version;
 }
 
 } // namespace Server

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -28,15 +28,6 @@ namespace Server {
 // from working. Operations code can then cope with this and do a full restart.
 const uint64_t SharedMemory::VERSION = 9;
 
-BlockMemoryHashSetOptions blockMemHashOptions(uint64_t max_stats) {
-  BlockMemoryHashSetOptions hash_set_options;
-  hash_set_options.capacity = max_stats;
-
-  // https://stackoverflow.com/questions/3980117/hash-table-why-size-should-be-prime
-  hash_set_options.num_slots = Primes::findPrimeLargerThan(hash_set_options.capacity / 2);
-  return hash_set_options;
-}
-
 SharedMemory& SharedMemory::initialize(uint32_t stats_set_size, Options& options) {
   Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
 
@@ -115,7 +106,7 @@ std::string SharedMemory::version(size_t max_num_stats, size_t max_stat_name_len
 }
 
 HotRestartImpl::HotRestartImpl(Options& options)
-    : options_(options), stats_set_options_(blockMemHashOptions(options.maxStats())),
+    : options_(options), stats_set_options_(Stats::blockMemHashOptions(options.maxStats())),
       shmem_(
           SharedMemory::initialize(Stats::RawStatDataSet::numBytes(stats_set_options_), options)),
       log_lock_(shmem_.log_lock_), access_log_lock_(shmem_.access_log_lock_),

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -436,7 +436,7 @@ std::string HotRestartImpl::version() {
 // Called from envoy --hot-restart-version -- needs to instantiate a RawStatDataSet so it
 // can generate the version string.
 std::string HotRestartImpl::hotRestartVersion(size_t max_num_stats, size_t max_stat_name_len) {
-  const BlockMemoryHashSetOptions options = blockMemHashOptions(max_num_stats);
+  const BlockMemoryHashSetOptions options = Stats::blockMemHashOptions(max_num_stats);
   const size_t bytes = Stats::RawStatDataSet::numBytes(options);
   std::unique_ptr<uint8_t[]> mem_buffer_for_dry_run_(new uint8_t[bytes]);
   Stats::RawStatDataSet stats_set(options, true /* init */, mem_buffer_for_dry_run_.get());

--- a/source/server/hot_restart_impl.h
+++ b/source/server/hot_restart_impl.h
@@ -18,8 +18,6 @@
 namespace Envoy {
 namespace Server {
 
-BlockMemoryHashSetOptions blockMemHashOptions(uint64_t max_stats);
-
 /**
  * Shared memory segment. This structure is laid directly into shared memory and is used amongst
  * all running envoy processes.

--- a/source/server/hot_restart_nop_impl.h
+++ b/source/server/hot_restart_nop_impl.h
@@ -7,8 +7,6 @@
 #include "common/common/thread.h"
 #include "common/stats/stats_impl.h"
 
-#include "server/hot_restart_impl.h"
-
 namespace Envoy {
 namespace Server {
 
@@ -18,7 +16,7 @@ namespace Server {
 class HotRestartNopImpl : public Server::HotRestart {
 public:
   HotRestartNopImpl(Options& options)
-      : stats_set_options_(blockMemHashOptions(options.maxStats())) {
+      : stats_set_options_(Stats::blockMemHashOptions(options.maxStats())) {
     uint32_t num_bytes = BlockMemoryHashSet<Stats::RawStatData>::numBytes(stats_set_options_);
     memory_.reset(new uint8_t[num_bytes]);
     memset(memory_.get(), 0, num_bytes);

--- a/source/server/hot_restart_nop_impl.h
+++ b/source/server/hot_restart_nop_impl.h
@@ -18,7 +18,7 @@ namespace Server {
 class HotRestartNopImpl : public Server::HotRestart {
 public:
   HotRestartNopImpl(Options& options)
-      : options_(options), stats_set_options_(blockMemHashOptions(options.maxStats())) {
+      : stats_set_options_(blockMemHashOptions(options.maxStats())) {
     uint32_t num_bytes = BlockMemoryHashSet<Stats::RawStatData>::numBytes(stats_set_options_);
     memory_.reset(new uint8_t[num_bytes]);
     memset(memory_.get(), 0, num_bytes);
@@ -40,7 +40,6 @@ public:
   Stats::RawStatDataAllocator& statsAllocator() override { return *stats_allocator_; }
 
 private:
-  Options& options_;
   BlockMemoryHashSetOptions stats_set_options_;
   std::unique_ptr<uint8_t[]> memory_;
   Thread::MutexBasicLockable log_lock_;

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -14,11 +14,6 @@
 #include "tclap/CmdLine.h"
 
 // Can be overridden at compile time
-#ifndef ENVOY_DEFAULT_MAX_STATS
-#define ENVOY_DEFAULT_MAX_STATS 16384
-#endif
-
-// Can be overridden at compile time
 // See comment in common/stat/stat_impl.h for rationale behind
 // this constant.
 #ifndef ENVOY_DEFAULT_MAX_OBJ_NAME_LENGTH

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -9,6 +9,11 @@
 
 #include "spdlog/spdlog.h"
 
+// Can be overridden at compile time
+#ifndef ENVOY_DEFAULT_MAX_STATS
+#define ENVOY_DEFAULT_MAX_STATS 16384
+#endif
+
 namespace Envoy {
 /**
  * Implementation of Server::Options.

--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -13,6 +13,9 @@ envoy_cc_test(
     srcs = ["stats_impl_test.cc"],
     deps = [
         "//source/common/stats:stats_lib",
+        "//source/server:hot_restart_lib",
+        "//source/server:options_lib",
+        "//test/mocks/server:server_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/metrics/v2:stats_cc",
     ],
@@ -22,8 +25,11 @@ envoy_cc_test(
     name = "thread_local_store_test",
     srcs = ["thread_local_store_test.cc"],
     deps = [
+        "//source/common/stats:stats_lib",
         "//source/common/stats:thread_local_store_lib",
+        "//source/server:hot_restart_lib",
         "//test/mocks/event:event_mocks",
+        "//test/mocks/server:server_mocks",
         "//test/mocks/stats:stats_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/test_common:utility_lib",

--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -13,7 +13,6 @@ envoy_cc_test(
     srcs = ["stats_impl_test.cc"],
     deps = [
         "//source/common/stats:stats_lib",
-        "//source/server:hot_restart_lib",
         "//source/server:options_lib",
         "//test/mocks/server:server_mocks",
         "//test/test_common:utility_lib",
@@ -27,7 +26,6 @@ envoy_cc_test(
     deps = [
         "//source/common/stats:stats_lib",
         "//source/common/stats:thread_local_store_lib",
-        "//source/server:hot_restart_lib",
         "//test/mocks/event:event_mocks",
         "//test/mocks/server:server_mocks",
         "//test/mocks/stats:stats_mocks",

--- a/test/common/stats/stats_impl_test.cc
+++ b/test/common/stats/stats_impl_test.cc
@@ -615,7 +615,7 @@ TEST_P(BlockRawStatDataAllocatorAlignmentTest, objectOverlap) {
 
 INSTANTIATE_TEST_CASE_P(BlockRawStatDataAllocatorAlignmentTest,
                         BlockRawStatDataAllocatorAlignmentTest,
-                        testing::Range(0UL, alignof(Stats::RawStatData) + 1));
+                        testing::Range(0UL, alignof(Stats::RawStatData) + 1UL));
 
 } // namespace Stats
 } // namespace Envoy

--- a/test/common/stats/stats_impl_test.cc
+++ b/test/common/stats/stats_impl_test.cc
@@ -8,7 +8,6 @@
 #include "common/config/well_known_names.h"
 #include "common/stats/stats_impl.h"
 
-#include "server/hot_restart_impl.h"
 #include "server/options_impl.h"
 
 #include "test/mocks/server/mocks.h"
@@ -479,7 +478,7 @@ public:
   void setup() {
     Stats::RawStatData::configureForTestsOnly(options_);
     BlockMemoryHashSetOptions memory_hash_set_options_ =
-        Server::blockMemHashOptions(options_.maxStats());
+        Stats::blockMemHashOptions(options_.maxStats());
     uint32_t num_bytes = BlockMemoryHashSet<Stats::RawStatData>::numBytes(memory_hash_set_options_);
     memory_.reset(new uint8_t[num_bytes]);
     memset(memory_.get(), 0, num_bytes);

--- a/test/common/stats/stats_impl_test.cc
+++ b/test/common/stats/stats_impl_test.cc
@@ -615,7 +615,7 @@ TEST_P(BlockRawStatDataAllocatorAlignmentTest, objectOverlap) {
 
 INSTANTIATE_TEST_CASE_P(BlockRawStatDataAllocatorAlignmentTest,
                         BlockRawStatDataAllocatorAlignmentTest,
-                        testing::Range(0UL, alignof(Stats::RawStatData) + 1UL));
+                        testing::Range(std::size_t{0}, alignof(Stats::RawStatData) + std::size_t{1}));
 
 } // namespace Stats
 } // namespace Envoy

--- a/test/common/stats/stats_impl_test.cc
+++ b/test/common/stats/stats_impl_test.cc
@@ -8,9 +8,15 @@
 #include "common/config/well_known_names.h"
 #include "common/stats/stats_impl.h"
 
+#include "server/hot_restart_impl.h"
+#include "server/options_impl.h"
+
+#include "test/mocks/server/mocks.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
+
+using testing::Return;
 
 namespace Envoy {
 namespace Stats {
@@ -467,6 +473,150 @@ TEST(TagProducerTest, CheckConstructor) {
       TagProducerImpl{stats_config}, EnvoyException,
       "No regex specified for tag specifier and no default regex for name: 'test_extractor'");
 }
+
+class BlockRawStatDataAllocatorTest : public testing::Test {
+public:
+  void setup() {
+    Stats::RawStatData::configureForTestsOnly(options_);
+    BlockMemoryHashSetOptions memory_hash_set_options_ =
+        Server::blockMemHashOptions(options_.maxStats());
+    uint32_t num_bytes = BlockMemoryHashSet<Stats::RawStatData>::numBytes(memory_hash_set_options_);
+    memory_.reset(new uint8_t[num_bytes]);
+    memset(memory_.get(), 0, num_bytes);
+    allocator_ = std::make_unique<Stats::BlockRawStatDataAllocator>(memory_hash_set_options_, true,
+                                                                    memory_.get(), stat_lock_);
+  }
+
+  std::unique_ptr<uint8_t[]> memory_;
+  std::unique_ptr<Stats::BlockRawStatDataAllocator> allocator_;
+  NiceMock<Server::MockOptions> options_;
+  Thread::MutexBasicLockable stat_lock_;
+};
+
+TEST_F(BlockRawStatDataAllocatorTest, truncateKey) {
+  setup();
+
+  std::string key1(Stats::RawStatData::maxNameLength(), 'a');
+  Stats::RawStatData* stat1 = allocator_->alloc(key1);
+  std::string key2 = key1 + "a";
+  Stats::RawStatData* stat2 = allocator_->alloc(key2);
+  EXPECT_EQ(stat1, stat2);
+}
+
+TEST_F(BlockRawStatDataAllocatorTest, uniqueNaming) {
+  setup();
+
+  auto foo_1 = allocator_->alloc("foo");
+  auto foo_2 = allocator_->alloc("foo");
+  EXPECT_EQ(foo_1, foo_2);
+  auto bar_1 = allocator_->alloc("bar");
+  EXPECT_NE(foo_1, bar_1);
+  EXPECT_NE(foo_2, bar_1);
+}
+
+TEST_F(BlockRawStatDataAllocatorTest, allocFail) {
+  EXPECT_CALL(options_, maxStats()).WillRepeatedly(Return(2));
+  setup();
+
+  Stats::RawStatData* s1 = allocator_->alloc("1");
+  Stats::RawStatData* s2 = allocator_->alloc("2");
+  Stats::RawStatData* s3 = allocator_->alloc("3");
+  EXPECT_NE(s1, nullptr);
+  EXPECT_NE(s2, nullptr);
+  EXPECT_EQ(s3, nullptr);
+}
+
+// Because the shared memory is managed manually, make sure it meets
+// basic requirements:
+//   - Objects are correctly aligned so that std::atomic works properly
+//   - Objects don't overlap
+class BlockRawStatDataAllocatorAlignmentTest : public BlockRawStatDataAllocatorTest,
+                                               public testing::WithParamInterface<uint64_t> {
+public:
+  BlockRawStatDataAllocatorAlignmentTest() : name_len_(8 + GetParam()) {
+    EXPECT_CALL(options_, maxObjNameLength()).WillRepeatedly(Return(name_len_));
+    setup();
+    EXPECT_EQ(name_len_, Stats::RawStatData::maxObjNameLength());
+  }
+
+  static const uint64_t num_stats_ = 8;
+  const uint64_t name_len_;
+};
+
+TEST_P(BlockRawStatDataAllocatorAlignmentTest, objectAlignment) {
+  std::set<Stats::RawStatData*> used;
+  for (uint64_t i = 0; i < num_stats_; i++) {
+    Stats::RawStatData* stat = allocator_->alloc(fmt::format("stat {}", i));
+    EXPECT_TRUE((reinterpret_cast<uintptr_t>(stat) % alignof(decltype(*stat))) == 0);
+    EXPECT_TRUE(used.find(stat) == used.end());
+    used.insert(stat);
+  }
+}
+
+TEST_P(BlockRawStatDataAllocatorAlignmentTest, objectOverlap) {
+  // Iterate through all stats forwards and backwards, writing to all fields, then read them back to
+  // make sure that writing to an adjacent stat didn't overwrite
+  struct TestStat {
+    Stats::RawStatData* stat_;
+    std::string name_;
+    uint64_t index_;
+  };
+  std::vector<TestStat> stats;
+  for (uint64_t i = 0; i < num_stats_; i++) {
+    std::string name = fmt::format("{}zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+                                   "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+                                   "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+                                   i)
+                           .substr(0, Stats::RawStatData::maxNameLength());
+    TestStat ts;
+    ts.stat_ = allocator_->alloc(name);
+    ts.name_ = ts.stat_->name_;
+    ts.index_ = i;
+
+    // If this isn't true then the hard coded part of the name isn't long enough to make the test
+    // valid.
+    EXPECT_EQ(ts.name_.size(), Stats::RawStatData::maxNameLength());
+
+    stats.push_back(ts);
+  }
+
+  auto write = [](TestStat& ts) {
+    ts.stat_->value_ = ts.index_;
+    ts.stat_->pending_increment_ = ts.index_;
+    ts.stat_->flags_ = ts.index_;
+    ts.stat_->ref_count_ = ts.index_;
+    ts.stat_->unused_ = ts.index_;
+  };
+
+  auto verify = [](TestStat& ts) {
+    EXPECT_EQ(ts.stat_->key(), ts.name_);
+    EXPECT_EQ(ts.stat_->value_, ts.index_);
+    EXPECT_EQ(ts.stat_->pending_increment_, ts.index_);
+    EXPECT_EQ(ts.stat_->flags_, ts.index_);
+    EXPECT_EQ(ts.stat_->ref_count_, ts.index_);
+    EXPECT_EQ(ts.stat_->unused_, ts.index_);
+  };
+
+  for (TestStat& ts : stats) {
+    write(ts);
+  }
+
+  for (TestStat& ts : stats) {
+    verify(ts);
+  }
+
+  for (auto it = stats.rbegin(); it != stats.rend(); ++it) {
+    write(*it);
+  }
+
+  for (auto it = stats.rbegin(); it != stats.rend(); ++it) {
+    verify(*it);
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(BlockRawStatDataAllocatorAlignmentTest,
+                        BlockRawStatDataAllocatorAlignmentTest,
+                        testing::Range(0UL, alignof(Stats::RawStatData) + 1));
 
 } // namespace Stats
 } // namespace Envoy

--- a/test/common/stats/stats_impl_test.cc
+++ b/test/common/stats/stats_impl_test.cc
@@ -615,7 +615,8 @@ TEST_P(BlockRawStatDataAllocatorAlignmentTest, objectOverlap) {
 
 INSTANTIATE_TEST_CASE_P(BlockRawStatDataAllocatorAlignmentTest,
                         BlockRawStatDataAllocatorAlignmentTest,
-                        testing::Range(std::size_t{0}, alignof(Stats::RawStatData) + std::size_t{1}));
+                        testing::Range(std::size_t{0},
+                                       alignof(Stats::RawStatData) + std::size_t{1}));
 
 } // namespace Stats
 } // namespace Envoy

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -4,9 +4,13 @@
 #include <unordered_map>
 
 #include "common/common/c_smart_ptr.h"
+#include "common/stats/stats_impl.h"
 #include "common/stats/thread_local_store.h"
 
+#include "server/hot_restart_impl.h"
+
 #include "test/mocks/event/mocks.h"
+#include "test/mocks/server/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/test_common/utility.h"
@@ -24,55 +28,24 @@ using testing::_;
 namespace Envoy {
 namespace Stats {
 
-/**
- * This is a heap test allocator that works similar to how the shared memory allocator works in
- * terms of reference counting, etc.
- */
-class TestAllocator : public RawStatDataAllocator {
-public:
-  ~TestAllocator() { EXPECT_TRUE(stats_.empty()); }
-
-  RawStatData* alloc(const std::string& name) override {
-    CSmartPtr<RawStatData, freeAdapter>& stat_ref = stats_[name];
-    if (!stat_ref) {
-      stat_ref.reset(static_cast<RawStatData*>(::calloc(RawStatData::size(), 1)));
-      stat_ref->initialize(name);
-    } else {
-      stat_ref->ref_count_++;
-    }
-
-    return stat_ref.get();
-  }
-
-  void free(RawStatData& data) override {
-    if (--data.ref_count_ > 0) {
-      return;
-    }
-
-    for (auto i = stats_.begin(); i != stats_.end(); i++) {
-      if (i->second.get() == &data) {
-        stats_.erase(i);
-        return;
-      }
-    }
-
-    FAIL();
-  }
-
-private:
-  static void freeAdapter(RawStatData* data) { ::free(data); }
-  std::unordered_map<std::string, CSmartPtr<RawStatData, freeAdapter>> stats_;
-};
-
 class StatsThreadLocalStoreTest : public testing::Test, public RawStatDataAllocator {
 public:
   StatsThreadLocalStoreTest() {
+    Stats::RawStatData::configureForTestsOnly(options_);
+    BlockMemoryHashSetOptions memory_hash_set_options_ =
+        Server::blockMemHashOptions(options_.maxStats());
+    uint32_t num_bytes = BlockMemoryHashSet<Stats::RawStatData>::numBytes(memory_hash_set_options_);
+    memory_.reset(new uint8_t[num_bytes]);
+    memset(memory_.get(), 0, num_bytes);
+    allocator_ = std::make_unique<Stats::BlockRawStatDataAllocator>(memory_hash_set_options_, true,
+                                                                    memory_.get(), stat_lock_);
+
     ON_CALL(*this, alloc(_)).WillByDefault(Invoke([this](const std::string& name) -> RawStatData* {
-      return alloc_.alloc(name);
+      return allocator_->alloc(name);
     }));
 
     ON_CALL(*this, free(_)).WillByDefault(Invoke([this](RawStatData& data) -> void {
-      return alloc_.free(data);
+      return allocator_->free(data);
     }));
 
     EXPECT_CALL(*this, alloc("stats.overflow"));
@@ -83,9 +56,12 @@ public:
   MOCK_METHOD1(alloc, RawStatData*(const std::string& name));
   MOCK_METHOD1(free, void(RawStatData& data));
 
+  std::unique_ptr<uint8_t[]> memory_;
+  std::unique_ptr<Stats::BlockRawStatDataAllocator> allocator_;
+  NiceMock<Server::MockOptions> options_;
+  Thread::MutexBasicLockable stat_lock_;
   NiceMock<Event::MockDispatcher> main_thread_dispatcher_;
   NiceMock<ThreadLocal::MockInstance> tls_;
-  TestAllocator alloc_;
   MockSink sink_;
   std::unique_ptr<ThreadLocalStoreImpl> store_;
 };

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -7,8 +7,6 @@
 #include "common/stats/stats_impl.h"
 #include "common/stats/thread_local_store.h"
 
-#include "server/hot_restart_impl.h"
-
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/stats/mocks.h"
@@ -33,7 +31,7 @@ public:
   StatsThreadLocalStoreTest() {
     Stats::RawStatData::configureForTestsOnly(options_);
     BlockMemoryHashSetOptions memory_hash_set_options_ =
-        Server::blockMemHashOptions(options_.maxStats());
+        Stats::blockMemHashOptions(options_.maxStats());
     uint32_t num_bytes = BlockMemoryHashSet<Stats::RawStatData>::numBytes(memory_hash_set_options_);
     memory_.reset(new uint8_t[num_bytes]);
     memset(memory_.get(), 0, num_bytes);

--- a/test/extensions/filters/http/dynamo/dynamo_utility_test.cc
+++ b/test/extensions/filters/http/dynamo/dynamo_utility_test.cc
@@ -25,7 +25,7 @@ TEST(DynamoUtility, PartitionIdStatString) {
     std::string expected_stat_string =
         "stat.prefix.table.locations.capacity.GetItem.__partition_id=c5883ca";
     EXPECT_EQ(expected_stat_string, partition_stat_string);
-    EXPECT_TRUE(partition_stat_string.size() <= Stats::RawStatData::maxNameLength());
+    EXPECT_TRUE(partition_stat_string.size() <= Utility::exampleMaxNameLength());
   }
 
   {
@@ -40,7 +40,7 @@ TEST(DynamoUtility, PartitionIdStatString) {
                                        "partition-test-iad-mytest-rea.capacity.GetItem.__partition_"
                                        "id=c5883ca";
     EXPECT_EQ(expected_stat_string, partition_stat_string);
-    EXPECT_TRUE(partition_stat_string.size() == Stats::RawStatData::maxNameLength());
+    EXPECT_TRUE(partition_stat_string.size() <= Utility::exampleMaxNameLength());
   }
   {
     std::string stat_prefix = "http.egress_dynamodb_iad.dynamodb.";
@@ -55,7 +55,7 @@ TEST(DynamoUtility, PartitionIdStatString) {
                                        "id=c5883ca";
 
     EXPECT_EQ(expected_stat_string, partition_stat_string);
-    EXPECT_TRUE(partition_stat_string.size() == Stats::RawStatData::maxNameLength());
+    EXPECT_TRUE(partition_stat_string.size() <= Utility::exampleMaxNameLength());
   }
 }
 

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -84,7 +84,7 @@ void IntegrationTestServer::onWorkerListenerRemoved() {
 
 void IntegrationTestServer::threadRoutine(const Network::Address::IpVersion version) {
   Server::TestOptionsImpl options(config_path_, version);
-  Server::HotRestartNopImpl restarter;
+  Server::HotRestartNopImpl restarter(options);
   Thread::MutexBasicLockable lock;
 
   ThreadLocal::InstanceImpl tls;

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -55,6 +55,7 @@ MockGuardDog::~MockGuardDog() {}
 
 MockHotRestart::MockHotRestart() {
   ON_CALL(*this, logLock()).WillByDefault(ReturnRef(log_lock_));
+  ON_CALL(*this, statLock()).WillByDefault(ReturnRef(stat_lock_));
   ON_CALL(*this, accessLogLock()).WillByDefault(ReturnRef(access_log_lock_));
   ON_CALL(*this, statsAllocator()).WillByDefault(ReturnRef(stats_allocator_));
 }

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -156,11 +156,13 @@ public:
   MOCK_METHOD0(shutdown, void());
   MOCK_METHOD0(version, std::string());
   MOCK_METHOD0(logLock, Thread::BasicLockable&());
+  MOCK_METHOD0(statLock, Thread::BasicLockable&());
   MOCK_METHOD0(accessLogLock, Thread::BasicLockable&());
   MOCK_METHOD0(statsAllocator, Stats::RawStatDataAllocator&());
 
 private:
   Thread::MutexBasicLockable log_lock_;
+  Thread::MutexBasicLockable stat_lock_;
   Thread::MutexBasicLockable access_log_lock_;
   Stats::HeapRawStatDataAllocator stats_allocator_;
 };

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -74,6 +74,17 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "hot_restart_nop_impl_test",
+    srcs = envoy_select_hot_restart(["hot_restart_nop_impl_test.cc"]),
+    deps = [
+        "//source/common/stats:stats_lib",
+        "//source/server:hot_restart_nop_lib",
+        "//test/mocks/server:server_mocks",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "init_manager_impl_test",
     srcs = ["init_manager_impl_test.cc"],
     deps = [

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -88,13 +88,13 @@ TEST_F(HotRestartImplTest, versionString) {
 TEST_F(HotRestartImplTest, crossAlloc) {
   setup();
 
-  Stats::RawStatData* stat1 = hot_restart_->alloc("stat1");
-  Stats::RawStatData* stat2 = hot_restart_->alloc("stat2");
-  Stats::RawStatData* stat3 = hot_restart_->alloc("stat3");
-  Stats::RawStatData* stat4 = hot_restart_->alloc("stat4");
-  Stats::RawStatData* stat5 = hot_restart_->alloc("stat5");
-  hot_restart_->free(*stat2);
-  hot_restart_->free(*stat4);
+  Stats::RawStatData* stat1 = hot_restart_->statsAllocator().alloc("stat1");
+  Stats::RawStatData* stat2 = hot_restart_->statsAllocator().alloc("stat2");
+  Stats::RawStatData* stat3 = hot_restart_->statsAllocator().alloc("stat3");
+  Stats::RawStatData* stat4 = hot_restart_->statsAllocator().alloc("stat4");
+  Stats::RawStatData* stat5 = hot_restart_->statsAllocator().alloc("stat5");
+  hot_restart_->statsAllocator().free(*stat2);
+  hot_restart_->statsAllocator().free(*stat4);
   stat2 = nullptr;
   stat4 = nullptr;
 
@@ -103,128 +103,13 @@ TEST_F(HotRestartImplTest, crossAlloc) {
   EXPECT_CALL(os_sys_calls_, mmap(_, _, _, _, _, _)).WillOnce(Return(buffer_.data()));
   EXPECT_CALL(os_sys_calls_, bind(_, _, _));
   HotRestartImpl hot_restart2(options_);
-  Stats::RawStatData* stat1_prime = hot_restart2.alloc("stat1");
-  Stats::RawStatData* stat3_prime = hot_restart2.alloc("stat3");
-  Stats::RawStatData* stat5_prime = hot_restart2.alloc("stat5");
+  Stats::RawStatData* stat1_prime = hot_restart2.statsAllocator().alloc("stat1");
+  Stats::RawStatData* stat3_prime = hot_restart2.statsAllocator().alloc("stat3");
+  Stats::RawStatData* stat5_prime = hot_restart2.statsAllocator().alloc("stat5");
   EXPECT_EQ(stat1, stat1_prime);
   EXPECT_EQ(stat3, stat3_prime);
   EXPECT_EQ(stat5, stat5_prime);
 }
-
-TEST_F(HotRestartImplTest, truncateKey) {
-  setup();
-
-  std::string key1(Stats::RawStatData::maxNameLength(), 'a');
-  Stats::RawStatData* stat1 = hot_restart_->alloc(key1);
-  std::string key2 = key1 + "a";
-  Stats::RawStatData* stat2 = hot_restart_->alloc(key2);
-  EXPECT_EQ(stat1, stat2);
-}
-
-TEST_F(HotRestartImplTest, allocFail) {
-  EXPECT_CALL(options_, maxStats()).WillRepeatedly(Return(2));
-  setup();
-
-  Stats::RawStatData* s1 = hot_restart_->alloc("1");
-  Stats::RawStatData* s2 = hot_restart_->alloc("2");
-  Stats::RawStatData* s3 = hot_restart_->alloc("3");
-  EXPECT_NE(s1, nullptr);
-  EXPECT_NE(s2, nullptr);
-  EXPECT_EQ(s3, nullptr);
-}
-
-// Because the shared memory is managed manually, make sure it meets
-// basic requirements:
-//   - Objects are correctly aligned so that std::atomic works properly
-//   - Objects don't overlap
-class HotRestartImplAlignmentTest : public HotRestartImplTest,
-                                    public testing::WithParamInterface<uint64_t> {
-public:
-  HotRestartImplAlignmentTest() : name_len_(8 + GetParam()) {
-    EXPECT_CALL(options_, maxStats()).WillRepeatedly(Return(num_stats_));
-    EXPECT_CALL(options_, maxObjNameLength()).WillRepeatedly(Return(name_len_));
-    setup();
-    EXPECT_EQ(name_len_, Stats::RawStatData::maxObjNameLength());
-  }
-
-  static const uint64_t num_stats_ = 8;
-  const uint64_t name_len_;
-};
-
-TEST_P(HotRestartImplAlignmentTest, objectAlignment) {
-
-  std::set<Stats::RawStatData*> used;
-  for (uint64_t i = 0; i < num_stats_; i++) {
-    Stats::RawStatData* stat = hot_restart_->alloc(fmt::format("stat {}", i));
-    EXPECT_TRUE((reinterpret_cast<uintptr_t>(stat) % alignof(decltype(*stat))) == 0);
-    EXPECT_TRUE(used.find(stat) == used.end());
-    used.insert(stat);
-  }
-}
-
-TEST_P(HotRestartImplAlignmentTest, objectOverlap) {
-  // Iterate through all stats forwards and backwards, writing to all fields, then read them back to
-  // make sure that writing to an adjacent stat didn't overwrite
-  struct TestStat {
-    Stats::RawStatData* stat_;
-    std::string name_;
-    uint64_t index_;
-  };
-  std::vector<TestStat> stats;
-  for (uint64_t i = 0; i < num_stats_; i++) {
-    std::string name = fmt::format("{}zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
-                                   "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
-                                   "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
-                                   i)
-                           .substr(0, Stats::RawStatData::maxNameLength());
-    TestStat ts;
-    ts.stat_ = hot_restart_->alloc(name);
-    ts.name_ = ts.stat_->name_;
-    ts.index_ = i;
-
-    // If this isn't true then the hard coded part of the name isn't long enough to make the test
-    // valid.
-    EXPECT_EQ(ts.name_.size(), Stats::RawStatData::maxNameLength());
-
-    stats.push_back(ts);
-  }
-
-  auto write = [](TestStat& ts) {
-    ts.stat_->value_ = ts.index_;
-    ts.stat_->pending_increment_ = ts.index_;
-    ts.stat_->flags_ = ts.index_;
-    ts.stat_->ref_count_ = ts.index_;
-    ts.stat_->unused_ = ts.index_;
-  };
-
-  auto verify = [](TestStat& ts) {
-    EXPECT_EQ(ts.stat_->key(), ts.name_);
-    EXPECT_EQ(ts.stat_->value_, ts.index_);
-    EXPECT_EQ(ts.stat_->pending_increment_, ts.index_);
-    EXPECT_EQ(ts.stat_->flags_, ts.index_);
-    EXPECT_EQ(ts.stat_->ref_count_, ts.index_);
-    EXPECT_EQ(ts.stat_->unused_, ts.index_);
-  };
-
-  for (TestStat& ts : stats) {
-    write(ts);
-  }
-
-  for (TestStat& ts : stats) {
-    verify(ts);
-  }
-
-  for (auto it = stats.rbegin(); it != stats.rend(); ++it) {
-    write(*it);
-  }
-
-  for (auto it = stats.rbegin(); it != stats.rend(); ++it) {
-    verify(*it);
-  }
-}
-
-INSTANTIATE_TEST_CASE_P(HotRestartImplAlignmentTest, HotRestartImplAlignmentTest,
-                        testing::Range(0UL, alignof(Stats::RawStatData) + 1));
 
 } // namespace Server
 } // namespace Envoy

--- a/test/server/hot_restart_nop_impl_test.cc
+++ b/test/server/hot_restart_nop_impl_test.cc
@@ -1,0 +1,66 @@
+#include "common/stats/stats_impl.h"
+
+#include "server/hot_restart_nop_impl.h"
+
+#include "test/mocks/api/mocks.h"
+#include "test/mocks/server/mocks.h"
+#include "test/test_common/threadsafe_singleton_injector.h"
+
+#include "absl/strings/match.h"
+#include "absl/strings/string_view.h"
+#include "gtest/gtest.h"
+
+using testing::Invoke;
+using testing::InvokeWithoutArgs;
+using testing::Return;
+using testing::WithArg;
+using testing::_;
+
+namespace Envoy {
+namespace Server {
+
+class HotRestartNopImplTest : public testing::Test {
+public:
+  void setup() {
+    Stats::RawStatData::configureForTestsOnly(options_);
+
+    // Test we match the correct stat with empty-slots before, after, or both.
+    hot_restart_nop_.reset(new HotRestartNopImpl(options_));
+    hot_restart_nop_->drainParentListeners();
+  }
+
+  void TearDown() {
+    // Configure it back so that later tests don't get the wonky values
+    // used here
+    NiceMock<MockOptions> default_options;
+    Stats::RawStatData::configureForTestsOnly(default_options);
+  }
+
+  NiceMock<MockOptions> options_;
+  std::vector<uint8_t> buffer_;
+  std::unique_ptr<HotRestartNopImpl> hot_restart_nop_;
+};
+
+TEST_F(HotRestartNopImplTest, sameAlloc) {
+  setup();
+
+  Stats::RawStatData* stat1 = hot_restart_nop_->statsAllocator().alloc("stat1");
+  Stats::RawStatData* stat2 = hot_restart_nop_->statsAllocator().alloc("stat2");
+  Stats::RawStatData* stat3 = hot_restart_nop_->statsAllocator().alloc("stat3");
+  Stats::RawStatData* stat4 = hot_restart_nop_->statsAllocator().alloc("stat4");
+  Stats::RawStatData* stat5 = hot_restart_nop_->statsAllocator().alloc("stat5");
+  hot_restart_nop_->statsAllocator().free(*stat2);
+  hot_restart_nop_->statsAllocator().free(*stat4);
+  stat2 = nullptr;
+  stat4 = nullptr;
+
+  Stats::RawStatData* stat1_prime = hot_restart_nop_->statsAllocator().alloc("stat1");
+  Stats::RawStatData* stat3_prime = hot_restart_nop_->statsAllocator().alloc("stat3");
+  Stats::RawStatData* stat5_prime = hot_restart_nop_->statsAllocator().alloc("stat5");
+  EXPECT_EQ(stat1, stat1_prime);
+  EXPECT_EQ(stat3, stat3_prime);
+  EXPECT_EQ(stat5, stat5_prime);
+}
+
+} // namespace Server
+} // namespace Envoy


### PR DESCRIPTION
Signed-off-by: James Buckland <jbuckland@google.com>

*title*: Fixes issue with Envoy not reference counting stats across scopes under not-hot restart.

*Description*: Addresses issue https://github.com/envoyproxy/envoy/issues/2453, continuing draft work in https://github.com/ambuc/envoy/pull/1.  Summary of changes:
 - `HotRestartImpl` no longer is a child class of `RawStatDataAllocator`. It now has a member variable allocator, which is a more general-purpose `BlockRawStatDataAllocator`. This `BlockRawStatDataAllocator` accepts shared- or not- memory, and accepts / uses a mutex internally.
 - We now use this `BlockRawStatDataAllocator` in both `HotRestartImpl` and `HotRestartNopImpl`, which implements the reference counting by means of a `RawStatDataSet`. This leaves `HotRestartImpl` functionally unchanged, and extends that functionality to the no-op case.
 - This means `HotRestartNopImpl` needs to know a few `Options` and `BlockMemoryHashSetOptions` for creating its stat set, which means a small change to `main_common.cc` to pass in options to both kinds of restarters.
 - Associated changes to mocks / test suites to test this reference counting behaviors in both kinds of restart scenarios.

This also justifies the renaming changes in https://github.com/envoyproxy/envoy/pull/3150.

*Risk Level*: Medium.

*Testing*: Changed `stats_impl_test`, `thread_local_store_test`, `hot_restart_impl_test`, and `hot_restart_nop_impl_test` in large ways, and made minor updates to the server mocks. Added unit tests for `BlockRawStatDataAllocator` and the hot restart / no-op hot restart modes. Passes `bazel test test/...`.

*Docs Changes*: N/A

*Release Notes*: This is user-facing in that non-hot restart stat allocation now resolves namespace properly, but no effect on user configs.

Fixes: https://github.com/envoyproxy/envoy/issues/2453