### PR TITLE
upstream: original dst cluster support for host override header

### DIFF
--- a/docs/root/configuration/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/cluster_manager/cluster_stats.rst
@@ -201,6 +201,7 @@ the following statistics:
   lb_local_cluster_not_ok, Counter, Local host set is not set or it is panic mode for local cluster
   lb_zone_number_differs, Counter, Number of zones in local and upstream cluster different
   lb_zone_no_capacity_left, Counter, Total number of times ended with random zone selection due to rounding error
+  original_dst_host_invalid, Counter, Total number of invalid hosts passed to original destination load balancer
 
 Load balancer subset statistics
 -------------------------------

--- a/docs/root/intro/arch_overview/load_balancing.rst
+++ b/docs/root/intro/arch_overview/load_balancing.rst
@@ -108,8 +108,8 @@ destination address of the incoming connection was before the connection was red
 Envoy. New destinations are added to the cluster by the load balancer on-demand, and the cluster
 :ref:`periodically <config_cluster_manager_cluster_cleanup_interval_ms>` cleans out unused hosts
 from the cluster. No other :ref:`load balancing type <config_cluster_manager_cluster_lb_type>` can
-be used with original destination clusters. Upstream host selection can also be overrided on a per
-request by specifying the host ip address in the header ``x-envoy-original-dst-override-host``.
+be used with original destination clusters. Upstream host selection can also be overriden on a per
+request basis by specifying the host ip address in the header ``x-envoy-original-dst-override-host``.
 
 .. _arch_overview_load_balancing_panic_threshold:
 

--- a/docs/root/intro/arch_overview/load_balancing.rst
+++ b/docs/root/intro/arch_overview/load_balancing.rst
@@ -108,7 +108,8 @@ destination address of the incoming connection was before the connection was red
 Envoy. New destinations are added to the cluster by the load balancer on-demand, and the cluster
 :ref:`periodically <config_cluster_manager_cluster_cleanup_interval_ms>` cleans out unused hosts
 from the cluster. No other :ref:`load balancing type <config_cluster_manager_cluster_lb_type>` can
-be used with original destination clusters.
+be used with original destination clusters. Upstream host selection can also be overrided on a per
+request by specifying the host ip address in the header ``x-envoy-original-dst-override-host``.
 
 .. _arch_overview_load_balancing_panic_threshold:
 

--- a/docs/root/intro/arch_overview/load_balancing.rst
+++ b/docs/root/intro/arch_overview/load_balancing.rst
@@ -99,7 +99,7 @@ towards the host in the set that comes after a failed host.
 .. _arch_overview_load_balancing_types_original_destination:
 
 Original destination
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 This is a special purpose load balancer that can only be used with :ref:`an original destination
 cluster <arch_overview_service_discovery_types_original_destination>`. Upstream host is selected
@@ -108,9 +108,16 @@ destination address of the incoming connection was before the connection was red
 Envoy. New destinations are added to the cluster by the load balancer on-demand, and the cluster
 :ref:`periodically <config_cluster_manager_cluster_cleanup_interval_ms>` cleans out unused hosts
 from the cluster. No other :ref:`load balancing type <config_cluster_manager_cluster_lb_type>` can
-be used with original destination clusters. Envoy can pick up the original destination either from 
-the kernel or from a HTTP header called ``x-envoy-original-destination-host``. Please note that
-fully resolved IP address should be passed in this header.
+be used with original destination clusters.
+
+.. _arch_overview_load_balancing_types_original_destination_request_header:
+
+Original destination host request header
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Envoy can also pick up the original destination from a HTTP header called ``x-envoy-original-destination-host``. 
+Please note that fully resolved IP address should be passed in this header. For example if a request has to be
+routed to a host with IP address 10.195.16.237 at port 8888, the request header value should be set as
+``10.195.16.237:8888``.
 
 .. _arch_overview_load_balancing_panic_threshold:
 

