### PR TITLE
source_ip_access: add source IP access filter

### DIFF
--- a/api/docs/BUILD
+++ b/api/docs/BUILD
@@ -48,6 +48,7 @@ proto_library(
         "//envoy/config/filter/network/mongo_proxy/v2:mongo_proxy",
         "//envoy/config/filter/network/rate_limit/v2:rate_limit",
         "//envoy/config/filter/network/redis_proxy/v2:redis_proxy",
+        "//envoy/config/filter/network/source_ip_access/v2:source_ip_access",
         "//envoy/config/filter/network/tcp_proxy/v2:tcp_proxy",
         "//envoy/config/grpc_credential/v2alpha:file_based_metadata",
         "//envoy/config/health_checker/redis/v2:redis",

--- a/api/envoy/config/filter/network/source_ip_access/v2/BUILD
+++ b/api/envoy/config/filter/network/source_ip_access/v2/BUILD
@@ -1,0 +1,9 @@
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "source_ip_access",
+    srcs = ["source_ip_access.proto"],
+    deps = ["//envoy/api/v2/core:address"],
+)

--- a/api/envoy/config/filter/network/source_ip_access/v2/source_ip_access.proto
+++ b/api/envoy/config/filter/network/source_ip_access/v2/source_ip_access.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package envoy.config.filter.network.source_ip_access.v2;
+option go_package = "v2";
+
+import "envoy/api/v2/core/address.proto";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Source IP Access ]
+// Source IP Access
+// :ref:`configuration overview <config_network_filters_source_ip_access>`.
+
+// Source IP Access filter allows whitelisting or blacklisting IP addresses using CIDR notation.
+// TCP connections from IP addresses that are denied will be closed immediately.
+message SourceIpAccess {
+  // The prefix to use when emitting statistics.
+  string stat_prefix = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Will accept all connections other than from addresses specified in exception_prefixes field if
+  // true. Will deny all connections other than from addresses specified in exception_prefixes field
+  // if false.
+  bool allow_by_default = 2;
+
+  // List of source IP addresses to be exceptions from the default behavior.
+  repeated envoy.api.v2.core.CidrRange exception_prefixes = 3;
+}

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -95,6 +95,7 @@ PROTO_RST="
   /envoy/config/filter/http/transcoder/v2/transcoder/envoy/config/filter/http/transcoder/v2/transcoder.proto.rst
   /envoy/config/filter/network/client_ssl_auth/v2/client_ssl_auth/envoy/config/filter/network/client_ssl_auth/v2/client_ssl_auth.proto.rst
   /envoy/config/filter/network/ext_authz/v2/ext_authz/envoy/config/filter/network/ext_authz/v2/ext_authz.proto.rst
+  /envoy/config/filter/network/source_ip_access/v2/source_ip_access/envoy/config/filter/network/source_ip_access/v2/source_ip_access.proto.rst
   /envoy/config/filter/network/http_connection_manager/v2/http_connection_manager/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto.rst
   /envoy/config/filter/network/mongo_proxy/v2/mongo_proxy/envoy/config/filter/network/mongo_proxy/v2/mongo_proxy.proto.rst
   /envoy/config/filter/network/rate_limit/v2/rate_limit/envoy/config/filter/network/rate_limit/v2/rate_limit.proto.rst

--- a/docs/root/configuration/network_filters/network_filters.rst
+++ b/docs/root/configuration/network_filters/network_filters.rst
@@ -17,3 +17,4 @@ filters.
   rate_limit_filter
   redis_proxy_filter
   tcp_proxy_filter
+  source_ip_access_filter

--- a/docs/root/configuration/network_filters/source_ip_access_filter.rst
+++ b/docs/root/configuration/network_filters/source_ip_access_filter.rst
@@ -1,0 +1,47 @@
+.. _config_network_filters_source_ip_access:
+
+Source IP access
+======================
+
+* :ref:`Architecture overview <arch_overview_source_ip_access_filter>`
+* :ref:`Network filter v2 API reference <envoy_api_msg_config.filter.network.source_ip_access.v2.SourceIpAccess>`
+
+
+Source IP access filter will immediately close the TCP connection if:
+
+* the filter is configured to allow connections by default and the source address is on the exception list, or
+* the filter is configured to deny connections by default and the source address in not on the exception list.
+
+Otherwise, connection will continue to next filters.
+  
+.. tip::
+  It is recommended that the filter is configured as the first filter in the filter chain so
+  that the requests are access controlled prior to rest of the filters processing the request.
+
+Example
+-------
+
+A sample filter configuration could be:
+
+.. code-block:: yaml
+
+  filters:
+    - name: envoy.source_ip_access
+      stat_prefix: source_ip_access
+      allow_by_default: false
+      exception_prefixes:
+      - address_prefix: 10.0.0.0
+        prefix_len: 8
+
+Statistics
+----------
+
+The network filter outputs statistics in the *config.<stat_prefix>.* namespace.
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: 1, 1, 2
+
+  total, Counter, Total number of responses from the filter.
+  allowed, Counter, Number of allowed responses from the filter.
+  denied, Counter, Number of denied responses from the filter.

