### PR TITLE
router: move ASSERT(headers.Path()) to avoid segfault

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -298,8 +298,8 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 
   ENVOY_STREAM_LOG(debug, "router decoding headers:\n{}", *callbacks_, headers);
 
-  // Finally assert that an http sceme was selected
-  // in the setUpstreamScheme function.
+  // Finally assert that an http scheme was selected
+  // in the before continuing.
   ASSERT(headers.Scheme());
 
   grpc_request_ = Grpc::Common::hasGrpcContentType(headers);

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -293,7 +293,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 
   // Ensure an http transport scheme is selected before continuing with decoding.
   ASSERT(headers.Scheme());
-  
+
   retry_state_ =
       createRetryState(route_entry_->retryPolicy(), headers, *cluster_, config_.runtime_,
                        config_.random_, callbacks_->dispatcher(), route_entry_->priority());

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -290,6 +290,10 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
 
   route_entry_->finalizeRequestHeaders(headers, callbacks_->requestInfo());
   FilterUtility::setUpstreamScheme(headers, *cluster_);
+
+  // Ensure an http transport scheme is selected before continuing with decoding.
+  ASSERT(headers.Scheme());
+  
   retry_state_ =
       createRetryState(route_entry_->retryPolicy(), headers, *cluster_, config_.runtime_,
                        config_.random_, callbacks_->dispatcher(), route_entry_->priority());
@@ -297,10 +301,6 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
                                               callbacks_->streamId());
 
   ENVOY_STREAM_LOG(debug, "router decoding headers:\n{}", *callbacks_, headers);
-
-  // Finally assert that an http scheme was selected
-  // in the before continuing.
-  ASSERT(headers.Scheme());
 
   grpc_request_ = Grpc::Common::hasGrpcContentType(headers);
   upstream_request_.reset(new UpstreamRequest(*this, *conn_pool));

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -190,6 +190,10 @@ void Filter::sendLocalReply(Http::Code code, const std::string& body,
 }
 
 Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool end_stream) {
+  // Do a check for the HTTP Path header value,
+  // This is a required http header.
+  ASSERT(headers.Path());
+
   downstream_headers_ = &headers;
 
   // Only increment rq total stat if we actually decode headers here. This does not count requests
@@ -297,7 +301,6 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
   ASSERT(headers.Scheme());
   ASSERT(headers.Method());
   ASSERT(headers.Host());
-  ASSERT(headers.Path());
 
   grpc_request_ = Grpc::Common::hasGrpcContentType(headers);
   upstream_request_.reset(new UpstreamRequest(*this, *conn_pool));


### PR DESCRIPTION
*title*: *router: move ASSERT(headers.Path()) to avoid segfault*

*Description*:
When using the `Upstream::ClusterManager::httpAsyncClientForCluster->send()` with a MessagePtr that has an empty path field envoy will segfault but leave no obvious reason for the segfault.  This moves an existing `ASSERT` further up the function to catch this potentially empty value.

*Risk Level*: Low

*Testing*:
Manual testing:
```c++
Envoy::Http::MessagePtr request(new Envoy::Http::RequestMessageImpl());
request->headers().insertContentType().value().setReference(
      Http::Headers::get().ContentTypeValues.TextUtf8);
request->headers().insertHost().value(config_->cluster());
request->headers().insertMethod().value().setReference(Http::Headers::get().MethodValues.Get);

cm_.httpAsyncClientForCluster(config_->cluster())
    .send(std::move(request), create_request_callback_, config_->timeout());
```

Output:
```
[2018-05-08 22:50:14.039][5016753][critical][assert] external/envoy/source/common/router/router.cc:195] assert failure: headers.Path()
[2018-05-08 22:50:14.039][5016753][critical][backtrace] bazel-out/darwin-dbg/bin/external/envoy/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:114] Caught Abort trap: 6, suspect faulting address 0x7fffa0779d42
[2018-05-08 22:50:14.045][5016753][critical][backtrace] bazel-out/darwin-dbg/bin/external/envoy/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:87] Backtrace obj<envoy> thr<123145517580288>:
[2018-05-08 22:50:14.045][5016753][critical][backtrace] bazel-out/darwin-dbg/bin/external/envoy/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:99] thr<123145517580288> obj<envoy                               0x000000010787de76 _ZN8backward7details6unwindINS_14StackTraceImplINS_10system_tag10darwin_tagEE8callbackEEEmT_m>
[2018-05-08 22:50:14.045][5016753][critical][backtrace] bazel-out/darwin-dbg/bin/external/envoy/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:105] thr<123145517580288> #0 0x10787de76:
[2018-05-08 22:50:14.045][5016753][critical][backtrace] bazel-out/darwin-dbg/bin/external/envoy/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:99] thr<123145517580288> obj<envoy>
[2018-05-08 22:50:14.045][5016753][critical][backtrace] bazel-out/darwin-dbg/bin/external/envoy/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:105] thr<123145517580288> #1 0x10787da05: backward::StackTraceImpl<backward::system_tag::darwin_tag>::load_here(unsigned long) + 101
[2018-05-08 22:50:14.045][5016753][critical][backtrace] bazel-out/darwin-dbg/bin/external/envoy/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:105] thr<123145517580288> #2 0x10787d801: backward::StackTraceImpl<backward::system_tag::darwin_tag>::load_from(void*, unsigned long) + 49
[2018-05-08 22:50:14.045][5016753][critical][backtrace] bazel-out/darwin-dbg/bin/external/envoy/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:105] thr<123145517580288> #3 0x10787bd8e: Envoy::BackwardsTrace::captureFrom(void*) + 46
[2018-05-08 22:50:14.045][5016753][critical][backtrace] bazel-out/darwin-dbg/bin/external/envoy/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:105] thr<123145517580288> #4 0x10787bc4f: Envoy::SignalAction::sigHandler(int, __siginfo*, void*) + 143
[2018-05-08 22:50:14.045][5016753][critical][backtrace] bazel-out/darwin-dbg/bin/external/envoy/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:110] end backtrace thread 123145517580288
```

*Docs Changes*:
N/A

*Release Notes*:
N/A

Fixes: #2268

Signed-off-by: Nicholas J <nicholas.a.johns5@gmail.com>