### PR TITLE
common: extract buffer and thrift proxy refactors to a separate commit

### DIFF
--- a/include/envoy/buffer/BUILD
+++ b/include/envoy/buffer/BUILD
@@ -11,5 +11,8 @@ envoy_package()
 envoy_cc_library(
     name = "buffer_interface",
     hdrs = ["buffer.h"],
-    deps = ["//include/envoy/api:os_sys_calls_interface"],
+    deps = [
+        "//include/envoy/api:os_sys_calls_interface",
+        "//source/common/common:byte_order_lib",
+    ],
 )

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -6,7 +6,10 @@
 #include <string>
 
 #include "envoy/api/os_sys_calls.h"
+#include "envoy/common/exception.h"
 #include "envoy/common/pure.h"
+
+#include "common/common/byte_order.h"
 
 #include "absl/strings/string_view.h"
 
@@ -194,6 +197,118 @@ public:
    * -1 for failure. If the call is successful, errno_ shouldn't be used.
    */
   virtual Api::SysCallIntResult write(int fd) PURE;
+
+  /**
+   * Copy an integer out of the buffer.
+   * @param start supplies the buffer index to start copying from.
+   * @param Size how many bytes to read out of the buffer.
+   * @param Endianness specifies the byte order to use when decoding the integer.
+   */
+  template <typename T, ByteOrder Endianness = ByteOrder::Host, size_t Size = sizeof(T)>
+  T peekInt(uint64_t start = 0) {
+    static_assert(Size <= sizeof(T), "requested size is bigger than integer being read");
+
+    if (length() < start + Size) {
+      throw EnvoyException("buffer underflow");
+    }
+
+    constexpr const auto displacement = Endianness == ByteOrder::BigEndian ? sizeof(T) - Size : 0;
+
+    auto result = static_cast<T>(0);
+    copyOut(start, Size, reinterpret_cast<char*>(std::addressof(result)) + displacement);
+    return fromEndianness<Endianness>(result);
+  }
+
+  /**
+   * Copy a little endian integer out of the buffer.
+   * @param start supplies the buffer index to start copying from.
+   * @param Size how many bytes to read out of the buffer.
+   */
+  template <typename T, size_t Size = sizeof(T)> T peekLEInt(uint64_t start = 0) {
+    return peekInt<T, ByteOrder::LittleEndian, Size>(start);
+  }
+
+  /**
+   * Copy a big endian integer out of the buffer.
+   * @param start supplies the buffer index to start copying from.
+   * @param Size how many bytes to read out of the buffer.
+   */
+  template <typename T, size_t Size = sizeof(T)> T peekBEInt(uint64_t start = 0) {
+    return peekInt<T, ByteOrder::BigEndian, Size>(start);
+  }
+
+  /**
+   * Copy an integer out of the buffer and drain the read data.
+   * @param Size how many bytes to read out of the buffer.
+   * @param Endianness specifies the byte order to use when decoding the integer.
+   */
+  template <typename T, ByteOrder Endianness = ByteOrder::Host, size_t Size = sizeof(T)>
+  T drainInt() {
+    auto const result = peekInt<T, Endianness, Size>();
+    drain(Size);
+    return result;
+  }
+
+  /**
+   * Copy a little endian integer out of the buffer and drain the read data.
+   * @param Size how many bytes to read out of the buffer.
+   */
+  template <typename T, size_t Size = sizeof(T)> T drainLEIntOut() {
+    return drainInt<T, ByteOrder::LittleEndian, Size>();
+  }
+
+  /**
+   * Copy a big endian integer out of the buffer and drain the read data.
+   * @param Size how many bytes to read out of the buffer.
+   */
+  template <typename T, size_t Size = sizeof(T)> T drainBEIntOut() {
+    return drainInt<T, ByteOrder::BigEndian, Size>();
+  }
+
+  /**
+   * Copy a byte into the buffer.
+   * @param value supplies the byte to copy into the buffer.
+   */
+  void writeByte(uint8_t value) { add(std::addressof(value), 1); }
+
+  /**
+   * Copy value as a byte into the buffer.
+   * @param value supplies the byte to copy into the buffer.
+   */
+  template <typename T> void writeByte(T value) { writeByte(static_cast<uint8_t>(value)); }
+
+  /**
+   * Copy an integer into the buffer.
+   * @param value supplies the integer to copy into the buffer.
+   * @param Size how many bytes to write from the requested integer.
+   * @param Endianness specifies the byte order to use when encoding the integer.
+   */
+  template <ByteOrder Endianness = ByteOrder::Host, typename T, size_t Size = sizeof(T)>
+  void writeInt(T value) {
+    static_assert(Size <= sizeof(T), "requested size is bigger than integer being read");
+
+    auto const data = toEndianness<Endianness>(value);
+    constexpr const auto displacement = Endianness == ByteOrder::BigEndian ? sizeof(T) - Size : 0;
+    add(reinterpret_cast<const char*>(std::addressof(data)) + displacement, Size);
+  }
+
+  /**
+   * Copy an integer into the buffer in little endian byte order.
+   * @param value supplies the integer to copy into the buffer.
+   * @param Size how many bytes to write from the requested integer.
+   */
+  template <typename T, size_t Size = sizeof(T)> void writeLEInt(T value) {
+    writeInt<ByteOrder::LittleEndian, T, Size>(value);
+  }
+
+  /**
+   * Copy an integer into the buffer in big endian byte order.
+   * @param value supplies the integer to copy into the buffer.
+   * @param Size how many bytes to write from the requested integer.
+   */
+  template <typename T, size_t Size = sizeof(T)> void writeBEInt(T value) {
+    writeInt<ByteOrder::BigEndian, T, Size>(value);
+  }
 };
 
 typedef std::unique_ptr<Instance> InstancePtr;

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -246,16 +246,11 @@ public:
 
     const auto extension =
         std::is_signed<T>::value && Size < sizeof(T) && bytes[most_significant_read_byte] < 0
-            ? Endianness == ByteOrder::BigEndian
-                  ? static_cast<T>(
-                        static_cast<typename std::make_unsigned<T>::type>(all_bits_enabled) >>
-                        (Size * CHAR_BIT))
-                  : static_cast<T>(
-                        static_cast<typename std::make_unsigned<T>::type>(all_bits_enabled)
-                        << (Size * CHAR_BIT))
+            ? static_cast<T>(static_cast<typename std::make_unsigned<T>::type>(all_bits_enabled)
+                             << (Size * CHAR_BIT))
             : static_cast<T>(0);
 
