### PR TITLE
config: allow unknown fields flag (take 2)

### DIFF
--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -55,11 +55,7 @@ public:
       if (!resource.UnpackTo(typed_resource)) {
         throw EnvoyException("Unable to unpack " + resource.DebugString());
       }
-      if (!MessageUtil::allow_unknown_fields &&
-          !typed_resource->GetReflection()->GetUnknownFields(*typed_resource).empty()) {
-        throw EnvoyException("Protobuf Any (type " + typed_resource->GetTypeName() +
-                             ") has unknown fields");
-      }
+      MessageUtil::checkUnknownFields(*typed_resource);
     }
     return typed_resources;
   }

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -78,6 +78,11 @@ void MessageUtil::loadFromFile(const std::string& path, Protobuf::Message& messa
   if (StringUtil::endsWith(path, ".pb")) {
     // Attempt to parse the binary format.
     if (message.ParseFromString(contents)) {
+      if (!MessageUtil::allow_unknown_fields &&
+          !message.GetReflection()->GetUnknownFields(message).empty()) {
+        throw EnvoyException("Protobuf Any (type " + message.GetTypeName() +
+                             ") has unknown fields");
+      }
       return;
     }
     throw EnvoyException("Unable to parse file \"" + path + "\" as a binary protobuf (type " +

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -78,11 +78,7 @@ void MessageUtil::loadFromFile(const std::string& path, Protobuf::Message& messa
   if (StringUtil::endsWith(path, ".pb")) {
     // Attempt to parse the binary format.
     if (message.ParseFromString(contents)) {
-      if (!MessageUtil::allow_unknown_fields &&
-          !message.GetReflection()->GetUnknownFields(message).empty()) {
-        throw EnvoyException("Protobuf Any (type " + message.GetTypeName() +
-                             ") has unknown fields");
-      }
+      MessageUtil::checkUnknownFields(message);
       return;
     }
     throw EnvoyException("Unable to parse file \"" + path + "\" as a binary protobuf (type " +

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -158,7 +158,10 @@ public:
     return HashUtil::xxHash64(text);
   }
 
+  static bool allow_unknown_fields;
+
   static void loadFromJson(const std::string& json, Protobuf::Message& message);
+  static void loadFromJsonLenient(const std::string& json, Protobuf::Message& message);
   static void loadFromYaml(const std::string& yaml, Protobuf::Message& message);
   static void loadFromFile(const std::string& path, Protobuf::Message& message);
 

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -160,6 +160,13 @@ public:
 
   static bool allow_unknown_fields;
 
+  static void checkUnknownFields(const Protobuf::Message& message) {
+    if (!MessageUtil::allow_unknown_fields &&
+        !message.GetReflection()->GetUnknownFields(message).empty()) {
+      throw EnvoyException("Protobuf Any (type " + message.GetTypeName() + ") has unknown fields");
+    }
+  }
+
   static void loadFromJson(const std::string& json, Protobuf::Message& message);
   static void loadFromJsonLenient(const std::string& json, Protobuf::Message& message);
   static void loadFromYaml(const std::string& yaml, Protobuf::Message& message);
@@ -217,11 +224,7 @@ public:
     if (!message.UnpackTo(&typed_message)) {
       throw EnvoyException("Unable to unpack " + message.DebugString());
     }
-    if (!MessageUtil::allow_unknown_fields &&
-        !typed_message.GetReflection()->GetUnknownFields(typed_message).empty()) {
-      throw EnvoyException("Protobuf Any (type " + typed_message.GetTypeName() +
-                           ") has unknown fields");
-    }
+    checkUnknownFields(typed_message);
     return typed_message;
   };
 

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -217,6 +217,11 @@ public:
     if (!message.UnpackTo(&typed_message)) {
       throw EnvoyException("Unable to unpack " + message.DebugString());
     }
+    if (!MessageUtil::allow_unknown_fields &&
+        !typed_message.GetReflection()->GetUnknownFields(typed_message).empty()) {
+      throw EnvoyException("Protobuf Any (type " + typed_message.GetTypeName() +
+                           ") has unknown fields");
+    }
     return typed_message;
   };
 

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -133,6 +133,8 @@ public:
   ProtoValidationException(const std::string& validation_error, const Protobuf::Message& message);
 };
 
+enum class ProtoUnknownFieldsMode { Strict, Allow };
+
 class MessageUtil {
 public:
   // std::hash
@@ -158,10 +160,10 @@ public:
     return HashUtil::xxHash64(text);
   }
 
-  static bool allow_unknown_fields;
+  static ProtoUnknownFieldsMode proto_unknown_fields;
 
   static void checkUnknownFields(const Protobuf::Message& message) {
-    if (!MessageUtil::allow_unknown_fields &&
+    if (MessageUtil::proto_unknown_fields == ProtoUnknownFieldsMode::Strict &&
         !message.GetReflection()->GetUnknownFields(message).empty()) {
       throw EnvoyException("Protobuf message (type " + message.GetTypeName() +
                            ") has unknown fields");
@@ -169,8 +171,8 @@ public:
   }
 
   static void loadFromJson(const std::string& json, Protobuf::Message& message);
-  static void loadFromJsonCustom(const std::string& json, Protobuf::Message& message,
-                                 bool allow_unknown_fields);
+  static void loadFromJsonEx(const std::string& json, Protobuf::Message& message,
+                             ProtoUnknownFieldsMode proto_unknown_fields);
   static void loadFromYaml(const std::string& yaml, Protobuf::Message& message);
   static void loadFromFile(const std::string& path, Protobuf::Message& message);
 

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -163,12 +163,14 @@ public:
   static void checkUnknownFields(const Protobuf::Message& message) {
     if (!MessageUtil::allow_unknown_fields &&
         !message.GetReflection()->GetUnknownFields(message).empty()) {
-      throw EnvoyException("Protobuf Any (type " + message.GetTypeName() + ") has unknown fields");
+      throw EnvoyException("Protobuf message (type " + message.GetTypeName() +
+                           ") has unknown fields");
     }
   }
 
   static void loadFromJson(const std::string& json, Protobuf::Message& message);
-  static void loadFromJsonLenient(const std::string& json, Protobuf::Message& message);
+  static void loadFromJsonCustom(const std::string& json, Protobuf::Message& message,
+                                 bool allow_unknown_fields);
   static void loadFromYaml(const std::string& yaml, Protobuf::Message& message);
   static void loadFromFile(const std::string& path, Protobuf::Message& message);
 

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -156,6 +156,7 @@ envoy_cc_library(
         "//include/envoy/stats:stats_interface",
         "//source/common/common:macros",
         "//source/common/common:version_lib",
+        "//source/common/protobuf:utility_lib",
         "//source/common/stats:stats_lib",
     ],
 )

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -188,7 +188,9 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   config_path_ = config_path.getValue();
   config_yaml_ = config_yaml.getValue();
   v2_config_only_ = !allow_v1_config.getValue();
-  MessageUtil::allow_unknown_fields = allow_unknown_fields.getValue();
+  if (allow_unknown_fields.getValue()) {
+    MessageUtil::proto_unknown_fields = ProtoUnknownFieldsMode::Allow;
+  }
   admin_address_path_ = admin_address_path.getValue();
   log_path_ = log_path.getValue();
   restart_epoch_ = restart_epoch.getValue();

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -66,7 +66,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
                                    cmd, false);
 
   TCLAP::SwitchArg allow_unknown_fields(
-      "", "allow-unknown-fields", "allow unknown fields in the filter configuration", cmd, false);
+      "", "allow-unknown-fields", "allow unknown fields in the configuration", cmd, false);
 
   TCLAP::ValueArg<std::string> admin_address_path("", "admin-address-path", "Admin address path",
                                                   false, "", "string", cmd);

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -65,8 +65,8 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   TCLAP::SwitchArg allow_v1_config("", "allow-deprecated-v1-api", "allow use of legacy v1 config",
                                    cmd, false);
 
-  TCLAP::SwitchArg allow_unknown_fields(
-      "", "allow-unknown-fields", "allow unknown fields in the configuration", cmd, false);
+  TCLAP::SwitchArg allow_unknown_fields("", "allow-unknown-fields",
+                                        "allow unknown fields in the configuration", cmd, false);
 
   TCLAP::ValueArg<std::string> admin_address_path("", "admin-address-path", "Admin address path",
                                                   false, "", "string", cmd);

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -9,6 +9,7 @@
 #include "common/common/logger.h"
 #include "common/common/macros.h"
 #include "common/common/version.h"
+#include "common/protobuf/utility.h"
 
 #include "spdlog/spdlog.h"
 #include "tclap/CmdLine.h"
@@ -63,6 +64,9 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
 
   TCLAP::SwitchArg allow_v1_config("", "allow-deprecated-v1-api", "allow use of legacy v1 config",
                                    cmd, false);
+
+  TCLAP::SwitchArg allow_unknown_fields(
+      "", "allow-unknown-fields", "allow unknown fields in the filter configuration", cmd, false);
 
   TCLAP::ValueArg<std::string> admin_address_path("", "admin-address-path", "Admin address path",
                                                   false, "", "string", cmd);
@@ -184,6 +188,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   config_path_ = config_path.getValue();
   config_yaml_ = config_yaml.getValue();
   v2_config_only_ = !allow_v1_config.getValue();
+  MessageUtil::allow_unknown_fields = allow_unknown_fields.getValue();
   admin_address_path_ = admin_address_path.getValue();
   log_path_ = log_path.getValue();
   restart_epoch_ = restart_epoch.getValue();

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -46,6 +46,16 @@ TEST(UtilityTest, GetTypedResources) {
   EXPECT_EQ("1", typed_resources[1].cluster_name());
 }
 
+TEST(UtilityTest, GetTypedResourcesWrongType) {
+  envoy::api::v2::DiscoveryResponse response;
+  envoy::api::v2::ClusterLoadAssignment load_assignment_0;
+  load_assignment_0.set_cluster_name("0");
+  response.add_resources()->PackFrom(load_assignment_0);
+
+  EXPECT_THROW_WITH_REGEX(Utility::getTypedResources<envoy::api::v2::Listener>(response),
+                          EnvoyException, "Unable to unpack .*");
+}
+
 TEST(UtilityTest, ComputeHashedVersion) {
   EXPECT_EQ("hash_2e1472b57af294d1", Utility::computeHashedVersion("{}").first);
   EXPECT_EQ("hash_33bf00a859c4ba3f", Utility::computeHashedVersion("foo").first);

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -251,11 +251,11 @@ TEST(UtilityTest, JsonConvertSuccess) {
 }
 
 TEST(UtilityTest, JsonConvertUnknownFieldSuccess) {
-  MessageUtil::allow_unknown_fields = true;
+  MessageUtil::proto_unknown_fields = ProtoUnknownFieldsMode::Allow;
   const ProtobufWkt::Struct obj = MessageUtil::keyValueStruct("test_key", "test_value");
   envoy::config::bootstrap::v2::Bootstrap bootstrap;
   EXPECT_NO_THROW(MessageUtil::jsonConvert(obj, bootstrap));
-  MessageUtil::allow_unknown_fields = false;
+  MessageUtil::proto_unknown_fields = ProtoUnknownFieldsMode::Strict;
 }
 
 TEST(UtilityTest, JsonConvertFail) {

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -62,7 +62,7 @@ TEST(UtilityTest, LoadBinaryProtoUnknownFieldFromFile) {
   envoy::config::bootstrap::v2::Bootstrap proto_from_file;
   EXPECT_THROW_WITH_MESSAGE(
       MessageUtil::loadFromFile(filename, proto_from_file), EnvoyException,
-      "Protobuf Any (type envoy.config.bootstrap.v2.Bootstrap) has unknown fields");
+      "Protobuf message (type envoy.config.bootstrap.v2.Bootstrap) has unknown fields");
 }
 
 TEST(UtilityTest, LoadTextProtoFromFile) {
@@ -239,7 +239,7 @@ TEST(UtilityTest, AnyConvertWrongFields) {
   source_any.set_type_url("type.google.com/google.protobuf.Timestamp");
   EXPECT_THROW_WITH_MESSAGE(MessageUtil::anyConvert<ProtobufWkt::Timestamp>(source_any),
                             EnvoyException,
-                            "Protobuf Any (type google.protobuf.Timestamp) has unknown fields");
+                            "Protobuf message (type google.protobuf.Timestamp) has unknown fields");
 }
 
 TEST(UtilityTest, JsonConvertSuccess) {

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -221,9 +221,11 @@ TEST(UtilityTest, JsonConvertSuccess) {
 }
 
 TEST(UtilityTest, JsonConvertUnknownFieldSuccess) {
+  MessageUtil::allow_unknown_fields = true;
   const ProtobufWkt::Struct obj = MessageUtil::keyValueStruct("test_key", "test_value");
   envoy::config::bootstrap::v2::Bootstrap bootstrap;
   EXPECT_NO_THROW(MessageUtil::jsonConvert(obj, bootstrap));
+  MessageUtil::allow_unknown_fields = false;
 }
 
 TEST(UtilityTest, JsonConvertFail) {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4490,6 +4490,9 @@ public:
                                        Server::Configuration::FactoryContext&) override {
       NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
     }
+    ProtobufTypes::MessagePtr createEmptyRouteConfigProto() override {
+      return ProtobufTypes::MessagePtr{new ProtobufWkt::Timestamp()};
+    }
   };
 
   void checkEach(const std::string& yaml, uint32_t expected_entry, uint32_t expected_route,
@@ -4563,7 +4566,7 @@ virtual_hosts:
     routes:
       - match: { prefix: "/" }
         route: { cluster: baz }
-    per_filter_config: { test.default.filter: { unknown_key: 123} }
+    per_filter_config: { test.default.filter: { seconds: 123} }
 )EOF";
 
   checkNoPerFilterConfig(yaml);

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -89,7 +89,6 @@ const std::string ConfigHelper::DEFAULT_HEALTH_CHECK_FILTER =
 name: envoy.health_check
 config:
     pass_through_mode: false
-    endpoint: /healthcheck
 )EOF";
 
 const std::string ConfigHelper::DEFAULT_SQUASH_FILTER =

--- a/test/extensions/filters/network/thrift_proxy/integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/integration_test.cc
@@ -46,12 +46,7 @@ public:
             route_config:
               name: "routes"
               routes:
-                - match:
-                    method_name: "execute"
-                  route:
-                    cluster: "cluster_0"
-                - match:
-                    method_name: "poke"
+                - match: {}
                   route:
                     cluster: "cluster_0"
       )EOF";

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -409,7 +409,6 @@ void HttpIntegrationTest::testComputedHealthCheck() {
 name: envoy.health_check
 config:
     pass_through_mode: false
-    endpoint: /healthcheck
     cluster_min_healthy_percentages:
         example_cluster_name: { value: 75 }
 )EOF");

