### PR TITLE
gzip: add stats to filter and fix accept-encoding identity bug 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ BROWSE
 SOURCE_VERSION
 .cache
 .vimrc
+.vscode

--- a/docs/root/configuration/http_filters/gzip_filter.rst
+++ b/docs/root/configuration/http_filters/gzip_filter.rst
@@ -44,7 +44,7 @@ By *default* compression will be *skipped* when:
   that the "gzip" will have a higher weight then "\*". For example, if *accept-encoding*
   is "gzip;q=0,\*;q=1", the filter will not compress. But if the header is set to
   "\*;q=0,gzip;q=1", the filter will compress.
-- A request includes *accept-encoding* header includes "identity".
+- A request whose *accept-encoding* header includes "identity".
 - A response contains a *content-encoding* header.
 - A response contains a *cache-control* header whose value includes "no-transform".
 - A response contains a *transfer-encoding* header whose value includes "gzip".
@@ -63,3 +63,27 @@ When compression is *applied*:
 - Response headers contain "*transfer-encoding: chunked*" and
   "*content-encoding: gzip*".
 - The "*vary: accept-encoding*" header is inserted on every response.
+
+.. _gzip-statistics:
+
+Statistics
+----------
+
+Every configured Gzip filter has statistics rooted at <stat_prefix>.gzip.* with the following:
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: 1, 1, 2
+
+  compressed, Counter, Number of requests compressed.
+  not_compressed, Counter, Number of requests not compressed.
+  no_accept_header, Counter, Number of requests with no accept header sent.
+  header_identity, Counter, Number of requests sent with the "identity" set as the *accept-encoding*.
+  header_gzip, Counter, Number of requests sent with the "gzip" set as the *accept-encoding*.
+  header_wildcard, Counter, Number of requests sent with the "\*" set as the *accept-encoding*.
+  header_not_valid, Counter, Number of requests sent with the a not valid *accept-encoding* header (aka "q=0" or an unsupported encoding type).
+  total_uncompressed_bytes, Counter, The total uncompressed bytes of all the requests that were marked for compression.
+  total_compressed_bytes, Counter, The total compressed bytes of all the requests that were marked for compression.
+  content_length_too_small, Counter, Number of requests that accepted gzip encoding but did not compress because the payload was too small.
+  not_compressed_etag, Counter, Number of requests that were not compressed due to the etag header. *disable_on_etag_header* must be turned on for this to happen.
+  

--- a/docs/root/configuration/http_filters/gzip_filter.rst
+++ b/docs/root/configuration/http_filters/gzip_filter.rst
@@ -78,10 +78,10 @@ Every configured Gzip filter has statistics rooted at <stat_prefix>.gzip.* with 
   compressed, Counter, Number of requests compressed.
   not_compressed, Counter, Number of requests not compressed.
   no_accept_header, Counter, Number of requests with no accept header sent.
-  header_identity, Counter, Number of requests sent with the "identity" set as the *accept-encoding*.
-  header_gzip, Counter, Number of requests sent with the "gzip" set as the *accept-encoding*.
-  header_wildcard, Counter, Number of requests sent with the "\*" set as the *accept-encoding*.
-  header_not_valid, Counter, Number of requests sent with the a not valid *accept-encoding* header (aka "q=0" or an unsupported encoding type).
+  header_identity, Counter, Number of requests sent with "identity" set as the *accept-encoding*.
+  header_gzip, Counter, Number of requests sent with "gzip" set as the *accept-encoding*.
+  header_wildcard, Counter, Number of requests sent with "\*" set as the *accept-encoding*.
+  header_not_valid, Counter, Number of requests sent with a not valid *accept-encoding* header (aka "q=0" or an unsupported encoding type).
   total_uncompressed_bytes, Counter, The total uncompressed bytes of all the requests that were marked for compression.
   total_compressed_bytes, Counter, The total compressed bytes of all the requests that were marked for compression.
   content_length_too_small, Counter, Number of requests that accepted gzip encoding but did not compress because the payload was too small.

--- a/docs/root/configuration/http_filters/gzip_filter.rst
+++ b/docs/root/configuration/http_filters/gzip_filter.rst
@@ -39,9 +39,14 @@ response and request allow.
 By *default* compression will be *skipped* when:
 
 - A request does NOT contain *accept-encoding* header.
