### PR TITLE
Use gRPC local channel credentials

### DIFF
--- a/api/envoy/api/v2/core/grpc_service.proto
+++ b/api/envoy/api/v2/core/grpc_service.proto
@@ -57,7 +57,7 @@ message GrpcService {
         // Use local channel credentials. Currently only UDS is supported.
         // See
         // https://github.com/grpc/grpc/blob/782e5c2b8dc6973b6fc0959ba08da0f5b9db2f6f/include/grpcpp/security/credentials.h#L239
-        bool local_credentail = 3;
+        google.protobuf.Empty local_credentail = 3;
       }
     }
 

--- a/api/envoy/api/v2/core/grpc_service.proto
+++ b/api/envoy/api/v2/core/grpc_service.proto
@@ -46,7 +46,7 @@ message GrpcService {
 
     // Local channel credentials. Only UDS is supported for now.
     // See https://github.com/grpc/grpc/pull/15909.
-    message googleLocalCredentials {
+    message GoogleLocalCredentials {
     }
 
     // See https://grpc.io/docs/guides/auth.html#credential-types to understand Channel and Call
@@ -59,7 +59,7 @@ message GrpcService {
         // https://grpc.io/grpc/cpp/namespacegrpc.html#a6beb3ac70ff94bd2ebbd89b8f21d1f61
         google.protobuf.Empty google_default = 2;
 
-        googleLocalCredentials local_credentials = 3;
+        GoogleLocalCredentials local_credentials = 3;
       }
     }
 

--- a/api/envoy/api/v2/core/grpc_service.proto
+++ b/api/envoy/api/v2/core/grpc_service.proto
@@ -57,7 +57,7 @@ message GrpcService {
         // Use local channel credentials. Currently only UDS is supported.
         // See
         // https://github.com/grpc/grpc/blob/782e5c2b8dc6973b6fc0959ba08da0f5b9db2f6f/include/grpcpp/security/credentials.h#L239
-        bool local_channel_credentials = 3;
+        bool local_credentail = 3;
       }
     }
 

--- a/api/envoy/api/v2/core/grpc_service.proto
+++ b/api/envoy/api/v2/core/grpc_service.proto
@@ -53,6 +53,11 @@ message GrpcService {
 
         // https://grpc.io/grpc/cpp/namespacegrpc.html#a6beb3ac70ff94bd2ebbd89b8f21d1f61
         google.protobuf.Empty google_default = 2;
+
+        // Use local channel credentials. Currently only UDS is supported.
+        // See
+        // https://github.com/grpc/grpc/blob/782e5c2b8dc6973b6fc0959ba08da0f5b9db2f6f/include/grpcpp/security/credentials.h#L239
+        bool local_channel_credentials = 3;
       }
     }
 

--- a/api/envoy/api/v2/core/grpc_service.proto
+++ b/api/envoy/api/v2/core/grpc_service.proto
@@ -57,7 +57,7 @@ message GrpcService {
         // Use local channel credentials. Currently only UDS is supported.
         // See
         // https://github.com/grpc/grpc/blob/782e5c2b8dc6973b6fc0959ba08da0f5b9db2f6f/include/grpcpp/security/credentials.h#L239
-        google.protobuf.Empty local_credentail = 3;
+        google.protobuf.Empty local_credentials = 3;
       }
     }
 

--- a/api/envoy/api/v2/core/grpc_service.proto
+++ b/api/envoy/api/v2/core/grpc_service.proto
@@ -44,6 +44,11 @@ message GrpcService {
       DataSource cert_chain = 3;
     }
 
