### PR TITLE
docs: fix code formatting

### DIFF
--- a/docs/root/start/start.rst
+++ b/docs/root/start/start.rst
@@ -22,7 +22,7 @@ the same configuration.
 
 A very minimal Envoy configuration that can be used to validate basic plain HTTP
 proxying is available in :repo:`configs/google_com_proxy.v2.yaml`. This is not
-intended to represent a realistic Envoy deployment.
+intended to represent a realistic Envoy deployment::
 
   $ docker pull envoyproxy/envoy:latest
   $ docker run --rm -d -p 10000:10000 envoyproxy/envoy:latest


### PR DESCRIPTION
*Description*:
the [current docs](https://www.envoyproxy.io/docs/envoy/latest/start/start#quick-start-to-run-simple-example) doesn't format `--rm` correctly. It is rendered as `-rm`, which causes the command to fail if copied and pasted:
![image](https://user-images.githubusercontent.com/10189197/39241720-c8e658fa-487f-11e8-8e5d-e7dc94f5cefa.png)

this PR fixes that behaviour.

*Risk Level*: Low
*Testing*: None