### PR TITLE
stats: Fix flushStats during shutdown

### DIFF
--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -190,7 +190,48 @@ The fields are:
 
   .. http:get:: /stats?format=json
 
-  Outputs /stats in JSON format. This can be used for programmatic access of stats.
+  Outputs /stats in JSON format. This can be used for programmatic access of stats. Counters and Gauges
+  will be in the form of a set of (name,value) pairs. Histograms will be under the element "histograms",
+  that contains "supported_quantiles" which lists the quantiles supported and an array of computed_quantiles
+  that has the computed quantile for each histogram.
+
+  The JSON structure would as shown below.
+
+  .. code-block:: json
+
+  {
+    "stats": [
+        {
+            "name": "example.counter",
+            "value": 0
+        },
+        {
+            "name": "example.gauge",
+            "value": 0
+        },
+        {
+            "histograms": {
+                "supported_quantiles": [...],
+                "computed_quantiles": [
+                    {
+                        "name": "example.histogram",
+                        "values": [
+                            {
+                                "interval": null,
+                                "cumulative": null
+                            },
+                            {
+                                "interval": null,
+                                "cumulative": null
+                            },
+                            ...
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+  }
 
   .. http:get:: /stats?format=prometheus
 

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -202,34 +202,34 @@ The fields are:
   {
     "stats": [
         {
-            "name": "example.counter",
-            "value": 0
+          "name": "example.counter",
+          "value": 0
         },
         {
-            "name": "example.gauge",
-            "value": 0
+          "name": "example.gauge",
+          "value": 0
         },
         {
-            "histograms": {
-                "supported_quantiles": [...],
-                "computed_quantiles": [
+          "histograms": {
+            "supported_quantiles": [...],
+              "computed_quantiles": [
+                {
+                  "name": "example.histogram",
+                  "values": [
                     {
-                        "name": "example.histogram",
-                        "values": [
-                            {
-                                "interval": null,
-                                "cumulative": null
-                            },
-                            {
-                                "interval": null,
-                                "cumulative": null
-                            },
-                            ...
-                        ]
-                    }
+                      "interval": null,
+                      "cumulative": null
+                    },
+                    {
+                      "interval": null,
+                      "cumulative": null
+                    },
+                    ...
                 ]
-            }
+              }
+          ]
         }
+       }
     ]
   }
 

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -193,45 +193,112 @@ The fields are:
   Outputs /stats in JSON format. This can be used for programmatic access of stats. Counters and Gauges
   will be in the form of a set of (name,value) pairs. Histograms will be under the element "histograms",
   that contains "supported_quantiles" which lists the quantiles supported and an array of computed_quantiles
-  that has the computed quantile for each histogram.
+  that has the computed quantile for each histogram. Only histograms with recorded values will be exported.
 
-  The JSON structure would as shown below.
+  The JSON structure for histograms is shown below. If a histogram is not updated during an interval, it will show
+  null for all the quantiles.
 
   .. code-block:: json
 
   {
-    "stats": [
-        {
-          "name": "example.counter",
-          "value": 0
-        },
-        {
-          "name": "example.gauge",
-          "value": 0
-        },
-        {
-          "histograms": {
-            "supported_quantiles": [...],
-              "computed_quantiles": [
-                {
-                  "name": "example.histogram",
-                  "values": [
-                    {
-                      "interval": null,
-                      "cumulative": null
-                    },
-                    {
-                      "interval": null,
-                      "cumulative": null
-                    },
-                    ...
-                ]
-              }
-          ]
-        }
-       }
+  "histograms":{
+    "supported_quantiles":[
+      0.0,
+      25.0,
+      50.0,
+      75.0,
+      90.0,
+      95.0,
+      99.0,
+      99.9,
+      100.0
+    ],
+    "computed_quantiles":[
+      {
+        "name":"cluster.external_auth_cluster.upstream_cx_length_ms",
+        "values":[
+          {
+            "interval":0.0,
+            "cumulative":0.0
+          },
+          {
+            "interval":0.0,
+            "cumulative":0.0
+          },
+          {
+            "interval":1.043578738857709,
+            "cumulative":1.043578738857709
+          },
+          {
+            "interval":1.0941564872895345,
+            "cumulative":1.0941564872895345
+          },
+          {
+            "interval":2.086002317497103,
+            "cumulative":2.086002317497103
+          },
+          {
+            "interval":3.066523297491039,
+            "cumulative":3.066523297491039
+          },
+          {
+            "interval":6.046608695652175,
+            "cumulative":6.046608695652175
+          },
+          {
+            "interval":229.57333333333436,
+            "cumulative":229.57333333333436
+          },
+          {
+            "interval":260.0,
+            "cumulative":260.0
+          }
+        ]
+      },
+      {
+        "name":"http.admin.downstream_rq_time",
+        "values":[
+          {
+            "interval":null,
+            "cumulative":0.0
+          },
+          {
+            "interval":null,
+            "cumulative":0.0
+          },
+          {
+            "interval":null,
+            "cumulative":1.043578738857709
+          },
+          {
+            "interval":null,
+            "cumulative":1.0941564872895345
+          },
+          {
+            "interval":null,
+            "cumulative":2.086002317497103
+          },
+          {
+            "interval":null,
+            "cumulative":3.066523297491039
+          },
+          {
+            "interval":null,
+            "cumulative":6.046608695652175
+          },
+          {
+            "interval":null,
+            "cumulative":229.57333333333436
+          },
+          {
+            "interval":null,
+            "cumulative":260.0
+          }
+        ]
+      }
     ]
   }
+}
 
   .. http:get:: /stats?format=prometheus
 

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -201,104 +201,109 @@ The fields are:
   .. code-block:: json
 
   {
-  "histograms":{
-    "supported_quantiles":[
-      0.0,
-      25.0,
-      50.0,
-      75.0,
-      90.0,
-      95.0,
-      99.0,
-      99.9,
-      100.0
-    ],
-    "computed_quantiles":[
-      {
-        "name":"cluster.external_auth_cluster.upstream_cx_length_ms",
-        "values":[
-          {
-            "interval":0.0,
-            "cumulative":0.0
-          },
-          {
-            "interval":0.0,
-            "cumulative":0.0
-          },
-          {
-            "interval":1.043578738857709,
-            "cumulative":1.043578738857709
-          },
-          {
-            "interval":1.0941564872895345,
-            "cumulative":1.0941564872895345
-          },
-          {
-            "interval":2.086002317497103,
-            "cumulative":2.086002317497103
-          },
-          {
-            "interval":3.066523297491039,
-            "cumulative":3.066523297491039
-          },
-          {
-            "interval":6.046608695652175,
-            "cumulative":6.046608695652175
-          },
-          {
-            "interval":229.57333333333436,
-            "cumulative":229.57333333333436
-          },
-          {
-            "interval":260.0,
-            "cumulative":260.0
-          }
-        ]
-      },
-      {
-        "name":"http.admin.downstream_rq_time",
-        "values":[
-          {
-            "interval":null,
-            "cumulative":0.0
-          },
-          {
-            "interval":null,
-            "cumulative":0.0
-          },
-          {
-            "interval":null,
-            "cumulative":1.043578738857709
-          },
-          {
-            "interval":null,
-            "cumulative":1.0941564872895345
-          },
-          {
-            "interval":null,
-            "cumulative":2.086002317497103
-          },
-          {
-            "interval":null,
-            "cumulative":3.066523297491039
-          },
-          {
-            "interval":null,
-            "cumulative":6.046608695652175
-          },
-          {
-            "interval":null,
-            "cumulative":229.57333333333436
-          },
-          {
-            "interval":null,
-            "cumulative":260.0
-          }
-        ]
-      }
-    ]
+    "histograms": 
+    {
+      "supported_quantiles": 
+      [
+        0,
+        25,
+        50,
+        75,
+        90,
+        95,
+        99,
+        99.9,
+        100
+      ],
+      "computed_quantiles": 
+      [      
+        {
+          "name": "cluster.external_auth_cluster.upstream_cx_length_ms",
+          "values": 
+          [          
+            {
+              "interval": 0,
+              "cumulative": 0
+            },          
+            {
+              "interval": 0,
+              "cumulative": 0
+            },          
+            {
+              "interval": 1.0435787,
+              "cumulative": 1.0435787
+            },          
+            {
+              "interval": 1.0941565,
+              "cumulative": 1.0941565
+            },          
+            {
+              "interval": 2.0860023,
+              "cumulative": 2.0860023
+            },          
+            {
+              "interval": 3.0665233,
+              "cumulative": 3.0665233
+            },          
+            {
+              "interval": 6.046609,
+              "cumulative": 6.046609
+            },          
+            {
+              "interval": 229.57333,
+              "cumulative": 229.57333
+            },          
+            {
+              "interval": 260,
+              "cumulative": 260
+            }
+          ]
+        },      
+        {
+          "name": "http.admin.downstream_rq_time",
+          "values": 
+          [          
+            {
+              "interval": null,
+              "cumulative": 0
+            },          
+            {
+              "interval": null,
+              "cumulative": 0
+            },          
+            {
+              "interval": null,
+              "cumulative": 1.0435787
+            },          
+            {
+              "interval": null,
+              "cumulative": 1.0941565
+            },          
+            {
+              "interval": null,
+              "cumulative": 2.0860023
+            },          
+            {
+              "interval": null,
+              "cumulative": 3.0665233
+            },          
+            {
+              "interval": null,
+              "cumulative": 6.046609
+            },          
+            {
+              "interval": null,
+              "cumulative": 229.57333
+            },          
+            {
+              "interval": null,
+              "cumulative": 260
+            }
+          ]
+        }
+      ]
+    }
   }
-}
 
   .. http:get:: /stats?format=prometheus
 

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -96,8 +96,8 @@ void ThreadLocalStoreImpl::shutdownThreading() {
 }
 
 void ThreadLocalStoreImpl::mergeHistograms(PostMergeCb merge_complete_cb) {
-  ASSERT(!merge_in_progress_);
   if (!shutting_down_) {
+    ASSERT(!merge_in_progress_);
     merge_in_progress_ = true;
     tls_->runOnAllThreads(
         [this]() -> void {
@@ -109,6 +109,9 @@ void ThreadLocalStoreImpl::mergeHistograms(PostMergeCb merge_complete_cb) {
           }
         },
         [this, merge_complete_cb]() -> void { mergeInternal(merge_complete_cb); });
+  } else {
+    // If shutdown is in progress, just call the callback to allow flush to continue.
+    merge_complete_cb();
   }
 }
 
@@ -131,7 +134,7 @@ void ThreadLocalStoreImpl::releaseScopeCrossThread(ScopeImpl* scope) {
   // cache flush operation.
   if (!shutting_down_ && main_thread_dispatcher_) {
     main_thread_dispatcher_->post(
-        [ this, scope_id = scope->scope_id_ ]()->void { clearScopeFromCaches(scope_id); });
+        [this, scope_id = scope->scope_id_]() -> void { clearScopeFromCaches(scope_id); });
   }
 }
 

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -520,6 +520,24 @@ AdminImpl::statsAsJson(const std::map<std::string, uint64_t>& all_stats,
     stats_array.PushBack(stat_obj, allocator);
   }
 
+  Value histograms_container_obj;
+  histograms_container_obj.SetObject();
+
+  Value histograms_obj;
+  histograms_obj.SetObject();
+
+  // It is not possible for the supported quantiles to differ across histograms, so it is ok to
+  // send them once.
+  Stats::HistogramStatisticsImpl empty_statistics;
+  rapidjson::Value supported_quantile_array(rapidjson::kArrayType);
+  for (double quantile : empty_statistics.supportedQuantiles()) {
+    Value quantile_type;
+    quantile_type.SetDouble(quantile * 100);
+    supported_quantile_array.PushBack(quantile_type, allocator);
+  }
+  histograms_obj.AddMember("supported_quantiles", supported_quantile_array, allocator);
+  rapidjson::Value histogram_array(rapidjson::kArrayType);
+
   for (const Stats::ParentHistogramSharedPtr& histogram : all_histograms) {
     Value histogram_obj;
     histogram_obj.SetObject();
@@ -527,32 +545,29 @@ AdminImpl::statsAsJson(const std::map<std::string, uint64_t>& all_stats,
     histogram_name.SetString(histogram->name().c_str(), allocator);
     histogram_obj.AddMember("name", histogram_name, allocator);
 
-    rapidjson::Value quantile_array(rapidjson::kArrayType);
+    rapidjson::Value computed_quantile_array(rapidjson::kArrayType);
 
-    // TODO(ramaraochavali): consider optimizing the model here. Quantiles can be added once,
-    // followed by two arrays interval and cumulative.
     for (size_t i = 0; i < histogram->intervalStatistics().supportedQuantiles().size(); ++i) {
       Value quantile_obj;
       quantile_obj.SetObject();
-      Value quantile_type;
-      quantile_type.SetDouble(histogram->intervalStatistics().supportedQuantiles()[i] * 100);
-      quantile_obj.AddMember("quantile", quantile_type, allocator);
       Value interval_value;
       if (!std::isnan(histogram->intervalStatistics().computedQuantiles()[i])) {
         interval_value.SetDouble(histogram->intervalStatistics().computedQuantiles()[i]);
       }
-      quantile_obj.AddMember("interval_value", interval_value, allocator);
+      quantile_obj.AddMember("interval", interval_value, allocator);
       Value cumulative_value;
       if (!std::isnan(histogram->cumulativeStatistics().computedQuantiles()[i])) {
         cumulative_value.SetDouble(histogram->cumulativeStatistics().computedQuantiles()[i]);
       }
-      quantile_obj.AddMember("cumulative_value", cumulative_value, allocator);
-      quantile_array.PushBack(quantile_obj, allocator);
+      quantile_obj.AddMember("cumulative", cumulative_value, allocator);
+      computed_quantile_array.PushBack(quantile_obj, allocator);
     }
-    histogram_obj.AddMember("quantiles", quantile_array, allocator);
-    stats_array.PushBack(histogram_obj, allocator);
+    histogram_obj.AddMember("values", computed_quantile_array, allocator);
+    histogram_array.PushBack(histogram_obj, allocator);
   }
-
+  histograms_obj.AddMember("computed_quantiles", histogram_array, allocator);
+  histograms_container_obj.AddMember("histograms", histograms_obj, allocator);
+  stats_array.PushBack(histograms_container_obj, allocator);
   document.AddMember("stats", stats_array, allocator);
   rapidjson::StringBuffer strbuf;
   rapidjson::PrettyWriter<StringBuffer> writer(strbuf);

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -161,10 +161,37 @@ TEST_P(IntegrationAdminTest, Admin) {
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/stats?format=json",
                                                 "", downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());
-  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+
   Json::ObjectSharedPtr statsjson = Json::Factory::loadFromString(response->body());
   EXPECT_TRUE(statsjson->hasObject("stats"));
   EXPECT_STREQ("application/json", ContentType(response));
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+
+  uint64_t histogram_count = 0;
+  for (Json::ObjectSharedPtr obj_ptr : statsjson->getObjectArray("stats")) {
+    if (obj_ptr->hasObject("histograms")) {
+      histogram_count++;
+      const Json::ObjectSharedPtr& histograms_ptr = obj_ptr->getObject("histograms");
+      // Validate that both supported_quantiles and computed_quantiles are present in JSON.
+      EXPECT_TRUE(histograms_ptr->hasObject("supported_quantiles"));
+      EXPECT_TRUE(histograms_ptr->hasObject("computed_quantiles"));
+
+      const std::vector<Json::ObjectSharedPtr>& computed_quantiles =
+          histograms_ptr->getObjectArray("computed_quantiles");
+      EXPECT_GT(computed_quantiles.size(), 0);
+
+      // Validate that each computed_quantile has name and value objects.
+      EXPECT_TRUE(computed_quantiles[0]->hasObject("name"));
+      EXPECT_TRUE(computed_quantiles[0]->hasObject("values"));
+
+      // Validate that supported and computed quantiles are of the same size.
+      EXPECT_EQ(histograms_ptr->getObjectArray("supported_quantiles").size(),
+                computed_quantiles[0]->getObjectArray("values").size());
+    }
+  }
+
+  // Validate that the stats JSON has exactly one histograms element.
+  EXPECT_EQ(1, histogram_count);
 
   response = IntegrationUtil::makeSingleRequest(
       lookupPort("admin"), "GET", "/stats?format=prometheus", "", downstreamProtocol(), version_);


### PR DESCRIPTION

*Description*:
Move the ASSERT of merge_in_progress inside shutdown branch and allow the flush to continue in the shutdown process.
*Risk Level*: Low
*Testing*:  Automated
*Docs Changes*: NA
*Release Notes*: NA
Fixes https://github.com/envoyproxy/envoy/issues/3287