### PR TITLE
Throw an exception instead of crashing when socket creation fails.

### DIFF
--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -128,7 +128,10 @@ int InstanceBase::socketFromSocketType(SocketType socketType) const {
   }
 
   int fd = ::socket(domain, flags, 0);
-  RELEASE_ASSERT(fd != -1);
+  if (fd == -1) {
+    throw EnvoyException(
+        fmt::format("socket failed for '{}, {}, {}': {}", domain, flags, 0, strerror(errno)));
+  }
 
 #ifdef __APPLE__
   // Cannot set SOCK_NONBLOCK as a ::socket flag.


### PR DESCRIPTION
Throw an exception instead of crashing when socket creation fails.

Trying to open an IPv4 socket in an IPv6 only environment will cause the call to ::socket to fail. This could happen if the bootstrap config specified an IPv4 address for the admin interface, for example.

Signed-off-by: Kyle Myerson <kmyerson@google.com>
