### PR TITLE
load balancer: improve LR LB when operating in weighted mode

### DIFF
--- a/docs/root/configuration/cluster_manager/cluster_runtime.rst
+++ b/docs/root/configuration/cluster_manager/cluster_runtime.rst
@@ -98,10 +98,6 @@ upstream.use_http2
   Whether the cluster utilizes the *http2* :ref:`feature <config_cluster_manager_cluster_features>`
   if configured. Set to 0 to disable HTTP/2 even if the feature is configured. Defaults to enabled.
 
-upstream.weight_enabled
-  Binary switch to turn on or off weighted load balancing. If set to non 0, weighted load balancing
-  is enabled. Defaults to enabled.
-
 .. _config_cluster_manager_cluster_runtime_zone_routing:
 
 Zone aware load balancing

--- a/docs/root/intro/arch_overview/load_balancing.rst
+++ b/docs/root/intro/arch_overview/load_balancing.rst
@@ -39,13 +39,16 @@ weight greater than 1.
   picks the host which has fewer active requests (`Research
   <http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf>`_ has shown that this
   approach is nearly as good as an O(N) full scan). This is also known as P2C (power of two
-  choices).
+  choices). The P2C load balancer has the property that a host with the highest number of active
+  requests in the cluster will never receive new requests. It will be allowed to drain until it is
+  less than or equal to all of the other hosts.
 * *all weights not 1*:  If any host in the cluster has a load balancing weight greater than 1, the
   load balancer shifts into a mode where it uses a weighted round robin schedule in which weights
-  are dynamically adjusted based on the host's request load at the time of selection. This
-  algorithm provides good balance at steady state but may not adapt to load imbalance as quickly.
-  Additionally, unlike P2C, a host will never truly drain, though it will receive fewer requests
-  over time.
+  are dynamically adjusted based on the host's request load at the time of selection (weight is
+  divided by the current active request count. For example, a host with weight 2 and an active
+  request count of 4 will have a synthetic weight of 2 / 4 = 0.5). This algorithm provides good
+  balance at steady state but may not adapt to load imbalance as quickly. Additionally, unlike P2C,
+  a host will never truly drain, though it will receive fewer requests over time.
 
 .. _arch_overview_load_balancing_types_ring_hash:
 

--- a/docs/root/intro/arch_overview/load_balancing.rst
+++ b/docs/root/intro/arch_overview/load_balancing.rst
@@ -50,6 +50,10 @@ weight greater than 1.
   balance at steady state but may not adapt to load imbalance as quickly. Additionally, unlike P2C,
   a host will never truly drain, though it will receive fewer requests over time.
 
+  .. note::
+    If all weights are not 1, but are the same (e.g., 42), Envoy will still use the weighted round
+    robin schedule instead of P2C.
+
 .. _arch_overview_load_balancing_types_ring_hash:
 
 Ring hash

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -67,14 +67,17 @@ Version history
 * listeners: :ref:`sni_domains <envoy_api_field_listener.FilterChainMatch.sni_domains>` has been deprecated/renamed to
   :ref:`server_names <envoy_api_field_listener.FilterChainMatch.server_names>`.
 * listeners: removed restriction on all filter chains having identical filters.
-* load balancing: added :ref:`weighted round robin
+* load balancer: added :ref:`weighted round robin
   <arch_overview_load_balancing_types_round_robin>` support. The round robin
   scheduler now respects endpoint weights and also has improved fidelity across
   picks.
 * load balancer: :ref:`Locality weighted load balancing
   <arch_overview_load_balancer_subsets>` is now supported.
 * load balancer: ability to configure zone aware load balancer settings :ref:`through the API
