### PR TITLE
Add new field to access log

### DIFF
--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -102,6 +102,14 @@ The following command operators are supported:
   TCP
     Total duration in milliseconds of the downstream connection.
 
+%RESPONSE_DURATION%
+  HTTP
+    Total duration in milliseconds of the request from the start time to the first byte read from the
+    upstream host.
+
+  TCP
+    Not implemented ("-").
+
 .. _config_access_log_format_response_flags:
 
 %RESPONSE_FLAGS%
@@ -122,6 +130,14 @@ The following command operators are supported:
     * **DI**: The request processing was delayed for a period specified via :ref:`fault injection <config_http_filters_fault_injection>`.
     * **FI**: The request was aborted with a response code specified via :ref:`fault injection <config_http_filters_fault_injection>`.
     * **RL**: The request was ratelimited locally by the :ref:`HTTP rate limit filter <config_http_filters_rate_limit>` in addition to 429 response code.
+
+%RESPONSE_TX_DURATION%
+  HTTP
+    Total duration in milliseconds of the request from the first byte read from the upstream host to the last
+    byte sent downstream.
+
+  TCP
+    Not implemented ("-").
 
 %UPSTREAM_HOST%
   Upstream host URL (e.g., tcp://ip:port for TCP connections).

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -40,6 +40,7 @@ Version history
   <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.tracing>`.
 * upstream: added configuration option to the subset load balancer to take locality weights into account when
   selecting a host from a subset.
+* access log: added RESPONSE_DURATION and RESPONSE_TX_DURATION.
 
 1.7.0
 ===============

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -35,12 +35,14 @@ FormatterPtr AccessLogFormatUtils::defaultAccessLogFormatter() {
 std::string
 AccessLogFormatUtils::durationToString(const absl::optional<std::chrono::nanoseconds>& time) {
   if (time) {
-    return fmt::FormatInt(
-               std::chrono::duration_cast<std::chrono::milliseconds>(time.value()).count())
-        .str();
+    return durationToString(time.value());
   } else {
     return UnspecifiedValueString;
   }
+}
+
+std::string AccessLogFormatUtils::durationToString(const std::chrono::nanoseconds& time) {
+  return fmt::FormatInt(std::chrono::duration_cast<std::chrono::milliseconds>(time).count()).str();
 }
 
 const std::string&
@@ -220,6 +222,18 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
   } else if (field_name == "RESPONSE_DURATION") {
     field_extractor_ = [](const RequestInfo::RequestInfo& request_info) {
       return AccessLogFormatUtils::durationToString(request_info.firstUpstreamRxByteReceived());
+    };
+  } else if (field_name == "TIME_TO_LAST_BYTE_DURATION") {
+    field_extractor_ = [](const RequestInfo::RequestInfo& request_info) {
+      auto downstream = request_info.lastDownstreamTxByteSent();
+      auto upstream = request_info.firstUpstreamRxByteReceived();
+
+      if (downstream && upstream) {
+        auto val = downstream.value() - upstream.value();
+        return AccessLogFormatUtils::durationToString(val);
+      }
+
+      return UnspecifiedValueString;
     };
   } else if (field_name == "BYTES_RECEIVED") {
     field_extractor_ = [](const RequestInfo::RequestInfo& request_info) {

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -223,7 +223,7 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
     field_extractor_ = [](const RequestInfo::RequestInfo& request_info) {
       return AccessLogFormatUtils::durationToString(request_info.firstUpstreamRxByteReceived());
     };
-  } else if (field_name == "TIME_TO_LAST_BYTE_DURATION") {
+  } else if (field_name == "RESPONSE_TX_DURATION") {
     field_extractor_ = [](const RequestInfo::RequestInfo& request_info) {
       auto downstream = request_info.lastDownstreamTxByteSent();
       auto upstream = request_info.firstUpstreamRxByteReceived();

--- a/source/common/access_log/access_log_formatter.h
+++ b/source/common/access_log/access_log_formatter.h
@@ -73,6 +73,7 @@ public:
   static FormatterPtr defaultAccessLogFormatter();
   static const std::string& protocolToString(const absl::optional<Http::Protocol>& protocol);
   static std::string durationToString(const absl::optional<std::chrono::nanoseconds>& time);
+  static std::string durationToString(const std::chrono::nanoseconds& time);
 
 private:
   AccessLogFormatUtils();

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -74,7 +74,7 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
   }
 
   {
-    RequestInfoFormatter ttlb_duration_format("TIME_TO_LAST_BYTE_DURATION");
+    RequestInfoFormatter ttlb_duration_format("RESPONSE_TX_DURATION");
 
     absl::optional<std::chrono::nanoseconds> dur_upstream = std::chrono::nanoseconds(10000000);
     EXPECT_CALL(request_info, firstUpstreamRxByteReceived()).WillRepeatedly(Return(dur_upstream));
@@ -85,7 +85,7 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
   }
 
   {
-    RequestInfoFormatter ttlb_duration_format("TIME_TO_LAST_BYTE_DURATION");
+    RequestInfoFormatter ttlb_duration_format("RESPONSE_TX_DURATION");
 
     absl::optional<std::chrono::nanoseconds> dur_upstream;
     EXPECT_CALL(request_info, firstUpstreamRxByteReceived()).WillRepeatedly(Return(dur_upstream));

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -74,6 +74,28 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
   }
 
   {
+    RequestInfoFormatter ttlb_duration_format("TIME_TO_LAST_BYTE_DURATION");
+
+    absl::optional<std::chrono::nanoseconds> dur_upstream = std::chrono::nanoseconds(10000000);
+    EXPECT_CALL(request_info, firstUpstreamRxByteReceived()).WillRepeatedly(Return(dur_upstream));
+    absl::optional<std::chrono::nanoseconds> dur_downstream = std::chrono::nanoseconds(25000000);
+    EXPECT_CALL(request_info, lastDownstreamTxByteSent()).WillRepeatedly(Return(dur_downstream));
+
+    EXPECT_EQ("15", ttlb_duration_format.format(header, header, header, request_info));
+  }
+
+  {
+    RequestInfoFormatter ttlb_duration_format("TIME_TO_LAST_BYTE_DURATION");
+
+    absl::optional<std::chrono::nanoseconds> dur_upstream;
+    EXPECT_CALL(request_info, firstUpstreamRxByteReceived()).WillRepeatedly(Return(dur_upstream));
+    absl::optional<std::chrono::nanoseconds> dur_downstream;
+    EXPECT_CALL(request_info, lastDownstreamTxByteSent()).WillRepeatedly(Return(dur_downstream));
+
+    EXPECT_EQ("-", ttlb_duration_format.format(header, header, header, request_info));
+  }
+
+  {
     RequestInfoFormatter bytes_received_format("BYTES_RECEIVED");
     EXPECT_CALL(request_info, bytesReceived()).WillOnce(Return(1));
     EXPECT_EQ("1", bytes_received_format.format(header, header, header, request_info));


### PR DESCRIPTION
This new field, `RESPONSE_TX_DURATION`, represents the duration
between the first upstream byte received and the last downstream
byte sent. Similarly to `RESPONSE_DURATION`, we can leave it undocumented
for now until it proofs to be generally useful.

For context, we rely on this metric heavily internally. We tried to implemented
from a regular filter but it's harder to get right.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
