### PR TITLE
format: run clang-format on protos again

### DIFF
--- a/api/envoy/admin/v2alpha/clusters.proto
+++ b/api/envoy/admin/v2alpha/clusters.proto
@@ -29,6 +29,7 @@ message ClusterStatus {
   // :ref:`Cluster outlier detection <arch_overview_outlier_detection>` statistics
   //
   // Note: this field may be omitted in any of the three following cases:
+  //
   // 1. There were not enough hosts with enough request volume to proceed with success rate based
   //    outlier ejection.
   // 2. The threshold is computed to be < 0 because a negative value implies that there was no

--- a/api/envoy/admin/v2alpha/clusters.proto
+++ b/api/envoy/admin/v2alpha/clusters.proto
@@ -25,13 +25,14 @@ message ClusterStatus {
   bool added_via_api = 2;
 
   // The success rate threshold used in the last interval. The threshold is used to eject hosts
-  // based on their success rate. See 
+  // based on their success rate. See
   // :ref:`Cluster outlier detection <arch_overview_outlier_detection>` statistics
   //
   // Note: this field may be omitted in any of the three following cases:
-  // 1. There were not enough hosts with enough request volume to proceed with success rate based outlier ejection.
-  // 2. The threshold is computed to be < 0 because a negative value implies that there was no threshold for that
-  // interval.
+  // 1. There were not enough hosts with enough request volume to proceed with success rate based
+  //    outlier ejection.
+  // 2. The threshold is computed to be < 0 because a negative value implies that there was no
+  //    threshold for that interval.
   // 3. Outlier detection is not enabled for this cluster.
   envoy.type.Percent success_rate_ejection_threshold = 3;
 
@@ -66,7 +67,8 @@ message HostHealthStatus {
   // The host is currently considered an outlier and has been ejected.
   bool failed_outlier_check = 2;
 
-  // Health status as reported by EDS. Note: only HEALTHY and UNHEALTHY are currently supported here.
+  // Health status as reported by EDS. Note: only HEALTHY and UNHEALTHY are currently supported
+  // here.
   // TODO(mrice32): pipe through remaining EDS health status possibilities.
   envoy.api.v2.core.HealthStatus eds_health_status = 3;
 }

--- a/api/envoy/config/filter/http/ext_authz/v2alpha/ext_authz.proto
+++ b/api/envoy/config/filter/http/ext_authz/v2alpha/ext_authz.proto
@@ -12,11 +12,12 @@ import "envoy/api/v2/core/http_uri.proto";
 
 // External Authorization filter calls out to an external service over either:
 //
-//  1. gRPC Authorization API defined by :ref:`CheckRequest <envoy_api_msg_service.auth.v2alpha.CheckRequest>`.
+//  1. gRPC Authorization API defined by :ref:`CheckRequest
+//     <envoy_api_msg_service.auth.v2alpha.CheckRequest>`.
 //  2. Raw HTTP Authorization server by passing the request headers to the service.
-// 
-// A failed check will cause this filter to close the HTTP request normally with 403 (Forbidden), unless
-// a different status code has been indicated in the authorization response.
+//
+// A failed check will cause this filter to close the HTTP request normally with 403 (Forbidden),
+// unless a different status code has been indicated in the authorization response.
 message ExtAuthz {
 
   oneof services {
@@ -36,27 +37,29 @@ message ExtAuthz {
   bool failure_mode_allow = 2;
 }
 
-// External Authorization filter calls out to an upstream authorization server by passing the raw HTTP
-// request headers to the server. This allows the authorization service to take a decision whether the
-// request is authorized or not.
+// External Authorization filter calls out to an upstream authorization server by passing the raw
+// HTTP request headers to the server. This allows the authorization service to take a decision
+// whether the request is authorized or not.
 //
-// A successful check allows the authorization service adding or overriding headers from the original 
-// request before dispatching it to the upstream. This is done by including the headers in the response 
-// sent back from the authorization service to the filter. Note that `Status`, `Method`, `Path` and 
-// `Content Length` response headers are automatically removed from this response by the filter. If other 
-// headers need be deleted, they should be specified in `response_headers_to_remove` field.
+// A successful check allows the authorization service adding or overriding headers from the
+// original request before dispatching it to the upstream. This is done by including the headers in
+// the response sent back from the authorization service to the filter. Note that `Status`,
+// `Method`, `Path` and `Content Length` response headers are automatically removed from this
+// response by the filter. If other headers need be deleted, they should be specified in
+// `response_headers_to_remove` field.
 //
-// A failed check will cause this filter to close the HTTP request normally with 403 (Forbidden), unless 
-// a different status code has been indicated by the authorization service via response headers. The HTTP
-// service also allows the authorization filter to also pass data from the response body to the downstream 
-// client in case of a denied request.
+// A failed check will cause this filter to close the HTTP request normally with 403 (Forbidden),
+// unless a different status code has been indicated by the authorization service via response
+// headers. The HTTP service also allows the authorization filter to also pass data from the
+// response body to the downstream client in case of a denied request.
 message HttpService {
   // Sets the HTTP server URI which the authorization requests must be sent to.
   envoy.api.v2.core.HttpUri server_uri = 1;
 
   // Sets an optional prefix to the value of authorization request header `path`.
-  string path_prefix = 2; 
+  string path_prefix = 2;
 
-  // Sets a list of headers that should be not be sent *from the authorization server* to the upstream.
+  // Sets a list of headers that should be not be sent *from the authorization server* to the
+  // upstream.
   repeated string response_headers_to_remove = 3;
 }

--- a/api/envoy/config/ratelimit/v2/rls.proto
+++ b/api/envoy/config/ratelimit/v2/rls.proto
@@ -29,9 +29,9 @@ message RateLimitServiceConfig {
   }
 
   // Specifies if Envoy should use the data-plane-api client
-  // :repo:`api/envoy/service/ratelimit/v2/rls.proto` or the legacy 
+  // :repo:`api/envoy/service/ratelimit/v2/rls.proto` or the legacy
   // client :repo:`source/common/ratelimit/ratelimit.proto` when
-  // making requests to the rate limit service. 
+  // making requests to the rate limit service.
   //
   // .. note::
   //

--- a/api/envoy/service/auth/v2alpha/external_auth.proto
+++ b/api/envoy/service/auth/v2alpha/external_auth.proto
@@ -38,7 +38,7 @@ message DeniedHttpResponse {
   // This field allows the authorization service to send HTTP response headers
   // to the the downstream client.
   repeated envoy.api.v2.core.HeaderValueOption headers = 2;
-  
+
   // This field allows the authorization service to send a response body data
   // to the the downstream client.
   string body = 3;
@@ -46,10 +46,10 @@ message DeniedHttpResponse {
 
 // HTTP attributes for an ok response.
 message OkHttpResponse {
-  // HTTP entity headers in addition to the original request headers. This allows the authorization 
+  // HTTP entity headers in addition to the original request headers. This allows the authorization
   // service to append, to add or to override headers from the original request before
   // dispatching it to the upstream. By setting `append` field to `true` in the `HeaderValueOption`,
-  // the filter will append the correspondent header value to the matched request header. Note that 
+  // the filter will append the correspondent header value to the matched request header. Note that
   // by Leaving `append` as false, the filter will either add a new header, or override an existing
   // one if there is a match.
   repeated envoy.api.v2.core.HeaderValueOption headers = 2;
@@ -66,7 +66,7 @@ message CheckResponse {
   oneof http_response {
     // Supplies http attributes for a denied response.
     DeniedHttpResponse denied_response = 2;
-    
+
     // Supplies http attributes for an ok response.
     OkHttpResponse ok_response = 3;
   }

--- a/api/envoy/type/http_status.proto
+++ b/api/envoy/type/http_status.proto
@@ -4,80 +4,78 @@ package envoy.type;
 
 import "validate/validate.proto";
 
-// HTTP response codes supported in Envoy. 
+// HTTP response codes supported in Envoy.
 // For more details: http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
 enum StatusCode {
-  // Empty - This code not part of the HTTP status code specification, but it is needed for proto `enum` type.
-  Empty                         = 0;
-  
-  Continue                      = 100;
+  // Empty - This code not part of the HTTP status code specification, but it is needed for proto
+  // `enum` type.
+  Empty = 0;
 
-  OK                            = 200;
-  Created                       = 201;
-  Accepted                      = 202;
-  NonAuthoritativeInformation   = 203;
-  NoContent                     = 204;
-  ResetContent                  = 205;
-  PartialContent                = 206;
-  MultiStatus                   = 207;
-  AlreadyReported               = 208;
-  IMUsed                        = 226;
+  Continue = 100;
 
-  MultipleChoices               = 300;
-  MovedPermanently              = 301;
-  Found                         = 302;
-  SeeOther                      = 303;
-  NotModified                   = 304;
-  UseProxy                      = 305;
-  TemporaryRedirect             = 307;
-  PermanentRedirect             = 308;
+  OK = 200;
+  Created = 201;
+  Accepted = 202;
+  NonAuthoritativeInformation = 203;
+  NoContent = 204;
+  ResetContent = 205;
+  PartialContent = 206;
+  MultiStatus = 207;
+  AlreadyReported = 208;
+  IMUsed = 226;
 
-  BadRequest                    = 400;
-  Unauthorized                  = 401;
-  PaymentRequired               = 402;
-  Forbidden                     = 403;
-  NotFound                      = 404;
-  MethodNotAllowed              = 405;
-  NotAcceptable                 = 406;
-  ProxyAuthenticationRequired   = 407;
-  RequestTimeout                = 408;
-  Conflict                      = 409;
-  Gone                          = 410;
-  LengthRequired                = 411;
-  PreconditionFailed            = 412;
-  PayloadTooLarge               = 413;
-  URITooLong                    = 414;
-  UnsupportedMediaType          = 415;
-  RangeNotSatisfiable           = 416;
-  ExpectationFailed             = 417;
-  MisdirectedRequest            = 421;
-  UnprocessableEntity           = 422;
-  Locked                        = 423;
-  FailedDependency              = 424;
-  UpgradeRequired               = 426;
-  PreconditionRequired          = 428;
-  TooManyRequests               = 429;
-  RequestHeaderFieldsTooLarge   = 431;
+  MultipleChoices = 300;
+  MovedPermanently = 301;
+  Found = 302;
+  SeeOther = 303;
+  NotModified = 304;
+  UseProxy = 305;
+  TemporaryRedirect = 307;
+  PermanentRedirect = 308;
 
-  InternalServerError           = 500;
-  NotImplemented                = 501;
-  BadGateway                    = 502;
-  ServiceUnavailable            = 503;
-  GatewayTimeout                = 504;
-  HTTPVersionNotSupported       = 505;
-  VariantAlsoNegotiates         = 506;
-  InsufficientStorage           = 507;
-  LoopDetected                  = 508;
-  NotExtended                   = 510;
+  BadRequest = 400;
+  Unauthorized = 401;
+  PaymentRequired = 402;
+  Forbidden = 403;
+  NotFound = 404;
+  MethodNotAllowed = 405;
+  NotAcceptable = 406;
+  ProxyAuthenticationRequired = 407;
+  RequestTimeout = 408;
+  Conflict = 409;
+  Gone = 410;
+  LengthRequired = 411;
+  PreconditionFailed = 412;
+  PayloadTooLarge = 413;
+  URITooLong = 414;
+  UnsupportedMediaType = 415;
+  RangeNotSatisfiable = 416;
+  ExpectationFailed = 417;
+  MisdirectedRequest = 421;
+  UnprocessableEntity = 422;
+  Locked = 423;
+  FailedDependency = 424;
+  UpgradeRequired = 426;
+  PreconditionRequired = 428;
+  TooManyRequests = 429;
+  RequestHeaderFieldsTooLarge = 431;
+
+  InternalServerError = 500;
+  NotImplemented = 501;
+  BadGateway = 502;
+  ServiceUnavailable = 503;
+  GatewayTimeout = 504;
+  HTTPVersionNotSupported = 505;
+  VariantAlsoNegotiates = 506;
+  InsufficientStorage = 507;
+  LoopDetected = 508;
+  NotExtended = 510;
   NetworkAuthenticationRequired = 511;
-  
 }
 
 // HTTP status.
 message HttpStatus {
   // Supplies HTTP response code.
-  StatusCode code = 1 [
-    (validate.rules).enum = {not_in: [0]},
-    (validate.rules).enum.defined_only = true
-  ];
+  StatusCode code = 1
+      [(validate.rules).enum = {not_in: [0]}, (validate.rules).enum.defined_only = true];
 }

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -184,18 +184,20 @@ def fixSourcePath(file_path):
     sys.stdout.write(fixSourceLine(line))
 
   error_messages = []
-  if not file_path.endswith(DOCS_SUFFIX) and not file_path.endswith(PROTO_SUFFIX):
-    error_messages += fixHeaderOrder(file_path)
+  if not file_path.endswith(DOCS_SUFFIX):
+    if not file_path.endswith(PROTO_SUFFIX):
+      error_messages += fixHeaderOrder(file_path)
     error_messages += clangFormat(file_path)
   return error_messages
 
 def checkSourcePath(file_path):
   error_messages = checkFileContents(file_path, checkSourceLine)
 
-  if not file_path.endswith(DOCS_SUFFIX) and not file_path.endswith(PROTO_SUFFIX):
-    error_messages += checkNamespace(file_path)
-    command = ("%s %s | diff %s -" % (HEADER_ORDER_PATH, file_path, file_path))
-    error_messages += executeCommand(command, "header_order.py check failed", file_path)
+  if not file_path.endswith(DOCS_SUFFIX):
+    if not file_path.endswith(PROTO_SUFFIX):
+      error_messages += checkNamespace(file_path)
+      command = ("%s %s | diff %s -" % (HEADER_ORDER_PATH, file_path, file_path))
+      error_messages += executeCommand(command, "header_order.py check failed", file_path)
     command = ("%s %s | diff %s -" % (CLANG_FORMAT_PATH, file_path, file_path))
     error_messages += executeCommand(command, "clang-format check failed", file_path)
 


### PR DESCRIPTION
I think this broke in a recent refactor.