### PR TITLE
build: Fix ASAN build with --define=google_grpc=disabled

### DIFF
--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -22,7 +22,7 @@ private:
 
 class GoogleAsyncClientFactoryImpl : public AsyncClientFactory {
 public:
-  GoogleAsyncClientFactoryImpl(ThreadLocal::Instance& tls, ThreadLocal::Slot& google_tls_slot,
+  GoogleAsyncClientFactoryImpl(ThreadLocal::Instance& tls, ThreadLocal::Slot* google_tls_slot,
                                Stats::Scope& scope,
                                const envoy::api::v2::core::GrpcService& config);
 
@@ -30,7 +30,7 @@ public:
 
 private:
   ThreadLocal::Instance& tls_;
-  ThreadLocal::Slot& google_tls_slot_;
+  ThreadLocal::Slot* google_tls_slot_;
   Stats::ScopeSharedPtr scope_;
   const envoy::api::v2::core::GrpcService config_;
 };


### PR DESCRIPTION
ASAN does not allow *(nullptr) being converted to a reference.

Fixes #3208

Signed-off-by: Greg Greenway <ggreenway@apple.com>

*Risk Level*: Low

*Testing*: Built ASAN with --define=google_grpc=disabled