### PR TITLE
ratelimit: link legacy proto when message is being used

### DIFF
--- a/source/common/ratelimit/ratelimit_impl.cc
+++ b/source/common/ratelimit/ratelimit_impl.cc
@@ -103,6 +103,8 @@ GrpcFactoryImpl::GrpcFactoryImpl(const envoy::config::ratelimit::v2::RateLimitSe
 
   // TODO(junr03): legacy rate limit is deprecated. Remove this warning after 1.8.0.
   if (!use_data_plane_proto_) {
+    // Force link time dependency on deprecated message type.
+    pb::lyft::ratelimit::RateLimit _ignore;
     ENVOY_LOG_MISC(warn, "legacy rate limit client is deprecated, update your service to support "
                          "the data-plane-api defined rate limit service");
   }


### PR DESCRIPTION
Signed-off-by: Jose Nino <jnino@lyft.com>

*Description*: the legacy ratelimit message is selectively used, so it is not linked by default. Previous to #4233 we had [forced linking](https://github.com/envoyproxy/envoy/pull/4233/files#diff-7c14edf737f5e1bc2176e28b833b11cbL436). In #4233 linking was forced while running tests, but --understandably so -- not in production code. This means that when this path is executed on a compiled binary, we would get a segfault due to a failure to resolved the service_method_ [here](https://github.com/envoyproxy/envoy/blob/master/source/common/ratelimit/ratelimit_impl.cc#L21).

*Risk Level*: medium, fixes a crash
*Testing*: Fixed the concrete repro showing the invalid reference on gdb, turn into a valid reference.