### PR TITLE
ci: retry integration tests on OS X

### DIFF
--- a/ci/mac_ci_steps.sh
+++ b/ci/mac_ci_steps.sh
@@ -3,7 +3,9 @@
 set -e
 
 BAZEL_BUILD_OPTIONS="--curses=no --show_task_finish --verbose_failures"
-BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_output=all"
+# TODO(zuercher): remove --flaky_test_attempts when https://github.com/envoyproxy/envoy/issues/2428
+# is resolved.
+BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_output=all --flaky_test_attempts=integration@2"
 
 # Build envoy and run tests as separate steps so that failure output
 # is somewhat more deterministic (rather than interleaving the build


### PR DESCRIPTION
Adds the `--flaky_test_attempts` flag for OS X CI builds to paper over the flaky tests noted in #2428. Test with "integration" in their names will be retried on failure and the CI will succeed if the retry succeeds.

*Risk Level*: Low 
*Testing*: n/a
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>