### PR TITLE
debug: improving symbolization further

### DIFF
--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -43,6 +43,9 @@ envoy_cc_library(
 envoy_cc_library(
     name = "envoy_main_entry_lib",
     srcs = ["main.cc"],
+    external_deps = [
+        "abseil_symbolize",
+    ],
     deps = [
         ":envoy_main_common_lib",
     ],

--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -10,6 +10,11 @@
  * after setting up command line options.
  */
 int main(int argc, char** argv) {
+#ifndef __APPLE__
+  // absl::Symbolize mostly works without this, but this improves corner case
+  // handling, such as running in a chroot jail.
+  absl::InitializeSymbolizer(argv[0]);
+#endif
   std::unique_ptr<Envoy::MainCommon> main_common;
 
   // Initialize the server's main context under a try/catch loop and simply return EXIT_FAILURE

--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -1,5 +1,7 @@
 #include "exe/main_common.h"
 
+#include "absl/debugging/symbolize.h"
+
 // NOLINT(namespace-envoy)
 
 /**

--- a/test/BUILD
+++ b/test/BUILD
@@ -20,6 +20,9 @@ envoy_cc_test_library(
         "main.cc",
         "test_runner.h",
     ],
+    external_deps = [
+        "abseil_symbolize",
+    ],
     deps = [
         "//source/common/common:logger_lib",
         "//source/common/common:thread_lib",

--- a/test/main.cc
+++ b/test/main.cc
@@ -2,6 +2,8 @@
 #include "test/test_common/environment.h"
 #include "test/test_runner.h"
 
+#include "absl/debugging/symbolize.h"
+
 #ifdef ENVOY_HANDLE_SIGNALS
 #include "exe/signal_action.h"
 #endif

--- a/test/main.cc
+++ b/test/main.cc
@@ -14,6 +14,9 @@ const char* __asan_default_options() {
 // The main entry point (and the rest of this file) should have no logic in it,
 // this allows overriding by site specific versions of main.cc.
 int main(int argc, char** argv) {
+#ifndef __APPLE__
+  absl::InitializeSymbolizer(argv[0]);
+#endif
 #ifdef ENVOY_HANDLE_SIGNALS
   // Enabled by default. Control with "bazel --define=signal_trace=disabled"
   Envoy::SignalAction handle_sigs;


### PR DESCRIPTION
Initializing absl::Symbolize for improved symbolization in a few corner cases.

*Risk Level*: Low
*Testing*: //test/server:backtrace_test looks good
*Docs Changes*: n/a
*Release Notes*: n/a
