### PR TITLE
thrift: sniffing thrift filter with request/response stats

### DIFF
--- a/api/envoy/extensions/filters/network/thrift_proxy/v2alpha1/BUILD
+++ b/api/envoy/extensions/filters/network/thrift_proxy/v2alpha1/BUILD
@@ -1,0 +1,8 @@
+load("//bazel:api_build_system.bzl", "api_proto_library")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library(
+    name = "thrift_proxy",
+    srcs = ["thrift_proxy.proto"],
+)

--- a/api/envoy/extensions/filters/network/thrift_proxy/v2alpha1/README.md
+++ b/api/envoy/extensions/filters/network/thrift_proxy/v2alpha1/README.md
@@ -1,0 +1,1 @@
+Protocol buffer definitions for the Thrift proxy.

--- a/api/envoy/extensions/filters/network/thrift_proxy/v2alpha1/thrift_proxy.proto
+++ b/api/envoy/extensions/filters/network/thrift_proxy/v2alpha1/thrift_proxy.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.thrift_proxy.v2alpha1;
+option go_package = "v2";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Extensions Thrift Proxy]
+// Thrift Proxy filter configuration.
+message ThriftProxy {
+  // The human readable prefix to use when emitting statistics.
+  string stat_prefix = 1 [(validate.rules).string.min_bytes = 1];
+}

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -66,8 +66,7 @@ EXTENSIONS = {
     "envoy.filters.network.redis_proxy":                "//source/extensions/filters/network/redis_proxy:config",
     "envoy.filters.network.ratelimit":                  "//source/extensions/filters/network/ratelimit:config",
     "envoy.filters.network.tcp_proxy":                  "//source/extensions/filters/network/tcp_proxy:config",
-    # TODO(zuercher): switch to config target once a filter exists
-    "envoy.filters.network.thrift_proxy":               "//source/extensions/filters/network/thrift_proxy:transport_lib",
+    "envoy.filters.network.thrift_proxy":               "//source/extensions/filters/network/thrift_proxy:config",
 
     #
     # Stat sinks

--- a/source/extensions/filters/network/thrift_proxy/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/BUILD
@@ -20,6 +20,20 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    deps = [
+        ":filter_lib",
+        "//include/envoy/registry",
+        "//source/common/config:filter_json_lib",
+        "//source/extensions/filters/network:well_known_names",
+        "//source/extensions/filters/network/common:factory_base_lib",
+        "@envoy_api//envoy/extensions/filters/network/thrift_proxy/v2alpha1:thrift_proxy_cc",
+    ],
+)
+
+envoy_cc_library(
     name = "decoder_lib",
     srcs = ["decoder.cc"],
     hdrs = ["decoder.h"],
@@ -27,6 +41,24 @@ envoy_cc_library(
         ":protocol_lib",
         ":transport_lib",
         "//source/common/buffer:buffer_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "filter_lib",
+    srcs = ["filter.cc"],
+    hdrs = ["filter.h"],
+    deps = [
+        ":decoder_lib",
+        "//include/envoy/network:connection_interface",
+        "//include/envoy/network:filter_interface",
+        "//include/envoy/stats:stats_interface",
+        "//include/envoy/stats:stats_macros",
+        "//include/envoy/stats:timespan",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/common:logger_lib",
+        "//source/common/network:filter_lib",
     ],
 )
 

--- a/source/extensions/filters/network/thrift_proxy/buffer_helper.h
+++ b/source/extensions/filters/network/thrift_proxy/buffer_helper.h
@@ -11,6 +11,52 @@ namespace NetworkFilters {
 namespace ThriftProxy {
 
 /**
+ * BufferWrapper provides a partial implementation of Buffer::Instance that is sufficient for
+ * BufferHelper to read Thrift protocol data without draining the buffer's contents.
+ */
+class BufferWrapper : public Buffer::Instance {
+public:
+  BufferWrapper(Buffer::Instance& underlying) : underlying_(underlying) {}
+
+  uint64_t position() { return position_; }
+
+  // Buffer::Instance
+  void copyOut(size_t start, uint64_t size, void* data) const override {
+    ASSERT(position_ + start + size <= underlying_.length());
+    underlying_.copyOut(start + position_, size, data);
+  }
+  void drain(uint64_t size) override {
+    ASSERT(position_ + size <= underlying_.length());
+    position_ += size;
+  }
+  uint64_t length() const override {
+    ASSERT(underlying_.length() >= position_);
+    return underlying_.length() - position_;
+  }
+  void* linearize(uint32_t size) override {
+    ASSERT(position_ + size <= underlying_.length());
+    uint8_t* p = static_cast<uint8_t*>(underlying_.linearize(position_ + size));
+    return p + position_;
+  }
+  void add(const void*, uint64_t) override { NOT_IMPLEMENTED; }
+  void addBufferFragment(Buffer::BufferFragment&) override { NOT_IMPLEMENTED; }
+  void add(const std::string&) override { NOT_IMPLEMENTED; }
+  void add(const Buffer::Instance&) override { NOT_IMPLEMENTED; }
+  void commit(Buffer::RawSlice*, uint64_t) override { NOT_IMPLEMENTED; }
+  uint64_t getRawSlices(Buffer::RawSlice*, uint64_t) const override { NOT_IMPLEMENTED; }
+  void move(Buffer::Instance&) override { NOT_IMPLEMENTED; }
+  void move(Buffer::Instance&, uint64_t) override { NOT_IMPLEMENTED; }
+  int read(int, uint64_t) override { NOT_IMPLEMENTED; }
+  uint64_t reserve(uint64_t, Buffer::RawSlice*, uint64_t) override { NOT_IMPLEMENTED; }
+  ssize_t search(const void*, uint64_t, size_t) const override { NOT_IMPLEMENTED; }
+  int write(int) override { NOT_IMPLEMENTED; }
+
+private:
+  Buffer::Instance& underlying_;
+  uint64_t position_{0};
+};
+
+/**
  * BufferHelper provides buffer operations for reading bytes and numbers in the various encodings
  * used by Thrift protocols.
  */

--- a/source/extensions/filters/network/thrift_proxy/config.cc
+++ b/source/extensions/filters/network/thrift_proxy/config.cc
@@ -1,0 +1,37 @@
+#include "extensions/filters/network/thrift_proxy/config.h"
+
+#include <string>
+
+#include "envoy/network/connection.h"
+#include "envoy/registry/registry.h"
+
+#include "extensions/filters/network/thrift_proxy/filter.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+
+Network::FilterFactoryCb ThriftProxyFilterConfigFactory::createFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::network::thrift_proxy::v2alpha1::ThriftProxy& proto_config,
+    Server::Configuration::FactoryContext& context) {
+  ASSERT(!proto_config.stat_prefix().empty());
+
+  const std::string stat_prefix = fmt::format("thrift.{}.", proto_config.stat_prefix());
+
+  return [stat_prefix, &context](Network::FilterManager& filter_manager) -> void {
+    filter_manager.addFilter(std::make_shared<Filter>(stat_prefix, context.scope()));
+  };
+}
+
+/**
+ * Static registration for the thrift filter. @see RegisterFactory.
+ */
+static Registry::RegisterFactory<ThriftProxyFilterConfigFactory,
+                                 Server::Configuration::NamedNetworkFilterConfigFactory>
+    registered_;
+
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/thrift_proxy/config.h
+++ b/source/extensions/filters/network/thrift_proxy/config.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/extensions/filters/network/thrift_proxy/v2alpha1/thrift_proxy.pb.h"
+#include "envoy/extensions/filters/network/thrift_proxy/v2alpha1/thrift_proxy.pb.validate.h"
+
+#include "extensions/filters/network/common/factory_base.h"
+#include "extensions/filters/network/well_known_names.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+
+/**
+ * Config registration for the thrift proxy filter. @see NamedNetworkFilterConfigFactory.
+ */
+class ThriftProxyFilterConfigFactory
+    : public Common::FactoryBase<
+          envoy::extensions::filters::network::thrift_proxy::v2alpha1::ThriftProxy> {
+public:
+  ThriftProxyFilterConfigFactory() : FactoryBase(NetworkFilterNames::get().THRIFT) {}
+
+private:
+  Network::FilterFactoryCb createFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::network::thrift_proxy::v2alpha1::ThriftProxy& proto_config,
+      Server::Configuration::FactoryContext& context) override;
+};
+
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/thrift_proxy/config.h
+++ b/source/extensions/filters/network/thrift_proxy/config.h
@@ -20,7 +20,7 @@ class ThriftProxyFilterConfigFactory
     : public Common::FactoryBase<
           envoy::extensions::filters::network::thrift_proxy::v2alpha1::ThriftProxy> {
 public:
-  ThriftProxyFilterConfigFactory() : FactoryBase(NetworkFilterNames::get().THRIFT) {}
+  ThriftProxyFilterConfigFactory() : FactoryBase(NetworkFilterNames::get().THRIFT_PROXY) {}
 
 private:
   Network::FilterFactoryCb createFilterFactoryFromProtoTyped(

--- a/source/extensions/filters/network/thrift_proxy/decoder.cc
+++ b/source/extensions/filters/network/thrift_proxy/decoder.cc
@@ -77,8 +77,9 @@ ProtocolState DecoderStateMachine::fieldBegin(Buffer::Instance& buffer) {
 // FieldValue -> FieldEnd (via stack return state)
 ProtocolState DecoderStateMachine::fieldValue(Buffer::Instance& buffer) {
   ASSERT(!stack_.empty());
-  FieldType field_type = stack_.back().elem_type_;
-  return handleValue(buffer, field_type, popReturnState());
+
+  Frame& frame = stack_.back();
+  return handleValue(buffer, frame.elem_type_, frame.return_state_);
 }
 
 // FieldEnd -> FieldBegin
@@ -86,6 +87,8 @@ ProtocolState DecoderStateMachine::fieldEnd(Buffer::Instance& buffer) {
   if (!proto_.readFieldEnd(buffer)) {
     return ProtocolState::WaitForData;
   }
+
+  popReturnState();
 
   return ProtocolState::FieldBegin;
 }

--- a/source/extensions/filters/network/thrift_proxy/filter.cc
+++ b/source/extensions/filters/network/thrift_proxy/filter.cc
@@ -1,0 +1,307 @@
+#include "extensions/filters/network/thrift_proxy/filter.h"
+
+#include "envoy/common/exception.h"
+
+#include "common/common/assert.h"
+
+#include "extensions/filters/network/thrift_proxy/buffer_helper.h"
+#include "extensions/filters/network/thrift_proxy/protocol.h"
+#include "extensions/filters/network/thrift_proxy/transport.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+
+Filter::Filter(const std::string& stat_prefix, Stats::Scope& scope)
+    : req_callbacks_(*this), resp_callbacks_(*this), stats_(generateStats(stat_prefix, scope)) {}
+
+Filter::~Filter() {}
+
+void Filter::onEvent(Network::ConnectionEvent event) {
+  bool any_active_request = !active_call_list_.empty() || req_ != nullptr || resp_ != nullptr;
+
+  if (event == Network::ConnectionEvent::RemoteClose && any_active_request) {
+    stats_.cx_destroy_local_with_active_rq_.inc();
+  }
+
+  if (event == Network::ConnectionEvent::LocalClose && any_active_request) {
+    stats_.cx_destroy_remote_with_active_rq_.inc();
+  }
+}
+
+Network::FilterStatus Filter::onData(Buffer::Instance& data, bool) {
+  if (!sniffing_) {
+    if (req_buffer_.length() > 0) {
+      // Stopped sniffing during response (in onWrite). Make sure leftover req_buffer_ contents are
+      // at the start of data or the upstream will see a corrupted request.
+      req_buffer_.move(data);
+      data.move(req_buffer_);
+      ASSERT(req_buffer_.length() == 0);
+    }
+
+    return Network::FilterStatus::Continue;
+  }
+
+  if (req_decoder_ == nullptr) {
+    req_decoder_ = std::make_unique<Decoder>(std::make_unique<AutoTransportImpl>(req_callbacks_),
+                                             std::make_unique<AutoProtocolImpl>(req_callbacks_));
+  }
+
+  ENVOY_LOG(trace, "thrift: read {} bytes", data.length());
+  req_buffer_.move(data);
+
+  try {
+    BufferWrapper wrapped(req_buffer_);
+
+    req_decoder_->onData(wrapped);
+
+    // Move consumed portion of request back to data for the upstream to consume.
+    uint64_t pos = wrapped.position();
+    if (pos > 0) {
+      data.move(req_buffer_, pos);
+    }
+  } catch (const EnvoyException& ex) {
+    ENVOY_LOG(error, "thrift error: {}", ex.what());
+    req_decoder_.reset();
+    data.move(req_buffer_);
+    stats_.request_decoding_error_.inc();
+    sniffing_ = false;
+  }
+
+  return Network::FilterStatus::Continue;
+}
+
+Network::FilterStatus Filter::onWrite(Buffer::Instance& data, bool) {
+  if (!sniffing_) {
+    if (resp_buffer_.length() > 0) {
+      // Stopped sniffing during request (in onData). Make sure resp_buffer_ contents are at the
+      // start of data or the downstream will see a corrupted response.
+      resp_buffer_.move(data);
+      data.move(resp_buffer_);
+      ASSERT(resp_buffer_.length() == 0);
+    }
+
+    return Network::FilterStatus::Continue;
+  }
+
+  if (resp_decoder_ == nullptr) {
+    resp_decoder_ = std::make_unique<Decoder>(std::make_unique<AutoTransportImpl>(resp_callbacks_),
+                                              std::make_unique<AutoProtocolImpl>(resp_callbacks_));
+  }
+
+  ENVOY_LOG(trace, "thrift wrote {} bytes", data.length());
+  resp_buffer_.move(data);
+
+  try {
+    BufferWrapper wrapped(resp_buffer_);
+
+    resp_decoder_->onData(wrapped);
+
+    // Move consumed portion of response back to data for the downstream to consume.
+    uint64_t pos = wrapped.position();
+    if (pos > 0) {
+      data.move(resp_buffer_, pos);
+    }
+  } catch (const EnvoyException& ex) {
+    ENVOY_LOG(error, "thrift error: {}", ex.what());
+    resp_decoder_.reset();
+    data.move(resp_buffer_);
+
+    stats_.response_decoding_error_.inc();
+    sniffing_ = false;
+  }
+
+  return Network::FilterStatus::Continue;
+}
+
+void Filter::chargeDownstreamRequestStart(MessageType msg_type, int32_t seq_id) {
+  if (req_ != nullptr) {
+    throw EnvoyException("unexpected request messageStart callback");
+  }
+
+  req_ = std::make_unique<ActiveMessage>(*this, msg_type, seq_id);
+
+  stats_.request_.inc();
+  switch (msg_type) {
+  case MessageType::Call:
+    stats_.request_call_.inc();
+    break;
+  case MessageType::Oneway:
+    stats_.request_oneway_.inc();
+    break;
+  default:
+    stats_.request_invalid_type_.inc();
+    break;
+  }
+}
+
+void Filter::chargeDownstreamRequestComplete() {
+  if (req_ == nullptr) {
+    throw EnvoyException("unexpected request messageComplete callback");
+  }
+
+  // One-way messages do not receive responses.
+  if (req_->msg_type_ == MessageType::Oneway) {
+    req_.reset();
+    return;
+  }
+
+  active_call_list_.emplace_back(std::move(req_));
+}
+
+void Filter::chargeUpstreamResponseStart(MessageType msg_type, int32_t seq_id) {
+  if (resp_ != nullptr) {
+    throw EnvoyException("unexpected response messageStart callback");
+  }
+
+  for (auto i = active_call_list_.begin(); i != active_call_list_.end(); i++) {
+    if ((*i)->seq_id_ == seq_id) {
+      resp_ = std::move(*i);
+      resp_->response_msg_type_ = msg_type;
+      active_call_list_.erase(i);
+      break;
+    }
+  }
+
+  if (resp_ == nullptr) {
+    throw EnvoyException(fmt::format("unknown reply seq_id {}", seq_id));
+  }
+}
+
+void Filter::chargeUpstreamResponseField(FieldType field_type, int16_t field_id) {
+  if (resp_ == nullptr) {
+    throw EnvoyException("unexpected response messageField callback");
+  }
+
+  if (resp_->response_msg_type_ != MessageType::Reply) {
+    // If this is not a reply, we'll count an exception instead of an error, so leave
+    // resp_->success_ unset.
+    return;
+  }
+
+  if (resp_->success_.has_value()) {
+    // If resp->success_ is already set, leave the existing value.
+    return;
+  }
+
+  // Successful replies have a single field, with field_id 0 that contains the response value.
+  // IDL-level exceptions are encoded as a single field with field_id >= 1.
+  resp_->success_ = field_id == 0 && field_type != FieldType::Stop;
+}
+
+void Filter::chargeUpstreamResponseComplete() {
+  if (resp_ == nullptr) {
+    throw EnvoyException("unexpected response messageComplete callback");
+  }
+
+  stats_.response_.inc();
+  switch (resp_->response_msg_type_) {
+  case MessageType::Reply:
+    stats_.response_reply_.inc();
+    break;
+  case MessageType::Exception:
+    stats_.response_exception_.inc();
+    break;
+  default:
+    stats_.response_invalid_type_.inc();
+    break;
+  }
+
+  if (resp_->success_.has_value()) {
+    if (resp_->success_.value()) {
+      stats_.response_success_.inc();
+    } else {
+      stats_.response_error_.inc();
+    }
+  }
+
+  resp_.reset();
+}
+
+void Filter::RequestCallbacks::transportFrameStart(absl::optional<uint32_t> size) {
+  UNREFERENCED_PARAMETER(size);
+  ENVOY_LOG(debug, "thrift request: started {} frame", parent_.req_decoder_->transport().name());
+}
+
+void Filter::RequestCallbacks::transportFrameComplete() {
+  ENVOY_LOG(debug, "thrift request: ended {} frame", parent_.req_decoder_->transport().name());
+}
+
+void Filter::RequestCallbacks::messageStart(const absl::string_view name, MessageType msg_type,
+                                            int32_t seq_id) {
+  ENVOY_LOG(debug, "thrift request: started {} message {}: {}",
+            parent_.req_decoder_->protocol().name(), name, seq_id);
+  parent_.chargeDownstreamRequestStart(msg_type, seq_id);
+}
+
+void Filter::RequestCallbacks::structBegin(const absl::string_view name) {
+  UNREFERENCED_PARAMETER(name);
+  ENVOY_LOG(debug, "thrift request: started {} struct", parent_.req_decoder_->protocol().name());
+}
+
+void Filter::RequestCallbacks::structField(const absl::string_view name, FieldType field_type,
+                                           int16_t field_id) {
+  UNREFERENCED_PARAMETER(name);
+  ENVOY_LOG(debug, "thrift request: started {} field {}, type {}",
+            parent_.req_decoder_->protocol().name(), field_id, static_cast<int8_t>(field_type));
+}
+
+void Filter::RequestCallbacks::structEnd() {
+  ENVOY_LOG(debug, "thrift request: ended {} struct", parent_.req_decoder_->protocol().name());
+}
+
+void Filter::RequestCallbacks::messageComplete() {
+  ENVOY_LOG(debug, "thrift request: ended {} message", parent_.req_decoder_->protocol().name());
+  parent_.chargeDownstreamRequestComplete();
+}
+
+void Filter::ResponseCallbacks::transportFrameStart(absl::optional<uint32_t> size) {
+  UNREFERENCED_PARAMETER(size);
+  ENVOY_LOG(debug, "thrift response: started {} frame", parent_.resp_decoder_->transport().name());
+}
+
+void Filter::ResponseCallbacks::transportFrameComplete() {
+  ENVOY_LOG(debug, "thrift response: ended {} frame", parent_.resp_decoder_->transport().name());
+}
+
+void Filter::ResponseCallbacks::messageStart(const absl::string_view name, MessageType msg_type,
+                                             int32_t seq_id) {
+  ENVOY_LOG(debug, "thrift response: started {} message {}: {}",
+            parent_.resp_decoder_->protocol().name(), name, seq_id);
+  parent_.chargeUpstreamResponseStart(msg_type, seq_id);
+}
+
+void Filter::ResponseCallbacks::structBegin(const absl::string_view name) {
+  UNREFERENCED_PARAMETER(name);
+  ENVOY_LOG(debug, "thrift response: started {} struct", parent_.req_decoder_->protocol().name());
+  depth_++;
+}
+
+void Filter::ResponseCallbacks::structField(const absl::string_view name, FieldType field_type,
+                                            int16_t field_id) {
+  UNREFERENCED_PARAMETER(name);
+  ENVOY_LOG(debug, "thrift response: started {} field {}, type {}",
+            parent_.req_decoder_->protocol().name(), field_id, static_cast<int8_t>(field_type));
+
+  if (depth_ == 1) {
+    // Only care about the outermost struct, which corresponds to the success or failure of the
+    // request.
+    parent_.chargeUpstreamResponseField(field_type, field_id);
+  }
+}
+
+void Filter::ResponseCallbacks::structEnd() {
+  ENVOY_LOG(debug, "thrift request: ended {} struct", parent_.req_decoder_->protocol().name());
+  depth_--;
+}
+
+void Filter::ResponseCallbacks::messageComplete() {
+  ENVOY_LOG(debug, "thrift response: ended {} message", parent_.resp_decoder_->protocol().name());
+  parent_.chargeUpstreamResponseComplete();
+}
+
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/thrift_proxy/filter.h
+++ b/source/extensions/filters/network/thrift_proxy/filter.h
@@ -1,0 +1,171 @@
+#pragma once
+
+#include "envoy/network/connection.h"
+#include "envoy/network/filter.h"
+#include "envoy/stats/stats.h"
+#include "envoy/stats/stats_macros.h"
+#include "envoy/stats/timespan.h"
+
+#include "common/buffer/buffer_impl.h"
+#include "common/common/logger.h"
+
+#include "extensions/filters/network/thrift_proxy/decoder.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+
+/**
+ * All thrift filter stats. @see stats_macros.h
+ */
+// clang-format off
+#define ALL_THRIFT_FILTER_STATS(COUNTER, GAUGE, HISTOGRAM)                                         \
+  COUNTER(request)                                                                                 \
+  COUNTER(request_call)                                                                            \
+  COUNTER(request_oneway)                                                                          \
+  COUNTER(request_invalid_type)                                                                    \
+  GAUGE(request_active)                                                                            \
+  COUNTER(request_decoding_error)                                                                  \
+  HISTOGRAM(request_time_ms)                                                                       \
+  COUNTER(response)                                                                                \
+  COUNTER(response_reply)                                                                          \
+  COUNTER(response_success)                                                                        \
+  COUNTER(response_error)                                                                          \
+  COUNTER(response_exception)                                                                      \
+  COUNTER(response_invalid_type)                                                                   \
+  COUNTER(response_decoding_error)                                                                 \
+  COUNTER(cx_destroy_local_with_active_rq)                                                         \
+  COUNTER(cx_destroy_remote_with_active_rq)
+// clang-format on
+
+/**
+ * Struct definition for all mongo proxy stats. @see stats_macros.h
+ */
+struct ThriftFilterStats {
+  ALL_THRIFT_FILTER_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT)
+};
+
+/**
+ * A sniffing filter for thrift traffic.
+ */
+class Filter : public Network::Filter,
+               public Network::ConnectionCallbacks,
+               Logger::Loggable<Logger::Id::thrift> {
+public:
+  Filter(const std::string& stat_prefix, Stats::Scope& scope);
+  ~Filter();
+
+  // Network::ReadFilter
+  Network::FilterStatus onData(Buffer::Instance& data, bool end_stream) override;
+  Network::FilterStatus onNewConnection() override { return Network::FilterStatus::Continue; }
+  void initializeReadFilterCallbacks(Network::ReadFilterCallbacks&) override {}
+
+  // Network::WriteFilter
+  Network::FilterStatus onWrite(Buffer::Instance& data, bool end_stream) override;
+
+  // Network::ConnectionCallbacks
+  void onEvent(Network::ConnectionEvent) override;
+  void onAboveWriteBufferHighWatermark() override {}
+  void onBelowWriteBufferLowWatermark() override {}
+
+private:
+  // RequestCallbacks handles callbacks related to decoding downstream requests.
+  class RequestCallbacks : public virtual ProtocolCallbacks, public virtual TransportCallbacks {
+  public:
+    RequestCallbacks(Filter& parent) : parent_(parent) {}
+
+    // TransportCallbacks
+    void transportFrameStart(absl::optional<uint32_t> size) override;
+    void transportFrameComplete() override;
+
+    // ProtocolCallbacks
+    void messageStart(const absl::string_view name, MessageType msg_type, int32_t seq_id) override;
+    void structBegin(const absl::string_view name) override;
+    void structField(const absl::string_view name, FieldType field_type, int16_t field_id) override;
+    void structEnd() override;
+    void messageComplete() override;
+
+  private:
+    Filter& parent_;
+  };
+
+  // ResponseCallbacks handles callbacks related to decoding upstream responses.
+  class ResponseCallbacks : public virtual ProtocolCallbacks, public virtual TransportCallbacks {
+  public:
+    ResponseCallbacks(Filter& parent) : parent_(parent) {}
+
+    // TransportCallbacks
+    void transportFrameStart(absl::optional<uint32_t> size) override;
+    void transportFrameComplete() override;
+
+    // ProtocolCallbacks
+    void messageStart(const absl::string_view name, MessageType msg_type, int32_t seq_id) override;
+    void structBegin(const absl::string_view name) override;
+    void structField(const absl::string_view name, FieldType field_type, int16_t field_id) override;
+    void structEnd() override;
+    void messageComplete() override;
+
+  private:
+    Filter& parent_;
+    int depth_{0};
+  };
+
+  // ActiveMessage tracks downstream requests for which no response has been received.
+  struct ActiveMessage {
+    ActiveMessage(Filter& parent, MessageType msg_type, int32_t seq_id)
+        : parent_(parent), request_timer_(new Stats::Timespan(parent_.stats_.request_time_ms_)),
+          msg_type_(msg_type), seq_id_(seq_id) {
+      parent_.stats_.request_active_.inc();
+    }
+    ~ActiveMessage() {
+      request_timer_->complete();
+      parent_.stats_.request_active_.dec();
+    }
+
+    Filter& parent_;
+    Stats::TimespanPtr request_timer_;
+    const MessageType msg_type_;
+    const int32_t seq_id_;
+    MessageType response_msg_type_{};
+    absl::optional<bool> success_{};
+  };
+  typedef std::unique_ptr<ActiveMessage> ActiveMessagePtr;
+
+  ThriftFilterStats generateStats(const std::string& prefix, Stats::Scope& scope) {
+    return ThriftFilterStats{ALL_THRIFT_FILTER_STATS(POOL_COUNTER_PREFIX(scope, prefix),
+                                                     POOL_GAUGE_PREFIX(scope, prefix),
+                                                     POOL_HISTOGRAM_PREFIX(scope, prefix))};
+  }
+
+  void chargeDownstreamRequestStart(MessageType msg_type, int32_t seq_id);
+  void chargeDownstreamRequestComplete();
+  void chargeUpstreamResponseStart(MessageType msg_type, int32_t seq_id);
+  void chargeUpstreamResponseField(FieldType field_type, int16_t field_id);
+  void chargeUpstreamResponseComplete();
+
+  // Downstream request decoder, callbacks, and buffer.
+  DecoderPtr req_decoder_{};
+  RequestCallbacks req_callbacks_;
+  Buffer::OwnedImpl req_buffer_;
+  // Request currently being decoded.
+  ActiveMessagePtr req_;
+
+  // Upstream response decoder, callbacks, and buffer.
+  DecoderPtr resp_decoder_{};
+  ResponseCallbacks resp_callbacks_;
+  Buffer::OwnedImpl resp_buffer_;
+  // Response currently being decoded.
+  ActiveMessagePtr resp_;
+
+  // List of active request messages.
+  std::list<ActiveMessagePtr> active_call_list_;
+
+  bool sniffing_{true};
+  ThriftFilterStats stats_;
+};
+
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/thrift_proxy/filter.h
+++ b/source/extensions/filters/network/thrift_proxy/filter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <unordered_map>
+
 #include "envoy/network/connection.h"
 #include "envoy/network/filter.h"
 #include "envoy/stats/stats.h"
@@ -159,7 +161,7 @@ private:
   ActiveMessagePtr resp_;
 
   // List of active request messages.
-  std::list<ActiveMessagePtr> active_call_list_;
+  std::unordered_map<int32_t, ActiveMessagePtr> active_call_map_;
 
   bool sniffing_{true};
   ThriftFilterStats stats_;

--- a/source/extensions/filters/network/thrift_proxy/protocol.h
+++ b/source/extensions/filters/network/thrift_proxy/protocol.h
@@ -101,7 +101,7 @@ public:
   virtual void structBegin(const absl::string_view name) PURE;
 
   /**
-   * Indicates that that start of Thrift protocol struct field was detected.
+   * Indicates that the start of Thrift protocol struct field was detected.
    * @param name the name of the field, if available
    * @param field_type the type of the field
    * @param field_id the field id

--- a/source/extensions/filters/network/well_known_names.h
+++ b/source/extensions/filters/network/well_known_names.h
@@ -29,7 +29,7 @@ public:
   // Authorization filter
   const std::string EXT_AUTHORIZATION = "envoy.ext_authz";
   // Thrift proxy filter
-  const std::string THRIFT_PROXY = "envoy.thrift_proxy";
+  const std::string THRIFT_PROXY = "envoy.filters.network.thrift_proxy";
 
   // Converts names from v1 to v2
   const Config::V1Converter v1_converter_;

--- a/source/extensions/filters/network/well_known_names.h
+++ b/source/extensions/filters/network/well_known_names.h
@@ -28,6 +28,8 @@ public:
   const std::string TCP_PROXY = "envoy.tcp_proxy";
   // Authorization filter
   const std::string EXT_AUTHORIZATION = "envoy.ext_authz";
+  // Thrift filter
+  const std::string THRIFT = "envoy.thrift";
 
   // Converts names from v1 to v2
   const Config::V1Converter v1_converter_;

--- a/source/extensions/filters/network/well_known_names.h
+++ b/source/extensions/filters/network/well_known_names.h
@@ -28,8 +28,8 @@ public:
   const std::string TCP_PROXY = "envoy.tcp_proxy";
   // Authorization filter
   const std::string EXT_AUTHORIZATION = "envoy.ext_authz";
-  // Thrift filter
-  const std::string THRIFT = "envoy.thrift";
+  // Thrift proxy filter
+  const std::string THRIFT_PROXY = "envoy.thrift_proxy";
 
   // Converts names from v1 to v2
   const Config::V1Converter v1_converter_;

--- a/test/extensions/filters/network/thrift_proxy/BUILD
+++ b/test/extensions/filters/network/thrift_proxy/BUILD
@@ -72,6 +72,16 @@ envoy_extension_cc_test(
 )
 
 envoy_extension_cc_test(
+    name = "config_test",
+    srcs = ["config_test.cc"],
+    extension_name = "envoy.filters.network.thrift_proxy",
+    deps = [
+        "//source/extensions/filters/network/thrift_proxy:config",
+        "//test/mocks/server:server_mocks",
+    ],
+)
+
+envoy_extension_cc_test(
     name = "decoder_test",
     srcs = ["decoder_test.cc"],
     extension_name = "envoy.filters.network.thrift_proxy",
@@ -80,6 +90,19 @@ envoy_extension_cc_test(
         "//source/extensions/filters/network/thrift_proxy:decoder_lib",
         "//test/test_common:printers_lib",
         "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "filter_test",
+    srcs = ["filter_test.cc"],
+    extension_name = "envoy.filters.network.thrift_proxy",
+    deps = [
+        ":utility_lib",
+        "//source/common/stats:stats_lib",
+        "//source/extensions/filters/network/thrift_proxy:filter_lib",
+        "//test/mocks/network:network_mocks",
+        "//test/test_common:printers_lib",
     ],
 )
 

--- a/test/extensions/filters/network/thrift_proxy/buffer_helper_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/buffer_helper_test.cc
@@ -15,6 +15,50 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace ThriftProxy {
 
+TEST(BufferWrapperTest, ImplementedFunctions) {
+  Buffer::OwnedImpl buffer;
+  addString(buffer, "abcdefghij");
+
+  BufferWrapper wrapper(buffer);
+  {
+    char s[4] = {0};
+    wrapper.copyOut(0, 3, s);
+    EXPECT_EQ("abc", std::string(s));
+    EXPECT_EQ(10, wrapper.length());
+    EXPECT_EQ(0, wrapper.position());
+  }
+
+  {
+    char s[6] = {0};
+    wrapper.copyOut(5, 5, s);
+    EXPECT_EQ("fghij", std::string(s));
+    EXPECT_EQ(10, wrapper.length());
+    EXPECT_EQ(0, wrapper.position());
+  }
+
+  {
+    std::string s(static_cast<char*>(wrapper.linearize(5)), 5);
+    EXPECT_EQ("abcde", s);
+    EXPECT_EQ(0, wrapper.position());
+  }
+
+  wrapper.drain(2);
+
+  {
+    char s[4] = {0};
+    wrapper.copyOut(4, 3, s);
+    EXPECT_EQ("ghi", std::string(s));
+    EXPECT_EQ(8, wrapper.length());
+    EXPECT_EQ(2, wrapper.position());
+  }
+
+  {
+    std::string s(static_cast<char*>(wrapper.linearize(8)), 8);
+    EXPECT_EQ("cdefghij", s);
+    EXPECT_EQ(2, wrapper.position());
+  }
+}
+
 TEST(BufferHelperTest, PeekI8) {
   {
     Buffer::OwnedImpl buffer;

--- a/test/extensions/filters/network/thrift_proxy/config_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/config_test.cc
@@ -1,0 +1,55 @@
+#include "envoy/extensions/filters/network/thrift_proxy/v2alpha1/thrift_proxy.pb.validate.h"
+
+#include "extensions/filters/network/thrift_proxy/config.h"
+
+#include "test/mocks/server/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+
+TEST(ThriftFilterConfigTest, ValidateFail) {
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  EXPECT_THROW(
+      ThriftProxyFilterConfigFactory().createFilterFactoryFromProto(
+          envoy::extensions::filters::network::thrift_proxy::v2alpha1::ThriftProxy(), context),
+      ProtoValidationException);
+}
+
+TEST(ThriftFilterConfigTest, ValidProtoConfiguration) {
+  envoy::extensions::filters::network::thrift_proxy::v2alpha1::ThriftProxy config{};
+
+  config.set_stat_prefix("my_stat_prefix");
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  ThriftProxyFilterConfigFactory factory;
+  Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, context);
+  Network::MockConnection connection;
+  EXPECT_CALL(connection, addFilter(_));
+  cb(connection);
+}
+
+TEST(ThriftFilterConfigTest, ThriftProxyWithEmptyProto) {
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  ThriftProxyFilterConfigFactory factory;
+  envoy::extensions::filters::network::thrift_proxy::v2alpha1::ThriftProxy config =
+      *dynamic_cast<envoy::extensions::filters::network::thrift_proxy::v2alpha1::ThriftProxy*>(
+          factory.createEmptyConfigProto().get());
+  config.set_stat_prefix("my_stat_prefix");
+
+  Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, context);
+  Network::MockConnection connection;
+  EXPECT_CALL(connection, addFilter(_));
+  cb(connection);
+}
+
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/network/thrift_proxy/decoder_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/decoder_test.cc
@@ -153,12 +153,18 @@ TEST_P(DecoderStateMachineValueTest, NoFieldValueData) {
       .WillOnce(DoAll(SetArgReferee<1>(std::string("")), SetArgReferee<2>(field_type),
                       SetArgReferee<3>(1), Return(true)));
   expectValue(proto, field_type, false);
+  expectValue(proto, field_type, true);
+  EXPECT_CALL(proto, readFieldEnd(Ref(buffer))).WillOnce(Return(true));
+  EXPECT_CALL(proto, readFieldBegin(Ref(buffer), _, _, _)).WillOnce(Return(false));
 
   DecoderStateMachine dsm(proto);
 
   dsm.setCurrentState(ProtocolState::FieldBegin);
   EXPECT_EQ(dsm.run(buffer), ProtocolState::WaitForData);
   EXPECT_EQ(dsm.currentState(), ProtocolState::FieldValue);
+
+  EXPECT_EQ(dsm.run(buffer), ProtocolState::WaitForData);
+  EXPECT_EQ(dsm.currentState(), ProtocolState::FieldBegin);
 }
 
 TEST_P(DecoderStateMachineValueTest, FieldValue) {

--- a/test/extensions/filters/network/thrift_proxy/filter_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filter_test.cc
@@ -1,0 +1,542 @@
+#include "common/buffer/buffer_impl.h"
+#include "common/stats/stats_impl.h"
+
+#include "extensions/filters/network/thrift_proxy/buffer_helper.h"
+#include "extensions/filters/network/thrift_proxy/filter.h"
+
+#include "test/extensions/filters/network/thrift_proxy/utility.h"
+#include "test/mocks/network/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::NiceMock;
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+
+class ThriftFilterTest : public testing::Test {
+public:
+  ThriftFilterTest() {}
+
+  void initializeFilter() {
+    for (auto counter : store_.counters()) {
+      counter->reset();
+    }
+
+    filter_.reset(new Filter("test.", store_));
+    filter_->initializeReadFilterCallbacks(read_filter_callbacks_);
+    filter_->onNewConnection();
+
+    // NOP currently.
+    filter_->onAboveWriteBufferHighWatermark();
+    filter_->onBelowWriteBufferLowWatermark();
+  }
+
+  void writeFramedBinaryMessage(Buffer::Instance& buffer, MessageType msg_type, int32_t seq_id) {
+    uint8_t mt = static_cast<int8_t>(msg_type);
+    uint8_t s1 = (seq_id >> 24) & 0xFF;
+    uint8_t s2 = (seq_id >> 16) & 0xFF;
+    uint8_t s3 = (seq_id >> 8) & 0xFF;
+    uint8_t s4 = seq_id & 0xFF;
+
+    addSeq(buffer, {
+                       0x00, 0x00, 0x00, 0x1d,                          // framed: 29 bytes
+                       0x80, 0x01, 0x00, mt,                            // binary proto, type
+                       0x00, 0x00, 0x00, 0x04, 'n', 'a', 'm', 'e',      // message name
+                       s1,   s2,   s3,   s4,                            // sequence id
+                       0x0b, 0x00, 0x00,                                // begin string field
+                       0x00, 0x00, 0x00, 0x05, 'f', 'i', 'e', 'l', 'd', // string
+                       0x00,                                            // stop field
+                   });
+  }
+
+  void writePartialFramedBinaryMessage(Buffer::Instance& buffer, MessageType msg_type,
+                                       int32_t seq_id, bool start) {
+    if (start) {
+      uint8_t mt = static_cast<int8_t>(msg_type);
+      uint8_t s1 = (seq_id >> 24) & 0xFF;
+      uint8_t s2 = (seq_id >> 16) & 0xFF;
+      uint8_t s3 = (seq_id >> 8) & 0xFF;
+      uint8_t s4 = seq_id & 0xFF;
+
+      addSeq(buffer, {
+                         0x00, 0x00, 0x00, 0x2d,                     // framed: 45 bytes
+                         0x80, 0x01, 0x00, mt,                       // binary proto, type
+                         0x00, 0x00, 0x00, 0x04, 'n', 'a', 'm', 'e', // message name
+                         s1,   s2,   s3,   s4,                       // sequence id
+                         0x0c, 0x00, 0x00,                           // begin struct field
+                         0x0b, 0x00, 0x01,                           // begin string field
+                         0x00, 0x00, 0x00, 0x05                      // string length only
+                     });
+    } else {
+      addSeq(buffer, {
+                         'f',  'i',  'e',  'l',  'd',                     // string data
+                         0x0b, 0x00, 0x02,                                // begin string field
+                         0x00, 0x00, 0x00, 0x05, 'x', 'x', 'x', 'x', 'x', // string
+                         0x00,                                            // stop field
+                         0x00,                                            // stop field
+                     });
+    }
+  }
+
+  void writeFramedBinaryTApplicationException(Buffer::Instance& buffer, int32_t seq_id) {
+    uint8_t s1 = (seq_id >> 24) & 0xFF;
+    uint8_t s2 = (seq_id >> 16) & 0xFF;
+    uint8_t s3 = (seq_id >> 8) & 0xFF;
+    uint8_t s4 = seq_id & 0xFF;
+
+    addSeq(buffer, {
+                       0x00, 0x00, 0x00, 0x24,                          // framed: 36 bytes
+                       0x80, 0x01, 0x00, 0x03,                          // binary, exception
+                       0x00, 0x00, 0x00, 0x04, 'n', 'a', 'm', 'e',      // message name
+                       s1,   s2,   s3,   s4,                            // sequence id
+                       0x0B, 0x00, 0x01,                                // begin string field
+                       0x00, 0x00, 0x00, 0x05, 'e', 'r', 'r', 'o', 'r', // string
+                       0x08, 0x00, 0x02,                                // begin i32 field
+                       0x00, 0x00, 0x00, 0x01,                          // exception type 1
+                       0x00,                                            // stop field
+                   });
+  }
+
+  void writeFramedBinaryIDLException(Buffer::Instance& buffer, int32_t seq_id) {
+    uint8_t s1 = (seq_id >> 24) & 0xFF;
+    uint8_t s2 = (seq_id >> 16) & 0xFF;
+    uint8_t s3 = (seq_id >> 8) & 0xFF;
+    uint8_t s4 = seq_id & 0xFF;
+
+    addSeq(buffer, {
+                       0x00, 0x00, 0x00, 0x23,                     // framed: 35 bytes
+                       0x80, 0x01, 0x00, 0x02,                     // binary proto, reply
+                       0x00, 0x00, 0x00, 0x04, 'n', 'a', 'm', 'e', // message name
+                       s1,   s2,   s3,   s4,                       // sequence id
+                       0x0C, 0x00, 0x02,                           // begin exception struct
+                       0x0B, 0x00, 0x01,                           // begin string field
+                       0x00, 0x00, 0x00, 0x03, 'e', 'r', 'r',      // string
+                       0x00,                                       // exception struct stop
+                       0x00,                                       // reply struct stop field
+                   });
+  }
+
+  Buffer::OwnedImpl buffer_;
+  Buffer::OwnedImpl write_buffer_;
+  Stats::IsolatedStoreImpl store_;
+  std::unique_ptr<Filter> filter_;
+  NiceMock<Network::MockReadFilterCallbacks> read_filter_callbacks_;
+};
+
+TEST_F(ThriftFilterTest, OnDataHandlesThriftCall) {
+  initializeFilter();
+  writeFramedBinaryMessage(buffer_, MessageType::Call, 0x0F);
+
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+  EXPECT_EQ(1U, store_.counter("test.request").value());
+  EXPECT_EQ(1U, store_.counter("test.request_call").value());
+  EXPECT_EQ(0U, store_.counter("test.request_oneway").value());
+  EXPECT_EQ(0U, store_.counter("test.request_invalid_type").value());
+  EXPECT_EQ(0U, store_.counter("test.request_decoding_error").value());
+  EXPECT_EQ(1U, store_.gauge("test.request_active").value());
+  EXPECT_EQ(0U, store_.counter("test.response").value());
+}
+
+TEST_F(ThriftFilterTest, OnDataHandlesThriftOneWay) {
+  initializeFilter();
+  writeFramedBinaryMessage(buffer_, MessageType::Oneway, 0x0F);
+
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+  EXPECT_EQ(1U, store_.counter("test.request").value());
+  EXPECT_EQ(0U, store_.counter("test.request_call").value());
+  EXPECT_EQ(1U, store_.counter("test.request_oneway").value());
+  EXPECT_EQ(0U, store_.counter("test.request_invalid_type").value());
+  EXPECT_EQ(0U, store_.counter("test.request_decoding_error").value());
+  EXPECT_EQ(0U, store_.gauge("test.request_active").value());
+  EXPECT_EQ(0U, store_.counter("test.response").value());
+}
+
+TEST_F(ThriftFilterTest, OnDataHandlesFrameSplitAcrossBuffers) {
+  initializeFilter();
+
+  writePartialFramedBinaryMessage(buffer_, MessageType::Call, 0x10, true);
+  std::string expected_contents = bufferToString(buffer_);
+  uint64_t len = buffer_.length();
+
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+
+  // Filter passes on the partial buffer, up to the last 4 bytes which it needs to resume the
+  // decoder on the next call.
+  std::string contents = bufferToString(buffer_);
+  EXPECT_EQ(len - 4, buffer_.length());
+  EXPECT_EQ(expected_contents.substr(0, len - 4), contents);
+
+  buffer_.drain(buffer_.length());
+
+  // Complete the buffer
+  writePartialFramedBinaryMessage(buffer_, MessageType::Call, 0x10, false);
+  expected_contents = expected_contents.substr(len - 4) + bufferToString(buffer_);
+  len = buffer_.length();
+
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+
+  // Filter buffered bytes from end of first buffer and passes them on now.
+  contents = bufferToString(buffer_);
+  EXPECT_EQ(len + 4, buffer_.length());
+  EXPECT_EQ(expected_contents, contents);
+
+  EXPECT_EQ(1U, store_.counter("test.request_call").value());
+  EXPECT_EQ(0U, store_.counter("test.request_decoding_error").value());
+}
+
+TEST_F(ThriftFilterTest, OnDataHandlesInvalidMsgType) {
+  initializeFilter();
+  writeFramedBinaryMessage(buffer_, MessageType::Reply, 0x0F); // reply is invalid for a request
+
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+  EXPECT_EQ(1U, store_.counter("test.request").value());
+  EXPECT_EQ(0U, store_.counter("test.request_call").value());
+  EXPECT_EQ(0U, store_.counter("test.request_oneway").value());
+  EXPECT_EQ(1U, store_.counter("test.request_invalid_type").value());
+  EXPECT_EQ(1U, store_.gauge("test.request_active").value());
+  EXPECT_EQ(0U, store_.counter("test.response").value());
+}
+
+TEST_F(ThriftFilterTest, OnDataHandlesProtocolError) {
+  initializeFilter();
+  addSeq(buffer_, {
+                      0x00, 0x00, 0x00, 0x1d,                     // framed: 29 bytes
+                      0x80, 0x01, 0x00, 0xFF,                     // binary, illegal type
+                      0x00, 0x00, 0x00, 0x04, 'n', 'a', 'm', 'e', // message name
+                      0x00, 0x00, 0x00, 0x01,                     // sequence id
+                      0x00,                                       // struct stop field
+                  });
+  uint64_t len = buffer_.length();
+
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+  EXPECT_EQ(1U, store_.counter("test.request_decoding_error").value());
+  EXPECT_EQ(len, buffer_.length());
+
+  // Sniffing is now disabled.
+  buffer_.drain(buffer_.length());
+  writeFramedBinaryMessage(buffer_, MessageType::Oneway, 0x0F);
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+  EXPECT_EQ(0U, store_.counter("test.request").value());
+}
+
+TEST_F(ThriftFilterTest, OnDataHandlesProtocolErrorOnWrite) {
+  initializeFilter();
+
+  // Start the read buffer
+  writePartialFramedBinaryMessage(buffer_, MessageType::Call, 0x10, true);
+  uint64_t len = buffer_.length();
+
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+  len -= buffer_.length();
+
+  // Disable sniffing
+  addSeq(write_buffer_, {
+                            0x00, 0x00, 0x00, 0x1d,                     // framed: 29 bytes
+                            0x80, 0x01, 0x00, 0xFF,                     // binary, illegal type
+                            0x00, 0x00, 0x00, 0x04, 'n', 'a', 'm', 'e', // message name
+                            0x00, 0x00, 0x00, 0x01,                     // sequence id
+                            0x00,                                       // struct stop field
+                        });
+  EXPECT_EQ(filter_->onWrite(write_buffer_, false), Network::FilterStatus::Continue);
+  EXPECT_EQ(1U, store_.counter("test.response_decoding_error").value());
+
+  // Complete the read buffer
+  writePartialFramedBinaryMessage(buffer_, MessageType::Call, 0x10, false);
+  len += buffer_.length();
+
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+  len -= buffer_.length();
+  EXPECT_EQ(0, len);
+}
+
+TEST_F(ThriftFilterTest, OnWriteHandlesThriftReply) {
+  initializeFilter();
+  writeFramedBinaryMessage(buffer_, MessageType::Call, 0x0F); // set up request
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+  EXPECT_EQ(1U, store_.counter("test.request").value());
+  EXPECT_EQ(1U, store_.gauge("test.request_active").value());
+
+  writeFramedBinaryMessage(write_buffer_, MessageType::Reply, 0x0F);
+  EXPECT_EQ(filter_->onWrite(write_buffer_, false), Network::FilterStatus::Continue);
+
+  EXPECT_EQ(1U, store_.counter("test.response").value());
+  EXPECT_EQ(1U, store_.counter("test.response_reply").value());
+  EXPECT_EQ(1U, store_.counter("test.response_success").value());
+  EXPECT_EQ(0U, store_.counter("test.response_error").value());
+  EXPECT_EQ(0U, store_.counter("test.response_exception").value());
+  EXPECT_EQ(0U, store_.counter("test.response_invalid_type").value());
+  EXPECT_EQ(0U, store_.counter("test.response_decoding_error").value());
+  EXPECT_EQ(0U, store_.gauge("test.request_active").value());
+}
+
+TEST_F(ThriftFilterTest, OnWriteHandlesOutOrOrderThriftReply) {
+  initializeFilter();
+
+  // set up two requests
+  writeFramedBinaryMessage(buffer_, MessageType::Call, 1);
+  writeFramedBinaryMessage(buffer_, MessageType::Call, 2);
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+  EXPECT_EQ(2U, store_.counter("test.request").value());
+  EXPECT_EQ(2U, store_.gauge("test.request_active").value());
+
+  writeFramedBinaryMessage(write_buffer_, MessageType::Reply, 2);
+  EXPECT_EQ(filter_->onWrite(write_buffer_, false), Network::FilterStatus::Continue);
+
+  EXPECT_EQ(1U, store_.counter("test.response").value());
+  EXPECT_EQ(1U, store_.counter("test.response_reply").value());
+  EXPECT_EQ(1U, store_.counter("test.response_success").value());
+  EXPECT_EQ(0U, store_.counter("test.response_error").value());
+  EXPECT_EQ(1U, store_.gauge("test.request_active").value());
+
+  write_buffer_.drain(write_buffer_.length());
+  writeFramedBinaryMessage(write_buffer_, MessageType::Reply, 1);
+  EXPECT_EQ(filter_->onWrite(write_buffer_, false), Network::FilterStatus::Continue);
+
+  EXPECT_EQ(2U, store_.counter("test.response").value());
+  EXPECT_EQ(2U, store_.counter("test.response_reply").value());
+  EXPECT_EQ(2U, store_.counter("test.response_success").value());
+  EXPECT_EQ(0U, store_.counter("test.response_error").value());
+  EXPECT_EQ(0U, store_.gauge("test.request_active").value());
+}
+
+TEST_F(ThriftFilterTest, OnWriteHandlesFrameSplitAcrossBuffers) {
+  initializeFilter();
+
+  writeFramedBinaryMessage(buffer_, MessageType::Call, 0x0F); // set up request
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+
+  writePartialFramedBinaryMessage(write_buffer_, MessageType::Reply, 0x0F, true);
+  std::string expected_contents = bufferToString(write_buffer_);
+  uint64_t len = write_buffer_.length();
+
+  EXPECT_EQ(filter_->onWrite(write_buffer_, false), Network::FilterStatus::Continue);
+
+  // Filter passes on the partial buffer, up to the last 4 bytes which it needs to resume the
+  // decoder on the next call.
+  std::string contents = bufferToString(write_buffer_);
+  EXPECT_EQ(len - 4, write_buffer_.length());
+  EXPECT_EQ(expected_contents.substr(0, len - 4), contents);
+
+  write_buffer_.drain(write_buffer_.length());
+
+  // Complete the buffer
+  writePartialFramedBinaryMessage(write_buffer_, MessageType::Reply, 0x0F, false);
+  expected_contents = expected_contents.substr(len - 4) + bufferToString(write_buffer_);
+  len = write_buffer_.length();
+
+  EXPECT_EQ(filter_->onWrite(write_buffer_, false), Network::FilterStatus::Continue);
+
+  // Filter buffered bytes from end of first buffer and passes them on now.
+  contents = bufferToString(write_buffer_);
+  EXPECT_EQ(len + 4, write_buffer_.length());
+  EXPECT_EQ(expected_contents, contents);
+
+  EXPECT_EQ(1U, store_.counter("test.response").value());
+  EXPECT_EQ(1U, store_.counter("test.response_reply").value());
+  EXPECT_EQ(1U, store_.counter("test.response_success").value());
+  EXPECT_EQ(0U, store_.counter("test.response_decoding_error").value());
+}
+
+TEST_F(ThriftFilterTest, OnWriteHandlesTApplicationException) {
+  initializeFilter();
+  writeFramedBinaryMessage(buffer_, MessageType::Call, 0x0F); // set up request
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+  EXPECT_EQ(1U, store_.counter("test.request").value());
+  EXPECT_EQ(1U, store_.gauge("test.request_active").value());
+
+  writeFramedBinaryTApplicationException(write_buffer_, 0x0F);
+  EXPECT_EQ(filter_->onWrite(write_buffer_, false), Network::FilterStatus::Continue);
+
+  EXPECT_EQ(1U, store_.counter("test.response").value());
+  EXPECT_EQ(0U, store_.counter("test.response_reply").value());
+  EXPECT_EQ(0U, store_.counter("test.response_success").value());
+  EXPECT_EQ(0U, store_.counter("test.response_error").value());
+  EXPECT_EQ(1U, store_.counter("test.response_exception").value());
+  EXPECT_EQ(0U, store_.counter("test.response_invalid_type").value());
+  EXPECT_EQ(0U, store_.counter("test.response_decoding_error").value());
+  EXPECT_EQ(0U, store_.gauge("test.request_active").value());
+}
+
+TEST_F(ThriftFilterTest, OnWriteHandlesIDLException) {
+  initializeFilter();
+  writeFramedBinaryMessage(buffer_, MessageType::Call, 0x0F); // set up request
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+  EXPECT_EQ(1U, store_.counter("test.request").value());
+  EXPECT_EQ(1U, store_.gauge("test.request_active").value());
+
+  writeFramedBinaryIDLException(write_buffer_, 0x0F);
+  EXPECT_EQ(filter_->onWrite(write_buffer_, false), Network::FilterStatus::Continue);
+
+  EXPECT_EQ(1U, store_.counter("test.response").value());
+  EXPECT_EQ(1U, store_.counter("test.response_reply").value());
+  EXPECT_EQ(0U, store_.counter("test.response_success").value());
+  EXPECT_EQ(1U, store_.counter("test.response_error").value());
+  EXPECT_EQ(0U, store_.counter("test.response_exception").value());
+  EXPECT_EQ(0U, store_.counter("test.response_invalid_type").value());
+  EXPECT_EQ(0U, store_.counter("test.response_decoding_error").value());
+  EXPECT_EQ(0U, store_.gauge("test.request_active").value());
+}
+
+TEST_F(ThriftFilterTest, OnWriteHandlesInvalidMsgType) {
+  initializeFilter();
+  writeFramedBinaryMessage(buffer_, MessageType::Call, 0x0F);
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+  EXPECT_EQ(1U, store_.counter("test.request").value());
+  EXPECT_EQ(1U, store_.gauge("test.request_active").value());
+
+  writeFramedBinaryMessage(write_buffer_, MessageType::Call, 0x0F); // call is invalid for response
+  EXPECT_EQ(filter_->onWrite(write_buffer_, false), Network::FilterStatus::Continue);
+  EXPECT_EQ(1U, store_.counter("test.response").value());
+  EXPECT_EQ(0U, store_.counter("test.response_success").value());
+  EXPECT_EQ(0U, store_.counter("test.response_error").value());
+  EXPECT_EQ(0U, store_.counter("test.response_exception").value());
+  EXPECT_EQ(1U, store_.counter("test.response_invalid_type").value());
+  EXPECT_EQ(0U, store_.gauge("test.request_active").value());
+}
+
+TEST_F(ThriftFilterTest, OnWriteHandlesProtocolError) {
+  initializeFilter();
+  addSeq(write_buffer_, {
+                            0x00, 0x00, 0x00, 0x1d,                     // framed: 29 bytes
+                            0x80, 0x01, 0x00, 0xFF,                     // binary, illegal type
+                            0x00, 0x00, 0x00, 0x04, 'n', 'a', 'm', 'e', // message name
+                            0x00, 0x00, 0x00, 0x01,                     // sequence id
+                            0x00,                                       // struct stop field
+                        });
+  uint64_t len = buffer_.length();
+
+  EXPECT_EQ(filter_->onWrite(write_buffer_, false), Network::FilterStatus::Continue);
+  EXPECT_EQ(1U, store_.counter("test.response_decoding_error").value());
+  EXPECT_EQ(len, buffer_.length());
+
+  // Sniffing is now disabled.
+  write_buffer_.drain(write_buffer_.length());
+  writeFramedBinaryMessage(write_buffer_, MessageType::Reply, 1);
+  EXPECT_EQ(filter_->onWrite(write_buffer_, false), Network::FilterStatus::Continue);
+}
+
+TEST_F(ThriftFilterTest, OnWriteHandlesProtocolErrorOnData) {
+  initializeFilter();
+
+  // Set up a request for the partial write
+  writeFramedBinaryMessage(buffer_, MessageType::Call, 1);
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+  buffer_.drain(buffer_.length());
+
+  // Start the write buffer
+  writePartialFramedBinaryMessage(write_buffer_, MessageType::Reply, 1, true);
+  uint64_t len = write_buffer_.length();
+
+  EXPECT_EQ(filter_->onWrite(write_buffer_, false), Network::FilterStatus::Continue);
+  len -= write_buffer_.length();
+
+  // Force an error on the next request.
+  addSeq(buffer_, {
+                      0x00, 0x00, 0x00, 0x1d,                     // framed: 29 bytes
+                      0x80, 0x01, 0x00, 0xFF,                     // binary, illegal type
+                      0x00, 0x00, 0x00, 0x04, 'n', 'a', 'm', 'e', // message name
+                      0x00, 0x00, 0x00, 0x02,                     // sequence id
+                      0x00,                                       // struct stop field
+                  });
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+  EXPECT_EQ(1U, store_.counter("test.request_decoding_error").value());
+
+  // Complete the read buffer
+  writePartialFramedBinaryMessage(write_buffer_, MessageType::Reply, 1, false);
+  len += write_buffer_.length();
+
+  EXPECT_EQ(filter_->onWrite(write_buffer_, false), Network::FilterStatus::Continue);
+  len -= write_buffer_.length();
+  EXPECT_EQ(0, len);
+}
+
+TEST_F(ThriftFilterTest, OnEvent) {
+  // No active calls
+  {
+    initializeFilter();
+    filter_->onEvent(Network::ConnectionEvent::RemoteClose);
+    filter_->onEvent(Network::ConnectionEvent::LocalClose);
+    EXPECT_EQ(0U, store_.counter("test.cx_destroy_local_with_active_rq").value());
+    EXPECT_EQ(0U, store_.counter("test.cx_destroy_remote_with_active_rq").value());
+  }
+
+  // Close mid-request
+  {
+    initializeFilter();
+    addSeq(buffer_, {
+                        0x00, 0x00, 0x00, 0x1d,                     // framed: 29 bytes
+                        0x80, 0x01, 0x00, 0x01,                     // binary proto, call type
+                        0x00, 0x00, 0x00, 0x04, 'n', 'a', 'm', 'e', // message name
+                        0x00, 0x00, 0x00, 0x0F,                     // seq id
+                    });
+    EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+
+    filter_->onEvent(Network::ConnectionEvent::RemoteClose);
+    EXPECT_EQ(1U, store_.counter("test.cx_destroy_local_with_active_rq").value());
+
+    filter_->onEvent(Network::ConnectionEvent::LocalClose);
+    EXPECT_EQ(1U, store_.counter("test.cx_destroy_remote_with_active_rq").value());
+
+    buffer_.drain(buffer_.length());
+  }
+
+  // Close before response
+  {
+    initializeFilter();
+    writeFramedBinaryMessage(buffer_, MessageType::Call, 0x0F);
+    EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+
+    filter_->onEvent(Network::ConnectionEvent::RemoteClose);
+    EXPECT_EQ(1U, store_.counter("test.cx_destroy_local_with_active_rq").value());
+
+    filter_->onEvent(Network::ConnectionEvent::LocalClose);
+    EXPECT_EQ(1U, store_.counter("test.cx_destroy_remote_with_active_rq").value());
+
+    buffer_.drain(buffer_.length());
+  }
+
+  // Close mid-response
+  {
+    initializeFilter();
+    writeFramedBinaryMessage(buffer_, MessageType::Call, 0x0F);
+    EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+
+    addSeq(write_buffer_, {
+                              0x00, 0x00, 0x00, 0x1d, // framed: 29 bytes
+                              0x80, 0x01, 0x00, 0x02, // binary proto, reply type
+                              0x00, 0x00, 0x00, 0x04, 'n', 'a', 'm', 'e', // message name
+                              0x00, 0x00, 0x00, 0x0F,                     // seq id
+                          });
+    EXPECT_EQ(filter_->onWrite(write_buffer_, false), Network::FilterStatus::Continue);
+
+    filter_->onEvent(Network::ConnectionEvent::RemoteClose);
+    EXPECT_EQ(1U, store_.counter("test.cx_destroy_local_with_active_rq").value());
+
+    filter_->onEvent(Network::ConnectionEvent::LocalClose);
+    EXPECT_EQ(1U, store_.counter("test.cx_destroy_remote_with_active_rq").value());
+
+    buffer_.drain(buffer_.length());
+    write_buffer_.drain(write_buffer_.length());
+  }
+}
+
+TEST_F(ThriftFilterTest, ResponseWithUnknownSequenceID) {
+  initializeFilter();
+  writeFramedBinaryMessage(buffer_, MessageType::Call, 0x0F);
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::Continue);
+
+  writeFramedBinaryMessage(write_buffer_, MessageType::Reply, 0x10);
+  EXPECT_EQ(filter_->onWrite(write_buffer_, false), Network::FilterStatus::Continue);
+
+  EXPECT_EQ(1U, store_.counter("test.response_decoding_error").value());
+}
+
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/network/thrift_proxy/utility.h
+++ b/test/extensions/filters/network/thrift_proxy/utility.h
@@ -43,6 +43,15 @@ inline void addSeq(Buffer::Instance& buffer, const std::initializer_list<uint8_t
 
 inline void addString(Buffer::Instance& buffer, const std::string& s) { buffer.add(s); }
 
+inline std::string bufferToString(Buffer::Instance& buffer) {
+  if (buffer.length() == 0) {
+    return "";
+  }
+
+  char* data = static_cast<char*>(buffer.linearize(buffer.length()));
+  return std::string(data, buffer.length());
+}
+
 } // namespace
 } // namespace ThriftProxy
 } // namespace NetworkFilters


### PR DESCRIPTION
Glues together code from previous PRs into a ThriftFilter that counts requests (by type) and responses (by type and result), counts protocol errors for requests and responses, and records timings of request/response pairs.

*Risk Level*: Low
*Testing*: unit and manual testing
*Docs Changes*: trivial documentation of thrift config
*Release Notes*: introduced envoy.thrift filter
*Relates to*: #2247 
