### PR TITLE
upstream: init host hc value based on hc value from other priorities

### DIFF
--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -110,7 +110,7 @@ void EdsClusterImpl::onConfigUpdate(const ResourceVector& resources, const std::
                                priority_state_manager, updated_hosts);
   }
 
-  all_hosts_ = std::move(updated_hosts);
+  updateHostMap(std::move(updated_hosts));
 
   if (!cluster_rebuilt) {
     info_->stats().update_no_rebuild_.inc();

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -138,7 +138,6 @@ bool EdsClusterImpl::updateHostsPerLocality(
   // out of the locality scheduler, we discover their new weights. We don't currently have a shared
   // object for locality weights that we can update here, we should add something like this to
   // improve performance and scalability of locality weight updates.
-
   if (updateDynamicHostList(new_hosts, *current_hosts_copy, hosts_added, hosts_removed,
                             updated_hosts) ||
       locality_weights_map != new_locality_weights_map) {

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -139,7 +139,8 @@ bool EdsClusterImpl::updateHostsPerLocality(
   // object for locality weights that we can update here, we should add something like this to
   // improve performance and scalability of locality weight updates.
 
-  if (updateDynamicHostList(new_hosts, *current_hosts_copy, hosts_added, hosts_removed, updated_hosts) ||
+  if (updateDynamicHostList(new_hosts, *current_hosts_copy, hosts_added, hosts_removed,
+                            updated_hosts) ||
       locality_weights_map != new_locality_weights_map) {
     locality_weights_map = new_locality_weights_map;
     ENVOY_LOG(debug, "EDS hosts or locality weights changed for cluster: {} ({}) priority {}",

--- a/source/common/upstream/eds.h
+++ b/source/common/upstream/eds.h
@@ -41,7 +41,7 @@ private:
                               LocalityWeightsMap& locality_weights_map,
                               LocalityWeightsMap& new_locality_weights_map,
                               PriorityStateManager& priority_state_manager,
-                              const HostVector& all_hosts);
+                              std::unordered_map<std::string, HostSharedPtr>& updated_hosts);
 
   // ClusterImplBase
   void startPreInit() override;

--- a/source/common/upstream/eds.h
+++ b/source/common/upstream/eds.h
@@ -40,7 +40,8 @@ private:
   bool updateHostsPerLocality(const uint32_t priority, const HostVector& new_hosts,
                               LocalityWeightsMap& locality_weights_map,
                               LocalityWeightsMap& new_locality_weights_map,
-                              PriorityStateManager& priority_state_manager);
+                              PriorityStateManager& priority_state_manager,
+                              const HostVector& all_hosts);
 
   // ClusterImplBase
   void startPreInit() override;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1081,7 +1081,7 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
           parent_.updateAllHosts(hosts_added, hosts_removed, locality_lb_endpoint_.priority());
         }
 
-        parent_.all_hosts_ = std::move(updated_hosts);
+        parent_.updateHostMap(std::move(updated_hosts));
 
         // If there is an initialize callback, fire it now. Note that if the cluster refers to
         // multiple DNS names, this will return initialized after a single DNS resolution

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -895,7 +895,7 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(
         max_host_weight = host->weight();
       }
 
-      // If we are depending on a health checker, determine what to initialize the new host
+      // If we are depending on a health checker, we initialize to unhealthy.
       if (health_checker_ != nullptr) {
         host->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
       }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -907,7 +907,6 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(const HostVector& new_hosts,
         // and potentially fail traffic, search through all hosts for the clusters to
         // see if we already know about this host.
         bool failed_active_health_check = true;
-        // see if we can find it in the list of all hosts
         for (auto i = all_hosts.begin(); i != all_hosts.end(); ++i) {
           if (*(*i)->address() == *host->address()) {
             // We've found a match, so stop the loop and copy the health check flag from the other

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -503,7 +503,6 @@ protected:
 
 protected:
   PrioritySetImpl priority_set_;
-  std::unordered_map<std::string, Upstream::HostSharedPtr> all_hosts_;
 
 private:
   void finishInitialization();
@@ -597,9 +596,24 @@ class BaseDynamicClusterImpl : public ClusterImplBase {
 protected:
   using ClusterImplBase::ClusterImplBase;
 
-  bool updateDynamicHostList(const HostVector& new_hosts, HostVector& current_hosts,
-                             HostVector& hosts_added, HostVector& hosts_removed,
+  /**
+   * Updates the host list of a single priority by reconciling the list of new hosts
+   * with existing hosts.
+   *
+   * @param new_hosts the full lists of hosts in the new configuration.
+   * @param current_priority_hosts the full lists of hosts for the priority to be updated. The list
+   * will be modified to contain the updated list of hosts.
+   * @param hosts_added_to_priority will be populated with hosts added to the priority.
+   * @param hosts_removed_from_priority will be populated with hosts removed from the priority.
+   * @param updated_hosts is used to aggregate the new state of all hosts accross priority, and will
+   * be be updated with the hosts that remain in this priority after the update.
+   * @return whether the hosts for the priority changed.
+   */
+  bool updateDynamicHostList(const HostVector& new_hosts, HostVector& current_priority_hosts,
+                             HostVector& hosts_added_to_priority, HostVector& hosts_removed,
                              std::unordered_map<std::string, HostSharedPtr>& updated_hosts);
+
+  std::unordered_map<std::string, Upstream::HostSharedPtr> all_hosts_;
 };
 
 /**
@@ -632,7 +646,6 @@ private:
     uint32_t port_;
     Event::TimerPtr resolve_timer_;
     HostVector hosts_;
-    std::unordered_map<std::string, HostSharedPtr> all_hosts_;
     const envoy::api::v2::endpoint::LocalityLbEndpoints locality_lb_endpoint_;
     const envoy::api::v2::endpoint::LbEndpoint lb_endpoint_;
   };

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -603,14 +603,16 @@ protected:
    * @param new_hosts the full lists of hosts in the new configuration.
    * @param current_priority_hosts the full lists of hosts for the priority to be updated. The list
    * will be modified to contain the updated list of hosts.
-   * @param hosts_added_to_priority will be populated with hosts added to the priority.
-   * @param hosts_removed_from_priority will be populated with hosts removed from the priority.
+   * @param hosts_added_to_current_priority will be populated with hosts added to the priority.
+   * @param hosts_removed_from_current_priority will be populated with hosts removed from the
+   * priority.
    * @param updated_hosts is used to aggregate the new state of all hosts accross priority, and will
-   * be be updated with the hosts that remain in this priority after the update.
+   * be updated with the hosts that remain in this priority after the update.
    * @return whether the hosts for the priority changed.
    */
   bool updateDynamicHostList(const HostVector& new_hosts, HostVector& current_priority_hosts,
-                             HostVector& hosts_added_to_priority, HostVector& hosts_removed,
+                             HostVector& hosts_added_to_current_priority,
+                             HostVector& hosts_removed_from_current_priority,
                              std::unordered_map<std::string, HostSharedPtr>& updated_hosts);
 
   std::unordered_map<std::string, Upstream::HostSharedPtr> all_hosts_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -615,7 +615,18 @@ protected:
                              HostVector& hosts_removed_from_current_priority,
                              std::unordered_map<std::string, HostSharedPtr>& updated_hosts);
 
-  std::unordered_map<std::string, Upstream::HostSharedPtr> all_hosts_;
+  typedef std::unordered_map<std::string, Upstream::HostSharedPtr> HostMap;
+
+  /**
+   * Updates the internal collection of all hosts. This should be called with the updated
+   * map of hosts after issuing updateDynamicHostList for each priority.
+   *
+   * @param all_hosts the updated map of address to host after a cluster update.
+   */
+  void updateHostMap(HostMap&& all_hosts) { all_hosts_ = std::move(all_hosts); }
+
+private:
+  HostMap all_hosts_;
 };
 
 /**

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -503,6 +503,7 @@ protected:
 
 protected:
   PrioritySetImpl priority_set_;
+  std::unordered_map<std::string, Upstream::HostSharedPtr> all_hosts_;
 
 private:
   void finishInitialization();
@@ -598,7 +599,8 @@ protected:
 
   bool updateDynamicHostList(const HostVector& new_hosts, HostVector& current_hosts,
                              HostVector& hosts_added, HostVector& hosts_removed,
-                             const HostVector& all_current_hosts);
+                             std::unordered_map<std::string, HostSharedPtr>& updated_hosts,
+                             const std::unordered_map<std::string, HostSharedPtr>& existing_hosts);
 };
 
 /**
@@ -631,6 +633,7 @@ private:
     uint32_t port_;
     Event::TimerPtr resolve_timer_;
     HostVector hosts_;
+    std::unordered_map<std::string, HostSharedPtr> all_hosts_;
     const envoy::api::v2::endpoint::LocalityLbEndpoints locality_lb_endpoint_;
     const envoy::api::v2::endpoint::LbEndpoint lb_endpoint_;
   };

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -599,8 +599,7 @@ protected:
 
   bool updateDynamicHostList(const HostVector& new_hosts, HostVector& current_hosts,
                              HostVector& hosts_added, HostVector& hosts_removed,
-                             std::unordered_map<std::string, HostSharedPtr>& updated_hosts,
-                             const std::unordered_map<std::string, HostSharedPtr>& existing_hosts);
+                             std::unordered_map<std::string, HostSharedPtr>& updated_hosts);
 };
 
 /**

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -597,7 +597,8 @@ protected:
   using ClusterImplBase::ClusterImplBase;
 
   bool updateDynamicHostList(const HostVector& new_hosts, HostVector& current_hosts,
-                             HostVector& hosts_added, HostVector& hosts_removed);
+                             HostVector& hosts_added, HostVector& hosts_removed,
+                             const HostVector& all_current_hosts);
 };
 
 /**

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -459,14 +459,6 @@ TEST_F(EdsTest, EndpointMoved) {
 
   VERBOSE_EXPECT_NO_THROW(cluster_->onConfigUpdate(resources, ""));
 
-  int p = 0;
-  for (auto& hs : cluster_->prioritySet().hostSetsPerPriority()) {
-    std::cout << p++ << std::endl;
-    for (auto& h : hs->hosts()) {
-      std::cout << h->address()->asString() << std::endl; 
-    }
-  }
-
   {
     auto& hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
     EXPECT_EQ(hosts.size(), 1);

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -390,6 +390,76 @@ TEST_F(EdsTest, EndpointRemoval) {
   }
 }
 
+// Verifies that if an endpoint is moved between priorities, the health check value
+// of the host is preserved
+TEST_F(EdsTest, EndpointMoved) {
+  resetCluster(R"EOF(
+      name: name
+      connect_timeout: 0.25s
+      type: EDS
+      lb_policy: ROUND_ROBIN
+      drain_connections_on_host_removal: true
+      eds_cluster_config:
+        service_name: fare
+        eds_config:
+          api_config_source:
+            cluster_names:
+            - eds
+            refresh_delay: 1s
+  )EOF");
+
+  auto health_checker = std::make_shared<MockHealthChecker>();
+  EXPECT_CALL(*health_checker, start());
+  EXPECT_CALL(*health_checker, addHostCheckCompleteCb(_)).Times(2);
+  cluster_->setHealthChecker(health_checker);
+
+  Protobuf::RepeatedPtrField<envoy::api::v2::ClusterLoadAssignment> resources;
+  auto* cluster_load_assignment = resources.Add();
+  cluster_load_assignment->set_cluster_name("fare");
+
+  auto add_endpoint = [cluster_load_assignment](int port, int priority) {
+    auto* endpoints = cluster_load_assignment->add_endpoints();
+    endpoints->set_priority(priority);
+
+    auto* socket_address = endpoints->add_lb_endpoints()
+                               ->mutable_endpoint()
+                               ->mutable_address()
+                               ->mutable_socket_address();
+    socket_address->set_address("1.2.3.4");
+    socket_address->set_port_value(port);
+  };
+
+  add_endpoint(80, 0);
+  add_endpoint(81, 1);
+
+  VERBOSE_EXPECT_NO_THROW(cluster_->onConfigUpdate(resources, ""));
+
+  {
+    auto& hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
+    EXPECT_EQ(hosts.size(), 1);
+
+    EXPECT_TRUE(hosts[0]->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC));
+    // Mark the hosts as healthy
+    hosts[0]->healthFlagClear(Host::HealthFlag::FAILED_ACTIVE_HC);
+  }
+
+  // Moves the endpoints between priorities
+  cluster_load_assignment->clear_endpoints();
+  add_endpoint(81, 0);
+  add_endpoint(80, 1);
+
+  VERBOSE_EXPECT_NO_THROW(cluster_->onConfigUpdate(resources, ""));
+
+  {
+    auto& hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
+    EXPECT_EQ(hosts.size(), 1);
+
+    // Since the endpoint was healthy in the other priority, it should remain
+    // healthy after having moved.
+    EXPECT_FALSE(hosts[0]->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC));
+  }
+}
+
 // Validate that onConfigUpdate() updates the endpoint locality.
 TEST_F(EdsTest, EndpointLocality) {
   Protobuf::RepeatedPtrField<envoy::api::v2::ClusterLoadAssignment> resources;


### PR DESCRIPTION
*Description*:
In order to allow hosts to move from one priority to another, this
compares a "new" host against all known hosts in order to determine
whether we've already health checked this host successfully.
The idea is that if we already know that a host is healthy we should
treat it as such when it's added to a different priority. Without this, we'll
fail requests coming in between the EDS update and the moved hosts
being successfully health checked. 

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Low, only affects the initial health check value when hosts are added to a priority
*Testing*: Unit test
*Docs Changes*: N/A
*Release Notes*: N/A

Fixes #3930 
