### PR TITLE
Adding missing `@bazel` prefixes that dependencies need.

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -63,22 +63,22 @@ def _envoy_stamped_linkopts():
     # MacOS doesn't have an official equivalent to the `.note.gnu.build-id`
     # ELF section, so just stuff the raw ID into a new text section.
     "@bazel_tools//tools/osx:darwin": [
-        "-sectcreate __TEXT __build_id", "$(location //bazel:raw_build_id.ldscript)"
+        "-sectcreate __TEXT __build_id", "$(location @envoy//bazel:raw_build_id.ldscript)"
     ],
 
     # Note: assumes GNU GCC (or compatible) handling of `--build-id` flag.
     "//conditions:default": [
-        "-Wl,@$(location //bazel:gnu_build_id.ldscript)",
+        "-Wl,@$(location @envoy//bazel:gnu_build_id.ldscript)",
     ],
   })
 
 def _envoy_stamped_deps():
   return select({
     "@bazel_tools//tools/osx:darwin": [
-        "//bazel:raw_build_id.ldscript"
+        "@envoy//bazel:raw_build_id.ldscript"
     ],
     "//conditions:default": [
-        "//bazel:gnu_build_id.ldscript",
+        "@envoy//bazel:gnu_build_id.ldscript",
     ],
   })
 


### PR DESCRIPTION
I tested https://github.com/envoyproxy/envoy/pull/3021 with
envoy-filter-example to verify it works for non-default workspace roots,
but didn't realize the filter example's envoy binary is built without
linkstamping so the testing was worthless.

Experimental evidence is that the `deps` field needs `@envoy` but the
linker options are fine without it. I don't understand why this would be
true so I'm going to put `@envoy` in both places.

*Risk Level*: Low

Signed-off-by: John Millikin <jmillikin@stripe.com>

*Testing*:
Tested on a local envoy-filter-example clone with `stamped = True` set.
