### PR TITLE
fuzz: make temporary path and port handling less flaky for server fuz…

### DIFF
--- a/test/fuzz/BUILD
+++ b/test/fuzz/BUILD
@@ -37,6 +37,7 @@ envoy_cc_test_library(
     deps = [
         "//source/common/common:minimal_logger_lib",
         "//source/common/common:thread_lib",
+        "//source/common/common:utility_lib",
         "//source/common/event:libevent_lib",
         "//test/test_common:environment_lib",
     ],

--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -12,13 +12,14 @@ namespace Fuzz {
 
 spdlog::level::level_enum Runner::log_level_;
 
-PerTestEnvironment::PerTestEnvironment() {
-  const std::string fuzz_path = TestEnvironment::temporaryPath("fuzz_XXXXXX");
-  char test_tmpdir[fuzz_path.size() + 1];
-  StringUtil::strlcpy(test_tmpdir, fuzz_path.data(), fuzz_path.size() + 1);
-  RELEASE_ASSERT(::mkdtemp(test_tmpdir) != nullptr, "");
-  test_tmpdir_ = std::string(test_tmpdir);
-}
+PerTestEnvironment::PerTestEnvironment()
+    : test_tmpdir_([] {
+        const std::string fuzz_path = TestEnvironment::temporaryPath("fuzz_XXXXXX");
+        char test_tmpdir[fuzz_path.size() + 1];
+        StringUtil::strlcpy(test_tmpdir, fuzz_path.data(), fuzz_path.size() + 1);
+        RELEASE_ASSERT(::mkdtemp(test_tmpdir) != nullptr, "");
+        return std::string(test_tmpdir);
+      }()) {}
 
 void Runner::setupEnvironment(int argc, char** argv, spdlog::level::level_enum default_log_level) {
   Event::Libevent::Global::initialize();

--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -2,6 +2,7 @@
 
 #include "common/common/logger.h"
 #include "common/common/thread.h"
+#include "common/common/utility.h"
 #include "common/event/libevent.h"
 
 #include "test/test_common/environment.h"
@@ -10,6 +11,14 @@ namespace Envoy {
 namespace Fuzz {
 
 spdlog::level::level_enum Runner::log_level_;
+
+PerTestEnvironment::PerTestEnvironment() {
+  const std::string fuzz_path = TestEnvironment::temporaryPath("fuzz_XXXXXX");
+  char test_tmpdir[fuzz_path.size() + 1];
+  StringUtil::strlcpy(test_tmpdir, fuzz_path.data(), fuzz_path.size() + 1);
+  RELEASE_ASSERT(::mkdtemp(test_tmpdir) != nullptr, "");
+  test_tmpdir_ = std::string(test_tmpdir);
+}
 
 void Runner::setupEnvironment(int argc, char** argv, spdlog::level::level_enum default_log_level) {
   Event::Libevent::Global::initialize();

--- a/test/fuzz/fuzz_runner.h
+++ b/test/fuzz/fuzz_runner.h
@@ -11,6 +11,19 @@
 namespace Envoy {
 namespace Fuzz {
 
+// Each test may need a sub-environment of that provided by //test/test_common:environment_lib,
+// since each fuzz invocation runs in the same process, but might want a distinct tmp sandbox for
+// example.
+class PerTestEnvironment {
+public:
+  PerTestEnvironment();
+
+  std::string temporaryPath(const std::string& path) const { return test_tmpdir_ + "/" + path; }
+
+private:
+  std::string test_tmpdir_;
+};
+
 class Runner {
 public:
   /**

--- a/test/fuzz/fuzz_runner.h
+++ b/test/fuzz/fuzz_runner.h
@@ -21,7 +21,7 @@ public:
   std::string temporaryPath(const std::string& path) const { return test_tmpdir_ + "/" + path; }
 
 private:
-  std::string test_tmpdir_;
+  const std::string test_tmpdir_;
 };
 
 class Runner {

--- a/test/server/config_validation/config_fuzz_test.cc
+++ b/test/server/config_validation/config_fuzz_test.cc
@@ -16,8 +16,9 @@ namespace Server {
 DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v2::Bootstrap& input) {
   testing::NiceMock<MockOptions> options;
   TestComponentFactory component_factory;
+  Fuzz::PerTestEnvironment test_env;
 
-  const std::string bootstrap_path = TestEnvironment::temporaryPath("bootstrap.pb_text");
+  const std::string bootstrap_path = test_env.temporaryPath("bootstrap.pb_text");
   std::ofstream bootstrap_file(bootstrap_path);
   bootstrap_file << input.DebugString();
   options.config_path_ = bootstrap_path;

--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -16,6 +16,39 @@
 namespace Envoy {
 namespace Server {
 
+void makePortHermetic(envoy::api::v2::core::Address& address) {
+  if (address.has_socket_address()) {
+    address.mutable_socket_address()->set_port_value(0);
+  }
+}
+
+envoy::config::bootstrap::v2::Bootstrap
+makeHermeticPathsAndPorts(Fuzz::PerTestEnvironment& test_env,
+                          const envoy::config::bootstrap::v2::Bootstrap& input) {
+  envoy::config::bootstrap::v2::Bootstrap output;
+  output.MergeFrom(input);
+  // This is not a complete list of places where we need to zero out ports or sanitize paths, so we
+  // should adapt it as we go and encounter places that we need to stabilize server test flakes.
+  // config_validation_fuzz_test doesn't need to do this sanitization, so should pickup the coverage
+  // we lose here. If we don't sanitize here, we get flakes due to port bind conflicts, file
+  // conflicts, etc.
+  output.mutable_admin()->set_access_log_path(test_env.temporaryPath("admin.log"));
+  if (output.admin().has_address()) {
+    makePortHermetic(*output.mutable_admin()->mutable_address());
+  }
+  for (auto& listener : *output.mutable_static_resources()->mutable_listeners()) {
+    if (listener.has_address()) {
+      makePortHermetic(*listener.mutable_address());
+    }
+  }
+  for (auto& cluster : *output.mutable_static_resources()->mutable_clusters()) {
+    for (auto& host : *cluster.mutable_hosts()) {
+      makePortHermetic(host);
+    }
+  }
+  return output;
+}
+
 DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v2::Bootstrap& input) {
   testing::NiceMock<MockOptions> options;
   DefaultTestHooks hooks;
@@ -24,13 +57,14 @@ DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v2::Bootstrap& input) {
   Thread::MutexBasicLockable fakelock;
   TestComponentFactory component_factory;
   ThreadLocal::InstanceImpl thread_local_instance;
+  Fuzz::PerTestEnvironment test_env;
 
   RELEASE_ASSERT(Envoy::Server::validateProtoDescriptors(), "");
 
   {
-    const std::string bootstrap_path = TestEnvironment::temporaryPath("bootstrap.pb_text");
+    const std::string bootstrap_path = test_env.temporaryPath("bootstrap.pb_text");
     std::ofstream bootstrap_file(bootstrap_path);
-    bootstrap_file << input.DebugString();
+    bootstrap_file << makeHermeticPathsAndPorts(test_env, input).DebugString();
     options.config_path_ = bootstrap_path;
     options.v2_config_only_ = true;
     options.log_level_ = Fuzz::Runner::logLevel();

--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -25,8 +25,7 @@ void makePortHermetic(envoy::api::v2::core::Address& address) {
 envoy::config::bootstrap::v2::Bootstrap
 makeHermeticPathsAndPorts(Fuzz::PerTestEnvironment& test_env,
                           const envoy::config::bootstrap::v2::Bootstrap& input) {
-  envoy::config::bootstrap::v2::Bootstrap output;
-  output.MergeFrom(input);
+  envoy::config::bootstrap::v2::Bootstrap output(input);
   // This is not a complete list of places where we need to zero out ports or sanitize paths, so we
   // should adapt it as we go and encounter places that we need to stabilize server test flakes.
   // config_validation_fuzz_test doesn't need to do this sanitization, so should pickup the coverage

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -62,7 +62,11 @@ std::string getTemporaryDirectory() {
   if (::getenv("TMPDIR")) {
     return TestEnvironment::getCheckedEnvVar("TMPDIR");
   }
-  return "/tmp";
+  // In environments outside of Bazel, we still don't want to use deterministic paths, as we may
+  // have multiple instances conflict, e.g. when running under a fuzzer.
+  char test_tmpdir[] = "/tmp/envoy_test_tmp.XXXXXX";
+  RELEASE_ASSERT(::mkdtemp(test_tmpdir) != nullptr, "");
+  return std::string(test_tmpdir);
 }
 
 // Allow initializeOptions() to remember CLI args for getOptions().


### PR DESCRIPTION
…z tests.

* Avoid reusing temporary paths across tests.

* Force port zero binding on server_fuzz_test.

* Force server_fuzz_test not to write access log to random places on FS.

I don't think this is the last we'll see on the server_fuzz_test flake test, since this particular
fuzz test is inherently non-hermetic. So, this seems to be the high payoff whackamole for now.

Risk level: Low.
Testing: Ran server_fuzz_test test under Bazel and oss-fuzz Docker image.

Signed-off-by: Harvey Tuch <htuch@google.com>