### PR TITLE
ci: report compiler version when setting up cache

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -2,7 +2,7 @@
 
 # Run a CI build/test target, e.g. docs, asan.
 
-function dump_cc_version {
+function dump_version {
     local XCC="${CC:-gcc}"
 
     if [[ $(uname -s) == "Linux" ]]; then
@@ -12,7 +12,7 @@ function dump_cc_version {
     else
         local XCC_VERSION=$(clang -v 2>&1 | head -n 1)
     fi
-    echo "running do_ci.sh with ${XCC_VERSION}"
+    echo "running do_ci.sh with ${XCC} @ ${XCC_VERSION}"
 }
 
 set -e
@@ -29,7 +29,7 @@ echo "building using ${NUM_CPUS} CPUs"
 
 function bazel_release_binary_build() {
   echo "Building..."
-  dump_cc_version
+  dump_version
   cd "${ENVOY_CI_DIR}"
   bazel build ${BAZEL_BUILD_OPTIONS} -c opt //source/exe:envoy-static
   # Copy the envoy-static binary somewhere that we can access outside of the
@@ -48,7 +48,7 @@ function bazel_release_binary_build() {
 
 function bazel_debug_binary_build() {
   echo "Building..."
-  dump_cc_version
+  dump_version
   cd "${ENVOY_CI_DIR}"
   bazel build ${BAZEL_BUILD_OPTIONS} -c dbg //source/exe:envoy-static
   # Copy the envoy-static binary somewhere that we can access outside of the
@@ -106,7 +106,7 @@ elif [[ "$1" == "bazel.debug.server_only" ]]; then
 elif [[ "$1" == "bazel.asan" ]]; then
   setup_clang_toolchain
   echo "bazel ASAN/UBSAN debug build with tests..."
-  dump_cc_version
+  dump_version
   cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
   echo "Building and testing..."
   bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-asan @envoy//test/... \
@@ -115,7 +115,7 @@ elif [[ "$1" == "bazel.asan" ]]; then
 elif [[ "$1" == "bazel.tsan" ]]; then
   setup_clang_toolchain
   echo "bazel TSAN debug build with tests..."
-  dump_cc_version
+  dump_version
   cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
   echo "Building and testing..."
   bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-tsan @envoy//test/... \
@@ -152,7 +152,7 @@ elif [[ "$1" == "bazel.ipv6_tests" ]]; then
 
   setup_clang_toolchain
   echo "Testing..."
-  dump_cc_version
+  dump_version
   cd "${ENVOY_CI_DIR}"
   bazel test ${BAZEL_TEST_OPTIONS} -c fastbuild //test/integration/... //test/common/network/...
   exit 0

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -2,6 +2,19 @@
 
 # Run a CI build/test target, e.g. docs, asan.
 
+function dump_cc_version {
+    local XCC="${CC:-gcc}"
+
+    if [[ $(uname -s) == "Linux" ]]; then
+        local XCC_PATH=$(readlink -f $(which "${XCC}"))
+        local XCC_PKG=$(dpkg -S "${XCC}" | grep "${XCC_PATH}" | cut -d':' -f1)
+        local XCC_VERSION=$(dpkg-query --showformat='${Version}' --show "${XCC_PKG}")
+    else
+        local XCC_VERSION=$(clang -v 2>&1 | head -n 1)
+    fi
+    echo "running do_ci.sh with ${XCC_VERSION}"
+}
+
 set -e
 
 build_setup_args=""
@@ -16,6 +29,7 @@ echo "building using ${NUM_CPUS} CPUs"
 
 function bazel_release_binary_build() {
   echo "Building..."
+  dump_cc_version
   cd "${ENVOY_CI_DIR}"
   bazel build ${BAZEL_BUILD_OPTIONS} -c opt //source/exe:envoy-static
   # Copy the envoy-static binary somewhere that we can access outside of the
@@ -34,6 +48,7 @@ function bazel_release_binary_build() {
 
 function bazel_debug_binary_build() {
   echo "Building..."
+  dump_cc_version
   cd "${ENVOY_CI_DIR}"
   bazel build ${BAZEL_BUILD_OPTIONS} -c dbg //source/exe:envoy-static
   # Copy the envoy-static binary somewhere that we can access outside of the
@@ -51,15 +66,15 @@ if [[ "$1" == "bazel.release" ]]; then
     echo 'Ignoring build for git tag event'
     exit 0
   fi
-  
+
   setup_gcc_toolchain
   echo "bazel release build with tests..."
   bazel_release_binary_build
-  
+
   if [[ $# > 1 ]]; then
     shift
     echo "Testing $* ..."
-    # Run only specified tests. Argument can be a single test 
+    # Run only specified tests. Argument can be a single test
     # (e.g. '//test/common/common:assert_test') or a test group (e.g. '//test/common/...')
     bazel test ${BAZEL_TEST_OPTIONS} -c opt $*
   else
@@ -91,6 +106,7 @@ elif [[ "$1" == "bazel.debug.server_only" ]]; then
 elif [[ "$1" == "bazel.asan" ]]; then
   setup_clang_toolchain
   echo "bazel ASAN/UBSAN debug build with tests..."
+  dump_cc_version
   cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
   echo "Building and testing..."
   bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-asan @envoy//test/... \
@@ -99,6 +115,7 @@ elif [[ "$1" == "bazel.asan" ]]; then
 elif [[ "$1" == "bazel.tsan" ]]; then
   setup_clang_toolchain
   echo "bazel TSAN debug build with tests..."
+  dump_cc_version
   cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
   echo "Building and testing..."
   bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-tsan @envoy//test/... \
@@ -135,6 +152,7 @@ elif [[ "$1" == "bazel.ipv6_tests" ]]; then
 
   setup_clang_toolchain
   echo "Testing..."
+  dump_cc_version
   cd "${ENVOY_CI_DIR}"
   bazel test ${BAZEL_TEST_OPTIONS} -c fastbuild //test/integration/... //test/common/network/...
   exit 0

--- a/ci/setup_gcs_cache.sh
+++ b/ci/setup_gcs_cache.sh
@@ -2,8 +2,22 @@
 
 set -e
 
+function dump_cc_version {
+    local XCC="${CC:-gcc}"
+
+    if [[ $(uname -s) == "Linux" ]]; then
+        local XCC_PATH=$(readlink -f $(which "${XCC}"))
+        local XCC_PKG=$(dpkg -S "${XCC}" | grep "${XCC_PATH}" | cut -d':' -f1)
+        local XCC_VERSION=$(dpkg-query --showformat='${Version}' --show "${XCC_PKG}")
+    else
+        local XCC_VERSION=$(clang -v 2>&1 | head -n 1)
+    fi
+    echo "Setting up $1 remote cache for ${XCC_VERSION}"
+}
+
 if [[ ! -z "${BAZEL_REMOTE_CACHE}" ]]; then
   if [[ ! -z "${GCP_SERVICE_ACCOUNT_KEY}" ]]; then
+    dump_cc_version "read/write"
     # mktemp will create a tempfile with u+rw permission minus umask, it will not be readable by all
     # users by default.
     GCP_SERVICE_ACCOUNT_KEY_FILE=$(mktemp -t gcp_service_account.XXXXXX.json)
@@ -22,6 +36,7 @@ if [[ ! -z "${BAZEL_REMOTE_CACHE}" ]]; then
       --google_credentials=${GCP_SERVICE_ACCOUNT_KEY_FILE}"
     echo "Set up bazel read/write HTTP cache at ${BAZEL_REMOTE_CACHE}."
   else
+    dump_cc_version "read-only"
     export BAZEL_BUILD_EXTRA_OPTIONS="${BAZEL_BUILD_EXTRA_OPTIONS} \
       --remote_http_cache=${BAZEL_REMOTE_CACHE} --noremote_upload_local_results"
     echo "Set up bazel read only HTTP cache at ${BAZEL_REMOTE_CACHE}."


### PR DESCRIPTION
Experiment that attempts to establish if https://github.com/bazelbuild/bazel/issues/4558 is responsible for our periodic errors related to ar lib format.

If this proves out, I'll provide another PR that attempts to rectify the problem.

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
