### PR TITLE
repo layout: add grpc credentials extension type to repo layout

### DIFF
--- a/REPO_LAYOUT.md
+++ b/REPO_LAYOUT.md
@@ -81,6 +81,8 @@ currently implemented but that is the plan moving forward.)
     `Envoy::Extensions::ListenerFilters` namespace.
   * [filters/network/](/source/extensions/filters/network): L4 network filters which use the
     `Envoy::Extensions::NetworkFilters` namespace.
+  * [grpc_credentials/](/source/extensions/grpc_credentials): Custom gRPC credentials which use the
+    `Envoy::Extensions::GrpcCredentials` namespace.
   * [health_checker/](/source/extensions/health_checker): Custom health checkers which use the
     `Envoy::Extensions::HealthCheckers` namespace.
   * [resolvers/](/source/extensions/resolvers): Network address resolvers which use the


### PR DESCRIPTION
*Description*:
Adds a new extension type to REPO LAYOUT as a follow up to #3161 

*Risk Level*: Low: docs only

*Testing*:
docs only, no testing

*Docs Changes*:
Update REPO LAYOUT for new grpc credentials extension type

*Release Notes*:
N/A
