### PR TITLE
health_check: remove deprecated endpoint field

### DIFF
--- a/api/envoy/config/filter/http/health_check/v2/health_check.proto
+++ b/api/envoy/config/filter/http/health_check/v2/health_check.proto
@@ -33,8 +33,6 @@ message HealthCheck {
 
   // Specifies a set of health check request headers to match on. The health check filter will
   // check a request’s headers against all the specified headers. To specify the health check
-  // endpoint, set the ``:path`` header to match on. Note that if the
-  // :ref:`endpoint <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.endpoint>`
-  // field is set, it will overwrite any ``:path`` header to match.
+  // endpoint, set the ``:path`` header to match on.
   repeated envoy.api.v2.route.HeaderMatcher headers = 5;
 }

--- a/api/envoy/config/filter/http/health_check/v2/health_check.proto
+++ b/api/envoy/config/filter/http/health_check/v2/health_check.proto
@@ -19,11 +19,8 @@ message HealthCheck {
   // Specifies whether the filter operates in pass through mode or not.
   google.protobuf.BoolValue pass_through_mode = 1 [(validate.rules).message.required = true];
 
-  // Specifies the incoming HTTP endpoint that should be considered the
-  // health check endpoint. For example */healthcheck*.
-  // Note that this field is deprecated in favor of
-  // :ref:`headers <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.headers>`.
-  string endpoint = 2 [deprecated = true];
+  reserved 2;
+  reserved "endpoint";
 
   // If operating in pass through mode, the amount of time in milliseconds
   // that the filter should cache the upstream response.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -91,8 +91,7 @@ Version history
 * health check: health check connections can now be configured to use http/2.
 * health check http filter: added
   :ref:`generic header matching <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.headers>`
-  to trigger health check response. Deprecated the
-  :ref:`endpoint option <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.endpoint>`.
+  to trigger health check response. Deprecated the endpoint option.
 * http: filters can now optionally support
   :ref:`virtual host <envoy_api_field_route.VirtualHost.per_filter_config>`,
   :ref:`route <envoy_api_field_route.Route.per_filter_config>`, and

--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -302,7 +302,10 @@ void FilterJson::translateHealthCheckFilter(
 
   JSON_UTIL_SET_BOOL(json_config, proto_config, pass_through_mode);
   JSON_UTIL_SET_DURATION(json_config, proto_config, cache_time);
-  JSON_UTIL_SET_STRING(json_config, proto_config, endpoint);
+  std::string endpoint = json_config.getString("endpoint");
+  auto& header = *proto_config.add_headers();
+  header.set_name(":path");
+  header.set_exact_match(endpoint);
 }
 
 void FilterJson::translateGrpcJsonTranscoder(

--- a/source/extensions/filters/http/health_check/config.cc
+++ b/source/extensions/filters/http/health_check/config.cc
@@ -20,25 +20,12 @@ Http::FilterFactoryCb HealthCheckFilterConfig::createFilterFactoryFromProtoTyped
 
   const bool pass_through_mode = proto_config.pass_through_mode().value();
   const int64_t cache_time_ms = PROTOBUF_GET_MS_OR_DEFAULT(proto_config, cache_time, 0);
-  const std::string hc_endpoint = proto_config.endpoint();
 
   auto header_match_data = std::make_shared<std::vector<Http::HeaderUtility::HeaderData>>();
 
-  // TODO(mrice32): remove endpoint field at the end of the 1.7.0 deprecation cycle.
-  const bool endpoint_set = !proto_config.endpoint().empty();
-  if (endpoint_set) {
-    envoy::api::v2::route::HeaderMatcher matcher;
-    matcher.set_name(Http::Headers::get().Path.get());
-    matcher.set_exact_match(proto_config.endpoint());
-    header_match_data->emplace_back(matcher);
-  }
-
   for (const envoy::api::v2::route::HeaderMatcher& matcher : proto_config.headers()) {
     Http::HeaderUtility::HeaderData single_header_match(matcher);
-    // Ignore any path header matchers if the endpoint field has been set.
-    if (!(endpoint_set && single_header_match.name_ == Http::Headers::get().Path)) {
-      header_match_data->push_back(std::move(single_header_match));
-    }
+    header_match_data->push_back(std::move(single_header_match));
   }
 
   if (!pass_through_mode && cache_time_ms) {


### PR DESCRIPTION
*Description*: Removes the deprecated endpoint field for 1.8 release.

*Risk Level*: Low
*Testing*: N/A
*Docs Changes*: N/A
*Release Notes*: Already listed under 1.7.

Fixes #3717 
