### PR TITLE
Tell tar to follow symlinks.

### DIFF
--- a/configs/configgen.sh
+++ b/configs/configgen.sh
@@ -22,4 +22,4 @@ for FILE in $*; do
 done
 
 # tar is having issues with -C for some reason so just cd into OUT_DIR.
-(cd "$OUT_DIR"; tar -cvf example_configs.tar *.json *.yaml certs/*.pem)
+(cd "$OUT_DIR"; tar -hcvf example_configs.tar *.json *.yaml certs/*.pem)


### PR DESCRIPTION
build: Tell tar to follow symlinks

*Description*:
In Google our distributed build system ends up generating symlinks local
to the build cluster which are not valid when outputs are untarred
elsewhere. This tells tar to dereference those symlinks and instead
capture the file contents.

Signed-off-by: Trevor Schroeder <trevors@google.com>

*Risk Level*: Low
*Testing*: All tests run and pass, in particular example_configs_test.
