### PR TITLE
thirdpary: explicit libdir path

### DIFF
--- a/ci/build_container/build_recipes/nghttp2.sh
+++ b/ci/build_container/build_recipes/nghttp2.sh
@@ -36,6 +36,7 @@ mkdir build
 cd build
 
 cmake -G "Ninja" -DCMAKE_INSTALL_PREFIX="$THIRDPARTY_BUILD" \
+  -DCMAKE_INSTALL_LIBDIR="$THIRDPARTY_BUILD/lib" \
   -DENABLE_STATIC_LIB=on \
   -DENABLE_LIB_ONLY=on \
   ..


### PR DESCRIPTION
on some hosts (amd64 centos and fedora) the libdir path defaults to
lib64, though elsewhere the path is expected to be ./lib/

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>

*Description*: explicit path for dep to cover more platforms
*Risk Level*: low
*Testing*:
*Docs Changes*: none
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
