### PR TITLE
Add requestedServerName() to Network::connection

### DIFF
--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -187,6 +187,11 @@ public:
   virtual const Ssl::Connection* ssl() const PURE;
 
   /**
+   * @return requested server name (e.g. SNI in TLS), if any.
+   */
+  virtual absl::string_view requestedServerName() const PURE;
+
+  /**
    * @return State the current state of the connection.
    */
   virtual State state() const PURE;

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -89,6 +89,7 @@ public:
   const ConnectionSocket::OptionsSharedPtr& socketOptions() const override {
     return socket_->options();
   }
+  absl::string_view requestedServerName() const override { return socket_->requestedServerName(); }
 
   // Network::BufferSource
   BufferSource::StreamBuffer getReadBuffer() override { return {read_buffer_, read_end_stream_}; }

--- a/test/common/ssl/ssl_socket_test.cc
+++ b/test/common/ssl/ssl_socket_test.cc
@@ -2549,6 +2549,23 @@ TEST_P(SslSocketTest, RevokedCertificate) {
            true, GetParam());
 }
 
+TEST_P(SslSocketTest, GetRequestedServerName) {
+  envoy::api::v2::Listener listener;
+  envoy::api::v2::listener::FilterChain* filter_chain = listener.add_filter_chains();
+  envoy::api::v2::auth::TlsCertificate* server_cert =
+      filter_chain->mutable_tls_context()->mutable_common_tls_context()->add_tls_certificates();
+  server_cert->mutable_certificate_chain()->set_filename(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/ssl/test_data/san_dns_cert.pem"));
+  server_cert->mutable_private_key()->set_filename(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/ssl/test_data/san_dns_key.pem"));
+
+  envoy::api::v2::auth::UpstreamTlsContext client;
+  client.set_sni("lyft.com");
+
+  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, "lyft.com",
+             GetParam());
+}
+
 class SslReadBufferLimitTest : public SslCertsTest,
                                public testing::WithParamInterface<Network::Address::IpVersion> {
 public:

--- a/test/common/ssl/ssl_socket_test.cc
+++ b/test/common/ssl/ssl_socket_test.cc
@@ -142,6 +142,7 @@ const std::string testUtilV2(const envoy::api::v2::Listener& server_proto,
                              const std::string& expected_client_cert_uri,
                              const std::string& expected_alpn_protocol,
                              const std::string& expected_stats, unsigned expected_stats_value,
+                             const std::string& expected_requested_server_name,
                              const Network::Address::IpVersion version) {
   Stats::IsolatedStoreImpl stats_store;
   Runtime::MockLoader runtime;
@@ -188,6 +189,7 @@ const std::string testUtilV2(const envoy::api::v2::Listener& server_proto,
   Network::MockConnectionCallbacks server_connection_callbacks;
   EXPECT_CALL(callbacks, onAccept_(_, _))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& socket, bool) -> void {
+        socket->setRequestedServerName(client_ctx_proto.sni());
         Network::ConnectionPtr new_connection = dispatcher.createServerConnection(
             std::move(socket), server_ssl_socket_factory.createTransportSocket());
         callbacks.onNewConnection(std::move(new_connection));
@@ -236,7 +238,10 @@ const std::string testUtilV2(const envoy::api::v2::Listener& server_proto,
     EXPECT_CALL(client_connection_callbacks, onEvent(Network::ConnectionEvent::Connected))
         .WillOnce(Invoke([&](Network::ConnectionEvent) -> void { stopSecondTime(); }));
     EXPECT_CALL(server_connection_callbacks, onEvent(Network::ConnectionEvent::Connected))
-        .WillOnce(Invoke([&](Network::ConnectionEvent) -> void { stopSecondTime(); }));
+        .WillOnce(Invoke([&](Network::ConnectionEvent) -> void {
+          EXPECT_EQ(expected_requested_server_name, server_connection->requestedServerName());
+          stopSecondTime();
+        }));
     EXPECT_CALL(client_connection_callbacks, onEvent(Network::ConnectionEvent::LocalClose));
     EXPECT_CALL(server_connection_callbacks, onEvent(Network::ConnectionEvent::LocalClose));
   } else {
@@ -448,7 +453,7 @@ TEST_P(SslSocketTest, GetCertDigestInline) {
   // ssl.handshake logged by both: client & server.
   testUtilV2(listener, client_ctx, "", true, "",
              "1406294e80c818158697d65d2aaca16748ff132442ab0e2f28bc1109f1d47a2e",
-             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, GetParam());
+             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, "", GetParam());
 }
 
 TEST_P(SslSocketTest, GetCertDigestServerCertWithIntermediateCA) {
@@ -715,7 +720,7 @@ TEST_P(SslSocketTest, FailedClientCertificateDefaultExpirationVerification) {
   configureServerAndExpiredClientCertificate(listener, client);
 
   testUtilV2(listener, client, "", false, "", "", "spiffe://lyft.com/test-team", "",
-             "ssl.fail_verify_error", 1, GetParam());
+             "ssl.fail_verify_error", 1, "", GetParam());
 }
 
 // Expired certificates will not be accepted when explicitly disallowed via
@@ -733,7 +738,7 @@ TEST_P(SslSocketTest, FailedClientCertificateExpirationVerification) {
       ->set_allow_expired_certificate(false);
 
   testUtilV2(listener, client, "", false, "", "", "spiffe://lyft.com/test-team", "",
-             "ssl.fail_verify_error", 1, GetParam());
+             "ssl.fail_verify_error", 1, "", GetParam());
 }
 
 // Expired certificates will be accepted when explicitly allowed via allow_expired_certificate.
@@ -750,7 +755,7 @@ TEST_P(SslSocketTest, ClientCertificateExpirationAllowedVerification) {
       ->set_allow_expired_certificate(true);
 
   testUtilV2(listener, client, "", true, "", "", "spiffe://lyft.com/test-team", "", "ssl.handshake",
-             2, GetParam());
+             2, "", GetParam());
 }
 
 // Allow expired certificates, but add a certificate hash requirement so it still fails.
@@ -771,7 +776,7 @@ TEST_P(SslSocketTest, FailedClientCertAllowExpiredBadHashVerification) {
       "0000000000000000000000000000000000000000000000000000000000000000");
 
   testUtilV2(listener, client, "", false, "", "", "spiffe://lyft.com/test-team", "",
-             "ssl.fail_verify_cert_hash", 1, GetParam());
+             "ssl.fail_verify_cert_hash", 1, "", GetParam());
 }
 
 // Allow expired certificatess, but use the wrong CA so it should fail still.
