### PR TITLE
runtime: blacklist /dev, /proc and /sys from watch dirs.

### DIFF
--- a/source/common/filesystem/filesystem_impl.cc
+++ b/source/common/filesystem/filesystem_impl.cc
@@ -21,6 +21,8 @@
 #include "common/common/fmt.h"
 #include "common/common/thread.h"
 
+#include "absl/strings/match.h"
+
 namespace Envoy {
 namespace Filesystem {
 
@@ -59,6 +61,31 @@ std::string fileReadToEnd(const std::string& path) {
   file_string << file.rdbuf();
 
   return file_string.str();
+}
+
+std::string canonicalPath(const std::string& path) {
+  // TODO(htuch): When we are using C++17, switch to std::filesystem::canonical.
+  char* resolved_path = ::realpath(path.c_str(), nullptr);
+  if (resolved_path == nullptr) {
+    throw EnvoyException(fmt::format("Unable to determine canonical path for {}", path));
+  }
+  std::string resolved_path_string{resolved_path};
+  free(resolved_path);
+  return resolved_path_string;
+}
+
+bool illegalPath(const std::string& path) {
+  const std::string canonical_path = canonicalPath(path);
+  // Platform specific path sanity; we provide a convenience to avoid Envoy
+  // instances poking in bad places. We may have to consider conditioning on
+  // platform in the future, growing these or relaxing some constraints (e.g.
+  // there are valid reasons to go via /proc for file paths).
+  // TODO(htuch): Optimize this as a hash lookup if we grow any further.
+  if (absl::StartsWith(canonical_path, "/dev") || absl::StartsWith(canonical_path, "/sys") ||
+      absl::StartsWith(canonical_path, "/proc")) {
+    return true;
+  }
+  return false;
 }
 
 FileImpl::FileImpl(const std::string& path, Event::Dispatcher& dispatcher,

--- a/source/common/filesystem/filesystem_impl.cc
+++ b/source/common/filesystem/filesystem_impl.cc
@@ -89,7 +89,7 @@ bool illegalPath(const std::string& path) {
     return false;
   } catch (const EnvoyException& ex) {
     ENVOY_LOG_MISC(debug, "Unable to determine canonical path for {}: {}", path, ex.what());
-    return false;
+    return true;
   }
 }
 

--- a/source/common/filesystem/filesystem_impl.h
+++ b/source/common/filesystem/filesystem_impl.h
@@ -57,6 +57,23 @@ ssize_t fileSize(const std::string& path);
 std::string fileReadToEnd(const std::string& path);
 
 /**
+ * @param path some filesystem path.
+ * @return std::string the canonical path (see realpath(3)).
+ */
+std::string canonicalPath(const std::string& path);
+
+/**
+ * Determine if the path is on a list of paths Envoy will refuse to access. This
+ * is a basic sanity check for users, blacklisting some clearly bad paths. Paths
+ * may still be problematic (e.g. indirectly leading to /dev/mem) even if this
+ * returns false, it is up to the user to validate that supplied paths are
+ * valid.
+ * @param path some filesystem path.
+ * @return is the path on the blacklist?
+ */
+bool illegalPath(const std::string& path);
+
+/**
  * This is a file implementation geared for writing out access logs. It turn out that in certain
  * cases even if a standard file is opened with O_NONBLOCK, the kernel can still block when writing.
  * This implementation uses a flush thread per file, with the idea there there aren't that many

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -231,6 +231,10 @@ DiskLayer::DiskLayer(const std::string& name, const std::string& path,
 
 void DiskLayer::walkDirectory(const std::string& path, const std::string& prefix) {
   ENVOY_LOG(debug, "walking directory: {}", path);
+  // Check if this is an obviously bad path.
+  if (Filesystem::illegalPath(path)) {
+    throw EnvoyException(fmt::format("Invalid path: {}", path));
+  }
   Directory current_dir(path);
   while (true) {
     errno = 0;

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -232,6 +232,7 @@ DiskLayer::DiskLayer(const std::string& name, const std::string& path,
 void DiskLayer::walkDirectory(const std::string& path, const std::string& prefix) {
   ENVOY_LOG(debug, "walking directory: {}", path);
   // Check if this is an obviously bad path.
+  // TODO(htuch): We should also add a depth check for the recursion in future.
   if (Filesystem::illegalPath(path)) {
     throw EnvoyException(fmt::format("Invalid path: {}", path));
   }

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -226,13 +226,15 @@ void AdminLayer::mergeValues(const std::unordered_map<std::string, std::string>&
 DiskLayer::DiskLayer(const std::string& name, const std::string& path,
                      Api::OsSysCalls& os_sys_calls)
     : OverrideLayerImpl{name}, os_sys_calls_(os_sys_calls) {
-  walkDirectory(path, "");
+  walkDirectory(path, "", 1);
 }
 
-void DiskLayer::walkDirectory(const std::string& path, const std::string& prefix) {
+void DiskLayer::walkDirectory(const std::string& path, const std::string& prefix, uint32_t depth) {
   ENVOY_LOG(debug, "walking directory: {}", path);
+  if (depth > MaxWalkDepth) {
+    throw EnvoyException(fmt::format("Walk recursion depth exceded {}", MaxWalkDepth));
+  }
   // Check if this is an obviously bad path.
-  // TODO(htuch): We should also add a depth check for the recursion in future.
   if (Filesystem::illegalPath(path)) {
     throw EnvoyException(fmt::format("Invalid path: {}", path));
   }
@@ -264,7 +266,7 @@ void DiskLayer::walkDirectory(const std::string& path, const std::string& prefix
 
     if (S_ISDIR(stat_result.st_mode) && std::string(entry->d_name) != "." &&
         std::string(entry->d_name) != "..") {
-      walkDirectory(full_path, full_prefix);
+      walkDirectory(full_path, full_prefix, depth + 1);
     } else if (S_ISREG(stat_result.st_mode)) {
       // Suck the file into a string. This is not very efficient but it should be good enough
       // for small files. Also, as noted elsewhere, none of this is non-blocking which could

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -143,10 +143,12 @@ private:
     DIR* dir_;
   };
 
-  void walkDirectory(const std::string& path, const std::string& prefix);
+  void walkDirectory(const std::string& path, const std::string& prefix, uint32_t depth);
 
   const std::string path_;
   Api::OsSysCalls& os_sys_calls_;
+  // Maximum recursion depth for walkDirectory().
+  const uint32_t MaxWalkDepth = 4;
 };
 
 /**

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -148,7 +148,7 @@ private:
   const std::string path_;
   Api::OsSysCalls& os_sys_calls_;
   // Maximum recursion depth for walkDirectory().
-  const uint32_t MaxWalkDepth = 4;
+  const uint32_t MaxWalkDepth = 16;
 };
 
 /**

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -85,6 +85,23 @@ TEST(FileSystemImpl, fileReadToEndDoesNotExist) {
                EnvoyException);
 }
 
+TEST(FilesystemImpl, CanonicalPathSuccess) { EXPECT_EQ("/", Filesystem::canonicalPath("//")); }
+
+TEST(FilesystemImpl, CanonicalPathFail) {
+  EXPECT_THROW_WITH_MESSAGE(Filesystem::canonicalPath("/_some_non_existant_file"), EnvoyException,
+                            "Unable to determine canonical path for /_some_non_existant_file");
+}
+
+TEST(FilesystemImpl, IllegalPath) {
+  EXPECT_FALSE(Filesystem::illegalPath("/"));
+  EXPECT_TRUE(Filesystem::illegalPath("/dev"));
+  EXPECT_TRUE(Filesystem::illegalPath("/dev/"));
+  EXPECT_TRUE(Filesystem::illegalPath("/proc"));
+  EXPECT_TRUE(Filesystem::illegalPath("/proc/"));
+  EXPECT_TRUE(Filesystem::illegalPath("/sys"));
+  EXPECT_TRUE(Filesystem::illegalPath("/sys/"));
+}
+
 TEST(FileSystemImpl, flushToLogFilePeriodically) {
   NiceMock<Event::MockDispatcher> dispatcher;
   NiceMock<Event::MockTimer>* timer = new NiceMock<Event::MockTimer>(&dispatcher);

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -100,6 +100,7 @@ TEST(FilesystemImpl, IllegalPath) {
   EXPECT_TRUE(Filesystem::illegalPath("/proc/"));
   EXPECT_TRUE(Filesystem::illegalPath("/sys"));
   EXPECT_TRUE(Filesystem::illegalPath("/sys/"));
+  EXPECT_TRUE(Filesystem::illegalPath("/_some_non_existant_file"));
 }
 
 TEST(FileSystemImpl, flushToLogFilePeriodically) {

--- a/test/common/runtime/filesystem_setup.sh
+++ b/test/common/runtime/filesystem_setup.sh
@@ -4,9 +4,15 @@ set -e
 
 TEST_DATA=test/common/runtime/test_data
 
+# Regular runtime tests.
 cd "${TEST_RUNDIR}"
 mkdir -p "${TEST_TMPDIR}/${TEST_DATA}"
 cp -RfL "${TEST_DATA}"/* "${TEST_TMPDIR}/${TEST_DATA}"
 chmod -R u+rwX "${TEST_TMPDIR}/${TEST_DATA}"
 ln -sf "${TEST_TMPDIR}/${TEST_DATA}/root" "${TEST_TMPDIR}/${TEST_DATA}/current"
 ln -sf "${TEST_TMPDIR}/${TEST_DATA}/root/envoy/subdir" "${TEST_TMPDIR}/${TEST_DATA}/root/envoy/badlink"
+
+# Deliberate symlink of doom.
+LOOP_PATH="${TEST_TMPDIR}/${TEST_DATA}/loop"
+mkdir -p "${LOOP_PATH}"
+ln -sf "${LOOP_PATH}" "${LOOP_PATH}"/loop

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -251,5 +251,15 @@ TEST(DiskLayer, IllegalPath) {
                             "Invalid path: /dev");
 }
 
+// Validate that we catch recursion that goes too deep in the runtime filesystem
+// walk.
+TEST(DiskLayer, Loop) {
+  Api::OsSysCallsImpl os_syscalls;
+  EXPECT_THROW_WITH_MESSAGE(
+      DiskLayer("test", TestEnvironment::temporaryPath("test/common/runtime/test_data/loop"),
+                os_syscalls),
+      EnvoyException, "Walk recursion depth exceded 4");
+}
+
 } // namespace Runtime
 } // namespace Envoy

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -245,5 +245,11 @@ TEST(LoaderImplTest, All) {
   testNewOverrides(loader, store);
 }
 
+TEST(DiskLayer, IllegalPath) {
+  Api::MockOsSysCalls mock_os_syscalls;
+  EXPECT_THROW_WITH_MESSAGE(DiskLayer("test", "/dev", mock_os_syscalls), EnvoyException,
+                            "Invalid path: /dev");
+}
+
 } // namespace Runtime
 } // namespace Envoy

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -258,7 +258,7 @@ TEST(DiskLayer, Loop) {
   EXPECT_THROW_WITH_MESSAGE(
       DiskLayer("test", TestEnvironment::temporaryPath("test/common/runtime/test_data/loop"),
                 os_syscalls),
-      EnvoyException, "Walk recursion depth exceded 4");
+      EnvoyException, "Walk recursion depth exceded 16");
 }
 
 } // namespace Runtime

--- a/test/server/server_corpus/oom-550f56d376b3a23320724b98c79905f7c73e4e55
+++ b/test/server/server_corpus/oom-550f56d376b3a23320724b98c79905f7c73e4e55
@@ -1,0 +1,11 @@
+runtime {
+  symlink_root: "/"
+}
+admin {
+  access_log_path: "@"
+  address {
+    pipe {
+      path: "]"
+    }
+  }
+}


### PR DESCRIPTION
server_test proto fuzzing resulted in OOM because of /dev traversal. It
seems bad to allow runtime paths to point in these places.

Risk Level: Low
Testing: New unit tests.

Signed-off-by: Harvey Tuch <htuch@google.com>
