### PR TITLE
thrift: refactor Thrift router to allow protocol upgrade

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/BUILD
@@ -105,6 +105,7 @@ envoy_cc_library(
     external_deps = ["abseil_optional"],
     deps = [
         ":thrift_lib",
+        "//include/envoy/buffer:buffer_interface",
         "//source/common/common:macros",
     ],
 )
@@ -128,14 +129,18 @@ envoy_cc_library(
     ],
     external_deps = ["abseil_optional"],
     deps = [
+        ":conn_state_lib",
         ":decoder_events_lib",
         ":metadata_lib",
         ":thrift_lib",
+        ":thrift_object_interface",
+        ":transport_interface",
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/registry",
         "//source/common/common:assert_lib",
         "//source/common/config:utility_lib",
         "//source/common/singleton:const_singleton",
+        "//source/extensions/filters/network/thrift_proxy/filters:filter_interface",
     ],
 )
 
@@ -222,11 +227,40 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "conn_state_lib",
+    hdrs = ["conn_state.h"],
+    deps = [
+        "//include/envoy/tcp:conn_pool_interface",
+    ],
+)
+
+envoy_cc_library(
     name = "thrift_lib",
     hdrs = ["thrift.h"],
     deps = [
         "//source/common/common:assert_lib",
         "//source/common/singleton:const_singleton",
+    ],
+)
+
+envoy_cc_library(
+    name = "thrift_object_interface",
+    hdrs = ["thrift_object.h"],
+    deps = [
+        "//include/envoy/buffer:buffer_interface",
+    ],
+)
+
+envoy_cc_library(
+    name = "thrift_object_lib",
+    srcs = ["thrift_object_impl.cc"],
+    hdrs = ["thrift_object_impl.h"],
+    deps = [
+        ":decoder_lib",
+        ":thrift_lib",
+        ":thrift_object_interface",
+        ":unframed_transport_lib",
+        "//source/extensions/filters/network/thrift_proxy/filters:filter_interface",
     ],
 )
 

--- a/source/extensions/filters/network/thrift_proxy/config.cc
+++ b/source/extensions/filters/network/thrift_proxy/config.cc
@@ -142,10 +142,6 @@ void ConfigImpl::createFilterChain(ThriftFilters::FilterChainFactoryCallbacks& c
   }
 }
 
-DecoderPtr ConfigImpl::createDecoder(DecoderCallbacks& callbacks) {
-  return std::make_unique<Decoder>(createTransport(), createProtocol(), callbacks);
-}
-
 TransportPtr ConfigImpl::createTransport() {
   return NamedTransportConfigFactory::getFactory(transport_).createTransport();
 }

--- a/source/extensions/filters/network/thrift_proxy/config.h
+++ b/source/extensions/filters/network/thrift_proxy/config.h
@@ -76,13 +76,11 @@ public:
   // Config
   ThriftFilterStats& stats() override { return stats_; }
   ThriftFilters::FilterChainFactory& filterFactory() override { return *this; }
-  DecoderPtr createDecoder(DecoderCallbacks& callbacks) override;
+  TransportPtr createTransport() override;
+  ProtocolPtr createProtocol() override;
   Router::Config& routerConfig() override { return *this; }
 
 private:
