### PR TITLE
http: changing mutate[request|response] to special case all upgrade headers

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -107,31 +107,6 @@ public:
   bool find(const char* str) const { return strstr(c_str(), str); }
 
   /**
-   * HeaderString is in token list form, each token separated by commas or whitespace,
-   * see https://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.1 for more information,
-   * header field value's case sensitivity depends on each header.
-   * @return whether contains token in case insensitive manner.
-   */
-  bool caseInsensitiveContains(const char* token) const {
-    // Avoid dead loop if token argument is empty.
-    const int n = strlen(token);
-    if (n == 0) {
-      return false;
-    }
-
-    // Find token substring, skip if it's partial of other token.
-    const char* tokens = c_str();
-    for (const char* p = tokens; (p = strcasestr(p, token)); p += n) {
-      if ((p == tokens || *(p - 1) == ' ' || *(p - 1) == ',') &&
-          (*(p + n) == '\0' || *(p + n) == ' ' || *(p + n) == ',')) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  /**
    * Set the value of the string by copying data into it. This overwrites any existing string.
    */
   void setCopy(const char* data, uint32_t size);

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -45,6 +45,7 @@ Network::Address::InstanceConstSharedPtr ConnectionManagerUtility::mutateRequest
   request_headers.removeEnvoyInternalRequest();
   request_headers.removeKeepAlive();
   request_headers.removeProxyConnection();
+  // TODO(alyssawilk) handle this with current and new websocket here and below.
   request_headers.removeTransferEncoding();
 
   // If we are "using remote address" this means that we create/append to XFF with our immediate
@@ -315,8 +316,8 @@ void ConnectionManagerUtility::mutateResponseHeaders(Http::HeaderMap& response_h
     }
   } else {
     response_headers.removeConnection();
-    response_headers.removeTransferEncoding();
   }
+  response_headers.removeTransferEncoding();
 
   if (request_headers.EnvoyForceTrace() && request_headers.RequestId()) {
     response_headers.insertRequestId().value(*request_headers.RequestId());

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -304,12 +304,10 @@ void ConnectionManagerUtility::mutateResponseHeaders(Http::HeaderMap& response_h
                                                      const Http::HeaderMap& request_headers,
                                                      const std::string& via) {
   if (Utility::isUpgrade(request_headers) && Utility::isUpgrade(response_headers)) {
-    // As in mutateRequestHeaders, for WebSocket responses do not strip connection or and
-    // do explicitly set a 0 content length. They also retain the existing transfer-encoding.
+    // As in mutateRequestHeaders, Upgrade responses have special handling.
     //
-    // Unlike mutateRequestHeaders we do not explicitly check protocol because
-    // if we're proxying an upgrade response we've already passed the protocol
-    // checks.
+    // Unlike mutateRequestHeaders there is no explicit protocol check. If Envoy is proxying an
+    // upgrade response it has already passed the protocol checks.
     const bool no_body =
         (!response_headers.TransferEncoding() && !response_headers.ContentLength());
     if (no_body) {

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -201,15 +201,18 @@ uint64_t Utility::getResponseStatus(const HeaderMap& headers) {
   return response_code;
 }
 
-bool Utility::isWebSocketUpgradeRequest(const HeaderMap& headers) {
+bool Utility::isUpgrade(const HeaderMap& headers) {
   // In firefox the "Connection" request header value is "keep-alive, Upgrade",
   // we should check if it contains the "Upgrade" token.
   return (headers.Connection() && headers.Upgrade() &&
-          headers.Connection()->value().caseInsensitiveContains(
-              Http::Headers::get().ConnectionValues.Upgrade.c_str()) &&
-          (0 == StringUtil::caseInsensitiveCompare(
-                    headers.Upgrade()->value().c_str(),
-                    Http::Headers::get().UpgradeValues.WebSocket.c_str())));
+          Envoy::StringUtil::caseFindToken(headers.Connection()->value().getStringView(), ",",
+                                           Http::Headers::get().ConnectionValues.Upgrade.c_str()));
+}
+
+bool Utility::isWebSocketUpgradeRequest(const HeaderMap& headers) {
+  return (isUpgrade(headers) && (0 == StringUtil::caseInsensitiveCompare(
+                                          headers.Upgrade()->value().c_str(),
+                                          Http::Headers::get().UpgradeValues.WebSocket.c_str())));
 }
 
 Http2Settings

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -99,6 +99,14 @@ public:
   static uint64_t getResponseStatus(const HeaderMap& headers);
 
   /**
+   * Determine whether these headers are a valid Upgrade request or response.
+   * This function returns true if the following HTTP headers and values are present:
+   * - Connection: Upgrade
+   * - Upgrade: [any value]
+   */
+  static bool isUpgrade(const HeaderMap& headers);
+
+  /**
    * Determine whether this is a WebSocket Upgrade request.
    * This function returns true if the following HTTP headers and values are present:
    * - Connection: Upgrade

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -548,15 +548,73 @@ TEST_F(ConnectionManagerUtilityTest, RemoveConnectionUpgradeForHttp2Requests) {
 // Test cleaning response headers.
 TEST_F(ConnectionManagerUtilityTest, MutateResponseHeaders) {
   TestHeaderMapImpl response_headers{
-      {"connection", "foo"}, {"transfer-encoding", "foo"}, {"custom_header", "foo"}};
+      {"connection", "foo"}, {"transfer-encoding", "foo"}, {"custom_header", "custom_value"}};
   TestHeaderMapImpl request_headers{{"x-request-id", "request-id"}};
 
   ConnectionManagerUtility::mutateResponseHeaders(response_headers, request_headers, "");
 
   EXPECT_EQ(1UL, response_headers.size());
-  EXPECT_EQ("foo", response_headers.get_("custom_header"));
+  EXPECT_EQ("custom_value", response_headers.get_("custom_header"));
   EXPECT_FALSE(response_headers.has("x-request-id"));
   EXPECT_FALSE(response_headers.has(Headers::get().Via));
+}
+
+// Make sure we don't remove connection headers on all Upgrade responses.
+TEST_F(ConnectionManagerUtilityTest, DoNotRemoveConnectionUpgradeForWebSocketResponses) {
+  TestHeaderMapImpl request_headers{{"connection", "UpGrAdE"}, {"upgrade", "foo"}};
+  TestHeaderMapImpl response_headers{
+      {"connection", "upgrade"}, {"transfer-encoding", "foo"}, {"upgrade", "bar"}};
+  EXPECT_TRUE(Utility::isUpgrade(request_headers));
+  EXPECT_TRUE(Utility::isUpgrade(response_headers));
+  ConnectionManagerUtility::mutateResponseHeaders(response_headers, request_headers, "");
+
+  EXPECT_EQ(3UL, response_headers.size()) << response_headers;
+  EXPECT_EQ("foo", response_headers.get_("transfer-encoding"));
+  EXPECT_EQ("upgrade", response_headers.get_("connection"));
+  EXPECT_EQ("bar", response_headers.get_("upgrade"));
+}
+
+TEST_F(ConnectionManagerUtilityTest, ClearUpgradeHeadersForNonUpgradeRequests) {
+  // Test clearing non-upgrade request and response headers
+  {
+    TestHeaderMapImpl request_headers{{"x-request-id", "request-id"}};
+    TestHeaderMapImpl response_headers{
+        {"connection", "foo"}, {"transfer-encoding", "bar"}, {"custom_header", "custom_value"}};
+    EXPECT_FALSE(Utility::isUpgrade(request_headers));
+    EXPECT_FALSE(Utility::isUpgrade(response_headers));
+    ConnectionManagerUtility::mutateResponseHeaders(response_headers, request_headers, "");
+
+    EXPECT_EQ(1UL, response_headers.size()) << response_headers;
+    EXPECT_EQ("custom_value", response_headers.get_("custom_header"));
+  }
+
+  // Test with the request headers not valid upgrade headers
+  {
+    TestHeaderMapImpl request_headers{{"upgrade", "foo"}};
+    TestHeaderMapImpl response_headers{{"connection", "upgrade"},
+                                       {"transfer-encoding", "eep"},
+                                       {"upgrade", "foo"},
+                                       {"custom_header", "custom_value"}};
+    EXPECT_FALSE(Utility::isUpgrade(request_headers));
+    EXPECT_TRUE(Utility::isUpgrade(response_headers));
+    ConnectionManagerUtility::mutateResponseHeaders(response_headers, request_headers, "");
+
+    EXPECT_EQ(2UL, response_headers.size()) << response_headers;
+    EXPECT_EQ("custom_value", response_headers.get_("custom_header"));
+    EXPECT_EQ("foo", response_headers.get_("upgrade"));
+  }
+
+  // Test with the response headers not valid upgrade headers
+  {
+    TestHeaderMapImpl request_headers{{"connection", "UpGrAdE"}, {"upgrade", "foo"}};
+    TestHeaderMapImpl response_headers{{"transfer-encoding", "foo"}, {"upgrade", "bar"}};
+    EXPECT_TRUE(Utility::isUpgrade(request_headers));
+    EXPECT_FALSE(Utility::isUpgrade(response_headers));
+    ConnectionManagerUtility::mutateResponseHeaders(response_headers, request_headers, "");
+
+    EXPECT_EQ(1UL, response_headers.size()) << response_headers;
+    EXPECT_EQ("bar", response_headers.get_("upgrade"));
+  }
 }
 
 // Test that we correctly return x-request-id if we were requested to force a trace.

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -568,8 +568,7 @@ TEST_F(ConnectionManagerUtilityTest, DoNotRemoveConnectionUpgradeForWebSocketRes
   EXPECT_TRUE(Utility::isUpgrade(response_headers));
   ConnectionManagerUtility::mutateResponseHeaders(response_headers, request_headers, "");
 
-  EXPECT_EQ(3UL, response_headers.size()) << response_headers;
-  EXPECT_EQ("foo", response_headers.get_("transfer-encoding"));
+  EXPECT_EQ(2UL, response_headers.size()) << response_headers;
   EXPECT_EQ("upgrade", response_headers.get_("connection"));
   EXPECT_EQ("bar", response_headers.get_("upgrade"));
 }

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -261,31 +261,6 @@ TEST(HeaderStringTest, All) {
     EXPECT_EQ(HeaderString::Type::Reference, string.type());
   }
 
-  // caseInsensitiveContains
-  {
-    const std::string static_string("keep-alive, Upgrade, close");
-    HeaderString string(static_string);
-    EXPECT_TRUE(string.caseInsensitiveContains("keep-alive"));
-    EXPECT_TRUE(string.caseInsensitiveContains("Keep-alive"));
-    EXPECT_TRUE(string.caseInsensitiveContains("Upgrade"));
-    EXPECT_TRUE(string.caseInsensitiveContains("upgrade"));
-    EXPECT_TRUE(string.caseInsensitiveContains("close"));
-    EXPECT_TRUE(string.caseInsensitiveContains("Close"));
-    EXPECT_FALSE(string.caseInsensitiveContains(""));
-    EXPECT_FALSE(string.caseInsensitiveContains("keep"));
-    EXPECT_FALSE(string.caseInsensitiveContains("alive"));
-    EXPECT_FALSE(string.caseInsensitiveContains("grade"));
-
-    const std::string small("close");
-    string.setCopy(small.c_str(), small.size());
-    EXPECT_FALSE(string.caseInsensitiveContains("keep-alive"));
-
-    const std::string empty("");
-    string.setCopy(empty.c_str(), empty.size());
-    EXPECT_FALSE(string.caseInsensitiveContains("keep-alive"));
-    EXPECT_FALSE(string.caseInsensitiveContains(""));
-  }
-
   // getString
   {
     std::string static_string("HELLO");

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -46,6 +46,8 @@ TEST(HttpUtility, isWebSocketUpgradeRequest) {
   EXPECT_FALSE(Utility::isWebSocketUpgradeRequest(TestHeaderMapImpl{{"upgrade", "websocket"}}));
   EXPECT_FALSE(Utility::isWebSocketUpgradeRequest(
       TestHeaderMapImpl{{"Connection", "close"}, {"Upgrade", "websocket"}}));
+  EXPECT_FALSE(Utility::isUpgrade(
+      TestHeaderMapImpl{{"Connection", "IsNotAnUpgrade"}, {"Upgrade", "websocket"}}));
 
   EXPECT_TRUE(Utility::isWebSocketUpgradeRequest(
       TestHeaderMapImpl{{"Connection", "upgrade"}, {"Upgrade", "websocket"}}));
@@ -53,6 +55,23 @@ TEST(HttpUtility, isWebSocketUpgradeRequest) {
       TestHeaderMapImpl{{"connection", "upgrade"}, {"upgrade", "websocket"}}));
   EXPECT_TRUE(Utility::isWebSocketUpgradeRequest(
       TestHeaderMapImpl{{"connection", "Upgrade"}, {"upgrade", "WebSocket"}}));
+}
+
+TEST(HttpUtility, isUpgrade) {
+  EXPECT_FALSE(Utility::isUpgrade(TestHeaderMapImpl{}));
+  EXPECT_FALSE(Utility::isUpgrade(TestHeaderMapImpl{{"connection", "upgrade"}}));
+  EXPECT_FALSE(Utility::isUpgrade(TestHeaderMapImpl{{"upgrade", "foo"}}));
+  EXPECT_FALSE(Utility::isUpgrade(TestHeaderMapImpl{{"Connection", "close"}, {"Upgrade", "foo"}}));
+  EXPECT_FALSE(
+      Utility::isUpgrade(TestHeaderMapImpl{{"Connection", "IsNotAnUpgrade"}, {"Upgrade", "foo"}}));
+  EXPECT_FALSE(Utility::isUpgrade(
+      TestHeaderMapImpl{{"Connection", "Is Not An Upgrade"}, {"Upgrade", "foo"}}));
+
+  EXPECT_TRUE(Utility::isUpgrade(TestHeaderMapImpl{{"Connection", "upgrade"}, {"Upgrade", "foo"}}));
+  EXPECT_TRUE(Utility::isUpgrade(TestHeaderMapImpl{{"connection", "upgrade"}, {"upgrade", "foo"}}));
+  EXPECT_TRUE(Utility::isUpgrade(TestHeaderMapImpl{{"connection", "Upgrade"}, {"upgrade", "FoO"}}));
+  EXPECT_TRUE(Utility::isUpgrade(
+      TestHeaderMapImpl{{"connection", "keep-alive, Upgrade"}, {"upgrade", "FOO"}}));
 }
 
 TEST(HttpUtility, appendXff) {

--- a/test/integration/websocket_integration_test.h
+++ b/test/integration/websocket_integration_test.h
@@ -17,6 +17,8 @@ protected:
   void validateInitialDownstreamData(const std::string& received_data);
   void validateFinalDownstreamData(const std::string& received_data,
                                    const std::string& expected_data);
+  void validateFinalUpstreamData(const std::string& received_data,
+                                 const std::string& expected_data);
 
   const std::string upgrade_req_str_ = "GET /websocket/test HTTP/1.1\r\nHost: host\r\nConnection: "
                                        "keep-alive, Upgrade\r\nUpgrade: websocket\r\n\r\n";


### PR DESCRIPTION
Extending the mutateRequestHeaders to special case all upgrades, not just WebSocket.

Adding special handling for mutateResponse headers to do similar special casing of upgrade responses.

Changing the utility we use to determine if there is an upgrade header.  The now removed caseInsensitiveContains had a bug where it would parse "upgrade: Websocket Keep-Alive" as a websocket upgrade.  The existing Envoy::StringUtil::caseFindToken will parse that as one token but still handles "upgrade: Webocket, keep-alive" correctly.

*Risk Level*: Medium (changing existing websocket handling)
*Testing*: new unit tests, regression test for fixed bug.
*Docs Changes*: n/a
*Release Notes*: not added.  We could note the bugfix if we think it noteworthy.
Part of #3301