### PR TITLE
test: deflaking ratelimit_integration_test

### DIFF
--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -427,10 +427,12 @@ public:
   bool createListenerFilterChain(Network::ListenerFilterManager& listener) override;
   void set_allow_unexpected_disconnects(bool value) { allow_unexpected_disconnects_ = value; }
 
+  // Stops the dispatcher loop and joins the listening thread.
+  void cleanUp();
+
 protected:
   Stats::IsolatedStoreImpl stats_store_;
   const FakeHttpConnection::Type http_type_;
-  void cleanUp();
 
 private:
   FakeUpstream(Network::TransportSocketFactoryPtr&& transport_socket_factory,


### PR DESCRIPTION
*Risk Level*: Low (test only)
*Testing*: bazel test //test/integration:ratelimit_integration_test --runs_per_test=1000 --local_resources 100000000000,100000000000,10000000 goes from 14% flakes to 0
*Docs Changes*: n/a
*Release Notes*: b/a