+    // Local channel credentials. Only UDS is supported for now.
+    // See https://github.com/grpc/grpc/pull/15909.
+    message googleLocalCredentials {
+    }
+
     // See https://grpc.io/docs/guides/auth.html#credential-types to understand Channel and Call
     // credential types.
     message ChannelCredentials {
@@ -54,10 +59,7 @@ message GrpcService {
         // https://grpc.io/grpc/cpp/namespacegrpc.html#a6beb3ac70ff94bd2ebbd89b8f21d1f61
         google.protobuf.Empty google_default = 2;
 
-        // Use local channel credentials. Currently only UDS is supported.
-        // See
-        // https://github.com/grpc/grpc/blob/782e5c2b8dc6973b6fc0959ba08da0f5b9db2f6f/include/grpcpp/security/credentials.h#L239
-        google.protobuf.Empty local_credentials = 3;
+        googleLocalCredentials local_credentials = 3;
       }
     }
 

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -52,9 +52,9 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/google/libprotobuf-mutator",
     ),
     com_github_grpc_grpc = dict(
-        sha256 = "c747e4d903f7dcf803be53abed4e4efc5d3e96f6c274ed1dfca7a03fa6f4e36b",
-        strip_prefix = "grpc-1.14.2",
-        urls = ["https://github.com/grpc/grpc/archive/v1.14.2.tar.gz"],
+        sha256 = "66d1286fe37f9853af42e1e76f8c2265a2e9ec00afd6dd79a5d23e0880bbe874",
+        strip_prefix = "grpc-1.15.0-pre1",
+        urls = ["https://github.com/grpc/grpc/archive/v1.15.0-pre1.tar.gz"],
     ),
     com_github_nanopb_nanopb = dict(
         # From: https://github.com/grpc/grpc/blob/v1.14.0/bazel/grpc_deps.bzl#L123

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -52,9 +52,9 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/google/libprotobuf-mutator",
     ),
     com_github_grpc_grpc = dict(
-        sha256 = "66d1286fe37f9853af42e1e76f8c2265a2e9ec00afd6dd79a5d23e0880bbe874",
-        strip_prefix = "grpc-1.15.0-pre1",
-        urls = ["https://github.com/grpc/grpc/archive/v1.15.0-pre1.tar.gz"],
+        sha256 = "013cc34f3c51c0f87e059a12ea203087a7a15dca2e453295345e1d02e2b9634b",
+        strip_prefix = "grpc-1.15.0",
+        urls = ["https://github.com/grpc/grpc/archive/v1.15.0.tar.gz"],
     ),
     com_github_nanopb_nanopb = dict(
         # From: https://github.com/grpc/grpc/blob/v1.14.0/bazel/grpc_deps.bzl#L123

--- a/source/common/grpc/google_grpc_creds_impl.cc
+++ b/source/common/grpc/google_grpc_creds_impl.cc
@@ -21,7 +21,7 @@ std::shared_ptr<grpc::ChannelCredentials> CredsUtility::sslChannelCredentials(
       };
       return grpc::SslCredentials(ssl_credentials_options);
     }
-    if (google_grpc.channel_credentials().local_channel_credentials()) {
+    if (google_grpc.channel_credentials().local_credentail()) {
       return grpc::experimental::LocalCredentials(UDS);
     }
   }

