### PR TITLE
Update dependencies, standardize on retrieval via tag where available

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -14,6 +14,7 @@ REPOSITORY_LOCATIONS = dict(
         strip_prefix = "thrift-0.11.0",
     ),
     com_github_bombela_backward = dict(
+        sha256 = "ad73be31c5cfcbffbde7d34dba18158a42043a109e7f41946f0b0abd589ed55e",
         commit = "v1.4",
         remote = "https://github.com/bombela/backward-cpp",
     ),
@@ -22,22 +23,27 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/circonus-labs/libcircllhist",
     ),
     com_github_cyan4973_xxhash = dict(
+        sha256 = "19030315f4fc1b4b2cdb9d7a317069a109f90e39d1fe4c9159b7aaa39030eb95",
         commit = "v0.6.5",
         remote = "https://github.com/Cyan4973/xxHash",
     ),
     com_github_eile_tclap = dict(
+        sha256 = "f0ede0721dddbb5eba3a47385a6e8681b14f155e1129dd39d1a959411935098f",
         commit = "tclap-1-2-1-release-final",
         remote = "https://github.com/eile/tclap",
     ),
     com_github_fmtlib_fmt = dict(
+        sha256 = "46628a2f068d0e33c716be0ed9dcae4370242df135aed663a180b9fd8e36733d",
         commit = "4.1.0",
         remote = "https://github.com/fmtlib/fmt",
     ),
     com_github_gabime_spdlog = dict(
+        sha256 = "94f74fd1b3344733d1db3de2ec22e6cbeb769f93a8baa0d4a22b1f62dc7369f8",
         commit = "v0.17.0",
         remote = "https://github.com/gabime/spdlog",
     ),
     com_github_gcovr_gcovr = dict(
+        sha256 = "1c52a71f245adfe1b45e30fbe5015337fe66546f17f40038b3969b7b42acceed",
         commit = "3.3",
         remote = "https://github.com/gcovr/gcovr",
     ),
@@ -46,6 +52,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/google/libprotobuf-mutator",
     ),
     com_github_grpc_grpc = dict(
+        sha256 = "c747e4d903f7dcf803be53abed4e4efc5d3e96f6c274ed1dfca7a03fa6f4e36b",
         commit = "v1.14.2",
         remote = "https://github.com/grpc/grpc",
     ),
@@ -80,14 +87,17 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/nodejs/http-parser",
     ),
     com_github_pallets_jinja = dict(
+        sha256 = "0d31d3466c313a9ca014a2d904fed18cdac873a5ba1f7b70b8fd8b206cd860d6",
         commit = "2.10",
         remote = "https://github.com/pallets/jinja",
     ),
     com_github_pallets_markupsafe = dict(
+        sha256 = "dc3938045d9407a73cf9fdd709e2b1defd0588d50ffc85eb0786c095ec846f15",
         commit = "1.0",
         remote = "https://github.com/pallets/markupsafe",
     ),
     com_github_tencent_rapidjson = dict(
+        sha256 ="bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e",
         commit = "v1.1.0",
         remote = "https://github.com/tencent/rapidjson",
     ),
@@ -107,6 +117,7 @@ REPOSITORY_LOCATIONS = dict(
         strip_prefix = "twitter.common.finagle-thrift-0.3.9/src",
     ),
     com_google_googletest = dict(
+        sha256 = "9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c",
         commit = "release-1.8.1",
         remote = "https://github.com/google/googletest",
     ),
@@ -123,6 +134,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/grpc-ecosystem/grpc-httpjson-transcoding",
     ),
     io_bazel_rules_go = dict(
+        sha256 = "5a89e9c1fe89d45c4a45132fae94bf130842ce3c77e3a735a68f6991d4e00a25",
         commit = "0.11.2",
         remote = "https://github.com/bazelbuild/rules_go",
     ),
