### PR TITLE
debug: improving stack traces

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -161,10 +161,11 @@ bazel test //test/common/http:async_client_impl_test --strategy=TestRunner=stand
 
 Envoy can produce backtraces on demand and from assertions and other fatal
 actions like segfaults. Where supported, stack traces will contain resolved
-symbols. On systems where absl::Symbolization is not supported, the stack
-traces written in the log or to stderr contain addresses rather than resolved symbols.
-The `tools/stack_decode.py` script exists to process the output and do symbol resolution
-to make the stack traces useful. Any log lines not relevant to the backtrace capability
+symbols, though not include line numbers. On systems where absl::Symbolization is
+not supported, the stack traces written in the log or to stderr contain addresses rather
+than resolved symbols. The `tools/stack_decode.py` script exists to process the output
+and do symbol resolution including line numbers, to make the stack traces useful.
+Any log lines not relevant to the backtrace capability
 are passed through the script unchanged (it acts like a filter).
 
 The script runs in one of two modes. If passed no arguments it anticipates

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -160,11 +160,12 @@ bazel test //test/common/http:async_client_impl_test --strategy=TestRunner=stand
 # Stack trace symbol resolution
 
 Envoy can produce backtraces on demand and from assertions and other fatal
-actions like segfaults. The stack traces written in the log or to stderr contain
-addresses rather than resolved symbols. The `tools/stack_decode.py` script exists
-to process the output and do symbol resolution to make the stack traces useful. Any
-log lines not relevant to the backtrace capability are passed through the script unchanged
-(it acts like a filter).
+actions like segfaults. Where supported, stack traces will contain resolved
+symbols. On systems where absl::Symbolization is not supported, the stack
+traces written in the log or to stderr contain addresses rather than resolved symbols.
+The `tools/stack_decode.py` script exists to process the output and do symbol resolution
+to make the stack traces useful. Any log lines not relevant to the backtrace capability
+are passed through the script unchanged (it acts like a filter).
 
 The script runs in one of two modes. If passed no arguments it anticipates
 Envoy (or test) output on stdin. You can postprocess a log or pipe the output of

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -407,6 +407,10 @@ def _com_google_absl():
         name = "abseil_synchronization",
         actual = "@com_google_absl//absl/synchronization:synchronization",
     )
+    native.bind(
+        name = "abseil_symbolize",
+        actual = "@com_google_absl//absl/debugging:symbolize",
+    )
 
 def _com_google_protobuf():
     _repository_impl("com_google_protobuf")

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -31,6 +31,7 @@ Version history
 * cluster: Add :ref:`option <envoy_api_field_Cluster.drain_connections_on_host_removal>` to drain
   connections from hosts after they are removed from service discovery, regardless of health status.
 * cluster: fixed bug preventing the deletion of all endpoints in a priority
