### PR TITLE
Support mutable metadata for endpoints

### DIFF
--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -60,7 +60,7 @@ public:
   /**
    * @return the metadata associated with this host
    */
-  virtual const envoy::api::v2::core::Metadata& metadata() const PURE;
+  virtual const std::shared_ptr<envoy::api::v2::core::Metadata> metadata() const PURE;
 
   /**
    * Set the current metadata.

--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -53,9 +53,19 @@ public:
   virtual bool canary() const PURE;
 
   /**
+   * Update the canary status of the host.
+   */
+  virtual void canary(bool is_canary) PURE;
+
+  /**
    * @return the metadata associated with this host
    */
   virtual const envoy::api::v2::core::Metadata& metadata() const PURE;
+
+  /**
+   * Set the current metadata.
+   */
+  virtual void metadata(const envoy::api::v2::core::Metadata& new_metadata) PURE;
 
   /**
    * @return the cluster the host is a member of.

--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -67,7 +67,7 @@ parseUpstreamMetadataField(absl::string_view params_str) {
     }
 
     const ProtobufWkt::Value* value =
-        &Config::Metadata::metadataValue(host->metadata(), params[0], params[1]);
+        &Config::Metadata::metadataValue(*host->metadata(), params[0], params[1]);
     if (value->kind_case() == ProtobufWkt::Value::KIND_NOT_SET) {
       // No kind indicates default ProtobufWkt::Value which means namespace or key not
       // found.

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -58,14 +58,15 @@ private:
   struct RealHostDescription : public HostDescription {
     RealHostDescription(Network::Address::InstanceConstSharedPtr address,
                         HostConstSharedPtr logical_host)
-        : address_(address), logical_host_(logical_host) {}
+        : address_(address), logical_host_(logical_host),
+          metadata_(std::make_shared<envoy::api::v2::core::Metadata>(
+              envoy::api::v2::core::Metadata::default_instance())) {}
 
     // Upstream:HostDescription
     bool canary() const override { return false; }
     void canary(bool) override {}
     const std::shared_ptr<envoy::api::v2::core::Metadata> metadata() const override {
-      return std::make_shared<envoy::api::v2::core::Metadata>(
-          envoy::api::v2::core::Metadata::default_instance());
+      return metadata_;
     }
     void metadata(const envoy::api::v2::core::Metadata&) override {}
 
@@ -88,6 +89,7 @@ private:
     }
     Network::Address::InstanceConstSharedPtr address_;
     HostConstSharedPtr logical_host_;
+    const std::shared_ptr<envoy::api::v2::core::Metadata> metadata_;
   };
 
   struct PerThreadCurrentHostData : public ThreadLocal::ThreadLocalObject {

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -63,8 +63,9 @@ private:
     // Upstream:HostDescription
     bool canary() const override { return false; }
     void canary(bool) override {}
-    const envoy::api::v2::core::Metadata& metadata() const override {
-      return envoy::api::v2::core::Metadata::default_instance();
+    const std::shared_ptr<envoy::api::v2::core::Metadata> metadata() const override {
+      return std::make_shared<envoy::api::v2::core::Metadata>(
+          envoy::api::v2::core::Metadata::default_instance());
     }
     void metadata(const envoy::api::v2::core::Metadata&) override {}
 

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -62,9 +62,12 @@ private:
 
     // Upstream:HostDescription
     bool canary() const override { return false; }
+    void canary(bool) override {}
     const envoy::api::v2::core::Metadata& metadata() const override {
       return envoy::api::v2::core::Metadata::default_instance();
     }
+    void metadata(const envoy::api::v2::core::Metadata&) override {}
+
     const ClusterInfo& cluster() const override { return logical_host_->cluster(); }
     HealthCheckHostMonitor& healthChecker() const override {
       return logical_host_->healthChecker();

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -248,7 +248,7 @@ void SubsetLoadBalancer::update(uint32_t priority, const HostVector& hosts_added
 }
 
 bool SubsetLoadBalancer::hostMatches(const SubsetMetadata& kvs, const Host& host) {
-  const envoy::api::v2::core::Metadata& host_metadata = host.metadata();
+  const envoy::api::v2::core::Metadata& host_metadata = *host.metadata();
 
   for (const auto& kv : kvs) {
     const ProtobufWkt::Value& host_value = Config::Metadata::metadataValue(
@@ -269,7 +269,7 @@ SubsetLoadBalancer::extractSubsetMetadata(const std::set<std::string>& subset_ke
                                           const Host& host) {
   SubsetMetadata kvs;
 
-  const envoy::api::v2::core::Metadata& metadata = host.metadata();
+  const envoy::api::v2::core::Metadata& metadata = *host.metadata();
   const auto& filter_it = metadata.filter_metadata().find(Config::MetadataFilters::get().ENVOY_LB);
   if (filter_it == metadata.filter_metadata().end()) {
     return kvs;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -685,7 +685,7 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(const HostVector& new_hosts,
                                                    HostVector& hosts_removed) {
   uint64_t max_host_weight = 1;
 
-  // Did hosts changed?
+  // Did hosts change?
   //
   // Has the EDS health status changed the health of any endpoint? If so, we
   // rebuild the hosts vectors. We only do this if the health status of an

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -109,11 +109,6 @@ parseClusterSocketOptions(const envoy::api::v2::Cluster& config,
   return cluster_options;
 }
 
-bool metadataEq(const envoy::api::v2::core::Metadata& lhs,
-                const envoy::api::v2::core::Metadata& rhs) {
-  return Protobuf::util::MessageDifferencer::Equivalent(lhs, rhs);
-}
-
 } // namespace
 
 Host::CreateConnectionData
@@ -689,16 +684,22 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(const HostVector& new_hosts,
                                                    HostVector& hosts_added,
                                                    HostVector& hosts_removed) {
   uint64_t max_host_weight = 1;
+
+  // Did hosts changed?
+  //
   // Has the EDS health status changed the health of any endpoint? If so, we
   // rebuild the hosts vectors. We only do this if the health status of an
   // endpoint has materially changed (e.g. if previously failing active health
   // checks, we just note it's now failing EDS health status but don't rebuild).
+  //
+  // Likewise, if metadata for an endpoint changed we rebuild the hosts vectors.
+  //
   // TODO(htuch): We can be smarter about this potentially, and not force a full
   // host set update on health status change. The way this would work is to
   // implement a HealthChecker subclass that provides thread local health
   // updates to the Cluster object. This will probably make sense to do in
   // conjunction with https://github.com/envoyproxy/envoy/issues/2874.
-  bool health_changed = false;
+  bool hosts_changed = false;
 
   // Go through and see if the list we have is different from what we just got. If it is, we make a
   // new host list and raise a change notification. This uses an N^2 search given that this does not
@@ -730,22 +731,24 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(const HostVector& new_hosts,
             (*i)->healthFlagSet(Host::HealthFlag::FAILED_EDS_HEALTH);
             // If the host was previously healthy and we're now unhealthy, we need to
             // rebuild.
-            health_changed |= previously_healthy;
+            hosts_changed |= previously_healthy;
           } else {
             (*i)->healthFlagClear(Host::HealthFlag::FAILED_EDS_HEALTH);
             // If the host was previously unhealthy and now healthy, we need to
             // rebuild.
-            health_changed |= !previously_healthy && (*i)->healthy();
+            hosts_changed |= !previously_healthy && (*i)->healthy();
           }
         }
 
         // Did metadata change?
-        if (!metadataEq(host->metadata(), (*i)->metadata())) {
+        const bool metadata_changed =
+            !Protobuf::util::MessageDifferencer::Equivalent(host->metadata(), (*i)->metadata());
+        if (metadata_changed) {
           (*i)->metadata(host->metadata());
           (*i)->canary(host->canary());
 
           // If metadata changed, we need to rebuild. See github issue #3810.
-          health_changed = true;
+          hosts_changed = true;
         }
 
         (*i)->weight(host->weight());
@@ -805,11 +808,11 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(const HostVector& new_hosts,
     // During the search we moved all of the hosts from hosts_ into final_hosts so just
     // move them back.
     current_hosts = std::move(final_hosts);
-    // We return false here in the absence of EDS health status, because we
+    // We return false here in the absence of EDS health status or metadata changes, because we
     // have no changes to host vector status (modulo weights). When we have EDS
-    // health status, we return true, causing updateHosts() to fire in the
+    // health status or metadata changed, we return true, causing updateHosts() to fire in the
     // caller.
-    return health_changed;
+    return hosts_changed;
   }
 }
 

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -129,7 +129,7 @@ protected:
   Network::Address::InstanceConstSharedPtr address_;
   Network::Address::InstanceConstSharedPtr health_check_address_;
   std::atomic<bool> canary_;
-  std::shared_timed_mutex metadata_mutex_;
+  mutable std::shared_timed_mutex metadata_mutex_;
   std::shared_ptr<envoy::api::v2::core::Metadata> metadata_;
   const envoy::api::v2::core::Locality locality_;
   Stats::IsolatedStoreImpl stats_store_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -77,13 +77,25 @@ public:
   // Upstream::HostDescription
   bool canary() const override { return canary_; }
   void canary(bool is_canary) override { canary_ = is_canary; }
+
+  // Metadata getter/setter.
+  //
+  // It's possible that the lock that guards the metadata will become highly contended (e.g.:
+  // endpoints churning during a deploy of a large cluster). A possible improvement
+  // would be to use TLS and post metadata updates from the main thread. This model would
+  // possibly benefit other related and expensive computations too (e.g.: updating subsets).
+  //
+  // TODO(rgs1): we should move to absl locks, once there's support for R/W locks. We should
+  // also add lock annotations, once they work correctly with R/W locks.
   const std::shared_ptr<envoy::api::v2::core::Metadata> metadata() const override {
+    std::shared_lock<std::shared_timed_mutex> lock(metadata_mutex_);
     return metadata_;
   }
   virtual void metadata(const envoy::api::v2::core::Metadata& new_metadata) override {
     std::unique_lock<std::shared_timed_mutex> lock(metadata_mutex_);
     metadata_ = std::make_shared<envoy::api::v2::core::Metadata>(new_metadata);
   }
+
   const ClusterInfo& cluster() const override { return *cluster_; }
   HealthCheckHostMonitor& healthChecker() const override {
     if (health_checker_) {

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -75,7 +75,15 @@ public:
 
   // Upstream::HostDescription
   bool canary() const override { return canary_; }
+
+  // Upstream::HostDescription
+  void canary(bool is_canary) override { canary_ = is_canary; }
+
   const envoy::api::v2::core::Metadata& metadata() const override { return metadata_; }
+  virtual void metadata(const envoy::api::v2::core::Metadata& new_metadata) override {
+    metadata_ = new_metadata;
+  }
+
   const ClusterInfo& cluster() const override { return *cluster_; }
   HealthCheckHostMonitor& healthChecker() const override {
     if (health_checker_) {
@@ -108,8 +116,8 @@ protected:
   const std::string hostname_;
   Network::Address::InstanceConstSharedPtr address_;
   Network::Address::InstanceConstSharedPtr health_check_address_;
-  const bool canary_;
-  const envoy::api::v2::core::Metadata metadata_;
+  bool canary_;
+  envoy::api::v2::core::Metadata metadata_;
   const envoy::api::v2::core::Locality locality_;
   Stats::IsolatedStoreImpl stats_store_;
   HostStats stats_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -76,10 +76,7 @@ public:
 
   // Upstream::HostDescription
   bool canary() const override { return canary_; }
-
-  // Upstream::HostDescription
   void canary(bool is_canary) override { canary_ = is_canary; }
-
   const std::shared_ptr<envoy::api::v2::core::Metadata> metadata() const override {
     return metadata_;
   }
@@ -87,7 +84,6 @@ public:
     std::unique_lock<std::shared_timed_mutex> lock(metadata_mutex_);
     metadata_ = std::make_shared<envoy::api::v2::core::Metadata>(new_metadata);
   }
-
   const ClusterInfo& cluster() const override { return *cluster_; }
   HealthCheckHostMonitor& healthChecker() const override {
     if (health_checker_) {

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -180,27 +180,27 @@ TEST_F(EdsTest, EndpointMetadata) {
 
   auto& hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
   EXPECT_EQ(hosts.size(), 2);
-  EXPECT_EQ(hosts[0]->metadata().filter_metadata_size(), 2);
-  EXPECT_EQ(Config::Metadata::metadataValue(hosts[0]->metadata(),
+  EXPECT_EQ(hosts[0]->metadata()->filter_metadata_size(), 2);
+  EXPECT_EQ(Config::Metadata::metadataValue(*hosts[0]->metadata(),
                                             Config::MetadataFilters::get().ENVOY_LB, "string_key")
                 .string_value(),
             std::string("string_value"));
-  EXPECT_EQ(Config::Metadata::metadataValue(hosts[0]->metadata(), "custom_namespace", "num_key")
+  EXPECT_EQ(Config::Metadata::metadataValue(*hosts[0]->metadata(), "custom_namespace", "num_key")
                 .number_value(),
             1.1);
-  EXPECT_FALSE(Config::Metadata::metadataValue(hosts[0]->metadata(),
+  EXPECT_FALSE(Config::Metadata::metadataValue(*hosts[0]->metadata(),
                                                Config::MetadataFilters::get().ENVOY_LB,
                                                Config::MetadataEnvoyLbKeys::get().CANARY)
                    .bool_value());
   EXPECT_FALSE(hosts[0]->canary());
 
-  EXPECT_EQ(hosts[1]->metadata().filter_metadata_size(), 1);
-  EXPECT_TRUE(Config::Metadata::metadataValue(hosts[1]->metadata(),
+  EXPECT_EQ(hosts[1]->metadata()->filter_metadata_size(), 1);
+  EXPECT_TRUE(Config::Metadata::metadataValue(*hosts[1]->metadata(),
                                               Config::MetadataFilters::get().ENVOY_LB,
                                               Config::MetadataEnvoyLbKeys::get().CANARY)
                   .bool_value());
   EXPECT_TRUE(hosts[1]->canary());
-  EXPECT_EQ(Config::Metadata::metadataValue(hosts[1]->metadata(),
+  EXPECT_EQ(Config::Metadata::metadataValue(*hosts[1]->metadata(),
                                             Config::MetadataFilters::get().ENVOY_LB, "version")
                 .string_value(),
             "v1");
@@ -216,7 +216,7 @@ TEST_F(EdsTest, EndpointMetadata) {
   VERBOSE_EXPECT_NO_THROW(cluster_->onConfigUpdate(resources, ""));
   auto& nhosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
   EXPECT_EQ(nhosts.size(), 2);
-  EXPECT_EQ(Config::Metadata::metadataValue(nhosts[1]->metadata(),
+  EXPECT_EQ(Config::Metadata::metadataValue(*nhosts[1]->metadata(),
                                             Config::MetadataFilters::get().ENVOY_LB, "version")
                 .string_value(),
             "v2");

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -168,6 +168,9 @@ TEST_F(EdsTest, EndpointMetadata) {
                                          Config::MetadataFilters::get().ENVOY_LB,
                                          Config::MetadataEnvoyLbKeys::get().CANARY)
       .set_bool_value(true);
+  Config::Metadata::mutableMetadataValue(*canary->mutable_metadata(),
+                                         Config::MetadataFilters::get().ENVOY_LB, "version")
+      .set_string_value("v1");
 
   bool initialized = false;
   cluster_->initialize([&initialized] { initialized = true; });
@@ -197,10 +200,26 @@ TEST_F(EdsTest, EndpointMetadata) {
                                               Config::MetadataEnvoyLbKeys::get().CANARY)
                   .bool_value());
   EXPECT_TRUE(hosts[1]->canary());
+  EXPECT_EQ(Config::Metadata::metadataValue(hosts[1]->metadata(),
+                                            Config::MetadataFilters::get().ENVOY_LB, "version")
+                .string_value(),
+            "v1");
 
   // We don't rebuild with the exact same config.
   VERBOSE_EXPECT_NO_THROW(cluster_->onConfigUpdate(resources, ""));
   EXPECT_EQ(1UL, stats_.counter("cluster.name.update_no_rebuild").value());
+
+  // New resources with Metadata updated.
+  Config::Metadata::mutableMetadataValue(*canary->mutable_metadata(),
+                                         Config::MetadataFilters::get().ENVOY_LB, "version")
+      .set_string_value("v2");
+  VERBOSE_EXPECT_NO_THROW(cluster_->onConfigUpdate(resources, ""));
+  auto& nhosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
+  EXPECT_EQ(nhosts.size(), 2);
+  EXPECT_EQ(Config::Metadata::metadataValue(nhosts[1]->metadata(),
+                                            Config::MetadataFilters::get().ENVOY_LB, "version")
+                .string_value(),
+            "v2");
 }
 
 // Validate that onConfigUpdate() updates endpoint health status.

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -210,8 +210,8 @@ TEST_F(LogicalDnsClusterTest, Basic) {
   EXPECT_EQ("", data.host_description_->locality().zone());
   EXPECT_EQ("", data.host_description_->locality().sub_zone());
   EXPECT_EQ("foo.bar.com", data.host_description_->hostname());
-  EXPECT_EQ(&envoy::api::v2::core::Metadata::default_instance(),
-            &data.host_description_->metadata());
+  EXPECT_TRUE(TestUtility::protoEqual(envoy::api::v2::core::Metadata::default_instance(),
+                                      *data.host_description_->metadata()));
   data.host_description_->outlierDetector().putHttpResponseCode(200);
   data.host_description_->healthChecker().setUnhealthy();
 

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -78,7 +78,9 @@ public:
   MOCK_CONST_METHOD0(address, Network::Address::InstanceConstSharedPtr());
   MOCK_CONST_METHOD0(healthCheckAddress, Network::Address::InstanceConstSharedPtr());
   MOCK_CONST_METHOD0(canary, bool());
+  MOCK_METHOD1(canary, void(bool new_canary));
   MOCK_CONST_METHOD0(metadata, const envoy::api::v2::core::Metadata&());
+  MOCK_METHOD1(metadata, void(const envoy::api::v2::core::Metadata&));
   MOCK_CONST_METHOD0(cluster, const ClusterInfo&());
   MOCK_CONST_METHOD0(outlierDetector, Outlier::DetectorHostMonitor&());
   MOCK_CONST_METHOD0(healthChecker, HealthCheckHostMonitor&());
@@ -128,7 +130,9 @@ public:
   MOCK_CONST_METHOD0(address, Network::Address::InstanceConstSharedPtr());
   MOCK_CONST_METHOD0(healthCheckAddress, Network::Address::InstanceConstSharedPtr());
   MOCK_CONST_METHOD0(canary, bool());
+  MOCK_METHOD1(canary, void(bool new_canary));
   MOCK_CONST_METHOD0(metadata, const envoy::api::v2::core::Metadata&());
+  MOCK_METHOD1(metadata, void(const envoy::api::v2::core::Metadata&));
   MOCK_CONST_METHOD0(cluster, const ClusterInfo&());
   MOCK_CONST_METHOD0(counters, std::vector<Stats::CounterSharedPtr>());
   MOCK_CONST_METHOD2(

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -79,7 +79,7 @@ public:
   MOCK_CONST_METHOD0(healthCheckAddress, Network::Address::InstanceConstSharedPtr());
   MOCK_CONST_METHOD0(canary, bool());
   MOCK_METHOD1(canary, void(bool new_canary));
-  MOCK_CONST_METHOD0(metadata, const envoy::api::v2::core::Metadata&());
+  MOCK_CONST_METHOD0(metadata, const std::shared_ptr<envoy::api::v2::core::Metadata>());
   MOCK_METHOD1(metadata, void(const envoy::api::v2::core::Metadata&));
   MOCK_CONST_METHOD0(cluster, const ClusterInfo&());
   MOCK_CONST_METHOD0(outlierDetector, Outlier::DetectorHostMonitor&());
@@ -131,7 +131,7 @@ public:
   MOCK_CONST_METHOD0(healthCheckAddress, Network::Address::InstanceConstSharedPtr());
   MOCK_CONST_METHOD0(canary, bool());
   MOCK_METHOD1(canary, void(bool new_canary));
-  MOCK_CONST_METHOD0(metadata, const envoy::api::v2::core::Metadata&());
+  MOCK_CONST_METHOD0(metadata, const std::shared_ptr<envoy::api::v2::core::Metadata>());
   MOCK_METHOD1(metadata, void(const envoy::api::v2::core::Metadata&));
   MOCK_CONST_METHOD0(cluster, const ClusterInfo&());
   MOCK_CONST_METHOD0(counters, std::vector<Stats::CounterSharedPtr>());


### PR DESCRIPTION
This change will force a rebuild in updateDynamicHostList(), if metadata
has changed.

The concrete use-case this fixes is when an EDS service does not emit
removals for endpoints that had metadata changes (e.g.: version
changed). If metadata doesn't get updated, the subset load balancer
won't be able to create new subsets nor remove inactive ones.

Fixes #3810

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
