### PR TITLE
health check: update address when needed

### DIFF
--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -108,9 +108,14 @@ public:
    * @return the address used to health check the host.
    */
   virtual Network::Address::InstanceConstSharedPtr healthCheckAddress() const PURE;
+
+  /**
+   * Sets the address used to health check the host. This noop by default.
+   */
+  virtual void setHealthCheckAddress(Network::Address::InstanceConstSharedPtr){};
 };
 
 typedef std::shared_ptr<const HostDescription> HostDescriptionConstSharedPtr;
 
-} // Upstream
+} // namespace Upstream
 } // namespace Envoy

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -903,6 +903,13 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(const HostVector& new_hosts,
           hosts_changed = true;
         }
 
+        // Did the health check address change?
+        if (*(*i)->healthCheckAddress() != *host->healthCheckAddress()) {
+          // If the health check address is updated, set the current host's health check address
+          // using the updated one.
+          (*i)->setHealthCheckAddress(host->healthCheckAddress());
+        }
+
         (*i)->weight(host->weight());
         final_hosts.push_back(*i);
         i = current_hosts.erase(i);

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -121,6 +121,10 @@ public:
   Network::Address::InstanceConstSharedPtr healthCheckAddress() const override {
     return health_check_address_;
   }
+  void
+  setHealthCheckAddress(Network::Address::InstanceConstSharedPtr health_check_address) override {
+    health_check_address_ = health_check_address;
+  }
   const envoy::api::v2::core::Locality& locality() const override { return locality_; }
 
 protected:


### PR DESCRIPTION
*Description*:
This PR makes sure the health check address of an active host is updated when needed.

*Risk Level*: low
*Testing*: unit
*Docs Changes*: N/A
*Release Notes*: N/A

Fixes #4070

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>
