### PR TITLE
dns: fix callback contract bug in #4307.

### DIFF
--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -37,6 +37,8 @@ public:
 
 private:
   friend class DnsResolverImplPeer;
+  // This object is self-owned, resource reclamation occurs via self-deleting on
+  // query completion or error.
   struct PendingResolution : public ActiveDnsQuery {
     // Network::ActiveDnsQuery
     PendingResolution(ResolveCb callback, Event::Dispatcher& dispatcher, ares_channel channel,
@@ -66,11 +68,6 @@ private:
     const ResolveCb callback_;
     // Dispatcher to post callback_ to.
     Event::Dispatcher& dispatcher_;
-    // Does the object own itself? Resource reclamation occurs via self-deleting
-    // on query completion or error.
-    bool owned_ = false;
-    // Has the query completed? Only meaningful if !owned_;
-    bool completed_ = false;
     // Was the query cancelled via cancel()?
     bool cancelled_ = false;
     // If dns_lookup_family is "fallback", fallback to v4 address if v6

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-4797819802615808
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-4797819802615808
@@ -1,0 +1,99 @@
+static_resources {
+  clusters {
+    name: "i"
+    type: STRICT_DNS
+    connect_timeout {
+      nanos: 65535
+    }
+    hosts {
+      pipe {
+        path: "i"
+      }
+    }
+    tls_context {
+      common_tls_context {
+        validation_context {
+          verify_certificate_hash: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        }
+      }
+    }
+    dns_lookup_family: V4_ONLY
+  }
+}
+cluster_manager {
+  load_stats_config {
+    api_type: GRPC
+    grpc_services {
+      google_grpc {
+        target_uri: "["
+        call_credentials {
+          service_account_jwt_access {
+            json_key: "[]"
+            token_lifetime_seconds: 1
+          }
+        }
+        call_credentials {
+          access_token: "["
+        }
+        call_credentials {
+          google_iam {
+            authorization_token: "/"
+          }
+        }
+        call_credentials {
+          service_account_jwt_access {
+            json_key: "[]"
+            token_lifetime_seconds: 1
+          }
+        }
+        call_credentials {
+          access_token: "["
+        }
+        call_credentials {
+          google_iam {
+            authorization_token: "/"
+          }
+        }
+        call_credentials {
+          service_account_jwt_access {
+            json_key: "[["
+            token_lifetime_seconds: 1
+          }
+        }
+        call_credentials {
+          access_token: "/"
+        }
+        call_credentials {
+          service_account_jwt_access {
+            json_key: "[["
+            token_lifetime_seconds: 3
+          }
+        }
+        call_credentials {
+          access_token: "["
+        }
+        call_credentials {
+          google_iam {
+            authorization_token: "/"
+          }
+        }
+        call_credentials {
+          service_account_jwt_access {
+            json_key: "/"
+            token_lifetime_seconds: 1
+          }
+        }
+        stat_prefix: "`"
+      }
+    }
+  }
+}
+flags_path: ",istener_9223372036854775808"
+admin {
+  access_log_path: "@@"
+  address {
+    pipe {
+      path: "R"
+    }
+  }
+}


### PR DESCRIPTION
Previously, once the callback was posted to the dispatcher, the
PendingResolution was destructed. This then broke the ability to
cancel() after the post. This PR restores this capability and simplifies
some of the object ownership aspects of PendingResolution post #4307.

Fixes oss-fuzz issue
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10184.

Risk level: Medium (this code has scary complicated lifetime and
  ownership guarantees).
Testing: Additional unit test and corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>