### PR TITLE
router: implement RetryHostPredicate

### DIFF
--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -169,6 +169,12 @@ public:
    * @return uint32_t a local OR of RETRY_ON values above.
    */
   virtual uint32_t retryOn() const PURE;
+
+  /**
+   * Initializes the RetryHostPredicates to be used with this retry attempt.
+   * @return list of RetryHostPredicates to use
+   */
+  virtual std::vector<Upstream::RetryHostPredicateSharedPtr> retryHostPredicates() const PURE;
 };
 
 /**
@@ -204,6 +210,21 @@ public:
   virtual RetryStatus shouldRetry(const Http::HeaderMap* response_headers,
                                   const absl::optional<Http::StreamResetReason>& reset_reason,
                                   DoRetryCallback callback) PURE;
+
+  /**
+   * Called when a host was attempted but the request failed and is eligible for another retry.
+   * Should be used to update whatever internal state depends on previously attempted hosts.
+   * @param host the previously attempted host.
+   */
+  virtual void onHostAttempted(Upstream::HostDescriptionConstSharedPtr host) PURE;
+
+  /**
+   * Determine whether host selection should be reattempted. Applies to host selection during
+   * retries, and is used to provide configurable host selection for retries.
+   * @param host the host under consideration
+   * @return whether host selection should be reattempted
+   */
+  virtual bool shouldSelectAnotherHost(const Upstream::Host& host) PURE;
 };
 
 typedef std::unique_ptr<RetryState> RetryStatePtr;

--- a/include/envoy/upstream/retry.h
+++ b/include/envoy/upstream/retry.h
@@ -36,7 +36,7 @@ public:
    *
    * @param attempted_host the host that was previously attempted.
    */
-  virtual void onHostAttempted(HostSharedPtr attempted_host) PURE;
+  virtual void onHostAttempted(HostDescriptionConstSharedPtr attempted_host) PURE;
 };
 
 typedef std::shared_ptr<RetryPriority> RetryPrioritySharedPtr;
@@ -67,7 +67,7 @@ public:
    *
    * @param attempted_host the host that was previously attempted.
    */
-  virtual void onHostAttempted(HostSharedPtr attempted_host) PURE;
+  virtual void onHostAttempted(HostDescriptionConstSharedPtr attempted_host) PURE;
 };
 
 typedef std::shared_ptr<RetryHostPredicate> RetryHostPredicateSharedPtr;
@@ -116,6 +116,11 @@ public:
   virtual ~RetryHostPredicateFactory() {}
 
   virtual void createHostPredicate(RetryHostPredicateFactoryCallbacks& callbacks) PURE;
+
+  /**
+   * @return name name of this factory.
+   */
+  virtual std::string name() PURE;
 };
 
 } // namespace Upstream

