### PR TITLE
lc trie: fix memory leak.

### DIFF
--- a/source/common/network/lc_trie.h
+++ b/source/common/network/lc_trie.h
@@ -459,6 +459,7 @@ private:
 
       // The value of next_free_index is the final size of the trie_.
       trie_.resize(next_free_index);
+      trie_.shrink_to_fit();
     }
 
     // Thin wrapper around computeBranch output to facilitate code readability.


### PR DESCRIPTION
*Risk Level*: Low
*Testing*: curl -s 127.0.0.1:<admin_port>/stats | grep server.memory
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Piotr Sikora <piotrsikora@google.com>