### PR TITLE
thrift: protocol callbacks

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/binary_protocol.cc
+++ b/source/extensions/filters/network/thrift_proxy/binary_protocol.cc
@@ -58,22 +58,26 @@ bool BinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, std::string&
   msg_type = type;
   seq_id = BufferHelper::drainI32(buffer);
 
+  onMessageStart(absl::string_view(name), msg_type, seq_id);
   return true;
 }
 
 bool BinaryProtocolImpl::readMessageEnd(Buffer::Instance& buffer) {
   UNREFERENCED_PARAMETER(buffer);
+  onMessageComplete();
   return true;
 }
 
 bool BinaryProtocolImpl::readStructBegin(Buffer::Instance& buffer, std::string& name) {
   UNREFERENCED_PARAMETER(buffer);
   name.clear(); // binary protocol does not transmit struct names
+  onStructBegin(absl::string_view(name));
   return true;
 }
 
 bool BinaryProtocolImpl::readStructEnd(Buffer::Instance& buffer) {
   UNREFERENCED_PARAMETER(buffer);
+  onStructEnd();
   return true;
 }
 
@@ -100,6 +104,7 @@ bool BinaryProtocolImpl::readFieldBegin(Buffer::Instance& buffer, std::string& n
   name.clear(); // binary protocol does not transmit field names
   field_type = type;
 
+  onStructField(absl::string_view(name), field_type, field_id);
   return true;
 }
 
@@ -289,8 +294,9 @@ bool LaxBinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, std::stri
 
   msg_type = type;
   seq_id = BufferHelper::peekI32(buffer, 1);
-
   buffer.drain(5);
+
+  onMessageStart(absl::string_view(name), msg_type, seq_id);
   return true;
 }
 

