### PR TITLE
Add option for merging cluster updates

### DIFF
--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -432,14 +432,14 @@ message Cluster {
       ZoneAwareLbConfig zone_aware_lb_config = 2;
       LocalityWeightedLbConfig locality_weighted_lb_config = 3;
     }
-    // If set, all healthcheck/weight/metadata updates that happen within this duration will be
+    // If set, all health check/weight/metadata updates that happen within this duration will be
     // merged and delivered in one shot when the duration expires. The start of the duration is when
     // the first update happens. This is useful for big clusters, with potentially noisy deploys
     // that might trigger excessive CPU usage due to a constant stream of healthcheck state changes
     // or metadata updates. By default, this is not configured and updates apply immediately. Also,
     // the first set of updates to be seen apply immediately as well (e.g.: a new cluster).
     //
-    // Note: merging does not apply to cluser membership changes (e.g.: adds/removes); this is
+    // Note: merging does not apply to cluster membership changes (e.g.: adds/removes); this is
     // because merging those updates isn't currently safe. See
     // https://github.com/envoyproxy/envoy/pull/3941.
     google.protobuf.Duration update_merge_window = 4;

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -432,7 +432,7 @@ message Cluster {
       ZoneAwareLbConfig zone_aware_lb_config = 2;
       LocalityWeightedLbConfig locality_weighted_lb_config = 3;
     }
-    // If set, membership and healthcheck updates that happen within this duration will be coalesced
+    // If set, membership and healthcheck updates that happen within this duration will be merged
     // and delivered in one shot when the duration expires. The start of the duration is when the
     // first update happens. This is useful for big clusters, with potentially noisy deploys that
     // might trigger excessive CPU usage due to a constant stream of healthcheck state changes or

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -432,12 +432,16 @@ message Cluster {
       ZoneAwareLbConfig zone_aware_lb_config = 2;
       LocalityWeightedLbConfig locality_weighted_lb_config = 3;
     }
-    // If set, membership and healthcheck updates that happen within this duration will be merged
-    // and delivered in one shot when the duration expires. The start of the duration is when the
-    // first update happens. This is useful for big clusters, with potentially noisy deploys that
-    // might trigger excessive CPU usage due to a constant stream of healthcheck state changes or
-    // membership updates. By default, this is not configured and updates apply immediately.
-    // Also, the first set of updates to be seen apply immediately as well (e.g.: a new cluster).
+    // If set, all healthcheck/weight/metadata updates that happen within this duration will be
+    // merged and delivered in one shot when the duration expires. The start of the duration is when
+    // the first update happens. This is useful for big clusters, with potentially noisy deploys
+    // that might trigger excessive CPU usage due to a constant stream of healthcheck state changes
+    // or metadata updates. By default, this is not configured and updates apply immediately. Also,
+    // the first set of updates to be seen apply immediately as well (e.g.: a new cluster).
+    //
+    // Note: merging does not apply to cluser membership changes (e.g.: adds/removes); this is
+    // because merging those updates isn't currently safe. See
+    // https://github.com/envoyproxy/envoy/pull/3941.
     google.protobuf.Duration update_merge_window = 4;
   }
 

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -432,6 +432,12 @@ message Cluster {
       ZoneAwareLbConfig zone_aware_lb_config = 2;
       LocalityWeightedLbConfig locality_weighted_lb_config = 3;
     }
+    // If set, membership and healthcheck updates that happen within this duration will be coalesced
+    // and delivered in one shot when the duration expires. The start of the duration is when the
+    // first update happens. This is useful for big clusters, with potentially noisy deploys that
+    // might trigger excessive CPU usage due to a constant stream of healthcheck state changes or
+    // membership updates.
+    google.protobuf.Duration time_between_updates = 4;
   }
 
   // Common configuration for all load balancer implementations.

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -436,8 +436,9 @@ message Cluster {
     // and delivered in one shot when the duration expires. The start of the duration is when the
     // first update happens. This is useful for big clusters, with potentially noisy deploys that
     // might trigger excessive CPU usage due to a constant stream of healthcheck state changes or
-    // membership updates.
-    google.protobuf.Duration time_between_updates = 4;
+    // membership updates. By default, this is not configured and updates apply immediately.
+    // Also, the first set of updates to be seen apply immediately as well (e.g.: a new cluster).
+    google.protobuf.Duration update_merge_window = 4;
   }
 
   // Common configuration for all load balancer implementations.

--- a/docs/root/configuration/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/cluster_manager/cluster_stats.rst
@@ -19,6 +19,10 @@ statistics. Any ``:`` character in the stats name is replaced with ``_``.
   cluster_added, Counter, Total clusters added (either via static config or CDS)
   cluster_modified, Counter, Total clusters modified (via CDS)
   cluster_removed, Counter, Total clusters removed (via CDS)
+  cluster_updated, Counter, Total cluster updates
+  cluster_updated_via_merge, Counter, Total cluster updates applied as merged updates
+  update_merge_cancelled, Counter, Total merged updates that got cancelled and delivered early
+  update_out_of_merge_window, Counter, Total updates which arrived out of a merge window
   active_clusters, Gauge, Number of currently active (warmed) clusters
   warming_clusters, Gauge, Number of currently warming (not active) clusters
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -5,10 +5,13 @@ Version history
 ===============
 * access log: added :ref:`response flag filter <envoy_api_msg_config.filter.accesslog.v2.ResponseFlagFilter>`
   to filter based on the presence of Envoy response flags.
+* access log: added RESPONSE_DURATION and RESPONSE_TX_DURATION.
 * admin: added :http:get:`/hystrix_event_stream` as an endpoint for monitoring envoy's statistics
   through `Hystrix dashboard <https://github.com/Netflix-Skunkworks/hystrix-dashboard/wiki>`_.
 * grpc-json: added support for building HTTP response from
   `google.api.HttpBody <https://github.com/googleapis/googleapis/blob/master/google/api/httpbody.proto>`_.
