### PR TITLE
admin: complete /config_dump

### DIFF
--- a/api/docs/BUILD
+++ b/api/docs/BUILD
@@ -12,6 +12,7 @@ package_group(
 proto_library(
     name = "protos",
     deps = [
+        "//envoy/admin/v2alpha:config_dump",
         "//envoy/api/v2:cds",
         "//envoy/api/v2:discovery",
         "//envoy/api/v2:eds",

--- a/api/envoy/admin/v2alpha/config_dump.proto
+++ b/api/envoy/admin/v2alpha/config_dump.proto
@@ -13,18 +13,15 @@ import "gogoproto/gogo.proto";
 
 // [#protodoc-title: ConfigDump]
 
-// The /config_dump admin endpoint uses this wrapper message to maintain and serve arbitrary
-// configuration information from any component in Envoy.
-// TODO(jsedgwick) In the future, we may want to formalize this further with an RPC for config_dump,
-// and perhaps even with an RPC per config type. That strategy across all endpoints will allow for
-// more flexibility w.r.t. protocol, serialization, parameters, etc.
+// The :ref:`/config_dump <operations_admin_interface_config_dump>` admin endpoint uses this wrapper
+// message to maintain and serve arbitrary configuration information from any component in Envoy.
 message ConfigDump {
-  // This map is serialized and dumped in its entirety at the /config_dump endpoint.
+  // This map is serialized and dumped in its entirety at the
+  // :ref:`/config_dump <operations_admin_interface_config_dump>` endpoint.
   //
   // Keys should be a short descriptor of the config object they map to. For example, Envoy's HTTP
-  // routing subsystem might use "routes" as the key for its config, for which it uses the message
-  // RouteConfigDump as defined below. In the future, the key will also be used to filter the output
-  // of the /config_dump endpoint.
+  // routing subsystem uses "routes" as the key for its config, for which it uses the message
+  // :ref:`RoutesConfigDump <envoy_api_msg_admin.v2alpha.RoutesConfigDump>` as defined below.
   map<string, google.protobuf.Any> configs = 1 [(gogoproto.nullable) = false];
 }
 
@@ -40,15 +37,17 @@ message BootstrapConfigDump {
 // configuration information can be used to recreate an Envoy configuration by populating all
 // listeners as static listeners or by returning them in a LDS response.
 message ListenersConfigDump {
-  // This is the *version_info* in the last processed LDS discovery response. If there
-  // are only static bootstrap listeners, this field will be "".
+  // This is the :ref:`version_info <envoy_api_field_DiscoveryResponse.version_info>` in the
+  // last processed LDS discovery response. If there are only static bootstrap listeners, this field
+  // will be "".
   string version_info = 1;
 
   // Describes a dynamically loaded cluster via the LDS API.
   message DynamicListener {
     // This is the per-resource version information. This version is currently taken from the
-    // *version_info* field at the time that the listener was loaded. In the future, discrete
-    // per-listener versions may be supported by the API.
+    // :ref:`version_info <envoy_api_field_DiscoveryResponse.version_info>` field at the time
+    // that the listener was loaded. In the future, discrete per-listener versions may be supported
+    // by the API.
     string version_info = 1;
 
     // The listener config.
@@ -79,15 +78,17 @@ message ListenersConfigDump {
 // configuration information can be used to recreate an Envoy configuration by populating all
 // clusters as static clusters or by returning them in a CDS response.
 message ClustersConfigDump {
-  // This is the *version_info* in the last processed CDS discovery response. If there
-  // are only static bootstrap clusters, this field will be "".
+  // This is the :ref:`version_info <envoy_api_field_DiscoveryResponse.version_info>` in the
+  // last processed CDS discovery response. If there are only static bootstrap clusters, this field
+  // will be "".
   string version_info = 1;
 
   // Describes a dynamically loaded cluster via the CDS API.
   message DynamicCluster {
     // This is the per-resource version information. This version is currently taken from the
-    // *version_info* field at the time that the cluster was loaded. In the future, discrete
-    // per-cluster versions may be supported by the API.
+    // :ref:`version_info <envoy_api_field_DiscoveryResponse.version_info>` field at the time
+    // that the cluster was loaded. In the future, discrete per-cluster versions may be supported by
+    // the API.
     string version_info = 1;
 
     // The cluster config.
@@ -116,7 +117,8 @@ message ClustersConfigDump {
 message RoutesConfigDump {
   message DynamicRouteConfig {
     // This is the per-resource version information. This version is currently taken from the
-    // *version_info* field at the time that the route configuration was loaded.
+    // :ref:`version_info <envoy_api_field_DiscoveryResponse.version_info>` field at the time that
+    // the route configuration was loaded.
     string version_info = 1;
 
     // The route config.

--- a/api/envoy/config/filter/http/ip_tagging/v2/ip_tagging.proto
+++ b/api/envoy/config/filter/http/ip_tagging/v2/ip_tagging.proto
@@ -9,6 +9,9 @@ import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
 
+// [#protodoc-title: IP tagging]
+// IP tagging :ref:`configuration overview <config_http_filters_ip_tagging>`.
+
 message IPTagging {
 
   // The type of requests the filter should apply to. The supported types

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -49,6 +49,7 @@ bazel --batch build ${BAZEL_BUILD_OPTIONS} @envoy_api//docs:protos --aspects \
 # These are the protos we want to put in docs, this list will grow.
 # TODO(htuch): Factor this out of this script.
 PROTO_RST="
+  /envoy/admin/v2alpha/config_dump/envoy/admin/v2alpha/config_dump.proto.rst
   /envoy/api/v2/core/address/envoy/api/v2/core/address.proto.rst
   /envoy/api/v2/core/base/envoy/api/v2/core/base.proto.rst
   /envoy/api/v2/core/config_source/envoy/api/v2/core/config_source.proto.rst

--- a/docs/root/api-v2/admin/admin.rst
+++ b/docs/root/api-v2/admin/admin.rst
@@ -1,0 +1,8 @@
+Admin
+========
+
+.. toctree::
+  :glob:
+  :maxdepth: 2
+
+  ../admin/v2alpha/config_dump.proto

--- a/docs/root/api-v2/api.rst
+++ b/docs/root/api-v2/api.rst
@@ -14,5 +14,6 @@ v2 API reference
   config/filter/filter
   config/health_checker/health_checker
   config/transport_socket/transport_socket
+  admin/admin
   common_messages/common_messages
   types/types

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -9,7 +9,8 @@ Version history
 * access log: added DYNAMIC_METADATA :ref:`access log formatter <config_access_log_format>`.
 * access log: added :ref:`HeaderFilter <envoy_api_msg_config.filter.accesslog.v2.HeaderFilter>`
   to filter logs based on request headers
-* admin: added :http:get:`/config_dump` for dumping current configs
+* admin: added :http:get:`/config_dump` for dumping the current configuration and associated xDS
+  version information (if applicable).
 * admin: added :http:get:`/stats/prometheus` as an alternative endpoint for getting stats in prometheus format.
 * admin: added :ref:`/runtime_modify endpoint <operations_admin_interface_runtime_modify>` to add or change runtime values
 * admin: mutations must be sent as POSTs, rather than GETs. Mutations include:

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -115,9 +115,8 @@ modify different aspects of the server:
 .. http:get:: /config_dump
 
   Dump currently loaded configuration from various Envoy components as JSON-serialized proto
-  messages. Currently, only route configs are available but more are on the way. See
-  :api:`envoy/admin/v2/config_dump.proto` for more information. That proto is in draft state and is
-  subject to change.
+  messages. See the :ref:`response definition <envoy_api_msg_admin.v2alpha.ConfigDump>` for more
+  information.
 
 .. http:post:: /cpuprofiler
 
@@ -182,9 +181,9 @@ The fields are:
 .. http:get:: /stats
 
   Outputs all statistics on demand. This command is very useful for local debugging.
-  Histograms will output the computed quantiles i.e P0,P25,P50,P75,P90,P99,P99.9 and P100. 
-  The output for each quantile will be in the form of (interval,cumulative) where interval value 
-  represents the summary since last flush interval and cumulative value represents the 
+  Histograms will output the computed quantiles i.e P0,P25,P50,P75,P90,P99,P99.9 and P100.
+  The output for each quantile will be in the form of (interval,cumulative) where interval value
+  represents the summary since last flush interval and cumulative value represents the
   summary since the start of envoy instance.
   See :ref:`here <operations_stats>` for more information.
 

--- a/include/envoy/server/listener_manager.h
+++ b/include/envoy/server/listener_manager.h
@@ -14,11 +14,32 @@ namespace Envoy {
 namespace Server {
 
 /**
+ * Interface for an LDS API provider.
+ */
+class LdsApi {
+public:
+  virtual ~LdsApi() {}
+
+  /**
+   * @return the last received version by the xDS API for LDS.
+   */
+  virtual std::string versionInfo() const PURE;
+};
+
+typedef std::unique_ptr<LdsApi> LdsApiPtr;
+
+/**
  * Factory for creating listener components.
  */
 class ListenerComponentFactory {
 public:
   virtual ~ListenerComponentFactory() {}
+
+  /**
+   * @return an LDS API provider.
+   * @param lds_config supplies the management server configuration.
+   */
+  virtual LdsApiPtr createLdsApi(const envoy::api::v2::core::ConfigSource& lds_config) PURE;
 
   /**
    * Creates a socket.
@@ -78,6 +99,7 @@ public:
    * will be gracefully drained once the new listener is ready to take traffic (e.g. when RDS has
    * been initialized).
    * @param config supplies the configuration proto.
+   * @param version_info supplies the xDS version of the listener.
    * @param modifiable supplies whether the added listener can be updated or removed. If the
    *        listener is not modifiable, future calls to this function or removeListener() on behalf
    *        of this listener will return false.
@@ -85,7 +107,15 @@ public:
    *         a duplicate of the existing listener. This routine will throw an EnvoyException if
    *         there is a fundamental error preventing the listener from being added or updated.
    */
-  virtual bool addOrUpdateListener(const envoy::api::v2::Listener& config, bool modifiable) PURE;
+  virtual bool addOrUpdateListener(const envoy::api::v2::Listener& config,
+                                   const std::string& version_info, bool modifiable) PURE;
+
+  /**
+   * Instruct the listener manager to create an LDS API provider. This is a separate operation
+   * during server initialization because the listener manager is created prior to several core
+   * pieces of the server existing.
+   */
+  virtual void createLdsApi(const envoy::api::v2::core::ConfigSource& lds_config) PURE;
 
   /**
    * @return std::vector<std::reference_wrapper<Network::ListenerConfig>> a list of the currently

--- a/include/envoy/upstream/BUILD
+++ b/include/envoy/upstream/BUILD
@@ -22,6 +22,7 @@ envoy_cc_library(
         "//include/envoy/http:conn_pool_interface",
         "//include/envoy/local_info:local_info_interface",
         "//include/envoy/runtime:runtime_interface",
+        "//include/envoy/server:admin_interface",
         "@envoy_api//envoy/api/v2:cds_cc",
         "@envoy_api//envoy/config/bootstrap/v2:bootstrap_cc",
     ],

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -15,6 +15,7 @@
 #include "envoy/http/conn_pool.h"
 #include "envoy/local_info/local_info.h"
 #include "envoy/runtime/runtime.h"
+#include "envoy/server/admin.h"
 #include "envoy/upstream/load_balancer.h"
 #include "envoy/upstream/thread_local_cluster.h"
 #include "envoy/upstream/upstream.h"
@@ -70,9 +71,12 @@ public:
    *    Nothing is done if the hash matches the previously running configuration.
    * 2) Statically defined clusters (those present when Envoy starts) can not be updated via API.
    *
+   * @param cluster supplies the cluster configuration.
+   * @param version_info supplies the xDS version of the cluster.
    * @return true if the action results in an add/update of a cluster.
    */
-  virtual bool addOrUpdateCluster(const envoy::api::v2::Cluster& cluster) PURE;
+  virtual bool addOrUpdateCluster(const envoy::api::v2::Cluster& cluster,
+                                  const std::string& version_info) PURE;
 
   /**
    * Set a callback that will be invoked when all owned clusters have been initialized.
@@ -228,7 +232,7 @@ public:
   clusterManagerFromProto(const envoy::config::bootstrap::v2::Bootstrap& bootstrap,
                           Stats::Store& stats, ThreadLocal::Instance& tls, Runtime::Loader& runtime,
                           Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info,
-                          AccessLog::AccessLogManager& log_manager) PURE;
+                          AccessLog::AccessLogManager& log_manager, Server::Admin& admin) PURE;
 
   /**
    * Allocate an HTTP connection pool for the host. Pools are separated by 'priority',

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -82,6 +82,7 @@ envoy_cc_library(
         "//source/common/protobuf:utility_lib",
         "//source/common/router:shadow_writer_lib",
         "//source/common/upstream:upstream_lib",
+        "@envoy_api//envoy/admin/v2alpha:config_dump_cc",
         "@envoy_api//envoy/api/v2/core:base_cc",
     ],
 )

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -55,7 +55,7 @@ void CdsApiImpl::onConfigUpdate(const ResourceVector& resources, const std::stri
   for (auto& cluster : resources) {
     const std::string cluster_name = cluster.name();
     clusters_to_remove.erase(cluster_name);
-    if (cm_.addOrUpdateCluster(cluster)) {
+    if (cm_.addOrUpdateCluster(cluster, version_info)) {
       ENVOY_LOG(debug, "cds: add/update cluster '{}'", cluster_name);
     }
   }

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "envoy/admin/v2alpha/config_dump.pb.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/network/dns.h"
 #include "envoy/runtime/runtime.h"
@@ -168,11 +169,14 @@ ClusterManagerImpl::ClusterManagerImpl(const envoy::config::bootstrap::v2::Boots
                                        Runtime::RandomGenerator& random,
                                        const LocalInfo::LocalInfo& local_info,
                                        AccessLog::AccessLogManager& log_manager,
-                                       Event::Dispatcher& main_thread_dispatcher)
+                                       Event::Dispatcher& main_thread_dispatcher,
+                                       Server::Admin& admin)
     : factory_(factory), runtime_(runtime), stats_(stats), tls_(tls.allocateSlot()),
       random_(random), bind_config_(bootstrap.cluster_manager().upstream_bind_config()),
       local_info_(local_info), cm_stats_(generateStats(stats)),
-      init_helper_([this](Cluster& cluster) { onClusterInit(cluster); }) {
+      init_helper_([this](Cluster& cluster) { onClusterInit(cluster); }),
+      config_tracker_entry_(
+          admin.getConfigTracker().add("clusters", [this] { return dumpClusterConfigs(); })) {
   async_client_manager_ = std::make_unique<Grpc::AsyncClientManagerImpl>(*this, tls);
   const auto& cm_config = bootstrap.cluster_manager();
   if (cm_config.has_outlier_detection()) {
@@ -196,7 +200,7 @@ ClusterManagerImpl::ClusterManagerImpl(const envoy::config::bootstrap::v2::Boots
   for (const auto& cluster : bootstrap.static_resources().clusters()) {
     // First load all the primary clusters.
     if (cluster.type() != envoy::api::v2::Cluster::EDS) {
-      loadCluster(cluster, false, active_clusters_);
+      loadCluster(cluster, "", false, active_clusters_);
     }
   }
 
@@ -218,7 +222,7 @@ ClusterManagerImpl::ClusterManagerImpl(const envoy::config::bootstrap::v2::Boots
   for (const auto& cluster : bootstrap.static_resources().clusters()) {
     // Now load all the secondary clusters.
     if (cluster.type() == envoy::api::v2::Cluster::EDS) {
-      loadCluster(cluster, false, active_clusters_);
+      loadCluster(cluster, "", false, active_clusters_);
     }
   }
 
@@ -335,7 +339,8 @@ void ClusterManagerImpl::onClusterInit(Cluster& cluster) {
   }
 }
 
-bool ClusterManagerImpl::addOrUpdateCluster(const envoy::api::v2::Cluster& cluster) {
+bool ClusterManagerImpl::addOrUpdateCluster(const envoy::api::v2::Cluster& cluster,
+                                            const std::string& version_info) {
   // First we need to see if this new config is new or an update to an existing dynamic cluster.
   // We don't allow updates to statically configured clusters in the main configuration. We check
   // both the warming clusters and the active clusters to see if we need an update or the update
@@ -373,7 +378,7 @@ bool ClusterManagerImpl::addOrUpdateCluster(const envoy::api::v2::Cluster& clust
   //       and easy to understand.
   const bool use_active_map =
       init_helper_.state() != ClusterManagerInitHelper::State::AllClustersInitialized;
-  loadCluster(cluster, true, use_active_map ? active_clusters_ : warming_clusters_);
+  loadCluster(cluster, version_info, true, use_active_map ? active_clusters_ : warming_clusters_);
 
   if (use_active_map) {
     ENVOY_LOG(info, "add/update cluster {} during init", cluster_name);
@@ -464,7 +469,8 @@ bool ClusterManagerImpl::removeCluster(const std::string& cluster_name) {
   return removed;
 }
 
-void ClusterManagerImpl::loadCluster(const envoy::api::v2::Cluster& cluster, bool added_via_api,
+void ClusterManagerImpl::loadCluster(const envoy::api::v2::Cluster& cluster,
+                                     const std::string& version_info, bool added_via_api,
                                      ClusterMap& cluster_map) {
   ClusterSharedPtr new_cluster =
       factory_.clusterFromProto(cluster, *this, outlier_event_logger_, added_via_api);
@@ -495,8 +501,8 @@ void ClusterManagerImpl::loadCluster(const envoy::api::v2::Cluster& cluster, boo
     });
   }
 
-  cluster_map[cluster_reference.info()->name()] = std::make_unique<ClusterData>(
-      MessageUtil::hash(cluster), added_via_api, std::move(new_cluster));
+  cluster_map[cluster_reference.info()->name()] =
+      std::make_unique<ClusterData>(cluster, version_info, added_via_api, std::move(new_cluster));
   const auto cluster_entry_it = cluster_map.find(cluster_reference.info()->name());
 
   // If an LB is thread aware, create it here. The LB is not initialized until cluster pre-init
@@ -614,6 +620,30 @@ ClusterUpdateCallbacksHandlePtr
 ClusterManagerImpl::addThreadLocalClusterUpdateCallbacks(ClusterUpdateCallbacks& cb) {
   ThreadLocalClusterManagerImpl& cluster_manager = tls_->getTyped<ThreadLocalClusterManagerImpl>();
   return std::make_unique<ClusterUpdateCallbacksHandleImpl>(cb, cluster_manager.update_callbacks_);
+}
+
+ProtobufTypes::MessagePtr ClusterManagerImpl::dumpClusterConfigs() {
+  auto config_dump = std::make_unique<envoy::admin::v2alpha::ClustersConfigDump>();
+  config_dump->set_version_info(cds_api_ != nullptr ? cds_api_->versionInfo() : "");
+  for (const auto& active_cluster_pair : active_clusters_) {
+    const auto& cluster = *active_cluster_pair.second;
+    if (!cluster.added_via_api_) {
+      config_dump->mutable_static_clusters()->Add()->MergeFrom(cluster.cluster_config_);
+    } else {
+      auto& dynamic_cluster = *config_dump->mutable_dynamic_active_clusters()->Add();
+      dynamic_cluster.set_version_info(cluster.version_info_);
+      dynamic_cluster.mutable_cluster()->MergeFrom(cluster.cluster_config_);
+    }
+  }
+
+  for (const auto& warming_cluster_pair : warming_clusters_) {
+    const auto& cluster = *warming_cluster_pair.second;
+    auto& dynamic_cluster = *config_dump->mutable_dynamic_warming_clusters()->Add();
+    dynamic_cluster.set_version_info(cluster.version_info_);
+    dynamic_cluster.mutable_cluster()->MergeFrom(cluster.cluster_config_);
+  }
+
+  return config_dump;
 }
 
 ClusterManagerImpl::ClusterUpdateCallbacksHandleImpl::ClusterUpdateCallbacksHandleImpl(
@@ -906,10 +936,11 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::connPool(
 ClusterManagerPtr ProdClusterManagerFactory::clusterManagerFromProto(
     const envoy::config::bootstrap::v2::Bootstrap& bootstrap, Stats::Store& stats,
     ThreadLocal::Instance& tls, Runtime::Loader& runtime, Runtime::RandomGenerator& random,
-    const LocalInfo::LocalInfo& local_info, AccessLog::AccessLogManager& log_manager) {
+    const LocalInfo::LocalInfo& local_info, AccessLog::AccessLogManager& log_manager,
+    Server::Admin& admin) {
   return ClusterManagerPtr{new ClusterManagerImpl(bootstrap, *this, stats, tls, runtime, random,
-                                                  local_info, log_manager,
-                                                  main_thread_dispatcher_)};
+                                                  local_info, log_manager, main_thread_dispatcher_,
+                                                  admin)};
 }
 
 Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -22,7 +22,6 @@ envoy_cc_library(
     srcs = ["configuration_impl.cc"],
     hdrs = ["configuration_impl.h"],
     deps = [
-        ":lds_api_lib",
         "//include/envoy/http:filter_interface",
         "//include/envoy/network:connection_interface",
         "//include/envoy/network:filter_interface",
@@ -198,6 +197,7 @@ envoy_cc_library(
         ":configuration_lib",
         ":drain_manager_lib",
         ":init_manager_lib",
+        ":lds_api_lib",
         "//include/envoy/server:filter_config_interface",
         "//include/envoy/server:listener_manager_interface",
         "//include/envoy/server:transport_socket_config_interface",
@@ -212,6 +212,7 @@ envoy_cc_library(
         "//source/common/ssl:context_config_lib",
         "//source/extensions/filters/listener:well_known_names",
         "//source/extensions/transport_sockets:well_known_names",
+        "@envoy_api//envoy/admin/v2alpha:config_dump_cc",
         "@envoy_api//envoy/api/v2:lds_cc",
     ],
 )

--- a/source/server/config_validation/cluster_manager.cc
+++ b/source/server/config_validation/cluster_manager.cc
@@ -14,10 +14,11 @@ ValidationClusterManagerFactory::ValidationClusterManagerFactory(
 ClusterManagerPtr ValidationClusterManagerFactory::clusterManagerFromProto(
     const envoy::config::bootstrap::v2::Bootstrap& bootstrap, Stats::Store& stats,
     ThreadLocal::Instance& tls, Runtime::Loader& runtime, Runtime::RandomGenerator& random,
-    const LocalInfo::LocalInfo& local_info, AccessLog::AccessLogManager& log_manager) {
+    const LocalInfo::LocalInfo& local_info, AccessLog::AccessLogManager& log_manager,
+    Server::Admin& admin) {
   return ClusterManagerPtr{new ValidationClusterManager(bootstrap, *this, stats, tls, runtime,
                                                         random, local_info, log_manager,
-                                                        main_thread_dispatcher_)};
+                                                        main_thread_dispatcher_, admin)};
 }
 
 CdsApiPtr ValidationClusterManagerFactory::createCds(
@@ -33,9 +34,10 @@ ValidationClusterManager::ValidationClusterManager(
     const envoy::config::bootstrap::v2::Bootstrap& bootstrap, ClusterManagerFactory& factory,
     Stats::Store& stats, ThreadLocal::Instance& tls, Runtime::Loader& runtime,
     Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info,
-    AccessLog::AccessLogManager& log_manager, Event::Dispatcher& main_thread_dispatcher)
+    AccessLog::AccessLogManager& log_manager, Event::Dispatcher& main_thread_dispatcher,
+    Server::Admin& admin)
     : ClusterManagerImpl(bootstrap, factory, stats, tls, runtime, random, local_info, log_manager,
-                         main_thread_dispatcher) {}
+                         main_thread_dispatcher, admin) {}
 
 Http::ConnectionPool::Instance*
 ValidationClusterManager::httpConnPoolForCluster(const std::string&, ResourcePriority,

--- a/source/server/config_validation/cluster_manager.h
+++ b/source/server/config_validation/cluster_manager.h
@@ -26,7 +26,7 @@ public:
   clusterManagerFromProto(const envoy::config::bootstrap::v2::Bootstrap& bootstrap,
                           Stats::Store& stats, ThreadLocal::Instance& tls, Runtime::Loader& runtime,
                           Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info,
-                          AccessLog::AccessLogManager& log_manager) override;
+                          AccessLog::AccessLogManager& log_manager, Server::Admin& admin) override;
 
   // Delegates to ProdClusterManagerFactory::createCds, but discards the result and returns nullptr
   // unconditionally.
@@ -44,7 +44,8 @@ public:
                            ClusterManagerFactory& factory, Stats::Store& stats,
                            ThreadLocal::Instance& tls, Runtime::Loader& runtime,
                            Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info,
-                           AccessLog::AccessLogManager& log_manager, Event::Dispatcher& dispatcher);
+                           AccessLog::AccessLogManager& log_manager, Event::Dispatcher& dispatcher,
+                           Server::Admin& admin);
 
   Http::ConnectionPool::Instance* httpConnPoolForCluster(const std::string&, ResourcePriority,
                                                          Http::Protocol,

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -90,6 +90,10 @@ public:
   const LocalInfo::LocalInfo& localInfo() override { return *local_info_; }
 
   // Server::ListenerComponentFactory
+  LdsApiPtr createLdsApi(const envoy::api::v2::core::ConfigSource& lds_config) override {
+    return std::make_unique<LdsApiImpl>(lds_config, clusterManager(), dispatcher(), random(),
+                                        initManager(), localInfo(), stats(), listenerManager());
+  }
   std::vector<Network::FilterFactoryCb> createNetworkFilterFactoryList(
       const Protobuf::RepeatedPtrField<envoy::api::v2::listener::Filter>& filters,
       Configuration::FactoryContext& context) override {

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -48,18 +48,12 @@ void MainImpl::initialize(const envoy::config::bootstrap::v2::Bootstrap& bootstr
                           Upstream::ClusterManagerFactory& cluster_manager_factory) {
   cluster_manager_ = cluster_manager_factory.clusterManagerFromProto(
       bootstrap, server.stats(), server.threadLocal(), server.runtime(), server.random(),
-      server.localInfo(), server.accessLogManager());
+      server.localInfo(), server.accessLogManager(), server.admin());
   const auto& listeners = bootstrap.static_resources().listeners();
   ENVOY_LOG(info, "loading {} listener(s)", listeners.size());
   for (ssize_t i = 0; i < listeners.size(); i++) {
     ENVOY_LOG(debug, "listener #{}:", i);
-    server.listenerManager().addOrUpdateListener(listeners[i], false);
-  }
-
-  if (bootstrap.dynamic_resources().has_lds_config()) {
-    lds_api_.reset(new LdsApi(bootstrap.dynamic_resources().lds_config(), *cluster_manager_,
-                              server.dispatcher(), server.random(), server.initManager(),
-                              server.localInfo(), server.stats(), server.listenerManager()));
+    server.listenerManager().addOrUpdateListener(listeners[i], "", false);
   }
 
   stats_flush_interval_ =

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -23,8 +23,6 @@
 #include "common/network/resolver_impl.h"
 #include "common/network/utility.h"
 
-#include "server/lds_api.h"
-
 namespace Envoy {
 namespace Server {
 namespace Configuration {
@@ -147,7 +145,6 @@ private:
                             Instance& server);
 
   std::unique_ptr<Upstream::ClusterManager> cluster_manager_;
-  std::unique_ptr<LdsApi> lds_api_;
   Tracing::HttpTracerPtr http_tracer_;
   std::list<Stats::SinkPtr> stats_sinks_;
   RateLimit::ClientFactoryPtr ratelimit_client_factory_;

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -278,7 +278,7 @@ Http::Code AdminImpl::handlerClusters(absl::string_view, Http::HeaderMap&,
 }
 
 // TODO(jsedgwick) Use query params to list available dumps, selectively dump, etc
-Http::Code AdminImpl::handlerConfigDump(absl::string_view, Http::HeaderMap&,
+Http::Code AdminImpl::handlerConfigDump(absl::string_view, Http::HeaderMap& response_headers,
                                         Buffer::Instance& response) const {
   envoy::admin::v2alpha::ConfigDump dump;
   auto& config_dump_map = *(dump.mutable_configs());
@@ -290,6 +290,8 @@ Http::Code AdminImpl::handlerConfigDump(absl::string_view, Http::HeaderMap&,
     config_dump_map[key_callback_pair.first] = any_message;
   }
 
+  response_headers.insertContentType().value().setReference(
+      Http::Headers::get().ContentTypeValues.Json);
   response.add(MessageUtil::getJsonStringFromMessage(dump, true)); // pretty-print
   return Http::Code::OK;
 }

--- a/source/server/lds_api.h
+++ b/source/server/lds_api.h
@@ -15,16 +15,18 @@ namespace Server {
 /**
  * LDS API implementation that fetches via Subscription.
  */
-class LdsApi : public Init::Target,
-               Config::SubscriptionCallbacks<envoy::api::v2::Listener>,
-               Logger::Loggable<Logger::Id::upstream> {
+class LdsApiImpl : public LdsApi,
+                   public Init::Target,
+                   Config::SubscriptionCallbacks<envoy::api::v2::Listener>,
+                   Logger::Loggable<Logger::Id::upstream> {
 public:
-  LdsApi(const envoy::api::v2::core::ConfigSource& lds_config, Upstream::ClusterManager& cm,
-         Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
-         Init::Manager& init_manager, const LocalInfo::LocalInfo& local_info, Stats::Scope& scope,
-         ListenerManager& lm);
+  LdsApiImpl(const envoy::api::v2::core::ConfigSource& lds_config, Upstream::ClusterManager& cm,
+             Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
+             Init::Manager& init_manager, const LocalInfo::LocalInfo& local_info,
+             Stats::Scope& scope, ListenerManager& lm);
 
-  const std::string versionInfo() const { return version_info_; }
+  // Server::LdsApi
+  std::string versionInfo() const override { return version_info_; }
 
   // Init::Target
   void initialize(std::function<void()> callback) override;

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -1,5 +1,6 @@
 #include "server/listener_manager_impl.h"
 
+#include "envoy/admin/v2alpha/config_dump.pb.h"
 #include "envoy/registry/registry.h"
 #include "envoy/server/transport_socket_config.h"
 
@@ -109,9 +110,9 @@ ProdListenerComponentFactory::createDrainManager(envoy::api::v2::Listener::Drain
   return DrainManagerPtr{new DrainManagerImpl(server_, drain_type)};
 }
 
-ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, ListenerManagerImpl& parent,
-                           const std::string& name, bool modifiable, bool workers_started,
-                           uint64_t hash)
+ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::string& version_info,
+                           ListenerManagerImpl& parent, const std::string& name, bool modifiable,
+                           bool workers_started, uint64_t hash)
     : parent_(parent), address_(Network::Address::resolveProtoAddress(config.address())),
       global_scope_(parent_.server_.stats().createScope("")),
       listener_scope_(
@@ -124,8 +125,7 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, ListenerManag
       listener_tag_(parent_.factory_.nextListenerTag()), name_(name), modifiable_(modifiable),
       workers_started_(workers_started), hash_(hash),
       local_drain_manager_(parent.factory_.createDrainManager(config.drain_type())),
-      metadata_(config.has_metadata() ? config.metadata()
-                                      : envoy::api::v2::core::Metadata::default_instance()) {
+      config_(config), version_info_(version_info) {
   // TODO(htuch): Support multiple filter chains #1280, add constraint to ensure we have at least on
   // filter chain #1308.
   ASSERT(config.filter_chains().size() >= 1);
@@ -313,10 +313,40 @@ void ListenerImpl::setSocket(const Network::SocketSharedPtr& socket) {
 ListenerManagerImpl::ListenerManagerImpl(Instance& server,
                                          ListenerComponentFactory& listener_factory,
                                          WorkerFactory& worker_factory)
-    : server_(server), factory_(listener_factory), stats_(generateStats(server.stats())) {
+    : server_(server), factory_(listener_factory), stats_(generateStats(server.stats())),
+      config_tracker_entry_(server.admin().getConfigTracker().add(
+          "listeners", [this] { return dumpListenerConfigs(); })) {
   for (uint32_t i = 0; i < std::max(1U, server.options().concurrency()); i++) {
     workers_.emplace_back(worker_factory.createWorker());
   }
+}
+
+ProtobufTypes::MessagePtr ListenerManagerImpl::dumpListenerConfigs() {
+  auto config_dump = std::make_unique<envoy::admin::v2alpha::ListenersConfigDump>();
+  config_dump->set_version_info(lds_api_ != nullptr ? lds_api_->versionInfo() : "");
+  for (const auto& listener : active_listeners_) {
+    if (listener->blockRemove()) {
+      config_dump->mutable_static_listeners()->Add()->MergeFrom(listener->config());
+    } else {
+      auto& dynamic_listener = *config_dump->mutable_dynamic_active_listeners()->Add();
+      dynamic_listener.set_version_info(listener->versionInfo());
+      dynamic_listener.mutable_listener()->MergeFrom(listener->config());
+    }
+  }
+
+  for (const auto& listener : warming_listeners_) {
+    auto& dynamic_listener = *config_dump->mutable_dynamic_warming_listeners()->Add();
+    dynamic_listener.set_version_info(listener->versionInfo());
+    dynamic_listener.mutable_listener()->MergeFrom(listener->config());
+  }
+
+  for (const auto& listener : draining_listeners_) {
+    auto& dynamic_listener = *config_dump->mutable_dynamic_draining_listeners()->Add();
+    dynamic_listener.set_version_info(listener.listener_->versionInfo());
+    dynamic_listener.mutable_listener()->MergeFrom(listener.listener_->config());
+  }
+
+  return config_dump;
 }
 
 ListenerManagerStats ListenerManagerImpl::generateStats(Stats::Scope& scope) {
@@ -326,7 +356,7 @@ ListenerManagerStats ListenerManagerImpl::generateStats(Stats::Scope& scope) {
 }
 
 bool ListenerManagerImpl::addOrUpdateListener(const envoy::api::v2::Listener& config,
-                                              bool modifiable) {
+                                              const std::string& version_info, bool modifiable) {
   std::string name;
   if (!config.name().empty()) {
     name = config.name();
@@ -350,7 +380,7 @@ bool ListenerManagerImpl::addOrUpdateListener(const envoy::api::v2::Listener& co
   }
 
   ListenerImplPtr new_listener(
-      new ListenerImpl(config, *this, name, modifiable, workers_started_, hash));
+      new ListenerImpl(config, version_info, *this, name, modifiable, workers_started_, hash));
   ListenerImpl& new_listener_ref = *new_listener;
 
   // We mandate that a listener with the same name must have the same configured address. This

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -170,6 +170,7 @@ public:
   const LocalInfo::LocalInfo& localInfo() override { return *local_info_; }
 
 private:
+  ProtobufTypes::MessagePtr dumpBootstrapConfig();
   void flushStats();
   void initialize(Options& options, Network::Address::InstanceConstSharedPtr local_address,
                   ComponentFactory& component_factory);
@@ -207,6 +208,8 @@ private:
   std::unique_ptr<Server::GuardDog> guard_dog_;
   bool terminated_;
   std::unique_ptr<Logger::FileSinkDelegate> file_logger_;
+  envoy::config::bootstrap::v2::Bootstrap bootstrap_;
+  ConfigTracker::EntryOwnerPtr config_tracker_entry_;
 };
 
 } // namespace Server

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -46,6 +46,7 @@ envoy_cc_test(
         "//test/mocks/local_info:local_info_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/server:server_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:threadsafe_singleton_injector_lib",

--- a/test/extensions/filters/network/http_connection_manager/BUILD
+++ b/test/extensions/filters/network/http_connection_manager/BUILD
@@ -19,7 +19,6 @@ envoy_extension_cc_test(
         "//source/common/buffer:buffer_lib",
         "//source/common/config:filter_json_lib",
         "//source/common/event:dispatcher_lib",
-        "//source/common/router:rds_lib",
         "//source/extensions/filters/http/dynamo:config",
         "//source/extensions/filters/network/http_connection_manager:config",
         "//test/mocks/network:network_mocks",

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -1,7 +1,6 @@
 #include "common/buffer/buffer_impl.h"
 #include "common/config/filter_json.h"
 #include "common/http/date_provider_impl.h"
-#include "common/router/rds_impl.h"
 
 #include "extensions/filters/network/http_connection_manager/config.h"
 
@@ -34,7 +33,7 @@ class HttpConnectionManagerConfigTest : public testing::Test {
 public:
   NiceMock<Server::Configuration::MockFactoryContext> context_;
   Http::SlowDateProviderImpl date_provider_;
-  Router::RouteConfigProviderManagerImpl route_config_provider_manager_{context_.admin()};
+  NiceMock<Router::MockRouteConfigProviderManager> route_config_provider_manager_;
 };
 
 TEST_F(HttpConnectionManagerConfigTest, ValidateFail) {

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -80,7 +80,7 @@ TEST_P(EchoIntegrationTest, AddRemoveListener) {
       [&listener_added_by_worker]() -> void { listener_added_by_worker.setReady(); });
   test_server_->server().dispatcher().post([this, json, &listener_added_by_manager]() -> void {
     EXPECT_TRUE(test_server_->server().listenerManager().addOrUpdateListener(
-        Server::parseListenerFromJson(json), true));
+        Server::parseListenerFromJson(json), "", true));
     listener_added_by_manager.setReady();
   });
   listener_added_by_worker.waitReady();

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -263,6 +263,16 @@ TEST_P(IntegrationAdminTest, Admin) {
     EXPECT_EQ(listener_it->get().socket().localAddress()->asString(),
               (*listener_info_it)->asString());
   }
+
+  response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/config_dump", "",
+                                                downstreamProtocol(), version_);
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_STREQ("application/json", ContentType(response));
+  json = Json::Factory::loadFromString(response->body());
+  EXPECT_TRUE(json->getObject("configs")->hasObject("bootstrap"));
+  EXPECT_TRUE(json->getObject("configs")->hasObject("clusters"));
+  EXPECT_TRUE(json->getObject("configs")->hasObject("listeners"));
 }
 
 // Successful call to startProfiler requires tcmalloc.

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -303,7 +303,6 @@ public:
   MockRouteConfigProviderManager();
   ~MockRouteConfigProviderManager();
 
-  MOCK_METHOD0(routeConfigProviders, std::vector<RouteConfigProviderSharedPtr>());
   MOCK_METHOD3(getRdsRouteConfigProvider,
                RouteConfigProviderSharedPtr(
                    const envoy::config::filter::network::http_connection_manager::v2::Rds& rds,
@@ -313,8 +312,8 @@ public:
       getStaticRouteConfigProvider,
       RouteConfigProviderSharedPtr(const envoy::api::v2::RouteConfiguration& route_config,
                                    Server::Configuration::FactoryContext& factory_context));
-
-  MOCK_METHOD1(removeRouteConfigProvider, void(const std::string& identifier));
+  MOCK_METHOD0(getRdsRouteConfigProviders, std::vector<RouteConfigProviderSharedPtr>());
+  MOCK_METHOD0(getStaticRouteConfigProviders, std::vector<RouteConfigProviderSharedPtr>());
 };
 
 } // namespace Router

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -33,10 +33,18 @@ MockOptions::MockOptions(const std::string& config_path) : config_path_(config_p
 }
 MockOptions::~MockOptions() {}
 
+MockConfigTracker::MockConfigTracker() {
+  ON_CALL(*this, add_(_, _))
+      .WillByDefault(Invoke([this](const std::string& key, Cb callback) -> EntryOwner* {
+        EXPECT_TRUE(config_tracker_callbacks_.find(key) == config_tracker_callbacks_.end());
+        config_tracker_callbacks_[key] = callback;
+        return new MockEntryOwner();
+      }));
+}
+MockConfigTracker::~MockConfigTracker() {}
+
 MockAdmin::MockAdmin() {
-  ON_CALL(*this, getConfigTracker()).WillByDefault(testing::ReturnRef(config_tracker));
-  ON_CALL(config_tracker, addReturnsRaw(_, _))
-      .WillByDefault(ReturnNew<Server::MockConfigTracker::MockEntryOwner>());
+  ON_CALL(*this, getConfigTracker()).WillByDefault(testing::ReturnRef(config_tracker_));
 }
 MockAdmin::~MockAdmin() {}
 

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -146,7 +146,8 @@ public:
   }
 
   // Upstream::ClusterManager
-  MOCK_METHOD1(addOrUpdateCluster, bool(const envoy::api::v2::Cluster& cluster));
+  MOCK_METHOD2(addOrUpdateCluster,
+               bool(const envoy::api::v2::Cluster& cluster, const std::string& version_info));
   MOCK_METHOD1(setInitializedCb, void(std::function<void()>));
   MOCK_METHOD0(clusters, ClusterInfoMap());
   MOCK_METHOD1(get, ThreadLocalCluster*(const std::string& cluster));

--- a/test/server/config_validation/BUILD
+++ b/test/server/config_validation/BUILD
@@ -31,6 +31,7 @@ envoy_cc_test(
         "//test/mocks/local_info:local_info_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/server:server_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:utility_lib",

--- a/test/server/config_validation/cluster_manager_test.cc
+++ b/test/server/config_validation/cluster_manager_test.cc
@@ -12,6 +12,7 @@
 #include "test/mocks/local_info/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
+#include "test/mocks/server/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/mocks.h"
 #include "test/test_common/utility.h"
@@ -28,6 +29,7 @@ TEST(ValidationClusterManagerTest, MockedMethods) {
   Ssl::ContextManagerImpl ssl_context_manager{runtime};
   NiceMock<Event::MockDispatcher> dispatcher;
   LocalInfo::MockLocalInfo local_info;
+  NiceMock<Server::MockAdmin> admin;
 
   ValidationClusterManagerFactory factory(runtime, stats, tls, random, dns_resolver,
                                           ssl_context_manager, dispatcher, local_info);
@@ -35,7 +37,7 @@ TEST(ValidationClusterManagerTest, MockedMethods) {
   AccessLog::MockAccessLogManager log_manager;
   const envoy::config::bootstrap::v2::Bootstrap bootstrap;
   ClusterManagerPtr cluster_manager = factory.clusterManagerFromProto(
-      bootstrap, stats, tls, runtime, random, local_info, log_manager);
+      bootstrap, stats, tls, runtime, random, local_info, log_manager, admin);
   EXPECT_EQ(nullptr, cluster_manager->httpConnPoolForCluster("cluster", ResourcePriority::Default,
                                                              Http::Protocol::Http11, nullptr));
   Host::CreateConnectionData data = cluster_manager->tcpConnForCluster("cluster", nullptr);

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -1,3 +1,4 @@
+#include "envoy/admin/v2alpha/config_dump.pb.h"
 #include "envoy/registry/registry.h"
 #include "envoy/server/filter_config.h"
 
@@ -95,6 +96,16 @@ public:
               server_.stats_store_.gauge("listener_manager.total_listeners_draining").value());
   }
 
+  void checkConfigDump(const std::string& expected_dump_yaml) {
+    auto message_ptr = server_.admin_.config_tracker_.config_tracker_callbacks_["listeners"]();
+    const auto& listeners_config_dump =
+        dynamic_cast<const envoy::admin::v2alpha::ListenersConfigDump&>(*message_ptr);
+
+    envoy::admin::v2alpha::ListenersConfigDump expected_listeners_config_dump;
+    MessageUtil::loadFromYaml(expected_dump_yaml, expected_listeners_config_dump);
+    EXPECT_EQ(expected_listeners_config_dump.DebugString(), listeners_config_dump.DebugString());
+  }
+
   NiceMock<MockInstance> server_;
   NiceMock<MockListenerComponentFactory> listener_factory_;
   MockWorker* worker_ = new MockWorker();
@@ -125,6 +136,11 @@ public:
   }
 };
 
+class MockLdsApi : public LdsApi {
+public:
+  MOCK_CONST_METHOD0(versionInfo, std::string());
+};
+
 TEST_F(ListenerManagerImplWithRealFiltersTest, EmptyFilter) {
   const std::string json = R"EOF(
   {
@@ -135,7 +151,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, EmptyFilter) {
 
   EXPECT_CALL(server_.random_, uuid());
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  manager_->addOrUpdateListener(parseListenerFromJson(json), true);
+  manager_->addOrUpdateListener(parseListenerFromJson(json), "", true);
   EXPECT_EQ(1U, manager_->listeners().size());
 }
 
@@ -148,7 +164,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, DefaultListenerPerConnectionBuffe
   )EOF";
 
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  manager_->addOrUpdateListener(parseListenerFromJson(json), true);
+  manager_->addOrUpdateListener(parseListenerFromJson(json), "", true);
   EXPECT_EQ(1024 * 1024U, manager_->listeners().back().get().perConnectionBufferLimitBytes());
 }
 
@@ -162,7 +178,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, SetListenerPerConnectionBufferLim
   )EOF";
 
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  manager_->addOrUpdateListener(parseListenerFromJson(json), true);
+  manager_->addOrUpdateListener(parseListenerFromJson(json), "", true);
   EXPECT_EQ(8192U, manager_->listeners().back().get().perConnectionBufferLimitBytes());
 }
 
@@ -184,7 +200,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, SslContext) {
                                                        Network::Address::IpVersion::v4);
 
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  manager_->addOrUpdateListener(parseListenerFromJson(json), true);
+  manager_->addOrUpdateListener(parseListenerFromJson(json), "", true);
   EXPECT_TRUE(
       manager_->listeners().back().get().transportSocketFactory().implementsSecureTransport());
 }
@@ -198,7 +214,8 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, BadListenerConfig) {
   }
   )EOF";
 
-  EXPECT_THROW(manager_->addOrUpdateListener(parseListenerFromJson(json), true), Json::Exception);
+  EXPECT_THROW(manager_->addOrUpdateListener(parseListenerFromJson(json), "", true),
+               Json::Exception);
 }
 
 TEST_F(ListenerManagerImplWithRealFiltersTest, BadFilterConfig) {
@@ -215,7 +232,8 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, BadFilterConfig) {
   }
   )EOF";
 
-  EXPECT_THROW(manager_->addOrUpdateListener(parseListenerFromJson(json), true), Json::Exception);
+  EXPECT_THROW(manager_->addOrUpdateListener(parseListenerFromJson(json), "", true),
+               Json::Exception);
 }
 
 TEST_F(ListenerManagerImplWithRealFiltersTest, BadFilterName) {
@@ -232,7 +250,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, BadFilterName) {
   }
   )EOF";
 
-  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromJson(json), true),
+  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromJson(json), "", true),
                             EnvoyException,
                             "Didn't find a registered implementation for name: 'invalid'");
 }
@@ -267,7 +285,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, StatsScopeTest) {
   )EOF";
 
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, false));
-  manager_->addOrUpdateListener(parseListenerFromJson(json), true);
+  manager_->addOrUpdateListener(parseListenerFromJson(json), "", true);
   manager_->listeners().front().get().listenerScope().counter("foo").inc();
 
   EXPECT_EQ(1UL, server_.stats_store_.counter("bar").value());
