### PR TITLE
fuzz: disable logging when running under fuzz engine.

### DIFF
--- a/test/fuzz/fuzz_runner.h
+++ b/test/fuzz/fuzz_runner.h
@@ -6,6 +6,7 @@
 // Bring in DEFINE_PROTO_FUZZER definition as per
 // https://github.com/google/libprotobuf-mutator#integrating-with-libfuzzer.
 #include "libprotobuf_mutator/src/libfuzzer/libfuzzer_macro.h"
+#include "spdlog/spdlog.h"
 
 namespace Envoy {
 namespace Fuzz {
@@ -17,8 +18,17 @@ public:
    * invoked in this environment.
    * @param argc number of command-line args.
    * @param argv array of command-line args.
+   * @param default_loglevel default log level (overridable with -l).
    */
-  static void setupEnvironment(int argc, char** argv);
+  static void setupEnvironment(int argc, char** argv, spdlog::level::level_enum default_log_level);
+
+  /**
+   * @return spdlog::level::level_enum the log level for the fuzzer.
+   */
+  static spdlog::level::level_enum logLevel() { return log_level_; }
+
+private:
+  static spdlog::level::level_enum log_level_;
 };
 
 } // namespace Fuzz

--- a/test/fuzz/main.cc
+++ b/test/fuzz/main.cc
@@ -51,6 +51,6 @@ int main(int argc, char** argv) {
   RELEASE_ASSERT(Envoy::Filesystem::directoryExists(corpus_path), "");
   Envoy::test_corpus_ = Envoy::TestUtility::listFiles(corpus_path, true);
   testing::InitGoogleTest(&argc, argv);
-  Envoy::Fuzz::Runner::setupEnvironment(argc, argv);
+  Envoy::Fuzz::Runner::setupEnvironment(argc, argv, spdlog::level::info);
   return RUN_ALL_TESTS();
 }

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -26,6 +26,7 @@ MockOptions::MockOptions(const std::string& config_path) : config_path_(config_p
   ON_CALL(*this, serviceClusterName()).WillByDefault(ReturnRef(service_cluster_name_));
   ON_CALL(*this, serviceNodeName()).WillByDefault(ReturnRef(service_node_name_));
   ON_CALL(*this, serviceZone()).WillByDefault(ReturnRef(service_zone_name_));
+  ON_CALL(*this, logLevel()).WillByDefault(Return(log_level_));
   ON_CALL(*this, logPath()).WillByDefault(ReturnRef(log_path_));
   ON_CALL(*this, maxStats()).WillByDefault(Return(1000));
   ON_CALL(*this, statsOptions()).WillByDefault(ReturnRef(stats_options_));

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -80,6 +80,7 @@ public:
   std::string service_cluster_name_;
   std::string service_node_name_;
   std::string service_zone_name_;
+  spdlog::level::level_enum log_level_{spdlog::level::trace};
   std::string log_path_;
   Stats::StatsOptionsImpl stats_options_;
   bool hot_restart_disabled_{};

--- a/test/server/config_validation/config_fuzz_test.cc
+++ b/test/server/config_validation/config_fuzz_test.cc
@@ -22,6 +22,7 @@ DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v2::Bootstrap& input) {
   bootstrap_file << input.DebugString();
   options.config_path_ = bootstrap_path;
   options.v2_config_only_ = true;
+  options.log_level_ = Fuzz::Runner::logLevel();
 
   try {
     validateConfig(options, Network::Address::InstanceConstSharedPtr(), component_factory);

--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -33,6 +33,7 @@ DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v2::Bootstrap& input) {
     bootstrap_file << input.DebugString();
     options.config_path_ = bootstrap_path;
     options.v2_config_only_ = true;
+    options.log_level_ = Fuzz::Runner::logLevel();
   }
 
   try {


### PR DESCRIPTION
The ClusterFuzz stats indicated a lot of log spew, this is a structural
attempt to reduce it. We now run with logging off when under the engine,
but at ::info when running under bazel test. This can be further
overriden when debugging with -l to more verbose levels. The usual flow
is we download a repeater from the database and then reproduce with
logs.

There's still some log spam from libproto, will look into that
separately.

Risk Level: low
Testing: manual tests on CLI with different combinations of flags.

Signed-off-by: Harvey Tuch <htuch@google.com>