### PR TITLE
WIP: stats: refactor to enable non-hot-restart stats to have distinct representation from hot-restart stats.

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -79,15 +79,17 @@ if [[ -d /bazel-prebuilt-output && ! -d "${TEST_TMPDIR}/_bazel_${USER}" ]]; then
   rsync -a /bazel-prebuilt-output "${BAZEL_OUTPUT_BASE}"
 fi
 
-# Setup Envoy consuming project.
-if [[ ! -a "${ENVOY_FILTER_EXAMPLE_SRCDIR}" ]]
-then
-  git clone https://github.com/envoyproxy/envoy-filter-example.git "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
+if [ "$1" != "-nofetch" ]; then
+  # Setup Envoy consuming project.
+  if [[ ! -a "${ENVOY_FILTER_EXAMPLE_SRCDIR}" ]]
+  then
+    git clone https://github.com/envoyproxy/envoy-filter-example.git "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
+  fi
+  
+  # This is the hash on https://github.com/envoyproxy/envoy-filter-example.git we pin to.
+  (cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout -f 4b6c55b726eda8a1f99e6f4ca1a87f6ce670604f)
+  cp -f "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/WORKSPACE
 fi
-
-# This is the hash on https://github.com/envoyproxy/envoy-filter-example.git we pin to.
-(cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout -f 4b6c55b726eda8a1f99e6f4ca1a87f6ce670604f)
-cp -f "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/WORKSPACE
 
 # Also setup some space for building Envoy standalone.
 export ENVOY_BUILD_DIR="${BUILD_DIR}"/envoy

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -4,7 +4,13 @@
 
 set -e
 
-. "$(dirname "$0")"/build_setup.sh
+build_setup_args=""
+if [[ "$1" == "fix_format" || "$1" == "check_format" ]]; then
+  build_setup_args="-nofetch"
+fi
+
+. "$(dirname "$0")"/build_setup.sh $build_setup_args
+
 echo "building using ${NUM_CPUS} CPUs"
 
 function bazel_release_binary_build() {

--- a/include/envoy/server/hot_restart.h
+++ b/include/envoy/server/hot_restart.h
@@ -94,7 +94,7 @@ public:
   /**
    * @returns an allocator for stats.
    */
-  virtual Stats::RawStatDataAllocator& statsAllocator() PURE;
+  virtual Stats::StatDataAllocator& statsAllocator() PURE;
 };
 
 } // namespace Server

--- a/include/envoy/stats/stats.h
+++ b/include/envoy/stats/stats.h
@@ -408,11 +408,11 @@ typedef std::unique_ptr<StoreRoot> StoreRootPtr;
 struct RawStatData;
 
 /**
- * Abstract interface for allocating a RawStatData.
+ * Abstract interface for allocating statistics.
  */
-class RawStatDataAllocator {
+class StatDataAllocator {
 public:
-  virtual ~RawStatDataAllocator() {}
+  virtual ~StatDataAllocator() {}
 
   /**
    * @return RawStatData* a raw stat data block for a given stat name or nullptr if there is no
@@ -420,13 +420,18 @@ public:
    *         data location by name if one already exists with the same name. This is used for
    *         intra-process scope swapping as well as inter-process hot restart.
    */
-  virtual RawStatData* alloc(const std::string& name) PURE;
+  // virtual RawStatData* alloc(const std::string& name) PURE;
 
   /**
    * Free a raw stat data block. The allocator should handle reference counting and only truly
    * free the block if it is no longer needed.
    */
-  virtual void free(RawStatData& data) PURE;
+  // virtual void free(RawStatData& data) PURE;
+
+  virtual Counter* makeCounter(const std::string& name, std::string&& tag_extracted_name,
+                               std::vector<Tag>&& tags) PURE;
+  virtual Gauge* makeGauge(const std::string& name, std::string&& tag_extracted_name,
+                           std::vector<Tag>&& tags) PURE;
 };
 
 } // namespace Stats

