### PR TITLE
access_log: log requested_server_name in tcp proxy

### DIFF
--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -228,6 +228,8 @@ The following command operators are supported:
     Not implemented ("-").
 
 %REQUESTED_SERVER_NAME%
+  HTTP
+    String value set on ssl connection socket for Server Name Indication (SNI)
   TCP
     String value set on ssl connection socket for Server Name Indication (SNI)
 

--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -227,6 +227,10 @@ The following command operators are supported:
   TCP
     Not implemented ("-").
 
+%REQUESTED_SERVER_NAME%
+  TCP
+    String value set on ssl connection socket for Server Name Indication (SNI)
+
 .. _config_access_log_default_format:
 
 Default format

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -6,7 +6,7 @@ Version history
 * access log: added :ref:`response flag filter <envoy_api_msg_config.filter.accesslog.v2.ResponseFlagFilter>`
   to filter based on the presence of Envoy response flags.
 * access log: added RESPONSE_DURATION and RESPONSE_TX_DURATION.
-* access log: added REQUESTED_SERVER_NAME for SNI    
+* access log: added REQUESTED_SERVER_NAME for SNI to tcp_proxy and http
 * admin: added :http:get:`/hystrix_event_stream` as an endpoint for monitoring envoy's statistics
   through `Hystrix dashboard <https://github.com/Netflix-Skunkworks/hystrix-dashboard/wiki>`_.
 * grpc-json: added support for building HTTP response from

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -6,6 +6,7 @@ Version history
 * access log: added :ref:`response flag filter <envoy_api_msg_config.filter.accesslog.v2.ResponseFlagFilter>`
   to filter based on the presence of Envoy response flags.
 * access log: added RESPONSE_DURATION and RESPONSE_TX_DURATION.
+* access log: added REQUESTED_SERVER_NAME for SNI    
 * admin: added :http:get:`/hystrix_event_stream` as an endpoint for monitoring envoy's statistics
   through `Hystrix dashboard <https://github.com/Netflix-Skunkworks/hystrix-dashboard/wiki>`_.
 * grpc-json: added support for building HTTP response from

--- a/include/envoy/request_info/request_info.h
+++ b/include/envoy/request_info/request_info.h
@@ -301,6 +301,16 @@ public:
    * the same key overriding existing.
    */
   virtual void setDynamicMetadata(const std::string& name, const ProtobufWkt::Struct& value) PURE;
+
+  /**
+   * @param SNI value requested
+   */
+  virtual void setRequestedServerName(const absl::string_view& requested_server_name) PURE;
+
+  /**
+   * @return SNI value for downstream host
+   */
+  virtual const absl::string_view& requestedServerName() const PURE;
 };
 
 } // namespace RequestInfo

--- a/include/envoy/request_info/request_info.h
+++ b/include/envoy/request_info/request_info.h
@@ -305,7 +305,7 @@ public:
   /**
    * @param SNI value requested
    */
-  virtual void setRequestedServerName(const absl::string_view& requested_server_name) PURE;
+  virtual void setRequestedServerName(const absl::string_view requested_server_name) PURE;
 
   /**
    * @return SNI value for downstream host

--- a/include/envoy/request_info/request_info.h
+++ b/include/envoy/request_info/request_info.h
@@ -310,7 +310,7 @@ public:
   /**
    * @return SNI value for downstream host
    */
