### PR TITLE
docs: document request_timeout in version_history

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -48,6 +48,7 @@ Version history
   :ref:`use_data_plane_proto<envoy_api_field_config.ratelimit.v2.RateLimitServiceConfig.use_data_plane_proto>`
   boolean flag in the ratelimit configuration.
   Support for the legacy proto :repo:`source/common/ratelimit/ratelimit.proto` is deprecated and will be removed at the start of the 1.9.0 release cycle.
+* rest-api: added ability to set the :ref:`request timeout <envoy_api_field_core.ApiConfigSource.request_timeout>` for REST API requests.
 * router: added ability to set request/response headers at the :ref:`envoy_api_msg_route.Route` level.
 * tracing: added support for configuration of :ref:`tracing sampling
   <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.tracing>`.


### PR DESCRIPTION
*Description*:
This PR documents the proto change in #4006.

Signed-off-by: Venil Noronha <veniln@vmware.com>

*Risk Level*: Low
*Testing*: N/A
*Docs Changes*: N/A
*Release Notes*: Documented the proto change in `version_history.rst`.

/cc @mattklein123 
