### PR TITLE
websocket: fixing websocket to consistently not send connection: close when draining

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1006,7 +1006,7 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
     // If the connection manager is draining send "Connection: Close" on HTTP/1.1 connections.
     // Do not do this for H2 (which drains via GOAWA) or Upgrade (as the upgrade
     // payload is no longer HTTP/1.1)
-    if (headers.Connection() == nullptr || headers.Connection()->value() != "Upgrade") {
+    if (!Utility::isUpgrade(headers)) {
       headers.insertConnection().value().setReference(Headers::get().ConnectionValues.Close);
     }
   }


### PR DESCRIPTION
Using the isUpgrade utility for consistent handling of upgrade strings w.r.t. case sensitivity.

*Risk Level*: Low (should only affect WebSocket, only when draining)
*Testing*: new regression unit test
*Docs Changes*: n/a
*Release Notes*: n/a
