### PR TITLE
docs: fix a small typo

### DIFF
--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -183,7 +183,7 @@ The fields are:
 
   Outputs all statistics on demand. This command is very useful for local debugging.
   Histograms will output the computed quantiles i.e P0,P25,P50,P75,P90,P99,P99.9 and P100. 
-  The output for each quantile will be in the form of (inteval,cumulative) where interval value 
+  The output for each quantile will be in the form of (interval,cumulative) where interval value 
   represents the summary since last flush interval and cumulative value represents the 
   summary since the start of envoy instance.
   See :ref:`here <operations_stats>` for more information.


### PR DESCRIPTION
Signed-off-by: Simon Pasquier <spasquie@redhat.com>

*title*: docs: fix a small typo

*Description*:
s/inteval/interval/

*Risk Level*: Low 

*Testing*: N/A

*Docs Changes*: see description


*Release Notes*: N/A
