### PR TITLE
[WIP] common: call syscalls via Api::OsSysCalls and not directly.

### DIFF
--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -115,6 +115,7 @@ envoy_cc_library(
         ":address_lib",
         ":utility_lib",
         "//include/envoy/network:listen_socket_interface",
+        "//source/common/api:os_sys_calls_lib",
         "//source/common/common:assert_lib",
         "//source/common/ssl:context_lib",
     ],

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -7,6 +7,7 @@
 
 #include "envoy/common/exception.h"
 
+#include "common/api/os_sys_calls_impl.h"
 #include "common/common/assert.h"
 #include "common/common/fmt.h"
 #include "common/network/address_impl.h"
@@ -14,6 +15,13 @@
 
 namespace Envoy {
 namespace Network {
+
+void SocketImpl::close() {
+  if (fd_ != -1) {
+    Api::OsSysCallsSingleton::get().close(fd_);
+    fd_ = -1;
+  }
+}
 
 void ListenSocketImpl::doBind() {
   int rc = local_address_->bind(fd_);

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -21,12 +21,7 @@ public:
   // Network::Socket
   const Address::InstanceConstSharedPtr& localAddress() const override { return local_address_; }
   int fd() const override { return fd_; }
-  void close() override {
-    if (fd_ != -1) {
-      ::close(fd_);
-      fd_ = -1;
-    }
-  }
+  void close() override;
   void ensureOptions() {
     if (!options_) {
       options_ = std::make_shared<std::vector<OptionConstSharedPtr>>();


### PR DESCRIPTION
*Risk Level*: Low
*Testing*: bazel test //test/...
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Piotr Sikora <piotrsikora@google.com>