-- A request includes *accept-encoding* header, but it does not contain "gzip".
+- A request includes *accept-encoding* header, but it does not contain "gzip" or "*".
+- A request inclues *accept-encoding* with "gzip" or "*" with the weight "q=0". Note
+  that the "gzip" will have a higher weight then "*". For example, if *accept-encoding*
+  is "gzip;q=0,*;q=1", the filter will not compress. But if the header is set to
+  "*;q=0,gzip;q=1", the filter will compress.
+- A request includes *accept-encoding* header includes "identity".
 - A response contains a *content-encoding* header.
-- A Response contains a *cache-control* header whose value includes "no-transform".
+- A response contains a *cache-control* header whose value includes "no-transform".
 - A response contains a *transfer-encoding* header whose value includes "gzip".
 - A response does not contain a *content-type* value that matches one of the selected
   mime-types, which default to *application/javascript*, *application/json*,

--- a/docs/root/configuration/http_filters/gzip_filter.rst
+++ b/docs/root/configuration/http_filters/gzip_filter.rst
@@ -39,11 +39,11 @@ response and request allow.
 By *default* compression will be *skipped* when:
 
 - A request does NOT contain *accept-encoding* header.
-- A request includes *accept-encoding* header, but it does not contain "gzip" or "*".
-- A request inclues *accept-encoding* with "gzip" or "*" with the weight "q=0". Note
-  that the "gzip" will have a higher weight then "*". For example, if *accept-encoding*
-  is "gzip;q=0,*;q=1", the filter will not compress. But if the header is set to
-  "*;q=0,gzip;q=1", the filter will compress.
+- A request includes *accept-encoding* header, but it does not contain "gzip" or "\*".
+- A request includes *accept-encoding* with "gzip" or "\*" with the weight "q=0". Note
+  that the "gzip" will have a higher weight then "\*". For example, if *accept-encoding*
+  is "gzip;q=0,\*;q=1", the filter will not compress. But if the header is set to
+  "\*;q=0,gzip;q=1", the filter will compress.
 - A request includes *accept-encoding* header includes "identity".
 - A response contains a *content-encoding* header.
 - A response contains a *cache-control* header whose value includes "no-transform".

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -3,7 +3,6 @@ Version history
 
 1.7.0 (Pending)
 ===============
-
 * access log: added ability to log response trailers.
 * access log: added ability to format START_TIME.
 * access log: added DYNAMIC_METADATA :ref:`access log formatter <config_access_log_format>`.
@@ -36,6 +35,7 @@ Version history
 * debug: added symbolized stack traces (where supported)
 * grpc: support added for the full set of :ref:`Google gRPC call credentials
   <envoy_api_msg_core.GrpcService.GoogleGrpc.CallCredentials>`.
+* gzip filter: sending accept-encoding header as identity no longer compresses the payload.
 * health check: added ability to set :ref:`additional HTTP headers
   <envoy_api_field_core.HealthCheck.HttpHealthCheck.request_headers_to_add>` for HTTP health check.
 * health check: added support for EDS delivered :ref:`endpoint health status

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -35,7 +35,8 @@ Version history
 * debug: added symbolized stack traces (where supported)
 * grpc: support added for the full set of :ref:`Google gRPC call credentials
   <envoy_api_msg_core.GrpcService.GoogleGrpc.CallCredentials>`.
-* gzip filter: sending accept-encoding header as identity no longer compresses the payload.
+* gzip filter: added :ref:`stats <gzip-statistics>` to the filter.
+* gzip filter: sending *accept-encoding* header as *identity* no longer compresses the payload.
 * health check: added ability to set :ref:`additional HTTP headers
   <envoy_api_field_core.HealthCheck.HttpHealthCheck.request_headers_to_add>` for HTTP health check.
 * health check: added support for EDS delivered :ref:`endpoint health status

--- a/source/extensions/filters/http/gzip/config.cc
+++ b/source/extensions/filters/http/gzip/config.cc
@@ -11,10 +11,10 @@ namespace HttpFilters {
 namespace Gzip {
 
 Http::FilterFactoryCb GzipFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::config::filter::http::gzip::v2::Gzip& proto_config, const std::string&,
-    Server::Configuration::FactoryContext& context) {
-  GzipFilterConfigSharedPtr config =
-      std::make_shared<GzipFilterConfig>(proto_config, context.runtime());
+    const envoy::config::filter::http::gzip::v2::Gzip& proto_config,
+    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+  GzipFilterConfigSharedPtr config = std::make_shared<GzipFilterConfig>(
+      proto_config, stats_prefix, context.scope(), context.runtime());
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<GzipFilter>(config));
   };

