### PR TITLE
build: include vector in header_map.h

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "envoy/common/pure.h"
 


### PR DESCRIPTION
When doing a clean build I received the following error from following the change in #3162 https://github.com/envoyproxy/envoy/pull/3162/files#diff-3409ea78c43f00bd0010ae7082ac212aR504

```ERROR: /home/dhochman/.cache/bazel/_bazel_dhochman/e06497486d669085a224b69c0561f4fe/external/envoy/source/common/http/BUILD:221:1: C++ compilation of rule '@envoy//source/common/http:user_agent_lib' failed (Exit 1)
In file included from external/envoy/source/common/http/user_agent.cc:1:
In file included from bazel-out/k8-fastbuild/bin/external/envoy/source/common/http/_virtual_includes/user_agent_lib/common/http/user_agent.h:7:
bazel-out/k8-fastbuild/bin/external/envoy/include/envoy/http/_virtual_includes/header_map_interface/envoy/http/header_map.h:504:14: error: no template named 'vector' in namespace 'std'
typedef std::vector<std::pair<LowerCaseString, std::string>> HeaderVector;
        ~~~~~^
1 error generated.
```

Signed-off-by: Daniel Hochman <danielhochman@users.noreply.github.com>