### PR TITLE
Fixes #3756 by creating a new api_proto_library_internal build rule that

### DIFF
--- a/api/bazel/api_build_system.bzl
+++ b/api/bazel/api_build_system.bzl
@@ -74,6 +74,17 @@ def api_go_grpc_library(name, proto, deps = []):
         ]
     )
 
+# This is api_proto_library plus some logic internal to //envoy/api.
+def api_proto_library_internal(visibility = ["//visibility:private"], **kwargs):
+    # //envoy/docs/build.sh needs visibility in order to generate documents.
+    if visibility == ["//visibility:private"]:
+      visibility = ["//docs"]
+    elif visibility != ["//visibility:public"]:
+      visibility = visibility + ["//docs"]
+
+    api_proto_library(visibility=visibility, **kwargs)
+
+
 # TODO(htuch): has_services is currently ignored but will in future support
 # gRPC stub generation.
 # TODO(htuch): Automatically generate go_proto_library and go_grpc_library
@@ -85,11 +96,6 @@ def api_proto_library(name, visibility = ["//visibility:private"], srcs = [], de
     # cc_proto_library (or some Bazel aspect that works on proto_library) when
     # it can play well with the PGV plugin and (2) other language support that
     # can make use of native proto_library.
-
-    if visibility == ["//visibility:private"]:
-      visibility = ["//docs"]
-    elif visibility != ["//visibility:public"]:
-      visibility = visibility + ["//docs"]
 
     native.proto_library(
         name = name,

--- a/api/envoy/admin/v2alpha/BUILD
+++ b/api/envoy/admin/v2alpha/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "config_dump",
     srcs = ["config_dump.proto"],
     visibility = ["//visibility:public"],
@@ -14,7 +14,7 @@ api_proto_library(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "clusters",
     srcs = ["clusters.proto"],
     visibility = ["//visibility:public"],
@@ -26,7 +26,7 @@ api_proto_library(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "metrics",
     srcs = ["metrics.proto"],
     visibility = ["//visibility:public"],

--- a/api/envoy/api/v2/BUILD
+++ b/api/envoy/api/v2/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
@@ -16,7 +16,7 @@ package_group(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "discovery",
     srcs = ["discovery.proto"],
     visibility = [":friends"],
@@ -29,7 +29,7 @@ api_go_proto_library(
     deps = ["//envoy/api/v2/core:base_go_proto"],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "eds",
     srcs = ["eds.proto"],
     has_services = 1,
@@ -55,7 +55,7 @@ api_go_grpc_library(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "cds",
     srcs = ["cds.proto"],
     has_services = 1,
@@ -95,7 +95,7 @@ api_go_grpc_library(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "lds",
     srcs = ["lds.proto"],
     has_services = 1,
@@ -119,7 +119,7 @@ api_go_grpc_library(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "rds",
     srcs = ["rds.proto"],
     has_services = 1,

--- a/api/envoy/api/v2/auth/BUILD
+++ b/api/envoy/api/v2/auth/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
@@ -15,7 +15,7 @@ package_group(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "cert",
     srcs = ["cert.proto"],
     visibility = [":friends"],

--- a/api/envoy/api/v2/cluster/BUILD
+++ b/api/envoy/api/v2/cluster/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "circuit_breaker",
     srcs = ["circuit_breaker.proto"],
     visibility = [
@@ -21,7 +21,7 @@ api_go_proto_library(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "outlier_detection",
     srcs = ["outlier_detection.proto"],
     visibility = [

--- a/api/envoy/api/v2/core/BUILD
+++ b/api/envoy/api/v2/core/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
@@ -16,7 +16,7 @@ package_group(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "address",
     srcs = ["address.proto"],
     visibility = [
@@ -31,7 +31,7 @@ api_go_proto_library(
     deps = [":base_go_proto"],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "base",
     srcs = ["base.proto"],
     visibility = [
@@ -44,7 +44,7 @@ api_go_proto_library(
     proto = ":base",
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "health_check",
     srcs = ["health_check.proto"],
     visibility = [
@@ -59,7 +59,7 @@ api_go_proto_library(
     deps = [":base_go_proto"],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "config_source",
     srcs = ["config_source.proto"],
     visibility = [
@@ -85,7 +85,7 @@ api_go_proto_library(
     proto = ":http_uri",
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "http_uri",
     srcs = ["http_uri.proto"],
     visibility = [
@@ -93,7 +93,7 @@ api_proto_library(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "grpc_service",
     srcs = ["grpc_service.proto"],
     visibility = [
@@ -108,7 +108,7 @@ api_go_proto_library(
     deps = [":base_go_proto"],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "protocol",
     srcs = ["protocol.proto"],
     visibility = [

--- a/api/envoy/api/v2/endpoint/BUILD
+++ b/api/envoy/api/v2/endpoint/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "endpoint",
     srcs = ["endpoint.proto"],
     visibility = ["//envoy/api/v2:friends"],
@@ -29,7 +29,7 @@ api_go_proto_library(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "load_report",
     srcs = ["load_report.proto"],
     visibility = ["//envoy/api/v2:friends"],

--- a/api/envoy/api/v2/listener/BUILD
+++ b/api/envoy/api/v2/listener/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "listener",
     srcs = ["listener.proto"],
     visibility = ["//envoy/api/v2:friends"],

--- a/api/envoy/api/v2/ratelimit/BUILD
+++ b/api/envoy/api/v2/ratelimit/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "ratelimit",
     srcs = ["ratelimit.proto"],
     visibility = ["//envoy/api/v2:friends"],

--- a/api/envoy/api/v2/route/BUILD
+++ b/api/envoy/api/v2/route/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "route",
     srcs = ["route.proto"],
     visibility = ["//envoy/api/v2:friends"],

--- a/api/envoy/config/accesslog/v2/BUILD
+++ b/api/envoy/config/accesslog/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "als",
     srcs = ["als.proto"],
     deps = [
@@ -10,7 +10,7 @@ api_proto_library(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "file",
     srcs = ["file.proto"],
 )

--- a/api/envoy/config/bootstrap/v2/BUILD
+++ b/api/envoy/config/bootstrap/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "bootstrap",
     srcs = ["bootstrap.proto"],
     visibility = ["//visibility:public"],

--- a/api/envoy/config/filter/accesslog/v2/BUILD
+++ b/api/envoy/config/filter/accesslog/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "accesslog",
     srcs = ["accesslog.proto"],
     visibility = [

--- a/api/envoy/config/filter/fault/v2/BUILD
+++ b/api/envoy/config/filter/fault/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "fault",
     srcs = ["fault.proto"],
     visibility = [

--- a/api/envoy/config/filter/http/buffer/v2/BUILD
+++ b/api/envoy/config/filter/http/buffer/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "buffer",
     srcs = ["buffer.proto"],
 )

--- a/api/envoy/config/filter/http/ext_authz/v2alpha/BUILD
+++ b/api/envoy/config/filter/http/ext_authz/v2alpha/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "ext_authz",
     srcs = ["ext_authz.proto"],
     deps = [

--- a/api/envoy/config/filter/http/fault/v2/BUILD
+++ b/api/envoy/config/filter/http/fault/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "fault",
     srcs = ["fault.proto"],
     deps = [

--- a/api/envoy/config/filter/http/gzip/v2/BUILD
+++ b/api/envoy/config/filter/http/gzip/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "gzip",
     srcs = ["gzip.proto"],
 )

--- a/api/envoy/config/filter/http/header_to_metadata/v2/BUILD
+++ b/api/envoy/config/filter/http/header_to_metadata/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "header_to_metadata",
     srcs = ["header_to_metadata.proto"],
     deps = [],

--- a/api/envoy/config/filter/http/health_check/v2/BUILD
+++ b/api/envoy/config/filter/http/health_check/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "health_check",
     srcs = ["health_check.proto"],
     deps = [

--- a/api/envoy/config/filter/http/ip_tagging/v2/BUILD
+++ b/api/envoy/config/filter/http/ip_tagging/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "ip_tagging",
     srcs = ["ip_tagging.proto"],
     deps = ["//envoy/api/v2/core:address"],

--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/BUILD
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/BUILD
@@ -1,8 +1,8 @@
 licenses(["notice"])  # Apache 2
 
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
-api_proto_library(
+api_proto_library_internal(
     name = "jwt_authn",
     srcs = ["config.proto"],
     deps = [

--- a/api/envoy/config/filter/http/lua/v2/BUILD
+++ b/api/envoy/config/filter/http/lua/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "lua",
     srcs = ["lua.proto"],
 )

--- a/api/envoy/config/filter/http/rate_limit/v2/BUILD
+++ b/api/envoy/config/filter/http/rate_limit/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "rate_limit",
     srcs = ["rate_limit.proto"],
 )

--- a/api/envoy/config/filter/http/rbac/v2/BUILD
+++ b/api/envoy/config/filter/http/rbac/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "rbac",
     srcs = ["rbac.proto"],
     deps = ["//envoy/config/rbac/v2alpha:rbac"],

--- a/api/envoy/config/filter/http/router/v2/BUILD
+++ b/api/envoy/config/filter/http/router/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "router",
     srcs = ["router.proto"],
     deps = ["//envoy/config/filter/accesslog/v2:accesslog"],

--- a/api/envoy/config/filter/http/squash/v2/BUILD
+++ b/api/envoy/config/filter/http/squash/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "squash",
     srcs = ["squash.proto"],
 )

--- a/api/envoy/config/filter/http/transcoder/v2/BUILD
+++ b/api/envoy/config/filter/http/transcoder/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "transcoder",
     srcs = ["transcoder.proto"],
 )

--- a/api/envoy/config/filter/network/client_ssl_auth/v2/BUILD
+++ b/api/envoy/config/filter/network/client_ssl_auth/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "client_ssl_auth",
     srcs = ["client_ssl_auth.proto"],
     deps = ["//envoy/api/v2/core:address"],

--- a/api/envoy/config/filter/network/ext_authz/v2/BUILD
+++ b/api/envoy/config/filter/network/ext_authz/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "ext_authz",
     srcs = ["ext_authz.proto"],
     deps = ["//envoy/api/v2/core:grpc_service"],

--- a/api/envoy/config/filter/network/http_connection_manager/v2/BUILD
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "http_connection_manager",
     srcs = ["http_connection_manager.proto"],
     deps = [

--- a/api/envoy/config/filter/network/mongo_proxy/v2/BUILD
+++ b/api/envoy/config/filter/network/mongo_proxy/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "mongo_proxy",
     srcs = ["mongo_proxy.proto"],
     deps = ["//envoy/config/filter/fault/v2:fault"],

--- a/api/envoy/config/filter/network/rate_limit/v2/BUILD
+++ b/api/envoy/config/filter/network/rate_limit/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "rate_limit",
     srcs = ["rate_limit.proto"],
     deps = ["//envoy/api/v2/ratelimit"],

--- a/api/envoy/config/filter/network/redis_proxy/v2/BUILD
+++ b/api/envoy/config/filter/network/redis_proxy/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "redis_proxy",
     srcs = ["redis_proxy.proto"],
 )

--- a/api/envoy/config/filter/network/tcp_proxy/v2/BUILD
+++ b/api/envoy/config/filter/network/tcp_proxy/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "tcp_proxy",
     srcs = ["tcp_proxy.proto"],
     deps = [

--- a/api/envoy/config/grpc_credential/v2alpha/BUILD
+++ b/api/envoy/config/grpc_credential/v2alpha/BUILD
@@ -1,8 +1,8 @@
 licenses(["notice"])  # Apache 2
 
-load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
-api_proto_library(
+api_proto_library_internal(
     name = "file_based_metadata",
     srcs = ["file_based_metadata.proto"],
     deps = ["//envoy/api/v2/core:base"],

--- a/api/envoy/config/health_checker/redis/v2/BUILD
+++ b/api/envoy/config/health_checker/redis/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "redis",
     srcs = ["redis.proto"],
 )

--- a/api/envoy/config/metrics/v2/BUILD
+++ b/api/envoy/config/metrics/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "metrics_service",
     srcs = ["metrics_service.proto"],
     visibility = [
@@ -21,7 +21,7 @@ api_go_proto_library(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "stats",
     srcs = ["stats.proto"],
     visibility = [

--- a/api/envoy/config/ratelimit/v2/BUILD
+++ b/api/envoy/config/ratelimit/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "rls",
     srcs = ["rls.proto"],
     visibility = [

--- a/api/envoy/config/rbac/v2alpha/BUILD
+++ b/api/envoy/config/rbac/v2alpha/BUILD
@@ -1,8 +1,8 @@
 licenses(["notice"])  # Apache 2
 
-load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
-api_proto_library(
+api_proto_library_internal(
     name = "rbac",
     srcs = ["rbac.proto"],
     visibility = ["//visibility:public"],

--- a/api/envoy/config/trace/v2/BUILD
+++ b/api/envoy/config/trace/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "trace",
     srcs = ["trace.proto"],
     visibility = [

--- a/api/envoy/config/transport_socket/capture/v2alpha/BUILD
+++ b/api/envoy/config/transport_socket/capture/v2alpha/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "capture",
     srcs = ["capture.proto"],
     deps = [

--- a/api/envoy/data/accesslog/v2/BUILD
+++ b/api/envoy/data/accesslog/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "accesslog",
     srcs = ["accesslog.proto"],
     visibility = [

--- a/api/envoy/data/tap/v2alpha/BUILD
+++ b/api/envoy/data/tap/v2alpha/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "capture",
     srcs = ["capture.proto"],
     deps = ["//envoy/api/v2/core:address"],

--- a/api/envoy/extensions/filters/network/thrift_proxy/v2alpha1/BUILD
+++ b/api/envoy/extensions/filters/network/thrift_proxy/v2alpha1/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "thrift_proxy",
     srcs = ["thrift_proxy.proto"],
 )

--- a/api/envoy/service/accesslog/v2/BUILD
+++ b/api/envoy/service/accesslog/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "als",
     srcs = ["als.proto"],
     has_services = 1,

--- a/api/envoy/service/auth/v2alpha/BUILD
+++ b/api/envoy/service/auth/v2alpha/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "attribute_context",
     srcs = [
         "attribute_context.proto",
@@ -12,7 +12,7 @@ api_proto_library(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "external_auth",
     srcs = [
         "external_auth.proto",

--- a/api/envoy/service/discovery/v2/BUILD
+++ b/api/envoy/service/discovery/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "ads",
     srcs = ["ads.proto"],
     has_services = 1,
@@ -19,7 +19,7 @@ api_go_grpc_library(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "hds",
     srcs = ["hds.proto"],
     has_services = 1,
@@ -40,7 +40,7 @@ api_go_grpc_library(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "sds",
     srcs = ["sds.proto"],
     has_services = 1,

--- a/api/envoy/service/load_stats/v2/BUILD
+++ b/api/envoy/service/load_stats/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "lrs",
     srcs = ["lrs.proto"],
     has_services = 1,

--- a/api/envoy/service/metrics/v2/BUILD
+++ b/api/envoy/service/metrics/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "metrics_service",
     srcs = ["metrics_service.proto"],
     has_services = 1,

--- a/api/envoy/service/ratelimit/v2/BUILD
+++ b/api/envoy/service/ratelimit/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "rls",
     srcs = ["rls.proto"],
     has_services = 1,

--- a/api/envoy/service/trace/v2/BUILD
+++ b/api/envoy/service/trace/v2/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_grpc_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "trace_service",
     srcs = ["trace_service.proto"],
     has_services = 1,

--- a/api/envoy/type/BUILD
+++ b/api/envoy/type/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "http_status",
     srcs = ["http_status.proto"],
     visibility = ["//visibility:public"],
@@ -13,7 +13,7 @@ api_go_proto_library(
     proto = ":http_status",
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "percent",
     srcs = ["percent.proto"],
     visibility = ["//visibility:public"],
@@ -24,7 +24,7 @@ api_go_proto_library(
     proto = ":percent",
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "range",
     srcs = ["range.proto"],
     visibility = ["//visibility:public"],

--- a/api/envoy/type/matcher/BUILD
+++ b/api/envoy/type/matcher/BUILD
@@ -1,8 +1,8 @@
-load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
-api_proto_library(
+api_proto_library_internal(
     name = "metadata",
     srcs = ["metadata.proto"],
     visibility = ["//visibility:public"],
@@ -21,7 +21,7 @@ api_go_proto_library(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "number",
     srcs = ["number.proto"],
     visibility = ["//visibility:public"],
@@ -38,7 +38,7 @@ api_go_proto_library(
     ],
 )
 
-api_proto_library(
+api_proto_library_internal(
     name = "string",
     srcs = ["string.proto"],
     visibility = ["//visibility:public"],

--- a/api/test/validate/BUILD
+++ b/api/test/validate/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:api_build_system.bzl", "api_cc_test", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_cc_test", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 


### PR DESCRIPTION
adds the required visibility rules and delegates the rest to the generic
api_proto_library.  I tested the change by doing the following without
getting errors.

./ci/run_envoy_docker.sh './ci/do_ci.sh docs'

I changed the BUILD files using the following commands.

/envoy/api$ find . -type f -name BUILD | xargs sed -i -e 's/api_proto_library(/api_proto_library_internal(/g'

envoy/api$ find . -type f -name BUILD | xargs sed -i -e 's/"api_proto_library"/"api_proto_library_internal"/g'

Signed-off-by: mickey <mickeyju@google.com>
