### PR TITLE
api: add non-empty constraints for route cluster and cluster header.

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -338,7 +338,7 @@ message RouteAction {
 
     // Indicates the upstream cluster to which the request should be routed
     // to.
-    string cluster = 1;
+    string cluster = 1 [(validate.rules).string.min_bytes = 1];
 
     // Envoy will determine the cluster to route to by reading the value of the
     // HTTP header named by cluster_header from the request headers. If the
@@ -349,7 +349,7 @@ message RouteAction {
     //
     //   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
     //   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
-    string cluster_header = 2;
+    string cluster_header = 2 [(validate.rules).string.min_bytes = 1];
 
     // Multiple upstream clusters can be specified for a given route. The
     // request is routed to one of the upstream clusters based on weights

--- a/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-5198208916520960
+++ b/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-5198208916520960
@@ -1,0 +1,1 @@
+config {   virtual_hosts {     name: " "     domains: "*"     routes {       match {         path: ""       }       route {         cluster: ""       }     }   } } headers {   headers {     key: ":path"   } } 


### PR DESCRIPTION
Fixes oss-fuzz issue
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=9991.

Risk level: Low
Testing: Corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>