### PR TITLE
Sink delegates should be non-copyable.

### DIFF
--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -89,6 +89,7 @@ envoy_cc_library(
     hdrs = ["logger.h"],
     deps = [
         ":macros",
+        ":non_copyable",
         "//include/envoy/thread:thread_interface",
     ],
 )

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -9,6 +9,7 @@
 
 #include "common/common/fmt.h"
 #include "common/common/macros.h"
+#include "common/common/non_copyable.h"
 
 #include "absl/strings/string_view.h"
 #include "fmt/ostream.h"
@@ -94,7 +95,7 @@ typedef std::shared_ptr<DelegatingLogSink> DelegatingLogSinkPtr;
  * On destruction, logging is reverted to its previous state. SinkDelegates must
  * be allocated/freed as a stack.
  */
-class SinkDelegate {
+class SinkDelegate : NonCopyable {
 public:
   explicit SinkDelegate(DelegatingLogSinkPtr log_sink);
   virtual ~SinkDelegate();


### PR DESCRIPTION
Signed-off-by: Joshua Marantz <jmarantz@google.com>

*Description*:
>I don't think it makes sense to copy a SinkDelegate, but this was not prevented, so this PR just adds a NonCopyable inheritance.

*Risk Level*: Low

*Testing*: //test/...

*Docs Changes*: N/A

*Release Notes*: N/A