### PR TITLE
WIP: Allow for config-specified sockopts

### DIFF
--- a/api/envoy/api/v2/core/address.proto
+++ b/api/envoy/api/v2/core/address.proto
@@ -74,6 +74,29 @@ message TcpKeepalive {
   google.protobuf.UInt32Value keepalive_interval = 3;
 }
 
+// Generic socket option message. This would be used to set socket options that
+// might not exist in upstream kernels or precompiled Envoy binaries.
+message SocketOption {
+  // An optional name to give this socket option
+  // No special meaning is assumed.
+  string readable_name = 1;
+  // Corresponding to the level value passed to setsockopt, such as IPPROTO_TCP
+  int32 level = 2;
+  // The numeric name as passed to setsockopt
+  int32 name = 3;
+  // The setsopt option value. Integers should be encoded in network byte order.
+  bytes value = 4;
+  enum SocketState {
+    option (gogoproto.goproto_enum_prefix) = false;
+    STATE_PREBIND = 0;
+    STATE_POSTBIND = 1;
+    STATE_LISTENING = 2;
+  }
+  // For listeners the option can only be used on sockets in the given state.
+  // For BindConfig, state is ignored.
+  SocketState state = 5 [(validate.rules).enum.defined_only = true];
+}
+
 message BindConfig {
   // The address to bind to when creating a socket.
   SocketAddress source_address = 1
@@ -87,6 +110,10 @@ message BindConfig {
   // flag is not set (default), the socket is not modified, i.e. the option is
   // neither enabled nor disabled.
   google.protobuf.BoolValue freebind = 2;
+
+  // Additional socket options that may not be present in Envoy source code or
+  // precompiled binaries.
+  repeated SocketOption socket_options = 3;
 }
 
 // Addresses specify either a logical or physical address and port, which are

--- a/api/envoy/api/v2/core/address.proto
+++ b/api/envoy/api/v2/core/address.proto
@@ -84,8 +84,15 @@ message SocketOption {
   int32 level = 2;
   // The numeric name as passed to setsockopt
   int32 name = 3;
-  // The setsopt option value. Integers should be encoded in network byte order.
-  bytes value = 4;
+  // The setsockopt option value. Integers should be encoded in network byte order.
+  oneof value {
+    option (validate.required) = true;
+
+    // Because many sockopts take an int value.
+    int32 int = 4;
+    // Otherwise it's a byte buffer.
+    bytes buf = 5;
+  }
   enum SocketState {
     option (gogoproto.goproto_enum_prefix) = false;
     // Socket options are applied after socket creation but before binding the socket to a port
@@ -97,7 +104,7 @@ message SocketOption {
   }
   // For listeners the option can only be used on sockets in the given state.
   // For BindConfig, state is ignored.
-  SocketState state = 5
+  SocketState state = 6
       [(validate.rules).message.required = true, (validate.rules).enum.defined_only = true];
 }
 

--- a/api/envoy/api/v2/core/address.proto
+++ b/api/envoy/api/v2/core/address.proto
@@ -88,13 +88,17 @@ message SocketOption {
   bytes value = 4;
   enum SocketState {
     option (gogoproto.goproto_enum_prefix) = false;
+    // Socket options are applied after socket creation but before binding the socket to a port
     STATE_PREBIND = 0;
-    STATE_POSTBIND = 1;
+    // Socket options are applied after binding the socket to a port but before calling listen()
+    STATE_BOUND = 1;
+    // Socket options are applied after calling listen()
     STATE_LISTENING = 2;
   }
   // For listeners the option can only be used on sockets in the given state.
   // For BindConfig, state is ignored.
-  SocketState state = 5 [(validate.rules).enum.defined_only = true];
+  SocketState state = 5
+      [(validate.rules).message.required = true, (validate.rules).enum.defined_only = true];
 }
 
 message BindConfig {

--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -144,6 +144,10 @@ message Listener {
   // nor disabled.
   google.protobuf.BoolValue freebind = 11;
 
+  // Additional socket options that may not be present in Envoy source code or
+  // precompiled binaries.
+  repeated core.SocketOption socket_options = 13;
+
   // Whether the listener should accept TCP Fast Open (TFO) connections.
   // When this flag is set to a value greater than 0, the option TCP_FASTOPEN is enabled on
   // the socket, with a queue length of the specified size

--- a/include/envoy/network/BUILD
+++ b/include/envoy/network/BUILD
@@ -62,7 +62,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "listen_socket_interface",
     hdrs = ["listen_socket.h"],
-    deps = ["//include/envoy/network:address_interface"],
+    deps = [
+        "//include/envoy/network:address_interface",
+        "@envoy_api//envoy/api/v2/core:address_cc",
+    ],
 )
 
 envoy_cc_library(

--- a/include/envoy/network/listen_socket.h
+++ b/include/envoy/network/listen_socket.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include "envoy/api/v2/core/address.pb.h"
 #include "envoy/common/pure.h"
 #include "envoy/network/address.h"
 
@@ -35,11 +36,11 @@ public:
 
   enum class SocketState {
     // Socket options are applied after socket creation but before binding the socket to a port
-    PreBind,
+    PreBind = envoy::api::v2::core::SocketOption::STATE_PREBIND,
     // Socket options are applied after binding the socket to a port but before calling listen()
-    PostBind,
+    PostBind = envoy::api::v2::core::SocketOption::STATE_POSTBIND,
     // Socket options are applied after calling listen()
-    Listening,
+    Listening = envoy::api::v2::core::SocketOption::STATE_LISTENING,
   };
 
   /**

--- a/include/envoy/network/listen_socket.h
+++ b/include/envoy/network/listen_socket.h
@@ -34,15 +34,6 @@ public:
    */
   virtual void close() PURE;
 
-  enum class SocketState {
-    // Socket options are applied after socket creation but before binding the socket to a port
-    PreBind = envoy::api::v2::core::SocketOption::STATE_PREBIND,
-    // Socket options are applied after binding the socket to a port but before calling listen()
-    PostBind = envoy::api::v2::core::SocketOption::STATE_POSTBIND,
-    // Socket options are applied after calling listen()
-    Listening = envoy::api::v2::core::SocketOption::STATE_LISTENING,
-  };
-
   /**
    * Visitor class for setting socket options.
    */
@@ -56,7 +47,8 @@ public:
      *        set for some particular state of the socket.
      * @return true if succeeded, false otherwise.
      */
-    virtual bool setOption(Socket& socket, SocketState state) const PURE;
+    virtual bool setOption(Socket& socket,
+                           envoy::api::v2::core::SocketOption::SocketState state) const PURE;
 
     /**
      * @param vector of bytes to which the option should append hash key data that will be used
@@ -74,7 +66,8 @@ public:
     return to;
   }
 
-  static bool applyOptions(const OptionsSharedPtr& options, Socket& socket, SocketState state) {
+  static bool applyOptions(const OptionsSharedPtr& options, Socket& socket,
+                           envoy::api::v2::core::SocketOption::SocketState state) {
     if (options == nullptr) {
       return true;
     }

--- a/source/common/network/addr_family_aware_socket_option_impl.cc
+++ b/source/common/network/addr_family_aware_socket_option_impl.cc
@@ -10,12 +10,14 @@
 namespace Envoy {
 namespace Network {
 
-bool AddrFamilyAwareSocketOptionImpl::setOption(Socket& socket, Socket::SocketState state) const {
+bool AddrFamilyAwareSocketOptionImpl::setOption(
+    Socket& socket, envoy::api::v2::core::SocketOption::SocketState state) const {
   return setIpSocketOption(socket, state, ipv4_option_, ipv6_option_);
 }
 
 bool AddrFamilyAwareSocketOptionImpl::setIpSocketOption(
-    Socket& socket, Socket::SocketState state, const std::unique_ptr<SocketOptionImpl>& ipv4_option,
+    Socket& socket, envoy::api::v2::core::SocketOption::SocketState state,
+    const std::unique_ptr<SocketOptionImpl>& ipv4_option,
     const std::unique_ptr<SocketOptionImpl>& ipv6_option) {
   // If this isn't IP, we're out of luck.
   Address::InstanceConstSharedPtr address;

--- a/source/common/network/addr_family_aware_socket_option_impl.h
+++ b/source/common/network/addr_family_aware_socket_option_impl.h
@@ -17,13 +17,15 @@ namespace Network {
 class AddrFamilyAwareSocketOptionImpl : public Socket::Option,
                                         Logger::Loggable<Logger::Id::connection> {
 public:
-  AddrFamilyAwareSocketOptionImpl(Socket::SocketState in_state, SocketOptionName ipv4_optname,
-                                  SocketOptionName ipv6_optname, int value)
+  AddrFamilyAwareSocketOptionImpl(envoy::api::v2::core::SocketOption::SocketState in_state,
+                                  SocketOptionName ipv4_optname, SocketOptionName ipv6_optname,
+                                  int value)
       : ipv4_option_(absl::make_unique<SocketOptionImpl>(in_state, ipv4_optname, value)),
         ipv6_option_(absl::make_unique<SocketOptionImpl>(in_state, ipv6_optname, value)) {}
 
   // Socket::Option
-  bool setOption(Socket& socket, Socket::SocketState state) const override;
+  bool setOption(Socket& socket,
+                 envoy::api::v2::core::SocketOption::SocketState state) const override;
   // The common socket options don't require a hash key.
   void hashKey(std::vector<uint8_t>&) const override {}
 
@@ -42,7 +44,8 @@ public:
    * platform for fd after the above option level fallback semantics are taken into account or the
    *         socket is non-IP.
    */
-  static bool setIpSocketOption(Socket& socket, Socket::SocketState state,
+  static bool setIpSocketOption(Socket& socket,
+                                envoy::api::v2::core::SocketOption::SocketState state,
                                 const std::unique_ptr<SocketOptionImpl>& ipv4_option,
                                 const std::unique_ptr<SocketOptionImpl>& ipv6_option);
 

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -535,7 +535,8 @@ ClientConnectionImpl::ClientConnectionImpl(
     const Network::ConnectionSocket::OptionsSharedPtr& options)
     : ConnectionImpl(dispatcher, std::make_unique<ClientSocketImpl>(remote_address),
                      std::move(transport_socket), false) {
-  if (!Network::Socket::applyOptions(options, *socket_, Socket::SocketState::PreBind)) {
+  if (!Network::Socket::applyOptions(options, *socket_,
+                                     envoy::api::v2::core::SocketOption::STATE_PREBIND)) {
     // Set a special error state to ensure asynchronous close to give the owner of the
     // ConnectionImpl a chance to add callbacks and detect the "disconnect".
     immediate_error_event_ = ConnectionEvent::LocalClose;

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -30,7 +30,8 @@ void ListenSocketImpl::doBind() {
 }
 
 void ListenSocketImpl::setListenSocketOptions(const Network::Socket::OptionsSharedPtr& options) {
-  if (!Network::Socket::applyOptions(options, *this, Socket::SocketState::PreBind)) {
+  if (!Network::Socket::applyOptions(options, *this,
+                                     envoy::api::v2::core::SocketOption::STATE_PREBIND)) {
     throw EnvoyException("ListenSocket: Setting socket options failed");
   }
 }

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -66,7 +66,8 @@ ListenerImpl::ListenerImpl(Event::DispatcherImpl& dispatcher, Socket& socket, Li
           fmt::format("cannot listen on socket: {}", socket.localAddress()->asString()));
     }
 
-    if (!Network::Socket::applyOptions(socket.options(), socket, Socket::SocketState::Listening)) {
+    if (!Network::Socket::applyOptions(socket.options(), socket,
+                                       envoy::api::v2::core::SocketOption::STATE_LISTENING)) {
       throw CreateListenerException(fmt::format(
           "cannot set post-listen socket option on socket: {}", socket.localAddress()->asString()));
     }

--- a/source/common/network/socket_option_factory.cc
+++ b/source/common/network/socket_option_factory.cc
@@ -10,21 +10,21 @@ std::unique_ptr<Socket::Options>
 SocketOptionFactory::buildTcpKeepaliveOptions(Network::TcpKeepaliveConfig keepalive_config) {
   std::unique_ptr<Socket::Options> options = absl::make_unique<Socket::Options>();
   options->push_back(std::make_shared<Network::SocketOptionImpl>(
-      Network::Socket::SocketState::PreBind, ENVOY_SOCKET_SO_KEEPALIVE, 1));
+      envoy::api::v2::core::SocketOption::STATE_PREBIND, ENVOY_SOCKET_SO_KEEPALIVE, 1));
 
   if (keepalive_config.keepalive_probes_.has_value()) {
     options->push_back(std::make_shared<Network::SocketOptionImpl>(
-        Network::Socket::SocketState::PreBind, ENVOY_SOCKET_TCP_KEEPCNT,
+        envoy::api::v2::core::SocketOption::STATE_PREBIND, ENVOY_SOCKET_TCP_KEEPCNT,
         keepalive_config.keepalive_probes_.value()));
   }
   if (keepalive_config.keepalive_interval_.has_value()) {
     options->push_back(std::make_shared<Network::SocketOptionImpl>(
-        Network::Socket::SocketState::PreBind, ENVOY_SOCKET_TCP_KEEPINTVL,
+        envoy::api::v2::core::SocketOption::STATE_PREBIND, ENVOY_SOCKET_TCP_KEEPINTVL,
         keepalive_config.keepalive_interval_.value()));
   }
   if (keepalive_config.keepalive_time_.has_value()) {
     options->push_back(std::make_shared<Network::SocketOptionImpl>(
-        Network::Socket::SocketState::PreBind, ENVOY_SOCKET_TCP_KEEPIDLE,
+        envoy::api::v2::core::SocketOption::STATE_PREBIND, ENVOY_SOCKET_TCP_KEEPIDLE,
         keepalive_config.keepalive_time_.value()));
   }
   return options;
@@ -33,18 +33,18 @@ SocketOptionFactory::buildTcpKeepaliveOptions(Network::TcpKeepaliveConfig keepal
 std::unique_ptr<Socket::Options> SocketOptionFactory::buildIpFreebindOptions() {
   std::unique_ptr<Socket::Options> options = absl::make_unique<Socket::Options>();
   options->push_back(std::make_shared<Network::AddrFamilyAwareSocketOptionImpl>(
-      Network::Socket::SocketState::PreBind, ENVOY_SOCKET_IP_FREEBIND, ENVOY_SOCKET_IPV6_FREEBIND,
-      1));
+      envoy::api::v2::core::SocketOption::STATE_PREBIND, ENVOY_SOCKET_IP_FREEBIND,
+      ENVOY_SOCKET_IPV6_FREEBIND, 1));
   return options;
 }
 
 std::unique_ptr<Socket::Options> SocketOptionFactory::buildIpTransparentOptions() {
   std::unique_ptr<Socket::Options> options = absl::make_unique<Socket::Options>();
   options->push_back(std::make_shared<Network::AddrFamilyAwareSocketOptionImpl>(
-      Network::Socket::SocketState::PreBind, ENVOY_SOCKET_IP_TRANSPARENT,
+      envoy::api::v2::core::SocketOption::STATE_PREBIND, ENVOY_SOCKET_IP_TRANSPARENT,
       ENVOY_SOCKET_IPV6_TRANSPARENT, 1));
   options->push_back(std::make_shared<Network::AddrFamilyAwareSocketOptionImpl>(
-      Network::Socket::SocketState::PostBind, ENVOY_SOCKET_IP_TRANSPARENT,
+      envoy::api::v2::core::SocketOption::STATE_BOUND, ENVOY_SOCKET_IP_TRANSPARENT,
       ENVOY_SOCKET_IPV6_TRANSPARENT, 1));
   return options;
 }
@@ -53,7 +53,8 @@ std::unique_ptr<Socket::Options>
 SocketOptionFactory::buildTcpFastOpenOptions(uint32_t queue_length) {
   std::unique_ptr<Socket::Options> options = absl::make_unique<Socket::Options>();
   options->push_back(std::make_shared<Network::SocketOptionImpl>(
-      Network::Socket::SocketState::Listening, ENVOY_SOCKET_TCP_FASTOPEN, queue_length));
+      envoy::api::v2::core::SocketOption::STATE_LISTENING, ENVOY_SOCKET_TCP_FASTOPEN,
+      queue_length));
   return options;
 }
 

--- a/source/common/network/socket_option_impl.cc
+++ b/source/common/network/socket_option_impl.cc
@@ -10,7 +10,8 @@ namespace Envoy {
 namespace Network {
 
 // Socket::Option
-bool SocketOptionImpl::setOption(Socket& socket, Socket::SocketState state) const {
+bool SocketOptionImpl::setOption(Socket& socket,
+                                 envoy::api::v2::core::SocketOption::SocketState state) const {
   if (in_state_ == state) {
     const int error = SocketOptionImpl::setSocketOption(socket, optname_, value_);
     if (error != 0) {

--- a/source/common/network/socket_option_impl.h
+++ b/source/common/network/socket_option_impl.h
@@ -84,11 +84,13 @@ typedef absl::optional<std::pair<int, int>> SocketOptionName;
 
 class SocketOptionImpl : public Socket::Option, Logger::Loggable<Logger::Id::connection> {
 public:
-  SocketOptionImpl(Socket::SocketState in_state, Network::SocketOptionName optname, int value)
+  SocketOptionImpl(envoy::api::v2::core::SocketOption::SocketState in_state,
+                   Network::SocketOptionName optname, int value)
       : in_state_(in_state), optname_(optname), value_(value) {}
 
   // Socket::Option
-  bool setOption(Socket& socket, Socket::SocketState state) const override;
+  bool setOption(Socket& socket,
+                 envoy::api::v2::core::SocketOption::SocketState state) const override;
 
   // The common socket options don't require a hash key.
   void hashKey(std::vector<uint8_t>&) const override {}
@@ -98,7 +100,7 @@ public:
   static int setSocketOption(Socket& socket, Network::SocketOptionName optname, int value);
 
 private:
-  const Socket::SocketState in_state_;
+  const envoy::api::v2::core::SocketOption::SocketState in_state_;
   const Network::SocketOptionName optname_;
   const int value_;
 };

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -438,7 +438,7 @@ void ListenerImpl::setSocket(const Network::SocketSharedPtr& socket) {
   if (socket_ && listen_socket_options_) {
     // 'pre_bind = false' as bind() is never done after this.
     bool ok = Network::Socket::applyOptions(listen_socket_options_, *socket_,
-                                            Network::Socket::SocketState::PostBind);
+                                            envoy::api::v2::core::SocketOption::STATE_BOUND);
     const std::string message =
         fmt::format("{}: Setting socket options {}", name_, ok ? "succeeded" : "failed");
     if (!ok) {
@@ -448,7 +448,7 @@ void ListenerImpl::setSocket(const Network::SocketSharedPtr& socket) {
       ENVOY_LOG(debug, "{}", message);
     }
 
-    // Add the options to the socket_ so that SocketState::Listening options can be
+    // Add the options to the socket_ so that STATE_LISTENING options can be
     // set in the worker after listen()/evconnlistener_new() is called.
     socket_->addOptions(listen_socket_options_);
   }

--- a/test/common/network/addr_family_aware_socket_option_impl_test.cc
+++ b/test/common/network/addr_family_aware_socket_option_impl_test.cc
@@ -11,11 +11,13 @@ class AddrFamilyAwareSocketOptionImplTest : public SocketOptionTest {};
 // We fail to set the option when the underlying setsockopt syscall fails.
 TEST_F(AddrFamilyAwareSocketOptionImplTest, SetOptionFailure) {
   EXPECT_CALL(socket_, fd()).WillOnce(Return(-1));
-  AddrFamilyAwareSocketOptionImpl socket_option{
-      Socket::SocketState::PreBind, Network::SocketOptionName(std::make_pair(5, 10)), {}, 1};
-  EXPECT_LOG_CONTAINS(
-      "warning", "Failed to set IP socket option on non-IP socket",
-      EXPECT_FALSE(socket_option.setOption(socket_, Socket::SocketState::PreBind)););
+  AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
+                                                Network::SocketOptionName(std::make_pair(5, 10)),
+                                                {},
+                                                1};
+  EXPECT_LOG_CONTAINS("warning", "Failed to set IP socket option on non-IP socket",
+                      EXPECT_FALSE(socket_option.setOption(
+                          socket_, envoy::api::v2::core::SocketOption::STATE_PREBIND)));
 }
 
 // If a platform supports IPv4 socket option variant for an IPv4 address, it works
@@ -24,10 +26,12 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, SetOptionSuccess) {
   const int fd = address.socket(Address::SocketType::Stream);
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
 
-  AddrFamilyAwareSocketOptionImpl socket_option{
-      Socket::SocketState::PreBind, Network::SocketOptionName(std::make_pair(5, 10)), {}, 1};
+  AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
+                                                Network::SocketOptionName(std::make_pair(5, 10)),
+                                                {},
+                                                1};
   testSetSocketOptionSuccess(socket_option, Network::SocketOptionName(std::make_pair(5, 10)), 1,
-                             {Socket::SocketState::PreBind});
+                             {envoy::api::v2::core::SocketOption::STATE_PREBIND});
 }
 
 // If a platform doesn't support IPv4 socket option variant for an IPv4 address we fail
@@ -35,10 +39,12 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V4EmptyOptionNames) {
   Address::Ipv4Instance address("1.2.3.4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
-  AddrFamilyAwareSocketOptionImpl socket_option{Socket::SocketState::PreBind, {}, {}, 1};
+  AddrFamilyAwareSocketOptionImpl socket_option{
+      envoy::api::v2::core::SocketOption::STATE_PREBIND, {}, {}, 1};
 
   EXPECT_LOG_CONTAINS("warning", "Setting option on socket failed: Operation not supported",
-                      EXPECT_FALSE(socket_option.setOption(socket_, Socket::SocketState::PreBind)));
+                      EXPECT_FALSE(socket_option.setOption(
+                          socket_, envoy::api::v2::core::SocketOption::STATE_PREBIND)));
 }
 
 // If a platform doesn't support IPv4 and IPv6 socket option variants for an IPv4 address, we fail
@@ -46,10 +52,12 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V6EmptyOptionNames) {
   Address::Ipv6Instance address("::1:2:3:4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
-  AddrFamilyAwareSocketOptionImpl socket_option{Socket::SocketState::PreBind, {}, {}, 1};
+  AddrFamilyAwareSocketOptionImpl socket_option{
+      envoy::api::v2::core::SocketOption::STATE_PREBIND, {}, {}, 1};
 
   EXPECT_LOG_CONTAINS("warning", "Setting option on socket failed: Operation not supported",
-                      EXPECT_FALSE(socket_option.setOption(socket_, Socket::SocketState::PreBind)));
+                      EXPECT_FALSE(socket_option.setOption(
+                          socket_, envoy::api::v2::core::SocketOption::STATE_PREBIND)));
 }
 
 // If a platform suppports IPv4 and IPv6 socket option variants for an IPv4 address, we apply the
@@ -59,11 +67,12 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V4IgnoreV6) {
   const int fd = address.socket(Address::SocketType::Stream);
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
 
-  AddrFamilyAwareSocketOptionImpl socket_option{
-      Socket::SocketState::PreBind, Network::SocketOptionName(std::make_pair(5, 10)),
-      Network::SocketOptionName(std::make_pair(6, 11)), 1};
+  AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
+                                                Network::SocketOptionName(std::make_pair(5, 10)),
+                                                Network::SocketOptionName(std::make_pair(6, 11)),
+                                                1};
   testSetSocketOptionSuccess(socket_option, Network::SocketOptionName(std::make_pair(5, 10)), 1,
-                             {Socket::SocketState::PreBind});
+                             {envoy::api::v2::core::SocketOption::STATE_PREBIND});
 }
 
 // If a platform suppports IPv6 socket option variant for an IPv6 address it works
@@ -72,10 +81,12 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V6Only) {
   const int fd = address.socket(Address::SocketType::Stream);
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
 
-  AddrFamilyAwareSocketOptionImpl socket_option{
-      Socket::SocketState::PreBind, {}, Network::SocketOptionName(std::make_pair(6, 11)), 1};
+  AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
+                                                {},
+                                                Network::SocketOptionName(std::make_pair(6, 11)),
+                                                1};
   testSetSocketOptionSuccess(socket_option, Network::SocketOptionName(std::make_pair(6, 11)), 1,
-                             {Socket::SocketState::PreBind});
+                             {envoy::api::v2::core::SocketOption::STATE_PREBIND});
 }
 
 // If a platform suppports only the IPv4 variant for an IPv6 address,
