### PR TITLE
stats: refactoring MetricImpl without strings

### DIFF
--- a/include/envoy/stats/stats.h
+++ b/include/envoy/stats/stats.h
@@ -23,7 +23,7 @@ public:
   /**
    * Returns the full name of the Metric.
    */
-  virtual const std::string& name() const PURE;
+  virtual const std::string name() const PURE;
 
   /**
    * Returns a vector of configurable tags to identify this Metric.

--- a/source/common/stats/BUILD
+++ b/source/common/stats/BUILD
@@ -54,6 +54,7 @@ envoy_cc_library(
     hdrs = ["metric_impl.h"],
     deps = [
         "//include/envoy/stats:stats_interface",
+        "//source/common/common:assert_lib",
     ],
 )
 

--- a/source/common/stats/heap_stat_data.h
+++ b/source/common/stats/heap_stat_data.h
@@ -24,6 +24,11 @@ struct HeapStatData {
    */
   absl::string_view key() const { return name_; }
 
+  /**
+   * @returns std::string the name as a std::string.
+   */
+  std::string name() const { return name_; }
+
   std::atomic<uint64_t> value_{0};
   std::atomic<uint64_t> pending_increment_{0};
   std::atomic<uint16_t> flags_{0};

--- a/source/common/stats/histogram_impl.h
+++ b/source/common/stats/histogram_impl.h
@@ -46,7 +46,10 @@ class HistogramImpl : public Histogram, public MetricImpl {
 public:
   HistogramImpl(const std::string& name, Store& parent, std::string&& tag_extracted_name,
                 std::vector<Tag>&& tags)
-      : MetricImpl(name, std::move(tag_extracted_name), std::move(tags)), parent_(parent) {}
+      : MetricImpl(std::move(tag_extracted_name), std::move(tags)), parent_(parent), name_(name) {}
+
+  // Stats:;Metric
+  const std::string name() const override { return name_; }
 
   // Stats::Histogram
   void recordValue(uint64_t value) override { parent_.deliverHistogramToSinks(*this, value); }
@@ -56,6 +59,8 @@ public:
 private:
   // This is used for delivering the histogram data to sinks.
   Store& parent_;
+
+  const std::string name_;
 };
 
 } // namespace Stats

