### PR TITLE
grpc: use service full name as authority in the async client

### DIFF
--- a/source/common/grpc/async_client_impl.cc
+++ b/source/common/grpc/async_client_impl.cc
@@ -79,8 +79,8 @@ void AsyncStreamImpl::initialize(bool buffer_body_for_retry) {
 
   // TODO(htuch): match Google gRPC base64 encoding behavior for *-bin headers, see
   // https://github.com/envoyproxy/envoy/pull/2444#discussion_r163914459.
-  headers_message_ = Common::prepareHeaders(
-      service_method_.service()->full_name(), service_method_.name());
+  headers_message_ =
+      Common::prepareHeaders(service_method_.service()->full_name(), service_method_.name());
   // Fill service-wide initial metadata.
   for (const auto& header_value : parent_.initial_metadata_) {
     headers_message_->headers().addCopy(Http::LowerCaseString(header_value.key()),

--- a/source/common/grpc/async_client_impl.cc
+++ b/source/common/grpc/async_client_impl.cc
@@ -80,7 +80,7 @@ void AsyncStreamImpl::initialize(bool buffer_body_for_retry) {
   // TODO(htuch): match Google gRPC base64 encoding behavior for *-bin headers, see
   // https://github.com/envoyproxy/envoy/pull/2444#discussion_r163914459.
   headers_message_ = Common::prepareHeaders(
-      parent_.remote_cluster_name_, service_method_.service()->full_name(), service_method_.name());
+      service_method_.service()->full_name(), service_method_.name());
   // Fill service-wide initial metadata.
   for (const auto& header_value : parent_.initial_metadata_) {
     headers_message_->headers().addCopy(Http::LowerCaseString(header_value.key()),

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -238,7 +238,7 @@ Http::MessagePtr Common::prepareHeaders(const std::string& upstream_cluster,
                                                  service_full_name.size());
   message->headers().insertPath().value().append("/", 1);
   message->headers().insertPath().value().append(method_name.c_str(), method_name.size());
-  message->headers().insertHost().value(upstream_cluster);
+  message->headers().insertHost().value(service_full_name);
   message->headers().insertContentType().value().setReference(
       Http::Headers::get().ContentTypeValues.Grpc);
   message->headers().insertTE().value().setReference(Http::Headers::get().TEValues.Trailers);

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -228,8 +228,7 @@ Buffer::InstancePtr Common::serializeBody(const Protobuf::Message& message) {
   return body;
 }
 
-Http::MessagePtr Common::prepareHeaders(const std::string& upstream_cluster,
-                                        const std::string& service_full_name,
+Http::MessagePtr Common::prepareHeaders(const std::string& service_full_name,
                                         const std::string& method_name) {
   Http::MessagePtr message(new Http::RequestMessageImpl());
   message->headers().insertMethod().value().setReference(Http::Headers::get().MethodValues.Post);

--- a/source/common/grpc/common.h
+++ b/source/common/grpc/common.h
@@ -123,8 +123,7 @@ public:
   /**
    * Prepare headers for protobuf service.
    */
-  static Http::MessagePtr prepareHeaders(const std::string& upstream_cluster,
-                                         const std::string& service_full_name,
+  static Http::MessagePtr prepareHeaders(const std::string& service_full_name,
                                          const std::string& method_name);
 
   /**

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -449,7 +449,7 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::onInterval() {
   request_encoder_->getStream().addCallbacks(*this);
 
   auto headers_message = Grpc::Common::prepareHeaders(
-      parent_.cluster_.info()->name(), parent_.service_method_.service()->full_name(),
+      parent_.service_method_.service()->full_name(),
       parent_.service_method_.name());
   headers_message->headers().insertUserAgent().value().setReference(
       Http::Headers::get().UserAgentValues.EnvoyHealthChecker);

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -449,8 +449,7 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::onInterval() {
   request_encoder_->getStream().addCallbacks(*this);
 
   auto headers_message = Grpc::Common::prepareHeaders(
-      parent_.service_method_.service()->full_name(),
-      parent_.service_method_.name());
+      parent_.service_method_.service()->full_name(), parent_.service_method_.name());
   headers_message->headers().insertUserAgent().value().setReference(
       Http::Headers::get().UserAgentValues.EnvoyHealthChecker);
   Router::FilterUtility::setUpstreamScheme(headers_message->headers(), *parent_.cluster_.info());

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -49,9 +49,8 @@ void LightStepDriver::LightStepTransporter::Send(const Protobuf::Message& reques
   active_callback_ = &callback;
   active_response_ = &response;
 
-  Http::MessagePtr message =
-      Grpc::Common::prepareHeaders(lightstep::CollectorServiceFullName(),
-                                   lightstep::CollectorMethodName());
+  Http::MessagePtr message = Grpc::Common::prepareHeaders(lightstep::CollectorServiceFullName(),
+                                                          lightstep::CollectorMethodName());
   message->body() = Grpc::Common::serializeBody(request);
 
   const uint64_t timeout =

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -50,7 +50,7 @@ void LightStepDriver::LightStepTransporter::Send(const Protobuf::Message& reques
   active_response_ = &response;
 
   Http::MessagePtr message =
-      Grpc::Common::prepareHeaders(driver_.cluster()->name(), lightstep::CollectorServiceFullName(),
+      Grpc::Common::prepareHeaders(lightstep::CollectorServiceFullName(),
                                    lightstep::CollectorMethodName());
   message->body() = Grpc::Common::serializeBody(request);
 

--- a/test/common/grpc/common_test.cc
+++ b/test/common/grpc/common_test.cc
@@ -70,11 +70,11 @@ TEST(GrpcCommonTest, ChargeStats) {
 }
 
 TEST(GrpcCommonTest, PrepareHeaders) {
-  Http::MessagePtr message = Common::prepareHeaders("cluster", "service_name", "method_name");
+  Http::MessagePtr message = Common::prepareHeaders("service_name", "method_name");
 
   EXPECT_STREQ("POST", message->headers().Method()->value().c_str());
   EXPECT_STREQ("/service_name/method_name", message->headers().Path()->value().c_str());
-  EXPECT_STREQ("cluster", message->headers().Host()->value().c_str());
+  EXPECT_STREQ("service_name", message->headers().Host()->value().c_str());
   EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
 }
 

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -175,7 +175,7 @@ TEST_F(LightStepDriverTest, FlushSeveralSpans) {
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
-            EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
+            EXPECT_STREQ("lightstep.collector.CollectorService", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
 
             return &request;
@@ -235,7 +235,7 @@ TEST_F(LightStepDriverTest, FlushOneFailure) {
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
-            EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
+            EXPECT_STREQ("lightstep.collector.CollectorService", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
 
             return &request;
@@ -277,7 +277,7 @@ TEST_F(LightStepDriverTest, FlushOneInvalidResponse) {
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
-            EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
+            EXPECT_STREQ("lightstep.collector.CollectorService", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
 
             return &request;
@@ -351,7 +351,7 @@ TEST_F(LightStepDriverTest, FlushOneSpanGrpcFailure) {
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
-            EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
+            EXPECT_STREQ("lightstep.collector.CollectorService", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
 
             return &request;

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -175,7 +175,8 @@ TEST_F(LightStepDriverTest, FlushSeveralSpans) {
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
-            EXPECT_STREQ("lightstep.collector.CollectorService", message->headers().Host()->value().c_str());
+            EXPECT_STREQ("lightstep.collector.CollectorService",
+                         message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
 
             return &request;
@@ -235,7 +236,8 @@ TEST_F(LightStepDriverTest, FlushOneFailure) {
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
-            EXPECT_STREQ("lightstep.collector.CollectorService", message->headers().Host()->value().c_str());
+            EXPECT_STREQ("lightstep.collector.CollectorService",
+                         message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
 
             return &request;
@@ -277,7 +279,8 @@ TEST_F(LightStepDriverTest, FlushOneInvalidResponse) {
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
-            EXPECT_STREQ("lightstep.collector.CollectorService", message->headers().Host()->value().c_str());
+            EXPECT_STREQ("lightstep.collector.CollectorService",
+                         message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
 
             return &request;
@@ -351,7 +354,8 @@ TEST_F(LightStepDriverTest, FlushOneSpanGrpcFailure) {
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
-            EXPECT_STREQ("lightstep.collector.CollectorService", message->headers().Host()->value().c_str());
+            EXPECT_STREQ("lightstep.collector.CollectorService",
+                         message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
 
             return &request;


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Use service full name instead of the upstream cluster name for gRPC async calls.
gRPC services are valid host names but the upstream cluster names are not (see https://developers.google.com/protocol-buffers/docs/reference/proto3-spec). 

*Risk Level*: _Low_ | Medium | High

*Testing*: unit regression tests

Fixes #3297 