### PR TITLE
Refactor address APIs for deeper errno latching

### DIFF
--- a/include/envoy/network/address.h
+++ b/include/envoy/network/address.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <tuple>
 
 #include "envoy/common/pure.h"
 
@@ -128,19 +129,19 @@ public:
    * Bind a socket to this address. The socket should have been created with a call to socket() on
    * an Instance of the same address family.
    * @param fd supplies the platform socket handle.
-   * @return 0 for success and -1 for failure. The error code associated with a failure will
-   * be accessible in a plaform dependent fashion (e.g. errno for Unix platforms).
+   * @return a tuple of <0, errno> for success and <-1, errno> for failure. If the call is
+   *   successful, errno shouldn't be used.
    */
-  virtual int bind(int fd) const PURE;
+  virtual std::tuple<int, int> bind(int fd) const PURE;
 
   /**
    * Connect a socket to this address. The socket should have been created with a call to socket()
    * on this object.
    * @param fd supplies the platform socket handle.
-   * @return 0 for success and -1 for failure. The error code associated with a failure will
-   * be accessible in a plaform dependent fashion (e.g. errno for Unix platforms).
+   * @return a tuple of <0, errno> for success and <-1, errno> for failure. If the call is
+   *   successful, errno shouldn't be used.
    */
-  virtual int connect(int fd) const PURE;
+  virtual std::tuple<int, int> connect(int fd) const PURE;
 
   /**
    * @return the IP address information IFF type() == Type::Ip, otherwise nullptr.

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -91,8 +91,8 @@ public:
 
   // Network::Address::Instance
   bool operator==(const Instance& rhs) const override;
-  int bind(int fd) const override;
-  int connect(int fd) const override;
+  std::tuple<int, int> bind(int fd) const override;
+  std::tuple<int, int> connect(int fd) const override;
   const Ip* ip() const override { return &ip_; }
   int socket(SocketType type) const override;
 
@@ -151,8 +151,8 @@ public:
 
   // Network::Address::Instance
   bool operator==(const Instance& rhs) const override;
-  int bind(int fd) const override;
-  int connect(int fd) const override;
+  std::tuple<int, int> bind(int fd) const override;
+  std::tuple<int, int> connect(int fd) const override;
   const Ip* ip() const override { return &ip_; }
   int socket(SocketType type) const override;
 
@@ -208,8 +208,8 @@ public:
 
   // Network::Address::Instance
   bool operator==(const Instance& rhs) const override;
-  int bind(int fd) const override;
-  int connect(int fd) const override;
+  std::tuple<int, int> bind(int fd) const override;
+  std::tuple<int, int> connect(int fd) const override;
   const Ip* ip() const override { return nullptr; }
   int socket(SocketType type) const override;
 

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -16,11 +16,11 @@ namespace Envoy {
 namespace Network {
 
 void ListenSocketImpl::doBind() {
-  int rc = local_address_->bind(fd_);
-  if (rc == -1) {
+  const std::tuple<int, int> result = local_address_->bind(fd_);
+  if (std::get<0>(result) == -1) {
     close();
-    throw EnvoyException(
-        fmt::format("cannot bind '{}': {}", local_address_->asString(), strerror(errno)));
+    throw EnvoyException(fmt::format("cannot bind '{}': {}", local_address_->asString(),
+                                     strerror(std::get<1>(result))));
   }
   if (local_address_->type() == Address::Type::Ip && local_address_->ip()->port() == 0) {
     // If the port we bind is zero, then the OS will pick a free port for us (assuming there are

--- a/source/extensions/stat_sinks/common/statsd/statsd.cc
+++ b/source/extensions/stat_sinks/common/statsd/statsd.cc
@@ -23,7 +23,7 @@ Writer::Writer(Network::Address::InstanceConstSharedPtr address) {
   fd_ = address->socket(Network::Address::SocketType::Datagram);
   ASSERT(fd_ != -1);
 
-  int rc = address->connect(fd_);
+  const int rc = std::get<0>(address->connect(fd_));
   ASSERT(rc != -1);
 }
 

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -64,8 +64,9 @@ void testSocketBindAndConnect(Network::Address::IpVersion ip_version, bool v6onl
   }
 
   // Bind the socket to the desired address and port.
-  const int rc = addr_port->bind(listen_fd);
-  const int err = errno;
+  const std::tuple<int, int> result = addr_port->bind(listen_fd);
+  const int rc = std::get<0>(result);
+  const int err = std::get<1>(result);
   ASSERT_EQ(rc, 0) << addr_port->asString() << "\nerror: " << strerror(err) << "\nerrno: " << err;
 
   // Do a bare listen syscall. Not bothering to accept connections as that would
@@ -85,8 +86,9 @@ void testSocketBindAndConnect(Network::Address::IpVersion ip_version, bool v6onl
     makeFdBlocking(client_fd);
 
     // Connect to the server.
-    const int rc = addr_port->connect(client_fd);
-    const int err = errno;
+    const std::tuple<int, int> result = addr_port->connect(client_fd);
+    const int rc = std::get<0>(result);
+    const int err = std::get<1>(result);
     ASSERT_EQ(rc, 0) << addr_port->asString() << "\nerror: " << strerror(err) << "\nerrno: " << err;
   };
 
@@ -314,8 +316,9 @@ TEST(PipeInstanceTest, UnlinksExistingFile) {
     ASSERT_GE(listen_fd, 0) << address.asString();
     ScopedFdCloser closer(listen_fd);
 
-    const int rc = address.bind(listen_fd);
-    const int err = errno;
+    const std::tuple<int, int> result = address.bind(listen_fd);
+    const int rc = std::get<0>(result);
+    const int err = std::get<1>(result);
     ASSERT_EQ(rc, 0) << address.asString() << "\nerror: " << strerror(err) << "\nerrno: " << err;
   };
 

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -359,8 +359,8 @@ public:
   }
   const std::string& asString() const override { return antagonistic_name_; }
   const std::string& logicalName() const override { return antagonistic_name_; }
-  int bind(int fd) const override { return instance_.bind(fd); }
-  int connect(int fd) const override { return instance_.connect(fd); }
+  std::tuple<int, int> bind(int fd) const override { return instance_.bind(fd); }
+  std::tuple<int, int> connect(int fd) const override { return instance_.connect(fd); }
   const Address::Ip* ip() const override { return instance_.ip(); }
   int socket(Address::SocketType type) const override { return instance_.socket(type); }
   Address::Type type() const override { return instance_.type(); }

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -409,8 +409,8 @@ public:
     return asString() == other.asString();
   }
 
-  MOCK_CONST_METHOD1(bind, int(int));
-  MOCK_CONST_METHOD1(connect, int(int));
+  MOCK_CONST_METHOD1(bind, std::tuple<int, int>(int));
+  MOCK_CONST_METHOD1(connect, std::tuple<int, int>(int));
   MOCK_CONST_METHOD0(ip, Address::Ip*());
   MOCK_CONST_METHOD1(socket, int(Address::SocketType));
   MOCK_CONST_METHOD0(type, Address::Type());


### PR DESCRIPTION
*Description*:
The `errno` set by a syscall can be overwritten by code (e.g. logging) as it propagates up through the call stack. This PR refactors the `bind` and `connect` methods in the `address` API to allow for returning the `errno` from deeper down the call stack i.e. as soon as a syscall is performed. See #3819 for more information.

*Risk Level*: Low
*Testing*: `bazel test //test/... --test_env=ENVOY_IP_TEST_VERSIONS=v4only` runs without failures
*Docs Changes*: N/A
*Release Notes*: N/A

/cc @alyssawilk @mattklein123