### PR TITLE
Fix wrong mock function name.

### DIFF
--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -428,7 +428,7 @@ public:
   MOCK_CONST_METHOD0(statsScope, Stats::Scope&());
   MOCK_METHOD0(clusterManager, Upstream::ClusterManager&());
   MOCK_METHOD0(secretManager, Secret::SecretManager&());
-  MOCK_METHOD0(local_info, const LocalInfo::LocalInfo&());
+  MOCK_METHOD0(localInfo, const LocalInfo::LocalInfo&());
   MOCK_METHOD0(dispatcher, Event::Dispatcher&());
   MOCK_METHOD0(random, Envoy::Runtime::RandomGenerator&());
   MOCK_METHOD0(stats, Stats::Store&());


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@chromium.org>

Description:
Mock out TransportSocketFactory::ContextlocalInfo() in MockTransportSocketFactoryContext.
Risk Level: low (test only)
Testing: bazel test //test/...
Docs Changes: N/A
Release Notes: N/A
Fixes #4186