--- a/docs/root/intro/arch_overview/arch_overview.rst
+++ b/docs/root/intro/arch_overview/arch_overview.rst
@@ -38,3 +38,4 @@ Architecture overview
   scripting
   ext_authz_filter
   overload_manager
+  source_ip_access_filter

--- a/docs/root/intro/arch_overview/source_ip_access_filter.rst
+++ b/docs/root/intro/arch_overview/source_ip_access_filter.rst
@@ -1,0 +1,9 @@
+.. _arch_overview_source_ip_access_filter:
+
+Source IP access
+======================
+
+* :ref:`Network filter configuration <config_network_filters_source_ip_access>`.
+
+
+Source IP access filter allows to configure whitelist or blacklist of IP addresses that will be allowed or denied further processing.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -3,6 +3,7 @@ Version history
 
 1.8.0 (Pending)
 ===============
+* access filter: added :ref:`Source IP access filter <config_network_filters_source_ip_access>`.
 * access log: added :ref:`response flag filter <envoy_api_msg_config.filter.accesslog.v2.ResponseFlagFilter>`
   to filter based on the presence of Envoy response flags.
 * access log: added RESPONSE_DURATION and RESPONSE_TX_DURATION.

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -69,6 +69,7 @@ EXTENSIONS = {
     "envoy.filters.network.ratelimit":                  "//source/extensions/filters/network/ratelimit:config",
     "envoy.filters.network.tcp_proxy":                  "//source/extensions/filters/network/tcp_proxy:config",
     "envoy.filters.network.thrift_proxy":               "//source/extensions/filters/network/thrift_proxy:config",
+    "envoy.filters.network.source_ip_access":           "//source/extensions/filters/network/source_ip_access:config",  
 
     #
     # Resource monitors

--- a/source/extensions/filters/network/source_ip_access/BUILD
+++ b/source/extensions/filters/network/source_ip_access/BUILD
@@ -1,0 +1,39 @@
+licenses(["notice"])  # Apache 2
+
+# Source IP access filter
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "source_ip_access",
+    srcs = ["source_ip_access.cc"],
+    hdrs = ["source_ip_access.h"],
+    deps = [
+        "//include/envoy/network:connection_interface",
+        "//include/envoy/network:filter_interface",
+        "//include/envoy/runtime:runtime_interface",
+        "//include/envoy/stats:stats_macros",
+        "//source/common/network:lc_trie_lib",
+        "@envoy_api//envoy/config/filter/network/source_ip_access/v2:source_ip_access_cc",
+    ],
+)
+
+envoy_cc_library(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    deps = [
+        "//include/envoy/registry",
+        "//source/common/protobuf:utility_lib",
+        "//source/extensions/filters/network:well_known_names",
+        "//source/extensions/filters/network/common:factory_base_lib",
+        "//source/extensions/filters/network/source_ip_access",
+        "@envoy_api//envoy/config/filter/network/source_ip_access/v2:source_ip_access_cc",
+    ],
+)

