### PR TITLE
fuzz: another take at mkdtemp for individual fuzz test cases.

### DIFF
--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -14,10 +14,15 @@ spdlog::level::level_enum Runner::log_level_;
 
 PerTestEnvironment::PerTestEnvironment()
     : test_tmpdir_([] {
-        const std::string fuzz_path = TestEnvironment::temporaryPath("fuzz_XXXXXX");
+        static uint32_t test_num;
+        const std::string fuzz_path =
+            TestEnvironment::temporaryPath(fmt::format("fuzz_{}.XXXXXX", test_num++));
         char test_tmpdir[fuzz_path.size() + 1];
         StringUtil::strlcpy(test_tmpdir, fuzz_path.data(), fuzz_path.size() + 1);
-        RELEASE_ASSERT(::mkdtemp(test_tmpdir) != nullptr, "");
+        if (::mkdtemp(test_tmpdir) == nullptr) {
+          ENVOY_LOG_MISC(critical, "Failed to create tmpdir {} {}", fuzz_path, strerror(errno));
+          RELEASE_ASSERT(false, "");
+        }
         return std::string(test_tmpdir);
       }()) {}
 

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -62,11 +62,7 @@ std::string getTemporaryDirectory() {
   if (::getenv("TMPDIR")) {
     return TestEnvironment::getCheckedEnvVar("TMPDIR");
   }
-  // In environments outside of Bazel, we still don't want to use deterministic paths, as we may
-  // have multiple instances conflict, e.g. when running under a fuzzer.
-  char test_tmpdir[] = "/tmp/envoy_test_tmp.XXXXXX";
-  RELEASE_ASSERT(::mkdtemp(test_tmpdir) != nullptr, "");
-  return std::string(test_tmpdir);
+  return "/tmp";
 }
 
 // Allow initializeOptions() to remember CLI args for getOptions().


### PR DESCRIPTION
Overnight, ClusterFuzz reported failures on mkdtemp; maybe due to collisions? Added test number and
better debugging. Also, removed the double mkdtemp, less places to fail (both sites were
triggering).

Risk level: Low
Testing: Under bazel test and oss-fuzz Docker image.

Signed-off-by: Harvey Tuch <htuch@google.com>