### PR TITLE
server: handle non-EnvoyExceptions safely if thrown in constructor.

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -76,7 +76,14 @@ InstanceImpl::InstanceImpl(Options& options, Network::Address::InstanceConstShar
   } catch (const EnvoyException& e) {
     ENVOY_LOG(critical, "error initializing configuration '{}': {}", options.configPath(),
               e.what());
-
+    terminate();
+    throw;
+  } catch (const std::exception& e) {
+    ENVOY_LOG(critical, "error initializing due to unexpected exception: {}", e.what());
+    terminate();
+    throw;
+  } catch (...) {
+    ENVOY_LOG(critical, "error initializing due to unknown exception");
     terminate();
     throw;
   }


### PR DESCRIPTION
This came up while addressing oss-fuzz issue
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=9335 in
https://github.com/envoyproxy/envoy/pull/4171.

Without this PR, the server would shutdown non-gracefully, with TLS
posts still possible to deleted worker thread dispatchers, resulting
in heap-user-after-free. Protobuf was throwing a CHECK exception, which
was not picked up as EnvoyException.

Risk level: Low
Testing: Unit tests added, corpus entry is in
https://github.com/envoyproxy/envoy/pull/4171.

Signed-off-by: Harvey Tuch <htuch@google.com>