### PR TITLE
config: fix stats inconsistency between xds and ads

### DIFF
--- a/docs/root/configuration/cluster_manager/cds.rst
+++ b/docs/root/configuration/cluster_manager/cds.rst
@@ -27,5 +27,6 @@ CDS has a statistics tree rooted at *cluster_manager.cds.* with the following st
   config_reload, Counter, Total API fetches that resulted in a config reload due to a different config
   update_attempt, Counter, Total API fetches attempted
   update_success, Counter, Total API fetches completed successfully
-  update_failure, Counter, Total API fetches that failed because of schema errors
+  update_failure, Counter, Total API fetches that failed because of network errors
+  update_rejected, Counter, Total API fetches that failed because of schema/validation errors
   version, Gauge, Hash of the contents from the last successful API fetch

--- a/docs/root/configuration/http_conn_man/rds.rst
+++ b/docs/root/configuration/http_conn_man/rds.rst
@@ -26,5 +26,6 @@ stats tree. The stats tree contains the following statistics:
   config_reload, Counter, Total API fetches that resulted in a config reload due to a different config
   update_attempt, Counter, Total API fetches attempted
   update_success, Counter, Total API fetches completed successfully
-  update_failure, Counter, Total API fetches that failed (either network or schema errors)
+  update_failure, Counter, Total API fetches that failed because of network errors
+  update_rejected, Counter, Total API fetches that failed because of schema/validation errors
   version, Gauge, Hash of the contents from the last successful API fetch

--- a/docs/root/configuration/listeners/lds.rst
+++ b/docs/root/configuration/listeners/lds.rst
@@ -46,5 +46,6 @@ LDS has a statistics tree rooted at *listener_manager.lds.* with the following s
   config_reload, Counter, Total API fetches that resulted in a config reload due to a different config
   update_attempt, Counter, Total API fetches attempted
   update_success, Counter, Total API fetches completed successfully
-  update_failure, Counter, Total API fetches that failed (either network or schema errors)
+  update_failure, Counter, Total API fetches that failed because of network errors
+  update_rejected, Counter, Total API fetches that failed because of schema/validation errors
   version, Gauge, Hash of the contents from the last successful API fetch

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -82,6 +82,9 @@ Version history
 * ratelimit: added :ref:`failure_mode_deny <envoy_api_msg_config.filter.http.rate_limit.v2.RateLimit>` option to control traffic flow in 
   case of rate limit service error.
 * route checker: Added v2 config support and removed support for v1 configs.
+* config: Fixed stat inconsistency between xDS and ADS implementation. :ref:`update_failure <config_cluster_manager_cds>`  
+  stat is incremented in case of network failure and :ref:`update_rejected <config_cluster_manager_cds>` stat is incremented 
+  in case of schema/validation error.
 
 1.7.0
 ===============

--- a/source/common/router/rds_subscription.cc
+++ b/source/common/router/rds_subscription.cc
@@ -51,10 +51,11 @@ void RdsSubscription::onFetchComplete() {}
 
 void RdsSubscription::onFetchFailure(const EnvoyException* e) {
   callbacks_->onConfigUpdateFailed(e);
-  stats_.update_failure_.inc();
   if (e) {
+    stats_.update_rejected_.inc();
     ENVOY_LOG(warn, "rds: fetch failure: {}", e->what());
   } else {
+    stats_.update_failure_.inc();
     ENVOY_LOG(debug, "rds: fetch failure: network error");
   }
 }

--- a/source/common/upstream/cds_subscription.cc
+++ b/source/common/upstream/cds_subscription.cc
@@ -55,10 +55,11 @@ void CdsSubscription::onFetchComplete() {}
 
 void CdsSubscription::onFetchFailure(const EnvoyException* e) {
   callbacks_->onConfigUpdateFailed(e);
-  stats_.update_failure_.inc();
   if (e) {
+    stats_.update_rejected_.inc();
     ENVOY_LOG(warn, "cds: fetch failure: {}", e->what());
   } else {
+    stats_.update_failure_.inc();
     ENVOY_LOG(debug, "cds: fetch failure: network error");
   }
 }

