### PR TITLE
build: Add bazel tap to Mac CI builds

### DIFF
--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -16,10 +16,20 @@ function install {
     fi
 }
 
+# TODO (cmluciano): remove once homebrew core is properly updated
+# with bazel 0.17.0
+function bazel_tap {
+    echo "Installing bazel tap"
+    brew tap bazelbuild/tap
+    brew tap-pin bazelbuild/tap
+}
+
 if ! brew update; then
     echo "Failed to update homebrew"
     exit 1
 fi
+
+bazel_tap
 
 DEPS="automake bazel cmake coreutils go libtool wget ninja"
 for DEP in ${DEPS}


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

*Description*: Bazel  0.16.0 is not currently available in homebrew core
*Risk Level*: Medium
*Testing*: Leveraging ci
*Docs Changes*: N/A
*Release Notes*: N/A
Fixes: #4267 
