### PR TITLE
grpc-json transcoder: allow to use /<package>.<Service>/<Method> without breaking gRPC calls

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -143,7 +143,7 @@ ProtobufUtil::Status JsonTranscoderConfig::createTranscoder(
     std::unique_ptr<Transcoder>& transcoder, const Protobuf::MethodDescriptor*& method_descriptor) {
   if (Grpc::Common::hasGrpcContentType(headers)) {
     return ProtobufUtil::Status(Code::INVALID_ARGUMENT,
-                                "This request headers has application/grpc content-type");
+                                "Request headers has application/grpc content-type");
   }
   const ProtobufTypes::String method = headers.Method()->value().c_str();
   ProtobufTypes::String path = headers.Path()->value().c_str();

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -143,6 +143,8 @@ ProtobufUtil::Status JsonTranscoderConfig::createTranscoder(
     std::unique_ptr<Transcoder>& transcoder, const Protobuf::MethodDescriptor*& method_descriptor) {
   const ProtobufTypes::String method = headers.Method()->value().c_str();
   ProtobufTypes::String path = headers.Path()->value().c_str();
+  absl::string_view content_type =
+      headers.ContentType() == nullptr ? "" : headers.ContentType()->value().c_str();
   ProtobufTypes::String args;
 
   const size_t pos = path.find('?');
@@ -155,7 +157,8 @@ ProtobufUtil::Status JsonTranscoderConfig::createTranscoder(
   std::vector<VariableBinding> variable_bindings;
   method_descriptor =
       path_matcher_->Lookup(method, path, args, &variable_bindings, &request_info.body_field_path);
-  if (!method_descriptor) {
+  if (!method_descriptor ||
+      StringUtil::caseCompare(content_type, Http::Headers::get().ContentTypeValues.Grpc)) {
     return ProtobufUtil::Status(Code::NOT_FOUND, "Could not resolve " + path + " to a method");
   }
 

--- a/test/proto/bookstore.proto
+++ b/test/proto/bookstore.proto
@@ -187,9 +187,3 @@ message GetAuthorRequest {
   // The ID of the author resource to retrieve.
   int64 author = 1;
 }
-
-// Request message for CreateAuthor method.
-message CreateAuthorRequest {
-  // The ID of the author resource to retrieve.
-  int64 author = 1;
-}

--- a/test/proto/bookstore.proto
+++ b/test/proto/bookstore.proto
@@ -22,6 +22,13 @@ service Bookstore {
       body: "shelf"
     };
   }
+  // Creates a new shelf in the bookstore via a mapped package.service.method as its HTTP path.
+  rpc CreateShelfWithPackageServiceAndMethod(CreateShelfRequest) returns (Shelf) {
+    option (google.api.http) = {
+      post: "/bookstore.Bookstore/CreateShelfWithPackageServiceAndMethod"
+      body: "shelf"
+    };
+  }
   // Creates multiple shelves with one streaming call
   rpc BulkCreateShelf(stream CreateShelfRequest) returns (stream Shelf) {
     option (google.api.http) = {
@@ -177,6 +184,12 @@ message DeleteBookRequest {
 
 // Request message for GetAuthor method.
 message GetAuthorRequest {
+  // The ID of the author resource to retrieve.
+  int64 author = 1;
+}
+
+// Request message for CreateAuthor method.
+message CreateAuthorRequest {
   // The ID of the author resource to retrieve.
   int64 author = 1;
 }


### PR DESCRIPTION
grpc-json transcoder: allow to use `/<package>.<Service>/<Method>` without breaking gRPC calls

*Description*:
This patch enables grpc-json transcoder to use `/<package>.<Service>/<Method>` as `path` in
annotated (`option (google.api.http)`) method/rpc, without breaking gRPC calls as
observed in #3637.

This patch deals with the third case in this [response summary](https://github.com/chuhlomin/envoy-json-trancoding-grpc#envoy-responses-summary).

NOTE: this is not an attempt for supporting default HTTP binding (#3631).

*Risk Level*: Low
*Testing*: Unit and manual testing. The manual testing is as described in #3637 (https://github.com/chuhlomin/envoy-json-trancoding-grpc/blob/master/README.md).

*Docs Changes*: N/A
*Release Notes*: N/A

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>