### PR TITLE
tls: require trusted_ca when using verify_subject_alt_name.

### DIFF
--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -191,6 +191,12 @@ message CertificateValidationContext {
 
   // An optional list of Subject Alternative Names. If specified, Envoy will verify that the
   // Subject Alternative Name of the presented certificate matches one of the specified values.
+  //
+  // .. attention::
+  //
+  //   Subject Alternative Names are easily spoofable and verifying only them is insecure,
+  //   therefore this option must be used together with :ref:`trusted_ca
+  //   <envoy_api_field_auth.CertificateValidationContext.trusted_ca>`.
   repeated string verify_subject_alt_name = 4;
 
   // [#not-implemented-hide:] Must present a signed time-stamped OCSP response.

--- a/configs/envoy_double_proxy.template.json
+++ b/configs/envoy_double_proxy.template.json
@@ -130,6 +130,7 @@
       "ssl_context": {
         "cert_chain_file": "certs/clientcert.pem",
         "private_key_file": "certs/clientkey.pem",
+        "ca_cert_file": "certs/cacert.pem",
         "verify_subject_alt_name": ["front-proxy.yourcompany.net"]
       },
       "hosts": [{"url": "tcp://front-proxy.yourcompany.net:9400"}]

--- a/source/common/ssl/context_config_impl.cc
+++ b/source/common/ssl/context_config_impl.cc
@@ -67,9 +67,16 @@ ContextConfigImpl::ContextConfigImpl(const envoy::api::v2::auth::CommonTlsContex
           tlsVersionFromProto(config.tls_params().tls_minimum_protocol_version(), TLS1_VERSION)),
       max_protocol_version_(
           tlsVersionFromProto(config.tls_params().tls_maximum_protocol_version(), TLS1_2_VERSION)) {
-  if (ca_cert_.empty() && !certificate_revocation_list_.empty()) {
-    throw EnvoyException(fmt::format("Failed to load CRL from {} without trusted CA certificates",
-                                     certificateRevocationListPath()));
+  if (ca_cert_.empty()) {
+    if (!certificate_revocation_list_.empty()) {
+      throw EnvoyException(fmt::format("Failed to load CRL from {} without trusted CA",
+                                       certificateRevocationListPath()));
+    }
+    if (!verify_subject_alt_name_list_.empty()) {
+      throw EnvoyException(fmt::format("SAN-based verification of peer certificates without "
+                                       "trusted CA is insecure and not allowed",
+                                       certificateRevocationListPath()));
+    }
   }
 }
 

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -329,7 +329,21 @@ TEST_F(SslServerContextImplTicketTest, CRLWithNoCA) {
   )EOF";
 
   EXPECT_THROW_WITH_REGEX(loadConfigJson(json), EnvoyException,
-                          "^Failed to load CRL from .* without trusted CA certificates$");
+                          "^Failed to load CRL from .* without trusted CA$");
+}
+
+TEST_F(SslServerContextImplTicketTest, VerifySanWithNoCA) {
+  std::string json = R"EOF(
+  {
+    "cert_chain_file": "{{ test_rundir }}/test/common/ssl/test_data/san_dns_cert.pem",
+    "private_key_file": "{{ test_rundir }}/test/common/ssl/test_data/san_dns_key.pem",
+    "verify_subject_alt_name": [ "spiffe://lyft.com/testclient" ]
+  }
+  )EOF";
+
+  EXPECT_THROW_WITH_MESSAGE(loadConfigJson(json), EnvoyException,
+                            "SAN-based verification of peer certificates without trusted CA "
+                            "is insecure and not allowed");
 }
 
 // Validate that empty SNI (according to C string rules) fails config validation.


### PR DESCRIPTION
SAN-based verification without trusted CA is insecure, since provided
values are easily spoofable.

Becasue of how the existing verification code is structured, this was
already enforced at run-time, and all certificates were rejected when
trusted CA wasn't specified, but previously it wasn't obvious why.

*Risk Level*: None
*Testing*: bazel test //test/...
*Docs Changes*: Added
*Release Notes*: n/a

Fixes #1268.