### PR TITLE
thrift_proxy: fix early close bug for calls

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -28,6 +28,20 @@ Network::FilterStatus ConnectionManager::onData(Buffer::Instance& data, bool end
   request_buffer_.move(data);
   dispatch();
 
+  if (end_stream && stopped_) {
+    MessageMetadata& metadata = *(*rpcs_.begin())->metadata_;
+    ASSERT(metadata.hasMessageType());
+    if (metadata.messageType() != MessageType::Oneway) {
+      // Downstream has closed, so unless we're still processing a oneway request, close. By
+      // writing an empty buffer with end_stream set, we allow a remote close event to be
+      // triggered, which maintains accurate bookkeeping of which end of the connection closed
+      // during an active request.
+      ENVOY_CONN_LOG(trace, "downstream half-closed", read_callbacks_->connection());
+      Buffer::OwnedImpl empty;
+      read_callbacks_->connection().write(empty, true);
+    }
+  }
+
   return Network::FilterStatus::StopIteration;
 }
 
@@ -107,8 +121,10 @@ void ConnectionManager::initializeReadFilterCallbacks(Network::ReadFilterCallbac
 void ConnectionManager::onEvent(Network::ConnectionEvent event) {
   if (!rpcs_.empty()) {
     if (event == Network::ConnectionEvent::RemoteClose) {
+      ENVOY_CONN_LOG(debug, "remote close with active request", read_callbacks_->connection());
       stats_.cx_destroy_remote_with_active_rq_.inc();
     } else if (event == Network::ConnectionEvent::LocalClose) {
+      ENVOY_CONN_LOG(debug, "local close with active request", read_callbacks_->connection());
       stats_.cx_destroy_local_with_active_rq_.inc();
     }
 

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -407,6 +407,10 @@ void Router::UpstreamRequest::onResetStream(Tcp::ConnectionPool::PoolFailureReas
         fmt::format("too many connections to '{}'", upstream_host_->address()->asString())));
     break;
   case Tcp::ConnectionPool::PoolFailureReason::LocalConnectionFailure:
+    // Should only happen if we closed the connection, due to an error condition, in which case
+    // we've already handled any possible downstream response.
+    parent_.callbacks_->resetDownstreamConnection();
+    break;
   case Tcp::ConnectionPool::PoolFailureReason::RemoteConnectionFailure:
   case Tcp::ConnectionPool::PoolFailureReason::Timeout:
     // TODO(zuercher): distinguish between these cases where appropriate (particularly timeout)

--- a/test/extensions/filters/network/thrift_proxy/integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/integration_test.cc
@@ -250,6 +250,26 @@ TEST_P(ThriftConnManagerIntegrationTest, Exception) {
   EXPECT_EQ(1U, counter->value());
 }
 
+TEST_P(ThriftConnManagerIntegrationTest, EarlyClose) {
+  initializeCall(DriverMode::Success);
+
+  std::string partial_request = request_bytes_.toString().substr(0, request_bytes_.length() - 5);
+
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  tcp_client->write(partial_request);
+  tcp_client->close();
+
+  FakeUpstream* expected_upstream = getExpectedUpstream(false);
+  FakeRawConnectionPtr fake_upstream_connection;
+  ASSERT_TRUE(expected_upstream->waitForRawConnection(fake_upstream_connection));
+
+  test_server_->waitForCounterGe("thrift.thrift_stats.cx_destroy_remote_with_active_rq", 1);
+
+  Stats::CounterSharedPtr counter =
+      test_server_->counter("thrift.thrift_stats.cx_destroy_remote_with_active_rq");
+  EXPECT_EQ(1U, counter->value());
+}
+
 TEST_P(ThriftConnManagerIntegrationTest, Oneway) {
   initializeOneway();
 

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -355,12 +355,6 @@ TEST_F(ThriftRouterTest, PoolLocalConnectionFailure) {
 
   startRequest(MessageType::Call);
 
-  EXPECT_CALL(callbacks_, sendLocalReply(_))
-      .WillOnce(Invoke([&](const DirectResponse& response) -> void {
-        auto& app_ex = dynamic_cast<const AppException&>(response);
-        EXPECT_EQ(AppExceptionType::InternalError, app_ex.type_);
-        EXPECT_THAT(app_ex.what(), ContainsRegex(".*connection failure.*"));
-      }));
   context_.cluster_manager_.tcp_conn_pool_.poolFailure(
       Tcp::ConnectionPool::PoolFailureReason::LocalConnectionFailure);
 }
@@ -515,12 +509,6 @@ TEST_F(ThriftRouterTest, UpstreamLocalCloseMidResponse) {
   startRequest(MessageType::Call);
   connectUpstream();
 
-  EXPECT_CALL(callbacks_, sendLocalReply(_))
-      .WillOnce(Invoke([&](const DirectResponse& response) -> void {
-        auto& app_ex = dynamic_cast<const AppException&>(response);
-        EXPECT_EQ(AppExceptionType::InternalError, app_ex.type_);
-        EXPECT_THAT(app_ex.what(), ContainsRegex(".*connection failure.*"));
-      }));
   upstream_callbacks_->onEvent(Network::ConnectionEvent::LocalClose);
   destroyRouter();
 }


### PR DESCRIPTION
When a downstream client closed its connection mid-request,
the proxy would still attempt to generate an error response.
The result was a segmentation fault in ConnectionImpl. This
PR modifies the ConnectionManager and Router to correctly
handle this condition gracefully.

*Risk Level*: low
*Testing*: integration test added
*Docs Changes*: n/a
*Release Notes*: n/a
*Fixes*: #4368

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
