### PR TITLE
test: remove response_ as member variable.

### DIFF
--- a/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
@@ -40,17 +40,18 @@ TEST_P(BufferIntegrationTest, RouterRequestBufferLimitExceeded) {
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                             {":path", "/dynamo/url"},
-                                                             {":scheme", "http"},
-                                                             {":authority", "host"},
-                                                             {"x-forwarded-for", "10.0.0.1"},
-                                                             {"x-envoy-retry-on", "5xx"}},
-                                     1024 * 65, *response_);
+  auto response =
+      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/dynamo/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"},
+                                                                 {"x-forwarded-for", "10.0.0.1"},
+                                                                 {"x-envoy-retry-on", "5xx"}},
+                                         1024 * 65);
 
-  response_->waitForEndStream();
-  ASSERT_TRUE(response_->complete());
-  EXPECT_STREQ("413", response_->headers().Status()->value().c_str());
+  response->waitForEndStream();
+  ASSERT_TRUE(response->complete());
+  EXPECT_STREQ("413", response->headers().Status()->value().c_str());
 }
 
 ConfigHelper::HttpModifierFunction overrideConfig(const std::string& json_config) {
@@ -77,19 +78,20 @@ TEST_P(BufferIntegrationTest, RouteDisabled) {
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                             {":path", "/test/long/url"},
-                                                             {":scheme", "http"},
-                                                             {":authority", "host"},
-                                                             {"x-forwarded-for", "10.0.0.1"}},
-                                     1024 * 65, *response_);
+  auto response =
+      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"},
+                                                                 {"x-forwarded-for", "10.0.0.1"}},
+                                         1024 * 65);
 
   waitForNextUpstreamRequest();
   upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, true);
 
-  response_->waitForEndStream();
-  ASSERT_TRUE(response_->complete());
-  EXPECT_STREQ("200", response_->headers().Status()->value().c_str());
+  response->waitForEndStream();
+  ASSERT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 }
 
 TEST_P(BufferIntegrationTest, RouteOverride) {
@@ -103,19 +105,20 @@ TEST_P(BufferIntegrationTest, RouteOverride) {
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                             {":path", "/test/long/url"},
-                                                             {":scheme", "http"},
-                                                             {":authority", "host"},
-                                                             {"x-forwarded-for", "10.0.0.1"}},
-                                     1024 * 65, *response_);
+  auto response =
+      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"},
+                                                                 {"x-forwarded-for", "10.0.0.1"}},
+                                         1024 * 65);
 
   waitForNextUpstreamRequest();
   upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, true);
 
-  response_->waitForEndStream();
-  ASSERT_TRUE(response_->complete());
-  EXPECT_STREQ("200", response_->headers().Status()->value().c_str());
+  response->waitForEndStream();
+  ASSERT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 }
 
 } // namespace

--- a/test/extensions/filters/http/cors/cors_filter_integration_test.cc
+++ b/test/extensions/filters/http/cors/cors_filter_integration_test.cc
@@ -66,20 +66,20 @@ protected:
                      Http::TestHeaderMapImpl&& expected_response_headers) {
     initialize();
     codec_client_ = makeHttpConnection(lookupPort("http"));
-    codec_client_->makeHeaderOnlyRequest(request_headers, *response_);
-    response_->waitForEndStream();
-    EXPECT_TRUE(response_->complete());
-    compareHeaders(response_->headers(), expected_response_headers);
+    auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
+    response->waitForEndStream();
+    EXPECT_TRUE(response->complete());
+    compareHeaders(response->headers(), expected_response_headers);
   }
 
   void testNormalRequest(Http::TestHeaderMapImpl&& request_headers,
                          Http::TestHeaderMapImpl&& expected_response_headers) {
     initialize();
     codec_client_ = makeHttpConnection(lookupPort("http"));
-    sendRequestAndWaitForResponse(request_headers, 0, expected_response_headers, 0);
+    auto response = sendRequestAndWaitForResponse(request_headers, 0, expected_response_headers, 0);
 
-    EXPECT_TRUE(response_->complete());
-    compareHeaders(response_->headers(), expected_response_headers);
+    EXPECT_TRUE(response->complete());
+    compareHeaders(response->headers(), expected_response_headers);
   }
 
   void compareHeaders(Http::TestHeaderMapImpl&& response_headers,

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -319,14 +319,14 @@ protected:
     registerTestServerPorts({"http"});
 
     codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
-    codec_client_->makeHeaderOnlyRequest(request_headers, *response_);
+    auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
     waitForNextUpstreamRequest();
 
     upstream_request_->encodeHeaders(response_headers, true);
-    response_->waitForEndStream();
+    response->waitForEndStream();
 
     compareHeaders(upstream_request_->headers(), expected_request_headers);
-    compareHeaders(response_->headers(), expected_response_headers);
+    compareHeaders(response->headers(), expected_response_headers);
   }
 
   void compareHeaders(Http::TestHeaderMapImpl&& headers,

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -90,12 +90,13 @@ void Http2UpstreamIntegrationTest::bidirectionalStreaming(uint32_t bytes) {
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   // Start the request.
-  request_encoder_ =
-      &codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                           {":path", "/test/long/url"},
-                                                           {":scheme", "http"},
-                                                           {":authority", "host"}},
-                                   *response_);
+  auto encoder_decoder =
+      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
+                                                          {":path", "/test/long/url"},
+                                                          {":scheme", "http"},
+                                                          {":authority", "host"}});
+  auto response = std::move(encoder_decoder.second);
+  request_encoder_ = &encoder_decoder.first;
   fake_upstream_connection_ = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
   upstream_request_ = fake_upstream_connection_->waitForNewStream(*dispatcher_);
 
