### PR TITLE
add more precise detail for grpc json transcoder doc

### DIFF
--- a/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
+++ b/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
@@ -23,10 +23,11 @@ message GrpcJsonTranscoder {
     bytes proto_descriptor_bin = 4;
   }
 
-  // A list of strings that supplies the service names that the
-  // transcoder will translate. If the service name doesn't exist in ``proto_descriptor``, Envoy
-  // will fail at startup. The ``proto_descriptor`` may contain more services than the service names
-  // specified here, but they won't be translated.
+  // A list of strings that
+  // supplies the fully qualified service names (i.e. "package_name.service_name") that
+  // the transcoder will translate. If the service name doesn't exist in ``proto_descriptor``,
+  // Envoy will fail at startup. The ``proto_descriptor`` may contain more services than 
+  // the service names specified here, but they won't be translated.
   repeated string services = 2 [(validate.rules).repeated .min_items = 1];
 
   message PrintOptions {

--- a/docs/root/api-v1/http_filters/grpc_json_transcoder_filter.rst
+++ b/docs/root/api-v1/http_filters/grpc_json_transcoder_filter.rst
@@ -33,9 +33,10 @@ proto_descriptor
   services.
 
 services
-  *(required, array)* A list of strings that supplies the service names that the
-  transcoder will translate. If the service name doesn't exist in ``proto_descriptor``, Envoy
-  will fail at startup. The ``proto_descriptor`` may contain more services than the service names
+  *(required, array)* A list of strings that supplies the fully qualified service names
+  (i.e. "package_name.service_name") that the transcoder will translate.
+  If the service name doesn't exist in ``proto_descriptor``, Envoy will fail at startup. 
+  The ``proto_descriptor`` may contain more services than the service names
   specified here, but they won't be translated.
 
 print_options


### PR DESCRIPTION
When I checked the grpc json transcoder in envoy document, it's hard to figure out the value of `services ` config parameter, after tries all possible combination. I found the correct value was `package_name.service_name`, perhaps the documentation could be more clear at some point. so I petition a pull request 

Signed-off-by: Mark Woo <wcgwuxinwei@gmail.com>