### PR TITLE
resource_monitors: convert tests to use timeSystem v. timeSource

### DIFF
--- a/test/extensions/resource_monitors/injected_resource/config_test.cc
+++ b/test/extensions/resource_monitors/injected_resource/config_test.cc
@@ -26,7 +26,7 @@ TEST(InjectedResourceMonitorFactoryTest, CreateMonitor) {
   envoy::config::resource_monitor::injected_resource::v2alpha::InjectedResourceConfig config;
   config.set_filename(TestEnvironment::temporaryPath("injected_resource"));
   DangerousDeprecatedTestTime test_time;
-  Event::DispatcherImpl dispatcher(test_time.timeSource());
+  Event::DispatcherImpl dispatcher(test_time.timeSystem());
   Server::Configuration::ResourceMonitorFactoryContextImpl context(dispatcher);
   Server::ResourceMonitorPtr monitor = factory->createResourceMonitor(config, context);
   EXPECT_NE(monitor, nullptr);

--- a/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
+++ b/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
@@ -47,7 +47,7 @@ public:
 class InjectedResourceMonitorTest : public testing::Test {
 protected:
   InjectedResourceMonitorTest()
-      : dispatcher_(test_time_.timeSource()),
+      : dispatcher_(test_time_.timeSystem()),
         resource_filename_(TestEnvironment::temporaryPath("injected_resource")),
         file_updater_(resource_filename_), monitor_(createMonitor()) {}
 


### PR DESCRIPTION
Fixes build.

*Risk Level*: low
*Testing*: existing tests
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
