### PR TITLE
Use shared_ptr for SSL context objects

### DIFF
--- a/include/envoy/ssl/context.h
+++ b/include/envoy/ssl/context.h
@@ -32,12 +32,13 @@ public:
    */
   virtual std::string getCertChainInformation() const PURE;
 };
+typedef std::shared_ptr<Context> ContextSharedPtr;
 
 class ClientContext : public virtual Context {};
-typedef std::unique_ptr<ClientContext> ClientContextPtr;
+typedef std::shared_ptr<ClientContext> ClientContextSharedPtr;
 
 class ServerContext : public virtual Context {};
-typedef std::unique_ptr<ServerContext> ServerContextPtr;
+typedef std::shared_ptr<ServerContext> ServerContextSharedPtr;
 
 } // namespace Ssl
 } // namespace Envoy

--- a/include/envoy/ssl/context_manager.h
+++ b/include/envoy/ssl/context_manager.h
@@ -30,11 +30,6 @@ public:
                          const std::vector<std::string>& server_names) PURE;
 
   /**
-   * Remove a context from the manager.
-   */
-  virtual void removeContext(Context* context) PURE;
-
-  /**
    * @return the number of days until the next certificate being managed will expire.
    */
   virtual size_t daysUntilFirstCertExpires() const PURE;

--- a/include/envoy/ssl/context_manager.h
+++ b/include/envoy/ssl/context_manager.h
@@ -20,7 +20,7 @@ public:
    * Builds a ClientContext from a ClientContextConfig.
    */
   virtual ClientContextSharedPtr createSslClientContext(Stats::Scope& scope,
-                                                  const ClientContextConfig& config) PURE;
+                                                        const ClientContextConfig& config) PURE;
 
   /**
    * Builds a ServerContext from a ServerContextConfig.
@@ -28,6 +28,11 @@ public:
   virtual ServerContextSharedPtr
   createSslServerContext(Stats::Scope& scope, const ServerContextConfig& config,
                          const std::vector<std::string>& server_names) PURE;
+
+  /**
+   * Remove a context from the manager.
+   */
+  virtual void removeContext(Context* context) PURE;
 
   /**
    * @return the number of days until the next certificate being managed will expire.

--- a/include/envoy/ssl/context_manager.h
+++ b/include/envoy/ssl/context_manager.h
@@ -19,13 +19,13 @@ public:
   /**
    * Builds a ClientContext from a ClientContextConfig.
    */
