### PR TITLE
health check: adding support for basic mysql health checks

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,3 +10,5 @@
 /*/extensions/filters/http/header_to_metadata @rgs1 @zuercher
 # alts transport socket extension
 /*/extensions/transport_sockets/alts @lizan @yangminzhu
+# mysql health_checker extension
+/*/extensions/health_checkers/mysql @Jason-Jian

--- a/api/envoy/config/health_checker/mysql/v2/BUILD
+++ b/api/envoy/config/health_checker/mysql/v2/BUILD
@@ -1,0 +1,8 @@
+load("//bazel:api_build_system.bzl", "api_proto_library")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library(
+    name = "mysql",
+    srcs = ["mysql.proto"],
+)

--- a/api/envoy/config/health_checker/mysql/v2/mysql.proto
+++ b/api/envoy/config/health_checker/mysql/v2/mysql.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package envoy.config.health_checker.mysql.v2;
+option go_package = "v2";
+
+// [#protodoc-title: MySQL]
+// MySQL health checker :ref:`configuration overview <config_health_checkers_mysql>`.
+
+// Configuration for MySQL health check. The health check involves authenticating against the MySQL
+// server with a passwordless user and closing the session immediatelly after, while validating the
+// server response. It's recommended to create a user with no privileges, exclusively for the
+// health check operation.
+message MySQL {
+  // Username to authenticate with for health checking.
+  string user = 1;
+}

--- a/api/envoy/data/core/v2alpha/health_check_event.proto
+++ b/api/envoy/data/core/v2alpha/health_check_event.proto
@@ -43,6 +43,7 @@ enum HealthCheckerType {
   TCP = 1;
   GRPC = 2;
   REDIS = 3;
+  MYSQL = 4;
 }
 
 message HealthCheckEjectUnhealthy {

--- a/docs/root/configuration/health_checkers/health_checkers.rst
+++ b/docs/root/configuration/health_checkers/health_checkers.rst
@@ -7,3 +7,4 @@ Health checkers
   :maxdepth: 2
 
   redis
+  mysql

--- a/docs/root/configuration/health_checkers/mysql.rst
+++ b/docs/root/configuration/health_checkers/mysql.rst
@@ -1,0 +1,13 @@
+.. _config_health_checkers_mysql:
+
+MySQL
+=====
+
+The MySQL health checker is a custom health checker which checks MySQL upstream hosts. It sends
+a MySQL LOGIN command followed by a QUIT command, so that the session is ended properly, and expects
+an OK response. The upstream MySQL server can respond with anything other than OK to cause an
+immediate active health check failure. A user name must be provided for the LOGIN command to
+authenticate with. Such user must not have an associated password (passwordless). It's recommended
+to create a MySQL user with no privileges, exclusively for the health check operation.
+
+* :ref:`v2 API reference <envoy_api_msg_core.HealthCheck.CustomHealthCheck>`

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -101,6 +101,7 @@ Version history
   <envoy_api_field_core.HealthCheck.unhealthy_edge_interval>`, :ref:`unhealthy to healthy
   <envoy_api_field_core.HealthCheck.healthy_edge_interval>` and for subsequent checks on
   :ref:`unhealthy hosts <envoy_api_field_core.HealthCheck.unhealthy_interval>`.
+* health check: added basic support for :ref:`MySQL health checks <config_health_checkers_mysql>`.
 * health check: added support for :ref:`custom health check <envoy_api_field_core.HealthCheck.custom_health_check>`.
 * health check: health check connections can now be configured to use http/2.
 * health check http filter: added

--- a/include/envoy/buffer/BUILD
+++ b/include/envoy/buffer/BUILD
@@ -11,5 +11,8 @@ envoy_package()
 envoy_cc_library(
     name = "buffer_interface",
     hdrs = ["buffer.h"],
-    deps = ["//include/envoy/api:os_sys_calls_interface"],
+    deps = [
+        "//include/envoy/api:os_sys_calls_interface",
+        "//source/common/common:byte_order_lib",
+    ],
 )

--- a/source/common/common/byte_order.h
+++ b/source/common/common/byte_order.h
@@ -25,3 +25,147 @@
 #include <endian.h>
 
 #endif
+
+enum class ByteOrder { Host, LittleEndian, BigEndian };
+
+template <ByteOrder, typename Integral, size_t = sizeof(Integral)> struct EndiannessConverter;
+
+// convenience function that converts an integral from host byte-order to a specified endianness
+template <ByteOrder Endianness, typename T> inline T toEndianness(T value) {
+  return EndiannessConverter<Endianness, T>::to(value);
+}
+
+// convenience function that converts an integral from a specified endianness to host byte-order
+template <ByteOrder Endianness, typename T> inline T fromEndianness(T value) {
+  return EndiannessConverter<Endianness, T>::from(value);
+}
+
+// convenience function that converts a host byte-order integral to little endian byte-order
+template <typename T> inline T toLittleEndian(T value) {
+  return EndiannessConverter<ByteOrder::LittleEndian, T>::to(value);
+}
+
+// convenience function that converts a little endian byte-order integral to host byte-order
+template <typename T> inline T fromLittleEndian(T value) {
+  return EndiannessConverter<ByteOrder::LittleEndian, T>::from(value);
+}
+
+// convenience function that converts a host byte-order integral to big endian byte-order
+template <typename T> inline T toBigEndian(T value) {
+  return EndiannessConverter<ByteOrder::BigEndian, T>::to(value);
+}
+
+// convenience function that converts a big endian byte-order integral to host byte-order
+template <typename T> inline T fromBigEndian(T value) {
+  return EndiannessConverter<ByteOrder::BigEndian, T>::from(value);
+}
+
+// Implementation details below
+
+// implementation details of EndiannessConverter for 8-bit host endianness integrals
+template <typename T> struct EndiannessConverter<ByteOrder::Host, T, sizeof(uint8_t)> {
+  static_assert(sizeof(T) == sizeof(uint8_t), "incorrect type width");
+
+  static T to(T value) { return value; }
+
+  static T from(T value) { return value; }
+};
+
+// implementation details of EndiannessConverter for 16-bit host endianness integrals
+template <typename T> struct EndiannessConverter<ByteOrder::Host, T, sizeof(uint16_t)> {
+  static_assert(sizeof(T) == sizeof(uint16_t), "incorrect type width");
+
+  static T to(T value) { return value; }
+
+  static T from(T value) { return value; }
+};
+
+// implementation details of EndiannessConverter for 32-bit host endianness integrals
+template <typename T> struct EndiannessConverter<ByteOrder::Host, T, sizeof(uint32_t)> {
+  static_assert(sizeof(T) == sizeof(uint32_t), "incorrect type width");
+
+  static T to(T value) { return value; }
+
+  static T from(T value) { return value; }
+};
+
+// implementation details of EndiannessConverter for 64-bit host endianness integrals
+template <typename T> struct EndiannessConverter<ByteOrder::Host, T, sizeof(uint64_t)> {
+  static_assert(sizeof(T) == sizeof(uint64_t), "incorrect type width");
+
+  static T to(T value) { return value; }
+
+  static T from(T value) { return value; }
+};
+
+// implementation details of EndiannessConverter for 8-bit little endian integrals
+template <typename T> struct EndiannessConverter<ByteOrder::LittleEndian, T, sizeof(uint8_t)> {
+  static_assert(sizeof(T) == sizeof(uint8_t), "incorrect type width");
+
+  static T to(T value) { return value; }
+
+  static T from(T value) { return value; }
+};
+
+// implementation details of EndiannessConverter for 16-bit little endian integrals
+template <typename T> struct EndiannessConverter<ByteOrder::LittleEndian, T, sizeof(uint16_t)> {
+  static_assert(sizeof(T) == sizeof(uint16_t), "incorrect type width");
+
+  static T to(T value) { return static_cast<T>(htole16(static_cast<uint16_t>(value))); }
+
+  static T from(T value) { return static_cast<T>(le16toh(static_cast<uint16_t>(value))); }
+};
+
+// implementation details of EndiannessConverter for 32-bit little endian integrals
+template <typename T> struct EndiannessConverter<ByteOrder::LittleEndian, T, sizeof(uint32_t)> {
+  static_assert(sizeof(T) == sizeof(uint32_t), "incorrect type width");
+
+  static T to(T value) { return static_cast<T>(htole32(static_cast<uint32_t>(value))); }
+
+  static T from(T value) { return static_cast<T>(le32toh(static_cast<uint32_t>(value))); }
+};
+
+// implementation details of EndiannessConverter for 64-bit little endian integrals
+template <typename T> struct EndiannessConverter<ByteOrder::LittleEndian, T, sizeof(uint64_t)> {
+  static_assert(sizeof(T) == sizeof(uint64_t), "incorrect type width");
+
+  static T to(T value) { return static_cast<T>(htole64(static_cast<uint64_t>(value))); }
+
+  static T from(T value) { return static_cast<T>(le64toh(static_cast<uint64_t>(value))); }
+};
+
+// implementation details of EndiannessConverter for 8-bit big endian integrals
+template <typename T> struct EndiannessConverter<ByteOrder::BigEndian, T, sizeof(uint8_t)> {
+  static_assert(sizeof(T) == sizeof(uint8_t), "incorrect type width");
+
+  static T to(T value) { return value; }
+
+  static T from(T value) { return value; }
+};
+
+// implementation details of EndiannessConverter for 16-bit big endian integrals
+template <typename T> struct EndiannessConverter<ByteOrder::BigEndian, T, sizeof(uint16_t)> {
+  static_assert(sizeof(T) == sizeof(uint16_t), "incorrect type width");
+
+  static T to(T value) { return static_cast<T>(htobe16(static_cast<uint16_t>(value))); }
+
+  static T from(T value) { return static_cast<T>(be16toh(static_cast<uint16_t>(value))); }
+};
+
+// implementation details of EndiannessConverter for 32-bit big endian integrals
+template <typename T> struct EndiannessConverter<ByteOrder::BigEndian, T, sizeof(uint32_t)> {
+  static_assert(sizeof(T) == sizeof(uint32_t), "incorrect type width");
+
+  static T to(T value) { return static_cast<T>(htobe32(static_cast<uint32_t>(value))); }
+
+  static T from(T value) { return static_cast<T>(be32toh(static_cast<uint32_t>(value))); }
+};
+
+// implementation details of EndiannessConverter for 64-bit big endian integrals
+template <typename T> struct EndiannessConverter<ByteOrder::BigEndian, T, sizeof(uint64_t)> {
+  static_assert(sizeof(T) == sizeof(uint64_t), "incorrect type width");
+
+  static T to(T value) { return static_cast<T>(htobe64(static_cast<uint64_t>(value))); }
+
+  static T from(T value) { return static_cast<T>(be64toh(static_cast<uint64_t>(value))); }
+};

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -18,6 +18,7 @@ EXTENSIONS = {
     #
 
     "envoy.health_checkers.redis":                      "//source/extensions/health_checkers/redis:config",
+    "envoy.health_checkers.mysql":                      "//source/extensions/health_checkers/mysql:config",
 
     #
     # HTTP filters

--- a/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
@@ -30,7 +30,7 @@ bool BinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, std::string&
     return false;
   }
 
-  uint16_t version = BufferHelper::peekU16(buffer);
+  uint16_t version = buffer.peekBEInt<uint16_t>();
   if (version != Magic) {
     throw EnvoyException(
         fmt::format("invalid binary protocol version 0x{:04x} != 0x{:04x}", version, Magic));
@@ -38,13 +38,13 @@ bool BinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, std::string&
 
   // The byte at offset 2 is unused and ignored.
 
-  MessageType type = static_cast<MessageType>(BufferHelper::peekI8(buffer, 3));
+  MessageType type = static_cast<MessageType>(buffer.peekInt<int8_t>(3));
   if (type < MessageType::Call || type > MessageType::LastMessageType) {
     throw EnvoyException(
         fmt::format("invalid binary protocol message type {}", static_cast<int8_t>(type)));
   }
 
-  uint32_t name_len = BufferHelper::peekU32(buffer, 4);
+  uint32_t name_len = buffer.peekBEInt<uint32_t>(4);
   if (buffer.length() < name_len + 12) {
     return false;
   }
@@ -58,7 +58,7 @@ bool BinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, std::string&
     name.clear();
   }
   msg_type = type;
-  seq_id = BufferHelper::drainI32(buffer);
+  seq_id = buffer.drainBEIntOut<int32_t>();
 
   return true;
 }
@@ -86,7 +86,7 @@ bool BinaryProtocolImpl::readFieldBegin(Buffer::Instance& buffer, std::string& n
     return false;
   }
 
-  FieldType type = static_cast<FieldType>(BufferHelper::peekI8(buffer));
+  FieldType type = static_cast<FieldType>(buffer.peekInt<int8_t>());
   if (type == FieldType::Stop) {
     field_id = 0;
     buffer.drain(1);
@@ -95,7 +95,7 @@ bool BinaryProtocolImpl::readFieldBegin(Buffer::Instance& buffer, std::string& n
     if (buffer.length() < 3) {
       return false;
     }
-    int16_t id = BufferHelper::peekI16(buffer, 1);
+    int16_t id = buffer.peekBEInt<int16_t>(1);
     if (id < 0) {
       throw EnvoyException(fmt::format("invalid binary protocol field id {}", id));
     }
@@ -124,9 +124,9 @@ bool BinaryProtocolImpl::readMapBegin(Buffer::Instance& buffer, FieldType& key_t
     return false;
   }
 
-  FieldType ktype = static_cast<FieldType>(BufferHelper::peekI8(buffer, 0));
-  FieldType vtype = static_cast<FieldType>(BufferHelper::peekI8(buffer, 1));
-  int32_t s = BufferHelper::peekI32(buffer, 2);
+  FieldType ktype = static_cast<FieldType>(buffer.peekInt<int8_t>(0));
+  FieldType vtype = static_cast<FieldType>(buffer.peekInt<int8_t>(1));
+  int32_t s = buffer.peekBEInt<int32_t>(2);
   if (s < 0) {
     throw EnvoyException(fmt::format("negative binary protocol map size {}", s));
   }
@@ -154,8 +154,8 @@ bool BinaryProtocolImpl::readListBegin(Buffer::Instance& buffer, FieldType& elem
     return false;
   }
 
-  FieldType type = static_cast<FieldType>(BufferHelper::peekI8(buffer));
-  int32_t s = BufferHelper::peekI32(buffer, 1);
+  FieldType type = static_cast<FieldType>(buffer.peekInt<int8_t>());
+  int32_t s = buffer.peekBEInt<int32_t>(1);
   if (s < 0) {
     throw EnvoyException(fmt::format("negative binary protocol list/set size {}", s));
   }
@@ -184,7 +184,7 @@ bool BinaryProtocolImpl::readBool(Buffer::Instance& buffer, bool& value) {
     return false;
   }
 
-  value = BufferHelper::drainI8(buffer) != 0;
+  value = buffer.drainInt<int8_t>() != 0;
   return true;
 }
 
@@ -192,7 +192,7 @@ bool BinaryProtocolImpl::readByte(Buffer::Instance& buffer, uint8_t& value) {
   if (buffer.length() < 1) {
     return false;
   }
-  value = BufferHelper::drainI8(buffer);
+  value = buffer.drainInt<int8_t>();
   return true;
 }
 
@@ -200,7 +200,7 @@ bool BinaryProtocolImpl::readInt16(Buffer::Instance& buffer, int16_t& value) {
   if (buffer.length() < 2) {
     return false;
   }
-  value = BufferHelper::drainI16(buffer);
+  value = buffer.drainBEIntOut<int16_t>();
   return true;
 }
 
@@ -208,7 +208,7 @@ bool BinaryProtocolImpl::readInt32(Buffer::Instance& buffer, int32_t& value) {
   if (buffer.length() < 4) {
     return false;
   }
-  value = BufferHelper::drainI32(buffer);
+  value = buffer.drainBEIntOut<int32_t>();
   return true;
 }
 
@@ -216,7 +216,7 @@ bool BinaryProtocolImpl::readInt64(Buffer::Instance& buffer, int64_t& value) {
   if (buffer.length() < 8) {
     return false;
   }
-  value = BufferHelper::drainI64(buffer);
+  value = buffer.drainBEIntOut<int64_t>();
   return true;
 }
 
@@ -227,7 +227,7 @@ bool BinaryProtocolImpl::readDouble(Buffer::Instance& buffer, double& value) {
     return false;
   }
 
-  value = BufferHelper::drainDouble(buffer);
+  value = BufferHelper::drainBEDouble(buffer);
   return true;
 }
 
@@ -237,7 +237,7 @@ bool BinaryProtocolImpl::readString(Buffer::Instance& buffer, std::string& value
     return false;
   }
 
-  int32_t str_len = BufferHelper::peekI32(buffer);
+  int32_t str_len = buffer.peekBEInt<int32_t>();
   if (str_len < 0) {
     throw EnvoyException(fmt::format("negative binary protocol string/binary length {}", str_len));
   }
@@ -264,10 +264,10 @@ bool BinaryProtocolImpl::readBinary(Buffer::Instance& buffer, std::string& value
 
 void BinaryProtocolImpl::writeMessageBegin(Buffer::Instance& buffer, const std::string& name,
                                            MessageType msg_type, int32_t seq_id) {
-  BufferHelper::writeU16(buffer, Magic);
-  BufferHelper::writeU16(buffer, static_cast<uint16_t>(msg_type));
+  buffer.writeBEInt<uint16_t>(Magic);
+  buffer.writeBEInt<uint16_t>(static_cast<uint16_t>(msg_type));
   writeString(buffer, name);
-  BufferHelper::writeI32(buffer, seq_id);
+  buffer.writeBEInt<int32_t>(seq_id);
 }
 
 void BinaryProtocolImpl::writeMessageEnd(Buffer::Instance& buffer) {
@@ -287,12 +287,12 @@ void BinaryProtocolImpl::writeFieldBegin(Buffer::Instance& buffer, const std::st
                                          FieldType field_type, int16_t field_id) {
   UNREFERENCED_PARAMETER(name);
 
-  BufferHelper::writeI8(buffer, static_cast<uint8_t>(field_type));
+  buffer.writeByte(static_cast<uint8_t>(field_type));
   if (field_type == FieldType::Stop) {
     return;
   }
 
-  BufferHelper::writeI16(buffer, field_id);
+  buffer.writeBEInt<int16_t>(field_id);
 }
 
 void BinaryProtocolImpl::writeFieldEnd(Buffer::Instance& buffer) { UNREFERENCED_PARAMETER(buffer); }
@@ -303,9 +303,9 @@ void BinaryProtocolImpl::writeMapBegin(Buffer::Instance& buffer, FieldType key_t
     throw EnvoyException(fmt::format("illegal binary protocol map size {}", size));
   }
 
-  BufferHelper::writeI8(buffer, static_cast<int8_t>(key_type));
-  BufferHelper::writeI8(buffer, static_cast<int8_t>(value_type));
-  BufferHelper::writeI32(buffer, static_cast<int32_t>(size));
+  buffer.writeByte(static_cast<int8_t>(key_type));
+  buffer.writeByte(static_cast<int8_t>(value_type));
+  buffer.writeBEInt<int32_t>(static_cast<int32_t>(size));
 }
 
 void BinaryProtocolImpl::writeMapEnd(Buffer::Instance& buffer) { UNREFERENCED_PARAMETER(buffer); }
@@ -316,8 +316,8 @@ void BinaryProtocolImpl::writeListBegin(Buffer::Instance& buffer, FieldType elem
     throw EnvoyException(fmt::format("illegal binary protocol list/set size {}", size));
   }
 
-  BufferHelper::writeI8(buffer, static_cast<int8_t>(elem_type));
-  BufferHelper::writeI32(buffer, static_cast<int32_t>(size));
+  buffer.writeByte(static_cast<int8_t>(elem_type));
+  buffer.writeBEInt<int32_t>(static_cast<int32_t>(size));
 }
 
 void BinaryProtocolImpl::writeListEnd(Buffer::Instance& buffer) { UNREFERENCED_PARAMETER(buffer); }
@@ -330,31 +330,31 @@ void BinaryProtocolImpl::writeSetBegin(Buffer::Instance& buffer, FieldType elem_
 void BinaryProtocolImpl::writeSetEnd(Buffer::Instance& buffer) { writeListEnd(buffer); }
 
 void BinaryProtocolImpl::writeBool(Buffer::Instance& buffer, bool value) {
-  BufferHelper::writeI8(buffer, value ? 1 : 0);
+  buffer.writeByte(value ? 1 : 0);
 }
 
 void BinaryProtocolImpl::writeByte(Buffer::Instance& buffer, uint8_t value) {
-  BufferHelper::writeI8(buffer, value);
+  buffer.writeByte(value);
 }
 
 void BinaryProtocolImpl::writeInt16(Buffer::Instance& buffer, int16_t value) {
-  BufferHelper::writeI16(buffer, value);
+  buffer.writeBEInt<int16_t>(value);
 }
 
 void BinaryProtocolImpl::writeInt32(Buffer::Instance& buffer, int32_t value) {
-  BufferHelper::writeI32(buffer, value);
+  buffer.writeBEInt<int32_t>(value);
 }
 
 void BinaryProtocolImpl::writeInt64(Buffer::Instance& buffer, int64_t value) {
-  BufferHelper::writeI64(buffer, value);
+  buffer.writeBEInt<int64_t>(value);
 }
 
 void BinaryProtocolImpl::writeDouble(Buffer::Instance& buffer, double value) {
-  BufferHelper::writeDouble(buffer, value);
+  BufferHelper::writeBEDouble(buffer, value);
 }
 
 void BinaryProtocolImpl::writeString(Buffer::Instance& buffer, const std::string& value) {
-  BufferHelper::writeU32(buffer, value.length());
+  buffer.writeBEInt<uint32_t>(value.length());
   buffer.add(value);
 }
 
@@ -373,13 +373,13 @@ bool LaxBinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, std::stri
     return false;
   }
 
-  uint32_t name_len = BufferHelper::peekU32(buffer);
+  uint32_t name_len = buffer.peekBEInt<uint32_t>();
 
   if (buffer.length() < 9 + name_len) {
     return false;
   }
 
-  MessageType type = static_cast<MessageType>(BufferHelper::peekI8(buffer, name_len + 4));
+  MessageType type = static_cast<MessageType>(buffer.peekInt<int8_t>(name_len + 4));
   if (type < MessageType::Call || type > MessageType::LastMessageType) {
     throw EnvoyException(
         fmt::format("invalid (lax) binary protocol message type {}", static_cast<int8_t>(type)));
@@ -394,7 +394,7 @@ bool LaxBinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, std::stri
   }
 
   msg_type = type;
-  seq_id = BufferHelper::peekI32(buffer, 1);
+  seq_id = buffer.peekBEInt<int32_t>(1);
   buffer.drain(5);
 
   return true;
@@ -403,8 +403,8 @@ bool LaxBinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, std::stri
 void LaxBinaryProtocolImpl::writeMessageBegin(Buffer::Instance& buffer, const std::string& name,
                                               MessageType msg_type, int32_t seq_id) {
   writeString(buffer, name);
-  BufferHelper::writeI8(buffer, static_cast<int8_t>(msg_type));
-  BufferHelper::writeI32(buffer, seq_id);
+  buffer.writeByte(static_cast<int8_t>(msg_type));
+  buffer.writeBEInt<int32_t>(seq_id);
 }
 
 class BinaryProtocolConfigFactory : public ProtocolFactoryBase<BinaryProtocolImpl> {

--- a/source/extensions/filters/network/thrift_proxy/buffer_helper.cc
+++ b/source/extensions/filters/network/thrift_proxy/buffer_helper.cc
@@ -7,113 +7,7 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace ThriftProxy {
 
-int8_t BufferHelper::peekI8(Buffer::Instance& buffer, uint64_t offset) {
-  if (buffer.length() < offset + 1) {
-    throw EnvoyException("buffer underflow");
-  }
-
-  int8_t i;
-  buffer.copyOut(offset, 1, &i);
-  return i;
-}
-
-int16_t BufferHelper::peekI16(Buffer::Instance& buffer, uint64_t offset) {
-  if (buffer.length() < offset + 2) {
-    throw EnvoyException("buffer underflow");
-  }
-
-  int16_t i;
-  buffer.copyOut(offset, 2, &i);
-  return be16toh(i);
-}
-
-int32_t BufferHelper::peekI32(Buffer::Instance& buffer, uint64_t offset) {
-  if (buffer.length() < offset + 4) {
-    throw EnvoyException("buffer underflow");
-  }
-
-  int32_t i;
-  buffer.copyOut(offset, 4, &i);
-  return be32toh(i);
-}
-
-int64_t BufferHelper::peekI64(Buffer::Instance& buffer, uint64_t offset) {
-  if (buffer.length() < offset + 8) {
-    throw EnvoyException("buffer underflow");
-  }
-
-  int64_t i;
-  buffer.copyOut(offset, 8, &i);
-  return be64toh(i);
-}
-
-uint16_t BufferHelper::peekU16(Buffer::Instance& buffer, uint64_t offset) {
-  if (buffer.length() < offset + 2) {
-    throw EnvoyException("buffer underflow");
-  }
-
-  uint16_t i;
-  buffer.copyOut(offset, 2, &i);
-  return be16toh(i);
-}
-
-uint32_t BufferHelper::peekU32(Buffer::Instance& buffer, uint64_t offset) {
-  if (buffer.length() < offset + 4) {
-    throw EnvoyException("buffer underflow");
-  }
-
-  uint32_t i;
-  buffer.copyOut(offset, 4, &i);
-  return be32toh(i);
-}
-
-uint64_t BufferHelper::peekU64(Buffer::Instance& buffer, uint64_t offset) {
-  if (buffer.length() < offset + 8) {
-    throw EnvoyException("buffer underflow");
-  }
-
-  uint64_t i;
-  buffer.copyOut(offset, 8, &i);
-  return be64toh(i);
-}
-
-int8_t BufferHelper::drainI8(Buffer::Instance& buffer) {
-  int8_t i = peekI8(buffer);
-  buffer.drain(1);
-  return i;
-}
-
-int16_t BufferHelper::drainI16(Buffer::Instance& buffer) {
-  int16_t i = peekI16(buffer);
-  buffer.drain(2);
-  return i;
-}
-
-int32_t BufferHelper::drainI32(Buffer::Instance& buffer) {
-  int32_t i = peekI32(buffer);
-  buffer.drain(4);
-  return i;
-}
-
-int64_t BufferHelper::drainI64(Buffer::Instance& buffer) {
-  int64_t i = peekI64(buffer);
-  buffer.drain(8);
-  return i;
-}
-
-uint32_t BufferHelper::drainU32(Buffer::Instance& buffer) {
-  uint32_t i = peekU32(buffer);
-  buffer.drain(4);
-  return i;
-}
-
-uint64_t BufferHelper::drainU64(Buffer::Instance& buffer) {
-  uint64_t i = peekU64(buffer);
-  buffer.drain(8);
-  return i;
-}
-
-double BufferHelper::drainDouble(Buffer::Instance& buffer) {
+double BufferHelper::drainBEDouble(Buffer::Instance& buffer) {
   static_assert(sizeof(double) == sizeof(uint64_t), "sizeof(double) != sizeof(uint64_t)");
   static_assert(std::numeric_limits<double>::is_iec559, "non-IEC559 (IEEE 754) double");
 
@@ -125,7 +19,7 @@ double BufferHelper::drainDouble(Buffer::Instance& buffer) {
   // 3. Using memcpy may be undefined, but probably reliable, and can be optimized to the
   //    same instructions as 1 and 2.
   // 4. Implementation of last resort is to manually copy from i to d via unsigned char*.
-  uint64_t i = drainU64(buffer);
+  uint64_t i = buffer.drainBEIntOut<uint64_t>();
   double d;
   std::memcpy(&d, &i, 8);
   return d;
@@ -145,7 +39,7 @@ uint64_t BufferHelper::peekVarInt(Buffer::Instance& buffer, uint64_t offset, int
   uint8_t shift = 0;
   uint64_t result = 0;
   for (uint64_t i = 0; i < last; i++) {
-    uint8_t b = peekI8(buffer, offset + i);
+    uint8_t b = buffer.peekInt<uint8_t>(offset + i);
 
     // Note: the compact protocol spec says these variable-length ints are encoded as big-endian,
     // but the Apache C++, Java, and Python implementations read and write them little-endian.
@@ -221,42 +115,14 @@ int32_t BufferHelper::peekZigZagI32(Buffer::Instance& buffer, uint64_t offset, i
   return (zz32 >> 1) ^ static_cast<uint32_t>(-static_cast<int32_t>(zz32 & 1));
 }
 
-void BufferHelper::writeI8(Buffer::Instance& buffer, int8_t value) { buffer.add(&value, 1); }
-
-void BufferHelper::writeI16(Buffer::Instance& buffer, int16_t value) {
-  value = htobe16(value);
-  buffer.add(&value, 2);
-}
-
-void BufferHelper::writeU16(Buffer::Instance& buffer, uint16_t value) {
-  value = htobe16(value);
-  buffer.add(&value, 2);
-}
-
-void BufferHelper::writeI32(Buffer::Instance& buffer, int32_t value) {
-  value = htobe32(value);
-  buffer.add(&value, 4);
-}
-
-void BufferHelper::writeU32(Buffer::Instance& buffer, uint32_t value) {
-  value = htobe32(value);
-  buffer.add(&value, 4);
-}
-
-void BufferHelper::writeI64(Buffer::Instance& buffer, int64_t value) {
-  value = htobe64(value);
-  buffer.add(&value, 8);
-}
-
-void BufferHelper::writeDouble(Buffer::Instance& buffer, double value) {
+void BufferHelper::writeBEDouble(Buffer::Instance& buffer, double value) {
   static_assert(sizeof(double) == sizeof(uint64_t), "sizeof(double) != sizeof(uint64_t)");
   static_assert(std::numeric_limits<double>::is_iec559, "non-IEC559 (IEEE 754) double");
 
   // See drainDouble for implementation details.
   uint64_t i;
   std::memcpy(&i, &value, 8);
-  i = htobe64(i);
-  buffer.add(&i, 8);
+  buffer.writeBEInt<uint64_t>(i);
 }
 
 // Thrift's var int encoding is described in

--- a/source/extensions/filters/network/thrift_proxy/buffer_helper.h
+++ b/source/extensions/filters/network/thrift_proxy/buffer_helper.h
@@ -17,109 +17,11 @@ namespace ThriftProxy {
 class BufferHelper {
 public:
   /**
-   * Reads an int8_t from the buffer at the given offset.
-   * @param buffer Buffer::Instance containing data to decode
-   * @param offset offset into buffer to peek at
-   * @return the int8_t at offset in buffer
-   */
-  static int8_t peekI8(Buffer::Instance& buffer, uint64_t offset = 0);
-
-  /**
-   * Reads an int16_t from the buffer at the given offset.
-   * @param buffer Buffer::Instance containing data to decode
-   * @param offset offset into buffer to peek at
-   * @return the int16_t at offset in buffer
-   */
-  static int16_t peekI16(Buffer::Instance& buffer, uint64_t offset = 0);
-
-  /**
-   * Reads an int32_t from the buffer at the given offset.
-   * @param buffer Buffer::Instance containing data to decode
-   * @param offset offset into buffer to peek at
-   * @return the int32_t at offset in buffer
-   */
-  static int32_t peekI32(Buffer::Instance& buffer, uint64_t offset = 0);
-
-  /**
-   * Reads an int64_t from the buffer at the given offset.
-   * @param buffer Buffer::Instance containing data to decode
-   * @param offset offset into buffer to peek at
-   * @return the int64_t at offset in buffer
-   */
-  static int64_t peekI64(Buffer::Instance& buffer, uint64_t offset = 0);
-
-  /**
-   * Reads an uint16_t from the buffer at the given offset.
-   * @param buffer Buffer::Instance containing data to decode
-   * @param offset offset into buffer to peek at
-   * @return the uint16_t at offset in buffer
-   */
-  static uint16_t peekU16(Buffer::Instance& buffer, uint64_t offset = 0);
-
-  /**
-   * Reads an uint32_t from the buffer at the given offset.
-   * @param buffer Buffer::Instance containing data to decode
-   * @param offset offset into buffer to peek at
-   * @return the uint32_t at offset in buffer
-   */
-  static uint32_t peekU32(Buffer::Instance& buffer, uint64_t offset = 0);
-
-  /**
-   * Reads an uint64_t from the buffer at the given offset.
-   * @param buffer Buffer::Instance containing data to decode
-   * @param offset offset into buffer to peek at
-   * @return the uint64_t at offset in buffer
-   */
-  static uint64_t peekU64(Buffer::Instance& buffer, uint64_t offset = 0);
-
-  /**
-   * Reads and drains an int8_t from a buffer.
-   * @param buffer Buffer::Instance containing data to decode
-   * @return the int8_t at the start of buffer
-   */
-  static int8_t drainI8(Buffer::Instance& buffer);
-
-  /**
-   * Reads and drains an int16_t from a buffer.
-   * @param buffer Buffer::Instance containing data to decode
-   * @return the int16_t at the start of buffer
-   */
-  static int16_t drainI16(Buffer::Instance& buffer);
-
-  /**
-   * Reads and drains an int32_t from a buffer.
-   * @param buffer Buffer::Instance containing data to decode
-   * @return the int32_t at the start of buffer
-   */
-  static int32_t drainI32(Buffer::Instance& buffer);
-
-  /**
-   * Reads and drains an int64_t from a buffer.
-   * @param buffer Buffer::Instance containing data to decode
-   * @return the int64_t at the start of buffer
-   */
-  static int64_t drainI64(Buffer::Instance& buffer);
-
-  /**
-   * Reads and drains an uint32_t from a buffer.
-   * @param buffer Buffer::Instance containing data to decode
-   * @return the uint32_t at the start of buffer
-   */
-  static uint32_t drainU32(Buffer::Instance& buffer);
-
-  /**
-   * Reads and drains an uint64_t from a buffer.
-   * @param buffer Buffer::Instance containing data to decode
-   * @return the uint64_t at the start of buffer
-   */
-  static uint64_t drainU64(Buffer::Instance& buffer);
-
-  /**
    * Reads and drains a double from a buffer.
    * @param buffer Buffer::Instance containing data to decode
    * @return the double at the start of buffer
    */
