### PR TITLE
fuzz: fixes oss-fuzz: 9621

### DIFF
--- a/api/envoy/api/v2/endpoint/endpoint.proto
+++ b/api/envoy/api/v2/endpoint/endpoint.proto
@@ -37,7 +37,7 @@ message Endpoint {
     // as the host's serving address port. This provides an alternative health
     // check port. Setting this with a non-zero value allows an upstream host
     // to have different health check address port.
-    uint32 port_value = 1;
+    uint32 port_value = 1 [(validate.rules).uint32.lte = 65535];
   }
 
   // The optional health check configuration is used as configuration for the

--- a/test/server/config_validation/config_corpus/clusterfuzz-testcase-config_fuzz_test-6287096397430784
+++ b/test/server/config_validation/config_corpus/clusterfuzz-testcase-config_fuzz_test-6287096397430784
@@ -1,0 +1,252 @@
+static_resources {
+  clusters {
+    name: " "
+    connect_timeout {
+      seconds: 2304
+    }
+    per_connection_buffer_limit_bytes {
+      value: 209
+    }
+    lb_policy: RING_HASH
+    hosts {
+      pipe {
+        path: "z"
+      }
+    }
+    hosts {
+      pipe {
+        path: " "
+      }
+    }
+    hosts {
+      pipe {
+        path: ";"
+      }
+    }
+    dns_lookup_family: V4_ONLY
+    outlier_detection {
+      success_rate_stdev_factor {
+        value: 268435456
+      }
+    }
+  }
+  clusters {
+    name: "@"
+    connect_timeout {
+      seconds: 2304
+    }
+    lb_policy: RING_HASH
+    hosts {
+      pipe {
+        path: "@"
+      }
+    }
+    hosts {
+      pipe {
+        path: "X"
+      }
+    }
+    hosts {
+      pipe {
+        path: "@"
+      }
+    }
+    dns_lookup_family: V4_ONLY
+    outlier_detection {
+      success_rate_stdev_factor {
+        value: 589951
+      }
+    }
+  }
+  clusters {
+    name: "#"
+    connect_timeout {
+      seconds: 2304
+      nanos: 235995425
+    }
+    lb_policy: MAGLEV
+    dns_lookup_family: V4_ONLY
+    cleanup_interval {
+      nanos: 235995425
+    }
+    upstream_connection_options {
+      tcp_keepalive {
+        keepalive_probes {
+          value: 589824
+        }
+      }
+    }
+  }
+  clusters {
+    name: "X"
+    connect_timeout {
+      seconds: 2304
+    }
+    outlier_detection {
+      success_rate_stdev_factor {
+        value: 589951
+      }
+    }
+    lb_subset_config {
+      fallback_policy: ANY_ENDPOINT
+      subset_selectors {
+      }
+      locality_weight_aware: true
+    }
+    ring_hash_lb_config {
+      deprecated_v1 {
+        use_std_hash {
+          value: true
+        }
+      }
+    }
+  }
+  clusters {
+    name: "0"
+    connect_timeout {
+      seconds: 2304
+    }
+    outlier_detection {
+      success_rate_stdev_factor {
+        value: 589951
+      }
+    }
+    lb_subset_config {
+      fallback_policy: ANY_ENDPOINT
+      subset_selectors {
+      }
+      locality_weight_aware: true
+    }
+  }
+  clusters {
+    name: "`"
+    connect_timeout {
+      seconds: 2304
+    }
+    lb_policy: RING_HASH
+    hosts {
+      pipe {
+        path: ";"
+      }
+    }
+    hosts {
+      pipe {
+        path: ";"
+      }
+    }
+    dns_lookup_family: V4_ONLY
+    outlier_detection {
+      success_rate_stdev_factor {
+        value: 589951
+      }
+    }
+    lb_subset_config {
+      default_subset {
+        fields {
+          key: ""
+          value {
+            bool_value: true
+          }
+        }
+      }
+    }
+    upstream_connection_options {
+      tcp_keepalive {
+        keepalive_probes {
+          value: 589824
+        }
+      }
+    }
+    close_connections_on_host_health_failure: true
+    drain_connections_on_host_removal: true
+  }
+  clusters {
+    name: "z"
+    connect_timeout {
+      seconds: 2304
+    }
+    hosts {
+      pipe {
+        path: "*"
+      }
+    }
+    hosts {
+      pipe {
+        path: "5"
+      }
+    }
+    hosts {
+      pipe {
+        path: "z"
+      }
+    }
+    hosts {
+      pipe {
+        path: "@"
+      }
+    }
+    hosts {
+      pipe {
+        path: "z"
+      }
+    }
+    upstream_connection_options {
+      tcp_keepalive {
+        keepalive_probes {
+          value: 589824
+        }
+      }
+    }
+    load_assignment {
+      cluster_name: " "
+      endpoints {
+        locality {
+          region: " "
+        }
+        lb_endpoints {
+          endpoint {
+            address {
+              pipe {
+                path: "\n\000\000\000"
+              }
+            }
+            health_check_config {
+              port_value: 10878976
+            }
+          }
+          health_status: TIMEOUT
+        }
+      }
+      endpoints {
+        lb_endpoints {
+          endpoint {
+            health_check_config {
+              port_value: 41216
+            }
+          }
+          health_status: TIMEOUT
+        }
+        priority: 41216
+      }
+      endpoints {
+        locality {
+          region: "\027"
+        }
+        lb_endpoints {
+        }
+      }
+      endpoints {
+        priority: 41216
+      }
+    }
+  }
+}
+admin {
+  access_log_path: "/tmp/admin_access.lss"
+  address {
+    pipe {
+      path: "*"
+    }
+  }
+}
+


### PR DESCRIPTION
Title: Fixes oss-fuzz: [9621](https://oss-fuzz.com/v2/testcase-detail/6287096397430784)

Description:

The issue is due to on the crash of `Envoy::Network::Utility::getAddressWithPort` because of the invalid `port_value`. Added max constraint validate rule to the `port_value` field.

Risk Level: Low

Testing: Tested unit tests (bazel test //test/server/config_validation:config_fuzz_test), built and ran fuzzers with oss-fuzz.

Signed-off-by: Anirudh M m.anirudh18@gmail.com