### PR TITLE
Fix broken entrypoint in front-proxy sample image

### DIFF
--- a/examples/front-proxy/start_service.sh
+++ b/examples/front-proxy/start_service.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 python3 /code/service.py &
 envoy -c /etc/service-envoy.yaml --service-cluster service${SERVICE_NAME}


### PR DESCRIPTION
## Issue description
When trying to execute the sample with docker compose I received an error for service1 and service2:

```
': No such file or directory
': No such file or directoryexecute 'bash

front-proxy_service1_1 exited with code 127
front-proxy_service2_1 exited with code 127
```

## Cause: 
the start_service.sh shell script was referring to bash and the latest alpine image uses sh.
#!/usr/bin/env bash

## Fix:
set shell to:
#!/bin/sh