@@ -290,7 +308,7 @@ TEST_F(ListenerManagerImplTest, ModifyOnlyDrainType) {
   ListenerHandle* listener_foo =
       expectListenerCreate(false, envoy::api::v2::Listener_DrainType_MODIFY_ONLY);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(listener_foo_yaml), true));
+  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(listener_foo_yaml), "", true));
   checkStats(1, 0, 0, 0, 1, 0);
 
   EXPECT_CALL(*listener_foo, onDestroy());
@@ -311,7 +329,7 @@ TEST_F(ListenerManagerImplTest, AddListenerAddressNotMatching) {
 
   ListenerHandle* listener_foo = expectListenerCreate(false);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), true));
+  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), "", true));
   checkStats(1, 0, 0, 0, 1, 0);
 
   // Update foo listener, but with a different address. Should throw.
@@ -327,11 +345,12 @@ TEST_F(ListenerManagerImplTest, AddListenerAddressNotMatching) {
   ListenerHandle* listener_foo_different_address =
       expectListenerCreate(false, envoy::api::v2::Listener_DrainType_MODIFY_ONLY);
   EXPECT_CALL(*listener_foo_different_address, onDestroy());
-  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(
-                                parseListenerFromJson(listener_foo_different_address_json), true),
-                            EnvoyException,
-                            "error updating listener: 'foo' has a different address "
-                            "'127.0.0.1:1235' from existing listener");
+  EXPECT_THROW_WITH_MESSAGE(
+      manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_different_address_json), "",
+                                    true),
+      EnvoyException,
+      "error updating listener: 'foo' has a different address "
+      "'127.0.0.1:1235' from existing listener");
 
   EXPECT_CALL(*listener_foo, onDestroy());
 }
