### PR TITLE
stats: use a release-assert when histogram-merging tries to run concurrently

### DIFF
--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -100,7 +100,7 @@ void ThreadLocalStoreImpl::shutdownThreading() {
 }
 
 void ThreadLocalStoreImpl::mergeHistograms(PostMergeCb merge_complete_cb) {
-  ASSERT(!merge_in_progress_);
+  RELEASE_ASSERT(!merge_in_progress_);
   if (!shutting_down_) {
     merge_in_progress_ = true;
     tls_->runOnAllThreads(


### PR DESCRIPTION
*Description*:
>Converts an ASSERT to a RELEASE_ASSERT, as it could be related to memory corruption observed in https://github.com/envoyproxy/envoy/issues/3223 .  This was originally an if-statement blocking the corruption in @ramaraochavali histogram PR but per @mrice32 we changed it to an ASSERT, which means if it happens in production, it's a silent corruption.

*Risk Level*: Low

*Testing*: //test/... pass.  but test/extensions/stats_sinks/metrics_service:metrics_service_integration_test fails with this assertion when run under valgrind.

*Docs Changes*: N/A

*Release Notes*: N/A
