### PR TITLE
Add sanitization of x-envoy-ip-tags

### DIFF
--- a/docs/root/configuration/http_conn_man/header_sanitizing.rst
+++ b/docs/root/configuration/http_conn_man/header_sanitizing.rst
@@ -20,6 +20,7 @@ Envoy will potentially sanitize the following headers:
 * :ref:`x-envoy-external-address <config_http_conn_man_headers_x-envoy-external-address>`
 * :ref:`x-envoy-force-trace <config_http_conn_man_headers_x-envoy-force-trace>`
 * :ref:`x-envoy-internal <config_http_conn_man_headers_x-envoy-internal>`
+* :ref:`x-envoy-ip-tags <config_http_filters_ip_tagging>`
 * :ref:`x-envoy-max-retries <config_http_filters_router_x-envoy-max-retries>`
 * :ref:`x-envoy-retry-grpc-on <config_http_filters_router_x-envoy-retry-grpc-on>`
 * :ref:`x-envoy-retry-on <config_http_filters_router_x-envoy-retry-on>`

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -133,6 +133,7 @@ Network::Address::InstanceConstSharedPtr ConnectionManagerUtility::mutateRequest
     request_headers.removeEnvoyUpstreamRequestTimeoutAltResponse();
     request_headers.removeEnvoyExpectedRequestTimeoutMs();
     request_headers.removeEnvoyForceTrace();
+    request_headers.removeEnvoyIpTags();
 
     for (const Http::LowerCaseString& header : route_config.internalOnlyHeaders()) {
       request_headers.remove(header);

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -379,6 +379,7 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
                             {"x-envoy-upstream-rq-timeout-alt-response", "204"},
                             {"x-envoy-upstream-rq-timeout-ms", "foo"},
                             {"x-envoy-expected-rq-timeout-ms", "10"},
+                            {"x-envoy-ip-tags", "bar"},
                             {"custom_header", "foo"}};
 
   EXPECT_EQ((MutateRequestRet{"50.0.0.1:0", false}),
@@ -393,6 +394,7 @@ TEST_F(ConnectionManagerUtilityTest, ExternalAddressExternalRequestUseRemote) {
   EXPECT_FALSE(headers.has("x-envoy-upstream-rq-timeout-alt-response"));
   EXPECT_FALSE(headers.has("x-envoy-upstream-rq-timeout-ms"));
   EXPECT_FALSE(headers.has("x-envoy-expected-rq-timeout-ms"));
+  EXPECT_FALSE(headers.has("x-envoy-ip-tags"));
   EXPECT_FALSE(headers.has("custom_header"));
 }
 


### PR DESCRIPTION
This is a follow-up to #1001. Given that the `x-envoy-ip-tags` header can be used
to apply ACLs, it should be sanitized for incoming requests to avoid trivial bypassing. 

Signed-off-by: Raul Gutierrez S <rgs@pinterest.com>
