### PR TITLE
Revert "tcp_proxy: convert TCP proxy to use TCP connection pool (#3938)"

### DIFF
--- a/include/envoy/tcp/conn_pool.h
+++ b/include/envoy/tcp/conn_pool.h
@@ -58,8 +58,7 @@ public:
 };
 
 /*
- * ConnectionData wraps a ClientConnection allocated to a caller. Open ClientConnections are
- * released back to the pool for re-use when their containing ConnectionData is destroyed.
+ * ConnectionData wraps a ClientConnection allocated to a caller.
  */
 class ConnectionData {
 public:
@@ -77,9 +76,13 @@ public:
    * @param callback the UpstreamCallbacks to invoke for upstream data
    */
   virtual void addUpstreamCallbacks(ConnectionPool::UpstreamCallbacks& callback) PURE;
-};
 
-typedef std::unique_ptr<ConnectionData> ConnectionDataPtr;
+  /**
+   * Release the connection after use. The connection should be closed first only if it is
+   * not viable for future use.
+   */
+  virtual void release() PURE;
+};
 
 /**
  * Pool callbacks invoked in the context of a newConnection() call, either synchronously or
@@ -99,17 +102,14 @@ public:
                              Upstream::HostDescriptionConstSharedPtr host) PURE;
 
   /**
-   * Called when a connection is available to process a request/response. Connections may be
-   * released back to the pool for re-use by resetting the ConnectionDataPtr. If the connection is
-   * no longer viable for reuse (e.g. due to some kind of protocol error), the underlying
-   * ClientConnection should be closed to prevent its reuse.
-   *
+   * Called when a connection is available to process a request/response. Recipients of connections
+   * must release the connection after use. They should only close the underlying ClientConnection
+   * if it is no longer viable for future requests.
    * @param conn supplies the connection data to use.
    * @param host supplies the description of the host that will carry the request. For logical
    *             connection pools the description may be different each time this is called.
    */
