### PR TITLE
config: v1 -> v2 JSON/YAML upgrade tool.

### DIFF
--- a/configs/BUILD
+++ b/configs/BUILD
@@ -30,9 +30,18 @@ filegroup(
 )
 
 genrule(
+    name = "v1_upgraded_configs",
+    srcs = ["google_com_proxy.yaml"],
+    outs = ["google_com_proxy.v2.upgraded.json"],
+    cmd = "$(location //tools:v1_to_bootstrap) $(location google_com_proxy.yaml) > $@",
+    tools = ["//tools:v1_to_bootstrap"],
+)
+
+genrule(
     name = "example_configs",
     srcs = [
         ":configs",
+        ":v1_upgraded_configs",
         "//examples:configs",
         "//test/config/integration/certs",
     ],

--- a/docs/root/configuration/overview/v2_overview.rst
+++ b/docs/root/configuration/overview/v2_overview.rst
@@ -288,6 +288,17 @@ The management server could respond to EDS requests with:
               address: 127.0.0.2
               port_value: 1234
 
+Upgrading from v1 configuration
+-------------------------------
+
+While new v2 bootstrap JSON/YAML can be written, it might be expedient to upgrade an existing
+:ref:`v1 JSON/YAML configuration <config_overview_v1>` to v2. To do this (in an Envoy source tree),
+you can run:
+
+.. code-block:: console
+
+  bazel run //tools:v1_to_bootstrap <path to v1 JSON/YAML configuration file>
+
 Management server
 -----------------
 

--- a/test/config_test/example_configs_test.cc
+++ b/test/config_test/example_configs_test.cc
@@ -17,9 +17,9 @@ TEST(ExampleConfigsTest, All) {
 
 #ifdef __APPLE__
   // freebind/freebind.yaml is not supported on OS X and disabled via Bazel.
-  EXPECT_EQ(28UL, ConfigTest::run(directory));
-#else
   EXPECT_EQ(29UL, ConfigTest::run(directory));
+#else
+  EXPECT_EQ(30UL, ConfigTest::run(directory));
 #endif
   ConfigTest::testMerge();
   ConfigTest::testIncompatibleMerge();

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -33,3 +33,14 @@ envoy_cc_binary(
         "@envoy_api//envoy/config/bootstrap/v2:bootstrap_cc",
     ],
 )
+
+envoy_cc_binary(
+    name = "v1_to_bootstrap",
+    srcs = ["v1_to_bootstrap.cc"],
+    deps = [
+        "//source/common/config:bootstrap_json_lib",
+        "//source/common/json:json_loader_lib",
+        "//source/common/protobuf:utility_lib",
+        "@envoy_api//envoy/config/bootstrap/v2:bootstrap_cc",
+    ],
+)

--- a/tools/v1_to_bootstrap.cc
+++ b/tools/v1_to_bootstrap.cc
@@ -1,0 +1,31 @@
+/**
+ * Utility to convert v1 JSON configuration file to v2 bootstrap JSON (on stdout).
+ *
+ * Usage:
+ *
+ * v1_to_bootstrap <input v1 JSON path>
+ */
+#include <cstdlib>
+
+#include "envoy/config/bootstrap/v2/bootstrap.pb.h"
+#include "envoy/config/bootstrap/v2/bootstrap.pb.validate.h"
+
+#include "common/config/bootstrap_json.h"
+#include "common/json/json_loader.h"
+#include "common/protobuf/utility.h"
+
+// NOLINT(namespace-envoy)
+int main(int argc, char** argv) {
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " <input v1 JSON path>" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  envoy::config::bootstrap::v2::Bootstrap bootstrap;
+  auto config_json = Envoy::Json::Factory::loadFromFile(argv[1]);
+  Envoy::Config::BootstrapJson::translateBootstrap(*config_json, bootstrap);
+  Envoy::MessageUtil::validate(bootstrap);
+  std::cout << Envoy::MessageUtil::getJsonStringFromMessage(bootstrap, true);
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Usage: bazel run //tools:v1_to_bootstrap <path to v1 JSON/YAML configuration file>

Risk level: Low
Testing: Added genrule with output added to //configs:example_configs.

Signed-off-by: Harvey Tuch <htuch@google.com>