-  virtual const absl::string_view& requestedServerName() const PURE;
+  virtual const std::string& requestedServerName() const PURE;
 };
 
 } // namespace RequestInfo

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -303,12 +303,10 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
     };
   } else if (field_name == "REQUESTED_SERVER_NAME") {
     field_extractor_ = [](const RequestInfo::RequestInfo& request_info) {
-      absl::string_view requested_server_name;
       if (!request_info.requestedServerName().empty()) {
-        return request_info.requestedServerName().data();
+        return request_info.requestedServerName();
       } else {
-        requested_server_name = UnspecifiedValueString;
-        return requested_server_name.data();
+        return UnspecifiedValueString;
       }
     };
   } else {

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -304,7 +304,7 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
   } else if (field_name == "REQUESTED_SERVER_NAME") {
     field_extractor_ = [](const RequestInfo::RequestInfo& request_info) {
       absl::string_view requested_server_name;
-      if (nullptr != request_info.requestedServerName()) {
+      if (!request_info.requestedServerName().empty()) {
         return request_info.requestedServerName().data();
       } else {
         requested_server_name = UnspecifiedValueString;

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -301,6 +301,16 @@ RequestInfoFormatter::RequestInfoFormatter(const std::string& field_name) {
       return RequestInfo::Utility::formatDownstreamAddressNoPort(
           *request_info.downstreamRemoteAddress());
     };
+  } else if (field_name == "REQUESTED_SERVER_NAME") {
+    field_extractor_ = [](const RequestInfo::RequestInfo& request_info) {
+      absl::string_view requested_server_name;
+      if (nullptr != request_info.requestedServerName()) {
+        return request_info.requestedServerName().data();
+      } else {
+        requested_server_name = UnspecifiedValueString;
+        return requested_server_name.data();
+      }
+    };
   } else {
     throw EnvoyException(fmt::format("Not supported field in RequestInfo: {}", field_name));
   }

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -380,6 +380,8 @@ ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connect
         [this]() -> void { onIdleTimeout(); });
     resetIdleTimer();
   }
+  request_info_.setRequestedServerName(
+      connection_manager_.read_callbacks_->connection().requestedServerName());
 }
 
 ConnectionManagerImpl::ActiveStream::~ActiveStream() {

--- a/source/common/request_info/request_info_impl.h
+++ b/source/common/request_info/request_info_impl.h
@@ -178,6 +178,12 @@ struct RequestInfoImpl : public RequestInfo {
     (*metadata_.mutable_filter_metadata())[name].MergeFrom(value);
   };
 
+  void setRequestedServerName(const absl::string_view& requested_server_name) override {
+    requested_server_name_ = requested_server_name;
+  }
+
+  const absl::string_view& requestedServerName() const override { return requested_server_name_; }
+
   const SystemTime start_time_;
   const MonotonicTime start_time_monotonic_;
 
@@ -197,6 +203,7 @@ struct RequestInfoImpl : public RequestInfo {
   bool hc_request_{};
   const Router::RouteEntry* route_entry_{};
   envoy::api::v2::core::Metadata metadata_{};
+  absl::string_view requestedServerName_;
 
 private:
   uint64_t bytes_received_{};
@@ -204,6 +211,7 @@ private:
   Network::Address::InstanceConstSharedPtr upstream_local_address_;
   Network::Address::InstanceConstSharedPtr downstream_local_address_;
   Network::Address::InstanceConstSharedPtr downstream_remote_address_;
+  absl::string_view requested_server_name_;
 };
 
 } // namespace RequestInfo

--- a/source/common/request_info/request_info_impl.h
+++ b/source/common/request_info/request_info_impl.h
@@ -203,7 +203,6 @@ struct RequestInfoImpl : public RequestInfo {
   bool hc_request_{};
   const Router::RouteEntry* route_entry_{};
   envoy::api::v2::core::Metadata metadata_{};
-  //  absl::string_view requestedServerName_;
 
 private:
   uint64_t bytes_received_{};

--- a/source/common/request_info/request_info_impl.h
+++ b/source/common/request_info/request_info_impl.h
@@ -178,11 +178,11 @@ struct RequestInfoImpl : public RequestInfo {
     (*metadata_.mutable_filter_metadata())[name].MergeFrom(value);
   };
 
-  void setRequestedServerName(const absl::string_view requested_server_name) override {
-    requested_server_name_ = requested_server_name;
+  void setRequestedServerName(absl::string_view requested_server_name) override {
+    requested_server_name_ = std::string(requested_server_name);
   }
 
-  const absl::string_view& requestedServerName() const override { return requested_server_name_; }
+  const std::string& requestedServerName() const override { return requested_server_name_; }
 
   const SystemTime start_time_;
   const MonotonicTime start_time_monotonic_;
@@ -210,7 +210,7 @@ private:
   Network::Address::InstanceConstSharedPtr upstream_local_address_;
   Network::Address::InstanceConstSharedPtr downstream_local_address_;
   Network::Address::InstanceConstSharedPtr downstream_remote_address_;
-  absl::string_view requested_server_name_;
+  std::string requested_server_name_;
 };
 
 } // namespace RequestInfo

