### PR TITLE
bug_fix: modified HTTP and gRPC clients to return Forbidden HTTP status error

### DIFF
--- a/source/extensions/filters/common/ext_authz/BUILD
+++ b/source/extensions/filters/common/ext_authz/BUILD
@@ -53,6 +53,7 @@ envoy_cc_library(
         ":ext_authz_interface",
         "//source/common/common:minimal_logger_lib",
         "//source/common/http:async_client_lib",
+        "//source/common/http:codes_lib",
     ],
 )
 

--- a/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
@@ -67,10 +67,12 @@ void GrpcClientImpl::onSuccess(
 
 void GrpcClientImpl::onFailure(Grpc::Status::GrpcStatus status, const std::string&,
                                Tracing::Span&) {
+  ENVOY_LOG(warn, "ext_authz gRPC client failed to call the authorization server.");
   ASSERT(status != Grpc::Status::GrpcStatus::Ok);
-  ResponsePtr authz_response = std::make_unique<Response>(Response{});
-  authz_response->status = CheckStatus::Error;
-  callbacks_->onComplete(std::move(authz_response));
+  Response response{};
+  response.status = CheckStatus::Error;
+  response.status_code = Http::Code::Forbidden;
+  callbacks_->onComplete(std::make_unique<Response>(response));
   callbacks_ = nullptr;
 }
 

--- a/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.h
@@ -16,6 +16,7 @@
 #include "envoy/tracing/http_tracer.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "common/common/logger.h"
 #include "common/singleton/const_singleton.h"
 
 #include "extensions/filters/common/ext_authz/check_request_utils.h"
@@ -45,7 +46,9 @@ typedef ConstSingleton<ConstantValues> Constants;
  * The gRPC client does not rewrite path. NOTE: We create gRPC client for each filter stack instead
  * of a client per thread. That is ok since this is unary RPC and the cost of doing this is minimal.
  */
-class GrpcClientImpl : public Client, public ExtAuthzAsyncCallbacks {
+class GrpcClientImpl : public Client,
+                       public ExtAuthzAsyncCallbacks,
+                       Logger::Loggable<Logger::Id::config> {
 public:
   GrpcClientImpl(Grpc::AsyncClientPtr&& async_client,
                  const absl::optional<std::chrono::milliseconds>& timeout);

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
@@ -41,6 +41,7 @@ public:
   void onFailure(Http::AsyncClient::FailureReason reason) override;
 
 private:
+  ResponsePtr messageToResponse(Http::MessagePtr& message);
   const std::string cluster_name_;
   const std::string path_prefix_;
   const Http::LowerCaseStrUnorderedSet& allowed_authorization_headers_;

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -30,7 +30,7 @@ void Filter::initiateCall(const Http::HeaderMap& headers) {
   // Don't let the filter chain continue as we are going to invoke check call.
   filter_return_ = FilterReturn::StopDecoding;
   initiating_call_ = true;
-  ENVOY_STREAM_LOG(trace, "Ext_authz filter calling authorization server", *callbacks_);
+  ENVOY_STREAM_LOG(trace, "ext_authz filter calling authorization server", *callbacks_);
   client_->check(*this, check_request_, callbacks_->activeSpan());
   initiating_call_ = false;
 }
@@ -94,15 +94,15 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
     break;
   }
 
-  ENVOY_STREAM_LOG(trace, "Ext_authz received status code {}", *callbacks_,
+  ENVOY_STREAM_LOG(trace, "ext_authz received status code {}", *callbacks_,
                    enumToInt(response->status_code));
 
   // We fail open/fail close based of filter config
   // if there is an error contacting the service.
   if (response->status == CheckStatus::Denied ||
       (response->status == CheckStatus::Error && !config_->failureModeAllow())) {
-    ENVOY_STREAM_LOG(debug, "Ext_authz rejected the request", *callbacks_);
-    ENVOY_STREAM_LOG(trace, "Ext_authz downstream header(s):", *callbacks_);
+    ENVOY_STREAM_LOG(debug, "ext_authz rejected the request", *callbacks_);
+    ENVOY_STREAM_LOG(trace, "ext_authz downstream header(s):", *callbacks_);
     callbacks_->sendLocalReply(response->status_code, response->body,
                                [& headers = response->headers_to_add, &callbacks = *callbacks_](
                                    Http::HeaderMap& response_headers) -> void {
@@ -116,7 +116,7 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
     callbacks_->requestInfo().setResponseFlag(
         RequestInfo::ResponseFlag::UnauthorizedExternalService);
   } else {
-    ENVOY_STREAM_LOG(debug, "Ext_authz accepted the request", *callbacks_);
+    ENVOY_STREAM_LOG(debug, "ext_authz accepted the request", *callbacks_);
     // Let the filter chain continue.
     filter_return_ = FilterReturn::ContinueDecoding;
     if (config_->failureModeAllow() && response->status == CheckStatus::Error) {
@@ -125,7 +125,7 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
     }
     // Only send headers if the response is ok.
     if (response->status == CheckStatus::OK) {
-      ENVOY_STREAM_LOG(trace, "Ext_authz upstream header(s):", *callbacks_);
+      ENVOY_STREAM_LOG(trace, "ext_authz upstream header(s):", *callbacks_);
       for (const auto& header : response->headers_to_add) {
         Http::HeaderEntry* header_to_modify = request_headers_->get(header.first);
         if (header_to_modify) {

--- a/test/extensions/filters/common/ext_authz/test_common.h
+++ b/test/extensions/filters/common/ext_authz/test_common.h
@@ -14,7 +14,17 @@ namespace Filters {
 namespace Common {
 namespace ExtAuthz {
 
-MATCHER_P(AuthzErrorResponse, status, "") { return arg->status == status; }
+MATCHER_P(AuthzErrorResponse, status, "") {
+  // These fields should be always empty when the status is an error.
+  if (!arg->headers_to_add.empty() || !arg->headers_to_append.empty() || !arg->body.empty()) {
+    return false;
+  }
+  // HTTP status code should be always set to Forbidden.
+  if (arg->status_code != Http::Code::Forbidden) {
+    return false;
+  }
+  return arg->status == status;
+}
 
 MATCHER_P(AuthzResponseNoAttributes, response, "") {
   if (arg->status != response.status) {


### PR DESCRIPTION
*Description*: Ext_Authz HTTP client has been modified so that 5xx errors received from the authorization server will set the filter response status to `error` instead of `denied` and HTTP status code field to `Forbidden`. The gRPC client has been also modified in order to return HTTP status code Forbidden whenever an error between the client and the authorization server occurs.

*Risk Level*: low
*Testing*: unit tests, manual tests.
*Docs Changes*: not needed.
*Fixes issue:* https://github.com/envoyproxy/envoy/issues/4124. 

Signed-off-by: Gabriel <gsagula@gmail.com>

cc @dio 