### PR TITLE
stats:added hot restart epoch stat

### DIFF
--- a/docs/root/configuration/statistics.rst
+++ b/docs/root/configuration/statistics.rst
@@ -28,7 +28,7 @@ Server related statistics are rooted at *server.* with following statistics:
   total_connections, Gauge, Total connections of both new and old Envoy processes
   version, Gauge, Integer represented version number based on SCM revision
   days_until_first_cert_expiring, Gauge, Number of days until the next certificate being managed will expire
-  hot_restart_epoch, Guage, Current hot restart epoch
+  hot_restart_epoch, Gauge, Current hot restart epoch
 
 File system
 -----------

--- a/docs/root/configuration/statistics.rst
+++ b/docs/root/configuration/statistics.rst
@@ -28,6 +28,7 @@ Server related statistics are rooted at *server.* with following statistics:
   total_connections, Gauge, Total connections of both new and old Envoy processes
   version, Gauge, Integer represented version number based on SCM revision
   days_until_first_cert_expiring, Gauge, Number of days until the next certificate being managed will expire
+  hot_restart_epoch, Guage, Current hot restart epoch
 
 File system
 -----------

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -129,6 +129,7 @@ void InstanceImpl::flushStats() {
     server_stats_->total_connections_.set(numConnections() + info.num_connections_);
     server_stats_->days_until_first_cert_expiring_.set(
         sslContextManager().daysUntilFirstCertExpires());
+    server_stats_->hot_restart_epoch_.set(options_.restartEpoch());
     InstanceUtil::flushMetricsToSinks(config_->statsSinks(), stats_store_.source());
     // TODO(ramaraochavali): consider adding different flush interval for histograms.
     if (stat_flush_timer_ != nullptr) {

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -44,7 +44,8 @@ namespace Server {
   GAUGE(parent_connections)                                                                        \
   GAUGE(total_connections)                                                                         \
   GAUGE(version)                                                                                   \
-  GAUGE(days_until_first_cert_expiring)
+  GAUGE(days_until_first_cert_expiring)                                                            \
+  GAUGE(hot_restart_epoch)
 // clang-format on
 
 struct ServerStats {

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -156,6 +156,7 @@ TEST_P(ServerInstanceImplTest, Stats) {
   options_.service_node_name_ = "some_node_name";
   initialize(std::string());
   EXPECT_NE(nullptr, TestUtility::findCounter(stats_store_, "server.watchdog_miss"));
+  EXPECT_NE(nullptr, TestUtility::findGauge(stats_store_, "server.hot_restart_epoch"));
 }
 
 // Validate server localInfo() from bootstrap Node.


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*:
Added hot restart epoch as a gauge metric
*Risk Level*: Low 
*Testing*: Current automated tests
*Docs Changes*: Updated
*Release Notes*: N/A
