### PR TITLE
router: allow path changes in regex routes.

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -371,7 +371,9 @@ void RouteEntryImplBase::finalizeRequestHeaders(Http::HeaderMap& headers,
   }
 
   // Handle path rewrite
-  rewritePathHeader(headers, insert_envoy_original_path);
+  if (!getPathRewrite().empty()) {
+    rewritePathHeader(headers, insert_envoy_original_path);
+  }
 }
 
 void RouteEntryImplBase::finalizeResponseHeaders(
@@ -397,7 +399,7 @@ RouteEntryImplBase::loadRuntimeData(const envoy::api::v2::route::RouteMatch& rou
 void RouteEntryImplBase::finalizePathHeader(Http::HeaderMap& headers,
                                             const std::string& matched_path,
                                             bool insert_envoy_original_path) const {
-  const auto& rewrite = (isRedirect()) ? prefix_rewrite_redirect_ : prefix_rewrite_;
+  const auto& rewrite = getPathRewrite();
   if (rewrite.empty()) {
     return;
   }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -665,9 +665,8 @@ void RegexRouteEntryImpl::rewritePathHeader(Http::HeaderMap& headers,
                                             bool insert_envoy_original_path) const {
   const Http::HeaderString& path = headers.Path()->value();
   const char* query_string_start = Http::Utility::findQueryStringStart(path);
-  // TODO(yuval-k): This ASSERT can happen in valid circumstances - if the path was changed by a
-  // filter without clearing the route cache. We should consider if ASSERT-ing is the correct
-  // behavior in this case.
+  // TODO(yuval-k): This ASSERT can happen if the path was changed by a filter without clearing the
+  // route cache. We should consider if ASSERT-ing is the desired behavior in this case.
   ASSERT(std::regex_match(path.c_str(), query_string_start, regex_));
   std::string matched_path(path.c_str(), query_string_start);
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -361,16 +361,17 @@ Http::WebSocketProxyPtr RouteEntryImplBase::createWebSocketProxy(
 void RouteEntryImplBase::finalizeRequestHeaders(Http::HeaderMap& headers,
                                                 const RequestInfo::RequestInfo& request_info,
                                                 bool insert_envoy_original_path) const {
-  UNREFERENCED_PARAMETER(insert_envoy_original_path);
   // Append user-specified request headers in the following order: route-level headers,
   // virtual host level headers and finally global connection manager level headers.
   request_headers_parser_->evaluateHeaders(headers, request_info);
   vhost_.requestHeaderParser().evaluateHeaders(headers, request_info);
   vhost_.globalRouteConfig().requestHeaderParser().evaluateHeaders(headers, request_info);
-  if (host_rewrite_.empty()) {
-    return;
+  if (!host_rewrite_.empty()) {
+    headers.Host()->value(host_rewrite_);
   }
-  headers.Host()->value(host_rewrite_);
+
+  // Handle path rewrite
+  rewritePathHeader(headers, insert_envoy_original_path);
 }
 
 void RouteEntryImplBase::finalizeResponseHeaders(
@@ -599,14 +600,6 @@ PrefixRouteEntryImpl::PrefixRouteEntryImpl(const VirtualHostImpl& vhost,
                                            Server::Configuration::FactoryContext& factory_context)
     : RouteEntryImplBase(vhost, route, factory_context), prefix_(route.match().prefix()) {}
 
-void PrefixRouteEntryImpl::finalizeRequestHeaders(Http::HeaderMap& headers,
-                                                  const RequestInfo::RequestInfo& request_info,
-                                                  bool insert_envoy_original_path) const {
-  RouteEntryImplBase::finalizeRequestHeaders(headers, request_info, insert_envoy_original_path);
-
-  finalizePathHeader(headers, prefix_, insert_envoy_original_path);
-}
-
 void PrefixRouteEntryImpl::rewritePathHeader(Http::HeaderMap& headers,
                                              bool insert_envoy_original_path) const {
   finalizePathHeader(headers, prefix_, insert_envoy_original_path);
@@ -625,14 +618,6 @@ PathRouteEntryImpl::PathRouteEntryImpl(const VirtualHostImpl& vhost,
                                        const envoy::api::v2::route::Route& route,
                                        Server::Configuration::FactoryContext& factory_context)
     : RouteEntryImplBase(vhost, route, factory_context), path_(route.match().path()) {}
-
-void PathRouteEntryImpl::finalizeRequestHeaders(Http::HeaderMap& headers,
-                                                const RequestInfo::RequestInfo& request_info,
-                                                bool insert_envoy_original_path) const {
-  RouteEntryImplBase::finalizeRequestHeaders(headers, request_info, insert_envoy_original_path);
-
-  finalizePathHeader(headers, path_, insert_envoy_original_path);
-}
 
 void PathRouteEntryImpl::rewritePathHeader(Http::HeaderMap& headers,
                                            bool insert_envoy_original_path) const {
@@ -682,13 +667,6 @@ void RegexRouteEntryImpl::rewritePathHeader(Http::HeaderMap& headers,
   std::string matched_path(path.c_str(), query_string_start);
 
   finalizePathHeader(headers, matched_path, insert_envoy_original_path);
-}
-
-void RegexRouteEntryImpl::finalizeRequestHeaders(Http::HeaderMap& headers,
-                                                 const RequestInfo::RequestInfo& request_info,
-                                                 bool insert_envoy_original_path) const {
-  RouteEntryImplBase::finalizeRequestHeaders(headers, request_info, insert_envoy_original_path);
-  rewritePathHeader(headers, insert_envoy_original_path);
 }
 
 RouteConstSharedPtr RegexRouteEntryImpl::matches(const Http::HeaderMap& headers,

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -665,6 +665,9 @@ void RegexRouteEntryImpl::rewritePathHeader(Http::HeaderMap& headers,
                                             bool insert_envoy_original_path) const {
   const Http::HeaderString& path = headers.Path()->value();
   const char* query_string_start = Http::Utility::findQueryStringStart(path);
+  // TODO(yuval-k): This ASSERT can happen in valid circumstances - if the path was changed by a
+  // filter without clearing the route cache. We should consider if ASSERT-ing is the correct
+  // behavior in this case.
   ASSERT(std::regex_match(path.c_str(), query_string_start, regex_));
   std::string matched_path(path.c_str(), query_string_start);
 

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -532,11 +532,6 @@ public:
   PrefixRouteEntryImpl(const VirtualHostImpl& vhost, const envoy::api::v2::route::Route& route,
                        Server::Configuration::FactoryContext& factory_context);
 
-  // Router::RouteEntry
-  void finalizeRequestHeaders(Http::HeaderMap& headers,
-                              const RequestInfo::RequestInfo& request_info,
-                              bool insert_envoy_original_path) const override;
-
   // Router::PathMatchCriterion
   const std::string& matcher() const override { return prefix_; }
   PathMatchType matchType() const override { return PathMatchType::Prefix; }
@@ -559,11 +554,6 @@ public:
   PathRouteEntryImpl(const VirtualHostImpl& vhost, const envoy::api::v2::route::Route& route,
                      Server::Configuration::FactoryContext& factory_context);
 
-  // Router::RouteEntry
-  void finalizeRequestHeaders(Http::HeaderMap& headers,
-                              const RequestInfo::RequestInfo& request_info,
-                              bool insert_envoy_original_path) const override;
-
   // Router::PathMatchCriterion
   const std::string& matcher() const override { return path_; }
   PathMatchType matchType() const override { return PathMatchType::Exact; }
@@ -585,11 +575,6 @@ class RegexRouteEntryImpl : public RouteEntryImplBase {
 public:
   RegexRouteEntryImpl(const VirtualHostImpl& vhost, const envoy::api::v2::route::Route& route,
                       Server::Configuration::FactoryContext& factory_context);
-
-  // Router::RouteEntry
-  void finalizeRequestHeaders(Http::HeaderMap& headers,
-                              const RequestInfo::RequestInfo& request_info,
-                              bool insert_envoy_original_path) const override;
 
   // Router::PathMatchCriterion
   const std::string& matcher() const override { return regex_str_; }

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -342,6 +342,14 @@ protected:
   bool include_vh_rate_limits_;
 
   RouteConstSharedPtr clusterEntry(const Http::HeaderMap& headers, uint64_t random_value) const;
+
+  /**
+   * returns the correct path rewrite string for this route.
+   */
+  const std::string& getPathRewrite() const {
+    return (isRedirect()) ? prefix_rewrite_redirect_ : prefix_rewrite_;
+  }
+
   void finalizePathHeader(Http::HeaderMap& headers, const std::string& matched_path,
                           bool insert_envoy_original_path) const;
   const HeaderParser& requestHeaderParser() const { return *request_headers_parser_; };

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4321,6 +4321,38 @@ virtual_hosts:
   }
 }
 
+TEST(RouteConfigurationV2, RegexPrefixWithNoRewriteWorksWhenPathChanged) {
+
+  // setup regex route entry. the regex is trivial, thats ok as we only want to test that
+  // path change works.
+  std::string RegexRewrite = R"EOF(
+name: RegexNoMatch
+virtual_hosts:
+  - name: regex
+    domains: [regex.lyft.com]
+    routes:
+      - match: { regex: "/regex"}
+        route: { cluster: some-cluster }
+  )EOF";
+
+  NiceMock<Server::Configuration::MockFactoryContext> factory_context;
+  ConfigImpl config(parseRouteConfigurationFromV2Yaml(RegexRewrite), factory_context, true);
+
+  {
+    // Get our regex route entry
+    Http::TestHeaderMapImpl headers = genRedirectHeaders("regex.lyft.com", "/regex", true, false);
+    const RouteEntry* route_entry = config.route(headers, 0)->routeEntry();
+
+    // simulate a filter changing the path
+    headers.remove(":path");
+    headers.addCopy(":path", "/not-the-original-regex");
+
+    // no re-write was specified; so this should not throw
+    NiceMock<Envoy::RequestInfo::MockRequestInfo> request_info;
+    EXPECT_NO_THROW(route_entry->finalizeRequestHeaders(headers, request_info, false));
+  }
+}
+
 class PerFilterConfigsTest : public testing::Test {
 public:
   PerFilterConfigsTest() : factory_(), registered_factory_(factory_) {}


### PR DESCRIPTION
Fixes an issue when a filter changes the ":path" header when a regex is used to match the route.
Previously and ASSERT that the route matches was called regardless of the whether or not that path re-write was required. This PR changes it so it is only called if a path rewrite is needed.

*Risk Level*: Low

*Testing*:
A failing unit test was added that now passes.

*Docs Changes*: N/A

*Release Notes*: N/A

Fixes #3417 