### PR TITLE
Renaming message types in hds.proto to improve readability

### DIFF
--- a/api/envoy/service/discovery/v2/hds.proto
+++ b/api/envoy/service/discovery/v2/hds.proto
@@ -77,7 +77,7 @@ message Capability {
     TCP = 1;
     REDIS = 2;
   }
-  repeated Protocol health_check_protocol = 1;
+  repeated Protocol health_check_protocols = 1;
 }
 
 message HealthCheckRequest {
@@ -113,11 +113,11 @@ message LocalityEndpoints {
 message ClusterHealthCheck {
   string cluster_name = 1;
   repeated envoy.api.v2.core.HealthCheck health_checks = 2;
-  repeated LocalityEndpoints endpoints = 3;
+  repeated LocalityEndpoints locality_endpoints = 3;
 }
 
 message HealthCheckSpecifier {
-  repeated ClusterHealthCheck health_check = 1;
+  repeated ClusterHealthCheck cluster_health_checks = 1;
   // The default is 1 second.
   google.protobuf.Duration interval = 2;
 }

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -26,7 +26,7 @@ HdsDelegate::HdsDelegate(const envoy::api::v2::core::Node& node, Stats::Scope& s
   hds_stream_response_timer_ = dispatcher.createTimer([this]() -> void { sendResponse(); });
 
   // TODO(lilika): Add support for other types of healthchecks
-  health_check_request_.mutable_capability()->add_health_check_protocol(
+  health_check_request_.mutable_capability()->add_health_check_protocols(
       envoy::service::discovery::v2::Capability::HTTP);
 
   establishNewStream();
@@ -101,7 +101,7 @@ void HdsDelegate::processMessage(
   ENVOY_LOG(debug, "New health check response message {} ", message->DebugString());
   ASSERT(message);
 
-  for (const auto& cluster_health_check : message->health_check()) {
+  for (const auto& cluster_health_check : message->cluster_health_checks()) {
     // Create HdsCluster config
     static const envoy::api::v2::core::BindConfig bind_config;
     envoy::api::v2::Cluster cluster_config;
@@ -112,7 +112,7 @@ void HdsDelegate::processMessage(
         ClusterConnectionBufferLimitBytes);
 
     // Add endpoints to cluster
-    for (const auto& locality_endpoints : cluster_health_check.endpoints()) {
+    for (const auto& locality_endpoints : cluster_health_check.locality_endpoints()) {
       for (const auto& endpoint : locality_endpoints.endpoints()) {
         cluster_config.add_hosts()->MergeFrom(endpoint.address());
       }

--- a/test/common/upstream/hds_test.cc
+++ b/test/common/upstream/hds_test.cc
@@ -69,7 +69,7 @@ public:
         new envoy::service::discovery::v2::HealthCheckSpecifier;
     msg->mutable_interval()->set_seconds(1);
 
-    auto* health_check = msg->add_health_check();
+    auto* health_check = msg->add_cluster_health_checks();
     health_check->set_cluster_name("anna");
     health_check->add_health_checks()->mutable_timeout()->set_seconds(1);
     health_check->mutable_health_checks(0)->mutable_interval()->set_seconds(1);
@@ -79,8 +79,10 @@ public:
     health_check->mutable_health_checks(0)->mutable_http_health_check()->set_use_http2(false);
     health_check->mutable_health_checks(0)->mutable_http_health_check()->set_path("/healthcheck");
 
-    auto* socket_address =
-        health_check->add_endpoints()->add_endpoints()->mutable_address()->mutable_socket_address();
+    auto* socket_address = health_check->add_locality_endpoints()
+                               ->add_endpoints()
+                               ->mutable_address()
+                               ->mutable_socket_address();
     socket_address->set_address("127.0.0.0");
     socket_address->set_port_value(1234);
 
@@ -127,10 +129,10 @@ TEST_F(HdsTest, TestProcessMessageEndpoints) {
   message->mutable_interval()->set_seconds(1);
 
   for (int i = 0; i < 2; i++) {
-    auto* health_check = message->add_health_check();
+    auto* health_check = message->add_cluster_health_checks();
     health_check->set_cluster_name("anna" + std::to_string(i));
     for (int j = 0; j < 3; j++) {
-      auto* address = health_check->add_endpoints()->add_endpoints()->mutable_address();
+      auto* address = health_check->add_locality_endpoints()->add_endpoints()->mutable_address();
       address->mutable_socket_address()->set_address("127.0.0." + std::to_string(i));
       address->mutable_socket_address()->set_port_value(1234 + j);
     }
@@ -165,7 +167,7 @@ TEST_F(HdsTest, TestProcessMessageHealthChecks) {
   message->mutable_interval()->set_seconds(1);
 
   for (int i = 0; i < 2; i++) {
-    auto* health_check = message->add_health_check();
+    auto* health_check = message->add_cluster_health_checks();
     health_check->set_cluster_name("minkowski" + std::to_string(i));
     for (int j = 0; j < i + 2; j++) {
       auto hc = health_check->add_health_checks();

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -117,22 +117,22 @@ public:
     envoy::service::discovery::v2::HealthCheckSpecifier server_health_check_specifier_;
     server_health_check_specifier_.mutable_interval()->set_seconds(1);
 
-    auto* health_check = server_health_check_specifier_.add_health_check();
+    auto* health_check = server_health_check_specifier_.add_cluster_health_checks();
 
     health_check->set_cluster_name("anna");
-    health_check->add_endpoints()
+    health_check->add_locality_endpoints()
         ->add_endpoints()
         ->mutable_address()
         ->mutable_socket_address()
         ->set_address(host_upstream_->localAddress()->ip()->addressAsString());
-    health_check->mutable_endpoints(0)
+    health_check->mutable_locality_endpoints(0)
         ->mutable_endpoints(0)
         ->mutable_address()
         ->mutable_socket_address()
         ->set_port_value(host_upstream_->localAddress()->ip()->port());
-    health_check->mutable_endpoints(0)->mutable_locality()->set_region("some_region");
-    health_check->mutable_endpoints(0)->mutable_locality()->set_zone("some_zone");
-    health_check->mutable_endpoints(0)->mutable_locality()->set_sub_zone("crete");
+    health_check->mutable_locality_endpoints(0)->mutable_locality()->set_region("some_region");
+    health_check->mutable_locality_endpoints(0)->mutable_locality()->set_zone("some_zone");
+    health_check->mutable_locality_endpoints(0)->mutable_locality()->set_sub_zone("crete");
 
     health_check->add_health_checks()->mutable_timeout()->set_seconds(1);
     health_check->mutable_health_checks(0)->mutable_interval()->set_seconds(1);
@@ -194,7 +194,7 @@ TEST_P(HdsIntegrationTest, SingleEndpointHealthy) {
   // Server <--> Envoy
   waitForHdsStream();
   ASSERT_TRUE(hds_stream_->waitForGrpcMessage(*dispatcher_, envoy_msg_));
-  EXPECT_EQ(envoy_msg_.capability().health_check_protocol(0),
+  EXPECT_EQ(envoy_msg_.capability().health_check_protocols(0),
             envoy::service::discovery::v2::Capability::HTTP);
 
   // Server asks for healthchecking
@@ -301,7 +301,9 @@ TEST_P(HdsIntegrationTest, TwoEndpointsSameLocality) {
   initialize();
 
   server_health_check_specifier_ = makeHealthCheckSpecifier();
-  auto* endpoint = server_health_check_specifier_.mutable_health_check(0)->mutable_endpoints(0);
+  auto* endpoint =
+      server_health_check_specifier_.mutable_cluster_health_checks(0)->mutable_locality_endpoints(
+          0);
   endpoint->add_endpoints()->mutable_address()->mutable_socket_address()->set_address(
       host2_upstream_->localAddress()->ip()->addressAsString());
   endpoint->mutable_endpoints(1)->mutable_address()->mutable_socket_address()->set_port_value(
@@ -348,21 +350,21 @@ TEST_P(HdsIntegrationTest, TwoEndpointsDifferentLocality) {
   server_health_check_specifier_ = makeHealthCheckSpecifier();
 
   // Add endpoint
-  auto* health_check = server_health_check_specifier_.mutable_health_check(0);
+  auto* health_check = server_health_check_specifier_.mutable_cluster_health_checks(0);
 
-  health_check->add_endpoints()
+  health_check->add_locality_endpoints()
       ->add_endpoints()
       ->mutable_address()
       ->mutable_socket_address()
       ->set_address(host2_upstream_->localAddress()->ip()->addressAsString());
-  health_check->mutable_endpoints(1)
+  health_check->mutable_locality_endpoints(1)
       ->mutable_endpoints(0)
       ->mutable_address()
       ->mutable_socket_address()
       ->set_port_value(host2_upstream_->localAddress()->ip()->port());
-  health_check->mutable_endpoints(1)->mutable_locality()->set_region("different_region");
-  health_check->mutable_endpoints(1)->mutable_locality()->set_zone("different_zone");
-  health_check->mutable_endpoints(1)->mutable_locality()->set_sub_zone("emplisi");
+  health_check->mutable_locality_endpoints(1)->mutable_locality()->set_region("different_region");
+  health_check->mutable_locality_endpoints(1)->mutable_locality()->set_zone("different_zone");
+  health_check->mutable_locality_endpoints(1)->mutable_locality()->set_sub_zone("emplisi");
 
   // Server <--> Envoy
   waitForHdsStream();
@@ -406,22 +408,22 @@ TEST_P(HdsIntegrationTest, TwoEndpointsDifferentClusters) {
   server_health_check_specifier_ = makeHealthCheckSpecifier();
 
   // Add endpoint
-  auto* health_check = server_health_check_specifier_.add_health_check();
+  auto* health_check = server_health_check_specifier_.add_cluster_health_checks();
 
   health_check->set_cluster_name("cat");
-  health_check->add_endpoints()
+  health_check->add_locality_endpoints()
       ->add_endpoints()
       ->mutable_address()
       ->mutable_socket_address()
       ->set_address(host2_upstream_->localAddress()->ip()->addressAsString());
-  health_check->mutable_endpoints(0)
+  health_check->mutable_locality_endpoints(0)
       ->mutable_endpoints(0)
       ->mutable_address()
       ->mutable_socket_address()
       ->set_port_value(host2_upstream_->localAddress()->ip()->port());
-  health_check->mutable_endpoints(0)->mutable_locality()->set_region("peculiar_region");
-  health_check->mutable_endpoints(0)->mutable_locality()->set_zone("peculiar_zone");
-  health_check->mutable_endpoints(0)->mutable_locality()->set_sub_zone("paris");
+  health_check->mutable_locality_endpoints(0)->mutable_locality()->set_region("peculiar_region");
+  health_check->mutable_locality_endpoints(0)->mutable_locality()->set_zone("peculiar_zone");
+  health_check->mutable_locality_endpoints(0)->mutable_locality()->set_sub_zone("paris");
 
   health_check->add_health_checks()->mutable_timeout()->set_seconds(1);
   health_check->mutable_health_checks(0)->mutable_interval()->set_seconds(1);
@@ -505,22 +507,22 @@ TEST_P(HdsIntegrationTest, TestUpdateMessage) {
   envoy::service::discovery::v2::HealthCheckSpecifier new_message;
   new_message.mutable_interval()->set_seconds(1);
 
-  auto* health_check = new_message.add_health_check();
+  auto* health_check = new_message.add_cluster_health_checks();
 
   health_check->set_cluster_name("cat");
-  health_check->add_endpoints()
+  health_check->add_locality_endpoints()
       ->add_endpoints()
       ->mutable_address()
       ->mutable_socket_address()
       ->set_address(host2_upstream_->localAddress()->ip()->addressAsString());
-  health_check->mutable_endpoints(0)
+  health_check->mutable_locality_endpoints(0)
       ->mutable_endpoints(0)
       ->mutable_address()
       ->mutable_socket_address()
       ->set_port_value(host2_upstream_->localAddress()->ip()->port());
-  health_check->mutable_endpoints(0)->mutable_locality()->set_region("peculiar_region");
-  health_check->mutable_endpoints(0)->mutable_locality()->set_zone("peculiar_zone");
-  health_check->mutable_endpoints(0)->mutable_locality()->set_sub_zone("paris");
+  health_check->mutable_locality_endpoints(0)->mutable_locality()->set_region("peculiar_region");
+  health_check->mutable_locality_endpoints(0)->mutable_locality()->set_zone("peculiar_zone");
+  health_check->mutable_locality_endpoints(0)->mutable_locality()->set_sub_zone("paris");
 
   health_check->add_health_checks()->mutable_timeout()->set_seconds(1);
   health_check->mutable_health_checks(0)->mutable_interval()->set_seconds(1);


### PR DESCRIPTION
Renaming message types in api/envoy/service/discovery/v2/hds.proto to improve readability

*Risk Level*:
Low

This is for https://github.com/envoyproxy/envoy/issues/1310.