### PR TITLE
health_check: default to 2xx or 3xx as healthy for active healthchecks

### DIFF
--- a/docs/root/intro/arch_overview/health_checking.rst
+++ b/docs/root/intro/arch_overview/health_checking.rst
@@ -12,7 +12,7 @@ checking along with various settings (check interval, failures required before m
 unhealthy, successes required before marking a host healthy, etc.):
 
 * **HTTP**: During HTTP health checking Envoy will send an HTTP request to the upstream host. It
-  expects a 200 response if the host is healthy. The upstream host can return 503 if it wants to
+  expects a 2xx or 3xx response if the host is healthy. The upstream host can return 503 if it wants to
   immediately notify downstream hosts to no longer forward traffic to it.
 * **L3/L4**: During L3/L4 health checking, Envoy will send a configurable byte buffer to the
   upstream host. It expects the byte buffer to be echoed in the response if the host is to be

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -25,6 +25,7 @@ Version history
   to the :ref:`health check event <envoy_api_msg_data.core.v2alpha.HealthCheckEvent>` definition.
 * health_check: added support for specifying :ref:`custom request headers <config_http_conn_man_headers_custom_request_headers>`
   to HTTP health checker requests.
+* health_check: HTTP health checking now treats any 2xx or 3xx as a healthy response.
 * http: added support for a per-stream idle timeout. This applies at both :ref:`connection manager
   <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_idle_timeout>`
   and :ref:`per-route granularity <envoy_api_field_route.RouteAction.idle_timeout>`. The timeout

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -9,6 +9,7 @@
 #include "common/config/utility.h"
 #include "common/config/well_known_names.h"
 #include "common/grpc/common.h"
+#include "common/http/codes.h"
 #include "common/http/header_map_impl.h"
 #include "common/network/address_impl.h"
 #include "common/router/router.h"
@@ -177,7 +178,7 @@ bool HttpHealthCheckerImpl::HttpActiveHealthCheckSession::isHealthCheckSucceeded
   ENVOY_CONN_LOG(debug, "hc response={} health_flags={}", *client_, response_code,
                  HostUtility::healthFlagsToString(*host_));
 
-  if (response_code != enumToInt(Http::Code::OK)) {
+  if (!(Http::CodeUtility::is2xx(response_code) || Http::CodeUtility::is3xx(response_code))) {
     return false;
   }
 

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -468,6 +468,27 @@ TEST_F(HttpHealthCheckerImplTest, Success) {
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
 }
 
+TEST_F(HttpHealthCheckerImplTest, SuccessNon200) {
+  setupNoServiceValidationHC();
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  cluster_->info_->stats().upstream_cx_total_.inc();
+  expectSessionCreate();
+  expectStreamCreate(0);
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("health_check.max_interval", _));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("health_check.min_interval", _))
+      .WillOnce(Return(45000));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(45000)));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  respond(0, "302", false, true);
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+}
+
 TEST_F(HttpHealthCheckerImplTest, SuccessIntervalJitter) {
   setupNoServiceValidationHC();
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(testing::AnyNumber());


### PR DESCRIPTION
Signed-off-by: Ben Plotnick <plotnick@yelp.com>

*Description*:
This partially fixes #4367 by allowing any 2xx or 3xx to be considered healthy during an active health check. This only partially addresses that issue because it does not allow for configuration (the "extra credit" in that issue). I wanted to get this PR up first to raise some questions about how to do this.

First, are we OK with changing the default here? This could be surprising to some people. I think it's the right move in the long term.

Second, do we want to also adjust the way the healthcheck filter works. Right now it is [already](https://github.com/envoyproxy/envoy/blob/15706964a29e595c045a5d7ef0646d04f347dcc1/source/extensions/filters/http/health_check/health_check.cc#L141) inconsistent, since it checks for any 2xx. In my mind, the active healthchecking and the healthcheck filter are two different systems, so perhaps it is ok to diverge.

Third, for configurability, I am taking influence from [HAProxy](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4.2-http-check%20expect) and [nginx](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-health-check/#defining-custom-conditions) in terms of syntax, but if anyone has a strong opinion on how this should be done, let me know.

I can either add the configuration in this PR or a followup.
*Risk Level*: Low
*Testing*: Added a unit test for 3xx
*Docs Changes*: Adjusted docs to say 2xx and 3xx instead of 200
*Release Notes*: Updated release notes to state this change in behavior
