### PR TITLE
RBAC filter test: Check JsonStringToMessage return value.

### DIFF
--- a/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
@@ -70,7 +70,7 @@ TEST_P(RBACIntegrationTest, RouteOverride) {
   config_helper_.addConfigModifier(
       [](envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager& cfg) {
         ProtobufWkt::Struct pfc;
-        Protobuf::util::JsonStringToMessage(R"EOF({"disabled": true})EOF", &pfc);
+        ASSERT_TRUE(Protobuf::util::JsonStringToMessage(R"EOF({"disabled": true})EOF", &pfc).ok());
 
         auto* config = cfg.mutable_route_config()
                            ->mutable_virtual_hosts()


### PR DESCRIPTION
Protobuf::util::JsonStringToMessage has a return value that shouldn't be
ignored. ASSERT_TRUE on it being OK in the RBAC filter integration test.

Testing: Ran existing tests.
Risk Level: low

Signed-off-by: Dan Noé <dpn@google.com>