### PR TITLE
thrift: transport and protocol write code

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/BUILD
@@ -97,8 +97,8 @@ envoy_cc_library(
 envoy_cc_library(
     name = "transport_interface",
     hdrs = ["transport.h"],
+    external_deps = ["abseil_optional"],
     deps = [
-        ":protocol_lib",
         "//include/envoy/buffer:buffer_interface",
         "//source/common/singleton:const_singleton",
     ],

--- a/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.h
@@ -45,6 +45,29 @@ public:
   bool readDouble(Buffer::Instance& buffer, double& value) override;
   bool readString(Buffer::Instance& buffer, std::string& value) override;
   bool readBinary(Buffer::Instance& buffer, std::string& value) override;
+  void writeMessageBegin(Buffer::Instance& buffer, const std::string& name, MessageType msg_type,
+                         int32_t seq_id) override;
+  void writeMessageEnd(Buffer::Instance& buffer) override;
+  void writeStructBegin(Buffer::Instance& buffer, const std::string& name) override;
+  void writeStructEnd(Buffer::Instance& buffer) override;
+  void writeFieldBegin(Buffer::Instance& buffer, const std::string& name, FieldType field_type,
+                       int16_t field_id) override;
+  void writeFieldEnd(Buffer::Instance& buffer) override;
+  void writeMapBegin(Buffer::Instance& buffer, FieldType key_type, FieldType value_type,
+                     uint32_t size) override;
+  void writeMapEnd(Buffer::Instance& buffer) override;
+  void writeListBegin(Buffer::Instance& buffer, FieldType elem_type, uint32_t size) override;
+  void writeListEnd(Buffer::Instance& buffer) override;
+  void writeSetBegin(Buffer::Instance& buffer, FieldType elem_type, uint32_t size) override;
+  void writeSetEnd(Buffer::Instance& buffer) override;
+  void writeBool(Buffer::Instance& buffer, bool value) override;
+  void writeByte(Buffer::Instance& buffer, uint8_t value) override;
+  void writeInt16(Buffer::Instance& buffer, int16_t value) override;
+  void writeInt32(Buffer::Instance& buffer, int32_t value) override;
+  void writeInt64(Buffer::Instance& buffer, int64_t value) override;
+  void writeDouble(Buffer::Instance& buffer, double value) override;
+  void writeString(Buffer::Instance& buffer, const std::string& value) override;
+  void writeBinary(Buffer::Instance& buffer, const std::string& value) override;
 
   static bool isMagic(uint16_t word) { return word == Magic; }
 
@@ -64,6 +87,8 @@ public:
 
   bool readMessageBegin(Buffer::Instance& buffer, std::string& name, MessageType& msg_type,
                         int32_t& seq_id) override;
+  void writeMessageBegin(Buffer::Instance& buffer, const std::string& name, MessageType msg_type,
+                         int32_t seq_id) override;
 };
 
 } // namespace ThriftProxy

--- a/source/extensions/filters/network/thrift_proxy/buffer_helper.cc
+++ b/source/extensions/filters/network/thrift_proxy/buffer_helper.cc
@@ -221,6 +221,95 @@ int32_t BufferHelper::peekZigZagI32(Buffer::Instance& buffer, uint64_t offset, i
   return (zz32 >> 1) ^ static_cast<uint32_t>(-static_cast<int32_t>(zz32 & 1));
 }
 
+void BufferHelper::writeI8(Buffer::Instance& buffer, int8_t value) { buffer.add(&value, 1); }
+
+void BufferHelper::writeI16(Buffer::Instance& buffer, int16_t value) {
+  value = htobe16(value);
+  buffer.add(&value, 2);
+}
+
+void BufferHelper::writeU16(Buffer::Instance& buffer, uint16_t value) {
+  value = htobe16(value);
+  buffer.add(&value, 2);
+}
+
+void BufferHelper::writeI32(Buffer::Instance& buffer, int32_t value) {
+  value = htobe32(value);
+  buffer.add(&value, 4);
+}
+
+void BufferHelper::writeU32(Buffer::Instance& buffer, uint32_t value) {
+  value = htobe32(value);
+  buffer.add(&value, 4);
+}
+
+void BufferHelper::writeI64(Buffer::Instance& buffer, int64_t value) {
+  value = htobe64(value);
+  buffer.add(&value, 8);
+}
+
+void BufferHelper::writeDouble(Buffer::Instance& buffer, double value) {
+  static_assert(sizeof(double) == sizeof(uint64_t), "sizeof(double) != sizeof(uint64_t)");
+  static_assert(std::numeric_limits<double>::is_iec559, "non-IEC559 (IEEE 754) double");
+
+  // See drainDouble for implementation details.
+  uint64_t i;
+  std::memcpy(&i, &value, 8);
+  i = htobe64(i);
+  buffer.add(&i, 8);
+}
+
+// Thrift's var int encoding is described in
+// https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md
+void BufferHelper::writeVarIntI32(Buffer::Instance& buffer, int32_t value) {
+  uint8_t bytes[5];
+  uint32_t v = static_cast<uint32_t>(value);
+  int pos = 0;
+  while (pos < 5) {
+    if ((v & ~0x7F) == 0) {
+      bytes[pos++] = static_cast<uint8_t>(v);
+      break;
+    }
+
+    bytes[pos++] = static_cast<uint8_t>(v & 0x7F) | 0x80;
+    v >>= 7;
+  }
+  ASSERT(v < 0x80);
+  ASSERT(pos <= 5);
+
+  buffer.add(bytes, pos);
+}
+
+void BufferHelper::writeVarIntI64(Buffer::Instance& buffer, int64_t value) {
+  uint8_t bytes[10];
+  uint64_t v = static_cast<uint64_t>(value);
+  int pos = 0;
+  while (pos < 10) {
+    if ((v & ~0x7F) == 0) {
+      bytes[pos++] = static_cast<uint8_t>(v);
+      break;
+    }
+
+    bytes[pos++] = static_cast<uint8_t>(v & 0x7F) | 0x80;
+    v >>= 7;
+  }
+
+  ASSERT(v < 0x80);
+  ASSERT(pos <= 10);
+
+  buffer.add(bytes, pos);
+}
+
+void BufferHelper::writeZigZagI32(Buffer::Instance& buffer, int32_t value) {
+  uint32_t zz32 = (static_cast<uint32_t>(value) << 1) ^ (value >> 31);
+  writeVarIntI32(buffer, zz32);
+}
+
+void BufferHelper::writeZigZagI64(Buffer::Instance& buffer, int64_t value) {
+  uint64_t zz64 = (static_cast<uint64_t>(value) << 1) ^ (value >> 63);
+  writeVarIntI64(buffer, zz64);
+}
+
 } // namespace ThriftProxy
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/source/extensions/filters/network/thrift_proxy/buffer_helper.h
+++ b/source/extensions/filters/network/thrift_proxy/buffer_helper.h
@@ -212,6 +212,83 @@ public:
    */
   static int32_t peekZigZagI32(Buffer::Instance& buffer, uint64_t offset, int& size);
 
