### PR TITLE
access_log: support beginning of epoch in START_TIME.

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -98,7 +98,13 @@ std::string DateFormatter::fromTime(const SystemTime& time) const {
   // Copy the current cached formatted format string, then replace its subseconds part (when it has
   // non-zero width) by correcting its position using prepared subseconds offsets.
   std::string formatted_str = formatted.str;
-  const std::string nanoseconds = fmt::FormatInt(epoch_time_ns.count()).str();
+  std::string nanoseconds = fmt::FormatInt(epoch_time_ns.count()).str();
+  // Special case handling for beginning of time, we should never need to do this outside of
+  // tests or a time machine.
+  if (nanoseconds.size() < 10) {
+    nanoseconds = std::string(10 - nanoseconds.size(), '0') + nanoseconds;
+  }
+
   for (size_t i = 0; i < specifiers_.size(); ++i) {
     const auto& specifier = specifiers_.at(i);
 

--- a/test/common/access_log/access_log_formatter_corpus/clusterfuzz-testcase-minimized-access_log_formatter_fuzz_test-4673648219652096
+++ b/test/common/access_log/access_log_formatter_corpus/clusterfuzz-testcase-minimized-access_log_formatter_fuzz_test-4673648219652096
@@ -1,0 +1,1 @@
+format: "%START_TIME(%f)%"

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -435,6 +435,20 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
   }
 
   {
+    // This tests the beginning of time.
+    const std::string format = "%START_TIME(%Y/%m/%d)%|%START_TIME(%s)%|%START_TIME(bad_format)%|"
+                               "%START_TIME%|%START_TIME(%f.%1f.%2f.%3f)%";
+
+    const time_t test_epoch = 0;
+    const SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
+    EXPECT_CALL(request_info, startTime()).WillRepeatedly(Return(time));
+    FormatterImpl formatter(format);
+
+    EXPECT_EQ("1970/01/01|0|bad_format|1970-01-01T00:00:00.000Z|000000000.0.00.000",
+              formatter.format(request_header, response_header, response_trailer, request_info));
+  }
+
+  {
     // This tests multiple START_TIMEs.
     const std::string format =
         "%START_TIME(%s.%3f)%|%START_TIME(%s.%4f)%|%START_TIME(%s.%5f)%|%START_TIME(%s.%6f)%";


### PR DESCRIPTION
This was confusing the fuzz tests, fixes oss-fuzz issue
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=9988.

Risk level: Low
Testing: Unit test and corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>