### PR TITLE
Revert ac0bd74f6f9716e3a44d1412f795317c30ca770a

### DIFF
--- a/api/envoy/config/filter/accesslog/v2/accesslog.proto
+++ b/api/envoy/config/filter/accesslog/v2/accesslog.proto
@@ -162,6 +162,6 @@ message ResponseFlagFilter {
   // This field is optional. If it is not specified, then any response flag will pass
   // the filter check.
   repeated string flags = 1 [(validate.rules).repeated .items.string = {
-    in: ["LH", "UH", "UT", "LR", "UR", "UF", "UC", "UO", "NR", "DI", "FI", "RL", "UAEX", "RLSE"]
+    in: ["LH", "UH", "UT", "LR", "UR", "UF", "UC", "UO", "NR", "DI", "FI", "RL", "UAEX"]
   }];
 }

--- a/api/envoy/config/filter/accesslog/v2/accesslog.proto
+++ b/api/envoy/config/filter/accesslog/v2/accesslog.proto
@@ -162,6 +162,6 @@ message ResponseFlagFilter {
   // This field is optional. If it is not specified, then any response flag will pass
   // the filter check.
   repeated string flags = 1 [(validate.rules).repeated .items.string = {
-    in: ["LH", "UH", "UT", "LR", "UR", "UF", "UC", "UO", "NR", "DI", "FI", "RL", "UAEX"]
+    in: ["LH", "UH", "UT", "LR", "UR", "UF", "UC", "UO", "NR", "DI", "FI", "RL", "UAEX", "RLSE"]
   }];
 }

