### PR TITLE
http: Adding flexible remove function to HeaderMap

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
+#include <regex>
 #include <string>
 
 #include "envoy/common/pure.h"
@@ -464,6 +465,14 @@ public:
    * @param key supplies the header key to remove.
    */
   virtual void remove(const LowerCaseString& key) PURE;
+
+  /**
+   * Remove all instances of headers with key matching the supplies regex.
+   * @param key_matcher supplies the regex to match header keys against. Note
+   * that this will be matching against LowerCaseString, so should be using
+   * lowercase characters.
+   */
+  virtual void remove(const std::regex& key_matcher) PURE;
 
   /**
    * @return the number of headers in the map.

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -467,7 +467,7 @@ public:
   virtual void remove(const LowerCaseString& key) PURE;
 
   /**
-   * Remove all instances of headers with key matching the supplies regex.
+   * Remove all instances of headers with key matching the supplied regex.
    * @param key_matcher supplies the regex to match header keys against. Note
    * that this will be matching against LowerCaseString, so should be using
    * lowercase characters.

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
-#include <regex>
 #include <string>
 
 #include "envoy/common/pure.h"
@@ -467,12 +466,10 @@ public:
   virtual void remove(const LowerCaseString& key) PURE;
 
   /**
-   * Remove all instances of headers with key matching the supplied regex.
-   * @param key_matcher supplies the regex to match header keys against. Note
-   * that this will be matching against LowerCaseString, so should be using
-   * lowercase characters.
+   * Remove all instances of headers where the key begins with the supplied prefix.
+   * @param prefix supplies the prefix to match header keys against.
    */