+  /**
+   * Writes an int8_t to the buffer.
+   * @param buffer Buffer::Instance written to
+   * @param value the int8_t to write
+   */
+  static void writeI8(Buffer::Instance& buffer, int8_t value);
+
+  /**
+   * Writes an int16_t to the buffer.
+   * @param buffer Buffer::Instance written to
+   * @param value the int16_t to write
+   */
+  static void writeI16(Buffer::Instance& buffer, int16_t value);
+
+  /**
+   * Writes an uint16_t to the buffer.
+   * @param buffer Buffer::Instance written to
+   * @param value the uint16_t to write
+   */
+  static void writeU16(Buffer::Instance& buffer, uint16_t value);
+
+  /**
+   * Writes an int32_t to the buffer.
+   * @param buffer Buffer::Instance written to
+   * @param value the int32_t to write
+   */
+  static void writeI32(Buffer::Instance& buffer, int32_t value);
+
+  /**
+   * Writes an uint32_t to the buffer.
+   * @param buffer Buffer::Instance written to
+   * @param value the uint32_t to write
+   */
+  static void writeU32(Buffer::Instance& buffer, uint32_t value);
+
+  /**
+   * Writes an int64_t to the buffer.
+   * @param buffer Buffer::Instance written to
+   * @param value the int64_t to write
+   */
+  static void writeI64(Buffer::Instance& buffer, int64_t value);
+
+  /**
+   * Writes a double to the buffer.
+   * @param buffer Buffer::Instance written to
+   * @param value the double to write
+   */
+  static void writeDouble(Buffer::Instance& buffer, double value);
+
+  /**
+   * Writes a var-int encoded int32_t to the buffer.
+   * @param buffer Buffer::Instance written to
+   * @param value the int32_t to write
+   */
+  static void writeVarIntI32(Buffer::Instance& buffer, int32_t value);
+
+  /**
+   * Writes a var-int encoded int64_t to the buffer.
+   * @param buffer Buffer::Instance written to
+   * @param value the int64_t to write
+   */
+  static void writeVarIntI64(Buffer::Instance& buffer, int64_t value);
+
+  /**
+   * Writes a zig-zag encoded int32_t to the buffer.
+   * @param buffer Buffer::Instance written to
+   * @param value the int32_t to write
+   */
+  static void writeZigZagI32(Buffer::Instance& buffer, int32_t value);
+
+  /**
+   * Writes a zig-zag encoded int64_t to the buffer.
+   * @param buffer Buffer::Instance written to
+   * @param value the int64_t to write
+   */
+  static void writeZigZagI64(Buffer::Instance& buffer, int64_t value);
+
 private:
   /**
    * Peeks at a variable-length int of up to 64 bits at offset. Updates size to indicate how many

--- a/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.cc
@@ -127,7 +127,7 @@ bool CompactProtocolImpl::readFieldBegin(Buffer::Instance& buffer, std::string& 
   }
 
   int16_t compact_field_id;
-  uint8_t compact_field_type;
+  CompactFieldType compact_field_type;
   int id_size = 0;
   if ((delta_and_type >> 4) == 0) {
     // Field ID delta is zero: this is a long-form field header, followed by zig-zag field id.
@@ -144,18 +144,18 @@ bool CompactProtocolImpl::readFieldBegin(Buffer::Instance& buffer, std::string& 
       throw EnvoyException(fmt::format("invalid compact protocol field id {}", id));
     }
 
-    compact_field_type = delta_and_type;
+    compact_field_type = static_cast<CompactFieldType>(delta_and_type);
     compact_field_id = static_cast<int16_t>(id);
   } else {
     // Short form field header: 4 bits of field id delta, 4 bits of field type.
-    compact_field_type = delta_and_type & 0x0F;
+    compact_field_type = static_cast<CompactFieldType>(delta_and_type & 0x0F);
     compact_field_id = last_field_id_ + static_cast<int16_t>(delta_and_type >> 4);
   }
 
   field_type = convertCompactFieldType(compact_field_type);
   // For simple fields, boolean values are transmitted as a type with no further data.
   if (field_type == FieldType::Bool) {
-    bool_value_ = compact_field_type == 1;
+    bool_value_ = compact_field_type == CompactFieldType::BoolTrue;
   }
 
   name.clear(); // compact protocol does not transmit field names
@@ -166,39 +166,6 @@ bool CompactProtocolImpl::readFieldBegin(Buffer::Instance& buffer, std::string& 
 
   onStructField(absl::string_view(name), field_type, field_id);
   return true;
-}
-
-FieldType CompactProtocolImpl::convertCompactFieldType(uint8_t compact_field_type) {
-  switch (compact_field_type) {
-  case 0:
-    return FieldType::Stop;
-  case 1:
-    return FieldType::Bool;
-  case 2:
-    return FieldType::Bool;
-  case 3:
-    return FieldType::Byte;
-  case 4:
-    return FieldType::I16;
-  case 5:
-    return FieldType::I32;
-  case 6:
-    return FieldType::I64;
-  case 7:
-    return FieldType::Double;
-  case 8:
-    return FieldType::String;
-  case 9:
-    return FieldType::List;
-  case 10:
-    return FieldType::Set;
-  case 11:
-    return FieldType::Map;
-  case 12:
-    return FieldType::Struct;
-  default:
-    throw EnvoyException(fmt::format("unknown compact protocol field type {}", compact_field_type));
-  }
 }
 
 bool CompactProtocolImpl::readFieldEnd(Buffer::Instance& buffer) {
@@ -232,8 +199,8 @@ bool CompactProtocolImpl::readMapBegin(Buffer::Instance& buffer, FieldType& key_
   }
 
   uint8_t types = BufferHelper::peekI8(buffer, s_size);
-  FieldType ktype = convertCompactFieldType(types >> 4);
-  FieldType vtype = convertCompactFieldType(types & 0xF);
+  FieldType ktype = convertCompactFieldType(static_cast<CompactFieldType>(types >> 4));
+  FieldType vtype = convertCompactFieldType(static_cast<CompactFieldType>(types & 0xF));
 
   // Drain the size and the types byte.
   buffer.drain(s_size + 1);
@@ -278,7 +245,7 @@ bool CompactProtocolImpl::readListBegin(Buffer::Instance& buffer, FieldType& ele
     sz = static_cast<uint32_t>(s);
   }
 
-  elem_type = convertCompactFieldType(size_and_type & 0x0F);
+  elem_type = convertCompactFieldType(static_cast<CompactFieldType>(size_and_type & 0x0F));
   size = sz;
 
   buffer.drain(s_size + 1);
@@ -417,6 +384,241 @@ bool CompactProtocolImpl::readString(Buffer::Instance& buffer, std::string& valu
 
 bool CompactProtocolImpl::readBinary(Buffer::Instance& buffer, std::string& value) {
   return readString(buffer, value);
+}
+
+void CompactProtocolImpl::writeMessageBegin(Buffer::Instance& buffer, const std::string& name,
+                                            MessageType msg_type, int32_t seq_id) {
+  UNREFERENCED_PARAMETER(name);
+
+  uint16_t ptv = (Magic & MagicMask) | (static_cast<uint16_t>(msg_type) << 5);
+  ASSERT((ptv & MagicMask) == Magic);
+  ASSERT((ptv & ~MagicMask) >> 5 == static_cast<uint16_t>(msg_type));
+
+  BufferHelper::writeU16(buffer, ptv);
+  BufferHelper::writeVarIntI32(buffer, seq_id);
+  writeString(buffer, name);
+}
+
+void CompactProtocolImpl::writeMessageEnd(Buffer::Instance& buffer) {
+  UNREFERENCED_PARAMETER(buffer);
+}
+
+void CompactProtocolImpl::writeStructBegin(Buffer::Instance& buffer, const std::string& name) {
+  UNREFERENCED_PARAMETER(buffer);
+  UNREFERENCED_PARAMETER(name);
+
+  // Field ids are encoded as deltas specific to the field's containing struct. Field ids are
+  // tracked in a stack to handle nested structs.
+  last_field_id_stack_.push(last_field_id_);
+  last_field_id_ = 0;
+}
+
+void CompactProtocolImpl::writeStructEnd(Buffer::Instance& buffer) {
+  UNREFERENCED_PARAMETER(buffer);
+
+  if (last_field_id_stack_.empty()) {
+    throw EnvoyException("invalid write of compact protocol struct end");
+  }
+
+  last_field_id_ = last_field_id_stack_.top();
+  last_field_id_stack_.pop();
+}
+
+void CompactProtocolImpl::writeFieldBegin(Buffer::Instance& buffer, const std::string& name,
+                                          FieldType field_type, int16_t field_id) {
+  UNREFERENCED_PARAMETER(name);
+
+  if (field_type == FieldType::Stop) {
+    BufferHelper::writeI8(buffer, 0);
+    return;
+  }
+
+  if (field_type == FieldType::Bool) {
+    bool_field_id_ = field_id;
+    return;
+  }
+
+  writeFieldBeginInternal(buffer, field_type, field_id, {});
+}
+
+void CompactProtocolImpl::writeFieldBeginInternal(
+    Buffer::Instance& buffer, FieldType field_type, int16_t field_id,
+    absl::optional<CompactFieldType> field_type_override) {
+  CompactFieldType compact_field_type;
+  if (field_type_override.has_value()) {
+    compact_field_type = field_type_override.value();
+  } else {
+    compact_field_type = convertFieldType(field_type);
+  }
+
+  if (field_id > last_field_id_ && field_id - last_field_id_ <= 15) {
+    // Encode short-form field header.
+    BufferHelper::writeI8(buffer, (static_cast<int8_t>(field_id - last_field_id_) << 4) |
+                                      static_cast<int8_t>(compact_field_type));
+  } else {
+    BufferHelper::writeI8(buffer, static_cast<int8_t>(compact_field_type));
+    BufferHelper::writeI16(buffer, field_id);
+  }
+
+  last_field_id_ = field_id;
+}
+
+void CompactProtocolImpl::writeFieldEnd(Buffer::Instance& buffer) {
+  UNREFERENCED_PARAMETER(buffer);
+
+  bool_field_id_.reset();
+}
+
+void CompactProtocolImpl::writeMapBegin(Buffer::Instance& buffer, FieldType key_type,
+                                        FieldType value_type, uint32_t size) {
+  if (size > INT32_MAX) {
+    throw EnvoyException(fmt::format("illegal compact protocol map size {}", size));
+  }
+
+  BufferHelper::writeVarIntI32(buffer, static_cast<int32_t>(size));
+  if (size == 0) {
+    return;
+  }
+
+  CompactFieldType compact_key_type = convertFieldType(key_type);
+  CompactFieldType compact_value_type = convertFieldType(value_type);
+  BufferHelper::writeI8(buffer, (static_cast<int8_t>(compact_key_type) << 4) |
+                                    static_cast<int8_t>(compact_value_type));
+}
+
+void CompactProtocolImpl::writeMapEnd(Buffer::Instance& buffer) { UNREFERENCED_PARAMETER(buffer); }
+
+void CompactProtocolImpl::writeListBegin(Buffer::Instance& buffer, FieldType elem_type,
+                                         uint32_t size) {
+  if (size > INT32_MAX) {
+    throw EnvoyException(fmt::format("illegal compact protocol list/set size {}", size));
+  }
+
+  CompactFieldType compact_elem_type = convertFieldType(elem_type);
+
+  if (size < 0xF) {
+    // Short form list/set header
+    int8_t short_size = static_cast<int8_t>(size & 0xF);
+    BufferHelper::writeI8(buffer, (short_size << 4) | static_cast<int8_t>(compact_elem_type));
+  } else {
+    BufferHelper::writeI8(buffer, 0xF0 | static_cast<int8_t>(compact_elem_type));
+    BufferHelper::writeVarIntI32(buffer, static_cast<int32_t>(size));
+  }
+}
+
+void CompactProtocolImpl::writeListEnd(Buffer::Instance& buffer) { UNREFERENCED_PARAMETER(buffer); }
+
+void CompactProtocolImpl::writeSetBegin(Buffer::Instance& buffer, FieldType elem_type,
+                                        uint32_t size) {
+  writeListBegin(buffer, elem_type, size);
+}
+
+void CompactProtocolImpl::writeSetEnd(Buffer::Instance& buffer) { UNREFERENCED_PARAMETER(buffer); }
+
+void CompactProtocolImpl::writeBool(Buffer::Instance& buffer, bool value) {
+  if (bool_field_id_.has_value()) {
+    // Boolean fields have their value encoded by type.
+    CompactFieldType bool_field_type =
+        value ? CompactFieldType::BoolTrue : CompactFieldType::BoolFalse;
+    writeFieldBeginInternal(buffer, FieldType::Bool, bool_field_id_.value(), {bool_field_type});
+    return;
+  }
+
+  // Map/Set/List booleans are encoded as bytes.
+  BufferHelper::writeI8(buffer, value ? 1 : 0);
+}
+
+void CompactProtocolImpl::writeByte(Buffer::Instance& buffer, uint8_t value) {
+  BufferHelper::writeI8(buffer, value);
+}
+
+void CompactProtocolImpl::writeInt16(Buffer::Instance& buffer, int16_t value) {
+  int32_t extended = static_cast<int32_t>(value);
+  BufferHelper::writeZigZagI32(buffer, extended);
+}
+
+void CompactProtocolImpl::writeInt32(Buffer::Instance& buffer, int32_t value) {
+  BufferHelper::writeZigZagI32(buffer, value);
+}
+
+void CompactProtocolImpl::writeInt64(Buffer::Instance& buffer, int64_t value) {
+  BufferHelper::writeZigZagI64(buffer, value);
+}
+
+void CompactProtocolImpl::writeDouble(Buffer::Instance& buffer, double value) {
+  BufferHelper::writeDouble(buffer, value);
+}
+
+void CompactProtocolImpl::writeString(Buffer::Instance& buffer, const std::string& value) {
+  BufferHelper::writeVarIntI32(buffer, value.length());
+  buffer.add(value);
+}
+
+void CompactProtocolImpl::writeBinary(Buffer::Instance& buffer, const std::string& value) {
+  writeString(buffer, value);
+}
+
+FieldType CompactProtocolImpl::convertCompactFieldType(CompactFieldType compact_field_type) {
+  switch (compact_field_type) {
+  case CompactFieldType::BoolTrue:
+    return FieldType::Bool;
+  case CompactFieldType::BoolFalse:
+    return FieldType::Bool;
+  case CompactFieldType::Byte:
+    return FieldType::Byte;
+  case CompactFieldType::I16:
+    return FieldType::I16;
+  case CompactFieldType::I32:
+    return FieldType::I32;
+  case CompactFieldType::I64:
+    return FieldType::I64;
+  case CompactFieldType::Double:
+    return FieldType::Double;
+  case CompactFieldType::String:
+    return FieldType::String;
+  case CompactFieldType::List:
+    return FieldType::List;
+  case CompactFieldType::Set:
+    return FieldType::Set;
+  case CompactFieldType::Map:
+    return FieldType::Map;
+  case CompactFieldType::Struct:
+    return FieldType::Struct;
+  default:
+    throw EnvoyException(fmt::format("unknown compact protocol field type {}",
+                                     static_cast<int8_t>(compact_field_type)));
+  }
+}
+
+CompactProtocolImpl::CompactFieldType CompactProtocolImpl::convertFieldType(FieldType field_type) {
+  switch (field_type) {
+  case FieldType::Bool:
+    // c.f. special handling in writeFieldBegin
+    return CompactFieldType::BoolTrue;
+  case FieldType::Byte:
+    return CompactFieldType::Byte;
+  case FieldType::I16:
+    return CompactFieldType::I16;
+  case FieldType::I32:
+    return CompactFieldType::I32;
+  case FieldType::I64:
+    return CompactFieldType::I64;
+  case FieldType::Double:
+    return CompactFieldType::Double;
+  case FieldType::String:
+    return CompactFieldType::String;
+  case FieldType::Struct:
+    return CompactFieldType::Struct;
+  case FieldType::Map:
+    return CompactFieldType::Map;
+  case FieldType::Set:
+    return CompactFieldType::Set;
+  case FieldType::List:
+    return CompactFieldType::List;
+  default:
+    throw EnvoyException(
+        fmt::format("unknown protocol field type {}", static_cast<int8_t>(field_type)));
+  }
 }
 
 } // namespace ThriftProxy

--- a/source/extensions/filters/network/thrift_proxy/framed_transport_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/framed_transport_impl.cc
@@ -32,6 +32,18 @@ bool FramedTransportImpl::decodeFrameEnd(Buffer::Instance&) {
   return true;
 }
 
+void FramedTransportImpl::encodeFrame(Buffer::Instance& buffer, Buffer::Instance& message) {
+  uint64_t size = message.length();
+  if (size == 0 || size > MaxFrameSize) {
+    throw EnvoyException(fmt::format("invalid thrift framed transport frame size {}", size));
+  }
+
+  int32_t thrift_size = static_cast<int32_t>(size);
+
+  BufferHelper::writeI32(buffer, thrift_size);
+  buffer.move(message);
+}
+
 } // namespace ThriftProxy
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/source/extensions/filters/network/thrift_proxy/framed_transport_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/framed_transport_impl.h
@@ -25,6 +25,7 @@ public:
   const std::string& name() const override { return TransportNames::get().FRAMED; }
   bool decodeFrameStart(Buffer::Instance& buffer) override;
   bool decodeFrameEnd(Buffer::Instance& buffer) override;
+  void encodeFrame(Buffer::Instance& buffer, Buffer::Instance& message) override;
 
   static const int32_t MaxFrameSize = 0xFA0000;
 };

--- a/source/extensions/filters/network/thrift_proxy/protocol.h
+++ b/source/extensions/filters/network/thrift_proxy/protocol.h
@@ -336,6 +336,151 @@ public:
    * @throw EnvoyException if the data is not a valid set footer
    */
   virtual bool readBinary(Buffer::Instance& buffer, std::string& value) PURE;
