### PR TITLE
upstream: fix http health checker not sending :scheme header

### DIFF
--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -141,6 +141,7 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onInterval() {
        parent_.host_value_.empty() ? parent_.cluster_.info()->name() : parent_.host_value_},
       {Http::Headers::get().Path, parent_.path_},
       {Http::Headers::get().UserAgent, Http::Headers::get().UserAgentValues.EnvoyHealthChecker}};
+  Router::FilterUtility::setUpstreamScheme(request_headers, *parent_.cluster_.info());
 
   parent_.request_headers_parser_->evaluateHeaders(request_headers, REQUEST_INFO);
   request_encoder_->encodeHeaders(request_headers, true);

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -531,6 +531,9 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheck) {
         EXPECT_NE(nullptr, headers.Path());
         EXPECT_EQ(headers.Host()->value().c_str(), host);
         EXPECT_EQ(headers.Path()->value().c_str(), path);
+        EXPECT_TRUE(headers.Scheme());
+        EXPECT_NE(nullptr, headers.Scheme());
+        EXPECT_EQ(headers.Scheme()->value().c_str(), Http::Headers::get().SchemeValues.Http);
       }));
   health_checker_->start();
 

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -531,8 +531,6 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheck) {
         EXPECT_NE(nullptr, headers.Path());
         EXPECT_EQ(headers.Host()->value().c_str(), host);
         EXPECT_EQ(headers.Path()->value().c_str(), path);
-        EXPECT_TRUE(headers.Scheme());
-        EXPECT_NE(nullptr, headers.Scheme());
         EXPECT_EQ(headers.Scheme()->value().c_str(), Http::Headers::get().SchemeValues.Http);
       }));
   health_checker_->start();

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -525,10 +525,6 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheck) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeHeaders(_, true))
       .WillOnce(Invoke([&](const Http::HeaderMap& headers, bool) {
-        EXPECT_TRUE(headers.Host());
-        EXPECT_TRUE(headers.Path());
-        EXPECT_NE(nullptr, headers.Host());
-        EXPECT_NE(nullptr, headers.Path());
         EXPECT_EQ(headers.Host()->value().c_str(), host);
         EXPECT_EQ(headers.Path()->value().c_str(), path);
         EXPECT_EQ(headers.Scheme()->value().c_str(), Http::Headers::get().SchemeValues.Http);
@@ -563,10 +559,6 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithCustomHostValue) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeHeaders(_, true))
       .WillOnce(Invoke([&](const Http::HeaderMap& headers, bool) {
-        EXPECT_TRUE(headers.Host());
-        EXPECT_TRUE(headers.Path());
-        EXPECT_NE(nullptr, headers.Host());
-        EXPECT_NE(nullptr, headers.Path());
         EXPECT_EQ(headers.Host()->value().c_str(), host);
         EXPECT_EQ(headers.Path()->value().c_str(), path);
       }));
@@ -608,14 +600,6 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithAdditionalHeaders) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeHeaders(_, true))
       .WillOnce(Invoke([&](const Http::HeaderMap& headers, bool) {
-        EXPECT_TRUE(headers.get(headerOk));
-        EXPECT_TRUE(headers.get(headerCool));
-        EXPECT_TRUE(headers.get(headerAwesome));
-
-        EXPECT_NE(nullptr, headers.get(headerOk));
-        EXPECT_NE(nullptr, headers.get(headerCool));
-        EXPECT_NE(nullptr, headers.get(headerAwesome));
-
         EXPECT_EQ(headers.get(headerOk)->value().c_str(), valueOk);
         EXPECT_EQ(headers.get(headerCool)->value().c_str(), valueCool);
         EXPECT_EQ(headers.get(headerAwesome)->value().c_str(), valueAwesome);
@@ -1317,10 +1301,6 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithAltPort) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeHeaders(_, true))
       .WillOnce(Invoke([&](const Http::HeaderMap& headers, bool) {
-        EXPECT_TRUE(headers.Host());
-        EXPECT_TRUE(headers.Path());
-        EXPECT_NE(nullptr, headers.Host());
-        EXPECT_NE(nullptr, headers.Path());
         EXPECT_EQ(headers.Host()->value().c_str(), host);
         EXPECT_EQ(headers.Path()->value().c_str(), path);
       }));


### PR DESCRIPTION
Signed-off-by: Neri Marschik <codesuki@users.noreply.github.com>

Using `use_http2` on the HTTP health checker together with a nginx backend results in error messages on the nginx side.
```
2018/06/20 05:56:25 [info] 9#9: *33340 client sent no :scheme header while reading client request headers, client: 10.100.4.200, server: , host: "web"
10.100.4.200 - - [20/Jun/2018:05:56:25 +0000] "-" 400 166 "-" "Envoy/HC"
```

This is fixed by adding the scheme header similarly to this PR for the grpc health checker.
https://github.com/envoyproxy/envoy/pull/2585/files

After: 
```
127.0.0.1 - - [20/Jun/2018:05:56:26 +0000] "GET /alive HTTP/2.0" 200 0 "-" "Envoy/HC"
```

*Risk Level*: Low

*Testing*:
Added a unit test to verify the header is added. 
Did manual testing to see if the above issue is resolved.