--- a/include/envoy/upstream/retry.h
+++ b/include/envoy/upstream/retry.h
@@ -115,7 +115,8 @@ class RetryHostPredicateFactory {
 public:
   virtual ~RetryHostPredicateFactory() {}
 
-  virtual void createHostPredicate(RetryHostPredicateFactoryCallbacks& callbacks) PURE;
+  virtual void createHostPredicate(RetryHostPredicateFactoryCallbacks& callbacks,
+                                   const ProtobufWkt::Struct& config) PURE;
 
   /**
    * @return name name of this factory.

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -122,6 +122,9 @@ private:
     std::chrono::milliseconds perTryTimeout() const override {
       return std::chrono::milliseconds(0);
     }
+    std::vector<Upstream::RetryHostPredicateSharedPtr> retryHostPredicates() const override {
+      return {};
+    }
     uint32_t numRetries() const override { return 0; }
     uint32_t retryOn() const override { return 0; }
   };

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -50,12 +50,9 @@ RetryPolicyImpl::RetryPolicyImpl(const envoy::api::v2::route::RouteAction& confi
   retry_on_ |= RetryStateImpl::parseRetryGrpcOn(config.retry_policy().retry_on());
 
   for (const auto& host_predicate : config.retry_policy().retry_host_predicate()) {
-    // TODO(snowp): support passing the config Struct during initialization.
-    auto factory = Registry::FactoryRegistry<Upstream::RetryHostPredicateFactory>::getFactory(
-        host_predicate.name());
-
-    ASSERT(factory);
-    factory->createHostPredicate(*this);
+    Registry::FactoryRegistry<Upstream::RetryHostPredicateFactory>::getFactory(
+        host_predicate.name())
+        ->createHostPredicate(*this, host_predicate.config());
   }
 }
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -48,6 +48,15 @@ RetryPolicyImpl::RetryPolicyImpl(const envoy::api::v2::route::RouteAction& confi
   num_retries_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.retry_policy(), num_retries, 1);
   retry_on_ = RetryStateImpl::parseRetryOn(config.retry_policy().retry_on());
   retry_on_ |= RetryStateImpl::parseRetryGrpcOn(config.retry_policy().retry_on());
+
+  for (auto& host_predicate : config.retry_policy().retry_host_predicate()) {
+    // TODO(snowp): support passing the config Struct during initialization.
+    auto factory = Registry::FactoryRegistry<Upstream::RetryHostPredicateFactory>::getFactory(
+        host_predicate.name());
+
+    ASSERT(factory);
+    factory->createHostPredicate(*this);
+  }
 }
 
 CorsPolicyImpl::CorsPolicyImpl(const envoy::api::v2::route::CorsPolicy& config) {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -49,7 +49,7 @@ RetryPolicyImpl::RetryPolicyImpl(const envoy::api::v2::route::RouteAction& confi
   retry_on_ = RetryStateImpl::parseRetryOn(config.retry_policy().retry_on());
   retry_on_ |= RetryStateImpl::parseRetryGrpcOn(config.retry_policy().retry_on());
 
-  for (auto& host_predicate : config.retry_policy().retry_host_predicate()) {
+  for (const auto& host_predicate : config.retry_policy().retry_host_predicate()) {
     // TODO(snowp): support passing the config Struct during initialization.
     auto factory = Registry::FactoryRegistry<Upstream::RetryHostPredicateFactory>::getFactory(
         host_predicate.name());

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -183,7 +183,7 @@ typedef std::shared_ptr<VirtualHostImpl> VirtualHostSharedPtr;
 /**
  * Implementation of RetryPolicy that reads from the proto route config.
  */
-class RetryPolicyImpl : public RetryPolicy {
+class RetryPolicyImpl : public RetryPolicy, Upstream::RetryHostPredicateFactoryCallbacks {
 public:
   RetryPolicyImpl(const envoy::api::v2::route::RouteAction& config);
 
@@ -191,11 +191,20 @@ public:
   std::chrono::milliseconds perTryTimeout() const override { return per_try_timeout_; }
   uint32_t numRetries() const override { return num_retries_; }
   uint32_t retryOn() const override { return retry_on_; }
+  std::vector<Upstream::RetryHostPredicateSharedPtr> retryHostPredicates() const override {
+    return retry_host_predicates_;
+  }
+
+  // Upstream::RetryHostPredicateFactoryCallbacks
+  void addHostPredicate(Upstream::RetryHostPredicateSharedPtr predicate) override {
+    retry_host_predicates_.emplace_back(predicate);
+  }
 
 private:
   std::chrono::milliseconds per_try_timeout_{0};
   uint32_t num_retries_{};
   uint32_t retry_on_{};
+  std::vector<Upstream::RetryHostPredicateSharedPtr> retry_host_predicates_;
 };
 
 /**

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -52,7 +52,7 @@ RetryStateImpl::RetryStateImpl(const RetryPolicy& route_policy, Http::HeaderMap&
                                Runtime::RandomGenerator& random, Event::Dispatcher& dispatcher,
                                Upstream::ResourcePriority priority)
     : cluster_(cluster), runtime_(runtime), random_(random), dispatcher_(dispatcher),
-      priority_(priority) {
+      priority_(priority), retry_host_predicates_(route_policy.retryHostPredicates()) {
 
   if (request_headers.EnvoyRetryOn()) {
     retry_on_ = parseRetryOn(request_headers.EnvoyRetryOn()->value().c_str());

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -469,6 +469,9 @@ void Filter::onUpstreamReset(UpstreamResetType type,
 
   // We don't retry on a global timeout or if we already started the response.
   if (type != UpstreamResetType::GlobalTimeout && !downstream_response_started_ && retry_state_) {
+    // Notify retry modifiers about the attempted host.
+    retry_state_->onHostAttempted(upstream_host);
+
     RetryStatus retry_status =
         retry_state_->shouldRetry(nullptr, reset_reason, [this]() -> void { doRetry(); });
     if (retry_status == RetryStatus::Yes && setupRetry(true)) {
@@ -589,6 +592,9 @@ void Filter::onUpstreamHeaders(const uint64_t response_code, Http::HeaderMapPtr&
   }
 
   if (retry_state_) {
+    // Notify retry modifiers about the attempted host.
+    retry_state_->onHostAttempted(upstream_request_->upstream_host_);
+
     RetryStatus retry_status = retry_state_->shouldRetry(
         headers.get(), absl::optional<Http::StreamResetReason>(), [this]() -> void { doRetry(); });
     // Capture upstream_host since setupRetry() in the following line will clear
@@ -744,6 +750,7 @@ bool Filter::setupRetry(bool end_stream) {
 }
 
 void Filter::doRetry() {
+  is_retry_ = true;
   Http::ConnectionPool::Instance* conn_pool = getConnPool();
   if (!conn_pool) {
     sendNoHealthyUpstreamResponse();

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -147,7 +147,7 @@ class Filter : Logger::Loggable<Logger::Id::router>,
 public:
   Filter(FilterConfig& config)
       : config_(config), downstream_response_started_(false), downstream_end_stream_(false),
-        do_shadowing_(false) {}
+        do_shadowing_(false), is_retry_(false) {}
 
   ~Filter();
 
@@ -203,6 +203,17 @@ public:
     return callbacks_->connection();
   }
   const Http::HeaderMap* downstreamHeaders() const override { return downstream_headers_; }
+
+  bool shouldSelectAnotherHost(const Upstream::Host& host) override {
+    // We only care about host selection when performing a retry, at which point we consult the
+    // RetryState to see if we're configured to avoid certain hosts during retries.
+    if (!is_retry_) {
+      return false;
+    }
+
+    ASSERT(retry_state_);
+    return retry_state_->shouldSelectAnotherHost(host);
+  }
 
   /**
    * Set a computed cookie to be sent with the downstream headers.
@@ -377,6 +388,7 @@ private:
   bool downstream_response_started_ : 1;
   bool downstream_end_stream_ : 1;
   bool do_shadowing_ : 1;
+  bool is_retry_ : 1;
 };
 
 class ProdFilter : public Filter {

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -98,7 +98,7 @@ public:
 
   bool shouldSelectAnotherHost(const Host&) override { return false; }
 
-  uint32_t hostSelectionRetryCount() const override { return 0; }
+  uint32_t hostSelectionRetryCount() const override { return 1; }
 };
 
 /**

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -37,7 +37,7 @@ public:
     EXPECT_CALL(*retry_timer_, enableTimer(_));
   }
 
-  TestRetryPolicy policy_;
+  NiceMock<TestRetryPolicy> policy_;
   NiceMock<Upstream::MockClusterInfo> cluster_;
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Runtime::MockRandomGenerator> random_;

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -1718,7 +1718,8 @@ TEST_F(RouterTest, RetryRespectsRetryHostPredicate) {
   router_.decodeHeaders(headers, false);
 
   // The router should accept any host at this point, since we're not in a retry.
-  EXPECT_FALSE(router_.shouldSelectAnotherHost(*dynamic_cast<Upstream::Host*>(cm_.conn_pool_.host_.get())));
+  EXPECT_FALSE(
+      router_.shouldSelectAnotherHost(*dynamic_cast<Upstream::Host*>(cm_.conn_pool_.host_.get())));
 
   Buffer::InstancePtr body_data(new Buffer::OwnedImpl("hello"));
   EXPECT_CALL(*router_.retry_state_, enabled()).WillOnce(Return(true));
@@ -1751,7 +1752,8 @@ TEST_F(RouterTest, RetryRespectsRetryHostPredicate) {
   router_.retry_state_->callback_();
 
   // Now that we're triggered a retry, we should see the router reject hosts.
-  EXPECT_TRUE(router_.shouldSelectAnotherHost(*dynamic_cast<Upstream::Host*>(cm_.conn_pool_.host_.get())));
+  EXPECT_TRUE(
+      router_.shouldSelectAnotherHost(*dynamic_cast<Upstream::Host*>(cm_.conn_pool_.host_.get())));
 
   // Normal response.
   EXPECT_CALL(*router_.retry_state_, shouldRetry(_, _, _)).WillOnce(Return(RetryStatus::No));

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -54,6 +54,10 @@ public:
                                  Upstream::ResourcePriority) override {
     EXPECT_EQ(nullptr, retry_state_);
     retry_state_ = new NiceMock<MockRetryState>();
+    if (reject_all_hosts_) {
+      // Set up RetryState to always reject the host
+      ON_CALL(*retry_state_, shouldSelectAnotherHost(_)).WillByDefault(Return(true));
+    }
     return RetryStatePtr{retry_state_};
   }
 
@@ -63,6 +67,7 @@ public:
 
   NiceMock<Network::MockConnection> downstream_connection_;
   MockRetryState* retry_state_{};
+  bool reject_all_hosts_;
 };
 
 class RouterTestBase : public testing::Test {
@@ -1689,6 +1694,71 @@ TEST_F(RouterTest, RetryUpstreamGrpcCancelled) {
       new Http::TestHeaderMapImpl{{":status", "200"}, {"grpc-status", "0"}});
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_, putHttpResponseCode(200));
   response_decoder->decodeHeaders(std::move(response_headers), true);
+  EXPECT_TRUE(verifyHostUpstreamStats(1, 1));
+}
+
+// Verifies that the initial request accepts any host, but during retries
+// RetryPolicy will be consulted.
+TEST_F(RouterTest, RetryRespectsRetryHostPredicate) {
+  router_.reject_all_hosts_ = true;
+
+  NiceMock<Http::MockStreamEncoder> encoder1;
+  Http::StreamDecoder* response_decoder = nullptr;
+  EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
+      .WillOnce(Invoke([&](Http::StreamDecoder& decoder, Http::ConnectionPool::Callbacks& callbacks)
+                           -> Http::ConnectionPool::Cancellable* {
+        response_decoder = &decoder;
+        callbacks.onPoolReady(encoder1, cm_.conn_pool_.host_);
+        return nullptr;
+      }));
+  expectResponseTimerCreate();
+
+  Http::TestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
+  HttpTestUtility::addDefaultHeaders(headers);
+  router_.decodeHeaders(headers, false);
+
+  // The router should accept any host at this point, since we're not in a retry.
+  EXPECT_FALSE(router_.shouldSelectAnotherHost(*dynamic_cast<Upstream::Host*>(cm_.conn_pool_.host_.get())));
+
+  Buffer::InstancePtr body_data(new Buffer::OwnedImpl("hello"));
+  EXPECT_CALL(*router_.retry_state_, enabled()).WillOnce(Return(true));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, router_.decodeData(*body_data, false));
+
+  Http::TestHeaderMapImpl trailers{{"some", "trailer"}};
+  router_.decodeTrailers(trailers);
+
+  // 5xx response.
+  router_.retry_state_->expectRetry();
+  Http::HeaderMapPtr response_headers1(new Http::TestHeaderMapImpl{{":status", "503"}});
+  EXPECT_CALL(encoder1.stream_, resetStream(Http::StreamResetReason::LocalReset));
+  EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_, putHttpResponseCode(503));
+  response_decoder->decodeHeaders(std::move(response_headers1), false);
+  EXPECT_TRUE(verifyHostUpstreamStats(0, 1));
+
+  // We expect the 5xx response to kick off a new request.
+  NiceMock<Http::MockStreamEncoder> encoder2;
+  EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
+      .WillOnce(Invoke([&](Http::StreamDecoder& decoder, Http::ConnectionPool::Callbacks& callbacks)
+                           -> Http::ConnectionPool::Cancellable* {
+        response_decoder = &decoder;
+        callbacks.onPoolReady(encoder2, cm_.conn_pool_.host_);
+        return nullptr;
+      }));
+  ON_CALL(callbacks_, decodingBuffer()).WillByDefault(Return(body_data.get()));
+  EXPECT_CALL(encoder2, encodeHeaders(_, false));
+  EXPECT_CALL(encoder2, encodeData(_, false));
+  EXPECT_CALL(encoder2, encodeTrailers(_));
+  router_.retry_state_->callback_();
+
+  // Now that we're triggered a retry, we should see the router reject hosts.
+  EXPECT_TRUE(router_.shouldSelectAnotherHost(*dynamic_cast<Upstream::Host*>(cm_.conn_pool_.host_.get())));
+
+  // Normal response.
+  EXPECT_CALL(*router_.retry_state_, shouldRetry(_, _, _)).WillOnce(Return(RetryStatus::No));
+  EXPECT_CALL(cm_.conn_pool_.host_->health_checker_, setUnhealthy()).Times(0);
+  Http::HeaderMapPtr response_headers2(new Http::TestHeaderMapImpl{{":status", "200"}});
+  EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_, putHttpResponseCode(200));
+  response_decoder->decodeHeaders(std::move(response_headers2), true);
   EXPECT_TRUE(verifyHostUpstreamStats(1, 1));
 }
 

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -1717,9 +1717,9 @@ TEST_F(RouterTest, RetryRespectsRetryHostPredicate) {
   HttpTestUtility::addDefaultHeaders(headers);
   router_.decodeHeaders(headers, false);
 
+  NiceMock<Upstream::MockHost> host;
   // The router should accept any host at this point, since we're not in a retry.
-  EXPECT_FALSE(
-      router_.shouldSelectAnotherHost(*dynamic_cast<Upstream::Host*>(cm_.conn_pool_.host_.get())));
+  EXPECT_FALSE(router_.shouldSelectAnotherHost(host));
 
   Buffer::InstancePtr body_data(new Buffer::OwnedImpl("hello"));
   EXPECT_CALL(*router_.retry_state_, enabled()).WillOnce(Return(true));
@@ -1752,8 +1752,7 @@ TEST_F(RouterTest, RetryRespectsRetryHostPredicate) {
   router_.retry_state_->callback_();
 
   // Now that we're triggered a retry, we should see the router reject hosts.
-  EXPECT_TRUE(
-      router_.shouldSelectAnotherHost(*dynamic_cast<Upstream::Host*>(cm_.conn_pool_.host_.get())));
+  EXPECT_TRUE(router_.shouldSelectAnotherHost(host));
 
   // Normal response.
   EXPECT_CALL(*router_.retry_state_, shouldRetry(_, _, _)).WillOnce(Return(RetryStatus::No));

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -311,7 +311,8 @@ void ConfigHelper::setConnectTimeout(std::chrono::milliseconds timeout) {
 void ConfigHelper::addRoute(const std::string& domains, const std::string& prefix,
                             const std::string& cluster, bool validate_clusters,
                             envoy::api::v2::route::RouteAction::ClusterNotFoundResponseCode code,
-                            envoy::api::v2::route::VirtualHost::TlsRequirementType type) {
+                            envoy::api::v2::route::VirtualHost::TlsRequirementType type,
+                            envoy::api::v2::route::RouteAction::RetryPolicy retry_policy) {
   RELEASE_ASSERT(!finalized_, "");
   envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager hcm_config;
   loadHttpConnectionManager(hcm_config);
@@ -324,6 +325,7 @@ void ConfigHelper::addRoute(const std::string& domains, const std::string& prefi
   virtual_host->add_routes()->mutable_match()->set_prefix(prefix);
   virtual_host->mutable_routes(0)->mutable_route()->set_cluster(cluster);
   virtual_host->mutable_routes(0)->mutable_route()->set_cluster_not_found_response_code(code);
+  virtual_host->mutable_routes(0)->mutable_route()->mutable_retry_policy()->Swap(&retry_policy);
   virtual_host->set_require_tls(type);
 
   storeHttpConnectionManager(hcm_config);

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -78,7 +78,8 @@ public:
                 bool validate_clusters,
                 envoy::api::v2::route::RouteAction::ClusterNotFoundResponseCode code,
                 envoy::api::v2::route::VirtualHost::TlsRequirementType type =
-                    envoy::api::v2::route::VirtualHost::NONE);
+                    envoy::api::v2::route::VirtualHost::NONE,
+                envoy::api::v2::route::RouteAction::RetryPolicy retry_policy = {});
 
   // Add an HTTP filter prior to existing filters.
   void addFilter(const std::string& filter_yaml);

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -179,6 +179,19 @@ envoy_cc_test(
 )
 
 envoy_cc_test_library(
+    name = "test_host_predicate_lib",
+    srcs = [
+        "test_host_predicate_config.h",
+        "test_host_predicate_config.cc",
+        "test_host_predicate.h",
+        ],
+    deps = [
+        "//include/envoy/upstream:retry_interface",
+        "//include/envoy/registry",
+    ],
+)
+
+envoy_cc_test_library(
     name = "add_trailers_filter_config_lib",
     srcs = [
         "add_trailers_filter.cc",
@@ -205,6 +218,7 @@ envoy_cc_test_library(
     deps = [
         ":add_trailers_filter_config_lib",
         ":integration_lib",
+        ":test_host_predicate_lib",
         "//source/extensions/filters/http/router:config",
         "//source/extensions/filters/network/http_connection_manager:config",
         "//test/common/upstream:utility_lib",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -181,13 +181,13 @@ envoy_cc_test(
 envoy_cc_test_library(
     name = "test_host_predicate_lib",
     srcs = [
-        "test_host_predicate_config.h",
-        "test_host_predicate_config.cc",
         "test_host_predicate.h",
-        ],
+        "test_host_predicate_config.cc",
+        "test_host_predicate_config.h",
+    ],
     deps = [
-        "//include/envoy/upstream:retry_interface",
         "//include/envoy/registry",
+        "//include/envoy/upstream:retry_interface",
     ],
 )
 

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -182,11 +182,9 @@ envoy_cc_test_library(
     name = "test_host_predicate_lib",
     srcs = [
         "test_host_predicate.h",
-        "test_host_predicate_config.cc",
         "test_host_predicate_config.h",
     ],
     deps = [
-        "//include/envoy/registry",
         "//include/envoy/upstream:retry_interface",
     ],
 )
@@ -222,6 +220,7 @@ envoy_cc_test_library(
         "//source/extensions/filters/http/router:config",
         "//source/extensions/filters/network/http_connection_manager:config",
         "//test/common/upstream:utility_lib",
+        "//test/test_common:registry_lib",
     ],
 )
 

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -360,7 +360,7 @@ public:
   virtual testing::AssertionResult initialize() {
     initialized_ = true;
     disconnect_callback_handle_ =
-        shared_connection_.addDisconnectCallback([this] {  connection_event_.notifyOne(); });
+        shared_connection_.addDisconnectCallback([this] { connection_event_.notifyOne(); });
     return testing::AssertionSuccess();
   }
   ABSL_MUST_USE_RESULT

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -360,7 +360,7 @@ public:
   virtual testing::AssertionResult initialize() {
     initialized_ = true;
     disconnect_callback_handle_ =
-        shared_connection_.addDisconnectCallback([this] { connection_event_.notifyOne(); });
+        shared_connection_.addDisconnectCallback([this] {  connection_event_.notifyOne(); });
     return testing::AssertionSuccess();
   }
   ABSL_MUST_USE_RESULT

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -105,6 +105,8 @@ TEST_P(Http2IntegrationTest, HittingEncoderFilterLimit) { testHittingEncoderFilt
 
 TEST_P(Http2IntegrationTest, GrpcRouterNotFound) { testGrpcRouterNotFound(); }
 
+TEST_P(Http2IntegrationTest, RetryHostPredicateFilter) { testRetryHostPredicateFilter(); }
+
 TEST_P(Http2IntegrationTest, GrpcRetry) { testGrpcRetry(); }
 
 // Send a request with overly large headers, and ensure it results in stream reset.

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -245,7 +245,8 @@ void HttpIntegrationTest::cleanupUpstreamAndDownstream() {
   }
 }
 
-uint64_t HttpIntegrationTest::waitForNextUpstreamRequest(uint64_t upstream_index, uint64_t second_upstream_index) {
+uint64_t HttpIntegrationTest::waitForNextUpstreamRequest(uint64_t upstream_index,
+                                                         uint64_t second_upstream_index) {
   uint64_t upstream_with_request = upstream_index;
   // If there is no upstream connection, wait for it to be established.
   if (!fake_upstream_connection_) {
@@ -776,9 +777,9 @@ void HttpIntegrationTest::testRetryHostPredicateFilter() {
 
   // We want to work with a cluster with two hosts.
   config_helper_.addConfigModifier([](envoy::config::bootstrap::v2::Bootstrap& bootstrap) {
-      auto* new_host = bootstrap.mutable_static_resources()->mutable_clusters(0)->add_hosts();
-      new_host->MergeFrom(bootstrap.static_resources().clusters(0).hosts(0));
-      });
+    auto* new_host = bootstrap.mutable_static_resources()->mutable_clusters(0)->add_hosts();
+    new_host->MergeFrom(bootstrap.static_resources().clusters(0).hosts(0));
+  });
   fake_upstreams_count_ = 2;
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -797,7 +798,8 @@ void HttpIntegrationTest::testRetryHostPredicateFilter() {
 
   if (fake_upstreams_[upstream_idx]->httpType() == FakeHttpConnection::Type::HTTP1) {
     ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
-    ASSERT_TRUE(fake_upstreams_[upstream_idx]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+    ASSERT_TRUE(fake_upstreams_[upstream_idx]->waitForHttpConnection(*dispatcher_,
+                                                                     fake_upstream_connection_));
   } else {
     ASSERT_TRUE(upstream_request_->waitForReset());
   }

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -245,11 +245,19 @@ void HttpIntegrationTest::cleanupUpstreamAndDownstream() {
   }
 }
 
-void HttpIntegrationTest::waitForNextUpstreamRequest(uint64_t upstream_index) {
+uint64_t HttpIntegrationTest::waitForNextUpstreamRequest(uint64_t upstream_index, uint64_t second_upstream_index) {
+  uint64_t upstream_with_request = upstream_index;
   // If there is no upstream connection, wait for it to be established.
   if (!fake_upstream_connection_) {
     AssertionResult result = fake_upstreams_[upstream_index]->waitForHttpConnection(
         *dispatcher_, fake_upstream_connection_);
+
+    // If we didn't get a connection against the first upstream, try the next one.
+    if (!result && upstream_index != second_upstream_index) {
+      upstream_with_request = second_upstream_index;
+      result = fake_upstreams_[second_upstream_index]->waitForHttpConnection(
+          *dispatcher_, fake_upstream_connection_);
+    }
     RELEASE_ASSERT(result, result.message());
   }
   // Wait for the next stream on the upstream connection.
@@ -259,6 +267,8 @@ void HttpIntegrationTest::waitForNextUpstreamRequest(uint64_t upstream_index) {
   // Wait for the stream to be completely received.
   result = upstream_request_->waitForEndStream(*dispatcher_);
   RELEASE_ASSERT(result, result.message());
+
+  return upstream_with_request;
 }
 
 void HttpIntegrationTest::testRouterRequestAndResponseWithBody(
@@ -749,6 +759,60 @@ void HttpIntegrationTest::testGrpcRetry() {
   if (fake_upstreams_[0]->httpType() == FakeHttpConnection::Type::HTTP2) {
     EXPECT_THAT(*response->trailers(), HeaderMapEqualRef(&response_trailers));
   }
+}
+
+// Verifies that a retry host filter can be configured and affect the host selected during retries.
+// The predicate will keep track of the first host attempted, and attempt to route all requests to
+// the same host. With a total of two upstream hosts, this should result in us continuously sending
+// requests to the same host.
+void HttpIntegrationTest::testRetryHostPredicateFilter() {
+  envoy::api::v2::route::RouteAction::RetryPolicy retry_policy;
+  retry_policy.add_retry_host_predicate()->set_name("test-host-predicate");
+
+  // Add route with custom retry policy
+  config_helper_.addRoute("host", "/test_retry", "cluster_0", false,
+                          envoy::api::v2::route::RouteAction::NOT_FOUND,
+                          envoy::api::v2::route::VirtualHost::NONE, retry_policy);
+
+  // We want to work with a cluster with two hosts.
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v2::Bootstrap& bootstrap) {
+      auto* new_host = bootstrap.mutable_static_resources()->mutable_clusters(0)->add_hosts();
+      new_host->MergeFrom(bootstrap.static_resources().clusters(0).hosts(0));
+      });
+  fake_upstreams_count_ = 2;
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response =
+      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/test_retry"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"},
+                                                                 {"x-forwarded-for", "10.0.0.1"},
+                                                                 {"x-envoy-retry-on", "5xx"}},
+                                         1024);
+
+  // Note how we're exepcting each upstream request to hit the same upstream.
+  auto upstream_idx = waitForNextUpstreamRequest(0, 1);
+  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
+
+  if (fake_upstreams_[upstream_idx]->httpType() == FakeHttpConnection::Type::HTTP1) {
+    ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
+    ASSERT_TRUE(fake_upstreams_[upstream_idx]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  } else {
+    ASSERT_TRUE(upstream_request_->waitForReset());
+  }
+
+  waitForNextUpstreamRequest(upstream_idx);
+  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeData(512, true);
+
+  response->waitForEndStream();
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ(1024U, upstream_request_->bodyLength());
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_EQ(512U, response->body().size());
 }
 
 // Very similar set-up to testRetry but with a 16k request the request will not

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -26,8 +26,8 @@
 #include "test/integration/utility.h"
 #include "test/mocks/upstream/mocks.h"
 #include "test/test_common/environment.h"
-#include "test/test_common/registry.h"
 #include "test/test_common/network_utility.h"
+#include "test/test_common/registry.h"
 
 #include "gtest/gtest.h"
 

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -247,8 +247,8 @@ void HttpIntegrationTest::cleanupUpstreamAndDownstream() {
   }
 }
 
-uint64_t HttpIntegrationTest::waitForNextUpstreamRequest(
-    const std::unordered_set<uint64_t>& upstream_indices) {
+uint64_t
+HttpIntegrationTest::waitForNextUpstreamRequest(const std::vector<uint64_t>& upstream_indices) {
   uint64_t upstream_with_request;
   // If there is no upstream connection, wait for it to be established.
   if (!fake_upstream_connection_) {
@@ -275,7 +275,7 @@ uint64_t HttpIntegrationTest::waitForNextUpstreamRequest(
 }
 
 void HttpIntegrationTest::waitForNextUpstreamRequest(uint64_t upstream_index) {
-  waitForNextUpstreamRequest(std::unordered_set<uint64_t>({upstream_index}));
+  waitForNextUpstreamRequest(std::vector<uint64_t>({upstream_index}));
 }
 
 void HttpIntegrationTest::testRouterRequestAndResponseWithBody(

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -103,9 +103,10 @@ protected:
 
   // Wait for the end of stream on the next upstream stream on either of the two fake_upstreams_
   // Sets fake_upstream_connection_ to the connection and upstream_request_ to stream.
-  // In cases where the upstream that will receive the request is not deterministic, two upstream indices
-  // may be provided, in which case both upstreams will be checked for requests.
-  uint64_t waitForNextUpstreamRequest(uint64_t upstream_index = 0, uint64_t second_upstream_index = 0);
+  // In cases where the upstream that will receive the request is not deterministic, two upstream
+  // indices may be provided, in which case both upstreams will be checked for requests.
+  uint64_t waitForNextUpstreamRequest(uint64_t upstream_index = 0,
+                                      uint64_t second_upstream_index = 0);
 
   // Close |codec_client_| and |fake_upstream_connection_| cleanly.
   void cleanupUpstreamAndDownstream();

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -101,9 +101,11 @@ protected:
       const Http::TestHeaderMapImpl& request_headers, uint32_t request_body_size,
       const Http::TestHeaderMapImpl& response_headers, uint32_t response_body_size);
 
-  // Wait for the end of stream on the next upstream stream on fake_upstreams_
+  // Wait for the end of stream on the next upstream stream on either of the two fake_upstreams_
   // Sets fake_upstream_connection_ to the connection and upstream_request_ to stream.
-  void waitForNextUpstreamRequest(uint64_t upstream_index = 0);
+  // In cases where the upstream that will receive the request is not deterministic, two upstream indices
+  // may be provided, in which case both upstreams will be checked for requests.
+  uint64_t waitForNextUpstreamRequest(uint64_t upstream_index = 0, uint64_t second_upstream_index = 0);
 
   // Close |codec_client_| and |fake_upstream_connection_| cleanly.
   void cleanupUpstreamAndDownstream();
@@ -167,6 +169,7 @@ protected:
   void testRetryHittingBufferLimit();
   void testGrpcRouterNotFound();
   void testGrpcRetry();
+  void testRetryHostPredicateFilter();
   void testHittingDecoderFilterLimit();
   void testHittingEncoderFilterLimit();
   void testEnvoyHandling100Continue(bool additional_continue_from_upstream = false,

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -105,7 +105,7 @@ protected:
   // Sets fake_upstream_connection_ to the connection and upstream_request_ to stream.
   // In cases where the upstream that will receive the request is not deterministic, a second
   // upstream index may be provided, in which case both upstreams will be checked for requests.
-  uint64_t waitForNextUpstreamRequest(const std::unordered_set<uint64_t>& upstream_indices);
+  uint64_t waitForNextUpstreamRequest(const std::vector<uint64_t>& upstream_indices);
   void waitForNextUpstreamRequest(uint64_t upstream_index = 0);
 
   // Close |codec_client_| and |fake_upstream_connection_| cleanly.

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -103,10 +103,10 @@ protected:
 
   // Wait for the end of stream on the next upstream stream on either of the two fake_upstreams_
   // Sets fake_upstream_connection_ to the connection and upstream_request_ to stream.
-  // In cases where the upstream that will receive the request is not deterministic, two upstream
-  // indices may be provided, in which case both upstreams will be checked for requests.
+  // In cases where the upstream that will receive the request is not deterministic, a second
+  // upstream index may be provided, in which case both upstreams will be checked for requests.
   uint64_t waitForNextUpstreamRequest(uint64_t upstream_index = 0,
-                                      uint64_t second_upstream_index = 0);
+                                      absl::optional<uint64_t> second_upstream_index = {});
 
   // Close |codec_client_| and |fake_upstream_connection_| cleanly.
   void cleanupUpstreamAndDownstream();

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -101,12 +101,12 @@ protected:
       const Http::TestHeaderMapImpl& request_headers, uint32_t request_body_size,
       const Http::TestHeaderMapImpl& response_headers, uint32_t response_body_size);
 
-  // Wait for the end of stream on the next upstream stream on either of the two fake_upstreams_
+  // Wait for the end of stream on the next upstream stream on any of the provided fake upstreams.
   // Sets fake_upstream_connection_ to the connection and upstream_request_ to stream.
   // In cases where the upstream that will receive the request is not deterministic, a second
   // upstream index may be provided, in which case both upstreams will be checked for requests.
-  uint64_t waitForNextUpstreamRequest(uint64_t upstream_index = 0,
-                                      absl::optional<uint64_t> second_upstream_index = {});
+  uint64_t waitForNextUpstreamRequest(const std::unordered_set<uint64_t>& upstream_indices);
+  void waitForNextUpstreamRequest(uint64_t upstream_index = 0);
 
   // Close |codec_client_| and |fake_upstream_connection_| cleanly.
   void cleanupUpstreamAndDownstream();

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -104,6 +104,8 @@ TEST_P(IntegrationTest, RouterUpstreamResponseBeforeRequestComplete) {
 
 TEST_P(IntegrationTest, Retry) { testRetry(); }
 
+TEST_P(IntegrationTest, RetryHostPredicateFilter) { testRetryHostPredicateFilter(); }
+
 TEST_P(IntegrationTest, EnvoyHandling100Continue) { testEnvoyHandling100Continue(); }
 
 TEST_P(IntegrationTest, EnvoyHandlingDuplicate100Continues) { testEnvoyHandling100Continue(true); }

--- a/test/integration/test_host_predicate.h
+++ b/test/integration/test_host_predicate.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "envoy/upstream/retry.h"
+
+namespace Envoy {
+
+/**
+ * A simple host predicate that will remember the first host it sees and reject
+ * all other hosts.
+ */
+class TestHostPredicate : public Upstream::RetryHostPredicate {
+  bool shouldSelectAnotherHost(const Upstream::Host& candidate_host) override {
+    return !first_host_address_ || *first_host_address_ != candidate_host.address()->asString();
+  } 
+
+  void onHostAttempted(Upstream::HostDescriptionConstSharedPtr attempted_host) override {
+    if (!first_host_address_) {
+      first_host_address_ = attempted_host->address()->asString();
+    }
+  }
+
+  absl::optional<std::string> first_host_address_;
+};
+}

--- a/test/integration/test_host_predicate.h
+++ b/test/integration/test_host_predicate.h
@@ -11,7 +11,7 @@ namespace Envoy {
 class TestHostPredicate : public Upstream::RetryHostPredicate {
   bool shouldSelectAnotherHost(const Upstream::Host& candidate_host) override {
     return !first_host_address_ || *first_host_address_ != candidate_host.address()->asString();
-  } 
+  }
 
   void onHostAttempted(Upstream::HostDescriptionConstSharedPtr attempted_host) override {
     if (!first_host_address_) {
@@ -21,4 +21,4 @@ class TestHostPredicate : public Upstream::RetryHostPredicate {
 
   absl::optional<std::string> first_host_address_;
 };
-}
+} // namespace Envoy

--- a/test/integration/test_host_predicate_config.cc
+++ b/test/integration/test_host_predicate_config.cc
@@ -1,7 +1,8 @@
-#include "envoy/registry/registry.h"
-
 #include "test/integration/test_host_predicate_config.h"
 
+#include "envoy/registry/registry.h"
+
 namespace Envoy {
-static Registry::RegisterFactory<TestHostPredicateFactory, Upstream::RetryHostPredicateFactory> register_;
+static Registry::RegisterFactory<TestHostPredicateFactory, Upstream::RetryHostPredicateFactory>
+    register_;
 } // namespace Envoy

--- a/test/integration/test_host_predicate_config.cc
+++ b/test/integration/test_host_predicate_config.cc
@@ -1,8 +1,0 @@
-#include "test/integration/test_host_predicate_config.h"
-
-#include "envoy/registry/registry.h"
-
-namespace Envoy {
-static Registry::RegisterFactory<TestHostPredicateFactory, Upstream::RetryHostPredicateFactory>
-    register_;
-} // namespace Envoy

--- a/test/integration/test_host_predicate_config.cc
+++ b/test/integration/test_host_predicate_config.cc
@@ -1,0 +1,7 @@
+#include "envoy/registry/registry.h"
+
+#include "test/integration/test_host_predicate_config.h"
+
+namespace Envoy {
+static Registry::RegisterFactory<TestHostPredicateFactory, Upstream::RetryHostPredicateFactory> register_;
+} // namespace Envoy

--- a/test/integration/test_host_predicate_config.h
+++ b/test/integration/test_host_predicate_config.h
@@ -9,7 +9,8 @@ class TestHostPredicateFactory : public Upstream::RetryHostPredicateFactory {
 public:
   std::string name() override { return "envoy.test_host_predicate"; }
 
-  void createHostPredicate(Upstream::RetryHostPredicateFactoryCallbacks& callbacks) override {
+  void createHostPredicate(Upstream::RetryHostPredicateFactoryCallbacks& callbacks,
+                           const ProtobufWkt::Struct&) override {
     callbacks.addHostPredicate(std::make_shared<TestHostPredicate>());
   }
 };

--- a/test/integration/test_host_predicate_config.h
+++ b/test/integration/test_host_predicate_config.h
@@ -6,7 +6,8 @@
 
 namespace Envoy {
 class TestHostPredicateFactory : public Upstream::RetryHostPredicateFactory {
-  std::string name() override { return "test-host-predicate"; }
+public:
+  std::string name() override { return "envoy.test_host_predicate"; }
 
   void createHostPredicate(Upstream::RetryHostPredicateFactoryCallbacks& callbacks) override {
     callbacks.addHostPredicate(std::make_shared<TestHostPredicate>());

--- a/test/integration/test_host_predicate_config.h
+++ b/test/integration/test_host_predicate_config.h
@@ -12,4 +12,4 @@ class TestHostPredicateFactory : public Upstream::RetryHostPredicateFactory {
     callbacks.addHostPredicate(std::make_shared<TestHostPredicate>());
   }
 };
-}
+} // namespace Envoy

--- a/test/integration/test_host_predicate_config.h
+++ b/test/integration/test_host_predicate_config.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "envoy/upstream/retry.h"
+
+#include "test/integration/test_host_predicate.h"
+
+namespace Envoy {
+class TestHostPredicateFactory : public Upstream::RetryHostPredicateFactory {
+  std::string name() override { return "test-host-predicate"; }
+
+  void createHostPredicate(Upstream::RetryHostPredicateFactoryCallbacks& callbacks) override {
+    callbacks.addHostPredicate(std::make_shared<TestHostPredicate>());
+  }
+};
+}

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -69,6 +69,7 @@ public:
   std::chrono::milliseconds perTryTimeout() const override { return per_try_timeout_; }
   uint32_t numRetries() const override { return num_retries_; }
   uint32_t retryOn() const override { return retry_on_; }
+  MOCK_CONST_METHOD0(retryHostPredicates, std::vector<Upstream::RetryHostPredicateSharedPtr>());
 
   std::chrono::milliseconds per_try_timeout_{0};
   uint32_t num_retries_{};
@@ -86,6 +87,8 @@ public:
   MOCK_METHOD3(shouldRetry, RetryStatus(const Http::HeaderMap* response_headers,
                                         const absl::optional<Http::StreamResetReason>& reset_reason,
                                         DoRetryCallback callback));
+  MOCK_METHOD1(onHostAttempted, void(Upstream::HostDescriptionConstSharedPtr));
+  MOCK_METHOD1(shouldSelectAnotherHost, bool(const Upstream::Host& host));
 
   DoRetryCallback callback_;
 };

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -122,5 +122,7 @@ MockClusterUpdateCallbacks::MockClusterUpdateCallbacks() {}
 
 MockClusterUpdateCallbacks::~MockClusterUpdateCallbacks() {}
 
+MockRetryHostPredicate::MockRetryHostPredicate() {}
+MockRetryHostPredicate::~MockRetryHostPredicate() {}
 } // namespace Upstream
 } // namespace Envoy

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -308,5 +308,11 @@ public:
                     Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random));
 };
 
+class MockRetryHostPredicate : public RetryHostPredicate {
+public:
+  MOCK_METHOD1(shouldSelectAnotherHost, bool(const Host& candidate_host));
+  MOCK_METHOD1(onHostAttempted, void(HostDescriptionConstSharedPtr));
+};
+
 } // namespace Upstream
 } // namespace Envoy

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -310,6 +310,9 @@ public:
 
 class MockRetryHostPredicate : public RetryHostPredicate {
 public:
+  MockRetryHostPredicate();
+  ~MockRetryHostPredicate();
+
   MOCK_METHOD1(shouldSelectAnotherHost, bool(const Host& candidate_host));
   MOCK_METHOD1(onHostAttempted, void(HostDescriptionConstSharedPtr));
 };


### PR DESCRIPTION
*Description*: Wires up route configuration to allow specifying what hosts should be
reattempted during retry host selection.
*Risk Level*: Medium, some changes made to the router. Otherwise new optional feature
*Testing*: unit and integration test
*Docs Changes*: n/a
*Release Notes*: n/a

Part of #3958
