### PR TITLE
tracing: don't sample requests classified as a health check

### DIFF
--- a/include/envoy/tracing/http_tracer.h
+++ b/include/envoy/tracing/http_tracer.h
@@ -99,6 +99,12 @@ public:
    */
   virtual SpanPtr spawnChild(const Config& config, const std::string& name,
                              SystemTime start_time) PURE;
+
+  /**
+   * Set the span's sampled flag.
+   * @param sampled whether the span and any subsequent child spans should be sampled
+   */
+  virtual void setSampled(const bool sampled) PURE;
 };
 
 /**

--- a/include/envoy/tracing/http_tracer.h
+++ b/include/envoy/tracing/http_tracer.h
@@ -101,7 +101,9 @@ public:
                              SystemTime start_time) PURE;
 
   /**
-   * Set the span's sampled flag.
+   * This method overrides any previous sampling decision associated with the trace instance.
+   * If the sampled parameter is false, this span and any subsequent child spans
+   * are not reported to the tracing system.
    * @param sampled whether the span and any subsequent child spans should be sampled
    */
   virtual void setSampled(bool sampled) PURE;

--- a/include/envoy/tracing/http_tracer.h
+++ b/include/envoy/tracing/http_tracer.h
@@ -104,7 +104,7 @@ public:
    * Set the span's sampled flag.
    * @param sampled whether the span and any subsequent child spans should be sampled
    */