-  <envoy_api_field_Cluster.CommonLbConfig.zone_aware_lb_config>`
+  <envoy_api_field_Cluster.CommonLbConfig.zone_aware_lb_config>`.
+* load balancer: the :ref:`weighted least request
+  <arch_overview_load_balancing_types_least_request>` load balancing algorithm has been improved
+  to have better balance when operating in weighted mode.
 * logger: added the ability to optionally set the log format via the :option:`--log-format` option.
 * logger: all :ref:`logging levels <operations_admin_interface_logging>` can be configured
   at run-time: trace debug info warning error critical.

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -484,7 +484,9 @@ HostConstSharedPtr EdfLoadBalancerBase::chooseHost(LoadBalancerContext*) {
   // BaseDynamicClusterImpl::updateDynamicHostList, we must do a runtime pivot here to determine
   // whether to use EDF or do unweighted (fast) selection.
   // TODO(mattklein123): As commented elsewhere, this is wasteful, and we should just refresh the
-  // host set if any weights change.
+  // host set if any weights change. Additionally, it has the property that if all weights are
+  // the same but not 1 (like 42), we will use the EDF schedule not the unweighted pick. This is
+  // not optimal. If this is fixed, remove the note in the arch overview docs for the LR LB.
   if (stats_.max_host_weight_.value() != 1) {
     auto host = scheduler.edf_.pick();
     if (host != nullptr) {

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -407,16 +407,13 @@ const HostVector& ZoneAwareLoadBalancerBase::hostSourceToHosts(HostsSource hosts
   }
 }
 
-RoundRobinLoadBalancer::RoundRobinLoadBalancer(
+EdfLoadBalancerBase::EdfLoadBalancerBase(
     const PrioritySet& priority_set, const PrioritySet* local_priority_set, ClusterStats& stats,
     Runtime::Loader& runtime, Runtime::RandomGenerator& random,
     const envoy::api::v2::Cluster::CommonLbConfig& common_config)
     : ZoneAwareLoadBalancerBase(priority_set, local_priority_set, stats, runtime, random,
                                 common_config),
       seed_(random_.random()) {
-  for (uint32_t priority = 0; priority < priority_set.hostSetsPerPriority().size(); ++priority) {
-    refresh(priority);
-  }
   // We fully recompute the schedulers for a given host set here on membership change, which is
   // consistent with what other LB implementations do (e.g. thread aware).
   // The downside of a full recompute is that time complexity is O(n * log n),
@@ -426,55 +423,43 @@ RoundRobinLoadBalancer::RoundRobinLoadBalancer(
       [this](uint32_t priority, const HostVector&, const HostVector&) { refresh(priority); });
 }
 
-void RoundRobinLoadBalancer::refresh(uint32_t priority) {
+void EdfLoadBalancerBase::initialize() {
+  for (uint32_t priority = 0; priority < priority_set_.hostSetsPerPriority().size(); ++priority) {
+    refresh(priority);
+  }
+}
+
+void EdfLoadBalancerBase::refresh(uint32_t priority) {
   const auto add_hosts_source = [this](HostsSource source, const HostVector& hosts) {
-    bool weighted = false;
-
-    for (const auto& host : hosts) {
-      if (host->weight() != hosts[0]->weight()) {
-        weighted = true;
-        break;
-      }
-    }
-
-    // Compute schedule offset for unweighted before deleting the existing
-    // scheduler.
-    uint64_t unweighted_offset = 0;
-    if (hosts.size() > 0) {
-      // If we already have been balancing for this locality, continue where we
-      // left off; a rebuild with the same hosts will have the expected RR
-      // across the rebuild. Otherwise, start with the LB seed.
-      if (scheduler_.find(source) != scheduler_.end()) {
-        unweighted_offset = scheduler_[source].rr_index_;
-      } else {
-        unweighted_offset = seed_ % hosts.size();
-      }
-    }
     // Nuke existing scheduler if it exists.
     auto& scheduler = scheduler_[source] = Scheduler{};
-    scheduler.weighted_ = weighted;
-    if (weighted) {
-      // Populate scheduler with host list.
-      for (const auto& host : hosts) {
-        // We use a fixed weight here. While the weight may change without
-        // notification, this will only be stale until this host is next picked,
-        // at which point it is reinserted into the EdfScheduler with its new
-        // weight in chooseHost().
-        scheduler.edf_.add(host->weight(), host);
-      }
-      // Cycle through hosts to achieve the intended offset behavior.
-      // TODO(htuch): Consider how we can avoid biasing towards earlier hosts in the
-      // schedule across refreshes for the weighted case.
+    refreshHostSource(source);
+
+    // Populate scheduler with host list.
+    // TODO(mattklein123): We must build the EDF schedule even if all of the hosts are currently
+    // weighted 1. This is because currently we don't refresh host sets of only weights change.
+    // We should probably change this to refresh at all times. See the comment in
+    // BaseDynamicClusterImpl::updateDynamicHostList about this.
+    for (const auto& host : hosts) {
+      // We use a fixed weight here. While the weight may change without
+      // notification, this will only be stale until this host is next picked,
+      // at which point it is reinserted into the EdfScheduler with its new
+      // weight in chooseHost().
+      scheduler.edf_.add(hostWeight(*host), host);
+    }
+
+    // Cycle through hosts to achieve the intended offset behavior.
+    // TODO(htuch): Consider how we can avoid biasing towards earlier hosts in the schedule across
+    // refreshes for the weighted case.
+    if (!hosts.empty()) {
       for (uint32_t i = 0; i < seed_ % hosts.size(); ++i) {
         auto host = scheduler.edf_.pick();
-        scheduler.edf_.add(host->weight(), host);
+        scheduler.edf_.add(hostWeight(*host), host);
       }
-    } else {
-      scheduler.rr_index_ = unweighted_offset;
     }
   };
-  // Populate EdfSchedulers for each valid HostsSource value for the host set
-  // at this priority.
+
+  // Populate EdfSchedulers for each valid HostsSource value for the host set at this priority.
   const auto& host_set = priority_set_.hostSetsPerPriority()[priority];
   add_hosts_source(HostsSource(priority, HostsSource::SourceType::AllHosts), host_set->hosts());
   add_hosts_source(HostsSource(priority, HostsSource::SourceType::HealthyHosts),
@@ -487,84 +472,43 @@ void RoundRobinLoadBalancer::refresh(uint32_t priority) {
   }
 }
 
-HostConstSharedPtr RoundRobinLoadBalancer::chooseHost(LoadBalancerContext*) {
+HostConstSharedPtr EdfLoadBalancerBase::chooseHost(LoadBalancerContext*) {
   const HostsSource hosts_source = hostSourceToUse();
   auto scheduler_it = scheduler_.find(hosts_source);
   // We should always have a scheduler for any return value from
   // hostSourceToUse() via the construction in refresh();
   ASSERT(scheduler_it != scheduler_.end());
   auto& scheduler = scheduler_it->second;
-  if (scheduler.weighted_) {
+
+  // As has been commented in both EdfLoadBalancerBase::refresh and
+  // BaseDynamicClusterImpl::updateDynamicHostList, we must do a runtime pivot here to determine
+  // whether to use EDF or do unweighted (fast) selection.
+  // TODO(mattklein123): As commented elsewhere, this is wasteful, and we should just refresh the
+  // host set if any weights change.
+  if (stats_.max_host_weight_.value() != 1) {
     auto host = scheduler.edf_.pick();
-    // We should always succeed if weighted, since when we compute the scheduler
-    // in refresh() above, any empty host vector will be treated as unweighted.
-    // We do not expire any hosts from the host list without rebuilding the scheduler.
-    ASSERT(host != nullptr);
-    scheduler.edf_.add(host->weight(), host);
+    if (host != nullptr) {
+      scheduler.edf_.add(hostWeight(*host), host);
+    }
     return host;
   } else {
     const HostVector& hosts_to_use = hostSourceToHosts(hosts_source);
     if (hosts_to_use.size() == 0) {
       return nullptr;
     }
-    return hosts_to_use[scheduler.rr_index_++ % hosts_to_use.size()];
+    return unweightedHostPick(hosts_to_use, hosts_source);
   }
 }
 
-LeastRequestLoadBalancer::LeastRequestLoadBalancer(
-    const PrioritySet& priority_set, const PrioritySet* local_priority_set, ClusterStats& stats,
-    Runtime::Loader& runtime, Runtime::RandomGenerator& random,
-    const envoy::api::v2::Cluster::CommonLbConfig& common_config)
-    : ZoneAwareLoadBalancerBase(priority_set, local_priority_set, stats, runtime, random,
-                                common_config) {
-  priority_set.addMemberUpdateCb(
-      [this](uint32_t, const HostVector&, const HostVector& hosts_removed) -> void {
-        if (last_host_) {
-          for (const HostSharedPtr& host : hosts_removed) {
-            if (host == last_host_) {
-              hits_left_ = 0;
-              last_host_.reset();
-
-              break;
-            }
-          }
-        }
-      });
-}
-
-HostConstSharedPtr LeastRequestLoadBalancer::chooseHost(LoadBalancerContext*) {
-  bool is_weight_imbalanced = stats_.max_host_weight_.value() != 1;
-  bool is_weight_enabled = runtime_.snapshot().getInteger("upstream.weight_enabled", 1UL) != 0;
-
-  if (is_weight_imbalanced && hits_left_ > 0 && is_weight_enabled) {
-    --hits_left_;
-
-    return last_host_;
+HostConstSharedPtr LeastRequestLoadBalancer::unweightedHostPick(const HostVector& hosts_to_use,
+                                                                const HostsSource&) {
+  // This is just basic unweighted P2C.
+  const HostSharedPtr host1 = hosts_to_use[random_.random() % hosts_to_use.size()];
+  const HostSharedPtr host2 = hosts_to_use[random_.random() % hosts_to_use.size()];
+  if (host1->stats().rq_active_.value() < host2->stats().rq_active_.value()) {
+    return host1;
   } else {
-    // To avoid hit stale last_host_ when all hosts become weight balanced.
-    hits_left_ = 0;
-    last_host_.reset();
-  }
-
-  const HostVector& hosts_to_use = hostSourceToHosts(hostSourceToUse());
-  if (hosts_to_use.empty()) {
-    return nullptr;
-  }
-
-  // Make weighed random if we have hosts with non 1 weights.
-  if (is_weight_imbalanced & is_weight_enabled) {
-    last_host_ = hosts_to_use[random_.random() % hosts_to_use.size()];
-    hits_left_ = last_host_->weight() - 1;
-
-    return last_host_;
-  } else {
-    HostSharedPtr host1 = hosts_to_use[random_.random() % hosts_to_use.size()];
-    HostSharedPtr host2 = hosts_to_use[random_.random() % hosts_to_use.size()];
-    if (host1->stats().rq_active_.value() < host2->stats().rq_active_.value()) {
-      return host1;
-    } else {
-      return host2;
-    }
+    return host2;
   }
 }
 

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -437,7 +437,7 @@ void EdfLoadBalancerBase::refresh(uint32_t priority) {
 
     // Populate scheduler with host list.
     // TODO(mattklein123): We must build the EDF schedule even if all of the hosts are currently
-    // weighted 1. This is because currently we don't refresh host sets of only weights change.
+    // weighted 1. This is because currently we don't refresh host sets if only weights change.
     // We should probably change this to refresh at all times. See the comment in
     // BaseDynamicClusterImpl::updateDynamicHostList about this.
     for (const auto& host : hosts) {

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -204,10 +204,10 @@ private:
 };
 
 /**
- * Implementation of LoadBalancer that performs RR selection across the hosts in the cluster.
- * This scheduler respects host weighting and utilizes an EdfScheduler to achieve O(log n)
- * pick and insertion time complexity, O(n) memory use. The key insight is that if we schedule with
- * 1 / weight deadline, we will achieve the desired pick frequency for weighted RR in a given
+ * Base implementation of LoadBalancer that performs weighted RR selection across the hosts in the
+ * cluster. This scheduler respects host weighting and utilizes an EdfScheduler to achieve O(log
+ * n) pick and insertion time complexity, O(n) memory use. The key insight is that if we schedule
+ * with 1 / weight deadline, we will achieve the desired pick frequency for weighted RR in a given
  * interval. Naive implementations of weighted RR are either O(n) pick time or O(m * n) memory use,
  * where m is the weight range. We also explicitly check for the unweighted special case and use a
  * simple index to acheive O(1) scheduling in that case.
@@ -216,64 +216,118 @@ private:
  * explicit schedule, since m will be a small constant factor in O(m * n). This
  * could also be done on a thread aware LB, avoiding creating multiple EDF
  * instances.
+ *
+ * This base class also supports unweighted selection which derived classes can use to customize
+ * behavior. Base classes can also override how host weight is determined when in weighted mode.
  */
-class RoundRobinLoadBalancer : public LoadBalancer, ZoneAwareLoadBalancerBase {
+class EdfLoadBalancerBase : public LoadBalancer, public ZoneAwareLoadBalancerBase {
 public:
-  RoundRobinLoadBalancer(const PrioritySet& priority_set, const PrioritySet* local_priority_set,
-                         ClusterStats& stats, Runtime::Loader& runtime,
-                         Runtime::RandomGenerator& random,
-                         const envoy::api::v2::Cluster::CommonLbConfig& common_config);
+  EdfLoadBalancerBase(const PrioritySet& priority_set, const PrioritySet* local_priority_set,
+                      ClusterStats& stats, Runtime::Loader& runtime,
+                      Runtime::RandomGenerator& random,
+                      const envoy::api::v2::Cluster::CommonLbConfig& common_config);
 
   // Upstream::LoadBalancer
   HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
 
-private:
-  void refresh(uint32_t priority);
-
+protected:
   struct Scheduler {
-    // EdfScheduler for weighted RR.
+    // EdfScheduler for weighted LB.
     EdfScheduler<const Host> edf_;
-    // Simple clock hand for when we do unweighted.
-    size_t rr_index_{};
-    bool weighted_{};
   };
 
-  // Scheduler for each valid HostsSource.
-  std::unordered_map<HostsSource, Scheduler, HostsSourceHash> scheduler_;
-  // Seed to allow us to desynchronize WRR balancers across a fleet. If we don't
+  void initialize();
+
+  // Seed to allow us to desynchronize load balancers across a fleet. If we don't
   // do this, multiple Envoys that receive an update at the same time (or even
-  // multiple RoundRobinLoadBalancers on the same host) will send requests to
+  // multiple load balancers on the same host) will send requests to
   // backends in roughly lock step, causing significant imbalance and potential
   // overload.
   const uint64_t seed_;
+
+private:
+  void refresh(uint32_t priority);
+  virtual void refreshHostSource(const HostsSource& source) PURE;
+  virtual double hostWeight(const Host& host) PURE;
+  virtual HostConstSharedPtr unweightedHostPick(const HostVector& hosts_to_use,
+                                                const HostsSource& source) PURE;
+
+  // Scheduler for each valid HostsSource.
+  std::unordered_map<HostsSource, Scheduler, HostsSourceHash> scheduler_;
+};
+
+/**
+ * A round roubin load balancer. When in weighted mode, EDF scheduling is used. When in not
+ * weighted mode, simple RR index selection is used.
+ */
+class RoundRobinLoadBalancer : public EdfLoadBalancerBase {
+public:
+  RoundRobinLoadBalancer(const PrioritySet& priority_set, const PrioritySet* local_priority_set,
+                         ClusterStats& stats, Runtime::Loader& runtime,
+                         Runtime::RandomGenerator& random,
+                         const envoy::api::v2::Cluster::CommonLbConfig& common_config)
+      : EdfLoadBalancerBase(priority_set, local_priority_set, stats, runtime, random,
+                            common_config) {
+    initialize();
+  }
+
+private:
+  void refreshHostSource(const HostsSource& source) override {
+    // insert() is used here on purpose so that we don't overwrite the index of the host source
+    // already exists. Note that host sources will never be removed, but given how uncommon this
+    // is it probably doesn't matter.
+    rr_indexes_.insert({source, seed_});
+  }
+  double hostWeight(const Host& host) override { return host.weight(); }
+  HostConstSharedPtr unweightedHostPick(const HostVector& hosts_to_use,
+                                        const HostsSource& source) override {
+    // To avoid storing the RR index in the base class, we end up using a second map here with
+    // host source as the key. This means that each LB decision will require two map lookups in
+    // the unweighted case. We might consider trying to optimize this in the future.
+    ASSERT(rr_indexes_.find(source) != rr_indexes_.end());
+    return hosts_to_use[rr_indexes_[source]++ % hosts_to_use.size()];
+  }
+
+  std::unordered_map<HostsSource, uint64_t, HostsSourceHash> rr_indexes_;
 };
 
 /**
  * Weighted Least Request load balancer.
  *
  * In a normal setup when all hosts have the same weight of 1 it randomly picks up two healthy hosts
- * and compares number of active requests.
- * Technique is based on http://www.eecs.harvard.edu/~michaelm/postscripts/mythesis.pdf
+ * and compares number of active requests. Technique is based on
+ * http://www.eecs.harvard.edu/~michaelm/postscripts/mythesis.pdf and is known as P2C (power of
+ * two choices).
  *
- * When any of the hosts have non 1 weight, apply random weighted balancing.
- * Randomly pickup the host and send 'weight' number of requests to it.
- * This technique is acceptable for load testing but
- * will not work well in situations where requests take a long time.
- * In that case a different algorithm using a full scan will be required.
+ * When any hosts have a weight that is not 1, an RR EDF schedule is used. Host weight is scaled
+ * by the number of active requests at pick/insert time. Thus, hosts will never fully drain as
+ * they would in normal P2C, though they will get picked less and less often. In the future, we
+ * can consider two alternate algorithms:
+ * 1) Expand out all hosts by weight (using more memory) and do standard P2C.
+ * 2) Use a weighted Maglev table, and perform P2C on two random hosts selected from the table.
+ *    The benefit of the Maglev table is at the expense of resolution, memory usage is capped.
+ *    Additionally, the Maglev table can be shared amongst all threads.
  */
-class LeastRequestLoadBalancer : public LoadBalancer, ZoneAwareLoadBalancerBase {
+class LeastRequestLoadBalancer : public EdfLoadBalancerBase {
 public:
   LeastRequestLoadBalancer(const PrioritySet& priority_set, const PrioritySet* local_priority_set,
                            ClusterStats& stats, Runtime::Loader& runtime,
                            Runtime::RandomGenerator& random,
-                           const envoy::api::v2::Cluster::CommonLbConfig& common_config);
-
-  // Upstream::LoadBalancer
-  HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
+                           const envoy::api::v2::Cluster::CommonLbConfig& common_config)
+      : EdfLoadBalancerBase(priority_set, local_priority_set, stats, runtime, random,
+                            common_config) {
+    initialize();
+  }
 
 private:
-  HostSharedPtr last_host_;
-  uint32_t hits_left_{};
+  void refreshHostSource(const HostsSource&) override {}
+  double hostWeight(const Host& host) override {
+    // Here we scale host weight by the number of active requests at the time we do the pick. We
+    // always add 1 to avoid division by 0.
+    return static_cast<double>(host.weight()) / (host.stats().rq_active_.value() + 1);
+  }
+  HostConstSharedPtr unweightedHostPick(const HostVector& hosts_to_use,
+                                        const HostsSource& source) override;
 };
 
 /**

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -328,6 +328,10 @@ private:
     // that hosts are always picked, regardless of their current request load at the time of pick.
     // It might be posible to do better by picking two hosts off of the schedule, and selecting
     // the one with fewer active requests at the time of selection.
+    // TODO(mattklein123): @htuch brings up the point that how we are scaling weight here might not
+    // be the only/best way of doing this. Essentially, it makes weight and active requests equally
+    // important. Are they equally important in practice? There is no right answer here and we might
+    // want to iterate on this as we gain more experience.
     return static_cast<double>(host.weight()) / (host.stats().rq_active_.value() + 1);
   }
   HostConstSharedPtr unweightedHostPick(const HostVector& hosts_to_use,

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -754,6 +754,11 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(const HostVector& new_hosts,
     }
   }
 
+  // TODO(mattklein123): This stat is used by both the RR and LR load balancer to decide at
+  // runtime whether to use either the weighted or unweighted mode. If we extend weights to
+  // static clusters or DNS SRV clusters we need to make sure this gets set. Better, we should
+  // avoid pivoting on this entirely and probably just force a host set refresh if any weights
+  // change.
   info_->stats().max_host_weight_.set(max_host_weight);
 
   if (!hosts_added.empty() || !current_hosts.empty()) {

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -32,6 +32,54 @@ static HostSharedPtr newTestHost(Upstream::ClusterInfoConstSharedPtr cluster,
                    envoy::api::v2::endpoint::Endpoint::HealthCheckConfig::default_instance())};
 }
 
+// Simulate weighted LR load balancer.
+TEST(DISABLED_LeastRequestLoadBalancerWeightTest, Weight) {
+  const uint64_t num_hosts = 4;
+  const uint64_t weighted_subset_percent = 50;
+  const uint64_t weight = 2;
+
+  PrioritySetImpl priority_set_;
+  std::shared_ptr<MockClusterInfo> info_{new NiceMock<MockClusterInfo>()};
+  HostSet& host_set = priority_set_.getOrCreateHostSet(0);
+  HostVector hosts;
+  for (uint64_t i = 0; i < num_hosts; i++) {
+    const bool should_weight = i < num_hosts * (weighted_subset_percent / 100.0);
+    hosts.push_back(makeTestHost(info_, fmt::format("tcp://10.0.{}.{}:6379", i / 256, i % 256),
+                                 should_weight ? weight : 1));
+  }
+  HostVectorConstSharedPtr updated_hosts{new HostVector(hosts)};
+  HostsPerLocalitySharedPtr updated_locality_hosts{new HostsPerLocalityImpl(hosts)};
+  host_set.updateHosts(updated_hosts, updated_hosts, updated_locality_hosts, updated_locality_hosts,
+                       {}, hosts, {});
+
+  Stats::IsolatedStoreImpl stats_store_;
+  ClusterStats stats_{ClusterInfoImpl::generateStats(stats_store_)};
+  stats_.max_host_weight_.set(weight);
+  NiceMock<Runtime::MockLoader> runtime_;
+  Runtime::RandomGeneratorImpl random_;
+  envoy::api::v2::Cluster::CommonLbConfig common_config_;
+  LeastRequestLoadBalancer lb_{priority_set_, nullptr, stats_, runtime_, random_, common_config_};
+
+  std::unordered_map<HostConstSharedPtr, uint64_t> host_hits;
+  const uint64_t total_requests = 100;
+  for (uint64_t i = 0; i < total_requests; i++) {
+    host_hits[lb_.chooseHost(nullptr)]++;
+  }
+
+  std::unordered_map<uint64_t, double> weight_to_percent;
+  for (const auto& host : host_hits) {
+    std::cout << fmt::format("url:{}, weight:{}, hits:{}, percent_of_total:{}\n",
+                             host.first->address()->asString(), host.first->weight(), host.second,
+                             (static_cast<double>(host.second) / total_requests) * 100);
+    weight_to_percent[host.first->weight()] +=
+        (static_cast<double>(host.second) / total_requests) * 100;
+  }
+
+  for (const auto& weight : weight_to_percent) {
+    std::cout << fmt::format("weight:{}, percent:{}\n", weight.first, weight.second);
+  }
+}
+
 /**
  * This test is for simulation only and should not be run as part of unit tests.
  */

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -107,7 +107,9 @@ enum UpdateOrder { REMOVES_FIRST, SIMULTANEOUS };
 
 class SubsetLoadBalancerTest : public testing::TestWithParam<UpdateOrder> {
 public:
-  SubsetLoadBalancerTest() : stats_(ClusterInfoImpl::generateStats(stats_store_)) {}
+  SubsetLoadBalancerTest() : stats_(ClusterInfoImpl::generateStats(stats_store_)) {
+    stats_.max_host_weight_.set(1UL);
+  }
 
   typedef std::map<std::string, std::string> HostMetadata;
   typedef std::map<std::string, HostMetadata> HostURLMetadataMap;


### PR DESCRIPTION
This change does several things:
1) Refactors the EDF RR LB into a base class that is shared by both the RR
   and LR load balancers.
2) Change weighted LR to use weighted RR with host weight adjust by host load
   at time of selection.
3) Fix an issue in which weighted RR would not be used if host weights go
   from all 1, to all not 1. The solution is not-optimal and we should look
   at changing this behavior in the future. I left a bunch of TODOs for
   follow up.

Fixes https://github.com/envoyproxy/envoy/issues/3284

*Risk Level*: High (LB changes are scary)
*Testing*: Existing tests, changed unit tests, and a new simulation test.
*Docs Changes*: Added
*Release Notes*: Added
