### PR TITLE
fuzz: tag trivial fuzzers with no_fuzz.

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -233,7 +233,7 @@ def envoy_cc_binary(
     )
 
 # Envoy C++ fuzz test targes. These are not included in coverage runs.
-def envoy_cc_fuzz_test(name, corpus, deps = [], **kwargs):
+def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
     test_lib_name = name + "_lib"
     envoy_cc_test_library(
         name = test_lib_name,
@@ -255,6 +255,7 @@ def envoy_cc_fuzz_test(name, corpus, deps = [], **kwargs):
                 "//test/fuzz:main",
             ],
         }),
+        tags = tags,
     )
     native.cc_binary(
         name = name + "_driverless",
@@ -263,7 +264,7 @@ def envoy_cc_fuzz_test(name, corpus, deps = [], **kwargs):
         linkstatic = 1,
         testonly = 1,
         deps = [":" + test_lib_name],
-        tags = ["manual"],
+        tags = ["manual"] + tags,
     )
 
 # Envoy C++ test targets should be specified with this function.

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -40,6 +40,8 @@ envoy_cc_fuzz_test(
     name = "base64_fuzz_test",
     srcs = ["base64_fuzz_test.cc"],
     corpus = "base64_corpus",
+    # Fuzzer is stable, no bugs, simple test target; avoid emitting CO2.
+    tags = ["no_fuzz"],
     deps = ["//source/common/common:base64_lib"],
 )
 
@@ -47,6 +49,8 @@ envoy_cc_fuzz_test(
     name = "utility_fuzz_test",
     srcs = ["utility_fuzz_test.cc"],
     corpus = "utility_corpus",
+    # Fuzzer is stable, no bugs, simple test target; avoid emitting CO2.
+    tags = ["no_fuzz"],
     deps = ["//source/common/common:utility_lib"],
 )
 

--- a/test/common/protobuf/BUILD
+++ b/test/common/protobuf/BUILD
@@ -24,5 +24,7 @@ envoy_cc_fuzz_test(
     name = "value_util_fuzz_test",
     srcs = ["value_util_fuzz_test.cc"],
     corpus = "value_util_corpus",
+    # Fuzzer is stable, no bugs, simple test target; avoid emitting CO2.
+    tags = ["no_fuzz"],
     deps = ["//source/common/protobuf:utility_lib"],
 )


### PR DESCRIPTION
In conjunction with https://github.com/google/oss-fuzz/pull/1712, this allows us to elide trivial
fuzzers on ClusterFuzz. This should save CPU cycles and project quota (depending on the nuances of
how they schedule).

Risk level: Low
Testing: Building with oss-fuzz Docker image.

Signed-off-by: Harvey Tuch <htuch@google.com>