-  static double drainDouble(Buffer::Instance& buffer);
+  static double drainBEDouble(Buffer::Instance& buffer);
 
   /**
    * Peeks at a variable-length int32_t at offset. Updates size to the number of bytes used to
@@ -166,53 +68,11 @@ public:
   static int32_t peekZigZagI32(Buffer::Instance& buffer, uint64_t offset, int& size);
 
   /**
-   * Writes an int8_t to the buffer.
-   * @param buffer Buffer::Instance written to
-   * @param value the int8_t to write
-   */
-  static void writeI8(Buffer::Instance& buffer, int8_t value);
-
-  /**
-   * Writes an int16_t to the buffer.
-   * @param buffer Buffer::Instance written to
-   * @param value the int16_t to write
-   */
-  static void writeI16(Buffer::Instance& buffer, int16_t value);
-
-  /**
-   * Writes an uint16_t to the buffer.
-   * @param buffer Buffer::Instance written to
-   * @param value the uint16_t to write
-   */
-  static void writeU16(Buffer::Instance& buffer, uint16_t value);
-
-  /**
-   * Writes an int32_t to the buffer.
-   * @param buffer Buffer::Instance written to
-   * @param value the int32_t to write
-   */
-  static void writeI32(Buffer::Instance& buffer, int32_t value);
-
-  /**
-   * Writes an uint32_t to the buffer.
-   * @param buffer Buffer::Instance written to
-   * @param value the uint32_t to write
-   */
-  static void writeU32(Buffer::Instance& buffer, uint32_t value);
-
-  /**
-   * Writes an int64_t to the buffer.
-   * @param buffer Buffer::Instance written to
-   * @param value the int64_t to write
-   */
-  static void writeI64(Buffer::Instance& buffer, int64_t value);
-
-  /**
    * Writes a double to the buffer.
    * @param buffer Buffer::Instance written to
    * @param value the double to write
    */
