### PR TITLE
server: fix duplicate listeners in lds response

### DIFF
--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -44,6 +44,12 @@ void LdsApiImpl::initialize(std::function<void()> callback) {
 void LdsApiImpl::onConfigUpdate(const ResourceVector& resources, const std::string& version_info) {
   cm_.adsMux().pause(Config::TypeUrl::get().RouteConfiguration);
   Cleanup rds_resume([this] { cm_.adsMux().resume(Config::TypeUrl::get().RouteConfiguration); });
+  std::unordered_set<std::string> listener_names;
+  for (const auto& listener : resources) {
+    if (!listener_names.insert(listener.name()).second) {
+      throw EnvoyException(fmt::format("duplicate listener {} found", listener.name()));
+    }
+  }
   for (const auto& listener : resources) {
     MessageUtil::validate(listener);
   }

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -182,6 +182,24 @@ TEST_F(LdsApiTest, MisconfiguredListenerNameIsPresentInException) {
   EXPECT_CALL(request_, cancel());
 }
 
+// Validate onConfigUpadte throws EnvoyException with duplicate listeners.
+TEST_F(LdsApiTest, ValidateDuplicateListeners) {
+  InSequence s;
+
+  setup(true);
+
+  Protobuf::RepeatedPtrField<envoy::api::v2::Listener> listeners;
+  auto* listener_1 = listeners.Add();
+  listener_1->set_name("duplicate_listener");
+
+  auto* listener_2 = listeners.Add();
+  listener_2->set_name("duplicate_listener");
+
+  EXPECT_THROW_WITH_MESSAGE(lds_->onConfigUpdate(listeners, ""), EnvoyException,
+                            "duplicate listener duplicate_listener found");
+  EXPECT_CALL(request_, cancel());
+}
+
 TEST_F(LdsApiTest, BadLocalInfo) {
   interval_timer_ = new Event::MockTimer(&dispatcher_);
   const std::string config_json = R"EOF(


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*: Validates duplicate listeners in LDS response and rejects the update if duplicates are found.
*Risk Level*: Low
*Testing*: Unit and Integration tests added
*Docs Changes*: N/A
*Release Notes*: N/A

