### PR TITLE
docs: fix a small mistyped in StringUtil::caseCompare example

### DIFF
--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -255,7 +255,9 @@ public:
    *
    * E.g.,
    *
-   * findToken("hello; world", ";", "HELLO")   . true
+   * caseCompare("hello", "hello")   . true
+   * caseCompare("hello", "HELLO")   . true
+   * caseCompare("hello", "HellO")   . true
    */
   static bool caseCompare(absl::string_view lhs, absl::string_view rhs);
 


### PR DESCRIPTION
*title*: docs: fix small typo of the StringUtil::caseCompare example

*Description*: Fix a small mistyped in `StringUtil::caseCompare` example.
*Docs Changes*: N/A
*Release Notes*: N/A

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>