-  virtual ClientContextPtr createSslClientContext(Stats::Scope& scope,
+  virtual ClientContextSharedPtr createSslClientContext(Stats::Scope& scope,
                                                   const ClientContextConfig& config) PURE;
 
   /**
    * Builds a ServerContext from a ServerContextConfig.
    */
-  virtual ServerContextPtr
+  virtual ServerContextSharedPtr
   createSslServerContext(Stats::Scope& scope, const ServerContextConfig& config,
                          const std::vector<std::string>& server_names) PURE;
 

--- a/source/common/ssl/context_impl.h
+++ b/source/common/ssl/context_impl.h
@@ -76,7 +76,7 @@ public:
 
 protected:
   ContextImpl(ContextManagerImpl& parent, Stats::Scope& scope, const ContextConfig& config);
-  ~ContextImpl() { parent_.releaseContext(this); }
+  ~ContextImpl() { parent_.removeContext(this); }
 
   /**
    * The global SSL-library index used for storing a pointer to the context

--- a/source/common/ssl/context_impl.h
+++ b/source/common/ssl/context_impl.h
@@ -75,8 +75,7 @@ public:
   std::string getCertChainInformation() const override;
 
 protected:
-  ContextImpl(ContextManagerImpl& parent, Stats::Scope& scope, const ContextConfig& config);
-  ~ContextImpl() { parent_.releaseContext(this); }
+  ContextImpl(Stats::Scope& scope, const ContextConfig& config);
 
   /**
    * The global SSL-library index used for storing a pointer to the context
@@ -123,7 +122,6 @@ protected:
   std::string getCaFileName() const { return ca_file_path_; };
   std::string getCertChainFileName() const { return cert_chain_file_path_; };
 
-  ContextManagerImpl& parent_;
   bssl::UniquePtr<SSL_CTX> ctx_;
   bool verify_trusted_ca_{false};
   std::vector<std::string> verify_subject_alt_name_list_;
@@ -142,8 +140,7 @@ typedef std::shared_ptr<ContextImpl> ContextImplSharedPtr;
 
 class ClientContextImpl : public ContextImpl, public ClientContext {
 public:
-  ClientContextImpl(ContextManagerImpl& parent, Stats::Scope& scope,
-                    const ClientContextConfig& config);
+  ClientContextImpl(Stats::Scope& scope, const ClientContextConfig& config);
 
   bssl::UniquePtr<SSL> newSsl() const override;
 
@@ -154,9 +151,8 @@ private:
 
 class ServerContextImpl : public ContextImpl, public ServerContext {
 public:
-  ServerContextImpl(ContextManagerImpl& parent, Stats::Scope& scope,
-                    const ServerContextConfig& config, const std::vector<std::string>& server_names,
-                    Runtime::Loader& runtime);
+  ServerContextImpl(Stats::Scope& scope, const ServerContextConfig& config,
+                    const std::vector<std::string>& server_names, Runtime::Loader& runtime);
 
 private:
   int alpnSelectCallback(const unsigned char** out, unsigned char* outlen, const unsigned char* in,

--- a/source/common/ssl/context_impl.h
+++ b/source/common/ssl/context_impl.h
@@ -76,7 +76,7 @@ public:
 
 protected:
   ContextImpl(ContextManagerImpl& parent, Stats::Scope& scope, const ContextConfig& config);
-  ~ContextImpl() { parent_.removeContext(this); }
+  ~ContextImpl() { parent_.releaseContext(this); }
 
   /**
    * The global SSL-library index used for storing a pointer to the context

--- a/source/common/ssl/context_impl.h
+++ b/source/common/ssl/context_impl.h
@@ -138,6 +138,8 @@ protected:
   std::string cert_chain_file_path_;
 };
 
+typedef std::shared_ptr<ContextImpl> ContextImplSharedPtr;
+
 class ClientContextImpl : public ContextImpl, public ClientContext {
 public:
   ClientContextImpl(ContextManagerImpl& parent, Stats::Scope& scope,

--- a/source/common/ssl/context_manager_impl.cc
+++ b/source/common/ssl/context_manager_impl.cc
@@ -11,7 +11,7 @@ namespace Ssl {
 
 ContextManagerImpl::~ContextManagerImpl() { ASSERT(contexts_.empty()); }
 
-void ContextManagerImpl::releaseContext(Context* context) {
+void ContextManagerImpl::removeContext(Context* context) {
   std::unique_lock<std::shared_timed_mutex> lock(contexts_lock_);
 
   // context may not be found, in the case that a subclass of Context throws
@@ -20,8 +20,8 @@ void ContextManagerImpl::releaseContext(Context* context) {
   contexts_.remove(context);
 }
 
-ClientContextSharedPtr ContextManagerImpl::createSslClientContext(Stats::Scope& scope,
-                                                            const ClientContextConfig& config) {
+ClientContextSharedPtr
+ContextManagerImpl::createSslClientContext(Stats::Scope& scope, const ClientContextConfig& config) {
   ClientContextSharedPtr context(new ClientContextImpl(*this, scope, config));
   std::unique_lock<std::shared_timed_mutex> lock(contexts_lock_);
   contexts_.emplace_back(context.get());
@@ -31,7 +31,8 @@ ClientContextSharedPtr ContextManagerImpl::createSslClientContext(Stats::Scope& 
 ServerContextSharedPtr
 ContextManagerImpl::createSslServerContext(Stats::Scope& scope, const ServerContextConfig& config,
                                            const std::vector<std::string>& server_names) {
-  ServerContextSharedPtr context(new ServerContextImpl(*this, scope, config, server_names, runtime_));
+  ServerContextSharedPtr context(
+      new ServerContextImpl(*this, scope, config, server_names, runtime_));
   std::unique_lock<std::shared_timed_mutex> lock(contexts_lock_);
   contexts_.emplace_back(context.get());
   return context;

--- a/source/common/ssl/context_manager_impl.cc
+++ b/source/common/ssl/context_manager_impl.cc
@@ -20,18 +20,18 @@ void ContextManagerImpl::releaseContext(Context* context) {
   contexts_.remove(context);
 }
 
-ClientContextPtr ContextManagerImpl::createSslClientContext(Stats::Scope& scope,
+ClientContextSharedPtr ContextManagerImpl::createSslClientContext(Stats::Scope& scope,
                                                             const ClientContextConfig& config) {
-  ClientContextPtr context(new ClientContextImpl(*this, scope, config));
+  ClientContextSharedPtr context(new ClientContextImpl(*this, scope, config));
   std::unique_lock<std::shared_timed_mutex> lock(contexts_lock_);
   contexts_.emplace_back(context.get());
   return context;
 }
 
-ServerContextPtr
+ServerContextSharedPtr
 ContextManagerImpl::createSslServerContext(Stats::Scope& scope, const ServerContextConfig& config,
                                            const std::vector<std::string>& server_names) {
-  ServerContextPtr context(new ServerContextImpl(*this, scope, config, server_names, runtime_));
+  ServerContextSharedPtr context(new ServerContextImpl(*this, scope, config, server_names, runtime_));
   std::unique_lock<std::shared_timed_mutex> lock(contexts_lock_);
   contexts_.emplace_back(context.get());
   return context;

--- a/source/common/ssl/context_manager_impl.cc
+++ b/source/common/ssl/context_manager_impl.cc
@@ -15,7 +15,7 @@ ContextManagerImpl::~ContextManagerImpl() {
 }
 
 void ContextManagerImpl::removeEmptyContexts() {
-  contexts_.remove_if([](std::weak_ptr<Context> n) { return n.expired(); });
+  contexts_.remove_if([](const std::weak_ptr<Context>& n) { return n.expired(); });
 }
 
 ClientContextSharedPtr
@@ -52,7 +52,6 @@ size_t ContextManagerImpl::daysUntilFirstCertExpires() const {
 
 void ContextManagerImpl::iterateContexts(std::function<void(const Context&)> callback) {
   std::shared_lock<std::shared_timed_mutex> lock(contexts_lock_);
-  removeEmptyContexts();
   for (const auto& ctx_weak_ptr : contexts_) {
     ContextSharedPtr context = ctx_weak_ptr.lock();
     if (context) {

--- a/source/common/ssl/context_manager_impl.cc
+++ b/source/common/ssl/context_manager_impl.cc
@@ -11,7 +11,7 @@ namespace Ssl {
 
 ContextManagerImpl::~ContextManagerImpl() { ASSERT(contexts_.empty()); }
 
-void ContextManagerImpl::removeContext(Context* context) {
+void ContextManagerImpl::releaseContext(Context* context) {
   std::unique_lock<std::shared_timed_mutex> lock(contexts_lock_);
 
   // context may not be found, in the case that a subclass of Context throws

--- a/source/common/ssl/context_manager_impl.cc
+++ b/source/common/ssl/context_manager_impl.cc
@@ -21,7 +21,6 @@ void ContextManagerImpl::removeEmptyContexts() {
 ClientContextSharedPtr
 ContextManagerImpl::createSslClientContext(Stats::Scope& scope, const ClientContextConfig& config) {
   ClientContextSharedPtr context = std::make_shared<ClientContextImpl>(scope, config);
-  std::unique_lock<std::shared_timed_mutex> lock(contexts_lock_);
   removeEmptyContexts();
   contexts_.emplace_back(context);
   return context;
@@ -32,14 +31,12 @@ ContextManagerImpl::createSslServerContext(Stats::Scope& scope, const ServerCont
                                            const std::vector<std::string>& server_names) {
   ServerContextSharedPtr context =
       std::make_shared<ServerContextImpl>(scope, config, server_names, runtime_);
-  std::unique_lock<std::shared_timed_mutex> lock(contexts_lock_);
   removeEmptyContexts();
   contexts_.emplace_back(context);
   return context;
 }
 
 size_t ContextManagerImpl::daysUntilFirstCertExpires() const {
-  std::shared_lock<std::shared_timed_mutex> lock(contexts_lock_);
   size_t ret = std::numeric_limits<int>::max();
   for (const auto& ctx_weak_ptr : contexts_) {
     ContextSharedPtr context = ctx_weak_ptr.lock();
@@ -51,7 +48,6 @@ size_t ContextManagerImpl::daysUntilFirstCertExpires() const {
 }
 
 void ContextManagerImpl::iterateContexts(std::function<void(const Context&)> callback) {
-  std::shared_lock<std::shared_timed_mutex> lock(contexts_lock_);
   for (const auto& ctx_weak_ptr : contexts_) {
     ContextSharedPtr context = ctx_weak_ptr.lock();
     if (context) {

--- a/source/common/ssl/context_manager_impl.cc
+++ b/source/common/ssl/context_manager_impl.cc
@@ -22,7 +22,7 @@ void ContextManagerImpl::releaseContext(Context* context) {
 
 ClientContextSharedPtr
 ContextManagerImpl::createSslClientContext(Stats::Scope& scope, const ClientContextConfig& config) {
-  ClientContextSharedPtr context(new ClientContextImpl(*this, scope, config));
+  ClientContextSharedPtr context = std::make_shared<ClientContextImpl>(*this, scope, config);
   std::unique_lock<std::shared_timed_mutex> lock(contexts_lock_);
   contexts_.emplace_back(context.get());
   return context;
@@ -31,8 +31,8 @@ ContextManagerImpl::createSslClientContext(Stats::Scope& scope, const ClientCont
 ServerContextSharedPtr
 ContextManagerImpl::createSslServerContext(Stats::Scope& scope, const ServerContextConfig& config,
                                            const std::vector<std::string>& server_names) {
-  ServerContextSharedPtr context(
-      new ServerContextImpl(*this, scope, config, server_names, runtime_));
+  ServerContextSharedPtr context =
+      std::make_shared<ServerContextImpl>(*this, scope, config, server_names, runtime_);
   std::unique_lock<std::shared_timed_mutex> lock(contexts_lock_);
   contexts_.emplace_back(context.get());
   return context;

--- a/source/common/ssl/context_manager_impl.cc
+++ b/source/common/ssl/context_manager_impl.cc
@@ -9,22 +9,27 @@
 namespace Envoy {
 namespace Ssl {
 
-ContextManagerImpl::~ContextManagerImpl() { ASSERT(contexts_.empty()); }
+ContextManagerImpl::~ContextManagerImpl() {
+  removeEmptyContexts();
+  ASSERT(contexts_.empty());
+}
 
-void ContextManagerImpl::releaseContext(Context* context) {
-  std::unique_lock<std::shared_timed_mutex> lock(contexts_lock_);
-
-  // context may not be found, in the case that a subclass of Context throws
-  // in it's constructor. In that case the context did not get added, but
-  // the destructor of Context will run and call releaseContext().
-  contexts_.remove(context);
+void ContextManagerImpl::removeEmptyContexts() {
+  for (auto it = contexts_.begin(); it != contexts_.end();) {
+    if (!it->lock()) {
+      it = contexts_.erase(it);
+    } else {
+      ++it;
+    }
+  }
 }
 
 ClientContextSharedPtr
 ContextManagerImpl::createSslClientContext(Stats::Scope& scope, const ClientContextConfig& config) {
-  ClientContextSharedPtr context = std::make_shared<ClientContextImpl>(*this, scope, config);
+  ClientContextSharedPtr context = std::make_shared<ClientContextImpl>(scope, config);
   std::unique_lock<std::shared_timed_mutex> lock(contexts_lock_);
-  contexts_.emplace_back(context.get());
+  removeEmptyContexts();
+  contexts_.emplace_back(context);
   return context;
 }
 
@@ -32,25 +37,32 @@ ServerContextSharedPtr
 ContextManagerImpl::createSslServerContext(Stats::Scope& scope, const ServerContextConfig& config,
                                            const std::vector<std::string>& server_names) {
   ServerContextSharedPtr context =
-      std::make_shared<ServerContextImpl>(*this, scope, config, server_names, runtime_);
+      std::make_shared<ServerContextImpl>(scope, config, server_names, runtime_);
   std::unique_lock<std::shared_timed_mutex> lock(contexts_lock_);
-  contexts_.emplace_back(context.get());
+  removeEmptyContexts();
+  contexts_.emplace_back(context);
   return context;
 }
 
 size_t ContextManagerImpl::daysUntilFirstCertExpires() const {
   std::shared_lock<std::shared_timed_mutex> lock(contexts_lock_);
   size_t ret = std::numeric_limits<int>::max();
-  for (Context* context : contexts_) {
-    ret = std::min<size_t>(context->daysUntilFirstCertExpires(), ret);
+  for (const auto& ctx_weak_ptr : contexts_) {
+    ContextSharedPtr context = ctx_weak_ptr.lock();
+    if (context) {
+      ret = std::min<size_t>(context->daysUntilFirstCertExpires(), ret);
+    }
   }
   return ret;
 }
 
 void ContextManagerImpl::iterateContexts(std::function<void(const Context&)> callback) {
   std::shared_lock<std::shared_timed_mutex> lock(contexts_lock_);
-  for (Context* context : contexts_) {
-    callback(*context);
+  for (const auto& ctx_weak_ptr : contexts_) {
+    ContextSharedPtr context = ctx_weak_ptr.lock();
+    if (context) {
+      callback(*context);
+    }
   }
 }
 

--- a/source/common/ssl/context_manager_impl.h
+++ b/source/common/ssl/context_manager_impl.h
@@ -27,7 +27,7 @@ public:
    * admin purposes. When a caller frees a context it will tell us to release it also from the list
    * of contexts.
    */
-  void removeContext(Context* context) override;
+  void releaseContext(Context* context);
 
   // Ssl::ContextManager
   Ssl::ClientContextSharedPtr createSslClientContext(Stats::Scope& scope,

--- a/source/common/ssl/context_manager_impl.h
+++ b/source/common/ssl/context_manager_impl.h
@@ -22,13 +22,6 @@ public:
   ContextManagerImpl(Runtime::Loader& runtime) : runtime_(runtime) {}
   ~ContextManagerImpl();
 
-  /**
-   * Allocated contexts are owned by the caller. However, we need to be able to iterate them for
-   * admin purposes. When a caller frees a context it will tell us to release it also from the list
-   * of contexts.
-   */
-  void releaseContext(Context* context);
-
   // Ssl::ContextManager
   Ssl::ClientContextSharedPtr createSslClientContext(Stats::Scope& scope,
                                                      const ClientContextConfig& config) override;
@@ -39,8 +32,9 @@ public:
   void iterateContexts(std::function<void(const Context&)> callback) override;
 
 private:
+  void removeEmptyContexts();
   Runtime::Loader& runtime_;
-  std::list<Context*> contexts_;
+  std::list<std::weak_ptr<Context>> contexts_;
   mutable std::shared_timed_mutex contexts_lock_;
 };
 

--- a/source/common/ssl/context_manager_impl.h
+++ b/source/common/ssl/context_manager_impl.h
@@ -27,11 +27,11 @@ public:
    * admin purposes. When a caller frees a context it will tell us to release it also from the list
    * of contexts.
    */
-  void releaseContext(Context* context);
+  void removeContext(Context* context) override;
 
   // Ssl::ContextManager
   Ssl::ClientContextSharedPtr createSslClientContext(Stats::Scope& scope,
-                                               const ClientContextConfig& config) override;
+                                                     const ClientContextConfig& config) override;
   Ssl::ServerContextSharedPtr
   createSslServerContext(Stats::Scope& scope, const ServerContextConfig& config,
                          const std::vector<std::string>& server_names) override;

