### PR TITLE
listener: add support for multiple protocol sniffers.

### DIFF
--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -176,8 +176,6 @@ void Filter::parseClientHello(const void* data, size_t len) {
       cb_->socket().setDetectedTransportProtocol(TransportSockets::TransportSocketNames::get().SSL);
     } else {
       config_->stats().tls_not_found_.inc();
-      cb_->socket().setDetectedTransportProtocol(
-          TransportSockets::TransportSocketNames::get().RAW_BUFFER);
     }
     done(true);
     break;

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -66,6 +66,7 @@ envoy_cc_library(
         "//source/common/common:linked_object",
         "//source/common/common:non_copyable",
         "//source/common/network:connection_lib",
+        "//source/extensions/transport_sockets:well_known_names",
     ],
 )
 

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -8,6 +8,8 @@
 #include "common/network/connection_impl.h"
 #include "common/network/utility.h"
 
+#include "extensions/transport_sockets/well_known_names.h"
+
 namespace Envoy {
 namespace Server {
 
@@ -148,6 +150,11 @@ void ConnectionHandlerImpl::ActiveSocket::continueFilterChain(bool success) {
       // prevent further redirection.
       new_listener->onAccept(std::move(socket_), false);
     } else {
+      // Set default transport protocol if none of the listener filters did it.
+      if (socket_->detectedTransportProtocol().empty()) {
+        socket_->setDetectedTransportProtocol(
+            Extensions::TransportSockets::TransportSocketNames::get().RAW_BUFFER);
+      }
       // Create a new connection on this listener.
       listener_.newConnection(std::move(socket_));
     }


### PR DESCRIPTION
Previously, TLS Inspector set detected transport protocol to either "tls"
or "raw_buffer", however, such approach didn't allow multiple sniffers to
be installed at the same time, since they would overwrite results from
each other.

After this change, protocol sniffers will set detected transport protocol
only when they find the one they know about it, and listener will set the
default one ("raw_buffer") in case no known transport protocol was found.