### PR TITLE
server: pause rds when initializing static listeners

### DIFF
--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -53,10 +53,6 @@ void MainImpl::initialize(const envoy::config::bootstrap::v2::Bootstrap& bootstr
   const auto& listeners = bootstrap.static_resources().listeners();
   ENVOY_LOG(info, "loading {} listener(s)", listeners.size());
 
-  // Immediately pause RDS to ensure that we don't send any requests until we've
-  // subscribed to all the RDS resources. The subscriptions happen in the init callbacks,
-  // so we pause RDS until we've completed all the callbacks.
-  cluster_manager_->adsMux().pause(Config::TypeUrl::get().RouteConfiguration);
 
   for (ssize_t i = 0; i < listeners.size(); i++) {
     ENVOY_LOG(debug, "listener #{}:", i);

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -15,7 +15,6 @@
 #include "common/common/assert.h"
 #include "common/common/utility.h"
 #include "common/config/lds_json.h"
-#include "common/config/resources.h"
 #include "common/config/utility.h"
 #include "common/protobuf/utility.h"
 #include "common/ratelimit/ratelimit_impl.h"
@@ -52,8 +51,6 @@ void MainImpl::initialize(const envoy::config::bootstrap::v2::Bootstrap& bootstr
       server.localInfo(), server.accessLogManager(), server.admin());
   const auto& listeners = bootstrap.static_resources().listeners();
   ENVOY_LOG(info, "loading {} listener(s)", listeners.size());
-
-
   for (ssize_t i = 0; i < listeners.size(); i++) {
     ENVOY_LOG(debug, "listener #{}:", i);
     server.listenerManager().addOrUpdateListener(listeners[i], "", false);

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -22,6 +22,7 @@
 #include "common/common/utility.h"
 #include "common/common/version.h"
 #include "common/config/bootstrap_json.h"
+#include "common/config/resources.h"
 #include "common/config/utility.h"
 #include "common/local_info/local_info_impl.h"
 #include "common/memory/stats.h"
@@ -388,7 +389,7 @@ RunHelper::RunHelper(Event::Dispatcher& dispatcher, Upstream::ClusterManager& cm
   // this can fire immediately if all clusters have already initialized. Also note that we need
   // to guard against shutdown at two different levels since SIGTERM can come in once the run loop
   // starts.
-  cm.setInitializedCb([this, &init_manager, workers_start_cb]() {
+  cm.setInitializedCb([this, &init_manager, &cm, workers_start_cb]() {
     if (shutdown_) {
       return;
     }
@@ -401,6 +402,10 @@ RunHelper::RunHelper(Event::Dispatcher& dispatcher, Upstream::ClusterManager& cm
 
       workers_start_cb();
     });
+
+    // Now that we're execute all the init callbacks we can resume RDS
+    // as we've subscribed to all the statically defined RDS resources.
+    cm.adsMux().resume(Config::TypeUrl::get().RouteConfiguration);
   });
 }
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -394,6 +394,11 @@ RunHelper::RunHelper(Event::Dispatcher& dispatcher, Upstream::ClusterManager& cm
       return;
     }
 
+    // Pause RDS to ensure that we don't send any requests until we've
+    // subscribed to all the RDS resources. The subscriptions happen in the init callbacks,
+    // so we pause RDS until we've completed all the callbacks.
+    cm.adsMux().pause(Config::TypeUrl::get().RouteConfiguration);
+
     ENVOY_LOG(info, "all clusters initialized. initializing init manager");
     init_manager.initialize([this, workers_start_cb]() {
       if (shutdown_) {

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -132,7 +132,7 @@ ConfigHelper::ConfigHelper(const Network::Address::IpVersion version, const std:
 
   for (int i = 0; i < static_resources->clusters_size(); ++i) {
     auto* cluster = static_resources->mutable_clusters(i);
-    if (cluster->mutable_hosts(0)->has_socket_address()) {
+    if (cluster->hosts().size() > 0 && cluster->mutable_hosts(0)->has_socket_address()) {
       auto host_socket_addr = cluster->mutable_hosts(0)->mutable_socket_address();
       host_socket_addr->set_address(Network::Test::getLoopbackAddressString(version));
     }

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -494,16 +494,16 @@ TEST_P(AdsConfigIntegrationTest, EdsClusterWithAdsConfigSource) {
 // Validates that the initial xDS request batches all resources referred to in static config
 TEST_P(AdsIntegrationTest, XdsBatching) {
   config_helper_.addConfigModifier([this](envoy::config::bootstrap::v2::Bootstrap& bootstrap) {
-      bootstrap.mutable_dynamic_resources()->clear_cds_config();
-      bootstrap.mutable_dynamic_resources()->clear_lds_config();
+    bootstrap.mutable_dynamic_resources()->clear_cds_config();
+    bootstrap.mutable_dynamic_resources()->clear_lds_config();
 
-      auto static_resources = bootstrap.mutable_static_resources();
-      static_resources->add_clusters()->MergeFrom(buildCluster("eds_cluster"));
-      static_resources->add_clusters()->MergeFrom(buildCluster("eds_cluster2"));
+    auto static_resources = bootstrap.mutable_static_resources();
+    static_resources->add_clusters()->MergeFrom(buildCluster("eds_cluster"));
+    static_resources->add_clusters()->MergeFrom(buildCluster("eds_cluster2"));
 
-      static_resources->add_listeners()->MergeFrom(buildListener("rds_listener", "route_config"));
-      static_resources->add_listeners()->MergeFrom(buildListener("rds_listener2", "route_config2"));
-      });
+    static_resources->add_listeners()->MergeFrom(buildListener("rds_listener", "route_config"));
+    static_resources->add_listeners()->MergeFrom(buildListener("rds_listener2", "route_config2"));
+  });
 
   pre_worker_start_test_steps_ = [this]() {
     ads_connection_ = fake_upstreams_.back()->waitForHttpConnection(*dispatcher_);
@@ -511,7 +511,7 @@ TEST_P(AdsIntegrationTest, XdsBatching) {
     ads_stream_->startGrpcStream();
 
     EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().ClusterLoadAssignment, "",
-          {"eds_cluster2", "eds_cluster"}));
+                                        {"eds_cluster2", "eds_cluster"}));
     sendDiscoveryResponse<envoy::api::v2::ClusterLoadAssignment>(
         Config::TypeUrl::get().ClusterLoadAssignment,
         {buildClusterLoadAssignment("eds_cluster"), buildClusterLoadAssignment("eds_cluster1")},
@@ -521,7 +521,8 @@ TEST_P(AdsIntegrationTest, XdsBatching) {
                                         {"route_config2", "route_config"}));
     sendDiscoveryResponse<envoy::api::v2::RouteConfiguration>(
         Config::TypeUrl::get().RouteConfiguration,
-        {buildRouteConfig("route_config2", "eds_cluster2"), buildRouteConfig("route_config", "dummy_cluster")},
+        {buildRouteConfig("route_config2", "eds_cluster2"),
+         buildRouteConfig("route_config", "dummy_cluster")},
         "1");
   };
 

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -493,112 +493,42 @@ TEST_P(AdsConfigIntegrationTest, EdsClusterWithAdsConfigSource) {
   ads_stream_->finishGrpcStream(Grpc::Status::Ok);
 }
 
-const std::string static_resources_config = R"EOF(
-dynamic_resources:
-  ads_config:
-    api_type: GRPC
-static_resources:
-  listeners:
-  - name: dummy_listener
-    address:
-      socket_address:
-        address: 127.0.0.1
-        port_value: 0
-    filter_chains:
-      filters:
-      - name: envoy.http_connection_manager
-        config:
-          stat_prefix: listener
-          idle_timeout: 90s
-          rds:
-            config_source:
-              ads: {}
-            route_config_name: route_config
-          http_filters:
-          - name: envoy.router
-  - name: dummy_listener2
-    address:
-      socket_address:
-        address: 127.0.0.1
-        port_value: 0
-    filter_chains:
-      filters:
-      - name: envoy.http_connection_manager
-        config:
-          stat_prefix: listener
-          idle_timeout: 90s
-          rds:
-            config_source:
-              ads: {}
-            route_config_name: route_config2
-          http_filters:
-          - name: envoy.router
-  clusters:
-  - name: ads_dummy
-    connect_timeout: { seconds: 5 }
-    type: STATIC
-    hosts:
-      socket_address:
-        address: 127.0.0.1
-        port_value: 0
-    lb_policy: ROUND_ROBIN
-    http2_protocol_options: {}
-  - name: dummy_cluster
-    connect_timeout: { seconds: 5 }
-    type: EDS
-    eds_cluster_config:
-      eds_config:
-        ads: {}
-    lb_policy: ROUND_ROBIN
-    http2_protocol_options: {}
-  - name: dummy_cluster_2
-    connect_timeout: { seconds: 5 }
-    type: EDS
-    eds_cluster_config:
-      eds_config:
-        ads: {}
-    lb_policy: ROUND_ROBIN
-    http2_protocol_options: {}
-admin:
-  access_log_path: /dev/null
-  address:
-    socket_address:
-      address: 127.0.0.1
-      port_value: 0
-  )EOF";
+// Validates that the initial xDS request batches all resources referred to in static config
+TEST_P(AdsIntegrationTest, XdsBatching) {
+  config_helper_.addConfigModifier([this](envoy::config::bootstrap::v2::Bootstrap& bootstrap) {
+      bootstrap.mutable_dynamic_resources()->clear_cds_config();
+      bootstrap.mutable_dynamic_resources()->clear_lds_config();
 
-class StaticAdsIntegrationTest : public AdsIntegrationTest {
-public:
-  StaticAdsIntegrationTest() : AdsIntegrationTest(static_resources_config) {}
-};
+      auto static_resources = bootstrap.mutable_static_resources();
+      static_resources->add_clusters()->MergeFrom(buildCluster("eds_cluster"));
+      static_resources->add_clusters()->MergeFrom(buildCluster("eds_cluster2"));
 
-TEST_P(StaticAdsIntegrationTest, XdsBatching) {
-  // Validates that the initial xDS request batches all resources referred to in static config
+      static_resources->add_listeners()->MergeFrom(buildListener("rds_listener", "route_config"));
+      static_resources->add_listeners()->MergeFrom(buildListener("rds_listener2", "route_config2"));
+      });
+
   pre_worker_start_test_steps_ = [this]() {
     ads_connection_ = fake_upstreams_.back()->waitForHttpConnection(*dispatcher_);
     ads_stream_ = ads_connection_->waitForNewStream(*dispatcher_);
     ads_stream_->startGrpcStream();
 
     EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().ClusterLoadAssignment, "",
-                                        {"dummy_cluster_2", "dummy_cluster"}));
+          {"eds_cluster2", "eds_cluster"}));
     sendDiscoveryResponse<envoy::api::v2::ClusterLoadAssignment>(
         Config::TypeUrl::get().ClusterLoadAssignment,
-        {buildClusterLoadAssignment("dummy_cluster"), buildClusterLoadAssignment("dummy_cluster1")},
+        {buildClusterLoadAssignment("eds_cluster"), buildClusterLoadAssignment("eds_cluster1")},
         "1");
 
     EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().RouteConfiguration, "",
                                         {"route_config2", "route_config"}));
     sendDiscoveryResponse<envoy::api::v2::RouteConfiguration>(
         Config::TypeUrl::get().RouteConfiguration,
-        {buildRouteConfig("route", "dummy_cluster"), buildRouteConfig("route1", "dummy_cluster")},
+        {buildRouteConfig("route_config2", "eds_cluster2"), buildRouteConfig("route_config", "dummy_cluster")},
         "1");
   };
 
   initialize();
 }
-
-INSTANTIATE_TEST_CASE_P(IpVersionsClientType, StaticAdsIntegrationTest,
-                        GRPC_CLIENT_INTEGRATION_PARAMS);
 
 } // namespace
 } // namespace Envoy

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -60,8 +60,6 @@ admin:
 class AdsIntegrationTest : public HttpIntegrationTest, public Grpc::GrpcClientIntegrationParamTest {
 public:
   AdsIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP2, ipVersion(), config) {}
-  AdsIntegrationTest(const std::string& config)
-      : HttpIntegrationTest(Http::CodecClient::Type::HTTP2, ipVersion(), config) {}
 
   void TearDown() override {
     test_server_.reset();


### PR DESCRIPTION
*title*: server: pause rds when initializing static listeners

*Description*:
In order to prevent RDS requests from being fired up before we know all
the route configurations we care about, pause RDS while we initialize
all the listeners from static config. This matches what we do during LDS
update.

We pause the RDS updates over ADS immediately, then once we know that all 
the init callbacks have been completed we resume RDS updates. This was 
necessary because the RDS subscriptions happen in the init callbacks. 

*Risk Level*: 
Low: Small bug fix

*Testing*:
Manually verified that it fixes the repro case from #3399

*Docs Changes*:
N/A

*Release Notes*:
N/A

Fixes #3399 
