### PR TITLE
util: Adds some LockGuard variants with thread annotation, and added GUARDED_BY declarations for hot_restart.

### DIFF
--- a/include/envoy/thread/BUILD
+++ b/include/envoy/thread/BUILD
@@ -11,4 +11,5 @@ envoy_package()
 envoy_cc_library(
     name = "thread_interface",
     hdrs = ["thread.h"],
+    external_deps = ["abseil_base"],
 )

--- a/include/envoy/thread/thread.h
+++ b/include/envoy/thread/thread.h
@@ -82,6 +82,11 @@ private:
   bool is_locked_;
 };
 
+/**
+ * Implements a LockGuard that is identical to absl::ReleasableMutexLock, but takes a
+ * BasicLockable& to allow usages to be agnostic to cross-process mutexes vs. single-process
+ * mutexes.
+ */
 class SCOPED_LOCKABLE LockGuard {
 public:
   /**

--- a/include/envoy/thread/thread.h
+++ b/include/envoy/thread/thread.h
@@ -49,12 +49,19 @@ private:
   BasicLockable* const lock_;
 };
 
+// At the moment, TryLockGuard is very hard to annotate correctly, I
+// believe due to limitations in clang. At the moment there are no
+// GUARDED_BY variables for any tryLocks in the codebase, so it's
+// easies just to leave it out. In a future clang release it's
+// possible we can enable this. See also the commented-out block
+// in ThreadTest.TestTryLockGuard in test/common/common/thread_test.cc.
+#define DISABLE_TRYLOCKGUARD_ANNOTATION(annotation)
+
 /**
  * Like LockGuard, but uses a tryLock() on construction rather than a lock(). This
  * class lacks thread annotations, as clang currently does appear to be able to handle
  * conditional thread annotations. So the ones we'd like are commented out.
  */
-#define DISABLE_TRYLOCK_ANNOTATION(annoation)
 class SCOPED_LOCKABLE TryLockGuard {
 public:
   /**
@@ -69,7 +76,7 @@ public:
   /**
    * Destruction of the DeferredLockGuard unlocks the lock, if it was locked.
    */
-  ~TryLockGuard() DISABLE_TRYLOCK_ANNOTATION(UNLOCK_FUNCTION()) {
+  ~TryLockGuard() DISABLE_TRYLOCKGUARD_ANNOTATION(UNLOCK_FUNCTION()) {
     if (is_locked_) {
       lock_.unlock();
     }
@@ -78,7 +85,7 @@ public:
   /**
    * @return bool whether the lock was successfully acquired.
    */
-  bool tryLock() DISABLE_TRYLOCK_ANNOTATION(EXCLUSIVE_TRYLOCK_FUNCTION(true)) {
+  bool tryLock() DISABLE_TRYLOCKGUARD_ANNOTATION(EXCLUSIVE_TRYLOCK_FUNCTION(true)) {
     is_locked_ = lock_.tryLock();
     return is_locked_;
   }

--- a/include/envoy/thread/thread.h
+++ b/include/envoy/thread/thread.h
@@ -1,4 +1,4 @@
-u#pragma once
+#pragma once
 
 #include "envoy/common/pure.h"
 

--- a/include/envoy/thread/thread.h
+++ b/include/envoy/thread/thread.h
@@ -86,6 +86,10 @@ private:
  * Implements a LockGuard that is identical to absl::ReleasableMutexLock, but takes a
  * BasicLockable& to allow usages to be agnostic to cross-process mutexes vs. single-process
  * mutexes.
+ *
+ * Note: this implementation holds the mutex for the lifetime of the LockGuard, simplifying
+ * implementation (no conditionals) and readability at call-sites. In some cases, an early
+ * release is needed, in which case, a ReleasableLockGuard can be used.
  */
 class SCOPED_LOCKABLE LockGuard {
 public:

--- a/include/envoy/thread/thread.h
+++ b/include/envoy/thread/thread.h
@@ -52,7 +52,7 @@ private:
 // At the moment, TryLockGuard is very hard to annotate correctly, I
 // believe due to limitations in clang. At the moment there are no
 // GUARDED_BY variables for any tryLocks in the codebase, so it's
-// easies just to leave it out. In a future clang release it's
+// easiest just to leave it out. In a future clang release it's
 // possible we can enable this. See also the commented-out block
 // in ThreadTest.TestTryLockGuard in test/common/common/thread_test.cc.
 #define DISABLE_TRYLOCKGUARD_ANNOTATION(annotation)
@@ -121,7 +121,7 @@ public:
   ~LockGuard() UNLOCK_FUNCTION() { lock_.unlock(); }
 
 private:
-  BasicLockable& lock_; // Set to nullptr on unlock, to prevent double-unlocking.
+  BasicLockable& lock_;
 };
 
 /**

--- a/include/envoy/thread/thread.h
+++ b/include/envoy/thread/thread.h
@@ -46,7 +46,7 @@ public:
   }
 
 private:
-  BasicLockable* lock_;
+  BasicLockable* const lock_;
 };
 
 /**
@@ -61,7 +61,7 @@ public:
    *
    * @param lock the mutex.
    */
-  TryLockGuard(BasicLockable& lock) EXCLUSIVE_TRYLOCK_FUNCTION(true)
+  TryLockGuard(BasicLockable& lock) EXCLUSIVE_LOCK_FUNCTION(lock)
       : lock_(lock.tryLock() ? &lock : nullptr) {}
 
   /**
@@ -79,7 +79,7 @@ public:
   bool isLocked() const { return lock_ != nullptr; }
 
 private:
-  BasicLockable* lock_;
+  BasicLockable* const lock_;
 };
 
 /**

--- a/include/envoy/thread/thread.h
+++ b/include/envoy/thread/thread.h
@@ -1,41 +1,116 @@
-#pragma once
+u#pragma once
 
 #include "envoy/common/pure.h"
+
+#include "absl/base/thread_annotations.h"
 
 namespace Envoy {
 namespace Thread {
 
 /**
- * Like the C++11 "basic lockable concept" but a concrete interface vs. a template.
+ * Like the C++11 "basic lockable concept" but a pure virtual interface vs. a template, and
+ * with thread annotations.
  */
-class BasicLockable {
+class LOCKABLE BasicLockable {
 public:
   virtual ~BasicLockable() {}
 
-  virtual void lock() PURE;
-  virtual bool try_lock() PURE;
-  virtual void unlock() PURE;
+  virtual void lock() EXCLUSIVE_LOCK_FUNCTION() PURE;
+  virtual bool tryLock() EXCLUSIVE_TRYLOCK_FUNCTION(true) PURE;
+  virtual void unlock() UNLOCK_FUNCTION() PURE;
 };
 
 /**
  * A lock guard that deals with an optional lock.
  */
-template <class T> class OptionalLockGuard {
+class SCOPED_LOCKABLE OptionalLockGuard {
 public:
-  OptionalLockGuard(T* lock) : lock_(lock) {
-    if (lock) {
-      lock->lock();
+  /**
+   * Establishes a scoped mutex-lock. If non-null, the mutex is locked upon construction.
+   *
+   * @param lock the mutex.
+   */
+  OptionalLockGuard(BasicLockable* lock) EXCLUSIVE_LOCK_FUNCTION(lock) : lock_(lock) {
+    if (lock_) {
+      lock_->lock();
     }
   }
 
-  ~OptionalLockGuard() {
+  /**
+   * Destruction of the OptionalLockGuard unlocks the lock, if it is non-null.
+   */
+  ~OptionalLockGuard() UNLOCK_FUNCTION() {
     if (lock_) {
       lock_->unlock();
     }
   }
 
 private:
-  T* lock_;
+  BasicLockable* lock_;
+};
+
+/**
+ * A lock guard that deals with a lock that is not locked on construction, although
+ * it is unlocked on destruction, if necessary.
+ */
+class DeferredLockGuard {
+public:
+  /**
+   * Establishes a scoped mutex-lock; the mutex is not locked upon construction.
+   *
+   * @param lock the mutex.
+   */
+  DeferredLockGuard(BasicLockable& lock) : lock_(lock), is_locked_(false) {}
+
+  /**
+   * Destruction of the DeferredLockGuard unlocks the lock, if it was locked.
+   */
+  ~DeferredLockGuard() {
+    if (is_locked_) {
+      lock_.unlock();
+    }
+  }
+
+  // Attempts to lock the mutex, if present. Returns false if no lock was taken.
+  bool tryLock() {
+    is_locked_ = lock_.tryLock();
+    return is_locked_;
+  }
+
+private:
+  BasicLockable& lock_;
+  bool is_locked_;
+};
+
+class SCOPED_LOCKABLE LockGuard {
+public:
+  /**
+   * Establishes a scoped mutex-lock; the mutex is locked upon construction.
+   *
+   * @param lock the mutex.
+   */
+  explicit LockGuard(BasicLockable& lock) EXCLUSIVE_LOCK_FUNCTION(lock) : lock_(&lock) {
+    lock_->lock();
+  }
+
+  /**
+   * Destruction of the LockGuard unlocks the lock, if it has not already been explicitly unlocked.
+   */
+  ~LockGuard() UNLOCK_FUNCTION() { unlock(); }
+
+  /**
+   * Unlocks the mutex. This enables call-sites to release the mutex prior to the Lock going out of
+   * scope.
+   */
+  void unlock() UNLOCK_FUNCTION() {
+    if (lock_ != nullptr) {
+      lock_->unlock();
+      lock_ = nullptr;
+    }
+  }
+
+private:
+  BasicLockable* lock_; // Set to nullptr on unlock, to prevent double-unlocking.
 };
 
 } // namespace Thread

--- a/include/envoy/thread/thread.h
+++ b/include/envoy/thread/thread.h
@@ -130,11 +130,7 @@ public:
   /**
    * Destruction of the LockGuard unlocks the lock, if it has not already been explicitly released.
    */
-  ~ReleasableLockGuard() UNLOCK_FUNCTION() {
-    if (lock_ != nullptr) {
-      lock_->unlock();
-    }
-  }
+  ~ReleasableLockGuard() UNLOCK_FUNCTION() { release(); }
 
   /**
    * Unlocks the mutex. This enables call-sites to release the mutex prior to the Lock going out of

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -39,12 +39,12 @@ SinkDelegate::~SinkDelegate() {
 StderrSinkDelegate::StderrSinkDelegate(DelegatingLogSinkPtr log_sink) : SinkDelegate(log_sink) {}
 
 void StderrSinkDelegate::log(absl::string_view msg) {
-  Thread::OptionalLockGuard<Thread::BasicLockable> guard(lock_);
+  Thread::OptionalLockGuard guard(lock_);
   std::cerr << msg;
 }
 
 void StderrSinkDelegate::flush() {
-  Thread::OptionalLockGuard<Thread::BasicLockable> guard(lock_);
+  Thread::OptionalLockGuard guard(lock_);
   std::cerr << std::flush;
 }
 

--- a/source/common/common/perf_annotation.cc
+++ b/source/common/common/perf_annotation.cc
@@ -37,7 +37,7 @@ void PerfAnnotationContext::record(std::chrono::nanoseconds duration, absl::stri
   CategoryDescription key((std::string(category)), (std::string(description)));
   {
 #if PERF_THREAD_SAFE
-    absl::MutexLock lock(&mutex_);
+    Thread::LockGuard lock(mutex_);
 #endif
     DurationStats& stats = duration_stats_map_[key];
     stats.stddev_.update(static_cast<double>(duration.count()));
@@ -57,7 +57,7 @@ std::string PerfAnnotationContext::toString() {
   PerfAnnotationContext* context = getOrCreate();
   std::string out;
 #if PERF_THREAD_SAFE
-  absl::MutexLock lock(&context->mutex_);
+  Thread::LockGuard lock(context->mutex_);
 #endif
 
   // The map is from category/description -> [duration, time]. Reverse-sort by duration.
@@ -140,7 +140,7 @@ std::string PerfAnnotationContext::toString() {
 void PerfAnnotationContext::clear() {
   PerfAnnotationContext* context = getOrCreate();
 #if PERF_THREAD_SAFE
-  absl::MutexLock lock(&context->mutex_);
+  Thread::LockGuard lock(context->mutex_);
 #endif
   context->duration_stats_map_.clear();
 }

--- a/source/common/common/perf_annotation.h
+++ b/source/common/common/perf_annotation.h
@@ -135,7 +135,7 @@ private:
   // Maps {category, description} to DurationStats.
 #if PERF_THREAD_SAFE
   DurationStatsMap duration_stats_map_ GUARDED_BY(mutex_);
-  absl::Mutex mutex_;
+  Thread::MutexBasicLockable mutex_;
 #else
   DurationStatsMap duration_stats_map_;
 #endif

--- a/source/common/common/thread.h
+++ b/source/common/common/thread.h
@@ -43,13 +43,12 @@ typedef std::unique_ptr<Thread> ThreadPtr;
  */
 class MutexBasicLockable : public BasicLockable {
 public:
-  void lock() override { mutex_.lock(); }
-  bool try_lock() override { return mutex_.try_lock(); }
-  void unlock() override { mutex_.unlock(); }
+  void lock() EXCLUSIVE_LOCK_FUNCTION() override { mutex_.Lock(); }
+  bool tryLock() EXCLUSIVE_TRYLOCK_FUNCTION(true) override { return mutex_.TryLock(); }
+  void unlock() UNLOCK_FUNCTION() override { mutex_.Unlock(); }
 
 private:
-  // TODO(jmarantz): change to absl::Mutex and add thread annotations.
-  std::mutex mutex_;
+  absl::Mutex mutex_;
 };
 
 } // namespace Thread

--- a/source/common/grpc/google_async_client_impl.cc
+++ b/source/common/grpc/google_async_client_impl.cc
@@ -42,7 +42,7 @@ void GoogleAsyncClientThreadLocal::completionThread() {
     const GoogleAsyncTag::Operation op = google_async_tag.op_;
     GoogleAsyncStreamImpl& stream = google_async_tag.stream_;
     ENVOY_LOG(trace, "completionThread CQ event {} {}", op, ok);
-    absl::MutexLock lock(&stream.completed_ops_lock_);
+    Thread::LockGuard lock(stream.completed_ops_lock_);
 
     // It's an invariant that there must only be one pending post for arbitrary
     // length completed_ops_, otherwise we can race in stream destruction, where
@@ -240,7 +240,7 @@ void GoogleAsyncStreamImpl::writeQueued() {
 }
 
 void GoogleAsyncStreamImpl::onCompletedOps() {
-  absl::MutexLock lock(&completed_ops_lock_);
+  Thread::LockGuard lock(completed_ops_lock_);
   while (!completed_ops_.empty()) {
     GoogleAsyncTag::Operation op;
     bool ok;

--- a/source/common/grpc/google_async_client_impl.h
+++ b/source/common/grpc/google_async_client_impl.h
@@ -293,7 +293,7 @@ private:
   // handleOpCompletion().
   std::deque<std::pair<GoogleAsyncTag::Operation, bool>>
       completed_ops_ GUARDED_BY(completed_ops_lock_);
-  absl::Mutex completed_ops_lock_;
+  Thread::MutexBasicLockable completed_ops_lock_;
 
   friend class GoogleAsyncClientImpl;
   friend class GoogleAsyncClientThreadLocal;

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -159,10 +159,10 @@ RawStatData* HeapRawStatDataAllocator::alloc(const std::string& name) {
   // storing the name twice. Performing a lookup on the set is similarly
   // expensive to performing a map lookup, since both require copying a truncated version of the
   // string before doing the hash lookup.
-  absl::ReleasableMutexLock lock(&mutex_);
+  Thread::ReleasableLockGuard lock(mutex_);
   auto ret = stats_.insert(data);
   RawStatData* existing_data = *ret.first;
-  lock.Release();
+  lock.release();
 
   if (!ret.second) {
     ::free(data);
@@ -280,7 +280,7 @@ void HeapRawStatDataAllocator::free(RawStatData& data) {
 
   size_t key_removed;
   {
-    absl::MutexLock lock(&mutex_);
+    Thread::LockGuard lock(mutex_);
     key_removed = stats_.erase(&data);
   }
 

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -435,7 +435,7 @@ private:
   // A mutex is needed here to protect the stats_ object from both alloc() and free() operations.
   // Although alloc() operations are called under existing locking, free() operations are made from
   // the destructors of the individual stat objects, which are not protected by locks.
-  absl::Mutex mutex_;
+  Thread::MutexBasicLockable mutex_;
 };
 
 /**

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -140,7 +140,7 @@ HotRestartImpl::HotRestartImpl(Options& options)
 
 Stats::RawStatData* HotRestartImpl::alloc(const std::string& name) {
   // Try to find the existing slot in shared memory, otherwise allocate a new one.
-  std::unique_lock<Thread::BasicLockable> lock(stat_lock_);
+  Thread::LockGuard lock(stat_lock_);
   absl::string_view key = name;
   if (key.size() > Stats::RawStatData::maxNameLength()) {
     key.remove_suffix(key.size() - Stats::RawStatData::maxNameLength());
@@ -161,7 +161,7 @@ Stats::RawStatData* HotRestartImpl::alloc(const std::string& name) {
 
 void HotRestartImpl::free(Stats::RawStatData& data) {
   // We must hold the lock since the reference decrement can race with an initialize above.
-  std::unique_lock<Thread::BasicLockable> lock(stat_lock_);
+  Thread::LockGuard lock(stat_lock_);
   ASSERT(data.ref_count_ > 0);
   if (--data.ref_count_ > 0) {
     return;
@@ -248,12 +248,12 @@ void HotRestartImpl::getParentStats(GetParentStatsInfo& info) {
   // could also potentially use connection oriented sockets and accept connections from our child,
   // and connect to our parent, but again, this becomes complicated.
   //
-  // Instead, we guard this condition with a lock. However, to avoid deadlock, we must try_lock()
+  // Instead, we guard this condition with a lock. However, to avoid deadlock, we must tryLock()
   // in this path, since this call runs in the same thread as the event loop that is receiving
-  // messages. If try_lock() fails it is sufficient to not return any parent stats.
-  std::unique_lock<Thread::BasicLockable> lock(init_lock_, std::defer_lock);
+  // messages. If tryLock() fails it is sufficient to not return any parent stats.
+  Thread::DeferredLockGuard lock(init_lock_);
   memset(&info, 0, sizeof(info));
-  if (options_.restartEpoch() == 0 || parent_terminated_ || !lock.try_lock()) {
+  if (options_.restartEpoch() == 0 || parent_terminated_ || !lock.tryLock()) {
     return;
   }
 
@@ -447,7 +447,7 @@ void HotRestartImpl::onSocketEvent() {
 
 void HotRestartImpl::shutdownParentAdmin(ShutdownParentAdminInfo& info) {
   // See large comment in getParentStats() on why this operation is locked.
-  std::unique_lock<Thread::BasicLockable> lock(init_lock_);
+  Thread::LockGuard lock(init_lock_);
   if (options_.restartEpoch() == 0) {
     return;
   }
@@ -472,6 +472,7 @@ void HotRestartImpl::terminateParent() {
 void HotRestartImpl::shutdown() { socket_event_.reset(); }
 
 std::string HotRestartImpl::version() {
+  Thread::LockGuard lock(stat_lock_);
   return versionHelper(shmem_.maxStats(), Stats::RawStatData::maxNameLength(), *stats_set_);
 }
 

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -251,8 +251,8 @@ void HotRestartImpl::getParentStats(GetParentStatsInfo& info) {
   // Instead, we guard this condition with a lock. However, to avoid deadlock, we must tryLock()
   // in this path, since this call runs in the same thread as the event loop that is receiving
   // messages. If tryLock() fails it is sufficient to not return any parent stats.
-  memset(&info, 0, sizeof(info));
   Thread::TryLockGuard lock(init_lock_);
+  memset(&info, 0, sizeof(info));
   if (options_.restartEpoch() == 0 || parent_terminated_ || !lock.tryLock()) {
     return;
   }

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -252,18 +252,16 @@ void HotRestartImpl::getParentStats(GetParentStatsInfo& info) {
   // in this path, since this call runs in the same thread as the event loop that is receiving
   // messages. If tryLock() fails it is sufficient to not return any parent stats.
   memset(&info, 0, sizeof(info));
-  if (options_.restartEpoch() == 0 || parent_terminated_) {
+  Thread::TryLockGuard lock(init_lock_);
+  if (options_.restartEpoch() == 0 || parent_terminated_ || !lock.tryLock()) {
     return;
   }
 
-  Thread::TryLockGuard lock(init_lock_);
-  if (lock.isLocked()) {
-    RpcBase rpc(RpcMessageType::GetStatsRequest);
-    sendMessage(parent_address_, rpc);
-    RpcGetStatsReply* reply = receiveTypedRpc<RpcGetStatsReply, RpcMessageType::GetStatsReply>();
-    info.memory_allocated_ = reply->memory_allocated_;
-    info.num_connections_ = reply->num_connections_;
-  }
+  RpcBase rpc(RpcMessageType::GetStatsRequest);
+  sendMessage(parent_address_, rpc);
+  RpcGetStatsReply* reply = receiveTypedRpc<RpcGetStatsReply, RpcMessageType::GetStatsReply>();
+  info.memory_allocated_ = reply->memory_allocated_;
+  info.num_connections_ = reply->num_connections_;
 }
 
 void HotRestartImpl::initialize(Event::Dispatcher& dispatcher, Server::Instance& server) {

--- a/source/server/hot_restart_impl.h
+++ b/source/server/hot_restart_impl.h
@@ -87,7 +87,7 @@ public:
     }
   }
 
-  bool try_lock() override {
+  bool tryLock() override {
     int rc = pthread_mutex_trylock(&mutex_);
     if (rc == EBUSY) {
       return false;
@@ -209,7 +209,7 @@ private:
   Options& options_;
   BlockMemoryHashSetOptions stats_set_options_;
   SharedMemory& shmem_;
-  std::unique_ptr<RawStatDataSet> stats_set_;
+  std::unique_ptr<RawStatDataSet> stats_set_ GUARDED_BY(stat_lock_);
   ProcessSharedMutex log_lock_;
   ProcessSharedMutex access_log_lock_;
   ProcessSharedMutex stat_lock_;

--- a/source/server/hot_restart_impl.h
+++ b/source/server/hot_restart_impl.h
@@ -76,7 +76,7 @@ class ProcessSharedMutex : public Thread::BasicLockable {
 public:
   ProcessSharedMutex(pthread_mutex_t& mutex) : mutex_(mutex) {}
 
-  void lock() override {
+  void lock() EXCLUSIVE_LOCK_FUNCTION() override {
     // Deal with robust handling here. If the other process dies without unlocking, we are going
     // to die shortly but try to make sure that we can handle any signals, etc. that happen without
     // getting into a further messed up state.
@@ -87,7 +87,7 @@ public:
     }
   }
 
-  bool tryLock() override {
+  bool tryLock() EXCLUSIVE_TRYLOCK_FUNCTION(true) override {
     int rc = pthread_mutex_trylock(&mutex_);
     if (rc == EBUSY) {
       return false;
@@ -101,7 +101,7 @@ public:
     return true;
   }
 
-  void unlock() override {
+  void unlock() UNLOCK_FUNCTION() override {
     int rc = pthread_mutex_unlock(&mutex_);
     ASSERT(rc == 0);
   }

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -135,3 +135,11 @@ envoy_cc_binary(
         "//source/common/common:utility_lib",
     ],
 )
+
+envoy_cc_test(
+    name = "thread_test",
+    srcs = ["thread_test.cc"],
+    deps = [
+        "//source/common/common:thread_lib",
+    ],
+)

--- a/test/common/common/thread_test.cc
+++ b/test/common/common/thread_test.cc
@@ -31,8 +31,16 @@ TEST_F(ThreadTest, TestReleasableLockGuard) {
 
 TEST_F(ThreadTest, TestTryLockGuard) {
   TryLockGuard lock(a_mutex_);
-  if (lock.isLocked()) {
-    EXPECT_EQ(1, ++a_);
+
+  // This test doesn't work, because a_mutex_ is guarded, and thread annotations
+  // don't work with TryLockGuard.
+  // if (lock.tryLock()) {
+  //   EXPECT_EQ(1, ++a_);
+  // }
+
+  // TryLockGuard does functionally work with unguarded variables.
+  if (lock.tryLock()) {
+    EXPECT_EQ(1, ++b_);
   }
 }
 

--- a/test/common/common/thread_test.cc
+++ b/test/common/common/thread_test.cc
@@ -34,7 +34,7 @@ TEST_F(ThreadTest, TestTryLockGuard) {
 
   if (lock.tryLock()) {
     // This test doesn't work, because a_mutex_ is guarded, and thread
-    // annotations don't work with TryLockGuard. The Macro is defined in
+    // annotations don't work with TryLockGuard. The macro is defined in
     // include/envoy/thread/thread.h.
     DISABLE_TRYLOCKGUARD_ANNOTATION(EXPECT_EQ(1, ++a_));
 

--- a/test/common/common/thread_test.cc
+++ b/test/common/common/thread_test.cc
@@ -1,0 +1,40 @@
+#include "common/common/thread.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Thread {
+
+class ThreadTest : public testing::Test {
+protected:
+  ThreadTest() : a_(0), b_(0) {}
+  int a_ GUARDED_BY(a_mutex_);
+  MutexBasicLockable a_mutex_;
+  int b_;
+};
+
+TEST_F(ThreadTest, TestLockGuard) {
+  LockGuard lock(a_mutex_);
+  EXPECT_EQ(1, ++a_);
+}
+
+TEST_F(ThreadTest, TestOptionalLockGuard) {
+  OptionalLockGuard lock(nullptr);
+  EXPECT_EQ(1, ++b_);
+}
+
+TEST_F(ThreadTest, TestReleasableLockGuard) {
+  ReleasableLockGuard lock(a_mutex_);
+  EXPECT_EQ(1, ++a_);
+  lock.release();
+}
+
+TEST_F(ThreadTest, TestTryLockGuard) {
+  TryLockGuard lock(a_mutex_);
+  if (lock.isLocked()) {
+    EXPECT_EQ(1, ++a_);
+  }
+}
+
+} // namespace Thread
+} // namespace Envoy

--- a/test/common/common/thread_test.cc
+++ b/test/common/common/thread_test.cc
@@ -32,14 +32,13 @@ TEST_F(ThreadTest, TestReleasableLockGuard) {
 TEST_F(ThreadTest, TestTryLockGuard) {
   TryLockGuard lock(a_mutex_);
 
-  // This test doesn't work, because a_mutex_ is guarded, and thread annotations
-  // don't work with TryLockGuard.
-  // if (lock.tryLock()) {
-  //   EXPECT_EQ(1, ++a_);
-  // }
-
-  // TryLockGuard does functionally work with unguarded variables.
   if (lock.tryLock()) {
+    // This test doesn't work, because a_mutex_ is guarded, and thread
+    // annotations don't work with TryLockGuard. The Macro is defined in
+    // include/envoy/thread/thread.h.
+    DISABLE_TRYLOCKGUARD_ANNOTATION(EXPECT_EQ(1, ++a_));
+
+    // TryLockGuard does functionally work with unguarded variables.
     EXPECT_EQ(1, ++b_);
   }
 }


### PR DESCRIPTION

Signed-off-by: Joshua Marantz <jmarantz@google.com>

*Description*:
>Adds infrastructure for thread-annotated lock guards of various types.   Use that to annotate that HotRestartImpl::stats_set_ is guarded -- in that case by a cross-process mutex.  Fix a usage of stats_set_ that was not guarded.

*Risk Level*: Low

*Testing*: //test/...

*Docs Changes*: N/A

*Release Notes*: N/A
