### PR TITLE
cluster: allow ignoring health check status during eds removal

### DIFF
--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -443,13 +443,12 @@ message Cluster {
   //   time exclusively closing these connections, and not processing any other traffic.
   bool close_connections_on_host_health_failure = 31;
 
-  // If this cluster uses EDS or STRICT_DNS to configure its host, immediately drain
-  // connections and remove the host from the cluster when the host is removed from
-  // service discovery.
+  // If this cluster uses EDS or STRICT_DNS to configure its hosts, immediately drain
+  // connections from any hosts that are removed from service discovery.
   //
   // This only affects behavior for hosts that are being actively health checked.
-  // If this flag is not set to true, Envoy will wait until the host fails active health
-  // checking before removing it from cluster.
+  // If this flag is not set to true, Envoy will wait until the hosts fail active health
+  // checking before removing it from the cluster.
   bool drain_connections_on_host_removal = 32;
 }
 

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -442,6 +442,14 @@ message Cluster {
   //   to an upstream host that becomes unhealthy, Envoy may spend a substantial amount of
   //   time exclusively closing these connections, and not processing any other traffic.
   bool close_connections_on_host_health_failure = 31;
+
+  // If this cluster uses EDS and its ClusterLoadAssignment is updated such that some endpoints
+  // have been removed, immediately drain connections and remove the endpoint from the cluster.
+  //
+  // This only affects behavior for endpoints that are being health checked. If this flag
+  // is not set to true, Envoy will wait until the endpoint fails health checking before
+  // removing it from cluster.
+  bool drain_connections_on_eds_removal = 32;
 }
 
 // An extensible structure containing the address Envoy should bind to when

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -446,9 +446,9 @@ message Cluster {
   // If this cluster uses EDS and its ClusterLoadAssignment is updated such that some endpoints
   // have been removed, immediately drain connections and remove the endpoint from the cluster.
   //
-  // This only affects behavior for endpoints that are being health checked. If this flag
-  // is not set to true, Envoy will wait until the endpoint fails health checking before
-  // removing it from cluster.
+  // This only affects behavior for endpoints that are being actively health checked.
+  // If this flag is not set to true, Envoy will wait until the endpoint fails active health
+  // checking before removing it from cluster.
   bool drain_connections_on_eds_removal = 32;
 }
 

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -443,13 +443,14 @@ message Cluster {
   //   time exclusively closing these connections, and not processing any other traffic.
   bool close_connections_on_host_health_failure = 31;
 
-  // If this cluster uses EDS and its ClusterLoadAssignment is updated such that some endpoints
-  // have been removed, immediately drain connections and remove the endpoint from the cluster.
+  // If this cluster uses EDS or STRICT_DNS to configure its host, immediately drain
+  // connections and remove the host from the cluster when the host is removed from
+  // service discovery.
   //
-  // This only affects behavior for endpoints that are being actively health checked.
-  // If this flag is not set to true, Envoy will wait until the endpoint fails active health
+  // This only affects behavior for hosts that are being actively health checked.
+  // If this flag is not set to true, Envoy will wait until the host fails active health
   // checking before removing it from cluster.
-  bool drain_connections_on_eds_removal = 32;
+  bool drain_connections_on_host_removal = 32;
 }
 
 // An extensible structure containing the address Envoy should bind to when

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -24,7 +24,7 @@ Version history
 * cli: added --config-yaml flag to the Envoy binary. When set its value is interpreted as a yaml
   representation of the bootstrap config and overrides --config-path.
 * cluster: Add :ref:`option <envoy_api_field_Cluster.close_connections_on_host_health_failure>`
-* cluster: Add :ref:`option <envoy_api_field_Clister.drain_connections_on_eds_removal>` to drain
+* cluster: Add :ref:`option <envoy_api_field_Cluster.drain_connections_on_eds_removal>` to drain
   endpoints after they are removed through EDS, despite health status.
 * health check: added ability to set :ref:`additional HTTP headers
   <envoy_api_field_core.HealthCheck.HttpHealthCheck.request_headers_to_add>` for HTTP health check.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -24,7 +24,8 @@ Version history
 * cli: added --config-yaml flag to the Envoy binary. When set its value is interpreted as a yaml
   representation of the bootstrap config and overrides --config-path.
 * cluster: Add :ref:`option <envoy_api_field_Cluster.close_connections_on_host_health_failure>`