+* cluster: added :ref:`option <envoy_api_field_Cluster.CommonLbConfig.update_merge_window>` to merge
+  health check/weight/metadata updates within the given duration.
 * config: v1 disabled by default. v1 support remains available until October via flipping --v2-config-only=false.
 * config: v1 disabled by default. v1 support remains available until October via setting :option:`--allow-deprecated-v1-api`.
 * health check: added support for :ref:`custom health check <envoy_api_field_core.HealthCheck.custom_health_check>`.
@@ -47,9 +50,6 @@ Version history
   <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.tracing>`.
 * upstream: added configuration option to the subset load balancer to take locality weights into account when
   selecting a host from a subset.
-* access log: added RESPONSE_DURATION and RESPONSE_TX_DURATION.
-* cluster: added :ref:`option <envoy_api_field_Cluster.CommonLbConfig.update_merge_window>` to merge health check/weight/metadata
-  updates within the given duration.
 
 1.7.0
 ===============

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -48,7 +48,7 @@ Version history
 * upstream: added configuration option to the subset load balancer to take locality weights into account when
   selecting a host from a subset.
 * access log: added RESPONSE_DURATION and RESPONSE_TX_DURATION.
-* cluster: added :ref:`option <envoy_api_field_Cluster.CommonLbConfig.time_between_updates>` to coalesce updates
+* cluster: added :ref:`option <envoy_api_field_Cluster.CommonLbConfig.update_merge_window>` to coalesce updates
   within the given duration.
 
 1.7.0

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -48,8 +48,8 @@ Version history
 * upstream: added configuration option to the subset load balancer to take locality weights into account when
   selecting a host from a subset.
 * access log: added RESPONSE_DURATION and RESPONSE_TX_DURATION.
-* cluster: added :ref:`option <envoy_api_field_Cluster.CommonLbConfig.update_merge_window>` to merge updates
-  within the given duration.
+* cluster: added :ref:`option <envoy_api_field_Cluster.CommonLbConfig.update_merge_window>` to merge healthcheck/weight/metadata
+  updates within the given duration.
 
 1.7.0
 ===============

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -48,6 +48,8 @@ Version history
 * upstream: added configuration option to the subset load balancer to take locality weights into account when
   selecting a host from a subset.
 * access log: added RESPONSE_DURATION and RESPONSE_TX_DURATION.
+* cluster: added :ref:`option <envoy_api_field_Cluster.CommonLbConfig.time_between_updates>` to coalesce updates
+  within the given duration.
 
 1.7.0
 ===============

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -48,7 +48,7 @@ Version history
 * upstream: added configuration option to the subset load balancer to take locality weights into account when
   selecting a host from a subset.
 * access log: added RESPONSE_DURATION and RESPONSE_TX_DURATION.
-* cluster: added :ref:`option <envoy_api_field_Cluster.CommonLbConfig.update_merge_window>` to merge healthcheck/weight/metadata
+* cluster: added :ref:`option <envoy_api_field_Cluster.CommonLbConfig.update_merge_window>` to merge health check/weight/metadata
   updates within the given duration.
 
 1.7.0

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -48,7 +48,7 @@ Version history
 * upstream: added configuration option to the subset load balancer to take locality weights into account when
   selecting a host from a subset.
 * access log: added RESPONSE_DURATION and RESPONSE_TX_DURATION.
-* cluster: added :ref:`option <envoy_api_field_Cluster.CommonLbConfig.update_merge_window>` to coalesce updates
+* cluster: added :ref:`option <envoy_api_field_Cluster.CommonLbConfig.update_merge_window>` to merge updates
   within the given duration.
 
 1.7.0

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -331,13 +331,13 @@ void ClusterManagerImpl::onClusterInit(Cluster& cluster) {
     // This fires when a cluster is about to have an updated member set. We need to send this
     // out to all of the thread local configurations.
 
-    // Should we coalesce updates?
+    // Should we save this update and merge it with other updates?
     bool scheduled = false;
     if (cluster.info()->lbConfig().has_update_merge_window()) {
       scheduled = scheduleUpdate(cluster, priority, hosts_added, hosts_removed);
     }
 
-    // If an update was not scheduled, deliver it immediately.
+    // If an update was not scheduled for later, deliver it immediately.
     if (!scheduled) {
       postThreadLocalClusterUpdate(cluster, priority, hosts_added, hosts_removed);
     }
@@ -453,7 +453,7 @@ void ClusterManagerImpl::applyUpdates(const Cluster& cluster, uint32_t priority,
   const HostVector& hosts_added = fromMap(updates->added);
   const HostVector& hosts_removed = fromMap(updates->removed);
   postThreadLocalClusterUpdate(cluster, priority, hosts_added, hosts_removed);
-  cm_stats_.coalesced_updates_.inc();
+  cm_stats_.merged_updates_.inc();
 
   // Reset everything.
   updates->timer = nullptr;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -423,8 +423,8 @@ void ClusterManagerImpl::applyUpdates(const Cluster& cluster, uint32_t priority,
   // Remember that these merged updates are _only_ for updates related to
   // HC/weight/metadata changes. That's why added/removed are empty. All
   // adds/removals were already immediately broadcasted.
-  const HostVector hosts_added;
-  const HostVector hosts_removed;
+  static const HostVector hosts_added;
+  static const HostVector hosts_removed;
 
   postThreadLocalClusterUpdate(cluster, priority, hosts_added, hosts_removed);
 

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -361,7 +361,7 @@ void ClusterManagerImpl::onClusterInit(Cluster& cluster) {
         cm_stats_.regular_updates_.inc();
       } else {
         // Or are we outside a merge window?
-        if (!scheduled) {
+        if (merging_enabled && !scheduled) {
           cm_stats_.merged_updates_offwindow_.inc();
         }
       }

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -402,6 +402,10 @@ bool ClusterManagerImpl::scheduleUpdate(const Cluster& cluster, uint32_t priorit
   const uint64_t delta_ms = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
   if (delta_ms > timeout || !mergeable) {
     // If there was a pending update, we cancel the pending merged update.
+    //
+    // Note: it's possible that even though we are outside of a merge window (delta_ms > timeout),
+    // a timer is enabled. This race condition is fine, since we'll disable the timer here and
+    // deliver the update immediately.
     if (updates->disableTimer()) {
       cm_stats_.merged_updates_cancelled_.inc();
     }

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -343,7 +343,6 @@ void ClusterManagerImpl::onClusterInit(Cluster& cluster) {
     // of removals, these maps will leak those HostSharedPtrs.
     //
     // See https://github.com/envoyproxy/envoy/pull/3941 for more context.
-
     bool scheduled = false;
     const bool merging_enabled = cluster.info()->lbConfig().has_update_merge_window();
 

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -391,8 +391,8 @@ bool ClusterManagerImpl::scheduleUpdate(const Cluster& cluster, uint32_t priorit
   // the update so it can be applied immediately. Ditto if this is not a mergeable update.
   const auto delta = std::chrono::steady_clock::now() - updates->last_updated_;
   const uint64_t delta_ms = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
-  const bool offwindow = delta_ms > timeout;
-  if (offwindow || !mergeable) {
+  const bool out_of_merge_window = delta_ms > timeout;
+  if (out_of_merge_window || !mergeable) {
     // If there was a pending update, we cancel the pending merged update.
     //
     // Note: it's possible that even though we are outside of a merge window (delta_ms > timeout),
@@ -400,8 +400,8 @@ bool ClusterManagerImpl::scheduleUpdate(const Cluster& cluster, uint32_t priorit
     // deliver the update immediately.
 
     // Why wasn't the update scheduled for later delivery?
-    if (mergeable && offwindow) {
-      cm_stats_.update_merge_offwindow_.inc();
+    if (mergeable && out_of_merge_window) {
+      cm_stats_.update_out_of_merge_window_.inc();
     }
 
     if (updates->disableTimer()) {

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -559,10 +559,8 @@ bool ClusterManagerImpl::removeCluster(const std::string& cluster_name) {
     cm_stats_.cluster_removed_.inc();
     updateGauges();
     // Did we ever deliver merged updates for this cluster?
-    if (updates_map_.count(cluster_name) == 1) {
-      // No need to manually disable timers, this should take care of it.
-      updates_map_.erase(cluster_name);
-    }
+    // No need to manually disable timers, this should take care of it.
+    updates_map_.erase(cluster_name);
   }
 
   return removed;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -376,16 +376,16 @@ bool ClusterManagerImpl::scheduleUpdate(const Cluster& cluster, uint32_t priorit
   const auto timeout = DurationUtil::durationToMilliseconds(update_merge_window);
 
   // Find pending updates for this cluster.
-  if (updates_map_.count(cluster.info()->name()) != 1) {
-    updates_map_[cluster.info()->name()] = std::make_unique<PendingUpdatesByPriorityMap>();
+  auto& updates_by_prio = updates_map_[cluster.info()->name()];
+  if (!updates_by_prio) {
+    updates_by_prio.reset(new PendingUpdatesByPriorityMap());
   }
-  PendingUpdatesByPriorityMapPtr& updates_by_prio = updates_map_[cluster.info()->name()];
 
   // Find pending updates for this priority.
-  if (updates_by_prio->count(priority) != 1) {
-    (*updates_by_prio)[priority] = std::make_unique<PendingUpdates>();
+  auto& updates = (*updates_by_prio)[priority];
+  if (!updates) {
+    updates.reset(new PendingUpdates());
   }
-  PendingUpdatesPtr& updates = (*updates_by_prio)[priority];
 
   // Has an update_merge_window gone by since the last update? If so, don't schedule
   // the update so it can be applied immediately. Ditto if this is not a mergeable update.

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -359,11 +359,11 @@ void ClusterManagerImpl::onClusterInit(Cluster& cluster) {
       // Is this a regular update?
       if (!is_mergeable) {
         cm_stats_.regular_updates_.inc();
-      }
-
-      // Or are we outside a merge window?
-      if (is_mergeable && !scheduled) {
-        cm_stats_.merged_updates_offwindow_.inc();
+      } else {
+        // Or are we outside a merge window?
+        if (!scheduled) {
+          cm_stats_.merged_updates_offwindow_.inc();
+        }
       }
 
       postThreadLocalClusterUpdate(cluster, priority, hosts_added, hosts_removed);

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -595,6 +595,11 @@ bool ClusterManagerImpl::removeCluster(const std::string& cluster_name) {
   if (removed) {
     cm_stats_.cluster_removed_.inc();
     updateGauges();
+    // Did we ever deliver merged updates for this cluster?
+    if (updates_map_.count(cluster_name) == 1) {
+      // No need to manually disable timers, this should take care of it.
+      updates_map_.erase(cluster_name);
+    }
   }
 
   return removed;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -345,11 +345,11 @@ void ClusterManagerImpl::onClusterInit(Cluster& cluster) {
     // See https://github.com/envoyproxy/envoy/pull/3941 for more context.
 
     bool scheduled = false;
-    bool merging_enabled = cluster.info()->lbConfig().has_update_merge_window();
+    const bool merging_enabled = cluster.info()->lbConfig().has_update_merge_window();
 
     if (merging_enabled) {
       // Remember: we only merge updates with no adds/removes — just hc/weight/metadata changes.
-      bool is_mergeable = !hosts_added.size() && !hosts_removed.size();
+      const bool is_mergeable = !hosts_added.size() && !hosts_removed.size();
 
       // If this is not mergeable, we should cancel any scheduled updates since
       // we'll deliver it immediately.

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -412,8 +412,12 @@ bool ClusterManagerImpl::scheduleUpdate(const Cluster& cluster, uint32_t priorit
 
   // If there's no timer, create one.
   if (updates->timer_ == nullptr) {
-    updates->timer_ = dispatcher_.createTimer([this, &cluster, priority, updates]() -> void {
-      applyUpdates(cluster, priority, updates);
+    std::weak_ptr<PendingUpdates> weak_ptr(updates);
+    updates->timer_ = dispatcher_.createTimer([this, &cluster, priority, weak_ptr]() -> void {
+      auto updates = weak_ptr.lock();
+      if (updates) {
+        applyUpdates(cluster, priority, updates);
+      }
     });
   }
 

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -380,10 +380,11 @@ bool ClusterManagerImpl::scheduleUpdate(const Cluster& cluster, uint32_t priorit
   }
 
   // Has an update_merge_window gone by since the last update? If so, don't schedule
-  // the update so it can be applied immediately.
+  // the update so it can be applied immediately as long as there's no active timer
+  // (to avoid changing the order of updates).
   const auto delta = std::chrono::steady_clock::now() - updates->last_updated;
   const uint64_t delta_ms = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
-  if (delta_ms > timeout) {
+  if (delta_ms > timeout && updates->timer == nullptr) {
     updates->last_updated = std::chrono::steady_clock::now();
     return false;
   }

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -404,7 +404,7 @@ bool ClusterManagerImpl::scheduleUpdate(const Cluster& cluster, uint32_t priorit
   // If there's no timer, create one.
   if (updates->timer_ == nullptr) {
     updates->timer_ = dispatcher_.createTimer([this, &cluster, priority, &updates]() -> void {
-      applyUpdates(cluster, priority, updates);
+      applyUpdates(cluster, priority, *updates);
     });
   }
 
@@ -417,7 +417,7 @@ bool ClusterManagerImpl::scheduleUpdate(const Cluster& cluster, uint32_t priorit
 }
 
 void ClusterManagerImpl::applyUpdates(const Cluster& cluster, uint32_t priority,
-                                      PendingUpdatesPtr& updates) {
+                                      PendingUpdates& updates) {
   // Deliver pending updates.
 
   // Remember that these merged updates are _only_ for updates related to
@@ -429,8 +429,8 @@ void ClusterManagerImpl::applyUpdates(const Cluster& cluster, uint32_t priority,
   postThreadLocalClusterUpdate(cluster, priority, hosts_added, hosts_removed);
 
   cm_stats_.merged_updates_.inc();
-  updates->timer_enabled_ = false;
-  updates->last_updated_ = std::chrono::steady_clock::now();
+  updates.timer_enabled_ = false;
+  updates.last_updated_ = std::chrono::steady_clock::now();
 }
 
 bool ClusterManagerImpl::addOrUpdateCluster(const envoy::api::v2::Cluster& cluster,

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -399,11 +399,15 @@ bool ClusterManagerImpl::scheduleUpdate(const Cluster& cluster, uint32_t priorit
     // a timer is enabled. This race condition is fine, since we'll disable the timer here and
     // deliver the update immediately.
 
-    // Why wasn't the update scheduled for later delivery?
+    // Why wasn't the update scheduled for later delivery? We keep some stats that are helpful
+    // to understand why merging did not happen. There's 2 things we are tracking here:
+
+    // 1) Was this update out of a merge window?
     if (mergeable && out_of_merge_window) {
       cm_stats_.update_out_of_merge_window_.inc();
     }
 
+    // 2) Were there previous updates that we are cancelling (and delivering immediately)?
     if (updates->disableTimer()) {
       cm_stats_.update_merge_cancelled_.inc();
     }

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -374,6 +374,8 @@ private:
   typedef std::unordered_map<std::string, PendingUpdatesByPriorityMapPtr> ClusterUpdatesMap;
 
   void applyUpdates(const Cluster& cluster, uint32_t priority, PendingUpdatesPtr updates);
+  void scheduleUpdate(const Cluster& cluster, uint32_t priority, const HostVector& hosts_added,
+                      const HostVector& hosts_removed);
   void createOrUpdateThreadLocalCluster(ClusterData& cluster);
   ProtobufTypes::MessagePtr dumpClusterConfigs();
   static ClusterManagerStats generateStats(Stats::Scope& scope);

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -362,10 +362,12 @@ private:
   // This map is ordered so that config dumping is consistent.
   typedef std::map<std::string, ClusterDataPtr> ClusterMap;
 
+  // Track hosts by their address (as a string).
+  using HostMap = std::map<std::string, HostSharedPtr>;
   struct PendingUpdates {
     Event::TimerPtr timer;
-    std::set<HostSharedPtr> added;
-    std::set<HostSharedPtr> removed;
+    HostMap added;
+    HostMap removed;
     MonotonicTime last_updated;
   };
   using PendingUpdatesPtr = std::shared_ptr<PendingUpdates>;
@@ -376,6 +378,7 @@ private:
   void applyUpdates(const Cluster& cluster, uint32_t priority, PendingUpdatesPtr updates);
   bool scheduleUpdate(const Cluster& cluster, uint32_t priority, const HostVector& hosts_added,
                       const HostVector& hosts_removed);
+  HostVector fromMap(HostMap map) const;
   void createOrUpdateThreadLocalCluster(ClusterData& cluster);
   ProtobufTypes::MessagePtr dumpClusterConfigs();
   static ClusterManagerStats generateStats(Stats::Scope& scope);

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -138,7 +138,7 @@ private:
   COUNTER(cluster_added)                                                                           \
   COUNTER(cluster_modified)                                                                        \
   COUNTER(cluster_removed)                                                                         \
-  COUNTER(coalesced_updates)                                                                       \
+  COUNTER(merged_updates)                                                                          \
   GAUGE  (active_clusters)                                                                         \
   GAUGE  (warming_clusters)
 // clang-format on

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -367,6 +367,7 @@ private:
     Event::TimerPtr timer;
     std::unordered_set<HostSharedPtr> added;
     std::unordered_set<HostSharedPtr> removed;
+    MonotonicTime last_updated;
   };
   typedef std::shared_ptr<PendingUpdates> PendingUpdatesPtr;
   typedef std::unordered_map<uint32_t, PendingUpdatesPtr> PendingUpdatesByPriorityMap;
@@ -374,7 +375,7 @@ private:
   typedef std::unordered_map<std::string, PendingUpdatesByPriorityMapPtr> ClusterUpdatesMap;
 
   void applyUpdates(const Cluster& cluster, uint32_t priority, PendingUpdatesPtr updates);
-  void scheduleUpdate(const Cluster& cluster, uint32_t priority, const HostVector& hosts_added,
+  bool scheduleUpdate(const Cluster& cluster, uint32_t priority, const HostVector& hosts_added,
                       const HostVector& hosts_removed);
   void createOrUpdateThreadLocalCluster(ClusterData& cluster);
   ProtobufTypes::MessagePtr dumpClusterConfigs();

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -369,7 +369,7 @@ private:
 
   struct PendingUpdates {
     Event::TimerPtr timer_;
-    bool timer_enabled_;
+    bool timer_enabled_{};
     MonotonicTime last_updated_;
     void enableTimer(const uint64_t timeout) {
       if (timer_ != nullptr) {
@@ -391,7 +391,7 @@ private:
   using PendingUpdatesByPriorityMapPtr = std::unique_ptr<PendingUpdatesByPriorityMap>;
   using ClusterUpdatesMap = std::unordered_map<std::string, PendingUpdatesByPriorityMapPtr>;
 
-  void applyUpdates(const Cluster& cluster, uint32_t priority, PendingUpdatesPtr& updates);
+  void applyUpdates(const Cluster& cluster, uint32_t priority, PendingUpdates& updates);
   bool scheduleUpdate(const Cluster& cluster, uint32_t priority, bool mergeable);
   void createOrUpdateThreadLocalCluster(ClusterData& cluster);
   ProtobufTypes::MessagePtr dumpClusterConfigs();

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -363,18 +363,15 @@ private:
   typedef std::map<std::string, ClusterDataPtr> ClusterMap;
 
   struct PendingUpdates {
-    PendingUpdates() {}
     Event::TimerPtr timer;
-    HostVector added;
-    HostVector removed;
-    std::unordered_set<HostSharedPtr> added_seen;
-    std::unordered_set<HostSharedPtr> removed_seen;
+    std::set<HostSharedPtr> added;
+    std::set<HostSharedPtr> removed;
     MonotonicTime last_updated;
   };
-  typedef std::shared_ptr<PendingUpdates> PendingUpdatesPtr;
-  typedef std::unordered_map<uint32_t, PendingUpdatesPtr> PendingUpdatesByPriorityMap;
-  typedef std::shared_ptr<PendingUpdatesByPriorityMap> PendingUpdatesByPriorityMapPtr;
-  typedef std::unordered_map<std::string, PendingUpdatesByPriorityMapPtr> ClusterUpdatesMap;
+  using PendingUpdatesPtr = std::shared_ptr<PendingUpdates>;
+  using PendingUpdatesByPriorityMap = std::unordered_map<uint32_t, PendingUpdatesPtr>;
+  using PendingUpdatesByPriorityMapPtr = std::shared_ptr<PendingUpdatesByPriorityMap>;
+  using ClusterUpdatesMap = std::unordered_map<std::string, PendingUpdatesByPriorityMapPtr>;
 
   void applyUpdates(const Cluster& cluster, uint32_t priority, PendingUpdatesPtr updates);
   bool scheduleUpdate(const Cluster& cluster, uint32_t priority, const HostVector& hosts_added,

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -369,6 +369,7 @@ private:
 
   struct PendingUpdates {
     void enableTimer(const uint64_t timeout) {
+      ASSERT(!timer_enabled_);
       if (timer_ != nullptr) {
         timer_->enableTimer(std::chrono::milliseconds(timeout));
         timer_enabled_ = true;

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -138,7 +138,10 @@ private:
   COUNTER(cluster_added)                                                                           \
   COUNTER(cluster_modified)                                                                        \
   COUNTER(cluster_removed)                                                                         \
+  COUNTER(regular_updates)                                                                         \
   COUNTER(merged_updates)                                                                          \
+  COUNTER(merged_updates_cancelled)                                                                \
+  COUNTER(merged_updates_offwindow)                                                                \
   GAUGE  (active_clusters)                                                                         \
   GAUGE  (warming_clusters)
 // clang-format on

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -386,12 +386,12 @@ private:
       return was_enabled;
     }
   };
-  using PendingUpdatesPtr = std::shared_ptr<PendingUpdates>;
+  using PendingUpdatesPtr = std::unique_ptr<PendingUpdates>;
   using PendingUpdatesByPriorityMap = std::unordered_map<uint32_t, PendingUpdatesPtr>;
-  using PendingUpdatesByPriorityMapPtr = std::shared_ptr<PendingUpdatesByPriorityMap>;
+  using PendingUpdatesByPriorityMapPtr = std::unique_ptr<PendingUpdatesByPriorityMap>;
   using ClusterUpdatesMap = std::unordered_map<std::string, PendingUpdatesByPriorityMapPtr>;
 
-  void applyUpdates(const Cluster& cluster, uint32_t priority, PendingUpdatesPtr updates);
+  void applyUpdates(const Cluster& cluster, uint32_t priority, PendingUpdatesPtr& updates);
   bool scheduleUpdate(const Cluster& cluster, uint32_t priority, bool mergeable);
   void createOrUpdateThreadLocalCluster(ClusterData& cluster);
   ProtobufTypes::MessagePtr dumpClusterConfigs();

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -210,6 +210,11 @@ public:
 
   ClusterManagerFactory& clusterManagerFactory() override { return factory_; }
 
+protected:
+  virtual void postThreadLocalClusterUpdate(const Cluster& cluster, uint32_t priority,
+                                            const HostVector& hosts_added,
+                                            const HostVector& hosts_removed);
+
 private:
   /**
    * Thread local cached cluster data. Each thread local cluster gets updates from the parent
@@ -385,8 +390,6 @@ private:
   void loadCluster(const envoy::api::v2::Cluster& cluster, const std::string& version_info,
                    bool added_via_api, ClusterMap& cluster_map);
   void onClusterInit(Cluster& cluster);
-  void postThreadLocalClusterUpdate(const Cluster& cluster, uint32_t priority,
-                                    const HostVector& hosts_added, const HostVector& hosts_removed);
   void postThreadLocalHealthFailure(const HostSharedPtr& host);
   void updateGauges();
 

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -378,7 +378,7 @@ private:
       }
     }
     bool disableTimer() {
-      bool was_enabled = timer_enabled_;
+      const bool was_enabled = timer_enabled_;
       if (timer_ != nullptr) {
         timer_->disableTimer();
         timer_enabled_ = false;

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -138,10 +138,10 @@ private:
   COUNTER(cluster_added)                                                                           \
   COUNTER(cluster_modified)                                                                        \
   COUNTER(cluster_removed)                                                                         \
-  COUNTER(regular_updates)                                                                         \
-  COUNTER(merged_updates)                                                                          \
-  COUNTER(merged_updates_cancelled)                                                                \
-  COUNTER(merged_updates_offwindow)                                                                \
+  COUNTER(cluster_updated)                                                                         \
+  COUNTER(cluster_updated_via_merge)                                                               \
+  COUNTER(update_merge_cancelled)                                                                  \
+  COUNTER(update_merge_offwindow)                                                                  \
   GAUGE  (active_clusters)                                                                         \
   GAUGE  (warming_clusters)
 // clang-format on

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -141,7 +141,7 @@ private:
   COUNTER(cluster_updated)                                                                         \
   COUNTER(cluster_updated_via_merge)                                                               \
   COUNTER(update_merge_cancelled)                                                                  \
-  COUNTER(update_merge_offwindow)                                                                  \
+  COUNTER(update_out_of_merge_window)                                                              \
   GAUGE  (active_clusters)                                                                         \
   GAUGE  (warming_clusters)
 // clang-format on

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -368,9 +368,6 @@ private:
   typedef std::map<std::string, ClusterDataPtr> ClusterMap;
 
   struct PendingUpdates {
-    Event::TimerPtr timer_;
-    bool timer_enabled_{};
-    MonotonicTime last_updated_;
     void enableTimer(const uint64_t timeout) {
       if (timer_ != nullptr) {
         timer_->enableTimer(std::chrono::milliseconds(timeout));
@@ -385,6 +382,16 @@ private:
       }
       return was_enabled;
     }
+
+    Event::TimerPtr timer_;
+    bool timer_enabled_{};
+    // This is default constructed to the clock's epoch:
+    // https://en.cppreference.com/w/cpp/chrono/time_point/time_point
+    //
+    // This will usually be the computer's boot time, which means that given a not very large
+    // `Cluster.CommonLbConfig.update_merge_window`, the first update will trigger immediately
+    // (the expected behavior).
+    MonotonicTime last_updated_;
   };
   using PendingUpdatesPtr = std::unique_ptr<PendingUpdates>;
   using PendingUpdatesByPriorityMap = std::unordered_map<uint32_t, PendingUpdatesPtr>;

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -384,6 +384,7 @@ private:
     }
 
     Event::TimerPtr timer_;
+    // TODO(rgs1): this should be part of Event::Timer's interface.
     bool timer_enabled_{};
     // This is default constructed to the clock's epoch:
     // https://en.cppreference.com/w/cpp/chrono/time_point/time_point

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -365,8 +365,10 @@ private:
   struct PendingUpdates {
     PendingUpdates() {}
     Event::TimerPtr timer;
-    std::unordered_set<HostSharedPtr> added;
-    std::unordered_set<HostSharedPtr> removed;
+    HostVector added;
+    HostVector removed;
+    std::unordered_set<HostSharedPtr> added_seen;
+    std::unordered_set<HostSharedPtr> removed_seen;
     MonotonicTime last_updated;
   };
   typedef std::shared_ptr<PendingUpdates> PendingUpdatesPtr;

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -175,7 +175,7 @@ public:
         monotonic_time_source_));
   }
 
-  void createWithLocalClusterUpdate(const bool enable_merge_window=true) {
+  void createWithLocalClusterUpdate(const bool enable_merge_window = true) {
     std::string yaml = R"EOF(
   static_resources:
     clusters:

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1662,6 +1662,19 @@ TEST_F(ClusterManagerImplTest, CoalescedUpdates) {
   // Ensure the coalesced updates were applied.
   timer->callback_();
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.coalesced_updates").value());
+
+  // Prepare a new timer.
+  timer = new NiceMock<Event::MockTimer>(&factory_.dispatcher_);
+
+  // Add them back.
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, hosts_per_locality, hosts_per_locality, {}, hosts_removed_0, hosts_added);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, hosts_per_locality, hosts_per_locality, {}, hosts_removed_1, hosts_added);
+
+  // Ensure the coalesced updates were applied again.
+  timer->callback_();
+  EXPECT_EQ(2, factory_.stats_.counter("cluster_manager.coalesced_updates").value());
 }
 
 class ClusterManagerInitHelperTest : public testing::Test {

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1684,16 +1684,6 @@ TEST_F(ClusterManagerImplTest, CoalescedUpdates) {
   createWithLocalClusterUpdate(parseBootstrapFromV2Yaml(yaml));
   EXPECT_FALSE(cluster_manager_->get("cluster_1")->info()->addedViaApi());
 
-  // Remove each host, sequentially.
-  const Cluster& cluster = cluster_manager_->clusters().begin()->second;
-
-  HostVectorSharedPtr hosts(
-      new HostVector(cluster.prioritySet().hostSetsPerPriority()[0]->hosts()));
-  HostsPerLocalitySharedPtr hosts_per_locality = std::make_shared<HostsPerLocalityImpl>();
-  HostVector hosts_added{};
-  HostVector hosts_removed_0{(*hosts)[0]};
-  HostVector hosts_removed_1{(*hosts)[1]};
-
   // Ensure we see the right set of added/removed hosts on every call.
   EXPECT_CALL(local_cluster_update_, post(_, _, _))
       .WillRepeatedly(Invoke([](uint32_t priority, const HostVector& hosts_added,
@@ -1720,6 +1710,15 @@ TEST_F(ClusterManagerImplTest, CoalescedUpdates) {
 
         ++call;
       }));
+
+  // Remove each host, sequentially.
+  const Cluster& cluster = cluster_manager_->clusters().begin()->second;
+  HostVectorSharedPtr hosts(
+      new HostVector(cluster.prioritySet().hostSetsPerPriority()[0]->hosts()));
+  HostsPerLocalitySharedPtr hosts_per_locality = std::make_shared<HostsPerLocalityImpl>();
+  HostVector hosts_added{};
+  HostVector hosts_removed_0{(*hosts)[0]};
+  HostVector hosts_removed_1{(*hosts)[1]};
 
   // No timer needs to be mocked at this point, since the first update should be applied
   // immediately.

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1812,7 +1812,7 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
 }
 
 // Tests that mergeable updates outside of a window get applied immediately.
-TEST_F(ClusterManagerImplTest, MergedUpdatesOffWindow) {
+TEST_F(ClusterManagerImplTest, MergedUpdatesOutOfWindow) {
   createWithLocalClusterUpdate();
 
   // Ensure we see the right set of added/removed hosts on every call.
@@ -1838,13 +1838,13 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesOffWindow) {
       hosts, hosts, hosts_per_locality, hosts_per_locality, {}, hosts_added, hosts_removed);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
-  EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.update_merge_offwindow").value());
+  EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.update_out_of_merge_window").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());
 }
 
 // Tests that mergeable updates outside of a window get applied immediately when
 // merging is disabled, and that the counters are correct.
-TEST_F(ClusterManagerImplTest, MergedUpdatesOffWindowDisabled) {
+TEST_F(ClusterManagerImplTest, MergedUpdatesOutOfWindowDisabled) {
   createWithLocalClusterUpdate(false);
 
   // Ensure we see the right set of added/removed hosts on every call.
@@ -1870,7 +1870,7 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesOffWindowDisabled) {
       hosts, hosts, hosts_per_locality, hosts_per_locality, {}, hosts_added, hosts_removed);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
-  EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_offwindow").value());
+  EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_out_of_merge_window").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());
 }
 

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1693,7 +1693,7 @@ TEST_F(ClusterManagerImplTest, OriginalDstInitialization) {
   factory_.tls_.shutdownThread();
 }
 
-TEST_F(ClusterManagerImplTest, CoalescedUpdates) {
+TEST_F(ClusterManagerImplTest, MergedUpdates) {
   createWithLocalClusterUpdate();
 
   // Ensure we see the right set of added/removed hosts on every call.
@@ -1744,9 +1744,9 @@ TEST_F(ClusterManagerImplTest, CoalescedUpdates) {
   cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
       hosts, hosts, hosts_per_locality, hosts_per_locality, {}, hosts_added, hosts_removed);
 
-  // Ensure the coalesced updates were applied.
+  // Ensure the merged updates were applied.
   timer->callback_();
-  EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.coalesced_updates").value());
+  EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.merged_updates").value());
 
   // Prepare a new timer for the next round of updates.
   timer = new NiceMock<Event::MockTimer>(&factory_.dispatcher_);
@@ -1761,12 +1761,12 @@ TEST_F(ClusterManagerImplTest, CoalescedUpdates) {
   cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
       hosts, hosts, hosts_per_locality, hosts_per_locality, {}, hosts_added, hosts_removed);
 
-  // Ensure the coalesced updates were applied again.
+  // Ensure the merged updates were applied again.
   timer->callback_();
-  EXPECT_EQ(2, factory_.stats_.counter("cluster_manager.coalesced_updates").value());
+  EXPECT_EQ(2, factory_.stats_.counter("cluster_manager.merged_updates").value());
 }
 
-TEST_F(ClusterManagerImplTest, CoalescedUpdatesAddRemoveAdd) {
+TEST_F(ClusterManagerImplTest, MergedUpdatesAddRemoveAdd) {
   createWithLocalClusterUpdate();
 
   // Ensure we see the right set of added/removed hosts on every call.
@@ -1782,7 +1782,7 @@ TEST_F(ClusterManagerImplTest, CoalescedUpdatesAddRemoveAdd) {
           EXPECT_EQ(0, hosts_removed.size());
           break;
         case 1:
-          // Merged call, add/remove/add is coalesced as 1 add.
+          // Merged call, add/remove/add is merged as 1 add.
           EXPECT_EQ(0, priority);
           EXPECT_EQ(1, hosts_added.size());
           EXPECT_EQ(0, hosts_removed.size());
@@ -1826,15 +1826,15 @@ TEST_F(ClusterManagerImplTest, CoalescedUpdatesAddRemoveAdd) {
   cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
       hosts, hosts, hosts_per_locality, hosts_per_locality, {}, hosts_added, hosts_removed);
 
-  // Ensure the coalesced updates were applied.
+  // Ensure the merged updates were applied.
   timer->callback_();
-  EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.coalesced_updates").value());
+  EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.merged_updates").value());
 
   // postThreadLocalClusterUpdate() calls.
   EXPECT_EQ(2, calls);
 }
 
-TEST_F(ClusterManagerImplTest, CoalescedUpdatesRemoveAddRemove) {
+TEST_F(ClusterManagerImplTest, MergedUpdatesRemoveAddRemove) {
   createWithLocalClusterUpdate();
 
   // Ensure we see the right set of added/removed hosts on every call.
@@ -1850,7 +1850,7 @@ TEST_F(ClusterManagerImplTest, CoalescedUpdatesRemoveAddRemove) {
           EXPECT_EQ(0, hosts_removed.size());
           break;
         case 1:
-          // Merged call, remove/add/remove is coalesced as 1 remove.
+          // Merged call, remove/add/remove is merged as 1 remove.
           EXPECT_EQ(0, priority);
           EXPECT_EQ(0, hosts_added.size());
           EXPECT_EQ(1, hosts_removed.size());
@@ -1895,15 +1895,15 @@ TEST_F(ClusterManagerImplTest, CoalescedUpdatesRemoveAddRemove) {
   cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
       hosts, hosts, hosts_per_locality, hosts_per_locality, {}, hosts_added, hosts_removed);
 
-  // Ensure the coalesced updates were applied.
+  // Ensure the merged updates were applied.
   timer->callback_();
-  EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.coalesced_updates").value());
+  EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.merged_updates").value());
 
   // postThreadLocalClusterUpdate() calls.
   EXPECT_EQ(2, calls);
 }
 
-TEST_F(ClusterManagerImplTest, CoalescedUpdatesHostChangesInPlace) {
+TEST_F(ClusterManagerImplTest, MergedUpdatesHostChangesInPlace) {
   createWithLocalClusterUpdate();
 
   // Ensure we see the right set of added/removed hosts on every call.
@@ -1919,7 +1919,7 @@ TEST_F(ClusterManagerImplTest, CoalescedUpdatesHostChangesInPlace) {
           EXPECT_EQ(0, hosts_removed.size());
           break;
         case 1:
-          // Merged call, failed/active/failed is coalesced as 1 call.
+          // Merged call, failed/active/failed is merged as 1 call.
           // Note, note, note: the host gets updated in place in the original
           // list of hosts in this case, so nothing expected here.
           EXPECT_EQ(0, priority);
@@ -1958,15 +1958,15 @@ TEST_F(ClusterManagerImplTest, CoalescedUpdatesHostChangesInPlace) {
   cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
       hosts, hosts, hosts_per_locality, hosts_per_locality, {}, hosts_added, hosts_removed);
 
-  // Ensure the coalesced updates were applied.
+  // Ensure the merged updates were applied.
   timer->callback_();
-  EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.coalesced_updates").value());
+  EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.merged_updates").value());
 
   // postThreadLocalClusterUpdate() calls.
   EXPECT_EQ(2, calls);
 }
 
-TEST_F(ClusterManagerImplTest, CoalescedUpdatesMetadataLatest) {
+TEST_F(ClusterManagerImplTest, MergedUpdatesMetadataLatest) {
   createWithLocalClusterUpdate();
 
   // Ensure we see the right set of added/removed hosts on every call.
@@ -1982,7 +1982,7 @@ TEST_F(ClusterManagerImplTest, CoalescedUpdatesMetadataLatest) {
           EXPECT_EQ(0, hosts_removed.size());
           break;
         case 1:
-          // Merged call, add/remove/add is coalesced as 1 add.
+          // Merged call, add/remove/add is merged as 1 add.
           // We should see the latest metadata.
           EXPECT_EQ(0, priority);
           EXPECT_EQ(1, hosts_added.size());
@@ -2034,15 +2034,15 @@ TEST_F(ClusterManagerImplTest, CoalescedUpdatesMetadataLatest) {
   cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
       hosts, hosts, hosts_per_locality, hosts_per_locality, {}, hosts_added, hosts_removed);
 
-  // Ensure the coalesced updates were applied.
+  // Ensure the merged updates were applied.
   timer->callback_();
-  EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.coalesced_updates").value());
+  EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.merged_updates").value());
 
   // postThreadLocalClusterUpdate() calls.
   EXPECT_EQ(2, calls);
 }
 
-TEST_F(ClusterManagerImplTest, CoalescedUpdatesWeightLatest) {
+TEST_F(ClusterManagerImplTest, MergedUpdatesWeightLatest) {
   createWithLocalClusterUpdate();
 
   // Ensure we see the right set of added/removed hosts on every call.
@@ -2058,7 +2058,7 @@ TEST_F(ClusterManagerImplTest, CoalescedUpdatesWeightLatest) {
           EXPECT_EQ(0, hosts_removed.size());
           break;
         case 1:
-          // Merged call, add/remove/add is coalesced as 1 add.
+          // Merged call, add/remove/add is merged as 1 add.
           // We should the latest weight
           EXPECT_EQ(0, priority);
           EXPECT_EQ(1, hosts_added.size());
@@ -2108,9 +2108,9 @@ TEST_F(ClusterManagerImplTest, CoalescedUpdatesWeightLatest) {
   cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
       hosts, hosts, hosts_per_locality, hosts_per_locality, {}, hosts_added, hosts_removed);
 
-  // Ensure the coalesced updates were applied.
+  // Ensure the merged updates were applied.
   timer->callback_();
-  EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.coalesced_updates").value());
+  EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.merged_updates").value());
 
   // postThreadLocalClusterUpdate() calls.
   EXPECT_EQ(2, calls);

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1809,7 +1809,6 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
   EXPECT_EQ(3, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());
-
 }
 
 // Tests that mergeable updates outside of a window get applied immediately.


### PR DESCRIPTION
This change introduces a new configuration parameter for clusters,
`update_merge_window`.

If this is set, health check/metadata/weight changes on endpoints that happen
within a `update_merge_window` duration will be merged and delivered
at once when the duration ends.

This is useful for big clusters (> 1k endpoints) using the subset LB.

Note, note, note: hosts added/removed *won't* be merged into a single
update because it's very hard to do this correctly right now.

Partially addresses https://github.com/envoyproxy/envoy/issues/3929.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
