### PR TITLE
fuzz: fixes oss-fuzz: 9895

### DIFF
--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -143,7 +143,10 @@ RequestInfoHeaderFormatter::RequestInfoHeaderFormatter(absl::string_view field_n
     }
     field_extractor_ = [this, pattern](const Envoy::RequestInfo::RequestInfo& request_info) {
       const auto& formatters = start_time_formatters_.at(pattern);
-      ASSERT(formatters.size() == 1);
+      if (formatters.size() != 1) {
+        throw EnvoyException(
+            fmt::format("multiple start_time values found: {}", formatters.size()));
+      }
       Http::HeaderMapImpl empty_map;
       return formatters.at(0)->format(empty_map, empty_map, empty_map, request_info);
     };

--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -11,6 +11,7 @@
 #include "common/json/json_loader.h"
 #include "common/request_info/utility.h"
 
+#include "absl/strings/str_cat.h"
 #include "absl/types/optional.h"
 
 namespace Envoy {
@@ -143,12 +144,13 @@ RequestInfoHeaderFormatter::RequestInfoHeaderFormatter(absl::string_view field_n
     }
     field_extractor_ = [this, pattern](const Envoy::RequestInfo::RequestInfo& request_info) {
       const auto& formatters = start_time_formatters_.at(pattern);
-      if (formatters.size() != 1) {
-        throw EnvoyException(
-            fmt::format("multiple start_time values found: {}", formatters.size()));
-      }
       Http::HeaderMapImpl empty_map;
-      return formatters.at(0)->format(empty_map, empty_map, empty_map, request_info);
+      std::string formatted;
+      for (const auto& formatter : formatters) {
+        absl::StrAppend(&formatted,
+                        formatter->format(empty_map, empty_map, empty_map, request_info));
+      }
+      return formatted;
     };
   } else if (field_name.find("UPSTREAM_METADATA") == 0) {
     field_extractor_ =

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -618,6 +618,10 @@ route:
         value: "%START_TIME(%s.%3f)%"
       append: true
     - header:
+        key: "x-request-start"
+        value: "%START_TIME(%s.%3f)%  %START_TIME% %START_TIME(%s)%"
+      append: true
+    - header:
         key: "x-request-start-f"
         value: "%START_TIME(f)%"
       append: true

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -644,7 +644,7 @@ route:
 
   // Initialize start_time as 2018-04-03T23:06:09.123Z in microseconds.
   const SystemTime start_time(std::chrono::microseconds(1522796769123456));
-  EXPECT_CALL(request_info, startTime()).Times(4).WillRepeatedly(Return(start_time));
+  EXPECT_CALL(request_info, startTime()).Times(7).WillRepeatedly(Return(start_time));
 
   resp_header_parser->evaluateHeaders(headerMap, request_info);
   EXPECT_TRUE(headerMap.has("x-client-ip"));

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -618,8 +618,8 @@ route:
         value: "%START_TIME(%s.%3f)%"
       append: true
     - header:
-        key: "x-request-start"
-        value: "%START_TIME(%s.%3f)%  %START_TIME% %START_TIME(%s)%"
+        key: "x-request-start-multiple"
+        value: "%START_TIME(%s.%3f)% %START_TIME% %START_TIME(%s)%"
       append: true
     - header:
         key: "x-request-start-f"
@@ -648,10 +648,13 @@ route:
 
   resp_header_parser->evaluateHeaders(headerMap, request_info);
   EXPECT_TRUE(headerMap.has("x-client-ip"));
+  EXPECT_TRUE(headerMap.has("x-request-start-multiple"));
   EXPECT_TRUE(headerMap.has("x-safe"));
   EXPECT_FALSE(headerMap.has("x-nope"));
   EXPECT_TRUE(headerMap.has("x-request-start"));
   EXPECT_EQ("1522796769.123", headerMap.get_("x-request-start"));
+  EXPECT_EQ("1522796769.123 2018-04-03T23:06:09.123Z 1522796769",
+            headerMap.get_("x-request-start-multiple"));
   EXPECT_TRUE(headerMap.has("x-request-start-f"));
   EXPECT_EQ("f", headerMap.get_("x-request-start-f"));
   EXPECT_TRUE(headerMap.has("x-request-start-default"));

--- a/test/common/router/header_parser_corpus/clusterfuzz-testcase-header_parser_fuzz_test-6195059702628352
+++ b/test/common/router/header_parser_corpus/clusterfuzz-testcase-header_parser_fuzz_test-6195059702628352
@@ -1,0 +1,8 @@
+headers_to_add {
+  header {
+    value: "%START_TIMEY()%T      %START_TIME(f, %�{{{{{_�����������85request_i:	1�227 f55555_n555555555555%85nfo 5#555.55f, %1f,  %85/5_inf %8,,,,,,,,,,,,,,,,,,,,,,,,,55555 start_timefo 5#5555#555.55f, %1f,  %85/55ime:	15227 f %1f,  %8555555555  %85/5555Fme:	15227 f-5555_inf 965L5559f)%"
+  }
+}
+request_info {
+  start_time:	1522796769123
+}


### PR DESCRIPTION
Title: Fixes oss-fuzz: 9895

Description: oss-fuzz issue (9895): https://oss-fuzz.com/v2/testcase-detail/6195059702628352
The given input testcase had multiple `START_TIME` formatters as value, a valid input must contain only one `START_TIME`, throwing exception if invalid.

Risk Level: Low

Testing: Tested unit tests (bazel test //test/common/router:header_parser_fuzz_test), built and ran fuzzers with oss-fuzz.

Signed-off-by: Anirudh M m.anirudh18@gmail.com