### PR TITLE
[extensions/thrift_proxy] Add header matching to thrift router

### DIFF
--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/BUILD
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/BUILD
@@ -8,4 +8,7 @@ api_proto_library_internal(
         "route.proto",
         "thrift_proxy.proto",
     ],
+    deps = [
+        "//envoy/api/v2/route",
+    ],
 )

--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
@@ -45,10 +45,17 @@ message RouteMatch {
   }
 
   // Inverts whatever matching is done in the :ref:`method_name
-  // <envoy_api_field_config.filter.network.thrift_proxy.v2alpha1.RouteMatch.method_name>` or :ref:
-  // `service_name
+  // <envoy_api_field_config.filter.network.thrift_proxy.v2alpha1.RouteMatch.method_name>` or
+  // :ref:`service_name
   // <envoy_api_field_config.filter.network.thrift_proxy.v2alpha1.RouteMatch.service_name>` fields.
   // Cannot be combined with wildcard matching as that would result in routes never being matched.
+  //
+  // .. note::
+  //
+  //   This does not invert matching done as part of the :ref:`headers field
+  //   <envoy_api_field_config.filter.network.thrift_proxy.v2alpha1.RouteMatch.headers>` field. To
+  //   invert header matching, see :ref:`invert_match
+  //   <envoy_api_field_route.HeaderMatcher.invert_match>`.
   bool invert = 3;
 
   // Specifies a set of headers that the route should match on. The router will check the request’s

--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
@@ -29,7 +29,7 @@ message Route {
   RouteAction route = 2 [(validate.rules).message.required = true, (gogoproto.nullable) = false];
 }
 
