### PR TITLE
Sds: Ssl socket factory owns ContextConfig

### DIFF
--- a/include/envoy/ssl/context_config.h
+++ b/include/envoy/ssl/context_config.h
@@ -127,6 +127,8 @@ public:
   virtual bool allowRenegotiation() const PURE;
 };
 
+typedef std::unique_ptr<ClientContextConfig> ClientContextConfigPtr;
+
 class ServerContextConfig : public virtual ContextConfig {
 public:
   struct SessionTicketKey {
@@ -147,6 +149,8 @@ public:
    */
   virtual const std::vector<SessionTicketKey>& sessionTicketKeys() const PURE;
 };
+
+typedef std::unique_ptr<ServerContextConfig> ServerContextConfigPtr;
 
 } // namespace Ssl
 } // namespace Envoy

--- a/source/common/ssl/ssl_socket.cc
+++ b/source/common/ssl/ssl_socket.cc
@@ -382,10 +382,11 @@ std::string SslSocket::subjectLocalCertificate() const {
   return getSubjectFromCertificate(cert);
 }
 
-ClientSslSocketFactory::ClientSslSocketFactory(const ClientContextConfig& config,
+ClientSslSocketFactory::ClientSslSocketFactory(ClientContextConfigPtr config,
                                                Ssl::ContextManager& manager,
                                                Stats::Scope& stats_scope)
-    : ssl_ctx_(manager.createSslClientContext(stats_scope, config)) {}
+    : manager_(manager), stats_scope_(stats_scope), config_(std::move(config)),
+      ssl_ctx_(manager_.createSslClientContext(stats_scope_, *config_)) {}
 
 Network::TransportSocketPtr ClientSslSocketFactory::createTransportSocket() const {
   return std::make_unique<Ssl::SslSocket>(ssl_ctx_, Ssl::InitialState::Client);
@@ -393,17 +394,27 @@ Network::TransportSocketPtr ClientSslSocketFactory::createTransportSocket() cons
 
 bool ClientSslSocketFactory::implementsSecureTransport() const { return true; }
 
-ServerSslSocketFactory::ServerSslSocketFactory(const ServerContextConfig& config,
+void ClientSslSocketFactory::onConfigUpdate() {
+  ssl_ctx_ = manager_.createSslClientContext(stats_scope_, *config_);
+}
+
+ServerSslSocketFactory::ServerSslSocketFactory(ServerContextConfigPtr config,
                                                Ssl::ContextManager& manager,
                                                Stats::Scope& stats_scope,
                                                const std::vector<std::string>& server_names)
-    : ssl_ctx_(manager.createSslServerContext(stats_scope, config, server_names)) {}
+    : manager_(manager), stats_scope_(stats_scope), config_(std::move(config)),
+      server_names_(server_names),
+      ssl_ctx_(manager_.createSslServerContext(stats_scope_, *config_, server_names_)) {}
 
 Network::TransportSocketPtr ServerSslSocketFactory::createTransportSocket() const {
   return std::make_unique<Ssl::SslSocket>(ssl_ctx_, Ssl::InitialState::Server);
 }
 
 bool ServerSslSocketFactory::implementsSecureTransport() const { return true; }
+
+void ServerSslSocketFactory::onConfigUpdate() {
+  ssl_ctx_ = manager_.createSslServerContext(stats_scope_, *config_, server_names_);
+}
 
 } // namespace Ssl
 } // namespace Envoy

--- a/source/common/ssl/ssl_socket.cc
+++ b/source/common/ssl/ssl_socket.cc
@@ -394,10 +394,6 @@ Network::TransportSocketPtr ClientSslSocketFactory::createTransportSocket() cons
 
 bool ClientSslSocketFactory::implementsSecureTransport() const { return true; }
 
-void ClientSslSocketFactory::onConfigUpdate() {
-  ssl_ctx_ = manager_.createSslClientContext(stats_scope_, *config_);
-}
-
 ServerSslSocketFactory::ServerSslSocketFactory(ServerContextConfigPtr config,
                                                Ssl::ContextManager& manager,
                                                Stats::Scope& stats_scope,
@@ -411,10 +407,6 @@ Network::TransportSocketPtr ServerSslSocketFactory::createTransportSocket() cons
 }
 
 bool ServerSslSocketFactory::implementsSecureTransport() const { return true; }
-
-void ServerSslSocketFactory::onConfigUpdate() {
-  ssl_ctx_ = manager_.createSslServerContext(stats_scope_, *config_, server_names_);
-}
 
 } // namespace Ssl
 } // namespace Envoy

