### PR TITLE
docs: add back accidentally deleted line in version_history

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -24,6 +24,7 @@ Version history
 * cli: added --config-yaml flag to the Envoy binary. When set its value is interpreted as a yaml
   representation of the bootstrap config and overrides --config-path.
 * cluster: Add :ref:`option <envoy_api_field_Cluster.close_connections_on_host_health_failure>`
+  to close tcp_proxy upstream connections when health checks fail.
 * cluster: Add :ref:`option <envoy_api_field_Cluster.drain_connections_on_host_removal>` to drain
   connections from hosts after they are removed from service discovery, regardless of health status.
 * health check: added ability to set :ref:`additional HTTP headers


### PR DESCRIPTION
*Description*:
This got deleted accidentally in #3302

*Risk Level*: 
Low: docs change

*Testing*:
N/A

*Docs Changes*:
Added back line that got deleted accidentally

*Release Notes*:
N/A