-    return fromEndianness<Endianness>(static_cast<T>(result | extension));
+    return fromEndianness<Endianness>(static_cast<T>(result)) | extension;
   }
 
   /**

--- a/source/common/common/byte_order.h
+++ b/source/common/common/byte_order.h
@@ -40,26 +40,6 @@ template <ByteOrder Endianness, typename T> inline T fromEndianness(T value) {
   return EndiannessConverter<Endianness, T>::from(value);
 }
 
-// convenience function that converts a host byte-order integer to little endian byte-order
-template <typename T> inline T toLittleEndian(T value) {
-  return EndiannessConverter<ByteOrder::LittleEndian, T>::to(value);
-}
-
-// convenience function that converts a little endian byte-order integer to host byte-order
-template <typename T> inline T fromLittleEndian(T value) {
-  return EndiannessConverter<ByteOrder::LittleEndian, T>::from(value);
-}
-
-// convenience function that converts a host byte-order integer to big endian byte-order
-template <typename T> inline T toBigEndian(T value) {
-  return EndiannessConverter<ByteOrder::BigEndian, T>::to(value);
-}
-
-// convenience function that converts a big endian byte-order integer to host byte-order
-template <typename T> inline T fromBigEndian(T value) {
-  return EndiannessConverter<ByteOrder::BigEndian, T>::from(value);
-}
-
 // Implementation details below
 
 // implementation details of EndiannessConverter for 8-bit host endianness integers

--- a/source/common/common/byte_order.h
+++ b/source/common/common/byte_order.h
@@ -25,3 +25,147 @@
 #include <endian.h>
 
 #endif
+
+enum class ByteOrder { Host, LittleEndian, BigEndian };
+
+template <ByteOrder, typename Integral, size_t = sizeof(Integral)> struct EndiannessConverter;
+
+// convenience function that converts an integer from host byte-order to a specified endianness
+template <ByteOrder Endianness, typename T> inline T toEndianness(T value) {
+  return EndiannessConverter<Endianness, T>::to(value);
+}
+
+// convenience function that converts an integer from a specified endianness to host byte-order
+template <ByteOrder Endianness, typename T> inline T fromEndianness(T value) {
+  return EndiannessConverter<Endianness, T>::from(value);
+}
+
+// convenience function that converts a host byte-order integer to little endian byte-order
+template <typename T> inline T toLittleEndian(T value) {
+  return EndiannessConverter<ByteOrder::LittleEndian, T>::to(value);
+}
+
+// convenience function that converts a little endian byte-order integer to host byte-order
+template <typename T> inline T fromLittleEndian(T value) {
+  return EndiannessConverter<ByteOrder::LittleEndian, T>::from(value);
+}
+
+// convenience function that converts a host byte-order integer to big endian byte-order
+template <typename T> inline T toBigEndian(T value) {
+  return EndiannessConverter<ByteOrder::BigEndian, T>::to(value);
+}
+
+// convenience function that converts a big endian byte-order integer to host byte-order
+template <typename T> inline T fromBigEndian(T value) {
+  return EndiannessConverter<ByteOrder::BigEndian, T>::from(value);
+}
+
+// Implementation details below
+
+// implementation details of EndiannessConverter for 8-bit host endianness integers
+template <typename T> struct EndiannessConverter<ByteOrder::Host, T, sizeof(uint8_t)> {
+  static_assert(sizeof(T) == sizeof(uint8_t), "incorrect type width");
+
+  static T to(T value) { return value; }
+
+  static T from(T value) { return value; }
+};
+
+// implementation details of EndiannessConverter for 16-bit host endianness integers
+template <typename T> struct EndiannessConverter<ByteOrder::Host, T, sizeof(uint16_t)> {
+  static_assert(sizeof(T) == sizeof(uint16_t), "incorrect type width");
+
+  static T to(T value) { return value; }
+
+  static T from(T value) { return value; }
+};
+
+// implementation details of EndiannessConverter for 32-bit host endianness integers
+template <typename T> struct EndiannessConverter<ByteOrder::Host, T, sizeof(uint32_t)> {
+  static_assert(sizeof(T) == sizeof(uint32_t), "incorrect type width");
+
+  static T to(T value) { return value; }
+
+  static T from(T value) { return value; }
+};
+
+// implementation details of EndiannessConverter for 64-bit host endianness integers
+template <typename T> struct EndiannessConverter<ByteOrder::Host, T, sizeof(uint64_t)> {
+  static_assert(sizeof(T) == sizeof(uint64_t), "incorrect type width");
+
+  static T to(T value) { return value; }
+
+  static T from(T value) { return value; }
+};
+
+// implementation details of EndiannessConverter for 8-bit little endian integers
+template <typename T> struct EndiannessConverter<ByteOrder::LittleEndian, T, sizeof(uint8_t)> {
+  static_assert(sizeof(T) == sizeof(uint8_t), "incorrect type width");
+
+  static T to(T value) { return value; }
+
+  static T from(T value) { return value; }
+};
+
+// implementation details of EndiannessConverter for 16-bit little endian integers
+template <typename T> struct EndiannessConverter<ByteOrder::LittleEndian, T, sizeof(uint16_t)> {
+  static_assert(sizeof(T) == sizeof(uint16_t), "incorrect type width");
+
+  static T to(T value) { return static_cast<T>(htole16(static_cast<uint16_t>(value))); }
+
+  static T from(T value) { return static_cast<T>(le16toh(static_cast<uint16_t>(value))); }
+};
+
+// implementation details of EndiannessConverter for 32-bit little endian integers
+template <typename T> struct EndiannessConverter<ByteOrder::LittleEndian, T, sizeof(uint32_t)> {
+  static_assert(sizeof(T) == sizeof(uint32_t), "incorrect type width");
+
+  static T to(T value) { return static_cast<T>(htole32(static_cast<uint32_t>(value))); }
+
+  static T from(T value) { return static_cast<T>(le32toh(static_cast<uint32_t>(value))); }
+};
+
+// implementation details of EndiannessConverter for 64-bit little endian integers
+template <typename T> struct EndiannessConverter<ByteOrder::LittleEndian, T, sizeof(uint64_t)> {
+  static_assert(sizeof(T) == sizeof(uint64_t), "incorrect type width");
+
+  static T to(T value) { return static_cast<T>(htole64(static_cast<uint64_t>(value))); }
+
+  static T from(T value) { return static_cast<T>(le64toh(static_cast<uint64_t>(value))); }
+};
+
+// implementation details of EndiannessConverter for 8-bit big endian integers
+template <typename T> struct EndiannessConverter<ByteOrder::BigEndian, T, sizeof(uint8_t)> {
+  static_assert(sizeof(T) == sizeof(uint8_t), "incorrect type width");
+
+  static T to(T value) { return value; }
+
+  static T from(T value) { return value; }
+};
+
+// implementation details of EndiannessConverter for 16-bit big endian integers
+template <typename T> struct EndiannessConverter<ByteOrder::BigEndian, T, sizeof(uint16_t)> {
+  static_assert(sizeof(T) == sizeof(uint16_t), "incorrect type width");
+
+  static T to(T value) { return static_cast<T>(htobe16(static_cast<uint16_t>(value))); }
+
+  static T from(T value) { return static_cast<T>(be16toh(static_cast<uint16_t>(value))); }
+};
+
+// implementation details of EndiannessConverter for 32-bit big endian integers
+template <typename T> struct EndiannessConverter<ByteOrder::BigEndian, T, sizeof(uint32_t)> {
+  static_assert(sizeof(T) == sizeof(uint32_t), "incorrect type width");
+
+  static T to(T value) { return static_cast<T>(htobe32(static_cast<uint32_t>(value))); }
+
+  static T from(T value) { return static_cast<T>(be32toh(static_cast<uint32_t>(value))); }
+};
+
+// implementation details of EndiannessConverter for 64-bit big endian integers
+template <typename T> struct EndiannessConverter<ByteOrder::BigEndian, T, sizeof(uint64_t)> {
+  static_assert(sizeof(T) == sizeof(uint64_t), "incorrect type width");
+
+  static T to(T value) { return static_cast<T>(htobe64(static_cast<uint64_t>(value))); }
+
+  static T from(T value) { return static_cast<T>(be64toh(static_cast<uint64_t>(value))); }
+};

--- a/source/extensions/filters/network/thrift_proxy/auto_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/auto_protocol_impl.cc
@@ -39,7 +39,7 @@ bool AutoProtocolImpl::readMessageBegin(Buffer::Instance& buffer, MessageMetadat
       return false;
     }
 
-    uint16_t version = BufferHelper::peekU16(buffer);
+    uint16_t version = buffer.peekBEInt<uint16_t>();
     if (BinaryProtocolImpl::isMagic(version)) {
       setType(ProtocolType::Binary);
     } else if (CompactProtocolImpl::isMagic(version)) {

--- a/source/extensions/filters/network/thrift_proxy/auto_transport_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/auto_transport_impl.cc
@@ -23,8 +23,8 @@ bool AutoTransportImpl::decodeFrameStart(Buffer::Instance& buffer, MessageMetada
       return false;
     }
 
-    int32_t size = BufferHelper::peekI32(buffer);
-    uint16_t proto_start = BufferHelper::peekU16(buffer, 4);
+    int32_t size = buffer.peekBEInt<int32_t>();
+    uint16_t proto_start = buffer.peekBEInt<uint16_t>(4);
 
     // Currently, transport detection depends on the following:
     // 1. Protocol may only be binary or compact, which start with 0x8001 or 0x8201.

--- a/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
@@ -58,7 +58,7 @@ bool BinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, MessageMetad
     metadata.setMethodName("");
   }
   metadata.setMessageType(type);
-  metadata.setSequenceId(buffer.drainBEIntOut<int32_t>());
+  metadata.setSequenceId(buffer.drainBEInt<int32_t>());
 
   return true;
 }
@@ -200,7 +200,7 @@ bool BinaryProtocolImpl::readInt16(Buffer::Instance& buffer, int16_t& value) {
   if (buffer.length() < 2) {
     return false;
   }
-  value = buffer.drainBEIntOut<int16_t>();
+  value = buffer.drainBEInt<int16_t>();
   return true;
 }
 
@@ -208,7 +208,7 @@ bool BinaryProtocolImpl::readInt32(Buffer::Instance& buffer, int32_t& value) {
   if (buffer.length() < 4) {
     return false;
   }
-  value = buffer.drainBEIntOut<int32_t>();
+  value = buffer.drainBEInt<int32_t>();
   return true;
 }
 
@@ -216,7 +216,7 @@ bool BinaryProtocolImpl::readInt64(Buffer::Instance& buffer, int64_t& value) {
   if (buffer.length() < 8) {
     return false;
   }
-  value = buffer.drainBEIntOut<int64_t>();
+  value = buffer.drainBEInt<int64_t>();
   return true;
 }
 

--- a/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
@@ -29,7 +29,7 @@ bool BinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, MessageMetad
     return false;
   }
 
-  uint16_t version = BufferHelper::peekU16(buffer);
+  uint16_t version = buffer.peekBEInt<uint16_t>();
   if (version != Magic) {
     throw EnvoyException(
         fmt::format("invalid binary protocol version 0x{:04x} != 0x{:04x}", version, Magic));
@@ -37,13 +37,13 @@ bool BinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, MessageMetad
 
   // The byte at offset 2 is unused and ignored.
 
-  MessageType type = static_cast<MessageType>(BufferHelper::peekI8(buffer, 3));
+  MessageType type = static_cast<MessageType>(buffer.peekInt<int8_t>(3));
   if (type < MessageType::Call || type > MessageType::LastMessageType) {
     throw EnvoyException(
         fmt::format("invalid binary protocol message type {}", static_cast<int8_t>(type)));
   }
 
-  uint32_t name_len = BufferHelper::peekU32(buffer, 4);
+  uint32_t name_len = buffer.peekBEInt<uint32_t>(4);
   if (buffer.length() < name_len + 12) {
     return false;
   }
@@ -58,7 +58,7 @@ bool BinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, MessageMetad
     metadata.setMethodName("");
   }
   metadata.setMessageType(type);
-  metadata.setSequenceId(BufferHelper::drainI32(buffer));
+  metadata.setSequenceId(buffer.drainBEIntOut<int32_t>());
 
   return true;
 }
@@ -86,7 +86,7 @@ bool BinaryProtocolImpl::readFieldBegin(Buffer::Instance& buffer, std::string& n
     return false;
   }
 
-  FieldType type = static_cast<FieldType>(BufferHelper::peekI8(buffer));
+  FieldType type = static_cast<FieldType>(buffer.peekInt<int8_t>());
   if (type == FieldType::Stop) {
     field_id = 0;
     buffer.drain(1);
@@ -95,7 +95,7 @@ bool BinaryProtocolImpl::readFieldBegin(Buffer::Instance& buffer, std::string& n
     if (buffer.length() < 3) {
       return false;
     }
-    int16_t id = BufferHelper::peekI16(buffer, 1);
+    int16_t id = buffer.peekBEInt<int16_t>(1);
     if (id < 0) {
       throw EnvoyException(fmt::format("invalid binary protocol field id {}", id));
     }
@@ -124,9 +124,9 @@ bool BinaryProtocolImpl::readMapBegin(Buffer::Instance& buffer, FieldType& key_t
     return false;
   }
 
-  FieldType ktype = static_cast<FieldType>(BufferHelper::peekI8(buffer, 0));
-  FieldType vtype = static_cast<FieldType>(BufferHelper::peekI8(buffer, 1));
-  int32_t s = BufferHelper::peekI32(buffer, 2);
+  FieldType ktype = static_cast<FieldType>(buffer.peekInt<int8_t>(0));
+  FieldType vtype = static_cast<FieldType>(buffer.peekInt<int8_t>(1));
+  int32_t s = buffer.peekBEInt<int32_t>(2);
   if (s < 0) {
     throw EnvoyException(fmt::format("negative binary protocol map size {}", s));
   }
@@ -154,8 +154,8 @@ bool BinaryProtocolImpl::readListBegin(Buffer::Instance& buffer, FieldType& elem
     return false;
   }
 
-  FieldType type = static_cast<FieldType>(BufferHelper::peekI8(buffer));
-  int32_t s = BufferHelper::peekI32(buffer, 1);
+  FieldType type = static_cast<FieldType>(buffer.peekInt<int8_t>());
+  int32_t s = buffer.peekBEInt<int32_t>(1);
   if (s < 0) {
     throw EnvoyException(fmt::format("negative binary protocol list/set size {}", s));
   }
@@ -184,7 +184,7 @@ bool BinaryProtocolImpl::readBool(Buffer::Instance& buffer, bool& value) {
     return false;
   }
 
-  value = BufferHelper::drainI8(buffer) != 0;
+  value = buffer.drainInt<int8_t>() != 0;
   return true;
 }
 
@@ -192,7 +192,7 @@ bool BinaryProtocolImpl::readByte(Buffer::Instance& buffer, uint8_t& value) {
   if (buffer.length() < 1) {
     return false;
   }
-  value = BufferHelper::drainI8(buffer);
+  value = buffer.drainInt<int8_t>();
   return true;
 }
 
@@ -200,7 +200,7 @@ bool BinaryProtocolImpl::readInt16(Buffer::Instance& buffer, int16_t& value) {
   if (buffer.length() < 2) {
     return false;
   }
-  value = BufferHelper::drainI16(buffer);
+  value = buffer.drainBEIntOut<int16_t>();
   return true;
 }
 
@@ -208,7 +208,7 @@ bool BinaryProtocolImpl::readInt32(Buffer::Instance& buffer, int32_t& value) {
   if (buffer.length() < 4) {
     return false;
   }
-  value = BufferHelper::drainI32(buffer);
+  value = buffer.drainBEIntOut<int32_t>();
   return true;
 }
 
@@ -216,7 +216,7 @@ bool BinaryProtocolImpl::readInt64(Buffer::Instance& buffer, int64_t& value) {
   if (buffer.length() < 8) {
     return false;
   }
-  value = BufferHelper::drainI64(buffer);
+  value = buffer.drainBEIntOut<int64_t>();
   return true;
 }
 
@@ -227,7 +227,7 @@ bool BinaryProtocolImpl::readDouble(Buffer::Instance& buffer, double& value) {
     return false;
   }
 
-  value = BufferHelper::drainDouble(buffer);
+  value = BufferHelper::drainBEDouble(buffer);
   return true;
 }
 
@@ -237,7 +237,7 @@ bool BinaryProtocolImpl::readString(Buffer::Instance& buffer, std::string& value
     return false;
   }
 
-  int32_t str_len = BufferHelper::peekI32(buffer);
+  int32_t str_len = buffer.peekBEInt<int32_t>();
   if (str_len < 0) {
     throw EnvoyException(fmt::format("negative binary protocol string/binary length {}", str_len));
   }
@@ -264,10 +264,10 @@ bool BinaryProtocolImpl::readBinary(Buffer::Instance& buffer, std::string& value
 
 void BinaryProtocolImpl::writeMessageBegin(Buffer::Instance& buffer,
                                            const MessageMetadata& metadata) {
-  BufferHelper::writeU16(buffer, Magic);
-  BufferHelper::writeU16(buffer, static_cast<uint16_t>(metadata.messageType()));
+  buffer.writeBEInt<uint16_t>(Magic);
+  buffer.writeBEInt<uint16_t>(static_cast<uint16_t>(metadata.messageType()));
   writeString(buffer, metadata.methodName());
-  BufferHelper::writeI32(buffer, metadata.sequenceId());
+  buffer.writeBEInt<int32_t>(metadata.sequenceId());
 }
 
 void BinaryProtocolImpl::writeMessageEnd(Buffer::Instance& buffer) {
@@ -287,12 +287,12 @@ void BinaryProtocolImpl::writeFieldBegin(Buffer::Instance& buffer, const std::st
                                          FieldType field_type, int16_t field_id) {
   UNREFERENCED_PARAMETER(name);
 
-  BufferHelper::writeI8(buffer, static_cast<uint8_t>(field_type));
+  buffer.writeByte(static_cast<uint8_t>(field_type));
   if (field_type == FieldType::Stop) {
     return;
   }
 
-  BufferHelper::writeI16(buffer, field_id);
+  buffer.writeBEInt<int16_t>(field_id);
 }
 
 void BinaryProtocolImpl::writeFieldEnd(Buffer::Instance& buffer) { UNREFERENCED_PARAMETER(buffer); }
@@ -303,9 +303,9 @@ void BinaryProtocolImpl::writeMapBegin(Buffer::Instance& buffer, FieldType key_t
     throw EnvoyException(fmt::format("illegal binary protocol map size {}", size));
   }
 
-  BufferHelper::writeI8(buffer, static_cast<int8_t>(key_type));
-  BufferHelper::writeI8(buffer, static_cast<int8_t>(value_type));
-  BufferHelper::writeI32(buffer, static_cast<int32_t>(size));
+  buffer.writeByte(static_cast<int8_t>(key_type));
+  buffer.writeByte(static_cast<int8_t>(value_type));
+  buffer.writeBEInt<int32_t>(static_cast<int32_t>(size));
 }
 
 void BinaryProtocolImpl::writeMapEnd(Buffer::Instance& buffer) { UNREFERENCED_PARAMETER(buffer); }
@@ -316,8 +316,8 @@ void BinaryProtocolImpl::writeListBegin(Buffer::Instance& buffer, FieldType elem
     throw EnvoyException(fmt::format("illegal binary protocol list/set size {}", size));
   }
 
-  BufferHelper::writeI8(buffer, static_cast<int8_t>(elem_type));
-  BufferHelper::writeI32(buffer, static_cast<int32_t>(size));
+  buffer.writeByte(static_cast<int8_t>(elem_type));
+  buffer.writeBEInt<int32_t>(static_cast<int32_t>(size));
 }
 
 void BinaryProtocolImpl::writeListEnd(Buffer::Instance& buffer) { UNREFERENCED_PARAMETER(buffer); }
@@ -330,31 +330,31 @@ void BinaryProtocolImpl::writeSetBegin(Buffer::Instance& buffer, FieldType elem_
 void BinaryProtocolImpl::writeSetEnd(Buffer::Instance& buffer) { writeListEnd(buffer); }
 
 void BinaryProtocolImpl::writeBool(Buffer::Instance& buffer, bool value) {
-  BufferHelper::writeI8(buffer, value ? 1 : 0);
+  buffer.writeByte(value ? 1 : 0);
 }
 
 void BinaryProtocolImpl::writeByte(Buffer::Instance& buffer, uint8_t value) {
-  BufferHelper::writeI8(buffer, value);
+  buffer.writeByte(value);
 }
 
 void BinaryProtocolImpl::writeInt16(Buffer::Instance& buffer, int16_t value) {
-  BufferHelper::writeI16(buffer, value);
+  buffer.writeBEInt<int16_t>(value);
 }
 
 void BinaryProtocolImpl::writeInt32(Buffer::Instance& buffer, int32_t value) {
-  BufferHelper::writeI32(buffer, value);
+  buffer.writeBEInt<int32_t>(value);
 }
 
 void BinaryProtocolImpl::writeInt64(Buffer::Instance& buffer, int64_t value) {
-  BufferHelper::writeI64(buffer, value);
+  buffer.writeBEInt<int64_t>(value);
 }
 
 void BinaryProtocolImpl::writeDouble(Buffer::Instance& buffer, double value) {
-  BufferHelper::writeDouble(buffer, value);
+  BufferHelper::writeBEDouble(buffer, value);
 }
 
 void BinaryProtocolImpl::writeString(Buffer::Instance& buffer, const std::string& value) {
-  BufferHelper::writeU32(buffer, value.length());
+  buffer.writeBEInt<uint32_t>(value.length());
   buffer.add(value);
 }
 
@@ -372,13 +372,13 @@ bool LaxBinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, MessageMe
     return false;
   }
 
-  uint32_t name_len = BufferHelper::peekU32(buffer);
+  uint32_t name_len = buffer.peekBEInt<uint32_t>();
 
   if (buffer.length() < 9 + name_len) {
     return false;
   }
 
-  MessageType type = static_cast<MessageType>(BufferHelper::peekI8(buffer, name_len + 4));
+  MessageType type = static_cast<MessageType>(buffer.peekInt<int8_t>(name_len + 4));
   if (type < MessageType::Call || type > MessageType::LastMessageType) {
     throw EnvoyException(
         fmt::format("invalid (lax) binary protocol message type {}", static_cast<int8_t>(type)));
@@ -394,7 +394,7 @@ bool LaxBinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, MessageMe
   }
 
   metadata.setMessageType(type);
-  metadata.setSequenceId(BufferHelper::peekI32(buffer, 1));
+  metadata.setSequenceId(buffer.peekBEInt<int32_t>(1));
   buffer.drain(5);
 
   return true;
@@ -403,8 +403,8 @@ bool LaxBinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, MessageMe
 void LaxBinaryProtocolImpl::writeMessageBegin(Buffer::Instance& buffer,
                                               const MessageMetadata& metadata) {
   writeString(buffer, metadata.methodName());
-  BufferHelper::writeI8(buffer, static_cast<int8_t>(metadata.messageType()));
-  BufferHelper::writeI32(buffer, metadata.sequenceId());
+  buffer.writeByte(static_cast<int8_t>(metadata.messageType()));
+  buffer.writeBEInt<int32_t>(metadata.sequenceId());
 }
 
 class BinaryProtocolConfigFactory : public ProtocolFactoryBase<BinaryProtocolImpl> {

--- a/source/extensions/filters/network/thrift_proxy/buffer_helper.cc
+++ b/source/extensions/filters/network/thrift_proxy/buffer_helper.cc
@@ -19,7 +19,7 @@ double BufferHelper::drainBEDouble(Buffer::Instance& buffer) {
   // 3. Using memcpy may be undefined, but probably reliable, and can be optimized to the
   //    same instructions as 1 and 2.
   // 4. Implementation of last resort is to manually copy from i to d via unsigned char*.
-  uint64_t i = buffer.drainBEIntOut<uint64_t>();
+  uint64_t i = buffer.drainBEInt<uint64_t>();
   double d;
   std::memcpy(&d, &i, 8);
   return d;

--- a/source/extensions/filters/network/thrift_proxy/buffer_helper.cc
+++ b/source/extensions/filters/network/thrift_proxy/buffer_helper.cc
@@ -7,113 +7,7 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace ThriftProxy {
 
-int8_t BufferHelper::peekI8(Buffer::Instance& buffer, uint64_t offset) {
-  if (buffer.length() < offset + 1) {
-    throw EnvoyException("buffer underflow");
-  }
-
-  int8_t i;
-  buffer.copyOut(offset, 1, &i);
-  return i;
-}
-
-int16_t BufferHelper::peekI16(Buffer::Instance& buffer, uint64_t offset) {
-  if (buffer.length() < offset + 2) {
-    throw EnvoyException("buffer underflow");
-  }
-
-  int16_t i;
-  buffer.copyOut(offset, 2, &i);
-  return be16toh(i);
-}
-
-int32_t BufferHelper::peekI32(Buffer::Instance& buffer, uint64_t offset) {
-  if (buffer.length() < offset + 4) {
-    throw EnvoyException("buffer underflow");
-  }
-
-  int32_t i;
-  buffer.copyOut(offset, 4, &i);
-  return be32toh(i);
-}
-
-int64_t BufferHelper::peekI64(Buffer::Instance& buffer, uint64_t offset) {
-  if (buffer.length() < offset + 8) {
-    throw EnvoyException("buffer underflow");
-  }
-
-  int64_t i;
-  buffer.copyOut(offset, 8, &i);
-  return be64toh(i);
-}
-
-uint16_t BufferHelper::peekU16(Buffer::Instance& buffer, uint64_t offset) {
-  if (buffer.length() < offset + 2) {
-    throw EnvoyException("buffer underflow");
-  }
-
-  uint16_t i;
-  buffer.copyOut(offset, 2, &i);
-  return be16toh(i);
-}
-
-uint32_t BufferHelper::peekU32(Buffer::Instance& buffer, uint64_t offset) {
-  if (buffer.length() < offset + 4) {
-    throw EnvoyException("buffer underflow");
-  }
-
-  uint32_t i;
-  buffer.copyOut(offset, 4, &i);
-  return be32toh(i);
-}
-
-uint64_t BufferHelper::peekU64(Buffer::Instance& buffer, uint64_t offset) {
-  if (buffer.length() < offset + 8) {
-    throw EnvoyException("buffer underflow");
-  }
-
-  uint64_t i;
-  buffer.copyOut(offset, 8, &i);
-  return be64toh(i);
-}
-
-int8_t BufferHelper::drainI8(Buffer::Instance& buffer) {
-  int8_t i = peekI8(buffer);
-  buffer.drain(1);
-  return i;
-}
-
-int16_t BufferHelper::drainI16(Buffer::Instance& buffer) {
-  int16_t i = peekI16(buffer);
-  buffer.drain(2);
-  return i;
-}
-
-int32_t BufferHelper::drainI32(Buffer::Instance& buffer) {
-  int32_t i = peekI32(buffer);
-  buffer.drain(4);
-  return i;
-}
-
-int64_t BufferHelper::drainI64(Buffer::Instance& buffer) {
-  int64_t i = peekI64(buffer);
-  buffer.drain(8);
-  return i;
-}
-
-uint32_t BufferHelper::drainU32(Buffer::Instance& buffer) {
-  uint32_t i = peekU32(buffer);
-  buffer.drain(4);
-  return i;
-}
-
-uint64_t BufferHelper::drainU64(Buffer::Instance& buffer) {
-  uint64_t i = peekU64(buffer);
-  buffer.drain(8);
-  return i;
-}
-
-double BufferHelper::drainDouble(Buffer::Instance& buffer) {
+double BufferHelper::drainBEDouble(Buffer::Instance& buffer) {
   static_assert(sizeof(double) == sizeof(uint64_t), "sizeof(double) != sizeof(uint64_t)");
   static_assert(std::numeric_limits<double>::is_iec559, "non-IEC559 (IEEE 754) double");
 
@@ -125,7 +19,7 @@ double BufferHelper::drainDouble(Buffer::Instance& buffer) {
   // 3. Using memcpy may be undefined, but probably reliable, and can be optimized to the
   //    same instructions as 1 and 2.
   // 4. Implementation of last resort is to manually copy from i to d via unsigned char*.
-  uint64_t i = drainU64(buffer);
+  uint64_t i = buffer.drainBEIntOut<uint64_t>();
   double d;
   std::memcpy(&d, &i, 8);
   return d;
@@ -145,7 +39,7 @@ uint64_t BufferHelper::peekVarInt(Buffer::Instance& buffer, uint64_t offset, int
   uint8_t shift = 0;
   uint64_t result = 0;
   for (uint64_t i = 0; i < last; i++) {
-    uint8_t b = peekI8(buffer, offset + i);
+    uint8_t b = buffer.peekInt<uint8_t>(offset + i);
 
     // Note: the compact protocol spec says these variable-length ints are encoded as big-endian,
     // but the Apache C++, Java, and Python implementations read and write them little-endian.
@@ -221,42 +115,14 @@ int32_t BufferHelper::peekZigZagI32(Buffer::Instance& buffer, uint64_t offset, i
   return (zz32 >> 1) ^ static_cast<uint32_t>(-static_cast<int32_t>(zz32 & 1));
 }
 
-void BufferHelper::writeI8(Buffer::Instance& buffer, int8_t value) { buffer.add(&value, 1); }
-
-void BufferHelper::writeI16(Buffer::Instance& buffer, int16_t value) {
-  value = htobe16(value);
-  buffer.add(&value, 2);
-}
-
-void BufferHelper::writeU16(Buffer::Instance& buffer, uint16_t value) {
-  value = htobe16(value);
-  buffer.add(&value, 2);
-}
-
-void BufferHelper::writeI32(Buffer::Instance& buffer, int32_t value) {
-  value = htobe32(value);
-  buffer.add(&value, 4);
-}
-
-void BufferHelper::writeU32(Buffer::Instance& buffer, uint32_t value) {
-  value = htobe32(value);
-  buffer.add(&value, 4);
-}
-
-void BufferHelper::writeI64(Buffer::Instance& buffer, int64_t value) {
-  value = htobe64(value);
-  buffer.add(&value, 8);
-}
-
-void BufferHelper::writeDouble(Buffer::Instance& buffer, double value) {
+void BufferHelper::writeBEDouble(Buffer::Instance& buffer, double value) {
   static_assert(sizeof(double) == sizeof(uint64_t), "sizeof(double) != sizeof(uint64_t)");
   static_assert(std::numeric_limits<double>::is_iec559, "non-IEC559 (IEEE 754) double");
 
   // See drainDouble for implementation details.
   uint64_t i;
   std::memcpy(&i, &value, 8);
-  i = htobe64(i);
-  buffer.add(&i, 8);
+  buffer.writeBEInt<uint64_t>(i);
 }
 
 // Thrift's var int encoding is described in

--- a/source/extensions/filters/network/thrift_proxy/buffer_helper.h
+++ b/source/extensions/filters/network/thrift_proxy/buffer_helper.h
@@ -17,109 +17,11 @@ namespace ThriftProxy {
 class BufferHelper {
 public:
   /**
-   * Reads an int8_t from the buffer at the given offset.
-   * @param buffer Buffer::Instance containing data to decode
-   * @param offset offset into buffer to peek at
-   * @return the int8_t at offset in buffer
-   */
-  static int8_t peekI8(Buffer::Instance& buffer, uint64_t offset = 0);
-
-  /**
-   * Reads an int16_t from the buffer at the given offset.
-   * @param buffer Buffer::Instance containing data to decode
-   * @param offset offset into buffer to peek at
-   * @return the int16_t at offset in buffer
-   */
-  static int16_t peekI16(Buffer::Instance& buffer, uint64_t offset = 0);
-
-  /**
-   * Reads an int32_t from the buffer at the given offset.
-   * @param buffer Buffer::Instance containing data to decode
-   * @param offset offset into buffer to peek at
-   * @return the int32_t at offset in buffer
-   */
-  static int32_t peekI32(Buffer::Instance& buffer, uint64_t offset = 0);
-
-  /**
-   * Reads an int64_t from the buffer at the given offset.
-   * @param buffer Buffer::Instance containing data to decode
-   * @param offset offset into buffer to peek at
-   * @return the int64_t at offset in buffer
-   */
-  static int64_t peekI64(Buffer::Instance& buffer, uint64_t offset = 0);
-
-  /**
-   * Reads an uint16_t from the buffer at the given offset.
-   * @param buffer Buffer::Instance containing data to decode
-   * @param offset offset into buffer to peek at
-   * @return the uint16_t at offset in buffer
-   */
-  static uint16_t peekU16(Buffer::Instance& buffer, uint64_t offset = 0);
-
-  /**
-   * Reads an uint32_t from the buffer at the given offset.
-   * @param buffer Buffer::Instance containing data to decode
-   * @param offset offset into buffer to peek at
-   * @return the uint32_t at offset in buffer
-   */
-  static uint32_t peekU32(Buffer::Instance& buffer, uint64_t offset = 0);
-
-  /**
-   * Reads an uint64_t from the buffer at the given offset.
-   * @param buffer Buffer::Instance containing data to decode
-   * @param offset offset into buffer to peek at
-   * @return the uint64_t at offset in buffer
-   */
-  static uint64_t peekU64(Buffer::Instance& buffer, uint64_t offset = 0);
-
-  /**
-   * Reads and drains an int8_t from a buffer.
-   * @param buffer Buffer::Instance containing data to decode
-   * @return the int8_t at the start of buffer
-   */
-  static int8_t drainI8(Buffer::Instance& buffer);
-
-  /**
-   * Reads and drains an int16_t from a buffer.
-   * @param buffer Buffer::Instance containing data to decode
-   * @return the int16_t at the start of buffer
-   */
-  static int16_t drainI16(Buffer::Instance& buffer);
-
-  /**
-   * Reads and drains an int32_t from a buffer.
-   * @param buffer Buffer::Instance containing data to decode
-   * @return the int32_t at the start of buffer
-   */
-  static int32_t drainI32(Buffer::Instance& buffer);
-
-  /**
-   * Reads and drains an int64_t from a buffer.
-   * @param buffer Buffer::Instance containing data to decode
-   * @return the int64_t at the start of buffer
-   */
-  static int64_t drainI64(Buffer::Instance& buffer);
-
-  /**
-   * Reads and drains an uint32_t from a buffer.
-   * @param buffer Buffer::Instance containing data to decode
-   * @return the uint32_t at the start of buffer
-   */
-  static uint32_t drainU32(Buffer::Instance& buffer);
-
-  /**
-   * Reads and drains an uint64_t from a buffer.
-   * @param buffer Buffer::Instance containing data to decode
-   * @return the uint64_t at the start of buffer
-   */
-  static uint64_t drainU64(Buffer::Instance& buffer);
-
-  /**
    * Reads and drains a double from a buffer.
    * @param buffer Buffer::Instance containing data to decode
    * @return the double at the start of buffer
    */
