### PR TITLE
bots: add skeleton for stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,41 +1,39 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
-# Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 7
+# Pull request specific configuration
+pulls:
+  # Number of days of inactivity before an Issue or Pull Request becomes stale
+  daysUntilStale: 7
+  # Number of days of inactivity before a stale Issue or Pull Request is closed.
+  # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+  daysUntilClose: 7
+  # Label to use when marking as stale
+  staleLabel: stale
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    activity in the last 7 days. It will be closed if no further activity occurs. Please
+    feel free to give a status update now, ping for review, or re-open when it's ready.
+    Thank you for your contributions!
+  # Comment to post when closing a stale Issue or Pull Request.
+  closeComment: >
+     This pull request has been automatically closed because it has not had
+     activity in the last 14 days. Please feel free to give a status update now, ping for review, or re-open when it's ready.
+     Thank you for your contributions!
+  # Limit the number of actions per hour, from 1-30. Default is 30
+  limitPerRun: 1
 
-# Number of days of inactivity before a stale Issue or Pull Request is closed.
-# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 7
-
-# Label to use when marking as stale
-staleLabel: stale
-
-# Comment to post when marking as stale. Set to `false` to disable
-markComment: >
-  This pull request has been automatically marked as stale because it has not had
-  activity in the last 7 days. It will be closed if no further activity occurs. Please
-  feel free to give a status update now, ping for review, or re-open when it's ready.
-  Thank you for your contributions!
-
-# Comment to post when removing the stale label.
-# unmarkComment: >
-#   Your comment here.
-
-# Comment to post when closing a stale Issue or Pull Request.
-#closeComment: >
-#   Your comment here.
-
-# Limit the number of actions per hour, from 1-30. Default is 30
-limitPerRun: 1
-
-# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# Pull request specific configuration
 issues:
   daysUntilStale: 30
+  daysUntilClose: 7
   markComment: >
     This issue has been automatically marked as stale because it has not had activity in the
     last 30 days. It will be closed unless it is tagged "help wanted" or other activity
     occurs. Thank you for your contributions.
-
- issues:
-   exemptLabels:
-     - help wanted
+  closeComment: >
+    This issue has been automatically closed because it has not had activity in the
+    last 30 days. If this issue is still valid, please ping a maintainer and ask them to label it as "help wanted".
+    Thank you for your contributions.
+  exemptLabels:
+    - help wanted

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,7 +12,7 @@ pulls:
   # Comment to post when marking as stale. Set to `false` to disable
   markComment: >
     This pull request has been automatically marked as stale because it has not had
-    activity in 7 days. It will be closed if no further activity occurs. Please
+    activity in the last 7 days. It will be closed in 7 days if not further activity occurs. Please
     feel free to give a status update now, ping for review, or re-open when it's ready.
     Thank you for your contributions!
   # Comment to post when closing a stale Issue or Pull Request.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -39,3 +39,4 @@ issues:
  issues:
    exemptLabels:
      - help wanted
+     - tech debt

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,41 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 7
+
+# Number of days of inactivity before a stale Issue or Pull Request is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This pull request has been automatically marked as stale because it has not had
+  activity in the last 7 days. It will be closed if no further activity occurs. Please
+  feel free to give a status update now, ping for review, or re-open when it's ready.
+  Thank you for your contributions!
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+#closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 1
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+issues:
+  daysUntilStale: 30
+  markComment: >
+    This issue has been automatically marked as stale because it has not had activity in the
+    last 30 days. It will be closed unless it is tagged "help wanted" or other activity
+    occurs. Thank you for your contributions.
+
+ issues:
+   exemptLabels:
+     - help wanted

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -39,4 +39,3 @@ issues:
  issues:
    exemptLabels:
      - help wanted
-     - tech debt

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,7 +12,7 @@ pulls:
   # Comment to post when marking as stale. Set to `false` to disable
   markComment: >
     This pull request has been automatically marked as stale because it has not had
-    activity in the last 7 days. It will be closed if no further activity occurs. Please
+    activity in 7 days. It will be closed if no further activity occurs. Please
     feel free to give a status update now, ping for review, or re-open when it's ready.
     Thank you for your contributions!
   # Comment to post when closing a stale Issue or Pull Request.
@@ -23,17 +23,19 @@ pulls:
   # Limit the number of actions per hour, from 1-30. Default is 30
   limitPerRun: 1
 
-# Pull request specific configuration
+# Issue specific configuration
 issues:
+  # TODO: Consider increasing the limitPerRun once we are satisfied with the bot's performance
+  limitPerRun: 1
   daysUntilStale: 30
   daysUntilClose: 7
   markComment: >
     This issue has been automatically marked as stale because it has not had activity in the
-    last 30 days. It will be closed unless it is tagged "help wanted" or other activity
+    last 30 days. It will be closed in the next 7 days unless it is tagged "help wanted" or other activity
     occurs. Thank you for your contributions.
   closeComment: >
     This issue has been automatically closed because it has not had activity in the
-    last 30 days. If this issue is still valid, please ping a maintainer and ask them to label it as "help wanted".
+    last 37 days. If this issue is still valid, please ping a maintainer and ask them to label it as "help wanted".
     Thank you for your contributions.
   exemptLabels:
     - help wanted

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,7 +12,7 @@ pulls:
   # Comment to post when marking as stale. Set to `false` to disable
   markComment: >
     This pull request has been automatically marked as stale because it has not had
-    activity in the last 7 days. It will be closed in 7 days if not further activity occurs. Please
+    activity in the last 7 days. It will be closed in 7 days if no further activity occurs. Please
     feel free to give a status update now, ping for review, or re-open when it's ready.
     Thank you for your contributions!
   # Comment to post when closing a stale Issue or Pull Request.


### PR DESCRIPTION
*title*:
bots: add skeleton for stalebot

*Description*:
This probot app integration will mark stale issues and PRs after 7
days. It should then close them after another 7 days. The help wanted
label will be ignored for now.

*Risk Level*: Low | Medium | High
Medium: Has power to close PRs/Issues , but should be ingnoring `help wanted` label

>Note: It isn’t expected to do all
forms of testing, please use your best judgement or ask for guidance
if you are unsure. A good rule of thumb is the riskier the change, the
more comprehensive the testing should be.

*Docs Changes*:
N/A

Related #2797 