### PR TITLE
util: Adds some basic unit tests for check_format.py.

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -12,7 +12,8 @@ import sys
 import traceback
 
 EXCLUDED_PREFIXES = ("./generated/", "./thirdparty/", "./build", "./.git/",
-                     "./bazel-", "./bazel/external", "./.cache")
+                     "./bazel-", "./bazel/external", "./.cache",
+                     "./tools/testdata/check_format/")
 SUFFIXES = (".cc", ".h", "BUILD", ".md", ".rst", ".proto")
 DOCS_SUFFIX = (".md", ".rst")
 PROTO_SUFFIX = (".proto")

--- a/tools/check_format_test.sh
+++ b/tools/check_format_test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+tools=$(dirname $(realpath $0))
+root=$(realpath $tools/..)
+ci=$root/ci
+cd $root
+exec ./ci/run_envoy_docker.sh ./tools/check_format_test_run_under_docker.py

--- a/tools/check_format_test_run_under_docker.py
+++ b/tools/check_format_test_run_under_docker.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+
+# Tests check_format.py. This must be run under docker via
+# check_format_test.py, or you are liable to get the wrong clang, and
+# all kinds of bad results.
+
+import os
+import shutil
+import subprocess
+
+def getenvFallback(envvar, fallback):
+  val = os.getenv(envvar)
+  if not val:
+    val = fallback
+  return val
+
+tools = os.path.dirname(os.path.realpath(__file__))
+tmp = os.path.join(getenvFallback('TEST_TMPDIR', "/tmp"), "check_format_test")
+src = os.path.join(tools, 'testdata', 'check_format')
+check_format = os.path.join(tools, 'check_format.py')
+errors = 0
+
+# Runs an OS command, returning exit status and the captured stdout as
+# a string array, printing the results.
+def runCommand(command):
+  stdout = []
+  status = 0
+  try:
+    out = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).strip()
+    if out:
+      stdout = out.split("\n")
+  except subprocess.CalledProcessError as e:
+    status = e.returncode
+    for line in e.output.splitlines():
+      stdout.append(line)
+  sep = "\n    "
+  print("%s" % command)
+  return status, stdout
+
+# Runs the 'check_format' operation, on the specified file, printing
+# the comamnd run and the status code as well as the stdout, and returning
+# all of that to the caller.
+def runCheckFormat(operation, filename):
+  command = check_format + " " + operation + " " + filename
+  status, stdout = runCommand(command)
+  return (command, status, stdout)
+
+def getInputFile(filename):
+  infile = os.path.join(src, filename)
+  shutil.copyfile(infile, filename)
+  return filename
+
+# Attempts to fix file, returning a 4-tuple: the command, input file name,
+# output filename, captured stdout as an array of lines, and the error status
+# code.
+def fixFileHelper(filename):
+  infile = os.path.join(src, filename)
+  shutil.copyfile(infile, filename)
+  command, status, stdout = runCheckFormat("fix", getInputFile(filename))
+  return (command, infile, filename, status, stdout)
+
+# Attempts to fix a file, returning the status code and the generated output.
+# If the fix was successful, the diff is returned as a string-array. If the file
+# was not fixable, the error-messages are returned as a string-array.
+def fixFileExpectingSuccess(file):
+  command, infile, outfile, status, stdout = fixFileHelper(file)
+  if status != 0:
+    return 1
+  status, stdout = runCommand('diff ' + outfile + ' ' + infile + '.gold')
+  if status != 0:
+    return 1
+  return 0
+
+def fixFileExpectingNoChange(file):
+  command, infile, outfile, status, stdout = fixFileHelper(file)
+  if status != 0:
+    return 1
+  status, stdout = runCommand('diff ' + outfile + ' ' + infile)
+  if status != 0:
+    return 1
+  return 0
+
+def emitStdout(stdout):
+  for line in stdout:
+    print("    %s" % line)
+
+def expectError(status, stdout, expected_substring):
+  if status == 0:
+    print("Expected failure, but succeeded")
+    return 1
+  for line in stdout:
+    if expected_substring in line:
+      return 0
+  print("Could not find '%s' in:\n" % expected_substring)
+  emitStdout(stdout)
+  return 1
+
+def fixFileExpectingFailure(filename, expected_substring):
+  command, infile, outfile, status, stdout = fixFileHelper(filename)
+  return expectError(status, stdout, expected_substring)
+
+def checkFileExpectingError(filename, expected_substring):
+  command, status, stdout = runCheckFormat("check", getInputFile(filename))
+  return expectError(status, stdout, expected_substring)
+
+def checkFileExpectingOK(filename):
+  command, status, stdout = runCheckFormat("check", getInputFile(filename))
+  if status != 0:
+    print("status=%d, output:\n" % status)
+    emitStdout(stdout)
+  return 0
+
+if __name__ == "__main__":
+  errors = 0
+
+  # Now create a temp directory to copy the input files, so we can fix them
+  # without actually fixing our testdata. This requires chdiring to the temp
+  # directory, so it's annoying to comingle check-tests and fix-tests.
+  shutil.rmtree(tmp, True)
+  os.makedirs(tmp)
+  os.chdir(tmp)
+  errors += fixFileExpectingSuccess("over_enthusiastic_spaces.cc")
+  errors += fixFileExpectingFailure("no_namespace_envoy.cc",
+                                    "Unable to find Envoy namespace or NOLINT(namespace-envoy)")
+  errors += fixFileExpectingNoChange("ok_file.cc")
+
+  errors += checkFileExpectingError("over_enthusiastic_spaces.cc",
+                                    "./over_enthusiastic_spaces.cc:3: over-enthusiastic spaces")
+  errors += checkFileExpectingOK("ok_file.cc")
+
+  if errors != 0:
+    print("%d FAILURES" % errors)
+    exit(1)
+  print("PASS")
+  exit(0)

