### PR TITLE
Remove std::string cast in upstream impl lib and tests.

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -337,9 +337,8 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
 namespace {
 
 Stats::ScopePtr generateStatsScope(const envoy::api::v2::Cluster& config, Stats::Store& stats) {
-  return stats.createScope(fmt::format("cluster.{}.", config.alt_stat_name().empty()
-                                                          ? config.name()
-                                                          : std::string(config.alt_stat_name())));
+  return stats.createScope(fmt::format(
+      "cluster.{}.", config.alt_stat_name().empty() ? config.name() : config.alt_stat_name()));
 }
 
 Network::TransportSocketFactoryPtr createTransportSocketFactory(

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -54,10 +54,9 @@ protected:
     EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
     EXPECT_CALL(cluster, info()).Times(2);
     EXPECT_CALL(*cluster.info_, addedViaApi());
-    Envoy::Stats::ScopePtr scope = stats_.createScope(
-        fmt::format("cluster.{}.", eds_cluster_.alt_stat_name().empty()
-                                       ? eds_cluster_.name()
-                                       : std::string(eds_cluster_.alt_stat_name())));
+    Envoy::Stats::ScopePtr scope = stats_.createScope(fmt::format(
+        "cluster.{}.",
+        eds_cluster_.alt_stat_name().empty() ? eds_cluster_.name() : eds_cluster_.alt_stat_name()));
     Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
         ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, random_, stats_);
     cluster_.reset(

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -39,10 +39,9 @@ public:
     resolve_timer_ = new Event::MockTimer(&dispatcher_);
     NiceMock<MockClusterManager> cm;
     envoy::api::v2::Cluster cluster_config = parseClusterFromJson(json);
-    Envoy::Stats::ScopePtr scope = stats_store_.createScope(
-        fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                       ? cluster_config.name()
-                                       : std::string(cluster_config.alt_stat_name())));
+    Envoy::Stats::ScopePtr scope = stats_store_.createScope(fmt::format(
+        "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                              : cluster_config.alt_stat_name()));
     Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
         ssl_context_manager_, *scope, cm, local_info_, dispatcher_, random_, stats_store_);
     cluster_.reset(new LogicalDnsCluster(cluster_config, runtime_, dns_resolver_, tls_,
@@ -58,10 +57,9 @@ public:
     resolve_timer_ = new Event::MockTimer(&dispatcher_);
     NiceMock<MockClusterManager> cm;
     envoy::api::v2::Cluster cluster_config = parseClusterFromV2Yaml(yaml);
-    Envoy::Stats::ScopePtr scope = stats_store_.createScope(
-        fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                       ? cluster_config.name()
-                                       : std::string(cluster_config.alt_stat_name())));
+    Envoy::Stats::ScopePtr scope = stats_store_.createScope(fmt::format(
+        "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                              : cluster_config.alt_stat_name()));
     Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
         ssl_context_manager_, *scope, cm, local_info_, dispatcher_, random_, stats_store_);
     cluster_.reset(new LogicalDnsCluster(cluster_config, runtime_, dns_resolver_, tls_,

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -67,10 +67,9 @@ public:
 
   void setup(const envoy::api::v2::Cluster& cluster_config) {
     NiceMock<MockClusterManager> cm;
-    Envoy::Stats::ScopePtr scope = stats_store_.createScope(
-        fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                       ? cluster_config.name()
-                                       : std::string(cluster_config.alt_stat_name())));
+    Envoy::Stats::ScopePtr scope = stats_store_.createScope(fmt::format(
+        "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                              : cluster_config.alt_stat_name()));
     Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
         ssl_context_manager_, *scope, cm, local_info_, dispatcher_, random_, stats_store_);
     cluster_.reset(

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -72,10 +72,9 @@ protected:
     EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_map));
     EXPECT_CALL(cluster, info()).Times(2);
     EXPECT_CALL(*cluster.info_, addedViaApi());
-    Envoy::Stats::ScopePtr scope = stats_.createScope(
-        fmt::format("cluster.{}.", sds_cluster_.alt_stat_name().empty()
-                                       ? sds_cluster_.name()
-                                       : std::string(sds_cluster_.alt_stat_name())));
+    Envoy::Stats::ScopePtr scope = stats_.createScope(fmt::format(
+        "cluster.{}.",
+        sds_cluster_.alt_stat_name().empty() ? sds_cluster_.name() : sds_cluster_.alt_stat_name()));
     Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
         ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, random_, stats_);
     cluster_.reset(

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -147,10 +147,9 @@ TEST_P(StrictDnsParamTest, ImmediateResolve) {
       }));
   NiceMock<MockClusterManager> cm;
   envoy::api::v2::Cluster cluster_config = parseClusterFromJson(json);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
 
@@ -183,10 +182,9 @@ TEST(StrictDnsClusterImplTest, ZeroHostsHealthChecker) {
 
   ResolverData resolver(*dns_resolver, dispatcher);
   envoy::api::v2::Cluster cluster_config = parseClusterFromV2Yaml(yaml);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
   StrictDnsClusterImpl cluster(cluster_config, runtime, dns_resolver, factory_context,
@@ -249,10 +247,9 @@ TEST(StrictDnsClusterImplTest, Basic) {
 
   NiceMock<MockClusterManager> cm;
   envoy::api::v2::Cluster cluster_config = parseClusterFromJson(json);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
   StrictDnsClusterImpl cluster(cluster_config, runtime, dns_resolver, factory_context,
@@ -374,10 +371,9 @@ TEST(StrictDnsClusterImplTest, HostRemovalActiveHealthSkipped) {
 
   ResolverData resolver(*dns_resolver, dispatcher);
   envoy::api::v2::Cluster cluster_config = parseClusterFromV2Yaml(yaml);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
   StrictDnsClusterImpl cluster(cluster_config, runtime, dns_resolver, factory_context,
@@ -473,10 +469,9 @@ TEST(StrictDnsClusterImplTest, LoadAssignmentBasic) {
 
   NiceMock<MockClusterManager> cm;
   envoy::api::v2::Cluster cluster_config = parseClusterFromV2Yaml(yaml);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
   StrictDnsClusterImpl cluster(cluster_config, runtime, dns_resolver, factory_context,
@@ -631,10 +626,9 @@ TEST(StrictDnsClusterImplTest, LoadAssignmentBasicMultiplePriorities) {
 
   NiceMock<MockClusterManager> cm;
   envoy::api::v2::Cluster cluster_config = parseClusterFromV2Yaml(yaml);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
   StrictDnsClusterImpl cluster(cluster_config, runtime, dns_resolver, factory_context,
@@ -786,10 +780,9 @@ TEST(StaticClusterImplTest, InitialHosts) {
 
   NiceMock<MockClusterManager> cm;
   envoy::api::v2::Cluster cluster_config = parseClusterFromV2Yaml(yaml);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
   StaticClusterImpl cluster(cluster_config, runtime, factory_context, std::move(scope), false);
@@ -820,10 +813,9 @@ TEST(StaticClusterImplTest, EmptyHostname) {
 
   NiceMock<MockClusterManager> cm;
   envoy::api::v2::Cluster cluster_config = parseClusterFromJson(json);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
   StaticClusterImpl cluster(cluster_config, runtime, factory_context, std::move(scope), false);
@@ -860,10 +852,9 @@ TEST(StaticClusterImplTest, LoadAssignmentEmptyHostname) {
 
   NiceMock<MockClusterManager> cm;
   envoy::api::v2::Cluster cluster_config = parseClusterFromV2Yaml(yaml);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
   StaticClusterImpl cluster(cluster_config, runtime, factory_context, std::move(scope), false);
@@ -919,10 +910,9 @@ TEST(StaticClusterImplTest, LoadAssignmentMultiplePriorities) {
 
   NiceMock<MockClusterManager> cm;
   envoy::api::v2::Cluster cluster_config = parseClusterFromV2Yaml(yaml);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
   StaticClusterImpl cluster(cluster_config, runtime, factory_context, std::move(scope), false);
@@ -972,10 +962,9 @@ TEST(StaticClusterImplTest, LoadAssignmentLocality) {
 
   NiceMock<MockClusterManager> cm;
   envoy::api::v2::Cluster cluster_config = parseClusterFromV2Yaml(yaml);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
   StaticClusterImpl cluster(cluster_config, runtime, factory_context, std::move(scope), false);
@@ -1012,10 +1001,9 @@ TEST(StaticClusterImplTest, AltStatName) {
 
   NiceMock<MockClusterManager> cm;
   envoy::api::v2::Cluster cluster_config = parseClusterFromV2Yaml(yaml);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
   StaticClusterImpl cluster(cluster_config, runtime, factory_context, std::move(scope), false);
@@ -1045,10 +1033,9 @@ TEST(StaticClusterImplTest, RingHash) {
 
   NiceMock<MockClusterManager> cm;
   envoy::api::v2::Cluster cluster_config = parseClusterFromJson(json);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
   StaticClusterImpl cluster(cluster_config, runtime, factory_context, std::move(scope), true);
@@ -1080,10 +1067,9 @@ TEST(StaticClusterImplTest, OutlierDetector) {
 
   NiceMock<MockClusterManager> cm;
   envoy::api::v2::Cluster cluster_config = parseClusterFromJson(json);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
   StaticClusterImpl cluster(cluster_config, runtime, factory_context, std::move(scope), false);
@@ -1137,10 +1123,9 @@ TEST(StaticClusterImplTest, HealthyStat) {
 
   NiceMock<MockClusterManager> cm;
   envoy::api::v2::Cluster cluster_config = parseClusterFromJson(json);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
   StaticClusterImpl cluster(cluster_config, runtime, factory_context, std::move(scope), false);
@@ -1229,10 +1214,9 @@ TEST(StaticClusterImplTest, UrlConfig) {
 
   NiceMock<MockClusterManager> cm;
   envoy::api::v2::Cluster cluster_config = parseClusterFromJson(json);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
   StaticClusterImpl cluster(cluster_config, runtime, factory_context, std::move(scope), false);
@@ -1284,10 +1268,10 @@ TEST(StaticClusterImplTest, UnsupportedLBType) {
   EXPECT_THROW_WITH_MESSAGE(
       {
         envoy::api::v2::Cluster cluster_config = parseClusterFromJson(json);
-        Envoy::Stats::ScopePtr scope = stats.createScope(
-            fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                           ? cluster_config.name()
-                                           : std::string(cluster_config.alt_stat_name())));
+        Envoy::Stats::ScopePtr scope =
+            stats.createScope(fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
+                                                             ? cluster_config.name()
+                                                             : cluster_config.alt_stat_name()));
         Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
             ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
         StaticClusterImpl(cluster_config, runtime, factory_context, std::move(scope), false);
@@ -1317,10 +1301,9 @@ TEST(StaticClusterImplTest, MalformedHostIP) {
 
   NiceMock<MockClusterManager> cm;
   envoy::api::v2::Cluster cluster_config = parseClusterFromV2Yaml(yaml);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
   EXPECT_THROW_WITH_MESSAGE(
@@ -1379,8 +1362,7 @@ TEST(StaticClusterImplTest, SourceAddressPriority) {
     NiceMock<MockClusterManager> cm;
     cm.bind_config_.mutable_source_address()->set_address("1.2.3.5");
     Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
-        "cluster.{}.",
-        config.alt_stat_name().empty() ? config.name() : std::string(config.alt_stat_name())));
+        "cluster.{}.", config.alt_stat_name().empty() ? config.name() : config.alt_stat_name()));
     Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
         ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
     StaticClusterImpl cluster(config, runtime, factory_context, std::move(scope), false);
@@ -1393,8 +1375,7 @@ TEST(StaticClusterImplTest, SourceAddressPriority) {
     // Verify source address from cluster config is used when present.
     NiceMock<MockClusterManager> cm;
     Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
-        "cluster.{}.",
-        config.alt_stat_name().empty() ? config.name() : std::string(config.alt_stat_name())));
+        "cluster.{}.", config.alt_stat_name().empty() ? config.name() : config.alt_stat_name()));
     Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
         ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
     StaticClusterImpl cluster(config, runtime, factory_context, std::move(scope), false);
@@ -1406,8 +1387,7 @@ TEST(StaticClusterImplTest, SourceAddressPriority) {
     NiceMock<MockClusterManager> cm;
     cm.bind_config_.mutable_source_address()->set_address("1.2.3.5");
     Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
-        "cluster.{}.",
-        config.alt_stat_name().empty() ? config.name() : std::string(config.alt_stat_name())));
+        "cluster.{}.", config.alt_stat_name().empty() ? config.name() : config.alt_stat_name()));
     Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
         ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
     StaticClusterImpl cluster(config, runtime, factory_context, std::move(scope), false);
@@ -1437,10 +1417,9 @@ TEST(ClusterImplTest, CloseConnectionsOnHostHealthFailure) {
     hosts: [{ socket_address: { address: foo.bar.com, port_value: 443 }}]
   )EOF";
   envoy::api::v2::Cluster cluster_config = parseClusterFromV2Yaml(yaml);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
 
@@ -1524,10 +1503,9 @@ TEST(ClusterMetadataTest, Metadata) {
   )EOF";
 
   envoy::api::v2::Cluster cluster_config = parseClusterFromV2Yaml(yaml);
-  Envoy::Stats::ScopePtr scope = stats.createScope(
-      fmt::format("cluster.{}.", cluster_config.alt_stat_name().empty()
-                                     ? cluster_config.name()
-                                     : std::string(cluster_config.alt_stat_name())));
+  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
+      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                            : cluster_config.alt_stat_name()));
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
   StrictDnsClusterImpl cluster(cluster_config, runtime, dns_resolver, factory_context,


### PR DESCRIPTION
Signed-off-by: Henna Huang <henna@google.com>

*Description*: Remove std::string cast of upstream protobuf string fields. This breaks the Google import.
*Risk Level*: Low
*Testing*: Existing tests
*Docs Changes*: N/A
*Release Notes*: N/A
[Optional Fixes #Issue]
[Optional *Deprecated*:]
