### PR TITLE
Absl string view to std string in dynamic metadata

### DIFF
--- a/source/common/request_info/dynamic_metadata_impl.cc
+++ b/source/common/request_info/dynamic_metadata_impl.cc
@@ -6,6 +6,7 @@ namespace Envoy {
 namespace RequestInfo {
 
 void DynamicMetadataImpl::setData(absl::string_view data_name, std::unique_ptr<Object>&& data) {
+  // TODO(Google): Remove string conversion when fixed internally.
   if (data_storage_.find(std::string(data_name)) != data_storage_.end()) {
     throw EnvoyException("DynamicMetadata::setData<T> called twice with same name.");
   }
@@ -15,11 +16,13 @@ void DynamicMetadataImpl::setData(absl::string_view data_name, std::unique_ptr<O
 }
 
 bool DynamicMetadataImpl::hasDataWithName(absl::string_view data_name) const {
+  // TODO(Google): Remove string conversion when fixed internally.
   return data_storage_.count(std::string(data_name)) > 0;
 }
 
 const DynamicMetadata::Object*
 DynamicMetadataImpl::getDataGeneric(absl::string_view data_name) const {
+  // TODO(Google): Remove string conversion when fixed internally.
   const auto& it = data_storage_.find(std::string(data_name));
 
   if (it == data_storage_.end()) {

--- a/source/common/request_info/dynamic_metadata_impl.cc
+++ b/source/common/request_info/dynamic_metadata_impl.cc
@@ -6,7 +6,7 @@ namespace Envoy {
 namespace RequestInfo {
 
 void DynamicMetadataImpl::setData(absl::string_view data_name, std::unique_ptr<Object>&& data) {
-  if (data_storage_.find(data_name) != data_storage_.end()) {
+  if (data_storage_.find(std::string(data_name)) != data_storage_.end()) {
     throw EnvoyException("DynamicMetadata::setData<T> called twice with same name.");
   }
   // absl::string_view will not convert to std::string without an explicit case; see
@@ -15,12 +15,12 @@ void DynamicMetadataImpl::setData(absl::string_view data_name, std::unique_ptr<O
 }
 
 bool DynamicMetadataImpl::hasDataWithName(absl::string_view data_name) const {
-  return data_storage_.count(data_name) > 0;
+  return data_storage_.count(std::string(data_name)) > 0;
 }
 
 const DynamicMetadata::Object*
 DynamicMetadataImpl::getDataGeneric(absl::string_view data_name) const {
-  const auto& it = data_storage_.find(data_name);
+  const auto& it = data_storage_.find(std::string(data_name));
 
   if (it == data_storage_.end()) {
     throw EnvoyException("DynamicMetadata::getData<T> called for unknown data name.");

--- a/source/common/request_info/dynamic_metadata_impl.cc
+++ b/source/common/request_info/dynamic_metadata_impl.cc
@@ -7,12 +7,13 @@ namespace RequestInfo {
 
 void DynamicMetadataImpl::setData(absl::string_view data_name, std::unique_ptr<Object>&& data) {
   // TODO(Google): Remove string conversion when fixed internally.
-  if (data_storage_.find(std::string(data_name)) != data_storage_.end()) {
+  const std::string name(data_name);
+  if (data_storage_.find(name) != data_storage_.end()) {
     throw EnvoyException("DynamicMetadata::setData<T> called twice with same name.");
   }
   // absl::string_view will not convert to std::string without an explicit case; see
   // https://github.com/abseil/abseil-cpp/blob/master/absl/strings/string_view.h#L328
-  data_storage_[static_cast<std::string>(data_name)] = std::move(data);
+  data_storage_[name] = std::move(data);
 }
 
 bool DynamicMetadataImpl::hasDataWithName(absl::string_view data_name) const {


### PR DESCRIPTION
Signed-off-by: Henna Huang <henna@google.com>

For an explanation of how to fill out the fields, please see the relevant section 
in PULL_REQUESTS.md

*Description*: Convert absl string_view to std::string in the dynamic metadata library. This is needed for the Google import.
*Risk Level*: Low
*Testing*: Existing tests
*Docs Changes*: N/A
*Release Notes*: N/A
[Optional Fixes #Issue]
[Optional *Deprecated*:]