--- a/source/common/grpc/google_grpc_creds_impl.cc
+++ b/source/common/grpc/google_grpc_creds_impl.cc
@@ -9,7 +9,7 @@
 namespace Envoy {
 namespace Grpc {
 
-std::shared_ptr<grpc::ChannelCredentials> CredsUtility::sslChannelCredentials(
+std::shared_ptr<grpc::ChannelCredentials> CredsUtility::getChannelCredentials(
     const envoy::api::v2::core::GrpcService::GoogleGrpc& google_grpc) {
   if (google_grpc.has_channel_credentials()) {
     switch (google_grpc.channel_credentials().credential_specifier_case()) {
@@ -34,7 +34,7 @@ std::shared_ptr<grpc::ChannelCredentials> CredsUtility::sslChannelCredentials(
 
 std::shared_ptr<grpc::ChannelCredentials> CredsUtility::defaultSslChannelCredentials(
     const envoy::api::v2::core::GrpcService& grpc_service_config) {
-  auto creds = sslChannelCredentials(grpc_service_config.google_grpc());
+  auto creds = getChannelCredentials(grpc_service_config.google_grpc());
   if (creds != nullptr) {
     return creds;
   }
@@ -86,7 +86,7 @@ CredsUtility::callCredentials(const envoy::api::v2::core::GrpcService::GoogleGrp
 std::shared_ptr<grpc::ChannelCredentials> CredsUtility::defaultChannelCredentials(
     const envoy::api::v2::core::GrpcService& grpc_service_config) {
   std::shared_ptr<grpc::ChannelCredentials> channel_creds =
-      sslChannelCredentials(grpc_service_config.google_grpc());
+      getChannelCredentials(grpc_service_config.google_grpc());
   if (channel_creds == nullptr) {
     channel_creds = grpc::InsecureChannelCredentials();
   }

--- a/source/common/grpc/google_grpc_creds_impl.cc
+++ b/source/common/grpc/google_grpc_creds_impl.cc
@@ -11,15 +11,19 @@ namespace Grpc {
 
 std::shared_ptr<grpc::ChannelCredentials> CredsUtility::sslChannelCredentials(
     const envoy::api::v2::core::GrpcService::GoogleGrpc& google_grpc) {
-  if (google_grpc.has_channel_credentials() &&
-      google_grpc.channel_credentials().has_ssl_credentials()) {
-    const auto& ssl_credentials = google_grpc.channel_credentials().ssl_credentials();
-    const grpc::SslCredentialsOptions ssl_credentials_options = {
-        .pem_root_certs = Config::DataSource::read(ssl_credentials.root_certs(), true),
-        .pem_private_key = Config::DataSource::read(ssl_credentials.private_key(), true),
-        .pem_cert_chain = Config::DataSource::read(ssl_credentials.cert_chain(), true),
-    };
-    return grpc::SslCredentials(ssl_credentials_options);
+  if (google_grpc.has_channel_credentials()) {
+    if (google_grpc.channel_credentials().has_ssl_credentials()) {
+      const auto& ssl_credentials = google_grpc.channel_credentials().ssl_credentials();
+      const grpc::SslCredentialsOptions ssl_credentials_options = {
+          .pem_root_certs = Config::DataSource::read(ssl_credentials.root_certs(), true),
+          .pem_private_key = Config::DataSource::read(ssl_credentials.private_key(), true),
+          .pem_cert_chain = Config::DataSource::read(ssl_credentials.cert_chain(), true),
+      };
+      return grpc::SslCredentials(ssl_credentials_options);
+    }
+    if (google_grpc.channel_credentials().local_channel_credentials()) {
+      return grpc::experimental::LocalCredentials(UDS);
+    }
   }
   return nullptr;
 }

--- a/source/common/grpc/google_grpc_creds_impl.cc
+++ b/source/common/grpc/google_grpc_creds_impl.cc
@@ -22,7 +22,7 @@ std::shared_ptr<grpc::ChannelCredentials> CredsUtility::sslChannelCredentials(
       };
       return grpc::SslCredentials(ssl_credentials_options);
     }
-    case envoy::api::v2::core::GrpcService::GoogleGrpc::ChannelCredentials::kLocalCredentail: {
+    case envoy::api::v2::core::GrpcService::GoogleGrpc::ChannelCredentials::kLocalCredentials: {
       return grpc::experimental::LocalCredentials(UDS);
     }
     default:

--- a/source/common/grpc/google_grpc_creds_impl.h
+++ b/source/common/grpc/google_grpc_creds_impl.h
@@ -17,13 +17,13 @@ class CredsUtility {
 public:
   /**
    * Translation from envoy::api::v2::core::GrpcService to grpc::ChannelCredentials
-   * for SSL channel credentials.
+   * for channel credentials.
    * @param google_grpc Google gRPC config.
-   * @return std::shared_ptr<grpc::ChannelCredentials> SSL channel credentials. A nullptr
-   *         will be returned in the absence of any configured SSL in grpc_service_config.
+   * @return std::shared_ptr<grpc::ChannelCredentials> channel credentials. A nullptr
+   *         will be returned in the absence of any configured credentials.
    */
   static std::shared_ptr<grpc::ChannelCredentials>
-  sslChannelCredentials(const envoy::api::v2::core::GrpcService::GoogleGrpc& google_grpc);
+  getChannelCredentials(const envoy::api::v2::core::GrpcService::GoogleGrpc& google_grpc);
 
   /**
    * Static translation from envoy::api::v2::core::GrpcService to a vector of grpc::CallCredentials.

--- a/test/common/grpc/google_grpc_creds_test.cc
+++ b/test/common/grpc/google_grpc_creds_test.cc
@@ -11,17 +11,17 @@ namespace {
 // In general, below, we force execution of all paths, but because the
 // underlying grpc::{CallCredentials,ChannelCredentials} don't have any real way
 // of getting at the underlying state, we can at best just make sure we don't
-// crash, compare with nullptr and/or look at vector lengths
+// crash, compare with nullptr and/or look at vector lengths.
 
-TEST(CredsUtility, SslChannelCredentials) {
-  EXPECT_EQ(nullptr, CredsUtility::sslChannelCredentials({}));
+TEST(CredsUtility, GetChannelCredentials) {
+  EXPECT_EQ(nullptr, CredsUtility::getChannelCredentials({}));
   envoy::api::v2::core::GrpcService::GoogleGrpc config;
   auto* creds = config.mutable_channel_credentials();
-  EXPECT_EQ(nullptr, CredsUtility::sslChannelCredentials(config));
+  EXPECT_EQ(nullptr, CredsUtility::getChannelCredentials(config));
   creds->mutable_ssl_credentials();
-  EXPECT_NE(nullptr, CredsUtility::sslChannelCredentials(config));
+  EXPECT_NE(nullptr, CredsUtility::getChannelCredentials(config));
   creds->mutable_local_credentials();
-  EXPECT_NE(nullptr, CredsUtility::sslChannelCredentials(config));
+  EXPECT_NE(nullptr, CredsUtility::getChannelCredentials(config));
 }
 
 TEST(CredsUtility, DefaultSslChannelCredentials) {

--- a/test/common/grpc/google_grpc_creds_test.cc
+++ b/test/common/grpc/google_grpc_creds_test.cc
@@ -20,6 +20,9 @@ TEST(CredsUtility, SslChannelCredentials) {
   EXPECT_EQ(nullptr, CredsUtility::sslChannelCredentials(config));
   creds->mutable_ssl_credentials();
   EXPECT_NE(nullptr, CredsUtility::sslChannelCredentials(config));
+  creds->clear_ssl_credentials();
+  creds->set_local_channel_credentials(true);
+  EXPECT_NE(nullptr, CredsUtility::sslChannelCredentials(config));
 }
 
 TEST(CredsUtility, DefaultSslChannelCredentials) {

--- a/test/common/grpc/google_grpc_creds_test.cc
+++ b/test/common/grpc/google_grpc_creds_test.cc
@@ -21,7 +21,7 @@ TEST(CredsUtility, SslChannelCredentials) {
   creds->mutable_ssl_credentials();
   EXPECT_NE(nullptr, CredsUtility::sslChannelCredentials(config));
   creds->clear_ssl_credentials();
-  creds->set_local_channel_credentials(true);
+  creds->set_local_credentail(true);
   EXPECT_NE(nullptr, CredsUtility::sslChannelCredentials(config));
 }
 

--- a/test/common/grpc/google_grpc_creds_test.cc
+++ b/test/common/grpc/google_grpc_creds_test.cc
@@ -20,7 +20,7 @@ TEST(CredsUtility, SslChannelCredentials) {
   EXPECT_EQ(nullptr, CredsUtility::sslChannelCredentials(config));
   creds->mutable_ssl_credentials();
   EXPECT_NE(nullptr, CredsUtility::sslChannelCredentials(config));
-  creds->mutable_local_credentail();
+  creds->mutable_local_credentials();
   EXPECT_NE(nullptr, CredsUtility::sslChannelCredentials(config));
 }
 

--- a/test/common/grpc/google_grpc_creds_test.cc
+++ b/test/common/grpc/google_grpc_creds_test.cc
@@ -20,7 +20,6 @@ TEST(CredsUtility, SslChannelCredentials) {
   EXPECT_EQ(nullptr, CredsUtility::sslChannelCredentials(config));
   creds->mutable_ssl_credentials();
   EXPECT_NE(nullptr, CredsUtility::sslChannelCredentials(config));
-  creds->clear_ssl_credentials();
   creds->set_local_credentail(true);
   EXPECT_NE(nullptr, CredsUtility::sslChannelCredentials(config));
 }

--- a/test/common/grpc/google_grpc_creds_test.cc
+++ b/test/common/grpc/google_grpc_creds_test.cc
@@ -20,7 +20,7 @@ TEST(CredsUtility, SslChannelCredentials) {
   EXPECT_EQ(nullptr, CredsUtility::sslChannelCredentials(config));
   creds->mutable_ssl_credentials();
   EXPECT_NE(nullptr, CredsUtility::sslChannelCredentials(config));
-  creds->set_local_credentail(true);
+  creds->mutable_local_credentail();
   EXPECT_NE(nullptr, CredsUtility::sslChannelCredentials(config));
 }
 


### PR DESCRIPTION
Add a new field local_credentail into GoogleGrpc which supports Envoy to use gRPC local channel credentials.
Updated gRPC library to 1.15.0 release, which provides new methods that we need in order to use local channel credentials. See https://github.com/grpc/grpc/pull/15909.
Certain Google gRPC features, such as passing Google default call credential, only works with a valid channel credential. Local credential is a valid channel credential.

Signed-off-by: JimmyCYJ jimmychen.0102@gmail.com

Risk Level: Low
Testing: Unit test