+
+  /**
+   * Writes the start of a Thrift protocol message to the buffer.
+   * @param buffer Buffer::Instance to modify
+   * @param name the message name
+   * @param msg_type the message's MessageType
+   * @param seq_id the message sequende ID
+   */
+  virtual void writeMessageBegin(Buffer::Instance& buffer, const std::string& name,
+                                 MessageType msg_type, int32_t seq_id) PURE;
+
+  /**
+   * Writes the end of a Thrift protocol message to the buffer.
+   * @param buffer Buffer::Instance to modify
+   */
+  virtual void writeMessageEnd(Buffer::Instance& buffer) PURE;
+
+  /**
+   * Writes the start of a Thrift struct to the buffer.
+   * @param buffer Buffer::Instance to modify
+   * @param name the struct name, if known
+   */
+  virtual void writeStructBegin(Buffer::Instance& buffer, const std::string& name) PURE;
+
+  /**
+   * Writes the end of a Thrift struct to the buffer.
+   * @param buffer Buffer::Instance to modify
+   */
+  virtual void writeStructEnd(Buffer::Instance& buffer) PURE;
+
+  /**
+   * Writes the start of a Thrift struct field to the buffer
+   * @param buffer Buffer::Instance to modify
+   * @param name the field name, if known
+   * @param field_type the field's FieldType
+   * @param field_id the field ID
+   */
+  virtual void writeFieldBegin(Buffer::Instance& buffer, const std::string& name,
+                               FieldType field_type, int16_t field_id) PURE;
+
+  /**
+   * Writes the end of a Thrift struct field to the buffer.
+   * @param buffer Buffer::Instance to modify
+   */
+  virtual void writeFieldEnd(Buffer::Instance& buffer) PURE;
+
+  /**
+   * Writes the start of a Thrift map to the buffer.
+   * @param buffer Buffer::Instance to modify
+   * @param key_type the map key FieldType
+   * @param value_type the map value FieldType
+   * @param size the number of key-value pairs in the map
+   */
+  virtual void writeMapBegin(Buffer::Instance& buffer, FieldType key_type, FieldType value_type,
+                             uint32_t size) PURE;
+
+  /**
+   * Writes the end of a Thrift map to the buffer.
+   * @param buffer Buffer::Instance to modify
+   */
+  virtual void writeMapEnd(Buffer::Instance& buffer) PURE;
+
+  /**
+   * Writes the start of a Thrift list to the buffer.
+   * @param buffer Buffer::Instance to modify
+   * @param elem_type the list element FieldType
+   * @param size the number of list members
+   */
+  virtual void writeListBegin(Buffer::Instance& buffer, FieldType elem_type, uint32_t size) PURE;
+
+  /**
+   * Writes the end of a Thrift list to the buffer.
+   * @param buffer Buffer::Instance to modify
+   */
+  virtual void writeListEnd(Buffer::Instance& buffer) PURE;
+
+  /**
+   * Writes the start of a Thrift set to the buffer.
+   * @param buffer Buffer::Instance to modify
+   * @param elem_type the set element FieldType
+   * @param size the number of set members
+   */
+  virtual void writeSetBegin(Buffer::Instance& buffer, FieldType elem_type, uint32_t size) PURE;
+
+  /**
+   * Writes the end of a Thrift set to the buffer.
+   * @param buffer Buffer::Instance to modify
+   */
+  virtual void writeSetEnd(Buffer::Instance& buffer) PURE;
+
+  /**
+   * Writes a boolean value to the buffer.
+   * @param buffer Buffer::Instance to modify
+   * @param value bool to write
+   */
+  virtual void writeBool(Buffer::Instance& buffer, bool value) PURE;
+
+  /**
+   * Writes a byte value to the buffer.
+   * @param buffer Buffer::Instance to modify
+   * @param value uint8_t to write
+   */
+  virtual void writeByte(Buffer::Instance& buffer, uint8_t value) PURE;
+
+  /**
+   * Writes a int16_t value to the buffer.
+   * @param buffer Buffer::Instance to modify
+   * @param value int16_t to write
+   */
+  virtual void writeInt16(Buffer::Instance& buffer, int16_t value) PURE;
+
+  /**
+   * Writes a int32_t value to the buffer.
+   * @param buffer Buffer::Instance to modify
+   * @param value int32_t to write
+   */
+  virtual void writeInt32(Buffer::Instance& buffer, int32_t value) PURE;
+
+  /**
+   * Writes a int64_t value to the buffer.
+   * @param buffer Buffer::Instance to modify
+   * @param value int64_t to write
+   */
+  virtual void writeInt64(Buffer::Instance& buffer, int64_t value) PURE;
+
+  /**
+   * Writes a double value to the buffer.
+   * @param buffer Buffer::Instance to modify
+   * @param value double to write
+   */
+  virtual void writeDouble(Buffer::Instance& buffer, double value) PURE;
+
+  /**
+   * Writes a string value to the buffer.
+   * @param buffer Buffer::Instance to modify
+   * @param value std::string to write
+   */
+  virtual void writeString(Buffer::Instance& buffer, const std::string& value) PURE;
+
+  /**
+   * Writes a binary value to the buffer.
+   * @param buffer Buffer::Instance to modify
+   * @param value std::string to write
+   */
+  virtual void writeBinary(Buffer::Instance& buffer, const std::string& value) PURE;
 };
 
 typedef std::unique_ptr<Protocol> ProtocolPtr;