-  virtual void onPoolReady(ConnectionDataPtr&& conn,
-                           Upstream::HostDescriptionConstSharedPtr host) PURE;
+  virtual void onPoolReady(ConnectionData& conn, Upstream::HostDescriptionConstSharedPtr host) PURE;
 };
 
 /**

--- a/source/common/http/websocket/ws_handler_impl.cc
+++ b/source/common/http/websocket/ws_handler_impl.cc
@@ -131,8 +131,7 @@ void WsHandlerImpl::onConnectionSuccess() {
   // the connection pool. The current approach is a stop gap solution, where
   // we put the onus on the user to tell us if a route (and corresponding upstream)
   // is supposed to allow websocket upgrades or not.
-  Http1::ClientConnectionImpl upstream_http(upstream_conn_data_->connection(),
-                                            http_conn_callbacks_);
+  Http1::ClientConnectionImpl upstream_http(*upstream_connection_, http_conn_callbacks_);
   Http1::RequestStreamEncoderImpl upstream_request = Http1::RequestStreamEncoderImpl(upstream_http);
   upstream_request.encodeHeaders(request_headers_, false);
   ASSERT(state_ == ConnectState::PreConnect);

--- a/source/common/tcp/conn_pool.cc
+++ b/source/common/tcp/conn_pool.cc
@@ -46,10 +46,8 @@ void ConnPoolImpl::addDrainedCallback(DrainedCb cb) {
 
 void ConnPoolImpl::assignConnection(ActiveConn& conn, ConnectionPool::Callbacks& callbacks) {
   ASSERT(conn.wrapper_ == nullptr);
-  conn.wrapper_ = std::make_shared<ConnectionWrapper>(conn);
-
-  callbacks.onPoolReady(std::make_unique<ConnectionDataImpl>(conn.wrapper_),
-                        conn.real_host_description_);
+  conn.wrapper_ = std::make_unique<ConnectionWrapper>(conn);
+  callbacks.onPoolReady(*conn.wrapper_, conn.real_host_description_);
 }
 
 void ConnPoolImpl::checkForDrained() {
@@ -126,8 +124,6 @@ void ConnPoolImpl::onConnectionEvent(ActiveConn& conn, Network::ConnectionEvent 
           host_->cluster().stats().upstream_cx_destroy_remote_with_active_rq_.inc();
         }
         host_->cluster().stats().upstream_cx_destroy_with_active_rq_.inc();
-
-        conn.wrapper_->release(true);
       }
 
       removed = conn.removeFromList(busy_conns_);
@@ -263,29 +259,23 @@ ConnPoolImpl::ConnectionWrapper::ConnectionWrapper(ActiveConn& parent) : parent_
   parent_.parent_.host_->stats().rq_active_.inc();
 }
 
-Network::ClientConnection& ConnPoolImpl::ConnectionWrapper::connection() {
-  ASSERT(!released_);
-  return *parent_.conn_;
+ConnPoolImpl::ConnectionWrapper::~ConnectionWrapper() {
+  parent_.parent_.host_->cluster().stats().upstream_rq_active_.dec();
+  parent_.parent_.host_->stats().rq_active_.dec();
 }
+
+Network::ClientConnection& ConnPoolImpl::ConnectionWrapper::connection() { return *parent_.conn_; }
 
 void ConnPoolImpl::ConnectionWrapper::addUpstreamCallbacks(ConnectionPool::UpstreamCallbacks& cb) {
   ASSERT(!released_);
   callbacks_ = &cb;
 }
 
-void ConnPoolImpl::ConnectionWrapper::release(bool closed) {
-  // Allow multiple calls: connection close and destruction of ConnectionDataImplPtr will both
-  // result in this call.
-  if (!released_) {
-    released_ = true;
-    callbacks_ = nullptr;
-    if (!closed) {
-      parent_.parent_.onConnReleased(parent_);
-    }
-
-    parent_.parent_.host_->cluster().stats().upstream_rq_active_.dec();
-    parent_.parent_.host_->stats().rq_active_.dec();
-  }
+void ConnPoolImpl::ConnectionWrapper::release() {
+  ASSERT(!released_);
+  released_ = true;
+  callbacks_ = nullptr;
+  parent_.parent_.onConnReleased(parent_);
 }
 
 ConnPoolImpl::PendingRequest::PendingRequest(ConnPoolImpl& parent,

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -34,32 +34,21 @@ public:
 protected:
   struct ActiveConn;
 
-  struct ConnectionWrapper {
+  struct ConnectionWrapper : public ConnectionPool::ConnectionData {
     ConnectionWrapper(ActiveConn& parent);
+    ~ConnectionWrapper();
 
-    Network::ClientConnection& connection();
-    void addUpstreamCallbacks(ConnectionPool::UpstreamCallbacks& callbacks);
-    void release(bool closed);
+    // ConnectionPool::ConnectionData
+    Network::ClientConnection& connection() override;
+    void addUpstreamCallbacks(ConnectionPool::UpstreamCallbacks& callbacks) override;
+    void release() override;
 
     ActiveConn& parent_;
     ConnectionPool::UpstreamCallbacks* callbacks_{};
     bool released_{false};
   };
 
-  typedef std::shared_ptr<ConnectionWrapper> ConnectionWrapperSharedPtr;
-
-  struct ConnectionDataImpl : public ConnectionPool::ConnectionData {
-    ConnectionDataImpl(ConnectionWrapperSharedPtr wrapper) : wrapper_(wrapper) {}
-    ~ConnectionDataImpl() { wrapper_->release(false); }
-
-    // ConnectionPool::ConnectionData
-    Network::ClientConnection& connection() override { return wrapper_->connection(); }
-    void addUpstreamCallbacks(ConnectionPool::UpstreamCallbacks& callbacks) override {
-      wrapper_->addUpstreamCallbacks(callbacks);
-    };
-
-    ConnectionWrapperSharedPtr wrapper_;
-  };
+  typedef std::unique_ptr<ConnectionWrapper> ConnectionWrapperPtr;
 
   struct ConnReadFilter : public Network::ReadFilterBaseImpl {
     ConnReadFilter(ActiveConn& parent) : parent_(parent) {}
@@ -89,7 +78,7 @@ protected:
 
     ConnPoolImpl& parent_;
     Upstream::HostDescriptionConstSharedPtr real_host_description_;
-    ConnectionWrapperSharedPtr wrapper_;
+    ConnectionWrapperPtr wrapper_;
     Network::ClientConnectionPtr conn_;
     Event::TimerPtr connect_timer_;
     Stats::TimespanPtr conn_length_;

--- a/source/common/tcp_proxy/BUILD
+++ b/source/common/tcp_proxy/BUILD
@@ -24,7 +24,6 @@ envoy_cc_library(
         "//include/envoy/stats:stats_interface",
         "//include/envoy/stats:stats_macros",
         "//include/envoy/stats:timespan",
-        "//include/envoy/tcp:conn_pool_interface",
         "//include/envoy/upstream:cluster_manager_interface",
         "//include/envoy/upstream:upstream_interface",
         "//source/common/access_log:access_log_lib",

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -224,7 +224,7 @@ void Router::UpstreamRequest::start() {
 void Router::UpstreamRequest::resetStream() {
   if (conn_data_ != nullptr) {
     conn_data_->connection().close(Network::ConnectionCloseType::NoFlush);
-    conn_data_.reset();
+    conn_data_ = nullptr;
   }
 }
 
@@ -235,10 +235,10 @@ void Router::UpstreamRequest::onPoolFailure(Tcp::ConnectionPool::PoolFailureReas
   onResetStream(reason);
 }
 
-void Router::UpstreamRequest::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data,
+void Router::UpstreamRequest::onPoolReady(Tcp::ConnectionPool::ConnectionData& conn_data,
                                           Upstream::HostDescriptionConstSharedPtr host) {
   onUpstreamHostSelected(host);
-  conn_data_ = std::move(conn_data);
+  conn_data_ = &conn_data;
   conn_data_->addUpstreamCallbacks(parent_);
 
   conn_pool_handle_ = nullptr;
@@ -263,7 +263,10 @@ void Router::UpstreamRequest::onRequestComplete() { request_complete_ = true; }
 
 void Router::UpstreamRequest::onResponseComplete() {
   response_complete_ = true;
-  conn_data_.reset();
+  if (conn_data_ != nullptr) {
+    conn_data_->release();
+  }
+  conn_data_ = nullptr;
 }
 
 void Router::UpstreamRequest::onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host) {

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -112,7 +112,7 @@ private:
     // Tcp::ConnectionPool::Callbacks
     void onPoolFailure(Tcp::ConnectionPool::PoolFailureReason reason,
                        Upstream::HostDescriptionConstSharedPtr host) override;
-    void onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn,
+    void onPoolReady(Tcp::ConnectionPool::ConnectionData& conn,
                      Upstream::HostDescriptionConstSharedPtr host) override;
 
     void onRequestComplete();
@@ -127,7 +127,7 @@ private:
     const int32_t seq_id_;
 
     Tcp::ConnectionPool::Cancellable* conn_pool_handle_{};
-    Tcp::ConnectionPool::ConnectionDataPtr conn_data_;
+    Tcp::ConnectionPool::ConnectionData* conn_data_{};
     Upstream::HostDescriptionConstSharedPtr upstream_host_;
     TransportPtr transport_;
     ProtocolType proto_type_{ProtocolType::Auto};

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -153,8 +153,6 @@ TEST_F(NetworkFilterManagerTest, RateLimitAndTcpProxy) {
   InSequence s;
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   NiceMock<MockConnection> connection;
-  NiceMock<MockClientConnection> upstream_connection;
-  NiceMock<Tcp::ConnectionPool::MockInstance> conn_pool;
   FilterManagerImpl manager(connection, *this);
 
   std::string rl_json = R"EOF(
@@ -203,15 +201,21 @@ TEST_F(NetworkFilterManagerTest, RateLimitAndTcpProxy) {
 
   EXPECT_EQ(manager.initializeReadFilters(), true);
 
-  EXPECT_CALL(factory_context.cluster_manager_, tcpConnPoolForCluster("fake_cluster", _, _))
-      .WillOnce(Return(&conn_pool));
+  NiceMock<Network::MockClientConnection>* upstream_connection =
+      new NiceMock<Network::MockClientConnection>();
+  Upstream::MockHost::MockCreateConnectionData conn_info;
+  conn_info.connection_ = upstream_connection;
+  conn_info.host_description_ = Upstream::makeTestHost(
+      factory_context.cluster_manager_.thread_local_cluster_.cluster_.info_, "tcp://127.0.0.1:80");
+  EXPECT_CALL(factory_context.cluster_manager_, tcpConnForCluster_("fake_cluster", _))
+      .WillOnce(Return(conn_info));
 
   request_callbacks->complete(RateLimit::LimitStatus::OK);
 
-  conn_pool.poolReady(upstream_connection);
+  upstream_connection->raiseEvent(Network::ConnectionEvent::Connected);
 
   Buffer::OwnedImpl buffer("hello");
-  EXPECT_CALL(upstream_connection, write(BufferEqual(&buffer), _));
+  EXPECT_CALL(*upstream_connection, write(BufferEqual(&buffer), _));
   read_buffer_.add("hello");
   manager.onRead();
 }

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -34,9 +34,9 @@ namespace Tcp {
  * Mock callbacks used for conn pool testing.
  */
 struct ConnPoolCallbacks : public Tcp::ConnectionPool::Callbacks {
-  void onPoolReady(ConnectionPool::ConnectionDataPtr&& conn,
+  void onPoolReady(ConnectionPool::ConnectionData& conn,
                    Upstream::HostDescriptionConstSharedPtr host) override {
-    conn_data_ = std::move(conn);
+    conn_data_ = &conn;
     host_ = host;
     pool_ready_.ready();
   }
@@ -50,7 +50,7 @@ struct ConnPoolCallbacks : public Tcp::ConnectionPool::Callbacks {
 
   ReadyWatcher pool_failure_;
   ReadyWatcher pool_ready_;
-  ConnectionPool::ConnectionDataPtr conn_data_{};
+  ConnectionPool::ConnectionData* conn_data_{};
   absl::optional<ConnectionPool::PoolFailureReason> reason_;
   Upstream::HostDescriptionConstSharedPtr host_;
 };
@@ -232,7 +232,7 @@ struct ActiveTestConn {
 
   void expectNewConn() { EXPECT_CALL(callbacks_.pool_ready_, ready()); }
 
-  void releaseConn() { callbacks_.conn_data_.reset(); }
+  void releaseConn() { callbacks_.conn_data_->release(); }
 
   void verifyConn() {
     EXPECT_EQ(&callbacks_.conn_data_->connection(),
@@ -589,7 +589,7 @@ TEST_F(TcpConnPoolImplTest, DisconnectWhilePending) {
   conn_pool_.test_conns_[0].connection_->raiseEvent(Network::ConnectionEvent::Connected);
 
   EXPECT_CALL(conn_pool_, onConnReleasedForTest());
-  callbacks2.conn_data_.reset();
+  callbacks2.conn_data_->release();
 
   // Disconnect
   EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
@@ -625,11 +625,11 @@ TEST_F(TcpConnPoolImplTest, MaxConnections) {
   EXPECT_CALL(conn_pool_, onConnReleasedForTest());
   conn_pool_.expectEnableUpstreamReady();
   EXPECT_CALL(callbacks2.pool_ready_, ready());
-  callbacks.conn_data_.reset();
+  callbacks.conn_data_->release();
 
   conn_pool_.expectAndRunUpstreamReady();
   EXPECT_CALL(conn_pool_, onConnReleasedForTest());
-  callbacks2.conn_data_.reset();
+  callbacks2.conn_data_->release();
 
   // Cause the connection to go away.
   EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
@@ -657,7 +657,7 @@ TEST_F(TcpConnPoolImplTest, MaxRequestsPerConnection) {
 
   EXPECT_CALL(conn_pool_, onConnReleasedForTest());
   EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
-  callbacks.conn_data_.reset();
+  callbacks.conn_data_->release();
   dispatcher_.clearDeferredDeleteList();
 
   EXPECT_EQ(0U, cluster_->stats_.upstream_cx_destroy_with_active_rq_.value());
@@ -743,7 +743,7 @@ TEST_F(TcpConnPoolImplDestructorTest, TestReadyConnectionsAreClosed) {
   prepareConn();
 
   // Transition connection to ready list
-  callbacks_->conn_data_.reset();
+  callbacks_->conn_data_->release();
 
   EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -18,7 +18,6 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/server/mocks.h"
-#include "test/mocks/tcp/mocks.h"
 #include "test/mocks/upstream/host.h"
 #include "test/mocks/upstream/mocks.h"
 #include "test/test_common/printers.h"
@@ -26,7 +25,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using testing::Invoke;
 using testing::MatchesRegex;
 using testing::NiceMock;
 using testing::Return;
@@ -381,50 +379,53 @@ public:
     upstream_local_address_ = Network::Utility::resolveUrl("tcp://2.2.2.2:50000");
     upstream_remote_address_ = Network::Utility::resolveUrl("tcp://127.0.0.1:80");
     if (connections >= 1) {
+      {
+        testing::InSequence sequence;
+        for (uint32_t i = 0; i < connections; i++) {
+          connect_timers_.push_back(
+              new NiceMock<Event::MockTimer>(&filter_callbacks_.connection_.dispatcher_));
+          EXPECT_CALL(*connect_timers_.at(i), enableTimer(_));
+        }
+      }
+
       for (uint32_t i = 0; i < connections; i++) {
-        upstream_connections_.push_back(
-            std::make_unique<NiceMock<Network::MockClientConnection>>());
-        upstream_connection_data_.push_back(
-            std::make_unique<NiceMock<Tcp::ConnectionPool::MockConnectionData>>());
-        ON_CALL(*upstream_connection_data_.back(), connection())
-            .WillByDefault(ReturnRef(*upstream_connections_.back()));
+        upstream_connections_.push_back(new NiceMock<Network::MockClientConnection>());
         upstream_hosts_.push_back(std::make_shared<NiceMock<Upstream::MockHost>>());
-        conn_pool_handles_.push_back(
-            std::make_unique<NiceMock<Tcp::ConnectionPool::MockCancellable>>());
+        conn_infos_.push_back(Upstream::MockHost::MockCreateConnectionData());
+        conn_infos_.at(i).connection_ = upstream_connections_.back();
+        conn_infos_.at(i).host_description_ = upstream_hosts_.back();
 
         ON_CALL(*upstream_hosts_.at(i), cluster())
             .WillByDefault(ReturnPointee(
                 factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_));
         ON_CALL(*upstream_hosts_.at(i), address()).WillByDefault(Return(upstream_remote_address_));
         upstream_connections_.at(i)->local_address_ = upstream_local_address_;
+        EXPECT_CALL(*upstream_connections_.at(i), addReadFilter(_))
+            .WillOnce(SaveArg<0>(&upstream_read_filter_));
         EXPECT_CALL(*upstream_connections_.at(i), dispatcher())
             .WillRepeatedly(ReturnRef(filter_callbacks_.connection_.dispatcher_));
+        EXPECT_CALL(*upstream_connections_.at(i), enableHalfClose(true));
       }
     }
 
     {
       testing::InSequence sequence;
       for (uint32_t i = 0; i < connections; i++) {
-        EXPECT_CALL(factory_context_.cluster_manager_, tcpConnPoolForCluster("fake_cluster", _, _))
-            .WillOnce(Return(&conn_pool_))
-            .RetiresOnSaturation();
-        EXPECT_CALL(conn_pool_, newConnection(_))
-            .WillOnce(Invoke(
-                [=](Tcp::ConnectionPool::Callbacks& cb) -> Tcp::ConnectionPool::Cancellable* {
-                  conn_pool_callbacks_.push_back(&cb);
-                  return conn_pool_handles_.at(i).get();
-                }))
+        EXPECT_CALL(factory_context_.cluster_manager_, tcpConnForCluster_("fake_cluster", _))
+            .WillOnce(Return(conn_infos_.at(i)))
             .RetiresOnSaturation();
       }
-      EXPECT_CALL(factory_context_.cluster_manager_, tcpConnPoolForCluster("fake_cluster", _, _))
-          .WillRepeatedly(Return(nullptr));
+      EXPECT_CALL(factory_context_.cluster_manager_, tcpConnForCluster_("fake_cluster", _))
+          .WillRepeatedly(Return(Upstream::MockHost::MockCreateConnectionData()));
     }
 
     filter_.reset(new Filter(config_, factory_context_.cluster_manager_));
     EXPECT_CALL(filter_callbacks_.connection_, readDisable(true));
     EXPECT_CALL(filter_callbacks_.connection_, enableHalfClose(true));
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
-    EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
+    EXPECT_EQ(connections >= 1 ? Network::FilterStatus::Continue
+                               : Network::FilterStatus::StopIteration,
+              filter_->onNewConnection());
 
     EXPECT_EQ(absl::optional<uint64_t>(), filter_->computeHashKey());
     EXPECT_EQ(&filter_callbacks_.connection_, filter_->downstreamConnection());
@@ -434,37 +435,19 @@ public:
   void setup(uint32_t connections) { setup(connections, defaultConfig()); }
 
   void raiseEventUpstreamConnected(uint32_t conn_index) {
+    EXPECT_CALL(*connect_timers_.at(conn_index), disableTimer());
     EXPECT_CALL(filter_callbacks_.connection_, readDisable(false));
-    EXPECT_CALL(*upstream_connection_data_.at(conn_index), addUpstreamCallbacks(_))
-        .WillOnce(Invoke([=](Tcp::ConnectionPool::UpstreamCallbacks& cb) -> void {
-          upstream_callbacks_ = &cb;
-
-          // Simulate TCP conn pool upstream callbacks. This is safe because the TCP proxy never
-          // releases a connection so all events go to the same UpstreamCallbacks instance.
-          upstream_connections_.at(conn_index)->addConnectionCallbacks(cb);
-        }));
-    EXPECT_CALL(*upstream_connections_.at(conn_index), enableHalfClose(true));
-    conn_pool_callbacks_.at(conn_index)
-        ->onPoolReady(std::move(upstream_connection_data_.at(conn_index)),
-                      upstream_hosts_.at(conn_index));
-  }
-
-  void raiseEventUpstreamConnectFailed(uint32_t conn_index,
-                                       Tcp::ConnectionPool::PoolFailureReason reason) {
-    conn_pool_callbacks_.at(conn_index)->onPoolFailure(reason, upstream_hosts_.at(conn_index));
+    upstream_connections_.at(conn_index)->raiseEvent(Network::ConnectionEvent::Connected);
   }
 
   ConfigSharedPtr config_;
   NiceMock<Network::MockReadFilterCallbacks> filter_callbacks_;
   NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
   std::vector<std::shared_ptr<NiceMock<Upstream::MockHost>>> upstream_hosts_{};
-  std::vector<std::unique_ptr<NiceMock<Network::MockClientConnection>>> upstream_connections_{};
-  std::vector<std::unique_ptr<NiceMock<Tcp::ConnectionPool::MockConnectionData>>>
-      upstream_connection_data_{};
-  std::vector<Tcp::ConnectionPool::Callbacks*> conn_pool_callbacks_;
-  std::vector<std::unique_ptr<NiceMock<Tcp::ConnectionPool::MockCancellable>>> conn_pool_handles_;
-  NiceMock<Tcp::ConnectionPool::MockInstance> conn_pool_;
-  Tcp::ConnectionPool::UpstreamCallbacks* upstream_callbacks_;
+  std::vector<NiceMock<Network::MockClientConnection>*> upstream_connections_{};
+  std::vector<Upstream::MockHost::MockCreateConnectionData> conn_infos_;
+  Network::ReadFilterSharedPtr upstream_read_filter_;
+  std::vector<NiceMock<Event::MockTimer>*> connect_timers_;
   std::unique_ptr<Filter> filter_;
   StringViewSaver access_log_data_;
   Network::Address::InstanceConstSharedPtr upstream_local_address_;
@@ -478,65 +461,67 @@ TEST_F(TcpProxyTest, HalfCloseProxy) {
   EXPECT_CALL(filter_callbacks_.connection_, close(_)).Times(0);
   EXPECT_CALL(*upstream_connections_.at(0), close(_)).Times(0);
 
-  raiseEventUpstreamConnected(0);
-
   Buffer::OwnedImpl buffer("hello");
   EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer), true));
   filter_->onData(buffer, true);
 
+  raiseEventUpstreamConnected(0);
+
   Buffer::OwnedImpl response("world");
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response), true));
-  upstream_callbacks_->onUpstreamData(response, true);
+  upstream_read_filter_->onData(response, true);
 
   EXPECT_CALL(filter_callbacks_.connection_, close(_));
-  upstream_callbacks_->onEvent(Network::ConnectionEvent::RemoteClose);
+  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_,
+              deferredDelete_(upstream_connections_.at(0)));
+  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
 // Test that downstream is closed after an upstream LocalClose.
 TEST_F(TcpProxyTest, UpstreamLocalDisconnect) {
   setup(1);
 
-  raiseEventUpstreamConnected(0);
-
   Buffer::OwnedImpl buffer("hello");
   EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer), false));
   filter_->onData(buffer, false);
 
+  raiseEventUpstreamConnected(0);
+
   Buffer::OwnedImpl response("world");
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response), _));
-  upstream_callbacks_->onUpstreamData(response, false);
+  upstream_read_filter_->onData(response, false);
 
   EXPECT_CALL(filter_callbacks_.connection_, close(_));
