### PR TITLE
docs: fix link to bazel style guide

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -167,4 +167,4 @@ such as the current time. Instead, mocks such as
 
 * [Python](https://google.github.io/styleguide/pyguide.html)
 * [Bash](https://google.github.io/styleguide/shell.xml)
-* [Bazel](https://github.com/bazelbuild/bazel/blob/master/site/versions/master/docs/skylark/build-style.md)
+* [Bazel](https://bazel.build/versions/master/docs/skylark/build-style.html)


### PR DESCRIPTION
Signed-off-by: Ben Plotnick <plotnick@yelp.com>

docs: fix link to bazel style guide

*Description*:
Fixes broken link to bazel style guide