-  virtual void setSampled(const bool sampled) PURE;
+  virtual void setSampled(bool sampled) PURE;
 };
 
 /**

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -387,7 +387,9 @@ ConnectionManagerImpl::ActiveStream::~ActiveStream() {
 
   if (request_info_.healthCheck()) {
     connection_manager_.config_.tracingStats().health_check_.inc();
-  } else if (active_span_) {
+  }
+
+  if (active_span_) {
     Tracing::HttpTracerUtility::finalizeSpan(*active_span_, request_headers_.get(), request_info_,
                                              *this);
   }

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -36,6 +36,7 @@ public:
   const std::string PEER_IPV6 = "peer.ipv6";
   const std::string PEER_PORT = "peer.port";
   const std::string PEER_SERVICE = "peer.service";
+  const std::string SAMPLING_PRIORITY = "sampling.priority";
   const std::string SPAN_KIND = "span.kind";
 
   // Non-standard tag names.
@@ -125,6 +126,7 @@ public:
   SpanPtr spawnChild(const Config&, const std::string&, SystemTime) override {
     return SpanPtr{new NullSpan()};
   }
+  void setSampled(const bool) override {}
 };
 
 class HttpNullTracer : public HttpTracer {

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -125,7 +125,7 @@ public:
   SpanPtr spawnChild(const Config&, const std::string&, SystemTime) override {
     return SpanPtr{new NullSpan()};
   }
-  void setSampled(const bool) override {}
+  void setSampled(bool) override {}
 };
 
 class HttpNullTracer : public HttpTracer {

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -36,7 +36,6 @@ public:
   const std::string PEER_IPV6 = "peer.ipv6";
   const std::string PEER_PORT = "peer.port";
   const std::string PEER_SERVICE = "peer.service";
-  const std::string SAMPLING_PRIORITY = "sampling.priority";
   const std::string SPAN_KIND = "span.kind";
 
   // Non-standard tag names.

--- a/source/extensions/filters/http/health_check/health_check.cc
+++ b/source/extensions/filters/http/health_check/health_check.cc
@@ -38,7 +38,12 @@ Http::FilterHeadersStatus HealthCheckFilter::decodeHeaders(Http::HeaderMap& head
     health_check_request_ = true;
     callbacks_->requestInfo().healthCheck(true);
 
-    // Hint to tracer to ignore the span and any subsequent child spans
+    // Hint to tracer to ignore the span and any subsequent child spans.
+    // Health check probes are providing an operational check to ensure that the
+    // service is performing correctly. The benefit of distributed tracing is to
+    // record the path (and latency) a business transaction takes through multiple services to
+    // help diagnose issues. Recording trace instances for health check provides
+    // limited value, but consumes resources in the tracing system.
     callbacks_->activeSpan().setSampled(false);
 
     // If we are not in pass through mode, we always handle. Otherwise, we handle if the server is

--- a/source/extensions/filters/http/health_check/health_check.cc
+++ b/source/extensions/filters/http/health_check/health_check.cc
@@ -38,6 +38,9 @@ Http::FilterHeadersStatus HealthCheckFilter::decodeHeaders(Http::HeaderMap& head
     health_check_request_ = true;
     callbacks_->requestInfo().healthCheck(true);
 
+    // Hint to tracer to ignore the span and any subsequent child spans
+    callbacks_->activeSpan().setSampled(false);
+
     // If we are not in pass through mode, we always handle. Otherwise, we handle if the server is
     // in the failed state or if we are using caching and we should use the cached response.
     if (!pass_through_mode_ || context_.healthCheckFailed() ||

--- a/source/extensions/filters/http/health_check/health_check.cc
+++ b/source/extensions/filters/http/health_check/health_check.cc
@@ -38,12 +38,10 @@ Http::FilterHeadersStatus HealthCheckFilter::decodeHeaders(Http::HeaderMap& head
     health_check_request_ = true;
     callbacks_->requestInfo().healthCheck(true);
 
-    // Hint to tracer to ignore the span and any subsequent child spans.
-    // Health check probes are providing an operational check to ensure that the
-    // service is performing correctly. The benefit of distributed tracing is to
-    // record the path (and latency) a business transaction takes through multiple services to
-    // help diagnose issues. Recording trace instances for health check provides
-    // limited value, but consumes resources in the tracing system.
+    // Set the 'sampled' status for the span to false. This overrides
+    // any previous sampling decision associated with the trace instance,
+    // resulting in this span (and any subsequent child spans) not being
+    // reported to the backend tracing system.
     callbacks_->activeSpan().setSampled(false);
 
     // If we are not in pass through mode, we always handle. Otherwise, we handle if the server is

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
@@ -120,6 +120,10 @@ void OpenTracingSpan::injectContext(Http::HeaderMap& request_headers) {
   }
 }
 
+void OpenTracingSpan::setSampled(const bool sampled) {
+  span_->SetTag(opentracing::ext::sampling_priority, sampled ? 1 : 0);
+}
+
 Tracing::SpanPtr OpenTracingSpan::spawnChild(const Tracing::Config&, const std::string& name,
                                              SystemTime start_time) {
   std::unique_ptr<opentracing::Span> ot_span = span_->tracer().StartSpan(

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
@@ -120,7 +120,7 @@ void OpenTracingSpan::injectContext(Http::HeaderMap& request_headers) {
   }
 }
 
-void OpenTracingSpan::setSampled(const bool sampled) {
+void OpenTracingSpan::setSampled(bool sampled) {
   span_->SetTag(opentracing::ext::sampling_priority, sampled ? 1 : 0);
 }
 

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.h
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.h
@@ -37,7 +37,7 @@ public:
   void injectContext(Http::HeaderMap& request_headers) override;
   Tracing::SpanPtr spawnChild(const Tracing::Config& config, const std::string& name,
                               SystemTime start_time) override;
-  void setSampled(const bool) override;
+  void setSampled(bool) override;
 
 private:
   OpenTracingDriver& driver_;

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.h
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.h
@@ -37,6 +37,7 @@ public:
   void injectContext(Http::HeaderMap& request_headers) override;
   Tracing::SpanPtr spawnChild(const Tracing::Config& config, const std::string& name,
                               SystemTime start_time) override;
+  void setSampled(const bool) override;
 
 private:
   OpenTracingDriver& driver_;

--- a/source/extensions/tracers/zipkin/zipkin_core_types.h
+++ b/source/extensions/tracers/zipkin/zipkin_core_types.h
@@ -336,7 +336,7 @@ public:
   /**
    * Set the span's sampled flag.
    */
