### PR TITLE
perf: reduce the memory usage of LC Trie construction

### DIFF
--- a/source/common/network/lc_trie.h
+++ b/source/common/network/lc_trie.h
@@ -446,13 +446,12 @@ private:
       std::sort(ip_prefixes_.begin(), ip_prefixes_.end());
 
       // Build the trie_.
-      trie_.reserve(ip_prefixes_.size());
+      trie_.reserve(size_t(ip_prefixes_.size() / fill_factor_));
       uint32_t next_free_index = 1;
       buildRecursive(0u, 0u, ip_prefixes_.size(), 0u, next_free_index);
 
       // The value of next_free_index is the final size of the trie_.
       ASSERT(next_free_index <= trie_.size());
-      trie_.resize(next_free_index);
     }
 
     // Thin wrapper around computeBranch output to facilitate code readability.

--- a/source/common/network/lc_trie.h
+++ b/source/common/network/lc_trie.h
@@ -446,7 +446,7 @@ private:
       std::sort(ip_prefixes_.begin(), ip_prefixes_.end());
 
       // Build the trie_.
-      trie_.reserve(size_t(ip_prefixes_.size() / fill_factor_));
+      trie_.reserve(static_cast<size_t>(ip_prefixes_.size() / fill_factor_));
       uint32_t next_free_index = 1;
       buildRecursive(0u, 0u, ip_prefixes_.size(), 0u, next_free_index);
 

--- a/source/common/network/lc_trie.h
+++ b/source/common/network/lc_trie.h
@@ -452,6 +452,8 @@ private:
 
       // The value of next_free_index is the final size of the trie_.
       ASSERT(next_free_index <= trie_.size());
+      trie_.resize(next_free_index);
+      trie_.shrink_to_fit();
     }
 
     // Thin wrapper around computeBranch output to facilitate code readability.

--- a/source/common/network/lc_trie.h
+++ b/source/common/network/lc_trie.h
@@ -445,21 +445,14 @@ private:
       ip_prefixes_ = data;
       std::sort(ip_prefixes_.begin(), ip_prefixes_.end());
 
-      // In theory, the trie_ vector can have at most twice the number of ip_prefixes entries - 1.
-      // However, due to the fill factor a buffer is added to the size of the
-      // trie_. The buffer value(2000000) is reused from the reference implementation in
-      // http://www.csc.kth.se/~snilsson/software/router/C/trie.c.
-      // TODO(ccaraman): Define a better buffer value when resizing the trie_.
-      maximum_trie_node_size = 2 * ip_prefixes_.size() + 2000000;
-      trie_.resize(maximum_trie_node_size);
-
       // Build the trie_.
+      trie_.reserve(ip_prefixes_.size());
       uint32_t next_free_index = 1;
       buildRecursive(0u, 0u, ip_prefixes_.size(), 0u, next_free_index);
 
       // The value of next_free_index is the final size of the trie_.
+      ASSERT(next_free_index <= trie_.size());
       trie_.resize(next_free_index);
-      trie_.shrink_to_fit();
     }
 
     // Thin wrapper around computeBranch output to facilitate code readability.
@@ -575,21 +568,23 @@ private:
      */
     void buildRecursive(uint32_t prefix, uint32_t first, uint32_t n, uint32_t position,
                         uint32_t& next_free_index) {
-      // Setting a leaf, the branch and skip are 0.
-      if (n == 1) {
+      if (position >= trie_.size()) {
         // There is no way to predictably determine the number of trie nodes required to build a
         // LC-Trie. If while building the trie the position that is being set exceeds the maximum
         // number of supported trie_ entries, throw an Envoy Exception.
-        if (position >= maximum_trie_node_size) {
+        if (position >= MaxLcTrieNodes) {
           // Adding 1 to the position to count how many nodes are trying to be set.
           throw EnvoyException(
               fmt::format("The number of internal nodes required for the LC-Trie "
                           "exceeded the maximum number of "
                           "supported nodes. Minimum number of internal nodes required: "
                           "'{0}'. Maximum number of supported nodes: '{1}'.",
-                          (position + 1), maximum_trie_node_size));
+                          (position + 1), MaxLcTrieNodes));
         }
-
+        trie_.resize(position + 1);
+      }
+      // Setting a leaf, the branch and skip are 0.
+      if (n == 1) {
         trie_[position].address_ = first;
         return;
       }
@@ -681,10 +676,6 @@ private:
       uint32_t skip_ : 7;
       uint32_t address_ : 20; // If this 20-bit size changes, please change MaxLcTrieNodes too.
     };
