### PR TITLE
format: forbid use of std::atomic_* free functions

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -165,6 +165,10 @@ def checkSourceLine(line, file_path, reportError):
   if not whitelistedForRealTime(file_path):
     if 'RealTimeSource' in line or 'RealTimeSystem' in line:
       reportError("Don't reference real-world time sources from production code; use injection")
+  if 'std::atomic_' in line:
+    # The std::atomic_* free functions are functionally equivalent to calling
+    # operations on std::atomic<T> objects, so prefer to use that instead.
+    reportError("Don't use free std::atomic_* functions, use std::atomic<T> members instead.")
 
 def checkBuildLine(line, file_path, reportError):
   if not whitelistedForProtobufDeps(file_path) and '"protobuf"' in line:

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -169,7 +169,6 @@ if __name__ == "__main__":
   errors += checkFileExpectingError("proto_format.proto", "clang-format check failed")
   errors += checkFileExpectingError("real_time_source.cc", real_time_inject_error)
   errors += checkFileExpectingError("real_time_system.cc", real_time_inject_error)
-
   errors += checkFileExpectingError("std_atomic_free_functions.cc", "std::atomic_*")
   errors += fixFileExpectingFailure("std_atomic_free_functions.cc", "std::atomic_*")
 

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -169,6 +169,7 @@ if __name__ == "__main__":
   errors += checkFileExpectingError("proto_format.proto", "clang-format check failed")
   errors += checkFileExpectingError("real_time_source.cc", real_time_inject_error)
   errors += checkFileExpectingError("real_time_system.cc", real_time_inject_error)
+  errors += checkFileExpectingError("std_atomic_free_functions.cc", "std::atomic_*")
 
   errors += checkFileExpectingOK("ok_file.cc")
 

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -169,7 +169,9 @@ if __name__ == "__main__":
   errors += checkFileExpectingError("proto_format.proto", "clang-format check failed")
   errors += checkFileExpectingError("real_time_source.cc", real_time_inject_error)
   errors += checkFileExpectingError("real_time_system.cc", real_time_inject_error)
+
   errors += checkFileExpectingError("std_atomic_free_functions.cc", "std::atomic_*")
+  errors += fixFileExpectingFailure("std_atomic_free_functions.cc", "std::atomic_*")
 
   errors += checkFileExpectingOK("ok_file.cc")
 

--- a/tools/testdata/check_format/std_atomic_free_functions.cc
+++ b/tools/testdata/check_format/std_atomic_free_functions.cc
@@ -1,0 +1,11 @@
+#include <atomic>
+
+namespace Envoy {
+
+void do_atomic_stuff() {
+  std::atomic<bool> atomic_flag(false);
+  std::atomic_store(&atomic_flag, true);
+}
+
+} // namespace Envoy
+


### PR DESCRIPTION
*Description*:
These functions are equivalent to calling methods on the std::atomic<T>
objects themselves, and the method invocations are easier to read.

*Risk Level*: Low
*Testing*: added format test
*Docs Changes*: n/a
*Release Notes*: n/a