### PR TITLE
jwt_authn: fix comments

### DIFF
--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -348,7 +348,7 @@ void Utility::extractHostPathFromUri(const absl::string_view& uri, absl::string_
    *
    *  Example:
    *  uri  = "https://example.com:8443/certs"
-   *  pos:          ^
+   *  pos:         ^
    *  host_pos:       ^
    *  path_pos:                       ^
    *  host = "example.com:8443"

--- a/source/extensions/filters/http/jwt_authn/jwks_cache.h
+++ b/source/extensions/filters/http/jwt_authn/jwks_cache.h
@@ -22,7 +22,7 @@ typedef std::unique_ptr<JwksCache> JwksCachePtr;
  *
  *     // for a given jwt
  *     auto jwks_data = jwks_cache->findByIssuer(jwt->getIssuer());
- *     if (!jwks_data->isAudidenceAllowed(jwt->getAudiences())) reject;
+ *     if (!jwks_data->areAudiencesAllowed(jwt->getAudiences())) reject;
  *
  *     if (jwks_data->getJwksObj() == nullptr || jwks_data->isExpired()) {
  *        // Fetch remote Jwks.


### PR DESCRIPTION
A minor fix of comments:
1. An off-by-one error in a URI parsing example.
2. A function name typo in a code sample.

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
