### PR TITLE
config_verification: fixed crash when running in config verification mode

### DIFF
--- a/source/server/config_validation/BUILD
+++ b/source/server/config_validation/BUILD
@@ -53,9 +53,13 @@ envoy_cc_library(
 envoy_cc_library(
     name = "dispatcher_lib",
     srcs = ["dispatcher.cc"],
-    hdrs = ["dispatcher.h"],
+    hdrs = [
+        "connection.h",
+        "dispatcher.h",
+    ],
     deps = [
         "//include/envoy/event:dispatcher_interface",
+        "//include/envoy/network:connection_interface",
         "//source/common/common:assert_lib",
         "//source/common/event:dispatcher_lib",
     ],

--- a/source/server/config_validation/connection.h
+++ b/source/server/config_validation/connection.h
@@ -1,0 +1,27 @@
+#include "common/network/connection_impl.h"
+
+namespace Envoy {
+namespace Network {
+
+/*
+  Class representing connection to upstream entity in config verification mode. The connection is
+  not really established, but sockets may be allocated. Methods doing "real" connections should be
+  overridden with no-op implementations.
+*/
+class ConfigValidateConnection : public Network::ClientConnectionImpl {
+public:
+  ConfigValidateConnection(Event::ValidationDispatcher& dispatcher,
+                           Network::Address::InstanceConstSharedPtr remote_address,
+                           Network::Address::InstanceConstSharedPtr source_address,
+                           Network::TransportSocketPtr&& transport_socket,
+                           const Network::ConnectionSocket::OptionsSharedPtr& options)
+      : Network::ClientConnectionImpl(dispatcher, remote_address, source_address,
+                                      std::move(transport_socket), options) {}
+
+  // Unit tests may instantiate it without proper event machine and leave opened sockets.
+  // Do some cleanup before invoking base class's destructor.
+  virtual ~ConfigValidateConnection() { close(ConnectionCloseType::NoFlush); }
+};
+
+} // namespace Network
+} // namespace Envoy

--- a/source/server/config_validation/connection.h
+++ b/source/server/config_validation/connection.h
@@ -21,6 +21,10 @@ public:
   // Unit tests may instantiate it without proper event machine and leave opened sockets.
   // Do some cleanup before invoking base class's destructor.
   virtual ~ConfigValidateConnection() { close(ConnectionCloseType::NoFlush); }
+
+  // connect may be called in config verification mode.
+  // It is redefined as no-op. Calling parent's method triggers connection to upstream host.
+  virtual void connect() override {}
 };
 
 } // namespace Network

--- a/source/server/config_validation/dispatcher.cc
+++ b/source/server/config_validation/dispatcher.cc
@@ -2,13 +2,18 @@
 
 #include "common/common/assert.h"
 
+#include "server/config_validation/connection.h"
+
 namespace Envoy {
 namespace Event {
 
 Network::ClientConnectionPtr ValidationDispatcher::createClientConnection(
-    Network::Address::InstanceConstSharedPtr, Network::Address::InstanceConstSharedPtr,
-    Network::TransportSocketPtr&&, const Network::ConnectionSocket::OptionsSharedPtr&) {
-  NOT_IMPLEMENTED;
+    Network::Address::InstanceConstSharedPtr remote_address,
+    Network::Address::InstanceConstSharedPtr source_address,
+    Network::TransportSocketPtr&& transport_socket,
+    const Network::ConnectionSocket::OptionsSharedPtr& options) {
+  return std::make_unique<Network::ConfigValidateConnection>(*this, remote_address, source_address,
+                                                             std::move(transport_socket), options);
 }
 
 Network::DnsResolverSharedPtr ValidationDispatcher::createDnsResolver(

--- a/test/server/config_validation/BUILD
+++ b/test/server/config_validation/BUILD
@@ -56,3 +56,13 @@ envoy_cc_test(
         "//test/test_common:utility_lib",
     ],
 )
+
+envoy_cc_test(
+    name = "dispatcher_test",
+    srcs = ["dispatcher_test.cc"],
+    deps = [
+        "//source/common/event:libevent_lib",
+        "//source/server/config_validation:api_lib",
+        "//test/test_common:network_utility_lib",
+    ],
+)

--- a/test/server/config_validation/dispatcher_test.cc
+++ b/test/server/config_validation/dispatcher_test.cc
@@ -1,0 +1,43 @@
+#include <chrono>
+
+#include "common/event/dispatcher_impl.h"
+#include "common/event/libevent.h"
+#include "common/network/address_impl.h"
+#include "common/network/utility.h"
+
+#include "server/config_validation/api.h"
+
+#include "test/test_common/network_utility.h"
+
+#include "gmock/gmock.h"
+
+namespace Envoy {
+
+// Define fixture which allocates ValidationDispatcher.
+class ConfigValidation : public ::testing::Test {
+public:
+  ConfigValidation() {
+    Event::Libevent::Global::initialize();
+
+    validation_ = std::make_unique<Api::ValidationImpl>(std::chrono::milliseconds(1000));
+    dispatcher_ = validation_->allocateDispatcher();
+  }
+
+  Event::DispatcherPtr dispatcher_;
+
+private:
+  // Using config validation API.
+  std::unique_ptr<Api::ValidationImpl> validation_;
+};
+
+// Simple test which creates a connection to fake upstream client. This is to test if
+// ValidationDispatcher can call createClientConnection without crashing.
+TEST_F(ConfigValidation, createConnection) {
+  dispatcher_->createClientConnection(
+      Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("127.0.0.1")),
+      Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("127.0.0.1")),
+      Network::Test::createRawBufferSocket(), nullptr);
+  SUCCEED();
+}
+
+} // namespace Envoy


### PR DESCRIPTION
Description: Envoy running in config verification mode was crashing when configured in static cluster mode with health checks enabled. Specific config is described in #3083.

Risk Level: Low.

Testing: Added unit test to cover creating fake upstream connection via ValidationDispatcher.

Docs Changes: No.

Release Notes: No.

Fixes: #3083