### PR TITLE
stats: Fix 32-bit limit for byte offsets in stats set, and guard against very high max-stats that will cause shared memory to explode.

### DIFF
--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -211,7 +211,7 @@ following are the command line options that Envoy supports.
 
   *(optional)* The maximum name length (in bytes) of the name field in a cluster/route_config/listener.
   This setting is typically used in scenarios where the cluster names are auto generated, and often exceed
-  the built-in limit of 60 characters. Defaults to 60.
+  the built-in limit of 60 characters. Defaults to 60, and it's not valid to set to less than 60.
 
   .. attention::
 
@@ -223,7 +223,7 @@ following are the command line options that Envoy supports.
 
   *(optional)* The maximum number of stats that can be shared between hot-restarts. This setting
   affects the output of :option:`--hot-restart-version`; the same value must be used to hot
-  restart. Defaults to 16384.
+  restart. Defaults to 16384. It's not valid to set this larger than 100 million.
 
 .. option:: --disable-hot-restart
 

--- a/source/common/common/block_memory_hash_set.h
+++ b/source/common/common/block_memory_hash_set.h
@@ -38,7 +38,7 @@ struct BlockMemoryHashSetOptions {
  * construction time. Value must provide these methods:
  *    absl::string_view Value::key()
  *    void Value::initialize(absl::string_view key)
- *    static size_t Value::size()
+ *    static uint64_t Value::size()
  *    static uint64_t Value::hash()
  *
  * This set may also be suitable for persisting a hash-table to long

--- a/source/common/common/block_memory_hash_set.h
+++ b/source/common/common/block_memory_hash_set.h
@@ -82,13 +82,13 @@ public:
    * backing-store (eg) in memory, which we do after
    * constructing the object with the desired sizing.
    */
-  static size_t numBytes(const BlockMemoryHashSetOptions& options) {
-    size_t size =
+  static uint64_t numBytes(const BlockMemoryHashSetOptions& options) {
+    uint64_t size =
         cellOffset(options.capacity) + sizeof(Control) + options.num_slots * sizeof(uint32_t);
     return align(size);
   }
 
-  size_t numBytes() const { return numBytes(control_->options); }
+  uint64_t numBytes() const { return numBytes(control_->options); }
 
   /**
    * Returns the options structure that was used to construct the set.
@@ -292,7 +292,7 @@ private:
   struct Control {
     BlockMemoryHashSetOptions options; // Options established at map construction time.
     uint64_t hash_signature;           // Hash of a constant signature string.
-    size_t num_bytes;                  // Bytes allocated on behalf of the map.
+    uint64_t num_bytes;                // Bytes allocated on behalf of the map.
     uint32_t size;                     // Number of values currently stored.
     uint32_t free_cell_index;          // Offset of first free cell.
   };
@@ -306,12 +306,12 @@ private:
   };
 
   // It seems like this is an obvious constexpr, but it won't compile as one.
-  static size_t calculateAlignment() {
+  static uint64_t calculateAlignment() {
     return std::max(alignof(Cell), std::max(alignof(uint32_t), alignof(Control)));
   }
 
-  static size_t align(uint64_t size) {
-    const size_t alignment = calculateAlignment();
+  static uint64_t align(uint64_t size) {
+    const uint64_t alignment = calculateAlignment();
     // Check that alignment is a power of 2:
     // http://www.graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2
     RELEASE_ASSERT((alignment > 0) && ((alignment & (alignment - 1)) == 0));
@@ -323,10 +323,10 @@ private:
    * simply an array index because we don't know the size of a key at
    * compile-time.
    */
-  static size_t cellOffset(uint32_t cell_index) {
+  static uint64_t cellOffset(uint32_t cell_index) {
     // sizeof(Cell) includes 'sizeof Value' which may not be accurate. So we need to
     // subtract that off, and add the template method's view of the actual value-size.
-    size_t cell_size = align(sizeof(Cell) + Value::size() - sizeof(Value));
+    uint64_t cell_size = align(sizeof(Cell) + Value::size() - sizeof(Value));
     return cell_index * cell_size;
   }
 

--- a/source/common/common/block_memory_hash_set.h
+++ b/source/common/common/block_memory_hash_set.h
@@ -82,13 +82,13 @@ public:
    * backing-store (eg) in memory, which we do after
    * constructing the object with the desired sizing.
    */
-  static uint32_t numBytes(const BlockMemoryHashSetOptions& options) {
-    uint32_t size =
+  static size_t numBytes(const BlockMemoryHashSetOptions& options) {
+    size_t size =
         cellOffset(options.capacity) + sizeof(Control) + options.num_slots * sizeof(uint32_t);
     return align(size);
   }
 
-  uint32_t numBytes() const { return numBytes(control_->options); }
+  size_t numBytes() const { return numBytes(control_->options); }
 
   /**
    * Returns the options structure that was used to construct the set.
@@ -103,7 +103,7 @@ public:
     // reachable from the slots, each of which has a valid
     // char_offset.
     //
-    // Avoid infinite loops if there is a next_cell cycle within a
+    // Avoid infinite loops if there is a next_cell_index cycle within a
     // slot. Note that the num_values message will be emitted outside
     // the loop.
     uint32_t num_values = 0;
@@ -115,7 +115,7 @@ public:
         Cell& cell = getCell(cell_index);
         absl::string_view key = cell.value.key();
         RELEASE_ASSERT(computeSlot(key) == slot);
-        next = cell.next_cell;
+        next = cell.next_cell_index;
         ++num_values;
       }
     }
@@ -127,7 +127,7 @@ public:
     // Don't infinite-loop with a corruption; break when we see there's a problem.
     for (uint32_t cell_index = control_->free_cell_index;
          (cell_index != Sentinal) && (num_free_entries <= expected_free_entries);
-         cell_index = getCell(cell_index).next_cell) {
+         cell_index = getCell(cell_index).next_cell_index) {
       ++num_free_entries;
     }
     RELEASE_ASSERT(num_free_entries == expected_free_entries);
@@ -158,8 +158,8 @@ public:
     const uint32_t slot = computeSlot(key);
     const uint32_t cell_index = control_->free_cell_index;
     Cell& cell = getCell(cell_index);
-    control_->free_cell_index = cell.next_cell;
-    cell.next_cell = slots_[slot];
+    control_->free_cell_index = cell.next_cell_index;
+    cell.next_cell_index = slots_[slot];
     slots_[slot] = cell_index;
     value = &cell.value;
     value->initialize(key);
@@ -180,16 +180,16 @@ public:
       Cell& cell = getCell(cell_index);
       if (cell.value.key() == key) {
         // Splice current cell out of slot-chain.
-        *cptr = cell.next_cell;
+        *cptr = cell.next_cell_index;
 
         // Splice current cell into free-list.
-        cell.next_cell = control_->free_cell_index;
+        cell.next_cell_index = control_->free_cell_index;
         control_->free_cell_index = cell_index;
 
         --control_->size;
         return true;
       }
-      next = &cell.next_cell;
+      next = &cell.next_cell_index;
     }
     return false;
   }
@@ -203,7 +203,7 @@ public:
    */
   Value* get(absl::string_view key) {
     const uint32_t slot = computeSlot(key);
-    for (uint32_t c = slots_[slot]; c != Sentinal; c = getCell(c).next_cell) {
+    for (uint32_t c = slots_[slot]; c != Sentinal; c = getCell(c).next_cell_index) {
       Cell& cell = getCell(c);
       if (cell.value.key() == key) {
         return &cell.value;
@@ -244,9 +244,9 @@ private:
     const uint32_t last_cell = options.capacity - 1;
     for (uint32_t cell_index = 0; cell_index < last_cell; ++cell_index) {
       Cell& cell = getCell(cell_index);
-      cell.next_cell = cell_index + 1;
+      cell.next_cell_index = cell_index + 1;
     }
-    getCell(last_cell).next_cell = Sentinal;
+    getCell(last_cell).next_cell_index = Sentinal;
   }
 
   /**
@@ -292,7 +292,7 @@ private:
   struct Control {
     BlockMemoryHashSetOptions options; // Options established at map construction time.
     uint64_t hash_signature;           // Hash of a constant signature string.
-    uint32_t num_bytes;                // Bytes allocated on behalf of the map.
+    size_t num_bytes;                  // Bytes allocated on behalf of the map.
     uint32_t size;                     // Number of values currently stored.
     uint32_t free_cell_index;          // Offset of first free cell.
   };
@@ -301,8 +301,8 @@ private:
    * Represents a value-cell, which is stored in a linked-list from each slot.
    */
   struct Cell {
-    uint32_t next_cell; // Offset of next cell in map->cells_, terminated with Sentinal.
-    Value value;        // Templated value field.
+    uint32_t next_cell_index; // Index of next cell in map->cells_, terminated with Sentinal.
+    Value value;              // Templated value field.
   };
 
   // It seems like this is an obvious constexpr, but it won't compile as one.
@@ -310,7 +310,7 @@ private:
     return std::max(alignof(Cell), std::max(alignof(uint32_t), alignof(Control)));
   }
 
-  static uint32_t align(uint32_t size) {
+  static size_t align(uint64_t size) {
     const size_t alignment = calculateAlignment();
     // Check that alignment is a power of 2:
     // http://www.graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2
@@ -323,10 +323,10 @@ private:
    * simply an array index because we don't know the size of a key at
    * compile-time.
    */
-  static uint32_t cellOffset(uint32_t cell_index) {
+  static size_t cellOffset(uint32_t cell_index) {
     // sizeof(Cell) includes 'sizeof Value' which may not be accurate. So we need to
     // subtract that off, and add the template method's view of the actual value-size.
-    uint32_t cell_size = align(sizeof(Cell) + Value::size() - sizeof(Value));
+    size_t cell_size = align(sizeof(Cell) + Value::size() - sizeof(Value));
     return cell_index * cell_size;
   }
 

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -24,8 +24,8 @@ namespace {
 
 // Round val up to the next multiple of the natural alignment.
 // Note: this implementation only works because 8 is a power of 2.
-size_t roundUpMultipleNaturalAlignment(size_t val) {
-  const size_t multiple = alignof(RawStatData);
+uint64_t roundUpMultipleNaturalAlignment(uint64_t val) {
+  const uint64_t multiple = alignof(RawStatData);
   static_assert(multiple == 1 || multiple == 2 || multiple == 4 || multiple == 8 || multiple == 16,
                 "multiple must be a power of 2 for this algorithm to work");
   return (val + multiple - 1) & ~(multiple - 1);
@@ -37,23 +37,23 @@ bool regexStartsWithDot(absl::string_view regex) {
 
 } // namespace
 
-size_t RawStatData::size() {
+uint64_t RawStatData::size() {
   // Normally the compiler would do this, but because name_ is a flexible-array-length
   // element, the compiler can't. RawStatData is put into an array in HotRestartImpl, so
   // it's important that each element starts on the required alignment for the type.
   return roundUpMultipleNaturalAlignment(sizeof(RawStatData) + nameSize());
 }
 
-size_t& RawStatData::initializeAndGetMutableMaxObjNameLength(size_t configured_size) {
+uint64_t& RawStatData::initializeAndGetMutableMaxObjNameLength(uint64_t configured_size) {
   // Like CONSTRUCT_ON_FIRST_USE, but non-const so that the value can be changed by tests
-  static size_t size = configured_size;
+  static uint64_t size = configured_size;
   return size;
 }
 
 void RawStatData::configure(Server::Options& options) {
-  const size_t configured = options.maxObjNameLength();
+  const uint64_t configured = options.maxObjNameLength();
   RELEASE_ASSERT(configured > 0);
-  size_t max_obj_name_length = initializeAndGetMutableMaxObjNameLength(configured);
+  uint64_t max_obj_name_length = initializeAndGetMutableMaxObjNameLength(configured);
 
   // If this fails, it means that this function was called too late during
   // startup because things were already using this size before it was set.
@@ -61,7 +61,7 @@ void RawStatData::configure(Server::Options& options) {
 }
 
 void RawStatData::configureForTestsOnly(Server::Options& options) {
-  const size_t configured = options.maxObjNameLength();
+  const uint64_t configured = options.maxObjNameLength();
   initializeAndGetMutableMaxObjNameLength(configured) = configured;
 }
 
@@ -300,7 +300,7 @@ void RawStatData::initialize(absl::string_view key) {
   ref_count_ = 1;
 
   // key is not necessarily nul-terminated, but we want to make sure name_ is.
-  size_t xfer_size = std::min(nameSize() - 1, key.size());
+  uint64_t xfer_size = std::min(nameSize() - 1, key.size());
   memcpy(name_, key.data(), xfer_size);
   name_[xfer_size] = '\0';
 }

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -222,7 +222,7 @@ struct RawStatData {
    * Returns the size of this struct, accounting for the length of name_
    * and padding for alignment. This is required by BlockMemoryHashSet.
    */
-  static size_t size();
+  static uint64_t size();
 
   /**
    * Initializes this object to have the specified key,
@@ -271,7 +271,11 @@ private:
   static const size_t DEFAULT_MAX_OBJ_NAME_LENGTH = 60;
   static const size_t MAX_STAT_SUFFIX_LENGTH = 67;
 
-  static size_t& initializeAndGetMutableMaxObjNameLength(size_t configured_size);
+  /**
+   * @return uint64_t& a reference to the configured size, which can then be changed
+   * by callers.
+   */
+  static uint64_t& initializeAndGetMutableMaxObjNameLength(size_t configured_size);
 };
 
 /**

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -275,7 +275,7 @@ private:
    * @return uint64_t& a reference to the configured size, which can then be changed
    * by callers.
    */
-  static uint64_t& initializeAndGetMutableMaxObjNameLength(size_t configured_size);
+  static uint64_t& initializeAndGetMutableMaxObjNameLength(uint64_t configured_size);
 };
 
 /**

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -37,7 +37,7 @@ static BlockMemoryHashSetOptions blockMemHashOptions(uint64_t max_stats) {
   return hash_set_options;
 }
 
-SharedMemory& SharedMemory::initialize(uint32_t stats_set_size, Options& options) {
+SharedMemory& SharedMemory::initialize(size_t stats_set_size, Options& options) {
   Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
 
   const uint64_t entry_size = Stats::RawStatData::size();

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -37,7 +37,7 @@ static BlockMemoryHashSetOptions blockMemHashOptions(uint64_t max_stats) {
   return hash_set_options;
 }
 
-SharedMemory& SharedMemory::initialize(size_t stats_set_size, Options& options) {
+SharedMemory& SharedMemory::initialize(uint64_t stats_set_size, Options& options) {
   Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
 
   const uint64_t entry_size = Stats::RawStatData::size();
@@ -109,7 +109,7 @@ void SharedMemory::initializeMutex(pthread_mutex_t& mutex) {
   pthread_mutex_init(&mutex, &attribute);
 }
 
-std::string SharedMemory::version(size_t max_num_stats, size_t max_stat_name_len) {
+std::string SharedMemory::version(uint64_t max_num_stats, uint64_t max_stat_name_len) {
   return fmt::format("{}.{}.{}.{}", VERSION, sizeof(SharedMemory), max_num_stats,
                      max_stat_name_len);
 }
@@ -479,16 +479,16 @@ std::string HotRestartImpl::version() {
 
 // Called from envoy --hot-restart-version -- needs to instantiate a RawStatDataSet so it
 // can generate the version string.
-std::string HotRestartImpl::hotRestartVersion(size_t max_num_stats, size_t max_stat_name_len) {
+std::string HotRestartImpl::hotRestartVersion(uint64_t max_num_stats, uint64_t max_stat_name_len) {
   const BlockMemoryHashSetOptions options = blockMemHashOptions(max_num_stats);
-  const size_t bytes = RawStatDataSet::numBytes(options);
+  const uint64_t bytes = RawStatDataSet::numBytes(options);
   std::unique_ptr<uint8_t[]> mem_buffer_for_dry_run_(new uint8_t[bytes]);
   RawStatDataSet stats_set(options, true /* init */, mem_buffer_for_dry_run_.get());
 
   return versionHelper(max_num_stats, max_stat_name_len, stats_set);
 }
 
-std::string HotRestartImpl::versionHelper(size_t max_num_stats, size_t max_stat_name_len,
+std::string HotRestartImpl::versionHelper(uint64_t max_num_stats, uint64_t max_stat_name_len,
                                           RawStatDataSet& stats_set) {
   return SharedMemory::version(max_num_stats, max_stat_name_len) + "." + stats_set.version();
 }

--- a/source/server/hot_restart_impl.h
+++ b/source/server/hot_restart_impl.h
@@ -48,7 +48,7 @@ private:
    * Initialize the shared memory segment, depending on whether we should be the first running
    * envoy, or a host restarted envoy process.
    */
-  static SharedMemory& initialize(size_t stats_set_size, Options& options);
+  static SharedMemory& initialize(uint64_t stats_set_size, Options& options);
 
   /**
    * Initialize a pthread mutex for process shared locking.

--- a/source/server/hot_restart_impl.h
+++ b/source/server/hot_restart_impl.h
@@ -26,7 +26,7 @@ typedef BlockMemoryHashSet<Stats::RawStatData> RawStatDataSet;
  */
 class SharedMemory {
 public:
-  static void configure(size_t max_num_stats, size_t max_stat_name_len);
+  static void configure(uint64_t max_num_stats, uint64_t max_stat_name_len);
   static std::string version(uint64_t max_num_stats, uint64_t max_stat_name_len);
 
   // Made public for testing.

--- a/source/server/hot_restart_impl.h
+++ b/source/server/hot_restart_impl.h
@@ -48,7 +48,7 @@ private:
    * Initialize the shared memory segment, depending on whether we should be the first running
    * envoy, or a host restarted envoy process.
    */
-  static SharedMemory& initialize(uint32_t stats_set_size, Options& options);
+  static SharedMemory& initialize(size_t stats_set_size, Options& options);
 
   /**
    * Initialize a pthread mutex for process shared locking.

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -123,13 +123,20 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
     throw NoServingException();
   }
 
-  if (max_obj_name_len.getValue() < 60) {
-    const std::string message = fmt::format(
-        "error: the 'max-obj-name-len' value specified ({}) is less than the minimum value of 60",
-        max_obj_name_len.getValue());
-    std::cerr << message << std::endl;
-    throw MalformedArgvException(message);
-  }
+  auto check_numeric_arg = [](bool is_error, uint64_t value, absl::string_view pattern) {
+    if (is_error) {
+      const std::string message = fmt::format(std::string(pattern), value);
+      std::cerr << message << std::endl;
+      throw MalformedArgvException(message);
+    }
+  };
+  check_numeric_arg(max_obj_name_len.getValue() < 60, max_obj_name_len.getValue(),
+                    "error: the 'max-obj-name-len' value specified ({}) is less than the minimum "
+                    "value of 60");
+  check_numeric_arg(max_stats.getValue() > 100 * 1000 * 1000, max_stats.getValue(),
+                    "error: the 'max-stats' value specified ({}) is more than the maximum value "
+                    "of 100M");
+  // TODO(jmarantz): should we also multiply these to bound the total amount of memory?
 
   hot_restart_disabled_ = disable_hot_restart.getValue();
   if (hot_restart_version_option.getValue()) {

--- a/test/common/common/block_memory_hash_set_test.cc
+++ b/test/common/common/block_memory_hash_set_test.cc
@@ -20,11 +20,11 @@ protected:
   struct TestValueBase {
     absl::string_view key() const { return name; }
     void initialize(absl::string_view key) {
-      size_t xfer = std::min(sizeof(name) - 1, key.size());
+      uint64_t xfer = std::min(sizeof(name) - 1, key.size());
       memcpy(name, key.data(), xfer);
       name[xfer] = '\0';
     }
-    static size_t size() { return sizeof(TestValue); }
+    static uint64_t size() { return sizeof(TestValue); }
 
     int64_t number;
     char name[256];

--- a/test/common/common/block_memory_hash_set_test.cc
+++ b/test/common/common/block_memory_hash_set_test.cc
@@ -64,7 +64,7 @@ protected:
     ret = fmt::format("options={}\ncontrol={}\n", hs.control_->options.toString(), control_string);
     for (uint32_t i = 0; i < hs.control_->options.num_slots; ++i) {
       ret += fmt::format("slot {}:", i);
-      for (uint32_t j = hs.slots_[i]; j != sentinal; j = hs.getCell(j).next_cell) {
+      for (uint32_t j = hs.slots_[i]; j != sentinal; j = hs.getCell(j).next_cell_index) {
         ret += " " + std::string(hs.getCell(j).value.key());
       }
       ret += "\n";

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -32,9 +32,10 @@ std::unique_ptr<OptionsImpl> createOptionsImpl(const std::string& args) {
                                                       spdlog::level::warn));
 }
 
-TEST(OptionsImplTest,
-     HotRestartVersion){EXPECT_THROW_WITH_REGEX(createOptionsImpl("envoy --hot-restart-version"),
-                                                NoServingException, "NoServingException")}
+TEST(OptionsImplTest, HotRestartVersion) {
+  EXPECT_THROW_WITH_REGEX(createOptionsImpl("envoy --hot-restart-version"), NoServingException,
+                          "NoServingException");
+}
 
 TEST(OptionsImplTest, InvalidMode) {
   EXPECT_THROW_WITH_REGEX(createOptionsImpl("envoy --mode bogus"), MalformedArgvException, "bogus");

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -32,31 +32,17 @@ std::unique_ptr<OptionsImpl> createOptionsImpl(const std::string& args) {
                                                       spdlog::level::warn));
 }
 
-TEST(OptionsImplTest, HotRestartVersion) {
-  try {
-    createOptionsImpl("envoy --hot-restart-version");
-    FAIL();
-  } catch (const NoServingException& e) {
-    SUCCEED();
-  }
-}
+TEST(OptionsImplTest,
+     HotRestartVersion){EXPECT_THROW_WITH_REGEX(createOptionsImpl("envoy --hot-restart-version"),
+                                                NoServingException, "NoServingException")}
 
 TEST(OptionsImplTest, InvalidMode) {
-  try {
-    createOptionsImpl("envoy --mode bogus");
-    FAIL();
-  } catch (const MalformedArgvException& e) {
-    EXPECT_THAT(e.what(), HasSubstr("bogus"));
-  }
+  EXPECT_THROW_WITH_REGEX(createOptionsImpl("envoy --mode bogus"), MalformedArgvException, "bogus");
 }
 
 TEST(OptionsImplTest, InvalidCommandLine) {
-  try {
-    createOptionsImpl("envoy --blah");
-    FAIL();
-  } catch (const MalformedArgvException& e) {
-    EXPECT_THAT(e.what(), HasSubstr("Couldn't find match for argument"));
-  }
+  EXPECT_THROW_WITH_REGEX(createOptionsImpl("envoy --blah"), MalformedArgvException,
+                          "Couldn't find match for argument");
 }
 
 TEST(OptionsImplTest, All) {

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -18,6 +18,7 @@
 using testing::HasSubstr;
 
 namespace Envoy {
+
 // Do the ugly work of turning a std::string into a char** and create an OptionsImpl. Args are
 // separated by a single space: no fancy quoting or escaping.
 std::unique_ptr<OptionsImpl> createOptionsImpl(const std::string& args) {
@@ -143,28 +144,18 @@ TEST(OptionsImplTest, DefaultParams) {
 }
 
 TEST(OptionsImplTest, BadCliOption) {
-  try {
-    createOptionsImpl("envoy -c hello --local-address-ip-version foo");
-    FAIL();
-  } catch (const MalformedArgvException& e) {
-    EXPECT_THAT(e.what(), HasSubstr("error: unknown IP address version 'foo'"));
-  }
+  EXPECT_THROW_WITH_REGEX(createOptionsImpl("envoy -c hello --local-address-ip-version foo"),
+                          MalformedArgvException, "error: unknown IP address version 'foo'");
 }
 
 TEST(OptionsImplTest, BadObjNameLenOption) {
-  try {
-    createOptionsImpl("envoy --max-obj-name-len 1");
-    FAIL();
-  } catch (const MalformedArgvException& e) {
-    EXPECT_THAT(e.what(), HasSubstr("'max-obj-name-len' value specified"));
-  }
+  EXPECT_THROW_WITH_REGEX(createOptionsImpl("envoy --max-obj-name-len 1"), MalformedArgvException,
+                          "'max-obj-name-len' value specified");
 }
+
 TEST(OptionsImplTest, BadMaxStatsOption) {
-  try {
-    createOptionsImpl("envoy --max-stats 1000000000");
-    FAIL();
-  } catch (const MalformedArgvException& e) {
-    EXPECT_THAT(e.what(), HasSubstr("'max-stats' value specified"));
-  }
+  EXPECT_THROW_WITH_REGEX(createOptionsImpl("envoy --max-stats 1000000000"), MalformedArgvException,
+                          "'max-stats' value specified");
 }
+
 } // namespace Envoy

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -159,4 +159,12 @@ TEST(OptionsImplTest, BadObjNameLenOption) {
     EXPECT_THAT(e.what(), HasSubstr("'max-obj-name-len' value specified"));
   }
 }
+TEST(OptionsImplTest, BadMaxStatsOption) {
+  try {
+    createOptionsImpl("envoy --max-stats 1000000000");
+    FAIL();
+  } catch (const MalformedArgvException& e) {
+    EXPECT_THAT(e.what(), HasSubstr("'max-stats' value specified"));
+  }
+}
 } // namespace Envoy


### PR DESCRIPTION
*Description*:
>Allows >4G of stats memory to be addressable by BlockMemoryHashSet by changing uint32_t to size_t for byte-offsets and sizes. Also adds an options-parsing sanity check to avoid huge numbers of stats, which will be successfully allocated, but SIGBUS when being initialized if they exceed the physical capacity of the machine.

*Risk Level*: Low
*Testing*: /test/...
Also tested that 30M stats:
```
bazel-bin/source/exe/envoy-static --config-path  $CFG --mode init_only --max-stats 30000000
```
works now, which SEGV'd prior to this change due to the 32-bit byte-offset limitation.

*Docs Changes*:  updating --max-stats doc in `docs/root/operations/cli.rst`
*Release Notes*: N/A

Fixes https://github.com/envoyproxy/envoy/issues/3463

