### PR TITLE
lua: add requestInfo():protocol() API

### DIFF
--- a/docs/root/configuration/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http_filters/lua_filter.rst
@@ -290,6 +290,17 @@ under the filter name i.e. *envoy.lua*. Below is an example of a *metadata* in a
 
 Returns a :ref:`metadata object <config_http_filters_lua_metadata_wrapper>`.
 
+requestInfo()
+^^^^^^^^^^^^^
+
+.. code-block:: lua
+
+  requestInfo = handle:requestInfo()
+
+Returns some :repo:`information <include/request_info/request_info.h>` related to the current request.
+
+Returns a :ref:`request info object <config_http_filters_lua_request_info_wrapper>`.
+
 .. _config_http_filters_lua_header_wrapper:
 
 Header object API
@@ -403,3 +414,18 @@ __pairs()
 
 Iterates through every *metadata* entry. *key* is a string that supplies a *metadata*
 key. *value* is *metadata* entry value.
+
+.. _config_http_filters_lua_request_info_wrapper:
+
+Request info object API
+-----------------------
+
+protocol()
+^^^^^^^^^^
+
+.. code-block:: lua
+
+  requestInfo:protocol()
+
+Returns the string representation of :repo:`HTTP protocol <include/envoy/http/protocol.h>`
+used by the current request. The possible values are: *HTTP/1.0*, *HTTP/1.1*, and *HTTP/2*.

--- a/docs/root/configuration/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http_filters/lua_filter.rst
@@ -297,7 +297,7 @@ requestInfo()
 
   requestInfo = handle:requestInfo()
 
-Returns some :repo:`information <include/request_info/request_info.h>` related to the current request.
+Returns :repo:`information <include/request_info/request_info.h>` related to the current request.
 
 Returns a :ref:`request info object <config_http_filters_lua_request_info_wrapper>`.
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -4,6 +4,7 @@ Version history
 1.8.0 (Pending)
 ===============
 * http: response filters not applied to early error paths such as http_parser generated 400s.
+* lua: added :ref:`requestInfo() <config_http_filters_lua_request_info_wrapper>` wrapper and *protocol()* API.
 * ratelimit: added support for :repo:`api/envoy/service/ratelimit/v2/rls.proto`.
   Lyft's reference implementation of the `ratelimit <https://github.com/lyft/ratelimit>`_ service also supports the data-plane-api proto as of v1.1.0.
   Envoy can use either proto to send client requests to a ratelimit server with the use of the

--- a/source/extensions/filters/http/lua/BUILD
+++ b/source/extensions/filters/http/lua/BUILD
@@ -34,6 +34,8 @@ envoy_cc_library(
     hdrs = ["wrappers.h"],
     deps = [
         "//include/envoy/http:header_map_interface",
+        "//include/envoy/request_info:request_info_interface",
+        "//source/common/http:utility_lib",
         "//source/extensions/filters/common/lua:lua_lib",
     ],
 )

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -367,6 +367,16 @@ int StreamHandleWrapper::luaMetadata(lua_State* state) {
   return 1;
 }
 
+int StreamHandleWrapper::luaRequestInfo(lua_State* state) {
+  ASSERT(state_ == State::Running);
+  if (request_info_wrapper_.get() != nullptr) {
+    request_info_wrapper_.pushStack();
+  } else {
+    request_info_wrapper_.reset(RequestInfoWrapper::create(state, callbacks_.requestInfo()), true);
+  }
+  return 1;
+}
+
 int StreamHandleWrapper::luaLogTrace(lua_State* state) {
   const char* message = luaL_checkstring(state, 2);
   filter_.scriptLog(spdlog::level::trace, message);
@@ -411,6 +421,7 @@ FilterConfig::FilterConfig(const std::string& lua_code, ThreadLocal::SlotAllocat
   lua_state_.registerType<Filters::Common::Lua::MetadataMapIterator>();
   lua_state_.registerType<HeaderMapWrapper>();
   lua_state_.registerType<HeaderMapIterator>();
+  lua_state_.registerType<RequestInfoWrapper>();
   lua_state_.registerType<StreamHandleWrapper>();
 
   request_function_slot_ = lua_state_.registerGlobal("envoy_on_request");

--- a/source/extensions/filters/http/lua/wrappers.cc
+++ b/source/extensions/filters/http/lua/wrappers.cc
@@ -1,5 +1,7 @@
 #include "extensions/filters/http/lua/wrappers.h"
 
+#include "common/http/utility.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -98,6 +100,11 @@ void HeaderMapWrapper::checkModifiable(lua_State* state) {
   if (!cb_()) {
     luaL_error(state, "header map can no longer be modified");
   }
+}
+
+int RequestInfoWrapper::luaProtocol(lua_State* state) {
+  lua_pushstring(state, Http::Utility::getProtocolString(request_info_.protocol().value()).c_str());
+  return 1;
 }
 
 } // namespace Lua

