### PR TITLE
stats: sanitize NULL in stat names.

### DIFF
--- a/test/common/stats/stats_impl_test.cc
+++ b/test/common/stats/stats_impl_test.cc
@@ -478,6 +478,14 @@ TEST(RawStatDataTest, Truncate) {
   alloc.free(*stat);
 }
 
+// Validate NULL-validation behavior of RawStatData.
+TEST(RawStatDataTest, NullName) {
+  HeapRawStatDataAllocator alloc;
+  const std::string null_embed_string("asdf\000dfsa", 9);
+  EXPECT_THROW_WITH_MESSAGE(alloc.alloc(null_embed_string), EnvoyException,
+                            "Stat names may not contain NULL (asdf\000dfsa)");
+}
+
 TEST(RawStatDataTest, HeapAlloc) {
   HeapRawStatDataAllocator alloc;
   RawStatData* stat_1 = alloc.alloc("ref_name");

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -266,6 +266,23 @@ TEST_F(StatsThreadLocalStoreTest, BasicScope) {
   EXPECT_CALL(*this, free(_)).Times(5);
 }
 
+// Validate that we sanitize away bad characters in the stats prefix.
+TEST_F(StatsThreadLocalStoreTest, SanitizePrefix) {
+  InSequence s;
+  store_->initializeThreading(main_thread_dispatcher_, tls_);
+
+  ScopePtr scope1 = store_->createScope(std::string("scope1:\0:foo.", 13));
+  EXPECT_CALL(*this, alloc(_));
+  Counter& c1 = scope1->counter("c1");
+  EXPECT_EQ("scope1___foo.c1", c1.name());
+
+  store_->shutdownThreading();
+  tls_.shutdownThread();
+
+  // Includes overflow stat.
+  EXPECT_CALL(*this, free(_)).Times(2);
+}
+
 TEST_F(StatsThreadLocalStoreTest, ScopeDelete) {
   InSequence s;
   store_->initializeThreading(main_thread_dispatcher_, tls_);

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5697356077989888
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5697356077989888
@@ -1,0 +1,53 @@
+static_resources {
+  clusters {
+    name: "="
+    type: LOGICAL_DNS
+    connect_timeout {
+      seconds: 1946186496
+    }
+    hosts {
+      socket_address {
+        address: "127.0.0.1"
+        port_value: 0
+      }
+    }
+    health_checks {
+      timeout {
+        nanos: 95
+      }
+      interval {
+        nanos: 95
+      }
+      unhealthy_threshold {
+      }
+      healthy_threshold {
+        value: 2147483648
+      }
+      redis_health_check {
+        key: "="
+      }
+      healthy_edge_interval {
+        nanos: 95
+      }
+    }
+    tls_context {
+      common_tls_context {
+        tls_params {
+        }
+      }
+    }
+    alt_stat_name: "\001\000\000\000\007\\\316\230"
+  }
+}
+admin {
+  access_log_path: "@"
+  address {
+    pipe {
+      path: "%"
+    }
+  }
+}
+stats_config {
+  use_all_default_tags {
+  }
+}


### PR DESCRIPTION
This addresses oss-fuzz issue 8324.

Risk Level: Low
Testing: Unit test, problematic corpus example.

Signed-off-by: Harvey Tuch <htuch@google.com>