### PR TITLE
Fix missing health check address for LOGICAL_DNS

### DIFF
--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -110,9 +110,9 @@ public:
   virtual Network::Address::InstanceConstSharedPtr healthCheckAddress() const PURE;
 
   /**
-   * Set the address used to health check the host. This is NOP by default.
+   * Set the address used to health check the host.
    */
-  virtual void setHealthCheckAddress(Network::Address::InstanceConstSharedPtr) {}
+  virtual void setHealthCheckAddress(Network::Address::InstanceConstSharedPtr) PURE;
 };
 
 typedef std::shared_ptr<const HostDescription> HostDescriptionConstSharedPtr;

--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -108,6 +108,11 @@ public:
    * @return the address used to health check the host.
    */
   virtual Network::Address::InstanceConstSharedPtr healthCheckAddress() const PURE;
+
+  /**
+   * Set the address used to health check the host. This is NOP by default.
+   */
+  virtual void setHealthCheckAddress(Network::Address::InstanceConstSharedPtr) {}
 };
 
 typedef std::shared_ptr<const HostDescription> HostDescriptionConstSharedPtr;

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -55,6 +55,10 @@ private:
                      const Network::ConnectionSocket::OptionsSharedPtr& options) const override;
 
     // Upstream::HostDescription
+    // Override setting health check address, since for logical DNS the registered host has 0.0.0.0
+    // as its address (see mattklein123's comment in logical_dns_cluster.cc why this is),
+    // while the health check address needs the resolved address to do the health checking, so we
+    // set it here.
     void setHealthCheckAddress(Network::Address::InstanceConstSharedPtr address) override {
       const auto& port_value = parent_.lbEndpoint().endpoint().health_check_config().port_value();
       health_check_address_ =
@@ -102,6 +106,8 @@ private:
     Network::Address::InstanceConstSharedPtr healthCheckAddress() const override {
       return health_check_address_;
     }
+    // Setting health check address is usually done at initialization. This is NOP by default.
+    void setHealthCheckAddress(Network::Address::InstanceConstSharedPtr) override {}
     uint32_t priority() const { return locality_lb_endpoint_.priority(); }
     Network::Address::InstanceConstSharedPtr address_;
     HostConstSharedPtr logical_host_;

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -54,6 +54,13 @@ private:
     createConnection(Event::Dispatcher& dispatcher,
                      const Network::ConnectionSocket::OptionsSharedPtr& options) const override;
 
+    // Upstream::HostDescription
+    void setHealthCheckAddress(Network::Address::InstanceConstSharedPtr address) override {
+      const auto& port_value = parent_.lbEndpoint().endpoint().health_check_config().port_value();
+      health_check_address_ =
+          port_value == 0 ? address : Network::Utility::getAddressWithPort(*address, port_value);
+    }
+
     LogicalDnsCluster& parent_;
   };
 

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -122,6 +122,8 @@ public:
   Network::Address::InstanceConstSharedPtr healthCheckAddress() const override {
     return health_check_address_;
   }
+  // Setting health check address is usually done at initialization. This is NOP by default.
+  void setHealthCheckAddress(Network::Address::InstanceConstSharedPtr) override {}
   const envoy::api::v2::core::Locality& locality() const override { return locality_; }
 
 protected:

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -75,6 +75,7 @@ public:
 
   MOCK_CONST_METHOD0(address, Network::Address::InstanceConstSharedPtr());
   MOCK_CONST_METHOD0(healthCheckAddress, Network::Address::InstanceConstSharedPtr());
+  MOCK_METHOD1(setHealthCheckAddress, void(Network::Address::InstanceConstSharedPtr));
   MOCK_CONST_METHOD0(canary, bool());
   MOCK_METHOD1(canary, void(bool new_canary));
   MOCK_CONST_METHOD0(metadata, const std::shared_ptr<envoy::api::v2::core::Metadata>());
@@ -127,6 +128,7 @@ public:
 
   MOCK_CONST_METHOD0(address, Network::Address::InstanceConstSharedPtr());
   MOCK_CONST_METHOD0(healthCheckAddress, Network::Address::InstanceConstSharedPtr());
+  MOCK_METHOD1(setHealthCheckAddress, void(Network::Address::InstanceConstSharedPtr));
   MOCK_CONST_METHOD0(canary, bool());
   MOCK_METHOD1(canary, void(bool new_canary));
   MOCK_CONST_METHOD0(metadata, const std::shared_ptr<envoy::api::v2::core::Metadata>());


### PR DESCRIPTION
This patch makes sure the member of `LOGICAL_DNS` cluster has a valid health
check address.

*Risk Level*: Low
*Testing*: Unit and manual
*Docs Changes*: N/A
*Release Notes*: N/A

Fixes #3908

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>

