### PR TITLE
Add load_assignment field in Cluster

### DIFF
--- a/api/envoy/api/v2/BUILD
+++ b/api/envoy/api/v2/BUILD
@@ -62,6 +62,7 @@ api_proto_library(
     visibility = [":friends"],
     deps = [
         ":discovery",
+        ":eds",
         "//envoy/api/v2/auth:cert",
         "//envoy/api/v2/cluster:circuit_breaker",
         "//envoy/api/v2/cluster:outlier_detection",
@@ -70,6 +71,7 @@ api_proto_library(
         "//envoy/api/v2/core:config_source",
         "//envoy/api/v2/core:health_check",
         "//envoy/api/v2/core:protocol",
+        "//envoy/api/v2/endpoint",
         "//envoy/type:percent",
     ],
 )
@@ -79,6 +81,7 @@ api_go_grpc_library(
     proto = ":cds",
     deps = [
         ":discovery_go_proto",
+        ":eds_go_grpc",
         "//envoy/api/v2/auth:cert_go_proto",
         "//envoy/api/v2/cluster:circuit_breaker_go_proto",
         "//envoy/api/v2/cluster:outlier_detection_go_proto",
@@ -87,6 +90,7 @@ api_go_grpc_library(
         "//envoy/api/v2/core:config_source_go_proto",
         "//envoy/api/v2/core:health_check_go_proto",
         "//envoy/api/v2/core:protocol_go_proto",
+        "//envoy/api/v2/endpoint:endpoint_go_proto",
         "//envoy/type:percent_go_proto",
     ],
 )

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -166,11 +166,12 @@ message Cluster {
   //
   // .. attention::
   //
-  //   Setting this allows CDS static/DNS assignments to contain embedded EDS equivalent
+  //   Setting this allows non-EDS cluster types to contain embedded EDS equivalent
   //   :ref:`endpoint assignments<envoy_api_msg_ClusterLoadAssignment>`.
   //   Setting this overrides :ref:`hosts<envoy_api_field_Cluster.hosts>` values.
   //
   // [#not-implemented-hide:]
+  // [#comment:TODO(dio): Deprecate hosts once load_assignment is implemented]
   ClusterLoadAssignment load_assignment = 33;
 
   // Optional :ref:`active health checking <arch_overview_health_checking>`

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -13,6 +13,7 @@ import "envoy/api/v2/core/health_check.proto";
 import "envoy/api/v2/core/protocol.proto";
 import "envoy/api/v2/cluster/circuit_breaker.proto";
 import "envoy/api/v2/cluster/outlier_detection.proto";
+import "envoy/api/v2/eds.proto";
 import "envoy/type/percent.proto";
 
 import "google/api/annotations.proto";
@@ -41,7 +42,7 @@ service ClusterDiscoveryService {
 // [#protodoc-title: Clusters]
 
 // Configuration for a single upstream cluster.
-// [#comment:next free field: 32]
+// [#comment:next free field: 34]
 message Cluster {
   // Supplies the name of the cluster which must be unique across all clusters.
   // The cluster name is used when emitting
@@ -156,6 +157,21 @@ message Cluster {
   // or :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`,
   // then hosts is required.
   repeated core.Address hosts = 7;
+
+  // Setting this is required for specifying members of
+  // :ref:`STATIC<envoy_api_enum_value_Cluster.DiscoveryType.STATIC>`,
+  // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`
+  // or :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>` clusters.
+  // This field supersedes :ref:`hosts<envoy_api_field_Cluster.hosts>` field.
+  //
+  // .. attention::
+  //
+  //   Setting this allows CDS static/DNS assignments to contain embedded EDS equivalent
+  //   :ref:`endpoint assignments<envoy_api_msg_ClusterLoadAssignment>`.
+  //   Setting this overrides :ref:`hosts<envoy_api_field_Cluster.hosts>` values.
+  //
+  // [#not-implemented-hide:]
+  ClusterLoadAssignment load_assignment = 33;
 
   // Optional :ref:`active health checking <arch_overview_health_checking>`
   // configuration for the cluster. If no

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -163,6 +163,8 @@ message Cluster {
   // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`
   // or :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>` clusters.
   // This field supersedes :ref:`hosts<envoy_api_field_Cluster.hosts>` field.
+  // [#comment:TODO(dio): Deprecate the hosts field and add it to DEPRECATED.md
+  // once load_assignment is implemented.]
   //
   // .. attention::
   //
@@ -171,7 +173,6 @@ message Cluster {
   //   Setting this overrides :ref:`hosts<envoy_api_field_Cluster.hosts>` values.
   //
   // [#not-implemented-hide:]
-  // [#comment:TODO(dio): Deprecate hosts once load_assignment is implemented]
   ClusterLoadAssignment load_assignment = 33;
 
   // Optional :ref:`active health checking <arch_overview_health_checking>`

--- a/api/envoy/api/v2/endpoint/endpoint.proto
+++ b/api/envoy/api/v2/endpoint/endpoint.proto
@@ -19,6 +19,14 @@ option (gogoproto.equal_all) = true;
 // Upstream host identifier.
 message Endpoint {
   // The upstream host address.
+  //
+  // .. attention::
+  //
+  //   The form of host address depends on the given cluster type. For STATIC,
+  //   it is expected to be a direct IP address (or something resolvable by the
+  //   specified :ref:`resolver <envoy_api_field_core.SocketAddress.resolver_name>`
+  //   in the Address). For LOGICAL or STRICT DNS, it is expected to be hostname,
+  //   and will be resolved via DNS.
   core.Address address = 1;
 
   // [#not-implemented-hide:] The optional health check configuration.


### PR DESCRIPTION
Add `load_assignment` field in Cluster

This patch introduces `load_assigment` field in CDS' Cluster. This is an API change only. 
This is part of effort on breaking https://github.com/envoyproxy/envoy/pull/3261 into multiple PRs.

*Risk Level*: 
- Low, since it is hidden.

*Testing*: 
- Build api and envoy-static without error

*Docs Changes*:
- Add load_assignment in Cluster of cds.proto.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>
