### PR TITLE
docs: fix non-rendered character in domains docs

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -31,16 +31,16 @@ message VirtualHost {
   string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // A list of domains (host/authority header) that will be matched to this
-  // virtual host. Wildcard hosts are supported in the form of “*.foo.com” or
-  // “*-bar.foo.com”.
+  // virtual host. Wildcard hosts are supported in the form of ``*.foo.com`` or
+  // ``*-bar.foo.com``.
   //
   // .. note::
   //
   //   The wildcard will not match the empty string.
-  //   e.g. “*-bar.foo.com” will match “baz-bar.foo.com” but not “-bar.foo.com”.
-  //   Additionally, a special entry “*” is allowed which will match any
+  //   e.g. ``*-bar.foo.com`` will match ``baz-bar.foo.com`` but not ``-bar.foo.com``.
+  //   Additionally, a special entry ``*`` is allowed which will match any
   //   host/authority header. Only a single virtual host in the entire route
-  //   configuration can match on “*”. A domain must be unique across all virtual
+  //   configuration can match on ``*``. A domain must be unique across all virtual
   //   hosts or the config will fail to load.
   repeated string domains = 2 [(validate.rules).repeated .min_items = 1];
 


### PR DESCRIPTION
Signed-off-by: Jose Nino <jnino@lyft.com>

*Description*: `*` is being rendered out off of the docs. This fixes that.
*Risk Level*: low
*Testing*: generated docs locally.