### PR TITLE
Add validation context provider

### DIFF
--- a/include/envoy/secret/BUILD
+++ b/include/envoy/secret/BUILD
@@ -19,6 +19,7 @@ envoy_cc_library(
     deps = [
         ":secret_callbacks_interface",
         "//include/envoy/common:callback",
+        "//include/envoy/ssl:certificate_validation_context_config_interface",
         "//include/envoy/ssl:tls_certificate_config_interface",
     ],
 )

--- a/include/envoy/secret/secret_manager.h
+++ b/include/envoy/secret/secret_manager.h
@@ -32,11 +32,29 @@ public:
   findStaticTlsCertificateProvider(const std::string& name) const PURE;
 
   /**
+   * @param name a name of the static CertificateValidationContextConfigProviderSharedPtr.
+   * @return the CertificateValidationContextConfigProviderSharedPtr. Returns nullptr
+   * if the static certificate validation context is not found.
+   */
+  virtual CertificateValidationContextConfigProviderSharedPtr
+  findStaticCertificateValidationContextProvider(const std::string& name) const PURE;
+
+  /**
    * @param tls_certificate the protobuf config of the TLS certificate.
    * @return a TlsCertificateConfigProviderSharedPtr created from tls_certificate.
    */
   virtual TlsCertificateConfigProviderSharedPtr createInlineTlsCertificateProvider(
       const envoy::api::v2::auth::TlsCertificate& tls_certificate) PURE;
+
+  /**
+   * @param tls_certificate the protobuf config of the certificate validation context.
+   * @return a CertificateValidationContextConfigProviderSharedPtr created from
+   * certificate_validation_context.
+   */
+  virtual CertificateValidationContextConfigProviderSharedPtr
+  createInlineCertificateValidationContextProvider(
+      const envoy::api::v2::auth::CertificateValidationContext& certificate_validation_context)
+      PURE;
 };
 
 } // namespace Secret

--- a/include/envoy/secret/secret_provider.h
+++ b/include/envoy/secret/secret_provider.h
@@ -4,6 +4,7 @@
 
 #include "envoy/common/callback.h"
 #include "envoy/common/pure.h"
+#include "envoy/ssl/certificate_validation_context_config.h"
 #include "envoy/ssl/tls_certificate_config.h"
 
 namespace Envoy {
@@ -33,6 +34,11 @@ public:
 
 typedef SecretProvider<Ssl::TlsCertificateConfig> TlsCertificateConfigProvider;
 typedef std::shared_ptr<TlsCertificateConfigProvider> TlsCertificateConfigProviderSharedPtr;
+
+typedef SecretProvider<Ssl::CertificateValidationContextConfig>
+    CertificateValidationContextConfigProvider;
+typedef std::shared_ptr<CertificateValidationContextConfigProvider>
+    CertificateValidationContextConfigProviderSharedPtr;
 
 } // namespace Secret
 } // namespace Envoy

--- a/include/envoy/ssl/BUILD
+++ b/include/envoy/ssl/BUILD
@@ -22,6 +22,7 @@ envoy_cc_library(
     name = "context_config_interface",
     hdrs = ["context_config.h"],
     deps = [
+        ":certificate_validation_context_config_interface",
         ":tls_certificate_config_interface",
     ],
 )
