### PR TITLE
fuzz: detect client-side resets in H2 codec fuzzer.

### DIFF
--- a/test/common/http/http2/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-5635096546639872
+++ b/test/common/http/http2/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-5635096546639872
@@ -1,0 +1,749 @@
+server_settings {   max_concurrent_streams: 2 } actions {   new_stream {   } } actions {   new_stream {     request_headers {     }   } } actions {   new_stream {   } } actions { } actions {   new_stream {     request_headers {     }   } } actions { } actions {   new_stream {     request_headers {     }   } } actions {   new_stream {   } } actions {   new_stream {     request_headers {       headers {         key: " "       }     }   } } actions {   new_stream {   } } actions { } actions {   quiesce_drain {   } } actions {   new_stream {   } } actions { } actions {   new_stream {   } } actions { } actions {   new_stream {   } } actions {   quiesce_drain {   } } actions { } actions {   new_stream {     request_headers {     }   } } actions { } actions { } actions {   new_stream {   } } actions {   new_stream {     request_headers {     }   } } actions { } actions {   new_stream {   } } actions {   new_stream {   } } actions {   new_stream {   } } actions {   new_stream {   } } actions {   new_stream {   } } actions { } actions { } actions {   new_stream {   } } actions {   new_stream {   } } actions { } actions {   new_stream {   } } actions {   new_stream {   } } actions {   new_stream {     request_headers {       headers {         key: ":method"         value: "  �"       }       headers {         key: ":path"         value: "�"       }       headers {         key: ":scheme"         value: "ttp"       }       headers {         key: ":authority"         value: "foo.com"       }     }   } } actions { } actions { } actions { } actions { } actions { } actions { } actions { } actions { } actions { } actions { } actions {   new_stream {   } } actions { } actions {   stream_action {     stream_id: 4   } } actions {   new_stream {     end_stream: true   } } actions { } actions {   new_stream {   } } actions { } actions {   new_stream {   } } actions {   new_stream {   } } actions {   swap_buffer {     server: true   } } actions { } actions { } actions { } actions {   new_stream {   } } actions { } actions {   new_stream {   } } actions { } actions {   server_drain {   } } actions {   new_stream {   } } actions { } actions {   new_stream {   } } actions { } actions { } actions {   new_stream {   } } actions {   new_stream {     request_headers {     }   } } actions {   new_stream {   } } actions { } actions {   new_stream {   } } actions {   new_stream {     request_headers {     }   } } actions {   new_stream {   } } actions {   swap_buffer {     buffer: 8    } } actions {   new_stream {   } } actions {   new_stream {   } } actions {   new_stream {   } } actions { } actions { } actions { } actions {   new_stream {   } } actions { } actions {   new_stream {   } } actions {   client_drain {   } } actions { } actions {   server_drain {   } } actions {   stream_action {   } } actions { } actions {   new_stream {   } } actions {   new_stream {   } } actions {   new_stream {   } } actions {   quiesce_drain {   } } actions { } actions { } actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+  stream_action {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 2
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+    end_stream: true
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  swap_buffer {
+    buffer: 350
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+    request_headers {
+    }
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+    end_stream: true
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+}
+actions {
+  stream_action {
+    stream_id: 65537
+    request {
+      data: 1
+    }
+  }
+}
+actions {
+}
+actions {
+  mutate {
+    offset: 524288
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  stream_action {
+    response {
+    }
+  }
+}
+actions {
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+    }
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+    request_headers {
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+    end_stream: true
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+    request_headers {
+    }
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+      }
+    }
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  swap_buffer {
+    buffer: 1
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  stream_action {
+    stream_id: 4
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: "\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177"
+      }
+    }
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 2
+    request {
+    }
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  stream_action {
+    request {
+    }
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  mutate {
+    server: true
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  stream_action {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+  mutate {
+    offset: 2
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+  mutate {
+    buffer: 10223616
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+  new_stream {
+  }
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}
+actions {
+}


### PR DESCRIPTION
Previously these were ignored, and data was sent to the codec after the
stream reset event was issued.

Fixes oss-fuzz issue https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10000.

Risk level: Low
Testing: Corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>