### PR TITLE
tests: Fix out of bounds error in conn_pool_test

### DIFF
--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -520,17 +520,17 @@ TEST_F(Http1ConnPoolImplTest, ConnectionCloseWithoutHeader) {
 
   conn_pool_.expectAndRunUpstreamReady();
 
-  EXPECT_CALL(*conn_pool_.test_clients_[1].codec_, newStream(_))
+  EXPECT_CALL(*conn_pool_.test_clients_[0].codec_, newStream(_))
       .WillOnce(DoAll(SaveArgAddress(&inner_decoder), ReturnRef(request_encoder)));
   EXPECT_CALL(callbacks2.pool_ready_, ready());
-  conn_pool_.test_clients_[1].connection_->raiseEvent(Network::ConnectionEvent::Connected);
+  conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::Connected);
 
   callbacks2.outer_encoder_->encodeHeaders(TestHeaderMapImpl{}, true);
   response_headers.reset(new TestHeaderMapImpl{{":status", "200"}});
   inner_decoder->decodeHeaders(std::move(response_headers), true);
 
   EXPECT_CALL(conn_pool_, onClientDestroy());
-  conn_pool_.test_clients_[1].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   dispatcher_.clearDeferredDeleteList();
 }
 


### PR DESCRIPTION
tests: Fix out of bounds error in conn_pool_test

The call to dispatcher_.clearDeferredDeleteList(); on line 519 deletes conn_pool_.test_clients_[0], and causing element 1 to shift over to index 0. This test was causing us to see a std::out_of_range exception.

(as a side note,  I'm surprised that there's no bounds checking in any part of our CI)

Signed-off-by: Kyle Myerson <kmyerson@google.com>