### PR TITLE
Add thread local cache of overload action states

### DIFF
--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -167,6 +167,7 @@ envoy_cc_library(
     deps = [
         "//include/envoy/server:overload_manager_interface",
         "//include/envoy/stats:stats_interface",
+        "//include/envoy/thread_local:thread_local_interface",
         "//source/common/common:logger_lib",
         "//source/common/config:utility_lib",
         "//source/server:resource_monitor_config_lib",

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -84,8 +84,9 @@ bool OverloadAction::isActive() const { return !fired_triggers_.empty(); }
 
 OverloadManagerImpl::OverloadManagerImpl(
     Event::Dispatcher& dispatcher, Stats::Scope& stats_scope,
+    ThreadLocal::SlotAllocator& slot_allocator,
     const envoy::config::overload::v2alpha::OverloadManager& config)
-    : started_(false), dispatcher_(dispatcher),
+    : started_(false), dispatcher_(dispatcher), tls_(slot_allocator.allocateSlot()),
       refresh_interval_(
           std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(config, refresh_interval, 1000))) {
   Configuration::ResourceMonitorFactoryContextImpl context(dispatcher);
@@ -125,6 +126,10 @@ OverloadManagerImpl::OverloadManagerImpl(
       resource_to_actions_.insert(std::make_pair(resource, name));
     }
   }
+
+  tls_->set([](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
+    return std::make_shared<OverloadActionStateCache>();
+  });
 }
 
 void OverloadManagerImpl::start() {
@@ -157,6 +162,10 @@ void OverloadManagerImpl::registerForAction(const std::string& action,
                                std::forward_as_tuple(dispatcher, callback));
 }
 
