### PR TITLE
common: don't throw from Hex::decode().

### DIFF
--- a/source/common/common/hex.cc
+++ b/source/common/common/hex.cc
@@ -28,7 +28,7 @@ std::string Hex::encode(const uint8_t* data, size_t length) {
 
 std::vector<uint8_t> Hex::decode(const std::string& hex_string) {
   if (hex_string.size() == 0 || hex_string.size() % 2 != 0) {
-    throw EnvoyException(fmt::format("invalid hex string '{}'", hex_string));
+    return {};
   }
 
   std::vector<uint8_t> segment;
@@ -36,7 +36,7 @@ std::vector<uint8_t> Hex::decode(const std::string& hex_string) {
     std::string hex_byte = hex_string.substr(i, 2);
     uint64_t out;
     if (!StringUtil::atoul(hex_byte.c_str(), out, 16)) {
-      throw EnvoyException(fmt::format("invalid hex string '{}'", hex_string));
+      return {};
     }
 
     segment.push_back(out);

--- a/source/common/common/hex.h
+++ b/source/common/common/hex.h
@@ -30,7 +30,7 @@ public:
   /**
    * Converts a hex dump to binary data
    * @param input the hex dump to decode
-   * @return binary data
+   * @return binary data or empty vector in case of invalid input
    */
   static std::vector<uint8_t> decode(const std::string& input);
 

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -217,8 +217,11 @@ TcpHealthCheckMatcher::MatchSegments TcpHealthCheckMatcher::loadProtoBytes(
   MatchSegments result;
 
   for (const auto& entry : byte_array) {
-    const std::string& hex_string = entry.text();
-    result.push_back(Hex::decode(hex_string));
+    const auto& decoded = Hex::decode(entry.text());
+    if (decoded.size() == 0) {
+      throw EnvoyException(fmt::format("invalid hex string '{}'", entry.text()));
+    }
+    result.push_back(decoded);
   }
 
   return result;

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -217,7 +217,7 @@ TcpHealthCheckMatcher::MatchSegments TcpHealthCheckMatcher::loadProtoBytes(
   MatchSegments result;
 
   for (const auto& entry : byte_array) {
-    const auto& decoded = Hex::decode(entry.text());
+    const auto decoded = Hex::decode(entry.text());
     if (decoded.size() == 0) {
       throw EnvoyException(fmt::format("invalid hex string '{}'", entry.text()));
     }

--- a/test/common/common/hex_test.cc
+++ b/test/common/common/hex_test.cc
@@ -25,9 +25,9 @@ TEST(Hex, RoundTrip) {
   EXPECT_EQ(bytes, decoded);
 }
 
-TEST(Hex, BadHex) { EXPECT_THROW(Hex::decode("abcde"), EnvoyException); }
+TEST(Hex, BadHex) { EXPECT_EQ(0, Hex::decode("abcde").size()); }
 
-TEST(Hex, DecodeUppercase) { Hex::decode("ABCDEFAB"); }
+TEST(Hex, DecodeUppercase) { EXPECT_EQ(4, Hex::decode("ABCDEFAB").size()); }
 
 TEST(Hex, UIntToHex) {
   std::string base16_string = Hex::uint64ToHex(2722130815203937912ULL);


### PR DESCRIPTION
This matches behavior of Base64::decode() and allows for a more complex
result validation to be performed by the caller.

*Risk Level*: Low
*Testing*: bazel test //test/...
*Docs Changes*: n/a
*Release Notes*: n/a

Fixes #3442.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>