-  upstream_callbacks_->onEvent(Network::ConnectionEvent::LocalClose);
+  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::LocalClose);
 }
 
 // Test that downstream is closed after an upstream RemoteClose.
 TEST_F(TcpProxyTest, UpstreamRemoteDisconnect) {
   setup(1);
 
-  raiseEventUpstreamConnected(0);
-
   Buffer::OwnedImpl buffer("hello");
   EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer), false));
   filter_->onData(buffer, false);
 
+  raiseEventUpstreamConnected(0);
+
   Buffer::OwnedImpl response("world");
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response), _));
-  upstream_callbacks_->onUpstreamData(response, false);
+  upstream_read_filter_->onData(response, false);
 
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
-  upstream_callbacks_->onEvent(Network::ConnectionEvent::RemoteClose);
+  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
 // Test that reconnect is attempted after a local connect failure
 TEST_F(TcpProxyTest, ConnectAttemptsUpstreamLocalFail) {
   envoy::config::filter::network::tcp_proxy::v2::TcpProxy config = defaultConfig();
   config.mutable_max_connect_attempts()->set_value(2);
-
   setup(2, config);
 
-  raiseEventUpstreamConnectFailed(0,
-                                  Tcp::ConnectionPool::PoolFailureReason::LocalConnectionFailure);
+  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_,
+              deferredDelete_(upstream_connections_.at(0)));
+  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::LocalClose);
   raiseEventUpstreamConnected(1);
 
   EXPECT_EQ(0U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
@@ -550,8 +535,9 @@ TEST_F(TcpProxyTest, ConnectAttemptsUpstreamRemoteFail) {
   config.mutable_max_connect_attempts()->set_value(2);
   setup(2, config);
 
-  raiseEventUpstreamConnectFailed(0,
-                                  Tcp::ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
+  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_,
+              deferredDelete_(upstream_connections_.at(0)));
+  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
   raiseEventUpstreamConnected(1);
 
   EXPECT_EQ(0U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
@@ -565,7 +551,8 @@ TEST_F(TcpProxyTest, ConnectAttemptsUpstreamTimeout) {
   config.mutable_max_connect_attempts()->set_value(2);
   setup(2, config);
 
-  raiseEventUpstreamConnectFailed(0, Tcp::ConnectionPool::PoolFailureReason::Timeout);
+  EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
+  connect_timers_.at(0)->callback_();
   raiseEventUpstreamConnected(1);
 
   EXPECT_EQ(0U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
@@ -579,21 +566,38 @@ TEST_F(TcpProxyTest, ConnectAttemptsLimit) {
   config.mutable_max_connect_attempts()->set_value(3);
   setup(3, config);
 
-  EXPECT_CALL(upstream_hosts_.at(0)->outlier_detector_,
-              putResult(Upstream::Outlier::Result::TIMEOUT));
-  EXPECT_CALL(upstream_hosts_.at(1)->outlier_detector_,
-              putResult(Upstream::Outlier::Result::CONNECT_FAILED));
-  EXPECT_CALL(upstream_hosts_.at(2)->outlier_detector_,
-              putResult(Upstream::Outlier::Result::CONNECT_FAILED));
-
-  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
+  {
+    testing::InSequence sequence;
+    EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
+    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_,
+                deferredDelete_(upstream_connections_.at(0)));
+    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_,
+                deferredDelete_(upstream_connections_.at(1)));
+    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_,
+                deferredDelete_(upstream_connections_.at(2)));
+    EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
+  }
 
   // Try both failure modes
-  raiseEventUpstreamConnectFailed(0, Tcp::ConnectionPool::PoolFailureReason::Timeout);
-  raiseEventUpstreamConnectFailed(1,
-                                  Tcp::ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
-  raiseEventUpstreamConnectFailed(2,
-                                  Tcp::ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
+  connect_timers_.at(0)->callback_();
+  upstream_connections_.at(1)->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  upstream_connections_.at(2)->raiseEvent(Network::ConnectionEvent::RemoteClose);
+
+  EXPECT_EQ(1U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
+                    .counter("upstream_cx_connect_timeout")
+                    .value());
+  EXPECT_EQ(2U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
+                    .counter("upstream_cx_connect_fail")
+                    .value());
+  EXPECT_EQ(1U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
+                    .counter("upstream_cx_connect_attempts_exceeded")
+                    .value());
+  EXPECT_EQ(0U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
+                    .counter("upstream_cx_overflow")
+                    .value());
+  EXPECT_EQ(0U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
+                    .counter("upstream_cx_no_successful_host")
+                    .value());
 }
 
 // Test that the tcp proxy sends the correct notifications to the outlier detector
@@ -604,12 +608,11 @@ TEST_F(TcpProxyTest, OutlierDetection) {
 
   EXPECT_CALL(upstream_hosts_.at(0)->outlier_detector_,
               putResult(Upstream::Outlier::Result::TIMEOUT));
-  raiseEventUpstreamConnectFailed(0, Tcp::ConnectionPool::PoolFailureReason::Timeout);
+  connect_timers_.at(0)->callback_();
 
   EXPECT_CALL(upstream_hosts_.at(1)->outlier_detector_,
               putResult(Upstream::Outlier::Result::CONNECT_FAILED));
-  raiseEventUpstreamConnectFailed(1,
-                                  Tcp::ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
+  upstream_connections_.at(1)->raiseEvent(Network::ConnectionEvent::RemoteClose);
 
   EXPECT_CALL(upstream_hosts_.at(2)->outlier_detector_,
               putResult(Upstream::Outlier::Result::SUCCESS));
@@ -619,21 +622,21 @@ TEST_F(TcpProxyTest, OutlierDetection) {
 TEST_F(TcpProxyTest, UpstreamDisconnectDownstreamFlowControl) {
   setup(1);
 
-  raiseEventUpstreamConnected(0);
-
   Buffer::OwnedImpl buffer("hello");
   EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer), _));
   filter_->onData(buffer, false);
 
+  raiseEventUpstreamConnected(0);
+
   Buffer::OwnedImpl response("world");
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response), _));
-  upstream_callbacks_->onUpstreamData(response, false);
+  upstream_read_filter_->onData(response, false);
 
   EXPECT_CALL(*upstream_connections_.at(0), readDisable(true));
   filter_callbacks_.connection_.runHighWatermarkCallbacks();
 
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
-  upstream_callbacks_->onEvent(Network::ConnectionEvent::RemoteClose);
+  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
 
   filter_callbacks_.connection_.runLowWatermarkCallbacks();
 }
@@ -641,15 +644,15 @@ TEST_F(TcpProxyTest, UpstreamDisconnectDownstreamFlowControl) {
 TEST_F(TcpProxyTest, DownstreamDisconnectRemote) {
   setup(1);
 
-  raiseEventUpstreamConnected(0);
-
   Buffer::OwnedImpl buffer("hello");
   EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer), _));
   filter_->onData(buffer, false);
 
