### PR TITLE
lua: add request info dynamic metadata api

### DIFF
--- a/docs/root/configuration/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http_filters/lua_filter.rst
@@ -290,6 +290,11 @@ under the filter name i.e. *envoy.lua*. Below is an example of a *metadata* in a
 
 Returns a :ref:`metadata object <config_http_filters_lua_metadata_wrapper>`.
 
+requestInfo()
+^^^^^^^^^^^^^
+
+Returns a :ref:`request info object <config_http_filters_lua_request_info_wrapper>`.
+
 .. _config_http_filters_lua_header_wrapper:
 
 Header object API
@@ -403,3 +408,52 @@ __pairs()
 
 Iterates through every *metadata* entry. *key* is a string that supplies a *metadata*
 key. *value* is *metadata* entry value.
+
+.. _config_http_filters_lua_request_info_wrapper:
+
+Request Info object API
+-----------------------
+
+dynamicMetadata()
+^^^^^^^^^^^^^^^^^
+
+Returns a :ref:`dynamicMetadata object <config_http_filters_lua_dynamic_metadata_wrapper>`.
+
+.. _config_http_filters_lua_dynamic_metadata_wrapper:
+
+Dynamic Metadata object API
+---------------------------
+
+get()
+^^^^^
+
+.. code-block:: lua
+
+  dynamicMetadata:get(filterName)
+
+  -- to get a value from a returned table.
+  dynamicMetadata:get(filterName)[key]
+
+Gets an entry in dynamic metadata struct. *filterName* is a string that supplies the filter name, e.g. *envoy.lb*.
+Returns the corresponding *table* of a given *filterName*.
+
+set()
+^^^^^
+
+.. code-block:: lua
+
+  dynamicMetadata:set(filterName, key, value)
+
+Sets key-value pair of a *filterName*'s metadata. *filterName* is a key specifying the target filter name,
+e.g. *envoy.lb*. The type of *key* and *value* is *string*.
+
+__pairs()
+^^^^^^^^^
+
+.. code-block:: lua
+
+  for key, value in pairs(dynamicMetadata) do
+  end
+
+Iterates through every *dynamicMetadata* entry. *key* is a string that supplies a *dynamicMetadata*
+key. *value* is *dynamicMetadata* entry value.

--- a/source/extensions/filters/common/lua/BUILD
+++ b/source/extensions/filters/common/lua/BUILD
@@ -30,6 +30,9 @@ envoy_cc_library(
     deps = [
         ":lua_lib",
         "//include/envoy/buffer:buffer_interface",
+        "//include/envoy/request_info:request_info_interface",
         "//source/common/protobuf",
+        "//source/common/protobuf:utility_lib",
+        "//source/common/request_info:request_info_lib",
     ],
 )

--- a/source/extensions/filters/common/lua/BUILD
+++ b/source/extensions/filters/common/lua/BUILD
@@ -33,6 +33,5 @@ envoy_cc_library(
         "//include/envoy/request_info:request_info_interface",
         "//source/common/protobuf",
         "//source/common/protobuf:utility_lib",
-        "//source/common/request_info:request_info_lib",
     ],
 )

--- a/source/extensions/filters/common/lua/BUILD
+++ b/source/extensions/filters/common/lua/BUILD
@@ -31,6 +31,7 @@ envoy_cc_library(
         ":lua_lib",
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/request_info:request_info_interface",
+        "//source/common/http:utility_lib",
         "//source/common/protobuf",
         "//source/common/protobuf:utility_lib",
     ],

--- a/source/extensions/filters/common/lua/wrappers.cc
+++ b/source/extensions/filters/common/lua/wrappers.cc
@@ -1,5 +1,6 @@
 #include "extensions/filters/common/lua/wrappers.h"
 
