### PR TITLE
api: added csharp namespace override to cluster and listener packages

### DIFF
--- a/api/envoy/api/v2/cluster/circuit_breaker.proto
+++ b/api/envoy/api/v2/cluster/circuit_breaker.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.api.v2.cluster;
 option go_package = "cluster";
+option csharp_namespace = "Envoy.Api.V2.ClusterNS";
 
 import "envoy/api/v2/core/base.proto";
 

--- a/api/envoy/api/v2/cluster/outlier_detection.proto
+++ b/api/envoy/api/v2/cluster/outlier_detection.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package envoy.api.v2.cluster;
+option csharp_namespace = "Envoy.Api.V2.ClusterNS";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";

--- a/api/envoy/api/v2/listener/listener.proto
+++ b/api/envoy/api/v2/listener/listener.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.api.v2.listener;
 option go_package = "listener";
+option csharp_namespace = "Envoy.Api.V2.ListenerNS";
 
 import "envoy/api/v2/core/address.proto";
 import "envoy/api/v2/auth/cert.proto";


### PR DESCRIPTION
*Description*: Api definitions for data plane api contain messages that cause naming conflict when used by protoc to build c# classes. There are two instances of the problem:
1. pacakge: envoy.api.v2 contains message Cluster which ends up being class Envoy.Api.V2.Cluster at the same time there exists a package: envoy.api.v2.cluster which ends up as namespace. Added namespace definition as  Envoy.Api.V2.ClusterNS.
2. Envoy.Api.V2.Cluster. This is not allowed in c# and causes compilation error.
The same problem occurs with package: envoy.api.v2 message: listener and package: envoy.api.v2.listener. Added namespace definition as  Envoy.Api.V2.ListenerNS.

*Risk Level*: Low
*Testing*: None (there is currently no testing done for csharp)
*Docs Changes*: None
*Release Notes*: CSharp namespace overrides for data plane api proto definitions.
*Fixes*: #3827

Signed-off-by: skwasiborski <skwa@demant-technology.com>