### PR TITLE
[WIP, POC] Add PolicyEnforcementMode to RBAC policy definition

### DIFF
--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -170,9 +170,6 @@ message RemoteJwks {
   // Duration after which the cached JWKS should be expired. If not specified, default cache
   // duration is 5 minutes.
   google.protobuf.Duration cache_duration = 2;
-
-  // The JWT public key content.
-  string jwt_pubkey = 3;
 }
 
 // This message specifies a header location to extract JWT token.

--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -170,6 +170,9 @@ message RemoteJwks {
   // Duration after which the cached JWKS should be expired. If not specified, default cache
   // duration is 5 minutes.
   google.protobuf.Duration cache_duration = 2;
+
+  // The JWT public key content.
+  string jwt_pubkey = 3;
 }
 
 // This message specifies a header location to extract JWT token.

--- a/api/envoy/config/rbac/v2alpha/rbac.proto
+++ b/api/envoy/config/rbac/v2alpha/rbac.proto
@@ -67,6 +67,14 @@ message RBAC {
   map<string, Policy> policies = 2;
 }
 
+// Policy enforcement mode, used to verify a new policy work as expected before rolling to prod.
+// RBAC filter results running from policies in dark launch mode, and discards result before return
+// to the user.
+enum PolicyEnforcementMode {
+  POLICY_ENFORCEMENT_ENFORCED = 0;
+  POLICY_ENFORCEMENT_DARKLAUNCH = 1;
+}
+
 // Policy specifies a role and the principals that are assigned/denied the role. A policy matches if
 // and only if at least one of its permissions match the action taking place AND at least one of its
 // principals match the downstream.
@@ -80,6 +88,9 @@ message Policy {
   // principal is matched with OR semantics. To match all downstreams for this policy, a single
   // Principal with the `any` field set to true should be used.
   repeated Principal principals = 2 [(validate.rules).repeated .min_items = 1];
+
+  // Indicates the policy enforcement mode.
+  PolicyEnforcementMode mode = 3;
 }
 
 // Permission defines an action (or actions) that a principal can take.

--- a/source/extensions/filters/common/rbac/engine.h
+++ b/source/extensions/filters/common/rbac/engine.h
@@ -24,8 +24,8 @@ public:
    * @param headers    the headers of the incoming request used to identify the action/principal. An
    *                   empty map should be used if there are no headers available.
    */
-  virtual bool allowed(const Network::Connection& connection,
-                       const Envoy::Http::HeaderMap& headers) const PURE;
+  virtual bool allowed(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
+                       bool& darklaunch_allowed) const PURE;
 };
 
 } // namespace RBAC

--- a/source/extensions/filters/common/rbac/engine_impl.h
+++ b/source/extensions/filters/common/rbac/engine_impl.h
@@ -18,8 +18,8 @@ public:
   RoleBasedAccessControlEngineImpl(
       const envoy::config::filter::http::rbac::v2::RBACPerRoute& per_route_config);
 
-  bool allowed(const Network::Connection& connection,
-               const Envoy::Http::HeaderMap& headers) const override;
+  bool allowed(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
+               bool& darklaunch_allowed) const override;
 
 private:
   // Indicates that the engine will not evaluate an action and just return true for calls to

--- a/source/extensions/filters/common/rbac/matchers.cc
+++ b/source/extensions/filters/common/rbac/matchers.cc
@@ -133,6 +133,7 @@ bool PolicyMatcher::matches(const Network::Connection& connection,
   return permissions_.matches(connection, headers) && principals_.matches(connection, headers);
 }
 
+envoy::config::rbac::v2alpha::PolicyEnforcementMode PolicyMatcher::mode() const { return mode_; }
 } // namespace RBAC
 } // namespace Common
 } // namespace Filters

--- a/source/extensions/filters/common/rbac/matchers.h
+++ b/source/extensions/filters/common/rbac/matchers.h
@@ -161,14 +161,18 @@ private:
 class PolicyMatcher : public Matcher {
 public:
   PolicyMatcher(const envoy::config::rbac::v2alpha::Policy& policy)
-      : permissions_(policy.permissions()), principals_(policy.principals()) {}
+      : permissions_(policy.permissions()), principals_(policy.principals()), mode_(policy.mode()) {
+  }
 
   bool matches(const Network::Connection& connection,
                const Envoy::Http::HeaderMap& headers) const override;
 
+  envoy::config::rbac::v2alpha::PolicyEnforcementMode mode() const;
+
 private:
   const OrMatcher permissions_;
   const OrMatcher principals_;
+  const envoy::config::rbac::v2alpha::PolicyEnforcementMode mode_;
 };
 
 } // namespace RBAC

