### PR TITLE
INCOMPLETE: upstream: add filter chains to upstream connections (#173)

### DIFF
--- a/api/envoy/api/v2/BUILD
+++ b/api/envoy/api/v2/BUILD
@@ -72,6 +72,7 @@ api_proto_library(
         "//envoy/api/v2/core:health_check",
         "//envoy/api/v2/core:protocol",
         "//envoy/api/v2/endpoint",
+        "//envoy/api/v2/listener", # TODO(alanconway): for Filter definition
         "//envoy/type:percent",
     ],
 )

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -11,6 +11,7 @@ import "envoy/api/v2/core/config_source.proto";
 import "envoy/api/v2/discovery.proto";
 import "envoy/api/v2/core/health_check.proto";
 import "envoy/api/v2/core/protocol.proto";
+import "envoy/api/v2/listener/listener.proto"; // TODO(alanconway): for Filter definition
 import "envoy/api/v2/cluster/circuit_breaker.proto";
 import "envoy/api/v2/cluster/outlier_detection.proto";
 import "envoy/api/v2/eds.proto";
@@ -468,6 +469,11 @@ message Cluster {
   // If this flag is not set to true, Envoy will wait until the hosts fail active health
   // checking before removing it from the cluster.
   bool drain_connections_on_host_removal = 32;
+
+  // An optional list of network filters that make up the filter chain for
+  // outgoing connections made by the cluster. Order matters as the filters are
+  // processed sequentially as connection events happen.
+  repeated listener.Filter filters = 34 [(gogoproto.nullable) = false];
 }
 
 // An extensible structure containing the address Envoy should bind to when

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -534,6 +534,11 @@ public:
    *         after a host is removed from service discovery.
    */
   virtual bool drainConnectionsOnHostRemoval() const PURE;
+
+  /**
+   * Create network filters on a new upstream connection.
+   */
+  virtual void createNetworkFilters(Network::Connection& connection) const PURE;
 };
 
 typedef std::shared_ptr<const ClusterInfo> ClusterInfoConstSharedPtr;

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -361,6 +361,7 @@ envoy_cc_library(
         "//include/envoy/network:dns_interface",
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/server:transport_socket_config_interface",
+        "//include/envoy/server:filter_config_interface",
         "//include/envoy/ssl:context_manager_interface",
         "//include/envoy/thread_local:thread_local_interface",
         "//include/envoy/upstream:cluster_manager_interface",
@@ -373,6 +374,7 @@ envoy_cc_library(
         "//source/common/config:metadata_lib",
         "//source/common/stats:stats_lib",
         "//source/common/upstream:locality_lib",
+        "//source/server:configuration_lib", # TODO(alanconway): bad dependency
         "@envoy_api//envoy/api/v2/core:base_cc",
         "@envoy_api//envoy/api/v2/endpoint:endpoint_cc",
     ],

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -16,6 +16,8 @@
 #include "envoy/event/timer.h"
 #include "envoy/local_info/local_info.h"
 #include "envoy/network/dns.h"
+
+#include "envoy/network/filter.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/server/transport_socket_config.h"
 #include "envoy/ssl/context_manager.h"
@@ -307,7 +309,8 @@ private:
  * Implementation of ClusterInfo that reads from JSON.
  */
 class ClusterInfoImpl : public ClusterInfo,
-                        public Server::Configuration::TransportSocketFactoryContext {
+                        public Server::Configuration::TransportSocketFactoryContext,
+                        protected Logger::Loggable<Logger::Id::upstream> {
 public:
   ClusterInfoImpl(const envoy::api::v2::Cluster& config,
                   const envoy::api::v2::core::BindConfig& bind_config, Runtime::Loader& runtime,
@@ -362,6 +365,8 @@ public:
 
   bool drainConnectionsOnHostRemoval() const override { return drain_connections_on_host_removal_; }
 
+  void createNetworkFilters(Network::Connection&) const;
+
 private:
   struct ResourceManagers {
     ResourceManagers(const envoy::api::v2::Cluster& config, Runtime::Loader& runtime,
@@ -401,6 +406,10 @@ private:
   const envoy::api::v2::Cluster::CommonLbConfig common_lb_config_;
   const Network::ConnectionSocket::OptionsSharedPtr cluster_socket_options_;
   const bool drain_connections_on_host_removal_;
+
+  class FactoryContextImpl;
+  std::unique_ptr<FactoryContextImpl> factory_context_;
+  std::vector<Network::FilterFactoryCb> filter_factories_;
 };
 
 /**


### PR DESCRIPTION
This is an initial pull request for review, it is not yet or ready to merge.

It is working for https://github.com/alanconway/envoy-amqp but has (at least)
the following issues:

1. The upstream uses a dummy NOT_IMPLEMENTED FactoryContext. FactoryContext has
   listener-specific methods, I'm not sure if/how they can be implemented by a
   Cluster.

2. The "Filter" configuration is defined in listener.proto. I made cds.proto and
   upstream_impl.cc depend on listener.proto and added server:configuration_lib
   to upstream_includes.  Probably the Filter definition and related bits should
   be moved to core.

3. Need automated unit and integration tests. The code works with the AMQP filters
   but needs independent tests in the envoy repo.

There are TODO(aconway) comments at the code in question.

I would appreciate help and/or direction on how to resolve these and any other
issues that come up during review.

Signed-off-by: Alan Conway <aconway@redhat.com>