### PR TITLE
thrift: split transport/protocol code into interface and implementation

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/BUILD
@@ -63,33 +63,63 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "protocol_lib",
-    srcs = [
-        "binary_protocol.cc",
-        "compact_protocol.cc",
-        "protocol.cc",
-    ],
+    name = "protocol_interface",
     hdrs = [
-        "binary_protocol.h",
-        "compact_protocol.h",
         "protocol.h",
     ],
     external_deps = ["abseil_optional"],
     deps = [
+        "//include/envoy/buffer:buffer_interface",
+        "//source/common/singleton:const_singleton",
+    ],
+)
+
+envoy_cc_library(
+    name = "protocol_lib",
+    srcs = [
+        "binary_protocol_impl.cc",
+        "compact_protocol_impl.cc",
+        "protocol_impl.cc",
+    ],
+    hdrs = [
+        "binary_protocol_impl.h",
+        "compact_protocol_impl.h",
+        "protocol_impl.h",
+    ],
+    external_deps = ["abseil_optional"],
+    deps = [
         ":buffer_helper_lib",
+        ":protocol_interface",
+        "//source/common/singleton:const_singleton",
+    ],
+)
+
+envoy_cc_library(
+    name = "transport_interface",
+    hdrs = ["transport.h"],
+    deps = [
+        ":protocol_lib",
+        "//include/envoy/buffer:buffer_interface",
         "//source/common/singleton:const_singleton",
     ],
 )
 
 envoy_cc_library(
     name = "transport_lib",
-    srcs = ["transport.cc"],
-    hdrs = ["transport.h"],
+    srcs = [
+        "framed_transport_impl.cc",
+        "transport_impl.cc",
+    ],
+    hdrs = [
+        "framed_transport_impl.h",
+        "transport_impl.h",
+        "unframed_transport_impl.h",
+    ],
     deps = [
         ":buffer_helper_lib",
         ":protocol_lib",
+        ":transport_interface",
         "//source/common/common:assert_lib",
-        "//source/common/common:utility_lib",
         "//source/common/singleton:const_singleton",
     ],
 )

--- a/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
@@ -1,4 +1,4 @@
-#include "extensions/filters/network/thrift_proxy/binary_protocol.h"
+#include "extensions/filters/network/thrift_proxy/binary_protocol_impl.h"
 
 #include "envoy/common/exception.h"
 

--- a/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.h
@@ -5,7 +5,7 @@
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/pure.h"
 
-#include "extensions/filters/network/thrift_proxy/protocol.h"
+#include "extensions/filters/network/thrift_proxy/protocol_impl.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.cc
@@ -1,4 +1,4 @@
-#include "extensions/filters/network/thrift_proxy/compact_protocol.h"
+#include "extensions/filters/network/thrift_proxy/compact_protocol_impl.h"
 
 #include "envoy/common/exception.h"
 

--- a/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.h
@@ -6,7 +6,7 @@
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/pure.h"
 
-#include "extensions/filters/network/thrift_proxy/protocol.h"
+#include "extensions/filters/network/thrift_proxy/protocol_impl.h"
 
 #include "absl/types/optional.h"
 

--- a/source/extensions/filters/network/thrift_proxy/filter.cc
+++ b/source/extensions/filters/network/thrift_proxy/filter.cc
@@ -5,8 +5,8 @@
 #include "common/common/assert.h"
 
 #include "extensions/filters/network/thrift_proxy/buffer_helper.h"
-#include "extensions/filters/network/thrift_proxy/protocol.h"
-#include "extensions/filters/network/thrift_proxy/transport.h"
+#include "extensions/filters/network/thrift_proxy/protocol_impl.h"
+#include "extensions/filters/network/thrift_proxy/transport_impl.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/filters/network/thrift_proxy/framed_transport_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/framed_transport_impl.cc
@@ -1,0 +1,38 @@
+#include "extensions/filters/network/thrift_proxy/framed_transport_impl.h"
+
+#include "envoy/common/exception.h"
+
+#include "extensions/filters/network/thrift_proxy/buffer_helper.h"
+#include "extensions/filters/network/thrift_proxy/transport_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+
+bool FramedTransportImpl::decodeFrameStart(Buffer::Instance& buffer) {
+  if (buffer.length() < 4) {
+    return false;
+  }
+
+  int32_t size = BufferHelper::peekI32(buffer);
+
+  if (size <= 0 || size > MaxFrameSize) {
+    throw EnvoyException(fmt::format("invalid thrift framed transport frame size {}", size));
+  }
+
+  onFrameStart(absl::optional<uint32_t>(static_cast<uint32_t>(size)));
+
+  buffer.drain(4);
+  return true;
+}
+
+bool FramedTransportImpl::decodeFrameEnd(Buffer::Instance&) {
+  onFrameComplete();
+  return true;
+}
+
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/thrift_proxy/framed_transport_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/framed_transport_impl.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/buffer/buffer.h"
+
+#include "extensions/filters/network/thrift_proxy/transport_impl.h"
+
+#include "absl/types/optional.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+
+/**
+ * FramedTransportImpl implements the Thrift Framed transport.
+ * See https://github.com/apache/thrift/blob/master/doc/specs/thrift-rpc.md
+ */
+class FramedTransportImpl : public TransportImplBase {
+public:
+  FramedTransportImpl(TransportCallbacks& callbacks) : TransportImplBase(callbacks) {}
+
+  // Transport
+  const std::string& name() const override { return TransportNames::get().FRAMED; }
+  bool decodeFrameStart(Buffer::Instance& buffer) override;
+  bool decodeFrameEnd(Buffer::Instance& buffer) override;
+
+  static const int32_t MaxFrameSize = 0xFA0000;
+};
+
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/thrift_proxy/protocol.h
+++ b/source/extensions/filters/network/thrift_proxy/protocol.h
@@ -1,17 +1,14 @@
 #pragma once
 
 #include <memory>