@@ -794,7 +799,7 @@ TEST_P(SslSocketTest, FailedClientCertAllowServerExpiredWrongCAVerification) {
       TestEnvironment::substitute("{{ test_rundir }}/test/common/ssl/test_data/fake_ca_cert.pem"));
 
   testUtilV2(listener, client, "", false, "", "", "spiffe://lyft.com/test-team", "",
-             "ssl.fail_verify_error", 1, GetParam());
+             "ssl.fail_verify_error", 1, "", GetParam());
 }
 
 TEST_P(SslSocketTest, ClientCertificateHashVerification) {
@@ -869,14 +874,14 @@ TEST_P(SslSocketTest, ClientCertificateHashListVerification) {
   // ssl.handshake logged by both: client & server.
   testUtilV2(listener, client, "", true, "",
              "1406294e80c818158697d65d2aaca16748ff132442ab0e2f28bc1109f1d47a2e",
-             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, GetParam());
+             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, "", GetParam());
 
   // Works even with client renegotiation.
   // ssl.handshake logged by both: client & server.
   client.set_allow_renegotiation(true);
   testUtilV2(listener, client, "", true, "",
              "1406294e80c818158697d65d2aaca16748ff132442ab0e2f28bc1109f1d47a2e",
-             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, GetParam());
+             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, "", GetParam());
 }
 
 TEST_P(SslSocketTest, ClientCertificateHashListVerificationNoCA) {
@@ -908,14 +913,14 @@ TEST_P(SslSocketTest, ClientCertificateHashListVerificationNoCA) {
   // ssl.handshake logged by both: client & server.
   testUtilV2(listener, client, "", true, "",
              "1406294e80c818158697d65d2aaca16748ff132442ab0e2f28bc1109f1d47a2e",
-             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, GetParam());
+             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, "", GetParam());
 
   // Works even with client renegotiation.
   // ssl.handshake logged by both: client & server.
   client.set_allow_renegotiation(true);
   testUtilV2(listener, client, "", true, "",
              "1406294e80c818158697d65d2aaca16748ff132442ab0e2f28bc1109f1d47a2e",
-             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, GetParam());
+             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, "", GetParam());
 }
 
 TEST_P(SslSocketTest, FailedClientCertificateHashVerificationNoClientCertificate) {
@@ -1042,14 +1047,14 @@ TEST_P(SslSocketTest, ClientCertificateSpkiVerification) {
   // ssl.handshake logged by both: client & server.
   testUtilV2(listener, client, "", true, "",
              "1406294e80c818158697d65d2aaca16748ff132442ab0e2f28bc1109f1d47a2e",
-             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, GetParam());
+             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, "", GetParam());
 
   // Works even with client renegotiation.
   // ssl.handshake logged by both: client & server.
   client.set_allow_renegotiation(true);
   testUtilV2(listener, client, "", true, "",
              "1406294e80c818158697d65d2aaca16748ff132442ab0e2f28bc1109f1d47a2e",
-             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, GetParam());
+             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, "", GetParam());
 }
 
 TEST_P(SslSocketTest, ClientCertificateSpkiVerificationNoCA) {
@@ -1081,14 +1086,14 @@ TEST_P(SslSocketTest, ClientCertificateSpkiVerificationNoCA) {
   // ssl.handshake logged by both: client & server.
   testUtilV2(listener, client, "", true, "",
              "1406294e80c818158697d65d2aaca16748ff132442ab0e2f28bc1109f1d47a2e",
-             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, GetParam());
+             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, "", GetParam());
 
   // Works even with client renegotiation.
   // ssl.handshake logged by both: client & server.
   client.set_allow_renegotiation(true);
   testUtilV2(listener, client, "", true, "",
              "1406294e80c818158697d65d2aaca16748ff132442ab0e2f28bc1109f1d47a2e",
-             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, GetParam());
+             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, "", GetParam());
 }
 
 TEST_P(SslSocketTest, FailedClientCertificateSpkiVerificationNoClientCertificate) {
@@ -1113,11 +1118,13 @@ TEST_P(SslSocketTest, FailedClientCertificateSpkiVerificationNoClientCertificate
 
   envoy::api::v2::auth::UpstreamTlsContext client;
 
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_no_cert", 1, GetParam());
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_no_cert", 1, "",
+             GetParam());
 
   // Fails even with client renegotiation.
   client.set_allow_renegotiation(true);
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_no_cert", 1, GetParam());
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_no_cert", 1, "",
+             GetParam());
 }
 
 TEST_P(SslSocketTest, FailedClientCertificateSpkiVerificationNoCANoClientCertificate) {
@@ -1140,11 +1147,13 @@ TEST_P(SslSocketTest, FailedClientCertificateSpkiVerificationNoCANoClientCertifi
 
   envoy::api::v2::auth::UpstreamTlsContext client;
 
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_no_cert", 1, GetParam());
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_no_cert", 1, "",
+             GetParam());
 
   // Fails even with client renegotiation.
   client.set_allow_renegotiation(true);
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_no_cert", 1, GetParam());
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_no_cert", 1, "",
+             GetParam());
 }
 
 TEST_P(SslSocketTest, FailedClientCertificateSpkiVerificationWrongClientCertificate) {
@@ -1175,12 +1184,12 @@ TEST_P(SslSocketTest, FailedClientCertificateSpkiVerificationWrongClientCertific
   client_cert->mutable_private_key()->set_filename(
       TestEnvironment::substitute("{{ test_rundir }}/test/common/ssl/test_data/no_san_key.pem"));
 
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_cert_hash", 1,
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_cert_hash", 1, "",
              GetParam());
 
   // Fails even with client renegotiation.
   client.set_allow_renegotiation(true);
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_cert_hash", 1,
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_cert_hash", 1, "",
              GetParam());
 }
 
