### PR TITLE
upstream: fix crash when all hosts are unhealthy for locality weighted clusters

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -115,6 +115,7 @@ Version history
 * tracing: the sampling decision is now delegated to the tracers, allowing the tracer to decide when and if
   to use it. For example, if the :ref:`x-b3-sampled <config_http_conn_man_headers_x-b3-sampled>` header
   is supplied with the client request, its value will override any sampling decision made by the Envoy proxy.
+* upstream: fixed crash during host selection from locality weighted clusters with no healthy hosts
 * websocket: support configuring
   :ref:`idle_timeout and max_connect_attempts <envoy_api_field_route.RouteAction.websocket_config>`.
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -177,7 +177,7 @@ void HostSetImpl::updateHosts(HostVectorConstSharedPtr hosts,
   // level WRR works, we would age out the existing entries via picks and lazily
   // apply the new weights.
   if (hosts_per_locality_ != nullptr && locality_weights_ != nullptr &&
-      !locality_weights_->empty()) {
+      !locality_weights_->empty() && !healthy_hosts_->empty()) {
     locality_scheduler_ = std::make_unique<EdfScheduler<LocalityEntry>>();
     locality_entries_.clear();
     for (uint32_t i = 0; i < hosts_per_locality_->get().size(); ++i) {


### PR DESCRIPTION
On host update we create a new scheduler containing localities with a
non-zero effective weight. We always create a new scheduler when
the locality weights are provided, if so if locality weights are provided and 
all localities have an effective weight of 0, the scheduler will remain empty.
This causes a segfault when trying to select a host from the cluster.

This fix simply checks that there are at least one healthy host before
creating the scheduler, which should be sufficient to guarantee that the
scheduler will always be non-empty.

The crash itself is guarded by this assert:
```
2018-06-01_03:15:32.21164 [2018-06-01 03:15:32.211][202346][critical][assert] external/envoy/source/common/upstream/upstream_impl.cc:202] assert failure: locality != nullptr
```

*Risk Level*: Low, small bug fix
*Testing*: Added unit test coverage
*Docs Changes*: N/A
*Release Notes*: Added note about bug fix
