### PR TITLE
test: fix heap use-after-free in ~IntegrationTestServer().

### DIFF
--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -309,6 +309,7 @@ private:
   Stats::Store* stat_store_{};
   std::function<void()> on_worker_listener_added_cb_;
   std::function<void()> on_worker_listener_removed_cb_;
+  Network::Address::InstanceConstSharedPtr admin_address_;
 };
 
 } // namespace Envoy


### PR DESCRIPTION
When the server thread exits independently of the main test thread (e.g. exception catch), we
could race on the access to the server admin port via server_. We latch this in this PR to avoid
unsafe behavior. We might still have a stale address, but the request should then fail or timeout.

Fixes oss-fuzz issues https://oss-fuzz.com/v2/testcase-detail/5719024990683136 and
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10027.

Risk level: Low
Testing: TSAN integration tests.

Signed-off-by: Harvey Tuch <htuch@google.com>