### PR TITLE
config_verify: Fixed crash when config processing fails.

### DIFF
--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -46,7 +46,7 @@ ValidationInstance::ValidationInstance(Options& options,
   } catch (const EnvoyException& e) {
     ENVOY_LOG(critical, "error initializing configuration '{}': {}", options.configPath(),
               e.what());
-    thread_local_.shutdownThread();
+    shutdown();
     throw;
   }
 }

--- a/test/config_test/example_configs_test_setup.sh
+++ b/test/config_test/example_configs_test_setup.sh
@@ -5,3 +5,6 @@ set -e
 DIR="$TEST_TMPDIR"/test/config_test
 mkdir -p "$DIR"
 tar -xvf "$TEST_RUNDIR"/configs/example_configs.tar -C "$DIR"
+
+# Extract the content of tar file, find all config files and save their names.
+tar -tf "$TEST_RUNDIR"/configs/example_configs.tar  | grep "yaml\|json" > "$DIR"/all_config_files.txt

--- a/test/config_test/example_configs_test_setup.sh
+++ b/test/config_test/example_configs_test_setup.sh
@@ -7,4 +7,5 @@ mkdir -p "$DIR"
 tar -xvf "$TEST_RUNDIR"/configs/example_configs.tar -C "$DIR"
 
 # Extract the content of tar file, find all config files and save their names.
-tar -tf "$TEST_RUNDIR"/configs/example_configs.tar  | grep "yaml\|json" > "$DIR"/all_config_files.txt
+mkdir -p "$DIR"/test_out
+tar -tf "$TEST_RUNDIR"/configs/example_configs.tar  | grep "yaml\|json" > "$DIR"/test_out/all_config_files.txt

--- a/test/config_test/example_configs_test_setup.sh
+++ b/test/config_test/example_configs_test_setup.sh
@@ -5,7 +5,3 @@ set -e
 DIR="$TEST_TMPDIR"/test/config_test
 mkdir -p "$DIR"
 tar -xvf "$TEST_RUNDIR"/configs/example_configs.tar -C "$DIR"
-
-# Extract the content of tar file, find all config files and save their names.
-mkdir -p "$DIR"/test_out
-tar -tf "$TEST_RUNDIR"/configs/example_configs.tar  | grep "yaml\|json" > "$DIR"/test_out/all_config_files.txt

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -39,7 +39,7 @@ public:
     SetupTestDirectory();
 
     std::string all_file_names =
-        TestEnvironment::readFileToStringForTest(directory_ + "all_config_files.txt");
+        TestEnvironment::readFileToStringForTest(directory_ + "test_out/all_config_files.txt");
     std::vector<std::string> files;
     // all_config_files.txt contains a list of all config files from tar file created by
     // example_configs_test_setup.sh Names of the files are separated by EOL. Tokenize those  names

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "server/config_validation/server.h"
 
 #include "test/integration/server.h"
