### PR TITLE
docs: added cluster_name to load assignment config for static cluster

### DIFF
--- a/docs/root/configuration/overview/v2_overview.rst
+++ b/docs/root/configuration/overview/v2_overview.rst
@@ -96,6 +96,7 @@ A minimal fully static bootstrap config is provided below:
       type: STATIC
       lb_policy: ROUND_ROBIN
       load_assignment:
+        cluster_name: some_service
         endpoints:
         - lb_endpoints:
           - endpoint:
@@ -158,6 +159,7 @@ on 127.0.0.3:5678 is provided below:
       lb_policy: ROUND_ROBIN
       http2_protocol_options: {}
       load_assignment:
+        cluster_name: xds_cluster
         endpoints:
         - lb_endpoints:
           - endpoint:


### PR DESCRIPTION
Signed-off-by: Achmad Gozali <gozali@gmail.com>

*Description*: Missing cluster_name on load assignment config for static cluster. Related to https://github.com/envoyproxy/envoy/issues/4056
*Risk Level*: Low
*Testing*: Bazel build on Mac OS 10.13.6 
*Docs Changes*: N/A
*Release Notes*: N/A