### PR TITLE
Revert "http: removing whitespace from appended XFF headers"

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -67,7 +67,6 @@ Version history
   to elide *x-forwarded-for* header modifications.
 * http: fixing a bug in inline headers where addCopy and addViaMove didn't add header values when
   encountering inline headers with multiple instances.
-* http: no longer adding whitespace when appending X-Forwarded-For headers.
 * listeners: added :ref:`tcp_fast_open_queue_length <envoy_api_field_Listener.tcp_fast_open_queue_length>` option.
 * listeners: added the ability to match :ref:`FilterChain <envoy_api_msg_listener.FilterChain>` using
   :ref:`application_protocols <envoy_api_field_listener.FilterChainMatch.application_protocols>`

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -30,9 +30,14 @@ void Utility::appendXff(HeaderMap& headers, const Network::Address::Instance& re
     return;
   }
 
+  // TODO(alyssawilk) move over to the append utility.
   HeaderString& header = headers.insertForwardedFor().value();
+  if (!header.empty()) {
+    header.append(", ", 2);
+  }
+
   const std::string& address_as_string = remote_address.ip()->addressAsString();
-  HeaderMapImpl::appendToHeader(header, address_as_string.c_str());
+  header.append(address_as_string.c_str(), address_as_string.size());
 }
 
 void Utility::appendVia(HeaderMap& headers, const std::string& via) {

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -497,7 +497,7 @@ TEST_F(ConnectionManagerUtilityTest, AppendInternalAddressXffNotInternalRequest)
 
   EXPECT_EQ((MutateRequestRet{"10.0.0.1:0", false}),
             callMutateRequestHeaders(headers, Protocol::Http2));
-  EXPECT_EQ("10.0.0.2,10.0.0.1", headers.get_("x-forwarded-for"));
+  EXPECT_EQ("10.0.0.2, 10.0.0.1", headers.get_("x-forwarded-for"));
 }
 
 // A request that is from an internal address and uses remote address should be an internal request.

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -67,7 +67,7 @@ TEST(HttpUtility, appendXff) {
     TestHeaderMapImpl headers{{"x-forwarded-for", "10.0.0.1"}};
     Network::Address::Ipv4Instance address("127.0.0.1");
     Utility::appendXff(headers, address);
-    EXPECT_EQ("10.0.0.1,127.0.0.1", headers.get_("x-forwarded-for"));
+    EXPECT_EQ("10.0.0.1, 127.0.0.1", headers.get_("x-forwarded-for"));
   }
 
   {


### PR DESCRIPTION
Reverts envoyproxy/envoy#3587

[`Utility::getLastAddressFromXFF()`](https://github.com/envoyproxy/envoy/blob/30537ebafedf8a69fbd44b21cdb9322be048e7f0/source/common/http/utility.cc#L295) should handle XFF with and without whitespace on the un-revert.

Fixes #3607