### PR TITLE
build: remove unnecessary calls to proto_register_toolchains

### DIFF
--- a/ci/WORKSPACE
+++ b/ci/WORKSPACE
@@ -23,5 +23,3 @@ load("@com_lyft_protoc_gen_validate//bazel:go_proto_library.bzl", "go_proto_repo
 go_proto_repositories(shared=0)
 go_rules_dependencies()
 go_register_toolchains()
-load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
-proto_register_toolchains()

--- a/ci/WORKSPACE.filter.example
+++ b/ci/WORKSPACE.filter.example
@@ -22,5 +22,3 @@ load("@com_lyft_protoc_gen_validate//bazel:go_proto_library.bzl", "go_proto_repo
 go_proto_repositories(shared=0)
 go_rules_dependencies()
 go_register_toolchains()
-load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
-proto_register_toolchains()


### PR DESCRIPTION
As per build output:
```
DEBUG: /build/tmp/_bazel_bazel/e1c4f70ea3ec3e18fe575296c4ce4334/external/io_bazel_rules_go/proto/def.bzl:138:3: You no longer need to call proto_register_toolchains(), it does nothing
```
*Risk Level*: Low
*Testing*: n/a
*Docs Changes*: n/a
*Release Notes*: n/a