@@ -1210,12 +1219,12 @@ TEST_P(SslSocketTest, FailedClientCertificateSpkiVerificationNoCAWrongClientCert
   client_cert->mutable_private_key()->set_filename(
       TestEnvironment::substitute("{{ test_rundir }}/test/common/ssl/test_data/no_san_key.pem"));
 
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_cert_hash", 1,
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_cert_hash", 1, "",
              GetParam());
 
   // Fails even with client renegotiation.
   client.set_allow_renegotiation(true);
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_cert_hash", 1,
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_cert_hash", 1, "",
              GetParam());
 }
 
@@ -1247,11 +1256,13 @@ TEST_P(SslSocketTest, FailedClientCertificateSpkiVerificationWrongCA) {
   client_cert->mutable_private_key()->set_filename(
       TestEnvironment::substitute("{{ test_rundir }}/test/common/ssl/test_data/san_uri_key.pem"));
 
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_error", 1, GetParam());
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_error", 1, "",
+             GetParam());
 
   // Fails even with client renegotiation.
   client.set_allow_renegotiation(true);
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_error", 1, GetParam());
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_error", 1, "",
+             GetParam());
 }
 
 TEST_P(SslSocketTest, ClientCertificateHashAndSpkiVerification) {
@@ -1287,14 +1298,14 @@ TEST_P(SslSocketTest, ClientCertificateHashAndSpkiVerification) {
   // ssl.handshake logged by both: client & server.
   testUtilV2(listener, client, "", true, "",
              "1406294e80c818158697d65d2aaca16748ff132442ab0e2f28bc1109f1d47a2e",
-             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, GetParam());
+             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, "", GetParam());
 
   // Works even with client renegotiation.
   // ssl.handshake logged by both: client & server.
   client.set_allow_renegotiation(true);
   testUtilV2(listener, client, "", true, "",
              "1406294e80c818158697d65d2aaca16748ff132442ab0e2f28bc1109f1d47a2e",
-             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, GetParam());
+             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, "", GetParam());
 }
 
 TEST_P(SslSocketTest, ClientCertificateHashAndSpkiVerificationNoCA) {
@@ -1328,14 +1339,14 @@ TEST_P(SslSocketTest, ClientCertificateHashAndSpkiVerificationNoCA) {
   // ssl.handshake logged by both: client & server.
   testUtilV2(listener, client, "", true, "",
              "1406294e80c818158697d65d2aaca16748ff132442ab0e2f28bc1109f1d47a2e",
-             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, GetParam());
+             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, "", GetParam());
 
   // Works even with client renegotiation.
   // ssl.handshake logged by both: client & server.
   client.set_allow_renegotiation(true);
   testUtilV2(listener, client, "", true, "",
              "1406294e80c818158697d65d2aaca16748ff132442ab0e2f28bc1109f1d47a2e",
-             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, GetParam());
+             "spiffe://lyft.com/test-team", "", "ssl.handshake", 2, "", GetParam());
 }
 
 TEST_P(SslSocketTest, FailedClientCertificateHashAndSpkiVerificationNoClientCertificate) {
@@ -1360,11 +1371,13 @@ TEST_P(SslSocketTest, FailedClientCertificateHashAndSpkiVerificationNoClientCert
 
   envoy::api::v2::auth::UpstreamTlsContext client;
 
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_no_cert", 1, GetParam());
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_no_cert", 1, "",
+             GetParam());
 
   // Fails even with client renegotiation.
   client.set_allow_renegotiation(true);
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_no_cert", 1, GetParam());
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_no_cert", 1, "",
+             GetParam());
 }
 
 TEST_P(SslSocketTest, FailedClientCertificateHashAndSpkiVerificationNoCANoClientCertificate) {
@@ -1387,11 +1400,13 @@ TEST_P(SslSocketTest, FailedClientCertificateHashAndSpkiVerificationNoCANoClient
 
   envoy::api::v2::auth::UpstreamTlsContext client;
 
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_no_cert", 1, GetParam());
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_no_cert", 1, "",
+             GetParam());
 
   // Fails even with client renegotiation.
   client.set_allow_renegotiation(true);
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_no_cert", 1, GetParam());
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_no_cert", 1, "",
+             GetParam());
 }
 
 TEST_P(SslSocketTest, FailedClientCertificateHashAndSpkiVerificationWrongClientCertificate) {
@@ -1422,12 +1437,12 @@ TEST_P(SslSocketTest, FailedClientCertificateHashAndSpkiVerificationWrongClientC
   client_cert->mutable_private_key()->set_filename(
       TestEnvironment::substitute("{{ test_rundir }}/test/common/ssl/test_data/no_san_key.pem"));
 
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_cert_hash", 1,
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_cert_hash", 1, "",
              GetParam());
 
   // Fails even with client renegotiation.
   client.set_allow_renegotiation(true);
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_cert_hash", 1,
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_cert_hash", 1, "",
              GetParam());
 }
 