--- a/source/extensions/filters/http/gzip/gzip_filter.cc
+++ b/source/extensions/filters/http/gzip/gzip_filter.cc
@@ -163,7 +163,7 @@ bool GzipFilter::isAcceptEncodingAllowed(Http::HeaderMap& headers) const {
   const Http::HeaderEntry* accept_encoding = headers.AcceptEncoding();
 
   if (accept_encoding) {
-    const bool is_wildcard = false; // true if found and not followed by `q=0`.
+    bool is_wildcard = false; // true if found and not followed by `q=0`.
     for (const auto token : StringUtil::splitToken(headers.AcceptEncoding()->value().c_str(), ",",
                                                    false /* keep_empty */)) {
       const auto value = StringUtil::trim(StringUtil::cropRight(token, ";"));

--- a/source/extensions/filters/http/gzip/gzip_filter.cc
+++ b/source/extensions/filters/http/gzip/gzip_filter.cc
@@ -226,12 +226,12 @@ bool GzipFilter::isMinimumContentLength(Http::HeaderMap& headers) const {
   const Http::HeaderEntry* content_length = headers.ContentLength();
   if (content_length) {
     uint64_t length;
-    bool isMinimumContentLength = StringUtil::atoul(content_length->value().c_str(), length) &&
-                                  length >= config_->minimumLength();
-    if (!isMinimumContentLength) {
+    bool is_minimum_content_length = StringUtil::atoul(content_length->value().c_str(), length) &&
+                                     length >= config_->minimumLength();
+    if (!is_minimum_content_length) {
       config_->stats().content_length_too_small_.inc();
     }
-    return isMinimumContentLength;
+    return is_minimum_content_length;
   }
 
   const Http::HeaderEntry* transfer_encoding = headers.TransferEncoding();

--- a/source/extensions/filters/http/gzip/gzip_filter.cc
+++ b/source/extensions/filters/http/gzip/gzip_filter.cc
@@ -131,7 +131,7 @@ Http::FilterHeadersStatus GzipFilter::encodeHeaders(Http::HeaderMap& headers, bo
   } else if (!skip_compression_) {
     skip_compression_ = true;
     config_->stats().not_compressed_.inc();
-  } 
+  }
   return Http::FilterHeadersStatus::Continue;
 }
 

--- a/source/extensions/filters/http/gzip/gzip_filter.cc
+++ b/source/extensions/filters/http/gzip/gzip_filter.cc
@@ -163,14 +163,14 @@ bool GzipFilter::isAcceptEncodingAllowed(Http::HeaderMap& headers) const {
   const Http::HeaderEntry* accept_encoding = headers.AcceptEncoding();
 
   if (accept_encoding) {
-    bool is_wildcard = false; // true if found and not followed by `q=0`.
+    const bool is_wildcard = false; // true if found and not followed by `q=0`.
     for (const auto token : StringUtil::splitToken(headers.AcceptEncoding()->value().c_str(), ",",
                                                    false /* keep_empty */)) {
       const auto value = StringUtil::trim(StringUtil::cropRight(token, ";"));
       const auto q_value = StringUtil::trim(StringUtil::cropLeft(token, ";"));
       // If value is the gzip coding, check the qvalue and return.
       if (value == Http::Headers::get().AcceptEncodingValues.Gzip) {
-        bool is_gzip = !StringUtil::caseCompare(q_value, ZeroQvalueString);
+        const bool is_gzip = !StringUtil::caseCompare(q_value, ZeroQvalueString);
         if (is_gzip) {
           config_->stats().header_gzip_.inc();
           return true;
@@ -186,7 +186,7 @@ bool GzipFilter::isAcceptEncodingAllowed(Http::HeaderMap& headers) const {
         return false;
       }
       // Otherwise, check if the header contains the wildcard. If so,
-      // mark as true. Use this as the very last resort, as gzip or 
+      // mark as true. Use this as the very last resort, as gzip or
       // identity is weighted higher. Note that this filter disregards
       // order/priority at this time.
       if (value == Http::Headers::get().AcceptEncodingValues.Wildcard) {
@@ -217,7 +217,7 @@ bool GzipFilter::isContentTypeAllowed(Http::HeaderMap& headers) const {
 }
 
 bool GzipFilter::isEtagAllowed(Http::HeaderMap& headers) const {
-  bool is_etag_allowed = !(config_->disableOnEtagHeader() && headers.Etag());
+  const bool is_etag_allowed = !(config_->disableOnEtagHeader() && headers.Etag());
   if (!is_etag_allowed) {
     config_->stats().not_compressed_etag_.inc();
   }
@@ -228,8 +228,9 @@ bool GzipFilter::isMinimumContentLength(Http::HeaderMap& headers) const {
   const Http::HeaderEntry* content_length = headers.ContentLength();
   if (content_length) {
     uint64_t length;
-    bool is_minimum_content_length = StringUtil::atoul(content_length->value().c_str(), length) &&
-                                     length >= config_->minimumLength();
+    const bool is_minimum_content_length =
+        StringUtil::atoul(content_length->value().c_str(), length) &&
+        length >= config_->minimumLength();
     if (!is_minimum_content_length) {
       config_->stats().content_length_too_small_.inc();
     }

--- a/source/extensions/filters/http/gzip/gzip_filter.cc
+++ b/source/extensions/filters/http/gzip/gzip_filter.cc
@@ -178,15 +178,17 @@ bool GzipFilter::isAcceptEncodingAllowed(Http::HeaderMap& headers) const {
         config_->stats().header_not_valid_.inc();
         return false;
       }
-      // If value is the identity coding, return false. The data needs should
+      // If value is the identity coding, return false. The data should
       // not be transformed in this case.
       // https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.5.
       if (value == Http::Headers::get().AcceptEncodingValues.Identity) {
         config_->stats().header_identity_.inc();
         return false;
       }
-      // Otherwise, check if the header contains the wildcard. If so
-      // return true.
+      // Otherwise, check if the header contains the wildcard. If so,
+      // mark as true. Use this as the very last resort, as gzip or 
+      // identity is weighted higher. Note that this filter disregards
+      // order/priority at this time.
       if (value == Http::Headers::get().AcceptEncodingValues.Wildcard) {
         is_wildcard = !StringUtil::caseCompare(q_value, ZeroQvalueString);
       }

--- a/source/extensions/filters/http/gzip/gzip_filter.h
+++ b/source/extensions/filters/http/gzip/gzip_filter.h
@@ -65,7 +65,7 @@ public:
   }
 
   Runtime::Loader& runtime() { return runtime_; }
-  Stats::Scope& scope() { return scope_; }
+  GzipStats& stats() { return stats_; }
   const std::string stats_prefix() { return stats_prefix_; }
   const StringUtil::CaseUnorderedSet& contentTypeValues() const { return content_type_values_; }
   bool disableOnEtagHeader() const { return disable_on_etag_header_; }
@@ -86,6 +86,10 @@ private:
   static uint64_t memoryLevelUint(Protobuf::uint32 level);
   static uint64_t windowBitsUint(Protobuf::uint32 window_bits);
 
+  static GzipStats generateStats(const std::string& prefix, Stats::Scope& scope) {
+    return GzipStats{ALL_GZIP_STATS(POOL_COUNTER_PREFIX(scope, prefix))};
+  }
+
   Compressor::ZlibCompressorImpl::CompressionLevel compression_level_;
   Compressor::ZlibCompressorImpl::CompressionStrategy compression_strategy_;
 
@@ -97,7 +101,7 @@ private:
   bool disable_on_etag_header_;
   bool remove_accept_encoding_header_;
   const std::string stats_prefix_;
-  Stats::Scope& scope_;
+  GzipStats stats_;
   Runtime::Loader& runtime_;
 };
 typedef std::shared_ptr<GzipFilterConfig> GzipFilterConfigSharedPtr;
@@ -152,15 +156,10 @@ private:
   void sanitizeEtagHeader(Http::HeaderMap& headers);
   void insertVaryHeader(Http::HeaderMap& headers);
 
-  static GzipStats generateStats(const std::string& prefix, Stats::Scope& scope) {
-    return GzipStats{ALL_GZIP_STATS(POOL_COUNTER_PREFIX(scope, prefix))};
-  }
-
   bool skip_compression_;
   Buffer::OwnedImpl compressed_data_;
   Compressor::ZlibCompressorImpl compressor_;
   GzipFilterConfigSharedPtr config_;
-  GzipStats stats_;
 
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{nullptr};
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{nullptr};

--- a/source/extensions/filters/http/gzip/gzip_filter.h
+++ b/source/extensions/filters/http/gzip/gzip_filter.h
@@ -103,7 +103,6 @@ private:
   StringUtil::CaseUnorderedSet content_type_values_;
   bool disable_on_etag_header_;
   bool remove_accept_encoding_header_;
-  const std::string stats_prefix_;
   GzipStats stats_;
   Runtime::Loader& runtime_;
 };

--- a/source/extensions/filters/http/gzip/gzip_filter.h
+++ b/source/extensions/filters/http/gzip/gzip_filter.h
@@ -54,7 +54,7 @@ class GzipFilterConfig {
 
 public:
   GzipFilterConfig(const envoy::config::filter::http::gzip::v2::Gzip& gzip,
-                    const std::string& stats_prefix,
+                   const std::string& stats_prefix,
                    Stats::Scope& scope, Runtime::Loader& runtime);
 
   Compressor::ZlibCompressorImpl::CompressionLevel compressionLevel() const {

--- a/source/extensions/filters/http/gzip/gzip_filter.h
+++ b/source/extensions/filters/http/gzip/gzip_filter.h
@@ -26,17 +26,18 @@ namespace Gzip {
  * the bytes are not expected to be compressed.
  */
 // clang-format off
-#define ALL_GZIP_STATS(COUNTER) \
-  COUNTER(compressed)   \
-  COUNTER(not_compressed) \
-  COUNTER(no_accept_header) \
-  COUNTER(header_identity)\
-  COUNTER(header_gzip)\
-  COUNTER(header_wildcard)\
-  COUNTER(header_not_valid)\
-  COUNTER(has_etag)\
+#define ALL_GZIP_STATS(COUNTER)    \
+  COUNTER(compressed)              \
+  COUNTER(not_compressed)          \
+  COUNTER(no_accept_header)        \
+  COUNTER(header_identity)         \
+  COUNTER(header_gzip)             \
+  COUNTER(header_wildcard)         \
+  COUNTER(header_not_valid)        \
   COUNTER(total_uncompressed_bytes)\
-  COUNTER(total_compressed_bytes)                 \
+  COUNTER(total_compressed_bytes)  \
+  COUNTER(content_length_too_small)\
+  COUNTER(not_compressed_etag)     \
 // clang-format on
 
 /**

--- a/source/extensions/filters/http/gzip/gzip_filter.h
+++ b/source/extensions/filters/http/gzip/gzip_filter.h
@@ -21,9 +21,13 @@ namespace Gzip {
 
 /**
  * All gzip filter stats. @see stats_macros.h
- * Note that the total_bytes is only if the response
- * is expected to be compressed. This does not get counted if
- * the bytes are not expected to be compressed.
+ * "total_uncompressed_bytes" only includes bytes
+ * from requests that were marked for compression.
+ * If the request was not marked for compression,
+ * the filter increments "not_compressed", but does
+ * not add to "total_uncompressed_bytes". This way,
+ * the user can measure the memory performance of the
+ * compression.
  */
 // clang-format off
 #define ALL_GZIP_STATS(COUNTER)    \
@@ -66,7 +70,6 @@ public:
 
   Runtime::Loader& runtime() { return runtime_; }
   GzipStats& stats() { return stats_; }
-  const std::string stats_prefix() { return stats_prefix_; }
   const StringUtil::CaseUnorderedSet& contentTypeValues() const { return content_type_values_; }
   bool disableOnEtagHeader() const { return disable_on_etag_header_; }
   bool removeAcceptEncodingHeader() const { return remove_accept_encoding_header_; }

--- a/test/extensions/filters/http/gzip/gzip_filter_integration_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_integration_test.cc
@@ -117,6 +117,21 @@ TEST_P(GzipIntegrationTest, AcceptanceFullConfigTest) {
 }
 
 /**
+ * Exercises filter when client request contains 'identity' type.
+ */
+TEST_P(GzipIntegrationTest, IdentityAcceptEncoding) {
+  initializeFilter(default_config);
+  doRequestAndNoCompression(Http::TestHeaderMapImpl{{":method", "GET"},
+                                                    {":path", "/test/long/url"},
+                                                    {":scheme", "http"},
+                                                    {":authority", "host"},
+                                                    {"accept-encoding", "identity"}},
+                            Http::TestHeaderMapImpl{{":status", "200"},
+                                                    {"content-length", "128"},
+                                                    {"content-type", "text/plain"}});
+}
+
+/**
  * Exercises filter when client request contains unsupported 'accept-encoding' type.
  */
 TEST_P(GzipIntegrationTest, NotSupportedAcceptEncoding) {

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -63,7 +63,6 @@ protected:
     envoy::config::filter::http::gzip::v2::Gzip gzip;
     MessageUtil::loadFromJson(json, gzip);
     config_.reset(new GzipFilterConfig(gzip, "test.", stats_, runtime_));
-    EXPECT_EQ("test.gzip.", config_->stats_prefix());
     filter_.reset(new GzipFilter(config_));
   }
 

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -6,6 +6,7 @@
 
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/runtime/mocks.h"
+#include "test/mocks/stats/mocks.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -61,7 +62,8 @@ protected:
     Json::ObjectSharedPtr config = Json::Factory::loadFromString(json);
     envoy::config::filter::http::gzip::v2::Gzip gzip;
     MessageUtil::loadFromJson(json, gzip);
-    config_.reset(new GzipFilterConfig(gzip, runtime_));
+    config_.reset(new GzipFilterConfig(gzip, "test.", stats_, runtime_));
+    EXPECT_EQ("test.gzip.", config_->stats_prefix());
     filter_.reset(new GzipFilter(config_));
   }
 
@@ -70,6 +72,8 @@ protected:
     const std::string uncompressed_str{TestUtility::bufferToString(decompressed_data_)};
     ASSERT_EQ(expected_str_.length(), uncompressed_str.length());
     EXPECT_EQ(expected_str_, uncompressed_str);
+    EXPECT_EQ(expected_str_.length(), stats_.counter("test.gzip.total_uncompressed_bytes").value());
+    EXPECT_EQ(data_.length(), stats_.counter("test.gzip.total_compressed_bytes").value());
   }
 
   void feedBuffer(uint64_t size) {
@@ -96,6 +100,7 @@ protected:
     EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(data_, true));
     verifyCompressedData();
     drainBuffer();
+    EXPECT_EQ(1U, stats_.counter("test.gzip.compressed").value());
   }
 
   void doResponseNoCompression(Http::TestHeaderMapImpl&& headers) {
@@ -118,6 +123,7 @@ protected:
   Decompressor::ZlibDecompressorImpl decompressor_;
   Buffer::OwnedImpl decompressed_data_;
   std::string expected_str_;
+  Stats::IsolatedStoreImpl stats_;
   NiceMock<Runtime::MockLoader> runtime_;
 };
 
@@ -131,7 +137,6 @@ TEST_F(GzipFilterTest, RuntimeDisabled) {
 
 // Default config values.
 TEST_F(GzipFilterTest, DefaultConfigValues) {
-
   EXPECT_EQ(5, config_->memoryLevel());
   EXPECT_EQ(30, config_->minimumLength());
   EXPECT_EQ(28, config_->windowBits());
@@ -190,87 +195,113 @@ TEST_F(GzipFilterTest, isAcceptEncodingAllowed) {
   {
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "deflate, gzip, br"}};
     EXPECT_TRUE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(1, stats_.counter("test.gzip.header_gzip").value());
   }
   {
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "deflate, gzip;q=1.0, *;q=0.5"}};
     EXPECT_TRUE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(2, stats_.counter("test.gzip.header_gzip").value());
   }
   {
     Http::TestHeaderMapImpl headers = {
         {"accept-encoding", "\tdeflate\t, gzip\t ; q\t =\t 1.0,\t * ;q=0.5\n"}};
     EXPECT_TRUE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(3, stats_.counter("test.gzip.header_gzip").value());
   }
   {
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "deflate,gzip;q=1.0,*;q=0"}};
     EXPECT_TRUE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(4, stats_.counter("test.gzip.header_gzip").value());
   }
   {
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "deflate, gzip;q=0.2, br;q=1"}};
     EXPECT_TRUE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(5, stats_.counter("test.gzip.header_gzip").value());
   }
   {
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "*"}};
     EXPECT_TRUE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(1, stats_.counter("test.gzip.header_wildcard").value());
   }
   {
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "*;q=1"}};
     EXPECT_TRUE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(2, stats_.counter("test.gzip.header_wildcard").value());
   }
   {
+    // gzip header is not valid due to q=0.
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "gzip;q=0,*;q=1"}};
     EXPECT_FALSE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(5, stats_.counter("test.gzip.header_gzip").value());
