### PR TITLE
stats: symbolize strings in HeapStatData and ThreadLocalStore

### DIFF
--- a/include/envoy/stats/symbol_table.h
+++ b/include/envoy/stats/symbol_table.h
@@ -18,9 +18,19 @@ class StatName {
 public:
   virtual ~StatName(){};
   virtual std::string toString() const PURE;
+  virtual uint64_t hash() const PURE;
+  virtual bool operator==(const StatName& rhs) const PURE;
 };
 
 using StatNamePtr = std::unique_ptr<StatName>;
+
+struct StatNameHash_ {
+  size_t operator()(const StatName* a) const { return a->hash(); }
+};
+
+struct StatNameCompare_ {
+  bool operator()(const StatName* a, const StatName* b) const { return (*a == *b); }
+};
 
 /**
  * Interface for shortening and retrieving stat names.

--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "absl/strings/ascii.h"
 #include "absl/strings/string_view.h"
@@ -34,6 +35,20 @@ public:
       hash += ((hash << 5) + hash) + absl::ascii_tolower(c);
     };
     return hash;
+  }
+
+  /**
+   * Return 64-bit hash from a vector of uint32s.
+   * @param input supplies the vector to be hashed.
+   * Adapted from boost::hash_combine. See details here: https://stackoverflow.com/a/4948967
+   * @return 64-bit hash of the supplied vector.
+   */
+  static uint64_t hashVector(std::vector<uint32_t> const& input) {
+    std::size_t seed = input.size();
+    for (auto& i : input) {
+      seed ^= i + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    }
+    return seed;
   }
 };
 