--- a/api/envoy/config/filter/http/rate_limit/v2/rate_limit.proto
+++ b/api/envoy/config/filter/http/rate_limit/v2/rate_limit.proto
@@ -35,6 +35,7 @@ message RateLimit {
   // set, this defaults to 20ms.
   google.protobuf.Duration timeout = 4 [(gogoproto.stdduration) = true];
 
+  // [#not-implemented-hide:] Hide from docs.
   // The filter's behaviour in case the rate limiting service does
   // not respond back. When it is set to true, Envoy will not allow traffic in case of
   // communication failure between rate limiting service and the proxy.

--- a/api/envoy/config/filter/network/rate_limit/v2/rate_limit.proto
+++ b/api/envoy/config/filter/network/rate_limit/v2/rate_limit.proto
@@ -27,6 +27,7 @@ message RateLimit {
   // set, this defaults to 20ms.
   google.protobuf.Duration timeout = 4 [(gogoproto.stdduration) = true];
 
+  // [#not-implemented-hide:] Hide from docs.
   // The filter's behaviour in case the rate limiting service does
   // not respond back. When it is set to true, Envoy will not allow traffic in case of
   // communication failure between rate limiting service and the proxy.

--- a/api/envoy/data/accesslog/v2/accesslog.proto
+++ b/api/envoy/data/accesslog/v2/accesslog.proto
@@ -185,6 +185,7 @@ message ResponseFlags {
   // Indicates if the request was deemed unauthorized and the reason for it.
   Unauthorized unauthorized_details = 13;
 
+  // [#not-implemented-hide:] Hide from docs.
   // Indicates that the request was rejected because there was an error in rate limit service.
   bool rate_limit_service_error = 14;
 }

--- a/docs/root/configuration/http_filters/rate_limit_filter.rst
+++ b/docs/root/configuration/http_filters/rate_limit_filter.rst
@@ -16,9 +16,6 @@ apply to a request. Each configuration results in a descriptor being sent to the
 If the rate limit service is called, and the response for any of the descriptors is over limit, a
 429 response is returned.
 
-If there is an error in calling rate limit service or rate limit service returns an error and :ref:`failure_mode_deny <envoy_api_msg_config.filter.http.rate_limit.v2.RateLimit>` is 
-set to true, a 500 response is returned.
-
 .. _config_http_filters_rate_limit_composing_actions:
 
 Composing Actions
@@ -111,8 +108,6 @@ The buffer filter outputs statistics in the *cluster.<route target cluster>.rate
   ok, Counter, Total under limit responses from the rate limit service
   error, Counter, Total errors contacting the rate limit service
   over_limit, Counter, total over limit responses from the rate limit service
-  failure_mode_allowed, Counter, "Total requests that were error(s) but were allowed through because
-  of :ref:`failure_mode_deny <envoy_api_msg_config.filter.http.rate_limit.v2.RateLimit>` set to false."
 
 Runtime
 -------

--- a/docs/root/configuration/network_filters/rate_limit_filter.rst
+++ b/docs/root/configuration/network_filters/rate_limit_filter.rst
@@ -25,8 +25,6 @@ following statistics:
   ok, Counter, Total under limit responses from the rate limit service
   cx_closed, Counter, Total connections closed due to an over limit response from the rate limit service
   active, Gauge, Total active requests to the rate limit service
-  failure_mode_allowed, Counter, "Total requests that were error(s) but were allowed through because
-  of :ref:`failure_mode_deny <envoy_api_msg_config.filter.http.rate_limit.v2.RateLimit>` set to false."
 
 Runtime
 -------

--- a/include/envoy/request_info/request_info.h
+++ b/include/envoy/request_info/request_info.h
@@ -48,10 +48,8 @@ enum ResponseFlag {
   RateLimited = 0x800,
   // Request was unauthorized by external authorization service.
   UnauthorizedExternalService = 0x1000,
-  // Unable to call Ratelimit service.
-  RateLimitServiceError = 0x2000,
   // ATTENTION: MAKE SURE THIS REMAINS EQUAL TO THE LAST FLAG.
-  LastFlag = RateLimitServiceError
+  LastFlag = UnauthorizedExternalService
 };
 
 /**

--- a/source/common/request_info/utility.cc
+++ b/source/common/request_info/utility.cc
@@ -19,7 +19,6 @@ const std::string ResponseFlagUtils::DELAY_INJECTED = "DI";
 const std::string ResponseFlagUtils::FAULT_INJECTED = "FI";
 const std::string ResponseFlagUtils::RATE_LIMITED = "RL";
 const std::string ResponseFlagUtils::UNAUTHORIZED_EXTERNAL_SERVICE = "UAEX";
-const std::string ResponseFlagUtils::RATELIMIT_SERVICE_ERROR = "RLSE";
 
 void ResponseFlagUtils::appendString(std::string& result, const std::string& append) {
   if (result.empty()) {
@@ -32,7 +31,7 @@ void ResponseFlagUtils::appendString(std::string& result, const std::string& app
 const std::string ResponseFlagUtils::toShortString(const RequestInfo& request_info) {
   std::string result;
 
-  static_assert(ResponseFlag::LastFlag == 0x2000, "A flag has been added. Fix this code.");
+  static_assert(ResponseFlag::LastFlag == 0x1000, "A flag has been added. Fix this code.");
 
   if (request_info.hasResponseFlag(ResponseFlag::FailedLocalHealthCheck)) {
     appendString(result, FAILED_LOCAL_HEALTH_CHECK);
@@ -86,10 +85,6 @@ const std::string ResponseFlagUtils::toShortString(const RequestInfo& request_in
     appendString(result, UNAUTHORIZED_EXTERNAL_SERVICE);
   }
 
-  if (request_info.hasResponseFlag(ResponseFlag::RateLimitServiceError)) {
-    appendString(result, RATELIMIT_SERVICE_ERROR);
-  }
-
   return result.empty() ? NONE : result;
 }
 
@@ -109,7 +104,6 @@ absl::optional<ResponseFlag> ResponseFlagUtils::toResponseFlag(const std::string
       {ResponseFlagUtils::FAULT_INJECTED, ResponseFlag::FaultInjected},
       {ResponseFlagUtils::RATE_LIMITED, ResponseFlag::RateLimited},
       {ResponseFlagUtils::UNAUTHORIZED_EXTERNAL_SERVICE, ResponseFlag::UnauthorizedExternalService},
-      {ResponseFlagUtils::RATELIMIT_SERVICE_ERROR, ResponseFlag::RateLimitServiceError},
   };
   const auto& it = map.find(flag);
   if (it != map.end()) {

--- a/source/common/request_info/utility.h
+++ b/source/common/request_info/utility.h
@@ -34,7 +34,6 @@ private:
   const static std::string FAULT_INJECTED;
   const static std::string RATE_LIMITED;
   const static std::string UNAUTHORIZED_EXTERNAL_SERVICE;
-  const static std::string RATELIMIT_SERVICE_ERROR;
 };
 
 /**

--- a/source/extensions/access_loggers/http_grpc/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/http_grpc/grpc_access_log_impl.cc
@@ -85,7 +85,7 @@ void HttpGrpcAccessLog::responseFlagsToAccessLogResponseFlags(
     envoy::data::accesslog::v2::AccessLogCommon& common_access_log,
     const RequestInfo::RequestInfo& request_info) {
 
-  static_assert(RequestInfo::ResponseFlag::LastFlag == 0x2000,
+  static_assert(RequestInfo::ResponseFlag::LastFlag == 0x1000,
                 "A flag has been added. Fix this code.");
 
   if (request_info.hasResponseFlag(RequestInfo::ResponseFlag::FailedLocalHealthCheck)) {
@@ -140,10 +140,6 @@ void HttpGrpcAccessLog::responseFlagsToAccessLogResponseFlags(
     common_access_log.mutable_response_flags()->mutable_unauthorized_details()->set_reason(
         envoy::data::accesslog::v2::ResponseFlags_Unauthorized_Reason::
             ResponseFlags_Unauthorized_Reason_EXTERNAL_SERVICE);
-  }
-
-  if (request_info.hasResponseFlag(RequestInfo::ResponseFlag::RateLimitServiceError)) {
-    common_access_log.mutable_response_flags()->set_rate_limit_service_error(true);
   }
 }
 

--- a/source/extensions/filters/http/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit.cc
@@ -147,15 +147,6 @@ void Filter::complete(RateLimit::LimitStatus status, Http::HeaderMapPtr&& header
     callbacks_->sendLocalReply(Http::Code::TooManyRequests, "",
                                [this](Http::HeaderMap& headers) { addHeaders(headers); });
     callbacks_->requestInfo().setResponseFlag(RequestInfo::ResponseFlag::RateLimited);
-  } else if (status == RateLimit::LimitStatus::Error) {
-    if (config_->failureModeAllow()) {
-      cluster_->statsScope().counter("ratelimit.failure_mode_allowed").inc();
-      callbacks_->continueDecoding();
-    } else {
-      state_ = State::Responded;
-      callbacks_->sendLocalReply(Http::Code::InternalServerError, "", nullptr);
-      callbacks_->requestInfo().setResponseFlag(RequestInfo::ResponseFlag::RateLimitServiceError);
-    }
   } else if (!initiating_call_) {
     callbacks_->continueDecoding();
   }

--- a/source/extensions/filters/http/ratelimit/ratelimit.h
+++ b/source/extensions/filters/http/ratelimit/ratelimit.h
@@ -37,8 +37,8 @@ public:
       : domain_(config.domain()), stage_(static_cast<uint64_t>(config.stage())),
         request_type_(config.request_type().empty() ? stringToType("both")
                                                     : stringToType(config.request_type())),
-        local_info_(local_info), scope_(scope), runtime_(runtime), cm_(cm),
-        failure_mode_deny_(config.failure_mode_deny()) {}
+        local_info_(local_info), scope_(scope), runtime_(runtime), cm_(cm) {}
+
   const std::string& domain() const { return domain_; }
   const LocalInfo::LocalInfo& localInfo() const { return local_info_; }
   uint64_t stage() const { return stage_; }
@@ -46,8 +46,6 @@ public:
   Stats::Scope& scope() { return scope_; }
   Upstream::ClusterManager& cm() { return cm_; }
   FilterRequestType requestType() const { return request_type_; }
-
-  bool failureModeAllow() const { return !failure_mode_deny_; }
 
 private:
   static FilterRequestType stringToType(const std::string& request_type) {
@@ -68,7 +66,6 @@ private:
   Stats::Scope& scope_;
   Runtime::Loader& runtime_;
   Upstream::ClusterManager& cm_;
-  const bool failure_mode_deny_;
 };
 
 typedef std::shared_ptr<FilterConfig> FilterConfigSharedPtr;

--- a/source/extensions/filters/network/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/ratelimit/ratelimit.h
@@ -27,7 +27,6 @@ namespace RateLimitFilter {
   COUNTER(error)                                                                                   \
   COUNTER(over_limit)                                                                              \
   COUNTER(ok)                                                                                      \
-  COUNTER(failure_mode_allowed)                                                                    \
   COUNTER(cx_closed)                                                                               \
   GAUGE  (active)
 // clang-format on
@@ -50,7 +49,6 @@ public:
   const std::vector<RateLimit::Descriptor>& descriptors() { return descriptors_; }
   Runtime::Loader& runtime() { return runtime_; }
   const InstanceStats& stats() { return stats_; }
-  bool failureModeAllow() const { return !failure_mode_deny_; };
 
 private:
   static InstanceStats generateStats(const std::string& name, Stats::Scope& scope);
@@ -59,7 +57,6 @@ private:
   std::vector<RateLimit::Descriptor> descriptors_;
   const InstanceStats stats_;
   Runtime::Loader& runtime_;
-  const bool failure_mode_deny_;
 };
 
 typedef std::shared_ptr<Config> ConfigSharedPtr;

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -813,12 +813,11 @@ filter:
       - FI
       - RL
       - UAEX
-      - RLSE
 config:
   path: /dev/null
   )EOF";
 
-  static_assert(RequestInfo::ResponseFlag::LastFlag == 0x2000,
+  static_assert(RequestInfo::ResponseFlag::LastFlag == 0x1000,
                 "A flag has been added. Fix this code.");
 
   std::vector<RequestInfo::ResponseFlag> all_response_flags = {
@@ -835,7 +834,6 @@ config:
       RequestInfo::ResponseFlag::FaultInjected,
       RequestInfo::ResponseFlag::RateLimited,
       RequestInfo::ResponseFlag::UnauthorizedExternalService,
-      RequestInfo::ResponseFlag::RateLimitServiceError,
   };
 
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV2Yaml(yaml), context_);
@@ -865,7 +863,7 @@ config:
       "Proto constraint validation failed (AccessLogFilterValidationError.ResponseFlagFilter: "
       "[\"embedded message failed validation\"] | caused by "
       "ResponseFlagFilterValidationError.Flags[i]: [\"value must be in list \" [\"LH\" \"UH\" "
-      "\"UT\" \"LR\" \"UR\" \"UF\" \"UC\" \"UO\" \"NR\" \"DI\" \"FI\" \"RL\" \"UAEX\" \"RLSE\"]]): "
+      "\"UT\" \"LR\" \"UR\" \"UF\" \"UC\" \"UO\" \"NR\" \"DI\" \"FI\" \"RL\" \"UAEX\"]]): "
       "response_flag_filter {\n  flags: \"UnsupportedFlag\"\n}\n");
 }
 

--- a/test/common/request_info/utility_test.cc
+++ b/test/common/request_info/utility_test.cc
@@ -14,7 +14,7 @@ namespace Envoy {
 namespace RequestInfo {
 
 TEST(ResponseFlagUtilsTest, toShortStringConversion) {
-  static_assert(ResponseFlag::LastFlag == 0x2000, "A flag has been added. Fix this code.");
+  static_assert(ResponseFlag::LastFlag == 0x1000, "A flag has been added. Fix this code.");
 
   std::vector<std::pair<ResponseFlag, std::string>> expected = {
       std::make_pair(ResponseFlag::FailedLocalHealthCheck, "LH"),
@@ -30,7 +30,6 @@ TEST(ResponseFlagUtilsTest, toShortStringConversion) {
       std::make_pair(ResponseFlag::FaultInjected, "FI"),
       std::make_pair(ResponseFlag::RateLimited, "RL"),
       std::make_pair(ResponseFlag::UnauthorizedExternalService, "UAEX"),
-      std::make_pair(ResponseFlag::RateLimitServiceError, "RLSE"),
   };
 
   for (const auto& test_case : expected) {
@@ -59,7 +58,7 @@ TEST(ResponseFlagUtilsTest, toShortStringConversion) {
 }
 
 TEST(ResponseFlagsUtilsTest, toResponseFlagConversion) {
-  static_assert(ResponseFlag::LastFlag == 0x2000, "A flag has been added. Fix this code.");
+  static_assert(ResponseFlag::LastFlag == 0x1000, "A flag has been added. Fix this code.");
 
   std::vector<std::pair<std::string, ResponseFlag>> expected = {
       std::make_pair("LH", ResponseFlag::FailedLocalHealthCheck),
@@ -75,7 +74,6 @@ TEST(ResponseFlagsUtilsTest, toResponseFlagConversion) {
       std::make_pair("FI", ResponseFlag::FaultInjected),
       std::make_pair("RL", ResponseFlag::RateLimited),
       std::make_pair("UAEX", ResponseFlag::UnauthorizedExternalService),
-      std::make_pair("RLSE", ResponseFlag::RateLimitServiceError),
   };
 
   EXPECT_FALSE(ResponseFlagUtils::toResponseFlag("NonExistentFlag").has_value());

--- a/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
@@ -434,7 +434,6 @@ TEST(responseFlagsToAccessLogResponseFlagsTest, All) {
   common_access_log_expected.mutable_response_flags()->mutable_unauthorized_details()->set_reason(
       envoy::data::accesslog::v2::ResponseFlags_Unauthorized_Reason::
           ResponseFlags_Unauthorized_Reason_EXTERNAL_SERVICE);
-  common_access_log_expected.mutable_response_flags()->set_rate_limit_service_error(true);
 
   EXPECT_EQ(common_access_log_expected.DebugString(), common_access_log.DebugString());
 }

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -46,10 +46,10 @@ public:
         .WillByDefault(Return(true));
   }
 
-  void SetUpTest(const std::string& yaml) {
+  void SetUpTest(const std::string json) {
+    Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json);
     envoy::config::filter::http::rate_limit::v2::RateLimit proto_config{};
-    MessageUtil::loadFromYaml(yaml, proto_config);
-
+    Config::FilterJson::translateHttpRateLimitFilter(*json_config, proto_config);
     config_.reset(new FilterConfig(proto_config, local_info_, stats_store_, runtime_, cm_));
 
     client_ = new RateLimit::MockClient();
@@ -64,13 +64,10 @@ public:
         .emplace_back(vh_rate_limit_);
   }
 
-  const std::string fail_close_config_ = R"EOF(
-  domain: foo
-  failure_mode_deny: true
-  )EOF";
-
   const std::string filter_config_ = R"EOF(
-  domain: foo
+  {
+    "domain": "foo"
+  }
   )EOF";
 
   FilterConfigSharedPtr config_;
@@ -331,37 +328,6 @@ TEST_F(HttpRateLimitFilterTest, ErrorResponse) {
   EXPECT_EQ(
       1U,
       cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("ratelimit.error").value());
-  EXPECT_EQ(1U, cm_.thread_local_cluster_.cluster_.info_->stats_store_
-                    .counter("ratelimit.failure_mode_allowed")
-                    .value());
-}
-
-TEST_F(HttpRateLimitFilterTest, ErrorResponseWithFailureModeAllowOff) {
-  SetUpTest(fail_close_config_);
-  InSequence s;
-
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
-      .WillOnce(SetArgReferee<1>(descriptor_));
-  EXPECT_CALL(*client_, limit(_, _, _, _))
-      .WillOnce(WithArgs<0>(Invoke([&](RateLimit::RequestCallbacks& callbacks) -> void {
-        request_callbacks_ = &callbacks;
-      })));
-
-  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
-            filter_->decodeHeaders(request_headers_, false));
-
-  request_callbacks_->complete(RateLimit::LimitStatus::Error, nullptr);
-
-  EXPECT_CALL(filter_callbacks_.request_info_,
-              setResponseFlag(RequestInfo::ResponseFlag::RateLimitServiceError))
-      .Times(0);
-
-  EXPECT_EQ(
-      1U,
-      cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("ratelimit.error").value());
-  EXPECT_EQ(0U, cm_.thread_local_cluster_.cluster_.info_->stats_store_
-                    .counter("ratelimit.failure_mode_allowed")
-                    .value());
 }
 
 TEST_F(HttpRateLimitFilterTest, LimitResponse) {

--- a/test/extensions/filters/network/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/ratelimit/ratelimit_test.cc
@@ -33,16 +33,26 @@ namespace RateLimitFilter {
 
 class RateLimitFilterTest : public testing::Test {
 public:
-  RateLimitFilterTest() {}
+  RateLimitFilterTest() {
+    std::string json = R"EOF(
+    {
+      "domain": "foo",
+      "descriptors": [
+         [{"key": "hello", "value": "world"}, {"key": "foo", "value": "bar"}],
+         [{"key": "foo2", "value": "bar2"}]
+       ],
+       "stat_prefix": "name"
+    }
+    )EOF";
 
-  void SetUpTest(const std::string& yaml) {
     ON_CALL(runtime_.snapshot_, featureEnabled("ratelimit.tcp_filter_enabled", 100))
         .WillByDefault(Return(true));
     ON_CALL(runtime_.snapshot_, featureEnabled("ratelimit.tcp_filter_enforcing", 100))
         .WillByDefault(Return(true));
 
+    Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json);
     envoy::config::filter::network::rate_limit::v2::RateLimit proto_config{};
-    MessageUtil::loadFromYaml(yaml, proto_config);
+    Envoy::Config::FilterJson::translateTcpRateLimitFilter(*json_config, proto_config);
     config_.reset(new Config(proto_config, stats_store_, runtime_));
     client_ = new RateLimit::MockClient();
     filter_.reset(new Filter(config_, RateLimit::ClientPtr{client_}));
@@ -58,35 +68,6 @@ public:
       EXPECT_EQ(0U, gauge->value());
     }
   }
-
-  const std::string filter_config_ = R"EOF(
-domain: foo
-descriptors:
-- entries:
-   - key: hello
-     value: world
-   - key: foo
-     value: bar
-- entries:
-   - key: foo2
-     value: bar2
-stat_prefix: name
-)EOF";
-
-  const std::string fail_close_config_ = R"EOF(
-domain: foo
-descriptors:
-- entries:
-   - key: hello
-     value: world
-   - key: foo
-     value: bar
-- entries:
-   - key: foo2
-     value: bar2
-stat_prefix: name
-failure_mode_deny: true
-)EOF";
 
   Stats::IsolatedStoreImpl stats_store_;
   NiceMock<Runtime::MockLoader> runtime_;
@@ -116,7 +97,6 @@ TEST_F(RateLimitFilterTest, BadRatelimitConfig) {
 
 TEST_F(RateLimitFilterTest, OK) {
   InSequence s;
-  SetUpTest(filter_config_);
 
   EXPECT_CALL(*client_, limit(_, "foo",
                               testing::ContainerEq(std::vector<RateLimit::Descriptor>{
@@ -145,7 +125,6 @@ TEST_F(RateLimitFilterTest, OK) {
 
 TEST_F(RateLimitFilterTest, OverLimit) {
   InSequence s;
-  SetUpTest(filter_config_);
 
   EXPECT_CALL(*client_, limit(_, "foo", _, _))
       .WillOnce(WithArgs<0>(Invoke([&](RateLimit::RequestCallbacks& callbacks) -> void {
@@ -169,7 +148,6 @@ TEST_F(RateLimitFilterTest, OverLimit) {
 
 TEST_F(RateLimitFilterTest, OverLimitNotEnforcing) {
   InSequence s;
-  SetUpTest(filter_config_);
 
   EXPECT_CALL(*client_, limit(_, "foo", _, _))
       .WillOnce(WithArgs<0>(Invoke([&](RateLimit::RequestCallbacks& callbacks) -> void {
@@ -196,7 +174,6 @@ TEST_F(RateLimitFilterTest, OverLimitNotEnforcing) {
 
 TEST_F(RateLimitFilterTest, Error) {
   InSequence s;
-  SetUpTest(filter_config_);
 
   EXPECT_CALL(*client_, limit(_, "foo", _, _))
       .WillOnce(WithArgs<0>(Invoke([&](RateLimit::RequestCallbacks& callbacks) -> void {
@@ -217,12 +194,10 @@ TEST_F(RateLimitFilterTest, Error) {
 
   EXPECT_EQ(1U, stats_store_.counter("ratelimit.name.total").value());
   EXPECT_EQ(1U, stats_store_.counter("ratelimit.name.error").value());
-  EXPECT_EQ(1U, stats_store_.counter("ratelimit.name.failure_mode_allowed").value());
 }
 
 TEST_F(RateLimitFilterTest, Disconnect) {
   InSequence s;
-  SetUpTest(filter_config_);
 
   EXPECT_CALL(*client_, limit(_, "foo", _, _))
       .WillOnce(WithArgs<0>(Invoke([&](RateLimit::RequestCallbacks& callbacks) -> void {
@@ -241,7 +216,6 @@ TEST_F(RateLimitFilterTest, Disconnect) {
 
 TEST_F(RateLimitFilterTest, ImmediateOK) {
   InSequence s;
-  SetUpTest(filter_config_);
 
   EXPECT_CALL(filter_callbacks_, continueReading()).Times(0);
   EXPECT_CALL(*client_, limit(_, "foo", _, _))
@@ -263,7 +237,6 @@ TEST_F(RateLimitFilterTest, ImmediateOK) {
 
 TEST_F(RateLimitFilterTest, RuntimeDisable) {
   InSequence s;
-  SetUpTest(filter_config_);
 
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("ratelimit.tcp_filter_enabled", 100))
       .WillOnce(Return(false));
@@ -272,30 +245,6 @@ TEST_F(RateLimitFilterTest, RuntimeDisable) {
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data, false));
-}
-
-TEST_F(RateLimitFilterTest, ErrorResponseWithFailureModeAllowOff) {
-  InSequence s;
-  SetUpTest(fail_close_config_);
-
-  EXPECT_CALL(*client_, limit(_, "foo", _, _))
-      .WillOnce(WithArgs<0>(Invoke([&](RateLimit::RequestCallbacks& callbacks) -> void {
-        request_callbacks_ = &callbacks;
-      })));
-
-  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
-  Buffer::OwnedImpl data("hello");
-  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data, false));
-  request_callbacks_->complete(RateLimit::LimitStatus::Error, nullptr);
-
-  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data, false));
-
-  EXPECT_CALL(*client_, cancel()).Times(0);
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
-
-  EXPECT_EQ(1U, stats_store_.counter("ratelimit.name.total").value());
-  EXPECT_EQ(1U, stats_store_.counter("ratelimit.name.error").value());
-  EXPECT_EQ(0U, stats_store_.counter("ratelimit.name.failure_mode_allowed").value());
 }
 
 } // namespace RateLimitFilter

--- a/test/integration/ratelimit_integration_test.cc
+++ b/test/integration/ratelimit_integration_test.cc
@@ -44,14 +44,8 @@ public:
   }
 
   void initialize() override {
-    if (failure_mode_deny_) {
-      config_helper_.addFilter("{ name: envoy.rate_limit, config: { domain: some_domain, "
-                               "failure_mode_deny: true, timeout: 0.5s } }");
-
-    } else {
-      config_helper_.addFilter(
-          "{ name: envoy.rate_limit, config: { domain: some_domain, timeout: 0.5s } }");
-    }
+    config_helper_.addFilter(
+        "{ name: envoy.rate_limit, config: { domain: some_domain, timeout: 0.5s } }");
     config_helper_.addConfigModifier([this](envoy::config::bootstrap::v2::Bootstrap& bootstrap) {
       auto* ratelimit_cluster = bootstrap.mutable_static_resources()->add_clusters();
       ratelimit_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
@@ -182,18 +176,9 @@ public:
 
   const uint64_t request_size_ = 1024;
   const uint64_t response_size_ = 512;
-  bool failure_mode_deny_ = false;
-};
-
-// Test that verifies failure mode cases.
-class RatelimitFailureModeIntegrationTest : public RatelimitIntegrationTest {
-public:
-  RatelimitFailureModeIntegrationTest() { failure_mode_deny_ = true; }
 };
 
 INSTANTIATE_TEST_CASE_P(IpVersionsClientType, RatelimitIntegrationTest,
-                        RATELIMIT_GRPC_CLIENT_INTEGRATION_PARAMS);
-INSTANTIATE_TEST_CASE_P(IpVersionsClientType, RatelimitFailureModeIntegrationTest,
                         RATELIMIT_GRPC_CLIENT_INTEGRATION_PARAMS);
 
 TEST_P(RatelimitIntegrationTest, Ok) {
@@ -283,7 +268,6 @@ TEST_P(RatelimitIntegrationTest, Error) {
   EXPECT_EQ(nullptr, test_server_->counter("cluster.cluster_0.ratelimit.ok"));
   EXPECT_EQ(nullptr, test_server_->counter("cluster.cluster_0.ratelimit.over_limit"));
   EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.ratelimit.error")->value());
-  EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.ratelimit.failure_mode_allowed")->value());
 }
 
 TEST_P(RatelimitIntegrationTest, Timeout) {
@@ -330,20 +314,6 @@ TEST_P(RatelimitIntegrationTest, FailedConnect) {
   // Rate limiter fails open
   waitForSuccessfulUpstreamResponse();
   cleanup();
-}
-
-TEST_P(RatelimitFailureModeIntegrationTest, ErrorWithFailureModeOff) {
-  initiateClientConnection();
-  waitForRatelimitRequest();
-  ratelimit_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, true);
-  // Rate limiter fail closed
-  waitForFailedUpstreamResponse(500);
-  cleanup();
-
-  EXPECT_EQ(nullptr, test_server_->counter("cluster.cluster_0.ratelimit.ok"));
-  EXPECT_EQ(nullptr, test_server_->counter("cluster.cluster_0.ratelimit.over_limit"));
-  EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.ratelimit.error")->value());
-  EXPECT_EQ(nullptr, test_server_->counter("cluster.cluster_0.ratelimit.failure_mode_allowed"));
 }
 
 } // namespace


### PR DESCRIPTION
This reverts commit  ac0bd74f. But leaves the API changes as not implemented in order to not scramble the proto field.

#4073 had a bug. The cause has been identified, and a fix PR is forthcoming. However, in the meantime, we want to leave master clean.
