### PR TITLE
docs: move draft status to Google gRPC only

### DIFF
--- a/api/envoy/api/v2/core/grpc_service.proto
+++ b/api/envoy/api/v2/core/grpc_service.proto
@@ -14,7 +14,6 @@ import "gogoproto/gogo.proto";
 option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: gRPC services]
-// [#proto-status: draft]
 
 // gRPC service configuration. This is used by :ref:`ApiConfigSource
 // <envoy_api_msg_core.ApiConfigSource>` and filter configurations.
@@ -26,6 +25,7 @@ message GrpcService {
     string cluster_name = 1 [(validate.rules).string.min_bytes = 1];
   }
 
+  // [#proto-status: draft]
   message GoogleGrpc {
     // The target URI when using the `Google C++ gRPC client
     // <https://github.com/grpc/grpc>`_. SSL credentials will be supplied in


### PR DESCRIPTION
The main gRPC service message is no longer draft.