### PR TITLE
admin: improve infrastructure

### DIFF
--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -15,6 +15,7 @@
 namespace Envoy {
 namespace Server {
 
+class AdminFilter;
 /**
  * This macro is used to add handlers to the Admin HTTP Endpoint. It builds
  * a callback that executes X when the specified admin handler is hit. This macro can be
@@ -23,8 +24,8 @@ namespace Server {
  */
 #define MAKE_ADMIN_HANDLER(X)                                                                      \
   [this](absl::string_view path_and_query, Http::HeaderMap& response_headers,                      \
-         Buffer::Instance& data) -> Http::Code {                                                   \
-    return X(path_and_query, response_headers, data);                                              \
+         Buffer::Instance& data, Server::AdminFilter& admin_filter) -> Http::Code {                \
+    return X(path_and_query, response_headers, data, admin_filter);                                \
   }
 
 /**
@@ -43,7 +44,9 @@ public:
    * @return Http::Code the response code.
    */
   typedef std::function<Http::Code(absl::string_view path_and_query,
-                                   Http::HeaderMap& response_headers, Buffer::Instance& response)>
+                                   Http::HeaderMap& response_headers, Buffer::Instance& response,
+                                   AdminFilter& admin_filter)>
+
       HandlerCb;
 
   /**

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -150,6 +150,16 @@ Http::FilterTrailersStatus AdminFilter::decodeTrailers(Http::HeaderMap&) {
   return Http::FilterTrailersStatus::StopIteration;
 }
 
+void AdminFilter::onDestroy() {
+  for (const auto& callback : on_destroy_callbacks_) {
+    callback();
+  }
+}
+
+void AdminFilter::addOnDestroyCallback(std::function<void()> cb) {
+  on_destroy_callbacks_.push_back(std::move(cb));
+}
+
 bool AdminImpl::changeLogLevel(const Http::Utility::QueryParams& params) {
   if (params.size() != 1) {
     return false;
@@ -222,7 +232,7 @@ void AdminImpl::addCircuitSettings(const std::string& cluster_name, const std::s
 }
 
 Http::Code AdminImpl::handlerClusters(absl::string_view, Http::HeaderMap&,
-                                      Buffer::Instance& response) {
+                                      Buffer::Instance& response, AdminFilter&) {
   response.add(fmt::format("version_info::{}\n", server_.clusterManager().versionInfo()));
 
   for (auto& cluster : server_.clusterManager().clusters()) {
@@ -280,7 +290,7 @@ Http::Code AdminImpl::handlerClusters(absl::string_view, Http::HeaderMap&,
 
 // TODO(jsedgwick) Use query params to list available dumps, selectively dump, etc
 Http::Code AdminImpl::handlerConfigDump(absl::string_view, Http::HeaderMap&,
-                                        Buffer::Instance& response) const {
+                                        Buffer::Instance& response, AdminFilter&) const {
   envoy::admin::v2::ConfigDump dump;
   auto& config_dump_map = *(dump.mutable_configs());
   for (const auto& key_callback_pair : config_tracker_.getCallbacksMap()) {
@@ -296,7 +306,7 @@ Http::Code AdminImpl::handlerConfigDump(absl::string_view, Http::HeaderMap&,
 }
 
 Http::Code AdminImpl::handlerCpuProfiler(absl::string_view url, Http::HeaderMap&,
-                                         Buffer::Instance& response) {
+                                         Buffer::Instance& response, AdminFilter&) {
   Http::Utility::QueryParams query_params = Http::Utility::parseQueryString(url);
   if (query_params.size() != 1 || query_params.begin()->first != "enable" ||
       (query_params.begin()->second != "y" && query_params.begin()->second != "n")) {
@@ -320,27 +330,27 @@ Http::Code AdminImpl::handlerCpuProfiler(absl::string_view url, Http::HeaderMap&
 }
 
 Http::Code AdminImpl::handlerHealthcheckFail(absl::string_view, Http::HeaderMap&,
-                                             Buffer::Instance& response) {
+                                             Buffer::Instance& response, AdminFilter&) {
   server_.failHealthcheck(true);
   response.add("OK\n");
   return Http::Code::OK;
 }
 
 Http::Code AdminImpl::handlerHealthcheckOk(absl::string_view, Http::HeaderMap&,
-                                           Buffer::Instance& response) {
+                                           Buffer::Instance& response, AdminFilter&) {
   server_.failHealthcheck(false);
   response.add("OK\n");
   return Http::Code::OK;
 }
 
 Http::Code AdminImpl::handlerHotRestartVersion(absl::string_view, Http::HeaderMap&,
-                                               Buffer::Instance& response) {
+                                               Buffer::Instance& response, AdminFilter&) {
   response.add(server_.hotRestart().version());
   return Http::Code::OK;
 }
 
 Http::Code AdminImpl::handlerLogging(absl::string_view url, Http::HeaderMap&,
-                                     Buffer::Instance& response) {
+                                     Buffer::Instance& response, AdminFilter&) {
   Http::Utility::QueryParams query_params = Http::Utility::parseQueryString(url);
 
   Http::Code rc = Http::Code::OK;
@@ -366,7 +376,7 @@ Http::Code AdminImpl::handlerLogging(absl::string_view url, Http::HeaderMap&,
 }
 
 Http::Code AdminImpl::handlerResetCounters(absl::string_view, Http::HeaderMap&,
-                                           Buffer::Instance& response) {
+                                           Buffer::Instance& response, AdminFilter&) {
   for (const Stats::CounterSharedPtr& counter : server_.stats().counters()) {
     counter->reset();
   }
@@ -376,7 +386,7 @@ Http::Code AdminImpl::handlerResetCounters(absl::string_view, Http::HeaderMap&,
 }
 
 Http::Code AdminImpl::handlerServerInfo(absl::string_view, Http::HeaderMap&,
-                                        Buffer::Instance& response) {
+                                        Buffer::Instance& response, AdminFilter&) {
   time_t current_time = time(nullptr);
   response.add(fmt::format("envoy {} {} {} {} {}\n", VersionInfo::version(),
                            server_.healthCheckFailed() ? "draining" : "live",
@@ -387,7 +397,7 @@ Http::Code AdminImpl::handlerServerInfo(absl::string_view, Http::HeaderMap&,
 }
 
 Http::Code AdminImpl::handlerStats(absl::string_view url, Http::HeaderMap& response_headers,
-                                   Buffer::Instance& response) {
+                                   Buffer::Instance& response, AdminFilter& admin_filter) {
   // We currently don't support timers locally (only via statsd) so just group all the counters
   // and gauges together, alpha sort them, and spit them out.
   Http::Code rc = Http::Code::OK;
@@ -414,7 +424,7 @@ Http::Code AdminImpl::handlerStats(absl::string_view url, Http::HeaderMap& respo
           Http::Headers::get().ContentTypeValues.Json);
       response.add(AdminImpl::statsAsJson(all_stats));
     } else if (format_key == "format" && format_value == "prometheus") {
-      return handlerPrometheusStats(url, response_headers, response);
+      return handlerPrometheusStats(url, response_headers, response, admin_filter);
     } else {
       response.add("usage: /stats?format=json \n");
       response.add("\n");
@@ -425,7 +435,7 @@ Http::Code AdminImpl::handlerStats(absl::string_view url, Http::HeaderMap& respo
 }
 
 Http::Code AdminImpl::handlerPrometheusStats(absl::string_view, Http::HeaderMap&,
-                                             Buffer::Instance& response) {
+                                             Buffer::Instance& response, AdminFilter&) {
   PrometheusStatsFormatter::statsAsPrometheus(server_.stats().counters(), server_.stats().gauges(),
                                               response);
   return Http::Code::OK;
@@ -504,14 +514,14 @@ std::string AdminImpl::statsAsJson(const std::map<std::string, uint64_t>& all_st
 }
 
 Http::Code AdminImpl::handlerQuitQuitQuit(absl::string_view, Http::HeaderMap&,
-                                          Buffer::Instance& response) {
+                                          Buffer::Instance& response, AdminFilter&) {
   server_.shutdown();
   response.add("OK\n");
   return Http::Code::OK;
 }
 
 Http::Code AdminImpl::handlerListenerInfo(absl::string_view, Http::HeaderMap& response_headers,
-                                          Buffer::Instance& response) {
+                                          Buffer::Instance& response, AdminFilter&) {
   response_headers.insertContentType().value().setReference(
       Http::Headers::get().ContentTypeValues.Json);
   std::list<std::string> listeners;
@@ -522,8 +532,8 @@ Http::Code AdminImpl::handlerListenerInfo(absl::string_view, Http::HeaderMap& re
   return Http::Code::OK;
 }
 
-Http::Code AdminImpl::handlerCerts(absl::string_view, Http::HeaderMap&,
-                                   Buffer::Instance& response) {
+Http::Code AdminImpl::handlerCerts(absl::string_view, Http::HeaderMap&, Buffer::Instance& response,
+                                   AdminFilter&) {
   // This set is used to track distinct certificates. We may have multiple listeners, upstreams, etc
   // using the same cert.
   std::unordered_set<std::string> context_info_set;
@@ -542,7 +552,7 @@ Http::Code AdminImpl::handlerCerts(absl::string_view, Http::HeaderMap&,
 }
 
 Http::Code AdminImpl::handlerRuntime(absl::string_view url, Http::HeaderMap& response_headers,
-                                     Buffer::Instance& response) {
+                                     Buffer::Instance& response, AdminFilter&) {
   const Http::Utility::QueryParams params = Http::Utility::parseQueryString(url);
   response_headers.insertContentType().value().setReference(
       Http::Headers::get().ContentTypeValues.Json);
@@ -630,7 +640,7 @@ std::string AdminImpl::runtimeAsJson(
 }
 
 Http::Code AdminImpl::handlerRuntimeModify(absl::string_view url, Http::HeaderMap&,
-                                           Buffer::Instance& response) {
+                                           Buffer::Instance& response, AdminFilter&) {
   const Http::Utility::QueryParams params = Http::Utility::parseQueryString(url);
   if (params.empty()) {
     response.add("usage: /runtime_modify?key1=value1&key2=value2&keyN=valueN\n");
@@ -653,7 +663,8 @@ void AdminFilter::onComplete() {
   Buffer::OwnedImpl response;
   Http::HeaderMapPtr header_map{new Http::HeaderMapImpl};
   RELEASE_ASSERT(request_headers_);
-  Http::Code code = parent_.runCallback(path, *request_headers_, *header_map, response);
+  Http::Code code = parent_.runCallback(path, *header_map, response, *this);
+
   header_map->insertStatus().value(std::to_string(enumToInt(code)));
   const auto& headers = Http::Headers::get();
   if (header_map->ContentType() == nullptr) {
@@ -668,10 +679,11 @@ void AdminFilter::onComplete() {
 
   // Under no circumstance should browsers sniff content-type.
   header_map->addReference(headers.XContentTypeOptions, headers.XContentTypeOptionValues.Nosniff);
-  callbacks_->encodeHeaders(std::move(header_map), response.length() == 0);
+  callbacks_->encodeHeaders(std::move(header_map),
+                            end_stream_on_complete_ && response.length() == 0);
 
   if (response.length() > 0) {
-    callbacks_->encodeData(response, true);
+    callbacks_->encodeData(response, end_stream_on_complete_);
   }
 }
 
@@ -702,7 +714,7 @@ AdminImpl::AdminImpl(const std::string& access_log_path, const std::string& prof
            MAKE_ADMIN_HANDLER(handlerHealthcheckOk), false, true},
           {"/help", "print out list of admin commands", MAKE_ADMIN_HANDLER(handlerHelp), false,
            false},
-          {"/hot_restart_version", "print the hot restart compatability version",
+          {"/hot_restart_version", "print the hot restart compatibility version",
            MAKE_ADMIN_HANDLER(handlerHotRestartVersion), false, false},
           {"/logging", "query/change logging levels", MAKE_ADMIN_HANDLER(handlerLogging), false,
            true},
@@ -719,7 +731,9 @@ AdminImpl::AdminImpl(const std::string& access_log_path, const std::string& prof
            false},
           {"/runtime", "print runtime values", MAKE_ADMIN_HANDLER(handlerRuntime), false, false},
           {"/runtime_modify", "modify runtime values", MAKE_ADMIN_HANDLER(handlerRuntimeModify),
-           false, true}},
+           false, true},
+      },
+
       // TODO(jsedgwick) add /runtime_reset endpoint that removes all admin-set values
       listener_(*this, std::move(listener_scope)) {
 
@@ -759,8 +773,8 @@ void AdminImpl::createFilterChain(Http::FilterChainFactoryCallbacks& callbacks) 
 }
 
 Http::Code AdminImpl::runCallback(absl::string_view path_and_query,
-                                  const Http::HeaderMap& request_headers,
-                                  Http::HeaderMap& response_headers, Buffer::Instance& response) {
+                                  Http::HeaderMap& response_headers, Buffer::Instance& response,
+                                  AdminFilter& admin_filter) {
   Http::Code code = Http::Code::OK;
   bool found_handler = false;
 
@@ -772,13 +786,14 @@ Http::Code AdminImpl::runCallback(absl::string_view path_and_query,
   for (const UrlHandler& handler : handlers_) {
     if (path_and_query.compare(0, query_index, handler.prefix_) == 0) {
       if (handler.mutates_server_state_) {
-        const absl::string_view method = request_headers.Method()->value().getStringView();
+        const absl::string_view method =
+            admin_filter.getRequestHeaders()->Method()->value().getStringView();
         if (method != Http::Headers::get().MethodValues.Post) {
           ENVOY_LOG(warn, "admin path \"{}\" mutates state, method={} rather than POST",
                     handler.prefix_, method);
         }
       }
-      code = handler.handler_(path_and_query, response_headers, response);
+      code = handler.handler_(path_and_query, response_headers, response, admin_filter);
       found_handler = true;
       break;
     }
@@ -788,7 +803,7 @@ Http::Code AdminImpl::runCallback(absl::string_view path_and_query,
     // Extra space is emitted below to have "invalid path." be a separate sentence in the
     // 404 output from "admin commands are:" in handlerHelp.
     response.add("invalid path. ");
-    handlerHelp(path_and_query, response_headers, response);
+    handlerHelp(path_and_query, response_headers, response, admin_filter);
     code = Http::Code::NotFound;
   }
 
@@ -806,7 +821,8 @@ std::vector<const AdminImpl::UrlHandler*> AdminImpl::sortedHandlers() const {
   return sorted_handlers;
 }
 
-Http::Code AdminImpl::handlerHelp(absl::string_view, Http::HeaderMap&, Buffer::Instance& response) {
+Http::Code AdminImpl::handlerHelp(absl::string_view, Http::HeaderMap&, Buffer::Instance& response,
+                                  AdminFilter&) {
   response.add("admin commands are:\n");
 
   // Prefix order is used during searching, but for printing do them in alpha order.
@@ -817,7 +833,7 @@ Http::Code AdminImpl::handlerHelp(absl::string_view, Http::HeaderMap&, Buffer::I
 }
 
 Http::Code AdminImpl::handlerAdminHome(absl::string_view, Http::HeaderMap& response_headers,
-                                       Buffer::Instance& response) {
+                                       Buffer::Instance& response, AdminFilter&) {
   response_headers.insertContentType().value().setReference(
       Http::Headers::get().ContentTypeValues.Html);
 

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -31,6 +31,7 @@
 namespace Envoy {
 namespace Server {
 
+class AdminFilter;
 /**
  * Implementation of Server::Admin.
  */
@@ -44,8 +45,8 @@ public:
             const std::string& address_out_path, Network::Address::InstanceConstSharedPtr address,
             Server::Instance& server, Stats::ScopePtr&& listener_scope);
 
