### PR TITLE
config: health checker timeout and interval should be greater than 0

### DIFF
--- a/api/envoy/api/v2/core/health_check.proto
+++ b/api/envoy/api/v2/core/health_check.proto
@@ -22,13 +22,13 @@ message HealthCheck {
   // The time to wait for a health check response. If the timeout is reached the
   // health check attempt will be considered a failure.
   google.protobuf.Duration timeout = 1 [
-    (validate.rules).duration = {required: true, gt: {}},
+    (validate.rules).duration = {required: true, gt: {seconds: 0}},
     (gogoproto.stdduration) = true
   ];
 
   // The interval between health checks.
   google.protobuf.Duration interval = 2 [
-    (validate.rules).duration = {required: true, gt: {}},
+    (validate.rules).duration = {required: true, gt: {seconds: 0}},
     (gogoproto.stdduration) = true
   ];
 

--- a/api/envoy/api/v2/core/health_check.proto
+++ b/api/envoy/api/v2/core/health_check.proto
@@ -21,10 +21,16 @@ option (gogoproto.equal_all) = true;
 message HealthCheck {
   // The time to wait for a health check response. If the timeout is reached the
   // health check attempt will be considered a failure.
-  google.protobuf.Duration timeout = 1 [(validate.rules).duration.required = true];
+  google.protobuf.Duration timeout = 1 [
+    (validate.rules).duration = {required: true, gt: {}},
+    (gogoproto.stdduration) = true
+  ];
 
   // The interval between health checks.
-  google.protobuf.Duration interval = 2 [(validate.rules).duration.required = true];
+  google.protobuf.Duration interval = 2 [
+    (validate.rules).duration = {required: true, gt: {}},
+    (gogoproto.stdduration) = true
+  ];
 
   // An optional jitter amount in millseconds. If specified, during every
   // internal Envoy will add 0 to interval_jitter to the wait time.

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -174,6 +174,7 @@ envoy_cc_test(
     srcs = ["server_test.cc"],
     data = [
         ":cluster_dupe_bootstrap.yaml",
+        ":cluster_health_check_bootstrap.yaml",
         ":empty_bootstrap.yaml",
         ":node_bootstrap.yaml",
         "//test/config/integration:server.json",

--- a/test/server/cluster_health_check_bootstrap.yaml
+++ b/test/server/cluster_health_check_bootstrap.yaml
@@ -1,0 +1,17 @@
+admin:
+  access_log_path: /dev/null
+  address:
+    socket_address:
+      address: {{ ntop_ip_loopback_address }}
+      port_value: 0
+static_resources:
+  clusters:
+  - name: service_google
+    connect_timeout: 0.25s
+    health_checks:
+      - timeout: {{ health_check_timeout }}s
+        interval: {{ health_check_interval }}s
+        unhealthy_threshold: 1
+        healthy_threshold: 1
+        http_health_check:
+          path: "/"


### PR DESCRIPTION
*Description*:
This patch adds value validation for interval and timeout fields to accept values greater than 0.

*Risk Level*: Low
*Testing*: Unit, manual by setting timeout or interval to 0s
*Docs Changes*: N/A
*Release Notes*: N/A

Fixes #3729 

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>