-  to close tcp_proxy upstream connections when health checks fail.
+* cluster: Add :ref:`option <envoy_api_field_Clister.drain_connections_on_eds_removal>` to drain
+  endpoints after they are removed through EDS, despite health status.
 * health check: added ability to set :ref:`additional HTTP headers
   <envoy_api_field_core.HealthCheck.HttpHealthCheck.request_headers_to_add>` for HTTP health check.
 * health check: added support for EDS delivered :ref:`endpoint health status

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -25,7 +25,7 @@ Version history
   representation of the bootstrap config and overrides --config-path.
 * cluster: Add :ref:`option <envoy_api_field_Cluster.close_connections_on_host_health_failure>`
 * cluster: Add :ref:`option <envoy_api_field_Cluster.drain_connections_on_host_removal>` to drain
-  endpoints after they are removed through EDS, regardless of health status.
+  connections from hosts after they are removed from service discovery, regardless of health status.
 * health check: added ability to set :ref:`additional HTTP headers
   <envoy_api_field_core.HealthCheck.HttpHealthCheck.request_headers_to_add>` for HTTP health check.
 * health check: added support for EDS delivered :ref:`endpoint health status

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -24,7 +24,7 @@ Version history
 * cli: added --config-yaml flag to the Envoy binary. When set its value is interpreted as a yaml
   representation of the bootstrap config and overrides --config-path.
 * cluster: Add :ref:`option <envoy_api_field_Cluster.close_connections_on_host_health_failure>`
-* cluster: Add :ref:`option <envoy_api_field_Cluster.drain_connections_on_eds_removal>` to drain
+* cluster: Add :ref:`option <envoy_api_field_Cluster.drain_connections_on_host_removal>` to drain
   endpoints after they are removed through EDS, regardless of health status.
 * health check: added ability to set :ref:`additional HTTP headers
   <envoy_api_field_core.HealthCheck.HttpHealthCheck.request_headers_to_add>` for HTTP health check.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -25,7 +25,7 @@ Version history
   representation of the bootstrap config and overrides --config-path.
 * cluster: Add :ref:`option <envoy_api_field_Cluster.close_connections_on_host_health_failure>`
 * cluster: Add :ref:`option <envoy_api_field_Cluster.drain_connections_on_eds_removal>` to drain
