### PR TITLE
network: fixing a bug in detecting closed connections

### DIFF
--- a/source/common/network/raw_buffer_socket.cc
+++ b/source/common/network/raw_buffer_socket.cc
@@ -18,7 +18,7 @@ IoResult RawBufferSocket::doRead(Buffer::Instance& buffer) {
   do {
     // 16K read is arbitrary. TODO(mattklein123) PERF: Tune the read size.
     int rc = buffer.read(callbacks_->fd(), 16384);
-    int error = errno; // Latch errno before any logging calls can overwrite it.
+    const int error = errno; // Latch errno before any logging calls can overwrite it.
     ENVOY_CONN_LOG(trace, "read returns: {}", callbacks_->connection(), rc);
 
     if (rc == 0) {
@@ -61,7 +61,7 @@ IoResult RawBufferSocket::doWrite(Buffer::Instance& buffer, bool end_stream) {
       break;
     }
     int rc = buffer.write(callbacks_->fd());
-    int error = errno; // Latch errno before any logging calls can overwrite it.
+    const int error = errno; // Latch errno before any logging calls can overwrite it.
     ENVOY_CONN_LOG(trace, "write returns: {}", callbacks_->connection(), rc);
     if (rc == -1) {
       ENVOY_CONN_LOG(trace, "write error: {} ({})", callbacks_->connection(), error,

--- a/source/common/network/raw_buffer_socket.cc
+++ b/source/common/network/raw_buffer_socket.cc
@@ -18,6 +18,7 @@ IoResult RawBufferSocket::doRead(Buffer::Instance& buffer) {
   do {
     // 16K read is arbitrary. TODO(mattklein123) PERF: Tune the read size.
     int rc = buffer.read(callbacks_->fd(), 16384);
+    int error = errno; // Latch errno before any logging calls can overwrite it.
     ENVOY_CONN_LOG(trace, "read returns: {}", callbacks_->connection(), rc);
 
     if (rc == 0) {
@@ -26,8 +27,8 @@ IoResult RawBufferSocket::doRead(Buffer::Instance& buffer) {
       break;
     } else if (rc == -1) {
       // Remote error (might be no data).
-      ENVOY_CONN_LOG(trace, "read error: {}", callbacks_->connection(), errno);
-      if (errno != EAGAIN) {
+      ENVOY_CONN_LOG(trace, "read error: {}", callbacks_->connection(), error);
+      if (error != EAGAIN) {
         action = PostIoAction::Close;
       }
 
@@ -60,11 +61,12 @@ IoResult RawBufferSocket::doWrite(Buffer::Instance& buffer, bool end_stream) {
       break;
     }
     int rc = buffer.write(callbacks_->fd());
+    int error = errno; // Latch errno before any logging calls can overwrite it.
     ENVOY_CONN_LOG(trace, "write returns: {}", callbacks_->connection(), rc);
     if (rc == -1) {
-      ENVOY_CONN_LOG(trace, "write error: {} ({})", callbacks_->connection(), errno,
-                     strerror(errno));
-      if (errno == EAGAIN) {
+      ENVOY_CONN_LOG(trace, "write error: {} ({})", callbacks_->connection(), error,
+                     strerror(error));
+      if (error == EAGAIN) {
         action = PostIoAction::KeepOpen;
       } else {
         action = PostIoAction::Close;

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -144,7 +144,7 @@ void Filter::onRead() {
   // platforms.
   auto& os_syscalls = Api::OsSysCallsSingleton::get();
   ssize_t n = os_syscalls.recv(cb_->socket().fd(), buf_, config_->maxClientHelloSize(), MSG_PEEK);
-  int error = errno; // Latch errno right after the recv call.
+  const int error = errno; // Latch errno right after the recv call.
   ENVOY_LOG(trace, "tls inspector: recv: {}", n);
 
   if (n == -1 && error == EAGAIN) {

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -144,9 +144,10 @@ void Filter::onRead() {
   // platforms.
   auto& os_syscalls = Api::OsSysCallsSingleton::get();
   ssize_t n = os_syscalls.recv(cb_->socket().fd(), buf_, config_->maxClientHelloSize(), MSG_PEEK);
+  int error = errno; // Latch errno right after the recv call.
   ENVOY_LOG(trace, "tls inspector: recv: {}", n);
 
-  if (n == -1 && errno == EAGAIN) {
+  if (n == -1 && error == EAGAIN) {
     return;
   } else if (n < 0) {
     config_->stats().read_error_.inc();


### PR DESCRIPTION
As documented in #3785, we had a disconnect test flaking out because the ECONNRESET was being overwritten by EAGAIN in the logging code, so the ECONNRESET was not properly handled and the test hung.  This represents an actual Envoy bug where an inopportune log flush can mask a connection close.    Presumably the same issue exists on the write path.

*Risk Level*: Low
*Testing*: IpVersions/Http2IntegrationTest.RouterDownstreamDisconnectBeforeRequestComplete/IPv6 less flaky
*Docs Changes*: n/a
*Release Notes*: n/a
Fixes #3785
