### PR TITLE
protobuf: improve robustness of jsonConvert().

### DIFF
--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -108,8 +108,10 @@ void MessageUtil::jsonConvert(const Protobuf::Message& source, Protobuf::Message
   Protobuf::util::JsonOptions json_options;
   ProtobufTypes::String json;
   const auto status = Protobuf::util::MessageToJsonString(source, &json, json_options);
-  // This should always succeed unless something crash-worthy such as out-of-memory.
-  RELEASE_ASSERT(status.ok());
+  if (!status.ok()) {
+    throw EnvoyException(fmt::format("Unable to convert protobuf message to JSON string: {} {}",
+                                     status.ToString(), source.DebugString()));
+  }
   MessageUtil::loadFromJson(json, dest);
 }
 

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -203,4 +203,22 @@ TEST(UtilityTest, HashedValueStdHash) {
   EXPECT_NE(set.find(hv3), set.end());
 }
 
+TEST(UtilityTest, JsonConvertSuccess) {
+  ProtobufWkt::Duration source_duration;
+  source_duration.set_seconds(42);
+  ProtobufWkt::Duration dest_duration;
+  MessageUtil::jsonConvert(source_duration, dest_duration);
+  EXPECT_EQ(42, dest_duration.seconds());
+}
+
+TEST(UtilityTest, JsonConvertFail) {
+  ProtobufWkt::Duration source_duration;
+  source_duration.set_seconds(-281474976710656);
+  ProtobufWkt::Duration dest_duration;
+  EXPECT_THROW_WITH_MESSAGE(MessageUtil::jsonConvert(source_duration, dest_duration),
+                            EnvoyException,
+                            "Unable to convert protobuf message to JSON string: INTERNAL:Duration "
+                            "seconds exceeds limit for field:  seconds: -281474976710656\n");
+}
+
 } // namespace Envoy

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-6610050496856064
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-6610050496856064
@@ -1,0 +1,45 @@
+static_resources {
+  listeners {
+    name: "listener_0"
+    address {
+      pipe {
+        path: "\t"
+      }
+    }
+    filter_chains {
+      tls_context {
+        common_tls_context {
+          tls_certificate_sds_secret_configs {
+            sds_config {
+              api_config_source {
+                refresh_delay {
+                  seconds: -281474976710656
+                }
+                grpc_services {
+                  envoy_grpc {
+                    cluster_name: "\000\000\000\000\000"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    filter_chains {
+      filter_chain_match {
+        sni_domains: "6e702f1f66d415068aabbc60377ad67a326b6b2b"
+      }
+    }
+    filter_chains {
+    }
+  }
+}
+admin {
+  access_log_path: "@"
+  address {
+    pipe {
+      path: "^"
+    }
+  }
+}


### PR DESCRIPTION
Turns out that it can fail when you round-trip values that are out-of-range for things like
duration.

This was found via proto fuzzing the server config.

Risk Level: Low
Testing: New utility_test.

Signed-off-by: Harvey Tuch <htuch@google.com>