### PR TITLE
http_filter: add addEncodedTrailers and addDecodedTrailers

### DIFF
--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -190,15 +190,13 @@ public:
    */
   virtual void addDecodedData(Buffer::Instance& data, bool streaming_filter) PURE;
 
-   /**
-    * Adds decoded trailers. May only be called in decodeData when end_stream is set to true.
-    * If called in any other context, std::logic_error will be thrown.
-    *
-    * When called in decodeData, the trailers map will be initialized to an empty map and returned by
-    * reference. Calling it more than once is invalid and will result in std::logic_error being thrown.
-    *
-    * @throws std::logic_error if called in the wrong context
-    */
+  /**
+   * Adds decoded trailers. May only be called in decodeData when end_stream is set to true.
+   * If called in any other context, an assertion will be triggered.
+   *
+   * When called in decodeData, the trailers map will be initialized to an empty map and returned by
+   * reference. Calling this function more than once is invalid.
+   */
   virtual HeaderMap& addDecodedTrailers() PURE;
 
   /**
@@ -407,13 +405,11 @@ public:
   virtual void addEncodedData(Buffer::Instance& data, bool streaming_filter) PURE;
 
   /**
-   * Adds encoded trailers. May only be called in encodeData when end_stream is set to true. If called 
-   * in any other context, std::logic_error will be thrown.
+   * Adds encoded trailers. May only be called in encodeData when end_stream is set to true.
+   * If called in any other context, an assertion will be triggered.
    *
    * When called in encodeData, the trailers map will be initialized to an empty map and returned by
-   * reference. Calling it more than once is invalid and will result in std::logic_error being thrown.
-   *
-   * @throws std::logic_error if called in the wrong context
+   * reference. Calling this function more than once is invalid.
    */
   virtual HeaderMap& addEncodedTrailers() PURE;
 

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -190,10 +190,17 @@ public:
    */
   virtual void addDecodedData(Buffer::Instance& data, bool streaming_filter) PURE;
 
-  /**
-   * Adds decoded trailers. This will overwrite any existing trailers should any already exist.
-   */
-  virtual void addDecodedTrailers(HeaderMapPtr&& trailers) PURE;
+   /**
+    * Adds decoded trailers. May only be called in decodeData when end_stream is set to true or in
+    * decodeTrailers. If called in any other context, std::logic_error will be thrown.
+    *
+    * When called in decodeData, the trailers map will be initialized to an empty map and returned by
+    * reference. Calling it more than once is invalid and will result in std::logic_error being thrown.
+    * 
+    * When called in decodeTrailers it will simply return the trailers (same data as passed in the 
+    * parameter).
+    */
+  virtual HeaderMap& addDecodedTrailers() PURE;
 
   /**
    * Create a locally generated response using the provided response_code and body_text parameters.
@@ -401,9 +408,16 @@ public:
   virtual void addEncodedData(Buffer::Instance& data, bool streaming_filter) PURE;
 
   /**
-   * Adds encoded trailers. This will overwrite any existing trailers should any already exist.
+   * Adds encoded trailers. May only be called in encodeData when end_stream is set to true or in
+   * encodeTrailers. If called in any other context, std::logic_error will be thrown.
+   *
+   * When called in encodeData, the trailers map will be initialized to an empty map and returned by
+   * reference. Calling it more than once is invalid and will result in std::logic_error being thrown.
+   * 
+   * When called in encodeTrailers it will simply return the trailers (same data as passed in the 
+   * parameter).
    */
-  virtual void addEncodedTrailers(HeaderMapPtr&& trailers) PURE;
+  virtual HeaderMap& addEncodedTrailers() PURE;
 
   /**
    * Called when an encoder filter goes over its high watermark.

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -196,6 +196,8 @@ public:
    *
    * When called in decodeData, the trailers map will be initialized to an empty map and returned by
    * reference. Calling this function more than once is invalid.
+   *
+   * @return a reference to the newly created trailers map.
    */
   virtual HeaderMap& addDecodedTrailers() PURE;
 
@@ -410,6 +412,8 @@ public:
    *
    * When called in encodeData, the trailers map will be initialized to an empty map and returned by
    * reference. Calling this function more than once is invalid.
+   *
+   * @return a reference to the newly created trailers map.
    */
   virtual HeaderMap& addEncodedTrailers() PURE;
 

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -191,14 +191,13 @@ public:
   virtual void addDecodedData(Buffer::Instance& data, bool streaming_filter) PURE;
 
    /**
-    * Adds decoded trailers. May only be called in decodeData when end_stream is set to true or in
-    * decodeTrailers. If called in any other context, std::logic_error will be thrown.
+    * Adds decoded trailers. May only be called in decodeData when end_stream is set to true.
+    * If called in any other context, std::logic_error will be thrown.
     *
     * When called in decodeData, the trailers map will be initialized to an empty map and returned by
     * reference. Calling it more than once is invalid and will result in std::logic_error being thrown.
-    * 
-    * When called in decodeTrailers it will simply return the trailers (same data as passed in the 
-    * parameter).
+    *
+    * @throws std::logic_error if called in the wrong context
     */
   virtual HeaderMap& addDecodedTrailers() PURE;
 
@@ -408,14 +407,13 @@ public:
   virtual void addEncodedData(Buffer::Instance& data, bool streaming_filter) PURE;
 
   /**
-   * Adds encoded trailers. May only be called in encodeData when end_stream is set to true or in
-   * encodeTrailers. If called in any other context, std::logic_error will be thrown.
+   * Adds encoded trailers. May only be called in encodeData when end_stream is set to true. If called 
+   * in any other context, std::logic_error will be thrown.
    *
    * When called in encodeData, the trailers map will be initialized to an empty map and returned by
    * reference. Calling it more than once is invalid and will result in std::logic_error being thrown.
-   * 
-   * When called in encodeTrailers it will simply return the trailers (same data as passed in the 
-   * parameter).
+   *
+   * @throws std::logic_error if called in the wrong context
    */
   virtual HeaderMap& addEncodedTrailers() PURE;
 

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -191,6 +191,11 @@ public:
   virtual void addDecodedData(Buffer::Instance& data, bool streaming_filter) PURE;
 
   /**
+   * Adds decoded trailers. This will overwrite any existing trailers should any already exist.
+   */
+  virtual void addDecodedTrailers(HeaderMapPtr&& trailers) PURE;
+
+  /**
    * Create a locally generated response using the provided response_code and body_text parameters.
    * If the request was a gRPC request the local reply will be encoded as a gRPC response with a 200
    * HTTP response code and grpc-status and grpc-message headers mapped from the provided
@@ -396,11 +401,9 @@ public:
   virtual void addEncodedData(Buffer::Instance& data, bool streaming_filter) PURE;
 
   /**
-   * Provides a trailer map that can be used to modify the trailers for a response. Used when
-   * trailers need to be injected into a response and the upstream response did not contain any
-   * trailers (in which case encodeTrailers is not called).
+   * Adds encoded trailers. This will overwrite any existing trailers should any already exist.
    */
