### PR TITLE
Remove dependence on util::Status implementation

### DIFF
--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -215,9 +215,9 @@ TEST(UtilityTest, JsonConvertFail) {
   ProtobufWkt::Duration source_duration;
   source_duration.set_seconds(-281474976710656);
   ProtobufWkt::Duration dest_duration;
-  EXPECT_THROW_WITH_MESSAGE(MessageUtil::jsonConvert(source_duration, dest_duration),
+  EXPECT_THROW_WITH_REGEX(MessageUtil::jsonConvert(source_duration, dest_duration),
                             EnvoyException,
-                            "Unable to convert protobuf message to JSON string: INTERNAL:Duration "
+                            "Unable to convert protobuf message to JSON string.*"
                             "seconds exceeds limit for field:  seconds: -281474976710656\n");
 }
 

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -215,10 +215,9 @@ TEST(UtilityTest, JsonConvertFail) {
   ProtobufWkt::Duration source_duration;
   source_duration.set_seconds(-281474976710656);
   ProtobufWkt::Duration dest_duration;
-  EXPECT_THROW_WITH_REGEX(MessageUtil::jsonConvert(source_duration, dest_duration),
-                            EnvoyException,
-                            "Unable to convert protobuf message to JSON string.*"
-                            "seconds exceeds limit for field:  seconds: -281474976710656\n");
+  EXPECT_THROW_WITH_REGEX(MessageUtil::jsonConvert(source_duration, dest_duration), EnvoyException,
+                          "Unable to convert protobuf message to JSON string.*"
+                          "seconds exceeds limit for field:  seconds: -281474976710656\n");
 }
 
 TEST(DurationUtilTest, OutOfRange) {


### PR DESCRIPTION
test: Remove test's dependence on util::Status implementation.

The test depended on the implementation of util::Status::ToString . This changes the test to use a regex instead.

Signed-off-by: Kyle Myerson <kmyerson@google.com>

