### PR TITLE
[envoy/router] Move MetadataMatchCriteriaImpl implementation to its own source file

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -189,10 +189,10 @@ message WeightedCluster {
     google.protobuf.UInt32Value weight = 2;
 
     // Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints in
-    // the upstream cluster with metadata matching what is set in this field will be considered.
-    // Note that this will be merged with what's provided in :ref: `RouteAction.MetadataMatch
-    // <envoy_api_field_route.RouteAction.metadata_match>`, with values here taking precedence. The
-    // filter name should be specified as *envoy.lb*.
+    // the upstream cluster with metadata matching what is set in this field will be considered for
+    // load balancing. Note that this will be merged with what's provided in :ref:
+    // `RouteAction.MetadataMatch <envoy_api_field_route.RouteAction.metadata_match>`, with values
+    // here taking precedence. The filter name should be specified as *envoy.lb*.
     core.Metadata metadata_match = 3;
 
     // Specifies a list of headers to be added to requests when this cluster is selected
@@ -375,10 +375,10 @@ message RouteAction {
       [(validate.rules).enum.defined_only = true];
 
   // Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints
-  // in the upstream cluster with metadata matching what's set in this field will be considered.
-  // If using :ref:`weighted_clusters <envoy_api_field_route.RouteAction.weighted_clusters>`,
-  // metadata will be merged, with values provided there taking precedence. The filter name should
-  // be specified as *envoy.lb*.
+  // in the upstream cluster with metadata matching what's set in this field will be considered
+  // for load balancing. If using :ref:`weighted_clusters
+  // <envoy_api_field_route.RouteAction.weighted_clusters>`, metadata will be merged, with values
+  // provided there taking precedence. The filter name should be specified as *envoy.lb*.
   core.Metadata metadata_match = 4;
 
   // Indicates that during forwarding, the matched prefix (or path) should be

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -189,10 +189,10 @@ message WeightedCluster {
     google.protobuf.UInt32Value weight = 2;
 
     // Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints in
-    // the upstream cluster with metadata matching that set in metadata_match will beconsidered.
-    // The filter name should be specified as *envoy.lb*. Note that this will be merged with what'
-    // s provided in :ref: `RouteAction.MetadataMatch
-    // <envoy_api_field_route.RouteAction.metadata_match>`, with values here taking precedence.
+    // the upstream cluster with metadata matching what is set in this field will be considered.
+    // Note that this will be merged with what's provided in :ref: `RouteAction.MetadataMatch
+    // <envoy_api_field_route.RouteAction.metadata_match>`, with values here taking precedence. The
+    // filter name should be specified as *envoy.lb*.
     core.Metadata metadata_match = 3;
 
     // Specifies a list of headers to be added to requests when this cluster is selected
@@ -375,8 +375,10 @@ message RouteAction {
       [(validate.rules).enum.defined_only = true];
 
   // Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints
-  // in the upstream cluster with metadata matching that set in metadata_match will be considered.
-  // The filter name should be specified as *envoy.lb*.
+  // in the upstream cluster with metadata matching what's set in this field will be considered.
+  // If using :ref:`weighted_clusters <envoy_api_field_route.RouteAction.weighted_clusters>`,
+  // metadata will be merged, with values provided there taking precedence. The filter name should
+  // be specified as *envoy.lb*.
   core.Metadata metadata_match = 4;
 
   // Indicates that during forwarding, the matched prefix (or path) should be

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -188,9 +188,11 @@ message WeightedCluster {
     // entries in the clusters array must add up to the total_weight, which defaults to 100.
     google.protobuf.UInt32Value weight = 2;
 
-    // Optional endpoint metadata match criteria. Only endpoints in the upstream
-    // cluster with metadata matching that set in metadata_match will be
-    // considered. The filter name should be specified as *envoy.lb*.
+    // Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints in
+    // the upstream cluster with metadata matching that set in metadata_match will beconsidered.
+    // The filter name should be specified as *envoy.lb*. Note that this will be merged with what'
+    // s provided in :ref: `RouteAction.MetadataMatch
+    // <envoy_api_field_route.RouteAction.metadata_match>`, with values here taking precedence.
     core.Metadata metadata_match = 3;
 
     // Specifies a list of headers to be added to requests when this cluster is selected
@@ -372,9 +374,9 @@ message RouteAction {
   ClusterNotFoundResponseCode cluster_not_found_response_code = 20
       [(validate.rules).enum.defined_only = true];
 
-  // Optional endpoint metadata match criteria. Only endpoints in the upstream
-  // cluster with metadata matching that set in metadata_match will be
-  // considered. The filter name should be specified as *envoy.lb*.
+  // Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints
+  // in the upstream cluster with metadata matching that set in metadata_match will be considered.
+  // The filter name should be specified as *envoy.lb*.
   core.Metadata metadata_match = 4;
 
   // Indicates that during forwarding, the matched prefix (or path) should be

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -10,6 +10,7 @@ envoy_package()
 
 envoy_cc_library(
     name = "metadatamatchcriteria_lib",
+    srcs = ["metadatamatchcriteria_impl.cc"],
     hdrs = ["metadatamatchcriteria_impl.h"],
     deps = [
         "//include/envoy/router:router_interface",

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -212,43 +212,6 @@ HashPolicyImpl::generateHash(const Network::Address::Instance* downstream_addr,
   return hash;
 }
 
-std::vector<MetadataMatchCriterionConstSharedPtr>
-MetadataMatchCriteriaImpl::extractMetadataMatchCriteria(const MetadataMatchCriteriaImpl* parent,
-                                                        const ProtobufWkt::Struct& matches) {
-  std::vector<MetadataMatchCriterionConstSharedPtr> v;
-
-  // Track locations of each name (from the parent) in v to make it
-  // easier to replace them when the same name exists in matches.
-  std::unordered_map<std::string, std::size_t> existing;
-
-  if (parent) {
-    for (const auto& it : parent->metadata_match_criteria_) {
-      // v.size() is the index of the emplaced name.
-      existing.emplace(it->name(), v.size());
-      v.emplace_back(it);
-    }
-  }
-
-  // Add values from matches, replacing name/values copied from parent.
-  for (const auto it : matches.fields()) {
-    const auto index_it = existing.find(it.first);
-    if (index_it != existing.end()) {
-      v[index_it->second] = std::make_shared<MetadataMatchCriterionImpl>(it.first, it.second);
-    } else {
-      v.emplace_back(std::make_shared<MetadataMatchCriterionImpl>(it.first, it.second));
-    }
-  }
-
-  // Sort criteria by name to speed matching in the subset load balancer.
-  // See source/docs/subset_load_balancer.md.
-  std::sort(
-      v.begin(), v.end(),
-      [](const MetadataMatchCriterionConstSharedPtr& a,
-         const MetadataMatchCriterionConstSharedPtr& b) -> bool { return a->name() < b->name(); });
-
-  return v;
-}
-
 DecoratorImpl::DecoratorImpl(const envoy::api::v2::route::Decorator& decorator)
     : operation_(decorator.operation()) {}
 

--- a/source/common/router/metadatamatchcriteria_impl.cc
+++ b/source/common/router/metadatamatchcriteria_impl.cc
@@ -1,0 +1,42 @@
+#include "common/router/metadatamatchcriteria_impl.h"
+
+namespace Envoy {
+namespace Router {
+std::vector<MetadataMatchCriterionConstSharedPtr>
+MetadataMatchCriteriaImpl::extractMetadataMatchCriteria(const MetadataMatchCriteriaImpl* parent,
+                                                        const ProtobufWkt::Struct& matches) {
+  std::vector<MetadataMatchCriterionConstSharedPtr> v;
+
+  // Track locations of each name (from the parent) in v to make it
+  // easier to replace them when the same name exists in matches.
+  std::unordered_map<std::string, std::size_t> existing;
+
+  if (parent) {
+    for (const auto& it : parent->metadata_match_criteria_) {
+      // v.size() is the index of the emplaced name.
+      existing.emplace(it->name(), v.size());
+      v.emplace_back(it);
+    }
+  }
+
+  // Add values from matches, replacing name/values copied from parent.
+  for (const auto it : matches.fields()) {
+    const auto index_it = existing.find(it.first);
+    if (index_it != existing.end()) {
+      v[index_it->second] = std::make_shared<MetadataMatchCriterionImpl>(it.first, it.second);
+    } else {
+      v.emplace_back(std::make_shared<MetadataMatchCriterionImpl>(it.first, it.second));
+    }
+  }
+
+  // Sort criteria by name to speed matching in the subset load balancer.
+  // See source/docs/subset_load_balancer.md.
+  std::sort(
+      v.begin(), v.end(),
+      [](const MetadataMatchCriterionConstSharedPtr& a,
+         const MetadataMatchCriterionConstSharedPtr& b) -> bool { return a->name() < b->name(); });
+
+  return v;
+}
+} // namespace Router
+} // namespace Envoy

--- a/source/common/router/metadatamatchcriteria_impl.h
+++ b/source/common/router/metadatamatchcriteria_impl.h
@@ -5,19 +5,6 @@
 namespace Envoy {
 namespace Router {
 
-class MetadataMatchCriterionImpl : public MetadataMatchCriterion {
-public:
-  MetadataMatchCriterionImpl(const std::string& name, const HashedValue& value)
-      : name_(name), value_(value) {}
-
-  const std::string& name() const override { return name_; }
-  const HashedValue& value() const override { return value_; }
-
-private:
-  const std::string name_;
-  const HashedValue value_;
-};
-
 class MetadataMatchCriteriaImpl;
 typedef std::unique_ptr<const MetadataMatchCriteriaImpl> MetadataMatchCriteriaImplConstPtr;
 
@@ -46,6 +33,19 @@ private:
                                const ProtobufWkt::Struct& metadata_matches);
 
   const std::vector<MetadataMatchCriterionConstSharedPtr> metadata_match_criteria_;
+};
+
+class MetadataMatchCriterionImpl : public MetadataMatchCriterion {
+public:
+  MetadataMatchCriterionImpl(const std::string& name, const HashedValue& value)
+      : name_(name), value_(value) {}
+
+  const std::string& name() const override { return name_; }
+  const HashedValue& value() const override { return value_; }
+
+private:
+  const std::string name_;
+  const HashedValue value_;
 };
 
 } // namespace Router

--- a/source/common/router/metadatamatchcriteria_impl.h
+++ b/source/common/router/metadatamatchcriteria_impl.h
@@ -5,6 +5,19 @@
 namespace Envoy {
 namespace Router {
 
+class MetadataMatchCriterionImpl : public MetadataMatchCriterion {
+public:
+  MetadataMatchCriterionImpl(const std::string& name, const HashedValue& value)
+      : name_(name), value_(value) {}
+
+  const std::string& name() const override { return name_; }
+  const HashedValue& value() const override { return value_; }
+
+private:
+  const std::string name_;
+  const HashedValue value_;
+};
+
 class MetadataMatchCriteriaImpl;
 typedef std::unique_ptr<const MetadataMatchCriteriaImpl> MetadataMatchCriteriaImplConstPtr;
 
@@ -33,19 +46,6 @@ private:
                                const ProtobufWkt::Struct& metadata_matches);
 
   const std::vector<MetadataMatchCriterionConstSharedPtr> metadata_match_criteria_;
-};
-
-class MetadataMatchCriterionImpl : public MetadataMatchCriterion {
-public:
-  MetadataMatchCriterionImpl(const std::string& name, const HashedValue& value)
-      : name_(name), value_(value) {}
-
-  const std::string& name() const override { return name_; }
-  const HashedValue& value() const override { return value_; }
-
-private:
-  const std::string name_;
-  const HashedValue value_;
 };
 
 } // namespace Router


### PR DESCRIPTION
*Description*:
Making this change so others can depend on metadatamatchcriteria_impl without needing
`config_impl`. Also update comments on metadata_match to specify that these fields only apply for the subset load balancer.

Context: https://github.com/envoyproxy/envoy/pull/4402/files#r216856765

*Risk Level*: low
*Testing*: tests, new and old, pass