### PR TITLE
docs: ForwardAction => RouteAction in endpoint docs

### DIFF
--- a/api/envoy/api/v2/endpoint/endpoint.proto
+++ b/api/envoy/api/v2/endpoint/endpoint.proto
@@ -62,7 +62,8 @@ message LbEndpoint {
   // balancer to select endpoints in a cluster for a given request. The filter
   // name should be specified as *envoy.lb*. An example boolean key-value pair
   // is *canary*, providing the optional canary status of the upstream host.
-  // This may be matched against in a route's ForwardAction metadata_match field
+  // This may be matched against in a route's
+  // :ref:`RouteAction <envoy_api_msg_route.RouteAction>` metadata_match field
   // to subset the endpoints considered in cluster load balancing.
   core.Metadata metadata = 3;
 


### PR DESCRIPTION
There's a typo in https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/endpoint/endpoint.proto.html?highlight=ForwardAction -- it references `ForwardAction` which as far as I can tell doesn't exist. I believe it should say RouteAction instead.