--- a/docs/root/intro/arch_overview/load_balancing.rst
+++ b/docs/root/intro/arch_overview/load_balancing.rst
@@ -109,7 +109,8 @@ Envoy. New destinations are added to the cluster by the load balancer on-demand,
 :ref:`periodically <config_cluster_manager_cluster_cleanup_interval_ms>` cleans out unused hosts
 from the cluster. No other :ref:`load balancing type <config_cluster_manager_cluster_lb_type>` can
 be used with original destination clusters. Envoy can pick up the original destination either from 
-the kernel or from a HTTP header called ``x-envoy-original-destination-host``.
+the kernel or from a HTTP header called ``x-envoy-original-destination-host``. Please note that
+fully resolved IP address should be passed in this header.
 
 .. _arch_overview_load_balancing_panic_threshold:
 

--- a/docs/root/intro/arch_overview/load_balancing.rst
+++ b/docs/root/intro/arch_overview/load_balancing.rst
@@ -108,8 +108,8 @@ destination address of the incoming connection was before the connection was red
 Envoy. New destinations are added to the cluster by the load balancer on-demand, and the cluster
 :ref:`periodically <config_cluster_manager_cluster_cleanup_interval_ms>` cleans out unused hosts
 from the cluster. No other :ref:`load balancing type <config_cluster_manager_cluster_lb_type>` can
-be used with original destination clusters. Upstream host selection can also be overriden on a per
-request basis by specifying the host ip address in the header ``x-envoy-original-dst-override-host``.
+be used with original destination clusters. Envoy can pick up the original destination either from 
+the kernel or from a HTTP header called ``x-envoy-original-destination-host``.
 
 .. _arch_overview_load_balancing_panic_threshold:
 

--- a/docs/root/intro/arch_overview/service_discovery.rst
+++ b/docs/root/intro/arch_overview/service_discovery.rst
@@ -59,14 +59,14 @@ Original destination
 Original destination cluster can be used when incoming connections are redirected to Envoy either
 via an iptables REDIRECT or TPROXY target or with Proxy Protocol. In these cases requests routed
 to an original destination cluster are forwarded to upstream hosts as addressed by the redirection
-metadata, without any explicit host configuration or upstream host discovery. Envoy can pick up 
-the original destination either from the kernel or from a HTTP header called ``x-envoy-original-destination-host``.
+metadata, without any explicit host configuration or upstream host discovery. 
 Connections to upstream hosts are pooled and unused hosts are flushed out when they have been idle longer than
 :ref:`cleanup_interval_ms <config_cluster_manager_cluster_cleanup_interval_ms>`, which defaults to
 5000ms. If the original destination address is is not available, no upstream connection is opened.
