### PR TITLE
admin: add /memory for inspection of heap usage

### DIFF
--- a/api/envoy/admin/v2alpha/BUILD
+++ b/api/envoy/admin/v2alpha/BUILD
@@ -31,3 +31,9 @@ api_proto_library_internal(
     srcs = ["metrics.proto"],
     visibility = ["//visibility:public"],
 )
+
+api_proto_library_internal(
+    name = "memory",
+    srcs = ["memory.proto"],
+    visibility = ["//visibility:public"],
+)

--- a/api/envoy/admin/v2alpha/memory.proto
+++ b/api/envoy/admin/v2alpha/memory.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package envoy.admin.v2alpha;
+
+// [#protodoc-title: Memory]
+
+// Proto representation of the internal memory consumption of an Envoy instance.
+message Memory {
+
+  // The number of bytes allocated by the heap for Envoy.
+  uint64 currently_allocated_bytes = 1;
+
+  // The number of bytes reserved by the heap but not necessarily allocated.
+  uint64 heap_size_bytes = 2;
+}

--- a/api/envoy/admin/v2alpha/memory.proto
+++ b/api/envoy/admin/v2alpha/memory.proto
@@ -8,8 +8,8 @@ package envoy.admin.v2alpha;
 message Memory {
 
   // The number of bytes allocated by the heap for Envoy.
-  uint64 currently_allocated_bytes = 1;
+  uint64 allocated = 1;
 
   // The number of bytes reserved by the heap but not necessarily allocated.
-  uint64 heap_size_bytes = 2;
+  uint64 heap_size = 2;
 }

--- a/api/envoy/admin/v2alpha/memory.proto
+++ b/api/envoy/admin/v2alpha/memory.proto
@@ -4,12 +4,16 @@ package envoy.admin.v2alpha;
 
 // [#protodoc-title: Memory]
 
-// Proto representation of the internal memory consumption of an Envoy instance.
+// Proto representation of the internal memory consumption of an Envoy instance. These represent
+// values extracted from an internal TCMalloc instance. For more information, see the section of the
+// docs entitled ["Generic Tcmalloc Status"](http://gperftools.github.io/gperftools/tcmalloc.html).
 message Memory {
 
-  // The number of bytes allocated by the heap for Envoy.
+  // The number of bytes allocated by the heap for Envoy. This is an alias for
+  // `generic.current_allocated_bytes`.
   uint64 allocated = 1;
 
-  // The number of bytes reserved by the heap but not necessarily allocated.
+  // The number of bytes reserved by the heap but not necessarily allocated. This is an alias for
+  // `generic.heap_size`.
   uint64 heap_size = 2;
 }

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -158,6 +158,10 @@ modify different aspects of the server:
   Enable/disable different logging levels on different subcomponents. Generally only used during
   development.
 
+.. http:post:: /memory
+
+  Prints current memory allocation / heap usage, in bytes. Useful in lieu of printing all `/stats` and filtering to get the memory-related statistics.
+
 .. http:post:: /quitquitquit
 
   Cleanly exit the server.

--- a/source/server/http/BUILD
+++ b/source/server/http/BUILD
@@ -60,6 +60,7 @@ envoy_cc_library(
         "//source/extensions/access_loggers/file:file_access_log_lib",
         "@envoy_api//envoy/admin/v2alpha:clusters_cc",
         "@envoy_api//envoy/admin/v2alpha:config_dump_cc",
+        "@envoy_api//envoy/admin/v2alpha:memory_cc",
     ],
 )
 

