### PR TITLE
test: Fix perf_annotation_test compilation under gcc 8.1.1

### DIFF
--- a/source/common/common/perf_annotation.h
+++ b/source/common/common/perf_annotation.h
@@ -30,7 +30,7 @@
  * Initiates a performance operation, storing its state in perf_var. A perf_var
  * can then be reported multiple times.
  */
-#define PERF_OPERATION(perf_var) Envoy::PerfOperation(perf_var)
+#define PERF_OPERATION(perf_var) Envoy::PerfOperation perf_var
 
 /**
  * Records performance data initiated with PERF_OPERATION. The category and description


### PR DESCRIPTION
Signed-off-by: Suresh Kumar <suresh@freshdesk.com>

*Description*: Fixes "unnecessary parentheses" warning/error when compiled in gcc8.1.1
*Risk Level*: Low
*Testing*: bazel test //test/...
*Docs Changes*: N/A
*Release Notes*: N/A
Fixes #3680 
