### PR TITLE
Bump yaml-cpp so it builds with Visual Studio 15.8

### DIFF
--- a/ci/build_container/build_recipes/yaml-cpp.sh
+++ b/ci/build_container/build_recipes/yaml-cpp.sh
@@ -2,11 +2,12 @@
 
 set -e
 
-VERSION=0.6.2
+# Pin to this commit to pick up fix for building on Visual Studio 15.8
+COMMIT=0f9a586ca1dc29c2ecb8dd715a315b93e3f40f79 # 2018-06-30
 
-curl https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-"$VERSION".tar.gz -sLo yaml-cpp-"$VERSION".tar.gz
-tar xf yaml-cpp-"$VERSION".tar.gz
-cd yaml-cpp-yaml-cpp-"$VERSION"
+git clone https://github.com/jbeder/yaml-cpp
+cd yaml-cpp
+git reset --hard "$COMMIT"
 
 mkdir build
 cd build

--- a/ci/build_container/build_recipes/yaml-cpp.sh
+++ b/ci/build_container/build_recipes/yaml-cpp.sh
@@ -5,9 +5,9 @@ set -e
 # Pin to this commit to pick up fix for building on Visual Studio 15.8
 COMMIT=0f9a586ca1dc29c2ecb8dd715a315b93e3f40f79 # 2018-06-30
 
-git clone https://github.com/jbeder/yaml-cpp
-cd yaml-cpp
-git reset --hard "$COMMIT"
+curl https://github.com/jbeder/yaml-cpp/archive/"$COMMIT".tar.gz -sLo yaml-cpp-"$COMMIT".tar.gz
+tar xf yaml-cpp-"$COMMIT".tar.gz
+cd yaml-cpp-"$COMMIT"
 
 mkdir build
 cd build


### PR DESCRIPTION
*Description*:
Version 0.6.2 of yaml-cpp does not build when using Visual Studio 15.8,
for context see: https://github.com/jbeder/yaml-cpp/pull/597

Updating to this commit fixes the issue.

*Risk Level*:
Low

*Testing*:
`bazel test //test/...` on Linux.

*Docs Changes*:
N/A
*Release Notes*:
N/A