### PR TITLE
Upgrade gperftools, spdlog, grpc, opentracing-cpp, jinja, rules_go

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -31,9 +31,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/fmtlib/fmt/releases/download/4.0.0/fmt-4.0.0.zip"],
     ),
     com_github_gabime_spdlog = dict(
-        sha256 = "b88d7be261d9089c817fc8cee6c000d69f349b357828e4c7f66985bc5d5360b8",
-        strip_prefix = "spdlog-0.16.3",
-        urls = ["https://github.com/gabime/spdlog/archive/v0.16.3.tar.gz"],
+        sha256 = "94f74fd1b3344733d1db3de2ec22e6cbeb769f93a8baa0d4a22b1f62dc7369f8",
+        strip_prefix = "spdlog-0.17.0",
+        urls = ["https://github.com/gabime/spdlog/archive/v0.17.0.tar.gz"],
     ),
     com_github_gcovr_gcovr = dict(
         commit = "c0d77201039c7b119b18bc7fb991564c602dd75d",
@@ -44,11 +44,11 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/google/libprotobuf-mutator",
     ),
     com_github_grpc_grpc = dict(
-        commit = "bd44e485f69d70ca4095cea92decd98de3892aa6", # v1.11.0
+        commit = "bec3b5ada2c5e5d782dff0b7b5018df646b65cb0", # v1.12.0
         remote = "https://github.com/grpc/grpc.git",
     ),
     io_opentracing_cpp = dict(
-        commit = "900f9d9297a71ddf4a5dff2051a01493014c07c5", # v1.4.0
+        commit = "3b36b084a4d7fffc196eac83203cf24dfb8696b3", # v1.4.2
         remote = "https://github.com/opentracing/opentracing-cpp",
     ),
     com_lightstep_tracer_cpp = dict(
@@ -64,7 +64,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/nodejs/http-parser",
     ),
     com_github_pallets_jinja = dict(
-        commit = "d78a1b079cd985eea7d636f79124ab4fc44cb538",  # 2.9.6
+        commit = "78d2f672149e5b9b7d539c575d2c1bfc12db67a9",  # 2.10
         remote = "https://github.com/pallets/jinja",
     ),
     com_github_pallets_markupsafe = dict(
@@ -89,7 +89,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/grpc-ecosystem/grpc-httpjson-transcoding",
     ),
     io_bazel_rules_go = dict(
-        commit = "0.10.3",
+        commit = "0.11.1",
         remote = "https://github.com/bazelbuild/rules_go",
     ),
     six_archive = dict(

--- a/ci/build_container/build_recipes/gperftools.sh
+++ b/ci/build_container/build_recipes/gperftools.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION=2.6.3
+VERSION=2.7
 
 wget -O gperftools-"$VERSION".tar.gz https://github.com/gperftools/gperftools/releases/download/gperftools-"$VERSION"/gperftools-"$VERSION".tar.gz
 tar xf gperftools-"$VERSION".tar.gz


### PR DESCRIPTION
Signed-off-by: Michael Payne <michael@sooper.org>

dependency: Upgrade to gperftools 2.7, spdlog 0.17.0, grpc 1.12.0, opentracing-cpp 1.4.2, jinja 2.10, rules_go 0.11.1.

Description: gperftools [release notes](https://github.com/gperftools/gperftools/releases/tag/gperftools-2.7), spdlog [release notes](https://github.com/gabime/spdlog/releases/tag/v0.17.0), grpc [release notes](https://github.com/grpc/grpc/releases/tag/v1.12.0), opentracing-cpp [1.4.1](https://github.com/opentracing/opentracing-cpp/releases/tag/v1.4.1) and [1.4.2](https://github.com/opentracing/opentracing-cpp/releases/tag/v1.4.2), jinja [release notes](https://github.com/pallets/jinja/releases/tag/2.10), rules_go [release notes](https://github.com/bazelbuild/rules_go/releases/tag/0.11.1) (note that rules_go 0.12.0 breaks the build and will require a refactoring of the Bazel build rules).

Risk Level: Low

Testing: bazel test //test/... and running on local instances for 1+ weeks.

Docs Changes: none required.