-  endpoints after they are removed through EDS, despite health status.
+  endpoints after they are removed through EDS, regardless of health status.
 * health check: added ability to set :ref:`additional HTTP headers
   <envoy_api_field_core.HealthCheck.HttpHealthCheck.request_headers_to_add>` for HTTP health check.
 * health check: added support for EDS delivered :ref:`endpoint health status

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -528,6 +528,12 @@ public:
    *         connections for this cluster.
    */
   virtual const Network::ConnectionSocket::OptionsSharedPtr& clusterSocketOptions() const PURE;
+
+  /**
+   * @return whether to skip waiting for health checking before draining connections
+   *         after an endpoint is removed from EDS.
+   */
+  virtual bool drainConnectionsOnEdsRemoval() const PURE;
 };
 
 typedef std::shared_ptr<const ClusterInfo> ClusterInfoConstSharedPtr;

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -531,9 +531,9 @@ public:
 
   /**
    * @return whether to skip waiting for health checking before draining connections
-   *         after an endpoint is removed from EDS.
+   *         after a host is removed from service discovery.
    */
-  virtual bool drainConnectionsOnEdsRemoval() const PURE;
+  virtual bool drainConnectionsOnHostRemoval() const PURE;
 };
 
 typedef std::shared_ptr<const ClusterInfo> ClusterInfoConstSharedPtr;

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -131,7 +131,7 @@ bool EdsClusterImpl::updateHostsPerLocality(HostSet& host_set, const HostVector&
   // object for locality weights that we can update here, we should add something like this to
   // improve performance and scalability of locality weight updates.
   if (updateDynamicHostList(new_hosts, *current_hosts_copy, hosts_added, hosts_removed,
-        depend_on_hc) ||
+                            depend_on_hc) ||
       locality_weights_map != new_locality_weights_map) {
     locality_weights_map = new_locality_weights_map;
     LocalityWeightsSharedPtr locality_weights;

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -121,6 +121,7 @@ bool EdsClusterImpl::updateHostsPerLocality(HostSet& host_set, const HostVector&
 
   HostVector hosts_added;
   HostVector hosts_removed;
+  const bool depend_on_hc = health_checker_ != nullptr && !info()->drainConnectionsOnEdsRemoval();
   // We need to trigger updateHosts with the new host vectors if they have changed. We also do this
   // when the locality weight map changes.
   // TODO(htuch): We eagerly update all the host sets here on weight changes, which isn't great,
@@ -130,7 +131,7 @@ bool EdsClusterImpl::updateHostsPerLocality(HostSet& host_set, const HostVector&
   // object for locality weights that we can update here, we should add something like this to
   // improve performance and scalability of locality weight updates.
   if (updateDynamicHostList(new_hosts, *current_hosts_copy, hosts_added, hosts_removed,
-                            health_checker_ != nullptr) ||
+        depend_on_hc) ||
       locality_weights_map != new_locality_weights_map) {
     locality_weights_map = new_locality_weights_map;
     LocalityWeightsSharedPtr locality_weights;

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -121,8 +121,6 @@ bool EdsClusterImpl::updateHostsPerLocality(HostSet& host_set, const HostVector&
 
   HostVector hosts_added;
   HostVector hosts_removed;
-  const bool has_health_checker = health_checker_ != nullptr;
-  const bool ignore_active_hc = !has_health_checker || info()->drainConnectionsOnEdsRemoval();
   // We need to trigger updateHosts with the new host vectors if they have changed. We also do this
   // when the locality weight map changes.
   // TODO(htuch): We eagerly update all the host sets here on weight changes, which isn't great,
@@ -131,8 +129,7 @@ bool EdsClusterImpl::updateHostsPerLocality(HostSet& host_set, const HostVector&
   // out of the locality scheduler, we discover their new weights. We don't currently have a shared
   // object for locality weights that we can update here, we should add something like this to
   // improve performance and scalability of locality weight updates.
-  if (updateDynamicHostList(new_hosts, *current_hosts_copy, hosts_added, hosts_removed,
-                            has_health_checker, ignore_active_hc) ||
+  if (updateDynamicHostList(new_hosts, *current_hosts_copy, hosts_added, hosts_removed) ||
       locality_weights_map != new_locality_weights_map) {
     locality_weights_map = new_locality_weights_map;
     LocalityWeightsSharedPtr locality_weights;

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -121,7 +121,8 @@ bool EdsClusterImpl::updateHostsPerLocality(HostSet& host_set, const HostVector&
 
   HostVector hosts_added;
   HostVector hosts_removed;
-  const bool depend_on_hc = health_checker_ != nullptr && !info()->drainConnectionsOnEdsRemoval();
+  const bool has_health_checker = health_checker_ != nullptr;
+  const bool ignore_active_hc = !has_health_checker || info()->drainConnectionsOnEdsRemoval();
   // We need to trigger updateHosts with the new host vectors if they have changed. We also do this
   // when the locality weight map changes.
   // TODO(htuch): We eagerly update all the host sets here on weight changes, which isn't great,
@@ -131,7 +132,7 @@ bool EdsClusterImpl::updateHostsPerLocality(HostSet& host_set, const HostVector&
   // object for locality weights that we can update here, we should add something like this to
   // improve performance and scalability of locality weight updates.
   if (updateDynamicHostList(new_hosts, *current_hosts_copy, hosts_added, hosts_removed,
-                            depend_on_hc) ||
+                            has_health_checker, ignore_active_hc) ||
       locality_weights_map != new_locality_weights_map) {
     locality_weights_map = new_locality_weights_map;
     LocalityWeightsSharedPtr locality_weights;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -270,7 +270,7 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
       lb_subset_(LoadBalancerSubsetInfoImpl(config.lb_subset_config())),
       metadata_(config.metadata()), common_lb_config_(config.common_lb_config()),
       cluster_socket_options_(parseClusterSocketOptions(config, bind_config)),
-      drain_connections_on_eds_removal_(config.drain_connections_on_eds_removal()) {
+      drain_connections_on_host_removal_(config.drain_connections_on_host_removal()) {
 
   // If the cluster doesn't have a transport socket configured, override with the default transport
   // socket implementation based on the tls_context. We copy by value first then override if
@@ -737,7 +737,7 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(const HostVector& new_hosts,
   }
 
   const bool skip_healthy_hosts =
-      health_checker_ != nullptr && !info()->drainConnectionsOnEdsRemoval();
+      health_checker_ != nullptr && !info()->drainConnectionsOnHostRemoval();
   // If there are removed hosts, check to see if we should only delete if unhealthy.
   if (!current_hosts.empty() && skip_healthy_hosts) {
     for (auto i = current_hosts.begin(); i != current_hosts.end();) {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -269,7 +269,8 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
       ssl_context_manager_(ssl_context_manager), added_via_api_(added_via_api),
       lb_subset_(LoadBalancerSubsetInfoImpl(config.lb_subset_config())),
       metadata_(config.metadata()), common_lb_config_(config.common_lb_config()),
-      cluster_socket_options_(parseClusterSocketOptions(config, bind_config)) {
+      cluster_socket_options_(parseClusterSocketOptions(config, bind_config)),
+      drain_connections_on_eds_removal_(config.drain_connections_on_eds_removal()) {
 
   // If the cluster doesn't have a transport socket configured, override with the default transport
   // socket implementation based on the tls_context. We copy by value first then override if

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -736,10 +736,10 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(const HostVector& new_hosts,
     }
   }
 
-  const bool skip_healthy_hosts =
+  const bool dont_remove_healthy_hosts =
       health_checker_ != nullptr && !info()->drainConnectionsOnHostRemoval();
   // If there are removed hosts, check to see if we should only delete if unhealthy.
-  if (!current_hosts.empty() && skip_healthy_hosts) {
+  if (!current_hosts.empty() && dont_remove_healthy_hosts) {
     for (auto i = current_hosts.begin(); i != current_hosts.end();) {
       if (!(*i)->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC)) {
         if ((*i)->weight() > max_host_weight) {

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -518,8 +518,7 @@ protected:
   using ClusterImplBase::ClusterImplBase;
 
   bool updateDynamicHostList(const HostVector& new_hosts, HostVector& current_hosts,
-                             HostVector& hosts_added, HostVector& hosts_removed,
-                             bool has_health_checker, bool ignore_active_hc);
+                             HostVector& hosts_added, HostVector& hosts_removed);
 };
 
 /**

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -360,6 +360,10 @@ public:
     return cluster_socket_options_;
   };
 
+  bool drainConnectionsOnEdsRemoval() const override {
+    return drain_connections_on_eds_removal_;
+  }
+
 private:
   struct ResourceManagers {
     ResourceManagers(const envoy::api::v2::Cluster& config, Runtime::Loader& runtime,
@@ -398,6 +402,7 @@ private:
   const envoy::api::v2::core::Metadata metadata_;
   const envoy::api::v2::Cluster::CommonLbConfig common_lb_config_;
   const Network::ConnectionSocket::OptionsSharedPtr cluster_socket_options_;
+  const bool drain_connections_on_eds_removal_;
 };
 
 /**

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -360,9 +360,7 @@ public:
     return cluster_socket_options_;
   };
 
-  bool drainConnectionsOnEdsRemoval() const override {
-    return drain_connections_on_eds_removal_;
-  }
+  bool drainConnectionsOnEdsRemoval() const override { return drain_connections_on_eds_removal_; }
 
 private:
   struct ResourceManagers {

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -518,7 +518,8 @@ protected:
   using ClusterImplBase::ClusterImplBase;
 
   bool updateDynamicHostList(const HostVector& new_hosts, HostVector& current_hosts,
-                             HostVector& hosts_added, HostVector& hosts_removed, bool depend_on_hc);
+                             HostVector& hosts_added, HostVector& hosts_removed,
+                             bool has_health_checker, bool ignore_active_hc);
 };
 
 /**

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -360,7 +360,7 @@ public:
     return cluster_socket_options_;
   };
 
-  bool drainConnectionsOnEdsRemoval() const override { return drain_connections_on_eds_removal_; }
+  bool drainConnectionsOnHostRemoval() const override { return drain_connections_on_host_removal_; }
 
 private:
   struct ResourceManagers {
@@ -400,7 +400,7 @@ private:
   const envoy::api::v2::core::Metadata metadata_;
   const envoy::api::v2::Cluster::CommonLbConfig common_lb_config_;
   const Network::ConnectionSocket::OptionsSharedPtr cluster_socket_options_;
-  const bool drain_connections_on_eds_removal_;
+  const bool drain_connections_on_host_removal_;
 };
 
 /**

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -350,6 +350,8 @@ TEST_F(EdsTest, EndpointRemoval) {
     auto& hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
     EXPECT_TRUE(hosts.size() == 2);
 
+    EXPECT_TRUE(hosts[0]->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC));
+    EXPECT_TRUE(hosts[1]->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC));
     // Mark the hosts as healthy
     hosts[0]->healthFlagClear(Host::HealthFlag::FAILED_ACTIVE_HC);
     hosts[1]->healthFlagClear(Host::HealthFlag::FAILED_ACTIVE_HC);

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -1,5 +1,7 @@
 #include "envoy/api/v2/eds.pb.h"
 
+#include <memory>
+
 #include "common/config/utility.h"
 #include "common/upstream/eds.h"
 
@@ -321,7 +323,7 @@ TEST_F(EdsTest, EndpointRemoval) {
             refresh_delay: 1s
   )EOF");
 
-  std::shared_ptr<MockHealthChecker> health_checker(new MockHealthChecker());
+  auto health_checker = std::make_shared<MockHealthChecker>();
   EXPECT_CALL(*health_checker, start());
   EXPECT_CALL(*health_checker, addHostCheckCompleteCb(_)).Times(2);
   cluster_->setHealthChecker(health_checker);
@@ -348,7 +350,7 @@ TEST_F(EdsTest, EndpointRemoval) {
 
   {
     auto& hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
-    EXPECT_TRUE(hosts.size() == 2);
+    EXPECT_EQ(hosts.size(), 2);
 
     EXPECT_TRUE(hosts[0]->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC));
     EXPECT_TRUE(hosts[1]->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC));

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -334,9 +334,9 @@ TEST_F(EdsTest, EndpointRemoval) {
     auto* endpoints = cluster_load_assignment->add_endpoints();
 
     auto* socket_address = endpoints->add_lb_endpoints()
-      ->mutable_endpoint()
-      ->mutable_address()
-      ->mutable_socket_address();
+                               ->mutable_endpoint()
+                               ->mutable_address()
+                               ->mutable_socket_address();
     socket_address->set_address("1.2.3.4");
     socket_address->set_port_value(port);
   };

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -1,6 +1,6 @@
-#include "envoy/api/v2/eds.pb.h"
-
 #include <memory>
+
+#include "envoy/api/v2/eds.pb.h"
 
 #include "common/config/utility.h"
 #include "common/upstream/eds.h"

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -311,7 +311,7 @@ TEST_F(EdsTest, EndpointRemoval) {
       connect_timeout: 0.25s
       type: EDS
       lb_policy: ROUND_ROBIN
-      drain_connections_on_eds_removal: true
+      drain_connections_on_host_removal: true
       eds_cluster_config:
         service_name: fare
         eds_config:

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -13,9 +13,9 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using testing::_;
 using testing::Return;
 using testing::ReturnRef;
+using testing::_;
 
 namespace Envoy {
 namespace Upstream {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -307,6 +307,58 @@ TEST(StrictDnsClusterImplTest, Basic) {
   EXPECT_CALL(resolver2.active_dns_query_, cancel());
 }
 
+// Verifies that host removal works correctly when hosts are being health checked
+// but the cluster is configured to always remove hosts
+TEST(StrictDnsClusterImplTest, HostRemovalActiveHealthSkipped) {
+  Stats::IsolatedStoreImpl stats;
+  Ssl::MockContextManager ssl_context_manager;
+  auto dns_resolver = std::make_shared<Network::MockDnsResolver>();
+  NiceMock<Event::MockDispatcher> dispatcher;
+  NiceMock<Runtime::MockLoader> runtime;
+  NiceMock<MockClusterManager> cm;
+
+  const std::string yaml = R"EOF(
+    name: name
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    drain_connections_on_host_removal: true
+    hosts: [{ socket_address: { address: foo.bar.com, port_value: 443 }}]
+  )EOF";
+
+  ResolverData resolver(*dns_resolver, dispatcher);
+  StrictDnsClusterImpl cluster(parseClusterFromV2Yaml(yaml), runtime, stats, ssl_context_manager,
+                               dns_resolver, cm, dispatcher, false);
+  std::shared_ptr<MockHealthChecker> health_checker(new MockHealthChecker());
+  EXPECT_CALL(*health_checker, start());
+  EXPECT_CALL(*health_checker, addHostCheckCompleteCb(_));
+  cluster.setHealthChecker(health_checker);
+  cluster.initialize([&]() -> void {});
+
+  EXPECT_CALL(*health_checker, addHostCheckCompleteCb(_));
+  EXPECT_CALL(*resolver.timer_, enableTimer(_)).Times(2);
+  resolver.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.1", "127.0.0.2"}));
+
+  // Verify that both endpoints are initially marked with FAILED_ACTIVE_HC, then
+  // clear the flag to simulate that these endpoints have been sucessfully health
+  // checked.
+  {
+    const auto& hosts = cluster.prioritySet().hostSetsPerPriority()[0]->hosts();
+    EXPECT_EQ(2UL, hosts.size());
+
+    for (size_t i = 0; i < hosts.size(); ++i) {
+      EXPECT_TRUE(hosts[i]->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC));
+      hosts[i]->healthFlagClear(Host::HealthFlag::FAILED_ACTIVE_HC);
+    }
+  }
+
+  // Re-resolve the DNS name with only one record
+  resolver.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.1"}));
+
+  const auto& hosts = cluster.prioritySet().hostSetsPerPriority()[0]->hosts();
+  EXPECT_EQ(1UL, hosts.size());
+}
+
 TEST(HostImplTest, HostCluster) {
   MockCluster cluster;
   HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", 1);

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -63,6 +63,7 @@ public:
   MOCK_CONST_METHOD0(lbSubsetInfo, const LoadBalancerSubsetInfo&());
   MOCK_CONST_METHOD0(metadata, const envoy::api::v2::core::Metadata&());
   MOCK_CONST_METHOD0(clusterSocketOptions, const Network::ConnectionSocket::OptionsSharedPtr&());
+  MOCK_CONST_METHOD0(drainConnectionsOnEdsRemoval, bool());
 
   std::string name_{"fake_cluster"};
   Http::Http2Settings http2_settings_{};

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -63,7 +63,7 @@ public:
   MOCK_CONST_METHOD0(lbSubsetInfo, const LoadBalancerSubsetInfo&());
   MOCK_CONST_METHOD0(metadata, const envoy::api::v2::core::Metadata&());
   MOCK_CONST_METHOD0(clusterSocketOptions, const Network::ConnectionSocket::OptionsSharedPtr&());
-  MOCK_CONST_METHOD0(drainConnectionsOnEdsRemoval, bool());
+  MOCK_CONST_METHOD0(drainConnectionsOnHostRemoval, bool());
 
   std::string name_{"fake_cluster"};
   Http::Http2Settings http2_settings_{};


### PR DESCRIPTION
*title*: cluster: allow ignoring health check status during eds removal

*Description*:
This PR adds a configuration flag that allows disabling the "eventually consistent" aspect of endpoint updates: instead of waiting for the endpoints to go unhealthy before removing them from the cluster, do so immediately. This gives greater control to the control plane in cases where one might want to divert traffic from an endpoint
without having it go unhealthy. The flag goes on the cluster and so applies to all endpoints within that cluster. 

*Risk Level*: 
Low: Small configurable feature which reuses existing behavior (identical  to the behavior when no health checker is configured). Defaults to disabled, so should have no impact on existing configurations.

*Testing*:
Added unit test for the case when endpoints are healthy then removed from the ClusterLoadAssignment in a subsequent config update. 

*Docs Changes*:
Docs were added to the proto field. 

*Release Notes*:
Added ```cluster: Add :ref:`option <envoy_api_field_Clister.drain_connections_on_eds_removal>` to drain endpoints after they are removed through EDS, despite health status.``` to the release notes. 

[Optional Fixes #Issue]
#440 and #3276 (note that this last issue also asks for more fine grained control over endpoint removal. The solution this PR provides was brought up as a partial solution to #3276). 
