### PR TITLE
config: making v2-config-only a boolean flag

### DIFF
--- a/docs/root/configuration/overview/v2_overview.rst
+++ b/docs/root/configuration/overview/v2_overview.rst
@@ -37,12 +37,9 @@ flag, i.e.:
 
 .. code-block:: console
 
-  ./envoy -c <path to config>.{json,yaml,pb,pb_text} --v2-config-only
+  ./envoy -c <path to config>.{json,yaml,pb,pb_text}
 
-where the extension reflects the underlying v2 config representation. The
-:option:`--v2-config-only` flag is not strictly required as Envoy will attempt
-to autodetect the config file version, but this option provides an enhanced
-debug experience when configuration parsing fails.
+where the extension reflects the underlying v2 config representation.
 
 The :ref:`Bootstrap <envoy_api_msg_config.bootstrap.v2.Bootstrap>` message is the root of the
 configuration. A key concept in the :ref:`Bootstrap <envoy_api_msg_config.bootstrap.v2.Bootstrap>`

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -7,7 +7,7 @@ Version history
   to filter based on the presence of Envoy response flags.
 * admin: added :http:get:`/hystrix_event_stream` as an endpoint for monitoring envoy's statistics
   through `Hystrix dashboard <https://github.com/Netflix-Skunkworks/hystrix-dashboard/wiki>`_.
-* config: v1 disabled by default. v1 support remains available until October via flipping --v2-config-only=false.
+* config: v1 disabled by default. v1 support remains available until October via setting --v2-config-only 0.
 * health check: added support for :ref:`custom health check <envoy_api_field_core.HealthCheck.custom_health_check>`.
 * health check: added support for :ref:`specifying jitter as a percentage <envoy_api_field_core.HealthCheck.interval_jitter_percent>`.
 * health_check: added support for :ref:`health check event logging <arch_overview_health_check_logging>`.

--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -32,11 +32,11 @@ following are the command line options that Envoy supports.
 
       ./envoy -c bootstrap.yaml --config-yaml "node: {id: 'node1'}"
 
-.. option:: --v2-config-only
+.. option:: --v2-config-only <bool>
 
   *(optional)* This flag determines whether the configuration file should only
   be parsed as a :ref:`v2 bootstrap configuration file
-  <config_overview_v2_bootstrap>`. If false (default), when a v2 bootstrap
+  <config_overview_v2_bootstrap>`. If false when a v2 bootstrap
   config parse fails, a second attempt to parse the config as a :ref:`v1 JSON
   configuration file <config_overview_v1>` will be made.
 

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -57,7 +57,9 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   TCLAP::ValueArg<std::string> config_yaml(
       "", "config-yaml", "Inline YAML configuration, merges with the contents of --config-path",
       false, "", "string", cmd);
-  TCLAP::SwitchArg v2_config_only("", "v2-config-only", "parse config as v2 only", cmd, true);
+
+  TCLAP::ValueArg<bool> v2_config_only("", "v2-config-only", "parse config as v2 only", false,
+                                       false, "bool", cmd);
   TCLAP::ValueArg<std::string> admin_address_path("", "admin-address-path", "Admin address path",
                                                   false, "", "string", cmd);
   TCLAP::ValueArg<std::string> local_address_ip_version("", "local-address-ip-version",

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -60,12 +60,32 @@ TEST(OptionsImplTest, InvalidCommandLine) {
                           "Couldn't find match for argument");
 }
 
+TEST(OptionsImplTest, v2True) {
+  std::unique_ptr<OptionsImpl> options = createOptionsImpl(
+      "envoy --mode validate --concurrency 2 -c hello --admin-address-path path --restart-epoch 1 "
+      "--local-address-ip-version v6 -l info --service-cluster cluster --service-node node "
+      "--service-zone zone --file-flush-interval-msec 9000 --drain-time-s 60 --log-format [%v] "
+      "--parent-shutdown-time-s 90 --log-path /foo/bar --v2-config-only 1 --disable-hot-restart");
+  EXPECT_EQ(Server::Mode::Validate, options->mode());
+  EXPECT_TRUE(options->v2ConfigOnly());
+}
+
+TEST(OptionsImplTest, v2False) {
+  std::unique_ptr<OptionsImpl> options = createOptionsImpl(
+      "envoy --mode validate --concurrency 2 -c hello --admin-address-path path --restart-epoch 1 "
+      "--local-address-ip-version v6 -l info --service-cluster cluster --service-node node "
+      "--service-zone zone --file-flush-interval-msec 9000 --drain-time-s 60 --log-format [%v] "
+      "--parent-shutdown-time-s 90 --log-path /foo/bar --v2-config-only 0 --disable-hot-restart");
+  EXPECT_EQ(Server::Mode::Validate, options->mode());
+  EXPECT_FALSE(options->v2ConfigOnly());
+}
+
 TEST(OptionsImplTest, All) {
   std::unique_ptr<OptionsImpl> options = createOptionsImpl(
       "envoy --mode validate --concurrency 2 -c hello --admin-address-path path --restart-epoch 1 "
       "--local-address-ip-version v6 -l info --service-cluster cluster --service-node node "
       "--service-zone zone --file-flush-interval-msec 9000 --drain-time-s 60 --log-format [%v] "
-      "--parent-shutdown-time-s 90 --log-path /foo/bar --v2-config-only --disable-hot-restart");
+      "--parent-shutdown-time-s 90 --log-path /foo/bar --v2-config-only 0 --disable-hot-restart");
   EXPECT_EQ(Server::Mode::Validate, options->mode());
   EXPECT_EQ(2U, options->concurrency());
   EXPECT_EQ("hello", options->configPath());


### PR DESCRIPTION
Note this is command-line breaking for folks who were explicitly setting --v2-config-only with no boolean
The good news is they can just remove it as it's now the default behavior.

As noted in https://github.com/envoyproxy/envoy/issues/3846 flipping the default on a command line switch is confusing at best.  Making the flag a boolean so we can have v2 config only by default but turn it on in a sensible way.

*Risk Level*: Low
*Testing*: Added unit tests
*Docs Changes*: updated docs
*Release Notes*: n/a
Fixes #3846
