### PR TITLE
upstream: fix PriorityStateManager indexing

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -696,6 +696,7 @@ void PriorityStateManager::updateClusterPrioritySet(
   LocalityWeightsMap empty_locality_map;
   LocalityWeightsMap& locality_weights_map =
       priority_state_.size() > priority ? priority_state_[priority].second : empty_locality_map;
+  ASSERT(priority_state_.size() > priority || locality_weights_map.empty());
   LocalityWeightsSharedPtr locality_weights;
   std::vector<HostVector> per_locality;
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -696,6 +696,7 @@ void PriorityStateManager::updateClusterPrioritySet(
   LocalityWeightsMap empty_locality_map;
   LocalityWeightsMap& locality_weights_map =
       priority_state_.empty() ? empty_locality_map : priority_state_[priority].second;
+  ASSERT(priority_state_.empty() || priority_state_.size() > priority);
   LocalityWeightsSharedPtr locality_weights;
   std::vector<HostVector> per_locality;
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -695,8 +695,7 @@ void PriorityStateManager::updateClusterPrioritySet(
   HostVectorSharedPtr hosts(std::move(current_hosts));
   LocalityWeightsMap empty_locality_map;
   LocalityWeightsMap& locality_weights_map =
-      priority_state_.empty() ? empty_locality_map : priority_state_[priority].second;
-  ASSERT(priority_state_.empty() || priority_state_.size() > priority);
+      priority_state_.size() > priority ? priority_state_[priority].second : empty_locality_map;
   LocalityWeightsSharedPtr locality_weights;
   std::vector<HostVector> per_locality;
 


### PR DESCRIPTION
The PriorityStateManager is indexing off the end of an array when the priority is large enough: https://github.com/envoyproxy/envoy/blob/c92a3017017dfa31241dec13dc6a1479090318d0/source/common/upstream/upstream_impl.cc#L697

I don't know why this was passing tests before - maybe fortuitous stack layout? Either way, indexing past the end of a `std::vector` is undefined, which is bad.

*Risk Level*: Low

*Testing*: Verified that the out-of-bounds indexing is actually happening by [testing with an additional assert](https://github.com/envoyproxy/envoy/commit/89f27cb352d8ae90fdb31f328e4c333298e4cd03).

*Docs Changes*: N/A
*Release Notes*: N/A