+  raiseEventUpstreamConnected(0);
+
   Buffer::OwnedImpl response("world");
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response), _));
-  upstream_callbacks_->onUpstreamData(response, false);
+  upstream_read_filter_->onData(response, false);
 
   EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::FlushWrite));
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
@@ -658,15 +661,15 @@ TEST_F(TcpProxyTest, DownstreamDisconnectRemote) {
 TEST_F(TcpProxyTest, DownstreamDisconnectLocal) {
   setup(1);
 
-  raiseEventUpstreamConnected(0);
-
   Buffer::OwnedImpl buffer("hello");
   EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer), _));
   filter_->onData(buffer, false);
 
+  raiseEventUpstreamConnected(0);
+
   Buffer::OwnedImpl response("world");
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response), _));
-  upstream_callbacks_->onUpstreamData(response, false);
+  upstream_read_filter_->onData(response, false);
 
   EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::LocalClose);
@@ -675,8 +678,16 @@ TEST_F(TcpProxyTest, DownstreamDisconnectLocal) {
 TEST_F(TcpProxyTest, UpstreamConnectTimeout) {
   setup(1, accessLogConfig("%RESPONSE_FLAGS%"));
 
+  Buffer::OwnedImpl buffer("hello");
+  EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer), _));
+  filter_->onData(buffer, false);
+
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
-  raiseEventUpstreamConnectFailed(0, Tcp::ConnectionPool::PoolFailureReason::Timeout);
+  EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
+  connect_timers_.at(0)->callback_();
+  EXPECT_EQ(1U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
+                    .counter("upstream_cx_connect_timeout")
+                    .value());
 
   filter_.reset();
   EXPECT_EQ(access_log_data_, "UF");
