### PR TITLE
router: make IP hash policy ignore downstream port

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -72,6 +72,8 @@ Version history
   already been proxied downstream when the timeout occurs. Previously, the response would be reset 
   leading to either an HTTP/2 reset or an HTTP/1 closed connection and a partial response. Now, the 
   timeout will be ignored and the response will continue to proxy up to the global request timeout. 
+* router: changed the behavior of :ref:`source IP routing <envoy_api_field_route.RouteAction.HashPolicy.ConnectionProperties.source_ip>`
+  to ignore the source port.
 * sockets: added :ref:`capture transport socket extension <operations_traffic_capture>` to support
   recording plain text traffic and PCAP generation.
 * sockets: added `IP_FREEBIND` socket option support for :ref:`listeners

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -310,17 +310,17 @@ public:
       AddCookieCallback;
 
   /**
-   * @param downstream_address contains the address of the connected client host, or an
-   * empty string if the request is initiated from within this host
+   * @param downstream_address is the address of the connected client host, or nullptr if the
+   * request is initiated from within this host
    * @param headers stores the HTTP headers for the stream
    * @param add_cookie is called to add a set-cookie header on the reply sent to the downstream
    * host
    * @return absl::optional<uint64_t> an optional hash value to route on. A hash value might not be
    * returned if for example the specified HTTP header does not exist.
    */
-  virtual absl::optional<uint64_t> generateHash(const std::string& downstream_address,
-                                                const Http::HeaderMap& headers,
-                                                AddCookieCallback add_cookie) const PURE;
+  virtual absl::optional<uint64_t>
+  generateHash(const Network::Address::Instance* downstream_address, const Http::HeaderMap& headers,
+               AddCookieCallback add_cookie) const PURE;
 };
 
 class MetadataMatchCriterion {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -222,14 +222,14 @@ public:
                      hash_policy);
 
   // Router::HashPolicy
-  absl::optional<uint64_t> generateHash(const std::string& downstream_addr,
+  absl::optional<uint64_t> generateHash(const Network::Address::Instance* downstream_addr,
                                         const Http::HeaderMap& headers,
                                         const AddCookieCallback add_cookie) const override;
 
   class HashMethod {
   public:
     virtual ~HashMethod() {}
-    virtual absl::optional<uint64_t> evaluate(const std::string& downstream_addr,
+    virtual absl::optional<uint64_t> evaluate(const Network::Address::Instance* downstream_addr,
                                               const Http::HeaderMap& headers,
                                               const AddCookieCallback add_cookie) const PURE;
   };

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -155,7 +155,7 @@ public:
       auto hash_policy = route_entry_->hashPolicy();
       if (hash_policy) {
         return hash_policy->generateHash(
-            callbacks_->requestInfo().downstreamRemoteAddress()->asString(), *downstream_headers_,
+            callbacks_->requestInfo().downstreamRemoteAddress().get(), *downstream_headers_,
             [this](const std::string& key, std::chrono::seconds max_age) {
               return addDownstreamSetCookie(key, max_age);
             });
@@ -376,5 +376,5 @@ private:
                                  Upstream::ResourcePriority priority) override;
 };
 
-} // Router
+} // namespace Router
 } // namespace Envoy

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -1280,13 +1280,14 @@ TEST_F(RouterMatcherHashPolicyTest, HashHeaders) {
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
-    EXPECT_FALSE(route->routeEntry()->hashPolicy()->generateHash("", headers, add_cookie_nop_));
+    EXPECT_FALSE(
+        route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie_nop_));
   }
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     headers.addCopy("foo_header", "bar");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
-    EXPECT_TRUE(route->routeEntry()->hashPolicy()->generateHash("", headers, add_cookie_nop_));
+    EXPECT_TRUE(route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie_nop_));
   }
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/bar", "GET");
@@ -1307,21 +1308,23 @@ TEST_F(RouterMatcherCookieHashPolicyTest, NoTtl) {
     // With no cookie, no hash is generated.
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
-    EXPECT_FALSE(route->routeEntry()->hashPolicy()->generateHash("", headers, add_cookie_nop_));
+    EXPECT_FALSE(
+        route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie_nop_));
   }
   {
     // With no matching cookie, no hash is generated.
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     headers.addCopy("Cookie", "choco=late; su=gar");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
-    EXPECT_FALSE(route->routeEntry()->hashPolicy()->generateHash("", headers, add_cookie_nop_));
+    EXPECT_FALSE(
+        route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie_nop_));
   }
   {
     // Matching cookie produces a valid hash.
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     headers.addCopy("Cookie", "choco=late; hash=brown");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
-    EXPECT_TRUE(route->routeEntry()->hashPolicy()->generateHash("", headers, add_cookie_nop_));
+    EXPECT_TRUE(route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie_nop_));
   }
   {
     // The hash policy is per-route.
@@ -1338,13 +1341,15 @@ TEST_F(RouterMatcherCookieHashPolicyTest, DifferentCookies) {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     headers.addCopy("Cookie", "hash=brown");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
-    hash_1 = route->routeEntry()->hashPolicy()->generateHash("", headers, add_cookie_nop_).value();
+    hash_1 =
+        route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie_nop_).value();
   }
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     headers.addCopy("Cookie", "hash=green");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
-    hash_2 = route->routeEntry()->hashPolicy()->generateHash("", headers, add_cookie_nop_).value();
+    hash_2 =
+        route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie_nop_).value();
   }
   EXPECT_NE(hash_1, hash_2);
 }
@@ -1362,20 +1367,20 @@ TEST_F(RouterMatcherCookieHashPolicyTest, TtlSet) {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
     EXPECT_CALL(mock_cookie_cb, Call("hash", 42));
-    EXPECT_TRUE(route->routeEntry()->hashPolicy()->generateHash("", headers, add_cookie));
+    EXPECT_TRUE(route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie));
   }
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     headers.addCopy("Cookie", "choco=late; su=gar");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
     EXPECT_CALL(mock_cookie_cb, Call("hash", 42));
-    EXPECT_TRUE(route->routeEntry()->hashPolicy()->generateHash("", headers, add_cookie));
+    EXPECT_TRUE(route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie));
   }
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     headers.addCopy("Cookie", "choco=late; hash=brown");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
-    EXPECT_TRUE(route->routeEntry()->hashPolicy()->generateHash("", headers, add_cookie));
+    EXPECT_TRUE(route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie));
   }
   {
     uint64_t hash_1, hash_2;
@@ -1383,13 +1388,15 @@ TEST_F(RouterMatcherCookieHashPolicyTest, TtlSet) {
       Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
       Router::RouteConstSharedPtr route = config().route(headers, 0);
       EXPECT_CALL(mock_cookie_cb, Call("hash", 42)).WillOnce(Return("AAAAAAA"));
-      hash_1 = route->routeEntry()->hashPolicy()->generateHash("", headers, add_cookie).value();
+      hash_1 =
+          route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie).value();
     }
     {
       Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
       Router::RouteConstSharedPtr route = config().route(headers, 0);
       EXPECT_CALL(mock_cookie_cb, Call("hash", 42)).WillOnce(Return("BBBBBBB"));
-      hash_2 = route->routeEntry()->hashPolicy()->generateHash("", headers, add_cookie).value();
+      hash_2 =
+          route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie).value();
     }
     EXPECT_NE(hash_1, hash_2);
   }
@@ -1401,17 +1408,19 @@ TEST_F(RouterMatcherCookieHashPolicyTest, TtlSet) {
 }
 
 TEST_F(RouterMatcherHashPolicyTest, HashIp) {
+  Network::Address::Ipv4Instance valid_address("1.2.3.4");
   firstRouteHashPolicy()->mutable_connection_properties()->set_source_ip(true);
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
-    EXPECT_FALSE(route->routeEntry()->hashPolicy()->generateHash("", headers, add_cookie_nop_));
+    EXPECT_FALSE(
+        route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie_nop_));
   }
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
     EXPECT_TRUE(
-        route->routeEntry()->hashPolicy()->generateHash("1.2.3.4", headers, add_cookie_nop_));
+        route->routeEntry()->hashPolicy()->generateHash(&valid_address, headers, add_cookie_nop_));
   }
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
@@ -1419,22 +1428,15 @@ TEST_F(RouterMatcherHashPolicyTest, HashIp) {
                             .route(headers, 0)
                             ->routeEntry()
                             ->hashPolicy()
-                            ->generateHash("1.2.3.4", headers, add_cookie_nop_)
+                            ->generateHash(&valid_address, headers, add_cookie_nop_)
                             .value();
     headers.addCopy("foo_header", "bar");
     EXPECT_EQ(old_hash, config()
                             .route(headers, 0)
                             ->routeEntry()
                             ->hashPolicy()
-                            ->generateHash("1.2.3.4", headers, add_cookie_nop_)
+                            ->generateHash(&valid_address, headers, add_cookie_nop_)
                             .value());
-  }
-  {
-    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
-    const auto hash_policy = config().route(headers, 0)->routeEntry()->hashPolicy();
-    const uint64_t hash_1 = hash_policy->generateHash("1.2.3.4", headers, add_cookie_nop_).value();
-    const uint64_t hash_2 = hash_policy->generateHash("4.3.2.1", headers, add_cookie_nop_).value();
-    EXPECT_NE(hash_1, hash_2);
   }
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/bar", "GET");
@@ -1443,39 +1445,86 @@ TEST_F(RouterMatcherHashPolicyTest, HashIp) {
   }
 }
 
+TEST_F(RouterMatcherHashPolicyTest, HashIpv4DifferentAddresses) {
+  firstRouteHashPolicy()->mutable_connection_properties()->set_source_ip(true);
+  {
+    // Different addresses should produce different hashes.
+    Network::Address::Ipv4Instance first_ip("1.2.3.4");
+    Network::Address::Ipv4Instance second_ip("4.3.2.1");
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
+    const auto hash_policy = config().route(headers, 0)->routeEntry()->hashPolicy();
+    const uint64_t hash_1 = hash_policy->generateHash(&first_ip, headers, add_cookie_nop_).value();
+    const uint64_t hash_2 = hash_policy->generateHash(&second_ip, headers, add_cookie_nop_).value();
+    EXPECT_NE(hash_1, hash_2);
+  }
+  {
+    // Same IP addresses but different ports should produce the same hash.
+    Network::Address::Ipv4Instance first_ip("1.2.3.4", 8081);
+    Network::Address::Ipv4Instance second_ip("1.2.3.4", 1331);
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
+    const auto hash_policy = config().route(headers, 0)->routeEntry()->hashPolicy();
+    const uint64_t hash_1 = hash_policy->generateHash(&first_ip, headers, add_cookie_nop_).value();
+    const uint64_t hash_2 = hash_policy->generateHash(&second_ip, headers, add_cookie_nop_).value();
+    EXPECT_EQ(hash_1, hash_2);
+  }
+}
+
+TEST_F(RouterMatcherHashPolicyTest, HashIpv6DifferentAddresses) {
+  firstRouteHashPolicy()->mutable_connection_properties()->set_source_ip(true);
+  {
+    // Different addresses should produce different hashes.
+    Network::Address::Ipv6Instance first_ip("2001:0db8:85a3:0000:0000::");
+    Network::Address::Ipv6Instance second_ip("::1");
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
+    const auto hash_policy = config().route(headers, 0)->routeEntry()->hashPolicy();
+    const uint64_t hash_1 = hash_policy->generateHash(&first_ip, headers, add_cookie_nop_).value();
+    const uint64_t hash_2 = hash_policy->generateHash(&second_ip, headers, add_cookie_nop_).value();
+    EXPECT_NE(hash_1, hash_2);
+  }
+  {
+    // Same IP addresses but different ports should produce the same hash.
+    Network::Address::Ipv6Instance first_ip("1:2:3:4:5::", 8081);
+    Network::Address::Ipv6Instance second_ip("1:2:3:4:5::", 1331);
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
+    const auto hash_policy = config().route(headers, 0)->routeEntry()->hashPolicy();
+    const uint64_t hash_1 = hash_policy->generateHash(&first_ip, headers, add_cookie_nop_).value();
+    const uint64_t hash_2 = hash_policy->generateHash(&second_ip, headers, add_cookie_nop_).value();
+    EXPECT_EQ(hash_1, hash_2);
+  }
+}
+
 TEST_F(RouterMatcherHashPolicyTest, HashMultiple) {
   auto route = route_config_.mutable_virtual_hosts(0)->mutable_routes(0)->mutable_route();
   route->add_hash_policy()->mutable_header()->set_header_name("foo_header");
   route->add_hash_policy()->mutable_connection_properties()->set_source_ip(true);
+  Network::Address::Ipv4Instance address("4.3.2.1");
 
   uint64_t hash_h, hash_ip, hash_both;
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
-    EXPECT_FALSE(route->routeEntry()->hashPolicy()->generateHash("", headers, add_cookie_nop_));
+    EXPECT_FALSE(
+        route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie_nop_));
   }
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     headers.addCopy("foo_header", "bar");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
-    hash_h = route->routeEntry()->hashPolicy()->generateHash("", headers, add_cookie_nop_).value();
+    hash_h =
+        route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie_nop_).value();
   }
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
-    hash_ip = route->routeEntry()
-                  ->hashPolicy()
-                  ->generateHash("4.2.1.3", headers, add_cookie_nop_)
-                  .value();
+    hash_ip =
+        route->routeEntry()->hashPolicy()->generateHash(&address, headers, add_cookie_nop_).value();
   }
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
     headers.addCopy("foo_header", "bar");
-    hash_both = route->routeEntry()
-                    ->hashPolicy()
-                    ->generateHash("4.2.1.3", headers, add_cookie_nop_)
-                    .value();
+    hash_both =
+        route->routeEntry()->hashPolicy()->generateHash(&address, headers, add_cookie_nop_).value();
   }
   {
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
@@ -1484,7 +1533,7 @@ TEST_F(RouterMatcherHashPolicyTest, HashMultiple) {
     // stability
     EXPECT_EQ(hash_both, route->routeEntry()
                              ->hashPolicy()
-                             ->generateHash("4.2.1.3", headers, add_cookie_nop_)
+                             ->generateHash(&address, headers, add_cookie_nop_)
                              .value());
   }
   EXPECT_NE(hash_ip, hash_h);

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -404,7 +404,7 @@ TEST_F(RouterTest, AddCookie) {
 
   std::string cookie_value;
   EXPECT_CALL(callbacks_.route_->route_entry_.hash_policy_, generateHash(_, _, _))
-      .WillOnce(Invoke([&](const std::string&, const Http::HeaderMap&,
+      .WillOnce(Invoke([&](const Network::Address::Instance*, const Http::HeaderMap&,
                            const HashPolicy::AddCookieCallback add_cookie) {
         cookie_value = add_cookie("foo", std::chrono::seconds(1337));
         return absl::optional<uint64_t>(10);
@@ -450,7 +450,7 @@ TEST_F(RouterTest, AddCookieNoDuplicate) {
           }));
 
   EXPECT_CALL(callbacks_.route_->route_entry_.hash_policy_, generateHash(_, _, _))
-      .WillOnce(Invoke([&](const std::string&, const Http::HeaderMap&,
+      .WillOnce(Invoke([&](const Network::Address::Instance*, const Http::HeaderMap&,
                            const HashPolicy::AddCookieCallback add_cookie) {
         // this should be ignored
         add_cookie("foo", std::chrono::seconds(1337));
@@ -498,7 +498,7 @@ TEST_F(RouterTest, AddMultipleCookies) {
 
   std::string choco_c, foo_c;
   EXPECT_CALL(callbacks_.route_->route_entry_.hash_policy_, generateHash(_, _, _))
-      .WillOnce(Invoke([&](const std::string&, const Http::HeaderMap&,
+      .WillOnce(Invoke([&](const Network::Address::Instance*, const Http::HeaderMap&,
                            const HashPolicy::AddCookieCallback add_cookie) {
         choco_c = add_cookie("choco", std::chrono::seconds(15));
         foo_c = add_cookie("foo", std::chrono::seconds(1337));

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -386,6 +386,17 @@ public:
   MOCK_METHOD0(stopListeners, void());
 };
 
+class MockIp : public Address::Ip {
+ public:
+  MOCK_CONST_METHOD0(addressAsString, const std::string&());
+  MOCK_CONST_METHOD0(isAnyAddress, bool());
+  MOCK_CONST_METHOD0(isUnicastAddress, bool());
+  MOCK_CONST_METHOD0(ipv4, Address::Ipv4*());
+  MOCK_CONST_METHOD0(ipv6, Address::Ipv6*());
+  MOCK_CONST_METHOD0(port, uint32_t());
+  MOCK_CONST_METHOD0(version, Address::IpVersion());
+};
+
 class MockResolvedAddress : public Address::Instance {
 public:
   MockResolvedAddress(const std::string& logical, const std::string& physical)

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -387,7 +387,7 @@ public:
 };
 
 class MockIp : public Address::Ip {
- public:
+public:
   MOCK_CONST_METHOD0(addressAsString, const std::string&());
   MOCK_CONST_METHOD0(isAnyAddress, bool());
   MOCK_CONST_METHOD0(isUnicastAddress, bool());

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -176,9 +176,10 @@ public:
   ~MockHashPolicy();
 
   // Router::HashPolicy
-  MOCK_CONST_METHOD3(generateHash, absl::optional<uint64_t>(const std::string& downstream_address,
-                                                            const Http::HeaderMap& headers,
-                                                            const AddCookieCallback add_cookie));
+  MOCK_CONST_METHOD3(generateHash,
+                     absl::optional<uint64_t>(const Network::Address::Instance* downstream_address,
+                                              const Http::HeaderMap& headers,
+                                              const AddCookieCallback add_cookie));
 };
 
 class MockMetadataMatchCriteria : public MetadataMatchCriteria {


### PR DESCRIPTION
Downstream clients initiate connections using ephemeral ports, which are
included in the Address::Instance::asString implementation. Including
the ports breaks client IP hashing for repeated short-lived connections,
though long-lived HTTP2 connections are unaffected. This patch changes
the IP hash policy to ignore ports and hash only on the IP address.

*Risk Level*: Low

*Testing*: added unit tests and ran existing test suite in addition to manual testing.

*Release Notes*: router: changed the behavior of source IP routing to ignore the source port.

Fixes #3068.