### PR TITLE
upstream: fix duplicate clusters

### DIFF
--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -52,7 +52,7 @@ void CdsApiImpl::onConfigUpdate(const ResourceVector& resources, const std::stri
   std::unordered_set<std::string> cluster_names;
   for (const auto& cluster : resources) {
     if (!cluster_names.insert(cluster.name()).second) {
-      throw EnvoyException("duplicate clusters found");
+      throw EnvoyException(fmt::format("duplicate cluster {} found", cluster.name()));
     }
   }
   for (const auto& cluster : resources) {

--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -48,6 +48,13 @@ CdsApiImpl::CdsApiImpl(const envoy::api::v2::core::ConfigSource& cds_config,
 void CdsApiImpl::onConfigUpdate(const ResourceVector& resources, const std::string& version_info) {
   cm_.adsMux().pause(Config::TypeUrl::get().ClusterLoadAssignment);
   Cleanup eds_resume([this] { cm_.adsMux().resume(Config::TypeUrl::get().ClusterLoadAssignment); });
+
+  std::unordered_set<std::string> cluster_names;
+  for (const auto& cluster : resources) {
+    if (!cluster_names.insert(cluster.name()).second) {
+      throw EnvoyException("duplicate clusters found");
+    }
+  }
   for (const auto& cluster : resources) {
     MessageUtil::validate(cluster);
   }

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -137,7 +137,8 @@ TEST_F(CdsApiImplTest, ValidateDuplicateClusters) {
   auto* cluster_2 = clusters.Add();
   cluster_2->set_name("duplicate_cluster");
 
-  EXPECT_THROW(dynamic_cast<CdsApiImpl*>(cds_.get())->onConfigUpdate(clusters, ""), EnvoyException);
+  EXPECT_THROW_WITH_MESSAGE(dynamic_cast<CdsApiImpl*>(cds_.get())->onConfigUpdate(clusters, ""),
+                            EnvoyException, "duplicate cluster duplicate_cluster found");
   EXPECT_CALL(request_, cancel());
 }
 

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -124,6 +124,23 @@ TEST_F(CdsApiImplTest, ValidateFail) {
   EXPECT_CALL(request_, cancel());
 }
 
+// Validate onConfigUpadte throws EnvoyException with duplicate clusters.
+TEST_F(CdsApiImplTest, ValidateDuplicateClusters) {
+  InSequence s;
+
+  setup(true);
+
+  Protobuf::RepeatedPtrField<envoy::api::v2::Cluster> clusters;
+  auto* cluster_1 = clusters.Add();
+  cluster_1->set_name("duplicate_cluster");
+
+  auto* cluster_2 = clusters.Add();
+  cluster_2->set_name("duplicate_cluster");
+
+  EXPECT_THROW(dynamic_cast<CdsApiImpl*>(cds_.get())->onConfigUpdate(clusters, ""), EnvoyException);
+  EXPECT_CALL(request_, cancel());
+}
+
 TEST_F(CdsApiImplTest, InvalidOptions) {
   const std::string config_json = R"EOF(
   {


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*: Fixes envoy crash with duplicate clusters in cds response.
*Risk Level*: Low
*Testing*: Added Automated tests
*Docs Changes*: N/A
*Release Notes*: N/A

Fixes #3987 
