### PR TITLE
thrift_proxy: fix another variant of the early close bug

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/conn_manager.h
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.h
@@ -191,6 +191,7 @@ private:
   Buffer::OwnedImpl request_buffer_;
   Runtime::RandomGenerator& random_generator_;
   bool stopped_{false};
+  bool half_closed_{false};
 };
 
 } // namespace ThriftProxy

--- a/source/extensions/filters/network/thrift_proxy/unframed_transport_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/unframed_transport_impl.h
@@ -22,9 +22,11 @@ public:
   // Transport
   const std::string& name() const override { return TransportNames::get().UNFRAMED; }
   TransportType type() const override { return TransportType::Unframed; }
-  bool decodeFrameStart(Buffer::Instance&, MessageMetadata& metadata) override {
+  bool decodeFrameStart(Buffer::Instance& buffer, MessageMetadata& metadata) override {
     UNREFERENCED_PARAMETER(metadata);
-    return true;
+
+    // Don't start a frame if there's no data at all.
+    return buffer.length() > 0;
   }
   bool decodeFrameEnd(Buffer::Instance&) override { return true; }
   void encodeFrame(Buffer::Instance& buffer, const MessageMetadata& metadata,

--- a/test/extensions/filters/network/thrift_proxy/integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/integration_test.cc
@@ -255,14 +255,38 @@ TEST_P(ThriftConnManagerIntegrationTest, EarlyClose) {
 
   std::string partial_request = request_bytes_.toString().substr(0, request_bytes_.length() - 5);
 
+  FakeUpstream* expected_upstream = getExpectedUpstream(false);
+  expected_upstream->set_allow_unexpected_disconnects(true);
+
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
   tcp_client->write(partial_request);
   tcp_client->close();
 
-  FakeUpstream* expected_upstream = getExpectedUpstream(false);
-  expected_upstream->set_allow_unexpected_disconnects(true);
   FakeRawConnectionPtr fake_upstream_connection;
   ASSERT_TRUE(expected_upstream->waitForRawConnection(fake_upstream_connection));
+
+  test_server_->waitForCounterGe("thrift.thrift_stats.cx_destroy_remote_with_active_rq", 1);
+
+  Stats::CounterSharedPtr counter =
+      test_server_->counter("thrift.thrift_stats.cx_destroy_remote_with_active_rq");
+  EXPECT_EQ(1U, counter->value());
+}
+
+// Tests when the downstream client closes before completing a request but an upstream has already
+// been connected/assigned.
+TEST_P(ThriftConnManagerIntegrationTest, EarlyCloseWithUpstream) {
+  initializeCall(DriverMode::Success);
+
+  std::string partial_request = request_bytes_.toString().substr(0, request_bytes_.length() - 5);
+
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  tcp_client->write(partial_request);
+
+  FakeUpstream* expected_upstream = getExpectedUpstream(false);
+  FakeRawConnectionPtr fake_upstream_connection;
+  ASSERT_TRUE(expected_upstream->waitForRawConnection(fake_upstream_connection));
+
+  tcp_client->close();
 
   test_server_->waitForCounterGe("thrift.thrift_stats.cx_destroy_remote_with_active_rq", 1);
 
@@ -308,6 +332,28 @@ TEST_P(ThriftConnManagerIntegrationTest, OnewayEarlyClose) {
   EXPECT_EQ(request_bytes_.toString(), upstream_request.toString());
 
   Stats::CounterSharedPtr counter = test_server_->counter("thrift.thrift_stats.request_oneway");
+  EXPECT_EQ(1U, counter->value());
+}
+
+TEST_P(ThriftConnManagerIntegrationTest, OnewayEarlyClosePartialRequest) {
+  initializeOneway();
+
+  std::string partial_request = request_bytes_.toString().substr(0, request_bytes_.length() - 1);
+
+  FakeUpstream* expected_upstream = getExpectedUpstream(true);
+  expected_upstream->set_allow_unexpected_disconnects(true);
+
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  tcp_client->write(partial_request);
+  tcp_client->close();
+
+  FakeRawConnectionPtr fake_upstream_connection;
+  ASSERT_TRUE(expected_upstream->waitForRawConnection(fake_upstream_connection));
+
+  test_server_->waitForCounterGe("thrift.thrift_stats.cx_destroy_remote_with_active_rq", 1);
+
+  Stats::CounterSharedPtr counter =
+      test_server_->counter("thrift.thrift_stats.cx_destroy_remote_with_active_rq");
   EXPECT_EQ(1U, counter->value());
 }
 

--- a/test/extensions/filters/network/thrift_proxy/unframed_transport_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/unframed_transport_impl_test.cc
@@ -36,6 +36,15 @@ TEST(UnframedTransportTest, DecodeFrameStart) {
   EXPECT_EQ(buffer.length(), 4);
 }
 
+TEST(UnframedTransportTest, DecodeFrameStartWithNoData) {
+  UnframedTransportImpl transport;
+
+  Buffer::OwnedImpl buffer;
+  MessageMetadata metadata;
+  EXPECT_FALSE(transport.decodeFrameStart(buffer, metadata));
+  EXPECT_THAT(metadata, IsEmptyMetadata());
+}
+
 TEST(UnframedTransportTest, DecodeFrameEnd) {
   UnframedTransportImpl transport;
 


### PR DESCRIPTION
In this case, the early close fix only worked if the upstream connection
hadn't yet been formed. Instead, handle early close as long as there
isn't a pending oneway request. Also discovered a case where the
Unframed transport causes an RPC to start on a zero-length buffer with
end_stream set.

Risk Level: low
Testing: added tests, ran 2000x each
Doc Changes: n/a
Release Notes: n/a
Fixes: #4416

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