-
-    // During build(), an estimate of the number of nodes required will be made and set this
-    // value. This is used to ensure no out_of_range exception is thrown.
-    uint32_t maximum_trie_node_size;
 
     // The CIDR range and data needs to be maintained separately from the LC-Trie. A LC-Trie skips
     // chunks of data while searching for a match. This means that the node found in the LC-Trie

--- a/test/common/network/lc_trie_speed_test.cc
+++ b/test/common/network/lc_trie_speed_test.cc
@@ -12,9 +12,14 @@ std::vector<std::pair<std::string, std::vector<Envoy::Network::Address::CidrRang
 std::vector<std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>>
     tag_data_nested_prefixes;
 
+std::vector<std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>>
+    tag_data_minimal;
+
 std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie;
 
 std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie_nested_prefixes;
+
+std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie_minimal;
 
 } // namespace
 
@@ -41,12 +46,10 @@ static void BM_LcTrieConstructNested(benchmark::State& state) {
 BENCHMARK(BM_LcTrieConstructNested);
 
 static void BM_LcTrieConstructMinimal(benchmark::State& state) {
-  std::vector<std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>> tags;
-  tags.emplace_back(std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>(
-      {"tag_1", {Envoy::Network::Address::CidrRange::create("0.0.0.0/0")}}));
+
   std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> trie;
   for (auto _ : state) {
-    trie = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(tags);
+    trie = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(tag_data_minimal);
   }
   benchmark::DoNotOptimize(trie);
 }
@@ -79,6 +82,19 @@ static void BM_LcTrieLookupWithNestedPrefixes(benchmark::State& state) {
 
 BENCHMARK(BM_LcTrieLookupWithNestedPrefixes);
 
+static void BM_LcTrieLookupMinimal(benchmark::State& state) {
+  static size_t i = 0;
+  size_t output_tags = 0;
+  for (auto _ : state) {
+    i++;
+    i %= addresses.size();
+    output_tags += lc_trie_minimal->getData(addresses[i]).size();
+  }
+  benchmark::DoNotOptimize(output_tags);
+}
+
+BENCHMARK(BM_LcTrieLookupMinimal);
+
 } // namespace Envoy
 
 // Boilerplate main(), which discovers benchmarks in the same file and runs them.
@@ -92,9 +108,10 @@ int main(int argc, char** argv) {
     addresses.push_back(Envoy::Network::Utility::parseInternetAddress(address));
   }
 
-  // Construct two sets of prefixes: one consisting of 1,024 addresses in an
-  // RFC 5737 netblock, the other consisting of those same addresses plus
-  // 0.0.0.0/0 (to exercise the LC Trie's support for nested prefixes)
+  // Construct three sets of prefixes: one consisting of 1,024 addresses in an
+  // RFC 5737 netblock, another consisting of those same addresses plus
+  // 0.0.0.0/0 (to exercise the LC Trie's support for nested prefixes),
+  // and finally a set containing only 0.0.0.0/0.
   for (int i = 0; i < 32; i++) {
     for (int j = 0; j < 32; j++) {
       tag_data.emplace_back(std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>(
@@ -106,10 +123,14 @@ int main(int argc, char** argv) {
   tag_data_nested_prefixes.emplace_back(
       std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>(
           {"tag_0", {Envoy::Network::Address::CidrRange::create("0.0.0.0/0")}}));
+  tag_data_minimal.emplace_back(
+      std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>(
+          {"tag_1", {Envoy::Network::Address::CidrRange::create("0.0.0.0/0")}}));
 
   lc_trie = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(tag_data);
   lc_trie_nested_prefixes =
       std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(tag_data_nested_prefixes);
+  lc_trie_minimal = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(tag_data_minimal);
 
   benchmark::Initialize(&argc, argv);
   if (benchmark::ReportUnrecognizedArguments(argc, argv)) {


### PR DESCRIPTION
*Description*:
Rather than preallocating a very large buffer to hold the LC Trie nodes
the way the reference implementation from the original  Nilsson & Karlsson
paper did, the trie construction now starts out with a size based on the
number of prefixes and lets the `std::vector` manage any needed reallocation
during trie construction.

In addition to using less memory during trie construction, this new approach
ended up being faster:

```
Benchmark                                  Time           CPU Iterations
-------------------------------------------------------------------------
Before:
BM_LcTrieConstruct                  26631971 ns   26522462 ns         26

After:
BM_LcTrieConstruct                   3654633 ns    3646942 ns        189
```

*Risk Level*: medium
*Testing*: unit tests plus new speed benchmark test
*Docs Changes*: N/A
*Release Notes*: N/A

Signed-off-by: Brian Pane <bpane@pinterest.com>