--- a/include/envoy/stats/stats.h
+++ b/include/envoy/stats/stats.h
@@ -408,28 +408,25 @@ typedef std::unique_ptr<StoreRoot> StoreRootPtr;
 struct RawStatData;
 
 /**
- * Abstract interface for allocating statistics.
+ * Abstract interface for allocating statistics. Alternate
+ * implementations can be created utilizing a single fixed-size block
+ * suitable for shared-memory, or in the heap, allowing for pointers
+ * and sharing of substrings, with an opportunity for reduced memory
+ * consumption.
  */
 class StatDataAllocator {
 public:
   virtual ~StatDataAllocator() {}
 
   /**
-   * @return RawStatData* a raw stat data block for a given stat name or nullptr if there is no
-   *         more memory available for stats. The allocator should return a reference counted
-   *         data location by name if one already exists with the same name. This is used for
-   *         intra-process scope swapping as well as inter-process hot restart.
+   * @return Counter* a counter.
    */
-  // virtual RawStatData* alloc(const std::string& name) PURE;
-
-  /**
-   * Free a raw stat data block. The allocator should handle reference counting and only truly
-   * free the block if it is no longer needed.
-   */
-  // virtual void free(RawStatData& data) PURE;
-
   virtual Counter* makeCounter(const std::string& name, std::string&& tag_extracted_name,
                                std::vector<Tag>&& tags) PURE;
+
+  /**
+   * @return Counter* a gauge.
+   */
   virtual Gauge* makeGauge(const std::string& name, std::string&& tag_extracted_name,
                            std::vector<Tag>&& tags) PURE;
 };

--- a/source/common/stats/stats_impl.cc
+++ b/source/common/stats/stats_impl.cc
@@ -171,6 +171,7 @@ RawStatData* HeapRawStatDataAllocator::alloc(const std::string& name) {
     ++existing_data->ref_count_;
     return existing_data;
   } else {
+    ++num_stats_;
     return data;
   }
 }
@@ -286,6 +287,7 @@ void HeapRawStatDataAllocator::free(RawStatData& data) {
   }
 
   ASSERT(key_removed == 1);
+  --num_stats_;
   ::free(&data);
 }
 
@@ -361,6 +363,17 @@ void SourceImpl::clearCache() {
   counters_.reset();
   gauges_.reset();
   histograms_.reset();
+}
+
+Counter* RawStatDataAllocator::makeCounter(const std::string& name,
+                                           std::string&& tag_extracted_name,
+                                           std::vector<Tag>&& tags) {
+  return new CounterImpl(*alloc(name), *this, std::move(tag_extracted_name), std::move(tags));
+}
+
+Gauge* RawStatDataAllocator::makeGauge(const std::string& name, std::string&& tag_extracted_name,
+                                       std::vector<Tag>&& tags) {
+  return new GaugeImpl(*alloc(name), *this, std::move(tag_extracted_name), std::move(tags));
 }
 
 } // namespace Stats

--- a/source/common/stats/stats_impl.h
+++ b/source/common/stats/stats_impl.h
@@ -305,8 +305,13 @@ private:
   const std::vector<Tag> tags_;
 };
 
