### PR TITLE
Upgrade to lightstep-tracer-cpp 0.8.0 & opentracing-cpp 1.5.0

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -63,14 +63,17 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/nanopb/nanopb/archive/f8ac463766281625ad710900479130c7fcb4d63b.tar.gz"],
     ),
     io_opentracing_cpp = dict(
-        commit = "3b36b084a4d7fffc196eac83203cf24dfb8696b3",  # v1.4.2
-        remote = "https://github.com/opentracing/opentracing-cpp",
+        sha256 = "4455ca507936bc4b658ded10a90d8ebbbd61c58f06207be565a4ffdc885687b5",
+        strip_prefix = "opentracing-cpp-1.5.0",
+        urls = ["https://github.com/opentracing/opentracing-cpp/archive/v1.5.0.tar.gz"],
     ),
     com_lightstep_tracer_cpp = dict(
-        commit = "ae6a6bba65f8c4d438a6a3ac855751ca8f52e1dc",
-        remote = "https://github.com/lightstep/lightstep-tracer-cpp",  # v0.7.1
+        sha256 = "defbf471facfebde6523ca1177529b63784893662d4ef2c60db074be8aef0634",
+        strip_prefix = "lightstep-tracer-cpp-0.8.0",
+        urls = ["https://github.com/lightstep/lightstep-tracer-cpp/archive/v0.8.0.tar.gz"],
     ),
     lightstep_vendored_googleapis = dict(
+        # From: https://github.com/lightstep/lightstep-tracer-cpp/blob/v0.8.0/lightstep-tracer-common/third_party/googleapis/README.lightstep-tracer-common#L6
         commit = "d6f78d948c53f3b400bb46996eb3084359914f9b",
         remote = "https://github.com/google/googleapis",
     ),

--- a/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
+++ b/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
@@ -73,7 +73,7 @@ TEST_F(OpenTracingDriverTest, FlushSpanWithTag) {
   first_span->setTag("abc", "123");
   first_span->finishSpan();
 
-  const std::unordered_map<std::string, opentracing::Value> expected_tags = {
+  const std::map<std::string, opentracing::Value> expected_tags = {
       {"abc", std::string{"123"}},
       {opentracing::ext::span_kind, std::string{opentracing::ext::span_kind_rpc_server}}};
 
@@ -88,7 +88,7 @@ TEST_F(OpenTracingDriverTest, TagSamplingFalseByDecision) {
                                                    start_time_, {Tracing::Reason::Sampling, false});
   first_span->finishSpan();
 
-  const std::unordered_map<std::string, opentracing::Value> expected_tags = {
+  const std::map<std::string, opentracing::Value> expected_tags = {
       {opentracing::ext::sampling_priority, 0},
       {opentracing::ext::span_kind, std::string{opentracing::ext::span_kind_rpc_server}}};
 
@@ -104,7 +104,7 @@ TEST_F(OpenTracingDriverTest, TagSamplingFalseByFlag) {
   first_span->setSampled(false);
   first_span->finishSpan();
 
-  const std::unordered_map<std::string, opentracing::Value> expected_tags = {
+  const std::map<std::string, opentracing::Value> expected_tags = {
       {opentracing::ext::sampling_priority, 0},
       {opentracing::ext::span_kind, std::string{opentracing::ext::span_kind_rpc_server}}};
 
@@ -121,7 +121,7 @@ TEST_F(OpenTracingDriverTest, TagSpanKindClient) {
                                                    start_time_, {Tracing::Reason::Sampling, true});
   first_span->finishSpan();
 
-  const std::unordered_map<std::string, opentracing::Value> expected_tags = {
+  const std::map<std::string, opentracing::Value> expected_tags = {
       {opentracing::ext::span_kind, std::string{opentracing::ext::span_kind_rpc_client}}};
 
   EXPECT_EQ(1, driver_->recorder().spans().size());
@@ -137,7 +137,7 @@ TEST_F(OpenTracingDriverTest, TagSpanKindServer) {
                                                    start_time_, {Tracing::Reason::Sampling, true});
   first_span->finishSpan();
 
-  const std::unordered_map<std::string, opentracing::Value> expected_tags = {
+  const std::map<std::string, opentracing::Value> expected_tags = {
       {opentracing::ext::span_kind, std::string{opentracing::ext::span_kind_rpc_server}}};
 
   EXPECT_EQ(1, driver_->recorder().spans().size());


### PR DESCRIPTION
Signed-off-by: Michael Payne michael@sooper.org

Dependency: Upgrade to lightstep-tracer-cpp 0.8.0 & opentracing-cpp 1.5.0.

Description: lightstep-tracer-cpp 0.8.0 [release notes](https://github.com/lightstep/lightstep-tracer-cpp/releases/tag/v0.8.0) and [commits between releases](https://github.com/lightstep/lightstep-tracer-cpp/compare/v0.7.0...v0.8.0), opentracing-cpp [release notes](https://github.com/opentracing/opentracing-cpp/releases/tag/v1.5.0) and [commits between releases](https://github.com/opentracing/opentracing-cpp/compare/v1.4.2...v1.5.0).

Risk Level: Low

Testing: bazel test //test/... and running on local instances.

Docs Changes: none required

Release Notes: none required