@@ -733,9 +744,15 @@ TEST_F(TcpProxyTest, DisconnectBeforeData) {
 TEST_F(TcpProxyTest, UpstreamConnectFailure) {
   setup(1, accessLogConfig("%RESPONSE_FLAGS%"));
 
+  Buffer::OwnedImpl buffer("hello");
+  filter_->onData(buffer, false);
+
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
-  raiseEventUpstreamConnectFailed(0,
-                                  Tcp::ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
+  EXPECT_CALL(*connect_timers_.at(0), disableTimer());
+  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  EXPECT_EQ(1U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
+                    .counter("upstream_cx_connect_fail")
+                    .value());
 
   filter_.reset();
   EXPECT_EQ(access_log_data_, "UF");
@@ -752,6 +769,10 @@ TEST_F(TcpProxyTest, UpstreamConnectionLimit) {
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   filter_->initializeReadFilterCallbacks(filter_callbacks_);
   filter_->onNewConnection();
+
+  EXPECT_EQ(1U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
+                    .counter("upstream_cx_overflow")
+                    .value());
 
   filter_.reset();
   EXPECT_EQ(access_log_data_, "UO");
@@ -774,7 +795,7 @@ TEST_F(TcpProxyTest, IdleTimeout) {
 
   buffer.add("hello2");
   EXPECT_CALL(*idle_timer, enableTimer(std::chrono::milliseconds(1000)));
-  upstream_callbacks_->onUpstreamData(buffer, false);
+  upstream_read_filter_->onData(buffer, false);
 
   EXPECT_CALL(*idle_timer, enableTimer(std::chrono::milliseconds(1000)));
   filter_callbacks_.connection_.raiseBytesSentCallbacks(1);
@@ -813,13 +834,12 @@ TEST_F(TcpProxyTest, IdleTimerDisabledUpstreamClose) {
   raiseEventUpstreamConnected(0);
 
   EXPECT_CALL(*idle_timer, disableTimer());
-  upstream_callbacks_->onEvent(Network::ConnectionEvent::RemoteClose);
+  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
 // Test that access log fields %UPSTREAM_HOST% and %UPSTREAM_CLUSTER% are correctly logged.
 TEST_F(TcpProxyTest, AccessLogUpstreamHost) {
   setup(1, accessLogConfig("%UPSTREAM_HOST% %UPSTREAM_CLUSTER%"));
-  raiseEventUpstreamConnected(0);
   filter_.reset();
   EXPECT_EQ(access_log_data_, "127.0.0.1:80 fake_cluster");
 }
@@ -827,7 +847,6 @@ TEST_F(TcpProxyTest, AccessLogUpstreamHost) {
 // Test that access log field %UPSTREAM_LOCAL_ADDRESS% is correctly logged.
 TEST_F(TcpProxyTest, AccessLogUpstreamLocalAddress) {
   setup(1, accessLogConfig("%UPSTREAM_LOCAL_ADDRESS%"));
-  raiseEventUpstreamConnected(0);
   filter_.reset();
   EXPECT_EQ(access_log_data_, "2.2.2.2:50000");
 }
@@ -854,10 +873,10 @@ TEST_F(TcpProxyTest, AccessLogBytesRxTxDuration) {
   Buffer::OwnedImpl buffer("a");
   filter_->onData(buffer, false);
   Buffer::OwnedImpl response("bb");
-  upstream_callbacks_->onUpstreamData(response, false);
+  upstream_read_filter_->onData(response, false);
 
   std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  upstream_callbacks_->onEvent(Network::ConnectionEvent::RemoteClose);
+  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
   filter_.reset();
 
   EXPECT_THAT(access_log_data_,
@@ -870,8 +889,7 @@ TEST_F(TcpProxyTest, UpstreamFlushNoTimeout) {
   setup(1);
   raiseEventUpstreamConnected(0);
 
-  EXPECT_CALL(*upstream_connections_.at(0),
-              close(Network::ConnectionCloseType::FlushWrite))
+  EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::FlushWrite))
       .WillOnce(Return()); // Cancel default action of raising LocalClose
   EXPECT_CALL(*upstream_connections_.at(0), state())
       .WillOnce(Return(Network::Connection::State::Closing));
@@ -884,7 +902,7 @@ TEST_F(TcpProxyTest, UpstreamFlushNoTimeout) {
   upstream_connections_.at(0)->raiseBytesSentCallbacks(1);
 
   // Simulate flush complete.
-  upstream_callbacks_->onEvent(Network::ConnectionEvent::LocalClose);
+  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::LocalClose);
   EXPECT_EQ(1U, config_->stats().upstream_flush_total_.value());
   EXPECT_EQ(0U, config_->stats().upstream_flush_active_.value());
 }
@@ -901,8 +919,7 @@ TEST_F(TcpProxyTest, UpstreamFlushTimeoutConfigured) {
   EXPECT_CALL(*idle_timer, enableTimer(_));
   raiseEventUpstreamConnected(0);
 
-  EXPECT_CALL(*upstream_connections_.at(0),
-              close(Network::ConnectionCloseType::FlushWrite))
+  EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::FlushWrite))
       .WillOnce(Return()); // Cancel default action of raising LocalClose
   EXPECT_CALL(*upstream_connections_.at(0), state())
       .WillOnce(Return(Network::Connection::State::Closing));
@@ -916,7 +933,7 @@ TEST_F(TcpProxyTest, UpstreamFlushTimeoutConfigured) {
 
   // Simulate flush complete.
   EXPECT_CALL(*idle_timer, disableTimer());
-  upstream_callbacks_->onEvent(Network::ConnectionEvent::LocalClose);
+  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::LocalClose);
   EXPECT_EQ(1U, config_->stats().upstream_flush_total_.value());
   EXPECT_EQ(0U, config_->stats().upstream_flush_active_.value());
   EXPECT_EQ(0U, config_->stats().idle_timeout_.value());
@@ -933,8 +950,7 @@ TEST_F(TcpProxyTest, UpstreamFlushTimeoutExpired) {
   EXPECT_CALL(*idle_timer, enableTimer(_));
   raiseEventUpstreamConnected(0);
 
-  EXPECT_CALL(*upstream_connections_.at(0),
-              close(Network::ConnectionCloseType::FlushWrite))
+  EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::FlushWrite))
       .WillOnce(Return()); // Cancel default action of raising LocalClose
   EXPECT_CALL(*upstream_connections_.at(0), state())
       .WillOnce(Return(Network::Connection::State::Closing));
@@ -956,8 +972,7 @@ TEST_F(TcpProxyTest, UpstreamFlushReceiveUpstreamData) {
   setup(1);
   raiseEventUpstreamConnected(0);
 
-  EXPECT_CALL(*upstream_connections_.at(0),
-              close(Network::ConnectionCloseType::FlushWrite))
+  EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::FlushWrite))
       .WillOnce(Return()); // Cancel default action of raising LocalClose
   EXPECT_CALL(*upstream_connections_.at(0), state())
       .WillOnce(Return(Network::Connection::State::Closing));
@@ -969,7 +984,7 @@ TEST_F(TcpProxyTest, UpstreamFlushReceiveUpstreamData) {
   // Send some bytes; no timeout configured so this should be a no-op (not a crash).
   Buffer::OwnedImpl buffer("a");
   EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
-  upstream_callbacks_->onUpstreamData(buffer, false);
+  upstream_read_filter_->onData(buffer, false);
 }
 
 class TcpProxyRoutingTest : public testing::Test {
@@ -1034,7 +1049,7 @@ TEST_F(TcpProxyRoutingTest, RoutableConnection) {
   connection_.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 9999);
 
   // Expect filter to try to open a connection to specified cluster.
-  EXPECT_CALL(factory_context_.cluster_manager_, tcpConnPoolForCluster("fake_cluster", _, _));
+  EXPECT_CALL(factory_context_.cluster_manager_, tcpConnForCluster_("fake_cluster", _));
 
   filter_->onNewConnection();
 

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -79,6 +79,9 @@ public:
     route_ = new NiceMock<MockRoute>();
     route_ptr_.reset(route_);
 
+    host_ = new NiceMock<Upstream::MockHostDescription>();
+    host_ptr_.reset(host_);
+
     router_.reset(new Router(context_.clusterManager()));
 
     EXPECT_EQ(nullptr, router_->downstreamConnection());
@@ -95,8 +98,16 @@ public:
     EXPECT_CALL(*route_, routeEntry()).WillOnce(Return(&route_entry_));
     EXPECT_CALL(route_entry_, clusterName()).WillRepeatedly(ReturnRef(cluster_name_));
 
+    EXPECT_CALL(context_.cluster_manager_.tcp_conn_pool_, newConnection(_))
+        .WillOnce(
+            Invoke([&](Tcp::ConnectionPool::Callbacks& cb) -> Tcp::ConnectionPool::Cancellable* {
+              conn_pool_callbacks_ = &cb;
+              return &handle_;
+            }));
+
     EXPECT_EQ(ThriftFilters::FilterStatus::StopIteration,
               router_->messageBegin(method_name_, msg_type_, seq_id_));
+    EXPECT_NE(nullptr, conn_pool_callbacks_);
 
     NiceMock<Network::MockClientConnection> connection;
     EXPECT_CALL(callbacks_, connection()).WillRepeatedly(Return(&connection));
@@ -109,7 +120,7 @@ public:
   }
 
   void connectUpstream() {
-    EXPECT_CALL(*context_.cluster_manager_.tcp_conn_pool_.connection_data_, addUpstreamCallbacks(_))
+    EXPECT_CALL(conn_data_, addUpstreamCallbacks(_))
         .WillOnce(Invoke([&](Tcp::ConnectionPool::UpstreamCallbacks& cb) -> void {
           upstream_callbacks_ = &cb;
         }));
@@ -124,8 +135,7 @@ public:
     EXPECT_CALL(*protocol_, writeMessageBegin(_, method_name_, msg_type_, seq_id_));
 
     EXPECT_CALL(callbacks_, continueDecoding());
-
-    context_.cluster_manager_.tcp_conn_pool_.poolReady(upstream_connection_);
+    conn_pool_callbacks_->onPoolReady(conn_data_, host_ptr_);
     EXPECT_NE(nullptr, upstream_callbacks_);
   }
 
@@ -184,10 +194,10 @@ public:
   void completeRequest() {
     EXPECT_CALL(*protocol_, writeMessageEnd(_));
     EXPECT_CALL(*transport_, encodeFrame(_, _));
-    EXPECT_CALL(upstream_connection_, write(_, false));
+    EXPECT_CALL(conn_data_.connection_, write(_, false));
 
     if (msg_type_ == MessageType::Oneway) {
-      EXPECT_CALL(context_.cluster_manager_.tcp_conn_pool_, released(Ref(upstream_connection_)));
+      EXPECT_CALL(conn_data_, release());
     }
 
     EXPECT_EQ(ThriftFilters::FilterStatus::Continue, router_->messageEnd());
@@ -203,7 +213,7 @@ public:
     upstream_callbacks_->onUpstreamData(buffer, false);
 
     EXPECT_CALL(callbacks_, upstreamData(Ref(buffer))).WillOnce(Return(true));
-    EXPECT_CALL(context_.cluster_manager_.tcp_conn_pool_, released(Ref(upstream_connection_)));
+    EXPECT_CALL(conn_data_, release());
     upstream_callbacks_->onUpstreamData(buffer, false);
   }
 
@@ -226,6 +236,8 @@ public:
   NiceMock<Upstream::MockHostDescription>* host_{};
 
   RouteConstSharedPtr route_ptr_;
+  Upstream::HostDescriptionConstSharedPtr host_ptr_;
+
   std::unique_ptr<Router> router_;
 
   std::string cluster_name_{"cluster"};
@@ -234,8 +246,10 @@ public:
   MessageType msg_type_{MessageType::Call};
   int32_t seq_id_{1};
 
+  NiceMock<Tcp::ConnectionPool::MockCancellable> handle_;
+  NiceMock<Tcp::ConnectionPool::MockConnectionData> conn_data_;
+  Tcp::ConnectionPool::Callbacks* conn_pool_callbacks_{};
   Tcp::ConnectionPool::UpstreamCallbacks* upstream_callbacks_{};
-  NiceMock<Network::MockClientConnection> upstream_connection_;
 };
 
 class ThriftRouterTest : public ThriftRouterTestBase, public Test {
@@ -276,8 +290,8 @@ TEST_F(ThriftRouterTest, PoolRemoteConnectionFailure) {
         EXPECT_EQ(AppExceptionType::InternalError, app_ex->type_);
         EXPECT_THAT(app_ex->error_message_, ContainsRegex(".*connection failure.*"));
       }));
-  context_.cluster_manager_.tcp_conn_pool_.poolFailure(
-      Tcp::ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
+  conn_pool_callbacks_->onPoolFailure(
+      Tcp::ConnectionPool::PoolFailureReason::RemoteConnectionFailure, host_ptr_);
 }
 
 TEST_F(ThriftRouterTest, PoolLocalConnectionFailure) {
@@ -294,8 +308,8 @@ TEST_F(ThriftRouterTest, PoolLocalConnectionFailure) {
         EXPECT_EQ(AppExceptionType::InternalError, app_ex->type_);
         EXPECT_THAT(app_ex->error_message_, ContainsRegex(".*connection failure.*"));
       }));
-  context_.cluster_manager_.tcp_conn_pool_.poolFailure(
-      Tcp::ConnectionPool::PoolFailureReason::LocalConnectionFailure);
+  conn_pool_callbacks_->onPoolFailure(
+      Tcp::ConnectionPool::PoolFailureReason::LocalConnectionFailure, host_ptr_);
 }
 
 TEST_F(ThriftRouterTest, PoolTimeout) {
@@ -312,8 +326,7 @@ TEST_F(ThriftRouterTest, PoolTimeout) {
         EXPECT_EQ(AppExceptionType::InternalError, app_ex->type_);
         EXPECT_THAT(app_ex->error_message_, ContainsRegex(".*connection failure.*"));
       }));
