### PR TITLE
http: ensure the per-stream idle timer is disabled at stream end.

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -164,6 +164,10 @@ void ConnectionManagerImpl::doEndStream(ActiveStream& stream) {
 }
 
 void ConnectionManagerImpl::doDeferredStreamDestroy(ActiveStream& stream) {
+  if (stream.idle_timer_ != nullptr) {
+    stream.idle_timer_->disableTimer();
+    stream.idle_timer_ = nullptr;
+  }
   stream.state_.destroyed_ = true;
   for (auto& filter : stream.decoder_filters_) {
     filter->handle_->onDestroy();


### PR DESCRIPTION
Previously, this could have left the idle timer active during deferred delete. Thanks to
@MattKlein123 for spotting this.

Risk Level: Low
Testing: New unit test.

Signed-off-by: Harvey Tuch <htuch@google.com>