### PR TITLE
ci: link ninja-build to ninja for centos

### DIFF
--- a/ci/build_container/build_container_centos.sh
+++ b/ci/build_container/build_container_centos.sh
@@ -14,6 +14,7 @@ yum install -y java-1.8.0-openjdk-devel unzip which openssl rpm-build \
 yum clean all
 
 ln -s /usr/bin/cmake3 /usr/bin/cmake
+ln -s /usr/bin/ninja-build /usr/bin/ninja
 
 # latest bazel installer
 BAZEL_VERSION="$(curl -s https://api.github.com/repos/bazelbuild/bazel/releases/latest |


### PR DESCRIPTION
*Description*: 
Fix `/build_recipes/cares.sh: line 35: ninja: command not found` when executing `build_container_centos.sh`.

*Risk Level*: Low
*Testing*: Existing
*Docs Changes*: N/A
*Release Notes*: N/A

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>