-#include <stack>
 #include <string>
-#include <utility>
-#include <vector>
 
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/pure.h"
 
-#include "common/common/fmt.h"
-#include "common/common/macros.h"
 #include "common/singleton/const_singleton.h"
+
+#include "absl/strings/string_view.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -342,102 +339,6 @@ public:
 };
 
 typedef std::unique_ptr<Protocol> ProtocolPtr;
-
-/*
- * ProtocolImplBase provides a base class for Protocol implementations.
- */
-class ProtocolImplBase : public virtual Protocol {
-public:
-  ProtocolImplBase(ProtocolCallbacks& callbacks) : callbacks_(callbacks) {}
-
-protected:
-  void onMessageStart(const absl::string_view name, MessageType msg_type, int32_t seq_id) const {
-    callbacks_.messageStart(name, msg_type, seq_id);
-  }
-  void onStructBegin(const absl::string_view name) const { callbacks_.structBegin(name); }
-  void onStructField(const absl::string_view name, FieldType field_type, int16_t field_id) const {
-    callbacks_.structField(name, field_type, field_id);
-  }
-  void onStructEnd() const { callbacks_.structEnd(); }
-  void onMessageComplete() const { callbacks_.messageComplete(); }
-
-  ProtocolCallbacks& callbacks_;
-};
-
-/**
- * AutoProtocolImpl attempts to distinguish between the Thrift binary (strict mode only) and
- * compact protocols and then delegates subsequent decoding operations to the appropriate Protocol
- * implementation.
- */
-class AutoProtocolImpl : public ProtocolImplBase {
-public:
-  AutoProtocolImpl(ProtocolCallbacks& callbacks)
-      : ProtocolImplBase(callbacks), name_(ProtocolNames::get().AUTO) {}
-
-  // Protocol
-  const std::string& name() const override { return name_; }
-  bool readMessageBegin(Buffer::Instance& buffer, std::string& name, MessageType& msg_type,
-                        int32_t& seq_id) override;
-  bool readMessageEnd(Buffer::Instance& buffer) override;
-  bool readStructBegin(Buffer::Instance& buffer, std::string& name) override {
-    return protocol_->readStructBegin(buffer, name);
-  }
-  bool readStructEnd(Buffer::Instance& buffer) override { return protocol_->readStructEnd(buffer); }
-  bool readFieldBegin(Buffer::Instance& buffer, std::string& name, FieldType& field_type,
-                      int16_t& field_id) override {
-    return protocol_->readFieldBegin(buffer, name, field_type, field_id);
-  }
-  bool readFieldEnd(Buffer::Instance& buffer) override { return protocol_->readFieldEnd(buffer); }
-  bool readMapBegin(Buffer::Instance& buffer, FieldType& key_type, FieldType& value_type,
-                    uint32_t& size) override {
-    return protocol_->readMapBegin(buffer, key_type, value_type, size);
-  }
-  bool readMapEnd(Buffer::Instance& buffer) override { return protocol_->readMapEnd(buffer); }
-  bool readListBegin(Buffer::Instance& buffer, FieldType& elem_type, uint32_t& size) override {
-    return protocol_->readListBegin(buffer, elem_type, size);
-  }
-  bool readListEnd(Buffer::Instance& buffer) override { return protocol_->readListEnd(buffer); }
-  bool readSetBegin(Buffer::Instance& buffer, FieldType& elem_type, uint32_t& size) override {
-    return protocol_->readSetBegin(buffer, elem_type, size);
-  }
-  bool readSetEnd(Buffer::Instance& buffer) override { return protocol_->readSetEnd(buffer); }
-  bool readBool(Buffer::Instance& buffer, bool& value) override {
-    return protocol_->readBool(buffer, value);
-  }
-  bool readByte(Buffer::Instance& buffer, uint8_t& value) override {
-    return protocol_->readByte(buffer, value);
-  }
-  bool readInt16(Buffer::Instance& buffer, int16_t& value) override {
-    return protocol_->readInt16(buffer, value);
-  }
-  bool readInt32(Buffer::Instance& buffer, int32_t& value) override {
-    return protocol_->readInt32(buffer, value);
-  }
-  bool readInt64(Buffer::Instance& buffer, int64_t& value) override {
-    return protocol_->readInt64(buffer, value);
-  }
-  bool readDouble(Buffer::Instance& buffer, double& value) override {
-    return protocol_->readDouble(buffer, value);
-  }
-  bool readString(Buffer::Instance& buffer, std::string& value) override {
-    return protocol_->readString(buffer, value);
-  }
-  bool readBinary(Buffer::Instance& buffer, std::string& value) override {
-    return protocol_->readBinary(buffer, value);
-  }
-
-  /*
-   * Explicitly set the protocol. Public to simplify testing.
-   */
-  void setProtocol(ProtocolPtr&& proto) {
-    protocol_ = std::move(proto);
-    name_ = fmt::format("{}({})", protocol_->name(), ProtocolNames::get().AUTO);
-  }
-
-private:
-  ProtocolPtr protocol_{};
-  std::string name_;
-};
 
 } // namespace ThriftProxy
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/thrift_proxy/protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/protocol_impl.cc
@@ -1,4 +1,4 @@
-#include "extensions/filters/network/thrift_proxy/protocol.h"
+#include "extensions/filters/network/thrift_proxy/protocol_impl.h"
 
 #include <algorithm>
 
