### PR TITLE
Access log trailers

### DIFF
--- a/api/envoy/config/accesslog/v2/als.proto
+++ b/api/envoy/config/accesslog/v2/als.proto
@@ -27,6 +27,9 @@ message HttpGrpcAccessLogConfig {
 
   // Additional response headers to log in *HTTPResponseProperties.response_headers*.
   repeated string additional_response_headers_to_log = 3;
+
+  // Additional response trailers to log in *HTTPResponseProperties.response_trailers*.
+  repeated string additional_response_trailers_to_log = 4;
 }
 
 // Common configuration for gRPC access logs.

--- a/api/envoy/config/filter/accesslog/v2/accesslog.proto
+++ b/api/envoy/config/filter/accesslog/v2/accesslog.proto
@@ -269,6 +269,9 @@ message HTTPResponseProperties {
 
   // Map of additional headers configured to be logged.
   map<string, string> response_headers = 4;
+
+  // Map of trailers configured to be logged.
+  map<string, string> response_trailers = 5;
 }
 
 // [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.

--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -164,6 +164,13 @@ The following command operators are supported:
   TCP
     Not implemented ("-").
 
+%TRAIL(X?Y):Z%
+  HTTP
+    Same as **%REQ(X?Y):Z%** but taken from HTTP response trailers.
+
+  TCP
+    Not implemented ("-").
+
 %DYNAMIC_METADATA(NAMESPACE:KEY*):Z%
   HTTP
     :ref:`Dynamic Metadata <envoy_api_msg_core.Metadata>` info,

--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -164,7 +164,7 @@ The following command operators are supported:
   TCP
     Not implemented ("-").
 
-%TRAIL(X?Y):Z%
+%TRAILER(X?Y):Z%
   HTTP
     Same as **%REQ(X?Y):Z%** but taken from HTTP response trailers.
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -4,6 +4,7 @@ Version history
 1.7.0 (Pending)
 ===============
 
+* access log: ability to log response trailers
 * access log: ability to format START_TIME
 * access log: added DYNAMIC_METADATA :ref:`access log formatter <config_access_log_format>`.
 * admin: added :http:get:`/config_dump` for dumping current configs

--- a/include/envoy/access_log/access_log.h
+++ b/include/envoy/access_log/access_log.h
@@ -62,7 +62,8 @@ public:
    *                      the request headers.
    */
   virtual void log(const Http::HeaderMap* request_headers, const Http::HeaderMap* response_headers,
-                   const Http::HeaderMap* response_trailers, const RequestInfo::RequestInfo& request_info) PURE;
+                   const Http::HeaderMap* response_trailers,
+                   const RequestInfo::RequestInfo& request_info) PURE;
 };
 
 typedef std::shared_ptr<Instance> InstanceSharedPtr;

--- a/include/envoy/access_log/access_log.h
+++ b/include/envoy/access_log/access_log.h
@@ -62,7 +62,7 @@ public:
    *                      the request headers.
    */
   virtual void log(const Http::HeaderMap* request_headers, const Http::HeaderMap* response_headers,
-                   const RequestInfo::RequestInfo& request_info) PURE;
+                   const Http::HeaderMap* response_trailers, const RequestInfo::RequestInfo& request_info) PURE;
 };
 
 typedef std::shared_ptr<Instance> InstanceSharedPtr;
@@ -76,6 +76,7 @@ public:
 
   virtual std::string format(const Http::HeaderMap& request_headers,
                              const Http::HeaderMap& response_headers,
+                             const Http::HeaderMap& response_trailers,
                              const RequestInfo::RequestInfo& request_info) const PURE;
 };
 

--- a/include/envoy/access_log/access_log.h
+++ b/include/envoy/access_log/access_log.h
@@ -58,6 +58,7 @@ public:
    * Log a completed request.
    * @param request_headers supplies the incoming request headers after filtering.
    * @param response_headers supplies response headers.
+   * @param response_trailers supplies response trailers.
    * @param request_info supplies additional information about the request not contained in
    *                      the request headers.
    */

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -171,7 +171,7 @@ std::vector<FormatterPtr> AccessLogFormatParser::parse(const std::string& format
 
         formatters.emplace_back(
             new ResponseHeaderFormatter(main_header, alternative_header, max_length));
-      } else if (token.find("TRAIL(") == 0) {
+      } else if (token.find("TRAILER(") == 0) {
         std::string main_header, alternative_header;
         absl::optional<size_t> max_length;
 

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -63,7 +63,8 @@ std::string FormatterImpl::format(const Http::HeaderMap& request_headers,
   log_line.reserve(256);
 
   for (const FormatterPtr& formatter : formatters_) {
-    log_line += formatter->format(request_headers, response_headers, response_trailers, request_info);
+    log_line +=
+        formatter->format(request_headers, response_headers, response_trailers, request_info);
   }
 
   return log_line;
@@ -293,14 +294,16 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
   }
 }
 
