### PR TITLE
authz_bugfix: headers need to be copied

### DIFF
--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -30,7 +30,7 @@ void Filter::initiateCall(const Http::HeaderMap& headers) {
   // Don't let the filter chain continue as we are going to invoke check call.
   filter_return_ = FilterReturn::StopDecoding;
   initiating_call_ = true;
-  ENVOY_STREAM_LOG(trace, "Ext_authz calling authorization server", *callbacks_);
+  ENVOY_STREAM_LOG(trace, "Ext_authz filter calling authorization server", *callbacks_);
   client_->check(*this, check_request_, callbacks_->activeSpan());
   initiating_call_ = false;
 }
@@ -102,15 +102,15 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
   if (response->status == CheckStatus::Denied ||
       (response->status == CheckStatus::Error && !config_->failureModeAllow())) {
     ENVOY_STREAM_LOG(debug, "Ext_authz rejected the request", *callbacks_);
+    ENVOY_STREAM_LOG(trace, "Ext_authz downstream header(s):", *callbacks_);
     callbacks_->sendLocalReply(
         response->status_code, response->body,
         [& authz_headers = response->headers_to_add,
          &callbacks = *callbacks_ ](Http::HeaderMap & response_headers)
             ->void {
               for (const auto& header : authz_headers) {
-                ENVOY_STREAM_LOG(trace, "Ext_authz rejected response header '{}':'{}'", callbacks,
-                                 header.first.get(), header.second);
-                response_headers.addReferenceKey(header.first, header.second);
+                ENVOY_STREAM_LOG(trace, " '{}':'{}'", callbacks, header.first.get(), header.second);
+                response_headers.addCopy(header.first, header.second);
               }
             });
     callbacks_->requestInfo().setResponseFlag(
@@ -125,17 +125,22 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
     }
     // Only send headers if the response is ok.
     if (response->status == CheckStatus::OK) {
+      ENVOY_STREAM_LOG(trace, "Ext_authz upstream header(s):", *callbacks_);
       for (const auto& header : response->headers_to_add) {
-        request_headers_->setReferenceKey(header.first, header.second);
-        ENVOY_STREAM_LOG(trace, "Ext_authz ok response added header '{}':'{}'", *callbacks_,
-                         header.first.get(), header.second);
+        Http::HeaderEntry* header_to_modify = request_headers_->get(header.first);
+        if (header_to_modify) {
+          header_to_modify->value(header.second.c_str(), header.second.size());
+
+        } else {
+          request_headers_->addCopy(header.first, header.second);
+        }
+        ENVOY_STREAM_LOG(trace, " '{}':'{}'", *callbacks_, header.first.get(), header.second);
       }
       for (const auto& header : response->headers_to_append) {
         Http::HeaderEntry* header_to_modify = request_headers_->get(header.first);
         if (header_to_modify) {
           Http::HeaderMapImpl::appendToHeader(header_to_modify->value(), header.second);
-          ENVOY_STREAM_LOG(trace, "Ext_authz ok response appended header '{}':'{}'", *callbacks_,
-                           header.first.get(), header.second);
+          ENVOY_STREAM_LOG(trace, " '{}':'{}'", *callbacks_, header.first.get(), header.second);
         }
       }
     }

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -103,16 +103,18 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
       (response->status == CheckStatus::Error && !config_->failureModeAllow())) {
     ENVOY_STREAM_LOG(debug, "Ext_authz rejected the request", *callbacks_);
     ENVOY_STREAM_LOG(trace, "Ext_authz downstream header(s):", *callbacks_);
+
+    std::string body{response->body};
+    Http::HeaderVector headers{response->headers_to_add};
+
     callbacks_->sendLocalReply(
-        response->status_code, response->body,
-        [& authz_headers = response->headers_to_add,
-         &callbacks = *callbacks_ ](Http::HeaderMap & response_headers)
-            ->void {
-              for (const auto& header : authz_headers) {
-                ENVOY_STREAM_LOG(trace, " '{}':'{}'", callbacks, header.first.get(), header.second);
-                response_headers.addCopy(header.first, header.second);
-              }
-            });
+        response->status_code, body,
+        [& headers = headers, &callbacks = *callbacks_ ](Http::HeaderMap & response_headers)->void {
+          for (const auto& header : headers) {
+            response_headers.setReferenceKey(header.first, header.second);
+            ENVOY_STREAM_LOG(trace, " '{}':'{}'", callbacks, header.first.get(), header.second);
+          }
+        });
     callbacks_->requestInfo().setResponseFlag(
         RequestInfo::ResponseFlag::UnauthorizedExternalService);
   } else {

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -104,16 +104,16 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
     ENVOY_STREAM_LOG(debug, "Ext_authz rejected the request", *callbacks_);
     ENVOY_STREAM_LOG(trace, "Ext_authz downstream header(s):", *callbacks_);
     const std::string body = std::move(response->body);
-    callbacks_->sendLocalReply(
-        response->status_code, body,
-        [& headers = response->headers_to_add,
-         &callbacks = *callbacks_ ](Http::HeaderMap & response_headers)
-            ->void {
-              for (const auto& header : headers) {
-                response_headers.addCopy(header.first, header.second);
-                ENVOY_STREAM_LOG(trace, " '{}':'{}'", callbacks, header.first.get(), header.second);
-              }
-            });
+    callbacks_->sendLocalReply(response->status_code, body,
+                               [& headers = response->headers_to_add,
+                                &callbacks = *callbacks_ ](Http::HeaderMap & response_headers)
+                                   ->void {
+                                     for (const auto& header : headers) {
+                                       response_headers.addCopy(header.first, header.second);
+                                       ENVOY_STREAM_LOG(trace, " '{}':'{}'", callbacks,
+                                                        header.first.get(), header.second);
+                                     }
+                                   });
     callbacks_->requestInfo().setResponseFlag(
         RequestInfo::ResponseFlag::UnauthorizedExternalService);
   } else {

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -103,18 +103,17 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
       (response->status == CheckStatus::Error && !config_->failureModeAllow())) {
     ENVOY_STREAM_LOG(debug, "Ext_authz rejected the request", *callbacks_);
     ENVOY_STREAM_LOG(trace, "Ext_authz downstream header(s):", *callbacks_);
-
-    std::string body{response->body};
-    Http::HeaderVector headers{response->headers_to_add};
-
+    const std::string body = std::move(response->body);
     callbacks_->sendLocalReply(
         response->status_code, body,
-        [& headers = headers, &callbacks = *callbacks_ ](Http::HeaderMap & response_headers)->void {
-          for (const auto& header : headers) {
-            response_headers.setReferenceKey(header.first, header.second);
-            ENVOY_STREAM_LOG(trace, " '{}':'{}'", callbacks, header.first.get(), header.second);
-          }
-        });
+        [& headers = response->headers_to_add,
+         &callbacks = *callbacks_ ](Http::HeaderMap & response_headers)
+            ->void {
+              for (const auto& header : headers) {
+                response_headers.addCopy(header.first, header.second);
+                ENVOY_STREAM_LOG(trace, " '{}':'{}'", callbacks, header.first.get(), header.second);
+              }
+            });
     callbacks_->requestInfo().setResponseFlag(
         RequestInfo::ResponseFlag::UnauthorizedExternalService);
   } else {

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -103,8 +103,7 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
       (response->status == CheckStatus::Error && !config_->failureModeAllow())) {
     ENVOY_STREAM_LOG(debug, "Ext_authz rejected the request", *callbacks_);
     ENVOY_STREAM_LOG(trace, "Ext_authz downstream header(s):", *callbacks_);
-    const std::string body = std::move(response->body);
-    callbacks_->sendLocalReply(response->status_code, body,
+    callbacks_->sendLocalReply(response->status_code, response->body,
                                [& headers = response->headers_to_add,
                                 &callbacks = *callbacks_ ](Http::HeaderMap & response_headers)
                                    ->void {

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -130,7 +130,6 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
         Http::HeaderEntry* header_to_modify = request_headers_->get(header.first);
         if (header_to_modify) {
           header_to_modify->value(header.second.c_str(), header.second.size());
-
         } else {
           request_headers_->addCopy(header.first, header.second);
         }

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -375,6 +375,57 @@ TEST_P(HttpExtAuthzFilterParamTest, DeniedResponseWith403) {
       cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("upstream_rq_403").value());
 }
 
+// Verify that authz response memory is not used after free.
+TEST_P(HttpExtAuthzFilterParamTest, DestroyResponseBeforeSendLocalReply) {
+  InSequence s;
+
+  ON_CALL(filter_callbacks_, connection()).WillByDefault(Return(&connection_));
+  EXPECT_CALL(connection_, remoteAddress()).WillOnce(ReturnRef(addr_));
+  EXPECT_CALL(connection_, localAddress()).WillOnce(ReturnRef(addr_));
+  EXPECT_CALL(*client_, check(_, _, _))
+      .WillOnce(
+          WithArgs<0>(Invoke([&](Filters::Common::ExtAuthz::RequestCallbacks& callbacks) -> void {
+            request_callbacks_ = &callbacks;
+          })));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers_, false));
+
+  Http::TestHeaderMapImpl response_headers{{":status", "403"},
+                                           {"content-length", "3"},
+                                           {"content-type", "text/plain"},
+                                           {"foo", "bar"},
+                                           {"bar", "foo"}};
+  EXPECT_CALL(filter_callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
+  EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
+  EXPECT_CALL(filter_callbacks_.request_info_,
+              setResponseFlag(Envoy::RequestInfo::ResponseFlag::UnauthorizedExternalService));
+
+  Filters::Common::ExtAuthz::Response response{};
+  response.status = Filters::Common::ExtAuthz::CheckStatus::Denied;
+  response.status_code = Http::Code::Forbidden;
+  response.body = std::string{"foo"};
+  response.headers_to_add = Http::HeaderVector{{Http::LowerCaseString{"foo"}, "bar"},
+                                               {Http::LowerCaseString{"bar"}, "foo"}};
+  Filters::Common::ExtAuthz::ResponsePtr response_ptr =
+      std::make_unique<Filters::Common::ExtAuthz::Response>(response);
+
+  ON_CALL(filter_callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false))
+      .WillByDefault(
+          Invoke([&response_ptr](Http::TestHeaderMapImpl, bool) -> void { response_ptr.reset(); }));
+
+  request_callbacks_->onComplete(std::move(response_ptr));
+
+  EXPECT_EQ(
+      1U,
+      cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("ext_authz.denied").value());
+  EXPECT_EQ(
+      1U,
+      cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("upstream_rq_4xx").value());
+  EXPECT_EQ(
+      1U,
+      cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("upstream_rq_403").value());
+}
+
 // Test that when a connection awaiting a authorization response is canceled then the
 // authorization call is closed.
 TEST_P(HttpExtAuthzFilterParamTest, ResetDuringCall) {


### PR DESCRIPTION
*Description*: This PR fixes https://github.com/envoyproxy/envoy/issues/3750. Headers passed from the ext_authz filter to either the upstream or to the downstream will need to be copied since they might not live beyond the request/response lifetime.

*Risk Level*: low
*Testing*: unit tests, manual test
*Docs Changes*: n/a
*Release Notes*: n/a