### PR TITLE
fuzz: make H2 codec fuzz test more robust to unexpected new streams.

### DIFF
--- a/test/common/http/http2/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-5728207897624576
+++ b/test/common/http/http2/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-5728207897624576
@@ -1,0 +1,1 @@
+actions {   new_stream {     request_headers {       headers {         key: " "         value: " "       }       headers {         value: "�"       }       headers {         key: ":method"         value: "GET"       }     }   } } actions {   mutate {     buffer: 2     offset: 2     value: 2   } } actions {   quiesce_drain {   } } 

--- a/test/common/http/http2/codec_impl_fuzz_test.cc
+++ b/test/common/http/http2/codec_impl_fuzz_test.cc
@@ -273,9 +273,14 @@ DEFINE_PROTO_FUZZER(const test::common::http::http2::CodecImplFuzzTestCase& inpu
   // the response encoder and can complete Stream initialization.
   std::list<StreamPtr> pending_streams;
   std::list<StreamPtr> streams;
+  // For new streams when we aren't expecting one (e.g. as a result of a mutation).
+  NiceMock<MockStreamDecoder> orphan_request_decoder;
 
   ON_CALL(server_callbacks, newStream(_))
       .WillByDefault(Invoke([&](StreamEncoder& encoder) -> StreamDecoder& {
+        if (pending_streams.empty()) {
+          return orphan_request_decoder;
+        }
         auto stream_ptr = pending_streams.front()->removeFromList(pending_streams);
         Stream* const stream = stream_ptr.get();
         stream_ptr->moveIntoListBack(std::move(stream_ptr), streams);


### PR DESCRIPTION
Previously, mutations that generated new streams that we weren't expecting could cause the fuzzer
itself to dereference a null pointers in ON_CALL(newStream).

Fixes oss-fuzz issue https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=9813.

Risk level: Low
Testing: Corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>