### PR TITLE
build: fixing a downstream compile error by noting explicit fallthrough

### DIFF
--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -205,6 +205,7 @@ void HeaderString::setInteger(uint64_t value) {
   case Type::Inline:
     // buffer_.dynamic_ should always point at inline_buffer_ for Type::Inline.
     ASSERT(buffer_.dynamic_ == inline_buffer_);
+    FALLTHRU;
   case Type::Dynamic: {
     // Whether dynamic or inline the buffer is guaranteed to be large enough.
     ASSERT(type_ == Type::Inline || dynamic_capacity_ >= MaxIntegerLength);


### PR DESCRIPTION
#4245 breaks the internal build for me because it wants a fallthrough macro.  TBD: why this passed CI and didn't work locally and get them in sync.

*Risk Level*: Low (adding fallthrough annotation)
*Testing*: n/a
*Docs Changes*: n/a
*Release Notes*: n/a