### PR TITLE
header_map: copy constructor for HeaderMapImpl.

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -67,8 +67,7 @@ ConnectionManagerImpl::ConnectionManagerImpl(ConnectionManagerConfig& config,
 
 const HeaderMapImpl& ConnectionManagerImpl::continueHeader() {
   CONSTRUCT_ON_FIRST_USE(HeaderMapImpl,
-                         Http::HeaderMapImpl{{Http::Headers::get().Status,
-                                              std::to_string(enumToInt(Code::Continue))}});
+                         {Http::Headers::get().Status, std::to_string(enumToInt(Code::Continue))});
 }
 
 void ConnectionManagerImpl::initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) {

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -292,6 +292,9 @@ HeaderMapImpl::HeaderMapImpl(const HeaderMap& rhs) : HeaderMapImpl() {
       this);
 }
 
+HeaderMapImpl::HeaderMapImpl(const HeaderMapImpl& rhs)
+    : HeaderMapImpl(static_cast<const HeaderMap&>(rhs)) {}
+
 HeaderMapImpl::HeaderMapImpl(
     const std::initializer_list<std::pair<LowerCaseString, std::string>>& values)
     : HeaderMapImpl() {

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -207,17 +207,6 @@ HeaderMapImpl::HeaderEntryImpl::HeaderEntryImpl(const LowerCaseString& key, Head
 HeaderMapImpl::HeaderEntryImpl::HeaderEntryImpl(HeaderString&& key, HeaderString&& value)
     : key_(std::move(key)), value_(std::move(value)) {}
 
-HeaderMapImpl& HeaderMapImpl::operator=(const HeaderMapImpl& rhs) {
-  if (&rhs == this) {
-    return *this;
-  }
-
-  removePrefix(LowerCaseString(""));
-  copyFrom(rhs);
-
-  return *this;
-}
-
 void HeaderMapImpl::HeaderEntryImpl::value(const char* value, uint32_t size) {
   value_.setCopy(value, size);
 }
@@ -286,11 +275,6 @@ void HeaderMapImpl::appendToHeader(HeaderString& header, absl::string_view data)
 }
 
 HeaderMapImpl::HeaderMapImpl() { memset(&inline_headers_, 0, sizeof(inline_headers_)); }
-
-HeaderMapImpl::HeaderMapImpl(const HeaderMap& rhs) : HeaderMapImpl() { copyFrom(rhs); }
-
-HeaderMapImpl::HeaderMapImpl(const HeaderMapImpl& rhs)
-    : HeaderMapImpl(static_cast<const HeaderMap&>(rhs)) {}
 
 HeaderMapImpl::HeaderMapImpl(
     const std::initializer_list<std::pair<LowerCaseString, std::string>>& values)

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -207,6 +207,17 @@ HeaderMapImpl::HeaderEntryImpl::HeaderEntryImpl(const LowerCaseString& key, Head
 HeaderMapImpl::HeaderEntryImpl::HeaderEntryImpl(HeaderString&& key, HeaderString&& value)
     : key_(std::move(key)), value_(std::move(value)) {}
 
+HeaderMapImpl& HeaderMapImpl::operator=(const HeaderMapImpl& rhs) {
+  if (&rhs == this) {
+    return *this;
+  }
+
+  removePrefix(LowerCaseString(""));
+  copyFrom(rhs);
+
+  return *this;
+}
+
 void HeaderMapImpl::HeaderEntryImpl::value(const char* value, uint32_t size) {
   value_.setCopy(value, size);
 }
@@ -296,7 +307,7 @@ HeaderMapImpl::HeaderMapImpl(
 void HeaderMapImpl::copyFrom(const HeaderMap& header_map) {
   header_map.iterate(
       [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {
-        // TODO(mattklein123) PERF: Avoid copying here is not necessary.
+        // TODO(mattklein123) PERF: Avoid copying here if not necessary.
         HeaderString key_string;
         key_string.setCopy(header.key().c_str(), header.key().size());
         HeaderString value_string;

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -49,7 +49,11 @@ public:
   explicit HeaderMapImpl(
       const std::initializer_list<std::pair<LowerCaseString, std::string>>& values);
   HeaderMapImpl(const HeaderMap& rhs);
+  // The above constructor for HeaderMap is not an actual copy constructor. This also prevent the
+  // implicit move constructor, moving HeaderMapImpl is unsafe (see HeaderList comments).
   HeaderMapImpl(const HeaderMapImpl& rhs);
+  // Safe copy assignment; this is highly inefficient, don't use this except for tests.
+  HeaderMapImpl& operator=(const HeaderMapImpl& rhs);
 
   /**
    * Add a header via full move. This is the expected high performance paths for codecs populating

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -48,7 +48,7 @@ public:
   HeaderMapImpl();
   explicit HeaderMapImpl(
       const std::initializer_list<std::pair<LowerCaseString, std::string>>& values);
-  explicit HeaderMapImpl(const HeaderMap& rhs);
+  HeaderMapImpl(const HeaderMap& rhs);
   HeaderMapImpl(const HeaderMapImpl& rhs);
 
   /**
@@ -134,6 +134,11 @@ protected:
   /**
    * List of HeaderEntryImpl that keeps the pseudo headers (key starting with ':') in the front
    * of the list (as required by nghttp2) and otherwise maintains insertion order.
+   *
+   * Note: the internal iterators held in fields make this unsafe to copy and move. The NonCopyable
+   * will supress both copy and move constructors/assignment.
+   * TODO(htuch): Maybe we want this to movable one day; for now, our header map moves happen on
+   * HeaderMapPtr, so the performance impact should not be evident.
    */
   class HeaderList : NonCopyable {
   public:

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -135,8 +135,10 @@ protected:
    * List of HeaderEntryImpl that keeps the pseudo headers (key starting with ':') in the front
    * of the list (as required by nghttp2) and otherwise maintains insertion order.
    *
-   * Note: the internal iterators held in fields make this unsafe to copy and move. The NonCopyable
-   * will supress both copy and move constructors/assignment.
+   * Note: the internal iterators held in fields make this unsafe to copy and move, since the
+   * reference to end() is not preserved across a move (see Notes in
+   * https://en.cppreference.com/w/cpp/container/list/list). The NonCopyable will supress both copy
+   * and move constructors/assignment.
    * TODO(htuch): Maybe we want this to movable one day; for now, our header map moves happen on
    * HeaderMapPtr, so the performance impact should not be evident.
    */

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -46,8 +46,8 @@ public:
   static void appendToHeader(HeaderString& header, absl::string_view data);
 
   HeaderMapImpl();
-  HeaderMapImpl(const std::initializer_list<std::pair<LowerCaseString, std::string>>& values);
-  HeaderMapImpl(const HeaderMap& rhs);
+  explicit HeaderMapImpl(const std::initializer_list<std::pair<LowerCaseString, std::string>>& values);
+  explicit HeaderMapImpl(const HeaderMap& rhs);
   HeaderMapImpl(const HeaderMapImpl& rhs);
 
   /**

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -81,6 +81,7 @@ public:
   size_t size() const override { return headers_.size(); }
 
 protected:
+  // For tests only, unoptimized, they aren't intended for regular HeaderMapImpl users.
   void copyFrom(const HeaderMap& rhs);
   void clear() { removePrefix(LowerCaseString("")); }
 

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -48,6 +48,7 @@ public:
   HeaderMapImpl();
   HeaderMapImpl(const std::initializer_list<std::pair<LowerCaseString, std::string>>& values);
   HeaderMapImpl(const HeaderMap& rhs);
+  HeaderMapImpl(const HeaderMapImpl& rhs);
 
   /**
    * Add a header via full move. This is the expected high performance paths for codecs populating

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -81,6 +81,8 @@ public:
   size_t size() const override { return headers_.size(); }
 
 protected:
+  void copyFrom(const HeaderMap& rhs);
+
   struct HeaderEntryImpl : public HeaderEntry, NonCopyable {
     HeaderEntryImpl(const LowerCaseString& key);
     HeaderEntryImpl(const LowerCaseString& key, HeaderString&& value);
@@ -132,7 +134,7 @@ protected:
    * List of HeaderEntryImpl that keeps the pseudo headers (key starting with ':') in the front
    * of the list (as required by nghttp2) and otherwise maintains insertion order.
    */
-  class HeaderList {
+  class HeaderList : NonCopyable {
   public:
     HeaderList() : pseudo_headers_end_(headers_.end()) {}
 

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -35,7 +35,7 @@ public:                                                                         
  * paths use O(1) direct access. In general, we try to copy as little as possible and allocate as
  * little as possible in any of the paths.
  */
-class HeaderMapImpl : public HeaderMap {
+class HeaderMapImpl : public HeaderMap, NonCopyable {
 public:
   /**
    * Appends data to header. If header already has a value, the string ',' is added between the
@@ -48,12 +48,7 @@ public:
   HeaderMapImpl();
   explicit HeaderMapImpl(
       const std::initializer_list<std::pair<LowerCaseString, std::string>>& values);
-  HeaderMapImpl(const HeaderMap& rhs);
-  // The above constructor for HeaderMap is not an actual copy constructor. This also prevent the
-  // implicit move constructor, moving HeaderMapImpl is unsafe (see HeaderList comments).
-  HeaderMapImpl(const HeaderMapImpl& rhs);
-  // Safe copy assignment; this is highly inefficient, don't use this except for tests.
-  HeaderMapImpl& operator=(const HeaderMapImpl& rhs);
+  explicit HeaderMapImpl(const HeaderMap& rhs) : HeaderMapImpl() { copyFrom(rhs); }
 
   /**
    * Add a header via full move. This is the expected high performance paths for codecs populating
@@ -87,6 +82,7 @@ public:
 
 protected:
   void copyFrom(const HeaderMap& rhs);
+  void clear() { removePrefix(LowerCaseString("")); }
 
   struct HeaderEntryImpl : public HeaderEntry, NonCopyable {
     HeaderEntryImpl(const LowerCaseString& key);

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -46,7 +46,8 @@ public:
   static void appendToHeader(HeaderString& header, absl::string_view data);
 
   HeaderMapImpl();
-  explicit HeaderMapImpl(const std::initializer_list<std::pair<LowerCaseString, std::string>>& values);
+  explicit HeaderMapImpl(
+      const std::initializer_list<std::pair<LowerCaseString, std::string>>& values);
   explicit HeaderMapImpl(const HeaderMap& rhs);
   HeaderMapImpl(const HeaderMapImpl& rhs);
 

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -120,7 +120,7 @@ public:
       reply_headers->addReference(value.first, value.second);
     }
     expectInitialMetadata(metadata);
-    fake_stream_->encodeHeaders(*reply_headers, false);
+    fake_stream_->encodeHeaders(Http::HeaderMapImpl(*reply_headers), false);
   }
 
   void sendReply() {

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -854,7 +854,8 @@ TEST(HeaderMapImplTest, PseudoHeaderOrder) {
 }
 
 // Validate that [Test]HeaderMapImpl copy construction works. This is a
-// regression for where we were missing a valid copy constructor.
+// regression for where we were missing a valid copy constructor and had the
+// default (dangerous) move semantics takeover.
 TEST(HeaderMapImplTest, HeaderMapImplyCopy) {
   {
     HeaderMapImpl foo;

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -853,15 +853,15 @@ TEST(HeaderMapImplTest, PseudoHeaderOrder) {
   }
 }
 
-// Validate that HeaderMapImpl copy construction and assignment works. This is a
+// Validate that TestHeaderMapImpl copy construction and assignment works. This is a
 // regression for where we were missing a valid copy constructor and had the
 // default (dangerous) move semantics takeover.
-TEST(HeaderMapImplTest, HeaderMapImplyCopy) {
-  HeaderMapImpl foo;
+TEST(HeaderMapImplTest, TestHeaderMapImplyCopy) {
+  TestHeaderMapImpl foo;
   foo.addCopy(LowerCaseString("foo"), "bar");
-  auto headers = std::make_unique<HeaderMapImpl>(foo);
+  auto headers = std::make_unique<TestHeaderMapImpl>(foo);
   EXPECT_STREQ("bar", headers->get(LowerCaseString("foo"))->value().c_str());
-  HeaderMapImpl baz{{LowerCaseString("foo"), "baz"}};
+  TestHeaderMapImpl baz{{"foo", "baz"}};
   baz = *headers;
   EXPECT_STREQ("bar", baz.get(LowerCaseString("foo"))->value().c_str());
   baz = baz;

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -853,22 +853,19 @@ TEST(HeaderMapImplTest, PseudoHeaderOrder) {
   }
 }
 
-// Validate that [Test]HeaderMapImpl copy construction works. This is a
+// Validate that HeaderMapImpl copy construction and assignment works. This is a
 // regression for where we were missing a valid copy constructor and had the
 // default (dangerous) move semantics takeover.
 TEST(HeaderMapImplTest, HeaderMapImplyCopy) {
-  {
-    HeaderMapImpl foo;
-    foo.addCopy(LowerCaseString("foo"), "bar");
-    auto headers = std::make_unique<HeaderMapImpl>(foo);
-    EXPECT_STREQ("bar", headers->get(LowerCaseString("foo"))->value().c_str());
-  }
-  {
-    TestHeaderMapImpl foo;
-    foo.addCopy("foo", "bar");
-    auto headers = std::make_unique<TestHeaderMapImpl>(foo);
-    EXPECT_EQ("bar", headers->get_("foo"));
-  }
+  HeaderMapImpl foo;
+  foo.addCopy(LowerCaseString("foo"), "bar");
+  auto headers = std::make_unique<HeaderMapImpl>(foo);
+  EXPECT_STREQ("bar", headers->get(LowerCaseString("foo"))->value().c_str());
+  HeaderMapImpl baz{{LowerCaseString("foo"), "baz"}};
+  baz = *headers;
+  EXPECT_STREQ("bar", baz.get(LowerCaseString("foo"))->value().c_str());
+  baz = baz;
+  EXPECT_STREQ("bar", baz.get(LowerCaseString("foo"))->value().c_str());
 }
 
 } // namespace Http

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -853,5 +853,22 @@ TEST(HeaderMapImplTest, PseudoHeaderOrder) {
   }
 }
 
+// Validate that [Test]HeaderMapImpl copy construction works. This is a
+// regression for where we were missing a valid copy constructor.
+TEST(HeaderMapImplTest, HeaderMapImplyCopy) {
+  {
+    HeaderMapImpl foo;
+    foo.addCopy(LowerCaseString("foo"), "bar");
+    auto headers = std::make_unique<HeaderMapImpl>(foo);
+    EXPECT_STREQ("bar", headers->get(LowerCaseString("foo"))->value().c_str());
+  }
+  {
+    TestHeaderMapImpl foo;
+    foo.addCopy("foo", "bar");
+    auto headers = std::make_unique<TestHeaderMapImpl>(foo);
+    EXPECT_EQ("bar", headers->get_("foo"));
+  }
+}
+
 } // namespace Http
 } // namespace Envoy

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -207,6 +207,20 @@ TestHeaderMapImpl::TestHeaderMapImpl(
 
 TestHeaderMapImpl::TestHeaderMapImpl(const HeaderMap& rhs) : HeaderMapImpl(rhs) {}
 
+TestHeaderMapImpl::TestHeaderMapImpl(const TestHeaderMapImpl& rhs)
+    : TestHeaderMapImpl(static_cast<const HeaderMap&>(rhs)) {}
+
+TestHeaderMapImpl& TestHeaderMapImpl::operator=(const TestHeaderMapImpl& rhs) {
+  if (&rhs == this) {
+    return *this;
+  }
+
+  clear();
+  copyFrom(rhs);
+
+  return *this;
+}
+
 void TestHeaderMapImpl::addCopy(const std::string& key, const std::string& value) {
   addCopy(LowerCaseString(key), value);
 }

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -207,6 +207,17 @@ TestHeaderMapImpl::TestHeaderMapImpl(
 
 TestHeaderMapImpl::TestHeaderMapImpl(const HeaderMap& rhs) : HeaderMapImpl(rhs) {}
 
+TestHeaderMapImpl& TestHeaderMapImpl::operator=(const TestHeaderMapImpl& other) {
+  if (&other == this) {
+    return *this;
+  }
+
+  removePrefix(LowerCaseString(""));
+  copyFrom(other);
+
+  return *this;
+}
+
 void TestHeaderMapImpl::addCopy(const std::string& key, const std::string& value) {
   addCopy(LowerCaseString(key), value);
 }

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -207,17 +207,6 @@ TestHeaderMapImpl::TestHeaderMapImpl(
 
 TestHeaderMapImpl::TestHeaderMapImpl(const HeaderMap& rhs) : HeaderMapImpl(rhs) {}
 
-TestHeaderMapImpl& TestHeaderMapImpl::operator=(const TestHeaderMapImpl& other) {
-  if (&other == this) {
-    return *this;
-  }
-
-  removePrefix(LowerCaseString(""));
-  copyFrom(other);
-
-  return *this;
-}
-
 void TestHeaderMapImpl::addCopy(const std::string& key, const std::string& value) {
   addCopy(LowerCaseString(key), value);
 }

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -323,6 +323,12 @@ public:
   TestHeaderMapImpl(const std::initializer_list<std::pair<std::string, std::string>>& values);
   TestHeaderMapImpl(const HeaderMap& rhs);
 
+  // The above constructor for TestHeaderMap is not an actual copy constructor.
+  TestHeaderMapImpl(const TestHeaderMapImpl& rhs);
+  TestHeaderMapImpl& operator=(const TestHeaderMapImpl& rhs);
+
+  bool operator==(const TestHeaderMapImpl& rhs) const { return HeaderMapImpl::operator==(rhs); }
+
   friend std::ostream& operator<<(std::ostream& os, const TestHeaderMapImpl& p) {
     p.iterate(
         [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -323,8 +323,6 @@ public:
   TestHeaderMapImpl(const std::initializer_list<std::pair<std::string, std::string>>& values);
   TestHeaderMapImpl(const HeaderMap& rhs);
 
-  TestHeaderMapImpl& operator=(const TestHeaderMapImpl& other);
-
   friend std::ostream& operator<<(std::ostream& os, const TestHeaderMapImpl& p) {
     p.iterate(
         [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -320,8 +320,8 @@ namespace Http {
 class TestHeaderMapImpl : public HeaderMapImpl {
 public:
   TestHeaderMapImpl();
-  TestHeaderMapImpl(const std::initializer_list<std::pair<std::string, std::string>>& values);
-  TestHeaderMapImpl(const HeaderMap& rhs);
+  explicit TestHeaderMapImpl(const std::initializer_list<std::pair<std::string, std::string>>& values);
+  explicit TestHeaderMapImpl(const HeaderMap& rhs);
 
   TestHeaderMapImpl& operator=(const TestHeaderMapImpl& other);
 

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -320,7 +320,8 @@ namespace Http {
 class TestHeaderMapImpl : public HeaderMapImpl {
 public:
   TestHeaderMapImpl();
-  explicit TestHeaderMapImpl(const std::initializer_list<std::pair<std::string, std::string>>& values);
+  explicit TestHeaderMapImpl(
+      const std::initializer_list<std::pair<std::string, std::string>>& values);
   explicit TestHeaderMapImpl(const HeaderMap& rhs);
 
   TestHeaderMapImpl& operator=(const TestHeaderMapImpl& other);

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -323,6 +323,8 @@ public:
   TestHeaderMapImpl(const std::initializer_list<std::pair<std::string, std::string>>& values);
   TestHeaderMapImpl(const HeaderMap& rhs);
 
+  TestHeaderMapImpl& operator=(const TestHeaderMapImpl& other);
+
   friend std::ostream& operator<<(std::ostream& os, const TestHeaderMapImpl& p) {
     p.iterate(
         [](const HeaderEntry& header, void* context) -> HeaderMap::Iterate {

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -320,9 +320,8 @@ namespace Http {
 class TestHeaderMapImpl : public HeaderMapImpl {
 public:
   TestHeaderMapImpl();
-  explicit TestHeaderMapImpl(
-      const std::initializer_list<std::pair<std::string, std::string>>& values);
-  explicit TestHeaderMapImpl(const HeaderMap& rhs);
+  TestHeaderMapImpl(const std::initializer_list<std::pair<std::string, std::string>>& values);
+  TestHeaderMapImpl(const HeaderMap& rhs);
 
   TestHeaderMapImpl& operator=(const TestHeaderMapImpl& other);
 


### PR DESCRIPTION
Previously, since we had an implicitly deleted copy constructor, we picked up the implicitly created move constructor. This then performed a move operation on HeaderList, which is not safe to move because it contains iterator elements, which can point to end() and so are not safe when when moved, see the Notes in https://en.cppreference.com/w/cpp/container/list/list.

In this PR, we explicitly mark HeaderList as non-copyable (also suppresses the implicit move constructor), then provide an explicit copy constructor and assignment operator for TestHeaderImpl.

This appears to resolve the leak in https://github.com/envoyproxy/envoy/pull/4118.

Risk level: Low
Testing: Unit test added.

Signed-off-by: Harvey Tuch <htuch@google.com>