### PR TITLE
bug fix in rbac shadow policy metric collection and add unit test

### DIFF
--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -82,15 +82,12 @@ Http::FilterHeadersStatus RoleBasedAccessControlFilter::decodeHeaders(Http::Head
 
     ProtobufWkt::Struct metrics;
 
+    auto& fields = *metrics.mutable_fields();
     if (!effective_policy_id.empty()) {
-      ProtobufWkt::Value policy_id;
-      policy_id.set_string_value(effective_policy_id);
-      (*metrics.mutable_fields())[shadow_policy_id_field] = policy_id;
+      *fields[shadow_policy_id_field].mutable_string_value() = effective_policy_id;
     }
 
-    ProtobufWkt::Value resp_code;
-    resp_code.set_string_value(shadow_resp_code);
-    (*metrics.mutable_fields())[shadow_resp_code_field] = resp_code;
+    *fields[shadow_resp_code_field].mutable_string_value() = shadow_resp_code;
 
     callbacks_->requestInfo().setDynamicMetadata(HttpFilterNames::get().Rbac, metrics);
   }

--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -95,8 +95,10 @@ Http::FilterHeadersStatus RoleBasedAccessControlFilter::decodeHeaders(Http::Head
       resp_code.set_string_value(shadow_resp_code);
       (*metrics.mutable_fields())[shadow_resp_code_field] = resp_code;
 
-      auto filter_meta = filter_metadata.at(HttpFilterNames::get().Rbac);
-      filter_meta.MergeFrom(metrics);
+      callbacks_->requestInfo().setDynamicMetadata(HttpFilterNames::get().Rbac, metrics);
+    } else {
+      ENVOY_LOG(debug, "No dynamic_metadata found for filter {}",
+                Extensions::HttpFilters::HttpFilterNames::get().Rbac);
     }
   }
 

--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -80,26 +80,19 @@ Http::FilterHeadersStatus RoleBasedAccessControlFilter::decodeHeaders(Http::Head
       shadow_resp_code = resp_code_403;
     }
 
-    const auto& filter_metadata = callbacks_->requestInfo().dynamicMetadata().filter_metadata();
-    const auto filter_it = filter_metadata.find(HttpFilterNames::get().Rbac);
-    if (filter_it != filter_metadata.end()) {
-      ProtobufWkt::Struct metrics;
+    ProtobufWkt::Struct metrics;
 
-      if (!effective_policy_id.empty()) {
-        ProtobufWkt::Value policy_id;
-        policy_id.set_string_value(effective_policy_id);
-        (*metrics.mutable_fields())[shadow_policy_id_field] = policy_id;
-      }
-
-      ProtobufWkt::Value resp_code;
-      resp_code.set_string_value(shadow_resp_code);
-      (*metrics.mutable_fields())[shadow_resp_code_field] = resp_code;
-
-      callbacks_->requestInfo().setDynamicMetadata(HttpFilterNames::get().Rbac, metrics);
-    } else {
-      ENVOY_LOG(debug, "No dynamic_metadata found for filter {}",
-                Extensions::HttpFilters::HttpFilterNames::get().Rbac);
+    if (!effective_policy_id.empty()) {
+      ProtobufWkt::Value policy_id;
+      policy_id.set_string_value(effective_policy_id);
+      (*metrics.mutable_fields())[shadow_policy_id_field] = policy_id;
     }
+
+    ProtobufWkt::Value resp_code;
+    resp_code.set_string_value(shadow_resp_code);
+    (*metrics.mutable_fields())[shadow_resp_code_field] = resp_code;
+
+    callbacks_->requestInfo().setDynamicMetadata(HttpFilterNames::get().Rbac, metrics);
   }
 
   const auto& engine =


### PR DESCRIPTION
Signed-off-by: Quanjie Lin <quanlin@google.com>

*Description*:
1. bug fixed in this PR - previous metrics collection is never invoked; previously it check if rbac metadata exists before setDynamicMetadata, however rbac metadata is only created when setting setDynamicMetadata; this PR removed the check before calling setDynamicMetadata
2. add unit test


*Risk Level*:
LOW
