### PR TITLE
upstream: allow custom extension protocol options

### DIFF
--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -46,7 +46,7 @@ service ClusterDiscoveryService {
 // [#protodoc-title: Clusters]
 
 // Configuration for a single upstream cluster.
-// [#comment:next free field: 35]
+// [#comment:next free field: 36]
 message Cluster {
   // Supplies the name of the cluster which must be unique across all clusters.
   // The cluster name is used when emitting
@@ -225,6 +225,12 @@ message Cluster {
   // with ALPN, `http2_protocol_options` must be specified. As an aside this allows HTTP/2
   // connections to happen over plain text.
   core.Http2ProtocolOptions http2_protocol_options = 14;
+
+  // The extension_protocol_options field is used to provide extension-specific protocol options
+  // for upstream connections. The key should match the extension filter name, such as
+  // "envoy.filters.network.thrift_proxy". See the extension's documentation for details on
+  // specific options.
+  map<string, google.protobuf.Struct> extension_protocol_options = 35;
 
   reserved 15;
 

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -221,6 +221,25 @@ public:
   virtual ProtobufTypes::MessagePtr createEmptyConfigProto() { return nullptr; }
 
   /**
+   * Create a particular network filter's protocol specific options implementation. If the factory
+   * implementation is unable to produce a factory with the provided parameters, it should throw an
+   * EnvoyException.
+   * @param config supplies the protobuf configuration for the filter
+   * @return Upstream::ProtocoOptionsConfigConstSharedPtr the protocol options
+   */
+  Upstream::ProtocolOptionsConfigConstSharedPtr
+  createProtocolOptionsConfig(const Protobuf::Message& config) {
+    UNREFERENCED_PARAMETER(config);
+    return nullptr;
+  }
+
+  /**
+   * @return ProtobufTypes::MessagePtr a newly created empty protocol specific options message or
+   *         nullptr if protocol specific options are not available.
+   */
+  virtual ProtobufTypes::MessagePtr createEmptyProtocolOptionsProto() { return nullptr; }
+
+  /**
    * @return std::string the identifying name for a particular implementation of a network filter
    * produced by the factory.
    */

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -390,6 +390,17 @@ struct ClusterLoadReportStats {
 };
 
 /**
+ * All extension protocol specific options returned by the method at
+ *   NamedNetworkFilterConfigFactory::createProtocolOptions
+ * must be derived from this class.
+ */
+class ProtocolOptionsConfig {
+public:
+  virtual ~ProtocolOptionsConfig() {}
+};
+typedef std::shared_ptr<const ProtocolOptionsConfig> ProtocolOptionsConfigConstSharedPtr;
+
+/**
  * Information about a given upstream cluster.
  */
 class ClusterInfo {
@@ -437,6 +448,15 @@ public:
    *         @see Http::Http2Settings.
    */
   virtual const Http::Http2Settings& http2Settings() const PURE;
+
+  /**
+   * @param name std::string containing the well-known name of the extension for which protocol
+   *        options are desired
+   * @return ProtocolOptionsConfigConstSharedPtr for extension protocol connections
+   *         created on behalf of this cluster.
+   */
+  virtual ProtocolOptionsConfigConstSharedPtr
+  extensionProtocolOptions(const std::string& name) const PURE;
 
   /**
    * @return const envoy::api::v2::Cluster::CommonLbConfig& the common configuration for all

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -269,6 +269,30 @@ public:
   }
 
   /**
+   * Translate a nested config into protocol specific options proto message provided by the
+   * implementation factory.
+   * @param source a message that contains the opaque config for the given factory's
+   *        protocol specific configuration.
+   * @param factory implementation factory with the method 'createEmptyProtocolOptionsProto' to
+   *        produce a proto to be filled with the translated configuration.
+   * @return ProtobufTypes::MessagePtr the converted message
+   * @throws EnvoyException if the factory does not support protocol options
+   */
+  template <class Factory>
+  static ProtobufTypes::MessagePtr
+  translateToFactoryProtocolOptionsConfig(const Protobuf::Message& source, Factory& factory) {
+    ProtobufTypes::MessagePtr config = factory.createEmptyProtocolOptionsProto();
+
+    if (config == nullptr) {
+      throw EnvoyException(
+          fmt::format("filter {} does not support protocol options", factory.name()));
+    }
+
+    MessageUtil::jsonConvert(source, *config);
+    return config;
+  }
+
+  /**
    * Create TagProducer instance. Check all tag names for conflicts to avoid
    * unexpected tag name overwriting.
    * @param bootstrap bootstrap proto.

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -359,6 +359,7 @@ envoy_cc_library(
         "//include/envoy/event:timer_interface",
         "//include/envoy/network:dns_interface",
         "//include/envoy/network:listen_socket_interface",
+        "//include/envoy/server:filter_config_interface",
         "//include/envoy/ssl:context_interface",
         "//include/envoy/upstream:health_checker_interface",
         "//source/common/common:enum_to_int",

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -12,6 +12,7 @@
 #include "envoy/event/timer.h"
 #include "envoy/network/dns.h"
 #include "envoy/secret/secret_manager.h"
+#include "envoy/server/filter_config.h"
 #include "envoy/server/transport_socket_config.h"
 #include "envoy/ssl/context_manager.h"
 #include "envoy/stats/scope.h"
@@ -110,6 +111,25 @@ parseClusterSocketOptions(const envoy::api::v2::Cluster& config,
     return nullptr;
   }
   return cluster_options;
+}
+
+std::map<std::string, ProtocolOptionsConfigConstSharedPtr>&&
+parseExtensionProtocolOptions(const envoy::api::v2::Cluster& config) {
+  std::map<std::string, ProtocolOptionsConfigConstSharedPtr> options;
+  for (const auto& iter : config.extension_protocol_options()) {
+    const std::string& name = iter.first;
+    const ProtobufWkt::Struct& config_struct = iter.second;
+
+    auto& factory = Envoy::Config::Utility::getAndCheckFactory<
+        Server::Configuration::NamedNetworkFilterConfigFactory>(name);
+
+    auto object = factory.createProtocolOptionsConfig(
+        *Envoy::Config::Utility::translateToFactoryProtocolOptionsConfig(config_struct, factory));
+    if (object) {
+      options[name] = object;
+    }
+  }
+  return std::move(options);
 }
 
 } // namespace
@@ -286,6 +306,7 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
       load_report_stats_(generateLoadReportStats(load_report_stats_store_)),
       features_(parseFeatures(config)),
       http2_settings_(Http::Utility::parseHttp2Settings(config.http2_protocol_options())),
+      extension_protocol_options_(parseExtensionProtocolOptions(config)),
       resource_managers_(config, runtime, name_),
       maintenance_mode_runtime_key_(fmt::format("upstream.maintenance_mode.{}", name_)),
       source_address_(getSourceAddress(config, bind_config)),
@@ -335,6 +356,16 @@ ClusterInfoImpl::ClusterInfoImpl(const envoy::api::v2::Cluster& config,
     idle_timeout_ = std::chrono::milliseconds(
         DurationUtil::durationToMilliseconds(config.common_http_protocol_options().idle_timeout()));
   }
+}
+
+ProtocolOptionsConfigConstSharedPtr
+ClusterInfoImpl::extensionProtocolOptions(const std::string& name) const {
+  auto i = extension_protocol_options_.find(name);
+  if (i != extension_protocol_options_.end()) {
+    return i->second;
+  }
+
+  return nullptr;
 }
 
 namespace {

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -353,6 +353,8 @@ public:
   }
   uint64_t features() const override { return features_; }
   const Http::Http2Settings& http2Settings() const override { return http2_settings_; }
+  ProtocolOptionsConfigConstSharedPtr
+  extensionProtocolOptions(const std::string& name) const override;
   LoadBalancerType lbType() const override { return lb_type_; }
   envoy::api::v2::Cluster::DiscoveryType type() const override { return type_; }
   const absl::optional<envoy::api::v2::Cluster::RingHashLbConfig>&
@@ -412,6 +414,7 @@ private:
   mutable ClusterLoadReportStats load_report_stats_;
   const uint64_t features_;
   const Http::Http2Settings http2_settings_;
+  const std::map<std::string, ProtocolOptionsConfigConstSharedPtr> extension_protocol_options_;
   mutable ResourceManagers resource_managers_;
   const std::string maintenance_mode_runtime_key_;
   const Network::Address::InstanceConstSharedPtr source_address_;

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -356,6 +356,7 @@ envoy_cc_test(
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:registry_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -25,6 +25,7 @@
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/registry.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -1478,18 +1479,33 @@ TEST(PrioritySet, Extend) {
   }
 }
 
-// Cluster metadata retrieval.
-TEST(ClusterMetadataTest, Metadata) {
-  Stats::IsolatedStoreImpl stats;
-  Ssl::MockContextManager ssl_context_manager;
-  auto dns_resolver = std::make_shared<Network::MockDnsResolver>();
-  NiceMock<Event::MockDispatcher> dispatcher;
-  NiceMock<Runtime::MockLoader> runtime;
-  NiceMock<MockClusterManager> cm;
-  NiceMock<LocalInfo::MockLocalInfo> local_info;
-  NiceMock<Runtime::MockRandomGenerator> random;
-  ReadyWatcher initialized;
+class ClusterInfoImplTest : public testing::Test {
+public:
+  std::unique_ptr<StrictDnsClusterImpl> makeCluster(const std::string& yaml) {
+    envoy::api::v2::Cluster cluster_config = parseClusterFromV2Yaml(yaml);
+    Envoy::Stats::ScopePtr scope = stats_.createScope(fmt::format(
+        "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
+                                                              : cluster_config.alt_stat_name()));
+    Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
+        ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, random_, stats_);
 
+    return std::make_unique<StrictDnsClusterImpl>(cluster_config, runtime_, dns_resolver_,
+                                                  factory_context, std::move(scope), false);
+  }
+
+  Stats::IsolatedStoreImpl stats_;
+  Ssl::MockContextManager ssl_context_manager_;
+  std::shared_ptr<Network::MockDnsResolver> dns_resolver_{new NiceMock<Network::MockDnsResolver>()};
+  NiceMock<Event::MockDispatcher> dispatcher_;
+  NiceMock<Runtime::MockLoader> runtime_;
+  NiceMock<MockClusterManager> cm_;
+  NiceMock<LocalInfo::MockLocalInfo> local_info_;
+  NiceMock<Runtime::MockRandomGenerator> random_;
+  ReadyWatcher initialized_;
+};
+
+// Cluster metadata retrieval.
+TEST_F(ClusterInfoImplTest, Metadata) {
   const std::string yaml = R"EOF(
     name: name
     connect_timeout: 0.25s
@@ -1502,19 +1518,112 @@ TEST(ClusterMetadataTest, Metadata) {
         value: 0.3
   )EOF";
 
-  envoy::api::v2::Cluster cluster_config = parseClusterFromV2Yaml(yaml);
-  Envoy::Stats::ScopePtr scope = stats.createScope(fmt::format(
-      "cluster.{}.", cluster_config.alt_stat_name().empty() ? cluster_config.name()
-                                                            : cluster_config.alt_stat_name()));
-  Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
-      ssl_context_manager, *scope, cm, local_info, dispatcher, random, stats);
-  StrictDnsClusterImpl cluster(cluster_config, runtime, dns_resolver, factory_context,
-                               std::move(scope), false);
+  auto cluster = makeCluster(yaml);
+
   EXPECT_EQ("test_value",
-            Config::Metadata::metadataValue(cluster.info()->metadata(), "com.bar.foo", "baz")
+            Config::Metadata::metadataValue(cluster->info()->metadata(), "com.bar.foo", "baz")
                 .string_value());
-  EXPECT_EQ(0.3, cluster.info()->lbConfig().healthy_panic_threshold().value());
-  EXPECT_EQ(LoadBalancerType::Maglev, cluster.info()->lbType());
+  EXPECT_EQ(0.3, cluster->info()->lbConfig().healthy_panic_threshold().value());
+  EXPECT_EQ(LoadBalancerType::Maglev, cluster->info()->lbType());
+}
+
+TEST_F(ClusterInfoImplTest, ExtensionProtocolOptionsForUnknownFilter) {
+  const std::string yaml = R"EOF(
+    name: name
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    hosts: [{ socket_address: { address: foo.bar.com, port_value: 443 }}]
+    extension_protocol_options:
+      no_such_filter: { option: value }
+  )EOF";
+
+  EXPECT_THROW_WITH_REGEX(makeCluster(yaml), EnvoyException,
+                          "Didn't find a registered implementation for name:.*");
+}
+
+class TestFilterConfigFactory : public Server::Configuration::NamedNetworkFilterConfigFactory {
+public:
+  TestFilterConfigFactory(
+      std::function<ProtobufTypes::MessagePtr()> empty_proto,
+      std::function<Upstream::ProtocolOptionsConfigConstSharedPtr(const Protobuf::Message&)> config)
+      : empty_proto_(empty_proto), config_(config) {}
+
+  // NamedNetworkFilterConfigFactory
+  Network::FilterFactoryCb createFilterFactory(const Json::Object&,
+                                               Server::Configuration::FactoryContext&) override {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
+  Network::FilterFactoryCb
+  createFilterFactoryFromProto(const Protobuf::Message&,
+                               Server::Configuration::FactoryContext&) override {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  ProtobufTypes::MessagePtr createEmptyProtocolOptionsProto() override { return empty_proto_(); }
+  Upstream::ProtocolOptionsConfigConstSharedPtr
+  createProtocolOptionsConfig(const Protobuf::Message& msg) {
+    return config_(msg);
+  }
+  std::string name() override { CONSTRUCT_ON_FIRST_USE(std::string, "envoy.test.filter"); }
+
+  std::function<ProtobufTypes::MessagePtr()> empty_proto_;
+  std::function<Upstream::ProtocolOptionsConfigConstSharedPtr(const Protobuf::Message&)> config_;
+};
+
+struct TestFilterProtocolOptionsConfig : public Upstream::ProtocolOptionsConfig {};
+
+TEST_F(ClusterInfoImplTest, ExtensionProtocolOptionsForFilterWithoutOptions) {
+  TestFilterConfigFactory factory(
+      []() -> ProtobufTypes::MessagePtr { return nullptr; },
+      [](const Protobuf::Message&) -> Upstream::ProtocolOptionsConfigConstSharedPtr {
+        return nullptr;
+      });
+  Registry::InjectFactory<Server::Configuration::NamedNetworkFilterConfigFactory> registry(factory);
+
+  const std::string yaml = R"EOF(
+    name: name
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    hosts: [{ socket_address: { address: foo.bar.com, port_value: 443 }}]
+    extension_protocol_options:
+      envoy.test.filter: { option: value }
+  )EOF";
+
+  EXPECT_THROW_WITH_MESSAGE(makeCluster(yaml), EnvoyException,
+                            "filter envoy.test.filter does not support protocol options");
+}
+
+TEST_F(ClusterInfoImplTest, ExtensionProtocolOptionsForFilterWithOptions) {
+  auto protocol_options = std::shared_ptr<TestFilterProtocolOptionsConfig>();
+
+  TestFilterConfigFactory factory(
+      []() -> ProtobufTypes::MessagePtr { return std::make_unique<ProtobufWkt::Struct>(); },
+      [&](const Protobuf::Message& msg) -> Upstream::ProtocolOptionsConfigConstSharedPtr {
+        const auto& msg_struct = dynamic_cast<const ProtobufWkt::Struct&>(msg);
+        EXPECT_TRUE(msg_struct.fields().find("option") != msg_struct.fields().end());
+
+        return protocol_options;
+      });
+  Registry::InjectFactory<Server::Configuration::NamedNetworkFilterConfigFactory> registry(factory);
+
+  const std::string yaml = R"EOF(
+    name: name
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    hosts: [{ socket_address: { address: foo.bar.com, port_value: 443 }}]
+    extension_protocol_options:
+      envoy.test.filter: { option: "value" }
+  )EOF";
+
+  auto cluster = makeCluster(yaml);
+
+  ProtocolOptionsConfigConstSharedPtr stored_options =
+      cluster->info()->extensionProtocolOptions("envoy.test.filter");
+  // Same pointer
+  EXPECT_EQ(stored_options.get(), protocol_options.get());
 }
 
 // Validate empty singleton for HostsPerLocalityImpl.

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -37,6 +37,7 @@ MockClusterInfo::MockClusterInfo()
   ON_CALL(*this, idleTimeout()).WillByDefault(Return(absl::optional<std::chrono::milliseconds>()));
   ON_CALL(*this, name()).WillByDefault(ReturnRef(name_));
   ON_CALL(*this, http2Settings()).WillByDefault(ReturnRef(http2_settings_));
+  ON_CALL(*this, extensionProtocolOptions(_)).WillByDefault(Return(extension_protocol_options_));
   ON_CALL(*this, maxRequestsPerConnection())
       .WillByDefault(ReturnPointee(&max_requests_per_connection_));
   ON_CALL(*this, stats()).WillByDefault(ReturnRef(stats_));

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -48,6 +48,8 @@ public:
   MOCK_CONST_METHOD0(perConnectionBufferLimitBytes, uint32_t());
   MOCK_CONST_METHOD0(features, uint64_t());
   MOCK_CONST_METHOD0(http2Settings, const Http::Http2Settings&());
+  MOCK_CONST_METHOD1(extensionProtocolOptions,
+                     ProtocolOptionsConfigConstSharedPtr(const std::string&));
   MOCK_CONST_METHOD0(lbConfig, const envoy::api::v2::Cluster::CommonLbConfig&());
   MOCK_CONST_METHOD0(lbType, LoadBalancerType());
   MOCK_CONST_METHOD0(type, envoy::api::v2::Cluster::DiscoveryType());
@@ -71,6 +73,7 @@ public:
 
   std::string name_{"fake_cluster"};
   Http::Http2Settings http2_settings_{};
+  ProtocolOptionsConfigConstSharedPtr extension_protocol_options_;
   uint64_t max_requests_per_connection_{};
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
   ClusterStats stats_;


### PR DESCRIPTION
Allows extension protocols to specify custom options. This is a precursor to adding Thrift-specific protocol options to the cluster configuration, but is extensible to any future extension that implements a non-HTTP protocol.

*Risk Level*: low, ignored by existing protocols
*Testing*: unit tests
*Docs Changes*: inline
*Release Notes*: n/a

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
