### PR TITLE
fuzz: fixes oss-fuzz: 9204

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -423,12 +423,10 @@ ClusterSharedPtr ClusterImplBase::create(
   if (!cluster.health_checks().empty()) {
     // TODO(htuch): Need to support multiple health checks in v2.
     if (cluster.health_checks().size() != 1) {
-      throw EnvoyException(
-          fmt::format("Multiple health checks not supported. Health checks count: {}",
-                      cluster.health_checks().size()));
+      throw EnvoyException("Multiple health checks not supported");
     } else {
       new_cluster->setHealthChecker(HealthCheckerFactory::create(
-          cluster.health_checks()[0], *new_cluster, runtime, random, dispatcher, log_manager));
+          cluster.health_checks()[0], *new_cluster, runtime, random, dispatcher));
     }
   }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -426,7 +426,7 @@ ClusterSharedPtr ClusterImplBase::create(
       throw EnvoyException("Multiple health checks not supported");
     } else {
       new_cluster->setHealthChecker(HealthCheckerFactory::create(
-          cluster.health_checks()[0], *new_cluster, runtime, random, dispatcher));
+          cluster.health_checks()[0], *new_cluster, runtime, random, dispatcher, log_manager));
     }
   }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -422,9 +422,14 @@ ClusterSharedPtr ClusterImplBase::create(
 
   if (!cluster.health_checks().empty()) {
     // TODO(htuch): Need to support multiple health checks in v2.
-    ASSERT(cluster.health_checks().size() == 1);
-    new_cluster->setHealthChecker(HealthCheckerFactory::create(
-        cluster.health_checks()[0], *new_cluster, runtime, random, dispatcher, log_manager));
+    if (cluster.health_checks().size() != 1) {
+      throw EnvoyException(
+          fmt::format("Multiple health checks not supported. Health checks count: {}",
+                      cluster.health_checks().size()));
+    } else {
+      new_cluster->setHealthChecker(HealthCheckerFactory::create(
+          cluster.health_checks()[0], *new_cluster, runtime, random, dispatcher, log_manager));
+    }
   }
 
   new_cluster->setOutlierDetector(Outlier::DetectorImplFactory::createForCluster(

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -193,6 +193,27 @@ TEST_F(ClusterManagerImplTest, MultipleProtocolClusterFail) {
       "'protocol_selection' values");
 }
 
+TEST_F(ClusterManagerImplTest, MultipleHealthCheckFail) {
+  const std::string yaml = R"EOF(
+ static_resources:
+  clusters:
+  - name: service_google
+    connect_timeout: 0.25s
+    health_checks:
+      - timeout: 1s
+        interval: 1s
+        http_health_check:
+          path: "/blah"
+      - timeout: 1s
+        interval: 1s
+        http_health_check:
+          path: "/"
+  )EOF";
+
+  EXPECT_THROW_WITH_MESSAGE(create(parseBootstrapFromV2Yaml(yaml)), EnvoyException,
+                            "Multiple health checks not supported");
+}
+
 TEST_F(ClusterManagerImplTest, MultipleProtocolCluster) {
   EXPECT_CALL(system_time_source_, currentTime())
       .WillRepeatedly(Return(SystemTime(std::chrono::milliseconds(1234567891234))));

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5366294281977856
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5366294281977856
@@ -1,0 +1,126 @@
+static_resources {
+  clusters {
+    name: "9"
+    connect_timeout {
+      nanos: 1
+    }
+    hosts {
+      pipe {
+        path: "N"
+      }
+    }
+    hosts {
+      pipe {
+        path: "n"
+      }
+    }
+    hosts {
+      pipe {
+        path: "="
+      }
+    }
+    hosts {
+      pipe {
+        path: "s"
+      }
+    }
+    hosts {
+      pipe {
+        path: "n"
+      }
+    }
+    hosts {
+      pipe {
+        path: "N"
+      }
+    }
+    hosts {
+      pipe {
+        path: "W"
+      }
+    }
+    hosts {
+      pipe {
+        path: "="
+      }
+    }
+    hosts {
+      pipe {
+        path: "N"
+      }
+    }
+    hosts {
+      pipe {
+        path: "n"
+      }
+    }
+    health_checks {
+      timeout {
+        nanos: 1
+      }
+      interval {
+        nanos: 1
+      }
+      unhealthy_threshold {
+      }
+      healthy_threshold {
+        value: 1701650432
+      }
+      http_health_check {
+        path: "~"
+        request_headers_to_add {
+        }
+        request_headers_to_add {
+          header {
+            value: "W"
+          }
+        }
+        request_headers_to_add {
+        }
+        request_headers_to_add {
+        }
+        request_headers_to_add {
+        }
+        request_headers_to_add {
+        }
+        request_headers_to_add {
+        }
+        request_headers_to_add {
+        }
+        request_headers_to_add {
+        }
+        use_http2: true
+      }
+    }
+    health_checks {
+      timeout {
+        nanos: 1
+      }
+      interval {
+        nanos: 1
+      }
+      unhealthy_threshold {
+      }
+      healthy_threshold {
+      }
+      http_health_check {
+        path: "E"
+        request_headers_to_add {
+        }
+        request_headers_to_add {
+        }
+        request_headers_to_add {
+        }
+      }
+    }
+  }
+}
+admin {
+  access_log_path: "@\'"
+  address {
+    socket_address {
+      address: "::"
+      port_value: 0
+    }
+  }
+}


### PR DESCRIPTION
Title: Fixes oss-fuzz: 9204

Description: oss-fuzz issue (9204): https://oss-fuzz.com/v2/testcase-detail/5366294281977856
I suppose Envoy doesn't support multiple health checks still. Instead of assertion, have replaced it with throw. This doesn't crash the build. Let me know if any changes.

Risk Level: Low

Testing: Tested unit tests (bazel test //server:server_fuzz_test), built and ran fuzzers with oss-fuzz.

Signed-off-by: Anirudh M m.anirudh18@gmail.com