-  TransportPtr createTransport();
-  ProtocolPtr createProtocol();
-
   Server::Configuration::FactoryContext& context_;
   const std::string stats_prefix_;
   ThriftFilterStats stats_;

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -16,7 +16,9 @@ namespace NetworkFilters {
 namespace ThriftProxy {
 
 ConnectionManager::ConnectionManager(Config& config)
-    : config_(config), stats_(config_.stats()), decoder_(config_.createDecoder(*this)) {}
+    : config_(config), stats_(config_.stats()), transport_(config.createTransport()),
+      protocol_(config.createProtocol()),
+      decoder_(std::make_unique<Decoder>(*transport_, *protocol_, *this)) {}
 
 ConnectionManager::~ConnectionManager() {}
 
@@ -67,22 +69,14 @@ void ConnectionManager::dispatch() {
 }
 
 void ConnectionManager::sendLocalReply(MessageMetadata& metadata, const DirectResponse& response) {
-  // Use the factory to get the concrete protocol from the decoder protocol (as opposed to
-  // potentially pre-detection auto protocol).
-  ProtocolType proto_type = decoder_->protocolType();
-  ProtocolPtr proto = NamedProtocolConfigFactory::getFactory(proto_type).createProtocol();
   Buffer::OwnedImpl buffer;
 
-  response.encode(metadata, *proto, buffer);
-
-  // Same logic as protocol above.
-  TransportPtr transport =
-      NamedTransportConfigFactory::getFactory(decoder_->transportType()).createTransport();
+  response.encode(metadata, *protocol_, buffer);
 
   Buffer::OwnedImpl response_buffer;
 
-  metadata.setProtocol(proto_type);
-  transport->encodeFrame(response_buffer, metadata, buffer);
+  metadata.setProtocol(protocol_->type());
+  transport_->encodeFrame(response_buffer, metadata, buffer);
 
   read_callbacks_->connection().write(response_buffer, false);
 }
@@ -230,11 +224,29 @@ FilterStatus ConnectionManager::ActiveRpc::transportEnd() {
     break;
   }
 
-  return decoder_filter_->transportEnd();
+  FilterStatus status = event_handler_->transportEnd();
+
+  if (metadata_->isProtocolUpgradeMessage()) {
+    ENVOY_CONN_LOG(error, "thrift: sending protocol upgrade response",
+                   parent_.read_callbacks_->connection());
+    sendLocalReply(*parent_.protocol_->upgradeResponse(*upgrade_handler_));
+  }
+
+  return status;
 }
 
 FilterStatus ConnectionManager::ActiveRpc::messageBegin(MessageMetadataSharedPtr metadata) {
   metadata_ = metadata;
+
+  if (metadata_->isProtocolUpgradeMessage()) {
+    ASSERT(parent_.protocol_->supportsUpgrade());
+
+    ENVOY_CONN_LOG(error, "thrift: decoding protocol upgrade request",
+                   parent_.read_callbacks_->connection());
+    upgrade_handler_ = parent_.protocol_->upgradeRequestDecoder();
+    ASSERT(upgrade_handler_ != nullptr);
+    event_handler_ = upgrade_handler_.get();
+  }
 
   return event_handler_->messageBegin(metadata);
 }
@@ -282,11 +294,10 @@ void ConnectionManager::ActiveRpc::sendLocalReply(const DirectResponse& response
   parent_.doDeferredRpcDestroy(*this);
 }
 
-void ConnectionManager::ActiveRpc::startUpstreamResponse(TransportType transport_type,
-                                                         ProtocolType protocol_type) {
+void ConnectionManager::ActiveRpc::startUpstreamResponse(Transport& transport, Protocol& protocol) {
   ASSERT(response_decoder_ == nullptr);
 
-  response_decoder_ = std::make_unique<ResponseDecoder>(*this, transport_type, protocol_type);
+  response_decoder_ = std::make_unique<ResponseDecoder>(*this, transport, protocol);
 }
 
 bool ConnectionManager::ActiveRpc::upstreamData(Buffer::Instance& buffer) {

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.h
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.h
@@ -31,7 +31,8 @@ public:
 
   virtual ThriftFilters::FilterChainFactory& filterFactory() PURE;
   virtual ThriftFilterStats& stats() PURE;
-  virtual DecoderPtr createDecoder(DecoderCallbacks& callbacks) PURE;
+  virtual TransportPtr createTransport() PURE;
+  virtual ProtocolPtr createProtocol() PURE;
   virtual Router::Config& routerConfig() PURE;
 };
 
@@ -74,18 +75,10 @@ private:
   struct ActiveRpc;
 
   struct ResponseDecoder : public DecoderCallbacks, public ProtocolConverter {
-    ResponseDecoder(ActiveRpc& parent, TransportType transport_type, ProtocolType protocol_type)
-        : parent_(parent),
-          decoder_(std::make_unique<Decoder>(
-              NamedTransportConfigFactory::getFactory(transport_type).createTransport(),
-              NamedProtocolConfigFactory::getFactory(protocol_type).createProtocol(), *this)),
+    ResponseDecoder(ActiveRpc& parent, Transport& transport, Protocol& protocol)
+        : parent_(parent), decoder_(std::make_unique<Decoder>(transport, protocol, *this)),
           complete_(false), first_reply_field_(false) {
-      // Use the factory to get the concrete protocol from the decoder protocol (as opposed to
-      // potentially pre-detection auto protocol).
-      initProtocolConverter(
-          NamedProtocolConfigFactory::getFactory(parent_.parent_.decoder_->protocolType())
-              .createProtocol(),
-          parent_.response_buffer_);
+      initProtocolConverter(parent_.parent_.protocol_.get(), parent_.response_buffer_);
     }
 
     bool onData(Buffer::Instance& data);
@@ -149,7 +142,7 @@ private:
       return parent_.decoder_->protocolType();
     }
     void sendLocalReply(const DirectResponse& response) override;
-    void startUpstreamResponse(TransportType transport_type, ProtocolType protocol_type) override;
+    void startUpstreamResponse(Transport& transport, Protocol& protocol) override;
     bool upstreamData(Buffer::Instance& buffer) override;
     void resetDownstreamConnection() override;
 
@@ -170,6 +163,7 @@ private:
     uint64_t stream_id_;
     MessageMetadataSharedPtr metadata_;
     ThriftFilters::DecoderFilterSharedPtr decoder_filter_;
+    DecoderEventHandlerSharedPtr upgrade_handler_;
     ResponseDecoderPtr response_decoder_;
     absl::optional<Router::RouteConstSharedPtr> cached_route_;
     Buffer::OwnedImpl response_buffer_;
@@ -188,6 +182,8 @@ private:
 
   Network::ReadFilterCallbacks* read_callbacks_{};
 
+  TransportPtr transport_;
+  ProtocolPtr protocol_;
   DecoderPtr decoder_;
   std::list<ActiveRpcPtr> rpcs_;
   Buffer::OwnedImpl request_buffer_;

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.h
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.h
@@ -78,7 +78,7 @@ private:
     ResponseDecoder(ActiveRpc& parent, Transport& transport, Protocol& protocol)
         : parent_(parent), decoder_(std::make_unique<Decoder>(transport, protocol, *this)),
           complete_(false), first_reply_field_(false) {
-      initProtocolConverter(parent_.parent_.protocol_.get(), parent_.response_buffer_);
+      initProtocolConverter(*parent_.parent_.protocol_, parent_.response_buffer_);
     }
 
     bool onData(Buffer::Instance& data);

--- a/source/extensions/filters/network/thrift_proxy/conn_state.h
+++ b/source/extensions/filters/network/thrift_proxy/conn_state.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "envoy/tcp/conn_pool.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+
+/**
+ * ThriftConnectionState tracks thrift-related connection state for pooled connections.
+ */
+class ThriftConnectionState : public Tcp::ConnectionPool::ConnectionState {
+public:
+  /**
+   * @return true if this upgrade has been attempted on this connection.
+   */
+  bool upgradeAttempted() const { return upgrade_attempted_; }
+  /**
+   * @return true if this connection has been upgraded
+   */
+  bool isUpgraded() const { return upgraded_; }
+
+  /**
+   * Marks the connection as successfully upgraded.
+   */
+  void markUpgraded() {
+    upgrade_attempted_ = true;
+    upgraded_ = true;
+  }
+
+  /**
+   * Marks the connection as not upgraded.
+   */
+  void markUpgradeFailed() {
+    upgrade_attempted_ = true;
+    upgraded_ = false;
+  }
+
+private:
+  bool upgrade_attempted_{false};
+  bool upgraded_{false};
+};
+
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/thrift_proxy/filters/filter.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/filter.h
@@ -68,10 +68,10 @@ public:
 
   /**
    * Indicates the start of an upstream response. May only be called once.
-   * @param transport_type TransportType the upstream is using
-   * @param protocol_type ProtocolType the upstream is using
+   * @param transport the transport used by the upstream response
+   * @param protocol the protocol used by the upstream response
    */
-  virtual void startUpstreamResponse(TransportType transport_type, ProtocolType protocol_type) PURE;
+  virtual void startUpstreamResponse(Transport& transport, Protocol& protocol) PURE;
 
   /**
    * Called with upstream response data.

--- a/source/extensions/filters/network/thrift_proxy/metadata.h
+++ b/source/extensions/filters/network/thrift_proxy/metadata.h
@@ -84,27 +84,6 @@ private:
 
 typedef std::shared_ptr<MessageMetadata> MessageMetadataSharedPtr;
 
-class Protocol;
-
-/**
- * A DirectResponse manipulates a Protocol to directly create a Thrift response message.
- */
-class DirectResponse {
-public:
-  virtual ~DirectResponse() {}
-
-  /**
-   * Encodes the response via the given Protocol.
-   * @param metadata the MessageMetadata for the request that generated this response
-   * @param proto the Protocol to be used for message encoding
-   * @param buffer the Buffer into which the message should be encoded
-   */
-  virtual void encode(MessageMetadata& metadata, Protocol& proto,
-                      Buffer::Instance& buffer) const PURE;
-};
-
-typedef std::unique_ptr<DirectResponse> DirectResponsePtr;
-
 } // namespace ThriftProxy
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/source/extensions/filters/network/thrift_proxy/protocol.h
+++ b/source/extensions/filters/network/thrift_proxy/protocol.h
@@ -25,6 +25,9 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace ThriftProxy {
 
+class DirectResponse;
+typedef std::unique_ptr<DirectResponse> DirectResponsePtr;
+
 /**
  * Protocol represents the operations necessary to implement the a generic Thrift protocol.
  * See https://github.com/apache/thrift/blob/master/doc/specs/thrift-protocol-spec.md
@@ -460,6 +463,23 @@ public:
 };
 
 typedef std::unique_ptr<Protocol> ProtocolPtr;
+
+/**
+ * A DirectResponse manipulates a Protocol to directly create a Thrift response message.
+ */
+class DirectResponse {
+public:
+  virtual ~DirectResponse() {}
+
+  /**
+   * Encodes the response via the given Protocol.
+   * @param metadata the MessageMetadata for the request that generated this response
+   * @param proto the Protocol to be used for message encoding
+   * @param buffer the Buffer into which the message should be encoded
+   */
+  virtual void encode(MessageMetadata& metadata, Protocol& proto,
+                      Buffer::Instance& buffer) const PURE;
+};
 
 /**
  * Implemented by each Thrift protocol and registered via Registry::registerFactory or the

--- a/source/extensions/filters/network/thrift_proxy/protocol.h
+++ b/source/extensions/filters/network/thrift_proxy/protocol.h
@@ -429,7 +429,7 @@ public:
   }
 
   /**
-   * Check whether a given upstream connection can be upgraded and generates an upgrade request
+   * Checks whether a given upstream connection can be upgraded and generates an upgrade request
    * message. If this method returns a ThriftObject it will be used to decode the upstream's next
    * response.
    *

--- a/source/extensions/filters/network/thrift_proxy/protocol.h
+++ b/source/extensions/filters/network/thrift_proxy/protocol.h
@@ -11,8 +11,12 @@
 #include "common/config/utility.h"
 #include "common/singleton/const_singleton.h"
 
+#include "extensions/filters/network/thrift_proxy/conn_state.h"
+#include "extensions/filters/network/thrift_proxy/decoder_events.h"
 #include "extensions/filters/network/thrift_proxy/metadata.h"
 #include "extensions/filters/network/thrift_proxy/thrift.h"
+#include "extensions/filters/network/thrift_proxy/thrift_object.h"
+#include "extensions/filters/network/thrift_proxy/transport.h"
 
 #include "absl/strings/string_view.h"
 
@@ -394,6 +398,65 @@ public:
    * @param value std::string to write
    */
   virtual void writeBinary(Buffer::Instance& buffer, const std::string& value) PURE;
+
+  /**
+   * Indicates whether a protocol uses start-of-connection messages to negotiate protocol options.
+   * If this method returns true, the Protocol must invoke setProtocolUpgradeMessage during
+   * readMessageBegin if it detects an upgrade request.
+   *
+   * @return true for protocols that exchange messages at the start of a connection to negotiate
+   *         protocol upgrade (or options)
+   */
+  virtual bool supportsUpgrade() { return false; }
+
+  /**
+   * Creates an opaque DecoderEventHandlerSharedPtr that can decode a downstream client's upgrade
+   * request. When the request is complete, the decoder is passed back to writeUpgradeResponse
+   * to allow the Protocol to update its internal state and generate a response to the request.
+   *
+   * @return a DecoderEventHandlerSharedPtr that decodes a downstream client's upgrade request
+   */
+  virtual DecoderEventHandlerSharedPtr upgradeRequestDecoder() { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+
+  /**
+   * Writes a response to a downstream client's upgrade request.
+   * @param decoder DecoderEventHandlerSharedPtr created by upgradeRequestDecoder
+   * @return DirectResponsePtr containing an upgrade response
+   */
+  virtual DirectResponsePtr upgradeResponse(const DecoderEventHandler& decoder) {
+    UNREFERENCED_PARAMETER(decoder);
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
+
+  /**
+   * Check whether a given upstream connection can be upgraded and generates an upgrade request
+   * message. If this method returns a ThriftObject it will be used to decode the upstream's next
+   * response.
+   *
+   * @param transport the Transport to use for decoding the response
+   * @param state ThriftConnectionState tracking whether upgrade has already been performed
+   * @param buffer Buffer::Instance to modify with an upgrade request
+   * @return a ThriftObject capable of decoding an upgrade response or nullptr if upgrade was
+   *         already completed (successfully or not)
+   */
+  virtual ThriftObjectPtr attemptUpgrade(Transport& transport, ThriftConnectionState& state,
+                                         Buffer::Instance& buffer) {
+    UNREFERENCED_PARAMETER(transport);
+    UNREFERENCED_PARAMETER(state);
+    UNREFERENCED_PARAMETER(buffer);
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
+
+  /**
+   * Completes an upgrade previously started via attemptUpgrade.
+   * @param response ThriftObject created by attemptUpgrade, after the response has completed
+   *        decoding
+   */
+  virtual void completeUpgrade(ThriftConnectionState& state, ThriftObject& response) {
+    UNREFERENCED_PARAMETER(state);
+    UNREFERENCED_PARAMETER(response);
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
 };
 
 typedef std::unique_ptr<Protocol> ProtocolPtr;
@@ -443,25 +506,6 @@ protected:
 private:
   const std::string name_;
 };
-
-/**
- * A DirectResponse manipulates a Protocol to directly create a Thrift response message.
- */
-class DirectResponse {
-public:
-  virtual ~DirectResponse() {}
-
-  /**
-   * Encodes the response via the given Protocol.
-   * @param metadata the MessageMetadata for the request that generated this response
-   * @param proto the Protocol to be used for message encoding
-   * @param buffer the Buffer into which the message should be encoded
-   */
-  virtual void encode(MessageMetadata& metadata, Protocol& proto,
-                      Buffer::Instance& buffer) const PURE;
-};
-
-typedef std::unique_ptr<DirectResponse> DirectResponsePtr;
 
 } // namespace ThriftProxy
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/thrift_proxy/protocol_converter.h
+++ b/source/extensions/filters/network/thrift_proxy/protocol_converter.h
@@ -19,8 +19,8 @@ public:
   ProtocolConverter() {}
   virtual ~ProtocolConverter() {}
 
-  void initProtocolConverter(Protocol* proto, Buffer::Instance& buffer) {
-    proto_ = proto;
+  void initProtocolConverter(Protocol& proto, Buffer::Instance& buffer) {
+    proto_ = &proto;
     buffer_ = &buffer;
   }
 

--- a/source/extensions/filters/network/thrift_proxy/protocol_converter.h
+++ b/source/extensions/filters/network/thrift_proxy/protocol_converter.h
@@ -19,8 +19,8 @@ public:
   ProtocolConverter() {}
   virtual ~ProtocolConverter() {}
 
-  void initProtocolConverter(ProtocolPtr&& proto, Buffer::Instance& buffer) {
-    proto_ = std::move(proto);
+  void initProtocolConverter(Protocol* proto, Buffer::Instance& buffer) {
+    proto_ = proto;
     buffer_ = &buffer;
   }
 
@@ -125,7 +125,7 @@ protected:
   ProtocolType protocolType() const { return proto_->type(); }
 
 private:
-  ProtocolPtr proto_;
+  Protocol* proto_;
   Buffer::Instance* buffer_{};
 };
 

--- a/source/extensions/filters/network/thrift_proxy/router/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/router/BUILD
@@ -26,7 +26,9 @@ envoy_cc_library(
     name = "router_interface",
     hdrs = ["router.h"],
     external_deps = ["abseil_optional"],
-    deps = [],
+    deps = [
+        "//source/extensions/filters/network/thrift_proxy:metadata_lib",
+    ],
 )
 
 envoy_cc_library(
@@ -46,8 +48,9 @@ envoy_cc_library(
         "//source/extensions/filters/network/thrift_proxy:app_exception_lib",
         "//source/extensions/filters/network/thrift_proxy:conn_manager_lib",
         "//source/extensions/filters/network/thrift_proxy:protocol_converter_lib",
-        "//source/extensions/filters/network/thrift_proxy:protocol_lib",
-        "//source/extensions/filters/network/thrift_proxy:transport_lib",
+        "//source/extensions/filters/network/thrift_proxy:protocol_interface",
+        "//source/extensions/filters/network/thrift_proxy:thrift_object_interface",
+        "//source/extensions/filters/network/thrift_proxy:transport_interface",
         "//source/extensions/filters/network/thrift_proxy/filters:filter_interface",
         "@envoy_api//envoy/config/filter/network/thrift_proxy/v2alpha1:thrift_proxy_cc",
     ],

--- a/source/extensions/filters/network/thrift_proxy/router/router.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router.h
@@ -3,6 +3,8 @@
 #include <memory>
 #include <string>
 
+#include "extensions/filters/network/thrift_proxy/metadata.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -213,13 +213,12 @@ FilterStatus Router::messageBegin(MessageMetadataSharedPtr metadata) {
 FilterStatus Router::messageEnd() {
   ProtocolConverter::messageEnd();
 
-  TransportPtr transport =
-      NamedTransportConfigFactory::getFactory(upstream_request_->transport_type_).createTransport();
   Buffer::OwnedImpl transport_buffer;
 
-  upstream_request_->metadata_->setProtocol(upstream_request_->protocol_type_);
+  upstream_request_->metadata_->setProtocol(upstream_request_->protocol_->type());
 
-  transport->encodeFrame(transport_buffer, *upstream_request_->metadata_, upstream_request_buffer_);
+  upstream_request_->transport_->encodeFrame(transport_buffer, *upstream_request_->metadata_,
+                                             upstream_request_buffer_);
   upstream_request_->conn_data_->connection().write(transport_buffer, false);
   upstream_request_->onRequestComplete();
   return FilterStatus::Continue;
@@ -228,16 +227,32 @@ FilterStatus Router::messageEnd() {
 void Router::onUpstreamData(Buffer::Instance& data, bool end_stream) {
   ASSERT(!upstream_request_->response_complete_);
 
-  if (!upstream_request_->response_started_) {
-    callbacks_->startUpstreamResponse(upstream_request_->transport_type_,
-                                      upstream_request_->protocol_type_);
-    upstream_request_->response_started_ = true;
-  }
+  if (upstream_request_->upgrade_response_ != nullptr) {
+    // Handle upgrade response.
+    if (!upstream_request_->upgrade_response_->onData(data)) {
+      // Wait for more data.
+      return;
+    }
 
-  if (callbacks_->upstreamData(data)) {
-    upstream_request_->onResponseComplete();
-    cleanup();
-    return;
+    upstream_request_->protocol_->completeUpgrade(
+        *upstream_request_->conn_data_->connectionStateTyped<ThriftConnectionState>(),
+        *upstream_request_->upgrade_response_);
+
+    upstream_request_->upgrade_response_.reset();
+    upstream_request_->onRequestStart(true);
+  } else {
+    // Handle normal response.
+    if (!upstream_request_->response_started_) {
+      callbacks_->startUpstreamResponse(*upstream_request_->transport_,
+                                        *upstream_request_->protocol_);
+      upstream_request_->response_started_ = true;
+    }
+
+    if (callbacks_->upstreamData(data)) {
+      upstream_request_->onResponseComplete();
+      cleanup();
+      return;
+    }
   }
 
   if (end_stream) {
@@ -284,9 +299,10 @@ void Router::cleanup() { upstream_request_.reset(); }
 Router::UpstreamRequest::UpstreamRequest(Router& parent, Tcp::ConnectionPool::Instance& pool,
                                          MessageMetadataSharedPtr& metadata,
                                          TransportType transport_type, ProtocolType protocol_type)
-    : parent_(parent), conn_pool_(pool), metadata_(metadata), transport_type_(transport_type),
-      protocol_type_(protocol_type), request_complete_(false), response_started_(false),
-      response_complete_(false) {}
+    : parent_(parent), conn_pool_(pool), metadata_(metadata),
+      transport_(NamedTransportConfigFactory::getFactory(transport_type).createTransport()),
+      protocol_(NamedProtocolConfigFactory::getFactory(protocol_type).createProtocol()),
+      request_complete_(false), response_started_(false), response_complete_(false) {}
 
 Router::UpstreamRequest::~UpstreamRequest() {}
 
@@ -295,6 +311,11 @@ FilterStatus Router::UpstreamRequest::start() {
   if (handle) {
     // Pause while we wait for a connection.
     conn_pool_handle_ = handle;
+    return FilterStatus::StopIteration;
+  }
+
+  if (upgrade_response_ != nullptr) {
+    // Pause while we wait for an upgrade response.
     return FilterStatus::StopIteration;
   }
 
@@ -329,12 +350,28 @@ void Router::UpstreamRequest::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr
   onUpstreamHostSelected(host);
   conn_data_ = std::move(conn_data);
   conn_data_->addUpstreamCallbacks(parent_);
-
   conn_pool_handle_ = nullptr;
 
-  parent_.initProtocolConverter(
-      NamedProtocolConfigFactory::getFactory(protocol_type_).createProtocol(),
-      parent_.upstream_request_buffer_);
+  ThriftConnectionState* state = conn_data_->connectionStateTyped<ThriftConnectionState>();
+  if (state == nullptr) {
+    conn_data_->setConnectionState(std::make_unique<ThriftConnectionState>());
+    state = conn_data_->connectionStateTyped<ThriftConnectionState>();
+  }
+
+  if (protocol_->supportsUpgrade()) {
+    upgrade_response_ =
+        protocol_->attemptUpgrade(*transport_, *state, parent_.upstream_request_buffer_);
+    if (upgrade_response_ != nullptr) {
+      conn_data_->connection().write(parent_.upstream_request_buffer_, false);
+      return;
+    }
+  }
+
+  onRequestStart(continue_decoding);
+}
+
+void Router::UpstreamRequest::onRequestStart(bool continue_decoding) {
+  parent_.initProtocolConverter(protocol_.get(), parent_.upstream_request_buffer_);
 
   // TODO(zuercher): need to use an upstream-connection-specific sequence id
   parent_.convertMessageBegin(metadata_);

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -371,7 +371,7 @@ void Router::UpstreamRequest::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr
 }
 
 void Router::UpstreamRequest::onRequestStart(bool continue_decoding) {
-  parent_.initProtocolConverter(protocol_.get(), parent_.upstream_request_buffer_);
+  parent_.initProtocolConverter(*protocol_, parent_.upstream_request_buffer_);
 
   // TODO(zuercher): need to use an upstream-connection-specific sequence id
   parent_.convertMessageBegin(metadata_);

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -15,6 +15,7 @@
 #include "extensions/filters/network/thrift_proxy/conn_manager.h"
 #include "extensions/filters/network/thrift_proxy/filters/filter.h"
 #include "extensions/filters/network/thrift_proxy/router/router.h"
+#include "extensions/filters/network/thrift_proxy/thrift_object.h"
 
 #include "absl/types/optional.h"
 
@@ -135,6 +136,7 @@ private:
     void onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn,
                      Upstream::HostDescriptionConstSharedPtr host) override;
 
+    void onRequestStart(bool continue_decoding);
     void onRequestComplete();
     void onResponseComplete();
     void onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host);
@@ -147,8 +149,9 @@ private:
     Tcp::ConnectionPool::Cancellable* conn_pool_handle_{};
     Tcp::ConnectionPool::ConnectionDataPtr conn_data_;
     Upstream::HostDescriptionConstSharedPtr upstream_host_;
-    TransportType transport_type_;
-    ProtocolType protocol_type_;
+    TransportPtr transport_;
+    ProtocolPtr protocol_;
+    ThriftObjectPtr upgrade_response_;
 
     bool request_complete_ : 1;
     bool response_started_ : 1;

--- a/source/extensions/filters/network/thrift_proxy/thrift_object.h
+++ b/source/extensions/filters/network/thrift_proxy/thrift_object.h
@@ -1,0 +1,247 @@
+#pragma once
+
+#include <list>
+#include <memory>
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/common/exception.h"
+
+#include "extensions/filters/network/thrift_proxy/thrift.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+
+class ThriftBase;
+
+/**
+ * ThriftValue is a field or container (list, set, or map) element.
+ */
+class ThriftValue {
+public:
+  virtual ~ThriftValue() {}
+
+  /**
+   * @return FieldType the type of this value
+   */
+  virtual FieldType type() const PURE;
+
+  /**
+   * @return const T& pointer to the value, provided that it can be cast to the given type
+   * @throw EnvoyException if the type T does not match the type
+   */
+  template <typename T> const T& getValueTyped() const {
+    // Use the Traits template to determine what FieldType the value must have to be cast to T
+    // and throw if the value's type doesn't match.
+    FieldType expected_field_type = Traits<T>::getFieldType();
+    if (expected_field_type != type()) {
+      throw EnvoyException(fmt::format("expected field type {}, got {}",
+                                       static_cast<int>(expected_field_type),
+                                       static_cast<int>(type())));
+    }
+
+    return *static_cast<const T*>(getValue());
+  }
+
+protected:
+  /**
+   * @return void* pointing to the underlying value, to be dynamically cast in getValueTyped
+   */
+  virtual const void* getValue() const PURE;
+
+private:
+  /**
+   * Traits allows getValueTyped() to enforce that the field type is being cast to the desired type.
+   */
+  template <typename T> class Traits {
+  public:
+    // Compilation failures where T does not have a member getFieldType typically mean that
+    // getValueTyped was called with a type T that is not used to encode Thrift values.
+    // The specializations below encode the valid types for Thrift primitive types.
+    static FieldType getFieldType() { return T::getFieldType(); }
+  };
+};
+
+// Explicit specializations of ThriftValue::Types for primitive types.
+template <> class ThriftValue::Traits<bool> {
+public:
+  static FieldType getFieldType() { return FieldType::Bool; }
+};
+
+template <> class ThriftValue::Traits<uint8_t> {
+public:
+  static FieldType getFieldType() { return FieldType::Byte; }
+};
+
+template <> class ThriftValue::Traits<int16_t> {
+public:
+  static FieldType getFieldType() { return FieldType::I16; }
+};
+
+template <> class ThriftValue::Traits<int32_t> {
+public:
+  static FieldType getFieldType() { return FieldType::I32; }
+};
+
+template <> class ThriftValue::Traits<int64_t> {
+public:
+  static FieldType getFieldType() { return FieldType::I64; }
+};
+
+template <> class ThriftValue::Traits<double> {
+public:
+  static FieldType getFieldType() { return FieldType::Double; }
+};
+
+template <> class ThriftValue::Traits<std::string> {
+public:
+  static FieldType getFieldType() { return FieldType::String; }
+};
+
+typedef std::unique_ptr<ThriftValue> ThriftValuePtr;
+typedef std::list<ThriftValuePtr> ThriftValuePtrList;
+typedef std::list<std::pair<ThriftValuePtr, ThriftValuePtr>> ThriftValuePtrPairList;
+
+/**
+ * ThriftField is a field within a ThriftStruct.
+ */
+class ThriftField {
+public:
+  virtual ~ThriftField() {}
+
+  /**
+   * @return FieldType this field's type
+   */
+  virtual FieldType fieldType() const PURE;
+
+  /**
+   * @return int16_t the field's identifier
+   */
+  virtual int16_t fieldId() const PURE;
+
+  /**
+   * @return const ThriftValue& containing the field's value
+   */
+  virtual const ThriftValue& getValue() const PURE;
+};
+
+typedef std::unique_ptr<ThriftField> ThriftFieldPtr;
+typedef std::list<ThriftFieldPtr> ThriftFieldPtrList;
+
+/**
+ * ThriftListValue is an ordered list of ThriftValues.
+ */
+class ThriftListValue {
+public:
+  virtual ~ThriftListValue() {}
+
+  /**
+   * @return const ThriftValuePtrList& containing the ThriftValues that comprise the list
+   */
+  virtual const ThriftValuePtrList& elements() const PURE;
+
+  /**
+   * @return FieldType of the underlying elements
+   */
+  virtual FieldType elementType() const PURE;
+
+  /**
+   * Used by ThriftValue::Traits to enforce type safety.
+   */
+  static FieldType getFieldType() { return FieldType::List; }
+};
+
+/**
+ * ThriftSetValue is a set of ThriftValues, maintained in their original order.
+ */
+class ThriftSetValue {
+public:
+  virtual ~ThriftSetValue() {}
+
+  /**
+   * @return const ThriftValuePtrList& containing the ThriftValues that comprise the set
+   */
+  virtual const ThriftValuePtrList& elements() const PURE;
+
+  /**
+   * @return FieldType of the underlying elements
+   */
+  virtual FieldType elementType() const PURE;
+
+  /**
+   * Used by ThriftValue::Traits to enforce type safety.
+   */
+  static FieldType getFieldType() { return FieldType::Set; }
+};
+
+/**
+ * ThriftMapValue is a map of pairs of ThriftValues, maintained in their original order.
+ */
+class ThriftMapValue {
+public:
+  virtual ~ThriftMapValue() {}
+
+  /**
+   * @return const ThriftValuePtrPairList& containing the ThriftValue key-value paris that comprise
+   *         the map.
+   */
+  virtual const ThriftValuePtrPairList& elements() const PURE;
+
+  /**
+   * @return FieldType of the underlying keys
+   */
+  virtual FieldType keyType() const PURE;
+
+  /**
+   * @return FieldType of the underlying values
+   */
+  virtual FieldType valueType() const PURE;
+
+  /**
+   * Used by ThriftValue::Traits to enforce type safety.
+   */
+  static FieldType getFieldType() { return FieldType::Map; }
+};
+
+/**
+ * ThriftStructValue is a sequence of ThriftFields.
+ */
+class ThriftStructValue {
+public:
+  virtual ~ThriftStructValue() {}
+
+  /**
+   * @return const ThriftFieldPtrList& containing the ThriftFields that comprise the struct.
+   */
+  virtual const ThriftFieldPtrList& fields() const PURE;
+
+  /**
+   * Used by ThriftValue::Traits to enforce type safety.
+   */
+  static FieldType getFieldType() { return FieldType::Struct; }
+};
+
+/**
+ * ThriftObject is a ThrfitStructValue that can be read from a Buffer::Instance.
+ */
+class ThriftObject : public ThriftStructValue {
+public:
+  virtual ~ThriftObject() {}
+
+  /*
+   * Consumes bytes from the buffer until a single complete Thrift struct has been consumed.
+   * @param buffer starting with a Thrift struct
+   * @return true when a single complete struct has been consumed; false if more data is needed to
+   *         complete decoding
+   * @throw EnvoyException if the struct is invalid
+   */
+  virtual bool onData(Buffer::Instance& buffer) PURE;
+};
+
+typedef std::unique_ptr<ThriftObject> ThriftObjectPtr;
+
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/thrift_proxy/thrift_object_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/thrift_object_impl.cc
@@ -1,0 +1,394 @@
+#include "extensions/filters/network/thrift_proxy/thrift_object_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+namespace {
+
+std::unique_ptr<ThriftValueBase> makeValue(ThriftBase* parent, FieldType type) {
+  switch (type) {
+  case FieldType::Stop:
+    NOT_REACHED_GCOVR_EXCL_LINE;
+
+  case FieldType::List:
+    return std::make_unique<ThriftListValueImpl>(parent);
+
+  case FieldType::Set:
+    return std::make_unique<ThriftSetValueImpl>(parent);
+
+  case FieldType::Map:
+    return std::make_unique<ThriftMapValueImpl>(parent);
+
+  case FieldType::Struct:
+    return std::make_unique<ThriftStructValueImpl>(parent);
+
+  default:
+    return std::make_unique<ThriftValueImpl>(parent, type);
+  }
+}
+
+} // namespace
+
+ThriftBase::ThriftBase(ThriftBase* parent) : parent_(parent) {}
+
+FilterStatus ThriftBase::structBegin(absl::string_view name) {
+  ASSERT(delegate_ != nullptr);
+  return delegate_->structBegin(name);
+}
+
+FilterStatus ThriftBase::structEnd() {
+  ASSERT(delegate_ != nullptr);
+  return delegate_->structEnd();
+}
+
+FilterStatus ThriftBase::fieldBegin(absl::string_view name, FieldType field_type,
+                                    int16_t field_id) {
+  ASSERT(delegate_ != nullptr);
+  return delegate_->fieldBegin(name, field_type, field_id);
+}
+
+FilterStatus ThriftBase::fieldEnd() {
+  ASSERT(delegate_ != nullptr);
+  return delegate_->fieldEnd();
+}
+
+FilterStatus ThriftBase::boolValue(bool value) {
+  ASSERT(delegate_ != nullptr);
+  return delegate_->boolValue(value);
+}
+
+FilterStatus ThriftBase::byteValue(uint8_t value) {
+  ASSERT(delegate_ != nullptr);
+  return delegate_->byteValue(value);
+}
+
+FilterStatus ThriftBase::int16Value(int16_t value) {
+  ASSERT(delegate_ != nullptr);
+  return delegate_->int16Value(value);
+}
+
+FilterStatus ThriftBase::int32Value(int32_t value) {
+  ASSERT(delegate_ != nullptr);
+  return delegate_->int32Value(value);
+}
+
+FilterStatus ThriftBase::int64Value(int64_t value) {
+  ASSERT(delegate_ != nullptr);
+  return delegate_->int64Value(value);
+}
+
+FilterStatus ThriftBase::doubleValue(double value) {
+  ASSERT(delegate_ != nullptr);
+  return delegate_->doubleValue(value);
+}
+
+FilterStatus ThriftBase::stringValue(absl::string_view value) {
+  ASSERT(delegate_ != nullptr);
+  return delegate_->stringValue(value);
+}
+
+FilterStatus ThriftBase::mapBegin(FieldType key_type, FieldType value_type, uint32_t size) {
+  ASSERT(delegate_ != nullptr);
+  return delegate_->mapBegin(key_type, value_type, size);
+}
+
+FilterStatus ThriftBase::mapEnd() {
+  ASSERT(delegate_ != nullptr);
+  return delegate_->mapEnd();
+}
+
+FilterStatus ThriftBase::listBegin(FieldType elem_type, uint32_t size) {
+  ASSERT(delegate_ != nullptr);
+  return delegate_->listBegin(elem_type, size);
+}
+
+FilterStatus ThriftBase::listEnd() {
+  ASSERT(delegate_ != nullptr);
+  return delegate_->listEnd();
+}
+
+FilterStatus ThriftBase::setBegin(FieldType elem_type, uint32_t size) {
+  ASSERT(delegate_ != nullptr);
+  return delegate_->setBegin(elem_type, size);
+}
+
+FilterStatus ThriftBase::setEnd() {
+  ASSERT(delegate_ != nullptr);
+  return delegate_->setEnd();
+}
+
+void ThriftBase::delegateComplete() {
+  ASSERT(delegate_ != nullptr);
+  delegate_ = nullptr;
+}
+
+ThriftFieldImpl::ThriftFieldImpl(ThriftStructValueImpl* parent, absl::string_view name,
+                                 FieldType field_type, int16_t field_id)
+    : ThriftBase(parent), name_(name), field_type_(field_type), field_id_(field_id) {
+  auto value = makeValue(this, field_type_);
+  delegate_ = value.get();
+  value_ = std::move(value);
+}
+
+FilterStatus ThriftFieldImpl::fieldEnd() {
+  if (delegate_) {
+    return delegate_->fieldEnd();
+  }
+
+  parent_->delegateComplete();
+  return FilterStatus::Continue;
+}
+
+FilterStatus ThriftListValueImpl::listBegin(FieldType elem_type, uint32_t size) {
+  if (delegate_) {
+    return delegate_->listBegin(elem_type, size);
+  }
+
+  elem_type_ = elem_type;
+  remaining_ = size;
+
+  delegateComplete();
+
+  return FilterStatus::Continue;
+}
+
+FilterStatus ThriftListValueImpl::listEnd() {
+  if (delegate_) {
+    return delegate_->listEnd();
+  }
+
+  ASSERT(remaining_ == 0);
+  parent_->delegateComplete();
+  return FilterStatus::Continue;
+}
+
+void ThriftListValueImpl::delegateComplete() {
+  delegate_ = nullptr;
+
+  if (remaining_ == 0) {
+    return;
+  }
+
+  auto elem = makeValue(this, elem_type_);
+  delegate_ = elem.get();
+  elements_.push_back(std::move(elem));
+  remaining_--;
+}
+
+FilterStatus ThriftSetValueImpl::setBegin(FieldType elem_type, uint32_t size) {
+  if (delegate_) {
+    return delegate_->setBegin(elem_type, size);
+  }
+
+  elem_type_ = elem_type;
+  remaining_ = size;
+
+  delegateComplete();
+
+  return FilterStatus::Continue;
+}
+
+FilterStatus ThriftSetValueImpl::setEnd() {
+  if (delegate_) {
+    return delegate_->setEnd();
+  }
+
+  ASSERT(remaining_ == 0);
+  parent_->delegateComplete();
+  return FilterStatus::Continue;
+}
+
+void ThriftSetValueImpl::delegateComplete() {
+  delegate_ = nullptr;
+
+  if (remaining_ == 0) {
+    return;
+  }
+
+  auto elem = makeValue(this, elem_type_);
+  delegate_ = elem.get();
+  elements_.push_back(std::move(elem));
+  remaining_--;
+}
+
+FilterStatus ThriftMapValueImpl::mapBegin(FieldType key_type, FieldType elem_type, uint32_t size) {
+  if (delegate_) {
+    return delegate_->mapBegin(key_type, elem_type, size);
+  }
+
+  key_type_ = key_type;
+  elem_type_ = elem_type;
+  remaining_ = size;
+
+  delegateComplete();
+
+  return FilterStatus::Continue;
+}
+
+FilterStatus ThriftMapValueImpl::mapEnd() {
+  if (delegate_) {
+    return delegate_->mapEnd();
+  }
+
+  ASSERT(remaining_ == 0);
+  parent_->delegateComplete();
+  return FilterStatus::Continue;
+}
+
+void ThriftMapValueImpl::delegateComplete() {
+  delegate_ = nullptr;
+
+  if (remaining_ == 0) {
+    return;
+  }
+
+  // Prepare for first element's key.
+  if (elements_.empty()) {
+    auto key = makeValue(this, key_type_);
+    delegate_ = key.get();
+    elements_.emplace_back(std::move(key), nullptr);
+    return;
+  }
+
+  // Prepare for any elements's value.
+  auto& elem = elements_.back();
+  if (elem.second == nullptr) {
+    auto value = makeValue(this, elem_type_);
+    delegate_ = value.get();
+    elem.second = std::move(value);
+
+    remaining_--;
+    return;
+  }
+
+  // Key-value pair completed, prepare for next key.
+  auto key = makeValue(this, key_type_);
+  delegate_ = key.get();
+  elements_.emplace_back(std::move(key), nullptr);
+}
+
+FilterStatus ThriftValueImpl::boolValue(bool value) {
+  ASSERT(value_type_ == FieldType::Bool);
+  bool_value_ = value;
+  parent_->delegateComplete();
+  return FilterStatus::Continue;
+}
+
+FilterStatus ThriftValueImpl::byteValue(uint8_t value) {
+  ASSERT(value_type_ == FieldType::Byte);
+  byte_value_ = value;
+  parent_->delegateComplete();
+  return FilterStatus::Continue;
+}
+
+FilterStatus ThriftValueImpl::int16Value(int16_t value) {
+  ASSERT(value_type_ == FieldType::I16);
+  int16_value_ = value;
+  parent_->delegateComplete();
+  return FilterStatus::Continue;
+}
+
+FilterStatus ThriftValueImpl::int32Value(int32_t value) {
+  ASSERT(value_type_ == FieldType::I32);
+  int32_value_ = value;
+  parent_->delegateComplete();
+  return FilterStatus::Continue;
+}
+
+FilterStatus ThriftValueImpl::int64Value(int64_t value) {
+  ASSERT(value_type_ == FieldType::I64);
+  int64_value_ = value;
+  parent_->delegateComplete();
+  return FilterStatus::Continue;
+}
+
+FilterStatus ThriftValueImpl::doubleValue(double value) {
+  ASSERT(value_type_ == FieldType::Double);
+  double_value_ = value;
+  parent_->delegateComplete();
+  return FilterStatus::Continue;
+}
+
+FilterStatus ThriftValueImpl::stringValue(absl::string_view value) {
+  ASSERT(value_type_ == FieldType::String);
+  string_value_ = std::string(value);
+  parent_->delegateComplete();
+  return FilterStatus::Continue;
+}
+
+const void* ThriftValueImpl::getValue() const {
+  switch (value_type_) {
+  case FieldType::Bool:
+    return &bool_value_;
+  case FieldType::Byte:
+    return &byte_value_;
+  case FieldType::I16:
+    return &int16_value_;
+  case FieldType::I32:
+    return &int32_value_;
+  case FieldType::I64:
+    return &int64_value_;
+  case FieldType::Double:
+    return &double_value_;
+  case FieldType::String:
+    return &string_value_;
+  default:
+    NOT_REACHED_GCOVR_EXCL_LINE;
+  }
+}
+
+FilterStatus ThriftStructValueImpl::structBegin(absl::string_view name) {
+  if (delegate_) {
+    return delegate_->structBegin(name);
+  }
+
+  return FilterStatus::Continue;
+}
+
+FilterStatus ThriftStructValueImpl::structEnd() {
+  if (delegate_) {
+    return delegate_->structEnd();
+  }
+
+  if (parent_) {
+    parent_->delegateComplete();
+  }
+
+  return FilterStatus::Continue;
+}
+
+FilterStatus ThriftStructValueImpl::fieldBegin(absl::string_view name, FieldType field_type,
+                                               int16_t field_id) {
+  if (delegate_) {
+    return delegate_->fieldBegin(name, field_type, field_id);
+  }
+
+  if (field_type != FieldType::Stop) {
+    auto field = std::make_unique<ThriftFieldImpl>(this, name, field_type, field_id);
+    delegate_ = field.get();
+    fields_.emplace_back(std::move(field));
+  }
+
+  return FilterStatus::Continue;
+}
+
+ThriftObjectImpl::ThriftObjectImpl(Transport& transport, Protocol& protocol)
+    : ThriftStructValueImpl(nullptr),
+      decoder_(std::make_unique<Decoder>(transport, protocol, *this)) {}
+
+bool ThriftObjectImpl::onData(Buffer::Instance& buffer) {
+  bool underflow = false;
+  auto result = decoder_->onData(buffer, underflow);
+  ASSERT(result == FilterStatus::Continue);
+
+  if (complete_) {
+    decoder_.reset();
+  }
+  return complete_;
+}
+
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/thrift_proxy/thrift_object_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/thrift_object_impl.h
@@ -1,0 +1,262 @@
+#pragma once
+
+#include "extensions/filters/network/thrift_proxy/decoder.h"
+#include "extensions/filters/network/thrift_proxy/filters/filter.h"
+#include "extensions/filters/network/thrift_proxy/thrift_object.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+
+/**
+ * ThriftBase is a base class for decoding Thrift objects. It implements methods from
+ * DecoderEventHandler to automatically delegate to an underlying ThriftBase so that, for example,
+ * the fieldBegin call for a struct field nested within a list is automatically delegated down the
+ * object hierarchy to the correct ThriftBase subclass.
+ */
+class ThriftBase : public DecoderEventHandler {
+public:
+  ThriftBase(ThriftBase* parent);
+  ~ThriftBase() {}
+
+  // DecoderEventHandler
+  FilterStatus transportBegin(MessageMetadataSharedPtr) override { return FilterStatus::Continue; }
+  FilterStatus transportEnd() override { return FilterStatus::Continue; }
+  FilterStatus messageBegin(MessageMetadataSharedPtr) override { return FilterStatus::Continue; }
+  FilterStatus messageEnd() override { return FilterStatus::Continue; }
+  FilterStatus structBegin(absl::string_view name) override;
+  FilterStatus structEnd() override;
+  FilterStatus fieldBegin(absl::string_view name, FieldType field_type, int16_t field_id) override;
+  FilterStatus fieldEnd() override;
+  FilterStatus boolValue(bool value) override;
+  FilterStatus byteValue(uint8_t value) override;
+  FilterStatus int16Value(int16_t value) override;
+  FilterStatus int32Value(int32_t value) override;
+  FilterStatus int64Value(int64_t value) override;
+  FilterStatus doubleValue(double value) override;
+  FilterStatus stringValue(absl::string_view value) override;
+  FilterStatus mapBegin(FieldType key_type, FieldType value_type, uint32_t size) override;
+  FilterStatus mapEnd() override;
+  FilterStatus listBegin(FieldType elem_type, uint32_t size) override;
+  FilterStatus listEnd() override;
+  FilterStatus setBegin(FieldType elem_type, uint32_t size) override;
+  FilterStatus setEnd() override;
+
+  // Invoked when the current delegate is complete. Completion implies that the delegate is fully
+  // specified (all list values processed, all struct fields processed, etc).
+  virtual void delegateComplete();
+
+protected:
+  ThriftBase* parent_;
+  ThriftBase* delegate_{nullptr};
+};
+
+/**
+ * ThriftValueBase is a base class for all struct field values, list values, set values, map keys,
+ * and map values.
+ */
+class ThriftValueBase : public ThriftValue, public ThriftBase {
+public:
+  ThriftValueBase(ThriftBase* parent, FieldType value_type)
+      : ThriftBase(parent), value_type_(value_type) {}
+  ~ThriftValueBase() {}
+
+  // ThriftValue
+  FieldType type() const override { return value_type_; }
+
+protected:
+  const FieldType value_type_;
+};
+
+class ThriftStructValueImpl;
+
+/**
+ * ThriftField represents a field in a thrift Struct. It always delegates DecoderEventHandler
+ * methods to a subclass of ThriftValueBase.
+ */
+class ThriftFieldImpl : public ThriftField, public ThriftBase {
+public:
+  ThriftFieldImpl(ThriftStructValueImpl* parent, absl::string_view name, FieldType field_type,
+                  int16_t field_id);
+
+  // DecoderEventHandler
+  FilterStatus fieldEnd() override;
+
+  // ThriftField
+  FieldType fieldType() const override { return field_type_; }
+  int16_t fieldId() const override { return field_id_; }
+  const ThriftValue& getValue() const override { return *value_; }
+
+private:
+  std::string name_;
+  FieldType field_type_;
+  int16_t field_id_;
+  ThriftValuePtr value_;
+};
+
+/**
+ * ThriftStructValueImpl implements ThriftStruct.
+ */
+class ThriftStructValueImpl : public ThriftStructValue, public ThriftValueBase {
+public:
+  ThriftStructValueImpl(ThriftBase* parent) : ThriftValueBase(parent, FieldType::Struct) {}
+
+  // DecoderEventHandler
+  FilterStatus structBegin(absl::string_view name) override;
+  FilterStatus structEnd() override;
+  FilterStatus fieldBegin(absl::string_view name, FieldType field_type, int16_t field_id) override;
+
+  // ThriftStructValue
+  const ThriftFieldPtrList& fields() const override { return fields_; }
+
+private:
+  // ThriftValue
+  const void* getValue() const override { return this; };
+
+  ThriftFieldPtrList fields_;
+};
+
+/**
+ * ThriftListValueImpl represents Thrift lists.
+ */
+class ThriftListValueImpl : public ThriftListValue, public ThriftValueBase {
+public:
+  ThriftListValueImpl(ThriftBase* parent) : ThriftValueBase(parent, FieldType::List) {}
+
+  // DecoderEventHandler
+  FilterStatus listBegin(FieldType elem_type, uint32_t size) override;
+  FilterStatus listEnd() override;
+
+  // ThriftListValue
+  const ThriftValuePtrList& elements() const override { return elements_; }
+  FieldType elementType() const override { return elem_type_; }
+
+  void delegateComplete() override;
+
+protected:
+  // ThriftValue
+  const void* getValue() const override { return this; };
+
+  FieldType elem_type_{FieldType::Stop};
+  uint32_t remaining_{0};
+  ThriftValuePtrList elements_;
+};
+
+/**
+ * ThriftSetValueImpl represents Thrift sets.
+ */
+class ThriftSetValueImpl : public ThriftSetValue, public ThriftValueBase {
+public:
+  ThriftSetValueImpl(ThriftBase* parent) : ThriftValueBase(parent, FieldType::Set) {}
+
+  // DecoderEventHandler
+  FilterStatus setBegin(FieldType elem_type, uint32_t size) override;
+  FilterStatus setEnd() override;
+
+  // ThriftSetValue
+  const ThriftValuePtrList& elements() const override { return elements_; }
+  FieldType elementType() const override { return elem_type_; }
+
+  void delegateComplete() override;
+
+protected:
+  // ThriftValue
+  const void* getValue() const override { return this; };
+
+  FieldType elem_type_{FieldType::Stop};
+  uint32_t remaining_{0};
+  ThriftValuePtrList elements_; // maintain original order
+};
+
+/**
+ * ThriftMapValueImpl represents Thrift maps.
+ */
+class ThriftMapValueImpl : public ThriftMapValue, public ThriftValueBase {
+public:
+  ThriftMapValueImpl(ThriftBase* parent) : ThriftValueBase(parent, FieldType::Map) {}
+
+  // DecoderEventHandler
+  FilterStatus mapBegin(FieldType key_type, FieldType elem_type, uint32_t size) override;
+  FilterStatus mapEnd() override;
+
+  // ThriftMapValue
+  const ThriftValuePtrPairList& elements() const override { return elements_; }
+  FieldType keyType() const override { return key_type_; }
+  FieldType valueType() const override { return elem_type_; }
+
+  void delegateComplete() override;
+
+protected:
+  // ThriftValue
+  const void* getValue() const override { return this; };
+
+  FieldType key_type_{FieldType::Stop};
+  FieldType elem_type_{FieldType::Stop};
+  uint32_t remaining_{0};
+  ThriftValuePtrPairList elements_; // maintain original order
+};
+
+/**
+ * ThriftValueImpl represents primitive Thrift types, including strings.
+ */
+class ThriftValueImpl : public ThriftValueBase {
+public:
+  ThriftValueImpl(ThriftBase* parent, FieldType value_type) : ThriftValueBase(parent, value_type) {}
+
+  // DecoderEventHandler
+  FilterStatus boolValue(bool value) override;
+  FilterStatus byteValue(uint8_t value) override;
+  FilterStatus int16Value(int16_t value) override;
+  FilterStatus int32Value(int32_t value) override;
+  FilterStatus int64Value(int64_t value) override;
+  FilterStatus doubleValue(double value) override;
+  FilterStatus stringValue(absl::string_view value) override;
+
+protected:
+  // ThriftValue
+  const void* getValue() const override;
+
+private:
+  union {
+    bool bool_value_;
+    uint8_t byte_value_;
+    int16_t int16_value_;
+    int32_t int32_value_;
+    int64_t int64_value_;
+    double double_value_;
+  };
+  std::string string_value_;
+};
+
+/**
+ * ThriftObjectImpl is a generic representation of a Thrift struct.
+ */
+class ThriftObjectImpl : public ThriftObject,
+                         public ThriftStructValueImpl,
+                         public DecoderCallbacks {
+public:
+  ThriftObjectImpl(Transport& transport, Protocol& protocol);
+
+  // DecoderCallbacks
+  DecoderEventHandler& newDecoderEventHandler() override { return *this; }
+  FilterStatus transportEnd() override {
+    complete_ = true;
+    return FilterStatus::Continue;
+  }
+
+  // ThriftObject
+  bool onData(Buffer::Instance& buffer) override;
+
+  // ThriftStruct
+  const ThriftFieldPtrList& fields() const override { return ThriftStructValueImpl::fields(); }
+
+private:
+  DecoderPtr decoder_;
+  bool complete_{false};
+};
+
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/network/thrift_proxy/BUILD
+++ b/test/extensions/filters/network/thrift_proxy/BUILD
@@ -246,6 +246,19 @@ envoy_extension_cc_test(
 )
 
 envoy_extension_cc_test(
+    name = "thrift_object_impl_test",
+    srcs = ["thrift_object_impl_test.cc"],
+    extension_name = "envoy.filters.network.thrift_proxy",
+    deps = [
+        ":mocks",
+        ":utility_lib",
+        "//source/extensions/filters/network/thrift_proxy:thrift_object_lib",
+        "//test/test_common:printers_lib",
+        "//test/test_common:registry_lib",
+    ],
+)
+
+envoy_extension_cc_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     data = [

--- a/test/extensions/filters/network/thrift_proxy/decoder_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/decoder_test.cc
@@ -710,17 +710,17 @@ TEST_P(DecoderStateMachineNestingTest, NestedTypes) {
 }
 
 TEST(DecoderTest, OnData) {
-  NiceMock<MockTransport>* transport = new NiceMock<MockTransport>();
-  NiceMock<MockProtocol>* proto = new NiceMock<MockProtocol>();
+  NiceMock<MockTransport> transport;
+  NiceMock<MockProtocol> proto;
   NiceMock<MockDecoderCallbacks> callbacks;
   StrictMock<MockDecoderEventHandler> handler;
   ON_CALL(callbacks, newDecoderEventHandler()).WillByDefault(ReturnRef(handler));
 
   InSequence dummy;
-  Decoder decoder(TransportPtr{transport}, ProtocolPtr{proto}, callbacks);
+  Decoder decoder(transport, proto, callbacks);
   Buffer::OwnedImpl buffer;
 
-  EXPECT_CALL(*transport, decodeFrameStart(Ref(buffer), _))
+  EXPECT_CALL(transport, decodeFrameStart(Ref(buffer), _))
       .WillOnce(Invoke([&](Buffer::Instance&, MessageMetadata& metadata) -> bool {
         metadata.setFrameSize(100);
         return true;
@@ -732,7 +732,7 @@ TEST(DecoderTest, OnData) {
         return FilterStatus::Continue;
       }));
 
-  EXPECT_CALL(*proto, readMessageBegin(Ref(buffer), _))
+  EXPECT_CALL(proto, readMessageBegin(Ref(buffer), _))
       .WillOnce(Invoke([&](Buffer::Instance&, MessageMetadata& metadata) -> bool {
         metadata.setMethodName("name");
         metadata.setMessageType(MessageType::Call);
@@ -750,18 +750,18 @@ TEST(DecoderTest, OnData) {
         return FilterStatus::Continue;
       }));
 
-  EXPECT_CALL(*proto, readStructBegin(Ref(buffer), _)).WillOnce(Return(true));
+  EXPECT_CALL(proto, readStructBegin(Ref(buffer), _)).WillOnce(Return(true));
   EXPECT_CALL(handler, structBegin(absl::string_view())).WillOnce(Return(FilterStatus::Continue));
 
-  EXPECT_CALL(*proto, readFieldBegin(Ref(buffer), _, _, _))
+  EXPECT_CALL(proto, readFieldBegin(Ref(buffer), _, _, _))
       .WillOnce(DoAll(SetArgReferee<2>(FieldType::Stop), Return(true)));
-  EXPECT_CALL(*proto, readStructEnd(Ref(buffer))).WillOnce(Return(true));
+  EXPECT_CALL(proto, readStructEnd(Ref(buffer))).WillOnce(Return(true));
   EXPECT_CALL(handler, structEnd()).WillOnce(Return(FilterStatus::Continue));
 
-  EXPECT_CALL(*proto, readMessageEnd(Ref(buffer))).WillOnce(Return(true));
+  EXPECT_CALL(proto, readMessageEnd(Ref(buffer))).WillOnce(Return(true));
   EXPECT_CALL(handler, messageEnd()).WillOnce(Return(FilterStatus::Continue));
 
-  EXPECT_CALL(*transport, decodeFrameEnd(Ref(buffer))).WillOnce(Return(true));
+  EXPECT_CALL(transport, decodeFrameEnd(Ref(buffer))).WillOnce(Return(true));
   EXPECT_CALL(handler, transportEnd()).WillOnce(Return(FilterStatus::Continue));
 
   bool underflow = false;
@@ -770,24 +770,24 @@ TEST(DecoderTest, OnData) {
 }
 
 TEST(DecoderTest, OnDataWithProtocolHint) {
-  NiceMock<MockTransport>* transport = new NiceMock<MockTransport>();
-  NiceMock<MockProtocol>* proto = new NiceMock<MockProtocol>();
+  NiceMock<MockTransport> transport;
+  NiceMock<MockProtocol> proto;
   NiceMock<MockDecoderCallbacks> callbacks;
   StrictMock<MockDecoderEventHandler> handler;
   ON_CALL(callbacks, newDecoderEventHandler()).WillByDefault(ReturnRef(handler));
 
   InSequence dummy;
-  Decoder decoder(TransportPtr{transport}, ProtocolPtr{proto}, callbacks);
+  Decoder decoder(transport, proto, callbacks);
   Buffer::OwnedImpl buffer;
 
-  EXPECT_CALL(*transport, decodeFrameStart(Ref(buffer), _))
+  EXPECT_CALL(transport, decodeFrameStart(Ref(buffer), _))
       .WillOnce(Invoke([&](Buffer::Instance&, MessageMetadata& metadata) -> bool {
         metadata.setFrameSize(100);
         metadata.setProtocol(ProtocolType::Binary);
         return true;
       }));
-  EXPECT_CALL(*proto, type()).WillOnce(Return(ProtocolType::Auto));
-  EXPECT_CALL(*proto, setType(ProtocolType::Binary));
+  EXPECT_CALL(proto, type()).WillOnce(Return(ProtocolType::Auto));
+  EXPECT_CALL(proto, setType(ProtocolType::Binary));
   EXPECT_CALL(handler, transportBegin(_))
       .WillOnce(Invoke([&](MessageMetadataSharedPtr metadata) -> FilterStatus {
         EXPECT_TRUE(metadata->hasFrameSize());
@@ -799,7 +799,7 @@ TEST(DecoderTest, OnDataWithProtocolHint) {
         return FilterStatus::Continue;
       }));
 
-  EXPECT_CALL(*proto, readMessageBegin(Ref(buffer), _))
+  EXPECT_CALL(proto, readMessageBegin(Ref(buffer), _))
       .WillOnce(Invoke([&](Buffer::Instance&, MessageMetadata& metadata) -> bool {
         metadata.setMethodName("name");
         metadata.setMessageType(MessageType::Call);
@@ -817,18 +817,18 @@ TEST(DecoderTest, OnDataWithProtocolHint) {
         return FilterStatus::Continue;
       }));
 
-  EXPECT_CALL(*proto, readStructBegin(Ref(buffer), _)).WillOnce(Return(true));
+  EXPECT_CALL(proto, readStructBegin(Ref(buffer), _)).WillOnce(Return(true));
   EXPECT_CALL(handler, structBegin(absl::string_view())).WillOnce(Return(FilterStatus::Continue));
 
-  EXPECT_CALL(*proto, readFieldBegin(Ref(buffer), _, _, _))
+  EXPECT_CALL(proto, readFieldBegin(Ref(buffer), _, _, _))
       .WillOnce(DoAll(SetArgReferee<2>(FieldType::Stop), Return(true)));
-  EXPECT_CALL(*proto, readStructEnd(Ref(buffer))).WillOnce(Return(true));
+  EXPECT_CALL(proto, readStructEnd(Ref(buffer))).WillOnce(Return(true));
   EXPECT_CALL(handler, structEnd()).WillOnce(Return(FilterStatus::Continue));
 
-  EXPECT_CALL(*proto, readMessageEnd(Ref(buffer))).WillOnce(Return(true));
+  EXPECT_CALL(proto, readMessageEnd(Ref(buffer))).WillOnce(Return(true));
   EXPECT_CALL(handler, messageEnd()).WillOnce(Return(FilterStatus::Continue));
 
-  EXPECT_CALL(*transport, decodeFrameEnd(Ref(buffer))).WillOnce(Return(true));
+  EXPECT_CALL(transport, decodeFrameEnd(Ref(buffer))).WillOnce(Return(true));
   EXPECT_CALL(handler, transportEnd()).WillOnce(Return(FilterStatus::Continue));
 
   bool underflow = false;
@@ -837,23 +837,23 @@ TEST(DecoderTest, OnDataWithProtocolHint) {
 }
 
 TEST(DecoderTest, OnDataWithInconsistentProtocolHint) {
-  NiceMock<MockTransport>* transport = new NiceMock<MockTransport>();
-  NiceMock<MockProtocol>* proto = new NiceMock<MockProtocol>();
+  NiceMock<MockTransport> transport;
+  NiceMock<MockProtocol> proto;
   NiceMock<MockDecoderCallbacks> callbacks;
   StrictMock<MockDecoderEventHandler> handler;
   ON_CALL(callbacks, newDecoderEventHandler()).WillByDefault(ReturnRef(handler));
 
   InSequence dummy;
-  Decoder decoder(TransportPtr{transport}, ProtocolPtr{proto}, callbacks);
+  Decoder decoder(transport, proto, callbacks);
   Buffer::OwnedImpl buffer;
 
-  EXPECT_CALL(*transport, decodeFrameStart(Ref(buffer), _))
+  EXPECT_CALL(transport, decodeFrameStart(Ref(buffer), _))
       .WillOnce(Invoke([&](Buffer::Instance&, MessageMetadata& metadata) -> bool {
         metadata.setFrameSize(100);
         metadata.setProtocol(ProtocolType::Binary);
         return true;
       }));
-  EXPECT_CALL(*proto, type()).WillRepeatedly(Return(ProtocolType::Compact));
+  EXPECT_CALL(proto, type()).WillRepeatedly(Return(ProtocolType::Compact));
 
   bool underflow = false;
   EXPECT_THROW_WITH_MESSAGE(decoder.onData(buffer, underflow), EnvoyException,
@@ -861,17 +861,17 @@ TEST(DecoderTest, OnDataWithInconsistentProtocolHint) {
 }
 
 TEST(DecoderTest, OnDataThrowsTransportAppException) {
-  NiceMock<MockTransport>* transport = new NiceMock<MockTransport>();
-  NiceMock<MockProtocol>* proto = new NiceMock<MockProtocol>();
+  NiceMock<MockTransport> transport;
+  NiceMock<MockProtocol> proto;
   NiceMock<MockDecoderCallbacks> callbacks;
   StrictMock<MockDecoderEventHandler> handler;
   ON_CALL(callbacks, newDecoderEventHandler()).WillByDefault(ReturnRef(handler));
 
   InSequence dummy;
-  Decoder decoder(TransportPtr{transport}, ProtocolPtr{proto}, callbacks);
+  Decoder decoder(transport, proto, callbacks);
   Buffer::OwnedImpl buffer;
 
-  EXPECT_CALL(*transport, decodeFrameStart(Ref(buffer), _))
+  EXPECT_CALL(transport, decodeFrameStart(Ref(buffer), _))
       .WillOnce(Invoke([&](Buffer::Instance&, MessageMetadata& metadata) -> bool {
         metadata.setAppException(AppExceptionType::InvalidTransform, "unknown xform");
         return true;
@@ -882,85 +882,85 @@ TEST(DecoderTest, OnDataThrowsTransportAppException) {
 }
 
 TEST(DecoderTest, OnDataResumes) {
-  NiceMock<MockTransport>* transport = new NiceMock<MockTransport>();
-  NiceMock<MockProtocol>* proto = new NiceMock<MockProtocol>();
+  NiceMock<MockTransport> transport;
+  NiceMock<MockProtocol> proto;
   NiceMock<MockDecoderCallbacks> callbacks;
   NiceMock<MockDecoderEventHandler> handler;
   ON_CALL(callbacks, newDecoderEventHandler()).WillByDefault(ReturnRef(handler));
 
   InSequence dummy;
 
-  Decoder decoder(TransportPtr{transport}, ProtocolPtr{proto}, callbacks);
+  Decoder decoder(transport, proto, callbacks);
   Buffer::OwnedImpl buffer;
   buffer.add("x");
 
-  EXPECT_CALL(*transport, decodeFrameStart(Ref(buffer), _))
+  EXPECT_CALL(transport, decodeFrameStart(Ref(buffer), _))
       .WillOnce(Invoke([&](Buffer::Instance&, MessageMetadata& metadata) -> bool {
         metadata.setFrameSize(100);
         return true;
       }));
-  EXPECT_CALL(*proto, readMessageBegin(_, _))
+  EXPECT_CALL(proto, readMessageBegin(_, _))
       .WillOnce(Invoke([&](Buffer::Instance&, MessageMetadata& metadata) -> bool {
         metadata.setMethodName("name");
         metadata.setMessageType(MessageType::Call);
         metadata.setSequenceId(100);
         return true;
       }));
-  EXPECT_CALL(*proto, readStructBegin(_, _)).WillOnce(Return(false));
+  EXPECT_CALL(proto, readStructBegin(_, _)).WillOnce(Return(false));
 
   bool underflow = false;
   EXPECT_EQ(FilterStatus::Continue, decoder.onData(buffer, underflow));
   EXPECT_TRUE(underflow);
 
-  EXPECT_CALL(*proto, readStructBegin(_, _)).WillOnce(Return(true));
-  EXPECT_CALL(*proto, readFieldBegin(_, _, _, _))
+  EXPECT_CALL(proto, readStructBegin(_, _)).WillOnce(Return(true));
+  EXPECT_CALL(proto, readFieldBegin(_, _, _, _))
       .WillOnce(DoAll(SetArgReferee<2>(FieldType::Stop), Return(true)));
-  EXPECT_CALL(*proto, readStructEnd(_)).WillOnce(Return(true));
-  EXPECT_CALL(*proto, readMessageEnd(_)).WillOnce(Return(true));
-  EXPECT_CALL(*transport, decodeFrameEnd(_)).WillOnce(Return(true));
+  EXPECT_CALL(proto, readStructEnd(_)).WillOnce(Return(true));
+  EXPECT_CALL(proto, readMessageEnd(_)).WillOnce(Return(true));
+  EXPECT_CALL(transport, decodeFrameEnd(_)).WillOnce(Return(true));
 
   EXPECT_EQ(FilterStatus::Continue, decoder.onData(buffer, underflow));
   EXPECT_FALSE(underflow); // buffer.length() == 1
 }
 
 TEST(DecoderTest, OnDataResumesTransportFrameStart) {
-  StrictMock<MockTransport>* transport = new StrictMock<MockTransport>();
-  StrictMock<MockProtocol>* proto = new StrictMock<MockProtocol>();
+  StrictMock<MockTransport> transport;
+  StrictMock<MockProtocol> proto;
   NiceMock<MockDecoderCallbacks> callbacks;
   NiceMock<MockDecoderEventHandler> handler;
   ON_CALL(callbacks, newDecoderEventHandler()).WillByDefault(ReturnRef(handler));
 
-  EXPECT_CALL(*transport, name()).Times(AnyNumber());
-  EXPECT_CALL(*proto, name()).Times(AnyNumber());
+  EXPECT_CALL(transport, name()).Times(AnyNumber());
+  EXPECT_CALL(proto, name()).Times(AnyNumber());
 
   InSequence dummy;
 
-  Decoder decoder(TransportPtr{transport}, ProtocolPtr{proto}, callbacks);
+  Decoder decoder(transport, proto, callbacks);
   Buffer::OwnedImpl buffer;
   bool underflow = false;
 
-  EXPECT_CALL(*transport, decodeFrameStart(Ref(buffer), _)).WillOnce(Return(false));
+  EXPECT_CALL(transport, decodeFrameStart(Ref(buffer), _)).WillOnce(Return(false));
   EXPECT_EQ(FilterStatus::Continue, decoder.onData(buffer, underflow));
   EXPECT_TRUE(underflow);
 
-  EXPECT_CALL(*transport, decodeFrameStart(Ref(buffer), _))
+  EXPECT_CALL(transport, decodeFrameStart(Ref(buffer), _))
       .WillOnce(Invoke([&](Buffer::Instance&, MessageMetadata& metadata) -> bool {
         metadata.setFrameSize(100);
         return true;
       }));
-  EXPECT_CALL(*proto, readMessageBegin(_, _))
+  EXPECT_CALL(proto, readMessageBegin(_, _))
       .WillOnce(Invoke([&](Buffer::Instance&, MessageMetadata& metadata) -> bool {
         metadata.setMethodName("name");
         metadata.setMessageType(MessageType::Call);
         metadata.setSequenceId(100);
         return true;
       }));
-  EXPECT_CALL(*proto, readStructBegin(_, _)).WillOnce(Return(true));
-  EXPECT_CALL(*proto, readFieldBegin(_, _, _, _))
+  EXPECT_CALL(proto, readStructBegin(_, _)).WillOnce(Return(true));
+  EXPECT_CALL(proto, readFieldBegin(_, _, _, _))
       .WillOnce(DoAll(SetArgReferee<2>(FieldType::Stop), Return(true)));
-  EXPECT_CALL(*proto, readStructEnd(_)).WillOnce(Return(true));
-  EXPECT_CALL(*proto, readMessageEnd(_)).WillOnce(Return(true));
-  EXPECT_CALL(*transport, decodeFrameEnd(_)).WillOnce(Return(true));
+  EXPECT_CALL(proto, readStructEnd(_)).WillOnce(Return(true));
+  EXPECT_CALL(proto, readMessageEnd(_)).WillOnce(Return(true));
+  EXPECT_CALL(transport, decodeFrameEnd(_)).WillOnce(Return(true));
 
   underflow = false;
   EXPECT_EQ(FilterStatus::Continue, decoder.onData(buffer, underflow));
@@ -968,66 +968,65 @@ TEST(DecoderTest, OnDataResumesTransportFrameStart) {
 }
 
 TEST(DecoderTest, OnDataResumesTransportFrameEnd) {
-  StrictMock<MockTransport>* transport = new StrictMock<MockTransport>();
-  StrictMock<MockProtocol>* proto = new StrictMock<MockProtocol>();
+  StrictMock<MockTransport> transport;
+  StrictMock<MockProtocol> proto;
   NiceMock<MockDecoderCallbacks> callbacks;
   NiceMock<MockDecoderEventHandler> handler;
   ON_CALL(callbacks, newDecoderEventHandler()).WillByDefault(ReturnRef(handler));
 
-  EXPECT_CALL(*transport, name()).Times(AnyNumber());
-  EXPECT_CALL(*proto, name()).Times(AnyNumber());
+  EXPECT_CALL(transport, name()).Times(AnyNumber());
+  EXPECT_CALL(proto, name()).Times(AnyNumber());
 
   InSequence dummy;
 
-  Decoder decoder(TransportPtr{transport}, ProtocolPtr{proto}, callbacks);
+  Decoder decoder(transport, proto, callbacks);
   Buffer::OwnedImpl buffer;
 
-  EXPECT_CALL(*transport, decodeFrameStart(Ref(buffer), _))
+  EXPECT_CALL(transport, decodeFrameStart(Ref(buffer), _))
       .WillOnce(Invoke([&](Buffer::Instance&, MessageMetadata& metadata) -> bool {
         metadata.setFrameSize(100);
         return true;
       }));
-  EXPECT_CALL(*proto, readMessageBegin(_, _))
+  EXPECT_CALL(proto, readMessageBegin(_, _))
       .WillOnce(Invoke([&](Buffer::Instance&, MessageMetadata& metadata) -> bool {
         metadata.setMethodName("name");
         metadata.setMessageType(MessageType::Call);
         metadata.setSequenceId(100);
         return true;
       }));
-  EXPECT_CALL(*proto, readStructBegin(_, _)).WillOnce(Return(true));
-  EXPECT_CALL(*proto, readFieldBegin(_, _, _, _))
+  EXPECT_CALL(proto, readStructBegin(_, _)).WillOnce(Return(true));
+  EXPECT_CALL(proto, readFieldBegin(_, _, _, _))
       .WillOnce(DoAll(SetArgReferee<2>(FieldType::Stop), Return(true)));
-  EXPECT_CALL(*proto, readStructEnd(_)).WillOnce(Return(true));
-  EXPECT_CALL(*proto, readMessageEnd(_)).WillOnce(Return(true));
-  EXPECT_CALL(*transport, decodeFrameEnd(_)).WillOnce(Return(false));
+  EXPECT_CALL(proto, readStructEnd(_)).WillOnce(Return(true));
+  EXPECT_CALL(proto, readMessageEnd(_)).WillOnce(Return(true));
+  EXPECT_CALL(transport, decodeFrameEnd(_)).WillOnce(Return(false));
 
   bool underflow = false;
   EXPECT_EQ(FilterStatus::Continue, decoder.onData(buffer, underflow));
   EXPECT_TRUE(underflow);
 
-  EXPECT_CALL(*transport, decodeFrameEnd(_)).WillOnce(Return(true));
+  EXPECT_CALL(transport, decodeFrameEnd(_)).WillOnce(Return(true));
   EXPECT_EQ(FilterStatus::Continue, decoder.onData(buffer, underflow));
   EXPECT_TRUE(underflow); // buffer.length() == 0
 }
 
 TEST(DecoderTest, OnDataHandlesStopIterationAndResumes) {
+  StrictMock<MockTransport> transport;
+  EXPECT_CALL(transport, name()).WillRepeatedly(ReturnRef(transport.name_));
 
-  StrictMock<MockTransport>* transport = new StrictMock<MockTransport>();
-  EXPECT_CALL(*transport, name()).WillRepeatedly(ReturnRef(transport->name_));
-
-  StrictMock<MockProtocol>* proto = new StrictMock<MockProtocol>();
-  EXPECT_CALL(*proto, name()).WillRepeatedly(ReturnRef(proto->name_));
+  StrictMock<MockProtocol> proto;
+  EXPECT_CALL(proto, name()).WillRepeatedly(ReturnRef(proto.name_));
 
   NiceMock<MockDecoderCallbacks> callbacks;
   StrictMock<MockDecoderEventHandler> handler;
   ON_CALL(callbacks, newDecoderEventHandler()).WillByDefault(ReturnRef(handler));
 
   InSequence dummy;
-  Decoder decoder(TransportPtr{transport}, ProtocolPtr{proto}, callbacks);
+  Decoder decoder(transport, proto, callbacks);
   Buffer::OwnedImpl buffer;
   bool underflow = true;
 
-  EXPECT_CALL(*transport, decodeFrameStart(Ref(buffer), _))
+  EXPECT_CALL(transport, decodeFrameStart(Ref(buffer), _))
       .WillOnce(Invoke([&](Buffer::Instance&, MessageMetadata& metadata) -> bool {
         metadata.setFrameSize(100);
         return true;
@@ -1042,7 +1041,7 @@ TEST(DecoderTest, OnDataHandlesStopIterationAndResumes) {
   EXPECT_EQ(FilterStatus::StopIteration, decoder.onData(buffer, underflow));
   EXPECT_FALSE(underflow);
 
-  EXPECT_CALL(*proto, readMessageBegin(Ref(buffer), _))
+  EXPECT_CALL(proto, readMessageBegin(Ref(buffer), _))
       .WillOnce(Invoke([&](Buffer::Instance&, MessageMetadata& metadata) -> bool {
         metadata.setMethodName("name");
         metadata.setMessageType(MessageType::Call);
@@ -1062,42 +1061,42 @@ TEST(DecoderTest, OnDataHandlesStopIterationAndResumes) {
   EXPECT_EQ(FilterStatus::StopIteration, decoder.onData(buffer, underflow));
   EXPECT_FALSE(underflow);
 
-  EXPECT_CALL(*proto, readStructBegin(Ref(buffer), _)).WillOnce(Return(true));
+  EXPECT_CALL(proto, readStructBegin(Ref(buffer), _)).WillOnce(Return(true));
   EXPECT_CALL(handler, structBegin(absl::string_view()))
       .WillOnce(Return(FilterStatus::StopIteration));
   EXPECT_EQ(FilterStatus::StopIteration, decoder.onData(buffer, underflow));
   EXPECT_FALSE(underflow);
 
-  EXPECT_CALL(*proto, readFieldBegin(Ref(buffer), _, _, _))
+  EXPECT_CALL(proto, readFieldBegin(Ref(buffer), _, _, _))
       .WillOnce(DoAll(SetArgReferee<2>(FieldType::I32), SetArgReferee<3>(1), Return(true)));
   EXPECT_CALL(handler, fieldBegin(absl::string_view(), FieldType::I32, 1))
       .WillOnce(Return(FilterStatus::StopIteration));
   EXPECT_EQ(FilterStatus::StopIteration, decoder.onData(buffer, underflow));
   EXPECT_FALSE(underflow);
 
-  EXPECT_CALL(*proto, readInt32(_, _)).WillOnce(Return(true));
+  EXPECT_CALL(proto, readInt32(_, _)).WillOnce(Return(true));
   EXPECT_CALL(handler, int32Value(_)).WillOnce(Return(FilterStatus::StopIteration));
   EXPECT_EQ(FilterStatus::StopIteration, decoder.onData(buffer, underflow));
   EXPECT_FALSE(underflow);
 
-  EXPECT_CALL(*proto, readFieldEnd(Ref(buffer))).WillOnce(Return(true));
+  EXPECT_CALL(proto, readFieldEnd(Ref(buffer))).WillOnce(Return(true));
   EXPECT_CALL(handler, fieldEnd()).WillOnce(Return(FilterStatus::StopIteration));
   EXPECT_EQ(FilterStatus::StopIteration, decoder.onData(buffer, underflow));
   EXPECT_FALSE(underflow);
 
-  EXPECT_CALL(*proto, readFieldBegin(Ref(buffer), _, _, _))
+  EXPECT_CALL(proto, readFieldBegin(Ref(buffer), _, _, _))
       .WillOnce(DoAll(SetArgReferee<2>(FieldType::Stop), Return(true)));
-  EXPECT_CALL(*proto, readStructEnd(Ref(buffer))).WillOnce(Return(true));
+  EXPECT_CALL(proto, readStructEnd(Ref(buffer))).WillOnce(Return(true));
   EXPECT_CALL(handler, structEnd()).WillOnce(Return(FilterStatus::StopIteration));
   EXPECT_EQ(FilterStatus::StopIteration, decoder.onData(buffer, underflow));
   EXPECT_FALSE(underflow);
 
-  EXPECT_CALL(*proto, readMessageEnd(Ref(buffer))).WillOnce(Return(true));
+  EXPECT_CALL(proto, readMessageEnd(Ref(buffer))).WillOnce(Return(true));
   EXPECT_CALL(handler, messageEnd()).WillOnce(Return(FilterStatus::StopIteration));
   EXPECT_EQ(FilterStatus::StopIteration, decoder.onData(buffer, underflow));
   EXPECT_FALSE(underflow);
 
-  EXPECT_CALL(*transport, decodeFrameEnd(Ref(buffer))).WillOnce(Return(true));
+  EXPECT_CALL(transport, decodeFrameEnd(Ref(buffer))).WillOnce(Return(true));
   EXPECT_CALL(handler, transportEnd()).WillOnce(Return(FilterStatus::StopIteration));
   EXPECT_EQ(FilterStatus::StopIteration, decoder.onData(buffer, underflow));
   EXPECT_FALSE(underflow);

--- a/test/extensions/filters/network/thrift_proxy/mocks.cc
+++ b/test/extensions/filters/network/thrift_proxy/mocks.cc
@@ -27,6 +27,7 @@ MockProtocol::MockProtocol() {
   ON_CALL(*this, setType(_)).WillByDefault(Invoke([&](ProtocolType type) -> void {
     type_ = type;
   }));
+  ON_CALL(*this, supportsUpgrade()).WillByDefault(Return(false));
 }
 MockProtocol::~MockProtocol() {}
 
@@ -38,6 +39,9 @@ MockDecoderEventHandler::~MockDecoderEventHandler() {}
 
 MockDirectResponse::MockDirectResponse() {}
 MockDirectResponse::~MockDirectResponse() {}
+
+MockThriftObject::MockThriftObject() {}
+MockThriftObject::~MockThriftObject() {}
 
 namespace ThriftFilters {
 

--- a/test/extensions/filters/network/thrift_proxy/thrift_object_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/thrift_object_impl_test.cc
@@ -1,0 +1,494 @@
+#include "common/buffer/buffer_impl.h"
+
+#include "extensions/filters/network/thrift_proxy/thrift_object_impl.h"
+
+#include "test/extensions/filters/network/thrift_proxy/mocks.h"
+#include "test/extensions/filters/network/thrift_proxy/utility.h"
+#include "test/test_common/printers.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::AnyNumber;
+using testing::Expectation;
+using testing::ExpectationSet;
+using testing::InSequence;
+using testing::NiceMock;
+using testing::Ref;
+using testing::Return;
+using testing::ReturnRef;
+using testing::Test;
+using testing::TestWithParam;
+using testing::Values;
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+
+class ThriftObjectImplTestBase {
+public:
+  virtual ~ThriftObjectImplTestBase() {}
+
+  Expectation expectValue(FieldType field_type) {
+    switch (field_type) {
+    case FieldType::Bool:
+      return EXPECT_CALL(protocol_, readBool(Ref(buffer_), _))
+          .WillOnce(Invoke([](Buffer::Instance&, bool& value) -> bool {
+            value = true;
+            return true;
+          }));
+    case FieldType::Byte:
+      return EXPECT_CALL(protocol_, readByte(Ref(buffer_), _))
+          .WillOnce(Invoke([](Buffer::Instance&, uint8_t& value) -> bool {
+            value = 1;
+            return true;
+          }));
+    case FieldType::Double:
+      return EXPECT_CALL(protocol_, readDouble(Ref(buffer_), _))
+          .WillOnce(Invoke([](Buffer::Instance&, double& value) -> bool {
+            value = 2.0;
+            return true;
+          }));
+    case FieldType::I16:
+      return EXPECT_CALL(protocol_, readInt16(Ref(buffer_), _))
+          .WillOnce(Invoke([](Buffer::Instance&, int16_t& value) -> bool {
+            value = 3;
+            return true;
+          }));
+    case FieldType::I32:
+      return EXPECT_CALL(protocol_, readInt32(Ref(buffer_), _))
+          .WillOnce(Invoke([](Buffer::Instance&, int32_t& value) -> bool {
+            value = 4;
+            return true;
+          }));
+    case FieldType::I64:
+      return EXPECT_CALL(protocol_, readInt64(Ref(buffer_), _))
+          .WillOnce(Invoke([](Buffer::Instance&, int64_t& value) -> bool {
+            value = 5;
+            return true;
+          }));
+    case FieldType::String:
+      return EXPECT_CALL(protocol_, readString(Ref(buffer_), _))
+          .WillOnce(Invoke([](Buffer::Instance&, std::string& value) -> bool {
+            value = "six";
+            return true;
+          }));
+    default:
+      NOT_REACHED_GCOVR_EXCL_LINE;
+    }
+  }
+
+  Expectation expectFieldBegin(FieldType field_type, int16_t field_id) {
+    return EXPECT_CALL(protocol_, readFieldBegin(Ref(buffer_), _, _, _))
+        .WillOnce(
+            Invoke([=](Buffer::Instance&, std::string&, FieldType& type, int16_t& id) -> bool {
+              type = field_type;
+              id = field_id;
+              return true;
+            }));
+  }
+
+  Expectation expectFieldEnd() {
+    return EXPECT_CALL(protocol_, readFieldEnd(Ref(buffer_))).WillOnce(Return(true));
+  }
+
+  ExpectationSet expectField(FieldType field_type, int16_t field_id) {
+    ExpectationSet s;
+    s += expectFieldBegin(field_type, field_id);
+    s += expectValue(field_type);
+    s += expectFieldEnd();
+    return s;
+  }
+
+  Expectation expectStopField() { return expectFieldBegin(FieldType::Stop, 0); }
+
+  void checkValue(FieldType field_type, const ThriftValue& value) {
+    EXPECT_EQ(field_type, value.type());
+
+    switch (field_type) {
+    case FieldType::Bool:
+      EXPECT_EQ(true, value.getValueTyped<bool>());
+      break;
+    case FieldType::Byte:
+      EXPECT_EQ(1, value.getValueTyped<uint8_t>());
+      break;
+    case FieldType::Double:
+      EXPECT_EQ(2.0, value.getValueTyped<double>());
+      break;
+    case FieldType::I16:
+      EXPECT_EQ(3, value.getValueTyped<int16_t>());
+      break;
+    case FieldType::I32:
+      EXPECT_EQ(4, value.getValueTyped<int32_t>());
+      break;
+    case FieldType::I64:
+      EXPECT_EQ(5, value.getValueTyped<int64_t>());
+      break;
+    case FieldType::String:
+      EXPECT_EQ("six", value.getValueTyped<std::string>());
+      break;
+    default:
+      NOT_REACHED_GCOVR_EXCL_LINE;
+    }
+  }
+
+  void checkFieldValue(const ThriftField& field) {
+    const ThriftValue& value = field.getValue();
+    checkValue(field.fieldType(), value);
+  }
+
+  NiceMock<MockTransport> transport_;
+  NiceMock<MockProtocol> protocol_;
+  Buffer::OwnedImpl buffer_;
+};
+
+class ThriftObjectImplTest : public ThriftObjectImplTestBase, public Test {};
+
+// Test parsing an empty struct (just a stop field).
+TEST_F(ThriftObjectImplTest, ParseEmptyStruct) {
+  ThriftObjectImpl thrift_obj(transport_, protocol_);
+
+  InSequence s;
+  EXPECT_CALL(transport_, decodeFrameStart(Ref(buffer_), _)).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMessageBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readStructBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  expectStopField();
+  EXPECT_CALL(protocol_, readStructEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMessageEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(transport_, decodeFrameEnd(Ref(buffer_))).WillOnce(Return(true));
+
+  EXPECT_TRUE(thrift_obj.onData(buffer_));
+  EXPECT_TRUE(thrift_obj.fields().empty());
+}
+
+class ThriftObjectImplValueTest : public ThriftObjectImplTestBase,
+                                  public TestWithParam<FieldType> {};
+
+INSTANTIATE_TEST_CASE_P(PrimitiveFieldTypes, ThriftObjectImplValueTest,
+                        Values(FieldType::Bool, FieldType::Byte, FieldType::Double, FieldType::I16,
+                               FieldType::I32, FieldType::I64, FieldType::String),
+                        fieldTypeParamToString);
+
+// Test parsing a struct with a single field with a simple value.
+TEST_P(ThriftObjectImplValueTest, ParseSingleValueStruct) {
+  FieldType field_type = GetParam();
+
+  ThriftObjectImpl thrift_obj(transport_, protocol_);
+
+  InSequence s;
+  EXPECT_CALL(transport_, decodeFrameStart(Ref(buffer_), _)).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMessageBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readStructBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  expectField(field_type, 1);
+  expectStopField();
+  EXPECT_CALL(protocol_, readStructEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMessageEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(transport_, decodeFrameEnd(Ref(buffer_))).WillOnce(Return(true));
+
+  EXPECT_TRUE(thrift_obj.onData(buffer_));
+  EXPECT_EQ(1, thrift_obj.fields().size());
+  EXPECT_EQ(field_type, thrift_obj.fields().front()->fieldType());
+  EXPECT_EQ(1, thrift_obj.fields().front()->fieldId());
+  checkFieldValue(*thrift_obj.fields().front());
+}
+
+// Test parsing nested structs (struct -> struct -> simple field).
+TEST_P(ThriftObjectImplValueTest, ParseNestedSingleValueStruct) {
+  FieldType field_type = GetParam();
+
+  ThriftObjectImpl thrift_obj(transport_, protocol_);
+
+  InSequence s;
+  EXPECT_CALL(transport_, decodeFrameStart(Ref(buffer_), _)).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMessageBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readStructBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  expectFieldBegin(FieldType::Struct, 1);
+
+  EXPECT_CALL(protocol_, readStructBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  expectField(field_type, 2);
+  expectStopField();
+  EXPECT_CALL(protocol_, readStructEnd(Ref(buffer_))).WillOnce(Return(true));
+
+  expectFieldEnd();
+  expectStopField();
+  EXPECT_CALL(protocol_, readStructEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMessageEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(transport_, decodeFrameEnd(Ref(buffer_))).WillOnce(Return(true));
+
+  EXPECT_TRUE(thrift_obj.onData(buffer_));
+  EXPECT_EQ(1, thrift_obj.fields().size());
+  const ThriftField& field = *thrift_obj.fields().front();
+  EXPECT_EQ(FieldType::Struct, field.fieldType());
+
+  const ThriftStructValue& nested = field.getValue().getValueTyped<ThriftStructValue>();
+  EXPECT_EQ(1, nested.fields().size());
+  EXPECT_EQ(field_type, nested.fields().front()->fieldType());
+  EXPECT_EQ(2, nested.fields().front()->fieldId());
+  checkFieldValue(*nested.fields().front());
+}
+
+// Test parsing a struct with a single list field (struct -> list).
+TEST_P(ThriftObjectImplValueTest, ParseNestedListValue) {
+  FieldType field_type = GetParam();
+
+  ThriftObjectImpl thrift_obj(transport_, protocol_);
+
+  InSequence s;
+  EXPECT_CALL(transport_, decodeFrameStart(Ref(buffer_), _)).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMessageBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readStructBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  expectFieldBegin(FieldType::List, 1);
+
+  EXPECT_CALL(protocol_, readListBegin(Ref(buffer_), _, _))
+      .WillOnce(Invoke([&](Buffer::Instance&, FieldType& type, uint32_t& size) -> bool {
+        type = field_type;
+        size = 2;
+        return true;
+      }));
+  expectValue(field_type);
+  expectValue(field_type);
+  EXPECT_CALL(protocol_, readListEnd(Ref(buffer_))).WillOnce(Return(true));
+
+  expectFieldEnd();
+  expectStopField();
+  EXPECT_CALL(protocol_, readStructEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMessageEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(transport_, decodeFrameEnd(Ref(buffer_))).WillOnce(Return(true));
+
+  EXPECT_TRUE(thrift_obj.onData(buffer_));
+  EXPECT_EQ(1, thrift_obj.fields().size());
+  const ThriftField& field = *thrift_obj.fields().front();
+  EXPECT_EQ(1, field.fieldId());
+  EXPECT_EQ(FieldType::List, field.fieldType());
+
+  const ThriftListValue& nested = field.getValue().getValueTyped<ThriftListValue>();
+  EXPECT_EQ(field_type, nested.elementType());
+  EXPECT_EQ(2, nested.elements().size());
+  for (auto& value : nested.elements()) {
+    checkValue(field_type, *value);
+  }
+}
+
+// Test parsing a struct with a single set field (struct -> set).
+TEST_P(ThriftObjectImplValueTest, ParseNestedSetValue) {
+  FieldType field_type = GetParam();
+
+  ThriftObjectImpl thrift_obj(transport_, protocol_);
+
+  InSequence s;
+  EXPECT_CALL(transport_, decodeFrameStart(Ref(buffer_), _)).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMessageBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readStructBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  expectFieldBegin(FieldType::Set, 1);
+
+  EXPECT_CALL(protocol_, readSetBegin(Ref(buffer_), _, _))
+      .WillOnce(Invoke([&](Buffer::Instance&, FieldType& type, uint32_t& size) -> bool {
+        type = field_type;
+        size = 2;
+        return true;
+      }));
+  expectValue(field_type);
+  expectValue(field_type);
+  EXPECT_CALL(protocol_, readSetEnd(Ref(buffer_))).WillOnce(Return(true));
+
+  expectFieldEnd();
+  expectStopField();
+  EXPECT_CALL(protocol_, readStructEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMessageEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(transport_, decodeFrameEnd(Ref(buffer_))).WillOnce(Return(true));
+
+  EXPECT_TRUE(thrift_obj.onData(buffer_));
+  EXPECT_EQ(1, thrift_obj.fields().size());
+  const ThriftField& field = *thrift_obj.fields().front();
+  EXPECT_EQ(1, field.fieldId());
+  EXPECT_EQ(FieldType::Set, field.fieldType());
+
+  const ThriftSetValue& nested = field.getValue().getValueTyped<ThriftSetValue>();
+  EXPECT_EQ(field_type, nested.elementType());
+  EXPECT_EQ(2, nested.elements().size());
+  for (auto& value : nested.elements()) {
+    checkValue(field_type, *value);
+  }
+}
+
+// Test parsing a struct with a single map field (struct -> map).
+TEST_P(ThriftObjectImplValueTest, ParseNestedMapValue) {
+  FieldType field_type = GetParam();
+
+  ThriftObjectImpl thrift_obj(transport_, protocol_);
+
+  InSequence s;
+  EXPECT_CALL(transport_, decodeFrameStart(Ref(buffer_), _)).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMessageBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readStructBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  expectFieldBegin(FieldType::Map, 1);
+
+  EXPECT_CALL(protocol_, readMapBegin(Ref(buffer_), _, _, _))
+      .WillOnce(Invoke([&](Buffer::Instance&, FieldType& key_type, FieldType& value_type,
+                           uint32_t& size) -> bool {
+        key_type = field_type;
+        value_type = FieldType::String;
+        size = 2;
+        return true;
+      }));
+  expectValue(field_type);
+  expectValue(FieldType::String);
+  expectValue(field_type);
+  expectValue(FieldType::String);
+  EXPECT_CALL(protocol_, readMapEnd(Ref(buffer_))).WillOnce(Return(true));
+
+  expectFieldEnd();
+  expectStopField();
+  EXPECT_CALL(protocol_, readStructEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMessageEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(transport_, decodeFrameEnd(Ref(buffer_))).WillOnce(Return(true));
+
+  EXPECT_TRUE(thrift_obj.onData(buffer_));
+  EXPECT_EQ(1, thrift_obj.fields().size());
+  const ThriftField& field = *thrift_obj.fields().front();
+  EXPECT_EQ(1, field.fieldId());
+  EXPECT_EQ(FieldType::Map, field.fieldType());
+
+  const ThriftMapValue& nested = field.getValue().getValueTyped<ThriftMapValue>();
+  EXPECT_EQ(field_type, nested.keyType());
+  EXPECT_EQ(FieldType::String, nested.valueType());
+  EXPECT_EQ(2, nested.elements().size());
+  for (auto& value : nested.elements()) {
+    checkValue(field_type, *value.first);
+    checkValue(FieldType::String, *value.second);
+  }
+}
+
+// Test a struct with a map -> list -> set -> map -> list -> set -> struct.
+TEST_F(ThriftObjectImplTest, DeeplyNestedStruct) {
+  ThriftObjectImpl thrift_obj(transport_, protocol_);
+
+  InSequence s;
+  EXPECT_CALL(transport_, decodeFrameStart(Ref(buffer_), _)).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMessageBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readStructBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  expectFieldBegin(FieldType::Map, 1);
+
+  EXPECT_CALL(protocol_, readMapBegin(Ref(buffer_), _, _, _))
+      .WillOnce(Invoke([&](Buffer::Instance&, FieldType& key_type, FieldType& value_type,
+                           uint32_t& size) -> bool {
+        key_type = FieldType::I32;
+        value_type = FieldType::List;
+        size = 1;
+        return true;
+      }));
+  expectValue(FieldType::I32);
+  EXPECT_CALL(protocol_, readListBegin(Ref(buffer_), _, _))
+      .WillOnce(Invoke([&](Buffer::Instance&, FieldType& elem_type, uint32_t& size) -> bool {
+        elem_type = FieldType::Set;
+        size = 1;
+        return true;
+      }));
+  EXPECT_CALL(protocol_, readSetBegin(Ref(buffer_), _, _))
+      .WillOnce(Invoke([&](Buffer::Instance&, FieldType& elem_type, uint32_t& size) -> bool {
+        elem_type = FieldType::Map;
+        size = 1;
+        return true;
+      }));
+
+  EXPECT_CALL(protocol_, readMapBegin(Ref(buffer_), _, _, _))
+      .WillOnce(Invoke([&](Buffer::Instance&, FieldType& key_type, FieldType& value_type,
+                           uint32_t& size) -> bool {
+        key_type = FieldType::I32;
+        value_type = FieldType::List;
+        size = 1;
+        return true;
+      }));
+  expectValue(FieldType::I32);
+  EXPECT_CALL(protocol_, readListBegin(Ref(buffer_), _, _))
+      .WillOnce(Invoke([&](Buffer::Instance&, FieldType& elem_type, uint32_t& size) -> bool {
+        elem_type = FieldType::Set;
+        size = 1;
+        return true;
+      }));
+  EXPECT_CALL(protocol_, readSetBegin(Ref(buffer_), _, _))
+      .WillOnce(Invoke([&](Buffer::Instance&, FieldType& elem_type, uint32_t& size) -> bool {
+        elem_type = FieldType::Struct;
+        size = 1;
+        return true;
+      }));
+  EXPECT_CALL(protocol_, readStructBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  expectField(FieldType::I64, 100);
+  expectStopField();
+  EXPECT_CALL(protocol_, readStructEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readSetEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readListEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMapEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readSetEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readListEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMapEnd(Ref(buffer_))).WillOnce(Return(true));
+
+  expectFieldEnd();
+  expectStopField();
+  EXPECT_CALL(protocol_, readStructEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMessageEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(transport_, decodeFrameEnd(Ref(buffer_))).WillOnce(Return(true));
+
+  EXPECT_TRUE(thrift_obj.onData(buffer_));
+  EXPECT_EQ(1, thrift_obj.fields().size());
+
+  EXPECT_EQ(FieldType::Map, thrift_obj.fields().front()->fieldType());
+  const ThriftMapValue& map_value =
+      thrift_obj.fields().front()->getValue().getValueTyped<ThriftMapValue>();
+  EXPECT_EQ(1, map_value.elements().size());
+
+  const ThriftListValue& list_value =
+      map_value.elements().front().second->getValueTyped<ThriftListValue>();
+  EXPECT_EQ(1, list_value.elements().size());
+
+  const ThriftSetValue& set_value = list_value.elements().front()->getValueTyped<ThriftSetValue>();
+  EXPECT_EQ(1, set_value.elements().size());
+
+  const ThriftMapValue& map_value2 = set_value.elements().front()->getValueTyped<ThriftMapValue>();
+  EXPECT_EQ(1, map_value2.elements().size());
+
+  const ThriftListValue& list_value2 =
+      map_value2.elements().front().second->getValueTyped<ThriftListValue>();
+  EXPECT_EQ(1, list_value2.elements().size());
+
+  const ThriftSetValue& set_value2 =
+      list_value2.elements().front()->getValueTyped<ThriftSetValue>();
+  EXPECT_EQ(1, set_value2.elements().size());
+
+  const ThriftStructValue& struct_value =
+      set_value2.elements().front()->getValueTyped<ThriftStructValue>();
+  EXPECT_EQ(1, struct_value.fields().size());
+
+  EXPECT_EQ(5, struct_value.fields().front()->getValue().getValueTyped<int64_t>());
+}
+
+// Tests when caller requests wrong value type.
+TEST_F(ThriftObjectImplTest, WrongValueType) {
+  ThriftObjectImpl thrift_obj(transport_, protocol_);
+
+  InSequence s;
+  EXPECT_CALL(transport_, decodeFrameStart(Ref(buffer_), _)).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMessageBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readStructBegin(Ref(buffer_), _)).WillOnce(Return(true));
+  expectField(FieldType::String, 1);
+  expectStopField();
+  EXPECT_CALL(protocol_, readStructEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(protocol_, readMessageEnd(Ref(buffer_))).WillOnce(Return(true));
+  EXPECT_CALL(transport_, decodeFrameEnd(Ref(buffer_))).WillOnce(Return(true));
+
+  EXPECT_TRUE(thrift_obj.onData(buffer_));
+  EXPECT_EQ(1, thrift_obj.fields().size());
+
+  const ThriftValue& value = thrift_obj.fields().front()->getValue();
+  EXPECT_THROW_WITH_MESSAGE(value.getValueTyped<int32_t>(), EnvoyException,
+                            fmt::format("expected field type {}, got {}",
+                                        static_cast<int>(FieldType::I32),
+                                        static_cast<int>(FieldType::String)));
+}
+
+} // Namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
Modifies the Thrift router to allow protocols to upgrade on initial
data from the downstream connection and upgrade an upstream connection
before transmitting a request. As part of this work, Transport and
Protocol objects are reused across downstream connections and for
an upstream's request and response.

*Risk Level*: low, upgrade path unused
*Testing*: unit tests
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
