### PR TITLE
rbac: not permission/principal matcher

### DIFF
--- a/api/envoy/config/rbac/v2alpha/rbac.proto
+++ b/api/envoy/config/rbac/v2alpha/rbac.proto
@@ -115,6 +115,11 @@ message Permission {
 
     // Metadata that describes additional information about the action.
     envoy.type.matcher.MetadataMatcher metadata = 7;
+
+    // Negates matching the provided permission. For instance, if the value of `not_rule` would
+    // match, this permission would not match. Conversely, if the value of `not_rule` would not
+    // match, this permission would match.
+    Permission not_rule = 8;
   }
 }
 
@@ -157,5 +162,10 @@ message Principal {
 
     // Metadata that describes additional information about the principal.
     envoy.type.matcher.MetadataMatcher metadata = 7;
+
+    // Negates matching the provided principal. For instance, if the value of `not_id` would match,
+    // this principal would not match. Conversely, if the value of `not_id` would not match, this
+    // principal would match.
+    Principal not_id = 8;
   }
 }

--- a/source/extensions/filters/common/rbac/matchers.cc
+++ b/source/extensions/filters/common/rbac/matchers.cc
@@ -24,6 +24,8 @@ MatcherConstSharedPtr Matcher::create(const envoy::config::rbac::v2alpha::Permis
     return std::make_shared<const AlwaysMatcher>();
   case envoy::config::rbac::v2alpha::Permission::RuleCase::kMetadata:
     return std::make_shared<const MetadataMatcher>(permission.metadata());
+  case envoy::config::rbac::v2alpha::Permission::RuleCase::kNotRule:
+    return std::make_shared<const NotMatcher>(permission.not_rule());
   default:
     NOT_REACHED;
   }
@@ -45,6 +47,8 @@ MatcherConstSharedPtr Matcher::create(const envoy::config::rbac::v2alpha::Princi
     return std::make_shared<const AlwaysMatcher>();
   case envoy::config::rbac::v2alpha::Principal::IdentifierCase::kMetadata:
     return std::make_shared<const MetadataMatcher>(principal.metadata());
+  case envoy::config::rbac::v2alpha::Principal::IdentifierCase::kNotId:
+    return std::make_shared<const NotMatcher>(principal.not_id());
   default:
     NOT_REACHED;
   }
@@ -98,6 +102,12 @@ bool OrMatcher::matches(const Network::Connection& connection,
   }
 
   return false;
+}
+
+bool NotMatcher::matches(const Network::Connection& connection,
+                         const Envoy::Http::HeaderMap& headers,
+                         const envoy::api::v2::core::Metadata& metadata) const {
+  return !matcher_->matches(connection, headers, metadata);
 }
 
 bool HeaderMatcher::matches(const Network::Connection&, const Envoy::Http::HeaderMap& headers,

--- a/source/extensions/filters/common/rbac/matchers.h
+++ b/source/extensions/filters/common/rbac/matchers.h
@@ -96,6 +96,20 @@ private:
   std::vector<MatcherConstSharedPtr> matchers_;
 };
 
+class NotMatcher : public Matcher {
+public:
+  NotMatcher(const envoy::config::rbac::v2alpha::Permission& permission)
+      : matcher_(Matcher::create(permission)) {}
+  NotMatcher(const envoy::config::rbac::v2alpha::Principal& principal)
+      : matcher_(Matcher::create(principal)) {}
+
+  bool matches(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
+               const envoy::api::v2::core::Metadata&) const override;
+
+private:
+  MatcherConstSharedPtr matcher_;
+};
+
 /**
  * Perform a match against any HTTP header (or pseudo-header, such as `:path` or `:authority`). Will
  * always fail to match on any non-HTTP connection.

--- a/test/extensions/filters/common/rbac/matchers_test.cc
+++ b/test/extensions/filters/common/rbac/matchers_test.cc
@@ -116,6 +116,20 @@ TEST(OrMatcher, Principal_Set) {
   checkMatcher(RBAC::OrMatcher(set), true, conn);
 }
 
+TEST(NotMatcher, Permission) {
+  envoy::config::rbac::v2alpha::Permission perm;
+  perm.set_any(true);
+
+  checkMatcher(RBAC::NotMatcher(perm), false, Envoy::Network::MockConnection());
+}
+
+TEST(NotMatcher, Principal) {
+  envoy::config::rbac::v2alpha::Principal principal;
+  principal.set_any(true);
+
+  checkMatcher(RBAC::NotMatcher(principal), false, Envoy::Network::MockConnection());
+}
+
 TEST(HeaderMatcher, HeaderMatcher) {
   envoy::api::v2::route::HeaderMatcher config;
   config.set_name("foo");


### PR DESCRIPTION
This patch adds `not` support to the RBAC Authz filter matchers for both permissions and principals. This allows for constructing matchers where the default case should match, but exceptional cases should not (eg, match all paths for a gRPC service, except for one specific method) as well as other more complex rule constructions.

*Risk Level*: low
*Testing*: unit
*Docs Changes*: inline to config changes
*Release Notes*: N/A

Signed-off-by: Chris Roche <croche@lyft.com>