--- a/source/extensions/filters/network/thrift_proxy/protocol_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/protocol_impl.h
@@ -95,6 +95,57 @@ public:
   bool readBinary(Buffer::Instance& buffer, std::string& value) override {
     return protocol_->readBinary(buffer, value);
   }
+  void writeMessageBegin(Buffer::Instance& buffer, const std::string& name, MessageType msg_type,
+                         int32_t seq_id) override {
+    protocol_->writeMessageBegin(buffer, name, msg_type, seq_id);
+  }
+  void writeMessageEnd(Buffer::Instance& buffer) override { protocol_->writeMessageEnd(buffer); }
+  void writeStructBegin(Buffer::Instance& buffer, const std::string& name) override {
+    protocol_->writeStructBegin(buffer, name);
+  }
+  void writeStructEnd(Buffer::Instance& buffer) override { protocol_->writeStructEnd(buffer); }
+  void writeFieldBegin(Buffer::Instance& buffer, const std::string& name, FieldType field_type,
+                       int16_t field_id) override {
+    protocol_->writeFieldBegin(buffer, name, field_type, field_id);
+  }
+  void writeFieldEnd(Buffer::Instance& buffer) override { protocol_->writeFieldEnd(buffer); }
+  void writeMapBegin(Buffer::Instance& buffer, FieldType key_type, FieldType value_type,
+                     uint32_t size) override {
+    protocol_->writeMapBegin(buffer, key_type, value_type, size);
+  }
+  void writeMapEnd(Buffer::Instance& buffer) override { protocol_->writeMapEnd(buffer); }
+  void writeListBegin(Buffer::Instance& buffer, FieldType elem_type, uint32_t size) override {
+    protocol_->writeListBegin(buffer, elem_type, size);
+  }
+  void writeListEnd(Buffer::Instance& buffer) override { protocol_->writeListEnd(buffer); }
+  void writeSetBegin(Buffer::Instance& buffer, FieldType elem_type, uint32_t size) override {
+    protocol_->writeSetBegin(buffer, elem_type, size);
+  }
+  void writeSetEnd(Buffer::Instance& buffer) override { protocol_->writeSetEnd(buffer); }
+  void writeBool(Buffer::Instance& buffer, bool value) override {
+    protocol_->writeBool(buffer, value);
+  }
+  void writeByte(Buffer::Instance& buffer, uint8_t value) override {
+    protocol_->writeByte(buffer, value);
+  }
+  void writeInt16(Buffer::Instance& buffer, int16_t value) override {
+    protocol_->writeInt16(buffer, value);
+  }
+  void writeInt32(Buffer::Instance& buffer, int32_t value) override {
+    protocol_->writeInt32(buffer, value);
+  }
+  void writeInt64(Buffer::Instance& buffer, int64_t value) override {
+    protocol_->writeInt64(buffer, value);
+  }
+  void writeDouble(Buffer::Instance& buffer, double value) override {
+    protocol_->writeDouble(buffer, value);
+  }
+  void writeString(Buffer::Instance& buffer, const std::string& value) override {
+    protocol_->writeString(buffer, value);
+  }
+  void writeBinary(Buffer::Instance& buffer, const std::string& value) override {
+    protocol_->writeBinary(buffer, value);
+  }
 
   /*
    * Explicitly set the protocol. Public to simplify testing.

--- a/source/extensions/filters/network/thrift_proxy/transport.h
+++ b/source/extensions/filters/network/thrift_proxy/transport.h
@@ -87,6 +87,15 @@ public:
    * @throws EnvoyException if the data is not valid for this transport.
    */
   virtual bool decodeFrameEnd(Buffer::Instance& buffer) PURE;
