### PR TITLE
build: use clang to build release binary.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -52,7 +52,7 @@ if [[ "$1" == "bazel.release" ]]; then
     exit 0
   fi
   
-  setup_gcc_toolchain
+  setup_clang_toolchain
   echo "bazel release build with tests..."
   bazel_release_binary_build
   
@@ -72,7 +72,7 @@ if [[ "$1" == "bazel.release" ]]; then
   fi
   exit 0
 elif [[ "$1" == "bazel.release.server_only" ]]; then
-  setup_gcc_toolchain
+  setup_clang_toolchain
   echo "bazel release build..."
   bazel_release_binary_build
   exit 0

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -8,6 +8,7 @@ Version history
 * access log: added RESPONSE_DURATION and RESPONSE_TX_DURATION.
 * admin: added :http:get:`/hystrix_event_stream` as an endpoint for monitoring envoy's statistics
   through `Hystrix dashboard <https://github.com/Netflix-Skunkworks/hystrix-dashboard/wiki>`_.
+* build: switched to clang for the release builds.
 * grpc-json: added support for building HTTP response from
   `google.api.HttpBody <https://github.com/googleapis/googleapis/blob/master/google/api/httpbody.proto>`_.
 * cluster: added :ref:`option <envoy_api_field_Cluster.CommonLbConfig.update_merge_window>` to merge


### PR DESCRIPTION
Loading 1000 static listeners in a binary built with gcc takes ~51s,
but only ~1.5s (34x faster) in a binary built with clang.

*Risk Level*: Low
*Testing*: Manual
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Piotr Sikora <piotrsikora@google.com>