### PR TITLE
Avoid extra `predicate()` calls

### DIFF
--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -494,8 +494,10 @@ void SubsetLoadBalancer::HostSubsetImpl::update(const HostVector& hosts_added,
   }
 
   // Calling predicate() is expensive since it involves metadata lookups; so we
-  // can take a shortcut and just filter healthy hosts in a follow-up call.
-  // Ideally, we would merge these two calls.
+  // avoid it in the 2nd call to filter() by using the result from the first call
+  // to filter() as the starting point.
+  //
+  // TODO(rgs1): merge these two filter() calls in one loop.
   HostsPerLocalityConstSharedPtr hosts_per_locality =
       original_host_set_.hostsPerLocality().filter(predicate);
   HostsPerLocalityConstSharedPtr healthy_hosts_per_locality =

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -499,7 +499,7 @@ void SubsetLoadBalancer::HostSubsetImpl::update(const HostVector& hosts_added,
   HostsPerLocalityConstSharedPtr hosts_per_locality =
       original_host_set_.hostsPerLocality().filter(predicate);
   HostsPerLocalityConstSharedPtr healthy_hosts_per_locality =
-      hosts_per_locality->filter([&predicate](const Host& host) { return host.healthy(); });
+      hosts_per_locality->filter([](const Host& host) { return host.healthy(); });
 
   if (locality_weight_aware_) {
     HostSetImpl::updateHosts(hosts, healthy_hosts, hosts_per_locality, healthy_hosts_per_locality,

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -282,18 +282,16 @@ bool SubsetLoadBalancer::hostMatches(const SubsetMetadata& kvs, const Host& host
     return kvs.size() == 0;
   }
 
-  const ProtobufWkt::Struct* data_struct = &(filter_it->second);
+  const ProtobufWkt::Struct& data_struct = filter_it->second;
+  const auto& fields = data_struct.fields();
 
   for (const auto& kv : kvs) {
-    const ProtobufWkt::Value* val = nullptr;
-
-    const auto entry_it = data_struct->fields().find(kv.first);
-    if (entry_it == data_struct->fields().end()) {
+    const auto entry_it = fields.find(kv.first);
+    if (entry_it == fields.end()) {
       return false;
     }
 
-    val = &(entry_it->second);
-    if (!ValueUtil::equal(*val, kv.second)) {
+    if (!ValueUtil::equal(entry_it->second, kv.second)) {
       return false;
     }
   }


### PR DESCRIPTION
In `SubsetLoadBalancer::HostSubsetImpl::update()` we have repeated calls
to `predicate()`. These calls are expensive mostly because of
`Envoy::Config::Metadata::metadataValue()` calls. Furthermore, metadata
is guarded by a lock since #3814 — so there is some contention too.

This change improves things by doing two things:
* avoid use of `predicate()` to derive `healthy_hosts_per_locality`
* cache `predicate()` calls for the special case of only metadata
  changing (current hosts == hosts added)

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
