### PR TITLE
logging: moving header pretty-printing to the base class

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <iostream>
 #include <memory>
 #include <string>
 

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -475,6 +475,22 @@ public:
    * @return the number of headers in the map.
    */
   virtual size_t size() const PURE;
+
+  /**
+   * Allow easy pretty-printing of the key/value pairs in HeaderMap
+   * @param os supplies the ostream to print to.
+   * @param headers the headers to print.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const HeaderMap& headers) {
+    headers.iterate(
+        [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {
+          *static_cast<std::ostream*>(context)
+              << "'" << header.key().c_str() << "', '" << header.value().c_str() << "'\n";
+          return HeaderMap::Iterate::Continue;
+        },
+        &os);
+    return os;
+  }
 };
 
 typedef std::unique_ptr<HeaderMap> HeaderMapPtr;

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -11,6 +11,7 @@
 #include "common/common/macros.h"
 
 #include "absl/strings/string_view.h"
+#include "fmt/ostream.h"
 #include "spdlog/spdlog.h"
 
 namespace Envoy {

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -87,15 +87,8 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
 }
 
 void AsyncStreamImpl::encodeHeaders(HeaderMapPtr&& headers, bool end_stream) {
-  if (ENVOY_LOG_CHECK_LEVEL(debug)) {
-    ENVOY_LOG(debug, "async http request response headers (end_stream={}):", end_stream);
-    headers->iterate(
-        [](const HeaderEntry& header, void*) -> HeaderMap::Iterate {
-          ENVOY_LOG(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());
-          return HeaderMap::Iterate::Continue;
-        },
-        nullptr);
-  }
+  ENVOY_LOG(debug, "async http request response headers (end_stream={}):\n{}", end_stream,
+            *headers);
   ASSERT(!remote_closed_);
   stream_callbacks_.onHeaders(std::move(headers), end_stream);
   closeRemote(end_stream);
@@ -110,15 +103,7 @@ void AsyncStreamImpl::encodeData(Buffer::Instance& data, bool end_stream) {
 }
 
 void AsyncStreamImpl::encodeTrailers(HeaderMapPtr&& trailers) {
-  if (ENVOY_LOG_CHECK_LEVEL(debug)) {
-    ENVOY_LOG(debug, "async http request response trailers:");
-    trailers->iterate(
-        [](const HeaderEntry& header, void*) -> HeaderMap::Iterate {
-          ENVOY_LOG(debug, "  '{}':'{}'", header.key().c_str(), header.value().c_str());
-          return HeaderMap::Iterate::Continue;
-        },
-        nullptr);
-  }
+  ENVOY_LOG(debug, "async http request response trailers:\n{}", *trailers);
   ASSERT(!remote_closed_);
   stream_callbacks_.onTrailers(std::move(trailers));
   closeRemote(true);

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -447,18 +447,8 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
   maybeEndDecode(end_stream);
   request_headers_ = std::move(headers);
 
-  // Iterate and log headers only if logger's level is at least debug
-  if (ENVOY_LOG_CHECK_LEVEL(debug)) {
-    ENVOY_STREAM_LOG(debug, "request headers complete (end_stream={}):", *this, end_stream);
-
-    request_headers_->iterate(
-        [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {
-          ENVOY_STREAM_LOG(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
-                           header.key().c_str(), header.value().c_str());
-          return HeaderMap::Iterate::Continue;
-        },
-        this);
-  }
+  ENVOY_STREAM_LOG(debug, "request headers complete (end_stream={}):\n{}", *this, end_stream,
+                   *request_headers_);
 
   if (!connection_manager_.config_.proxy100Continue() && request_headers_->Expect() &&
       request_headers_->Expect()->value() == Headers::get().ExpectValues._100Continue.c_str()) {
@@ -861,16 +851,7 @@ void ConnectionManagerImpl::ActiveStream::encode100ContinueHeaders(
   // Count both the 1xx and follow-up response code in stats.
   chargeStats(headers);
 
-  if (ENVOY_LOG_CHECK_LEVEL(debug)) {
-    ENVOY_STREAM_LOG(debug, "encoding 100 continue headers via codec", *this);
-    headers.iterate(
-        [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {
-          ENVOY_STREAM_LOG(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
-                           header.key().c_str(), header.value().c_str());
-          return HeaderMap::Iterate::Continue;
-        },
-        this);
-  }
+  ENVOY_STREAM_LOG(debug, "encoding 100 continue headers via codec:\n{}", *this, headers);
 
   // Now actually encode via the codec.
   response_encoder_->encode100ContinueHeaders(headers);
@@ -967,17 +948,8 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
 
   chargeStats(headers);
 
-  if (ENVOY_LOG_CHECK_LEVEL(debug)) {
-    ENVOY_STREAM_LOG(debug, "encoding headers via codec (end_stream={}):", *this,
-                     end_stream && continue_data_entry == encoder_filters_.end());
-    headers.iterate(
-        [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {
-          ENVOY_STREAM_LOG(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
-                           header.key().c_str(), header.value().c_str());
-          return HeaderMap::Iterate::Continue;
-        },
-        this);
-  }
+  ENVOY_STREAM_LOG(debug, "encoding headers via codec (end_stream={}):\n{}", *this,
+                     end_stream && continue_data_entry == encoder_filters_.end(), headers);
 
   // Now actually encode via the codec.
   request_info_.onFirstDownstreamTxByteSent();
@@ -1054,16 +1026,7 @@ void ConnectionManagerImpl::ActiveStream::encodeTrailers(ActiveStreamEncoderFilt
     }
   }
 
-  if (ENVOY_LOG_CHECK_LEVEL(debug)) {
-    ENVOY_STREAM_LOG(debug, "encoding trailers via codec", *this);
-    trailers.iterate(
-        [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {
-          ENVOY_STREAM_LOG(debug, "  '{}':'{}'", *static_cast<ActiveStream*>(context),
-                           header.key().c_str(), header.value().c_str());
-          return HeaderMap::Iterate::Continue;
-        },
-        this);
-  }
+  ENVOY_STREAM_LOG(debug, "encoding trailers via codec:\n{}", *this, trailers);
 
   response_encoder_->encodeTrailers(trailers);
   maybeEndEncode(true);

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -949,7 +949,7 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
   chargeStats(headers);
 
   ENVOY_STREAM_LOG(debug, "encoding headers via codec (end_stream={}):\n{}", *this,
-                     end_stream && continue_data_entry == encoder_filters_.end(), headers);
+                   end_stream && continue_data_entry == encoder_filters_.end(), headers);
 
   // Now actually encode via the codec.
   request_info_.onFirstDownstreamTxByteSent();

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -290,16 +290,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool e
   do_shadowing_ = FilterUtility::shouldShadow(route_entry_->shadowPolicy(), config_.runtime_,
                                               callbacks_->streamId());
 
-  if (ENVOY_LOG_CHECK_LEVEL(debug)) {
-    headers.iterate(
-        [](const Http::HeaderEntry& header, void* context) -> Http::HeaderMap::Iterate {
-          ENVOY_STREAM_LOG(debug, "  '{}':'{}'",
-                           *static_cast<Http::StreamDecoderFilterCallbacks*>(context),
-                           header.key().c_str(), header.value().c_str());
-          return Http::HeaderMap::Iterate::Continue;
-        },
-        callbacks_);
-  }
+  ENVOY_STREAM_LOG(debug, "router decoding headers:\n{}", *callbacks_, headers);
 
   // Do a common header check. We make sure that all outgoing requests have all HTTP/2 headers.
   // These get stripped by HTTP/1 codec where applicable.


### PR DESCRIPTION
All 7 call sites which print headers have duplicate code.  Moving this to include/envoy/http/header_map.h to make it easier to print headers.

This results in logs changing from the former style to the latter style

[2018-05-09 19:45:01.871][335][debug][http] source/common/http/conn_manager_impl.cc:450] [C86][S4107676710185973249] request headers complete (end_stream=false):
[2018-05-09 19:45:01.871][335][debug][http] source/common/http/conn_manager_impl.cc:455] [C86][S4107676710185973249]   ':authority':'host'
[2018-05-09 19:45:01.871][335][debug][http] source/common/http/conn_manager_impl.cc:455] [C86][S4107676710185973249]   'x-lyft-user-id':'123'
[2018-05-09 19:45:01.871][335][debug][http] source/common/http/conn_manager_impl.cc:455] [C86][S4107676710185973249]   'x-forwarded-for':'10.0.0.1'
[2018-05-09 19:45:01.871][335][debug][http] source/common/http/conn_manager_impl.cc:455] [C86][S4107676710185973249]   'transfer-encoding':'chunked'
[2018-05-09 19:45:01.871][335][debug][http] source/common/http/conn_manager_impl.cc:455] [C86][S4107676710185973249]   ':path':'/test/long/url'
[2018-05-09 19:45:01.871][335][debug][http] source/common/http/conn_manager_impl.cc:455] [C86][S4107676710185973249]   ':method':'POST'

[2018-05-09 19:55:05.606][29][debug][http] source/common/http/conn_manager_impl.cc:461] [C2][S3074720158228501815] request headers complete (end_stream=true):
':authority', 'host'
'content-length', '0'
':path', '/notfound'
':method', 'GET'

*Risk Level*: Low  (changes debug / trace logging)
*Testing*: Ran existing unit tests
*Docs Changes*: n/a
*Release Notes*: n/a
