### PR TITLE
thrift: replace numeric limit macros with std::numeric_limits

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
@@ -1,5 +1,7 @@
 #include "extensions/filters/network/thrift_proxy/binary_protocol_impl.h"
 
+#include <limits>
+
 #include "envoy/common/exception.h"
 
 #include "common/common/assert.h"
@@ -302,7 +304,7 @@ void BinaryProtocolImpl::writeFieldEnd(Buffer::Instance& buffer) { UNREFERENCED_
 
 void BinaryProtocolImpl::writeMapBegin(Buffer::Instance& buffer, FieldType key_type,
                                        FieldType value_type, uint32_t size) {
-  if (size > INT32_MAX) {
+  if (size > std::numeric_limits<int32_t>::max()) {
     throw EnvoyException(fmt::format("illegal binary protocol map size {}", size));
   }
 
@@ -315,7 +317,7 @@ void BinaryProtocolImpl::writeMapEnd(Buffer::Instance& buffer) { UNREFERENCED_PA
 
 void BinaryProtocolImpl::writeListBegin(Buffer::Instance& buffer, FieldType elem_type,
                                         uint32_t size) {
-  if (size > INT32_MAX) {
+  if (size > std::numeric_limits<int32_t>::max()) {
     throw EnvoyException(fmt::format("illegal binary protocol list/set size {}", size));
   }
 

--- a/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.cc
@@ -1,5 +1,7 @@
 #include "extensions/filters/network/thrift_proxy/compact_protocol_impl.h"
 
+#include <limits>
+
 #include "envoy/common/exception.h"
 
 #include "common/common/assert.h"
@@ -140,7 +142,7 @@ bool CompactProtocolImpl::readFieldBegin(Buffer::Instance& buffer, std::string& 
       return false;
     }
 
-    if (id < 0 || id > INT16_MAX) {
+    if (id < 0 || id > std::numeric_limits<int16_t>::max()) {
       throw EnvoyException(fmt::format("invalid compact protocol field id {}", id));
     }
 
@@ -299,7 +301,7 @@ bool CompactProtocolImpl::readInt16(Buffer::Instance& buffer, int16_t& value) {
     return false;
   }
 
-  if (i < INT16_MIN || i > INT16_MAX) {
+  if (i < std::numeric_limits<int16_t>::min() || i > std::numeric_limits<int16_t>::max()) {
     throw EnvoyException(fmt::format("compact protocol i16 exceeds allowable range {}", i));
   }
 
@@ -471,7 +473,7 @@ void CompactProtocolImpl::writeFieldEnd(Buffer::Instance& buffer) {
 
 void CompactProtocolImpl::writeMapBegin(Buffer::Instance& buffer, FieldType key_type,
                                         FieldType value_type, uint32_t size) {
-  if (size > INT32_MAX) {
+  if (size > std::numeric_limits<int32_t>::max()) {
     throw EnvoyException(fmt::format("illegal compact protocol map size {}", size));
   }
 
@@ -490,7 +492,7 @@ void CompactProtocolImpl::writeMapEnd(Buffer::Instance& buffer) { UNREFERENCED_P
 
 void CompactProtocolImpl::writeListBegin(Buffer::Instance& buffer, FieldType elem_type,
                                          uint32_t size) {
-  if (size > INT32_MAX) {
+  if (size > std::numeric_limits<int32_t>::max()) {
     throw EnvoyException(fmt::format("illegal compact protocol list/set size {}", size));
   }
 

--- a/test/extensions/filters/network/thrift_proxy/buffer_helper_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/buffer_helper_test.cc
@@ -519,7 +519,7 @@ TEST(BufferHelperTest, WriteU16) {
   }
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeU16(buffer, std::numeric_limits<int16_t>::max() + 1);
+    BufferHelper::writeU16(buffer, static_cast<uint16_t>(std::numeric_limits<int16_t>::max()) + 1);
     EXPECT_EQ(std::string("\x80\0", 2), buffer.toString());
   }
   {
@@ -565,7 +565,7 @@ TEST(BufferHelperTest, WriteU32) {
   }
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeU32(buffer, std::numeric_limits<int32_t>::max() + 1);
+    BufferHelper::writeU32(buffer, static_cast<uint32_t>(std::numeric_limits<int32_t>::max()) + 1);
     EXPECT_EQ(std::string("\x80\0\0\0", 4), buffer.toString());
   }
   {

--- a/test/extensions/filters/network/thrift_proxy/buffer_helper_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/buffer_helper_test.cc
@@ -1,3 +1,5 @@
+#include <limits>
+
 #include "envoy/common/exception.h"
 
 #include "common/buffer/buffer_impl.h"
@@ -283,7 +285,7 @@ TEST(BufferHelperTest, DrainDouble) {
   addSeq(buffer, {0xFF, 0xEF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
 
   EXPECT_EQ(BufferHelper::drainDouble(buffer), 3.0);
-  EXPECT_EQ(BufferHelper::drainDouble(buffer), -DBL_MAX);
+  EXPECT_EQ(BufferHelper::drainDouble(buffer), std::numeric_limits<double>::lowest());
   EXPECT_EQ(buffer.length(), 0);
 }
 
@@ -484,7 +486,7 @@ TEST(BufferHelperTest, WriteI8) {
 TEST(BufferHelperTest, WriteI16) {
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeI16(buffer, INT16_MIN);
+    BufferHelper::writeI16(buffer, std::numeric_limits<int16_t>::min());
     EXPECT_EQ(std::string("\x80\0", 2), buffer.toString());
   }
   {
@@ -499,7 +501,7 @@ TEST(BufferHelperTest, WriteI16) {
   }
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeI16(buffer, INT16_MAX);
+    BufferHelper::writeI16(buffer, std::numeric_limits<int16_t>::max());
     EXPECT_EQ("\x7F\xFF", buffer.toString());
   }
 }
@@ -517,12 +519,12 @@ TEST(BufferHelperTest, WriteU16) {
   }
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeU16(buffer, static_cast<uint16_t>(INT16_MAX) + 1);
+    BufferHelper::writeU16(buffer, std::numeric_limits<int16_t>::max() + 1);
     EXPECT_EQ(std::string("\x80\0", 2), buffer.toString());
   }
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeU16(buffer, UINT16_MAX);
+    BufferHelper::writeU16(buffer, std::numeric_limits<uint16_t>::max());
     EXPECT_EQ("\xFF\xFF", buffer.toString());
   }
 }
@@ -530,7 +532,7 @@ TEST(BufferHelperTest, WriteU16) {
 TEST(BufferHelperTest, WriteI32) {
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeI32(buffer, INT32_MIN);
+    BufferHelper::writeI32(buffer, std::numeric_limits<int32_t>::min());
     EXPECT_EQ(std::string("\x80\0\0\0", 4), buffer.toString());
   }
   {
@@ -545,7 +547,7 @@ TEST(BufferHelperTest, WriteI32) {
   }
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeI32(buffer, INT32_MAX);
+    BufferHelper::writeI32(buffer, std::numeric_limits<int32_t>::max());
     EXPECT_EQ("\x7F\xFF\xFF\xFF", buffer.toString());
   }
 }
@@ -563,19 +565,19 @@ TEST(BufferHelperTest, WriteU32) {
   }
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeU32(buffer, static_cast<uint32_t>(INT32_MAX) + 1);
+    BufferHelper::writeU32(buffer, std::numeric_limits<int32_t>::max() + 1);
     EXPECT_EQ(std::string("\x80\0\0\0", 4), buffer.toString());
   }
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeU32(buffer, UINT32_MAX);
+    BufferHelper::writeU32(buffer, std::numeric_limits<uint32_t>::max());
     EXPECT_EQ("\xFF\xFF\xFF\xFF", buffer.toString());
   }
 }
 TEST(BufferHelperTest, WriteI64) {
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeI64(buffer, INT64_MIN);
+    BufferHelper::writeI64(buffer, std::numeric_limits<int64_t>::min());
     EXPECT_EQ(std::string("\x80\0\0\0\0\0\0\0\0", 8), buffer.toString());
   }
   {
@@ -590,7 +592,7 @@ TEST(BufferHelperTest, WriteI64) {
   }
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeI64(buffer, INT64_MAX);
+    BufferHelper::writeI64(buffer, std::numeric_limits<int64_t>::max());
     EXPECT_EQ("\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF", buffer.toString());
   }
 }
@@ -605,7 +607,7 @@ TEST(BufferHelperTest, WriteDouble) {
 
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeDouble(buffer, -DBL_MAX);
+    BufferHelper::writeDouble(buffer, std::numeric_limits<double>::lowest());
     EXPECT_EQ("\xFF\xEF\xFF\xFF\xFF\xFF\xFF\xFF", buffer.toString());
   }
 }
@@ -638,7 +640,7 @@ TEST(BufferHelperTest, WriteVarIntI32) {
   }
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeVarIntI32(buffer, INT32_MAX);
+    BufferHelper::writeVarIntI32(buffer, std::numeric_limits<int32_t>::max());
     EXPECT_EQ("\xFF\xFF\xFF\xFF\x7", buffer.toString());
   }
   {
@@ -648,7 +650,7 @@ TEST(BufferHelperTest, WriteVarIntI32) {
   }
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeVarIntI32(buffer, INT32_MIN);
+    BufferHelper::writeVarIntI32(buffer, std::numeric_limits<int32_t>::min());
     EXPECT_EQ("\x80\x80\x80\x80\x8", buffer.toString());
   }
 }
@@ -686,12 +688,12 @@ TEST(BufferHelperTest, WriteVarIntI64) {
   }
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeVarIntI64(buffer, INT32_MAX);
+    BufferHelper::writeVarIntI64(buffer, std::numeric_limits<int32_t>::max());
     EXPECT_EQ("\xFF\xFF\xFF\xFF\x7", buffer.toString());
   }
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeVarIntI64(buffer, INT64_MAX);
+    BufferHelper::writeVarIntI64(buffer, std::numeric_limits<int64_t>::max());
     EXPECT_EQ("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F", buffer.toString());
   }
   {
@@ -701,12 +703,12 @@ TEST(BufferHelperTest, WriteVarIntI64) {
   }
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeVarIntI64(buffer, INT32_MIN);
+    BufferHelper::writeVarIntI64(buffer, std::numeric_limits<int32_t>::min());
     EXPECT_EQ("\x80\x80\x80\x80\xF8\xFF\xFF\xFF\xFF\x1", buffer.toString());
   }
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeVarIntI64(buffer, INT64_MIN);
+    BufferHelper::writeVarIntI64(buffer, std::numeric_limits<int64_t>::min());
     EXPECT_EQ("\x80\x80\x80\x80\x80\x80\x80\x80\x80\x1", buffer.toString());
   }
 }
@@ -757,14 +759,14 @@ TEST(BufferHelperTest, WriteZigZagI32) {
   // zigzag(0x7FFFFFFF) = 0xFFFFFFFE
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeZigZagI32(buffer, INT32_MAX);
+    BufferHelper::writeZigZagI32(buffer, std::numeric_limits<int32_t>::max());
     EXPECT_EQ("\xFE\xFF\xFF\xFF\xF", buffer.toString());
   }
 
   // zigzag(0x80000000) = 0xFFFFFFFF
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeZigZagI32(buffer, INT32_MIN);
+    BufferHelper::writeZigZagI32(buffer, std::numeric_limits<int32_t>::min());
     EXPECT_EQ("\xFF\xFF\xFF\xFF\xF", buffer.toString());
   }
 }
