### PR TITLE
syscall: refactor setSocketOption for better errno latching

### DIFF
--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -181,6 +181,7 @@ envoy_cc_library(
     external_deps = ["abseil_optional"],
     deps = [
         ":address_lib",
+        "//include/envoy/api:os_sys_calls_interface",
         "//include/envoy/network:listen_socket_interface",
         "//source/common/api:os_sys_calls_lib",
         "//source/common/common:assert_lib",

--- a/source/common/network/socket_option_impl.cc
+++ b/source/common/network/socket_option_impl.cc
@@ -13,9 +13,9 @@ namespace Network {
 bool SocketOptionImpl::setOption(Socket& socket,
                                  envoy::api::v2::core::SocketOption::SocketState state) const {
   if (in_state_ == state) {
-    const int error = SocketOptionImpl::setSocketOption(socket, optname_, value_);
-    if (error != 0) {
-      ENVOY_LOG(warn, "Setting option on socket failed: {}", strerror(errno));
+    const Api::SysCallResult result = SocketOptionImpl::setSocketOption(socket, optname_, value_);
+    if (result.rc_ != 0) {
+      ENVOY_LOG(warn, "Setting option on socket failed: {}", strerror(result.errno_));
       return false;
     }
   }
@@ -24,16 +24,17 @@ bool SocketOptionImpl::setOption(Socket& socket,
 
 bool SocketOptionImpl::isSupported() const { return optname_.has_value(); }
 
-int SocketOptionImpl::setSocketOption(Socket& socket, Network::SocketOptionName optname,
-                                      const absl::string_view value) {
+Api::SysCallResult SocketOptionImpl::setSocketOption(Socket& socket,
+                                                     Network::SocketOptionName optname,
+                                                     const absl::string_view value) {
 
   if (!optname.has_value()) {
-    errno = ENOTSUP;
-    return -1;
+    return {-1, ENOTSUP};
   }
   auto& os_syscalls = Api::OsSysCallsSingleton::get();
-  return os_syscalls.setsockopt(socket.fd(), optname.value().first, optname.value().second,
-                                value.data(), value.size());
+  const int rc = os_syscalls.setsockopt(socket.fd(), optname.value().first, optname.value().second,
+                                        value.data(), value.size());
+  return {rc, errno};
 }
 
 } // namespace Network

--- a/source/common/network/socket_option_impl.h
+++ b/source/common/network/socket_option_impl.h
@@ -5,6 +5,7 @@
 #include <netinet/tcp.h>
 #include <sys/socket.h>
 
+#include "envoy/api/os_sys_calls.h"
 #include "envoy/network/listen_socket.h"
 
 #include "common/common/logger.h"
@@ -102,8 +103,16 @@ public:
 
   bool isSupported() const;
 
-  static int setSocketOption(Socket& socket, Network::SocketOptionName optname,
-                             absl::string_view value);
+  /**
+   * Set the option on the given socket.
+   * @param socket the socket on which to apply the option.
+   * @param optname the option name.
+   * @param value the option value.
+   * @return a Api::SysCallResult with rc_ = 0 for success and rc = -1 for failure. If the call is
+   *   successful, errno_ shouldn't be used.
+   */
+  static Api::SysCallResult setSocketOption(Socket& socket, Network::SocketOptionName optname,
+                                            absl::string_view value);
 
 private:
   const envoy::api::v2::core::SocketOption::SocketState in_state_;

--- a/test/common/network/socket_option_impl_test.cc
+++ b/test/common/network/socket_option_impl_test.cc
@@ -8,8 +8,9 @@ class SocketOptionImplTest : public SocketOptionTest {};
 
 TEST_F(SocketOptionImplTest, BadFd) {
   absl::string_view zero("\0\0\0\0", 4);
-  EXPECT_EQ(-1, SocketOptionImpl::setSocketOption(socket_, {}, zero));
-  EXPECT_EQ(ENOTSUP, errno);
+  Api::SysCallResult result = SocketOptionImpl::setSocketOption(socket_, {}, zero);
+  EXPECT_EQ(-1, result.rc_);
+  EXPECT_EQ(ENOTSUP, result.errno_);
 }
 
 TEST_F(SocketOptionImplTest, SetOptionSuccessTrue) {


### PR DESCRIPTION
*Description*:
This PR refactors `setSocketOption` to allow for returning the `errno` that is captured as soon as the syscall is performed. See #3819 for more information.

Signed-off-by: Venil Noronha <veniln@vmware.com>

*Risk Level*: Low
*Testing*: Existing tests suffice
*Docs Changes*: N/A
*Release Notes*: N/A