### PR TITLE
Update dependencies.

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -14,11 +14,11 @@ REPOSITORY_LOCATIONS = dict(
         strip_prefix = "thrift-0.11.0",
     ),
     com_github_bombela_backward = dict(
-        commit = "44ae9609e860e3428cd057f7052e505b4819eb84",  # 2018-02-06
+        commit = "84ae4f5e80381aca765a0810d4c811acae3cd7c7",  # v1.4
         remote = "https://github.com/bombela/backward-cpp",
     ),
     com_github_circonus_labs_libcircllhist = dict(
-        commit = "050da53a44dede7bda136b93a9aeef47bd91fa12",  # 2018-07-02
+        commit = "243060f3489d07782674d28f1056caa5a4c51a56",  # 2018-08-27
         remote = "https://github.com/circonus-labs/libcircllhist",
     ),
     com_github_cyan4973_xxhash = dict(
@@ -44,11 +44,11 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/gcovr/gcovr",
     ),
     com_github_google_libprotobuf_mutator = dict(
-        commit = "c3d2faf04a1070b0b852b0efdef81e1a81ba925e",
+        commit = "f2eac713f65dc55d663426647a40aff72e68a430",  #2018-08-24
         remote = "https://github.com/google/libprotobuf-mutator",
     ),
     com_github_grpc_grpc = dict(
-        commit = "3eedb606a07738e5446ba852085f676b134ecca4",  # v1.14.0
+        commit = "d3e16042d57439bf554649d110dbc61efa1d5cf7",  # v1.14.2
         remote = "https://github.com/grpc/grpc.git",
     ),
     com_github_nanopb_nanopb = dict(
@@ -109,7 +109,7 @@ REPOSITORY_LOCATIONS = dict(
         strip_prefix = "twitter.common.finagle-thrift-0.3.9/src",
     ),
     com_google_googletest = dict(
-        commit = "3d5612182581df64acc12d2633e473decf5adc47",  # Aug 29, 2018
+        commit = "2fe3bd994b3189899d93f1d5a881e725e046fdc2",  # v1.8.1
         remote = "https://github.com/google/googletest",
     ),
     com_google_protobuf = dict(
@@ -125,7 +125,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/grpc-ecosystem/grpc-httpjson-transcoding",
     ),
     io_bazel_rules_go = dict(
-        commit = "0.11.1",
+        commit = "0.11.2",
         remote = "https://github.com/bazelbuild/rules_go",
     ),
     six_archive = dict(

--- a/ci/build_container/build_container_common.sh
+++ b/ci/build_container/build_container_common.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
 # buildifier
-curl --location --output /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.12.0/buildifier \
-  && echo '7a77601630e493e4d6cbe4dfabb48e0e9a32ff372d84233527180cfc11d49496  /usr/local/bin/buildifier' | sha256sum --check \
+curl --location --output /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.15.0/buildifier \
+  && echo '0dea01a7a511797878f486e6ed8e549980c0710a0a116c8ee953d4e26de41515  /usr/local/bin/buildifier' | sha256sum --check \
   && chmod +x /usr/local/bin/buildifier
 
 # GCC for everything.

--- a/ci/build_container/build_recipes/nghttp2.sh
+++ b/ci/build_container/build_recipes/nghttp2.sh
@@ -2,12 +2,9 @@
 
 set -e
 
-# Use master branch, which contains a fix for the spurious limit of 100 concurrent streams:
-# https://github.com/nghttp2/nghttp2/commit/2ba1389993729fcb6ee5794ac512f2b67b29952e
-# TODO(PiotrSikora): switch back to releases once v1.33.0 is out.
-VERSION=e5b3f9addd49bca27e2f99c5c65a564eb5c0cf6d  # 2018-06-09
+VERSION=1.33.0
 
-curl https://github.com/nghttp2/nghttp2/archive/"$VERSION".tar.gz -sLo nghttp2-"$VERSION".tar.gz
+curl https://github.com/nghttp2/nghttp2/releases/download/v"$VERSION"/nghttp2-"$VERSION".tar.gz -sLo nghttp2-"$VERSION".tar.gz
 tar xf nghttp2-"$VERSION".tar.gz
 cd nghttp2-"$VERSION"
 


### PR DESCRIPTION
Signed-off-by: Michael Payne <michael@sooper.org>

*Dependency*: Upgrade to backward-cpp v1.4, libcircllhist 2018-08-27, libprotobuf-mutator 2018-08-24, grpc v1.14.2, googletest v1.8.1, rules_go 0.11.2, buildifier 0.15.0 and nghttp2 1.33.0.

*Description*: nghttp1 1.33.0 [release notes](https://github.com/nghttp2/nghttp2/releases/tag/v1.33.0), backward-cpp v1.4 [release notes](https://github.com/bombela/backward-cpp/releases/tag/v1.4), libcircllhist [commits](https://github.com/circonus-labs/libcircllhist/compare/050da53a44dede7bda136b93a9aeef47bd91fa12...243060f3489d07782674d28f1056caa5a4c51a56), libprotobuf_mutator [commits](https://github.com/google/libprotobuf-mutator/compare/c3d2faf04a1070b0b852b0efdef81e1a81ba925e...f2eac713f65dc55d663426647a40aff72e68a430), grpc [release notes](https://github.com/grpc/grpc/releases/tag/v1.14.2), rules_go [release notes](https://github.com/bazelbuild/rules_go/releases/tag/0.11.2), buildifier [release notes](https://github.com/bazelbuild/buildtools/releases/tag/0.15.0) and googletest [release notes](https://github.com/google/googletest/releases/tag/release-1.8.1).

*Risk Level*: Low
*Testing*: `bazel test //test/...` and running on local instances for 1+ weeks.
*Docs Changes*: none required
*Release Notes*: none required
