### PR TITLE
upstream: replace std::shared_timed_mutex with absl::Mutex

### DIFF
--- a/source/common/ssl/context_manager_impl.cc
+++ b/source/common/ssl/context_manager_impl.cc
@@ -1,7 +1,6 @@
 #include "common/ssl/context_manager_impl.h"
 
 #include <functional>
-#include <shared_mutex>
 
 #include "envoy/stats/scope.h"
 

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -257,6 +257,7 @@ envoy_cc_library(
     name = "thread_aware_lb_lib",
     srcs = ["thread_aware_lb_impl.cc"],
     hdrs = ["thread_aware_lb_impl.h"],
+    external_deps = ["abseil_synchronization"],
     deps = [
         ":load_balancer_lib",
     ],
@@ -383,6 +384,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "upstream_includes",
     hdrs = ["upstream_impl.h"],
+    external_deps = ["abseil_synchronization"],
     deps = [
         ":load_balancer_lib",
         ":outlier_detection_lib",

--- a/source/common/upstream/thread_aware_lb_impl.cc
+++ b/source/common/upstream/thread_aware_lb_impl.cc
@@ -30,7 +30,7 @@ void ThreadAwareLoadBalancerBase::refresh() {
   }
 
   {
-    std::unique_lock<std::shared_timed_mutex> lock(factory_->mutex_);
+    absl::WriterMutexLock lock(&factory_->mutex_);
     factory_->per_priority_load_ = per_priority_load;
     factory_->per_priority_state_ = per_priority_state_vector;
   }
@@ -64,7 +64,7 @@ LoadBalancerPtr ThreadAwareLoadBalancerBase::LoadBalancerFactoryImpl::create() {
 
   // We must protect current_lb_ via a RW lock since it is accessed and written to by multiple
   // threads. All complex processing has already been precalculated however.
-  std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+  absl::ReaderMutexLock lock(&mutex_);
   lb->per_priority_load_ = per_priority_load_;
   lb->per_priority_state_ = per_priority_state_;
 

--- a/source/common/upstream/thread_aware_lb_impl.h
+++ b/source/common/upstream/thread_aware_lb_impl.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <shared_mutex>
-
 #include "common/upstream/load_balancer_impl.h"
 
 #include "absl/synchronization/mutex.h"

--- a/source/common/upstream/thread_aware_lb_impl.h
+++ b/source/common/upstream/thread_aware_lb_impl.h
@@ -4,6 +4,8 @@
 
 #include "common/upstream/load_balancer_impl.h"
 
+#include "absl/synchronization/mutex.h"
+
 namespace Envoy {
 namespace Upstream {
 
@@ -69,13 +71,10 @@ private:
 
     ClusterStats& stats_;
     Runtime::RandomGenerator& random_;
-    std::shared_timed_mutex mutex_;
-    // TOOD(mattklein123): Added GUARDED_BY(mutex_) to to the following variables. OSX clang
-    // seems to not like them with shared mutexes so we need to ifdef them out on OSX. I don't
-    // have time to do this right now.
-    std::shared_ptr<std::vector<PerPriorityStatePtr>> per_priority_state_;
+    absl::Mutex mutex_;
+    std::shared_ptr<std::vector<PerPriorityStatePtr>> per_priority_state_ GUARDED_BY(mutex_);
     // This is split out of PerPriorityState so LoadBalancerBase::ChoosePriorirty can be reused.
-    std::shared_ptr<std::vector<uint32_t>> per_priority_load_;
+    std::shared_ptr<std::vector<uint32_t>> per_priority_load_ GUARDED_BY(mutex_);
   };
 
   virtual HashingLoadBalancerSharedPtr createLoadBalancer(const HostSet& host_set) PURE;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -7,7 +7,6 @@
 #include <functional>
 #include <list>
 #include <memory>
-#include <shared_mutex>
 #include <string>
 #include <utility>
 #include <vector>

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -162,6 +162,10 @@ def checkSourceLine(line, file_path, reportError):
     # comments, for example this one.
     reportError("Don't use <mutex> or <condition_variable*>, switch to "
                 "Thread::MutexBasicLockable in source/common/common/thread.h")
+  if line.startswith('#include <shared_mutex>'):
+    # We don't check here for std::shared_timed_mutex because that may
+    # legitimately show up in comments, for example this one.
+    reportError("Don't use <shared_mutex>, use absl::Mutex for reader/writer locks.")
   if not whitelistedForRealTime(file_path):
     if 'RealTimeSource' in line or 'RealTimeSystem' in line:
       reportError("Don't reference real-world time sources from production code; use injection")

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -143,6 +143,9 @@ if __name__ == "__main__":
                                     "Don't use <mutex> or <condition_variable*>")
   errors += fixFileExpectingFailure("condition_variable_any.cc",
                                     "Don't use <mutex> or <condition_variable*>")
+  errors += checkFileExpectingError("shared_mutex.cc", "shared_mutex")
+  errors += fixFileExpectingFailure("shared_mutex.cc", "shared_mutex")
+
   real_time_inject_error = (
       "Don't reference real-world time sources from production code; use injection")
   errors += fixFileExpectingFailure("real_time_source.cc", real_time_inject_error)

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -124,6 +124,8 @@ if __name__ == "__main__":
   shutil.rmtree(tmp, True)
   os.makedirs(tmp)
   os.chdir(tmp)
+  # TODO(akonradi): reorder these by error instead of grouping the fixes
+  # together and checks together
   errors += fixFileExpectingSuccess("over_enthusiastic_spaces.cc")
   errors += fixFileExpectingSuccess("extra_enthusiastic_spaces.cc")
   errors += fixFileExpectingSuccess("angle_bracket_include.cc")

--- a/tools/testdata/check_format/shared_mutex.cc
+++ b/tools/testdata/check_format/shared_mutex.cc
@@ -1,0 +1,10 @@
+#include <shared_mutex>
+
+namespace Envoy {
+
+void make_a_mutex() {
+  std::shared_timed_mutex mutex;
+}
+
+} // namespace Envoy
+


### PR DESCRIPTION
*Description*:
The only use case that I'm aware of for std::shared_timed_mutex over std::mutex is support for reader/writer locks. Since absl::Mutex supports this, and since it supports thread annotations, use it instead of std::shared_timed_mutex.

*Risk Level*: low
*Testing*: ran unit and integration tests
*Docs Changes*: n/a
*Release Notes*: n/a