### PR TITLE
docs: clarify hc host default

### DIFF
--- a/api/envoy/api/v2/core/health_check.proto
+++ b/api/envoy/api/v2/core/health_check.proto
@@ -61,8 +61,8 @@ message HealthCheck {
 
   message HttpHealthCheck {
     // The value of the host header in the HTTP health check request. If
-    // left empty (default value), the IP on behalf of which this health check is performed will be
-    // used.
+    // left empty (default value), the name of the cluster this health check is associated
+    // with will be used.
     string host = 1;
 
     // Specifies the HTTP path that will be requested during health checking. For example


### PR DESCRIPTION
*title*: docs: clarify hc host default

*Description*:
Fixes a misleading comment, the default is actually the cluster name: https://github.com/envoyproxy/envoy/blob/master/source/common/upstream/health_checker_impl.cc#L140

*Risk Level*: Low | Medium | High
Low: Doc fix

*Testing*:
N/A

*Docs Changes*:
N/A

*Release Notes*:
N/A