--- a/tools/protodoc/protodoc.bzl
+++ b/tools/protodoc/protodoc.bzl
@@ -78,7 +78,6 @@ def _proto_doc_aspect_impl(target, ctx):
     return [OutputGroupInfo(rst = transitive_outputs)]
 
 proto_doc_aspect = aspect(
-    implementation = _proto_doc_aspect_impl,
     attr_aspects = ["deps"],
     attrs = {
         "_protoc": attr.label(
@@ -92,4 +91,5 @@ proto_doc_aspect = aspect(
             cfg = "host",
         ),
     },
+    implementation = _proto_doc_aspect_impl,
 )


### PR DESCRIPTION
*Description*: Add a flag `allow-unknown-fields` that controls whether proto conversion ignores unknown fields. Proto structs are uniformly used for extension configuration. A smaller fix than https://github.com/envoyproxy/envoy/pull/4094.

The validation is applied in the following places:
- Any conversion (e.g. xDS payloads)
- Struct conversion (e.g. filter configs)
- bootstrap proto binary

*Risk Level*: Medium. Allow unknown fields is set to false by default, meaning unknown fields will be rejected by envoy. A missing check for xDS type checking was discovered.

*Testing*: Unit tests were updated to have it strict by default. Some wrong filter configs were discovered.

*Docs Changes*: None

*Release Notes*:
Add a flag `allow-unknown-fields` to control validation of protobuf configurations for unknown fields.

Fixes #4053 

/cc @PiotrSikora 