--- a/source/extensions/filters/http/lua/wrappers.h
+++ b/source/extensions/filters/http/lua/wrappers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/http/header_map.h"
+#include "envoy/request_info/request_info.h"
 
 #include "extensions/filters/common/lua/lua.h"
 
@@ -96,6 +97,23 @@ private:
   Filters::Common::Lua::LuaDeathRef<HeaderMapIterator> iterator_;
 
   friend class HeaderMapIterator;
+};
+
+/**
+ * Lua wrapper for a request info.
+ */
+class RequestInfoWrapper : public Filters::Common::Lua::BaseLuaObject<RequestInfoWrapper> {
+public:
+  RequestInfoWrapper(RequestInfo::RequestInfo& request_info) : request_info_{request_info} {}
+  static ExportedFunctions exportedFunctions() { return {{"protocol", static_luaProtocol}}; }
+
+private:
+  /**
+   * Get current protocol being used.
+   * @return string representation of Http::Protocol.
+   */
+  DECLARE_LUA_FUNCTION(RequestInfoWrapper, luaProtocol);
+  RequestInfo::RequestInfo& request_info_;
 };
 
 } // namespace Lua

--- a/test/extensions/filters/http/lua/BUILD
+++ b/test/extensions/filters/http/lua/BUILD
@@ -31,6 +31,7 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/lua:wrappers_lib",
         "//test/extensions/filters/common/lua:lua_wrappers_lib",
+        "//test/mocks/request_info:request_info_mocks",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -75,8 +75,8 @@ public:
   }
 
   void setupRequestInfoProtocol(const absl::optional<Envoy::Http::Protocol>& protocol) {
-    ON_CALL(request_info_, protocol()).WillByDefault(ReturnPointee(&protocol));
     EXPECT_CALL(decoder_callbacks_, requestInfo()).WillOnce(ReturnRef(request_info_));
+    EXPECT_CALL(request_info_, protocol()).WillOnce(ReturnPointee(&protocol));
   }
 
   NiceMock<ThreadLocal::MockInstance> tls_;

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1468,38 +1468,6 @@ TEST_F(LuaHttpFilterTest, GetMetadataFromHandleNoLuaMetadata) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 }
 
-TEST_F(LuaHttpFilterTest, GetCurrentProtocolHTTP11) {
-  const std::string SCRIPT{R"EOF(
-    function envoy_on_request(request_handle)
-      request_handle:logTrace(request_handle:requestInfo():protocol())
-    end
-  )EOF"};
-
-  InSequence s;
-  setup(SCRIPT);
-
-  setupRequestInfoProtocol(Http::Protocol::Http11);
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
-  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("HTTP/1.1")));
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
-}
-
-TEST_F(LuaHttpFilterTest, GetCurrentProtocolHTTP2) {
-  const std::string SCRIPT{R"EOF(
-    function envoy_on_request(request_handle)
-      request_handle:logTrace(request_handle:requestInfo():protocol())
-    end
-  )EOF"};
-
-  InSequence s;
-  setup(SCRIPT);
-
-  setupRequestInfoProtocol(Http::Protocol::Http2);
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
-  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("HTTP/2")));
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
-}
-
 } // namespace Lua
 } // namespace HttpFilters
 } // namespace Extensions


### PR DESCRIPTION
*Description*:
This patch adds `requestInfo():protocol()` to `StreamHandleWrapper`. This
API returns the HTTP protocol version used by current the request.

*Risk Level*: Low

*Testing*: 
Unit and integration tests

*Docs Changes*: 
- Add `requestInfo():protocol()` API.

*Release Notes*:
- lua: added `requestInfo()` wrapper and `protocol()` API.

Related issue: #3704

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>