### PR TITLE
Ability to specify a test or a test group when building with docker release

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -83,6 +83,7 @@ The `./ci/run_envoy_docker.sh './ci/do_ci.sh <TARGET>'` targets are:
 * `bazel.debug.server_only` &mdash; build Envoy static binary under `-c dbg`.
 * `bazel.dev` &mdash; build Envoy static binary and run tests under `-c fastbuild` with gcc.
 * `bazel.release` &mdash; build Envoy static binary and run tests under `-c opt` with gcc.
+* `bazel.release <test>` &mdash; build Envoy static binary and run a specified test or test dir under `-c opt` with gcc.
 * `bazel.release.server_only` &mdash; build Envoy static binary under `-c opt` with gcc.
 * `bazel.coverage` &mdash; build and run tests under `-c dbg` with gcc, generating coverage information in `$ENVOY_DOCKER_BUILD_DIR/envoy/generated/coverage/coverage.html`.
 * `bazel.coverity` &mdash; build Envoy static binary and run Coverity Scan static analysis.

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -56,16 +56,17 @@ if [[ "$1" == "bazel.release" ]]; then
   bazel_release_binary_build
   
   if [[ $# == 2 ]]; then
- 	echo "Testing $2 ..."
-	# Run only specified tests.
-	bazel --batch test ${BAZEL_TEST_OPTIONS} -c opt $2
+    echo "Testing $2 ..."
+    # Run only specified tests. Argument can be a single test 
+    # (e.g. '//test/common/common:assert_test') or a test group (e.g. '//test/common/...')
+    bazel --batch test ${BAZEL_TEST_OPTIONS} -c opt $2
   else
     echo "Testing..."
-	# We have various test binaries in the test directory such as tools, benchmarks, etc. We
-	# run a build pass to make sure they compile.
-	bazel --batch build ${BAZEL_BUILD_OPTIONS} -c opt //include/... //source/... //test/...
-	# Now run all of the tests which should already be compiled.
-	bazel --batch test ${BAZEL_TEST_OPTIONS} -c opt //test/...
+    # We have various test binaries in the test directory such as tools, benchmarks, etc. We
+    # run a build pass to make sure they compile.
+    bazel --batch build ${BAZEL_BUILD_OPTIONS} -c opt //include/... //source/... //test/...
+    # Now run all of the tests which should already be compiled.
+    bazel --batch test ${BAZEL_TEST_OPTIONS} -c opt //test/...
   fi
   exit 0
 elif [[ "$1" == "bazel.release.server_only" ]]; then

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -55,7 +55,10 @@ if [[ "$1" == "bazel.release" ]]; then
   echo "bazel release build with tests..."
   bazel_release_binary_build
   
-  if [[ $# == 2 ]]; then
+  if [[ $# > 2 ]]; then
+  	echo "Multiple tests are not supported, only $2 will run"
+  fi
+  if [[ $# > 1 ]]; then
     echo "Testing $2 ..."
     # Run only specified tests. Argument can be a single test 
     # (e.g. '//test/common/common:assert_test') or a test group (e.g. '//test/common/...')

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -50,16 +50,23 @@ if [[ "$1" == "bazel.release" ]]; then
     echo 'Ignoring build for git tag event'
     exit 0
   fi
-
+  
   setup_gcc_toolchain
   echo "bazel release build with tests..."
   bazel_release_binary_build
-  echo "Testing..."
-  # We have various test binaries in the test directory such as tools, benchmarks, etc. We
-  # run a build pass to make sure they compile.
-  bazel --batch build ${BAZEL_BUILD_OPTIONS} -c opt //include/... //source/... //test/...
-  # Now run all of the tests which should already be compiled.
-  bazel --batch test ${BAZEL_TEST_OPTIONS} -c opt //test/...
+  
+  if [[ $# == 2 ]]; then
+ 	echo "Testing $2 ..."
+	# Run only specified tests.
+	bazel --batch test ${BAZEL_TEST_OPTIONS} -c opt $2
+  else
+    echo "Testing..."
+	# We have various test binaries in the test directory such as tools, benchmarks, etc. We
+	# run a build pass to make sure they compile.
+	bazel --batch build ${BAZEL_BUILD_OPTIONS} -c opt //include/... //source/... //test/...
+	# Now run all of the tests which should already be compiled.
+	bazel --batch test ${BAZEL_TEST_OPTIONS} -c opt //test/...
+  fi
   exit 0
 elif [[ "$1" == "bazel.release.server_only" ]]; then
   setup_gcc_toolchain

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -55,14 +55,12 @@ if [[ "$1" == "bazel.release" ]]; then
   echo "bazel release build with tests..."
   bazel_release_binary_build
   
-  if [[ $# > 2 ]]; then
-  	echo "Multiple tests are not supported, only $2 will run"
-  fi
   if [[ $# > 1 ]]; then
-    echo "Testing $2 ..."
+    shift
+    echo "Testing $* ..."
     # Run only specified tests. Argument can be a single test 
     # (e.g. '//test/common/common:assert_test') or a test group (e.g. '//test/common/...')
-    bazel --batch test ${BAZEL_TEST_OPTIONS} -c opt $2
+    bazel --batch test ${BAZEL_TEST_OPTIONS} -c opt $*
   else
     echo "Testing..."
     # We have various test binaries in the test directory such as tools, benchmarks, etc. We


### PR DESCRIPTION
added ability to specify a test (e.g. //test/common/common:assert_test) or a test group (e.g. //test/common/...) when building with docker release

Signed-off-by: trabetti <talis@il.ibm.com>

*Description*: When compiling with Docker for development, I found it useful to compile and run only one test which I am currently working on, so I updated locally the do_ci.sh script to accommodate this option.
I thought I can suggest it as a PR, maybe it can be useful for someone else. If seems unnecessary, feel free to close...

example usage:
*ENVOY_DOCKER_BUILD_DIR=~/envoy_fork/build-debug ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.release //test/common/stats:thread_local_store_test'*


*Risk Level*: Low
*Testing*:
*Docs Changes*: ci/README.md
*Release Notes*:
