### PR TITLE
ci: Copy WORKSPACE for api build

### DIFF
--- a/ci/api_mirror.sh
+++ b/ci/api_mirror.sh
@@ -34,7 +34,6 @@ then
     COMMIT_MSG=$(git -C "$API_WORKING_DIR" log --format=%B -n 1)
     QUALIFIED_COMMIT_MSG=$(echo -e "$COMMIT_MSG\n\n$MIRROR_MSG @ $sha")
     rsync -acv --delete --exclude "ci/" --exclude ".*" --exclude LICENSE \
-      --exclude WORKSPACE \
       "$API_WORKING_DIR"/api/ "$CHECKOUT_DIR"/
     git -C "$CHECKOUT_DIR" add .
     git -C "$CHECKOUT_DIR" commit -m "$QUALIFIED_COMMIT_MSG"


### PR DESCRIPTION
*Description*:
CI for data-plane-api has been failing since gogoproto was updated at envoyproxy/data-plane-api@43bc9ad. This patch makes it so that we also copy over the entirety of the WORKSPACE.

I am creating this PR so I can test if the CI passes successfully.

*Risk Level*:
Low

*Testing*:
Running CI in PR.

Fixes #4218
