### PR TITLE
[thrift_proxy/router] Add service name matching to router implementation

### DIFF
--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
@@ -32,10 +32,13 @@ message RouteMatch {
   oneof match_specifier {
     option (validate.required) = true;
 
-    // If specified, the method name that should match this route.
+    // If specified, the route must exactly match the request method name. As a special case, an
+    // empty string matches any request method name.
     string method_name = 1;
 
-    // If specified, the service name that should match this route.
+    // If specified, the route must have the service name as the request method name prefix. As a
+    // special case, an empty string matches any service name. Only relevant when service
+    // multiplexing.
     string service_name = 2;
   }
 

--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
@@ -27,11 +27,19 @@ message Route {
   RouteAction route = 2 [(validate.rules).message.required = true, (gogoproto.nullable) = false];
 }
 
-// [#comment:next free field: 2]
+// [#comment:next free field: 4]
 message RouteMatch {
-  // If specified, the route must exactly match the request method name. As a special case, an
-  // empty string matches any request method name.
-  string method = 1;
+  oneof match_specifier {
+    option (validate.required) = true;
+
+    // If specified, the method name that should match this route.
+    string method_name = 1;
+
+    // If specified, the service name that should match this route.
+    string service_name = 2;
+  }
+
+  bool invert = 3;
 }
 
 // [#comment:next free field: 2]

--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
@@ -42,6 +42,8 @@ message RouteMatch {
     string service_name = 2;
   }
 
+  // Inverts whatever matching is done in match_specifier. Cannot be combined with wildcard matching
+  // as that would result in routes never being matched.
   bool invert = 3;
 }
 

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -39,18 +39,24 @@ RouteConstSharedPtr MethodNameRouteEntryImpl::matches(const MessageMetadata& met
 
   if (matches ^ invert_) {
     return clusterEntry();
-  } else {
-    return nullptr;
   }
+
+  return nullptr;
 }
 
 ServiceNameRouteEntryImpl::ServiceNameRouteEntryImpl(
     const envoy::config::filter::network::thrift_proxy::v2alpha1::Route& route)
   : RouteEntryImplBase(route),
