### PR TITLE
Fix bug in `HostSetImpl::chooseLocality()`

### DIFF
--- a/source/common/upstream/edf_scheduler.h
+++ b/source/common/upstream/edf_scheduler.h
@@ -65,6 +65,12 @@ public:
     ASSERT(queue_.top().deadline_ >= current_time_);
   }
 
+  /**
+   * Implements empty() on the internal queue. Does not check for expired elements.
+   * @return bool whether or not the internal queue is empty.
+   */
+  bool empty() { return queue_.empty(); }
+
 private:
   struct EdfEntry {
     double deadline_;

--- a/source/common/upstream/edf_scheduler.h
+++ b/source/common/upstream/edf_scheduler.h
@@ -69,7 +69,7 @@ public:
    * Implements empty() on the internal queue. Does not attempt to discard expired elements.
    * @return bool whether or not the internal queue is empty.
    */
-  bool empty() { return queue_.empty(); }
+  bool empty() const { return queue_.empty(); }
 
 private:
   struct EdfEntry {

--- a/source/common/upstream/edf_scheduler.h
+++ b/source/common/upstream/edf_scheduler.h
@@ -66,31 +66,10 @@ public:
   }
 
   /**
-   * Implements empty() on the internal queue, discarding expired elements along the way.
+   * Implements empty() on the internal queue. Does not attempt to discard expired elements.
    * @return bool whether or not the internal queue is empty.
    */
-  bool empty() {
-    EDF_TRACE("Queue empty check: queue_.size()={}, current_time_={}.", queue_.size(),
-              current_time_);
-    while (true) {
-      if (queue_.empty()) {
-        EDF_TRACE("Queue is empty.");
-        return true;
-      }
-      const EdfEntry& edf_entry = queue_.top();
-      // Entry has been removed, let's see if there's another one.
-      if (edf_entry.entry_.expired()) {
-        EDF_TRACE("Entry has expired, continue seeking.");
-        queue_.pop();
-        continue;
-      }
-      std::shared_ptr<C> ret{edf_entry.entry_};
-      ASSERT(edf_entry.deadline_ >= current_time_);
-      current_time_ = edf_entry.deadline_;
-      EDF_TRACE("Found {}, current_time_={}.", static_cast<const void*>(ret.get()), current_time_);
-      return false;
-    }
-  }
+  bool empty() { return queue_.empty(); }
 
 private:
   struct EdfEntry {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -183,10 +183,10 @@ void HostSetImpl::updateHosts(HostVectorConstSharedPtr hosts,
   healthy_hosts_per_locality_ = std::move(healthy_hosts_per_locality);
   locality_weights_ = std::move(locality_weights);
   // Rebuild the locality scheduler by computing the effective weight of each
-  // locality in this priority. No scheduler is built if we don't have locality weights
-  // (i.e. not using EDS) or when there are 0 healthy hosts in this priority.
+  // locality in this priority. The scheduler is reset by default, and is rebuilt only if we have
+  // locality weights (i.e. using EDS) and there is at least one healthy host in this priority.
   //
-  // We omit building a scheduler when there are zero healhty hosts in the priority as all
+  // We omit building a scheduler when there are zero healthy hosts in the priority as all
   // the localities will have zero effective weight. At selection time, we'll only ever try
   // to select a host from such a priority if all priorities have zero healthy hosts. At
   // that point we'll rely on other mechanisms such as panic mode to select a host,
@@ -197,6 +197,7 @@ void HostSetImpl::updateHosts(HostVectorConstSharedPtr hosts,
   // could just update locality_weight_ without rebuilding. Similar to how host
   // level WRR works, we would age out the existing entries via picks and lazily
   // apply the new weights.
+  locality_scheduler_ = nullptr;
   if (hosts_per_locality_ != nullptr && locality_weights_ != nullptr &&
       !locality_weights_->empty() && !healthy_hosts_->empty()) {
     locality_scheduler_ = std::make_unique<EdfScheduler<LocalityEntry>>();
@@ -208,11 +209,10 @@ void HostSetImpl::updateHosts(HostVectorConstSharedPtr hosts,
         locality_scheduler_->add(effective_weight, locality_entries_.back());
       }
     }
+    // If all effective weights were zero, reset the scheduler.
     if (locality_scheduler_->empty()) {
       locality_scheduler_ = nullptr;
     }
-  } else {
-    locality_scheduler_ = nullptr;
   }
   runUpdateCallbacks(hosts_added, hosts_removed);
 }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -215,7 +215,7 @@ void HostSetImpl::updateHosts(HostVectorConstSharedPtr hosts,
 }
 
 absl::optional<uint32_t> HostSetImpl::chooseLocality() {
-  if (locality_scheduler_ == nullptr) {
+  if (locality_scheduler_ == nullptr || locality_scheduler_->empty()) {
     return {};
   }
   const std::shared_ptr<LocalityEntry> locality = locality_scheduler_->pick();

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -208,6 +208,9 @@ void HostSetImpl::updateHosts(HostVectorConstSharedPtr hosts,
         locality_scheduler_->add(effective_weight, locality_entries_.back());
       }
     }
+    if (locality_scheduler_->empty()) {
+      locality_scheduler_ = nullptr;
+    }
   } else {
     locality_scheduler_ = nullptr;
   }
@@ -215,7 +218,7 @@ void HostSetImpl::updateHosts(HostVectorConstSharedPtr hosts,
 }
 
 absl::optional<uint32_t> HostSetImpl::chooseLocality() {
-  if (locality_scheduler_ == nullptr || locality_scheduler_->empty()) {
+  if (locality_scheduler_ == nullptr) {
     return {};
   }
   const std::shared_ptr<LocalityEntry> locality = locality_scheduler_->pick();

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1629,7 +1629,7 @@ TEST_F(HostSetImplLocalityTest, AllUnhealthy) {
   EXPECT_FALSE(host_set_.chooseLocality().has_value());
 }
 
-// When all locality weights are the same we have unweighted RR behavior.
+// When all locality weights are zero we should fail to select a locality.
 TEST_F(HostSetImplLocalityTest, AllZeroWeights) {
   HostsPerLocalitySharedPtr hosts_per_locality = makeHostsPerLocality({{hosts_[0]}, {hosts_[1]}});
   LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{0, 0}};

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1630,6 +1630,16 @@ TEST_F(HostSetImplLocalityTest, AllUnhealthy) {
 }
 
 // When all locality weights are the same we have unweighted RR behavior.
+TEST_F(HostSetImplLocalityTest, AllZeroWeights) {
+  HostsPerLocalitySharedPtr hosts_per_locality = makeHostsPerLocality({{hosts_[0]}, {hosts_[1]}});
+  LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{0, 0}};
+  auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
+  host_set_.updateHosts(hosts, hosts, hosts_per_locality, hosts_per_locality, locality_weights, {},
+                        {});
+  EXPECT_FALSE(host_set_.chooseLocality().has_value());
+}
+
+// When all locality weights are the same we have unweighted RR behavior.
 TEST_F(HostSetImplLocalityTest, Unweighted) {
   HostsPerLocalitySharedPtr hosts_per_locality =
       makeHostsPerLocality({{hosts_[0]}, {hosts_[1]}, {hosts_[2]}});


### PR DESCRIPTION
*Description*: There is a bug in `HostSetImpl::chooseLocality()` where the pick()d locality could be nullptr. (and Envoy will crash on nullptr->access() as a result). 

This is because we won't build a schedule if there are no weighted localities, but we will build a schedule (albiet an empty one) if there are localities with weight zero. This PR introduces an `EdfScheduler<C>::empty()` fn which essentially walks thru the same logic as `EdfScheduler<C>::pick()`, except it does not pop the `C` at the end. This has the added benefit(?) of pruning expired weakptrs along the way, although it does not promise to prune all of them.

*Risk Level*: Low
*Testing*: Wrote new now-passing test under `//test/common/upstream:upstream_impl_test`.