+
+  /**
+   * encodeFrame wraps the given message buffer with the transport's header and trailer (if any).
+   * After encoding, message will be empty.
+   * @param buffer is the output buffer
+   * @param message a protocol-encoded message
+   * @throws EnvoyException if the message is too large for the transport
+   */
+  virtual void encodeFrame(Buffer::Instance& buffer, Buffer::Instance& message) PURE;
 };
 
 typedef std::unique_ptr<Transport> TransportPtr;

--- a/source/extensions/filters/network/thrift_proxy/transport_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/transport_impl.cc
@@ -59,6 +59,11 @@ bool AutoTransportImpl::decodeFrameEnd(Buffer::Instance& buffer) {
   return transport_->decodeFrameEnd(buffer);
 }
 
+void AutoTransportImpl::encodeFrame(Buffer::Instance& buffer, Buffer::Instance& message) {
+  RELEASE_ASSERT(transport_ != nullptr);
+  transport_->encodeFrame(buffer, message);
+}
+
 } // namespace ThriftProxy
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/source/extensions/filters/network/thrift_proxy/transport_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/transport_impl.h
@@ -43,13 +43,17 @@ public:
   const std::string& name() const override { return name_; }
   bool decodeFrameStart(Buffer::Instance& buffer) override;
   bool decodeFrameEnd(Buffer::Instance& buffer) override;
+  void encodeFrame(Buffer::Instance& buffer, Buffer::Instance& message) override;
 
-private:
+  /*
+   * Explicitly set the transport. Public to simplify testing.
+   */
   void setTransport(TransportPtr&& transport) {
     transport_ = std::move(transport);
     name_ = fmt::format("{}({})", transport_->name(), TransportNames::get().AUTO);
   }
 
+private:
   TransportPtr transport_{};
   std::string name_;
 };

--- a/source/extensions/filters/network/thrift_proxy/unframed_transport_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/unframed_transport_impl.h
@@ -31,6 +31,9 @@ public:
     onFrameComplete();
     return true;
   }
+  void encodeFrame(Buffer::Instance& buffer, Buffer::Instance& message) override {
+    buffer.move(message);
+  }
 };
 
 } // namespace ThriftProxy

--- a/test/extensions/filters/network/thrift_proxy/BUILD
+++ b/test/extensions/filters/network/thrift_proxy/BUILD
@@ -117,6 +117,7 @@ envoy_extension_cc_test(
         ":mocks",
         ":utility_lib",
         "//source/extensions/filters/network/thrift_proxy:transport_lib",
+        "//test/mocks/buffer:buffer_mocks",
         "//test/test_common:printers_lib",
         "//test/test_common:utility_lib",
     ],

