### PR TITLE
 tcp_proxy: convert TCP proxy to use TCP connection pool

### DIFF
--- a/include/envoy/tcp/conn_pool.h
+++ b/include/envoy/tcp/conn_pool.h
@@ -58,7 +58,8 @@ public:
 };
 
 /*
- * ConnectionData wraps a ClientConnection allocated to a caller.
+ * ConnectionData wraps a ClientConnection allocated to a caller. Open ClientConnections are
+ * released back to the pool for re-use when their containing ConnectionData is destroyed.
  */
 class ConnectionData {
 public:
@@ -76,13 +77,9 @@ public:
    * @param callback the UpstreamCallbacks to invoke for upstream data
    */
   virtual void addUpstreamCallbacks(ConnectionPool::UpstreamCallbacks& callback) PURE;
-
-  /**
-   * Release the connection after use. The connection should be closed first only if it is
-   * not viable for future use.
-   */
-  virtual void release() PURE;
 };
+
+typedef std::unique_ptr<ConnectionData> ConnectionDataPtr;
 
 /**
  * Pool callbacks invoked in the context of a newConnection() call, either synchronously or
@@ -102,14 +99,17 @@ public:
                              Upstream::HostDescriptionConstSharedPtr host) PURE;
 
   /**
-   * Called when a connection is available to process a request/response. Recipients of connections
-   * must release the connection after use. They should only close the underlying ClientConnection
-   * if it is no longer viable for future requests.
+   * Called when a connection is available to process a request/response. Connections may be
+   * released back to the pool for re-use by resetting the ConnectionDataPtr. If the connection is
+   * no longer viable for reuse (e.g. due to some kind of protocol error), the underlying
+   * ClientConnection should be closed to prevent its reuse.
+   *
    * @param conn supplies the connection data to use.
    * @param host supplies the description of the host that will carry the request. For logical
    *             connection pools the description may be different each time this is called.
    */
