### PR TITLE
overload: add an file-based injected resource monitor

### DIFF
--- a/api/docs/BUILD
+++ b/api/docs/BUILD
@@ -58,6 +58,7 @@ proto_library(
         "//envoy/config/ratelimit/v2:rls",
         "//envoy/config/rbac/v2alpha:rbac",
         "//envoy/config/resource_monitor/fixed_heap/v2alpha:fixed_heap",
+        "//envoy/config/resource_monitor/injected_resource/v2alpha:injected_resource",
         "//envoy/config/trace/v2:trace",
         "//envoy/config/transport_socket/capture/v2alpha:capture",
         "//envoy/data/accesslog/v2:accesslog",

--- a/api/envoy/config/overload/v2alpha/overload.proto
+++ b/api/envoy/config/overload/v2alpha/overload.proto
@@ -21,6 +21,8 @@ message ResourceMonitor {
   //
   // * :ref:`envoy.resource_monitors.fixed_heap
   //   <envoy_api_msg_config.resource_monitor.fixed_heap.v2alpha.FixedHeapConfig>`
+  // * :ref:`envoy.resource_monitors.injected_resource
+  //   <envoy_api_msg_config.resource_monitor.injected_resource.v2alpha.InjectedResourceConfig>`
   string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // Configuration for the resource monitor being instantiated.

--- a/api/envoy/config/resource_monitor/injected_resource/v2alpha/BUILD
+++ b/api/envoy/config/resource_monitor/injected_resource/v2alpha/BUILD
@@ -1,0 +1,9 @@
+load("//bazel:api_build_system.bzl", "api_proto_library_internal")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library_internal(
+    name = "injected_resource",
+    srcs = ["injected_resource.proto"],
+    visibility = ["//visibility:public"],
+)

--- a/api/envoy/config/resource_monitor/injected_resource/v2alpha/injected_resource.proto
+++ b/api/envoy/config/resource_monitor/injected_resource/v2alpha/injected_resource.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package envoy.config.resource_monitor.injected_resource.v2alpha;
+option go_package = "v2alpha";
+
+import "validate/validate.proto";
+
+// [#protodoc-title: Injected resource]
+
+// The injected resource monitor allows injecting a synthetic resource pressure into Envoy
+// via a text file, which must contain a floating-point number in the range [0..1] representing
+// the resource pressure and be updated atomically by a symbolic link swap.
+// This is intended primarily for integration tests to force Envoy into an overloaded state.
+message InjectedResourceConfig {
+  string filename = 1 [(validate.rules).string.min_bytes = 1];
+}

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -107,6 +107,7 @@ PROTO_RST="
   /envoy/config/overload/v2alpha/overload/envoy/config/overload/v2alpha/overload.proto.rst
   /envoy/config/rbac/v2alpha/rbac/envoy/config/rbac/v2alpha/rbac.proto.rst
   /envoy/config/resource_monitor/fixed_heap/v2alpha/fixed_heap/envoy/config/resource_monitor/fixed_heap/v2alpha/fixed_heap.proto.rst
+  /envoy/config/resource_monitor/injected_resource/v2alpha/injected_resource/envoy/config/resource_monitor/injected_resource/v2alpha/injected_resource.proto.rst
   /envoy/config/transport_socket/capture/v2alpha/capture/envoy/config/transport_socket/capture/v2alpha/capture.proto.rst
   /envoy/data/accesslog/v2/accesslog/envoy/data/accesslog/v2/accesslog.proto.rst
   /envoy/data/core/v2alpha/health_check_event/envoy/data/core/v2alpha/health_check_event.proto.rst

--- a/include/envoy/server/resource_monitor.h
+++ b/include/envoy/server/resource_monitor.h
@@ -10,6 +10,10 @@ namespace Server {
 
 // Struct for reporting usage for a particular resource.
 struct ResourceUsage {
+  bool operator==(const ResourceUsage& rhs) const {
+    return resource_pressure_ == rhs.resource_pressure_;
+  }
+
   // Fraction of (resource usage)/(resource limit).
   double resource_pressure_;
 };

--- a/source/extensions/resource_monitors/injected_resource/BUILD
+++ b/source/extensions/resource_monitors/injected_resource/BUILD
@@ -1,0 +1,35 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "injected_resource_monitor",
+    srcs = ["injected_resource_monitor.cc"],
+    hdrs = ["injected_resource_monitor.h"],
+    deps = [
+        "//include/envoy/filesystem:filesystem_interface",
+        "//include/envoy/server:resource_monitor_config_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/filesystem:filesystem_lib",
+        "@envoy_api//envoy/config/resource_monitor/injected_resource/v2alpha:injected_resource_cc",
+    ],
+)
+
+envoy_cc_library(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    deps = [
+        ":injected_resource_monitor",
+        "//include/envoy/registry",
+        "//source/common/common:assert_lib",
+        "//source/extensions/resource_monitors:well_known_names",
+        "//source/extensions/resource_monitors/common:factory_base_lib",
+    ],
+)

--- a/source/extensions/resource_monitors/injected_resource/config.cc
+++ b/source/extensions/resource_monitors/injected_resource/config.cc
@@ -1,0 +1,31 @@
+#include "extensions/resource_monitors/injected_resource/config.h"
+
+#include "envoy/registry/registry.h"
+
+#include "common/protobuf/utility.h"
+
+#include "extensions/resource_monitors/injected_resource/injected_resource_monitor.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace ResourceMonitors {
+namespace InjectedResourceMonitor {
+
+Server::ResourceMonitorPtr InjectedResourceMonitorFactory::createResourceMonitorFromProtoTyped(
+    const envoy::config::resource_monitor::injected_resource::v2alpha::InjectedResourceConfig&
+        config,
+    Server::Configuration::ResourceMonitorFactoryContext& context) {
+  return std::make_unique<InjectedResourceMonitor>(config, context);
+}
+
+/**
+ * Static registration for the injected resource monitor factory. @see RegistryFactory.
+ */
+static Registry::RegisterFactory<InjectedResourceMonitorFactory,
+                                 Server::Configuration::ResourceMonitorFactory>
+    registered_;
+
+} // namespace InjectedResourceMonitor
+} // namespace ResourceMonitors
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/resource_monitors/injected_resource/config.h
+++ b/source/extensions/resource_monitors/injected_resource/config.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "envoy/config/resource_monitor/injected_resource/v2alpha/injected_resource.pb.validate.h"
+#include "envoy/server/resource_monitor_config.h"
+
+#include "extensions/resource_monitors/common/factory_base.h"
+#include "extensions/resource_monitors/well_known_names.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace ResourceMonitors {
+namespace InjectedResourceMonitor {
+
+class InjectedResourceMonitorFactory
+    : public Common::FactoryBase<
+          envoy::config::resource_monitor::injected_resource::v2alpha::InjectedResourceConfig> {
+public:
+  InjectedResourceMonitorFactory() : FactoryBase(ResourceMonitorNames::get().InjectedResource) {}
+
+private:
+  Server::ResourceMonitorPtr createResourceMonitorFromProtoTyped(
+      const envoy::config::resource_monitor::injected_resource::v2alpha::InjectedResourceConfig&
+          config,
+      Server::Configuration::ResourceMonitorFactoryContext& context) override;
+};
+
+} // namespace InjectedResourceMonitor
+} // namespace ResourceMonitors
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/resource_monitors/injected_resource/injected_resource_monitor.cc
+++ b/source/extensions/resource_monitors/injected_resource/injected_resource_monitor.cc
@@ -1,0 +1,54 @@
+#include "extensions/resource_monitors/injected_resource/injected_resource_monitor.h"
+
+#include "common/common/assert.h"
+#include "common/filesystem/filesystem_impl.h"
+
+#include "absl/strings/numbers.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace ResourceMonitors {
+namespace InjectedResourceMonitor {
+
+InjectedResourceMonitor::InjectedResourceMonitor(
+    const envoy::config::resource_monitor::injected_resource::v2alpha::InjectedResourceConfig&
+        config,
+    Server::Configuration::ResourceMonitorFactoryContext& context)
+    : filename_(config.filename()), file_changed_(true),
+      watcher_(context.dispatcher().createFilesystemWatcher()) {
+  watcher_->addWatch(filename_, Filesystem::Watcher::Events::MovedTo,
+                     [this](uint32_t) { onFileChanged(); });
+}
+
+void InjectedResourceMonitor::onFileChanged() { file_changed_ = true; }
+
+void InjectedResourceMonitor::updateResourceUsage(Server::ResourceMonitor::Callbacks& callbacks) {
+  if (file_changed_) {
+    file_changed_ = false;
+    try {
+      const std::string contents = Filesystem::fileReadToEnd(filename_);
+      double pressure;
+      if (absl::SimpleAtod(contents, &pressure)) {
+        pressure_ = pressure;
+        error_.reset();
+      } else {
+        throw EnvoyException("failed to parse injected resource pressure");
+      }
+    } catch (const EnvoyException& error) {
+      error_ = error;
+      pressure_.reset();
+    }
+  }
+
+  ASSERT(pressure_.has_value() != error_.has_value());
+  if (pressure_.has_value()) {
+    callbacks.onSuccess({.resource_pressure_ = *pressure_});
+  } else {
+    callbacks.onFailure(*error_);
+  }
+}
+
+} // namespace InjectedResourceMonitor
+} // namespace ResourceMonitors
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/resource_monitors/injected_resource/injected_resource_monitor.h
+++ b/source/extensions/resource_monitors/injected_resource/injected_resource_monitor.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "envoy/config/resource_monitor/injected_resource/v2alpha/injected_resource.pb.validate.h"
+#include "envoy/filesystem/filesystem.h"
+#include "envoy/server/resource_monitor.h"
+#include "envoy/server/resource_monitor_config.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace ResourceMonitors {
+namespace InjectedResourceMonitor {
+
+class InjectedResourceMonitor : public Server::ResourceMonitor {
+public:
+  InjectedResourceMonitor(
+      const envoy::config::resource_monitor::injected_resource::v2alpha::InjectedResourceConfig&
+          config,
+      Server::Configuration::ResourceMonitorFactoryContext& context);
+
+  // Server::ResourceMonitor
+  void updateResourceUsage(Server::ResourceMonitor::Callbacks& callbacks) override;
+
+protected:
+  virtual void onFileChanged();
+
+private:
+  const std::string filename_;
+  bool file_changed_;
+  Filesystem::WatcherPtr watcher_;
+  absl::optional<double> pressure_;
+  absl::optional<EnvoyException> error_;
+};
+
+} // namespace InjectedResourceMonitor
+} // namespace ResourceMonitors
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/resource_monitors/well_known_names.h
+++ b/source/extensions/resource_monitors/well_known_names.h
@@ -14,6 +14,9 @@ class ResourceMonitorNameValues {
 public:
   // Heap monitor with statically configured max.
   const std::string FixedHeap = "envoy.resource_monitors.fixed_heap";
+
+  // File-based injected resource monitor.
+  const std::string InjectedResource = "envoy.resource_monitors.injected_resource";
 };
 
 typedef ConstSingleton<ResourceMonitorNameValues> ResourceMonitorNames;

