### PR TITLE
router: Add path rewrite via regex

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -333,7 +333,7 @@ message CorsPolicy {
   google.protobuf.BoolValue enabled = 7;
 }
 
-// [#comment:next free field: 25]
+// [#comment:next free field: 26]
 message RouteAction {
   oneof cluster_specifier {
     option (validate.required) = true;
@@ -381,34 +381,49 @@ message RouteAction {
   // provided there taking precedence. The filter name should be specified as *envoy.lb*.
   core.Metadata metadata_match = 4;
 
-  // Indicates that during forwarding, the matched prefix (or path) should be
-  // swapped with this value. This option allows application URLs to be rooted
-  // at a different path from those exposed at the reverse proxy layer. The router filter will
-  // place the original path before rewrite into the :ref:`x-envoy-original-path
-  // <config_http_filters_router_x-envoy-original-path>` header.
-  //
-  // .. attention::
-  //
-  //   Pay careful attention to the use of trailing slashes in the
-  //   :ref:`route's match <envoy_api_field_route.Route.match>` prefix value.
-  //   Stripping a prefix from a path requires multiple Routes to handle all cases. For example,
-  //   rewriting */prefix* to */* and */prefix/etc* to */etc* cannot be done in a single
-  //   :ref:`Route <envoy_api_msg_route.Route>`, as shown by the below config entries:
-  //
-  //   .. code-block:: yaml
-  //
-  //     - match:
-  //         prefix: "/prefix/"
-  //       route:
-  //         prefix_rewrite: "/"
-  //     - match:
-  //         prefix: "/prefix"
-  //       route:
-  //         prefix_rewrite: "/"
-  //
-  //   Having above entries in the config, requests to */prefix* will be stripped to */*, while
-  //   requests to */prefix/etc* will be stripped to */etc*.
-  string prefix_rewrite = 5;
+  oneof path_rewrite_specifier {
+    // Indicates that during forwarding, the matched prefix (or path) should be
+    // swapped with this value. This option allows application URLs to be rooted
+    // at a different path from those exposed at the reverse proxy layer. The router filter will
+    // place the original path before rewrite into the :ref:`x-envoy-original-path
+    // <config_http_filters_router_x-envoy-original-path>` header.
+    //
+    // .. attention::
+    //
+    //   Pay careful attention to the use of trailing slashes in the
+    //   :ref:`route's match <envoy_api_field_route.Route.match>` prefix value.
+    //   Stripping a prefix from a path requires multiple Routes to handle all cases. For example,
+    //   rewriting */prefix* to */* and */prefix/etc* to */etc* cannot be done in a single
+    //   :ref:`Route <envoy_api_msg_route.Route>`, as shown by the below config entries:
+    //
+    //   .. code-block:: yaml
+    //
+    //     - match:
+    //         prefix: "/prefix/"
+    //       route:
+    //         prefix_rewrite: "/"
+    //     - match:
+    //         prefix: "/prefix"
+    //       route:
+    //         prefix_rewrite: "/"
+    //
+    //   Having above entries in the config, requests to */prefix* will be stripped to */*, while
+    //   requests to */prefix/etc* will be stripped to */etc*.
+    string prefix_rewrite = 5;
+
+    // Indicates that during forwarding, paths that match the pattern should be
+    // rewritten, interpolating capture groups from the path pattern into the new path as specified by
+    // the rewrite pattern.
+    // This option allows application URLs to be rewritten at the reverse proxy layer in a way that is
+    // aware of segments with variable contents like IDs.
+    // The router filter will place the original path before rewrite into the
+    // :ref:`x-envoy-original-path // <config_http_filters_router_x-envoy-original-path>` header.
+    // Examples:
+    //
+    // * The path pattern *^/foo/(bar)/(.*)$ paired with rewrite pattern */$1/$2* would transform
+    // */foo/bar/baz/bang* into */bar/baz/bang*.
+    RegexRewrite regex_rewrite = 25;
+  }
 
   oneof host_rewrite_specifier {
     // Indicates that during forwarding, the host header will be swapped with
@@ -434,6 +449,18 @@ message RouteAction {
   //   :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
   //   :ref:`retry overview <arch_overview_http_routing_retry>`.
   google.protobuf.Duration timeout = 8 [(gogoproto.stdduration) = true];
+
+  message RegexRewrite {
+    // Represents a regular expression that the path must match in order for the substitution
+    // to be applied. The regular expression may include capture groups to be interpolated into the
+    // substitution.
+    string pattern = 1;
+
+    // Represents the subsitution used to build the final path of the request if the initial path matches
+    // the pattern. The substitution may include references to capture groups defined in the
+    // pattern which will be interpolated into the final path.
+    string substitution = 2;
+  }
 
   // HTTP retry :ref:`architecture overview <arch_overview_http_routing_retry>`.
   message RetryPolicy {

--- a/docs/root/configuration/tools/router_check.rst
+++ b/docs/root/configuration/tools/router_check.rst
@@ -76,6 +76,7 @@ expects a cluster name match of "instant-server".::
         "virtual_host_name": "...",
         "host_rewrite": "...",
         "path_rewrite": "...",
+        "regex_rewrite": "...",
         "path_redirect": "...",
         "header_fields" : [
           {

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -675,6 +675,13 @@ const std::string Json::Schema::ROUTE_ENTRY_CONFIGURATION_SCHEMA(R"EOF(
       "host_redirect" : {"type" : "string"},
       "path_redirect" : {"type" : "string"},
       "prefix_rewrite" : {"type" : "string"},
+      "regex_rewrite" : {
+        "type" : "object",
+        "properties" : {
+          "pattern": {"type" : "string"},
+          "substitution" : {"type" : "integer"}
+        }
+      },
       "host_rewrite" : {"type" : "string"},
       "auto_host_rewrite" : {"type" : "boolean"},
       "use_websocket" : {"type" : "boolean"},

--- a/test/tools/router_check/json/tool_config_schemas.cc
+++ b/test/tools/router_check/json/tool_config_schemas.cc
@@ -49,6 +49,13 @@ const std::string& Json::ToolSchema::routerCheckSchema() {
               "virtual_host_name": {"type": "string"},
               "host_rewrite": {"type": "string"},
               "path_rewrite": {"type": "string"},
+              "regex_rewrite" : {
+                "type" : "object",
+                "properties" : {
+                  "pattern": {"type" : "string"},
+                  "substitution" : {"type" : "integer"}
+                }
+              },
               "path_redirect": {"type": "string"},
               "header_fields": {
                 "type": "array",

--- a/test/tools/router_check/test/config/TestRoutes.golden.json
+++ b/test/tools/router_check/test/config/TestRoutes.golden.json
@@ -304,5 +304,16 @@
         }
       ]
     }
+  },
+  {
+    "test_name": "RegexPathRewrite",
+    "input": {
+      ":authority": "api.lyft.com",
+      ":path": "/v1/posts/123/upvote?foo=bar",
+      ":method": "GET"
+    },
+    "validate": {
+      "path_rewrite": "/public/v1/blog_posts/123/upvote?foo=bar"
+    }
   }
 ]

--- a/test/tools/router_check/test/config/TestRoutes.yaml
+++ b/test/tools/router_check/test/config/TestRoutes.yaml
@@ -89,6 +89,13 @@ virtual_hosts:
           prefix_rewrite: /oranGES
           cluster: instant-server
       - match:
+          regex: "^/v1/posts/([^/]+?)/upvote/?"
+        route:
+          regex_rewrite:
+            pattern: "^/v1/posts/([^/]+?)/(.*)$"
+            substitution: "/public/v1/blog_posts/$1/$2"
+          cluster: instant-server
+      - match:
           prefix: /customheaders
         route:
           cluster: ats


### PR DESCRIPTION
*Description*:
Enables flexible path rewrites using regular expressions similar to the [nginx rewrite directive](http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#rewrite).

The supported syntax is `pattern: "^/foo/(bar)/(.*)$"` `substitution: "/$1/$2"` which would rewrite a path from `/foo/bar/baz/123` to `/bar/baz/123`.

Relates to:
https://github.com/envoyproxy/envoy/issues/2092
https://github.com/envoyproxy/data-plane-api/pull/504
https://github.com/envoyproxy/envoy/issues/4274

*Risk Level*:
*Testing*:
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
