### PR TITLE
collect metrics for RBAC shadow policy

### DIFF
--- a/source/extensions/filters/common/rbac/engine.h
+++ b/source/extensions/filters/common/rbac/engine.h
@@ -28,7 +28,7 @@ public:
    */
   virtual bool allowed(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
                        const envoy::api::v2::core::Metadata& metadata,
-                       std::string& effectivePolicyID) const PURE;
+                       std::string& effective_policyID) const PURE;
 };
 
 } // namespace RBAC

--- a/source/extensions/filters/common/rbac/engine.h
+++ b/source/extensions/filters/common/rbac/engine.h
@@ -25,6 +25,7 @@ public:
    * @param headers    the headers of the incoming request used to identify the action/principal. An
    *                   empty map should be used if there are no headers available.
    * @param metadata   the metadata with additional information about the action/principal.
+   * @param effective_policy_id  the matching policy's ID to identity the source of the allow/deny.
    */
   virtual bool allowed(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
                        const envoy::api::v2::core::Metadata& metadata,

--- a/source/extensions/filters/common/rbac/engine.h
+++ b/source/extensions/filters/common/rbac/engine.h
@@ -29,7 +29,7 @@ public:
    */
   virtual bool allowed(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
                        const envoy::api::v2::core::Metadata& metadata,
-                       std::string& effective_policy_id) const PURE;
+                       std::string* effective_policy_id) const PURE;
 };
 
 } // namespace RBAC

--- a/source/extensions/filters/common/rbac/engine.h
+++ b/source/extensions/filters/common/rbac/engine.h
@@ -25,7 +25,8 @@ public:
    * @param headers    the headers of the incoming request used to identify the action/principal. An
    *                   empty map should be used if there are no headers available.
    * @param metadata   the metadata with additional information about the action/principal.
-   * @param effective_policy_id  the matching policy's ID to identity the source of the allow/deny.
+   * @param effective_policy_id  it will be filled by the matching policy's ID,
+   *                   which is used to identity the source of the allow/deny.
    */
   virtual bool allowed(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
                        const envoy::api::v2::core::Metadata& metadata,

--- a/source/extensions/filters/common/rbac/engine.h
+++ b/source/extensions/filters/common/rbac/engine.h
@@ -28,7 +28,7 @@ public:
    */
   virtual bool allowed(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
                        const envoy::api::v2::core::Metadata& metadata,
-                       std::string& effective_policyID) const PURE;
+                       std::string& effective_policy_id) const PURE;
 };
 
 } // namespace RBAC

--- a/source/extensions/filters/common/rbac/engine.h
+++ b/source/extensions/filters/common/rbac/engine.h
@@ -27,7 +27,8 @@ public:
    * @param metadata   the metadata with additional information about the action/principal.
    */
   virtual bool allowed(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
-                       const envoy::api::v2::core::Metadata& metadata) const PURE;
+                       const envoy::api::v2::core::Metadata& metadata,
+                       std::string& effectivePolicyID) const PURE;
 };
 
 } // namespace RBAC

