### PR TITLE
ssl: Specify test files relative to test_rundir

### DIFF
--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -25,12 +25,12 @@ TEST_F(SecretManagerImplTest, SecretLoadSuccess) {
 name: "abc.com"
 tls_certificate:
   certificate_chain:
-    filename: "test/common/ssl/test_data/selfsigned_cert.pem"
+    filename: "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_cert.pem"
   private_key:
-    filename: "test/common/ssl/test_data/selfsigned_key.pem"
+    filename: "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_key.pem"
 )EOF";
 
-  MessageUtil::loadFromYaml(yaml, secret_config);
+  MessageUtil::loadFromYaml(TestEnvironment::substitute(yaml), secret_config);
 
   std::unique_ptr<SecretManager> secret_manager(new SecretManagerImpl());
 
@@ -40,13 +40,13 @@ tls_certificate:
 
   ASSERT_NE(secret_manager->findTlsCertificate("abc.com"), nullptr);
 
-  EXPECT_EQ(
-      TestEnvironment::readFileToStringForTest("test/common/ssl/test_data/selfsigned_cert.pem"),
-      secret_manager->findTlsCertificate("abc.com")->certificateChain());
+  const std::string cert_pem = "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_cert.pem";
+  EXPECT_EQ(TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(cert_pem)),
+            secret_manager->findTlsCertificate("abc.com")->certificateChain());
 
-  EXPECT_EQ(
-      TestEnvironment::readFileToStringForTest("test/common/ssl/test_data/selfsigned_key.pem"),
-      secret_manager->findTlsCertificate("abc.com")->privateKey());
+  const std::string key_pem = "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_key.pem";
+  EXPECT_EQ(TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(key_pem)),
+            secret_manager->findTlsCertificate("abc.com")->privateKey());
 }
 
 TEST_F(SecretManagerImplTest, NotImplementedException) {
@@ -57,10 +57,10 @@ TEST_F(SecretManagerImplTest, NotImplementedException) {
 name: "abc.com"
 session_ticket_keys:
   keys:
-    - filename: "test/common/ssl/test_data/selfsigned_cert.pem"
+    - filename: "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_cert.pem"
 )EOF";
 
-  MessageUtil::loadFromYaml(yaml, secret_config);
+  MessageUtil::loadFromYaml(TestEnvironment::substitute(yaml), secret_config);
 
   std::unique_ptr<SecretManager> secret_manager(new SecretManagerImpl());
 

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -420,12 +420,12 @@ TEST(ClientContextConfigImplTest, StaticTlsCertificates) {
 name: "abc.com"
 tls_certificate:
   certificate_chain:
-    filename: "test/common/ssl/test_data/selfsigned_cert.pem"
+    filename: "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_cert.pem"
   private_key:
-    filename: "test/common/ssl/test_data/selfsigned_key.pem"
+    filename: "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_key.pem"
 )EOF";
 
-  MessageUtil::loadFromYaml(yaml, secret_config);
+  MessageUtil::loadFromYaml(TestEnvironment::substitute(yaml), secret_config);
 
   std::unique_ptr<Secret::SecretManager> secret_manager(new Secret::SecretManagerImpl());
   secret_manager->addOrUpdateSecret(secret_config);
@@ -438,12 +438,12 @@ tls_certificate:
 
   ClientContextConfigImpl client_context_config(tls_context, *secret_manager.get());
 
-  EXPECT_EQ(
-      TestEnvironment::readFileToStringForTest("test/common/ssl/test_data/selfsigned_cert.pem"),
-      client_context_config.certChain());
-  EXPECT_EQ(
-      TestEnvironment::readFileToStringForTest("test/common/ssl/test_data/selfsigned_key.pem"),
-      client_context_config.privateKey());
+  const std::string cert_pem = "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_cert.pem";
+  EXPECT_EQ(TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(cert_pem)),
+            client_context_config.certChain());
+  const std::string key_pem = "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_key.pem";
+  EXPECT_EQ(TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(key_pem)),
+            client_context_config.privateKey());
 }
 
 TEST(ClientContextConfigImplTest, MissingStaticSecretTlsCertificates) {
@@ -453,12 +453,12 @@ TEST(ClientContextConfigImplTest, MissingStaticSecretTlsCertificates) {
 name: "abc.com"
 tls_certificate:
   certificate_chain:
-    filename: "test/common/ssl/test_data/selfsigned_cert.pem"
+    filename: "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_cert.pem"
   private_key:
-    filename: "test/common/ssl/test_data/selfsigned_key.pem"
+    filename: "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_key.pem"
 )EOF";
 
-  MessageUtil::loadFromYaml(yaml, secret_config);
+  MessageUtil::loadFromYaml(TestEnvironment::substitute(yaml), secret_config);
 
   std::unique_ptr<Secret::SecretManager> secret_manager(new Secret::SecretManagerImpl());
 


### PR DESCRIPTION
Signed-off-by: Joshua Marantz <jmarantz@google.com>

*Description*: Adds symbolic prefixes for test files to read and write, so that environments where Envoy is not at the top level of the directory tree can be made to work.

*Risk Level*: Low
*Testing*: //test/...
*Docs Changes*: N/A
*Release Notes*: N/A
