### PR TITLE
fuzz: some more deflaking

### DIFF
--- a/test/fuzz/main.cc
+++ b/test/fuzz/main.cc
@@ -31,7 +31,7 @@ std::vector<std::string> test_corpus_;
 class FuzzerCorpusTest : public ::testing::TestWithParam<std::string> {};
 
 TEST_P(FuzzerCorpusTest, RunOneCorpusFile) {
-  ENVOY_LOG_MISC(debug, "Corpus file: {}", GetParam());
+  ENVOY_LOG_MISC(info, "Corpus file: {}", GetParam());
   const std::string buf = Filesystem::fileReadToEnd(GetParam());
   // Everything from here on is the same as under the fuzzer lib.
   LLVMFuzzerTestOneInput(reinterpret_cast<const uint8_t*>(buf.c_str()), buf.size());

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-4832853025095680
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-4832853025095680
@@ -25,7 +25,7 @@ static_resources {
     hosts {
       socket_address {
         address: "127.0.0.1"
-        port_value: 4294312379
+        port_value: 0
       }
     }
     dns_lookup_family: V4_ONLY

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-4832853025095680
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-4832853025095680
@@ -25,7 +25,7 @@ static_resources {
     hosts {
       socket_address {
         address: "127.0.0.1"
-        port_value: 0
+        port_value: 4294312379
       }
     }
     dns_lookup_family: V4_ONLY

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5705154446753792
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5705154446753792
@@ -9,13 +9,13 @@ static_resources {
     hosts {
       socket_address {
         address: "127.0.0.1"
-        port_value: 9901
+        port_value: 0
       }
     }
     hosts {
       socket_address {
         address: "127.0.0.1"
-        port_value: 9901
+        port_value: 0
       }
     }
     circuit_breakers {


### PR DESCRIPTION
* Print which test file is being used at info log level to make it
  easier to figure out in CircleCI traces what hangs.

* Zero out some more port values. Maybe it was connecting to some actual
  live ports and hanging during CM init or the like.

Relates to #3248.

Signed-off-by: Harvey Tuch <htuch@google.com>