@@ -1457,12 +1472,12 @@ TEST_P(SslSocketTest, FailedClientCertificateHashAndSpkiVerificationNoCAWrongCli
   client_cert->mutable_private_key()->set_filename(
       TestEnvironment::substitute("{{ test_rundir }}/test/common/ssl/test_data/no_san_key.pem"));
 
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_cert_hash", 1,
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_cert_hash", 1, "",
              GetParam());
 
   // Fails even with client renegotiation.
   client.set_allow_renegotiation(true);
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_cert_hash", 1,
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_cert_hash", 1, "",
              GetParam());
 }
 
@@ -1494,11 +1509,13 @@ TEST_P(SslSocketTest, FailedClientCertificateHashAndSpkiVerificationWrongCA) {
   client_cert->mutable_private_key()->set_filename(
       TestEnvironment::substitute("{{ test_rundir }}/test/common/ssl/test_data/san_uri_key.pem"));
 
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_error", 1, GetParam());
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_error", 1, "",
+             GetParam());
 
   // Fails even with client renegotiation.
   client.set_allow_renegotiation(true);
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_error", 1, GetParam());
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.fail_verify_error", 1, "",
+             GetParam());
 }
 
 // Make sure that we do not flush code and do an immediate close if we have not completed the
@@ -2273,43 +2290,44 @@ TEST_P(SslSocketTest, ProtocolVersions) {
 
   // Connection using defaults (client & server) succeeds, negotiating TLSv1.2.
   // ssl.handshake logged by both: client & server.
-  testUtilV2(listener, client, "", true, "TLSv1.2", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "TLSv1.2", "", "", "", "ssl.handshake", 2, "", GetParam());
 
   // Connection using defaults (client & server) succeeds, negotiating TLSv1.2,
   // even with client renegotiation.
   // ssl.handshake logged by both: client & server.
   client.set_allow_renegotiation(true);
-  testUtilV2(listener, client, "", true, "TLSv1.2", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "TLSv1.2", "", "", "", "ssl.handshake", 2, "", GetParam());
   client.set_allow_renegotiation(false);
 
   // Connection using TLSv1.0 (client) and defaults (server) succeeds.
   // ssl.handshake logged by both: client & server.
   client_params->set_tls_minimum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_0);
   client_params->set_tls_maximum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_0);