-  static double drainDouble(Buffer::Instance& buffer);
+  static double drainBEDouble(Buffer::Instance& buffer);
 
   /**
    * Peeks at a variable-length int32_t at offset. Updates size to the number of bytes used to
@@ -166,53 +68,11 @@ public:
   static int32_t peekZigZagI32(Buffer::Instance& buffer, uint64_t offset, int& size);
 
   /**
-   * Writes an int8_t to the buffer.
-   * @param buffer Buffer::Instance written to
-   * @param value the int8_t to write
-   */
-  static void writeI8(Buffer::Instance& buffer, int8_t value);
-
-  /**
-   * Writes an int16_t to the buffer.
-   * @param buffer Buffer::Instance written to
-   * @param value the int16_t to write
-   */
-  static void writeI16(Buffer::Instance& buffer, int16_t value);
-
-  /**
-   * Writes an uint16_t to the buffer.
-   * @param buffer Buffer::Instance written to
-   * @param value the uint16_t to write
-   */
-  static void writeU16(Buffer::Instance& buffer, uint16_t value);
-
-  /**
-   * Writes an int32_t to the buffer.
-   * @param buffer Buffer::Instance written to
-   * @param value the int32_t to write
-   */
-  static void writeI32(Buffer::Instance& buffer, int32_t value);
-
-  /**
-   * Writes an uint32_t to the buffer.
-   * @param buffer Buffer::Instance written to
-   * @param value the uint32_t to write
-   */
-  static void writeU32(Buffer::Instance& buffer, uint32_t value);
-
-  /**
-   * Writes an int64_t to the buffer.
-   * @param buffer Buffer::Instance written to
-   * @param value the int64_t to write
-   */
-  static void writeI64(Buffer::Instance& buffer, int64_t value);
-
-  /**
    * Writes a double to the buffer.
    * @param buffer Buffer::Instance written to
    * @param value the double to write
    */
