### PR TITLE
coverage: rename NOT_REACHED/NOT_IMPLEMENTED to exclude them from code coverage

### DIFF
--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -206,9 +206,11 @@ public:
    */
   virtual Network::FilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& config,
                                                                 FactoryContext& context) {
+    // GCOVR_EXCL_START
     UNREFERENCED_PARAMETER(config);
     UNREFERENCED_PARAMETER(context);
-    NOT_IMPLEMENTED;
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    // GCOVR_EXCL_STOP
   }
 
   /**
@@ -257,10 +259,12 @@ public:
   virtual Http::FilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& config,
                                                              const std::string& stat_prefix,
                                                              FactoryContext& context) {
+    // GCOVR_EXCL_START
     UNREFERENCED_PARAMETER(config);
     UNREFERENCED_PARAMETER(stat_prefix);
     UNREFERENCED_PARAMETER(context);
-    NOT_IMPLEMENTED;
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    // GCOVR_EXCL_STOP
   }
 
   /**

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -206,11 +206,9 @@ public:
    */
   virtual Network::FilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& config,
                                                                 FactoryContext& context) {
-    // GCOVR_EXCL_START
     UNREFERENCED_PARAMETER(config);
     UNREFERENCED_PARAMETER(context);
     NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-    // GCOVR_EXCL_STOP
   }
 
   /**
@@ -219,7 +217,7 @@ public:
    *         JSON and then parsed into this empty proto. Optional today, will be compulsory when v1
    *         is deprecated.
    */
-  virtual ProtobufTypes::MessagePtr createEmptyConfigProto() { return nullptr; }
+  virtual ProtobufTypes::MessagePtr createEmptyConfigProto() { return nullptr; } // GCOVR_EXCL_LINE
 
   /**
    * @return std::string the identifying name for a particular implementation of a network filter
@@ -259,12 +257,10 @@ public:
   virtual Http::FilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& config,
                                                              const std::string& stat_prefix,
                                                              FactoryContext& context) {
-    // GCOVR_EXCL_START
     UNREFERENCED_PARAMETER(config);
     UNREFERENCED_PARAMETER(stat_prefix);
     UNREFERENCED_PARAMETER(context);
     NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-    // GCOVR_EXCL_STOP
   }
 
   /**
@@ -273,7 +269,7 @@ public:
    *         JSON and then parsed into this empty proto. Optional today, will be compulsory when v1
    *         is deprecated.
    */
-  virtual ProtobufTypes::MessagePtr createEmptyConfigProto() { return nullptr; }
+  virtual ProtobufTypes::MessagePtr createEmptyConfigProto() { return nullptr; } // GCOVR_EXCL_LINE
 
   /**
    * @return ProtobufTypes::MessagePtr create an empty virtual host, route, or weighted
@@ -283,7 +279,7 @@ public:
    *         in implementations.
    */
   virtual ProtobufTypes::MessagePtr createEmptyRouteConfigProto() {
-    return createEmptyConfigProto();
+    return createEmptyConfigProto(); // GCOVR_EXCL_LINE
   }
 
   /**
@@ -292,7 +288,7 @@ public:
    */
   virtual Router::RouteSpecificFilterConfigConstSharedPtr
   createRouteSpecificFilterConfig(const Protobuf::Message&, FactoryContext&) {
-    return nullptr;
+    return nullptr; // GCOVR_EXCL_LINE
   }
 
   /**

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -217,7 +217,7 @@ public:
    *         JSON and then parsed into this empty proto. Optional today, will be compulsory when v1
    *         is deprecated.
    */
-  virtual ProtobufTypes::MessagePtr createEmptyConfigProto() { return nullptr; } // GCOVR_EXCL_LINE
+  virtual ProtobufTypes::MessagePtr createEmptyConfigProto() { return nullptr; }
 
   /**
    * @return std::string the identifying name for a particular implementation of a network filter
@@ -269,7 +269,7 @@ public:
    *         JSON and then parsed into this empty proto. Optional today, will be compulsory when v1
    *         is deprecated.
    */
