### PR TITLE
test: another echo_integration_test fix

### DIFF
--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -111,7 +111,7 @@ RawConnectionDriver::RawConnectionDriver(uint32_t port, Buffer::Instance& initia
                                          Network::Address::IpVersion version) {
   api_.reset(new Api::Impl(std::chrono::milliseconds(10000)));
   dispatcher_ = api_->allocateDispatcher(IntegrationUtil::evil_singleton_test_time_.timeSource());
-  callbacks_.reset(new ConnectionCallbacks());
+  callbacks_ = std::make_unique<ConnectionCallbacks>();
   client_ = dispatcher_->createClientConnection(
       Network::Utility::resolveUrl(
           fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version), port)),

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -111,10 +111,12 @@ RawConnectionDriver::RawConnectionDriver(uint32_t port, Buffer::Instance& initia
                                          Network::Address::IpVersion version) {
   api_.reset(new Api::Impl(std::chrono::milliseconds(10000)));
   dispatcher_ = api_->allocateDispatcher(IntegrationUtil::evil_singleton_test_time_.timeSource());
+  callbacks_.reset(new ConnectionCallbacks());
   client_ = dispatcher_->createClientConnection(
       Network::Utility::resolveUrl(
           fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version), port)),
       Network::Address::InstanceConstSharedPtr(), Network::Test::createRawBufferSocket(), nullptr);
+  client_->addConnectionCallbacks(*callbacks_);
   client_->addReadFilter(Network::ReadFilterSharedPtr{new ForwardingFilter(*this, data_callback)});
   client_->write(initial_data, false);
   client_->connect();

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -62,6 +62,7 @@ public:
                       Network::Address::IpVersion version);
   ~RawConnectionDriver();
   const Network::Connection& connection() { return *client_; }
+  bool connecting() { return callbacks_->connecting_; }
   void run(Event::Dispatcher::RunType run_type = Event::Dispatcher::RunType::Block);
   void close();
 
@@ -81,8 +82,17 @@ private:
     ReadCallback data_callback_;
   };
 
+  struct ConnectionCallbacks : public Network::ConnectionCallbacks {
+    void onEvent(Network::ConnectionEvent) override { connecting_ = false; }
+    void onAboveWriteBufferHighWatermark() override {}
+    void onBelowWriteBufferLowWatermark() override {}
+
+    bool connecting_{true};
+  };
+
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;
+  std::shared_ptr<ConnectionCallbacks> callbacks_;
   Network::ClientConnectionPtr client_;
 };
 

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -92,7 +92,7 @@ private:
 
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;
-  std::shared_ptr<ConnectionCallbacks> callbacks_;
+  std::unique_ptr<ConnectionCallbacks> callbacks_;
   Network::ClientConnectionPtr client_;
 };
 


### PR DESCRIPTION
OS X's localhost interface often takes longer to fail to connect
than Linux. Modifies RawConnectionDriver to detect when its
underlying connection is connected or failed and pauses the
echo_integration_test until that state is reached before
checking the connection state.

*Risk Level*: low, test-only changes
*Testing*: existing tests
*Doc Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
