### PR TITLE
Set content-type and content-length

### DIFF
--- a/source/common/config/http_subscription_impl.h
+++ b/source/common/config/http_subscription_impl.h
@@ -69,6 +69,9 @@ public:
     request.headers().insertMethod().value().setReference(Http::Headers::get().MethodValues.Post);
     request.headers().insertPath().value(path_);
     request.body().reset(new Buffer::OwnedImpl(MessageUtil::getJsonStringFromMessage(request_)));
+    request.headers().insertContentType().value().setReference(
+        Http::Headers::get().ContentTypeValues.Json);
+    request.headers().insertContentLength().value(request.body()->length());
   }
 
   void parseResponse(const Http::Message& response) override {

--- a/source/common/upstream/cds_subscription.cc
+++ b/source/common/upstream/cds_subscription.cc
@@ -29,9 +29,7 @@ void CdsSubscription::createRequest(Http::Message& request) {
       fmt::format("/v1/clusters/{}/{}", local_info_.clusterName(), local_info_.nodeName()));
   request.headers().insertContentType().value().setReference(
       Http::Headers::get().ContentTypeValues.Json);
-
-  const size_t empty_body_size = 0;
-  request.headers().insertContentLength().value(empty_body_size);
+  request.headers().insertContentLength().value(size_t(0));
 }
 
 void CdsSubscription::parseResponse(const Http::Message& response) {

--- a/source/common/upstream/cds_subscription.cc
+++ b/source/common/upstream/cds_subscription.cc
@@ -27,6 +27,11 @@ void CdsSubscription::createRequest(Http::Message& request) {
   request.headers().insertMethod().value().setReference(Http::Headers::get().MethodValues.Get);
   request.headers().insertPath().value(
       fmt::format("/v1/clusters/{}/{}", local_info_.clusterName(), local_info_.nodeName()));
+  request.headers().insertContentType().value().setReference(
+      Http::Headers::get().ContentTypeValues.Json);
+
+  const size_t empty_body_size = 0;
+  request.headers().insertContentLength().value(empty_body_size);
 }
 
 void CdsSubscription::parseResponse(const Http::Message& response) {

--- a/source/common/upstream/sds_subscription.cc
+++ b/source/common/upstream/sds_subscription.cc
@@ -85,6 +85,11 @@ void SdsSubscription::createRequest(Http::Message& message) {
 
   message.headers().insertMethod().value().setReference(Http::Headers::get().MethodValues.Get);
   message.headers().insertPath().value("/v1/registration/" + cluster_name_);
+  message.headers().insertContentType().value().setReference(
+      Http::Headers::get().ContentTypeValues.Json);
+
+  const size_t empty_body_size = 0;
+  message.headers().insertContentLength().value(empty_body_size);
 }
 
 void SdsSubscription::onFetchComplete() {

--- a/source/common/upstream/sds_subscription.cc
+++ b/source/common/upstream/sds_subscription.cc
@@ -87,9 +87,7 @@ void SdsSubscription::createRequest(Http::Message& message) {
   message.headers().insertPath().value("/v1/registration/" + cluster_name_);
   message.headers().insertContentType().value().setReference(
       Http::Headers::get().ContentTypeValues.Json);
-
-  const size_t empty_body_size = 0;
-  message.headers().insertContentLength().value(empty_body_size);
+  message.headers().insertContentLength().value(size_t(0));
 }
 
 void SdsSubscription::onFetchComplete() {

--- a/source/server/lds_subscription.cc
+++ b/source/server/lds_subscription.cc
@@ -30,6 +30,11 @@ void LdsSubscription::createRequest(Http::Message& request) {
   request.headers().insertMethod().value().setReference(Http::Headers::get().MethodValues.Get);
   request.headers().insertPath().value(
       fmt::format("/v1/listeners/{}/{}", local_info_.clusterName(), local_info_.nodeName()));
+  request.headers().insertContentType().value().setReference(
+      Http::Headers::get().ContentTypeValues.Json);
+
+  const size_t empty_body_size = 0;
+  request.headers().insertContentLength().value(empty_body_size);
 }
 
 void LdsSubscription::parseResponse(const Http::Message& response) {

--- a/source/server/lds_subscription.cc
+++ b/source/server/lds_subscription.cc
@@ -32,9 +32,7 @@ void LdsSubscription::createRequest(Http::Message& request) {
       fmt::format("/v1/listeners/{}/{}", local_info_.clusterName(), local_info_.nodeName()));
   request.headers().insertContentType().value().setReference(
       Http::Headers::get().ContentTypeValues.Json);
-
-  const size_t empty_body_size = 0;
-  request.headers().insertContentLength().value(empty_body_size);
+  request.headers().insertContentLength().value(size_t(0));
 }
 
 void LdsSubscription::parseResponse(const Http::Message& response) {

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -59,6 +59,8 @@ public:
           http_callbacks_ = &callbacks;
           UNREFERENCED_PARAMETER(timeout);
           EXPECT_EQ("POST", std::string(request->headers().Method()->value().c_str()));
+          EXPECT_EQ(Http::Headers::get().ContentTypeValues.Json,
+                    std::string(request->headers().ContentType()->value().c_str()));
           EXPECT_EQ("eds_cluster", std::string(request->headers().Host()->value().c_str()));
           EXPECT_EQ("/v2/discovery:endpoints",
                     std::string(request->headers().Path()->value().c_str()));
@@ -73,6 +75,8 @@ public:
           }
           expected_request += "}";
           EXPECT_EQ(expected_request, request->bodyAsString());
+          EXPECT_EQ(fmt::FormatInt(expected_request.size()).str(),
+                    std::string(request->headers().ContentLength()->value().c_str()));
           request_in_progress_ = true;
           return &http_request_;
         }));

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -77,15 +77,16 @@ public:
         .WillOnce(Invoke(
             [&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
                 const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
-              EXPECT_EQ((Http::TestHeaderMapImpl{
-                            {":method", v2_rest_ ? "POST" : "GET"},
-                            {":path", v2_rest_ ? "/v2/discovery:clusters"
-                                               : "/v1/clusters/cluster_name/node_name"},
-                            {":authority", "foo_cluster"},
-                            {"content-type", "application/json"},
-                            {"content-length",
-                             v2_rest_ ? fmt::FormatInt(request->body()->length()).str() : "0"}}),
-                        request->headers());
+              EXPECT_EQ(
+                  (Http::TestHeaderMapImpl{
+                      {":method", v2_rest_ ? "POST" : "GET"},
+                      {":path",
+                       v2_rest_ ? "/v2/discovery:clusters" : "/v1/clusters/cluster_name/node_name"},
+                      {":authority", "foo_cluster"},
+                      {"content-type", "application/json"},
+                      {"content-length",
+                       request->body() ? fmt::FormatInt(request->body()->length()).str() : "0"}}),
+                  request->headers());
               callbacks_ = &callbacks;
               return &request_;
             }));

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -77,12 +77,17 @@ public:
         .WillOnce(Invoke(
             [&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
                 const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
-              EXPECT_EQ((Http::TestHeaderMapImpl{
-                            {":method", v2_rest_ ? "POST" : "GET"},
-                            {":path", v2_rest_ ? "/v2/discovery:clusters"
-                                               : "/v1/clusters/cluster_name/node_name"},
-                            {":authority", "foo_cluster"}}),
-                        request->headers());
+              Http::TestHeaderMapImpl expected_headers{
+                  {":method", v2_rest_ ? "POST" : "GET"},
+                  {":path",
+                   v2_rest_ ? "/v2/discovery:clusters" : "/v1/clusters/cluster_name/node_name"},
+                  {":authority", "foo_cluster"}};
+              if (v2_rest_) {
+                expected_headers.addCopy("content-type", "application/json");
+                expected_headers.addCopy("content-length",
+                                         fmt::FormatInt(request->body()->length()).str());
+              }
+              EXPECT_EQ(expected_headers, request->headers());
               callbacks_ = &callbacks;
               return &request_;
             }));

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -77,17 +77,15 @@ public:
         .WillOnce(Invoke(
             [&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
                 const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
-              Http::TestHeaderMapImpl expected_headers{
-                  {":method", v2_rest_ ? "POST" : "GET"},
-                  {":path",
-                   v2_rest_ ? "/v2/discovery:clusters" : "/v1/clusters/cluster_name/node_name"},
-                  {":authority", "foo_cluster"}};
-              if (v2_rest_) {
-                expected_headers.addCopy("content-type", "application/json");
-                expected_headers.addCopy("content-length",
-                                         fmt::FormatInt(request->body()->length()).str());
-              }
-              EXPECT_EQ(expected_headers, request->headers());
+              EXPECT_EQ((Http::TestHeaderMapImpl{
+                            {":method", v2_rest_ ? "POST" : "GET"},
+                            {":path", v2_rest_ ? "/v2/discovery:clusters"
+                                               : "/v1/clusters/cluster_name/node_name"},
+                            {":authority", "foo_cluster"},
+                            {"content-type", "application/json"},
+                            {"content-length",
+                             v2_rest_ ? fmt::FormatInt(request->body()->length()).str() : "0"}}),
+                        request->headers());
               callbacks_ = &callbacks;
               return &request_;
             }));

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -82,15 +82,16 @@ public:
         .WillOnce(Invoke(
             [&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
                 const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
-              EXPECT_EQ((Http::TestHeaderMapImpl{
-                            {":method", v2_rest_ ? "POST" : "GET"},
-                            {":path", v2_rest_ ? "/v2/discovery:listeners"
-                                               : "/v1/listeners/cluster_name/node_name"},
-                            {":authority", "foo_cluster"},
-                            {"content-type", "application/json"},
-                            {"content-length",
-                             v2_rest_ ? fmt::FormatInt(request->body()->length()).str() : "0"}}),
-                        request->headers());
+              EXPECT_EQ(
+                  (Http::TestHeaderMapImpl{
+                      {":method", v2_rest_ ? "POST" : "GET"},
+                      {":path", v2_rest_ ? "/v2/discovery:listeners"
+                                         : "/v1/listeners/cluster_name/node_name"},
+                      {":authority", "foo_cluster"},
+                      {"content-type", "application/json"},
+                      {"content-length",
+                       request->body() ? fmt::FormatInt(request->body()->length()).str() : "0"}}),
+                  request->headers());
               callbacks_ = &callbacks;
               return &request_;
             }));

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -82,17 +82,15 @@ public:
         .WillOnce(Invoke(
             [&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
                 const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
-              Http::TestHeaderMapImpl expected_headers{
-                  {":method", v2_rest_ ? "POST" : "GET"},
-                  {":path",
-                   v2_rest_ ? "/v2/discovery:listeners" : "/v1/listeners/cluster_name/node_name"},
-                  {":authority", "foo_cluster"}};
-              if (v2_rest_) {
-                expected_headers.addCopy("content-type", "application/json");
-                expected_headers.addCopy("content-length",
-                                         fmt::FormatInt(request->body()->length()).str());
-              }
-              EXPECT_EQ(expected_headers, request->headers());
+              EXPECT_EQ((Http::TestHeaderMapImpl{
+                            {":method", v2_rest_ ? "POST" : "GET"},
+                            {":path", v2_rest_ ? "/v2/discovery:listeners"
+                                               : "/v1/listeners/cluster_name/node_name"},
+                            {":authority", "foo_cluster"},
+                            {"content-type", "application/json"},
+                            {"content-length",
+                             v2_rest_ ? fmt::FormatInt(request->body()->length()).str() : "0"}}),
+                        request->headers());
               callbacks_ = &callbacks;
               return &request_;
             }));

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -82,12 +82,17 @@ public:
         .WillOnce(Invoke(
             [&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
                 const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
-              EXPECT_EQ((Http::TestHeaderMapImpl{
-                            {":method", v2_rest_ ? "POST" : "GET"},
-                            {":path", v2_rest_ ? "/v2/discovery:listeners"
-                                               : "/v1/listeners/cluster_name/node_name"},
-                            {":authority", "foo_cluster"}}),
-                        request->headers());
+              Http::TestHeaderMapImpl expected_headers{
+                  {":method", v2_rest_ ? "POST" : "GET"},
+                  {":path",
+                   v2_rest_ ? "/v2/discovery:listeners" : "/v1/listeners/cluster_name/node_name"},
+                  {":authority", "foo_cluster"}};
+              if (v2_rest_) {
+                expected_headers.addCopy("content-type", "application/json");
+                expected_headers.addCopy("content-length",
+                                         fmt::FormatInt(request->body()->length()).str());
+              }
+              EXPECT_EQ(expected_headers, request->headers());
               callbacks_ = &callbacks;
               return &request_;
             }));


### PR DESCRIPTION
*Description*:
This patch sets the content-type and content-length of HTTP subscription
requests.
*Risk Level*: Low
*Testing*: Added
*Docs Changes*: N/A
*Release Notes*: N/A

Fixes #4112

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>