### PR TITLE
stats: unrevert and fix histograms

### DIFF
--- a/bazel/external/libcircllhist.BUILD
+++ b/bazel/external/libcircllhist.BUILD
@@ -1,0 +1,9 @@
+cc_library(
+    name = "libcircllhist",
+    srcs = ["src/circllhist.c"],
+    hdrs = [
+        "src/circllhist.h",
+    ],
+    includes = ["src"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -226,6 +226,7 @@ def envoy_dependencies(path = "@envoy_deps//", skip_targets = []):
     _boringssl()
     _com_google_absl()
     _com_github_bombela_backward()
+    _com_github_circonus_labs_libcircllhist()
     _com_github_cyan4973_xxhash()
     _com_github_eile_tclap()
     _com_github_fmtlib_fmt()
@@ -263,6 +264,16 @@ def _com_github_bombela_backward():
     native.bind(
         name = "backward",
         actual = "@com_github_bombela_backward//:backward",
+    )
+
+def _com_github_circonus_labs_libcircllhist():
+    _repository_impl(
+        name = "com_github_circonus_labs_libcircllhist",
+        build_file = "@envoy//bazel/external:libcircllhist.BUILD",
+    )
+    native.bind(
+        name = "libcircllhist",
+        actual = "@com_github_circonus_labs_libcircllhist//:libcircllhist",
     )
 
 def _com_github_cyan4973_xxhash():

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -12,6 +12,10 @@ REPOSITORY_LOCATIONS = dict(
         commit = "44ae9609e860e3428cd057f7052e505b4819eb84",  # 2018-02-06
         remote = "https://github.com/bombela/backward-cpp",
     ),
+    com_github_circonus_labs_libcircllhist = dict(
+        commit = "97ef5e088fd01fa8ec5a86334a6308ac0d51ea6f",  # 2018-04-07
+        remote = "https://github.com/circonus-labs/libcircllhist",
+    ),
     com_github_cyan4973_xxhash = dict(
         commit = "7cc9639699f64b750c0b82333dced9ea77e8436e",  # v0.6.5
         remote = "https://github.com/Cyan4973/xxHash",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -13,7 +13,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/bombela/backward-cpp",
     ),
     com_github_circonus_labs_libcircllhist = dict(
-        commit = "97ef5e088fd01fa8ec5a86334a6308ac0d51ea6f",  # 2018-04-07
+        commit = "0c44450723e34c9d8768e69b11bf919be83fd2ed",  # 2018-04-30
         remote = "https://github.com/circonus-labs/libcircllhist",
     ),
     com_github_cyan4973_xxhash = dict(

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -60,6 +60,7 @@ Version history
   <envoy_api_field_Listener.transparent>`.
 * sockets: added `SO_KEEPALIVE` socket option for upstream connections
   :ref:`per cluster <envoy_api_field_Cluster.upstream_connection_options>`.
+* stats: added support for histograms.
 * tracing: the sampling decision is now delegated to the tracers, allowing the tracer to decide when and if
   to use it. For example, if the :ref:`x-b3-sampled <config_http_conn_man_headers_x-b3-sampled>` header
   is supplied with the client request, its value will override any sampling decision made by the Envoy proxy.

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -181,10 +181,12 @@ The fields are:
 
 .. http:get:: /stats
 
-  Outputs all statistics on demand. This includes only counters and gauges. Histograms are not
-  output as Envoy currently has no built in histogram support and relies on statsd for
-  aggregation. This command is very useful for local debugging. See :ref:`here <operations_stats>`
-  for more information.
+  Outputs all statistics on demand. This command is very useful for local debugging.
+  Histograms will output the computed quantiles i.e P0,P25,P50,P75,P90,P99,P99.9 and P100. 
+  The output for each quantile will be in the form of (interval,cumulative) where interval value 
+  represents the summary since last flush interval and cumulative value represents the 
+  summary since the start of envoy instance.
+  See :ref:`here <operations_stats>` for more information.
 
   .. http:get:: /stats?format=json
 

--- a/include/envoy/thread_local/thread_local.h
+++ b/include/envoy/thread_local/thread_local.h
@@ -47,6 +47,15 @@ public:
   virtual void runOnAllThreads(Event::PostCb cb) PURE;
 
   /**
+   * Run a callback on all registered threads with a barrier. A shutdown initiated during the
+   * running of the PostCBs may prevent all_threads_complete_cb from being called.
+   * @param cb supplies the callback to run on each thread.
+   * @param all_threads_complete_cb supplies the callback to run on main thread after cb has
+   * been run on all registered threads.
+   */
+  virtual void runOnAllThreads(Event::PostCb cb, Event::PostCb all_threads_complete_cb) PURE;
+
+  /**
    * Set thread local data on all threads previously registered via registerThread().
    * @param initializeCb supplies the functor that will be called *on each thread*. The functor
    *                     returns the thread local object which is then stored. The storage is via

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -41,7 +41,9 @@ namespace Logger {
   FUNCTION(testing)              \
   FUNCTION(tracing)              \
   FUNCTION(upstream)             \
-  FUNCTION(grpc)
+  FUNCTION(grpc)                 \
+  FUNCTION(stats)
+
 
 enum class Id {
   ALL_LOGGER_IDS(GENERATE_ENUM)

--- a/source/common/stats/BUILD
+++ b/source/common/stats/BUILD
@@ -12,12 +12,17 @@ envoy_cc_library(
     name = "stats_lib",
     srcs = ["stats_impl.cc"],
     hdrs = ["stats_impl.h"],
+    external_deps = [
+        "abseil_optional",
+        "libcircllhist",
+    ],
     deps = [
         "//include/envoy/common:time_interface",
         "//include/envoy/server:options_interface",
         "//include/envoy/stats:stats_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:hash_lib",
+        "//source/common/common:non_copyable",
         "//source/common/common:perf_annotation_lib",
         "//source/common/common:utility_lib",
         "//source/common/config:well_known_names",

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -277,5 +277,38 @@ void RawStatData::initialize(absl::string_view key) {
   name_[xfer_size] = '\0';
 }
 
+HistogramStatisticsImpl::HistogramStatisticsImpl(const histogram_t* histogram_ptr)
+    : computed_quantiles_(supportedQuantiles().size(), 0.0) {
+  hist_approx_quantile(histogram_ptr, supportedQuantiles().data(), supportedQuantiles().size(),
+                       computed_quantiles_.data());
+}
+
+const std::vector<double>& HistogramStatisticsImpl::supportedQuantiles() const {
+  static const std::vector<double> supported_quantiles = {0,    0.25, 0.5,   0.75, 0.90,
+                                                          0.95, 0.99, 0.999, 1};
+  return supported_quantiles;
+}
+
+std::string HistogramStatisticsImpl::summary() const {
+  std::vector<std::string> summary;
+  const std::vector<double>& supported_quantiles_ref = supportedQuantiles();
+  summary.reserve(supported_quantiles_ref.size());
+  for (size_t i = 0; i < supported_quantiles_ref.size(); ++i) {
+    summary.push_back(
+        fmt::format("P{}: {}", 100 * supported_quantiles_ref[i], computed_quantiles_[i]));
+  }
+  return absl::StrJoin(summary, ", ");
+}
+
+/**
+ * Clears the old computed values and refreshes it with values computed from passed histogram.
+ */
+void HistogramStatisticsImpl::refresh(const histogram_t* new_histogram_ptr) {
+  std::fill(computed_quantiles_.begin(), computed_quantiles_.end(), 0.0);
+  ASSERT(supportedQuantiles().size() == computed_quantiles_.size());
+  hist_approx_quantile(new_histogram_ptr, supportedQuantiles().data(), supportedQuantiles().size(),
+                       computed_quantiles_.data());
+}
+
 } // namespace Stats
 } // namespace Envoy

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -18,10 +18,13 @@
 
 #include "common/common/assert.h"
 #include "common/common/hash.h"
+#include "common/common/non_copyable.h"
 #include "common/common/utility.h"
 #include "common/protobuf/protobuf.h"
 
+#include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
+#include "circllhist.h"
 
 namespace Envoy {
 namespace Stats {
@@ -167,9 +170,6 @@ public:
  * RawStatData::size() instead.
  */
 struct RawStatData {
-  struct Flags {
-    static const uint8_t Used = 0x1;
-  };
 
   /**
    * Due to the flexible-array-length of name_, c-style allocation
@@ -284,6 +284,14 @@ public:
   const std::string& tagExtractedName() const override { return tag_extracted_name_; }
   const std::vector<Tag>& tags() const override { return tags_; }
 
+protected:
+  /**
+   * Flags used by all stats types to figure out whether they have been used.
+   */
+  struct Flags {
+    static const uint8_t Used = 0x1;
+  };
+
 private:
   const std::string name_;
   const std::string tag_extracted_name_;
@@ -305,13 +313,13 @@ public:
   void add(uint64_t amount) override {
     data_.value_ += amount;
     data_.pending_increment_ += amount;
-    data_.flags_ |= RawStatData::Flags::Used;
+    data_.flags_ |= Flags::Used;
   }
 
   void inc() override { add(1); }
   uint64_t latch() override { return data_.pending_increment_.exchange(0); }
   void reset() override { data_.value_ = 0; }
-  bool used() const override { return data_.flags_ & RawStatData::Flags::Used; }
+  bool used() const override { return data_.flags_ & Flags::Used; }
   uint64_t value() const override { return data_.value_; }
 
 private:
@@ -333,13 +341,13 @@ public:
   // Stats::Gauge
   virtual void add(uint64_t amount) override {
     data_.value_ += amount;
-    data_.flags_ |= RawStatData::Flags::Used;
+    data_.flags_ |= Flags::Used;
   }
   virtual void dec() override { sub(1); }
   virtual void inc() override { add(1); }
   virtual void set(uint64_t value) override {
     data_.value_ = value;
-    data_.flags_ |= RawStatData::Flags::Used;
+    data_.flags_ |= Flags::Used;
   }
   virtual void sub(uint64_t amount) override {
     ASSERT(data_.value_ >= amount);
@@ -347,11 +355,35 @@ public:
     data_.value_ -= amount;
   }
   virtual uint64_t value() const override { return data_.value_; }
-  bool used() const override { return data_.flags_ & RawStatData::Flags::Used; }
+  bool used() const override { return data_.flags_ & Flags::Used; }
 
 private:
   RawStatData& data_;
   RawStatDataAllocator& alloc_;
+};
+
+/**
+ * Implementation of HistogramStatistics for circllhist.
+ */
+class HistogramStatisticsImpl : public HistogramStatistics, NonCopyable {
+public:
+  HistogramStatisticsImpl() : computed_quantiles_(supportedQuantiles().size(), 0.0) {}
+  /**
+   * HistogramStatisticsImpl object is constructed using the passed in histogram.
+   * @param histogram_ptr pointer to the histogram for which stats will be calculated. This pointer
+   * will not be retained.
+   */
+  HistogramStatisticsImpl(const histogram_t* histogram_ptr);
+
+  void refresh(const histogram_t* new_histogram_ptr);
+
+  // HistogramStatistics
+  std::string summary() const override;
+  const std::vector<double>& supportedQuantiles() const override;
+  const std::vector<double>& computedQuantiles() const override { return computed_quantiles_; }
+
+private:
+  std::vector<double> computed_quantiles_;
 };
 
 /**
@@ -366,6 +398,10 @@ public:
   // Stats::Histogram
   void recordValue(uint64_t value) override { parent_.deliverHistogramToSinks(*this, value); }
 
+  bool used() const override { return true; }
+
+private:
+  // This is used for delivering the histogram data to sinks.
   Store& parent_;
 };
 
@@ -446,6 +482,9 @@ public:
   // Stats::Store
   std::list<CounterSharedPtr> counters() const override { return counters_.toList(); }
   std::list<GaugeSharedPtr> gauges() const override { return gauges_.toList(); }
+  std::list<ParentHistogramSharedPtr> histograms() const override {
+    return std::list<ParentHistogramSharedPtr>{};
+  }
 
 private:
   struct ScopeImpl : public Scope {

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -61,6 +61,30 @@ std::list<GaugeSharedPtr> ThreadLocalStoreImpl::gauges() const {
   return ret;
 }
 
+std::list<ParentHistogramSharedPtr> ThreadLocalStoreImpl::histograms() const {
+  // Handle de-dup due to overlapping scopes.
+  std::list<ParentHistogramSharedPtr> ret;
+  std::unordered_set<std::string> names;
+  std::unique_lock<std::mutex> lock(lock_);
+  // TODO(ramaraochavali): As histograms don't share storage, there is a chance of duplicate names
+  // here. We need process global storage for histograms similar to how we have a central storage
+  // in shared memory for counters/gauges.
+  for (ScopeImpl* scope : scopes_) {
+    for (const auto& name_histogram_pair : scope->central_cache_.histograms_) {
+      const std::string& hist_name = name_histogram_pair.first;
+      const ParentHistogramSharedPtr& parent_hist = name_histogram_pair.second;
+      if (names.insert(hist_name).second) {
+        ret.push_back(parent_hist);
+      } else {
+        ENVOY_LOG(debug, "duplicate histogram {}{}: data loss will occur on output", scope->prefix_,
+                  hist_name);
+      }
+    }
+  }
+
+  return ret;
+}
+
 void ThreadLocalStoreImpl::initializeThreading(Event::Dispatcher& main_thread_dispatcher,
                                                ThreadLocal::Instance& tls) {
   main_thread_dispatcher_ = &main_thread_dispatcher;
@@ -73,6 +97,34 @@ void ThreadLocalStoreImpl::initializeThreading(Event::Dispatcher& main_thread_di
 void ThreadLocalStoreImpl::shutdownThreading() {
   // This will block both future cache fills as well as cache flushes.
   shutting_down_ = true;
+}
+
+void ThreadLocalStoreImpl::mergeHistograms(PostMergeCb merge_complete_cb) {
+  ASSERT(!merge_in_progress_);
+  if (!shutting_down_) {
+    merge_in_progress_ = true;
+    tls_->runOnAllThreads(
+        [this]() -> void {
+          for (ScopeImpl* scope : scopes_) {
+            for (const auto& name_histogram_pair :
+                 tls_->getTyped<TlsCache>().scope_cache_[scope].histograms_) {
+              const TlsHistogramSharedPtr& tls_hist = name_histogram_pair.second;
+              tls_hist->beginMerge();
+            }
+          }
+        },
+        [this, merge_complete_cb]() -> void { mergeInternal(merge_complete_cb); });
+  }
+}
+
+void ThreadLocalStoreImpl::mergeInternal(PostMergeCb merge_complete_cb) {
+  if (!shutting_down_) {
+    for (const ParentHistogramSharedPtr& histogram : histograms()) {
+      histogram->merge();
+    }
+    merge_complete_cb();
+    merge_in_progress_ = false;
+  }
 }
 
 void ThreadLocalStoreImpl::releaseScopeCrossThread(ScopeImpl* scope) {
@@ -208,10 +260,10 @@ Histogram& ThreadLocalStoreImpl::ScopeImpl::histogram(const std::string& name) {
   // See comments in counter(). There is no super clean way (via templates or otherwise) to
   // share this code so I'm leaving it largely duplicated for now.
   std::string final_name = prefix_ + name;
-  HistogramSharedPtr* tls_ref = nullptr;
+  ParentHistogramSharedPtr* tls_ref = nullptr;
+
   if (!parent_.shutting_down_ && parent_.tls_) {
-    tls_ref =
-        &parent_.tls_->getTyped<TlsCache>().scope_cache_[this->scope_id_].histograms_[final_name];
+    tls_ref = &parent_.tls_->getTyped<TlsCache>().scope_cache_[this->scope_id_].parent_histograms_[final_name];
   }
 
   if (tls_ref && *tls_ref) {
@@ -219,19 +271,134 @@ Histogram& ThreadLocalStoreImpl::ScopeImpl::histogram(const std::string& name) {
   }
 
   std::unique_lock<std::mutex> lock(parent_.lock_);
-  HistogramSharedPtr& central_ref = central_cache_.histograms_[final_name];
+  ParentHistogramImplSharedPtr& central_ref = central_cache_.histograms_[final_name];
+
+  std::vector<Tag> tags;
+  std::string tag_extracted_name = parent_.getTagsForName(final_name, tags);
   if (!central_ref) {
-    std::vector<Tag> tags;
-    std::string tag_extracted_name = parent_.getTagsForName(final_name, tags);
-    central_ref.reset(
-        new HistogramImpl(final_name, parent_, std::move(tag_extracted_name), std::move(tags)));
+    // Since MetricImpl only has move constructor, we are explicitly copying here.
+    std::string central_tag_extracted_name(tag_extracted_name);
+    std::vector<Tag> central_tags(tags);
+    central_ref.reset(new ParentHistogramImpl(final_name, parent_, *this,
+                                              std::move(central_tag_extracted_name),
+                                              std::move(central_tags)));
   }
 
   if (tls_ref) {
     *tls_ref = central_ref;
   }
-
   return *central_ref;
+}
+
+Histogram& ThreadLocalStoreImpl::ScopeImpl::tlsHistogram(const std::string& name,
+                                                         ParentHistogramImpl& parent) {
+  // See comments in counter() which explains the logic here.
+
+  // Here prefix will not be considered because, by the time ParentHistogram calls this method
+  // during recordValue, the prefix is already attached to the name.
+  TlsHistogramSharedPtr* tls_ref = nullptr;
+  if (!parent_.shutting_down_ && parent_.tls_) {
+    tls_ref = &parent_.tls_->getTyped<TlsCache>().scope_cache_[this].histograms_[name];
+  }
+
+  if (tls_ref && *tls_ref) {
+    return **tls_ref;
+  }
+
+  std::unique_lock<std::mutex> lock(parent_.lock_);
+  std::vector<Tag> tags;
+  std::string tag_extracted_name = parent_.getTagsForName(name, tags);
+  TlsHistogramSharedPtr hist_tls_ptr = std::make_shared<ThreadLocalHistogramImpl>(
+      name, std::move(tag_extracted_name), std::move(tags));
+
+  parent.addTlsHistogram(hist_tls_ptr);
+
+  if (tls_ref) {
+    *tls_ref = hist_tls_ptr;
+  }
+  return *hist_tls_ptr;
+}
+
+ThreadLocalHistogramImpl::ThreadLocalHistogramImpl(const std::string& name,
+                                                   std::string&& tag_extracted_name,
+                                                   std::vector<Tag>&& tags)
+    : MetricImpl(name, std::move(tag_extracted_name), std::move(tags)), current_active_(0),
+      flags_(0), created_thread_id_(std::this_thread::get_id()) {
+  histograms_[0] = hist_alloc();
+  histograms_[1] = hist_alloc();
+}
+
+ThreadLocalHistogramImpl::~ThreadLocalHistogramImpl() {
+  hist_free(histograms_[0]);
+  hist_free(histograms_[1]);
+}
+
+void ThreadLocalHistogramImpl::recordValue(uint64_t value) {
+  ASSERT(std::this_thread::get_id() == created_thread_id_);
+  hist_insert_intscale(histograms_[current_active_], value, 0, 1);
+  flags_ |= Flags::Used;
+}
+
+void ThreadLocalHistogramImpl::merge(histogram_t* target) {
+  histogram_t** other_histogram = &histograms_[otherHistogramIndex()];
+  hist_accumulate(target, other_histogram, 1);
+  hist_clear(*other_histogram);
+}
+
+ParentHistogramImpl::ParentHistogramImpl(const std::string& name, Store& parent,
+                                         TlsScope& tls_scope, std::string&& tag_extracted_name,
+                                         std::vector<Tag>&& tags)
+    : MetricImpl(name, std::move(tag_extracted_name), std::move(tags)), parent_(parent),
+      tls_scope_(tls_scope), interval_histogram_(hist_alloc()), cumulative_histogram_(hist_alloc()),
+      interval_statistics_(interval_histogram_), cumulative_statistics_(cumulative_histogram_) {}
+
+ParentHistogramImpl::~ParentHistogramImpl() {
+  hist_free(interval_histogram_);
+  hist_free(cumulative_histogram_);
+}
+
+void ParentHistogramImpl::recordValue(uint64_t value) {
+  Histogram& tls_histogram = tls_scope_.tlsHistogram(name(), *this);
+  tls_histogram.recordValue(value);
+  parent_.deliverHistogramToSinks(*this, value);
+}
+
+bool ParentHistogramImpl::used() const {
+  std::unique_lock<std::mutex> lock(merge_lock_);
+  return usedLockHeld();
+}
+
+void ParentHistogramImpl::merge() {
+  std::unique_lock<std::mutex> lock(merge_lock_);
+  if (usedLockHeld()) {
+    hist_clear(interval_histogram_);
+    // Here we could copy all the pointers to TLS histograms in the tls_histogram_ list,
+    // then release the lock before we do the actual merge. However it is not a big deal
+    // because the tls_histogram merge is not that expensive as it is a single histogram
+    // merge and adding TLS histograms is rare.
+    for (const TlsHistogramSharedPtr& tls_histogram : tls_histograms_) {
+      tls_histogram->merge(interval_histogram_);
+    }
+    // Since TLS merge is done, we can release the lock here.
+    lock.unlock();
+    hist_accumulate(cumulative_histogram_, &interval_histogram_, 1);
+    cumulative_statistics_.refresh(cumulative_histogram_);
+    interval_statistics_.refresh(interval_histogram_);
+  }
+}
+
+void ParentHistogramImpl::addTlsHistogram(const TlsHistogramSharedPtr& hist_ptr) {
+  std::unique_lock<std::mutex> lock(merge_lock_);
+  tls_histograms_.emplace_back(hist_ptr);
+}
+
+bool ParentHistogramImpl::usedLockHeld() const {
+  for (const TlsHistogramSharedPtr& tls_histogram : tls_histograms_) {
+    if (tls_histogram->used()) {
+      return true;
+    }
+  }
+  return false;
 }
 
 } // namespace Stats

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -25,7 +25,6 @@ class ThreadLocalHistogramImpl : public Histogram, public MetricImpl {
 public:
   ThreadLocalHistogramImpl(const std::string& name, std::string&& tag_extracted_name,
                            std::vector<Tag>&& tags);
-
   ~ThreadLocalHistogramImpl();
 
   void merge(histogram_t* target);
@@ -36,6 +35,7 @@ public:
    */
   void beginMerge() {
     // This switches the current_active_ between 1 and 0.
+    ASSERT(std::this_thread::get_id() == created_thread_id_);
     current_active_ = otherHistogramIndex();
   }
 
@@ -62,13 +62,12 @@ class ParentHistogramImpl : public ParentHistogram, public MetricImpl {
 public:
   ParentHistogramImpl(const std::string& name, Store& parent, TlsScope& tlsScope,
                       std::string&& tag_extracted_name, std::vector<Tag>&& tags);
-
-  virtual ~ParentHistogramImpl();
+  ~ParentHistogramImpl();
 
   void addTlsHistogram(const TlsHistogramSharedPtr& hist_ptr);
-
   bool used() const override;
   void recordValue(uint64_t value) override;
+
   /**
    * This method is called during the main stats flush process for each of the histograms. It
    * iterates through the TLS histograms and collects the histogram data of all of them

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -17,6 +17,102 @@ namespace Envoy {
 namespace Stats {
 
 /**
+ * A histogram that is stored in TLS and used to record values per thread. This holds two
+ * histograms, one to collect the values and other as backup that is used for merge process. The
+ * swap happens during the merge process.
+ */
+class ThreadLocalHistogramImpl : public Histogram, public MetricImpl {
+public:
+  ThreadLocalHistogramImpl(const std::string& name, std::string&& tag_extracted_name,
+                           std::vector<Tag>&& tags);
+
+  ~ThreadLocalHistogramImpl();
+
+  void merge(histogram_t* target);
+
+  /**
+   * Called in the beginning of merge process. Swaps the histogram used for collection so that we do
+   * not have to lock the histogram in high throughput TLS writes.
+   */
+  void beginMerge() {
+    // This switches the current_active_ between 1 and 0.
+    current_active_ = otherHistogramIndex();
+  }
+
+  // Stats::Histogram
+  void recordValue(uint64_t value) override;
+  bool used() const override { return flags_ & Flags::Used; }
+
+private:
+  uint64_t otherHistogramIndex() const { return 1 - current_active_; }
+  uint64_t current_active_;
+  histogram_t* histograms_[2];
+  std::atomic<uint16_t> flags_;
+  std::thread::id created_thread_id_;
+};
+
+typedef std::shared_ptr<ThreadLocalHistogramImpl> TlsHistogramSharedPtr;
+
+class TlsScope;
+
+/**
+ * Log Linear Histogram implementation that is stored in the main thread.
+ */
+class ParentHistogramImpl : public ParentHistogram, public MetricImpl {
+public:
+  ParentHistogramImpl(const std::string& name, Store& parent, TlsScope& tlsScope,
+                      std::string&& tag_extracted_name, std::vector<Tag>&& tags);
+
+  virtual ~ParentHistogramImpl();
+
+  void addTlsHistogram(const TlsHistogramSharedPtr& hist_ptr);
+
+  bool used() const override;
+  void recordValue(uint64_t value) override;
+  /**
+   * This method is called during the main stats flush process for each of the histograms. It
+   * iterates through the TLS histograms and collects the histogram data of all of them
+   * in to "interval_histogram". Then the collected "interval_histogram" is merged to a
+   * "cumulative_histogram".
+   */
+  void merge() override;
+
+  const HistogramStatistics& intervalStatistics() const override { return interval_statistics_; }
+  const HistogramStatistics& cumulativeStatistics() const override {
+    return cumulative_statistics_;
+  }
+
+private:
+  bool usedLockHeld() const;
+
+  Store& parent_;
+  TlsScope& tls_scope_;
+  histogram_t* interval_histogram_;
+  histogram_t* cumulative_histogram_;
+  HistogramStatisticsImpl interval_statistics_;
+  HistogramStatisticsImpl cumulative_statistics_;
+  mutable std::mutex merge_lock_;
+  std::list<TlsHistogramSharedPtr> tls_histograms_;
+};
+
+typedef std::shared_ptr<ParentHistogramImpl> ParentHistogramImplSharedPtr;
+
+/**
+ * Class used to create ThreadLocalHistogram in the scope.
+ */
+class TlsScope : public Scope {
+public:
+  virtual ~TlsScope() {}
+
+  // TODO(ramaraochavali): Allow direct TLS access for the advanced consumers.
+  /**
+   * @return a ThreadLocalHistogram within the scope's namespace.
+   * @param name name of the histogram with scope prefix attached.
+   */
+  virtual Histogram& tlsHistogram(const std::string& name, ParentHistogramImpl& parent) PURE;
+};
+
+/**
  * Store implementation with thread local caching. This implementation supports the following
  * features:
  * - Thread local per scope stat caching.
@@ -44,8 +140,28 @@ namespace Stats {
  *   back to heap allocated stats if needed. NOTE: In this case, overlapping scopes will not share
  *   the same backing store. This is to keep things simple, it could be done in the future if
  *   needed.
+ *
+ * The threading model for managing histograms is as described below.
+ * Each Histogram implementation will have 2 parts.
+ *  - "main" thread parent which is called "ParentHistogram".
+ *  - "per-thread" collector which is called "ThreadLocalHistogram".
+ * Worker threads will write to ParentHistogram which checks whether a TLS histogram is available.
+ * If there is one it will write to it, otherwise creates new one and writes to it.
+ * During the flush process the following sequence is followed.
+ *  - The main thread starts the flush process by posting a message to every worker which tells the
+ *    worker to swap its "active" histogram with its "backup" histogram. This is acheived via a call
+ *    to "beginMerge" method.
+ *  - Each TLS histogram has 2 histograms it makes use of, swapping back and forth. It manages a
+ *    current_active index via which it writes to the correct histogram.
+ *  - When all workers have done, the main thread continues with the flush process where the
+ *    "actual" merging happens.
+ *  - As the active histograms are swapped in TLS histograms, on the main thread, we can be sure
+ *    that no worker is writing into the "backup" histogram.
+ *  - The main thread now goes through all histograms, collect them across each worker and
+ *    accumulates in to "interval" histograms.
+ *  - Finally the main "interval" histogram is merged to "cumulative" histogram.
  */
-class ThreadLocalStoreImpl : public StoreRoot {
+class ThreadLocalStoreImpl : Logger::Loggable<Logger::Id::stats>, public StoreRoot {
 public:
   ThreadLocalStoreImpl(RawStatDataAllocator& alloc);
   ~ThreadLocalStoreImpl();
@@ -62,8 +178,11 @@ public:
   };
 
   // Stats::Store
+  // TODO(ramaraochavali): Consider changing the implementation of these methods to use vectors and
+  // use std::sort, rather than inserting into a map and pulling it out for better performance.
   std::list<CounterSharedPtr> counters() const override;
   std::list<GaugeSharedPtr> gauges() const override;
+  std::list<ParentHistogramSharedPtr> histograms() const override;
 
   // Stats::StoreRoot
   void addSink(Sink& sink) override { timer_sinks_.push_back(sink); }
@@ -74,14 +193,23 @@ public:
                            ThreadLocal::Instance& tls) override;
   void shutdownThreading() override;
 
+  void mergeHistograms(PostMergeCb mergeCb) override;
+
 private:
   struct TlsCacheEntry {
     std::unordered_map<std::string, CounterSharedPtr> counters_;
     std::unordered_map<std::string, GaugeSharedPtr> gauges_;
-    std::unordered_map<std::string, HistogramSharedPtr> histograms_;
+    std::unordered_map<std::string, TlsHistogramSharedPtr> histograms_;
+    std::unordered_map<std::string, ParentHistogramSharedPtr> parent_histograms_;
   };
 
-  struct ScopeImpl : public Scope {
+  struct CentralCacheEntry {
+    std::unordered_map<std::string, CounterSharedPtr> counters_;
+    std::unordered_map<std::string, GaugeSharedPtr> gauges_;
+    std::unordered_map<std::string, ParentHistogramImplSharedPtr> histograms_;
+  };
+
+  struct ScopeImpl : public TlsScope {
     ScopeImpl(ThreadLocalStoreImpl& parent, const std::string& prefix)
         : scope_id_(next_scope_id_++), parent_(parent),
           prefix_(Utility::sanitizeStatsName(prefix)) {}
@@ -95,13 +223,14 @@ private:
     void deliverHistogramToSinks(const Histogram& histogram, uint64_t value) override;
     Gauge& gauge(const std::string& name) override;
     Histogram& histogram(const std::string& name) override;
+    Histogram& tlsHistogram(const std::string& name, ParentHistogramImpl& parent) override;
 
     static std::atomic<uint64_t> next_scope_id_;
 
     const uint64_t scope_id_;
     ThreadLocalStoreImpl& parent_;
     const std::string prefix_;
-    TlsCacheEntry central_cache_;
+    CentralCacheEntry central_cache_;
   };
 
   struct TlsCache : public ThreadLocal::ThreadLocalObject {
@@ -124,6 +253,7 @@ private:
   void clearScopeFromCaches(uint64_t scope_id);
   void releaseScopeCrossThread(ScopeImpl* scope);
   SafeAllocData safeAlloc(const std::string& name);
+  void mergeInternal(PostMergeCb mergeCb);
 
   RawStatDataAllocator& alloc_;
   Event::Dispatcher* main_thread_dispatcher_{};
@@ -134,6 +264,7 @@ private:
   std::list<std::reference_wrapper<Sink>> timer_sinks_;
   TagProducerPtr tag_producer_;
   std::atomic<bool> shutting_down_{};
+  std::atomic<bool> merge_in_progress_{};
   Counter& num_last_resort_stats_;
   HeapRawStatDataAllocator heap_allocator_;
 };

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -91,6 +91,21 @@ void InstanceImpl::runOnAllThreads(Event::PostCb cb) {
   cb();
 }
 
+void InstanceImpl::runOnAllThreads(Event::PostCb cb, Event::PostCb all_threads_complete_cb) {
+  ASSERT(std::this_thread::get_id() == main_thread_id_);
+  ASSERT(!shutdown_);
+  std::shared_ptr<std::atomic<uint64_t>> worker_count =
+      std::make_shared<std::atomic<uint64_t>>(registered_threads_.size());
+  for (Event::Dispatcher& dispatcher : registered_threads_) {
+    dispatcher.post([this, worker_count, cb, all_threads_complete_cb]() -> void {
+      cb();
+      if (--*worker_count == 0) {
+        main_thread_dispatcher_->post(all_threads_complete_cb);
+      }
+    });
+  }
+}
+
 void InstanceImpl::SlotImpl::set(InitializeCb cb) {
   ASSERT(std::this_thread::get_id() == parent_.main_thread_id_);
   ASSERT(!parent_.shutdown_);

--- a/source/common/thread_local/thread_local_impl.h
+++ b/source/common/thread_local/thread_local_impl.h
@@ -35,6 +35,9 @@ private:
     // ThreadLocal::Slot
     ThreadLocalObjectSharedPtr get() override;
     void runOnAllThreads(Event::PostCb cb) override { parent_.runOnAllThreads(cb); }
+    void runOnAllThreads(Event::PostCb cb, Event::PostCb main_callback) override {
+      parent_.runOnAllThreads(cb, main_callback);
+    }
     void set(InitializeCb cb) override;
 
     InstanceImpl& parent_;
@@ -48,6 +51,7 @@ private:
 
   void removeSlot(SlotImpl& slot);
   void runOnAllThreads(Event::PostCb cb);
+  void runOnAllThreads(Event::PostCb cb, Event::PostCb main_callback);
   static void setThreadLocal(uint32_t index, ThreadLocalObjectSharedPtr object);
 
   static thread_local ThreadLocalData thread_local_data_;

--- a/source/extensions/stat_sinks/common/statsd/statsd.h
+++ b/source/extensions/stat_sinks/common/statsd/statsd.h
@@ -55,6 +55,7 @@ public:
   void beginFlush() override {}
   void flushCounter(const Stats::Counter& counter, uint64_t delta) override;
   void flushGauge(const Stats::Gauge& gauge, uint64_t value) override;
+  void flushHistogram(const Stats::ParentHistogram&) override {}
   void endFlush() override {}
   void onHistogramComplete(const Stats::Histogram& histogram, uint64_t value) override;
 
@@ -93,6 +94,8 @@ public:
   void flushGauge(const Stats::Gauge& gauge, uint64_t value) override {
     tls_->getTyped<TlsSink>().flushGauge(gauge.name(), value);
   }
+
+  void flushHistogram(const Stats::ParentHistogram&) override {}
 
   void endFlush() override { tls_->getTyped<TlsSink>().endFlush(true); }
 

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
@@ -61,6 +61,40 @@ void GrpcMetricsStreamerImpl::ThreadLocalStreamer::send(
 MetricsServiceSink::MetricsServiceSink(const GrpcMetricsStreamerSharedPtr& grpc_metrics_streamer)
     : grpc_metrics_streamer_(grpc_metrics_streamer) {}
 
+void MetricsServiceSink::flushCounter(const Stats::Counter& counter, uint64_t) {
+  io::prometheus::client::MetricFamily* metrics_family = message_.add_envoy_metrics();
+  metrics_family->set_type(io::prometheus::client::MetricType::COUNTER);
+  metrics_family->set_name(counter.name());
+  auto* metric = metrics_family->add_metric();
+  metric->set_timestamp_ms(std::chrono::system_clock::now().time_since_epoch().count());
+  auto* counter_metric = metric->mutable_counter();
+  counter_metric->set_value(counter.value());
+}
+
+void MetricsServiceSink::flushGauge(const Stats::Gauge& gauge, uint64_t value) {
+  io::prometheus::client::MetricFamily* metrics_family = message_.add_envoy_metrics();
+  metrics_family->set_type(io::prometheus::client::MetricType::GAUGE);
+  metrics_family->set_name(gauge.name());
+  auto* metric = metrics_family->add_metric();
+  metric->set_timestamp_ms(std::chrono::system_clock::now().time_since_epoch().count());
+  auto* gauage_metric = metric->mutable_gauge();
+  gauage_metric->set_value(value);
+}
+void MetricsServiceSink::flushHistogram(const Stats::ParentHistogram& histogram) {
+  io::prometheus::client::MetricFamily* metrics_family = message_.add_envoy_metrics();
+  metrics_family->set_type(io::prometheus::client::MetricType::SUMMARY);
+  metrics_family->set_name(histogram.name());
+  auto* metric = metrics_family->add_metric();
+  metric->set_timestamp_ms(std::chrono::system_clock::now().time_since_epoch().count());
+  auto* summary_metric = metric->mutable_summary();
+  const Stats::HistogramStatistics& hist_stats = histogram.intervalStatistics();
+  for (size_t i = 0; i < hist_stats.supportedQuantiles().size(); i++) {
+    auto* quantile = summary_metric->add_quantile();
+    quantile->set_quantile(hist_stats.supportedQuantiles()[i]);
+    quantile->set_value(hist_stats.computedQuantiles()[i]);
+  }
+}
+
 } // namespace MetricsService
 } // namespace StatSinks
 } // namespace Extensions

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h
@@ -112,25 +112,9 @@ public:
 
   void beginFlush() override { message_.clear_envoy_metrics(); }
 
-  void flushCounter(const Stats::Counter& counter, uint64_t) override {
-    io::prometheus::client::MetricFamily* metrics_family = message_.add_envoy_metrics();
-    metrics_family->set_type(io::prometheus::client::MetricType::COUNTER);
-    metrics_family->set_name(counter.name());
-    auto* metric = metrics_family->add_metric();
-    metric->set_timestamp_ms(std::chrono::system_clock::now().time_since_epoch().count());
-    auto* counter_metric = metric->mutable_counter();
-    counter_metric->set_value(counter.value());
-  }
-
-  void flushGauge(const Stats::Gauge& gauge, uint64_t value) override {
-    io::prometheus::client::MetricFamily* metrics_family = message_.add_envoy_metrics();
-    metrics_family->set_type(io::prometheus::client::MetricType::GAUGE);
-    metrics_family->set_name(gauge.name());
-    auto* metric = metrics_family->add_metric();
-    metric->set_timestamp_ms(std::chrono::system_clock::now().time_since_epoch().count());
-    auto* gauage_metric = metric->mutable_gauge();
-    gauage_metric->set_value(value);
-  }
+  void flushCounter(const Stats::Counter& counter, uint64_t) override;
+  void flushGauge(const Stats::Gauge& gauge, uint64_t value) override;
+  void flushHistogram(const Stats::ParentHistogram& histogram) override;
 
   void endFlush() override {
     grpc_metrics_streamer_->send(message_);
@@ -140,9 +124,7 @@ public:
     }
   }
 
-  void onHistogramComplete(const Stats::Histogram&, uint64_t) override {
-    // TODO : Need to figure out how to map existing histogram to Proto Model
-  }
+  void onHistogramComplete(const Stats::Histogram&, uint64_t) override {}
 
 private:
   GrpcMetricsStreamerSharedPtr grpc_metrics_streamer_;

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -36,6 +36,7 @@
 #include "common/network/listen_socket_impl.h"
 #include "common/profiler/profiler.h"
 #include "common/router/config_impl.h"
+#include "common/stats/stats_impl.h"
 #include "common/upstream/host_utility.h"
 
 #include "extensions/access_loggers/file/file_access_log_impl.h"
@@ -388,11 +389,10 @@ Http::Code AdminImpl::handlerServerInfo(absl::string_view, Http::HeaderMap&,
 
 Http::Code AdminImpl::handlerStats(absl::string_view url, Http::HeaderMap& response_headers,
                                    Buffer::Instance& response) {
-  // We currently don't support timers locally (only via statsd) so just group all the counters
-  // and gauges together, alpha sort them, and spit them out.
   Http::Code rc = Http::Code::OK;
   const Http::Utility::QueryParams params = Http::Utility::parseQueryString(url);
   std::map<std::string, uint64_t> all_stats;
+  std::map<std::string, std::string> all_histograms;
   for (const Stats::CounterSharedPtr& counter : server_.stats().counters()) {
     all_stats.emplace(counter->name(), counter->value());
   }
@@ -401,10 +401,27 @@ Http::Code AdminImpl::handlerStats(absl::string_view url, Http::HeaderMap& respo
     all_stats.emplace(gauge->name(), gauge->value());
   }
 
+  for (const Stats::ParentHistogramSharedPtr& histogram : server_.stats().histograms()) {
+    std::vector<std::string> summary;
+    const std::vector<double>& supported_quantiles_ref =
+        histogram->intervalStatistics().supportedQuantiles();
+    summary.reserve(supported_quantiles_ref.size());
+    for (size_t i = 0; i < supported_quantiles_ref.size(); ++i) {
+      summary.push_back(fmt::format("P{}({},{})", 100 * supported_quantiles_ref[i],
+                                    histogram->intervalStatistics().computedQuantiles()[i],
+                                    histogram->cumulativeStatistics().computedQuantiles()[i]));
+    }
+
+    all_histograms.emplace(histogram->name(), absl::StrJoin(summary, " "));
+  }
+
   if (params.size() == 0) {
     // No Arguments so use the standard.
     for (auto stat : all_stats) {
       response.add(fmt::format("{}: {}\n", stat.first, stat.second));
+    }
+    for (auto histogram : all_histograms) {
+      response.add(fmt::format("{}: {}\n", histogram.first, histogram.second));
     }
   } else {
     const std::string format_key = params.begin()->first;
@@ -412,7 +429,7 @@ Http::Code AdminImpl::handlerStats(absl::string_view url, Http::HeaderMap& respo
     if (format_key == "format" && format_value == "json") {
       response_headers.insertContentType().value().setReference(
           Http::Headers::get().ContentTypeValues.Json);
-      response.add(AdminImpl::statsAsJson(all_stats));
+      response.add(AdminImpl::statsAsJson(all_stats, server_.stats().histograms()));
     } else if (format_key == "format" && format_value == "prometheus") {
       return handlerPrometheusStats(url, response_headers, response);
     } else {
@@ -453,6 +470,7 @@ std::string PrometheusStatsFormatter::metricName(const std::string& extractedNam
   return fmt::format("envoy_{0}", sanitizeName(extractedName));
 }
 
+// TODO(ramaraochavali): Add summary histogram output for Prometheus.
 uint64_t
 PrometheusStatsFormatter::statsAsPrometheus(const std::list<Stats::CounterSharedPtr>& counters,
                                             const std::list<Stats::GaugeSharedPtr>& gauges,
@@ -480,7 +498,9 @@ PrometheusStatsFormatter::statsAsPrometheus(const std::list<Stats::CounterShared
   return metric_type_tracker.size();
 }
 
-std::string AdminImpl::statsAsJson(const std::map<std::string, uint64_t>& all_stats) {
+std::string
+AdminImpl::statsAsJson(const std::map<std::string, uint64_t>& all_stats,
+                       const std::list<Stats::ParentHistogramSharedPtr>& all_histograms) {
   rapidjson::Document document;
   document.SetObject();
   rapidjson::Value stats_array(rapidjson::kArrayType);
@@ -496,6 +516,40 @@ std::string AdminImpl::statsAsJson(const std::map<std::string, uint64_t>& all_st
     stat_obj.AddMember("value", stat_value, allocator);
     stats_array.PushBack(stat_obj, allocator);
   }
+
+  for (const Stats::ParentHistogramSharedPtr& histogram : all_histograms) {
+    Value histogram_obj;
+    histogram_obj.SetObject();
+    Value histogram_name;
+    histogram_name.SetString(histogram->name().c_str(), allocator);
+    histogram_obj.AddMember("name", histogram_name, allocator);
+
+    rapidjson::Value quantile_array(rapidjson::kArrayType);
+
+    // TODO(ramaraochavali): consider optimizing the model here. Quantiles can be added once,
+    // followed by two arrays interval and cumulative.
+    for (size_t i = 0; i < histogram->intervalStatistics().supportedQuantiles().size(); ++i) {
+      Value quantile_obj;
+      quantile_obj.SetObject();
+      Value quantile_type;
+      quantile_type.SetDouble(histogram->intervalStatistics().supportedQuantiles()[i] * 100);
+      quantile_obj.AddMember("quantile", quantile_type, allocator);
+      Value interval_value;
+      if (!std::isnan(histogram->intervalStatistics().computedQuantiles()[i])) {
+        interval_value.SetDouble(histogram->intervalStatistics().computedQuantiles()[i]);
+      }
+      quantile_obj.AddMember("interval_value", interval_value, allocator);
+      Value cumulative_value;
+      if (!std::isnan(histogram->cumulativeStatistics().computedQuantiles()[i])) {
+        cumulative_value.SetDouble(histogram->cumulativeStatistics().computedQuantiles()[i]);
+      }
+      quantile_obj.AddMember("cumulative_value", cumulative_value, allocator);
+      quantile_array.PushBack(quantile_obj, allocator);
+    }
+    histogram_obj.AddMember("quantiles", quantile_array, allocator);
+    stats_array.PushBack(histogram_obj, allocator);
+  }
+
   document.AddMember("stats", stats_array, allocator);
   rapidjson::StringBuffer strbuf;
   rapidjson::PrettyWriter<StringBuffer> writer(strbuf);

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -392,7 +392,6 @@ Http::Code AdminImpl::handlerStats(absl::string_view url, Http::HeaderMap& respo
   Http::Code rc = Http::Code::OK;
   const Http::Utility::QueryParams params = Http::Utility::parseQueryString(url);
   std::map<std::string, uint64_t> all_stats;
-  std::map<std::string, std::string> all_histograms;
   for (const Stats::CounterSharedPtr& counter : server_.stats().counters()) {
     all_stats.emplace(counter->name(), counter->value());
   }
@@ -401,6 +400,10 @@ Http::Code AdminImpl::handlerStats(absl::string_view url, Http::HeaderMap& respo
     all_stats.emplace(gauge->name(), gauge->value());
   }
 
+  // TOOD(ramaraochavali): See the comment in ThreadLocalStoreImpl::histograms() for why we use a
+  // multimap here. This makes sure that duplicate histograms get output. When shared storage is
+  // implemented this can be switched back to a normal map.
+  std::multimap<std::string, std::string> all_histograms;
   for (const Stats::ParentHistogramSharedPtr& histogram : server_.stats().histograms()) {
     std::vector<std::string> summary;
     const std::vector<double>& supported_quantiles_ref =

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -134,7 +134,8 @@ private:
   void addOutlierInfo(const std::string& cluster_name,
                       const Upstream::Outlier::Detector* outlier_detector,
                       Buffer::Instance& response);
-  static std::string statsAsJson(const std::map<std::string, uint64_t>& all_stats);
+  static std::string statsAsJson(const std::map<std::string, uint64_t>& all_stats,
+                                 const std::list<Stats::ParentHistogramSharedPtr>& all_histograms);
   static std::string
   runtimeAsJson(const std::vector<std::pair<std::string, Runtime::Snapshot::Entry>>& entries);
   std::vector<const UrlHandler*> sortedHandlers() const;

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -83,13 +83,13 @@ public:
   static Runtime::LoaderPtr createRuntime(Instance& server, Server::Configuration::Initial& config);
 
   /**
-   * Helper for flushing counters and gauges to sinks. This takes care of calling beginFlush(),
-   * latching of counters and flushing, flushing of gauges, and calling endFlush(), on each sink.
+   * Helper for flushing counters, gauges and hisograms to sinks. This takes care of calling
+   * beginFlush(), latching of counters and flushing, flushing of gauges, and calling endFlush(), on
+   * each sink.
    * @param sinks supplies the list of sinks.
    * @param store supplies the store to flush.
    */
-  static void flushCountersAndGaugesToSinks(const std::list<Stats::SinkPtr>& sinks,
-                                            Stats::Store& store);
+  static void flushMetricsToSinks(const std::list<Stats::SinkPtr>& sinks, Stats::Store& store);
 
   /**
    * Load a bootstrap config from either v1 or v2 and perform validation.
@@ -209,5 +209,5 @@ private:
   std::unique_ptr<Logger::FileSinkDelegate> file_logger_;
 };
 
-} // Server
+} // namespace Server
 } // namespace Envoy

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -11,6 +11,7 @@
 #include "test/mocks/thread_local/mocks.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/str_split.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -90,6 +91,120 @@ public:
   std::unique_ptr<ThreadLocalStoreImpl> store_;
 };
 
+class HistogramTest : public testing::Test, public RawStatDataAllocator {
+public:
+  typedef std::map<std::string, Stats::ParentHistogramSharedPtr> NameHistogramMap;
+
+  void SetUp() override {
+    ON_CALL(*this, alloc(_)).WillByDefault(Invoke([this](const std::string& name) -> RawStatData* {
+      return alloc_.alloc(name);
+    }));
+
+    ON_CALL(*this, free(_)).WillByDefault(Invoke([this](RawStatData& data) -> void {
+      return alloc_.free(data);
+    }));
+
+    EXPECT_CALL(*this, alloc("stats.overflow"));
+    store_.reset(new ThreadLocalStoreImpl(*this));
+    store_->addSink(sink_);
+    store_->initializeThreading(main_thread_dispatcher_, tls_);
+  }
+
+  void TearDown() override {
+    store_->shutdownThreading();
+    tls_.shutdownThread();
+    // Includes overflow stat.
+    EXPECT_CALL(*this, free(_));
+  }
+
+  NameHistogramMap makeHistogramMap(const std::list<ParentHistogramSharedPtr>& hist_list) {
+    NameHistogramMap name_histogram_map;
+    for (const Stats::ParentHistogramSharedPtr& histogram : hist_list) {
+      // Exclude the scope part of the name.
+      const std::vector<std::string>& split_vector = absl::StrSplit(histogram->name(), '.');
+      name_histogram_map.insert(std::make_pair(split_vector.back(), histogram));
+    }
+    return name_histogram_map;
+  }
+
+  /**
+   * Validates that Histogram merge happens as desired and returns the processed histogram count
+   * that can be asserted later.
+   */
+  uint64_t validateMerge() {
+    bool merge_called = false;
+    store_->mergeHistograms([&merge_called]() -> void { merge_called = true; });
+
+    EXPECT_TRUE(merge_called);
+
+    std::list<ParentHistogramSharedPtr> histogram_list = store_->histograms();
+
+    histogram_t* hist1_cumulative = makeHistogram(h1_cumulative_values_);
+    histogram_t* hist2_cumulative = makeHistogram(h2_cumulative_values_);
+    histogram_t* hist1_interval = makeHistogram(h1_interval_values_);
+    histogram_t* hist2_interval = makeHistogram(h2_interval_values_);
+
+    HistogramStatisticsImpl h1_cumulative_statistics(hist1_cumulative);
+    HistogramStatisticsImpl h2_cumulative_statistics(hist2_cumulative);
+    HistogramStatisticsImpl h1_interval_statistics(hist1_interval);
+    HistogramStatisticsImpl h2_interval_statistics(hist2_interval);
+
+    NameHistogramMap name_histogram_map = makeHistogramMap(histogram_list);
+    const Stats::ParentHistogramSharedPtr& h1 = name_histogram_map["h1"];
+    EXPECT_EQ(h1->cumulativeStatistics().summary(), h1_cumulative_statistics.summary());
+    EXPECT_EQ(h1->intervalStatistics().summary(), h1_interval_statistics.summary());
+
+    if (histogram_list.size() > 1) {
+      const Stats::ParentHistogramSharedPtr& h2 = name_histogram_map["h2"];
+      EXPECT_EQ(h2->cumulativeStatistics().summary(), h2_cumulative_statistics.summary());
+      EXPECT_EQ(h2->intervalStatistics().summary(), h2_interval_statistics.summary());
+    }
+
+    hist_free(hist1_cumulative);
+    hist_free(hist2_cumulative);
+    hist_free(hist1_interval);
+    hist_free(hist2_interval);
+
+    h1_interval_values_.clear();
+    h2_interval_values_.clear();
+
+    return histogram_list.size();
+  }
+
+  void expectCallAndAccumulate(Histogram& histogram, uint64_t record_value) {
+    EXPECT_CALL(sink_, onHistogramComplete(Ref(histogram), record_value));
+    histogram.recordValue(record_value);
+
+    if (histogram.name() == "h1") {
+      h1_cumulative_values_.push_back(record_value);
+      h1_interval_values_.push_back(record_value);
+    } else {
+      h2_cumulative_values_.push_back(record_value);
+      h2_interval_values_.push_back(record_value);
+    }
+  }
+
+  histogram_t* makeHistogram(const std::vector<uint64_t>& values) {
+    histogram_t* histogram = hist_alloc();
+    for (uint64_t value : values) {
+      hist_insert_intscale(histogram, value, 0, 1);
+    }
+    return histogram;
+  }
+
+  MOCK_METHOD1(alloc, RawStatData*(const std::string& name));
+  MOCK_METHOD1(free, void(RawStatData& data));
+
+  NiceMock<Event::MockDispatcher> main_thread_dispatcher_;
+  NiceMock<ThreadLocal::MockInstance> tls_;
+  TestAllocator alloc_;
+  MockSink sink_;
+  std::unique_ptr<ThreadLocalStoreImpl> store_;
+  InSequence s;
+  std::vector<uint64_t> h1_cumulative_values_, h2_cumulative_values_, h1_interval_values_,
+      h2_interval_values_;
+};
+
 TEST_F(StatsThreadLocalStoreTest, NoTls) {
   InSequence s;
   EXPECT_CALL(*this, alloc(_)).Times(2);
@@ -102,6 +217,7 @@ TEST_F(StatsThreadLocalStoreTest, NoTls) {
 
   Histogram& h1 = store_->histogram("h1");
   EXPECT_EQ(&h1, &store_->histogram("h1"));
+
   EXPECT_CALL(sink_, onHistogramComplete(Ref(h1), 200));
   h1.recordValue(200);
   EXPECT_CALL(sink_, onHistogramComplete(Ref(h1), 100));
@@ -341,6 +457,147 @@ TEST_F(StatsThreadLocalStoreTest, ShuttingDown) {
 
   // Includes overflow stat.
   EXPECT_CALL(*this, free(_)).Times(5);
+}
+
+// Histogram tests
+TEST_F(HistogramTest, BasicSingleHistogramMerge) {
+  Histogram& h1 = store_->histogram("h1");
+  EXPECT_EQ("h1", h1.name());
+
+  expectCallAndAccumulate(h1, 0);
+  expectCallAndAccumulate(h1, 43);
+  expectCallAndAccumulate(h1, 41);
+  expectCallAndAccumulate(h1, 415);
+  expectCallAndAccumulate(h1, 2201);
+  expectCallAndAccumulate(h1, 3201);
+  expectCallAndAccumulate(h1, 125);
+  expectCallAndAccumulate(h1, 13);
+
+  EXPECT_EQ(1, validateMerge());
+}
+
+TEST_F(HistogramTest, BasicMultiHistogramMerge) {
+  Histogram& h1 = store_->histogram("h1");
+  Histogram& h2 = store_->histogram("h2");
+  EXPECT_EQ("h1", h1.name());
+  EXPECT_EQ("h2", h2.name());
+
+  expectCallAndAccumulate(h1, 1);
+  expectCallAndAccumulate(h2, 1);
+  expectCallAndAccumulate(h2, 2);
+
+  EXPECT_EQ(2, validateMerge());
+}
+
+TEST_F(HistogramTest, MultiHistogramMultipleMerges) {
+  Histogram& h1 = store_->histogram("h1");
+  Histogram& h2 = store_->histogram("h2");
+  EXPECT_EQ("h1", h1.name());
+  EXPECT_EQ("h2", h2.name());
+
+  // Insert one value in to one histogram and validate
+  expectCallAndAccumulate(h1, 1);
+  EXPECT_EQ(2, validateMerge());
+
+  // Insert value into second histogram and validate that it is merged properly.
+  expectCallAndAccumulate(h2, 1);
+  EXPECT_EQ(2, validateMerge());
+
+  // Insert more values into both the histograms and validate that it is merged properly.
+  expectCallAndAccumulate(h1, 2);
+  EXPECT_EQ(2, validateMerge());
+
+  expectCallAndAccumulate(h2, 3);
+  EXPECT_EQ(2, validateMerge());
+
+  expectCallAndAccumulate(h2, 2);
+  EXPECT_EQ(2, validateMerge());
+
+  // Do not insert any value and validate that intervalSummary is empty for both the histograms and
+  // cumulativeSummary has right values.
+  EXPECT_EQ(2, validateMerge());
+}
+
+TEST_F(HistogramTest, BasicScopeHistogramMerge) {
+  ScopePtr scope1 = store_->createScope("scope1.");
+
+  Histogram& h1 = store_->histogram("h1");
+  Histogram& h2 = scope1->histogram("h2");
+  EXPECT_EQ("h1", h1.name());
+  EXPECT_EQ("scope1.h2", h2.name());
+
+  expectCallAndAccumulate(h1, 2);
+  expectCallAndAccumulate(h2, 2);
+  EXPECT_EQ(2, validateMerge());
+}
+
+TEST_F(HistogramTest, BasicHistogramSummaryValidate) {
+  Histogram& h1 = store_->histogram("h1");
+  Histogram& h2 = store_->histogram("h2");
+
+  expectCallAndAccumulate(h1, 1);
+
+  EXPECT_EQ(2, validateMerge());
+
+  const std::string h1_expected_summary =
+      "P0: 1, P25: 1.025, P50: 1.05, P75: 1.075, P90: 1.09, P95: 1.095, "
+      "P99: 1.099, P99.9: 1.0999, P100: 1.1";
+  const std::string h2_expected_summary =
+      "P0: 0, P25: 25, P50: 50, P75: 75, P90: 90, P95: 95, P99: 99, P99.9: 99.9, P100: 100";
+
+  for (size_t i = 0; i < 100; ++i) {
+    expectCallAndAccumulate(h2, i);
+  }
+
+  EXPECT_EQ(2, validateMerge());
+
+  NameHistogramMap name_histogram_map = makeHistogramMap(store_->histograms());
+  EXPECT_EQ(h1_expected_summary, name_histogram_map["h1"]->cumulativeStatistics().summary());
+  EXPECT_EQ(h2_expected_summary, name_histogram_map["h2"]->cumulativeStatistics().summary());
+}
+
+// Validates the summary after known value merge in to same histogram.
+TEST_F(HistogramTest, BasicHistogramMergeSummary) {
+  Histogram& h1 = store_->histogram("h1");
+
+  for (size_t i = 0; i < 50; ++i) {
+    expectCallAndAccumulate(h1, i);
+  }
+  EXPECT_EQ(1, validateMerge());
+
+  for (size_t i = 50; i < 100; ++i) {
+    expectCallAndAccumulate(h1, i);
+  }
+  EXPECT_EQ(1, validateMerge());
+
+  const std::string expected_summary =
+      "P0: 0, P25: 25, P50: 50, P75: 75, P90: 90, P95: 95, P99: 99, P99.9: 99.9, P100: 100";
+
+  NameHistogramMap name_histogram_map = makeHistogramMap(store_->histograms());
+  EXPECT_EQ(expected_summary, name_histogram_map["h1"]->cumulativeStatistics().summary());
+}
+
+TEST_F(HistogramTest, BasicHistogramUsed) {
+  ScopePtr scope1 = store_->createScope("scope1.");
+
+  Histogram& h1 = store_->histogram("h1");
+  Histogram& h2 = scope1->histogram("h2");
+  EXPECT_EQ("h1", h1.name());
+  EXPECT_EQ("scope1.h2", h2.name());
+
+  EXPECT_CALL(sink_, onHistogramComplete(Ref(h1), 1));
+  h1.recordValue(1);
+
+  NameHistogramMap name_histogram_map = makeHistogramMap(store_->histograms());
+  EXPECT_TRUE(name_histogram_map["h1"]->used());
+  EXPECT_FALSE(name_histogram_map["h2"]->used());
+
+  EXPECT_CALL(sink_, onHistogramComplete(Ref(h2), 2));
+  h2.recordValue(2);
+
+  for (const Stats::ParentHistogramSharedPtr& histogram : store_->histograms()) {
+    EXPECT_TRUE(histogram->used());
+  }
 }
 
 } // namespace Stats

--- a/test/common/thread_local/thread_local_impl_test.cc
+++ b/test/common/thread_local/thread_local_impl_test.cc
@@ -82,6 +82,34 @@ TEST_F(ThreadLocalInstanceImplTest, All) {
   tls_.shutdownThread();
 }
 
+// TODO(ramaraochavali): Run this test with real threads. The current issue in the unit
+// testing environment is, the post to main_dispatcher is not working as expected.
+
+// Validate ThreadLocal::runOnAllThreads behavior with all_thread_complete call back.
+TEST_F(ThreadLocalInstanceImplTest, RunOnAllThreads) {
+  SlotPtr tlsptr = tls_.allocateSlot();
+
+  EXPECT_CALL(thread_dispatcher_, post(_));
+  EXPECT_CALL(main_dispatcher_, post(_));
+
+  // Ensure that the thread local call back and all_thread_complete call back are called.
+  struct {
+    uint64_t thread_local_calls_{0};
+    bool all_threads_complete_ = false;
+  } thread_status;
+
+  tlsptr->runOnAllThreads([&thread_status]() -> void { ++thread_status.thread_local_calls_; },
+                          [&thread_status]() -> void {
+                            EXPECT_EQ(thread_status.thread_local_calls_, 1);
+                            thread_status.all_threads_complete_ = true;
+                          });
+
+  EXPECT_TRUE(thread_status.all_threads_complete_);
+
+  tls_.shutdownGlobalThreading();
+  tls_.shutdownThread();
+}
+
 // Validate ThreadLocal::InstanceImpl's dispatcher() behavior.
 TEST(ThreadLocalInstanceImplDispatcherTest, Dispatcher) {
   InstanceImpl tls;

--- a/test/extensions/stats_sinks/metrics_service/grpc_metrics_service_impl_test.cc
+++ b/test/extensions/stats_sinks/metrics_service/grpc_metrics_service_impl_test.cc
@@ -110,6 +110,10 @@ TEST(MetricsServiceSinkTest, CheckSendCall) {
   NiceMock<Stats::MockGauge> gauge;
   gauge.name_ = "test_gauge";
   sink.flushGauge(gauge, 1);
+
+  NiceMock<Stats::MockParentHistogram> histogram;
+  histogram.name_ = "test_histogram";
+  sink.flushHistogram(histogram);
   EXPECT_CALL(*streamer_, send(_));
 
   sink.endFlush();

--- a/test/extensions/stats_sinks/metrics_service/metrics_service_integration_test.cc
+++ b/test/extensions/stats_sinks/metrics_service/metrics_service_integration_test.cc
@@ -68,6 +68,7 @@ public:
         request_msg.envoy_metrics();
     bool known_counter_exists = false;
     bool known_gauge_exists = false;
+    bool known_histogram_exists = false;
     for (::io::prometheus::client::MetricFamily metrics_family : envoy_metrics) {
       if (metrics_family.name() == "cluster.cluster_0.membership_change" &&
           metrics_family.type() == ::io::prometheus::client::MetricType::COUNTER) {
@@ -79,13 +80,21 @@ public:
         known_gauge_exists = true;
         EXPECT_EQ(1, metrics_family.metric(0).gauge().value());
       }
+      if (metrics_family.name() == "cluster.cluster_0.upstream_rq_time" &&
+          metrics_family.type() == ::io::prometheus::client::MetricType::SUMMARY) {
+        known_histogram_exists = true;
+        Stats::HistogramStatisticsImpl empty_statistics;
+        EXPECT_EQ(metrics_family.metric(0).summary().quantile_size(),
+                  empty_statistics.supportedQuantiles().size());
+      }
       ASSERT(metrics_family.metric(0).has_timestamp_ms());
-      if (known_counter_exists && known_gauge_exists) {
+      if (known_counter_exists && known_gauge_exists && known_histogram_exists) {
         break;
       }
     }
     EXPECT_TRUE(known_counter_exists);
     EXPECT_TRUE(known_gauge_exists);
+    EXPECT_TRUE(known_histogram_exists);
   }
 
   void cleanup() {
@@ -102,18 +111,29 @@ public:
 INSTANTIATE_TEST_CASE_P(IpVersionsClientType, MetricsServiceIntegrationTest,
                         GRPC_CLIENT_INTEGRATION_PARAMS);
 
-// Test a basic full access logging flow.
+// Test a basic metric service flow.
 TEST_P(MetricsServiceIntegrationTest, BasicFlow) {
   initialize();
+  // Send an empty request so that histogram values merged for cluster_0.
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  Http::TestHeaderMapImpl request_headers{{":method", "GET"},
+                                          {":path", "/test/long/url"},
+                                          {":scheme", "http"},
+                                          {":authority", "host"},
+                                          {"x-lyft-user-id", "123"}};
+  sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
+
   waitForMetricsServiceConnection();
   waitForMetricsStream();
   waitForMetricsRequest();
+
   // Send an empty response and end the stream. This should never happen but make sure nothing
   // breaks and we make a new stream on a follow up request.
   metrics_service_request_->startGrpcStream();
   envoy::service::metrics::v2::StreamMetricsResponse response_msg;
   metrics_service_request_->sendGrpcMessage(response_msg);
   metrics_service_request_->finishGrpcStream(Grpc::Status::Ok);
+
   switch (clientType()) {
   case Grpc::ClientType::EnvoyGrpc:
     test_server_->waitForGaugeEq("cluster.metrics_service.upstream_rq_active", 0);

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -176,11 +176,17 @@ public:
     return store_.gauges();
   }
 
+  std::list<ParentHistogramSharedPtr> histograms() const override {
+    std::unique_lock<std::mutex> lock(lock_);
+    return store_.histograms();
+  }
+
   // Stats::StoreRoot
   void addSink(Sink&) override {}
   void setTagProducer(TagProducerPtr&&) override {}
   void initializeThreading(Event::Dispatcher&, ThreadLocal::Instance&) override {}
   void shutdownThreading() override {}
+  void mergeHistograms(PostMergeCb) override {}
 
 private:
   mutable std::mutex lock_;

--- a/test/mocks/stats/mocks.cc
+++ b/test/mocks/stats/mocks.cc
@@ -5,6 +5,7 @@
 
 using testing::Invoke;
 using testing::NiceMock;
+using testing::Return;
 using testing::ReturnRef;
 using testing::_;
 
@@ -34,7 +35,22 @@ MockHistogram::MockHistogram() {
   ON_CALL(*this, tagExtractedName()).WillByDefault(ReturnRef(name_));
   ON_CALL(*this, tags()).WillByDefault(ReturnRef(tags_));
 }
+
 MockHistogram::~MockHistogram() {}
+
+MockParentHistogram::MockParentHistogram() {
+  ON_CALL(*this, recordValue(_)).WillByDefault(Invoke([this](uint64_t value) {
+    if (store_ != nullptr) {
+      store_->deliverHistogramToSinks(*this, value);
+    }
+  }));
+  ON_CALL(*this, tagExtractedName()).WillByDefault(ReturnRef(name_));
+  ON_CALL(*this, tags()).WillByDefault(ReturnRef(tags_));
+  ON_CALL(*this, intervalStatistics()).WillByDefault(ReturnRef(*histogram_stats_));
+  ON_CALL(*this, cumulativeStatistics()).WillByDefault(ReturnRef(*histogram_stats_));
+}
+
+MockParentHistogram::~MockParentHistogram() {}
 
 MockSink::MockSink() {}
 MockSink::~MockSink() {}

--- a/test/mocks/thread_local/mocks.h
+++ b/test/mocks/thread_local/mocks.h
@@ -28,6 +28,11 @@ public:
 
   SlotPtr allocateSlot_() { return SlotPtr{new SlotImpl(*this, current_slot_++)}; }
   void runOnAllThreads_(Event::PostCb cb) { cb(); }
+  void runOnAllThreads(Event::PostCb cb, Event::PostCb main_callback) {
+    cb();
+    main_callback();
+  }
+
   void shutdownThread_() {
     shutdown_ = true;
     // Reverse order which is same as the production code.
@@ -53,6 +58,9 @@ public:
     // ThreadLocal::Slot
     ThreadLocalObjectSharedPtr get() override { return parent_.data_[index_]; }
     void runOnAllThreads(Event::PostCb cb) override { parent_.runOnAllThreads(cb); }
+    void runOnAllThreads(Event::PostCb cb, Event::PostCb main_callback) override {
+      parent_.runOnAllThreads(cb, main_callback);
+    }
     void set(InitializeCb cb) override { parent_.data_[index_] = cb(parent_.dispatcher_); }
 
     MockInstance& parent_;

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -36,7 +36,7 @@ TEST(ServerInstanceUtil, flushHelper) {
 
   std::list<Stats::SinkPtr> sinks;
   sinks.emplace_back(std::move(sink));
-  InstanceUtil::flushCountersAndGaugesToSinks(sinks, store);
+  InstanceUtil::flushMetricsToSinks(sinks, store);
 }
 
 class RunHelperTest : public testing::Test {


### PR DESCRIPTION
This change unreverts:
https://github.com/envoyproxy/envoy/pull/3130
https://github.com/envoyproxy/envoy/pull/3183
https://github.com/envoyproxy/envoy/pull/3219
Also fixes https://github.com/envoyproxy/envoy/issues/3223

Please see the 2nd commit for the actual changes. The changes are:
1) Bring in a new histogram library version with the fix (and more debug
 checking).
2) Fix a small issue with scope iteration during merging.
3) Remove de-dup for histograms until we iterate to shared
storage for overlapping scope histograms. Personally, I found
this very confusing when debugging and I think the way I changed
it is better for now given the code we have.

