### PR TITLE
fuzz: make runtime root hermetic in server_fuzz_test.

### DIFF
--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5730612661452800
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5730612661452800
@@ -1,0 +1,13 @@
+runtime {
+  symlink_root: "/"
+  subdirectory: "tmp"
+  override_subdirectory: "out"
+}
+admin {
+  access_log_path: "/"
+  address {
+    pipe {
+      path: "WW"
+    }
+  }
+}

--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -36,6 +36,9 @@ makeHermeticPathsAndPorts(Fuzz::PerTestEnvironment& test_env,
   if (output.admin().has_address()) {
     makePortHermetic(*output.mutable_admin()->mutable_address());
   }
+  if (output.has_runtime()) {
+    output.mutable_runtime()->set_symlink_root(test_env.temporaryPath(""));
+  }
   for (auto& listener : *output.mutable_static_resources()->mutable_listeners()) {
     if (listener.has_address()) {
       makePortHermetic(*listener.mutable_address());


### PR DESCRIPTION
It's kind of scary allowing this to point to arbitrary locations, we will see performance and
correctness issues as fuzz tests and the container filesystem interact.

Fixes oss-fuzz issue https://oss-fuzz.com/v2/testcase-detail/5730612661452800.

Risk level: Low
Testing: Corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>