### PR TITLE
config: allow unknown fields flag

### DIFF
--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -41,6 +41,11 @@ public:
   virtual AccessLog::AccessLogManager& accessLogManager() PURE;
 
   /**
+   * @return whether to allow unknown fields in the filter configs.
+   */
+  virtual bool allowUnknownFields() PURE;
+
+  /**
    * @return Upstream::ClusterManager& singleton for use by the entire server.
    */
   virtual Upstream::ClusterManager& clusterManager() PURE;

--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -83,6 +83,11 @@ public:
   virtual bool v2ConfigOnly() const PURE;
 
   /**
+   * @return bool whether to ignore unknown fields in the config (JSON, YAML, and protobuf).
+   */
+  virtual bool allowUnknownFields() const PURE;
+
+  /**
    * @return const std::string& the admin address output file.
    */
   virtual const std::string& adminAddressPath() const PURE;

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -209,7 +209,8 @@ AccessLogFactory::fromProto(const envoy::config::filter::accesslog::v2::AccessLo
   auto& factory =
       Config::Utility::getAndCheckFactory<Server::Configuration::AccessLogInstanceFactory>(
           config.name());
-  ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(config, factory);
+  ProtobufTypes::MessagePtr message =
+      Config::Utility::translateToFactoryConfig(config, factory, context.allowUnknownFields());
 
   return factory.createAccessLogInstance(*message, std::move(filter), context);
 }

