### PR TITLE
Add prepend functions to Buffer::Instance

### DIFF
--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -78,6 +78,26 @@ public:
   virtual void add(const Instance& data) PURE;
 
   /**
+   * Prepend data to the buffer.
+   * @param data supplies the data address.
+   * @param size supplies the data size.
+   */
+  virtual void prepend(const void* data, uint64_t size) PURE;
+
+  /**
+   * Prepend a string to the buffer.
+   * @param data supplies the string to copy.
+   */
+  virtual void prepend(const std::string& data) PURE;
+
+  /**
+   * Prepend data from another buffer to this buffer.
+   * The supplied buffer is drained after this operation.
+   * @param data supplies the buffer to copy.
+   */
+  virtual void prepend(Instance& data) PURE;
+
+  /**
    * Commit a set of slices originally obtained from reserve(). The number of slices can be
    * different from the number obtained from reserve(). The size of each slice can also be altered.
    * @param iovecs supplies the array of slices to commit.

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -41,6 +41,19 @@ void OwnedImpl::add(const Instance& data) {
   }
 }
 
+void OwnedImpl::prepend(const void* data, uint64_t size) {
+  evbuffer_prepend(buffer_.get(), data, size);
+}
+
+void OwnedImpl::prepend(const std::string& data) {
+  evbuffer_prepend(buffer_.get(), data.data(), data.size());
+}
+
+void OwnedImpl::prepend(Instance& data) {
+  evbuffer_prepend_buffer(buffer_.get(), static_cast<LibEventInstance&>(data).buffer().get());
+  data.drain(data.length());
+}
+
 void OwnedImpl::commit(RawSlice* iovecs, uint64_t num_iovecs) {
   int rc =
       evbuffer_commit_space(buffer_.get(), reinterpret_cast<evbuffer_iovec*>(iovecs), num_iovecs);

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -72,6 +72,9 @@ public:
   void addBufferFragment(BufferFragment& fragment) override;
   void add(const std::string& data) override;
   void add(const Instance& data) override;
+  void prepend(const void* data, uint64_t size) override;
+  void prepend(const std::string& data) override;
+  void prepend(Instance& data) override;
   void commit(RawSlice* iovecs, uint64_t num_iovecs) override;
   void copyOut(size_t start, uint64_t size, void* data) const override;
   void drain(uint64_t size) override;

--- a/test/common/buffer/owned_impl_test.cc
+++ b/test/common/buffer/owned_impl_test.cc
@@ -76,6 +76,43 @@ TEST_F(OwnedImplTest, AddBufferFragmentDynamicAllocation) {
   EXPECT_TRUE(release_callback_called_);
 }
 
+TEST_F(OwnedImplTest, Prepend) {
+
+  std::string suffix = "World!", prefix = "Hello, ";
+  Buffer::OwnedImpl buffer;
+  buffer.add(suffix.data(), suffix.size());
+  buffer.prepend(prefix.data(), prefix.size());
+
+  EXPECT_EQ(suffix.size() + prefix.size(), buffer.length());
+  EXPECT_EQ(prefix + suffix, buffer.toString());
+}
+
+TEST_F(OwnedImplTest, PrependString) {
+
+  std::string suffix = "World!", prefix = "Hello, ";
+  Buffer::OwnedImpl buffer;
+  buffer.add(suffix);
+  buffer.prepend(prefix);
+
+  EXPECT_EQ(suffix.size() + prefix.size(), buffer.length());
+  EXPECT_EQ(prefix + suffix, buffer.toString());
+}
+
+TEST_F(OwnedImplTest, PrependBuffer) {
+
+  std::string suffix = "World!", prefix = "Hello, ";
+  Buffer::OwnedImpl buffer;
+  buffer.add(suffix);
+  Buffer::OwnedImpl prefixBuffer;
+  prefixBuffer.add(prefix);
+
+  buffer.prepend(prefixBuffer);
+
+  EXPECT_EQ(suffix.size() + prefix.size(), buffer.length());
+  EXPECT_EQ(prefix + suffix, buffer.toString());
+  EXPECT_EQ(0, prefixBuffer.length());
+}
+
 TEST_F(OwnedImplTest, Write) {
   Api::MockOsSysCalls os_sys_calls;
   TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls(&os_sys_calls);


### PR DESCRIPTION
*Description*: This PR adds `prepend` functions that wraps around `evbuffer_prepend` and `evbuffer_prepend_buffer`to `Buffer::Instance`
*Risk Level*: low
*Testing*: Added unit tests to cover new functions
*Docs Changes*: N/A
*Release Notes*: N/A
Fixes #3994 
