### PR TITLE
health check: Remove the deprecated redis_health_check field

### DIFF
--- a/api/envoy/api/v2/core/health_check.proto
+++ b/api/envoy/api/v2/core/health_check.proto
@@ -152,15 +152,16 @@ message HealthCheck {
     // TCP health check.
     TcpHealthCheck tcp_health_check = 9;
 
-    // Redis health check.
-    RedisHealthCheck redis_health_check = 10;
-
     // gRPC health check.
     GrpcHealthCheck grpc_health_check = 11;
 
     // Custom health check.
     CustomHealthCheck custom_health_check = 13;
   }
+
+  reserved 10; // redis_health_check is deprecated by :ref:`custom_health_check
+               // <envoy_api_field_core.HealthCheck.custom_health_check>`
+  reserved "redis_health_check";
 
   // The "no traffic interval" is a special health check interval that is used when a cluster has
   // never had traffic routed to it. This lower interval allows cluster information to be kept up to

--- a/docs/root/configuration/health_checkers/redis.rst
+++ b/docs/root/configuration/health_checkers/redis.rst
@@ -3,12 +3,22 @@
 Redis
 =====
 
-The Redis health checker is a custom health checker which checks Redis upstream hosts. It sends
-a Redis PING command and expect a PONG response. The upstream Redis server can respond with
-anything other than PONG to cause an immediate active health check failure. Optionally, Envoy can
-perform EXISTS on a user-specified key. If the key does not exist it is considered a passing healthcheck.
-This allows the user to mark a Redis instance for maintenance by setting the specified
-:ref:`key <envoy_api_field_config.health_checker.redis.v2.Redis.key>` to any value and waiting for
-traffic to drain.
+The Redis health checker is a custom health checker (with :code:`envoy.health_checkers.redis` as name)
+which checks Redis upstream hosts. It sends a Redis PING command and expect a PONG response. The upstream
+Redis server can respond with anything other than PONG to cause an immediate active health check failure.
+Optionally, Envoy can perform EXISTS on a user-specified key. If the key does not exist it is considered a
+passing healthcheck. This allows the user to mark a Redis instance for maintenance by setting the
+specified :ref:`key <envoy_api_field_config.health_checker.redis.v2.Redis.key>` to any value and waiting
+for traffic to drain.
+
+An example setting for :ref:`custom_health_check <envoy_api_msg_core.HealthCheck.CustomHealthCheck>` as a
+Redis health checker is shown below:
+
+.. code-block:: yaml
+
+  custom_health_check:
+    name: envoy.health_checkers.redis
+      config:
+        key: foo
 
 * :ref:`v2 API reference <envoy_api_msg_core.HealthCheck.CustomHealthCheck>`

--- a/docs/root/intro/arch_overview/redis.rst
+++ b/docs/root/intro/arch_overview/redis.rst
@@ -43,8 +43,10 @@ For filter configuration details, see the Redis proxy filter
 The corresponding cluster definition should be configured with
 :ref:`ring hash load balancing <config_cluster_manager_cluster_lb_type>`.
 
-If active healthchecking is desired, the cluster should be configured with a
-:ref:`Redis healthcheck <config_cluster_manager_cluster_hc>`.
+If :ref:`active health checking <arch_overview_health_checking>` is desired, the
+cluster should be configured with a :ref:`custom health check
+<envoy_api_field_core.HealthCheck.custom_health_check>` which configured as a
+:ref:`Redis health checker <config_health_checkers_redis>`.
 
 If passive healthchecking is desired, also configure
 :ref:`outlier detection <config_cluster_manager_cluster_outlier_detection_summary>`.

--- a/source/common/config/cds_json.cc
+++ b/source/common/config/cds_json.cc
@@ -53,9 +53,11 @@ void CdsJson::translateHealthCheck(const Json::Object& json_health_check,
     }
   } else {
     ASSERT(hc_type == "redis");
-    auto* redis_health_check = health_check.mutable_redis_health_check();
+    auto* redis_health_check = health_check.mutable_custom_health_check();
+    redis_health_check->set_name("envoy.health_checkers.redis");
     if (json_health_check.hasObject("redis_key")) {
-      redis_health_check->set_key(json_health_check.getString("redis_key"));
+      redis_health_check->mutable_config()->MergeFrom(
+          MessageUtil::keyValueStruct("key", json_health_check.getString("redis_key")));
     }
   }
 }

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -65,16 +65,10 @@ HealthCheckerFactory::create(const envoy::api::v2::core::HealthCheck& hc_config,
     }
     return std::make_shared<ProdGrpcHealthCheckerImpl>(cluster, hc_config, dispatcher, runtime,
                                                        random, std::move(event_logger));