--- a/source/common/ssl/ssl_socket.h
+++ b/source/common/ssl/ssl_socket.h
@@ -76,9 +76,6 @@ public:
   bool implementsSecureTransport() const override;
 
 private:
-  // Will be called when config_ is changed
-  void onConfigUpdate();
-
   Ssl::ContextManager& manager_;
   Stats::Scope& stats_scope_;
   ClientContextConfigPtr config_;
@@ -94,9 +91,6 @@ public:
   bool implementsSecureTransport() const override;
 
 private:
-  // Will be called when config_ is changed
-  void onConfigUpdate();
-
   Ssl::ContextManager& manager_;
   Stats::Scope& stats_scope_;
   ServerContextConfigPtr config_;

--- a/source/common/ssl/ssl_socket.h
+++ b/source/common/ssl/ssl_socket.h
@@ -69,25 +69,38 @@ private:
 
 class ClientSslSocketFactory : public Network::TransportSocketFactory {
 public:
-  ClientSslSocketFactory(const ClientContextConfig& config, Ssl::ContextManager& manager,
+  ClientSslSocketFactory(ClientContextConfigPtr config, Ssl::ContextManager& manager,
                          Stats::Scope& stats_scope);
 
   Network::TransportSocketPtr createTransportSocket() const override;
   bool implementsSecureTransport() const override;
 
 private:
+  // Will be called when config_ is changed
+  void onConfigUpdate();
+
+  Ssl::ContextManager& manager_;
+  Stats::Scope& stats_scope_;
+  ClientContextConfigPtr config_;
   ClientContextSharedPtr ssl_ctx_;
 };
 
 class ServerSslSocketFactory : public Network::TransportSocketFactory {
 public:
-  ServerSslSocketFactory(const ServerContextConfig& config, Ssl::ContextManager& manager,
+  ServerSslSocketFactory(ServerContextConfigPtr config, Ssl::ContextManager& manager,
                          Stats::Scope& stats_scope, const std::vector<std::string>& server_names);
 
   Network::TransportSocketPtr createTransportSocket() const override;
   bool implementsSecureTransport() const override;
 
 private:
+  // Will be called when config_ is changed
+  void onConfigUpdate();
+
+  Ssl::ContextManager& manager_;
+  Stats::Scope& stats_scope_;
+  ServerContextConfigPtr config_;
+  const std::vector<std::string> server_names_;
   ServerContextSharedPtr ssl_ctx_;
 };
 

--- a/source/extensions/transport_sockets/ssl/config.cc
+++ b/source/extensions/transport_sockets/ssl/config.cc
@@ -16,12 +16,11 @@ namespace SslTransport {
 Network::TransportSocketFactoryPtr UpstreamSslSocketFactory::createTransportSocketFactory(
     const Protobuf::Message& message,
     Server::Configuration::TransportSocketFactoryContext& context) {
+  auto client_config = std::make_unique<Ssl::ClientContextConfigImpl>(
+      MessageUtil::downcastAndValidate<const envoy::api::v2::auth::UpstreamTlsContext&>(message),
+      context.secretManager());
   return std::make_unique<Ssl::ClientSslSocketFactory>(
-      Ssl::ClientContextConfigImpl(
-          MessageUtil::downcastAndValidate<const envoy::api::v2::auth::UpstreamTlsContext&>(
-              message),
-          context.secretManager()),
-      context.sslContextManager(), context.statsScope());
+      std::move(client_config), context.sslContextManager(), context.statsScope());
 }
 
 ProtobufTypes::MessagePtr UpstreamSslSocketFactory::createEmptyConfigProto() {
@@ -35,12 +34,11 @@ static Registry::RegisterFactory<UpstreamSslSocketFactory,
 Network::TransportSocketFactoryPtr DownstreamSslSocketFactory::createTransportSocketFactory(
     const Protobuf::Message& message, Server::Configuration::TransportSocketFactoryContext& context,
     const std::vector<std::string>& server_names) {
+  auto server_config = std::make_unique<Ssl::ServerContextConfigImpl>(
+      MessageUtil::downcastAndValidate<const envoy::api::v2::auth::DownstreamTlsContext&>(message),
+      context.secretManager());
   return std::make_unique<Ssl::ServerSslSocketFactory>(
-      Ssl::ServerContextConfigImpl(
-          MessageUtil::downcastAndValidate<const envoy::api::v2::auth::DownstreamTlsContext&>(
-              message),
-          context.secretManager()),
-      context.sslContextManager(), context.statsScope(), server_names);
+      std::move(server_config), context.sslContextManager(), context.statsScope(), server_names);
 }
 
 ProtobufTypes::MessagePtr DownstreamSslSocketFactory::createEmptyConfigProto() {

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -459,10 +459,10 @@ public:
       tls_cert->mutable_private_key()->set_filename(
           TestEnvironment::runfilesPath("test/config/integration/certs/clientkey.pem"));
     }
-    Ssl::ClientContextConfigImpl cfg(tls_context, secret_manager_);
+    auto cfg = std::make_unique<Ssl::ClientContextConfigImpl>(tls_context, secret_manager_);
 
-    mock_cluster_info_->transport_socket_factory_ =
-        std::make_unique<Ssl::ClientSslSocketFactory>(cfg, context_manager_, *stats_store_);
+    mock_cluster_info_->transport_socket_factory_ = std::make_unique<Ssl::ClientSslSocketFactory>(
+        std::move(cfg), context_manager_, *stats_store_);
     ON_CALL(*mock_cluster_info_, transportSocketFactory())
         .WillByDefault(ReturnRef(*mock_cluster_info_->transport_socket_factory_));
     async_client_transport_socket_ =
@@ -489,11 +489,11 @@ public:
           TestEnvironment::runfilesPath("test/config/integration/certs/cacert.pem"));
     }
 