-  testUtilV2(listener, client, "", true, "TLSv1", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "TLSv1", "", "", "", "ssl.handshake", 2, "", GetParam());
 
   // Connection using TLSv1.1 (client) and defaults (server) succeeds.
   // ssl.handshake logged by both: client & server.
   client_params->set_tls_minimum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_1);
   client_params->set_tls_maximum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_1);
-  testUtilV2(listener, client, "", true, "TLSv1.1", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "TLSv1.1", "", "", "", "ssl.handshake", 2, "", GetParam());
 
   // Connection using TLSv1.2 (client) and defaults (server) succeeds.
   // ssl.handshake logged by both: client & server.
   client_params->set_tls_minimum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_2);
   client_params->set_tls_maximum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_2);
-  testUtilV2(listener, client, "", true, "TLSv1.2", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "TLSv1.2", "", "", "", "ssl.handshake", 2, "", GetParam());
 
   // Connection using TLSv1.3 (client) and defaults (server) fails.
   client_params->set_tls_minimum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_3);
   client_params->set_tls_maximum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_3);
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.connection_error", 1, GetParam());
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.connection_error", 1, "",
+             GetParam());
 
   // Connection using TLSv1.3 (client) and TLSv1.0-1.3 (server) succeeds.
   // ssl.handshake logged by both: client & server.
   server_params->set_tls_minimum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_0);
   server_params->set_tls_maximum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_3);
-  testUtilV2(listener, client, "", true, "TLSv1.3", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "TLSv1.3", "", "", "", "ssl.handshake", 2, "", GetParam());
 
   // Connection using defaults (client) and TLSv1.0 (server) succeeds.
   // ssl.handshake logged by both: client & server.
@@ -2317,30 +2335,31 @@ TEST_P(SslSocketTest, ProtocolVersions) {
   client_params->clear_tls_maximum_protocol_version();
   server_params->set_tls_minimum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_0);
   server_params->set_tls_maximum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_0);
-  testUtilV2(listener, client, "", true, "TLSv1", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "TLSv1", "", "", "", "ssl.handshake", 2, "", GetParam());
 
   // Connection using defaults (client) and TLSv1.1 (server) succeeds.
   // ssl.handshake logged by both: client & server.
   server_params->set_tls_minimum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_1);
   server_params->set_tls_maximum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_1);
