### PR TITLE
grpc_json: add string conversion necessary for Google import

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -437,9 +437,13 @@ void JsonTranscoderFilter::buildResponseFromHttpBodyOutput(Http::HeaderMap& resp
       Buffer::ZeroCopyInputStreamImpl stream(std::move(frame.data_));
       http_body.ParseFromZeroCopyStream(&stream);
       const auto& body = http_body.data();
-      data.add(body);
+
+      // TODO(mrice32): This string conversion is currently required because body has a different
+      // type within Google. Remove when the string types merge.
+      data.add(ProtobufTypes::String(body));
+
       response_headers.insertContentType().value(http_body.content_type());
-      response_headers.insertContentLength().value(body.length());
+      response_headers.insertContentLength().value(body.size());
       return;
     }
   }


### PR DESCRIPTION
*Description*: String conversion will reduce to an extra move in the OSS world.

cc @htuch 

*Risk Level*: Low
*Testing*: N/A
*Docs Changes*: N/A
*Release Notes*: N/A
