### PR TITLE
Fix issue with Envoy not reference counting across scopes under not-hot restart

### DIFF
--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -276,16 +276,13 @@ void HeapRawStatDataAllocator::free(RawStatData& data) {
     return;
   }
 
-  std::cout << data.key() << "\n";
   size_t key_removed = stats_set_.erase(std::string(data.key()));
-  std::cout << key_removed << "\n";
   ASSERT(key_removed >= 1);
   ::free(&data);
 }
 
 void RawStatData::initialize(absl::string_view key) {
   ASSERT(!initialized());
-  std::cout << key << "\n";
   if (key.size() > Stats::RawStatData::maxNameLength()) {
     ENVOY_LOG_MISC(
         warn,

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -154,13 +154,17 @@ RawStatData* HeapRawStatDataAllocator::alloc(const std::string& name) {
 
   if (key.size() > Stats::RawStatData::maxNameLength()) {
     key.remove_suffix(key.size() - Stats::RawStatData::maxNameLength());
+    ENVOY_LOG_MISC(
+        warn,
+        "Statistic '{}' is too long with {} characters, it will be truncated to {} characters", key,
+        key.size(), Stats::RawStatData::maxNameLength());
   }
 
   auto ret = stats_set_.insert(std::pair<std::string, RawStatData*>(std::string(key), nullptr));
   RawStatData*& data = ret.first->second;
   if (ret.second) {
     data = static_cast<RawStatData*>(::calloc(RawStatData::size(), 1));
-    data->initialize(name);
+    data->initialize(key);
   } else {
     ++data->ref_count_;
   }

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -154,17 +154,13 @@ RawStatData* HeapRawStatDataAllocator::alloc(const std::string& name) {
 
   if (key.size() > Stats::RawStatData::maxNameLength()) {
     key.remove_suffix(key.size() - Stats::RawStatData::maxNameLength());
-    ENVOY_LOG_MISC(
-        warn,
-        "Statistic '{}' is too long with {} characters, it will be truncated to {} characters", key,
-        key.size(), Stats::RawStatData::maxNameLength());
   }
 
   auto ret = stats_set_.insert(std::pair<std::string, RawStatData*>(std::string(key), nullptr));
   RawStatData*& data = ret.first->second;
   if (ret.second) {
     data = static_cast<RawStatData*>(::calloc(RawStatData::size(), 1));
-    data->initialize(key);
+    data->initialize(name);
   } else {
     ++data->ref_count_;
   }
@@ -285,6 +281,13 @@ void HeapRawStatDataAllocator::free(RawStatData& data) {
 
 void RawStatData::initialize(absl::string_view key) {
   ASSERT(!initialized());
+  std::cout << key << "\n";
+  if (key.size() > Stats::RawStatData::maxNameLength()) {
+    ENVOY_LOG_MISC(
+        warn,
+        "Statistic '{}' is too long with {} characters, it will be truncated to {} characters", key,
+        key.size(), Stats::RawStatData::maxNameLength());
+  }
   ref_count_ = 1;
 
   // key is not necessarily nul-terminated, but we want to make sure name_ is.

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -163,7 +163,6 @@ RawStatData* HeapRawStatDataAllocator::alloc(const std::string& name) {
   auto ret = stats_set_.insert(std::pair<std::string, RawStatData*>(std::string(key), nullptr));
   RawStatData*& data = ret.first->second;
   if (ret.second) {
-    // didn't exist before now, actually create
     data = static_cast<RawStatData*>(::calloc(RawStatData::size(), 1));
     data->initialize(key);
   } else {

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -156,9 +156,11 @@ RawStatData* HeapRawStatDataAllocator::alloc(const std::string& name) {
     key.remove_suffix(key.size() - Stats::RawStatData::maxNameLength());
   }
 
-  RawStatData* data = stats_set_[std::string(key)];
+  bool name_not_in_map = (stats_set_.find(std::string(key)) == stats_set_.end());
 
-  if (stats_set_.count(std::string(key)) == 1) { // TODO do better
+  RawStatData*& data = stats_set_[std::string(key)];
+
+  if (name_not_in_map) {
     // didn't exist before now, actually create
     data = static_cast<RawStatData*>(::calloc(RawStatData::size(), 1));
     data->initialize(name);

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -414,6 +414,9 @@ public:
   // RawStatDataAllocator
   RawStatData* alloc(const std::string& name) override;
   void free(RawStatData& data) override;
+
+private:
+  std::unordered_map<std::string, RawStatData*> stats_set_;
 };
 
 /**

--- a/test/common/stats/stats_impl_test.cc
+++ b/test/common/stats/stats_impl_test.cc
@@ -478,5 +478,14 @@ TEST(RawStatDataTest, Truncate) {
   alloc.free(*stat);
 }
 
+TEST(RawStatDataTest, HeapAlloc) {
+  HeapRawStatDataAllocator alloc;
+  RawStatData* stat_1 = alloc.alloc("ref_name");
+  RawStatData* stat_2 = alloc.alloc("ref_name");
+  EXPECT_EQ(stat_1, stat_2);
+  ::free(stat_1);
+  ::free(stat_2);
+}
+
 } // namespace Stats
 } // namespace Envoy


### PR DESCRIPTION
Signed-off-by: James Buckland jbuckland@google.com

title: Fixes issue with Envoy not reference counting stats across scopes under not-hot restart.

Description: Simpler solution to issue #2453 than pull #3163, continuing draft work in ambuc#1 and ambuc#2. Summary of changes:

 - adds an unordered_map named `stats_set_` as a member variable of `HeapRawStatDataAllocator`, and implements reference counting / dedup on allocated stats.

Risk Level: Low.

Testing: Add a test to stats_impl_test. Passes `bazel test test/....`

Docs Changes: N/A

Release Notes: This is user-facing in that non-hot restart stat allocation now resolves namespace properly, but no effect on user configs.

Fixes: #2453 