### PR TITLE
Fix run_envoy_docker.sh 'do_ci.sh ' does not work behind proxy

### DIFF
--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -18,7 +18,7 @@ USER_GROUP=root
 
 mkdir -p "${ENVOY_DOCKER_BUILD_DIR}"
 # Since we specify an explicit hash, docker-run will pull from the remote repo if missing.
-docker run --rm -t -i -e http_proxy=${http_proxy} -e https_proxy=${https_proxy} \
+docker run --rm -t -i -e HTTP_PROXY=${http_proxy} -e HTTPS_PROXY=${https_proxy} \
   -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build \
   -v "$PWD":/source -e NUM_CPUS --cap-add SYS_PTRACE "${IMAGE_NAME}":"${IMAGE_ID}" \
   /bin/bash -lc "groupadd --gid $(id -g) -f envoygroup && useradd -o --uid $(id -u) --gid $(id -g) \


### PR DESCRIPTION
*Description*: In @io_bazel_rules_go/go/private/go_repository.bzl, it reads os env HTTP_PROXY and HTTPS_PROXY with upper case:
` 
  if "HTTP_PROXY" in ctx.os.environ:
      fetch_repo_env["HTTP_PROXY"] = ctx.os.environ["HTTP_PROXY"]
    if "HTTPS_PROXY" in ctx.os.environ:
      fetch_repo_env["HTTPS_PROXY"] = ctx.os.environ["HTTPS_PROXY"]
`
if set the container env with lower case, @io_bazel_rules_go/go/private/go_repository.bzl will not fetch the proxy, then the packages which will be downloaded by go_repository failed:
`ERROR: /build/tmp/_bazel_bazel/436badd4919a15958fa3800a4e21074a/external/io_bazel_rules_go/proto/BUILD.bazel:21:1: no such package '@org_golang_x_net//context': failed to fetch org_golang_x_net: 2018/07/26 02:33:07 unrecognized import path "golang.org/x/net"
 and referenced by '@io_bazel_rules_go//proto:go_grpc'
ERROR: Analysis of target '//src/envoy:envoy' failed; build aborted: no such package '@org_golang_x_net//context': failed to fetch org_golang_x_net: 2018/07/26 02:33:07 unrecognized import path "golang.org/x/net"
`
when change to upper case, it works fine, will not need git_hack.sh
*Risk Level*: CI
*Testing*:
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]  #2180
[Optional *Deprecated*:]