-    Ssl::ServerContextConfigImpl cfg(tls_context, secret_manager_);
+    auto cfg = std::make_unique<Ssl::ServerContextConfigImpl>(tls_context, secret_manager_);
 
     static Stats::Scope* upstream_stats_store = new Stats::IsolatedStoreImpl();
     return std::make_unique<Ssl::ServerSslSocketFactory>(
-        cfg, context_manager_, *upstream_stats_store, std::vector<std::string>{});
+        std::move(cfg), context_manager_, *upstream_stats_store, std::vector<std::string>{});
   }
 
   bool use_client_cert_{};

--- a/test/common/ssl/ssl_socket_test.cc
+++ b/test/common/ssl/ssl_socket_test.cc
@@ -56,9 +56,9 @@ void testUtil(const std::string& client_ctx_json, const std::string& server_ctx_
   Secret::MockSecretManager secret_manager;
 
   Json::ObjectSharedPtr server_ctx_loader = TestEnvironment::jsonLoadFromString(server_ctx_json);
-  ServerContextConfigImpl server_ctx_config(*server_ctx_loader, secret_manager);
+  auto server_cfg = std::make_unique<ServerContextConfigImpl>(*server_ctx_loader, secret_manager);
   ContextManagerImpl manager(runtime);
-  Ssl::ServerSslSocketFactory server_ssl_socket_factory(server_ctx_config, manager, stats_store,
+  Ssl::ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager, stats_store,
                                                         std::vector<std::string>{});
 
   Event::DispatcherImpl dispatcher;
@@ -69,8 +69,9 @@ void testUtil(const std::string& client_ctx_json, const std::string& server_ctx_
   Network::ListenerPtr listener = dispatcher.createListener(socket, callbacks, true, false);
 
   Json::ObjectSharedPtr client_ctx_loader = TestEnvironment::jsonLoadFromString(client_ctx_json);
-  ClientContextConfigImpl client_ctx_config(*client_ctx_loader, secret_manager);
-  Ssl::ClientSslSocketFactory client_ssl_socket_factory(client_ctx_config, manager, stats_store);
+  auto client_cfg = std::make_unique<ClientContextConfigImpl>(*client_ctx_loader, secret_manager);
+  Ssl::ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager,
+                                                        stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
       socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(), nullptr);
@@ -158,8 +159,9 @@ const std::string testUtilV2(const envoy::api::v2::Listener& server_proto,
   const auto& filter_chain = server_proto.filter_chains(0);
   std::vector<std::string> server_names(filter_chain.filter_chain_match().server_names().begin(),
                                         filter_chain.filter_chain_match().server_names().end());
-  Ssl::ServerContextConfigImpl server_ctx_config(filter_chain.tls_context(), secret_manager);
-  Ssl::ServerSslSocketFactory server_ssl_socket_factory(server_ctx_config, manager, stats_store,
+  auto server_cfg =
+      std::make_unique<Ssl::ServerContextConfigImpl>(filter_chain.tls_context(), secret_manager);
+  Ssl::ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager, stats_store,
                                                         server_names);
 
   Event::DispatcherImpl dispatcher;
@@ -169,9 +171,9 @@ const std::string testUtilV2(const envoy::api::v2::Listener& server_proto,
   Network::MockConnectionHandler connection_handler;
   Network::ListenerPtr listener = dispatcher.createListener(socket, callbacks, true, false);
 
-  ClientContextConfigImpl client_ctx_config(client_ctx_proto, secret_manager);
-  ClientSslSocketFactory client_ssl_socket_factory(client_ctx_config, manager, stats_store);
-  ClientContextSharedPtr client_ctx(manager.createSslClientContext(stats_store, client_ctx_config));
+  auto client_cfg = std::make_unique<ClientContextConfigImpl>(client_ctx_proto, secret_manager);
+  ClientContextSharedPtr client_ctx(manager.createSslClientContext(stats_store, *client_cfg));
+  ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager, stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
       socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(), nullptr);
@@ -1536,9 +1538,9 @@ TEST_P(SslSocketTest, FlushCloseDuringHandshake) {
   )EOF";
 
   Json::ObjectSharedPtr server_ctx_loader = TestEnvironment::jsonLoadFromString(server_ctx_json);
-  ServerContextConfigImpl server_ctx_config(*server_ctx_loader, secret_manager_);
+  auto server_cfg = std::make_unique<ServerContextConfigImpl>(*server_ctx_loader, secret_manager_);
   ContextManagerImpl manager(runtime);
-  Ssl::ServerSslSocketFactory server_ssl_socket_factory(server_ctx_config, manager, stats_store,
+  Ssl::ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager, stats_store,
                                                         std::vector<std::string>{});
 
   Event::DispatcherImpl dispatcher;
@@ -1594,9 +1596,9 @@ TEST_P(SslSocketTest, HalfClose) {
   )EOF";
 
   Json::ObjectSharedPtr server_ctx_loader = TestEnvironment::jsonLoadFromString(server_ctx_json);
-  ServerContextConfigImpl server_ctx_config(*server_ctx_loader, secret_manager_);
+  auto server_cfg = std::make_unique<ServerContextConfigImpl>(*server_ctx_loader, secret_manager_);
   ContextManagerImpl manager(runtime);
-  Ssl::ServerSslSocketFactory server_ssl_socket_factory(server_ctx_config, manager, stats_store,
+  Ssl::ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager, stats_store,
                                                         std::vector<std::string>{});
 
   Event::DispatcherImpl dispatcher;
@@ -1615,8 +1617,8 @@ TEST_P(SslSocketTest, HalfClose) {
   )EOF";
 
   Json::ObjectSharedPtr client_ctx_loader = TestEnvironment::jsonLoadFromString(client_ctx_json);
-  ClientContextConfigImpl client_ctx_config(*client_ctx_loader, secret_manager_);
-  ClientSslSocketFactory client_ssl_socket_factory(client_ctx_config, manager, stats_store);
+  auto client_cfg = std::make_unique<ClientContextConfigImpl>(*client_ctx_loader, secret_manager_);
+  ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager, stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
       socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
       client_ssl_socket_factory.createTransportSocket(), nullptr);
@@ -1678,9 +1680,9 @@ TEST_P(SslSocketTest, ClientAuthMultipleCAs) {
   )EOF";
 
   Json::ObjectSharedPtr server_ctx_loader = TestEnvironment::jsonLoadFromString(server_ctx_json);
-  ServerContextConfigImpl server_ctx_config(*server_ctx_loader, secret_manager);
+  auto server_cfg = std::make_unique<ServerContextConfigImpl>(*server_ctx_loader, secret_manager);
   ContextManagerImpl manager(runtime);
-  Ssl::ServerSslSocketFactory server_ssl_socket_factory(server_ctx_config, manager, stats_store,
+  Ssl::ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager, stats_store,
                                                         std::vector<std::string>{});
 
   Event::DispatcherImpl dispatcher;
@@ -1698,8 +1700,8 @@ TEST_P(SslSocketTest, ClientAuthMultipleCAs) {
   )EOF";
 
   Json::ObjectSharedPtr client_ctx_loader = TestEnvironment::jsonLoadFromString(client_ctx_json);
-  ClientContextConfigImpl client_ctx_config(*client_ctx_loader, secret_manager);
-  ClientSslSocketFactory ssl_socket_factory(client_ctx_config, manager, stats_store);
+  auto client_cfg = std::make_unique<ClientContextConfigImpl>(*client_ctx_loader, secret_manager);
+  ClientSslSocketFactory ssl_socket_factory(std::move(client_cfg), manager, stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
       socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
       ssl_socket_factory.createTransportSocket(), nullptr);
@@ -1760,12 +1762,12 @@ void testTicketSessionResumption(const std::string& server_ctx_json1,
 
   Json::ObjectSharedPtr server_ctx_loader1 = TestEnvironment::jsonLoadFromString(server_ctx_json1);
   Json::ObjectSharedPtr server_ctx_loader2 = TestEnvironment::jsonLoadFromString(server_ctx_json2);
-  ServerContextConfigImpl server_ctx_config1(*server_ctx_loader1, secret_manager);
-  ServerContextConfigImpl server_ctx_config2(*server_ctx_loader2, secret_manager);
-  Ssl::ServerSslSocketFactory server_ssl_socket_factory1(server_ctx_config1, manager, stats_store,
-                                                         server_names1);
-  Ssl::ServerSslSocketFactory server_ssl_socket_factory2(server_ctx_config2, manager, stats_store,
-                                                         server_names2);
+  auto server_cfg1 = std::make_unique<ServerContextConfigImpl>(*server_ctx_loader1, secret_manager);
+  auto server_cfg2 = std::make_unique<ServerContextConfigImpl>(*server_ctx_loader2, secret_manager);
+  Ssl::ServerSslSocketFactory server_ssl_socket_factory1(std::move(server_cfg1), manager,
+                                                         stats_store, server_names1);
+  Ssl::ServerSslSocketFactory server_ssl_socket_factory2(std::move(server_cfg2), manager,
+                                                         stats_store, server_names2);
 
   Event::DispatcherImpl dispatcher;
   Network::TcpListenSocket socket1(Network::Test::getCanonicalLoopbackAddress(ip_version), nullptr,
@@ -1778,8 +1780,8 @@ void testTicketSessionResumption(const std::string& server_ctx_json1,
   Network::ListenerPtr listener2 = dispatcher.createListener(socket2, callbacks, true, false);
 
   Json::ObjectSharedPtr client_ctx_loader = TestEnvironment::jsonLoadFromString(client_ctx_json);
-  ClientContextConfigImpl client_ctx_config(*client_ctx_loader, secret_manager);
-  ClientSslSocketFactory ssl_socket_factory(client_ctx_config, manager, stats_store);
+  auto client_cfg = std::make_unique<ClientContextConfigImpl>(*client_ctx_loader, secret_manager);
+  ClientSslSocketFactory ssl_socket_factory(std::move(client_cfg), manager, stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
       socket1.localAddress(), Network::Address::InstanceConstSharedPtr(),
       ssl_socket_factory.createTransportSocket(), nullptr);
@@ -2118,14 +2120,15 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
   )EOF";
 
   Json::ObjectSharedPtr server_ctx_loader = TestEnvironment::jsonLoadFromString(server_ctx_json);
-  ServerContextConfigImpl server_ctx_config(*server_ctx_loader, secret_manager_);
+  auto server_cfg = std::make_unique<ServerContextConfigImpl>(*server_ctx_loader, secret_manager_);
   Json::ObjectSharedPtr server2_ctx_loader = TestEnvironment::jsonLoadFromString(server2_ctx_json);
-  ServerContextConfigImpl server2_ctx_config(*server2_ctx_loader, secret_manager_);
+  auto server2_cfg =
+      std::make_unique<ServerContextConfigImpl>(*server2_ctx_loader, secret_manager_);
   ContextManagerImpl manager(runtime);
-  Ssl::ServerSslSocketFactory server_ssl_socket_factory(server_ctx_config, manager, stats_store,
+  Ssl::ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager, stats_store,
                                                         std::vector<std::string>{});
-  Ssl::ServerSslSocketFactory server2_ssl_socket_factory(server2_ctx_config, manager, stats_store,
-                                                         std::vector<std::string>{});
+  Ssl::ServerSslSocketFactory server2_ssl_socket_factory(std::move(server2_cfg), manager,
+                                                         stats_store, std::vector<std::string>{});
 
   Event::DispatcherImpl dispatcher;
   Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr,
@@ -2145,8 +2148,8 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
   )EOF";
 
   Json::ObjectSharedPtr client_ctx_loader = TestEnvironment::jsonLoadFromString(client_ctx_json);
-  ClientContextConfigImpl client_ctx_config(*client_ctx_loader, secret_manager_);
-  ClientSslSocketFactory ssl_socket_factory(client_ctx_config, manager, stats_store);
+  auto client_cfg = std::make_unique<ClientContextConfigImpl>(*client_ctx_loader, secret_manager_);
+  ClientSslSocketFactory ssl_socket_factory(std::move(client_cfg), manager, stats_store);
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
       socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
       ssl_socket_factory.createTransportSocket(), nullptr);
@@ -2231,9 +2234,9 @@ TEST_P(SslSocketTest, SslError) {
   )EOF";
 
   Json::ObjectSharedPtr server_ctx_loader = TestEnvironment::jsonLoadFromString(server_ctx_json);
-  ServerContextConfigImpl server_ctx_config(*server_ctx_loader, secret_manager_);
+  auto server_cfg = std::make_unique<ServerContextConfigImpl>(*server_ctx_loader, secret_manager_);
   ContextManagerImpl manager(runtime);
-  Ssl::ServerSslSocketFactory server_ssl_socket_factory(server_ctx_config, manager, stats_store,
+  Ssl::ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager, stats_store,
                                                         std::vector<std::string>{});
 
   Event::DispatcherImpl dispatcher;
@@ -2574,18 +2577,20 @@ class SslReadBufferLimitTest : public SslCertsTest,
 public:
   void initialize() {
     server_ctx_loader_ = TestEnvironment::jsonLoadFromString(server_ctx_json_);
-    server_ctx_config_.reset(new ServerContextConfigImpl(*server_ctx_loader_, secret_manager_));
+    auto server_cfg =
+        std::make_unique<ServerContextConfigImpl>(*server_ctx_loader_, secret_manager_);
     manager_.reset(new ContextManagerImpl(runtime_));
     server_ssl_socket_factory_.reset(new ServerSslSocketFactory(
-        *server_ctx_config_, *manager_, stats_store_, std::vector<std::string>{}));
+        std::move(server_cfg), *manager_, stats_store_, std::vector<std::string>{}));
 
     listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
 
     client_ctx_loader_ = TestEnvironment::jsonLoadFromString(client_ctx_json_);
