### PR TITLE
ci: only run IPv6 tests on the IPv6 machines

### DIFF
--- a/ci/do_circle_ci_ipv6_tests.sh
+++ b/ci/do_circle_ci_ipv6_tests.sh
@@ -10,6 +10,8 @@ export ENVOY_BUILD_DIR=/tmp/envoy-docker
 
 export TEST_TYPE="bazel.ipv6_tests"
 
+export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v6only"
+
 function finish {
   echo "disk space at end of build:"
   df -h


### PR DESCRIPTION
Changing our v6 CI build to be v6 only.  Ideally it'll be a little faster since the v6 resources are scarce.

*Risk Level*: Low
*Testing*: is there a way to test CI changes?
*Docs Changes*: n/a
*Release Notes*: n/a
