### PR TITLE
test: fixing a downstream tsan failure

### DIFF
--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -43,7 +43,10 @@ public:
 
   uint64_t bodyLength() { return body_.length(); }
   Buffer::Instance& body() { return body_; }
-  bool complete() { return end_stream_; }
+  bool complete() {
+    Thread::LockGuard lock(lock_);
+    return end_stream_;
+  }
   void encode100ContinueHeaders(const Http::HeaderMapImpl& headers);
   void encodeHeaders(const Http::HeaderMapImpl& headers, bool end_stream);
   void encodeData(uint64_t size, bool end_stream);


### PR DESCRIPTION
Adding a lock for checking response completion since as far as tsan can tell it's possibly accessed by the main thread and test thread simultaneously.

*Risk Level*: Low (test only)
*Testing*: ran idle_timeouts_test with internal tsan
*Docs Changes*: n/a
*Release Notes*: n/a