@@ -815,28 +817,28 @@ TEST(BufferHelperTest, WriteZigZagI64) {
   // zigzag(0x7FFFFFFF) = 0xFFFFFFFE
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeZigZagI64(buffer, INT32_MAX);
+    BufferHelper::writeZigZagI64(buffer, std::numeric_limits<int32_t>::max());
     EXPECT_EQ("\xFE\xFF\xFF\xFF\xF", buffer.toString());
   }
 
   // zigzag(0x80000000) = 0xFFFFFFFF
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeZigZagI64(buffer, INT32_MIN);
+    BufferHelper::writeZigZagI64(buffer, std::numeric_limits<int32_t>::min());
     EXPECT_EQ("\xFF\xFF\xFF\xFF\xF", buffer.toString());
   }
 
   // zigzag(0x7FFFFFFF FFFFFFFF) = 0xFFFFFFFFFFFFFFFE
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeZigZagI64(buffer, INT64_MAX);
+    BufferHelper::writeZigZagI64(buffer, std::numeric_limits<int64_t>::max());
     EXPECT_EQ("\xFE\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x1", buffer.toString());
   }
 
   // zigzag(0x8000000000000000) = 0xFFFFFFFFFFFFFFFF
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeZigZagI64(buffer, INT64_MIN);
+    BufferHelper::writeZigZagI64(buffer, std::numeric_limits<int64_t>::min());
     EXPECT_EQ("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x1", buffer.toString());
   }
 }

