### PR TITLE
Upgrade absl.

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -5,8 +5,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/google/boringssl",
     ),
     com_google_absl = dict(
-        # Do not upgrade further until https://github.com/abseil/abseil-cpp/issues/118 is fixed.
-        commit = "26b789f9a53d086c8b8c9c2668efb251e37861cd",  # 2018-05-04
+        commit = "92020a042c0cd46979db9f6f0cb32783dc07765e",  # 2018-06-08
         remote = "https://github.com/abseil/abseil-cpp",
     ),
     com_github_bombela_backward = dict(


### PR DESCRIPTION
This fixes an ASAN failure when run in a certain environment, as described by
https://github.com/abseil/abseil-cpp/issues/118. The failure was added by
https://github.com/envoyproxy/envoy/pull/3558, which pulled in the same
static initializer as described in the original absl issue linked here.

Signed-off-by: Greg Greenway <ggreenway@apple.com>

*title*: *one line description*

*Risk Level*: Low

*Testing*: Existing tests pass, plus this change fixes my internal ASAN build that was broken