### PR TITLE
move hystrix entry to keep the section alphabetically sorted

### DIFF
--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -75,10 +75,10 @@ EXTENSIONS = {
     #
 
     "envoy.stat_sinks.dog_statsd":                      "//source/extensions/stat_sinks/dog_statsd:config",
+    "envoy.stat_sinks.hystrix":                         "//source/extensions/stat_sinks/hystrix:config",
     "envoy.stat_sinks.metrics_service":                 "//source/extensions/stat_sinks/metrics_service:config",
     "envoy.stat_sinks.statsd":                          "//source/extensions/stat_sinks/statsd:config",
-    "envoy.stat_sinks.hystrix":                         "//source/extensions/stat_sinks/hystrix:config",
-
+ 
     #
     # Tracers
     #


### PR DESCRIPTION
Signed-off-by: trabetti <talis@il.ibm.com>

*Description*: move hystrix entry to keep the stats_sink section in extensions_build_config.bzl alphabetically sorted as the other sections
*Risk Level*: Low
*Testing*:
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue] Refers to a comment here #3425 
[Optional *Deprecated*:]
