### PR TITLE
Adds a Lua filter example

### DIFF
--- a/docs/root/configuration/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http_filters/lua_filter.rst
@@ -124,6 +124,11 @@ more details on the supported API.
 
 .. _config_http_filters_lua_stream_handle_api:
 
+Complete example
+----------------
+
+A complete example using Docker is available in :repo:`/examples/lua`.
+
 Stream handle API
 -----------------
 

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -24,6 +24,7 @@ filegroup(
         "jaeger-tracing/front-envoy-jaeger.yaml",
         "jaeger-tracing/service1-envoy-jaeger.yaml",
         "jaeger-tracing/service2-envoy-jaeger.yaml",
+        "lua/envoy.yaml",
         "zipkin-tracing/deprecated_v1/front-envoy-zipkin-v1.json",
         "zipkin-tracing/deprecated_v1/service1-envoy-zipkin-v1.json",
         "zipkin-tracing/deprecated_v1/service2-envoy-zipkin-v1.json",

--- a/examples/lua/Dockerfile-proxy
+++ b/examples/lua/Dockerfile-proxy
@@ -1,0 +1,2 @@
+FROM envoyproxy/envoy:latest
+CMD /usr/local/bin/envoy -c /etc/envoy.yaml -l debug --service-cluster proxy --v2-config-only

--- a/examples/lua/Dockerfile-web-service
+++ b/examples/lua/Dockerfile-web-service
@@ -1,0 +1,1 @@
+FROM solsson/http-echo

--- a/examples/lua/README.md
+++ b/examples/lua/README.md
@@ -1,0 +1,66 @@
+In this example, we show how a Lua filter can be used with the Envoy
+proxy. The Envoy proxy [configuration](./envoy.yaml) includes a lua
+filter that contains two functions namely
+`envoy_on_request(request_handle)` and
+`envoy_on_response(response_handle)` as documented
+[here](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_filters/lua_filter).
+
+
+
+# Usage
+1. `docker-compose build`
+2. `docker-compose up`
+3. `curl -v localhost:8000`
+
+## Sample Output:
+
+Curl output should include our headers:
+
+```
+# <b> curl -v localhost:8000</b>
+* Rebuilt URL to: localhost:8000/
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 8000 (#0)
+> GET / HTTP/1.1
+> Host: localhost:8000
+> User-Agent: curl/7.47.0
+> Accept: */*
+>
+< HTTP/1.1 200 OK
+< x-powered-by: Express
+< content-type: application/json; charset=utf-8
+< content-length: 544
+< etag: W/"220-PQ/ZOdrX2lwANTIy144XG4sc/sw"
+< date: Thu, 31 May 2018 15:29:56 GMT
+< x-envoy-upstream-service-time: 2
+< response-body-size: 544            <-- This is added to the response header by our Lua script. --<
+< server: envoy
+<
+{
+  "path": "/",
+  "headers": {
+    "host": "localhost:8000",
+    "user-agent": "curl/7.47.0",
+    "accept": "*/*",
+    "x-forwarded-proto": "http",
+    "x-request-id": "0adbf0d3-8dfd-452f-a80a-1d6aa2ab06e2",
+    "foo": "bar",                    <-- This is added to the request header by our Lua script. --<
+    "x-envoy-expected-rq-timeout-ms": "15000",
+    "content-length": "0"
+  },
+  "method": "GET",
+  "body": "",
+  "fresh": false,
+  "hostname": "localhost",
+  "ip": "::ffff:172.18.0.2",
+  "ips": [],
+  "protocol": "http",
+  "query": {},
+  "subdomains": [],
+  "xhr": false,
+  "os": {
+    "hostname": "5ad758105577"
+  }
+* Connection #0 to host localhost left intact
+}
+```

--- a/examples/lua/docker-compose.yaml
+++ b/examples/lua/docker-compose.yaml
@@ -1,0 +1,33 @@
+version: '2'
+services:
+
+  proxy:
+    build:
+      context: .
+      dockerfile: Dockerfile-proxy
+    volumes:
+      - ./envoy.yaml:/etc/envoy.yaml
+    networks:
+      - envoymesh
+    expose:
+      - "80"
+      - "8001"
+    ports:
+      - "8000:80"
+      - "8001:8001"
+
+  web_service:
+    build:
+      context: .
+      dockerfile: Dockerfile-web-service
+    networks:
+      envoymesh:
+        aliases:
+          - web_service
+    expose:
+      - "80"
+    ports:
+      - "8080:80"
+
+networks:
+  envoymesh: {}

--- a/examples/lua/envoy.yaml
+++ b/examples/lua/envoy.yaml
@@ -1,0 +1,53 @@
+static_resources:
+  listeners:
+  - name: main
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          stat_prefix: ingress_http
+          codec_type: auto
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route: 
+                  cluster: web_service
+          http_filters:
+          - name: envoy.lua
+            config:
+              inline_code: |
+                function envoy_on_request(request_handle)
+                  request_handle:headers():add("foo", "bar")
+                end
+                function envoy_on_response(response_handle)
+                  body_size = response_handle:body():length()
+                  response_handle:headers():add("response-body-size", tostring(body_size))
+                end
+          - name: envoy.router
+            config: {}
+
+  clusters:
+  - name: web_service
+    connect_timeout: 0.25s
+    type: strict_dns # static
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: web_service
+        port_value: 80
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/test/config_test/example_configs_test.cc
+++ b/test/config_test/example_configs_test.cc
@@ -17,9 +17,9 @@ TEST(ExampleConfigsTest, All) {
 
 #ifdef __APPLE__
   // freebind/freebind.yaml is not supported on OS X and disabled via Bazel.
-  EXPECT_EQ(27UL, ConfigTest::run(directory));
-#else
   EXPECT_EQ(28UL, ConfigTest::run(directory));
+#else
+  EXPECT_EQ(29UL, ConfigTest::run(directory));
 #endif
   ConfigTest::testMerge();
   ConfigTest::testIncompatibleMerge();


### PR DESCRIPTION
Adds a complete example with an echo server where a lua filter is used
to add headers to request and respons messages.

Fixes: #2152

Co-authored-by: Alex Buchanan <buchanae@gmail.com>
Co-authored-by: Robert Carosi <robert@carosi.nl>

Signed-off-by: Mohammad Banikazemi <MBanikazemi@gmail.com>