@@ -106,7 +107,7 @@ void Http2UpstreamIntegrationTest::bidirectionalStreaming(uint32_t bytes) {
   // Start sending the response and ensure it is received downstream.
   upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
   upstream_request_->encodeData(bytes, false);
-  response_->waitForBodyData(bytes);
+  response->waitForBodyData(bytes);
 
   // Finish the request.
   codec_client_->sendTrailers(*request_encoder_, Http::TestHeaderMapImpl{{"trailer", "foo"}});
@@ -114,8 +115,8 @@ void Http2UpstreamIntegrationTest::bidirectionalStreaming(uint32_t bytes) {
 
   // Finish the response.
   upstream_request_->encodeTrailers(Http::TestHeaderMapImpl{{"trailer", "bar"}});
-  response_->waitForEndStream();
-  EXPECT_TRUE(response_->complete());
+  response->waitForEndStream();
+  EXPECT_TRUE(response->complete());
 }
 
 TEST_P(Http2UpstreamIntegrationTest, BidirectionalStreaming) { bidirectionalStreaming(1024); }
@@ -130,12 +131,13 @@ TEST_P(Http2UpstreamIntegrationTest, BidirectionalStreamingReset) {
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   // Start sending the request.
-  request_encoder_ =
-      &codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                           {":path", "/test/long/url"},
-                                                           {":scheme", "http"},
-                                                           {":authority", "host"}},
-                                   *response_);
+  auto encoder_decoder =
+      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
+                                                          {":path", "/test/long/url"},
+                                                          {":scheme", "http"},
+                                                          {":authority", "host"}});
+  auto response = std::move(encoder_decoder.second);
+  request_encoder_ = &encoder_decoder.first;
   fake_upstream_connection_ = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
   upstream_request_ = fake_upstream_connection_->waitForNewStream(*dispatcher_);
 
@@ -146,7 +148,7 @@ TEST_P(Http2UpstreamIntegrationTest, BidirectionalStreamingReset) {
   // Start sending the response.
   upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
   upstream_request_->encodeData(1024, false);
-  response_->waitForBodyData(1024);
+  response->waitForBodyData(1024);
 
   // Finish sending therequest.
   codec_client_->sendTrailers(*request_encoder_, Http::TestHeaderMapImpl{{"trailer", "foo"}});
@@ -154,38 +156,38 @@ TEST_P(Http2UpstreamIntegrationTest, BidirectionalStreamingReset) {
 
   // Reset the stream.
   upstream_request_->encodeResetStream();
-  response_->waitForReset();
-  EXPECT_FALSE(response_->complete());
+  response->waitForReset();
+  EXPECT_FALSE(response->complete());
 }
 
 void Http2UpstreamIntegrationTest::simultaneousRequest(uint32_t request1_bytes,
                                                        uint32_t request2_bytes,
                                                        uint32_t response1_bytes,
                                                        uint32_t response2_bytes) {
-  IntegrationStreamDecoderPtr response1(new IntegrationStreamDecoder(*dispatcher_));
-  IntegrationStreamDecoderPtr response2(new IntegrationStreamDecoder(*dispatcher_));
   FakeStreamPtr upstream_request1;
   FakeStreamPtr upstream_request2;
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   // Start request 1
-  Http::StreamEncoder* encoder1 =
-      &codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                           {":path", "/test/long/url"},
-                                                           {":scheme", "http"},
-                                                           {":authority", "host"}},
-                                   *response1);
+  auto encoder_decoder1 =
+      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
+                                                          {":path", "/test/long/url"},
+                                                          {":scheme", "http"},
+                                                          {":authority", "host"}});
+  Http::StreamEncoder* encoder1 = &encoder_decoder1.first;
+  auto response1 = std::move(encoder_decoder1.second);
   fake_upstream_connection_ = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
   upstream_request1 = fake_upstream_connection_->waitForNewStream(*dispatcher_);
 
   // Start request 2
