### PR TITLE
Upgrade bazelbuild rules_go to latest release: 0.13.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,7 +10,5 @@ load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
 api_dependencies()
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
-load("@com_lyft_protoc_gen_validate//bazel:go_proto_library.bzl", "go_proto_repositories")
-go_proto_repositories(shared=0)
 go_rules_dependencies()
 go_register_toolchains()

--- a/api/bazel/repositories.bzl
+++ b/api/bazel/repositories.bzl
@@ -3,7 +3,7 @@ GOGOPROTO_SHA = "1adfc126b41513cc696b209667c8656ea7aac67c"  # v1.0.0
 PROMETHEUS_SHA = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"  # Nov 17, 2017
 OPENCENSUS_SHA = "ab82e5fdec8267dc2a726544b10af97675970847"  # May 23, 2018
 
-PGV_GIT_SHA = "f9d2b11e44149635b23a002693b76512b01ae515"
+PGV_GIT_SHA = "e60e7f91da46a87d9067679064571c6954343c3c"  # July 31, 2018
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -119,7 +119,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/grpc-ecosystem/grpc-httpjson-transcoding",
     ),
     io_bazel_rules_go = dict(
-        commit = "0.13.0",
+        commit = "e60e7f91da46a87d9067679064571c6954343c3c",  # 2018-07-31
         remote = "https://github.com/bazelbuild/rules_go",
     ),
     six_archive = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -119,7 +119,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/grpc-ecosystem/grpc-httpjson-transcoding",
     ),
     io_bazel_rules_go = dict(
-        commit = "e60e7f91da46a87d9067679064571c6954343c3c",  # 2018-07-31
+        commit = "0.13.0",
         remote = "https://github.com/bazelbuild/rules_go",
     ),
     six_archive = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -119,7 +119,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/grpc-ecosystem/grpc-httpjson-transcoding",
     ),
     io_bazel_rules_go = dict(
-        commit = "0.11.1",
+        commit = "0.13.0",
         remote = "https://github.com/bazelbuild/rules_go",
     ),
     six_archive = dict(

--- a/ci/WORKSPACE
+++ b/ci/WORKSPACE
@@ -19,8 +19,6 @@ load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
 api_dependencies()
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
-load("@com_lyft_protoc_gen_validate//bazel:go_proto_library.bzl", "go_proto_repositories")
-go_proto_repositories(shared=0)
 go_rules_dependencies()
 go_register_toolchains()
 load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")

--- a/ci/WORKSPACE.filter.example
+++ b/ci/WORKSPACE.filter.example
@@ -18,8 +18,6 @@ load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
 api_dependencies()
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
-load("@com_lyft_protoc_gen_validate//bazel:go_proto_library.bzl", "go_proto_repositories")
-go_proto_repositories(shared=0)
 go_rules_dependencies()
 go_register_toolchains()
 load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")


### PR DESCRIPTION
There have been some new features and significant improvements since release 0.11.0 that should be picked up.