### PR TITLE
Rename duplicated ads integration test case name

### DIFF
--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -477,7 +477,7 @@ TEST_P(AdsIntegrationTest, Failure) {
 }
 
 // Validate that the request with duplicate listeners is rejected.
-TEST_P(AdsIntegrationTest, RejectDuplicateWarmingClusters) {
+TEST_P(AdsIntegrationTest, DuplicateWarmingListeners) {
   initialize();
 
   // Send initial configuration, validate we can process a request.

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -477,7 +477,7 @@ TEST_P(AdsIntegrationTest, Failure) {
 }
 
 // Validate that the request with duplicate listeners is rejected.
-TEST_P(AdsIntegrationTest, DuplicateWarmingClusters) {
+TEST_P(AdsIntegrationTest, RejectDuplicateWarmingClusters) {
   initialize();
 
   // Send initial configuration, validate we can process a request.


### PR DESCRIPTION
*Description*:
Rename the duplicated DuplicateWarmingClusters test case, [here](https://github.com/envoyproxy/envoy/blob/7a8f5af1fda5d311603ea06e0f362736c2305e45/test/integration/ads_integration_test.cc#L556) and [here](https://github.com/envoyproxy/envoy/blob/02281809bd116ef36b4095c0a2103c4492b68296/test/integration/ads_integration_test.cc#L480).
*Risk Level*: Low
*Testing*: Current tests
*Docs Changes*: N/A
*Release Notes*: N/A

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>