-  Http::StreamEncoder* encoder2 =
-      &codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                           {":path", "/test/long/url"},
-                                                           {":scheme", "http"},
-                                                           {":authority", "host"}},
-                                   *response2);
+  auto encoder_decoder2 =
+      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
+                                                          {":path", "/test/long/url"},
+                                                          {":scheme", "http"},
+                                                          {":authority", "host"}});
+  Http::StreamEncoder* encoder2 = &encoder_decoder2.first;
+  auto response2 = std::move(encoder_decoder2.second);
   upstream_request2 = fake_upstream_connection_->waitForNewStream(*dispatcher_);
 
   // Finish request 1
@@ -237,7 +239,6 @@ void Http2UpstreamIntegrationTest::manySimultaneousRequests(uint32_t request_byt
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
   for (uint32_t i = 0; i < num_requests; ++i) {
-    responses.push_back(IntegrationStreamDecoderPtr{new IntegrationStreamDecoder(*dispatcher_)});
     response_bytes.push_back(rand.random() % (1024 * 2));
     auto headers = Http::TestHeaderMapImpl{
         {":method", "POST"},
@@ -249,7 +250,9 @@ void Http2UpstreamIntegrationTest::manySimultaneousRequests(uint32_t request_byt
     if (i % 2 == 0) {
       headers.addCopy(AutonomousStream::RESET_AFTER_REQUEST, "yes");
     }
-    encoders.push_back(&codec_client_->startRequest(headers, *responses[i]));
+    auto encoder_decoder = codec_client_->startRequest(headers);
+    encoders.push_back(&encoder_decoder.first);
+    responses.push_back(std::move(encoder_decoder.second));
     codec_client_->sendData(*encoders[i], request_bytes, true);
   }
 
@@ -285,13 +288,13 @@ TEST_P(Http2UpstreamIntegrationTest, UpstreamConnectionCloseWithManyStreams) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
   for (uint32_t i = 0; i < num_requests; ++i) {
-    responses.push_back(IntegrationStreamDecoderPtr{new IntegrationStreamDecoder(*dispatcher_)});
-    encoders.push_back(
-        &codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                             {":path", "/test/long/url"},
-                                                             {":scheme", "http"},
-                                                             {":authority", "host"}},
-                                     *responses[i]));
+    auto encoder_decoder =
+        codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
+                                                            {":path", "/test/long/url"},
+                                                            {":scheme", "http"},
+                                                            {":authority", "host"}});
+    encoders.push_back(&encoder_decoder.first);
+    responses.push_back(std::move(encoder_decoder.second));
     // Reset a few streams to test how reset and watermark interact.
     if (i % 15 == 0) {
       codec_client_->sendReset(*encoders[i]);

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -22,16 +22,16 @@ public:
                          Upstream::HostDescriptionConstSharedPtr host_description,
                          Http::CodecClient::Type type);
 
-  void makeHeaderOnlyRequest(const Http::HeaderMap& headers, IntegrationStreamDecoder& response);
-  void makeRequestWithBody(const Http::HeaderMap& headers, uint64_t body_size,
-                           IntegrationStreamDecoder& response);
+  IntegrationStreamDecoderPtr makeHeaderOnlyRequest(const Http::HeaderMap& headers);
+  IntegrationStreamDecoderPtr makeRequestWithBody(const Http::HeaderMap& headers,
+                                                  uint64_t body_size);
   bool sawGoAway() { return saw_goaway_; }
   void sendData(Http::StreamEncoder& encoder, Buffer::Instance& data, bool end_stream);
   void sendData(Http::StreamEncoder& encoder, uint64_t size, bool end_stream);
   void sendTrailers(Http::StreamEncoder& encoder, const Http::HeaderMap& trailers);
   void sendReset(Http::StreamEncoder& encoder);
-  Http::StreamEncoder& startRequest(const Http::HeaderMap& headers,
-                                    IntegrationStreamDecoder& response);
+  std::pair<Http::StreamEncoder&, IntegrationStreamDecoderPtr>
+  startRequest(const Http::HeaderMap& headers);
   void waitForDisconnect();
   Network::ClientConnection* connection() const { return connection_.get(); }
 
@@ -58,6 +58,7 @@ private:
 
   void flushWrite();
 
