### PR TITLE
stats: change duplicate histogram log level to debug

### DIFF
--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -76,7 +76,7 @@ std::list<ParentHistogramSharedPtr> ThreadLocalStoreImpl::histograms() const {
       if (names.insert(hist_name).second) {
         ret.push_back(parent_hist);
       } else {
-        ENVOY_LOG(warn, "duplicate histogram {}{}: data loss will occur on output", scope->prefix_,
+        ENVOY_LOG(debug, "duplicate histogram {}{}: data loss will occur on output", scope->prefix_,
                   hist_name);
       }
     }


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*:
Changes the log level to debug as this warning spams during every flush.

*Risk Level*: Low 
*Testing*: Automated test
*Docs Changes*: NA
*Release Notes*: NA

