### PR TITLE
protobuf: enforce Duration constraints in DurationUtil.

### DIFF
--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -190,6 +190,11 @@ void validateDuration(const ProtobufWkt::Duration& duration) {
     throw DurationUtil::OutOfRangeException(
         fmt::format("Expected positive duration: {}", duration.DebugString()));
   }
+  if (duration.nanos() > 999999999 ||
+      duration.seconds() > Protobuf::util::TimeUtil::kDurationMaxSeconds) {
+    throw DurationUtil::OutOfRangeException(
+        fmt::format("Duration out-of-range: {}", duration.DebugString()));
+  }
 }
 
 } // namespace

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -232,6 +232,16 @@ TEST(DurationUtilTest, OutOfRange) {
     duration.set_nanos(-1);
     EXPECT_THROW(DurationUtil::durationToMilliseconds(duration), DurationUtil::OutOfRangeException);
   }
+  {
+    ProtobufWkt::Duration duration;
+    duration.set_nanos(1000000000);
+    EXPECT_THROW(DurationUtil::durationToMilliseconds(duration), DurationUtil::OutOfRangeException);
+  }
+  {
+    ProtobufWkt::Duration duration;
+    duration.set_seconds(Protobuf::util::TimeUtil::kDurationMaxSeconds + 1);
+    EXPECT_THROW(DurationUtil::durationToMilliseconds(duration), DurationUtil::OutOfRangeException);
+  }
 }
 
 } // namespace Envoy

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-4890981380915200
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-4890981380915200
@@ -1,0 +1,13 @@
+stats_flush_interval {
+  seconds: 13792273858822144
+}
+tracing {
+}
+admin {
+  access_log_path: "127.0.0.1"
+  address {
+    pipe {
+      path: "\177"
+    }
+  }
+}


### PR DESCRIPTION
Turns out that protobuf library doesn't do this, and when we don't have
PGV constraints generated, neither does PGV.

Risk Level: Low
Testing: New utility_test.

Signed-off-by: Harvey Tuch <htuch@google.com>