### PR TITLE
Fix overload manager unit test build

### DIFF
--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -118,7 +118,7 @@ envoy_cc_test(
     srcs = ["overload_manager_impl_test.cc"],
     deps = [
         "//include/envoy/registry",
-        "//source/common/stats:stats_lib",
+        "//source/common/stats:isolated_store_lib",
         "//source/extensions/resource_monitors/common:factory_base_lib",
         "//source/server:overload_manager_lib",
         "//test/mocks/event:event_mocks",

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -1,7 +1,7 @@
 #include "envoy/server/resource_monitor.h"
 #include "envoy/server/resource_monitor_config.h"
 
-#include "common/stats/stats_impl.h"
+#include "common/stats/isolated_store_impl.h"
 
 #include "server/overload_manager_impl.h"
 


### PR DESCRIPTION
Fix build failure caused by conflicting PRs #4001 and #4004.

Signed-off-by: Elisha Ziskind <eziskind@google.com>