-    client_ctx_config_.reset(new ClientContextConfigImpl(*client_ctx_loader_, secret_manager_));
+    auto client_cfg =
+        std::make_unique<ClientContextConfigImpl>(*client_ctx_loader_, secret_manager_);
 
     client_ssl_socket_factory_.reset(
-        new ClientSslSocketFactory(*client_ctx_config_, *manager_, stats_store_));
+        new ClientSslSocketFactory(std::move(client_cfg), *manager_, stats_store_));
     client_connection_ = dispatcher_->createClientConnection(
         socket_.localAddress(), source_address_,
         client_ssl_socket_factory_->createTransportSocket(), nullptr);
@@ -2749,12 +2754,10 @@ public:
   )EOF";
   Runtime::MockLoader runtime_;
   Json::ObjectSharedPtr server_ctx_loader_;
-  std::unique_ptr<ServerContextConfigImpl> server_ctx_config_;
   std::unique_ptr<ContextManagerImpl> manager_;
   Network::TransportSocketFactoryPtr server_ssl_socket_factory_;
   Network::ListenerPtr listener_;
   Json::ObjectSharedPtr client_ctx_loader_;
-  std::unique_ptr<ClientContextConfigImpl> client_ctx_config_;
   ClientContextSharedPtr client_ctx_;
   Network::TransportSocketFactoryPtr client_ssl_socket_factory_;
   Network::ClientConnectionPtr client_connection_;

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -116,11 +116,11 @@ public:
         TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcert.pem"));
     tls_cert->mutable_private_key()->set_filename(
         TestEnvironment::runfilesPath("test/config/integration/certs/upstreamkey.pem"));
