### PR TITLE
health check: allow request header formatting for HTTP health check request

### DIFF
--- a/api/envoy/api/v2/core/health_check.proto
+++ b/api/envoy/api/v2/core/health_check.proto
@@ -95,7 +95,9 @@ message HealthCheck {
     string service_name = 5;
 
     // Specifies a list of HTTP headers that should be added to each request that is sent to the
-    // health checked cluster.
+    // health checked cluster. For more information, including details on header value syntax, see
+    // the documentation on :ref:`custom request headers
+    // <config_http_conn_man_headers_custom_request_headers>`.
     repeated core.HeaderValueOption request_headers_to_add = 6;
 
     // If set, health checks will be made using http/2.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -14,6 +14,8 @@ Version history
 * health check: added support for :ref:`custom health check <envoy_api_field_core.HealthCheck.custom_health_check>`.
 * health check: added support for :ref:`specifying jitter as a percentage <envoy_api_field_core.HealthCheck.interval_jitter_percent>`.
 * health_check: added support for :ref:`health check event logging <arch_overview_health_check_logging>`.
+* health_check: added support for specifying :ref:`custom request headers <config_http_conn_man_headers_custom_request_headers>`
+  to HTTP health checker requests.
 * http: added support for a :ref:`per-stream idle timeout
   <envoy_api_field_route.RouteAction.idle_timeout>`. This defaults to 5 minutes; if you have
   other timeouts (e.g. connection idle timeout, upstream response per-retry) that are longer than

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -10,6 +10,7 @@
 #include "common/config/well_known_names.h"
 #include "common/grpc/common.h"
 #include "common/http/header_map_impl.h"
+#include "common/network/address_impl.h"
 #include "common/router/router.h"
 #include "common/upstream/host_utility.h"
 
@@ -104,7 +105,13 @@ HttpHealthCheckerImpl::HttpHealthCheckerImpl(const Cluster& cluster,
 
 HttpHealthCheckerImpl::HttpActiveHealthCheckSession::HttpActiveHealthCheckSession(
     HttpHealthCheckerImpl& parent, const HostSharedPtr& host)
-    : ActiveHealthCheckSession(parent, host), parent_(parent) {}
+    : ActiveHealthCheckSession(parent, host), parent_(parent),
+      hostname_(parent_.host_value_.empty() ? parent_.cluster_.info()->name()
+                                            : parent_.host_value_),
+      protocol_(parent_.codec_client_type_ == Http::CodecClient::Type::HTTP1
+                    ? Http::Protocol::Http11
+                    : Http::Protocol::Http2),
+      local_address_(std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1")) {}
 
 HttpHealthCheckerImpl::HttpActiveHealthCheckSession::~HttpActiveHealthCheckSession() {
   if (client_) {
@@ -133,9 +140,6 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onEvent(Network::Conne
   }
 }
 
-const RequestInfo::RequestInfoImpl
-    HttpHealthCheckerImpl::HttpActiveHealthCheckSession::REQUEST_INFO;
-
 void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onInterval() {
   if (!client_) {
     Upstream::Host::CreateConnectionData conn =
@@ -150,13 +154,15 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onInterval() {
 
   Http::HeaderMapImpl request_headers{
       {Http::Headers::get().Method, "GET"},
-      {Http::Headers::get().Host,
-       parent_.host_value_.empty() ? parent_.cluster_.info()->name() : parent_.host_value_},
+      {Http::Headers::get().Host, hostname_},
       {Http::Headers::get().Path, parent_.path_},
       {Http::Headers::get().UserAgent, Http::Headers::get().UserAgentValues.EnvoyHealthChecker}};
   Router::FilterUtility::setUpstreamScheme(request_headers, *parent_.cluster_.info());
-
-  parent_.request_headers_parser_->evaluateHeaders(request_headers, REQUEST_INFO);
+  RequestInfo::RequestInfoImpl request_info(protocol_);
+  request_info.setDownstreamLocalAddress(local_address_);
+  request_info.setDownstreamRemoteAddress(local_address_);
+  request_info.onUpstreamHostSelected(host_);
+  parent_.request_headers_parser_->evaluateHeaders(request_headers, request_info);
   request_encoder_->encodeHeaders(request_headers, true);
   request_encoder_ = nullptr;
 }

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -90,13 +90,14 @@ private:
       HttpActiveHealthCheckSession& parent_;
     };
 
-    static const RequestInfo::RequestInfoImpl REQUEST_INFO;
-
     ConnectionCallbackImpl connection_callback_impl_{*this};
     HttpHealthCheckerImpl& parent_;
     Http::CodecClientPtr client_;
     Http::StreamEncoder* request_encoder_{};
     Http::HeaderMapPtr response_headers_;
+    const std::string& hostname_;
+    const Http::Protocol protocol_;
+    Network::Address::InstanceConstSharedPtr local_address_;
     bool expect_reset_{};
   };
 


### PR DESCRIPTION
*Description*: 
This PR enables the use of header formatting pattern for HTTP health check request.
And while at this, the hostname initialization is moved to the `HttpActiveHealthCheckSession`'s constructor for consistency.

*Risk Level*: Low.
*Testing*: Unit test.
*Docs Changes*: Updated.
*Release Notes*: Added.

Fixes #3835

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>