### PR TITLE
health check: overriding health threshold for edge intervals

### DIFF
--- a/include/envoy/upstream/health_checker.h
+++ b/include/envoy/upstream/health_checker.h
@@ -10,7 +10,7 @@ namespace Upstream {
 
 enum class HealthState { Unhealthy, Healthy };
 
-enum class HealthTransition { Unchanged, Changed };
+enum class HealthTransition { Unchanged, Changed, ChangePending };
 
 /**
  * Wraps active health checking of an upstream cluster.

--- a/include/envoy/upstream/health_checker.h
+++ b/include/envoy/upstream/health_checker.h
@@ -10,7 +10,21 @@ namespace Upstream {
 
 enum class HealthState { Unhealthy, Healthy };
 
-enum class HealthTransition { Unchanged, Changed, ChangePending };
+enum class HealthTransition {
+  /**
+   * Used when the health state of a host hasn't changed.
+   */
+  Unchanged,
+  /**
+   * Used when the health state of a host has changed.
+   */
+  Changed,
+  /**
+   * Used when the health check result differs from the health state of a host, but a change to the
+   * latter is delayed due to healthy/unhealthy threshold settings.
+   */
+  ChangePending
+};
 
 /**
  * Wraps active health checking of an upstream cluster.

--- a/source/common/upstream/health_checker_base_impl.cc
+++ b/source/common/upstream/health_checker_base_impl.cc
@@ -49,7 +49,8 @@ void HealthCheckerImplBase::incHealthy() {
 }
 
 std::chrono::milliseconds HealthCheckerImplBase::interval(HealthState state,
-                                                          HealthTransition changed_state) const {
+                                                          HealthTransition changed_state,
+                                                          uint32_t state_run) const {
   // See if the cluster has ever made a connection. If not, we use a much slower interval to keep
   // the host info relatively up to date in case we suddenly start sending traffic to this cluster.
   // In general host updates are rare and this should greatly smooth out needless health checking.
@@ -59,12 +60,18 @@ std::chrono::milliseconds HealthCheckerImplBase::interval(HealthState state,
   if (cluster_.info()->stats().upstream_cx_total_.used()) {
     switch (state) {
     case HealthState::Unhealthy:
-      base_time_ms = changed_state == HealthTransition::Changed ? unhealthy_edge_interval_.count()
-                                                                : unhealthy_interval_.count();
+      base_time_ms = (changed_state == HealthTransition::Changed ||
+                      changed_state == HealthTransition::ChangePending) &&
+                             state_run == 1
+                         ? unhealthy_edge_interval_.count()
+                         : unhealthy_interval_.count();
       break;
     default:
-      base_time_ms = changed_state == HealthTransition::Changed ? healthy_edge_interval_.count()
-                                                                : interval_.count();
+      base_time_ms = (changed_state == HealthTransition::Changed ||
+                      changed_state == HealthTransition::ChangePending) &&
+                             state_run == 1
+                         ? healthy_edge_interval_.count()
+                         : interval_.count();
       break;
     }
   } else {
@@ -179,16 +186,19 @@ HealthCheckerImplBase::ActiveHealthCheckSession::~ActiveHealthCheckSession() {
 void HealthCheckerImplBase::ActiveHealthCheckSession::handleSuccess() {
   // If we are healthy, reset the # of unhealthy to zero.
   num_unhealthy_ = 0;
+  ++num_healthy_;
 
   HealthTransition changed_state = HealthTransition::Unchanged;
   if (host_->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC)) {
     // If this is the first time we ever got a check result on this host, we immediately move
     // it to healthy. This makes startup faster with a small reduction in overall reliability
     // depending on the HC settings.
-    if (first_check_ || ++num_healthy_ == parent_.healthy_threshold_) {
+    if (first_check_ || num_healthy_ == parent_.healthy_threshold_) {
       host_->healthFlagClear(Host::HealthFlag::FAILED_ACTIVE_HC);
       parent_.incHealthy();
       changed_state = HealthTransition::Changed;
+    } else {
+      changed_state = HealthTransition::ChangePending;
     }
   }
 
@@ -197,19 +207,22 @@ void HealthCheckerImplBase::ActiveHealthCheckSession::handleSuccess() {
   parent_.runCallbacks(host_, changed_state);
 
   timeout_timer_->disableTimer();
-  interval_timer_->enableTimer(parent_.interval(HealthState::Healthy, changed_state));
+  interval_timer_->enableTimer(parent_.interval(HealthState::Healthy, changed_state, num_healthy_));
 }
 
 HealthTransition HealthCheckerImplBase::ActiveHealthCheckSession::setUnhealthy(FailureType type) {
   // If we are unhealthy, reset the # of healthy to zero.
   num_healthy_ = 0;
+  ++num_unhealthy_;
 
   HealthTransition changed_state = HealthTransition::Unchanged;
   if (!host_->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC)) {
-    if (type != FailureType::Network || ++num_unhealthy_ == parent_.unhealthy_threshold_) {
+    if (type != FailureType::Network || num_unhealthy_ == parent_.unhealthy_threshold_) {
       host_->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
       parent_.decHealthy();
       changed_state = HealthTransition::Changed;
+    } else {
+      changed_state = HealthTransition::ChangePending;
     }
   }
 
@@ -228,7 +241,8 @@ HealthTransition HealthCheckerImplBase::ActiveHealthCheckSession::setUnhealthy(F
 void HealthCheckerImplBase::ActiveHealthCheckSession::handleFailure(FailureType type) {
   HealthTransition changed_state = setUnhealthy(type);
   timeout_timer_->disableTimer();
-  interval_timer_->enableTimer(parent_.interval(HealthState::Unhealthy, changed_state));
+  interval_timer_->enableTimer(
+      parent_.interval(HealthState::Unhealthy, changed_state, num_unhealthy_));
 }
 
 void HealthCheckerImplBase::ActiveHealthCheckSession::onIntervalBase() {

--- a/source/common/upstream/health_checker_base_impl.h
+++ b/source/common/upstream/health_checker_base_impl.h
@@ -108,8 +108,7 @@ private:
   void decHealthy();
   HealthCheckerStats generateStats(Stats::Scope& scope);
   void incHealthy();
-  std::chrono::milliseconds interval(HealthState state, HealthTransition changed_state,
-                                     uint32_t state_run) const;
+  std::chrono::milliseconds interval(HealthState state, HealthTransition changed_state) const;
   void onClusterMemberUpdate(const HostVector& hosts_added, const HostVector& hosts_removed);
   void refreshHealthyStat();
   void runCallbacks(HostSharedPtr host, HealthTransition changed_state);

--- a/source/common/upstream/health_checker_base_impl.h
+++ b/source/common/upstream/health_checker_base_impl.h
@@ -108,7 +108,8 @@ private:
   void decHealthy();
   HealthCheckerStats generateStats(Stats::Scope& scope);
   void incHealthy();
-  std::chrono::milliseconds interval(HealthState state, HealthTransition changed_state) const;
+  std::chrono::milliseconds interval(HealthState state, HealthTransition changed_state,
+                                     uint32_t state_run) const;
   void onClusterMemberUpdate(const HostVector& hosts_added, const HostVector& hosts_removed);
   void refreshHealthyStat();
   void runCallbacks(HostSharedPtr host, HealthTransition changed_state);

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -610,6 +610,9 @@ std::ostream& operator<<(std::ostream& out, HealthTransition changed_state) {
   case HealthTransition::Changed:
     out << "Changed";
     break;
+  case HealthTransition::ChangePending:
+    out << "ChangePending";
+    break;
   }
   return out;
 }

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -964,7 +964,7 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   health_checker_->start();
 
-  // First check should respect no_traffic_interval setting
+  // First check should respect no_traffic_interval setting.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(5000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
@@ -972,29 +972,29 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   cluster_->info_->stats().upstream_cx_total_.inc();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // Follow up successful checks should respect interval setting
+  // Follow up successful checks should respect interval setting.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // ditto
+  // Follow up successful checks should respect interval setting.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -1007,29 +1007,29 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   respond(0, "503", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // Subsequent failing checks should respect unhealthy_interval
+  // Subsequent failing checks should respect unhealthy_interval.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(2000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "503", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // ditto
+  // Subsequent failing checks should respect unhealthy_interval.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(2000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "503", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -1041,7 +1041,7 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   respond(0, "200", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -1051,7 +1051,7 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   respond(0, "200", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -1063,18 +1063,18 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   respond(0, "200", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // Subsequent checks shouldn't change the state
+  // Subsequent checks shouldn't change the state.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -1087,9 +1087,9 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   test_sessions_[0]->timeout_timer_->callback_();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a network timeout
+  // Needed after a network timeout.
   expectClientCreate(0);
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -1099,9 +1099,9 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   test_sessions_[0]->timeout_timer_->callback_();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a network timeout
+  // Needed after a network timeout.
   expectClientCreate(0);
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -1113,9 +1113,9 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   test_sessions_[0]->timeout_timer_->callback_();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a network timeout
+  // Needed after a network timeout.
   expectClientCreate(0);
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -1126,20 +1126,20 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   test_sessions_[0]->timeout_timer_->callback_();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a network timeout
+  // Needed after a network timeout.
   expectClientCreate(0);
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // When transitioning to a successful state, checks should respect healthy_edge_interval
+  // When transitioning to a successful state, checks should respect healthy_edge_interval.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(4000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -1149,7 +1149,7 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   respond(0, "200", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -1161,11 +1161,11 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   respond(0, "200", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // Subsequent checks shouldn't change the state
+  // Subsequent checks shouldn't change the state.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
@@ -2414,7 +2414,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   health_checker_->start();
 
-  // First check should respect no_traffic_interval setting
+  // First check should respect no_traffic_interval setting.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(5000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
@@ -2422,29 +2422,29 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   cluster_->info_->stats().upstream_cx_total_.inc();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // Follow up successful checks should respect interval setting
+  // Follow up successful checks should respect interval setting.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // ditto
+  // Follow up successful checks should respect interval setting.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -2457,29 +2457,29 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::NOT_SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // Subsequent failing checks should respect unhealthy_interval
+  // Subsequent failing checks should respect unhealthy_interval.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(2000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::NOT_SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // ditto
+  // Subsequent failing checks should respect unhealthy_interval.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(2000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::NOT_SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -2491,7 +2491,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -2501,7 +2501,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -2513,18 +2513,18 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // Subsequent checks shouldn't change the state
+  // Subsequent checks shouldn't change the state.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -2537,7 +2537,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   test_sessions_[0]->timeout_timer_->callback_();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -2547,7 +2547,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   test_sessions_[0]->timeout_timer_->callback_();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -2559,7 +2559,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   test_sessions_[0]->timeout_timer_->callback_();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -2570,18 +2570,18 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   test_sessions_[0]->timeout_timer_->callback_();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // When transitioning to a successful state, checks should respect healthy_edge_interval
+  // When transitioning to a successful state, checks should respect healthy_edge_interval.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(4000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -2591,7 +2591,7 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
@@ -2603,11 +2603,11 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
-  // needed after a response is sent
+  // Needed after a response is sent.
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // Subsequent checks shouldn't change the state
+  // Subsequent checks shouldn't change the state.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -166,8 +166,8 @@ public:
     healthy_edge_interval: 4s
     no_traffic_interval: 5s
     interval_jitter: 0s
-    unhealthy_threshold: 1
-    healthy_threshold: 1
+    unhealthy_threshold: 2
+    healthy_threshold: 2
     http_health_check:
       service_name: locations
       path: /healthcheck
@@ -714,7 +714,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirstServiceCheck) {
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false, false, false, health_checked_cluster);
@@ -795,7 +795,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirst) {
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false);
@@ -835,7 +835,7 @@ TEST_F(HttpHealthCheckerImplTest, HttpFail) {
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false);
@@ -856,7 +856,7 @@ TEST_F(HttpHealthCheckerImplTest, HttpFail) {
 
 TEST_F(HttpHealthCheckerImplTest, Disconnect) {
   setupNoServiceValidationHC();
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending)).Times(1);
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
@@ -894,7 +894,7 @@ TEST_F(HttpHealthCheckerImplTest, Timeout) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   health_checker_->start();
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->client_connection_, close(_));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
@@ -972,78 +972,168 @@ TEST_F(HttpHealthCheckerImplTest, HealthCheckIntervals) {
   cluster_->info_->stats().upstream_cx_total_.inc();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // Follow up successful check should respect interval setting
+  // Follow up successful checks should respect interval setting
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
+  // ditto
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // First check transitioning to failed state should respect unhealthy_edge_interval
+  // First failed check should respect unhealthy_edge_interval. A logical failure is not considered
+  // a network failure, therefore the unhealthy threshold is ignored and health state changes
+  // immediately
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(3000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "503", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // Second failing check should respect unhealthy_interval
+  // Subsequent failing checks should respect unhealthy_interval
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(2000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "503", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // All subsequent failing checks should respect unhealthy_interval
+  // ditto
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(2000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "503", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // When transitioning to a successful state, checks should respect healthy_edge_interval
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
+  // When transitioning to a successful state, checks should respect healthy_edge_interval. Health
+  // state should be delayed pending healthy threshold.
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(4000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // Any subsequent successful checks should also respect interval
+  // After the healthy threshold is reached, health state should change while checks should respect
+  // the default interval.
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  respond(0, "200", false);
+
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
+  expectStreamCreate(0);
+  test_sessions_[0]->interval_timer_->callback_();
+
+  // Subsequent checks shouldn't change the state
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
+  // First failed check after a run o successful ones should respect unhealthy_edge_interval. A
+  // timeout, being a network type failure, should respect unhealthy threshold before changing the
+  // health state.
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(3000)));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  test_sessions_[0]->timeout_timer_->callback_();
+
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a network timeout
+  expectClientCreate(0);
+  // needed after a response is sent
+  expectStreamCreate(0);
+  test_sessions_[0]->interval_timer_->callback_();
+
+  // Subsequent failing checks should respect unhealthy_interval. As the unhealthy threshold is
+  // reached, health state should also change.
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(2000)));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  test_sessions_[0]->timeout_timer_->callback_();
+
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a network timeout
+  expectClientCreate(0);
+  // needed after a response is sent
+  expectStreamCreate(0);
+  test_sessions_[0]->interval_timer_->callback_();
+
+  // Remaining failing checks shouldn't change the state.
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(2000)));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  test_sessions_[0]->timeout_timer_->callback_();
+
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a network timeout
+  expectClientCreate(0);
+  // needed after a response is sent
+  expectStreamCreate(0);
+  test_sessions_[0]->interval_timer_->callback_();
+
+  // When transitioning to a successful state, checks should respect healthy_edge_interval
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(4000)));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  respond(0, "200", false);
+
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
+  expectStreamCreate(0);
+  test_sessions_[0]->interval_timer_->callback_();
+
+  // After the healthy threshold is reached, health state should change while checks should respect
+  // the default interval.
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  respond(0, "200", false);
+
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
+  expectStreamCreate(0);
+  test_sessions_[0]->interval_timer_->callback_();
+
+  // Subsequent checks shouldn't change the state
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
@@ -1796,8 +1886,8 @@ public:
     config.mutable_healthy_edge_interval()->set_seconds(4);
     config.mutable_no_traffic_interval()->set_seconds(5);
     config.mutable_interval_jitter()->set_seconds(0);
-    config.mutable_unhealthy_threshold()->set_value(1);
-    config.mutable_healthy_threshold()->set_value(1);
+    config.mutable_unhealthy_threshold()->set_value(2);
+    config.mutable_healthy_threshold()->set_value(2);
     health_checker_.reset(
         new TestGrpcHealthCheckerImpl(*cluster_, config, dispatcher_, runtime_, random_));
     health_checker_->addHostCheckCompleteCb(
@@ -2161,7 +2251,7 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessStartFailedFailFirst) {
 
   expectHealthcheckStop(0);
   // Host still unhealthy, need yet another healthcheck.
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
   expectHostHealthy(false);
 
@@ -2197,7 +2287,7 @@ TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFail) {
 
   expectHealthcheckStop(0);
   // Host still considered unhealthy.
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
   expectHostHealthy(false);
 
@@ -2223,7 +2313,7 @@ TEST_F(GrpcHealthCheckerImplTest, Disconnect) {
 
   expectHealthcheckStop(0);
   // Network-type healthcheck failure should make host unhealthy only after 2nd event in a row.
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   test_sessions_[0]->client_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   expectHostHealthy(true);
 
@@ -2250,7 +2340,7 @@ TEST_F(GrpcHealthCheckerImplTest, Timeout) {
 
   expectHealthcheckStop(0);
   // Timeouts are considered network failures and make host unhealthy also after 2nd event.
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   test_sessions_[0]->timeout_timer_->callback_();
   expectHostHealthy(true);
 
@@ -2300,78 +2390,162 @@ TEST_F(GrpcHealthCheckerImplTest, HealthCheckIntervals) {
   cluster_->info_->stats().upstream_cx_total_.inc();
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // Follow up successful check should respect interval setting
+  // Follow up successful checks should respect interval setting
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
+  // ditto
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // First check transitioning to failed state should respect unhealthy_edge_interval
+  // First failed check should respect unhealthy_edge_interval. A logical failure is not considered
+  // a network failure, therefore the unhealthy threshold is ignored and health state changes
+  // immediately
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(3000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::NOT_SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // Second failing check should respect unhealthy_interval
+  // Subsequent failing checks should respect unhealthy_interval
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(2000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::NOT_SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // All subsequent failing checks should respect unhealthy_interval
+  // ditto
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(2000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::NOT_SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // When transitioning to a successful state, checks should respect healthy_edge_interval
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
+  // When transitioning to a successful state, checks should respect healthy_edge_interval. Health
+  // state should be delayed pending healthy threshold.
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(4000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
-  // Any subsequent successful checks should also respect interval
+  // After the healthy threshold is reached, health state should change while checks should respect
+  // the default interval.
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
+
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
+  expectStreamCreate(0);
+  test_sessions_[0]->interval_timer_->callback_();
+
+  // Subsequent checks shouldn't change the state
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
   expectStreamCreate(0);
   test_sessions_[0]->interval_timer_->callback_();
 
+  // First failed check after a run o successful ones should respect unhealthy_edge_interval. A
+  // timeout, being a network type failure, should respect unhealthy threshold before changing the
+  // health state.
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(3000)));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  test_sessions_[0]->timeout_timer_->callback_();
+
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
+  expectStreamCreate(0);
+  test_sessions_[0]->interval_timer_->callback_();
+
+  // Subsequent failing checks should respect unhealthy_interval. As the unhealthy threshold is
+  // reached, health state should also change.
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(2000)));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  test_sessions_[0]->timeout_timer_->callback_();
+
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
+  expectStreamCreate(0);
+  test_sessions_[0]->interval_timer_->callback_();
+
+  // Remaining failing checks shouldn't change the state.
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(2000)));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  test_sessions_[0]->timeout_timer_->callback_();
+
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
+  expectStreamCreate(0);
+  test_sessions_[0]->interval_timer_->callback_();
+
+  // When transitioning to a successful state, checks should respect healthy_edge_interval
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(4000)));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
+
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
+  expectStreamCreate(0);
+  test_sessions_[0]->interval_timer_->callback_();
+
+  // After the healthy threshold is reached, health state should change while checks should respect
+  // the default interval.
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
+
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  // needed after a response is sent
+  expectStreamCreate(0);
+  test_sessions_[0]->interval_timer_->callback_();
+
+  // Subsequent checks shouldn't change the state
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(1000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());


### PR DESCRIPTION
The current implementation of `healthy_edge_interval` and
`unhealthy_edge_interval` will wait for the health threshold to be
reached before the interval is used.

That leads to situations like this:
- `healthy_threshold` is set to 3;
- host health state is currently `unhealthy`;
- host health check fails, next check happens after `unhealthy_interval`;
- host health check succeeds, next check happens after `interval`;
- host health check succeeds, next check happens after `interval`;
- host health check succeeds, next check happens after `healthy_edge_interval`;
- host health check succeeds, next check happens after `interval`.

The behavior above defeats the purpose of having an edge interval since
its goal is to detect health state changes faster whilst reducing the
burden of health checks on healthy hosts.

The intended behavior to achieve edge interval's purpose on the same scenario
would be:
- host health check fails, next check happens after `unhealthy_interval`;
- host health check succeeds, next check happens after `healthy_edge_interval`;
- host health check succeeds, next check happens after `healthy_edge_interval`;
- host health check succeeds, next check happens after `interval`;
- host health check succeeds, next check happens after `interval`.

This PR Fixes health check interval overrides so that the latter
bahavior is achieved.

Fixes: https://github.com/envoyproxy/envoy/issues/3173