### PR TITLE
ratelimit: check for initiating call before continue decoding

### DIFF
--- a/source/extensions/filters/http/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit.cc
@@ -150,7 +150,9 @@ void Filter::complete(RateLimit::LimitStatus status, Http::HeaderMapPtr&& header
   } else if (status == RateLimit::LimitStatus::Error) {
     if (config_->failureModeAllow()) {
       cluster_->statsScope().counter("ratelimit.failure_mode_allowed").inc();
-      callbacks_->continueDecoding();
+      if (!initiating_call_) {
+        callbacks_->continueDecoding();
+      }
     } else {
       state_ = State::Responded;
       callbacks_->sendLocalReply(Http::Code::InternalServerError, "", nullptr);

--- a/source/extensions/filters/network/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/network/ratelimit/ratelimit.cc
@@ -91,7 +91,9 @@ void Filter::complete(RateLimit::LimitStatus status, Http::HeaderMapPtr&&) {
   } else if (status == RateLimit::LimitStatus::Error) {
     if (config_->failureModeAllow()) {
       config_->stats().failure_mode_allowed_.inc();
-      filter_callbacks_->continueReading();
+      if (!calling_limit_) {
+        filter_callbacks_->continueReading();
+      }
     } else {
       config_->stats().cx_closed_.inc();
       filter_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>

*Description*: To check for initiating call before continue decoding. See https://github.com/envoyproxy/envoy/pull/4073#issuecomment-416752877 for more details to avoid the crash
*Risk Level*: Low
*Testing*: Existing tests
*Docs Changes*: N/A
*Release Notes*: N/A
[Optional Fixes #Issue]
[Optional *Deprecated*:]