-    Ssl::ServerContextConfigImpl cfg(tls_context, secret_manager_);
+    auto cfg = std::make_unique<Ssl::ServerContextConfigImpl>(tls_context, secret_manager_);
 
     static Stats::Scope* upstream_stats_store = new Stats::TestIsolatedStoreImpl();
     return std::make_unique<Ssl::ServerSslSocketFactory>(
-        cfg, context_manager_, *upstream_stats_store, std::vector<std::string>{});
+        std::move(cfg), context_manager_, *upstream_stats_store, std::vector<std::string>{});
   }
 
   AssertionResult

--- a/test/integration/sds_static_integration_test.cc
+++ b/test/integration/sds_static_integration_test.cc
@@ -166,11 +166,11 @@ public:
     tls_certificate->mutable_private_key()->set_filename(
         TestEnvironment::runfilesPath("/test/config/integration/certs/serverkey.pem"));
 
-    Ssl::ServerContextConfigImpl cfg(tls_context, secret_manager_);
+    auto cfg = std::make_unique<Ssl::ServerContextConfigImpl>(tls_context, secret_manager_);
 
     static Stats::Scope* upstream_stats_store = new Stats::TestIsolatedStoreImpl();
     return std::make_unique<Ssl::ServerSslSocketFactory>(
-        cfg, context_manager_, *upstream_stats_store, std::vector<std::string>{});
+        std::move(cfg), context_manager_, *upstream_stats_store, std::vector<std::string>{});
   }
 
 private:

--- a/test/integration/ssl_utility.cc
+++ b/test/integration/ssl_utility.cc
@@ -59,10 +59,10 @@ createClientSslTransportSocketFactory(bool alpn, bool san, ContextManager& conte
     target = san ? json_san : json_plain;
   }
   Json::ObjectSharedPtr loader = TestEnvironment::jsonLoadFromString(target);
-  ClientContextConfigImpl cfg(*loader, secret_manager);
+  auto cfg = std::make_unique<ClientContextConfigImpl>(*loader, secret_manager);
   static auto* client_stats_store = new Stats::TestIsolatedStoreImpl();
   return Network::TransportSocketFactoryPtr{
-      new Ssl::ClientSslSocketFactory(cfg, context_manager, *client_stats_store)};
+      new Ssl::ClientSslSocketFactory(std::move(cfg), context_manager, *client_stats_store)};
 }
 
 Network::Address::InstanceConstSharedPtr getSslAddress(const Network::Address::IpVersion& version,

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -60,10 +60,10 @@ Network::TransportSocketFactoryPtr XfccIntegrationTest::createClientSslContext(b
     target = json_tls;
   }
   Json::ObjectSharedPtr loader = TestEnvironment::jsonLoadFromString(target);
-  Ssl::ClientContextConfigImpl cfg(*loader, secret_manager_);
+  auto cfg = std::make_unique<Ssl::ClientContextConfigImpl>(*loader, secret_manager_);
   static auto* client_stats_store = new Stats::TestIsolatedStoreImpl();
   return Network::TransportSocketFactoryPtr{
-      new Ssl::ClientSslSocketFactory(cfg, *context_manager_, *client_stats_store)};
+      new Ssl::ClientSslSocketFactory(std::move(cfg), *context_manager_, *client_stats_store)};
 }
 
 Network::TransportSocketFactoryPtr XfccIntegrationTest::createUpstreamSslContext() {
@@ -75,10 +75,10 @@ Network::TransportSocketFactoryPtr XfccIntegrationTest::createUpstreamSslContext
 )EOF";
 
   Json::ObjectSharedPtr loader = TestEnvironment::jsonLoadFromString(json);
-  Ssl::ServerContextConfigImpl cfg(*loader, secret_manager_);
+  auto cfg = std::make_unique<Ssl::ServerContextConfigImpl>(*loader, secret_manager_);
   static Stats::Scope* upstream_stats_store = new Stats::TestIsolatedStoreImpl();
   return std::make_unique<Ssl::ServerSslSocketFactory>(
-      cfg, *context_manager_, *upstream_stats_store, std::vector<std::string>{});
+      std::move(cfg), *context_manager_, *upstream_stats_store, std::vector<std::string>{});
 }
 
 Network::ClientConnectionPtr XfccIntegrationTest::makeClientConnection() {


### PR DESCRIPTION

*Description*:

This change is one of PR to support dynamic SDS.  The overall implementation PR is here <https://github.com/envoyproxy/envoy/pull/3700>

Changes in this PR
* use unique_ptr for ContextConfig object.  If the config is updated (secret is updated),  the same object will be used.
* ssl socket factory owns ContextConfig object so later it can be used to re-create Context if config is updated
* ssl socket factory adds un-used function onConfigUpdate() to illustrate how Context is created from updated config.  This function will be called in a later PR.

*Risk Level*:  Low

*Testing*:   Unit-test

