### PR TITLE
test/mock: Add 3 new gmock matchers

### DIFF
--- a/test/mocks/buffer/mocks.h
+++ b/test/mocks/buffer/mocks.h
@@ -103,6 +103,13 @@ MATCHER_P(BufferStringEqual, rhs, rhs) {
   return TestUtility::buffersEqual(arg, buffer);
 }
 
+MATCHER_P(BufferStringContains, rhs,
+          string(negation ? "doesn't contain" : "contains") + " \"" + rhs +
+              "\"") {
+  *result_listener << "\"" << arg.toString() << "\"";
+  return arg.toString().find(rhs) != string::npos;
+}
+
 ACTION_P(AddBufferToString, target_string) {
   auto bufferToString = [](const Buffer::OwnedImpl& buf) -> std::string { return buf.toString(); };
   target_string->append(bufferToString(arg0));

--- a/test/mocks/buffer/mocks.h
+++ b/test/mocks/buffer/mocks.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/buffer/watermark_buffer.h"
 
@@ -104,10 +106,9 @@ MATCHER_P(BufferStringEqual, rhs, rhs) {
 }
 
 MATCHER_P(BufferStringContains, rhs,
-          string(negation ? "doesn't contain" : "contains") + " \"" + rhs +
-              "\"") {
+          std::string(negation ? "doesn't contain" : "contains") + " \"" + rhs + "\"") {
   *result_listener << "\"" << arg.toString() << "\"";
-  return arg.toString().find(rhs) != string::npos;
+  return arg.toString().find(rhs) != std::string::npos;
 }
 
 ACTION_P(AddBufferToString, target_string) {

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -460,4 +460,23 @@ MATCHER_P(HeaderMapEqualRef, rhs, "") {
   const Http::HeaderMapImpl& lhs = *dynamic_cast<const Http::HeaderMapImpl*>(&arg);
   return lhs == *dynamic_cast<const Http::HeaderMapImpl*>(rhs);
 }
+
+// Test that a HeaderMapPtr argument includes a given key-value pair, e.g.,
+//  HeaderHasValue("Upgrade", "WebSocket")
+MATCHER_P2(HeaderHasValue, key, value,
+           string(negation ? "doesn't have" : "has") + " a header " + key +
+               " with value \"" + value + "\"") {
+  const Envoy::Http::HeaderEntry* entry =
+      arg->get(Envoy::Http::LowerCaseString(key));
+  return entry != nullptr && entry->value() == value;
+}
+
+// Like HeaderHasValue, but matches against a (const) HeaderMap& argument.
+MATCHER_P2(HeaderHasValueRef, key, value,
+           string(negation ? "doesn't have" : "has") + " a header " + key +
+               " with value \"" + value + "\"") {
+  const Envoy::Http::HeaderEntry* entry =
+      arg.get(Envoy::Http::LowerCaseString(key));
+  return entry != nullptr && entry->value() == value;
+}
 } // namespace Envoy

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -464,19 +464,17 @@ MATCHER_P(HeaderMapEqualRef, rhs, "") {
 // Test that a HeaderMapPtr argument includes a given key-value pair, e.g.,
 //  HeaderHasValue("Upgrade", "WebSocket")
 MATCHER_P2(HeaderHasValue, key, value,
-           string(negation ? "doesn't have" : "has") + " a header " + key +
-               " with value \"" + value + "\"") {
-  const Envoy::Http::HeaderEntry* entry =
-      arg->get(Envoy::Http::LowerCaseString(key));
+           std::string(negation ? "doesn't have" : "has") + " a header " + key + " with value \"" +
+               value + "\"") {
+  const Envoy::Http::HeaderEntry* entry = arg->get(Envoy::Http::LowerCaseString(key));
   return entry != nullptr && entry->value() == value;
 }
 
 // Like HeaderHasValue, but matches against a (const) HeaderMap& argument.
 MATCHER_P2(HeaderHasValueRef, key, value,
-           string(negation ? "doesn't have" : "has") + " a header " + key +
-               " with value \"" + value + "\"") {
-  const Envoy::Http::HeaderEntry* entry =
-      arg.get(Envoy::Http::LowerCaseString(key));
+           std::string(negation ? "doesn't have" : "has") + " a header " + key + " with value \"" +
+               value + "\"") {
+  const Envoy::Http::HeaderEntry* entry = arg.get(Envoy::Http::LowerCaseString(key));
   return entry != nullptr && entry->value() == value;
 }
 } // namespace Envoy


### PR DESCRIPTION
*Description*: Adds three new gmock matchers: Envoy::Http::HeaderHasValue, Envoy::Http::HeaderHasValueRef, and Envoy::Buffer::BufferStringContains.
*Risk Level*: Low
*Testing*: New test code only
*Docs Changes*: n/a
*Release Notes*: n/a
