### PR TITLE
Add support for arm64

### DIFF
--- a/ci/build_container/build_recipes/luajit.sh
+++ b/ci/build_container/build_recipes/luajit.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION=2.0.5
+VERSION=2.1.0-beta3
 
 wget -O LuaJIT-"$VERSION".tar.gz https://github.com/LuaJIT/LuaJIT/archive/v"$VERSION".tar.gz
 tar xf LuaJIT-"$VERSION".tar.gz

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -81,6 +81,7 @@ elif [[ "$1" == "bazel.debug.server_only" ]]; then
 elif [[ "$1" == "bazel.asan" ]]; then
   setup_clang_toolchain
   echo "bazel ASAN/UBSAN debug build with tests..."
+
   cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
   echo "Building and testing..."
   bazel --batch test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-asan @envoy//test/... \

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -32,9 +32,9 @@ cc_library(
 cc_library(
     name = "luajit",
     srcs = ["thirdparty_build/lib/libluajit-5.1.a"],
-    hdrs = glob(["thirdparty_build/include/luajit-2.0/*"]),
+    hdrs = glob(["thirdparty_build/include/luajit-2.1/*"]),
     includes = ["thirdparty_build/include"],
-    # TODO(mattklein123): We should strip luajit-2.0 here for consumers. However, if we do that
+    # TODO(mattklein123): We should strip luajit-2.1 here for consumers. However, if we do that
     # the headers get included using -I vs. -isystem which then causes old-style-cast warnings.
 )
 

--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -11,7 +11,7 @@
 #include "common/common/c_smart_ptr.h"
 #include "common/common/logger.h"
 
-#include "luajit-2.0/lua.hpp"
+#include "luajit-2.1/lua.hpp"
 
 namespace Envoy {
 namespace Extensions {


### PR DESCRIPTION
Signed-off-by: Bin Lu <bin.lu@arm.com>

LuaJIT2.0 does not support for Arm64

Luajit 2.0.5 doesn't support Arm64, please see logs as reference.
So I need to update it into the latest version.
Logs:
bazel fetch //source/...
….
==== Building LuaJIT 2.0.5 ====
make -C src
make[2]: Entering directory '/root/.cache/bazel/_bazel_root/38a3de7f29554e17d452de52137c58b9/external/envoy_deps_cache_2c744dffd279d7e9e0910ce594eb4f4f/luajit.dep.build/LuaJIT-2.0.5/src'
lj_arch.h:55:2: error: #error "No support for this architecture (yet)"
#error "No support for this architecture (yet)"
  ^

*Risk Level*: Medium

*Testing*: unit test,integration

*Docs Changes*: None

*Release Notes*: None