-std::string RequestInfoFormatter::format(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
+std::string RequestInfoFormatter::format(const Http::HeaderMap&, const Http::HeaderMap&,
+                                         const Http::HeaderMap&,
                                          const RequestInfo::RequestInfo& request_info) const {
   return field_extractor_(request_info);
 }
 
 PlainStringFormatter::PlainStringFormatter(const std::string& str) : str_(str) {}
 
-std::string PlainStringFormatter::format(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
+std::string PlainStringFormatter::format(const Http::HeaderMap&, const Http::HeaderMap&,
+                                         const Http::HeaderMap&,
                                          const RequestInfo::RequestInfo&) const {
   return str_;
 }
@@ -401,14 +404,16 @@ DynamicMetadataFormatter::DynamicMetadataFormatter(const std::string& filter_nam
                                                    absl::optional<size_t> max_length)
     : MetadataFormatter(filter_namespace, path, max_length) {}
 
-std::string DynamicMetadataFormatter::format(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
+std::string DynamicMetadataFormatter::format(const Http::HeaderMap&, const Http::HeaderMap&,
+                                             const Http::HeaderMap&,
                                              const RequestInfo::RequestInfo& request_info) const {
   return MetadataFormatter::format(request_info.dynamicMetadata());
 }
 
 StartTimeFormatter::StartTimeFormatter(const std::string& format) : date_formatter_(format) {}
 
-std::string StartTimeFormatter::format(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
+std::string StartTimeFormatter::format(const Http::HeaderMap&, const Http::HeaderMap&,
+                                       const Http::HeaderMap&,
                                        const RequestInfo::RequestInfo& request_info) const {
   if (date_formatter_.formatString().empty()) {
     return AccessLogDateTimeFormatter::fromTime(request_info.startTime());

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -57,12 +57,13 @@ FormatterImpl::FormatterImpl(const std::string& format) {
 
 std::string FormatterImpl::format(const Http::HeaderMap& request_headers,
                                   const Http::HeaderMap& response_headers,
+                                  const Http::HeaderMap& response_trailers,
                                   const RequestInfo::RequestInfo& request_info) const {
   std::string log_line;
   log_line.reserve(256);
 
   for (const FormatterPtr& formatter : formatters_) {
-    log_line += formatter->format(request_headers, response_headers, request_info);
+    log_line += formatter->format(request_headers, response_headers, response_trailers, request_info);
   }
 
   return log_line;
@@ -169,6 +170,14 @@ std::vector<FormatterPtr> AccessLogFormatParser::parse(const std::string& format
 
         formatters.emplace_back(
             new ResponseHeaderFormatter(main_header, alternative_header, max_length));
+      } else if (token.find("TRAIL(") == 0) {
+        std::string main_header, alternative_header;
+        absl::optional<size_t> max_length;
+
+        parseCommandHeader(token, TrailParamStart, main_header, alternative_header, max_length);
+
+        formatters.emplace_back(
+            new ResponseTrailerFormatter(main_header, alternative_header, max_length));
       } else if (token.find(DYNAMIC_META_TOKEN) == 0) {
         std::string filter_namespace;
         absl::optional<size_t> max_length;
@@ -284,14 +293,14 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
   }
 }
 
-std::string RequestInfoFormatter::format(const Http::HeaderMap&, const Http::HeaderMap&,
+std::string RequestInfoFormatter::format(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
                                          const RequestInfo::RequestInfo& request_info) const {
   return field_extractor_(request_info);
 }
 
 PlainStringFormatter::PlainStringFormatter(const std::string& str) : str_(str) {}
 
-std::string PlainStringFormatter::format(const Http::HeaderMap&, const Http::HeaderMap&,
+std::string PlainStringFormatter::format(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
                                          const RequestInfo::RequestInfo&) const {
   return str_;
 }
@@ -329,6 +338,7 @@ ResponseHeaderFormatter::ResponseHeaderFormatter(const std::string& main_header,
 
 std::string ResponseHeaderFormatter::format(const Http::HeaderMap&,
                                             const Http::HeaderMap& response_headers,
+                                            const Http::HeaderMap&,
                                             const RequestInfo::RequestInfo&) const {
   return HeaderFormatter::format(response_headers);
 }
@@ -339,9 +349,20 @@ RequestHeaderFormatter::RequestHeaderFormatter(const std::string& main_header,
     : HeaderFormatter(main_header, alternative_header, max_length) {}
 
 std::string RequestHeaderFormatter::format(const Http::HeaderMap& request_headers,
-                                           const Http::HeaderMap&,
+                                           const Http::HeaderMap&, const Http::HeaderMap&,
                                            const RequestInfo::RequestInfo&) const {
   return HeaderFormatter::format(request_headers);
+}
+
+ResponseTrailerFormatter::ResponseTrailerFormatter(const std::string& main_header,
+                                                   const std::string& alternative_header,
+                                                   absl::optional<size_t> max_length)
+    : HeaderFormatter(main_header, alternative_header, max_length) {}
+
+std::string ResponseTrailerFormatter::format(const Http::HeaderMap&, const Http::HeaderMap&,
+                                             const Http::HeaderMap& response_trailers,
+                                             const RequestInfo::RequestInfo&) const {
+  return HeaderFormatter::format(response_trailers);
 }
 
 MetadataFormatter::MetadataFormatter(const std::string& filter_namespace,
@@ -380,14 +401,14 @@ DynamicMetadataFormatter::DynamicMetadataFormatter(const std::string& filter_nam
                                                    absl::optional<size_t> max_length)
     : MetadataFormatter(filter_namespace, path, max_length) {}
 
-std::string DynamicMetadataFormatter::format(const Http::HeaderMap&, const Http::HeaderMap&,
+std::string DynamicMetadataFormatter::format(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
                                              const RequestInfo::RequestInfo& request_info) const {
   return MetadataFormatter::format(request_info.dynamicMetadata());
 }
 
 StartTimeFormatter::StartTimeFormatter(const std::string& format) : date_formatter_(format) {}
 
-std::string StartTimeFormatter::format(const Http::HeaderMap&, const Http::HeaderMap&,
+std::string StartTimeFormatter::format(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
                                        const RequestInfo::RequestInfo& request_info) const {
   if (date_formatter_.formatString().empty()) {
     return AccessLogDateTimeFormatter::fromTime(request_info.startTime());

--- a/source/common/access_log/access_log_formatter.h
+++ b/source/common/access_log/access_log_formatter.h
@@ -61,6 +61,7 @@ private:
   // the indexes of where the parameters for each directive is expected to begin
   static const size_t ReqParamStart{std::strlen("REQ(")};
   static const size_t RespParamStart{std::strlen("RESP(")};
+  static const size_t TrailParamStart{std::strlen("TRAIL(")};
   static const size_t StartTimeParamStart{std::strlen("START_TIME(")};
 };
 
@@ -89,6 +90,7 @@ public:
   // Formatter::format
   std::string format(const Http::HeaderMap& request_headers,
                      const Http::HeaderMap& response_headers,
+                     const Http::HeaderMap& response_trailers,
                      const RequestInfo::RequestInfo& request_info) const override;
 
 private:
@@ -105,7 +107,7 @@ public:
 
   // Formatter::format
   std::string format(const Http::HeaderMap&, const Http::HeaderMap&,
-                     const RequestInfo::RequestInfo&) const override;
+                     const Http::HeaderMap&, const RequestInfo::RequestInfo&) const override;
 
 private:
   std::string str_;
@@ -134,7 +136,7 @@ public:
 
   // Formatter::format
   std::string format(const Http::HeaderMap& request_headers, const Http::HeaderMap&,
-                     const RequestInfo::RequestInfo&) const override;
+                     const Http::HeaderMap&, const RequestInfo::RequestInfo&) const override;
 };
 
 /**
@@ -147,7 +149,20 @@ public:
 
   // Formatter::format
   std::string format(const Http::HeaderMap&, const Http::HeaderMap& response_headers,
-                     const RequestInfo::RequestInfo&) const override;
+                     const Http::HeaderMap&, const RequestInfo::RequestInfo&) const override;
+};
+
+/**
+ * Formatter based on the response trailer.
+ */
+class ResponseTrailerFormatter : public Formatter, HeaderFormatter {
+public:
+  ResponseTrailerFormatter(const std::string& main_header, const std::string& alternative_header,
+                           absl::optional<size_t> max_length);
+
+  // Formatter::format
+  std::string format(const Http::HeaderMap&, const Http::HeaderMap&,
+                     const Http::HeaderMap& response_trailers, const RequestInfo::RequestInfo&) const override;
 };
 
 /**
@@ -158,7 +173,7 @@ public:
   RequestInfoFormatter(const std::string& field_name);
 
   // Formatter::format
-  std::string format(const Http::HeaderMap&, const Http::HeaderMap&,
+  std::string format(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
                      const RequestInfo::RequestInfo& request_info) const override;
 
 private:
@@ -190,7 +205,7 @@ public:
                            const std::vector<std::string>& path, absl::optional<size_t> max_length);
 
   // Formatter::format
-  std::string format(const Http::HeaderMap&, const Http::HeaderMap&,
+  std::string format(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
                      const RequestInfo::RequestInfo& request_info) const override;
 };
 
@@ -200,7 +215,7 @@ public:
 class StartTimeFormatter : public Formatter {
 public:
   StartTimeFormatter(const std::string& format);
-  std::string format(const Http::HeaderMap&, const Http::HeaderMap&,
+  std::string format(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
                      const RequestInfo::RequestInfo&) const override;
 
 private:

--- a/source/common/access_log/access_log_formatter.h
+++ b/source/common/access_log/access_log_formatter.h
@@ -106,8 +106,8 @@ public:
   PlainStringFormatter(const std::string& str);
 
   // Formatter::format
-  std::string format(const Http::HeaderMap&, const Http::HeaderMap&,
-                     const Http::HeaderMap&, const RequestInfo::RequestInfo&) const override;
+  std::string format(const Http::HeaderMap&, const Http::HeaderMap&, const Http::HeaderMap&,
+                     const RequestInfo::RequestInfo&) const override;
 
 private:
   std::string str_;
@@ -162,7 +162,8 @@ public:
 
   // Formatter::format
   std::string format(const Http::HeaderMap&, const Http::HeaderMap&,
-                     const Http::HeaderMap& response_trailers, const RequestInfo::RequestInfo&) const override;
+                     const Http::HeaderMap& response_trailers,
+                     const RequestInfo::RequestInfo&) const override;
 };
 
 /**

--- a/source/common/access_log/access_log_formatter.h
+++ b/source/common/access_log/access_log_formatter.h
@@ -61,7 +61,7 @@ private:
   // the indexes of where the parameters for each directive is expected to begin
   static const size_t ReqParamStart{std::strlen("REQ(")};
   static const size_t RespParamStart{std::strlen("RESP(")};
-  static const size_t TrailParamStart{std::strlen("TRAIL(")};
+  static const size_t TrailParamStart{std::strlen("TRAILER(")};
   static const size_t StartTimeParamStart{std::strlen("START_TIME(")};
 };
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -376,10 +376,12 @@ ConnectionManagerImpl::ActiveStream::~ActiveStream() {
 
   connection_manager_.stats_.named_.downstream_rq_active_.dec();
   for (const AccessLog::InstanceSharedPtr& access_log : connection_manager_.config_.accessLogs()) {
-    access_log->log(request_headers_.get(), response_headers_.get(), response_trailers_.get(), request_info_);
+    access_log->log(request_headers_.get(), response_headers_.get(), response_trailers_.get(),
+                    request_info_);
   }
   for (const auto& log_handler : access_log_handlers_) {
-    log_handler->log(request_headers_.get(), response_headers_.get(), response_trailers_.get(), request_info_);
+    log_handler->log(request_headers_.get(), response_headers_.get(), response_trailers_.get(),
+                     request_info_);
   }
 
   if (request_info_.healthCheck()) {

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -376,10 +376,10 @@ ConnectionManagerImpl::ActiveStream::~ActiveStream() {
 
   connection_manager_.stats_.named_.downstream_rq_active_.dec();
   for (const AccessLog::InstanceSharedPtr& access_log : connection_manager_.config_.accessLogs()) {
-    access_log->log(request_headers_.get(), response_headers_.get(), request_info_);
+    access_log->log(request_headers_.get(), response_headers_.get(), response_trailers_.get(), request_info_);
   }
   for (const auto& log_handler : access_log_handlers_) {
-    log_handler->log(request_headers_.get(), response_headers_.get(), request_info_);
+    log_handler->log(request_headers_.get(), response_headers_.get(), response_trailers_.get(), request_info_);
   }
 
   if (request_info_.healthCheck()) {

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -804,7 +804,8 @@ Filter::UpstreamRequest::~UpstreamRequest() {
 
   request_info_.onRequestComplete();
   for (const auto& upstream_log : parent_.config_.upstream_logs_) {
-    upstream_log->log(parent_.downstream_headers_, upstream_headers_, upstream_trailers_, request_info_);
+    upstream_log->log(parent_.downstream_headers_, upstream_headers_, upstream_trailers_,
+                      request_info_);
   }
 }
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -804,7 +804,7 @@ Filter::UpstreamRequest::~UpstreamRequest() {
 
   request_info_.onRequestComplete();
   for (const auto& upstream_log : parent_.config_.upstream_logs_) {
-    upstream_log->log(parent_.downstream_headers_, upstream_headers_, request_info_);
+    upstream_log->log(parent_.downstream_headers_, upstream_headers_, upstream_trailers_, request_info_);
   }
 }
 
@@ -833,6 +833,7 @@ void Filter::UpstreamRequest::decodeData(Buffer::Instance& data, bool end_stream
 
 void Filter::UpstreamRequest::decodeTrailers(Http::HeaderMapPtr&& trailers) {
   maybeEndDecode(true);
+  upstream_trailers_ = trailers.get();
   parent_.onUpstreamTrailers(std::move(trailers));
 }
 

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -272,6 +272,7 @@ private:
     Tracing::SpanPtr span_;
     RequestInfo::RequestInfoImpl request_info_;
     Http::HeaderMap* upstream_headers_{};
+    Http::HeaderMap* upstream_trailers_{};
 
     bool calling_encode_headers_ : 1;
     bool upstream_canary_ : 1;

--- a/source/extensions/access_loggers/file/file_access_log_impl.cc
+++ b/source/extensions/access_loggers/file/file_access_log_impl.cc
@@ -16,6 +16,7 @@ FileAccessLog::FileAccessLog(const std::string& access_log_path, AccessLog::Filt
 
 void FileAccessLog::log(const Http::HeaderMap* request_headers,
                         const Http::HeaderMap* response_headers,
+                        const Http::HeaderMap* response_trailers,
                         const RequestInfo::RequestInfo& request_info) {
   static Http::HeaderMapImpl empty_headers;
   if (!request_headers) {
@@ -24,6 +25,9 @@ void FileAccessLog::log(const Http::HeaderMap* request_headers,
   if (!response_headers) {
     response_headers = &empty_headers;
   }
+  if (!response_trailers) {
+    response_trailers = &empty_headers;
+  }
 
   if (filter_) {
     if (!filter_->evaluate(request_info, *request_headers)) {
@@ -31,7 +35,7 @@ void FileAccessLog::log(const Http::HeaderMap* request_headers,
     }
   }
 
-  log_file_->write(formatter_->format(*request_headers, *response_headers, request_info));
+  log_file_->write(formatter_->format(*request_headers, *response_headers, *response_trailers, request_info));
 }
 
 } // namespace File

--- a/source/extensions/access_loggers/file/file_access_log_impl.cc
+++ b/source/extensions/access_loggers/file/file_access_log_impl.cc
@@ -35,7 +35,8 @@ void FileAccessLog::log(const Http::HeaderMap* request_headers,
     }
   }
 
-  log_file_->write(formatter_->format(*request_headers, *response_headers, *response_trailers, request_info));
+  log_file_->write(
+      formatter_->format(*request_headers, *response_headers, *response_trailers, request_info));
 }
 
 } // namespace File

--- a/source/extensions/access_loggers/file/file_access_log_impl.h
+++ b/source/extensions/access_loggers/file/file_access_log_impl.h
@@ -17,7 +17,7 @@ public:
 
   // AccessLog::Instance
   void log(const Http::HeaderMap* request_headers, const Http::HeaderMap* response_headers,
-           const RequestInfo::RequestInfo& request_info) override;
+           const Http::HeaderMap* response_trailers, const RequestInfo::RequestInfo& request_info) override;
 
 private:
   Filesystem::FileSharedPtr log_file_;

--- a/source/extensions/access_loggers/file/file_access_log_impl.h
+++ b/source/extensions/access_loggers/file/file_access_log_impl.h
@@ -17,7 +17,8 @@ public:
 
   // AccessLog::Instance
   void log(const Http::HeaderMap* request_headers, const Http::HeaderMap* response_headers,
-           const Http::HeaderMap* response_trailers, const RequestInfo::RequestInfo& request_info) override;
+           const Http::HeaderMap* response_trailers,
+           const RequestInfo::RequestInfo& request_info) override;
 
 private:
   Filesystem::FileSharedPtr log_file_;

--- a/source/extensions/access_loggers/http_grpc/grpc_access_log_impl.h
+++ b/source/extensions/access_loggers/http_grpc/grpc_access_log_impl.h
@@ -123,7 +123,8 @@ public:
 
   // AccessLog::Instance
   void log(const Http::HeaderMap* request_headers, const Http::HeaderMap* response_headers,
-           const Http::HeaderMap* response_trailers, const RequestInfo::RequestInfo& request_info) override;
+           const Http::HeaderMap* response_trailers,
+           const RequestInfo::RequestInfo& request_info) override;
 
 private:
   AccessLog::FilterPtr filter_;

--- a/source/extensions/access_loggers/http_grpc/grpc_access_log_impl.h
+++ b/source/extensions/access_loggers/http_grpc/grpc_access_log_impl.h
@@ -123,7 +123,7 @@ public:
 
   // AccessLog::Instance
   void log(const Http::HeaderMap* request_headers, const Http::HeaderMap* response_headers,
-           const RequestInfo::RequestInfo& request_info) override;
+           const Http::HeaderMap* response_trailers, const RequestInfo::RequestInfo& request_info) override;
 
 private:
   AccessLog::FilterPtr filter_;
@@ -131,6 +131,7 @@ private:
   GrpcAccessLogStreamerSharedPtr grpc_access_log_streamer_;
   std::vector<Http::LowerCaseString> request_headers_to_log_;
   std::vector<Http::LowerCaseString> response_headers_to_log_;
+  std::vector<Http::LowerCaseString> response_trailers_to_log_;
 };
 
 } // namespace HttpGrpc

--- a/source/extensions/filters/network/tcp_proxy/tcp_proxy.cc
+++ b/source/extensions/filters/network/tcp_proxy/tcp_proxy.cc
@@ -135,7 +135,7 @@ TcpProxyFilter::~TcpProxyFilter() {
 
   if (config_ != nullptr) {
     for (const auto& access_log : config_->accessLogs()) {
-      access_log->log(nullptr, nullptr, request_info_);
+      access_log->log(nullptr, nullptr, nullptr, request_info_);
     }
   }
 

--- a/test/common/access_log/access_log_formatter_speed_test.cc
+++ b/test/common/access_log/access_log_formatter_speed_test.cc
@@ -19,8 +19,9 @@ static void BM_AccessLogFormatter(benchmark::State& state) {
   size_t output_bytes = 0;
   Http::TestHeaderMapImpl request_headers;
   Http::TestHeaderMapImpl response_headers;
+  Http::TestHeaderMapImpl response_trailers;
   for (auto _ : state) {
-    output_bytes += formatter->format(request_headers, response_headers, *request_info).length();
+    output_bytes += formatter->format(request_headers, response_headers, response_trailers, *request_info).length();
   }
   benchmark::DoNotOptimize(output_bytes);
 }

--- a/test/common/access_log/access_log_formatter_speed_test.cc
+++ b/test/common/access_log/access_log_formatter_speed_test.cc
@@ -21,7 +21,9 @@ static void BM_AccessLogFormatter(benchmark::State& state) {
   Http::TestHeaderMapImpl response_headers;
   Http::TestHeaderMapImpl response_trailers;
   for (auto _ : state) {
-    output_bytes += formatter->format(request_headers, response_headers, response_trailers, *request_info).length();
+    output_bytes +=
+        formatter->format(request_headers, response_headers, response_trailers, *request_info)
+            .length();
   }
   benchmark::DoNotOptimize(output_bytes);
 }

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -178,22 +178,26 @@ TEST(AccessLogFormatterTest, requestHeaderFormatter) {
 
   {
     RequestHeaderFormatter formatter(":Method", "", absl::optional<size_t>());
-    EXPECT_EQ("GET", formatter.format(request_header, response_header, response_trailer, request_info));
+    EXPECT_EQ("GET",
+              formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
     RequestHeaderFormatter formatter(":path", ":method", absl::optional<size_t>());
-    EXPECT_EQ("/", formatter.format(request_header, response_header, response_trailer, request_info));
+    EXPECT_EQ("/",
+              formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
     RequestHeaderFormatter formatter(":TEST", ":METHOD", absl::optional<size_t>());
-    EXPECT_EQ("GET", formatter.format(request_header, response_header, response_trailer, request_info));
+    EXPECT_EQ("GET",
+              formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
     RequestHeaderFormatter formatter("does_not_exist", "", absl::optional<size_t>());
-    EXPECT_EQ("-", formatter.format(request_header, response_header, response_trailer, request_info));
+    EXPECT_EQ("-",
+              formatter.format(request_header, response_header, response_trailer, request_info));
   }
 }
 
@@ -205,22 +209,26 @@ TEST(AccessLogFormatterTest, responseHeaderFormatter) {
 
   {
     ResponseHeaderFormatter formatter(":method", "", absl::optional<size_t>());
-    EXPECT_EQ("PUT", formatter.format(request_header, response_header, response_trailer, request_info));
+    EXPECT_EQ("PUT",
+              formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
     ResponseHeaderFormatter formatter("test", ":method", absl::optional<size_t>());
-    EXPECT_EQ("test", formatter.format(request_header, response_header, response_trailer, request_info));
+    EXPECT_EQ("test",
+              formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
     ResponseHeaderFormatter formatter(":path", ":method", absl::optional<size_t>());
-    EXPECT_EQ("PUT", formatter.format(request_header, response_header, response_trailer, request_info));
+    EXPECT_EQ("PUT",
+              formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
     ResponseHeaderFormatter formatter("does_not_exist", "", absl::optional<size_t>());
-    EXPECT_EQ("-", formatter.format(request_header, response_header, response_trailer, request_info));
+    EXPECT_EQ("-",
+              formatter.format(request_header, response_header, response_trailer, request_info));
   }
 }
 
@@ -232,22 +240,26 @@ TEST(AccessLogFormatterTest, responseTrailerFormatter) {
 
   {
     ResponseTrailerFormatter formatter(":method", "", absl::optional<size_t>());
-    EXPECT_EQ("POST", formatter.format(request_header, response_header, response_trailer, request_info));
+    EXPECT_EQ("POST",
+              formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
     ResponseTrailerFormatter formatter("test-2", ":method", absl::optional<size_t>());
-    EXPECT_EQ("test-2", formatter.format(request_header, response_header, response_trailer, request_info));
+    EXPECT_EQ("test-2",
+              formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
     ResponseTrailerFormatter formatter(":path", ":method", absl::optional<size_t>());
-    EXPECT_EQ("POST", formatter.format(request_header, response_header, response_trailer, request_info));
+    EXPECT_EQ("POST",
+              formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
     ResponseTrailerFormatter formatter("does_not_exist", "", absl::optional<size_t>());
-    EXPECT_EQ("-", formatter.format(request_header, response_header, response_trailer, request_info));
+    EXPECT_EQ("-",
+              formatter.format(request_header, response_header, response_trailer, request_info));
   }
 }
 
@@ -360,16 +372,18 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
     const std::string format = "{}*JUST PLAIN string]";
     FormatterImpl formatter(format);
 
-    EXPECT_EQ(format, formatter.format(request_header, response_header, response_trailer, request_info));
+    EXPECT_EQ(format,
+              formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
-    const std::string format =
-        "%REQ(first):3%|%REQ(first):1%|%RESP(first?second):2%|%REQ(first):10%|%TRAIL(second?third):3%";
+    const std::string format = "%REQ(first):3%|%REQ(first):1%|%RESP(first?second):2%|%REQ(first):"
+                               "10%|%TRAIL(second?third):3%";
 
     FormatterImpl formatter(format);
 
-    EXPECT_EQ("GET|G|PU|GET|POS", formatter.format(request_header, response_header, response_trailer, request_info));
+    EXPECT_EQ("GET|G|PU|GET|POS",
+              formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -358,7 +358,7 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
   {
     const std::string format = "{{%PROTOCOL%}}   %RESP(not exist)%++%RESP(test)% "
                                "%REQ(FIRST?SECOND)% %RESP(FIRST?SECOND)%"
-                               "\t@%TRAIL(THIRD)%@\t%TRAIL(TEST?TEST-2)%[]";
+                               "\t@%TRAILER(THIRD)%@\t%TRAILER(TEST?TEST-2)%[]";
     FormatterImpl formatter(format);
 
     absl::optional<Http::Protocol> protocol = Http::Protocol::Http11;
@@ -378,7 +378,7 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
 
   {
     const std::string format = "%REQ(first):3%|%REQ(first):1%|%RESP(first?second):2%|%REQ(first):"
-                               "10%|%TRAIL(second?third):3%";
+                               "10%|%TRAILER(second?third):3%";
 
     FormatterImpl formatter(format);
 
@@ -438,10 +438,10 @@ TEST(AccessLogFormatterTest, ParserFailures) {
       "%REQ(TEST:10%",
       "%REQ(",
       "%REQ(X?Y?Z)%",
-      "%TRAIL(TEST):%",
-      "%TRAIL(TEST):23u1%",
-      "%TRAIL(X?Y?Z)%",
-      "%TRAIL(:TEST):10",
+      "%TRAILER(TEST):%",
+      "%TRAILER(TEST):23u1%",
+      "%TRAILER(X?Y?Z)%",
+      "%TRAILER(:TEST):10",
       "%DYNAMIC_METADATA(TEST"};
 
   for (const std::string& test_case : test_cases) {

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -36,7 +36,7 @@ TEST(AccessLogFormatterTest, plainStringFormatter) {
   Http::TestHeaderMapImpl header{{":method", "GET"}, {":path", "/"}};
   RequestInfo::MockRequestInfo request_info;
 
-  EXPECT_EQ("plain", formatter.format(header, header, request_info));
+  EXPECT_EQ("plain", formatter.format(header, header, header, request_info));
 }
 
 TEST(AccessLogFormatterTest, requestInfoFormatter) {
@@ -49,124 +49,124 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
     RequestInfoFormatter request_duration_format("REQUEST_DURATION");
     absl::optional<std::chrono::nanoseconds> dur = std::chrono::nanoseconds(5000000);
     EXPECT_CALL(request_info, lastDownstreamRxByteReceived()).WillOnce(Return(dur));
-    EXPECT_EQ("5", request_duration_format.format(header, header, request_info));
+    EXPECT_EQ("5", request_duration_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter request_duration_format("REQUEST_DURATION");
     absl::optional<std::chrono::nanoseconds> dur;
     EXPECT_CALL(request_info, lastDownstreamRxByteReceived()).WillOnce(Return(dur));
-    EXPECT_EQ("-", request_duration_format.format(header, header, request_info));
+    EXPECT_EQ("-", request_duration_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter response_duration_format("RESPONSE_DURATION");
     absl::optional<std::chrono::nanoseconds> dur = std::chrono::nanoseconds(10000000);
     EXPECT_CALL(request_info, firstUpstreamRxByteReceived()).WillRepeatedly(Return(dur));
-    EXPECT_EQ("10", response_duration_format.format(header, header, request_info));
+    EXPECT_EQ("10", response_duration_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter response_duration_format("RESPONSE_DURATION");
     absl::optional<std::chrono::nanoseconds> dur;
     EXPECT_CALL(request_info, firstUpstreamRxByteReceived()).WillRepeatedly(Return(dur));
-    EXPECT_EQ("-", response_duration_format.format(header, header, request_info));
+    EXPECT_EQ("-", response_duration_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter bytes_received_format("BYTES_RECEIVED");
     EXPECT_CALL(request_info, bytesReceived()).WillOnce(Return(1));
-    EXPECT_EQ("1", bytes_received_format.format(header, header, request_info));
+    EXPECT_EQ("1", bytes_received_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter protocol_format("PROTOCOL");
     absl::optional<Http::Protocol> protocol = Http::Protocol::Http11;
     EXPECT_CALL(request_info, protocol()).WillOnce(Return(protocol));
-    EXPECT_EQ("HTTP/1.1", protocol_format.format(header, header, request_info));
+    EXPECT_EQ("HTTP/1.1", protocol_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter response_format("RESPONSE_CODE");
     absl::optional<uint32_t> response_code{200};
     EXPECT_CALL(request_info, responseCode()).WillRepeatedly(Return(response_code));
-    EXPECT_EQ("200", response_format.format(header, header, request_info));
+    EXPECT_EQ("200", response_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter response_code_format("RESPONSE_CODE");
     absl::optional<uint32_t> response_code;
     EXPECT_CALL(request_info, responseCode()).WillRepeatedly(Return(response_code));
-    EXPECT_EQ("0", response_code_format.format(header, header, request_info));
+    EXPECT_EQ("0", response_code_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter bytes_sent_format("BYTES_SENT");
     EXPECT_CALL(request_info, bytesSent()).WillOnce(Return(1));
-    EXPECT_EQ("1", bytes_sent_format.format(header, header, request_info));
+    EXPECT_EQ("1", bytes_sent_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter duration_format("DURATION");
     absl::optional<std::chrono::nanoseconds> dur = std::chrono::nanoseconds(15000000);
     EXPECT_CALL(request_info, requestComplete()).WillRepeatedly(Return(dur));
-    EXPECT_EQ("15", duration_format.format(header, header, request_info));
+    EXPECT_EQ("15", duration_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter response_flags_format("RESPONSE_FLAGS");
     ON_CALL(request_info, getResponseFlag(RequestInfo::ResponseFlag::LocalReset))
         .WillByDefault(Return(true));
-    EXPECT_EQ("LR", response_flags_format.format(header, header, request_info));
+    EXPECT_EQ("LR", response_flags_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter upstream_format("UPSTREAM_HOST");
-    EXPECT_EQ("10.0.0.1:443", upstream_format.format(header, header, request_info));
+    EXPECT_EQ("10.0.0.1:443", upstream_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter upstream_format("UPSTREAM_CLUSTER");
     const std::string upstream_cluster_name = "cluster_name";
     EXPECT_CALL(request_info.host_->cluster_, name()).WillOnce(ReturnRef(upstream_cluster_name));
-    EXPECT_EQ("cluster_name", upstream_format.format(header, header, request_info));
+    EXPECT_EQ("cluster_name", upstream_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter upstream_format("UPSTREAM_HOST");
     EXPECT_CALL(request_info, upstreamHost()).WillOnce(Return(nullptr));
-    EXPECT_EQ("-", upstream_format.format(header, header, request_info));
+    EXPECT_EQ("-", upstream_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter upstream_format("UPSTREAM_CLUSTER");
     EXPECT_CALL(request_info, upstreamHost()).WillOnce(Return(nullptr));
-    EXPECT_EQ("-", upstream_format.format(header, header, request_info));
+    EXPECT_EQ("-", upstream_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter upstream_format("DOWNSTREAM_LOCAL_ADDRESS");
-    EXPECT_EQ("127.0.0.2:0", upstream_format.format(header, header, request_info));
+    EXPECT_EQ("127.0.0.2:0", upstream_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter upstream_format("DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT");
-    EXPECT_EQ("127.0.0.2", upstream_format.format(header, header, request_info));
+    EXPECT_EQ("127.0.0.2", upstream_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter upstream_format("DOWNSTREAM_ADDRESS");
-    EXPECT_EQ("127.0.0.1", upstream_format.format(header, header, request_info));
+    EXPECT_EQ("127.0.0.1", upstream_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter upstream_format("DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT");
-    EXPECT_EQ("127.0.0.1", upstream_format.format(header, header, request_info));
+    EXPECT_EQ("127.0.0.1", upstream_format.format(header, header, header, request_info));
   }
 
   {
     RequestInfoFormatter upstream_format("DOWNSTREAM_REMOTE_ADDRESS");
-    EXPECT_EQ("127.0.0.1:0", upstream_format.format(header, header, request_info));
+    EXPECT_EQ("127.0.0.1:0", upstream_format.format(header, header, header, request_info));
   }
 }
 
@@ -174,25 +174,26 @@ TEST(AccessLogFormatterTest, requestHeaderFormatter) {
   RequestInfo::MockRequestInfo request_info;
   Http::TestHeaderMapImpl request_header{{":method", "GET"}, {":path", "/"}};
   Http::TestHeaderMapImpl response_header{{":method", "PUT"}};
+  Http::TestHeaderMapImpl response_trailer{{":method", "POST"}, {"test-2", "test-2"}};
 
   {
     RequestHeaderFormatter formatter(":Method", "", absl::optional<size_t>());
-    EXPECT_EQ("GET", formatter.format(request_header, response_header, request_info));
+    EXPECT_EQ("GET", formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
     RequestHeaderFormatter formatter(":path", ":method", absl::optional<size_t>());
-    EXPECT_EQ("/", formatter.format(request_header, response_header, request_info));
+    EXPECT_EQ("/", formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
     RequestHeaderFormatter formatter(":TEST", ":METHOD", absl::optional<size_t>());
-    EXPECT_EQ("GET", formatter.format(request_header, response_header, request_info));
+    EXPECT_EQ("GET", formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
     RequestHeaderFormatter formatter("does_not_exist", "", absl::optional<size_t>());
-    EXPECT_EQ("-", formatter.format(request_header, response_header, request_info));
+    EXPECT_EQ("-", formatter.format(request_header, response_header, response_trailer, request_info));
   }
 }
 
@@ -200,25 +201,53 @@ TEST(AccessLogFormatterTest, responseHeaderFormatter) {
   RequestInfo::MockRequestInfo request_info;
   Http::TestHeaderMapImpl request_header{{":method", "GET"}, {":path", "/"}};
   Http::TestHeaderMapImpl response_header{{":method", "PUT"}, {"test", "test"}};
+  Http::TestHeaderMapImpl response_trailer{{":method", "POST"}, {"test-2", "test-2"}};
 
   {
     ResponseHeaderFormatter formatter(":method", "", absl::optional<size_t>());
-    EXPECT_EQ("PUT", formatter.format(request_header, response_header, request_info));
+    EXPECT_EQ("PUT", formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
     ResponseHeaderFormatter formatter("test", ":method", absl::optional<size_t>());
-    EXPECT_EQ("test", formatter.format(request_header, response_header, request_info));
+    EXPECT_EQ("test", formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
     ResponseHeaderFormatter formatter(":path", ":method", absl::optional<size_t>());
-    EXPECT_EQ("PUT", formatter.format(request_header, response_header, request_info));
+    EXPECT_EQ("PUT", formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
     ResponseHeaderFormatter formatter("does_not_exist", "", absl::optional<size_t>());
-    EXPECT_EQ("-", formatter.format(request_header, response_header, request_info));
+    EXPECT_EQ("-", formatter.format(request_header, response_header, response_trailer, request_info));
+  }
+}
+
+TEST(AccessLogFormatterTest, responseTrailerFormatter) {
+  RequestInfo::MockRequestInfo request_info;
+  Http::TestHeaderMapImpl request_header{{":method", "GET"}, {":path", "/"}};
+  Http::TestHeaderMapImpl response_header{{":method", "PUT"}, {"test", "test"}};
+  Http::TestHeaderMapImpl response_trailer{{":method", "POST"}, {"test-2", "test-2"}};
+
+  {
+    ResponseTrailerFormatter formatter(":method", "", absl::optional<size_t>());
+    EXPECT_EQ("POST", formatter.format(request_header, response_header, response_trailer, request_info));
+  }
+
+  {
+    ResponseTrailerFormatter formatter("test-2", ":method", absl::optional<size_t>());
+    EXPECT_EQ("test-2", formatter.format(request_header, response_header, response_trailer, request_info));
+  }
+
+  {
+    ResponseTrailerFormatter formatter(":path", ":method", absl::optional<size_t>());
+    EXPECT_EQ("POST", formatter.format(request_header, response_header, response_trailer, request_info));
+  }
+
+  {
+    ResponseTrailerFormatter formatter("does_not_exist", "", absl::optional<size_t>());
+    EXPECT_EQ("-", formatter.format(request_header, response_header, response_trailer, request_info));
   }
 }
 
@@ -296,7 +325,7 @@ TEST(AccessLogFormatterTest, startTimeFormatter) {
     time_t test_epoch = 1522280158;
     SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
     EXPECT_CALL(request_info, startTime()).WillOnce(Return(time));
-    EXPECT_EQ("2018/03/28", start_time_format.format(header, header, request_info));
+    EXPECT_EQ("2018/03/28", start_time_format.format(header, header, header, request_info));
   }
 
   {
@@ -304,7 +333,7 @@ TEST(AccessLogFormatterTest, startTimeFormatter) {
     SystemTime time;
     EXPECT_CALL(request_info, startTime()).WillOnce(Return(time));
     EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time),
-              start_time_format.format(header, header, request_info));
+              start_time_format.format(header, header, header, request_info));
   }
 }
 
@@ -312,33 +341,35 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
   RequestInfo::MockRequestInfo request_info;
   Http::TestHeaderMapImpl request_header{{"first", "GET"}, {":path", "/"}};
   Http::TestHeaderMapImpl response_header{{"second", "PUT"}, {"test", "test"}};
+  Http::TestHeaderMapImpl response_trailer{{"third", "POST"}, {"test-2", "test-2"}};
 
   {
     const std::string format = "{{%PROTOCOL%}}   %RESP(not exist)%++%RESP(test)% "
-                               "%REQ(FIRST?SECOND)% %RESP(FIRST?SECOND)%[]";
+                               "%REQ(FIRST?SECOND)% %RESP(FIRST?SECOND)%"
+                               "\t@%TRAIL(THIRD)%@\t%TRAIL(TEST?TEST-2)%[]";
     FormatterImpl formatter(format);
 
     absl::optional<Http::Protocol> protocol = Http::Protocol::Http11;
     EXPECT_CALL(request_info, protocol()).WillRepeatedly(Return(protocol));
 
-    EXPECT_EQ("{{HTTP/1.1}}   -++test GET PUT[]",
-              formatter.format(request_header, response_header, request_info));
+    EXPECT_EQ("{{HTTP/1.1}}   -++test GET PUT\t@POST@\ttest-2[]",
+              formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
     const std::string format = "{}*JUST PLAIN string]";
     FormatterImpl formatter(format);
 
-    EXPECT_EQ(format, formatter.format(request_header, response_header, request_info));
+    EXPECT_EQ(format, formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
     const std::string format =
-        "%REQ(first):3%|%REQ(first):1%|%RESP(first?second):2%|%REQ(first):10%";
+        "%REQ(first):3%|%REQ(first):1%|%RESP(first?second):2%|%REQ(first):10%|%TRAIL(second?third):3%";
 
     FormatterImpl formatter(format);
 
-    EXPECT_EQ("GET|G|PU|GET", formatter.format(request_header, response_header, request_info));
+    EXPECT_EQ("GET|G|PU|GET|POS", formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
@@ -350,7 +381,7 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
     FormatterImpl formatter(format);
 
     EXPECT_EQ("\"test_value\"|{\"inner_key\":\"inner_value\"}|\"inner_value\"",
-              formatter.format(request_header, response_header, request_info));
+              formatter.format(request_header, response_header, response_trailer, request_info));
   }
 
   {
@@ -368,7 +399,7 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
     time_t expected_time_t = mktime(&time_val);
 
     EXPECT_EQ(fmt::format("2018/03/28|{}|bad_format|2018-03-28T23:35:58.000Z", expected_time_t),
-              formatter.format(request_header, response_header, request_info));
+              formatter.format(request_header, response_header, response_trailer, request_info));
   }
 }
 
@@ -393,10 +424,14 @@ TEST(AccessLogFormatterTest, ParserFailures) {
       "%REQ(TEST:10%",
       "%REQ(",
       "%REQ(X?Y?Z)%",
+      "%TRAIL(TEST):%",
+      "%TRAIL(TEST):23u1%",
+      "%TRAIL(X?Y?Z)%",
+      "%TRAIL(:TEST):10",
       "%DYNAMIC_METADATA(TEST"};
 
   for (const std::string& test_case : test_cases) {
-    EXPECT_THROW(parser.parse(test_case), EnvoyException);
+    EXPECT_THROW(parser.parse(test_case), EnvoyException) << test_case;
   }
 }
 

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -59,6 +59,7 @@ public:
 
   Http::TestHeaderMapImpl request_headers_{{":method", "GET"}, {":path", "/"}};
   Http::TestHeaderMapImpl response_headers_;
+  Http::TestHeaderMapImpl response_trailers_;
   TestRequestInfo request_info_;
   std::shared_ptr<Filesystem::MockFile> file_;
   StringViewSaver output_;
@@ -84,7 +85,7 @@ TEST_F(AccessLogImplTest, LogMoreData) {
   request_headers_.addCopy(Http::Headers::get().Host, "host");
   request_headers_.addCopy(Http::Headers::get().ForwardedFor, "x.x.x.x");
 
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
   EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 UF 1 2 3 - \"x.x.x.x\" "
             "\"user-agent-set\" \"id\" \"host\" \"-\"\n",
             output_);
@@ -102,7 +103,7 @@ TEST_F(AccessLogImplTest, EnvoyUpstreamServiceTime) {
   EXPECT_CALL(*file_, write(_));
   response_headers_.addCopy(Http::Headers::get().EnvoyUpstreamServiceTime, "999");
 
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
   EXPECT_EQ(
       "[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 - 1 2 3 999 \"-\" \"-\" \"-\" \"-\" \"-\"\n",
       output_);
@@ -118,7 +119,7 @@ TEST_F(AccessLogImplTest, NoFilter) {
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromJson(json), context_);
 
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
   EXPECT_EQ(
       "[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 - 1 2 3 - \"-\" \"-\" \"-\" \"-\" \"-\"\n",
       output_);
@@ -137,7 +138,7 @@ TEST_F(AccessLogImplTest, UpstreamHost) {
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromJson(json), context_);
 
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
   EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 - 1 2 3 - \"-\" \"-\" \"-\" \"-\" "
             "\"10.0.0.5:1234\"\n",
             output_);
@@ -158,10 +159,10 @@ TEST_F(AccessLogImplTest, WithFilterMiss) {
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromJson(json), context_);
 
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 
   request_info_.response_code_ = 200;
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 }
 
 TEST_F(AccessLogImplTest, WithFilterHit) {
@@ -180,15 +181,15 @@ TEST_F(AccessLogImplTest, WithFilterHit) {
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromJson(json), context_);
 
   EXPECT_CALL(*file_, write(_)).Times(3);
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 
   request_info_.response_code_ = 500;
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 
   request_info_.response_code_ = 200;
   request_info_.end_time_ =
       request_info_.startTimeMonotonic() + std::chrono::microseconds(1001000000000000);
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 }
 
 TEST_F(AccessLogImplTest, RuntimeFilter) {
@@ -206,25 +207,25 @@ TEST_F(AccessLogImplTest, RuntimeFilter) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 0, 42, 100))
       .WillOnce(Return(true));
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 
   EXPECT_CALL(context_.random_, random()).WillOnce(Return(43));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 0, 43, 100))
       .WillOnce(Return(false));
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 
   // Value is taken from x-request-id.
   request_headers_.addCopy("x-request-id", "000000ff-0000-0000-0000-000000000000");
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 0, 55, 100))
       .WillOnce(Return(true));
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 0, 55, 100))
       .WillOnce(Return(false));
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 }
 
 TEST_F(AccessLogImplTest, RuntimeFilterV2) {
@@ -247,25 +248,25 @@ config:
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 5, 42, 10000))
       .WillOnce(Return(true));
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 
   EXPECT_CALL(context_.random_, random()).WillOnce(Return(43));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 5, 43, 10000))
       .WillOnce(Return(false));
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 
   // Value is taken from x-request-id.
   request_headers_.addCopy("x-request-id", "000000ff-0000-0000-0000-000000000000");
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 5, 255, 10000))
       .WillOnce(Return(true));
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 5, 255, 10000))
       .WillOnce(Return(false));
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 }
 
 TEST_F(AccessLogImplTest, RuntimeFilterV2IndependentRandomness) {
@@ -290,13 +291,13 @@ config:
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 5, 42, 1000000))
       .WillOnce(Return(true));
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 
   EXPECT_CALL(context_.random_, random()).WillOnce(Return(43));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 5, 43, 1000000))
       .WillOnce(Return(false));
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 }
 
 TEST_F(AccessLogImplTest, PathRewrite) {
@@ -312,7 +313,7 @@ TEST_F(AccessLogImplTest, PathRewrite) {
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromJson(json), context_);
 
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
   EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET /bar HTTP/1.1\" 0 - 1 2 3 - \"-\" \"-\" \"-\" \"-\" "
             "\"-\"\n",
             output_);
@@ -332,7 +333,7 @@ TEST_F(AccessLogImplTest, healthCheckTrue) {
   request_info_.hc_request_ = true;
   EXPECT_CALL(*file_, write(_)).Times(0);
 
-  log->log(&header_map, &response_headers_, request_info_);
+  log->log(&header_map, &response_headers_, &response_trailers_, request_info_);
 }
 
 TEST_F(AccessLogImplTest, healthCheckFalse) {
@@ -348,7 +349,7 @@ TEST_F(AccessLogImplTest, healthCheckFalse) {
   Http::TestHeaderMapImpl header_map{};
   EXPECT_CALL(*file_, write(_));
 
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 }
 
 TEST_F(AccessLogImplTest, requestTracing) {
@@ -373,19 +374,19 @@ TEST_F(AccessLogImplTest, requestTracing) {
   {
     Http::TestHeaderMapImpl forced_header{{"x-request-id", force_tracing_guid}};
     EXPECT_CALL(*file_, write(_));
-    log->log(&forced_header, &response_headers_, request_info_);
+    log->log(&forced_header, &response_headers_, &response_trailers_, request_info_);
   }
 
   {
     Http::TestHeaderMapImpl not_traceable{{"x-request-id", not_traceable_guid}};
     EXPECT_CALL(*file_, write(_)).Times(0);
-    log->log(&not_traceable, &response_headers_, request_info_);
+    log->log(&not_traceable, &response_headers_, &response_trailers_, request_info_);
   }
 
   {
     Http::TestHeaderMapImpl sampled_header{{"x-request-id", sample_tracing_guid}};
     EXPECT_CALL(*file_, write(_)).Times(0);
-    log->log(&sampled_header, &response_headers_, request_info_);
+    log->log(&sampled_header, &response_headers_, &response_trailers_, request_info_);
   }
 }
 
@@ -436,14 +437,14 @@ TEST_F(AccessLogImplTest, andFilter) {
     EXPECT_CALL(*file_, write(_));
     Http::TestHeaderMapImpl header_map{{"user-agent", "NOT/Envoy/HC"}};
 
-    log->log(&header_map, &response_headers_, request_info_);
+    log->log(&header_map, &response_headers_, &response_trailers_, request_info_);
   }
 
   {
     EXPECT_CALL(*file_, write(_)).Times(0);
     Http::TestHeaderMapImpl header_map{};
     request_info_.hc_request_ = true;
-    log->log(&header_map, &response_headers_, request_info_);
+    log->log(&header_map, &response_headers_, &response_trailers_, request_info_);
   }
 }
 
@@ -466,13 +467,13 @@ TEST_F(AccessLogImplTest, orFilter) {
     EXPECT_CALL(*file_, write(_));
     Http::TestHeaderMapImpl header_map{{"user-agent", "NOT/Envoy/HC"}};
 
-    log->log(&header_map, &response_headers_, request_info_);
+    log->log(&header_map, &response_headers_, &response_trailers_, request_info_);
   }
 
   {
     EXPECT_CALL(*file_, write(_));
     Http::TestHeaderMapImpl header_map{{"user-agent", "Envoy/HC"}};
-    log->log(&header_map, &response_headers_, request_info_);
+    log->log(&header_map, &response_headers_, &response_trailers_, request_info_);
   }
 }
 
@@ -499,7 +500,7 @@ TEST_F(AccessLogImplTest, multipleOperators) {
     EXPECT_CALL(*file_, write(_));
     Http::TestHeaderMapImpl header_map{};
 
-    log->log(&header_map, &response_headers_, request_info_);
+    log->log(&header_map, &response_headers_, &response_trailers_, request_info_);
   }
 
   {
@@ -507,7 +508,7 @@ TEST_F(AccessLogImplTest, multipleOperators) {
     Http::TestHeaderMapImpl header_map{};
     request_info_.hc_request_ = true;
 
-    log->log(&header_map, &response_headers_, request_info_);
+    log->log(&header_map, &response_headers_, &response_trailers_, request_info_);
   }
 }
 
@@ -590,12 +591,12 @@ config:
   request_info_.response_code_ = 499;
   EXPECT_CALL(runtime_.snapshot_, getInteger("hello", 499)).WillOnce(Return(499));
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 
   request_info_.response_code_ = 500;
   EXPECT_CALL(runtime_.snapshot_, getInteger("hello", 499)).WillOnce(Return(499));
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, request_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, request_info_);
 }
 
 } // namespace

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -895,9 +895,9 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLog) {
         callbacks.addAccessLogHandler(handler);
       }));
 
-  EXPECT_CALL(*handler, log(_, _, _))
+  EXPECT_CALL(*handler, log(_, _, _, _))
       .WillOnce(Invoke(
-          [](const HeaderMap*, const HeaderMap*, const RequestInfo::RequestInfo& request_info) {
+          [](const HeaderMap*, const HeaderMap*, const HeaderMap*, const RequestInfo::RequestInfo& request_info) {
             EXPECT_TRUE(request_info.responseCode());
             EXPECT_EQ(request_info.responseCode().value(), uint32_t(200));
             EXPECT_NE(nullptr, request_info.downstreamLocalAddress());
@@ -927,6 +927,53 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLog) {
   conn_manager_->onData(fake_input, false);
 }
 
+TEST_F(HttpConnectionManagerImplTest, TestAccessLogWithTrailers) {
+  setup(false, "");
+
+  std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
+  std::shared_ptr<AccessLog::MockInstance> handler(new NiceMock<AccessLog::MockInstance>());
+
+  EXPECT_CALL(filter_factory_, createFilterChain(_))
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> void {
+        callbacks.addStreamDecoderFilter(filter);
+        callbacks.addAccessLogHandler(handler);
+      }));
+
+  EXPECT_CALL(*handler, log(_, _, _, _))
+      .WillOnce(Invoke(
+          [](const HeaderMap*, const HeaderMap*, const HeaderMap*, const RequestInfo::RequestInfo& request_info) {
+            EXPECT_TRUE(request_info.responseCode());
+            EXPECT_EQ(request_info.responseCode().value(), uint32_t(200));
+            EXPECT_NE(nullptr, request_info.downstreamLocalAddress());
+            EXPECT_NE(nullptr, request_info.downstreamRemoteAddress());
+            EXPECT_NE(nullptr, request_info.routeEntry());
+          }));
+
+  StreamDecoder* decoder = nullptr;
+  NiceMock<MockStreamEncoder> encoder;
+  EXPECT_CALL(*codec_, dispatch(_)).WillRepeatedly(Invoke([&](Buffer::Instance& data) -> void {
+    decoder = &conn_manager_->newStream(encoder);
+
+    HeaderMapPtr headers{
+        new TestHeaderMapImpl{{":method", "GET"},
+                              {":authority", "host"},
+                              {":path", "/"},
+                              {"x-request-id", "125a4afb-6f55-a4ba-ad80-413f09f48a28"}}};
+    decoder->decodeHeaders(std::move(headers), true);
+
+    HeaderMapPtr response_headers{new TestHeaderMapImpl{{":status", "200"}}};
+    filter->callbacks_->encodeHeaders(std::move(response_headers), false);
+
+    HeaderMapPtr response_trailers{new TestHeaderMapImpl{{"x-trailer", "1"}}};
+    filter->callbacks_->encodeTrailers(std::move(response_trailers));
+
+    data.drain(4);
+  }));
+
+  Buffer::OwnedImpl fake_input("1234");
+  conn_manager_->onData(fake_input, false);
+}
+
 TEST_F(HttpConnectionManagerImplTest, TestAccessLogWithInvalidRequest) {
   setup(false, "");
 
@@ -939,9 +986,9 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLogWithInvalidRequest) {
         callbacks.addAccessLogHandler(handler);
       }));
 
-  EXPECT_CALL(*handler, log(_, _, _))
+  EXPECT_CALL(*handler, log(_, _, _, _))
       .WillOnce(Invoke(
-          [](const HeaderMap*, const HeaderMap*, const RequestInfo::RequestInfo& request_info) {
+          [](const HeaderMap*, const HeaderMap*, const HeaderMap*, const RequestInfo::RequestInfo& request_info) {
             EXPECT_TRUE(request_info.responseCode());
             EXPECT_EQ(request_info.responseCode().value(), uint32_t(400));
             EXPECT_NE(nullptr, request_info.downstreamLocalAddress());

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -896,14 +896,14 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLog) {
       }));
 
   EXPECT_CALL(*handler, log(_, _, _, _))
-      .WillOnce(Invoke(
-          [](const HeaderMap*, const HeaderMap*, const HeaderMap*, const RequestInfo::RequestInfo& request_info) {
-            EXPECT_TRUE(request_info.responseCode());
-            EXPECT_EQ(request_info.responseCode().value(), uint32_t(200));
-            EXPECT_NE(nullptr, request_info.downstreamLocalAddress());
-            EXPECT_NE(nullptr, request_info.downstreamRemoteAddress());
-            EXPECT_NE(nullptr, request_info.routeEntry());
-          }));
+      .WillOnce(Invoke([](const HeaderMap*, const HeaderMap*, const HeaderMap*,
+                          const RequestInfo::RequestInfo& request_info) {
+        EXPECT_TRUE(request_info.responseCode());
+        EXPECT_EQ(request_info.responseCode().value(), uint32_t(200));
+        EXPECT_NE(nullptr, request_info.downstreamLocalAddress());
+        EXPECT_NE(nullptr, request_info.downstreamRemoteAddress());
+        EXPECT_NE(nullptr, request_info.routeEntry());
+      }));
 
   StreamDecoder* decoder = nullptr;
   NiceMock<MockStreamEncoder> encoder;
@@ -940,14 +940,14 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLogWithTrailers) {
       }));
 
   EXPECT_CALL(*handler, log(_, _, _, _))
-      .WillOnce(Invoke(
-          [](const HeaderMap*, const HeaderMap*, const HeaderMap*, const RequestInfo::RequestInfo& request_info) {
-            EXPECT_TRUE(request_info.responseCode());
-            EXPECT_EQ(request_info.responseCode().value(), uint32_t(200));
-            EXPECT_NE(nullptr, request_info.downstreamLocalAddress());
-            EXPECT_NE(nullptr, request_info.downstreamRemoteAddress());
-            EXPECT_NE(nullptr, request_info.routeEntry());
-          }));
+      .WillOnce(Invoke([](const HeaderMap*, const HeaderMap*, const HeaderMap*,
+                          const RequestInfo::RequestInfo& request_info) {
+        EXPECT_TRUE(request_info.responseCode());
+        EXPECT_EQ(request_info.responseCode().value(), uint32_t(200));
+        EXPECT_NE(nullptr, request_info.downstreamLocalAddress());
+        EXPECT_NE(nullptr, request_info.downstreamRemoteAddress());
+        EXPECT_NE(nullptr, request_info.routeEntry());
+      }));
 
   StreamDecoder* decoder = nullptr;
   NiceMock<MockStreamEncoder> encoder;
@@ -987,14 +987,14 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLogWithInvalidRequest) {
       }));
 
   EXPECT_CALL(*handler, log(_, _, _, _))
-      .WillOnce(Invoke(
-          [](const HeaderMap*, const HeaderMap*, const HeaderMap*, const RequestInfo::RequestInfo& request_info) {
-            EXPECT_TRUE(request_info.responseCode());
-            EXPECT_EQ(request_info.responseCode().value(), uint32_t(400));
-            EXPECT_NE(nullptr, request_info.downstreamLocalAddress());
-            EXPECT_NE(nullptr, request_info.downstreamRemoteAddress());
-            EXPECT_EQ(nullptr, request_info.routeEntry());
-          }));
+      .WillOnce(Invoke([](const HeaderMap*, const HeaderMap*, const HeaderMap*,
+                          const RequestInfo::RequestInfo& request_info) {
+        EXPECT_TRUE(request_info.responseCode());
+        EXPECT_EQ(request_info.responseCode().value(), uint32_t(400));
+        EXPECT_NE(nullptr, request_info.downstreamLocalAddress());
+        EXPECT_NE(nullptr, request_info.downstreamRemoteAddress());
+        EXPECT_EQ(nullptr, request_info.routeEntry());
+      }));
 
   StreamDecoder* decoder = nullptr;
   NiceMock<MockStreamEncoder> encoder;

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -37,7 +37,7 @@ absl::optional<envoy::config::filter::accesslog::v2::AccessLog> testUpstreamLog(
   const std::string json_string = R"EOF(
   {
     "path": "/dev/null",
-    "format": "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL% %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %REQ(:AUTHORITY)% %UPSTREAM_HOST% %RESP(X-UPSTREAM-HEADER)% %TRAIL(X-TRAILER)%\n"
+    "format": "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL% %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %REQ(:AUTHORITY)% %UPSTREAM_HOST% %RESP(X-UPSTREAM-HEADER)% %TRAILER(X-TRAILER)%\n"
   }
   )EOF";
 

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -37,7 +37,7 @@ absl::optional<envoy::config::filter::accesslog::v2::AccessLog> testUpstreamLog(
   const std::string json_string = R"EOF(
   {
     "path": "/dev/null",
-    "format": "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL% %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %REQ(:AUTHORITY)% %UPSTREAM_HOST% %RESP(X-UPSTREAM-HEADER)%\n"
+    "format": "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL% %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %REQ(:AUTHORITY)% %UPSTREAM_HOST% %RESP(X-UPSTREAM-HEADER)% %TRAIL(X-TRAILER)%\n"
   }
   )EOF";
 
@@ -120,7 +120,8 @@ public:
   void
   run(uint64_t response_code,
       const std::initializer_list<std::pair<std::string, std::string>>& request_headers_init,
-      const std::initializer_list<std::pair<std::string, std::string>>& response_headers_init) {
+      const std::initializer_list<std::pair<std::string, std::string>>& response_headers_init,
+      const std::initializer_list<std::pair<std::string, std::string>>& response_trailers_init) {
     NiceMock<Http::MockStreamEncoder> encoder;
     Http::StreamDecoder* response_decoder = nullptr;
 
@@ -145,10 +146,13 @@ public:
 
     EXPECT_CALL(context_.cluster_manager_.conn_pool_.host_->outlier_detector_,
                 putHttpResponseCode(response_code));
-    response_decoder->decodeHeaders(std::move(response_headers), true);
+    response_decoder->decodeHeaders(std::move(response_headers), false);
+
+    Http::HeaderMapPtr response_trailers(new Http::TestHeaderMapImpl(response_trailers_init));
+    response_decoder->decodeTrailers(std::move(response_trailers));
   }
 
-  void run() { run(200, {}, {}); }
+  void run() { run(200, {}, {}, {}); }
 
   void runWithRetry() {
     NiceMock<Http::MockStreamEncoder> encoder1;
@@ -223,7 +227,7 @@ TEST_F(RouterUpstreamLogTest, LogSingleTry) {
   run();
 
   EXPECT_EQ(output_.size(), 1U);
-  EXPECT_EQ(output_.front(), "GET / HTTP/1.0 200 - 0 0 host 10.0.0.5:9211 -\n");
+  EXPECT_EQ(output_.front(), "GET / HTTP/1.0 200 - 0 0 host 10.0.0.5:9211 - -\n");
 }
 
 TEST_F(RouterUpstreamLogTest, LogRetries) {
@@ -231,24 +235,24 @@ TEST_F(RouterUpstreamLogTest, LogRetries) {
   runWithRetry();
 
   EXPECT_EQ(output_.size(), 2U);
-  EXPECT_EQ(output_.front(), "GET / HTTP/1.0 0 UT 0 0 host 10.0.0.5:9211 -\n");
-  EXPECT_EQ(output_.back(), "GET / HTTP/1.0 200 - 0 0 host 10.0.0.5:9211 -\n");
+  EXPECT_EQ(output_.front(), "GET / HTTP/1.0 0 UT 0 0 host 10.0.0.5:9211 - -\n");
+  EXPECT_EQ(output_.back(), "GET / HTTP/1.0 200 - 0 0 host 10.0.0.5:9211 - -\n");
 }
 
 TEST_F(RouterUpstreamLogTest, LogFailure) {
   init(testUpstreamLog());
-  run(503, {}, {});
+  run(503, {}, {}, {});
 
   EXPECT_EQ(output_.size(), 1U);
-  EXPECT_EQ(output_.front(), "GET / HTTP/1.0 503 - 0 0 host 10.0.0.5:9211 -\n");
+  EXPECT_EQ(output_.front(), "GET / HTTP/1.0 503 - 0 0 host 10.0.0.5:9211 - -\n");
 }
 
 TEST_F(RouterUpstreamLogTest, LogHeaders) {
   init(testUpstreamLog());
-  run(200, {{"x-envoy-original-path", "/foo"}}, {{"x-upstream-header", "abcdef"}});
+  run(200, {{"x-envoy-original-path", "/foo"}}, {{"x-upstream-header", "abcdef"}}, {{"x-trailer", "value"}});
 
   EXPECT_EQ(output_.size(), 1U);
-  EXPECT_EQ(output_.front(), "GET /foo HTTP/1.0 200 - 0 0 host 10.0.0.5:9211 abcdef\n");
+  EXPECT_EQ(output_.front(), "GET /foo HTTP/1.0 200 - 0 0 host 10.0.0.5:9211 abcdef value\n");
 }
 
 // Test timestamps and durations are emitted.
@@ -266,7 +270,7 @@ TEST_F(RouterUpstreamLogTest, LogTimestampsAndDurations) {
   Envoy::Config::FilterJson::translateAccessLog(*json_object_ptr, upstream_log);
 
   init(absl::optional<envoy::config::filter::accesslog::v2::AccessLog>(upstream_log));
-  run(200, {{"x-envoy-original-path", "/foo"}}, {});
+  run(200, {{"x-envoy-original-path", "/foo"}}, {}, {});
 
   EXPECT_EQ(output_.size(), 1U);
 

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -249,7 +249,8 @@ TEST_F(RouterUpstreamLogTest, LogFailure) {
 
 TEST_F(RouterUpstreamLogTest, LogHeaders) {
   init(testUpstreamLog());
-  run(200, {{"x-envoy-original-path", "/foo"}}, {{"x-upstream-header", "abcdef"}}, {{"x-trailer", "value"}});
+  run(200, {{"x-envoy-original-path", "/foo"}}, {{"x-upstream-header", "abcdef"}},
+      {{"x-trailer", "value"}});
 
   EXPECT_EQ(output_.size(), 1U);
   EXPECT_EQ(output_.front(), "GET /foo HTTP/1.0 200 - 0 0 host 10.0.0.5:9211 abcdef value\n");

--- a/test/mocks/access_log/mocks.h
+++ b/test/mocks/access_log/mocks.h
@@ -40,9 +40,9 @@ public:
   ~MockInstance();
 
   // AccessLog::Instance
-  MOCK_METHOD3(log,
+  MOCK_METHOD4(log,
                void(const Http::HeaderMap* request_headers, const Http::HeaderMap* response_headers,
-                    const RequestInfo::RequestInfo& request_info));
+                    const Http::HeaderMap* response_trailers, const RequestInfo::RequestInfo& request_info));
 };
 
 } // namespace AccessLog

--- a/test/mocks/access_log/mocks.h
+++ b/test/mocks/access_log/mocks.h
@@ -42,7 +42,8 @@ public:
   // AccessLog::Instance
   MOCK_METHOD4(log,
                void(const Http::HeaderMap* request_headers, const Http::HeaderMap* response_headers,
-                    const Http::HeaderMap* response_trailers, const RequestInfo::RequestInfo& request_info));
+                    const Http::HeaderMap* response_trailers,
+                    const RequestInfo::RequestInfo& request_info));
 };
 
 } // namespace AccessLog


### PR DESCRIPTION
*access log*: *response trailer logging*

*Description*:
This PR introduces new `TRAILER(X?Y):Z` formatter for file-based access logs and new fields in grpc access log service protocol, allowing to log response trailer values.

*Risk Level*: Medium

*Testing*:
Mostly unit tests. Test cases modification for access/upstream logging in router, http_connection_manager, access_loggers/http_grpc and access_log_formatter unit tests.

*Docs Changes*:
- `api/envoy/config/accesslog/v2/als.proto` - new field `HttpGrpcAccessLogConfig#additional_response_trailers_to_log` - lists response trailer names to log into grpc access log service.

- `api/envoy/config/filter/accesslog/v2/accesslog.proto` - new field `HTTPResponseProperties#response_trailers` response trailers to be logged into grpc access log service.

- Mention new logging option in `docs/root/configuration/access_log.rst`.

*Release Notes*:
access log: ability to log response trailers

[Fixes #3073]