-  testUtilV2(listener, client, "", true, "TLSv1.1", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "TLSv1.1", "", "", "", "ssl.handshake", 2, "", GetParam());
 
   // Connection using defaults (client) and TLSv1.2 (server) succeeds.
   // ssl.handshake logged by both: client & server.
   server_params->set_tls_minimum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_2);
   server_params->set_tls_maximum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_2);
-  testUtilV2(listener, client, "", true, "TLSv1.2", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "TLSv1.2", "", "", "", "ssl.handshake", 2, "", GetParam());
 
   // Connection using defaults (client) and TLSv1.3 (server) fails.
   server_params->set_tls_minimum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_3);
   server_params->set_tls_maximum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_3);
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.connection_error", 1, GetParam());
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.connection_error", 1, "",
+             GetParam());
 
   // Connection using TLSv1.0-TLSv1.3 (client) and TLSv1.3 (server) succeeds.
   // ssl.handshake logged by both: client & server.
   client_params->set_tls_minimum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_0);
   client_params->set_tls_maximum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_3);
-  testUtilV2(listener, client, "", true, "TLSv1.3", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "TLSv1.3", "", "", "", "ssl.handshake", 2, "", GetParam());
 }
 
 TEST_P(SslSocketTest, ALPN) {
@@ -2360,30 +2379,30 @@ TEST_P(SslSocketTest, ALPN) {
 
   // Connection using defaults (client & server) succeeds, no ALPN is negotiated.
   // ssl.handshake logged by both: client & server.
-  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, "", GetParam());
 
   // Connection using defaults (client & server) succeeds, no ALPN is negotiated,
   // even with client renegotiation.
   // ssl.handshake logged by both: client & server.
   client.set_allow_renegotiation(true);
-  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, "", GetParam());
   client.set_allow_renegotiation(false);
 
   // Client connects without ALPN to a server with "test" ALPN, no ALPN is negotiated.
   server_ctx->add_alpn_protocols("test");
-  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, "", GetParam());
   server_ctx->clear_alpn_protocols();
 
   // Client connects with "test" ALPN to a server without ALPN, no ALPN is negotiated.
   client_ctx->add_alpn_protocols("test");
-  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, "", GetParam());
   client_ctx->clear_alpn_protocols();
 
   // Client connects with "test" ALPN to a server with "test" ALPN, "test" ALPN is negotiated.
   // ssl.handshake logged by both: client & server.
   client_ctx->add_alpn_protocols("test");
   server_ctx->add_alpn_protocols("test");
-  testUtilV2(listener, client, "", true, "", "", "", "test", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "", "", "", "test", "ssl.handshake", 2, "", GetParam());
   client_ctx->clear_alpn_protocols();
   server_ctx->clear_alpn_protocols();
 
@@ -2393,7 +2412,7 @@ TEST_P(SslSocketTest, ALPN) {
   client.set_allow_renegotiation(true);
   client_ctx->add_alpn_protocols("test");
   server_ctx->add_alpn_protocols("test");
-  testUtilV2(listener, client, "", true, "", "", "", "test", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "", "", "", "test", "ssl.handshake", 2, "", GetParam());
   client.set_allow_renegotiation(false);
   client_ctx->clear_alpn_protocols();
   server_ctx->clear_alpn_protocols();
@@ -2402,7 +2421,7 @@ TEST_P(SslSocketTest, ALPN) {
   // ssl.handshake logged by both: client & server.
   client_ctx->add_alpn_protocols("test");
   server_ctx->add_alpn_protocols("test2");
-  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, "", GetParam());
   client_ctx->clear_alpn_protocols();
   server_ctx->clear_alpn_protocols();
 }
@@ -2425,12 +2444,12 @@ TEST_P(SslSocketTest, CipherSuites) {
 
   // Connection using defaults (client & server) succeeds.
   // ssl.handshake logged by both: client & server.
-  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, "", GetParam());
 
   // Connection using defaults (client & server) succeeds, even with client renegotiation.
   // ssl.handshake logged by both: client & server.
   client.set_allow_renegotiation(true);
-  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, "", GetParam());
   client.set_allow_renegotiation(false);
 
   // Client connects with one of the supported cipher suites, connection succeeds.
