### PR TITLE
http1: fix crash when upstream sends extra CR/LF between responses

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -68,9 +68,11 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/google/jwt_verify_lib",
     ),
     com_github_nodejs_http_parser = dict(
-        # 2018-05-30 snapshot to pick up a performance fix, nodejs/http-parser PR 422
+        # 2018-07-20 snapshot to pick up:
+        # A performance fix, nodejs/http-parser PR 422.
+        # A bug fix, nodejs/http-parser PR 432.
         # TODO(brian-pane): Upgrade to the next http-parser release once it's available
-        commit = "cf69c8eda9fe79e4682598a7b3d39338dea319a3",
+        commit = "77310eeb839c4251c07184a5db8885a572a08352",
         remote = "https://github.com/nodejs/http-parser",
     ),
     com_github_pallets_jinja = dict(

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -436,6 +436,7 @@ void ConnectionImpl::onMessageCompleteBase() {
 }
 
 void ConnectionImpl::onMessageBeginBase() {
+  ENVOY_CONN_LOG(trace, "message begin", connection_);
   ASSERT(!current_header_map_);
   current_header_map_.reset(new HeaderMapImpl());
   header_parsing_state_ = HeaderParsingState::Field;
@@ -725,6 +726,7 @@ void ClientConnectionImpl::onBody(const char* data, size_t length) {
 }
 
 void ClientConnectionImpl::onMessageComplete() {
+  ENVOY_CONN_LOG(trace, "message complete", connection_);
   if (ignore_message_complete_for_100_continue_) {
     ignore_message_complete_for_100_continue_ = false;
     return;

--- a/test/integration/h1_capture_corpus/upstream_extra_crlf.pb_text
+++ b/test/integration/h1_capture_corpus/upstream_extra_crlf.pb_text
@@ -1,0 +1,38 @@
+events {
+  downstream_send_bytes: "POST /test/long/url HTTP/1.1\r\nhost: host\r\nx-lyft-user-id: 123\r\nx-forwarded-for: 10.0.0.1\r\ntransfer-encoding: chunked\r\n\r\n400\r\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\r\n0\r\n\r\n"
+}
+events {
+  upstream_recv_bytes {
+  }
+}
+events {
+  upstream_recv_bytes {
+  }
+}
+events {
+  upstream_send_bytes: "\r"
+}
+events {
+}
+events {
+  upstream_send_bytes: "\nStack trace:\n"
+}
+events {
+  upstream_recv_bytes {
+  }
+}
+events {
+  upstream_send_bytes: "\nStack trace:\n"
+}
+events {
+  upstream_send_bytes: ""
+}
+events {
+  upstream_recv_bytes {
+  }
+}
+events {
+  upstream_send_bytes: "1"
+}
+events {
+}


### PR DESCRIPTION
Requires pulling upstream http-parser fix.

Fixes https://github.com/envoyproxy/envoy/issues/3337

*Risk Level*: Low
*Testing*: New fuzz test that fails without the upstream fix
*Docs Changes*: N/A
*Release Notes*: N/A