-  virtual void onPoolReady(ConnectionData& conn, Upstream::HostDescriptionConstSharedPtr host) PURE;
+  virtual void onPoolReady(ConnectionDataPtr&& conn,
+                           Upstream::HostDescriptionConstSharedPtr host) PURE;
 };
 
 /**

--- a/source/common/http/websocket/ws_handler_impl.cc
+++ b/source/common/http/websocket/ws_handler_impl.cc
@@ -131,7 +131,8 @@ void WsHandlerImpl::onConnectionSuccess() {
   // the connection pool. The current approach is a stop gap solution, where
   // we put the onus on the user to tell us if a route (and corresponding upstream)
   // is supposed to allow websocket upgrades or not.
-  Http1::ClientConnectionImpl upstream_http(*upstream_connection_, http_conn_callbacks_);
+  Http1::ClientConnectionImpl upstream_http(upstream_conn_data_->connection(),
+                                            http_conn_callbacks_);
   Http1::RequestStreamEncoderImpl upstream_request = Http1::RequestStreamEncoderImpl(upstream_http);
   upstream_request.encodeHeaders(request_headers_, false);
   ASSERT(state_ == ConnectState::PreConnect);

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -34,21 +34,32 @@ public:
 protected:
   struct ActiveConn;
 
-  struct ConnectionWrapper : public ConnectionPool::ConnectionData {
+  struct ConnectionWrapper {
     ConnectionWrapper(ActiveConn& parent);
-    ~ConnectionWrapper();
 
-    // ConnectionPool::ConnectionData
-    Network::ClientConnection& connection() override;
-    void addUpstreamCallbacks(ConnectionPool::UpstreamCallbacks& callbacks) override;
-    void release() override;
+    Network::ClientConnection& connection();
+    void addUpstreamCallbacks(ConnectionPool::UpstreamCallbacks& callbacks);
+    void release(bool closed);
 
     ActiveConn& parent_;
     ConnectionPool::UpstreamCallbacks* callbacks_{};
     bool released_{false};
   };
 
-  typedef std::unique_ptr<ConnectionWrapper> ConnectionWrapperPtr;
+  typedef std::shared_ptr<ConnectionWrapper> ConnectionWrapperSharedPtr;
+
+  struct ConnectionDataImpl : public ConnectionPool::ConnectionData {
+    ConnectionDataImpl(ConnectionWrapperSharedPtr wrapper) : wrapper_(wrapper) {}
+    ~ConnectionDataImpl() { wrapper_->release(false); }
+
+    // ConnectionPool::ConnectionData
+    Network::ClientConnection& connection() override { return wrapper_->connection(); }
+    void addUpstreamCallbacks(ConnectionPool::UpstreamCallbacks& callbacks) override {
+      wrapper_->addUpstreamCallbacks(callbacks);
+    };
+
+    ConnectionWrapperSharedPtr wrapper_;
+  };
 
   struct ConnReadFilter : public Network::ReadFilterBaseImpl {
     ConnReadFilter(ActiveConn& parent) : parent_(parent) {}
@@ -78,7 +89,7 @@ protected:
 
     ConnPoolImpl& parent_;
     Upstream::HostDescriptionConstSharedPtr real_host_description_;
-    ConnectionWrapperPtr wrapper_;
+    ConnectionWrapperSharedPtr wrapper_;
     Network::ClientConnectionPtr conn_;
     Event::TimerPtr connect_timer_;
     Stats::TimespanPtr conn_length_;

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -41,9 +41,12 @@ protected:
     void addUpstreamCallbacks(ConnectionPool::UpstreamCallbacks& callbacks);
     void release(bool closed);
 
+    void invalidate() { conn_valid_ = false; }
+
     ActiveConn& parent_;
     ConnectionPool::UpstreamCallbacks* callbacks_{};
     bool released_{false};
+    bool conn_valid_{true};
   };
 
   typedef std::shared_ptr<ConnectionWrapper> ConnectionWrapperSharedPtr;

--- a/source/common/tcp_proxy/BUILD
+++ b/source/common/tcp_proxy/BUILD
@@ -24,6 +24,7 @@ envoy_cc_library(
         "//include/envoy/stats:stats_interface",
         "//include/envoy/stats:stats_macros",
         "//include/envoy/stats:timespan",
+        "//include/envoy/tcp:conn_pool_interface",
         "//include/envoy/upstream:cluster_manager_interface",
         "//include/envoy/upstream:upstream_interface",
         "//source/common/access_log:access_log_lib",

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -135,28 +135,17 @@ Filter::~Filter() {
     access_log->log(nullptr, nullptr, nullptr, getRequestInfo());
   }
 
-  if (upstream_connection_) {
-    finalizeUpstreamConnectionStats();
+  if (upstream_handle_) {
+    upstream_handle_->cancel();
+  }
+
+  if (upstream_conn_data_) {
+    upstream_conn_data_->connection().close(Network::ConnectionCloseType::NoFlush);
   }
 }
 
 TcpProxyStats Config::SharedConfig::generateStats(Stats::Scope& scope) {
   return {ALL_TCP_PROXY_STATS(POOL_COUNTER(scope), POOL_GAUGE(scope))};
-}
-
-namespace {
-void finalizeConnectionStats(const Upstream::HostDescription& host,
-                             Stats::Timespan connected_timespan) {
-  host.cluster().stats().upstream_cx_destroy_.inc();
-  host.cluster().stats().upstream_cx_active_.dec();
-  host.stats().cx_active_.dec();
-  host.cluster().resourceManager(Upstream::ResourcePriority::Default).connections().dec();
-  connected_timespan.complete();
-}
-} // namespace
-
-void Filter::finalizeUpstreamConnectionStats() {
-  finalizeConnectionStats(*read_callbacks_->upstreamHost(), *connected_timespan_);
 }
 
 void Filter::initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) {
@@ -188,15 +177,15 @@ void Filter::initialize(Network::ReadFilterCallbacks& callbacks, bool set_connec
 }
 
 void Filter::readDisableUpstream(bool disable) {
-  if (upstream_connection_ == nullptr ||
-      upstream_connection_->state() != Network::Connection::State::Open) {
+  if (upstream_conn_data_ == nullptr ||
+      upstream_conn_data_->connection().state() != Network::Connection::State::Open) {
     // Because we flush write downstream, we can have a case where upstream has already disconnected
     // and we are waiting to flush. If we had a watermark event during this time we should no
     // longer touch the upstream connection.
     return;
   }
 
-  upstream_connection_->readDisable(disable);
+  upstream_conn_data_->connection().readDisable(disable);
   if (disable) {
     read_callbacks_->upstreamHost()
         ->cluster()
@@ -262,13 +251,12 @@ void Filter::UpstreamCallbacks::onBelowWriteBufferLowWatermark() {
   }
 }
 
-Network::FilterStatus Filter::UpstreamCallbacks::onData(Buffer::Instance& data, bool end_stream) {
+void Filter::UpstreamCallbacks::onUpstreamData(Buffer::Instance& data, bool end_stream) {
   if (parent_) {
     parent_->onUpstreamData(data, end_stream);
   } else {
     drainer_->onData(data, end_stream);
   }
-  return Network::FilterStatus::StopIteration;
 }
 
 void Filter::UpstreamCallbacks::onBytesSent() {
@@ -294,7 +282,7 @@ void Filter::UpstreamCallbacks::drain(Drainer& drainer) {
 }
 
 Network::FilterStatus Filter::initializeUpstreamConnection() {
-  ASSERT(upstream_connection_ == nullptr);
+  ASSERT(upstream_conn_data_ == nullptr);
 
   const std::string& cluster_name = getUpstreamCluster();
 
@@ -311,6 +299,9 @@ Network::FilterStatus Filter::initializeUpstreamConnection() {
   }
 
   Upstream::ClusterInfoConstSharedPtr cluster = thread_local_cluster->info();
+
+  // Check this here because the TCP conn pool will queue our request waiting for a connection that
+  // will never be released.
   if (!cluster->resourceManager(Upstream::ResourcePriority::Default).connections().canCreate()) {
     getRequestInfo().setResponseFlag(RequestInfo::ResponseFlag::UpstreamOverflow);
     cluster->stats().upstream_cx_overflow_.inc();
@@ -325,86 +316,105 @@ Network::FilterStatus Filter::initializeUpstreamConnection() {
     return Network::FilterStatus::StopIteration;
   }
 
-  Upstream::Host::CreateConnectionData conn_info =
-      cluster_manager_.tcpConnForCluster(cluster_name, this);
-
-  upstream_connection_ = std::move(conn_info.connection_);
-  read_callbacks_->upstreamHost(conn_info.host_description_);
-  if (!upstream_connection_) {
-    // tcpConnForCluster() increments cluster->stats().upstream_cx_none_healthy.
+  Tcp::ConnectionPool::Instance* conn_pool = cluster_manager_.tcpConnPoolForCluster(
+      cluster_name, Upstream::ResourcePriority::Default, this);
+  if (!conn_pool) {
+    // Either cluster is unknown or there are no healthy hosts. tcpConnPoolForCluster() increments
+    // cluster->stats().upstream_cx_none_healthy in the latter case.
     getRequestInfo().setResponseFlag(RequestInfo::ResponseFlag::NoHealthyUpstream);
     onInitFailure(UpstreamFailureReason::NO_HEALTHY_UPSTREAM);
     return Network::FilterStatus::StopIteration;
   }
 
+  connecting_ = true;
   connect_attempts_++;
-  cluster->resourceManager(Upstream::ResourcePriority::Default).connections().inc();
-  upstream_connection_->addReadFilter(upstream_callbacks_);
-  upstream_connection_->addConnectionCallbacks(*upstream_callbacks_);
-  upstream_connection_->enableHalfClose(true);
-  upstream_connection_->setConnectionStats(
-      {read_callbacks_->upstreamHost()->cluster().stats().upstream_cx_rx_bytes_total_,
-       read_callbacks_->upstreamHost()->cluster().stats().upstream_cx_rx_bytes_buffered_,
-       read_callbacks_->upstreamHost()->cluster().stats().upstream_cx_tx_bytes_total_,
-       read_callbacks_->upstreamHost()->cluster().stats().upstream_cx_tx_bytes_buffered_,
-       &read_callbacks_->upstreamHost()->cluster().stats().bind_errors_});
-  upstream_connection_->connect();
-  upstream_connection_->noDelay(true);
-  getRequestInfo().onUpstreamHostSelected(conn_info.host_description_);
-  getRequestInfo().setUpstreamLocalAddress(upstream_connection_->localAddress());
 
-  ASSERT(connect_timeout_timer_ == nullptr);
-  connect_timeout_timer_ = read_callbacks_->connection().dispatcher().createTimer(
-      [this]() -> void { onConnectTimeout(); });
-  connect_timeout_timer_->enableTimer(cluster->connectTimeout());
+  // Because we never return open connections to the pool, this should either return a handle while
+  // a connection completes or it invokes onPoolFailure inline. Either way, stop iteration.
+  upstream_handle_ = conn_pool->newConnection(*this);
+  return Network::FilterStatus::StopIteration;
+}
 
-  read_callbacks_->upstreamHost()->cluster().stats().upstream_cx_total_.inc();
-  read_callbacks_->upstreamHost()->cluster().stats().upstream_cx_active_.inc();
-  read_callbacks_->upstreamHost()->stats().cx_total_.inc();
-  read_callbacks_->upstreamHost()->stats().cx_active_.inc();
-  connect_timespan_.reset(new Stats::Timespan(
-      read_callbacks_->upstreamHost()->cluster().stats().upstream_cx_connect_ms_));
-  connected_timespan_.reset(new Stats::Timespan(
-      read_callbacks_->upstreamHost()->cluster().stats().upstream_cx_length_ms_));
+void Filter::onPoolFailure(Tcp::ConnectionPool::PoolFailureReason reason,
+                           Upstream::HostDescriptionConstSharedPtr host) {
+  upstream_handle_ = nullptr;
 
-  return Network::FilterStatus::Continue;
+  read_callbacks_->upstreamHost(host);
+  getRequestInfo().onUpstreamHostSelected(host);
+
+  switch (reason) {
+  case Tcp::ConnectionPool::PoolFailureReason::Overflow:
+  case Tcp::ConnectionPool::PoolFailureReason::LocalConnectionFailure:
+    upstream_callbacks_->onEvent(Network::ConnectionEvent::LocalClose);
+    break;
+
+  case Tcp::ConnectionPool::PoolFailureReason::RemoteConnectionFailure:
+    upstream_callbacks_->onEvent(Network::ConnectionEvent::RemoteClose);
+    break;
+
+  case Tcp::ConnectionPool::PoolFailureReason::Timeout:
+    onConnectTimeout();
+    break;
+
+  default:
+    NOT_REACHED_GCOVR_EXCL_LINE;
+  }
+}
+
+void Filter::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data,
+                         Upstream::HostDescriptionConstSharedPtr host) {
+  upstream_handle_ = nullptr;
+  upstream_conn_data_ = std::move(conn_data);
+  read_callbacks_->upstreamHost(host);
+
+  upstream_conn_data_->addUpstreamCallbacks(*upstream_callbacks_);
+
+  Network::ClientConnection& connection = upstream_conn_data_->connection();
+
+  connection.enableHalfClose(true);
+
+  getRequestInfo().onUpstreamHostSelected(host);
+  getRequestInfo().setUpstreamLocalAddress(connection.localAddress());
+
+  // Simulate the event that onPoolReady represents.
+  upstream_callbacks_->onEvent(Network::ConnectionEvent::Connected);
+
+  read_callbacks_->continueReading();
 }
 
 void Filter::onConnectTimeout() {
   ENVOY_CONN_LOG(debug, "connect timeout", read_callbacks_->connection());
   read_callbacks_->upstreamHost()->outlierDetector().putResult(Upstream::Outlier::Result::TIMEOUT);
-  read_callbacks_->upstreamHost()->cluster().stats().upstream_cx_connect_timeout_.inc();
   getRequestInfo().setResponseFlag(RequestInfo::ResponseFlag::UpstreamConnectionFailure);
 
-  // This will cause a LocalClose event to be raised, which will trigger a reconnect if
-  // needed/configured.
-  upstream_connection_->close(Network::ConnectionCloseType::NoFlush);
+  // Raise LocalClose, which will trigger a reconnect if needed/configured.
+  upstream_callbacks_->onEvent(Network::ConnectionEvent::LocalClose);
 }
 
 Network::FilterStatus Filter::onData(Buffer::Instance& data, bool end_stream) {
   ENVOY_CONN_LOG(trace, "downstream connection received {} bytes, end_stream={}",
                  read_callbacks_->connection(), data.length(), end_stream);
   getRequestInfo().addBytesReceived(data.length());
-  upstream_connection_->write(data, end_stream);
+  upstream_conn_data_->connection().write(data, end_stream);
   ASSERT(0 == data.length());
   resetIdleTimer(); // TODO(ggreenway) PERF: do we need to reset timer on both send and receive?
   return Network::FilterStatus::StopIteration;
 }
 
 void Filter::onDownstreamEvent(Network::ConnectionEvent event) {
-  if (upstream_connection_) {
+  if (upstream_conn_data_) {
     if (event == Network::ConnectionEvent::RemoteClose) {
-      upstream_connection_->close(Network::ConnectionCloseType::FlushWrite);
+      upstream_conn_data_->connection().close(Network::ConnectionCloseType::FlushWrite);
 
-      if (upstream_connection_ != nullptr &&
-          upstream_connection_->state() != Network::Connection::State::Closed) {
-        config_->drainManager().add(config_->sharedConfig(), std::move(upstream_connection_),
+      if (upstream_conn_data_ != nullptr &&
+          upstream_conn_data_->connection().state() != Network::Connection::State::Closed) {
+        config_->drainManager().add(config_->sharedConfig(), std::move(upstream_conn_data_),
                                     std::move(upstream_callbacks_), std::move(idle_timer_),
-                                    read_callbacks_->upstreamHost(),
-                                    std::move(connected_timespan_));
+                                    read_callbacks_->upstreamHost());
       }
     } else if (event == Network::ConnectionEvent::LocalClose) {
-      upstream_connection_->close(Network::ConnectionCloseType::NoFlush);
+      upstream_conn_data_->connection().close(Network::ConnectionCloseType::NoFlush);
+      upstream_conn_data_.reset();
       disableIdleTimer();
     }
   }
@@ -420,36 +430,21 @@ void Filter::onUpstreamData(Buffer::Instance& data, bool end_stream) {
 }
 
 void Filter::onUpstreamEvent(Network::ConnectionEvent event) {
-  bool connecting = false;
-
-  // The timer must be cleared before, not after, processing the event because
-  // if initializeUpstreamConnection() is called it will reset the timer, so
-  // clearing after that call will leave the timer unset.
-  if (connect_timeout_timer_) {
-    connecting = true;
-    connect_timeout_timer_->disableTimer();
-    connect_timeout_timer_.reset();
-  }
+  // Update the connecting flag before processing the event because we may start a new connection
+  // attempt in initializeUpstreamConnection.
+  bool connecting = connecting_;
+  connecting_ = false;
 
   if (event == Network::ConnectionEvent::RemoteClose ||
       event == Network::ConnectionEvent::LocalClose) {
-    finalizeUpstreamConnectionStats();
-    read_callbacks_->connection().dispatcher().deferredDelete(std::move(upstream_connection_));
+    upstream_conn_data_.reset();
     disableIdleTimer();
-
-    auto& destroy_ctx_stat =
-        (event == Network::ConnectionEvent::RemoteClose)
-            ? read_callbacks_->upstreamHost()->cluster().stats().upstream_cx_destroy_remote_
-            : read_callbacks_->upstreamHost()->cluster().stats().upstream_cx_destroy_local_;
-    destroy_ctx_stat.inc();
 
     if (connecting) {
       if (event == Network::ConnectionEvent::RemoteClose) {
         getRequestInfo().setResponseFlag(RequestInfo::ResponseFlag::UpstreamConnectionFailure);
         read_callbacks_->upstreamHost()->outlierDetector().putResult(
             Upstream::Outlier::Result::CONNECT_FAILED);
-        read_callbacks_->upstreamHost()->cluster().stats().upstream_cx_connect_fail_.inc();
-        read_callbacks_->upstreamHost()->stats().cx_connect_fail_.inc();
       }
 
       initializeUpstreamConnection();
@@ -459,8 +454,6 @@ void Filter::onUpstreamEvent(Network::ConnectionEvent event) {
       }
     }
   } else if (event == Network::ConnectionEvent::Connected) {
-    connect_timespan_->complete();
-
     // Re-enable downstream reads now that the upstream connection is established
     // so we have a place to send downstream data to.
     read_callbacks_->connection().readDisable(false);
@@ -480,8 +473,10 @@ void Filter::onUpstreamEvent(Network::ConnectionEvent event) {
           });
       resetIdleTimer();
       read_callbacks_->connection().addBytesSentCallback([this](uint64_t) { resetIdleTimer(); });
-      upstream_connection_->addBytesSentCallback([upstream_callbacks = upstream_callbacks_](
-          uint64_t) { upstream_callbacks->onBytesSent(); });
+      upstream_conn_data_->connection().addBytesSentCallback([upstream_callbacks =
+                                                                  upstream_callbacks_](uint64_t) {
+        upstream_callbacks->onBytesSent();
+      });
     }
   }
 }
@@ -523,14 +518,12 @@ UpstreamDrainManager::~UpstreamDrainManager() {
 }
 
 void UpstreamDrainManager::add(const Config::SharedConfigSharedPtr& config,
-                               Network::ClientConnectionPtr&& upstream_connection,
+                               Tcp::ConnectionPool::ConnectionDataPtr&& upstream_conn_data,
                                const std::shared_ptr<Filter::UpstreamCallbacks>& callbacks,
                                Event::TimerPtr&& idle_timer,
-                               const Upstream::HostDescriptionConstSharedPtr& upstream_host,
-                               Stats::TimespanPtr&& connected_timespan) {
-  DrainerPtr drainer(new Drainer(*this, config, callbacks, std::move(upstream_connection),
-                                 std::move(idle_timer), upstream_host,
-                                 std::move(connected_timespan)));
+                               const Upstream::HostDescriptionConstSharedPtr& upstream_host) {
+  DrainerPtr drainer(new Drainer(*this, config, callbacks, std::move(upstream_conn_data),
+                                 std::move(idle_timer), upstream_host));
   callbacks->drain(*drainer);
 
   // Use temporary to ensure we get the pointer before we move it out of drainer
@@ -547,12 +540,10 @@ void UpstreamDrainManager::remove(Drainer& drainer, Event::Dispatcher& dispatche
 
 Drainer::Drainer(UpstreamDrainManager& parent, const Config::SharedConfigSharedPtr& config,
                  const std::shared_ptr<Filter::UpstreamCallbacks>& callbacks,
-                 Network::ClientConnectionPtr&& connection, Event::TimerPtr&& idle_timer,
-                 const Upstream::HostDescriptionConstSharedPtr& upstream_host,
-                 Stats::TimespanPtr&& connected_timespan)
-    : parent_(parent), callbacks_(callbacks), upstream_connection_(std::move(connection)),
-      timer_(std::move(idle_timer)), connected_timespan_(std::move(connected_timespan)),
-      upstream_host_(upstream_host), config_(config) {
+                 Tcp::ConnectionPool::ConnectionDataPtr&& conn_data, Event::TimerPtr&& idle_timer,
+                 const Upstream::HostDescriptionConstSharedPtr& upstream_host)
+    : parent_(parent), callbacks_(callbacks), upstream_conn_data_(std::move(conn_data)),
+      timer_(std::move(idle_timer)), upstream_host_(upstream_host), config_(config) {
   config_->stats().upstream_flush_total_.inc();
   config_->stats().upstream_flush_active_.inc();
 }
@@ -564,8 +555,7 @@ void Drainer::onEvent(Network::ConnectionEvent event) {
       timer_->disableTimer();
     }
     config_->stats().upstream_flush_active_.dec();
-    finalizeConnectionStats(*upstream_host_, *connected_timespan_);
-    parent_.remove(*this, upstream_connection_->dispatcher());
+    parent_.remove(*this, upstream_conn_data_->connection().dispatcher());
   }
 }
 
@@ -592,7 +582,7 @@ void Drainer::onBytesSent() {
 
 void Drainer::cancelDrain() {
   // This sends onEvent(LocalClose).
-  upstream_connection_->close(Network::ConnectionCloseType::NoFlush);
+  upstream_conn_data_->connection().close(Network::ConnectionCloseType::NoFlush);
 }
 
 } // namespace TcpProxy

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -14,6 +14,7 @@
 #include "envoy/server/filter_config.h"
 #include "envoy/stats/stats_macros.h"
 #include "envoy/stats/timespan.h"
+#include "envoy/tcp/conn_pool.h"
 #include "envoy/upstream/cluster_manager.h"
 #include "envoy/upstream/upstream.h"
 
@@ -138,6 +139,7 @@ typedef std::shared_ptr<Config> ConfigSharedPtr;
  * be proxied back and forth between the two connections.
  */
 class Filter : public Network::ReadFilter,
