### PR TITLE
router: fix matching when all domains have wildcards

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -851,7 +851,7 @@ RouteConstSharedPtr VirtualHostImpl::getRouteFromEntries(const Http::HeaderMap& 
 
 const VirtualHostImpl* RouteMatcher::findVirtualHost(const Http::HeaderMap& headers) const {
   // Fast path the case where we only have a default virtual host.
-  if (virtual_hosts_.empty() && default_virtual_host_) {
+  if (virtual_hosts_.empty() && wildcard_virtual_host_suffixes_.empty() && default_virtual_host_) {
     return default_virtual_host_.get();
   }
 

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -538,7 +538,7 @@ TEST(RouteMatcherTest, TestRoutes) {
 TEST(RouteMatcherTest, TestRoutesWithWildcardAndDefaultOnly) {
   std::string yaml = R"EOF(
 virtual_hosts:
-  - name: default
+  - name: wildcard
     domains: ["*.solo.io"]
     routes:
       - match: { prefix: "/" }

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -535,6 +535,31 @@ TEST(RouteMatcherTest, TestRoutes) {
   }
 }
 
+TEST(RouteMatcherTest, TestRoutesWithWildcardAndDefaultOnly) {
+  std::string yaml = R"EOF(
+virtual_hosts:
+  - name: default
+    domains: ["*.solo.io"]
+    routes:
+      - match: { prefix: "/" }
+        route: { cluster: "wildcard" }
+  - name: default
+    domains: ["*"]
+    routes:
+      - match: { prefix: "/" }
+        route: { cluster: "default" }
+  )EOF";
+
+  const auto&& proto_config{parseRouteConfigurationFromV2Yaml(yaml)};
+  NiceMock<Server::Configuration::MockFactoryContext> factory_context;
+  TestConfigImpl config(proto_config, factory_context, true);
+
+  EXPECT_EQ("wildcard",
+            config.route(genHeaders("gloo.solo.io", "/", "GET"), 0)->routeEntry()->clusterName());
+  EXPECT_EQ("default",
+            config.route(genHeaders("example.com", "/", "GET"), 0)->routeEntry()->clusterName());
+}
+
 TEST(RouteMatcherTest, TestRoutesWithInvalidRegex) {
   std::string invalid_route = R"EOF(
 virtual_hosts:

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -550,7 +550,7 @@ virtual_hosts:
         route: { cluster: "default" }
   )EOF";
 
-  const auto&& proto_config{parseRouteConfigurationFromV2Yaml(yaml)};
+  const auto proto_config = parseRouteConfigurationFromV2Yaml(yaml);
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   TestConfigImpl config(proto_config, factory_context, true);
 


### PR DESCRIPTION
When all domains of all virtual hosts had wildcard characters and there
was a default virtual host, `RouteMatcher::findVirtualHost()` used to
erroneously ignore the wildcard suffixes.

This patch fixes the issue and introduces a unit test that covers this
case.

Risk level: Medium. The fix is straightforward, but users who rely on
the erroneous behavior might be affected.

Testing: Introduced `TestRoutesWithWildcardAndDefaultOnly`

Signed-off-by: Tal Nordan <tal.nordan@solo.io>
