### PR TITLE
http: global connection manager per-stream idle timeouts.

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -439,12 +439,11 @@ message RouteAction {
     google.protobuf.Duration per_try_timeout = 3 [(gogoproto.stdduration) = true];
   }
 
-  // Specifies the idle timeout for the route. If not specified, this defaults
-  // to 5 minutes. The default value was select so as not to interfere with any
-  // smaller configured timeouts that may have existed in configurations prior
-  // to the introduction of this feature, while introducing robustness to TCP
-  // connections that terminate without FIN. A value of 0 will completely
-  // disable the idle timeout.
+  // Specifies the idle timeout for the route. If not specified, there is no per-route
+  // idle timeout specified, although the connection manager wide
+  // :ref:`stream_idle_timeout
+  // <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_idle_timeout>`
+  // will still apply.
   //
   // The idle timeout is distinct to :ref:`timeout
   // <envoy_api_field_route.RouteAction.timeout>`, which provides an upper bound

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -19,7 +19,7 @@ import "gogoproto/gogo.proto";
 // [#protodoc-title: HTTP connection manager]
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 
-// [#comment:next free field: 24]
+// [#comment:next free field: 25]
 message HttpConnectionManager {
   enum CodecType {
     option (gogoproto.goproto_enum_prefix) = false;
@@ -136,6 +136,27 @@ message HttpConnectionManager {
   // :ref:`drain_timeout
   // <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.drain_timeout>`.
   google.protobuf.Duration idle_timeout = 11 [(gogoproto.stdduration) = true];
+
+  // The stream idle timeout for connections managed by the connection manager.
+  // If not specified, this defaults to 5 minutes. The default value was select
+  // so as not to interfere with any smaller configured timeouts that may have
+  // existed in configurations prior to the introduction of this feature, while
+  // introducing robustness to TCP connections that terminate without FIN.
+  //
+  // This idle timeout applies to new streams and is overridable by the
+  // :ref:`route-level idle_timeout
+  // <envoy_api_field_route.RouteAction.idle_timeout>`. Even on a stream in
+  // which the override applies, prior to receipt of the initial request
+  // headers, the :ref:`stream_idle_timeout
+  // <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_idle_timeout>`
+  // applies. Each time an encode/decode event for headers or data is processed
+  // for the stream, the timer will be reset. If the timeout fires, the stream
+  // is terminated with a 408 Request Timeout error code if no upstream response
+  // header has been received, otherwise a stream reset occurs.
+  //
+  // A value of 0 will completely disable the connection manager stream idle
+  // timeout, although per-route idle timeout overrides will continue to apply.
+  google.protobuf.Duration stream_idle_timeout = 24 [(gogoproto.stdduration) = true];
 
   // The time that Envoy will wait between sending an HTTP/2 “shutdown
   // notification” (GOAWAY frame with max stream ID) and a final GOAWAY frame.

--- a/docs/root/intro/arch_overview/http_connection_management.rst
+++ b/docs/root/intro/arch_overview/http_connection_management.rst
@@ -42,3 +42,27 @@ table <arch_overview_http_routing>`. The route table can be specified in one of 
 
 * Statically.
 * Dynamically via the :ref:`RDS API <config_http_conn_man_rds>`.
+
+Timeouts
+--------
+
+Various configurable timeouts apply to an HTTP connection and its constituent streams:
+
+* Connection-level :ref:`idle timeout
+  <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.idle_timeout>`:
+  this applies to the idle period where no streams are active.
+* Connection-level :ref:`drain timeout
+  <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.drain_timeout>`:
+  this spans between an Envoy originated GOAWAY and connection termination.
+* Stream-level idle timeout: this applies to each individual stream. It may be configured at both
+  the :ref:`connection manage
+  <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_idle_timeout>`
+  and :ref:`per-route <envoy_api_field_route.RouteAction.idle_timeout>` granularity.
+  Header/data/trailer events on the stream reset the idle timeout.
+* Stream-level :ref:`per-route upstream timeout <envoy_api_field_route.RouteAction.timeout>`: this
+  applies to the upstream response, i.e. a maximum bound on the time from the end of the downstream
+  request until the end of the upstream response. This may also be specified at the :ref:`per-retry
+  <envoy_api_field_route.RouteAction.RetryPolicy.per_try_timeout>` granularity.
+* Stream-level :ref:`per-route gRPC max timeout
+  <envoy_api_field_route.RouteAction.max_grpc_timeout>`: this bounds the upstream timeout and allows
+  the timeout to be overriden via the *grpc-timeout* request header.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -14,10 +14,12 @@ Version history
 * health check: added support for :ref:`custom health check <envoy_api_field_core.HealthCheck.custom_health_check>`.
 * health check: added support for :ref:`specifying jitter as a percentage <envoy_api_field_core.HealthCheck.interval_jitter_percent>`.
 * health_check: added support for :ref:`health check event logging <arch_overview_health_check_logging>`.
-* http: added support for a :ref:`per-stream idle timeout
-  <envoy_api_field_route.RouteAction.idle_timeout>`. This defaults to 5 minutes; if you have
-  other timeouts (e.g. connection idle timeout, upstream response per-retry) that are longer than
-  this in duration, you may want to consider setting a non-default per-stream idle timeout.
+* http: added support for a per-stream idle timeout. This applies at both :ref:`connection manager
+  <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_idle_timeout>`
+  and :ref:`per-route granularity <envoy_api_field_route.RouteAction.idle_timeout>`. The timeout
+  defaults to 5 minutes; if you have other timeouts (e.g. connection idle timeout, upstream
+  response per-retry) that are longer than this in duration, you may want to consider setting a
+  non-default per-stream idle timeout.
 * http: better handling of HEAD requests. Now sending transfer-encoding: chunked rather than content-length: 0.
 * http: response filters not applied to early error paths such as http_parser generated 400s.
 * proxy_protocol: added support for HAProxy Proxy Protocol v2 (AF_INET/AF_INET6 only).

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -192,7 +192,12 @@ public:
   /**
    * @return optional idle timeout for incoming connection manager connections.
    */
-  virtual const absl::optional<std::chrono::milliseconds>& idleTimeout() PURE;
+  virtual const absl::optional<std::chrono::milliseconds> idleTimeout() PURE;
+
+  /**
+   * @return optional per-stream idle timeout for incoming connection manager connections.
+   */
+  virtual const absl::optional<std::chrono::milliseconds> streamIdleTimeout() PURE;
 
   /**
    * @return Router::RouteConfigProvider& the configuration provider used to acquire a route

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -258,8 +258,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
       cluster_not_found_response_code_(ConfigUtility::parseClusterNotFoundResponseCode(
           route.route().cluster_not_found_response_code())),
       timeout_(PROTOBUF_GET_MS_OR_DEFAULT(route.route(), timeout, DEFAULT_ROUTE_TIMEOUT_MS)),
-      idle_timeout_(
-          PROTOBUF_GET_MS_OR_DEFAULT(route.route(), idle_timeout, DEFAULT_ROUTE_IDLE_TIMEOUT_MS)),
+      idle_timeout_(PROTOBUF_GET_OPTIONAL_MS(route.route(), idle_timeout)),
       max_grpc_timeout_(PROTOBUF_GET_OPTIONAL_MS(route.route(), max_grpc_timeout)),
       runtime_(loadRuntimeData(route.match())), loader_(factory_context.runtime()),
       host_redirect_(route.redirect().host_redirect()),

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -311,10 +311,7 @@ public:
     return vhost_.virtualClusterFromEntries(headers);
   }
   std::chrono::milliseconds timeout() const override { return timeout_; }
-  absl::optional<std::chrono::milliseconds> idleTimeout() const override {
-    return idle_timeout_.count() == 0 ? absl::nullopt
-                                      : absl::optional<std::chrono::milliseconds>(idle_timeout_);
-  }
+  absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
   absl::optional<std::chrono::milliseconds> maxGrpcTimeout() const override {
     return max_grpc_timeout_;
   }
@@ -510,9 +507,6 @@ private:
   // Default timeout is 15s if nothing is specified in the route config.
   static const uint64_t DEFAULT_ROUTE_TIMEOUT_MS = 15000;
 
-  // Default idle timeout is 5 minutes if nothing is specified in the route config.
-  static const uint64_t DEFAULT_ROUTE_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
-
   std::unique_ptr<const CorsPolicyImpl> cors_policy_;
   const VirtualHostImpl& vhost_; // See note in RouteEntryImplBase::clusterEntry() on why raw ref
                                  // to virtual host is currently safe.
@@ -522,7 +516,7 @@ private:
   const Http::LowerCaseString cluster_header_name_;
   const Http::Code cluster_not_found_response_code_;
   const std::chrono::milliseconds timeout_;
-  const std::chrono::milliseconds idle_timeout_;
+  const absl::optional<std::chrono::milliseconds> idle_timeout_;
   const absl::optional<std::chrono::milliseconds> max_grpc_timeout_;
   const absl::optional<RuntimeData> runtime_;
   Runtime::Loader& loader_;

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -129,6 +129,9 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       route_config_provider_manager_(route_config_provider_manager),
       http2_settings_(Http::Utility::parseHttp2Settings(config.http2_protocol_options())),
       http1_settings_(Http::Utility::parseHttp1Settings(config.http_protocol_options())),
+      idle_timeout_(PROTOBUF_GET_OPTIONAL_MS(config, idle_timeout)),
+      stream_idle_timeout_(
+          PROTOBUF_GET_MS_OR_DEFAULT(config, stream_idle_timeout, StreamIdleTimeoutMs)),
       drain_timeout_(PROTOBUF_GET_MS_OR_DEFAULT(config, drain_timeout, 5000)),
       generate_request_id_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, generate_request_id, true)),
       date_provider_(date_provider),
@@ -214,10 +217,6 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     tracing_config_.reset(new Http::TracingConnectionManagerConfig(
         {tracing_operation_name, request_headers_for_tags, client_sampling, random_sampling,
          overall_sampling}));
-  }
-
-  if (config.has_idle_timeout()) {
-    idle_timeout_ = std::chrono::milliseconds(PROTOBUF_GET_MS_REQUIRED(config, idle_timeout));
   }
 
   for (const auto& access_log : config.access_log()) {

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -87,7 +87,12 @@ public:
   std::chrono::milliseconds drainTimeout() override { return drain_timeout_; }
   FilterChainFactory& filterFactory() override { return *this; }
   bool generateRequestId() override { return generate_request_id_; }
-  const absl::optional<std::chrono::milliseconds>& idleTimeout() override { return idle_timeout_; }
+  const absl::optional<std::chrono::milliseconds> idleTimeout() override { return idle_timeout_; }
+  const absl::optional<std::chrono::milliseconds> streamIdleTimeout() override {
+    return stream_idle_timeout_.count() == 0
+               ? absl::nullopt
+               : absl::optional<std::chrono::milliseconds>(stream_idle_timeout_);
+  }
   Router::RouteConfigProvider& routeConfigProvider() override { return *route_config_provider_; }
   const std::string& serverName() override { return server_name_; }
   Http::ConnectionManagerStats& stats() override { return stats_; }
@@ -137,12 +142,16 @@ private:
   Http::TracingConnectionManagerConfigPtr tracing_config_;
   absl::optional<std::string> user_agent_;
   absl::optional<std::chrono::milliseconds> idle_timeout_;
+  std::chrono::milliseconds stream_idle_timeout_;
   Router::RouteConfigProviderSharedPtr route_config_provider_;
   std::chrono::milliseconds drain_timeout_;
   bool generate_request_id_;
   Http::DateProvider& date_provider_;
   Http::ConnectionManagerListenerStats listener_stats_;
   const bool proxy_100_continue_;
+
+  // Default idle timeout is 5 minutes if nothing is specified in the HCM config.
+  static const uint64_t StreamIdleTimeoutMs = 5 * 60 * 1000;
 };
 
 } // namespace HttpConnectionManager

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -89,7 +89,10 @@ public:
   std::chrono::milliseconds drainTimeout() override { return std::chrono::milliseconds(100); }
   Http::FilterChainFactory& filterFactory() override { return *this; }
   bool generateRequestId() override { return false; }
-  const absl::optional<std::chrono::milliseconds>& idleTimeout() override { return idle_timeout_; }
+  const absl::optional<std::chrono::milliseconds> idleTimeout() override { return idle_timeout_; }
+  const absl::optional<std::chrono::milliseconds> streamIdleTimeout() override {
+    return absl::nullopt;
+  }
   Router::RouteConfigProvider& routeConfigProvider() override { return route_config_provider_; }
   const std::string& serverName() override { return Http::DefaultServerString::get(); }
   Http::ConnectionManagerStats& stats() override { return stats_; }

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -254,7 +254,10 @@ public:
   std::chrono::milliseconds drainTimeout() override { return std::chrono::milliseconds(100); }
   FilterChainFactory& filterFactory() override { return filter_factory_; }
   bool generateRequestId() override { return true; }
-  const absl::optional<std::chrono::milliseconds>& idleTimeout() override { return idle_timeout_; }
+  const absl::optional<std::chrono::milliseconds> idleTimeout() override { return idle_timeout_; }
+  const absl::optional<std::chrono::milliseconds> streamIdleTimeout() override {
+    return stream_idle_timeout_;
+  }
   Router::RouteConfigProvider& routeConfigProvider() override { return route_config_provider_; }
   const std::string& serverName() override { return server_name_; }
   ConnectionManagerStats& stats() override { return stats_; }
@@ -294,6 +297,7 @@ public:
   std::vector<Http::ClientCertDetailsType> set_current_client_cert_details_;
   absl::optional<std::string> user_agent_;
   absl::optional<std::chrono::milliseconds> idle_timeout_;
+  absl::optional<std::chrono::milliseconds> stream_idle_timeout_;
   NiceMock<Runtime::MockRandomGenerator> random_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
@@ -1093,7 +1097,9 @@ TEST_F(HttpConnectionManagerImplTest, NoPath) {
   conn_manager_->onData(fake_input, false);
 }
 
-// No idle timeout when route idle timeout is not configured.
+// No idle timeout when route idle timeout is implied at both global and
+// per-route level. The connection manager config is responsible for managing
+// the default configuration aspects.
 TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutNotConfigured) {
   setup(false, "");
 
@@ -1104,6 +1110,61 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutNotConfigured) {
         StreamDecoder* decoder = &conn_manager_->newStream(response_encoder_);
 
         HeaderMapPtr headers{new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}}};
+        decoder->decodeHeaders(std::move(headers), false);
+
+        data.drain(4);
+      }));
+
+  Buffer::OwnedImpl fake_input("1234");
+  conn_manager_->onData(fake_input, false);
+
+  EXPECT_EQ(0U, stats_.named_.downstream_rq_idle_timeout_.value());
+}
+
+// When the global timeout is configured, the timer is enabled before we receive
+// headers.
+TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutGlobal) {
+  stream_idle_timeout_ = std::chrono::milliseconds(10);
+  setup(false, "");
+
+  EXPECT_CALL(*codec_, dispatch(_))
+      .Times(1)
+      .WillRepeatedly(Invoke([&](Buffer::Instance& data) -> void {
+        Event::MockTimer* idle_timer =
+            new Event::MockTimer(&filter_callbacks_.connection_.dispatcher_);
+        EXPECT_CALL(*idle_timer, enableTimer(std::chrono::milliseconds(10)));
+        StreamDecoder* decoder = &conn_manager_->newStream(response_encoder_);
+
+        HeaderMapPtr headers{new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}}};
+        EXPECT_CALL(*idle_timer, enableTimer(std::chrono::milliseconds(10)));
+        decoder->decodeHeaders(std::move(headers), false);
+
+        data.drain(4);
+      }));
+
+  Buffer::OwnedImpl fake_input("1234");
+  conn_manager_->onData(fake_input, false);
+
+  EXPECT_EQ(0U, stats_.named_.downstream_rq_idle_timeout_.value());
+}
+
+// Per-route timeouts override the global stream idle timeout.
+TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutRouteOverride) {
+  stream_idle_timeout_ = std::chrono::milliseconds(10);
+  setup(false, "");
+  ON_CALL(route_config_provider_.route_config_->route_->route_entry_, idleTimeout())
+      .WillByDefault(Return(std::chrono::milliseconds(30)));
+
+  EXPECT_CALL(*codec_, dispatch(_))
+      .Times(1)
+      .WillRepeatedly(Invoke([&](Buffer::Instance& data) -> void {
+        Event::MockTimer* idle_timer =
+            new Event::MockTimer(&filter_callbacks_.connection_.dispatcher_);
+        EXPECT_CALL(*idle_timer, enableTimer(std::chrono::milliseconds(10)));
+        StreamDecoder* decoder = &conn_manager_->newStream(response_encoder_);
+
+        HeaderMapPtr headers{new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}}};
+        EXPECT_CALL(*idle_timer, enableTimer(std::chrono::milliseconds(30)));
         decoder->decodeHeaders(std::move(headers), false);
 
         data.drain(4);

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -44,7 +44,8 @@ public:
   MOCK_METHOD0(drainTimeout, std::chrono::milliseconds());
   MOCK_METHOD0(filterFactory, FilterChainFactory&());
   MOCK_METHOD0(generateRequestId, bool());
-  MOCK_METHOD0(idleTimeout, const absl::optional<std::chrono::milliseconds>&());
+  MOCK_METHOD0(idleTimeout, const absl::optional<std::chrono::milliseconds>());
+  MOCK_METHOD0(streamIdleTimeout, const absl::optional<std::chrono::milliseconds>());
   MOCK_METHOD0(routeConfigProvider, Router::RouteConfigProvider&());
   MOCK_METHOD0(serverName, const std::string&());
   MOCK_METHOD0(stats, ConnectionManagerStats&());

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -35,6 +35,14 @@ parseHttpConnectionManagerFromJson(const std::string& json_string) {
   return http_connection_manager;
 }
 
+envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager
+parseHttpConnectionManagerFromV2Yaml(const std::string& yaml) {
+  envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager
+      http_connection_manager;
+  MessageUtil::loadFromYaml(yaml, http_connection_manager);
+  return http_connection_manager;
+}
+
 class HttpConnectionManagerConfigTest : public testing::Test {
 public:
   NiceMock<Server::Configuration::MockFactoryContext> context_;
@@ -120,6 +128,23 @@ TEST_F(HttpConnectionManagerConfigTest, MiscConfig) {
               ContainerEq(config.tracingConfig()->request_headers_for_tags_));
   EXPECT_EQ(*context_.local_info_.address_, config.localAddress());
   EXPECT_EQ("foo", config.serverName());
+  EXPECT_EQ(5 * 60 * 1000, config.streamIdleTimeout().value().count());
+}
+
+// Validated that an explicit zero stream idle timeout disables.
+TEST_F(HttpConnectionManagerConfigTest, DisabledStreamIdleTimeout) {
+  const std::string yaml_string = R"EOF(
+  stat_prefix: ingress_http
+  stream_idle_timeout: 0s
+  route_config:
+    name: local_route
+  http_filters:
+  - name: envoy.router
+  )EOF";
+
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
+                                     date_provider_, route_config_provider_manager_);
+  EXPECT_FALSE(config.streamIdleTimeout());
 }
 
 TEST_F(HttpConnectionManagerConfigTest, SingleDateProvider) {

--- a/test/integration/idle_timeout_integration_test.cc
+++ b/test/integration/idle_timeout_integration_test.cc
@@ -9,11 +9,17 @@ public:
     config_helper_.addConfigModifier(
         [&](envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager& hcm)
             -> void {
-          auto* route_config = hcm.mutable_route_config();
-          auto* virtual_host = route_config->mutable_virtual_hosts(0);
-          auto* route = virtual_host->mutable_routes(0)->mutable_route();
-          route->mutable_idle_timeout()->set_seconds(0);
-          route->mutable_idle_timeout()->set_nanos(TimeoutMs * 1000 * 1000);
+          if (enable_global_idle_timeout_) {
+            hcm.mutable_stream_idle_timeout()->set_seconds(0);
+            hcm.mutable_stream_idle_timeout()->set_nanos(TimeoutMs * 1000 * 1000);
+          }
+          if (enable_per_stream_idle_timeout_) {
+            auto* route_config = hcm.mutable_route_config();
+            auto* virtual_host = route_config->mutable_virtual_hosts(0);
+            auto* route = virtual_host->mutable_routes(0)->mutable_route();
+            route->mutable_idle_timeout()->set_seconds(0);
+            route->mutable_idle_timeout()->set_nanos(TimeoutMs * 1000 * 1000);
+          }
           // For validating encode100ContinueHeaders() timer kick.
           hcm.set_proxy_100_continue(true);
         });
@@ -52,6 +58,8 @@ public:
   // TODO(htuch): This might require scaling for TSAN/ASAN/Valgrind/etc. Bump if
   // this is the cause of flakes.
   static constexpr uint64_t TimeoutMs = 200;
+  bool enable_global_idle_timeout_{};
+  bool enable_per_stream_idle_timeout_{true};
 };
 
 INSTANTIATE_TEST_CASE_P(Protocols, IdleTimeoutIntegrationTest,
@@ -60,6 +68,21 @@ INSTANTIATE_TEST_CASE_P(Protocols, IdleTimeoutIntegrationTest,
 
 // Per-stream idle timeout after having sent downstream headers.
 TEST_P(IdleTimeoutIntegrationTest, PerStreamIdleTimeoutAfterDownstreamHeaders) {
+  auto response = setupPerStreamIdleTimeoutTest();
+
+  waitForTimeout(*response);
+
+  EXPECT_FALSE(upstream_request_->complete());
+  EXPECT_EQ(0U, upstream_request_->bodyLength());
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("408", response->headers().Status()->value().c_str());
+  EXPECT_EQ("stream timeout", response->body());
+}
+
+// Global per-stream idle timeout applies if there is no per-stream idle timeout.
+TEST_P(IdleTimeoutIntegrationTest, GlobalPerStreamIdleTimeoutAfterDownstreamHeaders) {
+  enable_global_idle_timeout_ = true;
+  enable_per_stream_idle_timeout_ = false;
   auto response = setupPerStreamIdleTimeoutTest();
 
   waitForTimeout(*response);


### PR DESCRIPTION
This is a followup to #3841, where we introduce HCM-wide stream idle timeouts. This has two effects:

1. We can now timeout immediately after stream creation, potentially before receiving request
   headers and routing.

2. A default timeout can be configured across all routes. This is overridable on a per-route basis.

The default and overriding semantics are explained in the docs. Also added as a bonus some docs
about how timeouts interact more generally in Envoy.

Fixes #3853.

Risk Level: Low. While there is some change to the per-route vs. HCM wide semantics for stream idle
  timeouts, it's not anticipated this feature is in common use yet (it's only a couple of days since
  landing), and the caveats in #3841 with the new 5 minute default timeout should already apply.
Testing: Unit/integration tests added.

Signed-off-by: Harvey Tuch <htuch@google.com>