### PR TITLE
fuzz: fix H2 codec fuzzer post #4262.

### DIFF
--- a/test/common/http/http2/codec_impl_corpus/clusterfuzz-testcase-codec_impl_fuzz_test-5750359880892416
+++ b/test/common/http/http2/codec_impl_corpus/clusterfuzz-testcase-codec_impl_fuzz_test-5750359880892416
@@ -1,0 +1,23 @@
+actions {
+  new_stream {
+  }
+}
+actions {
+  mutate {
+    buffer: 2
+    offset: 2
+    value: 2
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      headers {
+      }
+    }
+  }
+}

--- a/test/common/http/http2/codec_impl_fuzz_test.cc
+++ b/test/common/http/http2/codec_impl_fuzz_test.cc
@@ -105,6 +105,7 @@ public:
   void directionalAction(DirectionalState& state,
                          const test::common::http::http2::DirectionalAction& directional_action) {
     const bool end_stream = directional_action.end_stream();
+    const bool response = &state == &response_;
     switch (directional_action.directional_action_selector_case()) {
     case test::common::http::http2::DirectionalAction::kContinueHeaders: {
       if (state.stream_state_ == StreamState::PendingHeaders) {
@@ -116,7 +117,11 @@ public:
     }
     case test::common::http::http2::DirectionalAction::kHeaders: {
       if (state.stream_state_ == StreamState::PendingHeaders) {
-        state.encoder_->encodeHeaders(Fuzz::fromHeaders(directional_action.headers()), end_stream);
+        auto headers = Fuzz::fromHeaders(directional_action.headers());
+        if (response && headers.Status() == nullptr) {
+          headers.setReferenceKey(Headers::get().Status, "200");
+        }
+        state.encoder_->encodeHeaders(headers, end_stream);
         state.stream_state_ = end_stream ? StreamState::Closed : StreamState::PendingDataOrTrailers;
       }
       break;


### PR DESCRIPTION
In #4262, an ASSERT was added to guarantee that we wouldn't violate the
codec response contract regarding :status. This needed a corresponding
change in the H2 codec fuzzer.

Risk level: Low
Testing: Corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>