### PR TITLE
Add go_package option in rbac.proto and cert.proto.

### DIFF
--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package envoy.api.v2.auth;
+option go_package = "auth";
 
 import "envoy/api/v2/core/base.proto";
 import "envoy/api/v2/core/config_source.proto";

--- a/api/envoy/config/rbac/v2alpha/rbac.proto
+++ b/api/envoy/config/rbac/v2alpha/rbac.proto
@@ -5,6 +5,7 @@ import "envoy/api/v2/core/address.proto";
 import "envoy/type/string_match.proto";
 
 package envoy.config.rbac.v2alpha;
+option go_package = "v2alpha";
 
 // Role Based Access Control (RBAC) provides service-level and method-level access control for a service.
 // The RBAC engine authorizes a request by evaluating the request context (expressed in the form of


### PR DESCRIPTION
Signed-off-by: Yangmin Zhu <ymzhu@google.com>

*Title*: add go_package option to rbac.proto and cert.proto.

*Description*:
- `rbac.proto` is newly introduced in #3133
- #3133 also removed `api/envoy/api/v2/auth/auth.proto`. However the `cert.proto`  in the same directory doesn't have the go_package option, so I added it back in this PR.

*Risk Level*: Low

*Testing*: `bazel test //test/...` passed

*Docs Changes*:N/A

*Release Notes*:N/A