-  static void writeDouble(Buffer::Instance& buffer, double value);
+  static void writeBEDouble(Buffer::Instance& buffer, double value);
 
   /**
    * Writes a var-int encoded int32_t to the buffer.

--- a/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.cc
@@ -29,7 +29,7 @@ bool CompactProtocolImpl::readMessageBegin(Buffer::Instance& buffer, std::string
     return false;
   }
 
-  uint16_t version = BufferHelper::peekU16(buffer);
+  uint16_t version = buffer.peekBEInt<uint16_t>();
   if ((version & MagicMask) != Magic) {
     throw EnvoyException(fmt::format("invalid compact protocol version 0x{:04x} != 0x{:04x}",
                                      version & MagicMask, Magic));
@@ -112,7 +112,7 @@ bool CompactProtocolImpl::readFieldBegin(Buffer::Instance& buffer, std::string& 
     return false;
   }
 
-  uint8_t delta_and_type = BufferHelper::peekI8(buffer);
+  uint8_t delta_and_type = buffer.peekInt<int8_t>();
   if ((delta_and_type & 0x0f) == 0) {
     // Type is stop, no need to do further decoding.
     name.clear();
@@ -194,7 +194,7 @@ bool CompactProtocolImpl::readMapBegin(Buffer::Instance& buffer, FieldType& key_
     return false;
   }
 
-  uint8_t types = BufferHelper::peekI8(buffer, s_size);
+  uint8_t types = buffer.peekInt<int8_t>(s_size);
   FieldType ktype = convertCompactFieldType(static_cast<CompactFieldType>(types >> 4));
   FieldType vtype = convertCompactFieldType(static_cast<CompactFieldType>(types & 0xF));
 
@@ -223,7 +223,7 @@ bool CompactProtocolImpl::readListBegin(Buffer::Instance& buffer, FieldType& ele
 
   uint32_t sz = 0;
   int s_size = 0;
-  uint8_t size_and_type = BufferHelper::peekI8(buffer);
+  uint8_t size_and_type = buffer.peekInt<int8_t>();
   if ((size_and_type & 0xF0) != 0xF0) {
     // Short form list header: size and type byte.
     sz = static_cast<uint32_t>(size_and_type >> 4);
@@ -272,7 +272,7 @@ bool CompactProtocolImpl::readBool(Buffer::Instance& buffer, bool& value) {
     return false;
   }
 
-  value = BufferHelper::drainI8(buffer) != 0;
+  value = buffer.drainInt<int8_t>() != 0;
   return true;
 }
 
@@ -280,7 +280,7 @@ bool CompactProtocolImpl::readByte(Buffer::Instance& buffer, uint8_t& value) {
   if (buffer.length() < 1) {
     return false;
   }
-  value = BufferHelper::drainI8(buffer);
+  value = buffer.drainInt<int8_t>();
   return true;
 }
 
@@ -343,7 +343,7 @@ bool CompactProtocolImpl::readDouble(Buffer::Instance& buffer, double& value) {
     return false;
   }
 
-  value = BufferHelper::drainDouble(buffer);
+  value = BufferHelper::drainBEDouble(buffer);
   return true;
 }
 
@@ -390,7 +390,7 @@ void CompactProtocolImpl::writeMessageBegin(Buffer::Instance& buffer, const std:
   ASSERT((ptv & MagicMask) == Magic);
   ASSERT((ptv & ~MagicMask) >> 5 == static_cast<uint16_t>(msg_type));
 
-  BufferHelper::writeU16(buffer, ptv);
+  buffer.writeBEInt<uint16_t>(ptv);
   BufferHelper::writeVarIntI32(buffer, seq_id);
   writeString(buffer, name);
 }
@@ -425,7 +425,7 @@ void CompactProtocolImpl::writeFieldBegin(Buffer::Instance& buffer, const std::s
   UNREFERENCED_PARAMETER(name);
 
   if (field_type == FieldType::Stop) {
-    BufferHelper::writeI8(buffer, 0);
+    buffer.writeByte(0);
     return;
   }
 
@@ -449,10 +449,10 @@ void CompactProtocolImpl::writeFieldBeginInternal(
 
   if (field_id > last_field_id_ && field_id - last_field_id_ <= 15) {
     // Encode short-form field header.
-    BufferHelper::writeI8(buffer, (static_cast<int8_t>(field_id - last_field_id_) << 4) |
-                                      static_cast<int8_t>(compact_field_type));
+    buffer.writeByte((static_cast<int8_t>(field_id - last_field_id_) << 4) |
+                     static_cast<int8_t>(compact_field_type));
   } else {
-    BufferHelper::writeI8(buffer, static_cast<int8_t>(compact_field_type));
+    buffer.writeByte(static_cast<int8_t>(compact_field_type));
     BufferHelper::writeZigZagI32(buffer, static_cast<int32_t>(field_id));
   }
 
@@ -478,8 +478,8 @@ void CompactProtocolImpl::writeMapBegin(Buffer::Instance& buffer, FieldType key_
 
   CompactFieldType compact_key_type = convertFieldType(key_type);
   CompactFieldType compact_value_type = convertFieldType(value_type);
-  BufferHelper::writeI8(buffer, (static_cast<int8_t>(compact_key_type) << 4) |
-                                    static_cast<int8_t>(compact_value_type));
+  buffer.writeByte((static_cast<int8_t>(compact_key_type) << 4) |
+                   static_cast<int8_t>(compact_value_type));
 }
 
 void CompactProtocolImpl::writeMapEnd(Buffer::Instance& buffer) { UNREFERENCED_PARAMETER(buffer); }
@@ -495,9 +495,9 @@ void CompactProtocolImpl::writeListBegin(Buffer::Instance& buffer, FieldType ele
   if (size < 0xF) {
     // Short form list/set header
     int8_t short_size = static_cast<int8_t>(size & 0xF);
-    BufferHelper::writeI8(buffer, (short_size << 4) | static_cast<int8_t>(compact_elem_type));
+    buffer.writeByte((short_size << 4) | static_cast<int8_t>(compact_elem_type));
   } else {
-    BufferHelper::writeI8(buffer, 0xF0 | static_cast<int8_t>(compact_elem_type));
+    buffer.writeByte(0xF0 | static_cast<int8_t>(compact_elem_type));
     BufferHelper::writeVarIntI32(buffer, static_cast<int32_t>(size));
   }
 }
@@ -521,11 +521,11 @@ void CompactProtocolImpl::writeBool(Buffer::Instance& buffer, bool value) {
   }
 
   // Map/Set/List booleans are encoded as bytes.
-  BufferHelper::writeI8(buffer, value ? 1 : 0);
+  buffer.writeByte(value ? 1 : 0);
 }
 
 void CompactProtocolImpl::writeByte(Buffer::Instance& buffer, uint8_t value) {
-  BufferHelper::writeI8(buffer, value);
+  buffer.writeByte(value);
 }
 
 void CompactProtocolImpl::writeInt16(Buffer::Instance& buffer, int16_t value) {
@@ -542,7 +542,7 @@ void CompactProtocolImpl::writeInt64(Buffer::Instance& buffer, int64_t value) {
 }
 
 void CompactProtocolImpl::writeDouble(Buffer::Instance& buffer, double value) {
-  BufferHelper::writeDouble(buffer, value);
+  BufferHelper::writeBEDouble(buffer, value);
 }
 
 void CompactProtocolImpl::writeString(Buffer::Instance& buffer, const std::string& value) {

--- a/source/extensions/filters/network/thrift_proxy/framed_transport_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/framed_transport_impl.cc
@@ -16,7 +16,7 @@ bool FramedTransportImpl::decodeFrameStart(Buffer::Instance& buffer,
     return false;
   }
 
-  int32_t thrift_size = BufferHelper::peekI32(buffer);
+  int32_t thrift_size = buffer.peekBEInt<int32_t>();
 
   if (thrift_size <= 0 || thrift_size > MaxFrameSize) {
     throw EnvoyException(fmt::format("invalid thrift framed transport frame size {}", thrift_size));
@@ -38,7 +38,7 @@ void FramedTransportImpl::encodeFrame(Buffer::Instance& buffer, Buffer::Instance
 
   int32_t thrift_size = static_cast<int32_t>(size);
 
-  BufferHelper::writeI32(buffer, thrift_size);
+  buffer.writeBEInt<int32_t>(thrift_size);
   buffer.move(message);
 }
 

--- a/source/extensions/filters/network/thrift_proxy/protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/protocol_impl.cc
@@ -24,7 +24,7 @@ bool AutoProtocolImpl::readMessageBegin(Buffer::Instance& buffer, std::string& n
       return false;
     }
 
-    uint16_t version = BufferHelper::peekU16(buffer);
+    uint16_t version = buffer.peekBEInt<uint16_t>();
     if (BinaryProtocolImpl::isMagic(version)) {
       setProtocol(std::make_unique<BinaryProtocolImpl>());
     } else if (CompactProtocolImpl::isMagic(version)) {

--- a/source/extensions/filters/network/thrift_proxy/transport_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/transport_impl.cc
@@ -22,8 +22,8 @@ bool AutoTransportImpl::decodeFrameStart(Buffer::Instance& buffer, absl::optiona
       return false;
     }
 
-    int32_t size = BufferHelper::peekI32(buffer);
-    uint16_t proto_start = BufferHelper::peekU16(buffer, 4);
+    int32_t size = buffer.peekBEInt<int32_t>();
+    uint16_t proto_start = buffer.peekBEInt<uint16_t>(4);
 
     if (size > 0 && size <= FramedTransportImpl::MaxFrameSize) {
       // TODO(zuercher): Spec says max size is 16,384,000 (0xFA0000). Apache C++ TFramedTransport

--- a/source/extensions/health_checkers/mysql/BUILD
+++ b/source/extensions/health_checkers/mysql/BUILD
@@ -1,0 +1,46 @@
+licenses(["notice"])  # Apache 2
+
+# MySQL custom health checker.
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "mysql",
+    srcs = ["mysql.cc"],
+    hdrs = ["mysql.h"],
+    deps = [
+        "//source/common/common:byte_order_lib",
+        "//source/common/upstream:health_checker_base_lib",
+        "@envoy_api//envoy/api/v2/core:health_check_cc",
+        "@envoy_api//envoy/config/health_checker/mysql/v2:mysql_cc",
+    ],
+)
+
+envoy_cc_library(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    deps = [
+        ":mysql",
+        ":utility",
+        "//include/envoy/registry",
+        "//include/envoy/server:health_checker_config_interface",
+        "//source/common/common:assert_lib",
+        "//source/extensions/health_checkers:well_known_names",
+    ],
+)
+
+envoy_cc_library(
+    name = "utility",
+    hdrs = ["utility.h"],
+    deps = [
+        "@envoy_api//envoy/api/v2/core:health_check_cc",
+        "@envoy_api//envoy/config/health_checker/mysql/v2:mysql_cc",
+    ],
+)

--- a/source/extensions/health_checkers/mysql/config.cc
+++ b/source/extensions/health_checkers/mysql/config.cc
@@ -1,0 +1,32 @@
+#include "extensions/health_checkers/mysql/config.h"
+
+#include "envoy/registry/registry.h"
+
+#include "common/config/utility.h"
+
+#include "extensions/health_checkers/mysql/utility.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HealthCheckers {
+namespace MySQLHealthChecker {
+
+Upstream::HealthCheckerSharedPtr MySQLHealthCheckerFactory::createCustomHealthChecker(
+    const envoy::api::v2::core::HealthCheck& config,
+    Server::Configuration::HealthCheckerFactoryContext& context) {
+  return std::make_shared<MySQLHealthChecker>(
+      context.cluster(), config, getMySQLHealthCheckConfig(config), context.dispatcher(),
+      context.runtime(), context.random(), context.eventLogger());
+};
+
+/**
+ * Static registration for the mysql custom health checker. @see RegisterFactory.
+ */
+static Registry::RegisterFactory<MySQLHealthCheckerFactory,
+                                 Server::Configuration::CustomHealthCheckerFactory>
+    registered_;
+
+} // namespace MySQLHealthChecker
+} // namespace HealthCheckers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/health_checkers/mysql/config.h
+++ b/source/extensions/health_checkers/mysql/config.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "envoy/server/health_checker_config.h"
+
+#include "extensions/health_checkers/mysql/mysql.h"
+#include "extensions/health_checkers/well_known_names.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HealthCheckers {
+namespace MySQLHealthChecker {
+
+/**
+ * Config registration for the mysql health checker.
+ */
+class MySQLHealthCheckerFactory : public Server::Configuration::CustomHealthCheckerFactory {
+public:
+  Upstream::HealthCheckerSharedPtr
+  createCustomHealthChecker(const envoy::api::v2::core::HealthCheck& config,
+                            Server::Configuration::HealthCheckerFactoryContext& context) override;
+
+  std::string name() override { return HealthCheckerNames::get().MysqlHealthChecker; }
+};
+
+} // namespace MySQLHealthChecker
+} // namespace HealthCheckers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/health_checkers/mysql/mysql.cc
+++ b/source/extensions/health_checkers/mysql/mysql.cc
@@ -1,0 +1,311 @@
+#include "extensions/health_checkers/mysql/mysql.h"
+
+#include "envoy/event/dispatcher.h"
+
+#include "common/buffer/buffer_impl.h"
+#include "common/common/byte_order.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HealthCheckers {
+namespace MySQLHealthChecker {
+
+MySQLHealthChecker::MySQLHealthChecker(
+    const Upstream::Cluster& cluster, const envoy::api::v2::core::HealthCheck& config,
+    const envoy::config::health_checker::mysql::v2::MySQL& mysql_config,
+    Event::Dispatcher& dispatcher, Runtime::Loader& runtime, Runtime::RandomGenerator& random,
+    Upstream::HealthCheckEventLoggerPtr&& event_logger)
+    : Upstream::HealthCheckerImplBase(cluster, config, dispatcher, runtime, random,
+                                      std::move(event_logger)),
+      user_(mysql_config.user()) {}
+
+MySQLHealthChecker::MySQLActiveHealthCheckSession::~MySQLActiveHealthCheckSession() {
+  if (client_) {
+    client_->close(Network::ConnectionCloseType::NoFlush);
+  }
+}
+
+constexpr const auto MYSQL_PROTOCOL_VERSION = 10;
+
+constexpr const auto mysql_payload_length_offset = 0;
+constexpr const size_t mysql_payload_length_size = 3;
+
+constexpr const auto mysql_sequence_id_offset =
+    mysql_payload_length_offset + mysql_payload_length_size;
+constexpr const size_t mysql_sequence_id_size = 1;
+
+constexpr const size_t mysql_packet_header_size = mysql_sequence_id_offset + mysql_sequence_id_size;
+constexpr const auto mysql_payload_offset = mysql_packet_header_size;
+
+bool MySQLHealthChecker::MySQLActiveHealthCheckSession::parseMySqlServerGreetingPacket(
+    Buffer::Instance& buffer) {
+  // parse server greeting packet:
+  // https://dev.mysql.com/doc/internals/en/connection-phase-packets.html
+  //  #packet-Protocol::Handshake
+
+  // If the packet contains less than the bare minimum information it is malformed
+  constexpr const size_t protocol_version_size = 1;
+  constexpr const size_t essential_packet_size = mysql_packet_header_size + protocol_version_size;
+  if (buffer.length() < essential_packet_size) {
+    ENVOY_CONN_LOG(trace,
+                   "mysql healthcheck failed [greeting]: packet truncated, expected at least {} "
+                   "bytes, got {} ",
+                   *client_, essential_packet_size, buffer.length());
+    return false;
+  }
+
+  const auto payload_length =
+      buffer.peekLEInt<size_t, mysql_payload_length_size>(mysql_payload_length_offset);
+  if (buffer.length() != mysql_packet_header_size + payload_length) {
+    ENVOY_CONN_LOG(
+        trace, "mysql healthcheck failed [greeting]: payload length mismatch, expected {}, got {} ",
+        *client_, mysql_packet_header_size + payload_length, buffer.length());
+    return false;
+  }
+
+  const auto sequence_id =
+      buffer.peekLEInt<size_t, mysql_sequence_id_size>(mysql_sequence_id_offset);
+  if (sequence_id != 0) {
+    ENVOY_CONN_LOG(trace, "mysql healthcheck failed [greeting]: invalid sequence id {} ", *client_,
+                   sequence_id);
+    return false;
+  }
+
+  // Handshake packet starts with the protocol version in the first byte. Currently we only
+  // support version 10 which has the version number immediately followed by a variable size
+  // NUL terminated string.
+  const auto protocol_version =
+      buffer.peekLEInt<uint8_t, protocol_version_size>(mysql_payload_offset);
+  if (protocol_version != MYSQL_PROTOCOL_VERSION) {
+    ENVOY_CONN_LOG(trace, "mysql healthcheck failed [greeting]: unsupported protocol version {} ",
+                   *client_, protocol_version);
+    return false;
+  }
+
+  // TODO (marcelo_juchem): limit the search width to discard malformed packets where the NUL
+  // byte doesn't exist or appears too far into the packet.
+  // `Buffer::search_range(needle, size, start, end)` seems like a useful function to help
+  // avoid performance degradation due to malformed packet attacks.
+  // See `evbuffer_search_range`.
+  const uint8_t nul = '\0';
+  constexpr const size_t server_version_offset = mysql_payload_offset + protocol_version_size;
+  auto server_version_nul_offset = buffer.search(&nul, 1, server_version_offset);
+
+  // If NUL not found the packet is malformed.
+  if (server_version_nul_offset < 0) {
+    ENVOY_CONN_LOG(trace, "mysql healthcheck failed [greeting]: malformed packet ", *client_);
+    return false;
+  }
+
+  // Calculate the amount of data needed in the packet
+  const auto payload_header_end = server_version_nul_offset + 1 + 4 + 8 + 1;
+
+  const auto lower_capabilities_offset = payload_header_end;
+  constexpr const size_t lower_capabilities_size = 2;
+
+  const size_t minimum_needed_packet_size = lower_capabilities_offset + lower_capabilities_size;
+  if (buffer.length() < minimum_needed_packet_size) {
+    ENVOY_CONN_LOG(trace,
+                   "mysql healthcheck failed [greeting]: packet truncated, expected at least {} "
+                   "bytes, got {} ",
+                   *client_, minimum_needed_packet_size, buffer.length());
+    return false;
+  }
+
+  constexpr const uint16_t MYSQL_CAPABILITIES_CLIENT_PROTOCOL_41 = 0x0200;
+  const auto lower_capabilities =
+      buffer.peekLEInt<uint16_t, lower_capabilities_size>(lower_capabilities_offset);
+  if (!(lower_capabilities & MYSQL_CAPABILITIES_CLIENT_PROTOCOL_41)) {
+    ENVOY_CONN_LOG(
+        trace, "mysql healthcheck failed [greeting]: server does not support 4.1 client protocol ",
+        *client_);
+    return false;
+  }
+
+  return true;
+}
+
+void MySQLHealthChecker::MySQLActiveHealthCheckSession::writeMySqlLoginRequestPacket(
+    Buffer::Instance& buffer) {
+  // write login request packet:
+  // https://dev.mysql.com/doc/internals/en/connection-phase-packets.html
+  //  #packet-Protocol::HandshakeResponse320
+
+  constexpr const uint32_t MYSQL_CAPABILITIES_CLIENT_CAN_DO_41_AUTH = 0x8000;
+  constexpr const size_t client_capabilities_size = 2;
+  constexpr const size_t max_packets_size = 3;
+  const size_t user_size = parent_.user_.size() + 1;
+  constexpr const size_t auth_response_size = 1;
+  const uint8_t nul = '\0';
+  const size_t auth_response = '\0';
+
+  // the extra +1 accounts for the NUL terminator in the user name
+  const size_t packet_size =
+      client_capabilities_size + max_packets_size + user_size + auth_response_size;
+  buffer.writeLEInt<size_t, mysql_payload_length_size>(packet_size);
+
+  constexpr const auto sequence_id = 1;
+  buffer.writeLEInt<size_t, mysql_sequence_id_size>(sequence_id);
+
+  constexpr const auto client_capabilities = MYSQL_CAPABILITIES_CLIENT_CAN_DO_41_AUTH;
+  buffer.writeLEInt<uint32_t, client_capabilities_size>(client_capabilities);
+
+  constexpr const auto max_packets = 65536;
+  buffer.writeLEInt<size_t, max_packets_size>(max_packets);
+
+  buffer.add(parent_.user_.data(), parent_.user_.size());
+  buffer.add(&nul, 1);
+
+  buffer.add(&auth_response, auth_response_size);
+}
+
+void MySQLHealthChecker::MySQLActiveHealthCheckSession::writeMySqlQuitPacket(
+    Buffer::Instance& buffer) {
+  // write quit packet:
+  // https://dev.mysql.com/doc/internals/en/com-quit.html
+  //  #packet-COM_QUIT
+
+  constexpr const auto MYSQL_QUIT_COMMAND = 1;
+  constexpr const size_t quit_command_size = 1;
+
+  const size_t packet_size = quit_command_size;
+  buffer.writeLEInt<size_t, mysql_payload_length_size>(packet_size);
+
+  constexpr const auto sequence_id = 0;
+  buffer.writeLEInt<size_t, mysql_sequence_id_size>(sequence_id);
+
+  buffer.writeLEInt<uint8_t, quit_command_size>(MYSQL_QUIT_COMMAND);
+}
+
+bool MySQLHealthChecker::MySQLActiveHealthCheckSession::parseMySqlOkPacket(
+    Buffer::Instance& buffer) {
+  // parse response packet
+  // https://dev.mysql.com/doc/internals/en/packet-OK_Packet.html
+  constexpr const auto MYSQL_OK_RESPONSE = 0;
+  constexpr const size_t ok_response_size = 1;
+  constexpr const size_t ok_packet_size_threshold = 7;
+
+  const size_t minimum_needed_packet_size = mysql_packet_header_size + ok_response_size;
+  if (buffer.length() < minimum_needed_packet_size) {
+    ENVOY_CONN_LOG(trace,
+                   "mysql healthcheck failed [response]: packet truncated, expected at least {} "
+                   "bytes, got {} ",
+                   *client_, minimum_needed_packet_size, buffer.length());
+    return false;
+  }
+
+  const auto payload_length =
+      buffer.peekLEInt<size_t, mysql_payload_length_size>(mysql_payload_length_offset);
+  if (buffer.length() != mysql_packet_header_size + payload_length) {
+    ENVOY_CONN_LOG(
+        trace, "mysql healthcheck failed [response]: payload length mismatch, expected {}, got {} ",
+        *client_, mysql_packet_header_size + payload_length, buffer.length());
+    return false;
+  }
+
+  const auto sequence_id =
+      buffer.peekLEInt<size_t, mysql_sequence_id_size>(mysql_sequence_id_offset);
+  if (sequence_id != 2) {
+    ENVOY_CONN_LOG(trace, "mysql healthcheck failed [response]: invalid sequence id {} ", *client_,
+                   sequence_id);
+    return false;
+  }
+
+  const auto response_code = buffer.peekLEInt<uint8_t, ok_response_size>(mysql_payload_offset);
+  if (response_code != MYSQL_OK_RESPONSE || buffer.length() < ok_packet_size_threshold) {
+    ENVOY_CONN_LOG(trace,
+                   "mysql healthcheck failed [response]: expected an OK ({}) response with minimum "
+                   "packet size {{}}, got {} with size {} ",
+                   *client_, MYSQL_OK_RESPONSE, ok_packet_size_threshold, response_code,
+                   buffer.length());
+    return false;
+  }
+
+  return true;
+}
+
+void MySQLHealthChecker::MySQLActiveHealthCheckSession::onData(Buffer::Instance& data) {
+  // TODO: support for partial data - there's no guarantee that the packet will arrive in one shot.
+
+  switch (phase_) {
+  case Phase::Greeting: {
+    if (!parseMySqlServerGreetingPacket(data)) {
+      break;
+    }
+
+    data.drain(data.length());
+    phase_ = Phase::Reply;
+
+    Buffer::OwnedImpl buffer;
+    writeMySqlLoginRequestPacket(buffer);
+    writeMySqlQuitPacket(buffer);
+    client_->write(buffer, false);
+    return;
+  }
+
+  case Phase::Reply: {
+    if (!parseMySqlOkPacket(data)) {
+      break;
+    }
+
+    phase_ = Phase::Over;
+    data.drain(data.length());
+
+    handleSuccess();
+    if (!parent_.reuse_connection_) {
+      client_->close(Network::ConnectionCloseType::NoFlush);
+    }
+    return;
+  }
+
+  case Phase::Over:
+    ENVOY_CONN_LOG(trace, "unexpected data received from mysql host", *client_);
+    data.drain(data.length());
+    return;
+  }
+
+  phase_ = Phase::Over;
+  data.drain(data.length());
+
+  handleFailure(envoy::data::core::v2alpha::HealthCheckFailureType::ACTIVE);
+  client_->close(Network::ConnectionCloseType::NoFlush);
+}
+
+void MySQLHealthChecker::MySQLActiveHealthCheckSession::onEvent(Network::ConnectionEvent event) {
+  if (event == Network::ConnectionEvent::RemoteClose && phase_ != Phase::Over) {
+    handleFailure(envoy::data::core::v2alpha::HealthCheckFailureType::NETWORK);
+  }
+
+  if (event == Network::ConnectionEvent::RemoteClose ||
+      event == Network::ConnectionEvent::LocalClose) {
+    parent_.dispatcher_.deferredDelete(std::move(client_));
+  }
+}
+
+void MySQLHealthChecker::MySQLActiveHealthCheckSession::onInterval() {
+  phase_ = Phase::Greeting;
+
+  if (!client_) {
+    client_ = host_->createHealthCheckConnection(parent_.dispatcher_).connection_;
+    session_callbacks_.reset(new MySQLSessionCallbacks(*this));
+    client_->addConnectionCallbacks(*session_callbacks_);
+    client_->addReadFilter(session_callbacks_);
+
+    client_->connect();
+    client_->noDelay(true);
+  } else {
+    Buffer::OwnedImpl buffer;
+    writeMySqlLoginRequestPacket(buffer);
+    writeMySqlQuitPacket(buffer);
+    client_->write(buffer, false);
+  }
+}
+
+void MySQLHealthChecker::MySQLActiveHealthCheckSession::onTimeout() {
+  client_->close(Network::ConnectionCloseType::NoFlush);
+}
+
+} // namespace MySQLHealthChecker
+} // namespace HealthCheckers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/health_checkers/mysql/mysql.h
+++ b/source/extensions/health_checkers/mysql/mysql.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include "envoy/config/health_checker/mysql/v2/mysql.pb.validate.h"
+#include "envoy/network/filter.h"
+
+#include "common/network/filter_impl.h"
+#include "common/upstream/health_checker_base_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HealthCheckers {
+namespace MySQLHealthChecker {
+
+/**
+ * MySQL health checker implementation. Connects, waits for the server greeting then sends a login
+ * request followed by a QUIT packet to properly close the session.
+ */
+class MySQLHealthChecker : public Upstream::HealthCheckerImplBase {
+public:
+  MySQLHealthChecker(const Upstream::Cluster& cluster,
+                     const envoy::api::v2::core::HealthCheck& config,
+                     const envoy::config::health_checker::mysql::v2::MySQL& mysql_config,
+                     Event::Dispatcher& dispatcher, Runtime::Loader& runtime,
+                     Runtime::RandomGenerator& random,
+                     Upstream::HealthCheckEventLoggerPtr&& event_logger);
+
+protected:
+  envoy::data::core::v2alpha::HealthCheckerType healthCheckerType() const override {
+    return envoy::data::core::v2alpha::HealthCheckerType::MYSQL;
+  }
+
+private:
+  typedef std::vector<uint8_t> Packet;
+
+  struct MySQLActiveHealthCheckSession;
+
+  struct MySQLSessionCallbacks : public Network::ConnectionCallbacks,
+                                 public Network::ReadFilterBaseImpl {
+    MySQLSessionCallbacks(MySQLActiveHealthCheckSession& parent) : parent_(parent) {}
+
+    // Network::ConnectionCallbacks
+    void onEvent(Network::ConnectionEvent event) override { parent_.onEvent(event); }
+    void onAboveWriteBufferHighWatermark() override {}
+    void onBelowWriteBufferLowWatermark() override {}
+
+    // Network::ReadFilter
+    Network::FilterStatus onData(Buffer::Instance& data, bool) override {
+      parent_.onData(data);
+      return Network::FilterStatus::StopIteration;
+    }
+
+    MySQLActiveHealthCheckSession& parent_;
+  };
+
+  struct MySQLActiveHealthCheckSession : public ActiveHealthCheckSession {
+    enum class Phase { Greeting, Reply, Over };
+
+    MySQLActiveHealthCheckSession(MySQLHealthChecker& parent, const Upstream::HostSharedPtr& host)
+        : ActiveHealthCheckSession(parent, host), parent_(parent) {}
+    ~MySQLActiveHealthCheckSession();
+
+    void onData(Buffer::Instance& data);
+    void onEvent(Network::ConnectionEvent event);
+
+    // ActiveHealthCheckSession
+    void onInterval() override;
+    void onTimeout() override;
+
+    bool parseMySqlServerGreetingPacket(Buffer::Instance& data);
+    void writeMySqlLoginRequestPacket(Buffer::Instance& buffer);
+    void writeMySqlQuitPacket(Buffer::Instance& buffer);
+    bool parseMySqlOkPacket(Buffer::Instance& data);
+
+    MySQLHealthChecker& parent_;
+    Network::ClientConnectionPtr client_;
+    std::shared_ptr<MySQLSessionCallbacks> session_callbacks_;
+    Phase phase_ = Phase::Over;
+  };
+
+  typedef std::unique_ptr<MySQLActiveHealthCheckSession> MySQLActiveHealthCheckSessionPtr;
+
+  // HealthCheckerImplBase
+  ActiveHealthCheckSessionPtr makeSession(Upstream::HostSharedPtr host) override {
+    return std::make_unique<MySQLActiveHealthCheckSession>(*this, host);
+  }
+
+  const std::string user_;
+};
+
+} // namespace MySQLHealthChecker
+} // namespace HealthCheckers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/health_checkers/mysql/utility.h
+++ b/source/extensions/health_checkers/mysql/utility.h
@@ -1,0 +1,23 @@
+#include "envoy/api/v2/core/health_check.pb.validate.h"
+#include "envoy/config/health_checker/mysql/v2/mysql.pb.validate.h"
+
+#include "common/protobuf/utility.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HealthCheckers {
+namespace MySQLHealthChecker {
+
+static const envoy::config::health_checker::mysql::v2::MySQL
+getMySQLHealthCheckConfig(const envoy::api::v2::core::HealthCheck& hc_config) {
+  ProtobufTypes::MessagePtr config =
+      ProtobufTypes::MessagePtr{new envoy::config::health_checker::mysql::v2::MySQL()};
+  MessageUtil::jsonConvert(hc_config.custom_health_check().config(), *config);
+  return MessageUtil::downcastAndValidate<const envoy::config::health_checker::mysql::v2::MySQL&>(
+      *config);
+}
+
+} // namespace MySQLHealthChecker
+} // namespace HealthCheckers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/health_checkers/well_known_names.h
+++ b/source/extensions/health_checkers/well_known_names.h
@@ -14,6 +14,9 @@ class HealthCheckerNameValues {
 public:
   // Redis health checker.
   const std::string RedisHealthChecker = "envoy.health_checkers.redis";
+
+  // MySQL health checker
+  const std::string MysqlHealthChecker = "envoy.health_checkers.mysql";
 };
 
 typedef ConstSingleton<HealthCheckerNameValues> HealthCheckerNames;