-  Http::Code runCallback(absl::string_view path_and_query, const Http::HeaderMap& request_headers,
-                         Http::HeaderMap& response_headers, Buffer::Instance& response);
+  Http::Code runCallback(absl::string_view path_and_query, Http::HeaderMap& response_headers,
+                         Buffer::Instance& response, AdminFilter& admin_filter);
   const Network::Socket& socket() override { return *socket_; }
   Network::Socket& mutable_socket() { return *socket_; }
   Network::ListenerConfig& listener() { return listener_; }
@@ -144,43 +145,50 @@ private:
    * URL handlers.
    */
   Http::Code handlerAdminHome(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                              Buffer::Instance& response);
+                              Buffer::Instance& response, AdminFilter&);
   Http::Code handlerCerts(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                          Buffer::Instance& response);
+                          Buffer::Instance& response, AdminFilter&);
   Http::Code handlerClusters(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                             Buffer::Instance& response);
+                             Buffer::Instance& response, AdminFilter&);
   Http::Code handlerConfigDump(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                               Buffer::Instance& response) const;
+                               Buffer::Instance& response, AdminFilter&) const;
   Http::Code handlerCpuProfiler(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                                Buffer::Instance& response);
+                                Buffer::Instance& response, AdminFilter&);
   Http::Code handlerHealthcheckFail(absl::string_view path_and_query,
-                                    Http::HeaderMap& response_headers, Buffer::Instance& response);
+                                    Http::HeaderMap& response_headers, Buffer::Instance& response,
+                                    AdminFilter&);
   Http::Code handlerHealthcheckOk(absl::string_view path_and_query,
-                                  Http::HeaderMap& response_headers, Buffer::Instance& response);
+                                  Http::HeaderMap& response_headers, Buffer::Instance& response,
+                                  AdminFilter&);
   Http::Code handlerHelp(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                         Buffer::Instance& response);