+  Event::Dispatcher& dispatcher_;
   ConnectionCallbacks callbacks_;
   CodecCallbacks codec_callbacks_;
   bool connected_{};
@@ -91,10 +92,9 @@ protected:
   //
   // Waits for the complete downstream response before returning.
   // Requires |codec_client_| to be initialized.
-  void sendRequestAndWaitForResponse(Http::TestHeaderMapImpl& request_headers,
-                                     uint32_t request_body_size,
-                                     Http::TestHeaderMapImpl& response_headers,
-                                     uint32_t response_body_size);
+  IntegrationStreamDecoderPtr sendRequestAndWaitForResponse(
+      Http::TestHeaderMapImpl& request_headers, uint32_t request_body_size,
+      Http::TestHeaderMapImpl& response_headers, uint32_t response_body_size);
 
   // Wait for the end of stream on the next upstream stream on fake_upstreams_
   // Sets fake_upstream_connection_ to the connection and upstream_request_ to stream.
@@ -175,8 +175,6 @@ protected:
   IntegrationCodecClientPtr codec_client_;
   // A placeholder for the first upstream connection.
   FakeHttpConnectionPtr fake_upstream_connection_;
-  // A placeholder for the first response received by the client.
-  IntegrationStreamDecoderPtr response_{new IntegrationStreamDecoder(*dispatcher_)};
   // A placeholder for the first request received at upstream.
   FakeStreamPtr upstream_request_;
   // A pointer to the request encoder, if used.

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -143,8 +143,7 @@ public:
     Http::TestHeaderMapImpl headers{{":method", "POST"},       {":path", "/test/long/url"},
                                     {":scheme", "http"},       {":authority", "host"},
                                     {"x-lyft-user-id", "123"}, {"x-forwarded-for", "10.0.0.1"}};
-    response_.reset(new IntegrationStreamDecoder(*dispatcher_));
-    codec_client_->makeRequestWithBody(headers, request_size_, *response_);
+    response_ = codec_client_->makeRequestWithBody(headers, request_size_);
   }
 
   void waitForLoadStatsStream() {
@@ -301,6 +300,7 @@ public:
 
   static constexpr uint32_t upstream_endpoints_ = 5;
 
+  IntegrationStreamDecoderPtr response_;
   std::string sub_zone_{"winter"};
   FakeHttpConnectionPtr fake_loadstats_connection_;
   FakeStreamPtr loadstats_stream_;

--- a/test/integration/ratelimit_integration_test.cc
+++ b/test/integration/ratelimit_integration_test.cc
@@ -54,7 +54,7 @@ public:
     Http::TestHeaderMapImpl headers{{":method", "POST"},       {":path", "/test/long/url"},
                                     {":scheme", "http"},       {":authority", "host"},
                                     {"x-lyft-user-id", "123"}, {"x-forwarded-for", "10.0.0.1"}};
-    codec_client_->makeRequestWithBody(headers, request_size_, *response_);
+    response_ = codec_client_->makeRequestWithBody(headers, request_size_);
   }
 
   void waitForRatelimitRequest() {
@@ -122,6 +122,7 @@ public:
 
   FakeHttpConnectionPtr fake_ratelimit_connection_;
   FakeStreamPtr ratelimit_request_;
+  IntegrationStreamDecoderPtr response_;
 
   const uint64_t request_size_ = 1024;
   const uint64_t response_size_ = 512;

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -146,7 +146,7 @@ void XfccIntegrationTest::testRequestAndResponseWithXfccHeader(std::string previ
   }
 
   codec_client_ = makeHttpConnection(std::move(conn));
-  codec_client_->makeHeaderOnlyRequest(header_map, *response_);
+  auto response = codec_client_->makeHeaderOnlyRequest(header_map);
   fake_upstream_connection_ = fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
   upstream_request_ = fake_upstream_connection_->waitForNewStream(*dispatcher_);
   upstream_request_->waitForEndStream(*dispatcher_);
@@ -157,9 +157,9 @@ void XfccIntegrationTest::testRequestAndResponseWithXfccHeader(std::string previ
                  upstream_request_->headers().ForwardedClientCert()->value().c_str());
   }
   upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, true);
-  response_->waitForEndStream();
+  response->waitForEndStream();
   EXPECT_TRUE(upstream_request_->complete());
-  EXPECT_TRUE(response_->complete());
+  EXPECT_TRUE(response->complete());
 }
 
 INSTANTIATE_TEST_CASE_P(IpVersions, XfccIntegrationTest,


### PR DESCRIPTION
This seems a "global variable" anti-pattern that led to bugs such as #3309.

Risk Level: Low
Testing: bazel test //test/...

Signed-off-by: Harvey Tuch <htuch@google.com>