### PR TITLE
Re-enable TcpProxySslIntegrationTest and make the tests pass again.

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -498,6 +498,9 @@ envoy_cc_test(
         "tcp_proxy_integration_test.cc",
         "tcp_proxy_integration_test.h",
     ],
+    data = [
+        "//test/config/integration/certs",
+    ],
     deps = [
         ":integration_lib",
         "//source/common/event:dispatcher_includes",
@@ -507,6 +510,7 @@ envoy_cc_test(
         "//source/common/ssl:context_lib",
         "//source/extensions/access_loggers/file:config",
         "//source/extensions/filters/network/tcp_proxy:config",
+        "//source/extensions/transport_sockets/ssl:config",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/secret:secret_mocks",
         "//test/test_common:utility_lib",

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -355,6 +355,10 @@ TEST_P(TcpProxyIntegrationTest, TestIdletimeoutWithLargeOutstandingData) {
   ASSERT_TRUE(fake_upstream_connection->waitForDisconnect(true));
 }
 
+INSTANTIATE_TEST_CASE_P(IpVersions, TcpProxySslIntegrationTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
+
 void TcpProxySslIntegrationTest::initialize() {
   config_helper_.addSslConfig();
   TcpProxyIntegrationTest::initialize();
@@ -451,6 +455,7 @@ TEST_P(TcpProxySslIntegrationTest, DownstreamHalfClose) {
 
   Buffer::OwnedImpl empty_buffer;
   ssl_client_->write(empty_buffer, true);
+  dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
   ASSERT_TRUE(fake_upstream_connection_->waitForHalfClose());
 
   const std::string data("data");

--- a/test/integration/tcp_proxy_integration_test.h
+++ b/test/integration/tcp_proxy_integration_test.h
@@ -18,12 +18,12 @@ public:
     enable_half_close_ = true;
   }
 
-  void initialize() override;
-
-  void TearDown() override {
+  ~TcpProxyIntegrationTest() {
     test_server_.reset();
     fake_upstreams_.clear();
   }
+
+  void initialize() override;
 };
 
 class TcpProxySslIntegrationTest : public TcpProxyIntegrationTest {
@@ -33,8 +33,6 @@ public:
   void sendAndReceiveTlsData(const std::string& data_to_send_upstream,
                              const std::string& data_to_send_downstream);
 
-  Network::ClientConnectionPtr ssl_client_;
-  FakeRawConnectionPtr fake_upstream_connection_;
   testing::NiceMock<Runtime::MockLoader> runtime_;
   std::unique_ptr<Ssl::ContextManager> context_manager_;
   Network::TransportSocketFactoryPtr context_;
@@ -42,6 +40,8 @@ public:
   MockWatermarkBuffer* client_write_buffer_;
   std::shared_ptr<WaitForPayloadReader> payload_reader_;
   testing::NiceMock<Secret::MockSecretManager> secret_manager_;
+  Network::ClientConnectionPtr ssl_client_;
+  FakeRawConnectionPtr fake_upstream_connection_;
 };
 
 } // namespace


### PR DESCRIPTION
Signed-off-by: Greg Greenway <ggreenway@apple.com>

*Description*: Re-enable tests that were inadvertently not running.
*Risk Level*: Low
