### PR TITLE
fuzz: H2 codec fuzzer.

### DIFF
--- a/test/common/http/http2/BUILD
+++ b/test/common/http/http2/BUILD
@@ -2,11 +2,33 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_fuzz_test",
     "envoy_cc_test",
     "envoy_package",
+    "envoy_proto_library",
 )
 
 envoy_package()
+
+envoy_proto_library(
+    name = "codec_impl_fuzz_proto",
+    srcs = ["codec_impl_fuzz.proto"],
+    external_deps = ["well_known_protos"],
+)
+
+envoy_cc_fuzz_test(
+    name = "codec_impl_fuzz_test",
+    srcs = ["codec_impl_fuzz_test.cc"],
+    corpus = "codec_impl_corpus",
+    deps = [
+        ":codec_impl_fuzz_proto",
+        "//source/common/http:header_map_lib",
+        "//source/common/http/http2:codec_lib",
+        "//source/common/stats:stats_lib",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/network:network_mocks",
+    ],
+)
 
 envoy_cc_test(
     name = "codec_impl_test",

--- a/test/common/http/http2/codec_impl_corpus/100-continue
+++ b/test/common/http/http2/codec_impl_corpus/100-continue
@@ -1,0 +1,56 @@
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "foo.com"
+      }
+      headers {
+        key: "expect"
+        value: "100-continue"
+      }
+    }
+  }
+}
+actions { quiesce_drain {} }
+actions {
+  stream_action {
+    stream_id: 0
+    response {
+      continue_100_headers {
+        headers {
+          key: ":status"
+          value: "100"
+        }
+      }
+    }
+  }
+}
+actions { quiesce_drain {} }
+actions {
+  stream_action {
+    stream_id: 0
+    response {
+      headers {
+        headers {
+          key: ":status"
+          value: "404"
+        }
+      }
+      end_stream: true
+    }
+  }
+}
+actions { quiesce_drain {} }

