### PR TITLE
router: gRPC retry on 'unavailable' status

### DIFF
--- a/docs/root/configuration/http_filters/router_filter.rst
+++ b/docs/root/configuration/http_filters/router_filter.rst
@@ -126,6 +126,9 @@ deadline-exceeded
 resource-exhausted
   Envoy will attempt a retry if the gRPC status code in the response headers is "resource-exhausted" (8)
 
+unavailable
+  Envoy will attempt a retry if the gRPC status code in the response headers is "unavailable" (14)
+
 As with the x-envoy-retry-grpc-on header, the number of retries can be controlled via the
 :ref:`config_http_filters_router_x-envoy-max-retries` header
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -94,6 +94,8 @@ Version history
 * router: added a :ref:`configuration option
   <envoy_api_field_config.filter.http.router.v2.Router.suppress_envoy_headers>` to disable *x-envoy-*
   header generation.
+* router: added 'unavailable' to the retriable gRPC status codes that can be specified
+  through :ref:`x-envoy-retry-grpc-on <config_http_filters_router_x-envoy-retry-grpc-on>`
 * sockets: added :ref:`capture transport socket extension <operations_traffic_capture>` to support
   recording plain text traffic and PCAP generation.
 * sockets: added `IP_FREEBIND` socket option support for :ref:`listeners

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -144,6 +144,7 @@ public:
   static const uint32_t RETRY_ON_GRPC_CANCELLED          = 0x20;
   static const uint32_t RETRY_ON_GRPC_DEADLINE_EXCEEDED  = 0x40;
   static const uint32_t RETRY_ON_GRPC_RESOURCE_EXHAUSTED = 0x80;
+  static const uint32_t RETRY_ON_GRPC_UNAVAILABLE        = 0x100;
   // clang-format on
 
   virtual ~RetryPolicy() {}

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -145,6 +145,7 @@ public:
     const std::string Cancelled{"cancelled"};
     const std::string DeadlineExceeded{"deadline-exceeded"};
     const std::string ResourceExhausted{"resource-exhausted"};
+    const std::string Unavailable{"unavailable"};
   } EnvoyRetryOnGrpcValues;
 
   struct {

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -223,6 +223,20 @@ TEST_F(RouterRetryStateImplTest, PolicyGrpcResourceExhausted) {
   EXPECT_EQ(RetryStatus::No, state_->shouldRetry(&response_headers, no_reset_, callback_));
 }
 
+TEST_F(RouterRetryStateImplTest, PolicyGrpcUnavilable) {
+  Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-grpc-on", "unavailable"}};
+  setup(request_headers);
+  EXPECT_TRUE(state_->enabled());
+
+  Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"grpc-status", "14"}};
+  expectTimerCreateAndEnable();
+  EXPECT_EQ(RetryStatus::Yes, state_->shouldRetry(&response_headers, no_reset_, callback_));
+  EXPECT_CALL(callback_ready_, ready());
+  retry_timer_->callback_();
+
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(&response_headers, no_reset_, callback_));
+}
+
 TEST_F(RouterRetryStateImplTest, Policy5xxRemote200RemoteReset) {
   // Don't retry after reply start.
   Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "5xx"}};


### PR DESCRIPTION
Adding gRPC unavailable (14) status code to the retriable gRPC errors, e.g.
```
x-envoy-retry-grpc-on: unavailable
```

Rationale - from the Go gRPC implementation:
> Unavailable indicates the service is currently unavailable. This is a most likely a transient condition and may be corrected by retrying with a backoff.

*Risk Level*: Low
*Testing*: Unit test