### PR TITLE
router: add support for prefix and suffix header matching

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -941,20 +941,20 @@ message HeaderMatcher {
     bool present_match = 7;
 
     // If specified, header match will be performed based on the prefix of the header value.
+    // Note: empty prefix is not allowed, please use present_match instead.
     //
     // Examples:
     //
     // * The prefix *abcd* matches the value *abcdxyz*, but not for *abcxyz*.
-    // * The empty prefix is also valid and matches any value.
-    string prefix_match = 9;
+    string prefix_match = 9 [(validate.rules).string.min_bytes = 1];
 
     // If specified, header match will be performed based on the suffix of the header value.
+    // Note: empty suffix is not allowed, please use present_match instead.
     //
     // Examples:
     //
     // * The suffix *abcd* matches the value *xyzabcd*, but not for *xyzbcd*.
-    // * The empty suffix is also valid and matches any value.
-    string suffix_match = 10;
+    string suffix_match = 10 [(validate.rules).string.min_bytes = 1];
   }
 
   // If specified, the match result will be inverted before before checking. Defaults to false.

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -939,6 +939,22 @@ message HeaderMatcher {
     // If specified, header match will be be performed based on whether the header is in the
     // request.
     bool present_match = 7;
+
+    // If specified, header match will be performed based on the prefix of the header value.
+    //
+    // Examples:
+    //
+    // * The prefix *abcd* matches the value *abcdxyz*, but not for *abcxyz*.
+    // * The empty prefix is also valid and matches any value.
+    string prefix_match = 9;
+
+    // If specified, header match will be performed based on the suffix of the header value.
+    //
+    // Examples:
+    //
+    // * The suffix *abcd* matches the value *xyzabcd*, but not for *xyzbcd*.
+    // * The empty suffix is also valid and matches any value.
+    string suffix_match = 10;
   }
 
   // If specified, the match result will be inverted before before checking. Defaults to false.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -87,6 +87,10 @@ Version history
   timeout will be ignored and the response will continue to proxy up to the global request timeout.
 * router: changed the behavior of :ref:`source IP routing <envoy_api_field_route.RouteAction.HashPolicy.ConnectionProperties.source_ip>`
   to ignore the source port.
+* router: added an :ref:`prefix_match <envoy_api_field_route.HeaderMatcher.prefix_match>` match type
+  to explicitly match based on the prefix of a header value.
+* router: added an :ref:`suffix_match <envoy_api_field_route.HeaderMatcher.suffix_match>` match type
+  to explicitly match based on the suffix of a header value.
 * router: added an :ref:`present_match <envoy_api_field_route.HeaderMatcher.present_match>` match type
   to explicitly match based on a header's presence.
 * router: added an :ref:`invert_match <envoy_api_field_route.HeaderMatcher.invert_match>` config option