--- a/source/common/ssl/context_manager_impl.h
+++ b/source/common/ssl/context_manager_impl.h
@@ -35,7 +35,6 @@ private:
   void removeEmptyContexts();
   Runtime::Loader& runtime_;
   std::list<std::weak_ptr<Context>> contexts_;
-  mutable std::shared_timed_mutex contexts_lock_;
 };
 
 } // namespace Ssl

--- a/source/common/ssl/context_manager_impl.h
+++ b/source/common/ssl/context_manager_impl.h
@@ -30,9 +30,9 @@ public:
   void releaseContext(Context* context);
 
   // Ssl::ContextManager
-  Ssl::ClientContextPtr createSslClientContext(Stats::Scope& scope,
+  Ssl::ClientContextSharedPtr createSslClientContext(Stats::Scope& scope,
                                                const ClientContextConfig& config) override;
-  Ssl::ServerContextPtr
+  Ssl::ServerContextSharedPtr
   createSslServerContext(Stats::Scope& scope, const ServerContextConfig& config,
                          const std::vector<std::string>& server_names) override;
   size_t daysUntilFirstCertExpires() const override;

--- a/source/common/ssl/ssl_socket.cc
+++ b/source/common/ssl/ssl_socket.cc
@@ -16,7 +16,7 @@ namespace Envoy {
 namespace Ssl {
 
 SslSocket::SslSocket(ContextSharedPtr ctx, InitialState state)
-    : ctx_(ctx), ssl_(dynamic_cast<Ssl::ContextImpl&>(*ctx_).newSsl()) {
+    : ctx_(std::dynamic_pointer_cast<ContextImpl>(ctx)), ssl_(ctx_->newSsl()) {
   if (state == InitialState::Client) {
     SSL_set_connect_state(ssl_.get());
   } else {
@@ -99,7 +99,7 @@ PostIoAction SslSocket::doHandshake() {
   if (rc == 1) {
     ENVOY_CONN_LOG(debug, "handshake complete", callbacks_->connection());
     handshake_complete_ = true;
-    dynamic_cast<Ssl::ContextImpl&>(*ctx_).logHandshake(ssl_.get());
+    ctx_->logHandshake(ssl_.get());
     callbacks_->raiseEvent(Network::ConnectionEvent::Connected);
 
     // It's possible that we closed during the handshake callback.
@@ -126,7 +126,7 @@ void SslSocket::drainErrorQueue() {
   while (uint64_t err = ERR_get_error()) {
     if (ERR_GET_LIB(err) == ERR_LIB_SSL) {
       if (ERR_GET_REASON(err) == SSL_R_PEER_DID_NOT_RETURN_A_CERTIFICATE) {
-        dynamic_cast<Ssl::ContextImpl&>(*ctx_).stats().fail_verify_no_cert_.inc();
+        ctx_->stats().fail_verify_no_cert_.inc();
         saw_counted_error = true;
       } else if (ERR_GET_REASON(err) == SSL_R_CERTIFICATE_VERIFY_FAILED) {
         saw_counted_error = true;
@@ -139,7 +139,7 @@ void SslSocket::drainErrorQueue() {
                    ERR_reason_error_string(err));
   }
   if (saw_error && !saw_counted_error) {
-    dynamic_cast<Ssl::ContextImpl&>(*ctx_).stats().connection_error_.inc();
+    ctx_->stats().connection_error_.inc();
   }
 }
 

--- a/source/common/ssl/ssl_socket.cc
+++ b/source/common/ssl/ssl_socket.cc
@@ -385,7 +385,7 @@ std::string SslSocket::subjectLocalCertificate() const {
 ClientSslSocketFactory::ClientSslSocketFactory(const ClientContextConfig& config,
                                                Ssl::ContextManager& manager,
                                                Stats::Scope& stats_scope)
-    : manager_(manager), ssl_ctx_(manager.createSslClientContext(stats_scope, config)) {}
+    : ssl_ctx_(manager.createSslClientContext(stats_scope, config)) {}
 
 Network::TransportSocketPtr ClientSslSocketFactory::createTransportSocket() const {
   return std::make_unique<Ssl::SslSocket>(ssl_ctx_, Ssl::InitialState::Client);
@@ -397,8 +397,7 @@ ServerSslSocketFactory::ServerSslSocketFactory(const ServerContextConfig& config
                                                Ssl::ContextManager& manager,
                                                Stats::Scope& stats_scope,
                                                const std::vector<std::string>& server_names)
-    : manager_(manager),
-      ssl_ctx_(manager.createSslServerContext(stats_scope, config, server_names)) {}
+    : ssl_ctx_(manager.createSslServerContext(stats_scope, config, server_names)) {}
 
 Network::TransportSocketPtr ServerSslSocketFactory::createTransportSocket() const {
   return std::make_unique<Ssl::SslSocket>(ssl_ctx_, Ssl::InitialState::Server);

--- a/source/common/ssl/ssl_socket.cc
+++ b/source/common/ssl/ssl_socket.cc
@@ -387,8 +387,6 @@ ClientSslSocketFactory::ClientSslSocketFactory(const ClientContextConfig& config
                                                Stats::Scope& stats_scope)
     : manager_(manager), ssl_ctx_(manager.createSslClientContext(stats_scope, config)) {}
 
-ClientSslSocketFactory::~ClientSslSocketFactory() { manager_.removeContext(ssl_ctx_.get()); }
-
 Network::TransportSocketPtr ClientSslSocketFactory::createTransportSocket() const {
   return std::make_unique<Ssl::SslSocket>(ssl_ctx_, Ssl::InitialState::Client);
 }
@@ -401,8 +399,6 @@ ServerSslSocketFactory::ServerSslSocketFactory(const ServerContextConfig& config
                                                const std::vector<std::string>& server_names)
     : manager_(manager),
       ssl_ctx_(manager.createSslServerContext(stats_scope, config, server_names)) {}
-
-ServerSslSocketFactory::~ServerSslSocketFactory() { manager_.removeContext(ssl_ctx_.get()); }
 
 Network::TransportSocketPtr ServerSslSocketFactory::createTransportSocket() const {
   return std::make_unique<Ssl::SslSocket>(ssl_ctx_, Ssl::InitialState::Server);

--- a/source/common/ssl/ssl_socket.cc
+++ b/source/common/ssl/ssl_socket.cc
@@ -15,8 +15,9 @@ using Envoy::Network::PostIoAction;
 namespace Envoy {
 namespace Ssl {
 
-SslSocket::SslSocket(Context& ctx, InitialState state)
-    : ctx_(dynamic_cast<Ssl::ContextImpl&>(ctx)), ssl_(ctx_.newSsl()) {
+SslSocket::SslSocket(ContextSharedPtr ctx, InitialState state)
+  //  : ctx_owner_(ctx), ctx_(dynamic_cast<Ssl::ContextImpl&>(*ctx)), ssl_(ctx_.newSsl()) {
+  : ctx_(dynamic_cast<Ssl::ContextImpl&>(*ctx)), ssl_(ctx_.newSsl()) {
   if (state == InitialState::Client) {
     SSL_set_connect_state(ssl_.get());
   } else {
@@ -388,7 +389,7 @@ ClientSslSocketFactory::ClientSslSocketFactory(const ClientContextConfig& config
     : ssl_ctx_(manager.createSslClientContext(stats_scope, config)) {}
 
 Network::TransportSocketPtr ClientSslSocketFactory::createTransportSocket() const {
-  return std::make_unique<Ssl::SslSocket>(*ssl_ctx_, Ssl::InitialState::Client);
+  return std::make_unique<Ssl::SslSocket>(ssl_ctx_, Ssl::InitialState::Client);
 }
 
 bool ClientSslSocketFactory::implementsSecureTransport() const { return true; }
@@ -400,7 +401,7 @@ ServerSslSocketFactory::ServerSslSocketFactory(const ServerContextConfig& config
     : ssl_ctx_(manager.createSslServerContext(stats_scope, config, server_names)) {}
 
 Network::TransportSocketPtr ServerSslSocketFactory::createTransportSocket() const {
-  return std::make_unique<Ssl::SslSocket>(*ssl_ctx_, Ssl::InitialState::Server);
+  return std::make_unique<Ssl::SslSocket>(ssl_ctx_, Ssl::InitialState::Server);
 }
 
 bool ServerSslSocketFactory::implementsSecureTransport() const { return true; }

--- a/source/common/ssl/ssl_socket.h
+++ b/source/common/ssl/ssl_socket.h
@@ -71,7 +71,6 @@ class ClientSslSocketFactory : public Network::TransportSocketFactory {
 public:
   ClientSslSocketFactory(const ClientContextConfig& config, Ssl::ContextManager& manager,
                          Stats::Scope& stats_scope);
-  ~ClientSslSocketFactory();
 
   Network::TransportSocketPtr createTransportSocket() const override;
   bool implementsSecureTransport() const override;
@@ -85,7 +84,6 @@ class ServerSslSocketFactory : public Network::TransportSocketFactory {
 public:
   ServerSslSocketFactory(const ServerContextConfig& config, Ssl::ContextManager& manager,
                          Stats::Scope& stats_scope, const std::vector<std::string>& server_names);
-  ~ServerSslSocketFactory();
 
   Network::TransportSocketPtr createTransportSocket() const override;
   bool implementsSecureTransport() const override;

--- a/source/common/ssl/ssl_socket.h
+++ b/source/common/ssl/ssl_socket.h
@@ -20,7 +20,7 @@ class SslSocket : public Network::TransportSocket,
                   public Connection,
                   protected Logger::Loggable<Logger::Id::connection> {
 public:
-  SslSocket(Context& ctx, InitialState state);
+  SslSocket(ContextSharedPtr ctx, InitialState state);
 
   // Ssl::Connection
   bool peerCertificatePresented() const override;
@@ -58,6 +58,7 @@ private:
   std::vector<std::string> getDnsSansFromCertificate(X509* cert);
 
   Network::TransportSocketCallbacks* callbacks_{};
+  ContextSharedPtr ctx_owner_;
   ContextImpl& ctx_;
   bssl::UniquePtr<SSL> ssl_;
   bool handshake_complete_{};
@@ -75,7 +76,7 @@ public:
   bool implementsSecureTransport() const override;
 
 private:
-  const ClientContextPtr ssl_ctx_;
+  ClientContextSharedPtr ssl_ctx_;
 };
 
 class ServerSslSocketFactory : public Network::TransportSocketFactory {
@@ -86,7 +87,7 @@ public:
   bool implementsSecureTransport() const override;
 
 private:
-  const ServerContextPtr ssl_ctx_;
+  ServerContextSharedPtr ssl_ctx_;
 };
 
 } // namespace Ssl

--- a/source/common/ssl/ssl_socket.h
+++ b/source/common/ssl/ssl_socket.h
@@ -58,7 +58,7 @@ private:
   std::vector<std::string> getDnsSansFromCertificate(X509* cert);
 
   Network::TransportSocketCallbacks* callbacks_{};
-  ContextSharedPtr ctx_;
+  ContextImplSharedPtr ctx_;
   bssl::UniquePtr<SSL> ssl_;
   bool handshake_complete_{};
   bool shutdown_sent_{};

--- a/source/common/ssl/ssl_socket.h
+++ b/source/common/ssl/ssl_socket.h
@@ -76,7 +76,6 @@ public:
   bool implementsSecureTransport() const override;
 
 private:
-  Ssl::ContextManager& manager_;
   ClientContextSharedPtr ssl_ctx_;
 };
 
@@ -89,7 +88,6 @@ public:
   bool implementsSecureTransport() const override;
 
 private:
-  Ssl::ContextManager& manager_;
   ServerContextSharedPtr ssl_ctx_;
 };
 

--- a/source/common/ssl/ssl_socket.h
+++ b/source/common/ssl/ssl_socket.h
@@ -58,8 +58,7 @@ private:
   std::vector<std::string> getDnsSansFromCertificate(X509* cert);
 
   Network::TransportSocketCallbacks* callbacks_{};
-  ContextSharedPtr ctx_owner_;
-  ContextImpl& ctx_;
+  ContextSharedPtr ctx_;
   bssl::UniquePtr<SSL> ssl_;
   bool handshake_complete_{};
   bool shutdown_sent_{};
@@ -72,10 +71,13 @@ class ClientSslSocketFactory : public Network::TransportSocketFactory {
 public:
   ClientSslSocketFactory(const ClientContextConfig& config, Ssl::ContextManager& manager,
                          Stats::Scope& stats_scope);
+  ~ClientSslSocketFactory();
+
   Network::TransportSocketPtr createTransportSocket() const override;
   bool implementsSecureTransport() const override;
 
 private:
+  Ssl::ContextManager& manager_;
   ClientContextSharedPtr ssl_ctx_;
 };
 
@@ -83,10 +85,13 @@ class ServerSslSocketFactory : public Network::TransportSocketFactory {
 public:
   ServerSslSocketFactory(const ServerContextConfig& config, Ssl::ContextManager& manager,
                          Stats::Scope& stats_scope, const std::vector<std::string>& server_names);
+  ~ServerSslSocketFactory();
+
   Network::TransportSocketPtr createTransportSocket() const override;
   bool implementsSecureTransport() const override;
 
 private:
+  Ssl::ContextManager& manager_;
   ServerContextSharedPtr ssl_ctx_;
 };
 

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -399,6 +399,7 @@ public:
   Upstream::MockThreadLocalCluster thread_local_cluster_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   Runtime::MockLoader runtime_;
+  Ssl::ContextManagerImpl context_manager_{runtime_};
   NiceMock<Runtime::MockRandomGenerator> random_;
   Http::AsyncClientPtr http_async_client_;
   Http::ConnectionPool::InstancePtr http_conn_pool_;
@@ -421,6 +422,7 @@ public:
     // doesn't like dangling contexts at destruction.
     GrpcClientIntegrationTest::TearDown();
     fake_upstream_.reset();
+    async_client_transport_socket_.reset();
     client_connection_.reset();
     mock_cluster_info_->transport_socket_factory_.reset();
   }
@@ -483,7 +485,6 @@ public:
 
   bool use_client_cert_{};
   Secret::MockSecretManager secret_manager_;
-  Ssl::ContextManagerImpl context_manager_{runtime_};
 };
 
 } // namespace

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -99,7 +99,7 @@ TEST_F(SslContextImplTest, TestExpiringCert) {
   Runtime::MockLoader runtime;
   ContextManagerImpl manager(runtime);
   Stats::IsolatedStoreImpl store;
-  ClientContextPtr context(manager.createSslClientContext(store, cfg));
+  ClientContextSharedPtr context(manager.createSslClientContext(store, cfg));
 
   // This is a total hack, but right now we generate the cert and it expires in 15 days only in the
   // first second that it's valid. This can become invalid and then cause slower tests to fail.
@@ -122,7 +122,7 @@ TEST_F(SslContextImplTest, TestExpiredCert) {
   Runtime::MockLoader runtime;
   ContextManagerImpl manager(runtime);
   Stats::IsolatedStoreImpl store;
-  ClientContextPtr context(manager.createSslClientContext(store, cfg));
+  ClientContextSharedPtr context(manager.createSslClientContext(store, cfg));
   EXPECT_EQ(0U, context->daysUntilFirstCertExpires());
 }
 
@@ -141,7 +141,7 @@ TEST_F(SslContextImplTest, TestGetCertInformation) {
   ContextManagerImpl manager(runtime);
   Stats::IsolatedStoreImpl store;
 
-  ClientContextPtr context(manager.createSslClientContext(store, cfg));
+  ClientContextSharedPtr context(manager.createSslClientContext(store, cfg));
   // This is similar to the hack above, but right now we generate the ca_cert and it expires in 15
   // days only in the first second that it's valid. We will partially match for up until Days until
   // Expiration: 1.
@@ -166,7 +166,7 @@ TEST_F(SslContextImplTest, TestNoCert) {
   Runtime::MockLoader runtime;
   ContextManagerImpl manager(runtime);
   Stats::IsolatedStoreImpl store;
-  ClientContextPtr context(manager.createSslClientContext(store, cfg));
+  ClientContextSharedPtr context(manager.createSslClientContext(store, cfg));
   EXPECT_EQ("", context->getCaCertInformation());
   EXPECT_EQ("", context->getCertChainInformation());
 }
@@ -178,7 +178,7 @@ public:
     Secret::MockSecretManager secret_manager;
     ContextManagerImpl manager(runtime);
     Stats::IsolatedStoreImpl store;
-    ServerContextPtr server_ctx(
+    ServerContextSharedPtr server_ctx(
         manager.createSslServerContext(store, cfg, std::vector<std::string>{}));
   }
 
@@ -500,7 +500,7 @@ TEST(ServerContextImplTest, TlsCertificateNonEmpty) {
   Runtime::MockLoader runtime;
   ContextManagerImpl manager(runtime);
   Stats::IsolatedStoreImpl store;
-  EXPECT_THROW_WITH_MESSAGE(ServerContextPtr server_ctx(manager.createSslServerContext(
+  EXPECT_THROW_WITH_MESSAGE(ServerContextSharedPtr server_ctx(manager.createSslServerContext(
                                 store, client_context_config, std::vector<std::string>{})),
                             EnvoyException,
                             "Server TlsCertificates must have a certificate specified");

--- a/test/common/ssl/ssl_socket_test.cc
+++ b/test/common/ssl/ssl_socket_test.cc
@@ -170,7 +170,7 @@ const std::string testUtilV2(const envoy::api::v2::Listener& server_proto,
 
   ClientContextConfigImpl client_ctx_config(client_ctx_proto, secret_manager);
   ClientSslSocketFactory client_ssl_socket_factory(client_ctx_config, manager, stats_store);
-  ClientContextPtr client_ctx(manager.createSslClientContext(stats_store, client_ctx_config));
+  ClientContextSharedPtr client_ctx(manager.createSslClientContext(stats_store, client_ctx_config));
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
       socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(), nullptr);
@@ -2754,7 +2754,7 @@ public:
   Network::ListenerPtr listener_;
   Json::ObjectSharedPtr client_ctx_loader_;
   std::unique_ptr<ClientContextConfigImpl> client_ctx_config_;
-  ClientContextPtr client_ctx_;
+  ClientContextSharedPtr client_ctx_;
   Network::TransportSocketFactoryPtr client_ssl_socket_factory_;
   Network::ClientConnectionPtr client_connection_;
   Network::ConnectionPtr server_connection_;

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -50,6 +50,8 @@ void SslIntegrationTest::TearDown() {
   client_ssl_ctx_alpn_.reset();
   client_ssl_ctx_san_.reset();
   client_ssl_ctx_alpn_san_.reset();
+  HttpIntegrationTest::cleanupUpstreamAndDownstream();
+  codec_client_.reset();
   context_manager_.reset();
   runtime_.reset();
 }

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -31,6 +31,8 @@ void XfccIntegrationTest::TearDown() {
   client_tls_ssl_ctx_.reset();
   fake_upstream_connection_.reset();
   fake_upstreams_.clear();
+  HttpIntegrationTest::cleanupUpstreamAndDownstream();
+  codec_client_.reset();
   context_manager_.reset();
   runtime_.reset();
 }

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -21,14 +21,14 @@ public:
   MockContextManager();
   ~MockContextManager();
 
-  ClientContextPtr createSslClientContext(Stats::Scope& scope,
+  ClientContextSharedPtr createSslClientContext(Stats::Scope& scope,
                                           const ClientContextConfig& config) override {
-    return ClientContextPtr{createSslClientContext_(scope, config)};
+    return ClientContextSharedPtr{createSslClientContext_(scope, config)};
   }
 
-  ServerContextPtr createSslServerContext(Stats::Scope& scope, const ServerContextConfig& config,
+  ServerContextSharedPtr createSslServerContext(Stats::Scope& scope, const ServerContextConfig& config,
                                           const std::vector<std::string>& server_names) override {
-    return ServerContextPtr{createSslServerContext_(scope, config, server_names)};
+    return ServerContextSharedPtr{createSslServerContext_(scope, config, server_names)};
   }
 
   MOCK_METHOD2(createSslClientContext_,

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -32,8 +32,6 @@ public:
     return ServerContextSharedPtr{createSslServerContext_(scope, config, server_names)};
   }
 
-  MOCK_METHOD1(removeContext, void(Context*));
-
   MOCK_METHOD2(createSslClientContext_,
                ClientContext*(Stats::Scope& scope, const ClientContextConfig& config));
   MOCK_METHOD3(createSslServerContext_,

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -22,14 +22,17 @@ public:
   ~MockContextManager();
 
   ClientContextSharedPtr createSslClientContext(Stats::Scope& scope,
-                                          const ClientContextConfig& config) override {
+                                                const ClientContextConfig& config) override {
     return ClientContextSharedPtr{createSslClientContext_(scope, config)};
   }
 
-  ServerContextSharedPtr createSslServerContext(Stats::Scope& scope, const ServerContextConfig& config,
-                                          const std::vector<std::string>& server_names) override {
+  ServerContextSharedPtr
+  createSslServerContext(Stats::Scope& scope, const ServerContextConfig& config,
+                         const std::vector<std::string>& server_names) override {
     return ServerContextSharedPtr{createSslServerContext_(scope, config, server_names)};
   }
+
+  MOCK_METHOD1(removeContext, void(Context*));
 
   MOCK_METHOD2(createSslClientContext_,
                ClientContext*(Stats::Scope& scope, const ClientContextConfig& config));

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -21,22 +21,11 @@ public:
   MockContextManager();
   ~MockContextManager();
 
-  ClientContextSharedPtr createSslClientContext(Stats::Scope& scope,
-                                                const ClientContextConfig& config) override {
-    return ClientContextSharedPtr{createSslClientContext_(scope, config)};
-  }
-
-  ServerContextSharedPtr
-  createSslServerContext(Stats::Scope& scope, const ServerContextConfig& config,
-                         const std::vector<std::string>& server_names) override {
-    return ServerContextSharedPtr{createSslServerContext_(scope, config, server_names)};
-  }
-
-  MOCK_METHOD2(createSslClientContext_,
-               ClientContext*(Stats::Scope& scope, const ClientContextConfig& config));
-  MOCK_METHOD3(createSslServerContext_,
-               ServerContext*(Stats::Scope& stats, const ServerContextConfig& config,
-                              const std::vector<std::string>& server_names));
+  MOCK_METHOD2(createSslClientContext,
+               ClientContextSharedPtr(Stats::Scope& scope, const ClientContextConfig& config));
+  MOCK_METHOD3(createSslServerContext,
+               ServerContextSharedPtr(Stats::Scope& stats, const ServerContextConfig& config,
+                                      const std::vector<std::string>& server_names));
   MOCK_CONST_METHOD0(daysUntilFirstCertExpires, size_t());
   MOCK_METHOD1(iterateContexts, void(std::function<void(const Context&)> callback));
 };


### PR DESCRIPTION
*Description*:  This is one of PR to support dynamic secret for SDS.  The master design is in this PR <https://github.com/envoyproxy/envoy/pull/3748>.
This PR only changes Ssl context to use shared_ptr.
1) ssl_socket is holding one ref_count of ctx;
2) socketFactory is holding another ref_count, but this one can be updated if dynamic secret is changed. 
With shared_ptr, existing sockets still work since they are holding ref_count to the old ctx so it will not be deleted. 

*Risk Level*:  Low

*Testing*:  all unit tests passed.

*Docs Changes*:  None

*Release Notes*: None
[Optional Fixes #Issue]
[Optional *Deprecated*:]
