### PR TITLE
ssl: introduce `serialNumberPeerCertificate()`

### DIFF
--- a/include/envoy/ssl/connection.h
+++ b/include/envoy/ssl/connection.h
@@ -39,6 +39,12 @@ public:
   virtual const std::string& sha256PeerCertificateDigest() const PURE;
 
   /**
+   * @return std::string the serial number field of the peer certificate. Returns "" if
+   *         there is no peer certificate, or no serial number.
+   **/
+  virtual std::string serialNumberPeerCertificate() const PURE;
+
+  /**
    * @return std::string the subject field of the peer certificate in RFC 2253 format. Returns "" if
    *         there is no peer certificate, or no subject.
    **/

--- a/source/common/ssl/BUILD
+++ b/source/common/ssl/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
     deps = [
         ":context_config_lib",
         ":context_lib",
+        ":utility_lib",
         "//include/envoy/network:connection_interface",
         "//include/envoy/network:transport_socket_interface",
         "//source/common/common:assert_lib",
@@ -57,6 +58,7 @@ envoy_cc_library(
     ],
     external_deps = ["ssl"],
     deps = [
+        ":utility_lib",
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/ssl:context_config_interface",
         "//include/envoy/ssl:context_interface",
@@ -77,5 +79,14 @@ envoy_cc_library(
         "//include/envoy/ssl:tls_certificate_config_interface",
         "//source/common/config:datasource_lib",
         "@envoy_api//envoy/api/v2/auth:cert_cc",
+    ],
+)
+
+envoy_cc_library(
+    name = "utility_lib",
+    srcs = ["utility.cc"],
+    hdrs = ["utility.h"],
+    external_deps = [
+        "ssl",
     ],
 )

--- a/source/common/ssl/context_impl.h
+++ b/source/common/ssl/context_impl.h
@@ -116,8 +116,10 @@ protected:
 
   std::vector<uint8_t> parseAlpnProtocols(const std::string& alpn_protocols);
   static SslStats generateStats(Stats::Scope& scope);
+
+  // TODO: Move helper function to the `Ssl::Utility` namespace.
   int32_t getDaysUntilExpiration(const X509* cert) const;
-  static std::string getSerialNumber(const X509* cert);
+
   std::string getCaFileName() const { return ca_file_path_; };
   std::string getCertChainFileName() const { return cert_chain_file_path_; };
 

--- a/source/common/ssl/ssl_socket.cc
+++ b/source/common/ssl/ssl_socket.cc
@@ -339,6 +339,30 @@ std::string SslSocket::protocol() const {
   return std::string(reinterpret_cast<const char*>(proto), proto_len);
 }
 
+std::string SslSocket::getSerialNumberFromCertificate(X509* cert) const {
+  ASSERT(cert);
+  ASN1_INTEGER* serial_number = X509_get_serialNumber(cert);
+  BIGNUM num_bn;
+  BN_init(&num_bn);
+  ASN1_INTEGER_to_BN(serial_number, &num_bn);
+  char* char_serial_number = BN_bn2hex(&num_bn);
+  BN_free(&num_bn);
+  if (char_serial_number != nullptr) {
+    std::string serial_number(char_serial_number);
+    OPENSSL_free(char_serial_number);
+    return serial_number;
+  }
+  return "";
+}
+
+std::string SslSocket::serialNumberPeerCertificate() const {
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  if (!cert) {
+    return "";
+  }
+  return getSerialNumberFromCertificate(cert.get());
+}
+
 std::string SslSocket::getSubjectFromCertificate(X509* cert) const {
   bssl::UniquePtr<BIO> buf(BIO_new(BIO_s_mem()));
   RELEASE_ASSERT(buf != nullptr);

--- a/source/common/ssl/ssl_socket.h
+++ b/source/common/ssl/ssl_socket.h
@@ -51,8 +51,9 @@ private:
   Network::PostIoAction doHandshake();
   void drainErrorQueue();
   void shutdownSsl();
+
+  // TODO: Move helper functions to the `Ssl::Utility` namespace.
   std::string getUriSanFromCertificate(X509* cert) const;
-  std::string getSerialNumberFromCertificate(X509* cert) const;
   std::string getSubjectFromCertificate(X509* cert) const;
   std::vector<std::string> getDnsSansFromCertificate(X509* cert);
 

--- a/source/common/ssl/ssl_socket.h
+++ b/source/common/ssl/ssl_socket.h
@@ -26,6 +26,7 @@ public:
   bool peerCertificatePresented() const override;
   std::string uriSanLocalCertificate() override;
   const std::string& sha256PeerCertificateDigest() const override;
+  std::string serialNumberPeerCertificate() const override;
   std::string subjectPeerCertificate() const override;
   std::string subjectLocalCertificate() const override;
   std::string uriSanPeerCertificate() const override;
@@ -51,6 +52,7 @@ private:
   void drainErrorQueue();
   void shutdownSsl();
   std::string getUriSanFromCertificate(X509* cert) const;
+  std::string getSerialNumberFromCertificate(X509* cert) const;
   std::string getSubjectFromCertificate(X509* cert) const;
   std::vector<std::string> getDnsSansFromCertificate(X509* cert);
 

--- a/source/common/ssl/utility.cc
+++ b/source/common/ssl/utility.cc
@@ -1,0 +1,22 @@
+#include "common/ssl/utility.h"
+
+namespace Envoy {
+namespace Ssl {
+
+std::string Utility::getSerialNumberFromCertificate(X509& cert) {
+  ASN1_INTEGER* serial_number = X509_get_serialNumber(&cert);
+  BIGNUM num_bn;
+  BN_init(&num_bn);
+  ASN1_INTEGER_to_BN(serial_number, &num_bn);
+  char* char_serial_number = BN_bn2hex(&num_bn);
+  BN_free(&num_bn);
+  if (char_serial_number != nullptr) {
+    std::string serial_number(char_serial_number);
+    OPENSSL_free(char_serial_number);
+    return serial_number;
+  }
+  return "";
+}
+
+} // namespace Ssl
+} // namespace Envoy

--- a/source/common/ssl/utility.h
+++ b/source/common/ssl/utility.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+
+#include "openssl/ssl.h"
+
+namespace Envoy {
+namespace Ssl {
+namespace Utility {
+
+/**
+ * Retrieve the serial number of a certificate.
+ * @param ssl the certificate
+ * @return std::string the serial number field of the certificate. Returns "" if
+ *         there is no serial number.
+ */
+std::string getSerialNumberFromCertificate(X509& cert);
+
+} // namespace Utility
+} // namespace Ssl
+} // namespace Envoy

--- a/test/common/ssl/ssl_socket_test.cc
+++ b/test/common/ssl/ssl_socket_test.cc
@@ -46,10 +46,10 @@ namespace {
 
 void testUtil(const std::string& client_ctx_json, const std::string& server_ctx_json,
               const std::string& expected_digest, const std::string& expected_uri,
-              const std::string& expected_local_uri, const std::string& expected_subject,
-              const std::string& expected_local_subject, const std::string& expected_peer_cert,
-              const std::string& expected_stats, bool expect_success,
-              const Network::Address::IpVersion version) {
+              const std::string& expected_local_uri, const std::string& expected_serial_number,
+              const std::string& expected_subject, const std::string& expected_local_subject,
+              const std::string& expected_peer_cert, const std::string& expected_stats,
+              bool expect_success, const Network::Address::IpVersion version) {
   Stats::IsolatedStoreImpl stats_store;
   Runtime::MockLoader runtime;
   Secret::MockSecretManager secret_manager;
@@ -101,6 +101,8 @@ void testUtil(const std::string& client_ctx_json, const std::string& server_ctx_
           if (!expected_local_uri.empty()) {
             EXPECT_EQ(expected_local_uri, server_connection->ssl()->uriSanLocalCertificate());
           }
+          EXPECT_EQ(expected_serial_number,
+                    server_connection->ssl()->serialNumberPeerCertificate());
           if (!expected_subject.empty()) {
             EXPECT_EQ(expected_subject, server_connection->ssl()->subjectPeerCertificate());
           }
@@ -309,8 +311,8 @@ TEST_P(SslSocketTest, GetCertDigest) {
   )EOF";
 
   testUtil(client_ctx_json, server_ctx_json,
-           "4444fbca965d916475f04fb4dd234dd556adb028ceb4300fa8ad6f2983c6aaa3", "", "", "", "", "",
-           "ssl.handshake", true, GetParam());
+           "4444fbca965d916475f04fb4dd234dd556adb028ceb4300fa8ad6f2983c6aaa3", "", "",
+           "f3828eb24fd779cf", "", "", "", "ssl.handshake", true, GetParam());
 }
 
 TEST_P(SslSocketTest, GetCertDigestInline) {
@@ -469,8 +471,8 @@ TEST_P(SslSocketTest, GetCertDigestServerCertWithIntermediateCA) {
   )EOF";
 
   testUtil(client_ctx_json, server_ctx_json,
-           "4444fbca965d916475f04fb4dd234dd556adb028ceb4300fa8ad6f2983c6aaa3", "", "", "", "", "",
-           "ssl.handshake", true, GetParam());
+           "4444fbca965d916475f04fb4dd234dd556adb028ceb4300fa8ad6f2983c6aaa3", "", "",
+           "f3828eb24fd779cf", "", "", "", "ssl.handshake", true, GetParam());
 }
 
 TEST_P(SslSocketTest, GetCertDigestServerCertWithoutCommonName) {
@@ -490,8 +492,8 @@ TEST_P(SslSocketTest, GetCertDigestServerCertWithoutCommonName) {
   )EOF";
 
   testUtil(client_ctx_json, server_ctx_json,
-           "4444fbca965d916475f04fb4dd234dd556adb028ceb4300fa8ad6f2983c6aaa3", "", "", "", "", "",
-           "ssl.handshake", true, GetParam());
+           "4444fbca965d916475f04fb4dd234dd556adb028ceb4300fa8ad6f2983c6aaa3", "", "",
+           "f3828eb24fd779cf", "", "", "", "ssl.handshake", true, GetParam());
 }
 
 TEST_P(SslSocketTest, GetUriWithUriSan) {
@@ -511,8 +513,8 @@ TEST_P(SslSocketTest, GetUriWithUriSan) {
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "spiffe://lyft.com/test-team", "", "", "", "",
-           "ssl.handshake", true, GetParam());
+  testUtil(client_ctx_json, server_ctx_json, "", "spiffe://lyft.com/test-team", "",
+           "de8a932ffc6a57da", "", "", "", "ssl.handshake", true, GetParam());
 }
 
 TEST_P(SslSocketTest, GetNoUriWithDnsSan) {
@@ -532,8 +534,8 @@ TEST_P(SslSocketTest, GetNoUriWithDnsSan) {
   )EOF";
 
   // The SAN field only has DNS, expect "" for uriSanPeerCertificate().
-  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "ssl.handshake", true,
-           GetParam());
+  testUtil(client_ctx_json, server_ctx_json, "", "", "", "f3828eb24fd779d0", "", "", "",
+           "ssl.handshake", true, GetParam());
 }
 
 TEST_P(SslSocketTest, NoCert) {
@@ -546,7 +548,7 @@ TEST_P(SslSocketTest, NoCert) {
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "ssl.no_certificate", true,
+  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "", "ssl.no_certificate", true,
            GetParam());
 }
 