--- a/source/extensions/filters/network/source_ip_access/config.cc
+++ b/source/extensions/filters/network/source_ip_access/config.cc
@@ -1,0 +1,37 @@
+#include "extensions/filters/network/source_ip_access/config.h"
+
+#include "envoy/config/filter/network/source_ip_access/v2/source_ip_access.pb.validate.h"
+#include "envoy/network/connection.h"
+#include "envoy/registry/registry.h"
+
+#include "common/protobuf/utility.h"
+
+#include "extensions/filters/network/source_ip_access/source_ip_access.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace SourceIpAccess {
+
+Network::FilterFactoryCb SourceIpAccessConfigFactory::createFilterFactoryFromProtoTyped(
+    const envoy::config::filter::network::source_ip_access::v2::SourceIpAccess& proto_config,
+    Server::Configuration::FactoryContext& context) {
+  ConfigSharedPtr source_ip_access_config(std::make_shared<Config>(proto_config, context.scope()));
+
+  return [source_ip_access_config](Network::FilterManager& filter_manager) -> void {
+    filter_manager.addReadFilter(
+        Network::ReadFilterSharedPtr{std::make_shared<Filter>(source_ip_access_config)});
+  };
+}
+
+/**
+ * Static registration for the source ip access filter. @see RegisterFactory.
+ */
+static Registry::RegisterFactory<SourceIpAccessConfigFactory,
+                                 Server::Configuration::NamedNetworkFilterConfigFactory>
+    registered_;
+
+} // namespace SourceIpAccess
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/source_ip_access/config.h
+++ b/source/extensions/filters/network/source_ip_access/config.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "envoy/config/filter/network/source_ip_access/v2/source_ip_access.pb.h"
+#include "envoy/config/filter/network/source_ip_access/v2/source_ip_access.pb.validate.h"
+
+#include "extensions/filters/network/common/factory_base.h"
+#include "extensions/filters/network/well_known_names.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace SourceIpAccess {
+
+/**
+ * Config registration for the source ip access filter. @see NamedNetworkFilterConfigFactory.
+ */
+class SourceIpAccessConfigFactory
+    : public Common::FactoryBase<
+          envoy::config::filter::network::source_ip_access::v2::SourceIpAccess> {
+public:
+  SourceIpAccessConfigFactory() : FactoryBase(NetworkFilterNames::get().SourceIpAccess) {}
+
+private:
+  Network::FilterFactoryCb createFilterFactoryFromProtoTyped(
+      const envoy::config::filter::network::source_ip_access::v2::SourceIpAccess& proto_config,
+      Server::Configuration::FactoryContext& context) override;
+};
+
+} // namespace SourceIpAccess
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/source_ip_access/source_ip_access.cc
+++ b/source/extensions/filters/network/source_ip_access/source_ip_access.cc
@@ -1,0 +1,62 @@
+#include "extensions/filters/network/source_ip_access/source_ip_access.h"
+
+#include <string>
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace SourceIpAccess {
+
+InstanceStats Config::generateStats(const std::string& name, Stats::Scope& scope) {
+  const std::string final_prefix = fmt::format("source_ip_access.{}.", name);
+  return {ALL_SOURCE_IP_ACCESS_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
+}
+
+Config::Config(const envoy::config::filter::network::source_ip_access::v2::SourceIpAccess& config,
+               Stats::Scope& scope)
+    : stats_(generateStats(config.stat_prefix(), scope)),
+      allow_by_default(config.allow_by_default()) {
+  std::vector<Network::Address::CidrRange> cidrs;
+  for (const auto& cidr : config.exception_prefixes()) {
+    Network::Address::CidrRange cidr_entry = Network::Address::CidrRange::create(cidr);
+    if (!cidr_entry.isValid()) {
+      throw EnvoyException(
+          fmt::format("invalid ip/mask combo '{}/{}' (format is <ip>/<# mask bits>)",
+                      cidr.address_prefix(), cidr.prefix_len().value()));
+    }
+
+    cidrs.emplace_back(cidr_entry);
+  }
+
+  std::vector<std::pair<bool, std::vector<Network::Address::CidrRange>>> data{
+      std::pair<bool, std::vector<Network::Address::CidrRange>>(true, cidrs)};
+
+  lc_trie_ = std::make_unique<Network::LcTrie::LcTrie<bool>>(data);
+}
+
+bool Config::should_allow(const Network::Address::InstanceConstSharedPtr& ip_address) const {
+  bool found = !lc_trie_->getData(ip_address).empty();
+  return allow_by_default ? !found : found;
+}
+
+Network::FilterStatus Filter::onNewConnection() {
+  auto& source_ip = callbacks_->connection().remoteAddress();
+
+  config_->stats().total_.inc();
+  if (config_->should_allow(source_ip)) {
+    config_->stats().allowed_.inc();
+    return Network::FilterStatus::Continue;
+  } else {
+    config_->stats().denied_.inc();
+    callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
+    return Network::FilterStatus::StopIteration;
+  }
+}
+
+void Filter::initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) {
+  callbacks_ = &callbacks;
+}
+} // namespace SourceIpAccess
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/source_ip_access/source_ip_access.h
+++ b/source/extensions/filters/network/source_ip_access/source_ip_access.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "envoy/config/filter/network/source_ip_access/v2/source_ip_access.pb.h"
+#include "envoy/network/connection.h"
+#include "envoy/network/filter.h"
+#include "envoy/runtime/runtime.h"
+#include "envoy/stats/scope.h"
+#include "envoy/stats/stats_macros.h"
+
+#include "common/network/lc_trie.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace SourceIpAccess {
+
+/**
+ * All source ip access stats. @see stats_macros.h
+ */
+// clang-format off
+#define ALL_SOURCE_IP_ACCESS_STATS(COUNTER)             \
+  COUNTER(total)                                        \
+  COUNTER(denied)                                       \
+  COUNTER(allowed)                                      \
+// clang-format on
+
+/**
+ * Struct definition for all source ip access stats. @see stats_macros.h
+ */
+struct InstanceStats {
+  ALL_SOURCE_IP_ACCESS_STATS(GENERATE_COUNTER_STRUCT)
+};
+
+/**
+ * Global configuration for source ip access filter.
+ */
+class Config {
+public:
+  Config(const envoy::config::filter::network::source_ip_access::v2::SourceIpAccess& config, Stats::Scope& scope);
+
+  bool should_allow(const Network::Address::InstanceConstSharedPtr& ip_address) const;
+  const InstanceStats& stats() { return stats_; }
+
+private:
+  static InstanceStats generateStats(const std::string& name, Stats::Scope& scope);
+  const InstanceStats stats_;
+  bool allow_by_default;
+  std::unique_ptr<Network::LcTrie::LcTrie<bool>> lc_trie_;
+};
+
+typedef std::shared_ptr<Config> ConfigSharedPtr;
+
+/**
+ * Source IP access filter instance. This filter will allow (continue to next filter) or deny (close the tcp connection) 
+ * based on provided config.
+ */
+class Filter : public Network::ReadFilter {
+public:
+  Filter(ConfigSharedPtr config)
+      : config_(config) {}
+  ~Filter() {}
+
+  // Network::ReadFilter
+  Network::FilterStatus onData(Buffer::Instance&, bool) override { return Network::FilterStatus::Continue; }
+  Network::FilterStatus onNewConnection() override;
+  void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override;
+  
+private:
+  ConfigSharedPtr config_;
+  Network::ReadFilterCallbacks* callbacks_{};
+};
+} // namespace SourceIpAccess
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/well_known_names.h
+++ b/source/extensions/filters/network/well_known_names.h
@@ -30,6 +30,8 @@ public:
   const std::string ExtAuthorization = "envoy.ext_authz";
   // Thrift proxy filter
   const std::string ThriftProxy = "envoy.filters.network.thrift_proxy";
