### PR TITLE
ssl: serialize accesses to SSL socket factory contexts

### DIFF
--- a/source/common/ssl/BUILD
+++ b/source/common/ssl/BUILD
@@ -12,7 +12,10 @@ envoy_cc_library(
     name = "ssl_socket_lib",
     srcs = ["ssl_socket.cc"],
     hdrs = ["ssl_socket.h"],
-    external_deps = ["ssl"],
+    external_deps = [
+        "abseil_synchronization",
+        "ssl",
+    ],
     deps = [
         ":context_config_lib",
         ":context_lib",
@@ -23,6 +26,7 @@ envoy_cc_library(
         "//source/common/common:assert_lib",
         "//source/common/common:empty_string",
         "//source/common/common:minimal_logger_lib",
+        "//source/common/common:thread_annotations",
         "//source/common/http:headers_lib",
     ],
 )

--- a/source/common/ssl/ssl_socket.cc
+++ b/source/common/ssl/ssl_socket.cc
@@ -422,7 +422,9 @@ Network::TransportSocketPtr ClientSslSocketFactory::createTransportSocket() cons
   // onAddOrUpdateSecret() could be invoked in the middle of checking the existence of ssl_ctx and
   // creating SslSocket using ssl_ctx. Capture ssl_ctx_ into a local variable so that we check and
   // use the same ssl_ctx to create SslSocket.
+  ssl_ctx_mu_.Lock();
   auto ssl_ctx = ssl_ctx_;
+  ssl_ctx_mu_.Unlock();
   if (ssl_ctx) {
     return std::make_unique<Ssl::SslSocket>(std::move(ssl_ctx), Ssl::InitialState::Client);
   } else {
@@ -436,7 +438,9 @@ bool ClientSslSocketFactory::implementsSecureTransport() const { return true; }
 
 void ClientSslSocketFactory::onAddOrUpdateSecret() {
   ENVOY_LOG(debug, "Secret is updated.");
+  ssl_ctx_mu_.Lock();
   ssl_ctx_ = manager_.createSslClientContext(stats_scope_, *config_);
+  ssl_ctx_mu_.Unlock();
   stats_.ssl_context_update_by_sds_.inc();
 }
 
@@ -454,7 +458,9 @@ Network::TransportSocketPtr ServerSslSocketFactory::createTransportSocket() cons
   // onAddOrUpdateSecret() could be invoked in the middle of checking the existence of ssl_ctx and
   // creating SslSocket using ssl_ctx. Capture ssl_ctx_ into a local variable so that we check and
   // use the same ssl_ctx to create SslSocket.
+  ssl_ctx_mu_.Lock();
   auto ssl_ctx = ssl_ctx_;
+  ssl_ctx_mu_.Unlock();
   if (ssl_ctx) {
     return std::make_unique<Ssl::SslSocket>(std::move(ssl_ctx), Ssl::InitialState::Server);
   } else {
@@ -468,7 +474,9 @@ bool ServerSslSocketFactory::implementsSecureTransport() const { return true; }
 
 void ServerSslSocketFactory::onAddOrUpdateSecret() {
   ENVOY_LOG(debug, "Secret is updated.");
+  ssl_ctx_mu_.Lock();
   ssl_ctx_ = manager_.createSslServerContext(stats_scope_, *config_, server_names_);
+  ssl_ctx_mu_.Unlock();
   stats_.ssl_context_update_by_sds_.inc();
 }
 

--- a/source/common/ssl/ssl_socket.h
+++ b/source/common/ssl/ssl_socket.h
@@ -12,8 +12,8 @@
 #include "common/common/logger.h"
 #include "common/ssl/context_impl.h"
 
-#include "openssl/ssl.h"
 #include "absl/synchronization/mutex.h"
+#include "openssl/ssl.h"
 
 namespace Envoy {
 namespace Ssl {

--- a/source/common/ssl/ssl_socket.h
+++ b/source/common/ssl/ssl_socket.h
@@ -13,6 +13,7 @@
 #include "common/ssl/context_impl.h"
 
 #include "openssl/ssl.h"
+#include "absl/synchronization/mutex.h"
 
 namespace Envoy {
 namespace Ssl {
@@ -101,7 +102,8 @@ private:
   Stats::Scope& stats_scope_;
   SslSocketFactoryStats stats_;
   ClientContextConfigPtr config_;
-  ClientContextSharedPtr ssl_ctx_;
+  mutable absl::Mutex ssl_ctx_mu_;
+  ClientContextSharedPtr ssl_ctx_ GUARDED_BY(ssl_ctx_mu_);
 };
 
 class ServerSslSocketFactory : public Network::TransportSocketFactory,
@@ -123,7 +125,8 @@ private:
   SslSocketFactoryStats stats_;
   ServerContextConfigPtr config_;
   const std::vector<std::string> server_names_;
-  ServerContextSharedPtr ssl_ctx_;
+  mutable absl::Mutex ssl_ctx_mu_;
+  ServerContextSharedPtr ssl_ctx_ GUARDED_BY(ssl_ctx_mu_);
 };
 
 } // namespace Ssl


### PR DESCRIPTION
*Description*:
The ssl_ctx_ fields of the ServerSslSocketFactory and ClientSslSocketFactory are accessed and mutated from different threads without external serialization. This is a bug since instances of std::shared_ptr are not thread-safe (though different instances pointing to the same object are). This patch fixes the bug by using a mutex to serialize accesses.

*Risk Level*: Low
*Testing*: ran test suite
*Docs Changes*: n/a
*Release Notes*: n/a
