### PR TITLE
Revert "http/2: better handling for messaging error resets (#3140)"

### DIFF
--- a/docs/root/configuration/http_conn_man/stats.rst
+++ b/docs/root/configuration/http_conn_man/stats.rst
@@ -103,13 +103,12 @@ All http2 statistics are rooted at *http2.*
    :header: Name, Type, Description
    :widths: 1, 1, 2
 
-   header_overflow, Counter, Total number of connections reset due to the headers being larger than `Envoy::Http::Http2::ConnectionImpl::StreamImpl::MAX_HEADER_SIZE` (63k)
-   headers_cb_no_stream, Counter, Total number of errors where a header callback is called without an associated stream. This tracks an unexpected occurrence due to an as yet undiagnosed bug
-   rx_messaging_error, Counter, Total number of invalid received frames that violated `section 8 <https://tools.ietf.org/html/rfc7540#section-8>`_ of the HTTP/2 spec. This will result in a *tx_reset*
    rx_reset, Counter, Total number of reset stream frames received by Envoy
-   too_many_header_frames, Counter, Total number of times an HTTP2 connection is reset due to receiving too many headers frames. Envoy currently supports proxying at most one header frame for 100-Continue one non-100 response code header frame and one frame with trailers
-   trailers, Counter, Total number of trailers seen on requests coming from downstream
    tx_reset, Counter, Total number of reset stream frames transmitted by Envoy
