### PR TITLE
eds: allow removing all priorities

### DIFF
--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -46,7 +46,7 @@ void EdsClusterImpl::startPreInit() { subscription_->start({cluster_name_}, *thi
 
 void EdsClusterImpl::onConfigUpdate(const ResourceVector& resources, const std::string&) {
   typedef std::unique_ptr<HostVector> HostListPtr;
-  std::vector<std::pair<HostListPtr, LocalityWeightsMap>> priority_state(1);
+  std::vector<std::pair<HostListPtr, LocalityWeightsMap>> priority_state;
   if (resources.empty()) {
     ENVOY_LOG(debug, "Missing ClusterLoadAssignment for {} in onConfigUpdate()", cluster_name_);
     info_->stats().update_empty_.inc();
@@ -69,7 +69,7 @@ void EdsClusterImpl::onConfigUpdate(const ResourceVector& resources, const std::
       throw EnvoyException(
           fmt::format("Unexpected non-zero priority for local cluster '{}'.", cluster_name_));
     }
-    if (priority_state.size() <= priority) {
+    if (priority_state.size() <= priority + 1) {
       priority_state.resize(priority + 1);
     }
     if (priority_state[priority].first == nullptr) {
@@ -115,6 +115,9 @@ void EdsClusterImpl::onConfigUpdate(const ResourceVector& resources, const std::
     const HostVector empty_hosts;
     LocalityWeightsMap empty_locality_map;
 
+    if (locality_weights_map_.size() <= i) {
+      locality_weights_map_.resize(i + 1);
+    }
     cluster_rebuilt |= updateHostsPerLocality(priority_set_.getOrCreateHostSet(i), empty_hosts,
                                               locality_weights_map_[i], empty_locality_map);
   }

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -594,6 +594,20 @@ TEST_F(EdsTest, RemoveUnreferencedLocalities) {
     auto& hosts_per_locality = cluster_->prioritySet().hostSetsPerPriority()[1]->hostsPerLocality().get();
     EXPECT_EQ(1, hosts_per_locality.size());
   }
+
+  // Clear out the new ClusterLoadAssignment. This should leave us with 0 localities per priority. 
+  cluster_load_assignment->clear_endpoints();
+  VERBOSE_EXPECT_NO_THROW(cluster_->onConfigUpdate(resources, ""));
+
+  {
+    auto& hosts_per_locality = cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get();
+    EXPECT_EQ(0, hosts_per_locality.size());
+  }
+
+  {
+    auto& hosts_per_locality = cluster_->prioritySet().hostSetsPerPriority()[1]->hostsPerLocality().get();
+    EXPECT_EQ(0, hosts_per_locality.size());
+  }
 }
 
 // Validate that onConfigUpdate() updates bins hosts per locality as expected.

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -528,6 +528,74 @@ TEST_F(EdsTest, EndpointLocalityWeights) {
   EXPECT_EQ(37, locality_weights[2]);
 }
 
+// Validate that onConfigUpdate() removes any locality not referenced in the
+// config update in each priority. 
+TEST_F(EdsTest, RemoveUnreferencedLocalities) {
+  Protobuf::RepeatedPtrField<envoy::api::v2::ClusterLoadAssignment> resources;
+  auto* cluster_load_assignment = resources.Add();
+  cluster_load_assignment->set_cluster_name("fare");
+  uint32_t port = 1000;
+  auto add_hosts_to_locality = [cluster_load_assignment,
+                                &port](const std::string& region, const std::string& zone,
+                                       const std::string& sub_zone, uint32_t n, uint32_t priority) {
+    auto* endpoints = cluster_load_assignment->add_endpoints();
+    endpoints->set_priority(priority);
+    auto* locality = endpoints->mutable_locality();
+    locality->set_region(region);
+    locality->set_zone(zone);
+    locality->set_sub_zone(sub_zone);
+
+    for (uint32_t i = 0; i < n; ++i) {
+      auto* socket_address = endpoints->add_lb_endpoints()
+                                 ->mutable_endpoint()
+                                 ->mutable_address()
+                                 ->mutable_socket_address();
+      socket_address->set_address("1.2.3.4");
+      socket_address->set_port_value(port++);
+    }
+  };
+
+  // Add two localities to each of priority 0 and 1
+  add_hosts_to_locality("oceania", "koala", "ingsoc", 2, 0);
+  add_hosts_to_locality("", "us-east-1a", "", 1, 0);
+
+  add_hosts_to_locality("oceania", "bear", "best", 4, 1);
+  add_hosts_to_locality("", "us-west-1a", "", 2, 1);
+
+  bool initialized = false;
+  cluster_->initialize([&initialized] { initialized = true; });
+  VERBOSE_EXPECT_NO_THROW(cluster_->onConfigUpdate(resources, ""));
+  EXPECT_TRUE(initialized);
+
+  {
+    auto& hosts_per_locality = cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get();
+    EXPECT_EQ(2, hosts_per_locality.size());
+  }
+
+  {
+    auto& hosts_per_locality = cluster_->prioritySet().hostSetsPerPriority()[1]->hostsPerLocality().get();
+    EXPECT_EQ(2, hosts_per_locality.size());
+  }
+
+  // Reset the ClusterLoadAssingment to only contain one of the locality per priority.
+  // This should leave us with only one locality.
+  cluster_load_assignment->clear_endpoints();
+  add_hosts_to_locality("oceania", "koala", "ingsoc", 4, 0);
+  add_hosts_to_locality("oceania", "bear", "best", 2, 1);
+
+  VERBOSE_EXPECT_NO_THROW(cluster_->onConfigUpdate(resources, ""));
+
+  {
+    auto& hosts_per_locality = cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get();
+    EXPECT_EQ(1, hosts_per_locality.size());
+  }
+
+  {
+    auto& hosts_per_locality = cluster_->prioritySet().hostSetsPerPriority()[1]->hostsPerLocality().get();
+    EXPECT_EQ(1, hosts_per_locality.size());
+  }
+}
+
 // Validate that onConfigUpdate() updates bins hosts per locality as expected.
 TEST_F(EdsTest, EndpointHostsPerLocality) {
   Protobuf::RepeatedPtrField<envoy::api::v2::ClusterLoadAssignment> resources;

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -529,7 +529,7 @@ TEST_F(EdsTest, EndpointLocalityWeights) {
 }
 
 // Validate that onConfigUpdate() removes any locality not referenced in the
-// config update in each priority. 
+// config update in each priority.
 TEST_F(EdsTest, RemoveUnreferencedLocalities) {
   Protobuf::RepeatedPtrField<envoy::api::v2::ClusterLoadAssignment> resources;
   auto* cluster_load_assignment = resources.Add();
@@ -568,12 +568,14 @@ TEST_F(EdsTest, RemoveUnreferencedLocalities) {
   EXPECT_TRUE(initialized);
 
   {
-    auto& hosts_per_locality = cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get();
+    auto& hosts_per_locality =
+        cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get();
     EXPECT_EQ(2, hosts_per_locality.size());
   }
 
   {
-    auto& hosts_per_locality = cluster_->prioritySet().hostSetsPerPriority()[1]->hostsPerLocality().get();
+    auto& hosts_per_locality =
+        cluster_->prioritySet().hostSetsPerPriority()[1]->hostsPerLocality().get();
     EXPECT_EQ(2, hosts_per_locality.size());
   }
 
@@ -586,26 +588,30 @@ TEST_F(EdsTest, RemoveUnreferencedLocalities) {
   VERBOSE_EXPECT_NO_THROW(cluster_->onConfigUpdate(resources, ""));
 
   {
-    auto& hosts_per_locality = cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get();
+    auto& hosts_per_locality =
+        cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get();
     EXPECT_EQ(1, hosts_per_locality.size());
   }
 
   {
-    auto& hosts_per_locality = cluster_->prioritySet().hostSetsPerPriority()[1]->hostsPerLocality().get();
+    auto& hosts_per_locality =
+        cluster_->prioritySet().hostSetsPerPriority()[1]->hostsPerLocality().get();
     EXPECT_EQ(1, hosts_per_locality.size());
   }
 
-  // Clear out the new ClusterLoadAssignment. This should leave us with 0 localities per priority. 
+  // Clear out the new ClusterLoadAssignment. This should leave us with 0 localities per priority.
   cluster_load_assignment->clear_endpoints();
   VERBOSE_EXPECT_NO_THROW(cluster_->onConfigUpdate(resources, ""));
 
   {
-    auto& hosts_per_locality = cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get();
+    auto& hosts_per_locality =
+        cluster_->prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get();
     EXPECT_EQ(0, hosts_per_locality.size());
   }
 
   {
-    auto& hosts_per_locality = cluster_->prioritySet().hostSetsPerPriority()[1]->hostsPerLocality().get();
+    auto& hosts_per_locality =
+        cluster_->prioritySet().hostSetsPerPriority()[1]->hostsPerLocality().get();
     EXPECT_EQ(0, hosts_per_locality.size());
   }
 }


### PR DESCRIPTION
*title*: eds: allow removing all priorities

*Description*:
While writing some additional tests for #3327 I ran into an issue with clearing out all the priorities. This fixes this bug by only ever adding an element to priority_state when we see an actual endpoint. This allows clearing out *all* priorities for a cluster, which is something that we need to be able to do on our end in order to fully disable a cluster. 

Without this fix, attempts to clear out priority 0 would have no effect, since the secondary loop that cleans out all priorities that aren't in the update was starting at priority 1. 

The test case added here also serves to prove that the bug reported in #3327 actually works as intended: a locality can be removed from a priority simply by not referencing it in the EDS config update. 

*Risk Level*: 
Low: Small bug fix

*Docs Changes*:
N/A

*Release Notes*:
N/A