-  void setSampled(const bool val) { sampled_ = val; }
+  void setSampled(bool val) { sampled_ = val; }
 
   /**
    * @return a vector with all annotations added to the span.

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -41,7 +41,7 @@ void ZipkinSpan::injectContext(Http::HeaderMap& request_headers) {
                       : ZipkinCoreConstants::get().NOT_SAMPLED);
 }
 
-void ZipkinSpan::setSampled(const bool sampled) { span_.setSampled(sampled); }
+void ZipkinSpan::setSampled(bool sampled) { span_.setSampled(sampled); }
 
 Tracing::SpanPtr ZipkinSpan::spawnChild(const Tracing::Config& config, const std::string& name,
                                         SystemTime start_time) {

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -41,6 +41,8 @@ void ZipkinSpan::injectContext(Http::HeaderMap& request_headers) {
                       : ZipkinCoreConstants::get().NOT_SAMPLED);
 }
 
+void ZipkinSpan::setSampled(const bool sampled) { span_.setSampled(sampled); }
+
 Tracing::SpanPtr ZipkinSpan::spawnChild(const Tracing::Config& config, const std::string& name,
                                         SystemTime start_time) {
   SpanContext context(span_);

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -66,6 +66,8 @@ public:
   Tracing::SpanPtr spawnChild(const Tracing::Config&, const std::string& name,
                               SystemTime start_time) override;
 
+  void setSampled(const bool sampled) override;
+
   /**
    * @return a reference to the Zipkin::Span object.
    */

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -66,7 +66,7 @@ public:
   Tracing::SpanPtr spawnChild(const Tracing::Config&, const std::string& name,
                               SystemTime start_time) override;
 