+               Tcp::ConnectionPool::Callbacks,
                Upstream::LoadBalancerContext,
                protected Logger::Loggable<Logger::Id::filter> {
 public:
@@ -148,6 +150,12 @@ public:
   Network::FilterStatus onData(Buffer::Instance& data, bool end_stream) override;
   Network::FilterStatus onNewConnection() override { return initializeUpstreamConnection(); }
   void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override;
+
+  // Tcp::ConnectionPool::Callbacks
+  void onPoolFailure(Tcp::ConnectionPool::PoolFailureReason reason,
+                     Upstream::HostDescriptionConstSharedPtr host) override;
+  void onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data,
+                   Upstream::HostDescriptionConstSharedPtr host) override;
 
   // Upstream::LoadBalancerContext
   absl::optional<uint64_t> computeHashKey() override { return {}; }
@@ -166,17 +174,14 @@ public:
   void readDisableUpstream(bool disable);
   void readDisableDownstream(bool disable);
 
-  struct UpstreamCallbacks : public Network::ConnectionCallbacks,
-                             public Network::ReadFilterBaseImpl {
+  struct UpstreamCallbacks : public Tcp::ConnectionPool::UpstreamCallbacks {
     UpstreamCallbacks(Filter* parent) : parent_(parent) {}
 
-    // Network::ConnectionCallbacks
+    // Tcp::ConnectionPool::UpstreamCallbacks
+    void onUpstreamData(Buffer::Instance& data, bool end_stream) override;
     void onEvent(Network::ConnectionEvent event) override;
     void onAboveWriteBufferHighWatermark() override;
     void onBelowWriteBufferLowWatermark() override;
-
-    // Network::ReadFilter
-    Network::FilterStatus onData(Buffer::Instance& data, bool end_stream) override;
 
     void onBytesSent();
     void onIdleTimeout();
@@ -234,7 +239,6 @@ protected:
   void onDownstreamEvent(Network::ConnectionEvent event);
   void onUpstreamData(Buffer::Instance& data, bool end_stream);
   void onUpstreamEvent(Network::ConnectionEvent event);
-  void finalizeUpstreamConnectionStats();
   void onIdleTimeout();
   void resetIdleTimer();
   void disableIdleTimer();
@@ -242,29 +246,26 @@ protected:
   const ConfigSharedPtr config_;
   Upstream::ClusterManager& cluster_manager_;
   Network::ReadFilterCallbacks* read_callbacks_{};
-  Network::ClientConnectionPtr upstream_connection_;
+  Tcp::ConnectionPool::Cancellable* upstream_handle_{};
+  Tcp::ConnectionPool::ConnectionDataPtr upstream_conn_data_;
   DownstreamCallbacks downstream_callbacks_;
-  Event::TimerPtr connect_timeout_timer_;
   Event::TimerPtr idle_timer_;
-  Stats::TimespanPtr connect_timespan_;
-  Stats::TimespanPtr connected_timespan_;
   std::shared_ptr<UpstreamCallbacks> upstream_callbacks_; // shared_ptr required for passing as a
                                                           // read filter.
   RequestInfo::RequestInfoImpl request_info_;
   uint32_t connect_attempts_{};
+  bool connecting_{};
 };
 
-// This class holds ownership of an upstream connection that needs to finish
-// flushing, when the downstream connection has been closed. The TcpProxy is
-// destroyed when the downstream connection is closed, so moving the upstream
-// connection here allows it to finish draining or timeout.
+// This class deals with an upstream connection that needs to finish flushing, when the downstream
+// connection has been closed. The TcpProxy is destroyed when the downstream connection is closed,
+// so handling the upstream connection here allows it to finish draining or timeout.
 class Drainer : public Event::DeferredDeletable {
 public:
   Drainer(UpstreamDrainManager& parent, const Config::SharedConfigSharedPtr& config,
           const std::shared_ptr<Filter::UpstreamCallbacks>& callbacks,
-          Network::ClientConnectionPtr&& connection, Event::TimerPtr&& idle_timer,
-          const Upstream::HostDescriptionConstSharedPtr& upstream_host,
-          Stats::TimespanPtr&& connected_timespan);
+          Tcp::ConnectionPool::ConnectionDataPtr&& conn_data, Event::TimerPtr&& idle_timer,
+          const Upstream::HostDescriptionConstSharedPtr& upstream_host);
 
   void onEvent(Network::ConnectionEvent event);
   void onData(Buffer::Instance& data, bool end_stream);
@@ -275,9 +276,8 @@ public:
 private:
   UpstreamDrainManager& parent_;
   std::shared_ptr<Filter::UpstreamCallbacks> callbacks_;
-  Network::ClientConnectionPtr upstream_connection_;
+  Tcp::ConnectionPool::ConnectionDataPtr upstream_conn_data_;
   Event::TimerPtr timer_;
-  Stats::TimespanPtr connected_timespan_;
   Upstream::HostDescriptionConstSharedPtr upstream_host_;
   Config::SharedConfigSharedPtr config_;
 };
