### PR TITLE
fuzz: make server_fuzz corpus more hermetic.

### DIFF
--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-4832853025095680
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-4832853025095680
@@ -8,7 +8,7 @@ static_resources {
     hosts {
       socket_address {
         address: "google.com"
-        port_value: 443
+        port_value: 0
       }
     }
     tls_context {

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-6280208148594688
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-6280208148594688
@@ -8,7 +8,7 @@ static_resources {
     hosts {
       socket_address {
         address: "127.0.0.1"
-        port_value: 9901
+        port_value: 0
       }
     }
     tls_context {
@@ -23,7 +23,7 @@ admin {
   address {
     socket_address {
       address: "127.0.0.1"
-      port_value: 9901
+      port_value: 0
     }
   }
 }

--- a/test/server/server_corpus/crash-d60f68abcafaae8e7b135ca5144b062d969e5575
+++ b/test/server/server_corpus/crash-d60f68abcafaae8e7b135ca5144b062d969e5575
@@ -8,7 +8,7 @@ static_resources {
     hosts {
       socket_address {
         address: "google.com"
-        port_value: 443
+        port_value: 0
       }
     }
     tls_context {
@@ -25,7 +25,7 @@ static_resources {
     hosts {
       socket_address {
         address: "google.com"
-        port_value: 443
+        port_value: 0
       }
     }
     tls_context {
@@ -39,7 +39,7 @@ admin {
   address {
     socket_address {
       address: "127.0.0.1"
-      port_value: 9901
+      port_value: 0
     }
   }
 }

--- a/test/server/server_corpus/google_com_proxy.v2.pb_text
+++ b/test/server/server_corpus/google_com_proxy.v2.pb_text
@@ -4,7 +4,7 @@ static_resources {
     address {
       socket_address {
         address: "0.0.0.0"
-        port_value: 10000
+        port_value: 0
       }
     }
     filter_chains {
@@ -130,7 +130,7 @@ static_resources {
     hosts {
       socket_address {
         address: "google.com"
-        port_value: 443
+        port_value: 0
       }
     }
     tls_context {
@@ -144,7 +144,7 @@ admin {
   address {
     socket_address {
       address: "127.0.0.1"
-      port_value: 9901
+      port_value: 0
     }
   }
 }


### PR DESCRIPTION
Avoid binding to fixed ports, hopefully this avoids some of the hangs.

Risk Level: Low
Testing: server_fuzz_test

Signed-off-by: Harvey Tuch <htuch@google.com>