### PR TITLE
test: improve error output of router_check

### DIFF
--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -210,7 +210,8 @@ bool RouterCheckTool::compareResults(const std::string& actual, const std::strin
 
   // Output failure details to stdout if details_ flag is set to true
   if (details_) {
-    std::cerr << "expected: [" << expected << "], actual: [" << actual << "], test type: " << test_type << std::endl;
+    std::cerr << "expected: [" << expected << "], actual: [" << actual
+              << "], test type: " << test_type << std::endl;
   }
   return false;
 }

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -210,7 +210,7 @@ bool RouterCheckTool::compareResults(const std::string& actual, const std::strin
 
   // Output failure details to stdout if details_ flag is set to true
   if (details_) {
-    std::cout << expected << " " << actual << " " << test_type << std::endl;
+    std::cerr << "expected: [" << expected << "], actual: [" << actual << "], test type: " << test_type << std::endl;
   }
   return false;
 }

--- a/test/tools/router_check/test/route_tests.sh
+++ b/test/tools/router_check/test/route_tests.sh
@@ -19,15 +19,15 @@ done
 # Bad config file
 echo testing bad config output
 BAD_CONFIG_OUTPUT=$(("${PATH_BIN}" "${PATH_CONFIG}/Redirect.golden.json" "${PATH_CONFIG}/TestRoutes.yaml") 2>&1) ||
-  if [[ "${BAD_CONFIG_OUTPUT}" != *"Unable to parse"* ]]; then
-    echo ${BAD_CONFIG_OUTPUT}
-    exit 1
-  fi
+  echo ${BAD_CONFIG_OUTPUT:-no-output}
+if [[ "${BAD_CONFIG_OUTPUT}" != *"Unable to parse"* ]]; then
+  exit 1
+fi
 
 # Failure test case
 echo testing failure test case
 FAILURE_OUTPUT=$("${PATH_BIN}" "${PATH_CONFIG}/TestRoutes.yaml" "${PATH_CONFIG}/Weighted.golden.json" "--details" 2>&1) ||
-echo ${FAILURE_OUTPUT}
-  if [[ "${FAILURE_OUTPUT}" != *"expected: [cluster1], actual: [instant-server], test type: cluster_name"* ]]; then
-    exit 1
-  fi
+  echo ${FAILURE_OUTPUT:-no-output}
+if [[ "${FAILURE_OUTPUT}" != *"expected: [cluster1], actual: [instant-server], test type: cluster_name"* ]]; then
+  exit 1
+fi

--- a/test/tools/router_check/test/route_tests.sh
+++ b/test/tools/router_check/test/route_tests.sh
@@ -26,8 +26,8 @@ BAD_CONFIG_OUTPUT=$(("${PATH_BIN}" "${PATH_CONFIG}/Redirect.golden.json" "${PATH
 
 # Failure test case
 echo testing failure test case
-FAILURE_OUTPUT=$("${PATH_BIN}" "${PATH_CONFIG}/TestRoutes.yaml" "${PATH_CONFIG}/Weighted.golden.json" "--details") ||
+FAILURE_OUTPUT=$("${PATH_BIN}" "${PATH_CONFIG}/TestRoutes.yaml" "${PATH_CONFIG}/Weighted.golden.json" "--details" 2>&1) ||
 echo ${FAILURE_OUTPUT}
-  if [[ "${FAILURE_OUTPUT}" != *"cluster1 instant-server cluster_name"* ]]; then
+  if [[ "${FAILURE_OUTPUT}" != *"expected: [cluster1], actual: [instant-server], test type: cluster_name"* ]]; then
     exit 1
   fi


### PR DESCRIPTION
*Description*: Explains what the different values output means and writes to stderr
instead of stdout. This should make the error output appear in the
testlogs.
*Risk Level*: Low, change to test error reporting
*Testing*: bazel test //test/...
*Docs Changes*: n/a
*Release Notes*: n/a
