### PR TITLE
Handle lists with and without spaces in XFF

### DIFF
--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -287,7 +287,7 @@ Utility::getLastAddressFromXFF(const Http::HeaderMap& request_headers, uint32_t 
   }
 
   absl::string_view xff_string(xff_header->value().c_str(), xff_header->value().size());
-  static const std::string seperator(", ");
+  static const std::string seperator(",");
   // Ignore the last num_to_skip addresses at the end of XFF.
   for (uint32_t i = 0; i < num_to_skip; i++) {
     std::string::size_type last_comma = xff_string.rfind(seperator);
@@ -302,6 +302,10 @@ Utility::getLastAddressFromXFF(const Http::HeaderMap& request_headers, uint32_t 
   if (last_comma != std::string::npos && last_comma + seperator.size() < xff_string.size()) {
     xff_string = xff_string.substr(last_comma + seperator.size());
   }
+
+  // ignore the whitespace, since they are allowed in HTTP lists (see rfc7239)
+  xff_string = StringUtil::ltrim(xff_string);
+  xff_string = StringUtil::rtrim(xff_string);
 
   try {
     // This technically requires a copy because inet_pton takes a null terminated string. In

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -303,7 +303,7 @@ Utility::getLastAddressFromXFF(const Http::HeaderMap& request_headers, uint32_t 
     xff_string = xff_string.substr(last_comma + seperator.size());
   }
 
-  // ignore the whitespace, since they are allowed in HTTP lists (see rfc7239)
+  // Ignore the whitespace, since they are allowed in HTTP lists (see RFC7239#section-7.1).
   xff_string = StringUtil::ltrim(xff_string);
   xff_string = StringUtil::rtrim(xff_string);
 

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -162,25 +162,32 @@ TEST(HttpUtility, getLastAddressFromXFF) {
     const std::string first_address = "192.0.2.10";
     const std::string second_address = "192.0.2.1";
     const std::string third_address = "10.0.0.1";
-    TestHeaderMapImpl request_headers{{"x-forwarded-for", "192.0.2.10, 192.0.2.1 , 10.0.0.1"}};
+    const std::string fourth_address = "10.0.0.2";
+    TestHeaderMapImpl request_headers{
+        {"x-forwarded-for", "192.0.2.10, 192.0.2.1 ,10.0.0.1,10.0.0.2"}};
 
-    // Exercise ltrim().
+    // No space on the left.
     auto ret = Utility::getLastAddressFromXFF(request_headers);
+    EXPECT_EQ(fourth_address, ret.address_->ip()->addressAsString());
+    EXPECT_FALSE(ret.single_address_);
+
+    // No space on either side.
+    ret = Utility::getLastAddressFromXFF(request_headers, 1);
     EXPECT_EQ(third_address, ret.address_->ip()->addressAsString());
     EXPECT_FALSE(ret.single_address_);
 
     // Exercise rtrim() and ltrim().
-    ret = Utility::getLastAddressFromXFF(request_headers, 1);
+    ret = Utility::getLastAddressFromXFF(request_headers, 2);
     EXPECT_EQ(second_address, ret.address_->ip()->addressAsString());
     EXPECT_FALSE(ret.single_address_);
 
     // No space trimming.
-    ret = Utility::getLastAddressFromXFF(request_headers, 2);
+    ret = Utility::getLastAddressFromXFF(request_headers, 3);
     EXPECT_EQ(first_address, ret.address_->ip()->addressAsString());
     EXPECT_FALSE(ret.single_address_);
 
     // No address found.
-    ret = Utility::getLastAddressFromXFF(request_headers, 3);
+    ret = Utility::getLastAddressFromXFF(request_headers, 4);
     EXPECT_EQ(nullptr, ret.address_);
     EXPECT_FALSE(ret.single_address_);
   }

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -162,16 +162,22 @@ TEST(HttpUtility, getLastAddressFromXFF) {
     const std::string first_address = "192.0.2.10";
     const std::string second_address = "192.0.2.1";
     const std::string third_address = "10.0.0.1";
-    TestHeaderMapImpl request_headers{{"x-forwarded-for", "192.0.2.10,192.0.2.1,10.0.0.1"}};
+    TestHeaderMapImpl request_headers{{"x-forwarded-for", "192.0.2.10, 192.0.2.1 , 10.0.0.1"}};
     auto ret = Utility::getLastAddressFromXFF(request_headers);
     EXPECT_EQ(third_address, ret.address_->ip()->addressAsString());
     EXPECT_FALSE(ret.single_address_);
+
+    // Exercise ltrim().
     ret = Utility::getLastAddressFromXFF(request_headers, 1);
     EXPECT_EQ(second_address, ret.address_->ip()->addressAsString());
     EXPECT_FALSE(ret.single_address_);
+
+    // Exercise rtrim() and ltrim().
     ret = Utility::getLastAddressFromXFF(request_headers, 2);
     EXPECT_EQ(first_address, ret.address_->ip()->addressAsString());
     EXPECT_FALSE(ret.single_address_);
+
+    // No space trimming.
     ret = Utility::getLastAddressFromXFF(request_headers, 3);
     EXPECT_EQ(nullptr, ret.address_);
     EXPECT_FALSE(ret.single_address_);

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -163,21 +163,23 @@ TEST(HttpUtility, getLastAddressFromXFF) {
     const std::string second_address = "192.0.2.1";
     const std::string third_address = "10.0.0.1";
     TestHeaderMapImpl request_headers{{"x-forwarded-for", "192.0.2.10, 192.0.2.1 , 10.0.0.1"}};
+
+    // Exercise ltrim().
     auto ret = Utility::getLastAddressFromXFF(request_headers);
     EXPECT_EQ(third_address, ret.address_->ip()->addressAsString());
     EXPECT_FALSE(ret.single_address_);
 
-    // Exercise ltrim().
+    // Exercise rtrim() and ltrim().
     ret = Utility::getLastAddressFromXFF(request_headers, 1);
     EXPECT_EQ(second_address, ret.address_->ip()->addressAsString());
     EXPECT_FALSE(ret.single_address_);
 
-    // Exercise rtrim() and ltrim().
+    // No space trimming.
     ret = Utility::getLastAddressFromXFF(request_headers, 2);
     EXPECT_EQ(first_address, ret.address_->ip()->addressAsString());
     EXPECT_FALSE(ret.single_address_);
 
-    // No space trimming.
+    // No address found.
     ret = Utility::getLastAddressFromXFF(request_headers, 3);
     EXPECT_EQ(nullptr, ret.address_);
     EXPECT_FALSE(ret.single_address_);

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -159,6 +159,24 @@ TEST(HttpUtility, getLastAddressFromXFF) {
     EXPECT_FALSE(ret.single_address_);
   }
   {
+    const std::string first_address = "192.0.2.10";
+    const std::string second_address = "192.0.2.1";
+    const std::string third_address = "10.0.0.1";
+    TestHeaderMapImpl request_headers{{"x-forwarded-for", "192.0.2.10,192.0.2.1,10.0.0.1"}};
+    auto ret = Utility::getLastAddressFromXFF(request_headers);
+    EXPECT_EQ(third_address, ret.address_->ip()->addressAsString());
+    EXPECT_FALSE(ret.single_address_);
+    ret = Utility::getLastAddressFromXFF(request_headers, 1);
+    EXPECT_EQ(second_address, ret.address_->ip()->addressAsString());
+    EXPECT_FALSE(ret.single_address_);
+    ret = Utility::getLastAddressFromXFF(request_headers, 2);
+    EXPECT_EQ(first_address, ret.address_->ip()->addressAsString());
+    EXPECT_FALSE(ret.single_address_);
+    ret = Utility::getLastAddressFromXFF(request_headers, 3);
+    EXPECT_EQ(nullptr, ret.address_);
+    EXPECT_FALSE(ret.single_address_);
+  }
+  {
     TestHeaderMapImpl request_headers{{"x-forwarded-for", ""}};
     auto ret = Utility::getLastAddressFromXFF(request_headers);
     EXPECT_EQ(nullptr, ret.address_);


### PR DESCRIPTION
Currently, `Utility::getLastAddressFromXFF()` only handles lists that
use a comma plus a space as the separator.

Per https://tools.ietf.org/html/rfc7239#section-7.1, spaces are allowed
around commas — so we should handle that too.

This fixes #3607.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
