### PR TITLE
timer_impl: Make time conversions a bit more C++y.

### DIFF
--- a/source/common/event/timer_impl.cc
+++ b/source/common/event/timer_impl.cc
@@ -22,11 +22,11 @@ void TimerImpl::enableTimer(const std::chrono::milliseconds& d) {
   if (d.count() == 0) {
     event_active(&raw_event_, EV_TIMEOUT, 0);
   } else {
-    // TODO(#4332): use duration_cast more nicely to clean up this code.
-    std::chrono::microseconds us = std::chrono::duration_cast<std::chrono::microseconds>(d);
+    auto secs = std::chrono::duration_cast<std::chrono::seconds>(d);
+    auto usecs = std::chrono::duration_cast<std::chrono::microseconds>(d - secs);
     timeval tv;
-    tv.tv_sec = us.count() / 1000000;
-    tv.tv_usec = us.count() % 1000000;
+    tv.tv_sec = secs.count();
+    tv.tv_usec = usecs.count();
     event_add(&raw_event_, &tv);
   }
 }


### PR DESCRIPTION
Use std::chrono::duration_cast rather than dividing by numbers with an eyeball glazing number of zeros for better readability.

Risk Level: low, refactoring only
Testing: existing tests pass

Signed-off-by: Dan Noé <dpn@google.com>