@@ -39,4 +40,9 @@ envoy_cc_library(
 envoy_cc_library(
     name = "tls_certificate_config_interface",
     hdrs = ["tls_certificate_config.h"],
+)
+
+envoy_cc_library(
+    name = "certificate_validation_context_config_interface",
+    hdrs = ["certificate_validation_context_config.h"],
 )

--- a/include/envoy/ssl/certificate_validation_context_config.h
+++ b/include/envoy/ssl/certificate_validation_context_config.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "envoy/common/pure.h"
+
+namespace Envoy {
+namespace Ssl {
+
+class CertificateValidationContextConfig {
+public:
+  virtual ~CertificateValidationContextConfig() {}
+
+  /**
+   * @return The CA certificate to use for peer validation.
+   */
+  virtual const std::string& caCert() const PURE;
+
+  /**
+   * @return Path of the CA certificate to use for peer validation or "<inline>"
+   * if the CA certificate was inlined.
+   */
+  virtual const std::string& caCertPath() const PURE;
+
+  /**
+   * @return The CRL to check if a cert is revoked.
+   */
+  virtual const std::string& certificateRevocationList() const PURE;
+
+  /**
+   * @return Path of the certificate revocation list, or "<inline>" if the CRL
+   * was inlined.
+   */
+  virtual const std::string& certificateRevocationListPath() const PURE;
+
+  /**
+   * @return The subject alt names to be verified, if enabled. Otherwise, ""
+   */
+  virtual const std::vector<std::string>& verifySubjectAltNameList() const PURE;
+
+  /**
+   * @return A list of a hex-encoded SHA-256 certificate hashes to be verified.
+   */
+  virtual const std::vector<std::string>& verifyCertificateHashList() const PURE;
+
+  /**
+   * @return A list of a hex-encoded SHA-256 SPKI hashes to be verified.
+   */
+  virtual const std::vector<std::string>& verifyCertificateSpkiList() const PURE;
+
+  /**
+   * @return whether to ignore expired certificates (both too new and too old).
+   */
+  virtual bool allowExpiredCertificate() const PURE;
+};
+
+typedef std::unique_ptr<CertificateValidationContextConfig> CertificateValidationContextConfigPtr;
+
+} // namespace Ssl
+} // namespace Envoy

--- a/include/envoy/ssl/context_config.h
+++ b/include/envoy/ssl/context_config.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "envoy/common/pure.h"
+#include "envoy/ssl/certificate_validation_context_config.h"
 #include "envoy/ssl/tls_certificate_config.h"
 
 namespace Envoy {
@@ -40,51 +41,14 @@ public:
   virtual const std::string& ecdhCurves() const PURE;
 
   /**
-   * @return The CA certificate to use for peer validation.
-   */
-  virtual const std::string& caCert() const PURE;
-
-  /**
-   * @return Path of the CA certificate to use for peer validation or "<inline>"
-   * if the CA certificate was inlined.
-   */
-  virtual const std::string& caCertPath() const PURE;
-
-  /**
-   * @return The CRL to check if a cert is revoked.
-   */
-  virtual const std::string& certificateRevocationList() const PURE;
-
-  /**
-   * @return Path of the certificate revocation list, or "<inline>" if the CRL
-   * was inlined.
-   */
-  virtual const std::string& certificateRevocationListPath() const PURE;
-
-  /**
    * @return TlsCertificateConfig the certificate config used to identify the local side.
    */
   virtual const TlsCertificateConfig* tlsCertificate() const PURE;
 
   /**
-   * @return The subject alt names to be verified, if enabled. Otherwise, ""
+   * @return CertificateValidationContextConfig the certificate validation context config.
    */
-  virtual const std::vector<std::string>& verifySubjectAltNameList() const PURE;
-
-  /**
-   * @return A list of a hex-encoded SHA-256 certificate hashes to be verified.
-   */
-  virtual const std::vector<std::string>& verifyCertificateHashList() const PURE;
-
-  /**
-   * @return A list of a hex-encoded SHA-256 SPKI hashes to be verified.
-   */
-  virtual const std::vector<std::string>& verifyCertificateSpkiList() const PURE;
-
-  /**
-   * @return whether to ignore expired certificates (both too new and too old).
-   */
-  virtual bool allowExpiredCertificate() const PURE;
+  virtual const CertificateValidationContextConfig* certificateValidationContext() const PURE;
 
   /**
    * @return The minimum TLS protocol version to negotiate.

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -44,6 +44,7 @@ namespace Logger {
   FUNCTION(router)               \
   FUNCTION(runtime)              \
   FUNCTION(stats)                \
+  FUNCTION(secret)               \
   FUNCTION(testing)              \
   FUNCTION(thrift)               \
   FUNCTION(tracing)              \

--- a/source/common/secret/BUILD
+++ b/source/common/secret/BUILD
@@ -26,6 +26,7 @@ envoy_cc_library(
     hdrs = ["secret_provider_impl.h"],
     deps = [
         "//include/envoy/secret:secret_provider_interface",
+        "//source/common/ssl:certificate_validation_context_config_impl_lib",
         "//source/common/ssl:tls_certificate_config_impl_lib",
         "@envoy_api//envoy/api/v2/auth:cert_cc",
     ],

--- a/source/common/secret/secret_manager_impl.cc
+++ b/source/common/secret/secret_manager_impl.cc
@@ -4,6 +4,7 @@
 
 #include "common/common/assert.h"
 #include "common/secret/secret_provider_impl.h"
+#include "common/ssl/certificate_validation_context_config_impl.h"
 #include "common/ssl/tls_certificate_config_impl.h"
 
 namespace Envoy {
@@ -21,6 +22,17 @@ void SecretManagerImpl::addStaticSecret(const envoy::api::v2::auth::Secret& secr
     }
     break;
   }
+  case envoy::api::v2::auth::Secret::TypeCase::kValidationContext: {
+    auto secret_provider = std::make_shared<CertificateValidationContextConfigProviderImpl>(
+        secret.validation_context());
+    if (!static_certificate_validation_context_providers_
+             .insert(std::make_pair(secret.name(), secret_provider))
+             .second) {
+      throw EnvoyException(fmt::format(
+          "Duplicate static CertificateValidationContext secret name {}", secret.name()));
+    }
+    break;
+  }
   default:
     throw EnvoyException("Secret type not implemented");
   }
@@ -32,9 +44,23 @@ SecretManagerImpl::findStaticTlsCertificateProvider(const std::string& name) con
   return (secret != static_tls_certificate_providers_.end()) ? secret->second : nullptr;
 }
 
+CertificateValidationContextConfigProviderSharedPtr
+SecretManagerImpl::findStaticCertificateValidationContextProvider(const std::string& name) const {
+  auto secret = static_certificate_validation_context_providers_.find(name);
+  return (secret != static_certificate_validation_context_providers_.end()) ? secret->second
+                                                                            : nullptr;
+}
+
 TlsCertificateConfigProviderSharedPtr SecretManagerImpl::createInlineTlsCertificateProvider(
     const envoy::api::v2::auth::TlsCertificate& tls_certificate) {
   return std::make_shared<TlsCertificateConfigProviderImpl>(tls_certificate);
+}
+
+CertificateValidationContextConfigProviderSharedPtr
+SecretManagerImpl::createInlineCertificateValidationContextProvider(
+    const envoy::api::v2::auth::CertificateValidationContext& certificate_validation_context) {
+  return std::make_shared<CertificateValidationContextConfigProviderImpl>(
+      certificate_validation_context);
 }
 
 } // namespace Secret

--- a/source/common/secret/secret_manager_impl.h
+++ b/source/common/secret/secret_manager_impl.h
@@ -4,6 +4,7 @@
 
 #include "envoy/secret/secret_manager.h"
 #include "envoy/secret/secret_provider.h"
+#include "envoy/ssl/certificate_validation_context_config.h"
 #include "envoy/ssl/tls_certificate_config.h"
 
 #include "common/common/logger.h"
@@ -11,17 +12,32 @@
 namespace Envoy {
 namespace Secret {
 
-class SecretManagerImpl : public SecretManager, Logger::Loggable<Logger::Id::upstream> {
+class SecretManagerImpl : public SecretManager, Logger::Loggable<Logger::Id::secret> {
 public:
   void addStaticSecret(const envoy::api::v2::auth::Secret& secret) override;
+
   TlsCertificateConfigProviderSharedPtr
   findStaticTlsCertificateProvider(const std::string& name) const override;
+
+  CertificateValidationContextConfigProviderSharedPtr
+  findStaticCertificateValidationContextProvider(const std::string& name) const override;
+
   TlsCertificateConfigProviderSharedPtr createInlineTlsCertificateProvider(
       const envoy::api::v2::auth::TlsCertificate& tls_certificate) override;
 
+  CertificateValidationContextConfigProviderSharedPtr
+  createInlineCertificateValidationContextProvider(
+      const envoy::api::v2::auth::CertificateValidationContext& certificate_validation_context)
+      override;
+
 private:
+  // Manages pairs of secret name and TlsCertificateConfigProviderSharedPtr.
   std::unordered_map<std::string, TlsCertificateConfigProviderSharedPtr>
       static_tls_certificate_providers_;
+
+  // Manages pairs of secret name and CertificateValidationContextConfigProviderSharedPtr.
+  std::unordered_map<std::string, CertificateValidationContextConfigProviderSharedPtr>
+      static_certificate_validation_context_providers_;
 };
 
 } // namespace Secret

--- a/source/common/secret/secret_provider_impl.cc
+++ b/source/common/secret/secret_provider_impl.cc
@@ -1,6 +1,7 @@
 #include "common/secret/secret_provider_impl.h"
 
 #include "common/common/assert.h"
+#include "common/ssl/certificate_validation_context_config_impl.h"
 #include "common/ssl/tls_certificate_config_impl.h"
 
 namespace Envoy {
@@ -9,6 +10,13 @@ namespace Secret {
 TlsCertificateConfigProviderImpl::TlsCertificateConfigProviderImpl(
     const envoy::api::v2::auth::TlsCertificate& tls_certificate)
     : tls_certificate_(std::make_unique<Ssl::TlsCertificateConfigImpl>(tls_certificate)) {}
+
+CertificateValidationContextConfigProviderImpl::CertificateValidationContextConfigProviderImpl(
+    const envoy::api::v2::auth::CertificateValidationContext& certificate_validation_context)
+    : certificate_validation_context_(std::make_unique<Ssl::CertificateValidationContextConfigImpl>(
+          certificate_validation_context)) {
+  std::cout << "called CertificateValidationContextConfigProviderImpl()" << std::endl;
+}
 
 } // namespace Secret
 } // namespace Envoy

--- a/source/common/secret/secret_provider_impl.cc
+++ b/source/common/secret/secret_provider_impl.cc
@@ -14,9 +14,7 @@ TlsCertificateConfigProviderImpl::TlsCertificateConfigProviderImpl(
 CertificateValidationContextConfigProviderImpl::CertificateValidationContextConfigProviderImpl(
     const envoy::api::v2::auth::CertificateValidationContext& certificate_validation_context)
     : certificate_validation_context_(std::make_unique<Ssl::CertificateValidationContextConfigImpl>(
-          certificate_validation_context)) {
-  std::cout << "called CertificateValidationContextConfigProviderImpl()" << std::endl;
-}
+          certificate_validation_context)) {}
 
 } // namespace Secret
 } // namespace Envoy

--- a/source/common/secret/secret_provider_impl.h
+++ b/source/common/secret/secret_provider_impl.h
@@ -4,6 +4,7 @@
 
 #include "envoy/api/v2/auth/cert.pb.h"
 #include "envoy/secret/secret_provider.h"
+#include "envoy/ssl/certificate_validation_context_config.h"
 #include "envoy/ssl/tls_certificate_config.h"
 
 namespace Envoy {
@@ -19,6 +20,22 @@ public:
 
 private:
   Ssl::TlsCertificateConfigPtr tls_certificate_;
+};
+
+class CertificateValidationContextConfigProviderImpl
+    : public CertificateValidationContextConfigProvider {
+public:
+  CertificateValidationContextConfigProviderImpl(
+      const envoy::api::v2::auth::CertificateValidationContext& certificate_validation_context);
+
+  const Ssl::CertificateValidationContextConfig* secret() const override {
+    return certificate_validation_context_.get();
+  }
+
+  Common::CallbackHandle* addUpdateCallback(std::function<void()>) override { return nullptr; }
+
+private:
+  Ssl::CertificateValidationContextConfigPtr certificate_validation_context_;
 };
 
 } // namespace Secret

--- a/source/common/ssl/BUILD
+++ b/source/common/ssl/BUILD
@@ -86,6 +86,18 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "certificate_validation_context_config_impl_lib",
+    srcs = ["certificate_validation_context_config_impl.cc"],
+    hdrs = ["certificate_validation_context_config_impl.h"],
+    deps = [
+        "//include/envoy/ssl:certificate_validation_context_config_interface",
+        "//source/common/common:empty_string",
+        "//source/common/config:datasource_lib",
+        "@envoy_api//envoy/api/v2/auth:cert_cc",
+    ],
+)
+
+envoy_cc_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
     hdrs = ["utility.h"],

--- a/source/common/ssl/certificate_validation_context_config_impl.cc
+++ b/source/common/ssl/certificate_validation_context_config_impl.cc
@@ -1,0 +1,47 @@
+#include "common/ssl/certificate_validation_context_config_impl.h"
+
+#include "envoy/common/exception.h"
+
+#include "common/common/empty_string.h"
+#include "common/common/fmt.h"
+#include "common/config/datasource.h"
+
+namespace Envoy {
+namespace Ssl {
+
+static const std::string INLINE_STRING = "<inline>";
+
+CertificateValidationContextConfigImpl::CertificateValidationContextConfigImpl(
+    const envoy::api::v2::auth::CertificateValidationContext& config)
+    : ca_cert_(Config::DataSource::read(config.trusted_ca(), true)),
+      ca_cert_path_(Config::DataSource::getPath(config.trusted_ca())
+                        .value_or(ca_cert_.empty() ? EMPTY_STRING : INLINE_STRING)),
+      certificate_revocation_list_(Config::DataSource::read(config.crl(), true)),
+      certificate_revocation_list_path_(
+          Config::DataSource::getPath(config.crl())
+              .value_or(certificate_revocation_list_.empty() ? EMPTY_STRING : INLINE_STRING)),
+      verify_subject_alt_name_list_(config.verify_subject_alt_name().begin(),
+                                    config.verify_subject_alt_name().end()),
+      verify_certificate_hash_list_(config.verify_certificate_hash().begin(),
+                                    config.verify_certificate_hash().end()),
+      verify_certificate_spki_list_(config.verify_certificate_spki().begin(),
+                                    config.verify_certificate_spki().end()),
+      allow_expired_certificate_(config.allow_expired_certificate()) {
+  if (ca_cert_.empty()) {
+    if (!certificate_revocation_list_.empty()) {
+      throw EnvoyException(fmt::format("Failed to load CRL from {} without trusted CA",
+                                       certificateRevocationListPath()));
+    }
+    if (!verify_subject_alt_name_list_.empty()) {
+      throw EnvoyException(fmt::format("SAN-based verification of peer certificates without "
+                                       "trusted CA is insecure and not allowed"));
+    }
+    if (allow_expired_certificate_) {
+      throw EnvoyException(
+          fmt::format("Certificate validity period is always ignored without trusted CA"));
+    }
+  }
+}
+
+} // namespace Ssl
+} // namespace Envoy

--- a/source/common/ssl/certificate_validation_context_config_impl.h
+++ b/source/common/ssl/certificate_validation_context_config_impl.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/api/v2/auth/cert.pb.h"
+#include "envoy/ssl/certificate_validation_context_config.h"
+
+namespace Envoy {
+namespace Ssl {
+
+class CertificateValidationContextConfigImpl : public CertificateValidationContextConfig {
+public:
+  CertificateValidationContextConfigImpl(
+      const envoy::api::v2::auth::CertificateValidationContext& config);
+
+  const std::string& caCert() const override { return ca_cert_; }
+  const std::string& caCertPath() const override { return ca_cert_path_; }
+  const std::string& certificateRevocationList() const override {
+    return certificate_revocation_list_;
+  }
+  const std::string& certificateRevocationListPath() const override {
+    return certificate_revocation_list_path_;
+  }
+  const std::vector<std::string>& verifySubjectAltNameList() const override {
+    return verify_subject_alt_name_list_;
+  }
+  const std::vector<std::string>& verifyCertificateHashList() const override {
+    return verify_certificate_hash_list_;
+  }
+  const std::vector<std::string>& verifyCertificateSpkiList() const override {
+    return verify_certificate_spki_list_;
+  }
+  bool allowExpiredCertificate() const override { return allow_expired_certificate_; }
+
+private:
+  const std::string ca_cert_;
+  const std::string ca_cert_path_;
+  const std::string certificate_revocation_list_;
+  const std::string certificate_revocation_list_path_;
+  const std::vector<std::string> verify_subject_alt_name_list_;
+  const std::vector<std::string> verify_certificate_hash_list_;
+  const std::vector<std::string> verify_certificate_spki_list_;
+  const bool allow_expired_certificate_;
+};
+
+} // namespace Ssl
+} // namespace Envoy

--- a/source/common/ssl/context_config_impl.h
+++ b/source/common/ssl/context_config_impl.h
@@ -23,31 +23,14 @@ public:
   const std::string& altAlpnProtocols() const override { return alt_alpn_protocols_; }
   const std::string& cipherSuites() const override { return cipher_suites_; }
   const std::string& ecdhCurves() const override { return ecdh_curves_; }
-  const std::string& caCert() const override { return ca_cert_; }
-  const std::string& caCertPath() const override {
-    return (ca_cert_path_.empty() && !ca_cert_.empty()) ? INLINE_STRING : ca_cert_path_;
-  }
-  const std::string& certificateRevocationList() const override {
-    return certificate_revocation_list_;
-  }
-  const std::string& certificateRevocationListPath() const override {
-    return (certificate_revocation_list_path_.empty() && !certificate_revocation_list_.empty())
-               ? INLINE_STRING
-               : certificate_revocation_list_path_;
-  }
   const TlsCertificateConfig* tlsCertificate() const override {
     return tls_certficate_provider_ == nullptr ? nullptr : tls_certficate_provider_->secret();
   }
-  const std::vector<std::string>& verifySubjectAltNameList() const override {
-    return verify_subject_alt_name_list_;
-  };
-  const std::vector<std::string>& verifyCertificateHashList() const override {
-    return verify_certificate_hash_list_;
-  };
-  const std::vector<std::string>& verifyCertificateSpkiList() const override {
-    return verify_certificate_spki_list_;
-  };
-  bool allowExpiredCertificate() const override { return allow_expired_certificate_; };
+  const CertificateValidationContextConfig* certificateValidationContext() const override {
+    return certficate_validation_context_provider_ == nullptr
+               ? nullptr
+               : certficate_validation_context_provider_->secret();
+  }
   unsigned minProtocolVersion() const override { return min_protocol_version_; };
   unsigned maxProtocolVersion() const override { return max_protocol_version_; };
 
@@ -67,15 +50,9 @@ private:
   const std::string alt_alpn_protocols_;
   const std::string cipher_suites_;
   const std::string ecdh_curves_;
-  const std::string ca_cert_;
-  const std::string ca_cert_path_;
-  const std::string certificate_revocation_list_;
-  const std::string certificate_revocation_list_path_;
   Secret::TlsCertificateConfigProviderSharedPtr tls_certficate_provider_;
-  const std::vector<std::string> verify_subject_alt_name_list_;
-  const std::vector<std::string> verify_certificate_hash_list_;
-  const std::vector<std::string> verify_certificate_spki_list_;
-  const bool allow_expired_certificate_;
+  Secret::CertificateValidationContextConfigProviderSharedPtr
+      certficate_validation_context_provider_;
   const unsigned min_protocol_version_;
   const unsigned max_protocol_version_;
 };

--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -64,18 +64,19 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const ContextConfig& config)
   }
 
   int verify_mode = SSL_VERIFY_NONE;
-
-  if (!config.caCert().empty()) {
-    ca_file_path_ = config.caCertPath();
+  if (config.certificateValidationContext() != nullptr &&
+      !config.certificateValidationContext()->caCert().empty()) {
+    ca_file_path_ = config.certificateValidationContext()->caCertPath();
     bssl::UniquePtr<BIO> bio(
-        BIO_new_mem_buf(const_cast<char*>(config.caCert().data()), config.caCert().size()));
+        BIO_new_mem_buf(const_cast<char*>(config.certificateValidationContext()->caCert().data()),
+                        config.certificateValidationContext()->caCert().size()));
     RELEASE_ASSERT(bio != nullptr, "");
     // Based on BoringSSL's X509_load_cert_crl_file().
     bssl::UniquePtr<STACK_OF(X509_INFO)> list(
         PEM_X509_INFO_read_bio(bio.get(), nullptr, nullptr, nullptr));
     if (list == nullptr) {
-      throw EnvoyException(
-          fmt::format("Failed to load trusted CA certificates from {}", config.caCertPath()));
+      throw EnvoyException(fmt::format("Failed to load trusted CA certificates from {}",
+                                       config.certificateValidationContext()->caCertPath()));
     }
 
     X509_STORE* store = SSL_CTX_get_cert_store(ctx_.get());
@@ -92,8 +93,8 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const ContextConfig& config)
       }
     }
     if (ca_cert_ == nullptr) {
-      throw EnvoyException(
-          fmt::format("Failed to load trusted CA certificates from {}", config.caCertPath()));
+      throw EnvoyException(fmt::format("Failed to load trusted CA certificates from {}",
+                                       config.certificateValidationContext()->caCertPath()));
     }
     verify_mode = SSL_VERIFY_PEER;
     verify_trusted_ca_ = true;
@@ -102,15 +103,17 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const ContextConfig& config)
     // directly. However, our new callback is still calling X509_verify_cert() under
     // the hood. Therefore, to ignore cert expiration, we need to set the callback
     // for X509_verify_cert to ignore that error.
-    if (config.allowExpiredCertificate()) {
+    if (config.certificateValidationContext()->allowExpiredCertificate()) {
       X509_STORE_set_verify_cb(store, ContextImpl::ignoreCertificateExpirationCallback);
     }
   }
 
-  if (!config.certificateRevocationList().empty()) {
-    bssl::UniquePtr<BIO> bio(
-        BIO_new_mem_buf(const_cast<char*>(config.certificateRevocationList().data()),
-                        config.certificateRevocationList().size()));
+  if (config.certificateValidationContext() != nullptr &&
+      !config.certificateValidationContext()->certificateRevocationList().empty()) {
+    bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(
+        const_cast<char*>(
+            config.certificateValidationContext()->certificateRevocationList().data()),
+        config.certificateValidationContext()->certificateRevocationList().size()));
     RELEASE_ASSERT(bio != nullptr, "");
 
     // Based on BoringSSL's X509_load_cert_crl_file().
@@ -118,7 +121,8 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const ContextConfig& config)
         PEM_X509_INFO_read_bio(bio.get(), nullptr, nullptr, nullptr));
     if (list == nullptr) {
       throw EnvoyException(
-          fmt::format("Failed to load CRL from {}", config.certificateRevocationListPath()));
+          fmt::format("Failed to load CRL from {}",
+                      config.certificateValidationContext()->certificateRevocationListPath()));
     }
 
     X509_STORE* store = SSL_CTX_get_cert_store(ctx_.get());
@@ -131,13 +135,16 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const ContextConfig& config)
     X509_STORE_set_flags(store, X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL);
   }
 
-  if (!config.verifySubjectAltNameList().empty()) {
-    verify_subject_alt_name_list_ = config.verifySubjectAltNameList();
+  if (config.certificateValidationContext() != nullptr &&
+      !config.certificateValidationContext()->verifySubjectAltNameList().empty()) {
+    verify_subject_alt_name_list_ =
+        config.certificateValidationContext()->verifySubjectAltNameList();
     verify_mode = SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
   }
 
-  if (!config.verifyCertificateHashList().empty()) {
-    for (auto hash : config.verifyCertificateHashList()) {
+  if (config.certificateValidationContext() != nullptr &&
+      !config.certificateValidationContext()->verifyCertificateHashList().empty()) {
+    for (auto hash : config.certificateValidationContext()->verifyCertificateHashList()) {
       // Remove colons from the 95 chars long colon-separated "fingerprint"
       // in order to get the hex-encoded string.
       if (hash.size() == 95) {
@@ -152,8 +159,9 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const ContextConfig& config)
     verify_mode = SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
   }
 
-  if (!config.verifyCertificateSpkiList().empty()) {
-    for (auto hash : config.verifyCertificateSpkiList()) {
+  if (config.certificateValidationContext() != nullptr &&
+      !config.certificateValidationContext()->verifyCertificateSpkiList().empty()) {
+    for (auto hash : config.certificateValidationContext()->verifyCertificateSpkiList()) {
       const auto decoded = Base64::decode(hash);
       if (decoded.size() != SHA256_DIGEST_LENGTH) {
         throw EnvoyException(fmt::format("Invalid base64-encoded SHA-256 {}", hash));
@@ -501,9 +509,11 @@ ServerContextImpl::ServerContextImpl(Stats::Scope& scope, const ServerContextCon
   if (config.tlsCertificate() == nullptr) {
     throw EnvoyException("Server TlsCertificates must have a certificate specified");
   }
-  if (!config.caCert().empty()) {
+  if (config.certificateValidationContext() != nullptr &&
+      !config.certificateValidationContext()->caCert().empty()) {
     bssl::UniquePtr<BIO> bio(
-        BIO_new_mem_buf(const_cast<char*>(config.caCert().data()), config.caCert().size()));
+        BIO_new_mem_buf(const_cast<char*>(config.certificateValidationContext()->caCert().data()),
+                        config.certificateValidationContext()->caCert().size()));
     RELEASE_ASSERT(bio != nullptr, "");
     // Based on BoringSSL's SSL_add_file_cert_subjects_to_stack().
     bssl::UniquePtr<STACK_OF(X509_NAME)> list(sk_X509_NAME_new(
@@ -517,7 +527,7 @@ ServerContextImpl::ServerContextImpl(Stats::Scope& scope, const ServerContextCon
       X509_NAME* name = X509_get_subject_name(cert.get());
       if (name == nullptr) {
         throw EnvoyException(fmt::format("Failed to load trusted client CA certificates from {}",
-                                         config.caCertPath()));
+                                         config.certificateValidationContext()->caCertPath()));
       }
       // Check for duplicates.
       if (sk_X509_NAME_find(list.get(), nullptr, name)) {
@@ -526,7 +536,7 @@ ServerContextImpl::ServerContextImpl(Stats::Scope& scope, const ServerContextCon
       bssl::UniquePtr<X509_NAME> name_dup(X509_NAME_dup(name));
       if (name_dup == nullptr || !sk_X509_NAME_push(list.get(), name_dup.release())) {
         throw EnvoyException(fmt::format("Failed to load trusted client CA certificates from {}",
-                                         config.caCertPath()));
+                                         config.certificateValidationContext()->caCertPath()));
       }
     }
     // Check for EOF.
@@ -535,7 +545,7 @@ ServerContextImpl::ServerContextImpl(Stats::Scope& scope, const ServerContextCon
       ERR_clear_error();
     } else {
       throw EnvoyException(fmt::format("Failed to load trusted client CA certificates from {}",
-                                       config.caCertPath()));
+                                       config.certificateValidationContext()->caCertPath()));
     }
     SSL_CTX_set_client_CA_list(ctx_.get(), list.release());
 

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -98,7 +98,9 @@ TEST_F(SecretManagerImplTest, CertificateValidationContextSecretLoadSuccess) {
 
   const std::string cert_pem = "{{ test_rundir }}/test/common/ssl/test_data/ca_cert.pem";
   EXPECT_EQ(TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(cert_pem)),
-            secret_manager->findStaticCertificateValidationContextProvider("abc.com")->caCert());
+            secret_manager->findStaticCertificateValidationContextProvider("abc.com")
+                ->secret()
+                ->caCert());
 }
 
 TEST_F(SecretManagerImplTest, DuplicateStaticCertificateValidationContextSecret) {

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -122,9 +122,8 @@ TEST_F(SecretManagerImplTest, DuplicateStaticCertificateValidationContextSecret)
 
   ASSERT_NE(secret_manager->findStaticCertificateValidationContextProvider("abc.com"), nullptr);
 
-  EXPECT_THROW_WITH_MESSAGE(
-      secret_manager->findStaticCertificateValidationContextProvider(secret_config), EnvoyException,
-      "Duplicate static CertificateValidationContext secret name abc.com");
+  EXPECT_THROW_WITH_MESSAGE(secret_manager->addStaticSecret(secret_config), EnvoyException,
+                            "Duplicate static CertificateValidationContext secret name abc.com");
 }
 
 TEST_F(SecretManagerImplTest, NotImplementedException) {

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -17,10 +17,10 @@ namespace {
 
 class SecretManagerImplTest : public testing::Test {};
 
+// Validate that secret manager adds static TLS certificate secret successfully.
 TEST_F(SecretManagerImplTest, TlsCertificateSecretLoadSuccess) {
   envoy::api::v2::auth::Secret secret_config;
-
-  std::string yaml =
+  const std::string yaml =
       R"EOF(
 name: "abc.com"
 tls_certificate:
@@ -29,15 +29,11 @@ tls_certificate:
   private_key:
     filename: "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_key.pem"
 )EOF";
-
   MessageUtil::loadFromYaml(TestEnvironment::substitute(yaml), secret_config);
-
   std::unique_ptr<SecretManager> secret_manager(new SecretManagerImpl());
-
   secret_manager->addStaticSecret(secret_config);
 
   ASSERT_EQ(secret_manager->findStaticTlsCertificateProvider("undefined"), nullptr);
-
   ASSERT_NE(secret_manager->findStaticTlsCertificateProvider("abc.com"), nullptr);
 
   const std::string cert_pem = "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_cert.pem";
@@ -50,10 +46,11 @@ tls_certificate:
             secret_manager->findStaticTlsCertificateProvider("abc.com")->secret()->privateKey());
 }
 
+// Validate that secret manager throws an exception when adding duplicated static TLS certificate
+// secret.
 TEST_F(SecretManagerImplTest, DuplicateStaticTlsCertificateSecret) {
   envoy::api::v2::auth::Secret secret_config;
-
-  std::string yaml =
+  const std::string yaml =
       R"EOF(
     name: "abc.com"
     tls_certificate:
@@ -62,40 +59,31 @@ TEST_F(SecretManagerImplTest, DuplicateStaticTlsCertificateSecret) {
       private_key:
         filename: "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_key.pem"
     )EOF";
-
   MessageUtil::loadFromYaml(TestEnvironment::substitute(yaml), secret_config);
-
   std::unique_ptr<SecretManager> secret_manager(new SecretManagerImpl());
-
   secret_manager->addStaticSecret(secret_config);
 
   ASSERT_NE(secret_manager->findStaticTlsCertificateProvider("abc.com"), nullptr);
-
   EXPECT_THROW_WITH_MESSAGE(secret_manager->addStaticSecret(secret_config), EnvoyException,
                             "Duplicate static TlsCertificate secret name abc.com");
 }
 
+// Validate that secret manager adds static certificate validation context secret successfully.
 TEST_F(SecretManagerImplTest, CertificateValidationContextSecretLoadSuccess) {
   envoy::api::v2::auth::Secret secret_config;
-
-  std::string yaml =
+  const std::string yaml =
       R"EOF(
       name: "abc.com"
       validation_context:
         trusted_ca: { filename: "{{ test_rundir }}/test/common/ssl/test_data/ca_cert.pem" }
         allow_expired_certificate: true
       )EOF";
-
   MessageUtil::loadFromYaml(TestEnvironment::substitute(yaml), secret_config);
-
   std::unique_ptr<SecretManager> secret_manager(new SecretManagerImpl());
-
   secret_manager->addStaticSecret(secret_config);
 
   ASSERT_EQ(secret_manager->findStaticCertificateValidationContextProvider("undefined"), nullptr);
-
   ASSERT_NE(secret_manager->findStaticCertificateValidationContextProvider("abc.com"), nullptr);
-
   const std::string cert_pem = "{{ test_rundir }}/test/common/ssl/test_data/ca_cert.pem";
   EXPECT_EQ(TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(cert_pem)),
             secret_manager->findStaticCertificateValidationContextProvider("abc.com")
@@ -103,33 +91,32 @@ TEST_F(SecretManagerImplTest, CertificateValidationContextSecretLoadSuccess) {
                 ->caCert());
 }
 
+// Validate that secret manager throws an exception when adding duplicated static certificate
+// validation context secret.
 TEST_F(SecretManagerImplTest, DuplicateStaticCertificateValidationContextSecret) {
   envoy::api::v2::auth::Secret secret_config;
-
-  std::string yaml =
+  const std::string yaml =
       R"EOF(
     name: "abc.com"
     validation_context:
       trusted_ca: { filename: "{{ test_rundir }}/test/common/ssl/test_data/ca_cert.pem" }
       allow_expired_certificate: true
     )EOF";
-
   MessageUtil::loadFromYaml(TestEnvironment::substitute(yaml), secret_config);
-
   std::unique_ptr<SecretManager> secret_manager(new SecretManagerImpl());
-
   secret_manager->addStaticSecret(secret_config);
 
   ASSERT_NE(secret_manager->findStaticCertificateValidationContextProvider("abc.com"), nullptr);
-
   EXPECT_THROW_WITH_MESSAGE(secret_manager->addStaticSecret(secret_config), EnvoyException,
                             "Duplicate static CertificateValidationContext secret name abc.com");
 }
 
+// Validate that secret manager throws an exception when adding static secret of a type that is not
+// supported.
 TEST_F(SecretManagerImplTest, NotImplementedException) {
   envoy::api::v2::auth::Secret secret_config;
 
-  std::string yaml =
+  const std::string yaml =
       R"EOF(
 name: "abc.com"
 session_ticket_keys:

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -418,10 +418,11 @@ TEST(ClientContextConfigImplTest, MultipleTlsCertificates) {
       "Multiple TLS certificates are not supported for client contexts");
 }
 
+// Validate that client context config with static TLS certificates is created successfully.
 TEST(ClientContextConfigImplTest, StaticTlsCertificates) {
   envoy::api::v2::auth::Secret secret_config;
 
-  std::string yaml = R"EOF(
+  const std::string yaml = R"EOF(
 name: "abc.com"
 tls_certificate:
   certificate_chain:
@@ -451,10 +452,11 @@ tls_certificate:
             client_context_config.tlsCertificate()->privateKey());
 }
 
+// Validate that client context config with static certificate validation context is created
+// successfully.
 TEST(ClientContextConfigImplTest, StaticCertificateValidationContext) {
   envoy::api::v2::auth::Secret tls_certificate_secret_config;
-
-  std::string tls_certificate_yaml = R"EOF(
+  const std::string tls_certificate_yaml = R"EOF(
   name: "abc.com"
   tls_certificate:
     certificate_chain:
@@ -462,25 +464,19 @@ TEST(ClientContextConfigImplTest, StaticCertificateValidationContext) {
     private_key:
       filename: "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_key.pem"
   )EOF";
-
   MessageUtil::loadFromYaml(TestEnvironment::substitute(tls_certificate_yaml),
                             tls_certificate_secret_config);
-
   std::unique_ptr<Secret::SecretManager> secret_manager(new Secret::SecretManagerImpl());
   secret_manager->addStaticSecret(tls_certificate_secret_config);
-
   envoy::api::v2::auth::Secret certificate_validation_context_secret_config;
-
-  std::string certificate_validation_context_yaml = R"EOF(
+  const std::string certificate_validation_context_yaml = R"EOF(
     name: "def.com"
     validation_context:
       trusted_ca: { filename: "{{ test_rundir }}/test/common/ssl/test_data/ca_cert.pem" }
       allow_expired_certificate: true
   )EOF";
-
   MessageUtil::loadFromYaml(TestEnvironment::substitute(certificate_validation_context_yaml),
                             certificate_validation_context_secret_config);
-
   secret_manager->addStaticSecret(certificate_validation_context_secret_config);
 
   envoy::api::v2::auth::UpstreamTlsContext tls_context;
@@ -491,7 +487,6 @@ TEST(ClientContextConfigImplTest, StaticCertificateValidationContext) {
   tls_context.mutable_common_tls_context()
       ->mutable_validation_context_sds_secret_config()
       ->set_name("def.com");
-
   ClientContextConfigImpl client_context_config(tls_context, *secret_manager.get());
 
   const std::string cert_pem = "{{ test_rundir }}/test/common/ssl/test_data/ca_cert.pem";
@@ -499,10 +494,12 @@ TEST(ClientContextConfigImplTest, StaticCertificateValidationContext) {
             client_context_config.certificateValidationContext()->caCert());
 }
 
+// Validate that constructor of client context config throws an exception when static TLS
+// certificate is missing.
 TEST(ClientContextConfigImplTest, MissingStaticSecretTlsCertificates) {
   envoy::api::v2::auth::Secret secret_config;
 
-  std::string yaml = R"EOF(
+  const std::string yaml = R"EOF(
 name: "abc.com"
 tls_certificate:
   certificate_chain:
@@ -528,10 +525,11 @@ tls_certificate:
       EnvoyException, "Static secret is not defined: missing");
 }
 
+// Validate that constructor of client context config throws an exception when static certificate
+// validation context is missing.
 TEST(ClientContextConfigImplTest, MissingStaticCertificateValidationContext) {
   envoy::api::v2::auth::Secret tls_certificate_secret_config;
-
-  std::string tls_certificate_yaml = R"EOF(
+  const std::string tls_certificate_yaml = R"EOF(
     name: "abc.com"
     tls_certificate:
       certificate_chain:
@@ -539,25 +537,19 @@ TEST(ClientContextConfigImplTest, MissingStaticCertificateValidationContext) {
       private_key:
         filename: "{{ test_rundir }}/test/common/ssl/test_data/selfsigned_key.pem"
     )EOF";
-
   MessageUtil::loadFromYaml(TestEnvironment::substitute(tls_certificate_yaml),
                             tls_certificate_secret_config);
-
   std::unique_ptr<Secret::SecretManager> secret_manager(new Secret::SecretManagerImpl());
   secret_manager->addStaticSecret(tls_certificate_secret_config);
-
   envoy::api::v2::auth::Secret certificate_validation_context_secret_config;
-
-  std::string certificate_validation_context_yaml = R"EOF(
+  const std::string certificate_validation_context_yaml = R"EOF(
       name: "def.com"
       validation_context:
         trusted_ca: { filename: "{{ test_rundir }}/test/common/ssl/test_data/ca_cert.pem" }
         allow_expired_certificate: true
     )EOF";
-
   MessageUtil::loadFromYaml(TestEnvironment::substitute(certificate_validation_context_yaml),
                             certificate_validation_context_secret_config);
-
   secret_manager->addStaticSecret(certificate_validation_context_secret_config);
 
   envoy::api::v2::auth::UpstreamTlsContext tls_context;
@@ -568,7 +560,6 @@ TEST(ClientContextConfigImplTest, MissingStaticCertificateValidationContext) {
   tls_context.mutable_common_tls_context()
       ->mutable_validation_context_sds_secret_config()
       ->set_name("missing");
-
   EXPECT_THROW_WITH_MESSAGE(
       ClientContextConfigImpl client_context_config(tls_context, *secret_manager.get()),
       EnvoyException, "Unknown static certificate validation context: missing");

--- a/test/mocks/secret/mocks.cc
+++ b/test/mocks/secret/mocks.cc
@@ -13,6 +13,12 @@ MockSecretManager::MockSecretManager() {
       .WillByDefault(Invoke([](const envoy::api::v2::auth::TlsCertificate& tls_certificate) {
         return std::make_shared<Secret::TlsCertificateConfigProviderImpl>(tls_certificate);
       }));
+  ON_CALL(*this, createInlineCertificateValidationContextProvider(_))
+      .WillByDefault(Invoke([](const envoy::api::v2::auth::CertificateValidationContext&
+                                   certificate_validation_context) {
+        return std::make_shared<Secret::CertificateValidationContextConfigProviderImpl>(
+            certificate_validation_context);
+      }));
 }
 
 MockSecretManager::~MockSecretManager() {}

--- a/test/mocks/secret/mocks.h
+++ b/test/mocks/secret/mocks.h
@@ -18,9 +18,15 @@ public:
   MOCK_METHOD1(addStaticSecret, void(const envoy::api::v2::auth::Secret& secret));
   MOCK_CONST_METHOD1(findStaticTlsCertificateProvider,
                      TlsCertificateConfigProviderSharedPtr(const std::string& name));
+  MOCK_CONST_METHOD1(findStaticCertificateValidationContextProvider,
+                     CertificateValidationContextConfigProviderSharedPtr(const std::string& name));
   MOCK_METHOD1(createInlineTlsCertificateProvider,
                TlsCertificateConfigProviderSharedPtr(
                    const envoy::api::v2::auth::TlsCertificate& tls_certificate));
+  MOCK_METHOD1(createInlineCertificateValidationContextProvider,
+               CertificateValidationContextConfigProviderSharedPtr(
+                   const envoy::api::v2::auth::CertificateValidationContext&
+                       certificate_validation_context));
 };
 
 class MockSecretCallbacks : public SecretCallbacks {


### PR DESCRIPTION
Description:
Add certificate validation context config provider and refactor ContextConfigImpl. Make static and inline CertificateValidationContext utilize it. This is independent of PR #4256. Once #4256 is in, next step is to support fetching CertificateValidationContext via validation_context_sds_secret_config.

Risk Level: Low
Testing: unit test, integration test
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Jimmy Chen jimmychen.0102@gmail.com