### PR TITLE
test: tweaks to uds_integration_test (--runs_per_test)

### DIFF
--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -101,10 +101,12 @@ public:
   /**
    * Prefix a given path with the Unix Domain Socket temporary directory.
    * @param path path suffix.
+   * @param abstract_namespace true if an abstract namespace should be returned.
    * @return std::string path qualified with the Unix Domain Socket temporary directory.
    */
-  static std::string unixDomainSocketPath(const std::string& path) {
-    return unixDomainSocketDirectory() + "/" + path;
+  static std::string unixDomainSocketPath(const std::string& path,
+                                          bool abstract_namespace = false) {
+    return (abstract_namespace ? "@" : "") + unixDomainSocketDirectory() + "/" + path;
   }
 
   /**


### PR DESCRIPTION
I was trying to debug a ci flake of uds integration test.  Haven't managed to repo the flake even with 5k asan runs, but I figure it's worth allowing the parallelism.  

*Risk Level*: n/a (test only)
*Testing*: uds test now runs with --runs_per_test > 1
*Docs Changes*: n/a
*Release Notes*: n/a
