### PR TITLE
health checker: allow http health checker to use http/2

### DIFF
--- a/api/envoy/api/v2/core/health_check.proto
+++ b/api/envoy/api/v2/core/health_check.proto
@@ -83,6 +83,9 @@ message HealthCheck {
     // Specifies a list of HTTP headers that should be added to each request that is sent to the
     // health checked cluster.
     repeated core.HeaderValueOption request_headers_to_add = 6;
+
+    // If set, health checks will be made using http/2.
+    bool use_http2 = 7;
   }
 
   message TcpHealthCheck {

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -44,7 +44,7 @@ Version history
   to trigger health check response. Deprecated the
   :ref:`endpoint option <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.endpoint>`.
 * health check: added support for :ref:`custom health check <envoy_api_field_core.HealthCheck.custom_health_check>`.
-* health check: health check connections can now be configured to use http/2
+* health check: health check connections can now be configured to use http/2.
 * http: filters can now optionally support
   :ref:`virtual host <envoy_api_field_route.VirtualHost.per_filter_config>`,
   :ref:`route <envoy_api_field_route.Route.per_filter_config>`, and

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -44,6 +44,7 @@ Version history
   to trigger health check response. Deprecated the
   :ref:`endpoint option <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.endpoint>`.
 * health check: added support for :ref:`custom health check <envoy_api_field_core.HealthCheck.custom_health_check>`.
+* health check: health check connections can now be configured to use http/2
 * http: filters can now optionally support
   :ref:`virtual host <envoy_api_field_route.VirtualHost.per_filter_config>`,
   :ref:`route <envoy_api_field_route.Route.per_filter_config>`, and

--- a/source/common/http/codec_client.h
+++ b/source/common/http/codec_client.h
@@ -106,6 +106,8 @@ public:
 
   bool remoteClosed() const { return remote_closed_; }
 
+  Type type() const { return type_; }
+
 protected:
   /**
    * Create a codec client and connect to a remote host/port.

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -82,7 +82,8 @@ HttpHealthCheckerImpl::HttpHealthCheckerImpl(const Cluster& cluster,
     : HealthCheckerImplBase(cluster, config, dispatcher, runtime, random),
       path_(config.http_health_check().path()), host_value_(config.http_health_check().host()),
       request_headers_parser_(
-          Router::HeaderParser::configure(config.http_health_check().request_headers_to_add())) {
+          Router::HeaderParser::configure(config.http_health_check().request_headers_to_add())),
+      codec_client_type_(codecClientType(cluster)) {
   if (!config.http_health_check().service_name().empty()) {
     service_name_ = config.http_health_check().service_name();
   }
@@ -206,9 +207,17 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onTimeout() {
   client_->close();
 }
 
+Http::CodecClient::Type HttpHealthCheckerImpl::codecClientType(const Cluster& cluster) {
+  if (cluster.info()->features() & Upstream::ClusterInfo::Features::HTTP2) {
+    return Http::CodecClient::Type::HTTP2;
+  } else {
+    return Http::CodecClient::Type::HTTP1;
+  }
+}
+
 Http::CodecClient*
 ProdHttpHealthCheckerImpl::createCodecClient(Upstream::Host::CreateConnectionData& data) {
-  return new Http::CodecClientProd(Http::CodecClient::Type::HTTP1, std::move(data.connection_),
+  return new Http::CodecClientProd(codec_client_type_, std::move(data.connection_),
                                    data.host_description_, dispatcher_);
 }
 

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -83,7 +83,7 @@ HttpHealthCheckerImpl::HttpHealthCheckerImpl(const Cluster& cluster,
       path_(config.http_health_check().path()), host_value_(config.http_health_check().host()),
       request_headers_parser_(
           Router::HeaderParser::configure(config.http_health_check().request_headers_to_add())),
-      codec_client_type_(codecClientType(cluster)) {
+      codec_client_type_(codecClientType(config.http_health_check().use_http2())) {
   if (!config.http_health_check().service_name().empty()) {
     service_name_ = config.http_health_check().service_name();
   }
@@ -207,8 +207,8 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onTimeout() {
   client_->close();
 }
 
-Http::CodecClient::Type HttpHealthCheckerImpl::codecClientType(const Cluster& cluster) {
-  if (cluster.info()->features() & Upstream::ClusterInfo::Features::HTTP2) {
+Http::CodecClient::Type HttpHealthCheckerImpl::codecClientType(bool use_http2) {
+  if (use_http2) {
     return Http::CodecClient::Type::HTTP2;
   } else {
     return Http::CodecClient::Type::HTTP1;

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -106,10 +106,15 @@ private:
     return std::make_unique<HttpActiveHealthCheckSession>(*this, host);
   }
 
+  Http::CodecClient::Type codecClientType(const Cluster& cluster);
+
   const std::string path_;
   const std::string host_value_;
   absl::optional<std::string> service_name_;
   Router::HeaderParserPtr request_headers_parser_;
+
+protected:
+  const Http::CodecClient::Type codec_client_type_;
 };
 
 /**

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -106,7 +106,7 @@ private:
     return std::make_unique<HttpActiveHealthCheckSession>(*this, host);
   }
 
-  Http::CodecClient::Type codecClientType(const Cluster& cluster);
+  Http::CodecClient::Type codecClientType(bool use_http2);
 
   const std::string path_;
   const std::string host_value_;

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -91,6 +91,8 @@ public:
 
   // HttpHealthCheckerImpl
   MOCK_METHOD1(createCodecClient_, Http::CodecClient*(Upstream::Host::CreateConnectionData&));
+
+  Http::CodecClient::Type codecClientType() { return codec_client_type_; }
 };
 
 class HttpHealthCheckerImplTest : public testing::Test {
@@ -1342,6 +1344,13 @@ TEST_F(HttpHealthCheckerImplTest, SuccessWithMultipleHostsAndAltPort) {
   respond(1, "200", false, true);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[1]->healthy());
+}
+
+TEST_F(HttpHealthCheckerImplTest, Http2ClusterUsesHttp2CodecClient) {
+  EXPECT_CALL(*cluster_->info_, features())
+      .WillRepeatedly(Return(Upstream::ClusterInfo::Features::HTTP2));
+  setupNoServiceValidationHC();
+  EXPECT_EQ(Http::CodecClient::Type::HTTP2, health_checker_->codecClientType());
 }
 
 TEST(TcpHealthCheckMatcher, loadJsonBytes) {

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -1432,30 +1432,17 @@ public:
   }
 
   std::unique_ptr<Network::MockClientConnection> connection_ =
-      std::make_unique<Network::MockClientConnection>();
+      std::make_unique<NiceMock<Network::MockClientConnection>>();
   std::shared_ptr<TestProdHttpHealthChecker> health_checker_;
 };
 
 TEST_F(ProdHttpHealthCheckerTest, ProdHttpHealthCheckerH1HealthChecking) {
-  EXPECT_CALL(*connection_, connect());
-  EXPECT_CALL(*connection_, detectEarlyCloseWhenReadDisabled(_));
-  EXPECT_CALL(*connection_, addConnectionCallbacks(_));
-  EXPECT_CALL(*connection_, addReadFilter(_));
-  EXPECT_CALL(*connection_, noDelay(_));
-  EXPECT_CALL(*connection_, bufferLimit());
-
   setupNoServiceValidationHC();
   EXPECT_EQ(Http::CodecClient::Type::HTTP1,
             health_checker_->createCodecClientForTest(std::move(connection_))->type());
 }
 
 TEST_F(ProdHttpHealthCheckerTest, ProdHttpHealthCheckerH2HealthChecking) {
-  EXPECT_CALL(*connection_, connect());
-  EXPECT_CALL(*connection_, detectEarlyCloseWhenReadDisabled(_));
-  EXPECT_CALL(*connection_, addConnectionCallbacks(_));
-  EXPECT_CALL(*connection_, addReadFilter(_));
-  EXPECT_CALL(*connection_, noDelay(_));
-
   setupNoServiceValidationHCWithHttp2();
   EXPECT_EQ(Http::CodecClient::Type::HTTP2,
             health_checker_->createCodecClientForTest(std::move(connection_))->type());

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -1374,10 +1374,11 @@ TEST_F(HttpHealthCheckerImplTest, Http2ClusterUsesHttp2CodecClient) {
 }
 
 class TestProdHttpHealthChecker : public ProdHttpHealthCheckerImpl {
-  public:
+public:
   using ProdHttpHealthCheckerImpl::ProdHttpHealthCheckerImpl;
 
-  std::unique_ptr<Http::CodecClient> createCodecClientForTest(std::unique_ptr<Network::ClientConnection>&& connection) {
+  std::unique_ptr<Http::CodecClient>
+  createCodecClientForTest(std::unique_ptr<Network::ClientConnection>&& connection) {
     Upstream::Host::CreateConnectionData data;
     data.connection_ = std::move(connection);
     data.host_description_ = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
@@ -1386,7 +1387,7 @@ class TestProdHttpHealthChecker : public ProdHttpHealthCheckerImpl {
 };
 
 class ProdHttpHealthCheckerTest : public HttpHealthCheckerImplTest {
-  public:
+public:
   void setupNoServiceValidationHCWithHttp2() {
     const std::string yaml = R"EOF(
     timeout: 1s
@@ -1430,7 +1431,8 @@ class ProdHttpHealthCheckerTest : public HttpHealthCheckerImplTest {
         });
   }
 
-  std::unique_ptr<Network::MockClientConnection> connection_ = std::make_unique<Network::MockClientConnection>();
+  std::unique_ptr<Network::MockClientConnection> connection_ =
+      std::make_unique<Network::MockClientConnection>();
   std::shared_ptr<TestProdHttpHealthChecker> health_checker_;
 };
 
@@ -1443,7 +1445,8 @@ TEST_F(ProdHttpHealthCheckerTest, ProdHttpHealthCheckerH1HealthChecking) {
   EXPECT_CALL(*connection_, bufferLimit());
 
   setupNoServiceValidationHC();
-  EXPECT_EQ(Http::CodecClient::Type::HTTP1, health_checker_->createCodecClientForTest(std::move(connection_))->type());
+  EXPECT_EQ(Http::CodecClient::Type::HTTP1,
+            health_checker_->createCodecClientForTest(std::move(connection_))->type());
 }
 
 TEST_F(ProdHttpHealthCheckerTest, ProdHttpHealthCheckerH2HealthChecking) {
@@ -1454,7 +1457,8 @@ TEST_F(ProdHttpHealthCheckerTest, ProdHttpHealthCheckerH2HealthChecking) {
   EXPECT_CALL(*connection_, noDelay(_));
 
   setupNoServiceValidationHCWithHttp2();
-  EXPECT_EQ(Http::CodecClient::Type::HTTP2, health_checker_->createCodecClientForTest(std::move(connection_))->type());
+  EXPECT_EQ(Http::CodecClient::Type::HTTP2,
+            health_checker_->createCodecClientForTest(std::move(connection_))->type());
 }
 
 TEST(TcpHealthCheckMatcher, loadJsonBytes) {

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -1373,6 +1373,90 @@ TEST_F(HttpHealthCheckerImplTest, Http2ClusterUsesHttp2CodecClient) {
   EXPECT_EQ(Http::CodecClient::Type::HTTP2, health_checker_->codecClientType());
 }
 
+class TestProdHttpHealthChecker : public ProdHttpHealthCheckerImpl {
+  public:
+  using ProdHttpHealthCheckerImpl::ProdHttpHealthCheckerImpl;
+
+  std::unique_ptr<Http::CodecClient> createCodecClientForTest(std::unique_ptr<Network::ClientConnection>&& connection) {
+    Upstream::Host::CreateConnectionData data;
+    data.connection_ = std::move(connection);
+    data.host_description_ = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+    return std::unique_ptr<Http::CodecClient>(createCodecClient(data));
+  }
+};
+
+class ProdHttpHealthCheckerTest : public HttpHealthCheckerImplTest {
+  public:
+  void setupNoServiceValidationHCWithHttp2() {
+    const std::string yaml = R"EOF(
+    timeout: 1s
+    interval: 1s
+    no_traffic_interval: 5s
+    interval_jitter: 1s
+    unhealthy_threshold: 2
+    healthy_threshold: 2
+    http_health_check:
+      service_name: locations
+      path: /healthcheck
+      use_http2: true
+    )EOF";
+
+    health_checker_.reset(new TestProdHttpHealthChecker(*cluster_, parseHealthCheckFromV2Yaml(yaml),
+                                                        dispatcher_, runtime_, random_));
+    health_checker_->addHostCheckCompleteCb(
+        [this](HostSharedPtr host, HealthTransition changed_state) -> void {
+          onHostStatus(host, changed_state);
+        });
+  }
+
+  void setupNoServiceValidationHC() {
+    const std::string yaml = R"EOF(
+    timeout: 1s
+    interval: 1s
+    no_traffic_interval: 5s
+    interval_jitter: 1s
+    unhealthy_threshold: 2
+    healthy_threshold: 2
+    http_health_check:
+      service_name: locations
+      path: /healthcheck
+    )EOF";
+
+    health_checker_.reset(new TestProdHttpHealthChecker(*cluster_, parseHealthCheckFromV2Yaml(yaml),
+                                                        dispatcher_, runtime_, random_));
+    health_checker_->addHostCheckCompleteCb(
+        [this](HostSharedPtr host, HealthTransition changed_state) -> void {
+          onHostStatus(host, changed_state);
+        });
+  }
+
+  std::unique_ptr<Network::MockClientConnection> connection_ = std::make_unique<Network::MockClientConnection>();
+  std::shared_ptr<TestProdHttpHealthChecker> health_checker_;
+};
+
+TEST_F(ProdHttpHealthCheckerTest, ProdHttpHealthCheckerH1HealthChecking) {
+  EXPECT_CALL(*connection_, connect());
+  EXPECT_CALL(*connection_, detectEarlyCloseWhenReadDisabled(_));
+  EXPECT_CALL(*connection_, addConnectionCallbacks(_));
+  EXPECT_CALL(*connection_, addReadFilter(_));
+  EXPECT_CALL(*connection_, noDelay(_));
+  EXPECT_CALL(*connection_, bufferLimit());
+
+  setupNoServiceValidationHC();
+  EXPECT_EQ(Http::CodecClient::Type::HTTP1, health_checker_->createCodecClientForTest(std::move(connection_))->type());
+}
+
+TEST_F(ProdHttpHealthCheckerTest, ProdHttpHealthCheckerH2HealthChecking) {
+  EXPECT_CALL(*connection_, connect());
+  EXPECT_CALL(*connection_, detectEarlyCloseWhenReadDisabled(_));
+  EXPECT_CALL(*connection_, addConnectionCallbacks(_));
+  EXPECT_CALL(*connection_, addReadFilter(_));
+  EXPECT_CALL(*connection_, noDelay(_));
+
+  setupNoServiceValidationHCWithHttp2();
+  EXPECT_EQ(Http::CodecClient::Type::HTTP2, health_checker_->createCodecClientForTest(std::move(connection_))->type());
+}
+
 TEST(TcpHealthCheckMatcher, loadJsonBytes) {
   {
     Protobuf::RepeatedPtrField<envoy::api::v2::core::HealthCheck::Payload> repeated_payload;


### PR DESCRIPTION
This adds an option to the http health checking config to use http/2 for the health checking connection.

*Risk Level*: Low, new opt in functionality
*Testing*: Added unit test verifying that the correct code client is selected
*Docs Changes*: N/A
*Release Notes*: Added release note explaining change in behavior

Fixes #3452
