### PR TITLE
tcp/conn_pool: improve interface for callers

### DIFF
--- a/include/envoy/tcp/conn_pool.h
+++ b/include/envoy/tcp/conn_pool.h
@@ -29,16 +29,22 @@ public:
  * Reason that a pool stream could not be obtained.
  */
 enum class PoolFailureReason {
-  // A resource overflowed and policy prevented a new stream from being created.
+  // A resource overflowed and policy prevented a new connection from being created.
   Overflow,
-  // A connection failure took place and the stream could not be bound.
-  ConnectionFailure
+  // A local connection failure took place and the connection could not be bound.
+  LocalConnectionFailure,
+  // A remote connection failure took place and the connection could not be bound.
+  RemoteConnectionFailure,
+  // A connection timeout occurred.
+  Timeout,
 };
 
 /*
- * UpstreamCallbacks for connection pool upstream connection callbacks.
+ * UpstreamCallbacks for connection pool upstream connection callbacks and data. Note that
+ * onEvent(Connected) is never triggered since the event always occurs before a ConnectionPool
+ * caller is assigned a connection.
  */
-class UpstreamCallbacks {
+class UpstreamCallbacks : public Network::ConnectionCallbacks {
 public:
   virtual ~UpstreamCallbacks() {}
 

--- a/include/envoy/tcp/conn_pool.h
+++ b/include/envoy/tcp/conn_pool.h
@@ -26,16 +26,16 @@ public:
 };
 
 /**
- * Reason that a pool stream could not be obtained.
+ * Reason that a pool connection could not be obtained.
  */
 enum class PoolFailureReason {
   // A resource overflowed and policy prevented a new connection from being created.
   Overflow,
-  // A local connection failure took place and the connection could not be bound.
+  // A local connection failure took place while creating a new connection.
   LocalConnectionFailure,
-  // A remote connection failure took place and the connection could not be bound.
+  // A remote connection failure took place while creating a new connection.
   RemoteConnectionFailure,
-  // A connection timeout occurred.
+  // A timeout occurred while creating a new connection.
   Timeout,
 };
 
@@ -128,14 +128,14 @@ public:
   /**
    * Register a callback that gets called when the connection pool is fully drained. No actual
    * draining is done. The owner of the connection pool is responsible for not creating any
-   * new streams.
+   * new connections.
    */
   virtual void addDrainedCallback(DrainedCb cb) PURE;
 
   /**
    * Actively drain all existing connection pool connections. This method can be used in cases
    * where the connection pool is not being destroyed, but the caller wishes to make sure that
-   * all new streams take place on a new connection. For example, when a health check failure
+   * all new requests take place on a new connection. For example, when a health check failure
    * occurs.
    */
   virtual void drainConnections() PURE;

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -72,11 +72,9 @@ protected:
     void onUpstreamData(Buffer::Instance& data, bool end_stream);
 
     // Network::ConnectionCallbacks
-    void onEvent(Network::ConnectionEvent event) override {
-      parent_.onConnectionEvent(*this, event);
-    }
-    void onAboveWriteBufferHighWatermark() override {}
-    void onBelowWriteBufferLowWatermark() override {}
+    void onEvent(Network::ConnectionEvent event) override;
+    void onAboveWriteBufferHighWatermark() override;
+    void onBelowWriteBufferLowWatermark() override;
 
     ConnPoolImpl& parent_;
     Upstream::HostDescriptionConstSharedPtr real_host_description_;
@@ -85,6 +83,7 @@ protected:
     Event::TimerPtr connect_timer_;
     Stats::TimespanPtr conn_length_;
     uint64_t remaining_requests_;
+    bool timed_out_;
   };
 
   typedef std::unique_ptr<ActiveConn> ActiveConnPtr;

--- a/test/integration/tcp_conn_pool_integration_test.cc
+++ b/test/integration/tcp_conn_pool_integration_test.cc
@@ -46,6 +46,7 @@ private:
   public:
     Request(TestFilter& parent, Buffer::Instance& data) : parent_(parent) { data_.move(data); }
 
+    // Tcp::ConnectionPool::Callbacks
     void onPoolFailure(Tcp::ConnectionPool::PoolFailureReason,
                        Upstream::HostDescriptionConstSharedPtr) override {
       ASSERT(false);
@@ -59,6 +60,7 @@ private:
       upstream_->connection().write(data_, false);
     }
 
+    // Tcp::ConnectionPool::UpstreamCallbacks
     void onUpstreamData(Buffer::Instance& data, bool end_stream) override {
       UNREFERENCED_PARAMETER(end_stream);
 
@@ -67,6 +69,9 @@ private:
 
       upstream_->release();
     }
+    void onEvent(Network::ConnectionEvent) override {}
+    void onAboveWriteBufferHighWatermark() override {}
+    void onBelowWriteBufferLowWatermark() override {}
 
     TestFilter& parent_;
     Buffer::OwnedImpl data_;

--- a/test/mocks/tcp/BUILD
+++ b/test/mocks/tcp/BUILD
@@ -15,6 +15,7 @@ envoy_cc_mock(
     deps = [
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/tcp:conn_pool_interface",
+        "//test/mocks/network:network_mocks",
         "//test/mocks/upstream:host_mocks",
     ],
 )

--- a/test/mocks/tcp/mocks.cc
+++ b/test/mocks/tcp/mocks.cc
@@ -3,6 +3,10 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using testing::Invoke;
+using testing::ReturnRef;
+using testing::_;
+
 namespace Envoy {
 namespace Tcp {
 namespace ConnectionPool {
@@ -13,8 +17,39 @@ MockCancellable::~MockCancellable() {}
 MockUpstreamCallbacks::MockUpstreamCallbacks() {}
 MockUpstreamCallbacks::~MockUpstreamCallbacks() {}
 
-MockInstance::MockInstance() {}
+MockConnectionData::MockConnectionData() {
+  ON_CALL(*this, connection()).WillByDefault(ReturnRef(connection_));
+}
+MockConnectionData::~MockConnectionData() {}
+
+MockInstance::MockInstance() {
+  ON_CALL(*this, newConnection(_)).WillByDefault(Invoke([&](Callbacks& cb) -> Cancellable* {
+    return newConnectionImpl(cb);
+  }));
+}
 MockInstance::~MockInstance() {}
+
+MockCancellable* MockInstance::newConnectionImpl(Callbacks& cb) {
+  handles_.emplace_back();
+  callbacks_.push_back(&cb);
+  return &handles_.back();
+}
+
+void MockInstance::poolFailure(PoolFailureReason reason) {
+  Callbacks* cb = callbacks_.front();
+  callbacks_.pop_front();
+  handles_.pop_front();
+
+  cb->onPoolFailure(reason, host_);
+}
+
+void MockInstance::poolReady() {
+  Callbacks* cb = callbacks_.front();
+  callbacks_.pop_front();
+  handles_.pop_front();
+
+  cb->onPoolReady(connection_data_, host_);
+}
 
 } // namespace ConnectionPool
 } // namespace Tcp


### PR DESCRIPTION
Provides additional pool failure reasons to allow Tcp::ConnectionPool
callers to distinguish between time outs and connection failures.
Passes through connection and buffer watermark events.

A subsequent PR will switch the TCP proxy to use the TCP connection
pool (and makes use of these features). Relates to #3818.

*Risk Level*: low
*Testing*: unit tests
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