-  // Deprecated redis_health_check, preserving using old config until it is removed.
-  case envoy::api::v2::core::HealthCheck::HealthCheckerCase::kRedisHealthCheck:
-    ENVOY_LOG(warn, "redis_health_check is deprecated, use custom_health_check instead");
-    FALLTHRU;
   case envoy::api::v2::core::HealthCheck::HealthCheckerCase::kCustomHealthCheck: {
     auto& factory =
         Config::Utility::getAndCheckFactory<Server::Configuration::CustomHealthCheckerFactory>(
-            hc_config.has_redis_health_check()
-                ? Extensions::HealthCheckers::HealthCheckerNames::get().RedisHealthChecker
-                : std::string(hc_config.custom_health_check().name()));
+            std::string(hc_config.custom_health_check().name()));
     std::unique_ptr<Server::Configuration::HealthCheckerFactoryContext> context(
         new HealthCheckerFactoryContextImpl(cluster, runtime, random, dispatcher,
                                             std::move(event_logger)));

--- a/source/extensions/health_checkers/redis/utility.h
+++ b/source/extensions/health_checkers/redis/utility.h
@@ -10,20 +10,8 @@ namespace RedisHealthChecker {
 
 namespace {
 
-static const envoy::config::health_checker::redis::v2::Redis translateFromRedisHealthCheck(
-    const envoy::api::v2::core::HealthCheck::RedisHealthCheck& deprecated_redis_config) {
-  envoy::config::health_checker::redis::v2::Redis config;
-  config.set_key(deprecated_redis_config.key());
-  return config;
-}
-
 static const envoy::config::health_checker::redis::v2::Redis
 getRedisHealthCheckConfig(const envoy::api::v2::core::HealthCheck& hc_config) {
-  // TODO(dio): redis_health_check is deprecated.
-  if (hc_config.has_redis_health_check()) {
-    return translateFromRedisHealthCheck(hc_config.redis_health_check());
-  }
-
   ProtobufTypes::MessagePtr config =
       ProtobufTypes::MessagePtr{new envoy::config::health_checker::redis::v2::Redis()};
   MessageUtil::jsonConvert(hc_config.custom_health_check().config(), *config);

--- a/test/extensions/health_checkers/redis/config_test.cc
+++ b/test/extensions/health_checkers/redis/config_test.cc
@@ -39,6 +39,29 @@ TEST(HealthCheckerFactoryTest, createRedis) {
               .get()));
 }
 
+TEST(HealthCheckerFactoryTest, createRedisWithoutKey) {
+  const std::string yaml = R"EOF(
+    timeout: 1s
+    interval: 1s
+    no_traffic_interval: 5s
+    interval_jitter: 1s
+    unhealthy_threshold: 1
+    healthy_threshold: 1
+    custom_health_check:
+      name: envoy.health_checkers.redis
+      config:
+    )EOF";
+
+  NiceMock<Server::Configuration::MockHealthCheckerFactoryContext> context;
+
+  RedisHealthCheckerFactory factory;
+  EXPECT_NE(
+      nullptr,
+      dynamic_cast<CustomRedisHealthChecker*>(
+          factory.createCustomHealthChecker(Upstream::parseHealthCheckFromV2Yaml(yaml), context)
+              .get()));
+}
+
 TEST(HealthCheckerFactoryTest, createRedisViaUpstreamHealthCheckerFactory) {
   const std::string yaml = R"EOF(
     timeout: 1s
@@ -59,33 +82,6 @@ TEST(HealthCheckerFactoryTest, createRedisViaUpstreamHealthCheckerFactory) {
   Event::MockDispatcher dispatcher;
   AccessLog::MockAccessLogManager log_manager;
   EXPECT_NE(nullptr, dynamic_cast<CustomRedisHealthChecker*>(
-                         Upstream::HealthCheckerFactory::create(
-                             Upstream::parseHealthCheckFromV2Yaml(yaml), cluster, runtime, random,
-                             dispatcher, log_manager)
-                             .get()));
-}
-
-TEST(HealthCheckerFactoryTest, createRedisWithDeprecatedConfig) {
-  const std::string yaml = R"EOF(
-    timeout: 1s
-    interval: 1s
-    no_traffic_interval: 5s
-    interval_jitter: 1s
-    unhealthy_threshold: 1
-    healthy_threshold: 1
-    # Using the deprecated redis_health_check should work.
-    redis_health_check:
-      key: foo
-    )EOF";
-
-  NiceMock<Upstream::MockCluster> cluster;
-  Runtime::MockLoader runtime;
-  Runtime::MockRandomGenerator random;
-  Event::MockDispatcher dispatcher;
-  AccessLog::MockAccessLogManager log_manager;
-  EXPECT_NE(nullptr, dynamic_cast<CustomRedisHealthChecker*>(
-                         // Always use Upstream's HealthCheckerFactory when creating instance using
-                         // deprecated config.
                          Upstream::HealthCheckerFactory::create(
                              Upstream::parseHealthCheckFromV2Yaml(yaml), cluster, runtime, random,
                              dispatcher, log_manager)


### PR DESCRIPTION
*Description*: This removes the deprecated `redis_health_check` field and only allow setting 
redis health check via the custom health checker config.

*Risk Level*: Low
*Testing*: Removed tests related to the deprecated field.
*Docs Changes*: Updated
*Release Notes*: Already listed under 1.7.

Fixes #3713

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>