+Envoy can also pickup the original destination from a :ref:`HTTP header 
+<arch_overview_load_balancing_types_original_destination_request_header>`.
 Original destination service discovery must be used with the original destination :ref:`load
-balancer <arch_overview_load_balancing_types_original_destination>`. Please note that
-fully resolved IP address should be passed in this header.
+balancer <arch_overview_load_balancing_types_original_destination>`. 
 
 .. _arch_overview_service_discovery_types_sds:
 

--- a/docs/root/intro/arch_overview/service_discovery.rst
+++ b/docs/root/intro/arch_overview/service_discovery.rst
@@ -57,14 +57,14 @@ Original destination
 ^^^^^^^^^^^^^^^^^^^^
 
 Original destination cluster can be used when incoming connections are redirected to Envoy either
-via an iptables REDIRECT or TPROXY target or with Proxy Protocol. In these cases requests routed
-to an original destination cluster are forwarded to upstream hosts as addressed by the redirection
-metadata, without any explicit host configuration or upstream host discovery. Connections to
-upstream hosts are pooled and unused hosts are flushed out when they have been idle longer than
-:ref:`*cleanup_interval_ms* <config_cluster_manager_cluster_cleanup_interval_ms>`, which defaults to
-5000ms. If the original destination address is is not available, no upstream connection is opened.
-Original destination service discovery must be used with the original destination :ref:`load
-balancer <arch_overview_load_balancing_types_original_destination>`.
+via an iptables REDIRECT or TPROXY target or with Proxy Protocol or via HTTP header called ``x-envoy-original-destination-host``. 
+In these cases requests routed to an original destination cluster are forwarded to upstream hosts
+as addressed by the redirection metadata, without any explicit host configuration or upstream host
+discovery. Connections to upstream hosts are pooled and unused hosts are flushed out when they have
+been idle longer than :ref:`cleanup_interval_ms <config_cluster_manager_cluster_cleanup_interval_ms>`, 
+which defaults to 5000ms. If the original destination address is is not available, no upstream 
+connection is opened. Original destination service discovery must be used with the original destination 
+:ref:`load balancer <arch_overview_load_balancing_types_original_destination>`.
 
 .. _arch_overview_service_discovery_types_sds:
 

--- a/docs/root/intro/arch_overview/service_discovery.rst
+++ b/docs/root/intro/arch_overview/service_discovery.rst
@@ -57,14 +57,15 @@ Original destination
 ^^^^^^^^^^^^^^^^^^^^
 
 Original destination cluster can be used when incoming connections are redirected to Envoy either
-via an iptables REDIRECT or TPROXY target or with Proxy Protocol or via HTTP header called ``x-envoy-original-destination-host``. 
-In these cases requests routed to an original destination cluster are forwarded to upstream hosts
-as addressed by the redirection metadata, without any explicit host configuration or upstream host
-discovery. Connections to upstream hosts are pooled and unused hosts are flushed out when they have
-been idle longer than :ref:`cleanup_interval_ms <config_cluster_manager_cluster_cleanup_interval_ms>`, 
-which defaults to 5000ms. If the original destination address is is not available, no upstream 
-connection is opened. Original destination service discovery must be used with the original destination 
-:ref:`load balancer <arch_overview_load_balancing_types_original_destination>`.
+via an iptables REDIRECT or TPROXY target or with Proxy Protocol. In these cases requests routed
+to an original destination cluster are forwarded to upstream hosts as addressed by the redirection
+metadata, without any explicit host configuration or upstream host discovery. Envoy can pick up 
+the original destination either from the kernel or from a HTTP header called ``x-envoy-original-destination-host``.
+Connections to upstream hosts are pooled and unused hosts are flushed out when they have been idle longer than
+:ref:`cleanup_interval_ms <config_cluster_manager_cluster_cleanup_interval_ms>`, which defaults to
+5000ms. If the original destination address is is not available, no upstream connection is opened.
+Original destination service discovery must be used with the original destination :ref:`load
+balancer <arch_overview_load_balancing_types_original_destination>`.
 
 .. _arch_overview_service_discovery_types_sds:
 

--- a/docs/root/intro/arch_overview/service_discovery.rst
+++ b/docs/root/intro/arch_overview/service_discovery.rst
@@ -65,7 +65,8 @@ Connections to upstream hosts are pooled and unused hosts are flushed out when t
 :ref:`cleanup_interval_ms <config_cluster_manager_cluster_cleanup_interval_ms>`, which defaults to
 5000ms. If the original destination address is is not available, no upstream connection is opened.
 Original destination service discovery must be used with the original destination :ref:`load
-balancer <arch_overview_load_balancing_types_original_destination>`.
+balancer <arch_overview_load_balancing_types_original_destination>`. Please note that
+fully resolved IP address should be passed in this header.
 
 .. _arch_overview_service_discovery_types_sds:
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -101,7 +101,7 @@ Version history
   is supplied with the client request, its value will override any sampling decision made by the Envoy proxy.
 * websocket: support configuring
   :ref:`idle_timeout and max_connect_attempts <envoy_api_field_route.RouteAction.websocket_config>`.
-* upstream: added support for host override for a request in Original Destination Cluster.
+* upstream: added support for host override for a request in :ref:`Original Destination Cluster <arch_overview_load_balancing_types_original_destination>`.
 
 1.6.0 (March 20, 2018)
 ======================

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -101,6 +101,7 @@ Version history
   is supplied with the client request, its value will override any sampling decision made by the Envoy proxy.
 * websocket: support configuring
   :ref:`idle_timeout and max_connect_attempts <envoy_api_field_route.RouteAction.websocket_config>`.