@@ -288,11 +288,10 @@ class UpstreamDrainManager : public ThreadLocal::ThreadLocalObject {
 public:
   ~UpstreamDrainManager();
   void add(const Config::SharedConfigSharedPtr& config,
-           Network::ClientConnectionPtr&& upstream_connection,
+           Tcp::ConnectionPool::ConnectionDataPtr&& upstream_conn_data,
            const std::shared_ptr<Filter::UpstreamCallbacks>& callbacks,
            Event::TimerPtr&& idle_timer,
-           const Upstream::HostDescriptionConstSharedPtr& upstream_host,
-           Stats::TimespanPtr&& connected_timespan);
+           const Upstream::HostDescriptionConstSharedPtr& upstream_host);
   void remove(Drainer& drainer, Event::Dispatcher& dispatcher);
 
 private:

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -224,7 +224,7 @@ void Router::UpstreamRequest::start() {
 void Router::UpstreamRequest::resetStream() {
   if (conn_data_ != nullptr) {
     conn_data_->connection().close(Network::ConnectionCloseType::NoFlush);
-    conn_data_ = nullptr;
+    conn_data_.reset();
   }
 }
 
@@ -235,10 +235,10 @@ void Router::UpstreamRequest::onPoolFailure(Tcp::ConnectionPool::PoolFailureReas
   onResetStream(reason);
 }
 
-void Router::UpstreamRequest::onPoolReady(Tcp::ConnectionPool::ConnectionData& conn_data,
+void Router::UpstreamRequest::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data,
                                           Upstream::HostDescriptionConstSharedPtr host) {
   onUpstreamHostSelected(host);
-  conn_data_ = &conn_data;
+  conn_data_ = std::move(conn_data);
   conn_data_->addUpstreamCallbacks(parent_);
 
   conn_pool_handle_ = nullptr;
@@ -263,10 +263,7 @@ void Router::UpstreamRequest::onRequestComplete() { request_complete_ = true; }
 
 void Router::UpstreamRequest::onResponseComplete() {
   response_complete_ = true;
-  if (conn_data_ != nullptr) {
-    conn_data_->release();
-  }
-  conn_data_ = nullptr;
+  conn_data_.reset();
 }
 
 void Router::UpstreamRequest::onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host) {

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -112,7 +112,7 @@ private:
     // Tcp::ConnectionPool::Callbacks
     void onPoolFailure(Tcp::ConnectionPool::PoolFailureReason reason,
                        Upstream::HostDescriptionConstSharedPtr host) override;
-    void onPoolReady(Tcp::ConnectionPool::ConnectionData& conn,
+    void onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn,
                      Upstream::HostDescriptionConstSharedPtr host) override;
 
     void onRequestComplete();
@@ -127,7 +127,7 @@ private:
     const int32_t seq_id_;
 
     Tcp::ConnectionPool::Cancellable* conn_pool_handle_{};
-    Tcp::ConnectionPool::ConnectionData* conn_data_{};
+    Tcp::ConnectionPool::ConnectionDataPtr conn_data_;
     Upstream::HostDescriptionConstSharedPtr upstream_host_;
     TransportPtr transport_;
     ProtocolType proto_type_{ProtocolType::Auto};

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -153,6 +153,8 @@ TEST_F(NetworkFilterManagerTest, RateLimitAndTcpProxy) {
   InSequence s;
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   NiceMock<MockConnection> connection;
+  NiceMock<MockClientConnection> upstream_connection;
+  NiceMock<Tcp::ConnectionPool::MockInstance> conn_pool;
   FilterManagerImpl manager(connection, *this);
 
   std::string rl_json = R"EOF(
@@ -201,21 +203,15 @@ TEST_F(NetworkFilterManagerTest, RateLimitAndTcpProxy) {
 
   EXPECT_EQ(manager.initializeReadFilters(), true);
 
-  NiceMock<Network::MockClientConnection>* upstream_connection =
-      new NiceMock<Network::MockClientConnection>();
-  Upstream::MockHost::MockCreateConnectionData conn_info;
-  conn_info.connection_ = upstream_connection;
-  conn_info.host_description_ = Upstream::makeTestHost(
-      factory_context.cluster_manager_.thread_local_cluster_.cluster_.info_, "tcp://127.0.0.1:80");
-  EXPECT_CALL(factory_context.cluster_manager_, tcpConnForCluster_("fake_cluster", _))
-      .WillOnce(Return(conn_info));
+  EXPECT_CALL(factory_context.cluster_manager_, tcpConnPoolForCluster("fake_cluster", _, _))
+      .WillOnce(Return(&conn_pool));
 
   request_callbacks->complete(RateLimit::LimitStatus::OK);
 
-  upstream_connection->raiseEvent(Network::ConnectionEvent::Connected);
+  conn_pool.poolReady(upstream_connection);
 
   Buffer::OwnedImpl buffer("hello");
-  EXPECT_CALL(*upstream_connection, write(BufferEqual(&buffer), _));
+  EXPECT_CALL(upstream_connection, write(BufferEqual(&buffer), _));
   read_buffer_.add("hello");
   manager.onRead();
 }

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -18,6 +18,7 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/server/mocks.h"
+#include "test/mocks/tcp/mocks.h"
 #include "test/mocks/upstream/host.h"
 #include "test/mocks/upstream/mocks.h"
 #include "test/test_common/printers.h"
@@ -25,6 +26,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using testing::Invoke;
 using testing::MatchesRegex;
 using testing::NiceMock;
 using testing::Return;
@@ -379,53 +381,50 @@ public:
     upstream_local_address_ = Network::Utility::resolveUrl("tcp://2.2.2.2:50000");
     upstream_remote_address_ = Network::Utility::resolveUrl("tcp://127.0.0.1:80");
     if (connections >= 1) {
-      {
-        testing::InSequence sequence;
-        for (uint32_t i = 0; i < connections; i++) {
-          connect_timers_.push_back(
-              new NiceMock<Event::MockTimer>(&filter_callbacks_.connection_.dispatcher_));
-          EXPECT_CALL(*connect_timers_.at(i), enableTimer(_));
-        }
-      }
-
       for (uint32_t i = 0; i < connections; i++) {
-        upstream_connections_.push_back(new NiceMock<Network::MockClientConnection>());
+        upstream_connections_.push_back(
+            std::make_unique<NiceMock<Network::MockClientConnection>>());
+        upstream_connection_data_.push_back(
+            std::make_unique<NiceMock<Tcp::ConnectionPool::MockConnectionData>>());
+        ON_CALL(*upstream_connection_data_.back(), connection())
+            .WillByDefault(ReturnRef(*upstream_connections_.back()));
         upstream_hosts_.push_back(std::make_shared<NiceMock<Upstream::MockHost>>());
-        conn_infos_.push_back(Upstream::MockHost::MockCreateConnectionData());
-        conn_infos_.at(i).connection_ = upstream_connections_.back();
-        conn_infos_.at(i).host_description_ = upstream_hosts_.back();
+        conn_pool_handles_.push_back(
+            std::make_unique<NiceMock<Tcp::ConnectionPool::MockCancellable>>());
 
         ON_CALL(*upstream_hosts_.at(i), cluster())
             .WillByDefault(ReturnPointee(
                 factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_));
         ON_CALL(*upstream_hosts_.at(i), address()).WillByDefault(Return(upstream_remote_address_));
         upstream_connections_.at(i)->local_address_ = upstream_local_address_;
-        EXPECT_CALL(*upstream_connections_.at(i), addReadFilter(_))
-            .WillOnce(SaveArg<0>(&upstream_read_filter_));
         EXPECT_CALL(*upstream_connections_.at(i), dispatcher())
             .WillRepeatedly(ReturnRef(filter_callbacks_.connection_.dispatcher_));
-        EXPECT_CALL(*upstream_connections_.at(i), enableHalfClose(true));
       }
     }
 
     {
       testing::InSequence sequence;
       for (uint32_t i = 0; i < connections; i++) {
-        EXPECT_CALL(factory_context_.cluster_manager_, tcpConnForCluster_("fake_cluster", _))
-            .WillOnce(Return(conn_infos_.at(i)))
+        EXPECT_CALL(factory_context_.cluster_manager_, tcpConnPoolForCluster("fake_cluster", _, _))
+            .WillOnce(Return(&conn_pool_))
+            .RetiresOnSaturation();
+        EXPECT_CALL(conn_pool_, newConnection(_))
+            .WillOnce(Invoke(
+                [=](Tcp::ConnectionPool::Callbacks& cb) -> Tcp::ConnectionPool::Cancellable* {
+                  conn_pool_callbacks_.push_back(&cb);
+                  return conn_pool_handles_.at(i).get();
+                }))
             .RetiresOnSaturation();
       }
-      EXPECT_CALL(factory_context_.cluster_manager_, tcpConnForCluster_("fake_cluster", _))
-          .WillRepeatedly(Return(Upstream::MockHost::MockCreateConnectionData()));
+      EXPECT_CALL(factory_context_.cluster_manager_, tcpConnPoolForCluster("fake_cluster", _, _))
+          .WillRepeatedly(Return(nullptr));
     }
 
     filter_.reset(new Filter(config_, factory_context_.cluster_manager_));
     EXPECT_CALL(filter_callbacks_.connection_, readDisable(true));
     EXPECT_CALL(filter_callbacks_.connection_, enableHalfClose(true));
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
-    EXPECT_EQ(connections >= 1 ? Network::FilterStatus::Continue
-                               : Network::FilterStatus::StopIteration,
-              filter_->onNewConnection());
+    EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
 
     EXPECT_EQ(absl::optional<uint64_t>(), filter_->computeHashKey());
     EXPECT_EQ(&filter_callbacks_.connection_, filter_->downstreamConnection());
@@ -435,19 +434,37 @@ public:
   void setup(uint32_t connections) { setup(connections, defaultConfig()); }
 
   void raiseEventUpstreamConnected(uint32_t conn_index) {
-    EXPECT_CALL(*connect_timers_.at(conn_index), disableTimer());
     EXPECT_CALL(filter_callbacks_.connection_, readDisable(false));
-    upstream_connections_.at(conn_index)->raiseEvent(Network::ConnectionEvent::Connected);
+    EXPECT_CALL(*upstream_connection_data_.at(conn_index), addUpstreamCallbacks(_))
+        .WillOnce(Invoke([=](Tcp::ConnectionPool::UpstreamCallbacks& cb) -> void {
+          upstream_callbacks_ = &cb;
+
+          // Simulate TCP conn pool upstream callbacks. This is safe because the TCP proxy never
+          // releases a connection so all events go to the same UpstreamCallbacks instance.
+          upstream_connections_.at(conn_index)->addConnectionCallbacks(cb);
+        }));
+    EXPECT_CALL(*upstream_connections_.at(conn_index), enableHalfClose(true));
+    conn_pool_callbacks_.at(conn_index)
+        ->onPoolReady(std::move(upstream_connection_data_.at(conn_index)),
+                      upstream_hosts_.at(conn_index));
+  }
+
+  void raiseEventUpstreamConnectFailed(uint32_t conn_index,
+                                       Tcp::ConnectionPool::PoolFailureReason reason) {
+    conn_pool_callbacks_.at(conn_index)->onPoolFailure(reason, upstream_hosts_.at(conn_index));
   }
 
   ConfigSharedPtr config_;
   NiceMock<Network::MockReadFilterCallbacks> filter_callbacks_;
   NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
   std::vector<std::shared_ptr<NiceMock<Upstream::MockHost>>> upstream_hosts_{};
-  std::vector<NiceMock<Network::MockClientConnection>*> upstream_connections_{};
-  std::vector<Upstream::MockHost::MockCreateConnectionData> conn_infos_;
-  Network::ReadFilterSharedPtr upstream_read_filter_;
-  std::vector<NiceMock<Event::MockTimer>*> connect_timers_;
+  std::vector<std::unique_ptr<NiceMock<Network::MockClientConnection>>> upstream_connections_{};
+  std::vector<std::unique_ptr<NiceMock<Tcp::ConnectionPool::MockConnectionData>>>
+      upstream_connection_data_{};
+  std::vector<Tcp::ConnectionPool::Callbacks*> conn_pool_callbacks_;
+  std::vector<std::unique_ptr<NiceMock<Tcp::ConnectionPool::MockCancellable>>> conn_pool_handles_;
+  NiceMock<Tcp::ConnectionPool::MockInstance> conn_pool_;
+  Tcp::ConnectionPool::UpstreamCallbacks* upstream_callbacks_;
   std::unique_ptr<Filter> filter_;
   StringViewSaver access_log_data_;
   Network::Address::InstanceConstSharedPtr upstream_local_address_;
@@ -461,67 +478,65 @@ TEST_F(TcpProxyTest, HalfCloseProxy) {
   EXPECT_CALL(filter_callbacks_.connection_, close(_)).Times(0);
   EXPECT_CALL(*upstream_connections_.at(0), close(_)).Times(0);
 
+  raiseEventUpstreamConnected(0);
+
   Buffer::OwnedImpl buffer("hello");
   EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer), true));
   filter_->onData(buffer, true);
 
-  raiseEventUpstreamConnected(0);
-
   Buffer::OwnedImpl response("world");
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response), true));
-  upstream_read_filter_->onData(response, true);
+  upstream_callbacks_->onUpstreamData(response, true);
 
   EXPECT_CALL(filter_callbacks_.connection_, close(_));