--- a/test/extensions/resource_monitors/injected_resource/BUILD
+++ b/test/extensions/resource_monitors/injected_resource/BUILD
@@ -1,0 +1,37 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_package",
+)
+load(
+    "//test/extensions:extensions_build_system.bzl",
+    "envoy_cc_test",
+)
+
+envoy_package()
+
+envoy_cc_test(
+    name = "injected_resource_monitor_test",
+    srcs = ["injected_resource_monitor_test.cc"],
+    deps = [
+        "//source/common/event:dispatcher_lib",
+        "//source/extensions/resource_monitors/injected_resource:injected_resource_monitor",
+        "//source/server:resource_monitor_config_lib",
+        "//test/test_common:environment_lib",
+        "//test/test_common:test_time_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "config_test",
+    srcs = ["config_test.cc"],
+    deps = [
+        "//include/envoy/registry",
+        "//source/common/event:dispatcher_lib",
+        "//source/extensions/resource_monitors/injected_resource:config",
+        "//source/server:resource_monitor_config_lib",
+        "//test/test_common:test_time_lib",
+        "@envoy_api//envoy/config/resource_monitor/injected_resource/v2alpha:injected_resource_cc",
+    ],
+)

--- a/test/extensions/resource_monitors/injected_resource/config_test.cc
+++ b/test/extensions/resource_monitors/injected_resource/config_test.cc
@@ -1,0 +1,37 @@
+#include "envoy/config/resource_monitor/injected_resource/v2alpha/injected_resource.pb.validate.h"
+#include "envoy/registry/registry.h"
+
+#include "common/event/dispatcher_impl.h"
+
+#include "server/resource_monitor_config_impl.h"
+
+#include "extensions/resource_monitors/injected_resource/config.h"
+
+#include "test/test_common/test_time.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace ResourceMonitors {
+namespace InjectedResourceMonitor {
+
+TEST(InjectedResourceMonitorFactoryTest, CreateMonitor) {
+  auto factory =
+      Registry::FactoryRegistry<Server::Configuration::ResourceMonitorFactory>::getFactory(
+          "envoy.resource_monitors.injected_resource");
+  EXPECT_NE(factory, nullptr);
+
+  envoy::config::resource_monitor::injected_resource::v2alpha::InjectedResourceConfig config;
+  config.set_filename("/config");
+  DangerousDeprecatedTestTime test_time;
+  Event::DispatcherImpl dispatcher(test_time.timeSource());
+  Server::Configuration::ResourceMonitorFactoryContextImpl context(dispatcher);
+  auto monitor = factory->createResourceMonitor(config, context);
+  EXPECT_NE(monitor, nullptr);
+}
+
+} // namespace InjectedResourceMonitor
+} // namespace ResourceMonitors
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
+++ b/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
@@ -1,0 +1,137 @@
+#include <cstdint>
+#include <fstream>
+
+#include "common/event/dispatcher_impl.h"
+
+#include "server/resource_monitor_config_impl.h"
+
+#include "extensions/resource_monitors/injected_resource/injected_resource_monitor.h"
+
+#include "test/test_common/environment.h"
+#include "test/test_common/test_time.h"
+
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::Property;
+
+namespace Envoy {
+namespace Extensions {
+namespace ResourceMonitors {
+namespace InjectedResourceMonitor {
+
+class TestableInjectedResourceMonitor : public InjectedResourceMonitor {
+public:
+  TestableInjectedResourceMonitor(
+      const envoy::config::resource_monitor::injected_resource::v2alpha::InjectedResourceConfig&
+          config,
+      Server::Configuration::ResourceMonitorFactoryContext& context)
+      : InjectedResourceMonitor(config, context), dispatcher_(context.dispatcher()) {}
+
+protected:
+  void onFileChanged() override {
+    InjectedResourceMonitor::onFileChanged();
+    dispatcher_.exit();
+  }
+
+private:
+  Event::Dispatcher& dispatcher_;
+};
+
+class MockedCallbacks : public Server::ResourceMonitor::Callbacks {
+public:
+  MOCK_METHOD1(onSuccess, void(const Server::ResourceUsage&));
+  MOCK_METHOD1(onFailure, void(const EnvoyException&));
+};
+
+class InjectedResourceMonitorTest : public testing::Test {
+protected:
+  InjectedResourceMonitorTest() : dispatcher_(test_time_.timeSource()) {}
+
+  void SetUp() override {
+    injected_resource_target1_ = TestEnvironment::temporaryPath("envoy_test/injected_resource1");
+    injected_resource_target2_ = TestEnvironment::temporaryPath("envoy_test/injected_resource2");
+    injected_resource_link_ = TestEnvironment::temporaryPath("envoy_test/injected_resource");
+    injected_resource_new_link_ =
+        TestEnvironment::temporaryPath("envoy_test/injected_resource_tmp");
+
+    unlink(injected_resource_target1_.c_str());
+    unlink(injected_resource_target2_.c_str());
+    unlink(injected_resource_link_.c_str());
+    unlink(injected_resource_new_link_.c_str());
+    mkdir(TestEnvironment::temporaryPath("envoy_test").c_str(), S_IRWXU);
+
+    use_target1_ = true;
+  }
+
+  void updateResource(const std::string& contents) {
+    const std::string target =
+        use_target1_ ? injected_resource_target1_ : injected_resource_target2_;
+    use_target1_ = !use_target1_;
+    {
+      std::ofstream file(target);
+      file << contents;
+    }
+    int rc = symlink(target.c_str(), injected_resource_new_link_.c_str());
+    EXPECT_EQ(0, rc) << strerror(errno);
+    rc = rename(injected_resource_new_link_.c_str(), injected_resource_link_.c_str());
+    EXPECT_EQ(0, rc) << strerror(errno);
+  }
+
+  void updateResource(double pressure) { updateResource(absl::StrCat(pressure)); }
+
+  std::unique_ptr<InjectedResourceMonitor> createMonitor() {
+    envoy::config::resource_monitor::injected_resource::v2alpha::InjectedResourceConfig config;
+    config.set_filename(injected_resource_link_);
+    Server::Configuration::ResourceMonitorFactoryContextImpl context(dispatcher_);
+    return std::make_unique<TestableInjectedResourceMonitor>(config, context);
+  }
+
+  DangerousDeprecatedTestTime test_time_;
+  Event::DispatcherImpl dispatcher_;
+  bool use_target1_;
+  std::string injected_resource_target1_;
+  std::string injected_resource_target2_;
+  std::string injected_resource_link_;
+  std::string injected_resource_new_link_;
+  MockedCallbacks cb_;
+};
+
+TEST_F(InjectedResourceMonitorTest, ReportsCorrectPressure) {
+  auto monitor(createMonitor());
+
+  updateResource(0.6);
+  dispatcher_.run(Event::Dispatcher::RunType::Block);
+  EXPECT_CALL(cb_, onSuccess(Server::ResourceUsage{.resource_pressure_ = 0.6}));
+  monitor->updateResourceUsage(cb_);
+
+  updateResource(0.7);
+  dispatcher_.run(Event::Dispatcher::RunType::Block);
+  EXPECT_CALL(cb_, onSuccess(Server::ResourceUsage{.resource_pressure_ = 0.7}));
+  monitor->updateResourceUsage(cb_);
+}
+
+MATCHER_P(ExceptionContains, rhs, "") { return absl::StrContains(arg.what(), rhs); }
+
+TEST_F(InjectedResourceMonitorTest, ErrorOnParseError) {
+  auto monitor(createMonitor());
+
+  updateResource("bad content");
+  dispatcher_.run(Event::Dispatcher::RunType::Block);
+  EXPECT_CALL(cb_, onFailure(ExceptionContains("failed to parse injected resource pressure")));
+  monitor->updateResourceUsage(cb_);
+}
+
+TEST_F(InjectedResourceMonitorTest, ErrorOnFileRead) {
+  auto monitor(createMonitor());
+
+  EXPECT_CALL(cb_, onFailure(ExceptionContains("unable to read file")));
+  monitor->updateResourceUsage(cb_);
+}
+
+} // namespace InjectedResourceMonitor
+} // namespace ResourceMonitors
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
This allowed injected a synthetic resource pressure from a file, primarily intended for use in integration tests to force envoy into an overloaded state.

*Testing*: unit tests
*Docs Changes*: docs updated to reference new resource monitor

Signed-off-by: Elisha Ziskind <eziskind@google.com>