### PR TITLE
Correct AddrFaily to AddrFamily.

### DIFF
--- a/source/common/network/addr_family_aware_socket_option_impl.cc
+++ b/source/common/network/addr_family_aware_socket_option_impl.cc
@@ -10,11 +10,11 @@
 namespace Envoy {
 namespace Network {
 
-bool AddrFailyAwareSocketOptionImpl::setOption(Socket& socket, Socket::SocketState state) const {
+bool AddrFamilyAwareSocketOptionImpl::setOption(Socket& socket, Socket::SocketState state) const {
   return setIpSocketOption(socket, state, ipv4_option_, ipv6_option_);
 }
 
-bool AddrFailyAwareSocketOptionImpl::setIpSocketOption(
+bool AddrFamilyAwareSocketOptionImpl::setIpSocketOption(
     Socket& socket, Socket::SocketState state, const std::unique_ptr<SocketOptionImpl>& ipv4_option,
     const std::unique_ptr<SocketOptionImpl>& ipv6_option) {
   // If this isn't IP, we're out of luck.

--- a/source/common/network/addr_family_aware_socket_option_impl.h
+++ b/source/common/network/addr_family_aware_socket_option_impl.h
@@ -14,11 +14,11 @@
 namespace Envoy {
 namespace Network {
 
-class AddrFailyAwareSocketOptionImpl : public Socket::Option,
-                                       Logger::Loggable<Logger::Id::connection> {
+class AddrFamilyAwareSocketOptionImpl : public Socket::Option,
+                                        Logger::Loggable<Logger::Id::connection> {
 public:
-  AddrFailyAwareSocketOptionImpl(Socket::SocketState in_state, SocketOptionName ipv4_optname,
-                                 SocketOptionName ipv6_optname, int value)
+  AddrFamilyAwareSocketOptionImpl(Socket::SocketState in_state, SocketOptionName ipv4_optname,
+                                  SocketOptionName ipv6_optname, int value)
       : ipv4_option_(absl::make_unique<SocketOptionImpl>(in_state, ipv4_optname, value)),
         ipv6_option_(absl::make_unique<SocketOptionImpl>(in_state, ipv6_optname, value)) {}
 

--- a/source/common/network/socket_option_factory.cc
+++ b/source/common/network/socket_option_factory.cc
@@ -32,7 +32,7 @@ SocketOptionFactory::buildTcpKeepaliveOptions(Network::TcpKeepaliveConfig keepal
 
 std::unique_ptr<Socket::Options> SocketOptionFactory::buildIpFreebindOptions() {
   std::unique_ptr<Socket::Options> options = absl::make_unique<Socket::Options>();
-  options->push_back(std::make_shared<Network::AddrFailyAwareSocketOptionImpl>(
+  options->push_back(std::make_shared<Network::AddrFamilyAwareSocketOptionImpl>(
       Network::Socket::SocketState::PreBind, ENVOY_SOCKET_IP_FREEBIND, ENVOY_SOCKET_IPV6_FREEBIND,
       1));
   return options;
@@ -40,10 +40,10 @@ std::unique_ptr<Socket::Options> SocketOptionFactory::buildIpFreebindOptions() {
 
 std::unique_ptr<Socket::Options> SocketOptionFactory::buildIpTransparentOptions() {
   std::unique_ptr<Socket::Options> options = absl::make_unique<Socket::Options>();
-  options->push_back(std::make_shared<Network::AddrFailyAwareSocketOptionImpl>(
+  options->push_back(std::make_shared<Network::AddrFamilyAwareSocketOptionImpl>(
       Network::Socket::SocketState::PreBind, ENVOY_SOCKET_IP_TRANSPARENT,
       ENVOY_SOCKET_IPV6_TRANSPARENT, 1));
-  options->push_back(std::make_shared<Network::AddrFailyAwareSocketOptionImpl>(
+  options->push_back(std::make_shared<Network::AddrFamilyAwareSocketOptionImpl>(
       Network::Socket::SocketState::PostBind, ENVOY_SOCKET_IP_TRANSPARENT,
       ENVOY_SOCKET_IPV6_TRANSPARENT, 1));
   return options;

--- a/test/common/network/addr_family_aware_socket_option_impl_test.cc
+++ b/test/common/network/addr_family_aware_socket_option_impl_test.cc
@@ -6,12 +6,12 @@ namespace Envoy {
 namespace Network {
 namespace {
 
-class AddrFailyAwareSocketOptionImplTest : public SocketOptionTest {};
+class AddrFamilyAwareSocketOptionImplTest : public SocketOptionTest {};
 
 // We fail to set the option when the underlying setsockopt syscall fails.
-TEST_F(AddrFailyAwareSocketOptionImplTest, SetOptionFailure) {
+TEST_F(AddrFamilyAwareSocketOptionImplTest, SetOptionFailure) {
   EXPECT_CALL(socket_, fd()).WillOnce(Return(-1));
-  AddrFailyAwareSocketOptionImpl socket_option{
+  AddrFamilyAwareSocketOptionImpl socket_option{
       Socket::SocketState::PreBind, Network::SocketOptionName(std::make_pair(5, 10)), {}, 1};
   EXPECT_LOG_CONTAINS(
       "warning", "Failed to set IP socket option on non-IP socket",
@@ -19,34 +19,34 @@ TEST_F(AddrFailyAwareSocketOptionImplTest, SetOptionFailure) {
 }
 
 // If a platform supports IPv4 socket option variant for an IPv4 address, it works
-TEST_F(AddrFailyAwareSocketOptionImplTest, SetOptionSuccess) {
+TEST_F(AddrFamilyAwareSocketOptionImplTest, SetOptionSuccess) {
   Address::Ipv4Instance address("1.2.3.4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
 
-  AddrFailyAwareSocketOptionImpl socket_option{
+  AddrFamilyAwareSocketOptionImpl socket_option{
       Socket::SocketState::PreBind, Network::SocketOptionName(std::make_pair(5, 10)), {}, 1};
   testSetSocketOptionSuccess(socket_option, Network::SocketOptionName(std::make_pair(5, 10)), 1,
                              {Socket::SocketState::PreBind});
 }
 
 // If a platform doesn't support IPv4 socket option variant for an IPv4 address we fail
-TEST_F(AddrFailyAwareSocketOptionImplTest, V4EmptyOptionNames) {
+TEST_F(AddrFamilyAwareSocketOptionImplTest, V4EmptyOptionNames) {
   Address::Ipv4Instance address("1.2.3.4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
-  AddrFailyAwareSocketOptionImpl socket_option{Socket::SocketState::PreBind, {}, {}, 1};
+  AddrFamilyAwareSocketOptionImpl socket_option{Socket::SocketState::PreBind, {}, {}, 1};
 
   EXPECT_LOG_CONTAINS("warning", "Setting option on socket failed: Operation not supported",
                       EXPECT_FALSE(socket_option.setOption(socket_, Socket::SocketState::PreBind)));
 }
 
 // If a platform doesn't support IPv4 and IPv6 socket option variants for an IPv4 address, we fail
-TEST_F(AddrFailyAwareSocketOptionImplTest, V6EmptyOptionNames) {
+TEST_F(AddrFamilyAwareSocketOptionImplTest, V6EmptyOptionNames) {
   Address::Ipv6Instance address("::1:2:3:4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
-  AddrFailyAwareSocketOptionImpl socket_option{Socket::SocketState::PreBind, {}, {}, 1};
+  AddrFamilyAwareSocketOptionImpl socket_option{Socket::SocketState::PreBind, {}, {}, 1};
 
   EXPECT_LOG_CONTAINS("warning", "Setting option on socket failed: Operation not supported",
                       EXPECT_FALSE(socket_option.setOption(socket_, Socket::SocketState::PreBind)));
@@ -54,25 +54,25 @@ TEST_F(AddrFailyAwareSocketOptionImplTest, V6EmptyOptionNames) {
 
 // If a platform suppports IPv4 and IPv6 socket option variants for an IPv4 address, we apply the
 // IPv4 varient
-TEST_F(AddrFailyAwareSocketOptionImplTest, V4IgnoreV6) {
+TEST_F(AddrFamilyAwareSocketOptionImplTest, V4IgnoreV6) {
   Address::Ipv4Instance address("1.2.3.4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
 
-  AddrFailyAwareSocketOptionImpl socket_option{Socket::SocketState::PreBind,
-                                               Network::SocketOptionName(std::make_pair(5, 10)),
-                                               Network::SocketOptionName(std::make_pair(6, 11)), 1};
+  AddrFamilyAwareSocketOptionImpl socket_option{
+      Socket::SocketState::PreBind, Network::SocketOptionName(std::make_pair(5, 10)),
+      Network::SocketOptionName(std::make_pair(6, 11)), 1};
   testSetSocketOptionSuccess(socket_option, Network::SocketOptionName(std::make_pair(5, 10)), 1,
                              {Socket::SocketState::PreBind});
 }
 
 // If a platform suppports IPv6 socket option variant for an IPv6 address it works
-TEST_F(AddrFailyAwareSocketOptionImplTest, V6Only) {
+TEST_F(AddrFamilyAwareSocketOptionImplTest, V6Only) {
   Address::Ipv6Instance address("::1:2:3:4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
 
-  AddrFailyAwareSocketOptionImpl socket_option{
+  AddrFamilyAwareSocketOptionImpl socket_option{
       Socket::SocketState::PreBind, {}, Network::SocketOptionName(std::make_pair(6, 11)), 1};
   testSetSocketOptionSuccess(socket_option, Network::SocketOptionName(std::make_pair(6, 11)), 1,
                              {Socket::SocketState::PreBind});
@@ -80,27 +80,27 @@ TEST_F(AddrFailyAwareSocketOptionImplTest, V6Only) {
 
 // If a platform suppports only the IPv4 variant for an IPv6 address,
 // we apply the IPv4 variant.
-TEST_F(AddrFailyAwareSocketOptionImplTest, V6OnlyV4Fallback) {
+TEST_F(AddrFamilyAwareSocketOptionImplTest, V6OnlyV4Fallback) {
   Address::Ipv6Instance address("::1:2:3:4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
 
-  AddrFailyAwareSocketOptionImpl socket_option{
+  AddrFamilyAwareSocketOptionImpl socket_option{
       Socket::SocketState::PreBind, Network::SocketOptionName(std::make_pair(5, 10)), {}, 1};
   testSetSocketOptionSuccess(socket_option, Network::SocketOptionName(std::make_pair(5, 10)), 1,
                              {Socket::SocketState::PreBind});
 }
 
 // If a platform suppports IPv4 and IPv6 socket option variants for an IPv6 address,
-// AddrFailyAwareSocketOptionImpl::setIpSocketOption() works with the IPv6 variant.
-TEST_F(AddrFailyAwareSocketOptionImplTest, V6Precedence) {
+// AddrFamilyAwareSocketOptionImpl::setIpSocketOption() works with the IPv6 variant.
+TEST_F(AddrFamilyAwareSocketOptionImplTest, V6Precedence) {
   Address::Ipv6Instance address("::1:2:3:4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
 
-  AddrFailyAwareSocketOptionImpl socket_option{Socket::SocketState::PreBind,
-                                               Network::SocketOptionName(std::make_pair(5, 10)),
-                                               Network::SocketOptionName(std::make_pair(6, 11)), 1};
+  AddrFamilyAwareSocketOptionImpl socket_option{
+      Socket::SocketState::PreBind, Network::SocketOptionName(std::make_pair(5, 10)),
+      Network::SocketOptionName(std::make_pair(6, 11)), 1};
   testSetSocketOptionSuccess(socket_option, Network::SocketOptionName(std::make_pair(6, 11)), 1,
                              {Socket::SocketState::PreBind});
 }


### PR DESCRIPTION
Signed-off-by: Trevor Schroeder <trevors@google.com>

spelling: AddrFaily is amusing but not correct.

*Description*:
Correct the spelling AddrFaily to AddrFamily.

*Risk Level*: Low

*Testing*:
All tests pass.