@@ -351,8 +370,20 @@ TEST_F(ListenerManagerImplTest, UpdateRemoveNotModifiableListener) {
 
   ListenerHandle* listener_foo = expectListenerCreate(false);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), false));
+  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), "", false));
   checkStats(1, 0, 0, 0, 1, 0);
+  checkConfigDump(R"EOF(
+static_listeners:
+  name: "foo"
+  address:
+    socket_address:
+      address: "127.0.0.1"
+      port_value: 1234
+  filter_chains: {}
+dynamic_active_listeners:
+dynamic_warming_listeners:
+dynamic_draining_listeners:
+)EOF");
 
   // Update foo listener. Should be blocked.
   const std::string listener_foo_update1_json = R"EOF(
@@ -366,7 +397,7 @@ TEST_F(ListenerManagerImplTest, UpdateRemoveNotModifiableListener) {
   )EOF";
 
   EXPECT_FALSE(
-      manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_update1_json), false));
+      manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_update1_json), "", false));
   checkStats(1, 0, 0, 0, 1, 0);
 
   // Remove foo listener. Should be blocked.
@@ -379,40 +410,88 @@ TEST_F(ListenerManagerImplTest, UpdateRemoveNotModifiableListener) {
 TEST_F(ListenerManagerImplTest, AddOrUpdateListener) {
   InSequence s;
 
+  MockLdsApi* lds_api = new MockLdsApi();
+  EXPECT_CALL(listener_factory_, createLdsApi_(_)).WillOnce(Return(lds_api));
+  envoy::api::v2::core::ConfigSource lds_config;
+  manager_->createLdsApi(lds_config);
+
+  EXPECT_CALL(*lds_api, versionInfo()).WillOnce(Return(""));
+  checkConfigDump(R"EOF(
+static_listeners:
+dynamic_active_listeners:
+dynamic_warming_listeners:
+dynamic_draining_listeners:
+)EOF");
+
   // Add foo listener.
-  const std::string listener_foo_json = R"EOF(
-  {
-    "name": "foo",
-    "address": "tcp://127.0.0.1:1234",
-    "filters": []
-  }
+  const std::string listener_foo_yaml = R"EOF(
+name: "foo"
+address:
+  socket_address:
+    address: "127.0.0.1"
+    port_value: 1234
+filter_chains: {}
   )EOF";
 
   ListenerHandle* listener_foo = expectListenerCreate(false);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), true));
