### PR TITLE
Remove dep to stats_impl

### DIFF
--- a/test/common/http/http2/BUILD
+++ b/test/common/http/http2/BUILD
@@ -24,7 +24,6 @@ envoy_cc_fuzz_test(
         ":codec_impl_fuzz_proto",
         "//source/common/http:header_map_lib",
         "//source/common/http/http2:codec_lib",
-        "//source/common/stats:stats_lib",
         "//test/mocks/http:http_mocks",
         "//test/mocks/network:network_mocks",
     ],

--- a/test/common/http/http2/codec_impl_fuzz_test.cc
+++ b/test/common/http/http2/codec_impl_fuzz_test.cc
@@ -11,7 +11,6 @@
 #include "common/common/logger.h"
 #include "common/http/header_map_impl.h"
 #include "common/http/http2/codec_impl.h"
-#include "common/stats/stats_impl.h"
 
 #include "test/common/http/http2/codec_impl_fuzz.pb.h"
 #include "test/fuzz/fuzz_runner.h"


### PR DESCRIPTION
*Description*:
It seems stats_impl.* is removed since https://github.com/envoyproxy/envoy/commit/1f11661678a4dc25a2b9e279f340f8804aafbf3d

```
external/envoy/test/common/http/http2/codec_impl_fuzz_test.cc:14:10: fatal error: 'common/stats/stats_impl.h' file not found
#include "common/stats/stats_impl.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```


*Risk Level*: Low
*Testing*: Existing
*Docs Changes*: N/A
*Release Notes*: N/A

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>