### PR TITLE
docs: fix incorrect doc about cluster warming in CDS

### DIFF
--- a/api/XDS_PROTOCOL.md
+++ b/api/XDS_PROTOCOL.md
@@ -236,10 +236,10 @@ xDS updates can be pushed independently if no new clusters/routes/listeners
 are added or if it's acceptable to temporarily drop traffic during
 updates. Note that in case of LDS updates, the listeners will be warmed
 before they receive traffic, i.e. the dependent routes are fetched through
-RDS if configured. On the other hand, clusters are not warmed when
-adding/removing/updating clusters. Similarly, routes are not warmed --
-i.e., the management plane must ensure that clusters referenced by a route
-are in place, before pushing the updates for a rotue.
+RDS if configured. Clusters are warmed when adding/removing/updating
+clusters. On the other hand, routes are not warmed, i.e., the management
+plane must ensure that clusters referenced by a route are in place, before
+pushing the updates for a route.
 
 ### Aggregated Discovery Services (ADS)
 


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section 
in PULL_REQUESTS.md

*Description*: doc update
*Risk Level*: low
*Testing*:
*Docs Changes*: api/XDS_PROTOCOL.md
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