@@ -566,8 +568,8 @@ TEST_P(SslSocketTest, GetUriWithLocalUriSan) {
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "", "spiffe://lyft.com/test-team", "", "", "",
-           "ssl.handshake", true, GetParam());
+  testUtil(client_ctx_json, server_ctx_json, "", "", "spiffe://lyft.com/test-team",
+           "f3828eb24fd779cf", "", "", "", "ssl.handshake", true, GetParam());
 }
 
 TEST_P(SslSocketTest, GetSubjectsWithBothCerts) {
@@ -587,7 +589,7 @@ TEST_P(SslSocketTest, GetSubjectsWithBothCerts) {
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "", "",
+  testUtil(client_ctx_json, server_ctx_json, "", "", "", "f3828eb24fd779cf",
            "CN=Test Server,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US",
            "CN=Test Server,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US", "",
            "ssl.handshake", true, GetParam());
@@ -610,7 +612,7 @@ TEST_P(SslSocketTest, GetPeerCert) {
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "", "",
+  testUtil(client_ctx_json, server_ctx_json, "", "", "", "f3828eb24fd779cf",
            "CN=Test Server,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US",
            "CN=Test Server,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US",
            "-----BEGIN%20CERTIFICATE-----%0A"
@@ -646,7 +648,7 @@ TEST_P(SslSocketTest, FailedClientAuthCaVerificationNoClientCert) {
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "ssl.fail_verify_no_cert",
+  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "", "ssl.fail_verify_no_cert",
            false, GetParam());
 }
 
@@ -666,8 +668,8 @@ TEST_P(SslSocketTest, FailedClientAuthCaVerification) {
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "ssl.fail_verify_error", false,
-           GetParam());
+  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "", "ssl.fail_verify_error",
+           false, GetParam());
 }
 
 TEST_P(SslSocketTest, FailedClientAuthSanVerificationNoClientCert) {
@@ -682,7 +684,7 @@ TEST_P(SslSocketTest, FailedClientAuthSanVerificationNoClientCert) {
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "ssl.fail_verify_no_cert",
+  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "", "ssl.fail_verify_no_cert",
            false, GetParam());
 }
 
@@ -703,8 +705,8 @@ TEST_P(SslSocketTest, FailedClientAuthSanVerification) {
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "ssl.fail_verify_san", false,
-           GetParam());
+  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "", "ssl.fail_verify_san",
+           false, GetParam());
 }
 
 // By default, expired certificates are not permitted.
