### PR TITLE
http/2: use hpack_table_size to control both encoder and decoder.

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -37,7 +37,6 @@ bool Utility::reconstituteCrumbledCookies(const HeaderString& key, const HeaderS
 }
 
 ConnectionImpl::Http2Callbacks ConnectionImpl::http2_callbacks_;
-ConnectionImpl::Http2Options ConnectionImpl::http2_options_;
 
 /**
  * Helper to remove const during a cast. nghttp2 takes non-const pointers for headers even though
@@ -723,7 +722,7 @@ ConnectionImpl::Http2Callbacks::Http2Callbacks() {
 
 ConnectionImpl::Http2Callbacks::~Http2Callbacks() { nghttp2_session_callbacks_del(callbacks_); }
 
-ConnectionImpl::Http2Options::Http2Options() {
+ConnectionImpl::Http2Options::Http2Options(const Http2Settings& http2_settings) {
   nghttp2_option_new(&options_);
   // Currently we do not do anything with stream priority. Setting the following option prevents
   // nghttp2 from keeping around closed streams for use during stream priority dependency graph
@@ -731,6 +730,10 @@ ConnectionImpl::Http2Options::Http2Options() {
   // of kept alive HTTP/2 connections.
   nghttp2_option_set_no_closed_streams(options_, 1);
   nghttp2_option_set_no_auto_window_update(options_, 1);
+
+  if (http2_settings.hpack_table_size_ != NGHTTP2_DEFAULT_HEADER_TABLE_SIZE) {
+    nghttp2_option_set_max_deflate_dynamic_table_size(options_, http2_settings.hpack_table_size_);
+  }
 }
 
 ConnectionImpl::Http2Options::~Http2Options() { nghttp2_option_del(options_); }
@@ -739,8 +742,9 @@ ClientConnectionImpl::ClientConnectionImpl(Network::Connection& connection,
                                            Http::ConnectionCallbacks& callbacks,
                                            Stats::Scope& stats, const Http2Settings& http2_settings)
     : ConnectionImpl(connection, stats, http2_settings), callbacks_(callbacks) {
+  Http2Options http2_options(http2_settings);
   nghttp2_session_client_new2(&session_, http2_callbacks_.callbacks(), base(),
-                              http2_options_.options());
+                              http2_options.options());
   sendSettings(http2_settings, true);
 }
 
@@ -783,8 +787,9 @@ ServerConnectionImpl::ServerConnectionImpl(Network::Connection& connection,
                                            Http::ServerConnectionCallbacks& callbacks,
                                            Stats::Scope& scope, const Http2Settings& http2_settings)
     : ConnectionImpl(connection, scope, http2_settings), callbacks_(callbacks) {
+  Http2Options http2_options(http2_settings);
   nghttp2_session_server_new2(&session_, http2_callbacks_.callbacks(), base(),
-                              http2_options_.options());
+                              http2_options.options());
   sendSettings(http2_settings, false);
 }
 

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -118,7 +118,7 @@ protected:
    */
   class Http2Options {
   public:
-    Http2Options();
+    Http2Options(const Http2Settings& http2_settings);
     ~Http2Options();
 
     const nghttp2_option* options() { return options_; }

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -753,6 +753,34 @@ TEST_P(Http2CodecImplTest, TestCodecHeaderLimits) {
   request_encoder_->encodeHeaders(request_headers, false);
 }
 
+TEST_P(Http2CodecImplTest, TestCodecHeaderCompression) {
+  initialize();
+
+  TestHeaderMapImpl request_headers;
+  HttpTestUtility::addDefaultHeaders(request_headers);
+  EXPECT_CALL(request_decoder_, decodeHeaders_(_, true));
+  request_encoder_->encodeHeaders(request_headers, true);
+
+  TestHeaderMapImpl response_headers{{":status", "200"}, {"compression", "test"}};
+  EXPECT_CALL(response_decoder_, decodeHeaders_(_, true));
+  response_encoder_->encodeHeaders(response_headers, true);
+
+  // Sanity check to verify that state of encoders and decoders matches.
+  EXPECT_EQ(nghttp2_session_get_hd_deflate_dynamic_table_size(server_.session()),
+            nghttp2_session_get_hd_inflate_dynamic_table_size(client_.session()));
+  EXPECT_EQ(nghttp2_session_get_hd_deflate_dynamic_table_size(client_.session()),
+            nghttp2_session_get_hd_inflate_dynamic_table_size(server_.session()));
+
+  // Verify that headers are compressed only when both client and server advertise table size > 0:
+  if (client_http2settings_.hpack_table_size_ && server_http2settings_.hpack_table_size_) {
+    EXPECT_NE(0, nghttp2_session_get_hd_deflate_dynamic_table_size(client_.session()));
+    EXPECT_NE(0, nghttp2_session_get_hd_deflate_dynamic_table_size(server_.session()));
+  } else {
+    EXPECT_EQ(0, nghttp2_session_get_hd_deflate_dynamic_table_size(client_.session()));
+    EXPECT_EQ(0, nghttp2_session_get_hd_deflate_dynamic_table_size(server_.session()));
+  }
+}
+
 } // namespace Http2
 } // namespace Http
 } // namespace Envoy


### PR DESCRIPTION
Previously, hpack_table_size was used to configure maximum table size used by
the local endpoint for HPACK decoding, however, there was no way to configure
table size used for HPACK enoding.

Since this option is mostly used to disable header compression by setting the
size to 0, it means that Envoy only asked the remote endpoint not to compress
headers, but it was still compressing them itself (unless asked not to by the
remote endpoint).

Re-using hpack_table_size instead of adding a new option, since both: encoder
and decoder will usually use the same value anyway.

*Level*: Medium (some broken libraries don't support header table updates)
*Testing*: bazel test //test/...
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Piotr Sikora <piotrsikora@google.com>