### PR TITLE
test: fix flake in ssl_integration_test.

### DIFF
--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -57,7 +57,7 @@ protected:
                        const std::vector<std::string>& grpc_response_messages,
                        const Status& grpc_status, Http::HeaderMap&& response_headers,
                        const std::string& response_body, bool full_response = true) {
-    response_.reset(new IntegrationStreamDecoder(*dispatcher_));
+    resetResponse();
 
     codec_client_ = makeHttpConnection(lookupPort("http"));
 

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -206,6 +206,7 @@ public:
   void makeSingleRequest() {
     registerTestServerPorts({"http"});
     testRouterHeaderOnlyRequestAndResponse(true);
+    resetResponse();
     cleanupUpstreamAndDownstream();
     fake_upstream_connection_ = nullptr;
   }

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -189,6 +189,8 @@ void HttpIntegrationTest::sendRequestAndWaitForResponse(Http::TestHeaderMapImpl&
                                                         uint32_t request_body_size,
                                                         Http::TestHeaderMapImpl& response_headers,
                                                         uint32_t response_size) {
+  // If this fails, there was a lack of resetResponse() since last request.
+  ASSERT(!response_->complete());
   // Send the request to Envoy.
   if (request_body_size) {
     codec_client_->makeRequestWithBody(request_headers, request_body_size, *response_);
@@ -915,7 +917,7 @@ void HttpIntegrationTest::testIdleTimeoutWithTwoRequests() {
   test_server_->waitForCounterGe("cluster.cluster_0.upstream_rq_200", 1);
 
   // Request 2.
-  response_.reset(new IntegrationStreamDecoder(*dispatcher_));
+  resetResponse();
   codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "GET"},
                                                              {":path", "/test/long/url"},
                                                              {":scheme", "http"},
@@ -1011,7 +1013,7 @@ void HttpIntegrationTest::testTwoRequests() {
   EXPECT_EQ(512U, response_->body().size());
 
   // Request 2.
-  response_.reset(new IntegrationStreamDecoder(*dispatcher_));
+  resetResponse();
   codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "GET"},
                                                              {":path", "/test/long/url"},
                                                              {":scheme", "http"},

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -96,6 +96,9 @@ protected:
                                      Http::TestHeaderMapImpl& response_headers,
                                      uint32_t response_body_size);
 
+  // Invoke between requests to reset the response_ object.
+  void resetResponse() { response_.reset(new IntegrationStreamDecoder(*dispatcher_)); }
+
   // Wait for the end of stream on the next upstream stream on fake_upstreams_
   // Sets fake_upstream_connection_ to the connection and upstream_request_ to stream.
   void waitForNextUpstreamRequest(uint64_t upstream_index = 0);

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -143,7 +143,7 @@ public:
     Http::TestHeaderMapImpl headers{{":method", "POST"},       {":path", "/test/long/url"},
                                     {":scheme", "http"},       {":authority", "host"},
                                     {"x-lyft-user-id", "123"}, {"x-forwarded-for", "10.0.0.1"}};
-    response_.reset(new IntegrationStreamDecoder(*dispatcher_));
+    resetResponse();
     codec_client_->makeRequestWithBody(headers, request_size_, *response_);
   }
 

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -239,6 +239,7 @@ TEST_P(SslCaptureIntegrationTest, TwoRequestsWithBinaryProto) {
   ASSERT_TRUE(response_->complete());
   EXPECT_STREQ("200", response_->headers().Status()->value().c_str());
   EXPECT_EQ(256, response_->body().size());
+  resetResponse();
   checkStats();
   envoy::api::v2::core::Address expected_local_address;
   Network::Utility::addressToProtobufAddress(*codec_client_->connection()->remoteAddress(),
@@ -254,6 +255,7 @@ TEST_P(SslCaptureIntegrationTest, TwoRequestsWithBinaryProto) {
   EXPECT_EQ(first_id, trace.connection().id());
   EXPECT_THAT(expected_local_address, ProtoEq(trace.connection().local_address()));
   EXPECT_THAT(expected_remote_address, ProtoEq(trace.connection().remote_address()));
+  ASSERT_GE(trace.events().size(), 2);
   EXPECT_TRUE(absl::StartsWith(trace.events(0).read().data(), "POST /test/long/url HTTP/1.1"));
   EXPECT_TRUE(absl::StartsWith(trace.events(1).write().data(), "HTTP/1.1 200 OK"));
 
@@ -275,6 +277,7 @@ TEST_P(SslCaptureIntegrationTest, TwoRequestsWithBinaryProto) {
   MessageUtil::loadFromFile(fmt::format("{}_{}.pb", path_prefix_, second_id), trace);
   // Validate second connection ID.
   EXPECT_EQ(second_id, trace.connection().id());
+  ASSERT_GE(trace.events().size(), 2);
   EXPECT_TRUE(absl::StartsWith(trace.events(0).read().data(), "GET /test/long/url HTTP/1.1"));
   EXPECT_TRUE(absl::StartsWith(trace.events(1).write().data(), "HTTP/1.1 200 OK"));
 }


### PR DESCRIPTION
Fixes #3309, introduced by #3244.

Risk Level: Low
Testing: bazel test test/integration:ssl_integration_test --runs_per_test=200

Signed-off-by: Harvey Tuch <htuch@google.com>