+* upstream: added support for host override for a request in Original Destination Cluster.
 
 1.6.0 (March 20, 2018)
 ======================

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -101,7 +101,7 @@ Version history
   is supplied with the client request, its value will override any sampling decision made by the Envoy proxy.
 * websocket: support configuring
   :ref:`idle_timeout and max_connect_attempts <envoy_api_field_route.RouteAction.websocket_config>`.
-* upstream: added support for host override for a request in :ref:`Original Destination Cluster <arch_overview_load_balancing_types_original_destination>`.
+* upstream: added support for host override for a request in :ref:`Original destination host request header <arch_overview_load_balancing_types_original_destination_request_header>`.
 
 1.6.0 (March 20, 2018)
 ======================

--- a/include/envoy/upstream/load_balancer.h
+++ b/include/envoy/upstream/load_balancer.h
@@ -42,7 +42,7 @@ public:
    * @return const Http::HeaderMap* the incoming headers or nullptr to use during load
    * balancing.
    */
-  virtual const Http::HeaderMap* downStreamHeaders() const PURE;
+  virtual const Http::HeaderMap* downstreamHeaders() const PURE;
 };
 
 /**

--- a/include/envoy/upstream/load_balancer.h
+++ b/include/envoy/upstream/load_balancer.h
@@ -37,6 +37,12 @@ public:
    * balancing.
    */
   virtual const Network::Connection* downstreamConnection() const PURE;
