### PR TITLE
build: Initial bazel build file changes for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ SOURCE_VERSION
 .cache
 .vimrc
 .vscode
+.vs

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -36,6 +36,35 @@ genrule(
 )
 
 config_setting(
+    name = "windows_x86_64",
+    values = {"cpu": "x64_windows"},
+)
+
+config_setting(
+    name = "windows_opt_build",
+    values = {
+        "cpu": "x64_windows",
+        "compilation_mode": "opt",
+    },
+)
+
+config_setting(
+    name = "windows_dbg_build",
+    values = {
+        "cpu": "x64_windows",
+        "compilation_mode": "dbg",
+    },
+)
+
+config_setting(
+    name = "windows_fastbuild_build",
+    values = {
+        "cpu": "x64_windows",
+        "compilation_mode": "fastbuild",
+    },
+)
+
+config_setting(
     name = "opt_build",
     values = {"compilation_mode": "opt"},
 )

--- a/bazel/external/libcircllhist.BUILD
+++ b/bazel/external/libcircllhist.BUILD
@@ -6,4 +6,8 @@ cc_library(
     ],
     includes = ["src"],
     visibility = ["//visibility:public"],
+    copts = select({
+            "@envoy//bazel:windows_x86_64": ["-DWIN32"],
+            "//conditions:default": [],
+           }),
 )

