### PR TITLE
admin: fix config dump order

### DIFF
--- a/api/envoy/admin/v2alpha/config_dump.proto
+++ b/api/envoy/admin/v2alpha/config_dump.proto
@@ -17,17 +17,17 @@ import "gogoproto/gogo.proto";
 // The :ref:`/config_dump <operations_admin_interface_config_dump>` admin endpoint uses this wrapper
 // message to maintain and serve arbitrary configuration information from any component in Envoy.
 message ConfigDump {
-  // This map is serialized and dumped in its entirety at the
+  // This list is serialized and dumped in its entirety at the
   // :ref:`/config_dump <operations_admin_interface_config_dump>` endpoint.
   //
-  // Keys are a short descriptor of the config object they map to. The following keys (and the
-  // messages they map to) are currently supported:
+  // The following configurations are currently supported and will be dumped in the order given
+  // below:
   //
   // * *bootstrap*: :ref:`BootstrapConfigDump <envoy_api_msg_admin.v2alpha.BootstrapConfigDump>`
-  // * *listeners*: :ref:`ListenersConfigDump <envoy_api_msg_admin.v2alpha.ListenersConfigDump>`
   // * *clusters*: :ref:`ClustersConfigDump <envoy_api_msg_admin.v2alpha.ClustersConfigDump>`
+  // * *listeners*: :ref:`ListenersConfigDump <envoy_api_msg_admin.v2alpha.ListenersConfigDump>`
   // * *routes*:  :ref:`RoutesConfigDump <envoy_api_msg_admin.v2alpha.RoutesConfigDump>`
-  map<string, google.protobuf.Any> configs = 1 [(gogoproto.nullable) = false];
+  repeated google.protobuf.Any configs = 1 [(gogoproto.nullable) = false];
 }
 
 // This message describes the bootstrap configuration that Envoy was started with. This includes

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -389,13 +389,11 @@ Http::Code AdminImpl::handlerClusters(absl::string_view url, Http::HeaderMap& re
 Http::Code AdminImpl::handlerConfigDump(absl::string_view, Http::HeaderMap& response_headers,
                                         Buffer::Instance& response, AdminStream&) const {
   envoy::admin::v2alpha::ConfigDump dump;
-  auto& config_dump_map = *(dump.mutable_configs());
   for (const auto& key_callback_pair : config_tracker_.getCallbacksMap()) {
     ProtobufTypes::MessagePtr message = key_callback_pair.second();
     RELEASE_ASSERT(message, "");
-    ProtobufWkt::Any any_message;
+    auto& any_message = *(dump.add_configs());
     any_message.PackFrom(*message);
-    config_dump_map[key_callback_pair.first] = any_message;
   }
 
   response_headers.insertContentType().value().setReference(

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -532,17 +532,70 @@ TEST_P(AdminInstanceTest, ConfigDump) {
     return msg;
   });
   const std::string expected_json = R"EOF({
- "configs": {
-  "foo": {
+ "configs": [
+  {
    "@type": "type.googleapis.com/google.protobuf.StringValue",
    "value": "bar"
   }
- }
+ ]
 }
 )EOF";
   EXPECT_EQ(Http::Code::OK, getCallback("/config_dump", header_map, response));
   std::string output = response.toString();
   EXPECT_EQ(expected_json, output);
+}
+
+TEST_P(AdminInstanceTest, ConfigDumpMaintainsOrder) {
+  // Add configs in random order and validate config_dump dumps in the order.
+  auto bootstrap_entry = admin_.getConfigTracker().add("bootstrap", [] {
+    auto msg = std::make_unique<ProtobufWkt::StringValue>();
+    msg->set_value("bootstrap_config");
+    return msg;
+  });
+  auto route_entry = admin_.getConfigTracker().add("routes", [] {
+    auto msg = std::make_unique<ProtobufWkt::StringValue>();
+    msg->set_value("routes_config");
+    return msg;
+  });
+  auto listener_entry = admin_.getConfigTracker().add("listeners", [] {
+    auto msg = std::make_unique<ProtobufWkt::StringValue>();
+    msg->set_value("listeners_config");
+    return msg;
+  });
+  auto cluster_entry = admin_.getConfigTracker().add("clusters", [] {
+    auto msg = std::make_unique<ProtobufWkt::StringValue>();
+    msg->set_value("clusters_config");
+    return msg;
+  });
+  const std::string expected_json = R"EOF({
+ "configs": [
+  {
+   "@type": "type.googleapis.com/google.protobuf.StringValue",
+   "value": "bootstrap_config"
+  },
+  {
+   "@type": "type.googleapis.com/google.protobuf.StringValue",
+   "value": "clusters_config"
+  },
+  {
+   "@type": "type.googleapis.com/google.protobuf.StringValue",
+   "value": "listeners_config"
+  },
+  {
+   "@type": "type.googleapis.com/google.protobuf.StringValue",
+   "value": "routes_config"
+  }
+ ]
+}
+)EOF";
+  // Run it multiple times and validate that order is preserved.
+  for (size_t i = 0; i < 5; i++) {
+    Buffer::OwnedImpl response;
+    Http::HeaderMapImpl header_map;
+    EXPECT_EQ(Http::Code::OK, getCallback("/config_dump", header_map, response));
+    std::string output = response.toString();
+    EXPECT_EQ(expected_json, output);
+  }
 }
 
 TEST_P(AdminInstanceTest, Runtime) {

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -593,7 +593,7 @@ TEST_P(AdminInstanceTest, ConfigDumpMaintainsOrder) {
     Buffer::OwnedImpl response;
     Http::HeaderMapImpl header_map;
     EXPECT_EQ(Http::Code::OK, getCallback("/config_dump", header_map, response));
-    std::string output = response.toString();
+    const std::string output = response.toString();
     EXPECT_EQ(expected_json, output);
   }
 }


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*: Fixes the order of config_dump elements - bootstrap, clusters, listeners and routes will come in that order. Note that inside each of them, ordering is not guaranteed. This is a step in moving towards complete ordering.
*Risk Level*: Low
*Testing*: Added Automated tests
*Docs Changes*: Updated
*Release Notes*: N/A