+
+  /**
+   * @return const Http::HeaderMap* the incoming headers or nullptr to use during load
+   * balancing.
+   */
+  virtual const Http::HeaderMap* downStreamHeaders() const PURE;
 };
 
 /**

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -304,6 +304,7 @@ public:
   COUNTER  (lb_subsets_removed)                                                                    \
   COUNTER  (lb_subsets_selected)                                                                   \
   COUNTER  (lb_subsets_fallback)                                                                   \
+  COUNTER  (original_dst_host_invalid)                                                             \
   COUNTER  (upstream_cx_total)                                                                     \
   GAUGE    (upstream_cx_active)                                                                    \
   COUNTER  (upstream_cx_http1_total)                                                               \

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -41,6 +41,7 @@ public:
   const LowerCaseString EnvoyInternalRequest{"x-envoy-internal"};
   const LowerCaseString EnvoyIpTags{"x-envoy-ip-tags"};
   const LowerCaseString EnvoyMaxRetries{"x-envoy-max-retries"};
+  const LowerCaseString EnvoyOriginalDstHost{"x-envoy-original-dst-host"};
   const LowerCaseString EnvoyOriginalPath{"x-envoy-original-path"};
   const LowerCaseString EnvoyOverloaded{"x-envoy-overloaded"};
   const LowerCaseString EnvoyRetryOn{"x-envoy-retry-on"};
@@ -92,7 +93,6 @@ public:
   const LowerCaseString XB3Flags{"x-b3-flags"};
   const LowerCaseString XContentTypeOptions{"x-content-type-options"};
   const LowerCaseString XSquashDebug{"x-squash-debug"};
-  const LowerCaseString OriginalDstHostOverride{"x-envoy-original-dst-override-host"};
 
   struct {
     const std::string Close{"close"};

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -92,6 +92,7 @@ public:
   const LowerCaseString XB3Flags{"x-b3-flags"};
   const LowerCaseString XContentTypeOptions{"x-content-type-options"};
   const LowerCaseString XSquashDebug{"x-squash-debug"};
+  const LowerCaseString OriginalDstHostOverride{"x-envoy-original-dst-override-host"};
 
   struct {
     const std::string Close{"close"};

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -214,6 +214,15 @@ public:
     return cookie_value;
   }
 
+  std::string downStreamHeader(const std::string& key) {
+    const Http::LowerCaseString header_key{key};
+    std::string header_value;
+    if (downstream_headers_ != nullptr && downstream_headers_->get(header_key) != nullptr) {
+      header_value = downstream_headers_->get(header_key)->value().c_str();
+    }
+    return header_value;
+  }
+
 protected:
   RetryStatePtr retry_state_;
 

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -191,6 +191,7 @@ public:
   const Network::Connection* downstreamConnection() const override {
     return callbacks_->connection();
   }
+  const Http::HeaderMap* downStreamHeaders() const override { return downstream_headers_; }
 
   /**
    * Set a computed cookie to be sent with the downstream headers.
@@ -212,15 +213,6 @@ public:
     downstream_set_cookies_.emplace_back(
         Http::Utility::makeSetCookieValue(key, cookie_value, max_age));
     return cookie_value;
-  }
-
-  std::string downStreamHeader(const std::string& key) {
-    const Http::LowerCaseString header_key{key};
-    std::string header_value;
-    if (downstream_headers_ != nullptr && downstream_headers_->get(header_key) != nullptr) {
-      header_value = downstream_headers_->get(header_key)->value().c_str();
-    }
-    return header_value;
   }
 
 protected:

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -191,7 +191,7 @@ public:
   const Network::Connection* downstreamConnection() const override {
     return callbacks_->connection();
   }
-  const Http::HeaderMap* downStreamHeaders() const override { return downstream_headers_; }
+  const Http::HeaderMap* downstreamHeaders() const override { return downstream_headers_; }
 
   /**
    * Set a computed cookie to be sent with the downstream headers.

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -159,6 +159,8 @@ public:
     return &read_callbacks_->connection();
   }
 
+  const Http::HeaderMap* downStreamHeaders() const override { return nullptr; }
+
   // These two functions allow enabling/disabling reads on the upstream and downstream connections.
   // They are called by the Downstream/Upstream Watermark callbacks to limit buffering.
   void readDisableUpstream(bool disable);

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -159,7 +159,7 @@ public:
     return &read_callbacks_->connection();
   }
 
-  const Http::HeaderMap* downStreamHeaders() const override { return nullptr; }
+  const Http::HeaderMap* downstreamHeaders() const override { return nullptr; }
 
   // These two functions allow enabling/disabling reads on the upstream and downstream connections.
   // They are called by the Downstream/Upstream Watermark callbacks to limit buffering.

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -193,6 +193,7 @@ envoy_cc_library(
         "//source/common/common:empty_string",
         "//source/common/network:address_lib",
         "//source/common/network:utility_lib",
+        "//source/common/router:router_lib",
     ],
 )
 

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -193,7 +193,6 @@ envoy_cc_library(
         "//source/common/common:empty_string",
         "//source/common/network:address_lib",
         "//source/common/network:utility_lib",
-        "//source/common/router:router_lib",
     ],
 )
 

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -116,7 +116,7 @@ OriginalDstCluster::LoadBalancer::requestOverrideHost(LoadBalancerContext* conte
       ENVOY_LOG(debug, "Using request override host {}.", request_override_host);
     } catch (const Envoy::EnvoyException& e) {
       ENVOY_LOG(debug, "original_dst_load_balancer: invalid override header value. {}", e.what());
-      parent_.lock()->info_->stats().original_dst_host_invalid_.inc();
+      info_->stats().original_dst_host_invalid_.inc();
     }
   }
   return request_host;

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -27,7 +27,7 @@ OriginalDstCluster::LoadBalancer::LoadBalancer(PrioritySet& priority_set, Cluste
   priority_set_.addMemberUpdateCb(
       [this](uint32_t, const HostVector& hosts_added, const HostVector& hosts_removed) -> void {
         // Update the hosts map
-        //TODO(ramaraochavali): use cluster stats and move the log lines to debug.
+        // TODO(ramaraochavali): use cluster stats and move the log lines to debug.
         for (const HostSharedPtr& host : hosts_removed) {
           ENVOY_LOG(debug, "Removing host {}.", host->address()->asString());
           host_map_.remove(host);
@@ -98,7 +98,7 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
       }
     }
   }
-  //TODO(ramaraochavali): add a stat and move this log line to debug.
+  // TODO(ramaraochavali): add a stat and move this log line to debug.
   ENVOY_LOG(warn, "original_dst_load_balancer: No downstream connection or no original_dst.");
   return nullptr;
 }

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -27,6 +27,7 @@ OriginalDstCluster::LoadBalancer::LoadBalancer(PrioritySet& priority_set, Cluste
   priority_set_.addMemberUpdateCb(
       [this](uint32_t, const HostVector& hosts_added, const HostVector& hosts_removed) -> void {
         // Update the hosts map
+        //TODO(ramaraochavali): use cluster stats and move the log lines to debug.
         for (const HostSharedPtr& host : hosts_removed) {
           ENVOY_LOG(debug, "Removing host {}.", host->address()->asString());
           host_map_.remove(host);
@@ -97,7 +98,7 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
       }
     }
   }
-
+  //TODO(ramaraochavali): add a stat and move this log line to debug.
   ENVOY_LOG(warn, "original_dst_load_balancer: No downstream connection or no original_dst.");
   return nullptr;
 }
@@ -115,6 +116,7 @@ OriginalDstCluster::LoadBalancer::requestOverrideHost(LoadBalancerContext* conte
       ENVOY_LOG(debug, "Using request override host {}.", request_override_host);
     } catch (const Envoy::EnvoyException& e) {
       ENVOY_LOG(debug, "original_dst_load_balancer: invalid override header value. {}", e.what());
+      parent_.lock()->info_->stats().original_dst_host_invalid_.inc();
     }
   }
   return request_host;

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -50,17 +50,14 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
       try {
         Network::Address::InstanceConstSharedPtr overridehost_ip_port(
             Network::Utility::parseInternetAddressAndPort(request_override_host, false));
-        ENVOY_LOG(info, "Using request override host {}.", request_override_host);
+        ENVOY_LOG(debug, "Using request override host {}.", request_override_host);
         return HostSharedPtr{new HostImpl(
             info_, info_->name() + overridehost_ip_port->asString(),
             std::move(overridehost_ip_port), envoy::api::v2::core::Metadata::default_instance(), 1,
             envoy::api::v2::core::Locality().default_instance(),
             envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance())};
       } catch (const Envoy::EnvoyException& e) {
-        ENVOY_LOG(
-            warn,
-            "original_dst_load_balancer: Override header exists but has malformed ip address. {}",
-            e.what());
+        ENVOY_LOG(warn, "original_dst_load_balancer: invalid override header value. {}", e.what());
       }
     }
 

--- a/source/common/upstream/original_dst_cluster.h
+++ b/source/common/upstream/original_dst_cluster.h
@@ -91,6 +91,8 @@ public:
       std::unordered_multimap<std::string, HostSharedPtr> map_;
     };
 
+    Network::Address::InstanceConstSharedPtr requestOverrideHost(LoadBalancerContext* context);
+
     PrioritySet& priority_set_;                // Thread local priority set.
     std::weak_ptr<OriginalDstCluster> parent_; // Primary cluster managed by the main thread.
     ClusterInfoConstSharedPtr info_;

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
@@ -168,7 +168,7 @@ private:
     absl::optional<uint64_t> computeHashKey() override { return hash_key_; }
     const Router::MetadataMatchCriteria* metadataMatchCriteria() override { return nullptr; }
     const Network::Connection* downstreamConnection() const override { return nullptr; }
-    const Http::HeaderMap* downStreamHeaders() const override { return nullptr; }
+    const Http::HeaderMap* downstreamHeaders() const override { return nullptr; }
 
     const absl::optional<uint64_t> hash_key_;
   };

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
@@ -168,6 +168,7 @@ private:
     absl::optional<uint64_t> computeHashKey() override { return hash_key_; }
     const Router::MetadataMatchCriteria* metadataMatchCriteria() override { return nullptr; }
     const Network::Connection* downstreamConnection() const override { return nullptr; }
+    const Http::HeaderMap* downStreamHeaders() const override { return nullptr; }
 
     const absl::optional<uint64_t> hash_key_;
   };

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -103,7 +103,7 @@ public:
   absl::optional<uint64_t> computeHashKey() override { return hash_key_; }
   const Router::MetadataMatchCriteria* metadataMatchCriteria() override { return nullptr; }
   const Network::Connection* downstreamConnection() const override { return nullptr; }
-  const Http::HeaderMap* downStreamHeaders() const override { return nullptr; }
+  const Http::HeaderMap* downstreamHeaders() const override { return nullptr; }
 
   absl::optional<uint64_t> hash_key_;
 };

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -103,6 +103,7 @@ public:
   absl::optional<uint64_t> computeHashKey() override { return hash_key_; }
   const Router::MetadataMatchCriteria* metadataMatchCriteria() override { return nullptr; }
   const Network::Connection* downstreamConnection() const override { return nullptr; }
+  const Http::HeaderMap* downStreamHeaders() const override { return nullptr; }
 
   absl::optional<uint64_t> hash_key_;
 };

--- a/test/common/upstream/maglev_lb_test.cc
+++ b/test/common/upstream/maglev_lb_test.cc
@@ -14,7 +14,7 @@ public:
   absl::optional<uint64_t> computeHashKey() override { return hash_key_; }
   const Router::MetadataMatchCriteria* metadataMatchCriteria() override { return nullptr; }
   const Network::Connection* downstreamConnection() const override { return nullptr; }
-  const Http::HeaderMap* downStreamHeaders() const override { return nullptr; }
+  const Http::HeaderMap* downstreamHeaders() const override { return nullptr; }
 
   absl::optional<uint64_t> hash_key_;
 };

--- a/test/common/upstream/maglev_lb_test.cc
+++ b/test/common/upstream/maglev_lb_test.cc
@@ -14,6 +14,7 @@ public:
   absl::optional<uint64_t> computeHashKey() override { return hash_key_; }
   const Router::MetadataMatchCriteria* metadataMatchCriteria() override { return nullptr; }
   const Network::Connection* downstreamConnection() const override { return nullptr; }
+  const Http::HeaderMap* downStreamHeaders() const override { return nullptr; }
 
   absl::optional<uint64_t> hash_key_;
 };

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -37,17 +37,17 @@ public:
   TestLoadBalancerContext(const Network::Connection* connection, const std::string& key,
                           const std::string& value)
       : connection_(connection) {
-    downstream_headers_ = new Http::TestHeaderMapImpl{{key, value}};
+    downstream_headers_ = Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{key, value}}};
   }
 
   // Upstream::LoadBalancerContext
   absl::optional<uint64_t> computeHashKey() override { return 0; }
   const Network::Connection* downstreamConnection() const override { return connection_; }
   const Router::MetadataMatchCriteria* metadataMatchCriteria() override { return nullptr; }
-  const Http::HeaderMap* downStreamHeaders() const override { return downstream_headers_; }
+  const Http::HeaderMap* downStreamHeaders() const override { return downstream_headers_.get(); }
   absl::optional<uint64_t> hash_key_;
   const Network::Connection* connection_;
-  Http::HeaderMap* downstream_headers_{};
+  Http::HeaderMapPtr downstream_headers_;
 };
 
 class OriginalDstClusterTest : public testing::Test {
@@ -165,6 +165,16 @@ TEST_F(OriginalDstClusterTest, NoContext) {
     EXPECT_CALL(dispatcher_, post(_)).Times(0);
     HostConstSharedPtr host = lb.chooseHost(&lb_context);
     EXPECT_EQ("127.0.0.1:5555", host->address()->asString());
+  }
+
+  // Request host override empty ip => no host.
+  {
+    TestLoadBalancerContext lb_context(nullptr, Http::Headers::get().OriginalDstHostOverride.get(),
+                                       "");
+    OriginalDstCluster::LoadBalancer lb(cluster_->prioritySet(), cluster_);
+    EXPECT_CALL(dispatcher_, post(_)).Times(0);
+    HostConstSharedPtr host = lb.chooseHost(&lb_context);
+    EXPECT_EQ(host, nullptr);
   }
 
   // Downstream connection is not using original dst => no host.

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -176,7 +176,9 @@ TEST_F(OriginalDstClusterTest, NoContext) {
     EXPECT_CALL(dispatcher_, post(_)).Times(0);
     HostConstSharedPtr host = lb.chooseHost(&lb_context);
     EXPECT_EQ(host, nullptr);
-    EXPECT_EQ(1, TestUtility::findCounter(stats_store_, "cluster.name.original_dst_host_invalid")->value());
+    EXPECT_EQ(
+        1,
+        TestUtility::findCounter(stats_store_, "cluster.name.original_dst_host_invalid")->value());
   }
 
   // Request host override malformed ip => no host.
@@ -187,7 +189,9 @@ TEST_F(OriginalDstClusterTest, NoContext) {
     EXPECT_CALL(dispatcher_, post(_)).Times(0);
     HostConstSharedPtr host = lb.chooseHost(&lb_context);
     EXPECT_EQ(host, nullptr);
-    EXPECT_EQ(2, TestUtility::findCounter(stats_store_, "cluster.name.original_dst_host_invalid")->value());
+    EXPECT_EQ(
+        2,
+        TestUtility::findCounter(stats_store_, "cluster.name.original_dst_host_invalid")->value());
   }
 
   // Downstream connection is not using original dst => no host.

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -176,6 +176,7 @@ TEST_F(OriginalDstClusterTest, NoContext) {
     EXPECT_CALL(dispatcher_, post(_)).Times(0);
     HostConstSharedPtr host = lb.chooseHost(&lb_context);
     EXPECT_EQ(host, nullptr);
+    EXPECT_EQ(1, TestUtility::findCounter(stats_store_, "cluster.name.original_dst_host_invalid")->value());
   }
 
   // Request host override malformed ip => no host.
@@ -186,6 +187,7 @@ TEST_F(OriginalDstClusterTest, NoContext) {
     EXPECT_CALL(dispatcher_, post(_)).Times(0);
     HostConstSharedPtr host = lb.chooseHost(&lb_context);
     EXPECT_EQ(host, nullptr);
+    EXPECT_EQ(2, TestUtility::findCounter(stats_store_, "cluster.name.original_dst_host_invalid")->value());
   }
 
   // Downstream connection is not using original dst => no host.

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -30,7 +30,7 @@ public:
   absl::optional<uint64_t> computeHashKey() override { return hash_key_; }
   const Router::MetadataMatchCriteria* metadataMatchCriteria() override { return nullptr; }
   const Network::Connection* downstreamConnection() const override { return nullptr; }
-  const Http::HeaderMap* downStreamHeaders() const override { return nullptr; }
+  const Http::HeaderMap* downstreamHeaders() const override { return nullptr; }
 
   absl::optional<uint64_t> hash_key_;
 };

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -30,6 +30,7 @@ public:
   absl::optional<uint64_t> computeHashKey() override { return hash_key_; }
   const Router::MetadataMatchCriteria* metadataMatchCriteria() override { return nullptr; }
   const Network::Connection* downstreamConnection() const override { return nullptr; }
+  const Http::HeaderMap* downStreamHeaders() const override { return nullptr; }
 
   absl::optional<uint64_t> hash_key_;
 };

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -98,6 +98,7 @@ public:
   absl::optional<uint64_t> computeHashKey() override { return {}; }
   const Network::Connection* downstreamConnection() const override { return nullptr; }
   const Router::MetadataMatchCriteria* metadataMatchCriteria() override { return matches_.get(); }
+  const Http::HeaderMap* downStreamHeaders() const override { return nullptr; }
 
 private:
   const std::shared_ptr<Router::MetadataMatchCriteria> matches_;

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -98,7 +98,7 @@ public:
   absl::optional<uint64_t> computeHashKey() override { return {}; }
   const Network::Connection* downstreamConnection() const override { return nullptr; }
   const Router::MetadataMatchCriteria* metadataMatchCriteria() override { return matches_.get(); }
-  const Http::HeaderMap* downStreamHeaders() const override { return nullptr; }
+  const Http::HeaderMap* downstreamHeaders() const override { return nullptr; }
 
 private:
   const std::shared_ptr<Router::MetadataMatchCriteria> matches_;


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*:
Supports the ability to route a request to a given host (specified in header) using original dst cluster
*Risk Level*: Low 
*Testing*: Automated and Manual
*Docs Changes*: Updated
*Release Notes*: Updated