@@ -11,22 +13,59 @@ namespace Server {
 // Test param is the path to the config file to validate.
 class ValidationServerTest : public testing::TestWithParam<std::string> {
 public:
-  static void SetUpTestCase() {
+  static void SetupTestDirectory() {
     TestEnvironment::exec(
         {TestEnvironment::runfilesPath("test/config_test/example_configs_test_setup.sh")});
     directory_ = TestEnvironment::temporaryDirectory() + "/test/config_test/";
   }
 
+  static void SetUpTestCase() { SetupTestDirectory(); }
+
 protected:
   ValidationServerTest() : options_(directory_ + GetParam()) {}
 
   static std::string directory_;
-
   testing::NiceMock<MockOptions> options_;
   TestComponentFactory component_factory_;
 };
 
 std::string ValidationServerTest::directory_ = "";
+
+// ValidationServerTest_1 is created only to run different set of parameterized
+// tests than set of tests for ValidationServerTest.
+class ValidationServerTest_1 : public ValidationServerTest {
+public:
+  static const std::vector<std::string> GetAllConfigFiles() {
+    SetupTestDirectory();
+
+    std::string all_file_names =
+        TestEnvironment::readFileToStringForTest(directory_ + "all_config_files.txt");
+    std::vector<std::string> files;
+    // all_config_files.txt contains a list of all config files from tar file created by
+    // example_configs_test_setup.sh Names of the files are separated by EOL. Tokenize those  names
+    // and put them into a std container.
+    size_t pos = 0;
+    size_t prev_pos = pos;
+    while (pos != std::string::npos) {
+      pos = all_file_names.find('\n', pos);
+      if (pos != std::string::npos) {
+        files.emplace_back(all_file_names.substr(prev_pos, pos - prev_pos));
+        pos += 1;
+        prev_pos = pos;
+      } else {
+        // last item. Process it if not empty line.
+        if (prev_pos < all_file_names.length()) {
+          files.emplace_back(all_file_names.substr(prev_pos));
+        }
+      }
+    }
+    // Make sure that reading file with config file names and tokenizing was successful.
+    // If something went wrong, files container will be empty and parameterized tests will not be
+    // instantiated but there will be no warning.
+    ASSERT(!files.empty());
+    return files;
+  }
+};
 
 TEST_P(ValidationServerTest, Validate) {
   EXPECT_TRUE(
@@ -41,6 +80,16 @@ INSTANTIATE_TEST_CASE_P(ValidConfigs, ValidationServerTest,
                         ::testing::Values("front-envoy.yaml", "google_com_proxy.json",
                                           "google_com_proxy.yaml", "google_com_proxy.v2.yaml",
                                           "s2s-grpc-envoy.yaml", "service-envoy.yaml"));
+
+// Just make sure that all configs can be injested without a crash. Processing of config files
+// may not be successful, but there should be no crash.
+TEST_P(ValidationServerTest_1, RunWithoutCrash) {
+  validateConfig(options_, Network::Address::InstanceConstSharedPtr(), component_factory_);
+  SUCCEED();
+}
+
+INSTANTIATE_TEST_CASE_P(AllConfigs, ValidationServerTest_1,
+                        ::testing::ValuesIn(ValidationServerTest_1::GetAllConfigFiles()));
 
 } // namespace Server
 } // namespace Envoy

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -38,31 +38,12 @@ public:
   static const std::vector<std::string> GetAllConfigFiles() {
     SetupTestDirectory();
 
-    std::string all_file_names =
-        TestEnvironment::readFileToStringForTest(directory_ + "test_out/all_config_files.txt");
-    std::vector<std::string> files;
-    // all_config_files.txt contains a list of all config files from tar file created by
-    // example_configs_test_setup.sh Names of the files are separated by EOL. Tokenize those  names
-    // and put them into a std container.
-    size_t pos = 0;
-    size_t prev_pos = pos;
-    while (pos != std::string::npos) {
-      pos = all_file_names.find('\n', pos);
-      if (pos != std::string::npos) {
-        files.emplace_back(all_file_names.substr(prev_pos, pos - prev_pos));
-        pos += 1;
-        prev_pos = pos;
-      } else {
-        // last item. Process it if not empty line.
-        if (prev_pos < all_file_names.length()) {
-          files.emplace_back(all_file_names.substr(prev_pos));
-        }
-      }
+    auto files = TestUtility::listFiles(ValidationServerTest::directory_, false);
+
+    // Strip directory part. options_ adds it for each test.
+    for (std::vector<std::string>::iterator it = files.begin(); it != files.end(); it++) {
+      (*it) = it->substr(directory_.length() + 1);
     }
-    // Make sure that reading file with config file names and tokenizing was successful.
-    // If something went wrong, files container will be empty and parameterized tests will not be
-    // instantiated but there will be no warning.
-    ASSERT(!files.empty());
     return files;
   }
 };
@@ -90,6 +71,5 @@ TEST_P(ValidationServerTest_1, RunWithoutCrash) {
 
 INSTANTIATE_TEST_CASE_P(AllConfigs, ValidationServerTest_1,
                         ::testing::ValuesIn(ValidationServerTest_1::GetAllConfigFiles()));
-
 } // namespace Server
 } // namespace Envoy

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -62,7 +62,7 @@ INSTANTIATE_TEST_CASE_P(ValidConfigs, ValidationServerTest,
                                           "google_com_proxy.yaml", "google_com_proxy.v2.yaml",
                                           "s2s-grpc-envoy.yaml", "service-envoy.yaml"));
 
-// Just make sure that all configs can be injested without a crash. Processing of config files
+// Just make sure that all configs can be ingested without a crash. Processing of config files
 // may not be successful, but there should be no crash.
 TEST_P(ValidationServerTest_1, RunWithoutCrash) {
   validateConfig(options_, Network::Address::InstanceConstSharedPtr(), component_factory_);


### PR DESCRIPTION
*Description*:
When processing of a config file failed in config verify mode, it triggered incorrect shutdown routine and ASSERT failed.
Added parameterized unit test to test all example config files. Processing of config files may fail, but it should not cause crash. The parameterized test automatically picks all example config files.

*Risk Level*: 
Low: Change affects only config validation mode and unit tests.

*Testing*:
Added parameterized test to test all example config files.

*Docs Changes*:
No

*Release Notes*:
No

Fixes: #3389