@@ -134,6 +146,7 @@ REPOSITORY_LOCATIONS = dict(
     # I'd love to name this `com_github_google_subpar`, but something in the Subpar
     # code assumes its repository name is just `subpar`.
     subpar = dict(
+        sha256 = "eddbfc920e9cd565500370114316757848b672deba06dc2336acfa81b4ac0e6d",
         commit = "1.3.0",
         remote = "https://github.com/google/subpar",
     ),

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -14,7 +14,7 @@ REPOSITORY_LOCATIONS = dict(
         strip_prefix = "thrift-0.11.0",
     ),
     com_github_bombela_backward = dict(
-        commit = "44ae9609e860e3428cd057f7052e505b4819eb84",  # 2018-02-06
+        commit = "v1.4",
         remote = "https://github.com/bombela/backward-cpp",
     ),
     com_github_circonus_labs_libcircllhist = dict(
@@ -22,34 +22,32 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/circonus-labs/libcircllhist",
     ),
     com_github_cyan4973_xxhash = dict(
-        commit = "7cc9639699f64b750c0b82333dced9ea77e8436e",  # v0.6.5
+        commit = "v0.6.5",
         remote = "https://github.com/Cyan4973/xxHash",
     ),
     com_github_eile_tclap = dict(
-        commit = "3627d9402e529770df9b0edf2aa8c0e0d6c6bb41",  # tclap-1-2-1-release-final
+        commit = "tclap-1-2-1-release-final",
         remote = "https://github.com/eile/tclap",
     ),
     com_github_fmtlib_fmt = dict(
-        sha256 = "46628a2f068d0e33c716be0ed9dcae4370242df135aed663a180b9fd8e36733d",
-        strip_prefix = "fmt-4.1.0",
-        urls = ["https://github.com/fmtlib/fmt/archive/4.1.0.tar.gz"],
+        commit = "4.1.0",
+        remote = "https://github.com/fmtlib/fmt",
     ),
     com_github_gabime_spdlog = dict(
-        sha256 = "94f74fd1b3344733d1db3de2ec22e6cbeb769f93a8baa0d4a22b1f62dc7369f8",
-        strip_prefix = "spdlog-0.17.0",
-        urls = ["https://github.com/gabime/spdlog/archive/v0.17.0.tar.gz"],
+        commit = "v0.17.0",
+        remote = "https://github.com/gabime/spdlog",
     ),
     com_github_gcovr_gcovr = dict(
-        commit = "c0d77201039c7b119b18bc7fb991564c602dd75d",
+        commit = "3.3",
         remote = "https://github.com/gcovr/gcovr",
     ),
     com_github_google_libprotobuf_mutator = dict(
-        commit = "c3d2faf04a1070b0b852b0efdef81e1a81ba925e",
+        commit = "c3d2faf04a1070b0b852b0efdef81e1a81ba925e",  # 2018-03-06
         remote = "https://github.com/google/libprotobuf-mutator",
     ),
     com_github_grpc_grpc = dict(
-        commit = "3eedb606a07738e5446ba852085f676b134ecca4",  # v1.14.0
-        remote = "https://github.com/grpc/grpc.git",
+        commit = "v1.14.2",
+        remote = "https://github.com/grpc/grpc",
     ),
     com_github_nanopb_nanopb = dict(
         # From: https://github.com/grpc/grpc/blob/v1.14.0/bazel/grpc_deps.bzl#L123
@@ -70,7 +68,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/google/googleapis",
     ),
     com_github_google_jwt_verify = dict(
-        commit = "4eb9e96485b71e00d43acc7207501caafb085b4a",
+        commit = "4eb9e96485b71e00d43acc7207501caafb085b4a",  # 2018-06-11
         remote = "https://github.com/google/jwt_verify_lib",
     ),
     com_github_nodejs_http_parser = dict(
@@ -82,15 +80,15 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/nodejs/http-parser",
     ),
     com_github_pallets_jinja = dict(
-        commit = "78d2f672149e5b9b7d539c575d2c1bfc12db67a9",  # 2.10
+        commit = "2.10",
         remote = "https://github.com/pallets/jinja",
     ),
     com_github_pallets_markupsafe = dict(
-        commit = "d2a40c41dd1930345628ea9412d97e159f828157",  # 1.0
+        commit = "1.0",
         remote = "https://github.com/pallets/markupsafe",
     ),
     com_github_tencent_rapidjson = dict(
-        commit = "f54b0e47a08782a6131cc3d60f94d038fa6e0a51",  # v1.1.0
+        commit = "v1.1.0",
         remote = "https://github.com/tencent/rapidjson",
     ),
     com_github_twitter_common_lang = dict(
@@ -109,7 +107,7 @@ REPOSITORY_LOCATIONS = dict(
         strip_prefix = "twitter.common.finagle-thrift-0.3.9/src",
     ),
     com_google_googletest = dict(
-        commit = "3d5612182581df64acc12d2633e473decf5adc47",  # Aug 29, 2018
+        commit = "release-1.8.1",
         remote = "https://github.com/google/googletest",
     ),
     com_google_protobuf = dict(
@@ -125,7 +123,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/grpc-ecosystem/grpc-httpjson-transcoding",
     ),
     io_bazel_rules_go = dict(
-        commit = "0.11.1",
+        commit = "0.11.2",
         remote = "https://github.com/bazelbuild/rules_go",
     ),
     six_archive = dict(
@@ -136,7 +134,7 @@ REPOSITORY_LOCATIONS = dict(
     # I'd love to name this `com_github_google_subpar`, but something in the Subpar
     # code assumes its repository name is just `subpar`.
     subpar = dict(
-        commit = "eb23aa7a5361cabc02464476dd080389340a5522",  # HEAD
+        commit = "1.3.0",
         remote = "https://github.com/google/subpar",
     ),
 )

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -10,13 +10,13 @@ REPOSITORY_LOCATIONS = dict(
     ),
     com_github_apache_thrift = dict(
         sha256 = "7d59ac4fdcb2c58037ebd4a9da5f9a49e3e034bf75b3f26d9fe48ba3d8806e6b",
-        urls = ["https://files.pythonhosted.org/packages/c6/b4/510617906f8e0c5660e7d96fbc5585113f83ad547a3989b80297ac72a74c/thrift-0.11.0.tar.gz"],  # 0.11.0
         strip_prefix = "thrift-0.11.0",
+        urls = ["https://files.pythonhosted.org/packages/c6/b4/510617906f8e0c5660e7d96fbc5585113f83ad547a3989b80297ac72a74c/thrift-0.11.0.tar.gz"],
     ),
     com_github_bombela_backward = dict(
         sha256 = "ad73be31c5cfcbffbde7d34dba18158a42043a109e7f41946f0b0abd589ed55e",
-        commit = "v1.4",
-        remote = "https://github.com/bombela/backward-cpp",
+        strip_prefix = "backward-cpp-1.4",
+        urls = ["https://github.com/bombela/backward-cpp/archive/v1.4.tar.gz"],
     ),
     com_github_circonus_labs_libcircllhist = dict(
         commit = "050da53a44dede7bda136b93a9aeef47bd91fa12",  # 2018-07-02
@@ -24,28 +24,28 @@ REPOSITORY_LOCATIONS = dict(
     ),
     com_github_cyan4973_xxhash = dict(
         sha256 = "19030315f4fc1b4b2cdb9d7a317069a109f90e39d1fe4c9159b7aaa39030eb95",
-        commit = "v0.6.5",
-        remote = "https://github.com/Cyan4973/xxHash",
+        strip_prefix = "xxHash-0.6.5",
+        urls = ["https://github.com/Cyan4973/xxHash/archive/v0.6.5.tar.gz"],
     ),
     com_github_eile_tclap = dict(
         sha256 = "f0ede0721dddbb5eba3a47385a6e8681b14f155e1129dd39d1a959411935098f",
-        commit = "tclap-1-2-1-release-final",
-        remote = "https://github.com/eile/tclap",
+        strip_prefix = "tclap-tclap-1-2-1-release-final",
+        urls = ["https://github.com/eile/tclap/archive/tclap-1-2-1-release-final.tar.gz"],
     ),
     com_github_fmtlib_fmt = dict(
         sha256 = "46628a2f068d0e33c716be0ed9dcae4370242df135aed663a180b9fd8e36733d",
-        commit = "4.1.0",
-        remote = "https://github.com/fmtlib/fmt",
+        strip_prefix = "fmt-4.1.0",
+        urls = ["https://github.com/fmtlib/fmt/archive/4.1.0.tar.gz"],
     ),
     com_github_gabime_spdlog = dict(
         sha256 = "94f74fd1b3344733d1db3de2ec22e6cbeb769f93a8baa0d4a22b1f62dc7369f8",
-        commit = "v0.17.0",
-        remote = "https://github.com/gabime/spdlog",
+        strip_prefix = "spdlog-0.17.0",
+        urls = ["https://github.com/gabime/spdlog/archive/v0.17.0.tar.gz"],
     ),
     com_github_gcovr_gcovr = dict(
         sha256 = "1c52a71f245adfe1b45e30fbe5015337fe66546f17f40038b3969b7b42acceed",
-        commit = "3.3",
-        remote = "https://github.com/gcovr/gcovr",
+        strip_prefix = "gcovr-3.3",
+        urls = ["https://github.com/gcovr/gcovr/archive/3.3.tar.gz"],
     ),
     com_github_google_libprotobuf_mutator = dict(
         commit = "c3d2faf04a1070b0b852b0efdef81e1a81ba925e",  # 2018-03-06
@@ -53,8 +53,8 @@ REPOSITORY_LOCATIONS = dict(
     ),
     com_github_grpc_grpc = dict(
         sha256 = "c747e4d903f7dcf803be53abed4e4efc5d3e96f6c274ed1dfca7a03fa6f4e36b",
-        commit = "v1.14.2",
-        remote = "https://github.com/grpc/grpc",
+        strip_prefix = "grpc-1.14.2",
+        urls = ["https://github.com/grpc/grpc/archive/v1.14.2.tar.gz"],
     ),
     com_github_nanopb_nanopb = dict(
         # From: https://github.com/grpc/grpc/blob/v1.14.0/bazel/grpc_deps.bzl#L123
@@ -88,38 +88,38 @@ REPOSITORY_LOCATIONS = dict(
     ),
     com_github_pallets_jinja = dict(
         sha256 = "0d31d3466c313a9ca014a2d904fed18cdac873a5ba1f7b70b8fd8b206cd860d6",
-        commit = "2.10",
-        remote = "https://github.com/pallets/jinja",
+        strip_prefix = "jinja-2.10",
+        urls = ["https://github.com/pallets/jinja/archive/2.10.tar.gz"],
     ),
     com_github_pallets_markupsafe = dict(
         sha256 = "dc3938045d9407a73cf9fdd709e2b1defd0588d50ffc85eb0786c095ec846f15",
-        commit = "1.0",
-        remote = "https://github.com/pallets/markupsafe",
+        strip_prefix = "markupsafe-1.0",
+        urls = ["https://github.com/pallets/markupsafe/archive/1.0.tar.gz"],
     ),
     com_github_tencent_rapidjson = dict(
         sha256 = "bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e",
-        commit = "v1.1.0",
-        remote = "https://github.com/tencent/rapidjson",
+        strip_prefix = "rapidjson-1.1.0",
+        urls = ["https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz"],
     ),
     com_github_twitter_common_lang = dict(
         sha256 = "56d1d266fd4767941d11c27061a57bc1266a3342e551bde3780f9e9eb5ad0ed1",
-        urls = ["https://files.pythonhosted.org/packages/08/bc/d6409a813a9dccd4920a6262eb6e5889e90381453a5f58938ba4cf1d9420/twitter.common.lang-0.3.9.tar.gz"],  # 0.3.9
         strip_prefix = "twitter.common.lang-0.3.9/src",
+        urls = ["https://files.pythonhosted.org/packages/08/bc/d6409a813a9dccd4920a6262eb6e5889e90381453a5f58938ba4cf1d9420/twitter.common.lang-0.3.9.tar.gz"],
     ),
     com_github_twitter_common_rpc = dict(
         sha256 = "0792b63fb2fb32d970c2e9a409d3d00633190a22eb185145fe3d9067fdaa4514",
-        urls = ["https://files.pythonhosted.org/packages/be/97/f5f701b703d0f25fbf148992cd58d55b4d08d3db785aad209255ee67e2d0/twitter.common.rpc-0.3.9.tar.gz"],  # 0.3.9
         strip_prefix = "twitter.common.rpc-0.3.9/src",
+        urls = ["https://files.pythonhosted.org/packages/be/97/f5f701b703d0f25fbf148992cd58d55b4d08d3db785aad209255ee67e2d0/twitter.common.rpc-0.3.9.tar.gz"],
     ),
     com_github_twitter_common_finagle_thrift = dict(
         sha256 = "1e3a57d11f94f58745e6b83348ecd4fa74194618704f45444a15bc391fde497a",
-        urls = ["https://files.pythonhosted.org/packages/f9/e7/4f80d582578f8489226370762d2cf6bc9381175d1929eba1754e03f70708/twitter.common.finagle-thrift-0.3.9.tar.gz"],  # 0.3.9
         strip_prefix = "twitter.common.finagle-thrift-0.3.9/src",
+        urls = ["https://files.pythonhosted.org/packages/f9/e7/4f80d582578f8489226370762d2cf6bc9381175d1929eba1754e03f70708/twitter.common.finagle-thrift-0.3.9.tar.gz"],
     ),
     com_google_googletest = dict(
         sha256 = "9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c",
-        commit = "release-1.8.1",
-        remote = "https://github.com/google/googletest",
+        strip_prefix = "googletest-release-1.8.1",
+        urls = ["https://github.com/google/googletest/archive/release-1.8.1.tar.gz"],
     ),
     com_google_protobuf = dict(
         # TODO(htuch): Switch back to released versions for protobuf when a release > 3.6.0 happens
@@ -135,8 +135,8 @@ REPOSITORY_LOCATIONS = dict(
     ),
     io_bazel_rules_go = dict(
         sha256 = "5a89e9c1fe89d45c4a45132fae94bf130842ce3c77e3a735a68f6991d4e00a25",
-        commit = "0.11.2",
-        remote = "https://github.com/bazelbuild/rules_go",
+        strip_prefix = "rules_go-0.11.2",
+        urls = ["https://github.com/bazelbuild/rules_go/archive/0.11.2.tar.gz"],
     ),
     six_archive = dict(
         sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
@@ -147,7 +147,7 @@ REPOSITORY_LOCATIONS = dict(
     # code assumes its repository name is just `subpar`.
     subpar = dict(
         sha256 = "eddbfc920e9cd565500370114316757848b672deba06dc2336acfa81b4ac0e6d",
-        commit = "1.3.0",
-        remote = "https://github.com/google/subpar",
+        strip_prefix = "subpar-1.3.0",
+        urls = ["https://github.com/google/subpar/archive/1.3.0.tar.gz"],
     ),
 )

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -97,7 +97,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/pallets/markupsafe",
     ),
     com_github_tencent_rapidjson = dict(
-        sha256 ="bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e",
+        sha256 = "bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e",
         commit = "v1.1.0",
         remote = "https://github.com/tencent/rapidjson",
     ),

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -43,7 +43,7 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/gabime/spdlog/archive/v0.17.0.tar.gz"],
     ),
     com_github_gcovr_gcovr = dict(
-        sha256 = "1c52a71f245adfe1b45e30fbe5015337fe66546f17f40038b3969b7b42acceed",
+        sha256 = "8a60ba6242d67a58320e9e16630d80448ef6d5284fda5fb3eff927b63c8b04a2",
         strip_prefix = "gcovr-3.3",
         urls = ["https://github.com/gcovr/gcovr/archive/3.3.tar.gz"],
     ),

--- a/ci/build_container/build_container_common.sh
+++ b/ci/build_container/build_container_common.sh
@@ -1,8 +1,11 @@
 #!/bin/bash -e
 
+VERSION=0.15.0
+SHA256=0dea01a7a511797878f486e6ed8e549980c0710a0a116c8ee953d4e26de41515
+
 # buildifier
-curl --location --output /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.15.0/buildifier \
-  && echo '0dea01a7a511797878f486e6ed8e549980c0710a0a116c8ee953d4e26de41515  /usr/local/bin/buildifier' | sha256sum --check \
+curl --location --output /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/"$VERSION"/buildifier \
+  && echo "$SHA256" '/usr/local/bin/buildifier' | sha256sum --check \
   && chmod +x /usr/local/bin/buildifier
 
 # GCC for everything.

--- a/ci/build_container/build_container_common.sh
+++ b/ci/build_container/build_container_common.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
 # buildifier
-curl --location --output /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.12.0/buildifier \
-  && echo '7a77601630e493e4d6cbe4dfabb48e0e9a32ff372d84233527180cfc11d49496  /usr/local/bin/buildifier' | sha256sum --check \
+curl --location --output /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.15.0/buildifier \
+  && echo '0dea01a7a511797878f486e6ed8e549980c0710a0a116c8ee953d4e26de41515  /usr/local/bin/buildifier' | sha256sum --check \
   && chmod +x /usr/local/bin/buildifier
 
 # GCC for everything.

--- a/ci/build_container/build_recipes/benchmark.sh
+++ b/ci/build_container/build_recipes/benchmark.sh
@@ -3,9 +3,10 @@
 set -e
 
 VERSION=1.4.1
+SHA256=f8e525db3c42efc9c7f3bc5176a8fa893a9a9920bbd08cef30fb56a51854d60d
 
 curl https://github.com/google/benchmark/archive/v"$VERSION".tar.gz -sLo benchmark-"$VERSION".tar.gz \
-  && echo 'f8e525db3c42efc9c7f3bc5176a8fa893a9a9920bbd08cef30fb56a51854d60d' benchmark-"$VERSION".tar.gz | sha256sum --check
+  && echo "$SHA256" benchmark-"$VERSION".tar.gz | sha256sum --check
 tar xf benchmark-"$VERSION".tar.gz
 cd benchmark-"$VERSION"
 

--- a/ci/build_container/build_recipes/benchmark.sh
+++ b/ci/build_container/build_recipes/benchmark.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
 set -e
-export COMMIT="e1c3a83b8197cf02e794f61228461c27d4e78cfb"  # benchmark @ Jan 11, 2018
 
-git clone https://github.com/google/benchmark.git
-(cd benchmark; git reset --hard "$COMMIT")
+VERSION=1.4.1
+
+curl https://github.com/google/benchmark/archive/v"$VERSION".tar.gz -sLo benchmark-"$VERSION".tar.gz \
+  && echo 'f8e525db3c42efc9c7f3bc5176a8fa893a9a9920bbd08cef30fb56a51854d60d' benchmark-"$VERSION".tar.gz | sha256sum --check
+tar xf benchmark-"$VERSION".tar.gz
+cd benchmark-"$VERSION"
+
 mkdir build
-
 cd build
-cmake -G "Ninja" ../benchmark \
+
+cmake -G "Ninja" ../ \
   -DCMAKE_BUILD_TYPE=RELEASE \
   -DBENCHMARK_ENABLE_GTEST_TESTS=OFF
 ninja
@@ -19,7 +23,7 @@ if [[ "${OS}" == "Windows_NT" ]]; then
 fi
 
 cp "src/$benchmark_lib" "$THIRDPARTY_BUILD"/lib
-cd ../benchmark
+cd ../
 
 INCLUDE_DIR="$THIRDPARTY_BUILD/include/testing/base/public"
 mkdir -p "$INCLUDE_DIR"

--- a/ci/build_container/build_recipes/cares.sh
+++ b/ci/build_container/build_recipes/cares.sh
@@ -10,7 +10,8 @@ VERSION=cares-1_14_0
 CPPFLAGS="$(for f in $CXXFLAGS; do if [[ $f =~ -D.* ]]; then echo $f; fi; done | tr '\n' ' ')"
 CFLAGS="$(for f in $CXXFLAGS; do if [[ ! $f =~ -D.* ]]; then echo $f; fi; done | tr '\n' ' ')"
 
-curl https://github.com/c-ares/c-ares/archive/"$VERSION".tar.gz -sLo c-ares-"$VERSION".tar.gz
+curl https://github.com/c-ares/c-ares/archive/"$VERSION".tar.gz -sLo c-ares-"$VERSION".tar.gz \
+  && echo '62dd12f0557918f89ad6f5b759f0bf4727174ae9979499f5452c02be38d9d3e8' c-ares-"$VERSION".tar.gz | sha256sum --check
 tar xf c-ares-"$VERSION".tar.gz
 cd c-ares-"$VERSION"
 

--- a/ci/build_container/build_recipes/cares.sh
+++ b/ci/build_container/build_recipes/cares.sh
@@ -3,6 +3,7 @@
 set -e
 
 VERSION=cares-1_14_0
+SHA256=62dd12f0557918f89ad6f5b759f0bf4727174ae9979499f5452c02be38d9d3e8
 
 # cares is fussy over whether -D appears inside CFLAGS vs. CPPFLAGS, oss-fuzz
 # sets CFLAGS with -D, so we need to impedance match here. In turn, OS X automake
@@ -11,7 +12,7 @@ CPPFLAGS="$(for f in $CXXFLAGS; do if [[ $f =~ -D.* ]]; then echo $f; fi; done |
 CFLAGS="$(for f in $CXXFLAGS; do if [[ ! $f =~ -D.* ]]; then echo $f; fi; done | tr '\n' ' ')"
 
 curl https://github.com/c-ares/c-ares/archive/"$VERSION".tar.gz -sLo c-ares-"$VERSION".tar.gz \
-  && echo '62dd12f0557918f89ad6f5b759f0bf4727174ae9979499f5452c02be38d9d3e8' c-ares-"$VERSION".tar.gz | sha256sum --check
+  && echo "$SHA256" c-ares-"$VERSION".tar.gz | sha256sum --check
 tar xf c-ares-"$VERSION".tar.gz
 cd c-ares-"$VERSION"
 

--- a/ci/build_container/build_recipes/gperftools.sh
+++ b/ci/build_container/build_recipes/gperftools.sh
@@ -8,7 +8,8 @@ fi
 
 VERSION=2.7
 
-curl https://github.com/gperftools/gperftools/releases/download/gperftools-"$VERSION"/gperftools-"$VERSION".tar.gz -sLo gperftools-"$VERSION".tar.gz
+curl https://github.com/gperftools/gperftools/releases/download/gperftools-"$VERSION"/gperftools-"$VERSION".tar.gz -sLo gperftools-"$VERSION".tar.gz \
+  && echo '1ee8c8699a0eff6b6a203e59b43330536b22bbcbe6448f54c7091e5efb0763c9' gperftools-"$VERSION".tar.gz | sha256sum --check
 tar xf gperftools-"$VERSION".tar.gz
 cd gperftools-"$VERSION"
 

--- a/ci/build_container/build_recipes/gperftools.sh
+++ b/ci/build_container/build_recipes/gperftools.sh
@@ -7,9 +7,10 @@ if [[ "${OS}" == "Windows_NT" ]]; then
 fi
 
 VERSION=2.7
+SHA256=1ee8c8699a0eff6b6a203e59b43330536b22bbcbe6448f54c7091e5efb0763c9
 
 curl https://github.com/gperftools/gperftools/releases/download/gperftools-"$VERSION"/gperftools-"$VERSION".tar.gz -sLo gperftools-"$VERSION".tar.gz \
-  && echo '1ee8c8699a0eff6b6a203e59b43330536b22bbcbe6448f54c7091e5efb0763c9' gperftools-"$VERSION".tar.gz | sha256sum --check
+  && echo "$SHA256" gperftools-"$VERSION".tar.gz | sha256sum --check
 tar xf gperftools-"$VERSION".tar.gz
 cd gperftools-"$VERSION"
 

--- a/ci/build_container/build_recipes/libevent.sh
+++ b/ci/build_container/build_recipes/libevent.sh
@@ -3,9 +3,10 @@
 set -e
 
 VERSION=2.1.8-stable
+SHA256=316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d
 
 curl https://github.com/libevent/libevent/archive/release-"$VERSION".tar.gz -sLo libevent-release-"$VERSION".tar.gz \
-  && echo '316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d' libevent-release-"$VERSION".tar.gz | sha256sum --check
+  && echo "$SHA256" libevent-release-"$VERSION".tar.gz | sha256sum --check
 tar xf libevent-release-"$VERSION".tar.gz
 cd libevent-release-"$VERSION"
 

--- a/ci/build_container/build_recipes/libevent.sh
+++ b/ci/build_container/build_recipes/libevent.sh
@@ -4,7 +4,8 @@ set -e
 
 VERSION=2.1.8-stable
 
-curl https://github.com/libevent/libevent/archive/release-"$VERSION".tar.gz -sLo libevent-release-"$VERSION".tar.gz
+curl https://github.com/libevent/libevent/archive/release-"$VERSION".tar.gz -sLo libevent-release-"$VERSION".tar.gz \
+  && echo '316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d' libevent-release-"$VERSION".tar.gz | sha256sum --check
 tar xf libevent-release-"$VERSION".tar.gz
 cd libevent-release-"$VERSION"
 

--- a/ci/build_container/build_recipes/luajit.sh
+++ b/ci/build_container/build_recipes/luajit.sh
@@ -3,9 +3,10 @@
 set -e
 
 VERSION=2.0.5
+SHA256=8bb29d84f06eb23c7ea4aa4794dbb248ede9fcb23b6989cbef81dc79352afc97
 
 curl https://github.com/LuaJIT/LuaJIT/archive/v"$VERSION".tar.gz -sLo LuaJIT-"$VERSION".tar.gz \
-  && echo '8bb29d84f06eb23c7ea4aa4794dbb248ede9fcb23b6989cbef81dc79352afc97' LuaJIT-"$VERSION".tar.gz | sha256sum --check
+  && echo "$SHA256" LuaJIT-"$VERSION".tar.gz | sha256sum --check
 tar xf LuaJIT-"$VERSION".tar.gz
 cd LuaJIT-"$VERSION"
 

--- a/ci/build_container/build_recipes/luajit.sh
+++ b/ci/build_container/build_recipes/luajit.sh
@@ -4,7 +4,8 @@ set -e
 
 VERSION=2.0.5
 
-curl https://github.com/LuaJIT/LuaJIT/archive/v"$VERSION".tar.gz -sLo LuaJIT-"$VERSION".tar.gz
+curl https://github.com/LuaJIT/LuaJIT/archive/v"$VERSION".tar.gz -sLo LuaJIT-"$VERSION".tar.gz \
+  && echo '8bb29d84f06eb23c7ea4aa4794dbb248ede9fcb23b6989cbef81dc79352afc97' LuaJIT-"$VERSION".tar.gz | sha256sum --check
 tar xf LuaJIT-"$VERSION".tar.gz
 cd LuaJIT-"$VERSION"
 

--- a/ci/build_container/build_recipes/nghttp2.sh
+++ b/ci/build_container/build_recipes/nghttp2.sh
@@ -2,12 +2,9 @@
 
 set -e
 
-# Use master branch, which contains a fix for the spurious limit of 100 concurrent streams:
-# https://github.com/nghttp2/nghttp2/commit/2ba1389993729fcb6ee5794ac512f2b67b29952e
-# TODO(PiotrSikora): switch back to releases once v1.33.0 is out.
-VERSION=e5b3f9addd49bca27e2f99c5c65a564eb5c0cf6d  # 2018-06-09
+VERSION=1.33.0
 
-curl https://github.com/nghttp2/nghttp2/archive/"$VERSION".tar.gz -sLo nghttp2-"$VERSION".tar.gz
+curl https://github.com/nghttp2/nghttp2/releases/download/v"$VERSION"/nghttp2-"$VERSION".tar.gz -sLo nghttp2-"$VERSION".tar.gz
 tar xf nghttp2-"$VERSION".tar.gz
 cd nghttp2-"$VERSION"
 

--- a/ci/build_container/build_recipes/nghttp2.sh
+++ b/ci/build_container/build_recipes/nghttp2.sh
@@ -4,7 +4,8 @@ set -e
 
 VERSION=1.33.0
 
-curl https://github.com/nghttp2/nghttp2/releases/download/v"$VERSION"/nghttp2-"$VERSION".tar.gz -sLo nghttp2-"$VERSION".tar.gz
+curl https://github.com/nghttp2/nghttp2/releases/download/v"$VERSION"/nghttp2-"$VERSION".tar.gz -sLo nghttp2-"$VERSION".tar.gz \
+  && echo '42fff7f290100c02234ac3b0095852e4392e6bfd95ebed900ca8bd630850d88c' nghttp2-"$VERSION".tar.gz | sha256sum --check
 tar xf nghttp2-"$VERSION".tar.gz
 cd nghttp2-"$VERSION"
 

--- a/ci/build_container/build_recipes/nghttp2.sh
+++ b/ci/build_container/build_recipes/nghttp2.sh
@@ -3,9 +3,10 @@
 set -e
 
 VERSION=1.33.0
+SHA256=42fff7f290100c02234ac3b0095852e4392e6bfd95ebed900ca8bd630850d88c
 
 curl https://github.com/nghttp2/nghttp2/releases/download/v"$VERSION"/nghttp2-"$VERSION".tar.gz -sLo nghttp2-"$VERSION".tar.gz \
-  && echo '42fff7f290100c02234ac3b0095852e4392e6bfd95ebed900ca8bd630850d88c' nghttp2-"$VERSION".tar.gz | sha256sum --check
+  && echo "$SHA256" nghttp2-"$VERSION".tar.gz | sha256sum --check
 tar xf nghttp2-"$VERSION".tar.gz
 cd nghttp2-"$VERSION"
 

--- a/ci/build_container/build_recipes/yaml-cpp.sh
+++ b/ci/build_container/build_recipes/yaml-cpp.sh
@@ -4,9 +4,10 @@ set -e
 
 # Pin to this commit to pick up fix for building on Visual Studio 15.8
 COMMIT=0f9a586ca1dc29c2ecb8dd715a315b93e3f40f79 # 2018-06-30
+SHA256=53dcffd55f3433b379fcc694f45c54898711c0e29159a7bd02e82a3e0253bac3
 
 curl https://github.com/jbeder/yaml-cpp/archive/"$COMMIT".tar.gz -sLo yaml-cpp-"$COMMIT".tar.gz \
-  && echo '53dcffd55f3433b379fcc694f45c54898711c0e29159a7bd02e82a3e0253bac3' yaml-cpp-"$COMMIT".tar.gz | sha256sum --check
+  && echo "$SHA256" yaml-cpp-"$COMMIT".tar.gz | sha256sum --check
 tar xf yaml-cpp-"$COMMIT".tar.gz
 cd yaml-cpp-"$COMMIT"
 

--- a/ci/build_container/build_recipes/yaml-cpp.sh
+++ b/ci/build_container/build_recipes/yaml-cpp.sh
@@ -5,7 +5,8 @@ set -e
 # Pin to this commit to pick up fix for building on Visual Studio 15.8
 COMMIT=0f9a586ca1dc29c2ecb8dd715a315b93e3f40f79 # 2018-06-30
 
-curl https://github.com/jbeder/yaml-cpp/archive/"$COMMIT".tar.gz -sLo yaml-cpp-"$COMMIT".tar.gz
+curl https://github.com/jbeder/yaml-cpp/archive/"$COMMIT".tar.gz -sLo yaml-cpp-"$COMMIT".tar.gz \
+  && echo '53dcffd55f3433b379fcc694f45c54898711c0e29159a7bd02e82a3e0253bac3' yaml-cpp-"$COMMIT".tar.gz | sha256sum --check
 tar xf yaml-cpp-"$COMMIT".tar.gz
 cd yaml-cpp-"$COMMIT"
 

--- a/ci/build_container/build_recipes/zlib.sh
+++ b/ci/build_container/build_recipes/zlib.sh
@@ -4,11 +4,14 @@ set -e
 
 VERSION=1.2.11
 
-curl https://github.com/madler/zlib/archive/v"$VERSION".tar.gz -sLo zlib-"$VERSION".tar.gz
+curl https://github.com/madler/zlib/archive/v"$VERSION".tar.gz -sLo zlib-"$VERSION".tar.gz \
+  && echo '629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff' zlib-"$VERSION".tar.gz | sha256sum --check
 tar xf zlib-"$VERSION".tar.gz
 cd zlib-"$VERSION"
+
 mkdir build
 cd build
+
 cmake -G "Ninja" -DCMAKE_INSTALL_PREFIX:PATH="$THIRDPARTY_BUILD" ..
 ninja
 ninja install

--- a/ci/build_container/build_recipes/zlib.sh
+++ b/ci/build_container/build_recipes/zlib.sh
@@ -3,9 +3,10 @@
 set -e
 
 VERSION=1.2.11
+SHA256=629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff
 
 curl https://github.com/madler/zlib/archive/v"$VERSION".tar.gz -sLo zlib-"$VERSION".tar.gz \
-  && echo '629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff' zlib-"$VERSION".tar.gz | sha256sum --check
+  && echo "$SHA256" zlib-"$VERSION".tar.gz | sha256sum --check
 tar xf zlib-"$VERSION".tar.gz
 cd zlib-"$VERSION"
 

--- a/ci/mac_ci_steps.sh
+++ b/ci/mac_ci_steps.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+# Add non-g prefixed coreutils installed sha256sum to the path
+# allowing us to check the sha of dependencies downloaded in
+# ci/build_container/build_recipes/*.sh
+export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+
 . "$(dirname "$0")"/setup_gcs_cache.sh
 
 BAZEL_BUILD_OPTIONS="--curses=no --show_task_finish --verbose_failures ${BAZEL_BUILD_EXTRA_OPTIONS}"


### PR DESCRIPTION
Signed-off-by: Michael Payne michael@sooper.org

Dependency: Upgrade to backward-cpp v1.4, grpc v1.14.2, googletest v1.8.1, rules_go 0.11.2, buildifier 0.15.0, nghttp2 1.33.0 and subpar 1.3.0. This PR does not update dependencies that rely on commit shas.

Description: nghttp1 1.33.0 [release notes](https://github.com/nghttp2/nghttp2/releases/tag/v1.33.0), backward-cpp v1.4 [release notes](https://github.com/bombela/backward-cpp/releases/tag/v1.4), grpc [release notes](https://github.com/grpc/grpc/releases/tag/v1.14.2), rules_go [release notes](https://github.com/bazelbuild/rules_go/releases/tag/0.11.2), buildifier [release notes](https://github.com/bazelbuild/buildtools/releases/tag/0.15.0), googletest [release notes](https://github.com/google/googletest/releases/tag/release-1.8.1) and subpar [commits](https://github.com/google/subpar/compare/eb23aa7a5361cabc02464476dd080389340a5522...1.3.0) & [release notes](https://github.com/google/subpar/releases). Add commit date comments to libprotobuf-mutator & jwt_verify_lib

Risk Level: Low
Testing: bazel test //test/... and running on local instances.
Docs Changes: none required
Release Notes: none required