-  void setSampled(const bool sampled) override;
+  void setSampled(bool sampled) override;
 
   /**
    * @return a reference to the Zipkin::Span object.

--- a/test/extensions/filters/http/health_check/health_check_test.cc
+++ b/test/extensions/filters/http/health_check/health_check_test.cc
@@ -92,6 +92,7 @@ public:
 TEST_F(HealthCheckFilterNoPassThroughTest, OkOrFailed) {
   EXPECT_CALL(context_, healthCheckFailed()).Times(0);
   EXPECT_CALL(callbacks_.request_info_, healthCheck(true));
+  EXPECT_CALL(callbacks_.active_span_, setSampled(false));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
 }
@@ -192,6 +193,7 @@ TEST_F(HealthCheckFilterNoPassThroughTest, ComputedHealth) {
 TEST_F(HealthCheckFilterNoPassThroughTest, HealthCheckFailedCallbackCalled) {
   EXPECT_CALL(context_, healthCheckFailed()).WillOnce(Return(true));
   EXPECT_CALL(callbacks_.request_info_, healthCheck(true));
+  EXPECT_CALL(callbacks_.active_span_, setSampled(false));
   Http::TestHeaderMapImpl health_check_response{{":status", "503"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&health_check_response), true))
       .Times(1)
@@ -215,6 +217,7 @@ TEST_F(HealthCheckFilterNoPassThroughTest, HealthCheckFailedCallbackCalled) {
 TEST_F(HealthCheckFilterPassThroughTest, Ok) {
   EXPECT_CALL(context_, healthCheckFailed()).WillOnce(Return(false));
   EXPECT_CALL(callbacks_.request_info_, healthCheck(true));
+  EXPECT_CALL(callbacks_.active_span_, setSampled(false));
   EXPECT_CALL(callbacks_, encodeHeaders_(_, _)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
 
@@ -227,6 +230,7 @@ TEST_F(HealthCheckFilterPassThroughTest, Ok) {
 TEST_F(HealthCheckFilterPassThroughTest, OkWithContinue) {
   EXPECT_CALL(context_, healthCheckFailed()).WillOnce(Return(false));
   EXPECT_CALL(callbacks_.request_info_, healthCheck(true));
+  EXPECT_CALL(callbacks_.active_span_, setSampled(false));
   EXPECT_CALL(callbacks_, encodeHeaders_(_, _)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
 
@@ -244,6 +248,7 @@ TEST_F(HealthCheckFilterPassThroughTest, OkWithContinue) {
 TEST_F(HealthCheckFilterPassThroughTest, Failed) {
   EXPECT_CALL(context_, healthCheckFailed()).WillOnce(Return(true));
   EXPECT_CALL(callbacks_.request_info_, healthCheck(true));
+  EXPECT_CALL(callbacks_.active_span_, setSampled(false));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
 }
@@ -258,6 +263,7 @@ TEST_F(HealthCheckFilterPassThroughTest, NotHcRequest) {
 TEST_F(HealthCheckFilterCachingTest, CachedServiceUnavailableCallbackCalled) {
   EXPECT_CALL(context_, healthCheckFailed()).WillRepeatedly(Return(false));
   EXPECT_CALL(callbacks_.request_info_, healthCheck(true));
+  EXPECT_CALL(callbacks_.active_span_, setSampled(false));
   cache_manager_->setCachedResponseCode(Http::Code::ServiceUnavailable);
 
   Http::TestHeaderMapImpl health_check_response{{":status", "503"}};
@@ -278,6 +284,7 @@ TEST_F(HealthCheckFilterCachingTest, CachedServiceUnavailableCallbackCalled) {
 TEST_F(HealthCheckFilterCachingTest, CachedOkCallbackNotCalled) {
   EXPECT_CALL(context_, healthCheckFailed()).WillRepeatedly(Return(false));
   EXPECT_CALL(callbacks_.request_info_, healthCheck(true));
+  EXPECT_CALL(callbacks_.active_span_, setSampled(false));
   cache_manager_->setCachedResponseCode(Http::Code::OK);
 
   Http::TestHeaderMapImpl health_check_response{{":status", "200"}};
@@ -294,6 +301,7 @@ TEST_F(HealthCheckFilterCachingTest, CachedOkCallbackNotCalled) {
 
 TEST_F(HealthCheckFilterCachingTest, All) {
   EXPECT_CALL(callbacks_.request_info_, healthCheck(true)).Times(3);
+  EXPECT_CALL(callbacks_.active_span_, setSampled(false)).Times(3);
 
   // Verify that the first request goes through.
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, true));

--- a/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
+++ b/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
@@ -80,11 +80,26 @@ TEST_F(OpenTracingDriverTest, FlushSpanWithTag) {
   EXPECT_EQ(expected_tags, driver_->recorder().top().tags);
 }
 
-TEST_F(OpenTracingDriverTest, TagSamplingFalse) {
+TEST_F(OpenTracingDriverTest, TagSamplingFalseByDecision) {
   setupValidDriver(OpenTracingDriver::PropagationMode::TracerNative, {});
 
   Tracing::SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_,
                                                    start_time_, {Tracing::Reason::Sampling, false});
+  first_span->finishSpan();
+
+  const std::unordered_map<std::string, opentracing::Value> expected_tags = {
+      {opentracing::ext::sampling_priority, 0}};
+
+  EXPECT_EQ(1, driver_->recorder().spans().size());
+  EXPECT_EQ(expected_tags, driver_->recorder().top().tags);
+}
+
+TEST_F(OpenTracingDriverTest, TagSamplingFalseByFlag) {
+  setupValidDriver(OpenTracingDriver::PropagationMode::TracerNative, {});
+
+  Tracing::SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_,
+                                                   start_time_, {Tracing::Reason::Sampling, true});
+  first_span->setSampled(false);
   first_span->finishSpan();
 
   const std::unordered_map<std::string, opentracing::Value> expected_tags = {

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -31,6 +31,7 @@ public:
   MOCK_METHOD2(setTag, void(const std::string& name, const std::string& value));
   MOCK_METHOD0(finishSpan, void());
   MOCK_METHOD1(injectContext, void(Http::HeaderMap& request_headers));
+  MOCK_METHOD1(setSampled, void(const bool sampled));
 
   SpanPtr spawnChild(const Config& config, const std::string& name,
                      SystemTime start_time) override {


### PR DESCRIPTION
*Description*:
This PR fixes #3569.

There are two separate problems.

* The reason that the root span was not being reported for the health check is that if a request was classified as a health check, it didn't finish the span. So all spans were still being created and considered sampled.

* The second issue was that when the sampling decision is being made, the health check filter had not yet been invoked, and therefore was not being taken into account. Therefore I exposed the `setSampled` method in the abstract `Span` API and enabled the health check filter to explicitly set whether the span is sampled.

The issue is that potentially by the time the filter is invoked, other filters may have created child spans. However I am not sure how else we can use logic executed mid stream (i.e. the health check filter) to influence the sampling decision.

The other issue is that normally the sampling decision is made when a root span for a trace is being created. With this PR, it is possible that an existing trace will have a subpart of the trace (i.e. the part  considered to be the health check) not sampled, while the remainder of the trace is still reported. Let me know if I haven't clearly explained this, as might be confusing :)

*Risk Level*: Low

*Testing*:
Needs tests - currently just looking for feedback on the fix.

*Docs Changes*:
none.

*Release Notes*:
none.
