### PR TITLE
Use a jittered backoff strategy for handling HdsDelegate stream/connection failures

### DIFF
--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -175,6 +175,7 @@ envoy_cc_library(
         "//include/envoy/stats:stats_macros",
         "//include/envoy/upstream:cluster_manager_interface",
         "//include/envoy/upstream:upstream_interface",
+        "//source/common/common:backoff_lib",
         "//source/common/common:minimal_logger_lib",
         "//source/common/config:utility_lib",
         "//source/common/grpc:async_client_lib",

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -22,6 +22,8 @@ HdsDelegate::HdsDelegate(const envoy::api::v2::core::Node& node, Stats::Scope& s
       info_factory_(info_factory), access_log_manager_(access_log_manager), cm_(cm),
       local_info_(local_info) {
   health_check_request_.mutable_node()->MergeFrom(node);
+  backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(RetryInitialDelayMilliseconds,
+                                                                RetryMaxDelayMilliseconds, random_);
   hds_retry_timer_ = dispatcher.createTimer([this]() -> void { establishNewStream(); });
   hds_stream_response_timer_ = dispatcher.createTimer([this]() -> void { sendResponse(); });
 
@@ -33,7 +35,10 @@ HdsDelegate::HdsDelegate(const envoy::api::v2::core::Node& node, Stats::Scope& s
 }
 
 void HdsDelegate::setHdsRetryTimer() {
-  hds_retry_timer_->enableTimer(std::chrono::milliseconds(RetryDelayMilliseconds));
+  auto retry_ms = std::chrono::milliseconds(backoff_strategy_->nextBackOffMs());
+  ENVOY_LOG(warn, "HdsDelegate stream/connection failure, will retry in {} ms.", retry_ms.count());
+
+  hds_retry_timer_->enableTimer(retry_ms);
 }
 
 void HdsDelegate::setHdsStreamResponseTimer() {
@@ -52,12 +57,10 @@ void HdsDelegate::establishNewStream() {
   ENVOY_LOG(debug, "Sending HealthCheckRequest {} ", health_check_request_.DebugString());
   stream_->sendMessage(health_check_request_, false);
   stats_.responses_.inc();
+  backoff_strategy_->reset();
 }
 
-// TODO(lilika) : Use jittered backoff as in https://github.com/envoyproxy/envoy/pull/3791
 void HdsDelegate::handleFailure() {
-  ENVOY_LOG(warn, "HdsDelegate stream/connection failure, will retry in {} ms.",
-            RetryDelayMilliseconds);
   stats_.errors_.inc();
   setHdsRetryTimer();
 }

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -35,7 +35,7 @@ HdsDelegate::HdsDelegate(const envoy::api::v2::core::Node& node, Stats::Scope& s
 }
 
 void HdsDelegate::setHdsRetryTimer() {
-  auto retry_ms = std::chrono::milliseconds(backoff_strategy_->nextBackOffMs());
+  const auto retry_ms = std::chrono::milliseconds(backoff_strategy_->nextBackOffMs());
   ENVOY_LOG(warn, "HdsDelegate stream/connection failure, will retry in {} ms.", retry_ms.count());
 
   hds_retry_timer_->enableTimer(retry_ms);

--- a/source/common/upstream/health_discovery_service.h
+++ b/source/common/upstream/health_discovery_service.h
@@ -7,6 +7,7 @@
 #include "envoy/stats/stats_macros.h"
 #include "envoy/upstream/upstream.h"
 
+#include "common/common/backoff_strategy.h"
 #include "common/common/logger.h"
 #include "common/config/utility.h"
 #include "common/grpc/async_client_impl.h"
@@ -170,11 +171,17 @@ private:
 
   Event::TimerPtr hds_stream_response_timer_;
   Event::TimerPtr hds_retry_timer_;
+  BackOffStrategyPtr backoff_strategy_;
 
-  // TODO(lilika): Add API knob for RetryDelayMilliseconds, instead of
-  // hardcoding it.
-  // How often we retry to establish a stream to the management server
-  const uint32_t RetryDelayMilliseconds = 5000;
+  /**
+   * TODO(lilika): Add API knob for RetryInitialDelayMilliseconds
+   * and RetryMaxDelayMilliseconds, instead of hardcoding them.
+   *
+   * Parameters of the jittered backoff strategy that defines how often
+   * we retry to establish a stream to the management server
+   */
+  const uint32_t RetryInitialDelayMilliseconds = 1000;
+  const uint32_t RetryMaxDelayMilliseconds = 30000;
 
   // Soft limit on size of the cluster’s connections read and write buffers.
   static constexpr uint32_t ClusterConnectionBufferLimitBytes = 32768;

--- a/test/common/upstream/hds_test.cc
+++ b/test/common/upstream/hds_test.cc
@@ -229,12 +229,22 @@ TEST_F(HdsTest, TestStreamConnectionFailure) {
       .WillOnce(Return(nullptr))
       .WillOnce(Return(nullptr))
       .WillOnce(Return(nullptr))
+      .WillOnce(Return(nullptr))
+      .WillOnce(Return(nullptr))
       .WillOnce(Return(&async_stream_));
-  EXPECT_CALL(*retry_timer_, enableTimer(_)).Times(3);
+
+  EXPECT_CALL(random_, random()).WillOnce(Return(1000005)).WillRepeatedly(Return(1234567));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(5)));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(1567)));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(2567)));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(4567)));
+  EXPECT_CALL(*retry_timer_, enableTimer(std::chrono::milliseconds(25567)));
   EXPECT_CALL(async_stream_, sendMessage(_, _));
 
   // Test connection failure and retry
   createHdsDelegate();
+  retry_timer_cb_();
+  retry_timer_cb_();
   retry_timer_cb_();
   retry_timer_cb_();
   retry_timer_cb_();

--- a/test/common/upstream/hds_test.cc
+++ b/test/common/upstream/hds_test.cc
@@ -227,12 +227,16 @@ TEST_F(HdsTest, TestMinimalSendResponse) {
 TEST_F(HdsTest, TestStreamConnectionFailure) {
   EXPECT_CALL(*async_client_, start(_, _))
       .WillOnce(Return(nullptr))
+      .WillOnce(Return(nullptr))
+      .WillOnce(Return(nullptr))
       .WillOnce(Return(&async_stream_));
-  EXPECT_CALL(*retry_timer_, enableTimer(_));
+  EXPECT_CALL(*retry_timer_, enableTimer(_)).Times(3);
   EXPECT_CALL(async_stream_, sendMessage(_, _));
 
   // Test connection failure and retry
   createHdsDelegate();
+  retry_timer_cb_();
+  retry_timer_cb_();
   retry_timer_cb_();
 }
 


### PR DESCRIPTION
I changed the retry strategy of the HdsDelegate on stream/connection failures. Instead of retrying every set number of seconds, we now use a jittered backoff strategy, as in https://github.com/envoyproxy/envoy/pull/3791.

*Risk Level*:
Low

This is for https://github.com/envoyproxy/envoy/issues/1310.