### PR TITLE
stats: add server.concurrency.

### DIFF
--- a/docs/root/configuration/statistics.rst
+++ b/docs/root/configuration/statistics.rst
@@ -21,6 +21,7 @@ Server related statistics are rooted at *server.* with following statistics:
   :widths: 1, 1, 2
 
   uptime, Gauge, Current server uptime in seconds
+  concurrency, Gauge, Number of worker threads
   memory_allocated, Gauge, Current amount of allocated memory in bytes. Total of both new and old Envoy processes on hot restart. 
   memory_heap_size, Gauge, Current reserved heap size in bytes. New Envoy process heap size on hot restart. 
   live, Gauge, "1 if the server is not currently draining, 0 otherwise"

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -578,7 +578,7 @@ ListenerManagerImpl::ListenerManagerImpl(Instance& server,
       stats_(generateStats(server.stats())),
       config_tracker_entry_(server.admin().getConfigTracker().add(
           "listeners", [this] { return dumpListenerConfigs(); })) {
-  for (uint32_t i = 0; i < std::max(1U, server.options().concurrency()); i++) {
+  for (uint32_t i = 0; i < server.options().concurrency(); i++) {
     workers_.emplace_back(worker_factory.createWorker());
   }
 }

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -184,7 +184,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
 
   // For base ID, scale what the user inputs by 10 so that we have spread for domain sockets.
   base_id_ = base_id.getValue() * 10;
-  concurrency_ = concurrency.getValue();
+  concurrency_ = std::max(1U, concurrency.getValue());
   config_path_ = config_path.getValue();
   config_yaml_ = config_yaml.getValue();
   v2_config_only_ = !allow_v1_config.getValue();

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -137,7 +137,6 @@ void InstanceImpl::flushStats() {
     server_stats_->total_connections_.set(numConnections() + info.num_connections_);
     server_stats_->days_until_first_cert_expiring_.set(
         sslContextManager().daysUntilFirstCertExpires());
-    server_stats_->hot_restart_epoch_.set(options_.restartEpoch());
     InstanceUtil::flushMetricsToSinks(config_->statsSinks(), stats_store_.source());
     // TODO(ramaraochavali): consider adding different flush interval for histograms.
     if (stat_flush_timer_ != nullptr) {
@@ -222,6 +221,9 @@ void InstanceImpl::initialize(Options& options,
 
   server_stats_.reset(
       new ServerStats{ALL_SERVER_STATS(POOL_GAUGE_PREFIX(stats_store_, "server."))});
+
+  server_stats_->concurrency_.set(options_.concurrency());
+  server_stats_->hot_restart_epoch_.set(options_.restartEpoch());
 
   failHealthcheck(false);
 

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -41,6 +41,7 @@ namespace Server {
 // clang-format off
 #define ALL_SERVER_STATS(GAUGE)                                                                    \
   GAUGE(uptime)                                                                                    \
+  GAUGE(concurrency)                                                                               \
   GAUGE(memory_allocated)                                                                          \
   GAUGE(memory_heap_size)                                                                          \
   GAUGE(live)                                                                                      \

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -19,6 +19,7 @@ namespace Envoy {
 namespace Server {
 
 MockOptions::MockOptions(const std::string& config_path) : config_path_(config_path) {
+  ON_CALL(*this, concurrency()).WillByDefault(ReturnPointee(&concurrency_));
   ON_CALL(*this, configPath()).WillByDefault(ReturnRef(config_path_));
   ON_CALL(*this, configYaml()).WillByDefault(ReturnRef(config_yaml_));
   ON_CALL(*this, v2ConfigOnly()).WillByDefault(Invoke([this] { return v2_config_only_; }));
@@ -30,6 +31,7 @@ MockOptions::MockOptions(const std::string& config_path) : config_path_(config_p
   ON_CALL(*this, logPath()).WillByDefault(ReturnRef(log_path_));
   ON_CALL(*this, maxStats()).WillByDefault(Return(1000));
   ON_CALL(*this, statsOptions()).WillByDefault(ReturnRef(stats_options_));
+  ON_CALL(*this, restartEpoch()).WillByDefault(ReturnPointee(&hot_restart_epoch_));
   ON_CALL(*this, hotRestartDisabled()).WillByDefault(ReturnPointee(&hot_restart_disabled_));
 }
 MockOptions::~MockOptions() {}

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -83,6 +83,8 @@ public:
   spdlog::level::level_enum log_level_{spdlog::level::trace};
   std::string log_path_;
   Stats::StatsOptionsImpl stats_options_;
+  uint32_t concurrency_{1};
+  uint64_t hot_restart_epoch_{};
   bool hot_restart_disabled_{};
 };
 

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -173,9 +173,12 @@ TEST_P(ServerInstanceImplTest, V1ConfigFallback) {
 TEST_P(ServerInstanceImplTest, Stats) {
   options_.service_cluster_name_ = "some_cluster_name";
   options_.service_node_name_ = "some_node_name";
+  options_.concurrency_ = 2;
+  options_.hot_restart_epoch_ = 3;
   initialize(std::string());
   EXPECT_NE(nullptr, TestUtility::findCounter(stats_store_, "server.watchdog_miss"));
-  EXPECT_NE(nullptr, TestUtility::findGauge(stats_store_, "server.hot_restart_epoch"));
+  EXPECT_EQ(2L, TestUtility::findGauge(stats_store_, "server.concurrency")->value());
+  EXPECT_EQ(3L, TestUtility::findGauge(stats_store_, "server.hot_restart_epoch")->value());
 }
 
 // Validate server localInfo() from bootstrap Node.


### PR DESCRIPTION
While there, move server.hot_restart_epoch out of flushStats(),
since it has no business of being there.

*Risk Level*: Low
*Testing*: bazel test //test/...
*Docs Changes*: Added
*Release Notes*: n/a

Signed-off-by: Piotr Sikora <piotrsikora@google.com>