--- a/source/common/request_info/request_info_impl.h
+++ b/source/common/request_info/request_info_impl.h
@@ -178,7 +178,7 @@ struct RequestInfoImpl : public RequestInfo {
     (*metadata_.mutable_filter_metadata())[name].MergeFrom(value);
   };
 
-  void setRequestedServerName(const absl::string_view& requested_server_name) override {
+  void setRequestedServerName(const absl::string_view requested_server_name) override {
     requested_server_name_ = requested_server_name;
   }
 
@@ -203,7 +203,7 @@ struct RequestInfoImpl : public RequestInfo {
   bool hc_request_{};
   const Router::RouteEntry* route_entry_{};
   envoy::api::v2::core::Metadata metadata_{};
-  absl::string_view requestedServerName_;
+  //  absl::string_view requestedServerName_;
 
 private:
   uint64_t bytes_received_{};

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -388,9 +388,6 @@ Network::FilterStatus Filter::onData(Buffer::Instance& data, bool end_stream) {
   upstream_connection_->write(data, end_stream);
   ASSERT(0 == data.length());
   resetIdleTimer(); // TODO(ggreenway) PERF: do we need to reset timer on both send and receive?
-  getRequestInfo().setRequestedServerName(read_callbacks_->connection().requestedServerName());
-  ENVOY_LOG(debug, "TCP:onData(), requestedServerName: {} ",
-            getRequestInfo().requestedServerName());
   return Network::FilterStatus::StopIteration;
 }
 
@@ -471,6 +468,10 @@ void Filter::onUpstreamEvent(Network::ConnectionEvent event) {
     read_callbacks_->upstreamHost()->outlierDetector().putResult(
         Upstream::Outlier::Result::SUCCESS);
     onConnectionSuccess();
+
+    getRequestInfo().setRequestedServerName(read_callbacks_->connection().requestedServerName());
+    ENVOY_LOG(debug, "TCP:onData(), requestedServerName: {} ",
+              getRequestInfo().requestedServerName());
 
     if (config_->idleTimeout()) {
       // The idle_timer_ can be moved to a Drainer, so related callbacks call into

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -390,7 +390,7 @@ Network::FilterStatus Filter::onData(Buffer::Instance& data, bool end_stream) {
   resetIdleTimer(); // TODO(ggreenway) PERF: do we need to reset timer on both send and receive?
   getRequestInfo().setRequestedServerName(read_callbacks_->connection().requestedServerName());
   ENVOY_LOG(debug, "TCP:onData(), requestedServerName: {} ",
-            getRequestInfo().requestedServerName().data());
+            getRequestInfo().requestedServerName());
   return Network::FilterStatus::StopIteration;
 }
 

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -390,7 +390,7 @@ Network::FilterStatus Filter::onData(Buffer::Instance& data, bool end_stream) {
   resetIdleTimer(); // TODO(ggreenway) PERF: do we need to reset timer on both send and receive?
   getRequestInfo().setRequestedServerName(read_callbacks_->connection().requestedServerName());
   ENVOY_LOG(debug, "TCP:onData(), requestedServerName: {} ",
-            getRequestInfo().requestedServerName());
+            getRequestInfo().requestedServerName().data());
   return Network::FilterStatus::StopIteration;
 }
 

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -388,6 +388,9 @@ Network::FilterStatus Filter::onData(Buffer::Instance& data, bool end_stream) {
   upstream_connection_->write(data, end_stream);
   ASSERT(0 == data.length());
   resetIdleTimer(); // TODO(ggreenway) PERF: do we need to reset timer on both send and receive?
+  getRequestInfo().setRequestedServerName(read_callbacks_->connection().requestedServerName());
+  ENVOY_LOG(debug, "TCP:onData(), requestedServerName: {} ",
+            getRequestInfo().requestedServerName());
   return Network::FilterStatus::StopIteration;
 }
 

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -470,7 +470,7 @@ void Filter::onUpstreamEvent(Network::ConnectionEvent event) {
     onConnectionSuccess();
 
     getRequestInfo().setRequestedServerName(read_callbacks_->connection().requestedServerName());
-    ENVOY_LOG(debug, "TCP:onData(), requestedServerName: {} ",
+    ENVOY_LOG(debug, "TCP:onUpstreamEvent(), requestedServerName: {}",
               getRequestInfo().requestedServerName());
 
     if (config_->idleTimeout()) {

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -123,6 +123,8 @@ void Filter::onServername(absl::string_view name) {
   if (!name.empty()) {
     config_->stats().sni_found_.inc();
     cb_->socket().setRequestedServerName(name);
+    ENVOY_LOG(debug, "tls:onServerName(), requestedServerName: {}",
+              cb_->socket().requestedServerName());
   } else {
     config_->stats().sni_not_found_.inc();
   }

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -123,8 +123,7 @@ void Filter::onServername(absl::string_view name) {
   if (!name.empty()) {
     config_->stats().sni_found_.inc();
     cb_->socket().setRequestedServerName(name);
-    ENVOY_LOG(debug, "tls:onServerName(), requestedServerName: {}",
-              cb_->socket().requestedServerName());
+    ENVOY_LOG(debug, "tls:onServerName(), requestedServerName: {}", name);
   } else {
     config_->stats().sni_not_found_.inc();
   }

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -185,6 +185,20 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
     RequestInfoFormatter upstream_format("DOWNSTREAM_REMOTE_ADDRESS");
     EXPECT_EQ("127.0.0.1:0", upstream_format.format(header, header, header, request_info));
   }
+
+  // {
+  //   RequestInfoFormatter upstream_format("REQUESTED_SERVER_NAME");
+  //   absl::string_view requested_server_name = "stub_server";
+  //   EXPECT_CALL(request_info,
+  //   requestedServerName()).WillRepeatedly(ReturnRef(requested_server_name));
+  //   EXPECT_EQ("stub_server", upstream_format.format(header, header, header, request_info));
+  // }
+
+  {
+    RequestInfoFormatter upstream_format("REQUESTED_SERVER_NAME");
+    // EXPECT_CALL(request_info, requestedServerName()).WillOnce(Return(nullptr));
+    EXPECT_EQ("-", upstream_format.format(header, header, header, request_info));
+  }
 }
 
 TEST(AccessLogFormatterTest, requestHeaderFormatter) {

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -186,17 +186,19 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
     EXPECT_EQ("127.0.0.1:0", upstream_format.format(header, header, header, request_info));
   }
 
-  // {
-  //   RequestInfoFormatter upstream_format("REQUESTED_SERVER_NAME");
-  //   absl::string_view requested_server_name = "stub_server";
-  //   EXPECT_CALL(request_info,
-  //   requestedServerName()).WillRepeatedly(ReturnRef(requested_server_name));
-  //   EXPECT_EQ("stub_server", upstream_format.format(header, header, header, request_info));
-  // }
+  {
+    RequestInfoFormatter upstream_format("REQUESTED_SERVER_NAME");
+    absl::string_view requested_server_name = "stub_server";
+    EXPECT_CALL(request_info, requestedServerName())
+        .WillRepeatedly(ReturnRef(requested_server_name));
+    EXPECT_EQ("stub_server", upstream_format.format(header, header, header, request_info));
+  }
 
   {
     RequestInfoFormatter upstream_format("REQUESTED_SERVER_NAME");
-    // EXPECT_CALL(request_info, requestedServerName()).WillOnce(Return(nullptr));
+    absl::string_view requested_server_name;
+    EXPECT_CALL(request_info, requestedServerName())
+        .WillRepeatedly(ReturnRef(requested_server_name));
     EXPECT_EQ("-", upstream_format.format(header, header, header, request_info));
   }
 }

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -188,7 +188,7 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
 
   {
     RequestInfoFormatter upstream_format("REQUESTED_SERVER_NAME");
-    absl::string_view requested_server_name = "stub_server";
+    std::string requested_server_name = "stub_server";
     EXPECT_CALL(request_info, requestedServerName())
         .WillRepeatedly(ReturnRef(requested_server_name));
     EXPECT_EQ("stub_server", upstream_format.format(header, header, header, request_info));
@@ -196,7 +196,7 @@ TEST(AccessLogFormatterTest, requestInfoFormatter) {
 
   {
     RequestInfoFormatter upstream_format("REQUESTED_SERVER_NAME");
-    absl::string_view requested_server_name;
+    std::string requested_server_name;
     EXPECT_CALL(request_info, requestedServerName())
         .WillRepeatedly(ReturnRef(requested_server_name));
     EXPECT_EQ("-", upstream_format.format(header, header, header, request_info));

--- a/test/common/access_log/test_util.h
+++ b/test/common/access_log/test_util.h
@@ -155,10 +155,10 @@ public:
   };
 
   void setRequestedServerName(const absl::string_view requested_server_name) override {
-    requested_server_name_ = requested_server_name;
+    requested_server_name_ = std::string(requested_server_name);
   }
 
-  const absl::string_view& requestedServerName() const override { return requested_server_name_; }
+  const std::string& requestedServerName() const override { return requested_server_name_; }
 
   SystemTime start_time_;
   MonotonicTime start_time_monotonic_;
@@ -182,7 +182,7 @@ public:
   Network::Address::InstanceConstSharedPtr downstream_remote_address_;
   const Router::RouteEntry* route_entry_{};
   envoy::api::v2::core::Metadata metadata_{};
-  absl::string_view requested_server_name_;
+  std::string requested_server_name_;
 };
 
 } // namespace Envoy

--- a/test/common/access_log/test_util.h
+++ b/test/common/access_log/test_util.h
@@ -154,6 +154,12 @@ public:
     (*metadata_.mutable_filter_metadata())[name].MergeFrom(value);
   };
 
+  void setRequestedServerName(const absl::string_view& requested_server_name) override {
+    requested_server_name_ = requested_server_name;
+  }
+
+  const absl::string_view& requestedServerName() const override { return requested_server_name_; }
+
   SystemTime start_time_;
   MonotonicTime start_time_monotonic_;
 
@@ -176,6 +182,7 @@ public:
   Network::Address::InstanceConstSharedPtr downstream_remote_address_;
   const Router::RouteEntry* route_entry_{};
   envoy::api::v2::core::Metadata metadata_{};
+  absl::string_view requested_server_name_;
 };
 
 } // namespace Envoy

--- a/test/common/access_log/test_util.h
+++ b/test/common/access_log/test_util.h
@@ -154,7 +154,7 @@ public:
     (*metadata_.mutable_filter_metadata())[name].MergeFrom(value);
   };
 