+  EXPECT_TRUE(
+      manager_->addOrUpdateListener(parseListenerFromV2Yaml(listener_foo_yaml), "version1", true));
   checkStats(1, 0, 0, 0, 1, 0);
+  EXPECT_CALL(*lds_api, versionInfo()).WillOnce(Return("version1"));
+  checkConfigDump(R"EOF(
+version_info: version1
+static_listeners:
+dynamic_active_listeners:
+  version_info: "version1"
+  listener:
+    name: "foo"
+    address:
+      socket_address:
+        address: "127.0.0.1"
+        port_value: 1234
+    filter_chains: {}
+dynamic_warming_listeners:
+dynamic_draining_listeners:
+)EOF");
 
   // Update duplicate should be a NOP.
-  EXPECT_FALSE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), true));
+  EXPECT_FALSE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(listener_foo_yaml), "", true));
   checkStats(1, 0, 0, 0, 1, 0);
 
   // Update foo listener. Should share socket.
-  const std::string listener_foo_update1_json = R"EOF(
-  {
-    "name": "foo",
-    "address": "tcp://127.0.0.1:1234",
-    "filters": [
-      { "type" : "read", "name" : "fake", "config" : {} }
-    ]
-  }
+  const std::string listener_foo_update1_yaml = R"EOF(
+name: "foo"
+address:
+  socket_address:
+    address: "127.0.0.1"
+    port_value: 1234
+filter_chains: {}
+per_connection_buffer_limit_bytes: 10
   )EOF";
 
   ListenerHandle* listener_foo_update1 = expectListenerCreate(false);
   EXPECT_CALL(*listener_foo, onDestroy());