--- a/test/extensions/filters/network/thrift_proxy/buffer_helper_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/buffer_helper_test.cc
@@ -354,16 +354,16 @@ TEST(BufferHelperTest, PeekVarInt32BufferUnderflow) {
 
 TEST(BufferHelperTest, PeekZigZagI32) {
   Buffer::OwnedImpl buffer;
-  addInt8(buffer, 0);                             // zigzag(0) = 0
-  addInt8(buffer, 1);                             // zigzag(1) = -1
-  addInt8(buffer, 2);                             // zigzag(2) = 1
-  addSeq(buffer, {0xFE, 0x01});                   // zigzag(0xFE) = 127
-  addSeq(buffer, {0xFF, 0x01});                   // zigzag(0xFF) = -128
-  addSeq(buffer, {0xFF, 0xFF, 0x03});             // zigzag(0xFFFF) = -32768
-  addSeq(buffer, {0xFF, 0xFF, 0xFF, 0x07});       // zigzag(0xFFFFFF) = -8388608
-  addSeq(buffer, {0xFE, 0xFF, 0xFF, 0xFF, 0x07}); // zigzag(0x7FFFFFFE) = 0x3FFFFFFF
-  addSeq(buffer, {0xFE, 0xFF, 0xFF, 0xFF, 0x0F}); // zigzag(0xFFFFFFFE) = 0x7FFFFFFF
-  addSeq(buffer, {0xFF, 0xFF, 0xFF, 0xFF, 0x0F}); // zigzag(0xFFFFFFFF) = 0x80000000
+  addInt8(buffer, 0);                             // unzigzag(0) = 0
+  addInt8(buffer, 1);                             // unzigzag(1) = -1
+  addInt8(buffer, 2);                             // unzigzag(2) = 1
+  addSeq(buffer, {0xFE, 0x01});                   // unzigzag(0xFE) = 127
+  addSeq(buffer, {0xFF, 0x01});                   // unzigzag(0xFF) = -128
+  addSeq(buffer, {0xFF, 0xFF, 0x03});             // unzigzag(0xFFFF) = -32768
+  addSeq(buffer, {0xFF, 0xFF, 0xFF, 0x07});       // unzigzag(0xFFFFFF) = -8388608
+  addSeq(buffer, {0xFE, 0xFF, 0xFF, 0xFF, 0x07}); // unzigzag(0x7FFFFFFE) = 0x3FFFFFFF
+  addSeq(buffer, {0xFE, 0xFF, 0xFF, 0xFF, 0x0F}); // unzigzag(0xFFFFFFFE) = 0x7FFFFFFF
+  addSeq(buffer, {0xFF, 0xFF, 0xFF, 0xFF, 0x0F}); // unzigzag(0xFFFFFFFF) = 0x80000000
 
   int size = 0;
   EXPECT_EQ(BufferHelper::peekZigZagI32(buffer, 0, size), 0);
@@ -414,19 +414,19 @@ TEST(BufferHelperTest, PeekZigZagI32BufferUnderflow) {
 
 TEST(BufferHelperTest, PeekZigZagI64) {
   Buffer::OwnedImpl buffer;
-  addInt8(buffer, 0);                             // zigzag(0) = 0
-  addInt8(buffer, 1);                             // zigzag(1) = -1
-  addInt8(buffer, 2);                             // zigzag(2) = 1
-  addSeq(buffer, {0xFF, 0xFF, 0x03});             // zigzag(0xFFFF) = -32768
-  addSeq(buffer, {0xFE, 0xFF, 0xFF, 0xFF, 0x0F}); // zigzag(0xFFFF FFFE) = 0x7FFF FFFF
+  addInt8(buffer, 0);                             // unzigzag(0) = 0
+  addInt8(buffer, 1);                             // unzigzag(1) = -1
+  addInt8(buffer, 2);                             // unzigzag(2) = 1
+  addSeq(buffer, {0xFF, 0xFF, 0x03});             // unzigzag(0xFFFF) = -32768
+  addSeq(buffer, {0xFE, 0xFF, 0xFF, 0xFF, 0x0F}); // unzigzag(0xFFFF FFFE) = 0x7FFF FFFF
 
-  // zigzag(0xFFFF FFFF FFFE) = 0x7FFF FFFF FFFF
+  // unzigzag(0xFFFF FFFF FFFE) = 0x7FFF FFFF FFFF
   addSeq(buffer, {0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x3F});
 
-  // zigzag(0x7FFF FFFF FFFF FFFE) = 0x3FFF FFFF FFFF FFFF
+  // unzigzag(0x7FFF FFFF FFFF FFFE) = 0x3FFF FFFF FFFF FFFF
   addSeq(buffer, {0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F});
 
-  // zigzag(0xFFFF FFFF FFFF FFFF) = 0x8000 0000 0000 0000 (-2^63)
+  // unzigzag(0xFFFF FFFF FFFF FFFF) = 0x8000 0000 0000 0000 (-2^63)
   addSeq(buffer, {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01});
 
   int size = 0;
@@ -468,6 +468,377 @@ TEST(BufferHelperTest, PeekZigZagI64BufferUnderflow) {
   addInt8(buffer, 0x80);
   EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekZigZagI64(buffer, 0, size), EnvoyException,
                             "invalid compact protocol zig-zag i64");
+}
+
+TEST(BufferHelperTest, WriteI8) {
+  Buffer::OwnedImpl buffer;
+  BufferHelper::writeI8(buffer, -128);
+  BufferHelper::writeI8(buffer, -1);
+  BufferHelper::writeI8(buffer, 0);
+  BufferHelper::writeI8(buffer, 1);
+  BufferHelper::writeI8(buffer, 127);
+
+  EXPECT_EQ(std::string("\x80\xFF\0\x1\x7F", 5), buffer.toString());
+}
+
+TEST(BufferHelperTest, WriteI16) {
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeI16(buffer, INT16_MIN);
+    EXPECT_EQ(std::string("\x80\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeI16(buffer, 0);
+    EXPECT_EQ(std::string("\0\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeI16(buffer, 1);
+    EXPECT_EQ(std::string("\0\x1", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeI16(buffer, INT16_MAX);
+    EXPECT_EQ("\x7F\xFF", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteU16) {
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeU16(buffer, 0);
+    EXPECT_EQ(std::string("\0\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeU16(buffer, 1);
+    EXPECT_EQ(std::string("\0\x1", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeU16(buffer, static_cast<uint16_t>(INT16_MAX) + 1);
+    EXPECT_EQ(std::string("\x80\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeU16(buffer, UINT16_MAX);
+    EXPECT_EQ("\xFF\xFF", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteI32) {
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeI32(buffer, INT32_MIN);
+    EXPECT_EQ(std::string("\x80\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeI32(buffer, 0);
+    EXPECT_EQ(std::string("\0\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeI32(buffer, 1);
+    EXPECT_EQ(std::string("\0\0\0\x1", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeI32(buffer, INT32_MAX);
+    EXPECT_EQ("\x7F\xFF\xFF\xFF", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteU32) {
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeU32(buffer, 0);
+    EXPECT_EQ(std::string("\0\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeU32(buffer, 1);
+    EXPECT_EQ(std::string("\0\0\0\x1", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeU32(buffer, static_cast<uint32_t>(INT32_MAX) + 1);
+    EXPECT_EQ(std::string("\x80\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeU32(buffer, UINT32_MAX);
+    EXPECT_EQ("\xFF\xFF\xFF\xFF", buffer.toString());
+  }
+}
+TEST(BufferHelperTest, WriteI64) {
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeI64(buffer, INT64_MIN);
+    EXPECT_EQ(std::string("\x80\0\0\0\0\0\0\0\0", 8), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeI64(buffer, 1);
+    EXPECT_EQ(std::string("\0\0\0\0\0\0\0\x1", 8), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeI64(buffer, 0);
+    EXPECT_EQ(std::string("\0\0\0\0\0\0\0\0", 8), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeI64(buffer, INT64_MAX);
+    EXPECT_EQ("\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteDouble) {
+  // See the DrainDouble test.
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeDouble(buffer, 3.0);
+    EXPECT_EQ(std::string("\x40\x8\0\0\0\0\0\0", 8), buffer.toString());
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeDouble(buffer, -DBL_MAX);
+    EXPECT_EQ("\xFF\xEF\xFF\xFF\xFF\xFF\xFF\xFF", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteVarIntI32) {
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI32(buffer, 0);
+    EXPECT_EQ(std::string("\0", 1), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI32(buffer, 1);
+    EXPECT_EQ("\x1", buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI32(buffer, 128);
+    EXPECT_EQ("\x80\x1", buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI32(buffer, (1 << 14) + 1);
+    EXPECT_EQ("\x81\x80\x1", buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI32(buffer, (1 << 28) + 1);
+    EXPECT_EQ("\x81\x80\x80\x80\x1", buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI32(buffer, INT32_MAX);
+    EXPECT_EQ("\xFF\xFF\xFF\xFF\x7", buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI32(buffer, -1);
+    EXPECT_EQ("\xFF\xFF\xFF\xFF\xF", buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI32(buffer, INT32_MIN);
+    EXPECT_EQ("\x80\x80\x80\x80\x8", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteVarIntI64) {
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI64(buffer, 0);
+    EXPECT_EQ(std::string("\0", 1), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI64(buffer, 1);
+    EXPECT_EQ("\x1", buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI64(buffer, 128);
+    EXPECT_EQ("\x80\x1", buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI64(buffer, (1 << 14) + 1);
+    EXPECT_EQ("\x81\x80\x1", buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI64(buffer, (1 << 28) + 1);
+    EXPECT_EQ("\x81\x80\x80\x80\x1", buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI64(buffer, (static_cast<int64_t>(1) << 56) + 1);
+    EXPECT_EQ("\x81\x80\x80\x80\x80\x80\x80\x80\x1", buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI64(buffer, INT32_MAX);
+    EXPECT_EQ("\xFF\xFF\xFF\xFF\x7", buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI64(buffer, INT64_MAX);
+    EXPECT_EQ("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F", buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI64(buffer, -1);
+    EXPECT_EQ("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x1", buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI64(buffer, INT32_MIN);
+    EXPECT_EQ("\x80\x80\x80\x80\xF8\xFF\xFF\xFF\xFF\x1", buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeVarIntI64(buffer, INT64_MIN);
+    EXPECT_EQ("\x80\x80\x80\x80\x80\x80\x80\x80\x80\x1", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteZigZagI32) {
+  // zigzag(0) = 0
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI32(buffer, 0);
+    EXPECT_EQ(std::string("\0", 1), buffer.toString());
+  }
+
+  // zigzag(-1) = 1
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI32(buffer, -1);
+    EXPECT_EQ("\x1", buffer.toString());
+  }
+
+  // zigzag(1) = 2
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI32(buffer, 1);
+    EXPECT_EQ("\x2", buffer.toString());
+  }
+
+  // zigzag(127) = 0xFE
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI32(buffer, 127);
+    EXPECT_EQ("\xFE\x1", buffer.toString());
+  }
+
+  // zigzag(128) = 0x100
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI32(buffer, 128);
+    EXPECT_EQ("\x80\x2", buffer.toString());
+  }
+
+  // zigzag(-128) = 0xFF
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI32(buffer, -128);
+    EXPECT_EQ("\xFF\x1", buffer.toString());
+  }
+
+  // zigzag(0x7FFFFFFF) = 0xFFFFFFFE
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI32(buffer, INT32_MAX);
+    EXPECT_EQ("\xFE\xFF\xFF\xFF\xF", buffer.toString());
+  }
+
+  // zigzag(0x80000000) = 0xFFFFFFFF
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI32(buffer, INT32_MIN);
+    EXPECT_EQ("\xFF\xFF\xFF\xFF\xF", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteZigZagI64) {
+  // zigzag(0) = 0
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI64(buffer, 0);
+    EXPECT_EQ(std::string("\0", 1), buffer.toString());
+  }
+
+  // zigzag(-1) = 1
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI64(buffer, -1);
+    EXPECT_EQ("\x1", buffer.toString());
+  }
+
+  // zigzag(1) = 2
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI64(buffer, 1);
+    EXPECT_EQ("\x2", buffer.toString());
+  }
+
+  // zigzag(127) = 0xFE
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI64(buffer, 127);
+    EXPECT_EQ("\xFE\x1", buffer.toString());
+  }
+
+  // zigzag(128) = 0x100
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI64(buffer, 128);
+    EXPECT_EQ("\x80\x2", buffer.toString());
+  }
+
+  // zigzag(-128) = 0xFF
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI64(buffer, -128);
+    EXPECT_EQ("\xFF\x1", buffer.toString());
+  }
+
+  // zigzag(0x7FFFFFFF) = 0xFFFFFFFE
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI64(buffer, INT32_MAX);
+    EXPECT_EQ("\xFE\xFF\xFF\xFF\xF", buffer.toString());
+  }
+
+  // zigzag(0x80000000) = 0xFFFFFFFF
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI64(buffer, INT32_MIN);
+    EXPECT_EQ("\xFF\xFF\xFF\xFF\xF", buffer.toString());
+  }
+
+  // zigzag(0x7FFFFFFF FFFFFFFF) = 0xFFFFFFFFFFFFFFFE
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI64(buffer, INT64_MAX);
+    EXPECT_EQ("\xFE\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x1", buffer.toString());
+  }
+
+  // zigzag(0x8000000000000000) = 0xFFFFFFFFFFFFFFFF
+  {
+    Buffer::OwnedImpl buffer;
+    BufferHelper::writeZigZagI64(buffer, INT64_MIN);
+    EXPECT_EQ("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x1", buffer.toString());
+  }
 }
 
 } // namespace ThriftProxy

--- a/test/extensions/filters/network/thrift_proxy/mocks.h
+++ b/test/extensions/filters/network/thrift_proxy/mocks.h
@@ -31,6 +31,7 @@ public:
   MOCK_CONST_METHOD0(name, const std::string&());
   MOCK_METHOD1(decodeFrameStart, bool(Buffer::Instance&));
   MOCK_METHOD1(decodeFrameEnd, bool(Buffer::Instance&));
+  MOCK_METHOD2(encodeFrame, void(Buffer::Instance&, Buffer::Instance&));
 
   std::string name_{"mock"};
 };
@@ -78,6 +79,30 @@ public:
   MOCK_METHOD2(readDouble, bool(Buffer::Instance& buffer, double& value));
   MOCK_METHOD2(readString, bool(Buffer::Instance& buffer, std::string& value));
   MOCK_METHOD2(readBinary, bool(Buffer::Instance& buffer, std::string& value));
+
+  MOCK_METHOD4(writeMessageBegin, void(Buffer::Instance& buffer, const std::string& name,
+                                       MessageType msg_type, int32_t seq_id));
+  MOCK_METHOD1(writeMessageEnd, void(Buffer::Instance& buffer));
+  MOCK_METHOD2(writeStructBegin, void(Buffer::Instance& buffer, const std::string& name));
+  MOCK_METHOD1(writeStructEnd, void(Buffer::Instance& buffer));
+  MOCK_METHOD4(writeFieldBegin, void(Buffer::Instance& buffer, const std::string& name,
+                                     FieldType field_type, int16_t field_id));
+  MOCK_METHOD1(writeFieldEnd, void(Buffer::Instance& buffer));
+  MOCK_METHOD4(writeMapBegin, void(Buffer::Instance& buffer, FieldType key_type,
+                                   FieldType value_type, uint32_t size));
+  MOCK_METHOD1(writeMapEnd, void(Buffer::Instance& buffer));
+  MOCK_METHOD3(writeListBegin, void(Buffer::Instance& buffer, FieldType elem_type, uint32_t size));
+  MOCK_METHOD1(writeListEnd, void(Buffer::Instance& buffer));
+  MOCK_METHOD3(writeSetBegin, void(Buffer::Instance& buffer, FieldType elem_type, uint32_t size));
+  MOCK_METHOD1(writeSetEnd, void(Buffer::Instance& buffer));
+  MOCK_METHOD2(writeBool, void(Buffer::Instance& buffer, bool value));
+  MOCK_METHOD2(writeByte, void(Buffer::Instance& buffer, uint8_t value));
+  MOCK_METHOD2(writeInt16, void(Buffer::Instance& buffer, int16_t value));
+  MOCK_METHOD2(writeInt32, void(Buffer::Instance& buffer, int32_t value));
+  MOCK_METHOD2(writeInt64, void(Buffer::Instance& buffer, int64_t value));
+  MOCK_METHOD2(writeDouble, void(Buffer::Instance& buffer, double value));
+  MOCK_METHOD2(writeString, void(Buffer::Instance& buffer, const std::string& value));
+  MOCK_METHOD2(writeBinary, void(Buffer::Instance& buffer, const std::string& value));
 
   std::string name_{"mock"};
 };

--- a/test/extensions/filters/network/thrift_proxy/protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/protocol_impl_test.cc
@@ -104,7 +104,7 @@ TEST(AutoProtocolTest, ReadMessageBegin) {
   }
 }
 
-TEST(AutoProtocolTest, Delegation) {
+TEST(AutoProtocolTest, ReadDelegation) {
   NiceMock<MockProtocol>* proto = new NiceMock<MockProtocol>();
   NiceMock<MockProtocolCallbacks> dummy_cb;
   AutoProtocolImpl auto_proto(dummy_cb);
@@ -228,6 +228,94 @@ TEST(AutoProtocolTest, Delegation) {
     EXPECT_CALL(*proto, readBinary(Ref(buffer), Ref(value))).WillOnce(Return(true));
     EXPECT_TRUE(auto_proto.readBinary(buffer, value));
   }
+}
+
+TEST(AutoProtocolTest, WriteDelegation) {
+  NiceMock<MockProtocol>* proto = new NiceMock<MockProtocol>();
+  NiceMock<MockProtocolCallbacks> dummy_cb;
+  AutoProtocolImpl auto_proto(dummy_cb);
+  auto_proto.setProtocol(ProtocolPtr{proto});
+
+  // writeMessageBegin
+  Buffer::OwnedImpl buffer;
+  EXPECT_CALL(*proto, writeMessageBegin(Ref(buffer), "name", MessageType::Call, 100));
+  auto_proto.writeMessageBegin(buffer, "name", MessageType::Call, 100);
+
+  // writeMessageEnd
+  EXPECT_CALL(*proto, writeMessageEnd(Ref(buffer)));
+  auto_proto.writeMessageEnd(buffer);
+
+  // writeStructBegin
+  EXPECT_CALL(*proto, writeStructBegin(Ref(buffer), "name"));
+  auto_proto.writeStructBegin(buffer, "name");
+
+  // writeStructEnd
+  EXPECT_CALL(*proto, writeStructEnd(Ref(buffer)));
+  auto_proto.writeStructEnd(buffer);
+
+  // writeFieldBegin
+  EXPECT_CALL(*proto, writeFieldBegin(Ref(buffer), "name", FieldType::Stop, 100));
+  auto_proto.writeFieldBegin(buffer, "name", FieldType::Stop, 100);
+
+  // writeFieldEnd
+  EXPECT_CALL(*proto, writeFieldEnd(Ref(buffer)));
+  auto_proto.writeFieldEnd(buffer);
+
+  // writeMapBegin
+  EXPECT_CALL(*proto, writeMapBegin(Ref(buffer), FieldType::I32, FieldType::String, 100));
+  auto_proto.writeMapBegin(buffer, FieldType::I32, FieldType::String, 100);
+
+  // writeMapEnd
+  EXPECT_CALL(*proto, writeMapEnd(Ref(buffer)));
+  auto_proto.writeMapEnd(buffer);
+
+  // writeListBegin
+  EXPECT_CALL(*proto, writeListBegin(Ref(buffer), FieldType::String, 100));
+  auto_proto.writeListBegin(buffer, FieldType::String, 100);
+
+  // writeListEnd
+  EXPECT_CALL(*proto, writeListEnd(Ref(buffer)));
+  auto_proto.writeListEnd(buffer);
+
+  // writeSetBegin
+  EXPECT_CALL(*proto, writeSetBegin(Ref(buffer), FieldType::String, 100));
+  auto_proto.writeSetBegin(buffer, FieldType::String, 100);
+
+  // writeSetEnd
+  EXPECT_CALL(*proto, writeSetEnd(Ref(buffer)));
+  auto_proto.writeSetEnd(buffer);
+
+  // writeBool
+  EXPECT_CALL(*proto, writeBool(Ref(buffer), true));
+  auto_proto.writeBool(buffer, true);
+
+  // writeByte
+  EXPECT_CALL(*proto, writeByte(Ref(buffer), 100));
+  auto_proto.writeByte(buffer, 100);
+
+  // writeInt16
+  EXPECT_CALL(*proto, writeInt16(Ref(buffer), 100));
+  auto_proto.writeInt16(buffer, 100);
+
+  // writeInt32
+  EXPECT_CALL(*proto, writeInt32(Ref(buffer), 100));
+  auto_proto.writeInt32(buffer, 100);
+
+  // writeInt64
+  EXPECT_CALL(*proto, writeInt64(Ref(buffer), 100));
+  auto_proto.writeInt64(buffer, 100);
+
+  // writeDouble
+  EXPECT_CALL(*proto, writeDouble(Ref(buffer), 10.0));
+  auto_proto.writeDouble(buffer, 10.0);
+
+  // writeString
+  EXPECT_CALL(*proto, writeString(Ref(buffer), "string"));
+  auto_proto.writeString(buffer, "string");
+
+  // writeBinary
+  EXPECT_CALL(*proto, writeBinary(Ref(buffer), "binary"));
+  auto_proto.writeBinary(buffer, "binary");
 }
 
 TEST(AutoProtocolTest, Name) {

--- a/test/extensions/filters/network/thrift_proxy/transport_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/transport_impl_test.cc
@@ -13,6 +13,8 @@
 #include "gtest/gtest.h"
 
 using testing::NiceMock;
+using testing::Ref;
+using testing::StrictMock;
 
 namespace Envoy {
 namespace Extensions {
@@ -21,7 +23,7 @@ namespace ThriftProxy {
 
 TEST(AutoTransportTest, NotEnoughData) {
   Buffer::OwnedImpl buffer;
-  NiceMock<MockTransportCallbacks> cb;
+  StrictMock<MockTransportCallbacks> cb;
   AutoTransportImpl transport(cb);
 
   EXPECT_FALSE(transport.decodeFrameStart(buffer));
@@ -32,7 +34,7 @@ TEST(AutoTransportTest, NotEnoughData) {
 }
 
 TEST(AutoTransportTest, UnknownTransport) {
-  NiceMock<MockTransportCallbacks> cb;
+  StrictMock<MockTransportCallbacks> cb;
   AutoTransportImpl transport(cb);
 
   // Looks like unframed, but fails protocol check.
@@ -57,7 +59,7 @@ TEST(AutoTransportTest, UnknownTransport) {
 }
 
 TEST(AutoTransportTest, DecodeFrameStart) {
-  NiceMock<MockTransportCallbacks> cb;
+  StrictMock<MockTransportCallbacks> cb;
 
   // Framed transport + binary protocol
   {
@@ -115,7 +117,7 @@ TEST(AutoTransportTest, DecodeFrameStart) {
 }
 
 TEST(AutoTransportTest, DecodeFrameEnd) {
-  NiceMock<MockTransportCallbacks> cb;
+  StrictMock<MockTransportCallbacks> cb;
 
   AutoTransportImpl transport(cb);
   Buffer::OwnedImpl buffer;
@@ -131,8 +133,22 @@ TEST(AutoTransportTest, DecodeFrameEnd) {
   EXPECT_TRUE(transport.decodeFrameEnd(buffer));
 }
 
+TEST(AutoTransportTest, EncodeFrame) {
+  StrictMock<MockTransportCallbacks> cb;
+  MockTransport* mock_transport = new NiceMock<MockTransport>();
+
+  AutoTransportImpl transport(cb);
+  transport.setTransport(TransportPtr{mock_transport});
+
+  Buffer::OwnedImpl buffer;
+  Buffer::OwnedImpl message;
+
+  EXPECT_CALL(*mock_transport, encodeFrame(Ref(buffer), Ref(message)));
+  transport.encodeFrame(buffer, message);
+}
+
 TEST(AutoTransportTest, Name) {
-  NiceMock<MockTransportCallbacks> cb;
+  StrictMock<MockTransportCallbacks> cb;
   AutoTransportImpl transport(cb);
   EXPECT_EQ(transport.name(), "auto");
 }

--- a/test/extensions/filters/network/thrift_proxy/unframed_transport_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/unframed_transport_impl_test.cc
@@ -10,7 +10,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using testing::NiceMock;
+using testing::StrictMock;
 
 namespace Envoy {
 namespace Extensions {
@@ -18,13 +18,13 @@ namespace NetworkFilters {
 namespace ThriftProxy {
 
 TEST(UnframedTransportTest, Name) {
-  NiceMock<MockTransportCallbacks> cb;
+  StrictMock<MockTransportCallbacks> cb;
   UnframedTransportImpl transport(cb);
   EXPECT_EQ(transport.name(), "unframed");
 }
 
 TEST(UnframedTransportTest, DecodeFrameStart) {
-  MockTransportCallbacks cb;
+  StrictMock<MockTransportCallbacks> cb;
   EXPECT_CALL(cb, transportFrameStart(absl::optional<uint32_t>()));
 
   UnframedTransportImpl transport(cb);
@@ -38,13 +38,28 @@ TEST(UnframedTransportTest, DecodeFrameStart) {
 }
 
 TEST(UnframedTransportTest, DecodeFrameEnd) {
-  MockTransportCallbacks cb;
+  StrictMock<MockTransportCallbacks> cb;
   EXPECT_CALL(cb, transportFrameComplete());
 
   UnframedTransportImpl transport(cb);
 
   Buffer::OwnedImpl buffer;
   EXPECT_TRUE(transport.decodeFrameEnd(buffer));
+}
+
+TEST(UnframedTransportTest, EncodeFrame) {
+  StrictMock<MockTransportCallbacks> cb;
+
+  UnframedTransportImpl transport(cb);
+
+  Buffer::OwnedImpl message;
+  message.add("fake message");
+
+  Buffer::OwnedImpl buffer;
+  transport.encodeFrame(buffer, message);
+
+  EXPECT_EQ(0, message.length());
+  EXPECT_EQ("fake message", buffer.toString());
 }
 
 } // namespace ThriftProxy


### PR DESCRIPTION
Matches the read side implementations. Transport writes require having the
entire protocol message and so the write methods do not mirror reads. This
is further preparation for a Thrift router that can translate requests between
transports and protocols.

*Risk Level*: low, code not used
*Testing*: unit tests
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
