### PR TITLE
Cleanup: Fix lint errors.

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -95,7 +95,7 @@ private:
 
 class CookieHashMethod : public HashPolicyImpl::HashMethod {
 public:
-  CookieHashMethod(const std::string& key, const std::string path,
+  CookieHashMethod(const std::string& key, const std::string& path,
                    const absl::optional<std::chrono::seconds>& ttl)
       : key_(key), path_(path), ttl_(ttl) {}
 

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -11,8 +11,6 @@
 #include "gtest/gtest.h"
 
 using testing::Return;
-using testing::ReturnRef;
-using testing::_;
 
 namespace Envoy {
 namespace Extensions {


### PR DESCRIPTION
Removed unused 'using' statements in gzip_filter_test.
Pass path by const ref to CookieHashMethod constructor.

Signed-off-by: Kyle Myerson <kmyerson@google.com>
