### PR TITLE
[WIP] bazel: use GCS remote cache

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -9,6 +9,7 @@ if [[ "$1" == "fix_format" || "$1" == "check_format" ]]; then
   build_setup_args="-nofetch"
 fi
 
+. "$(dirname "$0")"/setup_gcs_cache.sh
 . "$(dirname "$0")"/build_setup.sh $build_setup_args
 
 echo "building using ${NUM_CPUS} CPUs"

--- a/ci/mac_ci_steps.sh
+++ b/ci/mac_ci_steps.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-BAZEL_BUILD_OPTIONS="--curses=no --show_task_finish --verbose_failures"
+. "$(dirname "$0")"/setup_gcs_cache.sh
+
+BAZEL_BUILD_OPTIONS="--curses=no --show_task_finish --verbose_failures ${BAZEL_BUILD_EXTRA_OPTIONS}"
 # TODO(zuercher): remove --flaky_test_attempts when https://github.com/envoyproxy/envoy/issues/2428
 # is resolved.
 BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_output=all --flaky_test_attempts=integration@2"

--- a/ci/setup_gcs_cache.sh
+++ b/ci/setup_gcs_cache.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+gcp_service_account_cleanup() {
+  echo "Deleting service account key file..."
+  rm -rf /tmp/gcp_service_account.json
+}
+
+if [[ ! -z "${GCP_SERVICE_ACCOUNT_KEY}" && ! -z "${BAZEL_REMOTE_CACHE}" ]]; then
+  echo "${GCP_SERVICE_ACCOUNT_KEY}" | base64 --decode > /tmp/gcp_service_account.json
+  trap gcp_service_account_cleanup EXIT
+
+  export BAZEL_BUILD_EXTRA_OPTIONS="${BAZEL_BUILD_EXTRA_OPTIONS} \
+    --remote_http_cache=${BAZEL_REMOTE_CACHE} --google_credentials=/tmp/gcp_service_account.json"
+  echo "Set up bazel HTTP cache at ${BAZEL_REMOTE_CACHE}."
+else
+  echo "No GCP service account key or remote cache bucket is set, skipping setup remote cache."
+fi


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <zlizan@google.com>

Partially addresses #3741 

*Description*:
Use GCS remote cache for CI builds when key is provided.

*Risk Level*: Low
*Testing*: CI
*Docs Changes*:
*Release Notes*: