### PR TITLE
Coverage for source/extensions/tracers/zipkin/span_buffer.cc is now a…

### DIFF
--- a/test/extensions/tracers/zipkin/span_buffer_test.cc
+++ b/test/extensions/tracers/zipkin/span_buffer_test.cc
@@ -12,6 +12,7 @@ TEST(ZipkinSpanBufferTest, defaultConstructorEndToEnd) {
 
   EXPECT_EQ(0ULL, buffer.pendingSpans());
   EXPECT_EQ("[]", buffer.toStringifiedJsonArray());
+  EXPECT_FALSE(buffer.addSpan(Span()));
 
   buffer.allocateBuffer(2);
   EXPECT_EQ(0ULL, buffer.pendingSpans());


### PR DESCRIPTION
Coverage for source/extensions/tracers/zipkin/span_buffer.cc is now at 100%.

Signed-off-by: Lilika Markatou <lilika@google.com>

*Risk Level*: Low 