### PR TITLE
fuzz: use nanoseconds for SystemTime in RequestInfo.

### DIFF
--- a/include/envoy/common/time.h
+++ b/include/envoy/common/time.h
@@ -11,8 +11,8 @@ namespace Envoy {
  * SystemTime should be used when getting a time to present to the user, e.g. for logging.
  * MonotonicTime should be used when tracking time for computing an interval.
  */
-typedef std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> SystemTime;
-typedef std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds> MonotonicTime;
+typedef std::chrono::time_point<std::chrono::system_clock> SystemTime;
+typedef std::chrono::time_point<std::chrono::steady_clock> MonotonicTime;
 
 /**
  * Abstraction for getting the current system time. Useful for testing.

--- a/include/envoy/common/time.h
+++ b/include/envoy/common/time.h
@@ -11,8 +11,8 @@ namespace Envoy {
  * SystemTime should be used when getting a time to present to the user, e.g. for logging.
  * MonotonicTime should be used when tracking time for computing an interval.
  */
-typedef std::chrono::time_point<std::chrono::system_clock> SystemTime;
-typedef std::chrono::time_point<std::chrono::steady_clock> MonotonicTime;
+typedef std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> SystemTime;
+typedef std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds> MonotonicTime;
 
 /**
  * Abstraction for getting the current system time. Useful for testing.

--- a/test/common/router/header_parser_corpus/clusterfuzz-testcase-minimized-header_parser_fuzz_test-5630125928873984
+++ b/test/common/router/header_parser_corpus/clusterfuzz-testcase-minimized-header_parser_fuzz_test-5630125928873984
@@ -1,0 +1,1 @@
+headers_to_add {   header {     key: " "     value: "%START_TIME(�)%"   } } request_info {   start_time: 72059116831228591 }

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -36,7 +36,13 @@ inline test::fuzz::Headers toHeaders(const Http::HeaderMap& headers) {
 inline TestRequestInfo fromRequestInfo(const test::fuzz::RequestInfo& request_info) {
   TestRequestInfo test_request_info;
   test_request_info.metadata_ = request_info.dynamic_metadata();
+#ifdef __APPLE__
+  // Clocks don't track at nanosecond on OS X.
+  test_request_info.start_time_ =
+      SystemTime(std::chrono::microseconds(request_info.start_time() / 1000));
+#else
   test_request_info.start_time_ = SystemTime(std::chrono::nanoseconds(request_info.start_time()));
+#endif
   if (request_info.has_response_code()) {
     test_request_info.response_code_ = request_info.response_code().value();
   }

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -36,7 +36,7 @@ inline test::fuzz::Headers toHeaders(const Http::HeaderMap& headers) {
 inline TestRequestInfo fromRequestInfo(const test::fuzz::RequestInfo& request_info) {
   TestRequestInfo test_request_info;
   test_request_info.metadata_ = request_info.dynamic_metadata();
-  test_request_info.start_time_ = SystemTime(std::chrono::microseconds(request_info.start_time()));
+  test_request_info.start_time_ = SystemTime(std::chrono::nanoseconds(request_info.start_time()));
   if (request_info.has_response_code()) {
     test_request_info.response_code_ = request_info.response_code().value();
   }


### PR DESCRIPTION
Avoids integer overflow that was previously occurring due to time in micros being too large, allows
exercise of nanosecond resolution formatters beyond all zero.

Fixes oss-fuzz issue https://oss-fuzz.com/v2/testcase-detail/5630125928873984.

Risk level: Low
Testing: Corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>