### PR TITLE
cleanup: code cleanup, no functionality changes

### DIFF
--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -334,13 +334,13 @@ bool ContextImpl::dNSNameMatch(const std::string& dNSName, const char* pattern) 
 }
 
 bool ContextImpl::verifyCertificateHashList(
-    X509* cert, const std::vector<std::vector<uint8_t>>& expected_hashes) {
+    X509* cert, const std::vector<std::vector<uint8_t>>& certificate_hash_list) {
   std::vector<uint8_t> computed_hash(SHA256_DIGEST_LENGTH);
   unsigned int n;
   X509_digest(cert, EVP_sha256(), computed_hash.data(), &n);
   RELEASE_ASSERT(n == computed_hash.size());
 
-  for (const auto& expected_hash : expected_hashes) {
+  for (const auto& expected_hash : certificate_hash_list) {
     if (computed_hash == expected_hash) {
       return true;
     }

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -198,8 +198,8 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
         Config::Utility::translateToFactoryConfig(transport_socket, config_factory);
 
     std::vector<std::string> server_names;
-    if (filter_chain_match.server_names().size() != 0) {
-      if (filter_chain_match.sni_domains().size() != 0) {
+    if (!filter_chain_match.server_names().empty()) {
+      if (!filter_chain_match.sni_domains().empty()) {
         throw EnvoyException(
             fmt::format("error adding listener '{}': both \"server_names\" and the deprecated "
                         "\"sni_domains\" are used, please merge the list of expected server names "
@@ -209,7 +209,7 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
 
       server_names.assign(filter_chain_match.server_names().begin(),
                           filter_chain_match.server_names().end());
-    } else if (filter_chain_match.sni_domains().size() != 0) {
+    } else if (!filter_chain_match.sni_domains().empty()) {
       server_names.assign(filter_chain_match.sni_domains().begin(),
                           filter_chain_match.sni_domains().end());
     }

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -132,7 +132,7 @@ ConfigHelper::ConfigHelper(const Network::Address::IpVersion version, const std:
 
   for (int i = 0; i < static_resources->clusters_size(); ++i) {
     auto* cluster = static_resources->mutable_clusters(i);
-    if (cluster->hosts().size() > 0 && cluster->mutable_hosts(0)->has_socket_address()) {
+    if (!cluster->hosts().empty() && cluster->mutable_hosts(0)->has_socket_address()) {
       auto host_socket_addr = cluster->mutable_hosts(0)->mutable_socket_address();
       host_socket_addr->set_address(Network::Test::getLoopbackAddressString(version));
     }


### PR DESCRIPTION
Fix some issues detected by clang-tidy:
- Replace protobuf .size() == 0 checks with .empty()
- Change function definition parameter name to match declaration

*Risk Level*: Low

*Testing*: ran unit and integration tests in //test/... test suite.

*Docs Changes*: N/A

*Release Notes*: N/A