### PR TITLE
Do not crash when converting YAML to JSON fails

### DIFF
--- a/include/envoy/json/json_object.h
+++ b/include/envoy/json/json_object.h
@@ -86,6 +86,18 @@ public:
   virtual bool isNull() const PURE;
 
   /**
+   * Determine if an object has type Object.
+   * @return bool is the object an Object?
+   */
+  virtual bool isObject() const PURE;
+
+  /**
+   * Determine if an object has type Array.
+   * @return bool is the object an Array?
+   */
+  virtual bool isArray() const PURE;
+
+  /**
    * Get an array by name.
    * @param name supplies the key name.
    * @param allow_empty specifies whether to return an empty array if the key does not exist.

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -743,8 +743,9 @@ FieldSharedPtr parseYamlNode(YAML::Node node) {
 } // namespace
 
 ObjectSharedPtr Factory::loadFromYamlString(const std::string& yaml) {
+  YAML::Node node;
   try {
-    return parseYamlNode(YAML::Load(yaml));
+    node = YAML::Load(yaml);
   } catch (YAML::ParserException& e) {
     throw EnvoyException(e.what());
   } catch (YAML::BadConversion& e) {
@@ -756,6 +757,12 @@ ObjectSharedPtr Factory::loadFromYamlString(const std::string& yaml) {
     // the Envoy Exception text.
     throw EnvoyException(fmt::format("Unexpected YAML exception: {}", +e.what()));
   }
+
+  // A valid JSON can only be built from a Map or a Sequence.
+  if (node.Type() == YAML::NodeType::Map || node.Type() == YAML::NodeType::Sequence) {
+    return parseYamlNode(node);
+  }
+  throw EnvoyException(fmt::format("Unable to convert YAML as JSON: {}", yaml));
 }
 
 ObjectSharedPtr Factory::loadFromString(const std::string& json) {

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -46,9 +46,9 @@ public:
   static FieldSharedPtr createArray() { return FieldSharedPtr{new Field(Type::Array)}; }
   static FieldSharedPtr createNull() { return FieldSharedPtr{new Field(Type::Null)}; }
 
-  bool isNull() const override { return type_ == Type::Null; }
-  bool isArray() const { return type_ == Type::Array; }
-  bool isObject() const { return type_ == Type::Object; }
+  bool isNull() const override { return type_ == Type::Null; };
+  bool isArray() const override { return type_ == Type::Array; };
+  bool isObject() const override { return type_ == Type::Object; };
 
   // Value factory.
   template <typename T> static FieldSharedPtr createValue(T value) {
@@ -743,9 +743,8 @@ FieldSharedPtr parseYamlNode(YAML::Node node) {
 } // namespace
 
 ObjectSharedPtr Factory::loadFromYamlString(const std::string& yaml) {
-  YAML::Node node;
   try {
-    node = YAML::Load(yaml);
+    return parseYamlNode(YAML::Load(yaml));
   } catch (YAML::ParserException& e) {
     throw EnvoyException(e.what());
   } catch (YAML::BadConversion& e) {
@@ -757,12 +756,6 @@ ObjectSharedPtr Factory::loadFromYamlString(const std::string& yaml) {
     // the Envoy Exception text.
     throw EnvoyException(fmt::format("Unexpected YAML exception: {}", +e.what()));
   }
-
-  // A valid JSON can only be built from a Map or a Sequence.
-  if (node.Type() == YAML::NodeType::Map || node.Type() == YAML::NodeType::Sequence) {
-    return parseYamlNode(node);
-  }
-  throw EnvoyException(fmt::format("Unable to convert YAML as JSON: {}", yaml));
 }
 
 ObjectSharedPtr Factory::loadFromString(const std::string& json) {

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -46,9 +46,9 @@ public:
   static FieldSharedPtr createArray() { return FieldSharedPtr{new Field(Type::Array)}; }
   static FieldSharedPtr createNull() { return FieldSharedPtr{new Field(Type::Null)}; }
 
-  bool isNull() const override { return type_ == Type::Null; };
-  bool isArray() const override { return type_ == Type::Array; };
-  bool isObject() const override { return type_ == Type::Object; };
+  bool isNull() const override { return type_ == Type::Null; }
+  bool isArray() const override { return type_ == Type::Array; }
+  bool isObject() const override { return type_ == Type::Object; }
 
   // Value factory.
   template <typename T> static FieldSharedPtr createValue(T value) {

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -60,8 +60,6 @@ void MessageUtil::loadFromJson(const std::string& json, Protobuf::Message& messa
 void MessageUtil::loadFromYaml(const std::string& yaml, Protobuf::Message& message) {
   const auto& loaded_object = Json::Factory::loadFromYamlString(yaml);
   // Load to the message if the loaded object has type Object or Array.
-  // TODO(dio): Switch to make this condition only valid for Object, since Array, at the end, gives:
-  // "Unable to parse JSON as proto...".
   if (loaded_object->isObject() || loaded_object->isArray()) {
     const std::string json = loaded_object->asJsonString();
     loadFromJson(json, message);

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -58,8 +58,8 @@ void MessageUtil::loadFromJson(const std::string& json, Protobuf::Message& messa
 }
 
 void MessageUtil::loadFromYaml(const std::string& yaml, Protobuf::Message& message) {
-  const auto& loaded_object = Json::Factory::loadFromYamlString(yaml);
-  // Load to the message if the loaded object has type Object or Array.
+  const auto loaded_object = Json::Factory::loadFromYamlString(yaml);
+  // Load the message if the loaded object has type Object or Array.
   if (loaded_object->isObject() || loaded_object->isArray()) {
     const std::string json = loaded_object->asJsonString();
     loadFromJson(json, message);

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -58,8 +58,16 @@ void MessageUtil::loadFromJson(const std::string& json, Protobuf::Message& messa
 }
 
 void MessageUtil::loadFromYaml(const std::string& yaml, Protobuf::Message& message) {
-  const std::string json = Json::Factory::loadFromYamlString(yaml)->asJsonString();
-  loadFromJson(json, message);
+  const auto& loaded_object = Json::Factory::loadFromYamlString(yaml);
+  // Load to the message if the loaded object has type Object or Array.
+  // TODO(dio): Switch to make this condition only valid for Object, since Array, at the end, gives:
+  // "Unable to parse JSON as proto...".
+  if (loaded_object->isObject() || loaded_object->isArray()) {
+    const std::string json = loaded_object->asJsonString();
+    loadFromJson(json, message);
+    return;
+  }
+  throw EnvoyException("Unable to convert YAML as JSON: " + yaml);
 }
 
 void MessageUtil::loadFromFile(const std::string& path, Protobuf::Message& message) {

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -255,10 +255,12 @@ TEST(UtilityTest, JsonConvertCamelSnake) {
 
 TEST(UtilityTest, YamlLoadFromStringFail) {
   envoy::config::bootstrap::v2::Bootstrap bootstrap;
-  // loadFromYaml expects a valid YAML string.
+  // Verify loadFromYaml can parse valid YAML string.
+  MessageUtil::loadFromYaml("node: { id: node1 }", bootstrap);
+  // Verify loadFromYaml throws error when the input is an invalid YAML string.
   EXPECT_THROW_WITH_MESSAGE(MessageUtil::loadFromYaml("not_a_yaml", bootstrap), EnvoyException,
                             "Unable to convert YAML as JSON: not_a_yaml");
-  // When wrongly inputted by a file path, the loadFromYaml throws an error.
+  // When wrongly inputted by a file path, loadFromYaml throws an error.
   EXPECT_THROW_WITH_MESSAGE(MessageUtil::loadFromYaml("/home/configs/config.yaml", bootstrap),
                             EnvoyException,
                             "Unable to convert YAML as JSON: /home/configs/config.yaml");

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -255,6 +255,10 @@ TEST(UtilityTest, JsonConvertCamelSnake) {
 
 TEST(UtilityTest, YamlLoadFromStringFail) {
   envoy::config::bootstrap::v2::Bootstrap bootstrap;
+  // loadFromYaml expects a valid YAML string.
+  EXPECT_THROW_WITH_MESSAGE(MessageUtil::loadFromYaml("not_a_yaml", bootstrap), EnvoyException,
+                            "Unable to convert YAML as JSON: not_a_yaml");
+  // When wrongly inputted by a file path, the loadFromYaml throws an error.
   EXPECT_THROW_WITH_MESSAGE(MessageUtil::loadFromYaml("/home/configs/config.yaml", bootstrap),
                             EnvoyException,
                             "Unable to convert YAML as JSON: /home/configs/config.yaml");

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -253,6 +253,13 @@ TEST(UtilityTest, JsonConvertCamelSnake) {
                        .string_value());
 }
 
+TEST(UtilityTest, YamlLoadFromStringFail) {
+  envoy::config::bootstrap::v2::Bootstrap bootstrap;
+  EXPECT_THROW_WITH_MESSAGE(MessageUtil::loadFromYaml("/home/configs/config.yaml", bootstrap),
+                            EnvoyException,
+                            "Unable to convert YAML as JSON: /home/configs/config.yaml");
+}
+
 TEST(DurationUtilTest, OutOfRange) {
   {
     ProtobufWkt::Duration duration;

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -258,12 +258,19 @@ TEST(UtilityTest, YamlLoadFromStringFail) {
   // Verify loadFromYaml can parse valid YAML string.
   MessageUtil::loadFromYaml("node: { id: node1 }", bootstrap);
   // Verify loadFromYaml throws error when the input is an invalid YAML string.
-  EXPECT_THROW_WITH_MESSAGE(MessageUtil::loadFromYaml("not_a_yaml", bootstrap), EnvoyException,
-                            "Unable to convert YAML as JSON: not_a_yaml");
+  EXPECT_THROW_WITH_MESSAGE(
+      MessageUtil::loadFromYaml("not_a_yaml_that_can_be_converted_to_json", bootstrap),
+      EnvoyException, "Unable to convert YAML as JSON: not_a_yaml_that_can_be_converted_to_json");
   // When wrongly inputted by a file path, loadFromYaml throws an error.
   EXPECT_THROW_WITH_MESSAGE(MessageUtil::loadFromYaml("/home/configs/config.yaml", bootstrap),
                             EnvoyException,
                             "Unable to convert YAML as JSON: /home/configs/config.yaml");
+  // Verify loadFromYaml throws error when the input leads to an Array. This error message is
+  // arguably more useful than only "Unable to convert YAML as JSON".
+  EXPECT_THROW_WITH_MESSAGE(MessageUtil::loadFromYaml("- node: { id: node1 }", bootstrap),
+                            EnvoyException,
+                            "Unable to parse JSON as proto (INVALID_ARGUMENT:: invalid name : Root "
+                            "element must be a message.): [{\"node\":{\"id\":\"node1\"}}]");
 }
 
 TEST(DurationUtilTest, OutOfRange) {


### PR DESCRIPTION
*Description*: Do not crash when converting YAML to JSON fails.
*Risk Level*: Low
*Testing*: Added
*Docs Changes*: N/A
*Release Notes*: N/A
Fixes #3990

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>

