### PR TITLE
[WIP] Support Envoy to use gRPC local channel credentials

### DIFF
--- a/api/envoy/api/v2/core/grpc_service.proto
+++ b/api/envoy/api/v2/core/grpc_service.proto
@@ -57,7 +57,7 @@ message GrpcService {
         // Use local channel credentials. Currently only UDS is supported.
         // See
         // https://github.com/grpc/grpc/blob/782e5c2b8dc6973b6fc0959ba08da0f5b9db2f6f/include/grpcpp/security/credentials.h#L239
-        bool local_channel_credentials = 3;
+        bool local_credentail = 3;
       }
     }
 

--- a/api/envoy/api/v2/core/grpc_service.proto
+++ b/api/envoy/api/v2/core/grpc_service.proto
@@ -53,6 +53,11 @@ message GrpcService {
 
         // https://grpc.io/grpc/cpp/namespacegrpc.html#a6beb3ac70ff94bd2ebbd89b8f21d1f61
         google.protobuf.Empty google_default = 2;
+
+        // Use local channel credentials. Currently only UDS is supported.
+        // See
+        // https://github.com/grpc/grpc/blob/782e5c2b8dc6973b6fc0959ba08da0f5b9db2f6f/include/grpcpp/security/credentials.h#L239
+        bool local_channel_credentials = 3;
       }
     }
 

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -52,9 +52,9 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/google/libprotobuf-mutator",
     ),
     com_github_grpc_grpc = dict(
-        sha256 = "c747e4d903f7dcf803be53abed4e4efc5d3e96f6c274ed1dfca7a03fa6f4e36b",
-        strip_prefix = "grpc-1.14.2",
-        urls = ["https://github.com/grpc/grpc/archive/v1.14.2.tar.gz"],
+        sha256 = "66d1286fe37f9853af42e1e76f8c2265a2e9ec00afd6dd79a5d23e0880bbe874",
+        strip_prefix = "grpc-1.15.0-pre1",
+        urls = ["https://github.com/grpc/grpc/archive/v1.15.0-pre1.tar.gz"],
     ),
     com_github_nanopb_nanopb = dict(
         # From: https://github.com/grpc/grpc/blob/v1.14.0/bazel/grpc_deps.bzl#L123

--- a/source/common/grpc/google_grpc_creds_impl.cc
+++ b/source/common/grpc/google_grpc_creds_impl.cc
@@ -21,7 +21,7 @@ std::shared_ptr<grpc::ChannelCredentials> CredsUtility::sslChannelCredentials(
       };
       return grpc::SslCredentials(ssl_credentials_options);
     }
-    if (google_grpc.channel_credentials().local_channel_credentials()) {
+    if (google_grpc.channel_credentials().local_credentail()) {
       return grpc::experimental::LocalCredentials(UDS);
     }
   }

--- a/source/common/grpc/google_grpc_creds_impl.cc
+++ b/source/common/grpc/google_grpc_creds_impl.cc
@@ -11,15 +11,19 @@ namespace Grpc {
 
 std::shared_ptr<grpc::ChannelCredentials> CredsUtility::sslChannelCredentials(
     const envoy::api::v2::core::GrpcService::GoogleGrpc& google_grpc) {
-  if (google_grpc.has_channel_credentials() &&
-      google_grpc.channel_credentials().has_ssl_credentials()) {
-    const auto& ssl_credentials = google_grpc.channel_credentials().ssl_credentials();
-    const grpc::SslCredentialsOptions ssl_credentials_options = {
-        .pem_root_certs = Config::DataSource::read(ssl_credentials.root_certs(), true),
-        .pem_private_key = Config::DataSource::read(ssl_credentials.private_key(), true),
-        .pem_cert_chain = Config::DataSource::read(ssl_credentials.cert_chain(), true),
-    };
-    return grpc::SslCredentials(ssl_credentials_options);
+  if (google_grpc.has_channel_credentials()) {
+    if (google_grpc.channel_credentials().has_ssl_credentials()) {
+      const auto& ssl_credentials = google_grpc.channel_credentials().ssl_credentials();
+      const grpc::SslCredentialsOptions ssl_credentials_options = {
+          .pem_root_certs = Config::DataSource::read(ssl_credentials.root_certs(), true),
+          .pem_private_key = Config::DataSource::read(ssl_credentials.private_key(), true),
+          .pem_cert_chain = Config::DataSource::read(ssl_credentials.cert_chain(), true),
+      };
+      return grpc::SslCredentials(ssl_credentials_options);
+    }
+    if (google_grpc.channel_credentials().local_channel_credentials()) {
+      return grpc::experimental::LocalCredentials(UDS);
+    }
   }
   return nullptr;
 }

--- a/test/common/grpc/google_grpc_creds_test.cc
+++ b/test/common/grpc/google_grpc_creds_test.cc
@@ -20,6 +20,9 @@ TEST(CredsUtility, SslChannelCredentials) {
   EXPECT_EQ(nullptr, CredsUtility::sslChannelCredentials(config));
   creds->mutable_ssl_credentials();
   EXPECT_NE(nullptr, CredsUtility::sslChannelCredentials(config));
+  creds->clear_ssl_credentials();
+  creds->set_local_channel_credentials(true);
+  EXPECT_NE(nullptr, CredsUtility::sslChannelCredentials(config));
 }
 
 TEST(CredsUtility, DefaultSslChannelCredentials) {

--- a/test/common/grpc/google_grpc_creds_test.cc
+++ b/test/common/grpc/google_grpc_creds_test.cc
@@ -21,7 +21,7 @@ TEST(CredsUtility, SslChannelCredentials) {
   creds->mutable_ssl_credentials();
   EXPECT_NE(nullptr, CredsUtility::sslChannelCredentials(config));
   creds->clear_ssl_credentials();
-  creds->set_local_channel_credentials(true);
+  creds->set_local_credentail(true);
   EXPECT_NE(nullptr, CredsUtility::sslChannelCredentials(config));
 }
 


### PR DESCRIPTION
Add a new field local_channel_credentials into GoogleGrpc which supports Envoy to use gRPC local channel credentials.

Signed-off-by: JimmyCYJ <jimmychen.0102@gmail.com>

*Risk Level*: Low
*Testing*: Unit test