### PR TITLE
api: limit regex to 1024 chars in allow_origin_regex.

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -310,7 +310,7 @@ message CorsPolicy {
   // Specifies regex patterns that match allowed origins.
   //
   // An origin is allowed if either allow_origin or allow_origin_regex match.
-  repeated string allow_origin_regex = 8;
+  repeated string allow_origin_regex = 8 [(validate.rules).repeated.items.string.max_bytes = 1024];
 
   // Specifies the content for the *access-control-allow-methods* header.
   string allow_methods = 2;

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -310,7 +310,7 @@ message CorsPolicy {
   // Specifies regex patterns that match allowed origins.
   //
   // An origin is allowed if either allow_origin or allow_origin_regex match.
-  repeated string allow_origin_regex = 8 [(validate.rules).repeated.items.string.max_bytes = 1024];
+  repeated string allow_origin_regex = 8 [(validate.rules).repeated .items.string.max_bytes = 1024];
 
   // Specifies the content for the *access-control-allow-methods* header.
   string allow_methods = 2;


### PR DESCRIPTION
I missed this one in #4198, this fixes oss-fuzz issue
https://oss-fuzz.com/v2/testcase-detail/5085445791678464.

Signed-off-by: Harvey Tuch <htuch@google.com>