### PR TITLE
tracing: Fixes issue with small LightStep reports.

### DIFF
--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -37,13 +37,12 @@ void LightStepLogger::operator()(lightstep::LogLevel level,
 LightStepDriver::LightStepTransporter::LightStepTransporter(LightStepDriver& driver)
     : driver_(driver) {}
 
-// If the default min_flush_spans value is too small, spans can be dropped between reports.
-// Hence, we choose a number that's large enough, but divide by the number of CPUs since Envoy
-// creates separate tracers for each thread.
+// If the default min_flush_spans value is too small, the larger number of reports can overwhelm
+// LightStep's sattelites. Hence, we need to choose a number that's large enough; though, it's
+// somewhat arbitrary.
 //
 // See https://github.com/lightstep/lightstep-tracer-cpp/issues/106
-const size_t LightStepDriver::default_min_flush_spans =
-    2'000U / std::thread::hardware_concurrency();
+const size_t LightStepDriver::default_min_flush_spans = 200U;
 
 LightStepDriver::LightStepTransporter::~LightStepTransporter() {
   if (active_request_ != nullptr) {

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -4,7 +4,6 @@
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <thread>
 
 #include "common/buffer/zero_copy_input_stream_impl.h"
 #include "common/common/base64.h"

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -37,11 +37,11 @@ LightStepDriver::LightStepTransporter::LightStepTransporter(LightStepDriver& dri
     : driver_(driver) {}
 
 // If the default min_flush_spans value is too small, the larger number of reports can overwhelm
-// LightStep's sattelites. Hence, we need to choose a number that's large enough; though, it's
+// LightStep's satellites. Hence, we need to choose a number that's large enough; though, it's
 // somewhat arbitrary.
 //
 // See https://github.com/lightstep/lightstep-tracer-cpp/issues/106
-const size_t LightStepDriver::DEFAULT_MIN_FLUSH_SPANS = 200U;
+const size_t LightStepDriver::DefaultMinFlushSpans = 200U;
 
 LightStepDriver::LightStepTransporter::~LightStepTransporter() {
   if (active_request_ != nullptr) {
@@ -160,7 +160,7 @@ LightStepDriver::LightStepDriver(const Json::Object& config,
 
     tls_options.max_buffered_spans = std::function<size_t()>{[this] {
       return runtime_.snapshot().getInteger("tracing.lightstep.min_flush_spans",
-                                            DEFAULT_MIN_FLUSH_SPANS);
+                                            DefaultMinFlushSpans);
     }};
     tls_options.metrics_observer.reset(new LightStepMetricsObserver{*this});
     tls_options.transporter.reset(new LightStepTransporter{*this});

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -42,7 +42,7 @@ LightStepDriver::LightStepTransporter::LightStepTransporter(LightStepDriver& dri
 // somewhat arbitrary.
 //
 // See https://github.com/lightstep/lightstep-tracer-cpp/issues/106
-const size_t LightStepDriver::default_min_flush_spans = 200U;
+const size_t LightStepDriver::DEFAULT_MIN_FLUSH_SPANS = 200U;
 
 LightStepDriver::LightStepTransporter::~LightStepTransporter() {
   if (active_request_ != nullptr) {
@@ -161,7 +161,7 @@ LightStepDriver::LightStepDriver(const Json::Object& config,
 
     tls_options.max_buffered_spans = std::function<size_t()>{[this] {
       return runtime_.snapshot().getInteger("tracing.lightstep.min_flush_spans",
-                                            default_min_flush_spans);
+                                            DEFAULT_MIN_FLUSH_SPANS);
     }};
     tls_options.metrics_observer.reset(new LightStepMetricsObserver{*this});
     tls_options.transporter.reset(new LightStepTransporter{*this});

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -152,13 +152,6 @@ LightStepDriver::LightStepDriver(const Json::Object& config,
     tls_options.use_single_key_propagation = true;
     tls_options.logger_sink = LightStepLogger{};
 
-    // If the default min_flush_spans value is too small, spans can be dropped between reports.
-    // Hence, we choose a number that's large enough, but divide by the number of CPUs since Envoy
-    // creates separate tracers for each thread.
-    //
-    // See https://github.com/lightstep/lightstep-tracer-cpp/issues/106
-    static const size_t default_min_flush_spans = 2'000U / std::thread::hardware_concurrency();
-
     tls_options.max_buffered_spans = std::function<size_t()>{[this] {
       return runtime_.snapshot().getInteger("tracing.lightstep.min_flush_spans",
                                             default_min_flush_spans);

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
@@ -60,7 +60,7 @@ public:
   Runtime::Loader& runtime() { return runtime_; }
   LightstepTracerStats& tracerStats() { return tracer_stats_; }
 
-  static const size_t DEFAULT_MIN_FLUSH_SPANS;
+  static const size_t DefaultMinFlushSpans;
 
   // Tracer::OpenTracingDriver
   opentracing::Tracer& tracer() override;

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
@@ -60,7 +60,7 @@ public:
   Runtime::Loader& runtime() { return runtime_; }
   LightstepTracerStats& tracerStats() { return tracer_stats_; }
 
-  static const size_t default_min_flush_spans;
+  static const size_t DEFAULT_MIN_FLUSH_SPANS;
 
   // Tracer::OpenTracingDriver
   opentracing::Tracer& tracer() override;

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
@@ -60,6 +60,13 @@ public:
   Runtime::Loader& runtime() { return runtime_; }
   LightstepTracerStats& tracerStats() { return tracer_stats_; }
 
+  // If the default min_flush_spans value is too small, spans can be dropped between reports.
+  // Hence, we choose a number that's large enough, but divide by the number of CPUs since Envoy
+  // creates separate tracers for each thread.
+  //
+  // See https://github.com/lightstep/lightstep-tracer-cpp/issues/106
+  static const size_t default_min_flush_spans = 2'000U / std::thread::hardware_concurrency();
+
   // Tracer::OpenTracingDriver
   opentracing::Tracer& tracer() override;
   PropagationMode propagationMode() const override { return propagation_mode_; }

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <thread>
 
 #include "envoy/runtime/runtime.h"
 #include "envoy/thread_local/thread_local.h"

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
@@ -3,7 +3,6 @@
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <thread>
 
 #include "envoy/runtime/runtime.h"
 #include "envoy/thread_local/thread_local.h"
@@ -61,12 +60,7 @@ public:
   Runtime::Loader& runtime() { return runtime_; }
   LightstepTracerStats& tracerStats() { return tracer_stats_; }
 
-  // If the default min_flush_spans value is too small, spans can be dropped between reports.
-  // Hence, we choose a number that's large enough, but divide by the number of CPUs since Envoy
-  // creates separate tracers for each thread.
-  //
-  // See https://github.com/lightstep/lightstep-tracer-cpp/issues/106
-  static const size_t default_min_flush_spans = 2'000U / std::thread::hardware_concurrency();
+  static const size_t default_min_flush_spans;
 
   // Tracer::OpenTracingDriver
   opentracing::Tracer& tracer() override;

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -182,7 +182,7 @@ TEST_F(LightStepDriverTest, FlushSeveralSpans) {
           }));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
-                                             LightStepDriver::default_min_flush_spans))
+                                             LightStepDriver::DEFAULT_MIN_FLUSH_SPANS))
       .Times(AtLeast(1))
       .WillRepeatedly(Return(2));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
@@ -243,7 +243,7 @@ TEST_F(LightStepDriverTest, FlushOneFailure) {
           }));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
-                                             LightStepDriver::default_min_flush_spans))
+                                             LightStepDriver::DEFAULT_MIN_FLUSH_SPANS))
       .WillOnce(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
       .WillOnce(Return(5000U));
@@ -286,7 +286,7 @@ TEST_F(LightStepDriverTest, FlushOneInvalidResponse) {
           }));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
