### PR TITLE
docs: fix typo in the docker build command on the getting started guide

### DIFF
--- a/docs/root/start/start.rst
+++ b/docs/root/start/start.rst
@@ -110,7 +110,7 @@ You can refer to the :ref:`Command line options <operations_cli>`.
 
 Build the Docker image that runs your configuration using::
 
-  $ docker build -t envoy:v1
+  $ docker build -t envoy:v1 .
 
 And now you can execute it with::
 


### PR DESCRIPTION
*Very* small fix for the docker build command used in the example.