-  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_,
-              deferredDelete_(upstream_connections_.at(0)));
-  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  upstream_callbacks_->onEvent(Network::ConnectionEvent::RemoteClose);
 }
 
 // Test that downstream is closed after an upstream LocalClose.
 TEST_F(TcpProxyTest, UpstreamLocalDisconnect) {
   setup(1);
 
+  raiseEventUpstreamConnected(0);
+
   Buffer::OwnedImpl buffer("hello");
   EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer), false));
   filter_->onData(buffer, false);
 
-  raiseEventUpstreamConnected(0);
-
   Buffer::OwnedImpl response("world");
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response), _));
-  upstream_read_filter_->onData(response, false);
+  upstream_callbacks_->onUpstreamData(response, false);
 
   EXPECT_CALL(filter_callbacks_.connection_, close(_));
-  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::LocalClose);
+  upstream_callbacks_->onEvent(Network::ConnectionEvent::LocalClose);
 }
 
 // Test that downstream is closed after an upstream RemoteClose.
 TEST_F(TcpProxyTest, UpstreamRemoteDisconnect) {
   setup(1);
 
+  raiseEventUpstreamConnected(0);
+
   Buffer::OwnedImpl buffer("hello");
   EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer), false));
   filter_->onData(buffer, false);
 
-  raiseEventUpstreamConnected(0);
-
   Buffer::OwnedImpl response("world");
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response), _));
-  upstream_read_filter_->onData(response, false);
+  upstream_callbacks_->onUpstreamData(response, false);
 
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
-  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  upstream_callbacks_->onEvent(Network::ConnectionEvent::RemoteClose);
 }
 
 // Test that reconnect is attempted after a local connect failure
 TEST_F(TcpProxyTest, ConnectAttemptsUpstreamLocalFail) {
   envoy::config::filter::network::tcp_proxy::v2::TcpProxy config = defaultConfig();
   config.mutable_max_connect_attempts()->set_value(2);
+
   setup(2, config);
 
-  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_,
-              deferredDelete_(upstream_connections_.at(0)));
-  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::LocalClose);
+  raiseEventUpstreamConnectFailed(0,
+                                  Tcp::ConnectionPool::PoolFailureReason::LocalConnectionFailure);
   raiseEventUpstreamConnected(1);
 
   EXPECT_EQ(0U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
@@ -535,9 +550,8 @@ TEST_F(TcpProxyTest, ConnectAttemptsUpstreamRemoteFail) {
   config.mutable_max_connect_attempts()->set_value(2);
   setup(2, config);
 
-  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_,
-              deferredDelete_(upstream_connections_.at(0)));
-  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  raiseEventUpstreamConnectFailed(0,
+                                  Tcp::ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
   raiseEventUpstreamConnected(1);
 
   EXPECT_EQ(0U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
@@ -551,8 +565,7 @@ TEST_F(TcpProxyTest, ConnectAttemptsUpstreamTimeout) {
   config.mutable_max_connect_attempts()->set_value(2);
   setup(2, config);
 
-  EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
-  connect_timers_.at(0)->callback_();
+  raiseEventUpstreamConnectFailed(0, Tcp::ConnectionPool::PoolFailureReason::Timeout);
   raiseEventUpstreamConnected(1);
 
   EXPECT_EQ(0U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
@@ -566,38 +579,21 @@ TEST_F(TcpProxyTest, ConnectAttemptsLimit) {
   config.mutable_max_connect_attempts()->set_value(3);
   setup(3, config);
 
-  {
-    testing::InSequence sequence;
-    EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
-    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_,
-                deferredDelete_(upstream_connections_.at(0)));
-    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_,
-                deferredDelete_(upstream_connections_.at(1)));
-    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_,
-                deferredDelete_(upstream_connections_.at(2)));
-    EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
-  }
+  EXPECT_CALL(upstream_hosts_.at(0)->outlier_detector_,
+              putResult(Upstream::Outlier::Result::TIMEOUT));
+  EXPECT_CALL(upstream_hosts_.at(1)->outlier_detector_,
+              putResult(Upstream::Outlier::Result::CONNECT_FAILED));
+  EXPECT_CALL(upstream_hosts_.at(2)->outlier_detector_,
+              putResult(Upstream::Outlier::Result::CONNECT_FAILED));
+
+  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
 
   // Try both failure modes
-  connect_timers_.at(0)->callback_();
-  upstream_connections_.at(1)->raiseEvent(Network::ConnectionEvent::RemoteClose);
-  upstream_connections_.at(2)->raiseEvent(Network::ConnectionEvent::RemoteClose);
-
-  EXPECT_EQ(1U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
-                    .counter("upstream_cx_connect_timeout")
-                    .value());
-  EXPECT_EQ(2U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
-                    .counter("upstream_cx_connect_fail")
-                    .value());
-  EXPECT_EQ(1U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
-                    .counter("upstream_cx_connect_attempts_exceeded")
-                    .value());
-  EXPECT_EQ(0U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
-                    .counter("upstream_cx_overflow")
-                    .value());
-  EXPECT_EQ(0U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
-                    .counter("upstream_cx_no_successful_host")
-                    .value());
+  raiseEventUpstreamConnectFailed(0, Tcp::ConnectionPool::PoolFailureReason::Timeout);
+  raiseEventUpstreamConnectFailed(1,
+                                  Tcp::ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
+  raiseEventUpstreamConnectFailed(2,
+                                  Tcp::ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
 }
 
 // Test that the tcp proxy sends the correct notifications to the outlier detector
@@ -608,11 +604,12 @@ TEST_F(TcpProxyTest, OutlierDetection) {
 
   EXPECT_CALL(upstream_hosts_.at(0)->outlier_detector_,
               putResult(Upstream::Outlier::Result::TIMEOUT));
-  connect_timers_.at(0)->callback_();
+  raiseEventUpstreamConnectFailed(0, Tcp::ConnectionPool::PoolFailureReason::Timeout);
 
   EXPECT_CALL(upstream_hosts_.at(1)->outlier_detector_,
               putResult(Upstream::Outlier::Result::CONNECT_FAILED));
-  upstream_connections_.at(1)->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  raiseEventUpstreamConnectFailed(1,
+                                  Tcp::ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
 
   EXPECT_CALL(upstream_hosts_.at(2)->outlier_detector_,
               putResult(Upstream::Outlier::Result::SUCCESS));
@@ -622,21 +619,21 @@ TEST_F(TcpProxyTest, OutlierDetection) {
 TEST_F(TcpProxyTest, UpstreamDisconnectDownstreamFlowControl) {
   setup(1);
 
+  raiseEventUpstreamConnected(0);
+
   Buffer::OwnedImpl buffer("hello");
   EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer), _));
   filter_->onData(buffer, false);
 
-  raiseEventUpstreamConnected(0);
-
   Buffer::OwnedImpl response("world");
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response), _));
-  upstream_read_filter_->onData(response, false);
+  upstream_callbacks_->onUpstreamData(response, false);
 
   EXPECT_CALL(*upstream_connections_.at(0), readDisable(true));
   filter_callbacks_.connection_.runHighWatermarkCallbacks();
 
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
-  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  upstream_callbacks_->onEvent(Network::ConnectionEvent::RemoteClose);
 
   filter_callbacks_.connection_.runLowWatermarkCallbacks();
 }
@@ -644,15 +641,15 @@ TEST_F(TcpProxyTest, UpstreamDisconnectDownstreamFlowControl) {
 TEST_F(TcpProxyTest, DownstreamDisconnectRemote) {
   setup(1);
 
+  raiseEventUpstreamConnected(0);
+
   Buffer::OwnedImpl buffer("hello");
   EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer), _));
   filter_->onData(buffer, false);
 
