### PR TITLE
test: Fix inverted exact match logic in IntegrationTcpClient::waitForData()

### DIFF
--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -155,7 +155,7 @@ void IntegrationTcpClient::close() { connection_->close(Network::ConnectionClose
 
 void IntegrationTcpClient::waitForData(const std::string& data, bool exact_match) {
   auto found = payload_reader_->data().find(data);
-  if ((exact_match && found != std::string::npos) || (!exact_match && found == 0)) {
+  if (found == 0 || (!exact_match && found != std::string::npos)) {
     return;
   }
 

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -38,6 +38,8 @@ TEST_P(TcpProxyIntegrationTest, TcpProxyUpstreamWritesFirst) {
 
   ASSERT_TRUE(fake_upstream_connection->write("hello"));
   tcp_client->waitForData("hello");
+  // Make sure inexact matches work also on data already received.
+  tcp_client->waitForData("ello", false);
 
   tcp_client->write("hello");
   ASSERT_TRUE(fake_upstream_connection->waitForData(5));


### PR DESCRIPTION
The initial check in IntegrationTcpClient::waitForData() did exact
match check when 'exact_match' parameter was 'false', and an inexact
match when 'exact_match' parameter was 'true'. If the initial test
fails, the forthcoming test in WaitForPayloadReader::onData() was
using the logically correct interpretation of the 'exact_match'
parameter.

This resulted in wait never completing for inexact matches
that should have matched data that was already received. The correct
test in WaitForPayloadReader::onData() would always correctly match
data that is received after IntegrationTcpClient::waitForData() is
called.

Fix the incorrect logic by reuing the logical pattern of
WaitForPayloadReader::onData() also in
IntegrationTcpClient::waitForData(), except for not skipping the exact
match on an empty search string.

Testing: Added a iine in TCP proxy integration test that fails/hangs
without the fix.
Risk Level: Low
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
