### PR TITLE
test: fix merge snafu with integration_admin_test.

### DIFF
--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -297,7 +297,7 @@ TEST_P(IntegrationAdminTest, Admin) {
   // .. and that we can unpack one of the entries.
   envoy::admin::v2alpha::RoutesConfigDump route_config_dump;
   config_dump.configs().at("routes").UnpackTo(&route_config_dump);
-  EXPECT_EQ("route_config_0", route_config_dump.static_route_configs(0).name());
+  EXPECT_EQ("route_config_0", route_config_dump.static_route_configs(0).route_config().name());
 }
 
 TEST_P(IntegrationAdminTest, AdminOnDestroyCallbacks) {


### PR DESCRIPTION
Race between two PR merges that interacted with the ConfigDump proto (they were both green on
CircleCI prior to the merge).

Signed-off-by: Harvey Tuch <htuch@google.com>
