### PR TITLE
test: deflaking a tcp proxy test on asan build

### DIFF
--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -294,6 +294,8 @@ TEST_P(TcpProxyIntegrationTest, ShutdownWithOpenConnections) {
 }
 
 TEST_P(TcpProxyIntegrationTest, TestIdletimeoutWithNoData) {
+  autonomous_upstream_ = true;
+
   enable_half_close_ = false;
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v2::Bootstrap& bootstrap) -> void {
     auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(0);
@@ -310,9 +312,7 @@ TEST_P(TcpProxyIntegrationTest, TestIdletimeoutWithNoData) {
 
   initialize();
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("tcp_proxy"));
-  FakeRawConnectionPtr fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection();
   tcp_client->waitForDisconnect(true);
-  fake_upstream_connection->waitForDisconnect(true);
 }
 
 TEST_P(TcpProxyIntegrationTest, TestIdletimeoutWithLargeOutstandingData) {


### PR DESCRIPTION
On ASAN build the short timeout occasionally causes the tcp proxy session to time out before the upstream connection is established.  Autonomous upstream will handle any incoming connection if it's made and not fail if the connection is not made.

*Risk Level*: n/a
*Testing*: integration test passes
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Alyssa Wilk <alyssar@chromium.org>