### PR TITLE
docs: minor typo and grammar fixups

### DIFF
--- a/api/XDS_PROTOCOL.md
+++ b/api/XDS_PROTOCOL.md
@@ -147,7 +147,7 @@ management server will provide the complete state of the LDS/CDS resources in
 each response. An absent `Listener` or `Cluster` will be deleted.
 
 For EDS/RDS, the management server does not need to supply every requested
-resource and may also supply additional, unrequested resources, `resource_names`
+resource and may also supply additional, unrequested resources. `resource_names`
 is only a hint. Envoy will silently ignore any superfluous resources. When a
 requested resource is missing in a RDS or EDS update, Envoy will retain the last
 known value for this resource. The management server may be able to infer all
@@ -166,7 +166,7 @@ For EDS/RDS, Envoy may either generate a distinct stream for each resource of a
 given type (e.g. if each `ConfigSource` has its own distinct upstream cluster
 for a management server), or may combine together multiple resource requests for
 a given resource type when they are destined for the same management server.
-This is left to implementation specifics, management servers should be capable
+While this is left to implementation specifics, management servers should be capable
 of handling one or more `resource_names` for a given resource type in each
 request. Both sequence diagrams below are valid for fetching two EDS resources
 `{foo, bar}`:
@@ -287,7 +287,7 @@ admin:
 
 ### Incremental xDS
 
-Incremental xDS is separate xDS endpoint available for ADS, CDS and RDS that
+Incremental xDS is a separate xDS endpoint available for ADS, CDS and RDS that
 allows:
 
   * Incremental updates of the list of tracked resources by the xDS client.
@@ -295,7 +295,7 @@ allows:
     example, this may occur when a request corresponding to an unknown cluster
     arrives.
   * The xDS server can incremetally update the resources on the client.
-    This support the goal of scalability of xDS resources. Rather than deliver
+    This supports the goal of scalability of xDS resources. Rather than deliver
     all 100k clusters when a single cluster is modified, the management server
     only needs to deliver the single cluster that changed.
 
@@ -319,7 +319,7 @@ debugging purposes only.
      This can be done to dynamically add or remove elements from the tracked
      `resource_names` set. In this case `response_nonce` must be omitted.
 
-In this first example the client connects and receive a first update that it
+In this first example the client connects and receives a first update that it
 ACKs. The second update fails and the client NACKs the update. Later the xDS
 client spontaneously requests the "wc" resource.
 


### PR DESCRIPTION
Minor fixups for the xDS protocol documentation.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>

*Risk Level*: Low
*Docs Changes*: Spelling and grammar in XDS_PROTOCOL.md