### PR TITLE
rds: make RouteConfigProvider unique_ptr

### DIFF
--- a/include/envoy/router/rds.h
+++ b/include/envoy/router/rds.h
@@ -45,7 +45,7 @@ public:
   virtual SystemTime lastUpdated() const PURE;
 };
 
-typedef std::shared_ptr<RouteConfigProvider> RouteConfigProviderSharedPtr;
+typedef std::unique_ptr<RouteConfigProvider> RouteConfigProviderPtr;
 
 } // namespace Router
 } // namespace Envoy

--- a/include/envoy/router/route_config_provider_manager.h
+++ b/include/envoy/router/route_config_provider_manager.h
@@ -27,43 +27,41 @@ public:
   virtual ~RouteConfigProviderManager() {}
 
   /**
-   * Get a RouteConfigProviderSharedPtr for a route from RDS. Ownership of the RouteConfigProvider
-   * is shared by all the HttpConnectionManagers who own a RouteConfigProviderSharedPtr. The
-   * RouteConfigProviderManager holds weak_ptrs to the RouteConfigProviders. Clean up of the weak
-   * ptrs happen from the destructor of the RouteConfigProvider. This function creates a
-   * RouteConfigProvider if there isn't one with the same (route_config_name, cluster) already.
-   * Otherwise, it returns a RouteConfigProviderSharedPtr created from the manager held weak_ptr.
+   * Get a RouteConfigProviderPtr for a route from RDS. Ownership of the RouteConfigProvider is the
+   * HttpConnectionManagers who calls this function. The RouteConfigProviderManager holds raw
+   * pointers to the RouteConfigProviders. Clean up of the pointers happen from the destructor of
+   * the RouteConfigProvider. This method creates a RouteConfigProvider which may share the
+   * underlying RDS subscription with the same (route_config_name, cluster).
    * @param rds supplies the proto configuration of an RDS-configured RouteConfigProvider.
    * @param factory_context is the context to use for the route config provider.
    * @param stat_prefix supplies the stat_prefix to use for the provider stats.
    */
-  virtual RouteConfigProviderSharedPtr getRdsRouteConfigProvider(
+  virtual RouteConfigProviderPtr createRdsRouteConfigProvider(
       const envoy::config::filter::network::http_connection_manager::v2::Rds& rds,
       Server::Configuration::FactoryContext& factory_context, const std::string& stat_prefix) PURE;
 
   /**
    * Get a RouteConfigSharedPtr for a statically defined route. Ownership is as described for
-   * getRdsRouteConfigProvider above. Unlike getRdsRouteConfigProvider(), this method always creates
-   * a new RouteConfigProvider.
+   * getRdsRouteConfigProvider above. This method always create a new RouteConfigProvider.
    * @param route_config supplies the RouteConfiguration for this route
    * @param runtime supplies the runtime loader.
    * @param cm supplies the ClusterManager.
    */
-  virtual RouteConfigProviderSharedPtr
-  getStaticRouteConfigProvider(const envoy::api::v2::RouteConfiguration& route_config,
-                               Server::Configuration::FactoryContext& factory_context) PURE;
+  virtual RouteConfigProviderPtr
+  createStaticRouteConfigProvider(const envoy::api::v2::RouteConfiguration& route_config,
+                                  Server::Configuration::FactoryContext& factory_context) PURE;
 
   /**
-   * @return std::vector<Router::RouteConfigProviderSharedPtr> a list of all the
+   * @return std::vector<Router::RouteConfigProvider*> a list of all the
    * dynamic (RDS) RouteConfigProviders currently loaded.
    */
-  virtual std::vector<RouteConfigProviderSharedPtr> getRdsRouteConfigProviders() PURE;
+  virtual std::vector<RouteConfigProvider*> getRdsRouteConfigProviders() PURE;
 
   /**
-   * @return std::vector<Router::RouteConfigProviderSharedPtr> a list of all the
+   * @return std::vector<Router::RouteConfigProvider*> a list of all the
    * static RouteConfigProviders currently loaded.
    */
-  virtual std::vector<RouteConfigProviderSharedPtr> getStaticRouteConfigProviders() PURE;
+  virtual std::vector<RouteConfigProvider*> getStaticRouteConfigProviders() PURE;
 };
 
 } // namespace Router

--- a/include/envoy/router/route_config_provider_manager.h
+++ b/include/envoy/router/route_config_provider_manager.h
@@ -50,18 +50,6 @@ public:
   virtual RouteConfigProviderPtr
   createStaticRouteConfigProvider(const envoy::api::v2::RouteConfiguration& route_config,
                                   Server::Configuration::FactoryContext& factory_context) PURE;
