### PR TITLE
test: deflaking header_integration_test

### DIFF
--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -192,8 +192,9 @@ void HttpIntegrationTest::setDownstreamProtocol(Http::CodecClient::Type downstre
 }
 
 IntegrationStreamDecoderPtr HttpIntegrationTest::sendRequestAndWaitForResponse(
-    Http::TestHeaderMapImpl& request_headers, uint32_t request_body_size,
-    Http::TestHeaderMapImpl& response_headers, uint32_t response_size) {
+    const Http::TestHeaderMapImpl& request_headers, uint32_t request_body_size,
+    const Http::TestHeaderMapImpl& response_headers, uint32_t response_size) {
+  ASSERT(codec_client_ != nullptr);
   // Send the request to Envoy.
   IntegrationStreamDecoderPtr response;
   if (request_body_size) {

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -93,8 +93,8 @@ protected:
   // Waits for the complete downstream response before returning.
   // Requires |codec_client_| to be initialized.
   IntegrationStreamDecoderPtr sendRequestAndWaitForResponse(
-      Http::TestHeaderMapImpl& request_headers, uint32_t request_body_size,
-      Http::TestHeaderMapImpl& response_headers, uint32_t response_body_size);
+      const Http::TestHeaderMapImpl& request_headers, uint32_t request_body_size,
+      const Http::TestHeaderMapImpl& response_headers, uint32_t response_body_size);
 
   // Wait for the end of stream on the next upstream stream on fake_upstreams_
   // Sets fake_upstream_connection_ to the connection and upstream_request_ to stream.


### PR DESCRIPTION
The EDS connection was reconnecting during shutdown, causing the dreaded parenting_ assert.

Moving over to standard test utilities and making some things const while I'm in here

*Risk Level*: Low (test only)
*Testing*: bazel test //test/integration:header_integration_test --runs_per_test=1000 --test_timeout=60
*Docs Changes*: n/a
*Release Notes*: n/a