@@ -8,9 +8,9 @@
 #include "common/common/byte_order.h"
 #include "common/common/macros.h"
 
-#include "extensions/filters/network/thrift_proxy/binary_protocol.h"
+#include "extensions/filters/network/thrift_proxy/binary_protocol_impl.h"
 #include "extensions/filters/network/thrift_proxy/buffer_helper.h"
-#include "extensions/filters/network/thrift_proxy/compact_protocol.h"
+#include "extensions/filters/network/thrift_proxy/compact_protocol_impl.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/filters/network/thrift_proxy/protocol_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/protocol_impl.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/buffer/buffer.h"
+
+#include "common/common/fmt.h"
+
+#include "extensions/filters/network/thrift_proxy/protocol.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+
+/*
+ * ProtocolImplBase provides a base class for Protocol implementations.
+ */
+class ProtocolImplBase : public virtual Protocol {
+public:
+  ProtocolImplBase(ProtocolCallbacks& callbacks) : callbacks_(callbacks) {}
+
+protected:
+  void onMessageStart(const absl::string_view name, MessageType msg_type, int32_t seq_id) const {
+    callbacks_.messageStart(name, msg_type, seq_id);
+  }
+  void onStructBegin(const absl::string_view name) const { callbacks_.structBegin(name); }
+  void onStructField(const absl::string_view name, FieldType field_type, int16_t field_id) const {
+    callbacks_.structField(name, field_type, field_id);
+  }
+  void onStructEnd() const { callbacks_.structEnd(); }
+  void onMessageComplete() const { callbacks_.messageComplete(); }
+
+  ProtocolCallbacks& callbacks_;
+};
+
+/**
+ * AutoProtocolImpl attempts to distinguish between the Thrift binary (strict mode only) and
+ * compact protocols and then delegates subsequent decoding operations to the appropriate Protocol
+ * implementation.
+ */
+class AutoProtocolImpl : public ProtocolImplBase {
+public:
+  AutoProtocolImpl(ProtocolCallbacks& callbacks)
+      : ProtocolImplBase(callbacks), name_(ProtocolNames::get().AUTO) {}
+
+  // Protocol
+  const std::string& name() const override { return name_; }
+  bool readMessageBegin(Buffer::Instance& buffer, std::string& name, MessageType& msg_type,
+                        int32_t& seq_id) override;
+  bool readMessageEnd(Buffer::Instance& buffer) override;
+  bool readStructBegin(Buffer::Instance& buffer, std::string& name) override {
+    return protocol_->readStructBegin(buffer, name);
+  }
+  bool readStructEnd(Buffer::Instance& buffer) override { return protocol_->readStructEnd(buffer); }
+  bool readFieldBegin(Buffer::Instance& buffer, std::string& name, FieldType& field_type,
+                      int16_t& field_id) override {
+    return protocol_->readFieldBegin(buffer, name, field_type, field_id);
+  }
+  bool readFieldEnd(Buffer::Instance& buffer) override { return protocol_->readFieldEnd(buffer); }
+  bool readMapBegin(Buffer::Instance& buffer, FieldType& key_type, FieldType& value_type,
+                    uint32_t& size) override {
+    return protocol_->readMapBegin(buffer, key_type, value_type, size);
+  }
+  bool readMapEnd(Buffer::Instance& buffer) override { return protocol_->readMapEnd(buffer); }
+  bool readListBegin(Buffer::Instance& buffer, FieldType& elem_type, uint32_t& size) override {
+    return protocol_->readListBegin(buffer, elem_type, size);
+  }
+  bool readListEnd(Buffer::Instance& buffer) override { return protocol_->readListEnd(buffer); }
+  bool readSetBegin(Buffer::Instance& buffer, FieldType& elem_type, uint32_t& size) override {
+    return protocol_->readSetBegin(buffer, elem_type, size);
+  }
+  bool readSetEnd(Buffer::Instance& buffer) override { return protocol_->readSetEnd(buffer); }
+  bool readBool(Buffer::Instance& buffer, bool& value) override {
+    return protocol_->readBool(buffer, value);
+  }
+  bool readByte(Buffer::Instance& buffer, uint8_t& value) override {
+    return protocol_->readByte(buffer, value);
+  }
+  bool readInt16(Buffer::Instance& buffer, int16_t& value) override {
+    return protocol_->readInt16(buffer, value);
+  }
+  bool readInt32(Buffer::Instance& buffer, int32_t& value) override {
+    return protocol_->readInt32(buffer, value);
+  }
+  bool readInt64(Buffer::Instance& buffer, int64_t& value) override {
+    return protocol_->readInt64(buffer, value);
+  }
+  bool readDouble(Buffer::Instance& buffer, double& value) override {
+    return protocol_->readDouble(buffer, value);
+  }
+  bool readString(Buffer::Instance& buffer, std::string& value) override {
+    return protocol_->readString(buffer, value);
+  }
+  bool readBinary(Buffer::Instance& buffer, std::string& value) override {
+    return protocol_->readBinary(buffer, value);
+  }
+
+  /*
+   * Explicitly set the protocol. Public to simplify testing.
+   */
+  void setProtocol(ProtocolPtr&& proto) {
+    protocol_ = std::move(proto);
+    name_ = fmt::format("{}({})", protocol_->name(), ProtocolNames::get().AUTO);
+  }
+
+private:
+  ProtocolPtr protocol_{};
+  std::string name_;
+};
+
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/thrift_proxy/transport.h
+++ b/source/extensions/filters/network/thrift_proxy/transport.h
@@ -5,7 +5,6 @@
 
 #include "envoy/buffer/buffer.h"
 