-  virtual ProtobufTypes::MessagePtr createEmptyConfigProto() { return nullptr; } // GCOVR_EXCL_LINE
+  virtual ProtobufTypes::MessagePtr createEmptyConfigProto() { return nullptr; }
 
   /**
    * @return ProtobufTypes::MessagePtr create an empty virtual host, route, or weighted
@@ -279,7 +279,7 @@ public:
    *         in implementations.
    */
   virtual ProtobufTypes::MessagePtr createEmptyRouteConfigProto() {
-    return createEmptyConfigProto(); // GCOVR_EXCL_LINE
+    return createEmptyConfigProto();
   }
 
   /**
@@ -288,7 +288,7 @@ public:
    */
   virtual Router::RouteSpecificFilterConfigConstSharedPtr
   createRouteSpecificFilterConfig(const Protobuf::Message&, FactoryContext&) {
-    return nullptr; // GCOVR_EXCL_LINE
+    return nullptr;
   }
 
   /**

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -47,7 +47,7 @@ bool ComparisonFilter::compareAgainstValue(uint64_t lhs) {
   case envoy::config::filter::accesslog::v2::ComparisonFilter::LE:
     return lhs <= value;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -75,7 +75,7 @@ FilterFactory::fromProto(const envoy::config::filter::accesslog::v2::AccessLogFi
     MessageUtil::validate(config);
     return FilterPtr{new ResponseFlagFilter(config.response_flag_filter())};
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/common/buffer/zero_copy_input_stream_impl.cc
+++ b/source/common/buffer/zero_copy_input_stream_impl.cc
@@ -44,7 +44,7 @@ bool ZeroCopyInputStreamImpl::Next(const void** data, int* size) {
   return false;
 }
 
-bool ZeroCopyInputStreamImpl::Skip(int) { NOT_IMPLEMENTED; }
+bool ZeroCopyInputStreamImpl::Skip(int) { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 
 void ZeroCopyInputStreamImpl::BackUp(int count) {
   ASSERT(count >= 0);

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -48,10 +48,14 @@ namespace Envoy {
                       "panic: {}", X);                                                             \
   abort();
 
-#define NOT_IMPLEMENTED PANIC("not implemented")
+// NOT_IMPLEMENTED_GCOVR_EXCL_LINE is for overridden functions that are expressly not implemented.
+// The macro name includes "GCOVR_EXCL_LINE" to exclude the macro's usage from code coverage
+// reports.
+#define NOT_IMPLEMENTED_GCOVR_EXCL_LINE PANIC("not implemented")
 
-// NOT_REACHED is for spots the compiler insists on having a return, but where we know that it
-// shouldn't be possible to arrive there, assuming no horrendous bugs. For example, after a
-// switch (some_enum) with all enum values included in the cases.
-#define NOT_REACHED PANIC("not reached")
+// NOT_REACHED_GCOVR_EXCL_LINE is for spots the compiler insists on having a return, but where we
+// know that it shouldn't be possible to arrive there, assuming no horrendous bugs. For example,
+// after a switch (some_enum) with all enum values included in the cases. The macro name includes
+// "GCOVR_EXCL_LINE" to exclude the macro's usage from code coverage reports.
+#define NOT_REACHED_GCOVR_EXCL_LINE PANIC("not reached")
 } // Envoy

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -53,6 +53,9 @@ namespace Envoy {
 // reports.
 #define NOT_IMPLEMENTED_GCOVR_EXCL_LINE PANIC("not implemented")
 
+// Deprecated: use NOT_IMPLEMENTED_GCOVR_EXCL_LINE instead.
+#define NOT_IMPLEMENTED NOT_IMPLEMENTED_GCOVR_EXCL_LINE
+
 // NOT_REACHED_GCOVR_EXCL_LINE is for spots the compiler insists on having a return, but where we
 // know that it shouldn't be possible to arrive there, assuming no horrendous bugs. For example,
 // after a switch (some_enum) with all enum values included in the cases. The macro name includes

--- a/source/common/common/matchers.cc
+++ b/source/common/common/matchers.cc
@@ -17,7 +17,7 @@ bool DoubleMatcher::match(double value) const {
   case envoy::type::matcher::DoubleMatcher::kExact:
     return matcher_.exact() == value;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   };
 }
 
@@ -32,7 +32,7 @@ bool StringMatcher::match(const std::string& value) const {
   case envoy::type::matcher::StringMatcher::kRegex:
     return std::regex_match(value, regex_);
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -59,7 +59,7 @@ MetadataMatcher::MetadataMatcher(const envoy::type::matcher::MetadataMatcher& ma
     present_matcher_ = v.present_match();
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -82,7 +82,7 @@ bool MetadataMatcher::match(const envoy::api::v2::core::Metadata& metadata) cons
   case ProtobufWkt::Value::KIND_NOT_SET:
     return false;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/common/config/subscription_factory.h
+++ b/source/common/config/subscription_factory.h
@@ -73,7 +73,7 @@ public:
         break;
       }
       default:
-        NOT_REACHED;
+        NOT_REACHED_GCOVR_EXCL_LINE;
       }
       break;
     }

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -80,7 +80,7 @@ AsyncClientManagerImpl::factoryForGrpcService(const envoy::api::v2::core::GrpcSe
     return std::make_unique<GoogleAsyncClientFactoryImpl>(tls_, google_tls_slot_.get(), scope,
                                                           config);
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
   return nullptr;
 }

--- a/source/common/grpc/google_async_client_impl.cc
+++ b/source/common/grpc/google_async_client_impl.cc
@@ -332,7 +332,7 @@ void GoogleAsyncStreamImpl::handleOpCompletion(GoogleAsyncTag::Operation op, boo
     break;
   }
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -211,7 +211,7 @@ private:
                                                  Http::WebSocketProxyCallbacks&,
                                                  Upstream::ClusterManager&,
                                                  Network::ReadFilterCallbacks*) const override {
-      NOT_IMPLEMENTED;
+      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
     }
     bool includeVirtualHostRateLimits() const override { return true; }
     const envoy::api::v2::core::Metadata& metadata() const override { return metadata_; }
@@ -266,8 +266,8 @@ private:
   RequestInfo::RequestInfo& requestInfo() override { return request_info_; }
   Tracing::Span& activeSpan() override { return active_span_; }
   const Tracing::Config& tracingConfig() override { return tracing_config_; }
-  void continueDecoding() override { NOT_IMPLEMENTED; }
-  void addDecodedData(Buffer::Instance&, bool) override { NOT_IMPLEMENTED; }
+  void continueDecoding() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void addDecodedData(Buffer::Instance&, bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   const Buffer::Instance* decodingBuffer() override { return buffered_body_.get(); }
   void sendLocalReply(Code code, const std::string& body,
                       std::function<void(HeaderMap& headers)> modify_headers) override {

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -745,7 +745,7 @@ void ConnectionManagerImpl::ActiveStream::addDecodedData(ActiveStreamDecoderFilt
   } else {
     // TODO(mattklein123): Formalize error handling for filters and add tests. Should probably
     // throw an exception here.
-    NOT_IMPLEMENTED;
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -1013,7 +1013,7 @@ void ConnectionManagerImpl::ActiveStream::addEncodedData(ActiveStreamEncoderFilt
   } else {
     // TODO(mattklein123): Formalize error handling for filters and add tests. Should probably
     // throw an exception here.
-    NOT_IMPLEMENTED;
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -150,7 +150,7 @@ private:
     Buffer::WatermarkBufferPtr createBuffer() override;
     Buffer::WatermarkBufferPtr& bufferedData() override { return parent_.buffered_request_data_; }
     bool complete() override { return parent_.state_.remote_complete_; }
-    void do100ContinueHeaders() override { NOT_REACHED; }
+    void do100ContinueHeaders() override { NOT_REACHED_GCOVR_EXCL_LINE; }
     void doHeaders(bool end_stream) override {
       parent_.decodeHeaders(this, *parent_.request_headers_, end_stream);
     }
@@ -287,7 +287,7 @@ private:
     void onBelowWriteBufferLowWatermark() override;
 
     // Http::StreamDecoder
-    void decode100ContinueHeaders(HeaderMapPtr&&) override { NOT_REACHED; }
+    void decode100ContinueHeaders(HeaderMapPtr&&) override { NOT_REACHED_GCOVR_EXCL_LINE; }
     void decodeHeaders(HeaderMapPtr&& headers, bool end_stream) override;
     void decodeData(Buffer::Instance& data, bool end_stream) override;
     void decodeTrailers(HeaderMapPtr&& trailers) override;

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -292,7 +292,7 @@ void ConnectionManagerUtility::mutateXfccRequestHeader(Http::HeaderMap& request_
   } else if (config.forwardClientCert() == Http::ForwardClientCertType::SanitizeSet) {
     request_headers.insertForwardedClientCert().value(client_cert_details_str);
   } else {
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -109,7 +109,7 @@ bool HeaderUtility::matchHeaders(const Http::HeaderMap& request_headers,
     match = absl::EndsWith(header->value().getStringView(), header_data.value_);
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 
   return match != header_data.invert_match_;

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -341,7 +341,7 @@ private:
   // ConnectionImpl
   void onEncodeComplete() override;
   void onMessageBegin() override {}
-  void onUrl(const char*, size_t) override { NOT_IMPLEMENTED; }
+  void onUrl(const char*, size_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   int onHeadersComplete(HeaderMapImplPtr&& headers) override;
   void onBody(const char* data, size_t length) override;
   void onMessageComplete() override;

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -410,7 +410,7 @@ int ConnectionImpl::onFrameReceived(const nghttp2_frame* frame) {
 
     default:
       // We do not currently support push.
-      NOT_IMPLEMENTED;
+      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
     }
 
     stream->headers_.reset();

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -338,7 +338,7 @@ const std::string& Utility::getProtocolString(const Protocol protocol) {
     return Headers::get().ProtocolStrings.Http2String;
   }
 
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 void Utility::extractHostPathFromUri(const absl::string_view& uri, absl::string_view& host,

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -118,7 +118,7 @@ private:
       return "String";
     }
 
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 
   struct Value {
@@ -312,7 +312,7 @@ void Field::buildRapidJsonDocument(const Field& field, rapidjson::Value& value,
     break;
   }
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -557,7 +557,7 @@ bool ObjectHandler::StartObject() {
     state_ = expectKeyOrEndObject;
     return true;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -576,7 +576,7 @@ bool ObjectHandler::EndObject(rapidjson::SizeType) {
     }
     return true;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -587,7 +587,7 @@ bool ObjectHandler::Key(const char* value, rapidjson::SizeType size, bool) {
     state_ = expectValueOrStartObjectArray;
     return true;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -611,7 +611,7 @@ bool ObjectHandler::StartArray() {
     state_ = expectArrayValueOrEndArray;
     return true;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -631,7 +631,7 @@ bool ObjectHandler::EndArray(rapidjson::SizeType) {
 
     return true;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -661,7 +661,7 @@ bool ObjectHandler::String(const char* value, rapidjson::SizeType size, bool) {
 
 bool ObjectHandler::RawNumber(const char*, rapidjson::SizeType, bool) {
   // Only called if kParseNumbersAsStrings is set as a parse flag, which it is not.
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 bool ObjectHandler::handleValueEvent(FieldSharedPtr ptr) {
@@ -737,7 +737,7 @@ FieldSharedPtr parseYamlNode(YAML::Node node) {
   case YAML::NodeType::Undefined:
     throw EnvoyException("Undefined YAML value");
   }
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 } // namespace

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -90,7 +90,7 @@ Address::InstanceConstSharedPtr addressFromSockAddr(const sockaddr_storage& ss, 
   default:
     throw EnvoyException(fmt::format("Unexpected sockaddr family: {}", ss.ss_family));
   }
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 InstanceConstSharedPtr addressFromFd(int fd) {

--- a/source/common/network/cidr_range.cc
+++ b/source/common/network/cidr_range.cc
@@ -194,7 +194,7 @@ InstanceConstSharedPtr CidrRange::truncateIpAddressAndLength(InstanceConstShared
     return std::make_shared<Ipv6Instance>(sa6);
   }
   }
-  NOT_REACHED
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 IpList::IpList(const std::vector<std::string>& subnets) {

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -98,7 +98,7 @@ Address::InstanceConstSharedPtr Utility::parseInternetAddress(const std::string&
     return std::make_shared<Address::Ipv6Instance>(sa6, v6only);
   }
   throwWithMalformedIp(ip_address);
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 Address::InstanceConstSharedPtr Utility::parseInternetAddressAndPort(const std::string& ip_address,
@@ -250,7 +250,7 @@ bool Utility::isLoopbackAddress(const Address::Instance& address) {
     absl::uint128 addr = address.ip()->ipv6()->address();
     return 0 == memcmp(&addr, &in6addr_loopback, sizeof(in6addr_loopback));
   }
-  NOT_IMPLEMENTED;
+  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
 }
 
 Address::InstanceConstSharedPtr Utility::getCanonicalIpv4LoopbackAddress() {
@@ -285,7 +285,7 @@ Address::InstanceConstSharedPtr Utility::getAddressWithPort(const Address::Insta
   case Network::Address::IpVersion::v6:
     return std::make_shared<Address::Ipv6Instance>(address.ip()->addressAsString(), port);
   }
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 Address::InstanceConstSharedPtr Utility::getOriginalDst(int fd) {
@@ -384,7 +384,7 @@ Utility::protobufAddressToAddress(const envoy::api::v2::core::Address& proto_add
   case envoy::api::v2::core::Address::kPipe:
     return std::make_shared<Address::PipeInstance>(proto_address.pipe().path());
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -30,7 +30,7 @@ uint64_t fractionalPercentDenominatorToInt(const envoy::type::FractionalPercent&
     return 1000000;
   default:
     // Checked by schema.
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -188,7 +188,7 @@ bool ValueUtil::equal(const ProtobufWkt::Value& v1, const ProtobufWkt::Value& v2
   }
 
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -540,7 +540,7 @@ RouteConstSharedPtr RouteEntryImplBase::clusterEntry(const Http::HeaderMap& head
     }
     begin = end;
   }
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 void RouteEntryImplBase::validateClusters(Upstream::ClusterManager& cm) const {
@@ -713,7 +713,7 @@ VirtualHostImpl::VirtualHostImpl(const envoy::api::v2::route::VirtualHost& virtu
     ssl_requirements_ = SslRequirements::ALL;
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 
   for (const auto& route : virtual_host.routes()) {

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -32,7 +32,7 @@ ConfigUtility::parsePriority(const envoy::api::v2::core::RoutingPriority& priori
   case envoy::api::v2::core::RoutingPriority::HIGH:
     return Upstream::ResourcePriority::High;
   default:
-    NOT_IMPLEMENTED;
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -62,7 +62,7 @@ Http::Code ConfigUtility::parseRedirectResponseCode(
   case envoy::api::v2::route::RedirectAction::PERMANENT_REDIRECT:
     return Http::Code::PermanentRedirect;
   default:
-    NOT_IMPLEMENTED;
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -114,7 +114,7 @@ Http::Code ConfigUtility::parseClusterNotFoundResponseCode(
   case envoy::api::v2::route::RouteAction::NOT_FOUND:
     return Http::Code::NotFound;
   default:
-    NOT_IMPLEMENTED;
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/common/router/header_parser.cc
+++ b/source/common/router/header_parser.cc
@@ -179,7 +179,7 @@ parseInternal(const envoy::api::v2::core::HeaderValueOption& header_value_option
       break;
 
     default:
-      NOT_REACHED;
+      NOT_REACHED_GCOVR_EXCL_LINE;
     }
   } while (++pos < format.size());
 

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -35,7 +35,7 @@ RouteConfigProviderSharedPtr RouteConfigProviderUtil::create(
     return route_config_provider_manager.getRdsRouteConfigProvider(config.rds(), factory_context,
                                                                    stat_prefix);
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/common/router/rds_subscription.h
+++ b/source/common/router/rds_subscription.h
@@ -44,7 +44,7 @@ private:
     // We should never hit this at runtime, since this legacy adapter is only used by HTTP
     // connection manager that doesn't do dynamic modification of resources.
     UNREFERENCED_PARAMETER(resources);
-    NOT_IMPLEMENTED;
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 
   // Http::RestApiFetcher

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -108,7 +108,7 @@ RateLimitPolicyEntryImpl::RateLimitPolicyEntryImpl(const envoy::api::v2::route::
       actions_.emplace_back(new HeaderValueMatchAction(action.header_value_match()));
       break;
     default:
-      NOT_REACHED;
+      NOT_REACHED_GCOVR_EXCL_LINE;
     }
   }
 }

--- a/source/common/ssl/context_config_impl.cc
+++ b/source/common/ssl/context_config_impl.cc
@@ -132,10 +132,10 @@ unsigned ContextConfigImpl::tlsVersionFromProto(
   case envoy::api::v2::auth::TlsParameters::TLSv1_3:
     return TLS1_3_VERSION;
   default:
-    NOT_IMPLEMENTED;
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 ClientContextConfigImpl::ClientContextConfigImpl(

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -50,7 +50,7 @@ const std::string& HttpTracerUtility::toString(OperationName operation_name) {
     return EGRESS_OPERATION;
   }
 
-  NOT_REACHED
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 Decision HttpTracerUtility::isTracing(const RequestInfo::RequestInfo& request_info,

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -79,7 +79,7 @@ Decision HttpTracerUtility::isTracing(const RequestInfo::RequestInfo& request_in
     return {Reason::NotTraceableRequestId, false};
   }
 
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 void HttpTracerUtility::finalizeSpan(Span& span, const Http::HeaderMap* request_headers,

--- a/source/common/upstream/cds_subscription.h
+++ b/source/common/upstream/cds_subscription.h
@@ -43,7 +43,7 @@ private:
     // We should never hit this at runtime, since this legacy adapter is only used by CdsApiImpl
     // that doesn't do dynamic modification of resources.
     UNREFERENCED_PARAMETER(resources);
-    NOT_IMPLEMENTED;
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 
   // Http::RestApiFetcher

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -255,7 +255,7 @@ ClusterManagerImpl::ClusterManagerImpl(const envoy::config::bootstrap::v2::Boots
     }
     default:
       // Validated by schema.
-      NOT_REACHED;
+      NOT_REACHED_GCOVR_EXCL_LINE;
     }
   }
 

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -82,7 +82,7 @@ HealthCheckerFactory::create(const envoy::api::v2::core::HealthCheck& hc_config,
   }
   default:
     // Checked by schema.
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -597,7 +597,7 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::logHealthCheckStatus(
       break;
     default:
       // Should not happen really, Protobuf should not parse undefined enums values.
-      NOT_REACHED;
+      NOT_REACHED_GCOVR_EXCL_LINE;
       break;
     }
   }

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -34,7 +34,7 @@ uint32_t LoadBalancerBase::choosePriority(uint64_t hash,
     }
   }
   // The percentages should always add up to 100 but we have to have a return for the compiler.
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 LoadBalancerBase::LoadBalancerBase(const PrioritySet& priority_set, ClusterStats& stats,
@@ -403,7 +403,7 @@ const HostVector& ZoneAwareLoadBalancerBase::hostSourceToHosts(HostsSource hosts
   case HostsSource::SourceType::LocalityHealthyHosts:
     return host_set.healthyHostsPerLocality().get()[hosts_source.locality_index_];
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -44,7 +44,7 @@ LogicalDnsCluster::LogicalDnsCluster(const envoy::api::v2::Cluster& cluster,
     dns_lookup_family_ = Network::DnsLookupFamily::Auto;
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 
   const auto& socket_address = hosts[0].socket_address();

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -234,7 +234,7 @@ bool DetectorImpl::enforceEjection(EjectionType type) {
                                               config_.enforcingSuccessRate());
   }
 
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 void DetectorImpl::updateEnforcedEjectionStats(EjectionType type) {
@@ -342,7 +342,7 @@ void DetectorImpl::onConsecutiveErrorWorker(HostSharedPtr host, EjectionType typ
     host_monitors_[host]->resetConsecutiveGatewayFailure();
     break;
   case EjectionType::SuccessRate:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -539,7 +539,7 @@ std::string EventLoggerImpl::typeToString(EjectionType type) {
     return "SuccessRate";
   }
 
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 int EventLoggerImpl::secsSinceLastAction(const absl::optional<MonotonicTime>& lastActionTime,

--- a/source/common/upstream/sds_subscription.h
+++ b/source/common/upstream/sds_subscription.h
@@ -42,7 +42,7 @@ private:
     // We should never hit this at runtime, since this legacy adapter is only used by EdsClusterImpl
     // that doesn't do dynamic modification of resources.
     UNREFERENCED_PARAMETER(resources);
-    NOT_IMPLEMENTED;
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 
   // Http::RestApiFetcher

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -448,7 +448,7 @@ SubsetLoadBalancer::PrioritySubsetImpl::PrioritySubsetImpl(const SubsetLoadBalan
     break;
 
   case LoadBalancerType::OriginalDst:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 
   triggerCallbacks();

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -337,7 +337,7 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
     lb_type_ = LoadBalancerType::Maglev;
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 
   if (config.protocol_selection() == envoy::api::v2::Cluster::USE_CONFIGURED_PROTOCOL) {
@@ -417,7 +417,7 @@ ClusterSharedPtr ClusterImplBase::create(
                                          cm, dispatcher, random, added_via_api));
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 
   if (!cluster.health_checks().empty()) {
@@ -620,7 +620,7 @@ ClusterInfoImpl::ResourceManagers::load(const envoy::api::v2::Cluster& config,
     priority_name = "high";
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 
   const std::string runtime_prefix =
@@ -952,7 +952,7 @@ StrictDnsClusterImpl::StrictDnsClusterImpl(const envoy::api::v2::Cluster& cluste
     dns_lookup_family_ = Network::DnsLookupFamily::Auto;
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 
   for (const auto& host : cluster.hosts()) {

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -90,7 +90,7 @@ bool MainCommonBase::run() {
     PERF_DUMP();
     return true;
   }
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 MainCommon::MainCommon(int argc, const char* const* argv)

--- a/source/extensions/filters/common/lua/wrappers.cc
+++ b/source/extensions/filters/common/lua/wrappers.cc
@@ -72,7 +72,7 @@ void MetadataMapWrapper::setValue(lua_State* state, const ProtobufWkt::Value& va
   }
 
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/extensions/filters/common/rbac/matchers.cc
+++ b/source/extensions/filters/common/rbac/matchers.cc
@@ -27,7 +27,7 @@ MatcherConstSharedPtr Matcher::create(const envoy::config::rbac::v2alpha::Permis
   case envoy::config::rbac::v2alpha::Permission::RuleCase::kNotRule:
     return std::make_shared<const NotMatcher>(permission.not_rule());
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -50,7 +50,7 @@ MatcherConstSharedPtr Matcher::create(const envoy::config::rbac::v2alpha::Princi
   case envoy::config::rbac::v2alpha::Principal::IdentifierCase::kNotId:
     return std::make_shared<const NotMatcher>(principal.not_id());
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/extensions/filters/http/common/factory_base.h
+++ b/source/extensions/filters/http/common/factory_base.h
@@ -18,7 +18,7 @@ public:
   Http::FilterFactoryCb createFilterFactory(const Json::Object&, const std::string&,
                                             Server::Configuration::FactoryContext&) override {
     // Only used in v1 filters.
-    NOT_IMPLEMENTED;
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 
   Http::FilterFactoryCb

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -92,7 +92,7 @@ JsonTranscoderConfig::JsonTranscoderConfig(
     }
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 
   for (const auto& file : descriptor_set.file()) {

--- a/source/extensions/filters/http/ip_tagging/ip_tagging_filter.h
+++ b/source/extensions/filters/http/ip_tagging/ip_tagging_filter.h
@@ -86,7 +86,7 @@ private:
     case envoy::config::filter::http::ip_tagging::v2::IPTagging_RequestType_EXTERNAL:
       return FilterRequestType::EXTERNAL;
     default:
-      NOT_REACHED;
+      NOT_REACHED_GCOVR_EXCL_LINE;
     }
   }
 

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -539,7 +539,7 @@ void Filter::scriptLog(spdlog::level::level_enum level, const char* message) {
     ENVOY_LOG(critical, "script log: {}", message);
     return;
   case spdlog::level::off:
-    NOT_IMPLEMENTED;
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/extensions/filters/network/common/factory_base.h
+++ b/source/extensions/filters/network/common/factory_base.h
@@ -18,7 +18,7 @@ public:
   Network::FilterFactoryCb createFilterFactory(const Json::Object&,
                                                Server::Configuration::FactoryContext&) override {
     // Only used in v1 filters.
-    NOT_IMPLEMENTED;
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 
   Network::FilterFactoryCb

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -160,7 +160,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     forward_client_cert_ = Http::ForwardClientCertType::AlwaysForwardOnly;
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 
   const auto& set_current_client_cert_details = config.set_current_client_cert_details();
@@ -197,7 +197,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       tracing_operation_name = Tracing::OperationName::Egress;
       break;
     default:
-      NOT_REACHED;
+      NOT_REACHED_GCOVR_EXCL_LINE;
     }
 
     for (const std::string& header : tracing_config.request_headers_for_tags()) {
@@ -243,7 +243,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     codec_type_ = CodecType::HTTP2;
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 
   const auto& filters = config.http_filters();
@@ -321,7 +321,7 @@ HttpConnectionManagerConfig::createCodec(Network::Connection& connection,
     }
   }
 
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 void HttpConnectionManagerConfig::createFilterChain(Http::FilterChainFactoryCallbacks& callbacks) {

--- a/source/extensions/filters/network/mongo_proxy/bson_impl.cc
+++ b/source/extensions/filters/network/mongo_proxy/bson_impl.cc
@@ -199,7 +199,7 @@ int32_t FieldImpl::byteSize() const {
   }
   }
 
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 void FieldImpl::encode(Buffer::Instance& output) const {
@@ -252,7 +252,7 @@ void FieldImpl::encode(Buffer::Instance& output) const {
     return BufferHelper::writeInt32(output, value_.int32_value_);
   }
 
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 bool FieldImpl::operator==(const Field& rhs) const {
@@ -314,7 +314,7 @@ bool FieldImpl::operator==(const Field& rhs) const {
   }
   }
 
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 std::string FieldImpl::toString() const {
@@ -362,7 +362,7 @@ std::string FieldImpl::toString() const {
   }
   }
 
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 void DocumentImpl::fromBuffer(Buffer::Instance& data) {

--- a/source/extensions/filters/network/redis_proxy/codec_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/codec_impl.cc
@@ -35,7 +35,7 @@ std::string RespValue::toString() const {
     return std::to_string(asInteger());
   }
 
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 std::vector<RespValue>& RespValue::asArray() {

--- a/source/extensions/filters/network/thrift_proxy/buffer_helper.h
+++ b/source/extensions/filters/network/thrift_proxy/buffer_helper.h
@@ -38,19 +38,23 @@ public:
     uint8_t* p = static_cast<uint8_t*>(underlying_.linearize(position_ + size));
     return p + position_;
   }
-  void add(const void*, uint64_t) override { NOT_IMPLEMENTED; }
-  void addBufferFragment(Buffer::BufferFragment&) override { NOT_IMPLEMENTED; }
-  void add(const std::string&) override { NOT_IMPLEMENTED; }
-  void add(const Buffer::Instance&) override { NOT_IMPLEMENTED; }
-  void commit(Buffer::RawSlice*, uint64_t) override { NOT_IMPLEMENTED; }
-  uint64_t getRawSlices(Buffer::RawSlice*, uint64_t) const override { NOT_IMPLEMENTED; }
-  void move(Buffer::Instance&) override { NOT_IMPLEMENTED; }
-  void move(Buffer::Instance&, uint64_t) override { NOT_IMPLEMENTED; }
-  int read(int, uint64_t) override { NOT_IMPLEMENTED; }
-  uint64_t reserve(uint64_t, Buffer::RawSlice*, uint64_t) override { NOT_IMPLEMENTED; }
-  ssize_t search(const void*, uint64_t, size_t) const override { NOT_IMPLEMENTED; }
-  int write(int) override { NOT_IMPLEMENTED; }
-  std::string toString() const override { NOT_IMPLEMENTED; }
+  void add(const void*, uint64_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void addBufferFragment(Buffer::BufferFragment&) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void add(const std::string&) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void add(const Buffer::Instance&) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void commit(Buffer::RawSlice*, uint64_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  uint64_t getRawSlices(Buffer::RawSlice*, uint64_t) const override {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
+  void move(Buffer::Instance&) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void move(Buffer::Instance&, uint64_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  int read(int, uint64_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  uint64_t reserve(uint64_t, Buffer::RawSlice*, uint64_t) override {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
+  ssize_t search(const void*, uint64_t, size_t) const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  int write(int) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  std::string toString() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 
 private:
   Buffer::Instance& underlying_;

--- a/source/extensions/filters/network/thrift_proxy/decoder.cc
+++ b/source/extensions/filters/network/thrift_proxy/decoder.cc
@@ -315,7 +315,7 @@ ProtocolState DecoderStateMachine::handleState(Buffer::Instance& buffer) {
   case ProtocolState::MessageEnd:
     return messageEnd(buffer);
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/extensions/health_checkers/redis/redis.cc
+++ b/source/extensions/health_checkers/redis/redis.cc
@@ -60,7 +60,7 @@ void RedisHealthChecker::RedisActiveHealthCheckSession::onInterval() {
     current_request_ = client_->makeRequest(pingHealthCheckRequest(), *this);
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -86,7 +86,7 @@ void RedisHealthChecker::RedisActiveHealthCheckSession::onResponse(
     }
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 
   if (!parent_.reuse_connection_) {

--- a/source/extensions/stat_sinks/statsd/config.cc
+++ b/source/extensions/stat_sinks/statsd/config.cc
@@ -34,7 +34,7 @@ Stats::SinkPtr StatsdSinkFactory::createStatsSink(const Protobuf::Message& confi
         server.clusterManager(), server.stats(), statsd_sink.prefix());
   default:
     // Verified by schema.
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
@@ -54,7 +54,7 @@ public:
     case Http::HeaderMap::Lookup::NotSupported:
       return opentracing::make_unexpected(opentracing::lookup_key_not_supported_error);
     }
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 
   opentracing::expected<void> ForeachKey(OpenTracingCb f) const override {

--- a/source/server/config_validation/admin.cc
+++ b/source/server/config_validation/admin.cc
@@ -9,13 +9,13 @@ bool ValidationAdmin::addHandler(const std::string&, const std::string&, Handler
 
 bool ValidationAdmin::removeHandler(const std::string&) { return false; };
 
-const Network::Socket& ValidationAdmin::socket() { NOT_IMPLEMENTED; };
+const Network::Socket& ValidationAdmin::socket() { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; };
 
 ConfigTracker& ValidationAdmin::getConfigTracker() { return config_tracker_; };
 
 Http::Code ValidationAdmin::request(absl::string_view, const Http::Utility::QueryParams&,
                                     absl::string_view, Http::HeaderMap&, std::string&) {
-  NOT_IMPLEMENTED;
+  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
 }
 
 } // namespace Server

--- a/source/server/config_validation/dispatcher.cc
+++ b/source/server/config_validation/dispatcher.cc
@@ -23,7 +23,7 @@ Network::DnsResolverSharedPtr ValidationDispatcher::createDnsResolver(
 
 Network::ListenerPtr ValidationDispatcher::createListener(Network::Socket&,
                                                           Network::ListenerCallbacks&, bool, bool) {
-  NOT_IMPLEMENTED;
+  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
 }
 
 } // namespace Event

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -66,12 +66,12 @@ public:
   Network::DnsResolverSharedPtr dnsResolver() override {
     return dispatcher().createDnsResolver({});
   }
-  void drainListeners() override { NOT_IMPLEMENTED; }
-  DrainManager& drainManager() override { NOT_IMPLEMENTED; }
+  void drainListeners() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  DrainManager& drainManager() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   AccessLog::AccessLogManager& accessLogManager() override { return access_log_manager_; }
-  void failHealthcheck(bool) override { NOT_IMPLEMENTED; }
-  void getParentStats(HotRestart::GetParentStatsInfo&) override { NOT_IMPLEMENTED; }
-  HotRestart& hotRestart() override { NOT_IMPLEMENTED; }
+  void failHealthcheck(bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void getParentStats(HotRestart::GetParentStatsInfo&) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  HotRestart& hotRestart() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   Init::Manager& initManager() override { return init_manager_; }
   ListenerManager& listenerManager() override { return listener_manager_; }
   Secret::SecretManager& secretManager() override { return *secret_manager_; }
@@ -82,12 +82,12 @@ public:
   }
   Runtime::Loader& runtime() override { return *runtime_loader_; }
   void shutdown() override;
-  void shutdownAdmin() override { NOT_IMPLEMENTED; }
+  void shutdownAdmin() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   Singleton::Manager& singletonManager() override { return *singleton_manager_; }
-  bool healthCheckFailed() override { NOT_IMPLEMENTED; }
+  bool healthCheckFailed() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   Options& options() override { return options_; }
-  time_t startTimeCurrentEpoch() override { NOT_IMPLEMENTED; }
-  time_t startTimeFirstEpoch() override { NOT_IMPLEMENTED; }
+  time_t startTimeCurrentEpoch() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  time_t startTimeFirstEpoch() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   Stats::Store& stats() override { return stats_store_; }
   Tracing::HttpTracer& httpTracer() override { return config_->httpTracer(); }
   ThreadLocal::Instance& threadLocal() override { return thread_local_; }

--- a/source/server/lds_subscription.h
+++ b/source/server/lds_subscription.h
@@ -40,7 +40,7 @@ private:
     // We should never hit this at runtime, since this legacy adapter is only used by CdsApiImpl
     // that doesn't do dynamic modification of resources.
     UNREFERENCED_PARAMETER(resources);
-    NOT_IMPLEMENTED;
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
 
   // Http::RestApiFetcher

--- a/test/common/access_log/test_util.h
+++ b/test/common/access_log/test_util.h
@@ -21,12 +21,12 @@ public:
   SystemTime startTime() const override { return start_time_; }
   MonotonicTime startTimeMonotonic() const override { return start_time_monotonic_; }
 
-  void addBytesReceived(uint64_t) override { NOT_IMPLEMENTED; }
+  void addBytesReceived(uint64_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   uint64_t bytesReceived() const override { return 1; }
   absl::optional<Http::Protocol> protocol() const override { return protocol_; }
   void protocol(Http::Protocol protocol) override { protocol_ = protocol; }
   absl::optional<uint32_t> responseCode() const override { return response_code_; }
-  void addBytesSent(uint64_t) override { NOT_IMPLEMENTED; }
+  void addBytesSent(uint64_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   uint64_t bytesSent() const override { return 2; }
   bool intersectResponseFlags(uint64_t response_flags) const override {
     return (response_flags_ & response_flags) != 0;

--- a/test/common/grpc/grpc_client_integration.h
+++ b/test/common/grpc/grpc_client_integration.h
@@ -30,7 +30,7 @@ public:
       break;
     }
     default:
-      NOT_REACHED;
+      NOT_REACHED_GCOVR_EXCL_LINE;
     }
   }
 };

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -286,7 +286,7 @@ public:
     return std::make_unique<GoogleAsyncClientImpl>(dispatcher_, *google_tls_, stub_factory,
                                                    stats_scope_, createGoogleGrpcConfig());
 #else
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
 #endif
   }
 

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4386,7 +4386,7 @@ public:
 
     Http::FilterFactoryCb createFilter(const std::string&,
                                        Server::Configuration::FactoryContext&) override {
-      NOT_IMPLEMENTED;
+      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
     }
     ProtobufTypes::MessagePtr createEmptyRouteConfigProto() override {
       return ProtobufTypes::MessagePtr{new ProtobufWkt::Timestamp()};

--- a/test/extensions/access_loggers/http_grpc/grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/http_grpc/grpc_access_log_integration_test.cc
@@ -162,7 +162,7 @@ http_logs:
     test_server_->waitForCounterGe("grpc.accesslog.streams_closed_0", 1);
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
   response = IntegrationUtil::makeSingleRequest(lookupPort("http"), "GET", "/notfound", "",
                                                 downstream_protocol_, version_);

--- a/test/extensions/filters/network/redis_proxy/mocks.cc
+++ b/test/extensions/filters/network/redis_proxy/mocks.cc
@@ -50,7 +50,7 @@ bool operator==(const RespValue& lhs, const RespValue& rhs) {
   }
   }
 
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 MockEncoder::MockEncoder() {

--- a/test/extensions/filters/network/thrift_proxy/decoder_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/decoder_test.cc
@@ -50,7 +50,7 @@ Expectation expectValue(NiceMock<MockProtocol>& proto, FieldType field_type, boo
   case FieldType::String:
     return EXPECT_CALL(proto, readString(_, _)).WillOnce(Return(result));
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -77,7 +77,7 @@ ExpectationSet expectContainerStart(NiceMock<MockProtocol>& proto, FieldType fie
              .WillOnce(DoAll(SetArgReferee<1>(inner_type), SetArgReferee<2>(1), Return(true)));
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
   return s;
 }
@@ -101,7 +101,7 @@ ExpectationSet expectContainerEnd(NiceMock<MockProtocol>& proto, FieldType field
     s += EXPECT_CALL(proto, readSetEnd(_)).WillOnce(Return(true));
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
   return s;
 }

--- a/test/extensions/filters/network/thrift_proxy/filter_integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filter_integration_test.cc
@@ -65,7 +65,7 @@ public:
       result_mode = "exception";
       break;
     default:
-      NOT_REACHED;
+      NOT_REACHED_GCOVR_EXCL_LINE;
     }
 
     preparePayloads(result_mode, "execute");

--- a/test/extensions/stats_sinks/metrics_service/metrics_service_integration_test.cc
+++ b/test/extensions/stats_sinks/metrics_service/metrics_service_integration_test.cc
@@ -149,7 +149,7 @@ TEST_P(MetricsServiceIntegrationTest, BasicFlow) {
     test_server_->waitForCounterGe("grpc.metrics_service.streams_closed_0", 1);
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
   cleanup();
 }

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -323,7 +323,7 @@ public:
 
   // Http::ServerConnectionCallbacks
   Http::StreamDecoder& newStream(Http::StreamEncoder& response_encoder) override;
-  void onGoAway() override { NOT_IMPLEMENTED; }
+  void onGoAway() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 
 private:
   struct ReadFilter : public Network::ReadFilterBaseImpl {

--- a/test/integration/ratelimit_integration_test.cc
+++ b/test/integration/ratelimit_integration_test.cc
@@ -201,7 +201,7 @@ TEST_P(RatelimitIntegrationTest, Timeout) {
     EXPECT_EQ(1, test_server_->counter("grpc.ratelimit.streams_closed_4")->value());
     break;
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
   // Rate limiter fails open
   waitForSuccessfulUpstreamResponse();

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -50,8 +50,8 @@ public:
     return local_address_ip_version_;
   }
   std::chrono::seconds drainTime() const override { return std::chrono::seconds(1); }
-  spdlog::level::level_enum logLevel() const override { NOT_IMPLEMENTED; }
-  const std::string& logFormat() const override { NOT_IMPLEMENTED; }
+  spdlog::level::level_enum logLevel() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  const std::string& logFormat() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   std::chrono::seconds parentShutdownTime() const override { return std::chrono::seconds(2); }
   const std::string& logPath() const override { return log_path_; }
   uint64_t restartEpoch() const override { return 0; }

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -42,7 +42,9 @@ void BufferingStreamDecoder::decodeData(Buffer::Instance& data, bool end_stream)
   }
 }
 
-void BufferingStreamDecoder::decodeTrailers(Http::HeaderMapPtr&&) { NOT_IMPLEMENTED; }
+void BufferingStreamDecoder::decodeTrailers(Http::HeaderMapPtr&&) {
+  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+}
 
 void BufferingStreamDecoder::onComplete() {
   ASSERT(complete_);

--- a/test/tools/schema_validator/validator.cc
+++ b/test/tools/schema_validator/validator.cc
@@ -17,7 +17,7 @@ const std::string& Schema::toString(Type type) {
     return ROUTE;
   }
 
-  NOT_REACHED;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 Options::Options(int argc, char** argv) {
@@ -63,7 +63,7 @@ void Validator::validate(const std::string& json_path, Schema::Type schema_type)
     break;
   }
   default:
-    NOT_REACHED;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 


### PR DESCRIPTION
gcovr ignores any line containing GCOVR_EXCL_LINE without regard to syntax.
This change makes use of this to automatically exclude the NOT_REACHED and
NOT_IMPLEMENTED macros from code coverage.

*Risk Level*: low (macro rename)
*Testing*: manual
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
