### PR TITLE
bump backward-cpp commit

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -14,7 +14,7 @@ REPOSITORY_LOCATIONS = dict(
         strip_prefix = "thrift-0.11.0",
     ),
     com_github_bombela_backward = dict(
-        commit = "44ae9609e860e3428cd057f7052e505b4819eb84",  # 2018-02-06
+        commit = "84ae4f5e80381aca765a0810d4c811acae3cd7c7",  # v1.4
         remote = "https://github.com/bombela/backward-cpp",
     ),
     com_github_circonus_labs_libcircllhist = dict(


### PR DESCRIPTION
*Description*: One of the compile flag configurations breaks the backward-cpp build for
Power because it had been using a deprecated flag. This release of
backward-cpp pulls in a fix to make sure the right define is used.

*Risk Level*: low
*Testing*: Circle
*Docs Changes*: n/a 
*Release Notes*: n/a

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>
