### PR TITLE
ssl: refactor ContextConfig to use TlsCertificateConfig

### DIFF
--- a/include/envoy/ssl/BUILD
+++ b/include/envoy/ssl/BUILD
@@ -21,6 +21,9 @@ envoy_cc_library(
 envoy_cc_library(
     name = "context_config_interface",
     hdrs = ["context_config.h"],
+    deps = [
+        ":tls_certificate_config_interface",
+    ],
 )
 
 envoy_cc_library(

--- a/include/envoy/ssl/context_config.h
+++ b/include/envoy/ssl/context_config.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "envoy/common/pure.h"
+#include "envoy/ssl/tls_certificate_config.h"
 
 namespace Envoy {
 namespace Ssl {
@@ -60,28 +61,10 @@ public:
    */
   virtual const std::string& certificateRevocationListPath() const PURE;
 
-  // TODO(lizan): consider refactor 4 methods below to Ssl::TlsCertificateConfig
   /**
-   * @return The certificate chain used to identify the local side.
+   * @return TlsCertificateConfig the certificate config used to identify the local side.
    */
-  virtual const std::string& certChain() const PURE;
-
-  /**
-   * @return Path of the certificate chain used to identify the local side or "<inline>"
-   * if the certificate chain was inlined.
-   */
-  virtual const std::string& certChainPath() const PURE;
-
-  /**
-   * @return The private key used to identify the local side.
-   */
-  virtual const std::string& privateKey() const PURE;
-
-  /**
-   * @return Path of the private key used to identify the local side or "<inline>"
-   * if the private key was inlined.
-   */
-  virtual const std::string& privateKeyPath() const PURE;
+  virtual const TlsCertificateConfig* tlsCertificate() const PURE;
 
   /**
    * @return The subject alt names to be verified, if enabled. Otherwise, ""

--- a/source/common/ssl/context_config_impl.h
+++ b/source/common/ssl/context_config_impl.h
@@ -35,24 +35,8 @@ public:
                ? INLINE_STRING
                : certificate_revocation_list_path_;
   }
-  const std::string& certChain() const override {
-    return tls_certficate_provider_ == nullptr
-               ? EMPTY_STRING
-               : tls_certficate_provider_->secret()->certificateChain();
-  }
-  const std::string& certChainPath() const override {
-    return tls_certficate_provider_ == nullptr
-               ? EMPTY_STRING
-               : tls_certficate_provider_->secret()->certificateChainPath();
-  }
-  const std::string& privateKey() const override {
-    return tls_certficate_provider_ == nullptr ? EMPTY_STRING
-                                               : tls_certficate_provider_->secret()->privateKey();
-  }
-  const std::string& privateKeyPath() const override {
-    return tls_certficate_provider_ == nullptr
-               ? EMPTY_STRING
-               : tls_certficate_provider_->secret()->privateKeyPath();
+  const TlsCertificateConfig* tlsCertificate() const override {
+    return tls_certficate_provider_ == nullptr ? nullptr : tls_certficate_provider_->secret();
   }
   const std::vector<std::string>& verifySubjectAltNameList() const override {
     return verify_subject_alt_name_list_;

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -445,10 +445,10 @@ tls_certificate:
 
   const std::string cert_pem = "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_cert.pem";
   EXPECT_EQ(TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(cert_pem)),
-            client_context_config.certChain());
+            client_context_config.tlsCertificate()->certificateChain());
   const std::string key_pem = "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_key.pem";
   EXPECT_EQ(TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(key_pem)),
-            client_context_config.privateKey());
+            client_context_config.tlsCertificate()->privateKey());
 }
 
 TEST(ClientContextConfigImplTest, MissingStaticSecretTlsCertificates) {


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <zlizan@google.com>

*Description*:
Follow up of #4086, make context config cleaner.

*Risk Level*: Low
*Testing*: unit test, integration test
*Docs Changes*: N/A
*Release Notes*: N/A