-  context_.cluster_manager_.tcp_conn_pool_.poolFailure(
-      Tcp::ConnectionPool::PoolFailureReason::Timeout);
+  conn_pool_callbacks_->onPoolFailure(Tcp::ConnectionPool::PoolFailureReason::Timeout, host_ptr_);
 }
 
 TEST_F(ThriftRouterTest, PoolOverflowFailure) {
@@ -330,8 +343,7 @@ TEST_F(ThriftRouterTest, PoolOverflowFailure) {
         EXPECT_EQ(AppExceptionType::InternalError, app_ex->type_);
         EXPECT_THAT(app_ex->error_message_, ContainsRegex(".*too many connections.*"));
       }));
-  context_.cluster_manager_.tcp_conn_pool_.poolFailure(
-      Tcp::ConnectionPool::PoolFailureReason::Overflow);
+  conn_pool_callbacks_->onPoolFailure(Tcp::ConnectionPool::PoolFailureReason::Overflow, host_ptr_);
 }
 
 TEST_F(ThriftRouterTest, NoRoute) {
@@ -428,7 +440,7 @@ TEST_F(ThriftRouterTest, TruncatedResponse) {
 
   EXPECT_CALL(callbacks_, startUpstreamResponse(TransportType::Framed, ProtocolType::Binary));
   EXPECT_CALL(callbacks_, upstreamData(Ref(buffer))).WillOnce(Return(false));
-  EXPECT_CALL(context_.cluster_manager_.tcp_conn_pool_, released(Ref(upstream_connection_)));
+  EXPECT_CALL(conn_data_, release());
   EXPECT_CALL(callbacks_, resetDownstreamConnection());
 
   upstream_callbacks_->onUpstreamData(buffer, true);
@@ -450,7 +462,7 @@ TEST_F(ThriftRouterTest, UpstreamDataTriggersReset) {
         router_->resetUpstreamConnection();
         return true;
       }));
