### PR TITLE
admin: change adminRequest to return a future

### DIFF
--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -93,16 +93,21 @@ bool MainCommonBase::run() {
   NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
-void MainCommonBase::adminRequest(absl::string_view path_and_query, absl::string_view method,
-                                  const AdminRequestFn& handler) {
+std::future<AdminResponse> MainCommonBase::adminRequest(absl::string_view path_and_query,
+                                                        absl::string_view method) {
   std::string path_and_query_buf = std::string(path_and_query);
   std::string method_buf = std::string(method);
-  server_->dispatcher().post([this, path_and_query_buf, method_buf, handler]() {
-    Http::HeaderMapImpl response_headers;
-    std::string body;
-    server_->admin().request(path_and_query_buf, method_buf, response_headers, body);
-    handler(response_headers, body);
-  });
+  // Note: must be a shared_ptr to allow the std::function to be copyable.
+  auto promise = std::make_shared<std::promise<AdminResponse>>();
+  std::future<AdminResponse> future = promise->get_future();
+  server_->dispatcher().post(
+      [ this, path_and_query_buf, method_buf, promise{std::move(promise)} ]() {
+        AdminResponse response;
+        response.headers = std::make_unique<Http::HeaderMapImpl>();
+        server_->admin().request(path_and_query_buf, method_buf, *response.headers, response.body);
+        promise->set_value(std::move(response));
+      });
+  return future;
 }
 
 MainCommon::MainCommon(int argc, const char* const* argv)

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -98,16 +98,16 @@ std::future<AdminResponse> MainCommonBase::adminRequest(absl::string_view path_a
   std::string path_and_query_buf = std::string(path_and_query);
   std::string method_buf = std::string(method);
   // Note: must be a shared_ptr to allow the std::function to be copyable.
-  auto promise = std::make_shared<std::promise<AdminResponse>>();
-  std::future<AdminResponse> future = promise->get_future();
+  auto response_promise = std::make_shared<std::promise<AdminResponse>>();
+  std::future<AdminResponse> response_future = response_promise->get_future();
   server_->dispatcher().post(
-      [ this, path_and_query_buf, method_buf, promise{std::move(promise)} ]() {
+      [ this, path_and_query_buf, method_buf, response_promise{std::move(response_promise)} ]() {
         AdminResponse response;
         response.headers = std::make_unique<Http::HeaderMapImpl>();
         server_->admin().request(path_and_query_buf, method_buf, *response.headers, response.body);
-        promise->set_value(std::move(response));
+        response_promise->set_value(std::move(response));
       });
-  return future;
+  return response_future;
 }
 
 MainCommon::MainCommon(int argc, const char* const* argv)

--- a/source/exe/main_common.h
+++ b/source/exe/main_common.h
@@ -35,18 +35,14 @@ public:
 
   bool run();
 
-  // Makes an admin-console request by path, calling handler() when complete.
-  // The caller can initiate this from any thread, but it posts the request
-  // onto the main thread, so the handler is called asynchronously.
+  // Makes an admin-console request by path. Returns a future that can be used
+  // to access the response once ready.
   //
   // This is designed to be called from downstream consoles, so they can access
   // the admin console information stream without opening up a network port.
   //
   // This should only be called while run() is active; ensuring this is the
   // responsibility of the caller.
-  //
-  // TODO(jmarantz): consider std::future for encapsulating this delayed request
-  // semantics, rather than a handler callback.
   std::future<AdminResponse> adminRequest(absl::string_view path_and_query,
                                           absl::string_view method);
 
@@ -67,9 +63,8 @@ public:
   MainCommon(int argc, const char* const* argv);
   bool run() { return base_.run(); }
 
-  // Makes an admin-console request by path, calling handler() when complete.
-  // The caller can initiate this from any thread, but it posts the request
-  // onto the main thread, so the handler is called asynchronously.
+  // Makes an admin-console request by path. Returns a future that can be used
+  // to access the response once ready.
   //
   // This is designed to be called from downstream consoles, so they can access
   // the admin console information stream without opening up a network port.

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -90,8 +90,8 @@ public:
   // Runs a an admin request specified in path, blocking until completion, and
   // returning the response body.
   std::string adminRequest(absl::string_view path, absl::string_view method) {
-    auto future = main_common_->adminRequest(path, method);
-    return future.get().body;
+    std::future<AdminResponse> response_future = main_common_->adminRequest(path, method);
+    return response_future.get().body;
   }
 
   // Initiates Envoy running in its own thread.

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -90,26 +90,9 @@ public:
   // Runs a an admin request specified in path, blocking until completion, and
   // returning the response body.
   std::string adminRequest(absl::string_view path, absl::string_view method) {
-    Thread::MutexBasicLockable mutex;
-    Thread::CondVar condvar;
-    bool done = false;
-    std::string out;
-    main_common_->adminRequest(
-        path, method,
-        [&mutex, &condvar, &done, &out](const Http::HeaderMap& /*response_headers*/,
-                                        absl::string_view body) {
-          Thread::LockGuard lock(mutex);
-          out = std::string(body);
-          done = true;
-          condvar.notifyOne();
-        });
-    {
-      Thread::LockGuard lock(mutex);
-      while (!done) {
-        condvar.wait(mutex);
-      }
-    }
-    return out;
+    auto future = main_common_->adminRequest(path, method);
+    future.wait();
+    return future.get().body;
   }
 
   // Initiates Envoy running in its own thread.

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -91,7 +91,6 @@ public:
   // returning the response body.
   std::string adminRequest(absl::string_view path, absl::string_view method) {
     auto future = main_common_->adminRequest(path, method);
-    future.wait();
     return future.get().body;
   }
 


### PR DESCRIPTION
*Description*: Moved the `adminRequest()` function that operates at the boundary of Envoy to return a future so the caller doesn't have to be concerned with the thread safety of their callback function.

Note: please see the test for an example of how this simplifies the interface for the caller.

*Risk Level*:
*Testing*: Updated tests.
