### PR TITLE
http: external authz correct stat names

### DIFF
--- a/docs/root/configuration/http_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/http_filters/ext_authz_filter.rst
@@ -82,5 +82,5 @@ The HTTP filter outputs statistics in the *cluster.<route target cluster>.ext_au
   ok, Counter, Total responses from the filter.
   error, Counter, Total errors contacting the external service.
   denied, Counter, Total responses from the authorizations service that were to deny the traffic.
-  failure_mode_allow, Counter, "Total requests that were error(s) but were allowed through because
+  failure_mode_allowed, Counter, "Total requests that were error(s) but were allowed through because
   of failure_mode_allow set to true."

--- a/docs/root/configuration/network_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/network_filters/ext_authz_filter.rst
@@ -55,7 +55,7 @@ The network filter outputs statistics in the *config.ext_authz.* namespace.
   total, Counter, Total responses from the filter.
   error, Counter, Total errors contacting the external service.
   denied, Counter, Total responses from the authorizations service that were to deny the traffic. 
-  failure_mode_allow, Counter, "Total requests that were error(s) but were allowed through
+  failure_mode_allowed, Counter, "Total requests that were error(s) but were allowed through
   because of failure_mode_allow set to true."
   ok, Counter, Total responses from the authorization service that were to allow the traffic.
   cx_closed, Counter, Total connections that were closed.


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>

For an explanation of how to fill out the fields, please see the relevant section 
in PULL_REQUESTS.md

*Description*: Typo in external auth stat `failure_mode_allow`. It should be `failure_mode_allowed` as per this [line](https://github.com/envoyproxy/envoy/blob/master/source/extensions/filters/network/ext_authz/ext_authz.h#L32)
*Risk Level*: Low
*Testing*: N/a
*Docs Changes*: N/A
*Release Notes*: N/A