+#include "common/http/utility.h"
 #include "common/protobuf/utility.h"
 
 namespace Envoy {
@@ -137,20 +138,7 @@ int RequestInfoWrapper::luaDynamicMetadata(lua_State* state) {
 }
 
 int RequestInfoWrapper::luaProtocol(lua_State* state) {
-  switch (request_info_.protocol().value()) {
-  case Http::Protocol::Http10:
-    lua_pushstring(state, "HTTP10");
-    break;
-  case Http::Protocol::Http11:
-    lua_pushstring(state, "HTTP11");
-    break;
-  case Http::Protocol::Http2:
-    lua_pushstring(state, "HTTP2");
-    break;
-  default:
-    lua_pushstring(state, "UNKNOWN");
-  }
-
+  lua_pushstring(state, Http::Utility::getProtocolString(request_info_.protocol().value()).c_str());
   return 1;
 }
 

--- a/source/extensions/filters/common/lua/wrappers.cc
+++ b/source/extensions/filters/common/lua/wrappers.cc
@@ -165,19 +165,11 @@ int DynamicMetadataMapWrapper::luaGet(lua_State* state) {
 }
 
 int DynamicMetadataMapWrapper::luaSet(lua_State* state) {
+  // TODO(dio): Allow to set dynamic metadata using a table.
   const char* filter_name = luaL_checkstring(state, 2);
-  if (lua_istable(state, 3)) {
-    // TODO(dio): Allow to set other than string. Create a Struct based on this table.
-    luaL_error(state, "not implemented");
-  } else {
-    const absl::string_view key = luaL_checkstring(state, 3);
-    const absl::string_view value = luaL_checkstring(state, 4);
-    if (key.empty() || value.empty()) {
-      luaL_error(state, "cannot set dynamic metadata with empty key or value");
-    }
-    request_info_.setDynamicMetadata(filter_name,
-                                     MessageUtil::keyValueStruct(key.data(), value.data()));
-  }
+  const char* key = luaL_checkstring(state, 3);
+  const char* value = luaL_checkstring(state, 4);
+  request_info_.setDynamicMetadata(filter_name, MessageUtil::keyValueStruct(key, value));
   return 0;
 }
 

--- a/source/extensions/filters/common/lua/wrappers.cc
+++ b/source/extensions/filters/common/lua/wrappers.cc
@@ -1,5 +1,7 @@
 #include "extensions/filters/common/lua/wrappers.h"
 
+#include "common/protobuf/utility.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace Filters {
@@ -26,7 +28,7 @@ int BufferWrapper::luaGetBytes(lua_State* state) {
   return 1;
 }
 
-void MetadataMapWrapper::setValue(lua_State* state, const ProtobufWkt::Value& value) {
+void MetadataMapHelper::setValue(lua_State* state, const ProtobufWkt::Value& value) {
   ProtobufWkt::Value::KindCase kind = value.kind_case();
 
   switch (kind) {
@@ -76,7 +78,7 @@ void MetadataMapWrapper::setValue(lua_State* state, const ProtobufWkt::Value& va
   }
 }
 
-void MetadataMapWrapper::createTable(
+void MetadataMapHelper::createTable(
     lua_State* state,
     const Protobuf::Map<Envoy::ProtobufTypes::String, ProtobufWkt::Value>& fields) {
   lua_createtable(state, 0, fields.size());
@@ -98,7 +100,7 @@ int MetadataMapIterator::luaPairsIterator(lua_State* state) {
   }
 
   lua_pushstring(state, current_->first.c_str());
-  parent_.setValue(state, current_->second);
+  MetadataMapHelper::setValue(state, current_->second);
 
   current_++;
   return 2;
@@ -111,7 +113,7 @@ int MetadataMapWrapper::luaGet(lua_State* state) {
     return 0;
   }
 
-  setValue(state, filter_it->second);
+  MetadataMapHelper::setValue(state, filter_it->second);
   return 1;
 }
 
@@ -122,6 +124,63 @@ int MetadataMapWrapper::luaPairs(lua_State* state) {
 
   iterator_.reset(MetadataMapIterator::create(state, *this), true);
   lua_pushcclosure(state, MetadataMapIterator::static_luaPairsIterator, 1);
+  return 1;
+}
+
+int RequestInfoWrapper::luaDynamicMetadata(lua_State* state) {
+  if (metadata_wrapper_.get() != nullptr) {
+    metadata_wrapper_.pushStack();
+  } else {
+    metadata_wrapper_.reset(DynamicMetadataMapWrapper::create(state, request_info_), true);
+  }
+  return 1;
+}
+
+DynamicMetadataMapIterator::DynamicMetadataMapIterator(DynamicMetadataMapWrapper& parent)
+    : parent_{parent}, current_{parent.request_info_.dynamicMetadata().filter_metadata().begin()} {}
+
+int DynamicMetadataMapIterator::luaPairsIterator(lua_State* state) {
+  if (current_ == parent_.request_info_.dynamicMetadata().filter_metadata().end()) {
+    parent_.iterator_.reset();
+    return 0;
+  }
+
+  lua_pushstring(state, current_->first.c_str());
+  MetadataMapHelper::createTable(state, current_->second.fields());
+
+  current_++;
+  return 2;
+}
+
+int DynamicMetadataMapWrapper::luaGet(lua_State* state) {
+  const char* filter_name = luaL_checkstring(state, 2);
+  const auto& metadata = request_info_.dynamicMetadata().filter_metadata();
+  const auto filter_it = metadata.find(filter_name);
+  if (filter_it == metadata.end()) {
+    return 0;
+  }
+
+  MetadataMapHelper::createTable(state, filter_it->second.fields());
+  return 1;
+}
+
+int DynamicMetadataMapWrapper::luaSet(lua_State* state) {
+  const char* filter_name = luaL_checkstring(state, 2);
+  const char* key = luaL_checkstring(state, 3);
+
+  // TODO(dio): Allow to set other than string.
+  const char* value = luaL_checkstring(state, 4);
+  request_info_.setDynamicMetadata(filter_name, MessageUtil::keyValueStruct(key, value));
+  return 0;
+}
+
+int DynamicMetadataMapWrapper::luaPairs(lua_State* state) {
+  if (iterator_.get() != nullptr) {
+    luaL_error(state, "cannot create a second iterator before completing the first");
+  }
+
+  iterator_.reset(DynamicMetadataMapIterator::create(state, *this), true);
+  lua_pushcclosure(state, DynamicMetadataMapIterator::static_luaPairsIterator, 1);
   return 1;
 }
 

--- a/source/extensions/filters/common/lua/wrappers.cc
+++ b/source/extensions/filters/common/lua/wrappers.cc
@@ -136,6 +136,24 @@ int RequestInfoWrapper::luaDynamicMetadata(lua_State* state) {
   return 1;
 }
 
+int RequestInfoWrapper::luaProtocol(lua_State* state) {
+  switch (request_info_.protocol().value()) {
+  case Http::Protocol::Http10:
+    lua_pushstring(state, "HTTP10");
+    break;
+  case Http::Protocol::Http11:
+    lua_pushstring(state, "HTTP11");
+    break;
+  case Http::Protocol::Http2:
+    lua_pushstring(state, "HTTP2");
+    break;
+  default:
+    lua_pushstring(state, "UNKNOWN");
+  }
+
+  return 1;
+}
+
 DynamicMetadataMapIterator::DynamicMetadataMapIterator(DynamicMetadataMapWrapper& parent)
     : parent_{parent}, current_{parent.request_info_.dynamicMetadata().filter_metadata().begin()} {}
 
@@ -180,6 +198,11 @@ int DynamicMetadataMapWrapper::luaPairs(lua_State* state) {
 
   iterator_.reset(DynamicMetadataMapIterator::create(state, *this), true);
   lua_pushcclosure(state, DynamicMetadataMapIterator::static_luaPairsIterator, 1);
+  return 1;
+}
+
+int ConnectionWrapper::luaSecure(lua_State* state) {
+  lua_pushboolean(state, connection_->ssl() != nullptr);
   return 1;
 }
 

--- a/source/extensions/filters/common/lua/wrappers.cc
+++ b/source/extensions/filters/common/lua/wrappers.cc
@@ -166,11 +166,18 @@ int DynamicMetadataMapWrapper::luaGet(lua_State* state) {
 
 int DynamicMetadataMapWrapper::luaSet(lua_State* state) {
   const char* filter_name = luaL_checkstring(state, 2);
-  const char* key = luaL_checkstring(state, 3);
-
-  // TODO(dio): Allow to set other than string.
-  const char* value = luaL_checkstring(state, 4);
-  request_info_.setDynamicMetadata(filter_name, MessageUtil::keyValueStruct(key, value));
+  if (lua_istable(state, 3)) {
+    // TODO(dio): Allow to set other than string. Create a Struct based on this table.
+    luaL_error(state, "not implemented");
+  } else {
+    const absl::string_view key = luaL_checkstring(state, 3);
+    const absl::string_view value = luaL_checkstring(state, 4);
+    if (key.empty() || value.empty()) {
+      luaL_error(state, "cannot set dynamic metadata with empty key or value");
+    }
+    request_info_.setDynamicMetadata(filter_name,
+                                     MessageUtil::keyValueStruct(key.data(), value.data()));
+  }
   return 0;
 }
 

--- a/source/extensions/filters/common/lua/wrappers.h
+++ b/source/extensions/filters/common/lua/wrappers.h
@@ -140,8 +140,8 @@ private:
   /**
    * Get a metadata value from the map.
    * @param 1 (string): filter name.
-   * @param 2 (string): key.
-   * @param 1 (string): value.
+   * @param 2 (string or table): key.
+   * @param 3 (string or table): value.
    * @return nil.
    */
   DECLARE_LUA_FUNCTION(DynamicMetadataMapWrapper, luaSet);

--- a/source/extensions/filters/common/lua/wrappers.h
+++ b/source/extensions/filters/common/lua/wrappers.h
@@ -168,7 +168,7 @@ class RequestInfoWrapper : public BaseLuaObject<RequestInfoWrapper> {
 public:
   RequestInfoWrapper(RequestInfo::RequestInfo& request_info) : request_info_{request_info} {}
   static ExportedFunctions exportedFunctions() {
-    return {{"dynamicMetadata", static_luaDynamicMetadata}};
+    return {{"dynamicMetadata", static_luaDynamicMetadata}, {"protocol", static_luaProtocol}};
   }
 
 private:
@@ -178,6 +178,12 @@ private:
    */
   DECLARE_LUA_FUNCTION(RequestInfoWrapper, luaDynamicMetadata);
 
+  /**
+   * Get current protocol being used.
+   * @return string, Http::Protocol.
+   */
+  DECLARE_LUA_FUNCTION(RequestInfoWrapper, luaProtocol);
+
   // Envoy::Lua::BaseLuaObject
   void onMarkDead() override {
     // TODO(dio): Check if it is required to always reset in here.
@@ -186,6 +192,23 @@ private:
 
   LuaDeathRef<DynamicMetadataMapWrapper> metadata_wrapper_;
   RequestInfo::RequestInfo& request_info_;
+};
+
+typedef std::shared_ptr<const Network::Connection> NetworkConnectionSharedPtr;
+
+class ConnectionWrapper : public BaseLuaObject<ConnectionWrapper> {
+public:
+  ConnectionWrapper(const Network::Connection* connection) : connection_{connection} {}
+  static ExportedFunctions exportedFunctions() { return {{"secure", static_luaSecure}}; }
+
+private:
+  /**
+   * Check if the connection is secured or not.
+   * @return boolean true if secure and false if not.
+   */
+  DECLARE_LUA_FUNCTION(ConnectionWrapper, luaSecure);
+
+  const NetworkConnectionSharedPtr connection_;
 };
 
 } // namespace Lua

--- a/source/extensions/filters/common/lua/wrappers.h
+++ b/source/extensions/filters/common/lua/wrappers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/buffer/buffer.h"
+#include "envoy/request_info/request_info.h"
 
 #include "common/protobuf/protobuf.h"
 
@@ -41,6 +42,13 @@ private:
 };
 
 class MetadataMapWrapper;
+
+struct MetadataMapHelper {
+  static void setValue(lua_State* state, const ProtobufWkt::Value& value);
+  static void
+  createTable(lua_State* state,
+              const Protobuf::Map<Envoy::ProtobufTypes::String, ProtobufWkt::Value>& fields);
+};
 
 /**
  * Iterator over a metadata map.
@@ -89,14 +97,95 @@ private:
     iterator_.reset();
   }
 
-  void setValue(lua_State* state, const ProtobufWkt::Value& value);
-  void createTable(lua_State* state,
-                   const Protobuf::Map<Envoy::ProtobufTypes::String, ProtobufWkt::Value>& fields);
-
   const ProtobufWkt::Struct metadata_;
   LuaDeathRef<MetadataMapIterator> iterator_;
 
   friend class MetadataMapIterator;
+};
+
+class DynamicMetadataMapWrapper;
+
+/**
+ * Iterator over a dynamic metadata map.
+ */
+class DynamicMetadataMapIterator : public BaseLuaObject<DynamicMetadataMapIterator> {
+public:
+  DynamicMetadataMapIterator(DynamicMetadataMapWrapper& parent);
+
+  static ExportedFunctions exportedFunctions() { return {}; }
+
+  DECLARE_LUA_CLOSURE(DynamicMetadataMapIterator, luaPairsIterator);
+
+private:
+  DynamicMetadataMapWrapper& parent_;
+  Protobuf::Map<Envoy::ProtobufTypes::String, ProtobufWkt::Struct>::const_iterator current_;
+};
+
+class DynamicMetadataMapWrapper : public BaseLuaObject<DynamicMetadataMapWrapper> {
+public:
+  DynamicMetadataMapWrapper(RequestInfo::RequestInfo& request_info) : request_info_{request_info} {}
+
+  static ExportedFunctions exportedFunctions() {
+    return {{"get", static_luaGet}, {"set", static_luaSet}, {"__pairs", static_luaPairs}};
+  }
+
+private:
+  /**
+   * Get a metadata value from the map.
+   * @param 1 (string): filter name.
+   * @return value if found or nil.
+   */
+  DECLARE_LUA_FUNCTION(DynamicMetadataMapWrapper, luaGet);
+
+  /**
+   * Get a metadata value from the map.
+   * @param 1 (string): filter name.
+   * @param 2 (string): key.
+   * @param 1 (string): value.
+   * @return nil.
+   */
+  DECLARE_LUA_FUNCTION(DynamicMetadataMapWrapper, luaSet);
+
+  /**
+   * Implementation of the __pairs metamethod so a dynamic metadata wrapper can be iterated over
+   * using pairs().
+   */
+  DECLARE_LUA_FUNCTION(DynamicMetadataMapWrapper, luaPairs);
+
+  // Envoy::Lua::BaseLuaObject
+  void onMarkDead() override {
+    // Iterators do not survive yields.
+    iterator_.reset();
+  }
+
+  RequestInfo::RequestInfo& request_info_;
+  LuaDeathRef<DynamicMetadataMapIterator> iterator_;
+
+  friend class DynamicMetadataMapIterator;
+};
+
+class RequestInfoWrapper : public BaseLuaObject<RequestInfoWrapper> {
+public:
+  RequestInfoWrapper(RequestInfo::RequestInfo& request_info) : request_info_{request_info} {}
+  static ExportedFunctions exportedFunctions() {
+    return {{"dynamicMetadata", static_luaDynamicMetadata}};
+  }
+
+private:
+  /**
+   * Get a dynamic metadata value from the map.
+   * @return value if found or nil.
+   */
+  DECLARE_LUA_FUNCTION(RequestInfoWrapper, luaDynamicMetadata);
+
+  // Envoy::Lua::BaseLuaObject
+  void onMarkDead() override {
+    // TODO(dio): Check if it is required to always reset in here.
+    metadata_wrapper_.reset();
+  }
+
+  LuaDeathRef<DynamicMetadataMapWrapper> metadata_wrapper_;
+  RequestInfo::RequestInfo& request_info_;
 };
 
 } // namespace Lua

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -378,6 +378,17 @@ int StreamHandleWrapper::luaRequestInfo(lua_State* state) {
   return 1;
 }
 
+int StreamHandleWrapper::luaConnection(lua_State* state) {
+  ASSERT(state_ == State::Running);
+  if (connection_wrapper_.get() != nullptr) {
+    connection_wrapper_.pushStack();
+  } else {
+    connection_wrapper_.reset(
+        Filters::Common::Lua::ConnectionWrapper::create(state, callbacks_.connection()), true);
+  }
+  return 1;
+}
+
 int StreamHandleWrapper::luaLogTrace(lua_State* state) {
   const char* message = luaL_checkstring(state, 2);
   filter_.scriptLog(spdlog::level::trace, message);
@@ -423,6 +434,7 @@ FilterConfig::FilterConfig(const std::string& lua_code, ThreadLocal::SlotAllocat
   lua_state_.registerType<Filters::Common::Lua::DynamicMetadataMapWrapper>();
   lua_state_.registerType<Filters::Common::Lua::DynamicMetadataMapIterator>();
   lua_state_.registerType<Filters::Common::Lua::RequestInfoWrapper>();
+  lua_state_.registerType<Filters::Common::Lua::ConnectionWrapper>();
   lua_state_.registerType<HeaderMapWrapper>();
   lua_state_.registerType<HeaderMapIterator>();
   lua_state_.registerType<StreamHandleWrapper>();

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -367,6 +367,17 @@ int StreamHandleWrapper::luaMetadata(lua_State* state) {
   return 1;
 }
 
+int StreamHandleWrapper::luaRequestInfo(lua_State* state) {
+  ASSERT(state_ == State::Running);
+  if (metadata_wrapper_.get() != nullptr) {
+    request_info_wrapper_.pushStack();
+  } else {
+    request_info_wrapper_.reset(
+        Filters::Common::Lua::RequestInfoWrapper::create(state, callbacks_.requestInfo()), true);
+  }
+  return 1;
+}
+
 int StreamHandleWrapper::luaLogTrace(lua_State* state) {
   const char* message = luaL_checkstring(state, 2);
   filter_.scriptLog(spdlog::level::trace, message);
@@ -409,6 +420,9 @@ FilterConfig::FilterConfig(const std::string& lua_code, ThreadLocal::SlotAllocat
   lua_state_.registerType<Filters::Common::Lua::BufferWrapper>();
   lua_state_.registerType<Filters::Common::Lua::MetadataMapWrapper>();
   lua_state_.registerType<Filters::Common::Lua::MetadataMapIterator>();
+  lua_state_.registerType<Filters::Common::Lua::DynamicMetadataMapWrapper>();
+  lua_state_.registerType<Filters::Common::Lua::DynamicMetadataMapIterator>();
+  lua_state_.registerType<Filters::Common::Lua::RequestInfoWrapper>();
   lua_state_.registerType<HeaderMapWrapper>();
   lua_state_.registerType<HeaderMapIterator>();
   lua_state_.registerType<StreamHandleWrapper>();

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -369,7 +369,7 @@ int StreamHandleWrapper::luaMetadata(lua_State* state) {
 
 int StreamHandleWrapper::luaRequestInfo(lua_State* state) {
   ASSERT(state_ == State::Running);
-  if (metadata_wrapper_.get() != nullptr) {
+  if (request_info_wrapper_.get() != nullptr) {
     request_info_wrapper_.pushStack();
   } else {
     request_info_wrapper_.reset(

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -69,7 +69,15 @@ public:
    */
   virtual const ProtobufWkt::Struct& metadata() const PURE;
 
+  /**
+   * @return RequestInfo::RequestInfo& the current request info handle. This handle is mutable.
+   */
   virtual RequestInfo::RequestInfo& requestInfo() PURE;
+
+  /**
+   * @return const const Network::Connection* the current network connection handle.
+   */
+  virtual const Network::Connection* connection() const PURE;
 };
 
 class Filter;
@@ -124,7 +132,8 @@ public:
             {"logDebug", static_luaLogDebug},       {"logInfo", static_luaLogInfo},
             {"logWarn", static_luaLogWarn},         {"logErr", static_luaLogErr},
             {"logCritical", static_luaLogCritical}, {"httpCall", static_luaHttpCall},
-            {"respond", static_luaRespond},         {"requestInfo", static_luaRequestInfo}};
+            {"respond", static_luaRespond},         {"requestInfo", static_luaRequestInfo},
+            {"connection", static_luaConnection}};
   }
 
 private:
@@ -178,7 +187,15 @@ private:
    */
   DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaMetadata);
 
+  /**
+   * @return a handle to the request info.
+   */
   DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaRequestInfo);
+
+  /**
+   * @return a handle to the network connection.
+   */
+  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaConnection);
 
   /**
    * Log a message to the Envoy log.
@@ -207,6 +224,7 @@ private:
     trailers_wrapper_.reset();
     metadata_wrapper_.reset();
     request_info_wrapper_.reset();
+    connection_wrapper_.reset();
   }
 
   // Http::AsyncClient::Callbacks
@@ -227,6 +245,7 @@ private:
   Filters::Common::Lua::LuaDeathRef<HeaderMapWrapper> trailers_wrapper_;
   Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::MetadataMapWrapper> metadata_wrapper_;
   Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::RequestInfoWrapper> request_info_wrapper_;
+  Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::ConnectionWrapper> connection_wrapper_;
   State state_{State::Running};
   std::function<void()> yield_callback_;
   Http::AsyncClient::Request* http_request_{};
@@ -317,6 +336,7 @@ private:
 
     const ProtobufWkt::Struct& metadata() const override { return getMetadata(callbacks_); }
     RequestInfo::RequestInfo& requestInfo() override { return callbacks_->requestInfo(); }
+    const Network::Connection* connection() const override { return callbacks_->connection(); }
 
     Filter& parent_;
     Http::StreamDecoderFilterCallbacks* callbacks_{};
@@ -336,6 +356,7 @@ private:
 
     const ProtobufWkt::Struct& metadata() const override { return getMetadata(callbacks_); }
     RequestInfo::RequestInfo& requestInfo() override { return callbacks_->requestInfo(); }
+    const Network::Connection* connection() const override { return callbacks_->connection(); }
 
     Filter& parent_;
     Http::StreamEncoderFilterCallbacks* callbacks_{};

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -68,6 +68,8 @@ public:
    * route entry.
    */
   virtual const ProtobufWkt::Struct& metadata() const PURE;
+
+  virtual RequestInfo::RequestInfo& requestInfo() PURE;
 };
 
 class Filter;
@@ -122,7 +124,7 @@ public:
             {"logDebug", static_luaLogDebug},       {"logInfo", static_luaLogInfo},
             {"logWarn", static_luaLogWarn},         {"logErr", static_luaLogErr},
             {"logCritical", static_luaLogCritical}, {"httpCall", static_luaHttpCall},
-            {"respond", static_luaRespond}};
+            {"respond", static_luaRespond},         {"requestInfo", static_luaRequestInfo}};
   }
 
 private:
@@ -176,6 +178,8 @@ private:
    */
   DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaMetadata);
 