-                                             LightStepDriver::default_min_flush_spans))
+                                             LightStepDriver::DEFAULT_MIN_FLUSH_SPANS))
       .WillOnce(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
       .WillOnce(Return(5000U));
@@ -320,8 +320,8 @@ TEST_F(LightStepDriverTest, FlushSpansTimer) {
   EXPECT_CALL(cm_.async_client_, send_(_, _, timeout));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
-                                             LightStepDriver::default_min_flush_spans))
-      .WillOnce(Return(LightStepDriver::default_min_flush_spans));
+                                             LightStepDriver::DEFAULT_MIN_FLUSH_SPANS))
+      .WillOnce(Return(LightStepDriver::DEFAULT_MIN_FLUSH_SPANS));
 
   Tracing::SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_,
                                              start_time_, {Tracing::Reason::Sampling, true});
@@ -361,7 +361,7 @@ TEST_F(LightStepDriverTest, FlushOneSpanGrpcFailure) {
             return &request;
           }));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
-                                             LightStepDriver::default_min_flush_spans))
+                                             LightStepDriver::DEFAULT_MIN_FLUSH_SPANS))
       .WillOnce(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
       .WillOnce(Return(5000U));
@@ -401,7 +401,7 @@ TEST_F(LightStepDriverTest, CancelRequestOnDestruction) {
             return &request;
           }));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
