### PR TITLE
http: remove double 100 headers ASSERT from H2 codec.

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -409,10 +409,9 @@ int ConnectionImpl::onFrameReceived(const nghttp2_frame* frame) {
           ASSERT(!nghttp2_session_check_server_session(session_));
           stream->waiting_for_non_informational_headers_ = false;
 
-          // This can only happen in the client case in a response, when we received a 1xx to
-          // start out with. In this case, raise as headers. nghttp2 message checking guarantees
-          // proper flow here.
-          ASSERT(!stream->headers_->Status() || stream->headers_->Status()->value() != "100");
+          // Even if we have :status 100 in the client case in a response, when
+          // we received a 1xx to start out with, nghttp2 message checking
+          // guarantees proper flow here.
           stream->decodeHeaders();
         }
       }

--- a/test/common/http/http2/codec_impl_corpus/clusterfuzz-testcase-codec_impl_fuzz_test-5723814130876416
+++ b/test/common/http/http2/codec_impl_corpus/clusterfuzz-testcase-codec_impl_fuzz_test-5723814130876416
@@ -1,0 +1,54 @@
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "foo.com"
+      }
+      headers {
+        key: "expect"
+        value: "100-continue"
+      }
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      continue_headers {
+      }
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      continue_headers {
+      }
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}


### PR DESCRIPTION
This ASSERT can be triggered by uncontrolled wire traffic; since we have
sane handling of this behavior, this probably isn't the right thing to
have in place to detect this condition. I.e. we're not violating any
invariant here.

Fixes oss-fuzz issue
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10072.

Risk level: Low
Testing: Corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>