-  void setRequestedServerName(const absl::string_view& requested_server_name) override {
+  void setRequestedServerName(const absl::string_view requested_server_name) override {
     requested_server_name_ = requested_server_name;
   }
 

--- a/test/common/request_info/request_info_impl_test.cc
+++ b/test/common/request_info/request_info_impl_test.cc
@@ -140,6 +140,11 @@ TEST(RequestInfoImplTest, MiscSettersAndGetters) {
     NiceMock<Router::MockRouteEntry> route_entry;
     request_info.route_entry_ = &route_entry;
     EXPECT_EQ(&route_entry, request_info.routeEntry());
+
+    EXPECT_EQ(nullptr, request_info.requestedServerName());
+    absl::string_view sni_name = "stubserver.org";
+    request_info.setRequestedServerName(sni_name);
+    EXPECT_EQ(sni_name, request_info.requestedServerName());
   }
 }
 

--- a/test/common/request_info/request_info_impl_test.cc
+++ b/test/common/request_info/request_info_impl_test.cc
@@ -141,10 +141,10 @@ TEST(RequestInfoImplTest, MiscSettersAndGetters) {
     request_info.route_entry_ = &route_entry;
     EXPECT_EQ(&route_entry, request_info.routeEntry());
 
-    EXPECT_EQ(nullptr, request_info.requestedServerName());
+    EXPECT_EQ("", request_info.requestedServerName());
     absl::string_view sni_name = "stubserver.org";
     request_info.setRequestedServerName(sni_name);
-    EXPECT_EQ(sni_name, request_info.requestedServerName());
+    EXPECT_EQ(std::string(sni_name), request_info.requestedServerName());
   }
 }
 