-                                             LightStepDriver::default_min_flush_spans))
+                                             LightStepDriver::DEFAULT_MIN_FLUSH_SPANS))
       .WillOnce(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
       .WillOnce(Return(5000U));

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -182,7 +182,7 @@ TEST_F(LightStepDriverTest, FlushSeveralSpans) {
           }));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
-                                             LightStepDriver::DEFAULT_MIN_FLUSH_SPANS))
+                                             LightStepDriver::DefaultMinFlushSpans))
       .Times(AtLeast(1))
       .WillRepeatedly(Return(2));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
@@ -243,7 +243,7 @@ TEST_F(LightStepDriverTest, FlushOneFailure) {
           }));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
-                                             LightStepDriver::DEFAULT_MIN_FLUSH_SPANS))
+                                             LightStepDriver::DefaultMinFlushSpans))
       .WillOnce(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
       .WillOnce(Return(5000U));
@@ -286,7 +286,7 @@ TEST_F(LightStepDriverTest, FlushOneInvalidResponse) {
           }));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
-                                             LightStepDriver::DEFAULT_MIN_FLUSH_SPANS))
+                                             LightStepDriver::DefaultMinFlushSpans))
       .WillOnce(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
       .WillOnce(Return(5000U));
@@ -320,8 +320,8 @@ TEST_F(LightStepDriverTest, FlushSpansTimer) {
   EXPECT_CALL(cm_.async_client_, send_(_, _, timeout));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
-                                             LightStepDriver::DEFAULT_MIN_FLUSH_SPANS))
-      .WillOnce(Return(LightStepDriver::DEFAULT_MIN_FLUSH_SPANS));
+                                             LightStepDriver::DefaultMinFlushSpans))
+      .WillOnce(Return(LightStepDriver::DefaultMinFlushSpans));
 
   Tracing::SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_,
                                              start_time_, {Tracing::Reason::Sampling, true});
@@ -361,7 +361,7 @@ TEST_F(LightStepDriverTest, FlushOneSpanGrpcFailure) {
             return &request;
           }));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
-                                             LightStepDriver::DEFAULT_MIN_FLUSH_SPANS))
+                                             LightStepDriver::DefaultMinFlushSpans))
       .WillOnce(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
       .WillOnce(Return(5000U));
@@ -401,7 +401,7 @@ TEST_F(LightStepDriverTest, CancelRequestOnDestruction) {
             return &request;
           }));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
