### PR TITLE
Handling updates from the management server on HDS

### DIFF
--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -134,6 +134,7 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onEvent(Network::Conne
   }
 }
 
+// TODO(lilika) : Support connection pooling
 void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onInterval() {
   if (!client_) {
     Upstream::Host::CreateConnectionData conn =
@@ -327,6 +328,7 @@ void TcpHealthCheckerImpl::TcpActiveHealthCheckSession::onEvent(Network::Connect
   }
 }
 
+// TODO(lilika) : Support connection pooling
 void TcpHealthCheckerImpl::TcpActiveHealthCheckSession::onInterval() {
   if (!client_) {
     client_ = host_->createHealthCheckConnection(parent_.dispatcher_).connection_;

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -25,6 +25,10 @@ HdsDelegate::HdsDelegate(const envoy::api::v2::core::Node& node, Stats::Scope& s
   hds_retry_timer_ = dispatcher.createTimer([this]() -> void { establishNewStream(); });
   hds_stream_response_timer_ = dispatcher.createTimer([this]() -> void { sendResponse(); });
   establishNewStream();
+
+  // TODO(lilika): Add support for other types of healthchecks
+  health_check_request_.mutable_capability()->add_health_check_protocol(
+      envoy::service::discovery::v2::Capability::HTTP);
 }
 
 void HdsDelegate::setHdsRetryTimer() {
@@ -44,9 +48,6 @@ void HdsDelegate::establishNewStream() {
     return;
   }
 
-  // TODO(lilika): Add support for other types of healthchecks
-  health_check_request_.mutable_capability()->add_health_check_protocol(
-      envoy::service::discovery::v2::Capability::HTTP);
   ENVOY_LOG(debug, "Sending HealthCheckRequest {} ", health_check_request_.DebugString());
   stream_->sendMessage(health_check_request_, false);
   stats_.responses_.inc();

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -141,6 +141,9 @@ void HdsDelegate::onReceiveMessage(
   stats_.requests_.inc();
   ENVOY_LOG(debug, "New health check response message {} ", message->DebugString());
 
+  // Reset
+  hds_clusters_.clear();
+
   // Process the HealthCheckSpecifier message
   processMessage(std::move(message));
 

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -24,11 +24,12 @@ HdsDelegate::HdsDelegate(const envoy::api::v2::core::Node& node, Stats::Scope& s
   health_check_request_.mutable_node()->MergeFrom(node);
   hds_retry_timer_ = dispatcher.createTimer([this]() -> void { establishNewStream(); });
   hds_stream_response_timer_ = dispatcher.createTimer([this]() -> void { sendResponse(); });
-  establishNewStream();
 
   // TODO(lilika): Add support for other types of healthchecks
   health_check_request_.mutable_capability()->add_health_check_protocol(
       envoy::service::discovery::v2::Capability::HTTP);
+
+  establishNewStream();
 }
 
 void HdsDelegate::setHdsRetryTimer() {

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -211,7 +211,7 @@ TEST_P(HdsIntegrationTest, SingleEndpointHealthy) {
   // Envoy reports back to server
   ASSERT_TRUE(hds_stream_->waitForGrpcMessage(*dispatcher_, response_));
 
-  // Check that the response_ is correct
+  // Check that the response is correct
   checkEndpointHealthResponse(response_.endpoint_health_response().endpoints_health(0),
                               envoy::api::v2::core::HealthStatus::HEALTHY,
                               host_upstream_->localAddress());
@@ -245,7 +245,7 @@ TEST_P(HdsIntegrationTest, SingleEndpointTimeout) {
   // Envoy reports back to server
   ASSERT_TRUE(hds_stream_->waitForGrpcMessage(*dispatcher_, response_));
 
-  // Check that the response_ is correct
+  // Check that the response is correct
   // TODO(lilika): Ideally this would be envoy::api::v2::core::HealthStatus::TIMEOUT
   checkEndpointHealthResponse(response_.endpoint_health_response().endpoints_health(0),
                               envoy::api::v2::core::HealthStatus::UNHEALTHY,
@@ -282,7 +282,7 @@ TEST_P(HdsIntegrationTest, SingleEndpointUnhealthy) {
   // Envoy reports back to server
   ASSERT_TRUE(hds_stream_->waitForGrpcMessage(*dispatcher_, response_));
 
-  // Check that the response_ is correct
+  // Check that the response is correct
   checkEndpointHealthResponse(response_.endpoint_health_response().endpoints_health(0),
                               envoy::api::v2::core::HealthStatus::UNHEALTHY,
                               host_upstream_->localAddress());
@@ -325,7 +325,7 @@ TEST_P(HdsIntegrationTest, TwoEndpointsSameLocality) {
   // Envoy reports back to server
   ASSERT_TRUE(hds_stream_->waitForGrpcMessage(*dispatcher_, response_));
 
-  // Check that the response_ is correct
+  // Check that the response is correct
   checkEndpointHealthResponse(response_.endpoint_health_response().endpoints_health(0),
                               envoy::api::v2::core::HealthStatus::UNHEALTHY,
                               host_upstream_->localAddress());
@@ -383,7 +383,7 @@ TEST_P(HdsIntegrationTest, TwoEndpointsDifferentLocality) {
   // Envoy reports back to server
   ASSERT_TRUE(hds_stream_->waitForGrpcMessage(*dispatcher_, response_));
 
-  // Check that the response_ is correct
+  // Check that the response is correct
   checkEndpointHealthResponse(response_.endpoint_health_response().endpoints_health(0),
                               envoy::api::v2::core::HealthStatus::UNHEALTHY,
                               host_upstream_->localAddress());
@@ -450,7 +450,7 @@ TEST_P(HdsIntegrationTest, TwoEndpointsDifferentClusters) {
   // Envoy reports back to server
   ASSERT_TRUE(hds_stream_->waitForGrpcMessage(*dispatcher_, response_));
 
-  // Check that the response_ is correct
+  // Check that the response is correct
   checkEndpointHealthResponse(response_.endpoint_health_response().endpoints_health(0),
                               envoy::api::v2::core::HealthStatus::UNHEALTHY,
                               host_upstream_->localAddress());
@@ -466,8 +466,8 @@ TEST_P(HdsIntegrationTest, TwoEndpointsDifferentClusters) {
   cleanupHdsConnection();
 }
 
-// Tests Envoy healthchecking a single endpoint and receiving an update
-// message from the management and healthchecking a new endpoint
+// Tests Envoy healthchecking a single endpoint, receiving an update
+// message from the management server and healthchecking a new endpoint
 TEST_P(HdsIntegrationTest, TestUpdateMessage) {
   initialize();
 
@@ -491,13 +491,15 @@ TEST_P(HdsIntegrationTest, TestUpdateMessage) {
   // Envoy reports back to server
   ASSERT_TRUE(hds_stream_->waitForGrpcMessage(*dispatcher_, response_));
 
-  // Check that the response_ is correct
+  // Check that the response is correct
   checkEndpointHealthResponse(response_.endpoint_health_response().endpoints_health(0),
                               envoy::api::v2::core::HealthStatus::HEALTHY,
                               host_upstream_->localAddress());
   checkCounters(1, 2, 1, 0);
 
   cleanupHostConnections();
+
+  // New HealthCheckSpecifier message
   envoy::service::discovery::v2::HealthCheckSpecifier new_message;
   new_message.mutable_interval()->set_seconds(1);
 
@@ -526,7 +528,7 @@ TEST_P(HdsIntegrationTest, TestUpdateMessage) {
   health_check->mutable_health_checks(0)->mutable_http_health_check()->set_use_http2(false);
   health_check->mutable_health_checks(0)->mutable_http_health_check()->set_path("/healthcheck");
 
-  // Server asks for healthchecking
+  // Server asks for healthchecking with the new message
   hds_stream_->sendGrpcMessage(new_message);
   test_server_->waitForCounterGe("hds_delegate.requests", ++hds_requests_);
 
@@ -542,7 +544,7 @@ TEST_P(HdsIntegrationTest, TestUpdateMessage) {
   // Envoy reports back to server
   ASSERT_TRUE(hds_stream_->waitForGrpcMessage(*dispatcher_, response_));
 
-  // Check that the response_ is correct
+  // Check that the response is correct
   checkEndpointHealthResponse(response_.endpoint_health_response().endpoints_health(0),
                               envoy::api::v2::core::HealthStatus::UNHEALTHY,
                               host2_upstream_->localAddress());

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -194,6 +194,8 @@ TEST_P(HdsIntegrationTest, SingleEndpointHealthy) {
   // Server <--> Envoy
   waitForHdsStream();
   ASSERT_TRUE(hds_stream_->waitForGrpcMessage(*dispatcher_, envoy_msg_));
+  EXPECT_EQ(envoy_msg_.capability().health_check_protocol(0),
+            envoy::service::discovery::v2::Capability::HTTP);
 
   // Server asks for healthchecking
   server_health_check_specifier_ = makeHealthCheckSpecifier();

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -466,5 +466,91 @@ TEST_P(HdsIntegrationTest, TwoEndpointsDifferentClusters) {
   cleanupHdsConnection();
 }
 
+// Tests Envoy healthchecking a single endpoint and receiving an update
+// message from the management and healthchecking a new endpoint
+TEST_P(HdsIntegrationTest, TestUpdateMessage) {
+  initialize();
+
+  // Server <--> Envoy
+  waitForHdsStream();
+  ASSERT_TRUE(hds_stream_->waitForGrpcMessage(*dispatcher_, envoy_msg_));
+
+  // Server asks for healthchecking
+  server_health_check_specifier_ = makeHealthCheckSpecifier();
+  hds_stream_->startGrpcStream();
+  hds_stream_->sendGrpcMessage(server_health_check_specifier_);
+  test_server_->waitForCounterGe("hds_delegate.requests", ++hds_requests_);
+
+  // Envoy sends a healthcheck message to an endpoint
+  healthcheckEndpoints();
+
+  // Endpoint responds to the healthcheck
+  host_stream_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+  host_stream_->encodeData(1024, true);
+
+  // Envoy reports back to server
+  ASSERT_TRUE(hds_stream_->waitForGrpcMessage(*dispatcher_, response_));
+
+  // Check that the response_ is correct
+  checkEndpointHealthResponse(response_.endpoint_health_response().endpoints_health(0),
+                              envoy::api::v2::core::HealthStatus::HEALTHY,
+                              host_upstream_->localAddress());
+  checkCounters(1, 2, 1, 0);
+
+  cleanupHostConnections();
+  envoy::service::discovery::v2::HealthCheckSpecifier new_message;
+  new_message.mutable_interval()->set_seconds(1);
+
+  auto* health_check = new_message.add_health_check();
+
+  health_check->set_cluster_name("cat");
+  health_check->add_endpoints()
+      ->add_endpoints()
+      ->mutable_address()
+      ->mutable_socket_address()
+      ->set_address(host2_upstream_->localAddress()->ip()->addressAsString());
+  health_check->mutable_endpoints(0)
+      ->mutable_endpoints(0)
+      ->mutable_address()
+      ->mutable_socket_address()
+      ->set_port_value(host2_upstream_->localAddress()->ip()->port());
+  health_check->mutable_endpoints(0)->mutable_locality()->set_region("peculiar_region");
+  health_check->mutable_endpoints(0)->mutable_locality()->set_zone("peculiar_zone");
+  health_check->mutable_endpoints(0)->mutable_locality()->set_sub_zone("paris");
+
+  health_check->add_health_checks()->mutable_timeout()->set_seconds(1);
+  health_check->mutable_health_checks(0)->mutable_interval()->set_seconds(1);
+  health_check->mutable_health_checks(0)->mutable_unhealthy_threshold()->set_value(2);
+  health_check->mutable_health_checks(0)->mutable_healthy_threshold()->set_value(2);
+  health_check->mutable_health_checks(0)->mutable_grpc_health_check();
+  health_check->mutable_health_checks(0)->mutable_http_health_check()->set_use_http2(false);
+  health_check->mutable_health_checks(0)->mutable_http_health_check()->set_path("/healthcheck");
+
+  // Server asks for healthchecking
+  hds_stream_->sendGrpcMessage(new_message);
+  test_server_->waitForCounterGe("hds_delegate.requests", ++hds_requests_);
+
+  // Envoy sends a healthcheck message to an endpoint
+  ASSERT_TRUE(host2_upstream_->waitForHttpConnection(*dispatcher_, host2_fake_connection_));
+  ASSERT_TRUE(host2_fake_connection_->waitForNewStream(*dispatcher_, host2_stream_));
+  ASSERT_TRUE(host2_stream_->waitForEndStream(*dispatcher_));
+
+  // Endpoint responds to the healthcheck
+  host2_stream_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "404"}}, false);
+  host2_stream_->encodeData(1024, true);
+
+  // Envoy reports back to server
+  ASSERT_TRUE(hds_stream_->waitForGrpcMessage(*dispatcher_, response_));
+
+  // Check that the response_ is correct
+  checkEndpointHealthResponse(response_.endpoint_health_response().endpoints_health(0),
+                              envoy::api::v2::core::HealthStatus::UNHEALTHY,
+                              host2_upstream_->localAddress());
+
+  // Clean up connections
+  cleanupHostConnections();
+  cleanupHdsConnection();
+}
+
 } // namespace
 } // namespace Envoy


### PR DESCRIPTION
*Description*:
When the HdsDelegate receives an update from the management server, it restarts all healthchecking. 

*Risk Level*:
Low
