### PR TITLE
Make header interpolation consistent around empty values

### DIFF
--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -438,6 +438,12 @@ used to delimit variable names.
   doubling it. For example, to emit a header with the value ``100%``, the custom header value in
   the Envoy configuration must be ``100%%``.
 
+.. attention::
+
+  For a compound pattern, i.e. a combination of literal and supported variables, e.g.
+  **prefix-%UPSTREAM_METADATA(["namespace", "key"])%-suffix**, when the variable is formatted
+  as an empty string, the corresponding header value will not be appended or updated.
+
 Supported variable names are:
 
 %DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%

--- a/source/common/router/header_formatter.h
+++ b/source/common/router/header_formatter.h
@@ -6,6 +6,8 @@
 
 #include "envoy/access_log/access_log.h"
 
+#include "common/common/empty_string.h"
+
 #include "absl/strings/string_view.h"
 
 namespace Envoy {
@@ -77,7 +79,13 @@ public:
   const std::string format(const Envoy::RequestInfo::RequestInfo& request_info) const override {
     std::string buf;
     for (const auto& formatter : formatters_) {
-      buf += formatter->format(request_info);
+      const auto& formatted = formatter->format(request_info);
+      // If one of the formatted values is empty, don't set or append the corresponding header
+      // value.
+      if (formatted.empty()) {
+        return EMPTY_STRING;
+      }
+      buf += formatted;
     }
     return buf;
   };

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -473,6 +473,15 @@ route:
     - header:
         key: "x-metadata"
         value: "%UPSTREAM_METADATA([\"namespace\", \"%key%\"])%"
+    - header:
+        key: "x-metadata-missing"
+        value: "%UPSTREAM_METADATA([\"namespace\", \"key\"])%"
+    - header:
+        key: "x-metadata-missing-with-prefix"
+        value: "prefix-%UPSTREAM_METADATA([\"namespace\", \"key\"])%"
+    - header:
+        key: "x-metadata-missing-with-suffix"
+        value: "%UPSTREAM_METADATA([\"namespace\", \"key\"])%-suffix"
   )EOF";
 
   HeaderParserPtr req_header_parser =
@@ -521,6 +530,10 @@ route:
 
   EXPECT_TRUE(headerMap.has("x-metadata"));
   EXPECT_EQ("value", headerMap.get_("x-metadata"));
+
+  EXPECT_FALSE(headerMap.has("x-metadata-missing"));
+  EXPECT_FALSE(headerMap.has("x-metadata-missing-with-prefix"));
+  EXPECT_FALSE(headerMap.has("x-metadata-missing-with-suffix"));
 }
 
 TEST(HeaderParserTest, EvaluateHeadersWithAppendFalse) {


### PR DESCRIPTION
*Description*: 
This patch makes header interpolation consistent around empty values. This specifically handles the case when we have compound header pattern. The treatment is to avoid setting or adding header value when the resulted formatting process is empty.

*Risk Level*: Low
*Testing*: Unit
*Docs Changes*: Added
*Release Notes*: N/A
Fixes #3971

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>
