### PR TITLE
network: adding error handling for calling readDisable on a closed connection

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -224,7 +224,7 @@ void ConnectionImpl::enableHalfClose(bool enabled) {
 
 void ConnectionImpl::readDisable(bool disable) {
   ASSERT(state() == State::Open);
-  if (file_event_ == nullptr) {
+  if (state() != State::Open || file_event_ == nullptr) {
     // If readDisable is called on a closed connection in error, do not crash.
     return;
   }

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -224,6 +224,11 @@ void ConnectionImpl::enableHalfClose(bool enabled) {
 
 void ConnectionImpl::readDisable(bool disable) {
   ASSERT(state() == State::Open);
+  if (file_event_ == nullptr) {
+    // If readDisable is called on a closed connection in error, do not crash.
+    return;
+  }
+
   ENVOY_CONN_LOG(trace, "readDisable: enabled={} disable={}", *this, read_enabled_, disable);
 
   // When we disable reads, we still allow for early close notifications (the equivalent of

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -487,6 +487,7 @@ void Filter::onUpstreamEvent(Network::ConnectionEvent event) {
 }
 
 void Filter::onIdleTimeout() {
+  ENVOY_CONN_LOG(debug, "Session timed out", read_callbacks_->connection());
   config_->stats().idle_timeout_.inc();
 
   // This results in also closing the upstream connection.

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -447,6 +447,17 @@ TEST_P(ConnectionImplTest, ReadDisable) {
   disconnect(false);
 }
 
+// Regression test for (at least one failure mode of)
+// https://github.com/envoyproxy/envoy/issues/3639 where readDisable on a close
+// connection caused a crash.
+TEST_P(ConnectionImplTest, ReadDisableAfterClose) {
+  setUpBasicConnection();
+  disconnect(false);
+
+  EXPECT_DEBUG_DEATH(client_connection_->readDisable(true), "");
+  EXPECT_DEBUG_DEATH(client_connection_->readDisable(false), "");
+}
+
 TEST_P(ConnectionImplTest, EarlyCloseOnReadDisabledConnection) {
 #ifdef __APPLE__
   // On our current OSX build, the client connection does not get the early

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -162,9 +162,15 @@ void IntegrationTcpClient::waitForData(const std::string& data) {
   connection_->dispatcher().run(Event::Dispatcher::RunType::Block);
 }
 
-void IntegrationTcpClient::waitForDisconnect() {
-  connection_->dispatcher().run(Event::Dispatcher::RunType::Block);
-  EXPECT_TRUE(disconnected_);
+void IntegrationTcpClient::waitForDisconnect(bool ignore_spurious_events) {
+  if (ignore_spurious_events) {
+    while (!disconnected_) {
+      connection_->dispatcher().run(Event::Dispatcher::RunType::Block);
+    }
+  } else {
+    connection_->dispatcher().run(Event::Dispatcher::RunType::Block);
+    EXPECT_TRUE(disconnected_);
+  }
 }
 
 void IntegrationTcpClient::waitForHalfClose() {

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -77,7 +77,7 @@ public:
 
   void close();
   void waitForData(const std::string& data);
-  void waitForDisconnect();
+  void waitForDisconnect(bool ignore_spurious_events = false);
   void waitForHalfClose();
   void readDisable(bool disabled);
   void write(const std::string& data, bool end_stream = false, bool verify = true);


### PR DESCRIPTION
Hopefully changing an outstanding tcp proxy session crash to a more minor ASSERT failure

*Risk Level*: Low 
*Testing*: unit test of new code.  integration tests which fail to repro the underlying bug.
*Docs Changes*: n/a
*Release Notes*: none

Hopefully ameliorates https://github.com/envoyproxy/envoy/issues/3639