--- a/source/server/lds_subscription.cc
+++ b/source/server/lds_subscription.cc
@@ -58,10 +58,11 @@ void LdsSubscription::onFetchComplete() {}
 
 void LdsSubscription::onFetchFailure(const EnvoyException* e) {
   callbacks_->onConfigUpdateFailed(e);
-  stats_.update_failure_.inc();
   if (e) {
+    stats_.update_rejected_.inc();
     ENVOY_LOG(warn, "lds: fetch failure: {}", e->what());
   } else {
+    stats_.update_failure_.inc();
     ENVOY_LOG(info, "lds: fetch failure: network error");
   }
 }

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -325,8 +325,11 @@ TEST_F(RdsImplTest, Failure) {
 
   EXPECT_EQ(2UL,
             factory_context_.scope_.counter("foo.rds.foo_route_config.update_attempt").value());
-  EXPECT_EQ(2UL,
+  EXPECT_EQ(1UL,
             factory_context_.scope_.counter("foo.rds.foo_route_config.update_failure").value());
+  // Validate that the schema error increments update_rejected stat.
+  EXPECT_EQ(1UL,
+            factory_context_.scope_.counter("foo.rds.foo_route_config.update_rejected").value());
 }
 
 TEST_F(RdsImplTest, FailureArray) {
@@ -349,7 +352,7 @@ TEST_F(RdsImplTest, FailureArray) {
   EXPECT_EQ(1UL,
             factory_context_.scope_.counter("foo.rds.foo_route_config.update_attempt").value());
   EXPECT_EQ(1UL,
-            factory_context_.scope_.counter("foo.rds.foo_route_config.update_failure").value());
+            factory_context_.scope_.counter("foo.rds.foo_route_config.update_rejected").value());
 }
 
 class RouteConfigProviderManagerImplTest : public RdsTestBase {

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -242,7 +242,9 @@ TEST_F(CdsApiImplTest, Failure) {
 
   EXPECT_EQ("", cds_->versionInfo());
   EXPECT_EQ(2UL, store_.counter("cluster_manager.cds.update_attempt").value());
-  EXPECT_EQ(2UL, store_.counter("cluster_manager.cds.update_failure").value());
+  EXPECT_EQ(1UL, store_.counter("cluster_manager.cds.update_failure").value());
+  // Validate that the schema error increments update_rejected stat.
+  EXPECT_EQ(1UL, store_.counter("cluster_manager.cds.update_rejected").value());
   EXPECT_EQ(0UL, store_.gauge("cluster_manager.cds.version").value());
 }
 
@@ -266,7 +268,7 @@ TEST_F(CdsApiImplTest, FailureArray) {
 
   EXPECT_EQ("", cds_->versionInfo());
   EXPECT_EQ(1UL, store_.counter("cluster_manager.cds.update_attempt").value());
-  EXPECT_EQ(1UL, store_.counter("cluster_manager.cds.update_failure").value());
+  EXPECT_EQ(1UL, store_.counter("cluster_manager.cds.update_rejected").value());
   EXPECT_EQ(0UL, store_.gauge("cluster_manager.cds.version").value());
 }
 

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -407,7 +407,9 @@ TEST_F(LdsApiTest, Failure) {
   EXPECT_EQ("", lds_->versionInfo());
 
   EXPECT_EQ(2UL, store_.counter("listener_manager.lds.update_attempt").value());
-  EXPECT_EQ(2UL, store_.counter("listener_manager.lds.update_failure").value());
+  EXPECT_EQ(1UL, store_.counter("listener_manager.lds.update_failure").value());
+  // Validate that the schema error increments update_rejected stat.
+  EXPECT_EQ(1UL, store_.counter("listener_manager.lds.update_failure").value());
   EXPECT_EQ(0UL, store_.gauge("listener_manager.lds.version").value());
 }
 


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>

*Description*: There is an inconsistency on how xDS and ADS handle failures. ADS increments `update_failure` stat for network failures and `update_rejected` stat for schema/validation issues where as xDS just increments `update_failure` in both the cases. Also `update_rejected` stat is un documented. This PR addresses both.
*Risk Level*: Low
*Testing*: Automated tests
*Docs Changes*: N/A
*Release Notes*: N/A
