### PR TITLE
Update network utility getoriginaldst for IPv6

### DIFF
--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -226,6 +226,7 @@ envoy_cc_library(
         ":address_lib",
         "//include/envoy/network:connection_interface",
         "//include/envoy/stats:stats_interface",
+        "//source/common/api:os_sys_calls_lib",
         "//source/common/common:assert_lib",
         "//source/common/common:utility_lib",
         "//source/common/protobuf",

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -5,7 +5,7 @@
 
 #ifndef IP6T_SO_ORIGINAL_DST
 // From linux/netfilter_ipv6/ip6_tables.h
-# define IP6T_SO_ORIGINAL_DST 80
+#define IP6T_SO_ORIGINAL_DST 80
 #endif
 
 #include <netinet/ip.h>
@@ -296,21 +296,25 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(int fd) {
 
   int status;
   switch (orig_addr.ss_family) {
-      case AF_INET:
-        status = getsockopt(fd, SOL_IP, SO_ORIGINAL_DST, &orig_addr, &addr_len);
-      case AF_INET6:
-        status = getsockopt(fd, SOL_IPV6, IP6T_SO_ORIGINAL_DST, &orig_addr, &addr_len);
+  case AF_INET:
+    status = getsockopt(fd, SOL_IP, SO_ORIGINAL_DST, &orig_addr, &addr_len);
+  case AF_INET6:
+    status = getsockopt(fd, SOL_IPV6, IP6T_SO_ORIGINAL_DST, &orig_addr, &addr_len);
   }
 
   if (status == 0) {
-    if orig_addr.ss_family == AF_INET {
-      return Address::InstanceConstSharedPtr{
-        new Address::Ipv4Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};
-    } else if orig_addr.ss_family == AF_INET6 {
+    if
+      orig_addr.ss_family == AF_INET {
         return Address::InstanceConstSharedPtr{
-          new Address::Ipv6Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};
-    } else {
-        return nullptr;
+            new Address::Ipv4Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};
+      }
+    else if
+      orig_addr.ss_family == AF_INET6 {
+        return Address::InstanceConstSharedPtr{
+            new Address::Ipv6Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};
+      }
+    else {
+      return nullptr;
     }
   }
 #else

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -308,14 +308,14 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(int fd) {
     return nullptr;
   }
 
-  if ( socket_domain == AF_INET ) {
+  if (socket_domain == AF_INET) {
     status = os_syscalls.getsockopt(fd, SOL_IP, SO_ORIGINAL_DST, &orig_addr, &addr_len);
-  } else if ( socket_domain == AF_INET6 ){
+  } else if (socket_domain == AF_INET6) {
     status = os_syscalls.getsockopt(fd, SOL_IPV6, IP6T_SO_ORIGINAL_DST, &orig_addr, &addr_len);
   } else {
     return nullptr;
   }
-  
+
   if (status != 0) {
     return nullptr;
   }

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -319,11 +319,11 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(int fd) {
 
   switch (orig_addr.ss_family) {
   case AF_INET:
-  return Address::InstanceConstSharedPtr{
-      new Address::Ipv4Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};
+    return Address::InstanceConstSharedPtr{
+        new Address::Ipv4Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};
   case AF_INET6:
-  return Address::InstanceConstSharedPtr{
-      new Address::Ipv6Instance(reinterpret_cast<sockaddr_in*>(orig_addr))};
+    return Address::InstanceConstSharedPtr{
+        new Address::Ipv6Instance(reinterpret_cast<sockaddr_in*>(orig_addr))};
   default:
     return nullptr;
   }

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -297,12 +297,20 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(int fd) {
   sockaddr_storage orig_addr;
   socklen_t addr_len = sizeof(sockaddr_storage);
 
-  int status;
-  switch (orig_addr.ss_family) {
+  int socket_domain;
+  socklen_t domain_len = sizeof(socket_domain);
+  int status = getsockopt(fd, SOL_SOCKET, SO_DOMAIN, &socket_domain, &domain_len);
+  if (status != 0) {
+    return nullptr;
+  }
+
+  switch (socket_domain) {
   case AF_INET:
     status = getsockopt(fd, SOL_IP, SO_ORIGINAL_DST, &orig_addr, &addr_len);
   case AF_INET6:
     status = getsockopt(fd, SOL_IPV6, IP6T_SO_ORIGINAL_DST, &orig_addr, &addr_len);
+  default:
+    return nullptr;
   }
 
   if (status != 0) {

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -25,6 +25,7 @@
 #include "envoy/network/connection.h"
 #include "envoy/stats/stats.h"
 
+#include "common/api/os_sys_calls_impl.h"
 #include "common/common/assert.h"
 #include "common/common/utility.h"
 #include "common/network/address_impl.h"
@@ -300,15 +301,17 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(int fd) {
 
   int socket_domain;
   socklen_t domain_len = sizeof(socket_domain);
-  int status = getsockopt(fd, SOL_SOCKET, SO_DOMAIN, &socket_domain, &domain_len);
+  auto& os_syscalls = Api::OsSysCallsSingleton::get();
+  int status = os_syscalls.getsockopt(fd, SOL_SOCKET, SO_DOMAIN, &socket_domain, &domain_len);
+
   if (status != 0) {
     return nullptr;
   }
 
   if ( socket_domain == AF_INET ) {
-    status = getsockopt(fd, SOL_IP, SO_ORIGINAL_DST, &orig_addr, &addr_len);
+    status = os_syscalls.getsockopt(fd, SOL_IP, SO_ORIGINAL_DST, &orig_addr, &addr_len);
   } else if ( socket_domain == AF_INET6 ){
-    status = getsockopt(fd, SOL_IPV6, IP6T_SO_ORIGINAL_DST, &orig_addr, &addr_len);
+    status = os_syscalls.getsockopt(fd, SOL_IPV6, IP6T_SO_ORIGINAL_DST, &orig_addr, &addr_len);
   } else {
     return nullptr;
   }

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -3,9 +3,12 @@
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 
+#if defined(__linux__)
+#include <linux/netfilter_ipv4.h>
 #ifndef IP6T_SO_ORIGINAL_DST
 // From linux/netfilter_ipv6/ip6_tables.h
 #define IP6T_SO_ORIGINAL_DST 80
+#endif
 #endif
 
 #include <netinet/ip.h>
@@ -302,16 +305,19 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(int fd) {
     status = getsockopt(fd, SOL_IPV6, IP6T_SO_ORIGINAL_DST, &orig_addr, &addr_len);
   }
 
-  if (status == 0) {
-    if (orig_addr.ss_family == AF_INET) {
-      return Address::InstanceConstSharedPtr{
-          new Address::Ipv4Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};
-    } else if (orig_addr.ss_family == AF_INET6) {
-      return Address::InstanceConstSharedPtr{
-          new Address::Ipv6Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};
-    } else {
-      return nullptr;
-    }
+  if (status != 0) {
+    return nullptr;
+  }
+
+  switch (orig_addr.ss_family) {
+  case AF_INET:
+  return Address::InstanceConstSharedPtr{
+      new Address::Ipv4Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};
+  case AF_INET6:
+  return Address::InstanceConstSharedPtr{
+      new Address::Ipv6Instance(reinterpret_cast<sockaddr_in*>(orig_addr))};
+  default:
+    return nullptr;
   }
 #else
   // TODO(zuercher): determine if connection redirection is possible under OS X (c.f. pfctl and

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -323,7 +323,7 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(int fd) {
         new Address::Ipv4Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};
   case AF_INET6:
     return Address::InstanceConstSharedPtr{
-        new Address::Ipv6Instance(reinterpret_cast<sockaddr_in*>(orig_addr))};
+        new Address::Ipv6Instance(reinterpret_cast<sockaddr_in6&>(orig_addr))};
   default:
     return nullptr;
   }

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -5,10 +5,11 @@
 
 #if defined(__linux__)
 #include <linux/netfilter_ipv4.h>
+#endif
+
 #ifndef IP6T_SO_ORIGINAL_DST
 // From linux/netfilter_ipv6/ip6_tables.h
 #define IP6T_SO_ORIGINAL_DST 80
-#endif
 #endif
 
 #include <netinet/ip.h>
@@ -304,15 +305,14 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(int fd) {
     return nullptr;
   }
 
-  switch (socket_domain) {
-  case AF_INET:
+  if ( socket_domain == AF_INET ) {
     status = getsockopt(fd, SOL_IP, SO_ORIGINAL_DST, &orig_addr, &addr_len);
-  case AF_INET6:
+  } else if ( socket_domain == AF_INET6 ){
     status = getsockopt(fd, SOL_IPV6, IP6T_SO_ORIGINAL_DST, &orig_addr, &addr_len);
-  default:
+  } else {
     return nullptr;
   }
-
+  
   if (status != 0) {
     return nullptr;
   }

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -303,17 +303,13 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(int fd) {
   }
 
   if (status == 0) {
-    if
-      orig_addr.ss_family == AF_INET {
-        return Address::InstanceConstSharedPtr{
-            new Address::Ipv4Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};
-      }
-    else if
-      orig_addr.ss_family == AF_INET6 {
-        return Address::InstanceConstSharedPtr{
-            new Address::Ipv6Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};
-      }
-    else {
+    if (orig_addr.ss_family == AF_INET) {
+      return Address::InstanceConstSharedPtr{
+          new Address::Ipv4Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};
+    } else if (orig_addr.ss_family == AF_INET6) {
+      return Address::InstanceConstSharedPtr{
+          new Address::Ipv6Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};
+    } else {
       return nullptr;
     }
   }

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -1903,7 +1903,7 @@ class OriginalDstTestFilterIPv6
     : public Extensions::ListenerFilters::OriginalDst::OriginalDstFilter {
   Network::Address::InstanceConstSharedPtr getOriginalDst(int) override {
     return Network::Address::InstanceConstSharedPtr{
-        new Network::Address::Ipv6Instance("::0002", 2345)};
+        new Network::Address::Ipv6Instance("1::2", 2345)};
   }
 };
 
@@ -1982,7 +1982,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstTestFilterIPv6) {
 
   EXPECT_TRUE(filterChainFactory.createListenerFilterChain(manager));
   EXPECT_TRUE(socket.localAddressRestored());
-  EXPECT_EQ("[::2]:2345", socket.localAddress()->asString());
+  EXPECT_EQ("[1::2]:2345", socket.localAddress()->asString());
   EXPECT_NE(fd, -1);
 }
 

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -162,53 +162,6 @@ private:
   std::unique_ptr<Network::MockConnectionSocket> socket_;
 };
 
-class ListenerManagerImplWithRealFiltersTestIPv6 : public ListenerManagerImplTest {
-public:
-  ListenerManagerImplWithRealFiltersTestIPv6() {
-    // Use real filter loading by default.
-    ON_CALL(listener_factory_, createNetworkFilterFactoryList(_, _))
-        .WillByDefault(Invoke(
-            [](const Protobuf::RepeatedPtrField<envoy::api::v2::listener::Filter>& filters,
-               Configuration::FactoryContext& context) -> std::vector<Network::FilterFactoryCb> {
-              return ProdListenerComponentFactory::createNetworkFilterFactoryList_(filters,
-                                                                                   context);
-            }));
-    ON_CALL(listener_factory_, createListenerFilterFactoryList(_, _))
-        .WillByDefault(Invoke(
-            [](const Protobuf::RepeatedPtrField<envoy::api::v2::listener::ListenerFilter>& filters,
-               Configuration::ListenerFactoryContext& context)
-                -> std::vector<Network::ListenerFilterFactoryCb> {
-              return ProdListenerComponentFactory::createListenerFilterFactoryList_(filters,
-                                                                                    context);
-            }));
-    socket_.reset(new NiceMock<Network::MockConnectionSocket>());
-  }
-
-  const Network::FilterChain*
-  findFilterChain(const std::string& server_name, bool expect_server_name_match,
-                  const std::string& transport_protocol, bool expect_transport_protocol_match,
-                  const std::vector<std::string>& application_protocols) {
-    EXPECT_CALL(*socket_, requestedServerName()).WillOnce(Return(absl::string_view(server_name)));
-    if (expect_server_name_match) {
-      EXPECT_CALL(*socket_, detectedTransportProtocol())
-          .WillOnce(Return(absl::string_view(transport_protocol)));
-      if (expect_transport_protocol_match) {
-        EXPECT_CALL(*socket_, requestedApplicationProtocols())
-            .WillOnce(ReturnRef(application_protocols));
-      } else {
-        EXPECT_CALL(*socket_, requestedApplicationProtocols()).Times(0);
-      }
-    } else {
-      EXPECT_CALL(*socket_, detectedTransportProtocol()).Times(0);
-      EXPECT_CALL(*socket_, requestedApplicationProtocols()).Times(0);
-    }
-    return manager_->listeners().back().get().filterChainManager().findFilterChain(*socket_);
-  }
-
-private:
-  std::unique_ptr<Network::MockConnectionSocket> socket_;
-};
-
 class MockLdsApi : public LdsApi {
 public:
   MOCK_CONST_METHOD0(versionInfo, std::string());
@@ -1954,7 +1907,7 @@ class OriginalDstTestFilterIPv6
   }
 };
 
-TEST_F(ListenerManagerImplWithRealFiltersTestIPv6, OriginalDstTestFilterIPv6) {
+TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstTestFilterIPv6) {
   static int fd;
   fd = -1;
   EXPECT_CALL(*listener_factory_.socket_, fd()).WillOnce(Return(0));

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -1986,7 +1986,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstTestFilterIPv6) {
   EXPECT_NE(fd, -1);
 }
 
-TEST_F(ListenerManagerImplWithRealFiltersTestIPv6, OriginalDstTestFilterOptionFail) {
+TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstTestFilterOptionFailIPv6) {
   class OriginalDstTestConfigFactory : public Configuration::NamedListenerFilterConfigFactory {
   public:
     // NamedListenerFilterConfigFactory


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

*title*: Update network utility getoriginaldst for IPv6

*Description*:
This PR adds  IP6T_SO_ORIGINAL_DST to the network utility for retaining the original_dest.

*Risk Level*: 
Medium: Because we have to hardcode this with a define, there is a risk that upstream this gets changed and we would have to adjust. The define is necessary without the [unmerged patch from Oct 2016](https://patchwork.kernel.org/patch/9395683/). The TLDR is that the C code does not compile well with our compiler as shown [here](https://github.com/envoyproxy/envoy/issues/1094#issuecomment-308137745). 

*Testing*:
Current tests exist

*Docs Changes*:
In progress

*Release Notes*:
Support IPv6 for original_dest in network utility

Fixes #1094 