-  EXPECT_CALL(upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(conn_data_.connection_, close(Network::ConnectionCloseType::NoFlush));
 
   upstream_callbacks_->onUpstreamData(buffer, true);
   destroyRouter();
@@ -466,7 +478,7 @@ TEST_F(ThriftRouterTest, UnexpectedRouterDestroy) {
   initializeRouter();
   startRequest(MessageType::Call);
   connectUpstream();
-  EXPECT_CALL(upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(conn_data_.connection_, close(Network::ConnectionCloseType::NoFlush));
   destroyRouter();
 }
 

--- a/test/integration/tcp_conn_pool_integration_test.cc
+++ b/test/integration/tcp_conn_pool_integration_test.cc
@@ -52,9 +52,9 @@ private:
       ASSERT(false);
     }
 
-    void onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn,
+    void onPoolReady(Tcp::ConnectionPool::ConnectionData& conn,
                      Upstream::HostDescriptionConstSharedPtr) override {
-      upstream_ = std::move(conn);
+      upstream_ = &conn;
 
       upstream_->addUpstreamCallbacks(*this);
       upstream_->connection().write(data_, false);
@@ -67,7 +67,7 @@ private:
       Network::Connection& downstream = parent_.read_callbacks_->connection();
       downstream.write(data, false);
 
-      upstream_.reset();
+      upstream_->release();
     }
     void onEvent(Network::ConnectionEvent) override {}
     void onAboveWriteBufferHighWatermark() override {}
@@ -75,7 +75,7 @@ private:
 
     TestFilter& parent_;
     Buffer::OwnedImpl data_;
-    Tcp::ConnectionPool::ConnectionDataPtr upstream_;
+    Tcp::ConnectionPool::ConnectionData* upstream_;
   };
 
   Upstream::ClusterManager& cluster_manager_;