--- a/source/extensions/filters/network/thrift_proxy/binary_protocol.h
+++ b/source/extensions/filters/network/thrift_proxy/binary_protocol.h
@@ -16,8 +16,10 @@ namespace ThriftProxy {
  * BinaryProtocolImpl implements the Thrift Binary protocol with strict message encoding.
  * See https://github.com/apache/thrift/blob/master/doc/specs/thrift-binary-protocol.md
  */
-class BinaryProtocolImpl : public virtual Protocol {
+class BinaryProtocolImpl : public ProtocolImplBase {
 public:
+  BinaryProtocolImpl(ProtocolCallbacks& callbacks) : ProtocolImplBase(callbacks) {}
+
   // Protocol
   const std::string& name() const override { return ProtocolNames::get().BINARY; }
   bool readMessageBegin(Buffer::Instance& buffer, std::string& name, MessageType& msg_type,
@@ -56,6 +58,8 @@ private:
  */
 class LaxBinaryProtocolImpl : public BinaryProtocolImpl {
 public:
+  LaxBinaryProtocolImpl(ProtocolCallbacks& callbacks) : BinaryProtocolImpl(callbacks) {}
+
   const std::string& name() const override { return ProtocolNames::get().LAX_BINARY; }
 
   bool readMessageBegin(Buffer::Instance& buffer, std::string& name, MessageType& msg_type,

--- a/source/extensions/filters/network/thrift_proxy/compact_protocol.h
+++ b/source/extensions/filters/network/thrift_proxy/compact_protocol.h
@@ -19,8 +19,10 @@ namespace ThriftProxy {
  * CompactProtocolImpl implements the Thrift Compact protocol.
  * See https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md
  */
-class CompactProtocolImpl : public virtual Protocol {
+class CompactProtocolImpl : public ProtocolImplBase {
 public:
+  CompactProtocolImpl(ProtocolCallbacks& callbacks) : ProtocolImplBase(callbacks) {}
+
   // Protocol
   const std::string& name() const override { return ProtocolNames::get().COMPACT; }
   bool readMessageBegin(Buffer::Instance& buffer, std::string& name, MessageType& msg_type,

--- a/source/extensions/filters/network/thrift_proxy/protocol.cc
+++ b/source/extensions/filters/network/thrift_proxy/protocol.cc
@@ -26,9 +26,9 @@ bool AutoProtocolImpl::readMessageBegin(Buffer::Instance& buffer, std::string& n
 
     uint16_t version = BufferHelper::peekU16(buffer);
     if (BinaryProtocolImpl::isMagic(version)) {
-      setProtocol(std::make_unique<BinaryProtocolImpl>());
+      setProtocol(std::make_unique<BinaryProtocolImpl>(callbacks_));
     } else if (CompactProtocolImpl::isMagic(version)) {
-      setProtocol(std::make_unique<CompactProtocolImpl>());
+      setProtocol(std::make_unique<CompactProtocolImpl>(callbacks_));
     } else {
       throw EnvoyException(
           fmt::format("unknown thrift auto protocol message start {:04x}", version));

--- a/source/extensions/filters/network/thrift_proxy/protocol.h
+++ b/source/extensions/filters/network/thrift_proxy/protocol.h
@@ -79,6 +79,48 @@ enum class FieldType {
 };
 
 /**
+ * ProtocolCallbacks are Thrift protocol-level callbacks.
+ */
+class ProtocolCallbacks {
+public:
+  virtual ~ProtocolCallbacks() {}
+
+  /**
+   * Indicates that the start of a Thrift protocol message was detected.
+   * @param name the name of the message, if available
+   * @param msg_type the type of the message
+   * @param seq_id the message sequence id
+   */
+  virtual void messageStart(const absl::string_view name, MessageType msg_type,
+                            int32_t seq_id) PURE;
+
+  /**
+   * Indicates that the start of a Thrift protocol struct was detected.
+   * @param name the name of the struct, if available
+   */
+  virtual void structBegin(const absl::string_view name) PURE;
+
+  /**
+   * Indicates that a Thrift protocol struct field was detected.
+   * @param name the name of the field, if available
+   * @param field_type the type of the field
+   * @param field_id the field id
+   */
+  virtual void structField(const absl::string_view name, FieldType field_type,
+                           int16_t field_id) PURE;
+
+  /**
+   * Indicates that the end of a Thrift protocol struct was detected.
+   */
+  virtual void structEnd() PURE;
+
+  /**
+   * Indicates that the end of a Thrift protocol message was detected.
+   */
+  virtual void messageComplete() PURE;
+};
+
+/**
  * Protocol represents the operations necessary to implement the a generic Thrift protocol.
  * See https://github.com/apache/thrift/blob/master/doc/specs/thrift-protocol-spec.md
  */
@@ -301,14 +343,36 @@ public:
 
 typedef std::unique_ptr<Protocol> ProtocolPtr;
 
+/*
+ * ProtocolImplBase provides a base class for Protocol implementations.
+ */
+class ProtocolImplBase : public virtual Protocol {
+public:
+  ProtocolImplBase(ProtocolCallbacks& callbacks) : callbacks_(callbacks) {}
+
+protected:
+  void onMessageStart(const absl::string_view name, MessageType msg_type, int32_t seq_id) const {
+    callbacks_.messageStart(name, msg_type, seq_id);
+  }
+  void onStructBegin(const absl::string_view name) const { callbacks_.structBegin(name); }
+  void onStructField(const absl::string_view name, FieldType field_type, int16_t field_id) const {
+    callbacks_.structField(name, field_type, field_id);
+  }
+  void onStructEnd() const { callbacks_.structEnd(); }
+  void onMessageComplete() const { callbacks_.messageComplete(); }
+
+  ProtocolCallbacks& callbacks_;
+};
+
 /**
  * AutoProtocolImpl attempts to distinguish between the Thrift binary (strict mode only) and
  * compact protocols and then delegates subsequent decoding operations to the appropriate Protocol
  * implementation.
  */
-class AutoProtocolImpl : public virtual Protocol {
+class AutoProtocolImpl : public ProtocolImplBase {
 public:
-  AutoProtocolImpl() : Protocol(), name_(ProtocolNames::get().AUTO) {}
+  AutoProtocolImpl(ProtocolCallbacks& callbacks)
+      : ProtocolImplBase(callbacks), name_(ProtocolNames::get().AUTO) {}
 
   // Protocol
   const std::string& name() const override { return name_; }

--- a/source/extensions/filters/network/thrift_proxy/protocol.h
+++ b/source/extensions/filters/network/thrift_proxy/protocol.h
@@ -101,7 +101,7 @@ public:
   virtual void structBegin(const absl::string_view name) PURE;
 
   /**
-   * Indicates that a Thrift protocol struct field was detected.
+   * Indicates that that start of Thrift protocol struct field was detected.
    * @param name the name of the field, if available
    * @param field_type the type of the field
    * @param field_id the field id

--- a/test/extensions/filters/network/thrift_proxy/BUILD
+++ b/test/extensions/filters/network/thrift_proxy/BUILD
@@ -38,6 +38,7 @@ envoy_extension_cc_test(
     srcs = ["binary_protocol_test.cc"],
     extension_name = "envoy.filters.network.thrift_proxy",
     deps = [
+        ":mocks",
         ":utility_lib",
         "//source/extensions/filters/network/thrift_proxy:protocol_lib",
         "//test/test_common:printers_lib",
@@ -62,6 +63,7 @@ envoy_extension_cc_test(
     srcs = ["compact_protocol_test.cc"],
     extension_name = "envoy.filters.network.thrift_proxy",
     deps = [
+        ":mocks",
         ":utility_lib",
         "//source/extensions/filters/network/thrift_proxy:protocol_lib",
         "//test/test_common:printers_lib",

--- a/test/extensions/filters/network/thrift_proxy/mocks.cc
+++ b/test/extensions/filters/network/thrift_proxy/mocks.cc
@@ -12,8 +12,13 @@ namespace ThriftProxy {
 MockTransportCallbacks::MockTransportCallbacks() {}
 MockTransportCallbacks::~MockTransportCallbacks() {}
 
-MockProtocol::MockProtocol() { ON_CALL(*this, name()).WillByDefault(ReturnRef(name_)); }
+MockTransport::MockTransport() { ON_CALL(*this, name()).WillByDefault(ReturnRef(name_)); }
+MockTransport::~MockTransport() {}
 
+MockProtocolCallbacks::MockProtocolCallbacks() {}
+MockProtocolCallbacks::~MockProtocolCallbacks() {}
+
+MockProtocol::MockProtocol() { ON_CALL(*this, name()).WillByDefault(ReturnRef(name_)); }
 MockProtocol::~MockProtocol() {}
 
 } // namespace ThriftProxy

--- a/test/extensions/filters/network/thrift_proxy/mocks.h
+++ b/test/extensions/filters/network/thrift_proxy/mocks.h
@@ -22,6 +22,32 @@ public:
   MOCK_METHOD0(transportFrameComplete, void());
 };
 
+class MockTransport : public Transport {
+public:
+  MockTransport();
+  ~MockTransport();
+
+  // ThriftProxy::Transport
+  MOCK_CONST_METHOD0(name, const std::string&());
+  MOCK_METHOD1(decodeFrameStart, bool(Buffer::Instance&));
+  MOCK_METHOD1(decodeFrameEnd, bool(Buffer::Instance&));
+
+  std::string name_{"mock"};
+};
+
+class MockProtocolCallbacks : public ProtocolCallbacks {
+public:
+  MockProtocolCallbacks();
+  ~MockProtocolCallbacks();
+
+  // ThriftProxy::ProtocolCallbacks
+  MOCK_METHOD3(messageStart, void(const absl::string_view, MessageType, int32_t));
+  MOCK_METHOD1(structBegin, void(const absl::string_view));
+  MOCK_METHOD3(structField, void(const absl::string_view, FieldType, int16_t));
+  MOCK_METHOD0(structEnd, void());
+  MOCK_METHOD0(messageComplete, void());
+};
+
 class MockProtocol : public Protocol {
 public:
   MockProtocol();

--- a/test/extensions/filters/network/thrift_proxy/protocol_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/protocol_test.cc
@@ -26,7 +26,8 @@ namespace ThriftProxy {
 
 TEST(AutoProtocolTest, NotEnoughData) {
   Buffer::OwnedImpl buffer;
-  AutoProtocolImpl proto;
+  NiceMock<MockProtocolCallbacks> cb;
+  AutoProtocolImpl proto(cb);
   std::string name = "-";
   MessageType msg_type = MessageType::Oneway;
   int32_t seq_id = -1;
@@ -40,7 +41,8 @@ TEST(AutoProtocolTest, NotEnoughData) {
 
 TEST(AutoProtocolTest, UnknownProtocol) {
   Buffer::OwnedImpl buffer;
-  AutoProtocolImpl proto;
+  NiceMock<MockProtocolCallbacks> cb;
+  AutoProtocolImpl proto(cb);
   std::string name = "-";
   MessageType msg_type = MessageType::Oneway;
   int32_t seq_id = -1;
@@ -57,7 +59,8 @@ TEST(AutoProtocolTest, UnknownProtocol) {
 TEST(AutoProtocolTest, ReadMessageBegin) {
   // Binary Protocol
   {
-    AutoProtocolImpl proto;
+    NiceMock<MockProtocolCallbacks> cb;
+    AutoProtocolImpl proto(cb);
     std::string name = "-";
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = -1;
@@ -80,7 +83,8 @@ TEST(AutoProtocolTest, ReadMessageBegin) {
 
   // Compact protocol
   {
-    AutoProtocolImpl proto;
+    NiceMock<MockProtocolCallbacks> cb;
+    AutoProtocolImpl proto(cb);
     std::string name = "-";
     MessageType msg_type = MessageType::Oneway;
     int32_t seq_id = 1;
@@ -102,7 +106,8 @@ TEST(AutoProtocolTest, ReadMessageBegin) {
 
 TEST(AutoProtocolTest, Delegation) {
   NiceMock<MockProtocol>* proto = new NiceMock<MockProtocol>();
-  AutoProtocolImpl auto_proto;
+  NiceMock<MockProtocolCallbacks> dummy_cb;
+  AutoProtocolImpl auto_proto(dummy_cb);
   auto_proto.setProtocol(ProtocolPtr{proto});
 
   // readMessageBegin
@@ -226,7 +231,8 @@ TEST(AutoProtocolTest, Delegation) {
 }
 
 TEST(AutoProtocolTest, Name) {
-  AutoProtocolImpl proto;
+  NiceMock<MockProtocolCallbacks> cb;
+  AutoProtocolImpl proto(cb);
   EXPECT_EQ(proto.name(), "auto");
 }
 


### PR DESCRIPTION
Provides callbacks for Thrift Protocol events. I've provided only the events needed to allow a caller to distinguish requests and responses and to further divide those by message type (call vs oneway request, reply vs exception response) and reply type (successful reply vs IDL-defined exception).

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>

*Risk Level*: Low -- still laying groundwork for a filter
*Testing*: unit testing
*Release Notes*: n/a
*Relates to*: #2247 
