### PR TITLE
thrift: make test use `Buffer::Instance::toString()`

### DIFF
--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -426,7 +426,7 @@ TEST_F(ThriftConnectionManagerTest, OnDataHandlesProtocolError) {
 
   EXPECT_CALL(filter_callbacks_.connection_, write(_, false))
       .WillOnce(Invoke([&](Buffer::Instance& buffer, bool) -> void {
-        EXPECT_EQ(bufferToString(write_buffer_), bufferToString(buffer));
+        EXPECT_EQ(write_buffer_.toString(), buffer.toString());
       }));
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
   EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
@@ -488,7 +488,7 @@ TEST_F(ThriftConnectionManagerTest, OnDataHandlesTransportApplicationException) 
 
   EXPECT_CALL(filter_callbacks_.connection_, write(_, false))
       .WillOnce(Invoke([&](Buffer::Instance& buffer, bool) -> void {
-        EXPECT_EQ(bufferToString(write_buffer_), bufferToString(buffer));
+        EXPECT_EQ(write_buffer_.toString(), buffer.toString());
       }));
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
 

--- a/test/extensions/filters/network/thrift_proxy/utility.h
+++ b/test/extensions/filters/network/thrift_proxy/utility.h
@@ -51,15 +51,6 @@ inline void addSeq(Buffer::Instance& buffer, const std::initializer_list<uint8_t
 
 inline void addString(Buffer::Instance& buffer, const std::string& s) { buffer.add(s); }
 
-inline std::string bufferToString(Buffer::Instance& buffer) {
-  if (buffer.length() == 0) {
-    return "";
-  }
-
-  char* data = static_cast<char*>(buffer.linearize(buffer.length()));
-  return std::string(data, buffer.length());
-}
-
 inline std::string fieldTypeToString(const FieldType& field_type) {
   switch (field_type) {
   case FieldType::Stop:


### PR DESCRIPTION
Risk Level: Low
Testing: `//test/extensions/filters/network/thrift_proxy:conn_manager_test`
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Tal Nordan <tal.nordan@solo.io>