### PR TITLE
router: Change parser for user defined headers to allow for single string arguments

### DIFF
--- a/source/common/router/header_parser.cc
+++ b/source/common/router/header_parser.cc
@@ -19,9 +19,11 @@ namespace {
 enum class ParserState {
   Literal,                   // processing literal data
   VariableName,              // consuming a %VAR% name
-  ExpectArray,               // expect starting [ in %VAR([...])%
-  ExpectString,              // expect starting " in array of strings
-  String,                    // consuming an array element string
+  ExpectArrayOrString,       // expect starting [ in %VAR([...])% or " for a singular string.
+  ExpectStringElement,       // expect starting " in array of strings
+  QuotedString,              // Consuming a single argument quoted string
+  UnquotedString,            // Consuming a single argument unquoted string
+  StringElement,             // consuming an array element string
   ExpectArrayDelimiterOrEnd, // expect array delimiter (,) or end of array (])
   ExpectArgsEnd,             // expect closing ) in %VAR(...)%
   ExpectVariableEnd          // expect closing % in %VAR(...)%
@@ -30,10 +32,10 @@ enum class ParserState {
 std::string unescape(absl::string_view sv) { return absl::StrReplaceAll(sv, {{"%%", "%"}}); }
 
 // Implements a state machine to parse custom headers. Each character of the custom header format
-// is either literal text (with % escaped as %%) or part of a %VAR% or %VAR(["args"])% expression.
-// The statement machine does minimal validation of the arguments (if any) and does not know the
-// names of valid variables. Interpretation of the variable name and arguments is delegated to
-// RequestInfoHeaderFormatter.
+// is either literal text (with % escaped as %%) or part of a %VAR%, %VAR(arg), %VAR("arg"), or
+// %VAR(["arg1", "arg2", ...])% expression. The statement machine does minimal validation of the
+// arguments (if any) and does not know the names of valid variables. Interpretation of the
+// variable name and arguments is delegated to RequestInfoHeaderFormatter.
 HeaderFormatterPtr
 parseInternal(const envoy::api::v2::core::HeaderValueOption& header_value_option) {
   const bool append = PROTOBUF_GET_WRAPPED_OR_DEFAULT(header_value_option, append, true);
@@ -92,25 +94,28 @@ parseInternal(const envoy::api::v2::core::HeaderValueOption& header_value_option
 
       if (ch == '(') {
         // Variable with arguments, search for start of arg array.
-        state = ParserState::ExpectArray;
+        state = ParserState::ExpectArrayOrString;
       }
       break;
 
-    case ParserState::ExpectArray:
-      // Skip over whitespace searching for the start of JSON array args.
+    case ParserState::ExpectArrayOrString:
+      // Look for an argument that is either an array of strings or a string,
+      // skipping over whitespace.
       if (ch == '[') {
         // Search for first argument string
-        state = ParserState::ExpectString;
-      } else if (!isspace(ch)) {
+        state = ParserState::ExpectStringElement;
+      } else if (ch == '"') {
         // Consume it as a string argument.
-        state = ParserState::String;
+        state = ParserState::QuotedString;
+      } else if (!isspace(ch)) {
+        state = ParserState::UnquotedString;
       }
       break;
 
     case ParserState::ExpectArrayDelimiterOrEnd:
       // Skip over whitespace searching for a comma or close bracket.
       if (ch == ',') {
-        state = ParserState::ExpectString;
+        state = ParserState::ExpectStringElement;
       } else if (ch == ']') {
         state = ParserState::ExpectArgsEnd;
       } else if (!isspace(ch)) {
@@ -121,10 +126,10 @@ parseInternal(const envoy::api::v2::core::HeaderValueOption& header_value_option
       }
       break;
 
-    case ParserState::ExpectString:
+    case ParserState::ExpectStringElement:
       // Skip over whitespace looking for the starting quote of a JSON string.
       if (ch == '"') {
-        state = ParserState::String;
+        state = ParserState::StringElement;
       } else if (!isspace(ch)) {
         throw EnvoyException(fmt::format(
             "Invalid header configuration. Expecting '\"' or whitespace after '{}', but found '{}'",
@@ -132,7 +137,8 @@ parseInternal(const envoy::api::v2::core::HeaderValueOption& header_value_option
       }
       break;
 
-    case ParserState::String:
+    case ParserState::StringElement:
+    case ParserState::QuotedString:
       // Consume a JSON string (ignoring backslash-escaped chars).
       if (ch == '\\') {
         if (!has_next_ch) {
@@ -143,10 +149,15 @@ parseInternal(const envoy::api::v2::core::HeaderValueOption& header_value_option
 
         // Skip escaped char.
         pos++;
-      } else if (ch == ')') {
-        state = ParserState::ExpectVariableEnd;
       } else if (ch == '"') {
-        state = ParserState::ExpectArrayDelimiterOrEnd;
+        state = ((state == ParserState::StringElement) ? ParserState::ExpectArrayDelimiterOrEnd
+                                                       : ParserState::ExpectArgsEnd);
+      }
+      break;
+
+    case ParserState::UnquotedString:
+      if (ch == ')') {
+        state = ParserState::ExpectVariableEnd;
       }
       break;
 


### PR DESCRIPTION

*Description*:
Change the parser for user defined header configuration to allow for single (not array) string arguments for variables, e.g. '%PER_REQUEST_STATE("reverse.dns.data.name")%').

*Risk Level*: Low

*Testing*: This code is currently tested at the level above its implementation.  I'm relying on existing tests for lack of regression of functionality, and am adding new tests for the consumers of this new functionality in the PR which creates those consumers. 

*Docs Changes*: None in this PR.

*Release Notes*: None from this PR.
