### PR TITLE
complete decoder chain for headers on websocket requests

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -523,6 +523,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
     if (websocket_requested && websocket_allowed) {
       ENVOY_STREAM_LOG(debug, "found websocket connection. (end_stream={}):", *this, end_stream);
 
+      decodeHeaders(nullptr, *request_headers_, end_stream);
       connection_manager_.ws_connection_.reset(new WebSocket::WsHandlerImpl(
           *request_headers_, request_info_, *route_entry, *this,
           connection_manager_.cluster_manager_, connection_manager_.read_callbacks_));


### PR DESCRIPTION
Currently, the http connection manager immediately surrenders websocket requests to the websocket handler, bypassing all http_filters. This is problematic for API front proxies which need to terminate client TLS and pass authentication info in headers to upstream API servers. An Http::StreamDecoderFilter implementing such a proxy will not be called in the websocket handling code path, effectively disallowing TLS client auth on requests requiring websockets. This change finishes the header decoding before handing off the websocket connection to the websocket connection manager.