### PR TITLE
tracing: Fix propagation for Jaeger native example.

### DIFF
--- a/examples/front-proxy/service.py
+++ b/examples/front-proxy/service.py
@@ -10,11 +10,16 @@ app = Flask(__name__)
 TRACE_HEADERS_TO_PROPAGATE = [
     'X-Ot-Span-Context',
     'X-Request-Id',
+
+    # Zipkin headers
     'X-B3-TraceId',
     'X-B3-SpanId',
     'X-B3-ParentSpanId',
     'X-B3-Sampled',
-    'X-B3-Flags'
+    'X-B3-Flags',
+
+    # Jaeger header (for native client)
+    "uber-trace-id"
 ]
 
 @app.route('/service/<service_number>')


### PR DESCRIPTION
Signed-off-by: Ryan Burn <ryan.burn@gmail.com>
*Description*:
Sets up forwarding for Jaeger's [native header](https://www.jaegertracing.io/docs/client-libraries/#trace-span-identity), so that the sandbox example will properly connect the spans.

*Risk Level*: Low 