--- a/test/common/buffer/BUILD
+++ b/test/common/buffer/BUILD
@@ -3,10 +3,31 @@ licenses(["notice"])  # Apache 2
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",
+    "envoy_cc_test_library",
     "envoy_package",
 )
 
 envoy_package()
+
+envoy_cc_test_library(
+    name = "utility_lib",
+    hdrs = ["utility.h"],
+    deps = [
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:byte_order_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "buffer_test",
+    srcs = ["buffer_test.cc"],
+    deps = [
+        ":utility_lib",
+        "//source/common/buffer:buffer_lib",
+        "//test/test_common:printers_lib",
+        "//test/test_common:utility_lib",
+    ],
+)
 
 envoy_cc_test(
     name = "owned_impl_test",

--- a/test/common/buffer/buffer_test.cc
+++ b/test/common/buffer/buffer_test.cc
@@ -1,0 +1,652 @@
+#include <limits>
+
+#include "envoy/common/exception.h"
+
+#include "common/buffer/buffer_impl.h"
+
+#include "test/common/buffer/utility.h"
+#include "test/test_common/printers.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Buffer {
+namespace {
+
+TEST(BufferHelperTest, PeekI8) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 0xFE});
+    EXPECT_EQ(buffer.peekInt<int8_t>(), 0);
+    EXPECT_EQ(buffer.peekInt<int8_t>(0), 0);
+    EXPECT_EQ(buffer.peekInt<int8_t>(1), 1);
+    EXPECT_EQ(buffer.peekInt<int8_t>(2), -2);
+    EXPECT_EQ(buffer.length(), 3);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekInt<int8_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeByte(0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekInt<int8_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekLEI16) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekLEInt<int16_t>(), 0x0100);
+    EXPECT_EQ(buffer.peekLEInt<int16_t>(0), 0x0100);
+    EXPECT_EQ(buffer.peekLEInt<int16_t>(1), 0x0201);
+    EXPECT_EQ(buffer.peekLEInt<int16_t>(2), 0x0302);
+    EXPECT_EQ(buffer.peekLEInt<int16_t>(4), -1);
+    EXPECT_EQ(buffer.length(), 6);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<int16_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 2, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<int16_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekLEI32) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekLEInt<int32_t>(), 0x03020100);
+    EXPECT_EQ(buffer.peekLEInt<int32_t>(0), 0x03020100);
+    EXPECT_EQ(buffer.peekLEInt<int32_t>(1), 0xFF030201);
+    EXPECT_EQ(buffer.peekLEInt<int32_t>(2), 0xFFFF0302);
+    EXPECT_EQ(buffer.peekLEInt<int32_t>(4), -1);
+    EXPECT_EQ(buffer.length(), 8);
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<int32_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 4, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<int32_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekLEI64) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekLEInt<int64_t>(), 0x0706050403020100);
+    EXPECT_EQ(buffer.peekLEInt<int64_t>(0), 0x0706050403020100);
+    EXPECT_EQ(buffer.peekLEInt<int64_t>(1), 0xFF07060504030201);
+    EXPECT_EQ(buffer.peekLEInt<int64_t>(2), 0xFFFF070605040302);
+    EXPECT_EQ(buffer.peekLEInt<int64_t>(8), -1);
+    EXPECT_EQ(buffer.length(), 16);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<int64_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 8, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<int64_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekLEU16) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekLEInt<uint16_t>(), 0x0100);
+    EXPECT_EQ(buffer.peekLEInt<uint16_t>(0), 0x0100);
+    EXPECT_EQ(buffer.peekLEInt<uint16_t>(1), 0x0201);
+    EXPECT_EQ(buffer.peekLEInt<uint16_t>(2), 0x0302);
+    EXPECT_EQ(buffer.peekLEInt<uint16_t>(4), 0xFFFF);
+    EXPECT_EQ(buffer.length(), 6);
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<uint16_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 2, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<uint16_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekLEU32) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekLEInt<uint32_t>(), 0x03020100);
+    EXPECT_EQ(buffer.peekLEInt<uint32_t>(0), 0x03020100);
+    EXPECT_EQ(buffer.peekLEInt<uint32_t>(1), 0xFF030201);
+    EXPECT_EQ(buffer.peekLEInt<uint32_t>(2), 0xFFFF0302);
+    EXPECT_EQ(buffer.peekLEInt<uint32_t>(4), 0xFFFFFFFF);
+    EXPECT_EQ(buffer.length(), 8);
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<uint32_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 4, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<uint32_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekLEU64) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekLEInt<uint64_t>(), 0x0706050403020100);
+    EXPECT_EQ(buffer.peekLEInt<uint64_t>(0), 0x0706050403020100);
+    EXPECT_EQ(buffer.peekLEInt<uint64_t>(1), 0xFF07060504030201);
+    EXPECT_EQ(buffer.peekLEInt<uint64_t>(2), 0xFFFF070605040302);
+    EXPECT_EQ(buffer.peekLEInt<uint64_t>(8), 0xFFFFFFFFFFFFFFFF);
+    EXPECT_EQ(buffer.length(), 16);
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<uint64_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 8, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<uint64_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekBEI16) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekBEInt<int16_t>(), 1);
+    EXPECT_EQ(buffer.peekBEInt<int16_t>(0), 1);
+    EXPECT_EQ(buffer.peekBEInt<int16_t>(1), 0x0102);
+    EXPECT_EQ(buffer.peekBEInt<int16_t>(2), 0x0203);
+    EXPECT_EQ(buffer.peekBEInt<int16_t>(4), -1);
+    EXPECT_EQ(buffer.length(), 6);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<int16_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 2, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<int16_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekBEI32) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekBEInt<int32_t>(), 0x00010203);
+    EXPECT_EQ(buffer.peekBEInt<int32_t>(0), 0x00010203);
+    EXPECT_EQ(buffer.peekBEInt<int32_t>(1), 0x010203FF);
+    EXPECT_EQ(buffer.peekBEInt<int32_t>(2), 0x0203FFFF);
+    EXPECT_EQ(buffer.peekBEInt<int32_t>(4), -1);
+    EXPECT_EQ(buffer.length(), 8);
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<int32_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 4, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<int32_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekBEI64) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekBEInt<int64_t>(), 0x0001020304050607);
+    EXPECT_EQ(buffer.peekBEInt<int64_t>(0), 0x0001020304050607);
+    EXPECT_EQ(buffer.peekBEInt<int64_t>(1), 0x01020304050607FF);
+    EXPECT_EQ(buffer.peekBEInt<int64_t>(2), 0x020304050607FFFF);
+    EXPECT_EQ(buffer.peekBEInt<int64_t>(8), -1);
+    EXPECT_EQ(buffer.length(), 16);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<int64_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 8, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<int64_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekBEU16) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekBEInt<uint16_t>(), 1);
+    EXPECT_EQ(buffer.peekBEInt<uint16_t>(0), 1);
+    EXPECT_EQ(buffer.peekBEInt<uint16_t>(1), 0x0102);
+    EXPECT_EQ(buffer.peekBEInt<uint16_t>(2), 0x0203);
+    EXPECT_EQ(buffer.peekBEInt<uint16_t>(4), 0xFFFF);
+    EXPECT_EQ(buffer.length(), 6);
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<uint16_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 2, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<uint16_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekBEU32) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekBEInt<uint32_t>(), 0x00010203);
+    EXPECT_EQ(buffer.peekBEInt<uint32_t>(0), 0x00010203);
+    EXPECT_EQ(buffer.peekBEInt<uint32_t>(1), 0x010203FF);
+    EXPECT_EQ(buffer.peekBEInt<uint32_t>(2), 0x0203FFFF);
+    EXPECT_EQ(buffer.peekBEInt<uint32_t>(4), 0xFFFFFFFF);
+    EXPECT_EQ(buffer.length(), 8);
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<uint32_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 4, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<uint32_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekBEU64) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekBEInt<uint64_t>(), 0x0001020304050607);
+    EXPECT_EQ(buffer.peekBEInt<uint64_t>(0), 0x0001020304050607);
+    EXPECT_EQ(buffer.peekBEInt<uint64_t>(1), 0x01020304050607FF);
+    EXPECT_EQ(buffer.peekBEInt<uint64_t>(2), 0x020304050607FFFF);
+    EXPECT_EQ(buffer.peekBEInt<uint64_t>(8), 0xFFFFFFFFFFFFFFFF);
+    EXPECT_EQ(buffer.length(), 16);
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<uint64_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 8, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<uint64_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, DrainI8) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 0xFE});
+  EXPECT_EQ(buffer.drainInt<int8_t>(), 0);
+  EXPECT_EQ(buffer.drainInt<int8_t>(), 1);
+  EXPECT_EQ(buffer.drainInt<int8_t>(), -2);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainLEI16) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainLEIntOut<int16_t>(), 0x0100);
+  EXPECT_EQ(buffer.drainLEIntOut<int16_t>(), 0x0302);
+  EXPECT_EQ(buffer.drainLEIntOut<int16_t>(), -1);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainLEI32) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainLEIntOut<int32_t>(), 0x03020100);
+  EXPECT_EQ(buffer.drainLEIntOut<int32_t>(), -1);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainLEI64) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainLEIntOut<int64_t>(), 0x0706050403020100);
+  EXPECT_EQ(buffer.drainLEIntOut<int64_t>(), -1);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainLEU32) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainLEIntOut<uint32_t>(), 0x03020100);
+  EXPECT_EQ(buffer.drainLEIntOut<uint32_t>(), 0xFFFFFFFF);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainLEU64) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainLEIntOut<uint64_t>(), 0x0706050403020100);
+  EXPECT_EQ(buffer.drainLEIntOut<uint64_t>(), 0xFFFFFFFFFFFFFFFF);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainBEI16) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainBEIntOut<int16_t>(), 1);
+  EXPECT_EQ(buffer.drainBEIntOut<int16_t>(), 0x0203);
+  EXPECT_EQ(buffer.drainBEIntOut<int16_t>(), -1);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainBEI32) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainBEIntOut<int32_t>(), 0x00010203);
+  EXPECT_EQ(buffer.drainBEIntOut<int32_t>(), -1);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainBEI64) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainBEIntOut<int64_t>(), 0x0001020304050607);
+  EXPECT_EQ(buffer.drainBEIntOut<int64_t>(), -1);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainBEU32) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainBEIntOut<uint32_t>(), 0x00010203);
+  EXPECT_EQ(buffer.drainBEIntOut<uint32_t>(), 0xFFFFFFFF);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainBEU64) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainBEIntOut<uint64_t>(), 0x0001020304050607);
+  EXPECT_EQ(buffer.drainBEIntOut<uint64_t>(), 0xFFFFFFFFFFFFFFFF);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, WriteI8) {
+  Buffer::OwnedImpl buffer;
+  buffer.writeByte(-128);
+  buffer.writeByte(-1);
+  buffer.writeByte(0);
+  buffer.writeByte(1);
+  buffer.writeByte(127);
+
+  EXPECT_EQ(std::string("\x80\xFF\0\x1\x7F", 5), buffer.toString());
+}
+
+TEST(BufferHelperTest, WriteLEI16) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int16_t>(std::numeric_limits<int16_t>::min());
+    EXPECT_EQ(std::string("\0\x80", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int16_t>(0);
+    EXPECT_EQ(std::string("\0\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int16_t>(1);
+    EXPECT_EQ(std::string("\x1\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int16_t>(std::numeric_limits<int16_t>::max());
+    EXPECT_EQ("\xFF\x7F", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteLEU16) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<uint16_t>(0);
+    EXPECT_EQ(std::string("\0\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<uint16_t>(1);
+    EXPECT_EQ(std::string("\x1\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<uint16_t>(static_cast<uint16_t>(std::numeric_limits<int16_t>::max()) + 1);
+    EXPECT_EQ(std::string("\0\x80", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<uint16_t>(std::numeric_limits<uint16_t>::max());
+    EXPECT_EQ("\xFF\xFF", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteLEI32) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int32_t>(std::numeric_limits<int32_t>::min());
+    EXPECT_EQ(std::string("\0\0\0\x80", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int32_t>(0);
+    EXPECT_EQ(std::string("\0\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int32_t>(1);
+    EXPECT_EQ(std::string("\x1\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int32_t>(std::numeric_limits<int32_t>::max());
+    EXPECT_EQ("\xFF\xFF\xFF\x7F", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteLEU32) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<uint32_t>(0);
+    EXPECT_EQ(std::string("\0\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<uint32_t>(1);
+    EXPECT_EQ(std::string("\x1\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<uint32_t>(static_cast<uint32_t>(std::numeric_limits<int32_t>::max()) + 1);
+    EXPECT_EQ(std::string("\0\0\0\x80", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<uint32_t>(std::numeric_limits<uint32_t>::max());
+    EXPECT_EQ("\xFF\xFF\xFF\xFF", buffer.toString());
+  }
+}
+TEST(BufferHelperTest, WriteLEI64) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int64_t>(std::numeric_limits<int64_t>::min());
+    EXPECT_EQ(std::string("\0\0\0\0\0\0\0\x80", 8), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int64_t>(1);
+    EXPECT_EQ(std::string("\x1\0\0\0\0\0\0\0", 8), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int64_t>(0);
+    EXPECT_EQ(std::string("\0\0\0\0\0\0\0\0", 8), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int64_t>(std::numeric_limits<int64_t>::max());
+    EXPECT_EQ("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteBEI16) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int16_t>(std::numeric_limits<int16_t>::min());
+    EXPECT_EQ(std::string("\x80\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int16_t>(0);
+    EXPECT_EQ(std::string("\0\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int16_t>(1);
+    EXPECT_EQ(std::string("\0\x1", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int16_t>(std::numeric_limits<int16_t>::max());
+    EXPECT_EQ("\x7F\xFF", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteBEU16) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<uint16_t>(0);
+    EXPECT_EQ(std::string("\0\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<uint16_t>(1);
+    EXPECT_EQ(std::string("\0\x1", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<uint16_t>(static_cast<uint16_t>(std::numeric_limits<int16_t>::max()) + 1);
+    EXPECT_EQ(std::string("\x80\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<uint16_t>(std::numeric_limits<uint16_t>::max());
+    EXPECT_EQ("\xFF\xFF", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteBEI32) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int32_t>(std::numeric_limits<int32_t>::min());
+    EXPECT_EQ(std::string("\x80\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int32_t>(0);
+    EXPECT_EQ(std::string("\0\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int32_t>(1);
+    EXPECT_EQ(std::string("\0\0\0\x1", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int32_t>(std::numeric_limits<int32_t>::max());
+    EXPECT_EQ("\x7F\xFF\xFF\xFF", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteBEU32) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<uint32_t>(0);
+    EXPECT_EQ(std::string("\0\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<uint32_t>(1);
+    EXPECT_EQ(std::string("\0\0\0\x1", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<uint32_t>(static_cast<uint32_t>(std::numeric_limits<int32_t>::max()) + 1);
+    EXPECT_EQ(std::string("\x80\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<uint32_t>(std::numeric_limits<uint32_t>::max());
+    EXPECT_EQ("\xFF\xFF\xFF\xFF", buffer.toString());
+  }
+}
+TEST(BufferHelperTest, WriteBEI64) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int64_t>(std::numeric_limits<int64_t>::min());
+    EXPECT_EQ(std::string("\x80\0\0\0\0\0\0\0\0", 8), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int64_t>(1);
+    EXPECT_EQ(std::string("\0\0\0\0\0\0\0\x1", 8), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int64_t>(0);
+    EXPECT_EQ(std::string("\0\0\0\0\0\0\0\0", 8), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int64_t>(std::numeric_limits<int64_t>::max());
+    EXPECT_EQ("\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF", buffer.toString());
+  }
+}
+
+} // namespace
+} // namespace Buffer
+} // namespace Envoy

--- a/test/common/buffer/utility.h
+++ b/test/common/buffer/utility.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <initializer_list>
+
+#include "common/buffer/buffer_impl.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Buffer {
+namespace {
+
+inline void addRepeated(Buffer::Instance& buffer, int n, int8_t value) {
+  for (int i = 0; i < n; i++) {
+    buffer.add(&value, 1);
+  }
+}
+
+inline void addSeq(Buffer::Instance& buffer, const std::initializer_list<uint8_t> values) {
+  for (int8_t value : values) {
+    buffer.add(&value, 1);
+  }
+}
+
+inline void addString(Buffer::Instance& buffer, const std::string& s) { buffer.add(s); }
+
+inline std::string bufferToString(Buffer::Instance& buffer) {
+  if (buffer.length() == 0) {
+    return "";
+  }
+
+  char* data = static_cast<char*>(buffer.linearize(buffer.length()));
+  return std::string(data, buffer.length());
+}
+
+} // namespace
+} // namespace Buffer
+} // namespace Envoy

--- a/test/extensions/filters/network/thrift_proxy/BUILD
+++ b/test/extensions/filters/network/thrift_proxy/BUILD
@@ -37,6 +37,7 @@ envoy_extension_cc_test_library(
         "//source/common/buffer:buffer_lib",
         "//source/common/common:byte_order_lib",
         "//source/extensions/filters/network/thrift_proxy:protocol_lib",
+        "//test/common/buffer:utility_lib",
     ],
 )
 

--- a/test/extensions/filters/network/thrift_proxy/binary_protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/binary_protocol_impl_test.cc
@@ -46,7 +46,7 @@ TEST(BinaryProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt16(buffer, 0x0102);
+    buffer.writeBEInt<int16_t>(0x0102);
     addRepeated(buffer, 10, 'x');
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMessageBegin(buffer, name, msg_type, seq_id),
@@ -64,9 +64,9 @@ TEST(BinaryProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt16(buffer, 0x8001);
-    addInt8(buffer, 'x');
-    addInt8(buffer, static_cast<int8_t>(MessageType::LastMessageType) + 1);
+    buffer.writeBEInt<int16_t>(0x8001);
+    buffer.writeByte('x');
+    buffer.writeByte(static_cast<int8_t>(MessageType::LastMessageType) + 1);
     addRepeated(buffer, 8, 'x');
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMessageBegin(buffer, name, msg_type, seq_id),
@@ -86,11 +86,11 @@ TEST(BinaryProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt16(buffer, 0x8001);
-    addInt8(buffer, 'x');
-    addInt8(buffer, MessageType::Call);
-    addInt32(buffer, 0);
-    addInt32(buffer, 1234);
+    buffer.writeBEInt<int16_t>(0x8001);
+    buffer.writeByte('x');
+    buffer.writeByte(MessageType::Call);
+    buffer.writeBEInt<int32_t>(0);
+    buffer.writeBEInt<int32_t>(1234);
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, name, msg_type, seq_id));
     EXPECT_EQ(name, "");
@@ -106,10 +106,10 @@ TEST(BinaryProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt16(buffer, 0x8001);
-    addInt8(buffer, 'x');
-    addInt8(buffer, MessageType::Call);
-    addInt32(buffer, 4); // name length
+    buffer.writeBEInt<int16_t>(0x8001);
+    buffer.writeByte('x');
+    buffer.writeByte(MessageType::Call);
+    buffer.writeBEInt<int32_t>(4); // name length
     addString(buffer, "abcd");
 
     EXPECT_FALSE(proto.readMessageBegin(buffer, name, msg_type, seq_id));
@@ -126,12 +126,12 @@ TEST(BinaryProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt16(buffer, 0x8001);
-    addInt8(buffer, 0);
-    addInt8(buffer, MessageType::Call);
-    addInt32(buffer, 8);
+    buffer.writeBEInt<int16_t>(0x8001);
+    buffer.writeByte(0);
+    buffer.writeByte(MessageType::Call);
+    buffer.writeBEInt<int32_t>(8);
     addString(buffer, "the_name");
-    addInt32(buffer, 5678);
+    buffer.writeBEInt<int32_t>(5678);
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, name, msg_type, seq_id));
     EXPECT_EQ(name, "the_name");
@@ -187,7 +187,7 @@ TEST(BinaryProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, FieldType::Stop);
+    buffer.writeByte(FieldType::Stop);
 
     EXPECT_TRUE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "");
@@ -203,7 +203,7 @@ TEST(BinaryProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, FieldType::I32);
+    buffer.writeByte(FieldType::I32);
 
     EXPECT_FALSE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "-");
@@ -218,8 +218,8 @@ TEST(BinaryProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, FieldType::I32);
-    addInt16(buffer, 99);
+    buffer.writeByte(FieldType::I32);
+    buffer.writeBEInt<int16_t>(99);
 
     EXPECT_TRUE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "");
@@ -235,8 +235,8 @@ TEST(BinaryProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, FieldType::I32);
-    addInt16(buffer, -1);
+    buffer.writeByte(FieldType::I32);
+    buffer.writeBEInt<int16_t>(-1);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readFieldBegin(buffer, name, field_type, field_id),
                               EnvoyException, "invalid binary protocol field id -1");
@@ -279,9 +279,9 @@ TEST(BinaryProtocolTest, ReadMapBegin) {
     FieldType value_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, FieldType::I32);
-    addInt8(buffer, FieldType::I32);
-    addInt32(buffer, -1);
+    buffer.writeByte(FieldType::I32);
+    buffer.writeByte(FieldType::I32);
+    buffer.writeBEInt<int32_t>(-1);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMapBegin(buffer, key_type, value_type, size),
                               EnvoyException, "negative binary protocol map size -1");
@@ -298,9 +298,9 @@ TEST(BinaryProtocolTest, ReadMapBegin) {
     FieldType value_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, FieldType::I32);
-    addInt8(buffer, FieldType::Double);
-    addInt32(buffer, 10);
+    buffer.writeByte(FieldType::I32);
+    buffer.writeByte(FieldType::Double);
+    buffer.writeBEInt<int32_t>(10);
 
     EXPECT_TRUE(proto.readMapBegin(buffer, key_type, value_type, size));
     EXPECT_EQ(key_type, FieldType::I32);
@@ -339,8 +339,8 @@ TEST(BinaryProtocolTest, ReadListBegin) {
     FieldType elem_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, FieldType::I32);
-    addInt32(buffer, -1);
+    buffer.writeByte(FieldType::I32);
+    buffer.writeBEInt<int32_t>(-1);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readListBegin(buffer, elem_type, size), EnvoyException,
                               "negative binary protocol list/set size -1");
@@ -355,8 +355,8 @@ TEST(BinaryProtocolTest, ReadListBegin) {
     FieldType elem_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, FieldType::I32);
-    addInt32(buffer, 10);
+    buffer.writeByte(FieldType::I32);
+    buffer.writeBEInt<int32_t>(10);
 
     EXPECT_TRUE(proto.readListBegin(buffer, elem_type, size));
     EXPECT_EQ(elem_type, FieldType::I32);
@@ -379,8 +379,8 @@ TEST(BinaryProtocolTest, ReadSetBegin) {
   FieldType elem_type = FieldType::String;
   uint32_t size = 1;
 
-  addInt8(buffer, FieldType::I32);
-  addInt32(buffer, 10);
+  buffer.writeByte(FieldType::I32);
+  buffer.writeBEInt<int32_t>(10);
 
   EXPECT_TRUE(proto.readSetBegin(buffer, elem_type, size));
   EXPECT_EQ(elem_type, FieldType::I32);
@@ -405,12 +405,12 @@ TEST(BinaryProtocolTest, ReadIntegerTypes) {
     EXPECT_FALSE(proto.readBool(buffer, value));
     EXPECT_FALSE(value);
 
-    addInt8(buffer, 1);
+    buffer.writeByte(1);
     EXPECT_TRUE(proto.readBool(buffer, value));
     EXPECT_TRUE(value);
     EXPECT_EQ(buffer.length(), 0);
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_TRUE(proto.readBool(buffer, value));
     EXPECT_FALSE(value);
     EXPECT_EQ(buffer.length(), 0);
@@ -424,12 +424,12 @@ TEST(BinaryProtocolTest, ReadIntegerTypes) {
     EXPECT_FALSE(proto.readByte(buffer, value));
     EXPECT_EQ(value, 1);
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_TRUE(proto.readByte(buffer, value));
     EXPECT_EQ(value, 0);
     EXPECT_EQ(buffer.length(), 0);
 
-    addInt8(buffer, 0xFF);
+    buffer.writeByte(0xFF);
     EXPECT_TRUE(proto.readByte(buffer, value));
     EXPECT_EQ(value, 0xFF);
     EXPECT_EQ(buffer.length(), 0);
@@ -440,17 +440,17 @@ TEST(BinaryProtocolTest, ReadIntegerTypes) {
     Buffer::OwnedImpl buffer;
     int16_t value = 1;
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_FALSE(proto.readInt16(buffer, value));
     EXPECT_EQ(value, 1);
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_TRUE(proto.readInt16(buffer, value));
     EXPECT_EQ(value, 0);
     EXPECT_EQ(buffer.length(), 0);
 
-    addInt8(buffer, 0x01);
-    addInt8(buffer, 0x02);
+    buffer.writeByte(0x01);
+    buffer.writeByte(0x02);
     EXPECT_TRUE(proto.readInt16(buffer, value));
     EXPECT_EQ(value, 0x0102);
     EXPECT_EQ(buffer.length(), 0);
@@ -470,7 +470,7 @@ TEST(BinaryProtocolTest, ReadIntegerTypes) {
     EXPECT_FALSE(proto.readInt32(buffer, value));
     EXPECT_EQ(value, 1);
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_TRUE(proto.readInt32(buffer, value));
     EXPECT_EQ(value, 0);
     EXPECT_EQ(buffer.length(), 0);
@@ -495,7 +495,7 @@ TEST(BinaryProtocolTest, ReadIntegerTypes) {
     EXPECT_FALSE(proto.readInt64(buffer, value));
     EXPECT_EQ(value, 1);
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_TRUE(proto.readInt64(buffer, value));
     EXPECT_EQ(value, 0);
     EXPECT_EQ(buffer.length(), 0);
@@ -560,7 +560,7 @@ TEST(BinaryProtocolTest, ReadString) {
     Buffer::OwnedImpl buffer;
     std::string value = "-";
 
-    addInt32(buffer, 1);
+    buffer.writeBEInt<int32_t>(1);
 
     EXPECT_FALSE(proto.readString(buffer, value));
     EXPECT_EQ(value, "-");
@@ -572,7 +572,7 @@ TEST(BinaryProtocolTest, ReadString) {
     Buffer::OwnedImpl buffer;
     std::string value = "-";
 
-    addInt32(buffer, -1);
+    buffer.writeBEInt<int32_t>(-1);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readString(buffer, value), EnvoyException,
                               "negative binary protocol string/binary length -1");
@@ -585,7 +585,7 @@ TEST(BinaryProtocolTest, ReadString) {
     Buffer::OwnedImpl buffer;
     std::string value = "-";
 
-    addInt32(buffer, 0);
+    buffer.writeBEInt<int32_t>(0);
 
     EXPECT_TRUE(proto.readString(buffer, value));
     EXPECT_EQ(value, "");
@@ -597,7 +597,7 @@ TEST(BinaryProtocolTest, ReadString) {
     Buffer::OwnedImpl buffer;
     std::string value = "-";
 
-    addInt32(buffer, 6);
+    buffer.writeBEInt<int32_t>(6);
     addString(buffer, "string");
 
     EXPECT_TRUE(proto.readString(buffer, value));
@@ -612,7 +612,7 @@ TEST(BinaryProtocolTest, ReadBinary) {
   Buffer::OwnedImpl buffer;
   std::string value = "-";
 
-  addInt32(buffer, 6);
+  buffer.writeBEInt<int32_t>(6);
   addString(buffer, "binary");
 
   EXPECT_TRUE(proto.readBinary(buffer, value));
@@ -917,8 +917,8 @@ TEST(LaxBinaryProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt32(buffer, 0);
-    addInt8(buffer, static_cast<int8_t>(MessageType::LastMessageType) + 1);
+    buffer.writeBEInt<int32_t>(0);
+    buffer.writeByte(static_cast<int8_t>(MessageType::LastMessageType) + 1);
     addRepeated(buffer, 4, 'x');
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMessageBegin(buffer, name, msg_type, seq_id),
@@ -938,9 +938,9 @@ TEST(LaxBinaryProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt32(buffer, 0);
-    addInt8(buffer, MessageType::Call);
-    addInt32(buffer, 1234);
+    buffer.writeBEInt<int32_t>(0);
+    buffer.writeByte(MessageType::Call);
+    buffer.writeBEInt<int32_t>(1234);
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, name, msg_type, seq_id));
     EXPECT_EQ(name, "");
@@ -956,9 +956,9 @@ TEST(LaxBinaryProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt32(buffer, 1); // name length
-    addInt8(buffer, MessageType::Call);
-    addInt32(buffer, 1234);
+    buffer.writeBEInt<int32_t>(1); // name length
+    buffer.writeByte(MessageType::Call);
+    buffer.writeBEInt<int32_t>(1234);
 
     EXPECT_FALSE(proto.readMessageBegin(buffer, name, msg_type, seq_id));
     EXPECT_EQ(name, "-");
@@ -974,10 +974,10 @@ TEST(LaxBinaryProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt32(buffer, 8);
+    buffer.writeBEInt<int32_t>(8);
     addString(buffer, "the_name");
-    addInt8(buffer, MessageType::Call);
-    addInt32(buffer, 5678);
+    buffer.writeByte(MessageType::Call);
+    buffer.writeBEInt<int32_t>(5678);
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, name, msg_type, seq_id));
     EXPECT_EQ(name, "the_name");

--- a/test/extensions/filters/network/thrift_proxy/buffer_helper_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/buffer_helper_test.cc
@@ -17,219 +17,6 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace ThriftProxy {
 
-TEST(BufferHelperTest, PeekI8) {
-  {
-    Buffer::OwnedImpl buffer;
-    addSeq(buffer, {0, 1, 0xFE});
-    EXPECT_EQ(BufferHelper::peekI8(buffer), 0);
-    EXPECT_EQ(BufferHelper::peekI8(buffer, 0), 0);
-    EXPECT_EQ(BufferHelper::peekI8(buffer, 1), 1);
-    EXPECT_EQ(BufferHelper::peekI8(buffer, 2), -2);
-    EXPECT_EQ(buffer.length(), 3);
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekI8(buffer, 0), EnvoyException, "buffer underflow");
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    addInt8(buffer, 0);
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekI8(buffer, 1), EnvoyException, "buffer underflow");
-  }
-}
-
-TEST(BufferHelperTest, PeekI16) {
-  {
-    Buffer::OwnedImpl buffer;
-    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
-    EXPECT_EQ(BufferHelper::peekI16(buffer), 1);
-    EXPECT_EQ(BufferHelper::peekI16(buffer, 0), 1);
-    EXPECT_EQ(BufferHelper::peekI16(buffer, 1), 0x0102);
-    EXPECT_EQ(BufferHelper::peekI16(buffer, 2), 0x0203);
-    EXPECT_EQ(BufferHelper::peekI16(buffer, 4), -1);
-    EXPECT_EQ(buffer.length(), 6);
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekI16(buffer, 0), EnvoyException, "buffer underflow");
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    addRepeated(buffer, 2, 0);
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekI16(buffer, 1), EnvoyException, "buffer underflow");
-  }
-}
-
-TEST(BufferHelperTest, PeekI32) {
-  {
-    Buffer::OwnedImpl buffer;
-    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
-    EXPECT_EQ(BufferHelper::peekI32(buffer), 0x00010203);
-    EXPECT_EQ(BufferHelper::peekI32(buffer, 0), 0x00010203);
-    EXPECT_EQ(BufferHelper::peekI32(buffer, 1), 0x010203FF);
-    EXPECT_EQ(BufferHelper::peekI32(buffer, 2), 0x0203FFFF);
-    EXPECT_EQ(BufferHelper::peekI32(buffer, 4), -1);
-    EXPECT_EQ(buffer.length(), 8);
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekI32(buffer, 0), EnvoyException, "buffer underflow");
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    addRepeated(buffer, 4, 0);
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekI32(buffer, 1), EnvoyException, "buffer underflow");
-  }
-}
-
-TEST(BufferHelperTest, PeekI64) {
-  {
-    Buffer::OwnedImpl buffer;
-    addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
-    EXPECT_EQ(BufferHelper::peekI64(buffer), 0x0001020304050607);
-    EXPECT_EQ(BufferHelper::peekI64(buffer, 0), 0x0001020304050607);
-    EXPECT_EQ(BufferHelper::peekI64(buffer, 1), 0x01020304050607FF);
-    EXPECT_EQ(BufferHelper::peekI64(buffer, 2), 0x020304050607FFFF);
-    EXPECT_EQ(BufferHelper::peekI64(buffer, 8), -1);
-    EXPECT_EQ(buffer.length(), 16);
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekI64(buffer, 0), EnvoyException, "buffer underflow");
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    addRepeated(buffer, 8, 0);
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekI64(buffer, 1), EnvoyException, "buffer underflow");
-  }
-}
-
-TEST(BufferHelperTest, PeekU16) {
-  {
-    Buffer::OwnedImpl buffer;
-    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
-    EXPECT_EQ(BufferHelper::peekU16(buffer), 1);
-    EXPECT_EQ(BufferHelper::peekU16(buffer, 0), 1);
-    EXPECT_EQ(BufferHelper::peekU16(buffer, 1), 0x0102);
-    EXPECT_EQ(BufferHelper::peekU16(buffer, 2), 0x0203);
-    EXPECT_EQ(BufferHelper::peekU16(buffer, 4), 0xFFFF);
-    EXPECT_EQ(buffer.length(), 6);
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekU16(buffer, 0), EnvoyException, "buffer underflow");
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    addRepeated(buffer, 2, 0);
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekU16(buffer, 1), EnvoyException, "buffer underflow");
-  }
-}
-
-TEST(BufferHelperTest, PeekU32) {
-  {
-    Buffer::OwnedImpl buffer;
-    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
-    EXPECT_EQ(BufferHelper::peekU32(buffer), 0x00010203);
-    EXPECT_EQ(BufferHelper::peekU32(buffer, 0), 0x00010203);
-    EXPECT_EQ(BufferHelper::peekU32(buffer, 1), 0x010203FF);
-    EXPECT_EQ(BufferHelper::peekU32(buffer, 2), 0x0203FFFF);
-    EXPECT_EQ(BufferHelper::peekU32(buffer, 4), 0xFFFFFFFF);
-    EXPECT_EQ(buffer.length(), 8);
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekU32(buffer, 0), EnvoyException, "buffer underflow");
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    addRepeated(buffer, 4, 0);
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekU32(buffer, 1), EnvoyException, "buffer underflow");
-  }
-}
-
-TEST(BufferHelperTest, PeekU64) {
-  {
-    Buffer::OwnedImpl buffer;
-    addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
-    EXPECT_EQ(BufferHelper::peekU64(buffer), 0x0001020304050607);
-    EXPECT_EQ(BufferHelper::peekU64(buffer, 0), 0x0001020304050607);
-    EXPECT_EQ(BufferHelper::peekU64(buffer, 1), 0x01020304050607FF);
-    EXPECT_EQ(BufferHelper::peekU64(buffer, 2), 0x020304050607FFFF);
-    EXPECT_EQ(BufferHelper::peekU64(buffer, 8), 0xFFFFFFFFFFFFFFFF);
-    EXPECT_EQ(buffer.length(), 16);
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekU64(buffer, 0), EnvoyException, "buffer underflow");
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    addRepeated(buffer, 8, 0);
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekU64(buffer, 1), EnvoyException, "buffer underflow");
-  }
-}
-
-TEST(BufferHelperTest, DrainI8) {
-  Buffer::OwnedImpl buffer;
-  addSeq(buffer, {0, 1, 0xFE});
-  EXPECT_EQ(BufferHelper::drainI8(buffer), 0);
-  EXPECT_EQ(BufferHelper::drainI8(buffer), 1);
-  EXPECT_EQ(BufferHelper::drainI8(buffer), -2);
-  EXPECT_EQ(buffer.length(), 0);
-}
-
-TEST(BufferHelperTest, DrainI16) {
-  Buffer::OwnedImpl buffer;
-  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
-  EXPECT_EQ(BufferHelper::drainI16(buffer), 1);
-  EXPECT_EQ(BufferHelper::drainI16(buffer), 0x0203);
-  EXPECT_EQ(BufferHelper::drainI16(buffer), -1);
-  EXPECT_EQ(buffer.length(), 0);
-}
-
-TEST(BufferHelperTest, DrainI32) {
-  Buffer::OwnedImpl buffer;
-  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
-  EXPECT_EQ(BufferHelper::drainI32(buffer), 0x00010203);
-  EXPECT_EQ(BufferHelper::drainI32(buffer), -1);
-  EXPECT_EQ(buffer.length(), 0);
-}
-
-TEST(BufferHelperTest, DrainI64) {
-  Buffer::OwnedImpl buffer;
-  addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
-  EXPECT_EQ(BufferHelper::drainI64(buffer), 0x0001020304050607);
-  EXPECT_EQ(BufferHelper::drainI64(buffer), -1);
-  EXPECT_EQ(buffer.length(), 0);
-}
-
-TEST(BufferHelperTest, DrainU32) {
-  Buffer::OwnedImpl buffer;
-  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
-  EXPECT_EQ(BufferHelper::drainU32(buffer), 0x00010203);
-  EXPECT_EQ(BufferHelper::drainU32(buffer), 0xFFFFFFFF);
-  EXPECT_EQ(buffer.length(), 0);
-}
-
-TEST(BufferHelperTest, DrainU64) {
-  Buffer::OwnedImpl buffer;
-  addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
-  EXPECT_EQ(BufferHelper::drainU64(buffer), 0x0001020304050607);
-  EXPECT_EQ(BufferHelper::drainU64(buffer), 0xFFFFFFFFFFFFFFFF);
-  EXPECT_EQ(buffer.length(), 0);
-}
-
 TEST(BufferHelperTest, DrainDouble) {
   Buffer::OwnedImpl buffer;
 
@@ -240,16 +27,16 @@ TEST(BufferHelperTest, DrainDouble) {
   // 11111111 11101111 11111111 1111111 11111111 11111111 11111111 111111111 = -DBL_MAX
   addSeq(buffer, {0xFF, 0xEF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
 
-  EXPECT_EQ(BufferHelper::drainDouble(buffer), 3.0);
-  EXPECT_EQ(BufferHelper::drainDouble(buffer), std::numeric_limits<double>::lowest());
+  EXPECT_EQ(BufferHelper::drainBEDouble(buffer), 3.0);
+  EXPECT_EQ(BufferHelper::drainBEDouble(buffer), std::numeric_limits<double>::lowest());
   EXPECT_EQ(buffer.length(), 0);
 }
 
 TEST(BufferHelperTest, PeekVarInt32) {
   {
     Buffer::OwnedImpl buffer;
-    addInt8(buffer, 0);
-    addInt8(buffer, 0x7F);
+    buffer.writeByte(0);
+    buffer.writeByte(0x7F);
     addSeq(buffer, {0xFF, 0x01});                   // 0xFF
     addSeq(buffer, {0xFF, 0xFF, 0x03});             // 0xFFFF
     addSeq(buffer, {0xFF, 0xFF, 0xFF, 0x07});       // 0xFFFFFF
@@ -289,7 +76,7 @@ TEST(BufferHelperTest, PeekVarInt32) {
   {
     Buffer::OwnedImpl buffer;
     int size = 0;
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekVarIntI32(buffer, 1, size), EnvoyException,
                               "buffer underflow");
   }
@@ -300,21 +87,21 @@ TEST(BufferHelperTest, PeekVarInt32BufferUnderflow) {
   int size = 0;
 
   for (int i = 1; i < 5; i++) {
-    addInt8(buffer, 0x80);
+    buffer.writeByte(0x80);
     EXPECT_EQ(BufferHelper::peekVarIntI32(buffer, 0, size), 0);
     EXPECT_EQ(size, -i);
   }
 
-  addInt8(buffer, 0x80);
+  buffer.writeByte(0x80);
   EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekVarIntI32(buffer, 0, size), EnvoyException,
                             "invalid compact protocol varint i32");
 }
 
 TEST(BufferHelperTest, PeekZigZagI32) {
   Buffer::OwnedImpl buffer;
-  addInt8(buffer, 0);                             // unzigzag(0) = 0
-  addInt8(buffer, 1);                             // unzigzag(1) = -1
-  addInt8(buffer, 2);                             // unzigzag(2) = 1
+  buffer.writeByte(0);                            // unzigzag(0) = 0
+  buffer.writeByte(1);                            // unzigzag(1) = -1
+  buffer.writeByte(2);                            // unzigzag(2) = 1
   addSeq(buffer, {0xFE, 0x01});                   // unzigzag(0xFE) = 127
   addSeq(buffer, {0xFF, 0x01});                   // unzigzag(0xFF) = -128
   addSeq(buffer, {0xFF, 0xFF, 0x03});             // unzigzag(0xFFFF) = -32768
@@ -360,21 +147,21 @@ TEST(BufferHelperTest, PeekZigZagI32BufferUnderflow) {
   int size = 0;
 
   for (int i = 1; i < 5; i++) {
-    addInt8(buffer, 0x80);
+    buffer.writeByte(0x80);
     EXPECT_EQ(BufferHelper::peekZigZagI32(buffer, 0, size), 0);
     EXPECT_EQ(size, -i);
   }
 
-  addInt8(buffer, 0x80);
+  buffer.writeByte(0x80);
   EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekZigZagI32(buffer, 0, size), EnvoyException,
                             "invalid compact protocol zig-zag i32");
 }
 
 TEST(BufferHelperTest, PeekZigZagI64) {
   Buffer::OwnedImpl buffer;
-  addInt8(buffer, 0);                             // unzigzag(0) = 0
-  addInt8(buffer, 1);                             // unzigzag(1) = -1
-  addInt8(buffer, 2);                             // unzigzag(2) = 1
+  buffer.writeByte(0);                            // unzigzag(0) = 0
+  buffer.writeByte(1);                            // unzigzag(1) = -1
+  buffer.writeByte(2);                            // unzigzag(2) = 1
   addSeq(buffer, {0xFF, 0xFF, 0x03});             // unzigzag(0xFFFF) = -32768
   addSeq(buffer, {0xFE, 0xFF, 0xFF, 0xFF, 0x0F}); // unzigzag(0xFFFF FFFE) = 0x7FFF FFFF
 
@@ -418,152 +205,27 @@ TEST(BufferHelperTest, PeekZigZagI64BufferUnderflow) {
   int size = 0;
 
   for (int i = 1; i < 10; i++) {
-    addInt8(buffer, 0x80);
+    buffer.writeByte(0x80);
     EXPECT_EQ(BufferHelper::peekZigZagI64(buffer, 0, size), 0);
     EXPECT_EQ(size, -i);
   }
 
-  addInt8(buffer, 0x80);
+  buffer.writeByte(0x80);
   EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekZigZagI64(buffer, 0, size), EnvoyException,
                             "invalid compact protocol zig-zag i64");
-}
-
-TEST(BufferHelperTest, WriteI8) {
-  Buffer::OwnedImpl buffer;
-  BufferHelper::writeI8(buffer, -128);
-  BufferHelper::writeI8(buffer, -1);
-  BufferHelper::writeI8(buffer, 0);
-  BufferHelper::writeI8(buffer, 1);
-  BufferHelper::writeI8(buffer, 127);
-
-  EXPECT_EQ(std::string("\x80\xFF\0\x1\x7F", 5), buffer.toString());
-}
-
-TEST(BufferHelperTest, WriteI16) {
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI16(buffer, std::numeric_limits<int16_t>::min());
-    EXPECT_EQ(std::string("\x80\0", 2), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI16(buffer, 0);
-    EXPECT_EQ(std::string("\0\0", 2), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI16(buffer, 1);
-    EXPECT_EQ(std::string("\0\x1", 2), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI16(buffer, std::numeric_limits<int16_t>::max());
-    EXPECT_EQ("\x7F\xFF", buffer.toString());
-  }
-}
-
-TEST(BufferHelperTest, WriteU16) {
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeU16(buffer, 0);
-    EXPECT_EQ(std::string("\0\0", 2), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeU16(buffer, 1);
-    EXPECT_EQ(std::string("\0\x1", 2), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeU16(buffer, static_cast<uint16_t>(std::numeric_limits<int16_t>::max()) + 1);
-    EXPECT_EQ(std::string("\x80\0", 2), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeU16(buffer, std::numeric_limits<uint16_t>::max());
-    EXPECT_EQ("\xFF\xFF", buffer.toString());
-  }
-}
-
-TEST(BufferHelperTest, WriteI32) {
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI32(buffer, std::numeric_limits<int32_t>::min());
-    EXPECT_EQ(std::string("\x80\0\0\0", 4), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI32(buffer, 0);
-    EXPECT_EQ(std::string("\0\0\0\0", 4), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI32(buffer, 1);
-    EXPECT_EQ(std::string("\0\0\0\x1", 4), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI32(buffer, std::numeric_limits<int32_t>::max());
-    EXPECT_EQ("\x7F\xFF\xFF\xFF", buffer.toString());
-  }
-}
-
-TEST(BufferHelperTest, WriteU32) {
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeU32(buffer, 0);
-    EXPECT_EQ(std::string("\0\0\0\0", 4), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeU32(buffer, 1);
-    EXPECT_EQ(std::string("\0\0\0\x1", 4), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeU32(buffer, static_cast<uint32_t>(std::numeric_limits<int32_t>::max()) + 1);
-    EXPECT_EQ(std::string("\x80\0\0\0", 4), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeU32(buffer, std::numeric_limits<uint32_t>::max());
-    EXPECT_EQ("\xFF\xFF\xFF\xFF", buffer.toString());
-  }
-}
-TEST(BufferHelperTest, WriteI64) {
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI64(buffer, std::numeric_limits<int64_t>::min());
-    EXPECT_EQ(std::string("\x80\0\0\0\0\0\0\0\0", 8), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI64(buffer, 1);
-    EXPECT_EQ(std::string("\0\0\0\0\0\0\0\x1", 8), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI64(buffer, 0);
-    EXPECT_EQ(std::string("\0\0\0\0\0\0\0\0", 8), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI64(buffer, std::numeric_limits<int64_t>::max());
-    EXPECT_EQ("\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF", buffer.toString());
-  }
 }
 
 TEST(BufferHelperTest, WriteDouble) {
   // See the DrainDouble test.
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeDouble(buffer, 3.0);
+    BufferHelper::writeBEDouble(buffer, 3.0);
     EXPECT_EQ(std::string("\x40\x8\0\0\0\0\0\0", 8), buffer.toString());
   }
 
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeDouble(buffer, std::numeric_limits<double>::lowest());
+    BufferHelper::writeBEDouble(buffer, std::numeric_limits<double>::lowest());
     EXPECT_EQ("\xFF\xEF\xFF\xFF\xFF\xFF\xFF\xFF", buffer.toString());
   }
 }

--- a/test/extensions/filters/network/thrift_proxy/compact_protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/compact_protocol_impl_test.cc
@@ -49,7 +49,7 @@ TEST(CompactProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt16(buffer, 0x0102);
+    buffer.writeBEInt<int16_t>(0x0102);
     addRepeated(buffer, 2, 'x');
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMessageBegin(buffer, name, msg_type, seq_id),
@@ -69,7 +69,7 @@ TEST(CompactProtocolTest, ReadMessageBegin) {
 
     // Message type is encoded in the 3 highest order bits of the second byte.
     int8_t invalid_msg_type = static_cast<int8_t>(MessageType::LastMessageType) + 1;
-    addInt16(buffer, static_cast<int16_t>(0x8201 | (invalid_msg_type << 5)));
+    buffer.writeBEInt<int16_t>(static_cast<int16_t>(0x8201 | (invalid_msg_type << 5)));
     addRepeated(buffer, 2, 'x');
 
     EXPECT_THROW_WITH_MESSAGE(
@@ -88,7 +88,7 @@ TEST(CompactProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt16(buffer, 0x8221);
+    buffer.writeBEInt<int16_t>(0x8221);
     addRepeated(buffer, 2, 0x81);
 
     EXPECT_FALSE(proto.readMessageBegin(buffer, name, msg_type, seq_id));
@@ -105,9 +105,9 @@ TEST(CompactProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt16(buffer, 0x8221);
+    buffer.writeBEInt<int16_t>(0x8221);
     addSeq(buffer, {0x81, 0x81, 0x81, 0x81, 0x81, 0}); // > 32 bit varint
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMessageBegin(buffer, name, msg_type, seq_id),
                               EnvoyException, "invalid compact protocol varint i32");
@@ -124,9 +124,9 @@ TEST(CompactProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt16(buffer, 0x8221);
-    addInt8(buffer, 32);
-    addInt8(buffer, 0x81); // unterminated varint
+    buffer.writeBEInt<int16_t>(0x8221);
+    buffer.writeByte(32);
+    buffer.writeByte(0x81); // unterminated varint
 
     EXPECT_FALSE(proto.readMessageBegin(buffer, name, msg_type, seq_id));
     EXPECT_EQ(name, "-");
@@ -142,9 +142,9 @@ TEST(CompactProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt16(buffer, 0x8221);
-    addInt8(buffer, 32);
-    addInt8(buffer, 10);
+    buffer.writeBEInt<int16_t>(0x8221);
+    buffer.writeByte(32);
+    buffer.writeByte(10);
     addString(buffer, "partial");
 
     EXPECT_FALSE(proto.readMessageBegin(buffer, name, msg_type, seq_id));
@@ -161,9 +161,9 @@ TEST(CompactProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt16(buffer, 0x8221);
-    addInt8(buffer, 32);
-    addInt8(buffer, 0);
+    buffer.writeBEInt<int16_t>(0x8221);
+    buffer.writeByte(32);
+    buffer.writeByte(0);
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, name, msg_type, seq_id));
     EXPECT_EQ(name, "");
@@ -179,8 +179,8 @@ TEST(CompactProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt16(buffer, 0x8221);
-    addInt8(buffer, 32);
+    buffer.writeBEInt<int16_t>(0x8221);
+    buffer.writeByte(32);
     addSeq(buffer, {0x81, 0x81, 0x81, 0x81, 0x81, 0}); // > 32 bit varint
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMessageBegin(buffer, name, msg_type, seq_id),
@@ -198,8 +198,8 @@ TEST(CompactProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt16(buffer, 0x8221);
-    addInt8(buffer, 32);
+    buffer.writeBEInt<int16_t>(0x8221);
+    buffer.writeByte(32);
     addSeq(buffer, {0xFF, 0xFF, 0xFF, 0xFF, 0x1F}); // -1
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMessageBegin(buffer, name, msg_type, seq_id),
@@ -217,9 +217,9 @@ TEST(CompactProtocolTest, ReadMessageBegin) {
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
 
-    addInt16(buffer, 0x8221);
-    addInt16(buffer, 0x8202); // 0x0102
-    addInt8(buffer, 8);
+    buffer.writeBEInt<int16_t>(0x8221);
+    buffer.writeBEInt<int16_t>(0x8202); // 0x0102
+    buffer.writeByte(8);
     addString(buffer, "the_name");
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, name, msg_type, seq_id));
@@ -274,7 +274,7 @@ TEST(CompactProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, 0xF0);
+    buffer.writeByte(0xF0);
 
     EXPECT_TRUE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "");
@@ -290,7 +290,7 @@ TEST(CompactProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, 0x05);
+    buffer.writeByte(0x05);
 
     EXPECT_FALSE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "-");
@@ -306,8 +306,8 @@ TEST(CompactProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, 0x05);
-    addInt8(buffer, 0x81);
+    buffer.writeByte(0x05);
+    buffer.writeByte(0x81);
 
     EXPECT_FALSE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "-");
@@ -331,7 +331,7 @@ TEST(CompactProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, 0x05);
+    buffer.writeByte(0x05);
     addSeq(buffer, {0x80, 0x80, 0x04}); // zigzag(0x10000) = 0x8000
 
     EXPECT_THROW_WITH_MESSAGE(proto.readFieldBegin(buffer, name, field_type, field_id),
@@ -349,7 +349,7 @@ TEST(CompactProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, 0x05);
+    buffer.writeByte(0x05);
     addSeq(buffer, {0x01}); // zigzag(1) = -1
 
     EXPECT_THROW_WITH_MESSAGE(proto.readFieldBegin(buffer, name, field_type, field_id),
@@ -367,8 +367,8 @@ TEST(CompactProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, 0x0D);
-    addInt8(buffer, 0x04);
+    buffer.writeByte(0x0D);
+    buffer.writeByte(0x04);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readFieldBegin(buffer, name, field_type, field_id),
                               EnvoyException, "unknown compact protocol field type 13");
@@ -385,8 +385,8 @@ TEST(CompactProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, 0x05);
-    addInt8(buffer, 0x04);
+    buffer.writeByte(0x05);
+    buffer.writeByte(0x04);
 
     EXPECT_TRUE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "");
@@ -402,7 +402,7 @@ TEST(CompactProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, 0xF5);
+    buffer.writeByte(0xF5);
 
     EXPECT_TRUE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "");
@@ -428,7 +428,7 @@ TEST(CompactProtocolTest, ReadMapBegin) {
     FieldType value_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0x81); // unterminated varint
+    buffer.writeByte(0x81); // unterminated varint
 
     EXPECT_FALSE(proto.readMapBegin(buffer, key_type, value_type, size));
     EXPECT_EQ(key_type, FieldType::String);
@@ -478,7 +478,7 @@ TEST(CompactProtocolTest, ReadMapBegin) {
     FieldType value_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 2);
+    buffer.writeByte(2);
 
     EXPECT_FALSE(proto.readMapBegin(buffer, key_type, value_type, size));
     EXPECT_EQ(key_type, FieldType::String);
@@ -494,7 +494,7 @@ TEST(CompactProtocolTest, ReadMapBegin) {
     FieldType value_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
 
     EXPECT_TRUE(proto.readMapBegin(buffer, key_type, value_type, size));
     EXPECT_EQ(key_type, FieldType::Stop);
@@ -511,7 +511,7 @@ TEST(CompactProtocolTest, ReadMapBegin) {
     uint32_t size = 1;
 
     addSeq(buffer, {0x80, 0x01}); // 0x80
-    addInt8(buffer, 0x57);
+    buffer.writeByte(0x57);
 
     EXPECT_TRUE(proto.readMapBegin(buffer, key_type, value_type, size));
     EXPECT_EQ(key_type, FieldType::I32);
@@ -527,8 +527,8 @@ TEST(CompactProtocolTest, ReadMapBegin) {
     FieldType value_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0x02);
-    addInt8(buffer, 0xD7);
+    buffer.writeByte(0x02);
+    buffer.writeByte(0xD7);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMapBegin(buffer, key_type, value_type, size),
                               EnvoyException, "unknown compact protocol field type 13");
@@ -545,8 +545,8 @@ TEST(CompactProtocolTest, ReadMapBegin) {
     FieldType value_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0x02);
-    addInt8(buffer, 0x5D);
+    buffer.writeByte(0x02);
+    buffer.writeByte(0x5D);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMapBegin(buffer, key_type, value_type, size),
                               EnvoyException, "unknown compact protocol field type 13");
@@ -584,7 +584,7 @@ TEST(CompactProtocolTest, ReadListBegin) {
     FieldType elem_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0xE5);
+    buffer.writeByte(0xE5);
 
     EXPECT_TRUE(proto.readListBegin(buffer, elem_type, size));
     EXPECT_EQ(elem_type, FieldType::I32);
@@ -598,8 +598,8 @@ TEST(CompactProtocolTest, ReadListBegin) {
     FieldType elem_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0xF5);
-    addInt8(buffer, 0x81);
+    buffer.writeByte(0xF5);
+    buffer.writeByte(0x81);
 
     EXPECT_FALSE(proto.readListBegin(buffer, elem_type, size));
     EXPECT_EQ(elem_type, FieldType::String);
@@ -613,7 +613,7 @@ TEST(CompactProtocolTest, ReadListBegin) {
     FieldType elem_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0xF5);
+    buffer.writeByte(0xF5);
     addSeq(buffer, {0x81, 0x81, 0x81, 0x81, 0x81, 0}); // > 32 bit varint
 
     EXPECT_THROW_WITH_MESSAGE(proto.readListBegin(buffer, elem_type, size), EnvoyException,
@@ -629,7 +629,7 @@ TEST(CompactProtocolTest, ReadListBegin) {
     FieldType elem_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0xF5);
+    buffer.writeByte(0xF5);
     addSeq(buffer, {0xFF, 0xFF, 0xFF, 0xFF, 0x1F}); // -1
 
     EXPECT_THROW_WITH_MESSAGE(proto.readListBegin(buffer, elem_type, size), EnvoyException,
@@ -645,7 +645,7 @@ TEST(CompactProtocolTest, ReadListBegin) {
     FieldType elem_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0xF5);
+    buffer.writeByte(0xF5);
     addSeq(buffer, {0x80, 0x01}); // 0x80
 
     EXPECT_TRUE(proto.readListBegin(buffer, elem_type, size));
@@ -660,7 +660,7 @@ TEST(CompactProtocolTest, ReadListBegin) {
     FieldType elem_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0x1D);
+    buffer.writeByte(0x1D);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readListBegin(buffer, elem_type, size), EnvoyException,
                               "unknown compact protocol field type 13");
@@ -684,7 +684,7 @@ TEST(CompactProtocolTest, ReadSetBegin) {
   FieldType elem_type = FieldType::String;
   uint32_t size = 0;
 
-  addInt8(buffer, 0x15);
+  buffer.writeByte(0x15);
 
   EXPECT_TRUE(proto.readSetBegin(buffer, elem_type, size));
   EXPECT_EQ(elem_type, FieldType::I32);
@@ -709,8 +709,8 @@ TEST(CompactProtocolTest, ReadBool) {
     int16_t field_id = 1;
     bool value = false;
 
-    addInt8(buffer, 0x01);
-    addInt8(buffer, 0x04);
+    buffer.writeByte(0x01);
+    buffer.writeByte(0x04);
 
     EXPECT_TRUE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "");
@@ -725,8 +725,8 @@ TEST(CompactProtocolTest, ReadBool) {
     EXPECT_TRUE(proto.readFieldEnd(buffer));
     EXPECT_FALSE(proto.readBool(buffer, value));
 
-    addInt8(buffer, 0x02);
-    addInt8(buffer, 0x06);
+    buffer.writeByte(0x02);
+    buffer.writeByte(0x06);
 
     EXPECT_TRUE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "");
@@ -750,12 +750,12 @@ TEST(CompactProtocolTest, ReadBool) {
     EXPECT_FALSE(proto.readBool(buffer, value));
     EXPECT_FALSE(value);
 
-    addInt8(buffer, 1);
+    buffer.writeByte(1);
     EXPECT_TRUE(proto.readBool(buffer, value));
     EXPECT_TRUE(value);
     EXPECT_EQ(buffer.length(), 0);
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_TRUE(proto.readBool(buffer, value));
     EXPECT_FALSE(value);
     EXPECT_EQ(buffer.length(), 0);
@@ -773,12 +773,12 @@ TEST(CompactProtocolTest, ReadIntegerTypes) {
     EXPECT_FALSE(proto.readByte(buffer, value));
     EXPECT_EQ(value, 1);
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_TRUE(proto.readByte(buffer, value));
     EXPECT_EQ(value, 0);
     EXPECT_EQ(buffer.length(), 0);
 
-    addInt8(buffer, 0xFF);
+    buffer.writeByte(0xFF);
     EXPECT_TRUE(proto.readByte(buffer, value));
     EXPECT_EQ(value, 0xFF);
     EXPECT_EQ(buffer.length(), 0);
@@ -794,7 +794,7 @@ TEST(CompactProtocolTest, ReadIntegerTypes) {
     EXPECT_EQ(value, 1);
 
     // Still insufficient
-    addInt8(buffer, 0x80);
+    buffer.writeByte(0x80);
     EXPECT_FALSE(proto.readInt16(buffer, value));
     EXPECT_EQ(value, 1);
     buffer.drain(1);
@@ -836,7 +836,7 @@ TEST(CompactProtocolTest, ReadIntegerTypes) {
     EXPECT_EQ(value, 1);
 
     // Still insufficient
-    addInt8(buffer, 0x80);
+    buffer.writeByte(0x80);
     EXPECT_FALSE(proto.readInt32(buffer, value));
     EXPECT_EQ(value, 1);
     buffer.drain(1);
@@ -868,7 +868,7 @@ TEST(CompactProtocolTest, ReadIntegerTypes) {
     EXPECT_EQ(value, 1);
 
     // Still insufficient
-    addInt8(buffer, 0x80);
+    buffer.writeByte(0x80);
     EXPECT_FALSE(proto.readInt64(buffer, value));
     EXPECT_EQ(value, 1);
     buffer.drain(1);
@@ -913,8 +913,8 @@ TEST(CompactProtocolTest, ReadDouble) {
 
     // 01000000 00001000 00000000 0000000 00000000 00000000 00000000 000000000 = 3
     // c.f. https://en.wikipedia.org/wiki/Double-precision_floating-point_format
-    addInt8(buffer, 0x40);
-    addInt8(buffer, 0x08);
+    buffer.writeByte(0x40);
+    buffer.writeByte(0x08);
     addRepeated(buffer, 6, 0);
 
     EXPECT_TRUE(proto.readDouble(buffer, value));
@@ -941,7 +941,7 @@ TEST(CompactProtocolTest, ReadString) {
     Buffer::OwnedImpl buffer;
     std::string value = "-";
 
-    addInt8(buffer, 0x81);
+    buffer.writeByte(0x81);
 
     EXPECT_FALSE(proto.readString(buffer, value));
     EXPECT_EQ(value, "-");
@@ -953,7 +953,7 @@ TEST(CompactProtocolTest, ReadString) {
     Buffer::OwnedImpl buffer;
     std::string value = "-";
 
-    addInt8(buffer, 0x4);
+    buffer.writeByte(0x4);
 
     EXPECT_FALSE(proto.readString(buffer, value));
     EXPECT_EQ(value, "-");
@@ -978,7 +978,7 @@ TEST(CompactProtocolTest, ReadString) {
     Buffer::OwnedImpl buffer;
     std::string value = "-";
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
 
     EXPECT_TRUE(proto.readString(buffer, value));
     EXPECT_EQ(value, "");
@@ -990,7 +990,7 @@ TEST(CompactProtocolTest, ReadString) {
     Buffer::OwnedImpl buffer;
     std::string value = "-";
 
-    addInt8(buffer, 0x06);
+    buffer.writeByte(0x06);
     addString(buffer, "string");
 
     EXPECT_TRUE(proto.readString(buffer, value));
@@ -1005,7 +1005,7 @@ TEST(CompactProtocolTest, ReadBinary) {
   Buffer::OwnedImpl buffer;
   std::string value = "-";
 
-  addInt8(buffer, 0x06);
+  buffer.writeByte(0x06);
   addString(buffer, "string");
 
   EXPECT_TRUE(proto.readBinary(buffer, value));
@@ -1026,8 +1026,8 @@ TEST_P(CompactProtocolFieldTypeTest, ConvertsToFieldType) {
 
   {
     Buffer::OwnedImpl buffer;
-    addInt8(buffer, compact_field_type);
-    addInt8(buffer, 0x02); // zigzag(2) = 1
+    buffer.writeByte(compact_field_type);
+    buffer.writeByte(0x02); // zigzag(2) = 1
 
     EXPECT_TRUE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_LE(field_type, FieldType::LastFieldType);

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -363,7 +363,7 @@ TEST_F(ThriftConnectionManagerTest, OnDataHandlesProtocolError) {
                             0x00, 0x00, 0x00, 0x01,                     // sequence id
                             0x0b, 0x00, 0x01,                           // begin string field
                         });
-  addInt32(write_buffer_, err.length());
+  write_buffer_.writeBEInt<uint32_t>(err.length());
   addString(write_buffer_, err);
   addSeq(write_buffer_, {
                             0x08, 0x00, 0x02,       // begin i32 field

--- a/test/extensions/filters/network/thrift_proxy/framed_transport_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/framed_transport_impl_test.cc
@@ -44,7 +44,7 @@ TEST(FramedTransportTest, InvalidFrameSize) {
 
   {
     Buffer::OwnedImpl buffer;
-    addInt32(buffer, -1);
+    buffer.writeBEInt<int32_t>(-1);
 
     absl::optional<uint32_t> size = 1;
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, size), EnvoyException,
@@ -54,7 +54,7 @@ TEST(FramedTransportTest, InvalidFrameSize) {
 
   {
     Buffer::OwnedImpl buffer;
-    addInt32(buffer, 0x7fffffff);
+    buffer.writeBEInt<int32_t>(0x7fffffff);
 
     absl::optional<uint32_t> size = 1;
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, size), EnvoyException,
@@ -67,7 +67,8 @@ TEST(FramedTransportTest, DecodeFrameStart) {
   FramedTransportImpl transport;
 
   Buffer::OwnedImpl buffer;
-  addInt32(buffer, 100);
+  buffer.writeBEInt<int32_t>(100);
+
   EXPECT_EQ(buffer.length(), 4);
 
   absl::optional<uint32_t> size;

--- a/test/extensions/filters/network/thrift_proxy/protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/protocol_impl_test.cc
@@ -38,7 +38,7 @@ TEST(AutoProtocolTest, NotEnoughData) {
   MessageType msg_type = MessageType::Oneway;
   int32_t seq_id = -1;
 
-  addInt8(buffer, 0);
+  buffer.writeByte(0);
   EXPECT_FALSE(proto.readMessageBegin(buffer, name, msg_type, seq_id));
   EXPECT_EQ(name, "-");
   EXPECT_EQ(msg_type, MessageType::Oneway);
@@ -52,7 +52,7 @@ TEST(AutoProtocolTest, UnknownProtocol) {
   MessageType msg_type = MessageType::Oneway;
   int32_t seq_id = -1;
 
-  addInt16(buffer, 0x0102);
+  buffer.writeBEInt<int16_t>(0x0102);
 
   EXPECT_THROW_WITH_MESSAGE(proto.readMessageBegin(buffer, name, msg_type, seq_id), EnvoyException,
                             "unknown thrift auto protocol message start 0102");
@@ -70,12 +70,12 @@ TEST(AutoProtocolTest, ReadMessageBegin) {
     int32_t seq_id = -1;
 
     Buffer::OwnedImpl buffer;
-    addInt16(buffer, 0x8001);
-    addInt8(buffer, 0);
-    addInt8(buffer, MessageType::Call);
-    addInt32(buffer, 8);
+    buffer.writeBEInt<int16_t>(0x8001);
+    buffer.writeByte(0);
+    buffer.writeByte(MessageType::Call);
+    buffer.writeBEInt<int32_t>(8);
     addString(buffer, "the_name");
-    addInt32(buffer, 1);
+    buffer.writeBEInt<int32_t>(1);
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, name, msg_type, seq_id));
     EXPECT_EQ(name, "the_name");
@@ -94,9 +94,9 @@ TEST(AutoProtocolTest, ReadMessageBegin) {
     int32_t seq_id = 1;
 
     Buffer::OwnedImpl buffer;
-    addInt16(buffer, 0x8221);
-    addInt16(buffer, 0x8202); // 0x0102
-    addInt8(buffer, 8);
+    buffer.writeBEInt<int16_t>(0x8221);
+    buffer.writeBEInt<int16_t>(0x8202); // 0x0102
+    buffer.writeByte(8);
     addString(buffer, "the_name");
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, name, msg_type, seq_id));

--- a/test/extensions/filters/network/thrift_proxy/transport_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/transport_impl_test.cc
@@ -47,8 +47,8 @@ TEST(AutoTransportTest, UnknownTransport) {
   // Looks like unframed, but fails protocol check.
   {
     Buffer::OwnedImpl buffer;
-    addInt32(buffer, 0);
-    addInt32(buffer, 0);
+    buffer.writeBEInt<int32_t>(0);
+    buffer.writeBEInt<int32_t>(0);
 
     absl::optional<uint32_t> size = 100;
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, size), EnvoyException,
@@ -59,8 +59,8 @@ TEST(AutoTransportTest, UnknownTransport) {
   // Looks like framed, but fails protocol check.
   {
     Buffer::OwnedImpl buffer;
-    addInt32(buffer, 0xFF);
-    addInt32(buffer, 0);
+    buffer.writeBEInt<int32_t>(0xFF);
+    buffer.writeBEInt<int32_t>(0);
 
     absl::optional<uint32_t> size = 100;
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, size), EnvoyException,
@@ -74,9 +74,9 @@ TEST(AutoTransportTest, DecodeFrameStart) {
   {
     AutoTransportImpl transport;
     Buffer::OwnedImpl buffer;
-    addInt32(buffer, 0xFF);
-    addInt16(buffer, 0x8001);
-    addInt16(buffer, 0);
+    buffer.writeBEInt<int32_t>(0xFF);
+    buffer.writeBEInt<int16_t>(0x8001);
+    buffer.writeBEInt<int16_t>(0);
 
     absl::optional<uint32_t> size;
     EXPECT_TRUE(transport.decodeFrameStart(buffer, size));
@@ -90,9 +90,9 @@ TEST(AutoTransportTest, DecodeFrameStart) {
   {
     AutoTransportImpl transport;
     Buffer::OwnedImpl buffer;
-    addInt32(buffer, 0xFFF);
-    addInt16(buffer, 0x8201);
-    addInt16(buffer, 0);
+    buffer.writeBEInt<int32_t>(0xFFF);
+    buffer.writeBEInt<int16_t>(0x8201);
+    buffer.writeBEInt<int16_t>(0);
 
     absl::optional<uint32_t> size;
     EXPECT_TRUE(transport.decodeFrameStart(buffer, size));
@@ -106,7 +106,7 @@ TEST(AutoTransportTest, DecodeFrameStart) {
   {
     AutoTransportImpl transport;
     Buffer::OwnedImpl buffer;
-    addInt16(buffer, 0x8001);
+    buffer.writeBEInt<int16_t>(0x8001);
     addRepeated(buffer, 6, 0);
 
     absl::optional<uint32_t> size = 1;
@@ -121,7 +121,7 @@ TEST(AutoTransportTest, DecodeFrameStart) {
   {
     AutoTransportImpl transport;
     Buffer::OwnedImpl buffer;
-    addInt16(buffer, 0x8201);
+    buffer.writeBEInt<int16_t>(0x8201);
     addRepeated(buffer, 6, 0);
 
     absl::optional<uint32_t> size = 1;
@@ -136,9 +136,9 @@ TEST(AutoTransportTest, DecodeFrameStart) {
 TEST(AutoTransportTest, DecodeFrameEnd) {
   AutoTransportImpl transport;
   Buffer::OwnedImpl buffer;
-  addInt32(buffer, 0xFF);
-  addInt16(buffer, 0x8001);
-  addInt16(buffer, 0);
+  buffer.writeBEInt<int32_t>(0xFF);
+  buffer.writeBEInt<int16_t>(0x8001);
+  buffer.writeBEInt<int16_t>(0);
 
   absl::optional<uint32_t> size;
   EXPECT_TRUE(transport.decodeFrameStart(buffer, size));

--- a/test/extensions/filters/network/thrift_proxy/unframed_transport_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/unframed_transport_impl_test.cc
@@ -27,7 +27,7 @@ TEST(UnframedTransportTest, DecodeFrameStart) {
   UnframedTransportImpl transport;
 
   Buffer::OwnedImpl buffer;
-  addInt32(buffer, 0xDEADBEEF);
+  buffer.writeBEInt<uint32_t>(0xDEADBEEF);
   EXPECT_EQ(buffer.length(), 4);
 
   absl::optional<uint32_t> size = 1;

--- a/test/extensions/filters/network/thrift_proxy/utility.h
+++ b/test/extensions/filters/network/thrift_proxy/utility.h
@@ -7,6 +7,8 @@
 
 #include "extensions/filters/network/thrift_proxy/protocol.h"
 
+#include "test/common/buffer/utility.h"
+
 #include "gtest/gtest.h"
 
 using testing::TestParamInfo;
@@ -17,44 +19,10 @@ namespace NetworkFilters {
 namespace ThriftProxy {
 namespace {
 
-inline void addInt16(Buffer::Instance& buffer, int16_t value) {
-  value = htobe16(value);
-  buffer.add(&value, 2);
-}
-
-inline void addInt32(Buffer::Instance& buffer, int32_t value) {
-  value = htobe32(value);
-  buffer.add(&value, 4);
-}
-
-inline void addInt8(Buffer::Instance& buffer, int8_t value) { buffer.add(&value, 1); }
-
-inline void addInt8(Buffer::Instance& buffer, MessageType value) { buffer.add(&value, 1); }
-
-inline void addInt8(Buffer::Instance& buffer, FieldType value) { buffer.add(&value, 1); }
-
-inline void addRepeated(Buffer::Instance& buffer, int n, int8_t value) {
-  for (int i = 0; i < n; i++) {
-    buffer.add(&value, 1);
-  }
-}
-
-inline void addSeq(Buffer::Instance& buffer, const std::initializer_list<uint8_t> values) {
-  for (int8_t value : values) {
-    buffer.add(&value, 1);
-  }
-}
-
-inline void addString(Buffer::Instance& buffer, const std::string& s) { buffer.add(s); }
-
-inline std::string bufferToString(Buffer::Instance& buffer) {
-  if (buffer.length() == 0) {
-    return "";
-  }
-
-  char* data = static_cast<char*>(buffer.linearize(buffer.length()));
-  return std::string(data, buffer.length());
-}
+using Envoy::Buffer::addRepeated;
+using Envoy::Buffer::addSeq;
+using Envoy::Buffer::addString;
+using Envoy::Buffer::bufferToString;
 
 inline std::string fieldTypeToString(const FieldType& field_type) {
   switch (field_type) {

--- a/test/extensions/health_checkers/mysql/BUILD
+++ b/test/extensions/health_checkers/mysql/BUILD
@@ -1,0 +1,27 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_package",
+)
+load(
+    "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_cc_test",
+)
+
+envoy_package()
+
+envoy_extension_cc_test(
+    name = "mysql_test",
+    srcs = ["mysql_test.cc"],
+    extension_name = "envoy.health_checkers.mysql",
+    deps = [
+        "//source/extensions/health_checkers/mysql",
+        "//source/extensions/health_checkers/mysql:utility",
+        "//test/common/buffer:utility_lib",
+        "//test/common/upstream:utility_lib",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/upstream:upstream_mocks",
+    ],
+)

--- a/test/extensions/health_checkers/mysql/mysql_test.cc
+++ b/test/extensions/health_checkers/mysql/mysql_test.cc
@@ -1,0 +1,1251 @@
+#include "extensions/health_checkers/mysql/mysql.h"
+#include "extensions/health_checkers/mysql/utility.h"
+
+#include "test/common/buffer/utility.h"
+#include "test/common/upstream/utility.h"
+#include "test/mocks/buffer/mocks.h"
+#include "test/mocks/network/mocks.h"
+#include "test/mocks/runtime/mocks.h"
+#include "test/mocks/upstream/mocks.h"
+
+using testing::DoAll;
+using testing::InSequence;
+using testing::NiceMock;
+using testing::Ref;
+using testing::Return;
+using testing::ReturnRef;
+using testing::SaveArg;
+using testing::WithArg;
+using testing::_;
+
+namespace Envoy {
+namespace Extensions {
+namespace HealthCheckers {
+namespace MySQLHealthChecker {
+
+using namespace Upstream;
+
+class MySQLHealthCheckerImplTest : public testing::Test {
+public:
+  MySQLHealthCheckerImplTest()
+      : cluster_(new NiceMock<MockCluster>()),
+        event_logger_(new Upstream::MockHealthCheckEventLogger()) {}
+
+  void setupReuseConnection() {
+    const std::string yaml = R"EOF(
+    timeout: 1s
+    interval: 1s
+    no_traffic_interval: 5s
+    interval_jitter: 1s
+    unhealthy_threshold: 1
+    healthy_threshold: 1
+    custom_health_check:
+      name: envoy.health_checkers.mysql
+      config:
+        user: envoy-hc
+    )EOF";
+
+    const auto hc_config = parseHealthCheckFromV2Yaml(yaml);
+    const auto mysql_config = getMySQLHealthCheckConfig(hc_config);
+
+    health_checker_ = std::make_shared<MySQLHealthChecker>(
+        *cluster_, hc_config, mysql_config, dispatcher_, runtime_, random_,
+        Upstream::HealthCheckEventLoggerPtr(event_logger_));
+  }
+
+  void setupDontReuseConnection() {
+    const std::string yaml = R"EOF(
+    timeout: 1s
+    interval: 1s
+    no_traffic_interval: 5s
+    interval_jitter: 1s
+    unhealthy_threshold: 1
+    healthy_threshold: 1
+    reuse_connection: false
+    custom_health_check:
+      name: envoy.health_checkers.mysql
+      config:
+        user: envoy-hc
+    )EOF";
+
+    const auto hc_config = parseHealthCheckFromV2Yaml(yaml);
+    const auto mysql_config = getMySQLHealthCheckConfig(hc_config);
+
+    health_checker_ = std::make_shared<MySQLHealthChecker>(
+        *cluster_, hc_config, mysql_config, dispatcher_, runtime_, random_,
+        Upstream::HealthCheckEventLoggerPtr(event_logger_));
+  }
+
+  void expectSessionCreate() {
+    interval_timer_ = new Event::MockTimer(&dispatcher_);
+    timeout_timer_ = new Event::MockTimer(&dispatcher_);
+  }
+
+  void expectClientCreate() {
+    connection_ = new NiceMock<Network::MockClientConnection>();
+    EXPECT_CALL(dispatcher_, createClientConnection_(_, _, _, _)).WillOnce(Return(connection_));
+    EXPECT_CALL(*connection_, addReadFilter(_)).WillOnce(SaveArg<0>(&read_filter_));
+  }
+
+  auto& build_server_greeting_packet(Buffer::Instance& buffer) {
+    const char data[] = {
+        '\x5b', '\x00', '\x00', '\x00', '\x0a', '\x35', '\x2e', '\x37', '\x2e', '\x32', '\x32',
+        '\x2d', '\x30', '\x75', '\x62', '\x75', '\x6e', '\x74', '\x75', '\x30', '\x2e', '\x31',
+        '\x36', '\x2e', '\x30', '\x34', '\x2e', '\x31', '\x00', '\x04', '\x00', '\x00', '\x00',
+        '\x6d', '\x7a', '\x0c', '\x61', '\x7d', '\x44', '\x50', '\x57', '\x00', '\xff', '\xf7',
+        '\x08', '\x02', '\x00', '\xff', '\x81', '\x15', '\x00', '\x00', '\x00', '\x00', '\x00',
+        '\x00', '\x00', '\x00', '\x00', '\x00', '\x4f', '\x58', '\x61', '\x0c', '\x6e', '\x01',
+        '\x1a', '\x66', '\x15', '\x1e', '\x17', '\x7c', '\x00', '\x6d', '\x79', '\x73', '\x71',
+        '\x6c', '\x5f', '\x6e', '\x61', '\x74', '\x69', '\x76', '\x65', '\x5f', '\x70', '\x61',
+        '\x73', '\x73', '\x77', '\x6f', '\x72', '\x64', '\x00'};
+    buffer.add(data, sizeof(data));
+    return buffer;
+  }
+
+  auto& build_login_quit_packet(Buffer::Instance& buffer) {
+    const char data[] = {'\x0f', '\x00', '\x00', '\x01', '\x00', '\x80', '\x00', '\x00',
+                         '\x01', '\x65', '\x6e', '\x76', '\x6f', '\x79', '\x2d', '\x68',
+                         '\x63', '\x00', '\x00', '\x01', '\x00', '\x00', '\x00', '\x01'};
+    buffer.add(data, sizeof(data));
+    return buffer;
+  }
+
+  auto& build_ok_response_packet(Buffer::Instance& buffer) {
+    const char data[] = {'\x03', '\x00', '\x00', '\x02', '\x00', '\x00', '\x00'};
+    buffer.add(data, sizeof(data));
+    return buffer;
+  }
+
+  std::shared_ptr<MockCluster> cluster_;
+  NiceMock<Event::MockDispatcher> dispatcher_;
+  std::shared_ptr<MySQLHealthChecker> health_checker_;
+  Network::MockClientConnection* connection_{};
+  Event::MockTimer* timeout_timer_{};
+  Event::MockTimer* interval_timer_{};
+  Network::ReadFilterSharedPtr read_filter_;
+  NiceMock<Runtime::MockLoader> runtime_;
+  NiceMock<Runtime::MockRandomGenerator> random_;
+  Upstream::MockHealthCheckEventLogger* event_logger_{};
+};
+
+// Tests that a successful healthcheck will keep the client connected
+TEST_F(MySQLHealthCheckerImplTest, Success) {
+  InSequence s;
+
+  setupReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl login_quit_packet;
+  EXPECT_CALL(*connection_, write(BufferEqual(&build_login_quit_packet(login_quit_packet)), false))
+      .Times(1);
+  Buffer::OwnedImpl server_greeting_packet;
+  read_filter_->onData(build_server_greeting_packet(server_greeting_packet), false);
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  Buffer::OwnedImpl ok_response_packet;
+  read_filter_->onData(build_ok_response_packet(ok_response_packet), false);
+
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Open, connection_->state());
+}
+
+// Tests that a successful healthcheck will disconnect the client when reuse_connection is false.
+TEST_F(MySQLHealthCheckerImplTest, SuccessWithoutReusingConnection) {
+  InSequence s;
+
+  setupDontReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl login_quit_packet;
+  EXPECT_CALL(*connection_, write(BufferEqual(&build_login_quit_packet(login_quit_packet)), false))
+      .Times(1);
+  Buffer::OwnedImpl server_greeting_packet;
+  read_filter_->onData(build_server_greeting_packet(server_greeting_packet), false);
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  Buffer::OwnedImpl ok_response_packet;
+  read_filter_->onData(build_ok_response_packet(ok_response_packet), false);
+
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server greeting packet fails the health check immediately
+TEST_F(MySQLHealthCheckerImplTest, BadServerGreeting_EssentialDataTruncated) {
+  InSequence s;
+
+  setupReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl server_greeting_packet;
+  server_greeting_packet.add("\xff\xff", 2);
+  EXPECT_CALL(*connection_, write(_, _)).Times(0);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  read_filter_->onData(server_greeting_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server greeting packet fails the health check immediately
+TEST_F(MySQLHealthCheckerImplTest, BadServerGreeting_PayloadLengthMismatch) {
+  InSequence s;
+
+  setupReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl server_greeting_packet;
+  server_greeting_packet.add("\xff\xff\xff\xff\xff", 5);
+  EXPECT_CALL(*connection_, write(_, _)).Times(0);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  read_filter_->onData(server_greeting_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server greeting packet fails the health check immediately
+TEST_F(MySQLHealthCheckerImplTest, BadServerGreeting_InvalidSequenceId) {
+  InSequence s;
+
+  setupReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl server_greeting_packet;
+  server_greeting_packet.add("\x05\x00\x00\x00\x0a", 5);
+  EXPECT_CALL(*connection_, write(_, _)).Times(0);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  read_filter_->onData(server_greeting_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server greeting packet fails the health check immediately
+TEST_F(MySQLHealthCheckerImplTest, BadServerGreeting_UnsupportedProtocolVersion) {
+  InSequence s;
+
+  setupReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl server_greeting_packet;
+  server_greeting_packet.add("\x05\x00\x00\x00\xaa", 5);
+  EXPECT_CALL(*connection_, write(_, _)).Times(0);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  read_filter_->onData(server_greeting_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server greeting packet fails the health check immediately
+TEST_F(MySQLHealthCheckerImplTest, BadServerGreeting_MalformedServerVersion) {
+  InSequence s;
+
+  setupReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl server_greeting_packet;
+  server_greeting_packet.add("\x13\x00\x00\x00\x0aserver_version", 19);
+  EXPECT_CALL(*connection_, write(_, _)).Times(0);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  read_filter_->onData(server_greeting_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server greeting packet fails the health check immediately
+TEST_F(MySQLHealthCheckerImplTest, BadServerGreeting_PacketTruncated) {
+  InSequence s;
+
+  setupReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl server_greeting_packet;
+  server_greeting_packet.add("\x14\x00\x00\x00\x0aserver_version\x00", 20);
+  EXPECT_CALL(*connection_, write(_, _)).Times(0);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  read_filter_->onData(server_greeting_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server greeting packet fails the health check immediately
+TEST_F(MySQLHealthCheckerImplTest, BadServerGreeting_Client41Unsupported) {
+  InSequence s;
+
+  setupReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl server_greeting_packet;
+  server_greeting_packet.add("\x24\x00\x00\x00\x0aserver_"
+                             "version\x00\x04\x00\x00\x00\x6d\x7a\x0c\x61\x7d\x44\x50\x57\x00\x00"
+                             "\x00",
+                             36);
+  EXPECT_CALL(*connection_, write(_, _)).Times(0);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  read_filter_->onData(server_greeting_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server greeting packet fails the health check immediately
+TEST_F(MySQLHealthCheckerImplTest,
+       BadServerGreetingWithoutReusingConnection_EssentialDataTruncated) {
+  InSequence s;
+
+  setupDontReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl server_greeting_packet;
+  server_greeting_packet.add("\xff\xff", 2);
+  EXPECT_CALL(*connection_, write(_, _)).Times(0);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  read_filter_->onData(server_greeting_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server greeting packet fails the health check immediately
+TEST_F(MySQLHealthCheckerImplTest,
+       BadServerGreetingWithoutReusingConnection_PayloadLengthMismatch) {
+  InSequence s;
+
+  setupDontReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl server_greeting_packet;
+  server_greeting_packet.add("\xff\xff\xff\xff\xff", 5);
+  EXPECT_CALL(*connection_, write(_, _)).Times(0);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  read_filter_->onData(server_greeting_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server greeting packet fails the health check immediately
+TEST_F(MySQLHealthCheckerImplTest, BadServerGreetingWithoutReusingConnection_InvalidSequenceId) {
+  InSequence s;
+
+  setupDontReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl server_greeting_packet;
+  server_greeting_packet.add("\x05\x00\x00\x00\x0a", 5);
+  EXPECT_CALL(*connection_, write(_, _)).Times(0);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  read_filter_->onData(server_greeting_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server greeting packet fails the health check immediately
+TEST_F(MySQLHealthCheckerImplTest,
+       BadServerGreetingWithoutReusingConnection_UnsupportedProtocolVersion) {
+  InSequence s;
+
+  setupDontReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl server_greeting_packet;
+  server_greeting_packet.add("\x05\x00\x00\x00\xaa", 5);
+  EXPECT_CALL(*connection_, write(_, _)).Times(0);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  read_filter_->onData(server_greeting_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server greeting packet fails the health check immediately
+TEST_F(MySQLHealthCheckerImplTest,
+       BadServerGreetingWithoutReusingConnection_MalformedServerVersion) {
+  InSequence s;
+
+  setupDontReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl server_greeting_packet;
+  server_greeting_packet.add("\x13\x00\x00\x00\x0aserver_version", 19);
+  EXPECT_CALL(*connection_, write(_, _)).Times(0);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  read_filter_->onData(server_greeting_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server greeting packet fails the health check immediately
+TEST_F(MySQLHealthCheckerImplTest, BadServerGreetingWithoutReusingConnection_PacketTruncated) {
+  InSequence s;
+
+  setupDontReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl server_greeting_packet;
+  server_greeting_packet.add("\x14\x00\x00\x00\x0aserver_version\x00", 20);
+  EXPECT_CALL(*connection_, write(_, _)).Times(0);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  read_filter_->onData(server_greeting_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server greeting packet fails the health check immediately
+TEST_F(MySQLHealthCheckerImplTest, BadServerGreetingWithoutReusingConnection_Client41Unsupported) {
+  InSequence s;
+
+  setupDontReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl server_greeting_packet;
+  server_greeting_packet.add("\x24\x00\x00\x00\x0aserver_"
+                             "version\x00\x04\x00\x00\x00\x6d\x7a\x0c\x61\x7d\x44\x50\x57\x00\x00"
+                             "\x00",
+                             36);
+  EXPECT_CALL(*connection_, write(_, _)).Times(0);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  read_filter_->onData(server_greeting_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server reply packet fails the health check
+TEST_F(MySQLHealthCheckerImplTest, BadServerReply_PacketTruncated) {
+  InSequence s;
+
+  setupReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl login_quit_packet;
+  EXPECT_CALL(*connection_, write(BufferEqual(&build_login_quit_packet(login_quit_packet)), false))
+      .Times(1);
+  Buffer::OwnedImpl server_greeting_packet;
+  read_filter_->onData(build_server_greeting_packet(server_greeting_packet), false);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+
+  Buffer::OwnedImpl ok_response_packet;
+  ok_response_packet.add("\x04\x00\x00\x02", 4);
+  read_filter_->onData(ok_response_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server reply packet fails the health check
+TEST_F(MySQLHealthCheckerImplTest, BadServerReply_PayloadLengthMismatch) {
+  InSequence s;
+
+  setupReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl login_quit_packet;
+  EXPECT_CALL(*connection_, write(BufferEqual(&build_login_quit_packet(login_quit_packet)), false))
+      .Times(1);
+  Buffer::OwnedImpl server_greeting_packet;
+  read_filter_->onData(build_server_greeting_packet(server_greeting_packet), false);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+
+  Buffer::OwnedImpl ok_response_packet;
+  ok_response_packet.add("\x05\x00\x00\x02\x00\x00\x00", 7);
+  read_filter_->onData(ok_response_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server reply packet fails the health check
+TEST_F(MySQLHealthCheckerImplTest, BadServerReply_InvalidSequenceId) {
+  InSequence s;
+
+  setupReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl login_quit_packet;
+  EXPECT_CALL(*connection_, write(BufferEqual(&build_login_quit_packet(login_quit_packet)), false))
+      .Times(1);
+  Buffer::OwnedImpl server_greeting_packet;
+  read_filter_->onData(build_server_greeting_packet(server_greeting_packet), false);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+
+  Buffer::OwnedImpl ok_response_packet;
+  ok_response_packet.add("\x07\x00\x00\x01\x00\x00\x00", 7);
+  read_filter_->onData(ok_response_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server reply packet fails the health check
+TEST_F(MySQLHealthCheckerImplTest, BadServerReply_UnexpectedResponse) {
+  InSequence s;
+
+  setupReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl login_quit_packet;
+  EXPECT_CALL(*connection_, write(BufferEqual(&build_login_quit_packet(login_quit_packet)), false))
+      .Times(1);
+  Buffer::OwnedImpl server_greeting_packet;
+  read_filter_->onData(build_server_greeting_packet(server_greeting_packet), false);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+
+  Buffer::OwnedImpl ok_response_packet;
+  ok_response_packet.add("\x07\x00\x00\x02\x07\x00\x00", 7);
+  read_filter_->onData(ok_response_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server reply packet fails the health check
+TEST_F(MySQLHealthCheckerImplTest, BadServerReply_WrongPacketThreshold) {
+  InSequence s;
+
+  setupReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl login_quit_packet;
+  EXPECT_CALL(*connection_, write(BufferEqual(&build_login_quit_packet(login_quit_packet)), false))
+      .Times(1);
+  Buffer::OwnedImpl server_greeting_packet;
+  read_filter_->onData(build_server_greeting_packet(server_greeting_packet), false);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+
+  Buffer::OwnedImpl ok_response_packet;
+  ok_response_packet.add("\x05\x00\x00\x02\x00", 5);
+  read_filter_->onData(ok_response_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server reply packet fails the health check
+TEST_F(MySQLHealthCheckerImplTest, BadServerReplyWithoutReusingConnection_PacketTruncated) {
+  InSequence s;
+
+  setupDontReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl login_quit_packet;
+  EXPECT_CALL(*connection_, write(BufferEqual(&build_login_quit_packet(login_quit_packet)), false))
+      .Times(1);
+  Buffer::OwnedImpl server_greeting_packet;
+  read_filter_->onData(build_server_greeting_packet(server_greeting_packet), false);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+
+  Buffer::OwnedImpl ok_response_packet;
+  ok_response_packet.add("\x04\x00\x00\x02", 4);
+  read_filter_->onData(ok_response_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server reply packet fails the health check
+TEST_F(MySQLHealthCheckerImplTest, BadServerReplyWithoutReusingConnection_PayloadLengthMismatch) {
+  InSequence s;
+
+  setupDontReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl login_quit_packet;
+  EXPECT_CALL(*connection_, write(BufferEqual(&build_login_quit_packet(login_quit_packet)), false))
+      .Times(1);
+  Buffer::OwnedImpl server_greeting_packet;
+  read_filter_->onData(build_server_greeting_packet(server_greeting_packet), false);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+
+  Buffer::OwnedImpl ok_response_packet;
+  ok_response_packet.add("\x05\x00\x00\x02\x00\x00\x00", 7);
+  read_filter_->onData(ok_response_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server reply packet fails the health check
+TEST_F(MySQLHealthCheckerImplTest, BadServerReplyWithoutReusingConnection_InvalidSequenceId) {
+  InSequence s;
+
+  setupDontReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl login_quit_packet;
+  EXPECT_CALL(*connection_, write(BufferEqual(&build_login_quit_packet(login_quit_packet)), false))
+      .Times(1);
+  Buffer::OwnedImpl server_greeting_packet;
+  read_filter_->onData(build_server_greeting_packet(server_greeting_packet), false);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+
+  Buffer::OwnedImpl ok_response_packet;
+  ok_response_packet.add("\x07\x00\x00\x01\x00\x00\x00", 7);
+  read_filter_->onData(ok_response_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server reply packet fails the health check
+TEST_F(MySQLHealthCheckerImplTest, BadServerReplyWithoutReusingConnection_UnexpectedResponse) {
+  InSequence s;
+
+  setupDontReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl login_quit_packet;
+  EXPECT_CALL(*connection_, write(BufferEqual(&build_login_quit_packet(login_quit_packet)), false))
+      .Times(1);
+  Buffer::OwnedImpl server_greeting_packet;
+  read_filter_->onData(build_server_greeting_packet(server_greeting_packet), false);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+
+  Buffer::OwnedImpl ok_response_packet;
+  ok_response_packet.add("\x07\x00\x00\x02\x07\x00\x00", 7);
+  read_filter_->onData(ok_response_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a corrupt server reply packet fails the health check
+TEST_F(MySQLHealthCheckerImplTest, BadServerReplyWithoutReusingConnection_WrongPacketThreshold) {
+  InSequence s;
+
+  setupDontReuseConnection();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectClientCreate();
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  connection_->runHighWatermarkCallbacks();
+  connection_->runLowWatermarkCallbacks();
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl login_quit_packet;
+  EXPECT_CALL(*connection_, write(BufferEqual(&build_login_quit_packet(login_quit_packet)), false))
+      .Times(1);
+  Buffer::OwnedImpl server_greeting_packet;
+  read_filter_->onData(build_server_greeting_packet(server_greeting_packet), false);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+
+  Buffer::OwnedImpl ok_response_packet;
+  ok_response_packet.add("\x05\x00\x00\x02\x00", 5);
+  read_filter_->onData(ok_response_packet, false);
+
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Network::Connection::State::Closed, connection_->state());
+}
+
+// Tests that a timeout while waiting for the server reply fails the health check
+TEST_F(MySQLHealthCheckerImplTest, ServerGreetingTimeout) {
+  InSequence s;
+
+  setupReuseConnection();
+  health_checker_->start();
+
+  expectSessionCreate();
+  expectClientCreate();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+
+  cluster_->prioritySet().getMockHostSet(0)->runCallbacks(
+      {cluster_->prioritySet().getMockHostSet(0)->hosts_.back()}, {});
+
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  EXPECT_CALL(*connection_, close(_));
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  timeout_timer_->callback_();
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+
+  HostVector removed{cluster_->prioritySet().getMockHostSet(0)->hosts_.back()};
+  cluster_->prioritySet().getMockHostSet(0)->hosts_.clear();
+  cluster_->prioritySet().getMockHostSet(0)->runCallbacks({}, removed);
+}
+
+// Tests that a timeout while waiting for the server reply fails the health check
+TEST_F(MySQLHealthCheckerImplTest, ServerGreetingTimeoutWithoutReusingConnection) {
+  InSequence s;
+
+  setupDontReuseConnection();
+  health_checker_->start();
+
+  expectSessionCreate();
+  expectClientCreate();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+
+  cluster_->prioritySet().getMockHostSet(0)->runCallbacks(
+      {cluster_->prioritySet().getMockHostSet(0)->hosts_.back()}, {});
+
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  EXPECT_CALL(*connection_, close(_));
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  timeout_timer_->callback_();
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+
+  HostVector removed{cluster_->prioritySet().getMockHostSet(0)->hosts_.back()};
+  cluster_->prioritySet().getMockHostSet(0)->hosts_.clear();
+  cluster_->prioritySet().getMockHostSet(0)->runCallbacks({}, removed);
+}
+
+// Tests that a remote close while waiting for the server reply fails the health check
+TEST_F(MySQLHealthCheckerImplTest, ServerGreetingRemoteClose) {
+  InSequence s;
+
+  setupReuseConnection();
+  health_checker_->start();
+
+  expectSessionCreate();
+  expectClientCreate();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+
+  cluster_->prioritySet().getMockHostSet(0)->runCallbacks(
+      {cluster_->prioritySet().getMockHostSet(0)->hosts_.back()}, {});
+
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+}
+
+// Tests that a remote close while waiting for the server reply fails the health check
+TEST_F(MySQLHealthCheckerImplTest, ServerGreetingRemoteCloseWithoutReusingConnection) {
+  InSequence s;
+
+  setupDontReuseConnection();
+  health_checker_->start();
+
+  expectSessionCreate();
+  expectClientCreate();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+
+  cluster_->prioritySet().getMockHostSet(0)->runCallbacks(
+      {cluster_->prioritySet().getMockHostSet(0)->hosts_.back()}, {});
+
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+}
+
+// Tests that a timeout while waiting for the server reply fails the health check
+TEST_F(MySQLHealthCheckerImplTest, ServerReplyTimeout) {
+  InSequence s;
+
+  setupReuseConnection();
+  health_checker_->start();
+
+  expectSessionCreate();
+  expectClientCreate();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+
+  cluster_->prioritySet().getMockHostSet(0)->runCallbacks(
+      {cluster_->prioritySet().getMockHostSet(0)->hosts_.back()}, {});
+
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl login_quit_packet;
+  EXPECT_CALL(*connection_, write(BufferEqual(&build_login_quit_packet(login_quit_packet)), false))
+      .Times(1);
+  Buffer::OwnedImpl server_greeting_packet;
+  read_filter_->onData(build_server_greeting_packet(server_greeting_packet), false);
+
+  EXPECT_CALL(*connection_, close(_));
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  timeout_timer_->callback_();
+  connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+}
+
+// Tests that a timeout while waiting for the server reply fails the health check
+TEST_F(MySQLHealthCheckerImplTest, ServerReplyTimeoutWithoutReusingConnection) {
+  InSequence s;
+
+  setupDontReuseConnection();
+  health_checker_->start();
+
+  expectSessionCreate();
+  expectClientCreate();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+
+  cluster_->prioritySet().getMockHostSet(0)->runCallbacks(
+      {cluster_->prioritySet().getMockHostSet(0)->hosts_.back()}, {});
+
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl login_quit_packet;
+  EXPECT_CALL(*connection_, write(BufferEqual(&build_login_quit_packet(login_quit_packet)), false))
+      .Times(1);
+  Buffer::OwnedImpl server_greeting_packet;
+  read_filter_->onData(build_server_greeting_packet(server_greeting_packet), false);
+
+  EXPECT_CALL(*connection_, close(_));
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  timeout_timer_->callback_();
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+}
+
+// Tests that a remote close while waiting for the server reply fails the health check
+TEST_F(MySQLHealthCheckerImplTest, ServerReplyRemoteClose) {
+  InSequence s;
+
+  setupReuseConnection();
+  health_checker_->start();
+
+  expectSessionCreate();
+  expectClientCreate();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+
+  cluster_->prioritySet().getMockHostSet(0)->runCallbacks(
+      {cluster_->prioritySet().getMockHostSet(0)->hosts_.back()}, {});
+
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl login_quit_packet;
+  EXPECT_CALL(*connection_, write(BufferEqual(&build_login_quit_packet(login_quit_packet)), false))
+      .Times(1);
+  Buffer::OwnedImpl server_greeting_packet;
+  read_filter_->onData(build_server_greeting_packet(server_greeting_packet), false);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+
+  connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+}
+
+// Tests that a remote close while waiting for the server reply fails the health check
+TEST_F(MySQLHealthCheckerImplTest, ServerReplyRemoteCloseWithoutReusingConnection) {
+  InSequence s;
+
+  setupDontReuseConnection();
+  health_checker_->start();
+
+  expectSessionCreate();
+  expectClientCreate();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  EXPECT_CALL(*timeout_timer_, enableTimer(_));
+
+  cluster_->prioritySet().getMockHostSet(0)->runCallbacks(
+      {cluster_->prioritySet().getMockHostSet(0)->hosts_.back()}, {});
+
+  connection_->raiseEvent(Network::ConnectionEvent::Connected);
+
+  Buffer::OwnedImpl login_quit_packet;
+  EXPECT_CALL(*connection_, write(BufferEqual(&build_login_quit_packet(login_quit_packet)), false))
+      .Times(1);
+  Buffer::OwnedImpl server_greeting_packet;
+  read_filter_->onData(build_server_greeting_packet(server_greeting_packet), false);
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+
+  connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+}
+
+} // namespace MySQLHealthChecker
+} // namespace HealthCheckers
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
*Description*:
Adding support for basic mysql health checks, for feature parity with
HAProxy. Only passowrdless users are supported, so it's generally a good
idea to create a db user with no privileges exclusively for the health
checks.

*Risk Level*: Medium

*Testing*:
Unit tests added for the following scenarios:
{reuse_connection, dont_reuse_connection} x ({success, timeout, remote_close}  + { bad_server_greeting, bad_server_reply} x coverage)

*Docs Changes*:
Inline documentation added for the new health check API.

*Release Notes*:
Added an entry to `version_history.rst` with the new feature.

cc: @lap1817

Fixes #3501 