+  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaRequestInfo);
+
   /**
    * Log a message to the Envoy log.
    * @param 1 (string): The log message.
@@ -202,6 +206,7 @@ private:
     body_wrapper_.reset();
     trailers_wrapper_.reset();
     metadata_wrapper_.reset();
+    request_info_wrapper_.reset();
   }
 
   // Http::AsyncClient::Callbacks
@@ -221,6 +226,7 @@ private:
   Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::BufferWrapper> body_wrapper_;
   Filters::Common::Lua::LuaDeathRef<HeaderMapWrapper> trailers_wrapper_;
   Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::MetadataMapWrapper> metadata_wrapper_;
+  Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::RequestInfoWrapper> request_info_wrapper_;
   State state_{State::Running};
   std::function<void()> yield_callback_;
   Http::AsyncClient::Request* http_request_{};
@@ -310,6 +316,7 @@ private:
     void respond(Http::HeaderMapPtr&& headers, Buffer::Instance* body, lua_State* state) override;
 
     const ProtobufWkt::Struct& metadata() const override { return getMetadata(callbacks_); }
+    RequestInfo::RequestInfo& requestInfo() override { return callbacks_->requestInfo(); }
 
     Filter& parent_;
     Http::StreamDecoderFilterCallbacks* callbacks_{};
@@ -328,6 +335,7 @@ private:
     void respond(Http::HeaderMapPtr&& headers, Buffer::Instance* body, lua_State* state) override;
 
     const ProtobufWkt::Struct& metadata() const override { return getMetadata(callbacks_); }
+    RequestInfo::RequestInfo& requestInfo() override { return callbacks_->requestInfo(); }
 
     Filter& parent_;
     Http::StreamEncoderFilterCallbacks* callbacks_{};

--- a/test/extensions/filters/http/lua/BUILD
+++ b/test/extensions/filters/http/lua/BUILD
@@ -16,6 +16,7 @@ envoy_extension_cc_test(
     srcs = ["lua_filter_test.cc"],
     extension_name = "envoy.filters.http.lua",
     deps = [
+        "//source/common/request_info:request_info_lib",
         "//source/extensions/filters/http/lua:lua_filter_lib",
         "//test/mocks/http:http_mocks",
         "//test/mocks/thread_local:thread_local_mocks",


### PR DESCRIPTION
lua: add request info dynamic metadata API

*Description*:
This patch allows to get and set the dynamic metadata of a request via Lua.

Setting metadata,

```lua
request_handle:requestInfo():dynamicMetadata():set("envoy.lb", "foo", "bar")
```

Getting metadata,

```lua
-- returns a table
request_handle:requestInfo():dynamicMetadata():get("envoy.lb")
request_handle:requestInfo():dynamicMetadata():get("envoy.lb")["foo"]
```

*Risk Level*: Low

*Testing*: Unit and integration tests

*Docs Changes*:
- Added request info object API
- Added dynamic metadata object API

*Release Notes*:
- Added request info dynamic metadata Lua API

Fixes #3618