### PR TITLE
api/docs: fix XDS_PROTOCOL.md ads example

### DIFF
--- a/api/XDS_PROTOCOL.md
+++ b/api/XDS_PROTOCOL.md
@@ -266,7 +266,9 @@ dynamic_resources:
   lds_config: {ads: {}}
   ads_config:
     api_type: GRPC
-    cluster_name: [ads_cluster]
+    grpc_services:
+      envoy_grpc:
+        cluster_name: ads_cluster
 static_resources:
   clusters:
   - name: ads_cluster

--- a/test/config/integration/server_ads.yaml
+++ b/test/config/integration/server_ads.yaml
@@ -3,7 +3,9 @@ dynamic_resources:
   cds_config: {ads: {}}
   ads_config:
     api_type: GRPC
-    cluster_name: [ads_cluster]
+    grpc_services:
+      envoy_grpc:
+        cluster_name: ads_cluster
 static_resources:
   clusters:
   - name: ads_cluster


### PR DESCRIPTION
*title*: *api/docs: fix XDS_PROTOCOL.md ads example*

*Description*:
Fixes example that was broken with the `cluster_name -> cluster_names` change. Also changed it in a test file but couldn't find if it was used anywhere.

*Risk Level*:
Low: Doc fix

*Testing*:
N/A

*Docs Changes*:
N/A

*Release Notes*:
N/A