### PR TITLE
restarter: add restarter bazel package

### DIFF
--- a/restarter/BUILD
+++ b/restarter/BUILD
@@ -1,0 +1,12 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_package",
+)
+
+envoy_package()
+
+exports_files([
+    "hot-restarter.py",
+])


### PR DESCRIPTION
restarter: add restarter bazel package

*Description*:
This adds a BUILD file for the restarter package (containing only `hot-restarter.py`) and exports this target. The use-case for this is for packaging envoy using bazel. With this, users can use the `@envoy//restarter:hot-restarter.py` target to pull in the restarter script.

*Risk Level*: Low
This package and target are unused, and will likely only be used by users that are doing packaging via bazel.

*Testing*:
Manual testing by using the `@envoy//restarter:hot-restart.py` target in a `pkg_tar` bazel rule

Signed-off-by: Ben Plotnick <plotnick@yelp.com>