### PR TITLE
tracing: Enable zipkin shared span context to be configurable, with default true

### DIFF
--- a/api/envoy/config/trace/v2/trace.proto
+++ b/api/envoy/config/trace/v2/trace.proto
@@ -59,6 +59,10 @@ message ZipkinConfig {
   // Determines whether a 128bit trace id will be used when creating a new
   // trace instance. The default value is false, which will result in a 64 bit trace id being used.
   bool trace_id_128bit = 3;
+
+  // Determines whether client and server spans will shared the same span id.
+  // The default value is true.
+  bool shared_span_context = 4;
 }
 
 // DynamicOtConfig is used to dynamically load a tracer from a shared library

--- a/api/envoy/config/trace/v2/trace.proto
+++ b/api/envoy/config/trace/v2/trace.proto
@@ -10,6 +10,8 @@ import "envoy/api/v2/core/grpc_service.proto";
 
 import "google/protobuf/struct.proto";
 
+import "google/protobuf/wrappers.proto";
+
 import "validate/validate.proto";
 
 // The tracing configuration specifies global
@@ -62,7 +64,7 @@ message ZipkinConfig {
 
   // Determines whether client and server spans will shared the same span id.
   // The default value is true.
-  bool shared_span_context = 4;
+  google.protobuf.BoolValue shared_span_context = 4;
 }
 
 // DynamicOtConfig is used to dynamically load a tracer from a shared library

--- a/examples/jaeger-tracing/front-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/front-envoy-jaeger.yaml
@@ -52,6 +52,7 @@ tracing:
     config:
       collector_cluster: jaeger
       collector_endpoint: "/api/v1/spans"
+      shared_span_context: false
 admin:
   access_log_path: "/dev/null"
   address:

--- a/examples/jaeger-tracing/service1-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/service1-envoy-jaeger.yaml
@@ -88,6 +88,7 @@ tracing:
     config:
       collector_cluster: jaeger
       collector_endpoint: "/api/v1/spans"
+      shared_span_context: false
 admin:
   access_log_path: "/dev/null"
   address:

--- a/examples/jaeger-tracing/service2-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/service2-envoy-jaeger.yaml
@@ -51,6 +51,7 @@ tracing:
     config:
       collector_cluster: jaeger
       collector_endpoint: "/api/v1/spans"
+      shared_span_context: false
 admin:
   access_log_path: "/dev/null"
   address:

--- a/source/extensions/tracers/zipkin/tracer.cc
+++ b/source/extensions/tracers/zipkin/tracer.cc
@@ -66,7 +66,7 @@ SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& span
 
   span_ptr->setName(span_name);
 