@@ -2438,14 +2457,15 @@ TEST_P(SslSocketTest, CipherSuites) {
   client_params->add_cipher_suites("ECDHE-RSA-CHACHA20-POLY1305");
   server_params->add_cipher_suites("ECDHE-RSA-CHACHA20-POLY1305");
   server_params->add_cipher_suites("ECDHE-RSA-AES128-GCM-SHA256");
-  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, "", GetParam());
   client_params->clear_cipher_suites();
   server_params->clear_cipher_suites();
 
   // Client connects with unsupported cipher suite, connection fails.
   client_params->add_cipher_suites("ECDHE-RSA-AES128-GCM-SHA256");
   server_params->add_cipher_suites("ECDHE-RSA-CHACHA20-POLY1305");
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.connection_error", 1, GetParam());
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.connection_error", 1, "",
+             GetParam());
   client_params->clear_cipher_suites();
   server_params->clear_cipher_suites();
 }
@@ -2468,12 +2488,12 @@ TEST_P(SslSocketTest, EcdhCurves) {
 
   // Connection using defaults (client & server) succeeds.
   // ssl.handshake logged by both: client & server.
-  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, "", GetParam());
 
   // Connection using defaults (client & server) succeeds, even with client renegotiation.
   // ssl.handshake logged by both: client & server.
   client.set_allow_renegotiation(true);
-  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, "", GetParam());
   client.set_allow_renegotiation(false);
 
   // Client connects with one of the supported ECDH curves, connection succeeds.
@@ -2482,7 +2502,7 @@ TEST_P(SslSocketTest, EcdhCurves) {
   server_params->add_ecdh_curves("X25519");
   server_params->add_ecdh_curves("P-256");
   server_params->add_cipher_suites("ECDHE-RSA-AES128-GCM-SHA256");
-  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, GetParam());
+  testUtilV2(listener, client, "", true, "", "", "", "", "ssl.handshake", 2, "", GetParam());
   client_params->clear_ecdh_curves();
   server_params->clear_ecdh_curves();
   server_params->clear_cipher_suites();
@@ -2491,7 +2511,8 @@ TEST_P(SslSocketTest, EcdhCurves) {
   client_params->add_ecdh_curves("X25519");
   server_params->add_ecdh_curves("P-256");
   server_params->add_cipher_suites("ECDHE-RSA-AES128-GCM-SHA256");
-  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.connection_error", 1, GetParam());
+  testUtilV2(listener, client, "", false, "", "", "", "", "ssl.connection_error", 1, "",
+             GetParam());
   client_params->clear_ecdh_curves();
   server_params->clear_ecdh_curves();
   server_params->clear_cipher_suites();

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -78,6 +78,7 @@ public:
   MOCK_METHOD1(setConnectionStats, void(const ConnectionStats& stats));
   MOCK_METHOD0(ssl, Ssl::Connection*());
   MOCK_CONST_METHOD0(ssl, const Ssl::Connection*());
+  MOCK_CONST_METHOD0(requestedServerName, absl::string_view());
   MOCK_CONST_METHOD0(state, State());
   MOCK_METHOD2(write, void(Buffer::Instance& data, bool end_stream));
   MOCK_METHOD1(setBufferLimits, void(uint32_t limit));
@@ -117,6 +118,7 @@ public:
   MOCK_METHOD1(setConnectionStats, void(const ConnectionStats& stats));
   MOCK_METHOD0(ssl, Ssl::Connection*());
   MOCK_CONST_METHOD0(ssl, const Ssl::Connection*());
+  MOCK_CONST_METHOD0(requestedServerName, absl::string_view());
   MOCK_CONST_METHOD0(state, State());
   MOCK_METHOD2(write, void(Buffer::Instance& data, bool end_stream));
   MOCK_METHOD1(setBufferLimits, void(uint32_t limit));


### PR DESCRIPTION
*Description*: Add requestedServerName() to Network::connection, to enable using the SNI value in the filters. The current use case  is sending the SNI value to the Istio mixer for monitoring and policy enforcement. Suppose we have *.ibm.com value in sni_domains, and a request is sent to www.ibm.com, the requirement is to extract the value of www.ibm.com by a listener and to send it to Mixer.
*Risk Level*: Low
*Testing*: Added SslSocketTest.GetRequestedServerName test
*Docs Changes*: None
*Release Notes*: None
Is related to issue https://github.com/envoyproxy/envoy/issues/3707, is a prerequisite for https://github.com/istio/istio/issues/6810