### PR TITLE
Pull in an http_parser performance fix

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -60,7 +60,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/google/googleapis",
     ),
     com_github_nodejs_http_parser = dict(
-        commit = "54f55a2f02a823e5f5c87abe853bb76d1170718d",  # v2.8.1
+        commit = "cf69c8eda9fe79e4682598a7b3d39338dea319a3",
         remote = "https://github.com/nodejs/http-parser",
     ),
     com_github_pallets_jinja = dict(


### PR DESCRIPTION
*Description*:
Update the nodejs/http_parser dependency to incorporate https://github.com/nodejs/http-parser/pull/422

*Risk Level*: High
*Testing*: nodejs/http_parser unit tests and Envoy unit tests
*Docs Changes*: N/A
*Release Notes*: N/A
*Issues*: #2880 

Signed-off-by: Brian Pane <bpane@pinterest.com>