--- a/bazel/repositories.bat
+++ b/bazel/repositories.bat
@@ -1,0 +1,4 @@
+echo "Start"
+@ECHO OFF
+%BAZEL_SH% -c "./repositories.sh  %*"
+exit %ERRORLEVEL%

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -18,7 +18,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/bombela/backward-cpp",
     ),
     com_github_circonus_labs_libcircllhist = dict(
-        commit = "476687ac9cc636fc92ac3070246d757ae6854547",  # 2018-05-08
+        commit = "050da53a44dede7bda136b93a9aeef47bd91fa12",  # 2018-07-02
         remote = "https://github.com/circonus-labs/libcircllhist",
     ),
     com_github_cyan4973_xxhash = dict(

--- a/ci/build_setup.ps1
+++ b/ci/build_setup.ps1
@@ -1,0 +1,22 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+if ("$env:NUM_CPUS" -eq "") {
+  $env:NUM_CPUS = (Get-WmiObject -class Win32_computersystem).NumberOfLogicalProcessors
+}
+
+if ("$env:ENVOY_BAZEL_ROOT" -eq "") {
+  Write-Host "ENVOY_BAZEL_ROOT must be set!"
+  throw
+}
+
+mkdir -force "$env:ENVOY_BAZEL_ROOT" > $nul
+
+$env:ENVOY_SRCDIR = [System.IO.Path]::GetFullPath("$PSScriptRoot\..")
+
+echo "ENVOY_BAZEL_ROOT: $env:ENVOY_BAZEL_ROOT"
+echo "ENVOY_SRCDIR: $env:ENVOY_SRCDIR"
+
+$env:BAZEL_BASE_OPTIONS="--nomaster_bazelrc --output_base=$env:ENVOY_BAZEL_ROOT --bazelrc=$env:ENVOY_SRCDIR\windows\tools\bazel.rc --batch"
+$env:BAZEL_BUILD_OPTIONS="--strategy=Genrule=standalone --spawn_strategy=standalone --verbose_failures --action_env=HOME --action_env=PYTHONUSERBASE --jobs=$env:NUM_CPUS --show_task_finish $env:BAZEL_BUILD_EXTRA_OPTIONS"
+$env:BAZEL_TEST_OPTIONS="$env:BAZEL_BUILD_OPTIONS --test_env=HOME --test_env=PYTHONUSERBASE --test_env=UBSAN_OPTIONS=print_stacktrace=1 --cache_test_results=no --test_output=all $env:BAZEL_EXTRA_TEST_OPTIONS"

--- a/ci/build_setup.ps1
+++ b/ci/build_setup.ps1
@@ -17,6 +17,6 @@ $env:ENVOY_SRCDIR = [System.IO.Path]::GetFullPath("$PSScriptRoot\..")
 echo "ENVOY_BAZEL_ROOT: $env:ENVOY_BAZEL_ROOT"
 echo "ENVOY_SRCDIR: $env:ENVOY_SRCDIR"
 
-$env:BAZEL_BASE_OPTIONS="--nomaster_bazelrc --output_base=$env:ENVOY_BAZEL_ROOT --bazelrc=$env:ENVOY_SRCDIR\windows\tools\bazel.rc --batch"
-$env:BAZEL_BUILD_OPTIONS="--strategy=Genrule=standalone --spawn_strategy=standalone --verbose_failures --action_env=HOME --action_env=PYTHONUSERBASE --jobs=$env:NUM_CPUS --show_task_finish $env:BAZEL_BUILD_EXTRA_OPTIONS"
-$env:BAZEL_TEST_OPTIONS="$env:BAZEL_BUILD_OPTIONS --test_env=HOME --test_env=PYTHONUSERBASE --test_env=UBSAN_OPTIONS=print_stacktrace=1 --cache_test_results=no --test_output=all $env:BAZEL_EXTRA_TEST_OPTIONS"
+$env:BAZEL_BASE_OPTIONS="--nomaster_bazelrc --output_base=$env:ENVOY_BAZEL_ROOT --bazelrc=$env:ENVOY_SRCDIR\windows\tools\bazel.rc"
+$env:BAZEL_BUILD_OPTIONS="--strategy=Genrule=standalone --spawn_strategy=standalone --verbose_failures --jobs=$env:NUM_CPUS --show_task_finish $env:BAZEL_BUILD_EXTRA_OPTIONS"
+$env:BAZEL_TEST_OPTIONS="$env:BAZEL_BUILD_OPTIONS --cache_test_results=no --test_output=all $env:BAZEL_EXTRA_TEST_OPTIONS"

--- a/ci/do_ci.ps1
+++ b/ci/do_ci.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+. "$PSScriptRoot\build_setup.ps1"
+Write-Host "building using $env:NUM_CPUS CPUs"
+
+function bazel_debug_binary_build() {
+  echo "Building..."
+  pushd "$env:ENVOY_SRCDIR"
+    bazel  $env:BAZEL_BASE_OPTIONS.Split(" ") build $env:BAZEL_BUILD_OPTIONS.Split(" ") -c dbg "//source/exe:envoy-static"
+    $exit = $LASTEXITCODE
+    if ($exit -ne 0) {
+      popd
+      exit $exit
+    }
+  popd
+}
+
+echo "bazel debug build..."
+bazel_debug_binary_build

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -2,23 +2,37 @@ licenses(["notice"])  # Apache 2
 
 package(default_visibility = ["//visibility:public"])
 
+config_setting(
+    name = "windows_x86_64",
+    values = {"cpu": "x64_windows"},
+)
+
 cc_library(
     name = "ares",
-    srcs = ["thirdparty_build/lib/libcares.a"],
+    srcs = select({
+        ":windows_x86_64": ["thirdparty_build/lib/cares.lib"],
+        "//conditions:default": ["thirdparty_build/lib/libcares.a"],
+    }),
     hdrs = glob(["thirdparty_build/include/ares*.h"]),
     includes = ["thirdparty_build/include"],
 )
 
 cc_library(
     name = "benchmark",
-    srcs = ["thirdparty_build/lib/libbenchmark.a"],
+    srcs = select({
+        ":windows_x86_64": ["thirdparty_build/lib/benchmark.lib"],
+        "//conditions:default": ["thirdparty_build/lib/libbenchmark.a"],
+    }),
     hdrs = ["thirdparty_build/include/testing/base/public/benchmark.h"],
     includes = ["thirdparty_build/include"],
 )
 
 cc_library(
     name = "event",
-    srcs = ["thirdparty_build/lib/libevent.a"],
+    srcs = select({
+        ":windows_x86_64": ["thirdparty_build/lib/event.lib"],
+        "//conditions:default": ["thirdparty_build/lib/libevent.a"],
+    }),
     hdrs = glob(["thirdparty_build/include/event2/**/*.h"]),
     includes = ["thirdparty_build/include"],
 )
@@ -31,7 +45,10 @@ cc_library(
 
 cc_library(
     name = "luajit",
-    srcs = ["thirdparty_build/lib/libluajit-5.1.a"],
+    srcs = select({
+        ":windows_x86_64": ["thirdparty_build/lib/luajit.lib"],
+        "//conditions:default": ["thirdparty_build/lib/libluajit-5.1.a"],
+    }),
     hdrs = glob(["thirdparty_build/include/luajit-2.0/*"]),
     includes = ["thirdparty_build/include"],
     # TODO(mattklein123): We should strip luajit-2.0 here for consumers. However, if we do that
@@ -40,7 +57,10 @@ cc_library(
 
 cc_library(
     name = "nghttp2",
-    srcs = ["thirdparty_build/lib/libnghttp2.a"],
+    srcs = select({
+        ":windows_x86_64": ["thirdparty_build/lib/nghttp2.lib"],
+        "//conditions:default": ["thirdparty_build/lib/libnghttp2.a"],
+    }),
     hdrs = glob(["thirdparty_build/include/nghttp2/**/*.h"]),
     includes = ["thirdparty_build/include"],
 )
@@ -54,14 +74,20 @@ cc_library(
 
 cc_library(
     name = "yaml_cpp",
-    srcs = ["thirdparty_build/lib/libyaml-cpp.a"],
+    srcs = select({
+        ":windows_x86_64": glob(["thirdparty_build/lib/libyaml-cpp*.lib"]),
+        "//conditions:default": ["thirdparty_build/lib/libyaml-cpp.a"],
+    }),
     hdrs = glob(["thirdparty_build/include/yaml-cpp/**/*.h"]),
     includes = ["thirdparty_build/include"],
 )
 
 cc_library(
     name = "zlib",
-    srcs = ["thirdparty_build/lib/libz.a"],
+    srcs = select({
+        ":windows_x86_64": glob(["thirdparty_build/lib/zlibstaticd.lib"]),
+        "//conditions:default": ["thirdparty_build/lib/libz.a"],
+    }),
     hdrs = [
         "thirdparty_build/include/zconf.h",
         "thirdparty_build/include/zlib.h",

--- a/source/common/event/BUILD
+++ b/source/common/event/BUILD
@@ -57,10 +57,7 @@ envoy_cc_library(
     name = "libevent_lib",
     srcs = ["libevent.cc"],
     hdrs = ["libevent.h"],
-    external_deps = [
-        "event",
-        "event_pthreads",
-    ],
+    libevent_dep = 1,
     deps = [
         "//source/common/common:assert_lib",
         "//source/common/common:c_smart_ptr_lib",
@@ -71,10 +68,7 @@ envoy_cc_library(
     name = "dispatched_thread_lib",
     srcs = ["dispatched_thread.cc"],
     hdrs = ["dispatched_thread.h"],
-    external_deps = [
-        "event",
-        "event_pthreads",
-    ],
+    libevent_dep = 1,
     deps = [
         ":dispatcher_lib",
         "//include/envoy/event:dispatcher_interface",

--- a/source/common/filesystem/BUILD
+++ b/source/common/filesystem/BUILD
@@ -40,7 +40,7 @@ envoy_cc_library(
             "inotify/watcher_impl.h",
         ],
     }),
-    external_deps = ["event"],
+    libevent_dep = 1,
     strip_include_prefix = select({
         "@bazel_tools//tools/osx:darwin": "kqueue",
         "//conditions:default": "inotify",

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -9,6 +9,7 @@ load(
 load(
     "//source/extensions:all_extensions.bzl",
     "envoy_all_extensions",
+    "envoy_windows_extensions",
 )
 
 envoy_package()
@@ -37,7 +38,10 @@ envoy_cc_library(
         "//source/server:options_lib",
         "//source/server:server_lib",
         "//source/server:test_hooks_lib",
-    ] + envoy_all_extensions(),
+    ] + select({
+        "//bazel:windows_x86_64": envoy_windows_extensions(),
+        "//conditions:default": envoy_all_extensions(),
+    }),
 )
 
 envoy_cc_library(

--- a/source/extensions/all_extensions.bzl
+++ b/source/extensions/all_extensions.bzl
@@ -1,4 +1,4 @@
-load("@envoy_build_config//:extensions_build_config.bzl", "EXTENSIONS")
+load("@envoy_build_config//:extensions_build_config.bzl", "EXTENSIONS", "WINDOWS_EXTENSIONS")
 
 # Return all extensions to be compiled into Envoy.
 def envoy_all_extensions():
@@ -14,3 +14,17 @@ def envoy_all_extensions():
         all_extensions.append(path)
 
     return all_extensions
+
+def envoy_windows_extensions():
+    # These extensions are registered using the extension system but are required for the core
+    # Envoy build.
+    windows_extensions = [
+        "//source/extensions/transport_sockets/raw_buffer:config",
+        "//source/extensions/transport_sockets/ssl:config",
+    ]
+
+    # These extensions can be removed on a site specific basis.
+    for path in WINDOWS_EXTENSIONS.values():
+        windows_extensions.append(path)
+
+    return windows_extensions

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -95,3 +95,96 @@ EXTENSIONS = {
     "envoy.transport_sockets.alts":                     "//source/extensions/transport_sockets/alts:tsi_handshaker",
     "envoy.transport_sockets.capture":                  "//source/extensions/transport_sockets/capture:config",
 }
+
+WINDOWS_EXTENSIONS = {
+    #
+    # Access loggers
+    #
+
+    "envoy.access_loggers.file":                        "//source/extensions/access_loggers/file:config",
+    #"envoy.access_loggers.http_grpc":                   "//source/extensions/access_loggers/http_grpc:config",
+
+    #
+    # gRPC Credentials Plugins
+    #
+
+    #"envoy.grpc_credentials.file_based_metadata":      "//source/extensions/grpc_credentials/file_based_metadata:config",
+
+    #
+    # Health checkers
+    #
+
+    #"envoy.health_checkers.redis":                      "//source/extensions/health_checkers/redis:config",
+
+    #
+    # HTTP filters
+    #
+
+    #"envoy.filters.http.buffer":                        "//source/extensions/filters/http/buffer:config",
+    #"envoy.filters.http.cors":                          "//source/extensions/filters/http/cors:config",
+    #"envoy.filters.http.dynamo":                        "//source/extensions/filters/http/dynamo:config",
+    #"envoy.filters.http.ext_authz":                     "//source/extensions/filters/http/ext_authz:config",
+    #"envoy.filters.http.fault":                         "//source/extensions/filters/http/fault:config",
+    #"envoy.filters.http.grpc_http1_bridge":             "//source/extensions/filters/http/grpc_http1_bridge:config",
+    #"envoy.filters.http.grpc_json_transcoder":          "//source/extensions/filters/http/grpc_json_transcoder:config",
+    #"envoy.filters.http.grpc_web":                      "//source/extensions/filters/http/grpc_web:config",
+    #"envoy.filters.http.gzip":                          "//source/extensions/filters/http/gzip:config",
+    #"envoy.filters.http.health_check":                  "//source/extensions/filters/http/health_check:config",
+    #"envoy.filters.http.ip_tagging":                    "//source/extensions/filters/http/ip_tagging:config",
+    #"envoy.filters.http.lua":                           "//source/extensions/filters/http/lua:config",
+    #"envoy.filters.http.ratelimit":                     "//source/extensions/filters/http/ratelimit:config",
+    #"envoy.filters.http.rbac":                          "//source/extensions/filters/http/rbac:config",
+    #"envoy.filters.http.router":                        "//source/extensions/filters/http/router:config",
+    #"envoy.filters.http.squash":                        "//source/extensions/filters/http/squash:config",
+
+    #
+    # Listener filters
+    #
+
+    # NOTE: The proxy_protocol filter is implicitly loaded if proxy_protocol functionality is
+    #       configured on the listener. Do not remove it in that case or configs will fail to load.
+    "envoy.filters.listener.proxy_protocol":            "//source/extensions/filters/listener/proxy_protocol:config",
+
+    # NOTE: The original_dst filter is implicitly loaded if original_dst functionality is
+    #       configured on the listener. Do not remove it in that case or configs will fail to load.
+    #"envoy.filters.listener.original_dst":              "//source/extensions/filters/listener/original_dst:config",
+
+    "envoy.filters.listener.tls_inspector":             "//source/extensions/filters/listener/tls_inspector:config",
+
+    #
+    # Network filters
+    #
+
+    "envoy.filters.network.client_ssl_auth":            "//source/extensions/filters/network/client_ssl_auth:config",
+    #"envoy.filters.network.echo":                       "//source/extensions/filters/network/echo:config",
+    #"envoy.filters.network.ext_authz":                  "//source/extensions/filters/network/ext_authz:config",
+    #"envoy.filters.network.http_connection_manager":    "//source/extensions/filters/network/http_connection_manager:config",
+    #"envoy.filters.network.mongo_proxy":                "//source/extensions/filters/network/mongo_proxy:config",
+    #"envoy.filters.network.redis_proxy":                "//source/extensions/filters/network/redis_proxy:config",
+    #"envoy.filters.network.ratelimit":                  "//source/extensions/filters/network/ratelimit:config",
+    "envoy.filters.network.tcp_proxy":                  "//source/extensions/filters/network/tcp_proxy:config",
+    # TODO(zuercher): switch to config target once a filter exists
+    #"envoy.filters.network.thrift_proxy":               "//source/extensions/filters/network/thrift_proxy:transport_lib",
+
+    #
+    # Stat sinks
+    #
+
+    #"envoy.stat_sinks.dog_statsd":                      "//source/extensions/stat_sinks/dog_statsd:config",
+    #"envoy.stat_sinks.metrics_service":                 "//source/extensions/stat_sinks/metrics_service:config",
+    #"envoy.stat_sinks.statsd":                          "//source/extensions/stat_sinks/statsd:config",
+
+    #
+    # Tracers
+    #
+
+    #"envoy.tracers.dynamic_ot":                         "//source/extensions/tracers/dynamic_ot:config",
+    #"envoy.tracers.lightstep":                          "//source/extensions/tracers/lightstep:config",
+    #"envoy.tracers.zipkin":                             "//source/extensions/tracers/zipkin:config",
+
+    #
+    # Transport sockets
+    #
+
+    #"envoy.transport_sockets.capture":                  "//source/extensions/transport_sockets/capture:config",
+}

--- a/windows/setup/workstation_setup.ps1
+++ b/windows/setup/workstation_setup.ps1
@@ -3,7 +3,7 @@ $ProgressPreference="SilentlyContinue"
 
 trap { $host.SetShouldExit(1) }
 
-Invoke-WebRequest -UseBasicParsing "https://aka.ms/vs/15/release/vs_buildtools.exe" -OutFile "$env:TEMP\vs_buildtools.exe"
+Start-BitsTransfer "https://aka.ms/vs/15/release/vs_buildtools.exe" "$env:TEMP\vs_buildtools.exe"
 
 # Install VS Build Tools in a directory without spaces to work around: https://github.com/bazelbuild/bazel/issues/4496
 # otherwise none of the go code will build (c++ is fine)

--- a/windows/setup/workstation_setup.ps1
+++ b/windows/setup/workstation_setup.ps1
@@ -1,0 +1,54 @@
+$ErrorActionPreference = "Stop";
+$ProgressPreference="SilentlyContinue"
+
+trap { $host.SetShouldExit(1) }
+
+Invoke-WebRequest -UseBasicParsing "https://aka.ms/vs/15/release/vs_buildtools.exe" -OutFile "$env:TEMP\vs_buildtools.exe"
+
+# Install VS Build Tools in a directory without spaces to work around: https://github.com/bazelbuild/bazel/issues/4496
+# otherwise none of the go code will build (c++ is fine)
+
+$vsInstallDir="c:\VSBuildTools\2017"
+echo "Installing VS Build Tools..."
+cmd.exe /s /c "$env:TEMP\vs_buildtools.exe --installPath $vsInstallDir --passive --wait --norestart --nocache --add Microsoft.VisualStudio.Component.VC.CoreBuildTools --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK --add Microsoft.VisualStudio.Component.Windows10SDK.17134"
+
+if ($LASTEXITCODE -ne 0) {
+	echo "VS Build Tools install failed: $LASTEXITCODE"
+	exit $LASTEXITCODE
+}
+Remove-Item "$env:TEMP\vs_buildtools.exe"
+echo "Done"
+
+Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+
+choco install make bazel cmake ninja git -y
+if ($LASTEXITCODE -ne 0) {
+	echo "choco install failed: $LASTEXITCODE"
+	exit $LASTEXITCODE
+}
+
+$envoyBazelRootDir = "c:\_eb"
+
+$env:ENVOY_BAZEL_ROOT=$envoyBazelRootDir
+setx ENVOY_BAZEL_ROOT $envoyBazelRootDir > $nul
+if ($LASTEXITCODE -ne 0) {
+	exit $LASTEXITCODE
+}
+
+$env:PATH ="$env:PATH;c:\tools\msys64\usr\bin;c:\make\bin;c:\Program Files\CMake\bin;C:\Python27;c:\programdata\chocolatey\bin;C:\Program Files\Git\bin"
+setx PATH $env:PATH > $nul
+if ($LASTEXITCODE -ne 0) {
+	exit $LASTEXITCODE
+}
+
+$env:BAZEL_VC="$vsInstallDir\VC"
+setx BAZEL_VC $env:BAZEL_VC > $nul
+if ($LASTEXITCODE -ne 0) {
+	exit $LASTEXITCODE
+}
+
+$env:BAZEL_SH="C:\tools\msys64\usr\bin\bash.exe"
+setx BAZEL_SH $env:BAZEL_SH > $nul
+if ($LASTEXITCODE -ne 0) {
+	exit $LASTEXITCODE
+}

--- a/windows/tools/bazel.rc
+++ b/windows/tools/bazel.rc
@@ -1,0 +1,6 @@
+# Windows/Envoy specific Bazel build/test options.
+
+build --experimental_shortened_obj_file_path
+build --define signal_trace=disabled
+build --define hot_restart=disabled
+build --define tcmalloc=disabled

--- a/windows/tools/bazel.rc
+++ b/windows/tools/bazel.rc
@@ -1,5 +1,6 @@
 # Windows/Envoy specific Bazel build/test options.
 
+// TODO: remove experimental_shortened_obj_file_path for Bazel 0.16.0
 build --experimental_shortened_obj_file_path
 build --define signal_trace=disabled
 build --define hot_restart=disabled


### PR DESCRIPTION
*Description*:
This is the first step in breaking up #3786 into smaller chunks. This contains the Bazel config / compiler options to allow Envoy to build on Windows. Future PRs will address the external deps build scripts and PGV.

*Risk Level*:
Low
*Testing*:
Ran `bazel build //source/exe:envoy-static` and `bazel test //test/...` on Linux
*Docs Changes*:
None
*Release Notes*:
None