-  static void writeDouble(Buffer::Instance& buffer, double value);
+  static void writeBEDouble(Buffer::Instance& buffer, double value);
 
   /**
    * Writes a var-int encoded int32_t to the buffer.

--- a/source/extensions/filters/network/thrift_proxy/framed_transport_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/framed_transport_impl.cc
@@ -16,7 +16,7 @@ bool FramedTransportImpl::decodeFrameStart(Buffer::Instance& buffer, MessageMeta
     return false;
   }
 
-  int32_t thrift_size = BufferHelper::peekI32(buffer);
+  int32_t thrift_size = buffer.peekBEInt<int32_t>();
 
   if (thrift_size <= 0 || thrift_size > MaxFrameSize) {
     throw EnvoyException(fmt::format("invalid thrift framed transport frame size {}", thrift_size));
@@ -41,7 +41,7 @@ void FramedTransportImpl::encodeFrame(Buffer::Instance& buffer, const MessageMet
 
   int32_t thrift_size = static_cast<int32_t>(size);
 
-  BufferHelper::writeI32(buffer, thrift_size);
+  buffer.writeBEInt<int32_t>(thrift_size);
   buffer.move(message);
 }
 

--- a/test/common/buffer/BUILD
+++ b/test/common/buffer/BUILD
@@ -3,10 +3,31 @@ licenses(["notice"])  # Apache 2
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",
+    "envoy_cc_test_library",
     "envoy_package",
 )
 
 envoy_package()
+
+envoy_cc_test_library(
+    name = "utility_lib",
+    hdrs = ["utility.h"],
+    deps = [
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:byte_order_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "buffer_test",
+    srcs = ["buffer_test.cc"],
+    deps = [
+        ":utility_lib",
+        "//source/common/buffer:buffer_lib",
+        "//test/test_common:printers_lib",
+        "//test/test_common:utility_lib",
+    ],
+)
 
 envoy_cc_test(
     name = "owned_impl_test",

--- a/test/common/buffer/buffer_test.cc
+++ b/test/common/buffer/buffer_test.cc
@@ -1,0 +1,652 @@
+#include <limits>
+
+#include "envoy/common/exception.h"
+
+#include "common/buffer/buffer_impl.h"
+
+#include "test/common/buffer/utility.h"
+#include "test/test_common/printers.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Buffer {
+namespace {
+
+TEST(BufferHelperTest, PeekI8) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 0xFE});
+    EXPECT_EQ(buffer.peekInt<int8_t>(), 0);
+    EXPECT_EQ(buffer.peekInt<int8_t>(0), 0);
+    EXPECT_EQ(buffer.peekInt<int8_t>(1), 1);
+    EXPECT_EQ(buffer.peekInt<int8_t>(2), -2);
+    EXPECT_EQ(buffer.length(), 3);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekInt<int8_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeByte(0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekInt<int8_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekLEI16) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekLEInt<int16_t>(), 0x0100);
+    EXPECT_EQ(buffer.peekLEInt<int16_t>(0), 0x0100);
+    EXPECT_EQ(buffer.peekLEInt<int16_t>(1), 0x0201);
+    EXPECT_EQ(buffer.peekLEInt<int16_t>(2), 0x0302);
+    EXPECT_EQ(buffer.peekLEInt<int16_t>(4), -1);
+    EXPECT_EQ(buffer.length(), 6);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<int16_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 2, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<int16_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekLEI32) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekLEInt<int32_t>(), 0x03020100);
+    EXPECT_EQ(buffer.peekLEInt<int32_t>(0), 0x03020100);
+    EXPECT_EQ(buffer.peekLEInt<int32_t>(1), 0xFF030201);
+    EXPECT_EQ(buffer.peekLEInt<int32_t>(2), 0xFFFF0302);
+    EXPECT_EQ(buffer.peekLEInt<int32_t>(4), -1);
+    EXPECT_EQ(buffer.length(), 8);
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<int32_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 4, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<int32_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekLEI64) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekLEInt<int64_t>(), 0x0706050403020100);
+    EXPECT_EQ(buffer.peekLEInt<int64_t>(0), 0x0706050403020100);
+    EXPECT_EQ(buffer.peekLEInt<int64_t>(1), 0xFF07060504030201);
+    EXPECT_EQ(buffer.peekLEInt<int64_t>(2), 0xFFFF070605040302);
+    EXPECT_EQ(buffer.peekLEInt<int64_t>(8), -1);
+    EXPECT_EQ(buffer.length(), 16);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<int64_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 8, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<int64_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekLEU16) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekLEInt<uint16_t>(), 0x0100);
+    EXPECT_EQ(buffer.peekLEInt<uint16_t>(0), 0x0100);
+    EXPECT_EQ(buffer.peekLEInt<uint16_t>(1), 0x0201);
+    EXPECT_EQ(buffer.peekLEInt<uint16_t>(2), 0x0302);
+    EXPECT_EQ(buffer.peekLEInt<uint16_t>(4), 0xFFFF);
+    EXPECT_EQ(buffer.length(), 6);
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<uint16_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 2, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<uint16_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekLEU32) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekLEInt<uint32_t>(), 0x03020100);
+    EXPECT_EQ(buffer.peekLEInt<uint32_t>(0), 0x03020100);
+    EXPECT_EQ(buffer.peekLEInt<uint32_t>(1), 0xFF030201);
+    EXPECT_EQ(buffer.peekLEInt<uint32_t>(2), 0xFFFF0302);
+    EXPECT_EQ(buffer.peekLEInt<uint32_t>(4), 0xFFFFFFFF);
+    EXPECT_EQ(buffer.length(), 8);
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<uint32_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 4, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<uint32_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekLEU64) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekLEInt<uint64_t>(), 0x0706050403020100);
+    EXPECT_EQ(buffer.peekLEInt<uint64_t>(0), 0x0706050403020100);
+    EXPECT_EQ(buffer.peekLEInt<uint64_t>(1), 0xFF07060504030201);
+    EXPECT_EQ(buffer.peekLEInt<uint64_t>(2), 0xFFFF070605040302);
+    EXPECT_EQ(buffer.peekLEInt<uint64_t>(8), 0xFFFFFFFFFFFFFFFF);
+    EXPECT_EQ(buffer.length(), 16);
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<uint64_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 8, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekLEInt<uint64_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekBEI16) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekBEInt<int16_t>(), 1);
+    EXPECT_EQ(buffer.peekBEInt<int16_t>(0), 1);
+    EXPECT_EQ(buffer.peekBEInt<int16_t>(1), 0x0102);
+    EXPECT_EQ(buffer.peekBEInt<int16_t>(2), 0x0203);
+    EXPECT_EQ(buffer.peekBEInt<int16_t>(4), -1);
+    EXPECT_EQ(buffer.length(), 6);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<int16_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 2, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<int16_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekBEI32) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekBEInt<int32_t>(), 0x00010203);
+    EXPECT_EQ(buffer.peekBEInt<int32_t>(0), 0x00010203);
+    EXPECT_EQ(buffer.peekBEInt<int32_t>(1), 0x010203FF);
+    EXPECT_EQ(buffer.peekBEInt<int32_t>(2), 0x0203FFFF);
+    EXPECT_EQ(buffer.peekBEInt<int32_t>(4), -1);
+    EXPECT_EQ(buffer.length(), 8);
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<int32_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 4, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<int32_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekBEI64) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekBEInt<int64_t>(), 0x0001020304050607);
+    EXPECT_EQ(buffer.peekBEInt<int64_t>(0), 0x0001020304050607);
+    EXPECT_EQ(buffer.peekBEInt<int64_t>(1), 0x01020304050607FF);
+    EXPECT_EQ(buffer.peekBEInt<int64_t>(2), 0x020304050607FFFF);
+    EXPECT_EQ(buffer.peekBEInt<int64_t>(8), -1);
+    EXPECT_EQ(buffer.length(), 16);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<int64_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 8, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<int64_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekBEU16) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekBEInt<uint16_t>(), 1);
+    EXPECT_EQ(buffer.peekBEInt<uint16_t>(0), 1);
+    EXPECT_EQ(buffer.peekBEInt<uint16_t>(1), 0x0102);
+    EXPECT_EQ(buffer.peekBEInt<uint16_t>(2), 0x0203);
+    EXPECT_EQ(buffer.peekBEInt<uint16_t>(4), 0xFFFF);
+    EXPECT_EQ(buffer.length(), 6);
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<uint16_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 2, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<uint16_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekBEU32) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekBEInt<uint32_t>(), 0x00010203);
+    EXPECT_EQ(buffer.peekBEInt<uint32_t>(0), 0x00010203);
+    EXPECT_EQ(buffer.peekBEInt<uint32_t>(1), 0x010203FF);
+    EXPECT_EQ(buffer.peekBEInt<uint32_t>(2), 0x0203FFFF);
+    EXPECT_EQ(buffer.peekBEInt<uint32_t>(4), 0xFFFFFFFF);
+    EXPECT_EQ(buffer.length(), 8);
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<uint32_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 4, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<uint32_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, PeekBEU64) {
+  {
+    Buffer::OwnedImpl buffer;
+    addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+    EXPECT_EQ(buffer.peekBEInt<uint64_t>(), 0x0001020304050607);
+    EXPECT_EQ(buffer.peekBEInt<uint64_t>(0), 0x0001020304050607);
+    EXPECT_EQ(buffer.peekBEInt<uint64_t>(1), 0x01020304050607FF);
+    EXPECT_EQ(buffer.peekBEInt<uint64_t>(2), 0x020304050607FFFF);
+    EXPECT_EQ(buffer.peekBEInt<uint64_t>(8), 0xFFFFFFFFFFFFFFFF);
+    EXPECT_EQ(buffer.length(), 16);
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<uint64_t>(0), EnvoyException, "buffer underflow");
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    addRepeated(buffer, 8, 0);
+    EXPECT_THROW_WITH_MESSAGE(buffer.peekBEInt<uint64_t>(1), EnvoyException, "buffer underflow");
+  }
+}
+
+TEST(BufferHelperTest, DrainI8) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 0xFE});
+  EXPECT_EQ(buffer.drainInt<int8_t>(), 0);
+  EXPECT_EQ(buffer.drainInt<int8_t>(), 1);
+  EXPECT_EQ(buffer.drainInt<int8_t>(), -2);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainLEI16) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainLEIntOut<int16_t>(), 0x0100);
+  EXPECT_EQ(buffer.drainLEIntOut<int16_t>(), 0x0302);
+  EXPECT_EQ(buffer.drainLEIntOut<int16_t>(), -1);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainLEI32) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainLEIntOut<int32_t>(), 0x03020100);
+  EXPECT_EQ(buffer.drainLEIntOut<int32_t>(), -1);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainLEI64) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainLEIntOut<int64_t>(), 0x0706050403020100);
+  EXPECT_EQ(buffer.drainLEIntOut<int64_t>(), -1);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainLEU32) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainLEIntOut<uint32_t>(), 0x03020100);
+  EXPECT_EQ(buffer.drainLEIntOut<uint32_t>(), 0xFFFFFFFF);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainLEU64) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainLEIntOut<uint64_t>(), 0x0706050403020100);
+  EXPECT_EQ(buffer.drainLEIntOut<uint64_t>(), 0xFFFFFFFFFFFFFFFF);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainBEI16) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainBEIntOut<int16_t>(), 1);
+  EXPECT_EQ(buffer.drainBEIntOut<int16_t>(), 0x0203);
+  EXPECT_EQ(buffer.drainBEIntOut<int16_t>(), -1);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainBEI32) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainBEIntOut<int32_t>(), 0x00010203);
+  EXPECT_EQ(buffer.drainBEIntOut<int32_t>(), -1);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainBEI64) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainBEIntOut<int64_t>(), 0x0001020304050607);
+  EXPECT_EQ(buffer.drainBEIntOut<int64_t>(), -1);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainBEU32) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainBEIntOut<uint32_t>(), 0x00010203);
+  EXPECT_EQ(buffer.drainBEIntOut<uint32_t>(), 0xFFFFFFFF);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, DrainBEU64) {
+  Buffer::OwnedImpl buffer;
+  addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  EXPECT_EQ(buffer.drainBEIntOut<uint64_t>(), 0x0001020304050607);
+  EXPECT_EQ(buffer.drainBEIntOut<uint64_t>(), 0xFFFFFFFFFFFFFFFF);
+  EXPECT_EQ(buffer.length(), 0);
+}
+
+TEST(BufferHelperTest, WriteI8) {
+  Buffer::OwnedImpl buffer;
+  buffer.writeByte(-128);
+  buffer.writeByte(-1);
+  buffer.writeByte(0);
+  buffer.writeByte(1);
+  buffer.writeByte(127);
+
+  EXPECT_EQ(std::string("\x80\xFF\0\x1\x7F", 5), buffer.toString());
+}
+
+TEST(BufferHelperTest, WriteLEI16) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int16_t>(std::numeric_limits<int16_t>::min());
+    EXPECT_EQ(std::string("\0\x80", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int16_t>(0);
+    EXPECT_EQ(std::string("\0\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int16_t>(1);
+    EXPECT_EQ(std::string("\x1\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int16_t>(std::numeric_limits<int16_t>::max());
+    EXPECT_EQ("\xFF\x7F", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteLEU16) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<uint16_t>(0);
+    EXPECT_EQ(std::string("\0\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<uint16_t>(1);
+    EXPECT_EQ(std::string("\x1\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<uint16_t>(static_cast<uint16_t>(std::numeric_limits<int16_t>::max()) + 1);
+    EXPECT_EQ(std::string("\0\x80", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<uint16_t>(std::numeric_limits<uint16_t>::max());
+    EXPECT_EQ("\xFF\xFF", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteLEI32) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int32_t>(std::numeric_limits<int32_t>::min());
+    EXPECT_EQ(std::string("\0\0\0\x80", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int32_t>(0);
+    EXPECT_EQ(std::string("\0\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int32_t>(1);
+    EXPECT_EQ(std::string("\x1\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int32_t>(std::numeric_limits<int32_t>::max());
+    EXPECT_EQ("\xFF\xFF\xFF\x7F", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteLEU32) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<uint32_t>(0);
+    EXPECT_EQ(std::string("\0\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<uint32_t>(1);
+    EXPECT_EQ(std::string("\x1\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<uint32_t>(static_cast<uint32_t>(std::numeric_limits<int32_t>::max()) + 1);
+    EXPECT_EQ(std::string("\0\0\0\x80", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<uint32_t>(std::numeric_limits<uint32_t>::max());
+    EXPECT_EQ("\xFF\xFF\xFF\xFF", buffer.toString());
+  }
+}
+TEST(BufferHelperTest, WriteLEI64) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int64_t>(std::numeric_limits<int64_t>::min());
+    EXPECT_EQ(std::string("\0\0\0\0\0\0\0\x80", 8), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int64_t>(1);
+    EXPECT_EQ(std::string("\x1\0\0\0\0\0\0\0", 8), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int64_t>(0);
+    EXPECT_EQ(std::string("\0\0\0\0\0\0\0\0", 8), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeLEInt<int64_t>(std::numeric_limits<int64_t>::max());
+    EXPECT_EQ("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteBEI16) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int16_t>(std::numeric_limits<int16_t>::min());
+    EXPECT_EQ(std::string("\x80\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int16_t>(0);
+    EXPECT_EQ(std::string("\0\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int16_t>(1);
+    EXPECT_EQ(std::string("\0\x1", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int16_t>(std::numeric_limits<int16_t>::max());
+    EXPECT_EQ("\x7F\xFF", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteBEU16) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<uint16_t>(0);
+    EXPECT_EQ(std::string("\0\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<uint16_t>(1);
+    EXPECT_EQ(std::string("\0\x1", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<uint16_t>(static_cast<uint16_t>(std::numeric_limits<int16_t>::max()) + 1);
+    EXPECT_EQ(std::string("\x80\0", 2), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<uint16_t>(std::numeric_limits<uint16_t>::max());
+    EXPECT_EQ("\xFF\xFF", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteBEI32) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int32_t>(std::numeric_limits<int32_t>::min());
+    EXPECT_EQ(std::string("\x80\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int32_t>(0);
+    EXPECT_EQ(std::string("\0\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int32_t>(1);
+    EXPECT_EQ(std::string("\0\0\0\x1", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int32_t>(std::numeric_limits<int32_t>::max());
+    EXPECT_EQ("\x7F\xFF\xFF\xFF", buffer.toString());
+  }
+}
+
+TEST(BufferHelperTest, WriteBEU32) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<uint32_t>(0);
+    EXPECT_EQ(std::string("\0\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<uint32_t>(1);
+    EXPECT_EQ(std::string("\0\0\0\x1", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<uint32_t>(static_cast<uint32_t>(std::numeric_limits<int32_t>::max()) + 1);
+    EXPECT_EQ(std::string("\x80\0\0\0", 4), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<uint32_t>(std::numeric_limits<uint32_t>::max());
+    EXPECT_EQ("\xFF\xFF\xFF\xFF", buffer.toString());
+  }
+}
+TEST(BufferHelperTest, WriteBEI64) {
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int64_t>(std::numeric_limits<int64_t>::min());
+    EXPECT_EQ(std::string("\x80\0\0\0\0\0\0\0\0", 8), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int64_t>(1);
+    EXPECT_EQ(std::string("\0\0\0\0\0\0\0\x1", 8), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int64_t>(0);
+    EXPECT_EQ(std::string("\0\0\0\0\0\0\0\0", 8), buffer.toString());
+  }
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.writeBEInt<int64_t>(std::numeric_limits<int64_t>::max());
+    EXPECT_EQ("\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF", buffer.toString());
+  }
+}
+
+} // namespace
+} // namespace Buffer
+} // namespace Envoy

--- a/test/common/buffer/utility.h
+++ b/test/common/buffer/utility.h
@@ -22,17 +22,6 @@ inline void addSeq(Buffer::Instance& buffer, const std::initializer_list<uint8_t
   }
 }
 
-inline void addString(Buffer::Instance& buffer, const std::string& s) { buffer.add(s); }
-
-inline std::string bufferToString(Buffer::Instance& buffer) {
-  if (buffer.length() == 0) {
-    return "";
-  }
-
-  char* data = static_cast<char*>(buffer.linearize(buffer.length()));
-  return std::string(data, buffer.length());
-}
-
 } // namespace
 } // namespace Buffer
 } // namespace Envoy

--- a/test/common/buffer/utility.h
+++ b/test/common/buffer/utility.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <initializer_list>
+
+#include "common/buffer/buffer_impl.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Buffer {
+namespace {
+
+inline void addRepeated(Buffer::Instance& buffer, int n, int8_t value) {
+  for (int i = 0; i < n; i++) {
+    buffer.add(&value, 1);
+  }
+}
+
+inline void addSeq(Buffer::Instance& buffer, const std::initializer_list<uint8_t> values) {
+  for (int8_t value : values) {
+    buffer.add(&value, 1);
+  }
+}
+
+inline void addString(Buffer::Instance& buffer, const std::string& s) { buffer.add(s); }
+
+inline std::string bufferToString(Buffer::Instance& buffer) {
+  if (buffer.length() == 0) {
+    return "";
+  }
+
+  char* data = static_cast<char*>(buffer.linearize(buffer.length()));
+  return std::string(data, buffer.length());
+}
+
+} // namespace
+} // namespace Buffer
+} // namespace Envoy

--- a/test/extensions/filters/network/thrift_proxy/BUILD
+++ b/test/extensions/filters/network/thrift_proxy/BUILD
@@ -51,7 +51,9 @@ envoy_extension_cc_test_library(
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/common:byte_order_lib",
+        "//source/extensions/filters/network/thrift_proxy:protocol_lib",
         "//source/extensions/filters/network/thrift_proxy:thrift_lib",
+        "//test/common/buffer:utility_lib",
         "@envoy_api//envoy/config/filter/network/thrift_proxy/v2alpha1:thrift_proxy_cc",
     ],
 )

--- a/test/extensions/filters/network/thrift_proxy/auto_protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/auto_protocol_impl_test.cc
@@ -65,7 +65,7 @@ TEST_F(AutoProtocolTest, NotEnoughData) {
   AutoProtocolImpl proto;
   resetMetadata();
 
-  addInt8(buffer, 0);
+  buffer.writeByte(0);
   EXPECT_FALSE(proto.readMessageBegin(buffer, metadata_));
   expectDefaultMetadata();
 }
@@ -75,7 +75,7 @@ TEST_F(AutoProtocolTest, UnknownProtocol) {
   AutoProtocolImpl proto;
   resetMetadata();
 
-  addInt16(buffer, 0x0102);
+  buffer.writeBEInt<int16_t>(0x0102);
 
   EXPECT_THROW_WITH_MESSAGE(proto.readMessageBegin(buffer, metadata_), EnvoyException,
                             "unknown thrift auto protocol message start 0102");
@@ -89,12 +89,12 @@ TEST_F(AutoProtocolTest, ReadMessageBegin) {
     resetMetadata();
 
     Buffer::OwnedImpl buffer;
-    addInt16(buffer, 0x8001);
-    addInt8(buffer, 0);
-    addInt8(buffer, MessageType::Call);
-    addInt32(buffer, 8);
+    buffer.writeBEInt<int16_t>(0x8001);
+    buffer.writeByte(0);
+    buffer.writeByte(MessageType::Call);
+    buffer.writeBEInt<int32_t>(8);
     addString(buffer, "the_name");
-    addInt32(buffer, 1);
+    buffer.writeBEInt<int32_t>(1);
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, metadata_));
     expectMetadata("the_name", MessageType::Call, 1);
@@ -109,9 +109,9 @@ TEST_F(AutoProtocolTest, ReadMessageBegin) {
     resetMetadata();
 
     Buffer::OwnedImpl buffer;
-    addInt16(buffer, 0x8221);
-    addInt16(buffer, 0x8202); // 0x0102
-    addInt8(buffer, 8);
+    buffer.writeBEInt<int16_t>(0x8221);
+    buffer.writeBEInt<int16_t>(0x8202); // 0x0102
+    buffer.writeByte(8);
     addString(buffer, "the_name");
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, metadata_));
@@ -347,7 +347,7 @@ TEST_F(AutoProtocolTest, SetUnexpectedType) {
   AutoProtocolImpl proto;
   resetMetadata();
 
-  addInt16(buffer, 0x0102);
+  buffer.writeBEInt<int16_t>(0x0102);
 
   proto.setType(ProtocolType::Auto);
   EXPECT_THROW_WITH_MESSAGE(proto.readMessageBegin(buffer, metadata_), EnvoyException,

--- a/test/extensions/filters/network/thrift_proxy/auto_protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/auto_protocol_impl_test.cc
@@ -93,7 +93,7 @@ TEST_F(AutoProtocolTest, ReadMessageBegin) {
     buffer.writeByte(0);
     buffer.writeByte(MessageType::Call);
     buffer.writeBEInt<int32_t>(8);
-    addString(buffer, "the_name");
+    buffer.add("the_name");
     buffer.writeBEInt<int32_t>(1);
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, metadata_));
@@ -112,7 +112,7 @@ TEST_F(AutoProtocolTest, ReadMessageBegin) {
     buffer.writeBEInt<int16_t>(0x8221);
     buffer.writeBEInt<int16_t>(0x8202); // 0x0102
     buffer.writeByte(8);
-    addString(buffer, "the_name");
+    buffer.add("the_name");
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, metadata_));
     expectMetadata("the_name", MessageType::Call, 0x0102);

--- a/test/extensions/filters/network/thrift_proxy/auto_transport_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/auto_transport_impl_test.cc
@@ -47,8 +47,8 @@ TEST(AutoTransportTest, UnknownTransport) {
   // Looks like unframed, but fails protocol check.
   {
     Buffer::OwnedImpl buffer;
-    addInt32(buffer, 0);
-    addInt32(buffer, 0);
+    buffer.writeBEInt<int32_t>(0);
+    buffer.writeBEInt<int32_t>(0);
 
     MessageMetadata metadata;
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
@@ -59,8 +59,8 @@ TEST(AutoTransportTest, UnknownTransport) {
   // Looks like framed, but fails protocol check.
   {
     Buffer::OwnedImpl buffer;
-    addInt32(buffer, 0xFF);
-    addInt32(buffer, 0);
+    buffer.writeBEInt<int32_t>(0xFF);
+    buffer.writeBEInt<int32_t>(0);
 
     MessageMetadata metadata;
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
@@ -74,9 +74,9 @@ TEST(AutoTransportTest, DecodeFrameStart) {
   {
     AutoTransportImpl transport;
     Buffer::OwnedImpl buffer;
-    addInt32(buffer, 0xFF);
-    addInt16(buffer, 0x8001);
-    addInt16(buffer, 0);
+    buffer.writeBEInt<int32_t>(0xFF);
+    buffer.writeBEInt<int16_t>(0x8001);
+    buffer.writeBEInt<int16_t>(0);
 
     MessageMetadata metadata;
     EXPECT_TRUE(transport.decodeFrameStart(buffer, metadata));
@@ -90,9 +90,9 @@ TEST(AutoTransportTest, DecodeFrameStart) {
   {
     AutoTransportImpl transport;
     Buffer::OwnedImpl buffer;
-    addInt32(buffer, 0xFFF);
-    addInt16(buffer, 0x8201);
-    addInt16(buffer, 0);
+    buffer.writeBEInt<int32_t>(0xFFF);
+    buffer.writeBEInt<int16_t>(0x8201);
+    buffer.writeBEInt<int16_t>(0);
 
     MessageMetadata metadata;
     EXPECT_TRUE(transport.decodeFrameStart(buffer, metadata));
@@ -106,7 +106,7 @@ TEST(AutoTransportTest, DecodeFrameStart) {
   {
     AutoTransportImpl transport;
     Buffer::OwnedImpl buffer;
-    addInt16(buffer, 0x8001);
+    buffer.writeBEInt<int16_t>(0x8001);
     addRepeated(buffer, 6, 0);
 
     MessageMetadata metadata;
@@ -121,7 +121,7 @@ TEST(AutoTransportTest, DecodeFrameStart) {
   {
     AutoTransportImpl transport;
     Buffer::OwnedImpl buffer;
-    addInt16(buffer, 0x8201);
+    buffer.writeBEInt<int16_t>(0x8201);
     addRepeated(buffer, 6, 0);
 
     MessageMetadata metadata;
@@ -136,13 +136,13 @@ TEST(AutoTransportTest, DecodeFrameStart) {
   {
     AutoTransportImpl transport;
     Buffer::OwnedImpl buffer;
-    addInt32(buffer, 0xFF);
-    addInt16(buffer, 0x0FFF); // header magic
-    addInt16(buffer, 0x0000);
-    addInt32(buffer, 0xEE); // sequence id
-    addInt16(buffer, 1);
-    addInt32(buffer, 0); // protocol (binary), 0 transforms + padding
-    addInt16(buffer, 0x8001);
+    buffer.writeBEInt<int32_t>(0xFF);
+    buffer.writeBEInt<int16_t>(0x0FFF); // header magic
+    buffer.writeBEInt<int16_t>(0x0000);
+    buffer.writeBEInt<int32_t>(0xEE); // sequence id
+    buffer.writeBEInt<int16_t>(1);
+    buffer.writeBEInt<int32_t>(0); // protocol (binary), 0 transforms + padding
+    buffer.writeBEInt<int16_t>(0x8001);
 
     MessageMetadata metadata;
     EXPECT_TRUE(transport.decodeFrameStart(buffer, metadata));
@@ -158,13 +158,13 @@ TEST(AutoTransportTest, DecodeFrameStart) {
   {
     AutoTransportImpl transport;
     Buffer::OwnedImpl buffer;
-    addInt32(buffer, 0xFF);
-    addInt16(buffer, 0x0FFF); // header magic
-    addInt16(buffer, 0x0000);
-    addInt32(buffer, 0xEE); // sequence id
-    addInt16(buffer, 1);
-    addInt32(buffer, 0x02000000); // protocol (binary), 0 transforms + padding
-    addInt16(buffer, 0x8201);
+    buffer.writeBEInt<int32_t>(0xFF);
+    buffer.writeBEInt<int16_t>(0x0FFF); // header magic
+    buffer.writeBEInt<int16_t>(0x0000);
+    buffer.writeBEInt<int32_t>(0xEE); // sequence id
+    buffer.writeBEInt<int16_t>(1);
+    buffer.writeBEInt<int32_t>(0x02000000); // protocol (binary), 0 transforms + padding
+    buffer.writeBEInt<int16_t>(0x8201);
 
     MessageMetadata metadata;
     EXPECT_TRUE(transport.decodeFrameStart(buffer, metadata));
@@ -180,9 +180,9 @@ TEST(AutoTransportTest, DecodeFrameStart) {
 TEST(AutoTransportTest, DecodeFrameEnd) {
   AutoTransportImpl transport;
   Buffer::OwnedImpl buffer;
-  addInt32(buffer, 0xFF);
-  addInt16(buffer, 0x8001);
-  addInt16(buffer, 0);
+  buffer.writeBEInt<int32_t>(0xFF);
+  buffer.writeBEInt<int16_t>(0x8001);
+  buffer.writeBEInt<int16_t>(0);
 
   MessageMetadata metadata;
   EXPECT_TRUE(transport.decodeFrameStart(buffer, metadata));

--- a/test/extensions/filters/network/thrift_proxy/binary_protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/binary_protocol_impl_test.cc
@@ -71,7 +71,7 @@ TEST_F(BinaryProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt16(buffer, 0x0102);
+    buffer.writeBEInt<int16_t>(0x0102);
     addRepeated(buffer, 10, 'x');
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMessageBegin(buffer, metadata_), EnvoyException,
@@ -85,9 +85,9 @@ TEST_F(BinaryProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt16(buffer, 0x8001);
-    addInt8(buffer, 'x');
-    addInt8(buffer, static_cast<int8_t>(MessageType::LastMessageType) + 1);
+    buffer.writeBEInt<int16_t>(0x8001);
+    buffer.writeByte('x');
+    buffer.writeByte(static_cast<int8_t>(MessageType::LastMessageType) + 1);
     addRepeated(buffer, 8, 'x');
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMessageBegin(buffer, metadata_), EnvoyException,
@@ -102,11 +102,11 @@ TEST_F(BinaryProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt16(buffer, 0x8001);
-    addInt8(buffer, 'x');
-    addInt8(buffer, MessageType::Call);
-    addInt32(buffer, 0);
-    addInt32(buffer, 1234);
+    buffer.writeBEInt<int16_t>(0x8001);
+    buffer.writeByte('x');
+    buffer.writeByte(MessageType::Call);
+    buffer.writeBEInt<int32_t>(0);
+    buffer.writeBEInt<int32_t>(1234);
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, metadata_));
     expectMetadata("", MessageType::Call, 1234);
@@ -118,10 +118,10 @@ TEST_F(BinaryProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt16(buffer, 0x8001);
-    addInt8(buffer, 'x');
-    addInt8(buffer, MessageType::Call);
-    addInt32(buffer, 4); // name length
+    buffer.writeBEInt<int16_t>(0x8001);
+    buffer.writeByte('x');
+    buffer.writeByte(MessageType::Call);
+    buffer.writeBEInt<int32_t>(4); // name length
     addString(buffer, "abcd");
 
     EXPECT_FALSE(proto.readMessageBegin(buffer, metadata_));
@@ -134,12 +134,12 @@ TEST_F(BinaryProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt16(buffer, 0x8001);
-    addInt8(buffer, 0);
-    addInt8(buffer, MessageType::Call);
-    addInt32(buffer, 8);
+    buffer.writeBEInt<int16_t>(0x8001);
+    buffer.writeByte(0);
+    buffer.writeByte(MessageType::Call);
+    buffer.writeBEInt<int32_t>(8);
     addString(buffer, "the_name");
-    addInt32(buffer, 5678);
+    buffer.writeBEInt<int32_t>(5678);
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, metadata_));
     expectMetadata("the_name", MessageType::Call, 5678);
@@ -193,7 +193,7 @@ TEST_F(BinaryProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, FieldType::Stop);
+    buffer.writeByte(FieldType::Stop);
 
     EXPECT_TRUE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "");
@@ -209,7 +209,7 @@ TEST_F(BinaryProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, FieldType::I32);
+    buffer.writeByte(FieldType::I32);
 
     EXPECT_FALSE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "-");
@@ -224,8 +224,8 @@ TEST_F(BinaryProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, FieldType::I32);
-    addInt16(buffer, 99);
+    buffer.writeByte(FieldType::I32);
+    buffer.writeBEInt<int16_t>(99);
 
     EXPECT_TRUE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "");
@@ -241,8 +241,8 @@ TEST_F(BinaryProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, FieldType::I32);
-    addInt16(buffer, -1);
+    buffer.writeByte(FieldType::I32);
+    buffer.writeBEInt<int16_t>(-1);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readFieldBegin(buffer, name, field_type, field_id),
                               EnvoyException, "invalid binary protocol field id -1");
@@ -285,9 +285,9 @@ TEST_F(BinaryProtocolTest, ReadMapBegin) {
     FieldType value_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, FieldType::I32);
-    addInt8(buffer, FieldType::I32);
-    addInt32(buffer, -1);
+    buffer.writeByte(FieldType::I32);
+    buffer.writeByte(FieldType::I32);
+    buffer.writeBEInt<int32_t>(-1);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMapBegin(buffer, key_type, value_type, size),
                               EnvoyException, "negative binary protocol map size -1");
@@ -304,9 +304,9 @@ TEST_F(BinaryProtocolTest, ReadMapBegin) {
     FieldType value_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, FieldType::I32);
-    addInt8(buffer, FieldType::Double);
-    addInt32(buffer, 10);
+    buffer.writeByte(FieldType::I32);
+    buffer.writeByte(FieldType::Double);
+    buffer.writeBEInt<int32_t>(10);
 
     EXPECT_TRUE(proto.readMapBegin(buffer, key_type, value_type, size));
     EXPECT_EQ(key_type, FieldType::I32);
@@ -345,8 +345,8 @@ TEST_F(BinaryProtocolTest, ReadListBegin) {
     FieldType elem_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, FieldType::I32);
-    addInt32(buffer, -1);
+    buffer.writeByte(FieldType::I32);
+    buffer.writeBEInt<int32_t>(-1);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readListBegin(buffer, elem_type, size), EnvoyException,
                               "negative binary protocol list/set size -1");
@@ -361,8 +361,8 @@ TEST_F(BinaryProtocolTest, ReadListBegin) {
     FieldType elem_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, FieldType::I32);
-    addInt32(buffer, 10);
+    buffer.writeByte(FieldType::I32);
+    buffer.writeBEInt<int32_t>(10);
 
     EXPECT_TRUE(proto.readListBegin(buffer, elem_type, size));
     EXPECT_EQ(elem_type, FieldType::I32);
@@ -385,8 +385,8 @@ TEST_F(BinaryProtocolTest, ReadSetBegin) {
   FieldType elem_type = FieldType::String;
   uint32_t size = 1;
 
-  addInt8(buffer, FieldType::I32);
-  addInt32(buffer, 10);
+  buffer.writeByte(FieldType::I32);
+  buffer.writeBEInt<int32_t>(10);
 
   EXPECT_TRUE(proto.readSetBegin(buffer, elem_type, size));
   EXPECT_EQ(elem_type, FieldType::I32);
@@ -411,12 +411,12 @@ TEST_F(BinaryProtocolTest, ReadIntegerTypes) {
     EXPECT_FALSE(proto.readBool(buffer, value));
     EXPECT_FALSE(value);
 
-    addInt8(buffer, 1);
+    buffer.writeByte(1);
     EXPECT_TRUE(proto.readBool(buffer, value));
     EXPECT_TRUE(value);
     EXPECT_EQ(buffer.length(), 0);
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_TRUE(proto.readBool(buffer, value));
     EXPECT_FALSE(value);
     EXPECT_EQ(buffer.length(), 0);
@@ -430,12 +430,12 @@ TEST_F(BinaryProtocolTest, ReadIntegerTypes) {
     EXPECT_FALSE(proto.readByte(buffer, value));
     EXPECT_EQ(value, 1);
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_TRUE(proto.readByte(buffer, value));
     EXPECT_EQ(value, 0);
     EXPECT_EQ(buffer.length(), 0);
 
-    addInt8(buffer, 0xFF);
+    buffer.writeByte(0xFF);
     EXPECT_TRUE(proto.readByte(buffer, value));
     EXPECT_EQ(value, 0xFF);
     EXPECT_EQ(buffer.length(), 0);
@@ -446,17 +446,17 @@ TEST_F(BinaryProtocolTest, ReadIntegerTypes) {
     Buffer::OwnedImpl buffer;
     int16_t value = 1;
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_FALSE(proto.readInt16(buffer, value));
     EXPECT_EQ(value, 1);
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_TRUE(proto.readInt16(buffer, value));
     EXPECT_EQ(value, 0);
     EXPECT_EQ(buffer.length(), 0);
 
-    addInt8(buffer, 0x01);
-    addInt8(buffer, 0x02);
+    buffer.writeByte(0x01);
+    buffer.writeByte(0x02);
     EXPECT_TRUE(proto.readInt16(buffer, value));
     EXPECT_EQ(value, 0x0102);
     EXPECT_EQ(buffer.length(), 0);
@@ -476,7 +476,7 @@ TEST_F(BinaryProtocolTest, ReadIntegerTypes) {
     EXPECT_FALSE(proto.readInt32(buffer, value));
     EXPECT_EQ(value, 1);
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_TRUE(proto.readInt32(buffer, value));
     EXPECT_EQ(value, 0);
     EXPECT_EQ(buffer.length(), 0);
@@ -501,7 +501,7 @@ TEST_F(BinaryProtocolTest, ReadIntegerTypes) {
     EXPECT_FALSE(proto.readInt64(buffer, value));
     EXPECT_EQ(value, 1);
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_TRUE(proto.readInt64(buffer, value));
     EXPECT_EQ(value, 0);
     EXPECT_EQ(buffer.length(), 0);
@@ -566,7 +566,7 @@ TEST_F(BinaryProtocolTest, ReadString) {
     Buffer::OwnedImpl buffer;
     std::string value = "-";
 
-    addInt32(buffer, 1);
+    buffer.writeBEInt<int32_t>(1);
 
     EXPECT_FALSE(proto.readString(buffer, value));
     EXPECT_EQ(value, "-");
@@ -578,7 +578,7 @@ TEST_F(BinaryProtocolTest, ReadString) {
     Buffer::OwnedImpl buffer;
     std::string value = "-";
 
-    addInt32(buffer, -1);
+    buffer.writeBEInt<int32_t>(-1);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readString(buffer, value), EnvoyException,
                               "negative binary protocol string/binary length -1");
@@ -591,7 +591,7 @@ TEST_F(BinaryProtocolTest, ReadString) {
     Buffer::OwnedImpl buffer;
     std::string value = "-";
 
-    addInt32(buffer, 0);
+    buffer.writeBEInt<int32_t>(0);
 
     EXPECT_TRUE(proto.readString(buffer, value));
     EXPECT_EQ(value, "");
@@ -603,7 +603,7 @@ TEST_F(BinaryProtocolTest, ReadString) {
     Buffer::OwnedImpl buffer;
     std::string value = "-";
 
-    addInt32(buffer, 6);
+    buffer.writeBEInt<int32_t>(6);
     addString(buffer, "string");
 
     EXPECT_TRUE(proto.readString(buffer, value));
@@ -618,7 +618,7 @@ TEST_F(BinaryProtocolTest, ReadBinary) {
   Buffer::OwnedImpl buffer;
   std::string value = "-";
 
-  addInt32(buffer, 6);
+  buffer.writeBEInt<int32_t>(6);
   addString(buffer, "binary");
 
   EXPECT_TRUE(proto.readBinary(buffer, value));
@@ -925,8 +925,8 @@ TEST_F(LaxBinaryProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt32(buffer, 0);
-    addInt8(buffer, static_cast<int8_t>(MessageType::LastMessageType) + 1);
+    buffer.writeBEInt<int32_t>(0);
+    buffer.writeByte(static_cast<int8_t>(MessageType::LastMessageType) + 1);
     addRepeated(buffer, 4, 'x');
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMessageBegin(buffer, metadata_), EnvoyException,
@@ -941,9 +941,9 @@ TEST_F(LaxBinaryProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt32(buffer, 0);
-    addInt8(buffer, MessageType::Call);
-    addInt32(buffer, 1234);
+    buffer.writeBEInt<int32_t>(0);
+    buffer.writeByte(MessageType::Call);
+    buffer.writeBEInt<int32_t>(1234);
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, metadata_));
     expectMetadata("", MessageType::Call, 1234);
@@ -955,9 +955,9 @@ TEST_F(LaxBinaryProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt32(buffer, 1); // name length
-    addInt8(buffer, MessageType::Call);
-    addInt32(buffer, 1234);
+    buffer.writeBEInt<int32_t>(1); // name length
+    buffer.writeByte(MessageType::Call);
+    buffer.writeBEInt<int32_t>(1234);
 
     EXPECT_FALSE(proto.readMessageBegin(buffer, metadata_));
     expectDefaultMetadata();
@@ -969,10 +969,10 @@ TEST_F(LaxBinaryProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt32(buffer, 8);
+    buffer.writeBEInt<int32_t>(8);
     addString(buffer, "the_name");
-    addInt8(buffer, MessageType::Call);
-    addInt32(buffer, 5678);
+    buffer.writeByte(MessageType::Call);
+    buffer.writeBEInt<int32_t>(5678);
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, metadata_));
     expectMetadata("the_name", MessageType::Call, 5678);

--- a/test/extensions/filters/network/thrift_proxy/binary_protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/binary_protocol_impl_test.cc
@@ -122,7 +122,7 @@ TEST_F(BinaryProtocolTest, ReadMessageBegin) {
     buffer.writeByte('x');
     buffer.writeByte(MessageType::Call);
     buffer.writeBEInt<int32_t>(4); // name length
-    addString(buffer, "abcd");
+    buffer.add("abcd");
 
     EXPECT_FALSE(proto.readMessageBegin(buffer, metadata_));
     expectDefaultMetadata();
@@ -138,7 +138,7 @@ TEST_F(BinaryProtocolTest, ReadMessageBegin) {
     buffer.writeByte(0);
     buffer.writeByte(MessageType::Call);
     buffer.writeBEInt<int32_t>(8);
-    addString(buffer, "the_name");
+    buffer.add("the_name");
     buffer.writeBEInt<int32_t>(5678);
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, metadata_));
@@ -604,7 +604,7 @@ TEST_F(BinaryProtocolTest, ReadString) {
     std::string value = "-";
 
     buffer.writeBEInt<int32_t>(6);
-    addString(buffer, "string");
+    buffer.add("string");
 
     EXPECT_TRUE(proto.readString(buffer, value));
     EXPECT_EQ(value, "string");
@@ -619,7 +619,7 @@ TEST_F(BinaryProtocolTest, ReadBinary) {
   std::string value = "-";
 
   buffer.writeBEInt<int32_t>(6);
-  addString(buffer, "binary");
+  buffer.add("binary");
 
   EXPECT_TRUE(proto.readBinary(buffer, value));
   EXPECT_EQ(value, "binary");
@@ -970,7 +970,7 @@ TEST_F(LaxBinaryProtocolTest, ReadMessageBegin) {
     resetMetadata();
 
     buffer.writeBEInt<int32_t>(8);
-    addString(buffer, "the_name");
+    buffer.add("the_name");
     buffer.writeByte(MessageType::Call);
     buffer.writeBEInt<int32_t>(5678);
 

--- a/test/extensions/filters/network/thrift_proxy/buffer_helper_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/buffer_helper_test.cc
@@ -17,219 +17,6 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace ThriftProxy {
 
-TEST(BufferHelperTest, PeekI8) {
-  {
-    Buffer::OwnedImpl buffer;
-    addSeq(buffer, {0, 1, 0xFE});
-    EXPECT_EQ(BufferHelper::peekI8(buffer), 0);
-    EXPECT_EQ(BufferHelper::peekI8(buffer, 0), 0);
-    EXPECT_EQ(BufferHelper::peekI8(buffer, 1), 1);
-    EXPECT_EQ(BufferHelper::peekI8(buffer, 2), -2);
-    EXPECT_EQ(buffer.length(), 3);
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekI8(buffer, 0), EnvoyException, "buffer underflow");
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    addInt8(buffer, 0);
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekI8(buffer, 1), EnvoyException, "buffer underflow");
-  }
-}
-
-TEST(BufferHelperTest, PeekI16) {
-  {
-    Buffer::OwnedImpl buffer;
-    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
-    EXPECT_EQ(BufferHelper::peekI16(buffer), 1);
-    EXPECT_EQ(BufferHelper::peekI16(buffer, 0), 1);
-    EXPECT_EQ(BufferHelper::peekI16(buffer, 1), 0x0102);
-    EXPECT_EQ(BufferHelper::peekI16(buffer, 2), 0x0203);
-    EXPECT_EQ(BufferHelper::peekI16(buffer, 4), -1);
-    EXPECT_EQ(buffer.length(), 6);
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekI16(buffer, 0), EnvoyException, "buffer underflow");
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    addRepeated(buffer, 2, 0);
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekI16(buffer, 1), EnvoyException, "buffer underflow");
-  }
-}
-
-TEST(BufferHelperTest, PeekI32) {
-  {
-    Buffer::OwnedImpl buffer;
-    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
-    EXPECT_EQ(BufferHelper::peekI32(buffer), 0x00010203);
-    EXPECT_EQ(BufferHelper::peekI32(buffer, 0), 0x00010203);
-    EXPECT_EQ(BufferHelper::peekI32(buffer, 1), 0x010203FF);
-    EXPECT_EQ(BufferHelper::peekI32(buffer, 2), 0x0203FFFF);
-    EXPECT_EQ(BufferHelper::peekI32(buffer, 4), -1);
-    EXPECT_EQ(buffer.length(), 8);
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekI32(buffer, 0), EnvoyException, "buffer underflow");
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    addRepeated(buffer, 4, 0);
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekI32(buffer, 1), EnvoyException, "buffer underflow");
-  }
-}
-
-TEST(BufferHelperTest, PeekI64) {
-  {
-    Buffer::OwnedImpl buffer;
-    addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
-    EXPECT_EQ(BufferHelper::peekI64(buffer), 0x0001020304050607);
-    EXPECT_EQ(BufferHelper::peekI64(buffer, 0), 0x0001020304050607);
-    EXPECT_EQ(BufferHelper::peekI64(buffer, 1), 0x01020304050607FF);
-    EXPECT_EQ(BufferHelper::peekI64(buffer, 2), 0x020304050607FFFF);
-    EXPECT_EQ(BufferHelper::peekI64(buffer, 8), -1);
-    EXPECT_EQ(buffer.length(), 16);
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekI64(buffer, 0), EnvoyException, "buffer underflow");
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    addRepeated(buffer, 8, 0);
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekI64(buffer, 1), EnvoyException, "buffer underflow");
-  }
-}
-
-TEST(BufferHelperTest, PeekU16) {
-  {
-    Buffer::OwnedImpl buffer;
-    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
-    EXPECT_EQ(BufferHelper::peekU16(buffer), 1);
-    EXPECT_EQ(BufferHelper::peekU16(buffer, 0), 1);
-    EXPECT_EQ(BufferHelper::peekU16(buffer, 1), 0x0102);
-    EXPECT_EQ(BufferHelper::peekU16(buffer, 2), 0x0203);
-    EXPECT_EQ(BufferHelper::peekU16(buffer, 4), 0xFFFF);
-    EXPECT_EQ(buffer.length(), 6);
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekU16(buffer, 0), EnvoyException, "buffer underflow");
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    addRepeated(buffer, 2, 0);
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekU16(buffer, 1), EnvoyException, "buffer underflow");
-  }
-}
-
-TEST(BufferHelperTest, PeekU32) {
-  {
-    Buffer::OwnedImpl buffer;
-    addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
-    EXPECT_EQ(BufferHelper::peekU32(buffer), 0x00010203);
-    EXPECT_EQ(BufferHelper::peekU32(buffer, 0), 0x00010203);
-    EXPECT_EQ(BufferHelper::peekU32(buffer, 1), 0x010203FF);
-    EXPECT_EQ(BufferHelper::peekU32(buffer, 2), 0x0203FFFF);
-    EXPECT_EQ(BufferHelper::peekU32(buffer, 4), 0xFFFFFFFF);
-    EXPECT_EQ(buffer.length(), 8);
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekU32(buffer, 0), EnvoyException, "buffer underflow");
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    addRepeated(buffer, 4, 0);
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekU32(buffer, 1), EnvoyException, "buffer underflow");
-  }
-}
-
-TEST(BufferHelperTest, PeekU64) {
-  {
-    Buffer::OwnedImpl buffer;
-    addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
-    EXPECT_EQ(BufferHelper::peekU64(buffer), 0x0001020304050607);
-    EXPECT_EQ(BufferHelper::peekU64(buffer, 0), 0x0001020304050607);
-    EXPECT_EQ(BufferHelper::peekU64(buffer, 1), 0x01020304050607FF);
-    EXPECT_EQ(BufferHelper::peekU64(buffer, 2), 0x020304050607FFFF);
-    EXPECT_EQ(BufferHelper::peekU64(buffer, 8), 0xFFFFFFFFFFFFFFFF);
-    EXPECT_EQ(buffer.length(), 16);
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekU64(buffer, 0), EnvoyException, "buffer underflow");
-  }
-
-  {
-    Buffer::OwnedImpl buffer;
-    addRepeated(buffer, 8, 0);
-    EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekU64(buffer, 1), EnvoyException, "buffer underflow");
-  }
-}
-
-TEST(BufferHelperTest, DrainI8) {
-  Buffer::OwnedImpl buffer;
-  addSeq(buffer, {0, 1, 0xFE});
-  EXPECT_EQ(BufferHelper::drainI8(buffer), 0);
-  EXPECT_EQ(BufferHelper::drainI8(buffer), 1);
-  EXPECT_EQ(BufferHelper::drainI8(buffer), -2);
-  EXPECT_EQ(buffer.length(), 0);
-}
-
-TEST(BufferHelperTest, DrainI16) {
-  Buffer::OwnedImpl buffer;
-  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF});
-  EXPECT_EQ(BufferHelper::drainI16(buffer), 1);
-  EXPECT_EQ(BufferHelper::drainI16(buffer), 0x0203);
-  EXPECT_EQ(BufferHelper::drainI16(buffer), -1);
-  EXPECT_EQ(buffer.length(), 0);
-}
-
-TEST(BufferHelperTest, DrainI32) {
-  Buffer::OwnedImpl buffer;
-  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
-  EXPECT_EQ(BufferHelper::drainI32(buffer), 0x00010203);
-  EXPECT_EQ(BufferHelper::drainI32(buffer), -1);
-  EXPECT_EQ(buffer.length(), 0);
-}
-
-TEST(BufferHelperTest, DrainI64) {
-  Buffer::OwnedImpl buffer;
-  addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
-  EXPECT_EQ(BufferHelper::drainI64(buffer), 0x0001020304050607);
-  EXPECT_EQ(BufferHelper::drainI64(buffer), -1);
-  EXPECT_EQ(buffer.length(), 0);
-}
-
-TEST(BufferHelperTest, DrainU32) {
-  Buffer::OwnedImpl buffer;
-  addSeq(buffer, {0, 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF});
-  EXPECT_EQ(BufferHelper::drainU32(buffer), 0x00010203);
-  EXPECT_EQ(BufferHelper::drainU32(buffer), 0xFFFFFFFF);
-  EXPECT_EQ(buffer.length(), 0);
-}
-
-TEST(BufferHelperTest, DrainU64) {
-  Buffer::OwnedImpl buffer;
-  addSeq(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
-  EXPECT_EQ(BufferHelper::drainU64(buffer), 0x0001020304050607);
-  EXPECT_EQ(BufferHelper::drainU64(buffer), 0xFFFFFFFFFFFFFFFF);
-  EXPECT_EQ(buffer.length(), 0);
-}
-
 TEST(BufferHelperTest, DrainDouble) {
   Buffer::OwnedImpl buffer;
 
@@ -240,16 +27,16 @@ TEST(BufferHelperTest, DrainDouble) {
   // 11111111 11101111 11111111 1111111 11111111 11111111 11111111 111111111 = -DBL_MAX
   addSeq(buffer, {0xFF, 0xEF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
 
-  EXPECT_EQ(BufferHelper::drainDouble(buffer), 3.0);
-  EXPECT_EQ(BufferHelper::drainDouble(buffer), std::numeric_limits<double>::lowest());
+  EXPECT_EQ(BufferHelper::drainBEDouble(buffer), 3.0);
+  EXPECT_EQ(BufferHelper::drainBEDouble(buffer), std::numeric_limits<double>::lowest());
   EXPECT_EQ(buffer.length(), 0);
 }
 
 TEST(BufferHelperTest, PeekVarInt32) {
   {
     Buffer::OwnedImpl buffer;
-    addInt8(buffer, 0);
-    addInt8(buffer, 0x7F);
+    buffer.writeByte(0);
+    buffer.writeByte(0x7F);
     addSeq(buffer, {0xFF, 0x01});                   // 0xFF
     addSeq(buffer, {0xFF, 0xFF, 0x03});             // 0xFFFF
     addSeq(buffer, {0xFF, 0xFF, 0xFF, 0x07});       // 0xFFFFFF
@@ -289,7 +76,7 @@ TEST(BufferHelperTest, PeekVarInt32) {
   {
     Buffer::OwnedImpl buffer;
     int size = 0;
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekVarIntI32(buffer, 1, size), EnvoyException,
                               "buffer underflow");
   }
@@ -300,21 +87,21 @@ TEST(BufferHelperTest, PeekVarInt32BufferUnderflow) {
   int size = 0;
 
   for (int i = 1; i < 5; i++) {
-    addInt8(buffer, 0x80);
+    buffer.writeByte(0x80);
     EXPECT_EQ(BufferHelper::peekVarIntI32(buffer, 0, size), 0);
     EXPECT_EQ(size, -i);
   }
 
-  addInt8(buffer, 0x80);
+  buffer.writeByte(0x80);
   EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekVarIntI32(buffer, 0, size), EnvoyException,
                             "invalid compact protocol varint i32");
 }
 
 TEST(BufferHelperTest, PeekZigZagI32) {
   Buffer::OwnedImpl buffer;
-  addInt8(buffer, 0);                             // unzigzag(0) = 0
-  addInt8(buffer, 1);                             // unzigzag(1) = -1
-  addInt8(buffer, 2);                             // unzigzag(2) = 1
+  buffer.writeByte(0);                            // unzigzag(0) = 0
+  buffer.writeByte(1);                            // unzigzag(1) = -1
+  buffer.writeByte(2);                            // unzigzag(2) = 1
   addSeq(buffer, {0xFE, 0x01});                   // unzigzag(0xFE) = 127
   addSeq(buffer, {0xFF, 0x01});                   // unzigzag(0xFF) = -128
   addSeq(buffer, {0xFF, 0xFF, 0x03});             // unzigzag(0xFFFF) = -32768
@@ -360,21 +147,21 @@ TEST(BufferHelperTest, PeekZigZagI32BufferUnderflow) {
   int size = 0;
 
   for (int i = 1; i < 5; i++) {
-    addInt8(buffer, 0x80);
+    buffer.writeByte(0x80);
     EXPECT_EQ(BufferHelper::peekZigZagI32(buffer, 0, size), 0);
     EXPECT_EQ(size, -i);
   }
 
-  addInt8(buffer, 0x80);
+  buffer.writeByte(0x80);
   EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekZigZagI32(buffer, 0, size), EnvoyException,
                             "invalid compact protocol zig-zag i32");
 }
 
 TEST(BufferHelperTest, PeekZigZagI64) {
   Buffer::OwnedImpl buffer;
-  addInt8(buffer, 0);                             // unzigzag(0) = 0
-  addInt8(buffer, 1);                             // unzigzag(1) = -1
-  addInt8(buffer, 2);                             // unzigzag(2) = 1
+  buffer.writeByte(0);                            // unzigzag(0) = 0
+  buffer.writeByte(1);                            // unzigzag(1) = -1
+  buffer.writeByte(2);                            // unzigzag(2) = 1
   addSeq(buffer, {0xFF, 0xFF, 0x03});             // unzigzag(0xFFFF) = -32768
   addSeq(buffer, {0xFE, 0xFF, 0xFF, 0xFF, 0x0F}); // unzigzag(0xFFFF FFFE) = 0x7FFF FFFF
 
@@ -418,152 +205,27 @@ TEST(BufferHelperTest, PeekZigZagI64BufferUnderflow) {
   int size = 0;
 
   for (int i = 1; i < 10; i++) {
-    addInt8(buffer, 0x80);
+    buffer.writeByte(0x80);
     EXPECT_EQ(BufferHelper::peekZigZagI64(buffer, 0, size), 0);
     EXPECT_EQ(size, -i);
   }
 
-  addInt8(buffer, 0x80);
+  buffer.writeByte(0x80);
   EXPECT_THROW_WITH_MESSAGE(BufferHelper::peekZigZagI64(buffer, 0, size), EnvoyException,
                             "invalid compact protocol zig-zag i64");
-}
-
-TEST(BufferHelperTest, WriteI8) {
-  Buffer::OwnedImpl buffer;
-  BufferHelper::writeI8(buffer, -128);
-  BufferHelper::writeI8(buffer, -1);
-  BufferHelper::writeI8(buffer, 0);
-  BufferHelper::writeI8(buffer, 1);
-  BufferHelper::writeI8(buffer, 127);
-
-  EXPECT_EQ(std::string("\x80\xFF\0\x1\x7F", 5), buffer.toString());
-}
-
-TEST(BufferHelperTest, WriteI16) {
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI16(buffer, std::numeric_limits<int16_t>::min());
-    EXPECT_EQ(std::string("\x80\0", 2), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI16(buffer, 0);
-    EXPECT_EQ(std::string("\0\0", 2), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI16(buffer, 1);
-    EXPECT_EQ(std::string("\0\x1", 2), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI16(buffer, std::numeric_limits<int16_t>::max());
-    EXPECT_EQ("\x7F\xFF", buffer.toString());
-  }
-}
-
-TEST(BufferHelperTest, WriteU16) {
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeU16(buffer, 0);
-    EXPECT_EQ(std::string("\0\0", 2), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeU16(buffer, 1);
-    EXPECT_EQ(std::string("\0\x1", 2), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeU16(buffer, static_cast<uint16_t>(std::numeric_limits<int16_t>::max()) + 1);
-    EXPECT_EQ(std::string("\x80\0", 2), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeU16(buffer, std::numeric_limits<uint16_t>::max());
-    EXPECT_EQ("\xFF\xFF", buffer.toString());
-  }
-}
-
-TEST(BufferHelperTest, WriteI32) {
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI32(buffer, std::numeric_limits<int32_t>::min());
-    EXPECT_EQ(std::string("\x80\0\0\0", 4), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI32(buffer, 0);
-    EXPECT_EQ(std::string("\0\0\0\0", 4), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI32(buffer, 1);
-    EXPECT_EQ(std::string("\0\0\0\x1", 4), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI32(buffer, std::numeric_limits<int32_t>::max());
-    EXPECT_EQ("\x7F\xFF\xFF\xFF", buffer.toString());
-  }
-}
-
-TEST(BufferHelperTest, WriteU32) {
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeU32(buffer, 0);
-    EXPECT_EQ(std::string("\0\0\0\0", 4), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeU32(buffer, 1);
-    EXPECT_EQ(std::string("\0\0\0\x1", 4), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeU32(buffer, static_cast<uint32_t>(std::numeric_limits<int32_t>::max()) + 1);
-    EXPECT_EQ(std::string("\x80\0\0\0", 4), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeU32(buffer, std::numeric_limits<uint32_t>::max());
-    EXPECT_EQ("\xFF\xFF\xFF\xFF", buffer.toString());
-  }
-}
-TEST(BufferHelperTest, WriteI64) {
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI64(buffer, std::numeric_limits<int64_t>::min());
-    EXPECT_EQ(std::string("\x80\0\0\0\0\0\0\0\0", 8), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI64(buffer, 1);
-    EXPECT_EQ(std::string("\0\0\0\0\0\0\0\x1", 8), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI64(buffer, 0);
-    EXPECT_EQ(std::string("\0\0\0\0\0\0\0\0", 8), buffer.toString());
-  }
-  {
-    Buffer::OwnedImpl buffer;
-    BufferHelper::writeI64(buffer, std::numeric_limits<int64_t>::max());
-    EXPECT_EQ("\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF", buffer.toString());
-  }
 }
 
 TEST(BufferHelperTest, WriteDouble) {
   // See the DrainDouble test.
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeDouble(buffer, 3.0);
+    BufferHelper::writeBEDouble(buffer, 3.0);
     EXPECT_EQ(std::string("\x40\x8\0\0\0\0\0\0", 8), buffer.toString());
   }
 
   {
     Buffer::OwnedImpl buffer;
-    BufferHelper::writeDouble(buffer, std::numeric_limits<double>::lowest());
+    BufferHelper::writeBEDouble(buffer, std::numeric_limits<double>::lowest());
     EXPECT_EQ("\xFF\xEF\xFF\xFF\xFF\xFF\xFF\xFF", buffer.toString());
   }
 }

--- a/test/extensions/filters/network/thrift_proxy/compact_protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/compact_protocol_impl_test.cc
@@ -72,7 +72,7 @@ TEST_F(CompactProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt16(buffer, 0x0102);
+    buffer.writeBEInt<int16_t>(0x0102);
     addRepeated(buffer, 2, 'x');
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMessageBegin(buffer, metadata_), EnvoyException,
@@ -88,7 +88,7 @@ TEST_F(CompactProtocolTest, ReadMessageBegin) {
 
     // Message type is encoded in the 3 highest order bits of the second byte.
     int8_t invalid_msg_type = static_cast<int8_t>(MessageType::LastMessageType) + 1;
-    addInt16(buffer, static_cast<int16_t>(0x8201 | (invalid_msg_type << 5)));
+    buffer.writeBEInt<int16_t>(static_cast<int16_t>(0x8201 | (invalid_msg_type << 5)));
     addRepeated(buffer, 2, 'x');
 
     EXPECT_THROW_WITH_MESSAGE(
@@ -103,7 +103,7 @@ TEST_F(CompactProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt16(buffer, 0x8221);
+    buffer.writeBEInt<int16_t>(0x8221);
     addRepeated(buffer, 2, 0x81);
 
     EXPECT_FALSE(proto.readMessageBegin(buffer, metadata_));
@@ -116,9 +116,9 @@ TEST_F(CompactProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt16(buffer, 0x8221);
+    buffer.writeBEInt<int16_t>(0x8221);
     addSeq(buffer, {0x81, 0x81, 0x81, 0x81, 0x81, 0}); // > 32 bit varint
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMessageBegin(buffer, metadata_), EnvoyException,
                               "invalid compact protocol varint i32");
@@ -131,9 +131,9 @@ TEST_F(CompactProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt16(buffer, 0x8221);
-    addInt8(buffer, 32);
-    addInt8(buffer, 0x81); // unterminated varint
+    buffer.writeBEInt<int16_t>(0x8221);
+    buffer.writeByte(32);
+    buffer.writeByte(0x81); // unterminated varint
 
     EXPECT_FALSE(proto.readMessageBegin(buffer, metadata_));
     expectDefaultMetadata();
@@ -145,9 +145,9 @@ TEST_F(CompactProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt16(buffer, 0x8221);
-    addInt8(buffer, 32);
-    addInt8(buffer, 10);
+    buffer.writeBEInt<int16_t>(0x8221);
+    buffer.writeByte(32);
+    buffer.writeByte(10);
     addString(buffer, "partial");
 
     EXPECT_FALSE(proto.readMessageBegin(buffer, metadata_));
@@ -160,9 +160,9 @@ TEST_F(CompactProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt16(buffer, 0x8221);
-    addInt8(buffer, 32);
-    addInt8(buffer, 0);
+    buffer.writeBEInt<int16_t>(0x8221);
+    buffer.writeByte(32);
+    buffer.writeByte(0);
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, metadata_));
     expectMetadata("", MessageType::Call, 32);
@@ -174,8 +174,8 @@ TEST_F(CompactProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt16(buffer, 0x8221);
-    addInt8(buffer, 32);
+    buffer.writeBEInt<int16_t>(0x8221);
+    buffer.writeByte(32);
     addSeq(buffer, {0x81, 0x81, 0x81, 0x81, 0x81, 0}); // > 32 bit varint
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMessageBegin(buffer, metadata_), EnvoyException,
@@ -189,8 +189,8 @@ TEST_F(CompactProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt16(buffer, 0x8221);
-    addInt8(buffer, 32);
+    buffer.writeBEInt<int16_t>(0x8221);
+    buffer.writeByte(32);
     addSeq(buffer, {0xFF, 0xFF, 0xFF, 0xFF, 0x1F}); // -1
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMessageBegin(buffer, metadata_), EnvoyException,
@@ -204,9 +204,9 @@ TEST_F(CompactProtocolTest, ReadMessageBegin) {
     Buffer::OwnedImpl buffer;
     resetMetadata();
 
-    addInt16(buffer, 0x8221);
-    addInt16(buffer, 0x8202); // 0x0102
-    addInt8(buffer, 8);
+    buffer.writeBEInt<int16_t>(0x8221);
+    buffer.writeBEInt<int16_t>(0x8202); // 0x0102
+    buffer.writeByte(8);
     addString(buffer, "the_name");
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, metadata_));
@@ -259,7 +259,7 @@ TEST_F(CompactProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, 0xF0);
+    buffer.writeByte(0xF0);
 
     EXPECT_TRUE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "");
@@ -275,7 +275,7 @@ TEST_F(CompactProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, 0x05);
+    buffer.writeByte(0x05);
 
     EXPECT_FALSE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "-");
@@ -291,8 +291,8 @@ TEST_F(CompactProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, 0x05);
-    addInt8(buffer, 0x81);
+    buffer.writeByte(0x05);
+    buffer.writeByte(0x81);
 
     EXPECT_FALSE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "-");
@@ -316,7 +316,7 @@ TEST_F(CompactProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, 0x05);
+    buffer.writeByte(0x05);
     addSeq(buffer, {0x80, 0x80, 0x04}); // zigzag(0x10000) = 0x8000
 
     EXPECT_THROW_WITH_MESSAGE(proto.readFieldBegin(buffer, name, field_type, field_id),
@@ -334,7 +334,7 @@ TEST_F(CompactProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, 0x05);
+    buffer.writeByte(0x05);
     addSeq(buffer, {0x01}); // zigzag(1) = -1
 
     EXPECT_THROW_WITH_MESSAGE(proto.readFieldBegin(buffer, name, field_type, field_id),
@@ -352,8 +352,8 @@ TEST_F(CompactProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, 0x0D);
-    addInt8(buffer, 0x04);
+    buffer.writeByte(0x0D);
+    buffer.writeByte(0x04);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readFieldBegin(buffer, name, field_type, field_id),
                               EnvoyException, "unknown compact protocol field type 13");
@@ -370,8 +370,8 @@ TEST_F(CompactProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, 0x05);
-    addInt8(buffer, 0x04);
+    buffer.writeByte(0x05);
+    buffer.writeByte(0x04);
 
     EXPECT_TRUE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "");
@@ -387,7 +387,7 @@ TEST_F(CompactProtocolTest, ReadFieldBegin) {
     FieldType field_type = FieldType::String;
     int16_t field_id = 1;
 
-    addInt8(buffer, 0xF5);
+    buffer.writeByte(0xF5);
 
     EXPECT_TRUE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "");
@@ -413,7 +413,7 @@ TEST_F(CompactProtocolTest, ReadMapBegin) {
     FieldType value_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0x81); // unterminated varint
+    buffer.writeByte(0x81); // unterminated varint
 
     EXPECT_FALSE(proto.readMapBegin(buffer, key_type, value_type, size));
     EXPECT_EQ(key_type, FieldType::String);
@@ -463,7 +463,7 @@ TEST_F(CompactProtocolTest, ReadMapBegin) {
     FieldType value_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 2);
+    buffer.writeByte(2);
 
     EXPECT_FALSE(proto.readMapBegin(buffer, key_type, value_type, size));
     EXPECT_EQ(key_type, FieldType::String);
@@ -479,7 +479,7 @@ TEST_F(CompactProtocolTest, ReadMapBegin) {
     FieldType value_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
 
     EXPECT_TRUE(proto.readMapBegin(buffer, key_type, value_type, size));
     EXPECT_EQ(key_type, FieldType::Stop);
@@ -496,7 +496,7 @@ TEST_F(CompactProtocolTest, ReadMapBegin) {
     uint32_t size = 1;
 
     addSeq(buffer, {0x80, 0x01}); // 0x80
-    addInt8(buffer, 0x57);
+    buffer.writeByte(0x57);
 
     EXPECT_TRUE(proto.readMapBegin(buffer, key_type, value_type, size));
     EXPECT_EQ(key_type, FieldType::I32);
@@ -512,8 +512,8 @@ TEST_F(CompactProtocolTest, ReadMapBegin) {
     FieldType value_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0x02);
-    addInt8(buffer, 0xD7);
+    buffer.writeByte(0x02);
+    buffer.writeByte(0xD7);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMapBegin(buffer, key_type, value_type, size),
                               EnvoyException, "unknown compact protocol field type 13");
@@ -530,8 +530,8 @@ TEST_F(CompactProtocolTest, ReadMapBegin) {
     FieldType value_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0x02);
-    addInt8(buffer, 0x5D);
+    buffer.writeByte(0x02);
+    buffer.writeByte(0x5D);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readMapBegin(buffer, key_type, value_type, size),
                               EnvoyException, "unknown compact protocol field type 13");
@@ -569,7 +569,7 @@ TEST_F(CompactProtocolTest, ReadListBegin) {
     FieldType elem_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0xE5);
+    buffer.writeByte(0xE5);
 
     EXPECT_TRUE(proto.readListBegin(buffer, elem_type, size));
     EXPECT_EQ(elem_type, FieldType::I32);
@@ -583,8 +583,8 @@ TEST_F(CompactProtocolTest, ReadListBegin) {
     FieldType elem_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0xF5);
-    addInt8(buffer, 0x81);
+    buffer.writeByte(0xF5);
+    buffer.writeByte(0x81);
 
     EXPECT_FALSE(proto.readListBegin(buffer, elem_type, size));
     EXPECT_EQ(elem_type, FieldType::String);
@@ -598,7 +598,7 @@ TEST_F(CompactProtocolTest, ReadListBegin) {
     FieldType elem_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0xF5);
+    buffer.writeByte(0xF5);
     addSeq(buffer, {0x81, 0x81, 0x81, 0x81, 0x81, 0}); // > 32 bit varint
 
     EXPECT_THROW_WITH_MESSAGE(proto.readListBegin(buffer, elem_type, size), EnvoyException,
@@ -614,7 +614,7 @@ TEST_F(CompactProtocolTest, ReadListBegin) {
     FieldType elem_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0xF5);
+    buffer.writeByte(0xF5);
     addSeq(buffer, {0xFF, 0xFF, 0xFF, 0xFF, 0x1F}); // -1
 
     EXPECT_THROW_WITH_MESSAGE(proto.readListBegin(buffer, elem_type, size), EnvoyException,
@@ -630,7 +630,7 @@ TEST_F(CompactProtocolTest, ReadListBegin) {
     FieldType elem_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0xF5);
+    buffer.writeByte(0xF5);
     addSeq(buffer, {0x80, 0x01}); // 0x80
 
     EXPECT_TRUE(proto.readListBegin(buffer, elem_type, size));
@@ -645,7 +645,7 @@ TEST_F(CompactProtocolTest, ReadListBegin) {
     FieldType elem_type = FieldType::String;
     uint32_t size = 1;
 
-    addInt8(buffer, 0x1D);
+    buffer.writeByte(0x1D);
 
     EXPECT_THROW_WITH_MESSAGE(proto.readListBegin(buffer, elem_type, size), EnvoyException,
                               "unknown compact protocol field type 13");
@@ -669,7 +669,7 @@ TEST_F(CompactProtocolTest, ReadSetBegin) {
   FieldType elem_type = FieldType::String;
   uint32_t size = 0;
 
-  addInt8(buffer, 0x15);
+  buffer.writeByte(0x15);
 
   EXPECT_TRUE(proto.readSetBegin(buffer, elem_type, size));
   EXPECT_EQ(elem_type, FieldType::I32);
@@ -694,8 +694,8 @@ TEST_F(CompactProtocolTest, ReadBool) {
     int16_t field_id = 1;
     bool value = false;
 
-    addInt8(buffer, 0x01);
-    addInt8(buffer, 0x04);
+    buffer.writeByte(0x01);
+    buffer.writeByte(0x04);
 
     EXPECT_TRUE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "");
@@ -710,8 +710,8 @@ TEST_F(CompactProtocolTest, ReadBool) {
     EXPECT_TRUE(proto.readFieldEnd(buffer));
     EXPECT_FALSE(proto.readBool(buffer, value));
 
-    addInt8(buffer, 0x02);
-    addInt8(buffer, 0x06);
+    buffer.writeByte(0x02);
+    buffer.writeByte(0x06);
 
     EXPECT_TRUE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_EQ(name, "");
@@ -735,12 +735,12 @@ TEST_F(CompactProtocolTest, ReadBool) {
     EXPECT_FALSE(proto.readBool(buffer, value));
     EXPECT_FALSE(value);
 
-    addInt8(buffer, 1);
+    buffer.writeByte(1);
     EXPECT_TRUE(proto.readBool(buffer, value));
     EXPECT_TRUE(value);
     EXPECT_EQ(buffer.length(), 0);
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_TRUE(proto.readBool(buffer, value));
     EXPECT_FALSE(value);
     EXPECT_EQ(buffer.length(), 0);
@@ -758,12 +758,12 @@ TEST_F(CompactProtocolTest, ReadIntegerTypes) {
     EXPECT_FALSE(proto.readByte(buffer, value));
     EXPECT_EQ(value, 1);
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
     EXPECT_TRUE(proto.readByte(buffer, value));
     EXPECT_EQ(value, 0);
     EXPECT_EQ(buffer.length(), 0);
 
-    addInt8(buffer, 0xFF);
+    buffer.writeByte(0xFF);
     EXPECT_TRUE(proto.readByte(buffer, value));
     EXPECT_EQ(value, 0xFF);
     EXPECT_EQ(buffer.length(), 0);
@@ -779,7 +779,7 @@ TEST_F(CompactProtocolTest, ReadIntegerTypes) {
     EXPECT_EQ(value, 1);
 
     // Still insufficient
-    addInt8(buffer, 0x80);
+    buffer.writeByte(0x80);
     EXPECT_FALSE(proto.readInt16(buffer, value));
     EXPECT_EQ(value, 1);
     buffer.drain(1);
@@ -821,7 +821,7 @@ TEST_F(CompactProtocolTest, ReadIntegerTypes) {
     EXPECT_EQ(value, 1);
 
     // Still insufficient
-    addInt8(buffer, 0x80);
+    buffer.writeByte(0x80);
     EXPECT_FALSE(proto.readInt32(buffer, value));
     EXPECT_EQ(value, 1);
     buffer.drain(1);
@@ -853,7 +853,7 @@ TEST_F(CompactProtocolTest, ReadIntegerTypes) {
     EXPECT_EQ(value, 1);
 
     // Still insufficient
-    addInt8(buffer, 0x80);
+    buffer.writeByte(0x80);
     EXPECT_FALSE(proto.readInt64(buffer, value));
     EXPECT_EQ(value, 1);
     buffer.drain(1);
@@ -898,8 +898,8 @@ TEST_F(CompactProtocolTest, ReadDouble) {
 
     // 01000000 00001000 00000000 0000000 00000000 00000000 00000000 000000000 = 3
     // c.f. https://en.wikipedia.org/wiki/Double-precision_floating-point_format
-    addInt8(buffer, 0x40);
-    addInt8(buffer, 0x08);
+    buffer.writeByte(0x40);
+    buffer.writeByte(0x08);
     addRepeated(buffer, 6, 0);
 
     EXPECT_TRUE(proto.readDouble(buffer, value));
@@ -926,7 +926,7 @@ TEST_F(CompactProtocolTest, ReadString) {
     Buffer::OwnedImpl buffer;
     std::string value = "-";
 
-    addInt8(buffer, 0x81);
+    buffer.writeByte(0x81);
 
     EXPECT_FALSE(proto.readString(buffer, value));
     EXPECT_EQ(value, "-");
@@ -938,7 +938,7 @@ TEST_F(CompactProtocolTest, ReadString) {
     Buffer::OwnedImpl buffer;
     std::string value = "-";
 
-    addInt8(buffer, 0x4);
+    buffer.writeByte(0x4);
 
     EXPECT_FALSE(proto.readString(buffer, value));
     EXPECT_EQ(value, "-");
@@ -963,7 +963,7 @@ TEST_F(CompactProtocolTest, ReadString) {
     Buffer::OwnedImpl buffer;
     std::string value = "-";
 
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
 
     EXPECT_TRUE(proto.readString(buffer, value));
     EXPECT_EQ(value, "");
@@ -975,7 +975,7 @@ TEST_F(CompactProtocolTest, ReadString) {
     Buffer::OwnedImpl buffer;
     std::string value = "-";
 
-    addInt8(buffer, 0x06);
+    buffer.writeByte(0x06);
     addString(buffer, "string");
 
     EXPECT_TRUE(proto.readString(buffer, value));
@@ -990,7 +990,7 @@ TEST_F(CompactProtocolTest, ReadBinary) {
   Buffer::OwnedImpl buffer;
   std::string value = "-";
 
-  addInt8(buffer, 0x06);
+  buffer.writeByte(0x06);
   addString(buffer, "string");
 
   EXPECT_TRUE(proto.readBinary(buffer, value));
@@ -1011,8 +1011,8 @@ TEST_P(CompactProtocolFieldTypeTest, ConvertsToFieldType) {
 
   {
     Buffer::OwnedImpl buffer;
-    addInt8(buffer, compact_field_type);
-    addInt8(buffer, 0x02); // zigzag(2) = 1
+    buffer.writeByte(compact_field_type);
+    buffer.writeByte(0x02); // zigzag(2) = 1
 
     EXPECT_TRUE(proto.readFieldBegin(buffer, name, field_type, field_id));
     EXPECT_LE(field_type, FieldType::LastFieldType);

--- a/test/extensions/filters/network/thrift_proxy/compact_protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/compact_protocol_impl_test.cc
@@ -148,7 +148,7 @@ TEST_F(CompactProtocolTest, ReadMessageBegin) {
     buffer.writeBEInt<int16_t>(0x8221);
     buffer.writeByte(32);
     buffer.writeByte(10);
-    addString(buffer, "partial");
+    buffer.add("partial");
 
     EXPECT_FALSE(proto.readMessageBegin(buffer, metadata_));
     expectDefaultMetadata();
@@ -207,7 +207,7 @@ TEST_F(CompactProtocolTest, ReadMessageBegin) {
     buffer.writeBEInt<int16_t>(0x8221);
     buffer.writeBEInt<int16_t>(0x8202); // 0x0102
     buffer.writeByte(8);
-    addString(buffer, "the_name");
+    buffer.add("the_name");
 
     EXPECT_TRUE(proto.readMessageBegin(buffer, metadata_));
     expectMetadata("the_name", MessageType::Call, 0x102);
@@ -976,7 +976,7 @@ TEST_F(CompactProtocolTest, ReadString) {
     std::string value = "-";
 
     buffer.writeByte(0x06);
-    addString(buffer, "string");
+    buffer.add("string");
 
     EXPECT_TRUE(proto.readString(buffer, value));
     EXPECT_EQ(value, "string");
@@ -991,7 +991,7 @@ TEST_F(CompactProtocolTest, ReadBinary) {
   std::string value = "-";
 
   buffer.writeByte(0x06);
-  addString(buffer, "string");
+  buffer.add("string");
 
   EXPECT_TRUE(proto.readBinary(buffer, value));
   EXPECT_EQ(value, "string");

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -387,7 +387,7 @@ TEST_F(ThriftConnectionManagerTest, OnDataHandlesProtocolError) {
                             0x0b, 0x00, 0x01,                           // begin string field
                         });
   write_buffer_.writeBEInt<uint32_t>(err.length());
-  addString(write_buffer_, err);
+  write_buffer_.add(err);
   addSeq(write_buffer_, {
                             0x08, 0x00, 0x02,       // begin i32 field
                             0x00, 0x00, 0x00, 0x07, // protocol error
@@ -396,7 +396,7 @@ TEST_F(ThriftConnectionManagerTest, OnDataHandlesProtocolError) {
 
   EXPECT_CALL(filter_callbacks_.connection_, write(_, false))
       .WillOnce(Invoke([&](Buffer::Instance& buffer, bool) -> void {
-        EXPECT_EQ(bufferToString(write_buffer_), bufferToString(buffer));
+        EXPECT_EQ(write_buffer_.toString(), buffer.toString());
       }));
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
   EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
@@ -449,7 +449,7 @@ TEST_F(ThriftConnectionManagerTest, OnDataHandlesTransportApplicationException) 
                             0x0b, 0x00, 0x01,       // begin string field
                         });
   write_buffer_.writeBEInt<int32_t>(err.length());
-  addString(write_buffer_, err);
+  write_buffer_.add(err);
   addSeq(write_buffer_, {
                             0x08, 0x00, 0x02,       // begin i32 field
                             0x00, 0x00, 0x00, 0x05, // missing result
@@ -458,7 +458,7 @@ TEST_F(ThriftConnectionManagerTest, OnDataHandlesTransportApplicationException) 
 
   EXPECT_CALL(filter_callbacks_.connection_, write(_, false))
       .WillOnce(Invoke([&](Buffer::Instance& buffer, bool) -> void {
-        EXPECT_EQ(bufferToString(write_buffer_), bufferToString(buffer));
+        EXPECT_EQ(write_buffer_.toString(), buffer.toString());
       }));
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
 

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -386,7 +386,7 @@ TEST_F(ThriftConnectionManagerTest, OnDataHandlesProtocolError) {
                             0x00, 0x00, 0x00, 0x01,                     // sequence id
                             0x0b, 0x00, 0x01,                           // begin string field
                         });
-  addInt32(write_buffer_, err.length());
+  write_buffer_.writeBEInt<uint32_t>(err.length());
   addString(write_buffer_, err);
   addSeq(write_buffer_, {
                             0x08, 0x00, 0x02,       // begin i32 field
@@ -448,7 +448,7 @@ TEST_F(ThriftConnectionManagerTest, OnDataHandlesTransportApplicationException) 
                             0x00, 0x00, 0x00, 0x00, // sequence id
                             0x0b, 0x00, 0x01,       // begin string field
                         });
-  addInt32(write_buffer_, err.length());
+  write_buffer_.writeBEInt<int32_t>(err.length());
   addString(write_buffer_, err);
   addSeq(write_buffer_, {
                             0x08, 0x00, 0x02,       // begin i32 field

--- a/test/extensions/filters/network/thrift_proxy/framed_transport_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/framed_transport_impl_test.cc
@@ -44,7 +44,7 @@ TEST(FramedTransportTest, InvalidFrameSize) {
 
   {
     Buffer::OwnedImpl buffer;
-    addInt32(buffer, -1);
+    buffer.writeBEInt<int32_t>(-1);
 
     MessageMetadata metadata;
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
@@ -54,7 +54,7 @@ TEST(FramedTransportTest, InvalidFrameSize) {
 
   {
     Buffer::OwnedImpl buffer;
-    addInt32(buffer, 0x7fffffff);
+    buffer.writeBEInt<int32_t>(0x7fffffff);
 
     MessageMetadata metadata;
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
@@ -67,7 +67,8 @@ TEST(FramedTransportTest, DecodeFrameStart) {
   FramedTransportImpl transport;
 
   Buffer::OwnedImpl buffer;
-  addInt32(buffer, 100);
+  buffer.writeBEInt<int32_t>(100);
+
   EXPECT_EQ(buffer.length(), 4);
 
   MessageMetadata metadata;

--- a/test/extensions/filters/network/thrift_proxy/header_transport_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/header_transport_impl_test.cc
@@ -409,7 +409,7 @@ TEST(HeaderTransportTest, InvalidInfoBlock) {
     buffer.writeBEInt<int16_t>(2); // size 8
     addSeq(buffer, {0, 0, 1, 1});  // 0 = binary proto, 0 = num transforms, 1 key-value, 1 = num kvs
     buffer.writeByte(4);           // exceeds specified header size
-    addString(buffer, "key_");
+    buffer.add("key_");
 
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
                               "unable to read header transport header key: header too small");
@@ -428,7 +428,7 @@ TEST(HeaderTransportTest, InvalidInfoBlock) {
     buffer.writeBEInt<int16_t>(2); // size 8
     addSeq(buffer, {0, 0, 1, 1});  // 0 = binary proto, 0 = num transforms, 1 key-value, 1 = num kvs
     buffer.writeByte(3);           // head ends with key, no room for value
-    addString(buffer, "abc");
+    buffer.add("abc");
     buffer.writeByte(0);
 
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
@@ -449,13 +449,13 @@ TEST(HeaderTransportTest, InfoBlock) {
   buffer.writeBEInt<int16_t>(38); // size 152
   addSeq(buffer, {0, 0, 1, 3}); // 0 = binary proto, 0 = num transforms, 1 = key value, 3 = num kvs
   buffer.writeByte(3);
-  addString(buffer, "key");
+  buffer.add("key");
   buffer.writeByte(5);
-  addString(buffer, "value");
+  buffer.add("value");
   buffer.writeByte(4);
-  addString(buffer, "key2");
+  buffer.add("key2");
   addSeq(buffer, {0x80, 0x01}); // var int 128
-  addString(buffer, std::string(128, 'x'));
+  buffer.add(std::string(128, 'x'));
   buffer.writeByte(0); // empty key
   buffer.writeByte(0); // empty value
   buffer.writeByte(0); // padding

--- a/test/extensions/filters/network/thrift_proxy/header_transport_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/header_transport_impl_test.cc
@@ -69,11 +69,11 @@ TEST(HeaderTransportTest, NotEnoughData) {
   // Missing header data
   {
     Buffer::OwnedImpl buffer;
-    addInt32(buffer, 100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1); // sequence number
-    addInt16(buffer, 1); // header size / 4
+    buffer.writeBEInt<int32_t>(100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1); // sequence number
+    buffer.writeBEInt<int16_t>(1); // header size / 4
     addRepeated(buffer, 3, 0);
     EXPECT_FALSE(transport.decodeFrameStart(buffer, metadata));
     EXPECT_THAT(metadata, IsEmptyMetadata());
@@ -86,7 +86,7 @@ TEST(HeaderTransportTest, InvalidFrameSize) {
 
   {
     Buffer::OwnedImpl buffer;
-    addInt32(buffer, -1);
+    buffer.writeBEInt<int32_t>(-1);
     addRepeated(buffer, 10, 0);
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
                               "invalid thrift header transport frame size -1");
@@ -95,7 +95,7 @@ TEST(HeaderTransportTest, InvalidFrameSize) {
 
   {
     Buffer::OwnedImpl buffer;
-    addInt32(buffer, 0x7fffffff);
+    buffer.writeBEInt<int32_t>(0x7fffffff);
     addRepeated(buffer, 10, 0);
 
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
@@ -109,8 +109,8 @@ TEST(HeaderTransportTest, InvalidMagic) {
   Buffer::OwnedImpl buffer;
   MessageMetadata metadata;
 
-  addInt32(buffer, 0x100);
-  addInt16(buffer, 0x0123);
+  buffer.writeBEInt<int32_t>(0x100);
+  buffer.writeBEInt<int16_t>(0x0123);
   addRepeated(buffer, 8, 0);
   EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
                             "invalid thrift header transport magic 0123");
@@ -125,11 +125,11 @@ TEST(HeaderTransportTest, InvalidHeaderSize) {
   {
     Buffer::OwnedImpl buffer;
 
-    addInt32(buffer, 0x100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1); // sequence number
-    addInt16(buffer, 0);
+    buffer.writeBEInt<int32_t>(0x100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1); // sequence number
+    buffer.writeBEInt<int16_t>(0);
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
                               "no header data");
     EXPECT_THAT(metadata, IsEmptyMetadata());
@@ -139,11 +139,11 @@ TEST(HeaderTransportTest, InvalidHeaderSize) {
   {
     Buffer::OwnedImpl buffer;
 
-    addInt32(buffer, 0x100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1); // sequence number
-    addInt16(buffer, -1);
+    buffer.writeBEInt<int32_t>(0x100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1); // sequence number
+    buffer.writeBEInt<int16_t>(-1);
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
                               "invalid thrift header transport header size -4 (ffff)");
     EXPECT_THAT(metadata, IsEmptyMetadata());
@@ -153,11 +153,11 @@ TEST(HeaderTransportTest, InvalidHeaderSize) {
   {
     Buffer::OwnedImpl buffer;
 
-    addInt32(buffer, 0x100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1); // sequence number
-    addInt16(buffer, 0x4001);
+    buffer.writeBEInt<int32_t>(0x100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1); // sequence number
+    buffer.writeBEInt<int16_t>(0x4001);
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
                               "invalid thrift header transport header size 65540 (4001)");
     EXPECT_THAT(metadata, IsEmptyMetadata());
@@ -167,11 +167,11 @@ TEST(HeaderTransportTest, InvalidHeaderSize) {
   {
     Buffer::OwnedImpl buffer;
 
-    addInt32(buffer, 0x100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1);                            // sequence number
-    addInt16(buffer, 1);                            // 4 bytes
+    buffer.writeBEInt<int32_t>(0x100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1);                  // sequence number
+    buffer.writeBEInt<int16_t>(1);                  // 4 bytes
     addSeq(buffer, {0xFF, 0xFF, 0xFF, 0xFF, 0x1F}); // var int -1, exceeds header size
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
                               "unable to read header transport protocol id: header too small");
@@ -181,11 +181,11 @@ TEST(HeaderTransportTest, InvalidHeaderSize) {
   {
     Buffer::OwnedImpl buffer;
 
-    addInt32(buffer, 0x100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1);                      // sequence number
-    addInt16(buffer, 1);                      // 4 bytes
+    buffer.writeBEInt<int32_t>(0x100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1);            // sequence number
+    buffer.writeBEInt<int16_t>(1);            // 4 bytes
     addSeq(buffer, {0xFF, 0xFF, 0xFF, 0xFF}); // partial var int
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
                               "unable to read header transport protocol id: header too small");
@@ -199,12 +199,12 @@ TEST(HeaderTransportTest, InvalidProto) {
   {
     Buffer::OwnedImpl buffer;
 
-    addInt32(buffer, 100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1);          // sequence number
-    addInt16(buffer, 1);          // size 4
-    addSeq(buffer, {1, 0, 0, 0}); // 1 = json, 0 = num transforms, pad, pad
+    buffer.writeBEInt<int32_t>(100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1); // sequence number
+    buffer.writeBEInt<int16_t>(1); // size 4
+    addSeq(buffer, {1, 0, 0, 0});  // 1 = json, 0 = num transforms, pad, pad
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
                               "Unknown protocol 1");
   }
@@ -212,12 +212,12 @@ TEST(HeaderTransportTest, InvalidProto) {
   {
     Buffer::OwnedImpl buffer;
 
-    addInt32(buffer, 100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1);          // sequence number
-    addInt16(buffer, 1);          // size 4
-    addSeq(buffer, {3, 0, 0, 0}); // 3 = invalid proto, 0 = num transforms, pad, pad
+    buffer.writeBEInt<int32_t>(100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1); // sequence number
+    buffer.writeBEInt<int16_t>(1); // size 4
+    addSeq(buffer, {3, 0, 0, 0});  // 3 = invalid proto, 0 = num transforms, pad, pad
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
                               "Unknown protocol 3");
   }
@@ -225,11 +225,11 @@ TEST(HeaderTransportTest, InvalidProto) {
   {
     Buffer::OwnedImpl buffer;
 
-    addInt32(buffer, 100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1);                            // sequence number
-    addInt16(buffer, 2);                            // size 8
+    buffer.writeBEInt<int32_t>(100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1);                  // sequence number
+    buffer.writeBEInt<int16_t>(2);                  // size 8
     addSeq(buffer, {0xFF, 0xFF, 0xFF, 0xFF, 0x1F}); // -1 = invalid proto
     addSeq(buffer, {0, 0, 0});                      // 0 transforms and padding
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
@@ -244,12 +244,12 @@ TEST(HeaderTransportTest, NoTransformsOrInfo) {
     Buffer::OwnedImpl buffer;
     MessageMetadata metadata;
 
-    addInt32(buffer, 100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1);          // sequence number
-    addInt16(buffer, 1);          // size 4
-    addSeq(buffer, {0, 0, 0, 0}); // 0 = binary proto, 0 = num transforms, pad, pad
+    buffer.writeBEInt<int32_t>(100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1); // sequence number
+    buffer.writeBEInt<int16_t>(1); // size 4
+    addSeq(buffer, {0, 0, 0, 0});  // 0 = binary proto, 0 = num transforms, pad, pad
     EXPECT_TRUE(transport.decodeFrameStart(buffer, metadata));
     EXPECT_THAT(metadata, HasFrameSize(86U));
     EXPECT_THAT(metadata, HasProtocol(ProtocolType::Binary));
@@ -262,12 +262,12 @@ TEST(HeaderTransportTest, NoTransformsOrInfo) {
     Buffer::OwnedImpl buffer;
     MessageMetadata metadata;
 
-    addInt32(buffer, 101);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 2);          // sequence number
-    addInt16(buffer, 1);          // size 4
-    addSeq(buffer, {2, 0, 0, 0}); // 2 = compact proto, 0 = num transforms, pad, pad
+    buffer.writeBEInt<int32_t>(101);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(2); // sequence number
+    buffer.writeBEInt<int16_t>(1); // size 4
+    addSeq(buffer, {2, 0, 0, 0});  // 2 = compact proto, 0 = num transforms, pad, pad
     EXPECT_TRUE(transport.decodeFrameStart(buffer, metadata));
     EXPECT_THAT(metadata, HasFrameSize(87U));
     EXPECT_THAT(metadata, HasProtocol(ProtocolType::Compact));
@@ -284,12 +284,12 @@ TEST(HeaderTransportTest, TransformErrors) {
     HeaderTransportImpl transport;
     Buffer::OwnedImpl buffer;
 
-    addInt32(buffer, 100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1);                            // sequence number
-    addInt16(buffer, 2);                            // size 8
-    addInt8(buffer, 0);                             // binary proto
+    buffer.writeBEInt<int32_t>(100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1);                  // sequence number
+    buffer.writeBEInt<int16_t>(2);                  // size 8
+    buffer.writeByte(0);                            // binary proto
     addSeq(buffer, {0xFF, 0xFF, 0xFF, 0xFF, 0x1F}); // -1 = invalid num transforms
     addSeq(buffer, {0, 0});                         // padding
 
@@ -302,11 +302,11 @@ TEST(HeaderTransportTest, TransformErrors) {
     HeaderTransportImpl transport;
     Buffer::OwnedImpl buffer;
 
-    addInt32(buffer, 100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1);                 // sequence number
-    addInt16(buffer, 1);                 // size 4
+    buffer.writeBEInt<int32_t>(100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1);       // sequence number
+    buffer.writeBEInt<int16_t>(1);       // size 4
     addSeq(buffer, {0, 1, xform_id, 0}); // 0 = binary proto, 1 = num transforms, xform id, pad
 
     EXPECT_TRUE(transport.decodeFrameStart(buffer, metadata));
@@ -321,12 +321,12 @@ TEST(HeaderTransportTest, TransformErrors) {
     HeaderTransportImpl transport;
     Buffer::OwnedImpl buffer;
 
-    addInt32(buffer, 100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1);          // sequence number
-    addInt16(buffer, 1);          // size 4
-    addSeq(buffer, {0, 2, 1, 2}); // 0 = binary proto, 2 = num transforms, xform id 1, xform id 2
+    buffer.writeBEInt<int32_t>(100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1); // sequence number
+    buffer.writeBEInt<int16_t>(1); // size 4
+    addSeq(buffer, {0, 2, 1, 2});  // 0 = binary proto, 2 = num transforms, xform id 1, xform id 2
 
     EXPECT_TRUE(transport.decodeFrameStart(buffer, metadata));
     EXPECT_THAT(metadata, HasFrameSize(86U));
@@ -342,12 +342,12 @@ TEST(HeaderTransportTest, InvalidInfoBlock) {
     Buffer::OwnedImpl buffer;
     MessageMetadata metadata;
 
-    addInt32(buffer, 100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1);          // sequence number
-    addInt16(buffer, 1);          // size 4
-    addSeq(buffer, {0, 0, 2, 0}); // 0 = binary proto, 0 = num transforms, 2 = unknown info id, pad
+    buffer.writeBEInt<int32_t>(100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1); // sequence number
+    buffer.writeBEInt<int16_t>(1); // size 4
+    addSeq(buffer, {0, 0, 2, 0});  // 0 = binary proto, 0 = num transforms, 2 = unknown info id, pad
 
     // Unknown info id is ignored.
     EXPECT_TRUE(transport.decodeFrameStart(buffer, metadata));
@@ -364,12 +364,12 @@ TEST(HeaderTransportTest, InvalidInfoBlock) {
     Buffer::OwnedImpl buffer;
     MessageMetadata metadata;
 
-    addInt32(buffer, 100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1);       // sequence number
-    addInt16(buffer, 3);       // size 12
-    addSeq(buffer, {0, 0, 1}); // 0 = binary proto, 0 = num transforms, 1 key-value
+    buffer.writeBEInt<int32_t>(100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1); // sequence number
+    buffer.writeBEInt<int16_t>(3); // size 12
+    addSeq(buffer, {0, 0, 1});     // 0 = binary proto, 0 = num transforms, 1 key-value
     addSeq(buffer, {0xFF, 0xFF, 0xFF, 0xFF, 0x1F}); // -1 headers
     addSeq(buffer, {0, 0, 0, 0});
 
@@ -383,14 +383,14 @@ TEST(HeaderTransportTest, InvalidInfoBlock) {
     Buffer::OwnedImpl buffer;
     MessageMetadata metadata;
 
-    addInt32(buffer, 100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1);          // sequence number
-    addInt16(buffer, 2);          // size 8
-    addSeq(buffer, {0, 0, 1, 1}); // 0 = binary proto, 0 = num transforms, 1 key-value, 1 = num kvs
+    buffer.writeBEInt<int32_t>(100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1); // sequence number
+    buffer.writeBEInt<int16_t>(2); // size 8
+    addSeq(buffer, {0, 0, 1, 1});  // 0 = binary proto, 0 = num transforms, 1 key-value, 1 = num kvs
     addSeq(buffer, {0x80, 0x80, 0x40}); // var int 0x100000
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
 
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
                               "header transport header key: value 1048576 exceeds max i16 (32767)");
@@ -402,13 +402,13 @@ TEST(HeaderTransportTest, InvalidInfoBlock) {
     Buffer::OwnedImpl buffer;
     MessageMetadata metadata;
 
-    addInt32(buffer, 100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1);          // sequence number
-    addInt16(buffer, 2);          // size 8
-    addSeq(buffer, {0, 0, 1, 1}); // 0 = binary proto, 0 = num transforms, 1 key-value, 1 = num kvs
-    addInt8(buffer, 4);           // exceeds specified header size
+    buffer.writeBEInt<int32_t>(100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1); // sequence number
+    buffer.writeBEInt<int16_t>(2); // size 8
+    addSeq(buffer, {0, 0, 1, 1});  // 0 = binary proto, 0 = num transforms, 1 key-value, 1 = num kvs
+    buffer.writeByte(4);           // exceeds specified header size
     addString(buffer, "key_");
 
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
@@ -421,15 +421,15 @@ TEST(HeaderTransportTest, InvalidInfoBlock) {
     Buffer::OwnedImpl buffer;
     MessageMetadata metadata;
 
-    addInt32(buffer, 100);
-    addInt16(buffer, 0x0FFF);
-    addInt16(buffer, 0);
-    addInt32(buffer, 1);          // sequence number
-    addInt16(buffer, 2);          // size 8
-    addSeq(buffer, {0, 0, 1, 1}); // 0 = binary proto, 0 = num transforms, 1 key-value, 1 = num kvs
-    addInt8(buffer, 3);           // head ends with key, no room for value
+    buffer.writeBEInt<int32_t>(100);
+    buffer.writeBEInt<int16_t>(0x0FFF);
+    buffer.writeBEInt<int16_t>(0);
+    buffer.writeBEInt<int32_t>(1); // sequence number
+    buffer.writeBEInt<int16_t>(2); // size 8
+    addSeq(buffer, {0, 0, 1, 1});  // 0 = binary proto, 0 = num transforms, 1 key-value, 1 = num kvs
+    buffer.writeByte(3);           // head ends with key, no room for value
     addString(buffer, "abc");
-    addInt8(buffer, 0);
+    buffer.writeByte(0);
 
     EXPECT_THROW_WITH_MESSAGE(transport.decodeFrameStart(buffer, metadata), EnvoyException,
                               "unable to read header transport header value: header too small");
@@ -442,23 +442,23 @@ TEST(HeaderTransportTest, InfoBlock) {
   MessageMetadata metadata;
   metadata.headers().addCopy(Http::LowerCaseString("not"), "empty");
 
-  addInt32(buffer, 200);
-  addInt16(buffer, 0x0FFF);
-  addInt16(buffer, 0);
-  addInt32(buffer, 1);          // sequence number
-  addInt16(buffer, 38);         // size 152
+  buffer.writeBEInt<int32_t>(200);
+  buffer.writeBEInt<int16_t>(0x0FFF);
+  buffer.writeBEInt<int16_t>(0);
+  buffer.writeBEInt<int32_t>(1);  // sequence number
+  buffer.writeBEInt<int16_t>(38); // size 152
   addSeq(buffer, {0, 0, 1, 3}); // 0 = binary proto, 0 = num transforms, 1 = key value, 3 = num kvs
-  addInt8(buffer, 3);
+  buffer.writeByte(3);
   addString(buffer, "key");
-  addInt8(buffer, 5);
+  buffer.writeByte(5);
   addString(buffer, "value");
-  addInt8(buffer, 4);
+  buffer.writeByte(4);
   addString(buffer, "key2");
   addSeq(buffer, {0x80, 0x01}); // var int 128
   addString(buffer, std::string(128, 'x'));
-  addInt8(buffer, 0); // empty key
-  addInt8(buffer, 0); // empty value
-  addInt8(buffer, 0); // padding
+  buffer.writeByte(0); // empty key
+  buffer.writeByte(0); // empty value
+  buffer.writeByte(0); // padding
 
   Http::HeaderMapImpl expected_headers;
   expected_headers.addCopy(Http::LowerCaseString("not"), "empty");

--- a/test/extensions/filters/network/thrift_proxy/unframed_transport_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/unframed_transport_impl_test.cc
@@ -27,7 +27,7 @@ TEST(UnframedTransportTest, DecodeFrameStart) {
   UnframedTransportImpl transport;
 
   Buffer::OwnedImpl buffer;
-  addInt32(buffer, 0xDEADBEEF);
+  buffer.writeBEInt<uint32_t>(0xDEADBEEF);
   EXPECT_EQ(buffer.length(), 4);
 
   MessageMetadata metadata;

--- a/test/extensions/filters/network/thrift_proxy/utility.h
+++ b/test/extensions/filters/network/thrift_proxy/utility.h
@@ -25,8 +25,6 @@ namespace {
 
 using Envoy::Buffer::addRepeated;
 using Envoy::Buffer::addSeq;
-using Envoy::Buffer::addString;
-using Envoy::Buffer::bufferToString;
 
 inline std::string fieldTypeToString(const FieldType& field_type) {
   switch (field_type) {

--- a/test/extensions/filters/network/thrift_proxy/utility.h
+++ b/test/extensions/filters/network/thrift_proxy/utility.h
@@ -9,6 +9,8 @@
 
 #include "extensions/filters/network/thrift_proxy/thrift.h"
 
+#include "test/common/buffer/utility.h"
+
 #include "absl/strings/ascii.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -21,44 +23,10 @@ namespace NetworkFilters {
 namespace ThriftProxy {
 namespace {
 
-inline void addInt16(Buffer::Instance& buffer, int16_t value) {
-  value = htobe16(value);
-  buffer.add(&value, 2);
-}
-
-inline void addInt32(Buffer::Instance& buffer, int32_t value) {
-  value = htobe32(value);
-  buffer.add(&value, 4);
-}
-
-inline void addInt8(Buffer::Instance& buffer, int8_t value) { buffer.add(&value, 1); }
-
-inline void addInt8(Buffer::Instance& buffer, MessageType value) { buffer.add(&value, 1); }
-
-inline void addInt8(Buffer::Instance& buffer, FieldType value) { buffer.add(&value, 1); }
-
-inline void addRepeated(Buffer::Instance& buffer, int n, int8_t value) {
-  for (int i = 0; i < n; i++) {
-    buffer.add(&value, 1);
-  }
-}
-
-inline void addSeq(Buffer::Instance& buffer, const std::initializer_list<uint8_t> values) {
-  for (int8_t value : values) {
-    buffer.add(&value, 1);
-  }
-}
-
-inline void addString(Buffer::Instance& buffer, const std::string& s) { buffer.add(s); }
-
-inline std::string bufferToString(Buffer::Instance& buffer) {
-  if (buffer.length() == 0) {
-    return "";
-  }
-
-  char* data = static_cast<char*>(buffer.linearize(buffer.length()));
-  return std::string(data, buffer.length());
-}
+using Envoy::Buffer::addRepeated;
+using Envoy::Buffer::addSeq;
+using Envoy::Buffer::addString;
+using Envoy::Buffer::bufferToString;
 
 inline std::string fieldTypeToString(const FieldType& field_type) {
   switch (field_type) {


### PR DESCRIPTION
Description:
Extract common buffer helper functions. 

This is split out and rebased with upstream as per discussion in: https://github.com/envoyproxy/envoy/pull/3502#issuecomment-416440742. After this is merged, I'll rebase mj's branch and reopen the PR.

Risk Level: Medium

Testing:
Unit tests added for buffer and byte_order changes

Docs Changes:
N/A

Release Notes:
Per discussion with @zuercher this change itself shouldn't need an entry in version_history.rst

PTAL: @mattklein123 @zuercher @juchem 