-  virtual void remove(const std::regex& key_matcher) PURE;
+  virtual void removePrefix(const LowerCaseString& prefix) PURE;
 
   /**
    * @return the number of headers in the map.

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -464,6 +464,17 @@ void HeaderMapImpl::remove(const LowerCaseString& key) {
   }
 }
 
+void HeaderMapImpl::remove(const std::regex& regex) {
+  for (auto i = headers_.begin(); i != headers_.end();) {
+    absl::string_view key = i->key().getStringView();
+    if (std::regex_search(key.begin(), key.end(), regex)) {
+      i = headers_.erase(i);
+    } else {
+      ++i;
+    }
+  }
+}
+
 HeaderMapImpl::HeaderEntryImpl& HeaderMapImpl::maybeCreateInline(HeaderEntryImpl** entry,
                                                                  const LowerCaseString& key) {
   if (*entry) {

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -68,6 +68,7 @@ public:
   void iterateReverse(ConstIterateCb cb, void* context) const override;
   Lookup lookup(const LowerCaseString& key, const HeaderEntry** entry) const override;
   void remove(const LowerCaseString& key) override;
+  void remove(const std::regex& regex) override;
   size_t size() const override { return headers_.size(); }
 
 protected:

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -68,7 +68,7 @@ public:
   void iterateReverse(ConstIterateCb cb, void* context) const override;
   Lookup lookup(const LowerCaseString& key, const HeaderEntry** entry) const override;
   void remove(const LowerCaseString& key) override;
-  void remove(const std::regex& regex) override;
+  void removePrefix(const LowerCaseString& key) override;
   size_t size() const override { return headers_.size(); }
 
 protected:

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -349,6 +349,44 @@ TEST(HeaderMapImplTest, Remove) {
   EXPECT_EQ(0UL, headers.size());
 }
 
+TEST(HeaderMapImplTest, RemoveRegex) {
+  // These will match.
+  LowerCaseString key1 = LowerCaseString("X-prefix-foo");
+  LowerCaseString key3 = LowerCaseString("X-Prefix-");
+  LowerCaseString key5 = LowerCaseString("x-prefix-eep");
+  // These will not.
+  LowerCaseString key2 = LowerCaseString(" x-prefix-foo");
+  LowerCaseString key4 = LowerCaseString("y-x-prefix-foo");
+
+  HeaderMapImpl headers;
+  headers.addReference(key1, "value");
+  headers.addReference(key2, "value");
+  headers.addReference(key3, "value");
+  headers.addReference(key4, "value");
+  headers.addReference(key5, "value");
+
+  // Trying to remove upper case strings from LowerCaseStrings will not work.
+  headers.remove(std::regex("^X-Prefix-"));
+  EXPECT_NE(nullptr, headers.get(key1));
+  EXPECT_NE(nullptr, headers.get(key2));
+  EXPECT_NE(nullptr, headers.get(key3));
+  EXPECT_NE(nullptr, headers.get(key4));
+  EXPECT_NE(nullptr, headers.get(key5));
+
+  // Test removing the first header, middle headers, and the end header.
+  headers.remove(std::regex("^x-prefix-"));
+  EXPECT_EQ(nullptr, headers.get(key1));
+  EXPECT_NE(nullptr, headers.get(key2));
+  EXPECT_EQ(nullptr, headers.get(key3));
+  EXPECT_NE(nullptr, headers.get(key4));
+  EXPECT_EQ(nullptr, headers.get(key5));
+
+  // Remove all headers.
+  headers.remove(std::regex(".*"));
+  EXPECT_EQ(nullptr, headers.get(key2));
+  EXPECT_EQ(nullptr, headers.get(key4));
+}
+
 TEST(HeaderMapImplTest, SetRemovesAllValues) {
   HeaderMapImpl headers;
 

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -385,6 +385,13 @@ TEST(HeaderMapImplTest, RemoveRegex) {
   headers.remove(std::regex(".*"));
   EXPECT_EQ(nullptr, headers.get(key2));
   EXPECT_EQ(nullptr, headers.get(key4));
+
+  // Add inline and remove by regex
+  headers.insertContentLength().value(5);
+  EXPECT_STREQ("5", headers.ContentLength()->value().c_str());
+  EXPECT_EQ(1UL, headers.size());
+  headers.remove(std::regex("content"));
+  EXPECT_EQ(nullptr, headers.ContentLength());
 }
 
 TEST(HeaderMapImplTest, SetRemovesAllValues) {

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -365,16 +365,8 @@ TEST(HeaderMapImplTest, RemoveRegex) {
   headers.addReference(key4, "value");
   headers.addReference(key5, "value");
 
-  // Trying to remove upper case strings from LowerCaseStrings will not work.
-  headers.remove(std::regex("^X-Prefix-"));
-  EXPECT_NE(nullptr, headers.get(key1));
-  EXPECT_NE(nullptr, headers.get(key2));
-  EXPECT_NE(nullptr, headers.get(key3));
-  EXPECT_NE(nullptr, headers.get(key4));
-  EXPECT_NE(nullptr, headers.get(key5));
-
   // Test removing the first header, middle headers, and the end header.
-  headers.remove(std::regex("^x-prefix-"));
+  headers.removePrefix(LowerCaseString("x-prefix-"));
   EXPECT_EQ(nullptr, headers.get(key1));
   EXPECT_NE(nullptr, headers.get(key2));
   EXPECT_EQ(nullptr, headers.get(key3));
@@ -382,7 +374,7 @@ TEST(HeaderMapImplTest, RemoveRegex) {
   EXPECT_EQ(nullptr, headers.get(key5));
 
   // Remove all headers.
-  headers.remove(std::regex(".*"));
+  headers.removePrefix(LowerCaseString(""));
   EXPECT_EQ(nullptr, headers.get(key2));
   EXPECT_EQ(nullptr, headers.get(key4));
 
@@ -390,7 +382,7 @@ TEST(HeaderMapImplTest, RemoveRegex) {
   headers.insertContentLength().value(5);
   EXPECT_STREQ("5", headers.ContentLength()->value().c_str());
   EXPECT_EQ(1UL, headers.size());
-  headers.remove(std::regex("content"));
+  headers.removePrefix(LowerCaseString("content"));
   EXPECT_EQ(nullptr, headers.ContentLength());
 }
 


### PR DESCRIPTION
It's fairly common in industry for companies to have their own internal headers with common prefixes (x-lyft- akamai-x-, etc) and seems generally useful to be able to clean headers going back to the public internet in a more performant way than collecting all keys with iterate() and following up with bunch of separate O(n) remove() calls. 

*Risk Level*: Low (adding unused-upstream header utility)
*Testing*: unit tests
*Docs Changes*: n/a
*Release Notes*: n/a