### PR TITLE
load balancer: plugging API config into zone aware load balancer

### DIFF
--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -377,15 +377,12 @@ message Cluster {
     envoy.type.Percent healthy_panic_threshold = 1;
     // Configuration for :ref:`zone aware routing
     // <arch_overview_load_balancing_zone_aware_routing>`.
-    // [#not-implemented-hide:]
     message ZoneAwareLbConfig {
-      // [#not-implemented-hide:]
       // Configures percentage of requests that will be considered for zone aware routing
       // if zone aware routing is configured. If not specified, the default is 100%.
       // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
       // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
       envoy.type.Percent routing_enabled = 1;
-      // [#not-implemented-hide:]
       // Configures minimum upstream cluster size required for zone aware routing
       // If upstream cluster size is less than specified, zone aware routing is not performed
       // even if zone aware routing is configured. If not specified, the default is 6.
@@ -398,7 +395,6 @@ message Cluster {
     message LocalityWeightedLbConfig {
     }
     oneof locality_config_specifier {
-      // [#not-implemented-hide:]
       ZoneAwareLbConfig zone_aware_lb_config = 2;
       LocalityWeightedLbConfig locality_weighted_lb_config = 3;
     }

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -50,6 +50,8 @@ Version history
   picks.
 * load balancer: :ref:`Locality weighted load balancing
   <arch_overview_load_balancer_subsets>` is now supported.
+* load balancer: ability to configure zone aware load balancer settings :ref:`through the API
+  <envoy_api_field_Cluster.CommonLbConfig.zone_aware_lb_config>`
 * logger: added the ability to optionally set the log format via the :option:`--log-format` option.
 * logger: all :ref:`logging levels <operations_admin_interface_logging>` can be configured
   at run-time: trace debug info warning error critical.

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -258,7 +258,7 @@ bool ZoneAwareLoadBalancerBase::earlyExitNonLocalityRouting() {
   }
 
   // Do not perform locality routing for small clusters.
-  uint64_t min_cluster_size =
+  uint64_t const min_cluster_size =
       runtime_.snapshot().getInteger(RuntimeMinClusterSize, min_cluster_size_);
   if (host_set.healthyHosts().size() < min_cluster_size) {
     stats_.lb_zone_cluster_too_small_.inc();

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -107,7 +107,11 @@ ZoneAwareLoadBalancerBase::ZoneAwareLoadBalancerBase(
     Runtime::Loader& runtime, Runtime::RandomGenerator& random,
     const envoy::api::v2::Cluster::CommonLbConfig& common_config)
     : LoadBalancerBase(priority_set, stats, runtime, random, common_config),
-      local_priority_set_(local_priority_set) {
+      local_priority_set_(local_priority_set),
+      routing_enabled_(PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(
+          common_config.zone_aware_lb_config(), routing_enabled, 100, 100)),
+      min_cluster_size_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(common_config.zone_aware_lb_config(),
+                                                        min_cluster_size, 6U)) {
   ASSERT(!priority_set.hostSetsPerPriority().empty());
   resizePerPriorityState();
   priority_set_.addMemberUpdateCb(
@@ -254,7 +258,8 @@ bool ZoneAwareLoadBalancerBase::earlyExitNonLocalityRouting() {
   }
 
   // Do not perform locality routing for small clusters.
-  uint64_t min_cluster_size = runtime_.snapshot().getInteger(RuntimeMinClusterSize, 6U);
+  uint64_t min_cluster_size =
+      runtime_.snapshot().getInteger(RuntimeMinClusterSize, min_cluster_size_);
   if (host_set.healthyHosts().size() < min_cluster_size) {
     stats_.lb_zone_cluster_too_small_.inc();
     return true;
@@ -370,7 +375,7 @@ ZoneAwareLoadBalancerBase::HostsSource ZoneAwareLoadBalancerBase::hostSourceToUs
   }
 
   // Determine if the load balancer should do zone based routing for this pick.
-  if (!runtime_.snapshot().featureEnabled(RuntimeZoneEnabled, 100)) {
+  if (!runtime_.snapshot().featureEnabled(RuntimeZoneEnabled, routing_enabled_)) {
     hosts_source.source_type_ = HostsSource::SourceType::HealthyHosts;
     return hosts_source;
   }

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -258,7 +258,7 @@ bool ZoneAwareLoadBalancerBase::earlyExitNonLocalityRouting() {
   }
 
   // Do not perform locality routing for small clusters.
-  uint64_t const min_cluster_size =
+  const uint64_t min_cluster_size =
       runtime_.snapshot().getInteger(RuntimeMinClusterSize, min_cluster_size_);
   if (host_set.healthyHosts().size() < min_cluster_size) {
     stats_.lb_zone_cluster_too_small_.inc();

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -184,8 +184,8 @@ private:
   // The set of local Envoy instances which are load balancing across priority_set_.
   const PrioritySet* local_priority_set_;
 
-  uint32_t routing_enabled_;
-  uint64_t min_cluster_size_;
+  uint32_t const routing_enabled_;
+  uint64_t const min_cluster_size_;
 
   struct PerPriorityState {
     // The percent of requests which can be routed to the local locality.

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -184,6 +184,9 @@ private:
   // The set of local Envoy instances which are load balancing across priority_set_.
   const PrioritySet* local_priority_set_;
 
+  uint32_t routing_enabled_;
+  uint64_t min_cluster_size_;
+
   struct PerPriorityState {
     // The percent of requests which can be routed to the local locality.
     uint64_t local_percent_to_route_{};

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -184,8 +184,8 @@ private:
   // The set of local Envoy instances which are load balancing across priority_set_.
   const PrioritySet* local_priority_set_;
 
-  uint32_t const routing_enabled_;
-  uint64_t const min_cluster_size_;
+  const uint32_t routing_enabled_;
+  const uint64_t min_cluster_size_;
 
   struct PerPriorityState {
     // The percent of requests which can be routed to the local locality.

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -462,6 +462,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareSmallCluster) {
   hostSet().healthy_hosts_ = *hosts;
   hostSet().healthy_hosts_per_locality_ = hosts_per_locality;
   common_config_.mutable_healthy_panic_threshold()->set_value(0);
+  common_config_.mutable_zone_aware_lb_config()->mutable_routing_enabled()->set_value(100);
+  common_config_.mutable_zone_aware_lb_config()->mutable_min_cluster_size()->set_value(6);
   init(true);
   local_host_set_->updateHosts(hosts, hosts, hosts_per_locality, hosts_per_locality, {},
                                empty_host_vector_, empty_host_vector_);
@@ -510,6 +512,8 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareDifferentZoneSize) {
   hostSet().hosts_ = *hosts;
   hostSet().healthy_hosts_per_locality_ = upstream_hosts_per_locality;
   common_config_.mutable_healthy_panic_threshold()->set_value(100);
+  common_config_.mutable_zone_aware_lb_config()->mutable_routing_enabled()->set_value(100);
+  common_config_.mutable_zone_aware_lb_config()->mutable_min_cluster_size()->set_value(6);
   init(true);
   local_host_set_->updateHosts(hosts, hosts, local_hosts_per_locality, local_hosts_per_locality, {},
                                empty_host_vector_, empty_host_vector_);

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -462,18 +462,18 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareSmallCluster) {
   hostSet().healthy_hosts_ = *hosts;
   hostSet().healthy_hosts_per_locality_ = hosts_per_locality;
   common_config_.mutable_healthy_panic_threshold()->set_value(0);
-  common_config_.mutable_zone_aware_lb_config()->mutable_routing_enabled()->set_value(100);
-  common_config_.mutable_zone_aware_lb_config()->mutable_min_cluster_size()->set_value(6);
+  common_config_.mutable_zone_aware_lb_config()->mutable_routing_enabled()->set_value(98);
+  common_config_.mutable_zone_aware_lb_config()->mutable_min_cluster_size()->set_value(7);
   init(true);
   local_host_set_->updateHosts(hosts, hosts, hosts_per_locality, hosts_per_locality, {},
                                empty_host_vector_, empty_host_vector_);
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 0))
       .WillRepeatedly(Return(50));
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 98))
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
-      .WillRepeatedly(Return(6));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 7))
+      .WillRepeatedly(Return(7));
 
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
@@ -486,7 +486,7 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareSmallCluster) {
     EXPECT_EQ(0U, stats_.lb_zone_cluster_too_small_.value());
     return;
   }
-  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 6))
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 7))
       .WillRepeatedly(Return(1));
   // Trigger reload.
   local_host_set_->updateHosts(hosts, hosts, hosts_per_locality, hosts_per_locality, {},
@@ -512,16 +512,18 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareDifferentZoneSize) {
   hostSet().hosts_ = *hosts;
   hostSet().healthy_hosts_per_locality_ = upstream_hosts_per_locality;
   common_config_.mutable_healthy_panic_threshold()->set_value(100);
-  common_config_.mutable_zone_aware_lb_config()->mutable_routing_enabled()->set_value(100);
-  common_config_.mutable_zone_aware_lb_config()->mutable_min_cluster_size()->set_value(6);
+  common_config_.mutable_zone_aware_lb_config()->mutable_routing_enabled()->set_value(98);
+  common_config_.mutable_zone_aware_lb_config()->mutable_min_cluster_size()->set_value(7);
   init(true);
   local_host_set_->updateHosts(hosts, hosts, local_hosts_per_locality, local_hosts_per_locality, {},
                                empty_host_vector_, empty_host_vector_);
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 100))
       .WillRepeatedly(Return(50));
-  EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 100))
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("upstream.zone_routing.enabled", 98))
       .WillRepeatedly(Return(true));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 7))
+      .WillRepeatedly(Return(7));
 
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
   EXPECT_EQ(1U, stats_.lb_zone_number_differs_.value());


### PR DESCRIPTION
*Description*:
This PR allows `upstream.zone_routing.enabled` and `upstream.zone_routing.min_cluster_size` to be set through the configuration API.

It closes the loop on the work started with https://github.com/envoyproxy/data-plane-api/pull/480

*Risk Level*: Low

*Testing*: Existing unit tests were updated with these settings.

Fixes: https://github.com/envoyproxy/envoy/issues/1344

Signed-off-by: Marcelo Juchem <juchem@gmail.com>