### PR TITLE
Mark FactoryContext localInfo method as const

### DIFF
--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -79,7 +79,7 @@ public:
   /**
    * @return information about the local environment the server is running in.
    */
-  virtual const LocalInfo::LocalInfo& localInfo() PURE;
+  virtual const LocalInfo::LocalInfo& localInfo() const PURE;
 
   /**
    * @return RandomGenerator& the random generator for the server.

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -254,7 +254,7 @@ public:
   bool healthCheckFailed() override { return parent_.server_.healthCheckFailed(); }
   Tracing::HttpTracer& httpTracer() override { return parent_.server_.httpTracer(); }
   Init::Manager& initManager() override;
-  const LocalInfo::LocalInfo& localInfo() override { return parent_.server_.localInfo(); }
+  const LocalInfo::LocalInfo& localInfo() const override { return parent_.server_.localInfo(); }
   Envoy::Runtime::RandomGenerator& random() override { return parent_.server_.random(); }
   RateLimit::ClientPtr
   rateLimitClient(const absl::optional<std::chrono::milliseconds>& timeout) override {

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -365,7 +365,6 @@ public:
   MOCK_METHOD0(healthCheckFailed, bool());
   MOCK_METHOD0(httpTracer, Tracing::HttpTracer&());
   MOCK_METHOD0(initManager, Init::Manager&());
-  MOCK_METHOD0(localInfo, const LocalInfo::LocalInfo&());
   MOCK_METHOD0(random, Envoy::Runtime::RandomGenerator&());
   MOCK_METHOD0(rateLimitClient_, RateLimit::Client*());
   MOCK_METHOD0(runtime, Envoy::Runtime::Loader&());
@@ -374,6 +373,7 @@ public:
   MOCK_METHOD0(threadLocal, ThreadLocal::Instance&());
   MOCK_METHOD0(admin, Server::Admin&());
   MOCK_METHOD0(listenerScope, Stats::Scope&());
+  MOCK_CONST_METHOD0(localInfo, const LocalInfo::LocalInfo&());
   MOCK_CONST_METHOD0(listenerMetadata, const envoy::api::v2::core::Metadata&());
 
   testing::NiceMock<AccessLog::MockAccessLogManager> access_log_manager_;


### PR DESCRIPTION
Signed-off-by: James Buckland <jbuckland@google.com>

*Title*: Mark FactoryContext localInfo() method as `const`.

*Description*: Every method in https://github.com/envoyproxy/envoy/blob/master/include/envoy/local_info/local_info.h is const, so I could like to mark the FactoryContext localInfo() method const as well. Not every method under FactoryContext is const, but a few (like `listenerMetadata()`) are.