### PR TITLE
fuzz: fixes oss-fuzz: 9599, 9600

### DIFF
--- a/api/envoy/api/v2/endpoint/endpoint.proto
+++ b/api/envoy/api/v2/endpoint/endpoint.proto
@@ -123,5 +123,5 @@ message LocalityLbEndpoints {
   // next highest priority group.
   //
   // Priorities should range from 0 (highest) to N (lowest) without skipping.
-  uint32 priority = 5;
+  uint32 priority = 5 [(validate.rules).uint32 = {gte: 0, lte: 128}];
 }

--- a/api/envoy/api/v2/endpoint/endpoint.proto
+++ b/api/envoy/api/v2/endpoint/endpoint.proto
@@ -123,5 +123,5 @@ message LocalityLbEndpoints {
   // next highest priority group.
   //
   // Priorities should range from 0 (highest) to N (lowest) without skipping.
-  uint32 priority = 5 [(validate.rules).uint32 = {gte: 0, lte: 128}];
+  uint32 priority = 5 [(validate.rules).uint32 = {lte: 128}];
 }

--- a/test/server/config_validation/config_corpus/clusterfuzz-testcase-config_fuzz_test-5697041979146240
+++ b/test/server/config_validation/config_corpus/clusterfuzz-testcase-config_fuzz_test-5697041979146240
@@ -1,0 +1,231 @@
+static_resources {
+  clusters {
+    name: "ineasrh_stsB"
+    eds_cluster_config {
+      service_name: "\177"
+    }
+    connect_timeout {
+      nanos: 249999905
+    }
+    dns_refresh_rate {
+      nanos: 249999905
+    }
+    dns_lookup_family: V4_ONLY
+    load_assignment {
+      cluster_name: "GGG"
+      endpoints {
+        priority: 538970624
+      }
+      endpoints {
+        lb_endpoints {
+          load_balancing_weight {
+            value: 2
+          }
+        }
+        priority: 11264
+      }
+      endpoints {
+        priority: 246
+      }
+      endpoints {
+        priority: 538970624
+      }
+      endpoints {
+        priority: 2
+      }
+      endpoints {
+        priority: 538970624
+      }
+      endpoints {
+        priority: 2105354
+      }
+      endpoints {
+        lb_endpoints {
+          load_balancing_weight {
+            value: 2
+          }
+        }
+        priority: 11264
+      }
+      endpoints {
+        priority: 671091188
+      }
+      endpoints {
+        priority: 2105354
+      }
+      endpoints {
+        priority: 11264
+      }
+      endpoints {
+        lb_endpoints {
+        }
+        load_balancing_weight {
+          value: 2
+        }
+        priority: 11264
+      }
+      endpoints {
+        priority: 538970624
+      }
+      endpoints {
+        priority: 538970624
+      }
+      endpoints {
+        priority: 538970624
+      }
+      endpoints {
+        priority: 11264
+      }
+      endpoints {
+        priority: 2105354
+      }
+      endpoints {
+        priority: 671091190
+      }
+      endpoints {
+        priority: 671151625
+      }
+      endpoints {
+        priority: 671151625
+      }
+      endpoints {
+        lb_endpoints {
+          load_balancing_weight {
+            value: 2
+          }
+        }
+        priority: 11264
+      }
+      endpoints {
+        lb_endpoints {
+          load_balancing_weight {
+            value: 2
+          }
+        }
+        priority: 11264
+      }
+      endpoints {
+        priority: 671091190
+      }
+      endpoints {
+        priority: 538976256
+      }
+      endpoints {
+        priority: 671091188
+      }
+      endpoints {
+        priority: 671091188
+      }
+      endpoints {
+        priority: 11264
+      }
+      endpoints {
+        lb_endpoints {
+          health_status: DRAINING
+          load_balancing_weight {
+            value: 2
+          }
+        }
+        priority: 11264
+      }
+      endpoints {
+        lb_endpoints {
+          load_balancing_weight {
+            value: 2
+          }
+        }
+        priority: 11264
+      }
+      endpoints {
+        priority: 11264
+      }
+      endpoints {
+        priority: 538970624
+      }
+      endpoints {
+        lb_endpoints {
+          load_balancing_weight {
+            value: 2
+          }
+        }
+        priority: 11264
+      }
+      endpoints {
+        priority: 11264
+      }
+      endpoints {
+        lb_endpoints {
+          load_balancing_weight {
+            value: 2
+          }
+        }
+        priority: 738208768
+      }
+      endpoints {
+        priority: 671151625
+      }
+      endpoints {
+        priority: 671091188
+      }
+      endpoints {
+        priority: 30
+      }
+      endpoints {
+        priority: 671151625
+      }
+      endpoints {
+        lb_endpoints {
+        }
+        load_balancing_weight {
+          value: 64
+        }
+        priority: 2
+      }
+      endpoints {
+        lb_endpoints {
+          health_status: DRAINING
+        }
+        priority: 11264
+      }
+      endpoints {
+        lb_endpoints {
+        }
+        priority: 11264
+      }
+      endpoints {
+        locality {
+          zone: "\177\r"
+        }
+        priority: 538970624
+      }
+      endpoints {
+        priority: 671091190
+      }
+      endpoints {
+        priority: 244
+      }
+      endpoints {
+        priority: 538970624
+      }
+      endpoints {
+        locality {
+          region: "~"
+        }
+        lb_endpoints {
+        }
+        priority: 11264
+      }
+      endpoints {
+        priority: 2
+      }
+    }
+  }
+}
+admin {
+  access_log_path: "/tmp/admin_access.log"
+  address {
+    pipe {
+      path: "*"
+    }
+  }
+}

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-6419204524736512
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-6419204524736512
@@ -1,0 +1,22 @@
+static_resources {
+  clusters {
+    name: "`"
+    connect_timeout {
+      nanos: 20
+    }
+    load_assignment {
+      cluster_name: "`"
+      endpoints {
+        priority: 1030831324
+      }
+    }
+  }
+}
+admin {
+  access_log_path: "@@"
+  address {
+    pipe {
+      path: "`"
+    }
+  }
+}


### PR DESCRIPTION
Title: Fixes oss-fuzz: [9599](https://oss-fuzz.com/v2/testcase-detail/5697041979146240), [9600](https://oss-fuzz.com/v2/testcase-detail/6419204524736512)

Description: 

Both issues are due to `ERROR: libFuzzer: out-of-memory` because of the usage of a large integer in the corpus. Added max constraint validate rule to the appropriate field.

Risk Level: Low

Testing: Tested unit tests (`bazel test //test/server:server_fuzz_test` and `bazel test //test/server/config_validation:config_fuzz_test`), built and ran fuzzers with oss-fuzz.

Signed-off-by: Anirudh M m.anirudh18@gmail.com