### PR TITLE
Fixes for GCC 8

### DIFF
--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -185,7 +185,8 @@ int Ipv4Instance::socket(SocketType type) const { return socketFromSocketType(ty
 absl::uint128 Ipv6Instance::Ipv6Helper::address() const {
   absl::uint128 result{0};
   static_assert(sizeof(absl::uint128) == 16, "The size of asbl::uint128 is not 16.");
-  memcpy(&result, &address_.sin6_addr.s6_addr, sizeof(absl::uint128));
+  memcpy(static_cast<void*>(&result), static_cast<const void*>(&address_.sin6_addr.s6_addr),
+         sizeof(absl::uint128));
   return result;
 }
 

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -168,7 +168,7 @@ void HotRestartImpl::free(Stats::RawStatData& data) {
   }
   bool key_removed = stats_set_->remove(data.key());
   ASSERT(key_removed);
-  memset(&data, 0, Stats::RawStatData::size());
+  memset(static_cast<void*>(&data), 0, Stats::RawStatData::size());
 }
 
 int HotRestartImpl::bindDomainSocket(uint64_t id) {


### PR DESCRIPTION
memset and memcpy have some increased strictness in GCC 8

Found while updating the build for fedora 28 and rawhide (https://copr.fedorainfracloud.org/coprs/vbatts/envoy/builds/).
```
$ gcc --version
gcc (GCC) 8.0.1 20180324 (Red Hat 8.0.1-0.20)
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```



>Title can be a one or two words to describe the subsystem or the aspect
 this PR applies to. Title and description must be lower case. For example:
* ci: update build image to 44d539cb
* docs: fix indent, buffer: add copyOut() method
* router:add x-envoy-overloaded header
* tls: add support for specifying TLS session ticket keys

*Description*:
>What does this PR do? What was the behavior before the PR?
What is the behavior with the PR? If fixing a bug, please describe what
the original issue is and how the change resolves it. How does this
feature get enabled? By default, config change, etc...

*Risk Level*: Low | Medium | High
>Low: Small bug fix or small optional feature.

>Medium: New features that are not enabled(for example: new filter). Small-medium
features added to existing components(for example: modification to an existing
filter).

>High: Complicated changes such as flow control, rewrites of critical
components, etc.

>Note: The above is only a rough guide for choosing a level,
please ask if you have any concerns about the risk of the PR.

*Testing*:
>Explanation of what testing was done, for example: unit test,
integration, manual testing, etc.

>Note: It isn’t expected to do all
forms of testing, please use your best judgement or ask for guidance
if you are unsure. A good rule of thumb is the riskier the change, the
more comprehensive the testing should be.

*Docs Changes*:
Description of documentation changes. These should be made in [docs/root](docs/root) and/or inline
with the API protos. Please write in N/A if there were no documentation changes.

*Release Notes*:
>If this change is user impacting you **must** add a release note to
[version_history.rst](docs/root/intro/version_history.rst). Please include any relevant links. Each
release note should be prefixed with the relevant subsystem in alphabetical order (see existing
examples as a guide) and include links to relevant parts of the documentation. Thank you! Please
write in N/A if there are no release notes.

[Optional Fixes #Issue]

[Optional *Deprecated*:]
>Description of what is [deprecated](DEPRECATED.md).
