### PR TITLE
Clarify in the docs matching by wildcard of the sni_domains field in listener components

### DIFF
--- a/api/envoy/api/v2/listener/listener.proto
+++ b/api/envoy/api/v2/listener/listener.proto
@@ -49,7 +49,7 @@ message Filter {
 // listener.
 message FilterChainMatch {
   // If non-empty, the SNI domain names to consider. May contain a wildcard prefix for
-  // the bottom-level domain of a domain name, e.g. ``*.example.com``. Note that ``foo.example.com`` will be matched by ``foo.example.com`` and ``*.example.com`` SNI domain names, but not by ``*oo.example.com``, ``*example.com``, ``*.com`` or ``*``.
+  // the bottom-level domain of a domain name, e.g. ``*.example.com``. Note that ``foo.example.com`` will be matched by ``foo.example.com`` and ``*.example.com`` SNI domain names, but **not** by ``*foo.example.com``, ``*oo.example.com``, ``*example.com``, ``*.com`` or ``*``.
   //
   // .. attention::
   //

--- a/api/envoy/api/v2/listener/listener.proto
+++ b/api/envoy/api/v2/listener/listener.proto
@@ -49,7 +49,10 @@ message Filter {
 // listener.
 message FilterChainMatch {
   // If non-empty, the SNI domain names to consider. May contain a wildcard prefix for
-  // the bottom-level domain of a domain name, e.g. ``*.example.com``. Note that ``foo.example.com`` will be matched by ``foo.example.com`` and ``*.example.com`` SNI domain names, but **not** by ``*foo.example.com``, ``*oo.example.com``, ``*example.com``, ``*.com`` or ``*``.
+  // the bottom-level domain of a domain name, e.g. ``*.example.com``. Note that
+  // ``foo.example.com`` will be matched by ``foo.example.com`` and ``*.example.com``
+  // SNI domain names, but **not** by ``*foo.example.com``, ``*oo.example.com``,
+  // ``*example.com``, ``*.com`` or ``*``.
   //
   // .. attention::
   //

--- a/api/envoy/api/v2/listener/listener.proto
+++ b/api/envoy/api/v2/listener/listener.proto
@@ -48,8 +48,8 @@ message Filter {
 // Specifies the match criteria for selecting a specific filter chain for a
 // listener.
 message FilterChainMatch {
-  // If non-empty, the SNI domains to consider. May contain a wildcard prefix,
-  // e.g. ``*.example.com``.
+  // If non-empty, the SNI domain names to consider. May contain a wildcard prefix for
+  // the bottom-level domain of a domain name, e.g. ``*.example.com``. Note that ``foo.example.com`` will be matched by ``foo.example.com`` and ``*.example.com`` SNI domain names, but not by ``*oo.example.com``, ``*example.com``, ``*.com`` or ``*``.
   //
   // .. attention::
   //


### PR DESCRIPTION
*title*: sni_domains: clarify in the documentation matching by a wildcard

*Description*:
According to https://github.com/envoyproxy/envoy/blob/a22159aa1274f63b1b83e56ccc4482e0a01a6d80/source/common/ssl/context_manager_impl.cc#L116

the wildcard is allowed before the first dot, it means that `www.example.com` will be matched by an SNI domain `*.example.com`, but not by `*.com` or `*`. The proposed PR changes the docs to explain it.

*Risk Level*: Low 

*Testing*:
Documentation change, no testing.

*Docs Changes*:
The PR is a docs change only.

*Release Notes*:
None.

Fixes #3363 .
