### PR TITLE
rbac: fix flaky integration test.

### DIFF
--- a/test/extensions/filters/network/rbac/integration_test.cc
+++ b/test/extensions/filters/network/rbac/integration_test.cc
@@ -89,10 +89,10 @@ config:
   ASSERT_TRUE(tcp_client->connected());
   tcp_client->close();
 
-  EXPECT_EQ(1U, test_server_->counter("tcp.rbac.allowed")->value());
+  test_server_->waitForCounterGe("tcp.rbac.allowed", 1);
   EXPECT_EQ(0U, test_server_->counter("tcp.rbac.denied")->value());
   EXPECT_EQ(0U, test_server_->counter("tcp.rbac.shadow_allowed")->value());
-  EXPECT_EQ(1U, test_server_->counter("tcp.rbac.shadow_denied")->value());
+  test_server_->waitForCounterGe("tcp.rbac.shadow_denied", 1);
 }
 
 TEST_P(RoleBasedAccessControlNetworkFilterIntegrationTest, Denied) {
@@ -118,7 +118,6 @@ config:
 )EOF");
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
   tcp_client->write("hello");
-  ASSERT_TRUE(tcp_client->connected());
   tcp_client->waitForDisconnect();
 
   EXPECT_EQ(0U, test_server_->counter("tcp.rbac.allowed")->value());


### PR DESCRIPTION
Signed-off-by: Yangmin Zhu <ymzhu@google.com>

*Description*: Fix flaky tests.
*Risk Level*: Low
*Testing*:
The flaky tests could be reproduced by running:
`bazel test //test/extensions/filters/network/rbac:integration_test  --jobs 60 --runs_per_test=3000 --local_resources 100000000000,100000000000,10000000 --cache_test_results=no` and confirmed this doesn't reproduce anymore after this fix.

*Docs Changes*: N/A
*Release Notes*: N/A
Fixes #4146

