### PR TITLE
Add overload manager for Envoy

### DIFF
--- a/api/envoy/config/overload/v2alpha/BUILD
+++ b/api/envoy/config/overload/v2alpha/BUILD
@@ -6,5 +6,6 @@ api_proto_library_internal(
     name = "overload",
     srcs = ["overload.proto"],
     deps = [
+        "//envoy/type:percent",
     ],
 )

--- a/api/envoy/config/overload/v2alpha/BUILD
+++ b/api/envoy/config/overload/v2alpha/BUILD
@@ -5,7 +5,4 @@ licenses(["notice"])  # Apache 2
 api_proto_library_internal(
     name = "overload",
     srcs = ["overload.proto"],
-    deps = [
-        "//envoy/type:percent",
-    ],
 )

--- a/api/envoy/config/overload/v2alpha/BUILD
+++ b/api/envoy/config/overload/v2alpha/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "overload",
+    srcs = ["overload.proto"],
+    deps = [
+    ],
+)

--- a/api/envoy/config/overload/v2alpha/overload.proto
+++ b/api/envoy/config/overload/v2alpha/overload.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 package envoy.config.overload.v2alpha;
 option go_package = "v2alpha";
 
+import "envoy/type/percent.proto";
+
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 
@@ -24,14 +26,14 @@ message ResourceMonitor {
 }
 
 message ThresholdTrigger {
-  // If the resource metric (ie. pressure) is greater than or equal to this value, the trigger
+  // If the resource pressure is greater than or equal to this value, the trigger
   // will fire.
-  double value = 1;
+  envoy.type.Percent pressure = 1;
 }
 
 message Trigger {
   // The name of the resource this is a trigger for.
-  string name = 1;
+  string name = 1 [(validate.rules).string.min_bytes = 1];
 
   oneof trigger_oneof {
     ThresholdTrigger threshold = 2;
@@ -42,12 +44,12 @@ message OverloadAction {
   // The name of the overload action. This is just a well-known string that listeners can
   // use for registering callbacks. Custom overload actions should be named using reverse
   // DNS to ensure uniqueness.
-  string name = 1;
+  string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // A set of triggers for this action. If any of these triggers fires the overload action
   // is activated. Listeners are notified when the overload action transitions from
   // inactivated to activated, or vice versa.
-  repeated Trigger triggers = 2;
+  repeated Trigger triggers = 2 [(validate.rules).repeated .min_items = 1];
 }
 
 message OverloadManager {
@@ -55,8 +57,8 @@ message OverloadManager {
   google.protobuf.Duration refresh_interval = 1;
 
   // The set of resources to monitor.
-  repeated ResourceMonitor resource_monitors = 2;
+  repeated ResourceMonitor resource_monitors = 2 [(validate.rules).repeated .min_items = 1];
 
   // The set of overload actions.
-  repeated OverloadAction actions = 3;
+  repeated OverloadAction actions = 3 [(validate.rules).repeated .min_items = 1];
 }

--- a/api/envoy/config/overload/v2alpha/overload.proto
+++ b/api/envoy/config/overload/v2alpha/overload.proto
@@ -3,8 +3,6 @@ syntax = "proto3";
 package envoy.config.overload.v2alpha;
 option go_package = "v2alpha";
 
-import "envoy/type/percent.proto";
-
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 
@@ -28,7 +26,7 @@ message ResourceMonitor {
 message ThresholdTrigger {
   // If the resource pressure is greater than or equal to this value, the trigger
   // will fire.
-  envoy.type.Percent pressure = 1;
+  double value = 1 [(validate.rules).double = {gte: 0, lte: 1}];
 }
 
 message Trigger {
@@ -36,6 +34,7 @@ message Trigger {
   string name = 1 [(validate.rules).string.min_bytes = 1];
 
   oneof trigger_oneof {
+    option (validate.required) = true;
     ThresholdTrigger threshold = 2;
   }
 }

--- a/api/envoy/config/overload/v2alpha/overload.proto
+++ b/api/envoy/config/overload/v2alpha/overload.proto
@@ -1,0 +1,62 @@
+syntax = "proto3";
+
+package envoy.config.overload.v2alpha;
+option go_package = "v2alpha";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+
+import "validate/validate.proto";
+
+// The Overload Manager provides an extensible framework to protect Envoy instances
+// from overload of various resources (memory, cpu, file descriptors, etc)
+
+message EmptyConfig {
+}
+
+message ResourceMonitor {
+  // The name of the resource monitor to instantiate. Must match a registered
+  // resource monitor type.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Configuration for the resource monitor being instantiated.
+  google.protobuf.Struct config = 2;
+}
+
+message ThresholdTrigger {
+  // If the resource metric (ie. pressure) is greater than or equal to this value, the trigger
+  // will fire.
+  double value = 1;
+}
+
+message Trigger {
+  // The name of the resource this is a trigger for.
+  string name = 1;
+
+  oneof trigger_oneof {
+    ThresholdTrigger threshold = 2;
+  }
+}
+
+message OverloadAction {
+  // The name of the overload action. This is just a well-known string that listeners can
+  // use for registering callbacks. Custom overload actions should be named using reverse
+  // DNS to ensure uniqueness.
+  string name = 1;
+
+  // A set of triggers for this action. If any of these triggers fires the overload action
+  // is activated. Listeners are notified when the overload action transitions from
+  // inactivated to activated, or vice versa.
+  repeated Trigger triggers = 2;
+}
+
+message OverloadManager {
+  // The interval for refreshing resource usage.
+  google.protobuf.Duration refresh_interval = 1;
+
+  // The set of resources to monitor.
+  repeated ResourceMonitor resource_monitors = 2;
+
+  // The set of overload actions.
+  repeated OverloadAction actions = 3;
+}

--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -198,3 +198,10 @@ envoy_cc_library(
         "//include/envoy/event:dispatcher_interface",
     ],
 )
+
+envoy_cc_library(
+    name = "overload_manager_interface",
+    hdrs = ["overload_manager.h"],
+    deps = [
+    ],
+)

--- a/include/envoy/server/overload_manager.h
+++ b/include/envoy/server/overload_manager.h
@@ -5,6 +5,22 @@
 namespace Envoy {
 namespace Server {
 
+enum class OverloadActionState {
+  /**
+   * Indicates that an overload action is active because at least one of its triggers has fired.
+   */
+  Active,
+  /**
+   * Indicates that an overload action is inactive because none of its triggers have fired.
+   */
+  Inactive
+};
+
+/**
+ * Callback invoked when an overload action changes state.
+ */
+typedef std::function<void(OverloadActionState)> OverloadActionCb;
+
 /**
  * The OverloadManager protects the Envoy instance from being overwhelmed by client
  * requests. It monitors a set of resources and notifies registered listeners if
@@ -15,21 +31,15 @@ public:
   virtual ~OverloadManager() {}
 
   /**
-   * Start a recurring timer to monitor resources and notify listeners when overload actions
-   * change state.
-   */
-  virtual void start() PURE;
-
-  /**
    * Register a callback to be invoked when the specified overload action changes state
    * (ie. becomes activated or inactivated). Must be called before the start method is called.
    * @param action const std::string& the name of the overload action to register for
    * @param dispatcher Event::Dispatcher& the dispatcher on which callbacks will be posted
-   * @param callback std::function<void(bool)> the callback to post when the overload action
+   * @param callback OverloadActionCb the callback to post when the overload action
    *        changes state
    */
   virtual void registerForAction(const std::string& action, Event::Dispatcher& dispatcher,
-                                 std::function<void(bool)> callback) PURE;
+                                 OverloadActionCb callback) PURE;
 };
 
 } // namespace Server

--- a/include/envoy/server/overload_manager.h
+++ b/include/envoy/server/overload_manager.h
@@ -21,9 +21,12 @@ public:
   virtual void start() PURE;
 
   /**
-   * Register a callback to be invoked when the specified action changes state (ie. becomes
-   * activated or inactivated). The callback is posted with the given dispatcher.
-   * Must only be called during Envoy initialization when still in single-threaded mode.
+   * Register a callback to be invoked when the specified overload action changes state
+   * (ie. becomes activated or inactivated). Must be called before the start method is called.
+   * @param action const std::string& the name of the overload action to register for
+   * @param dispatcher Event::Dispatcher& the dispatcher on which callbacks will be posted
+   * @param callback std::function<void(bool)> the callback to post when the overload action
+   *        changes state
    */
   virtual void registerForAction(const std::string& action, Event::Dispatcher& dispatcher,
                                  std::function<void(bool)> callback) PURE;

--- a/include/envoy/server/overload_manager.h
+++ b/include/envoy/server/overload_manager.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "envoy/common/pure.h"
+
+namespace Envoy {
+namespace Server {
+
+/**
+ * The OverloadManager protects the Envoy instance from being overwhelmed by client
+ * requests. It monitors a set of resources and notifies registered listeners if
+ * configured thresholds for those resources have been exceeded.
+ */
+class OverloadManager {
+public:
+  virtual ~OverloadManager() {}
+
+  /**
+   * Start a recurring timer to monitor resources and notify listeners when overload actions
+   * change state.
+   */
+  virtual void start() PURE;
+
+  /**
+   * Register a callback to be invoked when the specified action changes state (ie. becomes
+   * activated or inactivated). The callback is posted with the given dispatcher.
+   * Must only be called during Envoy initialization when still in single-threaded mode.
+   */
+  virtual void registerForAction(const std::string& action, Event::Dispatcher& dispatcher,
+                                 std::function<void(bool)> callback) PURE;
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/include/envoy/server/resource_monitor_config.h
+++ b/include/envoy/server/resource_monitor_config.h
@@ -42,6 +42,13 @@ public:
                                                    ResourceMonitorFactoryContext& context) PURE;
 
   /**
+   * @return ProtobufTypes::MessagePtr create empty config proto message. The resource monitor
+   *         config, which arrives in an opaque google.protobuf.Struct message, will be converted
+   *         to JSON and then parsed into this empty proto.
+   */
+  virtual ProtobufTypes::MessagePtr createEmptyConfigProto() PURE;
+
+  /**
    * @return std::string the identifying name for a particular implementation of a resource
    * monitor produced by the factory.
    */

--- a/source/extensions/resource_monitors/common/factory_base.h
+++ b/source/extensions/resource_monitors/common/factory_base.h
@@ -19,6 +19,10 @@ public:
         MessageUtil::downcastAndValidate<const ConfigProto&>(config), context);
   }
 
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<ConfigProto>();
+  }
+
   std::string name() override { return name_; }
 
 protected:

--- a/source/extensions/resource_monitors/fixed_heap/config.h
+++ b/source/extensions/resource_monitors/fixed_heap/config.h
@@ -15,8 +15,7 @@ class FixedHeapMonitorFactory
     : public Common::FactoryBase<
           envoy::config::resource_monitor::fixed_heap::v2alpha::FixedHeapConfig> {
 public:
-  FixedHeapMonitorFactory()
-      : FactoryBase(ResourceMonitorNames::get().FIXED_HEAP_RESOURCE_MONITOR) {}
+  FixedHeapMonitorFactory() : FactoryBase(ResourceMonitorNames::get().FixedHeap) {}
 
 private:
   Server::ResourceMonitorPtr createResourceMonitorFromProtoTyped(

--- a/source/extensions/resource_monitors/well_known_names.h
+++ b/source/extensions/resource_monitors/well_known_names.h
@@ -13,7 +13,7 @@ namespace ResourceMonitors {
 class ResourceMonitorNameValues {
 public:
   // Heap monitor with statically configured max.
-  const std::string FIXED_HEAP_RESOURCE_MONITOR = "envoy.resource_monitors.fixed_heap";
+  const std::string FixedHeap = "envoy.resource_monitors.fixed_heap";
 };
 
 typedef ConstSingleton<ResourceMonitorNameValues> ResourceMonitorNames;

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -160,6 +160,19 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "overload_manager_lib",
+    srcs = ["overload_manager_impl.cc"],
+    hdrs = ["overload_manager_impl.h"],
+    deps = [
+        "//include/envoy/server:overload_manager_interface",
+        "//source/common/common:logger_lib",
+        "//source/common/config:utility_lib",
+        "//source/server:resource_monitor_config_lib",
+        "@envoy_api//envoy/config/overload/v2alpha:overload_cc",
+    ],
+)
+
+envoy_cc_library(
     name = "lds_api_lib",
     srcs = ["lds_api.cc"],
     hdrs = ["lds_api.h"],

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -157,7 +157,7 @@ void OverloadManagerImpl::updateResourcePressure(const std::string& resource, do
                     std::for_each(callback_range.first, callback_range.second,
                                   [&](ActionToCallbackMap::value_type& cb_entry) {
                                     auto& cb = cb_entry.second;
-                                    cb.dispatcher_.post([&, is_active]() { cb.callback_(state); });
+                                    cb.dispatcher_.post([&, state]() { cb.callback_(state); });
                                   });
                   }
                 });

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -1,0 +1,184 @@
+#include "server/overload_manager_impl.h"
+
+#include "common/config/utility.h"
+#include "common/protobuf/utility.h"
+
+#include "server/resource_monitor_config_impl.h"
+
+namespace Envoy {
+namespace Server {
+
+namespace {
+
+class ThresholdTriggerImpl : public OverloadActionImpl::Trigger {
+public:
+  ThresholdTriggerImpl(const envoy::config::overload::v2alpha::ThresholdTrigger& config)
+      : threshold_(config.value()) {
+    RELEASE_ASSERT(threshold_ >= 0, "");
+    RELEASE_ASSERT(threshold_ <= 1, "");
+  }
+
+  bool updateValue(double value) {
+    const bool fired = isFired();
+    value_ = value;
+    return fired != isFired();
+  }
+
+  bool isFired() const { return value_.has_value() && value_ >= threshold_; }
+
+private:
+  const double threshold_;
+  absl::optional<double> value_;
+};
+
+} // namespace
+
+OverloadActionImpl::OverloadActionImpl(
+    const envoy::config::overload::v2alpha::OverloadAction& config) {
+  for (const auto& trigger_config : config.triggers()) {
+    TriggerPtr trigger;
+
+    switch (trigger_config.trigger_oneof_case()) {
+    case envoy::config::overload::v2alpha::Trigger::kThreshold:
+      trigger = std::make_unique<ThresholdTriggerImpl>(trigger_config.threshold());
+      break;
+    case envoy::config::overload::v2alpha::Trigger::TRIGGER_ONEOF_NOT_SET:
+      RELEASE_ASSERT(false, "missing trigger");
+    }
+
+    const auto result = triggers_.insert(std::make_pair(trigger_config.name(), std::move(trigger)));
+    RELEASE_ASSERT(result.second, "duplicate trigger");
+  }
+}
+
+bool OverloadActionImpl::updateResourcePressure(const std::string& name, double pressure) {
+  const bool active = isActive();
+
+  auto it = triggers_.find(name);
+  ASSERT(it != triggers_.end());
+  if (it->second->updateValue(pressure)) {
+    if (it->second->isFired()) {
+      const auto result = fired_triggers_.insert(name);
+      ASSERT(result.second);
+    } else {
+      const auto result = fired_triggers_.erase(name);
+      ASSERT(result == 1);
+    }
+  }
+
+  return active != isActive();
+}
+
+bool OverloadActionImpl::isActive() const { return !fired_triggers_.empty(); }
+
+OverloadManagerImpl::OverloadManagerImpl(
+    Event::Dispatcher& dispatcher, const envoy::config::overload::v2alpha::OverloadManager& config)
+    : started_(false), dispatcher_(dispatcher),
+      refresh_interval_(
+          std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(config, refresh_interval, 1000))) {
+  Configuration::ResourceMonitorFactoryContextImpl context(dispatcher);
+  for (const auto& resource : config.resource_monitors()) {
+    const auto& name = resource.name();
+    ENVOY_LOG(debug, "Adding resource monitor for {}", name);
+    auto& factory =
+        Config::Utility::getAndCheckFactory<Configuration::ResourceMonitorFactory>(name);
+    auto config = Config::Utility::translateToFactoryConfig(resource, factory);
+    auto monitor = factory.createResourceMonitor(*config, context);
+
+    auto result = resources_.emplace(std::piecewise_construct, std::forward_as_tuple(name),
+                                     std::forward_as_tuple(name, std::move(monitor), *this));
+    RELEASE_ASSERT(result.second, "duplicate resource monitor");
+  }
+
+  for (const auto& action : config.actions()) {
+    const auto& name = action.name();
+    ENVOY_LOG(debug, "Adding overload action {}", name);
+    auto result = actions_.emplace(std::piecewise_construct, std::forward_as_tuple(name),
+                                   std::forward_as_tuple(action));
+    RELEASE_ASSERT(result.second, "duplicate overload action");
+
+    std::unordered_set<std::string> resources;
+    for (const auto& trigger : action.triggers()) {
+      const std::string resource = trigger.name();
+
+      RELEASE_ASSERT(resources_.find(resource) != resources_.end(), "unknown resource");
+      RELEASE_ASSERT(resources.insert(resource).second, "duplicate trigger");
+
+      resource_to_actions_.insert(std::make_pair(resource, name));
+    }
+  }
+}
+
+void OverloadManagerImpl::start() {
+  RELEASE_ASSERT(!started_, "");
+  started_ = true;
+  timer_ = dispatcher_.createTimer([this]() -> void {
+    for (auto& resource : resources_) {
+      resource.second.update();
+    }
+
+    timer_->enableTimer(refresh_interval_);
+  });
+  timer_->enableTimer(refresh_interval_);
+}
+
+void OverloadManagerImpl::registerForAction(const std::string& action,
+                                            Event::Dispatcher& dispatcher,
+                                            std::function<void(bool)> callback) {
+  RELEASE_ASSERT(!started_, "");
+
+  if (actions_.find(action) == actions_.end()) {
+    ENVOY_LOG(debug, "No overload action configured for {}.", action);
+    return;
+  }
+
+  action_to_callbacks_.emplace(std::piecewise_construct, std::forward_as_tuple(action),
+                               std::forward_as_tuple(dispatcher, callback));
+}
+
+void OverloadManagerImpl::updateResourcePressure(const std::string& resource, double pressure) {
+  auto action_range = resource_to_actions_.equal_range(resource);
+  typedef std::unordered_multimap<std::string, std::string> ActionMap;
+  typedef std::unordered_multimap<std::string, ActionCallback> CallbackMap;
+  std::for_each(action_range.first, action_range.second, [&](ActionMap::value_type& entry) {
+    const std::string& action = entry.second;
+    auto action_it = actions_.find(entry.second);
+    ASSERT(action_it != actions_.end());
+    if (action_it->second.updateResourcePressure(resource, pressure)) {
+      const bool is_active = action_it->second.isActive();
+      ENVOY_LOG(info, "Overload action {} has become {}", action,
+                is_active ? "active" : "inactive");
+      auto callback_range = action_to_callbacks_.equal_range(action);
+      std::for_each(callback_range.first, callback_range.second,
+                    [&](CallbackMap::value_type& cb_entry) {
+                      auto& cb = cb_entry.second;
+                      cb.dispatcher_.post([&]() { cb.callback_(is_active); });
+                    });
+    }
+  });
+}
+
+void OverloadManagerImpl::Resource::update() {
+  if (!pending_update_) {
+    pending_update_ = true;
+    monitor_->updateResourceUsage(*this);
+    return;
+  }
+  ENVOY_LOG(debug, "Skipping update for resource {} which has pending update", name_);
+  // TODO(eziskind) add stat
+}
+
+void OverloadManagerImpl::Resource::onSuccess(const ResourceUsage& usage) {
+  pending_update_ = false;
+  manager_.updateResourcePressure(name_, usage.resource_pressure_);
+}
+
+void OverloadManagerImpl::Resource::onFailure(const EnvoyException& error) {
+  pending_update_ = false;
+  ENVOY_LOG(info, "Failed to update resource {}: {}", name_, error.what());
+
+  // TODO(eziskind): add stat
+}
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -14,7 +14,7 @@ namespace {
 class ThresholdTriggerImpl : public OverloadActionImpl::Trigger {
 public:
   ThresholdTriggerImpl(const envoy::config::overload::v2alpha::ThresholdTrigger& config)
-      : threshold_(config.pressure().value()) {}
+      : threshold_(config.value()) {}
 
   bool updateValue(double value) {
     const bool fired = isFired();

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <chrono>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "envoy/config/overload/v2alpha/overload.pb.validate.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/server/overload_manager.h"
+#include "envoy/server/resource_monitor.h"
+
+#include "common/common/logger.h"
+
+namespace Envoy {
+namespace Server {
+
+class OverloadActionImpl {
+public:
+  OverloadActionImpl(const envoy::config::overload::v2alpha::OverloadAction& config);
+
+  // Updates the current pressure for the given resource and returns whether the action
+  // has changed state.
+  bool updateResourcePressure(const std::string& name, double pressure);
+
+  // Returns whether the action is currently active or not.
+  bool isActive() const;
+
+  class Trigger {
+  public:
+    virtual ~Trigger() {}
+
+    // Updates the current value of the metric and returns whether the trigger has changed state.
+    virtual bool updateValue(double value) = 0;
+
+    // Returns whether the trigger is currently fired or not.
+    virtual bool isFired() const = 0;
+  };
+  typedef std::unique_ptr<Trigger> TriggerPtr;
+
+private:
+  std::unordered_map<std::string, TriggerPtr> triggers_;
+  std::unordered_set<std::string> fired_triggers_;
+};
+
+class OverloadManagerImpl : Logger::Loggable<Logger::Id::main>, public OverloadManager {
+public:
+  OverloadManagerImpl(Event::Dispatcher& dispatcher,
+                      const envoy::config::overload::v2alpha::OverloadManager& config);
+
+  void start() override;
+
+  void registerForAction(const std::string& action, Event::Dispatcher& dispatcher,
+                         std::function<void(bool)> callback) override;
+
+private:
+  class Resource : public ResourceMonitor::Callbacks {
+  public:
+    Resource(const std::string& name, ResourceMonitorPtr monitor, OverloadManagerImpl& manager)
+        : name_(name), monitor_(std::move(monitor)), manager_(manager), pending_update_(false) {}
+
+    void onSuccess(const ResourceUsage& usage) override;
+    void onFailure(const EnvoyException& error) override;
+
+    void update();
+
+  private:
+    const std::string name_;
+    ResourceMonitorPtr monitor_;
+    OverloadManagerImpl& manager_;
+    bool pending_update_;
+  };
+
+  struct ActionCallback {
+    ActionCallback(Event::Dispatcher& dispatcher, std::function<void(bool)> callback)
+        : dispatcher_(dispatcher), callback_(callback) {}
+    Event::Dispatcher& dispatcher_;
+    std::function<void(bool)> callback_;
+  };
+
+  void updateResourcePressure(const std::string& resource, double pressure);
+
+  bool started_;
+  Event::Dispatcher& dispatcher_;
+  const std::chrono::milliseconds refresh_interval_;
+  Event::TimerPtr timer_;
+  std::unordered_map<std::string, Resource> resources_;
+  std::unordered_map<std::string, OverloadActionImpl> actions_;
+  std::unordered_multimap<std::string, std::string> resource_to_actions_;
+  std::unordered_multimap<std::string, ActionCallback> action_to_callbacks_;
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -48,8 +48,8 @@ public:
   OverloadManagerImpl(Event::Dispatcher& dispatcher,
                       const envoy::config::overload::v2alpha::OverloadManager& config);
 
+  // Server::OverloadManager
   void start() override;
-
   void registerForAction(const std::string& action, Event::Dispatcher& dispatcher,
                          std::function<void(bool)> callback) override;
 
@@ -59,6 +59,7 @@ private:
     Resource(const std::string& name, ResourceMonitorPtr monitor, OverloadManagerImpl& manager)
         : name_(name), monitor_(std::move(monitor)), manager_(manager), pending_update_(false) {}
 
+    // ResourceMonitor::Callbacks
     void onSuccess(const ResourceUsage& usage) override;
     void onFailure(const EnvoyException& error) override;
 
@@ -86,8 +87,12 @@ private:
   Event::TimerPtr timer_;
   std::unordered_map<std::string, Resource> resources_;
   std::unordered_map<std::string, OverloadActionImpl> actions_;
-  std::unordered_multimap<std::string, std::string> resource_to_actions_;
-  std::unordered_multimap<std::string, ActionCallback> action_to_callbacks_;
+
+  typedef std::unordered_multimap<std::string, std::string> ResourceToActionMap;
+  ResourceToActionMap resource_to_actions_;
+
+  typedef std::unordered_multimap<std::string, ActionCallback> ActionToCallbackMap;
+  ActionToCallbackMap action_to_callbacks_;
 };
 
 } // namespace Server

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -120,6 +120,8 @@ envoy_cc_test(
         "//source/extensions/resource_monitors/common:factory_base_lib",
         "//source/server:overload_manager_lib",
         "//test/mocks/event:event_mocks",
+        "//test/test_common:registry_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -113,6 +113,17 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "overload_manager_impl_test",
+    srcs = ["overload_manager_impl_test.cc"],
+    deps = [
+        "//include/envoy/registry",
+        "//source/extensions/resource_monitors/common:factory_base_lib",
+        "//source/server:overload_manager_lib",
+        "//test/mocks/event:event_mocks",
+    ],
+)
+
+envoy_cc_test(
     name = "lds_api_test",
     srcs = ["lds_api_test.cc"],
     data = [

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -83,7 +83,7 @@ protected:
   envoy::config::overload::v2alpha::OverloadManager parseConfig(const std::string& config) {
     envoy::config::overload::v2alpha::OverloadManager proto;
     bool success = Protobuf::TextFormat::ParseFromString(config, &proto);
-    RELEASE_ASSERT(success, "");
+    ASSERT(success);
     return proto;
   }
 
@@ -133,7 +133,7 @@ TEST_F(OverloadManagerImplTest, CallbackOnlyFiresWhenStateChanges) {
     cb_count++;
   });
   manager.registerForAction("envoy.overload_actions.unknown_action", dispatcher_,
-                            [&](bool) { RELEASE_ASSERT(false, ""); });
+                            [&](bool) { ASSERT(false); });
   manager.start();
 
   factory1_.monitor_->setPressure(0.5);

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -128,12 +128,13 @@ TEST_F(OverloadManagerImplTest, CallbackOnlyFiresWhenStateChanges) {
   OverloadManagerImpl manager(dispatcher_, parseConfig(config));
   bool is_active = false;
   int cb_count = 0;
-  manager.registerForAction("envoy.overload_actions.dummy_action", dispatcher_, [&](bool value) {
-    is_active = value;
-    cb_count++;
-  });
+  manager.registerForAction("envoy.overload_actions.dummy_action", dispatcher_,
+                            [&](OverloadActionState state) {
+                              is_active = state == OverloadActionState::Active;
+                              cb_count++;
+                            });
   manager.registerForAction("envoy.overload_actions.unknown_action", dispatcher_,
-                            [&](bool) { ASSERT(false); });
+                            [&](OverloadActionState) { ASSERT(false); });
   manager.start();
 
   factory1_.monitor_->setPressure(0.5);

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -1,0 +1,169 @@
+#include "envoy/registry/registry.h"
+#include "envoy/server/resource_monitor.h"
+#include "envoy/server/resource_monitor_config.h"
+
+#include "server/overload_manager_impl.h"
+
+#include "extensions/resource_monitors/common/factory_base.h"
+
+#include "test/mocks/event/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::Invoke;
+using testing::NiceMock;
+using testing::_;
+
+namespace Envoy {
+namespace Server {
+
+class FakeResourceMonitor : public ResourceMonitor {
+public:
+  FakeResourceMonitor(Event::Dispatcher& dispatcher)
+      : success_(true), pressure_(0), error_("fake error"), dispatcher_(dispatcher) {}
+
+  void setPressure(double pressure) {
+    success_ = true;
+    pressure_ = pressure;
+  }
+
+  void setError() { success_ = false; }
+
+  void updateResourceUsage(ResourceMonitor::Callbacks& callbacks) override {
+    if (success_) {
+      Server::ResourceUsage usage;
+      usage.resource_pressure_ = pressure_;
+      dispatcher_.post([&, usage]() { callbacks.onSuccess(usage); });
+    } else {
+      EnvoyException& error = error_;
+      dispatcher_.post([&, error]() { callbacks.onFailure(error); });
+    }
+  }
+
+private:
+  bool success_;
+  double pressure_;
+  EnvoyException error_;
+  Event::Dispatcher& dispatcher_;
+};
+
+class FakeResourceMonitorFactory : public Extensions::ResourceMonitors::Common::FactoryBase<
+                                       envoy::config::overload::v2alpha::EmptyConfig> {
+public:
+  FakeResourceMonitorFactory(const std::string& name) : FactoryBase(name), monitor_(nullptr) {}
+
+  ResourceMonitorPtr createResourceMonitorFromProtoTyped(
+      const envoy::config::overload::v2alpha::EmptyConfig&,
+      Server::Configuration::ResourceMonitorFactoryContext& context) override {
+    ASSERT(!monitor_);
+    auto monitor = std::make_unique<FakeResourceMonitor>(context.dispatcher());
+    monitor_ = monitor.get();
+    return std::move(monitor);
+  }
+
+  FakeResourceMonitor* monitor_; // not owned
+};
+
+class OverloadManagerImplTest : public testing::Test {
+protected:
+  OverloadManagerImplTest()
+      : factory1_("envoy.resource_monitors.fake_resource1"),
+        factory2_("envoy.resource_monitors.fake_resource2") {
+    EXPECT_CALL(dispatcher_, createTimer_(_)).WillOnce(Invoke([&](Event::TimerCb cb) {
+      timer_cb_ = cb;
+      return new NiceMock<Event::MockTimer>();
+    }));
+
+    Registry::FactoryRegistry<Configuration::ResourceMonitorFactory>::registerFactory(factory1_);
+    Registry::FactoryRegistry<Configuration::ResourceMonitorFactory>::registerFactory(factory2_);
+  }
+
+  envoy::config::overload::v2alpha::OverloadManager getConfig() {
+    const std::string config = R"EOF(
+    refresh_interval {
+      seconds: 1
+    }
+    resource_monitors {
+      name: "envoy.resource_monitors.fake_resource1"
+    }
+    resource_monitors {
+      name: "envoy.resource_monitors.fake_resource2"
+    }
+    actions {
+      name: "envoy.overload_actions.dummy_action"
+      triggers {
+        name: "envoy.resource_monitors.fake_resource1"
+        threshold {
+          value: 0.9
+        }
+      }
+      triggers {
+        name: "envoy.resource_monitors.fake_resource2"
+        threshold {
+          value: 0.8
+        }
+      }
+    }
+    )EOF";
+
+    envoy::config::overload::v2alpha::OverloadManager proto;
+    ASSERT(Protobuf::TextFormat::ParseFromString(config, &proto));
+    return proto;
+  }
+
+  FakeResourceMonitorFactory factory1_;
+  FakeResourceMonitorFactory factory2_;
+  NiceMock<Event::MockDispatcher> dispatcher_;
+  Event::TimerCb timer_cb_;
+};
+
+TEST_F(OverloadManagerImplTest, CallbackOnlyFiresWhenStateChanges) {
+  OverloadManagerImpl manager(dispatcher_, getConfig());
+  bool is_active = false;
+  int cb_count = 0;
+  manager.registerForAction("envoy.overload_actions.dummy_action", dispatcher_, [&](bool value) {
+    is_active = value;
+    cb_count++;
+  });
+  manager.registerForAction("envoy.overload_actions.unknown_action", dispatcher_,
+                            [&](bool) { ASSERT(false); });
+  manager.start();
+
+  factory1_.monitor_->setPressure(0.5);
+  timer_cb_();
+  EXPECT_FALSE(is_active);
+  EXPECT_EQ(0, cb_count);
+
+  factory1_.monitor_->setPressure(0.95);
+  timer_cb_();
+  EXPECT_TRUE(is_active);
+  EXPECT_EQ(1, cb_count);
+
+  // Callback should not be invoked if action active state has not changed
+  factory1_.monitor_->setPressure(0.94);
+  timer_cb_();
+  EXPECT_TRUE(is_active);
+  EXPECT_EQ(1, cb_count);
+
+  // Different triggers firing but overall action remains active so no callback expected
+  factory1_.monitor_->setPressure(0.5);
+  factory2_.monitor_->setPressure(0.9);
+  timer_cb_();
+  EXPECT_TRUE(is_active);
+  EXPECT_EQ(1, cb_count);
+
+  factory2_.monitor_->setPressure(0.4);
+  timer_cb_();
+  EXPECT_FALSE(is_active);
+  EXPECT_EQ(2, cb_count);
+
+  factory1_.monitor_->setPressure(0.95);
+  factory1_.monitor_->setError();
+  timer_cb_();
+  EXPECT_FALSE(is_active);
+  EXPECT_EQ(2, cb_count);
+}
+
+} // namespace Server
+} // namespace Envoy

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -113,13 +113,13 @@ TEST_F(OverloadManagerImplTest, CallbackOnlyFiresWhenStateChanges) {
       triggers {
         name: "envoy.resource_monitors.fake_resource1"
         threshold {
-          pressure { value: 0.9 }
+          value: 0.9
         }
       }
       triggers {
         name: "envoy.resource_monitors.fake_resource2"
         threshold {
-          pressure { value: 0.8 }
+          value: 0.8
         }
       }
     }
@@ -206,7 +206,7 @@ TEST_F(OverloadManagerImplTest, UnknownTrigger) {
       triggers {
         name: "envoy.resource_monitors.fake_resource1"
         threshold {
-          pressure { value: 0.9 }
+          value: 0.9
         }
       }
     }
@@ -226,13 +226,13 @@ TEST_F(OverloadManagerImplTest, DuplicateTrigger) {
       triggers {
         name: "envoy.resource_monitors.fake_resource1"
         threshold {
-          pressure { value: 0.9 }
+          value: 0.9
         }
       }
       triggers {
         name: "envoy.resource_monitors.fake_resource1"
         threshold {
-          pressure { value: 0.8 }
+          value: 0.8
         }
       }
     }


### PR DESCRIPTION
Add an overload manager module to protect an Envoy instance from resource starvation.
For issue #373 - see design doc linked from there

Risk level: low (not linked into envoy main yet)

Signed-off-by: Elisha Ziskind <eziskind@google.com>