-  EXPECT_TRUE(
-      manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_update1_json), true));
+  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(listener_foo_update1_yaml),
+                                            "version2", true));
   checkStats(1, 1, 0, 0, 1, 0);
+  EXPECT_CALL(*lds_api, versionInfo()).WillOnce(Return("version2"));
+  checkConfigDump(R"EOF(
+version_info: version2
+static_listeners:
+dynamic_active_listeners:
+  version_info: "version2"
+  listener:
+    name: "foo"
+    address:
+      socket_address:
+        address: "127.0.0.1"
+        port_value: 1234
+    filter_chains: {}
+    per_connection_buffer_limit_bytes: 10
+dynamic_warming_listeners:
+dynamic_draining_listeners:
+)EOF");
 
   // Start workers.
   EXPECT_CALL(*worker_, addListener(_, _));
@@ -422,7 +501,7 @@ TEST_F(ListenerManagerImplTest, AddOrUpdateListener) {
 
   // Update duplicate should be a NOP.
   EXPECT_FALSE(
-      manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_update1_json), true));
+      manager_->addOrUpdateListener(parseListenerFromV2Yaml(listener_foo_update1_yaml), "", true));
   checkStats(1, 1, 0, 0, 1, 0);
 
   // Update foo. Should go into warming, have an immediate warming callback, and start immediate
