### PR TITLE
ip tagging: enable unit tests to run on hosts with smaller memory

### DIFF
--- a/source/common/network/lc_trie.cc
+++ b/source/common/network/lc_trie.cc
@@ -4,9 +4,6 @@ namespace Envoy {
 namespace Network {
 namespace LcTrie {
 
-template <class IpType, uint32_t address_size>
-const uint32_t LcTrie::LcTrieInternal<IpType, address_size>::MAXIMUM_CIDR_RANGE_ENTRIES;
-
 LcTrie::LcTrie(const std::vector<std::pair<std::string, std::vector<Address::CidrRange>>>& tag_data,
                double fill_factor, uint32_t root_branching_factor) {
 

--- a/source/common/network/lc_trie.cc
+++ b/source/common/network/lc_trie.cc
@@ -9,6 +9,24 @@ const uint32_t LcTrie::LcTrieInternal<IpType, address_size>::MAXIMUM_CIDR_RANGE_
 
 LcTrie::LcTrie(const std::vector<std::pair<std::string, std::vector<Address::CidrRange>>>& tag_data,
                double fill_factor, uint32_t root_branching_factor) {
+
+  // The LcTrie implementation uses 20-bit "pointers" in its compact internal representation,
+  // so it cannot hold more than 2^20 nodes. But the number of nodes can be greater than the
+  // number of supported prefixes. Given N prefixes in the tag_data input list, step 2 below
+  // can produce a new list of up to 2*N prefixes to insert in the LC trie. And the LC trie
+  // can use up to 2*N/fill_factor nodes.
+  size_t num_prefixes = 0;
+  for (const auto& tag : tag_data) {
+    num_prefixes += tag.second.size();
+  }
+  size_t max_prefixes = MaxLcTrieNodes * fill_factor / 2;
+  if (num_prefixes > max_prefixes) {
+    throw EnvoyException(fmt::format("The input vector has '{0}' CIDR range entries. LC-Trie "
+                                     "can only support '{1}' CIDR ranges with the specified "
+                                     "fill factor.",
+                                     num_prefixes, max_prefixes));
+  }
+
   // Step 1: separate the provided prefixes by protocol (IPv4 vs IPv6),
   // and build a Binary Trie per protocol.
   //

--- a/source/common/network/lc_trie.cc
+++ b/source/common/network/lc_trie.cc
@@ -16,7 +16,7 @@ LcTrie::LcTrie(const std::vector<std::pair<std::string, std::vector<Address::Cid
   for (const auto& tag : tag_data) {
     num_prefixes += tag.second.size();
   }
-  size_t max_prefixes = MaxLcTrieNodes * fill_factor / 2;
+  const size_t max_prefixes = MaxLcTrieNodes * fill_factor / 2;
   if (num_prefixes > max_prefixes) {
     throw EnvoyException(fmt::format("The input vector has '{0}' CIDR range entries. LC-Trie "
                                      "can only support '{1}' CIDR ranges with the specified "

--- a/source/common/network/lc_trie.h
+++ b/source/common/network/lc_trie.h
@@ -26,7 +26,7 @@ namespace LcTrie {
  * @note If the size of LcTrieInternal::LcNode::address_ ever changes, this constant
  *       should be changed to match.
  */
-static const size_t MaxLcTrieNodes = (1 << 20);
+constexpr size_t MaxLcTrieNodes = (1 << 20);
 
 /**
  * Level Compressed Trie for tagging IP addresses. Both IPv4 and IPv6 addresses are supported

--- a/source/common/network/lc_trie.h
+++ b/source/common/network/lc_trie.h
@@ -553,12 +553,8 @@ private:
     struct LcNode {
       uint32_t branch_ : 5;
       uint32_t skip_ : 7;
-      uint32_t address_ : 20; // If this 20-bit size changes, please change MaxLcTrieNodes too
+      uint32_t address_ : 20; // If this 20-bit size changes, please change MaxLcTrieNodes too.
     };
-
-    // Refer to LcNode to for further explanation on the current limitations for the maximum number
-    // of CIDR ranges supported and the maximum amount of nodes of supported in the trie.
-    static constexpr uint32_t MAXIMUM_CIDR_RANGE_ENTRIES = (1 << 19);
 
     // During build(), an estimate of the number of nodes required will be made and set this value.
     // This is used to ensure no out_of_range exception is thrown.

--- a/source/common/network/lc_trie.h
+++ b/source/common/network/lc_trie.h
@@ -22,6 +22,13 @@ namespace Network {
 namespace LcTrie {
 
 /**
+ * Maximum number of nodes an LC trie can hold.
+ * @note If the size of LcTrieInternal::LcNode::address_ ever changes, this constant
+ *       should be changed to match.
+ */
+static const size_t MaxLcTrieNodes = (1 << 20);
+
+/**
  * Level Compressed Trie for tagging IP addresses. Both IPv4 and IPv6 addresses are supported
  * within this class with no calling pattern changes.
  *
@@ -310,15 +317,6 @@ private:
         return;
       }
 
-      // LcNode uses the last 20 bits to store either the index into ip_prefixes_ or trie_.
-      // In theory, the trie_ should only need twice the amount of entries of CIDR ranges.
-      // To prevent index out of bounds issues, only support a maximum of (2^19) CIDR ranges.
-      if (tag_data.size() > MAXIMUM_CIDR_RANGE_ENTRIES) {
-        throw EnvoyException(fmt::format("The input vector has '{0}' CIDR ranges entires. LC-Trie "
-                                         "can only support '{1}' CIDR ranges.",
-                                         tag_data.size(), MAXIMUM_CIDR_RANGE_ENTRIES));
-      }
-
       ip_prefixes_ = tag_data;
       std::sort(ip_prefixes_.begin(), ip_prefixes_.end());
 
@@ -555,7 +553,7 @@ private:
     struct LcNode {
       uint32_t branch_ : 5;
       uint32_t skip_ : 7;
-      uint32_t address_ : 20;
+      uint32_t address_ : 20; // If this 20-bit size changes, please change MaxLcTrieNodes too
     };
 
     // Refer to LcNode to for further explanation on the current limitations for the maximum number

--- a/test/common/network/lc_trie_test.cc
+++ b/test/common/network/lc_trie_test.cc
@@ -302,53 +302,25 @@ TEST_F(LcTrieTest, NestedPrefixesWithCatchAll) {
 
 // Test the trie can only support 2^19 Cidr Entries.
 TEST_F(LcTrieTest, MaximumEntriesException) {
-  static const size_t num_prefixes = (1 << 19) + 1;
-  std::vector<Address::CidrRange> large_vector_cidr;
-  large_vector_cidr.reserve(num_prefixes);
-  for (size_t i = 0; i < 256; i++) {
-    for (size_t j = 0; j < 256; j++) {
-      for (size_t k = 0; k < 8; k++) {
-        large_vector_cidr.emplace_back(
-            Address::CidrRange::create(fmt::format("10.{}.{}.{}/32", i, j, k)));
+  static const size_t num_prefixes = 8192;
+  std::vector<Address::CidrRange> prefixes;
+  prefixes.reserve(num_prefixes);
+  for (size_t i = 0; i < 16; i++) {
+    for (size_t j = 0; j < 16; j++) {
+      for (size_t k = 0; k < 32; k++) {
+        prefixes.emplace_back(Address::CidrRange::create(fmt::format("10.{}.{}.{}/8", i, j, k)));
       }
     }
   }
-  large_vector_cidr.emplace_back(Address::CidrRange::create("0.0.0.1/32"));
-  EXPECT_EQ(num_prefixes, large_vector_cidr.size());
+  EXPECT_EQ(num_prefixes, prefixes.size());
 
   std::pair<std::string, std::vector<Address::CidrRange>> ip_tag =
-      std::make_pair("bad_tag", large_vector_cidr);
+      std::make_pair("bad_tag", prefixes);
   std::vector<std::pair<std::string, std::vector<Address::CidrRange>>> ip_tags_input{ip_tag};
-  EXPECT_THROW_WITH_MESSAGE(new LcTrie(ip_tags_input), EnvoyException,
-                            "The input vector has '524289' CIDR ranges entires. LC-Trie can only "
-                            "support '524288' CIDR ranges.");
-}
-
-// Test the exception will be thrown when the maximum allocated trie nodes are being set.
-TEST_F(LcTrieTest, ExceedingAllocatedTrieNodesException) {
-  std::vector<Address::CidrRange> large_vector_cidr((1 << 19));
-
-  // The CIDR ranges have to be unique as to force getting towards the higher range of nodes
-  // inserted in the trie.
-  uint32_t ip_address = 1u;
-  for (int i = 0; i < (1 << 19); i++) {
-    ip_address++;
-    sockaddr_in addr4;
-    addr4.sin_family = AF_INET;
-    addr4.sin_addr.s_addr = ip_address;
-    addr4.sin_port = 0;
-    Address::InstanceConstSharedPtr address = std::make_shared<Address::Ipv4Instance>(&addr4);
-    large_vector_cidr[i] = Address::CidrRange::create(address, 32);
-  }
-
-  std::pair<std::string, std::vector<Address::CidrRange>> ip_tag =
-      std::make_pair("bad_tag", large_vector_cidr);
-  std::vector<std::pair<std::string, std::vector<Address::CidrRange>>> ip_tags_input{ip_tag};
-  EXPECT_THROW_WITH_MESSAGE(
-      new LcTrie(ip_tags_input, 0.01, 16), EnvoyException,
-      "The number of internal nodes required for the LC-Trie exceeded the "
-      "maximum number of supported nodes. Minimum number of internal nodes required: "
-      "'3048577'. Maximum number of supported nodes: '3048576'.");
+  EXPECT_THROW_WITH_MESSAGE(new LcTrie(ip_tags_input, 0.01), EnvoyException,
+                            "The input vector has '8192' CIDR range entries. "
+                            "LC-Trie can only support '5242' CIDR ranges with "
+                            "the specified fill factor.");
 }
 
 } // namespace LcTrie


### PR DESCRIPTION
*Description*:
During LC trie construction, do a pessimistic capacity check before building the temporary binary tries and throw an exception if it is possible for the specified prefixes to result in an LC trie node with more than the maximum 2^20 prefixes.

The motivation for this change is to prevent an OOM error when the unit tests are run on hosts with relatively little memory.

*Risk Level*: Low

*Testing*: Updated unit tests included
I merged the two unit tests into one, because the new, earlier check makes it impossible for the LC trie construction code to get far enough to throw the later exception that one of the tests was checking. 

*Docs Changes*: N/A
*Release Notes*: N/A

Signed-off-by: Brian Pane <bpane@pinterest.com>