### PR TITLE
config_validate: Fix for crash when running in config validation mode with DNS specific config

### DIFF
--- a/source/server/config_validation/BUILD
+++ b/source/server/config_validation/BUILD
@@ -56,6 +56,7 @@ envoy_cc_library(
     hdrs = [
         "connection.h",
         "dispatcher.h",
+        "dns.h",
     ],
     deps = [
         "//include/envoy/event:dispatcher_interface",

--- a/source/server/config_validation/dispatcher.cc
+++ b/source/server/config_validation/dispatcher.cc
@@ -18,7 +18,7 @@ Network::ClientConnectionPtr ValidationDispatcher::createClientConnection(
 
 Network::DnsResolverSharedPtr ValidationDispatcher::createDnsResolver(
     const std::vector<Network::Address::InstanceConstSharedPtr>&) {
-  NOT_IMPLEMENTED;
+  return Network::DnsResolverSharedPtr(dns_resolver_);
 }
 
 Network::ListenerPtr ValidationDispatcher::createListener(Network::Socket&,

--- a/source/server/config_validation/dispatcher.h
+++ b/source/server/config_validation/dispatcher.h
@@ -4,6 +4,8 @@
 
 #include "common/event/dispatcher_impl.h"
 
+#include "dns.h"
+
 namespace Envoy {
 namespace Event {
 
@@ -23,6 +25,10 @@ public:
   Network::ListenerPtr createListener(Network::Socket&, Network::ListenerCallbacks&,
                                       bool bind_to_port,
                                       bool hand_off_restored_destination_connections) override;
+
+protected:
+  std::shared_ptr<Network::ValidationDnsResolver> dns_resolver_{
+      std::make_shared<Network::ValidationDnsResolver>()};
 };
 
 } // namespace Event

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -62,7 +62,9 @@ public:
   Upstream::ClusterManager& clusterManager() override { return *config_->clusterManager(); }
   Ssl::ContextManager& sslContextManager() override { return *ssl_context_manager_; }
   Event::Dispatcher& dispatcher() override { return *dispatcher_; }
-  Network::DnsResolverSharedPtr dnsResolver() override { return dns_resolver_; }
+  Network::DnsResolverSharedPtr dnsResolver() override {
+    return dispatcher().createDnsResolver({});
+  }
   void drainListeners() override { NOT_IMPLEMENTED; }
   DrainManager& drainManager() override { NOT_IMPLEMENTED; }
   AccessLog::AccessLogManager& accessLogManager() override { return access_log_manager_; }
@@ -142,7 +144,6 @@ private:
   Runtime::RandomGeneratorImpl random_generator_;
   std::unique_ptr<Ssl::ContextManagerImpl> ssl_context_manager_;
   std::unique_ptr<Configuration::Main> config_;
-  std::shared_ptr<Network::ValidationDnsResolver> dns_resolver_{new Network::ValidationDnsResolver};
   LocalInfo::LocalInfoPtr local_info_;
   AccessLog::AccessLogManagerImpl access_log_manager_;
   std::unique_ptr<Upstream::ValidationClusterManagerFactory> cluster_manager_factory_;

--- a/test/server/config_validation/BUILD
+++ b/test/server/config_validation/BUILD
@@ -64,6 +64,7 @@ envoy_cc_test(
     deps = [
         "//source/common/event:libevent_lib",
         "//source/server/config_validation:api_lib",
+        "//source/server/config_validation:dns_lib",
         "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
     ],

--- a/test/server/config_validation/dispatcher_test.cc
+++ b/test/server/config_validation/dispatcher_test.cc
@@ -42,8 +42,20 @@ TEST_P(ConfigValidation, createConnection) {
   SUCCEED();
 }
 
+// Make sure that creating DnsResolver does not cause crash and each call to create
+// DNS resolver returns the same shared_ptr.
+TEST_F(ConfigValidation, SharedDnsResolver) {
+  std::vector<Network::Address::InstanceConstSharedPtr> resolvers;
+
+  Network::DnsResolverSharedPtr dns1 = dispatcher_->createDnsResolver(resolvers);
+  long use_count = dns1.use_count();
+  Network::DnsResolverSharedPtr dns2 = dispatcher_->createDnsResolver(resolvers);
+
+  EXPECT_EQ(dns1.get(), dns2.get());          // Both point to the same instance.
+  EXPECT_EQ(use_count + 1, dns2.use_count()); // Each call causes ++ in use_count.
+}
+
 INSTANTIATE_TEST_CASE_P(IpVersions, ConfigValidation,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
-
 } // namespace Envoy


### PR DESCRIPTION
*Description*:
Implemented no-op DNS resolver which is instantiated when running in config validation mode.

*Risk Level*: 
Low

*Testing*:
Added Unit test to verify that DNS resolver returns expected value.

*Docs Changes*:
No

*Release Notes*:
No

Fixes #2881 