-                                             LightStepDriver::DEFAULT_MIN_FLUSH_SPANS))
+                                             LightStepDriver::DefaultMinFlushSpans))
       .WillOnce(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
       .WillOnce(Return(5000U));

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -181,8 +181,8 @@ TEST_F(LightStepDriverTest, FlushSeveralSpans) {
             return &request;
           }));
 
-  EXPECT_CALL(runtime_.snapshot_,
-              getInteger("tracing.lightstep.min_flush_spans", LightStepDriver::min_flush_spans))
+  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
+                                             LightStepDriver::default_min_flush_spans))
       .Times(AtLeast(1))
       .WillRepeatedly(Return(2));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
@@ -242,8 +242,8 @@ TEST_F(LightStepDriverTest, FlushOneFailure) {
             return &request;
           }));
 
-  EXPECT_CALL(runtime_.snapshot_,
-              getInteger("tracing.lightstep.min_flush_spans", LightStepDriver::min_flush_spans))
+  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
+                                             LightStepDriver::default_min_flush_spans))
       .WillOnce(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
       .WillOnce(Return(5000U));
@@ -360,8 +360,8 @@ TEST_F(LightStepDriverTest, FlushOneSpanGrpcFailure) {
 
             return &request;
           }));
-  EXPECT_CALL(runtime_.snapshot_,
-              getInteger("tracing.lightstep.min_flush_spans", LightStepDriver::min_flush_spans))
+  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
+                                             LightStepDriver::default_min_flush_spans))
       .WillOnce(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
       .WillOnce(Return(5000U));

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -181,7 +181,8 @@ TEST_F(LightStepDriverTest, FlushSeveralSpans) {
             return &request;
           }));
 
-  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans", 5))
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("tracing.lightstep.min_flush_spans", LightStepDriver::min_flush_spans))
       .Times(AtLeast(1))
       .WillRepeatedly(Return(2));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
@@ -241,7 +242,8 @@ TEST_F(LightStepDriverTest, FlushOneFailure) {
             return &request;
           }));
 
-  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans", 5))
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("tracing.lightstep.min_flush_spans", LightStepDriver::min_flush_spans))
       .WillOnce(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
       .WillOnce(Return(5000U));
@@ -283,7 +285,8 @@ TEST_F(LightStepDriverTest, FlushOneInvalidResponse) {
             return &request;
           }));
 
-  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans", 5))
+  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
+                                             LightStepDriver::default_min_flush_spans))
       .WillOnce(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
       .WillOnce(Return(5000U));
@@ -316,8 +319,9 @@ TEST_F(LightStepDriverTest, FlushSpansTimer) {
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
   EXPECT_CALL(cm_.async_client_, send_(_, _, timeout));
 
-  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans", 5))
-      .WillOnce(Return(5));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
+                                             LightStepDriver::default_min_flush_spans))
+      .WillOnce(Return(LightStepDriver::default_min_flush_spans));
 
   Tracing::SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_,
                                              start_time_, {Tracing::Reason::Sampling, true});
@@ -356,7 +360,8 @@ TEST_F(LightStepDriverTest, FlushOneSpanGrpcFailure) {
 
             return &request;
           }));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans", 5))
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("tracing.lightstep.min_flush_spans", LightStepDriver::min_flush_spans))
       .WillOnce(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
       .WillOnce(Return(5000U));
@@ -395,7 +400,8 @@ TEST_F(LightStepDriverTest, CancelRequestOnDestruction) {
 
             return &request;
           }));
-  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans", 5))
+  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
+                                             LightStepDriver::default_min_flush_spans))
       .WillOnce(Return(1));
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
       .WillOnce(Return(5000U));


### PR DESCRIPTION
*Description*:
Changes to use a larger default size for LightStep reports sent to satellites. Fixes https://github.com/lightstep/lightstep-tracer-cpp/issues/106

*Risk Level*: Low

