### PR TITLE
lua: make sure resetting dynamic metadata wrapper when request info is marked dead

### DIFF
--- a/source/extensions/filters/http/lua/wrappers.h
+++ b/source/extensions/filters/http/lua/wrappers.h
@@ -192,6 +192,9 @@ private:
    */
   DECLARE_LUA_FUNCTION(RequestInfoWrapper, luaDynamicMetadata);
 
+  // Envoy::Lua::BaseLuaObject
+  void onMarkDead() override { dynamic_metadata_wrapper_.reset(); }
+
   RequestInfo::RequestInfo& request_info_;
   Filters::Common::Lua::LuaDeathRef<DynamicMetadataMapWrapper> dynamic_metadata_wrapper_;
 

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -342,5 +342,41 @@ config:
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 }
 
+// Should survive from 30 calls when calling requestInfo():dynamicMetadata(). This is a regression
+// test for #4305.
+TEST_P(LuaIntegrationTest, SurviveMultipleCalls) {
+  const std::string FILTER_AND_CODE =
+      R"EOF(
+name: envoy.lua
+config:
+  inline_code: |
+    function envoy_on_request(request_handle)
+      request_handle:requestInfo():dynamicMetadata()
+    end
+)EOF";
+
+  initializeFilter(FILTER_AND_CODE);
+
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  Http::TestHeaderMapImpl request_headers{{":method", "GET"},
+                                          {":path", "/test/long/url"},
+                                          {":scheme", "http"},
+                                          {":authority", "host"},
+                                          {"x-forwarded-for", "10.0.0.1"}};
+
+  for (uint32_t i = 0; i < 30; i++) {
+    auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
+
+    waitForNextUpstreamRequest();
+    upstream_request_->encodeHeaders(default_response_headers_, true);
+    response->waitForEndStream();
+
+    EXPECT_TRUE(response->complete());
+    EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  }
+
+  cleanup();
+}
+
 } // namespace
 } // namespace Envoy

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -364,7 +364,7 @@ config:
                                           {":authority", "host"},
                                           {"x-forwarded-for", "10.0.0.1"}};
 
-  for (uint32_t i = 0; i < 30; i++) {
+  for (uint32_t i = 0; i < 30; ++i) {
     auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
 
     waitForNextUpstreamRequest();


### PR DESCRIPTION
This PR makes sure we reset dynamic metadata wrapper when its parent (request info wrapper) is marked dead.

*Risk Level*: Low
*Testing*: Add integration testing
*Docs Changes*: N/A
*Release Notes*: N/A
Fixes #4305
