### PR TITLE
Not to send a discovery request at GrpcSubscriptionImpl destructor

### DIFF
--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -29,10 +29,10 @@ GrpcMuxImpl::~GrpcMuxImpl() {
   }
 }
 
-void GrpcMuxImpl::noMoreRequestSending() {
+void GrpcMuxImpl::disableSendUpdateAtWatcherDelete() {
   for (const auto& api_state : api_state_) {
     for (auto watch : api_state.second.watches_) {
-      watch->send_update_ = false;
+      watch->send_update_at_delete_ = false;
     }
   }
 }

--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -29,6 +29,14 @@ GrpcMuxImpl::~GrpcMuxImpl() {
   }
 }
 
+void GrpcMuxImpl::noMoreRequestSending() {
+  for (const auto& api_state : api_state_) {
+    for (auto watch : api_state.second.watches_) {
+      watch->send_update_ = false;
+    }
+  }
+}
+
 void GrpcMuxImpl::start() { establishNewStream(); }
 
 void GrpcMuxImpl::setRetryTimer() {

--- a/source/common/config/grpc_mux_impl.h
+++ b/source/common/config/grpc_mux_impl.h
@@ -29,6 +29,9 @@ public:
               Runtime::RandomGenerator& random);
   ~GrpcMuxImpl();
 
+  // Not to send any request, the object is about to be deleted.
+  void noMoreRequestSending();
+
   void start() override;
   GrpcMuxWatchPtr subscribe(const std::string& type_url, const std::vector<std::string>& resources,
                             GrpcMuxCallbacks& callbacks) override;
@@ -56,14 +59,14 @@ private:
     GrpcMuxWatchImpl(const std::vector<std::string>& resources, GrpcMuxCallbacks& callbacks,
                      const std::string& type_url, GrpcMuxImpl& parent)
         : resources_(resources), callbacks_(callbacks), type_url_(type_url), parent_(parent),
-          inserted_(true) {
+          inserted_(true), send_update_(true) {
       entry_ = parent.api_state_[type_url].watches_.emplace(
           parent.api_state_[type_url].watches_.begin(), this);
     }
     ~GrpcMuxWatchImpl() override {
       if (inserted_) {
         parent_.api_state_[type_url_].watches_.erase(entry_);
-        if (!resources_.empty()) {
+        if (send_update_ && !resources_.empty()) {
           parent_.sendDiscoveryRequest(type_url_);
         }
       }
@@ -74,6 +77,7 @@ private:
     GrpcMuxImpl& parent_;
     std::list<GrpcMuxWatchImpl*>::iterator entry_;
     bool inserted_;
+    bool send_update_;
   };
 
   // Per muxed API state.

--- a/source/common/config/grpc_mux_impl.h
+++ b/source/common/config/grpc_mux_impl.h
@@ -29,8 +29,8 @@ public:
               Runtime::RandomGenerator& random);
   ~GrpcMuxImpl();
 
-  // Not to send any request, the object is about to be deleted.
-  void noMoreRequestSending();
+  // Not to send any update requests when watchers are removed.
+  void disableSendUpdateAtWatcherDelete();
 
   void start() override;
   GrpcMuxWatchPtr subscribe(const std::string& type_url, const std::vector<std::string>& resources,
@@ -59,14 +59,14 @@ private:
     GrpcMuxWatchImpl(const std::vector<std::string>& resources, GrpcMuxCallbacks& callbacks,
                      const std::string& type_url, GrpcMuxImpl& parent)
         : resources_(resources), callbacks_(callbacks), type_url_(type_url), parent_(parent),
-          inserted_(true), send_update_(true) {
+          inserted_(true), send_update_at_delete_(true) {
       entry_ = parent.api_state_[type_url].watches_.emplace(
           parent.api_state_[type_url].watches_.begin(), this);
     }
     ~GrpcMuxWatchImpl() override {
       if (inserted_) {
         parent_.api_state_[type_url_].watches_.erase(entry_);
-        if (send_update_ && !resources_.empty()) {
+        if (send_update_at_delete_ && !resources_.empty()) {
           parent_.sendDiscoveryRequest(type_url_);
         }
       }
@@ -77,7 +77,7 @@ private:
     GrpcMuxImpl& parent_;
     std::list<GrpcMuxWatchImpl*>::iterator entry_;
     bool inserted_;
-    bool send_update_;
+    bool send_update_at_delete_;
   };
 
   // Per muxed API state.

--- a/source/common/config/grpc_subscription_impl.h
+++ b/source/common/config/grpc_subscription_impl.h
@@ -19,6 +19,7 @@ public:
                        const Protobuf::MethodDescriptor& service_method, SubscriptionStats stats)
       : grpc_mux_(local_info, std::move(async_client), dispatcher, service_method, random),
         grpc_mux_subscription_(grpc_mux_, stats) {}
+  ~GrpcSubscriptionImpl() { grpc_mux_.noMoreRequestSending(); }
 
   // Config::Subscription
   void start(const std::vector<std::string>& resources,

--- a/source/common/config/grpc_subscription_impl.h
+++ b/source/common/config/grpc_subscription_impl.h
@@ -19,7 +19,7 @@ public:
                        const Protobuf::MethodDescriptor& service_method, SubscriptionStats stats)
       : grpc_mux_(local_info, std::move(async_client), dispatcher, service_method, random),
         grpc_mux_subscription_(grpc_mux_, stats) {}
-  ~GrpcSubscriptionImpl() { grpc_mux_.noMoreRequestSending(); }
+  ~GrpcSubscriptionImpl() { grpc_mux_.disableSendUpdateAtWatcherDelete(); }
 
   // Config::Subscription
   void start(const std::vector<std::string>& resources,

--- a/test/common/config/grpc_subscription_test_harness.h
+++ b/test/common/config/grpc_subscription_test_harness.h
@@ -45,8 +45,6 @@ public:
         *method_descriptor_, stats_));
   }
 
-  ~GrpcSubscriptionTestHarness() { EXPECT_CALL(async_stream_, sendMessage(_, false)); }
-
   void expectSendMessage(const std::vector<std::string>& cluster_names,
                          const std::string& version) override {
     expectSendMessage(cluster_names, version, Grpc::Status::GrpcStatus::Ok, "");


### PR DESCRIPTION
*Description*:

This change tries to fix https://github.com/envoyproxy/envoy/issues/4352

The root cause with detail log is described at: https://github.com/envoyproxy/envoy/issues/4167
This PR is a re-open of closed PR: https://github.com/envoyproxy/envoy/pull/4178

Problem:
When GrpcSubscriptionImpl is deleted, it tries to send one more request update.  Newly added sds_api is using GrpcSubscriptionImpl which is owned by a ListenerImpl.  When server is killed, GoogleAsyncClientThreadLocal is removed before ListenerManager is deleted.  It will cause sds_api to send a google grpc request with a deleted GoogleAsyncClientThreadLocal. Hence the crash.

Ideal solution (suggested by htuch)
When GoogleAsyncClientThreadLocal is removed, somehow notify all its clients;
GoogleAsyncClientImpl, not to send any more requests.  The Google grpc code is fairly complicated.  It is not easy to achieve.  The change could be big and high risk.

Short-team solution:
When GrpcSubscriptionImpl is deleted, not to send last request update.  The change is simple and low-risk.

*Risk Level*:  Low

*Testing*:   tested with
bazel test --runs_per_test=1000 //test/integration:sds_dynamic_integration_test

*Docs Changes*: No
*Release Notes*: No
[Optional Fixes #Issue]
[Optional *Deprecated*:]
