### PR TITLE
admin: order stats in clusters json admin

### DIFF
--- a/api/envoy/admin/v2alpha/clusters.proto
+++ b/api/envoy/admin/v2alpha/clusters.proto
@@ -46,7 +46,7 @@ message HostStatus {
   // Address of this host.
   envoy.api.v2.core.Address address = 1;
 
-  // list of stats specific to this host.
+  // List of stats specific to this host.
   repeated SimpleMetric stats = 2;
 
   // The host's current health status.

--- a/api/envoy/admin/v2alpha/clusters.proto
+++ b/api/envoy/admin/v2alpha/clusters.proto
@@ -46,8 +46,8 @@ message HostStatus {
   // Address of this host.
   envoy.api.v2.core.Address address = 1;
 
-  // Mapping from the name of the statistic to the current value.
-  map<string, SimpleMetric> stats = 2;
+  // list of stats specific to this host.
+  repeated SimpleMetric stats = 2;
 
   // The host's current health status.
   HostHealthStatus health_status = 3;

--- a/api/envoy/admin/v2alpha/metrics.proto
+++ b/api/envoy/admin/v2alpha/metrics.proto
@@ -11,9 +11,12 @@ message SimpleMetric {
     GAUGE = 1;
   }
 
-  // Type of metric represented.
-  Type type = 1;
+  // Name of the metric.
+  string name = 3;
 
   // Current metric value.
   uint64 value = 2;
+
+  // Type of the metric represented.
+  Type type = 1;
 }

--- a/api/envoy/admin/v2alpha/metrics.proto
+++ b/api/envoy/admin/v2alpha/metrics.proto
@@ -11,12 +11,12 @@ message SimpleMetric {
     GAUGE = 1;
   }
 
-  // Name of the metric.
-  string name = 3;
+  // Type of the metric represented.
+  Type type = 1;
 
   // Current metric value.
   uint64 value = 2;
 
-  // Type of the metric represented.
-  Type type = 1;
+  // Name of the metric.
+  string name = 3;
 }

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -284,17 +284,18 @@ void AdminImpl::writeClustersAsJson(Buffer::Instance& response) {
         envoy::admin::v2alpha::HostStatus& host_status = *cluster_status.add_host_statuses();
         Network::Utility::addressToProtobufAddress(*host->address(),
                                                    *host_status.mutable_address());
-
         for (const Stats::CounterSharedPtr& counter : host->counters()) {
-          auto& metric = (*host_status.mutable_stats())[counter->name()];
-          metric.set_type(envoy::admin::v2alpha::SimpleMetric::COUNTER);
+          auto& metric = *host_status.add_stats();
+          metric.set_name(counter->name());
           metric.set_value(counter->value());
+          metric.set_type(envoy::admin::v2alpha::SimpleMetric::COUNTER);
         }
 
         for (const Stats::GaugeSharedPtr& gauge : host->gauges()) {
-          auto& metric = (*host_status.mutable_stats())[gauge->name()];
-          metric.set_type(envoy::admin::v2alpha::SimpleMetric::GAUGE);
+          auto& metric = *host_status.add_stats();
+          metric.set_name(gauge->name());
           metric.set_value(gauge->value());
+          metric.set_type(envoy::admin::v2alpha::SimpleMetric::GAUGE);
         }
 
         envoy::admin::v2alpha::HostHealthStatus& health_status =
@@ -314,7 +315,7 @@ void AdminImpl::writeClustersAsJson(Buffer::Instance& response) {
       }
     }
   }
-  response.add(MessageUtil::getJsonStringFromMessage(clusters, true)); // pretty-print
+  response.add(MessageUtil::getJsonStringFromMessage(clusters, true, true)); // pretty-print
 }
 
 void AdminImpl::writeClustersAsText(Buffer::Instance& response) {

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -737,9 +737,13 @@ TEST_P(AdminInstanceTest, ClustersJson) {
       Network::Utility::resolveUrl("tcp://1.2.3.4:80");
   ON_CALL(*host, address()).WillByDefault(Return(address));
 
+  // Add stats in random order and validate that they come in order.
   Stats::IsolatedStoreImpl store;
   store.counter("test_counter").add(10);
+  store.counter("rest_counter").add(10);
+  store.counter("arest_counter").add(5);
   store.gauge("test_gauge").set(11);
+  store.gauge("atest_gauge").set(10);
   ON_CALL(*host, gauges()).WillByDefault(Invoke([&store]() { return store.gauges(); }));
   ON_CALL(*host, counters()).WillByDefault(Invoke([&store]() { return store.counters(); }));
 
@@ -776,16 +780,33 @@ TEST_P(AdminInstanceTest, ClustersJson) {
        "port_value": 80
       }
      },
-     "stats": {
-      "test_counter": {
+     "stats": [
+       {
+       "name": "arest_counter",
+       "value": "5",
+       "type": "COUNTER"
+       },
+       {
+       "name": "rest_counter",
        "value": "10",
        "type": "COUNTER"
       },
-      "test_gauge": {
+      {
+       "name": "test_counter",
+       "value": "10",
+       "type": "COUNTER"
+      },
+      {
+       "name": "atest_gauge",
+       "value": "10",
+       "type": "GAUGE"
+      },
+      {
+       "name": "test_gauge",
        "value": "11",
        "type": "GAUGE"
       },
-     },
+     ],
      "health_status": {
       "eds_health_status": "HEALTHY",
       "failed_active_health_check": true,


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*: Currently host level stats in clusters [proto](https://github.com/envoyproxy/envoy/blob/master/api/envoy/admin/v2alpha/clusters.proto#L50) uses map so they are outputted in random order. This PR changes it to list so that the order is predictable.
*Risk Level*: Low
*Testing*: Added automated tests
*Docs Changes*: N/A
*Release Notes*: N/A