+  // Source Ip Access filter
+  const std::string SourceIpAccess = "envoy.source_ip_access";
 
   // Converts names from v1 to v2
   const Config::V1Converter v1_converter_;
@@ -37,7 +39,7 @@ public:
   // NOTE: Do not add any new filters to this list. All future filters are v2 only.
   NetworkFilterNameValues()
       : v1_converter_({ClientSslAuth, Echo, HttpConnectionManager, MongoProxy, RateLimit,
-                       RedisProxy, TcpProxy, ExtAuthorization}) {}
+                       RedisProxy, TcpProxy, ExtAuthorization, SourceIpAccess}) {}
 };
 
 typedef ConstSingleton<NetworkFilterNameValues> NetworkFilterNames;

--- a/test/extensions/filters/network/source_ip_access/BUILD
+++ b/test/extensions/filters/network/source_ip_access/BUILD
@@ -1,0 +1,28 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_package",
+)
+load(
+    "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_cc_test",
+)
+
+envoy_package()
+
+envoy_extension_cc_test(
+    name = "source_ip_access_test",
+    srcs = ["source_ip_access_test.cc"],
+    extension_name = "envoy.filters.network.source_ip_access",
+    deps = [
+        "//source/common/buffer:buffer_lib",
+        "//source/common/network:address_lib",
+        "//source/common/network:utility_lib",
+        "//source/common/protobuf:utility_lib",
+        "//source/common/stats:stats_lib",
+        "//source/extensions/filters/network/source_ip_access",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/upstream:upstream_mocks",
+    ],
+)