--- a/source/common/stats/metric_impl.h
+++ b/source/common/stats/metric_impl.h
@@ -13,6 +13,9 @@ namespace Stats {
 /**
  * Implementation of the Metric interface. Virtual inheritance is used because the interfaces that
  * will inherit from Metric will have other base classes that will also inherit from Metric.
+ *
+ * MetricImpl is not meant to be instantiated as-is. For performance reasons we keep name() virtual
+ * and expect child classes to implement it.
  */
 class MetricImpl : public virtual Metric {
 public:

--- a/source/common/stats/metric_impl.h
+++ b/source/common/stats/metric_impl.h
@@ -5,6 +5,8 @@
 
 #include "envoy/stats/stats.h"
 
+#include "common/common/assert.h"
+
 namespace Envoy {
 namespace Stats {
 
@@ -14,10 +16,10 @@ namespace Stats {
  */
 class MetricImpl : public virtual Metric {
 public:
-  MetricImpl(const std::string& name, std::string&& tag_extracted_name, std::vector<Tag>&& tags)
-      : name_(name), tag_extracted_name_(std::move(tag_extracted_name)), tags_(std::move(tags)) {}
+  MetricImpl(std::string&& tag_extracted_name, std::vector<Tag>&& tags)
+      : tag_extracted_name_(std::move(tag_extracted_name)), tags_(std::move(tags)) {}
 
-  const std::string& name() const override { return name_; }
+  const std::string name() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   const std::string& tagExtractedName() const override { return tag_extracted_name_; }
   const std::vector<Tag>& tags() const override { return tags_; }
 
@@ -30,7 +32,6 @@ protected:
   };
 
 private:
-  const std::string name_;
   const std::string tag_extracted_name_;
   const std::vector<Tag> tags_;
 };

--- a/source/common/stats/metric_impl.h
+++ b/source/common/stats/metric_impl.h
@@ -19,7 +19,6 @@ public:
   MetricImpl(std::string&& tag_extracted_name, std::vector<Tag>&& tags)
       : tag_extracted_name_(std::move(tag_extracted_name)), tags_(std::move(tags)) {}
 
-  const std::string name() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   const std::string& tagExtractedName() const override { return tag_extracted_name_; }
   const std::vector<Tag>& tags() const override { return tags_; }
 

--- a/source/common/stats/raw_stat_data.h
+++ b/source/common/stats/raw_stat_data.h
@@ -74,6 +74,11 @@ struct RawStatData {
    */
   absl::string_view key() const { return absl::string_view(name_); }
 
+  /**
+   * Returns the name as a std::string.
+   */
+  std::string name() const { return std::string(name_); }
+
   std::atomic<uint64_t> value_;
   std::atomic<uint64_t> pending_increment_;
   std::atomic<uint16_t> flags_;

--- a/source/common/stats/stat_data_allocator_impl.h
+++ b/source/common/stats/stat_data_allocator_impl.h
@@ -63,9 +63,11 @@ template <class StatData> class CounterImpl : public Counter, public MetricImpl 
 public:
   CounterImpl(StatData& data, StatDataAllocatorImpl<StatData>& alloc,
               std::string&& tag_extracted_name, std::vector<Tag>&& tags)
-      : MetricImpl(data.name_, std::move(tag_extracted_name), std::move(tags)), data_(data),
-        alloc_(alloc) {}
+      : MetricImpl(std::move(tag_extracted_name), std::move(tags)), data_(data), alloc_(alloc) {}
   ~CounterImpl() { alloc_.free(data_); }
+
+  // Stats::Metric
+  const std::string name() const override { return data_.name(); }
 
   // Stats::Counter
   void add(uint64_t amount) override {
@@ -92,9 +94,11 @@ template <class StatData> class GaugeImpl : public Gauge, public MetricImpl {
 public:
   GaugeImpl(StatData& data, StatDataAllocatorImpl<StatData>& alloc,
             std::string&& tag_extracted_name, std::vector<Tag>&& tags)
-      : MetricImpl(data.name_, std::move(tag_extracted_name), std::move(tags)), data_(data),
-        alloc_(alloc) {}
+      : MetricImpl(std::move(tag_extracted_name), std::move(tags)), data_(data), alloc_(alloc) {}
   ~GaugeImpl() { alloc_.free(data_); }
+
+  // Stats::Metric
+  const std::string name() const override { return data_.name(); }
 
   // Stats::Gauge
   virtual void add(uint64_t amount) override {

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -347,8 +347,8 @@ Histogram& ThreadLocalStoreImpl::ScopeImpl::tlsHistogram(const std::string& name
 ThreadLocalHistogramImpl::ThreadLocalHistogramImpl(const std::string& name,
                                                    std::string&& tag_extracted_name,
                                                    std::vector<Tag>&& tags)
-    : MetricImpl(name, std::move(tag_extracted_name), std::move(tags)), current_active_(0),
-      flags_(0), created_thread_id_(std::this_thread::get_id()) {
+    : MetricImpl(std::move(tag_extracted_name), std::move(tags)), current_active_(0), flags_(0),
+      created_thread_id_(std::this_thread::get_id()), name_(name) {
   histograms_[0] = hist_alloc();
   histograms_[1] = hist_alloc();
 }
@@ -373,10 +373,10 @@ void ThreadLocalHistogramImpl::merge(histogram_t* target) {
 ParentHistogramImpl::ParentHistogramImpl(const std::string& name, Store& parent,
                                          TlsScope& tls_scope, std::string&& tag_extracted_name,
                                          std::vector<Tag>&& tags)
-    : MetricImpl(name, std::move(tag_extracted_name), std::move(tags)), parent_(parent),
+    : MetricImpl(std::move(tag_extracted_name), std::move(tags)), parent_(parent),
       tls_scope_(tls_scope), interval_histogram_(hist_alloc()), cumulative_histogram_(hist_alloc()),
       interval_statistics_(interval_histogram_), cumulative_statistics_(cumulative_histogram_),
-      merged_(false) {}
+      merged_(false), name_(name) {}
 
 ParentHistogramImpl::~ParentHistogramImpl() {
   hist_free(interval_histogram_);

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -47,12 +47,16 @@ public:
   void recordValue(uint64_t value) override;
   bool used() const override { return flags_ & Flags::Used; }
 
+  // Stats::Metric
+  const std::string name() const override { return name_; }
+
 private:
   uint64_t otherHistogramIndex() const { return 1 - current_active_; }
   uint64_t current_active_;
   histogram_t* histograms_[2];
   std::atomic<uint16_t> flags_;
   std::thread::id created_thread_id_;
+  const std::string name_;
 };
 
 typedef std::shared_ptr<ThreadLocalHistogramImpl> TlsHistogramSharedPtr;
@@ -86,6 +90,9 @@ public:
   }
   const std::string summary() const override;
 
+  // Stats::Metric
+  const std::string name() const override { return name_; }
+
 private:
   bool usedLockHeld() const EXCLUSIVE_LOCKS_REQUIRED(merge_lock_);
 
@@ -98,6 +105,7 @@ private:
   mutable Thread::MutexBasicLockable merge_lock_;
   std::list<TlsHistogramSharedPtr> tls_histograms_ GUARDED_BY(merge_lock_);
   bool merged_;
+  const std::string name_;
 };
 
 typedef std::shared_ptr<ParentHistogramImpl> ParentHistogramImplSharedPtr;

--- a/test/mocks/stats/mocks.cc
+++ b/test/mocks/stats/mocks.cc
@@ -14,7 +14,6 @@ namespace Envoy {
 namespace Stats {
 
 MockCounter::MockCounter() {
-  ON_CALL(*this, name()).WillByDefault(ReturnRef(name_));
   ON_CALL(*this, tagExtractedName()).WillByDefault(ReturnRef(name_));
   ON_CALL(*this, tags()).WillByDefault(ReturnRef(tags_));
   ON_CALL(*this, used()).WillByDefault(ReturnPointee(&used_));
@@ -24,7 +23,6 @@ MockCounter::MockCounter() {
 MockCounter::~MockCounter() {}
 
 MockGauge::MockGauge() {
-  ON_CALL(*this, name()).WillByDefault(ReturnRef(name_));
   ON_CALL(*this, tagExtractedName()).WillByDefault(ReturnRef(name_));
   ON_CALL(*this, tags()).WillByDefault(ReturnRef(tags_));
   ON_CALL(*this, used()).WillByDefault(ReturnPointee(&used_));

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -27,10 +27,13 @@ public:
   MockCounter();
   ~MockCounter();
 
+  // Note: cannot be mocked because it is accessed as a Property in a gmock EXPECT_CALL. This
+  // creates a deadlock in gmock and is an unintended use of mock functions.
+  const std::string name() const override { return name_; };
+
   MOCK_METHOD1(add, void(uint64_t amount));
   MOCK_METHOD0(inc, void());
   MOCK_METHOD0(latch, uint64_t());
-  MOCK_CONST_METHOD0(name, const std::string&());
   MOCK_CONST_METHOD0(tagExtractedName, const std::string&());
   MOCK_CONST_METHOD0(tags, const std::vector<Tag>&());
   MOCK_METHOD0(reset, void());
@@ -49,10 +52,13 @@ public:
   MockGauge();
   ~MockGauge();
 
+  // Note: cannot be mocked because it is accessed as a Property in a gmock EXPECT_CALL. This
+  // creates a deadlock in gmock and is an unintended use of mock functions.
+  const std::string name() const override { return name_; };
+
   MOCK_METHOD1(add, void(uint64_t amount));
   MOCK_METHOD0(dec, void());
   MOCK_METHOD0(inc, void());
-  MOCK_CONST_METHOD0(name, const std::string&());
   MOCK_CONST_METHOD0(tagExtractedName, const std::string&());
   MOCK_CONST_METHOD0(tags, const std::vector<Tag>&());
   MOCK_METHOD1(set, void(uint64_t value));
@@ -73,7 +79,7 @@ public:
 
   // Note: cannot be mocked because it is accessed as a Property in a gmock EXPECT_CALL. This
   // creates a deadlock in gmock and is an unintended use of mock functions.
-  const std::string& name() const override { return name_; };
+  const std::string name() const override { return name_; };
 
   MOCK_CONST_METHOD0(tagExtractedName, const std::string&());
   MOCK_CONST_METHOD0(tags, const std::vector<Tag>&());
@@ -92,7 +98,7 @@ public:
 
   // Note: cannot be mocked because it is accessed as a Property in a gmock EXPECT_CALL. This
   // creates a deadlock in gmock and is an unintended use of mock functions.
-  const std::string& name() const override { return name_; };
+  const std::string name() const override { return name_; };
   void merge() override {}
   const std::string summary() const override { return ""; };
 


### PR DESCRIPTION
Signed-off-by: James Buckland <jbuckland@google.com>

*Description*: This reworks `MetricImpl` to get rid of the `std::string` it keeps as a private member variable. Since `MetricImpl` never gets instantiated as-is, I let each of its extending classes implement `name()` for themselves, often without the need to copy strings.  (Part of https://github.com/envoyproxy/envoy/issues/3585/)

In my estimation, running 

    bazel build //source/exe:envoy-static --copt='-ltcmalloc'
    timeout 90 bazel-bin/source/exe/envoy-static --disable-hot-restart --config-path <a_config_with_10k_clusters>
    pprof -text bazel-bin/source/exe/envoy-static main_common_base*

on upstream as-is vs. this branch saves ~20% memory consumption on the heap. 

*Risk Level*: Medium -- anything that changes stats is tricky. But this doesn't change RawStatData, just `MetricImpl`.
*Testing*: This required editing the `MockCounter`/`MockGauge` classes, but otherwise it passes all tests.
*Docs Changes*: N/A
*Release Notes*: N/A