-#include "common/common/fmt.h"
 #include "common/singleton/const_singleton.h"
 
 #include "absl/types/optional.h"
@@ -91,81 +90,6 @@ public:
 };
 
 typedef std::unique_ptr<Transport> TransportPtr;
-
-/*
- * TransportImplBase provides a base class for Transport implementations.
- */
-class TransportImplBase : public virtual Transport {
-public:
-  TransportImplBase(TransportCallbacks& callbacks) : callbacks_(callbacks) {}
-
-protected:
-  void onFrameStart(absl::optional<uint32_t> size) const { callbacks_.transportFrameStart(size); }
-  void onFrameComplete() const { callbacks_.transportFrameComplete(); }
-
-  TransportCallbacks& callbacks_;
-};
-
-/**
- * FramedTransportImpl implements the Thrift Framed transport.
- * See https://github.com/apache/thrift/blob/master/doc/specs/thrift-rpc.md
- */
-class FramedTransportImpl : public TransportImplBase {
-public:
-  FramedTransportImpl(TransportCallbacks& callbacks) : TransportImplBase(callbacks) {}
-
-  // Transport
-  const std::string& name() const override { return TransportNames::get().FRAMED; }
-  bool decodeFrameStart(Buffer::Instance& buffer) override;
-  bool decodeFrameEnd(Buffer::Instance& buffer) override;
-
-  static const int32_t MaxFrameSize = 0xFA0000;
-};
-
-/**
- * UnframedTransportImpl implements the Thrift Unframed transport.
- * See https://github.com/apache/thrift/blob/master/doc/specs/thrift-rpc.md
- */
-class UnframedTransportImpl : public TransportImplBase {
-public:
-  UnframedTransportImpl(TransportCallbacks& callbacks) : TransportImplBase(callbacks) {}
-
-  // Transport
-  const std::string& name() const override { return TransportNames::get().UNFRAMED; }
-  bool decodeFrameStart(Buffer::Instance&) override {
-    onFrameStart(absl::optional<uint32_t>());
-    return true;
-  }
-  bool decodeFrameEnd(Buffer::Instance&) override {
-    onFrameComplete();
-    return true;
-  }
-};
-
-/**
- * AutoTransportImpl implements Transport and attempts to distinguish between the Thrift framed and
- * unframed transports. Once the transport is detected, subsequent operations are delegated to the
- * appropriate implementation.
- */
-class AutoTransportImpl : public TransportImplBase {
-public:
-  AutoTransportImpl(TransportCallbacks& callbacks)
-      : TransportImplBase(callbacks), name_(TransportNames::get().AUTO){};
-
-  // Transport
-  const std::string& name() const override { return name_; }
-  bool decodeFrameStart(Buffer::Instance& buffer) override;
-  bool decodeFrameEnd(Buffer::Instance& buffer) override;
-
-private:
-  void setTransport(TransportPtr&& transport) {
-    transport_ = std::move(transport);
-    name_ = fmt::format("{}({})", transport_->name(), TransportNames::get().AUTO);
-  }
-
-  TransportPtr transport_{};
-  std::string name_;
-};
 
 } // namespace ThriftProxy
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/thrift_proxy/transport_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/transport_impl.cc
@@ -1,46 +1,19 @@
-#include "extensions/filters/network/thrift_proxy/transport.h"
-
-#include <ctype.h>
-
-#include <algorithm>
-#include <vector>
+#include "extensions/filters/network/thrift_proxy/transport_impl.h"
 
 #include "envoy/common/exception.h"
 
 #include "common/common/assert.h"