--- a/source/common/stats/BUILD
+++ b/source/common/stats/BUILD
@@ -14,6 +14,7 @@ envoy_cc_library(
     hdrs = ["heap_stat_data.h"],
     deps = [
         ":stat_data_allocator_lib",
+        ":symbol_table_lib",
         "//source/common/common:assert_lib",
         "//source/common/common:hash_lib",
         "//source/common/common:thread_annotations",
@@ -64,6 +65,7 @@ envoy_cc_library(
     hdrs = ["raw_stat_data.h"],
     deps = [
         ":stat_data_allocator_lib",
+        ":symbol_table_lib",
         "//include/envoy/stats:stats_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:hash_lib",
@@ -126,6 +128,9 @@ envoy_cc_library(
     deps = [
         "//include/envoy/stats:symbol_table_interface",
         "//source/common/common:assert_lib",
+        "//source/common/common:hash_lib",
+        "//source/common/common:lock_guard_lib",
+        "//source/common/common:thread_lib",
         "//source/common/common:utility_lib",
     ],
 )

--- a/source/common/stats/heap_stat_data.cc
+++ b/source/common/stats/heap_stat_data.cc
@@ -6,7 +6,7 @@
 namespace Envoy {
 namespace Stats {
 
-HeapStatData::HeapStatData(absl::string_view key) : name_(key.data(), key.size()) {}
+HeapStatData::HeapStatData(StatNamePtr name_ptr) : name_ptr_(std::move(name_ptr)) {}
 
 HeapStatDataAllocator::HeapStatDataAllocator() {}
 
@@ -15,8 +15,8 @@ HeapStatDataAllocator::~HeapStatDataAllocator() { ASSERT(stats_.empty()); }
 HeapStatData* HeapStatDataAllocator::alloc(absl::string_view name) {
   // Any expected truncation of name is done at the callsite. No truncation is
   // required to use this allocator.
-  auto data = std::make_unique<HeapStatData>(name);
   Thread::ReleasableLockGuard lock(mutex_);
+  auto data = std::make_unique<HeapStatData>(table_.encode(name));
   auto ret = stats_.insert(data.get());
   HeapStatData* existing_data = *ret.first;
   lock.release();

--- a/source/common/stats/heap_stat_data.h
+++ b/source/common/stats/heap_stat_data.h
@@ -5,9 +5,11 @@
 #include <unordered_set>
 
 #include "common/common/hash.h"
+#include "common/common/lock_guard.h"
 #include "common/common/thread.h"
 #include "common/common/thread_annotations.h"
 #include "common/stats/stat_data_allocator_impl.h"
+#include "common/stats/symbol_table_impl.h"
 
 namespace Envoy {
 namespace Stats {
@@ -17,23 +19,25 @@ namespace Stats {
  * so that it can be allocated efficiently from the heap on demand.
  */
 struct HeapStatData {
-  explicit HeapStatData(absl::string_view key);
+  explicit HeapStatData(StatNamePtr name_ptr);
 
   /**
-   * @returns absl::string_view the name as a string_view.
+   * @returns std::string the name as a std::string with no truncation.
    */
-  absl::string_view key() const { return name_; }
+  std::string name() const { return name_ptr_->toString(); }
 
   /**
-   * @returns std::string the name as a std::string.
+   * Alias for name(), because BlockMemoryHashSet<Value> expects Value::key().
    */
-  std::string name() const { return name_; }
+  std::string key() const { return name(); }
+
+  bool operator==(const HeapStatData& rhs) const { return *name_ptr_ == *(rhs.name_ptr_); }
 
   std::atomic<uint64_t> value_{0};
   std::atomic<uint64_t> pending_increment_{0};
   std::atomic<uint16_t> flags_{0};
   std::atomic<uint16_t> ref_count_{1};
-  std::string name_;
+  StatNamePtr name_ptr_;
 };
 
 /**
@@ -52,27 +56,33 @@ public:
   // StatDataAllocator
   bool requiresBoundedStatNameSize() const override { return false; }
 
+  // SymbolTableImpl
+  StatNamePtr encode(absl::string_view sv) {
+    Thread::LockGuard lock(mutex_);
+    return table_.encode(sv);
+  }
+
 private:
   struct HeapStatHash_ {
-    size_t operator()(const HeapStatData* a) const { return HashUtil::xxHash64(a->key()); }
+    size_t operator()(const HeapStatData* a) const { return a->name_ptr_->hash(); }
   };
   struct HeapStatCompare_ {
-    bool operator()(const HeapStatData* a, const HeapStatData* b) const {
-      return (a->key() == b->key());
-    }
+    bool operator()(const HeapStatData* a, const HeapStatData* b) const { return (*a == *b); }
   };
 
-  // TODO(jmarantz): See https://github.com/envoyproxy/envoy/pull/3927 and
-  //  https://github.com/envoyproxy/envoy/issues/3585, which can help reorganize
-  // the heap stats using a ref-counted symbol table to compress the stat strings.
   typedef std::unordered_set<HeapStatData*, HeapStatHash_, HeapStatCompare_> StatSet;
 
   // An unordered set of HeapStatData pointers which keys off the key()
-  // field in each object. This necessitates a custom comparator and hasher.
+  // field in each object. This necessitates a custom comparator and hasher, which key off of the
+  // StatNamePtr's own StatNamePtrHash_ and StatNamePtrCompare_ operators.
   StatSet stats_ GUARDED_BY(mutex_);
-  // A mutex is needed here to protect the stats_ object from both alloc() and free() operations.
-  // Although alloc() operations are called under existing locking, free() operations are made from
-  // the destructors of the individual stat objects, which are not protected by locks.
+  // A locally held symbol table which encodes stat names as StatNamePtrs and decodes StatNamePtrs
+  // back into strings.
+  SymbolTableImpl table_ GUARDED_BY(mutex_);
+  // A mutex is needed here to protect both the stats_ object and the table_ object from both
+  // alloc() and free() operations. Although alloc() operations are called under existing locking,
+  // free() operations are made from the destructors of the individual stat objects, which are not
+  // protected by locks.
   Thread::MutexBasicLockable mutex_;
 };
 

--- a/source/common/stats/isolated_store_impl.cc
+++ b/source/common/stats/isolated_store_impl.cc
@@ -13,19 +13,26 @@ namespace Envoy {
 namespace Stats {
 
 IsolatedStoreImpl::IsolatedStoreImpl()
-    : counters_([this](const std::string& name) -> CounterSharedPtr {
-        std::string tag_extracted_name = name;
-        std::vector<Tag> tags;
-        return alloc_.makeCounter(name, std::move(tag_extracted_name), std::move(tags));
-      }),
-      gauges_([this](const std::string& name) -> GaugeSharedPtr {
-        std::string tag_extracted_name = name;
-        std::vector<Tag> tags;
-        return alloc_.makeGauge(name, std::move(tag_extracted_name), std::move(tags));
-      }),
-      histograms_([this](const std::string& name) -> HistogramSharedPtr {
-        return std::make_shared<HistogramImpl>(name, *this, std::string(name), std::vector<Tag>());
-      }) {}
+    : counters_(
+          [this](const std::string& name) -> CounterSharedPtr {
+            std::string tag_extracted_name = name;
+            std::vector<Tag> tags;
+            return alloc_.makeCounter(name, std::move(tag_extracted_name), std::move(tags));
+          },
+          alloc_),
+      gauges_(
+          [this](const std::string& name) -> GaugeSharedPtr {
+            std::string tag_extracted_name = name;
+            std::vector<Tag> tags;
+            return alloc_.makeGauge(name, std::move(tag_extracted_name), std::move(tags));
+          },
+          alloc_),
+      histograms_(
+          [this](const std::string& name) -> HistogramSharedPtr {
+            return std::make_shared<HistogramImpl>(name, *this, std::string(name),
+                                                   std::vector<Tag>());
+          },
+          alloc_) {}
 
 struct IsolatedScopeImpl : public Scope {
   IsolatedScopeImpl(IsolatedStoreImpl& parent, const std::string& prefix)

--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -8,10 +8,12 @@
 #include "envoy/stats/stats.h"
 #include "envoy/stats/stats_options.h"
 #include "envoy/stats/store.h"
+#include "envoy/stats/symbol_table.h"
 
 #include "common/common/utility.h"
 #include "common/stats/heap_stat_data.h"
 #include "common/stats/stats_options_impl.h"
+#include "common/stats/symbol_table_impl.h"
 #include "common/stats/utility.h"
 
 namespace Envoy {
@@ -24,16 +26,18 @@ template <class Base> class IsolatedStatsCache {
 public:
   typedef std::function<std::shared_ptr<Base>(const std::string& name)> Allocator;
 
-  IsolatedStatsCache(Allocator alloc) : alloc_(alloc) {}
+  IsolatedStatsCache(Allocator alloc, HeapStatDataAllocator& heap_alloc)
+      : alloc_(alloc), heap_alloc_(heap_alloc) {}
 
   Base& get(const std::string& name) {
-    auto stat = stats_.find(name);
+    StatNamePtr ptr = heap_alloc_.encode(name);
+    auto stat = stats_.find(ptr);
     if (stat != stats_.end()) {
       return *stat->second;
     }
 
     std::shared_ptr<Base> new_stat = alloc_(name);
-    stats_.emplace(name, new_stat);
+    stats_.emplace(std::move(ptr), new_stat);
     return *new_stat;
   }
 
@@ -48,8 +52,10 @@ public:
   }
 
 private:
-  std::unordered_map<std::string, std::shared_ptr<Base>> stats_;
+  std::unordered_map<StatNamePtr, std::shared_ptr<Base>, StatNamePtrHash_, StatNamePtrCompare_>
+      stats_;
   Allocator alloc_;
+  HeapStatDataAllocator& heap_alloc_;
 };
 
 class IsolatedStoreImpl : public Store {

--- a/source/common/stats/symbol_table_impl.cc
+++ b/source/common/stats/symbol_table_impl.cc
@@ -9,10 +9,11 @@
 namespace Envoy {
 namespace Stats {
 
-// TODO(ambuc): There is a possible performance optimization here for avoiding the encoding of IPs,
-// if they appear in stat names. We don't want to waste time symbolizing an integer as an integer,
-// if we can help it.
+// TODO(ambuc): There is a possible performance optimization here for avoiding the encoding of IPs /
+// numbers if they appear in stat names. We don't want to waste time symbolizing an integer as an
+// integer, if we can help it.
 StatNamePtr SymbolTableImpl::encode(const absl::string_view name) {
+  Thread::LockGuard lock(lock_);
   SymbolVec symbol_vec;
   std::vector<absl::string_view> name_vec = absl::StrSplit(name, '.');
   symbol_vec.reserve(name_vec.size());
@@ -31,6 +32,7 @@ std::string SymbolTableImpl::decode(const SymbolVec& symbol_vec) const {
 }
 
 void SymbolTableImpl::free(const SymbolVec& symbol_vec) {
+  Thread::LockGuard lock(lock_);
   for (const Symbol symbol : symbol_vec) {
     auto decode_search = decode_map_.find(symbol);
     ASSERT(decode_search != decode_map_.end());

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -36,11 +36,11 @@ ThreadLocalStoreImpl::~ThreadLocalStoreImpl() {
 std::vector<CounterSharedPtr> ThreadLocalStoreImpl::counters() const {
   // Handle de-dup due to overlapping scopes.
   std::vector<CounterSharedPtr> ret;
-  std::unordered_set<std::string> names;
+  std::unordered_set<StatName*, StatNameHash_, StatNameCompare_> names;
   Thread::LockGuard lock(lock_);
   for (ScopeImpl* scope : scopes_) {
     for (auto& counter : scope->central_cache_.counters_) {
-      if (names.insert(counter.first).second) {
+      if (names.insert(counter.first.get()).second) {
         ret.push_back(counter.second);
       }
     }
@@ -59,11 +59,11 @@ ScopePtr ThreadLocalStoreImpl::createScope(const std::string& name) {
 std::vector<GaugeSharedPtr> ThreadLocalStoreImpl::gauges() const {
   // Handle de-dup due to overlapping scopes.
   std::vector<GaugeSharedPtr> ret;
-  std::unordered_set<std::string> names;
+  std::unordered_set<StatName*, StatNameHash_, StatNameCompare_> names;
   Thread::LockGuard lock(lock_);
   for (ScopeImpl* scope : scopes_) {
     for (auto& gauge : scope->central_cache_.gauges_) {
-      if (names.insert(gauge.first).second) {
+      if (names.insert(gauge.first.get()).second) {
         ret.push_back(gauge.second);
       }
     }
@@ -190,7 +190,8 @@ ThreadLocalStoreImpl::ScopeImpl::~ScopeImpl() { parent_.releaseScopeCrossThread(
 template <class StatType>
 StatType& ThreadLocalStoreImpl::ScopeImpl::safeMakeStat(
     const std::string& name,
-    std::unordered_map<std::string, std::shared_ptr<StatType>>& central_cache_map,
+    std::unordered_map<StatNamePtr, std::shared_ptr<StatType>, StatNamePtrHash_,
+                       StatNamePtrCompare_>& central_cache_map,
     MakeStatFn<StatType> make_stat, std::shared_ptr<StatType>* tls_ref) {
 
   // If we have a valid cache entry, return it.
@@ -201,7 +202,8 @@ StatType& ThreadLocalStoreImpl::ScopeImpl::safeMakeStat(
   // We must now look in the central store so we must be locked. We grab a reference to the
   // central store location. It might contain nothing. In this case, we allocate a new stat.
   Thread::LockGuard lock(parent_.lock_);
-  std::shared_ptr<StatType>& central_ref = central_cache_map[name];
+  StatNamePtr stat_name_ptr = parent_.heap_allocator_.encode(name);
+  std::shared_ptr<StatType>& central_ref = central_cache_map[std::move(stat_name_ptr)];
   if (!central_ref) {
     std::vector<Tag> tags;
 
@@ -237,9 +239,11 @@ Counter& ThreadLocalStoreImpl::ScopeImpl::counter(const std::string& name) {
   // if we don't have TLS initialized currently. The de-referenced pointer might be null if there
   // is no cache entry.
   CounterSharedPtr* tls_ref = nullptr;
+  StatNamePtr stat_name_ptr = parent_.heap_allocator_.encode(final_name);
   if (!parent_.shutting_down_ && parent_.tls_) {
-    tls_ref =
-        &parent_.tls_->getTyped<TlsCache>().scope_cache_[this->scope_id_].counters_[final_name];
+    tls_ref = &parent_.tls_->getTyped<TlsCache>()
+                   .scope_cache_[this->scope_id_]
+                   .counters_[std::move(stat_name_ptr)];
   }
 
   return safeMakeStat<Counter>(
@@ -272,8 +276,11 @@ Gauge& ThreadLocalStoreImpl::ScopeImpl::gauge(const std::string& name) {
   // share this code so I'm leaving it largely duplicated for now.
   std::string final_name = prefix_ + name;
   GaugeSharedPtr* tls_ref = nullptr;
+  StatNamePtr stat_name_ptr = parent_.heap_allocator_.encode(final_name);
   if (!parent_.shutting_down_ && parent_.tls_) {
-    tls_ref = &parent_.tls_->getTyped<TlsCache>().scope_cache_[this->scope_id_].gauges_[final_name];
+    tls_ref = &parent_.tls_->getTyped<TlsCache>()
+                   .scope_cache_[this->scope_id_]
+                   .gauges_[std::move(stat_name_ptr)];
   }
 
   return safeMakeStat<Gauge>(
@@ -290,11 +297,11 @@ Histogram& ThreadLocalStoreImpl::ScopeImpl::histogram(const std::string& name) {
   // share this code so I'm leaving it largely duplicated for now.
   std::string final_name = prefix_ + name;
   ParentHistogramSharedPtr* tls_ref = nullptr;
-
+  StatNamePtr stat_name_ptr = parent_.heap_allocator_.encode(final_name);
   if (!parent_.shutting_down_ && parent_.tls_) {
     tls_ref = &parent_.tls_->getTyped<TlsCache>()
                    .scope_cache_[this->scope_id_]
-                   .parent_histograms_[final_name];
+                   .parent_histograms_[std::move(stat_name_ptr)];
   }
 
   if (tls_ref && *tls_ref) {
@@ -302,7 +309,12 @@ Histogram& ThreadLocalStoreImpl::ScopeImpl::histogram(const std::string& name) {
   }
 
   Thread::LockGuard lock(parent_.lock_);
-  ParentHistogramImplSharedPtr& central_ref = central_cache_.histograms_[final_name];
+  // TODO(ambuc): This is obviously a duplicate of the work done just a few lines ago. If these were
+  // shared ptrs, or if we had a good method for duplicating StatNamePtrs without the cost of
+  // lookups, this could be optimized.
+  StatNamePtr stat_name_ptr_reencode = parent_.heap_allocator_.encode(final_name);
+  ParentHistogramImplSharedPtr& central_ref =
+      central_cache_.histograms_[std::move(stat_name_ptr_reencode)];
   if (!central_ref) {
     std::vector<Tag> tags;
     std::string tag_extracted_name = parent_.getTagsForName(final_name, tags);
@@ -323,8 +335,11 @@ Histogram& ThreadLocalStoreImpl::ScopeImpl::tlsHistogram(const std::string& name
   // Here prefix will not be considered because, by the time ParentHistogram calls this method
   // during recordValue, the prefix is already attached to the name.
   TlsHistogramSharedPtr* tls_ref = nullptr;
+  StatNamePtr stat_name_ptr = parent_.heap_allocator_.encode(name);
   if (!parent_.shutting_down_ && parent_.tls_) {
-    tls_ref = &parent_.tls_->getTyped<TlsCache>().scope_cache_[this->scope_id_].histograms_[name];
+    tls_ref = &parent_.tls_->getTyped<TlsCache>()
+                   .scope_cache_[this->scope_id_]
+                   .histograms_[std::move(stat_name_ptr)];
   }
 
   if (tls_ref && *tls_ref) {


### PR DESCRIPTION
*Description*: On the heels of https://github.com/envoyproxy/envoy/pull/3927, and in pursuit of lower heap consumption for Envoy (https://github.com/envoyproxy/envoy/issues/3585), this implementation uses the new `Stats::SymbolTable` library to symbolize `std::string` instances within `HeapStatData` and `ThreadLocalStore`.

Preliminary heap allocation improvements here:

|            |         | short       | short       | long        | long        |                          |            |
|-----------:|--------:|------------------:|------------------:|------------------:|------------------:|-------------------------:|-----------:|
|            |         | current impl      | w/ symbol table | current impl      | w/ symbol table |  improvement |  improvement |
| clusters | runtime | allocated on heap | allocated on heap | allocated on heap | allocated on heap | short              | long |
| (#)        | (sec)   | (kB)              | (kB)              | (kB)              | (kB)              | (%)                      | (%)        |
| 10         | 30      | 2484              | 2481              | 2637              | 2564              | -0.15%                   | -2.77%     |
| 100        | 45      | 7996              | 8008              | 9552              | 8854              | 0.14%                    | -7.31%     |
| 1000       | 60      | 63145             | 63158             | 78793             | 71702             | 0.02%                    | -9.00%     |
| 10000      | 90      | 3566177           | 3480433           | 5509859           | 4420003           | -2.40%                   | -19.78%    |

Here, 'short' character names are ~10 characters long, 'long' character names are ~60 characters long, and all runs are against an `envoy-static` binary with `--disable-hot-restart`.

*Risk Level*: Medium -- this affects non-hot-restart binaries, so there won't be any issues with trying to restart against a different internal memory representation. But any PR which changes internal memory stuff comes with some risk.
*Testing*: As a drop-in replacement for HeapStatData / ThreadLocalStore, there are no new tests for these classes.
*Docs Changes*: N/A
*Release Notes*: N/A, no user-facing changes.
*Fixes* https://github.com/envoyproxy/envoy/issues/3585