### PR TITLE
add protolock to ci build

### DIFF
--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -107,7 +107,7 @@ message TlsSessionTicketKeys {
   //   * Keep the session ticket keys at least as secure as your TLS certificate private keys
   //   * Rotate session ticket keys at least daily, and preferably hourly
   //   * Always generate keys using a cryptographically-secure random data source
-  repeated core.DataSource keys = 1 [(validate.rules).repeated .min_items = 1];
+  repeated core.DataSource keys = 1 [(validate.rules).repeated.min_items = 1];
 }
 
 message CertificateValidationContext {
@@ -160,7 +160,7 @@ message CertificateValidationContext {
   //   because SPKI is tied to a private key, so it doesn't change when the certificate
   //   is renewed using the same private key.
   repeated string verify_certificate_spki = 3
-      [(validate.rules).repeated .items.string = {min_bytes: 44, max_bytes: 44}];
+      [(validate.rules).repeated.items.string = {min_bytes: 44, max_bytes: 44}];
 
   // An optional list of hex-encoded SHA-256 hashes. If specified, Envoy will verify that
   // the SHA-256 of the DER-encoded presented certificate matches one of the specified values.
@@ -189,7 +189,7 @@ message CertificateValidationContext {
   // <envoy_api_field_auth.CertificateValidationContext.verify_certificate_spki>` are specified,
   // a hash matching value from either of the lists will result in the certificate being accepted.
   repeated string verify_certificate_hash = 2
-      [(validate.rules).repeated .items.string = {min_bytes: 64, max_bytes: 95}];
+      [(validate.rules).repeated.items.string = {min_bytes: 64, max_bytes: 95}];
 
   // An optional list of Subject Alternative Names. If specified, Envoy will verify that the
   // Subject Alternative Name of the presented certificate matches one of the specified values.
@@ -230,7 +230,7 @@ message CommonTlsContext {
   //
   //   Although this is a list, currently only a single certificate is supported. This will be
   //   relaxed in the future.
-  repeated TlsCertificate tls_certificates = 2 [(validate.rules).repeated .max_items = 1];
+  repeated TlsCertificate tls_certificates = 2 [(validate.rules).repeated.max_items = 1];
 
   // [#not-implemented-hide:]
   repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6;

--- a/api/envoy/api/v2/endpoint/load_report.proto
+++ b/api/envoy/api/v2/endpoint/load_report.proto
@@ -78,7 +78,7 @@ message ClusterStats {
 
   // Need at least one.
   repeated UpstreamLocalityStats upstream_locality_stats = 2
-      [(validate.rules).repeated .min_items = 1];
+      [(validate.rules).repeated.min_items = 1];
 
   // Cluster-level stats such as total_successful_requests may be computed by
   // summing upstream_locality_stats. In addition, below there are additional

--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -58,7 +58,7 @@ message Listener {
   // Example using SNI for filter chain selection can be found in the
   // :ref:`FAQ entry <faq_how_to_setup_sni>`.
   repeated listener.FilterChain filter_chains = 3
-      [(validate.rules).repeated .min_items = 1, (gogoproto.nullable) = false];
+      [(validate.rules).repeated.min_items = 1, (gogoproto.nullable) = false];
 
   // If a connection is redirected using *iptables*, the port on which the proxy
   // receives it might be different from the original destination address. When this flag is set to

--- a/api/envoy/api/v2/ratelimit/ratelimit.proto
+++ b/api/envoy/api/v2/ratelimit/ratelimit.proto
@@ -58,5 +58,5 @@ message RateLimitDescriptor {
   }
 
   // Descriptor entries.
-  repeated Entry entries = 1 [(validate.rules).repeated .min_items = 1];
+  repeated Entry entries = 1 [(validate.rules).repeated.min_items = 1];
 }

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -42,7 +42,7 @@ message VirtualHost {
   //   host/authority header. Only a single virtual host in the entire route
   //   configuration can match on “*”. A domain must be unique across all virtual
   //   hosts or the config will fail to load.
-  repeated string domains = 2 [(validate.rules).repeated .min_items = 1];
+  repeated string domains = 2 [(validate.rules).repeated.min_items = 1];
 
   // The list of routes that will be matched, in order, for incoming requests.
   // The first route that matches will be used.
@@ -208,7 +208,7 @@ message WeightedCluster {
   }
 
   // Specifies one or more upstream clusters associated with the route.
-  repeated ClusterWeight clusters = 1 [(validate.rules).repeated .min_items = 1];
+  repeated ClusterWeight clusters = 1 [(validate.rules).repeated.min_items = 1];
 
   // Specifies the total weight across all clusters. The sum of all cluster weights must equal this
   // value, which must be greater than 0. Defaults to 100.
@@ -837,7 +837,7 @@ message RateLimit {
       // specified headers in the config. A match will happen if all the
       // headers in the config are present in the request with the same values
       // (or based on presence if the value field is not in the config).
-      repeated HeaderMatcher headers = 3 [(validate.rules).repeated .min_items = 1];
+      repeated HeaderMatcher headers = 3 [(validate.rules).repeated.min_items = 1];
     }
 
     oneof action_specifier {
@@ -869,7 +869,7 @@ message RateLimit {
   // cannot append a descriptor entry, no descriptor is generated for the
   // configuration. See :ref:`composing actions
   // <config_http_filters_rate_limit_composing_actions>` for additional documentation.
-  repeated Action actions = 3 [(validate.rules).repeated .min_items = 1];
+  repeated Action actions = 3 [(validate.rules).repeated.min_items = 1];
 }
 
 // .. attention::

--- a/api/envoy/config/filter/accesslog/v2/accesslog.proto
+++ b/api/envoy/config/filter/accesslog/v2/accesslog.proto
@@ -134,14 +134,14 @@ message RuntimeFilter {
 // Filters are evaluated sequentially and if one of them returns false, the
 // filter returns false immediately.
 message AndFilter {
-  repeated AccessLogFilter filters = 1 [(validate.rules).repeated .min_items = 2];
+  repeated AccessLogFilter filters = 1 [(validate.rules).repeated.min_items = 2];
 }
 
 // Performs a logical “or” operation on the result of each individual filter.
 // Filters are evaluated sequentially and if one of them returns true, the
 // filter returns true immediately.
 message OrFilter {
-  repeated AccessLogFilter filters = 2 [(validate.rules).repeated .min_items = 2];
+  repeated AccessLogFilter filters = 2 [(validate.rules).repeated.min_items = 2];
 }
 
 // Filters requests based on the presence or value of a request header.

--- a/api/envoy/config/filter/http/ip_tagging/v2/ip_tagging.proto
+++ b/api/envoy/config/filter/http/ip_tagging/v2/ip_tagging.proto
@@ -47,5 +47,5 @@ message IPTagging {
   // [#comment:TODO(ccaraman): Extend functionality to load IP tags from file system.
   // Tracked by issue https://github.com/envoyproxy/envoy/issues/2695]
   // The set of IP tags for the filter.
-  repeated IPTag ip_tags = 4 [(validate.rules).repeated .min_items = 1];
+  repeated IPTag ip_tags = 4 [(validate.rules).repeated.min_items = 1];
 }

--- a/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
+++ b/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
@@ -28,7 +28,7 @@ message GrpcJsonTranscoder {
   // the transcoder will translate. If the service name doesn't exist in ``proto_descriptor``,
   // Envoy will fail at startup. The ``proto_descriptor`` may contain more services than
   // the service names specified here, but they won't be translated.
-  repeated string services = 2 [(validate.rules).repeated .min_items = 1];
+  repeated string services = 2 [(validate.rules).repeated.min_items = 1];
 
   message PrintOptions {
     // Whether to add spaces, line breaks and indentation to make the JSON

--- a/api/envoy/config/filter/network/rate_limit/v2/rate_limit.proto
+++ b/api/envoy/config/filter/network/rate_limit/v2/rate_limit.proto
@@ -21,7 +21,7 @@ message RateLimit {
 
   // The rate limit descriptor list to use in the rate limit service request.
   repeated envoy.api.v2.ratelimit.RateLimitDescriptor descriptors = 3
-      [(validate.rules).repeated .min_items = 1];
+      [(validate.rules).repeated.min_items = 1];
 
   // The timeout in milliseconds for the rate limit service RPC. If not
   // set, this defaults to 20ms.

--- a/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
+++ b/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
@@ -114,7 +114,7 @@ message TcpProxy {
 
     // The route table for the filter. All filter instances must have a route
     // table, even if it is empty.
-    repeated TCPRoute routes = 1 [(validate.rules).repeated .min_items = 1];
+    repeated TCPRoute routes = 1 [(validate.rules).repeated.min_items = 1];
   }
 
   // TCP Proxy filter configuration using deprecated V1 format. This is required for complex

--- a/api/envoy/config/rbac/v2alpha/rbac.proto
+++ b/api/envoy/config/rbac/v2alpha/rbac.proto
@@ -74,12 +74,12 @@ message Policy {
   // Required. The set of permissions that define a role. Each permission is matched with OR
   // semantics. To match all actions for this policy, a single Permission with the `any` field set
   // to true should be used.
-  repeated Permission permissions = 1 [(validate.rules).repeated .min_items = 1];
+  repeated Permission permissions = 1 [(validate.rules).repeated.min_items = 1];
 
   // Required. The set of principals that are assigned/denied the role based on “action”. Each
   // principal is matched with OR semantics. To match all downstreams for this policy, a single
   // Principal with the `any` field set to true should be used.
-  repeated Principal principals = 2 [(validate.rules).repeated .min_items = 1];
+  repeated Principal principals = 2 [(validate.rules).repeated.min_items = 1];
 }
 
 // Permission defines an action (or actions) that a principal can take.
@@ -88,7 +88,7 @@ message Permission {
   // Used in the `and_rules` and `or_rules` fields in the `rule` oneof. Depending on the context,
   // each are applied with the associated behavior.
   message Set {
-    repeated Permission rules = 1 [(validate.rules).repeated .min_items = 1];
+    repeated Permission rules = 1 [(validate.rules).repeated.min_items = 1];
   }
 
   oneof rule {
@@ -120,7 +120,7 @@ message Principal {
   // Used in the `and_ids` and `or_ids` fields in the `identifier` oneof. Depending on the context,
   // each are applied with the associated behavior.
   message Set {
-    repeated Principal ids = 1 [(validate.rules).repeated .min_items = 1];
+    repeated Principal ids = 1 [(validate.rules).repeated.min_items = 1];
   }
 
   // Authentication attributes for a downstream.

--- a/api/envoy/service/accesslog/v2/als.proto
+++ b/api/envoy/service/accesslog/v2/als.proto
@@ -46,14 +46,14 @@ message StreamAccessLogsMessage {
   // Wrapper for batches of HTTP access log entries.
   message HTTPAccessLogEntries {
     repeated envoy.data.accesslog.v2.HTTPAccessLogEntry log_entry = 1
-        [(validate.rules).repeated .min_items = 1];
+        [(validate.rules).repeated.min_items = 1];
   }
 
   // [#not-implemented-hide:]
   // Wrapper for batches of TCP access log entries.
   message TCPAccessLogEntries {
     repeated envoy.data.accesslog.v2.TCPAccessLogEntry log_entry = 1
-        [(validate.rules).repeated .min_items = 1];
+        [(validate.rules).repeated.min_items = 1];
   }
 
   // Batches of log entries of a single type. Generally speaking, a given stream should only

--- a/api/envoy/service/load_stats/v2/lrs.proto
+++ b/api/envoy/service/load_stats/v2/lrs.proto
@@ -61,7 +61,7 @@ message LoadStatsRequest {
 // [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
 message LoadStatsResponse {
   // Clusters to report stats for.
-  repeated string clusters = 1 [(validate.rules).repeated .min_items = 1];
+  repeated string clusters = 1 [(validate.rules).repeated.min_items = 1];
 
   // The interval of time to collect stats. The default is 10 seconds.
   google.protobuf.Duration load_reporting_interval = 2;

--- a/api/proto.lock
+++ b/api/proto.lock
@@ -1,0 +1,7256 @@
+{
+  "definitions": [
+    {
+      "protopath": "envoy:/:config:/:filter:/:http:/:jwt_authn:/:v2alpha:/:config.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "JwtRule",
+            "fields": [
+              {
+                "id": 1,
+                "name": "issuer",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "audiences",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "remote_jwks",
+                "type": "RemoteJwks"
+              },
+              {
+                "id": 4,
+                "name": "local_jwks",
+                "type": "envoy.api.v2.core.DataSource"
+              },
+              {
+                "id": 5,
+                "name": "forward",
+                "type": "bool"
+              },
+              {
+                "id": 6,
+                "name": "from_headers",
+                "type": "JwtHeader",
+                "is_repeated": true
+              },
+              {
+                "id": 7,
+                "name": "from_params",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 8,
+                "name": "forward_payload_header",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "RemoteJwks",
+            "fields": [
+              {
+                "id": 1,
+                "name": "http_uri",
+                "type": "envoy.api.v2.core.HttpUri"
+              },
+              {
+                "id": 2,
+                "name": "cache_duration",
+                "type": "google.protobuf.Duration"
+              }
+            ]
+          },
+          {
+            "name": "JwtHeader",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "value_prefix",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "JwtAuthentication",
+            "fields": [
+              {
+                "id": 1,
+                "name": "rules",
+                "type": "JwtRule",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "allow_missing_or_failed",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "bypass",
+                "type": "envoy.api.v2.route.RouteMatch",
+                "is_repeated": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:network:/:client_ssl_auth:/:v2:/:client_ssl_auth.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "ClientSSLAuth",
+            "fields": [
+              {
+                "id": 1,
+                "name": "auth_api_cluster",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "stat_prefix",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "refresh_delay",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 4,
+                "name": "ip_white_list",
+                "type": "envoy.api.v2.core.CidrRange",
+                "is_repeated": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:extensions:/:filters:/:network:/:thrift_proxy:/:v2alpha1:/:thrift_proxy.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "ThriftProxy",
+            "fields": [
+              {
+                "id": 1,
+                "name": "stat_prefix",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:service:/:discovery:/:v2:/:hds.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "Capability.Protocol",
+            "enum_fields": [
+              {
+                "name": "HTTP",
+                "integer": 0
+              },
+              {
+                "name": "TCP",
+                "integer": 1
+              },
+              {
+                "name": "REDIS",
+                "integer": 2
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "Capability",
+            "fields": [
+              {
+                "id": 1,
+                "name": "health_check_protocol",
+                "type": "Protocol",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "HealthCheckRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "node",
+                "type": "envoy.api.v2.core.Node"
+              },
+              {
+                "id": 2,
+                "name": "capability",
+                "type": "Capability"
+              }
+            ]
+          },
+          {
+            "name": "EndpointHealth",
+            "fields": [
+              {
+                "id": 1,
+                "name": "endpoint",
+                "type": "envoy.api.v2.endpoint.Endpoint"
+              },
+              {
+                "id": 2,
+                "name": "health_status",
+                "type": "envoy.api.v2.core.HealthStatus"
+              }
+            ]
+          },
+          {
+            "name": "EndpointHealthResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "endpoints_health",
+                "type": "EndpointHealth",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "HealthCheckRequestOrEndpointHealthResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "health_check_request",
+                "type": "HealthCheckRequest"
+              },
+              {
+                "id": 2,
+                "name": "endpoint_health_response",
+                "type": "EndpointHealthResponse"
+              }
+            ]
+          },
+          {
+            "name": "LocalityEndpoints",
+            "fields": [
+              {
+                "id": 1,
+                "name": "locality",
+                "type": "envoy.api.v2.core.Locality"
+              },
+              {
+                "id": 2,
+                "name": "endpoints",
+                "type": "envoy.api.v2.endpoint.Endpoint",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ClusterHealthCheck",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cluster_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "health_checks",
+                "type": "envoy.api.v2.core.HealthCheck",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "endpoints",
+                "type": "LocalityEndpoints",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "HealthCheckSpecifier",
+            "fields": [
+              {
+                "id": 1,
+                "name": "health_check",
+                "type": "ClusterHealthCheck",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "interval",
+                "type": "google.protobuf.Duration"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "HealthDiscoveryService",
+            "rpcs": [
+              {
+                "name": "StreamHealthCheck",
+                "in_type": "HealthCheckRequestOrEndpointHealthResponse",
+                "out_type": "HealthCheckSpecifier",
+                "in_streamed": true,
+                "out_streamed": true
+              },
+              {
+                "name": "FetchHealthCheck",
+                "in_type": "HealthCheckRequestOrEndpointHealthResponse",
+                "out_type": "HealthCheckSpecifier"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:cluster:/:circuit_breaker.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "CircuitBreakers",
+            "fields": [
+              {
+                "id": 1,
+                "name": "thresholds",
+                "type": "Thresholds",
+                "is_repeated": true
+              }
+            ],
+            "messages": [
+              {
+                "name": "Thresholds",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "priority",
+                    "type": "core.RoutingPriority"
+                  },
+                  {
+                    "id": 2,
+                    "name": "max_connections",
+                    "type": "google.protobuf.UInt32Value"
+                  },
+                  {
+                    "id": 3,
+                    "name": "max_pending_requests",
+                    "type": "google.protobuf.UInt32Value"
+                  },
+                  {
+                    "id": 4,
+                    "name": "max_requests",
+                    "type": "google.protobuf.UInt32Value"
+                  },
+                  {
+                    "id": 5,
+                    "name": "max_retries",
+                    "type": "google.protobuf.UInt32Value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:ratelimit:/:v2:/:rls.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "RateLimitServiceConfig",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cluster_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "grpc_service",
+                "type": "envoy.api.v2.core.GrpcService"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:transport_socket:/:capture:/:v2alpha:/:capture.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "FileSink.Format",
+            "enum_fields": [
+              {
+                "name": "PROTO_BINARY",
+                "integer": 0
+              },
+              {
+                "name": "PROTO_TEXT",
+                "integer": 1
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "FileSink",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path_prefix",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "format",
+                "type": "Format"
+              }
+            ]
+          },
+          {
+            "name": "Capture",
+            "fields": [
+              {
+                "id": 1,
+                "name": "file_sink",
+                "type": "FileSink"
+              },
+              {
+                "id": 2,
+                "name": "transport_socket",
+                "type": "api.v2.core.TransportSocket"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:service:/:auth:/:v2alpha:/:attribute_context.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "AttributeContext",
+            "fields": [
+              {
+                "id": 1,
+                "name": "source",
+                "type": "Peer"
+              },
+              {
+                "id": 2,
+                "name": "destination",
+                "type": "Peer"
+              },
+              {
+                "id": 4,
+                "name": "request",
+                "type": "Request"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 10,
+                  "name": "context_extensions",
+                  "type": "string"
+                }
+              }
+            ],
+            "messages": [
+              {
+                "name": "Peer",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "address",
+                    "type": "envoy.api.v2.core.Address"
+                  },
+                  {
+                    "id": 2,
+                    "name": "service",
+                    "type": "string"
+                  },
+                  {
+                    "id": 4,
+                    "name": "principal",
+                    "type": "string"
+                  }
+                ],
+                "maps": [
+                  {
+                    "key_type": "string",
+                    "field": {
+                      "id": 3,
+                      "name": "labels",
+                      "type": "string"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "Request",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "time",
+                    "type": "google.protobuf.Timestamp"
+                  },
+                  {
+                    "id": 2,
+                    "name": "http",
+                    "type": "HttpRequest"
+                  }
+                ]
+              },
+              {
+                "name": "HttpRequest",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "id",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "method",
+                    "type": "string"
+                  },
+                  {
+                    "id": 4,
+                    "name": "path",
+                    "type": "string"
+                  },
+                  {
+                    "id": 5,
+                    "name": "host",
+                    "type": "string"
+                  },
+                  {
+                    "id": 6,
+                    "name": "scheme",
+                    "type": "string"
+                  },
+                  {
+                    "id": 7,
+                    "name": "query",
+                    "type": "string"
+                  },
+                  {
+                    "id": 8,
+                    "name": "fragment",
+                    "type": "string"
+                  },
+                  {
+                    "id": 9,
+                    "name": "size",
+                    "type": "int64"
+                  },
+                  {
+                    "id": 10,
+                    "name": "protocol",
+                    "type": "string"
+                  }
+                ],
+                "maps": [
+                  {
+                    "key_type": "string",
+                    "field": {
+                      "id": 3,
+                      "name": "headers",
+                      "type": "string"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:service:/:auth:/:v2alpha:/:external_auth.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "CheckRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "attributes",
+                "type": "AttributeContext"
+              }
+            ]
+          },
+          {
+            "name": "CheckResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "google.rpc.Status"
+              }
+            ],
+            "messages": [
+              {
+                "name": "HttpResponse",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "status_code",
+                    "type": "uint32"
+                  },
+                  {
+                    "id": 3,
+                    "name": "body",
+                    "type": "string"
+                  }
+                ],
+                "maps": [
+                  {
+                    "key_type": "string",
+                    "field": {
+                      "id": 2,
+                      "name": "headers",
+                      "type": "string"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "Authorization",
+            "rpcs": [
+              {
+                "name": "Check",
+                "in_type": "CheckRequest",
+                "out_type": "CheckResponse"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:core:/:config_source.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "ApiConfigSource.ApiType",
+            "enum_fields": [
+              {
+                "name": "REST_LEGACY",
+                "integer": 0
+              },
+              {
+                "name": "REST",
+                "integer": 1
+              },
+              {
+                "name": "GRPC",
+                "integer": 2
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "ApiConfigSource",
+            "fields": [
+              {
+                "id": 1,
+                "name": "api_type",
+                "type": "ApiType"
+              },
+              {
+                "id": 2,
+                "name": "cluster_names",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "grpc_services",
+                "type": "GrpcService",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "refresh_delay",
+                "type": "google.protobuf.Duration"
+              }
+            ]
+          },
+          {
+            "name": "AggregatedConfigSource"
+          },
+          {
+            "name": "ConfigSource",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "api_config_source",
+                "type": "ApiConfigSource"
+              },
+              {
+                "id": 3,
+                "name": "ads",
+                "type": "AggregatedConfigSource"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:listener:/:listener.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "Filter",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "config",
+                "type": "google.protobuf.Struct"
+              },
+              {
+                "id": 3,
+                "name": "deprecated_v1",
+                "type": "DeprecatedV1"
+              }
+            ],
+            "messages": [
+              {
+                "name": "DeprecatedV1",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "type",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "FilterChainMatch",
+            "fields": [
+              {
+                "id": 3,
+                "name": "prefix_ranges",
+                "type": "core.CidrRange",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "address_suffix",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "suffix_len",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 6,
+                "name": "source_prefix_ranges",
+                "type": "core.CidrRange",
+                "is_repeated": true
+              },
+              {
+                "id": 7,
+                "name": "source_ports",
+                "type": "google.protobuf.UInt32Value",
+                "is_repeated": true
+              },
+              {
+                "id": 8,
+                "name": "destination_port",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 11,
+                "name": "server_names",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 9,
+                "name": "transport_protocol",
+                "type": "string"
+              },
+              {
+                "id": 10,
+                "name": "application_protocols",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 1,
+                "name": "sni_domains",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "FilterChain",
+            "fields": [
+              {
+                "id": 1,
+                "name": "filter_chain_match",
+                "type": "FilterChainMatch"
+              },
+              {
+                "id": 2,
+                "name": "tls_context",
+                "type": "auth.DownstreamTlsContext"
+              },
+              {
+                "id": 3,
+                "name": "filters",
+                "type": "Filter",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "use_proxy_proto",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 5,
+                "name": "metadata",
+                "type": "core.Metadata"
+              },
+              {
+                "id": 6,
+                "name": "transport_socket",
+                "type": "core.TransportSocket"
+              }
+            ]
+          },
+          {
+            "name": "ListenerFilter",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "config",
+                "type": "google.protobuf.Struct"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:rds.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "RouteConfiguration",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "virtual_hosts",
+                "type": "route.VirtualHost",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "internal_only_headers",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "response_headers_to_add",
+                "type": "core.HeaderValueOption",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "response_headers_to_remove",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "request_headers_to_add",
+                "type": "core.HeaderValueOption",
+                "is_repeated": true
+              },
+              {
+                "id": 7,
+                "name": "validate_clusters",
+                "type": "google.protobuf.BoolValue"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "RouteDiscoveryService",
+            "rpcs": [
+              {
+                "name": "StreamRoutes",
+                "in_type": "DiscoveryRequest",
+                "out_type": "DiscoveryResponse",
+                "in_streamed": true,
+                "out_streamed": true
+              },
+              {
+                "name": "FetchRoutes",
+                "in_type": "DiscoveryRequest",
+                "out_type": "DiscoveryResponse"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:network:/:http_connection_manager:/:v2:/:http_connection_manager.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "HttpConnectionManager.CodecType",
+            "enum_fields": [
+              {
+                "name": "AUTO",
+                "integer": 0
+              },
+              {
+                "name": "HTTP1",
+                "integer": 1
+              },
+              {
+                "name": "HTTP2",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "Tracing.OperationName",
+            "enum_fields": [
+              {
+                "name": "INGRESS",
+                "integer": 0
+              },
+              {
+                "name": "EGRESS",
+                "integer": 1
+              }
+            ]
+          },
+          {
+            "name": "HttpConnectionManager.ForwardClientCertDetails",
+            "enum_fields": [
+              {
+                "name": "SANITIZE",
+                "integer": 0
+              },
+              {
+                "name": "FORWARD_ONLY",
+                "integer": 1
+              },
+              {
+                "name": "APPEND_FORWARD",
+                "integer": 2
+              },
+              {
+                "name": "SANITIZE_SET",
+                "integer": 3
+              },
+              {
+                "name": "ALWAYS_FORWARD_ONLY",
+                "integer": 4
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "HttpConnectionManager",
+            "fields": [
+              {
+                "id": 1,
+                "name": "codec_type",
+                "type": "CodecType"
+              },
+              {
+                "id": 2,
+                "name": "stat_prefix",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "rds",
+                "type": "Rds"
+              },
+              {
+                "id": 4,
+                "name": "route_config",
+                "type": "envoy.api.v2.RouteConfiguration"
+              },
+              {
+                "id": 5,
+                "name": "http_filters",
+                "type": "HttpFilter",
+                "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "add_user_agent",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 7,
+                "name": "tracing",
+                "type": "Tracing"
+              },
+              {
+                "id": 8,
+                "name": "http_protocol_options",
+                "type": "envoy.api.v2.core.Http1ProtocolOptions"
+              },
+              {
+                "id": 9,
+                "name": "http2_protocol_options",
+                "type": "envoy.api.v2.core.Http2ProtocolOptions"
+              },
+              {
+                "id": 10,
+                "name": "server_name",
+                "type": "string"
+              },
+              {
+                "id": 11,
+                "name": "idle_timeout",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 12,
+                "name": "drain_timeout",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 13,
+                "name": "access_log",
+                "type": "envoy.config.filter.accesslog.v2.AccessLog",
+                "is_repeated": true
+              },
+              {
+                "id": 14,
+                "name": "use_remote_address",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 19,
+                "name": "xff_num_trusted_hops",
+                "type": "uint32"
+              },
+              {
+                "id": 21,
+                "name": "skip_xff_append",
+                "type": "bool"
+              },
+              {
+                "id": 22,
+                "name": "via",
+                "type": "string"
+              },
+              {
+                "id": 15,
+                "name": "generate_request_id",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 16,
+                "name": "forward_client_cert_details",
+                "type": "ForwardClientCertDetails"
+              },
+              {
+                "id": 17,
+                "name": "set_current_client_cert_details",
+                "type": "SetCurrentClientCertDetails"
+              },
+              {
+                "id": 18,
+                "name": "proxy_100_continue",
+                "type": "bool"
+              },
+              {
+                "id": 20,
+                "name": "represent_ipv4_remote_address_as_ipv4_mapped_ipv6",
+                "type": "bool"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Tracing",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "operation_name",
+                    "type": "OperationName"
+                  },
+                  {
+                    "id": 2,
+                    "name": "request_headers_for_tags",
+                    "type": "string",
+                    "is_repeated": true
+                  },
+                  {
+                    "id": 3,
+                    "name": "client_sampling",
+                    "type": "envoy.type.Percent"
+                  },
+                  {
+                    "id": 4,
+                    "name": "random_sampling",
+                    "type": "envoy.type.Percent"
+                  },
+                  {
+                    "id": 5,
+                    "name": "overall_sampling",
+                    "type": "envoy.type.Percent"
+                  }
+                ]
+              },
+              {
+                "name": "SetCurrentClientCertDetails",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "subject",
+                    "type": "google.protobuf.BoolValue"
+                  },
+                  {
+                    "id": 2,
+                    "name": "san",
+                    "type": "google.protobuf.BoolValue"
+                  },
+                  {
+                    "id": 3,
+                    "name": "cert",
+                    "type": "bool"
+                  },
+                  {
+                    "id": 4,
+                    "name": "dns",
+                    "type": "bool"
+                  },
+                  {
+                    "id": 5,
+                    "name": "uri",
+                    "type": "bool"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Rds",
+            "fields": [
+              {
+                "id": 1,
+                "name": "config_source",
+                "type": "envoy.api.v2.core.ConfigSource"
+              },
+              {
+                "id": 2,
+                "name": "route_config_name",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "HttpFilter",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "config",
+                "type": "google.protobuf.Struct"
+              },
+              {
+                "id": 3,
+                "name": "deprecated_v1",
+                "type": "DeprecatedV1"
+              }
+            ],
+            "messages": [
+              {
+                "name": "DeprecatedV1",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "type",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:network:/:redis_proxy:/:v2:/:redis_proxy.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "RedisProxy",
+            "fields": [
+              {
+                "id": 1,
+                "name": "stat_prefix",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "cluster",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "settings",
+                "type": "ConnPoolSettings"
+              }
+            ],
+            "messages": [
+              {
+                "name": "ConnPoolSettings",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "op_timeout",
+                    "type": "google.protobuf.Duration"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:admin:/:v2alpha:/:config_dump.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "ConfigDump",
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 1,
+                  "name": "configs",
+                  "type": "google.protobuf.Any"
+                }
+              }
+            ]
+          },
+          {
+            "name": "BootstrapConfigDump",
+            "fields": [
+              {
+                "id": 1,
+                "name": "bootstrap",
+                "type": "envoy.config.bootstrap.v2.Bootstrap"
+              }
+            ]
+          },
+          {
+            "name": "ListenersConfigDump",
+            "fields": [
+              {
+                "id": 1,
+                "name": "version_info",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "static_listeners",
+                "type": "envoy.api.v2.Listener",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "dynamic_active_listeners",
+                "type": "DynamicListener",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "dynamic_warming_listeners",
+                "type": "DynamicListener",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "dynamic_draining_listeners",
+                "type": "DynamicListener",
+                "is_repeated": true
+              }
+            ],
+            "messages": [
+              {
+                "name": "DynamicListener",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "version_info",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "listener",
+                    "type": "envoy.api.v2.Listener"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "ClustersConfigDump",
+            "fields": [
+              {
+                "id": 1,
+                "name": "version_info",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "static_clusters",
+                "type": "envoy.api.v2.Cluster",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "dynamic_active_clusters",
+                "type": "DynamicCluster",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "dynamic_warming_clusters",
+                "type": "DynamicCluster",
+                "is_repeated": true
+              }
+            ],
+            "messages": [
+              {
+                "name": "DynamicCluster",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "version_info",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "cluster",
+                    "type": "envoy.api.v2.Cluster"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "RoutesConfigDump",
+            "fields": [
+              {
+                "id": 2,
+                "name": "static_route_configs",
+                "type": "envoy.api.v2.RouteConfiguration",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "dynamic_route_configs",
+                "type": "DynamicRouteConfig",
+                "is_repeated": true
+              }
+            ],
+            "messages": [
+              {
+                "name": "DynamicRouteConfig",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "version_info",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "route_config",
+                    "type": "envoy.api.v2.RouteConfiguration"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:discovery.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "DiscoveryRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "version_info",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "node",
+                "type": "core.Node"
+              },
+              {
+                "id": 3,
+                "name": "resource_names",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "type_url",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "response_nonce",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "error_detail",
+                "type": "google.rpc.Status"
+              }
+            ]
+          },
+          {
+            "name": "DiscoveryResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "version_info",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "resources",
+                "type": "google.protobuf.Any",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "canary",
+                "type": "bool"
+              },
+              {
+                "id": 4,
+                "name": "type_url",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "nonce",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:http:/:ip_tagging:/:v2:/:ip_tagging.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "IPTagging.RequestType",
+            "enum_fields": [
+              {
+                "name": "BOTH",
+                "integer": 0
+              },
+              {
+                "name": "INTERNAL",
+                "integer": 1
+              },
+              {
+                "name": "EXTERNAL",
+                "integer": 2
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "IPTagging",
+            "fields": [
+              {
+                "id": 1,
+                "name": "request_type",
+                "type": "RequestType"
+              },
+              {
+                "id": 4,
+                "name": "ip_tags",
+                "type": "IPTag",
+                "is_repeated": true
+              }
+            ],
+            "messages": [
+              {
+                "name": "IPTag",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "ip_tag_name",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "ip_list",
+                    "type": "envoy.api.v2.core.CidrRange",
+                    "is_repeated": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:network:/:ext_authz:/:v2:/:ext_authz.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "ExtAuthz",
+            "fields": [
+              {
+                "id": 1,
+                "name": "stat_prefix",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "grpc_service",
+                "type": "envoy.api.v2.core.GrpcService"
+              },
+              {
+                "id": 3,
+                "name": "failure_mode_allow",
+                "type": "bool"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:service:/:discovery:/:v2:/:ads.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "AdsDummy"
+          }
+        ],
+        "services": [
+          {
+            "name": "AggregatedDiscoveryService",
+            "rpcs": [
+              {
+                "name": "StreamAggregatedResources",
+                "in_type": "envoy.api.v2.DiscoveryRequest",
+                "out_type": "envoy.api.v2.DiscoveryResponse",
+                "in_streamed": true,
+                "out_streamed": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:cds.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "Cluster.DiscoveryType",
+            "enum_fields": [
+              {
+                "name": "STATIC",
+                "integer": 0
+              },
+              {
+                "name": "STRICT_DNS",
+                "integer": 1
+              },
+              {
+                "name": "LOGICAL_DNS",
+                "integer": 2
+              },
+              {
+                "name": "EDS",
+                "integer": 3
+              },
+              {
+                "name": "ORIGINAL_DST",
+                "integer": 4
+              }
+            ]
+          },
+          {
+            "name": "Cluster.LbPolicy",
+            "enum_fields": [
+              {
+                "name": "ROUND_ROBIN",
+                "integer": 0
+              },
+              {
+                "name": "LEAST_REQUEST",
+                "integer": 1
+              },
+              {
+                "name": "RING_HASH",
+                "integer": 2
+              },
+              {
+                "name": "RANDOM",
+                "integer": 3
+              },
+              {
+                "name": "ORIGINAL_DST_LB",
+                "integer": 4
+              },
+              {
+                "name": "MAGLEV",
+                "integer": 5
+              }
+            ]
+          },
+          {
+            "name": "Cluster.DnsLookupFamily",
+            "enum_fields": [
+              {
+                "name": "AUTO",
+                "integer": 0
+              },
+              {
+                "name": "V4_ONLY",
+                "integer": 1
+              },
+              {
+                "name": "V6_ONLY",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "LbSubsetConfig.LbSubsetFallbackPolicy",
+            "enum_fields": [
+              {
+                "name": "NO_FALLBACK",
+                "integer": 0
+              },
+              {
+                "name": "ANY_ENDPOINT",
+                "integer": 1
+              },
+              {
+                "name": "DEFAULT_SUBSET",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "Cluster.ClusterProtocolSelection",
+            "enum_fields": [
+              {
+                "name": "USE_CONFIGURED_PROTOCOL",
+                "integer": 0
+              },
+              {
+                "name": "USE_DOWNSTREAM_PROTOCOL",
+                "integer": 1
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "Cluster",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 28,
+                "name": "alt_stat_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "type",
+                "type": "DiscoveryType"
+              },
+              {
+                "id": 3,
+                "name": "eds_cluster_config",
+                "type": "EdsClusterConfig"
+              },
+              {
+                "id": 4,
+                "name": "connect_timeout",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 5,
+                "name": "per_connection_buffer_limit_bytes",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 6,
+                "name": "lb_policy",
+                "type": "LbPolicy"
+              },
+              {
+                "id": 7,
+                "name": "hosts",
+                "type": "core.Address",
+                "is_repeated": true
+              },
+              {
+                "id": 33,
+                "name": "load_assignment",
+                "type": "ClusterLoadAssignment"
+              },
+              {
+                "id": 8,
+                "name": "health_checks",
+                "type": "core.HealthCheck",
+                "is_repeated": true
+              },
+              {
+                "id": 9,
+                "name": "max_requests_per_connection",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 10,
+                "name": "circuit_breakers",
+                "type": "cluster.CircuitBreakers"
+              },
+              {
+                "id": 11,
+                "name": "tls_context",
+                "type": "auth.UpstreamTlsContext"
+              },
+              {
+                "id": 29,
+                "name": "common_http_protocol_options",
+                "type": "core.HttpProtocolOptions"
+              },
+              {
+                "id": 13,
+                "name": "http_protocol_options",
+                "type": "core.Http1ProtocolOptions"
+              },
+              {
+                "id": 14,
+                "name": "http2_protocol_options",
+                "type": "core.Http2ProtocolOptions"
+              },
+              {
+                "id": 16,
+                "name": "dns_refresh_rate",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 17,
+                "name": "dns_lookup_family",
+                "type": "DnsLookupFamily"
+              },
+              {
+                "id": 18,
+                "name": "dns_resolvers",
+                "type": "core.Address",
+                "is_repeated": true
+              },
+              {
+                "id": 19,
+                "name": "outlier_detection",
+                "type": "cluster.OutlierDetection"
+              },
+              {
+                "id": 20,
+                "name": "cleanup_interval",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 21,
+                "name": "upstream_bind_config",
+                "type": "core.BindConfig"
+              },
+              {
+                "id": 22,
+                "name": "lb_subset_config",
+                "type": "LbSubsetConfig"
+              },
+              {
+                "id": 23,
+                "name": "ring_hash_lb_config",
+                "type": "RingHashLbConfig"
+              },
+              {
+                "id": 27,
+                "name": "common_lb_config",
+                "type": "CommonLbConfig"
+              },
+              {
+                "id": 24,
+                "name": "transport_socket",
+                "type": "core.TransportSocket"
+              },
+              {
+                "id": 25,
+                "name": "metadata",
+                "type": "core.Metadata"
+              },
+              {
+                "id": 26,
+                "name": "protocol_selection",
+                "type": "ClusterProtocolSelection"
+              },
+              {
+                "id": 30,
+                "name": "upstream_connection_options",
+                "type": "envoy.api.v2.UpstreamConnectionOptions"
+              },
+              {
+                "id": 31,
+                "name": "close_connections_on_host_health_failure",
+                "type": "bool"
+              },
+              {
+                "id": 32,
+                "name": "drain_connections_on_host_removal",
+                "type": "bool"
+              }
+            ],
+            "reserved_ids": [
+              12,
+              15
+            ],
+            "messages": [
+              {
+                "name": "EdsClusterConfig",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "eds_config",
+                    "type": "core.ConfigSource"
+                  },
+                  {
+                    "id": 2,
+                    "name": "service_name",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "name": "LbSubsetConfig",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "fallback_policy",
+                    "type": "LbSubsetFallbackPolicy"
+                  },
+                  {
+                    "id": 2,
+                    "name": "default_subset",
+                    "type": "google.protobuf.Struct"
+                  },
+                  {
+                    "id": 3,
+                    "name": "subset_selectors",
+                    "type": "LbSubsetSelector",
+                    "is_repeated": true
+                  }
+                ],
+                "messages": [
+                  {
+                    "name": "LbSubsetSelector",
+                    "fields": [
+                      {
+                        "id": 1,
+                        "name": "keys",
+                        "type": "string",
+                        "is_repeated": true
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "RingHashLbConfig",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "minimum_ring_size",
+                    "type": "google.protobuf.UInt64Value"
+                  },
+                  {
+                    "id": 2,
+                    "name": "deprecated_v1",
+                    "type": "DeprecatedV1"
+                  }
+                ],
+                "messages": [
+                  {
+                    "name": "DeprecatedV1",
+                    "fields": [
+                      {
+                        "id": 1,
+                        "name": "use_std_hash",
+                        "type": "google.protobuf.BoolValue"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "CommonLbConfig",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "healthy_panic_threshold",
+                    "type": "envoy.type.Percent"
+                  },
+                  {
+                    "id": 2,
+                    "name": "zone_aware_lb_config",
+                    "type": "ZoneAwareLbConfig"
+                  },
+                  {
+                    "id": 3,
+                    "name": "locality_weighted_lb_config",
+                    "type": "LocalityWeightedLbConfig"
+                  }
+                ],
+                "messages": [
+                  {
+                    "name": "ZoneAwareLbConfig",
+                    "fields": [
+                      {
+                        "id": 1,
+                        "name": "routing_enabled",
+                        "type": "envoy.type.Percent"
+                      },
+                      {
+                        "id": 2,
+                        "name": "min_cluster_size",
+                        "type": "google.protobuf.UInt64Value"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "LocalityWeightedLbConfig"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "UpstreamBindConfig",
+            "fields": [
+              {
+                "id": 1,
+                "name": "source_address",
+                "type": "core.Address"
+              }
+            ]
+          },
+          {
+            "name": "UpstreamConnectionOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "tcp_keepalive",
+                "type": "core.TcpKeepalive"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "ClusterDiscoveryService",
+            "rpcs": [
+              {
+                "name": "StreamClusters",
+                "in_type": "DiscoveryRequest",
+                "out_type": "DiscoveryResponse",
+                "in_streamed": true,
+                "out_streamed": true
+              },
+              {
+                "name": "FetchClusters",
+                "in_type": "DiscoveryRequest",
+                "out_type": "DiscoveryResponse"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:endpoint:/:endpoint.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "Endpoint",
+            "fields": [
+              {
+                "id": 1,
+                "name": "address",
+                "type": "core.Address"
+              },
+              {
+                "id": 2,
+                "name": "health_check_config",
+                "type": "HealthCheckConfig"
+              }
+            ],
+            "messages": [
+              {
+                "name": "HealthCheckConfig",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "port_value",
+                    "type": "uint32"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "LbEndpoint",
+            "fields": [
+              {
+                "id": 1,
+                "name": "endpoint",
+                "type": "Endpoint"
+              },
+              {
+                "id": 2,
+                "name": "health_status",
+                "type": "core.HealthStatus"
+              },
+              {
+                "id": 3,
+                "name": "metadata",
+                "type": "core.Metadata"
+              },
+              {
+                "id": 4,
+                "name": "load_balancing_weight",
+                "type": "google.protobuf.UInt32Value"
+              }
+            ]
+          },
+          {
+            "name": "LocalityLbEndpoints",
+            "fields": [
+              {
+                "id": 1,
+                "name": "locality",
+                "type": "core.Locality"
+              },
+              {
+                "id": 2,
+                "name": "lb_endpoints",
+                "type": "LbEndpoint",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "load_balancing_weight",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 5,
+                "name": "priority",
+                "type": "uint32"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:http:/:ext_authz:/:v2alpha:/:ext_authz.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "HttpService",
+            "fields": [
+              {
+                "id": 1,
+                "name": "server_uri",
+                "type": "envoy.api.v2.core.HttpUri"
+              },
+              {
+                "id": 2,
+                "name": "path_prefix",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ExtAuthz",
+            "fields": [
+              {
+                "id": 1,
+                "name": "grpc_service",
+                "type": "envoy.api.v2.core.GrpcService"
+              },
+              {
+                "id": 3,
+                "name": "http_service",
+                "type": "HttpService"
+              },
+              {
+                "id": 2,
+                "name": "failure_mode_allow",
+                "type": "bool"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:http:/:rate_limit:/:v2:/:rate_limit.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "RateLimit",
+            "fields": [
+              {
+                "id": 1,
+                "name": "domain",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "stage",
+                "type": "uint32"
+              },
+              {
+                "id": 3,
+                "name": "request_type",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "timeout",
+                "type": "google.protobuf.Duration"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:service:/:metrics:/:v2:/:metrics_service.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "StreamMetricsResponse"
+          },
+          {
+            "name": "StreamMetricsMessage",
+            "fields": [
+              {
+                "id": 1,
+                "name": "identifier",
+                "type": "Identifier"
+              },
+              {
+                "id": 2,
+                "name": "envoy_metrics",
+                "type": "io.prometheus.client.MetricFamily",
+                "is_repeated": true
+              }
+            ],
+            "messages": [
+              {
+                "name": "Identifier",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "node",
+                    "type": "envoy.api.v2.core.Node"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "MetricsService",
+            "rpcs": [
+              {
+                "name": "StreamMetrics",
+                "in_type": "StreamMetricsMessage",
+                "out_type": "StreamMetricsResponse",
+                "in_streamed": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:service:/:trace:/:v2:/:trace_service.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "StreamTracesResponse"
+          },
+          {
+            "name": "StreamTracesMessage",
+            "fields": [
+              {
+                "id": 1,
+                "name": "identifier",
+                "type": "Identifier"
+              },
+              {
+                "id": 2,
+                "name": "spans",
+                "type": "opencensus.proto.trace.Span",
+                "is_repeated": true
+              }
+            ],
+            "messages": [
+              {
+                "name": "Identifier",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "node",
+                    "type": "envoy.api.v2.core.Node"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "TraceService",
+            "rpcs": [
+              {
+                "name": "StreamTraces",
+                "in_type": "StreamTracesMessage",
+                "out_type": "StreamTracesResponse",
+                "in_streamed": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:network:/:mongo_proxy:/:v2:/:mongo_proxy.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "MongoProxy",
+            "fields": [
+              {
+                "id": 1,
+                "name": "stat_prefix",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "access_log",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "delay",
+                "type": "envoy.config.filter.fault.v2.FaultDelay"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:metrics:/:v2:/:metrics_service.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "MetricsServiceConfig",
+            "fields": [
+              {
+                "id": 1,
+                "name": "grpc_service",
+                "type": "envoy.api.v2.core.GrpcService"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:type:/:string_match.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "StringMatch",
+            "fields": [
+              {
+                "id": 1,
+                "name": "simple",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "prefix",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "suffix",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "regex",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:core:/:health_check.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "HealthStatus",
+            "enum_fields": [
+              {
+                "name": "UNKNOWN",
+                "integer": 0
+              },
+              {
+                "name": "HEALTHY",
+                "integer": 1
+              },
+              {
+                "name": "UNHEALTHY",
+                "integer": 2
+              },
+              {
+                "name": "DRAINING",
+                "integer": 3
+              },
+              {
+                "name": "TIMEOUT",
+                "integer": 4
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "HealthCheck",
+            "fields": [
+              {
+                "id": 1,
+                "name": "timeout",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 2,
+                "name": "interval",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 3,
+                "name": "interval_jitter",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 4,
+                "name": "unhealthy_threshold",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 5,
+                "name": "healthy_threshold",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 6,
+                "name": "alt_port",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 7,
+                "name": "reuse_connection",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 8,
+                "name": "http_health_check",
+                "type": "HttpHealthCheck"
+              },
+              {
+                "id": 9,
+                "name": "tcp_health_check",
+                "type": "TcpHealthCheck"
+              },
+              {
+                "id": 10,
+                "name": "redis_health_check",
+                "type": "RedisHealthCheck"
+              },
+              {
+                "id": 11,
+                "name": "grpc_health_check",
+                "type": "GrpcHealthCheck"
+              },
+              {
+                "id": 13,
+                "name": "custom_health_check",
+                "type": "CustomHealthCheck"
+              },
+              {
+                "id": 12,
+                "name": "no_traffic_interval",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 14,
+                "name": "unhealthy_interval",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 15,
+                "name": "unhealthy_edge_interval",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 16,
+                "name": "healthy_edge_interval",
+                "type": "google.protobuf.Duration"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Payload",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "text",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "binary",
+                    "type": "bytes"
+                  }
+                ]
+              },
+              {
+                "name": "HttpHealthCheck",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "host",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "path",
+                    "type": "string"
+                  },
+                  {
+                    "id": 3,
+                    "name": "send",
+                    "type": "Payload"
+                  },
+                  {
+                    "id": 4,
+                    "name": "receive",
+                    "type": "Payload"
+                  },
+                  {
+                    "id": 5,
+                    "name": "service_name",
+                    "type": "string"
+                  },
+                  {
+                    "id": 6,
+                    "name": "request_headers_to_add",
+                    "type": "core.HeaderValueOption",
+                    "is_repeated": true
+                  },
+                  {
+                    "id": 7,
+                    "name": "use_http2",
+                    "type": "bool"
+                  }
+                ]
+              },
+              {
+                "name": "TcpHealthCheck",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "send",
+                    "type": "Payload"
+                  },
+                  {
+                    "id": 2,
+                    "name": "receive",
+                    "type": "Payload",
+                    "is_repeated": true
+                  }
+                ]
+              },
+              {
+                "name": "RedisHealthCheck",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "key",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "name": "GrpcHealthCheck",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "service_name",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "name": "CustomHealthCheck",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "name",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "config",
+                    "type": "google.protobuf.Struct"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:http:/:health_check:/:v2:/:health_check.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "HealthCheck",
+            "fields": [
+              {
+                "id": 1,
+                "name": "pass_through_mode",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 2,
+                "name": "endpoint",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "cache_time",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 5,
+                "name": "headers",
+                "type": "envoy.api.v2.route.HeaderMatcher",
+                "is_repeated": true
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 4,
+                  "name": "cluster_min_healthy_percentages",
+                  "type": "envoy.type.Percent"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:http:/:squash:/:v2:/:squash.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "Squash",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cluster",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "attachment_template",
+                "type": "google.protobuf.Struct"
+              },
+              {
+                "id": 3,
+                "name": "request_timeout",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 4,
+                "name": "attachment_timeout",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 5,
+                "name": "attachment_poll_period",
+                "type": "google.protobuf.Duration"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:network:/:tcp_proxy:/:v2:/:tcp_proxy.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "TcpProxy",
+            "fields": [
+              {
+                "id": 1,
+                "name": "stat_prefix",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "cluster",
+                "type": "string"
+              },
+              {
+                "id": 9,
+                "name": "metadata_match",
+                "type": "envoy.api.v2.core.Metadata"
+              },
+              {
+                "id": 8,
+                "name": "idle_timeout",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 3,
+                "name": "downstream_idle_timeout",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 4,
+                "name": "upstream_idle_timeout",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 5,
+                "name": "access_log",
+                "type": "envoy.config.filter.accesslog.v2.AccessLog",
+                "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "deprecated_v1",
+                "type": "DeprecatedV1"
+              },
+              {
+                "id": 7,
+                "name": "max_connect_attempts",
+                "type": "google.protobuf.UInt32Value"
+              }
+            ],
+            "messages": [
+              {
+                "name": "DeprecatedV1",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "routes",
+                    "type": "TCPRoute",
+                    "is_repeated": true
+                  }
+                ],
+                "messages": [
+                  {
+                    "name": "TCPRoute",
+                    "fields": [
+                      {
+                        "id": 1,
+                        "name": "cluster",
+                        "type": "string"
+                      },
+                      {
+                        "id": 2,
+                        "name": "destination_ip_list",
+                        "type": "envoy.api.v2.core.CidrRange",
+                        "is_repeated": true
+                      },
+                      {
+                        "id": 3,
+                        "name": "destination_ports",
+                        "type": "string"
+                      },
+                      {
+                        "id": 4,
+                        "name": "source_ip_list",
+                        "type": "envoy.api.v2.core.CidrRange",
+                        "is_repeated": true
+                      },
+                      {
+                        "id": 5,
+                        "name": "source_ports",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:metrics:/:v2:/:stats.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "StatsSink",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "config",
+                "type": "google.protobuf.Struct"
+              }
+            ]
+          },
+          {
+            "name": "StatsConfig",
+            "fields": [
+              {
+                "id": 1,
+                "name": "stats_tags",
+                "type": "TagSpecifier",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "use_all_default_tags",
+                "type": "google.protobuf.BoolValue"
+              }
+            ]
+          },
+          {
+            "name": "TagSpecifier",
+            "fields": [
+              {
+                "id": 1,
+                "name": "tag_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "regex",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "fixed_value",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "StatsdSink",
+            "fields": [
+              {
+                "id": 1,
+                "name": "address",
+                "type": "envoy.api.v2.core.Address"
+              },
+              {
+                "id": 2,
+                "name": "tcp_cluster_name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "prefix",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "DogStatsdSink",
+            "fields": [
+              {
+                "id": 1,
+                "name": "address",
+                "type": "envoy.api.v2.core.Address"
+              }
+            ],
+            "reserved_ids": [
+              2
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:data:/:accesslog:/:v2:/:accesslog.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "HTTPAccessLogEntry.HTTPVersion",
+            "enum_fields": [
+              {
+                "name": "PROTOCOL_UNSPECIFIED",
+                "integer": 0
+              },
+              {
+                "name": "HTTP10",
+                "integer": 1
+              },
+              {
+                "name": "HTTP11",
+                "integer": 2
+              },
+              {
+                "name": "HTTP2",
+                "integer": 3
+              }
+            ]
+          },
+          {
+            "name": "Unauthorized.Reason",
+            "enum_fields": [
+              {
+                "name": "REASON_UNSPECIFIED",
+                "integer": 0
+              },
+              {
+                "name": "EXTERNAL_SERVICE",
+                "integer": 1
+              }
+            ]
+          },
+          {
+            "name": "TLSProperties.TLSVersion",
+            "enum_fields": [
+              {
+                "name": "VERSION_UNSPECIFIED",
+                "integer": 0
+              },
+              {
+                "name": "TLSv1",
+                "integer": 1
+              },
+              {
+                "name": "TLSv1_1",
+                "integer": 2
+              },
+              {
+                "name": "TLSv1_2",
+                "integer": 3
+              },
+              {
+                "name": "TLSv1_3",
+                "integer": 4
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "TCPAccessLogEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "common_properties",
+                "type": "AccessLogCommon"
+              }
+            ]
+          },
+          {
+            "name": "HTTPAccessLogEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "common_properties",
+                "type": "AccessLogCommon"
+              },
+              {
+                "id": 2,
+                "name": "protocol_version",
+                "type": "HTTPVersion"
+              },
+              {
+                "id": 3,
+                "name": "request",
+                "type": "HTTPRequestProperties"
+              },
+              {
+                "id": 4,
+                "name": "response",
+                "type": "HTTPResponseProperties"
+              }
+            ]
+          },
+          {
+            "name": "AccessLogCommon",
+            "fields": [
+              {
+                "id": 1,
+                "name": "sample_rate",
+                "type": "double"
+              },
+              {
+                "id": 2,
+                "name": "downstream_remote_address",
+                "type": "envoy.api.v2.core.Address"
+              },
+              {
+                "id": 3,
+                "name": "downstream_local_address",
+                "type": "envoy.api.v2.core.Address"
+              },
+              {
+                "id": 4,
+                "name": "tls_properties",
+                "type": "TLSProperties"
+              },
+              {
+                "id": 5,
+                "name": "start_time",
+                "type": "google.protobuf.Timestamp"
+              },
+              {
+                "id": 6,
+                "name": "time_to_last_rx_byte",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 7,
+                "name": "time_to_first_upstream_tx_byte",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 8,
+                "name": "time_to_last_upstream_tx_byte",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 9,
+                "name": "time_to_first_upstream_rx_byte",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 10,
+                "name": "time_to_last_upstream_rx_byte",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 11,
+                "name": "time_to_first_downstream_tx_byte",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 12,
+                "name": "time_to_last_downstream_tx_byte",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 13,
+                "name": "upstream_remote_address",
+                "type": "envoy.api.v2.core.Address"
+              },
+              {
+                "id": 14,
+                "name": "upstream_local_address",
+                "type": "envoy.api.v2.core.Address"
+              },
+              {
+                "id": 15,
+                "name": "upstream_cluster",
+                "type": "string"
+              },
+              {
+                "id": 16,
+                "name": "response_flags",
+                "type": "ResponseFlags"
+              },
+              {
+                "id": 17,
+                "name": "metadata",
+                "type": "envoy.api.v2.core.Metadata"
+              }
+            ]
+          },
+          {
+            "name": "ResponseFlags",
+            "fields": [
+              {
+                "id": 1,
+                "name": "failed_local_healthcheck",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "no_healthy_upstream",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "upstream_request_timeout",
+                "type": "bool"
+              },
+              {
+                "id": 4,
+                "name": "local_reset",
+                "type": "bool"
+              },
+              {
+                "id": 5,
+                "name": "upstream_remote_reset",
+                "type": "bool"
+              },
+              {
+                "id": 6,
+                "name": "upstream_connection_failure",
+                "type": "bool"
+              },
+              {
+                "id": 7,
+                "name": "upstream_connection_termination",
+                "type": "bool"
+              },
+              {
+                "id": 8,
+                "name": "upstream_overflow",
+                "type": "bool"
+              },
+              {
+                "id": 9,
+                "name": "no_route_found",
+                "type": "bool"
+              },
+              {
+                "id": 10,
+                "name": "delay_injected",
+                "type": "bool"
+              },
+              {
+                "id": 11,
+                "name": "fault_injected",
+                "type": "bool"
+              },
+              {
+                "id": 12,
+                "name": "rate_limited",
+                "type": "bool"
+              },
+              {
+                "id": 13,
+                "name": "unauthorized_details",
+                "type": "Unauthorized"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Unauthorized",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "reason",
+                    "type": "Reason"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "TLSProperties",
+            "fields": [
+              {
+                "id": 1,
+                "name": "tls_version",
+                "type": "TLSVersion"
+              },
+              {
+                "id": 2,
+                "name": "tls_cipher_suite",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 3,
+                "name": "tls_sni_hostname",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "HTTPRequestProperties",
+            "fields": [
+              {
+                "id": 1,
+                "name": "request_method",
+                "type": "envoy.api.v2.core.RequestMethod"
+              },
+              {
+                "id": 2,
+                "name": "scheme",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "authority",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "port",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 5,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "user_agent",
+                "type": "string"
+              },
+              {
+                "id": 7,
+                "name": "referer",
+                "type": "string"
+              },
+              {
+                "id": 8,
+                "name": "forwarded_for",
+                "type": "string"
+              },
+              {
+                "id": 9,
+                "name": "request_id",
+                "type": "string"
+              },
+              {
+                "id": 10,
+                "name": "original_path",
+                "type": "string"
+              },
+              {
+                "id": 11,
+                "name": "request_headers_bytes",
+                "type": "uint64"
+              },
+              {
+                "id": 12,
+                "name": "request_body_bytes",
+                "type": "uint64"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 13,
+                  "name": "request_headers",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "HTTPResponseProperties",
+            "fields": [
+              {
+                "id": 1,
+                "name": "response_code",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 2,
+                "name": "response_headers_bytes",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "response_body_bytes",
+                "type": "uint64"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 4,
+                  "name": "response_headers",
+                  "type": "string"
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 5,
+                  "name": "response_trailers",
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:core:/:http_uri.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "HttpUri",
+            "fields": [
+              {
+                "id": 1,
+                "name": "uri",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "cluster",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "timeout",
+                "type": "google.protobuf.Duration"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:lds.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "Listener.DrainType",
+            "enum_fields": [
+              {
+                "name": "DEFAULT",
+                "integer": 0
+              },
+              {
+                "name": "MODIFY_ONLY",
+                "integer": 1
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "Listener",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "address",
+                "type": "core.Address"
+              },
+              {
+                "id": 3,
+                "name": "filter_chains",
+                "type": "listener.FilterChain",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "use_original_dst",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 5,
+                "name": "per_connection_buffer_limit_bytes",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 6,
+                "name": "metadata",
+                "type": "core.Metadata"
+              },
+              {
+                "id": 7,
+                "name": "deprecated_v1",
+                "type": "DeprecatedV1"
+              },
+              {
+                "id": 8,
+                "name": "drain_type",
+                "type": "DrainType"
+              },
+              {
+                "id": 9,
+                "name": "listener_filters",
+                "type": "listener.ListenerFilter",
+                "is_repeated": true
+              },
+              {
+                "id": 10,
+                "name": "transparent",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 11,
+                "name": "freebind",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 12,
+                "name": "tcp_fast_open_queue_length",
+                "type": "google.protobuf.UInt32Value"
+              }
+            ],
+            "messages": [
+              {
+                "name": "DeprecatedV1",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "bind_to_port",
+                    "type": "google.protobuf.BoolValue"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "ListenerDiscoveryService",
+            "rpcs": [
+              {
+                "name": "StreamListeners",
+                "in_type": "DiscoveryRequest",
+                "out_type": "DiscoveryResponse",
+                "in_streamed": true,
+                "out_streamed": true
+              },
+              {
+                "name": "FetchListeners",
+                "in_type": "DiscoveryRequest",
+                "out_type": "DiscoveryResponse"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:ratelimit:/:ratelimit.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "RateLimitDescriptor",
+            "fields": [
+              {
+                "id": 1,
+                "name": "entries",
+                "type": "Entry",
+                "is_repeated": true
+              }
+            ],
+            "messages": [
+              {
+                "name": "Entry",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "key",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "value",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:route:/:route.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "VirtualHost.TlsRequirementType",
+            "enum_fields": [
+              {
+                "name": "NONE",
+                "integer": 0
+              },
+              {
+                "name": "EXTERNAL_ONLY",
+                "integer": 1
+              },
+              {
+                "name": "ALL",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "RouteAction.ClusterNotFoundResponseCode",
+            "enum_fields": [
+              {
+                "name": "SERVICE_UNAVAILABLE",
+                "integer": 0
+              },
+              {
+                "name": "NOT_FOUND",
+                "integer": 1
+              }
+            ]
+          },
+          {
+            "name": "RedirectAction.RedirectResponseCode",
+            "enum_fields": [
+              {
+                "name": "MOVED_PERMANENTLY",
+                "integer": 0
+              },
+              {
+                "name": "FOUND",
+                "integer": 1
+              },
+              {
+                "name": "SEE_OTHER",
+                "integer": 2
+              },
+              {
+                "name": "TEMPORARY_REDIRECT",
+                "integer": 3
+              },
+              {
+                "name": "PERMANENT_REDIRECT",
+                "integer": 4
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "VirtualHost",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "domains",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "routes",
+                "type": "Route",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "require_tls",
+                "type": "TlsRequirementType"
+              },
+              {
+                "id": 5,
+                "name": "virtual_clusters",
+                "type": "VirtualCluster",
+                "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "rate_limits",
+                "type": "RateLimit",
+                "is_repeated": true
+              },
+              {
+                "id": 7,
+                "name": "request_headers_to_add",
+                "type": "core.HeaderValueOption",
+                "is_repeated": true
+              },
+              {
+                "id": 10,
+                "name": "response_headers_to_add",
+                "type": "core.HeaderValueOption",
+                "is_repeated": true
+              },
+              {
+                "id": 11,
+                "name": "response_headers_to_remove",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 8,
+                "name": "cors",
+                "type": "CorsPolicy"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 12,
+                  "name": "per_filter_config",
+                  "type": "google.protobuf.Struct"
+                }
+              }
+            ],
+            "reserved_ids": [
+              9
+            ]
+          },
+          {
+            "name": "Route",
+            "fields": [
+              {
+                "id": 1,
+                "name": "match",
+                "type": "RouteMatch"
+              },
+              {
+                "id": 2,
+                "name": "route",
+                "type": "RouteAction"
+              },
+              {
+                "id": 3,
+                "name": "redirect",
+                "type": "RedirectAction"
+              },
+              {
+                "id": 7,
+                "name": "direct_response",
+                "type": "DirectResponseAction"
+              },
+              {
+                "id": 4,
+                "name": "metadata",
+                "type": "core.Metadata"
+              },
+              {
+                "id": 5,
+                "name": "decorator",
+                "type": "Decorator"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 8,
+                  "name": "per_filter_config",
+                  "type": "google.protobuf.Struct"
+                }
+              }
+            ],
+            "reserved_ids": [
+              6
+            ]
+          },
+          {
+            "name": "WeightedCluster",
+            "fields": [
+              {
+                "id": 1,
+                "name": "clusters",
+                "type": "ClusterWeight",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "total_weight",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 2,
+                "name": "runtime_key_prefix",
+                "type": "string"
+              }
+            ],
+            "messages": [
+              {
+                "name": "ClusterWeight",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "name",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "weight",
+                    "type": "google.protobuf.UInt32Value"
+                  },
+                  {
+                    "id": 3,
+                    "name": "metadata_match",
+                    "type": "core.Metadata"
+                  },
+                  {
+                    "id": 4,
+                    "name": "request_headers_to_add",
+                    "type": "core.HeaderValueOption",
+                    "is_repeated": true
+                  },
+                  {
+                    "id": 5,
+                    "name": "response_headers_to_add",
+                    "type": "core.HeaderValueOption",
+                    "is_repeated": true
+                  },
+                  {
+                    "id": 6,
+                    "name": "response_headers_to_remove",
+                    "type": "string",
+                    "is_repeated": true
+                  }
+                ],
+                "maps": [
+                  {
+                    "key_type": "string",
+                    "field": {
+                      "id": 8,
+                      "name": "per_filter_config",
+                      "type": "google.protobuf.Struct"
+                    }
+                  }
+                ],
+                "reserved_ids": [
+                  7
+                ]
+              }
+            ]
+          },
+          {
+            "name": "RouteMatch",
+            "fields": [
+              {
+                "id": 1,
+                "name": "prefix",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "regex",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "case_sensitive",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 5,
+                "name": "runtime",
+                "type": "core.RuntimeUInt32"
+              },
+              {
+                "id": 6,
+                "name": "headers",
+                "type": "HeaderMatcher",
+                "is_repeated": true
+              },
+              {
+                "id": 7,
+                "name": "query_parameters",
+                "type": "QueryParameterMatcher",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "CorsPolicy",
+            "fields": [
+              {
+                "id": 1,
+                "name": "allow_origin",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "allow_methods",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "allow_headers",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "expose_headers",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "max_age",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "allow_credentials",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 7,
+                "name": "enabled",
+                "type": "google.protobuf.BoolValue"
+              }
+            ]
+          },
+          {
+            "name": "RouteAction",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cluster",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "cluster_header",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "weighted_clusters",
+                "type": "WeightedCluster"
+              },
+              {
+                "id": 20,
+                "name": "cluster_not_found_response_code",
+                "type": "ClusterNotFoundResponseCode"
+              },
+              {
+                "id": 4,
+                "name": "metadata_match",
+                "type": "core.Metadata"
+              },
+              {
+                "id": 5,
+                "name": "prefix_rewrite",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "host_rewrite",
+                "type": "string"
+              },
+              {
+                "id": 7,
+                "name": "auto_host_rewrite",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 8,
+                "name": "timeout",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 9,
+                "name": "retry_policy",
+                "type": "RetryPolicy"
+              },
+              {
+                "id": 10,
+                "name": "request_mirror_policy",
+                "type": "RequestMirrorPolicy"
+              },
+              {
+                "id": 11,
+                "name": "priority",
+                "type": "core.RoutingPriority"
+              },
+              {
+                "id": 12,
+                "name": "request_headers_to_add",
+                "type": "core.HeaderValueOption",
+                "is_repeated": true
+              },
+              {
+                "id": 18,
+                "name": "response_headers_to_add",
+                "type": "core.HeaderValueOption",
+                "is_repeated": true
+              },
+              {
+                "id": 19,
+                "name": "response_headers_to_remove",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 13,
+                "name": "rate_limits",
+                "type": "RateLimit",
+                "is_repeated": true
+              },
+              {
+                "id": 14,
+                "name": "include_vh_rate_limits",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 15,
+                "name": "hash_policy",
+                "type": "HashPolicy",
+                "is_repeated": true
+              },
+              {
+                "id": 16,
+                "name": "use_websocket",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 22,
+                "name": "websocket_config",
+                "type": "WebSocketProxyConfig"
+              },
+              {
+                "id": 17,
+                "name": "cors",
+                "type": "CorsPolicy"
+              },
+              {
+                "id": 23,
+                "name": "max_grpc_timeout",
+                "type": "google.protobuf.Duration"
+              }
+            ],
+            "reserved_ids": [
+              21
+            ],
+            "messages": [
+              {
+                "name": "RetryPolicy",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "retry_on",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "num_retries",
+                    "type": "google.protobuf.UInt32Value"
+                  },
+                  {
+                    "id": 3,
+                    "name": "per_try_timeout",
+                    "type": "google.protobuf.Duration"
+                  }
+                ]
+              },
+              {
+                "name": "RequestMirrorPolicy",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "cluster",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "runtime_key",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "name": "HashPolicy",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "header",
+                    "type": "Header"
+                  },
+                  {
+                    "id": 2,
+                    "name": "cookie",
+                    "type": "Cookie"
+                  },
+                  {
+                    "id": 3,
+                    "name": "connection_properties",
+                    "type": "ConnectionProperties"
+                  }
+                ],
+                "messages": [
+                  {
+                    "name": "Header",
+                    "fields": [
+                      {
+                        "id": 1,
+                        "name": "header_name",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "Cookie",
+                    "fields": [
+                      {
+                        "id": 1,
+                        "name": "name",
+                        "type": "string"
+                      },
+                      {
+                        "id": 2,
+                        "name": "ttl",
+                        "type": "google.protobuf.Duration"
+                      },
+                      {
+                        "id": 3,
+                        "name": "path",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "ConnectionProperties",
+                    "fields": [
+                      {
+                        "id": 1,
+                        "name": "source_ip",
+                        "type": "bool"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "WebSocketProxyConfig",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "stat_prefix",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "idle_timeout",
+                    "type": "google.protobuf.Duration"
+                  },
+                  {
+                    "id": 3,
+                    "name": "max_connect_attempts",
+                    "type": "google.protobuf.UInt32Value"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "RedirectAction",
+            "fields": [
+              {
+                "id": 1,
+                "name": "host_redirect",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "path_redirect",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "prefix_rewrite",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "response_code",
+                "type": "RedirectResponseCode"
+              },
+              {
+                "id": 4,
+                "name": "https_redirect",
+                "type": "bool"
+              },
+              {
+                "id": 6,
+                "name": "strip_query",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "DirectResponseAction",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "uint32"
+              },
+              {
+                "id": 2,
+                "name": "body",
+                "type": "core.DataSource"
+              }
+            ]
+          },
+          {
+            "name": "Decorator",
+            "fields": [
+              {
+                "id": 1,
+                "name": "operation",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "VirtualCluster",
+            "fields": [
+              {
+                "id": 1,
+                "name": "pattern",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "method",
+                "type": "core.RequestMethod"
+              }
+            ]
+          },
+          {
+            "name": "RateLimit",
+            "fields": [
+              {
+                "id": 1,
+                "name": "stage",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 2,
+                "name": "disable_key",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "actions",
+                "type": "Action",
+                "is_repeated": true
+              }
+            ],
+            "messages": [
+              {
+                "name": "Action",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "source_cluster",
+                    "type": "SourceCluster"
+                  },
+                  {
+                    "id": 2,
+                    "name": "destination_cluster",
+                    "type": "DestinationCluster"
+                  },
+                  {
+                    "id": 3,
+                    "name": "request_headers",
+                    "type": "RequestHeaders"
+                  },
+                  {
+                    "id": 4,
+                    "name": "remote_address",
+                    "type": "RemoteAddress"
+                  },
+                  {
+                    "id": 5,
+                    "name": "generic_key",
+                    "type": "GenericKey"
+                  },
+                  {
+                    "id": 6,
+                    "name": "header_value_match",
+                    "type": "HeaderValueMatch"
+                  }
+                ],
+                "messages": [
+                  {
+                    "name": "SourceCluster"
+                  },
+                  {
+                    "name": "DestinationCluster"
+                  },
+                  {
+                    "name": "RequestHeaders",
+                    "fields": [
+                      {
+                        "id": 1,
+                        "name": "header_name",
+                        "type": "string"
+                      },
+                      {
+                        "id": 2,
+                        "name": "descriptor_key",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "RemoteAddress"
+                  },
+                  {
+                    "name": "GenericKey",
+                    "fields": [
+                      {
+                        "id": 1,
+                        "name": "descriptor_value",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "HeaderValueMatch",
+                    "fields": [
+                      {
+                        "id": 1,
+                        "name": "descriptor_value",
+                        "type": "string"
+                      },
+                      {
+                        "id": 2,
+                        "name": "expect_match",
+                        "type": "google.protobuf.BoolValue"
+                      },
+                      {
+                        "id": 3,
+                        "name": "headers",
+                        "type": "HeaderMatcher",
+                        "is_repeated": true
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "HeaderMatcher",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "value",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "regex",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 4,
+                "name": "exact_match",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "regex_match",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "range_match",
+                "type": "envoy.type.Int64Range"
+              },
+              {
+                "id": 7,
+                "name": "present_match",
+                "type": "bool"
+              },
+              {
+                "id": 9,
+                "name": "prefix_match",
+                "type": "string"
+              },
+              {
+                "id": 10,
+                "name": "suffix_match",
+                "type": "string"
+              },
+              {
+                "id": 8,
+                "name": "invert_match",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "QueryParameterMatcher",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "value",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "regex",
+                "type": "google.protobuf.BoolValue"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:service:/:discovery:/:v2:/:sds.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "SdsDummy"
+          }
+        ],
+        "services": [
+          {
+            "name": "SecretDiscoveryService",
+            "rpcs": [
+              {
+                "name": "StreamSecrets",
+                "in_type": "envoy.api.v2.DiscoveryRequest",
+                "out_type": "envoy.api.v2.DiscoveryResponse",
+                "in_streamed": true,
+                "out_streamed": true
+              },
+              {
+                "name": "FetchSecrets",
+                "in_type": "envoy.api.v2.DiscoveryRequest",
+                "out_type": "envoy.api.v2.DiscoveryResponse"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:type:/:range.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "Int64Range",
+            "fields": [
+              {
+                "id": 1,
+                "name": "start",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "end",
+                "type": "int64"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:core:/:address.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "SocketAddress.Protocol",
+            "enum_fields": [
+              {
+                "name": "TCP",
+                "integer": 0
+              },
+              {
+                "name": "UDP",
+                "integer": 1
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "Pipe",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "SocketAddress",
+            "fields": [
+              {
+                "id": 1,
+                "name": "protocol",
+                "type": "Protocol"
+              },
+              {
+                "id": 2,
+                "name": "address",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "port_value",
+                "type": "uint32"
+              },
+              {
+                "id": 4,
+                "name": "named_port",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "resolver_name",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "ipv4_compat",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "TcpKeepalive",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keepalive_probes",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 2,
+                "name": "keepalive_time",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 3,
+                "name": "keepalive_interval",
+                "type": "google.protobuf.UInt32Value"
+              }
+            ]
+          },
+          {
+            "name": "BindConfig",
+            "fields": [
+              {
+                "id": 1,
+                "name": "source_address",
+                "type": "SocketAddress"
+              },
+              {
+                "id": 2,
+                "name": "freebind",
+                "type": "google.protobuf.BoolValue"
+              }
+            ]
+          },
+          {
+            "name": "Address",
+            "fields": [
+              {
+                "id": 1,
+                "name": "socket_address",
+                "type": "SocketAddress"
+              },
+              {
+                "id": 2,
+                "name": "pipe",
+                "type": "Pipe"
+              }
+            ]
+          },
+          {
+            "name": "CidrRange",
+            "fields": [
+              {
+                "id": 1,
+                "name": "address_prefix",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "prefix_len",
+                "type": "google.protobuf.UInt32Value"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:http:/:header_to_metadata:/:v2:/:header_to_metadata.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "Config.ValueType",
+            "enum_fields": [
+              {
+                "name": "STRING",
+                "integer": 0
+              },
+              {
+                "name": "NUMBER",
+                "integer": 1
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "Config",
+            "fields": [
+              {
+                "id": 1,
+                "name": "request_rules",
+                "type": "Rule",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "response_rules",
+                "type": "Rule",
+                "is_repeated": true
+              }
+            ],
+            "messages": [
+              {
+                "name": "KeyValuePair",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "metadata_namespace",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "key",
+                    "type": "string"
+                  },
+                  {
+                    "id": 3,
+                    "name": "value",
+                    "type": "string"
+                  },
+                  {
+                    "id": 4,
+                    "name": "type",
+                    "type": "ValueType"
+                  }
+                ]
+              },
+              {
+                "name": "Rule",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "header",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "on_header_present",
+                    "type": "KeyValuePair"
+                  },
+                  {
+                    "id": 3,
+                    "name": "on_header_missing",
+                    "type": "KeyValuePair"
+                  },
+                  {
+                    "id": 4,
+                    "name": "remove",
+                    "type": "bool"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:grpc_credential:/:v2alpha:/:file_based_metadata.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "FileBasedMetadataConfig",
+            "fields": [
+              {
+                "id": 1,
+                "name": "secret_data",
+                "type": "envoy.api.v2.core.DataSource"
+              },
+              {
+                "id": 2,
+                "name": "header_key",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "header_prefix",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:type:/:percent.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "FractionalPercent.DenominatorType",
+            "enum_fields": [
+              {
+                "name": "HUNDRED",
+                "integer": 0
+              },
+              {
+                "name": "TEN_THOUSAND",
+                "integer": 1
+              },
+              {
+                "name": "MILLION",
+                "integer": 2
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "Percent",
+            "fields": [
+              {
+                "id": 1,
+                "name": "value",
+                "type": "double"
+              }
+            ]
+          },
+          {
+            "name": "FractionalPercent",
+            "fields": [
+              {
+                "id": 1,
+                "name": "numerator",
+                "type": "uint32"
+              },
+              {
+                "id": 2,
+                "name": "denominator",
+                "type": "DenominatorType"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:endpoint:/:load_report.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "UpstreamLocalityStats",
+            "fields": [
+              {
+                "id": 1,
+                "name": "locality",
+                "type": "core.Locality"
+              },
+              {
+                "id": 2,
+                "name": "total_successful_requests",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "total_requests_in_progress",
+                "type": "uint64"
+              },
+              {
+                "id": 4,
+                "name": "total_error_requests",
+                "type": "uint64"
+              },
+              {
+                "id": 5,
+                "name": "load_metric_stats",
+                "type": "EndpointLoadMetricStats",
+                "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "priority",
+                "type": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "EndpointLoadMetricStats",
+            "fields": [
+              {
+                "id": 1,
+                "name": "metric_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "num_requests_finished_with_metric",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "total_metric_value",
+                "type": "double"
+              }
+            ]
+          },
+          {
+            "name": "ClusterStats",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cluster_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "upstream_locality_stats",
+                "type": "UpstreamLocalityStats",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "total_dropped_requests",
+                "type": "uint64"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:http:/:fault:/:v2:/:fault.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "FaultAbort",
+            "fields": [
+              {
+                "id": 1,
+                "name": "percent",
+                "type": "uint32"
+              },
+              {
+                "id": 2,
+                "name": "http_status",
+                "type": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "HTTPFault",
+            "fields": [
+              {
+                "id": 1,
+                "name": "delay",
+                "type": "envoy.config.filter.fault.v2.FaultDelay"
+              },
+              {
+                "id": 2,
+                "name": "abort",
+                "type": "FaultAbort"
+              },
+              {
+                "id": 3,
+                "name": "upstream_cluster",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "headers",
+                "type": "envoy.api.v2.route.HeaderMatcher",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "downstream_nodes",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:http:/:gzip:/:v2:/:gzip.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "CompressionLevel.Enum",
+            "enum_fields": [
+              {
+                "name": "DEFAULT",
+                "integer": 0
+              },
+              {
+                "name": "BEST",
+                "integer": 1
+              },
+              {
+                "name": "SPEED",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "Gzip.CompressionStrategy",
+            "enum_fields": [
+              {
+                "name": "DEFAULT",
+                "integer": 0
+              },
+              {
+                "name": "FILTERED",
+                "integer": 1
+              },
+              {
+                "name": "HUFFMAN",
+                "integer": 2
+              },
+              {
+                "name": "RLE",
+                "integer": 3
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "Gzip",
+            "fields": [
+              {
+                "id": 1,
+                "name": "memory_level",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 2,
+                "name": "content_length",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 3,
+                "name": "compression_level",
+                "type": "CompressionLevel.Enum"
+              },
+              {
+                "id": 4,
+                "name": "compression_strategy",
+                "type": "CompressionStrategy"
+              },
+              {
+                "id": 6,
+                "name": "content_type",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 7,
+                "name": "disable_on_etag_header",
+                "type": "bool"
+              },
+              {
+                "id": 8,
+                "name": "remove_accept_encoding_header",
+                "type": "bool"
+              },
+              {
+                "id": 9,
+                "name": "window_bits",
+                "type": "google.protobuf.UInt32Value"
+              }
+            ],
+            "messages": [
+              {
+                "name": "CompressionLevel"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:rbac:/:v2alpha:/:rbac.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "RBAC.Action",
+            "enum_fields": [
+              {
+                "name": "ALLOW",
+                "integer": 0
+              },
+              {
+                "name": "DENY",
+                "integer": 1
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "RBAC",
+            "fields": [
+              {
+                "id": 1,
+                "name": "action",
+                "type": "Action"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "policies",
+                  "type": "Policy"
+                }
+              }
+            ]
+          },
+          {
+            "name": "Policy",
+            "fields": [
+              {
+                "id": 1,
+                "name": "permissions",
+                "type": "Permission",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "principals",
+                "type": "Principal",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "Permission",
+            "fields": [
+              {
+                "id": 1,
+                "name": "and_rules",
+                "type": "Set"
+              },
+              {
+                "id": 2,
+                "name": "or_rules",
+                "type": "Set"
+              },
+              {
+                "id": 3,
+                "name": "any",
+                "type": "bool"
+              },
+              {
+                "id": 4,
+                "name": "header",
+                "type": "envoy.api.v2.route.HeaderMatcher"
+              },
+              {
+                "id": 5,
+                "name": "destination_ip",
+                "type": "envoy.api.v2.core.CidrRange"
+              },
+              {
+                "id": 6,
+                "name": "destination_port",
+                "type": "uint32"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Set",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "rules",
+                    "type": "Permission",
+                    "is_repeated": true
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Principal",
+            "fields": [
+              {
+                "id": 1,
+                "name": "and_ids",
+                "type": "Set"
+              },
+              {
+                "id": 2,
+                "name": "or_ids",
+                "type": "Set"
+              },
+              {
+                "id": 3,
+                "name": "any",
+                "type": "bool"
+              },
+              {
+                "id": 4,
+                "name": "authenticated",
+                "type": "Authenticated"
+              },
+              {
+                "id": 5,
+                "name": "source_ip",
+                "type": "envoy.api.v2.core.CidrRange"
+              },
+              {
+                "id": 6,
+                "name": "header",
+                "type": "envoy.api.v2.route.HeaderMatcher"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Set",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "ids",
+                    "type": "Principal",
+                    "is_repeated": true
+                  }
+                ]
+              },
+              {
+                "name": "Authenticated",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:data:/:tap:/:v2alpha:/:capture.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "Connection",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "uint64"
+              },
+              {
+                "id": 2,
+                "name": "local_address",
+                "type": "envoy.api.v2.core.Address"
+              },
+              {
+                "id": 3,
+                "name": "remote_address",
+                "type": "envoy.api.v2.core.Address"
+              }
+            ]
+          },
+          {
+            "name": "Event",
+            "fields": [
+              {
+                "id": 1,
+                "name": "timestamp",
+                "type": "google.protobuf.Timestamp"
+              },
+              {
+                "id": 2,
+                "name": "read",
+                "type": "Read"
+              },
+              {
+                "id": 3,
+                "name": "write",
+                "type": "Write"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Read",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "data",
+                    "type": "bytes"
+                  }
+                ]
+              },
+              {
+                "name": "Write",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "data",
+                    "type": "bytes"
+                  },
+                  {
+                    "id": 2,
+                    "name": "end_stream",
+                    "type": "bool"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Trace",
+            "fields": [
+              {
+                "id": 1,
+                "name": "connection",
+                "type": "Connection"
+              },
+              {
+                "id": 2,
+                "name": "events",
+                "type": "Event",
+                "is_repeated": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:cluster:/:outlier_detection.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "OutlierDetection",
+            "fields": [
+              {
+                "id": 1,
+                "name": "consecutive_5xx",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 2,
+                "name": "interval",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 3,
+                "name": "base_ejection_time",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 4,
+                "name": "max_ejection_percent",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 5,
+                "name": "enforcing_consecutive_5xx",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 6,
+                "name": "enforcing_success_rate",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 7,
+                "name": "success_rate_minimum_hosts",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 8,
+                "name": "success_rate_request_volume",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 9,
+                "name": "success_rate_stdev_factor",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 10,
+                "name": "consecutive_gateway_failure",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 11,
+                "name": "enforcing_consecutive_gateway_failure",
+                "type": "google.protobuf.UInt32Value"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:eds.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "ClusterLoadAssignment",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cluster_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "endpoints",
+                "type": "endpoint.LocalityLbEndpoints",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "policy",
+                "type": "Policy"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Policy",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "drop_overload",
+                    "type": "double"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "EndpointDiscoveryService",
+            "rpcs": [
+              {
+                "name": "StreamEndpoints",
+                "in_type": "DiscoveryRequest",
+                "out_type": "DiscoveryResponse",
+                "in_streamed": true,
+                "out_streamed": true
+              },
+              {
+                "name": "FetchEndpoints",
+                "in_type": "DiscoveryRequest",
+                "out_type": "DiscoveryResponse"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:trace:/:v2:/:trace.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "Tracing",
+            "fields": [
+              {
+                "id": 1,
+                "name": "http",
+                "type": "Http"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Http",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "name",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "config",
+                    "type": "google.protobuf.Struct"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "LightstepConfig",
+            "fields": [
+              {
+                "id": 1,
+                "name": "collector_cluster",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "access_token_file",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ZipkinConfig",
+            "fields": [
+              {
+                "id": 1,
+                "name": "collector_cluster",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "collector_endpoint",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "trace_id_128bit",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "DynamicOtConfig",
+            "fields": [
+              {
+                "id": 1,
+                "name": "library",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "config",
+                "type": "google.protobuf.Struct"
+              }
+            ]
+          },
+          {
+            "name": "TraceServiceConfig",
+            "fields": [
+              {
+                "id": 1,
+                "name": "grpc_service",
+                "type": "envoy.api.v2.core.GrpcService"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:auth:/:cert.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "TlsParameters.TlsProtocol",
+            "enum_fields": [
+              {
+                "name": "TLS_AUTO",
+                "integer": 0
+              },
+              {
+                "name": "TLSv1_0",
+                "integer": 1
+              },
+              {
+                "name": "TLSv1_1",
+                "integer": 2
+              },
+              {
+                "name": "TLSv1_2",
+                "integer": 3
+              },
+              {
+                "name": "TLSv1_3",
+                "integer": 4
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "TlsParameters",
+            "fields": [
+              {
+                "id": 1,
+                "name": "tls_minimum_protocol_version",
+                "type": "TlsProtocol"
+              },
+              {
+                "id": 2,
+                "name": "tls_maximum_protocol_version",
+                "type": "TlsProtocol"
+              },
+              {
+                "id": 3,
+                "name": "cipher_suites",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "ecdh_curves",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "TlsCertificate",
+            "fields": [
+              {
+                "id": 1,
+                "name": "certificate_chain",
+                "type": "core.DataSource"
+              },
+              {
+                "id": 2,
+                "name": "private_key",
+                "type": "core.DataSource"
+              },
+              {
+                "id": 3,
+                "name": "password",
+                "type": "core.DataSource"
+              },
+              {
+                "id": 4,
+                "name": "ocsp_staple",
+                "type": "core.DataSource"
+              },
+              {
+                "id": 5,
+                "name": "signed_certificate_timestamp",
+                "type": "core.DataSource",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "TlsSessionTicketKeys",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keys",
+                "type": "core.DataSource",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "CertificateValidationContext",
+            "fields": [
+              {
+                "id": 1,
+                "name": "trusted_ca",
+                "type": "core.DataSource"
+              },
+              {
+                "id": 3,
+                "name": "verify_certificate_spki",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "verify_certificate_hash",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "verify_subject_alt_name",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "require_ocsp_staple",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 6,
+                "name": "require_signed_certificate_timestamp",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 7,
+                "name": "crl",
+                "type": "core.DataSource"
+              },
+              {
+                "id": 8,
+                "name": "allow_expired_certificate",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "CommonTlsContext",
+            "fields": [
+              {
+                "id": 1,
+                "name": "tls_params",
+                "type": "TlsParameters"
+              },
+              {
+                "id": 2,
+                "name": "tls_certificates",
+                "type": "TlsCertificate",
+                "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "tls_certificate_sds_secret_configs",
+                "type": "SdsSecretConfig",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "validation_context",
+                "type": "CertificateValidationContext"
+              },
+              {
+                "id": 7,
+                "name": "validation_context_sds_secret_config",
+                "type": "SdsSecretConfig"
+              },
+              {
+                "id": 4,
+                "name": "alpn_protocols",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "deprecated_v1",
+                "type": "DeprecatedV1"
+              }
+            ],
+            "messages": [
+              {
+                "name": "DeprecatedV1",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "alt_alpn_protocols",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "UpstreamTlsContext",
+            "fields": [
+              {
+                "id": 1,
+                "name": "common_tls_context",
+                "type": "CommonTlsContext"
+              },
+              {
+                "id": 2,
+                "name": "sni",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "allow_renegotiation",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "DownstreamTlsContext",
+            "fields": [
+              {
+                "id": 1,
+                "name": "common_tls_context",
+                "type": "CommonTlsContext"
+              },
+              {
+                "id": 2,
+                "name": "require_client_certificate",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 3,
+                "name": "require_sni",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 4,
+                "name": "session_ticket_keys",
+                "type": "TlsSessionTicketKeys"
+              },
+              {
+                "id": 5,
+                "name": "session_ticket_keys_sds_secret_config",
+                "type": "SdsSecretConfig"
+              }
+            ]
+          },
+          {
+            "name": "SdsSecretConfig",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "sds_config",
+                "type": "core.ConfigSource"
+              }
+            ]
+          },
+          {
+            "name": "Secret",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "tls_certificate",
+                "type": "TlsCertificate"
+              },
+              {
+                "id": 3,
+                "name": "session_ticket_keys",
+                "type": "TlsSessionTicketKeys"
+              },
+              {
+                "id": 4,
+                "name": "validation_context",
+                "type": "CertificateValidationContext"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:core:/:base.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "RoutingPriority",
+            "enum_fields": [
+              {
+                "name": "DEFAULT",
+                "integer": 0
+              },
+              {
+                "name": "HIGH",
+                "integer": 1
+              }
+            ]
+          },
+          {
+            "name": "RequestMethod",
+            "enum_fields": [
+              {
+                "name": "METHOD_UNSPECIFIED",
+                "integer": 0
+              },
+              {
+                "name": "GET",
+                "integer": 1
+              },
+              {
+                "name": "HEAD",
+                "integer": 2
+              },
+              {
+                "name": "POST",
+                "integer": 3
+              },
+              {
+                "name": "PUT",
+                "integer": 4
+              },
+              {
+                "name": "DELETE",
+                "integer": 5
+              },
+              {
+                "name": "CONNECT",
+                "integer": 6
+              },
+              {
+                "name": "OPTIONS",
+                "integer": 7
+              },
+              {
+                "name": "TRACE",
+                "integer": 8
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "Locality",
+            "fields": [
+              {
+                "id": 1,
+                "name": "region",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "zone",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "sub_zone",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Node",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "cluster",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "metadata",
+                "type": "google.protobuf.Struct"
+              },
+              {
+                "id": 4,
+                "name": "locality",
+                "type": "Locality"
+              },
+              {
+                "id": 5,
+                "name": "build_version",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Metadata",
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 1,
+                  "name": "filter_metadata",
+                  "type": "google.protobuf.Struct"
+                }
+              }
+            ]
+          },
+          {
+            "name": "RuntimeUInt32",
+            "fields": [
+              {
+                "id": 2,
+                "name": "default_value",
+                "type": "uint32"
+              },
+              {
+                "id": 3,
+                "name": "runtime_key",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "HeaderValue",
+            "fields": [
+              {
+                "id": 1,
+                "name": "key",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "value",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "HeaderValueOption",
+            "fields": [
+              {
+                "id": 1,
+                "name": "header",
+                "type": "HeaderValue"
+              },
+              {
+                "id": 2,
+                "name": "append",
+                "type": "google.protobuf.BoolValue"
+              }
+            ]
+          },
+          {
+            "name": "DataSource",
+            "fields": [
+              {
+                "id": 1,
+                "name": "filename",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "inline_bytes",
+                "type": "bytes"
+              },
+              {
+                "id": 3,
+                "name": "inline_string",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "TransportSocket",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "config",
+                "type": "google.protobuf.Struct"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:core:/:grpc_service.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "GrpcService",
+            "fields": [
+              {
+                "id": 1,
+                "name": "envoy_grpc",
+                "type": "EnvoyGrpc"
+              },
+              {
+                "id": 2,
+                "name": "google_grpc",
+                "type": "GoogleGrpc"
+              },
+              {
+                "id": 3,
+                "name": "timeout",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 5,
+                "name": "initial_metadata",
+                "type": "HeaderValue",
+                "is_repeated": true
+              }
+            ],
+            "reserved_ids": [
+              4
+            ],
+            "messages": [
+              {
+                "name": "EnvoyGrpc",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "cluster_name",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "name": "GoogleGrpc",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "target_uri",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "channel_credentials",
+                    "type": "ChannelCredentials"
+                  },
+                  {
+                    "id": 3,
+                    "name": "call_credentials",
+                    "type": "CallCredentials",
+                    "is_repeated": true
+                  },
+                  {
+                    "id": 4,
+                    "name": "stat_prefix",
+                    "type": "string"
+                  },
+                  {
+                    "id": 5,
+                    "name": "credentials_factory_name",
+                    "type": "string"
+                  },
+                  {
+                    "id": 6,
+                    "name": "config",
+                    "type": "google.protobuf.Struct"
+                  }
+                ],
+                "messages": [
+                  {
+                    "name": "SslCredentials",
+                    "fields": [
+                      {
+                        "id": 1,
+                        "name": "root_certs",
+                        "type": "DataSource"
+                      },
+                      {
+                        "id": 2,
+                        "name": "private_key",
+                        "type": "DataSource"
+                      },
+                      {
+                        "id": 3,
+                        "name": "cert_chain",
+                        "type": "DataSource"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "ChannelCredentials",
+                    "fields": [
+                      {
+                        "id": 1,
+                        "name": "ssl_credentials",
+                        "type": "SslCredentials"
+                      },
+                      {
+                        "id": 2,
+                        "name": "google_default",
+                        "type": "google.protobuf.Empty"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "CallCredentials",
+                    "fields": [
+                      {
+                        "id": 1,
+                        "name": "access_token",
+                        "type": "string"
+                      },
+                      {
+                        "id": 2,
+                        "name": "google_compute_engine",
+                        "type": "google.protobuf.Empty"
+                      },
+                      {
+                        "id": 3,
+                        "name": "google_refresh_token",
+                        "type": "string"
+                      },
+                      {
+                        "id": 4,
+                        "name": "service_account_jwt_access",
+                        "type": "ServiceAccountJWTAccessCredentials"
+                      },
+                      {
+                        "id": 5,
+                        "name": "google_iam",
+                        "type": "GoogleIAMCredentials"
+                      },
+                      {
+                        "id": 6,
+                        "name": "from_plugin",
+                        "type": "MetadataCredentialsFromPlugin"
+                      }
+                    ],
+                    "messages": [
+                      {
+                        "name": "ServiceAccountJWTAccessCredentials",
+                        "fields": [
+                          {
+                            "id": 1,
+                            "name": "json_key",
+                            "type": "string"
+                          },
+                          {
+                            "id": 2,
+                            "name": "token_lifetime_seconds",
+                            "type": "uint64"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "GoogleIAMCredentials",
+                        "fields": [
+                          {
+                            "id": 1,
+                            "name": "authorization_token",
+                            "type": "string"
+                          },
+                          {
+                            "id": 2,
+                            "name": "authority_selector",
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "MetadataCredentialsFromPlugin",
+                        "fields": [
+                          {
+                            "id": 1,
+                            "name": "name",
+                            "type": "string"
+                          },
+                          {
+                            "id": 2,
+                            "name": "config",
+                            "type": "google.protobuf.Struct"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:accesslog:/:v2:/:file.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "FileAccessLog",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "format",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:bootstrap:/:v2:/:bootstrap.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "Bootstrap",
+            "fields": [
+              {
+                "id": 1,
+                "name": "node",
+                "type": "envoy.api.v2.core.Node"
+              },
+              {
+                "id": 2,
+                "name": "static_resources",
+                "type": "StaticResources"
+              },
+              {
+                "id": 3,
+                "name": "dynamic_resources",
+                "type": "DynamicResources"
+              },
+              {
+                "id": 4,
+                "name": "cluster_manager",
+                "type": "ClusterManager"
+              },
+              {
+                "id": 5,
+                "name": "flags_path",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "stats_sinks",
+                "type": "envoy.config.metrics.v2.StatsSink",
+                "is_repeated": true
+              },
+              {
+                "id": 13,
+                "name": "stats_config",
+                "type": "envoy.config.metrics.v2.StatsConfig"
+              },
+              {
+                "id": 7,
+                "name": "stats_flush_interval",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 8,
+                "name": "watchdog",
+                "type": "Watchdog"
+              },
+              {
+                "id": 9,
+                "name": "tracing",
+                "type": "envoy.config.trace.v2.Tracing"
+              },
+              {
+                "id": 10,
+                "name": "rate_limit_service",
+                "type": "envoy.config.ratelimit.v2.RateLimitServiceConfig"
+              },
+              {
+                "id": 11,
+                "name": "runtime",
+                "type": "Runtime"
+              },
+              {
+                "id": 12,
+                "name": "admin",
+                "type": "Admin"
+              }
+            ],
+            "messages": [
+              {
+                "name": "StaticResources",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "listeners",
+                    "type": "envoy.api.v2.Listener",
+                    "is_repeated": true
+                  },
+                  {
+                    "id": 2,
+                    "name": "clusters",
+                    "type": "envoy.api.v2.Cluster",
+                    "is_repeated": true
+                  },
+                  {
+                    "id": 3,
+                    "name": "secrets",
+                    "type": "envoy.api.v2.auth.Secret",
+                    "is_repeated": true
+                  }
+                ]
+              },
+              {
+                "name": "DynamicResources",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "lds_config",
+                    "type": "envoy.api.v2.core.ConfigSource"
+                  },
+                  {
+                    "id": 2,
+                    "name": "cds_config",
+                    "type": "envoy.api.v2.core.ConfigSource"
+                  },
+                  {
+                    "id": 3,
+                    "name": "ads_config",
+                    "type": "envoy.api.v2.core.ApiConfigSource"
+                  },
+                  {
+                    "id": 4,
+                    "name": "deprecated_v1",
+                    "type": "DeprecatedV1"
+                  }
+                ],
+                "messages": [
+                  {
+                    "name": "DeprecatedV1",
+                    "fields": [
+                      {
+                        "id": 1,
+                        "name": "sds_config",
+                        "type": "envoy.api.v2.core.ConfigSource"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Admin",
+            "fields": [
+              {
+                "id": 1,
+                "name": "access_log_path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "profile_path",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "address",
+                "type": "envoy.api.v2.core.Address"
+              }
+            ]
+          },
+          {
+            "name": "ClusterManager",
+            "fields": [
+              {
+                "id": 1,
+                "name": "local_cluster_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "outlier_detection",
+                "type": "OutlierDetection"
+              },
+              {
+                "id": 3,
+                "name": "upstream_bind_config",
+                "type": "envoy.api.v2.core.BindConfig"
+              },
+              {
+                "id": 4,
+                "name": "load_stats_config",
+                "type": "envoy.api.v2.core.ApiConfigSource"
+              }
+            ],
+            "messages": [
+              {
+                "name": "OutlierDetection",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "event_log_path",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Watchdog",
+            "fields": [
+              {
+                "id": 1,
+                "name": "miss_timeout",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 2,
+                "name": "megamiss_timeout",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 3,
+                "name": "kill_timeout",
+                "type": "google.protobuf.Duration"
+              },
+              {
+                "id": 4,
+                "name": "multikill_timeout",
+                "type": "google.protobuf.Duration"
+              }
+            ]
+          },
+          {
+            "name": "Runtime",
+            "fields": [
+              {
+                "id": 1,
+                "name": "symlink_root",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "subdirectory",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "override_subdirectory",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:http:/:rbac:/:v2:/:rbac.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "RBAC",
+            "fields": [
+              {
+                "id": 1,
+                "name": "rules",
+                "type": "config.rbac.v2alpha.RBAC"
+              },
+              {
+                "id": 2,
+                "name": "shadow_rules",
+                "type": "config.rbac.v2alpha.RBAC"
+              }
+            ]
+          },
+          {
+            "name": "RBACPerRoute",
+            "fields": [
+              {
+                "id": 2,
+                "name": "rbac",
+                "type": "RBAC"
+              }
+            ],
+            "reserved_ids": [
+              1
+            ],
+            "reserved_names": [
+              "disabled"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:health_checker:/:redis:/:v2:/:redis.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "Redis",
+            "fields": [
+              {
+                "id": 1,
+                "name": "key",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:accesslog:/:v2:/:als.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "HttpGrpcAccessLogConfig",
+            "fields": [
+              {
+                "id": 1,
+                "name": "common_config",
+                "type": "CommonGrpcAccessLogConfig"
+              },
+              {
+                "id": 2,
+                "name": "additional_request_headers_to_log",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "additional_response_headers_to_log",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "additional_response_trailers_to_log",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "TcpGrpcAccessLogConfig",
+            "fields": [
+              {
+                "id": 1,
+                "name": "common_config",
+                "type": "CommonGrpcAccessLogConfig"
+              }
+            ]
+          },
+          {
+            "name": "CommonGrpcAccessLogConfig",
+            "fields": [
+              {
+                "id": 1,
+                "name": "log_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "grpc_service",
+                "type": "envoy.api.v2.core.GrpcService"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:http:/:buffer:/:v2:/:buffer.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "Buffer",
+            "fields": [
+              {
+                "id": 1,
+                "name": "max_request_bytes",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 2,
+                "name": "max_request_time",
+                "type": "google.protobuf.Duration"
+              }
+            ]
+          },
+          {
+            "name": "BufferPerRoute",
+            "fields": [
+              {
+                "id": 1,
+                "name": "disabled",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "buffer",
+                "type": "Buffer"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:http:/:lua:/:v2:/:lua.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "Lua",
+            "fields": [
+              {
+                "id": 1,
+                "name": "inline_code",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:service:/:ratelimit:/:v2:/:rls.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "RateLimitResponse.Code",
+            "enum_fields": [
+              {
+                "name": "UNKNOWN",
+                "integer": 0
+              },
+              {
+                "name": "OK",
+                "integer": 1
+              },
+              {
+                "name": "OVER_LIMIT",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "RateLimit.Unit",
+            "enum_fields": [
+              {
+                "name": "UNKNOWN",
+                "integer": 0
+              },
+              {
+                "name": "SECOND",
+                "integer": 1
+              },
+              {
+                "name": "MINUTE",
+                "integer": 2
+              },
+              {
+                "name": "HOUR",
+                "integer": 3
+              },
+              {
+                "name": "DAY",
+                "integer": 4
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "RateLimitRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "domain",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "descriptors",
+                "type": "envoy.api.v2.ratelimit.RateLimitDescriptor",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "hits_addend",
+                "type": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "RateLimitResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "overall_code",
+                "type": "Code"
+              },
+              {
+                "id": 2,
+                "name": "statuses",
+                "type": "DescriptorStatus",
+                "is_repeated": true
+              }
+            ],
+            "messages": [
+              {
+                "name": "RateLimit",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "requests_per_unit",
+                    "type": "uint32"
+                  },
+                  {
+                    "id": 2,
+                    "name": "unit",
+                    "type": "Unit"
+                  }
+                ]
+              },
+              {
+                "name": "DescriptorStatus",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "code",
+                    "type": "Code"
+                  },
+                  {
+                    "id": 2,
+                    "name": "current_limit",
+                    "type": "RateLimit"
+                  },
+                  {
+                    "id": 3,
+                    "name": "limit_remaining",
+                    "type": "uint32"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "RateLimitService",
+            "rpcs": [
+              {
+                "name": "ShouldRateLimit",
+                "in_type": "RateLimitRequest",
+                "out_type": "RateLimitResponse"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:http:/:router:/:v2:/:router.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "Router",
+            "fields": [
+              {
+                "id": 1,
+                "name": "dynamic_stats",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 2,
+                "name": "start_child_span",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "upstream_log",
+                "type": "envoy.config.filter.accesslog.v2.AccessLog",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "suppress_envoy_headers",
+                "type": "bool"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:service:/:load_stats:/:v2:/:lrs.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "LoadStatsRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "node",
+                "type": "envoy.api.v2.core.Node"
+              },
+              {
+                "id": 2,
+                "name": "cluster_stats",
+                "type": "envoy.api.v2.endpoint.ClusterStats",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "LoadStatsResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "clusters",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "load_reporting_interval",
+                "type": "google.protobuf.Duration"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "LoadReportingService",
+            "rpcs": [
+              {
+                "name": "StreamLoadStats",
+                "in_type": "LoadStatsRequest",
+                "out_type": "LoadStatsResponse",
+                "in_streamed": true,
+                "out_streamed": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:api:/:v2:/:core:/:protocol.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "TcpProtocolOptions"
+          },
+          {
+            "name": "HttpProtocolOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "idle_timeout",
+                "type": "google.protobuf.Duration"
+              }
+            ]
+          },
+          {
+            "name": "Http1ProtocolOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "allow_absolute_url",
+                "type": "google.protobuf.BoolValue"
+              },
+              {
+                "id": 2,
+                "name": "accept_http_10",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "default_host_for_http_10",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Http2ProtocolOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "hpack_table_size",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 2,
+                "name": "max_concurrent_streams",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 3,
+                "name": "initial_stream_window_size",
+                "type": "google.protobuf.UInt32Value"
+              },
+              {
+                "id": 4,
+                "name": "initial_connection_window_size",
+                "type": "google.protobuf.UInt32Value"
+              }
+            ]
+          },
+          {
+            "name": "GrpcProtocolOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "http2_protocol_options",
+                "type": "Http2ProtocolOptions"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:accesslog:/:v2:/:accesslog.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "ComparisonFilter.Op",
+            "enum_fields": [
+              {
+                "name": "EQ",
+                "integer": 0
+              },
+              {
+                "name": "GE",
+                "integer": 1
+              },
+              {
+                "name": "LE",
+                "integer": 2
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "AccessLog",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "filter",
+                "type": "AccessLogFilter"
+              },
+              {
+                "id": 3,
+                "name": "config",
+                "type": "google.protobuf.Struct"
+              }
+            ]
+          },
+          {
+            "name": "AccessLogFilter",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status_code_filter",
+                "type": "StatusCodeFilter"
+              },
+              {
+                "id": 2,
+                "name": "duration_filter",
+                "type": "DurationFilter"
+              },
+              {
+                "id": 3,
+                "name": "not_health_check_filter",
+                "type": "NotHealthCheckFilter"
+              },
+              {
+                "id": 4,
+                "name": "traceable_filter",
+                "type": "TraceableFilter"
+              },
+              {
+                "id": 5,
+                "name": "runtime_filter",
+                "type": "RuntimeFilter"
+              },
+              {
+                "id": 6,
+                "name": "and_filter",
+                "type": "AndFilter"
+              },
+              {
+                "id": 7,
+                "name": "or_filter",
+                "type": "OrFilter"
+              },
+              {
+                "id": 8,
+                "name": "header_filter",
+                "type": "HeaderFilter"
+              }
+            ]
+          },
+          {
+            "name": "ComparisonFilter",
+            "fields": [
+              {
+                "id": 1,
+                "name": "op",
+                "type": "Op"
+              },
+              {
+                "id": 2,
+                "name": "value",
+                "type": "envoy.api.v2.core.RuntimeUInt32"
+              }
+            ]
+          },
+          {
+            "name": "StatusCodeFilter",
+            "fields": [
+              {
+                "id": 1,
+                "name": "comparison",
+                "type": "ComparisonFilter"
+              }
+            ]
+          },
+          {
+            "name": "DurationFilter",
+            "fields": [
+              {
+                "id": 1,
+                "name": "comparison",
+                "type": "ComparisonFilter"
+              }
+            ]
+          },
+          {
+            "name": "NotHealthCheckFilter"
+          },
+          {
+            "name": "TraceableFilter"
+          },
+          {
+            "name": "RuntimeFilter",
+            "fields": [
+              {
+                "id": 1,
+                "name": "runtime_key",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "percent_sampled",
+                "type": "envoy.type.FractionalPercent"
+              },
+              {
+                "id": 3,
+                "name": "use_independent_randomness",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "AndFilter",
+            "fields": [
+              {
+                "id": 1,
+                "name": "filters",
+                "type": "AccessLogFilter",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "OrFilter",
+            "fields": [
+              {
+                "id": 2,
+                "name": "filters",
+                "type": "AccessLogFilter",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "HeaderFilter",
+            "fields": [
+              {
+                "id": 1,
+                "name": "header",
+                "type": "envoy.api.v2.route.HeaderMatcher"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:fault:/:v2:/:fault.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "FaultDelay.FaultDelayType",
+            "enum_fields": [
+              {
+                "name": "FIXED",
+                "integer": 0
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "FaultDelay",
+            "fields": [
+              {
+                "id": 1,
+                "name": "type",
+                "type": "FaultDelayType"
+              },
+              {
+                "id": 2,
+                "name": "percent",
+                "type": "uint32"
+              },
+              {
+                "id": 3,
+                "name": "fixed_delay",
+                "type": "google.protobuf.Duration"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:http:/:transcoder:/:v2:/:transcoder.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "GrpcJsonTranscoder",
+            "fields": [
+              {
+                "id": 1,
+                "name": "proto_descriptor",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "proto_descriptor_bin",
+                "type": "bytes"
+              },
+              {
+                "id": 2,
+                "name": "services",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "print_options",
+                "type": "PrintOptions"
+              },
+              {
+                "id": 5,
+                "name": "match_incoming_request_route",
+                "type": "bool"
+              }
+            ],
+            "messages": [
+              {
+                "name": "PrintOptions",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "add_whitespace",
+                    "type": "bool"
+                  },
+                  {
+                    "id": 2,
+                    "name": "always_print_primitive_fields",
+                    "type": "bool"
+                  },
+                  {
+                    "id": 3,
+                    "name": "always_print_enums_as_ints",
+                    "type": "bool"
+                  },
+                  {
+                    "id": 4,
+                    "name": "preserve_proto_field_names",
+                    "type": "bool"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:config:/:filter:/:network:/:rate_limit:/:v2:/:rate_limit.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "RateLimit",
+            "fields": [
+              {
+                "id": 1,
+                "name": "stat_prefix",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "domain",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "descriptors",
+                "type": "envoy.api.v2.ratelimit.RateLimitDescriptor",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "timeout",
+                "type": "google.protobuf.Duration"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "envoy:/:service:/:accesslog:/:v2:/:als.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "StreamAccessLogsResponse"
+          },
+          {
+            "name": "StreamAccessLogsMessage",
+            "fields": [
+              {
+                "id": 1,
+                "name": "identifier",
+                "type": "Identifier"
+              },
+              {
+                "id": 2,
+                "name": "http_logs",
+                "type": "HTTPAccessLogEntries"
+              },
+              {
+                "id": 3,
+                "name": "tcp_logs",
+                "type": "TCPAccessLogEntries"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Identifier",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "node",
+                    "type": "envoy.api.v2.core.Node"
+                  },
+                  {
+                    "id": 2,
+                    "name": "log_name",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "name": "HTTPAccessLogEntries",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "log_entry",
+                    "type": "envoy.data.accesslog.v2.HTTPAccessLogEntry",
+                    "is_repeated": true
+                  }
+                ]
+              },
+              {
+                "name": "TCPAccessLogEntries",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "log_entry",
+                    "type": "envoy.data.accesslog.v2.TCPAccessLogEntry",
+                    "is_repeated": true
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "AccessLogService",
+            "rpcs": [
+              {
+                "name": "StreamAccessLogs",
+                "in_type": "StreamAccessLogsMessage",
+                "out_type": "StreamAccessLogsResponse",
+                "in_streamed": true
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -130,12 +130,23 @@ elif [[ "$1" == "bazel.ipv6_tests" ]]; then
   exit 0
 elif [[ "$1" == "bazel.api" ]]; then
   setup_clang_toolchain
+ 
+  cd "${ENVOY_CI_DIR}"
+  cd ../api
+  curl https://github.com/nilslice/protolock/releases/download/0.6.0/protolock.20180621T191216Z.linux-amd64.tgz > protolock.tar.gz
+  tar xzf protolock.tar.gz
+  echo "Check protobuf API compatibilty..."
+  ./protolock status --ignore=v2alpha
+
   cd "${ENVOY_CI_DIR}"
   echo "Building API..."
   bazel --batch build ${BAZEL_BUILD_OPTIONS} -c fastbuild @envoy_api//envoy/...
   echo "Testing API..."
   bazel --batch test ${BAZEL_TEST_OPTIONS} -c fastbuild @envoy_api//test/... @envoy_api//tools/... \
     @envoy_api//tools:capture2pcap_test
+
+  protolock status --ignore=v2alpha
+
   exit 0
 elif [[ "$1" == "bazel.coverage" ]]; then
   setup_gcc_toolchain


### PR DESCRIPTION
*ci*: *add protolock tool to build step, checking envoy/api protos*

*Description*:
>What does this PR do? What was the behavior before the PR?

Add [`protolock`](https://github.com/nilslice/protolock) lock file to `api` directory and checks `api` protos for various breaking changes. Additionally, running protolock uncovered some syntax errors in a few of the validation options. 

Currently, the `v2alpha` path is the only set of protos ignored. This can be augmented for the case of experimental proto elements by marking them individually with a comment hint, i.e:
```protobuf
// @protolock:skip
message NextLevel_v3 {
// ...
}
```

*Risk Level*: Low 

*Testing*:
>Explanation of what testing was done, for example: unit test,
integration, manual testing, etc.

TODO: push a new branch with an example of an API breaking change within a locked proto. Once the tests run on CI, `protolock status --ignore=v2alpha` should report a warning and stop the build.

Fixes #3368