### PR TITLE
hot restarter: Log errno for 'panic: cannot open shared memory' error

### DIFF
--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -55,7 +55,8 @@ SharedMemory& SharedMemory::initialize(uint64_t stats_set_size, Options& options
 
   int shmem_fd = os_sys_calls.shmOpen(shmem_name.c_str(), flags, S_IRUSR | S_IWUSR);
   if (shmem_fd == -1) {
-    PANIC(fmt::format("cannot open shared memory region {} check user permissions. Error code: {}", shmem_name, errno));
+    PANIC(fmt::format("cannot open shared memory region {} check user permissions. Error: {}",
+                      shmem_name, strerror(errno)));
   }
 
   if (options.restartEpoch() == 0) {

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -55,7 +55,7 @@ SharedMemory& SharedMemory::initialize(uint64_t stats_set_size, Options& options
 
   int shmem_fd = os_sys_calls.shmOpen(shmem_name.c_str(), flags, S_IRUSR | S_IWUSR);
   if (shmem_fd == -1) {
-    PANIC(fmt::format("cannot open shared memory region {} check user permissions", shmem_name));
+    PANIC(fmt::format("cannot open shared memory region {} check user permissions. Error code: {}", shmem_name, errno));
   }
 
   if (options.restartEpoch() == 0) {


### PR DESCRIPTION
*Description*:

We've been seeing very frequent `panic: cannot open shared memory region /envoy_shared_memory_160 check user permissions` errors. This error message assumes that the reason the file can't be opened is because of permissions (`EACCESS`), but this can be misleading -- there are many reasons files might fail to open. In our case the cause was that the file didn't exist (`ENOENT`).

Logging the errno makes this particular error much easier to debug.

*Risk Level*: low
*Testing*: Ran in our QA cluster
