### PR TITLE
ssl: don't panic on SDS secret config for session tickets.

### DIFF
--- a/source/common/ssl/context_config_impl.cc
+++ b/source/common/ssl/context_config_impl.cc
@@ -133,7 +133,7 @@ ServerContextConfigImpl::ServerContextConfigImpl(
           }
           break;
         case envoy::api::v2::auth::DownstreamTlsContext::kSessionTicketKeysSdsSecretConfig:
-          NOT_IMPLEMENTED;
+          throw EnvoyException("SDS not supported yet");
           break;
         case envoy::api::v2::auth::DownstreamTlsContext::SESSION_TICKET_KEYS_TYPE_NOT_SET:
           break;

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -285,6 +285,12 @@ TEST_F(SslServerContextImplTicketTest, TicketKeyInlineStringFailTooSmall) {
   EXPECT_THROW(loadConfigV2(cfg), EnvoyException);
 }
 
+TEST_F(SslServerContextImplTicketTest, TicketKeySdsFail) {
+  envoy::api::v2::auth::DownstreamTlsContext cfg;
+  cfg.mutable_session_ticket_keys_sds_secret_config();
+  EXPECT_THROW_WITH_MESSAGE(loadConfigV2(cfg), EnvoyException, "SDS not supported yet");
+}
+
 TEST_F(SslServerContextImplTicketTest, CRLSuccess) {
   std::string json = R"EOF(
   {

--- a/test/server/server_corpus/crash-e0339370f24027b5c73b5355e74c0b68c8b33314
+++ b/test/server/server_corpus/crash-e0339370f24027b5c73b5355e74c0b68c8b33314
@@ -1,0 +1,27 @@
+static_resources {
+  listeners {
+    name: "listener_0"
+    address {
+      pipe {
+        path: "\000\000\000j"
+      }
+    }
+    filter_chains {
+      tls_context {
+        session_ticket_keys_sds_secret_config {
+        }
+      }
+    }
+    tcp_fast_open_queue_length {
+      value: 1
+    }
+  }
+}
+admin {
+  access_log_path: "/tmp/admin_access,lOg"
+  address {
+    pipe {
+      path: "\026runt"
+    }
+  }
+}


### PR DESCRIPTION
This was found via proto fuzzing the server config.

Risk Level: Low
Testing: New context_impl_test.

Signed-off-by: Harvey Tuch <htuch@google.com>