--- a/source/extensions/filters/common/rbac/engine_impl.cc
+++ b/source/extensions/filters/common/rbac/engine_impl.cc
@@ -18,13 +18,15 @@ RoleBasedAccessControlEngineImpl::RoleBasedAccessControlEngineImpl(
 bool RoleBasedAccessControlEngineImpl::allowed(const Network::Connection& connection,
                                                const Envoy::Http::HeaderMap& headers,
                                                const envoy::api::v2::core::Metadata& metadata,
-                                               std::string& effective_policy_id) const {
+                                               std::string* effective_policy_id) const {
   bool matched = false;
 
   for (auto it = policies_.begin(); it != policies_.end(); it++) {
     if (it->second.matches(connection, headers, metadata)) {
       matched = true;
-      effective_policy_id = it->first;
+      if (effective_policy_id != nullptr) {
+        *effective_policy_id = it->first;
+      }
       break;
     }
   }

--- a/source/extensions/filters/common/rbac/engine_impl.cc
+++ b/source/extensions/filters/common/rbac/engine_impl.cc
@@ -11,20 +11,20 @@ RoleBasedAccessControlEngineImpl::RoleBasedAccessControlEngineImpl(
     : allowed_if_matched_(rules.action() ==
                           envoy::config::rbac::v2alpha::RBAC_Action::RBAC_Action_ALLOW) {
   for (const auto& policy : rules.policies()) {
-    policies_.insert(std::pair<std::string, PolicyMatcher>(policy.first, policy.second));
+    policies_.insert(std::make_pair(policy.first, policy.second));
   }
 }
 
 bool RoleBasedAccessControlEngineImpl::allowed(const Network::Connection& connection,
                                                const Envoy::Http::HeaderMap& headers,
                                                const envoy::api::v2::core::Metadata& metadata,
-                                               std::string& effectivePolicyID) const {
+                                               std::string& effective_policyID) const {
   bool matched = false;
 
   for (auto it = policies_.begin(); it != policies_.end(); it++) {
     if (it->second.matches(connection, headers, metadata)) {
       matched = true;
-      effectivePolicyID = it->first;
+      effective_policyID = it->first;
       break;
     }
   }

--- a/source/extensions/filters/common/rbac/engine_impl.cc
+++ b/source/extensions/filters/common/rbac/engine_impl.cc
@@ -11,17 +11,20 @@ RoleBasedAccessControlEngineImpl::RoleBasedAccessControlEngineImpl(
     : allowed_if_matched_(rules.action() ==
                           envoy::config::rbac::v2alpha::RBAC_Action::RBAC_Action_ALLOW) {
   for (const auto& policy : rules.policies()) {
-    policies_.emplace_back(policy.second);
+    policies_.insert(std::pair<std::string, PolicyMatcher>(policy.first, policy.second));
   }
 }
 
-bool RoleBasedAccessControlEngineImpl::allowed(
-    const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
-    const envoy::api::v2::core::Metadata& metadata) const {
+bool RoleBasedAccessControlEngineImpl::allowed(const Network::Connection& connection,
+                                               const Envoy::Http::HeaderMap& headers,
+                                               const envoy::api::v2::core::Metadata& metadata,
+                                               std::string& effectivePolicyID) const {
   bool matched = false;
-  for (const auto& policy : policies_) {
-    if (policy.matches(connection, headers, metadata)) {
+
+  for (auto it = policies_.begin(); it != policies_.end(); it++) {
+    if (it->second.matches(connection, headers, metadata)) {
       matched = true;
+      effectivePolicyID = it->first;
       break;
     }
   }

--- a/source/extensions/filters/common/rbac/engine_impl.cc
+++ b/source/extensions/filters/common/rbac/engine_impl.cc
@@ -18,13 +18,13 @@ RoleBasedAccessControlEngineImpl::RoleBasedAccessControlEngineImpl(
 bool RoleBasedAccessControlEngineImpl::allowed(const Network::Connection& connection,
                                                const Envoy::Http::HeaderMap& headers,
                                                const envoy::api::v2::core::Metadata& metadata,
-                                               std::string& effective_policyID) const {
+                                               std::string& effective_policy_id) const {
   bool matched = false;
 
   for (auto it = policies_.begin(); it != policies_.end(); it++) {
     if (it->second.matches(connection, headers, metadata)) {
       matched = true;
-      effective_policyID = it->first;
+      effective_policy_id = it->first;
       break;
     }
   }

--- a/source/extensions/filters/common/rbac/engine_impl.h
+++ b/source/extensions/filters/common/rbac/engine_impl.h
@@ -16,12 +16,13 @@ public:
   RoleBasedAccessControlEngineImpl(const envoy::config::rbac::v2alpha::RBAC& rules);
 
   bool allowed(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
-               const envoy::api::v2::core::Metadata& metadata) const override;
+               const envoy::api::v2::core::Metadata& metadata,
+               std::string& effectivePolicyID) const override;
 
 private:
   const bool allowed_if_matched_;
 
-  std::vector<PolicyMatcher> policies_;
+  std::map<std::string, PolicyMatcher> policies_;
 };
 
 } // namespace RBAC

--- a/source/extensions/filters/common/rbac/engine_impl.h
+++ b/source/extensions/filters/common/rbac/engine_impl.h
@@ -17,7 +17,7 @@ public:
 
   bool allowed(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
                const envoy::api::v2::core::Metadata& metadata,
-               std::string& effective_policyID) const override;
+               std::string& effective_policy_id) const override;
 
 private:
   const bool allowed_if_matched_;

--- a/source/extensions/filters/common/rbac/engine_impl.h
+++ b/source/extensions/filters/common/rbac/engine_impl.h
@@ -17,7 +17,7 @@ public:
 
   bool allowed(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
                const envoy::api::v2::core::Metadata& metadata,
-               std::string& effective_policy_id) const override;
+               std::string* effective_policy_id) const override;
 
 private:
   const bool allowed_if_matched_;

--- a/source/extensions/filters/common/rbac/engine_impl.h
+++ b/source/extensions/filters/common/rbac/engine_impl.h
@@ -17,7 +17,7 @@ public:
 
   bool allowed(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
                const envoy::api::v2::core::Metadata& metadata,
-               std::string& effectivePolicyID) const override;
+               std::string& effective_policyID) const override;
 
 private:
   const bool allowed_if_matched_;

--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -88,7 +88,7 @@ Http::FilterHeadersStatus RoleBasedAccessControlFilter::decodeHeaders(Http::Head
   if (shadow_engine.has_value()) {
     std::string shadow_resp_code = resp_code_200;
     if (shadow_engine->allowed(*callbacks_->connection(), headers,
-                               callbacks_->requestInfo().dynamicMetadata(), effective_policy_id)) {
+                               callbacks_->requestInfo().dynamicMetadata(), &effective_policy_id)) {
       ENVOY_LOG(debug, "shadow allowed");
       config_->stats().shadow_allowed_.inc();
     } else {
@@ -121,7 +121,7 @@ Http::FilterHeadersStatus RoleBasedAccessControlFilter::decodeHeaders(Http::Head
       config_->engine(callbacks_->route(), EnforcementMode::Enforced);
   if (engine.has_value()) {
     if (engine->allowed(*callbacks_->connection(), headers,
-                        callbacks_->requestInfo().dynamicMetadata(), effective_policy_id)) {
+                        callbacks_->requestInfo().dynamicMetadata(), nullptr)) {
       ENVOY_LOG(debug, "enforced allowed");
       config_->stats().allowed_.inc();
       return Http::FilterHeadersStatus::Continue;

--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -77,13 +77,13 @@ Http::FilterHeadersStatus RoleBasedAccessControlFilter::decodeHeaders(Http::Head
                 callbacks_->connection()->ssl()->subjectPeerCertificate()
           : "none",
       headers, callbacks_->requestInfo().dynamicMetadata().DebugString());
-  std::string effective_policyID;
+  std::string effective_policy_id;
   const absl::optional<Filters::Common::RBAC::RoleBasedAccessControlEngineImpl>& shadow_engine =
       config_->engine(callbacks_->route(), EnforcementMode::Shadow);
   if (shadow_engine.has_value()) {
     std::string shadow_resp_code = "200";
     if (shadow_engine->allowed(*callbacks_->connection(), headers,
-                               callbacks_->requestInfo().dynamicMetadata(), effective_policyID)) {
+                               callbacks_->requestInfo().dynamicMetadata(), effective_policy_id)) {
       ENVOY_LOG(debug, "shadow allowed");
       config_->stats().shadow_allowed_.inc();
     } else {
@@ -97,9 +97,9 @@ Http::FilterHeadersStatus RoleBasedAccessControlFilter::decodeHeaders(Http::Head
     if (filter_it != filter_metadata.end()) {
       ProtobufWkt::Struct metrics;
 
-      if (effective_policyID != "") {
+      if (effective_policy_id != "") {
         ProtobufWkt::Value policy_id;
-        policy_id.set_string_value(effective_policyID);
+        policy_id.set_string_value(effective_policy_id);
         (*metrics.mutable_fields())["shadow_effective_policyID"] = policy_id;
       }
 
@@ -116,7 +116,7 @@ Http::FilterHeadersStatus RoleBasedAccessControlFilter::decodeHeaders(Http::Head
       config_->engine(callbacks_->route(), EnforcementMode::Enforced);
   if (engine.has_value()) {
     if (engine->allowed(*callbacks_->connection(), headers,
-                        callbacks_->requestInfo().dynamicMetadata(), effective_policyID)) {
+                        callbacks_->requestInfo().dynamicMetadata(), effective_policy_id)) {
       ENVOY_LOG(debug, "enforced allowed");
       config_->stats().allowed_.inc();
       return Http::FilterHeadersStatus::Continue;

--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -77,24 +77,34 @@ Http::FilterHeadersStatus RoleBasedAccessControlFilter::decodeHeaders(Http::Head
                 callbacks_->connection()->ssl()->subjectPeerCertificate()
           : "none",
       headers, callbacks_->requestInfo().dynamicMetadata().DebugString());
+  std::string effective_policyID;
   const absl::optional<Filters::Common::RBAC::RoleBasedAccessControlEngineImpl>& shadow_engine =
       config_->engine(callbacks_->route(), EnforcementMode::Shadow);
   if (shadow_engine.has_value()) {
+    std::string shadow_resp_code = "200";
     if (shadow_engine->allowed(*callbacks_->connection(), headers,
-                               callbacks_->requestInfo().dynamicMetadata())) {
+                               callbacks_->requestInfo().dynamicMetadata(), effective_policyID)) {
       ENVOY_LOG(debug, "shadow allowed");
       config_->stats().shadow_allowed_.inc();
     } else {
       ENVOY_LOG(debug, "shadow denied");
       config_->stats().shadow_denied_.inc();
+      shadow_resp_code = "403";
     }
+
+    auto filter_meta = callbacks_->requestInfo().dynamicMetadata().filter_metadata();
+    if (effective_policyID != "") {
+      filter_meta["shadow"].MergeFrom(
+          MessageUtil::keyValueStruct("effective_policyID", effective_policyID));
+    }
+    filter_meta["shadow"].MergeFrom(MessageUtil::keyValueStruct("response_code", shadow_resp_code));
   }
 
   const absl::optional<Filters::Common::RBAC::RoleBasedAccessControlEngineImpl>& engine =
       config_->engine(callbacks_->route(), EnforcementMode::Enforced);
   if (engine.has_value()) {
     if (engine->allowed(*callbacks_->connection(), headers,
-                        callbacks_->requestInfo().dynamicMetadata())) {
+                        callbacks_->requestInfo().dynamicMetadata(), effective_policyID)) {
       ENVOY_LOG(debug, "enforced allowed");
       config_->stats().allowed_.inc();
       return Http::FilterHeadersStatus::Continue;

--- a/test/extensions/filters/common/rbac/engine_impl_test.cc
+++ b/test/extensions/filters/common/rbac/engine_impl_test.cc
@@ -24,7 +24,7 @@ void checkEngine(const RBAC::RoleBasedAccessControlEngineImpl& engine, bool expe
                  const Envoy::Network::Connection& connection = Envoy::Network::MockConnection(),
                  const Envoy::Http::HeaderMap& headers = Envoy::Http::HeaderMapImpl(),
                  const envoy::api::v2::core::Metadata& metadata = envoy::api::v2::core::Metadata(),
-                 std::string policy_id = "") {
+                 std::string* policy_id = nullptr) {
   EXPECT_EQ(expected, engine.allowed(connection, headers, metadata, policy_id));
 }
 

--- a/test/extensions/filters/common/rbac/engine_impl_test.cc
+++ b/test/extensions/filters/common/rbac/engine_impl_test.cc
@@ -20,12 +20,12 @@ namespace Common {
 namespace RBAC {
 namespace {
 
-void checkEngine(
-    const RBAC::RoleBasedAccessControlEngineImpl& engine, bool expected,
-    const Envoy::Network::Connection& connection = Envoy::Network::MockConnection(),
-    const Envoy::Http::HeaderMap& headers = Envoy::Http::HeaderMapImpl(),
-    const envoy::api::v2::core::Metadata& metadata = envoy::api::v2::core::Metadata()) {
-  EXPECT_EQ(expected, engine.allowed(connection, headers, metadata));
+void checkEngine(const RBAC::RoleBasedAccessControlEngineImpl& engine, bool expected,
+                 const Envoy::Network::Connection& connection = Envoy::Network::MockConnection(),
+                 const Envoy::Http::HeaderMap& headers = Envoy::Http::HeaderMapImpl(),
+                 const envoy::api::v2::core::Metadata& metadata = envoy::api::v2::core::Metadata(),
+                 std::string policyID = "") {
+  EXPECT_EQ(expected, engine.allowed(connection, headers, metadata, policyID));
 }
 
 TEST(RoleBasedAccessControlEngineImpl, Disabled) {

--- a/test/extensions/filters/common/rbac/engine_impl_test.cc
+++ b/test/extensions/filters/common/rbac/engine_impl_test.cc
@@ -24,8 +24,8 @@ void checkEngine(const RBAC::RoleBasedAccessControlEngineImpl& engine, bool expe
                  const Envoy::Network::Connection& connection = Envoy::Network::MockConnection(),
                  const Envoy::Http::HeaderMap& headers = Envoy::Http::HeaderMapImpl(),
                  const envoy::api::v2::core::Metadata& metadata = envoy::api::v2::core::Metadata(),
-                 std::string policyID = "") {
-  EXPECT_EQ(expected, engine.allowed(connection, headers, metadata, policyID));
+                 std::string policy_id = "") {
+  EXPECT_EQ(expected, engine.allowed(connection, headers, metadata, policy_id));
 }
 
 TEST(RoleBasedAccessControlEngineImpl, Disabled) {

--- a/test/extensions/filters/common/rbac/mocks.h
+++ b/test/extensions/filters/common/rbac/mocks.h
@@ -15,8 +15,9 @@ public:
   MockEngine(const envoy::config::rbac::v2alpha::RBAC& rules)
       : RoleBasedAccessControlEngineImpl(rules){};
 
-  MOCK_CONST_METHOD3(allowed, bool(const Envoy::Network::Connection&, const Envoy::Http::HeaderMap&,
-                                   const envoy::api::v2::core::Metadata&));
+  MOCK_CONST_METHOD4(allowed,
+                     bool(const Envoy::Network::Connection&, const Envoy::Http::HeaderMap&,
+                          const envoy::api::v2::core::Metadata&, std::string& effectivePolicyID));
 };
 
 } // namespace RBAC

--- a/test/extensions/filters/common/rbac/mocks.h
+++ b/test/extensions/filters/common/rbac/mocks.h
@@ -17,7 +17,7 @@ public:
 
   MOCK_CONST_METHOD4(allowed,
                      bool(const Envoy::Network::Connection&, const Envoy::Http::HeaderMap&,
-                          const envoy::api::v2::core::Metadata&, std::string& effective_policy_id));
+                          const envoy::api::v2::core::Metadata&, std::string* effective_policy_id));
 };
 
 } // namespace RBAC

--- a/test/extensions/filters/common/rbac/mocks.h
+++ b/test/extensions/filters/common/rbac/mocks.h
@@ -17,7 +17,7 @@ public:
 
   MOCK_CONST_METHOD4(allowed,
                      bool(const Envoy::Network::Connection&, const Envoy::Http::HeaderMap&,
-                          const envoy::api::v2::core::Metadata&, std::string& effectivePolicyID));
+                          const envoy::api::v2::core::Metadata&, std::string& effective_policy_id));
 };
 
 } // namespace RBAC

--- a/test/extensions/filters/http/rbac/rbac_filter_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_test.cc
@@ -59,6 +59,7 @@ public:
   Stats::IsolatedStoreImpl store_;
   RoleBasedAccessControlFilterConfigSharedPtr config_;
 
+  envoy::api::v2::core::Metadata metadata_;
   RoleBasedAccessControlFilter filter_;
   Network::Address::InstanceConstSharedPtr address_;
   Http::TestHeaderMapImpl headers_;

--- a/test/extensions/filters/http/rbac/rbac_filter_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_test.cc
@@ -1,3 +1,4 @@
+#include "common/config/metadata.h"
 #include "common/network/utility.h"
 
 #include "extensions/filters/http/rbac/rbac_filter.h"
@@ -43,6 +44,7 @@ public:
 
   void SetUp() {
     EXPECT_CALL(callbacks_, connection()).WillRepeatedly(Return(&connection_));
+    EXPECT_CALL(callbacks_, requestInfo()).WillRepeatedly(ReturnRef(req_info_));
     filter_.setDecoderFilterCallbacks(callbacks_);
   }
 
@@ -53,6 +55,7 @@ public:
 
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks_;
   NiceMock<Network::MockConnection> connection_{};
+  NiceMock<Envoy::RequestInfo::MockRequestInfo> req_info_;
   Stats::IsolatedStoreImpl store_;
   RoleBasedAccessControlFilterConfigSharedPtr config_;
 
@@ -98,7 +101,7 @@ TEST_F(RoleBasedAccessControlFilterTest, RouteLocalOverride) {
   NiceMock<Filters::Common::RBAC::MockEngine> engine{route_config.rbac().rules()};
   NiceMock<MockRoleBasedAccessControlRouteSpecificFilterConfig> per_route_config_{route_config};
 
-  EXPECT_CALL(engine, allowed(_, _, _)).WillRepeatedly(Return(true));
+  EXPECT_CALL(engine, allowed(_, _, _, _)).WillRepeatedly(Return(true));
   EXPECT_CALL(per_route_config_, engine()).WillRepeatedly(ReturnRef(engine));
 
   EXPECT_CALL(callbacks_.route_->route_entry_, perFilterConfig(HttpFilterNames::get().Rbac))


### PR DESCRIPTION
*Description*:
To complete RBAC policy dark launch from envoy side(https://github.com/envoyproxy/envoy/issues/3552), shadow policy metrics needs to be collected(shadow response code + effective policyID); so that we could use those metrics to build report/dashboard to monitor dark launch policy running result. 

*Risk Level*: Low

Signed-off-by: Quanjie Lin quanlin@google.com
