### PR TITLE
grpc decoder: expose whether it has buffered partial data

### DIFF
--- a/source/common/grpc/codec.h
+++ b/source/common/grpc/codec.h
@@ -50,6 +50,9 @@ public:
   // the frame.
   uint32_t length() const { return frame_.length_; }
 
+  // Indicates whether it has buffered any partial data.
+  bool hasBufferedData() const { return state_ != State::FH_FLAG; }
+
 private:
   // Wire format (http://www.grpc.io/docs/guides/wire.html) of GRPC data frame
   // header:

--- a/test/common/grpc/codec_test.cc
+++ b/test/common/grpc/codec_test.cc
@@ -72,12 +72,14 @@ TEST(GrpcCodecTest, decodeIncompleteFrame) {
   EXPECT_EQ(static_cast<size_t>(0), buffer.length());
   EXPECT_EQ(static_cast<size_t>(0), frames.size());
   EXPECT_EQ(static_cast<uint32_t>(request.ByteSize()), decoder.length());
+  EXPECT_EQ(true, decoder.hasBufferedData());
 
   buffer.add(request_buffer.c_str() + 5);
   EXPECT_TRUE(decoder.decode(buffer, frames));
   EXPECT_EQ(static_cast<size_t>(0), buffer.length());
   EXPECT_EQ(static_cast<size_t>(1), frames.size());
   EXPECT_EQ(static_cast<uint32_t>(0), decoder.length());
+  EXPECT_EQ(false, decoder.hasBufferedData());
   helloworld::HelloRequest decoded_request;
   EXPECT_TRUE(decoded_request.ParseFromArray(frames[0].data_->linearize(frames[0].data_->length()),
                                              frames[0].data_->length()));


### PR DESCRIPTION
Signed-off-by: jiangtaoli2016 <jiangtao@google.com>

*title*: *grpc decoder: expose whether it has buffered partial data*

*Description*: In current grpc decoder implementation, internal state is not exposed. Caller does not know whether the decoder has consumed any partial data. With this PR, caller can easily tell whether the decoder has buffered grpc frame data.

*Risk Level*: Low 

*Testing*: unit test

*Docs Changes*: N/A

*Release Notes*: N/A