@@ -431,9 +510,35 @@ TEST_F(ListenerManagerImplTest, AddOrUpdateListener) {
   EXPECT_CALL(*worker_, addListener(_, _));
   EXPECT_CALL(*worker_, stopListener(_));
   EXPECT_CALL(*listener_foo_update1->drain_manager_, startDrainSequence(_));
-  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), true));
+  EXPECT_TRUE(
+      manager_->addOrUpdateListener(parseListenerFromV2Yaml(listener_foo_yaml), "version3", true));
   worker_->callAddCompletion(true);
   checkStats(1, 2, 0, 0, 1, 1);
+  EXPECT_CALL(*lds_api, versionInfo()).WillOnce(Return("version3"));
+  checkConfigDump(R"EOF(
+version_info: version3
+static_listeners:
+dynamic_active_listeners:
+  version_info: "version3"
+  listener:
+    name: "foo"
+    address:
+      socket_address:
+        address: "127.0.0.1"
+        port_value: 1234
+    filter_chains: {}
+dynamic_warming_listeners:
+dynamic_draining_listeners:
+  version_info: "version2"
+  listener:
+    name: "foo"
+    address:
+      socket_address:
+        address: "127.0.0.1"
+        port_value: 1234
+    filter_chains: {}
+    per_connection_buffer_limit_bytes: 10
+)EOF");
 
   EXPECT_CALL(*worker_, removeListener(_, _));
   listener_foo_update1->drain_manager_->drain_sequence_completion_();
