### PR TITLE
mongo_proxy: fix peak/peek typo

### DIFF
--- a/source/extensions/filters/network/mongo_proxy/bson_impl.cc
+++ b/source/extensions/filters/network/mongo_proxy/bson_impl.cc
@@ -16,7 +16,7 @@ namespace NetworkFilters {
 namespace MongoProxy {
 namespace Bson {
 
-int32_t BufferHelper::peakInt32(Buffer::Instance& data) {
+int32_t BufferHelper::peekInt32(Buffer::Instance& data) {
   if (data.length() < sizeof(int32_t)) {
     throw EnvoyException("invalid buffer size");
   }
@@ -77,7 +77,7 @@ double BufferHelper::removeDouble(Buffer::Instance& data) {
 }
 
 int32_t BufferHelper::removeInt32(Buffer::Instance& data) {
-  int32_t ret = peakInt32(data);
+  int32_t ret = peekInt32(data);
   data.drain(sizeof(int32_t));
   return ret;
 }

--- a/source/extensions/filters/network/mongo_proxy/bson_impl.h
+++ b/source/extensions/filters/network/mongo_proxy/bson_impl.h
@@ -22,7 +22,7 @@ namespace Bson {
  */
 class BufferHelper {
 public:
-  static int32_t peakInt32(Buffer::Instance& data);
+  static int32_t peekInt32(Buffer::Instance& data);
   static uint8_t removeByte(Buffer::Instance& data);
   static void removeBytes(Buffer::Instance& data, uint8_t* out, size_t out_len);
   static std::string removeCString(Buffer::Instance& data);

--- a/source/extensions/filters/network/mongo_proxy/codec_impl.cc
+++ b/source/extensions/filters/network/mongo_proxy/codec_impl.cc
@@ -349,7 +349,7 @@ bool DecoderImpl::decode(Buffer::Instance& data) {
     return false;
   }
 
-  uint32_t message_length = Bson::BufferHelper::peakInt32(data);
+  uint32_t message_length = Bson::BufferHelper::peekInt32(data);
   ENVOY_LOG(trace, "message is {} bytes", message_length);
   if (data.length() < message_length) {
     return false;

--- a/test/extensions/filters/network/mongo_proxy/bson_impl_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/bson_impl_test.cc
@@ -55,7 +55,7 @@ TEST(BsonImplTest, InvalodDocumentTermination) {
 TEST(BufferHelperTest, InvalidSize) {
   {
     Buffer::OwnedImpl buffer;
-    EXPECT_THROW(BufferHelper::peakInt32(buffer), EnvoyException);
+    EXPECT_THROW(BufferHelper::peekInt32(buffer), EnvoyException);
     EXPECT_THROW(BufferHelper::removeByte(buffer), EnvoyException);
     EXPECT_THROW(BufferHelper::removeBytes(buffer, nullptr, 1), EnvoyException);
     EXPECT_THROW(BufferHelper::removeCString(buffer), EnvoyException);


### PR DESCRIPTION
Noticed this typo the other day.

*Risk Level*: Low
*Testing*: n/a
*Release Notes*: n/a
Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
