### PR TITLE
Revert benchmark dependency to commit removing cmake 3.6 feature

### DIFF
--- a/ci/build_container/build_recipes/benchmark.sh
+++ b/ci/build_container/build_recipes/benchmark.sh
@@ -2,18 +2,17 @@
 
 set -e
 
-VERSION=1.4.1
-SHA256=f8e525db3c42efc9c7f3bc5176a8fa893a9a9920bbd08cef30fb56a51854d60d
+# use commit where cmake 3.6 feature removed. Unblocks Ubuntu 16.xx or below builds
+# TODO (moderation) change back to tarball method on next benchmark release
+export COMMIT="505be96ab23056580a3a2315abba048f4428b04e"
 
-curl https://github.com/google/benchmark/archive/v"$VERSION".tar.gz -sLo benchmark-"$VERSION".tar.gz \
-  && echo "$SHA256" benchmark-"$VERSION".tar.gz | sha256sum --check
-tar xf benchmark-"$VERSION".tar.gz
-cd benchmark-"$VERSION"
-
+git clone https://github.com/google/benchmark.git
+(cd benchmark; git reset --hard "$COMMIT")
 mkdir build
+
 cd build
 
-cmake -G "Ninja" ../ \
+cmake -G "Ninja" ../benchmark \
   -DCMAKE_BUILD_TYPE=RELEASE \
   -DBENCHMARK_ENABLE_GTEST_TESTS=OFF
 ninja
@@ -24,7 +23,7 @@ if [[ "${OS}" == "Windows_NT" ]]; then
 fi
 
 cp "src/$benchmark_lib" "$THIRDPARTY_BUILD"/lib
-cd ../
+cd ../benchmark
 
 INCLUDE_DIR="$THIRDPARTY_BUILD/include/testing/base/public"
 mkdir -p "$INCLUDE_DIR"


### PR DESCRIPTION
Dependency: Changes the benchmark dependency to a post 1.4.1 release commit that remove a feature requiring cmake 3.6. Unblocks building on Ubuntu 16.xx or less.

Risk Level: Low
Testing: bazel test //test/...
Docs Changes: none required
Release Notes: none required