### PR TITLE
fuzz: ensure HCM fuzzer always has a request method.

### DIFF
--- a/test/common/http/conn_manager_impl_corpus/clusterfuzz-testcase-minimized-conn_manager_impl_fuzz_test-5687458439102464
+++ b/test/common/http/conn_manager_impl_corpus/clusterfuzz-testcase-minimized-conn_manager_impl_fuzz_test-5687458439102464
@@ -1,0 +1,1 @@
+actions {   new_stream {   } }

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -155,6 +155,9 @@ public:
         .WillOnce(InvokeWithoutArgs([this, &request_headers, end_stream] {
           decoder_ = &conn_manager_.newStream(encoder_);
           auto headers = std::make_unique<TestHeaderMapImpl>(request_headers);
+          if (headers->Method() == nullptr) {
+            headers->setReferenceKey(Headers::get().Method, "GET");
+          }
           decoder_->decodeHeaders(std::move(headers), end_stream);
         }));
     fakeOnData();


### PR DESCRIPTION
The H1/H2 codecs should reject streams without a :method before the HCM decodeHeaders() callback.

Fixes oss-fuzz issue https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=9985.

Risk level: Low
Testing: Corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>