### PR TITLE
logger: ensure stderr lock is not overwritten

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -126,7 +126,11 @@ public:
   void flush() override;
 
   bool hasLock() const { return lock_ != nullptr; }
-  void setLock(Thread::BasicLockable& lock) { lock_ = &lock; }
+  void setLock(Thread::BasicLockable& lock) {
+    if (!lock_) {
+      lock_ = &lock;
+    }
+  }
 
 private:
   Thread::BasicLockable* lock_{};


### PR DESCRIPTION
Currently the lock gets overwritten by tests that invoke main, which
is problematic due to the new lock only being kept alive for the
duration of those tests. If anything tries to acquire the lock after
these tests have run, we invoke UB and risk crashing.

This changes the logger to ignore subsequent calls to setLock, ensuring
that we keep using the original lock (defined in test_runner.h) for the
duration of the tests.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Medium, unclear whether there's subtle consequences to this change
*Testing*: Verified that this fixed the crash I reproduced in #4396 
*Docs Changes*: n/a
*Release Notes*: n/a
Fixes #4396 
