### PR TITLE
sds/dns: fix late SDS exception throw during c-ares callbacks.

### DIFF
--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -124,7 +124,7 @@ void DnsResolverImpl::PendingResolution::onAresHostCallback(int status, int time
         callback_(std::move(address_list));
       } catch (const EnvoyException& e) {
         ENVOY_LOG(critical, "EnvoyException in c-ares callback");
-        dispatcher_.post([e] { throw e; });
+        dispatcher_.post([s = std::string(e.what())] { throw EnvoyException(s); });
       } catch (const std::exception& e) {
         ENVOY_LOG(critical, "std::exception in c-ares callback");
         dispatcher_.post([s = std::string(e.what())] { throw EnvoyException(s); });

--- a/source/common/secret/sds_api.cc
+++ b/source/common/secret/sds_api.cc
@@ -20,6 +20,7 @@ SdsApi::SdsApi(const LocalInfo::LocalInfo& local_info, Event::Dispatcher& dispat
     : local_info_(local_info), dispatcher_(dispatcher), random_(random), stats_(stats),
       cluster_manager_(cluster_manager), sds_config_(sds_config), sds_config_name_(sds_config_name),
       secret_hash_(0), clean_up_(destructor_cb) {
+  Config::Utility::checkLocalInfo("sds", local_info_);
   // TODO(JimmyCYJ): Implement chained_init_manager, so that multiple init_manager
   // can be chained together to behave as one init_manager. In that way, we let
   // two listeners which share same SdsApi to register at separate init managers, and
@@ -36,7 +37,6 @@ void SdsApi::initialize(std::function<void()> callback) {
       /* rest_legacy_constructor */ nullptr,
       "envoy.service.discovery.v2.SecretDiscoveryService.FetchSecrets",
       "envoy.service.discovery.v2.SecretDiscoveryService.StreamSecrets");
-  Config::Utility::checkLocalInfo("sds", local_info_);
 
   subscription_->start({sds_config_name_}, *this);
 }

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5696568846450688
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5696568846450688
@@ -1,0 +1,33 @@
+static_resources {
+  clusters {
+    name: "/"
+    type: STRICT_DNS
+    connect_timeout {
+      seconds: 539000848
+      nanos: 15
+    }
+    hosts {
+      pipe {
+        path: "4"
+      }
+    }
+    tls_context {
+      common_tls_context {
+        tls_certificate_sds_secret_configs {
+          sds_config {
+            path: "/"
+          }
+        }
+      }
+    }
+  }
+}
+tracing {
+}
+admin {
+  address {
+    pipe {
+      path: " "
+    }
+  }
+}


### PR DESCRIPTION
Previously, we only validated local info in SDS initialize(), which could happen during c-ares
resolution. This is too late to be throwing config validation exceptions, so instead do it at SdsApi
construction time.

Also, make sure we safely copy exception info for EnvoyExceptions; for libc++ in oss-fuzz,
attempting to copy/throw the exception in the post() was causing UBSAN failures.

Fixes oss-fuzz issue https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10262.

Risk level: Low
Testing: Corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>