### PR TITLE
Port bind range3

### DIFF
--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -429,10 +429,3 @@ message Cluster {
   // Determines how Envoy selects the protocol used to speak to upstream hosts.
   ClusterProtocolSelection protocol_selection = 26;
 }
-
-// An extensible structure containing the address Envoy should bind to when
-// establishing upstream connections.
-message UpstreamBindConfig {
-  // The address Envoy should bind to when establishing upstream connections.
-  core.Address source_address = 1;
-}

--- a/api/envoy/api/v2/core/address.proto
+++ b/api/envoy/api/v2/core/address.proto
@@ -19,13 +19,14 @@ message Pipe {
   string path = 1 [(validate.rules).string.min_bytes = 1];
 }
 
+enum Protocol {
+  option (gogoproto.goproto_enum_prefix) = false;
+  TCP = 0;
+  // [#not-implemented-hide:]
+  UDP = 1;
+};
+
 message SocketAddress {
-  enum Protocol {
-    option (gogoproto.goproto_enum_prefix) = false;
-    TCP = 0;
-    // [#not-implemented-hide:]
-    UDP = 1;
-  }
   Protocol protocol = 1 [(validate.rules).enum.defined_only = true];
   // The address for this socket. :ref:`Listeners <config_listeners>` will bind
   // to the address or outbound connections will be made. An empty address is
@@ -69,12 +70,6 @@ message PortRange {
 // A set of socket addresses that include the same host address but may have a
 // range of ports.
 message SocketAddressPortRange {
-  enum Protocol {
-    option (gogoproto.goproto_enum_prefix) = false;
-    TCP = 0;
-    // [#not-implemented-hide:]
-    UDP = 1;
-  }
   Protocol protocol = 1 [(validate.rules).enum.defined_only = true];
   // The address for this socket. :ref:`Listeners <config_listeners>` will bind
   // to the address or outbound connections will be made. An empty address is
@@ -111,7 +106,7 @@ message SocketAddressPortRange {
 
 message BindConfig {
   // The address to bind to when creating a socket.
-  SocketAddress source_address = 1
+  SocketAddressPortRange source_address_port_range = 1
       [(validate.rules).message.required = true, (gogoproto.nullable) = false];
 
   // Whether to set the *IP_FREEBIND* option when creating the socket. When this

--- a/api/envoy/api/v2/core/address.proto
+++ b/api/envoy/api/v2/core/address.proto
@@ -58,6 +58,57 @@ message SocketAddress {
   bool ipv4_compat = 6;
 }
 
+// A range of port values
+message PortRange {
+  // First element in the port range.
+  uint32 port_value_start = 1 [(gogoproto.nullable) = false];
+  // Last element in the port range.
+  uint32 port_value_end = 2 [(gogoproto.nullable) = false];
+}
+
+// A set of socket addresses that include the same host address but may have a
+// range of ports.
+message SocketAddressPortRange {
+  enum Protocol {
+    option (gogoproto.goproto_enum_prefix) = false;
+    TCP = 0;
+    // [#not-implemented-hide:]
+    UDP = 1;
+  }
+  Protocol protocol = 1 [(validate.rules).enum.defined_only = true];
+  // The address for this socket. :ref:`Listeners <config_listeners>` will bind
+  // to the address or outbound connections will be made. An empty address is
+  // not allowed, specify ``0.0.0.0`` or ``::`` to bind any. It's still possible to
+  // distinguish on an address via the prefix/suffix matching in
+  // FilterChainMatch after connection. For :ref:`clusters
+  // <config_cluster_manager_cluster>`, an address may be either an IP or
+  // hostname to be resolved via DNS. If it is a hostname, :ref:`resolver_name
+  // <envoy_api_field_core.SocketAddress.resolver_name>` should be set unless default
+  // (i.e. DNS) resolution is expected.
+  string address = 2 [(validate.rules).string.min_bytes = 1];
+  oneof port_specifier {
+    option (validate.required) = true;
+    uint32 port_value = 3;
+    PortRange port_range = 4;
+    // This is only valid if :ref:`resolver_name
+    // <envoy_api_field_core.SocketAddress.resolver_name>` is specified below and the
+    // named resolver is capable of named port resolution.
+    string named_port = 5;
+  }
+
+  // The name of the resolver. This must have been registered with Envoy. If this is
+  // empty, a context dependent default applies. If address is a hostname this
+  // should be set for resolution other than DNS. If the address is a concrete
+  // IP address, no resolution will occur.
+  string resolver_name = 6;
+
+  // When binding to an IPv6 address above, this enables `IPv4 compatibity
+  // <https://tools.ietf.org/html/rfc3493#page-11>`_. Binding to ``::`` will
+  // allow both IPv4 and IPv6 connections, with peer IPv4 addresses mapped into
+  // IPv6 space as ``::FFFF:<IPv4-address>``.
+  bool ipv4_compat = 7;
+}
+
 message BindConfig {
   // The address to bind to when creating a socket.
   SocketAddress source_address = 1

--- a/api/envoy/api/v2/core/address.proto
+++ b/api/envoy/api/v2/core/address.proto
@@ -59,7 +59,7 @@ message SocketAddress {
   bool ipv4_compat = 6;
 }
 
-// A range of port values
+// A range (inclusive) of port values
 message PortRange {
   // First element in the port range.
   uint32 port_value_start = 1 [(gogoproto.nullable) = false];
@@ -81,27 +81,20 @@ message SocketAddressPortRange {
   // <envoy_api_field_core.SocketAddress.resolver_name>` should be set unless default
   // (i.e. DNS) resolution is expected.
   string address = 2 [(validate.rules).string.min_bytes = 1];
-  oneof port_specifier {
-    option (validate.required) = true;
-    uint32 port_value = 3;
-    PortRange port_range = 4;
-    // This is only valid if :ref:`resolver_name
-    // <envoy_api_field_core.SocketAddress.resolver_name>` is specified below and the
-    // named resolver is capable of named port resolution.
-    string named_port = 5;
-  }
+
+  PortRange port_range = 3;
 
   // The name of the resolver. This must have been registered with Envoy. If this is
   // empty, a context dependent default applies. If address is a hostname this
   // should be set for resolution other than DNS. If the address is a concrete
   // IP address, no resolution will occur.
-  string resolver_name = 6;
+  string resolver_name = 4;
 
   // When binding to an IPv6 address above, this enables `IPv4 compatibity
   // <https://tools.ietf.org/html/rfc3493#page-11>`_. Binding to ``::`` will
   // allow both IPv4 and IPv6 connections, with peer IPv4 addresses mapped into
   // IPv6 space as ``::FFFF:<IPv4-address>``.
-  bool ipv4_compat = 7;
+  bool ipv4_compat = 5;
 }
 
 message BindConfig {

--- a/include/envoy/event/BUILD
+++ b/include/envoy/event/BUILD
@@ -28,6 +28,7 @@ envoy_cc_library(
         "//include/envoy/network:listen_socket_interface",
         "//include/envoy/network:listener_interface",
         "//include/envoy/network:transport_socket_interface",
+        "//include/envoy/runtime:runtime_interface",
     ],
 )
 

--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -53,7 +53,8 @@ public:
   /**
    * Create a client connection.
    * @param address supplies the address to connect to.
-   * @param source_address supplies an address to bind to or nullptr if no bind is necessary.
+   * @param source_address_range supplies an address range to bind to or nullptr if no 
+   *        bind is necessary.
    * @param transport_socket supplies a transport socket to be used by the connection.
    * @param options the socket options to be set on the underlying socket before anything is sent
    *        on the socket.
@@ -61,7 +62,7 @@ public:
    */
   virtual Network::ClientConnectionPtr
   createClientConnection(Network::Address::InstanceConstSharedPtr address,
-                         Network::Address::InstanceConstSharedPtr source_address,
+                         Network::Address::InstanceRangeConstSharedPtr source_address_range,
                          Network::TransportSocketPtr&& transport_socket,
                          const Network::ConnectionSocket::OptionsSharedPtr& options,
                          Runtime::RandomGenerator& random) PURE;

--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -16,6 +16,7 @@
 #include "envoy/network/listen_socket.h"
 #include "envoy/network/listener.h"
 #include "envoy/network/transport_socket.h"
+#include "envoy/runtime/runtime.h"
 #include "envoy/stats/stats.h"
 
 namespace Envoy {
@@ -62,7 +63,8 @@ public:
   createClientConnection(Network::Address::InstanceConstSharedPtr address,
                          Network::Address::InstanceConstSharedPtr source_address,
                          Network::TransportSocketPtr&& transport_socket,
-                         const Network::ConnectionSocket::OptionsSharedPtr& options) PURE;
+                         const Network::ConnectionSocket::OptionsSharedPtr& options,
+                         Runtime::RandomGenerator& random) PURE;
 
   /**
    * Create an async DNS resolver. The resolver should only be used on the thread that runs this

--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -58,6 +58,8 @@ public:
    * @param transport_socket supplies a transport socket to be used by the connection.
    * @param options the socket options to be set on the underlying socket before anything is sent
    *        on the socket.
+   * @param random a random generator to be used for aspects of client connection (e.g. binding 
+   *        to a port range) that may need to be randomized. 
    * @return Network::ClientConnectionPtr a client connection that is owned by the caller.
    */
   virtual Network::ClientConnectionPtr

--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -53,13 +53,13 @@ public:
   /**
    * Create a client connection.
    * @param address supplies the address to connect to.
-   * @param source_address_range supplies an address range to bind to or nullptr if no 
+   * @param source_address_range supplies an address range to bind to or nullptr if no
    *        bind is necessary.
    * @param transport_socket supplies a transport socket to be used by the connection.
    * @param options the socket options to be set on the underlying socket before anything is sent
    *        on the socket.
-   * @param random a random generator to be used for aspects of client connection (e.g. binding 
-   *        to a port range) that may need to be randomized. 
+   * @param random a random generator to be used for aspects of client connection (e.g. binding
+   *        to a port range) that may need to be randomized.
    * @return Network::ClientConnectionPtr a client connection that is owned by the caller.
    */
   virtual Network::ClientConnectionPtr

--- a/include/envoy/network/BUILD
+++ b/include/envoy/network/BUILD
@@ -11,6 +11,9 @@ envoy_package()
 envoy_cc_library(
     name = "address_interface",
     hdrs = ["address.h"],
+    deps = [
+        "//include/envoy/runtime:runtime_interface",
+    ]
 )
 
 envoy_cc_library(

--- a/include/envoy/network/BUILD
+++ b/include/envoy/network/BUILD
@@ -13,7 +13,7 @@ envoy_cc_library(
     hdrs = ["address.h"],
     deps = [
         "//include/envoy/runtime:runtime_interface",
-    ]
+    ],
 )
 
 envoy_cc_library(

--- a/include/envoy/network/address.h
+++ b/include/envoy/network/address.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "envoy/common/pure.h"
+#include "envoy/runtime/runtime.h"
 
 #include "absl/numeric/int128.h"
 
@@ -190,12 +191,13 @@ public:
   virtual const std::string& logicalName() const PURE;
 
   /**
-   * Bind a socket to this address. The socket should have been created with a call to socket() on
-   * an Instance of the same address family.
+   * Bind a socket to this address range. The socket should have been created with a call to 
+   * socket() on an Instance of the same address family.
    * @param fd supplies the platform socket handle.
+   * @param random may be used to randomize the port in the port range.
    * @return the platform error code.
    */
-  virtual int bind(int fd) const PURE;
+  virtual int bind(int fd, Runtime::RandomGenerator& random) const PURE;
 
   /**
    * @return the IP address information IFF type() == Type::Ip, otherwise nullptr.

--- a/include/envoy/network/address.h
+++ b/include/envoy/network/address.h
@@ -158,6 +158,80 @@ public:
 
 typedef std::shared_ptr<const Instance> InstanceConstSharedPtr;
 
+/**
+ * Interface for all network addresses that may include ranges of ports.  
+ */
+class InstanceRange {
+public:
+  virtual ~InstanceRange() {}
+
+  virtual bool operator==(const InstanceRange& rhs) const PURE;
+  bool operator!=(const InstanceRange& rhs) const { return !operator==(rhs); }
+
+  /**
+   * @return a human readable string for the address that represents the
+   * physical/resolved address.
+   *
+   * This string will be in the following format:
+   * For IPv4 addresses: "1.2.3.4:80"
+   * For IPv6 addresses: "[1234:5678::9]:443"
+   * For pipe addresses: "/foo"
+   */
+  virtual const std::string& asString() const PURE;
+
+  /**
+   * @return a human readable string for the address that represents the
+   * logical/unresolved name.
+   *
+   * This string has a source-dependent format and should be obviously 
+   * convertable to a set of names for Address::instances that can be resolved by 
+   * a Network::Address::Resolver.
+   */
+  virtual const std::string& logicalName() const PURE;
+
+  /**
+   * Bind a socket to this address. The socket should have been created with a call to socket() on
+   * an Instance of the same address family.
+   * @param fd supplies the platform socket handle.
+   * @return the platform error code.
+   */
+  virtual int bind(int fd) const PURE;
+
+  /**
+   * @return the IP address information IFF type() == Type::Ip, otherwise nullptr.
+   * ip()->port() will be invalid; use starting_port() and ending_port() instead.
+   */
+  virtual const Ip* ip() const PURE;
+
+  /**
+   * @return the starting port of the port range (inclusive).
+   * If this is a degenerate pipe InstanceRange (i.e. an address instance referring to 
+   * a single pipe) this value will be 0.
+   */
+  virtual uint32_t starting_port() const PURE;
+
+  /**
+   * @return the ending port of the port range (inclusive).
+   * If this is a degenerate pipe InstanceRange (i.e. an address instance referring to 
+   * a single pipe) this value will be 0.
+   */
+  virtual uint32_t ending_port() const PURE;
+
+  /**
+   * Create a socket for this address.
+   * @param type supplies the socket type to create.
+   * @return the platform error code.
+   */
+  virtual int socket(SocketType type) const PURE;
+
+  /**
+   * @return the type of address.
+   */
+  virtual Type type() const PURE;
+};
+
+typedef std::shared_ptr<const InstanceRange> InstanceRangeConstSharedPtr;
+
 } // namespace Address
 } // namespace Network
 } // namespace Envoy

--- a/include/envoy/network/address.h
+++ b/include/envoy/network/address.h
@@ -160,7 +160,7 @@ public:
 typedef std::shared_ptr<const Instance> InstanceConstSharedPtr;
 
 /**
- * Interface for all network addresses that may include ranges of ports.  
+ * Interface for all network addresses that may include ranges of ports.
  */
 class InstanceRange {
 public:
@@ -184,14 +184,14 @@ public:
    * @return a human readable string for the address that represents the
    * logical/unresolved name.
    *
-   * This string has a source-dependent format and should be obviously 
-   * convertable to a set of names for Address::instances that can be resolved by 
+   * This string has a source-dependent format and should be obviously
+   * convertable to a set of names for Address::instances that can be resolved by
    * a Network::Address::Resolver.
    */
   virtual const std::string& logicalName() const PURE;
 
   /**
-   * Bind a socket to this address range. The socket should have been created with a call to 
+   * Bind a socket to this address range. The socket should have been created with a call to
    * socket() on an Instance of the same address family.
    * @param fd supplies the platform socket handle.
    * @param random may be used to randomize the port in the port range.
@@ -207,14 +207,14 @@ public:
 
   /**
    * @return the starting port of the port range (inclusive).
-   * If this is a degenerate pipe InstanceRange (i.e. an address instance referring to 
+   * If this is a degenerate pipe InstanceRange (i.e. an address instance referring to
    * a single pipe) this value will be 0.
    */
   virtual uint32_t starting_port() const PURE;
 
   /**
    * @return the ending port of the port range (inclusive).
-   * If this is a degenerate pipe InstanceRange (i.e. an address instance referring to 
+   * If this is a degenerate pipe InstanceRange (i.e. an address instance referring to
    * a single pipe) this value will be 0.
    */
   virtual uint32_t ending_port() const PURE;

--- a/include/envoy/network/resolver.h
+++ b/include/envoy/network/resolver.h
@@ -29,6 +29,14 @@ public:
   resolve(const envoy::api::v2::core::SocketAddress& socket_address) PURE;
 
   /**
+   * Resolve a custom address string and port range to an Address::InstanceRange.
+   * @param socket_address_port_range supplies the socket address port range to resolve.
+   * @return InstanceRangeConstSharedPtr appropriate Address::InstanceRange.
+   */
+  virtual InstanceRangeConstSharedPtr
+  resolve(const envoy::api::v2::core::SocketAddressPortRange& socket_address) PURE;
+
+  /**
    * @return std::string the identifying name for a particular implementation of
    * a resolver.
    */

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -197,7 +197,7 @@ public:
    * This method returns a RandomGenerator that can be used if needed during cluster 
    * configuration and connection.
    */
-  virtual Envoy::Runtime::RandomGenerator& randomGenerator() PURE;
+  virtual Runtime::RandomGenerator& randomGenerator() PURE;
 };
 
 typedef std::unique_ptr<ClusterManager> ClusterManagerPtr;

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -194,7 +194,7 @@ public:
   addThreadLocalClusterUpdateCallbacks(ClusterUpdateCallbacks& callbacks) PURE;
 
   /**
-   * This method returns a RandomGenerator that can be used if needed during cluster 
+   * This method returns a RandomGenerator that can be used if needed during cluster
    * configuration and connection.
    */
   virtual Runtime::RandomGenerator& randomGenerator() PURE;

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -192,6 +192,12 @@ public:
    */
   virtual ClusterUpdateCallbacksHandlePtr
   addThreadLocalClusterUpdateCallbacks(ClusterUpdateCallbacks& callbacks) PURE;
+
+  /**
+   * This method returns a RandomGenerator that can be used if needed during cluster 
+   * configuration and connection.
+   */
+  virtual Envoy::Runtime::RandomGenerator& randomGenerator() PURE;
 };
 
 typedef std::unique_ptr<ClusterManager> ClusterManagerPtr;

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -506,11 +506,11 @@ public:
   virtual ClusterLoadReportStats& loadReportStats() const PURE;
 
   /**
-   * Returns an optional source address for upstream connections to bind to.
+   * Returns an optional source address range for upstream connections to bind to.
    *
-   * @return a source address to bind to or nullptr if no bind need occur.
+   * @return a source address range to bind to or nullptr if no bind need occur.
    */
-  virtual const Network::Address::InstanceConstSharedPtr& sourceAddress() const PURE;
+  virtual const Network::Address::InstanceRangeConstSharedPtr& sourceAddressRange() const PURE;
 
   /**
    * @return the configuration for load balancer subsets.

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -85,7 +85,7 @@ DispatcherImpl::createClientConnection(Network::Address::InstanceConstSharedPtr 
                                        Network::Address::InstanceConstSharedPtr source_address,
                                        Network::TransportSocketPtr&& transport_socket,
                                        const Network::ConnectionSocket::OptionsSharedPtr& options,
-                                       Runtime::RandomGenerator& random) {
+                                       Runtime::RandomGenerator&) {
   ASSERT(isThreadSafe());
   return std::make_unique<Network::ClientConnectionImpl>(*this, address, source_address,
                                                          std::move(transport_socket), options);

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -84,7 +84,8 @@ Network::ClientConnectionPtr
 DispatcherImpl::createClientConnection(Network::Address::InstanceConstSharedPtr address,
                                        Network::Address::InstanceConstSharedPtr source_address,
                                        Network::TransportSocketPtr&& transport_socket,
-                                       const Network::ConnectionSocket::OptionsSharedPtr& options) {
+                                       const Network::ConnectionSocket::OptionsSharedPtr& options,
+                                       Runtime::RandomGenerator& random) {
   ASSERT(isThreadSafe());
   return std::make_unique<Network::ClientConnectionImpl>(*this, address, source_address,
                                                          std::move(transport_socket), options);

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -85,10 +85,11 @@ DispatcherImpl::createClientConnection(Network::Address::InstanceConstSharedPtr 
                                        Network::Address::InstanceConstSharedPtr source_address,
                                        Network::TransportSocketPtr&& transport_socket,
                                        const Network::ConnectionSocket::OptionsSharedPtr& options,
-                                       Runtime::RandomGenerator&) {
+                                       Runtime::RandomGenerator& random) {
   ASSERT(isThreadSafe());
   return std::make_unique<Network::ClientConnectionImpl>(*this, address, source_address,
-                                                         std::move(transport_socket), options);
+                                                         std::move(transport_socket), options,
+                                                         random);
 }
 
 Network::DnsResolverSharedPtr DispatcherImpl::createDnsResolver(

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -80,17 +80,14 @@ DispatcherImpl::createServerConnection(Network::ConnectionSocketPtr&& socket,
                                                    std::move(transport_socket), true);
 }
 
-Network::ClientConnectionPtr
-DispatcherImpl::createClientConnection(
+Network::ClientConnectionPtr DispatcherImpl::createClientConnection(
     Network::Address::InstanceConstSharedPtr address,
     Network::Address::InstanceRangeConstSharedPtr source_address_range,
     Network::TransportSocketPtr&& transport_socket,
-    const Network::ConnectionSocket::OptionsSharedPtr& options,
-    Runtime::RandomGenerator& random) {
+    const Network::ConnectionSocket::OptionsSharedPtr& options, Runtime::RandomGenerator& random) {
   ASSERT(isThreadSafe());
-  return std::make_unique<Network::ClientConnectionImpl>(*this, address, source_address_range,
-                                                         std::move(transport_socket), options,
-                                                         random);
+  return std::make_unique<Network::ClientConnectionImpl>(
+      *this, address, source_address_range, std::move(transport_socket), options, random);
 }
 
 Network::DnsResolverSharedPtr DispatcherImpl::createDnsResolver(

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -81,13 +81,14 @@ DispatcherImpl::createServerConnection(Network::ConnectionSocketPtr&& socket,
 }
 
 Network::ClientConnectionPtr
-DispatcherImpl::createClientConnection(Network::Address::InstanceConstSharedPtr address,
-                                       Network::Address::InstanceConstSharedPtr source_address,
-                                       Network::TransportSocketPtr&& transport_socket,
-                                       const Network::ConnectionSocket::OptionsSharedPtr& options,
-                                       Runtime::RandomGenerator& random) {
+DispatcherImpl::createClientConnection(
+    Network::Address::InstanceConstSharedPtr address,
+    Network::Address::InstanceRangeConstSharedPtr source_address_range,
+    Network::TransportSocketPtr&& transport_socket,
+    const Network::ConnectionSocket::OptionsSharedPtr& options,
+    Runtime::RandomGenerator& random) {
   ASSERT(isThreadSafe());
-  return std::make_unique<Network::ClientConnectionImpl>(*this, address, source_address,
+  return std::make_unique<Network::ClientConnectionImpl>(*this, address, source_address_range,
                                                          std::move(transport_socket), options,
                                                          random);
 }

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -40,7 +40,8 @@ public:
   createClientConnection(Network::Address::InstanceConstSharedPtr address,
                          Network::Address::InstanceConstSharedPtr source_address,
                          Network::TransportSocketPtr&& transport_socket,
-                         const Network::ConnectionSocket::OptionsSharedPtr& options) override;
+                         const Network::ConnectionSocket::OptionsSharedPtr& options,
+                         Runtime::RandomGenerator& random) override;
   Network::DnsResolverSharedPtr createDnsResolver(
       const std::vector<Network::Address::InstanceConstSharedPtr>& resolvers) override;
   FileEventPtr createFileEvent(int fd, FileReadyCb cb, FileTriggerType trigger,

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -38,7 +38,7 @@ public:
                          Network::TransportSocketPtr&& transport_socket) override;
   Network::ClientConnectionPtr
   createClientConnection(Network::Address::InstanceConstSharedPtr address,
-                         Network::Address::InstanceRangeConstSharedPtr source_address,
+                         Network::Address::InstanceRangeConstSharedPtr source_address_range,
                          Network::TransportSocketPtr&& transport_socket,
                          const Network::ConnectionSocket::OptionsSharedPtr& options,
                          Runtime::RandomGenerator& random) override;

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -38,7 +38,7 @@ public:
                          Network::TransportSocketPtr&& transport_socket) override;
   Network::ClientConnectionPtr
   createClientConnection(Network::Address::InstanceConstSharedPtr address,
-                         Network::Address::InstanceConstSharedPtr source_address,
+                         Network::Address::InstanceRangeConstSharedPtr source_address,
                          Network::TransportSocketPtr&& transport_socket,
                          const Network::ConnectionSocket::OptionsSharedPtr& options,
                          Runtime::RandomGenerator& random) override;

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -16,7 +16,7 @@ envoy_cc_library(
         "//include/envoy/network:address_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:utility_lib",
-	"//source/common/runtime:runtime_lib",
+        "//source/common/runtime:runtime_lib",
     ],
 )
 

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -57,6 +57,7 @@ envoy_cc_library(
         "//source/common/common:logger_lib",
         "//source/common/event:libevent_lib",
         "//source/common/network:listen_socket_lib",
+        "//source/common/runtime:runtime_lib",
         "//source/common/ssl:ssl_socket_lib",
     ],
 )

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
         "//include/envoy/network:address_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:utility_lib",
+	"//source/common/runtime:runtime_lib",
     ],
 )
 

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -14,6 +14,7 @@
 #include "common/common/assert.h"
 #include "common/common/fmt.h"
 #include "common/common/utility.h"
+#include "common/runtime/runtime_impl.h"
 
 namespace Envoy {
 namespace Network {
@@ -356,6 +357,15 @@ Ipv4InstanceRange::Ipv4InstanceRange(uint32_t starting_port, uint32_t ending_por
 }
 
 int Ipv4InstanceRange::bind(int fd) const {
+  RandomGeneratorImpl generator;// TODO(XXX): Nope, doesn't allow for injection.
+  std::set<uint32_t> ports_tried;
+  while (ports_tried.size() < ending_port_ - starting_port_ + 1) {
+    // The offset of the next port to try, counting only the untried ports.
+    int port_index =
+        generator.random() % (ending_port_ - starting_port_ + 1 - ports_tried.size());
+    XXX;
+  }
+
   // Implementing via linear search from the bottom of the range.
   // TODO(rdsmith): Make this random when you have access to a RandomGenerator.
   for (uint32_t port_to_try = starting_port_; port_to_try <= ending_port_; ++port_to_try) {

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -357,15 +357,6 @@ Ipv4InstanceRange::Ipv4InstanceRange(uint32_t starting_port, uint32_t ending_por
 }
 
 int Ipv4InstanceRange::bind(int fd) const {
-  RandomGeneratorImpl generator;// TODO(XXX): Nope, doesn't allow for injection.
-  std::set<uint32_t> ports_tried;
-  while (ports_tried.size() < ending_port_ - starting_port_ + 1) {
-    // The offset of the next port to try, counting only the untried ports.
-    int port_index =
-        generator.random() % (ending_port_ - starting_port_ + 1 - ports_tried.size());
-    XXX;
-  }
-
   // Implementing via linear search from the bottom of the range.
   // TODO(rdsmith): Make this random when you have access to a RandomGenerator.
   for (uint32_t port_to_try = starting_port_; port_to_try <= ending_port_; ++port_to_try) {

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -33,16 +33,15 @@ namespace {
 //
 // Note that choosing with replacement is only a good strategy for large port ranges;
 // if InstanceRanges with only a few ports in them are used, this file should
-// either choose without replacement or search linearly. 
+// either choose without replacement or search linearly.
 const int kBindingRangeNumberOfTries = 4;
 
-// Random port to try for port ranges.  
+// Random port to try for port ranges.
 uint32_t portToTry(uint32_t starting_port, uint32_t ending_port, Runtime::RandomGenerator& random) {
   double unitary_scaled_random_value =
       (static_cast<double>(random.random()) / std::numeric_limits<uint64_t>::max());
-  uint32_t port_to_try =
-      starting_port + static_cast<uint32_t>((ending_port + 1 - starting_port) *
-                                            unitary_scaled_random_value);
+  uint32_t port_to_try = starting_port + static_cast<uint32_t>((ending_port + 1 - starting_port) *
+                                                               unitary_scaled_random_value);
   // port_to_try has prob(0) of being ending_port_ + 1, but prob(0) != never.
   if (port_to_try == ending_port + 1) {
     port_to_try = ending_port;
@@ -87,7 +86,7 @@ int socketFromSocketType(SocketType socketType, Type addressType, IpVersion ipVe
   return fd;
 }
 
-}  // namespace
+} // namespace
 
 Address::InstanceConstSharedPtr addressFromSockAddr(const sockaddr_storage& ss, socklen_t ss_len,
                                                     bool v6only) {
@@ -338,10 +337,8 @@ int PipeInstance::socket(SocketType type) const {
   return socketFromSocketType(type, Type::Pipe, static_cast<IpVersion>(0));
 }
 
-Ipv4InstanceRange::Ipv4InstanceRange(
-    const std::string& address,
-    uint32_t starting_port,
-    uint32_t ending_port) {
+Ipv4InstanceRange::Ipv4InstanceRange(const std::string& address, uint32_t starting_port,
+                                     uint32_t ending_port) {
   memset(&ip_.ipv4_.address_, 0, sizeof(ip_.ipv4_.address_));
   ip_.ipv4_.address_.sin_family = AF_INET;
   int rc = inet_pton(AF_INET, address.c_str(), &ip_.ipv4_.address_.sin_addr);
@@ -356,8 +353,8 @@ Ipv4InstanceRange::Ipv4InstanceRange(
     throw EnvoyException(fmt::format("invalid ending ip port '{}'", ending_port));
   }
   if (ending_port < starting_port) {
-    throw EnvoyException(fmt::format("ending ip port '{}' < starting ip port '{}'",
-                                     ending_port, starting_port));
+    throw EnvoyException(
+        fmt::format("ending ip port '{}' < starting ip port '{}'", ending_port, starting_port));
   }
   starting_port_ = starting_port;
   ending_port_ = ending_port;
@@ -378,8 +375,8 @@ Ipv4InstanceRange::Ipv4InstanceRange(uint32_t starting_port, uint32_t ending_por
     throw EnvoyException(fmt::format("invalid ending ip port '{}'", ending_port));
   }
   if (ending_port < starting_port) {
-    throw EnvoyException(fmt::format("ending ip port '{}' < starting ip port '{}'",
-                                     ending_port, starting_port));
+    throw EnvoyException(
+        fmt::format("ending ip port '{}' < starting ip port '{}'", ending_port, starting_port));
   }
   friendly_name_ = fmt::format("0.0.0.0:{}-{}", starting_port, ending_port);
 }
@@ -390,7 +387,8 @@ int Ipv4InstanceRange::bind(int fd, Runtime::RandomGenerator& random) const {
     sockaddr_in socket_address(ip_.ipv4_.address_);
     socket_address.sin_port =
         static_cast<in_port_t>(portToTry(starting_port_, ending_port_, random));
-    int ret = ::bind(fd, reinterpret_cast<const sockaddr*>(&socket_address), sizeof(socket_address));
+    int ret =
+        ::bind(fd, reinterpret_cast<const sockaddr*>(&socket_address), sizeof(socket_address));
     if (ret != EADDRINUSE)
       return ret;
   }
@@ -401,10 +399,8 @@ int Ipv4InstanceRange::socket(SocketType type) const {
   return socketFromSocketType(type, Type::Ip, IpVersion::v4);
 }
 
-Ipv6InstanceRange::Ipv6InstanceRange(
-    const std::string& address,
-    uint32_t starting_port,
-    uint32_t ending_port) {
+Ipv6InstanceRange::Ipv6InstanceRange(const std::string& address, uint32_t starting_port,
+                                     uint32_t ending_port) {
   memset(&ip_.ipv6_.address_, 0, sizeof(ip_.ipv6_.address_));
   ip_.ipv6_.address_.sin6_family = AF_INET6;
   if (!address.empty()) {
@@ -422,8 +418,8 @@ Ipv6InstanceRange::Ipv6InstanceRange(
     throw EnvoyException(fmt::format("invalid ending ip port '{}'", ending_port));
   }
   if (ending_port < starting_port) {
-    throw EnvoyException(fmt::format("ending ip port '{}' < starting ip port '{}'",
-                                     ending_port, starting_port));
+    throw EnvoyException(
+        fmt::format("ending ip port '{}' < starting ip port '{}'", ending_port, starting_port));
   }
   starting_port_ = starting_port;
   ending_port_ = ending_port;
@@ -441,7 +437,8 @@ int Ipv6InstanceRange::bind(int fd, Runtime::RandomGenerator&) const {
   for (uint32_t port_to_try = starting_port_; port_to_try <= ending_port_; ++port_to_try) {
     sockaddr_in6 socket_address(ip_.ipv6_.address_);
     socket_address.sin6_port = static_cast<in_port_t>(port_to_try);
-    int ret = ::bind(fd, reinterpret_cast<const sockaddr*>(&socket_address), sizeof(socket_address));
+    int ret =
+        ::bind(fd, reinterpret_cast<const sockaddr*>(&socket_address), sizeof(socket_address));
     if (ret != EADDRINUSE)
       return ret;
   }

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -356,7 +356,7 @@ Ipv4InstanceRange::Ipv4InstanceRange(uint32_t starting_port, uint32_t ending_por
   friendly_name_ = fmt::format("0.0.0.0:{}-{}", starting_port, ending_port);
 }
 
-int Ipv4InstanceRange::bind(int fd) const {
+int Ipv4InstanceRange::bind(int fd, Runtime::RandomGenerator&) const {
   // Implementing via linear search from the bottom of the range.
   // TODO(rdsmith): Make this random when you have access to a RandomGenerator.
   for (uint32_t port_to_try = starting_port_; port_to_try <= ending_port_; ++port_to_try) {
@@ -407,7 +407,7 @@ Ipv6InstanceRange::Ipv6InstanceRange(
 Ipv6InstanceRange::Ipv6InstanceRange(uint32_t starting_port, uint32_t ending_port)
     : Ipv6InstanceRange("", starting_port, ending_port) {}
 
-int Ipv6InstanceRange::bind(int fd) const {
+int Ipv6InstanceRange::bind(int fd, Runtime::RandomGenerator&) const {
   // Implementing via linear search from the bottom of the range.
   // TODO(rdsmith): Make this random when you have access to a RandomGenerator.
   for (uint32_t port_to_try = starting_port_; port_to_try <= ending_port_; ++port_to_try) {

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -277,16 +277,13 @@ class Ipv6InstanceRange : public InstanceRange {
   virtual Type type() const { return Type::Ip; }
 
  private:
-  const std::string friendly_name_;
+  std::string friendly_name_;
   Ipv6Instance::IpHelper ip_;           // Valid except for port()
   uint32_t starting_port_;
   uint32_t ending_port_;
 };
 
 #if 0
-class Ipv6InstanceRange : public InstanceRange {
-};
-
 class PipeInstanceRange : public InstanceRange {
 };
 #endif

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -298,7 +298,9 @@ class PipeInstanceRange : public InstanceRange {
   explicit PipeInstanceRange(const std::string& pipe_path) : instance_(pipe_path) {}
 
   // InstanceRange
-  bool operator==(const PipeInstanceRange& rhs) const override { return instance_ == rhs.instance_; }
+  bool operator==(const InstanceRange& rhs) const override {
+    return asString() == rhs.asString();
+  }
   const std::string& asString() const override { return instance_.asString(); }
   const std::string& logicalName() const override {return instance_.logicalName(); }
   int bind(int fd) const override { return instance_.bind(fd); }

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -224,6 +224,7 @@ private:
 // Implementations of InstanceRange
 
 class Ipv4InstanceRange : public InstanceRange {
+ public:
   /**
    * Construct from a string IPv4 address such as "1.2.3.4" as well as a starting and ending port.
    */
@@ -236,15 +237,15 @@ class Ipv4InstanceRange : public InstanceRange {
   Ipv4InstanceRange(uint32_t starting_port, uint32_t ending_port);
 
   // Network::Address::InstanceRange
-  virtual bool operator==(const InstanceRange& rhs) const {
+  virtual bool operator==(const InstanceRange& rhs) const override {
     return asString() == rhs.asString();
   }
-  virtual const std::string& asString() const { return friendly_name_; }
-  virtual const std::string& logicalName() const { return friendly_name_; }
-  virtual int bind(int fd) const;
-  virtual const Ip* ip() const { return &ip_; }
-  virtual int socket(SocketType type) const;
-  virtual Type type() const { return Type::Ip; }
+  virtual const std::string& asString() const override { return friendly_name_; }
+  virtual const std::string& logicalName() const override { return friendly_name_; }
+  virtual int bind(int fd) const override;
+  virtual const Ip* ip() const override { return &ip_; }
+  virtual int socket(SocketType type) const override;
+  virtual Type type() const override { return Type::Ip; }
 
  private:
   std::string friendly_name_;
@@ -254,6 +255,7 @@ class Ipv4InstanceRange : public InstanceRange {
 };
 
 class Ipv6InstanceRange : public InstanceRange {
+ public:
   /**
    * Construct from a string IPv4 address such as "1.2.3.4" as well as a starting and ending port.
    */
@@ -266,15 +268,15 @@ class Ipv6InstanceRange : public InstanceRange {
   Ipv6InstanceRange(uint32_t starting_port, uint32_t ending_port);
 
   // Network::Address::InstanceRange
-  virtual bool operator==(const InstanceRange& rhs) const {
+  bool operator==(const InstanceRange& rhs) const override {
     return asString() == rhs.asString();
   }
-  virtual const std::string& asString() const { return friendly_name_; }
-  virtual const std::string& logicalName() const { return friendly_name_; }
-  virtual int bind(int fd) const;
-  virtual const Ip* ip() const { return &ip_; }
-  virtual int socket(SocketType type) const;
-  virtual Type type() const { return Type::Ip; }
+  const std::string& asString() const override { return friendly_name_; }
+  const std::string& logicalName() const override { return friendly_name_; }
+  int bind(int fd) const override;
+  const Ip* ip() const override { return &ip_; }
+  int socket(SocketType type) const override;
+  Type type() const override { return Type::Ip; }
 
  private:
   std::string friendly_name_;
@@ -283,10 +285,32 @@ class Ipv6InstanceRange : public InstanceRange {
   uint32_t ending_port_;
 };
 
-#if 0
 class PipeInstanceRange : public InstanceRange {
+ public:
+  /**
+   * Construct from an existing unix address.
+   */
+  explicit PipeInstanceRange(const sockaddr_un* address, socklen_t ss_len) : instance_(address, ss_len) {}
+
+  /**
+   * Construct from a string pipe path.
+   */
+  explicit PipeInstanceRange(const std::string& pipe_path) : instance_(pipe_path) {}
+
+  // InstanceRange
+  bool operator==(const PipeInstanceRange& rhs) const override { return instance_ == rhs.instance_; }
+  const std::string& asString() const override { return instance_.asString(); }
+  const std::string& logicalName() const override {return instance_.logicalName(); }
+  int bind(int fd) const override { return instance_.bind(fd); }
+  const Ip* ip() const override { return nullptr; }
+  uint32_t starting_port() const override { return 0; }
+  uint32_t ending_port() const override { return 0; }
+  int socket(SocketType type) const override { return instance_.socket(type); }
+  Type type() const override { return Type::Pipe; }
+
+ private:
+  PipeInstance instance_;
 };
-#endif
 
 } // namespace Address
 } // namespace Network

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -237,15 +237,17 @@ class Ipv4InstanceRange : public InstanceRange {
   Ipv4InstanceRange(uint32_t starting_port, uint32_t ending_port);
 
   // Network::Address::InstanceRange
-  virtual bool operator==(const InstanceRange& rhs) const override {
+  bool operator==(const InstanceRange& rhs) const override {
     return asString() == rhs.asString();
   }
-  virtual const std::string& asString() const override { return friendly_name_; }
-  virtual const std::string& logicalName() const override { return friendly_name_; }
-  virtual int bind(int fd, Runtime::RandomGenerator& random) const override;
-  virtual const Ip* ip() const override { return &ip_; }
-  virtual int socket(SocketType type) const override;
-  virtual Type type() const override { return Type::Ip; }
+  const std::string& asString() const override { return friendly_name_; }
+  const std::string& logicalName() const override { return friendly_name_; }
+  int bind(int fd, Runtime::RandomGenerator& random) const override;
+  const Ip* ip() const override { return &ip_; }
+  uint32_t starting_port() const override { return starting_port_; }
+  uint32_t ending_port() const override {return ending_port_; }
+  int socket(SocketType type) const override;
+  Type type() const override { return Type::Ip; }
 
  private:
   std::string friendly_name_;
@@ -275,6 +277,8 @@ class Ipv6InstanceRange : public InstanceRange {
   const std::string& logicalName() const override { return friendly_name_; }
   int bind(int fd, Runtime::RandomGenerator& random) const override;
   const Ip* ip() const override { return &ip_; }
+  uint32_t starting_port() const override { return starting_port_; }
+  uint32_t ending_port() const override {return ending_port_; }
   int socket(SocketType type) const override;
   Type type() const override { return Type::Ip; }
 

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -96,7 +96,7 @@ public:
   int socket(SocketType type) const override;
 
 private:
-  friend class Ipv4InstanceRange;       // For access to helper classes.
+  friend class Ipv4InstanceRange; // For access to helper classes.
 
   struct Ipv4Helper : public Ipv4 {
     uint32_t address() const override { return address_.sin_addr.s_addr; }
@@ -157,7 +157,7 @@ public:
   int socket(SocketType type) const override;
 
 private:
-  friend class Ipv6InstanceRange;       // For access to help structures. 
+  friend class Ipv6InstanceRange; // For access to help structures.
 
   struct Ipv6Helper : public Ipv6 {
     Ipv6Helper() { memset(&address_, 0, sizeof(address_)); }
@@ -224,77 +224,74 @@ private:
 // Implementations of InstanceRange
 
 class Ipv4InstanceRange : public InstanceRange {
- public:
+public:
   /**
    * Construct from a string IPv4 address such as "1.2.3.4" as well as a starting and ending port.
    */
   Ipv4InstanceRange(const std::string& address, uint32_t starting_port, uint32_t ending_port);
 
   /**
-   * Construct from a starting and ending port.  The IPv4 address will be set to "any" and is 
+   * Construct from a starting and ending port. The IPv4 address will be set to "any" and is
    * suitable for binding a port to any available address.
    */
   Ipv4InstanceRange(uint32_t starting_port, uint32_t ending_port);
 
   // Network::Address::InstanceRange
-  bool operator==(const InstanceRange& rhs) const override {
-    return asString() == rhs.asString();
-  }
+  bool operator==(const InstanceRange& rhs) const override { return asString() == rhs.asString(); }
   const std::string& asString() const override { return friendly_name_; }
   const std::string& logicalName() const override { return friendly_name_; }
   int bind(int fd, Runtime::RandomGenerator& random) const override;
   const Ip* ip() const override { return &ip_; }
   uint32_t starting_port() const override { return starting_port_; }
-  uint32_t ending_port() const override {return ending_port_; }
+  uint32_t ending_port() const override { return ending_port_; }
   int socket(SocketType type) const override;
   Type type() const override { return Type::Ip; }
 
- private:
+private:
   std::string friendly_name_;
-  Ipv4Instance::IpHelper ip_;           // Valid except for port()
+  Ipv4Instance::IpHelper ip_; // Valid except for port()
   uint32_t starting_port_;
   uint32_t ending_port_;
 };
 
 class Ipv6InstanceRange : public InstanceRange {
- public:
+public:
   /**
    * Construct from a string IPv4 address such as "1.2.3.4" as well as a starting and ending port.
    */
   Ipv6InstanceRange(const std::string& address, uint32_t starting_port, uint32_t ending_port);
 
   /**
-   * Construct from a starting and ending port.  The IPv4 address will be set to "any" and is 
+   * Construct from a starting and ending port. The IPv4 address will be set to "any" and is
    * suitable for binding a port to any available address.
    */
   Ipv6InstanceRange(uint32_t starting_port, uint32_t ending_port);
 
   // Network::Address::InstanceRange
-  bool operator==(const InstanceRange& rhs) const override {
-    return asString() == rhs.asString();
-  }
+  bool operator==(const InstanceRange& rhs) const override { return asString() == rhs.asString(); }
   const std::string& asString() const override { return friendly_name_; }
   const std::string& logicalName() const override { return friendly_name_; }
   int bind(int fd, Runtime::RandomGenerator& random) const override;
   const Ip* ip() const override { return &ip_; }
   uint32_t starting_port() const override { return starting_port_; }
-  uint32_t ending_port() const override {return ending_port_; }
+  uint32_t ending_port() const override { return ending_port_; }
   int socket(SocketType type) const override;
   Type type() const override { return Type::Ip; }
 
- private:
+private:
   std::string friendly_name_;
-  Ipv6Instance::IpHelper ip_;           // Valid except for port()
+  Ipv6Instance::IpHelper ip_; // Valid except for port()
   uint32_t starting_port_;
   uint32_t ending_port_;
 };
 
 class PipeInstanceRange : public InstanceRange {
- public:
+public:
   /**
    * Construct from an existing unix address.
    */
-  explicit PipeInstanceRange(const sockaddr_un* address, socklen_t ss_len) : instance_(address, ss_len) {}
+  explicit PipeInstanceRange(const sockaddr_un* address, socklen_t ss_len)
+      : instance_(address, ss_len) {}
 
   /**
    * Construct from a string pipe path.
@@ -302,11 +299,9 @@ class PipeInstanceRange : public InstanceRange {
   explicit PipeInstanceRange(const std::string& pipe_path) : instance_(pipe_path) {}
 
   // InstanceRange
-  bool operator==(const InstanceRange& rhs) const override {
-    return asString() == rhs.asString();
-  }
+  bool operator==(const InstanceRange& rhs) const override { return asString() == rhs.asString(); }
   const std::string& asString() const override { return instance_.asString(); }
-  const std::string& logicalName() const override {return instance_.logicalName(); }
+  const std::string& logicalName() const override { return instance_.logicalName(); }
   int bind(int fd, Runtime::RandomGenerator&) const override { return instance_.bind(fd); }
   const Ip* ip() const override { return nullptr; }
   uint32_t starting_port() const override { return 0; }
@@ -314,7 +309,7 @@ class PipeInstanceRange : public InstanceRange {
   int socket(SocketType type) const override { return instance_.socket(type); }
   Type type() const override { return Type::Pipe; }
 
- private:
+private:
   PipeInstance instance_;
 };
 

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -242,7 +242,7 @@ class Ipv4InstanceRange : public InstanceRange {
   }
   virtual const std::string& asString() const override { return friendly_name_; }
   virtual const std::string& logicalName() const override { return friendly_name_; }
-  virtual int bind(int fd) const override;
+  virtual int bind(int fd, Runtime::RandomGenerator& random) const override;
   virtual const Ip* ip() const override { return &ip_; }
   virtual int socket(SocketType type) const override;
   virtual Type type() const override { return Type::Ip; }
@@ -273,7 +273,7 @@ class Ipv6InstanceRange : public InstanceRange {
   }
   const std::string& asString() const override { return friendly_name_; }
   const std::string& logicalName() const override { return friendly_name_; }
-  int bind(int fd) const override;
+  int bind(int fd, Runtime::RandomGenerator& random) const override;
   const Ip* ip() const override { return &ip_; }
   int socket(SocketType type) const override;
   Type type() const override { return Type::Ip; }
@@ -303,7 +303,7 @@ class PipeInstanceRange : public InstanceRange {
   }
   const std::string& asString() const override { return instance_.asString(); }
   const std::string& logicalName() const override {return instance_.logicalName(); }
-  int bind(int fd) const override { return instance_.bind(fd); }
+  int bind(int fd, Runtime::RandomGenerator&) const override { return instance_.bind(fd); }
   const Ip* ip() const override { return nullptr; }
   uint32_t starting_port() const override { return 0; }
   uint32_t ending_port() const override { return 0; }

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -531,10 +531,10 @@ bool ConnectionImpl::bothSidesHalfClosed() {
 
 ClientConnectionImpl::ClientConnectionImpl(
     Event::Dispatcher& dispatcher, const Address::InstanceConstSharedPtr& remote_address,
-    const Network::Address::InstanceConstSharedPtr& source_address,
+    const Network::Address::InstanceRangeConstSharedPtr& source_address_range,
     Network::TransportSocketPtr&& transport_socket,
     const Network::ConnectionSocket::OptionsSharedPtr& options,
-    Runtime::RandomGenerator&)
+    Runtime::RandomGenerator& random)
     : ConnectionImpl(dispatcher, std::make_unique<ClientSocketImpl>(remote_address),
                      std::move(transport_socket), false) {
   if (options) {
@@ -549,11 +549,11 @@ ClientConnectionImpl::ClientConnectionImpl(
       }
     }
   }
-  if (source_address != nullptr) {
-    const int rc = source_address->bind(fd());
+  if (source_address_range != nullptr) {
+    const int rc = source_address_range->bind(fd(), random);
     if (rc < 0) {
-      ENVOY_LOG_MISC(debug, "Bind failure. Failed to bind to {}: {}", source_address->asString(),
-                     strerror(errno));
+      ENVOY_LOG_MISC(debug, "Bind failure. Failed to bind to {}: {}",
+                     source_address_range->asString(), strerror(errno));
       bind_error_ = true;
       // Set a special error state to ensure asynchronous close to give the owner of the
       // ConnectionImpl a chance to add callbacks and detect the "disconnect".

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -533,7 +533,8 @@ ClientConnectionImpl::ClientConnectionImpl(
     Event::Dispatcher& dispatcher, const Address::InstanceConstSharedPtr& remote_address,
     const Network::Address::InstanceConstSharedPtr& source_address,
     Network::TransportSocketPtr&& transport_socket,
-    const Network::ConnectionSocket::OptionsSharedPtr& options)
+    const Network::ConnectionSocket::OptionsSharedPtr& options,
+    Runtime::RandomGenerator&)
     : ConnectionImpl(dispatcher, std::make_unique<ClientSocketImpl>(remote_address),
                      std::move(transport_socket), false) {
   if (options) {

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -533,8 +533,7 @@ ClientConnectionImpl::ClientConnectionImpl(
     Event::Dispatcher& dispatcher, const Address::InstanceConstSharedPtr& remote_address,
     const Network::Address::InstanceRangeConstSharedPtr& source_address_range,
     Network::TransportSocketPtr&& transport_socket,
-    const Network::ConnectionSocket::OptionsSharedPtr& options,
-    Runtime::RandomGenerator& random)
+    const Network::ConnectionSocket::OptionsSharedPtr& options, Runtime::RandomGenerator& random)
     : ConnectionImpl(dispatcher, std::make_unique<ClientSocketImpl>(remote_address),
                      std::move(transport_socket), false) {
   if (options) {

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -174,9 +174,10 @@ private:
  */
 class ClientConnectionImpl : public ConnectionImpl, virtual public ClientConnection {
 public:
+  // Note that a reference to the RandomGenerator will not be held by the constructor.
   ClientConnectionImpl(Event::Dispatcher& dispatcher,
                        const Address::InstanceConstSharedPtr& remote_address,
-                       const Address::InstanceConstSharedPtr& source_address,
+                       const Address::InstanceRangeConstSharedPtr& source_address_range,
                        Network::TransportSocketPtr&& transport_socket,
                        const Network::ConnectionSocket::OptionsSharedPtr& options,
                        Runtime::RandomGenerator& random);

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -9,6 +9,7 @@
 #include "envoy/event/dispatcher.h"
 #include "envoy/network/connection.h"
 #include "envoy/network/transport_socket.h"
+#include "envoy/runtime/runtime.h"
 
 #include "common/buffer/watermark_buffer.h"
 #include "common/common/logger.h"
@@ -177,7 +178,8 @@ public:
                        const Address::InstanceConstSharedPtr& remote_address,
                        const Address::InstanceConstSharedPtr& source_address,
                        Network::TransportSocketPtr&& transport_socket,
-                       const Network::ConnectionSocket::OptionsSharedPtr& options);
+                       const Network::ConnectionSocket::OptionsSharedPtr& options,
+                       Runtime::RandomGenerator& random);
 
   // Network::ClientConnection
   void connect() override;

--- a/source/common/network/resolver_impl.cc
+++ b/source/common/network/resolver_impl.cc
@@ -35,6 +35,60 @@ public:
     }
   }
 
+  InstanceRangeConstSharedPtr
+  resolve(const envoy::api::v2::core::SocketAddressPortRange& socket_address_port_range) override {
+    switch (socket_address_port_range.port_specifier_case()) {
+    case envoy::api::v2::core::SocketAddressPortRange::kPortValue:
+    // Default to port 0 if no port value is specified.
+    case envoy::api::v2::core::SocketAddressPortRange::PORT_SPECIFIER_NOT_SET: {
+      InstanceConstSharedPtr instance = Network::Utility::parseInternetAddress(
+          socket_address_port_range.address(), socket_address_port_range.port_value(),
+          !socket_address_port_range.ipv4_compat());
+      // TODO(rdsmith): Assertion of some kind that this is an IP instance?
+      switch (instance->ip()->version()) {
+      case IpVersion::v4:
+        return std::make_shared<Ipv4InstanceRange>(instance->ip()->addressAsString(),
+                                                   instance->ip()->port(),
+                                                   instance->ip()->port());
+      case IpVersion::v6:
+        return std::make_shared<Ipv6InstanceRange>(instance->ip()->addressAsString(),
+                                                   instance->ip()->port(),
+                                                   instance->ip()->port());
+      }
+    }
+    case envoy::api::v2::core::SocketAddressPortRange::kPortRange: {
+      uint32_t starting_port = socket_address_port_range.port_range().port_value_start();
+      uint32_t ending_port = socket_address_port_range.port_range().port_value_end();
+      if (ending_port < starting_port)  {
+        throw EnvoyException(
+            fmt::format("IP resolver given port range with end before start: [{}, {}]",
+                        starting_port, ending_port));
+      }
+      if (static_cast<in_port_t>(ending_port) != ending_port) {
+        throw EnvoyException(
+            fmt::format("IP resolver given port to large for in_port_t: {}", ending_port));
+      }
+
+      InstanceConstSharedPtr instance = Network::Utility::parseInternetAddress(
+          socket_address_port_range.address(), starting_port,
+          !socket_address_port_range.ipv4_compat());
+      // TODO(rdsmith): Assertion of some kind that this is an IP instance?
+      switch (instance->ip()->version()) {
+      case IpVersion::v4:
+        return std::make_shared<Ipv4InstanceRange>(instance->ip()->addressAsString(),
+                                                   starting_port, ending_port);
+      case IpVersion::v6:
+        return std::make_shared<Ipv6InstanceRange>(instance->ip()->addressAsString(),
+                                                   starting_port, ending_port);
+      }
+    }
+
+    default:
+      throw EnvoyException(fmt::format("IP resolver can't handle port specifier type {}",
+                                       socket_address_port_range.port_specifier_case()));
+    }
+  }
+
   std::string name() const override { return Config::AddressResolverNames::get().IP; }
 };
 
@@ -68,6 +122,23 @@ resolveProtoSocketAddress(const envoy::api::v2::core::SocketAddress& socket_addr
     throw EnvoyException(fmt::format("Unknown address resolver: {}", resolver_name));
   }
   return resolver->resolve(socket_address);
+}
+
+InstanceRangeConstSharedPtr
+resolveProtoSocketAddress(
+    const envoy::api::v2::core::SocketAddressPortRange& socket_address_port_range) {
+  Resolver* resolver = nullptr;
+  const std::string& resolver_name = socket_address_port_range.resolver_name();
+  if (resolver_name.empty()) {
+    resolver =
+        Registry::FactoryRegistry<Resolver>::getFactory(Config::AddressResolverNames::get().IP);
+  } else {
+    resolver = Registry::FactoryRegistry<Resolver>::getFactory(resolver_name);
+  }
+  if (resolver == nullptr) {
+    throw EnvoyException(fmt::format("Unknown address resolver: {}", resolver_name));
+  }
+  return resolver->resolve(socket_address_port_range);
 }
 
 } // namespace Address

--- a/source/common/network/resolver_impl.cc
+++ b/source/common/network/resolver_impl.cc
@@ -39,27 +39,27 @@ public:
   resolve(const envoy::api::v2::core::SocketAddressPortRange& socket_address_port_range) override {
     uint32_t starting_port = socket_address_port_range.port_range().port_value_start();
     uint32_t ending_port = socket_address_port_range.port_range().port_value_end();
-    if (ending_port < starting_port)  {
+    if (ending_port < starting_port) {
       throw EnvoyException(
-          fmt::format("IP resolver given port range with end before start: [{}, {}]",
-                      starting_port, ending_port));
+          fmt::format("IP resolver given port range with end before start: [{}, {}]", starting_port,
+                      ending_port));
     }
     if (static_cast<in_port_t>(ending_port) != ending_port) {
       throw EnvoyException(
           fmt::format("IP resolver given port to large for in_port_t: {}", ending_port));
     }
 
-    InstanceConstSharedPtr instance = Network::Utility::parseInternetAddress(
-        socket_address_port_range.address(), starting_port,
-        !socket_address_port_range.ipv4_compat());
+    InstanceConstSharedPtr instance =
+        Network::Utility::parseInternetAddress(socket_address_port_range.address(), starting_port,
+                                               !socket_address_port_range.ipv4_compat());
     ASSERT(instance->type() == Type::Ip);
     switch (instance->ip()->version()) {
-      case IpVersion::v4:
-        return std::make_shared<Ipv4InstanceRange>(instance->ip()->addressAsString(),
-                                                   starting_port, ending_port);
-      case IpVersion::v6:
-        return std::make_shared<Ipv6InstanceRange>(instance->ip()->addressAsString(),
-                                                   starting_port, ending_port);
+    case IpVersion::v4:
+      return std::make_shared<Ipv4InstanceRange>(instance->ip()->addressAsString(), starting_port,
+                                                 ending_port);
+    case IpVersion::v6:
+      return std::make_shared<Ipv6InstanceRange>(instance->ip()->addressAsString(), starting_port,
+                                                 ending_port);
     }
   }
 
@@ -98,8 +98,7 @@ resolveProtoSocketAddress(const envoy::api::v2::core::SocketAddress& socket_addr
   return resolver->resolve(socket_address);
 }
 
-InstanceRangeConstSharedPtr
-resolveProtoSocketAddressRange(
+InstanceRangeConstSharedPtr resolveProtoSocketAddressRange(
     const envoy::api::v2::core::SocketAddressPortRange& socket_address_port_range) {
   Resolver* resolver = nullptr;
   const std::string& resolver_name = socket_address_port_range.resolver_name();

--- a/source/common/network/resolver_impl.cc
+++ b/source/common/network/resolver_impl.cc
@@ -44,7 +44,7 @@ public:
       InstanceConstSharedPtr instance = Network::Utility::parseInternetAddress(
           socket_address_port_range.address(), socket_address_port_range.port_value(),
           !socket_address_port_range.ipv4_compat());
-      // TODO(rdsmith): Assertion of some kind that this is an IP instance?
+      ASSERT(instance->type() == Type::Ip);
       switch (instance->ip()->version()) {
       case IpVersion::v4:
         return std::make_shared<Ipv4InstanceRange>(instance->ip()->addressAsString(),
@@ -72,7 +72,7 @@ public:
       InstanceConstSharedPtr instance = Network::Utility::parseInternetAddress(
           socket_address_port_range.address(), starting_port,
           !socket_address_port_range.ipv4_compat());
-      // TODO(rdsmith): Assertion of some kind that this is an IP instance?
+      ASSERT(instance->type() == Type::Ip);
       switch (instance->ip()->version()) {
       case IpVersion::v4:
         return std::make_shared<Ipv4InstanceRange>(instance->ip()->addressAsString(),
@@ -125,7 +125,7 @@ resolveProtoSocketAddress(const envoy::api::v2::core::SocketAddress& socket_addr
 }
 
 InstanceRangeConstSharedPtr
-resolveProtoSocketAddress(
+resolveProtoSocketAddressRange(
     const envoy::api::v2::core::SocketAddressPortRange& socket_address_port_range) {
   Resolver* resolver = nullptr;
   const std::string& resolver_name = socket_address_port_range.resolver_name();

--- a/source/common/network/resolver_impl.h
+++ b/source/common/network/resolver_impl.h
@@ -31,7 +31,7 @@ resolveProtoSocketAddress(const envoy::api::v2::core::SocketAddress& address);
  * @return pointer to the Instance.
  */
 Address::InstanceRangeConstSharedPtr
-resolveProtoSocketAddress(const envoy::api::v2::core::SocketAddressPortRange& address);
+resolveProtoSocketAddressRange(const envoy::api::v2::core::SocketAddressPortRange& address);
 } // namespace Address
 } // namespace Network
 } // namespace Envoy

--- a/source/common/network/resolver_impl.h
+++ b/source/common/network/resolver_impl.h
@@ -24,6 +24,14 @@ Address::InstanceConstSharedPtr resolveProtoAddress(const envoy::api::v2::core::
  */
 Address::InstanceConstSharedPtr
 resolveProtoSocketAddress(const envoy::api::v2::core::SocketAddress& address);
+
+/**
+ * Create an InstanceRange from a envoy::api::v2::core::SocketAddressPortRange.
+ * @param address_range supplies the socket address port range proto to resolve.
+ * @return pointer to the Instance.
+ */
+Address::InstanceRangeConstSharedPtr
+resolveProtoSocketAddress(const envoy::api::v2::core::SocketAddressPortRange& address);
 } // namespace Address
 } // namespace Network
 } // namespace Envoy

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -797,7 +797,8 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(
     case LoadBalancerType::OriginalDst: {
       ASSERT(lb_factory_ == nullptr);
       lb_.reset(new OriginalDstCluster::LoadBalancer(
-          priority_set_, parent.parent_.active_clusters_.at(cluster->name())->cluster_));
+          priority_set_, parent.parent_.active_clusters_.at(cluster->name())->cluster_,
+          parent_.parent_.random_));
       break;
     }
     }

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -192,6 +192,8 @@ public:
   ClusterUpdateCallbacksHandlePtr
   addThreadLocalClusterUpdateCallbacks(ClusterUpdateCallbacks&) override;
 
+  Envoy::Runtime::RandomGenerator& randomGenerator() override { return random_; }
+
 private:
   /**
    * Thread local cached cluster data. Each thread local cluster gets updates from the parent

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -192,7 +192,7 @@ public:
   ClusterUpdateCallbacksHandlePtr
   addThreadLocalClusterUpdateCallbacks(ClusterUpdateCallbacks&) override;
 
-  Envoy::Runtime::RandomGenerator& randomGenerator() override { return random_; }
+  Runtime::RandomGenerator& randomGenerator() override { return random_; }
 
 private:
   /**

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -23,7 +23,7 @@ EdsClusterImpl::EdsClusterImpl(const envoy::api::v2::Cluster& cluster, Runtime::
                                Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
                                bool added_via_api)
     : BaseDynamicClusterImpl(cluster, cm.bindConfig(), runtime, stats, ssl_context_manager,
-                             added_via_api),
+                             cm.randomGenerator(), added_via_api),
       cm_(cm), local_info_(local_info),
       cluster_name_(cluster.eds_cluster_config().service_name().empty()
                         ? cluster.name()
@@ -83,7 +83,7 @@ void EdsClusterImpl::onConfigUpdate(const ResourceVector& resources) {
       priority_state[priority].first->emplace_back(new HostImpl(
           info_, "", resolveProtoAddress(lb_endpoint.endpoint().address()), lb_endpoint.metadata(),
           lb_endpoint.load_balancing_weight().value(), locality_lb_endpoint.locality(),
-          lb_endpoint.endpoint().health_check_config()));
+          lb_endpoint.endpoint().health_check_config(), random_));
       const auto& health_status = lb_endpoint.health_status();
       if (health_status == envoy::api::v2::core::HealthStatus::UNHEALTHY ||
           health_status == envoy::api::v2::core::HealthStatus::DRAINING ||

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -129,7 +129,7 @@ Upstream::Host::CreateConnectionData LogicalDnsCluster::LogicalHost::createConne
   PerThreadCurrentHostData& data = parent_.tls_->getTyped<PerThreadCurrentHostData>();
   ASSERT(data.current_resolved_address_);
   return {HostImpl::createConnection(dispatcher, *parent_.info_, data.current_resolved_address_,
-                                     options),
+                                     options, parent_.random_),
           HostDescriptionConstSharedPtr{
               new RealHostDescription(data.current_resolved_address_, shared_from_this())}};
 }

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -21,7 +21,8 @@ LogicalDnsCluster::LogicalDnsCluster(const envoy::api::v2::Cluster& cluster,
                                      Network::DnsResolverSharedPtr dns_resolver,
                                      ThreadLocal::SlotAllocator& tls, ClusterManager& cm,
                                      Event::Dispatcher& dispatcher, bool added_via_api)
-    : ClusterImplBase(cluster, cm.bindConfig(), runtime, stats, ssl_context_manager, added_via_api),
+    : ClusterImplBase(cluster, cm.bindConfig(), runtime, stats, ssl_context_manager,
+                      cm.randomGenerator(), added_via_api),
       dns_resolver_(dns_resolver),
       dns_refresh_rate_ms_(
           std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(cluster, dns_refresh_rate, 5000))),

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -44,7 +44,8 @@ private:
                 Network::Address::InstanceConstSharedPtr address, LogicalDnsCluster& parent)
         : HostImpl(cluster, hostname, address, envoy::api::v2::core::Metadata::default_instance(),
                    1, envoy::api::v2::core::Locality().default_instance(),
-                   envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance()),
+                   envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance(),
+                   parent.random_),
           parent_(parent) {}
 
     // Upstream::Host

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -20,7 +20,7 @@ namespace Upstream {
 // and throws an exception otherwise.
 
 OriginalDstCluster::LoadBalancer::LoadBalancer(
-    PrioritySet& priority_set, ClusterSharedPtr& parent, Envoy::Runtime::RandomGenerator& random)
+    PrioritySet& priority_set, ClusterSharedPtr& parent, Runtime::RandomGenerator& random)
     : priority_set_(priority_set), parent_(std::static_pointer_cast<OriginalDstCluster>(parent)),
       info_(parent->info()), random_(random) {
   // priority_set_ is initially empty.

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -19,9 +19,10 @@ namespace Upstream {
 // OriginalDstCluster::LoadBalancer is never configured with any other type of cluster,
 // and throws an exception otherwise.
 
-OriginalDstCluster::LoadBalancer::LoadBalancer(PrioritySet& priority_set, ClusterSharedPtr& parent)
+OriginalDstCluster::LoadBalancer::LoadBalancer(
+    PrioritySet& priority_set, ClusterSharedPtr& parent, Envoy::Runtime::RandomGenerator& random)
     : priority_set_(priority_set), parent_(std::static_pointer_cast<OriginalDstCluster>(parent)),
-      info_(parent->info()) {
+      info_(parent->info()), random_(random) {
   // priority_set_ is initially empty.
   priority_set_.addMemberUpdateCb(
       [this](uint32_t, const HostVector& hosts_added, const HostVector& hosts_removed) -> void {
@@ -64,7 +65,8 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
             info_, info_->name() + dst_addr.asString(), std::move(host_ip_port),
             envoy::api::v2::core::Metadata::default_instance(), 1,
             envoy::api::v2::core::Locality().default_instance(),
-            envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance()));
+            envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance(),
+            random_));
 
         ENVOY_LOG(debug, "Created host {}.", host->address()->asString());
         // Add the new host to the map. We just failed to find it in
@@ -97,7 +99,7 @@ OriginalDstCluster::OriginalDstCluster(const envoy::api::v2::Cluster& config,
                                        Runtime::Loader& runtime, Stats::Store& stats,
                                        Ssl::ContextManager& ssl_context_manager, ClusterManager& cm,
                                        Event::Dispatcher& dispatcher, bool added_via_api)
-    : ClusterImplBase(config, cm.bindConfig(), runtime, stats, ssl_context_manager, added_via_api),
+    : ClusterImplBase(config, cm.bindConfig(), runtime, stats, ssl_context_manager, cm.randomGenerator(), added_via_api),
       dispatcher_(dispatcher), cleanup_interval_ms_(std::chrono::milliseconds(
                                    PROTOBUF_GET_MS_OR_DEFAULT(config, cleanup_interval, 5000))),
       cleanup_timer_(dispatcher.createTimer([this]() -> void { cleanup(); })) {

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -19,8 +19,8 @@ namespace Upstream {
 // OriginalDstCluster::LoadBalancer is never configured with any other type of cluster,
 // and throws an exception otherwise.
 
-OriginalDstCluster::LoadBalancer::LoadBalancer(
-    PrioritySet& priority_set, ClusterSharedPtr& parent, Runtime::RandomGenerator& random)
+OriginalDstCluster::LoadBalancer::LoadBalancer(PrioritySet& priority_set, ClusterSharedPtr& parent,
+                                               Runtime::RandomGenerator& random)
     : priority_set_(priority_set), parent_(std::static_pointer_cast<OriginalDstCluster>(parent)),
       info_(parent->info()), random_(random) {
   // priority_set_ is initially empty.
@@ -65,8 +65,7 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
             info_, info_->name() + dst_addr.asString(), std::move(host_ip_port),
             envoy::api::v2::core::Metadata::default_instance(), 1,
             envoy::api::v2::core::Locality().default_instance(),
-            envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance(),
-            random_));
+            envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance(), random_));
 
         ENVOY_LOG(debug, "Created host {}.", host->address()->asString());
         // Add the new host to the map. We just failed to find it in
@@ -99,7 +98,8 @@ OriginalDstCluster::OriginalDstCluster(const envoy::api::v2::Cluster& config,
                                        Runtime::Loader& runtime, Stats::Store& stats,
                                        Ssl::ContextManager& ssl_context_manager, ClusterManager& cm,
                                        Event::Dispatcher& dispatcher, bool added_via_api)
-    : ClusterImplBase(config, cm.bindConfig(), runtime, stats, ssl_context_manager, cm.randomGenerator(), added_via_api),
+    : ClusterImplBase(config, cm.bindConfig(), runtime, stats, ssl_context_manager,
+                      cm.randomGenerator(), added_via_api),
       dispatcher_(dispatcher), cleanup_interval_ms_(std::chrono::milliseconds(
                                    PROTOBUF_GET_MS_OR_DEFAULT(config, cleanup_interval, 5000))),
       cleanup_timer_(dispatcher.createTimer([this]() -> void { cleanup(); })) {

--- a/source/common/upstream/original_dst_cluster.h
+++ b/source/common/upstream/original_dst_cluster.h
@@ -43,7 +43,7 @@ public:
   class LoadBalancer : public Upstream::LoadBalancer {
   public:
     LoadBalancer(PrioritySet& priority_set, ClusterSharedPtr& parent,
-                 Envoy::Runtime::RandomGenerator& random);
+                 Runtime::RandomGenerator& random);
 
     // Upstream::LoadBalancer
     HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
@@ -96,7 +96,7 @@ public:
     std::weak_ptr<OriginalDstCluster> parent_; // Primary cluster managed by the main thread.
     ClusterInfoConstSharedPtr info_;
     HostMap host_map_;
-    Envoy::Runtime::RandomGenerator& random_;
+    Runtime::RandomGenerator& random_;
   };
 
 private:

--- a/source/common/upstream/original_dst_cluster.h
+++ b/source/common/upstream/original_dst_cluster.h
@@ -42,7 +42,8 @@ public:
    */
   class LoadBalancer : public Upstream::LoadBalancer {
   public:
-    LoadBalancer(PrioritySet& priority_set, ClusterSharedPtr& parent);
+    LoadBalancer(PrioritySet& priority_set, ClusterSharedPtr& parent,
+                 Envoy::Runtime::RandomGenerator& random);
 
     // Upstream::LoadBalancer
     HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
@@ -95,6 +96,7 @@ public:
     std::weak_ptr<OriginalDstCluster> parent_; // Primary cluster managed by the main thread.
     ClusterInfoConstSharedPtr info_;
     HostMap host_map_;
+    Envoy::Runtime::RandomGenerator& random_;
   };
 
 private:

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -40,7 +40,7 @@ namespace {
 
 const Network::Address::InstanceRangeConstSharedPtr
 getSourceAddressRange(const envoy::api::v2::Cluster& cluster,
-                 const envoy::api::v2::core::BindConfig& bind_config) {
+                      const envoy::api::v2::core::BindConfig& bind_config) {
   // The source address from cluster config takes precedence.
   const envoy::api::v2::core::BindConfig* config = nullptr;
   if (cluster.upstream_bind_config().has_source_address_port_range()) {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -111,7 +111,7 @@ HostImpl::createConnection(Event::Dispatcher& dispatcher, const ClusterInfo& clu
   }
   Network::ClientConnectionPtr connection = dispatcher.createClientConnection(
       address, cluster.sourceAddress(), cluster.transportSocketFactory().createTransportSocket(),
-      cluster_options);
+      cluster_options, random_);
   connection->setBufferLimits(cluster.perConnectionBufferLimitBytes());
   return connection;
 }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -50,7 +50,7 @@ getSourceAddressRange(const envoy::api::v2::Cluster& cluster,
   } else {
     return nullptr;
   }
-    
+
   return Network::Address::resolveProtoSocketAddressRange(config->source_address_port_range());
 }
 
@@ -605,7 +605,8 @@ StaticClusterImpl::StaticClusterImpl(const envoy::api::v2::Cluster& cluster,
                                      Runtime::Loader& runtime, Stats::Store& stats,
                                      Ssl::ContextManager& ssl_context_manager, ClusterManager& cm,
                                      bool added_via_api)
-    : ClusterImplBase(cluster, cm.bindConfig(), runtime, stats, ssl_context_manager, cm.randomGenerator(), added_via_api),
+    : ClusterImplBase(cluster, cm.bindConfig(), runtime, stats, ssl_context_manager,
+                      cm.randomGenerator(), added_via_api),
       initial_hosts_(new HostVector()) {
 
   for (const auto& host : cluster.hosts()) {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -394,7 +394,7 @@ ClusterImplBase::ClusterImplBase(const envoy::api::v2::Cluster& cluster,
                                  const envoy::api::v2::core::BindConfig& bind_config,
                                  Runtime::Loader& runtime, Stats::Store& stats,
                                  Ssl::ContextManager& ssl_context_manager,
-                                 Envoy::Runtime::RandomGenerator& random, bool added_via_api)
+                                 Runtime::RandomGenerator& random, bool added_via_api)
     : runtime_(runtime), info_(new ClusterInfoImpl(cluster, bind_config, runtime, stats,
                                                    ssl_context_manager, added_via_api)),
       random_(random) {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -86,19 +86,20 @@ public:
 Host::CreateConnectionData
 HostImpl::createConnection(Event::Dispatcher& dispatcher,
                            const Network::ConnectionSocket::OptionsSharedPtr& options) const {
-  return {createConnection(dispatcher, *cluster_, address_, options), shared_from_this()};
+  return {createConnection(dispatcher, *cluster_, address_, options, random_), shared_from_this()};
 }
 
 Host::CreateConnectionData
 HostImpl::createHealthCheckConnection(Event::Dispatcher& dispatcher) const {
-  return {createConnection(dispatcher, *cluster_, healthCheckAddress(), nullptr),
+  return {createConnection(dispatcher, *cluster_, healthCheckAddress(), nullptr, random_),
           shared_from_this()};
 }
 
 Network::ClientConnectionPtr
 HostImpl::createConnection(Event::Dispatcher& dispatcher, const ClusterInfo& cluster,
                            Network::Address::InstanceConstSharedPtr address,
-                           const Network::ConnectionSocket::OptionsSharedPtr& options) {
+                           const Network::ConnectionSocket::OptionsSharedPtr& options,
+                           Runtime::RandomGenerator& random) {
   Network::ConnectionSocket::OptionsSharedPtr cluster_options;
   if (cluster.features() & ClusterInfo::Features::FREEBIND) {
     cluster_options = std::make_shared<Network::ConnectionSocket::Options>();
@@ -111,7 +112,7 @@ HostImpl::createConnection(Event::Dispatcher& dispatcher, const ClusterInfo& clu
   }
   Network::ClientConnectionPtr connection = dispatcher.createClientConnection(
       address, cluster.sourceAddress(), cluster.transportSocketFactory().createTransportSocket(),
-      cluster_options, random_);
+      cluster_options, random);
   connection->setBufferLimits(cluster.perConnectionBufferLimitBytes());
   return connection;
 }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -128,7 +128,7 @@ public:
            const envoy::api::v2::core::Metadata& metadata, uint32_t initial_weight,
            const envoy::api::v2::core::Locality& locality,
            const envoy::api::v2::endpoint::Endpoint::HealthCheckConfig& health_check_config,
-           Envoy::Runtime::RandomGenerator& random)
+           Runtime::RandomGenerator& random)
       : HostDescriptionImpl(cluster, hostname, address, metadata, locality, health_check_config),
         used_(true), random_(random) {
     weight(initial_weight);
@@ -167,7 +167,7 @@ private:
   std::atomic<uint64_t> health_flags_{};
   std::atomic<uint32_t> weight_;
   std::atomic<bool> used_;
-  Envoy::Runtime::RandomGenerator& random_;
+  Runtime::RandomGenerator& random_;
 };
 
 class HostsPerLocalityImpl : public HostsPerLocality {
@@ -449,7 +449,7 @@ protected:
   ClusterImplBase(const envoy::api::v2::Cluster& cluster,
                   const envoy::api::v2::core::BindConfig& bind_config, Runtime::Loader& runtime,
                   Stats::Store& stats, Ssl::ContextManager& ssl_context_manager,
-                  Envoy::Runtime::RandomGenerator& random, bool added_via_api);
+                  Runtime::RandomGenerator& random, bool added_via_api);
 
   static HostVectorConstSharedPtr createHealthyHostList(const HostVector& hosts);
   static HostsPerLocalityConstSharedPtr createHealthyHostLists(const HostsPerLocality& hosts);
@@ -472,7 +472,7 @@ protected:
              // and destroyed last.
   HealthCheckerSharedPtr health_checker_;
   Outlier::DetectorSharedPtr outlier_detector_;
-  Envoy::Runtime::RandomGenerator& random_;
+  Runtime::RandomGenerator& random_;
 
 protected:
   PrioritySetImpl priority_set_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -127,9 +127,10 @@ public:
            Network::Address::InstanceConstSharedPtr address,
            const envoy::api::v2::core::Metadata& metadata, uint32_t initial_weight,
            const envoy::api::v2::core::Locality& locality,
-           const envoy::api::v2::endpoint::Endpoint::HealthCheckConfig& health_check_config)
+           const envoy::api::v2::endpoint::Endpoint::HealthCheckConfig& health_check_config,
+           Envoy::Runtime::RandomGenerator& random)
       : HostDescriptionImpl(cluster, hostname, address, metadata, locality, health_check_config),
-        used_(true) {
+        used_(true), random_(random) {
     weight(initial_weight);
   }
 
@@ -165,6 +166,7 @@ private:
   std::atomic<uint64_t> health_flags_{};
   std::atomic<uint32_t> weight_;
   std::atomic<bool> used_;
+  Envoy::Runtime::RandomGenerator& random_;
 };
 
 class HostsPerLocalityImpl : public HostsPerLocality {
@@ -446,7 +448,7 @@ protected:
   ClusterImplBase(const envoy::api::v2::Cluster& cluster,
                   const envoy::api::v2::core::BindConfig& bind_config, Runtime::Loader& runtime,
                   Stats::Store& stats, Ssl::ContextManager& ssl_context_manager,
-                  bool added_via_api);
+                  Envoy::Runtime::RandomGenerator& random, bool added_via_api);
 
   static HostVectorConstSharedPtr createHealthyHostList(const HostVector& hosts);
   static HostsPerLocalityConstSharedPtr createHealthyHostLists(const HostsPerLocality& hosts);
@@ -469,6 +471,7 @@ protected:
              // and destroyed last.
   HealthCheckerSharedPtr health_checker_;
   Outlier::DetectorSharedPtr outlier_detector_;
+  Envoy::Runtime::RandomGenerator& random_;
 
 protected:
   PrioritySetImpl priority_set_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -350,8 +350,8 @@ public:
   ClusterStats& stats() const override { return stats_; }
   Stats::Scope& statsScope() const override { return *stats_scope_; }
   ClusterLoadReportStats& loadReportStats() const override { return load_report_stats_; }
-  const Network::Address::InstanceConstSharedPtr& sourceAddress() const override {
-    return source_address_;
+  const Network::Address::InstanceRangeConstSharedPtr& sourceAddressRange() const override {
+    return source_address_range_;
   };
   const LoadBalancerSubsetInfo& lbSubsetInfo() const override { return lb_subset_; }
   const envoy::api::v2::core::Metadata& metadata() const override { return metadata_; }
@@ -388,7 +388,7 @@ private:
   const Http::Http2Settings http2_settings_;
   mutable ResourceManagers resource_managers_;
   const std::string maintenance_mode_runtime_key_;
-  const Network::Address::InstanceConstSharedPtr source_address_;
+  const Network::Address::InstanceRangeConstSharedPtr source_address_range_;
   LoadBalancerType lb_type_;
   absl::optional<envoy::api::v2::Cluster::RingHashLbConfig> lb_ring_hash_config_;
   Ssl::ContextManager& ssl_context_manager_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -160,7 +160,8 @@ protected:
   static Network::ClientConnectionPtr
   createConnection(Event::Dispatcher& dispatcher, const ClusterInfo& cluster,
                    Network::Address::InstanceConstSharedPtr address,
-                   const Network::ConnectionSocket::OptionsSharedPtr& options);
+                   const Network::ConnectionSocket::OptionsSharedPtr& options,
+                   Runtime::RandomGenerator& random);
 
 private:
   std::atomic<uint64_t> health_flags_{};

--- a/source/server/config_validation/dispatcher.cc
+++ b/source/server/config_validation/dispatcher.cc
@@ -6,7 +6,7 @@ namespace Envoy {
 namespace Event {
 
 Network::ClientConnectionPtr ValidationDispatcher::createClientConnection(
-    Network::Address::InstanceConstSharedPtr, Network::Address::InstanceConstSharedPtr,
+    Network::Address::InstanceConstSharedPtr, Network::Address::InstanceRangeConstSharedPtr,
     Network::TransportSocketPtr&&, const Network::ConnectionSocket::OptionsSharedPtr&,
     Runtime::RandomGenerator&) {
   NOT_IMPLEMENTED;

--- a/source/server/config_validation/dispatcher.cc
+++ b/source/server/config_validation/dispatcher.cc
@@ -7,7 +7,8 @@ namespace Event {
 
 Network::ClientConnectionPtr ValidationDispatcher::createClientConnection(
     Network::Address::InstanceConstSharedPtr, Network::Address::InstanceConstSharedPtr,
-    Network::TransportSocketPtr&&, const Network::ConnectionSocket::OptionsSharedPtr&) {
+    Network::TransportSocketPtr&&, const Network::ConnectionSocket::OptionsSharedPtr&,
+    Runtime::RandomGenerator&) {
   NOT_IMPLEMENTED;
 }
 

--- a/source/server/config_validation/dispatcher.h
+++ b/source/server/config_validation/dispatcher.h
@@ -16,7 +16,8 @@ class ValidationDispatcher : public DispatcherImpl {
 public:
   Network::ClientConnectionPtr
   createClientConnection(Network::Address::InstanceConstSharedPtr,
-                         Network::Address::InstanceConstSharedPtr, Network::TransportSocketPtr&&,
+                         Network::Address::InstanceRangeConstSharedPtr,
+                         Network::TransportSocketPtr&&,
                          const Network::ConnectionSocket::OptionsSharedPtr& options,
                          Runtime::RandomGenerator&) override;
   Network::DnsResolverSharedPtr createDnsResolver(

--- a/source/server/config_validation/dispatcher.h
+++ b/source/server/config_validation/dispatcher.h
@@ -14,12 +14,10 @@ namespace Event {
  */
 class ValidationDispatcher : public DispatcherImpl {
 public:
-  Network::ClientConnectionPtr
-  createClientConnection(Network::Address::InstanceConstSharedPtr,
-                         Network::Address::InstanceRangeConstSharedPtr,
-                         Network::TransportSocketPtr&&,
-                         const Network::ConnectionSocket::OptionsSharedPtr& options,
-                         Runtime::RandomGenerator&) override;
+  Network::ClientConnectionPtr createClientConnection(
+      Network::Address::InstanceConstSharedPtr, Network::Address::InstanceRangeConstSharedPtr,
+      Network::TransportSocketPtr&&, const Network::ConnectionSocket::OptionsSharedPtr& options,
+      Runtime::RandomGenerator&) override;
   Network::DnsResolverSharedPtr createDnsResolver(
       const std::vector<Network::Address::InstanceConstSharedPtr>& resolvers) override;
   Network::ListenerPtr createListener(Network::Socket&, Network::ListenerCallbacks&,

--- a/source/server/config_validation/dispatcher.h
+++ b/source/server/config_validation/dispatcher.h
@@ -17,7 +17,8 @@ public:
   Network::ClientConnectionPtr
   createClientConnection(Network::Address::InstanceConstSharedPtr,
                          Network::Address::InstanceConstSharedPtr, Network::TransportSocketPtr&&,
-                         const Network::ConnectionSocket::OptionsSharedPtr& options) override;
+                         const Network::ConnectionSocket::OptionsSharedPtr& options,
+                         Runtime::RandomGenerator&) override;
   Network::DnsResolverSharedPtr createDnsResolver(
       const std::vector<Network::Address::InstanceConstSharedPtr>& resolvers) override;
   Network::ListenerPtr createListener(Network::Socket&, Network::ListenerCallbacks&,

--- a/test/common/grpc/BUILD
+++ b/test/common/grpc/BUILD
@@ -74,6 +74,7 @@ envoy_cc_test_library(
     hdrs = ["grpc_client_integration.h"],
     deps = [
         "//source/common/common:assert_lib",
+        "//source/common/runtime:runtime_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/common/grpc/grpc_client_integration_test.cc
+++ b/test/common/grpc/grpc_client_integration_test.cc
@@ -9,6 +9,7 @@
 #include "common/http/http2/conn_pool.h"
 #include "common/network/connection_impl.h"
 #include "common/network/raw_buffer_socket.h"
+#include "common/runtime/runtime_impl.h"
 #include "common/ssl/context_config_impl.h"
 #include "common/ssl/context_manager_impl.h"
 #include "common/ssl/ssl_socket.h"
@@ -417,6 +418,7 @@ public:
   Router::MockShadowWriter* mock_shadow_writer_ = new Router::MockShadowWriter();
   Router::ShadowWriterPtr shadow_writer_ptr_{mock_shadow_writer_};
   Network::ClientConnectionPtr client_connection_;
+  Runtime::RandomGeneratorImpl& random_;
 };
 
 // Parameterize the loopback test server socket address and gRPC client type.

--- a/test/common/grpc/grpc_client_integration_test.cc
+++ b/test/common/grpc/grpc_client_integration_test.cc
@@ -252,9 +252,10 @@ public:
   // Create a Grpc::AsyncClientImpl instance backed by enough fake/mock
   // infrastructure to initiate a loopback TCP connection to fake_upstream_.
   AsyncClientPtr createAsyncClientImpl() {
+    Runtime::RandomGeneratorImpl random;
     client_connection_ = std::make_unique<Network::ClientConnectionImpl>(
         dispatcher_, fake_upstream_->localAddress(), nullptr,
-        std::move(async_client_transport_socket_), nullptr);
+        std::move(async_client_transport_socket_), nullptr, random);
     ON_CALL(*mock_cluster_info_, connectTimeout())
         .WillByDefault(Return(std::chrono::milliseconds(1000)));
     EXPECT_CALL(*mock_cluster_info_, name()).WillRepeatedly(ReturnRef(fake_cluster_name_));

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -6,6 +6,7 @@
 #include "common/http/exception.h"
 #include "common/network/listen_socket_impl.h"
 #include "common/network/utility.h"
+#include "common/runtime/runtime_impl.h"
 #include "common/upstream/upstream_impl.h"
 
 #include "test/common/http/common.h"
@@ -263,7 +264,8 @@ public:
     dispatcher_.reset(new Event::DispatcherImpl);
     upstream_listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
     Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
-        socket_.localAddress(), source_address_, Network::Test::createRawBufferSocket(), nullptr);
+        socket_.localAddress(), source_address_, Network::Test::createRawBufferSocket(), nullptr,
+        random_);
     client_connection_ = client_connection.get();
     client_connection_->addConnectionCallbacks(client_callbacks_);
 
@@ -344,6 +346,7 @@ protected:
   NiceMock<Network::MockConnectionCallbacks> client_callbacks_;
   NiceMock<Http::MockStreamEncoder> inner_encoder_;
   NiceMock<Http::MockStreamDecoder> outer_decoder_;
+  Runtime::RandomGeneratorImpl random_;
 };
 
 // Send a block of data from upstream, and ensure it is received by the codec.

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -264,7 +264,7 @@ public:
     dispatcher_.reset(new Event::DispatcherImpl);
     upstream_listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
     Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
-        socket_.localAddress(), source_address_, Network::Test::createRawBufferSocket(), nullptr,
+        socket_.localAddress(), source_address_range_, Network::Test::createRawBufferSocket(), nullptr,
         random_);
     client_connection_ = client_connection.get();
     client_connection_->addConnectionCallbacks(client_callbacks_);
@@ -332,7 +332,7 @@ protected:
   Network::ListenerPtr upstream_listener_;
   Network::MockListenerCallbacks listener_callbacks_;
   Network::MockConnectionHandler connection_handler_;
-  Network::Address::InstanceConstSharedPtr source_address_;
+  Network::Address::InstanceRangeConstSharedPtr source_address_range_;
   Stats::IsolatedStoreImpl stats_store_;
   Network::TcpListenSocket socket_{Network::Test::getAnyAddress(GetParam()), nullptr, true};
   Http::MockClientConnection* codec_;

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -264,8 +264,8 @@ public:
     dispatcher_.reset(new Event::DispatcherImpl);
     upstream_listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
     Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
-        socket_.localAddress(), source_address_range_, Network::Test::createRawBufferSocket(), nullptr,
-        random_);
+        socket_.localAddress(), source_address_range_, Network::Test::createRawBufferSocket(),
+        nullptr, random_);
     client_connection_ = client_connection.get();
     client_connection_->addConnectionCallbacks(client_callbacks_);
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -1244,6 +1244,7 @@ TEST_F(HttpConnectionManagerImplTest, WebSocketConnectTimeoutError) {
   NiceMock<Network::MockClientConnection>* upstream_connection =
       new NiceMock<Network::MockClientConnection>();
   Upstream::MockHost::MockCreateConnectionData conn_info;
+  Runtime::RandomGeneratorImpl randomGenerator;
 
   conn_info.connection_ = upstream_connection;
   conn_info.host_description_.reset(new Upstream::HostImpl(
@@ -1251,7 +1252,7 @@ TEST_F(HttpConnectionManagerImplTest, WebSocketConnectTimeoutError) {
       Network::Utility::resolveUrl("tcp://127.0.0.1:80"),
       envoy::api::v2::core::Metadata::default_instance(), 1,
       envoy::api::v2::core::Locality().default_instance(),
-      envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance()));
+      envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance(), randomGenerator));
   EXPECT_CALL(*connect_timer, enableTimer(_));
   EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster", _)).WillOnce(Return(conn_info));
 
@@ -1293,6 +1294,7 @@ TEST_F(HttpConnectionManagerImplTest, WebSocketConnectionFailure) {
   NiceMock<Network::MockClientConnection>* upstream_connection =
       new NiceMock<Network::MockClientConnection>();
   Upstream::MockHost::MockCreateConnectionData conn_info;
+  Runtime::RandomGeneratorImpl randomGenerator;
 
   conn_info.connection_ = upstream_connection;
   conn_info.host_description_.reset(new Upstream::HostImpl(
@@ -1300,7 +1302,7 @@ TEST_F(HttpConnectionManagerImplTest, WebSocketConnectionFailure) {
       Network::Utility::resolveUrl("tcp://127.0.0.1:80"),
       envoy::api::v2::core::Metadata::default_instance(), 1,
       envoy::api::v2::core::Locality().default_instance(),
-      envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance()));
+      envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance(), randomGenerator));
   EXPECT_CALL(*connect_timer, enableTimer(_));
   EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster", _)).WillOnce(Return(conn_info));
 
@@ -1349,6 +1351,7 @@ TEST_F(HttpConnectionManagerImplTest, WebSocketPrefixAndAutoHostRewrite) {
                                              {"connection", "Upgrade"},
                                              {"upgrade", "websocket"}}};
   auto raw_header_ptr = headers.get();
+  Runtime::RandomGeneratorImpl randomGenerator;
 
   conn_info.connection_ = upstream_connection;
   conn_info.host_description_.reset(new Upstream::HostImpl(
@@ -1356,7 +1359,7 @@ TEST_F(HttpConnectionManagerImplTest, WebSocketPrefixAndAutoHostRewrite) {
       Network::Utility::resolveUrl("tcp://127.0.0.1:80"),
       envoy::api::v2::core::Metadata::default_instance(), 1,
       envoy::api::v2::core::Locality().default_instance(),
-      envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance()));
+      envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance(), randomGenerator));
   EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster", _)).WillOnce(Return(conn_info));
 
   ON_CALL(route_config_provider_.route_config_->route_->route_entry_, useWebSocket())
@@ -1396,6 +1399,7 @@ TEST_F(HttpConnectionManagerImplTest, WebSocketEarlyData) {
   NiceMock<Network::MockClientConnection>* upstream_connection =
       new NiceMock<Network::MockClientConnection>();
   Upstream::MockHost::MockCreateConnectionData conn_info;
+  Runtime::RandomGeneratorImpl randomGenerator;
 
   conn_info.connection_ = upstream_connection;
   conn_info.host_description_.reset(new Upstream::HostImpl(
@@ -1403,7 +1407,7 @@ TEST_F(HttpConnectionManagerImplTest, WebSocketEarlyData) {
       Network::Utility::resolveUrl("tcp://127.0.0.1:80"),
       envoy::api::v2::core::Metadata::default_instance(), 1,
       envoy::api::v2::core::Locality().default_instance(),
-      envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance()));
+      envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance(), randomGenerator));
   EXPECT_CALL(*connect_timer, enableTimer(_));
   EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster", _)).WillOnce(Return(conn_info));
 
@@ -1449,6 +1453,7 @@ TEST_F(HttpConnectionManagerImplTest, WebSocketEarlyEndStream) {
   NiceMock<Network::MockClientConnection>* upstream_connection =
       new NiceMock<Network::MockClientConnection>();
   Upstream::MockHost::MockCreateConnectionData conn_info;
+  Runtime::RandomGeneratorImpl randomGenerator;
 
   conn_info.connection_ = upstream_connection;
   conn_info.host_description_.reset(new Upstream::HostImpl(
@@ -1456,7 +1461,7 @@ TEST_F(HttpConnectionManagerImplTest, WebSocketEarlyEndStream) {
       Network::Utility::resolveUrl("tcp://127.0.0.1:80"),
       envoy::api::v2::core::Metadata::default_instance(), 1,
       envoy::api::v2::core::Locality().default_instance(),
-      envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance()));
+      envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance(), randomGenerator));
   EXPECT_CALL(*connect_timer, enableTimer(_));
   EXPECT_CALL(cluster_manager_, tcpConnForCluster_("fake_cluster", _)).WillOnce(Return(conn_info));
 

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -93,8 +93,8 @@ public:
     listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
 
     client_connection_ = dispatcher_->createClientConnection(
-        socket_.localAddress(), source_address_range_, Network::Test::createRawBufferSocket(), nullptr,
-        random_);
+        socket_.localAddress(), source_address_range_, Network::Test::createRawBufferSocket(),
+        nullptr, random_);
     client_connection_->addConnectionCallbacks(client_callbacks_);
     EXPECT_EQ(nullptr, client_connection_->ssl());
     const Network::ClientConnection& const_connection = *client_connection_;
@@ -243,8 +243,9 @@ TEST_P(ConnectionImplTest, ImmediateConnectError) {
     broadcast_address.reset(new Address::Ipv6Instance("ff02::1", 0));
   }
 
-  client_connection_ = dispatcher_->createClientConnection(
-      broadcast_address, source_address_range_, Network::Test::createRawBufferSocket(), nullptr, random_);
+  client_connection_ =
+      dispatcher_->createClientConnection(broadcast_address, source_address_range_,
+                                          Network::Test::createRawBufferSocket(), nullptr, random_);
   client_connection_->addConnectionCallbacks(client_callbacks_);
   client_connection_->connect();
 
@@ -787,9 +788,9 @@ TEST_P(ConnectionImplTest, BindFailureTest) {
   dispatcher_.reset(new Event::DispatcherImpl);
   listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
 
-  client_connection_ = dispatcher_->createClientConnection(
-      socket_.localAddress(), source_address_range_, Network::Test::createRawBufferSocket(), nullptr,
-      random_);
+  client_connection_ =
+      dispatcher_->createClientConnection(socket_.localAddress(), source_address_range_,
+                                          Network::Test::createRawBufferSocket(), nullptr, random_);
 
   MockConnectionStats connection_stats;
   client_connection_->setConnectionStats(connection_stats.toBufferStats());
@@ -1280,7 +1281,8 @@ TEST_P(TcpClientConnectionImplTest, BadConnectConnRefused) {
   ClientConnectionPtr connection = dispatcher.createClientConnection(
       Utility::resolveUrl(
           fmt::format("tcp://{}:1", Network::Test::getLoopbackAddressUrlString(GetParam()))),
-      Network::Address::InstanceRangeConstSharedPtr(), Network::Test::createRawBufferSocket(), nullptr, random_);
+      Network::Address::InstanceRangeConstSharedPtr(), Network::Test::createRawBufferSocket(),
+      nullptr, random_);
   connection->connect();
   connection->noDelay(true);
   dispatcher.run(Event::Dispatcher::RunType::Block);

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -35,7 +35,7 @@ static void errorCallbackTest(Address::IpVersion version) {
   Runtime::RandomGeneratorImpl random;
 
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
-      socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket.localAddress(), Network::Address::InstanceRangeConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr, random);
   client_connection->connect();
 
@@ -134,7 +134,7 @@ TEST_P(ListenerImplTest, UseActualDst) {
   Runtime::RandomGeneratorImpl random;
 
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
-      socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket.localAddress(), Network::Address::InstanceRangeConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr, random);
   client_connection->connect();
 
@@ -171,7 +171,7 @@ TEST_P(ListenerImplTest, WildcardListenerUseActualDst) {
   auto local_dst_address = Network::Utility::getAddressWithPort(
       *Network::Test::getCanonicalLoopbackAddress(version_), socket.localAddress()->ip()->port());
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
-      local_dst_address, Network::Address::InstanceConstSharedPtr(),
+      local_dst_address, Network::Address::InstanceRangeConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr, random);
   client_connection->connect();
 
@@ -221,7 +221,7 @@ TEST_P(ListenerImplTest, WildcardListenerIpv4Compat) {
   auto local_dst_address = Network::Utility::getAddressWithPort(
       *Network::Utility::getCanonicalIpv4LoopbackAddress(), socket.localAddress()->ip()->port());
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
-      local_dst_address, Network::Address::InstanceConstSharedPtr(),
+      local_dst_address, Network::Address::InstanceRangeConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr, random);
   client_connection->connect();
 

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -1,8 +1,8 @@
 #include "common/network/address_impl.h"
 #include "common/network/listener_impl.h"
 #include "common/network/utility.h"
-#include "common/stats/stats_impl.h"
 #include "common/runtime/runtime_impl.h"
+#include "common/stats/stats_impl.h"
 
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/mocks.h"

--- a/test/common/network/resolver_impl_test.cc
+++ b/test/common/network/resolver_impl_test.cc
@@ -90,6 +90,11 @@ public:
                                                           fmt::format("{}:{}", physical, port))};
   }
 
+  InstanceRangeConstSharedPtr
+  resolve(const envoy::api::v2::core::SocketAddressPortRange& socket_address) override {
+    throw EnvoyException("Not yet implemented");
+  }
+
   void addMapping(const std::string& logical, const std::string& physical) {
     name_mappings_[logical] = physical;
   }

--- a/test/common/ssl/ssl_socket_test.cc
+++ b/test/common/ssl/ssl_socket_test.cc
@@ -70,7 +70,7 @@ void testUtil(const std::string& client_ctx_json, const std::string& server_ctx_
   Ssl::ClientSslSocketFactory client_ssl_socket_factory(client_ctx_config, manager, stats_store);
   Runtime::RandomGeneratorImpl random;
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
-      socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket.localAddress(), Network::Address::InstanceRangeConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(), nullptr, random);
   client_connection->connect();
 
@@ -171,7 +171,7 @@ const std::string testUtilV2(const envoy::api::v2::Listener& server_proto,
   ClientContextPtr client_ctx(manager.createSslClientContext(stats_store, client_ctx_config));
   Runtime::RandomGeneratorImpl random;
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
-      socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket.localAddress(), Network::Address::InstanceRangeConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(), nullptr, random);
 
   if (!client_session.empty()) {
@@ -749,7 +749,7 @@ TEST_P(SslSocketTest, FlushCloseDuringHandshake) {
   Runtime::RandomGeneratorImpl random;
 
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
-      socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket.localAddress(), Network::Address::InstanceRangeConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr, random);
   client_connection->connect();
   Network::MockConnectionCallbacks client_connection_callbacks;
@@ -819,7 +819,7 @@ TEST_P(SslSocketTest, HalfClose) {
   ClientSslSocketFactory client_ssl_socket_factory(client_ctx_config, manager, stats_store);
   Runtime::RandomGeneratorImpl random;
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
-      socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket.localAddress(), Network::Address::InstanceRangeConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(), nullptr, random);
   client_connection->enableHalfClose(true);
   client_connection->addReadFilter(client_read_filter);
@@ -902,7 +902,7 @@ TEST_P(SslSocketTest, ClientAuthMultipleCAs) {
   ClientSslSocketFactory ssl_socket_factory(client_ctx_config, manager, stats_store);
   Runtime::RandomGeneratorImpl random;
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
-      socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket.localAddress(), Network::Address::InstanceRangeConstSharedPtr(),
       ssl_socket_factory.createTransportSocket(), nullptr, random);
 
   // Verify that server sent list with 2 acceptable client certificate CA names.
@@ -979,7 +979,7 @@ void testTicketSessionResumption(const std::string& server_ctx_json1,
   ClientContextConfigImpl client_ctx_config(*client_ctx_loader);
   ClientSslSocketFactory ssl_socket_factory(client_ctx_config, manager, stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
-      socket1.localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket1.localAddress(), Network::Address::InstanceRangeConstSharedPtr(),
       ssl_socket_factory.createTransportSocket(), nullptr, random);
 
   Network::MockConnectionCallbacks client_connection_callbacks;
@@ -1017,7 +1017,7 @@ void testTicketSessionResumption(const std::string& server_ctx_json1,
   EXPECT_EQ(0UL, stats_store.counter("ssl.session_reused").value());
 
   client_connection = dispatcher.createClientConnection(
-      socket2.localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket2.localAddress(), Network::Address::InstanceRangeConstSharedPtr(),
       ssl_socket_factory.createTransportSocket(), nullptr, random);
   client_connection->addConnectionCallbacks(client_connection_callbacks);
   Ssl::SslSocket* ssl_socket = dynamic_cast<Ssl::SslSocket*>(client_connection->ssl());
@@ -1311,7 +1311,7 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
   ClientSslSocketFactory ssl_socket_factory(client_ctx_config, manager, stats_store);
   Runtime::RandomGeneratorImpl random;
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
-      socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket.localAddress(), Network::Address::InstanceRangeConstSharedPtr(),
       ssl_socket_factory.createTransportSocket(), nullptr, random);
 
   Network::MockConnectionCallbacks client_connection_callbacks;
@@ -1357,7 +1357,7 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
 
   Runtime::RandomGeneratorImpl random;
   client_connection = dispatcher.createClientConnection(
-      socket2.localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket2.localAddress(), Network::Address::InstanceRangeConstSharedPtr(),
       ssl_socket_factory.createTransportSocket(), nullptr, random);
   client_connection->addConnectionCallbacks(client_connection_callbacks);
   Ssl::SslSocket* ssl_socket = dynamic_cast<Ssl::SslSocket*>(client_connection->ssl());
@@ -1409,7 +1409,7 @@ TEST_P(SslSocketTest, SslError) {
   Runtime::RandomGeneratorImpl random;
 
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
-      socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
+      socket.localAddress(), Network::Address::InstanceRangeConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr, random);
   client_connection->connect();
   Buffer::OwnedImpl bad_data("bad_handshake_data");

--- a/test/common/ssl/ssl_socket_test.cc
+++ b/test/common/ssl/ssl_socket_test.cc
@@ -68,9 +68,10 @@ void testUtil(const std::string& client_ctx_json, const std::string& server_ctx_
   Json::ObjectSharedPtr client_ctx_loader = TestEnvironment::jsonLoadFromString(client_ctx_json);
   ClientContextConfigImpl client_ctx_config(*client_ctx_loader);
   Ssl::ClientSslSocketFactory client_ssl_socket_factory(client_ctx_config, manager, stats_store);
+  Runtime::RandomGeneratorImpl random;
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
       socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
-      client_ssl_socket_factory.createTransportSocket(), nullptr);
+      client_ssl_socket_factory.createTransportSocket(), nullptr, random);
   client_connection->connect();
 
   Network::ConnectionPtr server_connection;
@@ -168,9 +169,10 @@ const std::string testUtilV2(const envoy::api::v2::Listener& server_proto,
   ClientContextConfigImpl client_ctx_config(client_ctx_proto);
   ClientSslSocketFactory client_ssl_socket_factory(client_ctx_config, manager, stats_store);
   ClientContextPtr client_ctx(manager.createSslClientContext(stats_store, client_ctx_config));
+  Runtime::RandomGeneratorImpl random;
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
       socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
-      client_ssl_socket_factory.createTransportSocket(), nullptr);
+      client_ssl_socket_factory.createTransportSocket(), nullptr, random);
 
   if (!client_session.empty()) {
     Ssl::SslSocket* ssl_socket = dynamic_cast<Ssl::SslSocket*>(client_connection->ssl());
@@ -744,10 +746,11 @@ TEST_P(SslSocketTest, FlushCloseDuringHandshake) {
   Network::MockListenerCallbacks callbacks;
   Network::MockConnectionHandler connection_handler;
   Network::ListenerPtr listener = dispatcher.createListener(socket, callbacks, true, false);
+  Runtime::RandomGeneratorImpl random;
 
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
       socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
-      Network::Test::createRawBufferSocket(), nullptr);
+      Network::Test::createRawBufferSocket(), nullptr, random);
   client_connection->connect();
   Network::MockConnectionCallbacks client_connection_callbacks;
   client_connection->addConnectionCallbacks(client_connection_callbacks);
@@ -814,9 +817,10 @@ TEST_P(SslSocketTest, HalfClose) {
   Json::ObjectSharedPtr client_ctx_loader = TestEnvironment::jsonLoadFromString(client_ctx_json);
   ClientContextConfigImpl client_ctx_config(*client_ctx_loader);
   ClientSslSocketFactory client_ssl_socket_factory(client_ctx_config, manager, stats_store);
+  Runtime::RandomGeneratorImpl random;
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
       socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
-      client_ssl_socket_factory.createTransportSocket(), nullptr);
+      client_ssl_socket_factory.createTransportSocket(), nullptr, random);
   client_connection->enableHalfClose(true);
   client_connection->addReadFilter(client_read_filter);
   client_connection->connect();
@@ -896,9 +900,10 @@ TEST_P(SslSocketTest, ClientAuthMultipleCAs) {
   Json::ObjectSharedPtr client_ctx_loader = TestEnvironment::jsonLoadFromString(client_ctx_json);
   ClientContextConfigImpl client_ctx_config(*client_ctx_loader);
   ClientSslSocketFactory ssl_socket_factory(client_ctx_config, manager, stats_store);
+  Runtime::RandomGeneratorImpl random;
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
       socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
-      ssl_socket_factory.createTransportSocket(), nullptr);
+      ssl_socket_factory.createTransportSocket(), nullptr, random);
 
   // Verify that server sent list with 2 acceptable client certificate CA names.
   Ssl::SslSocket* ssl_socket = dynamic_cast<Ssl::SslSocket*>(client_connection->ssl());
@@ -975,7 +980,7 @@ void testTicketSessionResumption(const std::string& server_ctx_json1,
   ClientSslSocketFactory ssl_socket_factory(client_ctx_config, manager, stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
       socket1.localAddress(), Network::Address::InstanceConstSharedPtr(),
-      ssl_socket_factory.createTransportSocket(), nullptr);
+      ssl_socket_factory.createTransportSocket(), nullptr, random);
 
   Network::MockConnectionCallbacks client_connection_callbacks;
   client_connection->addConnectionCallbacks(client_connection_callbacks);
@@ -1013,7 +1018,7 @@ void testTicketSessionResumption(const std::string& server_ctx_json1,
 
   client_connection = dispatcher.createClientConnection(
       socket2.localAddress(), Network::Address::InstanceConstSharedPtr(),
-      ssl_socket_factory.createTransportSocket(), nullptr);
+      ssl_socket_factory.createTransportSocket(), nullptr, random);
   client_connection->addConnectionCallbacks(client_connection_callbacks);
   Ssl::SslSocket* ssl_socket = dynamic_cast<Ssl::SslSocket*>(client_connection->ssl());
   SSL_set_session(ssl_socket->rawSslForTest(), ssl_session);
@@ -1304,9 +1309,10 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
   Json::ObjectSharedPtr client_ctx_loader = TestEnvironment::jsonLoadFromString(client_ctx_json);
   ClientContextConfigImpl client_ctx_config(*client_ctx_loader);
   ClientSslSocketFactory ssl_socket_factory(client_ctx_config, manager, stats_store);
+  Runtime::RandomGeneratorImpl random;
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
       socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
-      ssl_socket_factory.createTransportSocket(), nullptr);
+      ssl_socket_factory.createTransportSocket(), nullptr, random);
 
   Network::MockConnectionCallbacks client_connection_callbacks;
   client_connection->addConnectionCallbacks(client_connection_callbacks);

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -22,6 +22,7 @@ namespace Envoy {
 namespace Upstream {
 
 static HostSharedPtr newTestHost(Upstream::ClusterInfoConstSharedPtr cluster,
+                                 RandomGenerator& random,
                                  const std::string& url, uint32_t weight = 1,
                                  const std::string& zone = "") {
   envoy::api::v2::core::Locality locality;
@@ -29,7 +30,8 @@ static HostSharedPtr newTestHost(Upstream::ClusterInfoConstSharedPtr cluster,
   return HostSharedPtr{
       new HostImpl(cluster, "", Network::Utility::resolveUrl(url),
                    envoy::api::v2::core::Metadata::default_instance(), weight, locality,
-                   envoy::api::v2::endpoint::Endpoint::HealthCheckConfig::default_instance())};
+                   envoy::api::v2::endpoint::Endpoint::HealthCheckConfig::default_instance(),
+                   random)};
 }
 
 /**
@@ -133,7 +135,7 @@ public:
       const std::string zone = std::to_string(i);
       for (uint32_t j = 0; j < hosts[i]; ++j) {
         const std::string url = fmt::format("tcp://host.{}.{}:80", i, j);
-        ret->push_back(newTestHost(info_, url, 1, zone));
+        ret->push_back(newTestHost(info_, random_, url, 1, zone));
       }
     }
 
@@ -152,7 +154,7 @@ public:
 
       for (uint32_t j = 0; j < hosts[i]; ++j) {
         const std::string url = fmt::format("tcp://host.{}.{}:80", i, j);
-        zone_hosts.push_back(newTestHost(info_, url, 1, zone));
+        zone_hosts.push_back(newTestHost(info_, random, url, 1, zone));
       }
 
       ret.push_back(std::move(zone_hosts));
@@ -173,6 +175,7 @@ public:
   Stats::IsolatedStoreImpl stats_store_;
   ClusterStats stats_;
   envoy::api::v2::Cluster::CommonLbConfig common_config_;
+  Runtime::RandomGeneratorImpl random_;
 };
 
 TEST_F(DISABLED_SimulationTest, strictlyEqualDistribution) {

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -22,16 +22,14 @@ namespace Envoy {
 namespace Upstream {
 
 static HostSharedPtr newTestHost(Upstream::ClusterInfoConstSharedPtr cluster,
-                                 RandomGenerator& random,
-                                 const std::string& url, uint32_t weight = 1,
-                                 const std::string& zone = "") {
+                                 RandomGenerator& random, const std::string& url,
+                                 uint32_t weight = 1, const std::string& zone = "") {
   envoy::api::v2::core::Locality locality;
   locality.set_zone(zone);
-  return HostSharedPtr{
-      new HostImpl(cluster, "", Network::Utility::resolveUrl(url),
-                   envoy::api::v2::core::Metadata::default_instance(), weight, locality,
-                   envoy::api::v2::endpoint::Endpoint::HealthCheckConfig::default_instance(),
-                   random)};
+  return HostSharedPtr{new HostImpl(
+      cluster, "", Network::Utility::resolveUrl(url),
+      envoy::api::v2::core::Metadata::default_instance(), weight, locality,
+      envoy::api::v2::endpoint::Endpoint::HealthCheckConfig::default_instance(), random)};
 }
 
 /**

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -685,7 +685,7 @@ TEST(StaticClusterImplTest, SourceAddressPriority) {
     NiceMock<MockClusterManager> cm;
     cm.bind_config_.mutable_source_address()->set_address("1.2.3.5");
     StaticClusterImpl cluster(config, runtime, stats, ssl_context_manager, cm, false);
-    EXPECT_EQ("1.2.3.5:0", cluster.info()->sourceAddress()->asString());
+    EXPECT_EQ("1.2.3.5:0", cluster.info()->sourceAddressRange()->asString());
   }
 
   const std::string cluster_address = "5.6.7.8";
@@ -694,7 +694,7 @@ TEST(StaticClusterImplTest, SourceAddressPriority) {
     // Verify source address from cluster config is used when present.
     NiceMock<MockClusterManager> cm;
     StaticClusterImpl cluster(config, runtime, stats, ssl_context_manager, cm, false);
-    EXPECT_EQ(cluster_address, cluster.info()->sourceAddress()->ip()->addressAsString());
+    EXPECT_EQ(cluster_address, cluster.info()->sourceAddressRange()->ip()->addressAsString());
   }
 
   {
@@ -702,7 +702,7 @@ TEST(StaticClusterImplTest, SourceAddressPriority) {
     NiceMock<MockClusterManager> cm;
     cm.bind_config_.mutable_source_address()->set_address("1.2.3.5");
     StaticClusterImpl cluster(config, runtime, stats, ssl_context_manager, cm, false);
-    EXPECT_EQ(cluster_address, cluster.info()->sourceAddress()->ip()->addressAsString());
+    EXPECT_EQ(cluster_address, cluster.info()->sourceAddressRange()->ip()->addressAsString());
   }
 }
 

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -343,9 +343,11 @@ TEST(HostImplTest, HostnameCanaryAndLocality) {
   locality.set_region("oceania");
   locality.set_zone("hello");
   locality.set_sub_zone("world");
+  Runtime::RandomGeneratorImpl randomGenerator;
   HostImpl host(cluster.info_, "lyft.com", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"),
                 metadata, 1, locality,
-                envoy::api::v2::endpoint::Endpoint::HealthCheckConfig::default_instance());
+                envoy::api::v2::endpoint::Endpoint::HealthCheckConfig::default_instance(),
+                randomGenerator);
   EXPECT_EQ(cluster.info_.get(), &host.cluster());
   EXPECT_EQ("lyft.com", host.hostname());
   EXPECT_TRUE(host.canary());

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -47,9 +47,9 @@ public:
         connection_handler_(new Server::ConnectionHandlerImpl(ENVOY_LOGGER(), dispatcher_)),
         name_("proxy") {
     connection_handler_->addListener(*this);
-    conn_ = dispatcher_.createClientConnection(socket_.localAddress(),
-                                               Network::Address::InstanceRangeConstSharedPtr(),
-                                               Network::Test::createRawBufferSocket(), nullptr, random_);
+    conn_ = dispatcher_.createClientConnection(
+        socket_.localAddress(), Network::Address::InstanceRangeConstSharedPtr(),
+        Network::Test::createRawBufferSocket(), nullptr, random_);
     conn_->addConnectionCallbacks(connection_callbacks_);
   }
 
@@ -332,9 +332,9 @@ public:
         connection_handler_(new Server::ConnectionHandlerImpl(ENVOY_LOGGER(), dispatcher_)),
         name_("proxy") {
     connection_handler_->addListener(*this);
-    conn_ = dispatcher_.createClientConnection(local_dst_address_,
-                                               Network::Address::InstanceRangeConstSharedPtr(),
-                                               Network::Test::createRawBufferSocket(), nullptr, random_);
+    conn_ = dispatcher_.createClientConnection(
+        local_dst_address_, Network::Address::InstanceRangeConstSharedPtr(),
+        Network::Test::createRawBufferSocket(), nullptr, random_);
     conn_->addConnectionCallbacks(connection_callbacks_);
 
     EXPECT_CALL(factory_, createListenerFilterChain(_))

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -48,7 +48,7 @@ public:
         name_("proxy") {
     connection_handler_->addListener(*this);
     conn_ = dispatcher_.createClientConnection(socket_.localAddress(),
-                                               Network::Address::InstanceConstSharedPtr(),
+                                               Network::Address::InstanceRangeConstSharedPtr(),
                                                Network::Test::createRawBufferSocket(), nullptr, random_);
     conn_->addConnectionCallbacks(connection_callbacks_);
   }
@@ -333,7 +333,7 @@ public:
         name_("proxy") {
     connection_handler_->addListener(*this);
     conn_ = dispatcher_.createClientConnection(local_dst_address_,
-                                               Network::Address::InstanceConstSharedPtr(),
+                                               Network::Address::InstanceRangeConstSharedPtr(),
                                                Network::Test::createRawBufferSocket(), nullptr, random_);
     conn_->addConnectionCallbacks(connection_callbacks_);
 

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -49,7 +49,7 @@ public:
     connection_handler_->addListener(*this);
     conn_ = dispatcher_.createClientConnection(socket_.localAddress(),
                                                Network::Address::InstanceConstSharedPtr(),
-                                               Network::Test::createRawBufferSocket(), nullptr);
+                                               Network::Test::createRawBufferSocket(), nullptr, random_);
     conn_->addConnectionCallbacks(connection_callbacks_);
   }
 
@@ -138,6 +138,7 @@ public:
   Network::MockConnectionCallbacks server_callbacks_;
   std::shared_ptr<Network::MockReadFilter> read_filter_;
   std::string name_;
+  Runtime::RandomGeneratorImpl random;
 };
 
 // Parameterize the listener socket address version.
@@ -333,7 +334,7 @@ public:
     connection_handler_->addListener(*this);
     conn_ = dispatcher_.createClientConnection(local_dst_address_,
                                                Network::Address::InstanceConstSharedPtr(),
-                                               Network::Test::createRawBufferSocket(), nullptr);
+                                               Network::Test::createRawBufferSocket(), nullptr, random_);
     conn_->addConnectionCallbacks(connection_callbacks_);
 
     EXPECT_CALL(factory_, createListenerFilterChain(_))
@@ -412,6 +413,7 @@ public:
   Network::MockConnectionCallbacks server_callbacks_;
   std::shared_ptr<Network::MockReadFilter> read_filter_;
   std::string name_;
+  Runtime::RandomGeneratorImpl random;
 };
 
 // Parameterize the listener socket address version.

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -26,7 +26,7 @@ envoy_cc_test(
         "//source/common/config:protobuf_link_hacks",
         "//source/common/config:resources_lib",
         "//source/common/protobuf:utility_lib",
-	"//source/common/runtime:runtime_lib",
+        "//source/common/runtime:runtime_lib",
         "//source/common/ssl:context_config_lib",
         "//source/common/ssl:context_lib",
         "//source/common/ssl:ssl_socket_lib",
@@ -402,8 +402,8 @@ envoy_cc_test(
         "//source/common/event:dispatcher_includes",
         "//source/common/event:dispatcher_lib",
         "//source/common/http:codec_client_lib",
-        "//source/common/stats:stats_lib",
         "//source/common/runtime:runtime_lib",
+        "//source/common/stats:stats_lib",
         "//test/test_common:environment_lib",
     ],
 )

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -26,6 +26,7 @@ envoy_cc_test(
         "//source/common/config:protobuf_link_hacks",
         "//source/common/config:resources_lib",
         "//source/common/protobuf:utility_lib",
+	"//source/common/runtime:runtime_lib",
         "//source/common/ssl:context_config_lib",
         "//source/common/ssl:context_lib",
         "//source/common/ssl:ssl_socket_lib",
@@ -402,6 +403,7 @@ envoy_cc_test(
         "//source/common/event:dispatcher_lib",
         "//source/common/http:codec_client_lib",
         "//source/common/stats:stats_lib",
+        "//source/common/runtime:runtime_lib",
         "//test/test_common:environment_lib",
     ],
 )
@@ -429,6 +431,7 @@ envoy_cc_test(
     deps = [
         ":http_integration_lib",
         "//source/common/http:header_map_lib",
+        "//source/common/runtime:runtime_lib",
         "//source/extensions/transport_sockets/ssl:config",
         "//test/test_common:utility_lib",
     ],

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -140,7 +140,7 @@ IntegrationTcpClient::IntegrationTcpClient(Event::Dispatcher& dispatcher,
   connection_ = dispatcher.createClientConnection(
       Network::Utility::resolveUrl(
           fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version), port)),
-      Network::Address::InstanceConstSharedPtr(), Network::Test::createRawBufferSocket(), nullptr, random);
+      Network::Address::InstanceRangeConstSharedPtr(), Network::Test::createRawBufferSocket(), nullptr, random);
 
   ON_CALL(*client_write_buffer_, drain(_))
       .WillByDefault(testing::Invoke(client_write_buffer_, &MockWatermarkBuffer::baseDrain));
@@ -222,7 +222,7 @@ Network::ClientConnectionPtr BaseIntegrationTest::makeClientConnection(uint32_t 
   Network::ClientConnectionPtr connection(dispatcher_->createClientConnection(
       Network::Utility::resolveUrl(
           fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version_), port)),
-      Network::Address::InstanceConstSharedPtr(), Network::Test::createRawBufferSocket(), nullptr, random_));
+      Network::Address::InstanceRangeConstSharedPtr(), Network::Test::createRawBufferSocket(), nullptr, random_));
 
   connection->enableHalfClose(enable_half_close_);
   return connection;

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -136,10 +136,11 @@ IntegrationTcpClient::IntegrationTcpClient(Event::Dispatcher& dispatcher,
         return client_write_buffer_;
       }));
 
+  Runtime::RandomGeneratorImpl random;
   connection_ = dispatcher.createClientConnection(
       Network::Utility::resolveUrl(
           fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version), port)),
-      Network::Address::InstanceConstSharedPtr(), Network::Test::createRawBufferSocket(), nullptr);
+      Network::Address::InstanceConstSharedPtr(), Network::Test::createRawBufferSocket(), nullptr, random);
 
   ON_CALL(*client_write_buffer_, drain(_))
       .WillByDefault(testing::Invoke(client_write_buffer_, &MockWatermarkBuffer::baseDrain));
@@ -221,7 +222,7 @@ Network::ClientConnectionPtr BaseIntegrationTest::makeClientConnection(uint32_t 
   Network::ClientConnectionPtr connection(dispatcher_->createClientConnection(
       Network::Utility::resolveUrl(
           fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version_), port)),
-      Network::Address::InstanceConstSharedPtr(), Network::Test::createRawBufferSocket(), nullptr));
+      Network::Address::InstanceConstSharedPtr(), Network::Test::createRawBufferSocket(), nullptr, random_));
 
   connection->enableHalfClose(enable_half_close_);
   return connection;

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -140,7 +140,8 @@ IntegrationTcpClient::IntegrationTcpClient(Event::Dispatcher& dispatcher,
   connection_ = dispatcher.createClientConnection(
       Network::Utility::resolveUrl(
           fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version), port)),
-      Network::Address::InstanceRangeConstSharedPtr(), Network::Test::createRawBufferSocket(), nullptr, random);
+      Network::Address::InstanceRangeConstSharedPtr(), Network::Test::createRawBufferSocket(),
+      nullptr, random);
 
   ON_CALL(*client_write_buffer_, drain(_))
       .WillByDefault(testing::Invoke(client_write_buffer_, &MockWatermarkBuffer::baseDrain));
@@ -222,7 +223,8 @@ Network::ClientConnectionPtr BaseIntegrationTest::makeClientConnection(uint32_t 
   Network::ClientConnectionPtr connection(dispatcher_->createClientConnection(
       Network::Utility::resolveUrl(
           fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version_), port)),
-      Network::Address::InstanceRangeConstSharedPtr(), Network::Test::createRawBufferSocket(), nullptr, random_));
+      Network::Address::InstanceRangeConstSharedPtr(), Network::Test::createRawBufferSocket(),
+      nullptr, random_));
 
   connection->enableHalfClose(enable_half_close_);
   return connection;

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -201,6 +201,7 @@ protected:
   bool enable_half_close_{false};
 
   Runtime::RandomGeneratorImpl random_;
+
 private:
   // The codec type for the client-to-Envoy connection
   Http::CodecClient::Type downstream_protocol_{Http::CodecClient::Type::HTTP1};

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -7,6 +7,8 @@
 
 #include "common/http/codec_client.h"
 
+#include "source/common/runtime/runtime_impl.h"
+
 #include "test/config/utility.h"
 #include "test/integration/fake_upstream.h"
 #include "test/integration/server.h"
@@ -198,6 +200,7 @@ protected:
 
   bool enable_half_close_{false};
 
+  Runtime::RandomGeneratorImpl random_;
 private:
   // The codec type for the client-to-Envoy connection
   Http::CodecClient::Type downstream_protocol_{Http::CodecClient::Type::HTTP1};

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -54,12 +54,12 @@ Network::ClientConnectionPtr SslIntegrationTest::makeSslClientConnection(bool al
         address, Network::Address::InstanceConstSharedPtr(),
         san ? client_ssl_ctx_alpn_san_->createTransportSocket()
             : client_ssl_ctx_alpn_->createTransportSocket(),
-        nullptr);
+        nullptr, random_);
   } else {
     return dispatcher_->createClientConnection(address, Network::Address::InstanceConstSharedPtr(),
                                                san ? client_ssl_ctx_san_->createTransportSocket()
                                                    : client_ssl_ctx_plain_->createTransportSocket(),
-                                               nullptr);
+                                               nullptr, random_);
   }
 }
 

--- a/test/integration/ssl_integration_test.h
+++ b/test/integration/ssl_integration_test.h
@@ -3,6 +3,8 @@
 #include <memory>
 #include <string>
 
+#include "source/common/runtime/runtime_impl.h"
+
 #include "test/integration/http_integration.h"
 #include "test/integration/server.h"
 #include "test/mocks/runtime/mocks.h"
@@ -36,6 +38,7 @@ private:
   Network::TransportSocketFactoryPtr client_ssl_ctx_alpn_;
   Network::TransportSocketFactoryPtr client_ssl_ctx_san_;
   Network::TransportSocketFactoryPtr client_ssl_ctx_alpn_san_;
+  Runtime::RandomGeneratorImpl random_;
 };
 
 } // namespace Ssl

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -293,7 +293,7 @@ void TcpProxySslIntegrationTest::setupConnections() {
       Ssl::getSslAddress(version_, lookupPort("tcp_proxy"));
   context_ = Ssl::createClientSslTransportSocketFactory(false, false, *context_manager_);
   ssl_client_ =
-      dispatcher_->createClientConnection(address, Network::Address::InstanceConstSharedPtr(),
+      dispatcher_->createClientConnection(address, Network::Address::InstanceRangeConstSharedPtr(),
                                           context_->createTransportSocket(), nullptr);
 
   // Perform the SSL handshake. Loopback is whitelisted in tcp_proxy.json for the ssl_auth

--- a/test/integration/tcp_proxy_integration_test.h
+++ b/test/integration/tcp_proxy_integration_test.h
@@ -3,6 +3,8 @@
 #include <memory>
 #include <string>
 
+#include "source/common/runtime/runtime_impl.h"
+
 #include "test/integration/integration.h"
 #include "test/mocks/runtime/mocks.h"
 
@@ -40,6 +42,7 @@ public:
   ConnectionStatusCallbacks connect_callbacks_;
   MockWatermarkBuffer* client_write_buffer_;
   std::shared_ptr<WaitForPayloadReader> payload_reader_;
+  Runtime::RandomGeneratorImpl random;
 };
 
 } // namespace

--- a/test/integration/uds_integration_test.cc
+++ b/test/integration/uds_integration_test.cc
@@ -68,7 +68,7 @@ HttpIntegrationTest::ConnectionCreationFunction UdsListenerIntegrationTest::crea
   return [&]() -> Network::ClientConnectionPtr {
     Network::ClientConnectionPtr conn(dispatcher_->createClientConnection(
         Network::Utility::resolveUrl(fmt::format("unix://{}", getListenerSocketName())),
-        Network::Address::InstanceConstSharedPtr(), Network::Test::createRawBufferSocket(),
+        Network::Address::InstanceRangeConstSharedPtr(), Network::Test::createRawBufferSocket(),
         nullptr));
     conn->enableHalfClose(enable_half_close_);
     return conn;

--- a/test/integration/uds_integration_test.h
+++ b/test/integration/uds_integration_test.h
@@ -6,6 +6,8 @@
 #include "common/http/codec_client.h"
 #include "common/stats/stats_impl.h"
 
+#include "source/common/runtime/runtime_impl.h"
+
 #include "test/integration/fake_upstream.h"
 #include "test/integration/http_integration.h"
 #include "test/integration/server.h"
@@ -46,6 +48,7 @@ public:
 
 protected:
   const bool abstract_namespace_;
+  Runtime::RandomGeneratorImpl random;
 };
 
 class UdsListenerIntegrationTest

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -104,7 +104,8 @@ RawConnectionDriver::RawConnectionDriver(uint32_t port, Buffer::Instance& initia
   client_ = dispatcher_->createClientConnection(
       Network::Utility::resolveUrl(
           fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version), port)),
-      Network::Address::InstanceRangeConstSharedPtr(), Network::Test::createRawBufferSocket(), nullptr);
+      Network::Address::InstanceRangeConstSharedPtr(), Network::Test::createRawBufferSocket(),
+      nullptr);
   client_->addReadFilter(Network::ReadFilterSharedPtr{new ForwardingFilter(*this, data_callback)});
   client_->write(initial_data, false);
   client_->connect();

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -63,7 +63,7 @@ IntegrationUtil::makeSingleRequest(const Network::Address::InstanceConstSharedPt
       Upstream::makeTestHostDescription(cluster, "tcp://127.0.0.1:80")};
   Http::CodecClientProd client(
       type,
-      dispatcher->createClientConnection(addr, Network::Address::InstanceConstSharedPtr(),
+      dispatcher->createClientConnection(addr, Network::Address::InstanceRangeConstSharedPtr(),
                                          Network::Test::createRawBufferSocket(), nullptr),
       host_description, *dispatcher);
   BufferingStreamDecoderPtr response(new BufferingStreamDecoder([&]() -> void {
@@ -104,7 +104,7 @@ RawConnectionDriver::RawConnectionDriver(uint32_t port, Buffer::Instance& initia
   client_ = dispatcher_->createClientConnection(
       Network::Utility::resolveUrl(
           fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version), port)),
-      Network::Address::InstanceConstSharedPtr(), Network::Test::createRawBufferSocket(), nullptr);
+      Network::Address::InstanceRangeConstSharedPtr(), Network::Test::createRawBufferSocket(), nullptr);
   client_->addReadFilter(Network::ReadFilterSharedPtr{new ForwardingFilter(*this, data_callback)});
   client_->write(initial_data, false);
   client_->connect();

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -83,7 +83,7 @@ Network::ClientConnectionPtr XfccIntegrationTest::makeClientConnection() {
   Network::Address::InstanceConstSharedPtr address =
       Network::Utility::resolveUrl("tcp://" + Network::Test::getLoopbackAddressUrlString(version_) +
                                    ":" + std::to_string(lookupPort("http")));
-  return dispatcher_->createClientConnection(address, Network::Address::InstanceConstSharedPtr(),
+  return dispatcher_->createClientConnection(address, Network::Address::InstanceRangeConstSharedPtr(),
                                              Network::Test::createRawBufferSocket(), nullptr, random_);
 }
 
@@ -91,7 +91,7 @@ Network::ClientConnectionPtr XfccIntegrationTest::makeMtlsClientConnection() {
   Network::Address::InstanceConstSharedPtr address =
       Network::Utility::resolveUrl("tcp://" + Network::Test::getLoopbackAddressUrlString(version_) +
                                    ":" + std::to_string(lookupPort("http")));
-  return dispatcher_->createClientConnection(address, Network::Address::InstanceConstSharedPtr(),
+  return dispatcher_->createClientConnection(address, Network::Address::InstanceRangeConstSharedPtr(),
                                              client_mtls_ssl_ctx_->createTransportSocket(),
                                              nullptr, random_);
 }

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -83,17 +83,18 @@ Network::ClientConnectionPtr XfccIntegrationTest::makeClientConnection() {
   Network::Address::InstanceConstSharedPtr address =
       Network::Utility::resolveUrl("tcp://" + Network::Test::getLoopbackAddressUrlString(version_) +
                                    ":" + std::to_string(lookupPort("http")));
-  return dispatcher_->createClientConnection(address, Network::Address::InstanceRangeConstSharedPtr(),
-                                             Network::Test::createRawBufferSocket(), nullptr, random_);
+  return dispatcher_->createClientConnection(
+      address, Network::Address::InstanceRangeConstSharedPtr(),
+      Network::Test::createRawBufferSocket(), nullptr, random_);
 }
 
 Network::ClientConnectionPtr XfccIntegrationTest::makeMtlsClientConnection() {
   Network::Address::InstanceConstSharedPtr address =
       Network::Utility::resolveUrl("tcp://" + Network::Test::getLoopbackAddressUrlString(version_) +
                                    ":" + std::to_string(lookupPort("http")));
-  return dispatcher_->createClientConnection(address, Network::Address::InstanceRangeConstSharedPtr(),
-                                             client_mtls_ssl_ctx_->createTransportSocket(),
-                                             nullptr, random_);
+  return dispatcher_->createClientConnection(
+      address, Network::Address::InstanceRangeConstSharedPtr(),
+      client_mtls_ssl_ctx_->createTransportSocket(), nullptr, random_);
 }
 
 void XfccIntegrationTest::createUpstreams() {

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -84,7 +84,7 @@ Network::ClientConnectionPtr XfccIntegrationTest::makeClientConnection() {
       Network::Utility::resolveUrl("tcp://" + Network::Test::getLoopbackAddressUrlString(version_) +
                                    ":" + std::to_string(lookupPort("http")));
   return dispatcher_->createClientConnection(address, Network::Address::InstanceConstSharedPtr(),
-                                             Network::Test::createRawBufferSocket(), nullptr);
+                                             Network::Test::createRawBufferSocket(), nullptr, random_);
 }
 
 Network::ClientConnectionPtr XfccIntegrationTest::makeMtlsClientConnection() {
@@ -93,7 +93,7 @@ Network::ClientConnectionPtr XfccIntegrationTest::makeMtlsClientConnection() {
                                    ":" + std::to_string(lookupPort("http")));
   return dispatcher_->createClientConnection(address, Network::Address::InstanceConstSharedPtr(),
                                              client_mtls_ssl_ctx_->createTransportSocket(),
-                                             nullptr);
+                                             nullptr, random_);
 }
 
 void XfccIntegrationTest::createUpstreams() {

--- a/test/integration/xfcc_integration_test.h
+++ b/test/integration/xfcc_integration_test.h
@@ -3,6 +3,8 @@
 #include <memory>
 #include <string>
 
+#include "source/envoy/common/runtime/runtime_impl.h"
+
 #include "test/integration/http_integration.h"
 #include "test/integration/server.h"
 #include "test/mocks/runtime/mocks.h"
@@ -55,6 +57,7 @@ private:
   Network::TransportSocketFactoryPtr client_tls_ssl_ctx_;
   Network::TransportSocketFactoryPtr client_mtls_ssl_ctx_;
   Network::TransportSocketFactoryPtr upstream_ssl_ctx_;
+  RandomGeneratorImpl random_;
 };
 } // namespace Xfcc
 } // namespace Envoy

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -39,7 +39,8 @@ public:
   createClientConnection(Network::Address::InstanceConstSharedPtr address,
                          Network::Address::InstanceConstSharedPtr source_address,
                          Network::TransportSocketPtr&& transport_socket,
-                         const Network::ConnectionSocket::OptionsSharedPtr& options) override {
+                         const Network::ConnectionSocket::OptionsSharedPtr& options,
+                         RandomGenerator&) override {
     return Network::ClientConnectionPtr{
         createClientConnection_(address, source_address, transport_socket, options)};
   }

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -37,12 +37,12 @@ public:
 
   Network::ClientConnectionPtr
   createClientConnection(Network::Address::InstanceConstSharedPtr address,
-                         Network::Address::InstanceConstSharedPtr source_address,
+                         Network::Address::InstanceRangeConstSharedPtr source_address_range,
                          Network::TransportSocketPtr&& transport_socket,
                          const Network::ConnectionSocket::OptionsSharedPtr& options,
                          RandomGenerator&) override {
     return Network::ClientConnectionPtr{
-        createClientConnection_(address, source_address, transport_socket, options)};
+        createClientConnection_(address, source_address_range, transport_socket, options)};
   }
 
   FileEventPtr createFileEvent(int fd, FileReadyCb cb, FileTriggerType trigger,
@@ -82,7 +82,7 @@ public:
   MOCK_METHOD4(
       createClientConnection_,
       Network::ClientConnection*(Network::Address::InstanceConstSharedPtr address,
-                                 Network::Address::InstanceConstSharedPtr source_address,
+                                 Network::Address::InstanceRangeConstSharedPtr source_address,
                                  Network::TransportSocketPtr& transport_socket,
                                  const Network::ConnectionSocket::OptionsSharedPtr& options));
   MOCK_METHOD1(createDnsResolver,

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -157,9 +157,8 @@ public:
 
   MOCK_METHOD1(resolve,
                Address::InstanceConstSharedPtr(const envoy::api::v2::core::SocketAddress&));
-  MOCK_METHOD1(resolve,
-               Address::InstanceRangeConstSharedPtr(
-                   const envoy::api::v2::core::SocketAddressPortRange&));
+  MOCK_METHOD1(resolve, Address::InstanceRangeConstSharedPtr(
+                            const envoy::api::v2::core::SocketAddressPortRange&));
   MOCK_CONST_METHOD0(name, std::string());
 };
 

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -157,6 +157,9 @@ public:
 
   MOCK_METHOD1(resolve,
                Address::InstanceConstSharedPtr(const envoy::api::v2::core::SocketAddress&));
+  MOCK_METHOD1(resolve,
+               Address::InstanceRangeConstSharedPtr(
+                   const envoy::api::v2::core::SocketAddressPortRange&));
   MOCK_CONST_METHOD0(name, std::string());
 };
 

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -59,7 +59,7 @@ public:
   MOCK_CONST_METHOD0(stats, ClusterStats&());
   MOCK_CONST_METHOD0(statsScope, Stats::Scope&());
   MOCK_CONST_METHOD0(loadReportStats, ClusterLoadReportStats&());
-  MOCK_CONST_METHOD0(sourceAddress, const Network::Address::InstanceConstSharedPtr&());
+  MOCK_CONST_METHOD0(sourceAddressRange, const Network::Address::InstanceRangeConstSharedPtr&());
   MOCK_CONST_METHOD0(lbSubsetInfo, const LoadBalancerSubsetInfo&());
   MOCK_CONST_METHOD0(metadata, const envoy::api::v2::core::Metadata&());
 

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -167,7 +167,7 @@ public:
   MOCK_CONST_METHOD0(localClusterName, const std::string&());
   MOCK_METHOD1(addThreadLocalClusterUpdateCallbacks,
                std::unique_ptr<ClusterUpdateCallbacksHandle>(ClusterUpdateCallbacks& callbacks));
-  MOCK_METHOD0(randomGenerator, Envoy::Runtime::RandomGenerator&());
+  MOCK_METHOD0(randomGenerator, Runtime::RandomGenerator&());
 
   NiceMock<Http::ConnectionPool::MockInstance> conn_pool_;
   NiceMock<Http::MockAsyncClient> async_client_;

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -167,6 +167,7 @@ public:
   MOCK_CONST_METHOD0(localClusterName, const std::string&());
   MOCK_METHOD1(addThreadLocalClusterUpdateCallbacks,
                std::unique_ptr<ClusterUpdateCallbacksHandle>(ClusterUpdateCallbacks& callbacks));
+  MOCK_METHOD0(randomGenerator, Envoy::Runtime::RandomGenerator&());
 
   NiceMock<Http::ConnectionPool::MockInstance> conn_pool_;
   NiceMock<Http::MockAsyncClient> async_client_;


### PR DESCRIPTION
*title*: WIP: Allow specification of a port range to bind to on the source when connecting upstream.

*Description*:
Allow specification in cluster or bootstrap configuration of a port range (rather than just a single
port) to bind the local socket to when connecting to an upstream cluster.

This is a Work In Progress.  Specifically, I don't believe the tests compile yet; please completely ignore tests.  I'm looking for high level feedback, specifically around the following issues:
+ The basic data schema chosen, including naming, both for API and implementation.  This is captured by the changes to address.proto, address.h, and address_impl.h.  A minor style question on the .proto file: I've copied documentation in common between SocketAddress and SocketAddressPortRange; should I instead just reference SocketAddress from SocketAddressPortRange? 

+ Whether the (large amount of) plumbing looks acceptable.  This is primarily plumbing access to a RandomGenerator everywhere it's needed.  One possible modification: I could save a reference to the RandomGenerator in the InstanceRange when it's created, which would allow InstanceRange::bind() to not take a RandomGenerator, and avoid the plumbing through HostImpl, Dispatcher::createClientConnection, and ClientConnectionImpl.  I suspect this is worth doing, but I wanted to hold on feedback in case larger changes that would subsume this one were required.

+ Are there any lifetime issues I should be aware of passing around and holding onto references?  

*Risk Level*: Medium 

*Testing*:
None yet; WIP.

*Docs Changes*:
N/A

*Release Notes*:
>If this change is user impacting you **must** add a release note to
[version_history.rst](docs/root/intro/version_history.rst). Please include any relevant links. Each
release note should be prefixed with the relevant subsystem in alphabetical order (see existing
examples as a guide) and include links to relevant parts of the documentation. Thank you! Please
write in N/A if there are no release notes.

Fixes #3010 
