### PR TITLE
upstream: desynchronize WRR picks.

### DIFF
--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -488,7 +488,7 @@ HostConstSharedPtr RoundRobinLoadBalancer::chooseHost(LoadBalancerContext*) {
     // We do not expire any hosts from the host list without rebuilding the scheduler.
     ASSERT(host != nullptr);
     scheduler.edf_.add(host->weight(), host);
-    // Track the nubmer of picks so we can pick up where we left of when
+    // Track the number of picks so we can pick up where we left off when
     // rebuilding.
     ++scheduler.rr_index_;
     return host;

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -228,13 +228,16 @@ private:
   struct Scheduler {
     // EdfScheduler for weighted RR.
     EdfScheduler<const Host> edf_;
-    // Simple clock hand for when we do unweighted.
+    // Simple clock hand for when we do unweighted. Tracks the total number of
+    // picks when weighted.
     size_t rr_index_{};
     bool weighted_{};
   };
 
   // Scheduler for each valid HostsSource.
   std::unordered_map<HostsSource, Scheduler, HostsSourceHash> scheduler_;
+  // Seed to allow us to desynchronize WRR balancers across a fleet.
+  const uint64_t seed_;
 };
 
 /**

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -228,15 +228,20 @@ private:
   struct Scheduler {
     // EdfScheduler for weighted RR.
     EdfScheduler<const Host> edf_;
-    // Simple clock hand for when we do unweighted. Tracks the total number of
-    // picks when weighted.
+    // Simple clock hand for when we do unweighted. We also maintain this to
+    // provide the total number of picks when weighted, since this allows us to
+    // resume in the schedule on a rebuild where we left off.
     size_t rr_index_{};
     bool weighted_{};
   };
 
   // Scheduler for each valid HostsSource.
   std::unordered_map<HostsSource, Scheduler, HostsSourceHash> scheduler_;
-  // Seed to allow us to desynchronize WRR balancers across a fleet.
+  // Seed to allow us to desynchronize WRR balancers across a fleet. If we don't
+  // do this, multiple Envoys that receive an update at the same time (or even
+  // multiple RoundRobinLoadBalancers on the same host) will send requests to
+  // backends in roughly lock step, causing significant imbalance and potential
+  // overload.
   const uint64_t seed_;
 };
 

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -210,7 +210,9 @@ private:
  * simple index to acheive O(1) scheduling in that case.
  * TODO(htuch): We use EDF at Google, but the EDF scheduler may be overkill if we don't want to
  * support large ranges of weights or arbitrary precision floating weights, we could construct an
- * explicit schedule, since m will be a small constant factor in O(m * n).
+ * explicit schedule, since m will be a small constant factor in O(m * n). This
+ * could also be done on a thread aware LB, avoiding creating multiple EDF
+ * instances.
  */
 class RoundRobinLoadBalancer : public LoadBalancer, ZoneAwareLoadBalancerBase {
 public:
@@ -228,9 +230,7 @@ private:
   struct Scheduler {
     // EdfScheduler for weighted RR.
     EdfScheduler<const Host> edf_;
-    // Simple clock hand for when we do unweighted. We also maintain this to
-    // provide the total number of picks when weighted, since this allows us to
-    // resume in the schedule on a rebuild where we left off.
+    // Simple clock hand for when we do unweighted.
     size_t rr_index_{};
     bool weighted_{};
   };

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -63,9 +63,9 @@ MainCommonBase::MainCommonBase(OptionsImpl& options) : options_(options) {
     Logger::Registry::initialize(options_.logLevel(), options_.logFormat(), log_lock);
 
     stats_store_.reset(new Stats::ThreadLocalStoreImpl(restarter_->statsAllocator()));
-    server_.reset(new Server::InstanceImpl(options_, local_address, default_test_hooks_,
-                                           *restarter_, *stats_store_, access_log_lock,
-                                           component_factory_, *tls_));
+    server_.reset(new Server::InstanceImpl(
+        options_, local_address, default_test_hooks_, *restarter_, *stats_store_, access_log_lock,
+        component_factory_, std::make_unique<Runtime::RandomGeneratorImpl>(), *tls_));
     break;
   }
   case Server::Mode::Validate:

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -43,13 +43,16 @@ namespace Server {
 InstanceImpl::InstanceImpl(Options& options, Network::Address::InstanceConstSharedPtr local_address,
                            TestHooks& hooks, HotRestart& restarter, Stats::StoreRoot& store,
                            Thread::BasicLockable& access_log_lock,
-                           ComponentFactory& component_factory, ThreadLocal::Instance& tls)
+                           ComponentFactory& component_factory,
+                           Runtime::RandomGeneratorPtr&& random_generator,
+                           ThreadLocal::Instance& tls)
     : options_(options), restarter_(restarter), start_time_(time(nullptr)),
       original_start_time_(start_time_), stats_store_(store), thread_local_(tls),
       api_(new Api::Impl(options.fileFlushIntervalMsec())), dispatcher_(api_->allocateDispatcher()),
       singleton_manager_(new Singleton::ManagerImpl()),
       handler_(new ConnectionHandlerImpl(ENVOY_LOGGER(), *dispatcher_)),
-      listener_component_factory_(*this), worker_factory_(thread_local_, *api_, hooks),
+      random_generator_(std::move(random_generator)), listener_component_factory_(*this),
+      worker_factory_(thread_local_, *api_, hooks),
       dns_resolver_(dispatcher_->createDnsResolver({})),
       access_log_manager_(*api_, *dispatcher_, access_log_lock, store), terminated_(false) {
 

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -130,7 +130,7 @@ public:
   InstanceImpl(Options& options, Network::Address::InstanceConstSharedPtr local_address,
                TestHooks& hooks, HotRestart& restarter, Stats::StoreRoot& store,
                Thread::BasicLockable& access_log_lock, ComponentFactory& component_factory,
-               ThreadLocal::Instance& tls);
+               Runtime::RandomGeneratorPtr&& random_generator, ThreadLocal::Instance& tls);
 
   ~InstanceImpl() override;
 
@@ -151,7 +151,7 @@ public:
   HotRestart& hotRestart() override { return restarter_; }
   Init::Manager& initManager() override { return init_manager_; }
   ListenerManager& listenerManager() override { return *listener_manager_; }
-  Runtime::RandomGenerator& random() override { return random_generator_; }
+  Runtime::RandomGenerator& random() override { return *random_generator_; }
   RateLimit::ClientPtr
   rateLimitClient(const absl::optional<std::chrono::milliseconds>& timeout) override {
     return config_->rateLimitClientFactory().create(timeout);
@@ -190,7 +190,7 @@ private:
   std::unique_ptr<AdminImpl> admin_;
   Singleton::ManagerPtr singleton_manager_;
   Network::ConnectionHandlerPtr handler_;
-  Runtime::RandomGeneratorImpl random_generator_;
+  Runtime::RandomGeneratorPtr random_generator_;
   Runtime::LoaderPtr runtime_loader_;
   std::unique_ptr<Ssl::ContextManagerImpl> ssl_context_manager_;
   ProdListenerComponentFactory listener_component_factory_;

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -407,6 +407,8 @@ TEST_P(RoundRobinLoadBalancerTest, Weighted) {
   hostSet().hosts_.push_back(hostSet().healthy_hosts_.back());
   hostSet().runCallbacks({hostSet().healthy_hosts_.back()}, {});
   EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr));
@@ -415,8 +417,6 @@ TEST_P(RoundRobinLoadBalancerTest, Weighted) {
   EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
-  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
-  EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
   // Remove last two hosts, add a new one with different weights.
   HostVector removed_hosts = {hostSet().hosts_[1], hostSet().hosts_[2]};

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -333,6 +333,22 @@ TEST_P(RoundRobinLoadBalancerTest, Normal) {
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
 }
 
+// Validate that the RNG seed influences pick order.
+TEST_P(RoundRobinLoadBalancerTest, Seed) {
+  hostSet().healthy_hosts_ = {
+      makeTestHost(info_, "tcp://127.0.0.1:80"),
+      makeTestHost(info_, "tcp://127.0.0.1:81"),
+      makeTestHost(info_, "tcp://127.0.0.1:82"),
+  };
+  hostSet().hosts_ = hostSet().healthy_hosts_;
+  EXPECT_CALL(random_, random()).WillRepeatedly(Return(1));
+  init(false);
+  EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
+}
+
 TEST_P(RoundRobinLoadBalancerTest, Locality) {
   HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:80"),
                                             makeTestHost(info_, "tcp://127.0.0.1:81"),
@@ -391,8 +407,6 @@ TEST_P(RoundRobinLoadBalancerTest, Weighted) {
   hostSet().hosts_.push_back(hostSet().healthy_hosts_.back());
   hostSet().runCallbacks({hostSet().healthy_hosts_.back()}, {});
   EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr));
-  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
-  EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr));
@@ -401,6 +415,8 @@ TEST_P(RoundRobinLoadBalancerTest, Weighted) {
   EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
   // Remove last two hosts, add a new one with different weights.
   HostVector removed_hosts = {hostSet().hosts_[1], hostSet().hosts_[2]};
@@ -421,6 +437,22 @@ TEST_P(RoundRobinLoadBalancerTest, Weighted) {
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
+}
+
+// Validate that the RNG seed influences pick order when weighted RR.
+TEST_P(RoundRobinLoadBalancerTest, WeightedSeed) {
+  hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", 1),
+                              makeTestHost(info_, "tcp://127.0.0.1:81", 2)};
+  hostSet().hosts_ = hostSet().healthy_hosts_;
+  EXPECT_CALL(random_, random()).WillRepeatedly(Return(1));
+  init(false);
+  // Initial weights respected.
+  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
 }
 

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -388,8 +388,8 @@ TEST_P(SubsetLoadBalancerTest, FallbackAnyEndpointAfterUpdate) {
   HostSharedPtr added_host = makeHost("tcp://127.0.0.1:8000", {{"version", "1.0"}});
   modifyHosts({added_host}, {host_set_.hosts_.back()});
 
-  EXPECT_EQ(host_set_.hosts_[0], lb_->chooseHost(nullptr));
   EXPECT_EQ(added_host, lb_->chooseHost(nullptr));
+  EXPECT_EQ(host_set_.hosts_[0], lb_->chooseHost(nullptr));
 }
 
 TEST_F(SubsetLoadBalancerTest, FallbackDefaultSubset) {
@@ -898,7 +898,7 @@ TEST_P(SubsetLoadBalancerTest, ZoneAwareFallbackAfterUpdate) {
 
   // Force request out of small zone.
   EXPECT_CALL(random_, random()).WillOnce(Return(0)).WillOnce(Return(9999)).WillOnce(Return(2));
-  EXPECT_EQ(host_set_.healthy_hosts_per_locality_->get()[1][0], lb_->chooseHost(nullptr));
+  EXPECT_EQ(host_set_.healthy_hosts_per_locality_->get()[1][1], lb_->chooseHost(nullptr));
 }
 
 TEST_F(SubsetLoadBalancerTest, ZoneAwareFallbackDefaultSubset) {
@@ -1019,7 +1019,7 @@ TEST_P(SubsetLoadBalancerTest, ZoneAwareFallbackDefaultSubsetAfterUpdate) {
 
   // Force request out of small zone.
   EXPECT_CALL(random_, random()).WillOnce(Return(0)).WillOnce(Return(9999)).WillOnce(Return(2));
-  EXPECT_EQ(host_set_.healthy_hosts_per_locality_->get()[1][1], lb_->chooseHost(nullptr));
+  EXPECT_EQ(host_set_.healthy_hosts_per_locality_->get()[1][3], lb_->chooseHost(nullptr));
 }
 
 TEST_F(SubsetLoadBalancerTest, ZoneAwareBalancesSubsets) {
@@ -1138,7 +1138,7 @@ TEST_P(SubsetLoadBalancerTest, ZoneAwareBalancesSubsetsAfterUpdate) {
 
   // Force request out of small zone.
   EXPECT_CALL(random_, random()).WillOnce(Return(0)).WillOnce(Return(9999)).WillOnce(Return(2));
-  EXPECT_EQ(host_set_.healthy_hosts_per_locality_->get()[1][1], lb_->chooseHost(&context));
+  EXPECT_EQ(host_set_.healthy_hosts_per_locality_->get()[1][3], lb_->chooseHost(&context));
 }
 
 TEST_F(SubsetLoadBalancerTest, DescribeMetadata) {

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -388,14 +388,8 @@ TEST_P(SubsetLoadBalancerTest, FallbackAnyEndpointAfterUpdate) {
   HostSharedPtr added_host = makeHost("tcp://127.0.0.1:8000", {{"version", "1.0"}});
   modifyHosts({added_host}, {host_set_.hosts_.back()});
 
-  if (GetParam() == REMOVES_FIRST) {
-    EXPECT_EQ(host_set_.hosts_[0], lb_->chooseHost(nullptr));
-    EXPECT_EQ(added_host, lb_->chooseHost(nullptr));
-  } else {
-    ASSERT(GetParam() == SIMULTANEOUS);
-    EXPECT_EQ(added_host, lb_->chooseHost(nullptr));
-    EXPECT_EQ(host_set_.hosts_[0], lb_->chooseHost(nullptr));
-  }
+  EXPECT_EQ(added_host, lb_->chooseHost(nullptr));
+  EXPECT_EQ(host_set_.hosts_[0], lb_->chooseHost(nullptr));
 }
 
 TEST_F(SubsetLoadBalancerTest, FallbackDefaultSubset) {

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -388,8 +388,14 @@ TEST_P(SubsetLoadBalancerTest, FallbackAnyEndpointAfterUpdate) {
   HostSharedPtr added_host = makeHost("tcp://127.0.0.1:8000", {{"version", "1.0"}});
   modifyHosts({added_host}, {host_set_.hosts_.back()});
 
-  EXPECT_EQ(added_host, lb_->chooseHost(nullptr));
-  EXPECT_EQ(host_set_.hosts_[0], lb_->chooseHost(nullptr));
+  if (GetParam() == REMOVES_FIRST) {
+    EXPECT_EQ(host_set_.hosts_[0], lb_->chooseHost(nullptr));
+    EXPECT_EQ(added_host, lb_->chooseHost(nullptr));
+  } else {
+    ASSERT(GetParam() == SIMULTANEOUS);
+    EXPECT_EQ(added_host, lb_->chooseHost(nullptr));
+    EXPECT_EQ(host_set_.hosts_[0], lb_->chooseHost(nullptr));
+  }
 }
 
 TEST_F(SubsetLoadBalancerTest, FallbackDefaultSubset) {

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -326,8 +326,8 @@ void BaseIntegrationTest::registerTestServerPorts(const std::vector<std::string>
 
 void BaseIntegrationTest::createGeneratedApiTestServer(const std::string& bootstrap_path,
                                                        const std::vector<std::string>& port_names) {
-  test_server_ =
-      IntegrationTestServer::create(bootstrap_path, version_, pre_worker_start_test_steps_);
+  test_server_ = IntegrationTestServer::create(bootstrap_path, version_,
+                                               pre_worker_start_test_steps_, deterministic_);
   if (config_helper_.bootstrap().static_resources().listeners_size() > 0) {
     // Wait for listeners to be created before invoking registerTestServerPorts() below, as that
     // needs to know about the bound listener ports.
@@ -356,7 +356,8 @@ void BaseIntegrationTest::createApiTestServer(const ApiFilesystemConfig& api_fil
 void BaseIntegrationTest::createTestServer(const std::string& json_path,
                                            const std::vector<std::string>& port_names) {
   test_server_ = IntegrationTestServer::create(
-      TestEnvironment::temporaryFileSubstitute(json_path, port_map_, version_), version_, nullptr);
+      TestEnvironment::temporaryFileSubstitute(json_path, port_map_, version_), version_, nullptr,
+      deterministic_);
   registerTestServerPorts(port_names);
 }
 

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -134,6 +134,8 @@ public:
   void setUpstreamProtocol(FakeHttpConnection::Type protocol);
   // Sets fake_upstreams_count_ and alters the upstream protocol in the config_helper_
   void setUpstreamCount(uint32_t count) { fake_upstreams_count_ = count; }
+  // Make test more deterministic by using a fixed RNG value.
+  void setDeterministic() { deterministic_ = true; }
 
   FakeHttpConnection::Type upstreamProtocol() const { return upstream_protocol_; }
 
@@ -205,6 +207,8 @@ private:
   FakeHttpConnection::Type upstream_protocol_{FakeHttpConnection::Type::HTTP1};
   // True if initialized() has been called.
   bool initialized_{};
+  // True if test will use a fixed RNG value.
+  bool deterministic_{};
 };
 
 } // namespace Envoy

--- a/test/integration/legacy_json_integration_test.cc
+++ b/test/integration/legacy_json_integration_test.cc
@@ -59,7 +59,7 @@ TEST_P(LegacyJsonIntegrationTest, TestServerXfc) {
   param_map["set_current_client_cert_details"] = "";
   std::string config = TestEnvironment::temporaryFileSubstitute(
       "test/config/integration/server_xfcc.json", param_map, port_map_, version_);
-  IntegrationTestServer::create(config, version_, nullptr);
+  IntegrationTestServer::create(config, version_, nullptr, false);
 }
 
 TEST_P(LegacyJsonIntegrationTest, TestEchoServer) {

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -18,7 +18,11 @@ namespace {
 class LoadStatsIntegrationTest : public HttpIntegrationTest,
                                  public testing::TestWithParam<Network::Address::IpVersion> {
 public:
-  LoadStatsIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
+  LoadStatsIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {
+    // We rely on some fairly specific load balancing picks in this test, so
+    // determinizie the schedule.
+    setDeterministic();
+  }
 
   void addEndpoint(envoy::api::v2::endpoint::LocalityLbEndpoints& locality_lb_endpoints,
                    uint32_t index, uint32_t& num_endpoints) {
@@ -346,7 +350,7 @@ TEST_P(LoadStatsIntegrationTest, Success) {
   requestLoadStatsResponse({"cluster_0"});
 
   for (uint32_t i = 0; i < 6; ++i) {
-    sendAndReceiveUpstream(i % 3);
+    sendAndReceiveUpstream((4 + i) % 3);
   }
 
   // No locality for priority=1 since there's no "winter" endpoints.

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -202,7 +202,8 @@ class IntegrationTestServer : Logger::Loggable<Logger::Id::testing>,
 public:
   static IntegrationTestServerPtr create(const std::string& config_path,
                                          const Network::Address::IpVersion version,
-                                         std::function<void()> pre_worker_start_test_steps);
+                                         std::function<void()> pre_worker_start_test_steps,
+                                         bool deterministic);
   ~IntegrationTestServer();
 
   Server::TestDrainManager& drainManager() { return *drain_manager_; }
@@ -217,7 +218,7 @@ public:
     on_worker_listener_removed_cb_ = on_worker_listener_removed;
   }
   void start(const Network::Address::IpVersion version,
-             std::function<void()> pre_worker_start_test_steps);
+             std::function<void()> pre_worker_start_test_steps, bool deterministic);
   void start();
 
   void waitForCounterGe(const std::string& name, uint64_t value) override {
@@ -275,7 +276,7 @@ private:
   /**
    * Runs the real server on a thread.
    */
-  void threadRoutine(const Network::Address::IpVersion version);
+  void threadRoutine(const Network::Address::IpVersion version, bool deterministic);
 
   const std::string config_path_;
   Thread::ThreadPtr thread_;

--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -35,7 +35,8 @@ DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v2::Bootstrap& input) {
   try {
     auto server = std::make_unique<InstanceImpl>(
         options, std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1"), hooks, restart,
-        stats_store, fakelock, component_factory, thread_local_instance);
+        stats_store, fakelock, component_factory, std::make_unique<Runtime::RandomGeneratorImpl>(),
+        thread_local_instance);
   } catch (const EnvoyException& ex) {
     ENVOY_LOG_MISC(debug, "Controlled EnvoyException exit: {}", ex.what());
   }

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -103,7 +103,8 @@ protected:
     server_.reset(new InstanceImpl(
         options_,
         Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("127.0.0.1")),
-        hooks_, restart_, stats_store_, fakelock_, component_factory_, thread_local_));
+        hooks_, restart_, stats_store_, fakelock_, component_factory_,
+        std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), thread_local_));
 
     EXPECT_TRUE(server_->api().fileExists("/dev/null"));
   }
@@ -231,7 +232,8 @@ TEST_P(ServerInstanceImplTest, NoOptionsPassed) {
       server_.reset(new InstanceImpl(
           options_,
           Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("127.0.0.1")),
-          hooks_, restart_, stats_store_, fakelock_, component_factory_, thread_local_)),
+          hooks_, restart_, stats_store_, fakelock_, component_factory_,
+          std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), thread_local_)),
       EnvoyException, "unable to read file: ")
 }
 } // namespace Server


### PR DESCRIPTION
This PR fixes two issues:

* Avoid having synchronized behavior across the fleet by having a seed
  applied to each WRR balancer instance.
* Avoid having unweighted RR reset to same host on each refresh, biasing towards
  earlier hosts in the schedule. This TODO still exists for weighted.

Risk Level: Medium (there will be observable traffic effects due to
  changes in host pick schedule).
Testing: New unit tests, modified existing.

Signed-off-by: Harvey Tuch <htuch@google.com>
