### PR TITLE
routing: allow generating session cookies

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -519,7 +519,8 @@ message RouteAction {
       string name = 1 [(validate.rules).string.min_bytes = 1];
 
       // If specified, a cookie with the TTL will be generated if the cookie is
-      // not present.
+      // not present. If the TTL is present and zero, the generated cookie will
+      // be a session cookie.
       google.protobuf.Duration ttl = 2 [(gogoproto.stdduration) = true];
     }
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -74,6 +74,8 @@ Version history
   timeout will be ignored and the response will continue to proxy up to the global request timeout. 
 * router: changed the behavior of :ref:`source IP routing <envoy_api_field_route.RouteAction.HashPolicy.ConnectionProperties.source_ip>`
   to ignore the source port.
+* router: allow :ref:`cookie routing <envoy_api_msg_route.RouteAction.HashPolicy.Cookie>` to
+  generate session cookies.
 * sockets: added :ref:`capture transport socket extension <operations_traffic_capture>` to support
   recording plain text traffic and PCAP generation.
 * sockets: added `IP_FREEBIND` socket option support for :ref:`listeners

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -127,6 +127,9 @@ std::string Utility::parseCookieValue(const HeaderMap& headers, const std::strin
 
 std::string Utility::makeSetCookieValue(const std::string& key, const std::string& value,
                                         const std::chrono::seconds max_age) {
+  if (max_age == std::chrono::seconds::zero()) {
+    return fmt::format("{}=\"{}\"", key, value);
+  }
   return fmt::format("{}=\"{}\"; Max-Age={}", key, value, max_age.count());
 }
 

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -70,7 +70,8 @@ public:
    * Produce the value for a Set-Cookie header with the given parameters.
    * @param key is the name of the cookie that is being set.
    * @param value the value to set the cookie to; this value is trusted.
-   * @param max_age the length of time for which the cookie is valid.
+   * @param max_age the length of time for which the cookie is valid, or zero
+   * to create a session cookie.
    * @return std::string a valid Set-Cookie header value string
    */
   static std::string makeSetCookieValue(const std::string& key, const std::string& value,

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -156,7 +156,8 @@ HashPolicyImpl::HashPolicyImpl(
         ttl = std::chrono::seconds(hash_policy.cookie().ttl().seconds());
       }
       hash_impls_.emplace_back(new CookieHashMethod(hash_policy.cookie().name(), ttl));
-    } break;
+      break;
+    }
     case envoy::api::v2::route::RouteAction::HashPolicy::kConnectionProperties:
       if (hash_policy.connection_properties().source_ip()) {
         hash_impls_.emplace_back(new IpHashMethod());

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -95,7 +95,8 @@ private:
 
 class CookieHashMethod : public HashPolicyImpl::HashMethod {
 public:
-  CookieHashMethod(const std::string& key, long ttl) : key_(key), ttl_(ttl) {}
+  CookieHashMethod(const std::string& key, const absl::optional<std::chrono::seconds>& ttl)
+      : key_(key), ttl_(ttl) {}
 
   absl::optional<uint64_t> evaluate(const Network::Address::Instance*,
                                     const Http::HeaderMap& headers,
@@ -103,8 +104,8 @@ public:
     absl::optional<uint64_t> hash;
     std::string value = Http::Utility::parseCookieValue(headers, key_);
 
-    if (value.empty() && ttl_ != std::chrono::seconds(0)) {
-      value = add_cookie(key_, ttl_);
+    if (value.empty() && ttl_.has_value()) {
+      value = add_cookie(key_, ttl_.value());
       hash = HashUtil::xxHash64(value);
 
     } else if (!value.empty()) {
@@ -115,7 +116,7 @@ public:
 
 private:
   const std::string key_;
-  const std::chrono::seconds ttl_;
+  const absl::optional<std::chrono::seconds> ttl_;
 };
 
 class IpHashMethod : public HashPolicyImpl::HashMethod {
@@ -149,10 +150,13 @@ HashPolicyImpl::HashPolicyImpl(
     case envoy::api::v2::route::RouteAction::HashPolicy::kHeader:
       hash_impls_.emplace_back(new HeaderHashMethod(hash_policy.header().header_name()));
       break;
-    case envoy::api::v2::route::RouteAction::HashPolicy::kCookie:
-      hash_impls_.emplace_back(
-          new CookieHashMethod(hash_policy.cookie().name(), hash_policy.cookie().ttl().seconds()));
-      break;
+    case envoy::api::v2::route::RouteAction::HashPolicy::kCookie: {
+      absl::optional<std::chrono::seconds> ttl;
+      if (hash_policy.cookie().has_ttl()) {
+        ttl = std::chrono::seconds(hash_policy.cookie().ttl().seconds());
+      }
+      hash_impls_.emplace_back(new CookieHashMethod(hash_policy.cookie().name(), ttl));
+    } break;
     case envoy::api::v2::route::RouteAction::HashPolicy::kConnectionProperties:
       if (hash_policy.connection_properties().source_ip()) {
         hash_impls_.emplace_back(new IpHashMethod());

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -241,6 +241,13 @@ TEST(HttpUtility, TestHasSetCookieBadValues) {
   EXPECT_TRUE(Utility::hasSetCookie(headers, "key2"));
 }
 
+TEST(HttpUtility, TestMakeSetCookieValue) {
+  EXPECT_EQ("name=\"value\"; Max-Age=10",
+            Utility::makeSetCookieValue("name", "value", std::chrono::seconds(10)));
+  EXPECT_EQ("name=\"value\"",
+            Utility::makeSetCookieValue("name", "value", std::chrono::seconds::zero()));
+}
+
 TEST(HttpUtility, SendLocalReply) {
   MockStreamDecoderFilterCallbacks callbacks;
   bool is_reset = false;


### PR DESCRIPTION
This enables configuring Envoy to generate cookies that expire at the
end of a session instead of requiring them to have an explicit max-age.

*Risk Level*: Low

*Testing*: added unit tests and an integration test

*Docs Changes*: documented new behavior in API and release docs

*Release Notes*: router: allow cookie routing to generate session cookies.