### PR TITLE
[DONTREVIEW] Add test for unused subset removal

### DIFF
--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -569,13 +569,21 @@ TEST_P(SubsetLoadBalancerTest, UpdateMetadata) {
   EXPECT_EQ(0U, stats_.lb_subsets_removed_.value());
 
   // Update the metadata for each host. Subsets should be removed.
+  HostSharedPtr host_v12 = host_set_.hosts_[0];
+  HostSharedPtr host_v10 = host_set_.hosts_[1];
+
   modifyHosts({makeHost("tcp://127.0.0.1:8000", {{"version", "1.3"}}),
                makeHost("tcp://127.0.0.1:8001", {{"version", "1.2"}})},
-              {makeHost("tcp://127.0.0.1:8000", {{"version", "1.2"}}),
-               makeHost("tcp://127.0.0.1:8001", {{"version", "1.0"}})});
-  EXPECT_EQ(2U, stats_.lb_subsets_active_.value());
-  EXPECT_EQ(3U, stats_.lb_subsets_created_.value());
-  EXPECT_EQ(1U, stats_.lb_subsets_removed_.value());
+              {host_v12, host_v10});
+  if (GetParam() != REMOVES_FIRST) {
+    EXPECT_EQ(2U, stats_.lb_subsets_active_.value());
+    EXPECT_EQ(3U, stats_.lb_subsets_created_.value());
+    EXPECT_EQ(1U, stats_.lb_subsets_removed_.value());
+  } else {
+    EXPECT_EQ(2U, stats_.lb_subsets_active_.value());
+    EXPECT_EQ(4U, stats_.lb_subsets_created_.value());
+    EXPECT_EQ(2U, stats_.lb_subsets_removed_.value());
+  }
 }
 
 TEST_P(SubsetLoadBalancerTest, UpdateRemovingLastSubsetHost) {

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -554,6 +554,32 @@ TEST_P(SubsetLoadBalancerTest, UpdateFailover) {
   EXPECT_FALSE(nullptr == lb_->chooseHost(&context_10).get());
 }
 
+TEST_P(SubsetLoadBalancerTest, UpdateMetadata) {
+  EXPECT_CALL(subset_info_, fallbackPolicy())
+      .WillRepeatedly(Return(envoy::api::v2::Cluster::LbSubsetConfig::ANY_ENDPOINT));
+
+  std::vector<std::set<std::string>> subset_keys = {{"version"}};
+  EXPECT_CALL(subset_info_, subsetKeys()).WillRepeatedly(ReturnRef(subset_keys));
+
+  // Add hosts initial hosts.
+  init({
+      {"tcp://127.0.0.1:8000", {{"version", "1.2"}}},
+      {"tcp://127.0.0.1:8001", {{"version", "1.0"}}}
+  });
+  EXPECT_EQ(2U, stats_.lb_subsets_active_.value());
+  EXPECT_EQ(2U, stats_.lb_subsets_created_.value());
+  EXPECT_EQ(0U, stats_.lb_subsets_removed_.value());
+
+  // Update the metadata for each host. Subsets should be removed.
+  modifyHosts({makeHost("tcp://127.0.0.1:8000", {{"version", "1.3"}}),
+               makeHost("tcp://127.0.0.1:8001", {{"version", "1.2"}})},
+              {makeHost("tcp://127.0.0.1:8000", {{"version", "1.2"}}),
+               makeHost("tcp://127.0.0.1:8001", {{"version", "1.0"}})});
+  EXPECT_EQ(2U, stats_.lb_subsets_active_.value());
+  EXPECT_EQ(3U, stats_.lb_subsets_created_.value());
+  EXPECT_EQ(1U, stats_.lb_subsets_removed_.value());
+}
+
 TEST_P(SubsetLoadBalancerTest, UpdateRemovingLastSubsetHost) {
   EXPECT_CALL(subset_info_, fallbackPolicy())
       .WillRepeatedly(Return(envoy::api::v2::Cluster::LbSubsetConfig::ANY_ENDPOINT));

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -562,10 +562,8 @@ TEST_P(SubsetLoadBalancerTest, UpdateMetadata) {
   EXPECT_CALL(subset_info_, subsetKeys()).WillRepeatedly(ReturnRef(subset_keys));
 
   // Add hosts initial hosts.
-  init({
-      {"tcp://127.0.0.1:8000", {{"version", "1.2"}}},
-      {"tcp://127.0.0.1:8001", {{"version", "1.0"}}}
-  });
+  init({{"tcp://127.0.0.1:8000", {{"version", "1.2"}}},
+        {"tcp://127.0.0.1:8001", {{"version", "1.0"}}}});
   EXPECT_EQ(2U, stats_.lb_subsets_active_.value());
   EXPECT_EQ(2U, stats_.lb_subsets_created_.value());
   EXPECT_EQ(0U, stats_.lb_subsets_removed_.value());


### PR DESCRIPTION
We are tracking down why our active subsets keep growing without
the unused ones being removed, e.g.:

```
$ curl -s localhost:9901/stats | grep subset | grep app
cluster.app.lb_subsets_active: 396
cluster.app.lb_subsets_created: 396
cluster.app.lb_subsets_fallback: 1171992
cluster.app.lb_subsets_removed: 0
cluster.app.lb_subsets_selected: 46201647
```

We have the following subset LB config:

```
    "lb_subset_config": {
      "fallback_policy": "DEFAULT_SUBSET",
      "default_subset": {
        "default": "true"
      },
      "subset_selectors": [
        {
          "keys": [
            "default"
          ]
        },
        {
          "keys": [
            "version"
          ]
        },
        {
          "keys": [
            "canary"
          ]
        }
      ]
    }
```

And we never have more than have more than 6 possible subsets at a given
time:

```
default/true
version/v1
version/v2
version/v3
version/v4
canary/true
```

Of course, versions keep changing but there are never more than 4 at the same
time. It looks like the old ones are not being removed.

One important note is that endpoints remain constant (e.g.: (ip, port)), but
their metadata changes (e.g.: the version).

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>