@@ -443,40 +548,76 @@ TEST_F(ListenerManagerImplTest, AddOrUpdateListener) {
   checkStats(1, 2, 0, 0, 1, 0);
 
   // Add bar listener.
-  const std::string listener_bar_json = R"EOF(
-  {
-    "name": "bar",
-    "address": "tcp://127.0.0.1:1235",
-    "filters": []
-  }
+  const std::string listener_bar_yaml = R"EOF(
+name: "bar"
+address:
+  socket_address:
+    address: "127.0.0.1"
+    port_value: 1235
+filter_chains: {}
   )EOF";
 
   ListenerHandle* listener_bar = expectListenerCreate(false);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
   EXPECT_CALL(*worker_, addListener(_, _));
-  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_bar_json), true));
+  EXPECT_TRUE(
+      manager_->addOrUpdateListener(parseListenerFromV2Yaml(listener_bar_yaml), "version4", true));
   EXPECT_EQ(2UL, manager_->listeners().size());
   worker_->callAddCompletion(true);
   checkStats(2, 2, 0, 0, 2, 0);
 
   // Add baz listener, this time requiring initializing.
-  const std::string listener_baz_json = R"EOF(
-  {
-    "name": "baz",
-    "address": "tcp://127.0.0.1:1236",
-    "filters": []
-  }
+  const std::string listener_baz_yaml = R"EOF(
+name: "baz"
+address:
+  socket_address:
+    address: "127.0.0.1"
+    port_value: 1236
+filter_chains: {}
   )EOF";
 
   ListenerHandle* listener_baz = expectListenerCreate(true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
   EXPECT_CALL(listener_baz->target_, initialize(_));
-  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_baz_json), true));
+  EXPECT_TRUE(
+      manager_->addOrUpdateListener(parseListenerFromV2Yaml(listener_baz_yaml), "version5", true));
   EXPECT_EQ(2UL, manager_->listeners().size());
   checkStats(3, 2, 0, 1, 2, 0);
+  EXPECT_CALL(*lds_api, versionInfo()).WillOnce(Return("version5"));
+  checkConfigDump(R"EOF(
+version_info: version5
+static_listeners:
+dynamic_active_listeners:
+  - version_info: "version3"
+    listener:
+      name: "foo"
+      address:
+        socket_address:
+          address: "127.0.0.1"
+          port_value: 1234
+      filter_chains: {}
+  - version_info: "version4"
+    listener:
+      name: "bar"
+      address:
+        socket_address:
+          address: "127.0.0.1"
+          port_value: 1235
+      filter_chains: {}
+dynamic_warming_listeners:
+  - version_info: "version5"
+    listener:
+      name: "baz"
+      address:
+        socket_address:
+          address: "127.0.0.1"
+          port_value: 1236
+      filter_chains: {}
+dynamic_draining_listeners:
+)EOF");
 
   // Update a duplicate baz that is currently warming.
-  EXPECT_FALSE(manager_->addOrUpdateListener(parseListenerFromJson(listener_baz_json), true));
+  EXPECT_FALSE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(listener_baz_yaml), "", true));
   checkStats(3, 2, 0, 1, 2, 0);
 
   // Update baz while it is warming.
@@ -497,7 +638,7 @@ TEST_F(ListenerManagerImplTest, AddOrUpdateListener) {
   }));
   EXPECT_CALL(listener_baz_update1->target_, initialize(_));
   EXPECT_TRUE(
-      manager_->addOrUpdateListener(parseListenerFromJson(listener_baz_update1_json), true));
+      manager_->addOrUpdateListener(parseListenerFromJson(listener_baz_update1_json), "", true));
   EXPECT_EQ(2UL, manager_->listeners().size());
   checkStats(3, 3, 0, 1, 2, 0);
 
@@ -535,7 +676,7 @@ TEST_F(ListenerManagerImplTest, AddDrainingListener) {
   ListenerHandle* listener_foo = expectListenerCreate(false);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
   EXPECT_CALL(*worker_, addListener(_, _));
-  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), true));
+  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), "", true));
   worker_->callAddCompletion(true);
   checkStats(1, 0, 0, 0, 1, 0);
 
@@ -551,7 +692,7 @@ TEST_F(ListenerManagerImplTest, AddDrainingListener) {
   // Add foo again. We should use the socket from draining.
   ListenerHandle* listener_foo2 = expectListenerCreate(false);
   EXPECT_CALL(*worker_, addListener(_, _));
-  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), true));
+  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), "", true));
   worker_->callAddCompletion(true);
   checkStats(2, 0, 1, 0, 1, 1);
 
@@ -580,7 +721,7 @@ TEST_F(ListenerManagerImplTest, CantBindSocket) {
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true))
       .WillOnce(Throw(EnvoyException("can't bind")));
   EXPECT_CALL(*listener_foo, onDestroy());
-  EXPECT_THROW(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), true),
+  EXPECT_THROW(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), "", true),
                EnvoyException);
 }
 
@@ -601,7 +742,7 @@ TEST_F(ListenerManagerImplTest, ListenerDraining) {
   ListenerHandle* listener_foo = expectListenerCreate(false);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
   EXPECT_CALL(*worker_, addListener(_, _));
-  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), true));
+  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), "", true));
   worker_->callAddCompletion(true);
   checkStats(1, 0, 0, 0, 1, 0);
 
@@ -653,7 +794,7 @@ TEST_F(ListenerManagerImplTest, RemoveListener) {
   ListenerHandle* listener_foo = expectListenerCreate(true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
   EXPECT_CALL(listener_foo->target_, initialize(_));
-  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), true));
+  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), "", true));
   EXPECT_EQ(0UL, manager_->listeners().size());
   checkStats(1, 0, 0, 1, 0, 0);
 
@@ -667,7 +808,7 @@ TEST_F(ListenerManagerImplTest, RemoveListener) {
   listener_foo = expectListenerCreate(true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
   EXPECT_CALL(listener_foo->target_, initialize(_));
-  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), true));
+  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), "", true));
   checkStats(2, 0, 1, 1, 0, 0);
   EXPECT_CALL(*worker_, addListener(_, _));
   listener_foo->target_.callback_();
@@ -689,7 +830,7 @@ TEST_F(ListenerManagerImplTest, RemoveListener) {
   ListenerHandle* listener_foo_update1 = expectListenerCreate(true);
   EXPECT_CALL(listener_foo_update1->target_, initialize(_));
   EXPECT_TRUE(
-      manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_update1_json), true));
+      manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_update1_json), "", true));
   EXPECT_EQ(1UL, manager_->listeners().size());
   checkStats(2, 1, 1, 1, 1, 0);
 
@@ -726,7 +867,7 @@ TEST_F(ListenerManagerImplTest, AddListenerFailure) {
   ListenerHandle* listener_foo = expectListenerCreate(false);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
   EXPECT_CALL(*worker_, addListener(_, _));
-  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), true));
+  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), "", true));
 
   EXPECT_CALL(*worker_, stopListener(_));
   EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(_));
@@ -750,7 +891,7 @@ TEST_F(ListenerManagerImplTest, StatsNameValidCharacterTest) {
   }
   )EOF";
 
-  manager_->addOrUpdateListener(parseListenerFromJson(json), true);
+  manager_->addOrUpdateListener(parseListenerFromJson(json), "", true);
   manager_->listeners().front().get().listenerScope().counter("foo").inc();
 
   EXPECT_EQ(1UL, server_.stats_store_.counter("listener.[__1]_10000.foo").value());
@@ -775,7 +916,7 @@ TEST_F(ListenerManagerImplTest, DuplicateAddressDontBind) {
   ListenerHandle* listener_foo = expectListenerCreate(true);
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, false));
   EXPECT_CALL(listener_foo->target_, initialize(_));
-  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), true));
+  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromJson(listener_foo_json), "", true));
 
   // Add bar with same non-binding address. Should fail.
   const std::string listener_bar_json = R"EOF(
