### PR TITLE
stats: add config option to skip flushing individual stats to stat sinks

### DIFF
--- a/api/envoy/config/metrics/v2/stats.proto
+++ b/api/envoy/config/metrics/v2/stats.proto
@@ -56,11 +56,13 @@ message StatsConfig {
   // If not provided, this value defaults to true.
   google.protobuf.BoolValue use_all_default_tags = 2;
 
-  // Flush each individual statistic to the configured sinks. If this is set to false, each sink
-  // will be responsible for querying the stats manually in startFlush() and endFlush().
+  // Disable flushing individual stats to the sinks. If this is set to true, each sink
+  // will be responsible for querying the stats manually in startFlush() and endFlush(). The
+  // typical use case for disabling this is a sink that queries a small number of specific stats,
+  // which makes pushing each stat unnecessary.
   //
-  // If not provided, this value defaults to true.
-  google.protobuf.BoolValue flush_individual_stats = 3;
+  // If not provided, this value defaults to false.
+  bool disable_individual_stats_flush = 3;
 }
 
 // Designates a tag name and value pair. The value may be either a fixed value

--- a/api/envoy/config/metrics/v2/stats.proto
+++ b/api/envoy/config/metrics/v2/stats.proto
@@ -53,8 +53,14 @@ message StatsConfig {
   // <https://github.com/envoyproxy/envoy/blob/master/source/common/config/well_known_names.h>`_
   // for a list of the default tags in Envoy.
   //
-  // If not provided, the value is assumed to be true.
+  // If not provided, this value defaults to true.
   google.protobuf.BoolValue use_all_default_tags = 2;
+
+  // Flush each individual statistic to the configured sinks. If this is set to false, each sink
+  // will be responsible for querying the stats manually in startFlush() and endFlush().
+  //
+  // If not provided, this value defaults to true.
+  google.protobuf.BoolValue flush_individual_stats = 3;
 }
 
 // Designates a tag name and value pair. The value may be either a fixed value

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -65,6 +65,7 @@ Version history
 * sockets: added `SO_KEEPALIVE` socket option for upstream connections
   :ref:`per cluster <envoy_api_field_Cluster.upstream_connection_options>`.
 * stats: added support for histograms.
+* stats: added config option to disable the flushing of individual stats to the sinks.
 * tracing: the sampling decision is now delegated to the tracers, allowing the tracer to decide when and if
   to use it. For example, if the :ref:`x-b3-sampled <config_http_conn_man_headers_x-b3-sampled>` header
   is supplied with the client request, its value will override any sampling decision made by the Envoy proxy.

--- a/include/envoy/server/configuration.h
+++ b/include/envoy/server/configuration.h
@@ -98,6 +98,11 @@ public:
    *         multiple nonresponsive threads.
    */
   virtual std::chrono::milliseconds wdMultiKillTimeout() const PURE;
+
+  /**
+   * @return bool whether the server should flush individual stats to sinks.
+   */
+  virtual bool flushIndividualStats() const PURE;
 };
 
 /**

--- a/include/envoy/server/configuration.h
+++ b/include/envoy/server/configuration.h
@@ -100,9 +100,9 @@ public:
   virtual std::chrono::milliseconds wdMultiKillTimeout() const PURE;
 
   /**
-   * @return bool whether the server should flush individual stats to sinks.
+   * @return bool whether the individual stats flush is disabled.
    */