-  if (config.operationName() == Tracing::OperationName::Egress) {
+  if (config.operationName() == Tracing::OperationName::Egress || !shared_span_context_) {
     // We need to create a new span that is a child of the previous span; no shared context
 
     // Create a new span id

--- a/source/extensions/tracers/zipkin/tracer.h
+++ b/source/extensions/tracers/zipkin/tracer.h
@@ -57,13 +57,14 @@ public:
    * in all annotations' endpoints of the spans created by the Tracer.
    * @param random_generator Reference to the random-number generator to be used by the Tracer.
    * @param trace_id_128bit Whether 128bit ids should be used.
+   * @param shared_span_context Whether shared span id should be used.
    */
   Tracer(const std::string& service_name, Network::Address::InstanceConstSharedPtr address,
          Runtime::RandomGenerator& random_generator, const bool trace_id_128bit,
-         TimeSource& time_source)
+         const bool shared_span_context, TimeSource& time_source)
       : service_name_(service_name), address_(address), reporter_(nullptr),
         random_generator_(random_generator), trace_id_128bit_(trace_id_128bit),
-        time_source_(time_source) {}
+        shared_span_context_(shared_span_context), time_source_(time_source) {}
 
   /**
    * Creates a "root" Zipkin span.
@@ -116,6 +117,7 @@ private:
   ReporterPtr reporter_;
   Runtime::RandomGenerator& random_generator_;
   const bool trace_id_128bit_;
+  const bool shared_span_context_;
   TimeSource& time_source_;
 };
 

--- a/source/extensions/tracers/zipkin/zipkin_core_constants.h
+++ b/source/extensions/tracers/zipkin/zipkin_core_constants.h
@@ -41,6 +41,7 @@ public:
 
   const std::string DEFAULT_COLLECTOR_ENDPOINT = "/api/v1/spans";
   const bool DEFAULT_TRACE_ID_128BIT = false;
+  const bool DEFAULT_SHARED_SPAN_CONTEXT = true;
 };
 
 typedef ConstSingleton<ZipkinCoreConstantValues> ZipkinCoreConstants;

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -75,8 +75,8 @@ Driver::Driver(const Json::Object& config, Upstream::ClusterManager& cluster_man
   const bool trace_id_128bit =
       config.getBoolean("trace_id_128bit", ZipkinCoreConstants::get().DEFAULT_TRACE_ID_128BIT);
 
-  const bool shared_span_context =
-      config.getBoolean("shared_span_context", ZipkinCoreConstants::get().DEFAULT_SHARED_SPAN_CONTEXT);
+  const bool shared_span_context = config.getBoolean(
+      "shared_span_context", ZipkinCoreConstants::get().DEFAULT_SHARED_SPAN_CONTEXT);
 
   tls_->set([this, collector_endpoint, &random_generator, trace_id_128bit, shared_span_context](
                 Event::Dispatcher& dispatcher) -> ThreadLocal::ThreadLocalObjectSharedPtr {

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -75,10 +75,13 @@ Driver::Driver(const Json::Object& config, Upstream::ClusterManager& cluster_man
   const bool trace_id_128bit =
       config.getBoolean("trace_id_128bit", ZipkinCoreConstants::get().DEFAULT_TRACE_ID_128BIT);
 
-  tls_->set([this, collector_endpoint, &random_generator, trace_id_128bit](
+  const bool shared_span_context =
+      config.getBoolean("shared_span_context", ZipkinCoreConstants::get().DEFAULT_SHARED_SPAN_CONTEXT);
+
+  tls_->set([this, collector_endpoint, &random_generator, trace_id_128bit, shared_span_context](
                 Event::Dispatcher& dispatcher) -> ThreadLocal::ThreadLocalObjectSharedPtr {
     TracerPtr tracer(new Tracer(local_info_.clusterName(), local_info_.address(), random_generator,
-                                trace_id_128bit, time_source_));
+                                trace_id_128bit, shared_span_context, time_source_));
     tracer->setReporter(
         ReporterImpl::NewInstance(std::ref(*this), std::ref(dispatcher), collector_endpoint));
     return ThreadLocal::ThreadLocalObjectSharedPtr{new TlsTracer(std::move(tracer), *this)};

--- a/test/extensions/tracers/zipkin/tracer_test.cc
+++ b/test/extensions/tracers/zipkin/tracer_test.cc
@@ -386,13 +386,18 @@ TEST_F(ZipkinTracerTest, RootSpan128bitTraceId) {
   EXPECT_TRUE(root_span->isSetTraceIdHigh());
 }
 
+// This test checks that when configured to use shared span context, a child span
+// is created with the same id as the parent span.
 TEST_F(ZipkinTracerTest, SharedSpanContext) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:9000");
   NiceMock<Runtime::MockRandomGenerator> random_generator;
-  Tracer tracer("my_service_name", addr, random_generator, false, true, time_source_);
+
+  const bool shared_span_context = true;
+  Tracer tracer("my_service_name", addr, random_generator, false, shared_span_context,
+                time_source_);
   NiceMock<MockTimeSource> mock_start_time;
-  SystemTime timestamp = mock_start_time.systemTime();
+  const SystemTime timestamp = mock_start_time.systemTime();
 
   NiceMock<Tracing::MockConfig> config;
   ON_CALL(config, operationName()).WillByDefault(Return(Tracing::OperationName::Ingress));
@@ -406,13 +411,18 @@ TEST_F(ZipkinTracerTest, SharedSpanContext) {
   EXPECT_EQ(parent_span->id(), child_span->id());
 }
 
+// This test checks that when configured to NOT use shared span context, a child span
+// is created with a different id to the parent span.
 TEST_F(ZipkinTracerTest, NotSharedSpanContext) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:9000");
   NiceMock<Runtime::MockRandomGenerator> random_generator;
-  Tracer tracer("my_service_name", addr, random_generator, false, false, time_source_);
+
+  const bool shared_span_context = false;
+  Tracer tracer("my_service_name", addr, random_generator, false, shared_span_context,
+                time_source_);
   NiceMock<MockTimeSource> mock_start_time;
-  SystemTime timestamp = mock_start_time.systemTime();
+  const SystemTime timestamp = mock_start_time.systemTime();
 
   NiceMock<Tracing::MockConfig> config;
   ON_CALL(config, operationName()).WillByDefault(Return(Tracing::OperationName::Ingress));

--- a/test/extensions/tracers/zipkin/tracer_test.cc
+++ b/test/extensions/tracers/zipkin/tracer_test.cc
@@ -47,7 +47,7 @@ TEST_F(ZipkinTracerTest, spanCreation) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:9000");
   NiceMock<Runtime::MockRandomGenerator> random_generator;
-  Tracer tracer("my_service_name", addr, random_generator, false, time_source_);
+  Tracer tracer("my_service_name", addr, random_generator, false, true, time_source_);
   NiceMock<MockTimeSource> mock_start_time;
   SystemTime timestamp = mock_start_time.systemTime();
 
@@ -230,7 +230,7 @@ TEST_F(ZipkinTracerTest, finishSpan) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:9000");
   NiceMock<Runtime::MockRandomGenerator> random_generator;
-  Tracer tracer("my_service_name", addr, random_generator, false, test_time_.timeSystem());
+  Tracer tracer("my_service_name", addr, random_generator, false, true, test_time_.timeSystem());
   NiceMock<MockTimeSource> mock_start_time;
   SystemTime timestamp = mock_start_time.systemTime();
 
@@ -314,7 +314,7 @@ TEST_F(ZipkinTracerTest, finishNotSampledSpan) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:9000");
   NiceMock<Runtime::MockRandomGenerator> random_generator;
-  Tracer tracer("my_service_name", addr, random_generator, false, time_source_);
+  Tracer tracer("my_service_name", addr, random_generator, false, true, time_source_);
   NiceMock<MockTimeSource> mock_start_time;
   SystemTime timestamp = mock_start_time.systemTime();
 
@@ -343,7 +343,7 @@ TEST_F(ZipkinTracerTest, SpanSampledPropagatedToChild) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:9000");
   NiceMock<Runtime::MockRandomGenerator> random_generator;
-  Tracer tracer("my_service_name", addr, random_generator, false, time_source_);
+  Tracer tracer("my_service_name", addr, random_generator, false, true, time_source_);
   NiceMock<MockTimeSource> mock_start_time;
   SystemTime timestamp = mock_start_time.systemTime();
 
@@ -372,7 +372,7 @@ TEST_F(ZipkinTracerTest, RootSpan128bitTraceId) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:9000");
   NiceMock<Runtime::MockRandomGenerator> random_generator;
-  Tracer tracer("my_service_name", addr, random_generator, true, time_source_);
+  Tracer tracer("my_service_name", addr, random_generator, true, true, time_source_);
   NiceMock<MockTimeSource> mock_start_time;
   SystemTime timestamp = mock_start_time.systemTime();
 
@@ -384,6 +384,46 @@ TEST_F(ZipkinTracerTest, RootSpan128bitTraceId) {
 
   // Test that high 64 bit trace id is set
   EXPECT_TRUE(root_span->isSetTraceIdHigh());
+}
+
+TEST_F(ZipkinTracerTest, SharedSpanContext) {
+  Network::Address::InstanceConstSharedPtr addr =
+      Network::Utility::parseInternetAddressAndPort("127.0.0.1:9000");
+  NiceMock<Runtime::MockRandomGenerator> random_generator;
+  Tracer tracer("my_service_name", addr, random_generator, false, true, time_source_);
+  NiceMock<MockTimeSource> mock_start_time;
+  SystemTime timestamp = mock_start_time.systemTime();
+
+  NiceMock<Tracing::MockConfig> config;
+  ON_CALL(config, operationName()).WillByDefault(Return(Tracing::OperationName::Ingress));
+
+  // Create parent span
+  SpanPtr parent_span = tracer.startSpan(config, "parent_span", timestamp);
+  SpanContext parent_context(*parent_span);
+
+  SpanPtr child_span = tracer.startSpan(config, "child_span", timestamp, parent_context);
+
+  EXPECT_EQ(parent_span->id(), child_span->id());
+}
+
+TEST_F(ZipkinTracerTest, NotSharedSpanContext) {
+  Network::Address::InstanceConstSharedPtr addr =
+      Network::Utility::parseInternetAddressAndPort("127.0.0.1:9000");
+  NiceMock<Runtime::MockRandomGenerator> random_generator;
+  Tracer tracer("my_service_name", addr, random_generator, false, false, time_source_);
+  NiceMock<MockTimeSource> mock_start_time;
+  SystemTime timestamp = mock_start_time.systemTime();
+
+  NiceMock<Tracing::MockConfig> config;
+  ON_CALL(config, operationName()).WillByDefault(Return(Tracing::OperationName::Ingress));
+
+  // Create parent span
+  SpanPtr parent_span = tracer.startSpan(config, "parent_span", timestamp);
+  SpanContext parent_context(*parent_span);
+
+  SpanPtr child_span = tracer.startSpan(config, "child_span", timestamp, parent_context);
+
+  EXPECT_EQ(parent_span->id(), child_span->parentId());
 }
 
 } // namespace Zipkin


### PR DESCRIPTION
*Description*:
Adds configuration option to zipkin tracer config to determine whether shared span context should be used.

Resolves #4397

*Risk Level*: Medium

*Testing*:
Currently defined unit tests but will try on some examples early next week.

*Docs Changes*:
Config option defined in proto.

*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