-  virtual HeaderMap& addEncodedTrailers() PURE;
+  virtual void addEncodedTrailers(HeaderMapPtr&& trailers) PURE;
 
   /**
    * Called when an encoder filter goes over its high watermark.

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -396,6 +396,13 @@ public:
   virtual void addEncodedData(Buffer::Instance& data, bool streaming_filter) PURE;
 
   /**
+   * Provides a trailer map that can be used to modify the trailers for a response. Used when
+   * trailers need to be injected into a response and the upstream response did not contain any
+   * trailers (in which case encodeTrailers is not called).
+   */
+  virtual HeaderMap& addEncodedTrailers() PURE;
+
+  /**
    * Called when an encoder filter goes over its high watermark.
    */
   virtual void onEncoderFilterAboveWriteBufferHighWatermark() PURE;

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -268,7 +268,7 @@ private:
   Tracing::Span& activeSpan() override { return active_span_; }
   const Tracing::Config& tracingConfig() override { return tracing_config_; }
   void continueDecoding() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  void addDecodedTrailers(HeaderMapPtr&&) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  HeaderMap& addDecodedTrailers() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   void addDecodedData(Buffer::Instance&, bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   const Buffer::Instance* decodingBuffer() override { return buffered_body_.get(); }
   void sendLocalReply(Code code, const std::string& body,

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -268,6 +268,7 @@ private:
   Tracing::Span& activeSpan() override { return active_span_; }
   const Tracing::Config& tracingConfig() override { return tracing_config_; }
   void continueDecoding() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void addDecodedTrailers(HeaderMapPtr&&) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   void addDecodedData(Buffer::Instance&, bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   const Buffer::Instance* decodingBuffer() override { return buffered_body_.get(); }
   void sendLocalReply(Code code, const std::string& body,

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -797,7 +797,8 @@ void ConnectionManagerImpl::ActiveStream::decodeData(ActiveStreamDecoderFilter* 
       trailers_added_entry = entry;
     }
 
-    if (!(*entry)->commonHandleAfterDataCallback(status, data, state_.decoder_filters_streaming_) && std::next(entry) != decoder_filters_.end()) {
+    if (!(*entry)->commonHandleAfterDataCallback(status, data, state_.decoder_filters_streaming_) &&
+        std::next(entry) != decoder_filters_.end()) {
       // break here to ensure that we call decodeTrailers below
       return;
     }
@@ -1101,11 +1102,6 @@ HeaderMap& ConnectionManagerImpl::ActiveStream::addEncodedTrailers() {
   // traileres can only be added once
   ASSERT(!response_trailers_);
 
-  // local_complete_ is set to true at the start of encodeData(..., true), but since
-  // we've now added trailers we have to undo this to prevent encodeTrailers from
-  // blowing up when it assert on local_complete_
-  state_.local_complete_ = false;
-
   response_trailers_ = std::make_unique<HeaderMapImpl>();
   return *response_trailers_;
 }
@@ -1148,7 +1144,8 @@ void ConnectionManagerImpl::ActiveStream::encodeData(ActiveStreamEncoderFilter* 
     if (end_stream) {
       state_.filter_call_state_ |= FilterCallState::LastDataFrame;
     }
-    FilterDataStatus status = (*entry)->handle_->encodeData(data, end_stream && !response_trailers_);
+    FilterDataStatus status =
+        (*entry)->handle_->encodeData(data, end_stream && !response_trailers_);
     state_.filter_call_state_ &= ~FilterCallState::EncodeData;
     if (end_stream) {
       state_.filter_call_state_ &= ~FilterCallState::LastDataFrame;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -792,7 +792,8 @@ void ConnectionManagerImpl::ActiveStream::decodeData(ActiveStreamDecoderFilter* 
     ENVOY_STREAM_LOG(trace, "decode data called: filter={} status={}", *this,
                      static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
     if (!(*entry)->commonHandleAfterDataCallback(status, data, state_.decoder_filters_streaming_)) {
-      return;
+      // break here to ensure that we call decodeTrailers below
+      break;
     }
   }
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -813,10 +813,10 @@ void ConnectionManagerImpl::ActiveStream::decodeData(ActiveStreamDecoderFilter* 
 }
 
 HeaderMap& ConnectionManagerImpl::ActiveStream::addDecodedTrailers() {
-  // trailers can only be added during the last data frame (i.e. end_stream = true)
+  // Trailers can only be added during the last data frame (i.e. end_stream = true).
   ASSERT(state_.filter_call_state_ & FilterCallState::LastDataFrame);
 
-  // traileres can only be added once
+  // Trailers can only be added once.
   ASSERT(!request_trailers_);
 
   request_trailers_ = std::make_unique<HeaderMapImpl>();
@@ -1096,10 +1096,10 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
 }
 
 HeaderMap& ConnectionManagerImpl::ActiveStream::addEncodedTrailers() {
-  // trailers can only be added during the last data frame (i.e. end_stream = true)
+  // Trailers can only be added during the last data frame (i.e. end_stream = true).
   ASSERT(state_.filter_call_state_ & FilterCallState::LastDataFrame);
 
-  // traileres can only be added once
+  // Trailers can only be added once.
   ASSERT(!response_trailers_);
 
   response_trailers_ = std::make_unique<HeaderMapImpl>();

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -768,7 +768,7 @@ void ConnectionManagerImpl::ActiveStream::decodeData(ActiveStreamDecoderFilter* 
 
   std::list<ActiveStreamDecoderFilterPtr>::iterator entry;
   auto trailers_added_entry = decoder_filters_.end();
-  bool trailers_exists_at_start = request_trailers_ != nullptr;
+  const bool trailers_exists_at_start = request_trailers_ != nullptr;
   if (!filter) {
     entry = decoder_filters_.begin();
   } else {
@@ -1135,7 +1135,7 @@ void ConnectionManagerImpl::ActiveStream::encodeData(ActiveStreamEncoderFilter* 
   std::list<ActiveStreamEncoderFilterPtr>::iterator entry = commonEncodePrefix(filter, end_stream);
   auto trailers_added_entry = encoder_filters_.end();
 
-  bool trailers_exists_at_start = response_trailers_ != nullptr;
+  const bool trailers_exists_at_start = response_trailers_ != nullptr;
   for (; entry != encoder_filters_.end(); entry++) {
     ASSERT(!(state_.filter_call_state_ & FilterCallState::EncodeData));
 

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -162,7 +162,7 @@ private:
 
     // Http::StreamDecoderFilterCallbacks
     void addDecodedData(Buffer::Instance& data, bool streaming) override;
-    void addDecodedTrailers(HeaderMapPtr&& trailers) override;
+    HeaderMap& addDecodedTrailers() override;
     void continueDecoding() override;
     const Buffer::Instance* decodingBuffer() override {
       return parent_.buffered_request_data_.get();
@@ -230,7 +230,7 @@ private:
 
     // Http::StreamEncoderFilterCallbacks
     void addEncodedData(Buffer::Instance& data, bool streaming) override;
-    void addEncodedTrailers(HeaderMapPtr&& trailers) override;
+    HeaderMap& addEncodedTrailers() override;
     void onEncoderFilterAboveWriteBufferHighWatermark() override;
     void onEncoderFilterBelowWriteBufferLowWatermark() override;
     void setEncoderBufferLimit(uint32_t limit) override { parent_.setBufferLimit(limit); }
@@ -269,13 +269,13 @@ private:
     commonEncodePrefix(ActiveStreamEncoderFilter* filter, bool end_stream);
     const Network::Connection* connection();
     void addDecodedData(ActiveStreamDecoderFilter& filter, Buffer::Instance& data, bool streaming);
-    void addDecodedTrailers(HeaderMapPtr&& trailers);
+    HeaderMap& addDecodedTrailers();
     void decodeHeaders(ActiveStreamDecoderFilter* filter, HeaderMap& headers, bool end_stream);
     void decodeData(ActiveStreamDecoderFilter* filter, Buffer::Instance& data, bool end_stream);
     void decodeTrailers(ActiveStreamDecoderFilter* filter, HeaderMap& trailers);
     void maybeEndDecode(bool end_stream);
     void addEncodedData(ActiveStreamEncoderFilter& filter, Buffer::Instance& data, bool streaming);
-    void addEncodedTrailers(HeaderMapPtr&& trailers);
+    HeaderMap& addEncodedTrailers();
     void sendLocalReply(bool is_grpc_request, Code code, const std::string& body,
                         std::function<void(HeaderMap& headers)> modify_headers);
     void encode100ContinueHeaders(ActiveStreamEncoderFilter* filter, HeaderMap& headers);

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -343,7 +343,7 @@ private:
       // to verify we do not encode100Continue headers more than once per
       // filter.
       static constexpr uint32_t Encode100ContinueHeaders  = 0x40;
-      // Used to indicate that we're processing the final [en|de]Code frame,
+      // Used to indicate that we're processing the final [En|De]codeData frame,
       // i.e. end_stream = true
       static constexpr uint32_t LastDataFrame = 0x80;
     };

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -229,6 +229,7 @@ private:
 
     // Http::StreamEncoderFilterCallbacks
     void addEncodedData(Buffer::Instance& data, bool streaming) override;
+    HeaderMap& addEncodedTrailers() override;
     void onEncoderFilterAboveWriteBufferHighWatermark() override;
     void onEncoderFilterBelowWriteBufferLowWatermark() override;
     void setEncoderBufferLimit(uint32_t limit) override { parent_.setBufferLimit(limit); }
@@ -272,6 +273,7 @@ private:
     void decodeTrailers(ActiveStreamDecoderFilter* filter, HeaderMap& trailers);
     void maybeEndDecode(bool end_stream);
     void addEncodedData(ActiveStreamEncoderFilter& filter, Buffer::Instance& data, bool streaming);
+    HeaderMap& addEncodedTrailers();
     void sendLocalReply(bool is_grpc_request, Code code, const std::string& body,
                         std::function<void(HeaderMap& headers)> modify_headers);
     void encode100ContinueHeaders(ActiveStreamEncoderFilter* filter, HeaderMap& headers);

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -157,11 +157,12 @@ private:
     void doData(bool end_stream) override {
       parent_.decodeData(this, *parent_.buffered_request_data_, end_stream);
     }
-    void doTrailers() override { parent_.decodeTrailers(this, *parent_.request_trailers_); }
+    void doTrailers() override { parent_.decodeTrailers(this); }
     const HeaderMapPtr& trailers() override { return parent_.request_trailers_; }
 
     // Http::StreamDecoderFilterCallbacks
     void addDecodedData(Buffer::Instance& data, bool streaming) override;
+    void addDecodedTrailers(HeaderMapPtr&& trailers) override;
     void continueDecoding() override;
     const Buffer::Instance* decodingBuffer() override {
       return parent_.buffered_request_data_.get();
@@ -224,12 +225,12 @@ private:
     void doData(bool end_stream) override {
       parent_.encodeData(this, *parent_.buffered_response_data_, end_stream);
     }
-    void doTrailers() override { parent_.encodeTrailers(this, *parent_.response_trailers_); }
+    void doTrailers() override { parent_.encodeTrailers(this); }
     const HeaderMapPtr& trailers() override { return parent_.response_trailers_; }
 
     // Http::StreamEncoderFilterCallbacks
     void addEncodedData(Buffer::Instance& data, bool streaming) override;
-    HeaderMap& addEncodedTrailers() override;
+    void addEncodedTrailers(HeaderMapPtr&& trailers) override;
     void onEncoderFilterAboveWriteBufferHighWatermark() override;
     void onEncoderFilterBelowWriteBufferLowWatermark() override;
     void setEncoderBufferLimit(uint32_t limit) override { parent_.setBufferLimit(limit); }
@@ -268,18 +269,19 @@ private:
     commonEncodePrefix(ActiveStreamEncoderFilter* filter, bool end_stream);
     const Network::Connection* connection();
     void addDecodedData(ActiveStreamDecoderFilter& filter, Buffer::Instance& data, bool streaming);
+    void addDecodedTrailers(HeaderMapPtr&& trailers);
     void decodeHeaders(ActiveStreamDecoderFilter* filter, HeaderMap& headers, bool end_stream);
     void decodeData(ActiveStreamDecoderFilter* filter, Buffer::Instance& data, bool end_stream);
-    void decodeTrailers(ActiveStreamDecoderFilter* filter, HeaderMap& trailers);
+    void decodeTrailers(ActiveStreamDecoderFilter* filter);
     void maybeEndDecode(bool end_stream);
     void addEncodedData(ActiveStreamEncoderFilter& filter, Buffer::Instance& data, bool streaming);
-    HeaderMap& addEncodedTrailers();
+    void addEncodedTrailers(HeaderMapPtr&& trailers);
     void sendLocalReply(bool is_grpc_request, Code code, const std::string& body,
                         std::function<void(HeaderMap& headers)> modify_headers);
     void encode100ContinueHeaders(ActiveStreamEncoderFilter* filter, HeaderMap& headers);
     void encodeHeaders(ActiveStreamEncoderFilter* filter, HeaderMap& headers, bool end_stream);
     void encodeData(ActiveStreamEncoderFilter* filter, Buffer::Instance& data, bool end_stream);
-    void encodeTrailers(ActiveStreamEncoderFilter* filter, HeaderMap& trailers);
+    void encodeTrailers(ActiveStreamEncoderFilter* filter);
     void maybeEndEncode(bool end_stream);
     uint64_t streamId() { return stream_id_; }
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -2384,7 +2384,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddTrailersInDataCallbackNoTrailers)
       .WillOnce(Return(FilterDataStatus::Continue));
 
   // since we added trailers, we should see decodeTrailers
-  EXPECT_CALL(*decoder_filters_[0], decodeTrailers(_)).WillOnce(Invoke([&](HeaderMap& trailers) {
+  EXPECT_CALL(*decoder_filters_[1], decodeTrailers(_)).WillOnce(Invoke([&](HeaderMap& trailers) {
     // ensure that we see the trailers set in decodeData
     Http::LowerCaseString key("foo");
     auto t = trailers.get(key);
@@ -2392,8 +2392,6 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddTrailersInDataCallbackNoTrailers)
     EXPECT_EQ(t->value(), trailers_data.c_str());
     return FilterTrailersStatus::Continue;
   }));
-  EXPECT_CALL(*decoder_filters_[1], decodeTrailers(_))
-      .WillOnce(Return(FilterTrailersStatus::Continue));
 
   // Kick off the incoming data.
   Buffer::OwnedImpl fake_input("1234");

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -2387,12 +2387,6 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddTrailersInDataCallbackNoTrailers)
   EXPECT_CALL(*decoder_filters_[0], decodeTrailers(_)).WillOnce(Invoke([&](HeaderMap& trailers) {
     // ensure that we see the trailers set in decodeData
     Http::LowerCaseString key("foo");
-    trailers.iterate(
-        [](const HeaderEntry& e, void*) -> Http::HeaderMap::Iterate {
-          std::cout << e.key().getStringView() << std::endl;
-          return Http::HeaderMap::Iterate::Continue;
-        },
-        nullptr);
     auto t = trailers.get(key);
     ASSERT(t);
     EXPECT_EQ(t->value(), trailers_data.c_str());
@@ -2429,15 +2423,13 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddTrailersInDataCallbackNoTrailers)
   EXPECT_CALL(response_encoder_, encodeData(_, false));
 
   // since we added trailers, we should see encodeTrailer callbacks
-  EXPECT_CALL(*encoder_filters_[0], encodeTrailers(_)).WillOnce(Invoke([&](HeaderMap& trailers) {
+  EXPECT_CALL(*encoder_filters_[1], encodeTrailers(_)).WillOnce(Invoke([&](HeaderMap& trailers) {
     // ensure that we see the trailers set in decodeData
     Http::LowerCaseString key("foo");
     auto t = trailers.get(key);
     EXPECT_EQ(t->value(), trailers_data.c_str());
     return FilterTrailersStatus::Continue;
   }));
-  EXPECT_CALL(*encoder_filters_[1], encodeTrailers(_))
-      .WillOnce(Return(FilterTrailersStatus::Continue));
 
   // Ensure that we call encodeTrailers
   EXPECT_CALL(response_encoder_, encodeTrailers(_));

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -2297,7 +2297,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddTrailersInTrailersCallback) {
       .WillOnce(Return(FilterDataStatus::StopIterationAndBuffer));
   EXPECT_CALL(*decoder_filters_[0], decodeTrailers(_))
       .WillOnce(Invoke([&](Http::HeaderMap&) -> FilterTrailersStatus {
-        decoder_filters_[0]->callbacks_->addDecodedTrailers().addCopy(trailer_key, trailers_data);
+        EXPECT_THROW(decoder_filters_[0]->callbacks_->addDecodedTrailers().addCopy(trailer_key, trailers_data), std::logic_error);
         return FilterTrailersStatus::Continue;
       }));
   EXPECT_CALL(*decoder_filters_[1], decodeHeaders(_, false))
@@ -2339,7 +2339,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddTrailersInTrailersCallback) {
   // set up encodeTrailer expectations
   EXPECT_CALL(*encoder_filters_[0], encodeTrailers(_))
       .WillOnce(Invoke([&](Http::HeaderMap&) -> FilterTrailersStatus {
-        encoder_filters_[0]->callbacks_->addEncodedTrailers().addCopy(trailer_key, trailers_data);
+        EXPECT_THROW(encoder_filters_[0]->callbacks_->addEncodedTrailers().addCopy(trailer_key, trailers_data), std::logic_error);
         return FilterTrailersStatus::Continue;
       }));
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -2325,18 +2325,98 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddTrailersInTrailersCallback) {
   // set up encodeTrailer expectations
   std::string trailers_data("trailers");
   EXPECT_CALL(*encoder_filters_[0], encodeTrailers(_))
-      .WillOnce(InvokeWithoutArgs([&]() -> FilterTrailersStatus {
-        encoder_filters_[0]->callbacks_->addEncodedTrailers().addCopy(trailer_key, trailers_data);
+      .WillOnce(Invoke([&](Http::HeaderMap&) -> FilterTrailersStatus {
+        encoder_filters_[0]->callbacks_->addEncodedTrailers(
+            HeaderMapPtr{new TestHeaderMapImpl{{"foo", trailers_data}}});
         return FilterTrailersStatus::Continue;
       }));
 
   EXPECT_CALL(*encoder_filters_[1], encodeTrailers(_))
       .WillOnce(Invoke([&](Http::HeaderMap& trailers) -> FilterTrailersStatus {
         auto v = trailers.get(trailer_key);
-        EXPECT_NE(v, nullptr);
         EXPECT_EQ(v->value().getStringView(), trailers_data);
         return FilterTrailersStatus::Continue;
       }));
+  EXPECT_CALL(response_encoder_, encodeTrailers(_));
+  expectOnDestroy();
+
+  // invoke encodeTrailers
+  decoder_filters_[0]->callbacks_->encodeTrailers(
+      HeaderMapPtr{new TestHeaderMapImpl{{"some", "trailer"}}});
+}
+
+TEST_F(HttpConnectionManagerImplTest, FilterAddTrailersInDataCallbackWithTrailers) {
+  InSequence s;
+  setup(false, "");
+
+  EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    StreamDecoder* decoder = &conn_manager_->newStream(response_encoder_);
+    HeaderMapPtr headers{new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}}};
+    decoder->decodeHeaders(std::move(headers), false);
+
+    Buffer::OwnedImpl fake_data("hello");
+    decoder->decodeData(fake_data, false);
+
+    decoder->decodeTrailers(HeaderMapPtr{new TestHeaderMapImpl{{"decoding", "trailers"}}});
+  }));
+
+  setupFilterChain(2, 2);
+
+  std::string trailers_data("trailers");
+  Http::LowerCaseString trailer_key("foo");
+  EXPECT_CALL(*decoder_filters_[0], decodeHeaders(_, false))
+      .WillOnce(Return(FilterHeadersStatus::Continue));
+  EXPECT_CALL(*decoder_filters_[1], decodeHeaders(_, false))
+      .WillOnce(Return(FilterHeadersStatus::Continue));
+  EXPECT_CALL(*decoder_filters_[0], decodeData(_, false))
+      .WillOnce(InvokeWithoutArgs([&]() -> FilterDataStatus {
+        decoder_filters_[0]->callbacks_->addDecodedTrailers(
+            HeaderMapPtr{new TestHeaderMapImpl{{"foo", trailers_data}}});
+        return FilterDataStatus::Continue;
+      }));
+  EXPECT_CALL(*decoder_filters_[1], decodeData(_, false))
+      .WillOnce(Return(FilterDataStatus::Continue));
+  EXPECT_CALL(*decoder_filters_[0], decodeTrailers(_))
+      .WillOnce(Return(FilterTrailersStatus::Continue));
+  EXPECT_CALL(*decoder_filters_[1], decodeTrailers(_))
+      .WillOnce(Return(FilterTrailersStatus::Continue));
+
+  // Kick off the incoming data.
+  Buffer::OwnedImpl fake_input("1234");
+  conn_manager_->onData(fake_input, false);
+
+  // set up encodeHeaders expectations
+  EXPECT_CALL(*encoder_filters_[0], encodeHeaders(_, false))
+      .WillOnce(Return(FilterHeadersStatus::Continue));
+  EXPECT_CALL(*encoder_filters_[1], encodeHeaders(_, false))
+      .WillOnce(Return(FilterHeadersStatus::Continue));
+  EXPECT_CALL(response_encoder_, encodeHeaders(_, false));
+
+  // invoke encodeHeaders
+  decoder_filters_[0]->callbacks_->encodeHeaders(
+      HeaderMapPtr{new TestHeaderMapImpl{{":status", "200"}}}, false);
+
+  // set up encodeData expectations
+  EXPECT_CALL(*encoder_filters_[0], encodeData(_, false))
+      .WillOnce(Return(FilterDataStatus::Continue));
+  EXPECT_CALL(*encoder_filters_[1], encodeData(_, false))
+      .WillOnce(InvokeWithoutArgs([&]() -> FilterDataStatus {
+        encoder_filters_[1]->callbacks_->addEncodedTrailers(
+            HeaderMapPtr{new TestHeaderMapImpl{{"foo", trailers_data}}});
+        return FilterDataStatus::Continue;
+      }));
+
+  EXPECT_CALL(response_encoder_, encodeData(_, false));
+
+  // invoke encodeData
+  Buffer::OwnedImpl response_body("response");
+  decoder_filters_[0]->callbacks_->encodeData(response_body, false);
+
+  // set up encodeTrailers expectations
+  EXPECT_CALL(*encoder_filters_[0], encodeTrailers(_))
+      .WillOnce(Return(FilterTrailersStatus::Continue));
+  EXPECT_CALL(*encoder_filters_[1], encodeTrailers(_))
+      .WillOnce(Return(FilterTrailersStatus::Continue));
   EXPECT_CALL(response_encoder_, encodeTrailers(_));
   expectOnDestroy();
 
@@ -2355,20 +2435,25 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddTrailersInDataCallbackNoTrailers)
     decoder->decodeHeaders(std::move(headers), false);
 
     Buffer::OwnedImpl fake_data("hello");
-    decoder->decodeData(fake_data, false);
-
-    HeaderMapPtr trailers{new TestHeaderMapImpl{{"foo", "bar"}}};
-    decoder->decodeTrailers(std::move(trailers));
+    decoder->decodeData(fake_data, true);
   }));
 
-  setupFilterChain(1, 2);
+  setupFilterChain(2, 2);
 
+  std::string trailers_data("trailers");
+  Http::LowerCaseString trailer_key("foo");
   EXPECT_CALL(*decoder_filters_[0], decodeHeaders(_, false))
-      .WillOnce(Return(FilterHeadersStatus::StopIteration));
-  EXPECT_CALL(*decoder_filters_[0], decodeData(_, false))
-      .WillOnce(Return(FilterDataStatus::StopIterationAndBuffer));
-  EXPECT_CALL(*decoder_filters_[0], decodeTrailers(_))
-      .WillOnce(Return(FilterTrailersStatus::StopIteration));
+      .WillOnce(Return(FilterHeadersStatus::Continue));
+  EXPECT_CALL(*decoder_filters_[1], decodeHeaders(_, false))
+      .WillOnce(Return(FilterHeadersStatus::Continue));
+  EXPECT_CALL(*decoder_filters_[0], decodeData(_, true))
+      .WillOnce(InvokeWithoutArgs([&]() -> FilterDataStatus {
+        decoder_filters_[0]->callbacks_->addDecodedTrailers(
+            HeaderMapPtr{new TestHeaderMapImpl{{"foo", trailers_data}}});
+        return FilterDataStatus::Continue;
+      }));
+  EXPECT_CALL(*decoder_filters_[1], decodeData(_, true))
+      .WillOnce(Return(FilterDataStatus::Continue));
 
   // Kick off the incoming data.
   Buffer::OwnedImpl fake_input("1234");
@@ -2388,14 +2473,14 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddTrailersInDataCallbackNoTrailers)
   // set up encodeData expectations
   EXPECT_CALL(*encoder_filters_[0], encodeData(_, true))
       .WillOnce(Return(FilterDataStatus::Continue));
-  std::string trailers_data("trailers");
-  Http::LowerCaseString trailer_key("foo");
   EXPECT_CALL(*encoder_filters_[1], encodeData(_, true))
       .WillOnce(InvokeWithoutArgs([&]() -> FilterDataStatus {
-        encoder_filters_[1]->callbacks_->addEncodedTrailers().addCopy(trailer_key, trailers_data);
+        encoder_filters_[1]->callbacks_->addEncodedTrailers(
+            HeaderMapPtr{new TestHeaderMapImpl{{"foo", trailers_data}}});
         return FilterDataStatus::Continue;
       }));
 
+  // Ensure that we call encodeTrailers
   EXPECT_CALL(response_encoder_, encodeData(_, false));
   EXPECT_CALL(response_encoder_, encodeTrailers(_));
 

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -192,6 +192,22 @@ envoy_cc_test(
 )
 
 envoy_cc_test_library(
+    name = "add_trailers_filter_config_lib",
+    srcs = [
+        "add_trailers_filter.cc",
+        "add_trailers_filter.h",
+        "add_trailers_filter_config.cc",
+        "add_trailers_filter_config.h",
+    ],
+    deps = [
+        "//include/envoy/http:filter_interface",
+        "//include/envoy/registry",
+        "//include/envoy/server:filter_config_interface",
+        "//source/extensions/filters/http/common:empty_http_filter_config_lib",
+    ],
+)
+
+envoy_cc_test_library(
     name = "http_integration_lib",
     srcs = [
         "http_integration.cc",
@@ -200,6 +216,7 @@ envoy_cc_test_library(
         "http_integration.h",
     ],
     deps = [
+        ":add_trailers_filter_config_lib",
         ":integration_lib",
         "//source/extensions/filters/http/router:config",
         "//source/extensions/filters/network/http_connection_manager:config",

--- a/test/integration/add_trailers_filter.cc
+++ b/test/integration/add_trailers_filter.cc
@@ -5,7 +5,7 @@
 namespace Envoy {
 Http::FilterDataStatus AddTrailersStreamFilter::decodeData(Buffer::Instance&, bool end_stream) {
   if (end_stream) {
-    /* decoder_callbacks_->addDecodedTrailers().insertGrpcMessage().value(std::string("decode")); */
+    decoder_callbacks_->addDecodedTrailers().insertGrpcMessage().value(std::string("decode"));
   }
 
   return Http::FilterDataStatus::Continue;

--- a/test/integration/add_trailers_filter.cc
+++ b/test/integration/add_trailers_filter.cc
@@ -1,0 +1,21 @@
+#include "test/integration/add_trailers_filter.h"
+
+#include <string>
+
+namespace Envoy {
+Http::FilterDataStatus AddTrailersStreamFilter::decodeData(Buffer::Instance&, bool end_stream) {
+  if (end_stream) {
+    /* decoder_callbacks_->addDecodedTrailers().insertGrpcMessage().value(std::string("decode")); */
+  }
+
+  return Http::FilterDataStatus::Continue;
+}
+
+Http::FilterDataStatus AddTrailersStreamFilter::encodeData(Buffer::Instance&, bool end_stream) {
+  if (end_stream) {
+    encoder_callbacks_->addEncodedTrailers().insertGrpcMessage().value(std::string("encode"));
+  }
+
+  return Http::FilterDataStatus::Continue;
+}
+} // namespace Envoy

--- a/test/integration/add_trailers_filter.h
+++ b/test/integration/add_trailers_filter.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "envoy/http/filter.h"
+
+namespace Envoy {
+// a test filter that inserts trailers at the end of encode/decode
+class AddTrailersStreamFilter : public Http::StreamFilter {
+public:
+  // Http::StreamFilterBase
+  void onDestroy() override {}
+
+  // Http::StreamDecoderFilter
+  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap&, bool) override {
+    return Http::FilterHeadersStatus::Continue;
+  }
+  Http::FilterDataStatus decodeData(Buffer::Instance&, bool end_stream) override;
+
+  Http::FilterTrailersStatus decodeTrailers(Http::HeaderMap&) override {
+    std::cout << "trailers cb" << std::endl;
+    return Http::FilterTrailersStatus::Continue;
+  }
+  void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override {
+    decoder_callbacks_ = &callbacks;
+  }
+
+  // Http::StreamEncoderFilter
+  Http::FilterHeadersStatus encode100ContinueHeaders(Http::HeaderMap&) override {
+    return Http::FilterHeadersStatus::Continue;
+  }
+  Http::FilterHeadersStatus encodeHeaders(Http::HeaderMap&, bool) override {
+    return Http::FilterHeadersStatus::Continue;
+  }
+  Http::FilterDataStatus encodeData(Buffer::Instance&, bool end_stream) override;
+  Http::FilterTrailersStatus encodeTrailers(Http::HeaderMap&) override {
+    return Http::FilterTrailersStatus::Continue;
+  }
+  void setEncoderFilterCallbacks(Http::StreamEncoderFilterCallbacks& callbacks) override {
+    encoder_callbacks_ = &callbacks;
+  }
+
+private:
+  Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
+  Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};
+};
+} // namespace Envoy

--- a/test/integration/add_trailers_filter.h
+++ b/test/integration/add_trailers_filter.h
@@ -16,7 +16,6 @@ public:
   Http::FilterDataStatus decodeData(Buffer::Instance&, bool end_stream) override;
 
   Http::FilterTrailersStatus decodeTrailers(Http::HeaderMap&) override {
-    std::cout << "trailers cb" << std::endl;
     return Http::FilterTrailersStatus::Continue;
   }
   void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override {

--- a/test/integration/add_trailers_filter_config.cc
+++ b/test/integration/add_trailers_filter_config.cc
@@ -1,0 +1,18 @@
+#include "test/integration/add_trailers_filter_config.h"
+#include "test/integration/add_trailers_filter.h"
+#include "envoy/registry/registry.h"
+
+namespace Envoy {
+Http::FilterFactoryCb
+AddTrailersStreamFilterConfig::createFilter(const std::string&,
+                                            Server::Configuration::FactoryContext&) {
+  return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<::Envoy::AddTrailersStreamFilter>());
+  };
+}
+
+// perform static registration
+static Registry::RegisterFactory<AddTrailersStreamFilterConfig,
+                                 Server::Configuration::NamedHttpFilterConfigFactory>
+    register_;
+} // namespace Envoy

--- a/test/integration/add_trailers_filter_config.cc
+++ b/test/integration/add_trailers_filter_config.cc
@@ -1,6 +1,8 @@
 #include "test/integration/add_trailers_filter_config.h"
-#include "test/integration/add_trailers_filter.h"
+
 #include "envoy/registry/registry.h"
+
+#include "test/integration/add_trailers_filter.h"
 
 namespace Envoy {
 Http::FilterFactoryCb

--- a/test/integration/add_trailers_filter_config.h
+++ b/test/integration/add_trailers_filter_config.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "envoy/server/filter_config.h"
+#include "test/integration/add_trailers_filter.h"
+#include "extensions/filters/http/common/empty_http_filter_config.h"
+#include "envoy/registry/registry.h"
+
+namespace Envoy {
+class AddTrailersStreamFilterConfig
+    : public Extensions::HttpFilters::Common::EmptyHttpFilterConfig {
+public:
+  AddTrailersStreamFilterConfig() : EmptyHttpFilterConfig("add-trailers-filter") {}
+
+  Http::FilterFactoryCb createFilter(const std::string&, Server::Configuration::FactoryContext&);
+};
+} // namespace Envoy

--- a/test/integration/add_trailers_filter_config.h
+++ b/test/integration/add_trailers_filter_config.h
@@ -1,9 +1,11 @@
 #pragma once
 
-#include "envoy/server/filter_config.h"
-#include "test/integration/add_trailers_filter.h"
-#include "extensions/filters/http/common/empty_http_filter_config.h"
 #include "envoy/registry/registry.h"
+#include "envoy/server/filter_config.h"
+
+#include "extensions/filters/http/common/empty_http_filter_config.h"
+
+#include "test/integration/add_trailers_filter.h"
 
 namespace Envoy {
 class AddTrailersStreamFilterConfig

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -38,6 +38,8 @@ TEST_P(Http2IntegrationTest, MultipleContentLengths) { testMultipleContentLength
 
 TEST_P(Http2IntegrationTest, ComputedHealthCheck) { testComputedHealthCheck(); }
 
+TEST_P(Http2IntegrationTest, AddEncodedTrailers) { testAddEncodedTrailers(); }
+
 TEST_P(Http2IntegrationTest, DrainClose) { testDrainClose(); }
 
 TEST_P(Http2IntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -22,6 +22,8 @@ TEST_P(Http2UpstreamIntegrationTest, RouterRedirect) { testRouterRedirect(); }
 
 TEST_P(Http2UpstreamIntegrationTest, ComputedHealthCheck) { testComputedHealthCheck(); }
 
+TEST_P(Http2UpstreamIntegrationTest, AddEncodedTrailers) { testAddEncodedTrailers(); }
+
 TEST_P(Http2UpstreamIntegrationTest, DrainClose) { testDrainClose(); }
 
 TEST_P(Http2UpstreamIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -442,7 +442,9 @@ config: {}
   }
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("503", response->headers().Status()->value().c_str());
-  EXPECT_STREQ("encode", response->trailers()->GrpcMessage()->value().c_str());
+  if (downstream_protocol_ == Http::CodecClient::Type::HTTP2) {
+    EXPECT_STREQ("encode", response->trailers()->GrpcMessage()->value().c_str());
+  }
 }
 
 // Add a health check filter and verify correct behavior when draining.

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -28,11 +28,11 @@
 
 #include "gtest/gtest.h"
 
-using testing::_;
 using testing::AnyNumber;
 using testing::HasSubstr;
 using testing::Invoke;
 using testing::Not;
+using testing::_;
 
 namespace Envoy {
 

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -437,6 +437,9 @@ config: {}
   upstream_request_->encodeData(128, true);
   response->waitForEndStream();
 
+  if (upstreamProtocol() == FakeHttpConnection::Type::HTTP2) {
+    EXPECT_STREQ("decode", upstream_request_->trailers()->GrpcMessage()->value().c_str());
+  }
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("503", response->headers().Status()->value().c_str());
   EXPECT_STREQ("encode", response->trailers()->GrpcMessage()->value().c_str());

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -28,11 +28,11 @@
 
 #include "gtest/gtest.h"
 
+using testing::_;
 using testing::AnyNumber;
 using testing::HasSubstr;
 using testing::Invoke;
 using testing::Not;
-using testing::_;
 
 namespace Envoy {
 
@@ -416,6 +416,30 @@ config:
 
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("503", response->headers().Status()->value().c_str());
+}
+
+void HttpIntegrationTest::testAddEncodedTrailers() {
+  config_helper_.addFilter(R"EOF(
+name: add-trailers-filter
+config: {}
+)EOF");
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response =
+      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "GET"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"}},
+                                         128);
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
+  upstream_request_->encodeData(128, true);
+  response->waitForEndStream();
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("503", response->headers().Status()->value().c_str());
+  EXPECT_STREQ("encode", response->trailers()->GrpcMessage()->value().c_str());
 }
 
 // Add a health check filter and verify correct behavior when draining.

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -156,6 +156,7 @@ protected:
   void testInvalidContentLength();
   void testMultipleContentLengths();
   void testComputedHealthCheck();
+  void testAddEncodedTrailers();
   void testDrainClose();
   void testRetry();
   void testRetryHittingBufferLimit();

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -40,6 +40,8 @@ TEST_P(IntegrationTest, RouterDirectResponse) { testRouterDirectResponse(); }
 
 TEST_P(IntegrationTest, ComputedHealthCheck) { testComputedHealthCheck(); }
 
+TEST_P(IntegrationTest, AddEncodedTrailers) { testAddEncodedTrailers(); }
+
 TEST_P(IntegrationTest, DrainClose) { testDrainClose(); }
 
 TEST_P(IntegrationTest, ConnectionClose) {

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -220,11 +220,9 @@ public:
   }
   void encodeTrailers(HeaderMapPtr&& trailers) override { encodeTrailers_(*trailers); }
 
-  void addDecodedTrailers(HeaderMapPtr&& trailers) override { addDecodedTrailers_(*trailers); }
-
   MOCK_METHOD0(continueDecoding, void());
   MOCK_METHOD2(addDecodedData, void(Buffer::Instance& data, bool streaming));
-  MOCK_METHOD1(addDecodedTrailers_, void(const HeaderMap& trailers));
+  MOCK_METHOD0(addDecodedTrailers, HeaderMap&());
   MOCK_METHOD0(decodingBuffer, const Buffer::Instance*());
   MOCK_METHOD1(encode100ContinueHeaders_, void(HeaderMap& headers));
   MOCK_METHOD2(encodeHeaders_, void(HeaderMap& headers, bool end_stream));
@@ -262,11 +260,9 @@ public:
 
   // Http::StreamEncoderFilterCallbacks
   MOCK_METHOD2(addEncodedData, void(Buffer::Instance& data, bool streaming));
-  MOCK_METHOD1(addEncodedTrailers_, void(const HeaderMap& trailers));
+  MOCK_METHOD0(addEncodedTrailers, HeaderMap&());
   MOCK_METHOD0(continueEncoding, void());
   MOCK_METHOD0(encodingBuffer, const Buffer::Instance*());
-
-  void addEncodedTrailers(HeaderMapPtr&& trailers) override { addEncodedTrailers_(*trailers); }
 
   Buffer::InstancePtr buffer_;
   testing::NiceMock<Tracing::MockSpan> active_span_;

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -220,8 +220,11 @@ public:
   }
   void encodeTrailers(HeaderMapPtr&& trailers) override { encodeTrailers_(*trailers); }
 
+  void addDecodedTrailers(HeaderMapPtr&& trailers) override { addDecodedTrailers_(*trailers); }
+
   MOCK_METHOD0(continueDecoding, void());
   MOCK_METHOD2(addDecodedData, void(Buffer::Instance& data, bool streaming));
+  MOCK_METHOD1(addDecodedTrailers_, void(const HeaderMap& trailers));
   MOCK_METHOD0(decodingBuffer, const Buffer::Instance*());
   MOCK_METHOD1(encode100ContinueHeaders_, void(HeaderMap& headers));
   MOCK_METHOD2(encodeHeaders_, void(HeaderMap& headers, bool end_stream));
@@ -259,9 +262,11 @@ public:
 
   // Http::StreamEncoderFilterCallbacks
   MOCK_METHOD2(addEncodedData, void(Buffer::Instance& data, bool streaming));
-  MOCK_METHOD0(addEncodedTrailers, HeaderMap&());
+  MOCK_METHOD1(addEncodedTrailers_, void(const HeaderMap& trailers));
   MOCK_METHOD0(continueEncoding, void());
   MOCK_METHOD0(encodingBuffer, const Buffer::Instance*());
+
+  void addEncodedTrailers(HeaderMapPtr&& trailers) override { addEncodedTrailers_(*trailers); }
 
   Buffer::InstancePtr buffer_;
   testing::NiceMock<Tracing::MockSpan> active_span_;

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -259,6 +259,7 @@ public:
 
   // Http::StreamEncoderFilterCallbacks
   MOCK_METHOD2(addEncodedData, void(Buffer::Instance& data, bool streaming));
+  MOCK_METHOD0(addEncodedTrailers, HeaderMap&());
   MOCK_METHOD0(continueEncoding, void());
   MOCK_METHOD0(encodingBuffer, const Buffer::Instance*());
 


### PR DESCRIPTION
Adds a function that allows inserting trailers into the stream response
outside of the encodeTrailers callback. This allows inserting trailers
when the upstream response has no trailers to begin with (e.g. h/1.1).

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Low, new optional feature
*Testing*: Unit tests
*Docs Changes*: Doc string on public interface
*Release Notes*: n/a

Fixes: #3966