-// [#comment:next free field: 4]
+// [#comment:next free field: 5]
 message RouteMatch {
   oneof match_specifier {
     option (validate.required) = true;
@@ -44,10 +44,18 @@ message RouteMatch {
     string service_name = 2;
   }
 
-  // Inverts whatever matching is done in match_specifier. Cannot be combined with wildcard matching
-  // as that would result in routes never being matched.
+  // Inverts whatever matching is done in the :ref:`method_name
+  // <envoy_api_field_config.filter.network.thrift_proxy.v2alpha1.RouteMatch.method_name>` or :ref:
+  // `service_name
+  // <envoy_api_field_config.filter.network.thrift_proxy.v2alpha1.RouteMatch.service_name>` fields.
+  // Cannot be combined with wildcard matching as that would result in routes never being matched.
   bool invert = 3;
 
+  // Specifies a set of headers that the route should match on. The router will check the request’s
+  // headers against all the specified headers in the route config. A match will happen if all the
+  // headers in the route are present in the request with the same values (or based on presence if
+  // the value field is not in the config). Note that this only applies when using the Header thrift
+  // transport type.
   repeated envoy.api.v2.route.HeaderMatcher headers = 4;
 }
 

--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
@@ -54,8 +54,8 @@ message RouteMatch {
   // Specifies a set of headers that the route should match on. The router will check the request’s
   // headers against all the specified headers in the route config. A match will happen if all the
   // headers in the route are present in the request with the same values (or based on presence if
-  // the value field is not in the config). Note that this only applies when using the Header thrift
-  // transport type.
+  // the value field is not in the config). Note that this only applies for Thrift transports and/or
+  // protocols that support headers.
   repeated envoy.api.v2.route.HeaderMatcher headers = 4;
 }
 

--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.config.filter.network.thrift_proxy.v2alpha1;
 option go_package = "v2";
 
+import "envoy/api/v2/route/route.proto";
 import "validate/validate.proto";
 import "gogoproto/gogo.proto";
 
@@ -46,6 +47,8 @@ message RouteMatch {
   // Inverts whatever matching is done in match_specifier. Cannot be combined with wildcard matching
   // as that would result in routes never being matched.
   bool invert = 3;
+
+  repeated envoy.api.v2.route.HeaderMatcher headers = 4;
 }
 
 // [#comment:next free field: 2]

--- a/source/extensions/filters/network/thrift_proxy/router/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/router/BUILD
@@ -40,6 +40,7 @@ envoy_cc_library(
         "//include/envoy/upstream:load_balancer_interface",
         "//include/envoy/upstream:thread_local_cluster_interface",
         "//source/common/common:logger_lib",
+        "//source/common/http:header_utility_lib",
         "//source/common/upstream:load_balancer_lib",
         "//source/extensions/filters/network:well_known_names",
         "//source/extensions/filters/network/thrift_proxy:app_exception_lib",

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -45,7 +45,7 @@ MethodNameRouteEntryImpl::MethodNameRouteEntryImpl(
 RouteConstSharedPtr MethodNameRouteEntryImpl::matches(const MessageMetadata& metadata) const {
   if (RouteEntryImplBase::headersMatch(metadata.headers())) {
     bool matches =
-      method_name_.empty() || (metadata.hasMethodName() && metadata.methodName() == method_name_);
+        method_name_.empty() || (metadata.hasMethodName() && metadata.methodName() == method_name_);
 
     if (matches ^ invert_) {
       return clusterEntry();
@@ -74,7 +74,7 @@ RouteConstSharedPtr ServiceNameRouteEntryImpl::matches(const MessageMetadata& me
   if (RouteEntryImplBase::headersMatch(metadata.headers())) {
     bool matches = service_name_.empty() ||
                    (metadata.hasMethodName() &&
-                   StringUtil::startsWith(metadata.methodName().c_str(), service_name_));
+                    StringUtil::startsWith(metadata.methodName().c_str(), service_name_));
 
     if (matches ^ invert_) {
       return clusterEntry();

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -17,13 +17,21 @@ namespace Router {
 
 RouteEntryImplBase::RouteEntryImplBase(
     const envoy::config::filter::network::thrift_proxy::v2alpha1::Route& route)
-    : cluster_name_(route.route().cluster()) {}
+    : cluster_name_(route.route().cluster()) {
+  for (const auto& header_map : route.match().headers()) {
+    config_headers_.push_back(header_map);
+  }
+}
 
 const std::string& RouteEntryImplBase::clusterName() const { return cluster_name_; }
 
 const RouteEntry* RouteEntryImplBase::routeEntry() const { return this; }
 
 RouteConstSharedPtr RouteEntryImplBase::clusterEntry() const { return shared_from_this(); }
+
+bool RouteEntryImplBase::headersMatch(const Http::HeaderMap& headers) const {
+  return Http::HeaderUtility::matchHeaders(headers, config_headers_);
+}
 
 MethodNameRouteEntryImpl::MethodNameRouteEntryImpl(
     const envoy::config::filter::network::thrift_proxy::v2alpha1::Route& route)
@@ -35,11 +43,13 @@ MethodNameRouteEntryImpl::MethodNameRouteEntryImpl(
 }
 
 RouteConstSharedPtr MethodNameRouteEntryImpl::matches(const MessageMetadata& metadata) const {
-  bool matches =
+  if (RouteEntryImplBase::headersMatch(metadata.headers())) {
+    bool matches =
       method_name_.empty() || (metadata.hasMethodName() && metadata.methodName() == method_name_);
 
-  if (matches ^ invert_) {
-    return clusterEntry();
+    if (matches ^ invert_) {
+      return clusterEntry();
+    }
   }
 
   return nullptr;
@@ -61,12 +71,14 @@ ServiceNameRouteEntryImpl::ServiceNameRouteEntryImpl(
 }
 
 RouteConstSharedPtr ServiceNameRouteEntryImpl::matches(const MessageMetadata& metadata) const {
-  bool matches = service_name_.empty() ||
-                 (metadata.hasMethodName() &&
-                  StringUtil::startsWith(metadata.methodName().c_str(), service_name_));
+  if (RouteEntryImplBase::headersMatch(metadata.headers())) {
+    bool matches = service_name_.empty() ||
+                   (metadata.hasMethodName() &&
+                   StringUtil::startsWith(metadata.methodName().c_str(), service_name_));
 
-  if (matches ^ invert_) {
-    return clusterEntry();
+    if (matches ^ invert_) {
+      return clusterEntry();
+    }
   }
 
   return nullptr;

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -9,6 +9,7 @@
 #include "envoy/upstream/load_balancer.h"
 
 #include "common/common/logger.h"
+#include "common/http/header_utility.h"
 #include "common/upstream/load_balancer_impl.h"
 
 #include "extensions/filters/network/thrift_proxy/conn_manager.h"
@@ -39,9 +40,11 @@ public:
 
 protected:
   RouteConstSharedPtr clusterEntry() const;
+  bool headersMatch(const Http::HeaderMap& headers) const;
 
 private:
   const std::string cluster_name_;
+  std::vector<Http::HeaderUtility::HeaderData> config_headers_;
 };
 
 typedef std::shared_ptr<const RouteEntryImplBase> RouteEntryImplBaseConstSharedPtr;

--- a/test/extensions/filters/network/thrift_proxy/driver/client.py
+++ b/test/extensions/filters/network/thrift_proxy/driver/client.py
@@ -79,6 +79,13 @@ def main(cfg, reqhandle, resphandle):
             transport,
             client_type=THeaderTransport.CLIENT_TYPE.HEADER,
         )
+
+        if cfg.headers is not None:
+            pairs = cfg.headers.split(",")
+            for p in pairs:
+                key,value=p.split("=")
+                transport.set_header(key,value)
+
         if cfg.protocol == "binary":
             transport.set_protocol_id(THeaderTransport.T_BINARY_PROTOCOL)
         elif cfg.protocol == "compact":
@@ -159,7 +166,6 @@ def main(cfg, reqhandle, resphandle):
 
     transport.close()
 
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Thrift client tool.",
@@ -225,6 +231,13 @@ if __name__ == "__main__":
         dest="unix",
         action="store_true",
     )
+    parser.add_argument(
+        "--headers",
+        dest="headers",
+        metavar="KEY=VALUE[,KEY=VALUE]",
+        help="list of comma-delimited, key value pairs to include as tranport headers.",
+    )
+
     cfg = parser.parse_args()
 
     reqhandle = io.BytesIO()

--- a/test/extensions/filters/network/thrift_proxy/driver/generate_fixture.sh
+++ b/test/extensions/filters/network/thrift_proxy/driver/generate_fixture.sh
@@ -2,7 +2,7 @@
 
 # Generates request and response fixtures for integration tests.
 
-# Usage: generate_fixture.sh <transport> <protocol> -s [multiplex-service] -H [headers ] method [param...]
+# Usage: generate_fixture.sh <transport> <protocol> -s [multiplex-service] -H [headers] method [param...]
 
 set -e
 

--- a/test/extensions/filters/network/thrift_proxy/driver/generate_fixture.sh
+++ b/test/extensions/filters/network/thrift_proxy/driver/generate_fixture.sh
@@ -2,12 +2,12 @@
 
 # Generates request and response fixtures for integration tests.
 
-# Usage: generate_fixture.sh <transport> <protocol> [multiplex-service] -- method [param...]
+# Usage: generate_fixture.sh <transport> <protocol> -s [multiplex-service] -H [headers ] method [param...]
 
 set -e
 
 function usage() {
-    echo "Usage: $0 <mode> <transport> <protocol> [multiplex-service] -- method [param...]"
+    echo "Usage: $0 <mode> <transport> <protocol> -s [multiplex-service] -H [headers] method [param...]"
     echo "where mode is success, exception, or idl-exception"
     exit 1
 }
@@ -24,24 +24,37 @@ fi
 MODE="$1"
 TRANSPORT="$2"
 PROTOCOL="$3"
-MULTIPLEX="$4"
-if ! shift 4; then
+
+if ! shift 3; then
     usage
 fi
 
-if [[ -z "${MODE}" || -z "${TRANSPORT}" || -z "${PROTOCOL}" || -z "${MULTIPLEX}" ]]; then
+if [[ -z "${MODE}" || -z "${TRANSPORT}" || -z "${PROTOCOL}" ]]; then
     usage
 fi
 
-if [[ "${MULTIPLEX}" != "--" ]]; then
-    if [[ "$1" != "--" ]]; then
-        echo "expected -- after multiplex service name"
-        exit 1
-    fi
-    shift
-else
-    MULTIPLEX=""
-fi
+MULTIPLEX=
+HEADERS=
+while getopts ":s:H:" opt; do
+    case ${opt} in
+        s)
+            MULTIPLEX=$OPTARG
+            ;;
+        H)
+            HEADERS=$OPTARG
+            ;;
+
+        \?)
+            echo "Invalid Option: -$OPTARG" >&2
+            exit 1
+            ;;
+        :)
+            echo "Invalid Option: -$OPTARG requires an argument" >&2
+            exit 1
+            ;;
+    esac
+done
+shift $((OPTIND -1))
 
 METHOD="$1"
 if [[ "${METHOD}" == "" ]]; then
@@ -59,8 +72,8 @@ SERVICE_FLAGS=("--addr" "${SOCKET}"
                "--protocol" "${PROTOCOL}")
 
 if [[ -n "$MULTIPLEX" ]]; then
-    SERVICE_FLAGS[9]="--multiplex"
-    SERVICE_FLAGS[10]="${MULTIPLEX}"
+    SERVICE_FLAGS+=("--multiplex")
+    SERVICE_FLAGS+=("${MULTIPLEX}")
 
     REQUEST_FILE="${FIXTURE_DIR}/${TRANSPORT}-${PROTOCOL}-${MULTIPLEX}-${MODE}.request"
     RESPONSE_FILE="${FIXTURE_DIR}/${TRANSPORT}-${PROTOCOL}-${MULTIPLEX}-${MODE}.response"
@@ -83,6 +96,11 @@ while [[ ! -a "${SOCKET}" ]]; do
         exit 1
     fi
 done
+
+if [[ -n "$HEADERS" ]]; then
+    SERVICE_FLAGS+=("--headers")
+    SERVICE_FLAGS+=("$HEADERS")
+fi
 
 "${DRIVER_DIR}/client" "${SERVICE_FLAGS[@]}" \
                        --request "${REQUEST_FILE}" \

--- a/test/extensions/filters/network/thrift_proxy/integration.cc
+++ b/test/extensions/filters/network/thrift_proxy/integration.cc
@@ -63,9 +63,26 @@ void BaseThriftIntegrationTest::preparePayloads(const PayloadOptions& options,
   };
 
   if (options.service_name_) {
+    args.push_back("-s");
     args.push_back(*options.service_name_);
   }
-  args.push_back("--");
+
+  if (options.headers_.size() > 0) {
+    args.push_back("-H");
+
+    std::stringstream ss;
+    size_t sz = options.headers_.size();
+    for (size_t i = 0; i < sz; i++) {
+      std::pair<std::string, std::string> p = options.headers_.at(i);
+      ss << p.first << "=" << p.second;
+      if (i < sz - 1) {
+        ss << ",";
+      }
+    }
+
+    args.push_back(ss.str());
+  }
+
   args.push_back(options.method_name_);
   std::copy(options.method_args_.begin(), options.method_args_.end(), std::back_inserter(args));
 

--- a/test/extensions/filters/network/thrift_proxy/integration.cc
+++ b/test/extensions/filters/network/thrift_proxy/integration.cc
@@ -70,17 +70,12 @@ void BaseThriftIntegrationTest::preparePayloads(const PayloadOptions& options,
   if (options.headers_.size() > 0) {
     args.push_back("-H");
 
-    std::stringstream ss;
-    size_t sz = options.headers_.size();
-    for (size_t i = 0; i < sz; i++) {
-      std::pair<std::string, std::string> p = options.headers_.at(i);
-      ss << p.first << "=" << p.second;
-      if (i < sz - 1) {
-        ss << ",";
-      }
-    }
-
-    args.push_back(ss.str());
+    std::vector<std::string> headers;
+    std::transform(options.headers_.begin(), options.headers_.end(), std::back_inserter(headers),
+                   [](const std::pair<std::string, std::string>& header) -> std::string {
+                     return header.first + "=" + header.second;
+                   });
+    args.push_back(StringUtil::join(headers, ","));
   }
 
   args.push_back(options.method_name_);

--- a/test/extensions/filters/network/thrift_proxy/integration.h
+++ b/test/extensions/filters/network/thrift_proxy/integration.h
@@ -29,9 +29,10 @@ enum class DriverMode {
 struct PayloadOptions {
   PayloadOptions(TransportType transport, ProtocolType protocol, DriverMode mode,
                  absl::optional<std::string> service_name, std::string method_name,
-                 std::vector<std::string> method_args = {})
+                 std::vector<std::string> method_args = {},
+                 std::vector<std::pair<std::string, std::string>> headers = {})
       : transport_(transport), protocol_(protocol), mode_(mode), service_name_(service_name),
-        method_name_(method_name), method_args_(method_args) {}
+        method_name_(method_name), method_args_(method_args), headers_(headers) {}
 
   std::string modeName() const;
   std::string transportName() const;
@@ -43,6 +44,7 @@ struct PayloadOptions {
   const absl::optional<std::string> service_name_;
   const std::string method_name_;
   const std::vector<std::string> method_args_;
+  const std::vector<std::pair<std::string, std::string>> headers_;
 };
 
 class BaseThriftIntegrationTest : public BaseIntegrationTest {

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -959,6 +959,225 @@ routes:
   EXPECT_THROW(new RouteMatcher(config), EnvoyException);
 }
 
+TEST(RouteMatcherTest, RouteByExactHeaderMatcher) {
+  const std::string yaml = R"EOF(
+name: config
+routes:
+  - match:
+      method_name: "method1"
+      headers:
+      - name: "content-type"
+        exact_match: "application/grpc"
+    route:
+      cluster: "cluster1"
+)EOF";
+
+  envoy::config::filter::network::thrift_proxy::v2alpha1::RouteConfiguration config =
+      parseRouteConfigurationFromV2Yaml(yaml);
+
+  RouteMatcher matcher(config);
+  MessageMetadata metadata;
+  RouteConstSharedPtr route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+
+  metadata.setMethodName("method1");
+  route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+
+  metadata.headers().addCopy(Http::LowerCaseString("content-type"), "application/grpc");
+  route = matcher.route(metadata);
+  EXPECT_NE(nullptr, route);
+  EXPECT_EQ("cluster1", route->routeEntry()->clusterName());
+}
+
+TEST(RouteMatcherTest, RouteByRegexHeaderMatcher) {
+  const std::string yaml = R"EOF(
+name: config
+routes:
+  - match:
+      method_name: "method1"
+      headers:
+      - name: "x-version"
+        regex_match: "0.[5-9]"
+    route:
+      cluster: "cluster1"
+)EOF";
+
+  envoy::config::filter::network::thrift_proxy::v2alpha1::RouteConfiguration config =
+      parseRouteConfigurationFromV2Yaml(yaml);
+
+  RouteMatcher matcher(config);
+  MessageMetadata metadata;
+  RouteConstSharedPtr route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+
+  metadata.setMethodName("method1");
+  route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+
+  metadata.headers().addCopy(Http::LowerCaseString("x-version"), "0.1");
+  route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+  metadata.headers().remove(Http::LowerCaseString("x-version"));
+
+  metadata.headers().addCopy(Http::LowerCaseString("x-version"), "0.8");
+  route = matcher.route(metadata);
+  EXPECT_NE(nullptr, route);
+  EXPECT_EQ("cluster1", route->routeEntry()->clusterName());
+}
+
+TEST(RouteMatcherTest, RouteByRangeHeaderMatcher) {
+  const std::string yaml = R"EOF(
+name: config
+routes:
+  - match:
+      method_name: "method1"
+      headers:
+      - name: "x-user-id"
+        range_match:
+          start: 100
+          end: 200
+    route:
+      cluster: "cluster1"
+)EOF";
+
+  envoy::config::filter::network::thrift_proxy::v2alpha1::RouteConfiguration config =
+      parseRouteConfigurationFromV2Yaml(yaml);
+
+  RouteMatcher matcher(config);
+  MessageMetadata metadata;
+  RouteConstSharedPtr route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+
+  metadata.setMethodName("method1");
+  route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+
+  metadata.headers().addCopy(Http::LowerCaseString("x-user-id"), "50");
+  route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+  metadata.headers().remove(Http::LowerCaseString("x-user-id"));
+
+  metadata.headers().addCopy(Http::LowerCaseString("x-user-id"), "199");
+  route = matcher.route(metadata);
+  EXPECT_NE(nullptr, route);
+  EXPECT_EQ("cluster1", route->routeEntry()->clusterName());
+}
+
+TEST(RouteMatcherTest, RouteByPresentHeaderMatcher) {
+  const std::string yaml = R"EOF(
+name: config
+routes:
+  - match:
+      method_name: "method1"
+      headers:
+      - name: "x-user-id"
+        present_match: true
+    route:
+      cluster: "cluster1"
+)EOF";
+
+  envoy::config::filter::network::thrift_proxy::v2alpha1::RouteConfiguration config =
+      parseRouteConfigurationFromV2Yaml(yaml);
+
+  RouteMatcher matcher(config);
+  MessageMetadata metadata;
+  RouteConstSharedPtr route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+
+  metadata.setMethodName("method1");
+  route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+
+  metadata.headers().addCopy(Http::LowerCaseString("x-user-id"), "50");
+  route = matcher.route(metadata);
+  EXPECT_NE(nullptr, route);
+  EXPECT_EQ("cluster1", route->routeEntry()->clusterName());
+  metadata.headers().remove(Http::LowerCaseString("x-user-id"));
+
+  metadata.headers().addCopy(Http::LowerCaseString("x-user-id"), "");
+  route = matcher.route(metadata);
+  EXPECT_NE(nullptr, route);
+  EXPECT_EQ("cluster1", route->routeEntry()->clusterName());
+}
+
+TEST(RouteMatcherTest, RouteByPrefixHeaderMatcher) {
+  const std::string yaml = R"EOF(
+name: config
+routes:
+  - match:
+      method_name: "method1"
+      headers:
+      - name: "x-header-1"
+        prefix_match: "user_id:"
+    route:
+      cluster: "cluster1"
+)EOF";
+
+  envoy::config::filter::network::thrift_proxy::v2alpha1::RouteConfiguration config =
+      parseRouteConfigurationFromV2Yaml(yaml);
+
+  RouteMatcher matcher(config);
+  MessageMetadata metadata;
+  RouteConstSharedPtr route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+
+  metadata.setMethodName("method1");
+  route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+
+  metadata.headers().addCopy(Http::LowerCaseString("x-header-1"), "500");
+  route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+  metadata.headers().remove(Http::LowerCaseString("x-header-1"));
+
+  metadata.headers().addCopy(Http::LowerCaseString("x-header-1"), "user_id:500");
+  route = matcher.route(metadata);
+  EXPECT_NE(nullptr, route);
+  EXPECT_EQ("cluster1", route->routeEntry()->clusterName());
+}
+
+TEST(RouteMatcherTest, RouteBySuffixHeaderMatcher) {
+  const std::string yaml = R"EOF(
+name: config
+routes:
+  - match:
+      method_name: "method1"
+      headers:
+      - name: "x-header-1"
+        suffix_match: "asdf"
+    route:
+      cluster: "cluster1"
+)EOF";
+
+  envoy::config::filter::network::thrift_proxy::v2alpha1::RouteConfiguration config =
+      parseRouteConfigurationFromV2Yaml(yaml);
+
+  RouteMatcher matcher(config);
+  MessageMetadata metadata;
+  RouteConstSharedPtr route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+
+  metadata.setMethodName("method1");
+  route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+
+  metadata.headers().addCopy(Http::LowerCaseString("x-header-1"), "asdfvalue");
+  route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+  metadata.headers().remove(Http::LowerCaseString("x-header-1"));
+
+  metadata.headers().addCopy(Http::LowerCaseString("x-header-1"), "valueasdfvalue");
+  route = matcher.route(metadata);
+  EXPECT_EQ(nullptr, route);
+  metadata.headers().remove(Http::LowerCaseString("x-header-1"));
+
+  metadata.headers().addCopy(Http::LowerCaseString("x-header-1"), "value:asdf");
+  route = matcher.route(metadata);
+  EXPECT_NE(nullptr, route);
+  EXPECT_EQ("cluster1", route->routeEntry()->clusterName());
+}
+
 } // namespace Router
 } // namespace ThriftProxy
 } // namespace NetworkFilters

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -966,8 +966,8 @@ routes:
   - match:
       method_name: "method1"
       headers:
