### PR TITLE
request_info: minor mock class improvements

### DIFF
--- a/test/mocks/request_info/mocks.cc
+++ b/test/mocks/request_info/mocks.cc
@@ -38,29 +38,29 @@ MockRequestInfo::MockRequestInfo()
   ON_CALL(*this, setUpstreamLocalAddress(_))
       .WillByDefault(
           Invoke([this](const Network::Address::InstanceConstSharedPtr& upstream_local_address) {
-            this->upstream_local_address_ = upstream_local_address;
+            upstream_local_address_ = upstream_local_address;
           }));
   ON_CALL(*this, upstreamLocalAddress()).WillByDefault(ReturnRef(upstream_local_address_));
   ON_CALL(*this, setDownstreamLocalAddress(_))
       .WillByDefault(
           Invoke([this](const Network::Address::InstanceConstSharedPtr& downstream_local_address) {
-            this->downstream_local_address_ = downstream_local_address;
+            downstream_local_address_ = downstream_local_address;
           }));
   ON_CALL(*this, downstreamLocalAddress()).WillByDefault(ReturnRef(downstream_local_address_));
   ON_CALL(*this, setDownstreamRemoteAddress(_))
       .WillByDefault(
           Invoke([this](const Network::Address::InstanceConstSharedPtr& downstream_remote_address) {
-            this->downstream_remote_address_ = downstream_remote_address;
+            downstream_remote_address_ = downstream_remote_address;
           }));
   ON_CALL(*this, downstreamRemoteAddress()).WillByDefault(ReturnRef(downstream_remote_address_));
   ON_CALL(*this, protocol()).WillByDefault(ReturnPointee(&protocol_));
   ON_CALL(*this, responseCode()).WillByDefault(ReturnPointee(&response_code_));
   ON_CALL(*this, addBytesReceived(_)).WillByDefault(Invoke([this](uint64_t bytes_received) {
-    this->bytes_received_ += bytes_received;
+    bytes_received_ += bytes_received;
   }));
   ON_CALL(*this, bytesReceived()).WillByDefault(ReturnPointee(&bytes_received_));
   ON_CALL(*this, addBytesSent(_)).WillByDefault(Invoke([this](uint64_t bytes_sent) {
-    this->bytes_sent_ += bytes_sent;
+    bytes_sent_ += bytes_sent;
   }));
   ON_CALL(*this, bytesSent()).WillByDefault(ReturnPointee(&bytes_sent_));
   ON_CALL(*this, dynamicMetadata()).WillByDefault(ReturnRef(metadata_));

--- a/test/mocks/request_info/mocks.h
+++ b/test/mocks/request_info/mocks.h
@@ -74,8 +74,6 @@ public:
   absl::optional<Http::Protocol> protocol_;
   absl::optional<uint32_t> response_code_;
   envoy::api::v2::core::Metadata metadata_;
-
-private:
   uint64_t bytes_received_{};
   uint64_t bytes_sent_{};
   Network::Address::InstanceConstSharedPtr upstream_local_address_;


### PR DESCRIPTION
*Description*:
Minor updates to `MockRequestInfo` class changes that were made in #3580 to ensure it remains as flexible as it was before.  Variables in mocks are generally public to ensure their interface is as flexible as possible for the tests that use them.  Also removed a few instances of unnecessary `this->`.

cc @d-kowalski @mattklein123 @jamessynge 

*Risk Level*: Low

*Testing*: N/A - only changes a mock class.
