### PR TITLE
upstream: fix segfault in http health checker

### DIFF
--- a/source/common/upstream/health_checker_base_impl.h
+++ b/source/common/upstream/health_checker_base_impl.h
@@ -126,7 +126,11 @@ private:
   const std::chrono::milliseconds unhealthy_interval_;
   const std::chrono::milliseconds unhealthy_edge_interval_;
   const std::chrono::milliseconds healthy_edge_interval_;
+
+protected:
   std::unordered_map<HostSharedPtr, ActiveHealthCheckSessionPtr> active_sessions_;
+
+private:
   uint64_t local_process_healthy_{};
 };
 

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -221,7 +221,10 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onTimeout() {
 
   // If there is an active request it will get reset, so make sure we ignore the reset.
   expect_reset_ = true;
-  client_->close();
+
+  if (client_) {
+    client_->close();
+  }
 }
 
 Http::CodecClient::Type HttpHealthCheckerImpl::codecClientType(bool use_http2) {

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -47,7 +47,7 @@ public:
                         Event::Dispatcher& dispatcher, Runtime::Loader& runtime,
                         Runtime::RandomGenerator& random, HealthCheckEventLoggerPtr&& event_logger);
 
-private:
+protected:
   struct HttpActiveHealthCheckSession : public ActiveHealthCheckSession,
                                         public Http::StreamDecoder,
                                         public Http::StreamCallbacks {


### PR DESCRIPTION
*Description*: The http health checker would occasionally segfault due to trying to
close an already closed connection after a health check timeout. This
adds a null check before trying to do so.

*Risk Level*: Low, small bug fix
*Testing*: Unit test
*Docs Changes*: n/a
*Release Notes*: n/a
Fixes #4351