+   header_overflow, Counter, Total number of connections reset due to the headers being larger than `Envoy::Http::Http2::ConnectionImpl::StreamImpl::MAX_HEADER_SIZE` (63k)
+   trailers, Counter, Total number of trailers seen on requests coming from downstream
+   headers_cb_no_stream, Counter, Total number of errors where a header callback is called without an associated stream. This tracks an unexpected occurrence due to an as yet undiagnosed bug
+   too_many_header_frames, Counter, Total number of times an HTTP2 connection is reset due to receiving too many headers frames. Envoy currently supports proxying at most one header frame for 100-Continue one non-100 response code header frame and one frame with trailers
 
 Tracing statistics
 ------------------

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -52,7 +52,7 @@ ConnectionImpl::StreamImpl::StreamImpl(ConnectionImpl& parent, uint32_t buffer_l
       remote_end_stream_(false), data_deferred_(false),
       waiting_for_non_informational_headers_(false),
       pending_receive_buffer_high_watermark_called_(false),
-      pending_send_buffer_high_watermark_called_(false), reset_due_to_messaging_error_(false) {
+      pending_send_buffer_high_watermark_called_(false) {
   if (buffer_limit > 0) {
     setWriteBufferWatermarks(buffer_limit / 2, buffer_limit);
   }
@@ -483,18 +483,12 @@ int ConnectionImpl::onFrameSend(const nghttp2_frame* frame) {
   return 0;
 }
 
-int ConnectionImpl::onInvalidFrame(int32_t stream_id, int error_code) {
+int ConnectionImpl::onInvalidFrame(int error_code) {
   ENVOY_CONN_LOG(debug, "invalid frame: {}", connection_, nghttp2_strerror(error_code));
 
-  // The stream is about to be closed due to an invalid header or messaging. Don't kill the
-  // entire connection if one stream has bad headers or messaging.
-  if (error_code == NGHTTP2_ERR_HTTP_HEADER || error_code == NGHTTP2_ERR_HTTP_MESSAGING) {
-    stats_.rx_messaging_error_.inc();
-    StreamImpl* stream = getStream(stream_id);
-    if (stream != nullptr) {
-      // See comment below in onStreamClose() for why we do this.
-      stream->reset_due_to_messaging_error_ = true;
-    }
+  // The stream is about to be closed due to an invalid header. Don't kill the
+  // entire connection if one stream has bad headers.
+  if (error_code == NGHTTP2_ERR_HTTP_HEADER) {
     return 0;
   }
 
@@ -510,26 +504,14 @@ ssize_t ConnectionImpl::onSend(const uint8_t* data, size_t length) {
 }
 
 int ConnectionImpl::onStreamClose(int32_t stream_id, uint32_t error_code) {
+
   StreamImpl* stream = getStream(stream_id);
   if (stream) {
     ENVOY_CONN_LOG(debug, "stream closed: {}", connection_, error_code);
     if (!stream->remote_end_stream_ || !stream->local_end_stream_) {
-      StreamResetReason reason;
-      if (stream->reset_due_to_messaging_error_) {
-        // Unfortunately, the nghttp2 API makes it incredibly difficult to clearly understand
-        // the flow of resets. I.e., did the reset originate locally? Was it remote? Here,
-        // we attempt to track cases in which we sent a reset locally due to an invalid frame
-        // received from the remote. We only do that in two cases currently (HTTP messaging layer
-        // errors from https://tools.ietf.org/html/rfc7540#section-8 which nghttp2 is very strict
-        // about). In other cases we treat invalid frames as a protocol error and just kill
-        // the connection.
-        reason = StreamResetReason::LocalReset;
-      } else {
-        reason = error_code == NGHTTP2_REFUSED_STREAM ? StreamResetReason::RemoteRefusedStreamReset
-                                                      : StreamResetReason::RemoteReset;
-      }
-
-      stream->runResetCallbacks(reason);
+      stream->runResetCallbacks(error_code == NGHTTP2_REFUSED_STREAM
+                                    ? StreamResetReason::RemoteRefusedStreamReset
+                                    : StreamResetReason::RemoteReset);
     }
 
     connection_.dispatcher().deferredDelete(stream->removeFromList(active_streams_));
@@ -729,9 +711,8 @@ ConnectionImpl::Http2Callbacks::Http2Callbacks() {
 
   nghttp2_session_callbacks_set_on_invalid_frame_recv_callback(
       callbacks_,
-      [](nghttp2_session*, const nghttp2_frame* frame, int error_code, void* user_data) -> int {
-        return static_cast<ConnectionImpl*>(user_data)->onInvalidFrame(frame->hd.stream_id,
-                                                                       error_code);
+      [](nghttp2_session*, const nghttp2_frame*, int error_code, void* user_data) -> int {
+        return static_cast<ConnectionImpl*>(user_data)->onInvalidFrame(error_code);
       });
 }
 

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -37,13 +37,12 @@ const std::string CLIENT_MAGIC_PREFIX = "PRI * HTTP/2";
  */
 // clang-format off
 #define ALL_HTTP2_CODEC_STATS(COUNTER)                                                             \
-  COUNTER(header_overflow)                                                                         \
-  COUNTER(headers_cb_no_stream)                                                                    \
-  COUNTER(rx_messaging_error)                                                                      \
   COUNTER(rx_reset)                                                                                \
-  COUNTER(too_many_header_frames)                                                                  \
+  COUNTER(tx_reset)                                                                                \
+  COUNTER(header_overflow)                                                                         \
   COUNTER(trailers)                                                                                \
-  COUNTER(tx_reset)
+  COUNTER(headers_cb_no_stream)                                                                    \
+  COUNTER(too_many_header_frames)
 // clang-format on
 
 /**
@@ -204,7 +203,6 @@ protected:
     bool waiting_for_non_informational_headers_ : 1;
     bool pending_receive_buffer_high_watermark_called_ : 1;
     bool pending_send_buffer_high_watermark_called_ : 1;
-    bool reset_due_to_messaging_error_ : 1;
   };
 
   typedef std::unique_ptr<StreamImpl> StreamImplPtr;
@@ -253,7 +251,7 @@ private:
   int onFrameReceived(const nghttp2_frame* frame);
   int onFrameSend(const nghttp2_frame* frame);
   virtual int onHeader(const nghttp2_frame* frame, HeaderString&& name, HeaderString&& value) PURE;
-  int onInvalidFrame(int32_t stream_id, int error_code);
+  int onInvalidFrame(int error_code);
   ssize_t onSend(const uint8_t* data, size_t length);
   int onStreamClose(int32_t stream_id, uint32_t error_code);
 


### PR DESCRIPTION
This reverts commit e293ffb881c9d2b9cf664ff8521e86fedb141de7.