### PR TITLE
Upgrade to xxHash 0.6.5 and nghttp2 1.31.1

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -17,7 +17,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/circonus-labs/libcircllhist",
     ),
     com_github_cyan4973_xxhash = dict(
-        commit = "7caf8bd76440c75dfe1070d3acfbd7891aea8fca",  # v0.6.4
+        commit = "7cc9639699f64b750c0b82333dced9ea77e8436e",  # v0.6.5
         remote = "https://github.com/Cyan4973/xxHash",
     ),
     com_github_eile_tclap = dict(

--- a/ci/build_container/build_recipes/gperftools.sh
+++ b/ci/build_container/build_recipes/gperftools.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION=2.6.90
+VERSION=2.6.3
 
 wget -O gperftools-"$VERSION".tar.gz https://github.com/gperftools/gperftools/releases/download/gperftools-"$VERSION"/gperftools-"$VERSION".tar.gz
 tar xf gperftools-"$VERSION".tar.gz

--- a/ci/build_container/build_recipes/gperftools.sh
+++ b/ci/build_container/build_recipes/gperftools.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION=2.6.3
+VERSION=2.6.90
 
 wget -O gperftools-"$VERSION".tar.gz https://github.com/gperftools/gperftools/releases/download/gperftools-"$VERSION"/gperftools-"$VERSION".tar.gz
 tar xf gperftools-"$VERSION".tar.gz

--- a/ci/build_container/build_recipes/nghttp2.sh
+++ b/ci/build_container/build_recipes/nghttp2.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION=1.31.0
+VERSION=1.31.1
 
 wget -O nghttp2-"$VERSION".tar.gz https://github.com/nghttp2/nghttp2/releases/download/v"$VERSION"/nghttp2-"$VERSION".tar.gz
 tar xf nghttp2-"$VERSION".tar.gz


### PR DESCRIPTION
Signed-off-by: Michael Payne <michael@sooper.org>

*dependency*: Upgrade to gperftools 2.6.90, xxHash 0.6.5 and nghttp2 1.31.1.

*Description*: Upgrade dependencies for gperftools [release notes](https://github.com/gperftools/gperftools/releases/tag/gperftools-2.6.90), nghttp2 which fixes a CVE [release notes](https://github.com/nghttp2/nghttp2/releases/tag/v1.31.1) and xxHash [release notes](https://github.com/Cyan4973/xxHash/releases/tag/v0.6.5).

*Risk Level*: Low

*Testing*: `bazel test //test/...` and running on local instances for 1+ weeks.

*Docs Changes*: none required.