### PR TITLE
listener: fix automatic injection of TLS Inspector.

### DIFF
--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -232,9 +232,9 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
                    config_factory.createTransportSocketFactory(*message, *this, server_names),
                    parent_.factory_.createNetworkFilterFactoryList(filter_chain.filters(), *this));
 
-    need_tls_inspector = filter_chain_match.transport_protocol() == "tls" ||
-                         (filter_chain_match.transport_protocol().empty() &&
-                          (!server_names.empty() || !application_protocols.empty()));
+    need_tls_inspector |= filter_chain_match.transport_protocol() == "tls" ||
+                          (filter_chain_match.transport_protocol().empty() &&
+                           (!server_names.empty() || !application_protocols.empty()));
   }
 
   // Automatically inject TLS Inspector if it wasn't configured explicitly and it's needed.

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -1444,6 +1444,8 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, TlsFilterChainWithoutTlsInspector
     filter_chains:
     - filter_chain_match:
         transport_protocol: "tls"
+    - filter_chain_match:
+        # empty
   )EOF",
                                                        Network::Address::IpVersion::v4);
 
@@ -1469,6 +1471,8 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, SniFilterChainWithoutTlsInspector
     filter_chains:
     - filter_chain_match:
         server_names: "example.com"
+    - filter_chain_match:
+        # empty
   )EOF",
                                                        Network::Address::IpVersion::v4);
 
@@ -1494,6 +1498,8 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, AlpnFilterChainWithoutTlsInspecto
     filter_chains:
     - filter_chain_match:
         application_protocols: ["h2", "http/1.1"]
+    - filter_chain_match:
+        # empty
   )EOF",
                                                        Network::Address::IpVersion::v4);
 
@@ -1520,6 +1526,8 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, CustomTransportProtocolWithSniWit
     - filter_chain_match:
         server_names: "example.com"
         transport_protocol: "custom"
+    - filter_chain_match:
+        # empty
   )EOF",
                                                        Network::Address::IpVersion::v4);
 


### PR DESCRIPTION
Previously, automatic injection was based only on the requirements
of the last filter chain and not all of them.

*Risk Level*: Low
*Testing*: bazel test //test/... (extended tests fail without the fix)
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Piotr Sikora <piotrsikora@google.com>