+* debug: added symbolized stack traces (where supported)
 * health check: added ability to set :ref:`additional HTTP headers
   <envoy_api_field_core.HealthCheck.HttpHealthCheck.request_headers_to_add>` for HTTP health check.
 * health check: added support for EDS delivered :ref:`endpoint health status

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -12,7 +12,10 @@ envoy_package()
 envoy_cc_library(
     name = "backtrace_lib",
     hdrs = ["backtrace.h"],
-    external_deps = ["backward"],
+    external_deps = [
+        "backward",
+        "abseil_symbolize",
+    ],
     tags = ["backtrace"],
     deps = ["//source/common/common:minimal_logger_lib"],
 )

--- a/source/server/backtrace.h
+++ b/source/server/backtrace.h
@@ -111,9 +111,11 @@ public:
 #else
 
       if (absl::Symbolize(stack_trace_[i].addr, out, 200)) {
-        ENVOY_LOG(critical, "thr<{}> #{} {}", thread_id, stack_trace_[i].idx, out);
+        ENVOY_LOG(critical, "thr<{}> #{} {} {}", thread_id, stack_trace_[i].idx,
+                  stack_trace_[i].addr, out);
       } else {
-        ENVOY_LOG(critical, "thr<{}> #{} {}", thread_id, stack_trace_[i].idx, stack_trace_[i].addr);
+        ENVOY_LOG(critical, "thr<{}> #{} (unknown)", thread_id, stack_trace_[i].idx,
+                  stack_trace_[i].addr);
       }
 #endif
     }

--- a/source/server/backtrace.h
+++ b/source/server/backtrace.h
@@ -106,7 +106,7 @@ public:
 
 #ifdef __APPLE__
       // In the absence of stack_decode.py, print the function name.
-      ENVOY_LOG(critical, "thr<{}> #{} {}: {}", thread_id, stack_trace_[i].idx,
+      ENVOY_LOG(critical, "thr<{}> #{} {} {}", thread_id, stack_trace_[i].idx,
                 stack_trace_[i].addr, trace.object_function);
 #else
       if (absl::Symbolize(stack_trace_[i].addr, out, sizeof(out))) {

--- a/source/server/backtrace.h
+++ b/source/server/backtrace.h
@@ -106,8 +106,8 @@ public:
 
 #ifdef __APPLE__
       // In the absence of stack_decode.py, print the function name.
-      ENVOY_LOG(critical, "thr<{}> #{} {} {}", thread_id, stack_trace_[i].idx,
-                stack_trace_[i].addr, trace.object_function);
+      ENVOY_LOG(critical, "thr<{}> #{} {} {}", thread_id, stack_trace_[i].idx, stack_trace_[i].addr,
+                trace.object_function);
 #else
       if (absl::Symbolize(stack_trace_[i].addr, out, sizeof(out))) {
         ENVOY_LOG(critical, "thr<{}> #{} {} {}", thread_id, stack_trace_[i].idx,

--- a/source/server/backtrace.h
+++ b/source/server/backtrace.h
@@ -86,12 +86,12 @@ public:
 #ifdef __APPLE__
     // The stack_decode.py script uses addr2line which isn't readily available and doesn't seem to
     // work when installed.
-    ENVOY_LOG(critical, "Backtrace obj<{}> thr<{}>:", obj_name, thread_id);
+    ENVOY_LOG(critical, "Backtrace thr<{}> obj<{}>:", thread_id, obj_name);
 #else
     char out[200];
     ENVOY_LOG(critical,
-              "Backtrace obj<{}> thr<{}> (If unsymbolized, use tools/stack_decode.py):", obj_name,
-              thread_id);
+              "Backtrace thr<{}> obj<{}> (If unsymbolized, use tools/stack_decode.py):", thread_id,
+              obj_name);
 #endif
 
     // Backtrace gets tagged by ASAN when we try the object name resolution for the last
@@ -109,12 +109,11 @@ public:
       ENVOY_LOG(critical, "thr<{}> #{} {}: {}", thread_id, stack_trace_[i].idx,
                 stack_trace_[i].addr, trace.object_function);
 #else
-
-      if (absl::Symbolize(stack_trace_[i].addr, out, 200)) {
+      if (absl::Symbolize(stack_trace_[i].addr, out, sizeof(out))) {
         ENVOY_LOG(critical, "thr<{}> #{} {} {}", thread_id, stack_trace_[i].idx,
                   stack_trace_[i].addr, out);
       } else {
-        ENVOY_LOG(critical, "thr<{}> #{} (unknown)", thread_id, stack_trace_[i].idx,
+        ENVOY_LOG(critical, "thr<{}> #{} {} (unknown)", thread_id, stack_trace_[i].idx,
                   stack_trace_[i].addr);
       }
 #endif

--- a/source/server/backtrace.h
+++ b/source/server/backtrace.h
@@ -88,6 +88,7 @@ public:
     // work when installed.
     ENVOY_LOG(critical, "Backtrace obj<{}> thr<{}>:", obj_name, thread_id);
 #else
+    char out[200];
     ENVOY_LOG(critical,
               "Backtrace obj<{}> thr<{}> (If unsymbolized, use tools/stack_decode.py):", obj_name,
               thread_id);
@@ -95,7 +96,6 @@ public:
 
     // Backtrace gets tagged by ASAN when we try the object name resolution for the last
     // frame on stack, so skip the last one. It has no useful info anyway.
-    char out[200];
 
     for (unsigned int i = 0; i < stack_trace_.size() - 1; ++i) {
       backward::ResolvedTrace trace = resolver.resolve(stack_trace_[i]);

--- a/tools/stack_decode.py
+++ b/tools/stack_decode.py
@@ -29,7 +29,7 @@ def decode_stacktrace_log(input_source):
   # bazel-out/local-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:84]
   backtrace_marker = "\[backtrace\] [^\s]+"
   trace_begin_re = re.compile(
-      "^(.+)%s Backtrace thr<(\d+).*obj<(.+)>" % backtrace_marker)
+      "^(.+)%s Backtrace thr<(\d+)> obj<(.+)>" % backtrace_marker)
   stackaddr_re = re.compile("%s thr<(\d+)> #\d+ (0x[0-9a-fA-F]+) " % backtrace_marker)
   new_object_re = re.compile("%s thr<(\d+)> obj<(.+)>$" % backtrace_marker)
   trace_end_re = re.compile("%s end backtrace thread (\d+)" % backtrace_marker)

--- a/tools/stack_decode.py
+++ b/tools/stack_decode.py
@@ -29,7 +29,7 @@ def decode_stacktrace_log(input_source):
   # bazel-out/local-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:84]
   backtrace_marker = "\[backtrace\] [^\s]+"
   trace_begin_re = re.compile(
-      "^(.+)%s Backtrace obj<(.+)> thr<(\d+)" % backtrace_marker)
+      "^(.+)%s Backtrace thr<(\d+).*obj<(.+)>" % backtrace_marker)
   stackaddr_re = re.compile("%s thr<(\d+)> #\d+ (0x[0-9a-fA-F]+) " % backtrace_marker)
   new_object_re = re.compile("%s thr<(\d+)> obj<(.+)>$" % backtrace_marker)
   trace_end_re = re.compile("%s end backtrace thread (\d+)" % backtrace_marker)
@@ -42,7 +42,7 @@ def decode_stacktrace_log(input_source):
         return  # EOF
       begin_trace_match = trace_begin_re.search(line)
       if begin_trace_match:
-        log_prefix, objfile, thread_id = begin_trace_match.groups()
+        log_prefix, thread_id, objfile = begin_trace_match.groups()
         traces[thread_id] = Backtrace(log_prefix=log_prefix, obj_list=[])
         traces[thread_id].obj_list.append(
             AddressList(obj_file=objfile, addresses=[]))

--- a/tools/stack_decode.py
+++ b/tools/stack_decode.py
@@ -30,7 +30,7 @@ def decode_stacktrace_log(input_source):
   backtrace_marker = "\[backtrace\] [^\s]+"
   trace_begin_re = re.compile(
       "^(.+)%s Backtrace obj<(.+)> thr<(\d+)" % backtrace_marker)
-  stackaddr_re = re.compile("%s thr<(\d+)> #\d+ (0x[0-9a-fA-F]+)$" % backtrace_marker)
+  stackaddr_re = re.compile("%s thr<(\d+)> #\d+ (0x[0-9a-fA-F]+) " % backtrace_marker)
   new_object_re = re.compile("%s thr<(\d+)> obj<(.+)>$" % backtrace_marker)
   trace_end_re = re.compile("%s end backtrace thread (\d+)" % backtrace_marker)
 


### PR DESCRIPTION
Dumping function names in stack traces where absl::Sybolize is supported.

before: https://pastebin.com/raw/kZihnpSK
after: https://pastebin.com/raw/XcDwcx15

*Risk Level*: Low (worst case someone gets a borked stack trace and we roll back)
*Testing*: manual: see pastebin links.
*Docs Changes*: updated current docs on stack traces
*Release Notes*: inline.