@@ -790,7 +931,8 @@ TEST_F(ListenerManagerImplTest, DuplicateAddressDontBind) {
   ListenerHandle* listener_bar = expectListenerCreate(true);
   EXPECT_CALL(*listener_bar, onDestroy());
   EXPECT_THROW_WITH_MESSAGE(
-      manager_->addOrUpdateListener(parseListenerFromJson(listener_bar_json), true), EnvoyException,
+      manager_->addOrUpdateListener(parseListenerFromJson(listener_bar_json), "", true),
+      EnvoyException,
       "error adding listener: 'bar' has duplicate address '0.0.0.0:1234' as existing listener");
 
   // Move foo to active and then try to add again. This should still fail.
@@ -801,7 +943,8 @@ TEST_F(ListenerManagerImplTest, DuplicateAddressDontBind) {
   listener_bar = expectListenerCreate(true);
   EXPECT_CALL(*listener_bar, onDestroy());
   EXPECT_THROW_WITH_MESSAGE(
-      manager_->addOrUpdateListener(parseListenerFromJson(listener_bar_json), true), EnvoyException,
+      manager_->addOrUpdateListener(parseListenerFromJson(listener_bar_json), "", true),
+      EnvoyException,
       "error adding listener: 'bar' has duplicate address '0.0.0.0:1234' as existing listener");
 
   EXPECT_CALL(*listener_foo, onDestroy());
@@ -843,7 +986,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, SniWithSingleFilterChain) {
 
   EXPECT_CALL(server_.random_, uuid());
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true);
+  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true);
   EXPECT_EQ(1U, manager_->listeners().size());
 }
 
@@ -899,7 +1042,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, SniWithTwoEqualFilterChains) {
 
   EXPECT_CALL(server_.random_, uuid());
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true);
+  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true);
   EXPECT_EQ(1U, manager_->listeners().size());
 }
 
@@ -956,7 +1099,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest,
 
   EXPECT_CALL(server_.random_, uuid());
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true);
+  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true);
   EXPECT_EQ(1U, manager_->listeners().size());
 }
 
@@ -1008,7 +1151,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest,
   )EOF",
                                                        Network::Address::IpVersion::v4);
 
-  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true),
+  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true),
                             EnvoyException,
                             "error adding listener '127.0.0.1:1234': filter chains with mixed use "
                             "of Session Ticket Keys are currently not supported");
@@ -1058,7 +1201,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, SniWithTwoDifferentFilterChains) 
   )EOF",
                                                        Network::Address::IpVersion::v4);
 
-  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true),
+  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true),
                             EnvoyException,
                             "error adding listener '127.0.0.1:1234': use of different filter "
                             "chains is currently not supported");
@@ -1080,7 +1223,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, TlsCertificateInline) {
 
   EXPECT_CALL(server_.random_, uuid());
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true);
+  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true);
   EXPECT_EQ(1U, manager_->listeners().size());
 }
 
@@ -1099,7 +1242,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, TlsCertificateChainInlinePrivateK
 
   EXPECT_CALL(server_.random_, uuid());
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true);
+  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true);
   EXPECT_EQ(1U, manager_->listeners().size());
 }
 
@@ -1116,7 +1259,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, TlsCertificateIncomplete) {
                                                        Network::Address::IpVersion::v4);
 
   EXPECT_THROW_WITH_MESSAGE(
-      manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true), EnvoyException,
+      manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true), EnvoyException,
       TestEnvironment::substitute("Failed to load incomplete certificate from {{ test_rundir }}"
                                   "/test/common/ssl/test_data/san_dns_chain3.pem, ",
                                   Network::Address::IpVersion::v4));
@@ -1135,7 +1278,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, TlsCertificateInvalidCertificateC
   )EOF",
                                                        Network::Address::IpVersion::v4);
 
-  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true),
+  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true),
                             EnvoyException, "Failed to load certificate chain from <inline>");
 }
 
@@ -1152,7 +1295,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, TlsCertificateInvalidIntermediate
   )EOF",
                                                        Network::Address::IpVersion::v4);
 
-  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true),
+  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true),
                             EnvoyException, "Failed to load certificate chain from <inline>");
 }
 
@@ -1169,7 +1312,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, TlsCertificateInvalidPrivateKey) 
   )EOF",
                                                        Network::Address::IpVersion::v4);
 
-  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true),
+  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true),
                             EnvoyException, "Failed to load private key from <inline>");
 }
 
@@ -1188,7 +1331,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, TlsCertificateInvalidTrustedCA) {
   )EOF",
                                                        Network::Address::IpVersion::v4);
 
-  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true),
+  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true),
                             EnvoyException, "Failed to load trusted CA certificates from <inline>");
 }
 
@@ -1212,7 +1355,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, Metadata) {
                 route: { cluster: service_foo }
   )EOF",
                                                        Network::Address::IpVersion::v4);
-  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true);
+  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true);
   auto context = dynamic_cast<Configuration::FactoryContext*>(&manager_->listeners().front().get());
   ASSERT_NE(nullptr, context);
   EXPECT_EQ("test_value",
@@ -1233,7 +1376,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstFilter) {
 
   EXPECT_CALL(server_.random_, uuid());
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true);
+  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true);
   EXPECT_EQ(1U, manager_->listeners().size());
 
   Network::ListenerConfig& listener = manager_->listeners().back().get();
@@ -1318,7 +1461,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstTestFilter) {
 
   EXPECT_CALL(server_.random_, uuid());
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true);
+  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true);
   EXPECT_EQ(1U, manager_->listeners().size());
 
   Network::ListenerConfig& listener = manager_->listeners().back().get();
@@ -1389,7 +1532,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstTestFilterOptionFail) 
 
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
 
-  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true),
+  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true),
                             EnvoyException,
                             "MockListenerComponentFactory: Setting socket options failed");
   EXPECT_EQ(0U, manager_->listeners().size());
@@ -1413,7 +1556,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, TransparentFreebindListenerDisabl
         EXPECT_EQ(options, nullptr);
         return listener_factory_.socket_;
       }));
-  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true);
+  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true);
   EXPECT_EQ(1U, manager_->listeners().size());
 }
 
@@ -1456,13 +1599,13 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, TransparentListenerEnabled) {
           EXPECT_EQ(1, *static_cast<const int*>(optval));
           return 0;
         }));
-    manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true);
+    manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true);
     EXPECT_EQ(1U, manager_->listeners().size());
   } else {
     // MockListenerSocket is not a real socket, so this always fails in testing.
-    EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true),
-                              EnvoyException,
-                              "MockListenerComponentFactory: Setting socket options failed");
+    EXPECT_THROW_WITH_MESSAGE(
+        manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true), EnvoyException,
+        "MockListenerComponentFactory: Setting socket options failed");
     EXPECT_EQ(0U, manager_->listeners().size());
   }
 }
@@ -1503,13 +1646,13 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, FreebindListenerEnabled) {
           EXPECT_EQ(1, *static_cast<const int*>(optval));
           return 0;
         }));
-    manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true);
+    manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true);
     EXPECT_EQ(1U, manager_->listeners().size());
   } else {
     // MockListenerSocket is not a real socket, so this always fails in testing.
-    EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true),
-                              EnvoyException,
-                              "MockListenerComponentFactory: Setting socket options failed");
+    EXPECT_THROW_WITH_MESSAGE(
+        manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true), EnvoyException,
+        "MockListenerComponentFactory: Setting socket options failed");
     EXPECT_EQ(0U, manager_->listeners().size());
   }
 }
@@ -1533,7 +1676,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, AddressResolver) {
   Registry::InjectFactory<Network::Address::Resolver> register_resolver(mock_resolver);
 
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true);
+  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true);
   EXPECT_EQ(1U, manager_->listeners().size());
 }
 
@@ -1555,7 +1698,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, CRLFilename) {
 
   EXPECT_CALL(server_.random_, uuid());
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true);
+  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true);
   EXPECT_EQ(1U, manager_->listeners().size());
 }
 
@@ -1577,7 +1720,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, CRLInline) {
 
   EXPECT_CALL(server_.random_, uuid());
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
-  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true);
+  manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true);
   EXPECT_EQ(1U, manager_->listeners().size());
 }
 
@@ -1597,7 +1740,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, InvalidCRLInline) {
   )EOF",
                                                        Network::Address::IpVersion::v4);
 
-  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true),
+  EXPECT_THROW_WITH_MESSAGE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true),
                             EnvoyException, "Failed to load CRL from <inline>");
 }
 
@@ -1616,7 +1759,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, CRLWithNoCA) {
   )EOF",
                                                        Network::Address::IpVersion::v4);
 
-  EXPECT_THROW_WITH_REGEX(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), true),
+  EXPECT_THROW_WITH_REGEX(manager_->addOrUpdateListener(parseListenerFromV2Yaml(yaml), "", true),
                           EnvoyException,
                           "^Failed to load CRL from .* without trusted CA certificates$");
 }


### PR DESCRIPTION
This completes initial implementation of the /config_dump admin endpoint,
allowing for detailed display of the currently loaded Envoy configuration,
including versions of each resource.

Fixes https://github.com/envoyproxy/envoy/issues/2421
Fixes https://github.com/envoyproxy/envoy/issues/2172

*Risk Level*: Low 
*Testing*: Unit/integration
*Docs Changes*: Added
*Release Notes*: Added