-#include "common/common/byte_order.h"
-#include "common/common/utility.h"
 
-#include "extensions/filters/network/thrift_proxy/binary_protocol.h"
+#include "extensions/filters/network/thrift_proxy/binary_protocol_impl.h"
 #include "extensions/filters/network/thrift_proxy/buffer_helper.h"
-#include "extensions/filters/network/thrift_proxy/compact_protocol.h"
+#include "extensions/filters/network/thrift_proxy/compact_protocol_impl.h"
+#include "extensions/filters/network/thrift_proxy/framed_transport_impl.h"
+#include "extensions/filters/network/thrift_proxy/unframed_transport_impl.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
 namespace ThriftProxy {
-
-bool FramedTransportImpl::decodeFrameStart(Buffer::Instance& buffer) {
-  if (buffer.length() < 4) {
-    return false;
-  }
-
-  int32_t size = BufferHelper::peekI32(buffer);
-
-  if (size <= 0 || size > MaxFrameSize) {
-    throw EnvoyException(fmt::format("invalid thrift framed transport frame size {}", size));
-  }
-
-  onFrameStart(absl::optional<uint32_t>(static_cast<uint32_t>(size)));
-
-  buffer.drain(4);
-  return true;
-}
-
-bool FramedTransportImpl::decodeFrameEnd(Buffer::Instance&) {
-  onFrameComplete();
-  return true;
-}
 
 bool AutoTransportImpl::decodeFrameStart(Buffer::Instance& buffer) {
   if (transport_ == nullptr) {

--- a/source/extensions/filters/network/thrift_proxy/transport_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/transport_impl.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/buffer/buffer.h"
+
+#include "common/common/fmt.h"
+
+#include "extensions/filters/network/thrift_proxy/transport.h"
+
+#include "absl/types/optional.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+
+/*
+ * TransportImplBase provides a base class for Transport implementations.
+ */
+class TransportImplBase : public virtual Transport {
+public:
+  TransportImplBase(TransportCallbacks& callbacks) : callbacks_(callbacks) {}
+
+protected:
+  void onFrameStart(absl::optional<uint32_t> size) const { callbacks_.transportFrameStart(size); }
+  void onFrameComplete() const { callbacks_.transportFrameComplete(); }
+
+  TransportCallbacks& callbacks_;
+};
+
+/**
+ * AutoTransportImpl implements Transport and attempts to distinguish between the Thrift framed and
+ * unframed transports. Once the transport is detected, subsequent operations are delegated to the
+ * appropriate implementation.
+ */
+class AutoTransportImpl : public TransportImplBase {
+public:
+  AutoTransportImpl(TransportCallbacks& callbacks)
+      : TransportImplBase(callbacks), name_(TransportNames::get().AUTO){};
+
+  // Transport
+  const std::string& name() const override { return name_; }
+  bool decodeFrameStart(Buffer::Instance& buffer) override;
+  bool decodeFrameEnd(Buffer::Instance& buffer) override;
+
+private:
+  void setTransport(TransportPtr&& transport) {
+    transport_ = std::move(transport);
+    name_ = fmt::format("{}({})", transport_->name(), TransportNames::get().AUTO);
+  }
+
+  TransportPtr transport_{};
+  std::string name_;
+};
+
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/thrift_proxy/unframed_transport_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/unframed_transport_impl.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/buffer/buffer.h"
+
+#include "extensions/filters/network/thrift_proxy/transport_impl.h"
+
+#include "absl/types/optional.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+
+/**
+ * UnframedTransportImpl implements the Thrift Unframed transport.
+ * See https://github.com/apache/thrift/blob/master/doc/specs/thrift-rpc.md
+ */
+class UnframedTransportImpl : public TransportImplBase {
+public:
+  UnframedTransportImpl(TransportCallbacks& callbacks) : TransportImplBase(callbacks) {}
+
+  // Transport
+  const std::string& name() const override { return TransportNames::get().UNFRAMED; }
+  bool decodeFrameStart(Buffer::Instance&) override {
+    onFrameStart(absl::optional<uint32_t>());
+    return true;
+  }
+  bool decodeFrameEnd(Buffer::Instance&) override {
+    onFrameComplete();
+    return true;
+  }
+};
+
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/network/thrift_proxy/BUILD
+++ b/test/extensions/filters/network/thrift_proxy/BUILD
@@ -36,8 +36,8 @@ envoy_extension_cc_test_library(
 )
 
 envoy_extension_cc_test(
-    name = "binary_protocol_test",
-    srcs = ["binary_protocol_test.cc"],
+    name = "binary_protocol_impl_test",
+    srcs = ["binary_protocol_impl_test.cc"],
     extension_name = "envoy.filters.network.thrift_proxy",
     deps = [
         ":mocks",
@@ -61,8 +61,8 @@ envoy_extension_cc_test(
 )
 
 envoy_extension_cc_test(
-    name = "compact_protocol_test",
-    srcs = ["compact_protocol_test.cc"],
+    name = "compact_protocol_impl_test",
+    srcs = ["compact_protocol_impl_test.cc"],
     extension_name = "envoy.filters.network.thrift_proxy",
     deps = [
         ":mocks",
@@ -110,8 +110,21 @@ envoy_extension_cc_test(
 )
 
 envoy_extension_cc_test(
-    name = "protocol_test",
-    srcs = ["protocol_test.cc"],
+    name = "framed_transport_impl_test",
+    srcs = ["framed_transport_impl_test.cc"],
+    extension_name = "envoy.filters.network.thrift_proxy",
+    deps = [
+        ":mocks",
+        ":utility_lib",
+        "//source/extensions/filters/network/thrift_proxy:transport_lib",
+        "//test/test_common:printers_lib",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "protocol_impl_test",
+    srcs = ["protocol_impl_test.cc"],
     extension_name = "envoy.filters.network.thrift_proxy",
     deps = [
         ":mocks",
@@ -123,8 +136,21 @@ envoy_extension_cc_test(
 )
 
 envoy_extension_cc_test(
-    name = "transport_test",
-    srcs = ["transport_test.cc"],
+    name = "transport_impl_test",
+    srcs = ["transport_impl_test.cc"],
+    extension_name = "envoy.filters.network.thrift_proxy",
+    deps = [
+        ":mocks",
+        ":utility_lib",
+        "//source/extensions/filters/network/thrift_proxy:transport_lib",
+        "//test/test_common:printers_lib",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "unframed_transport_impl_test",
+    srcs = ["unframed_transport_impl_test.cc"],
     extension_name = "envoy.filters.network.thrift_proxy",
     deps = [
         ":mocks",

--- a/test/extensions/filters/network/thrift_proxy/binary_protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/binary_protocol_impl_test.cc
@@ -2,7 +2,7 @@
 
 #include "common/buffer/buffer_impl.h"
 
-#include "extensions/filters/network/thrift_proxy/binary_protocol.h"
+#include "extensions/filters/network/thrift_proxy/binary_protocol_impl.h"
 
 #include "test/extensions/filters/network/thrift_proxy/mocks.h"
 #include "test/extensions/filters/network/thrift_proxy/utility.h"

--- a/test/extensions/filters/network/thrift_proxy/compact_protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/compact_protocol_impl_test.cc
@@ -2,7 +2,7 @@
 
 #include "common/buffer/buffer_impl.h"
 
-#include "extensions/filters/network/thrift_proxy/compact_protocol.h"
+#include "extensions/filters/network/thrift_proxy/compact_protocol_impl.h"
 
 #include "test/extensions/filters/network/thrift_proxy/mocks.h"
 #include "test/extensions/filters/network/thrift_proxy/utility.h"

--- a/test/extensions/filters/network/thrift_proxy/framed_transport_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/framed_transport_impl_test.cc
@@ -1,0 +1,89 @@
+#include "envoy/common/exception.h"
+
+#include "common/buffer/buffer_impl.h"
+
+#include "extensions/filters/network/thrift_proxy/framed_transport_impl.h"
+
+#include "test/extensions/filters/network/thrift_proxy/mocks.h"
+#include "test/extensions/filters/network/thrift_proxy/utility.h"
+#include "test/test_common/printers.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::NiceMock;
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+
+TEST(FramedTransportTest, Name) {
+  NiceMock<MockTransportCallbacks> cb;
+  FramedTransportImpl transport(cb);
+  EXPECT_EQ(transport.name(), "framed");
+}
+
+TEST(FramedTransportTest, NotEnoughData) {
+  Buffer::OwnedImpl buffer;
+  NiceMock<MockTransportCallbacks> cb;
+  FramedTransportImpl transport(cb);
+
+  EXPECT_FALSE(transport.decodeFrameStart(buffer));
+
+  addRepeated(buffer, 3, 0);
+
+  EXPECT_FALSE(transport.decodeFrameStart(buffer));
+}
+
+TEST(FramedTransportTest, InvalidFrameSize) {
+  NiceMock<MockTransportCallbacks> cb;
+  FramedTransportImpl transport(cb);
+
+  {
+    Buffer::OwnedImpl buffer;
+    addInt32(buffer, -1);
+
+    EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer), EnvoyException,
+                              "invalid thrift framed transport frame size -1");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addInt32(buffer, 0x7fffffff);
+
+    EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer), EnvoyException,
+                              "invalid thrift framed transport frame size 2147483647");
+  }
+}
+
+TEST(FramedTransportTest, DecodeFrameStart) {
+  MockTransportCallbacks cb;
+  EXPECT_CALL(cb, transportFrameStart(absl::optional<uint32_t>(100U)));
+
+  FramedTransportImpl transport(cb);
+
+  Buffer::OwnedImpl buffer;
+  addInt32(buffer, 100);
+
+  EXPECT_EQ(buffer.length(), 4);
+  EXPECT_TRUE(transport.decodeFrameStart(buffer));
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(FramedTransportTest, DecodeFrameEnd) {
+  MockTransportCallbacks cb;
+  EXPECT_CALL(cb, transportFrameComplete());
+
+  FramedTransportImpl transport(cb);
+
+  Buffer::OwnedImpl buffer;
+
+  EXPECT_TRUE(transport.decodeFrameEnd(buffer));
+}
+
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/network/thrift_proxy/protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/protocol_impl_test.cc
@@ -2,9 +2,9 @@
 
 #include "common/buffer/buffer_impl.h"
 
-#include "extensions/filters/network/thrift_proxy/binary_protocol.h"
-#include "extensions/filters/network/thrift_proxy/compact_protocol.h"
-#include "extensions/filters/network/thrift_proxy/protocol.h"
+#include "extensions/filters/network/thrift_proxy/binary_protocol_impl.h"
+#include "extensions/filters/network/thrift_proxy/compact_protocol_impl.h"
+#include "extensions/filters/network/thrift_proxy/protocol_impl.h"
 
 #include "test/extensions/filters/network/thrift_proxy/mocks.h"
 #include "test/extensions/filters/network/thrift_proxy/utility.h"

--- a/test/extensions/filters/network/thrift_proxy/transport_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/transport_impl_test.cc
@@ -2,7 +2,7 @@
 
 #include "common/buffer/buffer_impl.h"
 
-#include "extensions/filters/network/thrift_proxy/transport.h"
+#include "extensions/filters/network/thrift_proxy/transport_impl.h"
 
 #include "test/extensions/filters/network/thrift_proxy/mocks.h"
 #include "test/extensions/filters/network/thrift_proxy/utility.h"
@@ -18,100 +18,6 @@ namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
 namespace ThriftProxy {
-
-TEST(FramedTransportTest, Name) {
-  NiceMock<MockTransportCallbacks> cb;
-  FramedTransportImpl transport(cb);
-  EXPECT_EQ(transport.name(), "framed");
-}
-
-TEST(FramedTransportTest, NotEnoughData) {
-  Buffer::OwnedImpl buffer;
-  NiceMock<MockTransportCallbacks> cb;
-  FramedTransportImpl transport(cb);
-
-  EXPECT_FALSE(transport.decodeFrameStart(buffer));
-
-  addRepeated(buffer, 3, 0);
-
-  EXPECT_FALSE(transport.decodeFrameStart(buffer));
-}
-
-TEST(FramedTransportTest, InvalidFrameSize) {
-  NiceMock<MockTransportCallbacks> cb;
-  FramedTransportImpl transport(cb);
-
-  {
-    Buffer::OwnedImpl buffer;
-    addInt32(buffer, -1);
-
-    EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer), EnvoyException,
-                              "invalid thrift framed transport frame size -1");
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    addInt32(buffer, 0x7fffffff);
-
-    EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer), EnvoyException,
-                              "invalid thrift framed transport frame size 2147483647");
-  }
-}
-
-TEST(FramedTransportTest, DecodeFrameStart) {
-  MockTransportCallbacks cb;
-  EXPECT_CALL(cb, transportFrameStart(absl::optional<uint32_t>(100U)));
-
-  FramedTransportImpl transport(cb);
-
-  Buffer::OwnedImpl buffer;
-  addInt32(buffer, 100);
-
-  EXPECT_EQ(buffer.length(), 4);
-  EXPECT_TRUE(transport.decodeFrameStart(buffer));
-  EXPECT_EQ(buffer.length(), 0);
-}
-
-TEST(FramedTransportTest, DecodeFrameEnd) {
-  MockTransportCallbacks cb;
-  EXPECT_CALL(cb, transportFrameComplete());
-
-  FramedTransportImpl transport(cb);
-
-  Buffer::OwnedImpl buffer;
-
-  EXPECT_TRUE(transport.decodeFrameEnd(buffer));
-}
-
-TEST(UnframedTransportTest, Name) {
-  NiceMock<MockTransportCallbacks> cb;
-  UnframedTransportImpl transport(cb);
-  EXPECT_EQ(transport.name(), "unframed");
-}
-
-TEST(UnframedTransportTest, DecodeFrameStart) {
-  MockTransportCallbacks cb;
-  EXPECT_CALL(cb, transportFrameStart(absl::optional<uint32_t>()));
-
-  UnframedTransportImpl transport(cb);
-
-  Buffer::OwnedImpl buffer;
-  addInt32(buffer, 0xDEADBEEF);
-
-  EXPECT_EQ(buffer.length(), 4);
-  EXPECT_TRUE(transport.decodeFrameStart(buffer));
-  EXPECT_EQ(buffer.length(), 4);
-}
-
-TEST(UnframedTransportTest, DecodeFrameEnd) {
-  MockTransportCallbacks cb;
-  EXPECT_CALL(cb, transportFrameComplete());
-
-  UnframedTransportImpl transport(cb);
-
-  Buffer::OwnedImpl buffer;
-  EXPECT_TRUE(transport.decodeFrameEnd(buffer));
-}
 
 TEST(AutoTransportTest, NotEnoughData) {
   Buffer::OwnedImpl buffer;

--- a/test/extensions/filters/network/thrift_proxy/unframed_transport_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/unframed_transport_impl_test.cc
@@ -1,0 +1,53 @@
+#include "common/buffer/buffer_impl.h"
+
+#include "extensions/filters/network/thrift_proxy/unframed_transport_impl.h"
+
+#include "test/extensions/filters/network/thrift_proxy/mocks.h"
+#include "test/extensions/filters/network/thrift_proxy/utility.h"
+#include "test/test_common/printers.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::NiceMock;
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+
+TEST(UnframedTransportTest, Name) {
+  NiceMock<MockTransportCallbacks> cb;
+  UnframedTransportImpl transport(cb);
+  EXPECT_EQ(transport.name(), "unframed");
+}
+
+TEST(UnframedTransportTest, DecodeFrameStart) {
+  MockTransportCallbacks cb;
+  EXPECT_CALL(cb, transportFrameStart(absl::optional<uint32_t>()));
+
+  UnframedTransportImpl transport(cb);
+
+  Buffer::OwnedImpl buffer;
+  addInt32(buffer, 0xDEADBEEF);
+
+  EXPECT_EQ(buffer.length(), 4);
+  EXPECT_TRUE(transport.decodeFrameStart(buffer));
+  EXPECT_EQ(buffer.length(), 4);
+}
+
+TEST(UnframedTransportTest, DecodeFrameEnd) {
+  MockTransportCallbacks cb;
+  EXPECT_CALL(cb, transportFrameComplete());
+
+  UnframedTransportImpl transport(cb);
+
+  Buffer::OwnedImpl buffer;
+  EXPECT_TRUE(transport.decodeFrameEnd(buffer));
+}
+
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
Changes the organization of code, but there are no functional changes in
this PR. I'm doing this in preparation for adding more code to the transport
and protocol implementations.

*Risk Level*: low
*Testing*: existing tests
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
