### PR TITLE
tools: apply whitespace checks to .proto files

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -13,8 +13,8 @@ import traceback
 
 EXCLUDED_PREFIXES = ("./generated/", "./thirdparty/", "./build", "./.git/",
                      "./bazel-", "./bazel/external", "./.cache")
-SUFFIXES = (".cc", ".h", "BUILD", ".md", ".rst")
-DOCS_SUFFIX = (".md", ".rst")
+SUFFIXES = (".cc", ".h", "BUILD", ".md", ".rst", ".proto")
+DOCS_SUFFIX = (".md", ".rst", ".proto")
 
 # Files in these paths can make reference to protobuf stuff directly
 GOOGLE_PROTOBUF_WHITELIST = ('ci/prebuilt', 'source/common/protobuf', 'api/test')


### PR DESCRIPTION
*Description*:
makes sure proto files don't have overenthusiastic spaces

*Risk Level*: n/a
*Testing*: manually added whitespace.
*Docs Changes*: n/a
*Release Notes*: n/a
