### PR TITLE
stats: fix stat flush crash during hot restart

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -155,7 +155,9 @@ void InstanceImpl::flushStats() {
         sslContextManager().daysUntilFirstCertExpires());
     InstanceUtil::flushMetricsToSinks(config_->statsSinks(), stats_store_);
     // TODO(ramaraochavali): consider adding different flush interval for histograms.
-    stat_flush_timer_->enableTimer(config_->statsFlushInterval());
+    if (stat_flush_timer_ != nullptr) {
+      stat_flush_timer_->enableTimer(config_->statsFlushInterval());
+    }
   });
 }
 
@@ -451,6 +453,9 @@ void InstanceImpl::shutdown() {
 
 void InstanceImpl::shutdownAdmin() {
   ENVOY_LOG(warn, "shutting down admin due to child startup");
+  // TODO(mattklein123): Since histograms are not shared between processes, this will also stop
+  //                     histogram flushing. In the future we can consider whether we want to
+  //                     somehow keep flushing histograms from the old process.
   stat_flush_timer_.reset();
   handler_->stopListeners();
   admin_->mutable_socket().close();


### PR DESCRIPTION
If histogram merge completion happens after admin shutdown, there is
no longer any refresh timer and we crash. Guard the timer enable.

*Risk Level*: Low
*Testing*: Existing tests. Add a test for this case is non-trivial without
doing a bunch of work which seems not worth it for this simple fix.
*Docs Changes*: N/A
*Release Notes*: N/A
