### PR TITLE
Bail out GoogleAsyncStreamImpl::writeQueued if cq is drained

### DIFF
--- a/source/common/grpc/google_async_client_impl.cc
+++ b/source/common/grpc/google_async_client_impl.cc
@@ -205,7 +205,8 @@ void GoogleAsyncStreamImpl::resetStream() {
 }
 
 void GoogleAsyncStreamImpl::writeQueued() {
-  if (!call_initialized_ || finish_pending_ || write_pending_ || write_pending_queue_.empty()) {
+  if (!call_initialized_ || finish_pending_ || write_pending_ || write_pending_queue_.empty() ||
+      draining_cq_) {
     return;
   }
   write_pending_ = true;


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

*Description*:

This change tries to fix #4352

Problem:
When GrpcSubscriptionImpl is deleted, it tries to send one more request update. Newly added sds_api is using GrpcSubscriptionImpl which is owned by a ListenerImpl. When server is killed, GoogleAsyncClientThreadLocal is removed before ListenerManager is deleted. It will cause sds_api to send a google grpc request with a deleted GoogleAsyncClientThreadLocal. Hence the crash.

Fix:
When GoogleAsyncClientThreadLocal is removed, all its active streams will be marked as draining_cq_ = true. If GoogleAsyncClientImpl::writeQueued is called with that flag, bail out.

*Risk Level*: Low

*Testing*:
bazel test --runs_per_test=1000 //test/integration:sds_dynamic_integration_test

*Docs Changes*: None

*Release Notes*: None
