### PR TITLE
listener: use real ConnectionImpl in TLS Inspector's benchmark.

### DIFF
--- a/test/extensions/filters/listener/tls_inspector/BUILD
+++ b/test/extensions/filters/listener/tls_inspector/BUILD
@@ -30,6 +30,7 @@ envoy_cc_binary(
         "benchmark",
     ],
     deps = [
+        "//source/common/network:listen_socket_lib",
         "//source/extensions/filters/listener/tls_inspector:tls_inspector_lib",
         "//test/mocks/api:api_mocks",
         "//test/mocks/network:network_mocks",

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
@@ -1,5 +1,7 @@
 #include <vector>
 
+#include "common/network/listen_socket_impl.h"
+
 #include "extensions/filters/listener/tls_inspector/tls_inspector.h"
 
 #include "test/mocks/api/mocks.h"
@@ -36,24 +38,6 @@ public:
 
   Network::ConnectionSocket& socket_;
   Event::Dispatcher& dispatcher_;
-};
-
-class FastMockConnectionSocket : public Network::MockConnectionSocket {
-public:
-  int fd() const override { return 42; }
-  void setRequestedApplicationProtocols(const std::vector<absl::string_view>& protocols) override {
-    if (protocols.front() == "h2") {
-      got_alpn_ = true;
-    }
-  }
-  void setRequestedServerName(absl::string_view server_name) override {
-    if (server_name == "example.com") {
-      got_server_name_ = true;
-    }
-  }
-
-  bool got_alpn_{false};
-  bool got_server_name_{false};
 };
 
 // Don't inherit from the mock implementation at all, because this is instantiated
@@ -93,7 +77,7 @@ static void BM_TlsInspector(benchmark::State& state) {
   TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls{&os_sys_calls};
   NiceMock<Stats::MockStore> store;
   ConfigSharedPtr cfg(std::make_shared<Config>(store));
-  FastMockConnectionSocket socket;
+  Network::ConnectionSocketImpl socket(42, nullptr, nullptr);
   NiceMock<FastMockDispatcher> dispatcher;
   FastMockListenerFilterCallbacks cb(socket, dispatcher);
 
@@ -101,10 +85,13 @@ static void BM_TlsInspector(benchmark::State& state) {
     Filter filter(cfg);
     filter.onAccept(cb);
     dispatcher.file_event_callback_(Event::FileReadyType::Read);
-    RELEASE_ASSERT(socket.got_server_name_);
-    socket.got_server_name_ = false;
-    RELEASE_ASSERT(socket.got_alpn_);
-    socket.got_alpn_ = false;
+    RELEASE_ASSERT(socket.detectedTransportProtocol() == "tls");
+    RELEASE_ASSERT(socket.requestedServerName() == "example.com");
+    RELEASE_ASSERT(socket.requestedApplicationProtocols().size() == 2 &&
+                   socket.requestedApplicationProtocols().front() == "h2");
+    socket.setDetectedTransportProtocol("");
+    socket.setRequestedServerName("");
+    socket.setRequestedApplicationProtocols({});
   }
 }
 

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
@@ -77,7 +77,7 @@ static void BM_TlsInspector(benchmark::State& state) {
   TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls{&os_sys_calls};
   NiceMock<Stats::MockStore> store;
   ConfigSharedPtr cfg(std::make_shared<Config>(store));
-  Network::ConnectionSocketImpl socket(42, nullptr, nullptr);
+  Network::ConnectionSocketImpl socket(-1, nullptr, nullptr);
   NiceMock<FastMockDispatcher> dispatcher;
   FastMockListenerFilterCallbacks cb(socket, dispatcher);
 


### PR DESCRIPTION
*Risk Level*: None
*Testing*: bazel run -c opt //test/extensions/filters/listener/tls_inspector:tls_inspector_benchmark
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Piotr Sikora <piotrsikora@google.com>