-      - name: "content-type"
-        exact_match: "application/grpc"
+      - name: "x-header-1"
+        exact_match: "x-value-1"
     route:
       cluster: "cluster1"
 )EOF";
@@ -984,7 +984,7 @@ routes:
   route = matcher.route(metadata);
   EXPECT_EQ(nullptr, route);
 
-  metadata.headers().addCopy(Http::LowerCaseString("content-type"), "application/grpc");
+  metadata.headers().addCopy(Http::LowerCaseString("x-header-1"), "x-value-1");
   route = matcher.route(metadata);
   EXPECT_NE(nullptr, route);
   EXPECT_EQ("cluster1", route->routeEntry()->clusterName());


### PR DESCRIPTION
*Description*
This change adds header matching to the thrift router We do this by pulling in the route proto definition into the thrift route proto and making use of the `Http::HeaderUtility` class to do the matching for us. As such, we support the same type of header matching that exists for the http router.

The integration tests got interesting in that we can only define headers for the thrift payload generation infra at the transport level so I had to modify the script(s) to take a headers parameter and pass it through the `PayloadOptions` class.

*Note* I have an outstanding PR that touches  the `HeaderMatcher` thrift proto definitions [here](https://github.com/envoyproxy/envoy/pull/4207) but this takes precedence and will only affect this change in that I'd have to change BUILD files and namespaces.

*Risk Level*
LOW

*Testing*
- unit and integrations tests, new and old, pass.
