### PR TITLE
test: fixing the fix for echo integration test

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -68,7 +68,7 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
 }
 
 ConnectionImpl::~ConnectionImpl() {
-  ASSERT(fd() == -1);
+  ASSERT(fd() == -1, "ConnectionImpl was unexpectedly torn down without being closed.");
 
   // In general we assume that owning code has called close() previously to the destructor being
   // run. This generally must be done so that callbacks run in the correct context (vs. deferred

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -134,6 +134,8 @@ TEST_P(EchoIntegrationTest, AddRemoveListener) {
     if (connection2.connection().state() == Network::Connection::State::Closed) {
       connect_fail = true;
       break;
+    } else {
+      connection2.close();
     }
   }
   ASSERT_TRUE(connect_fail);


### PR DESCRIPTION
follow up on #4304, actually closing the connection if multiple connection attempts are required.
Sorry for missing it as said on that PR it's hard to stress test with "exclusive" on, but running with ASAN helps.

*Risk Level*: low (test fix + assert details)
*Testing*: 500 asan runs clean (as opposed to 4 failures)
*Docs Changes*: n/a
*Release Notes*: n/a