--- a/test/extensions/filters/network/thrift_proxy/compact_protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/compact_protocol_impl_test.cc
@@ -868,11 +868,11 @@ TEST(CompactProtocolTest, ReadIntegerTypes) {
 
     addSeq(buffer, {0xFE, 0xFF, 0xFF, 0xFF, 0x0F}); // zigzag(0xFFFFFFFE) = 0x7FFFFFFF
     EXPECT_TRUE(proto.readInt32(buffer, value));
-    EXPECT_EQ(value, INT32_MAX);
+    EXPECT_EQ(value, std::numeric_limits<int32_t>::max());
 
     addSeq(buffer, {0xFF, 0xFF, 0xFF, 0xFF, 0x0F}); // zigzag(0xFFFFFFFF) = 0x80000000
     EXPECT_TRUE(proto.readInt32(buffer, value));
-    EXPECT_EQ(value, INT32_MIN);
+    EXPECT_EQ(value, std::numeric_limits<int32_t>::min());
 
     // More than 32 bits
     value = 1;
@@ -901,12 +901,12 @@ TEST(CompactProtocolTest, ReadIntegerTypes) {
     // zigzag(0xFFFFFFFFFFFFFFFE) = 0x7FFFFFFFFFFFFFFF
     addSeq(buffer, {0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01});
     EXPECT_TRUE(proto.readInt64(buffer, value));
-    EXPECT_EQ(value, INT64_MAX);
+    EXPECT_EQ(value, std::numeric_limits<int64_t>::max());
 
     // zigzag(0xFFFFFFFFFFFFFFFF) = 0x8000000000000000
     addSeq(buffer, {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01});
     EXPECT_TRUE(proto.readInt64(buffer, value));
-    EXPECT_EQ(value, INT64_MIN);
+    EXPECT_EQ(value, std::numeric_limits<int64_t>::min());
 
     // More than 64 bits
     value = 1;
@@ -1423,14 +1423,14 @@ TEST(CompactProtocolTest, WriteInt16) {
   // zigzag(32767) = 65534 (0xFFFE)
   {
     Buffer::OwnedImpl buffer;
-    proto.writeInt16(buffer, INT16_MAX);
+    proto.writeInt16(buffer, std::numeric_limits<int16_t>::max());
     EXPECT_EQ("\xFE\xFF\x3", buffer.toString());
   }
 
   // zigzag(-32768) = 65535 (0xFFFF)
   {
     Buffer::OwnedImpl buffer;
-    proto.writeInt16(buffer, INT16_MIN);
+    proto.writeInt16(buffer, std::numeric_limits<int16_t>::min());
     EXPECT_EQ("\xFF\xFF\x3", buffer.toString());
   }
 }
@@ -1463,14 +1463,14 @@ TEST(CompactProtocolTest, WriteInt32) {
   // zigzag(0x7FFFFFFF) = 0xFFFFFFFE
   {
     Buffer::OwnedImpl buffer;
-    proto.writeInt32(buffer, INT32_MAX);
+    proto.writeInt32(buffer, std::numeric_limits<int32_t>::max());
     EXPECT_EQ("\xFE\xFF\xFF\xFF\xF", buffer.toString());
   }
 
   // zigzag(0x80000000) = 0xFFFFFFFF
   {
     Buffer::OwnedImpl buffer;
-    proto.writeInt32(buffer, INT32_MIN);
+    proto.writeInt32(buffer, std::numeric_limits<int32_t>::min());
     EXPECT_EQ("\xFF\xFF\xFF\xFF\xF", buffer.toString());
   }
 }
@@ -1503,14 +1503,14 @@ TEST(CompactProtocolTest, WriteInt64) {
   // zigzag(0x7FFFFFFF FFFFFFFF) = 0xFFFFFFFF FFFFFFFE
   {
     Buffer::OwnedImpl buffer;
-    proto.writeInt64(buffer, INT64_MAX);
+    proto.writeInt64(buffer, std::numeric_limits<int64_t>::max());
     EXPECT_EQ("\xFE\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x1", buffer.toString());
   }
 
   // zigzag(0x80000000 00000000) = 0xFFFFFFFF FFFFFFFF
   {
     Buffer::OwnedImpl buffer;
-    proto.writeInt64(buffer, INT64_MIN);
+    proto.writeInt64(buffer, std::numeric_limits<int64_t>::min());
     EXPECT_EQ("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x1", buffer.toString());
   }
 }


### PR DESCRIPTION
Trivial replacement of macros with their std::numeric_limits counterparts.

*Risk Level*: low (no functional change)
*Testing*: unit tests
*Docs changes*: n/a
*Release notes*: n/a

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
