### PR TITLE
grpc_json_transcoder: remove Trailer headers from http/1 responses

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -322,6 +322,12 @@ Http::FilterHeadersStatus JsonTranscoderFilter::encodeHeaders(Http::HeaderMap& h
 
   response_headers_ = &headers;
 
+  // if the client connection was http/1 then Trailer headers are prohibited
+  // (unless the transfer encoding is chunked, which it isn't), remove them
+  if (encoder_callbacks_->requestInfo().protocol() < Http::Protocol::Http2) {
+    response_headers_->remove(Http::LowerCaseString("trailer"));
+  }
+
   if (end_stream) {
     // In gRPC wire protocol, headers frame with end_stream is a trailers-only response.
     // The return value from encodeTrailers is ignored since it is always continue.

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -322,10 +322,10 @@ Http::FilterHeadersStatus JsonTranscoderFilter::encodeHeaders(Http::HeaderMap& h
 
   response_headers_ = &headers;
 
-  // if the client connection was http/1 then Trailer headers are prohibited
-  // (unless the transfer encoding is chunked, which it isn't), remove them
-  if (encoder_callbacks_->requestInfo().protocol() < Http::Protocol::Http2) {
-    response_headers_->remove(Http::LowerCaseString("trailer"));
+  // remove Trailer headers if the client connection was http/1
+  if (encoder_callbacks_->requestInfo().protocol() != Http::Protocol::Http2) {
+    const Http::LowerCaseString trailerKey = Http::LowerCaseString("trailer");
+    response_headers_->remove(trailerKey);
   }
 
   if (end_stream) {

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -324,7 +324,7 @@ Http::FilterHeadersStatus JsonTranscoderFilter::encodeHeaders(Http::HeaderMap& h
 
   // remove Trailer headers if the client connection was http/1
   if (encoder_callbacks_->requestInfo().protocol() != Http::Protocol::Http2) {
-    const Http::LowerCaseString trailerKey = Http::LowerCaseString("trailer");
+    static const Http::LowerCaseString trailerKey = Http::LowerCaseString("trailer");
     response_headers_->remove(trailerKey);
   }
 

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -400,8 +400,8 @@ Http::FilterTrailersStatus JsonTranscoderFilter::encodeTrailers(Http::HeaderMap&
 
   // remove Trailer headers if the client connection was http/1
   if (encoder_callbacks_->requestInfo().protocol() != Http::Protocol::Http2) {
-    static const Http::LowerCaseString trailerKey = Http::LowerCaseString("trailer");
-    response_headers_->remove(trailerKey);
+    static const Http::LowerCaseString trailer_key = Http::LowerCaseString("trailer");
+    response_headers_->remove(trailer_key);
   }
 
   response_headers_->insertContentLength().value(

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -100,6 +100,8 @@ protected:
         response_headers.insertGrpcMessage().value(grpc_status.error_message());
         upstream_request_->encodeHeaders(response_headers, true);
       } else {
+        response_headers.addCopy(Http::LowerCaseString("trailer"), "Grpc-Status");
+        response_headers.addCopy(Http::LowerCaseString("trailer"), "Grpc-Message");
         upstream_request_->encodeHeaders(response_headers, false);
         for (const auto& response_message_str : grpc_response_messages) {
           ResponseType response_message;
@@ -119,6 +121,7 @@ protected:
 
     response->waitForEndStream();
     EXPECT_TRUE(response->complete());
+    EXPECT_EQ(response->headers().get(Http::LowerCaseString("trailer")), nullptr);
     response_headers.iterate(
         [](const Http::HeaderEntry& entry, void* context) -> Http::HeaderMap::Iterate {
           IntegrationStreamDecoder* response = static_cast<IntegrationStreamDecoder*>(context);

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -121,7 +121,14 @@ protected:
 
     response->waitForEndStream();
     EXPECT_TRUE(response->complete());
-    EXPECT_EQ(response->headers().get(Http::LowerCaseString("trailer")), nullptr);
+
+    if (response->headers().get(Http::LowerCaseString("transfer-encoding")) == nullptr ||
+        strncmp(
+            response->headers().get(Http::LowerCaseString("transfer-encoding"))->value().c_str(),
+            "chunked", strlen("chunked")) != 0) {
+      EXPECT_EQ(response->headers().get(Http::LowerCaseString("trailer")), nullptr);
+    }
+
     response_headers.iterate(
         [](const Http::HeaderEntry& entry, void* context) -> Http::HeaderMap::Iterate {
           IntegrationStreamDecoder* response = static_cast<IntegrationStreamDecoder*>(context);


### PR DESCRIPTION
*Description*: When clients connect using http/1, Trailer headers are prohibited unless the transfer encoding is chunked, which it shouldn't be. Remove these headers in this case.
*Risk Level*: Low
*Testing*: Integration testing has been done to ensure that these headers are in fact removed.
*Docs Changes*: N/A
*Release Notes*: N/A
[Fixes #4240]