### PR TITLE
config_dump: bump protobuf/PGV versions to fix round-trip proto conve…

### DIFF
--- a/api/bazel/repositories.bzl
+++ b/api/bazel/repositories.bzl
@@ -3,7 +3,7 @@ GOGOPROTO_SHA = "1adfc126b41513cc696b209667c8656ea7aac67c" # v1.0.0
 PROMETHEUS_SHA = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c" # Nov 17, 2017
 OPENCENSUS_SHA = "ab82e5fdec8267dc2a726544b10af97675970847" # May 23, 2018
 
-PGV_GIT_SHA = "9f600c2cd2d7031fdc8e25e1c9f5ad81c8cab4fe"
+PGV_GIT_SHA = "345b6b478ef955ad31382955d21fb504e95f38c7"
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -420,7 +420,7 @@ def _com_google_protobuf():
     # see https://groups.google.com/forum/#!topic/bazel-discuss/859ybHQZnuI and
     # https://github.com/bazelbuild/bazel/issues/3219.
     location = REPOSITORY_LOCATIONS["com_google_protobuf"]
-    native.http_archive(name = "com_google_protobuf_cc", **location)
+    git_repository(name = "com_google_protobuf_cc", **location)
     native.bind(
         name = "protobuf",
         actual = "@com_google_protobuf//:protobuf",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -85,9 +85,12 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/google/googletest",
     ),
     com_google_protobuf = dict(
-        sha256 = "826425182ee43990731217b917c5c3ea7190cfda141af4869e6d4ad9085a740f",
-        strip_prefix = "protobuf-3.5.1",
-        urls = ["https://github.com/google/protobuf/archive/v3.5.1.tar.gz"],
+        # TODO(htuch): Switch back to released versions for protobuf when a release > 3.6.0 happens
+        # that includes:
+        # - https://github.com/google/protobuf/commit/f35669b8d3f46f7f1236bd21f14d744bba251e60
+        # - https://github.com/google/protobuf/commit/6a4fec616ec4b20f54d5fb530808b855cb664390
+        commit = "6a4fec616ec4b20f54d5fb530808b855cb664390",
+        remote = "https://github.com/google/protobuf",
     ),
     grpc_httpjson_transcoding = dict(
         commit = "05a15e4ecd0244a981fdf0348a76658def62fa9c",  # 2018-05-30

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -187,6 +187,7 @@ envoy_cc_test(
         "//include/envoy/http:header_map_interface",
         "//source/extensions/filters/http/buffer:config",
         "//source/extensions/filters/http/health_check:config",
+        "@envoy_api//envoy/admin/v2alpha:config_dump_cc",
     ],
 )
 


### PR DESCRIPTION
…rsion bugs.

* Bump protobuf dependency post 3.6.0 to 6a4fec616ec4b20f54d5fb530808b855cb664390. This
  brings in the following fixes:
  - https://github.com/google/protobuf/pull/4813 (fix bug when Any is directly embedded in a map)
  - https://github.com/google/protobuf/pull/4812 (preserve snake/camel-case across Any)
  - https://github.com/google/protobuf/pull/4811 (provide meaningful errors messages for missing fields)

* Bump PGV dependency to 345b6b478ef955ad31382955d21fb504e95f38c7. This bumps the Protobuf Go
  dependency to 1.0, necessary for the above protobuf dependency bump.

Fixes #3665.

Risk level: Low
Testing: Added proto conversion and validation to integration_admin_test.

Signed-off-by: Harvey Tuch <htuch@google.com>