### PR TITLE
protobuf: disallow negative durations.

### DIFF
--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -157,7 +157,7 @@ std::chrono::milliseconds Utility::apiConfigSourceRefreshDelay(
   }
 
   return std::chrono::milliseconds(
-      Protobuf::util::TimeUtil::DurationToMilliseconds(api_config_source.refresh_delay()));
+      DurationUtil::durationToMilliseconds(api_config_source.refresh_delay()));
 }
 
 void Utility::translateEdsConfig(const Json::Object& json_config,

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -183,4 +183,25 @@ bool ValueUtil::equal(const ProtobufWkt::Value& v1, const ProtobufWkt::Value& v2
   }
 }
 
+namespace {
+
+void validateDuration(const ProtobufWkt::Duration& duration) {
+  if (duration.seconds() < 0 || duration.nanos() < 0) {
+    throw DurationUtil::OutOfRangeException(
+        fmt::format("Expected positive duration: {}", duration.DebugString()));
+  }
+}
+
+} // namespace
+
+uint64_t DurationUtil::durationToMilliseconds(const ProtobufWkt::Duration& duration) {
+  validateDuration(duration);
+  return Protobuf::util::TimeUtil::DurationToMilliseconds(duration);
+}
+
+uint64_t DurationUtil::durationToSeconds(const ProtobufWkt::Duration& duration) {
+  validateDuration(duration);
+  return Protobuf::util::TimeUtil::DurationToSeconds(duration);
+}
+
 } // namespace Envoy

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -24,23 +24,20 @@
 // Obtain the milliseconds value of a google.protobuf.Duration field if set. Otherwise, return the
 // default value.
 #define PROTOBUF_GET_MS_OR_DEFAULT(message, field_name, default_value)                             \
-  ((message).has_##field_name()                                                                    \
-       ? Protobuf::util::TimeUtil::DurationToMilliseconds((message).field_name())                  \
-       : (default_value))
+  ((message).has_##field_name() ? DurationUtil::durationToMilliseconds((message).field_name())     \
+                                : (default_value))
 
 // Obtain the milliseconds value of a google.protobuf.Duration field if set. Otherwise, throw a
 // MissingFieldException.
 #define PROTOBUF_GET_MS_REQUIRED(message, field_name)                                              \