--- a/test/common/http/http2/codec_impl_corpus/example
+++ b/test/common/http/http2/codec_impl_corpus/example
@@ -1,0 +1,258 @@
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: "foo"
+        value: "bar"
+      }
+    }
+  }
+}
+actions { quiesce_drain {} }
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: "foo"
+        value: "bar"
+      }
+    }
+    end_stream: true
+  }
+}
+actions { quiesce_drain {} }
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "foo.com"
+      }
+      headers {
+        key: "blah"
+        value: "nosniff"
+      }
+      headers {
+        key: "cookie"
+        value: "foo=bar"
+      }
+      headers {
+        key: "cookie"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions { quiesce_drain {} }
+actions {
+  stream_action {
+    stream_id: 0
+    request {
+      data: 128000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 2
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 2
+    request {
+      data: 54
+    }
+  }
+}
+actions { quiesce_drain {} }
+actions {
+  stream_action {
+    stream_id: 2
+    request {
+      data: 54
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 2
+    response {
+      headers {
+        headers {
+          key: ":status"
+          value: "200"
+        }
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 2
+    response {
+      data: 5
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 2
+    request {
+      read_disable: true
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 2
+    request {
+      read_disable: false
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 2
+    request {
+      read_disable: true
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 2
+    request {
+      trailers {
+        headers {
+          key: "foo"
+          value: "bar"
+        }
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 2
+    request {
+      read_disable: false
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 2
+    response {
+      trailers {
+        headers {
+          key: "foo"
+          value: "bar"
+        }
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 2
+    response {
+      data: 2
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 2
+    response {
+      trailers {
+        headers {
+          key: "foo"
+          value: "bar"
+        }
+        headers {
+          key: "cookie"
+          value: "foo2=bar2"
+        }
+      }
+    }
+  }
+}
+actions { quiesce_drain {} }
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "foo.com"
+      }
+    }
+  }
+}
+actions { quiesce_drain {} }
+actions {
+  stream_action {
+    stream_id: 3
+    request {
+      reset: 0
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "foo.com"
+      }
+    }
+  }
+}
+actions { quiesce_drain {} }
+actions {
+  stream_action {
+    stream_id: 4
+    response {
+      reset: 0
+    }
+  }
+}

--- a/test/common/http/http2/codec_impl_corpus/goaway
+++ b/test/common/http/http2/codec_impl_corpus/goaway
@@ -1,0 +1,44 @@
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "foo.com"
+      }
+    }
+  }
+}
+actions {
+  mutate {
+    buffer: 2
+    offset: 2
+    value: 8
+  }
+}
+actions {
+  mutate {
+    buffer: 2
+    offset: 3
+    value: 7
+  }
+}
+actions {
+  mutate {
+    buffer: 2
+    offset: 8
+    value: 0
+  }
+}
+actions { quiesce_drain {} }

--- a/test/common/http/http2/codec_impl_corpus/protocol_exception
+++ b/test/common/http/http2/codec_impl_corpus/protocol_exception
@@ -1,0 +1,18 @@
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+    }
+  }
+}
+actions {
+  mutate {
+    buffer: 0
+    offset: 2
+    value: 123
+  }
+}
+actions { quiesce_drain {} }

--- a/test/common/http/http2/codec_impl_corpus/swap_buffer
+++ b/test/common/http/http2/codec_impl_corpus/swap_buffer
@@ -1,0 +1,68 @@
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "foo.com"
+      }
+    }
+  }
+}
+actions { quiesce_drain {} }
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "foo.com"
+      }
+    }
+  }
+}
+actions { quiesce_drain {} }
+actions {
+  stream_action {
+    stream_id: 0
+    request {
+      data: 123
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    request {
+      data: 1234
+    }
+  }
+}
+actions {
+  swap_buffer {
+    buffer: 1
+  }
+}
+actions { quiesce_drain {} }

--- a/test/common/http/http2/codec_impl_fuzz.proto
+++ b/test/common/http/http2/codec_impl_fuzz.proto
@@ -1,0 +1,94 @@
+syntax = "proto3";
+
+package test.common.http.http2;
+
+import "google/protobuf/empty.proto";
+
+// Structured input for H2 codec_impl_fuzz_test.
+
+message Header {
+  string key = 1;
+  string value = 2;
+}
+
+message Headers {
+  repeated Header headers = 1;
+}
+
+message NewStream {
+  Headers request_headers = 1;
+  bool end_stream = 2;
+}
+
+message DirectionalAction {
+  oneof directional_action_selector {
+    Headers continue_100_headers = 1;
+    Headers headers = 2;
+    uint32 data = 3;
+    Headers trailers = 4;
+    uint32 reset = 5;
+    bool read_disable = 6;
+  }
+  bool end_stream = 7;
+}
+
+message StreamAction {
+  uint32 stream_id = 1;
+  oneof stream_action_selector {
+    DirectionalAction request = 2;
+    DirectionalAction response = 3;
+  }
+}
+
+message MutateAction {
+  // Buffer index.
+  uint32 buffer = 1;
+  // Offset withing buffer.
+  uint32 offset = 2;
+  // Value to set (only lower byte is significant).
+  uint32 value = 3;
+  // Server connection buffer? Otherwise client.
+  bool server = 4;
+}
+
+message SwapBufferAction {
+  // Target buffer index to swap with. The buffer at index 0 is swapped with the
+  // target buffer.
+  uint32 buffer = 1;
+  // Server connection buffer? Otherwise client.
+  bool server = 2;
+}
+
+message Action {
+  oneof action_selector {
+    // Create new stream.
+    NewStream new_stream = 1;
+    // Perform an action on an existing stream.
+    StreamAction stream_action = 2;
+    // Mutate a connection buffer.
+    MutateAction mutate = 3;
+    // Swap two fragments in a connection buffer.
+    SwapBufferAction swap_buffer = 4;
+    // Drain client connection buffer.
+    google.protobuf.Empty client_drain = 5;
+    // Drain server connection buffer.
+    google.protobuf.Empty server_drain = 6;
+    // Drain client/server buffers alternatively until both are empty.
+    google.protobuf.Empty quiesce_drain = 7;
+  }
+}
+
+// Setting X below is interpreted as min_valid_setting + X % (1 +
+// max_valid_setting - min_valid_setting).
+message Http2Settings {
+  uint32 hpack_table_size = 1;
+  uint32 max_concurrent_streams = 2;
+  uint32 initial_stream_window_size = 3;
+  uint32 initial_connection_window_size = 4;
+}
+
+message CodecImplFuzzTestCase {
+  Http2Settings client_settings = 1;
+  Http2Settings server_settings = 2;
+  repeated Action actions = 3;
+}

--- a/test/common/http/http2/codec_impl_fuzz_test.cc
+++ b/test/common/http/http2/codec_impl_fuzz_test.cc
@@ -123,7 +123,7 @@ public:
     }
     case test::common::http::http2::DirectionalAction::kData: {
       if (state == StreamState::PendingDataOrTrailers) {
-        Buffer::OwnedImpl buf(std::string(directional_action.data(), 'a'));
+        Buffer::OwnedImpl buf(std::string(directional_action.data() % (1024 * 1024), 'a'));
         encoder.encodeData(buf, end_stream);
         state = end_stream ? StreamState::Closed : StreamState::PendingDataOrTrailers;
       }

--- a/test/common/http/http2/codec_impl_fuzz_test.cc
+++ b/test/common/http/http2/codec_impl_fuzz_test.cc
@@ -1,0 +1,353 @@
+// Fuzzer for the H2 codec. This is similar in structure to
+// //test/common/http/http2:codec_impl_test, where a client H2 codec is wired
+// via shared memory to a server H2 codec and stream actions are applied. We
+// fuzz the various client/server H2 codec API operations and in addition apply
+// fuzzing at the wire level by modeling explicit mutation, reordering and drain
+// operations on the connection buffers between client and server.
+
+#include <functional>
+
+#include "common/common/assert.h"
+#include "common/common/logger.h"
+#include "common/http/header_map_impl.h"
+#include "common/http/http2/codec_impl.h"
+#include "common/stats/stats_impl.h"
+
+#include "test/common/http/http2/codec_impl_fuzz.pb.h"
+#include "test/fuzz/fuzz_runner.h"
+#include "test/mocks/http/mocks.h"
+#include "test/mocks/network/mocks.h"
+
+#include "gmock/gmock.h"
+
+using testing::Invoke;
+using testing::InvokeWithoutArgs;
+using testing::_;
+
+namespace Envoy {
+namespace Http {
+namespace Http2 {
+
+class TestServerConnectionImpl : public ServerConnectionImpl {
+public:
+  TestServerConnectionImpl(Network::Connection& connection, ServerConnectionCallbacks& callbacks,
+                           Stats::Scope& scope, const Http2Settings& http2_settings)
+      : ServerConnectionImpl(connection, callbacks, scope, http2_settings) {}
+  nghttp2_session* session() { return session_; }
+  using ServerConnectionImpl::getStream;
+};
+
+class TestClientConnectionImpl : public ClientConnectionImpl {
+public:
+  TestClientConnectionImpl(Network::Connection& connection, Http::ConnectionCallbacks& callbacks,
+                           Stats::Scope& scope, const Http2Settings& http2_settings)
+      : ClientConnectionImpl(connection, callbacks, scope, http2_settings) {}
+  nghttp2_session* session() { return session_; }
+  using ClientConnectionImpl::getStream;
+};
+
+// Convert from test proto Headers to TestHeaderMapImpl.
+TestHeaderMapImpl fromHeaders(const test::common::http::http2::Headers& headers) {
+  TestHeaderMapImpl header_map;
+  for (const auto& header : headers.headers()) {
+    header_map.addCopy(header.key(), header.value());
+  }
+  return header_map;
+}
+
+// Convert from test proto Http2Settings to Http2Settings.
+Http2Settings fromHttp2Settings(const test::common::http::http2::Http2Settings& settings) {
+  Http2Settings h2_settings;
+  // We apply an offset and modulo interpretation to settings to ensure that
+  // they are valid. Rejecting invalid settings is orthogonal to the fuzzed
+  // code.
+  h2_settings.hpack_table_size_ = settings.hpack_table_size();
+  h2_settings.max_concurrent_streams_ =
+      Http2Settings::MIN_MAX_CONCURRENT_STREAMS +
+      settings.max_concurrent_streams() % (1 + Http2Settings::MAX_MAX_CONCURRENT_STREAMS -
+                                           Http2Settings::MIN_MAX_CONCURRENT_STREAMS);
+  h2_settings.initial_stream_window_size_ =
+      Http2Settings::MIN_INITIAL_STREAM_WINDOW_SIZE +
+      settings.initial_stream_window_size() % (1 + Http2Settings::MAX_INITIAL_STREAM_WINDOW_SIZE -
+                                               Http2Settings::MIN_INITIAL_STREAM_WINDOW_SIZE);
+  h2_settings.initial_connection_window_size_ =
+      Http2Settings::MIN_INITIAL_CONNECTION_WINDOW_SIZE +
+      settings.initial_connection_window_size() %
+          (1 + Http2Settings::MAX_INITIAL_CONNECTION_WINDOW_SIZE -
+           Http2Settings::MIN_INITIAL_CONNECTION_WINDOW_SIZE);
+  return h2_settings;
+}
+
+// Internal representation of stream state. Encapsulates the stream state, mocks
+// and encoders for both the request/response.
+class Stream : public LinkedObject<Stream> {
+public:
+  // We track stream state here to prevent illegal operations, e.g. applying an
+  // encodeData() to the codec after encodeTrailers(). This is necessary to
+  // maintain the preconditions for operations on the codec at the API level. Of
+  // course, it's the codecs must be robust to wire-level violations. We
+  // explore these violations via MutateAction and SwapAction at the connection
+  // buffer level.
+  enum class StreamState { PendingHeaders, PendingDataOrTrailers, Closed };
+
+  Stream(TestClientConnectionImpl& client, const TestHeaderMapImpl& request_headers,
+         bool end_stream)
+      : request_encoder_(&client.newStream(response_decoder_)) {
+    ON_CALL(server_stream_callbacks_, onResetStream(_)).WillByDefault(InvokeWithoutArgs([this] {
+      request_state_ = response_state_ = StreamState::Closed;
+    }));
+    request_encoder_->encodeHeaders(request_headers, end_stream);
+    request_state_ = end_stream ? StreamState::Closed : StreamState::PendingDataOrTrailers;
+    response_state_ = StreamState::PendingHeaders;
+  }
+
+  // Some stream action applied in either the request or resposne direction.
+  void directionalAction(StreamState& state, StreamEncoder& encoder,
+                         const test::common::http::http2::DirectionalAction& directional_action) {
+    const bool end_stream = directional_action.end_stream();
+    switch (directional_action.directional_action_selector_case()) {
+    case test::common::http::http2::DirectionalAction::kContinue100Headers: {
+      if (state == StreamState::PendingHeaders) {
+        Http::TestHeaderMapImpl headers = fromHeaders(directional_action.continue_100_headers());
+        headers.setReferenceKey(Headers::get().Status, "100");
+        encoder.encode100ContinueHeaders(headers);
+      }
+      break;
+    }
+    case test::common::http::http2::DirectionalAction::kHeaders: {
+      if (state == StreamState::PendingHeaders) {
+        encoder.encodeHeaders(fromHeaders(directional_action.headers()), end_stream);
+        state = end_stream ? StreamState::Closed : StreamState::PendingDataOrTrailers;
+      }
+      break;
+    }
+    case test::common::http::http2::DirectionalAction::kData: {
+      if (state == StreamState::PendingDataOrTrailers) {
+        Buffer::OwnedImpl buf(std::string(directional_action.data(), 'a'));
+        encoder.encodeData(buf, end_stream);
+        state = end_stream ? StreamState::Closed : StreamState::PendingDataOrTrailers;
+      }
+      break;
+    }
+    case test::common::http::http2::DirectionalAction::kTrailers: {
+      if (state == StreamState::PendingDataOrTrailers) {
+        encoder.encodeTrailers(fromHeaders(directional_action.trailers()));
+        state = StreamState::Closed;
+      }
+      break;
+    }
+    case test::common::http::http2::DirectionalAction::kReset: {
+      if (state != StreamState::Closed) {
+        encoder.getStream().resetStream(
+            static_cast<Http::StreamResetReason>(directional_action.reset()));
+        request_state_ = response_state_ = StreamState::Closed;
+      }
+      break;
+    }
+    case test::common::http::http2::DirectionalAction::kReadDisable: {
+      if (state != StreamState::Closed) {
+        const bool disable = directional_action.read_disable();
+        if (read_disable_count_ == 0 && !disable) {
+          return;
+        }
+        if (disable) {
+          ++read_disable_count_;
+        } else {
+          --read_disable_count_;
+        }
+        encoder.getStream().readDisable(disable);
+      }
+      break;
+    }
+    default:
+      // Maybe nothing is set?
+      break;
+    }
+  }
+
+  void streamAction(const test::common::http::http2::StreamAction& stream_action) {
+    switch (stream_action.stream_action_selector_case()) {
+    case test::common::http::http2::StreamAction::kRequest: {
+      directionalAction(request_state_, *request_encoder_, stream_action.request());
+      break;
+    }
+    case test::common::http::http2::StreamAction::kResponse: {
+      directionalAction(response_state_, *response_encoder_, stream_action.response());
+      break;
+    }
+    default:
+      // Maybe nothing is set?
+      break;
+    }
+  }
+
+  NiceMock<MockStreamCallbacks> server_stream_callbacks_;
+  NiceMock<MockStreamDecoder> response_decoder_;
+  StreamEncoder* request_encoder_;
+  StreamEncoder* response_encoder_;
+  NiceMock<MockStreamDecoder> request_decoder_;
+  StreamState request_state_;
+  StreamState response_state_;
+  uint32_t read_disable_count_{};
+};
+
+// Buffer between client and server H2 codecs. This models each write operation
+// as adding a distinct fragment that might be reordered with other fragments in
+// the buffer via swap() or modified with mutate().
+class ReorderBuffer {
+public:
+  ReorderBuffer(ConnectionImpl& connection) : connection_(connection) {}
+
+  void add(const Buffer::Instance& data) { bufs_.emplace_back(data); }
+
+  void drain() {
+    while (!bufs_.empty()) {
+      Buffer::OwnedImpl& buf = bufs_.front();
+      while (buf.length() > 0) {
+        connection_.dispatch(buf);
+      }
+      bufs_.pop_front();
+    }
+  }
+
+  void mutate(uint32_t buffer, uint32_t offset, uint8_t value) {
+    if (bufs_.empty()) {
+      return;
+    }
+    Buffer::OwnedImpl& buf = bufs_[buffer % bufs_.size()];
+    if (buf.length() == 0) {
+      return;
+    }
+    uint8_t* p = reinterpret_cast<uint8_t*>(buf.linearize(buf.length())) + offset % buf.length();
+    ENVOY_LOG_MISC(trace, "Mutating {} to {}", *p, value);
+    *p = value;
+  }
+
+  void swap(uint32_t buffer) {
+    if (bufs_.empty()) {
+      return;
+    }
+    const uint32_t effective_index = buffer % bufs_.size();
+    if (effective_index == 0) {
+      return;
+    }
+    Buffer::OwnedImpl tmp;
+    tmp.move(bufs_[0]);
+    bufs_[0].move(bufs_[effective_index]);
+    bufs_[effective_index].move(tmp);
+  }
+
+  bool empty() const { return bufs_.empty(); }
+
+  ConnectionImpl& connection_;
+  std::deque<Buffer::OwnedImpl> bufs_;
+};
+
+typedef std::unique_ptr<Stream> StreamPtr;
+
+// Fuzz the H2 codec implementation.
+DEFINE_PROTO_FUZZER(const test::common::http::http2::CodecImplFuzzTestCase& input) {
+  Stats::IsolatedStoreImpl stats_store;
+  NiceMock<Network::MockConnection> client_connection;
+  const Http2Settings client_http2settings{fromHttp2Settings(input.client_settings())};
+  NiceMock<MockConnectionCallbacks> client_callbacks;
+  TestClientConnectionImpl client(client_connection, client_callbacks, stats_store,
+                                  client_http2settings);
+
+  NiceMock<Network::MockConnection> server_connection;
+  const Http2Settings server_http2settings{fromHttp2Settings(input.server_settings())};
+  NiceMock<MockServerConnectionCallbacks> server_callbacks;
+  TestServerConnectionImpl server(server_connection, server_callbacks, stats_store,
+                                  server_http2settings);
+
+  ReorderBuffer client_write_buf{server};
+  ReorderBuffer server_write_buf{client};
+
+  ON_CALL(client_connection, write(_, _))
+      .WillByDefault(Invoke([&](Buffer::Instance& data, bool) -> void {
+        ENVOY_LOG_MISC(trace, "client -> server {} bytes", data.length());
+        client_write_buf.add(data);
+      }));
+  ON_CALL(server_connection, write(_, _))
+      .WillByDefault(Invoke([&](Buffer::Instance& data, bool) -> void {
+        ENVOY_LOG_MISC(trace, "server -> client {} bytes", data.length());
+        server_write_buf.add(data);
+      }));
+
+  // We hold Streams in pending_streams between the request encodeHeaders in the
+  // Stream constructor and server newStream() callback, where we learn about
+  // the response encoder and can complete Stream initialization.
+  std::list<StreamPtr> pending_streams;
+  std::list<StreamPtr> streams;
+
+  ON_CALL(server_callbacks, newStream(_))
+      .WillByDefault(Invoke([&](StreamEncoder& encoder) -> StreamDecoder& {
+        auto stream_ptr = pending_streams.front()->removeFromList(pending_streams);
+        Stream* const stream = stream_ptr.get();
+        stream_ptr->moveIntoListBack(std::move(stream_ptr), streams);
+        stream->response_encoder_ = &encoder;
+        encoder.getStream().addCallbacks(stream->server_stream_callbacks_);
+        return stream->request_decoder_;
+      }));
+
+  try {
+    for (const auto& action : input.actions()) {
+      ENVOY_LOG_MISC(trace, "action {} with {} streams", action.DebugString(), streams.size());
+      switch (action.action_selector_case()) {
+      case test::common::http::http2::Action::kNewStream: {
+        StreamPtr stream =
+            std::make_unique<Stream>(client, fromHeaders(action.new_stream().request_headers()),
+                                     action.new_stream().end_stream());
+        stream->moveIntoListBack(std::move(stream), pending_streams);
+        break;
+      }
+      case test::common::http::http2::Action::kStreamAction: {
+        const auto& stream_action = action.stream_action();
+        if (streams.empty()) {
+          break;
+        }
+        (*std::next(streams.begin(), stream_action.stream_id() % streams.size()))
+            ->streamAction(stream_action);
+        break;
+      }
+      case test::common::http::http2::Action::kMutate: {
+        const auto& mutate = action.mutate();
+        ReorderBuffer& write_buf = mutate.server() ? server_write_buf : client_write_buf;
+        write_buf.mutate(mutate.buffer(), mutate.offset(), mutate.value());
+        break;
+      }
+      case test::common::http::http2::Action::kSwapBuffer: {
+        const auto& swap_buffer = action.swap_buffer();
+        ReorderBuffer& write_buf = swap_buffer.server() ? server_write_buf : client_write_buf;
+        write_buf.swap(swap_buffer.buffer());
+        break;
+      }
+      case test::common::http::http2::Action::kClientDrain: {
+        client_write_buf.drain();
+        break;
+      }
+      case test::common::http::http2::Action::kServerDrain: {
+        server_write_buf.drain();
+        break;
+      }
+      case test::common::http::http2::Action::kQuiesceDrain: {
+        while (!client_write_buf.empty() || !server_write_buf.empty()) {
+          client_write_buf.drain();
+          server_write_buf.drain();
+        }
+        break;
+      }
+      default:
+        // Maybe nothing is set?
+        break;
+      }
+    }
+    client.goAway();
+    server.goAway();
+  } catch (EnvoyException&) {
+  }
+}
+
+} // namespace Http2
+} // namespace Http
+} // namespace Envoy


### PR DESCRIPTION
Fuzzer for the H2 codec. This is similar in structure to
//test/common/http/http2:codec_impl_test, where a client H2 codec is wired via
shared memory to a server H2 codec and stream actions are applied. We fuzz the
various client/server H2 codec API operations and in addition apply fuzzing at
the wire level by modeling explicit mutation, reordering and drain operations
on the connection buffers between client and server.

Part of #508.

Risk Level: Low
Testing: Tested with corpus under bazel test and under oss-fuzz Docker image.
~640 cases per second with python infra/helper.py build_fuzzers
--sanitizer=address envoy <envoy path> && python infra/helper.py run_fuzzer
envoy codec_impl_fuzz_test. Test corpus has 87.9% coverage of
http2/codec_impl.cc.

Signed-off-by: Harvey Tuch <htuch@google.com>