### PR TITLE
Add terminal attribute to request hash.

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -586,6 +586,11 @@ message RouteAction {
       ConnectionProperties connection_properties = 3;
     }
 
+    // The flag that shortcircuits the hash computing. This field provides a
+    // 'fallback' style of configuration: "if a terminal policy doesn't work,
+    // fallback to rest of the policy list", it saves time when the terminal
+    // policy works.
+    //
     // If true, and there is already a hash computed, ignore rest of the
     // list of hash polices.
     // For example, if the following hash methods are configured:
@@ -593,7 +598,8 @@ message RouteAction {
     //   [(Header A,    true),
     //    (Cookie B,    false),
     //    (Cookie C,    false)]
-    // The generateHash process ends after computing "header A", as it's a terminal policy.
+    // The generateHash process ends if policy "header A" generates a hash, as
+    // it's a terminal policy.
     bool terminal = 4;
   }
 

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -594,10 +594,15 @@ message RouteAction {
     // If true, and there is already a hash computed, ignore rest of the
     // list of hash polices.
     // For example, if the following hash methods are configured:
-    //   [(specifier, terminal),...]
-    //   [(Header A,    true),
-    //    (Cookie B,    false),
-    //    (Cookie C,    false)]
+    //
+    //  ========= ========
+    //  specifier terminal
+    //  ========= ========
+    //  Header A  true
+    //  Header B  false
+    //  Header C  false
+    //  ========= ========
+    //
     // The generateHash process ends if policy "header A" generates a hash, as
     // it's a terminal policy.
     bool terminal = 4;

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -540,8 +540,8 @@ message RouteAction {
 
     // Envoy supports two types of cookie affinity:
     //
-    // 1. Passive. Envoy takes a cookie that's present in the cookies header and
-    //    hashes on its value.
+    // 1. Passive. Envoy takes a cookie that's present in the cookies header or
+    // the whole cookies header and hashes on the value.
     //
     // 2. Generated. Envoy generates and sets a cookie with an expiration (TTL)
     //    on the first request from the client in its response to the client,
@@ -553,9 +553,11 @@ message RouteAction {
     //    streams on the same connection will independently receive the same
     //    cookie, even if they arrive at the Envoy simultaneously.
     message Cookie {
-      // The name of the cookie that will be used to obtain the hash key. If the
-      // cookie is not present and ttl below is not set, no hash will be
-      // produced.
+      // The name of the cookie that will be used to obtain the hash key.
+      // If the name is empty, hash on the cookies header, no hash will be
+      // produced if cookies header is empty.
+      // If the name is set but the cookie is not present and ttl below is
+      // not set, no hash will be produced.
       string name = 1 [(validate.rules).string.min_bytes = 1];
 
       // If specified, a cookie with the TTL will be generated if the cookie is
@@ -573,6 +575,15 @@ message RouteAction {
       bool source_ip = 1;
     }
 
+    message QueryParameter {
+      // Hash on query parameter value.
+      string key = 1;
+    }
+
+    message HostPath {
+      // Hash on host and path value.
+    }
+
     oneof policy_specifier {
       option (validate.required) = true;
 
@@ -584,13 +595,29 @@ message RouteAction {
 
       // Connection properties hash policy.
       ConnectionProperties connection_properties = 3;
+
+      // Query parameter hash policy.
+      QueryParameter query_parameter = 4;
+
+      // Host path hash policy.
+      HostPath host_path = 5;
     }
+
+    // If true, and there is already a hash computed, ignore rest of the
+    // list of hash polices.
+    // For example, if there are the following hash methods configured:
+    //   [(specifier, terminal),...]
+    //   [(Header A,    true),
+    //    (Cookie B,    false),
+    //    (Cookie C,    false)]
+    // The generateHash process ends after computing "header A", as it's a terminal policy.
+    bool terminal = 6;
   }
 
   // Specifies a list of hash policies to use for ring hash load balancing. Each
   // hash policy is evaluated individually and the combined result is used to
   // route the request. The method of combination is deterministic such that
-  // identical lists of hash policies will produce the same hash. Since a hash
+  // identical lists of hash policies will produce the same hash.Since a hash
   // policy examines specific parts of a request, it can fail to produce a hash
   // (i.e. if the hashed header is not present). If (and only if) all configured
   // hash policies fail to generate a hash, no hash will be produced for

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -585,8 +585,6 @@ message RouteAction {
       // Connection properties hash policy.
       ConnectionProperties connection_properties = 3;
     }
-    // Reserve for new policy_specifier.
-    /* RESERVED */ reserved 4 to 20;
 
     // If true, and there is already a hash computed, ignore rest of the
     // list of hash polices.
@@ -596,7 +594,7 @@ message RouteAction {
     //    (Cookie B,    false),
     //    (Cookie C,    false)]
     // The generateHash process ends after computing "header A", as it's a terminal policy.
-    bool terminal = 21;
+    bool terminal = 4;
   }
 
   // Specifies a list of hash policies to use for ring hash load balancing. Each

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -540,8 +540,8 @@ message RouteAction {
 
     // Envoy supports two types of cookie affinity:
     //
-    // 1. Passive. Envoy takes a cookie that's present in the cookies header or
-    // the whole cookies header and hashes on the value.
+    // 1. Passive. Envoy takes a cookie that's present in the cookies header and
+    //    hashes on its value.
     //
     // 2. Generated. Envoy generates and sets a cookie with an expiration (TTL)
     //    on the first request from the client in its response to the client,
@@ -553,11 +553,9 @@ message RouteAction {
     //    streams on the same connection will independently receive the same
     //    cookie, even if they arrive at the Envoy simultaneously.
     message Cookie {
-      // The name of the cookie that will be used to obtain the hash key.
-      // If the name is empty, hash on the cookies header, no hash will be
-      // produced if cookies header is empty.
-      // If the name is set but the cookie is not present and ttl below is
-      // not set, no hash will be produced.
+      // The name of the cookie that will be used to obtain the hash key. If the
+      // cookie is not present and ttl below is not set, no hash will be
+      // produced.
       string name = 1 [(validate.rules).string.min_bytes = 1];
 
       // If specified, a cookie with the TTL will be generated if the cookie is
@@ -575,15 +573,6 @@ message RouteAction {
       bool source_ip = 1;
     }
 
-    message QueryParameter {
-      // Hash on query parameter value.
-      string key = 1;
-    }
-
-    message HostPath {
-      // Hash on host and path value.
-    }
-
     oneof policy_specifier {
       option (validate.required) = true;
 
@@ -595,35 +584,33 @@ message RouteAction {
 
       // Connection properties hash policy.
       ConnectionProperties connection_properties = 3;
-
-      // Query parameter hash policy.
-      QueryParameter query_parameter = 4;
-
-      // Host path hash policy.
-      HostPath host_path = 5;
     }
+    // Reserve for new policy_specifier.
+    /* RESERVED */ reserved 4 to 20;
 
     // If true, and there is already a hash computed, ignore rest of the
     // list of hash polices.
-    // For example, if there are the following hash methods configured:
+    // For example, if the following hash methods are configured:
     //   [(specifier, terminal),...]
     //   [(Header A,    true),
     //    (Cookie B,    false),
     //    (Cookie C,    false)]
     // The generateHash process ends after computing "header A", as it's a terminal policy.
-    bool terminal = 6;
+    bool terminal = 21;
   }
 
   // Specifies a list of hash policies to use for ring hash load balancing. Each
   // hash policy is evaluated individually and the combined result is used to
   // route the request. The method of combination is deterministic such that
-  // identical lists of hash policies will produce the same hash.Since a hash
+  // identical lists of hash policies will produce the same hash. Since a hash
   // policy examines specific parts of a request, it can fail to produce a hash
   // (i.e. if the hashed header is not present). If (and only if) all configured
   // hash policies fail to generate a hash, no hash will be produced for
   // the route. In this case, the behavior is the same as if no hash policies
   // were specified (i.e. the ring hash load balancer will choose a random
-  // backend).
+  // backend). If a hash policy has the "terminal" attribute set to true, and
+  // there is already a hash generated, the hash is returned immediately,
+  // ignoring the rest of the hash policy list.
   repeated HashPolicy hash_policy = 15;
 
   // Indicates that a HTTP/1.1 client connection to this particular route is allowed to

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -81,7 +81,7 @@ public:
   HeaderHashMethod(const std::string& header_name, bool terminal)
       : header_name_(header_name), terminal_(terminal) {}
 
-  bool terminal() const { return terminal_; }
+  bool terminal() const override { return terminal_; }
 
   absl::optional<uint64_t> evaluate(const Network::Address::Instance*,
                                     const Http::HeaderMap& headers,
@@ -106,7 +106,7 @@ public:
                    const absl::optional<std::chrono::seconds>& ttl, bool terminal)
       : key_(key), path_(path), ttl_(ttl), terminal_(terminal) {}
 
-  bool terminal() const { return terminal_; }
+  bool terminal() const override { return terminal_; }
 
   absl::optional<uint64_t> evaluate(const Network::Address::Instance*,
                                     const Http::HeaderMap& headers,
@@ -142,7 +142,7 @@ class IpHashMethod : public HashPolicyImpl::HashMethod {
 public:
   IpHashMethod(bool terminal) : terminal_(terminal) {}
 
-  bool terminal() const { return terminal_; }
+  bool terminal() const override { return terminal_; }
 
   absl::optional<uint64_t> evaluate(const Network::Address::Instance* downstream_addr,
                                     const Http::HeaderMap&,

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -234,6 +234,7 @@ public:
     virtual absl::optional<uint64_t> evaluate(const Network::Address::Instance* downstream_addr,
                                               const Http::HeaderMap& headers,
                                               const AddCookieCallback add_cookie) const PURE;
+
     // If the method is a terminal method, ignore rest of the hash policy chain.
     virtual bool terminal() const PURE;
   };

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -234,6 +234,8 @@ public:
     virtual absl::optional<uint64_t> evaluate(const Network::Address::Instance* downstream_addr,
                                               const Http::HeaderMap& headers,
                                               const AddCookieCallback add_cookie) const PURE;
+    // If the method is a terminal method, ignore rest of the hash policy chain.
+    virtual bool terminal() const PURE;
   };
 
   typedef std::unique_ptr<HashMethod> HashMethodPtr;

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -1700,7 +1700,7 @@ TEST_F(RouterMatcherHashPolicyTest, HashMultiple) {
 }
 
 TEST_F(RouterMatcherHashPolicyTest, HashTerminal) {
-  // Hash pilicy list: cookie, header [terminal=true], user_ip.
+  // Hash policy list: cookie, header [terminal=true], user_ip.
   auto route = route_config_.mutable_virtual_hosts(0)->mutable_routes(0)->mutable_route();
   route->add_hash_policy()->mutable_cookie()->set_name("cookie_hash");
   auto* header_hash = route->add_hash_policy();
@@ -1738,6 +1738,7 @@ TEST_F(RouterMatcherHashPolicyTest, HashTerminal) {
   // If no hash computed after evaluating a hash policy, the rest of the policy
   // list is evaluated.
   {
+    // Input: {}, {}, address1. Hash on address1.
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
     hash_1 = route->routeEntry()
@@ -1746,6 +1747,7 @@ TEST_F(RouterMatcherHashPolicyTest, HashTerminal) {
                  .value();
   }
   {
+    // Input: {}, {}, address2. Hash on address2.
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
     hash_2 = route->routeEntry()

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -1348,9 +1348,9 @@ public:
     route_config_ = parseRouteConfigurationFromJson(json);
   }
 
-  envoy::api::v2::route::RouteAction_HashPolicy* getRouteHashPolicy(const uint32_t route_idx) {
+  envoy::api::v2::route::RouteAction_HashPolicy* firstRouteHashPolicy() {
     auto hash_policies = route_config_.mutable_virtual_hosts(0)
-                             ->mutable_routes(route_idx)
+                             ->mutable_routes(0)
                              ->mutable_route()
                              ->mutable_hash_policy();
     if (hash_policies->size() > 0) {
@@ -1358,12 +1358,6 @@ public:
     } else {
       return hash_policies->Add();
     }
-  }
-  envoy::api::v2::route::RouteAction_HashPolicy* firstRouteHashPolicy() {
-    return getRouteHashPolicy(0);
-  }
-  envoy::api::v2::route::RouteAction_HashPolicy* secondRouteHashPolicy() {
-    return getRouteHashPolicy(1);
   }
 
   ConfigImpl& config() {
@@ -1409,35 +1403,6 @@ public:
     firstRouteHashPolicy()->mutable_cookie()->set_name("hash");
   }
 };
-
-TEST_F(RouterMatcherCookieHashPolicyTest, EmptyKeyMatchesWholeCookieLine) {
-  // With no key specified, the whole cookie line is used.
-  firstRouteHashPolicy()->mutable_cookie()->set_name("");
-  {
-    // Nothing to hash on.
-    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
-    Router::RouteConstSharedPtr route = config().route(headers, 0);
-    EXPECT_FALSE(
-        route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie_nop_));
-  }
-  uint64_t hash_1;
-  uint64_t hash_2;
-  {
-    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
-    headers.addCopy("Cookie", "choco=late; su=gar");
-    Router::RouteConstSharedPtr route = config().route(headers, 0);
-    hash_1 =
-        route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie_nop_).value();
-  }
-  {
-    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
-    headers.addCopy("Cookie", "bluh=blur");
-    Router::RouteConstSharedPtr route = config().route(headers, 0);
-    hash_2 =
-        route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie_nop_).value();
-  }
-  EXPECT_NE(hash_1, hash_2);
-}
 
 TEST_F(RouterMatcherCookieHashPolicyTest, NoTtl) {
   {
@@ -1686,116 +1651,109 @@ TEST_F(RouterMatcherHashPolicyTest, HashIpv6DifferentAddresses) {
   }
 }
 
-TEST_F(RouterMatcherHashPolicyTest, QueryParameterHash) {
-  firstRouteHashPolicy()->mutable_query_parameter()->set_key("hash");
-  uint64_t hash_1;
-  uint64_t hash_2;
-  {
-    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo?hash=bluh", "GET");
-    const auto hash_policy = config().route(headers, 0)->routeEntry()->hashPolicy();
-    hash_1 = hash_policy->generateHash(nullptr, headers, add_cookie_nop_).value();
-  }
-  {
-    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo?hash=meh", "GET");
-    const auto hash_policy = config().route(headers, 0)->routeEntry()->hashPolicy();
-    hash_2 = hash_policy->generateHash(nullptr, headers, add_cookie_nop_).value();
-  }
-  EXPECT_NE(hash_1, hash_2);
-}
-
-TEST_F(RouterMatcherHashPolicyTest, QueryParameterHashNoSuchKey) {
-  Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo?hash=bluh&bluh=eh", "GET");
-
-  firstRouteHashPolicy()->mutable_query_parameter()->set_key("meh");
-  const auto hash_policy = config().route(headers, 0)->routeEntry()->hashPolicy();
-  EXPECT_FALSE(hash_policy->generateHash(nullptr, headers, add_cookie_nop_));
-}
-
-TEST_F(RouterMatcherHashPolicyTest, HostPathHash) {
-  firstRouteHashPolicy()->mutable_host_path()->default_instance();
-  secondRouteHashPolicy()->mutable_host_path()->default_instance();
-  uint64_t hash_1, hash_2;
-  {
-    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
-    const auto* hash_policy = config().route(headers, 0)->routeEntry()->hashPolicy();
-    hash_1 = hash_policy->generateHash(nullptr, headers, add_cookie_nop_).value();
-  }
-  {
-    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/bar", "GET");
-    const auto* hash_policy = config().route(headers, 0)->routeEntry()->hashPolicy();
-    hash_2 = hash_policy->generateHash(nullptr, headers, add_cookie_nop_).value();
-  }
-
-  EXPECT_NE(hash_1, hash_2);
-}
-
 TEST_F(RouterMatcherHashPolicyTest, HashMultiple) {
   auto route = route_config_.mutable_virtual_hosts(0)->mutable_routes(0)->mutable_route();
   route->add_hash_policy()->mutable_header()->set_header_name("foo_header");
   route->add_hash_policy()->mutable_connection_properties()->set_source_ip(true);
-  route->add_hash_policy()->mutable_host_path()->default_instance();
-  route->add_hash_policy()->mutable_query_parameter()->set_key("hash");
   Network::Address::Ipv4Instance address("4.3.2.1");
 
-  std::map<uint64_t, int> hash_by_count;
+  uint64_t hash_h, hash_ip, hash_both;
   {
-    // HostPath.
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
-    uint64_t h =
+    EXPECT_FALSE(
+        route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie_nop_));
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
+    headers.addCopy("foo_header", "bar");
+    Router::RouteConstSharedPtr route = config().route(headers, 0);
+    hash_h =
         route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie_nop_).value();
-    hash_by_count[h]++;
   }
   {
-    // HostPath and Header.
-    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
-    headers.addCopy("foo_header", "bar");
-    Router::RouteConstSharedPtr route = config().route(headers, 0);
-    uint64_t h =
-        route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie_nop_).value();
-    EXPECT_EQ(hash_by_count.end(), hash_by_count.find(h));
-    hash_by_count[h]++;
-  }
-  {
-    // HostPath and IP.
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
-    uint64_t h =
+    hash_ip =
         route->routeEntry()->hashPolicy()->generateHash(&address, headers, add_cookie_nop_).value();
-    EXPECT_EQ(hash_by_count.end(), hash_by_count.find(h));
-    hash_by_count[h]++;
   }
   {
-    // HostPath and Header and IP.
     Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
-    headers.addCopy("foo_header", "bar");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
-    uint64_t h =
-        route->routeEntry()->hashPolicy()->generateHash(&address, headers, add_cookie_nop_).value();
-    EXPECT_EQ(hash_by_count.end(), hash_by_count.find(h));
-    hash_by_count[h]++;
-  }
-
-  uint64_t hash_all;
-  {
-    // HostPath, Header, IP and QueryParams.
-    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo?hash=okey", "GET");
     headers.addCopy("foo_header", "bar");
-    Router::RouteConstSharedPtr route = config().route(headers, 0);
-    hash_all =
+    hash_both =
         route->routeEntry()->hashPolicy()->generateHash(&address, headers, add_cookie_nop_).value();
-    EXPECT_EQ(hash_by_count.end(), hash_by_count.find(hash_all));
   }
   {
-    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo?hash=okey", "GET");
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
     Router::RouteConstSharedPtr route = config().route(headers, 0);
     headers.addCopy("foo_header", "bar");
     // stability
-    EXPECT_EQ(hash_all, route->routeEntry()
-                            ->hashPolicy()
-                            ->generateHash(&address, headers, add_cookie_nop_)
-                            .value());
+    EXPECT_EQ(hash_both, route->routeEntry()
+                             ->hashPolicy()
+                             ->generateHash(&address, headers, add_cookie_nop_)
+                             .value());
   }
+  EXPECT_NE(hash_ip, hash_h);
+  EXPECT_NE(hash_ip, hash_both);
+  EXPECT_NE(hash_h, hash_both);
+}
+
+TEST_F(RouterMatcherHashPolicyTest, HashTerminal) {
+  // Hash pilicy list: cookie, header [terminal=true], user_ip.
+  auto route = route_config_.mutable_virtual_hosts(0)->mutable_routes(0)->mutable_route();
+  route->add_hash_policy()->mutable_cookie()->set_name("cookie_hash");
+  auto* header_hash = route->add_hash_policy();
+  header_hash->mutable_header()->set_header_name("foo_header");
+  header_hash->set_terminal(true);
+  route->add_hash_policy()->mutable_connection_properties()->set_source_ip(true);
+  Network::Address::Ipv4Instance address1("4.3.2.1");
+  Network::Address::Ipv4Instance address2("1.2.3.4");
+
+  uint64_t hash_1, hash_2;
+  // Test terminal works when there is hash computed, the rest of the policy
+  // list is ignored.
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
+    headers.addCopy("Cookie", "cookie_hash=foo;");
+    headers.addCopy("foo_header", "bar");
+    Router::RouteConstSharedPtr route = config().route(headers, 0);
+    hash_1 = route->routeEntry()
+                 ->hashPolicy()
+                 ->generateHash(&address1, headers, add_cookie_nop_)
+                 .value();
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
+    headers.addCopy("Cookie", "cookie_hash=foo;");
+    headers.addCopy("foo_header", "bar");
+    Router::RouteConstSharedPtr route = config().route(headers, 0);
+    hash_2 = route->routeEntry()
+                 ->hashPolicy()
+                 ->generateHash(&address2, headers, add_cookie_nop_)
+                 .value();
+  }
+  EXPECT_EQ(hash_1, hash_2);
+
+  // If no hash computed after evaluating a hash policy, the rest of the policy
+  // list is evaluated.
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
+    Router::RouteConstSharedPtr route = config().route(headers, 0);
+    hash_1 = route->routeEntry()
+                 ->hashPolicy()
+                 ->generateHash(&address1, headers, add_cookie_nop_)
+                 .value();
+  }
+  {
+    Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
+    Router::RouteConstSharedPtr route = config().route(headers, 0);
+    hash_2 = route->routeEntry()
+                 ->hashPolicy()
+                 ->generateHash(&address2, headers, add_cookie_nop_)
+                 .value();
+  }
+  EXPECT_NE(hash_1, hash_2);
 }
 
 TEST_F(RouterMatcherHashPolicyTest, InvalidHashPolicies) {


### PR DESCRIPTION
Add a terminal attribute to request hash policy.

Think about a case where customers want to hash on a cookie if it's present but if it's not present, do best-effort sticky based on something like IP so the customer has a stable hash. 

This "terminal"  allows request hashing to have the ability of "if A not working, fallback to B.", which also saves time to generate the hash.  

Changes:
    * Add a terminal attribute to HashMethod, which shortcircuit the hash generating process if a policy is marked terminal and there is a hash computed already.

Signed-off-by: Xin Zhuang <stevenzzz@google.com>

*Description*: Add terminal attribute to request hash.
*Risk Level*: Low
*Testing*:  unit tests.
[Optional Fixes #Issue]
[Optional *Deprecated*:]