--- a/test/extensions/filters/network/source_ip_access/source_ip_access_test.cc
+++ b/test/extensions/filters/network/source_ip_access/source_ip_access_test.cc
@@ -1,0 +1,97 @@
+#include <string>
+
+#include "envoy/config/filter/network/source_ip_access/v2/source_ip_access.pb.validate.h"
+#include "envoy/stats/stats.h"
+
+#include "common/buffer/buffer_impl.h"
+#include "common/network/address_impl.h"
+#include "common/protobuf/utility.h"
+
+#include "extensions/filters/network/source_ip_access/source_ip_access.h"
+
+#include "test/mocks/network/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::NiceMock;
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace SourceIpAccess {
+
+class SourceIpAccessFilterTest : public testing::Test {
+public:
+  SourceIpAccessFilterTest() {}
+
+  void loadConfig(std::string json) {
+    envoy::config::filter::network::source_ip_access::v2::SourceIpAccess proto_config{};
+    MessageUtil::loadFromJson(json, proto_config);
+    config_.reset(new Config(proto_config, stats_store_));
+    filter_.reset(new Filter(config_));
+
+    filter_callbacks_.connection_.remote_address_ =
+        std::make_shared<Network::Address::Ipv4Instance>("10.0.0.3");
+    filter_->initializeReadFilterCallbacks(filter_callbacks_);
+  }
+
+  void runWith(std::string address_prefix, std::string prefix_len, bool allow) {
+    std::string json_string = fmt::format(R"EOF(
+  {{
+    "stat_prefix": "my_stat_prefix",
+    "allow_by_default": "false",
+    "exception_prefixes": {{ "address_prefix": "{}", "prefix_len": "{}" }}
+  }}
+  )EOF",
+                                          address_prefix, prefix_len);
+
+    loadConfig(json_string);
+
+    auto result = allow ? Network::FilterStatus::Continue : Network::FilterStatus::StopIteration;
+
+    Buffer::OwnedImpl data("hello");
+    EXPECT_EQ(result, filter_->onNewConnection());
+    EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data, false));
+  }
+
+  void verifyStats(int ok, int denied) {
+    EXPECT_EQ(ok, stats_store_.counter("source_ip_access.my_stat_prefix.allowed").value());
+    EXPECT_EQ(denied, stats_store_.counter("source_ip_access.my_stat_prefix.denied").value());
+    EXPECT_EQ(ok + denied, stats_store_.counter("source_ip_access.my_stat_prefix.total").value());
+  }
+
+  Stats::IsolatedStoreImpl stats_store_;
+  ConfigSharedPtr config_;
+  std::unique_ptr<Filter> filter_;
+  NiceMock<Network::MockReadFilterCallbacks> filter_callbacks_;
+};
+
+TEST_F(SourceIpAccessFilterTest, AllowConfig) {
+  runWith("10.0.0.3", "32", true);
+  verifyStats(1, 0);
+}
+
+TEST_F(SourceIpAccessFilterTest, DenyConfig) {
+  runWith("10.0.0.4", "32", false);
+  verifyStats(0, 1);
+}
+
+TEST_F(SourceIpAccessFilterTest, AllowLargePrefixConfig) {
+  runWith("10.0.0.0", "16", true);
+  verifyStats(1, 0);
+}
+
+TEST_F(SourceIpAccessFilterTest, DenyLargePrefixConfig) {
+  runWith("11.0.0.0", "16", false);
+  verifyStats(0, 1);
+}
+
+TEST_F(SourceIpAccessFilterTest, BadConfig) {
+  EXPECT_THROW(runWith("10.0.0", "32", false), EnvoyException);
+}
+
+} // namespace SourceIpAccess
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -567,3 +567,18 @@ envoy_cc_test(
         "//test/test_common:utility_lib",
     ],
 )
+
+envoy_cc_test(
+    name = "source_ip_access_integration_test",
+    srcs = [
+        "source_ip_access_integration_test.cc",
+    ],
+    deps = [
+        ":integration_lib",
+        "//source/extensions/filters/network/source_ip_access:config",
+        "//source/extensions/filters/network/tcp_proxy:config",
+        "//test/server:utility_lib",
+        "//test/test_common:network_utility_lib",
+        "//test/test_common:utility_lib",
+    ],
+)