-    service_name_(route.match().service_name()),
     invert_(route.match().invert()) {
-  if (service_name_.empty() && invert_) {
+  std::string service_name = route.match().service_name();
+  if (service_name.empty() && invert_) {
     throw EnvoyException("Cannot have an empty service name with inversion enabled");
+  }
+
+  if (!service_name.empty() && !StringUtil::endsWith(service_name.c_str(), ":")) {
+    service_name_ = service_name + ":";
+  } else {
+    service_name_ = service_name;
   }
 }
 
@@ -60,9 +66,9 @@ RouteConstSharedPtr ServiceNameRouteEntryImpl::matches(const MessageMetadata& me
 
   if (matches ^ invert_) {
     return clusterEntry();
-  } else {
-    return nullptr;
   }
+
+  return nullptr;
 }
 
 RouteMatcher::RouteMatcher(

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -1,10 +1,10 @@
-#include "common/common/utility.h"
-
 #include "extensions/filters/network/thrift_proxy/router/router_impl.h"
 
 #include "envoy/config/filter/network/thrift_proxy/v2alpha1/thrift_proxy.pb.h"
 #include "envoy/upstream/cluster_manager.h"
 #include "envoy/upstream/thread_local_cluster.h"
+
+#include "common/common/utility.h"
 
 #include "extensions/filters/network/thrift_proxy/app_exception_impl.h"
 
@@ -26,16 +26,16 @@ RouteConstSharedPtr RouteEntryImplBase::clusterEntry() const { return shared_fro
 
 MethodNameRouteEntryImpl::MethodNameRouteEntryImpl(
     const envoy::config::filter::network::thrift_proxy::v2alpha1::Route& route)
-  : RouteEntryImplBase(route),
-    method_name_(route.match().method_name()),
-    invert_(route.match().invert()) {
+    : RouteEntryImplBase(route), method_name_(route.match().method_name()),
+      invert_(route.match().invert()) {
   if (method_name_.empty() && invert_) {
     throw EnvoyException("Cannot have an empty method name with inversion enabled");
   }
 }
 
 RouteConstSharedPtr MethodNameRouteEntryImpl::matches(const MessageMetadata& metadata) const {
-  bool matches = method_name_.empty() || (metadata.hasMethodName() && metadata.methodName() == method_name_);
+  bool matches =
+      method_name_.empty() || (metadata.hasMethodName() && metadata.methodName() == method_name_);
 
   if (matches ^ invert_) {
     return clusterEntry();
@@ -46,8 +46,7 @@ RouteConstSharedPtr MethodNameRouteEntryImpl::matches(const MessageMetadata& met
 
 ServiceNameRouteEntryImpl::ServiceNameRouteEntryImpl(
     const envoy::config::filter::network::thrift_proxy::v2alpha1::Route& route)
-  : RouteEntryImplBase(route),
-    invert_(route.match().invert()) {
+    : RouteEntryImplBase(route), invert_(route.match().invert()) {
   std::string service_name = route.match().service_name();
   if (service_name.empty() && invert_) {
     throw EnvoyException("Cannot have an empty service name with inversion enabled");
@@ -62,7 +61,8 @@ ServiceNameRouteEntryImpl::ServiceNameRouteEntryImpl(
 
 RouteConstSharedPtr ServiceNameRouteEntryImpl::matches(const MessageMetadata& metadata) const {
   bool matches = service_name_.empty() ||
-    (metadata.hasMethodName() && StringUtil::startsWith(metadata.methodName().c_str(), service_name_));
+                 (metadata.hasMethodName() &&
+                  StringUtil::startsWith(metadata.methodName().c_str(), service_name_));
 
   if (matches ^ invert_) {
     return clusterEntry();

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -28,7 +28,11 @@ MethodNameRouteEntryImpl::MethodNameRouteEntryImpl(
     const envoy::config::filter::network::thrift_proxy::v2alpha1::Route& route)
   : RouteEntryImplBase(route),
     method_name_(route.match().method_name()),
-    invert_(route.match().invert()) {}
+    invert_(route.match().invert()) {
+  if (method_name_.empty() && invert_) {
+    throw EnvoyException("Cannot have an empty method name with inversion enabled");
+  }
+}
 
 RouteConstSharedPtr MethodNameRouteEntryImpl::matches(const MessageMetadata& metadata) const {
   bool matches = method_name_.empty() || (metadata.hasMethodName() && metadata.methodName() == method_name_);
@@ -44,7 +48,11 @@ ServiceNameRouteEntryImpl::ServiceNameRouteEntryImpl(
     const envoy::config::filter::network::thrift_proxy::v2alpha1::Route& route)
   : RouteEntryImplBase(route),
     service_name_(route.match().service_name()),
-    invert_(route.match().invert()) {}
+    invert_(route.match().invert()) {
+  if (service_name_.empty() && invert_) {
+    throw EnvoyException("Cannot have an empty service name with inversion enabled");
+  }
+}
 
 RouteConstSharedPtr ServiceNameRouteEntryImpl::matches(const MessageMetadata& metadata) const {
   bool matches = service_name_.empty() ||

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -47,12 +47,12 @@ RouteConstSharedPtr MethodNameRouteEntryImpl::matches(const MessageMetadata& met
 ServiceNameRouteEntryImpl::ServiceNameRouteEntryImpl(
     const envoy::config::filter::network::thrift_proxy::v2alpha1::Route& route)
     : RouteEntryImplBase(route), invert_(route.match().invert()) {
-  std::string service_name = route.match().service_name();
+  const std::string service_name = route.match().service_name();
   if (service_name.empty() && invert_) {
     throw EnvoyException("Cannot have an empty service name with inversion enabled");
   }
 
-  if (!service_name.empty() && !StringUtil::endsWith(service_name.c_str(), ":")) {
+  if (!service_name.empty() && !StringUtil::endsWith(service_name, ":")) {
     service_name_ = service_name + ":";
   } else {
     service_name_ = service_name;

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -22,24 +22,8 @@ namespace NetworkFilters {
 namespace ThriftProxy {
 namespace Router {
 
-/**
- * Base interface for something that matches MessageMetadata.
- */
-class Matchable {
-public:
-  virtual ~Matchable() {}
-
-  /**
-   * See if this object matches the incoming MessageMetadata.
-   * @param metadata supplies the MessageMetadata to match.
-   * @return true if input metadata match this object.
-   */
-  virtual RouteConstSharedPtr matches(const MessageMetadata& metadata) const PURE;
-};
-
 class RouteEntryImplBase : public RouteEntry,
                            public Route,
-                           public Matchable,
                            public std::enable_shared_from_this<RouteEntryImplBase> {
 public:
   RouteEntryImplBase(const envoy::config::filter::network::thrift_proxy::v2alpha1::Route& route);
@@ -49,6 +33,8 @@ public:
 
   // Router::Route
   const RouteEntry* routeEntry() const override;
+
+  virtual RouteConstSharedPtr matches(const MessageMetadata& metadata) const PURE;
 
 protected:
   RouteConstSharedPtr clusterEntry() const;
@@ -66,7 +52,7 @@ public:
 
   const std::string& methodName() const { return method_name_; }
 
-  // Router::Matchable
+  // RouteEntryImplBase
   RouteConstSharedPtr matches(const MessageMetadata& metadata) const override;
 
 private:
@@ -81,7 +67,7 @@ public:
 
   const std::string& serviceName() const { return service_name_; }
 
-  // Router::Matchable
+  // RouteEntryImplBase
   RouteConstSharedPtr matches(const MessageMetadata& metadata) const override;
 
 private:

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -85,7 +85,7 @@ public:
   RouteConstSharedPtr matches(const MessageMetadata& metadata) const override;
 
 private:
-  const std::string service_name_;
+  std::string service_name_;
   bool invert_;
 };
 

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -57,7 +57,7 @@ public:
 
 private:
   const std::string method_name_;
-  bool invert_;
+  const bool invert_;
 };
 
 class ServiceNameRouteEntryImpl : public RouteEntryImplBase {
@@ -72,7 +72,7 @@ public:
 
 private:
   std::string service_name_;
-  bool invert_;
+  const bool invert_;
 };
 
 class RouteMatcher {

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -57,6 +57,22 @@ public:
 
 private:
   const std::string method_name_;
+  bool invert_;
+};
+
+class ServiceNameRouteEntryImpl : public RouteEntryImplBase {
+public:
+  ServiceNameRouteEntryImpl(
+      const envoy::config::filter::network::thrift_proxy::v2alpha1::Route& route);
+
+  const std::string& serviceName() const { return service_name_; }
+
+  // RoutEntryImplBase
+  RouteConstSharedPtr matches(const MessageMetadata& metadata) const override;
+
+private:
+  const std::string service_name_;
+  bool invert_;
 };
 
 class RouteMatcher {

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -22,8 +22,24 @@ namespace NetworkFilters {
 namespace ThriftProxy {
 namespace Router {
 
+/**
+ * Base interface for something that matches MessageMetadata.
+ */
+class Matchable {
+public:
+  virtual ~Matchable() {}
+
+  /**
+   * See if this object matches the incoming MessageMetadata.
+   * @param metadata supplies the MessageMetadata to match.
+   * @return true if input metadata match this object.
+   */
+  virtual RouteConstSharedPtr matches(const MessageMetadata& metadata) const PURE;
+};
+
 class RouteEntryImplBase : public RouteEntry,
                            public Route,
+                           public Matchable,
                            public std::enable_shared_from_this<RouteEntryImplBase> {
 public:
   RouteEntryImplBase(const envoy::config::filter::network::thrift_proxy::v2alpha1::Route& route);
@@ -33,8 +49,6 @@ public:
 
   // Router::Route
   const RouteEntry* routeEntry() const override;
-
-  virtual RouteConstSharedPtr matches(const MessageMetadata& metadata) const PURE;
 
 protected:
   RouteConstSharedPtr clusterEntry() const;
@@ -52,7 +66,7 @@ public:
 
   const std::string& methodName() const { return method_name_; }
 
-  // RoutEntryImplBase
+  // Router::Matchable
   RouteConstSharedPtr matches(const MessageMetadata& metadata) const override;
 
 private:
@@ -67,7 +81,7 @@ public:
 
   const std::string& serviceName() const { return service_name_; }
 
-  // RoutEntryImplBase
+  // Router::Matchable
   RouteConstSharedPtr matches(const MessageMetadata& metadata) const override;
 
 private:

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -518,7 +518,7 @@ route_config:
   name: "routes"
   routes:
     - match:
-        method: name
+        method_name: name
       route:
         cluster: cluster
 )EOF";

--- a/test/extensions/filters/network/thrift_proxy/integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/integration_test.cc
@@ -318,8 +318,9 @@ TEST_P(ThriftConnManagerIntegrationTest, OnewayEarlyClose) {
   tcp_client->write(request_bytes_.toString());
   tcp_client->close();
 
+  FakeUpstream* expected_upstream = getExpectedUpstream(true);
   FakeRawConnectionPtr fake_upstream_connection;
-  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
+  ASSERT_TRUE(expected_upstream->waitForRawConnection(fake_upstream_connection));
   std::string data;
   ASSERT_TRUE(fake_upstream_connection->waitForData(request_bytes_.length(), &data));
   Buffer::OwnedImpl upstream_request(data);

--- a/test/extensions/filters/network/thrift_proxy/integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/integration_test.cc
@@ -46,7 +46,16 @@ public:
             route_config:
               name: "routes"
               routes:
-                - match: {}
+                - match:
+                    service_name: "svcname"
+                  route:
+                    cluster: "cluster_0"
+                - match:
+                    method_name: "execute"
+                  route:
+                    cluster: "cluster_0"
+                - match:
+                    method_name: "poke"
                   route:
                     cluster: "cluster_0"
       )EOF";

--- a/test/extensions/filters/network/thrift_proxy/integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/integration_test.cc
@@ -95,7 +95,6 @@ public:
     initializeCommon();
   }
 
-
   // We allocate as many upstreams as there are clusters, with each upstream being allocated
   // to clusters in the order they're defined in the bootstrap config.
   void initializeCommon() {

--- a/test/extensions/filters/network/thrift_proxy/integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/integration_test.cc
@@ -53,11 +53,11 @@ public:
                 - match:
                     method_name: "execute"
                   route:
-                    cluster: "cluster_0"
+                    cluster: "cluster_1"
                 - match:
                     method_name: "poke"
                   route:
-                    cluster: "cluster_0"
+                    cluster: "cluster_2"
       )EOF";
   }
 
@@ -82,8 +82,7 @@ public:
     preparePayloads(result_mode, "execute");
     ASSERT(request_bytes_.length() > 0);
     ASSERT(response_bytes_.length() > 0);
-
-    BaseIntegrationTest::initialize();
+    initializeCommon();
   }
 
   void initializeOneway() {
@@ -92,6 +91,25 @@ public:
     preparePayloads("success", "poke");
     ASSERT(request_bytes_.length() > 0);
     ASSERT(response_bytes_.length() == 0);
+
+    initializeCommon();
+  }
+
+
+  // We allocate as many upstreams as there are clusters, with each upstream being allocated
+  // to clusters in the order they're defined in the bootstrap config.
+  void initializeCommon() {
+    setUpstreamCount(3);
+
+    config_helper_.addConfigModifier([](envoy::config::bootstrap::v2::Bootstrap& bootstrap) {
+      auto* c1 = bootstrap.mutable_static_resources()->add_clusters();
+      c1->MergeFrom(bootstrap.static_resources().clusters()[0]);
+      c1->set_name("cluster_1");
+
+      auto* c2 = bootstrap.mutable_static_resources()->add_clusters();
+      c2->MergeFrom(bootstrap.static_resources().clusters()[0]);
+      c2->set_name("cluster_2");
+    });
 
     BaseIntegrationTest::initialize();
   }
@@ -149,6 +167,20 @@ protected:
     }
   }
 
+  // Multiplexed requests are handled by the service name route match,
+  // while oneway's are handled by the "poke" method. All other requests
+  // are handled by "execute".
+  FakeUpstream* getExpectedUpstream(bool oneway) {
+    int upstreamIdx = 1;
+    if (multiplexed_) {
+      upstreamIdx = 0;
+    } else if (oneway) {
+      upstreamIdx = 2;
+    }
+
+    return fake_upstreams_[upstreamIdx].get();
+  }
+
   std::string transport_;
   std::string protocol_;
   bool multiplexed_;
@@ -185,7 +217,8 @@ TEST_P(ThriftConnManagerIntegrationTest, Success) {
   tcp_client->write(request_bytes_.toString());
 
   FakeRawConnectionPtr fake_upstream_connection;
-  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
+  FakeUpstream* expected_upstream = getExpectedUpstream(false);
+  ASSERT_TRUE(expected_upstream->waitForRawConnection(fake_upstream_connection));
   std::string data;
   ASSERT_TRUE(fake_upstream_connection->waitForData(request_bytes_.length(), &data));
   Buffer::OwnedImpl upstream_request(data);
@@ -210,8 +243,9 @@ TEST_P(ThriftConnManagerIntegrationTest, IDLException) {
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
   tcp_client->write(request_bytes_.toString());
 
+  FakeUpstream* expected_upstream = getExpectedUpstream(false);
   FakeRawConnectionPtr fake_upstream_connection;
-  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
+  ASSERT_TRUE(expected_upstream->waitForRawConnection(fake_upstream_connection));
   std::string data;
   ASSERT_TRUE(fake_upstream_connection->waitForData(request_bytes_.length(), &data));
   Buffer::OwnedImpl upstream_request(data);
@@ -236,8 +270,9 @@ TEST_P(ThriftConnManagerIntegrationTest, Exception) {
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
   tcp_client->write(request_bytes_.toString());
 
+  FakeUpstream* expected_upstream = getExpectedUpstream(false);
   FakeRawConnectionPtr fake_upstream_connection;
-  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
+  ASSERT_TRUE(expected_upstream->waitForRawConnection(fake_upstream_connection));
   std::string data;
   ASSERT_TRUE(fake_upstream_connection->waitForData(request_bytes_.length(), &data));
   Buffer::OwnedImpl upstream_request(data);
@@ -262,8 +297,9 @@ TEST_P(ThriftConnManagerIntegrationTest, Oneway) {
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
   tcp_client->write(request_bytes_.toString());
 
+  FakeUpstream* expected_upstream = getExpectedUpstream(true);
   FakeRawConnectionPtr fake_upstream_connection;
-  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
+  ASSERT_TRUE(expected_upstream->waitForRawConnection(fake_upstream_connection));
   std::string data;
   ASSERT_TRUE(fake_upstream_connection->waitForData(request_bytes_.length(), &data));
   Buffer::OwnedImpl upstream_request(data);

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -901,7 +901,7 @@ routes:
   EXPECT_NE(nullptr, route);
   EXPECT_EQ("cluster1", route->routeEntry()->clusterName());
 
-  metadata.setMethodName("service2");
+  metadata.setMethodName("service2:method1");
   route = matcher.route(metadata);
   EXPECT_EQ(nullptr, route);
 }

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -688,7 +688,7 @@ TEST_P(ThriftRouterContainerTest, DecoderFilterCallbacks) {
   destroyRouter();
 }
 
-TEST(RouteMatcherTest, Route) {
+TEST(RouteMatcherTest, RouteByMethodNameWithNoInversion) {
   const std::string yaml = R"EOF(
 name: config
 routes:
@@ -724,7 +724,51 @@ routes:
   EXPECT_EQ("cluster2", route2->routeEntry()->clusterName());
 }
 
-TEST(RouteMatcherTest, RouteMatchAny) {
+TEST(RouteMatcherTest, RouteByMethodNameWithInversion) {
+  const std::string yaml = R"EOF(
+name: config
+routes:
+  - match:
+      method_name: "method1"
+    route:
+      cluster: "cluster1"
+  - match:
+      method_name: "method2"
+      invert: true
+    route:
+      cluster: "cluster2"
+)EOF";
+
+  envoy::config::filter::network::thrift_proxy::v2alpha1::RouteConfiguration config =
+      parseRouteConfigurationFromV2Yaml(yaml);
+
+  RouteMatcher matcher(config);
+  MessageMetadata metadata;
+  RouteConstSharedPtr route = matcher.route(metadata);
+  EXPECT_NE(nullptr, route);
+  EXPECT_EQ("cluster2", route->routeEntry()->clusterName());
+
+  metadata.setMethodName("unknown");
+  route = matcher.route(metadata);
+  EXPECT_NE(nullptr, route);
+  EXPECT_EQ("cluster2", route->routeEntry()->clusterName());
+
+  metadata.setMethodName("METHOD1");
+  route = matcher.route(metadata);
+  EXPECT_NE(nullptr, route);
+  EXPECT_EQ("cluster2", route->routeEntry()->clusterName());
+
+  metadata.setMethodName("method1");
+  route = matcher.route(metadata);
+  EXPECT_NE(nullptr, route);
+  EXPECT_EQ("cluster1", route->routeEntry()->clusterName());
+
+  metadata.setMethodName("method2");
+  route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+}
+
+TEST(RouteMatcherTest, RouteByAnyMethodNameWithNoInversion) {
   const std::string yaml = R"EOF(
 name: config
 routes:
@@ -762,6 +806,161 @@ routes:
     EXPECT_NE(nullptr, route2);
     EXPECT_EQ("cluster2", route2->routeEntry()->clusterName());
   }
+}
+
+TEST(RouteMatcherTest, RouteByAnyMethodNameWithInversion) {
+  const std::string yaml = R"EOF(
+name: config
+routes:
+  - match:
+      method_name: ""
+      invert: true
+    route:
+      cluster: "cluster2"
+)EOF";
+
+  envoy::config::filter::network::thrift_proxy::v2alpha1::RouteConfiguration config =
+      parseRouteConfigurationFromV2Yaml(yaml);
+
+  EXPECT_THROW(new RouteMatcher(config), EnvoyException);
+}
+
+
+TEST(RouteMatcherTest, RouteByServiceNameWithNoInversion) {
+  const std::string yaml = R"EOF(
+name: config
+routes:
+  - match:
+      method_name: "method1"
+    route:
+      cluster: "cluster1"
+  - match:
+      service_name: "service2"
+    route:
+      cluster: "cluster2"
+)EOF";
+
+  envoy::config::filter::network::thrift_proxy::v2alpha1::RouteConfiguration config =
+      parseRouteConfigurationFromV2Yaml(yaml);
+
+  RouteMatcher matcher(config);
+  MessageMetadata metadata;
+  EXPECT_EQ(nullptr, matcher.route(metadata));
+  metadata.setMethodName("unknown");
+  EXPECT_EQ(nullptr, matcher.route(metadata));
+  metadata.setMethodName("METHOD1");
+  EXPECT_EQ(nullptr, matcher.route(metadata));
+
+  metadata.setMethodName("service2:method1");
+  RouteConstSharedPtr route = matcher.route(metadata);
+  EXPECT_NE(nullptr, route);
+  EXPECT_EQ("cluster2", route->routeEntry()->clusterName());
+
+  metadata.setMethodName("service2:method2");
+  RouteConstSharedPtr route2 = matcher.route(metadata);
+  EXPECT_NE(nullptr, route2);
+  EXPECT_EQ("cluster2", route2->routeEntry()->clusterName());
+}
+
+TEST(RouteMatcherTest, RouteByServiceNameWithInversion) {
+  const std::string yaml = R"EOF(
+name: config
+routes:
+  - match:
+      method_name: "method1"
+    route:
+      cluster: "cluster1"
+  - match:
+      service_name: "service2"
+      invert: true
+    route:
+      cluster: "cluster2"
+)EOF";
+
+  envoy::config::filter::network::thrift_proxy::v2alpha1::RouteConfiguration config =
+      parseRouteConfigurationFromV2Yaml(yaml);
+
+  RouteMatcher matcher(config);
+  MessageMetadata metadata;
+  RouteConstSharedPtr route = matcher.route(metadata);
+  EXPECT_NE(nullptr, route);
+  EXPECT_EQ("cluster2", route->routeEntry()->clusterName());
+
+  metadata.setMethodName("unknown");
+  route = matcher.route(metadata);
+  EXPECT_NE(nullptr, route);
+  EXPECT_EQ("cluster2", route->routeEntry()->clusterName());
+
+  metadata.setMethodName("METHOD1");
+  route = matcher.route(metadata);
+  EXPECT_NE(nullptr, route);
+  EXPECT_EQ("cluster2", route->routeEntry()->clusterName());
+
+  metadata.setMethodName("method1");
+  route = matcher.route(metadata);
+  EXPECT_NE(nullptr, route);
+  EXPECT_EQ("cluster1", route->routeEntry()->clusterName());
+
+  metadata.setMethodName("service2");
+  route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+}
+
+TEST(RouteMatcherTest, RouteByAnyServiceNameWithNoInversion) {
+  const std::string yaml = R"EOF(
+name: config
+routes:
+  - match:
+      method_name: "method1"
+    route:
+      cluster: "cluster1"
+  - match:
+      service_name: ""
+    route:
+      cluster: "cluster2"
+)EOF";
+
+  envoy::config::filter::network::thrift_proxy::v2alpha1::RouteConfiguration config =
+      parseRouteConfigurationFromV2Yaml(yaml);
+
+  RouteMatcher matcher(config);
+
+  {
+    MessageMetadata metadata;
+    metadata.setMethodName("method1");
+    RouteConstSharedPtr route = matcher.route(metadata);
+    EXPECT_NE(nullptr, route);
+    EXPECT_EQ("cluster1", route->routeEntry()->clusterName());
+
+    metadata.setMethodName("anything");
+    RouteConstSharedPtr route2 = matcher.route(metadata);
+    EXPECT_NE(nullptr, route2);
+    EXPECT_EQ("cluster2", route2->routeEntry()->clusterName());
+  }
+
+  {
+    MessageMetadata metadata;
+    RouteConstSharedPtr route2 = matcher.route(metadata);
+    EXPECT_NE(nullptr, route2);
+    EXPECT_EQ("cluster2", route2->routeEntry()->clusterName());
+  }
+}
+
+TEST(RouteMatcherTest, RouteByAnyServiceNameWithInversion) {
+  const std::string yaml = R"EOF(
+name: config
+routes:
+  - match:
+      service_name: ""
+      invert: true
+    route:
+      cluster: "cluster2"
+)EOF";
+
+  envoy::config::filter::network::thrift_proxy::v2alpha1::RouteConfiguration config =
+      parseRouteConfigurationFromV2Yaml(yaml);
+
+  EXPECT_THROW(new RouteMatcher(config), EnvoyException);
 }
 
 } // namespace Router

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -693,11 +693,11 @@ TEST(RouteMatcherTest, Route) {
 name: config
 routes:
   - match:
-      method: "method1"
+      method_name: "method1"
     route:
       cluster: "cluster1"
   - match:
-      method: "method2"
+      method_name: "method2"
     route:
       cluster: "cluster2"
 )EOF";
@@ -729,10 +729,11 @@ TEST(RouteMatcherTest, RouteMatchAny) {
 name: config
 routes:
   - match:
-      method: "method1"
+      method_name: "method1"
     route:
       cluster: "cluster1"
-  - match: {}
+  - match:
+      method_name: ""
     route:
       cluster: "cluster2"
 )EOF";

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -825,7 +825,6 @@ routes:
   EXPECT_THROW(new RouteMatcher(config), EnvoyException);
 }
 
-
 TEST(RouteMatcherTest, RouteByServiceNameWithNoInversion) {
   const std::string yaml = R"EOF(
 name: config


### PR DESCRIPTION
*Description*:
Currently, the thrift router only supports method matching as a way to route thrift requests. This builds on that by adding the ability to specify a service name that is used when matching. This change updates the `RouteMatch` proto definition to use a `oneof` field to indicate what type of matching should be done, as well as an `invert` flag that will allow for inverse matching rules.

Additionally:
- ensure new `RouteEntryImplBase` implementations check that inversion and wildcard matching are not enabled at the same time, as this would result in no matches for a route
- implement service matching as checking the prefix of the method name, as that's how it's implemented in thrift

*Risk Level*: 
Low

*Testing*: 
- new and existing unit tests pass. 
- updated integration test use new matching rules and ensure that expected upstreams receive requests.