### PR TITLE
ssl: clarify exception when tls_certificates are missing

### DIFF
--- a/docs/root/intro/arch_overview/ssl.rst
+++ b/docs/root/intro/arch_overview/ssl.rst
@@ -64,6 +64,9 @@ Example configuration
       hosts: [{ socket_address: { address: 127.0.0.2, port_value: 1234 }}]
       tls_context:
         common_tls_context:
+          tls_certificates:
+            certificate_chain: { "filename": "/cert.crt" }
+            private_key: { "filename": "/cert.key" }
           validation_context:
             trusted_ca:
               filename: /etc/ssl/certs/ca-certificates.crt

--- a/source/common/ssl/context_config_impl.cc
+++ b/source/common/ssl/context_config_impl.cc
@@ -189,7 +189,10 @@ ServerContextConfigImpl::ServerContextConfigImpl(
       }()) {
   // TODO(PiotrSikora): Support multiple TLS certificates.
   if ((config.common_tls_context().tls_certificates().size() +
-       config.common_tls_context().tls_certificate_sds_secret_configs().size()) != 1) {
+       config.common_tls_context().tls_certificate_sds_secret_configs().size()) == 0) {
+    throw EnvoyException("Missing tls_certificates specification for server context");
+  } else if ((config.common_tls_context().tls_certificates().size() +
+              config.common_tls_context().tls_certificate_sds_secret_configs().size()) > 1) {
     throw EnvoyException("A single TLS certificate is required for server contexts");
   }
 }

--- a/source/common/ssl/context_config_impl.cc
+++ b/source/common/ssl/context_config_impl.cc
@@ -190,7 +190,7 @@ ServerContextConfigImpl::ServerContextConfigImpl(
   // TODO(PiotrSikora): Support multiple TLS certificates.
   if ((config.common_tls_context().tls_certificates().size() +
        config.common_tls_context().tls_certificate_sds_secret_configs().size()) == 0) {
-    throw EnvoyException("Missing tls_certificates specification for server context");
+    throw EnvoyException("No TLS certificates found for server context");
   } else if ((config.common_tls_context().tls_certificates().size() +
               config.common_tls_context().tls_certificate_sds_secret_configs().size()) > 1) {
     throw EnvoyException("A single TLS certificate is required for server contexts");

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -610,7 +610,7 @@ TEST(ServerContextConfigImplTest, MultipleTlsCertificates) {
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
   EXPECT_THROW_WITH_MESSAGE(
       ServerContextConfigImpl client_context_config(tls_context, factory_context), EnvoyException,
-      "Missing tls_certificates specification for server context");
+      "No TLS certificates found for server context");
   tls_context.mutable_common_tls_context()->add_tls_certificates();
   tls_context.mutable_common_tls_context()->add_tls_certificates();
   EXPECT_THROW_WITH_MESSAGE(
@@ -623,7 +623,7 @@ TEST(ServerContextConfigImplTest, TlsCertificatesAndSdsConfig) {
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
   EXPECT_THROW_WITH_MESSAGE(
       ServerContextConfigImpl server_context_config(tls_context, factory_context), EnvoyException,
-      "Missing tls_certificates specification for server context");
+      "No TLS certificates found for server context");
   tls_context.mutable_common_tls_context()->add_tls_certificates();
   tls_context.mutable_common_tls_context()->add_tls_certificate_sds_secret_configs();
   EXPECT_THROW_WITH_MESSAGE(

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -610,7 +610,7 @@ TEST(ServerContextConfigImplTest, MultipleTlsCertificates) {
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
   EXPECT_THROW_WITH_MESSAGE(
       ServerContextConfigImpl client_context_config(tls_context, factory_context), EnvoyException,
-      "A single TLS certificate is required for server contexts");
+      "Missing tls_certificates specification for server context");
   tls_context.mutable_common_tls_context()->add_tls_certificates();
   tls_context.mutable_common_tls_context()->add_tls_certificates();
   EXPECT_THROW_WITH_MESSAGE(
@@ -623,7 +623,7 @@ TEST(ServerContextConfigImplTest, TlsCertificatesAndSdsConfig) {
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
   EXPECT_THROW_WITH_MESSAGE(
       ServerContextConfigImpl server_context_config(tls_context, factory_context), EnvoyException,
-      "A single TLS certificate is required for server contexts");
+      "Missing tls_certificates specification for server context");
   tls_context.mutable_common_tls_context()->add_tls_certificates();
   tls_context.mutable_common_tls_context()->add_tls_certificate_sds_secret_configs();
   EXPECT_THROW_WITH_MESSAGE(


### PR DESCRIPTION
*Description*
tls_certificates are necessary else validation errors with
"A single TLS certificate is required for server contexts".

context_config_impl and relevant tests have also been updated
to clarify that tls_certificates is required in the server context.
The existing error is still output if more than one certificate is detected.

Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

*Risk Level*: Low, clarifying error message and docs fix
*Testing*: bazel test
*Docs Changes*: Included
* Fixes #4408