@@ -814,8 +816,8 @@ TEST_P(SslSocketTest, ClientCertificateHashVerification) {
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "spiffe://lyft.com/test-team", "", "", "", "",
-           "ssl.handshake", true, GetParam());
+  testUtil(client_ctx_json, server_ctx_json, "", "spiffe://lyft.com/test-team", "",
+           "de8a932ffc6a57da", "", "", "", "ssl.handshake", true, GetParam());
 }
 
 TEST_P(SslSocketTest, ClientCertificateHashVerificationNoCA) {
@@ -834,8 +836,8 @@ TEST_P(SslSocketTest, ClientCertificateHashVerificationNoCA) {
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "spiffe://lyft.com/test-team", "", "", "", "",
-           "ssl.handshake", true, GetParam());
+  testUtil(client_ctx_json, server_ctx_json, "", "spiffe://lyft.com/test-team", "",
+           "de8a932ffc6a57da", "", "", "", "ssl.handshake", true, GetParam());
 }
 
 TEST_P(SslSocketTest, ClientCertificateHashListVerification) {
@@ -930,7 +932,7 @@ TEST_P(SslSocketTest, FailedClientCertificateHashVerificationNoClientCertificate
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "ssl.fail_verify_no_cert",
+  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "", "ssl.fail_verify_no_cert",
            false, GetParam());
 }
 
