### PR TITLE
fuzz: yet another attempt to deal with mkdtemp() failures.

### DIFF
--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -12,19 +12,12 @@ namespace Fuzz {
 
 spdlog::level::level_enum Runner::log_level_;
 
+uint32_t PerTestEnvironment::test_num_;
+
 PerTestEnvironment::PerTestEnvironment()
-    : test_tmpdir_([] {
-        static uint32_t test_num;
-        const std::string fuzz_path =
-            TestEnvironment::temporaryPath(fmt::format("fuzz_{}.XXXXXX", test_num++));
-        char test_tmpdir[fuzz_path.size() + 1];
-        StringUtil::strlcpy(test_tmpdir, fuzz_path.data(), fuzz_path.size() + 1);
-        if (::mkdtemp(test_tmpdir) == nullptr) {
-          ENVOY_LOG_MISC(critical, "Failed to create tmpdir {} {}", fuzz_path, strerror(errno));
-          RELEASE_ASSERT(false, "");
-        }
-        return std::string(test_tmpdir);
-      }()) {}
+    : test_tmpdir_(TestEnvironment::temporaryPath(fmt::format("fuzz_{}", test_num_++))) {
+  TestEnvironment::createPath(test_tmpdir_);
+}
 
 void Runner::setupEnvironment(int argc, char** argv, spdlog::level::level_enum default_log_level) {
   Event::Libevent::Global::initialize();

--- a/test/fuzz/fuzz_runner.h
+++ b/test/fuzz/fuzz_runner.h
@@ -21,6 +21,7 @@ public:
   std::string temporaryPath(const std::string& path) const { return test_tmpdir_ + "/" + path; }
 
 private:
+  static uint32_t test_num_;
   const std::string test_tmpdir_;
 };
 

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -175,5 +175,17 @@ public:
    * @return string the contents of the file.
    */
   static std::string readFileToStringForTest(const std::string& filename);
+
+  /**
+   * Create a path on the filesystem (mkdir -p ... equivalent).
+   * @param path.
+   */
+  static void createPath(const std::string& path);
+
+  /**
+   * Create a parent path on the filesystem (mkdir -p $(dirname ...) equivalent).
+   * @param path.
+   */
+  static void createParentPath(const std::string& path);
 };
 } // namespace Envoy


### PR DESCRIPTION
Still more failures overnight.

1. Avoid doing mkdtemp() more than once per fuzz run.

2. Make sure we pickup failures in RELEASE_ASSERT line, we were losing messages in truncated logs on
   ClusterFuzz.

3. Use C++ level std::filesystem for directory creation for each fuzz test case.

Hopefully this stabilizes or makes it clearer what is failing on ClusterFuzz.

Risk level: Low
Testing: bazel and oss-fuzz Docker server_fuzz_test.

Signed-off-by: Harvey Tuch <htuch@google.com>