### PR TITLE
stats: fix merge during shutdown

### DIFF
--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -96,8 +96,8 @@ void ThreadLocalStoreImpl::shutdownThreading() {
 }
 
 void ThreadLocalStoreImpl::mergeHistograms(PostMergeCb merge_complete_cb) {
-  ASSERT(!merge_in_progress_);
   if (!shutting_down_) {
+    ASSERT(!merge_in_progress_);
     merge_in_progress_ = true;
     tls_->runOnAllThreads(
         [this]() -> void {
@@ -109,6 +109,9 @@ void ThreadLocalStoreImpl::mergeHistograms(PostMergeCb merge_complete_cb) {
           }
         },
         [this, merge_complete_cb]() -> void { mergeInternal(merge_complete_cb); });
+  } else {
+    // If server is shutting down, just call the callback to allow flush to continue.
+    merge_complete_cb();
   }
 }
 
@@ -131,7 +134,7 @@ void ThreadLocalStoreImpl::releaseScopeCrossThread(ScopeImpl* scope) {
   // cache flush operation.
   if (!shutting_down_ && main_thread_dispatcher_) {
     main_thread_dispatcher_->post(
-        [ this, scope_id = scope->scope_id_ ]()->void { clearScopeFromCaches(scope_id); });
+        [this, scope_id = scope->scope_id_]() -> void { clearScopeFromCaches(scope_id); });
   }
 }
 

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -134,7 +134,7 @@ void ThreadLocalStoreImpl::releaseScopeCrossThread(ScopeImpl* scope) {
   // cache flush operation.
   if (!shutting_down_ && main_thread_dispatcher_) {
     main_thread_dispatcher_->post(
-        [this, scope_id = scope->scope_id_]() -> void { clearScopeFromCaches(scope_id); });
+        [ this, scope_id = scope->scope_id_ ]()->void { clearScopeFromCaches(scope_id); });
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>

*Description*:
- Move the ASSERT to inside shutting_down_ block
- Allow the rest of the flush to continue during shutdown

*Risk Level*: Low
*Testing*: Automated
*Docs Changes*: NA
*Release Notes*: NA

Fixes https://github.com/envoyproxy/envoy/issues/3287