### PR TITLE
protobuf: avoid camel/snake conversion during Struct conversion.

### DIFF
--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -105,7 +105,8 @@ std::string MessageUtil::getJsonStringFromMessage(const Protobuf::Message& messa
 
 void MessageUtil::jsonConvert(const Protobuf::Message& source, Protobuf::Message& dest) {
   // TODO(htuch): Consolidate with the inflight cleanups here.
-  Protobuf::util::JsonOptions json_options;
+  Protobuf::util::JsonPrintOptions json_options;
+  json_options.preserve_proto_field_names = true;
   ProtobufTypes::String json;
   const auto status = Protobuf::util::MessageToJsonString(source, &json, json_options);
   if (!status.ok()) {


### PR DESCRIPTION
This came up while investigating #3665. It's not the root cause (you can round-trip with the
camel/snake conversion), but it's unnnecessary overhead to perform this conversion and the resulting
proto JSON representations (e.g. when appearing in /config_dump) are uglified by the conversion.

Risk Level: Low
Testing: Unit test added.

Signed-off-by: Harvey Tuch <htuch@google.com>