### PR TITLE
Allow Prometheus label values to contain - and .

### DIFF
--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -564,7 +564,7 @@ std::string PrometheusStatsFormatter::sanitizeName(const std::string& name) {
 std::string PrometheusStatsFormatter::formattedTags(const std::vector<Stats::Tag>& tags) {
   std::vector<std::string> buf;
   for (const Stats::Tag& tag : tags) {
-    buf.push_back(fmt::format("{}=\"{}\"", sanitizeName(tag.name_), sanitizeName(tag.value_)));
+    buf.push_back(fmt::format("{}=\"{}\"", sanitizeName(tag.name_), tag.value_));
   }
   return StringUtil::join(buf, ",");
 }

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -817,13 +817,12 @@ TEST_F(PrometheusStatsFormatterTest, MetricName) {
 }
 
 TEST_F(PrometheusStatsFormatterTest, FormattedTags) {
-  // If value has - then it should be replaced by _ .
   std::vector<Stats::Tag> tags;
   Stats::Tag tag1 = {"a.tag-name", "a.tag-value"};
-  Stats::Tag tag2 = {"another_tag_name", "another.tag-value"};
+  Stats::Tag tag2 = {"another_tag_name", "another_tag-value"};
   tags.push_back(tag1);
   tags.push_back(tag2);
-  std::string expected = "a_tag_name=\"a_tag_value\",another_tag_name=\"another_tag_value\"";
+  std::string expected = "a_tag_name=\"a.tag-value\",another_tag_name=\"another_tag-value\"";
   auto actual = PrometheusStatsFormatter::formattedTags(tags);
   EXPECT_EQ(expected, actual);
 }


### PR DESCRIPTION
This reverts commit c2751df99c29afb4959fd998f0168f6229f42aca (PR #3049)

*Description*:
The originally reported bug (#3019) was due to metric names not being sanitized, which I think was resolved by #2303.
Change #3049, which was intended to fix #3019, erroneously applied sanitization to label values instead. Prometheus label values are permitted to contain any Unicode char, so this change was unnecessary and leads to an unexpected change in e.g. cluster names.

This PR reverts the change, so that - and . will be preserved in label values.

*Risk Level*: low