-
-  /**
-   * @return std::vector<Router::RouteConfigProvider*> a list of all the
-   * dynamic (RDS) RouteConfigProviders currently loaded.
-   */
-  virtual std::vector<RouteConfigProvider*> getRdsRouteConfigProviders() PURE;
-
-  /**
-   * @return std::vector<Router::RouteConfigProvider*> a list of all the
-   * static RouteConfigProviders currently loaded.
-   */
-  virtual std::vector<RouteConfigProvider*> getStaticRouteConfigProviders() PURE;
 };
 
 } // namespace Router

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -21,7 +21,7 @@
 namespace Envoy {
 namespace Router {
 
-RouteConfigProviderSharedPtr RouteConfigProviderUtil::create(
+RouteConfigProviderPtr RouteConfigProviderUtil::create(
     const envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager&
         config,
     Server::Configuration::FactoryContext& factory_context, const std::string& stat_prefix,
@@ -29,11 +29,11 @@ RouteConfigProviderSharedPtr RouteConfigProviderUtil::create(
   switch (config.route_specifier_case()) {
   case envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager::
       kRouteConfig:
-    return route_config_provider_manager.getStaticRouteConfigProvider(config.route_config(),
-                                                                      factory_context);
+    return route_config_provider_manager.createStaticRouteConfigProvider(config.route_config(),
+                                                                         factory_context);
   case envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager::kRds:
-    return route_config_provider_manager.getRdsRouteConfigProvider(config.rds(), factory_context,
-                                                                   stat_prefix);
+    return route_config_provider_manager.createRdsRouteConfigProvider(config.rds(), factory_context,
+                                                                      stat_prefix);
   default:
     NOT_REACHED_GCOVR_EXCL_LINE;
   }
@@ -41,9 +41,17 @@ RouteConfigProviderSharedPtr RouteConfigProviderUtil::create(
 
 StaticRouteConfigProviderImpl::StaticRouteConfigProviderImpl(
     const envoy::api::v2::RouteConfiguration& config,
-    Server::Configuration::FactoryContext& factory_context)
+    Server::Configuration::FactoryContext& factory_context,
+    RouteConfigProviderManagerImpl& route_config_provider_manager)
     : config_(new ConfigImpl(config, factory_context, true)), route_config_proto_{config},
-      last_updated_(factory_context.systemTimeSource().currentTime()) {}
+      last_updated_(factory_context.systemTimeSource().currentTime()),
+      route_config_provider_manager_(route_config_provider_manager) {
+  route_config_provider_manager_.static_route_config_providers_.insert(this);
+}
+
+StaticRouteConfigProviderImpl::~StaticRouteConfigProviderImpl() {
+  route_config_provider_manager_.static_route_config_providers_.erase(this);
+}
 
 // TODO(htuch): If support for multiple clusters is added per #1170 cluster_name_
 // initialization needs to be fixed.
@@ -189,9 +197,8 @@ RouteConfigProviderManagerImpl::RouteConfigProviderManagerImpl(Server::Admin& ad
   RELEASE_ASSERT(config_tracker_entry_, "");
 }
 
-std::vector<RouteConfigProviderSharedPtr>
-RouteConfigProviderManagerImpl::getRdsRouteConfigProviders() {
-  std::vector<RouteConfigProviderSharedPtr> ret;
+std::vector<RouteConfigProvider*> RouteConfigProviderManagerImpl::getRdsRouteConfigProviders() {
+  std::vector<RouteConfigProvider*> ret;
   ret.reserve(route_config_subscriptions_.size());
   for (const auto& element : route_config_subscriptions_) {
     // Because the RouteConfigProviderManager's weak_ptrs only get cleaned up
@@ -200,29 +207,20 @@ RouteConfigProviderManagerImpl::getRdsRouteConfigProviders() {
     auto subscription = element.second.lock();
     ASSERT(subscription);
     ASSERT(subscription->route_config_providers_.size() > 0);
-    ret.push_back((*subscription->route_config_providers_.begin())->shared_from_this());
+    ret.push_back(*subscription->route_config_providers_.begin());
   }
   return ret;
 };
 
-std::vector<RouteConfigProviderSharedPtr>
-RouteConfigProviderManagerImpl::getStaticRouteConfigProviders() {
-  std::vector<RouteConfigProviderSharedPtr> providers_strong;
-  // Collect non-expired providers.
-  for (const auto& weak_provider : static_route_config_providers_) {
-    const auto strong_provider = weak_provider.lock();
-    if (strong_provider != nullptr) {
-      providers_strong.push_back(strong_provider);
-    }
-  }
+std::vector<RouteConfigProvider*> RouteConfigProviderManagerImpl::getStaticRouteConfigProviders() {
+  std::vector<RouteConfigProvider*> ret;
 
-  // Replace our stored list of weak_ptrs with the filtered list.
-  static_route_config_providers_.assign(providers_strong.begin(), providers_strong.end());
+  ret.assign(static_route_config_providers_.begin(), static_route_config_providers_.end());
 
-  return providers_strong;
+  return ret;
 };
 
-Router::RouteConfigProviderSharedPtr RouteConfigProviderManagerImpl::getRdsRouteConfigProvider(
+Router::RouteConfigProviderPtr RouteConfigProviderManagerImpl::createRdsRouteConfigProvider(
     const envoy::config::filter::network::http_connection_manager::v2::Rds& rds,
     Server::Configuration::FactoryContext& factory_context, const std::string& stat_prefix) {
 
@@ -252,17 +250,17 @@ Router::RouteConfigProviderSharedPtr RouteConfigProviderManagerImpl::getRdsRoute
   }
   ASSERT(subscription);
 
-  Router::RouteConfigProviderSharedPtr new_provider{
+  Router::RouteConfigProviderPtr new_provider{
       new RdsRouteConfigProviderImpl(std::move(subscription), factory_context)};
   return new_provider;
 };
 
-RouteConfigProviderSharedPtr RouteConfigProviderManagerImpl::getStaticRouteConfigProvider(
+RouteConfigProviderPtr RouteConfigProviderManagerImpl::createStaticRouteConfigProvider(
     const envoy::api::v2::RouteConfiguration& route_config,
     Server::Configuration::FactoryContext& factory_context) {
   auto provider =
-      std::make_shared<StaticRouteConfigProviderImpl>(std::move(route_config), factory_context);
-  static_route_config_providers_.push_back(provider);
+      absl::make_unique<StaticRouteConfigProviderImpl>(route_config, factory_context, *this);
+  static_route_config_providers_.insert(provider.get());
   return provider;
 }
 

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -253,13 +253,13 @@ RouteConfigProviderManagerImpl::dumpRouteConfigs() const {
     ASSERT(subscription);
     ASSERT(subscription->route_config_providers_.size() > 0);
 
-    auto* dynamic_config = config_dump->mutable_dynamic_route_configs()->Add();
     if (subscription->config_info_) {
+      auto* dynamic_config = config_dump->mutable_dynamic_route_configs()->Add();
       dynamic_config->set_version_info(subscription->config_info_.value().last_config_version_);
       dynamic_config->mutable_route_config()->MergeFrom(subscription->route_config_proto_);
+      TimestampUtil::systemClockToTimestamp(subscription->last_updated_,
+                                            *dynamic_config->mutable_last_updated());
     }
-    TimestampUtil::systemClockToTimestamp(subscription->last_updated_,
-                                          *dynamic_config->mutable_last_updated());
   }
 
   for (const auto& provider : static_route_config_providers_) {

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "envoy/admin/v2alpha/config_dump.pb.h"
 #include "envoy/api/v2/rds.pb.h"
 #include "envoy/api/v2/route/route.pb.h"
 #include "envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.pb.h"
@@ -184,10 +185,9 @@ class RouteConfigProviderManagerImpl : public RouteConfigProviderManager,
 public:
   RouteConfigProviderManagerImpl(Server::Admin& admin);
 
-  // RouteConfigProviderManager
-  std::vector<RouteConfigProvider*> getRdsRouteConfigProviders() override;
-  std::vector<RouteConfigProvider*> getStaticRouteConfigProviders() override;
+  std::unique_ptr<envoy::admin::v2alpha::RoutesConfigDump> dumpRouteConfigs() const;
 
+  // RouteConfigProviderManager
   RouteConfigProviderPtr createRdsRouteConfigProvider(
       const envoy::config::filter::network::http_connection_manager::v2::Rds& rds,
       Server::Configuration::FactoryContext& factory_context,
@@ -198,8 +198,6 @@ public:
                                   Server::Configuration::FactoryContext& factory_context) override;
 
 private:
-  ProtobufTypes::MessagePtr dumpRouteConfigs();
-
   // TODO(jsedgwick) These two members are prime candidates for the owned-entry list/map
   // as in ConfigTracker. I.e. the ProviderImpls would have an EntryOwner for these lists
   // Then the lifetime management stuff is centralized and opaque. Plus the copypasta

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -200,8 +200,7 @@ public:
 private:
   // TODO(jsedgwick) These two members are prime candidates for the owned-entry list/map
   // as in ConfigTracker. I.e. the ProviderImpls would have an EntryOwner for these lists
-  // Then the lifetime management stuff is centralized and opaque. Plus the copypasta
-  // in getRdsRouteConfigProviders()/getStaticRouteConfigProviders() goes away.
+  // Then the lifetime management stuff is centralized and opaque.
   std::unordered_map<std::string, std::weak_ptr<RdsRouteConfigSubscription>>
       route_config_subscriptions_;
   std::unordered_set<RouteConfigProvider*> static_route_config_providers_;

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -139,7 +139,7 @@ private:
   absl::optional<std::string> user_agent_;
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   std::chrono::milliseconds stream_idle_timeout_;
-  Router::RouteConfigProviderSharedPtr route_config_provider_;
+  Router::RouteConfigProviderPtr route_config_provider_;
   std::chrono::milliseconds drain_timeout_;
   bool generate_request_id_;
   Http::DateProvider& date_provider_;

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -560,6 +560,7 @@ virtual_hosts:
   RouteConfigProviderPtr provider3 = route_config_provider_manager_->createRdsRouteConfigProvider(
       rds2, factory_context_, "foo_prefix");
   EXPECT_NE(provider3, provider_);
+  dynamic_cast<RdsRouteConfigProviderImpl&>(*provider3).subscription().onConfigUpdate(route_configs, "provider3");
 
   EXPECT_EQ(2UL,
             route_config_provider_manager_->dumpRouteConfigs()->dynamic_route_configs().size());
@@ -573,8 +574,8 @@ virtual_hosts:
       route_config_provider_manager_->dumpRouteConfigs()->dynamic_route_configs();
   EXPECT_EQ(1UL, dynamic_route_configs.size());
 
-  // Make sure the left one is provider3, which hasn't received route config yet.
-  EXPECT_FALSE(dynamic_route_configs[0].has_route_config());
+  // Make sure the left one is provider3
+  EXPECT_EQ("provider3", dynamic_route_configs[0].version_info());
 
   provider3.reset();
 

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -560,7 +560,9 @@ virtual_hosts:
   RouteConfigProviderPtr provider3 = route_config_provider_manager_->createRdsRouteConfigProvider(
       rds2, factory_context_, "foo_prefix");
   EXPECT_NE(provider3, provider_);
-  dynamic_cast<RdsRouteConfigProviderImpl&>(*provider3).subscription().onConfigUpdate(route_configs, "provider3");
+  dynamic_cast<RdsRouteConfigProviderImpl&>(*provider3)
+      .subscription()
+      .onConfigUpdate(route_configs, "provider3");
 
   EXPECT_EQ(2UL,
             route_config_provider_manager_->dumpRouteConfigs()->dynamic_route_configs().size());

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -310,17 +310,16 @@ public:
   MockRouteConfigProviderManager();
   ~MockRouteConfigProviderManager();
 
-  MOCK_METHOD3(getRdsRouteConfigProvider,
-               RouteConfigProviderSharedPtr(
+  MOCK_METHOD3(createRdsRouteConfigProvider,
+               RouteConfigProviderPtr(
                    const envoy::config::filter::network::http_connection_manager::v2::Rds& rds,
                    Server::Configuration::FactoryContext& factory_context,
                    const std::string& stat_prefix));
-  MOCK_METHOD2(
-      getStaticRouteConfigProvider,
-      RouteConfigProviderSharedPtr(const envoy::api::v2::RouteConfiguration& route_config,
-                                   Server::Configuration::FactoryContext& factory_context));
-  MOCK_METHOD0(getRdsRouteConfigProviders, std::vector<RouteConfigProviderSharedPtr>());
-  MOCK_METHOD0(getStaticRouteConfigProviders, std::vector<RouteConfigProviderSharedPtr>());
+  MOCK_METHOD2(createStaticRouteConfigProvider,
+               RouteConfigProviderPtr(const envoy::api::v2::RouteConfiguration& route_config,
+                                      Server::Configuration::FactoryContext& factory_context));
+  MOCK_METHOD0(getRdsRouteConfigProviders, std::vector<RouteConfigProvider*>());
+  MOCK_METHOD0(getStaticRouteConfigProviders, std::vector<RouteConfigProvider*>());
 };
 
 } // namespace Router

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -318,8 +318,6 @@ public:
   MOCK_METHOD2(createStaticRouteConfigProvider,
                RouteConfigProviderPtr(const envoy::api::v2::RouteConfiguration& route_config,
                                       Server::Configuration::FactoryContext& factory_context));
-  MOCK_METHOD0(getRdsRouteConfigProviders, std::vector<RouteConfigProvider*>());
-  MOCK_METHOD0(getStaticRouteConfigProviders, std::vector<RouteConfigProvider*>());
 };
 
 } // namespace Router


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <zlizan@google.com>


*Description*:
RouteConfigProvider is no longer shared ownership, make it unique_ptr.
Follow up of #3960.

*Risk Level*: Low
*Testing*: unit test, integration tests
*Docs Changes*: N/A
*Release Notes*: N/A
