### PR TITLE
bugfix: Fix type erasure when retrieving per-route filter config

### DIFF
--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -239,7 +239,7 @@ class Config;
  */
 class RouteSpecificFilterConfig {
 public:
-  virtual ~RouteSpecificFilterConfig() {}
+  virtual ~RouteSpecificFilterConfig() PURE;
 };
 typedef std::shared_ptr<const RouteSpecificFilterConfig> RouteSpecificFilterConfigConstSharedPtr;
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -876,6 +876,8 @@ ConfigImpl::ConfigImpl(const envoy::api::v2::RouteConfiguration& config, Runtime
                                                      config.response_headers_to_remove());
 }
 
+RouteSpecificFilterConfig::~RouteSpecificFilterConfig() {}
+
 PerFilterConfigs::PerFilterConfigs(
     const Protobuf::Map<ProtobufTypes::String, ProtobufWkt::Struct>& configs) {
   for (const auto& cfg : configs) {

--- a/source/extensions/filters/http/fault/config.cc
+++ b/source/extensions/filters/http/fault/config.cc
@@ -44,7 +44,7 @@ FaultFilterFactory::createFilterFactoryFromProto(const Protobuf::Message& proto_
 
 Router::RouteSpecificFilterConfigConstSharedPtr
 FaultFilterFactory::createRouteSpecificFilterConfig(const Protobuf::Message& proto_config) {
-  return std::make_shared<const Router::RouteSpecificFilterConfig>(Fault::FaultSettings(
+  return std::shared_ptr<const Router::RouteSpecificFilterConfig>(new Fault::FaultSettings(
       MessageUtil::downcastAndValidate<const envoy::config::filter::http::fault::v2::HTTPFault&>(
           proto_config)));
 }


### PR DESCRIPTION
Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>

bugfix: Fix type-erasure when retrieving per-route filter config


*Description*:
I don't know where the type was getting lost, but dynamic_cast<>  in perFilterConfigTyped<> was always returning null, though the unit tests seemed to pass. Per-route fault filter did not work (@rodaine also had a similar issue in his buffer filter implementation). Making the RouteSpecificFilterConfig an abstract class seems to fix the issue.

*Risk Level*: Low

*Testing*: Manually tested with per-route fault filters. @rodaine has an open PR that uses per-route buffer filter settings in integration tests.
