### PR TITLE
ads: Fix cluster remains not-initialized when eds is removed and then added.

### DIFF
--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -175,7 +175,7 @@ void GrpcMuxImpl::onReceiveMessage(std::unique_ptr<envoy::api::v2::DiscoveryResp
       // request, as we don't watch for anything.
       api_state_[type_url].request_.set_version_info(message->version_info());
     } else {
-      // No watches and we have resources - this should not happen. send ad NACK (by not updateding
+      // No watches and we have resources - this should not happen. send a NACK (by not updating
       // the version).
       ENVOY_LOG(warn, "Ignoring unwatched type URL {}", type_url);
       sendDiscoveryRequest(type_url);

--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -163,7 +163,12 @@ void GrpcMuxImpl::onReceiveMessage(std::unique_ptr<envoy::api::v2::DiscoveryResp
     return;
   }
   if (api_state_[type_url].watches_.empty()) {
-    ENVOY_LOG(warn, "Ignoring unwatched type URL {}", type_url);
+    if (message->resources().empty()) {
+      api_state_[type_url].request_.set_version_info(message->version_info());
+      api_state_[type_url].request_.set_response_nonce(message->nonce());
+    } else {
+      ENVOY_LOG(warn, "Ignoring unwatched type URL {}", type_url);
+    }
     return;
   }
   try {

--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -160,14 +160,25 @@ void GrpcMuxImpl::onReceiveMessage(std::unique_ptr<envoy::api::v2::DiscoveryResp
   ENVOY_LOG(debug, "Received gRPC message for {} at version {}", type_url, message->version_info());
   if (api_state_.count(type_url) == 0) {
     ENVOY_LOG(warn, "Ignoring unknown type URL {}", type_url);
+    // TODO(yuval-k): This should never happen. consider dropping the stream as this is a protocol
+    // violation
     return;
   }
   if (api_state_[type_url].watches_.empty()) {
+    // update the nonce as we are processing this response.
+    api_state_[type_url].request_.set_response_nonce(message->nonce());
     if (message->resources().empty()) {
+      // No watches and no resources. This can happen when envoy unregisters from a resource
+      // that's removed from the server as well. For example, a delted cluster triggers un-watching
+      // the ClusterLoadAssignment watch, and at the same time the xDS server sends an empty list of
+      // ClusterLoadAssignment resources. we'll accept this update. no need to send a discovery
+      // request, as we don't watch for anything.
       api_state_[type_url].request_.set_version_info(message->version_info());
-      api_state_[type_url].request_.set_response_nonce(message->nonce());
     } else {
+      // No watches and we have resources - this should not happen. send ad NACK (by not updateding
+      // the version).
       ENVOY_LOG(warn, "Ignoring unwatched type URL {}", type_url);
+      sendDiscoveryRequest(type_url);
     }
     return;
   }

--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -169,7 +169,7 @@ void GrpcMuxImpl::onReceiveMessage(std::unique_ptr<envoy::api::v2::DiscoveryResp
     api_state_[type_url].request_.set_response_nonce(message->nonce());
     if (message->resources().empty()) {
       // No watches and no resources. This can happen when envoy unregisters from a resource
-      // that's removed from the server as well. For example, a delted cluster triggers un-watching
+      // that's removed from the server as well. For example, a deleted cluster triggers un-watching
       // the ClusterLoadAssignment watch, and at the same time the xDS server sends an empty list of
       // ClusterLoadAssignment resources. we'll accept this update. no need to send a discovery
       // request, as we don't watch for anything.

--- a/test/common/config/grpc_mux_impl_test.cc
+++ b/test/common/config/grpc_mux_impl_test.cc
@@ -49,6 +49,7 @@ public:
 
   void expectSendMessage(const std::string& type_url,
                          const std::vector<std::string>& resource_names, const std::string& version,
+                         const std::string& nonce = "",
                          const Protobuf::int32 error_code = Grpc::Status::GrpcStatus::Ok,
                          const std::string& error_message = "") {
     envoy::api::v2::DiscoveryRequest expected_request;
@@ -59,7 +60,7 @@ public:
     if (!version.empty()) {
       expected_request.set_version_info(version);
     }
-    expected_request.set_response_nonce("");
+    expected_request.set_response_nonce(nonce);
     expected_request.set_type_url(type_url);
     if (error_code != Grpc::Status::GrpcStatus::Ok) {
       ::google::rpc::Status* error_detail = expected_request.mutable_error_detail();
@@ -170,7 +171,7 @@ TEST_F(GrpcMuxImplTest, TypeUrlMismatch) {
           IsSubstring("", "", "bar does not match foo type URL is DiscoveryResponse", e->what()));
     }));
 
-    expectSendMessage("foo", {"x", "y"}, "", Grpc::Status::GrpcStatus::Internal,
+    expectSendMessage("foo", {"x", "y"}, "", "", Grpc::Status::GrpcStatus::Internal,
                       fmt::format("bar does not match foo type URL is DiscoveryResponse {}",
                                   invalid_response->DebugString()));
     grpc_mux_->onReceiveMessage(std::move(invalid_response));

--- a/test/common/config/grpc_mux_impl_test.cc
+++ b/test/common/config/grpc_mux_impl_test.cc
@@ -376,12 +376,10 @@ TEST_F(GrpcMuxImplTest, UnwatchedTypeRejectsResources) {
   const std::string& type_url = Config::TypeUrl::get().ClusterLoadAssignment;
 
   grpc_mux_->start();
-  {
-    // subscribe and unsubscribe so that the type is known to envoy
-    expectSendMessage(type_url, {"y"}, "");
-    expectSendMessage(type_url, {}, "");
-    grpc_mux_->subscribe(type_url, {"y"}, callbacks_);
-  }
+  // subscribe and unsubscribe (by not keeping the return watch) so that the type is known to envoy
+  expectSendMessage(type_url, {"y"}, "");
+  expectSendMessage(type_url, {}, "");
+  grpc_mux_->subscribe(type_url, {"y"}, callbacks_);
 
   // simulate the server sending CLA message to notify envoy that the CLA was added,
   // even though envoy doesn't expect it. Envoy should reject this update.


### PR DESCRIPTION
*Risk Level*: Low

*Testing*:
Added unit test that fails before the patch and passes after.

Fixes #3355 