--- a/source/server/http/BUILD
+++ b/source/server/http/BUILD
@@ -47,6 +47,7 @@ envoy_cc_library(
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",
         "//source/common/http/http1:codec_lib",
+        "//source/common/memory:stats_lib",
         "//source/common/network:listen_socket_lib",
         "//source/common/network:raw_buffer_socket_lib",
         "//source/common/network:utility_lib",

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -494,6 +494,7 @@ Http::Code AdminImpl::handlerLogging(absl::string_view url, Http::HeaderMap&,
   return rc;
 }
 
+// TODO(ambuc): Add more tcmalloc stats, export proto details based on allocator.
 Http::Code AdminImpl::handlerMemory(absl::string_view, Http::HeaderMap&, Buffer::Instance& response,
                                     AdminStream&) {
   envoy::admin::v2alpha::Memory memory;

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -11,6 +11,7 @@
 
 #include "envoy/admin/v2alpha/clusters.pb.h"
 #include "envoy/admin/v2alpha/config_dump.pb.h"
+#include "envoy/admin/v2alpha/memory.pb.h"
 #include "envoy/filesystem/filesystem.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/server/hot_restart.h"
@@ -495,9 +496,10 @@ Http::Code AdminImpl::handlerLogging(absl::string_view url, Http::HeaderMap&,
 
 Http::Code AdminImpl::handlerMemory(absl::string_view, Http::HeaderMap&, Buffer::Instance& response,
                                     AdminStream&) {
-  response.add(
-      fmt::format("generic.current_allocated_bytes: {}", Memory::Stats::totalCurrentlyAllocated()));
-  response.add(fmt::format("generic.heap_size: {}", Memory::Stats::totalCurrentlyReserved()));
+  envoy::admin::v2alpha::Memory memory;
+  memory.set_currently_allocated_bytes(Memory::Stats::totalCurrentlyAllocated());
+  memory.set_heap_size_bytes(Memory::Stats::totalCurrentlyReserved());
+  response.add(MessageUtil::getJsonStringFromMessage(memory, true)); // pretty-print
   return Http::Code::OK;
 }
 

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -35,6 +35,7 @@
 #include "common/http/headers.h"
 #include "common/http/http1/codec_impl.h"
 #include "common/json/json_loader.h"
+#include "common/memory/stats.h"
 #include "common/network/listen_socket_impl.h"
 #include "common/network/utility.h"
 #include "common/profiler/profiler.h"
@@ -492,6 +493,14 @@ Http::Code AdminImpl::handlerLogging(absl::string_view url, Http::HeaderMap&,
   return rc;
 }
 
+Http::Code AdminImpl::handlerMemory(absl::string_view, Http::HeaderMap&, Buffer::Instance& response,
+                                    AdminStream&) {
+  response.add(
+      fmt::format("generic.current_allocated_bytes: {}", Memory::Stats::totalCurrentlyAllocated()));
+  response.add(fmt::format("generic.heap_size: {}", Memory::Stats::totalCurrentlyReserved()));
+  return Http::Code::OK;
+}
+
 Http::Code AdminImpl::handlerResetCounters(absl::string_view, Http::HeaderMap&,
                                            Buffer::Instance& response, AdminStream&) {
   for (const Stats::CounterSharedPtr& counter : server_.stats().counters()) {
@@ -905,6 +914,8 @@ AdminImpl::AdminImpl(const std::string& access_log_path, const std::string& prof
            MAKE_ADMIN_HANDLER(handlerHotRestartVersion), false, false},
           {"/logging", "query/change logging levels", MAKE_ADMIN_HANDLER(handlerLogging), false,
            true},
+          {"/memory", "print current allocation/heap usage", MAKE_ADMIN_HANDLER(handlerMemory),
+           false, false},
           {"/quitquitquit", "exit the server", MAKE_ADMIN_HANDLER(handlerQuitQuitQuit), false,
            true},
           {"/reset_counters", "reset all counters to zero",

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -497,8 +497,8 @@ Http::Code AdminImpl::handlerLogging(absl::string_view url, Http::HeaderMap&,
 Http::Code AdminImpl::handlerMemory(absl::string_view, Http::HeaderMap&, Buffer::Instance& response,
                                     AdminStream&) {
   envoy::admin::v2alpha::Memory memory;
-  memory.set_currently_allocated_bytes(Memory::Stats::totalCurrentlyAllocated());
-  memory.set_heap_size_bytes(Memory::Stats::totalCurrentlyReserved());
+  memory.set_allocated(Memory::Stats::totalCurrentlyAllocated());
+  memory.set_heap_size(Memory::Stats::totalCurrentlyReserved());
   response.add(MessageUtil::getJsonStringFromMessage(memory, true)); // pretty-print
   return Http::Code::OK;
 }

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -202,6 +202,8 @@ private:
                                  AdminStream&);
   Http::Code handlerLogging(absl::string_view path_and_query, Http::HeaderMap& response_headers,
                             Buffer::Instance& response, AdminStream&);
+  Http::Code handlerMemory(absl::string_view path_and_query, Http::HeaderMap& response_headers,
+                           Buffer::Instance& response, AdminStream&);
   Http::Code handlerMain(const std::string& path, Buffer::Instance& response, AdminStream&);
   Http::Code handlerQuitQuitQuit(absl::string_view path_and_query,
                                  Http::HeaderMap& response_headers, Buffer::Instance& response,

--- a/test/server/http/BUILD
+++ b/test/server/http/BUILD
@@ -27,6 +27,7 @@ envoy_cc_test(
         "//test/test_common:logging_lib",
         "//test/test_common:network_utility_lib",
         "//test/test_common:utility_lib",
+        "@envoy_api//envoy/admin/v2alpha:memory_cc",
     ],
 )
 

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -612,6 +612,17 @@ TEST_P(AdminInstanceTest, ConfigDumpMaintainsOrder) {
   }
 }
 
+TEST_P(AdminInstanceTest, Memory) {
+  Http::HeaderMapImpl header_map;
+  Buffer::OwnedImpl response;
+  EXPECT_EQ(Http::Code::OK, getCallback("/memory", header_map, response));
+  const std::string output = response.toString();
+  EXPECT_TRUE(absl::StrContains(output, "generic.current_allocated_bytes: "));
+  EXPECT_FALSE(absl::StrContains(output, "generic.current_allocated_bytes: 0"));
+  EXPECT_TRUE(absl::StrContains(output, "generic.heap_size: "));
+  EXPECT_FALSE(absl::StrContains(output, "generic.heap_size: 0"));
+}
+
 TEST_P(AdminInstanceTest, Runtime) {
   Http::HeaderMapImpl header_map;
   Buffer::OwnedImpl response;

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1,6 +1,7 @@
 #include <fstream>
 #include <unordered_map>
 
+#include "envoy/admin/v2alpha/memory.pb.h"
 #include "envoy/json/json_object.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/stats/stats.h"
@@ -27,10 +28,13 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::AllOf;
+using testing::Gt;
 using testing::HasSubstr;
 using testing::InSequence;
 using testing::Invoke;
 using testing::NiceMock;
+using testing::Property;
 using testing::Ref;
 using testing::Return;
 using testing::ReturnPointee;
@@ -616,11 +620,12 @@ TEST_P(AdminInstanceTest, Memory) {
   Http::HeaderMapImpl header_map;
   Buffer::OwnedImpl response;
   EXPECT_EQ(Http::Code::OK, getCallback("/memory", header_map, response));
-  const std::string output = response.toString();
-  EXPECT_TRUE(absl::StrContains(output, "generic.current_allocated_bytes: "));
-  EXPECT_FALSE(absl::StrContains(output, "generic.current_allocated_bytes: 0"));
-  EXPECT_TRUE(absl::StrContains(output, "generic.heap_size: "));
-  EXPECT_FALSE(absl::StrContains(output, "generic.heap_size: 0"));
+  std::string output_json = response.toString();
+  envoy::admin::v2alpha::Memory output_proto;
+  MessageUtil::loadFromJson(output_json, output_proto);
+  EXPECT_THAT(output_proto,
+              AllOf(Property(&envoy::admin::v2alpha::Memory::currently_allocated_bytes, Gt(0)),
+                    Property(&envoy::admin::v2alpha::Memory::heap_size_bytes, Gt(0))));
 }
 
 TEST_P(AdminInstanceTest, Runtime) {

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -29,7 +29,7 @@
 
 using testing::_;
 using testing::AllOf;
-using testing::Gt;
+using testing::Ge;
 using testing::HasSubstr;
 using testing::InSequence;
 using testing::Invoke;
@@ -624,8 +624,8 @@ TEST_P(AdminInstanceTest, Memory) {
   envoy::admin::v2alpha::Memory output_proto;
   MessageUtil::loadFromJson(output_json, output_proto);
   EXPECT_THAT(output_proto,
-              AllOf(Property(&envoy::admin::v2alpha::Memory::currently_allocated_bytes, Gt(0)),
-                    Property(&envoy::admin::v2alpha::Memory::heap_size_bytes, Gt(0))));
+              AllOf(Property(&envoy::admin::v2alpha::Memory::currently_allocated_bytes, Ge(0)),
+                    Property(&envoy::admin::v2alpha::Memory::heap_size_bytes, Ge(0))));
 }
 
 TEST_P(AdminInstanceTest, Runtime) {

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -620,12 +620,11 @@ TEST_P(AdminInstanceTest, Memory) {
   Http::HeaderMapImpl header_map;
   Buffer::OwnedImpl response;
   EXPECT_EQ(Http::Code::OK, getCallback("/memory", header_map, response));
-  std::string output_json = response.toString();
+  const std::string output_json = response.toString();
   envoy::admin::v2alpha::Memory output_proto;
   MessageUtil::loadFromJson(output_json, output_proto);
-  EXPECT_THAT(output_proto,
-              AllOf(Property(&envoy::admin::v2alpha::Memory::currently_allocated_bytes, Ge(0)),
-                    Property(&envoy::admin::v2alpha::Memory::heap_size_bytes, Ge(0))));
+  EXPECT_THAT(output_proto, AllOf(Property(&envoy::admin::v2alpha::Memory::allocated, Ge(0)),
+                                  Property(&envoy::admin::v2alpha::Memory::heap_size, Ge(0))));
 }
 
 TEST_P(AdminInstanceTest, Runtime) {


### PR DESCRIPTION
Signed-off-by: James Buckland <jbuckland@google.com>

*Description*: Adds a `/memory` endpoint to the admin panel for fast inspection of `Envoy::Memory`'s heap statistics, without needing to query stats.
*Risk Level*: Low
*Testing*: Added a test to `admin_test.cc`.
*Docs Changes*: Added a description of the option to `admin.rst`.
*Release Notes*: N/A