-  virtual bool flushIndividualStats() const PURE;
+  virtual bool disableIndividualStatsFlush() const PURE;
 };
 
 /**

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -156,8 +156,7 @@ RawStatData* HeapRawStatDataAllocator::alloc(const std::string& name) {
   return data;
 }
 
-TagProducerImpl::TagProducerImpl(const envoy::config::metrics::v2::StatsConfig& config)
-    : TagProducerImpl() {
+TagProducerImpl::TagProducerImpl(const envoy::config::metrics::v2::StatsConfig& config) {
   // To check name conflict.
   reserveResources(config);
   std::unordered_set<std::string> names = addDefaultExtractors(config);

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -64,8 +64,7 @@ void MainImpl::initialize(const envoy::config::bootstrap::v2::Bootstrap& bootstr
 
   stats_flush_interval_ =
       std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(bootstrap, stats_flush_interval, 5000));
-  flush_individual_stats_ = !bootstrap.stats_config().has_flush_individual_stats() ||
-                            bootstrap.stats_config().flush_individual_stats().value();
+  disable_individual_stats_flush_ = bootstrap.stats_config().disable_individual_stats_flush();
 
   const auto& watchdog = bootstrap.watchdog();
   watchdog_miss_timeout_ =

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -64,6 +64,8 @@ void MainImpl::initialize(const envoy::config::bootstrap::v2::Bootstrap& bootstr
 
   stats_flush_interval_ =
       std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(bootstrap, stats_flush_interval, 5000));
+  flush_individual_stats_ = !bootstrap.stats_config().has_flush_individual_stats() ||
+                            bootstrap.stats_config().flush_individual_stats().value();
 
   const auto& watchdog = bootstrap.watchdog();
   watchdog_miss_timeout_ =

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -136,7 +136,7 @@ public:
   std::chrono::milliseconds wdMultiKillTimeout() const override {
     return watchdog_multikill_timeout_;
   }
-  bool flushIndividualStats() const override { return flush_individual_stats_; }
+  bool disableIndividualStatsFlush() const override { return disable_individual_stats_flush_; }
 
 private:
   /**
@@ -157,7 +157,7 @@ private:
   std::chrono::milliseconds watchdog_megamiss_timeout_;
   std::chrono::milliseconds watchdog_kill_timeout_;
   std::chrono::milliseconds watchdog_multikill_timeout_;
-  bool flush_individual_stats_;
+  bool disable_individual_stats_flush_;
 };
 
 /**

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -136,6 +136,7 @@ public:
   std::chrono::milliseconds wdMultiKillTimeout() const override {
     return watchdog_multikill_timeout_;
   }
+  bool flushIndividualStats() const override { return flush_individual_stats_; }
 
 private:
   /**
@@ -156,6 +157,7 @@ private:
   std::chrono::milliseconds watchdog_megamiss_timeout_;
   std::chrono::milliseconds watchdog_kill_timeout_;
   std::chrono::milliseconds watchdog_multikill_timeout_;
+  bool flush_individual_stats_;
 };
 
 /**

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -103,12 +103,12 @@ void InstanceImpl::failHealthcheck(bool fail) {
 }
 
 void InstanceUtil::flushMetricsToSinks(const std::list<Stats::SinkPtr>& sinks, Stats::Store& store,
-                                       bool flush_individual_stats) {
+                                       bool disable_individual_stats_flush) {
   for (const auto& sink : sinks) {
     sink->beginFlush();
   }
 
-  if (flush_individual_stats) {
+  if (!disable_individual_stats_flush) {
     for (const Stats::CounterSharedPtr& counter : store.counters()) {
       uint64_t delta = counter->latch();
       if (counter->used()) {
@@ -156,7 +156,7 @@ void InstanceImpl::flushStats() {
     server_stats_->days_until_first_cert_expiring_.set(
         sslContextManager().daysUntilFirstCertExpires());
     InstanceUtil::flushMetricsToSinks(config_->statsSinks(), stats_store_,
-                                      config_->flushIndividualStats());
+                                      config_->disableIndividualStatsFlush());
     // TODO(ramaraochavali): consider adding different flush interval for histograms.
     stat_flush_timer_->enableTimer(config_->statsFlushInterval());
   });

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -83,13 +83,15 @@ public:
   static Runtime::LoaderPtr createRuntime(Instance& server, Server::Configuration::Initial& config);
 
   /**
-   * Helper for flushing counters, gauges and hisograms to sinks. This takes care of calling
-   * beginFlush(), latching of counters and flushing, flushing of gauges, and calling endFlush(), on
-   * each sink.
+   * Helper for flushing counters and gauges to sinks. This takes care of calling beginFlush(),
+   * optional latching of counters and flushing, optional flushing of gauges, merging of histograms
+   * and optional flushing, and calling endFlush(), on each sink.
    * @param sinks supplies the list of sinks.
    * @param store supplies the store to flush.
+   * @param flush_individual_stats whether to flush individual stats to the sinks.
    */
