### PR TITLE
Cleanup: Fix ClangTidy issues

### DIFF
--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -25,7 +25,7 @@ DetectorSharedPtr DetectorImplFactory::createForCluster(
     Runtime::Loader& runtime, EventLoggerSharedPtr event_logger) {
   if (cluster_config.has_outlier_detection()) {
     return DetectorImpl::create(cluster, cluster_config.outlier_detection(), dispatcher, runtime,
-                                dispatcher.timeSystem(), event_logger);
+                                dispatcher.timeSystem(), std::move(event_logger));
   } else {
     return nullptr;
   }

--- a/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
+++ b/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
@@ -13,8 +13,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using testing::Property;
-
 namespace Envoy {
 namespace Extensions {
 namespace ResourceMonitors {


### PR DESCRIPTION
Removes unused 'Property' using decl. (injected_resource_monitor_test.cc)
Moves a parameter that was only copied once (outlier_detection_impl.cc)

Signed-off-by: Kyle Myerson <kmyerson@google.com>

