### PR TITLE
build: document missing dependency when building nghttp2 from sources.

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -36,6 +36,7 @@ On Ubuntu, run the following commands:
  apt-get install clang-format-5.0
  apt-get install autoconf
  apt-get install automake
+ apt-get install pkg-config
 ```
 
 On Fedora (maybe also other red hat distros), run the following:
@@ -53,6 +54,7 @@ brew install go
 brew install bazel
 brew install autoconf
 brew install automake
+brew install pkg-config
 ```
 
 Envoy compiles and passes tests with the version of clang installed by XCode 9.3.0:


### PR DESCRIPTION
*Risk Level*: n/a
*Testing*: Fixed build on CircleCI without pkg-config.
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Piotr Sikora <piotrsikora@google.com>