### PR TITLE
docs: Document that outlier detection will always eject a single host

### DIFF
--- a/api/envoy/api/v2/cluster/outlier_detection.proto
+++ b/api/envoy/api/v2/cluster/outlier_detection.proto
@@ -30,7 +30,7 @@ message OutlierDetection {
   google.protobuf.Duration base_ejection_time = 3 [(validate.rules).duration.gt = {}];
 
   // The maximum % of an upstream cluster that can be ejected due to outlier
-  // detection. Defaults to 10%.
+  // detection. Defaults to 10% but will eject at least one host regardless of the value.
   google.protobuf.UInt32Value max_ejection_percent = 4 [(validate.rules).uint32.lte = 100];
 
   // The % chance that a host will be actually ejected when an outlier status

--- a/docs/root/api-v1/cluster_manager/cluster_outlier_detection.rst
+++ b/docs/root/api-v1/cluster_manager/cluster_outlier_detection.rst
@@ -47,7 +47,7 @@ base_ejection_time_ms
 
 max_ejection_percent
   *(optional, integer)* The maximum % of hosts in an upstream cluster that can be ejected due to outlier detection.
-  Defaults to 10%.
+  Defaults to 10% but will eject at least one host regardless of the value.
 
 .. _config_cluster_manager_cluster_outlier_detection_enforcing_consecutive_5xx:
 

--- a/docs/root/intro/arch_overview/outlier.rst
+++ b/docs/root/intro/arch_overview/outlier.rst
@@ -19,10 +19,10 @@ consecutive 5xx) or at a specified interval (for example in the case of periodic
 ejection algorithm works as follows:
 
 #. A host is determined to be an outlier.
-#. Envoy checks to make sure the number of ejected hosts is below the allowed threshold (specified
-   via the :ref:`outlier_detection.max_ejection_percent
-   <config_cluster_manager_cluster_outlier_detection>` setting).
-   If the number of ejected hosts is above the threshold the host is not ejected.
+#. If no hosts have been ejected, Envoy will eject the host immediately. Otherwise, it checks to make
+   sure the number of ejected hosts is below the allowed threshold (specified via the
+   :ref:`outlier_detection.max_ejection_percent<config_cluster_manager_cluster_outlier_detection>`
+   setting). If the number of ejected hosts is above the threshold, the host is not ejected.
 #. The host is ejected for some number of milliseconds. Ejection means that the host is marked
    unhealthy and will not be used during load balancing unless the load balancer is in a
    :ref:`panic <arch_overview_load_balancing_panic_threshold>` scenario. The number of milliseconds


### PR DESCRIPTION
*Description*:
While working with outlier detection, found that a single host would always be ejected regardless of the max ejection percentage. This change adds some notes to specify that in the v1 and v2 docs, as well as the arch overview.

*Testing*
Built docs locally and saw changes take.

Fixes #3263
