### PR TITLE
docs: remove not-implemented-hide for statsd sink prefix

### DIFF
--- a/api/envoy/config/metrics/v2/stats.proto
+++ b/api/envoy/config/metrics/v2/stats.proto
@@ -155,7 +155,7 @@ message StatsdSink {
     // Envoy will connect to this cluster to flush statistics.
     string tcp_cluster_name = 2;
   }
-  // [#not-implemented-hide:] Optional custom prefix for StatsdSink. If
+  // Optional custom prefix for StatsdSink. If
   // specified, this will override the default prefix.
   // For example:
   //

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -72,6 +72,7 @@ Version history
 * sockets: added `SO_KEEPALIVE` socket option for upstream connections
   :ref:`per cluster <envoy_api_field_Cluster.upstream_connection_options>`.
 * stats: added support for histograms.
+* stats: added :ref:`option to configure the statsd prefix<envoy_api_field_config.metrics.v2.StatsdSink.prefix>`
 * tls: removed support for legacy SHA-2 CBC cipher suites.
 * tracing: the sampling decision is now delegated to the tracers, allowing the tracer to decide when and if
   to use it. For example, if the :ref:`x-b3-sampled <config_http_conn_man_headers_x-b3-sampled>` header


### PR DESCRIPTION
*title*: docs: remove not-implemented-hide for statsd sink prefix

*Description*:
This seems to have been implemented in
https://github.com/envoyproxy/envoy/pull/3029.

*Risk Level*: 
Low: Docs change

*Testing*:
N/A

*Docs Changes*:
Unhides the statsd prefix option

*Release Notes*:
N/A