### PR TITLE
listener: add socket api in os sys calls for additional tests

### DIFF
--- a/include/envoy/api/os_sys_calls.h
+++ b/include/envoy/api/os_sys_calls.h
@@ -96,6 +96,11 @@ public:
    * @see man 2 getsockopt
    */
   virtual int getsockopt(int sockfd, int level, int optname, void* optval, socklen_t* optlen) PURE;
+
+  /**
+   * @see man 2 socket
+   */
+  virtual int socket(int domain, int type, int protocol) PURE;
 };
 
 typedef std::unique_ptr<OsSysCalls> OsSysCallsPtr;

--- a/source/common/api/os_sys_calls_impl.cc
+++ b/source/common/api/os_sys_calls_impl.cc
@@ -61,5 +61,9 @@ int OsSysCallsImpl::getsockopt(int sockfd, int level, int optname, void* optval,
   return ::getsockopt(sockfd, level, optname, optval, optlen);
 }
 
+int OsSysCallsImpl::socket(int domain, int type, int protocol) {
+  return ::socket(domain, type, protocol);
+}
+
 } // namespace Api
 } // namespace Envoy

--- a/source/common/api/os_sys_calls_impl.h
+++ b/source/common/api/os_sys_calls_impl.h
@@ -25,6 +25,7 @@ public:
   int stat(const char* pathname, struct stat* buf) override;
   int setsockopt(int sockfd, int level, int optname, const void* optval, socklen_t optlen) override;
   int getsockopt(int sockfd, int level, int optname, void* optval, socklen_t* optlen) override;
+  int socket(int domain, int type, int protocol) override;
 };
 
 typedef ThreadSafeSingleton<OsSysCallsImpl> OsSysCallsSingleton;

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -15,6 +15,7 @@ envoy_cc_library(
     hdrs = ["address_impl.h"],
     deps = [
         "//include/envoy/network:address_interface",
+        "//source/common/api:os_sys_calls_lib",
         "//source/common/common:assert_lib",
         "//source/common/common:utility_lib",
     ],

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -11,6 +11,7 @@
 
 #include "envoy/common/exception.h"
 
+#include "common/api/os_sys_calls_impl.h"
 #include "common/common/assert.h"
 #include "common/common/fmt.h"
 #include "common/common/utility.h"
@@ -45,9 +46,10 @@ void validateIpv6Supported(const std::string& address) {
 
 // Check if an IP family is supported on this machine.
 bool ipFamilySupported(int domain) {
-  const int fd = ::socket(domain, SOCK_STREAM, 0);
+  Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
+  const int fd = os_sys_calls.socket(domain, SOCK_STREAM, 0);
   if (fd >= 0) {
-    RELEASE_ASSERT(::close(fd) == 0, "");
+    RELEASE_ASSERT(os_sys_calls.close(fd) == 0, "");
   }
   return fd != -1;
 }

--- a/test/common/network/addr_family_aware_socket_option_impl_test.cc
+++ b/test/common/network/addr_family_aware_socket_option_impl_test.cc
@@ -49,6 +49,8 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V4EmptyOptionNames) {
 
 // If a platform doesn't support IPv4 and IPv6 socket option variants for an IPv4 address, we fail
 TEST_F(AddrFamilyAwareSocketOptionImplTest, V6EmptyOptionNames) {
+  EXPECT_CALL(os_sys_calls_, socket(_, _, _));
+  EXPECT_CALL(os_sys_calls_, close(_));
   Address::Ipv6Instance address("::1:2:3:4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
   EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));

--- a/test/mocks/api/mocks.h
+++ b/test/mocks/api/mocks.h
@@ -65,6 +65,7 @@ public:
                int(int sockfd, int level, int optname, const void* optval, socklen_t optlen));
   MOCK_METHOD5(getsockopt_,
                int(int sockfd, int level, int optname, void* optval, socklen_t* optlen));
+  MOCK_METHOD3(socket, int(int domain, int type, int protocol));
 
   size_t num_writes_;
   size_t num_open_;

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -448,7 +448,7 @@ TEST_F(ListenerManagerImplTest, AddListenerOnIpv6OnlySetups) {
   const std::string listener_foo_json = R"EOF(
   {
     "name": "foo",
-    "address": "tcp://127.0.0.1:1234",
+    "address": "tcp://[::0001]:1234",
     "filters": [],
     "drain_type": "default"
   }


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>

*Description*:
Adds additional test cases for https://github.com/envoyproxy/envoy/pull/3912
Add socket api in os sys calls
*Risk Level*: Low
*Testing*: Automated tests
*Docs Changes*: N/A
*Release Notes*: N/A