-  raiseEventUpstreamConnected(0);
-
   Buffer::OwnedImpl response("world");
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response), _));
-  upstream_read_filter_->onData(response, false);
+  upstream_callbacks_->onUpstreamData(response, false);
 
   EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::FlushWrite));
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
@@ -661,15 +658,15 @@ TEST_F(TcpProxyTest, DownstreamDisconnectRemote) {
 TEST_F(TcpProxyTest, DownstreamDisconnectLocal) {
   setup(1);
 
+  raiseEventUpstreamConnected(0);
+
   Buffer::OwnedImpl buffer("hello");
   EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer), _));
   filter_->onData(buffer, false);
 
-  raiseEventUpstreamConnected(0);
-
   Buffer::OwnedImpl response("world");
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferEqual(&response), _));
-  upstream_read_filter_->onData(response, false);
+  upstream_callbacks_->onUpstreamData(response, false);
 
   EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::LocalClose);
@@ -678,16 +675,8 @@ TEST_F(TcpProxyTest, DownstreamDisconnectLocal) {
 TEST_F(TcpProxyTest, UpstreamConnectTimeout) {
   setup(1, accessLogConfig("%RESPONSE_FLAGS%"));
 
-  Buffer::OwnedImpl buffer("hello");
-  EXPECT_CALL(*upstream_connections_.at(0), write(BufferEqual(&buffer), _));
-  filter_->onData(buffer, false);
-
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
-  EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
-  connect_timers_.at(0)->callback_();
-  EXPECT_EQ(1U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
-                    .counter("upstream_cx_connect_timeout")
-                    .value());
+  raiseEventUpstreamConnectFailed(0, Tcp::ConnectionPool::PoolFailureReason::Timeout);
 
   filter_.reset();
   EXPECT_EQ(access_log_data_, "UF");
@@ -744,15 +733,9 @@ TEST_F(TcpProxyTest, DisconnectBeforeData) {
 TEST_F(TcpProxyTest, UpstreamConnectFailure) {
   setup(1, accessLogConfig("%RESPONSE_FLAGS%"));
 
-  Buffer::OwnedImpl buffer("hello");
-  filter_->onData(buffer, false);
-
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
-  EXPECT_CALL(*connect_timers_.at(0), disableTimer());
-  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
-  EXPECT_EQ(1U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
-                    .counter("upstream_cx_connect_fail")
-                    .value());
+  raiseEventUpstreamConnectFailed(0,
+                                  Tcp::ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
 
   filter_.reset();
   EXPECT_EQ(access_log_data_, "UF");
@@ -769,10 +752,6 @@ TEST_F(TcpProxyTest, UpstreamConnectionLimit) {
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   filter_->initializeReadFilterCallbacks(filter_callbacks_);
   filter_->onNewConnection();
-
-  EXPECT_EQ(1U, factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
-                    .counter("upstream_cx_overflow")
-                    .value());
 
   filter_.reset();
   EXPECT_EQ(access_log_data_, "UO");
@@ -795,7 +774,7 @@ TEST_F(TcpProxyTest, IdleTimeout) {
 
   buffer.add("hello2");
   EXPECT_CALL(*idle_timer, enableTimer(std::chrono::milliseconds(1000)));
-  upstream_read_filter_->onData(buffer, false);
+  upstream_callbacks_->onUpstreamData(buffer, false);
 
   EXPECT_CALL(*idle_timer, enableTimer(std::chrono::milliseconds(1000)));
   filter_callbacks_.connection_.raiseBytesSentCallbacks(1);
@@ -834,12 +813,13 @@ TEST_F(TcpProxyTest, IdleTimerDisabledUpstreamClose) {
   raiseEventUpstreamConnected(0);
 
   EXPECT_CALL(*idle_timer, disableTimer());
-  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  upstream_callbacks_->onEvent(Network::ConnectionEvent::RemoteClose);
 }
 
 // Test that access log fields %UPSTREAM_HOST% and %UPSTREAM_CLUSTER% are correctly logged.
 TEST_F(TcpProxyTest, AccessLogUpstreamHost) {
   setup(1, accessLogConfig("%UPSTREAM_HOST% %UPSTREAM_CLUSTER%"));
+  raiseEventUpstreamConnected(0);
   filter_.reset();
   EXPECT_EQ(access_log_data_, "127.0.0.1:80 fake_cluster");
 }
@@ -847,6 +827,7 @@ TEST_F(TcpProxyTest, AccessLogUpstreamHost) {
 // Test that access log field %UPSTREAM_LOCAL_ADDRESS% is correctly logged.
 TEST_F(TcpProxyTest, AccessLogUpstreamLocalAddress) {
   setup(1, accessLogConfig("%UPSTREAM_LOCAL_ADDRESS%"));
+  raiseEventUpstreamConnected(0);
   filter_.reset();
   EXPECT_EQ(access_log_data_, "2.2.2.2:50000");
 }
@@ -873,10 +854,10 @@ TEST_F(TcpProxyTest, AccessLogBytesRxTxDuration) {
   Buffer::OwnedImpl buffer("a");
   filter_->onData(buffer, false);
   Buffer::OwnedImpl response("bb");
-  upstream_read_filter_->onData(response, false);
+  upstream_callbacks_->onUpstreamData(response, false);
 
   std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  upstream_callbacks_->onEvent(Network::ConnectionEvent::RemoteClose);
   filter_.reset();
 
   EXPECT_THAT(access_log_data_,
@@ -889,7 +870,8 @@ TEST_F(TcpProxyTest, UpstreamFlushNoTimeout) {
   setup(1);
   raiseEventUpstreamConnected(0);
 
-  EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::FlushWrite))
+  EXPECT_CALL(*upstream_connections_.at(0),
+              close(Network::ConnectionCloseType::FlushWrite))
       .WillOnce(Return()); // Cancel default action of raising LocalClose
   EXPECT_CALL(*upstream_connections_.at(0), state())
       .WillOnce(Return(Network::Connection::State::Closing));
@@ -902,7 +884,7 @@ TEST_F(TcpProxyTest, UpstreamFlushNoTimeout) {
   upstream_connections_.at(0)->raiseBytesSentCallbacks(1);
 
   // Simulate flush complete.
-  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::LocalClose);
+  upstream_callbacks_->onEvent(Network::ConnectionEvent::LocalClose);
   EXPECT_EQ(1U, config_->stats().upstream_flush_total_.value());
   EXPECT_EQ(0U, config_->stats().upstream_flush_active_.value());
 }
@@ -919,7 +901,8 @@ TEST_F(TcpProxyTest, UpstreamFlushTimeoutConfigured) {
   EXPECT_CALL(*idle_timer, enableTimer(_));
   raiseEventUpstreamConnected(0);
 
-  EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::FlushWrite))
+  EXPECT_CALL(*upstream_connections_.at(0),
+              close(Network::ConnectionCloseType::FlushWrite))
       .WillOnce(Return()); // Cancel default action of raising LocalClose
   EXPECT_CALL(*upstream_connections_.at(0), state())
       .WillOnce(Return(Network::Connection::State::Closing));
@@ -933,7 +916,7 @@ TEST_F(TcpProxyTest, UpstreamFlushTimeoutConfigured) {
 
   // Simulate flush complete.
   EXPECT_CALL(*idle_timer, disableTimer());
-  upstream_connections_.at(0)->raiseEvent(Network::ConnectionEvent::LocalClose);
+  upstream_callbacks_->onEvent(Network::ConnectionEvent::LocalClose);
   EXPECT_EQ(1U, config_->stats().upstream_flush_total_.value());
   EXPECT_EQ(0U, config_->stats().upstream_flush_active_.value());
   EXPECT_EQ(0U, config_->stats().idle_timeout_.value());
@@ -950,7 +933,8 @@ TEST_F(TcpProxyTest, UpstreamFlushTimeoutExpired) {
   EXPECT_CALL(*idle_timer, enableTimer(_));
   raiseEventUpstreamConnected(0);
 
-  EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::FlushWrite))
+  EXPECT_CALL(*upstream_connections_.at(0),
+              close(Network::ConnectionCloseType::FlushWrite))
       .WillOnce(Return()); // Cancel default action of raising LocalClose
   EXPECT_CALL(*upstream_connections_.at(0), state())
       .WillOnce(Return(Network::Connection::State::Closing));
@@ -972,7 +956,8 @@ TEST_F(TcpProxyTest, UpstreamFlushReceiveUpstreamData) {
   setup(1);
   raiseEventUpstreamConnected(0);
 
-  EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::FlushWrite))
+  EXPECT_CALL(*upstream_connections_.at(0),
+              close(Network::ConnectionCloseType::FlushWrite))
       .WillOnce(Return()); // Cancel default action of raising LocalClose
   EXPECT_CALL(*upstream_connections_.at(0), state())
       .WillOnce(Return(Network::Connection::State::Closing));
@@ -984,7 +969,7 @@ TEST_F(TcpProxyTest, UpstreamFlushReceiveUpstreamData) {
   // Send some bytes; no timeout configured so this should be a no-op (not a crash).
   Buffer::OwnedImpl buffer("a");
   EXPECT_CALL(*upstream_connections_.at(0), close(Network::ConnectionCloseType::NoFlush));
-  upstream_read_filter_->onData(buffer, false);
+  upstream_callbacks_->onUpstreamData(buffer, false);
 }
 
 class TcpProxyRoutingTest : public testing::Test {
@@ -1049,7 +1034,7 @@ TEST_F(TcpProxyRoutingTest, RoutableConnection) {
   connection_.local_address_ = std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 9999);
 
   // Expect filter to try to open a connection to specified cluster.
-  EXPECT_CALL(factory_context_.cluster_manager_, tcpConnForCluster_("fake_cluster", _));
+  EXPECT_CALL(factory_context_.cluster_manager_, tcpConnPoolForCluster("fake_cluster", _, _));
 
   filter_->onNewConnection();
 

--- a/test/integration/tcp_conn_pool_integration_test.cc
+++ b/test/integration/tcp_conn_pool_integration_test.cc
@@ -52,9 +52,9 @@ private:
       ASSERT(false);
     }
 
-    void onPoolReady(Tcp::ConnectionPool::ConnectionData& conn,
+    void onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn,
                      Upstream::HostDescriptionConstSharedPtr) override {
-      upstream_ = &conn;
+      upstream_ = std::move(conn);
 
       upstream_->addUpstreamCallbacks(*this);
       upstream_->connection().write(data_, false);
@@ -67,7 +67,7 @@ private:
       Network::Connection& downstream = parent_.read_callbacks_->connection();
       downstream.write(data, false);
 
-      upstream_->release();
+      upstream_.reset();
     }
     void onEvent(Network::ConnectionEvent) override {}
     void onAboveWriteBufferHighWatermark() override {}
@@ -75,7 +75,7 @@ private:
 
     TestFilter& parent_;
     Buffer::OwnedImpl data_;
-    Tcp::ConnectionPool::ConnectionData* upstream_;
+    Tcp::ConnectionPool::ConnectionDataPtr upstream_;
   };
 
   Upstream::ClusterManager& cluster_manager_;


### PR DESCRIPTION
Converts TcpProxy::Filter and WebSocket::WsHandlerImpl to use
Tcp::ConnectionPool to obtain connections. Much of the stats
handling and connection timeouts are handled by the connection
pool.

Stats were manually verified by comparing stats produced by
the tcp_proxy_integration_test with and without the connection
pool change.

This reapplies an earlier changed reverted due to #4043. That
bug is fixed by performing the connection pools state management
before forwarding callbacks.

*Risk Level*: medium
*Testing*: unit/integration testing
*Docs Changes*: n/a
*Release Notes*: n/a
*Fixes*: #4043

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