-  static void flushMetricsToSinks(const std::list<Stats::SinkPtr>& sinks, Stats::Store& store);
+  static void flushMetricsToSinks(const std::list<Stats::SinkPtr>& sinks, Stats::Store& store,
+                                  bool flush_individual_stats);
 
   /**
    * Load a bootstrap config from either v1 or v2 and perform validation.

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -131,7 +131,7 @@ MockMain::MockMain(int wd_miss, int wd_megamiss, int wd_kill, int wd_multikill)
   ON_CALL(*this, wdMegaMissTimeout()).WillByDefault(Return(wd_megamiss_));
   ON_CALL(*this, wdKillTimeout()).WillByDefault(Return(wd_kill_));
   ON_CALL(*this, wdMultiKillTimeout()).WillByDefault(Return(wd_multikill_));
-  ON_CALL(*this, flushIndividualStats()).WillByDefault(Return(flush_individual_stats_));
+  ON_CALL(*this, disableIndividualStatsFlush()).WillByDefault(Return(disable_individual_stats_flush_));
 }
 
 MockFactoryContext::MockFactoryContext() : singleton_manager_(new Singleton::ManagerImpl()) {

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -131,7 +131,8 @@ MockMain::MockMain(int wd_miss, int wd_megamiss, int wd_kill, int wd_multikill)
   ON_CALL(*this, wdMegaMissTimeout()).WillByDefault(Return(wd_megamiss_));
   ON_CALL(*this, wdKillTimeout()).WillByDefault(Return(wd_kill_));
   ON_CALL(*this, wdMultiKillTimeout()).WillByDefault(Return(wd_multikill_));
-  ON_CALL(*this, disableIndividualStatsFlush()).WillByDefault(Return(disable_individual_stats_flush_));
+  ON_CALL(*this, disableIndividualStatsFlush())
+      .WillByDefault(Return(disable_individual_stats_flush_));
 }
 
 MockFactoryContext::MockFactoryContext() : singleton_manager_(new Singleton::ManagerImpl()) {

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -131,6 +131,7 @@ MockMain::MockMain(int wd_miss, int wd_megamiss, int wd_kill, int wd_multikill)
   ON_CALL(*this, wdMegaMissTimeout()).WillByDefault(Return(wd_megamiss_));
   ON_CALL(*this, wdKillTimeout()).WillByDefault(Return(wd_kill_));
   ON_CALL(*this, wdMultiKillTimeout()).WillByDefault(Return(wd_multikill_));
+  ON_CALL(*this, flushIndividualStats()).WillByDefault(Return(flush_individual_stats_));
 }
 
 MockFactoryContext::MockFactoryContext() : singleton_manager_(new Singleton::ManagerImpl()) {

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -327,11 +327,13 @@ public:
   MOCK_CONST_METHOD0(wdMegaMissTimeout, std::chrono::milliseconds());
   MOCK_CONST_METHOD0(wdKillTimeout, std::chrono::milliseconds());
   MOCK_CONST_METHOD0(wdMultiKillTimeout, std::chrono::milliseconds());
+  MOCK_CONST_METHOD0(flushIndividualStats, bool());
 
   std::chrono::milliseconds wd_miss_;
   std::chrono::milliseconds wd_megamiss_;
   std::chrono::milliseconds wd_kill_;
   std::chrono::milliseconds wd_multikill_;
+  bool flush_individual_stats_{true};
 };
 
 class MockFactoryContext : public FactoryContext {

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -327,13 +327,13 @@ public:
   MOCK_CONST_METHOD0(wdMegaMissTimeout, std::chrono::milliseconds());
   MOCK_CONST_METHOD0(wdKillTimeout, std::chrono::milliseconds());
   MOCK_CONST_METHOD0(wdMultiKillTimeout, std::chrono::milliseconds());
-  MOCK_CONST_METHOD0(flushIndividualStats, bool());
+  MOCK_CONST_METHOD0(disableIndividualStatsFlush, bool());
 
   std::chrono::milliseconds wd_miss_;
   std::chrono::milliseconds wd_megamiss_;
   std::chrono::milliseconds wd_kill_;
   std::chrono::milliseconds wd_multikill_;
-  bool flush_individual_stats_{true};
+  bool disable_individual_stats_flush_{false};
 };
 
 class MockFactoryContext : public FactoryContext {

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -59,6 +59,35 @@ protected:
   Upstream::ProdClusterManagerFactory cluster_manager_factory_;
 };
 
+TEST_F(ConfigurationImplTest, DefaultFlushIndividualStats) {
+  envoy::config::bootstrap::v2::Bootstrap bootstrap;
+
+  MainImpl config;
+  config.initialize(bootstrap, server_, cluster_manager_factory_);
+
+  EXPECT_TRUE(config.flushIndividualStats());
+}
+
+TEST_F(ConfigurationImplTest, FlushIndividualStatsOn) {
+  envoy::config::bootstrap::v2::Bootstrap bootstrap;
+  bootstrap.mutable_stats_config()->mutable_flush_individual_stats()->set_value(true);
+
+  MainImpl config;
+  config.initialize(bootstrap, server_, cluster_manager_factory_);
+
+  EXPECT_TRUE(config.flushIndividualStats());
+}
+
+TEST_F(ConfigurationImplTest, FlushIndividualStatsOff) {
+  envoy::config::bootstrap::v2::Bootstrap bootstrap;
+  bootstrap.mutable_stats_config()->mutable_flush_individual_stats()->set_value(false);
+
+  MainImpl config;
+  config.initialize(bootstrap, server_, cluster_manager_factory_);
+
+  EXPECT_FALSE(config.flushIndividualStats());
+}
+
 TEST_F(ConfigurationImplTest, DefaultStatsFlushInterval) {
   envoy::config::bootstrap::v2::Bootstrap bootstrap;
 

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -65,27 +65,27 @@ TEST_F(ConfigurationImplTest, DefaultFlushIndividualStats) {
   MainImpl config;
   config.initialize(bootstrap, server_, cluster_manager_factory_);
 
-  EXPECT_TRUE(config.flushIndividualStats());
+  EXPECT_FALSE(config.disableIndividualStatsFlush());
 }
 
-TEST_F(ConfigurationImplTest, FlushIndividualStatsOn) {
+TEST_F(ConfigurationImplTest, DisableFlushIndividualStats) {
   envoy::config::bootstrap::v2::Bootstrap bootstrap;
-  bootstrap.mutable_stats_config()->mutable_flush_individual_stats()->set_value(true);
+  bootstrap.mutable_stats_config()->set_disable_individual_stats_flush(true);
 
   MainImpl config;
   config.initialize(bootstrap, server_, cluster_manager_factory_);
 
-  EXPECT_TRUE(config.flushIndividualStats());
+  EXPECT_TRUE(config.disableIndividualStatsFlush());
 }
 
-TEST_F(ConfigurationImplTest, FlushIndividualStatsOff) {
+TEST_F(ConfigurationImplTest, EnableFlushIndividualStats) {
   envoy::config::bootstrap::v2::Bootstrap bootstrap;
-  bootstrap.mutable_stats_config()->mutable_flush_individual_stats()->set_value(false);
+  bootstrap.mutable_stats_config()->set_disable_individual_stats_flush(false);
 
   MainImpl config;
   config.initialize(bootstrap, server_, cluster_manager_factory_);
 
-  EXPECT_FALSE(config.flushIndividualStats());
+  EXPECT_FALSE(config.disableIndividualStatsFlush());
 }
 
 TEST_F(ConfigurationImplTest, DefaultStatsFlushInterval) {

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -28,15 +28,20 @@ TEST(ServerInstanceUtil, flushHelper) {
   Stats::IsolatedStoreImpl store;
   store.counter("hello").inc();
   store.gauge("world").set(5);
-  std::unique_ptr<Stats::MockSink> sink(new StrictMock<Stats::MockSink>());
+  std::unique_ptr<Stats::MockSink> tmp(new StrictMock<Stats::MockSink>());
+  Stats::MockSink* sink = tmp.get();
+  std::list<Stats::SinkPtr> sinks;
+  sinks.emplace_back(std::move(tmp));
+
   EXPECT_CALL(*sink, beginFlush());
   EXPECT_CALL(*sink, flushCounter(Property(&Stats::Metric::name, "hello"), 1));
   EXPECT_CALL(*sink, flushGauge(Property(&Stats::Metric::name, "world"), 5));
   EXPECT_CALL(*sink, endFlush());
+  InstanceUtil::flushMetricsToSinks(sinks, store, true);
 
-  std::list<Stats::SinkPtr> sinks;
-  sinks.emplace_back(std::move(sink));
-  InstanceUtil::flushMetricsToSinks(sinks, store);
+  EXPECT_CALL(*sink, beginFlush());
+  EXPECT_CALL(*sink, endFlush());
+  InstanceUtil::flushMetricsToSinks(sinks, store, false);
 }
 
 class RunHelperTest : public testing::Test {

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -37,11 +37,11 @@ TEST(ServerInstanceUtil, flushHelper) {
   EXPECT_CALL(*sink, flushCounter(Property(&Stats::Metric::name, "hello"), 1));
   EXPECT_CALL(*sink, flushGauge(Property(&Stats::Metric::name, "world"), 5));
   EXPECT_CALL(*sink, endFlush());
-  InstanceUtil::flushMetricsToSinks(sinks, store, true);
+  InstanceUtil::flushMetricsToSinks(sinks, store, false);
 
   EXPECT_CALL(*sink, beginFlush());
   EXPECT_CALL(*sink, endFlush());
-  InstanceUtil::flushMetricsToSinks(sinks, store, false);
+  InstanceUtil::flushMetricsToSinks(sinks, store, true);
 }
 
 class RunHelperTest : public testing::Test {


### PR DESCRIPTION
*Description*: this config option allows the user to disable the managed latching and individual flush calls for each stat, which can become expensive if not needed.  This is part of a larger effort to make the sink interface more flexible as described in #3190, especially for sinks that wish to query a few stats directly during the flush rather than being pushed all stats.

*Risk Level*: Low

*Testing*: Changes to the server and configuration are unit tested.

*Docs Changes*: added docs in the proto.

*Release Notes*: added release notes.