### PR TITLE
load_stats: fix race condition.

### DIFF
--- a/api/envoy/service/load_stats/v2/lrs.proto
+++ b/api/envoy/service/load_stats/v2/lrs.proto
@@ -63,6 +63,12 @@ message LoadStatsResponse {
   // Clusters to report stats for.
   repeated string clusters = 1 [(validate.rules).repeated .min_items = 1];
 
-  // The interval of time to collect stats. The default is 10 seconds.
+  // The minimum interval of time to collect stats over. This is only a minimum for two reasons:
+  // 1. There may be some delay from when the timer fires until stats sampling occurs.
+  // 2. For clusters that were already feature in the previous *LoadStatsResponse*, any traffic
+  //    that is observed in between the corresponding previous *LoadStatsRequest* and this
+  //    *LoadStatsResponse* will also be accumulated and billed to the cluster. This avoids a period
+  //    of inobservability that might otherwise exists between the messages. New clusters are not
+  //    subject to this consideration.
   google.protobuf.Duration load_reporting_interval = 2;
 }


### PR DESCRIPTION
This PR avoids a situation in which we were losing track of data plane requests as follow:

1. Management server asks Envoy to track load stats for cluster Foo in a LoadStatsResponse for a 10s
   period. Envoy resets stats for Foo.
2. After the 10s timer, Envoy responds with Foo's stats, resetting them.
3. Management server asks Envoy to track load stats for cluster Foo in a LoadStatsResponse for a 10s
   period. Envoy resets stats for Foo.
4. After the 10s timer, Envoy responds with Foo's stats, resetting them.

Between 2 and 3, any stats for Foo requests that arrive were previously unaccounted for. We resolve
this (in a relatively backward compatible way) by not making any protocol changes except to require
Envoy to not reset stats for already tracked clusters.

If we were to design LRS from scratch to avoid this, there are better approaches, e.g. making it a
periodic reporting service rather than request-response, but we probably already have a bunch of
existing users of LRS and don't want to break them.

Rist Level: Low
Testing: Modified load_stats_integration_test.

Signed-off-by: Harvey Tuch <htuch@google.com>