### PR TITLE
websocket: deprecating old style websocket

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -18,7 +18,8 @@ A logged warning is expected for each deprecated item that is in deprecation win
   `use_data_plane_proto` boolean flag in the [ratelimit configuration](https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/ratelimit/v2/rls.proto).
   However, when using the deprecated client a warning is logged.
 * Use of the --v2-config-only flag.
-* Use of the `use_websocket` in [route.proto](https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/route/route.proto)
+* Use of both `use_websocket` and `websocket_config` in
+  [route.proto](https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/route/route.proto)
   is deprecated. Please use the new `upgrade_configs` in the
   [HttpConnectionManager](https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto)
   instead.

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -18,7 +18,10 @@ A logged warning is expected for each deprecated item that is in deprecation win
   `use_data_plane_proto` boolean flag in the [ratelimit configuration](https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/ratelimit/v2/rls.proto).
   However, when using the deprecated client a warning is logged.
 * Use of the --v2-config-only flag.
-* Use of the [HttpConnectionManager](https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto) `use_websocket` is deprecated. Please use the new `upgrade_configs` instead.
+* Use of the `use_websocket` in [route.proto](https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/route/route.proto)
+  is deprecated. Please use the new `upgrade_configs` in the
+  [HttpConnectionManager](https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto)
+  instead.
 
 ## Version 1.7.0
 

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -18,6 +18,7 @@ A logged warning is expected for each deprecated item that is in deprecation win
   `use_data_plane_proto` boolean flag in the [ratelimit configuration](https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/ratelimit/v2/rls.proto).
   However, when using the deprecated client a warning is logged.
 * Use of the --v2-config-only flag.
+* Use of the [HttpConnectionManager](https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto) `use_websocket` is deprecated. Please use the new `upgrade_configs` instead.
 
 ## Version 1.7.0
 

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -635,7 +635,7 @@ message RouteAction {
 
   // Proxy configuration used for WebSocket connections. If unset, the default values as specified
   // in :ref:`TcpProxy <envoy_api_msg_config.filter.network.tcp_proxy.v2.TcpProxy>` are used.
-  WebSocketProxyConfig websocket_config = 22;
+  WebSocketProxyConfig websocket_config = 22 [deprecated = true];
 
   // Indicates that the route has a CORS policy.
   CorsPolicy cors = 17;

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -605,7 +605,7 @@ message RouteAction {
   //   proxy data from the client to the upstream server.
   //
   //   Redirects are not supported on routes where WebSocket upgrades are allowed.
-  google.protobuf.BoolValue use_websocket = 16;
+  google.protobuf.BoolValue use_websocket = 16 [deprecated = true];
 
   message WebSocketProxyConfig {
     // See :ref:`stat_prefix


### PR DESCRIPTION
I think timeouts were the last critical feature - please correct me if I'm wrong.

I'm also happy to wait until folks have moved over, but note that deprecation simply means we'll clean up the old path in 1.5-4.5 months in stead of 4.5-7.5

*Risk Level*: n/a
*Testing*: added timeout test for websocket
*Docs Changes*: added deprecation notice
*Release Notes*: n/a