### PR TITLE
sandboxes: Add protobuf package to grpc-bridge Python dependencies

### DIFF
--- a/examples/grpc-bridge/Dockerfile-python
+++ b/examples/grpc-bridge/Dockerfile-python
@@ -3,7 +3,7 @@ FROM envoyproxy/envoy:latest
 RUN apt-get update
 RUN apt-get -q install -y python-dev \
     python-pip
-RUN pip install -q grpcio requests
+RUN pip install -q grpcio protobuf requests
 ADD ./client /client
 RUN chmod a+x /client/client.py
 RUN mkdir /var/log/envoy/


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section 
in PULL_REQUESTS.md

*Description*:

I encountered this error on the [grpc_bridge sandbox](https://www.envoyproxy.io/docs/envoy/latest/start/sandboxes/grpc_bridge):

```
$ docker-compose exec python /client/client.py set foo bar
Traceback (most recent call last):
  File "/client/client.py", line 4, in <module>
    import kv_pb2 as kv
  File "/client/kv_pb2.py", line 6, in <module>
    from google.protobuf import descriptor as _descriptor
```

Adding the Python `protobuf` package to the Dockerfile fixes it.

```
$ docker-compose exec python /client/client.py set foo bar
setf foo to bar
```

*Risk Level*: Low
*Testing*: Manual
*Docs Changes*:  N/A
