### PR TITLE
thrift: fix bad merge related to TestUtility::bufferToString

### DIFF
--- a/test/extensions/filters/network/thrift_proxy/filter_integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filter_integration_test.cc
@@ -171,16 +171,16 @@ TEST_P(ThriftFilterIntegrationTest, Success) {
   initializeCall(CallResult::Success);
 
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
-  tcp_client->write(TestUtility::bufferToString(request_bytes_));
+  tcp_client->write(request_bytes_.toString());
 
   FakeRawConnectionPtr fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection();
   Buffer::OwnedImpl upstream_request(
       fake_upstream_connection->waitForData(request_bytes_.length()));
   EXPECT_TRUE(TestUtility::buffersEqual(upstream_request, request_bytes_));
 
-  fake_upstream_connection->write(TestUtility::bufferToString(response_bytes_));
+  fake_upstream_connection->write(response_bytes_.toString());
 
-  tcp_client->waitForData(TestUtility::bufferToString(response_bytes_));
+  tcp_client->waitForData(response_bytes_.toString());
   tcp_client->close();
   fake_upstream_connection->waitForDisconnect();
 
@@ -196,16 +196,16 @@ TEST_P(ThriftFilterIntegrationTest, IDLException) {
   initializeCall(CallResult::IDLException);
 
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
-  tcp_client->write(TestUtility::bufferToString(request_bytes_));
+  tcp_client->write(request_bytes_.toString());
 
   FakeRawConnectionPtr fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection();
   Buffer::OwnedImpl upstream_request(
       fake_upstream_connection->waitForData(request_bytes_.length()));
   EXPECT_TRUE(TestUtility::buffersEqual(upstream_request, request_bytes_));
 
-  fake_upstream_connection->write(TestUtility::bufferToString(response_bytes_));
+  fake_upstream_connection->write(response_bytes_.toString());
 
-  tcp_client->waitForData(TestUtility::bufferToString(response_bytes_));
+  tcp_client->waitForData(response_bytes_.toString());
   tcp_client->close();
   fake_upstream_connection->waitForDisconnect();
 
@@ -221,16 +221,16 @@ TEST_P(ThriftFilterIntegrationTest, Exception) {
   initializeCall(CallResult::Exception);
 
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
-  tcp_client->write(TestUtility::bufferToString(request_bytes_));
+  tcp_client->write(request_bytes_.toString());
 
   FakeRawConnectionPtr fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection();
   Buffer::OwnedImpl upstream_request(
       fake_upstream_connection->waitForData(request_bytes_.length()));
   EXPECT_TRUE(TestUtility::buffersEqual(upstream_request, request_bytes_));
 
-  fake_upstream_connection->write(TestUtility::bufferToString(response_bytes_));
+  fake_upstream_connection->write(response_bytes_.toString());
 
-  tcp_client->waitForData(TestUtility::bufferToString(response_bytes_));
+  tcp_client->waitForData(response_bytes_.toString());
   tcp_client->close();
   fake_upstream_connection->waitForDisconnect();
 
@@ -246,7 +246,7 @@ TEST_P(ThriftFilterIntegrationTest, Oneway) {
   initializeOneway();
 
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
-  tcp_client->write(TestUtility::bufferToString(request_bytes_));
+  tcp_client->write(request_bytes_.toString());
 
   FakeRawConnectionPtr fake_upstream_connection = fake_upstreams_[0]->waitForRawConnection();
   Buffer::OwnedImpl upstream_request(

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -701,7 +701,7 @@ TEST_P(AdminInstanceTest, ClustersJson) {
   Buffer::OwnedImpl response;
   Http::HeaderMapImpl header_map;
   EXPECT_EQ(Http::Code::OK, getCallback("/clusters?format=json", header_map, response));
-  std::string output_json = TestUtility::bufferToString(response);
+  std::string output_json = response.toString();
   envoy::admin::v2alpha::Clusters output_proto;
   MessageUtil::loadFromJson(output_json, output_proto);
 
@@ -755,7 +755,7 @@ TEST_P(AdminInstanceTest, ClustersJson) {
 
   // Ensure that the normal text format is used by default.
   EXPECT_EQ(Http::Code::OK, getCallback("/clusters", header_map, response));
-  std::string text_output = TestUtility::bufferToString(response);
+  std::string text_output = response.toString();
   envoy::admin::v2alpha::Clusters failed_conversion_proto;
   EXPECT_THROW(MessageUtil::loadFromJson(text_output, failed_conversion_proto), EnvoyException);
 }


### PR DESCRIPTION
My thrift integration test merge and the conversion of TestUtility::bufferToString
to Buffer::Instance::toString conflicted.

*Risk Level*: low
*Testing*: unit tests
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