--- a/test/mocks/request_info/mocks.cc
+++ b/test/mocks/request_info/mocks.cc
@@ -65,7 +65,7 @@ MockRequestInfo::MockRequestInfo()
   ON_CALL(*this, bytesSent()).WillByDefault(ReturnPointee(&bytes_sent_));
   ON_CALL(*this, dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
   ON_CALL(*this, setRequestedServerName(_))
-      .WillByDefault(Invoke([this](const absl::string_view& requested_server_name) {
+      .WillByDefault(Invoke([this](const absl::string_view requested_server_name) {
         requested_server_name_ = requested_server_name;
       }));
   ON_CALL(*this, requestedServerName()).WillByDefault(ReturnRef(requested_server_name_));

--- a/test/mocks/request_info/mocks.cc
+++ b/test/mocks/request_info/mocks.cc
@@ -66,7 +66,7 @@ MockRequestInfo::MockRequestInfo()
   ON_CALL(*this, dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
   ON_CALL(*this, setRequestedServerName(_))
       .WillByDefault(Invoke([this](const absl::string_view requested_server_name) {
-        requested_server_name_ = requested_server_name;
+        requested_server_name_ = std::string(requested_server_name);
       }));
   ON_CALL(*this, requestedServerName()).WillByDefault(ReturnRef(requested_server_name_));
 }

--- a/test/mocks/request_info/mocks.cc
+++ b/test/mocks/request_info/mocks.cc
@@ -64,6 +64,11 @@ MockRequestInfo::MockRequestInfo()
   }));
   ON_CALL(*this, bytesSent()).WillByDefault(ReturnPointee(&bytes_sent_));
   ON_CALL(*this, dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
+  ON_CALL(*this, setRequestedServerName(_))
+      .WillByDefault(Invoke([this](const absl::string_view& requested_server_name) {
+        requested_server_name_ = requested_server_name;
+      }));
+  ON_CALL(*this, requestedServerName()).WillByDefault(ReturnRef(requested_server_name_));
 }
 
 MockRequestInfo::~MockRequestInfo() {}

--- a/test/mocks/request_info/mocks.h
+++ b/test/mocks/request_info/mocks.h
@@ -61,7 +61,7 @@ public:
   MOCK_METHOD3(setDynamicMetadata,
                void(const std::string&, const std::string&, const std::string&));
   MOCK_METHOD1(setRequestedServerName, void(const absl::string_view));
-  MOCK_CONST_METHOD0(requestedServerName, const absl::string_view&());
+  MOCK_CONST_METHOD0(requestedServerName, const std::string&());
 
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_{
       new testing::NiceMock<Upstream::MockHostDescription>()};
@@ -83,7 +83,7 @@ public:
   Network::Address::InstanceConstSharedPtr upstream_local_address_;
   Network::Address::InstanceConstSharedPtr downstream_local_address_;
   Network::Address::InstanceConstSharedPtr downstream_remote_address_;
-  absl::string_view requested_server_name_;
+  std::string requested_server_name_;
 };
 
 } // namespace RequestInfo

