### PR TITLE
options: Don't require a modifiable argv when parsing command-line options

### DIFF
--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -93,7 +93,7 @@ bool MainCommonBase::run() {
   NOT_REACHED;
 }
 
-MainCommon::MainCommon(int argc, char** argv)
+MainCommon::MainCommon(int argc, const char* const* argv)
     : options_(argc, argv, &MainCommon::hotRestartVersion, spdlog::level::info), base_(options_) {}
 
 std::string MainCommon::hotRestartVersion(uint64_t max_num_stats, uint64_t max_stat_name_len,

--- a/source/exe/main_common.h
+++ b/source/exe/main_common.h
@@ -40,7 +40,7 @@ protected:
 
 class MainCommon {
 public:
-  MainCommon(int argc, char** argv);
+  MainCommon(int argc, const char* const* argv);
   bool run() { return base_.run(); }
 
   static std::string hotRestartVersion(uint64_t max_num_stats, uint64_t max_stat_name_len,

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -30,7 +30,8 @@
 #endif
 
 namespace Envoy {
-OptionsImpl::OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_restart_version_cb,
+OptionsImpl::OptionsImpl(int argc, const char* const* argv,
+                         const HotRestartVersionCb& hot_restart_version_cb,
                          spdlog::level::level_enum default_log_level) {
   std::string log_levels_string = "Log levels: ";
   for (size_t i = 0; i < ARRAY_SIZE(spdlog::level::level_names); i++) {

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -27,7 +27,7 @@ public:
    * @throw MalformedArgvException if something is wrong with the arguments (invalid flag or flag
    *        value). The caller should call exit(1) after any necessary cleanup.
    */
-  OptionsImpl(int argc, char** argv, const HotRestartVersionCb& hot_restart_version_cb,
+  OptionsImpl(int argc, const char* const* argv, const HotRestartVersionCb& hot_restart_version_cb,
               spdlog::level::level_enum default_log_level);
 
   // Setters for option fields. These are not part of the Options interface.

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -64,7 +64,7 @@ public:
     return getpid() * four_digit_prime + random_generator_.random() % four_digit_prime;
   }
 
-  char** argv() { return const_cast<char**>(&argv_[0]); }
+  const char* const* argv() { return &argv_[0]; }
   int argc() { return argv_.size() - 1; }
 
   // Adds an argument, assuring that argv remains null-terminated.


### PR DESCRIPTION
Signed-off-by: Joshua Marantz <jmarantz@google.com>

*Description*:
>When invoking Envoy from another infrastructure, the argv may be formulated programmatically, e.g. from std::string or other non-modifiable sources. Currently const_casts are required, but really OptionsImpl never modifies argv, so it shouldn't take a `char**`.  The exact type of `const char* const*` matches that required by underlying parsing library `TCLAP::CmdLine`.

*Risk Level*: Low
*Testing*: /test/...
*Docs Changes*: N/A
*Release Notes*: N/A