--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -44,7 +44,16 @@ Http::FilterHeadersStatus RoleBasedAccessControlFilter::decodeHeaders(Http::Head
   const Filters::Common::RBAC::RoleBasedAccessControlEngine& engine =
       config_->engine(callbacks_->route());
 
-  if (engine.allowed(*callbacks_->connection(), headers)) {
+  bool darklaunch_allowed;
+  bool enforcement_allowed = engine.allowed(*callbacks_->connection(), headers, darklaunch_allowed);
+
+  if (darklaunch_allowed) {
+    config_->stats().darklaunch_allowed_.inc();
+  } else {
+    config_->stats().darklaunch_denied_.inc();
+  }
+
+  if (enforcement_allowed) {
     config_->stats().allowed_.inc();
     return Http::FilterHeadersStatus::Continue;
   }

--- a/source/extensions/filters/http/rbac/rbac_filter.h
+++ b/source/extensions/filters/http/rbac/rbac_filter.h
@@ -19,7 +19,9 @@ namespace RBACFilter {
 // clang-format off
 #define ALL_RBAC_FILTER_STATS(COUNTER)                                                             \
   COUNTER(allowed)                                                                                 \
-  COUNTER(denied)
+  COUNTER(denied)                                                                                  \
+  COUNTER(darklaunch_allowed)                                                                                 \
+  COUNTER(darklaunch_denied)                                                                                  \
 // clang-format on
 
 /**

--- a/test/extensions/filters/common/rbac/engine_impl_test.cc
+++ b/test/extensions/filters/common/rbac/engine_impl_test.cc
@@ -22,8 +22,9 @@ namespace {
 
 void checkEngine(const RBAC::RoleBasedAccessControlEngineImpl& engine, bool expected,
                  const Envoy::Network::Connection& connection = Envoy::Network::MockConnection(),
-                 const Envoy::Http::HeaderMap& headers = Envoy::Http::HeaderMapImpl()) {
-  EXPECT_EQ(expected, engine.allowed(connection, headers));
+                 const Envoy::Http::HeaderMap& headers = Envoy::Http::HeaderMapImpl(),
+                 bool darkallowed = true) {
+  EXPECT_EQ(expected, engine.allowed(connection, headers, darkallowed));
 }
 
 TEST(RoleBasedAccessControlEngineImpl, Disabled) {

--- a/test/extensions/filters/common/rbac/mocks.h
+++ b/test/extensions/filters/common/rbac/mocks.h
@@ -15,8 +15,8 @@ public:
   MockEngine();
   virtual ~MockEngine();
 
-  MOCK_CONST_METHOD2(allowed,
-                     bool(const Envoy::Network::Connection&, const Envoy::Http::HeaderMap&));
+  MOCK_CONST_METHOD3(allowed, bool(const Envoy::Network::Connection&, const Envoy::Http::HeaderMap&,
+                                   bool& darklaunch_allowed));
 };
 
 } // namespace RBAC

--- a/test/extensions/filters/http/rbac/rbac_filter_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_test.cc
@@ -89,7 +89,7 @@ TEST_F(RoleBasedAccessControlFilterTest, RouteLocalOverride) {
   setDestinationPort(456, 0);
 
   NiceMock<Filters::Common::RBAC::MockEngine> engine;
-  EXPECT_CALL(engine, allowed(_, _)).WillOnce(Return(true));
+  EXPECT_CALL(engine, allowed(_, _, _)).WillOnce(Return(true));
   EXPECT_CALL(callbacks_.route_->route_entry_, perFilterConfig(HttpFilterNames::get().RBAC))
       .WillRepeatedly(Return(&engine));
 


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/issues/3552 

Updated POC PR: https://github.com/envoyproxy/envoy/pull/3554 

Use case:  
rbac policy dark launch - test new rbac policies work as expected before it's rolled out to production, policy in dark_launch mode won't effect real users, rbac filter just log the results by applying policies and sending metrics to some metrics store/then build dashboard. 