### PR TITLE
gzip filter: add runtime gateway

### DIFF
--- a/docs/root/configuration/http_filters/gzip_filter.rst
+++ b/docs/root/configuration/http_filters/gzip_filter.rst
@@ -20,6 +20,15 @@ Configuration
   automatically set to 9. This issue might be solved in future releases of
   the library.
 
+Runtime
+-------
+
+The Gzip filter supports the following runtime settings:
+
+gzip.filter_enabled
+    The % of requests for which the filter is enabled. Default is 100.
+
+
 How it works
 ------------
 When gzip filter is enabled, request and response headers are inspected to

--- a/source/extensions/filters/http/gzip/BUILD
+++ b/source/extensions/filters/http/gzip/BUILD
@@ -17,6 +17,7 @@ envoy_cc_library(
     deps = [
         "//include/envoy/http:filter_interface",
         "//include/envoy/json:json_object_interface",
+        "//include/envoy/runtime:runtime_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/compressor:compressor_lib",
         "//source/common/http:header_map_lib",

--- a/source/extensions/filters/http/gzip/config.cc
+++ b/source/extensions/filters/http/gzip/config.cc
@@ -12,8 +12,9 @@ namespace Gzip {
 
 Http::FilterFactoryCb GzipFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::config::filter::http::gzip::v2::Gzip& proto_config, const std::string&,
-    Server::Configuration::FactoryContext&) {
-  GzipFilterConfigSharedPtr config = std::make_shared<GzipFilterConfig>(proto_config);
+    Server::Configuration::FactoryContext& context) {
+  GzipFilterConfigSharedPtr config =
+      std::make_shared<GzipFilterConfig>(proto_config, context.runtime());
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<GzipFilter>(config));
   };

--- a/source/extensions/filters/http/gzip/gzip_filter.h
+++ b/source/extensions/filters/http/gzip/gzip_filter.h
@@ -4,6 +4,7 @@
 #include "envoy/http/filter.h"
 #include "envoy/http/header_map.h"
 #include "envoy/json/json_object.h"
+#include "envoy/runtime/runtime.h"
 
 #include "common/buffer/buffer_impl.h"
 #include "common/compressor/zlib_compressor_impl.h"
@@ -23,7 +24,8 @@ namespace Gzip {
 class GzipFilterConfig {
 
 public:
-  GzipFilterConfig(const envoy::config::filter::http::gzip::v2::Gzip& gzip);
+  GzipFilterConfig(const envoy::config::filter::http::gzip::v2::Gzip& gzip,
+                   Runtime::Loader& runtime);
 
   Compressor::ZlibCompressorImpl::CompressionLevel compressionLevel() const {
     return compression_level_;
@@ -32,6 +34,7 @@ public:
     return compression_strategy_;
   }
 
+  Runtime::Loader& runtime() { return runtime_; }
   const StringUtil::CaseUnorderedSet& contentTypeValues() const { return content_type_values_; }
   bool disableOnEtagHeader() const { return disable_on_etag_header_; }
   bool removeAcceptEncodingHeader() const { return remove_accept_encoding_header_; }
@@ -62,6 +65,7 @@ private:
 
   bool disable_on_etag_header_;
   bool remove_accept_encoding_header_;
+  Runtime::Loader& runtime_;
 };
 typedef std::shared_ptr<GzipFilterConfig> GzipFilterConfigSharedPtr;
 

--- a/test/extensions/filters/http/gzip/BUILD
+++ b/test/extensions/filters/http/gzip/BUILD
@@ -16,6 +16,8 @@ envoy_cc_test(
         "//source/common/decompressor:decompressor_lib",
         "//source/common/protobuf:utility_lib",
         "//source/extensions/filters/http/gzip:gzip_filter_lib",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/runtime:runtime_mocks",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -4,9 +4,15 @@
 
 #include "extensions/filters/http/gzip/gzip_filter.h"
 
+#include "test/mocks/http/mocks.h"
+#include "test/mocks/runtime/mocks.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
+
+using testing::_;
+using testing::Return;
+using testing::ReturnRef;
 
 namespace Envoy {
 namespace Extensions {
@@ -15,7 +21,10 @@ namespace Gzip {
 
 class GzipFilterTest : public testing::Test {
 protected:
-  GzipFilterTest() {}
+  GzipFilterTest() {
+    ON_CALL(runtime_.snapshot_, featureEnabled("gzip.filter_enabled", 100))
+        .WillByDefault(Return(true));
+  }
 
   void SetUp() override {
     setUpFilter("{}");
@@ -54,7 +63,7 @@ protected:
     Json::ObjectSharedPtr config = Json::Factory::loadFromString(json);
     envoy::config::filter::http::gzip::v2::Gzip gzip;
     MessageUtil::loadFromJson(json, gzip);
-    config_.reset(new GzipFilterConfig(gzip));
+    config_.reset(new GzipFilterConfig(gzip, runtime_));
     filter_.reset(new GzipFilter(config_));
   }
 
@@ -111,7 +120,16 @@ protected:
   Decompressor::ZlibDecompressorImpl decompressor_;
   Buffer::OwnedImpl decompressed_data_;
   std::string expected_str_;
+  NiceMock<Runtime::MockLoader> runtime_;
 };
+
+// Test if Runtime Feature is Disabled
+TEST_F(GzipFilterTest, RuntimeDisabled) {
+  EXPECT_CALL(runtime_.snapshot_, featureEnabled("gzip.filter_enabled", 100))
+      .WillOnce(Return(false));
+  doRequest({{":method", "get"}, {"accept-encoding", "deflate, gzip"}}, false);
+  doResponseNoCompression({{":method", "get"}, {"content-length", "256"}});
+}
 
 // Default config values.
 TEST_F(GzipFilterTest, DefaultConfigValues) {

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -10,9 +10,9 @@
 
 #include "gtest/gtest.h"
 
-using testing::_;
 using testing::Return;
 using testing::ReturnRef;
+using testing::_;
 
 namespace Envoy {
 namespace Extensions {


### PR DESCRIPTION
Signed-off-by: Lita Cho <lcho@lyft.com>

*gzip filter*: *add a runtime gateway to slowly rollout gzip filter*

*Description*:
This PR adds a check a runtime flag check so people can slowly roll out the filter. The default is set to being "on" for backward compatibility on those using the filter already without a runtime flag.

*Risk Level*: Low

*Testing*: unit test

*Docs Changes*: None

*Release Notes*: None
