### PR TITLE
http: memory and perf fix for header appending

### DIFF
--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -264,14 +264,14 @@ HeaderMapImpl::StaticLookupTable::find(const char* key) const {
   return current->cb_;
 }
 
-void HeaderMapImpl::appendToHeader(HeaderString& header, const std::string& data) {
+void HeaderMapImpl::appendToHeader(HeaderString& header, absl::string_view data) {
   if (data.empty()) {
     return;
   }
   if (!header.empty()) {
     header.append(",", 1);
   }
-  header.append(data.c_str(), data.size());
+  header.append(data.data(), data.size());
 }
 
 HeaderMapImpl::HeaderMapImpl() { memset(&inline_headers_, 0, sizeof(inline_headers_)); }
@@ -337,6 +337,8 @@ void HeaderMapImpl::addViaMove(HeaderString&& key, HeaderString&& value) {
   auto* entry = getExistingInline(key.c_str());
   if (entry != nullptr) {
     appendToHeader(entry->value(), value.c_str());
+    key.clear();
+    value.clear();
   } else {
     insertByKey(std::move(key), std::move(value));
   }

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -43,7 +43,7 @@ public:
    * @param header the header to append to.
    * @param data to append to the header.
    */
-  static void appendToHeader(HeaderString& header, const std::string& data);
+  static void appendToHeader(HeaderString& header, absl::string_view data);
 
   HeaderMapImpl();
   HeaderMapImpl(const std::initializer_list<std::pair<LowerCaseString, std::string>>& values);

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -145,6 +145,7 @@ protected:
   void testAbsolutePathWithPort();
   void testAbsolutePathWithoutPort();
   void testConnect();
+  void testInlineHeaders();
   void testAllowAbsoluteSameRelative();
   // Test that a request returns the same content with both allow_absolute_urls enabled and
   // allow_absolute_urls disabled

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -174,6 +174,8 @@ TEST_P(IntegrationTest, Http09Enabled) { testHttp09Enabled(); }
 
 TEST_P(IntegrationTest, Http10Enabled) { testHttp10Enabled(); }
 
+TEST_P(IntegrationTest, TestInlineHeaders) { testInlineHeaders(); }
+
 TEST_P(IntegrationTest, Http10WithHostandKeepAlive) { testHttp10WithHostAndKeepAlive(); }
 
 TEST_P(IntegrationTest, NoHost) { testNoHost(); }


### PR DESCRIPTION
*Description*:
Fixes a bug where addViaMove wasn't clearing memory properly.
Also a perf improvement to addCopy(_, int)

*Risk Level*: Low 
*Testing*: regression integration test
*Docs Changes*: n/a
*Release Notes*: n/a
