### PR TITLE
Add hard-coded hot_restart_version test

### DIFF
--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -167,6 +167,19 @@ do
 
   disableHeapCheck
 
+  # To ensure that we don't accidentally change the /hot_restart_version
+  # string, compare it against a hard-coded string.
+  start_test Checking for consistency of /hot_restart_version
+  CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version --base-id "${BASE_ID}" 2>&1)
+  EXPECTED_CLI_HOT_RESTART_VERSION="10.200.16384.127.options=capacity=16384, num_slots=8209 hash=228984379728933363 size=2654312"
+  check [ "${CLI_HOT_RESTART_VERSION}" = "${EXPECTED_CLI_HOT_RESTART_VERSION}" ]
+
+  start_test Checking for consistency of /hot_restart_version with --max-obj-name-len 500
+  CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version --base-id "${BASE_ID}" \
+    --max-obj-name-len 500 2>&1)
+  EXPECTED_CLI_HOT_RESTART_VERSION="10.200.16384.567.options=capacity=16384, num_slots=8209 hash=228984379728933363 size=9863272"
+  check [ "${CLI_HOT_RESTART_VERSION}" = "${EXPECTED_CLI_HOT_RESTART_VERSION}" ]
+
   start_test Checking for match of --hot-restart-version and admin /hot_restart_version
   ADMIN_ADDRESS_0=$(cat "${ADMIN_ADDRESS_PATH_0}")
   echo fetching hot restart version from http://${ADMIN_ADDRESS_0}/hot_restart_version ...


### PR DESCRIPTION
*Description*: As noted in #3629, it would be useful to compare the output of `/hot_restart_version` to some hard-coded string, just to ensure that the version string doesn't accidentally get changed.
*Risk Level*: Low
*Testing*: N/A
*Docs Changes*: None
*Release Notes*: None