+                         Buffer::Instance& response, AdminFilter&);
   Http::Code handlerHotRestartVersion(absl::string_view path_and_query,
-                                      Http::HeaderMap& response_headers,
-                                      Buffer::Instance& response);
+                                      Http::HeaderMap& response_headers, Buffer::Instance& response,
+                                      AdminFilter&);
   Http::Code handlerListenerInfo(absl::string_view path_and_query,
-                                 Http::HeaderMap& response_headers, Buffer::Instance& response);
+                                 Http::HeaderMap& response_headers, Buffer::Instance& response,
+                                 AdminFilter&);
   Http::Code handlerLogging(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                            Buffer::Instance& response);
-  Http::Code handlerMain(const std::string& path, Buffer::Instance& response);
+                            Buffer::Instance& response, AdminFilter&);
+  Http::Code handlerMain(const std::string& path, Buffer::Instance& response, AdminFilter&);
   Http::Code handlerQuitQuitQuit(absl::string_view path_and_query,
-                                 Http::HeaderMap& response_headers, Buffer::Instance& response);
+                                 Http::HeaderMap& response_headers, Buffer::Instance& response,
+                                 AdminFilter&);
   Http::Code handlerResetCounters(absl::string_view path_and_query,
-                                  Http::HeaderMap& response_headers, Buffer::Instance& response);
+                                  Http::HeaderMap& response_headers, Buffer::Instance& response,
+                                  AdminFilter&);
   Http::Code handlerServerInfo(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                               Buffer::Instance& response);
