### PR TITLE
config: flipping v2-config-only to disable v1 support by default

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -8,6 +8,8 @@ A logged warning is expected for each deprecated item that is in deprecation win
 
 ## Version 1.8.0 (pending)
 
+* Use of the v1 API is deprecated. See envoy-announce
+  [email](https://groups.google.com/forum/#!topic/envoy-announce/oPnYMZw8H4U).
 * Use of the legacy 
   [ratelimit.proto](https://github.com/envoyproxy/envoy/blob/b0a518d064c8255e0e20557a8f909b6ff457558f/source/common/ratelimit/ratelimit.proto)
   is deprecated, in favor of the proto defined in

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -7,6 +7,7 @@ Version history
   to filter based on the presence of Envoy response flags.
 * admin: added :http:get:`/hystrix_event_stream` as an endpoint for monitoring envoy's statistics
   through `Hystrix dashboard <https://github.com/Netflix-Skunkworks/hystrix-dashboard/wiki>`_.
+* config: v1 disabled by default. v1 support remains available until October via flipping --v2-config-only=false.
 * health check: added support for :ref:`custom health check <envoy_api_field_core.HealthCheck.custom_health_check>`.
 * health_check: added support for :ref:`health check event logging <arch_overview_health_check_logging>`.
 * http: response filters not applied to early error paths such as http_parser generated 400s.

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -57,7 +57,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   TCLAP::ValueArg<std::string> config_yaml(
       "", "config-yaml", "Inline YAML configuration, merges with the contents of --config-path",
       false, "", "string", cmd);
-  TCLAP::SwitchArg v2_config_only("", "v2-config-only", "parse config as v2 only", cmd, false);
+  TCLAP::SwitchArg v2_config_only("", "v2-config-only", "parse config as v2 only", cmd, true);
   TCLAP::ValueArg<std::string> admin_address_path("", "admin-address-path", "Admin address path",
                                                   false, "", "string", cmd);
   TCLAP::ValueArg<std::string> local_address_ip_version("", "local-address-ip-version",

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -69,7 +69,7 @@ TEST(OptionsImplTest, All) {
   EXPECT_EQ(Server::Mode::Validate, options->mode());
   EXPECT_EQ(2U, options->concurrency());
   EXPECT_EQ("hello", options->configPath());
-  EXPECT_TRUE(options->v2ConfigOnly());
+  EXPECT_FALSE(options->v2ConfigOnly());
   EXPECT_EQ("path", options->adminAddressPath());
   EXPECT_EQ(Network::Address::IpVersion::v6, options->localAddressIpVersion());
   EXPECT_EQ(1U, options->restartEpoch());


### PR DESCRIPTION
Turning v1 support down by default.  The V1 API will still function until October, and can be used by flipping --v2-config-only=false on the command line.

For help migrating to the v2 API, please see the envoy-announce email:
https://groups.google.com/forum/#!topic/envoy-announce/oPnYMZw8H4U

*Risk Level*: risk of binary problems: low.  risk of user dismay: not low
*Testing*: existing unit tests
*Docs Changes*: pending v1 removal
*Release Notes*: yes.
*Deprecated*: v1 API