--- a/test/mocks/request_info/mocks.h
+++ b/test/mocks/request_info/mocks.h
@@ -60,6 +60,8 @@ public:
   MOCK_METHOD2(setDynamicMetadata, void(const std::string&, const ProtobufWkt::Struct&));
   MOCK_METHOD3(setDynamicMetadata,
                void(const std::string&, const std::string&, const std::string&));
+  MOCK_METHOD1(setRequestedServerName, void(const absl::string_view&));
+  MOCK_CONST_METHOD0(requestedServerName, const absl::string_view&());
 
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_{
       new testing::NiceMock<Upstream::MockHostDescription>()};
@@ -81,6 +83,7 @@ public:
   Network::Address::InstanceConstSharedPtr upstream_local_address_;
   Network::Address::InstanceConstSharedPtr downstream_local_address_;
   Network::Address::InstanceConstSharedPtr downstream_remote_address_;
+  absl::string_view requested_server_name_;
 };
 
 } // namespace RequestInfo

--- a/test/mocks/request_info/mocks.h
+++ b/test/mocks/request_info/mocks.h
@@ -60,7 +60,7 @@ public:
   MOCK_METHOD2(setDynamicMetadata, void(const std::string&, const ProtobufWkt::Struct&));
   MOCK_METHOD3(setDynamicMetadata,
                void(const std::string&, const std::string&, const std::string&));
-  MOCK_METHOD1(setRequestedServerName, void(const absl::string_view&));
+  MOCK_METHOD1(setRequestedServerName, void(const absl::string_view));
   MOCK_CONST_METHOD0(requestedServerName, const absl::string_view&());
 
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_{


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

*Description*: log SNI value when configured in TCP access log
*Risk Level*: low
*Testing*: current and new tests pass & manual testing with 2 envoys & tcp emitted the correct log entry
*Docs Changes*: WIP
*Release Notes*: WIP
Fixes: #3874 