+/**
+ * Implements a StatDataAllocator that uses RawStatData -- capable of deploying
+ * in a shared memory block without internal pointers.
+ */
 class RawStatDataAllocator : public StatDataAllocator {
 public:
+  // StatDataAllocator
   Counter* makeCounter(const std::string& name, std::string&& tag_extracted_name,
                        std::vector<Tag>&& tags) override;
   Gauge* makeGauge(const std::string& name, std::string&& tag_extracted_name,

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -155,21 +155,6 @@ void ThreadLocalStoreImpl::clearScopeFromCaches(uint64_t scope_id) {
   }
 }
 
-/*
-ThreadLocalStoreImpl::SafeAllocData ThreadLocalStoreImpl::safeAlloc(const std::string& name) {
-  RawStatData* data = alloc_.alloc(name);
-  if (!data) {
-    // If we run out of stat space from the allocator (which can happen if for example allocations
-    // are coming from a fixed shared memory region, we need to deal with this case the best we
-    // can. We must pass back the right allocator so that free() happens on the heap.
-    num_last_resort_stats_.inc();
-    return {*heap_allocator_.alloc(name), heap_allocator_};
-  } else {
-    return {*data, alloc_};
-  }
-}
-*/
-
 std::atomic<uint64_t> ThreadLocalStoreImpl::ScopeImpl::next_scope_id_;
 
 ThreadLocalStoreImpl::ScopeImpl::~ScopeImpl() { parent_.releaseScopeCrossThread(this); }
@@ -197,7 +182,6 @@ Counter& ThreadLocalStoreImpl::ScopeImpl::counter(const std::string& name) {
   Thread::LockGuard lock(parent_.lock_);
   CounterSharedPtr& central_ref = central_cache_.counters_[final_name];
   if (!central_ref) {
-    // SafeAllocData alloc = parent_.safeAlloc(final_name);
     std::vector<Tag> tags;
     std::string tag_extracted_name = parent_.getTagsForName(final_name, tags);
     central_ref.reset(
@@ -245,7 +229,6 @@ Gauge& ThreadLocalStoreImpl::ScopeImpl::gauge(const std::string& name) {
   Thread::LockGuard lock(parent_.lock_);
   GaugeSharedPtr& central_ref = central_cache_.gauges_[final_name];
   if (!central_ref) {
-    // SafeAllocData alloc = parent_.safeAlloc(final_name);
     std::vector<Tag> tags;
     std::string tag_extracted_name = parent_.getTagsForName(final_name, tags);
     central_ref.reset(

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -244,17 +244,9 @@ private:
     std::unordered_map<uint64_t, TlsCacheEntry> scope_cache_;
   };
 
-  /*
-  struct SafeAllocData {
-    RawStatData& data_;
-    RawStatDataAllocator& free_;
-  };
-  */
-
   std::string getTagsForName(const std::string& name, std::vector<Tag>& tags) const;
   void clearScopeFromCaches(uint64_t scope_id);
   void releaseScopeCrossThread(ScopeImpl* scope);
-  // SafeAllocData safeAlloc(const std::string& name);
   void mergeInternal(PostMergeCb mergeCb);
 
   StatDataAllocator& alloc_;

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -163,7 +163,7 @@ public:
  */
 class ThreadLocalStoreImpl : Logger::Loggable<Logger::Id::stats>, public StoreRoot {
 public:
-  ThreadLocalStoreImpl(RawStatDataAllocator& alloc);
+  ThreadLocalStoreImpl(StatDataAllocator& alloc);
   ~ThreadLocalStoreImpl();
 
   // Stats::Scope
@@ -244,18 +244,20 @@ private:
     std::unordered_map<uint64_t, TlsCacheEntry> scope_cache_;
   };
 
+  /*
   struct SafeAllocData {
     RawStatData& data_;
     RawStatDataAllocator& free_;
   };
+  */
 
   std::string getTagsForName(const std::string& name, std::vector<Tag>& tags) const;
   void clearScopeFromCaches(uint64_t scope_id);
   void releaseScopeCrossThread(ScopeImpl* scope);
-  SafeAllocData safeAlloc(const std::string& name);
+  // SafeAllocData safeAlloc(const std::string& name);
   void mergeInternal(PostMergeCb mergeCb);
 
-  RawStatDataAllocator& alloc_;
+  StatDataAllocator& alloc_;
   Event::Dispatcher* main_thread_dispatcher_{};
   ThreadLocal::SlotPtr tls_;
   mutable Thread::MutexBasicLockable lock_;
@@ -266,7 +268,6 @@ private:
   std::atomic<bool> shutting_down_{};
   std::atomic<bool> merge_in_progress_{};
   Counter& num_last_resort_stats_;
-  HeapRawStatDataAllocator heap_allocator_;
   SourceImpl source_;
 };
 

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -149,8 +149,9 @@ Stats::RawStatData* HotRestartImpl::alloc(const std::string& name) {
   auto value_created = stats_set_->insert(key);
   Stats::RawStatData* data = value_created.first;
   if (data == nullptr) {
+    // TODO(jmarantz): bump "stat.overflow" when this occurs, and make sure
+    // when this object gets freed that things work.
     return heap_allocator_.alloc(name);
-    // return nullptr;
   }
   // For new entries (value-created.second==true), BlockMemoryHashSet calls Value::initialize()
   // automatically, but on recycled entries (value-created.second==false) we need to bump the

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -149,7 +149,8 @@ Stats::RawStatData* HotRestartImpl::alloc(const std::string& name) {
   auto value_created = stats_set_->insert(key);
   Stats::RawStatData* data = value_created.first;
   if (data == nullptr) {
-    return nullptr;
+    return heap_allocator_.alloc(name);
+    // return nullptr;
   }
   // For new entries (value-created.second==true), BlockMemoryHashSet calls Value::initialize()
   // automatically, but on recycled entries (value-created.second==false) we need to bump the
@@ -491,6 +492,11 @@ std::string HotRestartImpl::hotRestartVersion(uint64_t max_num_stats, uint64_t m
 std::string HotRestartImpl::versionHelper(uint64_t max_num_stats, uint64_t max_stat_name_len,
                                           RawStatDataSet& stats_set) {
   return SharedMemory::version(max_num_stats, max_stat_name_len) + "." + stats_set.version();
+}
+
+uint32_t HotRestartImpl::numStats() const {
+  Thread::LockGuard lock(stat_lock_);
+  return stats_set_->size();
 }
 
 } // namespace Server

--- a/source/server/hot_restart_impl.h
+++ b/source/server/hot_restart_impl.h
@@ -130,7 +130,7 @@ public:
   std::string version() override;
   Thread::BasicLockable& logLock() override { return log_lock_; }
   Thread::BasicLockable& accessLogLock() override { return access_log_lock_; }
-  Stats::RawStatDataAllocator& statsAllocator() override { return *this; }
+  Stats::StatDataAllocator& statsAllocator() override { return *this; }
 
   /**
    * envoy --hot_restart_version doesn't initialize Envoy, but computes the version string
@@ -141,6 +141,9 @@ public:
   // RawStatDataAllocator
   Stats::RawStatData* alloc(const std::string& name) override;
   void free(Stats::RawStatData& data) override;
+
+  uint32_t numStats() const;
+  Stats::HeapRawStatDataAllocator& heapAllocator() { return heap_allocator_; }
 
 private:
   enum class RpcMessageType {
@@ -212,7 +215,7 @@ private:
   std::unique_ptr<RawStatDataSet> stats_set_ GUARDED_BY(stat_lock_);
   ProcessSharedMutex log_lock_;
   ProcessSharedMutex access_log_lock_;
-  ProcessSharedMutex stat_lock_;
+  mutable ProcessSharedMutex stat_lock_;
   ProcessSharedMutex init_lock_;
   int my_domain_socket_{-1};
   sockaddr_un parent_address_;
@@ -221,6 +224,7 @@ private:
   std::array<uint8_t, 4096> rpc_buffer_;
   Server::Instance* server_{};
   bool parent_terminated_{};
+  Stats::HeapRawStatDataAllocator heap_allocator_;
 };
 
 } // namespace Server

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -399,6 +399,7 @@ TEST_F(StatsThreadLocalStoreTest, OverlappingScopes) {
   EXPECT_CALL(*this, free(_)).Times(3);
 }
 
+/*
 TEST_F(StatsThreadLocalStoreTest, AllocFailed) {
   InSequence s;
   store_->initializeThreading(main_thread_dispatcher_, tls_);
@@ -416,6 +417,7 @@ TEST_F(StatsThreadLocalStoreTest, AllocFailed) {
   // Includes overflow but not the failsafe stat which we allocated from the heap.
   EXPECT_CALL(*this, free(_));
 }
+*/
 
 TEST_F(StatsThreadLocalStoreTest, ShuttingDown) {
   InSequence s;

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -400,6 +400,14 @@ TEST_F(StatsThreadLocalStoreTest, OverlappingScopes) {
 }
 
 /*
+DO NOT SUBMIT
+
+This test will not work, which I think is OK. This PR redefines the behavior
+of hot-restart alloc failing so that it will directly try the heap allocator.
+However this is not fully copacetic yet:
+  - I'm not sure stats free themselves correctly
+  - The 'stats.overflow' stat is not bumped on stat failure.
+
 TEST_F(StatsThreadLocalStoreTest, AllocFailed) {
   InSequence s;
   store_->initializeThreading(main_thread_dispatcher_, tls_);

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -139,7 +139,10 @@ TEST_F(HotRestartImplTest, allocFail) {
   Stats::RawStatData* s3 = hot_restart_->alloc("3");
   EXPECT_NE(s1, nullptr);
   EXPECT_NE(s2, nullptr);
-  EXPECT_EQ(s3, nullptr);
+  EXPECT_NE(s3, nullptr);
+  EXPECT_EQ(2, hot_restart_->numStats());
+  EXPECT_EQ(1, hot_restart_->heapAllocator().numStats());
+  hot_restart_->heapAllocator().free(*s3); // Else asserts if destructed with stats allocated.
 }
 
 // Because the shared memory is managed manually, make sure it meets


### PR DESCRIPTION
*title*: *one line description*

*Description*:
>Currently hot_restart requires stats to be allocated in block of memory pre-allocated at runtime. This may present scalability challenges in some environments for a couple of reasons: 
 1. Committing to the maximum number & size of stats on startup
 2. Difficulty of employing complex structures such as reference-counted symbol tables to share common substrings
This PR does some refactoring to make it easier to specify an alternate stats representation for the non-hot-restart case. Note that it does not actually do that: just makes it easier by virtualizing makeCounter and makeGauge.

See https://github.com/envoyproxy/envoy/issues/3585 for more discussion.

This is not ready for submit -- it doesn't have the right handling yet for failed alloc, as shown in some of the tests.

Also, ignore the .sh changes in this PR -- they should hopefully be submitted independently.

*Risk Level*: Medium

*Testing*: //test/...
