### PR TITLE
upstream: cluster manager api for dynamic cluster creation

### DIFF
--- a/include/envoy/thread_local/thread_local.h
+++ b/include/envoy/thread_local/thread_local.h
@@ -56,6 +56,11 @@ public:
   virtual void runOnAllThreads(Event::PostCb cb, Event::PostCb all_threads_complete_cb) PURE;
 
   /**
+   * Returns true if the thread is main dispatcher otherwise false.
+   */
+  virtual bool isMainThread() PURE;
+
+  /**
    * Set thread local data on all threads previously registered via registerThread().
    * @param initializeCb supplies the functor that will be called *on each thread*. The functor
    *                     returns the thread local object which is then stored. The storage is via

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -58,6 +58,37 @@ public:
 typedef std::unique_ptr<ClusterUpdateCallbacksHandle> ClusterUpdateCallbacksHandlePtr;
 
 /**
+ * A cancellable handler returned to the caller who initiates the dynamic cluster creation on the
+ * request path.
+ */
+class DynamicClusterHandler {
+public:
+  virtual ~DynamicClusterHandler() {}
+
+  /**
+   * @return Cluster that this handle is created for.
+   */
+  virtual const std::string& cluster() const PURE;
+
+  /**
+   * Cancels the callback.
+   */
+  virtual void cancel() PURE;
+
+  /**
+   * Called when cluster creation is complete.
+   */
+  virtual void onClusterCreationComplete() PURE;
+};
+
+typedef std::shared_ptr<DynamicClusterHandler> DynamicClusterHandlerPtr;
+
+/**
+ * Callback invoked when a cross thread cluster creation is complete.
+ */
+typedef std::function<void()> PostClusterCreationCb;
+
+/**
  * Manages connection pools and load balancing for upstream clusters. The cluster manager is
  * persistent and shared among multiple ongoing requests/connections.
  */
@@ -78,6 +109,20 @@ public:
   virtual bool addOrUpdateCluster(const envoy::api::v2::Cluster& cluster,
                                   const std::string& version_info) PURE;
 
+  /**
+   * Add a dynamic cluster via API on the request path. Currently this supports only STATIC type of
+   * clusters.
+   *
+   * @param cluster supplies the cluster configuration.
+   * @param version_info supplies the xDS version of the cluster.
+   * @param post_cluster_cb supplies the call back that allows the request to continue after the
+   *        cluster creation is done.
+   * @return DynamicClusterHandlerPtr that allows the caller to cancel if needed.
+   */
+  virtual DynamicClusterHandlerPtr
+  addOrUpdateClusterCrossThread(const envoy::api::v2::Cluster& cluster,
+                                const std::string& version_info,
+                                PostClusterCreationCb post_cluster_cb) PURE;
   /**
    * Set a callback that will be invoked when all owned clusters have been initialized.
    */

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -89,6 +89,16 @@ typedef std::shared_ptr<DynamicClusterHandler> DynamicClusterHandlerPtr;
 typedef std::function<void()> PostClusterCreationCb;
 
 /**
+ * List of response codes returned by addOrUpdateClusterCrossThread API.
+ */
+enum ClusterResponseCode {
+  Accepted,
+  DuplicateCluster,
+  ClusterCreationInProgress,
+  NonStaticClusterNotAllowed
+};
+
+/**
  * Manages connection pools and load balancing for upstream clusters. The cluster manager is
  * persistent and shared among multiple ongoing requests/connections.
  */
@@ -116,10 +126,12 @@ public:
    * @param cluster supplies the cluster configuration.
    * @param version_info supplies the xDS version of the cluster.
    * @param post_cluster_cb supplies the call back that allows the request to continue after the
-   *        cluster creation is done.
-   * @return DynamicClusterHandlerPtr that allows the caller to cancel if needed.
+   *        cluster creation is done or will be called immediately if cluster already exists.
+   * @return std::pair<ClusterResponseCode,DynamicClusterHandlerPtr>. ClusterResponseCode provides
+   *         the status of the API and DynamicClusterHandlerPtr allows the caller to cancel if
+   * needed.
    */
-  virtual DynamicClusterHandlerPtr
+  virtual std::pair<ClusterResponseCode, DynamicClusterHandlerPtr>
   addOrUpdateClusterCrossThread(const envoy::api::v2::Cluster& cluster,
                                 const std::string& version_info,
                                 PostClusterCreationCb post_cluster_cb) PURE;

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -110,6 +110,8 @@ void InstanceImpl::runOnAllThreads(Event::PostCb cb, Event::PostCb all_threads_c
   }
 }
 
