### PR TITLE
docs: Clarify how panic mode works with priorities

### DIFF
--- a/docs/root/intro/arch_overview/load_balancing.rst
+++ b/docs/root/intro/arch_overview/load_balancing.rst
@@ -125,7 +125,10 @@ is used to avoid a situation in which host failures cascade throughout the clust
 increases.
 
 Note that panic thresholds are *per-priority*. This means that if the percentage of healthy nodes
-in a single priority goes below the threshold, that priority is will enter panic mode.
+in a single priority goes below the threshold, that priority will enter panic mode. In general
+it is discouraged to use panic thresholds in conjunction with priorities, as by the time enough
+nodes are unhealthy to trigger the panic threshold most of the traffic should already have spilled
+over to the next priority level.
 
 .. _arch_overview_load_balancing_priority_levels:
 

--- a/docs/root/intro/arch_overview/load_balancing.rst
+++ b/docs/root/intro/arch_overview/load_balancing.rst
@@ -124,6 +124,9 @@ runtime as well as in the :ref:`cluster configuration
 is used to avoid a situation in which host failures cascade throughout the cluster as load
 increases.
 
+Note that panic thresholds are *per-priority*. This means that if the percentage of healthy nodes
+in a single priority goes below the threshold, that priority is will enter panic mode.
+
 .. _arch_overview_load_balancing_priority_levels:
 
 Priority levels


### PR DESCRIPTION
*title*: docs: Clarify how panic mode works with priorities

*Description*:
Clarifies that panic mode counts the number of healthy nodes per priority
and triggers panic mode for a priority. Based on my reading of this code: https://github.com/envoyproxy/envoy/blob/master/source/common/upstream/thread_aware_lb_impl.cc#L24-L30

*Risk Level*: 
Low: Documentation change

*Testing*:
N/A

*Docs Changes*:
See summary

*Release Notes*:
N/A