--- a/test/mocks/tcp/mocks.h
+++ b/test/mocks/tcp/mocks.h
@@ -44,10 +44,9 @@ public:
   // Tcp::ConnectionPool::ConnectionData
   MOCK_METHOD0(connection, Network::ClientConnection&());
   MOCK_METHOD1(addUpstreamCallbacks, void(ConnectionPool::UpstreamCallbacks&));
+  MOCK_METHOD0(release, void());
 
-  // If set, invoked in ~MockConnectionData, which indicates that the connection pool
-  // caller has relased a connection.
-  std::function<void()> release_callback_;
+  NiceMock<Network::MockClientConnection> connection_;
 };
 
 class MockInstance : public Instance {
@@ -62,18 +61,14 @@ public:
 
   MockCancellable* newConnectionImpl(Callbacks& cb);
   void poolFailure(PoolFailureReason reason);
-  void poolReady(Network::MockClientConnection& conn);
-
-  // Invoked when connection_data_, having been assigned via poolReady is released.
-  MOCK_METHOD1(released, void(Network::MockClientConnection&));
+  void poolReady();
 
   std::list<NiceMock<MockCancellable>> handles_;
   std::list<Callbacks*> callbacks_;
 
   std::shared_ptr<NiceMock<Upstream::MockHostDescription>> host_{
       new NiceMock<Upstream::MockHostDescription>()};
-  std::unique_ptr<NiceMock<MockConnectionData>> connection_data_{
-      new NiceMock<MockConnectionData>()};
+  NiceMock<MockConnectionData> connection_data_;
 };
 
 } // namespace ConnectionPool


### PR DESCRIPTION
Signed-off-by: Daniel Hochman <danielhochman@users.noreply.github.com>

This reverts commit 028387a3b0746deaf011ea50104692dfbb8b8d2f, #3938.

After this PR was deployed to production, our instances would periodically experience a sharp and sustained uptick in CPU.

![screenshot from 2018-08-03 10-20-36](https://user-images.githubusercontent.com/4712430/43656335-eb312360-9706-11e8-9add-e0feaaa8c5b4.png)

I removed traffic from one of the instances. It continued to consume 50% CPU. I took a perf capture to get the call stack which pointed me to this PR in the diff.

![image](https://user-images.githubusercontent.com/4712430/43656466-59bb0940-9707-11e8-9321-ef76cfdb294d.png)

For fun I also generated a flame graph. ![flame graph](https://cdn.rawgit.com/danielhochman/1dffab15b4957f26b539ec9a5b1e108f/raw/23bb387ac6d2cc126f5022db9b5e4ac975e2ecc3/flame.svg)