@@ -945,7 +947,7 @@ TEST_P(SslSocketTest, FailedClientCertificateHashVerificationNoCANoClientCertifi
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "ssl.fail_verify_no_cert",
+  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "", "ssl.fail_verify_no_cert",
            false, GetParam());
 }
 
@@ -966,8 +968,8 @@ TEST_P(SslSocketTest, FailedClientCertificateHashVerificationWrongClientCertific
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "ssl.fail_verify_cert_hash",
-           false, GetParam());
+  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "",
+           "ssl.fail_verify_cert_hash", false, GetParam());
 }
 
 TEST_P(SslSocketTest, FailedClientCertificateHashVerificationNoCAWrongClientCertificate) {
@@ -986,8 +988,8 @@ TEST_P(SslSocketTest, FailedClientCertificateHashVerificationNoCAWrongClientCert
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "ssl.fail_verify_cert_hash",
-           false, GetParam());
+  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "",
+           "ssl.fail_verify_cert_hash", false, GetParam());
 }
 
 TEST_P(SslSocketTest, FailedClientCertificateHashVerificationWrongCA) {
@@ -1007,8 +1009,8 @@ TEST_P(SslSocketTest, FailedClientCertificateHashVerificationWrongCA) {
   }
   )EOF";
 
-  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "ssl.fail_verify_error", false,
-           GetParam());
+  testUtil(client_ctx_json, server_ctx_json, "", "", "", "", "", "", "", "ssl.fail_verify_error",
+           false, GetParam());
 }
 
 TEST_P(SslSocketTest, ClientCertificateSpkiVerification) {
@@ -2514,7 +2516,7 @@ TEST_P(SslSocketTest, RevokedCertificate) {
     "private_key_file": "{{ test_rundir }}/test/common/ssl/test_data/san_dns_key.pem"
   }
   )EOF";
-  testUtil(revoked_client_ctx_json, server_ctx_json, "", "", "", "", "", "",
+  testUtil(revoked_client_ctx_json, server_ctx_json, "", "", "", "db6c9a4af16d9091", "", "", "",
            "ssl.fail_verify_error", false, GetParam());
 
   // This should succeed, since the cert isn't revoked.
@@ -2524,8 +2526,8 @@ TEST_P(SslSocketTest, RevokedCertificate) {
     "private_key_file": "{{ test_rundir }}/test/common/ssl/test_data/san_dns_key2.pem"
   }
   )EOF";
-  testUtil(successful_client_ctx_json, server_ctx_json, "", "", "", "", "", "", "ssl.handshake",
-           true, GetParam());
+  testUtil(successful_client_ctx_json, server_ctx_json, "", "", "", "db6c9a4af16d9091", "", "", "",
+           "ssl.handshake", true, GetParam());
 }
 
 class SslReadBufferLimitTest : public SslCertsTest,

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -48,6 +48,7 @@ public:
   MOCK_CONST_METHOD0(peerCertificatePresented, bool());
   MOCK_METHOD0(uriSanLocalCertificate, std::string());
   MOCK_CONST_METHOD0(sha256PeerCertificateDigest, std::string&());
+  MOCK_CONST_METHOD0(serialNumberPeerCertificate, std::string());
   MOCK_CONST_METHOD0(subjectPeerCertificate, std::string());
   MOCK_CONST_METHOD0(uriSanPeerCertificate, std::string());
   MOCK_CONST_METHOD0(subjectLocalCertificate, std::string());


### PR DESCRIPTION
Add a way to retrieve the serial number of a peer certificate.

Risk Level: Low
Testing: Make `//test/common/ssl:ssl_socket_test` cover this change.
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Tal Nordan <tal.nordan@solo.io>