+                               Buffer::Instance& response, AdminFilter&);
   Http::Code handlerStats(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                          Buffer::Instance& response);
+                          Buffer::Instance& response, AdminFilter&);
   Http::Code handlerPrometheusStats(absl::string_view path_and_query,
-                                    Http::HeaderMap& response_headers, Buffer::Instance& response);
+                                    Http::HeaderMap& response_headers, Buffer::Instance& response,
+                                    AdminFilter&);
   Http::Code handlerRuntime(absl::string_view path_and_query, Http::HeaderMap& response_headers,
-                            Buffer::Instance& response);
+                            Buffer::Instance& response, AdminFilter&);
   Http::Code handlerRuntimeModify(absl::string_view path_and_query,
-                                  Http::HeaderMap& response_headers, Buffer::Instance& response);
+                                  Http::HeaderMap& response_headers, Buffer::Instance& response,
+                                  AdminFilter&);
 
   class AdminListener : public Network::ListenerConfig {
   public:
@@ -233,8 +241,10 @@ public:
   AdminFilter(AdminImpl& parent);
 
   // Http::StreamFilterBase
-  void onDestroy() override {}
-
+  void onDestroy() override;
+  void addOnDestroyCallback(std::function<void()> cb);
+  Http::StreamDecoderFilterCallbacks* getDecoderFilterCallbacks() { return callbacks_; }
+  const Http::HeaderMap* getRequestHeaders() { return request_headers_; }
   // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap& headers, bool end_stream) override;
   Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override;
@@ -242,6 +252,7 @@ public:
   void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override {
     callbacks_ = &callbacks;
   }
+  void setEndStreamOnComplete(const bool& end_stream) { end_stream_on_complete_ = end_stream; }
 
 private:
   /**
@@ -252,6 +263,8 @@ private:
   AdminImpl& parent_;
   Http::StreamDecoderFilterCallbacks* callbacks_{};
   Http::HeaderMap* request_headers_{};
+  std::list<std::function<void()>> on_destroy_callbacks_;
+  bool end_stream_on_complete_ = true;
 };
 
 /**

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -81,7 +81,7 @@ public:
         admin_("/dev/null", cpu_profile_path_, address_out_path_,
                Network::Test::getCanonicalLoopbackAddress(GetParam()), server_,
                listener_scope_.createScope("listener.admin.")),
-        request_headers_{{":path", "/"}} {
+        request_headers_{{":path", "/"}}, admin_filter_(admin_) {
 
     EXPECT_EQ(std::chrono::milliseconds(100), admin_.drainTimeout());
     admin_.tracingStats().random_sampling_.inc();
@@ -91,7 +91,8 @@ public:
   Http::Code runCallback(absl::string_view path_and_query, Http::HeaderMap& response_headers,
                          Buffer::Instance& response, absl::string_view method) {
     request_headers_.insertMethod().value(method.data(), method.size());
-    return admin_.runCallback(path_and_query, request_headers_, response_headers, response);
+    admin_filter_.decodeHeaders(request_headers_, false);
+    return admin_.runCallback(path_and_query, response_headers, response, admin_filter_);
   }
 
   Http::Code getCallback(absl::string_view path_and_query, Http::HeaderMap& response_headers,
@@ -112,6 +113,7 @@ public:
   Stats::IsolatedStoreImpl listener_scope_;
   AdminImpl admin_;
   Http::TestHeaderMapImpl request_headers_;
+  Server::AdminFilter admin_filter_;
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersions, AdminInstanceTest,
@@ -153,9 +155,10 @@ TEST_P(AdminInstanceTest, AdminBadProfiler) {
   Http::HeaderMapImpl header_map;
   const absl::string_view post = Http::Headers::get().MethodValues.Post;
   request_headers_.insertMethod().value(post.data(), post.size());
+  admin_filter_.decodeHeaders(request_headers_, false);
   EXPECT_NO_LOGS(EXPECT_EQ(Http::Code::InternalServerError,
-                           admin_bad_profile_path.runCallback("/cpuprofiler?enable=y",
-                                                              request_headers_, header_map, data)));
+                           admin_bad_profile_path.runCallback("/cpuprofiler?enable=y", header_map,
+                                                              data, admin_filter_)));
   EXPECT_FALSE(Profiler::Cpu::profilerEnabled());
 }
 
@@ -179,9 +182,8 @@ TEST_P(AdminInstanceTest, AdminBadAddressOutPath) {
 }
 
 TEST_P(AdminInstanceTest, CustomHandler) {
-  auto callback = [](absl::string_view, Http::HeaderMap&, Buffer::Instance&) -> Http::Code {
-    return Http::Code::Accepted;
-  };
+  auto callback = [](absl::string_view, Http::HeaderMap&, Buffer::Instance&,
+                     AdminFilter&) -> Http::Code { return Http::Code::Accepted; };
 
   // Test removable handler.
   EXPECT_NO_LOGS(EXPECT_TRUE(admin_.addHandler("/foo/bar", "hello", callback, true, false)));
@@ -207,9 +209,8 @@ TEST_P(AdminInstanceTest, CustomHandler) {
 }
 
 TEST_P(AdminInstanceTest, RejectHandlerWithXss) {
-  auto callback = [](absl::string_view, Http::HeaderMap&, Buffer::Instance&) -> Http::Code {
-    return Http::Code::Accepted;
-  };
+  auto callback = [](absl::string_view, Http::HeaderMap&, Buffer::Instance&,
+                     AdminFilter&) -> Http::Code { return Http::Code::Accepted; };
   EXPECT_LOG_CONTAINS("error",
                       "filter \"/foo<script>alert('hi')</script>\" contains invalid character '<'",
                       EXPECT_FALSE(admin_.addHandler("/foo<script>alert('hi')</script>", "hello",
@@ -217,9 +218,8 @@ TEST_P(AdminInstanceTest, RejectHandlerWithXss) {
 }
 
 TEST_P(AdminInstanceTest, RejectHandlerWithEmbeddedQuery) {
-  auto callback = [](absl::string_view, Http::HeaderMap&, Buffer::Instance&) -> Http::Code {
-    return Http::Code::Accepted;
-  };
+  auto callback = [](absl::string_view, Http::HeaderMap&, Buffer::Instance&,
+                     AdminFilter&) -> Http::Code { return Http::Code::Accepted; };
   EXPECT_LOG_CONTAINS("error",
                       "filter \"/bar?queryShouldNotBeInPrefix\" contains invalid character '?'",
                       EXPECT_FALSE(admin_.addHandler("/bar?queryShouldNotBeInPrefix", "hello",
@@ -227,9 +227,8 @@ TEST_P(AdminInstanceTest, RejectHandlerWithEmbeddedQuery) {
 }
 
 TEST_P(AdminInstanceTest, EscapeHelpTextWithPunctuation) {
-  auto callback = [](absl::string_view, Http::HeaderMap&, Buffer::Instance&) -> Http::Code {
-    return Http::Code::Accepted;
-  };
+  auto callback = [](absl::string_view, Http::HeaderMap&, Buffer::Instance&,
+                     AdminFilter&) -> Http::Code { return Http::Code::Accepted; };
 
   // It's OK to have help text with HTML characters in it, but when we render the home
   // page they need to be escaped.


### PR DESCRIPTION
Signed-off-by: trabetti <talis@il.ibm.com>

*title*: admin: add infrastructure, which will later be used for hystrix dashboard support 

*Description*: split from PR #2736
* Pass `AdminFilter` to admin handler, so that all its parameters can be used by the handler, without the need to pass them as arguments, will also enable adding more handler parameters without adding arguments.
* Handlers can add callbacks to be executed when connection is destroyed
* Support for streaming response

*Risk Level*: Medium 

*Testing*:
Will need to add coverage tests