@@ -85,10 +96,12 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V6OnlyV4Fallback) {
   const int fd = address.socket(Address::SocketType::Stream);
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
 
-  AddrFamilyAwareSocketOptionImpl socket_option{
-      Socket::SocketState::PreBind, Network::SocketOptionName(std::make_pair(5, 10)), {}, 1};
+  AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
+                                                Network::SocketOptionName(std::make_pair(5, 10)),
+                                                {},
+                                                1};
   testSetSocketOptionSuccess(socket_option, Network::SocketOptionName(std::make_pair(5, 10)), 1,
-                             {Socket::SocketState::PreBind});
+                             {envoy::api::v2::core::SocketOption::STATE_PREBIND});
 }
 
 // If a platform suppports IPv4 and IPv6 socket option variants for an IPv6 address,
@@ -98,11 +111,12 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V6Precedence) {
   const int fd = address.socket(Address::SocketType::Stream);
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
 
-  AddrFamilyAwareSocketOptionImpl socket_option{
-      Socket::SocketState::PreBind, Network::SocketOptionName(std::make_pair(5, 10)),
-      Network::SocketOptionName(std::make_pair(6, 11)), 1};
+  AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
+                                                Network::SocketOptionName(std::make_pair(5, 10)),
+                                                Network::SocketOptionName(std::make_pair(6, 11)),
+                                                1};
   testSetSocketOptionSuccess(socket_option, Network::SocketOptionName(std::make_pair(6, 11)), 1,
-                             {Socket::SocketState::PreBind});
+                             {envoy::api::v2::core::SocketOption::STATE_PREBIND});
 }
 
 } // namespace

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -272,7 +272,8 @@ TEST_P(ConnectionImplTest, SocketOptions) {
 
   auto option = std::make_shared<MockSocketOption>();
 
-  EXPECT_CALL(*option, setOption(_, Network::Socket::SocketState::PreBind)).WillOnce(Return(true));
+  EXPECT_CALL(*option, setOption(_, envoy::api::v2::core::SocketOption::STATE_PREBIND))
+      .WillOnce(Return(true));
   EXPECT_CALL(listener_callbacks_, onAccept_(_, _))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& socket, bool) -> void {
         socket->addOption(option);
@@ -320,7 +321,8 @@ TEST_P(ConnectionImplTest, SocketOptionsFailureTest) {
 
   auto option = std::make_shared<MockSocketOption>();
 
-  EXPECT_CALL(*option, setOption(_, Network::Socket::SocketState::PreBind)).WillOnce(Return(false));
+  EXPECT_CALL(*option, setOption(_, envoy::api::v2::core::SocketOption::STATE_PREBIND))
+      .WillOnce(Return(false));
   EXPECT_CALL(listener_callbacks_, onAccept_(_, _))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& socket, bool) -> void {
         socket->addOption(option);

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -46,7 +46,8 @@ TEST_P(ListenSocketImplTest, BindSpecificPort) {
 
   auto option = std::make_unique<MockSocketOption>();
   auto options = std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>();
-  EXPECT_CALL(*option, setOption(_, Network::Socket::SocketState::PreBind)).WillOnce(Return(true));
+  EXPECT_CALL(*option, setOption(_, envoy::api::v2::core::SocketOption::STATE_PREBIND))
+      .WillOnce(Return(true));
   options->emplace_back(std::move(option));
   TcpListenSocket socket1(addr, options, true);
   EXPECT_EQ(0, listen(socket1.fd(), 0));
@@ -55,7 +56,8 @@ TEST_P(ListenSocketImplTest, BindSpecificPort) {
 
   auto option2 = std::make_unique<MockSocketOption>();
   auto options2 = std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>();
-  EXPECT_CALL(*option2, setOption(_, Network::Socket::SocketState::PreBind)).WillOnce(Return(true));
+  EXPECT_CALL(*option2, setOption(_, envoy::api::v2::core::SocketOption::STATE_PREBIND))
+      .WillOnce(Return(true));
   options2->emplace_back(std::move(option2));
   // The address and port are bound already, should throw exception.
   EXPECT_THROW(Network::TcpListenSocket socket2(addr, options2, true), EnvoyException);

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -96,7 +96,8 @@ TEST_P(ListenerImplTest, SetListeningSocketOptionsSuccess) {
                                   true);
   std::shared_ptr<MockSocketOption> option = std::make_shared<MockSocketOption>();
   socket.addOption(option);
-  EXPECT_CALL(*option, setOption(_, Socket::SocketState::Listening)).WillOnce(Return(true));
+  EXPECT_CALL(*option, setOption(_, envoy::api::v2::core::SocketOption::STATE_LISTENING))
+      .WillOnce(Return(true));
   TestListenerImpl listener(dispatcher, socket, listener_callbacks, true, false);
 }
 
@@ -110,7 +111,8 @@ TEST_P(ListenerImplTest, SetListeningSocketOptionsError) {
                                   true);
   std::shared_ptr<MockSocketOption> option = std::make_shared<MockSocketOption>();
   socket.addOption(option);
-  EXPECT_CALL(*option, setOption(_, Socket::SocketState::Listening)).WillOnce(Return(false));
+  EXPECT_CALL(*option, setOption(_, envoy::api::v2::core::SocketOption::STATE_LISTENING))
+      .WillOnce(Return(false));
   EXPECT_THROW_WITH_MESSAGE(TestListenerImpl(dispatcher, socket, listener_callbacks, true, false),
                             CreateListenerException,
                             fmt::format("cannot set post-listen socket option on socket: {}",
@@ -199,7 +201,8 @@ TEST_P(ListenerImplTest, WildcardListenerIpv4Compat) {
   Event::DispatcherImpl dispatcher;
   auto option = std::make_unique<MockSocketOption>();
   auto options = std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>();
-  EXPECT_CALL(*option, setOption(_, Network::Socket::SocketState::PreBind)).WillOnce(Return(true));
+  EXPECT_CALL(*option, setOption(_, envoy::api::v2::core::SocketOption::STATE_PREBIND))
+      .WillOnce(Return(true));
   options->emplace_back(std::move(option));
 
   Network::TcpListenSocket socket(Network::Test::getAnyAddress(version_, true), options, true);

--- a/test/common/network/socket_option_impl_test.cc
+++ b/test/common/network/socket_option_impl_test.cc
@@ -12,14 +12,14 @@ TEST_F(SocketOptionImplTest, BadFd) {
 }
 
 TEST_F(SocketOptionImplTest, SetOptionSuccessTrue) {
-  SocketOptionImpl socket_option{Socket::SocketState::PreBind,
+  SocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
                                  Network::SocketOptionName(std::make_pair(5, 10)), 1};
   EXPECT_CALL(os_sys_calls_, setsockopt_(_, 5, 10, _, sizeof(int)))
       .WillOnce(Invoke([](int, int, int, const void* optval, socklen_t) -> int {
         EXPECT_EQ(1, *static_cast<const int*>(optval));
         return 0;
       }));
-  EXPECT_TRUE(socket_option.setOption(socket_, Socket::SocketState::PreBind));
+  EXPECT_TRUE(socket_option.setOption(socket_, envoy::api::v2::core::SocketOption::STATE_PREBIND));
 }
 
 } // namespace

--- a/test/common/network/socket_option_test.h
+++ b/test/common/network/socket_option_test.h
@@ -25,10 +25,10 @@ public:
   Api::MockOsSysCalls os_sys_calls_;
   TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls{&os_sys_calls_};
 
-  void testSetSocketOptionSuccess(Socket::Option& socket_option,
-                                  Network::SocketOptionName option_name, int option_val,
-                                  const std::set<Socket::SocketState>& when) {
-    for (Socket::SocketState state : when) {
+  void testSetSocketOptionSuccess(
+      Socket::Option& socket_option, Network::SocketOptionName option_name, int option_val,
+      const std::set<envoy::api::v2::core::SocketOption::SocketState>& when) {
+    for (auto state : when) {
       if (option_name.has_value()) {
         EXPECT_CALL(os_sys_calls_, setsockopt_(_, option_name.value().first,
                                                option_name.value().second, _, sizeof(int)))
@@ -42,16 +42,18 @@ public:
       }
     }
 
-    // The set of SocketState for which this option should not be set. Initialize to all
-    // the states, and remove states that are passed in.
-    std::list<Socket::SocketState> unset_socketstates{
-        Socket::SocketState::PreBind,
-        Socket::SocketState::PostBind,
-        Socket::SocketState::Listening,
+    // The set of SocketOption::SocketState for which this option should not be set.
+    // Initialize to all the states, and remove states that are passed in.
+    std::list<envoy::api::v2::core::SocketOption::SocketState> unset_socketstates{
+        envoy::api::v2::core::SocketOption::STATE_PREBIND,
+        envoy::api::v2::core::SocketOption::STATE_BOUND,
+        envoy::api::v2::core::SocketOption::STATE_LISTENING,
     };
     unset_socketstates.remove_if(
-        [&](Socket::SocketState state) -> bool { return when.find(state) != when.end(); });
-    for (Socket::SocketState state : unset_socketstates) {
+        [&](envoy::api::v2::core::SocketOption::SocketState state) -> bool {
+          return when.find(state) != when.end();
+        });
+    for (auto state : unset_socketstates) {
       EXPECT_CALL(os_sys_calls_, setsockopt_(_, _, _, _, _)).Times(0);
       EXPECT_TRUE(socket_option.setOption(socket_, state));
     }

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1573,18 +1573,18 @@ public:
   void expectSetsockoptFreebind() {
     if (!ENVOY_SOCKET_IP_FREEBIND.has_value()) {
       EXPECT_CALL(factory_.tls_.dispatcher_, createClientConnection_(_, _, _, _))
-          .WillOnce(Invoke([this](Network::Address::InstanceConstSharedPtr,
-                                  Network::Address::InstanceConstSharedPtr,
-                                  Network::TransportSocketPtr&,
-                                  const Network::ConnectionSocket::OptionsSharedPtr& options)
-                               -> Network::ClientConnection* {
-            EXPECT_NE(nullptr, options.get());
-            EXPECT_EQ(1, options->size());
-            NiceMock<Network::MockConnectionSocket> socket;
-            EXPECT_FALSE((Network::Socket::applyOptions(
-                options, socket, envoy::api::v2::core::SocketOption::STATE_PREBIND)));
-            return connection_;
-          }));
+          .WillOnce(
+              Invoke([this](Network::Address::InstanceConstSharedPtr,
+                            Network::Address::InstanceConstSharedPtr, Network::TransportSocketPtr&,
+                            const Network::ConnectionSocket::OptionsSharedPtr& options)
+                         -> Network::ClientConnection* {
+                EXPECT_NE(nullptr, options.get());
+                EXPECT_EQ(1, options->size());
+                NiceMock<Network::MockConnectionSocket> socket;
+                EXPECT_FALSE((Network::Socket::applyOptions(
+                    options, socket, envoy::api::v2::core::SocketOption::STATE_PREBIND)));
+                return connection_;
+              }));
       cluster_manager_->tcpConnForCluster("FreebindCluster", nullptr);
       return;
     }
@@ -1724,18 +1724,18 @@ public:
                                    absl::optional<int> keepalive_interval) {
     if (!ENVOY_SOCKET_SO_KEEPALIVE.has_value()) {
       EXPECT_CALL(factory_.tls_.dispatcher_, createClientConnection_(_, _, _, _))
-          .WillOnce(Invoke([this](Network::Address::InstanceConstSharedPtr,
-                                  Network::Address::InstanceConstSharedPtr,
-                                  Network::TransportSocketPtr&,
-                                  const Network::ConnectionSocket::OptionsSharedPtr& options)
-                               -> Network::ClientConnection* {
-            EXPECT_NE(nullptr, options.get());
-            EXPECT_EQ(1, options->size());
-            NiceMock<Network::MockConnectionSocket> socket;
-            EXPECT_FALSE((Network::Socket::applyOptions(
-                options, socket, envoy::api::v2::core::SocketOption::STATE_PREBIND)));
-            return connection_;
-          }));
+          .WillOnce(
+              Invoke([this](Network::Address::InstanceConstSharedPtr,
+                            Network::Address::InstanceConstSharedPtr, Network::TransportSocketPtr&,
+                            const Network::ConnectionSocket::OptionsSharedPtr& options)
+                         -> Network::ClientConnection* {
+                EXPECT_NE(nullptr, options.get());
+                EXPECT_EQ(1, options->size());
+                NiceMock<Network::MockConnectionSocket> socket;
+                EXPECT_FALSE((Network::Socket::applyOptions(
+                    options, socket, envoy::api::v2::core::SocketOption::STATE_PREBIND)));
+                return connection_;
+              }));
       cluster_manager_->tcpConnForCluster("TcpKeepaliveCluster", nullptr);
       return;
     }

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1581,8 +1581,8 @@ public:
             EXPECT_NE(nullptr, options.get());
             EXPECT_EQ(1, options->size());
             NiceMock<Network::MockConnectionSocket> socket;
-            EXPECT_FALSE((Network::Socket::applyOptions(options, socket,
-                                                        Network::Socket::SocketState::PreBind)));
+            EXPECT_FALSE((Network::Socket::applyOptions(
+                options, socket, envoy::api::v2::core::SocketOption::STATE_PREBIND)));
             return connection_;
           }));
       cluster_manager_->tcpConnForCluster("FreebindCluster", nullptr);
@@ -1599,8 +1599,8 @@ public:
               EXPECT_NE(nullptr, options.get());
               EXPECT_EQ(1, options->size());
               NiceMock<Network::MockConnectionSocket> socket;
-              EXPECT_TRUE((Network::Socket::applyOptions(options, socket,
-                                                         Network::Socket::SocketState::PreBind)));
+              EXPECT_TRUE((Network::Socket::applyOptions(
+                  options, socket, envoy::api::v2::core::SocketOption::STATE_PREBIND)));
               return connection_;
             }));
     EXPECT_CALL(os_sys_calls, setsockopt_(_, ENVOY_SOCKET_IP_FREEBIND.value().first,
@@ -1732,8 +1732,8 @@ public:
             EXPECT_NE(nullptr, options.get());
             EXPECT_EQ(1, options->size());
             NiceMock<Network::MockConnectionSocket> socket;
-            EXPECT_FALSE((Network::Socket::applyOptions(options, socket,
-                                                        Network::Socket::SocketState::PreBind)));
+            EXPECT_FALSE((Network::Socket::applyOptions(
+                options, socket, envoy::api::v2::core::SocketOption::STATE_PREBIND)));
             return connection_;
           }));
       cluster_manager_->tcpConnForCluster("TcpKeepaliveCluster", nullptr);
@@ -1749,8 +1749,8 @@ public:
                        -> Network::ClientConnection* {
               EXPECT_NE(nullptr, options.get());
               NiceMock<Network::MockConnectionSocket> socket;
-              EXPECT_TRUE((Network::Socket::applyOptions(options, socket,
-                                                         Network::Socket::SocketState::PreBind)));
+              EXPECT_TRUE((Network::Socket::applyOptions(
+                  options, socket, envoy::api::v2::core::SocketOption::STATE_PREBIND)));
               return connection_;
             }));
     EXPECT_CALL(os_sys_calls, setsockopt_(_, ENVOY_SOCKET_SO_KEEPALIVE.value().first,

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -311,7 +311,8 @@ public:
   MockSocketOption();
   ~MockSocketOption();
 
-  MOCK_CONST_METHOD2(setOption, bool(Socket&, Network::Socket::SocketState state));
+  MOCK_CONST_METHOD2(setOption,
+                     bool(Socket&, envoy::api::v2::core::SocketOption::SocketState state));
   MOCK_CONST_METHOD1(hashKey, void(std::vector<uint8_t>&));
 };
 

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -75,7 +75,7 @@ MockListenerComponentFactory::MockListenerComponentFactory()
                                 const Network::Socket::OptionsSharedPtr& options,
                                 bool) -> Network::SocketSharedPtr {
         if (!Network::Socket::applyOptions(options, *socket_,
-                                           Network::Socket::SocketState::PreBind)) {
+                                           envoy::api::v2::core::SocketOption::STATE_PREBIND)) {
           throw EnvoyException("MockListenerComponentFactory: Setting socket options failed");
         }
         return socket_;


### PR DESCRIPTION
It may be desirable to specify socket options that are not supported
in upstream kernels or Envoy.

*Description*: Looking for feedback on the interface and idea in general

@hennna @htuch @ggreenway @mattklein123 