### PR TITLE
test-utillity: Remove test-utility wrapper for Buffer::toString().

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -87,7 +87,7 @@ if [ "$1" != "-nofetch" ]; then
   fi
   
   # This is the hash on https://github.com/envoyproxy/envoy-filter-example.git we pin to.
-  (cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout -f 4b6c55b726eda8a1f99e6f4ca1a87f6ce670604f)
+  (cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout -f 92307d723a1ead25c39f025a734fa091443efdbc)
   cp -f "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/WORKSPACE
 fi
 

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -165,7 +165,7 @@ public:
   virtual ssize_t search(const void* data, uint64_t size, size_t start) const PURE;
 
   /**
-   * Construct a flattened string from a buffer.
+   * Constructs a flattened string from a buffer.
    * @return the flattened string.
    */
   virtual std::string toString() const PURE;

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -165,6 +165,12 @@ public:
   virtual ssize_t search(const void* data, uint64_t size, size_t start) const PURE;
 
   /**
+   * Construct a flattened string from a buffer.
+   * @return the flattened string.
+   */
+  virtual std::string toString() const PURE;
+
+  /**
    * Write the buffer out to a file descriptor.
    * @param fd supplies the descriptor to write to.
    * @return the number of bytes written or -1 if there was an error.

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -85,12 +85,7 @@ public:
   ssize_t search(const void* data, uint64_t size, size_t start) const override;
   int write(int fd) override;
   void postProcess() override {}
-
-  /**
-   * Construct a flattened string from a buffer.
-   * @return the flattened string.
-   */
-  std::string toString() const;
+  std::string toString() const override;
 
   Event::Libevent::BufferPtr& buffer() override { return buffer_; }
 

--- a/source/extensions/filters/network/thrift_proxy/buffer_helper.h
+++ b/source/extensions/filters/network/thrift_proxy/buffer_helper.h
@@ -50,6 +50,7 @@ public:
   uint64_t reserve(uint64_t, Buffer::RawSlice*, uint64_t) override { NOT_IMPLEMENTED; }
   ssize_t search(const void*, uint64_t, size_t) const override { NOT_IMPLEMENTED; }
   int write(int) override { NOT_IMPLEMENTED; }
+  std::string toString() const override { NOT_IMPLEMENTED; }
 
 private:
   Buffer::Instance& underlying_;

