### PR TITLE
Add updateCertChain to SSL ContextImpl

### DIFF
--- a/source/common/ssl/context_impl.h
+++ b/source/common/ssl/context_impl.h
@@ -74,6 +74,11 @@ public:
   std::string getCaCertInformation() const override;
   std::string getCertChainInformation() const override;
 
+  /**
+     update the cert chain from the config.
+   */
+  void updateCertChain(const ContextConfig& config);
+
 protected:
   ContextImpl(ContextManagerImpl& parent, Stats::Scope& scope, const ContextConfig& config);
   ~ContextImpl() { parent_.releaseContext(this); }

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -158,6 +158,17 @@ TEST_F(SslContextImplTest, TestGetCertInformation) {
   EXPECT_TRUE(context->getCaCertInformation().find(ca_cert_partial_output) != std::string::npos);
   EXPECT_TRUE(context->getCertChainInformation().find(cert_chain_partial_output) !=
               std::string::npos);
+
+  // Update to an empty one.
+  Json::ObjectSharedPtr loader1 = TestEnvironment::jsonLoadFromString("{}");
+  ClientContextConfigImpl cfg1(*loader1, secret_manager_);
+  dynamic_cast<ContextImpl&>(*context).updateCertChain(cfg1);
+  EXPECT_EQ("", context->getCertChainInformation());
+
+  // Update back to a valid one.
+  dynamic_cast<ContextImpl&>(*context).updateCertChain(cfg);
+  EXPECT_TRUE(context->getCertChainInformation().find(cert_chain_partial_output) !=
+              std::string::npos);
 }
 
 TEST_F(SslContextImplTest, TestNoCert) {


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

*Description*:

This is one of PR to support SDS dynamic secret. Please see high level design PR:https://github.com/envoyproxy/envoy/pull/3748

In this PR,  a new function updateCertChain is added to SSL ContextImpl class to update SSL ctx for certchain. It will be used when certificate is updated from SDS, the Context object will update its internal SSL_CTX with the new certificates

*Risk Level*: Low

*Testing*:  Unit-test

*Docs Changes*:  None
*Release Notes*:  None