+    EXPECT_EQ(1, stats_.counter("test.gzip.header_not_valid").value());
   }
   {
     Http::TestHeaderMapImpl headers = {};
     EXPECT_FALSE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(1, stats_.counter("test.gzip.no_accept_header").value());
   }
   {
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "identity, *;q=0"}};
-    EXPECT_TRUE(isAcceptEncodingAllowed(headers));
+    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(1, stats_.counter("test.gzip.header_identity").value());
   }
   {
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "identity;q=0.5, *;q=0"}};
-    EXPECT_TRUE(isAcceptEncodingAllowed(headers));
+    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(2, stats_.counter("test.gzip.header_identity").value());
   }
   {
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "identity;q=0, *;q=0"}};
     EXPECT_FALSE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(3, stats_.counter("test.gzip.header_identity").value());
   }
   {
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "xyz;q=1, br;q=0.2, *"}};
     EXPECT_TRUE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(3, stats_.counter("test.gzip.header_wildcard").value());
   }
   {
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "xyz;q=1, br;q=0.2, *;q=0"}};
     EXPECT_FALSE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(3, stats_.counter("test.gzip.header_wildcard").value());
+    EXPECT_EQ(2, stats_.counter("test.gzip.header_not_valid").value());
   }
   {
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "xyz;q=1, br;q=0.2"}};
     EXPECT_FALSE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(3, stats_.counter("test.gzip.header_not_valid").value());
   }
   {
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "identity"}};
-    EXPECT_TRUE(isAcceptEncodingAllowed(headers));
+    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(4, stats_.counter("test.gzip.header_identity").value());
   }
   {
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "identity;q=1"}};
-    EXPECT_TRUE(isAcceptEncodingAllowed(headers));
+    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(5, stats_.counter("test.gzip.header_identity").value());
   }
   {
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "identity;q=0"}};
     EXPECT_FALSE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(6, stats_.counter("test.gzip.header_identity").value());
   }
   {
+    // Test that we return identity and ignore the invalid wildcard.
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "identity, *;q=0"}};
-    EXPECT_TRUE(isAcceptEncodingAllowed(headers));
+    EXPECT_FALSE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(7, stats_.counter("test.gzip.header_identity").value());
+    EXPECT_EQ(3, stats_.counter("test.gzip.header_not_valid").value());
   }
   {
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "deflate, gzip;Q=.5, br"}};
     EXPECT_TRUE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(6, stats_.counter("test.gzip.header_gzip").value());
   }
   {
     Http::TestHeaderMapImpl headers = {{"accept-encoding", "identity;Q=0"}};
     EXPECT_FALSE(isAcceptEncodingAllowed(headers));
+    EXPECT_EQ(8, stats_.counter("test.gzip.header_identity").value());
   }
 }
 
@@ -335,6 +366,7 @@ TEST_F(GzipFilterTest, ContentLengthCompression) {
 
 // Verifies isContentTypeAllowed function.
 TEST_F(GzipFilterTest, isContentTypeAllowed) {
+
   {
     Http::TestHeaderMapImpl headers = {{"content-type", "text/html"}};
     EXPECT_TRUE(isContentTypeAllowed(headers));


### PR DESCRIPTION
*gzip filter*: *add stats to filter and fix accept-encoding identity bug*

*Description*: This PR adds stats to the gzip filter. In the process of adding stats, I noticed a bug where the filter compresses when the Accept-Encoding is set to identity. I believe that goes against the RFC, as no transformation or encoding should happen to the data when "identity" is set. https://tools.ietf.org/html/rfc7231#section-5.3.4

*Risk Level*: Low

*Testing*: unit and integration

*Docs Changes*: Updated the gzip filter docs to clarify the behavior with identity and added more details with q=0. 

*Release Notes*: Added a change to the release notes as this is user impacting.
