### PR TITLE
Add overload manager to bootstrap config

### DIFF
--- a/api/docs/BUILD
+++ b/api/docs/BUILD
@@ -55,6 +55,7 @@ proto_library(
         "//envoy/config/metrics/v2:stats",
         "//envoy/config/ratelimit/v2:rls",
         "//envoy/config/rbac/v2alpha:rbac",
+        "//envoy/config/resource_monitor/fixed_heap/v2alpha:fixed_heap",
         "//envoy/config/trace/v2:trace",
         "//envoy/config/transport_socket/capture/v2alpha:capture",
         "//envoy/data/accesslog/v2:accesslog",

--- a/api/envoy/config/bootstrap/v2/BUILD
+++ b/api/envoy/config/bootstrap/v2/BUILD
@@ -33,6 +33,7 @@ api_go_proto_library(
         "//envoy/api/v2/core:config_source_go_proto",
         "//envoy/config/metrics/v2:metrics_service_go_proto",
         "//envoy/config/metrics/v2:stats_go_proto",
+        "//envoy/config/overload/v2alpha:overload_go_proto",
         "//envoy/config/ratelimit/v2:rls_go_grpc",
         "//envoy/config/trace/v2:trace_go_proto",
     ],

--- a/api/envoy/config/bootstrap/v2/BUILD
+++ b/api/envoy/config/bootstrap/v2/BUILD
@@ -15,6 +15,7 @@ api_proto_library_internal(
         "//envoy/api/v2/core:config_source",
         "//envoy/config/metrics/v2:metrics_service",
         "//envoy/config/metrics/v2:stats",
+        "//envoy/config/overload/v2alpha:overload",
         "//envoy/config/ratelimit/v2:rls",
         "//envoy/config/trace/v2:trace",
     ],

--- a/api/envoy/config/bootstrap/v2/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v2/bootstrap.proto
@@ -16,6 +16,7 @@ import "envoy/api/v2/cds.proto";
 import "envoy/api/v2/lds.proto";
 import "envoy/config/trace/v2/trace.proto";
 import "envoy/config/metrics/v2/stats.proto";
+import "envoy/config/overload/v2alpha/overload.proto";
 import "envoy/config/ratelimit/v2/rls.proto";
 
 import "google/protobuf/duration.proto";
@@ -123,6 +124,9 @@ message Bootstrap {
 
   // Configuration for the local administration HTTP server.
   Admin admin = 12 [(validate.rules).message.required = true, (gogoproto.nullable) = false];
+
+  // Optional overload manager configuration.
+  envoy.config.overload.v2alpha.OverloadManager overload_manager = 15;
 }
 
 // Administration interface :ref:`operations documentation

--- a/api/envoy/config/overload/v2alpha/BUILD
+++ b/api/envoy/config/overload/v2alpha/BUILD
@@ -5,4 +5,5 @@ licenses(["notice"])  # Apache 2
 api_proto_library_internal(
     name = "overload",
     srcs = ["overload.proto"],
+    visibility = ["//visibility:public"],
 )

--- a/api/envoy/config/overload/v2alpha/BUILD
+++ b/api/envoy/config/overload/v2alpha/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:api_build_system.bzl", "api_proto_library_internal")
+load("//bazel:api_build_system.bzl", "api_go_proto_library", "api_proto_library_internal")
 
 licenses(["notice"])  # Apache 2
 
@@ -6,4 +6,9 @@ api_proto_library_internal(
     name = "overload",
     srcs = ["overload.proto"],
     visibility = ["//visibility:public"],
+)
+
+api_go_proto_library(
+    name = "overload",
+    proto = ":overload",
 )

--- a/api/envoy/config/overload/v2alpha/overload.proto
+++ b/api/envoy/config/overload/v2alpha/overload.proto
@@ -19,7 +19,9 @@ message ResourceMonitor {
   // The name of the resource monitor to instantiate. Must match a registered
   // resource monitor type. The built-in resource monitors are:
   //
+  // clang-format off
   // * :ref:`envoy.resource_monitors.fixed_heap <envoy_api_msg_config.resource_monitor.fixed_heap.v2alpha.FixedHeapConfig>`
+  // clang-format on
   string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // Configuration for the resource monitor being instantiated.

--- a/api/envoy/config/overload/v2alpha/overload.proto
+++ b/api/envoy/config/overload/v2alpha/overload.proto
@@ -19,8 +19,7 @@ message ResourceMonitor {
   // The name of the resource monitor to instantiate. Must match a registered
   // resource monitor type. The built-in resource monitors are:
   //
-  // * :ref:`envoy.resource_monitors.fixed_heap
-  // <envoy_api_msg_config.resource_monitor.fixed_heap.v2alpha.FixedHeapConfig>`
+  // * :ref:`envoy.resource_monitors.fixed_heap <envoy_api_msg_config.resource_monitor.fixed_heap.v2alpha.FixedHeapConfig>`
   string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // Configuration for the resource monitor being instantiated.

--- a/api/envoy/config/overload/v2alpha/overload.proto
+++ b/api/envoy/config/overload/v2alpha/overload.proto
@@ -19,17 +19,12 @@ message ResourceMonitor {
   // The name of the resource monitor to instantiate. Must match a registered
   // resource monitor type. The built-in resource monitors are:
   //
-  // clang-format off
-  // * :ref:`envoy.resource_monitors.fixed_heap <envoy_api_msg_config.resource_monitor.fixed_heap.v2alpha.FixedHeapConfig>`
-  // clang-format on
+  // * :ref:`envoy.resource_monitors.fixed_heap
+  //   <envoy_api_msg_config.resource_monitor.fixed_heap.v2alpha.FixedHeapConfig>`
   string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // Configuration for the resource monitor being instantiated.
   google.protobuf.Struct config = 2;
-}
-
-// Convenience protobuf for resource monitors that do not require any configuration.
-message EmptyConfig {
 }
 
 message ThresholdTrigger {

--- a/api/envoy/config/overload/v2alpha/overload.proto
+++ b/api/envoy/config/overload/v2alpha/overload.proto
@@ -8,19 +8,27 @@ import "google/protobuf/struct.proto";
 
 import "validate/validate.proto";
 
-// The Overload Manager provides an extensible framework to protect Envoy instances
-// from overload of various resources (memory, cpu, file descriptors, etc)
+// [#protodoc-title: Overload Manager]
 
-message EmptyConfig {
-}
+// The Overload Manager provides an extensible framework to protect Envoy instances
+// from overload of various resources (memory, cpu, file descriptors, etc).
+// It monitors a configurable set of resources and notifies registered listeners
+// when triggers related to those resources fire.
 
 message ResourceMonitor {
   // The name of the resource monitor to instantiate. Must match a registered
-  // resource monitor type.
+  // resource monitor type. The built-in resource monitors are:
+  //
+  // * :ref:`envoy.resource_monitors.fixed_heap
+  // <envoy_api_msg_config.resource_monitor.fixed_heap.v2alpha.FixedHeapConfig>`
   string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // Configuration for the resource monitor being instantiated.
   google.protobuf.Struct config = 2;
+}
+
+// Convenience protobuf for resource monitors that do not require any configuration.
+message EmptyConfig {
 }
 
 message ThresholdTrigger {
@@ -45,7 +53,7 @@ message OverloadAction {
   // DNS to ensure uniqueness.
   string name = 1 [(validate.rules).string.min_bytes = 1];
 
-  // A set of triggers for this action. If any of these triggers fires the overload action
+  // A set of triggers for this action. If any of these triggers fire the overload action
   // is activated. Listeners are notified when the overload action transitions from
   // inactivated to activated, or vice versa.
   repeated Trigger triggers = 2 [(validate.rules).repeated .min_items = 1];
@@ -59,5 +67,5 @@ message OverloadManager {
   repeated ResourceMonitor resource_monitors = 2 [(validate.rules).repeated .min_items = 1];
 
   // The set of overload actions.
-  repeated OverloadAction actions = 3 [(validate.rules).repeated .min_items = 1];
+  repeated OverloadAction actions = 3;
 }

--- a/api/envoy/config/resource_monitor/fixed_heap/v2alpha/BUILD
+++ b/api/envoy/config/resource_monitor/fixed_heap/v2alpha/BUILD
@@ -5,4 +5,5 @@ licenses(["notice"])  # Apache 2
 api_proto_library_internal(
     name = "fixed_heap",
     srcs = ["fixed_heap.proto"],
+    visibility = ["//visibility:public"],
 )

--- a/api/envoy/config/resource_monitor/fixed_heap/v2alpha/fixed_heap.proto
+++ b/api/envoy/config/resource_monitor/fixed_heap/v2alpha/fixed_heap.proto
@@ -8,7 +8,6 @@ option go_package = "v2alpha";
 // The fixed heap resource monitor reports the Envoy process memory pressure, computed as a
 // fraction of currently reserved heap memory divided by a statically configured maximum
 // specified in the FixedHeapConfig.
-
 message FixedHeapConfig {
   uint64 max_heap_size_bytes = 1;
 }

--- a/api/envoy/config/resource_monitor/fixed_heap/v2alpha/fixed_heap.proto
+++ b/api/envoy/config/resource_monitor/fixed_heap/v2alpha/fixed_heap.proto
@@ -3,8 +3,12 @@ syntax = "proto3";
 package envoy.config.resource_monitor.fixed_heap.v2alpha;
 option go_package = "v2alpha";
 
+// [#protodoc-title: Fixed heap]
+
+// The fixed heap resource monitor reports the Envoy process memory pressure, computed as a
+// fraction of currently reserved heap memory divided by a statically configured maximum
+// specified in the FixedHeapConfig.
+
 message FixedHeapConfig {
-  // Limit of the Envoy process heap size. This is used to calculate heap memory pressure which
-  // is defined as (current heap size)/max_heap_size_bytes.
   uint64 max_heap_size_bytes = 1;
 }

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -101,7 +101,9 @@ PROTO_RST="
   /envoy/config/filter/network/redis_proxy/v2/redis_proxy/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto.rst
   /envoy/config/filter/network/tcp_proxy/v2/tcp_proxy/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto.rst
   /envoy/config/health_checker/redis/v2/redis/envoy/config/health_checker/redis/v2/redis.proto.rst
+  /envoy/config/overload/v2alpha/overload/envoy/config/overload/v2alpha/overload.proto.rst
   /envoy/config/rbac/v2alpha/rbac/envoy/config/rbac/v2alpha/rbac.proto.rst
+  /envoy/config/resource_monitor/fixed_heap/v2alpha/fixed_heap/envoy/config/resource_monitor/fixed_heap/v2alpha/fixed_heap.proto.rst
   /envoy/config/transport_socket/capture/v2alpha/capture/envoy/config/transport_socket/capture/v2alpha/capture.proto.rst
   /envoy/data/accesslog/v2/accesslog/envoy/data/accesslog/v2/accesslog.proto.rst
   /envoy/data/core/v2alpha/health_check_event/envoy/data/core/v2alpha/health_check_event.proto.rst

--- a/docs/root/api-v2/bootstrap/bootstrap.rst
+++ b/docs/root/api-v2/bootstrap/bootstrap.rst
@@ -8,5 +8,6 @@ Bootstrap
   ../config/bootstrap/v2/bootstrap.proto
   ../config/metrics/v2/stats.proto
   ../config/metrics/v2/metrics_service.proto
+  ../config/overload/v2alpha/overload.proto
   ../config/ratelimit/v2/rls.proto
   ../config/trace/v2/trace.proto

--- a/docs/root/api-v2/config/config.rst
+++ b/docs/root/api-v2/config/config.rst
@@ -10,3 +10,4 @@ Extensions
   rbac/rbac
   health_checker/health_checker
   transport_socket/transport_socket
+  resource_monitor/resource_monitor

--- a/docs/root/api-v2/config/resource_monitor/resource_monitor.rst
+++ b/docs/root/api-v2/config/resource_monitor/resource_monitor.rst
@@ -1,0 +1,10 @@
+.. _config_resource_monitors:
+
+Resource monitors
+=================
+
+.. toctree::
+  :glob:
+  :maxdepth: 1
+
+  */v2alpha/*

--- a/docs/root/configuration/configuration.rst
+++ b/docs/root/configuration/configuration.rst
@@ -21,3 +21,4 @@ Configuration reference
   runtime
   statistics
   tools/router_check
+  overload_manager/overload_manager

--- a/docs/root/configuration/overload_manager/overload_manager.rst
+++ b/docs/root/configuration/overload_manager/overload_manager.rst
@@ -3,7 +3,7 @@
 Overload manager
 ================
 
-The overload manager is configured in the Boostrap
+The :ref:`overload manager <arch_overview_overload_manager>` is configured in the Boostrap
 :ref:`overload_manager <envoy_api_field_config.bootstrap.v2.Bootstrap.overload_manager>`
 field.
 

--- a/docs/root/configuration/overload_manager/overload_manager.rst
+++ b/docs/root/configuration/overload_manager/overload_manager.rst
@@ -1,0 +1,38 @@
+.. _config_overload_manager:
+
+Overload manager
+================
+
+The overload manager is configured in the Boostrap
+:ref:`overload_manager <envoy_api_field_config.bootstrap.v2.Bootstrap.overload_manager>`
+field.
+
+Resource monitors
+-----------------
+
+The overload manager uses Envoy's :ref:`extension <extending>` framework for defining
+resource monitors. Envoy's builtin resource monitors are listed
+:ref:`here <config_resource_monitors>`.
+
+Statistics
+----------
+
+Each configured resource monitor has a statistics tree rooted at *overload.<name>.*
+with the following statistics:
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: 1, 1, 2
+
+  pressure, Gauge, Resource pressure as a percent
+  failed_updates, Counter, Total failed attempts to update the resource pressure
+  skipped_updates, Counter, Total skipped attempts to update the resource pressure due to a pending update
+
+Each configured overload action has a statistics tree rooted at *overload.<name>.*
+with the following statistics:
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: 1, 1, 2
+
+  active, Gauge, "Active state of the action (0=inactive, 1=active)"

--- a/docs/root/intro/arch_overview/arch_overview.rst
+++ b/docs/root/intro/arch_overview/arch_overview.rst
@@ -37,3 +37,4 @@ Architecture overview
   draining
   scripting
   ext_authz_filter
+  overload_manager

--- a/docs/root/intro/arch_overview/overload_manager.rst
+++ b/docs/root/intro/arch_overview/overload_manager.rst
@@ -1,0 +1,14 @@
+.. _arch_overview_overload_manager:
+
+Overload manager
+================
+
+The overload manager is an extensible component for protecting the Envoy server from overload
+with respect to various system resources (such as memory, cpu or file descriptors) due to too
+many client connections or requests. This is distinct from
+:ref:`circuit breaking <arch_overview_circuit_break>` which is primarily aimed at protecting
+upstream services.
+
+The overload manager is :ref:`configured <config_overload_manager>` by specifying a set of
+resources to monitor and a set of overload actions that will be taken when some of those
+resources exceed certain pressure thresholds.

--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -99,6 +99,7 @@ envoy_cc_library(
         "//include/envoy/ratelimit:ratelimit_interface",
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/secret:secret_manager_interface",
+        "//include/envoy/server:overload_manager_interface",
         "//include/envoy/ssl:context_manager_interface",
         "//include/envoy/thread_local:thread_local_interface",
         "//include/envoy/tracing:http_tracer_interface",

--- a/include/envoy/server/instance.h
+++ b/include/envoy/server/instance.h
@@ -17,6 +17,7 @@
 #include "envoy/server/hot_restart.h"
 #include "envoy/server/listener_manager.h"
 #include "envoy/server/options.h"
+#include "envoy/server/overload_manager.h"
 #include "envoy/ssl/context_manager.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/tracing/http_tracer.h"
@@ -113,6 +114,11 @@ public:
    * @return the server's listener manager.
    */
   virtual ListenerManager& listenerManager() PURE;
+
+  /**
+   * @return the server's overload manager.
+   */
+  virtual OverloadManager& overloadManager() PURE;
 
   /**
    * @return the server's secret manager

--- a/include/envoy/server/overload_manager.h
+++ b/include/envoy/server/overload_manager.h
@@ -31,6 +31,12 @@ public:
   virtual ~OverloadManager() {}
 
   /**
+   * Start a recurring timer to monitor resources and notify listeners when overload actions
+   * change state.
+   */
+  virtual void start() PURE;
+
+  /**
    * Register a callback to be invoked when the specified overload action changes state
    * (ie. becomes activated or inactivated). Must be called before the start method is called.
    * @param action const std::string& the name of the overload action to register for

--- a/source/extensions/resource_monitors/common/factory_base.h
+++ b/source/extensions/resource_monitors/common/factory_base.h
@@ -36,6 +36,33 @@ private:
   const std::string name_;
 };
 
+/**
+ * Factory for resource monitors that have empty configuration blocks.
+ */
+class EmptyConfigFactoryBase : public Server::Configuration::ResourceMonitorFactory {
+public:
+  Server::ResourceMonitorPtr
+  createResourceMonitor(const Protobuf::Message&,
+                        Server::Configuration::ResourceMonitorFactoryContext& context) override {
+    return createEmptyConfigResourceMonitor(context);
+  }
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return ProtobufTypes::MessagePtr{new Envoy::ProtobufWkt::Empty()};
+  }
+
+  std::string name() override { return name_; }
+
+protected:
+  EmptyConfigFactoryBase(const std::string& name) : name_(name) {}
+
+private:
+  virtual Server::ResourceMonitorPtr createEmptyConfigResourceMonitor(
+      Server::Configuration::ResourceMonitorFactoryContext& context) PURE;
+
+  const std::string name_;
+};
+
 } // namespace Common
 } // namespace ResourceMonitors
 } // namespace Extensions

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -309,6 +309,7 @@ envoy_cc_library(
         "//source/common/stats:thread_local_store_lib",
         "//source/common/upstream:cluster_manager_lib",
         "//source/common/upstream:health_discovery_service_lib",
+        "//source/server:overload_manager_lib",
         "//source/server/http:admin_lib",
         "@envoy_api//envoy/config/bootstrap/v2:bootstrap_cc",
     ],

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -83,6 +83,7 @@ public:
   void shutdown() override;
   void shutdownAdmin() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   Singleton::Manager& singletonManager() override { return *singleton_manager_; }
+  OverloadManager& overloadManager() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   bool healthCheckFailed() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   Options& options() override { return options_; }
   time_t startTimeCurrentEpoch() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -128,6 +128,9 @@ OverloadManagerImpl::OverloadManagerImpl(
 void OverloadManagerImpl::start() {
   ASSERT(!started_);
   started_ = true;
+  if (resources_.empty()) {
+    return;
+  }
   timer_ = dispatcher_.createTimer([this]() -> void {
     for (auto& resource : resources_) {
       resource.second.update();

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -51,9 +51,8 @@ public:
   OverloadManagerImpl(Event::Dispatcher& dispatcher, Stats::Scope& stats_scope,
                       const envoy::config::overload::v2alpha::OverloadManager& config);
 
-  void start();
-
   // Server::OverloadManager
+  void start() override;
   void registerForAction(const std::string& action, Event::Dispatcher& dispatcher,
                          OverloadActionCb callback) override;
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -248,10 +248,8 @@ void InstanceImpl::initialize(Options& options,
   loadServerFlags(initial_config.flagsPath());
 
   // Initialize the overload manager early so other modules can register for actions.
-  overload_manager_.reset(new OverloadManagerImpl(
-      dispatcher(), stats(),
-      bootstrap_.has_overload_manager() ? bootstrap_.overload_manager()
-                                        : envoy::config::overload::v2alpha::OverloadManager()));
+  overload_manager_.reset(
+      new OverloadManagerImpl(dispatcher(), stats(), bootstrap_.overload_manager()));
 
   // Workers get created first so they register for thread local updates.
   listener_manager_.reset(new ListenerManagerImpl(
@@ -359,7 +357,8 @@ uint64_t InstanceImpl::numConnections() { return listener_manager_->numConnectio
 
 RunHelper::RunHelper(Event::Dispatcher& dispatcher, Upstream::ClusterManager& cm,
                      HotRestart& hot_restart, AccessLog::AccessLogManager& access_log_manager,
-                     InitManagerImpl& init_manager, std::function<void()> workers_start_cb) {
+                     InitManagerImpl& init_manager, OverloadManager& overload_manager,
+                     std::function<void()> workers_start_cb) {
 
   // Setup signals.
   sigterm_ = dispatcher.listenForSignal(SIGTERM, [this, &hot_restart, &dispatcher]() {
@@ -406,13 +405,13 @@ RunHelper::RunHelper(Event::Dispatcher& dispatcher, Upstream::ClusterManager& cm
     // as we've subscribed to all the statically defined RDS resources.
     cm.adsMux().resume(Config::TypeUrl::get().RouteConfiguration);
   });
+
+  overload_manager.start();
 }
 
 void InstanceImpl::run() {
-  overload_manager_->start();
-
   RunHelper helper(*dispatcher_, clusterManager(), restarter_, access_log_manager_, init_manager_,
-                   [this]() -> void { startWorkers(); });
+                   overloadManager(), [this]() -> void { startWorkers(); });
 
   // Run the main dispatch loop waiting to exit.
   ENVOY_LOG(info, "starting main dispatch loop");

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -114,7 +114,7 @@ class RunHelper : Logger::Loggable<Logger::Id::main> {
 public:
   RunHelper(Event::Dispatcher& dispatcher, Upstream::ClusterManager& cm, HotRestart& hot_restart,
             AccessLog::AccessLogManager& access_log_manager, InitManagerImpl& init_manager,
-            std::function<void()> workers_start_cb);
+            OverloadManager& overload_manager, std::function<void()> workers_start_cb);
 
 private:
   Event::SignalEventPtr sigterm_;

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -27,6 +27,7 @@
 #include "server/http/admin.h"
 #include "server/init_manager_impl.h"
 #include "server/listener_manager_impl.h"
+#include "server/overload_manager_impl.h"
 #include "server/test_hooks.h"
 #include "server/worker_impl.h"
 
@@ -155,6 +156,7 @@ public:
   Init::Manager& initManager() override { return init_manager_; }
   ListenerManager& listenerManager() override { return *listener_manager_; }
   Secret::SecretManager& secretManager() override { return *secret_manager_; }
+  OverloadManager& overloadManager() override { return *overload_manager_; }
   Runtime::RandomGenerator& random() override { return *random_generator_; }
   RateLimit::ClientPtr
   rateLimitClient(const absl::optional<std::chrono::milliseconds>& timeout) override {
@@ -222,6 +224,7 @@ private:
   SystemTime bootstrap_config_update_time_;
   Grpc::AsyncClientManagerPtr async_client_manager_;
   Upstream::HdsDelegatePtr hds_delegate_;
+  std::unique_ptr<OverloadManagerImpl> overload_manager_;
 };
 
 } // namespace Server

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -22,6 +22,7 @@ envoy_cc_mock(
         "//include/envoy/server:health_checker_config_interface",
         "//include/envoy/server:instance_interface",
         "//include/envoy/server:options_interface",
+        "//include/envoy/server:overload_manager_interface",
         "//include/envoy/server:worker_interface",
         "//include/envoy/ssl:context_manager_interface",
         "//include/envoy/upstream:health_checker_interface",

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -128,6 +128,7 @@ MockInstance::MockInstance()
   ON_CALL(*this, initManager()).WillByDefault(ReturnRef(init_manager_));
   ON_CALL(*this, listenerManager()).WillByDefault(ReturnRef(listener_manager_));
   ON_CALL(*this, singletonManager()).WillByDefault(ReturnRef(*singleton_manager_));
+  ON_CALL(*this, overloadManager()).WillByDefault(ReturnRef(overload_manager_));
 }
 
 MockInstance::~MockInstance() {}

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -277,6 +277,7 @@ public:
   ~MockOverloadManager() {}
 
   // OverloadManager
+  MOCK_METHOD0(start, void());
   MOCK_METHOD3(registerForAction, void(const std::string& action, Event::Dispatcher& dispatcher,
                                        OverloadActionCb callback));
 };

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -12,6 +12,7 @@
 #include "envoy/server/health_checker_config.h"
 #include "envoy/server/instance.h"
 #include "envoy/server/options.h"
+#include "envoy/server/overload_manager.h"
 #include "envoy/server/transport_socket_config.h"
 #include "envoy/server/worker.h"
 #include "envoy/ssl/context_manager.h"
@@ -270,6 +271,16 @@ public:
   std::function<void()> remove_listener_completion_;
 };
 
+class MockOverloadManager : public OverloadManager {
+public:
+  MockOverloadManager() {}
+  ~MockOverloadManager() {}
+
+  // OverloadManager
+  MOCK_METHOD3(registerForAction, void(const std::string& action, Event::Dispatcher& dispatcher,
+                                       OverloadActionCb callback));
+};
+
 class MockInstance : public Instance {
 public:
   MockInstance();
@@ -298,6 +309,7 @@ public:
   MOCK_METHOD0(initManager, Init::Manager&());
   MOCK_METHOD0(listenerManager, ListenerManager&());
   MOCK_METHOD0(options, Options&());
+  MOCK_METHOD0(overloadManager, OverloadManager&());
   MOCK_METHOD0(random, Runtime::RandomGenerator&());
   MOCK_METHOD0(rateLimitClient_, RateLimit::Client*());
   MOCK_METHOD0(runtime, Runtime::Loader&());
@@ -333,6 +345,7 @@ public:
   testing::NiceMock<LocalInfo::MockLocalInfo> local_info_;
   testing::NiceMock<Init::MockManager> init_manager_;
   testing::NiceMock<MockListenerManager> listener_manager_;
+  testing::NiceMock<MockOverloadManager> overload_manager_;
   Singleton::ManagerPtr singleton_manager_;
 };
 

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -52,13 +52,13 @@ private:
   Event::Dispatcher& dispatcher_;
 };
 
-class FakeResourceMonitorFactory : public Extensions::ResourceMonitors::Common::FactoryBase<
-                                       envoy::config::overload::v2alpha::EmptyConfig> {
+class FakeResourceMonitorFactory
+    : public Extensions::ResourceMonitors::Common::EmptyConfigFactoryBase {
 public:
-  FakeResourceMonitorFactory(const std::string& name) : FactoryBase(name), monitor_(nullptr) {}
+  FakeResourceMonitorFactory(const std::string& name)
+      : EmptyConfigFactoryBase(name), monitor_(nullptr) {}
 
-  ResourceMonitorPtr createResourceMonitorFromProtoTyped(
-      const envoy::config::overload::v2alpha::EmptyConfig&,
+  ResourceMonitorPtr createEmptyConfigResourceMonitor(
       Server::Configuration::ResourceMonitorFactoryContext& context) override {
     auto monitor = std::make_unique<FakeResourceMonitor>(context.dispatcher());
     monitor_ = monitor.get();

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -56,15 +56,17 @@ public:
     sigusr1_ = new Event::MockSignalEvent(&dispatcher_);
     sighup_ = new Event::MockSignalEvent(&dispatcher_);
     EXPECT_CALL(cm_, setInitializedCb(_)).WillOnce(SaveArg<0>(&cm_init_callback_));
+    EXPECT_CALL(overload_manager_, start());
 
     helper_.reset(new RunHelper(dispatcher_, cm_, hot_restart_, access_log_manager_, init_manager_,
-                                [this] { start_workers_.ready(); }));
+                                overload_manager_, [this] { start_workers_.ready(); }));
   }
 
   NiceMock<Event::MockDispatcher> dispatcher_;
   NiceMock<Upstream::MockClusterManager> cm_;
   NiceMock<MockHotRestart> hot_restart_;
   NiceMock<AccessLog::MockAccessLogManager> access_log_manager_;
+  NiceMock<MockOverloadManager> overload_manager_;
   InitManagerImpl init_manager_;
   ReadyWatcher start_workers_;
   std::unique_ptr<RunHelper> helper_;


### PR DESCRIPTION
Initialize on startup and add documentation (issue #373)

*Risk Level*: low
*Testing*: unit tests
*Docs Changes*: add docs for overload manager

Signed-off-by: Elisha Ziskind <eziskind@google.com>