--- a/test/common/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/common/decompressor/zlib_decompressor_impl_test.cc
@@ -28,7 +28,7 @@ protected:
     std::string original_text{};
     for (uint64_t i = 0; i < 30; ++i) {
       TestUtility::feedBufferWithRandomCharacters(buffer, default_input_size * i, i);
-      original_text.append(TestUtility::bufferToString(buffer));
+      original_text.append(buffer.toString());
       compressor.compress(buffer, Compressor::State::Flush);
       accumulation_buffer.add(buffer);
       drainBuffer(buffer);
@@ -45,7 +45,7 @@ protected:
     decompressor.init(window_bits);
 
     decompressor.decompress(accumulation_buffer, buffer);
-    std::string decompressed_text{TestUtility::bufferToString(buffer)};
+    std::string decompressed_text{buffer.toString()};
 
     ASSERT_EQ(compressor.checksum(), decompressor.checksum());
     ASSERT_EQ(original_text.length(), decompressed_text.length());
@@ -122,7 +122,7 @@ TEST_F(ZlibDecompressorImplTest, CompressAndDecompress) {
   std::string original_text{};
   for (uint64_t i = 0; i < 20; ++i) {
     TestUtility::feedBufferWithRandomCharacters(buffer, default_input_size * i, i);
-    original_text.append(TestUtility::bufferToString(buffer));
+    original_text.append(buffer.toString());
     compressor.compress(buffer, Compressor::State::Flush);
     accumulation_buffer.add(buffer);
     drainBuffer(buffer);
@@ -142,7 +142,7 @@ TEST_F(ZlibDecompressorImplTest, CompressAndDecompress) {
   decompressor.init(gzip_window_bits);
 
   decompressor.decompress(accumulation_buffer, buffer);
-  std::string decompressed_text{TestUtility::bufferToString(buffer)};
+  std::string decompressed_text{buffer.toString()};
 
   ASSERT_EQ(compressor.checksum(), decompressor.checksum());
   ASSERT_EQ(original_text.length(), decompressed_text.length());
@@ -162,7 +162,7 @@ TEST_F(ZlibDecompressorImplTest, DecompressWithSmallOutputBuffer) {
   std::string original_text{};
   for (uint64_t i = 0; i < 20; ++i) {
     TestUtility::feedBufferWithRandomCharacters(buffer, default_input_size * i, i);
-    original_text.append(TestUtility::bufferToString(buffer));
+    original_text.append(buffer.toString());
     compressor.compress(buffer, Compressor::State::Flush);
     accumulation_buffer.add(buffer);
     drainBuffer(buffer);
@@ -182,7 +182,7 @@ TEST_F(ZlibDecompressorImplTest, DecompressWithSmallOutputBuffer) {
   decompressor.init(gzip_window_bits);
 
   decompressor.decompress(accumulation_buffer, buffer);
-  std::string decompressed_text{TestUtility::bufferToString(buffer)};
+  std::string decompressed_text{buffer.toString()};
 
   ASSERT_EQ(compressor.checksum(), decompressor.checksum());
   ASSERT_EQ(original_text.length(), decompressed_text.length());
@@ -244,7 +244,7 @@ TEST_F(ZlibDecompressorImplTest, CompressDecompressOfMultipleSlices) {
   ASSERT_EQ(0, buffer.length());
 
   decompressor.decompress(accumulation_buffer, buffer);
-  std::string decompressed_text{TestUtility::bufferToString(buffer)};
+  std::string decompressed_text{buffer.toString()};
 
   ASSERT_EQ(compressor.checksum(), decompressor.checksum());
   ASSERT_EQ(original_text.length(), decompressed_text.length());

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -354,7 +354,7 @@ TEST_P(CodecNetworkTest, SendData) {
   Buffer::OwnedImpl data(full_data);
   upstream_connection_->write(data, false);
   EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance& data) -> void {
-    EXPECT_EQ(full_data, TestUtility::bufferToString(data));
+    EXPECT_EQ(full_data, data.toString());
     dispatcher_->exit();
   }));
   dispatcher_->run(Event::Dispatcher::RunType::Block);
@@ -375,12 +375,9 @@ TEST_P(CodecNetworkTest, SendHeadersAndClose) {
   upstream_connection_->close(Network::ConnectionCloseType::FlushWrite);
   EXPECT_CALL(*codec_, dispatch(_))
       .Times(2)
-      .WillOnce(Invoke([&](Buffer::Instance& data) -> void {
-        EXPECT_EQ(full_data, TestUtility::bufferToString(data));
-      }))
-      .WillOnce(Invoke([&](Buffer::Instance& data) -> void {
-        EXPECT_EQ("", TestUtility::bufferToString(data));
-      }));
+      .WillOnce(
+          Invoke([&](Buffer::Instance& data) -> void { EXPECT_EQ(full_data, data.toString()); }))
+      .WillOnce(Invoke([&](Buffer::Instance& data) -> void { EXPECT_EQ("", data.toString()); }));
   // Because the headers are not complete, the disconnect will reset the stream.
   // Note even if the final \r\n were appended to the header data, enough of the
   // codec state is mocked out that the data would not be framed and the stream
@@ -411,12 +408,9 @@ TEST_P(CodecNetworkTest, SendHeadersAndCloseUnderReadDisable) {
 
   EXPECT_CALL(*codec_, dispatch(_))
       .Times(2)
-      .WillOnce(Invoke([&](Buffer::Instance& data) -> void {
-        EXPECT_EQ(full_data, TestUtility::bufferToString(data));
-      }))
-      .WillOnce(Invoke([&](Buffer::Instance& data) -> void {
-        EXPECT_EQ("", TestUtility::bufferToString(data));
-      }));
+      .WillOnce(
+          Invoke([&](Buffer::Instance& data) -> void { EXPECT_EQ(full_data, data.toString()); }))
+      .WillOnce(Invoke([&](Buffer::Instance& data) -> void { EXPECT_EQ("", data.toString()); }));
   EXPECT_CALL(inner_encoder_.stream_, resetStream(_)).WillOnce(InvokeWithoutArgs([&]() -> void {
     for (auto callbacks : inner_encoder_.stream_.callbacks_) {
       callbacks->onResetStream(StreamResetReason::RemoteReset);

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -1972,8 +1972,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddBodyDuringDecodeData) {
   EXPECT_CALL(*decoder_filters_[0], decodeData(_, true))
       .WillOnce(Invoke([&](Buffer::Instance& data, bool) -> FilterDataStatus {
         decoder_filters_[0]->callbacks_->addDecodedData(data, true);
-        EXPECT_EQ(TestUtility::bufferToString(*decoder_filters_[0]->callbacks_->decodingBuffer()),
-                  "helloworld");
+        EXPECT_EQ(decoder_filters_[0]->callbacks_->decodingBuffer()->toString(), "helloworld");
         return FilterDataStatus::Continue;
       }));
   EXPECT_CALL(*decoder_filters_[1], decodeHeaders(_, false))
@@ -1992,8 +1991,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddBodyDuringDecodeData) {
   EXPECT_CALL(*encoder_filters_[0], encodeData(_, true))
       .WillOnce(Invoke([&](Buffer::Instance& data, bool) -> FilterDataStatus {
         encoder_filters_[0]->callbacks_->addEncodedData(data, true);
-        EXPECT_EQ(TestUtility::bufferToString(*encoder_filters_[0]->callbacks_->encodingBuffer()),
-                  "goodbye");
+        EXPECT_EQ(encoder_filters_[0]->callbacks_->encodingBuffer()->toString(), "goodbye");
         return FilterDataStatus::Continue;
       }));
   EXPECT_CALL(*encoder_filters_[1], encodeHeaders(_, false))

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -84,8 +84,7 @@ protected:
       for (size_t i = 0; i < grpc_request_messages.size(); ++i) {
         RequestType actual_message;
         if (frames[i].length_ > 0) {
-          EXPECT_TRUE(
-              actual_message.ParseFromString(TestUtility::bufferToString(*frames[i].data_)));
+          EXPECT_TRUE(actual_message.ParseFromString(frames[i].data_->toString()));
         }
         RequestType expected_message;
         EXPECT_TRUE(TextFormat::ParseFromString(grpc_request_messages[i], &expected_message));

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -302,7 +302,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, TranscodingUnaryPost) {
   expected_request.mutable_shelf()->set_theme("Children");
 
   bookstore::CreateShelfRequest request;
-  request.ParseFromString(TestUtility::bufferToString(*frames[0].data_));
+  request.ParseFromString(frames[0].data_->toString());
 
   EXPECT_EQ(expected_request.ByteSize(), frames[0].length_);
   EXPECT_TRUE(MessageDifferencer::Equals(expected_request, request));
@@ -327,7 +327,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, TranscodingUnaryPost) {
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer,
             filter_.encodeData(*response_data, false));
 
-  std::string response_json = TestUtility::bufferToString(*response_data);
+  std::string response_json = response_data->toString();
 
   EXPECT_EQ("{\"id\":\"20\",\"theme\":\"Children\"}", response_json);
 
@@ -366,7 +366,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, TranscodingUnaryPostWithPackageServiceMetho
   expected_request.mutable_shelf()->set_theme("Children");
 
   bookstore::CreateShelfRequest request;
-  request.ParseFromString(TestUtility::bufferToString(*frames[0].data_));
+  request.ParseFromString(frames[0].data_->toString());
 
   EXPECT_EQ(expected_request.ByteSize(), frames[0].length_);
   EXPECT_TRUE(MessageDifferencer::Equals(expected_request, request));
@@ -391,7 +391,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, TranscodingUnaryPostWithPackageServiceMetho
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer,
             filter_.encodeData(*response_data, false));
 
-  std::string response_json = TestUtility::bufferToString(*response_data);
+  std::string response_json = response_data->toString();
 
   EXPECT_EQ("{\"id\":\"20\",\"theme\":\"Children\"}", response_json);
 
@@ -427,7 +427,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, ForwardUnaryPostGrpc) {
   expected_request.mutable_shelf()->set_theme("Children");
 
   bookstore::CreateShelfRequest forwarded_request;
-  forwarded_request.ParseFromString(TestUtility::bufferToString(*frames[0].data_));
+  forwarded_request.ParseFromString(frames[0].data_->toString());
 
   EXPECT_EQ(expected_request.ByteSize(), frames[0].length_);
   EXPECT_TRUE(MessageDifferencer::Equals(expected_request, forwarded_request));
@@ -458,7 +458,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, ForwardUnaryPostGrpc) {
   EXPECT_EQ(1, frames.size());
 
   bookstore::Shelf forwarded_response;
-  forwarded_response.ParseFromString(TestUtility::bufferToString(*frames[0].data_));
+  forwarded_response.ParseFromString(frames[0].data_->toString());
 
   EXPECT_EQ(expected_response.ByteSize(), frames[0].length_);
   EXPECT_TRUE(MessageDifferencer::Equals(expected_response, forwarded_response));
@@ -594,7 +594,7 @@ TEST_P(GrpcJsonTranscoderFilterPrintTest, PrintOptions) {
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer,
             filter_->encodeData(*response_data, false));
 
-  std::string response_json = TestUtility::bufferToString(*response_data);
+  std::string response_json = response_data->toString();
   EXPECT_EQ(GetParam().expected_response_, response_json);
 }
 

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -68,7 +68,7 @@ protected:
 
   void verifyCompressedData() {
     decompressor_.decompress(data_, decompressed_data_);
-    const std::string uncompressed_str{TestUtility::bufferToString(decompressed_data_)};
+    const std::string uncompressed_str{decompressed_data_.toString()};
     ASSERT_EQ(expected_str_.length(), uncompressed_str.length());
     EXPECT_EQ(expected_str_, uncompressed_str);
     EXPECT_EQ(expected_str_.length(), stats_.counter("test.gzip.total_uncompressed_bytes").value());
@@ -77,7 +77,7 @@ protected:
 
   void feedBuffer(uint64_t size) {
     TestUtility::feedBufferWithRandomCharacters(data_, size);
-    expected_str_ += TestUtility::bufferToString(data_);
+    expected_str_ += data_.toString();
   }
 
   void drainBuffer() {

--- a/test/extensions/filters/http/squash/squash_filter_integration_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_integration_test.cc
@@ -127,7 +127,7 @@ TEST_P(SquashFilterIntegrationTest, TestHappyPath) {
   EXPECT_STREQ("/api/v2/debugattachment/", create_stream->headers().Path()->value().c_str());
   // Make sure the env var was replaced
   ProtobufWkt::Struct actualbody;
-  MessageUtil::loadFromJson(TestUtility::bufferToString(create_stream->body()), actualbody);
+  MessageUtil::loadFromJson(create_stream->body().toString(), actualbody);
 
   ProtobufWkt::Struct expectedbody;
   MessageUtil::loadFromJson("{\"spec\": { \"attachment\" : { \"env\": \"" ENV_VAR_VALUE

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -103,7 +103,7 @@ public:
     EXPECT_CALL(*read_filter_, onNewConnection());
     EXPECT_CALL(*read_filter_, onData(_, _))
         .WillOnce(Invoke([&](Buffer::Instance& buffer, bool) -> Network::FilterStatus {
-          EXPECT_EQ(TestUtility::bufferToString(buffer), expected);
+          EXPECT_EQ(buffer.toString(), expected);
           buffer.drain(expected.length());
           dispatcher_.exit();
           return Network::FilterStatus::Continue;
@@ -391,7 +391,7 @@ public:
     EXPECT_CALL(*read_filter_, onNewConnection());
     EXPECT_CALL(*read_filter_, onData(_, _))
         .WillOnce(Invoke([&](Buffer::Instance& buffer, bool) -> Network::FilterStatus {
-          EXPECT_EQ(TestUtility::bufferToString(buffer), expected);
+          EXPECT_EQ(buffer.toString(), expected);
           buffer.drain(expected.length());
           dispatcher_.exit();
           return Network::FilterStatus::Continue;

--- a/test/extensions/filters/network/redis_proxy/codec_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/codec_impl_test.cc
@@ -35,7 +35,7 @@ TEST_F(RedisEncoderDecoderImplTest, Null) {
   RespValue value;
   EXPECT_EQ("null", value.toString());
   encoder_.encode(value, buffer_);
-  EXPECT_EQ("$-1\r\n", TestUtility::bufferToString(buffer_));
+  EXPECT_EQ("$-1\r\n", buffer_.toString());
   decoder_.decode(buffer_);
   EXPECT_EQ(value, *decoded_values_[0]);
   EXPECT_EQ(0UL, buffer_.length());
@@ -47,7 +47,7 @@ TEST_F(RedisEncoderDecoderImplTest, Error) {
   value.asString() = "error";
   EXPECT_EQ("\"error\"", value.toString());
   encoder_.encode(value, buffer_);
-  EXPECT_EQ("-error\r\n", TestUtility::bufferToString(buffer_));
+  EXPECT_EQ("-error\r\n", buffer_.toString());
   decoder_.decode(buffer_);
   EXPECT_EQ(value, *decoded_values_[0]);
   EXPECT_EQ(0UL, buffer_.length());
@@ -59,7 +59,7 @@ TEST_F(RedisEncoderDecoderImplTest, SimpleString) {
   value.asString() = "simple string";
   EXPECT_EQ("\"simple string\"", value.toString());
   encoder_.encode(value, buffer_);
-  EXPECT_EQ("+simple string\r\n", TestUtility::bufferToString(buffer_));
+  EXPECT_EQ("+simple string\r\n", buffer_.toString());
   decoder_.decode(buffer_);
   EXPECT_EQ(value, *decoded_values_[0]);
   EXPECT_EQ(0UL, buffer_.length());
@@ -71,7 +71,7 @@ TEST_F(RedisEncoderDecoderImplTest, Integer) {
   value.asInteger() = std::numeric_limits<int64_t>::max();
   EXPECT_EQ("9223372036854775807", value.toString());
   encoder_.encode(value, buffer_);
-  EXPECT_EQ(":9223372036854775807\r\n", TestUtility::bufferToString(buffer_));
+  EXPECT_EQ(":9223372036854775807\r\n", buffer_.toString());
   decoder_.decode(buffer_);
   EXPECT_EQ(value, *decoded_values_[0]);
   EXPECT_EQ(0UL, buffer_.length());
@@ -82,7 +82,7 @@ TEST_F(RedisEncoderDecoderImplTest, NegativeIntegerSmall) {
   value.type(RespType::Integer);
   value.asInteger() = -1;
   encoder_.encode(value, buffer_);
-  EXPECT_EQ(":-1\r\n", TestUtility::bufferToString(buffer_));
+  EXPECT_EQ(":-1\r\n", buffer_.toString());
   decoder_.decode(buffer_);
   EXPECT_EQ(value, *decoded_values_[0]);
   EXPECT_EQ(0UL, buffer_.length());
@@ -93,7 +93,7 @@ TEST_F(RedisEncoderDecoderImplTest, NegativeIntegerLarge) {
   value.type(RespType::Integer);
   value.asInteger() = std::numeric_limits<int64_t>::min();
   encoder_.encode(value, buffer_);
-  EXPECT_EQ(":-9223372036854775808\r\n", TestUtility::bufferToString(buffer_));
+  EXPECT_EQ(":-9223372036854775808\r\n", buffer_.toString());
   decoder_.decode(buffer_);
   EXPECT_EQ(value, *decoded_values_[0]);
   EXPECT_EQ(0UL, buffer_.length());
@@ -104,7 +104,7 @@ TEST_F(RedisEncoderDecoderImplTest, EmptyArray) {
   value.type(RespType::Array);
   EXPECT_EQ("[]", value.toString());
   encoder_.encode(value, buffer_);
-  EXPECT_EQ("*0\r\n", TestUtility::bufferToString(buffer_));
+  EXPECT_EQ("*0\r\n", buffer_.toString());
   decoder_.decode(buffer_);
   EXPECT_EQ(value, *decoded_values_[0]);
   EXPECT_EQ(0UL, buffer_.length());
@@ -122,7 +122,7 @@ TEST_F(RedisEncoderDecoderImplTest, Array) {
   value.asArray().swap(values);
   EXPECT_EQ("[\"hello\", -5]", value.toString());
   encoder_.encode(value, buffer_);
-  EXPECT_EQ("*2\r\n$5\r\nhello\r\n:-5\r\n", TestUtility::bufferToString(buffer_));
+  EXPECT_EQ("*2\r\n$5\r\nhello\r\n:-5\r\n", buffer_.toString());
   decoder_.decode(buffer_);
   EXPECT_EQ(value, *decoded_values_[0]);
   EXPECT_EQ(0UL, buffer_.length());
@@ -145,11 +145,10 @@ TEST_F(RedisEncoderDecoderImplTest, NestedArray) {
   value.type(RespType::Array);
   value.asArray().swap(values);
   encoder_.encode(value, buffer_);
-  EXPECT_EQ("*2\r\n*3\r\n$5\r\nhello\r\n:0\r\n$-1\r\n$5\r\nworld\r\n",
-            TestUtility::bufferToString(buffer_));
+  EXPECT_EQ("*2\r\n*3\r\n$5\r\nhello\r\n:0\r\n$-1\r\n$5\r\nworld\r\n", buffer_.toString());
 
   // To test partial decode we will feed the buffer in 1 char at a time.
-  for (char c : TestUtility::bufferToString(buffer_)) {
+  for (char c : buffer_.toString()) {
     Buffer::OwnedImpl temp_buffer(&c, 1);
     decoder_.decode(temp_buffer);
     EXPECT_EQ(0UL, temp_buffer.length());

--- a/test/extensions/stats_sinks/common/statsd/statsd_test.cc
+++ b/test/extensions/stats_sinks/common/statsd/statsd_test.cc
@@ -118,7 +118,7 @@ TEST_F(TcpStatsdSinkTest, BufferReallocate) {
         for (int i = 0; i < 2000; i++) {
           compare += "envoy.test_counter:1|c\n";
         }
-        EXPECT_EQ(compare, TestUtility::bufferToString(buffer));
+        EXPECT_EQ(compare, buffer.toString());
       }));
   sink_->flush(source_);
 }

--- a/test/extensions/transport_sockets/alts/tsi_handshaker_test.cc
+++ b/test/extensions/transport_sockets/alts/tsi_handshaker_test.cc
@@ -62,27 +62,27 @@ TEST_F(TsiHandshakerTest, DoHandshake) {
   client_callbacks_.expectDone(TSI_OK, client_sent, client_result);
   client_handshaker_.next(server_sent); // Initially server_sent is empty.
   EXPECT_EQ(nullptr, client_result);
-  EXPECT_EQ("CLIENT_INIT", TestUtility::bufferToString(client_sent).substr(4));
+  EXPECT_EQ("CLIENT_INIT", client_sent.toString().substr(4));
 
   server_callbacks_.expectDone(TSI_OK, server_sent, server_result);
   server_handshaker_.next(client_sent);
   EXPECT_EQ(nullptr, client_result);
-  EXPECT_EQ("SERVER_INIT", TestUtility::bufferToString(server_sent).substr(4));
+  EXPECT_EQ("SERVER_INIT", server_sent.toString().substr(4));
 
   client_callbacks_.expectDone(TSI_OK, client_sent, client_result);
   client_handshaker_.next(server_sent);
   EXPECT_EQ(nullptr, client_result);
-  EXPECT_EQ("CLIENT_FINISHED", TestUtility::bufferToString(client_sent).substr(4));
+  EXPECT_EQ("CLIENT_FINISHED", client_sent.toString().substr(4));
 
   server_callbacks_.expectDone(TSI_OK, server_sent, server_result);
   server_handshaker_.next(client_sent);
   EXPECT_NE(nullptr, server_result);
-  EXPECT_EQ("SERVER_FINISHED", TestUtility::bufferToString(server_sent).substr(4));
+  EXPECT_EQ("SERVER_FINISHED", server_sent.toString().substr(4));
 
   client_callbacks_.expectDone(TSI_OK, client_sent, client_result);
   client_handshaker_.next(server_sent);
   EXPECT_NE(nullptr, client_result);
-  EXPECT_EQ("", TestUtility::bufferToString(client_sent));
+  EXPECT_EQ("", client_sent.toString());
 
   tsi_peer client_peer;
   EXPECT_EQ(TSI_OK, tsi_handshaker_result_extract_peer(client_result.get(), &client_peer));
@@ -116,13 +116,13 @@ TEST_F(TsiHandshakerTest, IncompleteData) {
   client_callbacks_.expectDone(TSI_OK, client_sent, client_result);
   client_handshaker_.next(server_sent); // Initially server_sent is empty.
   EXPECT_EQ(nullptr, client_result);
-  EXPECT_EQ("CLIENT_INIT", TestUtility::bufferToString(client_sent).substr(4));
+  EXPECT_EQ("CLIENT_INIT", client_sent.toString().substr(4));
 
   client_sent.drain(3); // make data incomplete
   server_callbacks_.expectDone(TSI_INCOMPLETE_DATA, server_sent, server_result);
   server_handshaker_.next(client_sent);
   EXPECT_EQ(nullptr, client_result);
-  EXPECT_EQ("", TestUtility::bufferToString(server_sent));
+  EXPECT_EQ("", server_sent.toString());
 }
 
 TEST_F(TsiHandshakerTest, DeferredDelete) {

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -52,7 +52,7 @@ TEST_P(EchoIntegrationTest, Hello) {
   RawConnectionDriver connection(
       lookupPort("listener_0"), buffer,
       [&](Network::ClientConnection&, const Buffer::Instance& data) -> void {
-        response.append(TestUtility::bufferToString(data));
+        response.append(data.toString());
         connection.close();
       },
       version_);
@@ -101,7 +101,7 @@ TEST_P(EchoIntegrationTest, AddRemoveListener) {
   RawConnectionDriver connection(
       new_listener_port, buffer,
       [&](Network::ClientConnection&, const Buffer::Instance& data) -> void {
-        response.append(TestUtility::bufferToString(data));
+        response.append(data.toString());
         connection.close();
       },
       version_);

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -428,7 +428,7 @@ Network::FilterStatus FakeRawConnection::ReadFilter::onData(Buffer::Instance& da
                                                             bool end_stream) {
   Thread::LockGuard lock(parent_.lock_);
   ENVOY_LOG(debug, "got {} bytes", data.length());
-  parent_.data_.append(TestUtility::bufferToString(data));
+  parent_.data_.append(data.toString());
   parent_.half_closed_ = end_stream;
   data.drain(data.length());
   parent_.connection_event_.notifyOne();

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -131,7 +131,7 @@ TEST_P(Http2IntegrationTest, BadMagic) {
   RawConnectionDriver connection(
       lookupPort("http"), buffer,
       [&](Network::ClientConnection&, const Buffer::Instance& data) -> void {
-        response.append(TestUtility::bufferToString(data));
+        response.append(data.toString());
       },
       version_);
 
@@ -146,7 +146,7 @@ TEST_P(Http2IntegrationTest, BadFrame) {
   RawConnectionDriver connection(
       lookupPort("http"), buffer,
       [&](Network::ClientConnection&, const Buffer::Instance& data) -> void {
-        response.append(TestUtility::bufferToString(data));
+        response.append(data.toString());
       },
       version_);
 

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -382,7 +382,7 @@ void BaseIntegrationTest::sendRawHttpAndWaitForResponse(int port, const char* ra
   RawConnectionDriver connection(
       port, buffer,
       [&](Network::ClientConnection& client, const Buffer::Instance& data) -> void {
-        response->append(TestUtility::bufferToString(data));
+        response->append(data.toString());
         if (disconnect_after_headers_complete && response->find("\r\n\r\n") != std::string::npos) {
           client.close(Network::ConnectionCloseType::NoFlush);
         }

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -36,7 +36,7 @@ void BufferingStreamDecoder::decodeHeaders(Http::HeaderMapPtr&& headers, bool en
 void BufferingStreamDecoder::decodeData(Buffer::Instance& data, bool end_stream) {
   ASSERT(!complete_);
   complete_ = end_stream;
-  body_.append(TestUtility::bufferToString(data));
+  body_.append(data.toString());
   if (complete_) {
     onComplete();
   }
@@ -125,7 +125,7 @@ WaitForPayloadReader::WaitForPayloadReader(Event::Dispatcher& dispatcher)
     : dispatcher_(dispatcher) {}
 
 Network::FilterStatus WaitForPayloadReader::onData(Buffer::Instance& data, bool end_stream) {
-  data_.append(TestUtility::bufferToString(data));
+  data_.append(data.toString());
   data.drain(data.length());
   read_end_stream_ = end_stream;
   if ((!data_to_wait_for_.empty() && data_.find(data_to_wait_for_) == 0) ||

--- a/test/mocks/buffer/mocks.h
+++ b/test/mocks/buffer/mocks.h
@@ -99,19 +99,20 @@ MATCHER_P(BufferEqual, rhs, testing::PrintToString(*rhs)) {
 }
 
 MATCHER_P(BufferStringEqual, rhs, rhs) {
-  *result_listener << "\"" << TestUtility::bufferToString(arg) << "\"";
+  *result_listener << "\"" << arg.toString() << "\"";
 
   Buffer::OwnedImpl buffer(rhs);
   return TestUtility::buffersEqual(arg, buffer);
 }
 
 ACTION_P(AddBufferToString, target_string) {
-  target_string->append(TestUtility::bufferToString(arg0));
+  auto bufferToString = [](const Buffer::OwnedImpl& buf) -> std::string { return buf.toString(); };
+  target_string->append(bufferToString(arg0));
   arg0.drain(arg0.length());
 }
 
 ACTION_P(AddBufferToStringWithoutDraining, target_string) {
-  target_string->append(TestUtility::bufferToString(arg0));
+  target_string->append(arg0.toString());
 }
 
 } // namespace Envoy

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -549,7 +549,7 @@ TEST_P(AdminInstanceTest, ConfigDump) {
 }
 )EOF";
   EXPECT_EQ(Http::Code::OK, getCallback("/config_dump", header_map, response));
-  std::string output = TestUtility::bufferToString(response);
+  std::string output = response.toString();
   EXPECT_EQ(expected_json, output);
 }
 
@@ -616,7 +616,7 @@ TEST_P(AdminInstanceTest, Runtime) {
   EXPECT_CALL(loader, snapshot()).WillRepeatedly(testing::ReturnPointee(&snapshot));
   EXPECT_CALL(server_, runtime()).WillRepeatedly(testing::ReturnPointee(&loader));
   EXPECT_EQ(Http::Code::OK, getCallback("/runtime", header_map, response));
-  EXPECT_EQ(expected_json, TestUtility::bufferToString(response));
+  EXPECT_EQ(expected_json, response.toString());
 }
 
 TEST_P(AdminInstanceTest, RuntimeModify) {
@@ -633,7 +633,7 @@ TEST_P(AdminInstanceTest, RuntimeModify) {
   EXPECT_CALL(loader, mergeValues(overrides)).Times(1);
   EXPECT_EQ(Http::Code::OK,
             getCallback("/runtime_modify?foo=bar&x=42&nothing=", header_map, response));
-  EXPECT_EQ("OK\n", TestUtility::bufferToString(response));
+  EXPECT_EQ("OK\n", response.toString());
 }
 
 TEST_P(AdminInstanceTest, RuntimeModifyNoArguments) {
@@ -641,7 +641,7 @@ TEST_P(AdminInstanceTest, RuntimeModifyNoArguments) {
   Buffer::OwnedImpl response;
 
   EXPECT_EQ(Http::Code::BadRequest, getCallback("/runtime_modify", header_map, response));
-  EXPECT_TRUE(absl::StartsWith(TestUtility::bufferToString(response), "usage:"));
+  EXPECT_TRUE(absl::StartsWith(response.toString(), "usage:"));
 }
 
 TEST_P(AdminInstanceTest, TracingStatsDisabled) {

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -99,16 +99,6 @@ public:
   static bool buffersEqual(const Buffer::Instance& lhs, const Buffer::Instance& rhs);
 
   /**
-   * Convert a buffer to a string.
-   * @param buffer supplies the buffer to convert.
-   * @return std::string the converted string.
-   */
-  static std::string bufferToString(const Buffer::OwnedImpl& buffer) {
-    // TODO(jmarantz): remove this indirection and update all ~53 call sites.
-    return buffer.toString();
-  }
-
-  /**
    * Feed a buffer with random characters.
    * @param buffer supplies the buffer to be fed.
    * @param n_char number of characters that should be added to the supplied buffer.


### PR DESCRIPTION
Signed-off-by: Joshua Marantz <jmarantz@google.com>

*Description*: Follow-up to #3629 to eliminate intermediate test-util API bufferToString() and change all the call-sites to call buffer->toString() directly.

Due to Buffer::OwnedImpl's implicit constructor from Buffer:Instance,
it worked for TestUtility::bufferToString to take  a const Buffer::OwnedImpl&
argument, even though many of its call-sites only
had the interface, Buffer::Instance&. In the context of the call to a static method
with a known argument type, the implict ctor is applied by the compiler to do the
type conversion.

However that doesn't work when simplify dereferencing a Buffer::Instance and
calling toString() on it. The simplest approach to resolution is to add
Buffer::Instance::toString(). IMO this is defensible: it's nice to have a simple
read-only observer for this abstract type.

*Risk Level*: Low
*Testing*: //test/...
*Docs Changes*: N/A
*Release Notes*: N/A

