### PR TITLE
Small fix to quick start bazel build instructions

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -59,8 +59,7 @@ Apple LLVM version 9.1.0 (clang-902.0.30).
 3. Install Golang on your machine. This is required as part of building [BoringSSL](https://boringssl.googlesource.com/boringssl/+/HEAD/BUILDING.md)
 and also for [Buildifer](https://github.com/bazelbuild/buildtools) which is used for formatting bazel BUILD files.
 4. `go get github.com/bazelbuild/buildtools/buildifier` to install buildifier
-5. `bazel build //source/...` to fetch and build all external dependencies. This may take some time.
-6. `bazel build //source/exe:envoy-static` from the Envoy source directory.
+5. `bazel build //source/exe:envoy-static` from the Envoy source directory.
 
 ## Building Bazel with the CI Docker image
 

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -59,7 +59,7 @@ Apple LLVM version 9.1.0 (clang-902.0.30).
 3. Install Golang on your machine. This is required as part of building [BoringSSL](https://boringssl.googlesource.com/boringssl/+/HEAD/BUILDING.md)
 and also for [Buildifer](https://github.com/bazelbuild/buildtools) which is used for formatting bazel BUILD files.
 4. `go get github.com/bazelbuild/buildtools/buildifier` to install buildifier
-5. `bazel fetch //source/...` to fetch and build all external dependencies. This may take some time.
+5. `bazel build //source/...` to fetch and build all external dependencies. This may take some time.
 6. `bazel build //source/exe:envoy-static` from the Envoy source directory.
 
 ## Building Bazel with the CI Docker image


### PR DESCRIPTION
docs: fix quick start bazel build instructions

"bazel fetch //source/..." fails with errors about "no such target '//external:python_headers"

Signed-off-by: Elisha Ziskind eziskind@google.com
