### PR TITLE
syscall: refactor OsSysCalls for deeper errno latching

### DIFF
--- a/include/envoy/api/os_sys_calls.h
+++ b/include/envoy/api/os_sys_calls.h
@@ -17,18 +17,22 @@ namespace Api {
 /**
  * SysCallResult holds the rc and errno values resulting from a system call.
  */
-struct SysCallResult {
+template <typename T> struct SysCallResult {
 
   /**
    * The return code from the system call.
    */
-  int rc_;
+  T rc_;
 
   /**
    * The errno value as captured after the system call.
    */
   int errno_;
 };
+
+typedef SysCallResult<int> SysCallIntResult;
+typedef SysCallResult<ssize_t> SysCallSizeResult;
+typedef SysCallResult<void*> SysCallPtrResult;
 
 class OsSysCalls {
 public:
@@ -37,86 +41,88 @@ public:
   /**
    * @see bind (man 2 bind)
    */
-  virtual int bind(int sockfd, const sockaddr* addr, socklen_t addrlen) PURE;
+  virtual SysCallIntResult bind(int sockfd, const sockaddr* addr, socklen_t addrlen) PURE;
 
   /**
    * @see ioctl (man 2 ioctl)
    */
-  virtual int ioctl(int sockfd, unsigned long int request, void* argp) PURE;
+  virtual SysCallIntResult ioctl(int sockfd, unsigned long int request, void* argp) PURE;
 
   /**
    * Open file by full_path with given flags and mode.
    * @return file descriptor.
    */
-  virtual int open(const std::string& full_path, int flags, int mode) PURE;
+  virtual SysCallIntResult open(const std::string& full_path, int flags, int mode) PURE;
 
   /**
    * Write num_bytes to fd from buffer.
    * @return number of bytes written if non negative, otherwise error code.
    */
-  virtual ssize_t write(int fd, const void* buffer, size_t num_bytes) PURE;
+  virtual SysCallSizeResult write(int fd, const void* buffer, size_t num_bytes) PURE;
 
   /**
    * @see writev (man 2 writev)
    */
-  virtual ssize_t writev(int fd, const iovec* iovec, int num_iovec) PURE;
+  virtual SysCallSizeResult writev(int fd, const iovec* iovec, int num_iovec) PURE;
 
   /**
    * @see readv (man 2 readv)
    */
-  virtual ssize_t readv(int fd, const iovec* iovec, int num_iovec) PURE;
+  virtual SysCallSizeResult readv(int fd, const iovec* iovec, int num_iovec) PURE;
 
   /**
    * @see recv (man 2 recv)
    */
-  virtual ssize_t recv(int socket, void* buffer, size_t length, int flags) PURE;
+  virtual SysCallSizeResult recv(int socket, void* buffer, size_t length, int flags) PURE;
 
   /**
    * Release all resources allocated for fd.
    * @return zero on success, -1 returned otherwise.
    */
-  virtual int close(int fd) PURE;
+  virtual SysCallIntResult close(int fd) PURE;
 
   /**
    * @see shm_open (man 3 shm_open)
    */
-  virtual int shmOpen(const char* name, int oflag, mode_t mode) PURE;
+  virtual SysCallIntResult shmOpen(const char* name, int oflag, mode_t mode) PURE;
 
   /**
    * @see shm_unlink (man 3 shm_unlink)
    */
-  virtual int shmUnlink(const char* name) PURE;
+  virtual SysCallIntResult shmUnlink(const char* name) PURE;
 
   /**
    * @see man 2 ftruncate
    */
-  virtual int ftruncate(int fd, off_t length) PURE;
+  virtual SysCallIntResult ftruncate(int fd, off_t length) PURE;
 
   /**
    * @see man 2 mmap
    */
-  virtual void* mmap(void* addr, size_t length, int prot, int flags, int fd, off_t offset) PURE;
+  virtual SysCallPtrResult mmap(void* addr, size_t length, int prot, int flags, int fd,
+                                off_t offset) PURE;
 
   /**
    * @see man 2 stat
    */
-  virtual int stat(const char* pathname, struct stat* buf) PURE;
+  virtual SysCallIntResult stat(const char* pathname, struct stat* buf) PURE;
 
   /**
    * @see man 2 setsockopt
    */
-  virtual int setsockopt(int sockfd, int level, int optname, const void* optval,
-                         socklen_t optlen) PURE;
+  virtual SysCallIntResult setsockopt(int sockfd, int level, int optname, const void* optval,
+                                      socklen_t optlen) PURE;
 
   /**
    * @see man 2 getsockopt
    */
-  virtual int getsockopt(int sockfd, int level, int optname, void* optval, socklen_t* optlen) PURE;
+  virtual SysCallIntResult getsockopt(int sockfd, int level, int optname, void* optval,
+                                      socklen_t* optlen) PURE;
 
   /**
    * @see man 2 socket
    */
-  virtual int socket(int domain, int type, int protocol) PURE;
+  virtual SysCallIntResult socket(int domain, int type, int protocol) PURE;
 };
 
 typedef std::unique_ptr<OsSysCalls> OsSysCallsPtr;

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -158,10 +158,10 @@ public:
    * Read from a file descriptor directly into the buffer.
    * @param fd supplies the descriptor to read from.
    * @param max_length supplies the maximum length to read.
-   * @return a Api::SysCallResult with rc_ = the number of bytes read if successful, or rc_ = -1
+   * @return a Api::SysCallIntResult with rc_ = the number of bytes read if successful, or rc_ = -1
    *   for failure. If the call is successful, errno_ shouldn't be used.
    */
-  virtual Api::SysCallResult read(int fd, uint64_t max_length) PURE;
+  virtual Api::SysCallIntResult read(int fd, uint64_t max_length) PURE;
 
   /**
    * Reserve space in the buffer.
@@ -190,10 +190,10 @@ public:
   /**
    * Write the buffer out to a file descriptor.
    * @param fd supplies the descriptor to write to.
-   * @return a Api::SysCallResult with rc_ = the number of bytes written if successful, or rc_ = -1
-   *   for failure. If the call is successful, errno_ shouldn't be used.
+   * @return a Api::SysCallIntResult with rc_ = the number of bytes written if successful, or rc_ =
+   * -1 for failure. If the call is successful, errno_ shouldn't be used.
    */
-  virtual Api::SysCallResult write(int fd) PURE;
+  virtual Api::SysCallIntResult write(int fd) PURE;
 };
 
 typedef std::unique_ptr<Instance> InstancePtr;

--- a/include/envoy/network/address.h
+++ b/include/envoy/network/address.h
@@ -129,19 +129,19 @@ public:
    * Bind a socket to this address. The socket should have been created with a call to socket() on
    * an Instance of the same address family.
    * @param fd supplies the platform socket handle.
-   * @return a Api::SysCallResult with rc_ = 0 for success and rc_ = -1 for failure. If the call
+   * @return a Api::SysCallIntResult with rc_ = 0 for success and rc_ = -1 for failure. If the call
    *   is successful, errno_ shouldn't be used.
    */
-  virtual Api::SysCallResult bind(int fd) const PURE;
+  virtual Api::SysCallIntResult bind(int fd) const PURE;
 
   /**
    * Connect a socket to this address. The socket should have been created with a call to socket()
    * on this object.
    * @param fd supplies the platform socket handle.
-   * @return a Api::SysCallResult with rc_ = 0 for success and rc_ = -1 for failure. If the call
+   * @return a Api::SysCallIntResult with rc_ = 0 for success and rc_ = -1 for failure. If the call
    *   is successful, errno_ shouldn't be used.
    */
-  virtual Api::SysCallResult connect(int fd) const PURE;
+  virtual Api::SysCallIntResult connect(int fd) const PURE;
 
   /**
    * @return the IP address information IFF type() == Type::Ip, otherwise nullptr.

--- a/source/common/api/os_sys_calls_impl.cc
+++ b/source/common/api/os_sys_calls_impl.cc
@@ -7,62 +7,87 @@
 namespace Envoy {
 namespace Api {
 
-int OsSysCallsImpl::bind(int sockfd, const sockaddr* addr, socklen_t addrlen) {
-  return ::bind(sockfd, addr, addrlen);
+SysCallIntResult OsSysCallsImpl::bind(int sockfd, const sockaddr* addr, socklen_t addrlen) {
+  const int rc = ::bind(sockfd, addr, addrlen);
+  return {rc, errno};
 }
 
-int OsSysCallsImpl::ioctl(int sockfd, unsigned long int request, void* argp) {
-  return ::ioctl(sockfd, request, argp);
+SysCallIntResult OsSysCallsImpl::ioctl(int sockfd, unsigned long int request, void* argp) {
+  const int rc = ::ioctl(sockfd, request, argp);
+  return {rc, errno};
 }
 
-int OsSysCallsImpl::open(const std::string& full_path, int flags, int mode) {
-  return ::open(full_path.c_str(), flags, mode);
+SysCallIntResult OsSysCallsImpl::open(const std::string& full_path, int flags, int mode) {
+  const int rc = ::open(full_path.c_str(), flags, mode);
+  return {rc, errno};
 }
 
-int OsSysCallsImpl::close(int fd) { return ::close(fd); }
-
-ssize_t OsSysCallsImpl::write(int fd, const void* buffer, size_t num_bytes) {
-  return ::write(fd, buffer, num_bytes);
+SysCallIntResult OsSysCallsImpl::close(int fd) {
+  const int rc = ::close(fd);
+  return {rc, errno};
 }
 
-ssize_t OsSysCallsImpl::writev(int fd, const iovec* iovec, int num_iovec) {
-  return ::writev(fd, iovec, num_iovec);
+SysCallSizeResult OsSysCallsImpl::write(int fd, const void* buffer, size_t num_bytes) {
+  const ssize_t rc = ::write(fd, buffer, num_bytes);
+  return {rc, errno};
 }
 
-ssize_t OsSysCallsImpl::readv(int fd, const iovec* iovec, int num_iovec) {
-  return ::readv(fd, iovec, num_iovec);
+SysCallSizeResult OsSysCallsImpl::writev(int fd, const iovec* iovec, int num_iovec) {
+  const ssize_t rc = ::writev(fd, iovec, num_iovec);
+  return {rc, errno};
 }
 
-ssize_t OsSysCallsImpl::recv(int socket, void* buffer, size_t length, int flags) {
-  return ::recv(socket, buffer, length, flags);
+SysCallSizeResult OsSysCallsImpl::readv(int fd, const iovec* iovec, int num_iovec) {
+  const ssize_t rc = ::readv(fd, iovec, num_iovec);
+  return {rc, errno};
 }
 
-int OsSysCallsImpl::shmOpen(const char* name, int oflag, mode_t mode) {
-  return ::shm_open(name, oflag, mode);
+SysCallSizeResult OsSysCallsImpl::recv(int socket, void* buffer, size_t length, int flags) {
+  const ssize_t rc = ::recv(socket, buffer, length, flags);
+  return {rc, errno};
 }
 
-int OsSysCallsImpl::shmUnlink(const char* name) { return ::shm_unlink(name); }
-
-int OsSysCallsImpl::ftruncate(int fd, off_t length) { return ::ftruncate(fd, length); }
-
-void* OsSysCallsImpl::mmap(void* addr, size_t length, int prot, int flags, int fd, off_t offset) {
-  return ::mmap(addr, length, prot, flags, fd, offset);
+SysCallIntResult OsSysCallsImpl::shmOpen(const char* name, int oflag, mode_t mode) {
+  const int rc = ::shm_open(name, oflag, mode);
+  return {rc, errno};
 }
 
-int OsSysCallsImpl::stat(const char* pathname, struct stat* buf) { return ::stat(pathname, buf); }
-
-int OsSysCallsImpl::setsockopt(int sockfd, int level, int optname, const void* optval,
-                               socklen_t optlen) {
-  return ::setsockopt(sockfd, level, optname, optval, optlen);
+SysCallIntResult OsSysCallsImpl::shmUnlink(const char* name) {
+  const int rc = ::shm_unlink(name);
+  return {rc, errno};
 }
 
-int OsSysCallsImpl::getsockopt(int sockfd, int level, int optname, void* optval,
-                               socklen_t* optlen) {
-  return ::getsockopt(sockfd, level, optname, optval, optlen);
+SysCallIntResult OsSysCallsImpl::ftruncate(int fd, off_t length) {
+  const int rc = ::ftruncate(fd, length);
+  return {rc, errno};
 }
 
-int OsSysCallsImpl::socket(int domain, int type, int protocol) {
-  return ::socket(domain, type, protocol);
+SysCallPtrResult OsSysCallsImpl::mmap(void* addr, size_t length, int prot, int flags, int fd,
+                                      off_t offset) {
+  void* rc = ::mmap(addr, length, prot, flags, fd, offset);
+  return {rc, errno};
+}
+
+SysCallIntResult OsSysCallsImpl::stat(const char* pathname, struct stat* buf) {
+  const int rc = ::stat(pathname, buf);
+  return {rc, errno};
+}
+
+SysCallIntResult OsSysCallsImpl::setsockopt(int sockfd, int level, int optname, const void* optval,
+                                            socklen_t optlen) {
+  const int rc = ::setsockopt(sockfd, level, optname, optval, optlen);
+  return {rc, errno};
+}
+
+SysCallIntResult OsSysCallsImpl::getsockopt(int sockfd, int level, int optname, void* optval,
+                                            socklen_t* optlen) {
+  const int rc = ::getsockopt(sockfd, level, optname, optval, optlen);
+  return {rc, errno};
+}
+
+SysCallIntResult OsSysCallsImpl::socket(int domain, int type, int protocol) {
+  const int rc = ::socket(domain, type, protocol);
+  return {rc, errno};
 }
 
 } // namespace Api

--- a/source/common/api/os_sys_calls_impl.cc
+++ b/source/common/api/os_sys_calls_impl.cc
@@ -1,5 +1,6 @@
 #include "common/api/os_sys_calls_impl.h"
 
+#include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/source/common/api/os_sys_calls_impl.h
+++ b/source/common/api/os_sys_calls_impl.h
@@ -10,22 +10,25 @@ namespace Api {
 class OsSysCallsImpl : public OsSysCalls {
 public:
   // Api::OsSysCalls
-  int bind(int sockfd, const sockaddr* addr, socklen_t addrlen) override;
-  int ioctl(int sockfd, unsigned long int request, void* argp) override;
-  int open(const std::string& full_path, int flags, int mode) override;
-  ssize_t write(int fd, const void* buffer, size_t num_bytes) override;
-  ssize_t writev(int fd, const iovec* iovec, int num_iovec) override;
-  ssize_t readv(int fd, const iovec* iovec, int num_iovec) override;
-  ssize_t recv(int socket, void* buffer, size_t length, int flags) override;
-  int close(int fd) override;
-  int shmOpen(const char* name, int oflag, mode_t mode) override;
-  int shmUnlink(const char* name) override;
-  int ftruncate(int fd, off_t length) override;
-  void* mmap(void* addr, size_t length, int prot, int flags, int fd, off_t offset) override;
-  int stat(const char* pathname, struct stat* buf) override;
-  int setsockopt(int sockfd, int level, int optname, const void* optval, socklen_t optlen) override;
-  int getsockopt(int sockfd, int level, int optname, void* optval, socklen_t* optlen) override;
-  int socket(int domain, int type, int protocol) override;
+  SysCallIntResult bind(int sockfd, const sockaddr* addr, socklen_t addrlen) override;
+  SysCallIntResult ioctl(int sockfd, unsigned long int request, void* argp) override;
+  SysCallIntResult open(const std::string& full_path, int flags, int mode) override;
+  SysCallSizeResult write(int fd, const void* buffer, size_t num_bytes) override;
+  SysCallSizeResult writev(int fd, const iovec* iovec, int num_iovec) override;
+  SysCallSizeResult readv(int fd, const iovec* iovec, int num_iovec) override;
+  SysCallSizeResult recv(int socket, void* buffer, size_t length, int flags) override;
+  SysCallIntResult close(int fd) override;
+  SysCallIntResult shmOpen(const char* name, int oflag, mode_t mode) override;
+  SysCallIntResult shmUnlink(const char* name) override;
+  SysCallIntResult ftruncate(int fd, off_t length) override;
+  SysCallPtrResult mmap(void* addr, size_t length, int prot, int flags, int fd,
+                        off_t offset) override;
+  SysCallIntResult stat(const char* pathname, struct stat* buf) override;
+  SysCallIntResult setsockopt(int sockfd, int level, int optname, const void* optval,
+                              socklen_t optlen) override;
+  SysCallIntResult getsockopt(int sockfd, int level, int optname, void* optval,
+                              socklen_t* optlen) override;
+  SysCallIntResult socket(int domain, int type, int protocol) override;
 };
 
 typedef ThreadSafeSingleton<OsSysCallsImpl> OsSysCallsSingleton;

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -82,10 +82,10 @@ public:
   void* linearize(uint32_t size) override;
   void move(Instance& rhs) override;
   void move(Instance& rhs, uint64_t length) override;
-  Api::SysCallResult read(int fd, uint64_t max_length) override;
+  Api::SysCallIntResult read(int fd, uint64_t max_length) override;
   uint64_t reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iovecs) override;
   ssize_t search(const void* data, uint64_t size, size_t start) const override;
-  Api::SysCallResult write(int fd) override;
+  Api::SysCallIntResult write(int fd) override;
   void postProcess() override {}
   std::string toString() const override;
 

--- a/source/common/buffer/watermark_buffer.cc
+++ b/source/common/buffer/watermark_buffer.cc
@@ -50,8 +50,8 @@ void WatermarkBuffer::move(Instance& rhs, uint64_t length) {
   checkHighWatermark();
 }
 
-Api::SysCallResult WatermarkBuffer::read(int fd, uint64_t max_length) {
-  Api::SysCallResult result = OwnedImpl::read(fd, max_length);
+Api::SysCallIntResult WatermarkBuffer::read(int fd, uint64_t max_length) {
+  Api::SysCallIntResult result = OwnedImpl::read(fd, max_length);
   checkHighWatermark();
   return result;
 }
@@ -62,8 +62,8 @@ uint64_t WatermarkBuffer::reserve(uint64_t length, RawSlice* iovecs, uint64_t nu
   return bytes_reserved;
 }
 
-Api::SysCallResult WatermarkBuffer::write(int fd) {
-  Api::SysCallResult result = OwnedImpl::write(fd);
+Api::SysCallIntResult WatermarkBuffer::write(int fd) {
+  Api::SysCallIntResult result = OwnedImpl::write(fd);
   checkLowWatermark();
   return result;
 }

--- a/source/common/buffer/watermark_buffer.h
+++ b/source/common/buffer/watermark_buffer.h
@@ -30,9 +30,9 @@ public:
   void drain(uint64_t size) override;
   void move(Instance& rhs) override;
   void move(Instance& rhs, uint64_t length) override;
-  Api::SysCallResult read(int fd, uint64_t max_length) override;
+  Api::SysCallIntResult read(int fd, uint64_t max_length) override;
   uint64_t reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iovecs) override;
-  Api::SysCallResult write(int fd) override;
+  Api::SysCallIntResult write(int fd) override;
   void postProcess() override { checkLowWatermark(); }
 
   void setWatermarks(uint32_t watermark) { setWatermarks(watermark / 2, watermark); }

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -47,9 +47,10 @@ void validateIpv6Supported(const std::string& address) {
 // Check if an IP family is supported on this machine.
 bool ipFamilySupported(int domain) {
   Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
-  const int fd = os_sys_calls.socket(domain, SOCK_STREAM, 0);
+  const Api::SysCallIntResult result = os_sys_calls.socket(domain, SOCK_STREAM, 0);
+  const int fd = result.rc_;
   if (fd >= 0) {
-    RELEASE_ASSERT(os_sys_calls.close(fd) == 0, "");
+    RELEASE_ASSERT(os_sys_calls.close(fd).rc_ == 0, "");
   }
   return fd != -1;
 }
@@ -214,13 +215,13 @@ bool Ipv4Instance::operator==(const Instance& rhs) const {
           (ip_.port() == rhs_casted->ip_.port()));
 }
 
-Api::SysCallResult Ipv4Instance::bind(int fd) const {
+Api::SysCallIntResult Ipv4Instance::bind(int fd) const {
   const int rc = ::bind(fd, reinterpret_cast<const sockaddr*>(&ip_.ipv4_.address_),
                         sizeof(ip_.ipv4_.address_));
   return {rc, errno};
 }
 
-Api::SysCallResult Ipv4Instance::connect(int fd) const {
+Api::SysCallIntResult Ipv4Instance::connect(int fd) const {
   const int rc = ::connect(fd, reinterpret_cast<const sockaddr*>(&ip_.ipv4_.address_),
                            sizeof(ip_.ipv4_.address_));
   return {rc, errno};
@@ -279,13 +280,13 @@ bool Ipv6Instance::operator==(const Instance& rhs) const {
           (ip_.port() == rhs_casted->ip_.port()));
 }
 
-Api::SysCallResult Ipv6Instance::bind(int fd) const {
+Api::SysCallIntResult Ipv6Instance::bind(int fd) const {
   const int rc = ::bind(fd, reinterpret_cast<const sockaddr*>(&ip_.ipv6_.address_),
                         sizeof(ip_.ipv6_.address_));
   return {rc, errno};
 }
 
-Api::SysCallResult Ipv6Instance::connect(int fd) const {
+Api::SysCallIntResult Ipv6Instance::connect(int fd) const {
   const int rc = ::connect(fd, reinterpret_cast<const sockaddr*>(&ip_.ipv6_.address_),
                            sizeof(ip_.ipv6_.address_));
   return {rc, errno};
@@ -338,7 +339,7 @@ PipeInstance::PipeInstance(const std::string& pipe_path) : InstanceBase(Type::Pi
 
 bool PipeInstance::operator==(const Instance& rhs) const { return asString() == rhs.asString(); }
 
-Api::SysCallResult PipeInstance::bind(int fd) const {
+Api::SysCallIntResult PipeInstance::bind(int fd) const {
   if (abstract_namespace_) {
     const int rc = ::bind(fd, reinterpret_cast<const sockaddr*>(&address_),
                           offsetof(struct sockaddr_un, sun_path) + address_length_);
@@ -352,7 +353,7 @@ Api::SysCallResult PipeInstance::bind(int fd) const {
   return {rc, errno};
 }
 
-Api::SysCallResult PipeInstance::connect(int fd) const {
+Api::SysCallIntResult PipeInstance::connect(int fd) const {
   if (abstract_namespace_) {
     const int rc = ::connect(fd, reinterpret_cast<const sockaddr*>(&address_),
                              offsetof(struct sockaddr_un, sun_path) + address_length_);

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -48,11 +48,10 @@ void validateIpv6Supported(const std::string& address) {
 bool ipFamilySupported(int domain) {
   Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
   const Api::SysCallIntResult result = os_sys_calls.socket(domain, SOCK_STREAM, 0);
-  const int fd = result.rc_;
-  if (fd >= 0) {
-    RELEASE_ASSERT(os_sys_calls.close(fd).rc_ == 0, "");
+  if (result.rc_ >= 0) {
+    RELEASE_ASSERT(os_sys_calls.close(result.rc_).rc_ == 0, "");
   }
-  return fd != -1;
+  return result.rc_ != -1;
 }
 
 Address::InstanceConstSharedPtr addressFromSockAddr(const sockaddr_storage& ss, socklen_t ss_len,

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -97,8 +97,8 @@ public:
 
   // Network::Address::Instance
   bool operator==(const Instance& rhs) const override;
-  Api::SysCallResult bind(int fd) const override;
-  Api::SysCallResult connect(int fd) const override;
+  Api::SysCallIntResult bind(int fd) const override;
+  Api::SysCallIntResult connect(int fd) const override;
   const Ip* ip() const override { return &ip_; }
   int socket(SocketType type) const override;
 
@@ -157,8 +157,8 @@ public:
 
   // Network::Address::Instance
   bool operator==(const Instance& rhs) const override;
-  Api::SysCallResult bind(int fd) const override;
-  Api::SysCallResult connect(int fd) const override;
+  Api::SysCallIntResult bind(int fd) const override;
+  Api::SysCallIntResult connect(int fd) const override;
   const Ip* ip() const override { return &ip_; }
   int socket(SocketType type) const override;
 
@@ -214,8 +214,8 @@ public:
 
   // Network::Address::Instance
   bool operator==(const Instance& rhs) const override;
-  Api::SysCallResult bind(int fd) const override;
-  Api::SysCallResult connect(int fd) const override;
+  Api::SysCallIntResult bind(int fd) const override;
+  Api::SysCallIntResult connect(int fd) const override;
   const Ip* ip() const override { return nullptr; }
   int socket(SocketType type) const override;
 

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -553,7 +553,7 @@ ClientConnectionImpl::ClientConnectionImpl(
   }
 
   if (source_address != nullptr) {
-    const Api::SysCallResult result = source_address->bind(fd());
+    const Api::SysCallIntResult result = source_address->bind(fd());
     if (result.rc_ < 0) {
       ENVOY_LOG_MISC(debug, "Bind failure. Failed to bind to {}: {}", source_address->asString(),
                      strerror(result.errno_));
@@ -570,7 +570,7 @@ ClientConnectionImpl::ClientConnectionImpl(
 
 void ClientConnectionImpl::connect() {
   ENVOY_CONN_LOG(debug, "connecting to {}", *this, socket_->remoteAddress()->asString());
-  const Api::SysCallResult result = socket_->remoteAddress()->connect(fd());
+  const Api::SysCallIntResult result = socket_->remoteAddress()->connect(fd());
   if (result.rc_ == 0) {
     // write will become ready.
     ASSERT(connecting_);

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -16,7 +16,7 @@ namespace Envoy {
 namespace Network {
 
 void ListenSocketImpl::doBind() {
-  const Api::SysCallResult result = local_address_->bind(fd_);
+  const Api::SysCallIntResult result = local_address_->bind(fd_);
   if (result.rc_ == -1) {
     close();
     throw EnvoyException(

--- a/source/common/network/raw_buffer_socket.cc
+++ b/source/common/network/raw_buffer_socket.cc
@@ -17,7 +17,7 @@ IoResult RawBufferSocket::doRead(Buffer::Instance& buffer) {
   bool end_stream = false;
   do {
     // 16K read is arbitrary. TODO(mattklein123) PERF: Tune the read size.
-    Api::SysCallResult result = buffer.read(callbacks_->fd(), 16384);
+    Api::SysCallIntResult result = buffer.read(callbacks_->fd(), 16384);
     ENVOY_CONN_LOG(trace, "read returns: {}", callbacks_->connection(), result.rc_);
 
     if (result.rc_ == 0) {
@@ -58,7 +58,7 @@ IoResult RawBufferSocket::doWrite(Buffer::Instance& buffer, bool end_stream) {
       action = PostIoAction::KeepOpen;
       break;
     }
-    Api::SysCallResult result = buffer.write(callbacks_->fd());
+    Api::SysCallIntResult result = buffer.write(callbacks_->fd());
     ENVOY_CONN_LOG(trace, "write returns: {}", callbacks_->connection(), result.rc_);
 
     if (result.rc_ == -1) {

--- a/source/common/network/socket_option_impl.h
+++ b/source/common/network/socket_option_impl.h
@@ -108,11 +108,11 @@ public:
    * @param socket the socket on which to apply the option.
    * @param optname the option name.
    * @param value the option value.
-   * @return a Api::SysCallResult with rc_ = 0 for success and rc = -1 for failure. If the call is
-   *   successful, errno_ shouldn't be used.
+   * @return a Api::SysCallIntResult with rc_ = 0 for success and rc = -1 for failure. If the call
+   * is successful, errno_ shouldn't be used.
    */
-  static Api::SysCallResult setSocketOption(Socket& socket, Network::SocketOptionName optname,
-                                            absl::string_view value);
+  static Api::SysCallIntResult setSocketOption(Socket& socket, Network::SocketOptionName optname,
+                                               absl::string_view value);
 
 private:
   const envoy::api::v2::core::SocketOption::SocketState in_state_;

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -300,16 +300,18 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(int fd) {
   int socket_domain;
   socklen_t domain_len = sizeof(socket_domain);
   auto& os_syscalls = Api::OsSysCallsSingleton::get();
-  int status = os_syscalls.getsockopt(fd, SOL_SOCKET, SO_DOMAIN, &socket_domain, &domain_len);
+  const Api::SysCallIntResult result =
+      os_syscalls.getsockopt(fd, SOL_SOCKET, SO_DOMAIN, &socket_domain, &domain_len);
+  int status = result.rc_;
 
   if (status != 0) {
     return nullptr;
   }
 
   if (socket_domain == AF_INET) {
-    status = os_syscalls.getsockopt(fd, SOL_IP, SO_ORIGINAL_DST, &orig_addr, &addr_len);
+    status = os_syscalls.getsockopt(fd, SOL_IP, SO_ORIGINAL_DST, &orig_addr, &addr_len).rc_;
   } else if (socket_domain == AF_INET6) {
-    status = os_syscalls.getsockopt(fd, SOL_IPV6, IP6T_SO_ORIGINAL_DST, &orig_addr, &addr_len);
+    status = os_syscalls.getsockopt(fd, SOL_IPV6, IP6T_SO_ORIGINAL_DST, &orig_addr, &addr_len).rc_;
   } else {
     return nullptr;
   }

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -258,8 +258,8 @@ void DiskLayer::walkDirectory(const std::string& path, const std::string& prefix
     }
 
     struct stat stat_result;
-    int rc = os_sys_calls_.stat(full_path.c_str(), &stat_result);
-    if (rc != 0) {
+    const Api::SysCallIntResult result = os_sys_calls_.stat(full_path.c_str(), &stat_result);
+    if (result.rc_ != 0) {
       throw EnvoyException(fmt::format("unable to stat file: '{}'", full_path));
     }
 

--- a/source/extensions/stat_sinks/common/statsd/statsd.cc
+++ b/source/extensions/stat_sinks/common/statsd/statsd.cc
@@ -24,7 +24,7 @@ Writer::Writer(Network::Address::InstanceConstSharedPtr address) {
   fd_ = address->socket(Network::Address::SocketType::Datagram);
   ASSERT(fd_ != -1);
 
-  const Api::SysCallResult result = address->connect(fd_);
+  const Api::SysCallIntResult result = address->connect(fd_);
   ASSERT(result.rc_ != -1);
 }
 

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -55,19 +55,21 @@ SharedMemory& SharedMemory::initialize(uint64_t stats_set_size, Options& options
     os_sys_calls.shmUnlink(shmem_name.c_str());
   }
 
-  int shmem_fd = os_sys_calls.shmOpen(shmem_name.c_str(), flags, S_IRUSR | S_IWUSR);
-  if (shmem_fd == -1) {
+  const Api::SysCallIntResult result =
+      os_sys_calls.shmOpen(shmem_name.c_str(), flags, S_IRUSR | S_IWUSR);
+  if (result.rc_ == -1) {
     PANIC(fmt::format("cannot open shared memory region {} check user permissions. Error: {}",
-                      shmem_name, strerror(errno)));
+                      shmem_name, strerror(result.errno_)));
   }
 
   if (options.restartEpoch() == 0) {
-    int rc = os_sys_calls.ftruncate(shmem_fd, total_size);
-    RELEASE_ASSERT(rc != -1, "");
+    const Api::SysCallIntResult truncateRes = os_sys_calls.ftruncate(result.rc_, total_size);
+    RELEASE_ASSERT(truncateRes.rc_ != -1, "");
   }
 
-  SharedMemory* shmem = reinterpret_cast<SharedMemory*>(
-      os_sys_calls.mmap(nullptr, total_size, PROT_READ | PROT_WRITE, MAP_SHARED, shmem_fd, 0));
+  const Api::SysCallPtrResult mmapRes =
+      os_sys_calls.mmap(nullptr, total_size, PROT_READ | PROT_WRITE, MAP_SHARED, result.rc_, 0);
+  SharedMemory* shmem = reinterpret_cast<SharedMemory*>(mmapRes.rc_);
   RELEASE_ASSERT(shmem != MAP_FAILED, "");
   RELEASE_ASSERT((reinterpret_cast<uintptr_t>(shmem) % alignof(decltype(shmem))) == 0, "");
 
@@ -184,8 +186,9 @@ int HotRestartImpl::bindDomainSocket(uint64_t id) {
   // easily read single messages.
   int fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK, 0);
   sockaddr_un address = createDomainSocketAddress(id);
-  int rc = os_sys_calls.bind(fd, reinterpret_cast<sockaddr*>(&address), sizeof(address));
-  if (rc != 0) {
+  Api::SysCallIntResult result =
+      os_sys_calls.bind(fd, reinterpret_cast<sockaddr*>(&address), sizeof(address));
+  if (result.rc_ != 0) {
     throw EnvoyException(
         fmt::format("unable to bind domain socket with id={} (see --base-id option)", id));
   }

--- a/test/common/buffer/owned_impl_test.cc
+++ b/test/common/buffer/owned_impl_test.cc
@@ -120,28 +120,28 @@ TEST_F(OwnedImplTest, Write) {
 
   Buffer::OwnedImpl buffer;
   buffer.add("example");
-  EXPECT_CALL(os_sys_calls, writev(_, _, _)).WillOnce(Return(7));
-  Api::SysCallResult result = buffer.write(-1);
+  EXPECT_CALL(os_sys_calls, writev(_, _, _)).WillOnce(Return(Api::SysCallSizeResult{7, 0}));
+  Api::SysCallIntResult result = buffer.write(-1);
   EXPECT_EQ(7, result.rc_);
   EXPECT_EQ(0, buffer.length());
 
   buffer.add("example");
-  EXPECT_CALL(os_sys_calls, writev(_, _, _)).WillOnce(Return(6));
+  EXPECT_CALL(os_sys_calls, writev(_, _, _)).WillOnce(Return(Api::SysCallSizeResult{6, 0}));
   result = buffer.write(-1);
   EXPECT_EQ(6, result.rc_);
   EXPECT_EQ(1, buffer.length());
 
-  EXPECT_CALL(os_sys_calls, writev(_, _, _)).WillOnce(Return(0));
+  EXPECT_CALL(os_sys_calls, writev(_, _, _)).WillOnce(Return(Api::SysCallSizeResult{0, 0}));
   result = buffer.write(-1);
   EXPECT_EQ(0, result.rc_);
   EXPECT_EQ(1, buffer.length());
 
-  EXPECT_CALL(os_sys_calls, writev(_, _, _)).WillOnce(Return(-1));
+  EXPECT_CALL(os_sys_calls, writev(_, _, _)).WillOnce(Return(Api::SysCallSizeResult{-1, 0}));
   result = buffer.write(-1);
   EXPECT_EQ(-1, result.rc_);
   EXPECT_EQ(1, buffer.length());
 
-  EXPECT_CALL(os_sys_calls, writev(_, _, _)).WillOnce(Return(1));
+  EXPECT_CALL(os_sys_calls, writev(_, _, _)).WillOnce(Return(Api::SysCallSizeResult{1, 0}));
   result = buffer.write(-1);
   EXPECT_EQ(1, result.rc_);
   EXPECT_EQ(0, buffer.length());
@@ -157,12 +157,12 @@ TEST_F(OwnedImplTest, Read) {
   TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls(&os_sys_calls);
 
   Buffer::OwnedImpl buffer;
-  EXPECT_CALL(os_sys_calls, readv(_, _, _)).WillOnce(Return(0));
-  Api::SysCallResult result = buffer.read(-1, 100);
+  EXPECT_CALL(os_sys_calls, readv(_, _, _)).WillOnce(Return(Api::SysCallSizeResult{0, 0}));
+  Api::SysCallIntResult result = buffer.read(-1, 100);
   EXPECT_EQ(0, result.rc_);
   EXPECT_EQ(0, buffer.length());
 
-  EXPECT_CALL(os_sys_calls, readv(_, _, _)).WillOnce(Return(-1));
+  EXPECT_CALL(os_sys_calls, readv(_, _, _)).WillOnce(Return(Api::SysCallSizeResult{-1, 0}));
   result = buffer.read(-1, 100);
   EXPECT_EQ(-1, result.rc_);
   EXPECT_EQ(0, buffer.length());

--- a/test/common/buffer/watermark_buffer_test.cc
+++ b/test/common/buffer/watermark_buffer_test.cc
@@ -178,7 +178,7 @@ TEST_F(WatermarkBufferTest, WatermarkFdFunctions) {
 
   int bytes_written_total = 0;
   while (bytes_written_total < 20) {
-    Api::SysCallResult result = buffer_.write(pipe_fds[1]);
+    Api::SysCallIntResult result = buffer_.write(pipe_fds[1]);
     if (result.rc_ < 0) {
       ASSERT_EQ(EAGAIN, result.errno_);
     } else {
@@ -191,7 +191,7 @@ TEST_F(WatermarkBufferTest, WatermarkFdFunctions) {
 
   int bytes_read_total = 0;
   while (bytes_read_total < 20) {
-    Api::SysCallResult result = buffer_.read(pipe_fds[0], 20);
+    Api::SysCallIntResult result = buffer_.read(pipe_fds[0], 20);
     bytes_read_total += result.rc_;
   }
   EXPECT_EQ(2, times_high_watermark_called_);

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -64,7 +64,7 @@ void testSocketBindAndConnect(Network::Address::IpVersion ip_version, bool v6onl
   }
 
   // Bind the socket to the desired address and port.
-  const Api::SysCallResult result = addr_port->bind(listen_fd);
+  const Api::SysCallIntResult result = addr_port->bind(listen_fd);
   ASSERT_EQ(result.rc_, 0) << addr_port->asString() << "\nerror: " << strerror(result.errno_)
                            << "\nerrno: " << result.errno_;
 
@@ -85,7 +85,7 @@ void testSocketBindAndConnect(Network::Address::IpVersion ip_version, bool v6onl
     makeFdBlocking(client_fd);
 
     // Connect to the server.
-    const Api::SysCallResult result = addr_port->connect(client_fd);
+    const Api::SysCallIntResult result = addr_port->connect(client_fd);
     ASSERT_EQ(result.rc_, 0) << addr_port->asString() << "\nerror: " << strerror(result.errno_)
                              << "\nerrno: " << result.errno_;
   };
@@ -314,7 +314,7 @@ TEST(PipeInstanceTest, UnlinksExistingFile) {
     ASSERT_GE(listen_fd, 0) << address.asString();
     ScopedFdCloser closer(listen_fd);
 
-    const Api::SysCallResult result = address.bind(listen_fd);
+    const Api::SysCallIntResult result = address.bind(listen_fd);
     ASSERT_EQ(result.rc_, 0) << address.asString() << "\nerror: " << strerror(result.errno_)
                              << "\nerrno: " << result.errno_;
   };

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -358,8 +358,8 @@ public:
   }
   const std::string& asString() const override { return antagonistic_name_; }
   const std::string& logicalName() const override { return antagonistic_name_; }
-  Api::SysCallResult bind(int fd) const override { return instance_.bind(fd); }
-  Api::SysCallResult connect(int fd) const override { return instance_.connect(fd); }
+  Api::SysCallIntResult bind(int fd) const override { return instance_.bind(fd); }
+  Api::SysCallIntResult connect(int fd) const override { return instance_.connect(fd); }
   const Address::Ip* ip() const override { return instance_.ip(); }
   int socket(Address::SocketType type) const override { return instance_.socket(type); }
   Address::Type type() const override { return instance_.type(); }

--- a/test/common/network/socket_option_impl_test.cc
+++ b/test/common/network/socket_option_impl_test.cc
@@ -8,7 +8,7 @@ class SocketOptionImplTest : public SocketOptionTest {};
 
 TEST_F(SocketOptionImplTest, BadFd) {
   absl::string_view zero("\0\0\0\0", 4);
-  Api::SysCallResult result = SocketOptionImpl::setSocketOption(socket_, {}, zero);
+  Api::SysCallIntResult result = SocketOptionImpl::setSocketOption(socket_, {}, zero);
   EXPECT_EQ(-1, result.rc_);
   EXPECT_EQ(ENOTSUP, result.errno_);
 }

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
@@ -62,10 +62,10 @@ class FastMockOsSysCalls : public Api::MockOsSysCalls {
 public:
   FastMockOsSysCalls(const std::vector<uint8_t>& client_hello) : client_hello_(client_hello) {}
 
-  ssize_t recv(int, void* buffer, size_t length, int) override {
+  Api::SysCallSizeResult recv(int, void* buffer, size_t length, int) override {
     RELEASE_ASSERT(length >= client_hello_.size(), "");
     memcpy(buffer, client_hello_.data(), client_hello_.size());
-    return client_hello_.size();
+    return Api::SysCallSizeResult{ssize_t(client_hello_.size()), 0};
   }
 
   const std::vector<uint8_t> client_hello_;

--- a/test/mocks/api/mocks.h
+++ b/test/mocks/api/mocks.h
@@ -43,30 +43,33 @@ public:
   ~MockOsSysCalls();
 
   // Api::OsSysCalls
-  ssize_t write(int fd, const void* buffer, size_t num_bytes) override;
-  int open(const std::string& full_path, int flags, int mode) override;
-  int setsockopt(int sockfd, int level, int optname, const void* optval, socklen_t optlen) override;
-  int getsockopt(int sockfd, int level, int optname, void* optval, socklen_t* optlen) override;
+  SysCallSizeResult write(int fd, const void* buffer, size_t num_bytes) override;
+  SysCallIntResult open(const std::string& full_path, int flags, int mode) override;
+  SysCallIntResult setsockopt(int sockfd, int level, int optname, const void* optval,
+                              socklen_t optlen) override;
+  SysCallIntResult getsockopt(int sockfd, int level, int optname, void* optval,
+                              socklen_t* optlen) override;
 
-  MOCK_METHOD3(bind, int(int sockfd, const sockaddr* addr, socklen_t addrlen));
-  MOCK_METHOD3(ioctl, int(int sockfd, unsigned long int request, void* argp));
-  MOCK_METHOD1(close, int(int));
+  MOCK_METHOD3(bind, SysCallIntResult(int sockfd, const sockaddr* addr, socklen_t addrlen));
+  MOCK_METHOD3(ioctl, SysCallIntResult(int sockfd, unsigned long int request, void* argp));
+  MOCK_METHOD1(close, SysCallIntResult(int));
   MOCK_METHOD3(open_, int(const std::string& full_path, int flags, int mode));
   MOCK_METHOD3(write_, ssize_t(int, const void*, size_t));
-  MOCK_METHOD3(writev, ssize_t(int, const iovec*, int));
-  MOCK_METHOD3(readv, ssize_t(int, const iovec*, int));
-  MOCK_METHOD4(recv, ssize_t(int socket, void* buffer, size_t length, int flags));
+  MOCK_METHOD3(writev, SysCallSizeResult(int, const iovec*, int));
+  MOCK_METHOD3(readv, SysCallSizeResult(int, const iovec*, int));
+  MOCK_METHOD4(recv, SysCallSizeResult(int socket, void* buffer, size_t length, int flags));
 
-  MOCK_METHOD3(shmOpen, int(const char*, int, mode_t));
-  MOCK_METHOD1(shmUnlink, int(const char*));
-  MOCK_METHOD2(ftruncate, int(int fd, off_t length));
-  MOCK_METHOD6(mmap, void*(void* addr, size_t length, int prot, int flags, int fd, off_t offset));
-  MOCK_METHOD2(stat, int(const char* name, struct stat* stat));
+  MOCK_METHOD3(shmOpen, SysCallIntResult(const char*, int, mode_t));
+  MOCK_METHOD1(shmUnlink, SysCallIntResult(const char*));
+  MOCK_METHOD2(ftruncate, SysCallIntResult(int fd, off_t length));
+  MOCK_METHOD6(mmap, SysCallPtrResult(void* addr, size_t length, int prot, int flags, int fd,
+                                      off_t offset));
+  MOCK_METHOD2(stat, SysCallIntResult(const char* name, struct stat* stat));
   MOCK_METHOD5(setsockopt_,
                int(int sockfd, int level, int optname, const void* optval, socklen_t optlen));
   MOCK_METHOD5(getsockopt_,
                int(int sockfd, int level, int optname, void* optval, socklen_t* optlen));
-  MOCK_METHOD3(socket, int(int domain, int type, int protocol));
+  MOCK_METHOD3(socket, SysCallIntResult(int domain, int type, int protocol));
 
   size_t num_writes_;
   size_t num_open_;

--- a/test/mocks/buffer/mocks.h
+++ b/test/mocks/buffer/mocks.h
@@ -18,7 +18,7 @@ public:
   MockBufferBase();
   MockBufferBase(std::function<void()> below_low, std::function<void()> above_high);
 
-  MOCK_METHOD1(write, Api::SysCallResult(int fd));
+  MOCK_METHOD1(write, Api::SysCallIntResult(int fd));
   MOCK_METHOD1(move, void(Buffer::Instance& rhs));
   MOCK_METHOD2(move, void(Buffer::Instance& rhs, uint64_t length));
   MOCK_METHOD1(drain, void(uint64_t size));
@@ -26,8 +26,8 @@ public:
   void baseMove(Buffer::Instance& rhs) { BaseClass::move(rhs); }
   void baseDrain(uint64_t size) { BaseClass::drain(size); }
 
-  Api::SysCallResult trackWrites(int fd) {
-    Api::SysCallResult result = BaseClass::write(fd);
+  Api::SysCallIntResult trackWrites(int fd) {
+    Api::SysCallIntResult result = BaseClass::write(fd);
     if (result.rc_ > 0) {
       bytes_written_ += result.rc_;
     }
@@ -40,7 +40,7 @@ public:
   }
 
   // A convenience function to invoke on write() which fails the write with EAGAIN.
-  Api::SysCallResult failWrite(int) { return {-1, EAGAIN}; }
+  Api::SysCallIntResult failWrite(int) { return {-1, EAGAIN}; }
 
   int bytes_written() const { return bytes_written_; }
   uint64_t bytes_drained() const { return bytes_drained_; }

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -410,8 +410,8 @@ public:
     return asString() == other.asString();
   }
 
-  MOCK_CONST_METHOD1(bind, Api::SysCallResult(int));
-  MOCK_CONST_METHOD1(connect, Api::SysCallResult(int));
+  MOCK_CONST_METHOD1(bind, Api::SysCallIntResult(int));
+  MOCK_CONST_METHOD1(connect, Api::SysCallIntResult(int));
   MOCK_CONST_METHOD0(ip, Address::Ip*());
   MOCK_CONST_METHOD1(socket, int(Address::SocketType));
   MOCK_CONST_METHOD0(type, Address::Type());

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -29,10 +29,10 @@ public:
     EXPECT_CALL(os_sys_calls_, shmOpen(_, _, _));
     EXPECT_CALL(os_sys_calls_, ftruncate(_, _)).WillOnce(WithArg<1>(Invoke([this](off_t size) {
       buffer_.resize(size);
-      return 0;
+      return Api::SysCallIntResult{0, 0};
     })));
     EXPECT_CALL(os_sys_calls_, mmap(_, _, _, _, _, _)).WillOnce(InvokeWithoutArgs([this]() {
-      return buffer_.data();
+      return Api::SysCallPtrResult{buffer_.data(), 0};
     }));
     EXPECT_CALL(os_sys_calls_, bind(_, _, _));
     EXPECT_CALL(options_, statsOptions()).WillRepeatedly(ReturnRef(stats_options_));
@@ -142,7 +142,8 @@ TEST_F(HotRestartImplTest, crossAlloc) {
 
   EXPECT_CALL(options_, restartEpoch()).WillRepeatedly(Return(1));
   EXPECT_CALL(os_sys_calls_, shmOpen(_, _, _));
-  EXPECT_CALL(os_sys_calls_, mmap(_, _, _, _, _, _)).WillOnce(Return(buffer_.data()));
+  EXPECT_CALL(os_sys_calls_, mmap(_, _, _, _, _, _))
+      .WillOnce(Return(Api::SysCallPtrResult{buffer_.data(), 0}));
   EXPECT_CALL(os_sys_calls_, bind(_, _, _));
   HotRestartImpl hot_restart2(options_);
   Stats::RawStatData* stat1_prime = hot_restart2.alloc("stat1");

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -426,8 +426,8 @@ TEST_F(ListenerManagerImplTest, AddListenerOnIpv4OnlySetups) {
 
   ListenerHandle* listener_foo = expectListenerCreate(false);
 
-  EXPECT_CALL(os_sys_calls, socket(AF_INET, _, 0)).WillOnce(Return(5));
-  EXPECT_CALL(os_sys_calls, socket(AF_INET6, _, 0)).WillOnce(Return(-1));
+  EXPECT_CALL(os_sys_calls, socket(AF_INET, _, 0)).WillOnce(Return(Api::SysCallIntResult{5, 0}));
+  EXPECT_CALL(os_sys_calls, socket(AF_INET6, _, 0)).WillOnce(Return(Api::SysCallIntResult{-1, 0}));
 
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
 
@@ -456,8 +456,8 @@ TEST_F(ListenerManagerImplTest, AddListenerOnIpv6OnlySetups) {
 
   ListenerHandle* listener_foo = expectListenerCreate(false);
 
-  EXPECT_CALL(os_sys_calls, socket(AF_INET, _, 0)).WillOnce(Return(-1));
-  EXPECT_CALL(os_sys_calls, socket(AF_INET6, _, 0)).WillOnce(Return(5));
+  EXPECT_CALL(os_sys_calls, socket(AF_INET, _, 0)).WillOnce(Return(Api::SysCallIntResult{-1, 0}));
+  EXPECT_CALL(os_sys_calls, socket(AF_INET6, _, 0)).WillOnce(Return(Api::SysCallIntResult{5, 0}));
 
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
 

--- a/test/test_common/network_utility.cc
+++ b/test/test_common/network_utility.cc
@@ -31,7 +31,7 @@ Address::InstanceConstSharedPtr findOrCheckFreePort(Address::InstanceConstShared
   // Not setting REUSEADDR, therefore if the address has been recently used we won't reuse it here.
   // However, because we're going to use the address while checking if it is available, we'll need
   // to set REUSEADDR on listener sockets created by tests using an address validated by this means.
-  Api::SysCallResult result = addr_port->bind(fd);
+  Api::SysCallIntResult result = addr_port->bind(fd);
   int err;
   const char* failing_fn = nullptr;
   if (result.rc_ != 0) {
@@ -156,7 +156,7 @@ std::pair<Address::InstanceConstSharedPtr, int> bindFreeLoopbackPort(Address::Ip
                                                                      Address::SocketType type) {
   Address::InstanceConstSharedPtr addr = getCanonicalLoopbackAddress(version);
   const int fd = addr->socket(type);
-  Api::SysCallResult result = addr->bind(fd);
+  Api::SysCallIntResult result = addr->bind(fd);
   if (0 != result.rc_) {
     close(fd);
     std::string msg = fmt::format("bind failed for address {} with error: {} ({})",


### PR DESCRIPTION
*Description*:
This PR refactors `OsSysCalls` for deeper `errno` latching. See #3819 for more information.

* Introduce `SysCallIntResult`, `SysCallSizeResult` and `SysCallPtrResult`
* Refactor `OsSysCalls` routines to return appropriate `SysCallResult` types

Signed-off-by: Venil Noronha <veniln@vmware.com>

*Risk Level*: Low
*Testing*: Existing tests suffice
*Docs Changes*: N/A
*Release Notes*: N/A