--- a/tools/testdata/check_format/no_namespace_envoy.cc
+++ b/tools/testdata/check_format/no_namespace_envoy.cc
@@ -1,0 +1,1 @@
+// Lacks the proper Envoy namespace.

--- a/tools/testdata/check_format/ok_file.cc
+++ b/tools/testdata/check_format/ok_file.cc
@@ -1,0 +1,5 @@
+namespace Envoy {
+
+// All is OK in this file. Really.
+
+} // namespace Envoy

--- a/tools/testdata/check_format/over_enthusiastic_spaces.cc
+++ b/tools/testdata/check_format/over_enthusiastic_spaces.cc
@@ -1,0 +1,5 @@
+namespace Envoy {
+
+// Two spaces.  No, one space is the style in Envoy.
+
+} // namespace Envoy

--- a/tools/testdata/check_format/over_enthusiastic_spaces.cc.gold
+++ b/tools/testdata/check_format/over_enthusiastic_spaces.cc.gold
@@ -1,0 +1,5 @@
+namespace Envoy {
+
+// Two spaces. No, one space is the style in Envoy.
+
+} // namespace Envoy


### PR DESCRIPTION
*Description*:
>Adds a bit of unit-testing to the format fixer/checker script, which has grown complex. These unit tests are by no means comprehensive but I thought I'd get feedback on the pattern before going much further. I actually don't have a huge amount of experience writing gunit tests in python, and it looks like there's currently no gunit tests in Python in the Envoy codebase. But I'm willing to switch this to gunit if we think that's useful.

>The underlying python test program MUST be run under docker, so it's got an awkward name and comes with a bash script to run it under docker directly.

>IMO this Python script has grown organically and needs to be refactored. I have such a refactor pending, but it's difficult to get confidence in the refactor until there are tests.

>Once the script is tested and refactored, it will be trivial to add detection of std::mutex and std::condition_variable, which is the ultimate goal.

*Risk Level*: Low

*Testing*: tools/check_format.py -- to make sure this doesn't introduce format errors itself.
Manually ran test/check_format_test.sh.

*Docs Changes*: N/A
*Release Notes*: N/A