--- a/source/common/config/bootstrap_json.cc
+++ b/source/common/config/bootstrap_json.cc
@@ -84,7 +84,7 @@ void BootstrapJson::translateBootstrap(const Json::Object& json_config,
     envoy::config::metrics::v2::StatsdSink statsd_sink;
     AddressJson::translateAddress(json_config.getString("statsd_udp_ip_address"), false, true,
                                   *statsd_sink.mutable_address());
-    MessageUtil::jsonConvert(statsd_sink, *stats_sink->mutable_config());
+    MessageUtil::jsonConvert(statsd_sink, *stats_sink->mutable_config(), false);
   }
 
   if (json_config.hasObject("statsd_tcp_cluster_name")) {
@@ -92,7 +92,7 @@ void BootstrapJson::translateBootstrap(const Json::Object& json_config,
     stats_sink->set_name(Extensions::StatSinks::StatsSinkNames::get().Statsd);
     envoy::config::metrics::v2::StatsdSink statsd_sink;
     statsd_sink.set_tcp_cluster_name(json_config.getString("statsd_tcp_cluster_name"));
-    MessageUtil::jsonConvert(statsd_sink, *stats_sink->mutable_config());
+    MessageUtil::jsonConvert(statsd_sink, *stats_sink->mutable_config(), false);
   }
 
   JSON_UTIL_SET_DURATION(json_config, bootstrap, stats_flush_interval);
@@ -109,7 +109,7 @@ void BootstrapJson::translateBootstrap(const Json::Object& json_config,
     auto* http_tracing = bootstrap.mutable_tracing()->mutable_http();
     http_tracing->set_name("envoy." + driver->getString("type"));
     MessageUtil::loadFromJson(driver->getObject("config")->asJsonString(),
-                              *http_tracing->mutable_config());
+                              *http_tracing->mutable_config(), false);
   }
 
   if (json_config.hasObject("rate_limit_service")) {

--- a/source/common/config/filesystem_subscription_impl.h
+++ b/source/common/config/filesystem_subscription_impl.h
@@ -59,7 +59,7 @@ private:
     bool config_update_available = false;
     try {
       envoy::api::v2::DiscoveryResponse message;
-      MessageUtil::loadFromFile(path_, message);
+      MessageUtil::loadFromFile(path_, message, true);
       const auto typed_resources = Config::Utility::getTypedResources<ResourceType>(message);
       config_update_available = true;
       callbacks_->onConfigUpdate(typed_resources, message.version_info());

--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -113,7 +113,7 @@ void FilterJson::translateAccessLog(const Json::Object& json_config,
   JSON_UTIL_SET_STRING(json_config, file_access_log, format);
 
   ProtobufWkt::Struct& custom_config = *proto_config.mutable_config();
-  MessageUtil::jsonConvert(file_access_log, custom_config);
+  MessageUtil::jsonConvert(file_access_log, custom_config, false);
 
   // Statically registered access logs are a v2-only feature, so use the standard internal file
   // access log for json config conversion.
@@ -341,7 +341,7 @@ void FilterJson::translateSquashConfig(
   JSON_UTIL_SET_STRING(json_config, proto_config, cluster);
   // convert json object to google.protobuf.Struct
   std::string json_string = json_config.getObject("attachment_template")->asJsonString();
-  MessageUtil::loadFromJson(json_string, *proto_config.mutable_attachment_template());
+  MessageUtil::loadFromJson(json_string, *proto_config.mutable_attachment_template(), false);
 
   JSON_UTIL_SET_DURATION(json_config, proto_config, attachment_timeout);
   JSON_UTIL_SET_DURATION(json_config, proto_config, attachment_poll_period);

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -235,15 +235,15 @@ public:
    */
   template <class ProtoMessage, class Factory>
   static ProtobufTypes::MessagePtr translateToFactoryConfig(const ProtoMessage& enclosing_message,
-                                                            Factory& factory) {
+                                                            Factory& factory,
+                                                            bool allowUnknownFields) {
     ProtobufTypes::MessagePtr config = factory.createEmptyConfigProto();
 
     // Fail in an obvious way if a plugin does not return a proto.
     RELEASE_ASSERT(config != nullptr, "");
 
     if (enclosing_message.has_config()) {
-      // TODO(kuat)
-      MessageUtil::jsonConvert(enclosing_message.config(), *config, true);
+      MessageUtil::jsonConvert(enclosing_message.config(), *config, allowUnknownFields);
     }
 
     return config;
@@ -260,14 +260,14 @@ public:
    */
   template <class Factory>
   static ProtobufTypes::MessagePtr translateToFactoryRouteConfig(const Protobuf::Message& source,
-                                                                 Factory& factory) {
+                                                                 Factory& factory,
+                                                                 bool allowUnknownFields) {
     ProtobufTypes::MessagePtr config = factory.createEmptyRouteConfigProto();
 
     // Fail in an obvious way if a plugin does not return a proto.
     RELEASE_ASSERT(config != nullptr, "");
 
-    // TODO(kuat)
-    MessageUtil::jsonConvert(source, *config, true);
+    MessageUtil::jsonConvert(source, *config, allowUnknownFields);
     return config;
   }
 

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -52,6 +52,7 @@ public:
     Protobuf::RepeatedPtrField<ResourceType> typed_resources;
     for (const auto& resource : response.resources()) {
       auto* typed_resource = typed_resources.Add();
+      // TODO(kuat)
       resource.UnpackTo(typed_resource);
     }
     return typed_resources;
@@ -241,7 +242,8 @@ public:
     RELEASE_ASSERT(config != nullptr, "");
 
     if (enclosing_message.has_config()) {
-      MessageUtil::jsonConvert(enclosing_message.config(), *config);
+      // TODO(kuat)
+      MessageUtil::jsonConvert(enclosing_message.config(), *config, true);
     }
 
     return config;
@@ -264,7 +266,8 @@ public:
     // Fail in an obvious way if a plugin does not return a proto.
     RELEASE_ASSERT(config != nullptr, "");
 
-    MessageUtil::jsonConvert(source, *config);
+    // TODO(kuat)
+    MessageUtil::jsonConvert(source, *config, true);
     return config;
   }
 

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -52,7 +52,6 @@ public:
     Protobuf::RepeatedPtrField<ResourceType> typed_resources;
     for (const auto& resource : response.resources()) {
       auto* typed_resource = typed_resources.Add();
-      // TODO(kuat)
       resource.UnpackTo(typed_resource);
     }
     return typed_resources;

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -48,7 +48,8 @@ ProtoValidationException::ProtoValidationException(const std::string& validation
   ENVOY_LOG_MISC(debug, "Proto validation error; throwing {}", what());
 }
 
-void MessageUtil::loadFromJson(const std::string& json, Protobuf::Message& message, bool allow_unknown_fields) {
+void MessageUtil::loadFromJson(const std::string& json, Protobuf::Message& message,
+                               bool allow_unknown_fields) {
   Protobuf::util::JsonParseOptions options;
   options.ignore_unknown_fields = allow_unknown_fields;
   const auto status = Protobuf::util::JsonStringToMessage(json, &message, options);
@@ -57,12 +58,14 @@ void MessageUtil::loadFromJson(const std::string& json, Protobuf::Message& messa
   }
 }
 
-void MessageUtil::loadFromYaml(const std::string& yaml, Protobuf::Message& message, bool allow_unknown_fields) {
+void MessageUtil::loadFromYaml(const std::string& yaml, Protobuf::Message& message,
+                               bool allow_unknown_fields) {
   const std::string json = Json::Factory::loadFromYamlString(yaml)->asJsonString();
   loadFromJson(json, message, allow_unknown_fields);
 }
 
-void MessageUtil::loadFromFile(const std::string& path, Protobuf::Message& message, bool allow_unknown_fields) {
+void MessageUtil::loadFromFile(const std::string& path, Protobuf::Message& message,
+                               bool allow_unknown_fields) {
   const std::string contents = Filesystem::fileReadToEnd(path);
   // If the filename ends with .pb, attempt to parse it as a binary proto.
   if (StringUtil::endsWith(path, ".pb")) {
@@ -71,7 +74,7 @@ void MessageUtil::loadFromFile(const std::string& path, Protobuf::Message& messa
       // Check that no unknown fields are present if necessary.
       if (!allow_unknown_fields && !message.GetReflection()->GetUnknownFields(message).empty()) {
         throw EnvoyException("Unable to parse file \"" + path + "\" as a binary protobuf (type " +
-                              message.GetTypeName() + ") due to unknown fields");
+                             message.GetTypeName() + ") due to unknown fields");
       }
       return;
     }
@@ -117,7 +120,8 @@ std::string MessageUtil::getJsonStringFromMessage(const Protobuf::Message& messa
   return json;
 }
 
-void MessageUtil::jsonConvert(const Protobuf::Message& source, Protobuf::Message& dest, bool allow_unknown_fields) {
+void MessageUtil::jsonConvert(const Protobuf::Message& source, Protobuf::Message& dest,
+                              bool allow_unknown_fields) {
   // TODO(htuch): Consolidate with the inflight cleanups here.
   Protobuf::util::JsonPrintOptions json_options;
   json_options.preserve_proto_field_names = true;

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -158,9 +158,9 @@ public:
     return HashUtil::xxHash64(text);
   }
 
-  static void loadFromJson(const std::string& json, Protobuf::Message& message);
-  static void loadFromYaml(const std::string& yaml, Protobuf::Message& message);
-  static void loadFromFile(const std::string& path, Protobuf::Message& message);
+  static void loadFromJson(const std::string& json, Protobuf::Message& message, bool allow_unknown_fields);
+  static void loadFromYaml(const std::string& yaml, Protobuf::Message& message, bool allow_unknown_fields);
+  static void loadFromFile(const std::string& path, Protobuf::Message& message, bool allow_unknown_fields);
 
   /**
    * Validate protoc-gen-validate constraints on a given protobuf.
@@ -225,7 +225,7 @@ public:
    * @param source message.
    * @param dest message.
    */
-  static void jsonConvert(const Protobuf::Message& source, Protobuf::Message& dest);
+  static void jsonConvert(const Protobuf::Message& source, Protobuf::Message& dest, bool allow_unknown_fields);
 
   /**
    * Extract JSON as string from a google.protobuf.Message.

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -158,9 +158,12 @@ public:
     return HashUtil::xxHash64(text);
   }
 
-  static void loadFromJson(const std::string& json, Protobuf::Message& message, bool allow_unknown_fields);
-  static void loadFromYaml(const std::string& yaml, Protobuf::Message& message, bool allow_unknown_fields);
-  static void loadFromFile(const std::string& path, Protobuf::Message& message, bool allow_unknown_fields);
+  static void loadFromJson(const std::string& json, Protobuf::Message& message,
+                           bool allow_unknown_fields);
+  static void loadFromYaml(const std::string& yaml, Protobuf::Message& message,
+                           bool allow_unknown_fields);
+  static void loadFromFile(const std::string& path, Protobuf::Message& message,
+                           bool allow_unknown_fields);
 
   /**
    * Validate protoc-gen-validate constraints on a given protobuf.
@@ -225,7 +228,8 @@ public:
    * @param source message.
    * @param dest message.
    */
-  static void jsonConvert(const Protobuf::Message& source, Protobuf::Message& dest, bool allow_unknown_fields);
+  static void jsonConvert(const Protobuf::Message& source, Protobuf::Message& dest,
+                          bool allow_unknown_fields);
 
   /**
    * Extract JSON as string from a google.protobuf.Message.

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -932,7 +932,8 @@ PerFilterConfigs::PerFilterConfigs(
         Server::Configuration::NamedHttpFilterConfigFactory>(name);
 
     auto object = factory.createRouteSpecificFilterConfig(
-        *Envoy::Config::Utility::translateToFactoryRouteConfig(struct_config, factory),
+        *Envoy::Config::Utility::translateToFactoryRouteConfig(
+            struct_config, factory, factory_context.allowUnknownFields()),
         factory_context);
     if (object) {
       configs_[name] = object;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -363,8 +363,9 @@ Network::TransportSocketFactoryPtr createTransportSocketFactory(
 
   auto& config_factory = Config::Utility::getAndCheckFactory<
       Server::Configuration::UpstreamTransportSocketConfigFactory>(transport_socket.name());
+  // always downcast and ignore unknown fields (kuat)
   ProtobufTypes::MessagePtr message =
-      Config::Utility::translateToFactoryConfig(transport_socket, config_factory, true /* kuat */);
+      Config::Utility::translateToFactoryConfig(transport_socket, config_factory, true);
   return config_factory.createTransportSocketFactory(*message, factory_context);
 }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -354,7 +354,7 @@ Network::TransportSocketFactoryPtr createTransportSocketFactory(
   if (!config.has_transport_socket()) {
     if (config.has_tls_context()) {
       transport_socket.set_name(Extensions::TransportSockets::TransportSocketNames::get().Tls);
-      MessageUtil::jsonConvert(config.tls_context(), *transport_socket.mutable_config());
+      MessageUtil::jsonConvert(config.tls_context(), *transport_socket.mutable_config(), true);
     } else {
       transport_socket.set_name(
           Extensions::TransportSockets::TransportSocketNames::get().RawBuffer);

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -364,7 +364,7 @@ Network::TransportSocketFactoryPtr createTransportSocketFactory(
   auto& config_factory = Config::Utility::getAndCheckFactory<
       Server::Configuration::UpstreamTransportSocketConfigFactory>(transport_socket.name());
   ProtobufTypes::MessagePtr message =
-      Config::Utility::translateToFactoryConfig(transport_socket, config_factory);
+      Config::Utility::translateToFactoryConfig(transport_socket, config_factory, true /* kuat */);
   return config_factory.createTransportSocketFactory(*message, factory_context);
 }
 

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -290,8 +290,8 @@ void HttpConnectionManagerConfig::processFilter(
     callback = factory.createFilterFactory(*filter_config->getObject("value", true), stats_prefix_,
                                            context_);
   } else {
-    ProtobufTypes::MessagePtr message =
-        Config::Utility::translateToFactoryConfig(proto_config, factory);
+    ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
+        proto_config, factory, context_.allowUnknownFields());
     callback = factory.createFilterFactoryFromProto(*message, stats_prefix_, context_);
   }
   filter_factories.push_back(callback);

--- a/source/extensions/grpc_credentials/file_based_metadata/config.cc
+++ b/source/extensions/grpc_credentials/file_based_metadata/config.cc
@@ -29,7 +29,7 @@ FileBasedMetadataGrpcCredentialsFactory::getChannelCredentials(
         FileBasedMetadataGrpcCredentialsFactory file_based_metadata_credentials_factory;
         const Envoy::ProtobufTypes::MessagePtr file_based_metadata_config_message =
             Envoy::Config::Utility::translateToFactoryConfig(
-                credential.from_plugin(), file_based_metadata_credentials_factory);
+                credential.from_plugin(), file_based_metadata_credentials_factory, true /*kuat*/);
         const auto& file_based_metadata_config = Envoy::MessageUtil::downcastAndValidate<
             const envoy::config::grpc_credential::v2alpha::FileBasedMetadataConfig&>(
             *file_based_metadata_config_message);

--- a/source/extensions/grpc_credentials/file_based_metadata/config.cc
+++ b/source/extensions/grpc_credentials/file_based_metadata/config.cc
@@ -27,9 +27,10 @@ FileBasedMetadataGrpcCredentialsFactory::getChannelCredentials(
     case envoy::api::v2::core::GrpcService::GoogleGrpc::CallCredentials::kFromPlugin: {
       if (credential.from_plugin().name() == GrpcCredentialsNames::get().FileBasedMetadata) {
         FileBasedMetadataGrpcCredentialsFactory file_based_metadata_credentials_factory;
+        // downcast to file based config, ignore unknown fields (kuat)
         const Envoy::ProtobufTypes::MessagePtr file_based_metadata_config_message =
             Envoy::Config::Utility::translateToFactoryConfig(
-                credential.from_plugin(), file_based_metadata_credentials_factory, true /*kuat*/);
+                credential.from_plugin(), file_based_metadata_credentials_factory, true);
         const auto& file_based_metadata_config = Envoy::MessageUtil::downcastAndValidate<
             const envoy::config::grpc_credential::v2alpha::FileBasedMetadataConfig&>(
             *file_based_metadata_config_message);

--- a/source/extensions/health_checkers/redis/utility.h
+++ b/source/extensions/health_checkers/redis/utility.h
@@ -14,7 +14,7 @@ static const envoy::config::health_checker::redis::v2::Redis
 getRedisHealthCheckConfig(const envoy::api::v2::core::HealthCheck& hc_config) {
   ProtobufTypes::MessagePtr config =
       ProtobufTypes::MessagePtr{new envoy::config::health_checker::redis::v2::Redis()};
-  MessageUtil::jsonConvert(hc_config.custom_health_check().config(), *config);
+  MessageUtil::jsonConvert(hc_config.custom_health_check().config(), *config, true);
   return MessageUtil::downcastAndValidate<const envoy::config::health_checker::redis::v2::Redis&>(
       *config);
 }

--- a/source/extensions/transport_sockets/capture/config.cc
+++ b/source/extensions/transport_sockets/capture/config.cc
@@ -22,8 +22,9 @@ Network::TransportSocketFactoryPtr UpstreamCaptureSocketConfigFactory::createTra
   auto& inner_config_factory = Config::Utility::getAndCheckFactory<
       Server::Configuration::UpstreamTransportSocketConfigFactory>(
       outer_config.transport_socket().name());
+  // always downcast and ignore unknown fields (kuat)
   ProtobufTypes::MessagePtr inner_factory_config = Config::Utility::translateToFactoryConfig(
-      outer_config.transport_socket(), inner_config_factory, true /*kuat*/);
+      outer_config.transport_socket(), inner_config_factory, true);
   auto inner_transport_factory =
       inner_config_factory.createTransportSocketFactory(*inner_factory_config, context);
   return std::make_unique<CaptureSocketFactory>(outer_config.file_sink().path_prefix(),
@@ -40,8 +41,9 @@ DownstreamCaptureSocketConfigFactory::createTransportSocketFactory(
   auto& inner_config_factory = Config::Utility::getAndCheckFactory<
       Server::Configuration::DownstreamTransportSocketConfigFactory>(
       outer_config.transport_socket().name());
+  // always downcast and ignore unknown fields in the message (kuat)
   ProtobufTypes::MessagePtr inner_factory_config = Config::Utility::translateToFactoryConfig(
-      outer_config.transport_socket(), inner_config_factory, true /*kuat*/);
+      outer_config.transport_socket(), inner_config_factory, true);
   auto inner_transport_factory = inner_config_factory.createTransportSocketFactory(
       *inner_factory_config, context, server_names);
   return std::make_unique<CaptureSocketFactory>(outer_config.file_sink().path_prefix(),

--- a/source/extensions/transport_sockets/capture/config.cc
+++ b/source/extensions/transport_sockets/capture/config.cc
@@ -23,7 +23,7 @@ Network::TransportSocketFactoryPtr UpstreamCaptureSocketConfigFactory::createTra
       Server::Configuration::UpstreamTransportSocketConfigFactory>(
       outer_config.transport_socket().name());
   ProtobufTypes::MessagePtr inner_factory_config = Config::Utility::translateToFactoryConfig(
-      outer_config.transport_socket(), inner_config_factory);
+      outer_config.transport_socket(), inner_config_factory, true /*kuat*/);
   auto inner_transport_factory =
       inner_config_factory.createTransportSocketFactory(*inner_factory_config, context);
   return std::make_unique<CaptureSocketFactory>(outer_config.file_sink().path_prefix(),
@@ -41,7 +41,7 @@ DownstreamCaptureSocketConfigFactory::createTransportSocketFactory(
       Server::Configuration::DownstreamTransportSocketConfigFactory>(
       outer_config.transport_socket().name());
   ProtobufTypes::MessagePtr inner_factory_config = Config::Utility::translateToFactoryConfig(
-      outer_config.transport_socket(), inner_config_factory);
+      outer_config.transport_socket(), inner_config_factory, true /*kuat*/);
   auto inner_transport_factory = inner_config_factory.createTransportSocketFactory(
       *inner_factory_config, context, server_names);
   return std::make_unique<CaptureSocketFactory>(outer_config.file_sink().path_prefix(),

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -118,8 +118,8 @@ void MainImpl::initializeStatsSinks(const envoy::config::bootstrap::v2::Bootstra
   for (const envoy::config::metrics::v2::StatsSink& sink_object : bootstrap.stats_sinks()) {
     // Generate factory and translate stats sink custom config
     auto& factory = Config::Utility::getAndCheckFactory<StatsSinkFactory>(sink_object.name());
-    ProtobufTypes::MessagePtr message =
-        Config::Utility::translateToFactoryConfig(sink_object, factory);
+    ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
+        sink_object, factory, server.options().allowUnknownFields());
 
     stats_sinks_.emplace_back(factory.createStatsSink(*message, server));
   }

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -51,7 +51,8 @@ std::vector<Network::FilterFactoryCb> ProdListenerComponentFactory::createNetwor
     if (filter_config->getBoolean("deprecated_v1", false)) {
       callback = factory.createFilterFactory(*filter_config->getObject("value", true), context);
     } else {
-      auto message = Config::Utility::translateToFactoryConfig(proto_config, factory);
+      auto message = Config::Utility::translateToFactoryConfig(proto_config, factory,
+                                                               context.allowUnknownFields());
       callback = factory.createFilterFactoryFromProto(*message, context);
     }
     ret.push_back(callback);
@@ -77,7 +78,8 @@ ProdListenerComponentFactory::createListenerFilterFactoryList_(
     auto& factory =
         Config::Utility::getAndCheckFactory<Configuration::NamedListenerFilterConfigFactory>(
             string_name);
-    auto message = Config::Utility::translateToFactoryConfig(proto_config, factory);
+    auto message = Config::Utility::translateToFactoryConfig(proto_config, factory,
+                                                             context.allowUnknownFields());
     ret.push_back(factory.createFilterFactoryFromProto(*message, context));
   }
   return ret;
@@ -192,7 +194,8 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
     if (!filter_chain.has_transport_socket()) {
       if (filter_chain.has_tls_context()) {
         transport_socket.set_name(Extensions::TransportSockets::TransportSocketNames::get().Tls);
-        MessageUtil::jsonConvert(filter_chain.tls_context(), *transport_socket.mutable_config(), true);
+        MessageUtil::jsonConvert(filter_chain.tls_context(), *transport_socket.mutable_config(),
+                                 true);
       } else {
         transport_socket.set_name(
             Extensions::TransportSockets::TransportSocketNames::get().RawBuffer);
@@ -201,8 +204,8 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
 
     auto& config_factory = Config::Utility::getAndCheckFactory<
         Server::Configuration::DownstreamTransportSocketConfigFactory>(transport_socket.name());
-    ProtobufTypes::MessagePtr message =
-        Config::Utility::translateToFactoryConfig(transport_socket, config_factory);
+    ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
+        transport_socket, config_factory, parent_.server_.options().allowUnknownFields());
 
     // Validate IP addresses.
     std::vector<std::string> destination_ips;

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -192,7 +192,7 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
     if (!filter_chain.has_transport_socket()) {
       if (filter_chain.has_tls_context()) {
         transport_socket.set_name(Extensions::TransportSockets::TransportSocketNames::get().Tls);
-        MessageUtil::jsonConvert(filter_chain.tls_context(), *transport_socket.mutable_config());
+        MessageUtil::jsonConvert(filter_chain.tls_context(), *transport_socket.mutable_config(), true);
       } else {
         transport_socket.set_name(
             Extensions::TransportSockets::TransportSocketNames::get().RawBuffer);

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -253,6 +253,7 @@ public:
   AccessLog::AccessLogManager& accessLogManager() override {
     return parent_.server_.accessLogManager();
   }
+  bool allowUnknownFields() override { return parent_.server_.options().allowUnknownFields(); }
   Upstream::ClusterManager& clusterManager() override { return parent_.server_.clusterManager(); }
   Event::Dispatcher& dispatcher() override { return parent_.server_.dispatcher(); }
   Network::DrainDecision& drainDecision() override { return *this; }

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -61,7 +61,8 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   // Deprecated and unused.
   TCLAP::SwitchArg v2_config_only("", "v2-config-only", "deprecated", cmd, true);
 
-  TCLAP::SwitchArg allow_unknown_fields("", "allow-unknown-fields", "allow unknown fields in the config", cmd, true);
+  TCLAP::SwitchArg allow_unknown_fields("", "allow-unknown-fields",
+                                        "allow unknown fields in the config", cmd, true);
 
   TCLAP::SwitchArg allow_v1_config("", "allow-deprecated-v1-api", "allow use of legacy v1 config",
                                    cmd, false);

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -61,6 +61,8 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   // Deprecated and unused.
   TCLAP::SwitchArg v2_config_only("", "v2-config-only", "deprecated", cmd, true);
 
+  TCLAP::SwitchArg allow_unknown_fields("", "allow-unknown-fields", "allow unknown fields in the config", cmd, true);
+
   TCLAP::SwitchArg allow_v1_config("", "allow-deprecated-v1-api", "allow use of legacy v1 config",
                                    cmd, false);
 
@@ -184,6 +186,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   config_path_ = config_path.getValue();
   config_yaml_ = config_yaml.getValue();
   v2_config_only_ = !allow_v1_config.getValue();
+  allow_unknown_fields_ = allow_unknown_fields.getValue();
   admin_address_path_ = admin_address_path.getValue();
   log_path_ = log_path.getValue();
   restart_epoch_ = restart_epoch.getValue();

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -64,8 +64,8 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   TCLAP::SwitchArg allow_v1_config("", "allow-deprecated-v1-api", "allow use of legacy v1 config",
                                    cmd, false);
 
-  TCLAP::SwitchArg strict_fields("", "strict-fields",
-                                 "disallow unknown fields in the filter configuration", cmd, false);
+  TCLAP::SwitchArg allow_unknown_fields("", "allow-unknown-fields",
+                                 "allow unknown fields in the filter configuration", cmd, true);
 
   TCLAP::ValueArg<std::string> admin_address_path("", "admin-address-path", "Admin address path",
                                                   false, "", "string", cmd);
@@ -187,7 +187,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   config_path_ = config_path.getValue();
   config_yaml_ = config_yaml.getValue();
   v2_config_only_ = !allow_v1_config.getValue();
-  allow_unknown_fields_ = !strict_fields.getValue();
+  allow_unknown_fields_ = allow_unknown_fields.getValue();
   admin_address_path_ = admin_address_path.getValue();
   log_path_ = log_path.getValue();
   restart_epoch_ = restart_epoch.getValue();

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -64,8 +64,8 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   TCLAP::SwitchArg allow_v1_config("", "allow-deprecated-v1-api", "allow use of legacy v1 config",
                                    cmd, false);
 
-  TCLAP::SwitchArg allow_unknown_fields("", "allow-unknown-fields",
-                                 "allow unknown fields in the filter configuration", cmd, true);
+  TCLAP::SwitchArg allow_unknown_fields(
+      "", "allow-unknown-fields", "allow unknown fields in the filter configuration", cmd, false);
 
   TCLAP::ValueArg<std::string> admin_address_path("", "admin-address-path", "Admin address path",
                                                   false, "", "string", cmd);

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -61,11 +61,11 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   // Deprecated and unused.
   TCLAP::SwitchArg v2_config_only("", "v2-config-only", "deprecated", cmd, true);
 
-  TCLAP::SwitchArg allow_unknown_fields("", "allow-unknown-fields",
-                                        "allow unknown fields in the config", cmd, true);
-
   TCLAP::SwitchArg allow_v1_config("", "allow-deprecated-v1-api", "allow use of legacy v1 config",
                                    cmd, false);
+
+  TCLAP::SwitchArg strict_fields("", "strict-fields",
+                                 "disallow unknown fields in the filter configuration", cmd, false);
 
   TCLAP::ValueArg<std::string> admin_address_path("", "admin-address-path", "Admin address path",
                                                   false, "", "string", cmd);
@@ -187,7 +187,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   config_path_ = config_path.getValue();
   config_yaml_ = config_yaml.getValue();
   v2_config_only_ = !allow_v1_config.getValue();
-  allow_unknown_fields_ = allow_unknown_fields.getValue();
+  allow_unknown_fields_ = !strict_fields.getValue();
   admin_address_path_ = admin_address_path.getValue();
   log_path_ = log_path.getValue();
   restart_epoch_ = restart_epoch.getValue();

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -39,6 +39,7 @@ public:
   void setConfigPath(const std::string& config_path) { config_path_ = config_path; }
   void setConfigYaml(const std::string& config_yaml) { config_yaml_ = config_yaml; }
   void setV2ConfigOnly(bool v2_config_only) { v2_config_only_ = v2_config_only; }
+  void setAllowUnknownFields(bool allow_unknown_fields) { allow_unknown_fields_ = allow_unknown_fields; }
   void setAdminAddressPath(const std::string& admin_address_path) {
     admin_address_path_ = admin_address_path;
   }
@@ -74,6 +75,7 @@ public:
   const std::string& configPath() const override { return config_path_; }
   const std::string& configYaml() const override { return config_yaml_; }
   bool v2ConfigOnly() const override { return v2_config_only_; }
+  bool allowUnknownFields() const override { return allow_unknown_fields_; }
   const std::string& adminAddressPath() const override { return admin_address_path_; }
   Network::Address::IpVersion localAddressIpVersion() const override {
     return local_address_ip_version_;
@@ -101,6 +103,7 @@ private:
   std::string config_path_;
   std::string config_yaml_;
   bool v2_config_only_;
+  bool allow_unknown_fields_;
   std::string admin_address_path_;
   Network::Address::IpVersion local_address_ip_version_;
   spdlog::level::level_enum log_level_;

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -39,7 +39,9 @@ public:
   void setConfigPath(const std::string& config_path) { config_path_ = config_path; }
   void setConfigYaml(const std::string& config_yaml) { config_yaml_ = config_yaml; }
   void setV2ConfigOnly(bool v2_config_only) { v2_config_only_ = v2_config_only; }
-  void setAllowUnknownFields(bool allow_unknown_fields) { allow_unknown_fields_ = allow_unknown_fields; }
+  void setAllowUnknownFields(bool allow_unknown_fields) {
+    allow_unknown_fields_ = allow_unknown_fields;
+  }
   void setAdminAddressPath(const std::string& admin_address_path) {
     admin_address_path_ = admin_address_path;
   }

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -84,7 +84,7 @@ bool OverloadAction::isActive() const { return !fired_triggers_.empty(); }
 
 OverloadManagerImpl::OverloadManagerImpl(
     Event::Dispatcher& dispatcher, Stats::Scope& stats_scope,
-    const envoy::config::overload::v2alpha::OverloadManager& config)
+    const envoy::config::overload::v2alpha::OverloadManager& config, bool allow_unknown_fields)
     : started_(false), dispatcher_(dispatcher),
       refresh_interval_(
           std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(config, refresh_interval, 1000))) {
@@ -94,7 +94,8 @@ OverloadManagerImpl::OverloadManagerImpl(
     ENVOY_LOG(debug, "Adding resource monitor for {}", name);
     auto& factory =
         Config::Utility::getAndCheckFactory<Configuration::ResourceMonitorFactory>(name);
-    auto config = Config::Utility::translateToFactoryConfig(resource, factory);
+    auto config =
+        Config::Utility::translateToFactoryConfig(resource, factory, allow_unknown_fields);
     auto monitor = factory.createResourceMonitor(*config, context);
 
     auto result =

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -50,7 +50,8 @@ private:
 class OverloadManagerImpl : Logger::Loggable<Logger::Id::main>, public OverloadManager {
 public:
   OverloadManagerImpl(Event::Dispatcher& dispatcher, Stats::Scope& stats_scope,
-                      const envoy::config::overload::v2alpha::OverloadManager& config);
+                      const envoy::config::overload::v2alpha::OverloadManager& config,
+                      bool allow_unknown_fields);
 
   // Server::OverloadManager
   void start() override;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -155,7 +155,8 @@ InstanceUtil::loadBootstrapConfig(envoy::config::bootstrap::v2::Bootstrap& boots
     }
     if (!options.configYaml().empty()) {
       envoy::config::bootstrap::v2::Bootstrap bootstrap_override;
-      MessageUtil::loadFromYaml(options.configYaml(), bootstrap_override, options.allowUnknownFields());
+      MessageUtil::loadFromYaml(options.configYaml(), bootstrap_override,
+                                options.allowUnknownFields());
       bootstrap.MergeFrom(bootstrap_override);
     }
     MessageUtil::validate(bootstrap);
@@ -248,8 +249,8 @@ void InstanceImpl::initialize(Options& options,
   loadServerFlags(initial_config.flagsPath());
 
   // Initialize the overload manager early so other modules can register for actions.
-  overload_manager_.reset(
-      new OverloadManagerImpl(dispatcher(), stats(), bootstrap_.overload_manager()));
+  overload_manager_.reset(new OverloadManagerImpl(
+      dispatcher(), stats(), bootstrap_.overload_manager(), options.allowUnknownFields()));
 
   // Workers get created first so they register for thread local updates.
   listener_manager_.reset(new ListenerManagerImpl(

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -151,11 +151,11 @@ InstanceUtil::loadBootstrapConfig(envoy::config::bootstrap::v2::Bootstrap& boots
                                   Options& options) {
   try {
     if (!options.configPath().empty()) {
-      MessageUtil::loadFromFile(options.configPath(), bootstrap);
+      MessageUtil::loadFromFile(options.configPath(), bootstrap, options.allowUnknownFields());
     }
     if (!options.configYaml().empty()) {
       envoy::config::bootstrap::v2::Bootstrap bootstrap_override;
-      MessageUtil::loadFromYaml(options.configYaml(), bootstrap_override);
+      MessageUtil::loadFromYaml(options.configYaml(), bootstrap_override, options.allowUnknownFields());
       bootstrap.MergeFrom(bootstrap_override);
     }
     MessageUtil::validate(bootstrap);

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -44,7 +44,7 @@ parseAccessLogFromJson(const std::string& json_string) {
 
 envoy::config::filter::accesslog::v2::AccessLog parseAccessLogFromV2Yaml(const std::string& yaml) {
   envoy::config::filter::accesslog::v2::AccessLog access_log;
-  MessageUtil::loadFromYaml(yaml, access_log);
+  MessageUtil::loadFromYaml(yaml, access_log, false);
   return access_log;
 }
 

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -16,7 +16,7 @@ namespace Http {
 
 envoy::api::v2::route::HeaderMatcher parseHeaderMatcherFromYaml(const std::string& yaml) {
   envoy::api::v2::route::HeaderMatcher header_matcher;
-  MessageUtil::loadFromYaml(yaml, header_matcher);
+  MessageUtil::loadFromYaml(yaml, header_matcher, false);
   return header_matcher;
 }
 

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -62,8 +62,8 @@ TEST(UtilityTest, LoadBinaryProtoUnknownFieldFromFile) {
       TestEnvironment::writeStringToFileForTest("proto.pb", source_duration.SerializeAsString());
 
   envoy::config::bootstrap::v2::Bootstrap proto_from_file;
-  EXPECT_THROW_WITH_REGEX(MessageUtil::loadFromFile(filename, proto_from_file, false), EnvoyException,
-                          "Unable to parse file .* due to unknown fields");
+  EXPECT_THROW_WITH_REGEX(MessageUtil::loadFromFile(filename, proto_from_file, false),
+                          EnvoyException, "Unable to parse file .* due to unknown fields");
 }
 
 TEST(UtilityTest, LoadTextProtoFromFile) {
@@ -88,7 +88,8 @@ TEST(UtilityTest, LoadTextProtoFromFile_Failure) {
       TestEnvironment::writeStringToFileForTest("proto.pb_text", "invalid {");
 
   envoy::config::bootstrap::v2::Bootstrap proto_from_file;
-  EXPECT_THROW_WITH_MESSAGE(MessageUtil::loadFromFile(filename, proto_from_file, false), EnvoyException,
+  EXPECT_THROW_WITH_MESSAGE(MessageUtil::loadFromFile(filename, proto_from_file, false),
+                            EnvoyException,
                             "Unable to parse file \"" + filename +
                                 "\" as a text protobuf (type envoy.config.bootstrap.v2.Bootstrap)");
 }
@@ -237,15 +238,17 @@ TEST(UtilityTest, JsonConvertUnknownFieldSuccess) {
   envoy::config::bootstrap::v2::Bootstrap bootstrap;
   EXPECT_NO_THROW(MessageUtil::jsonConvert(obj, bootstrap, true));
   EXPECT_THROW_WITH_MESSAGE(MessageUtil::jsonConvert(obj, bootstrap, false), EnvoyException,
-                          "Unable to parse JSON as proto (INVALID_ARGUMENT:: invalid name test_key: Cannot find field.): "
-                          "{\"test_key\":\"test_value\"}");
+                            "Unable to parse JSON as proto (INVALID_ARGUMENT:: invalid name "
+                            "test_key: Cannot find field.): "
+                            "{\"test_key\":\"test_value\"}");
 }
 
 TEST(UtilityTest, JsonConvertFail) {
   ProtobufWkt::Duration source_duration;
   source_duration.set_seconds(-281474976710656);
   ProtobufWkt::Duration dest_duration;
-  EXPECT_THROW_WITH_REGEX(MessageUtil::jsonConvert(source_duration, dest_duration, false), EnvoyException,
+  EXPECT_THROW_WITH_REGEX(MessageUtil::jsonConvert(source_duration, dest_duration, false),
+                          EnvoyException,
                           "Unable to convert protobuf message to JSON string.*"
                           "seconds exceeds limit for field:  seconds: -281474976710656\n");
 }

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4490,6 +4490,10 @@ public:
                                        Server::Configuration::FactoryContext&) override {
       NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
     }
+
+    ProtobufTypes::MessagePtr createEmptyRouteConfigProto() override {
+      return ProtobufTypes::MessagePtr{new ProtobufWkt::Timestamp()};
+    }
   };
 
   void checkEach(const std::string& yaml, uint32_t expected_entry, uint32_t expected_route,
@@ -4563,7 +4567,7 @@ virtual_hosts:
     routes:
       - match: { prefix: "/" }
         route: { cluster: baz }
-    per_filter_config: { test.default.filter: { unknown_key: 123} }
+    per_filter_config: { test.default.filter: { seconds: 123} }
 )EOF";
 
   checkNoPerFilterConfig(yaml);

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -55,7 +55,7 @@ envoy::api::v2::RouteConfiguration parseRouteConfigurationFromJson(const std::st
 
 envoy::api::v2::RouteConfiguration parseRouteConfigurationFromV2Yaml(const std::string& yaml) {
   envoy::api::v2::RouteConfiguration route_config;
-  MessageUtil::loadFromYaml(yaml, route_config);
+  MessageUtil::loadFromYaml(yaml, route_config, false);
   return route_config;
 }
 

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -32,7 +32,7 @@ static envoy::api::v2::route::Route parseRouteFromJson(const std::string& json_s
 
 static envoy::api::v2::route::Route parseRouteFromV2Yaml(const std::string& yaml) {
   envoy::api::v2::route::Route route;
-  MessageUtil::loadFromYaml(yaml, route);
+  MessageUtil::loadFromYaml(yaml, route, false);
   return route;
 }
 

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -396,7 +396,7 @@ public:
 
 envoy::api::v2::RouteConfiguration parseRouteConfigurationFromV2Yaml(const std::string& yaml) {
   envoy::api::v2::RouteConfiguration route_config;
-  MessageUtil::loadFromYaml(yaml, route_config);
+  MessageUtil::loadFromYaml(yaml, route_config, false);
   return route_config;
 }
 
@@ -412,7 +412,7 @@ TEST_F(RouteConfigProviderManagerImplTest, ConfigDump) {
 static_route_configs:
 dynamic_route_configs:
 )EOF",
-                            expected_route_config_dump);
+                            expected_route_config_dump, false);
   EXPECT_EQ(expected_route_config_dump.DebugString(), route_config_dump.DebugString());
 
   std::string config_yaml = R"EOF(
@@ -452,7 +452,7 @@ static_route_configs:
       nanos: 234000000
 dynamic_route_configs:
 )EOF",
-                            expected_route_config_dump);
+                            expected_route_config_dump, false);
   EXPECT_EQ(expected_route_config_dump.DebugString(), route_config_dump2.DebugString());
 
   // Static + dynamic.
@@ -497,7 +497,7 @@ dynamic_route_configs:
       seconds: 1234567891
       nanos: 234000000
 )EOF",
-                            expected_route_config_dump);
+                            expected_route_config_dump, false);
   EXPECT_EQ(expected_route_config_dump.DebugString(), route_config_dump3.DebugString());
 }
 

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -30,7 +30,7 @@ tls_certificate:
     filename: "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_key.pem"
 )EOF";
 
-  MessageUtil::loadFromYaml(TestEnvironment::substitute(yaml), secret_config);
+  MessageUtil::loadFromYaml(TestEnvironment::substitute(yaml), secret_config, false);
 
   std::unique_ptr<SecretManager> secret_manager(new SecretManagerImpl());
 
@@ -60,7 +60,7 @@ session_ticket_keys:
     - filename: "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_cert.pem"
 )EOF";
 
-  MessageUtil::loadFromYaml(TestEnvironment::substitute(yaml), secret_config);
+  MessageUtil::loadFromYaml(TestEnvironment::substitute(yaml), secret_config, false);
 
   std::unique_ptr<SecretManager> secret_manager(new SecretManagerImpl());
 

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -428,7 +428,7 @@ tls_certificate:
     filename: "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_key.pem"
 )EOF";
 
-  MessageUtil::loadFromYaml(TestEnvironment::substitute(yaml), secret_config);
+  MessageUtil::loadFromYaml(TestEnvironment::substitute(yaml), secret_config, false);
 
   std::unique_ptr<Secret::SecretManager> secret_manager(new Secret::SecretManagerImpl());
   secret_manager->addOrUpdateSecret(secret_config);
@@ -461,7 +461,7 @@ tls_certificate:
     filename: "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_key.pem"
 )EOF";
 
-  MessageUtil::loadFromYaml(TestEnvironment::substitute(yaml), secret_config);
+  MessageUtil::loadFromYaml(TestEnvironment::substitute(yaml), secret_config, false);
 
   std::unique_ptr<Secret::SecretManager> secret_manager(new Secret::SecretManagerImpl());
 

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -320,7 +320,7 @@ TEST(ConfigTest, AccessLogConfig) {
     file_access_log.set_path("some_path");
     file_access_log.set_format("the format specifier");
     ProtobufWkt::Struct* custom_config = log->mutable_config();
-    MessageUtil::jsonConvert(file_access_log, *custom_config);
+    MessageUtil::jsonConvert(file_access_log, *custom_config, false);
   }
 
   log = config.mutable_access_log()->Add();
@@ -329,7 +329,7 @@ TEST(ConfigTest, AccessLogConfig) {
     envoy::config::accesslog::v2::FileAccessLog file_access_log;
     file_access_log.set_path("another path");
     ProtobufWkt::Struct* custom_config = log->mutable_config();
-    MessageUtil::jsonConvert(file_access_log, *custom_config);
+    MessageUtil::jsonConvert(file_access_log, *custom_config, false);
   }
 
   NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
@@ -368,7 +368,7 @@ public:
     envoy::config::accesslog::v2::FileAccessLog file_access_log;
     file_access_log.set_path("unused");
     file_access_log.set_format(access_log_format);
-    MessageUtil::jsonConvert(file_access_log, *access_log->mutable_config());
+    MessageUtil::jsonConvert(file_access_log, *access_log->mutable_config(), false);
 
     return config;
   }

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -160,7 +160,7 @@ protected:
 
 envoy::config::bootstrap::v2::Bootstrap parseBootstrapFromV2Yaml(const std::string& yaml) {
   envoy::config::bootstrap::v2::Bootstrap bootstrap;
-  MessageUtil::loadFromYaml(yaml, bootstrap);
+  MessageUtil::loadFromYaml(yaml, bootstrap, false);
   return bootstrap;
 }
 
@@ -221,7 +221,7 @@ public:
         dynamic_cast<const envoy::admin::v2alpha::ClustersConfigDump&>(*message_ptr);
 
     envoy::admin::v2alpha::ClustersConfigDump expected_clusters_config_dump;
-    MessageUtil::loadFromYaml(expected_dump_yaml, expected_clusters_config_dump);
+    MessageUtil::loadFromYaml(expected_dump_yaml, expected_clusters_config_dump, false);
     EXPECT_EQ(expected_clusters_config_dump.DebugString(), clusters_config_dump.DebugString());
   }
 

--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -56,7 +56,7 @@ inline envoy::api::v2::Cluster parseClusterFromJson(const std::string& json_stri
 
 inline envoy::api::v2::Cluster parseClusterFromV2Yaml(const std::string& yaml) {
   envoy::api::v2::Cluster cluster;
-  MessageUtil::loadFromYaml(yaml, cluster);
+  MessageUtil::loadFromYaml(yaml, cluster, false);
   return cluster;
 }
 
@@ -118,7 +118,7 @@ inline HostsPerLocalitySharedPtr makeHostsPerLocality(std::vector<HostVector>&& 
 inline envoy::api::v2::core::HealthCheck
 parseHealthCheckFromV2Yaml(const std::string& yaml_string) {
   envoy::api::v2::core::HealthCheck health_check;
-  MessageUtil::loadFromYaml(yaml_string, health_check);
+  MessageUtil::loadFromYaml(yaml_string, health_check, false);
   return health_check;
 }
 

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -89,7 +89,6 @@ const std::string ConfigHelper::DEFAULT_HEALTH_CHECK_FILTER =
 name: envoy.health_check
 config:
     pass_through_mode: false
-    endpoint: /healthcheck
 )EOF";
 
 const std::string ConfigHelper::DEFAULT_SQUASH_FILTER =

--- a/test/extensions/access_loggers/file/config_test.cc
+++ b/test/extensions/access_loggers/file/config_test.cc
@@ -31,7 +31,7 @@ TEST(FileAccessLogConfigTest, ConfigureFromProto) {
   envoy::config::accesslog::v2::FileAccessLog fal_config;
   fal_config.set_path("/dev/null");
 
-  MessageUtil::jsonConvert(fal_config, *config.mutable_config());
+  MessageUtil::jsonConvert(fal_config, *config.mutable_config(), false);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_THROW_WITH_MESSAGE(AccessLog::AccessLogFactory::fromProto(config, context), EnvoyException,
@@ -62,7 +62,7 @@ TEST(FileAccessLogConfigTest, FileAccessLogTest) {
   envoy::config::accesslog::v2::FileAccessLog file_access_log;
   file_access_log.set_path("/dev/null");
   file_access_log.set_format("%START_TIME%");
-  MessageUtil::jsonConvert(file_access_log, *message);
+  MessageUtil::jsonConvert(file_access_log, *message, false);
 
   AccessLog::FilterPtr filter;
   NiceMock<Server::Configuration::MockFactoryContext> context;

--- a/test/extensions/access_loggers/http_grpc/config_test.cc
+++ b/test/extensions/access_loggers/http_grpc/config_test.cc
@@ -38,7 +38,7 @@ public:
     auto* common_config = http_grpc_access_log_.mutable_common_config();
     common_config->set_log_name("foo");
     common_config->mutable_grpc_service()->mutable_envoy_grpc()->set_cluster_name("bar");
-    MessageUtil::jsonConvert(http_grpc_access_log_, *message_);
+    MessageUtil::jsonConvert(http_grpc_access_log_, *message_, false);
   }
 
   AccessLog::FilterPtr filter_;

--- a/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
@@ -124,7 +124,7 @@ public:
     }
 
     envoy::service::accesslog::v2::StreamAccessLogsMessage expected_request_msg;
-    MessageUtil::loadFromYaml(expected_request_msg_yaml, expected_request_msg);
+    MessageUtil::loadFromYaml(expected_request_msg_yaml, expected_request_msg, false);
     EXPECT_CALL(*streamer_, send(_, "hello_log"))
         .WillOnce(Invoke(
             [expected_request_msg](envoy::service::accesslog::v2::StreamAccessLogsMessage& message,

--- a/test/extensions/access_loggers/http_grpc/grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/http_grpc/grpc_access_log_integration_test.cc
@@ -46,7 +46,7 @@ public:
           common_config->set_log_name("foo");
           setGrpcService(*common_config->mutable_grpc_service(), "accesslog",
                          fake_upstreams_.back()->localAddress());
-          MessageUtil::jsonConvert(config, *access_log->mutable_config());
+          MessageUtil::jsonConvert(config, *access_log->mutable_config(), false);
         });
 
     HttpIntegrationTest::initialize();
@@ -72,7 +72,7 @@ public:
     EXPECT_STREQ("application/grpc", access_log_request_->headers().ContentType()->value().c_str());
 
     envoy::service::accesslog::v2::StreamAccessLogsMessage expected_request_msg;
-    MessageUtil::loadFromYaml(expected_request_msg_yaml, expected_request_msg);
+    MessageUtil::loadFromYaml(expected_request_msg_yaml, expected_request_msg, false);
 
     // Clear fields which are not deterministic.
     auto* log_entry = request_msg.mutable_http_logs()->mutable_log_entry(0);

--- a/test/extensions/filters/common/lua/wrappers_test.cc
+++ b/test/extensions/filters/common/lua/wrappers_test.cc
@@ -24,7 +24,7 @@ public:
 
   envoy::api::v2::core::Metadata parseMetadataFromYaml(const std::string& yaml_string) {
     envoy::api::v2::core::Metadata metadata;
-    MessageUtil::loadFromYaml(yaml_string, metadata);
+    MessageUtil::loadFromYaml(yaml_string, metadata, false);
     return metadata;
   }
 };

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -27,7 +27,7 @@ TEST(HttpExtAuthzConfigTest, CorrectProtoGrpc) {
 
   ExtAuthzFilterConfig factory;
   ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
-  MessageUtil::loadFromYaml(yaml, *proto_config);
+  MessageUtil::loadFromYaml(yaml, *proto_config, false);
 
   testing::StrictMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_CALL(context, localInfo()).Times(1);
@@ -60,7 +60,7 @@ TEST(HttpExtAuthzConfigTest, CorrectProtoHttp) {
 
   ExtAuthzFilterConfig factory;
   ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
-  MessageUtil::loadFromYaml(yaml, *proto_config);
+  MessageUtil::loadFromYaml(yaml, *proto_config, false);
   testing::StrictMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_CALL(context, localInfo()).Times(1);
   EXPECT_CALL(context, clusterManager()).Times(1);

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -68,7 +68,7 @@ public:
 
   void initialize(const std::string yaml) {
     envoy::config::filter::http::ext_authz::v2alpha::ExtAuthz proto_config{};
-    MessageUtil::loadFromYaml(yaml, proto_config);
+    MessageUtil::loadFromYaml(yaml, proto_config, false);
     config_.reset(new FilterConfig(proto_config, local_info_, stats_store_, runtime_, cm_));
 
     client_ = new Filters::Common::ExtAuthz::MockClient();
@@ -109,7 +109,7 @@ envoy::config::filter::http::ext_authz::v2alpha::ExtAuthz GetFilterConfig() {
       cluster_name: "ext_authz_server"
   )EOF";
   envoy::config::filter::http::ext_authz::v2alpha::ExtAuthz proto_config{};
-  MessageUtil::loadFromYaml(yaml, proto_config);
+  MessageUtil::loadFromYaml(yaml, proto_config, false);
   proto_config.set_failure_mode_allow(failure_mode_allow_value);
   return proto_config;
 }
@@ -521,7 +521,7 @@ TEST_F(HttpExtAuthzFilterTest, BadConfig) {
   )EOF";
 
   envoy::config::filter::http::ext_authz::v2alpha::ExtAuthz proto_config{};
-  MessageUtil::loadFromYaml(filter_config, proto_config);
+  MessageUtil::loadFromYaml(filter_config, proto_config, false);
 
   EXPECT_THROW(MessageUtil::downcastAndValidate<
                    const envoy::config::filter::http::ext_authz::v2alpha::ExtAuthz&>(proto_config),

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -61,7 +61,7 @@ protected:
   void setUpFilter(std::string&& json) {
     Json::ObjectSharedPtr config = Json::Factory::loadFromString(json);
     envoy::config::filter::http::gzip::v2::Gzip gzip;
-    MessageUtil::loadFromJson(json, gzip);
+    MessageUtil::loadFromJson(json, gzip, false);
     config_.reset(new GzipFilterConfig(gzip, "test.", stats_, runtime_));
     filter_.reset(new GzipFilter(config_));
   }

--- a/test/extensions/filters/http/header_to_metadata/header_to_metadata_filter_test.cc
+++ b/test/extensions/filters/http/header_to_metadata/header_to_metadata_filter_test.cc
@@ -37,7 +37,7 @@ request_rules:
 
   void initializeFilter(const std::string& yaml) {
     envoy::config::filter::http::header_to_metadata::v2::Config config;
-    MessageUtil::loadFromYaml(yaml, config);
+    MessageUtil::loadFromYaml(yaml, config, false);
     config_.reset(new Config(config));
     filter_.reset(new HeaderToMetadataFilter(config_));
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);

--- a/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
+++ b/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
@@ -41,7 +41,7 @@ ip_tags:
 
   void initializeFilter(const std::string& yaml) {
     envoy::config::filter::http::ip_tagging::v2::IPTagging config;
-    MessageUtil::loadFromYaml(yaml, config);
+    MessageUtil::loadFromYaml(yaml, config, false);
     config_.reset(new IpTaggingFilterConfig(config, "prefix.", stats_, runtime_));
     filter_.reset(new IpTaggingFilter(config_));
     filter_->setDecoderFilterCallbacks(filter_callbacks_);

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -25,7 +25,7 @@ namespace JwtAuthn {
 class AuthenticatorTest : public ::testing::Test {
 public:
   void SetUp() {
-    MessageUtil::loadFromYaml(ExampleConfig, proto_config_);
+    MessageUtil::loadFromYaml(ExampleConfig, proto_config_, false);
     CreateAuthenticator();
   }
 

--- a/test/extensions/filters/http/jwt_authn/extractor_test.cc
+++ b/test/extensions/filters/http/jwt_authn/extractor_test.cc
@@ -50,7 +50,7 @@ providers:
 class ExtractorTest : public ::testing::Test {
 public:
   void SetUp() {
-    MessageUtil::loadFromYaml(ExampleConfig, config_);
+    MessageUtil::loadFromYaml(ExampleConfig, config_, false);
     extractor_ = Extractor::create(config_);
   }
 

--- a/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
@@ -21,7 +21,7 @@ namespace JwtAuthn {
 TEST(HttpJwtAuthnFilterFactoryTest, GoodRemoteJwks) {
   FilterFactory factory;
   ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
-  MessageUtil::loadFromYaml(ExampleConfig, *proto_config);
+  MessageUtil::loadFromYaml(ExampleConfig, *proto_config, false);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -16,7 +16,7 @@ namespace {
 
 std::string getFilterConfig(bool use_local_jwks) {
   JwtAuthentication proto_config;
-  MessageUtil::loadFromYaml(ExampleConfig, proto_config);
+  MessageUtil::loadFromYaml(ExampleConfig, proto_config, false);
 
   if (use_local_jwks) {
     auto& provider0 = (*proto_config.mutable_providers())[std::string(ProviderName)];
@@ -27,7 +27,7 @@ std::string getFilterConfig(bool use_local_jwks) {
 
   HttpFilter filter;
   filter.set_name(HttpFilterNames::get().JwtAuthn);
-  MessageUtil::jsonConvert(proto_config, *filter.mutable_config());
+  MessageUtil::jsonConvert(proto_config, *filter.mutable_config(), false);
   return MessageUtil::getJsonStringFromMessage(filter);
 }
 

--- a/test/extensions/filters/http/jwt_authn/jwks_cache_test.cc
+++ b/test/extensions/filters/http/jwt_authn/jwks_cache_test.cc
@@ -20,7 +20,7 @@ namespace {
 class JwksCacheTest : public ::testing::Test {
 public:
   void SetUp() {
-    MessageUtil::loadFromYaml(ExampleConfig, config_);
+    MessageUtil::loadFromYaml(ExampleConfig, config_, false);
     cache_ = JwksCache::create(config_);
   }
 

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -81,7 +81,7 @@ public:
   }
 
   void setupMetadata(const std::string& yaml) {
-    MessageUtil::loadFromYaml(yaml, metadata_);
+    MessageUtil::loadFromYaml(yaml, metadata_, false);
     EXPECT_CALL(decoder_callbacks_.route_->route_entry_, metadata())
         .WillOnce(testing::ReturnRef(metadata_));
   }

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -54,7 +54,7 @@ public:
           )EOF";
 
           ProtobufWkt::Struct value;
-          MessageUtil::loadFromYaml(yaml, value);
+          MessageUtil::loadFromYaml(yaml, value, false);
 
           // Sets the route's metadata.
           hcm.mutable_route_config()

--- a/test/extensions/filters/http/lua/wrappers_test.cc
+++ b/test/extensions/filters/http/lua/wrappers_test.cc
@@ -248,7 +248,7 @@ protected:
 
   envoy::api::v2::core::Metadata parseMetadataFromYaml(const std::string& yaml_string) {
     envoy::api::v2::core::Metadata metadata;
-    MessageUtil::loadFromYaml(yaml_string, metadata);
+    MessageUtil::loadFromYaml(yaml_string, metadata, false);
     return metadata;
   }
 };

--- a/test/extensions/filters/http/squash/squash_filter_integration_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_integration_test.cc
@@ -135,12 +135,12 @@ TEST_P(SquashFilterIntegrationTest, TestHappyPath) {
   EXPECT_STREQ("/api/v2/debugattachment/", create_stream->headers().Path()->value().c_str());
   // Make sure the env var was replaced
   ProtobufWkt::Struct actualbody;
-  MessageUtil::loadFromJson(create_stream->body().toString(), actualbody);
+  MessageUtil::loadFromJson(create_stream->body().toString(), actualbody, false);
 
   ProtobufWkt::Struct expectedbody;
   MessageUtil::loadFromJson("{\"spec\": { \"attachment\" : { \"env\": \"" ENV_VAR_VALUE
                             "\" } , \"match_request\":true} }",
-                            expectedbody);
+                            expectedbody, false);
 
   EXPECT_TRUE(MessageDifferencer::Equals(expectedbody, actualbody));
   // The second request should be for the created object

--- a/test/extensions/filters/http/squash/squash_filter_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_test.cc
@@ -39,10 +39,10 @@ SquashFilterConfig constructSquashFilterConfigFromJson(
 
 void EXPECT_JSON_EQ(const std::string& expected, const std::string& actual) {
   ProtobufWkt::Struct actualjson;
-  MessageUtil::loadFromJson(actual, actualjson);
+  MessageUtil::loadFromJson(actual, actualjson, false);
 
   ProtobufWkt::Struct expectedjson;
-  MessageUtil::loadFromJson(expected, expectedjson);
+  MessageUtil::loadFromJson(expected, expectedjson, false);
 
   EXPECT_TRUE(MessageDifferencer::Equals(expectedjson, actualjson));
 }

--- a/test/extensions/filters/network/ext_authz/config_test.cc
+++ b/test/extensions/filters/network/ext_authz/config_test.cc
@@ -35,7 +35,7 @@ TEST(ExtAuthzFilterConfigTest, ExtAuthzCorrectProto) {
 
   ExtAuthzConfigFactory factory;
   ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
-  MessageUtil::loadFromYaml(yaml, *proto_config);
+  MessageUtil::loadFromYaml(yaml, *proto_config, false);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 

--- a/test/extensions/filters/network/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/network/ext_authz/ext_authz_test.cc
@@ -49,7 +49,7 @@ public:
     )EOF";
 
     envoy::config::filter::network::ext_authz::v2::ExtAuthz proto_config{};
-    MessageUtil::loadFromJson(json, proto_config);
+    MessageUtil::loadFromJson(json, proto_config, false);
     config_.reset(new Config(proto_config, stats_store_));
     client_ = new Filters::Common::ExtAuthz::MockClient();
     filter_.reset(new Filter(config_, Filters::Common::ExtAuthz::ClientPtr{client_}));
@@ -93,7 +93,7 @@ TEST_F(ExtAuthzFilterTest, BadExtAuthzConfig) {
   )EOF";
 
   envoy::config::filter::network::ext_authz::v2::ExtAuthz proto_config{};
-  MessageUtil::loadFromJson(json_string, proto_config);
+  MessageUtil::loadFromJson(json_string, proto_config, false);
 
   EXPECT_THROW(MessageUtil::downcastAndValidate<
                    const envoy::config::filter::network::ext_authz::v2::ExtAuthz&>(proto_config),

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -39,7 +39,7 @@ envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManag
 parseHttpConnectionManagerFromV2Yaml(const std::string& yaml) {
   envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager
       http_connection_manager;
-  MessageUtil::loadFromYaml(yaml, http_connection_manager);
+  MessageUtil::loadFromYaml(yaml, http_connection_manager, false);
   return http_connection_manager;
 }
 

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -65,7 +65,7 @@ public:
     if (yaml.empty()) {
       proto_config_.set_stat_prefix("test");
     } else {
-      MessageUtil::loadFromYaml(yaml, proto_config_);
+      MessageUtil::loadFromYaml(yaml, proto_config_, false);
       MessageUtil::validate(proto_config_);
     }
 

--- a/test/extensions/filters/network/thrift_proxy/integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/integration_test.cc
@@ -46,12 +46,7 @@ public:
             route_config:
               name: "routes"
               routes:
-                - match:
-                    method_name: "execute"
-                  route:
-                    cluster: "cluster_0"
-                - match:
-                    method_name: "poke"
+                - match: {}
                   route:
                     cluster: "cluster_0"
       )EOF";

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -41,7 +41,7 @@ namespace {
 envoy::config::filter::network::thrift_proxy::v2alpha1::RouteConfiguration
 parseRouteConfigurationFromV2Yaml(const std::string& yaml) {
   envoy::config::filter::network::thrift_proxy::v2alpha1::RouteConfiguration route_config;
-  MessageUtil::loadFromYaml(yaml, route_config);
+  MessageUtil::loadFromYaml(yaml, route_config, false);
   MessageUtil::validate(route_config);
   return route_config;
 }

--- a/test/extensions/grpc_credentials/file_based_metadata/file_based_metadata_grpc_credentials_test.cc
+++ b/test/extensions/grpc_credentials/file_based_metadata/file_based_metadata_grpc_credentials_test.cc
@@ -48,7 +48,7 @@ header_prefix: {}
       auto* plugin_config = google_grpc->add_call_credentials()->mutable_from_plugin();
       plugin_config->set_name(credentials_factory_name_);
       envoy::config::grpc_credential::v2alpha::FileBasedMetadataConfig metadata_config;
-      MessageUtil::loadFromYaml(yaml1, *plugin_config->mutable_config());
+      MessageUtil::loadFromYaml(yaml1, *plugin_config->mutable_config(), false);
     }
     if (!header_value_2_.empty()) {
       // uses default key/prefix
@@ -60,7 +60,7 @@ secret_data:
       envoy::config::grpc_credential::v2alpha::FileBasedMetadataConfig metadata_config2;
       auto* plugin_config2 = google_grpc->add_call_credentials()->mutable_from_plugin();
       plugin_config2->set_name(credentials_factory_name_);
-      MessageUtil::loadFromYaml(yaml2, *plugin_config2->mutable_config());
+      MessageUtil::loadFromYaml(yaml2, *plugin_config2->mutable_config(), false);
     }
     if (!access_token_value_.empty()) {
       google_grpc->add_call_credentials()->set_access_token(access_token_value_);

--- a/test/extensions/stats_sinks/dog_statsd/config_test.cc
+++ b/test/extensions/stats_sinks/dog_statsd/config_test.cc
@@ -47,7 +47,7 @@ TEST_P(DogStatsdConfigLoopbackTest, ValidUdpIp) {
   ASSERT_NE(factory, nullptr);
 
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
-  MessageUtil::jsonConvert(sink_config, *message);
+  MessageUtil::jsonConvert(sink_config, *message, false);
 
   NiceMock<Server::MockInstance> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);

--- a/test/extensions/stats_sinks/hystrix/config_test.cc
+++ b/test/extensions/stats_sinks/hystrix/config_test.cc
@@ -35,7 +35,7 @@ TEST(StatsConfigTest, ValidHystrixSink) {
   ASSERT_NE(factory, nullptr);
 
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
-  MessageUtil::jsonConvert(sink_config, *message);
+  MessageUtil::jsonConvert(sink_config, *message, false);
 
   NiceMock<Server::MockInstance> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);

--- a/test/extensions/stats_sinks/metrics_service/metrics_service_integration_test.cc
+++ b/test/extensions/stats_sinks/metrics_service/metrics_service_integration_test.cc
@@ -42,7 +42,7 @@ public:
       envoy::config::metrics::v2::MetricsServiceConfig config;
       setGrpcService(*config.mutable_grpc_service(), "metrics_service",
                      fake_upstreams_.back()->localAddress());
-      MessageUtil::jsonConvert(config, *metrics_sink->mutable_config());
+      MessageUtil::jsonConvert(config, *metrics_sink->mutable_config(), false);
       // Shrink reporting period down to 1s to make test not take forever.
       bootstrap.mutable_stats_flush_interval()->CopyFrom(
           Protobuf::util::TimeUtil::MillisecondsToDuration(100));

--- a/test/extensions/stats_sinks/statsd/config_test.cc
+++ b/test/extensions/stats_sinks/statsd/config_test.cc
@@ -38,7 +38,7 @@ TEST(StatsConfigTest, ValidTcpStatsd) {
   ASSERT_NE(factory, nullptr);
 
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
-  MessageUtil::jsonConvert(sink_config, *message);
+  MessageUtil::jsonConvert(sink_config, *message, false);
 
   NiceMock<Server::MockInstance> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
@@ -72,7 +72,7 @@ TEST_P(StatsConfigParameterizedTest, UdpSinkDefaultPrefix) {
       Registry::FactoryRegistry<Server::Configuration::StatsSinkFactory>::getFactory(name);
   ASSERT_NE(factory, nullptr);
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
-  MessageUtil::jsonConvert(sink_config, *message);
+  MessageUtil::jsonConvert(sink_config, *message, false);
 
   NiceMock<Server::MockInstance> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
@@ -104,7 +104,7 @@ TEST_P(StatsConfigParameterizedTest, UdpSinkCustomPrefix) {
       Registry::FactoryRegistry<Server::Configuration::StatsSinkFactory>::getFactory(name);
   ASSERT_NE(factory, nullptr);
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
-  MessageUtil::jsonConvert(sink_config, *message);
+  MessageUtil::jsonConvert(sink_config, *message, false);
 
   NiceMock<Server::MockInstance> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
@@ -127,7 +127,7 @@ TEST(StatsConfigTest, TcpSinkDefaultPrefix) {
   ASSERT_NE(factory, nullptr);
   EXPECT_EQ(sink_config.prefix(), "");
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
-  MessageUtil::jsonConvert(sink_config, *message);
+  MessageUtil::jsonConvert(sink_config, *message, false);
 
   NiceMock<Server::MockInstance> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
@@ -152,7 +152,7 @@ TEST(StatsConfigTest, TcpSinkCustomPrefix) {
   ASSERT_NE(factory, nullptr);
 
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
-  MessageUtil::jsonConvert(sink_config, *message);
+  MessageUtil::jsonConvert(sink_config, *message, false);
 
   NiceMock<Server::MockInstance> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
@@ -184,7 +184,7 @@ TEST_P(StatsConfigLoopbackTest, ValidUdpIpStatsd) {
   ASSERT_NE(factory, nullptr);
 
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
-  MessageUtil::jsonConvert(sink_config, *message);
+  MessageUtil::jsonConvert(sink_config, *message, false);
 
   NiceMock<Server::MockInstance> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -227,7 +227,8 @@ public:
           MessageUtil::loadFromYaml(http_connection_mgr_config, hcm, false);
           envoy::config::filter::http::router::v2::Router router_config;
           router_config.set_suppress_envoy_headers(routerSuppressEnvoyHeaders());
-          MessageUtil::jsonConvert(router_config, *hcm.mutable_http_filters(0)->mutable_config(), false);
+          MessageUtil::jsonConvert(router_config, *hcm.mutable_http_filters(0)->mutable_config(),
+                                   false);
 
           const bool append = mode == HeaderMode::Append;
 

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -224,10 +224,10 @@ public:
         [&](envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager&
                 hcm) {
           // Overwrite default config with our own.
-          MessageUtil::loadFromYaml(http_connection_mgr_config, hcm);
+          MessageUtil::loadFromYaml(http_connection_mgr_config, hcm, false);
           envoy::config::filter::http::router::v2::Router router_config;
           router_config.set_suppress_envoy_headers(routerSuppressEnvoyHeaders());
-          MessageUtil::jsonConvert(router_config, *hcm.mutable_http_filters(0)->mutable_config());
+          MessageUtil::jsonConvert(router_config, *hcm.mutable_http_filters(0)->mutable_config(), false);
 
           const bool append = mode == HeaderMode::Append;
 

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -409,7 +409,6 @@ void HttpIntegrationTest::testComputedHealthCheck() {
 name: envoy.health_check
 config:
     pass_through_mode: false
-    endpoint: /healthcheck
     cluster_min_healthy_percentages:
         example_cluster_name: { value: 75 }
 )EOF");

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -289,7 +289,8 @@ TEST_P(IntegrationAdminTest, Admin) {
   EXPECT_TRUE(json->getObject("configs")->hasObject("routes"));
   // Validate we can parse as proto.
   envoy::admin::v2alpha::ConfigDump config_dump;
-  MessageUtil::loadFromJson(response->body(), config_dump);
+  // TODO(kuat) make sure proto matches JSON
+  MessageUtil::loadFromJson(response->body(), config_dump, true);
   EXPECT_EQ(1, config_dump.configs().count("bootstrap"));
   EXPECT_EQ(1, config_dump.configs().count("clusters"));
   EXPECT_EQ(1, config_dump.configs().count("listeners"));

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -45,6 +45,7 @@ public:
   const std::string& configPath() const override { return config_path_; }
   const std::string& configYaml() const override { return config_yaml_; }
   bool v2ConfigOnly() const override { return false; }
+  bool allowUnknownFields() const override { return false; }
   const std::string& adminAddressPath() const override { return admin_address_path_; }
   Network::Address::IpVersion localAddressIpVersion() const override {
     return local_address_ip_version_;

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -197,7 +197,7 @@ public:
       // Configure inner SSL transport socket based on existing config.
       envoy::api::v2::core::TransportSocket ssl_transport_socket;
       ssl_transport_socket.set_name("tls");
-      MessageUtil::jsonConvert(filter_chain->tls_context(), *ssl_transport_socket.mutable_config());
+      MessageUtil::jsonConvert(filter_chain->tls_context(), *ssl_transport_socket.mutable_config(), false);
       // Configure outer capture transport socket.
       auto* transport_socket = filter_chain->mutable_transport_socket();
       transport_socket->set_name("envoy.transport_sockets.capture");
@@ -208,7 +208,7 @@ public:
           text_format_ ? envoy::config::transport_socket::capture::v2alpha::FileSink::PROTO_TEXT
                        : envoy::config::transport_socket::capture::v2alpha::FileSink::PROTO_BINARY);
       capture_config.mutable_transport_socket()->MergeFrom(ssl_transport_socket);
-      MessageUtil::jsonConvert(capture_config, *transport_socket->mutable_config());
+      MessageUtil::jsonConvert(capture_config, *transport_socket->mutable_config(), false);
       // Nuke TLS context from legacy location.
       filter_chain->clear_tls_context();
       // Rest of TLS initialization.
@@ -254,7 +254,7 @@ TEST_P(SslCaptureIntegrationTest, TwoRequestsWithBinaryProto) {
   codec_client_->close();
   test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
   envoy::data::tap::v2alpha::Trace trace;
-  MessageUtil::loadFromFile(fmt::format("{}_{}.pb", path_prefix_, first_id), trace);
+  MessageUtil::loadFromFile(fmt::format("{}_{}.pb", path_prefix_, first_id), trace, false);
   // Validate general expected properties in the trace.
   EXPECT_EQ(first_id, trace.connection().id());
   EXPECT_THAT(expected_local_address, ProtoEq(trace.connection().local_address()));
@@ -279,7 +279,7 @@ TEST_P(SslCaptureIntegrationTest, TwoRequestsWithBinaryProto) {
   checkStats();
   codec_client_->close();
   test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 2);
-  MessageUtil::loadFromFile(fmt::format("{}_{}.pb", path_prefix_, second_id), trace);
+  MessageUtil::loadFromFile(fmt::format("{}_{}.pb", path_prefix_, second_id), trace, false);
   // Validate second connection ID.
   EXPECT_EQ(second_id, trace.connection().id());
   ASSERT_GE(trace.events().size(), 2);
@@ -299,7 +299,7 @@ TEST_P(SslCaptureIntegrationTest, RequestWithTextProto) {
   codec_client_->close();
   test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
   envoy::data::tap::v2alpha::Trace trace;
-  MessageUtil::loadFromFile(fmt::format("{}_{}.pb_text", path_prefix_, id), trace);
+  MessageUtil::loadFromFile(fmt::format("{}_{}.pb_text", path_prefix_, id), trace, false);
   // Test some obvious properties.
   EXPECT_TRUE(absl::StartsWith(trace.events(0).read().data(), "POST /test/long/url HTTP/1.1"));
   EXPECT_TRUE(absl::StartsWith(trace.events(1).write().data(), "HTTP/1.1 200 OK"));

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -197,7 +197,8 @@ public:
       // Configure inner SSL transport socket based on existing config.
       envoy::api::v2::core::TransportSocket ssl_transport_socket;
       ssl_transport_socket.set_name("tls");
-      MessageUtil::jsonConvert(filter_chain->tls_context(), *ssl_transport_socket.mutable_config(), false);
+      MessageUtil::jsonConvert(filter_chain->tls_context(), *ssl_transport_socket.mutable_config(),
+                               false);
       // Configure outer capture transport socket.
       auto* transport_socket = filter_chain->mutable_transport_socket();
       transport_socket->set_name("envoy.transport_sockets.capture");

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -224,7 +224,7 @@ TEST_P(TcpProxyIntegrationTest, AccessLog) {
     auto* config_blob = filter_chain->mutable_filters(0)->mutable_config();
 
     envoy::config::filter::network::tcp_proxy::v2::TcpProxy tcp_proxy_config;
-    MessageUtil::jsonConvert(*config_blob, tcp_proxy_config);
+    MessageUtil::jsonConvert(*config_blob, tcp_proxy_config, false);
 
     auto* access_log = tcp_proxy_config.add_access_log();
     access_log->set_name("envoy.file_access_log");
@@ -233,9 +233,9 @@ TEST_P(TcpProxyIntegrationTest, AccessLog) {
     access_log_config.set_format(
         "upstreamlocal=%UPSTREAM_LOCAL_ADDRESS% "
         "upstreamhost=%UPSTREAM_HOST% downstream=%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%\n");
-    MessageUtil::jsonConvert(access_log_config, *access_log->mutable_config());
+    MessageUtil::jsonConvert(access_log_config, *access_log->mutable_config(), false);
 
-    MessageUtil::jsonConvert(tcp_proxy_config, *config_blob);
+    MessageUtil::jsonConvert(tcp_proxy_config, *config_blob, false);
   });
   initialize();
 
@@ -312,11 +312,11 @@ TEST_P(TcpProxyIntegrationTest, TestIdletimeoutWithNoData) {
     auto* config_blob = filter_chain->mutable_filters(0)->mutable_config();
 
     envoy::config::filter::network::tcp_proxy::v2::TcpProxy tcp_proxy_config;
-    MessageUtil::jsonConvert(*config_blob, tcp_proxy_config);
+    MessageUtil::jsonConvert(*config_blob, tcp_proxy_config, false);
     tcp_proxy_config.mutable_idle_timeout()->set_nanos(
         std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::milliseconds(100))
             .count());
-    MessageUtil::jsonConvert(tcp_proxy_config, *config_blob);
+    MessageUtil::jsonConvert(tcp_proxy_config, *config_blob, false);
   });
 
   initialize();
@@ -333,11 +333,11 @@ TEST_P(TcpProxyIntegrationTest, TestIdletimeoutWithLargeOutstandingData) {
     auto* config_blob = filter_chain->mutable_filters(0)->mutable_config();
 
     envoy::config::filter::network::tcp_proxy::v2::TcpProxy tcp_proxy_config;
-    MessageUtil::jsonConvert(*config_blob, tcp_proxy_config);
+    MessageUtil::jsonConvert(*config_blob, tcp_proxy_config, false);
     tcp_proxy_config.mutable_idle_timeout()->set_nanos(
         std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::milliseconds(500))
             .count());
-    MessageUtil::jsonConvert(tcp_proxy_config, *config_blob);
+    MessageUtil::jsonConvert(tcp_proxy_config, *config_blob, false);
   });
 
   initialize();

--- a/test/integration/websocket_integration_test.cc
+++ b/test/integration/websocket_integration_test.cc
@@ -317,7 +317,7 @@ TEST_P(WebsocketIntegrationTest, WebSocketLogging) {
 
     envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager
         http_conn_manager_config;
-    MessageUtil::jsonConvert(*config_blob, http_conn_manager_config);
+    MessageUtil::jsonConvert(*config_blob, http_conn_manager_config, false);
 
     auto* access_log = http_conn_manager_config.add_access_log();
     access_log->set_name("envoy.file_access_log");
@@ -327,8 +327,8 @@ TEST_P(WebsocketIntegrationTest, WebSocketLogging) {
         expected_log_template, "%BYTES_SENT%", "%BYTES_RECEIVED%", "%DOWNSTREAM_LOCAL_ADDRESS%",
         "%DOWNSTREAM_REMOTE_ADDRESS%", "%UPSTREAM_LOCAL_ADDRESS%"));
 
-    MessageUtil::jsonConvert(access_log_config, *access_log->mutable_config());
-    MessageUtil::jsonConvert(http_conn_manager_config, *config_blob);
+    MessageUtil::jsonConvert(access_log_config, *access_log->mutable_config(), false);
+    MessageUtil::jsonConvert(http_conn_manager_config, *config_blob, false);
   });
 
   initialize();
@@ -472,7 +472,7 @@ TEST_P(WebsocketIntegrationTest, WebsocketCustomFilterChain) {
         auto* filter_list_back = foo_upgrade->add_filters();
         const std::string json =
             Json::Factory::loadFromYamlString("name: envoy.router")->asJsonString();
-        MessageUtil::loadFromJson(json, *filter_list_back);
+        MessageUtil::loadFromJson(json, *filter_list_back, false);
       });
   initialize();
 

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -145,6 +145,7 @@ MockMain::MockMain(int wd_miss, int wd_megamiss, int wd_kill, int wd_multikill)
 
 MockFactoryContext::MockFactoryContext() : singleton_manager_(new Singleton::ManagerImpl()) {
   ON_CALL(*this, accessLogManager()).WillByDefault(ReturnRef(access_log_manager_));
+  ON_CALL(*this, allowUnknownFields()).WillByDefault(Return(false));
   ON_CALL(*this, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
   ON_CALL(*this, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
   ON_CALL(*this, drainDecision()).WillByDefault(ReturnRef(drain_manager_));

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -56,6 +56,7 @@ public:
   MOCK_CONST_METHOD0(configPath, const std::string&());
   MOCK_CONST_METHOD0(configYaml, const std::string&());
   MOCK_CONST_METHOD0(v2ConfigOnly, bool());
+  MOCK_CONST_METHOD0(allowUnknownFields, bool());
   MOCK_CONST_METHOD0(adminAddressPath, const std::string&());
   MOCK_CONST_METHOD0(localAddressIpVersion, Network::Address::IpVersion());
   MOCK_CONST_METHOD0(drainTime, std::chrono::seconds());
@@ -385,6 +386,7 @@ public:
   }
 
   MOCK_METHOD0(accessLogManager, AccessLog::AccessLogManager&());
+  MOCK_METHOD0(allowUnknownFields, bool());
   MOCK_METHOD0(clusterManager, Upstream::ClusterManager&());
   MOCK_METHOD0(dispatcher, Event::Dispatcher&());
   MOCK_METHOD0(drainDecision, const Network::DrainDecision&());

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -690,7 +690,7 @@ TEST_P(AdminInstanceTest, ClustersJson) {
   EXPECT_EQ(Http::Code::OK, getCallback("/clusters?format=json", header_map, response));
   std::string output_json = response.toString();
   envoy::admin::v2alpha::Clusters output_proto;
-  MessageUtil::loadFromJson(output_json, output_proto);
+  MessageUtil::loadFromJson(output_json, output_proto, false);
 
   const std::string expected_json = R"EOF({
  "cluster_statuses": [
@@ -735,7 +735,7 @@ TEST_P(AdminInstanceTest, ClustersJson) {
 )EOF";
 
   envoy::admin::v2alpha::Clusters expected_proto;
-  MessageUtil::loadFromJson(expected_json, expected_proto);
+  MessageUtil::loadFromJson(expected_json, expected_proto, false);
 
   // Ensure the protos created from each JSON are equivalent.
   EXPECT_THAT(output_proto, ProtoEq(expected_proto));
@@ -744,7 +744,7 @@ TEST_P(AdminInstanceTest, ClustersJson) {
   EXPECT_EQ(Http::Code::OK, getCallback("/clusters", header_map, response));
   std::string text_output = response.toString();
   envoy::admin::v2alpha::Clusters failed_conversion_proto;
-  EXPECT_THROW(MessageUtil::loadFromJson(text_output, failed_conversion_proto), EnvoyException);
+  EXPECT_THROW(MessageUtil::loadFromJson(text_output, failed_conversion_proto, false), EnvoyException);
 }
 
 TEST_P(AdminInstanceTest, GetRequest) {

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -744,7 +744,8 @@ TEST_P(AdminInstanceTest, ClustersJson) {
   EXPECT_EQ(Http::Code::OK, getCallback("/clusters", header_map, response));
   std::string text_output = response.toString();
   envoy::admin::v2alpha::Clusters failed_conversion_proto;
-  EXPECT_THROW(MessageUtil::loadFromJson(text_output, failed_conversion_proto, false), EnvoyException);
+  EXPECT_THROW(MessageUtil::loadFromJson(text_output, failed_conversion_proto, false),
+               EnvoyException);
 }
 
 TEST_P(AdminInstanceTest, GetRequest) {

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -105,7 +105,7 @@ public:
         dynamic_cast<const envoy::admin::v2alpha::ListenersConfigDump&>(*message_ptr);
 
     envoy::admin::v2alpha::ListenersConfigDump expected_listeners_config_dump;
-    MessageUtil::loadFromYaml(expected_dump_yaml, expected_listeners_config_dump);
+    MessageUtil::loadFromYaml(expected_dump_yaml, expected_listeners_config_dump, false);
     EXPECT_EQ(expected_listeners_config_dump.DebugString(), listeners_config_dump.DebugString());
   }
 

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -130,7 +130,7 @@ protected:
 TEST_F(OverloadManagerImplTest, CallbackOnlyFiresWhenStateChanges) {
   setDispatcherExpectation();
 
-  OverloadManagerImpl manager(dispatcher_, stats_, parseConfig(getConfig()));
+  OverloadManagerImpl manager(dispatcher_, stats_, parseConfig(getConfig()), false);
   bool is_active = false;
   int cb_count = 0;
   manager.registerForAction("envoy.overload_actions.dummy_action", dispatcher_,
@@ -188,7 +188,7 @@ TEST_F(OverloadManagerImplTest, CallbackOnlyFiresWhenStateChanges) {
 
 TEST_F(OverloadManagerImplTest, FailedUpdates) {
   setDispatcherExpectation();
-  OverloadManagerImpl manager(dispatcher_, stats_, parseConfig(getConfig()));
+  OverloadManagerImpl manager(dispatcher_, stats_, parseConfig(getConfig()), false);
   manager.start();
   Stats::Counter& failed_updates =
       stats_.counter("overload.envoy.resource_monitors.fake_resource1.failed_updates");
@@ -207,7 +207,7 @@ TEST_F(OverloadManagerImplTest, SkippedUpdates) {
   Event::PostCb post_cb;
   ON_CALL(dispatcher_, post(_)).WillByDefault(Invoke([&](Event::PostCb cb) { post_cb = cb; }));
 
-  OverloadManagerImpl manager(dispatcher_, stats_, parseConfig(getConfig()));
+  OverloadManagerImpl manager(dispatcher_, stats_, parseConfig(getConfig()), false);
   manager.start();
   Stats::Counter& skipped_updates =
       stats_.counter("overload.envoy.resource_monitors.fake_resource1.skipped_updates");
@@ -233,7 +233,7 @@ TEST_F(OverloadManagerImplTest, DuplicateResourceMonitor) {
     }
   )EOF";
 
-  EXPECT_THROW_WITH_REGEX(OverloadManagerImpl(dispatcher_, stats_, parseConfig(config)),
+  EXPECT_THROW_WITH_REGEX(OverloadManagerImpl(dispatcher_, stats_, parseConfig(config), false),
                           EnvoyException, "Duplicate resource monitor .*");
 }
 
@@ -247,7 +247,7 @@ TEST_F(OverloadManagerImplTest, DuplicateOverloadAction) {
     }
   )EOF";
 
-  EXPECT_THROW_WITH_REGEX(OverloadManagerImpl(dispatcher_, stats_, parseConfig(config)),
+  EXPECT_THROW_WITH_REGEX(OverloadManagerImpl(dispatcher_, stats_, parseConfig(config), false),
                           EnvoyException, "Duplicate overload action .*");
 }
 
@@ -264,7 +264,7 @@ TEST_F(OverloadManagerImplTest, UnknownTrigger) {
     }
   )EOF";
 
-  EXPECT_THROW_WITH_REGEX(OverloadManagerImpl(dispatcher_, stats_, parseConfig(config)),
+  EXPECT_THROW_WITH_REGEX(OverloadManagerImpl(dispatcher_, stats_, parseConfig(config), false),
                           EnvoyException, "Unknown trigger resource .*");
 }
 
@@ -290,7 +290,7 @@ TEST_F(OverloadManagerImplTest, DuplicateTrigger) {
     }
   )EOF";
 
-  EXPECT_THROW_WITH_REGEX(OverloadManagerImpl(dispatcher_, stats_, parseConfig(config)),
+  EXPECT_THROW_WITH_REGEX(OverloadManagerImpl(dispatcher_, stats_, parseConfig(config), false),
                           EnvoyException, "Duplicate trigger .*");
 }
 } // namespace

--- a/test/server/utility.h
+++ b/test/server/utility.h
@@ -18,7 +18,7 @@ inline envoy::api::v2::Listener parseListenerFromJson(const std::string& json_st
 
 inline envoy::api::v2::Listener parseListenerFromV2Yaml(const std::string& yaml) {
   envoy::api::v2::Listener listener;
-  MessageUtil::loadFromYaml(yaml, listener);
+  MessageUtil::loadFromYaml(yaml, listener, false);
   return listener;
 }
 

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -247,7 +247,7 @@ public:
    */
   template <class MessageType> static MessageType parseYaml(const std::string& yaml) {
     MessageType message;
-    MessageUtil::loadFromYaml(yaml, message);
+    MessageUtil::loadFromYaml(yaml, message, false);
     return message;
   }
 

--- a/tools/protodoc/protodoc.bzl
+++ b/tools/protodoc/protodoc.bzl
@@ -78,7 +78,6 @@ def _proto_doc_aspect_impl(target, ctx):
     return [OutputGroupInfo(rst = transitive_outputs)]
 
 proto_doc_aspect = aspect(
-    implementation = _proto_doc_aspect_impl,
     attr_aspects = ["deps"],
     attrs = {
         "_protoc": attr.label(
@@ -92,4 +91,5 @@ proto_doc_aspect = aspect(
             cfg = "host",
         ),
     },
+    implementation = _proto_doc_aspect_impl,
 )


### PR DESCRIPTION
*Description*: Add a flag `allow-unknown-fields` that controls whether all fields must be known in the filter configurations.

If allow unknown fields is set to false the following takes effect:
- filter configs (represented as proto structs) must only have fields defined in the protos
- files loaded from .pb, .yaml, and .json are also checked for known fields

Internal conversions in other parts of the code (upstream transport socket factories, etc) always allow unknown fields.

Proto text always requires known fields (general protobuf constraint).

Protos sent as Any always allow unknown fields. Reasoning here is that if the proto is packed then the schema has already been enforced on the supplier side. I also could not find a way to enforce strict checks in the protobuf API.

*Risk Level*: Medium. Allow unknown fields is set to false by default, meaning unknown fields will be rejected by envoy.

*Testing*: Unit tests were updated to have it strict by default. Some wrong filter configs were discovered.

*Docs Changes*: None

*Release Notes*:
Add a flag `allow-unknown-fields` to control validation of filter configurations for unknown fields.

Fixes #4053 

/cc @PiotrSikora 