-  ((message).has_##field_name()                                                                    \
-       ? Protobuf::util::TimeUtil::DurationToMilliseconds((message).field_name())                  \
-       : throw MissingFieldException(#field_name, (message)))
+  ((message).has_##field_name() ? DurationUtil::durationToMilliseconds((message).field_name())     \
+                                : throw MissingFieldException(#field_name, (message)))
 
 // Obtain the seconds value of a google.protobuf.Duration field if set. Otherwise, throw a
 // MissingFieldException.
 #define PROTOBUF_GET_SECONDS_REQUIRED(message, field_name)                                         \
-  ((message).has_##field_name()                                                                    \
-       ? Protobuf::util::TimeUtil::DurationToSeconds((message).field_name())                       \
-       : throw MissingFieldException(#field_name, (message)))
+  ((message).has_##field_name() ? DurationUtil::durationToSeconds((message).field_name())          \
+                                : throw MissingFieldException(#field_name, (message)))
 
 namespace Envoy {
 namespace ProtobufPercentHelper {
@@ -269,6 +266,33 @@ public:
 private:
   const ProtobufWkt::Value value_;
   const std::size_t hash_;
+};
+
+class DurationUtil {
+public:
+  class OutOfRangeException : public EnvoyException {
+  public:
+    OutOfRangeException(const std::string& error) : EnvoyException(error) {}
+  };
+
+  /**
+   * Same as DurationUtil::durationToMilliseconds but with extra validation logic.
+   * Same as Protobuf::util::TimeUtil::DurationToSeconds but with extra validation logic.
+   * Specifically, we ensure that the duration is positive.
+   * @param duration protobuf.
+   * @return duration in milliseconds.
+   * @throw OutOfRangeException when duration is out-of-range.
+   */
+  static uint64_t durationToMilliseconds(const ProtobufWkt::Duration& duration);
+
+  /**
+   * Same as Protobuf::util::TimeUtil::DurationToSeconds but with extra validation logic.
+   * Specifically, we ensure that the duration is positive.
+   * @param duration protobuf.
+   * @return duration in seconds.
+   * @throw OutOfRangeException when duration is out-of-range.
+   */
+  static uint64_t durationToSeconds(const ProtobufWkt::Duration& duration);
 };
 
 } // namespace Envoy

--- a/source/common/upstream/load_stats_reporter.cc
+++ b/source/common/upstream/load_stats_reporter.cc
@@ -128,7 +128,7 @@ void LoadStatsReporter::startLoadReportPeriod() {
     cluster.info()->loadReportStats().upstream_rq_dropped_.latch();
   }
   response_timer_->enableTimer(std::chrono::milliseconds(
-      Protobuf::util::TimeUtil::DurationToMilliseconds(message_->load_reporting_interval())));
+      DurationUtil::durationToMilliseconds(message_->load_reporting_interval())));
 }
 
 void LoadStatsReporter::onReceiveTrailingMetadata(Http::HeaderMapPtr&& metadata) {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -304,8 +304,8 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
   }
 
   if (config.common_http_protocol_options().has_idle_timeout()) {
-    idle_timeout_ = std::chrono::milliseconds(Protobuf::util::TimeUtil::DurationToMilliseconds(
-        config.common_http_protocol_options().idle_timeout()));
+    idle_timeout_ = std::chrono::milliseconds(
+        DurationUtil::durationToMilliseconds(config.common_http_protocol_options().idle_timeout()));
   }
 }
 

--- a/source/extensions/filters/network/tcp_proxy/tcp_proxy.cc
+++ b/source/extensions/filters/network/tcp_proxy/tcp_proxy.cc
@@ -44,8 +44,8 @@ TcpProxyConfig::SharedConfig::SharedConfig(
     : stats_scope_(context.scope().createScope(fmt::format("tcp.{}.", config.stat_prefix()))),
       stats_(generateStats(*stats_scope_)) {
   if (config.has_idle_timeout()) {
-    idle_timeout_ = std::chrono::milliseconds(
-        Protobuf::util::TimeUtil::DurationToMilliseconds(config.idle_timeout()));
+    idle_timeout_ =
+        std::chrono::milliseconds(DurationUtil::durationToMilliseconds(config.idle_timeout()));
   }
 }
 

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -65,24 +65,22 @@ TEST(UtilityTest, TranslateApiConfigSource) {
                                     api_config_source_rest_legacy);
   EXPECT_EQ(envoy::api::v2::core::ApiConfigSource::REST_LEGACY,
             api_config_source_rest_legacy.api_type());
-  EXPECT_EQ(10000, Protobuf::util::TimeUtil::DurationToMilliseconds(
-                       api_config_source_rest_legacy.refresh_delay()));
+  EXPECT_EQ(10000,
+            DurationUtil::durationToMilliseconds(api_config_source_rest_legacy.refresh_delay()));
   EXPECT_EQ("test_rest_legacy_cluster", api_config_source_rest_legacy.cluster_names(0));
 
   envoy::api::v2::core::ApiConfigSource api_config_source_rest;
   Utility::translateApiConfigSource("test_rest_cluster", 20000, ApiType::get().Rest,
                                     api_config_source_rest);
   EXPECT_EQ(envoy::api::v2::core::ApiConfigSource::REST, api_config_source_rest.api_type());
-  EXPECT_EQ(20000, Protobuf::util::TimeUtil::DurationToMilliseconds(
-                       api_config_source_rest.refresh_delay()));
+  EXPECT_EQ(20000, DurationUtil::durationToMilliseconds(api_config_source_rest.refresh_delay()));
   EXPECT_EQ("test_rest_cluster", api_config_source_rest.cluster_names(0));
 
   envoy::api::v2::core::ApiConfigSource api_config_source_grpc;
   Utility::translateApiConfigSource("test_grpc_cluster", 30000, ApiType::get().Grpc,
                                     api_config_source_grpc);
   EXPECT_EQ(envoy::api::v2::core::ApiConfigSource::GRPC, api_config_source_grpc.api_type());
-  EXPECT_EQ(30000, Protobuf::util::TimeUtil::DurationToMilliseconds(
-                       api_config_source_grpc.refresh_delay()));
+  EXPECT_EQ(30000, DurationUtil::durationToMilliseconds(api_config_source_grpc.refresh_delay()));
   EXPECT_EQ("test_grpc_cluster", api_config_source_grpc.cluster_names(0));
 }
 

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -221,4 +221,17 @@ TEST(UtilityTest, JsonConvertFail) {
                             "seconds exceeds limit for field:  seconds: -281474976710656\n");
 }
 
+TEST(DurationUtilTest, OutOfRange) {
+  {
+    ProtobufWkt::Duration duration;
+    duration.set_seconds(-1);
+    EXPECT_THROW(DurationUtil::durationToMilliseconds(duration), DurationUtil::OutOfRangeException);
+  }
+  {
+    ProtobufWkt::Duration duration;
+    duration.set_nanos(-1);
+    EXPECT_THROW(DurationUtil::durationToMilliseconds(duration), DurationUtil::OutOfRangeException);
+  }
+}
+
 } // namespace Envoy

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5085107063881728
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5085107063881728
@@ -1,0 +1,13 @@
+watchdog {
+  megamiss_timeout {
+    seconds: -27037478448
+  }
+}
+admin {
+  access_log_path: "@"
+  address {
+    pipe {
+      path: "!"
+    }
+  }
+}


### PR DESCRIPTION
We don't need negative duration in Envoy (yet), and they cause all kinds of weird (e.g. JSON
conversion fails, UBSAN warnings due to wrap around, etc.). We can always add methods that
explicitly support these later.

This was found via proto fuzzing the server config.

Risk Level: Low
Testing: New unit tests.

Signed-off-by: Harvey Tuch <htuch@google.com>