+const OverloadActionStateCache& OverloadManagerImpl::getOverloadActionStateCache() {
+  return tls_->getTyped<OverloadActionStateCache>();
+}
+
 void OverloadManagerImpl::updateResourcePressure(const std::string& resource, double pressure) {
   auto action_range = resource_to_actions_.equal_range(resource);
   std::for_each(action_range.first, action_range.second,
@@ -170,6 +179,9 @@ void OverloadManagerImpl::updateResourcePressure(const std::string& resource, do
                         is_active ? OverloadActionState::Active : OverloadActionState::Inactive;
                     ENVOY_LOG(info, "Overload action {} has become {}", action,
                               is_active ? "active" : "inactive");
+                    tls_->runOnAllThreads([this, action, state] {
+                      tls_->getTyped<OverloadActionStateCache>().setState(action, state);
+                    });
                     auto callback_range = action_to_callbacks_.equal_range(action);
                     std::for_each(callback_range.first, callback_range.second,
                                   [&](ActionToCallbackMap::value_type& cb_entry) {

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -128,7 +128,7 @@ OverloadManagerImpl::OverloadManagerImpl(
   }
 
   tls_->set([](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
-    return std::make_shared<OverloadActionStateCache>();
+    return std::make_shared<ThreadLocalOverloadState>();
   });
 }
 
@@ -162,8 +162,8 @@ void OverloadManagerImpl::registerForAction(const std::string& action,
                                std::forward_as_tuple(dispatcher, callback));
 }
 
-const OverloadActionStateCache& OverloadManagerImpl::getOverloadActionStateCache() {
-  return tls_->getTyped<OverloadActionStateCache>();
+ThreadLocalOverloadState& OverloadManagerImpl::getThreadLocalOverloadState() {
+  return tls_->getTyped<ThreadLocalOverloadState>();
 }
 
 void OverloadManagerImpl::updateResourcePressure(const std::string& resource, double pressure) {
@@ -180,7 +180,7 @@ void OverloadManagerImpl::updateResourcePressure(const std::string& resource, do
                     ENVOY_LOG(info, "Overload action {} has become {}", action,
                               is_active ? "active" : "inactive");
                     tls_->runOnAllThreads([this, action, state] {
-                      tls_->getTyped<OverloadActionStateCache>().setState(action, state);
+                      tls_->getTyped<ThreadLocalOverloadState>().setState(action, state);
                     });
                     auto callback_range = action_to_callbacks_.equal_range(action);
                     std::for_each(callback_range.first, callback_range.second,

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -11,6 +11,7 @@
 #include "envoy/server/resource_monitor.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats.h"
+#include "envoy/thread_local/thread_local.h"
 
 #include "common/common/logger.h"
 
@@ -50,12 +51,14 @@ private:
 class OverloadManagerImpl : Logger::Loggable<Logger::Id::main>, public OverloadManager {
 public:
   OverloadManagerImpl(Event::Dispatcher& dispatcher, Stats::Scope& stats_scope,
+                      ThreadLocal::SlotAllocator& slot_allocator,
                       const envoy::config::overload::v2alpha::OverloadManager& config);
 
   // Server::OverloadManager
   void start() override;
   void registerForAction(const std::string& action, Event::Dispatcher& dispatcher,
                          OverloadActionCb callback) override;
+  const OverloadActionStateCache& getOverloadActionStateCache() override;
 
 private:
   class Resource : public ResourceMonitor::Callbacks {
@@ -90,6 +93,7 @@ private:
 
   bool started_;
   Event::Dispatcher& dispatcher_;
+  ThreadLocal::SlotPtr tls_;
   const std::chrono::milliseconds refresh_interval_;
   Event::TimerPtr timer_;
   std::unordered_map<std::string, Resource> resources_;

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -58,7 +58,7 @@ public:
   void start() override;
   void registerForAction(const std::string& action, Event::Dispatcher& dispatcher,
                          OverloadActionCb callback) override;
-  const OverloadActionStateCache& getOverloadActionStateCache() override;
+  ThreadLocalOverloadState& getThreadLocalOverloadState() override;
 
 private:
   class Resource : public ResourceMonitor::Callbacks {

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -247,10 +247,6 @@ void InstanceImpl::initialize(Options& options,
 
   loadServerFlags(initial_config.flagsPath());
 
-  // Initialize the overload manager early so other modules can register for actions.
-  overload_manager_.reset(
-      new OverloadManagerImpl(dispatcher(), stats(), bootstrap_.overload_manager()));
-
   // Workers get created first so they register for thread local updates.
   listener_manager_.reset(new ListenerManagerImpl(
       *this, listener_component_factory_, worker_factory_, ProdSystemTimeSource::instance_));
@@ -258,6 +254,10 @@ void InstanceImpl::initialize(Options& options,
   // The main thread is also registered for thread local updates so that code that does not care
   // whether it runs on the main thread or on workers can still use TLS.
   thread_local_.registerThread(*dispatcher_, true);
+
+  // Initialize the overload manager early so other modules can register for actions.
+  overload_manager_.reset(
+      new OverloadManagerImpl(dispatcher(), stats(), threadLocal(), bootstrap_.overload_manager()));
 
   // We can now initialize stats for threading.
   stats_store_.initializeThreading(*dispatcher_, thread_local_);

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -282,6 +282,7 @@ public:
   MOCK_METHOD0(start, void());
   MOCK_METHOD3(registerForAction, void(const std::string& action, Event::Dispatcher& dispatcher,
                                        OverloadActionCb callback));
+  MOCK_METHOD0(getOverloadActionStateCache, const OverloadActionStateCache&());
 };
 
 class MockInstance : public Instance {

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -282,7 +282,7 @@ public:
   MOCK_METHOD0(start, void());
   MOCK_METHOD3(registerForAction, void(const std::string& action, Event::Dispatcher& dispatcher,
                                        OverloadActionCb callback));
-  MOCK_METHOD0(getOverloadActionStateCache, const OverloadActionStateCache&());
+  MOCK_METHOD0(getThreadLocalOverloadState, ThreadLocalOverloadState&());
 };
 
 class MockInstance : public Instance {

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -122,6 +122,7 @@ envoy_cc_test(
         "//source/extensions/resource_monitors/common:factory_base_lib",
         "//source/server:overload_manager_lib",
         "//test/mocks/event:event_mocks",
+        "//test/mocks/thread_local:thread_local_mocks",
         "//test/test_common:registry_lib",
         "//test/test_common:utility_lib",
     ],


### PR DESCRIPTION
Lookups in this cache can be used as an alternative to registering a callback for overload action state changes. Useful for objects (like the http connection manager) with dynamic lifetimes that are created after envoy initialization - currently callback registration must be done during initialization and there isn't support for unregistration. Those restrictions could be relaxed if we need to in the future but for now this keeps things simpler. For issue #373. 

*Risk Level*: low
*Testing*: unit tests

Signed-off-by: Elisha Ziskind <eziskind@google.com>
