### PR TITLE
util: Convert to using absl mutexes and Thread::LockGuard in source/..., adding annotations, where those are straightforward.

### DIFF
--- a/include/envoy/thread/thread.h
+++ b/include/envoy/thread/thread.h
@@ -74,7 +74,7 @@ public:
   TryLockGuard(BasicLockable& lock) : lock_(lock) {}
 
   /**
-   * Destruction of the DeferredLockGuard unlocks the lock, if it was locked.
+   * Destruction of the TryLockGuard unlocks the lock, if it was locked.
    */
   ~TryLockGuard() DISABLE_TRYLOCKGUARD_ANNOTATION(UNLOCK_FUNCTION()) {
     if (is_locked_) {

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -162,14 +162,14 @@ void DispatcherImpl::run(RunType type) {
 }
 
 void DispatcherImpl::runPostCallbacks() {
-  Thread::LockGuard lock(post_lock_);
+  std::unique_lock<Thread::BasicLockable> lock(post_lock_);
   while (!post_callbacks_.empty()) {
     std::function<void()> callback = post_callbacks_.front();
     post_callbacks_.pop_front();
 
-    post_lock_.unlock();
+    lock.unlock();
     callback();
-    post_lock_.lock();
+    lock.lock();
   }
 }
 

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -162,13 +162,17 @@ void DispatcherImpl::run(RunType type) {
 }
 
 void DispatcherImpl::runPostCallbacks() {
-  for (std::function<void()> callback; true; callback()) {
-    Thread::LockGuard lock(post_lock_);
-    if (post_callbacks_.empty()) {
-      return;
+  std::function<void()> callback;
+  while (true) {
+    {
+      Thread::LockGuard lock(post_lock_);
+      if (post_callbacks_.empty()) {
+        return;
+      }
+      callback = post_callbacks_.front();
+      post_callbacks_.pop_front();
     }
-    callback = post_callbacks_.front();
-    post_callbacks_.pop_front();
+    callback();
   }
 }
 

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -162,17 +162,13 @@ void DispatcherImpl::run(RunType type) {
 }
 
 void DispatcherImpl::runPostCallbacks() {
-  std::function<void()> callback;
-  while (true) {
-    {
-      Thread::LockGuard lock(post_lock_);
-      if (post_callbacks_.empty()) {
-        return;
-      }
-      callback = post_callbacks_.front();
-      post_callbacks_.pop_front();
+  for (std::function<void()> callback; true; callback()) {
+    Thread::LockGuard lock(post_lock_);
+    if (post_callbacks_.empty()) {
+      return;
     }
-    callback();
+    callback = post_callbacks_.front();
+    post_callbacks_.pop_front();
   }
 }
 

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -139,7 +139,7 @@ SignalEventPtr DispatcherImpl::listenForSignal(int signal_num, SignalCb cb) {
 void DispatcherImpl::post(std::function<void()> callback) {
   bool do_post;
   {
-    std::unique_lock<std::mutex> lock(post_lock_);
+    Thread::LockGuard lock(post_lock_);
     do_post = post_callbacks_.empty();
     post_callbacks_.push_back(callback);
   }
@@ -162,14 +162,14 @@ void DispatcherImpl::run(RunType type) {
 }
 
 void DispatcherImpl::runPostCallbacks() {
-  std::unique_lock<std::mutex> lock(post_lock_);
+  Thread::LockGuard lock(post_lock_);
   while (!post_callbacks_.empty()) {
     std::function<void()> callback = post_callbacks_.front();
     post_callbacks_.pop_front();
 
-    lock.unlock();
+    post_lock_.unlock();
     callback();
-    lock.lock();
+    post_lock_.lock();
   }
 }
 

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -75,8 +75,8 @@ private:
   std::vector<DeferredDeletablePtr> to_delete_1_;
   std::vector<DeferredDeletablePtr> to_delete_2_;
   std::vector<DeferredDeletablePtr>* current_to_delete_;
-  std::mutex post_lock_;
-  std::list<std::function<void()>> post_callbacks_;
+  Thread::MutexBasicLockable post_lock_;
+  std::list<std::function<void()>> post_callbacks_ GUARDED_BY(post_lock_);
   bool deferred_deleting_{};
 };
 

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -76,7 +76,8 @@ private:
   std::vector<DeferredDeletablePtr> to_delete_2_;
   std::vector<DeferredDeletablePtr>* current_to_delete_;
   Thread::MutexBasicLockable post_lock_;
-  std::list<std::function<void()>> post_callbacks_ GUARDED_BY(post_lock_);
+  std::list<std::function<void()>> post_callbacks_; // GUARDED_BY(post_lock_) fails
+                                                    // due to limitations in clang's analysis.
   bool deferred_deleting_{};
 };
 

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -76,8 +76,7 @@ private:
   std::vector<DeferredDeletablePtr> to_delete_2_;
   std::vector<DeferredDeletablePtr>* current_to_delete_;
   Thread::MutexBasicLockable post_lock_;
-  std::list<std::function<void()>> post_callbacks_; // GUARDED_BY(post_lock_) fails
-                                                    // due to limitations in clang's analysis.
+  std::list<std::function<void()>> post_callbacks_ GUARDED_BY(post_lock_);
   bool deferred_deleting_{};
 };
 

--- a/source/common/filesystem/filesystem_impl.cc
+++ b/source/common/filesystem/filesystem_impl.cc
@@ -168,7 +168,7 @@ void FileImpl::doWrite(Buffer::Instance& buffer) {
 void FileImpl::flushThreadFunc() {
 
   while (true) {
-    std::unique_ptr<Thread::LockGuard> flush_lock;
+    std::unique_lock<Thread::BasicLockable> flush_lock;
 
     {
       std::unique_lock<std::mutex> write_lock(write_lock_);
@@ -183,7 +183,7 @@ void FileImpl::flushThreadFunc() {
         return;
       }
 
-      flush_lock = std::make_unique<Thread::LockGuard>(flush_lock_);
+      flush_lock = std::unique_lock<Thread::BasicLockable>(flush_lock_);
       ASSERT(flush_buffer_.length() > 0);
       about_to_write_buffer_.move(flush_buffer_);
       ASSERT(flush_buffer_.length() == 0);
@@ -207,7 +207,7 @@ void FileImpl::flushThreadFunc() {
 }
 
 void FileImpl::flush() {
-  std::unique_ptr<Thread::LockGuard> flush_buffer_lock;
+  std::unique_lock<Thread::BasicLockable> flush_buffer_lock;
 
   {
     std::lock_guard<std::mutex> write_lock(write_lock_);
@@ -217,7 +217,7 @@ void FileImpl::flush() {
     // flush_buffer_ to about_to_write_buffer_, has unlocked write_lock_,
     // but has not yet completed doWrite(). This would allow flush() to
     // return before the pending data has actually been written to disk.
-    flush_buffer_lock = std::make_unique<Thread::LockGuard>(flush_lock_);
+    flush_buffer_lock = std::unique_lock<Thread::BasicLockable>(flush_lock_);
 
     if (flush_buffer_.length() == 0) {
       return;

--- a/source/common/filesystem/filesystem_impl.cc
+++ b/source/common/filesystem/filesystem_impl.cc
@@ -168,7 +168,7 @@ void FileImpl::doWrite(Buffer::Instance& buffer) {
 void FileImpl::flushThreadFunc() {
 
   while (true) {
-    std::unique_lock<std::mutex> flush_lock;
+    std::unique_ptr<Thread::LockGuard> flush_lock;
 
     {
       std::unique_lock<std::mutex> write_lock(write_lock_);
@@ -183,7 +183,7 @@ void FileImpl::flushThreadFunc() {
         return;
       }
 
-      flush_lock = std::unique_lock<std::mutex>(flush_lock_);
+      flush_lock = std::make_unique<Thread::LockGuard>(flush_lock_);
       ASSERT(flush_buffer_.length() > 0);
       about_to_write_buffer_.move(flush_buffer_);
       ASSERT(flush_buffer_.length() == 0);
@@ -207,7 +207,7 @@ void FileImpl::flushThreadFunc() {
 }
 
 void FileImpl::flush() {
-  std::unique_lock<std::mutex> flush_buffer_lock;
+  std::unique_ptr<Thread::LockGuard> flush_buffer_lock;
 
   {
     std::lock_guard<std::mutex> write_lock(write_lock_);
@@ -217,7 +217,7 @@ void FileImpl::flush() {
     // flush_buffer_ to about_to_write_buffer_, has unlocked write_lock_,
     // but has not yet completed doWrite(). This would allow flush() to
     // return before the pending data has actually been written to disk.
-    flush_buffer_lock = std::unique_lock<std::mutex>(flush_lock_);
+    flush_buffer_lock = std::make_unique<Thread::LockGuard>(flush_lock_);
 
     if (flush_buffer_.length() == 0) {
       return;

--- a/source/common/filesystem/filesystem_impl.h
+++ b/source/common/filesystem/filesystem_impl.h
@@ -116,18 +116,18 @@ private:
   //    1) write_lock_
   //    2) flush_lock_
   //    3) file_lock_
-  Thread::BasicLockable& file_lock_; // This lock is used only by the flush thread when writing
-                                     // to disk. This is used to make sure that file blocks do
-                                     // not get interleaved by multiple processes writing to
-                                     // the same file during hot-restart.
-  std::mutex flush_lock_;            // This lock is used to prevent simulataneous flushes from
-                                     // the flush thread and a syncronous flush. This protects
-                                     // concurrent access to the about_to_write_buffer_, fd_,
-                                     // and all other data used during flushing and file
-                                     // re-opening.
-  std::mutex write_lock_;            // The lock is used when filling the flush buffer. It allows
-                                     // multiple threads to write to the same file at relatively
-                                     // high performance. It is always local to the process.
+  Thread::BasicLockable& file_lock_;      // This lock is used only by the flush thread when writing
+                                          // to disk. This is used to make sure that file blocks do
+                                          // not get interleaved by multiple processes writing to
+                                          // the same file during hot-restart.
+  Thread::MutexBasicLockable flush_lock_; // This lock is used to prevent simulataneous flushes from
+                                          // the flush thread and a syncronous flush. This protects
+                                          // concurrent access to the about_to_write_buffer_, fd_,
+                                          // and all other data used during flushing and file
+                                          // re-opening.
+  std::mutex write_lock_; // The lock is used when filling the flush buffer. It allows
+                          // multiple threads to write to the same file at relatively
+                          // high performance. It is always local to the process.
   Thread::ThreadPtr flush_thread_;
   std::condition_variable_any flush_event_;
   std::atomic<bool> flush_thread_exit_{};

--- a/source/common/filesystem/filesystem_impl.h
+++ b/source/common/filesystem/filesystem_impl.h
@@ -132,9 +132,15 @@ private:
   std::condition_variable_any flush_event_;
   std::atomic<bool> flush_thread_exit_{};
   std::atomic<bool> reopen_file_{};
+  // TODO(jmarantz): this should be GUARDED_BY(write_lock_) but this will have to wait until
+  // absl::CondVar is integrated into the abstraction layer, so we can use an annoated mutex
+  // class.
   Buffer::OwnedImpl flush_buffer_; // This buffer is used by multiple threads. It gets filled and
                                    // then flushed either when max size is reached or when a timer
                                    // fires.
+  // TODO(jmarantz): this should be GUARDED_BY(flush_lock_) but the analysis cannot poke through
+  // the std::make_unique assignment. I do not believe it's possible to annotate this properly now
+  // due to limitations in the clang thread annotation analysis.
   Buffer::OwnedImpl about_to_write_buffer_; // This buffer is used only by the flush thread. Data
                                             // is moved from flush_buffer_ under lock, and then
                                             // the lock is released so that flush_buffer_ can

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -90,7 +90,7 @@ private:
   histogram_t* cumulative_histogram_;
   HistogramStatisticsImpl interval_statistics_;
   HistogramStatisticsImpl cumulative_statistics_;
-  mutable std::mutex merge_lock_;
+  mutable Thread::MutexBasicLockable merge_lock_;
   std::list<TlsHistogramSharedPtr> tls_histograms_;
 };
 
@@ -257,8 +257,8 @@ private:
   RawStatDataAllocator& alloc_;
   Event::Dispatcher* main_thread_dispatcher_{};
   ThreadLocal::SlotPtr tls_;
-  mutable std::mutex lock_;
-  std::unordered_set<ScopeImpl*> scopes_;
+  mutable Thread::MutexBasicLockable lock_;
+  std::unordered_set<ScopeImpl*> scopes_ GUARDED_BY(lock_);
   ScopePtr default_scope_;
   std::list<std::reference_wrapper<Sink>> timer_sinks_;
   TagProducerPtr tag_producer_;

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -82,7 +82,7 @@ public:
   }
 
 private:
-  bool usedLockHeld() const;
+  bool usedLockHeld() const EXCLUSIVE_LOCKS_REQUIRED(merge_lock_);
 
   Store& parent_;
   TlsScope& tls_scope_;
@@ -91,7 +91,7 @@ private:
   HistogramStatisticsImpl interval_statistics_;
   HistogramStatisticsImpl cumulative_statistics_;
   mutable Thread::MutexBasicLockable merge_lock_;
-  std::list<TlsHistogramSharedPtr> tls_histograms_;
+  std::list<TlsHistogramSharedPtr> tls_histograms_ GUARDED_BY(merge_lock_);
 };
 
 typedef std::shared_ptr<ParentHistogramImpl> ParentHistogramImplSharedPtr;

--- a/source/server/guarddog_impl.h
+++ b/source/server/guarddog_impl.h
@@ -47,7 +47,7 @@ public:
   int loopIntervalForTest() const { return loop_interval_.count(); }
   void forceCheckForTest() {
     exit_event_.notify_all();
-    std::lock_guard<std::mutex> guard(exit_lock_);
+    std::lock_guard<Thread::MutexBasicLockable> guard(exit_lock_);
     force_checked_event_.wait(exit_lock_);
   }
 
@@ -83,10 +83,10 @@ private:
   const std::chrono::milliseconds loop_interval_;
   Stats::Counter& watchdog_miss_counter_;
   Stats::Counter& watchdog_megamiss_counter_;
-  std::vector<WatchedDog> watched_dogs_;
-  std::mutex wd_lock_;
+  std::vector<WatchedDog> watched_dogs_ GUARDED_BY(wd_lock_);
+  Thread::MutexBasicLockable wd_lock_;
   Thread::ThreadPtr thread_;
-  std::mutex exit_lock_;
+  Thread::MutexBasicLockable exit_lock_;
   std::condition_variable_any exit_event_;
   bool run_thread_;
   std::condition_variable_any force_checked_event_;

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -121,7 +121,7 @@ HotRestartImpl::HotRestartImpl(Options& options)
   {
     // We must hold the stat lock when attaching to an existing memory segment
     // because it might be actively written to while we sanityCheck it.
-    std::unique_lock<Thread::BasicLockable> lock(stat_lock_);
+    Thread::LockGuard lock(stat_lock_);
     stats_set_.reset(new RawStatDataSet(stats_set_options_, options.restartEpoch() == 0,
                                         shmem_.stats_set_data_));
   }


### PR DESCRIPTION
Signed-off-by: Joshua Marantz <jmarantz@google.com>

*Description*:
>There are some mutex/condvar interactions and other cases that go beyond the abstractions currently in include/envoy/thread/thread.h.  This does not address those, but just tackles simple substitutions of equivalent semantics (with added annotations).

*Risk Level*: Low

*Testing*: //test/...

*Docs Changes*: N/A
*Release Notes*: N/A