--- a/test/integration/source_ip_access_integration_test.cc
+++ b/test/integration/source_ip_access_integration_test.cc
@@ -1,0 +1,121 @@
+#include "envoy/config/filter/network/source_ip_access/v2/source_ip_access.pb.validate.h"
+
+#include "test/integration/integration.h"
+#include "test/integration/utility.h"
+#include "test/server/utility.h"
+#include "test/test_common/network_utility.h"
+#include "test/test_common/utility.h"
+
+namespace Envoy {
+
+std::string config;
+
+class SourceIpAccessIntegrationTest : public BaseIntegrationTest,
+                                      public testing::TestWithParam<Network::Address::IpVersion> {
+public:
+  SourceIpAccessIntegrationTest() : BaseIntegrationTest(GetParam(), config) {}
+
+  // Called once by the gtest framework before any EchoIntegrationTests are run.
+  static void SetUpTestCase() {
+    config = ConfigHelper::BASE_CONFIG + R"EOF(
+    filter_chains:
+      filters:
+      - name: envoy.source_ip_access
+        config:
+          stat_prefix: my_stat_prefix
+          allow_by_default: true
+      - name: envoy.tcp_proxy
+        config:
+          stat_prefix: tcp_stats
+          cluster: cluster_0
+      )EOF";
+  }
+
+  void setTestConfig(bool allow_by_default, bool add_exceptions) {
+    config_helper_.addConfigModifier([this, allow_by_default,
+                                      add_exceptions](envoy::config::bootstrap::v2::Bootstrap& bs) {
+      auto* listener = bs.mutable_static_resources()->mutable_listeners(0);
+      auto* config = listener->mutable_filter_chains(0)->mutable_filters(0)->mutable_config();
+
+      envoy::config::filter::network::source_ip_access::v2::SourceIpAccess source_ip_access_config;
+
+      MessageUtil::jsonConvert(*config, source_ip_access_config);
+      source_ip_access_config.set_allow_by_default(allow_by_default);
+
+      if (add_exceptions) {
+        auto exception = source_ip_access_config.add_exception_prefixes();
+        if (GetParam() == Network::Address::IpVersion::v4) {
+          exception->set_address_prefix("127.0.0.1");
+          exception->mutable_prefix_len()->set_value(32);
+        } else {
+          exception->set_address_prefix("::1");
+          exception->mutable_prefix_len()->set_value(128);
+        }
+      }
+
+      MessageUtil::jsonConvert(source_ip_access_config, *config);
+    });
+    initialize();
+  }
+
+  /**
+   * Initializer for an individual test.
+   */
+  void SetUp() override { config_helper_.renameListener("source_ip_access"); }
+
+  /**
+   *  Destructor for an individual test.
+   */
+  void TearDown() override {
+    test_server_.reset();
+    fake_upstreams_.clear();
+  }
+
+  void testAllow() {
+    IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("source_ip_access"));
+    FakeRawConnectionPtr fake_upstream_connection;
+    ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
+
+    tcp_client->write("hello");
+    ASSERT_TRUE(fake_upstream_connection->waitForData(5));
+
+    ASSERT_TRUE(fake_upstream_connection->write("world"));
+    tcp_client->waitForData("world");
+
+    tcp_client->close();
+  }
+
+  void testDeny() {
+    IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("source_ip_access"));
+    FakeRawConnectionPtr fake_upstream_connection;
+    ASSERT_FALSE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection,
+                                                          std::chrono::milliseconds(100)));
+
+    tcp_client->waitForDisconnect();
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(IpVersions, SourceIpAccessIntegrationTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
+
+TEST_P(SourceIpAccessIntegrationTest, AllowThroughDefault) {
+  setTestConfig(true, false);
+  testAllow();
+}
+
+TEST_P(SourceIpAccessIntegrationTest, AllowThroughException) {
+  setTestConfig(false, true);
+  testAllow();
+}
+
+TEST_P(SourceIpAccessIntegrationTest, DenyThroughDefault) {
+  setTestConfig(false, false);
+  testDeny();
+}
+
+TEST_P(SourceIpAccessIntegrationTest, DenyThroughException) {
+  setTestConfig(true, true);
+  testDeny();
+}
+} // namespace Envoy


### PR DESCRIPTION
Description:
New filter with capability to close connections coming from specified IP addresses. Configuration supporting whitelisting and blacklisting in CIDR notation.

Risk Level: low
Testing: unit/integration tests
Docs Changes: added
Release Notes: added

Signed-off-by: David Kowalski <dkowalski@apple.com>