### PR TITLE
api: ensure HeaderValue keys are non-empty.

### DIFF
--- a/api/envoy/api/v2/core/base.proto
+++ b/api/envoy/api/v2/core/base.proto
@@ -133,7 +133,7 @@ enum RequestMethod {
 // Header name/value pair.
 message HeaderValue {
   // Header name.
-  string key = 1;
+  string key = 1 [(validate.rules).string.min_bytes = 1];
 
   // Header value.
   //

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -161,6 +161,7 @@ envoy_cc_fuzz_test(
     corpus = "server_corpus",
     deps = [
         "//source/common/thread_local:thread_local_lib",
+        "//source/server:proto_descriptors_lib",
         "//source/server:server_lib",
         "//test/integration:integration_lib",
         "//test/mocks/server:server_mocks",

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-6036175623028736
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-6036175623028736
@@ -1,0 +1,26 @@
+dynamic_resources {
+  ads_config {
+    api_type: GRPC
+    grpc_services {
+      google_grpc {
+        target_uri: "\177\177"
+        stat_prefix: "\177\001D\177"
+      }
+      timeout {
+        seconds: 2048
+      }
+      initial_metadata {
+        value: "\177\177\177\177"
+      }
+    }
+  }
+}
+flags_path: "\'"
+admin {
+  access_log_path: "@"
+  address {
+    pipe {
+      path: "^"
+    }
+  }
+}

--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -3,6 +3,7 @@
 #include "common/network/address_impl.h"
 #include "common/thread_local/thread_local_impl.h"
 
+#include "server/proto_descriptors.h"
 #include "server/server.h"
 #include "server/test_hooks.h"
 
@@ -23,6 +24,8 @@ DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v2::Bootstrap& input) {
   Thread::MutexBasicLockable fakelock;
   TestComponentFactory component_factory;
   ThreadLocal::InstanceImpl thread_local_instance;
+
+  RELEASE_ASSERT(Envoy::Server::validateProtoDescriptors(), "");
 
   {
     const std::string bootstrap_path = TestEnvironment::temporaryPath("bootstrap.pb_text");


### PR DESCRIPTION
Some sites where we consume HeaderValue, e.g. in Google gRPC client library metadata, require
non-empty keys as a precondition. This seems a general property; there shouldn't be any use case for
a header key that is empty.

Found with server_fuzz_test under oss-fuzz (issue 9373). As a bonus, also fixed another proto
descriptor crash that occurs with this corpus addition due to missing proto descriptor pool entries
in server_fuzz_test.

Risk level: Low
Testing: New server_fuzz corpus entry.

Signed-off-by: Harvey Tuch <htuch@google.com>