### PR TITLE
tests: Parameterize StatsConfigTest by IP version

### DIFF
--- a/test/extensions/stats_sinks/statsd/config_test.cc
+++ b/test/extensions/stats_sinks/statsd/config_test.cc
@@ -2,7 +2,6 @@
 #include "envoy/network/address.h"
 #include "envoy/registry/registry.h"
 
-
 #include "common/config/well_known_names.h"
 #include "common/protobuf/utility.h"
 


### PR DESCRIPTION
tests: Parameterize StatsConfigTest by IP version

Created a StatsConfigParameterizedTest to parameterize StatsConfigTests by IP version, instead of being hardcoded to IPv4. Also changed a std::string to ProtobufTypes::String.

Signed-off-by: Kyle Myerson <kmyerson@google.com>