### PR TITLE
tcp-proxy: fixing a TCP proxy bug readDisabling a closed connection

### DIFF
--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -200,6 +200,12 @@ void Filter::readDisableUpstream(bool disable) {
 }
 
 void Filter::readDisableDownstream(bool disable) {
+  if (read_callbacks_->connection().state() != Network::Connection::State::Open) {
+    // During idle timeouts, we close both upstream and downstream with NoFlush.
+    // Envoy still does a best-effort flush which can case readDisableDownstream to be called
+    // despite the downstream connection being closed.
+    return;
+  }
   read_callbacks_->connection().readDisable(disable);
 
   if (disable) {


### PR DESCRIPTION
Fixing and regression testing #3639

*Risk Level*: Low: avoids a no-op call during connection teardown
*Testing*: verified flow in integration test, wrote a regression unit test
*Docs Changes*: n/a
*Release Notes*: n/a
Fixes  #3639