### PR TITLE
Curl buildifier binary instead of installing go 1.8

### DIFF
--- a/ci/build_container/build_container_common.sh
+++ b/ci/build_container/build_container_common.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -e
 
 # buildifier
-export GOPATH=/usr/lib/go
-go get github.com/bazelbuild/buildifier/buildifier
+curl --location --output /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.11.1/buildifier \
+  && echo 'd7d41def74991a34dfd2ac8a73804ff11c514c024a901f64ab07f45a3cf0cfef  /usr/local/bin/buildifier' | sha256sum --check \
+  && chmod +x /usr/local/bin/buildifier
 
 # GCC for everything.
 export CC=gcc


### PR DESCRIPTION
Signed-off-by: James Buckland <jbuckland@google.com>

*title*: Curl buildifier binary instead of installing go 1.8

*Description*:
Addressing  https://github.com/envoyproxy/envoy/issues/3177, we now no longer need to rely on a local go installation, instead curling the binary from github and placing it in `/usr/local/bin`.

*Risk Level*: Medium

*Testing*:
```
jbuckland@ ~/gh/envoy/ci/build_container (buildifier-binary)
$ IMAGE_NAME=experiment CIRCLE_SHA1=foo ./docker_build.sh 
... (many lines later)
 ---> 8505b9571208
Successfully built 8505b9571208
Successfully tagged experiment:foo
```

Fixes issue #3177 
