### PR TITLE
JsonStringToMessage from ProtobufUtil to Protobuf::util. Check return…

### DIFF
--- a/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
@@ -55,7 +55,7 @@ TEST_P(BufferIntegrationTest, RouterRequestBufferLimitExceeded) {
 
 ConfigHelper::HttpModifierFunction overrideConfig(const std::string& json_config) {
   ProtobufWkt::Struct pfc;
-  ProtobufUtil::JsonStringToMessage(json_config, &pfc);
+  RELEASE_ASSERT(Protobuf::util::JsonStringToMessage(json_config, &pfc).ok());
 
   return
       [pfc](


### PR DESCRIPTION
…ed Status.

Signed-off-by: Trevor Schroeder <trevors@google.com>

test: fix up function alias and check return status.

ProtobufUtil and Protobuf::util are the same in opensource protobuf, but not at Google.

Risklevel: low