+bool InstanceImpl::isMainThread() { return (std::this_thread::get_id() == main_thread_id_); }
+
 void InstanceImpl::SlotImpl::set(InitializeCb cb) {
   ASSERT(std::this_thread::get_id() == parent_.main_thread_id_);
   ASSERT(!parent_.shutdown_);

--- a/source/common/thread_local/thread_local_impl.h
+++ b/source/common/thread_local/thread_local_impl.h
@@ -38,6 +38,7 @@ private:
     void runOnAllThreads(Event::PostCb cb, Event::PostCb main_callback) override {
       parent_.runOnAllThreads(cb, main_callback);
     }
+    bool isMainThread() override { return parent_.isMainThread(); }
     void set(InitializeCb cb) override;
 
     InstanceImpl& parent_;
@@ -52,6 +53,7 @@ private:
   void removeSlot(SlotImpl& slot);
   void runOnAllThreads(Event::PostCb cb);
   void runOnAllThreads(Event::PostCb cb, Event::PostCb main_callback);
+  bool isMainThread();
   static void setThreadLocal(uint32_t index, ThreadLocalObjectSharedPtr object);
 
   static thread_local ThreadLocalData thread_local_data_;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -384,7 +384,7 @@ ClusterManagerImpl::addOrUpdateClusterCrossThread(const envoy::api::v2::Cluster&
         cluster.name(), cluster_manager.pending_cluster_creations_, post_cluster_cb);
     cluster_manager.pending_cluster_creations_[cluster.name()] = cluster_handler;
     main_thread_dispatcher_.post(
-        [ this, cluster, version_info ]() -> void { addOrUpdateCluster(cluster, version_info); });
+        [ this, cluster, version_info ]()->void { addOrUpdateCluster(cluster, version_info); });
   }
 
   return cluster_handler;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -384,7 +384,7 @@ ClusterManagerImpl::addOrUpdateClusterCrossThread(const envoy::api::v2::Cluster&
         cluster.name(), cluster_manager.pending_cluster_creations_, post_cluster_cb);
     cluster_manager.pending_cluster_creations_[cluster.name()] = cluster_handler;
     main_thread_dispatcher_.post(
-        [this, cluster, version_info]() -> void { addOrUpdateCluster(cluster, version_info); });
+        [ this, cluster, version_info ]() -> void { addOrUpdateCluster(cluster, version_info); });
   }
 
   return cluster_handler;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -172,12 +172,10 @@ DynamicClusterHandlerImpl::DynamicClusterHandlerImpl(
       post_cluster_cb_(post_cluster_cb) {}
 
 void DynamicClusterHandlerImpl::cancel() {
-  ENVOY_LOG(debug, "cancelling dynamic cluster creation callback for cluster {}", cluster_name_);
   pending_clusters_.erase(cluster_name_);
 }
 
 void DynamicClusterHandlerImpl::onClusterCreationComplete() {
-  ENVOY_LOG(debug, "cluster {} creation complete. initiating post callback", cluster_name_);
   post_cluster_cb_();
   pending_clusters_.erase(cluster_name_);
 }
@@ -386,7 +384,6 @@ ClusterManagerImpl::addOrUpdateClusterCrossThread(const envoy::api::v2::Cluster&
     main_thread_dispatcher_.post(
         [ this, cluster, version_info ]()->void { addOrUpdateCluster(cluster, version_info); });
   }
-
   return cluster_handler;
 }
 

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -380,7 +380,7 @@ ClusterManagerImpl::addOrUpdateClusterCrossThread(const envoy::api::v2::Cluster&
         cluster.name(), cluster_manager.pending_cluster_creations_, post_cluster_cb);
     cluster_manager.pending_cluster_creations_[cluster.name()] = cluster_handler;
     main_thread_dispatcher_.post(
-        [ this, cluster, version_info ]()->void { addOrUpdateCluster(cluster, version_info); });
+        [this, cluster, version_info]() -> void { addOrUpdateCluster(cluster, version_info); });
   }
   return cluster_handler;
 }

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -461,24 +461,28 @@ bool ClusterManagerImpl::addOrUpdateCluster(const envoy::api::v2::Cluster& clust
 }
 
 void ClusterManagerImpl::createOrUpdateThreadLocalCluster(ClusterData& cluster) {
-  tls_->runOnAllThreads([this, new_cluster = cluster.cluster_->info(),
-                         thread_aware_lb_factory = cluster.loadBalancerFactory()]() -> void {
-    ThreadLocalClusterManagerImpl& cluster_manager =
-        tls_->getTyped<ThreadLocalClusterManagerImpl>();
+  tls_->runOnAllThreads(
+      [
+        this, new_cluster = cluster.cluster_->info(),
+        thread_aware_lb_factory = cluster.loadBalancerFactory()
+      ]()
+          ->void {
+            ThreadLocalClusterManagerImpl& cluster_manager =
+                tls_->getTyped<ThreadLocalClusterManagerImpl>();
 
-    if (cluster_manager.thread_local_clusters_.count(new_cluster->name()) > 0) {
-      ENVOY_LOG(debug, "updating TLS cluster {}", new_cluster->name());
-    } else {
-      ENVOY_LOG(debug, "adding TLS cluster {}", new_cluster->name());
-    }
+            if (cluster_manager.thread_local_clusters_.count(new_cluster->name()) > 0) {
+              ENVOY_LOG(debug, "updating TLS cluster {}", new_cluster->name());
+            } else {
+              ENVOY_LOG(debug, "adding TLS cluster {}", new_cluster->name());
+            }
 
-    auto thread_local_cluster = new ThreadLocalClusterManagerImpl::ClusterEntry(
-        cluster_manager, new_cluster, thread_aware_lb_factory);
-    cluster_manager.thread_local_clusters_[new_cluster->name()].reset(thread_local_cluster);
-    for (auto& cb : cluster_manager.update_callbacks_) {
-      cb->onClusterAddOrUpdate(*thread_local_cluster);
-    }
-  });
+            auto thread_local_cluster = new ThreadLocalClusterManagerImpl::ClusterEntry(
+                cluster_manager, new_cluster, thread_aware_lb_factory);
+            cluster_manager.thread_local_clusters_[new_cluster->name()].reset(thread_local_cluster);
+            for (auto& cb : cluster_manager.update_callbacks_) {
+              cb->onClusterAddOrUpdate(*thread_local_cluster);
+            }
+          });
 }
 
 bool ClusterManagerImpl::removeCluster(const std::string& cluster_name) {
@@ -525,6 +529,7 @@ void ClusterManagerImpl::loadCluster(const envoy::api::v2::Cluster& cluster,
                                      ClusterMap& cluster_map) {
   ClusterSharedPtr new_cluster =
       factory_.clusterFromProto(cluster, *this, outlier_event_logger_, added_via_api);
+
   if (!added_via_api) {
     if (cluster_map.find(new_cluster->info()->name()) != cluster_map.end()) {
       throw EnvoyException(
@@ -612,14 +617,15 @@ void ClusterManagerImpl::postThreadLocalClusterUpdate(const Cluster& cluster, ui
   HostsPerLocalityConstSharedPtr healthy_hosts_per_locality_copy =
       host_set->healthyHostsPerLocality().clone();
 
-  tls_->runOnAllThreads(
-      [this, name = cluster.info()->name(), priority, hosts_copy, healthy_hosts_copy,
-       hosts_per_locality_copy, healthy_hosts_per_locality_copy,
-       locality_weights = host_set->localityWeights(), hosts_added, hosts_removed]() {
-        ThreadLocalClusterManagerImpl::updateClusterMembership(
-            name, priority, hosts_copy, healthy_hosts_copy, hosts_per_locality_copy,
-            healthy_hosts_per_locality_copy, locality_weights, hosts_added, hosts_removed, *tls_);
-      });
+  tls_->runOnAllThreads([
+    this, name = cluster.info()->name(), priority, hosts_copy, healthy_hosts_copy,
+    hosts_per_locality_copy, healthy_hosts_per_locality_copy,
+    locality_weights = host_set->localityWeights(), hosts_added, hosts_removed
+  ]() {
+    ThreadLocalClusterManagerImpl::updateClusterMembership(
+        name, priority, hosts_copy, healthy_hosts_copy, hosts_per_locality_copy,
+        healthy_hosts_per_locality_copy, locality_weights, hosts_added, hosts_removed, *tls_);
+  });
 }
 
 void ClusterManagerImpl::postThreadLocalHealthFailure(const HostSharedPtr& host) {

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -14,7 +14,6 @@
 
 #include "common/common/enum_to_int.h"
 #include "common/common/fmt.h"
-#include "common/common/lock_guard.h"
 #include "common/common/utility.h"
 #include "common/config/cds_json.h"
 #include "common/config/utility.h"
@@ -399,7 +398,6 @@ bool ClusterManagerImpl::addOrUpdateCluster(const envoy::api::v2::Cluster& clust
   // We don't allow updates to statically configured clusters in the main configuration. We check
   // both the warming clusters and the active clusters to see if we need an update or the update
   // should be blocked.
-
   const std::string cluster_name = cluster.name();
   const auto existing_active_cluster = active_clusters_.find(cluster_name);
   const auto existing_warming_cluster = warming_clusters_.find(cluster_name);

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -171,9 +171,7 @@ DynamicClusterHandlerImpl::DynamicClusterHandlerImpl(
     : cluster_name_(cluster_name), pending_clusters_(pending_clusters),
       post_cluster_cb_(post_cluster_cb) {}
 
-void DynamicClusterHandlerImpl::cancel() {
-  pending_clusters_.erase(cluster_name_);
-}
+void DynamicClusterHandlerImpl::cancel() { pending_clusters_.erase(cluster_name_); }
 
 void DynamicClusterHandlerImpl::onClusterCreationComplete() {
   post_cluster_cb_();

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -140,7 +140,8 @@ struct ClusterManagerStats {
   ALL_CLUSTER_MANAGER_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
 };
 
-class DynamicClusterHandlerImpl : public DynamicClusterHandler {
+class DynamicClusterHandlerImpl : public DynamicClusterHandler,
+                                  Logger::Loggable<Logger::Id::upstream> {
 public:
   DynamicClusterHandlerImpl(
       const std::string& cluster_name,

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -140,8 +140,7 @@ struct ClusterManagerStats {
   ALL_CLUSTER_MANAGER_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
 };
 
-class DynamicClusterHandlerImpl : public DynamicClusterHandler,
-                                  Logger::Loggable<Logger::Id::upstream> {
+class DynamicClusterHandlerImpl : public DynamicClusterHandler {
 public:
   DynamicClusterHandlerImpl(
       const std::string& cluster_name,

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -330,6 +330,7 @@ private:
   typedef std::map<std::string, ClusterDataPtr> ClusterMap;
 
   void createOrUpdateThreadLocalCluster(ClusterData& cluster);
+  void createOrUpdateThreadLocalClusterInternal(std::function<void()> thread_local_clustercb);
   ProtobufTypes::MessagePtr dumpClusterConfigs();
   static ClusterManagerStats generateStats(Stats::Scope& scope);
   void loadCluster(const envoy::api::v2::Cluster& cluster, const std::string& version_info,
@@ -337,6 +338,7 @@ private:
   void onClusterInit(Cluster& cluster);
   void postThreadLocalClusterUpdate(const Cluster& cluster, uint32_t priority,
                                     const HostVector& hosts_added, const HostVector& hosts_removed);
+  void postThreadLocalClusterUpdateInternal(std::function<void()> thread_local_cluster_updatecb);
   void postThreadLocalHealthFailure(const HostSharedPtr& host);
   void updateGauges();
 
@@ -344,6 +346,7 @@ private:
   Runtime::Loader& runtime_;
   Stats::Store& stats_;
   ThreadLocal::SlotPtr tls_;
+  Event::Dispatcher& main_thread_dispatcher_;
   Runtime::RandomGenerator& random_;
   ClusterMap active_clusters_;
   ClusterMap warming_clusters_;

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -3,7 +3,6 @@
 #include <array>
 #include <cstdint>
 #include <functional>
-#include <future>
 #include <list>
 #include <map>
 #include <memory>
@@ -173,7 +172,7 @@ public:
   // Upstream::ClusterManager
   bool addOrUpdateCluster(const envoy::api::v2::Cluster& cluster,
                           const std::string& version_info) override;
-  DynamicClusterHandlerPtr
+  std::pair<ClusterResponseCode, DynamicClusterHandlerPtr>
   addOrUpdateClusterCrossThread(const envoy::api::v2::Cluster& cluster,
                                 const std::string& version_info,
                                 PostClusterCreationCb post_cluster_cb) override;
@@ -369,6 +368,8 @@ private:
   Stats::Store& stats_;
   ThreadLocal::SlotPtr tls_;
   Event::Dispatcher& main_thread_dispatcher_;
+  std::unordered_map<std::string, std::list<std::reference_wrapper<Event::Dispatcher>>>
+      pending_cluster_creations_;
   Runtime::RandomGenerator& random_;
   ClusterMap active_clusters_;
   ClusterMap warming_clusters_;

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -215,7 +215,7 @@ int StreamHandleWrapper::luaAddorUpdateCluster(lua_State* state) {
           state_ = State::Running;
           markLive();
           try {
-            coroutine_->resume(2, yield_callback_);
+            coroutine_->resume(0, yield_callback_);
             markDead();
           } catch (const Filters::Common::Lua::LuaException& e) {
             filter_.scriptError(e);

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -25,10 +25,10 @@ StreamHandleWrapper::StreamHandleWrapper(Filters::Common::Lua::CoroutinePtr&& co
 Http::FilterHeadersStatus StreamHandleWrapper::start(int function_ref) {
   // We are on the top of the stack.
   coroutine_->start(function_ref, 1, yield_callback_);
-  Http::FilterHeadersStatus status =
-      (state_ == State::WaitForBody || state_ == State::HttpCall || state_ == State::Responded)
-          ? Http::FilterHeadersStatus::StopIteration
-          : Http::FilterHeadersStatus::Continue;
+  Http::FilterHeadersStatus status = (state_ == State::WaitForBody || state_ == State::HttpCall ||
+                                      state_ == State::Responded || state_ == State::DynamicCluster)
+                                         ? Http::FilterHeadersStatus::StopIteration
+                                         : Http::FilterHeadersStatus::Continue;
 
   if (status == Http::FilterHeadersStatus::Continue) {
     headers_continued_ = true;
@@ -62,6 +62,9 @@ Http::FilterDataStatus StreamHandleWrapper::onData(Buffer::Instance& data, bool 
   if (state_ == State::HttpCall || state_ == State::WaitForBody) {
     ENVOY_LOG(trace, "buffering body");
     return Http::FilterDataStatus::StopIterationAndBuffer;
+  } else if (state_ == State::DynamicCluster) {
+    ENVOY_LOG(trace, "not buffering body");
+    return Http::FilterDataStatus::StopIterationAndBuffer;
   } else if (state_ == State::Responded) {
     return Http::FilterDataStatus::StopIterationNoBuffer;
   } else {
@@ -91,9 +94,10 @@ Http::FilterTrailersStatus StreamHandleWrapper::onTrailers(Http::HeaderMap& trai
     coroutine_->resume(luaTrailers(coroutine_->luaState()), yield_callback_);
   }
 
-  Http::FilterTrailersStatus status = (state_ == State::HttpCall || state_ == State::Responded)
-                                          ? Http::FilterTrailersStatus::StopIteration
-                                          : Http::FilterTrailersStatus::Continue;
+  Http::FilterTrailersStatus status =
+      (state_ == State::HttpCall || state_ == State::Responded || state_ == State::DynamicCluster)
+          ? Http::FilterTrailersStatus::StopIteration
+          : Http::FilterTrailersStatus::Continue;
 
   if (status == Http::FilterTrailersStatus::Continue) {
     headers_continued_ = true;
@@ -197,6 +201,37 @@ int StreamHandleWrapper::luaHttpCall(lua_State* state) {
     // Immediate failure case. The return arguments are already on the stack.
     ASSERT(lua_gettop(state) >= 2);
     return 2;
+  }
+}
+
+int StreamHandleWrapper::luaAddorUpdateCluster(lua_State* state) {
+  ASSERT(state_ == State::Running);
+  const std::string cluster_template_yaml = luaL_checkstring(state, 2);
+  envoy::api::v2::Cluster cluster;
+  MessageUtil::loadFromYaml(cluster_template_yaml, cluster);
+  cluster_handler_ =
+      filter_.clusterManager().addOrUpdateClusterCrossThread(cluster, "", [this]() -> void {
+        if (state_ == State::DynamicCluster) {
+          state_ = State::Running;
+          markLive();
+          try {
+            coroutine_->resume(2, yield_callback_);
+            markDead();
+          } catch (const Filters::Common::Lua::LuaException& e) {
+            filter_.scriptError(e);
+          }
+
+          if (state_ == State::Running) {
+            headers_continued_ = true;
+            callbacks_.continueIteration();
+          }
+        }
+      });
+  if (cluster_handler_) {
+    state_ = State::DynamicCluster;
+    return lua_yield(state, 0);
+  } else {
+    return 1;
   }
 }
 

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -122,12 +122,18 @@ public:
   }
 
   static ExportedFunctions exportedFunctions() {
-    return {{"headers", static_luaHeaders},         {"body", static_luaBody},
-            {"bodyChunks", static_luaBodyChunks},   {"trailers", static_luaTrailers},
-            {"metadata", static_luaMetadata},       {"logTrace", static_luaLogTrace},
-            {"logDebug", static_luaLogDebug},       {"logInfo", static_luaLogInfo},
-            {"logWarn", static_luaLogWarn},         {"logErr", static_luaLogErr},
-            {"logCritical", static_luaLogCritical}, {"httpCall", static_luaHttpCall},
+    return {{"headers", static_luaHeaders},
+            {"body", static_luaBody},
+            {"bodyChunks", static_luaBodyChunks},
+            {"trailers", static_luaTrailers},
+            {"metadata", static_luaMetadata},
+            {"logTrace", static_luaLogTrace},
+            {"logDebug", static_luaLogDebug},
+            {"logInfo", static_luaLogInfo},
+            {"logWarn", static_luaLogWarn},
+            {"logErr", static_luaLogErr},
+            {"logCritical", static_luaLogCritical},
+            {"httpCall", static_luaHttpCall},
             {"respond", static_luaRespond},
             {"addOrUpdateCluster", static_luaAddorUpdateCluster}};
   }

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -192,6 +192,10 @@ private:
   /**
    * @return a handle to create a cluster on the request path.
    */
+  /**
+   * Create a cluster on the request path. This call yields the script till cluster is created.
+   * @param 1 (string): Yaml representation of Cluster definition as per v2 APIs.
+   */
   DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaAddorUpdateCluster);
 
   /**

--- a/test/mocks/thread_local/mocks.h
+++ b/test/mocks/thread_local/mocks.h
@@ -32,6 +32,7 @@ public:
     cb();
     main_callback();
   }
+  bool isMainThread() { return true; }
 
   void shutdownThread_() {
     shutdown_ = true;
@@ -61,6 +62,7 @@ public:
     void runOnAllThreads(Event::PostCb cb, Event::PostCb main_callback) override {
       parent_.runOnAllThreads(cb, main_callback);
     }
+    bool isMainThread() override { return true; }
     void set(InitializeCb cb) override { parent_.data_[index_] = cb(parent_.dispatcher_); }
 
     MockInstance& parent_;

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -149,9 +149,9 @@ public:
   MOCK_METHOD2(addOrUpdateCluster,
                bool(const envoy::api::v2::Cluster& cluster, const std::string& version_info));
   MOCK_METHOD3(addOrUpdateClusterCrossThread,
-               DynamicClusterHandlerPtr(const envoy::api::v2::Cluster& cluster,
-                                        const std::string& version_info,
-                                        PostClusterCreationCb post_cluster_cb));
+               std::pair<ClusterResponseCode, DynamicClusterHandlerPtr>(
+                   const envoy::api::v2::Cluster& cluster, const std::string& version_info,
+                   PostClusterCreationCb post_cluster_cb));
   MOCK_METHOD1(setInitializedCb, void(std::function<void()>));
   MOCK_METHOD0(clusters, ClusterInfoMap());
   MOCK_METHOD1(get, ThreadLocalCluster*(const std::string& cluster));

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -148,6 +148,10 @@ public:
   // Upstream::ClusterManager
   MOCK_METHOD2(addOrUpdateCluster,
                bool(const envoy::api::v2::Cluster& cluster, const std::string& version_info));
+  MOCK_METHOD3(addOrUpdateClusterCrossThread,
+               DynamicClusterHandlerPtr(const envoy::api::v2::Cluster& cluster,
+                                        const std::string& version_info,
+                                        PostClusterCreationCb post_cluster_cb));
   MOCK_METHOD1(setInitializedCb, void(std::function<void()>));
   MOCK_METHOD0(clusters, ClusterInfoMap());
   MOCK_METHOD1(get, ThreadLocalCluster*(const std::string& cluster));


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>

*Description*:
Enhances the `addOrUpdateCluster` api so that it can be called from worker thread there by providing the ability to create the cluster on the request path.

*Risk Level*: Low 
*Testing*: Automated tests and manual testing
*Docs Changes*: N/A
*Release Notes*: N/A

