### PR TITLE
Parameterize the test for non-IPv4 environments.

### DIFF
--- a/test/server/config_validation/BUILD
+++ b/test/server/config_validation/BUILD
@@ -63,6 +63,7 @@ envoy_cc_test(
     deps = [
         "//source/common/event:libevent_lib",
         "//source/server/config_validation:api_lib",
+        "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
     ],
 )

--- a/test/server/config_validation/dispatcher_test.cc
+++ b/test/server/config_validation/dispatcher_test.cc
@@ -16,9 +16,8 @@
 namespace Envoy {
 
 // Define fixture which allocates ValidationDispatcher.
-class ConfigValidation
-    : public ::testing::TestWithParam<Network::Address::IpVersion> {
- public:
+class ConfigValidation : public ::testing::TestWithParam<Network::Address::IpVersion> {
+public:
   ConfigValidation() {
     Event::Libevent::Global::initialize();
 
@@ -38,22 +37,17 @@ private:
 TEST_P(ConfigValidation, createConnection) {
   Network::Address::InstanceConstSharedPtr address;
   if (GetParam() == Network::Address::IpVersion::v4) {
-    address = Network::Address::InstanceConstSharedPtr(
-        new Network::Address::Ipv4Instance("127.0.0.1"));
+    address = Network::Test::getCanonicalLoopbackAddress(Network::Address::IpVersion::v4);
   } else {
-    address = Network::Address::InstanceConstSharedPtr(
-        new Network::Address::Ipv6Instance("::1"));
+    address = Network::Test::getCanonicalLoopbackAddress(Network::Address::IpVersion::v6);
   }
-  dispatcher_->createClientConnection(
-      address, address, Network::Test::createRawBufferSocket(), nullptr);
+  dispatcher_->createClientConnection(address, address, Network::Test::createRawBufferSocket(),
+                                      nullptr);
   SUCCEED();
 }
 
-INSTANTIATE_TEST_CASE_P(
-    IpVersions, ConfigValidation,
-    testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
-    TestUtility::ipTestParamsToString);
+INSTANTIATE_TEST_CASE_P(IpVersions, ConfigValidation,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 } // namespace Envoy
-
-

--- a/test/server/config_validation/dispatcher_test.cc
+++ b/test/server/config_validation/dispatcher_test.cc
@@ -35,12 +35,8 @@ private:
 // Simple test which creates a connection to fake upstream client. This is to test if
 // ValidationDispatcher can call createClientConnection without crashing.
 TEST_P(ConfigValidation, createConnection) {
-  Network::Address::InstanceConstSharedPtr address;
-  if (GetParam() == Network::Address::IpVersion::v4) {
-    address = Network::Test::getCanonicalLoopbackAddress(Network::Address::IpVersion::v4);
-  } else {
-    address = Network::Test::getCanonicalLoopbackAddress(Network::Address::IpVersion::v6);
-  }
+  Network::Address::InstanceConstSharedPtr address(
+      Network::Test::getCanonicalLoopbackAddress(GetParam()));
   dispatcher_->createClientConnection(address, address, Network::Test::createRawBufferSocket(),
                                       nullptr);
   SUCCEED();


### PR DESCRIPTION
Signed-off-by: Trevor Schroeder <trevors@google.com>

test: fx ipv4 assumption

The test assumes that IPv4 is always supported. It is not. This PR parameterizes it to run in IPv6-only environments.

*Risk Level*: Low