### PR TITLE
Adds ability to add http2 configuration option SETTINGS_MAX_HEADER_LIST_SIZE

### DIFF
--- a/api/envoy/api/v2/core/protocol.proto
+++ b/api/envoy/api/v2/core/protocol.proto
@@ -77,11 +77,10 @@ message Http2ProtocolOptions {
   google.protobuf.UInt32Value initial_connection_window_size = 4
       [(validate.rules).uint32 = {gte: 65535, lte: 2147483647}];
 
-  // `SETTINGS_MAX_HEADER_LIST_SIZE <https://tools.ietf.org/html/rfc7540#section-6.5>`_
-  //  This option indicates client the maximum size of header, server is ready to accept
-  //  otherwise it throws an error.
-  google.protobuf.UInt32Value max_header_list_size = 5
-      [(validate.rules).uint32 = {gte: 8000, lte: 16000}];
+  // `SETTINGS_MAX_HEADER_LIST_SIZE <https://httpwg.org/specs/rfc7540.html#SettingValues>`_
+  //  This option informs upstream peers the maximum size of header list the sender is ready to accept
+  //  in octets. Initial value of this setting is unlimited.
+  google.protobuf.UInt32Value max_header_list_size = 5;
 }
 
 // [#not-implemented-hide:]

--- a/api/envoy/api/v2/core/protocol.proto
+++ b/api/envoy/api/v2/core/protocol.proto
@@ -76,6 +76,12 @@ message Http2ProtocolOptions {
   // window. Currently, this has the same minimum/maximum/default as *initial_stream_window_size*.
   google.protobuf.UInt32Value initial_connection_window_size = 4
       [(validate.rules).uint32 = {gte: 65535, lte: 2147483647}];
+
+  // `SETTINGS_MAX_HEADER_LIST_SIZE <https://tools.ietf.org/html/rfc7540#section-6.5>`_
+  //  This option indicates client the maximum size of header, server is ready to accept
+  //  otherwise it throws an error.
+  google.protobuf.UInt32Value max_header_list_size = 5
+      [(validate.rules).uint32 = {gte: 8000, lte: 16000}];
 }
 
 // [#not-implemented-hide:]

--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -242,8 +242,8 @@ struct Http2Settings {
   // our default connection-level window also equals to our stream-level
   static const uint32_t DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE = 256 * 1024 * 1024;
   static const uint32_t MAX_INITIAL_CONNECTION_WINDOW_SIZE = (1U << 31) - 1;
-  // defaults to maximum, value in octet
-  static const uint32_t DEFAULT_MAX_HEADER_LIST_SIZE = 8000;
+  // defaults to unlimited, value in octet
+  static const uint32_t DEFAULT_MAX_HEADER_LIST_SIZE = std::numeric_limits<uint32_t>::max();
 };
 
 /**

--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -208,6 +208,7 @@ struct Http2Settings {
   uint32_t max_concurrent_streams_{DEFAULT_MAX_CONCURRENT_STREAMS};
   uint32_t initial_stream_window_size_{DEFAULT_INITIAL_STREAM_WINDOW_SIZE};
   uint32_t initial_connection_window_size_{DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE};
+  uint32_t max_header_list_size_{DEFAULT_MAX_HEADER_LIST_SIZE};
 
   // disable HPACK compression
   static const uint32_t MIN_HPACK_TABLE_SIZE = 0;
@@ -241,6 +242,8 @@ struct Http2Settings {
   // our default connection-level window also equals to our stream-level
   static const uint32_t DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE = 256 * 1024 * 1024;
   static const uint32_t MAX_INITIAL_CONNECTION_WINDOW_SIZE = (1U << 31) - 1;
+  // defaults to maximum, value in octet
+  static const uint32_t DEFAULT_MAX_HEADER_LIST_SIZE = 8000;
 };
 
 /**

--- a/source/common/config/protocol_json.cc
+++ b/source/common/config/protocol_json.cc
@@ -19,6 +19,7 @@ void ProtocolJson::translateHttp2ProtocolOptions(
   JSON_UTIL_SET_INTEGER(json_http2_settings, http2_protocol_options, initial_stream_window_size);
   JSON_UTIL_SET_INTEGER(json_http2_settings, http2_protocol_options,
                         initial_connection_window_size);
+  JSON_UTIL_SET_INTEGER(json_http2_settings, http2_protocol_options, max_header_list_size);
 }
 
 } // namespace Config

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -635,6 +635,10 @@ void ConnectionImpl::sendSettings(const Http2Settings& http2_settings, bool disa
                    http2_settings.initial_stream_window_size_);
   }
 
+  if (http2_settings.max_header_list_size_ != Http2Settings::DEFAULT_MAX_HEADER_LIST_SIZE) {
+    iv.push_back({NGHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE, http2_settings.max_header_list_size_});
+  }
+
   if (disable_push) {
     // Universally disable receiving push promise frames as we don't currently support them. nghttp2
     // will fail the connection if the other side still sends them.

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -198,6 +198,8 @@ Utility::parseHttp2Settings(const envoy::api::v2::core::Http2ProtocolOptions& co
   ret.initial_connection_window_size_ =
       PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, initial_connection_window_size,
                                       Http::Http2Settings::DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE);
+  ret.max_header_list_size_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+      config, max_header_list_size, Http::Http2Settings::DEFAULT_MAX_HEADER_LIST_SIZE);
   return ret;
 }
 

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -114,13 +114,15 @@ TEST(HttpUtility, parseHttp2Settings) {
                                             "hpack_table_size": 1,
                                             "max_concurrent_streams": 2,
                                             "initial_stream_window_size": 3,
-                                            "initial_connection_window_size": 4
+                                            "initial_connection_window_size": 4,
+                                            "max_header_list_size": 5
                                           }
                                         })raw");
     EXPECT_EQ(1U, http2_settings.hpack_table_size_);
     EXPECT_EQ(2U, http2_settings.max_concurrent_streams_);
     EXPECT_EQ(3U, http2_settings.initial_stream_window_size_);
     EXPECT_EQ(4U, http2_settings.initial_connection_window_size_);
+    EXPECT_EQ(5U, http2_settings.max_header_list_size_);
   }
 }
 


### PR DESCRIPTION
Signed-off-by: sri kailash <sri.gandebathula@booking.com>

*title*: This PR adds ability to add SETTINGS_MAX_HEADER_LIST_SIZE http2 configuration option


*Description*:
This adds max_header_list_size configuration option that can be communicated to upstream hosts.
please see https://github.com/envoyproxy/envoy/issues/2958.

*Risk Level*: Low


TODO:
1. Need to add tests 