--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -16,7 +16,7 @@ namespace Http {
  */
 class HeaderUtility {
 public:
-  enum class HeaderMatchType { Value, Regex, Range, Present };
+  enum class HeaderMatchType { Value, Regex, Range, Present, Prefix, Suffix };
 
   // A HeaderData specifies one of exact value or regex or range element
   // to match in a request's header, specified in the header_match_type_ member.

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -132,6 +132,34 @@ present_match: true
   EXPECT_EQ("", header_data.value_);
 }
 
+TEST(HeaderDataConstructorTest, PrefixMatchSpecifier) {
+  const std::string yaml = R"EOF(
+name: test-header
+prefix_match: value
+  )EOF";
+
+  HeaderUtility::HeaderData header_data =
+      HeaderUtility::HeaderData(parseHeaderMatcherFromYaml(yaml));
+
+  EXPECT_EQ("test-header", header_data.name_.get());
+  EXPECT_EQ(HeaderUtility::HeaderMatchType::Prefix, header_data.header_match_type_);
+  EXPECT_EQ("value", header_data.value_);
+}
+
+TEST(HeaderDataConstructorTest, SuffixMatchSpecifier) {
+  const std::string yaml = R"EOF(
+name: test-header
+suffix_match: value
+  )EOF";
+
+  HeaderUtility::HeaderData header_data =
+      HeaderUtility::HeaderData(parseHeaderMatcherFromYaml(yaml));
+
+  EXPECT_EQ("test-header", header_data.name_.get());
+  EXPECT_EQ(HeaderUtility::HeaderMatchType::Suffix, header_data.header_match_type_);
+  EXPECT_EQ("value", header_data.value_);
+}
+
 TEST(HeaderDataConstructorTest, InvertMatchSpecifier) {
   const std::string yaml = R"EOF(
 name: test-header
@@ -333,6 +361,68 @@ TEST(MatchHeadersTest, HeaderPresentInverseMatch) {
   const std::string yaml = R"EOF(
 name: match-header
 present_match: true
+invert_match: true
+  )EOF";
+
+  std::vector<HeaderUtility::HeaderData> header_data;
+  header_data.push_back(HeaderUtility::HeaderData(parseHeaderMatcherFromYaml(yaml)));
+  EXPECT_TRUE(HeaderUtility::matchHeaders(matching_headers, header_data));
+  EXPECT_FALSE(HeaderUtility::matchHeaders(unmatching_headers, header_data));
+}
+
+TEST(MatchHeadersTest, HeaderPrefixMatch) {
+  TestHeaderMapImpl matching_headers{{"match-header", "value123"}};
+  TestHeaderMapImpl unmatching_headers{{"match-header", "123value"}};
+
+  const std::string yaml = R"EOF(
+name: match-header
+prefix_match: value
+  )EOF";
+
+  std::vector<HeaderUtility::HeaderData> header_data;
+  header_data.push_back(HeaderUtility::HeaderData(parseHeaderMatcherFromYaml(yaml)));
+  EXPECT_TRUE(HeaderUtility::matchHeaders(matching_headers, header_data));
+  EXPECT_FALSE(HeaderUtility::matchHeaders(unmatching_headers, header_data));
+}
+
+TEST(MatchHeadersTest, HeaderPrefixInverseMatch) {
+  TestHeaderMapImpl unmatching_headers{{"match-header", "value123"}};
+  TestHeaderMapImpl matching_headers{{"match-header", "123value"}};
+
+  const std::string yaml = R"EOF(
+name: match-header
+prefix_match: value
+invert_match: true
+  )EOF";
+
+  std::vector<HeaderUtility::HeaderData> header_data;
+  header_data.push_back(HeaderUtility::HeaderData(parseHeaderMatcherFromYaml(yaml)));
+  EXPECT_TRUE(HeaderUtility::matchHeaders(matching_headers, header_data));
+  EXPECT_FALSE(HeaderUtility::matchHeaders(unmatching_headers, header_data));
+}
+
+TEST(MatchHeadersTest, HeaderSuffixMatch) {
+  TestHeaderMapImpl matching_headers{{"match-header", "123value"}};
+  TestHeaderMapImpl unmatching_headers{{"match-header", "value123"}};
+
+  const std::string yaml = R"EOF(
+name: match-header
+suffix_match: value
+  )EOF";
+
+  std::vector<HeaderUtility::HeaderData> header_data;
+  header_data.push_back(HeaderUtility::HeaderData(parseHeaderMatcherFromYaml(yaml)));
+  EXPECT_TRUE(HeaderUtility::matchHeaders(matching_headers, header_data));
+  EXPECT_FALSE(HeaderUtility::matchHeaders(unmatching_headers, header_data));
+}
+
+TEST(MatchHeadersTest, HeaderSuffixInverseMatch) {
+  TestHeaderMapImpl unmatching_headers{{"match-header", "123value"}};
+  TestHeaderMapImpl matching_headers{{"match-header", "value123"}};
+
+  const std::string yaml = R"EOF(
+name: match-header
+suffix_match: value
 invert_match: true
   )EOF";
 


### PR DESCRIPTION
Signed-off-by: Yangmin Zhu <ymzhu@google.com>

*Description*:
This adds `prefix` and `suffix` match in HeaderMatcher .

*Risk Level*:
Low

*Testing*:
Added unit tests.

*Docs Changes*:
Inline with proto change.

*Release Notes*:
Noted the new options.

Fixes #3563