### PR TITLE
tcp_proxy: add support for weighted clusters

### DIFF
--- a/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
+++ b/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
@@ -41,6 +41,12 @@ message TcpProxy {
     // Multiple upstream clusters can be specified for a given route. The
     // request is routed to one of the upstream clusters based on weights
     // assigned to each cluster.
+    //
+    // .. note::
+    //
+    //  This field is ignored if the :ref:`deprecated_v1
+    //  <envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.deprecated_v1>`
+    //  configuration is set.
     WeightedCluster weighted_clusters = 10;
   }
 

--- a/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
+++ b/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
@@ -8,7 +8,6 @@ import "envoy/api/v2/core/address.proto";
 import "envoy/api/v2/core/base.proto";
 
 import "google/protobuf/duration.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
@@ -147,28 +146,13 @@ message TcpProxy {
   // The router selects an upstream cluster based on these weights.
   message WeightedCluster {
     message ClusterWeight {
-      // Name of the upstream cluster. The cluster must exist in the
-      // :ref:`cluster manager configuration <config_cluster_manager>`.
+      // Name of the upstream cluster.
       string name = 1 [(validate.rules).string.min_bytes = 1];
 
       // When a request matches the route, the choice of an upstream cluster is
       // determined by its weight. The sum of weights across all entries in the
       // clusters array determines the total weight.
       uint32 weight = 2 [(validate.rules).uint32.gte = 1];
-
-      // [#not-implemented-hide:] Optional endpoint metadata match
-      // criteria. Only endpoints in the upstream cluster with metadata
-      // matching that set in metadata_match will be considered. The filter
-      // name should be specified as *envoy.lb*.
-      envoy.api.v2.core.Metadata metadata_match = 3;
-
-      // [#not-implemented-hide:] The per_filter_config field can be used
-      // to provide weighted cluster-specific configurations for
-      // filters. The key should match the filter name, such as
-      // *envoy.buffer* for the HTTP buffer filter. Use of this field is
-      // filter specific; see the :ref:`HTTP filter documentation
-      // <config_http_filters>` for if and how it is utilized.
-      map<string, google.protobuf.Struct> per_filter_config = 4;
     }
 
     // Specifies one or more upstream clusters associated with the route.

--- a/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
+++ b/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
@@ -8,6 +8,7 @@ import "envoy/api/v2/core/address.proto";
 import "envoy/api/v2/core/base.proto";
 
 import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
@@ -146,13 +147,28 @@ message TcpProxy {
   // The router selects an upstream cluster based on these weights.
   message WeightedCluster {
     message ClusterWeight {
-      // Name of the upstream cluster.
+      // Name of the upstream cluster. The cluster must exist in the
+      // :ref:`cluster manager configuration <config_cluster_manager>`.
       string name = 1 [(validate.rules).string.min_bytes = 1];
 
       // When a request matches the route, the choice of an upstream cluster is
       // determined by its weight. The sum of weights across all entries in the
       // clusters array determines the total weight.
       uint32 weight = 2 [(validate.rules).uint32.gte = 1];
+
+      // [#not-implemented-hide:] Optional endpoint metadata match
+      // criteria. Only endpoints in the upstream cluster with metadata
+      // matching that set in metadata_match will be considered. The filter
+      // name should be specified as *envoy.lb*.
+      envoy.api.v2.core.Metadata metadata_match = 3;
+
+      // [#not-implemented-hide:] The per_filter_config field can be used
+      // to provide weighted cluster-specific configurations for
+      // filters. The key should match the filter name, such as
+      // *envoy.buffer* for the HTTP buffer filter. Use of this field is
+      // filter specific; see the :ref:`HTTP filter documentation
+      // <config_http_filters>` for if and how it is utilized.
+      map<string, google.protobuf.Struct> per_filter_config = 4;
     }
 
     // Specifies one or more upstream clusters associated with the route.

--- a/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
+++ b/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
@@ -21,19 +21,28 @@ message TcpProxy {
   // <config_network_filters_tcp_proxy_stats>`.
   string stat_prefix = 1 [(validate.rules).string.min_bytes = 1];
 
-  // The upstream cluster to connect to.
-  //
-  // .. note::
-  //
-  //  Once full filter chain matching is implemented in listeners, this field will become the only
-  //  way to configure the target cluster. All other matching will be done via :ref:`filter chain
-  //  matching rules <envoy_api_msg_listener.FilterChainMatch>`. For very simple configurations,
-  //  this field can still be used to select the cluster when no other matching rules are required.
-  //  Otherwise, a :ref:`deprecated_v1
-  //  <envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.deprecated_v1>` configuration is
-  //  required to use more complex routing in the interim.
-  //
-  string cluster = 2;
+  oneof cluster_specifier {
+    option (validate.required) = true;
+
+    // The upstream cluster to connect to.
+    //
+    // .. note::
+    //
+    //  Once full filter chain matching is implemented in listeners, this field will become the only
+    //  way to configure the target cluster. All other matching will be done via :ref:`filter chain
+    //  matching rules <envoy_api_msg_listener.FilterChainMatch>`. For very simple configurations,
+    //  this field can still be used to select the cluster when no other matching rules are
+    //  required. Otherwise, a :ref:`deprecated_v1
+    //  <envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.deprecated_v1>` configuration
+    //  is required to use more complex routing in the interim.
+    //
+    string cluster = 2;
+
+    // Multiple upstream clusters can be specified for a given route. The
+    // request is routed to one of the upstream clusters based on weights
+    // assigned to each cluster.
+    WeightedCluster weighted_clusters = 10;
+  }
 
   // Optional endpoint metadata match criteria. Only endpoints in the upstream
   // cluster with metadata matching that set in metadata_match will be
@@ -131,4 +140,22 @@ message TcpProxy {
   // The maximum number of unsuccessful connection attempts that will be made before
   // giving up. If the parameter is not specified, 1 connection attempt will be made.
   google.protobuf.UInt32Value max_connect_attempts = 7 [(validate.rules).uint32.gte = 1];
+
+  // Allows for specification of multiple upstream clusters along with weights
+  // that indicate the percentage of traffic to be forwarded to each cluster.
+  // The router selects an upstream cluster based on these weights.
+  message WeightedCluster {
+    message ClusterWeight {
+      // Name of the upstream cluster.
+      string name = 1 [(validate.rules).string.min_bytes = 1];
+
+      // When a request matches the route, the choice of an upstream cluster is
+      // determined by its weight. The sum of weights across all entries in the
+      // clusters array determines the total weight.
+      google.protobuf.UInt32Value weight = 2 [(validate.rules).uint32.gte = 1];
+    }
+
+    // Specifies one or more upstream clusters associated with the route.
+    repeated ClusterWeight clusters = 1 [(validate.rules).repeated .min_items = 1];
+  }
 }

--- a/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
+++ b/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
@@ -152,7 +152,7 @@ message TcpProxy {
       // When a request matches the route, the choice of an upstream cluster is
       // determined by its weight. The sum of weights across all entries in the
       // clusters array determines the total weight.
-      google.protobuf.UInt32Value weight = 2 [(validate.rules).uint32.gte = 1];
+      uint32 weight = 2 [(validate.rules).uint32.gte = 1];
     }
 
     // Specifies one or more upstream clusters associated with the route.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -71,6 +71,7 @@ Version history
 * rbac network filter: a :ref:`role-based access control network filter <config_network_filters_rbac>` has been added.
 * rest-api: added ability to set the :ref:`request timeout <envoy_api_field_core.ApiConfigSource.request_timeout>` for REST API requests.
 * router: added ability to set request/response headers at the :ref:`envoy_api_msg_route.Route` level.
+* tcp_proxy: added support for :ref:`weighted clusters <envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.weighted_clusters>`.
 * tracing: added support for configuration of :ref:`tracing sampling
   <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.tracing>`.
 * thrift_proxy: introduced thrift routing, moved configuration to correct location

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -552,24 +552,8 @@ RouteConstSharedPtr RouteEntryImplBase::clusterEntry(const Http::HeaderMap& head
     }
   }
 
-  uint64_t selected_value = random_value % total_cluster_weight_;
-  uint64_t begin = 0UL;
-  uint64_t end = 0UL;
-
-  // Find the right cluster to route to based on the interval in which
-  // the selected value falls. The intervals are determined as
-  // [0, cluster1_weight), [cluster1_weight, cluster1_weight+cluster2_weight),..
-  for (const WeightedClusterEntrySharedPtr& cluster : weighted_clusters_) {
-    end = begin + cluster->clusterWeight();
-    if (((selected_value >= begin) && (selected_value < end)) || (end >= total_cluster_weight_)) {
-      // end > total_cluster_weight_: This case can only occur with Runtimes, when the user
-      // specifies invalid weights such that sum(weights) > total_cluster_weight_. In this case,
-      // terminate the search and just return the cluster whose weight caused the overflow.
-      return cluster;
-    }
-    begin = end;
-  }
-  NOT_REACHED_GCOVR_EXCL_LINE;
+  return WeightedClusterUtil::pickCluster(weighted_clusters_, total_cluster_weight_, random_value,
+                                          true);
 }
 
 void RouteEntryImplBase::validateClusters(Upstream::ClusterManager& cm) const {

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -80,7 +80,7 @@ Config::Config(const envoy::config::filter::network::tcp_proxy::v2::TcpProxy& co
   // Weighted clusters will be enabled only if both the default cluster and
   // deprecated v1 routes are absent.
   if (routes_.empty() && config.has_weighted_clusters()) {
-    total_cluster_weight_ = 0UL;
+    total_cluster_weight_ = 0;
     for (const envoy::config::filter::network::tcp_proxy::v2::TcpProxy::WeightedCluster::
              ClusterWeight& cluster_desc : config.weighted_clusters().clusters()) {
       weighted_clusters_.emplace_back(WeightedClusterEntry(cluster_desc));

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -84,7 +84,8 @@ Config::Config(const envoy::config::filter::network::tcp_proxy::v2::TcpProxy& co
     total_cluster_weight_ = 0;
     for (const envoy::config::filter::network::tcp_proxy::v2::TcpProxy::WeightedCluster::
              ClusterWeight& cluster_desc : config.weighted_clusters().clusters()) {
-      std::unique_ptr<WeightedClusterEntry> cluster_entry(new WeightedClusterEntry(cluster_desc));
+      std::unique_ptr<WeightedClusterEntry> cluster_entry(
+          std::make_unique<WeightedClusterEntry>(cluster_desc));
       weighted_clusters_.emplace_back(std::move(cluster_entry));
       total_cluster_weight_ += weighted_clusters_.back()->clusterWeight();
     }

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -40,8 +40,7 @@ Config::Route::Route(
 Config::WeightedClusterEntry::WeightedClusterEntry(
     const envoy::config::filter::network::tcp_proxy::v2::TcpProxy::WeightedCluster::ClusterWeight&
         config)
-    : cluster_name_(config.name()), cluster_weight_(PROTOBUF_GET_WRAPPED_REQUIRED(config, weight)) {
-}
+    : cluster_name_(config.name()), cluster_weight_(config.weight()) {}
 
 Config::SharedConfig::SharedConfig(
     const envoy::config::filter::network::tcp_proxy::v2::TcpProxy& config,

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -139,7 +139,7 @@ private:
     const std::string cluster_name_;
     const uint64_t cluster_weight_;
   };
-  typedef std::shared_ptr<WeightedClusterEntry> WeightedClusterEntrySharedPtr;
+  typedef std::unique_ptr<WeightedClusterEntry> WeightedClusterEntrySharedPtr;
 
   std::vector<Route> routes_;
   std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -102,7 +102,6 @@ public:
    */
   const std::string& getRouteFromEntries(Network::Connection& connection);
   const std::string& getRegularRouteFromEntries(Network::Connection& connection);
-  const std::string& getWeightedClusterRoute(const uint64_t random_value);
 
   const TcpProxyStats& stats() { return shared_config_->stats(); }
   const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() { return access_logs_; }
@@ -128,16 +127,22 @@ private:
     std::string cluster_name_;
   };
 
-  struct WeightedClusterEntry {
+  class WeightedClusterEntry {
+  public:
     WeightedClusterEntry(const envoy::config::filter::network::tcp_proxy::v2::TcpProxy::
                              WeightedCluster::ClusterWeight& config);
 
+    const std::string& clusterName() const { return cluster_name_; }
+    uint64_t clusterWeight() const { return cluster_weight_; }
+
+  private:
     const std::string cluster_name_;
     const uint64_t cluster_weight_;
   };
+  typedef std::shared_ptr<WeightedClusterEntry> WeightedClusterEntrySharedPtr;
 
   std::vector<Route> routes_;
-  std::vector<WeightedClusterEntry> weighted_clusters_;
+  std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
   uint64_t total_cluster_weight_;
   std::vector<AccessLog::InstanceSharedPtr> access_logs_;
   const uint32_t max_connect_attempts_;

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -11,6 +11,7 @@
 #include "envoy/event/timer.h"
 #include "envoy/network/connection.h"
 #include "envoy/network/filter.h"
+#include "envoy/runtime/runtime.h"
 #include "envoy/server/filter_config.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats_macros.h"
@@ -100,6 +101,8 @@ public:
    * If no route applies, returns the empty string.
    */
   const std::string& getRouteFromEntries(Network::Connection& connection);
+  const std::string& getRegularRouteFromEntries(Network::Connection& connection);
+  const std::string& getWeightedClusterRoute(const uint64_t random_value);
 
   const TcpProxyStats& stats() { return shared_config_->stats(); }
   const std::vector<AccessLog::InstanceSharedPtr>& accessLogs() { return access_logs_; }
@@ -125,12 +128,23 @@ private:
     std::string cluster_name_;
   };
 
+  struct WeightedClusterEntry {
+    WeightedClusterEntry(const envoy::config::filter::network::tcp_proxy::v2::TcpProxy::
+                             WeightedCluster::ClusterWeight& config);
+
+    const std::string cluster_name_;
+    const uint64_t cluster_weight_;
+  };
+
   std::vector<Route> routes_;
+  std::vector<WeightedClusterEntry> weighted_clusters_;
+  uint64_t total_cluster_weight_;
   std::vector<AccessLog::InstanceSharedPtr> access_logs_;
   const uint32_t max_connect_attempts_;
   ThreadLocal::SlotPtr upstream_drain_manager_slot_;
   SharedConfigSharedPtr shared_config_;
   std::unique_ptr<const Router::MetadataMatchCriteria> cluster_metadata_match_criteria_;
+  Runtime::RandomGenerator& random_generator_;
 };
 
 typedef std::shared_ptr<Config> ConfigSharedPtr;

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -42,26 +42,8 @@ RouteConstSharedPtr RouteEntryImplBase::clusterEntry(uint64_t random_value) cons
   if (weighted_clusters_.empty()) {
     return shared_from_this();
   }
-
-  uint64_t selected_value = random_value % total_cluster_weight_;
-  uint64_t begin = 0UL;
-  uint64_t end = 0UL;
-
-  // Find the right cluster to route to based on the interval in which
-  // the selected value falls. The intervals are determined as
-  // [0, cluster1_weight), [cluster1_weight, cluster1_weight+cluster2_weight),..
-  for (const WeightedClusterEntrySharedPtr& cluster : weighted_clusters_) {
-    end = begin + cluster->clusterWeight();
-    ASSERT(end <= total_cluster_weight_);
-
-    if (selected_value >= begin && selected_value < end) {
-      return cluster;
-    }
-
-    begin = end;
-  }
-
-  NOT_REACHED_GCOVR_EXCL_LINE;
+  return WeightedClusterUtil::pickCluster(weighted_clusters_, total_cluster_weight_, random_value,
+                                          false);
 }
 
 bool RouteEntryImplBase::headersMatch(const Http::HeaderMap& headers) const {

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -470,6 +470,33 @@ TEST(RegexUtil, parseRegex) {
   }
 }
 
+class WeightedClusterEntry {
+public:
+  WeightedClusterEntry(const std::string name, const uint64_t weight)
+      : name_(name), weight_(weight) {}
+
+  const std::string& clusterName() const { return name_; }
+  uint64_t clusterWeight() const { return weight_; }
+
+private:
+  const std::string name_;
+  const uint64_t weight_;
+};
+typedef std::shared_ptr<WeightedClusterEntry> WeightedClusterEntrySharedPtr;
+
+TEST(WeightedClusterUtil, pickCluster) {
+  std::vector<WeightedClusterEntrySharedPtr> clusters;
+
+  std::unique_ptr<WeightedClusterEntry> cluster1(new WeightedClusterEntry("cluster1", 10));
+  clusters.emplace_back(std::move(cluster1));
+
+  std::unique_ptr<WeightedClusterEntry> cluster2(new WeightedClusterEntry("cluster2", 90));
+  clusters.emplace_back(std::move(cluster2));
+
+  EXPECT_EQ("cluster1", WeightedClusterUtil::pickCluster(clusters, 100, 5, false)->clusterName());
+  EXPECT_EQ("cluster2", WeightedClusterUtil::pickCluster(clusters, 80, 79, true)->clusterName());
+}
+
 static std::string intervalSetIntToString(const IntervalSetImpl<int>& interval_set) {
   std::string out;
   const char* prefix = "";

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -487,12 +487,12 @@ TEST_F(TcpProxyTest, WeightedClusters) {
   envoy::config::filter::network::tcp_proxy::v2::TcpProxy::WeightedCluster::ClusterWeight*
       cluster1 = config.mutable_weighted_clusters()->mutable_clusters()->Add();
   cluster1->set_name("cluster1");
-  cluster1->mutable_weight()->set_value(10);
+  cluster1->set_weight(10);
 
   envoy::config::filter::network::tcp_proxy::v2::TcpProxy::WeightedCluster::ClusterWeight*
       cluster2 = config.mutable_weighted_clusters()->mutable_clusters()->Add();
   cluster2->set_name("cluster2");
-  cluster2->mutable_weight()->set_value(90);
+  cluster2->set_weight(90);
 
   configure(config);
 
@@ -506,7 +506,7 @@ TEST_F(TcpProxyTest, DefaultRoutes) {
   envoy::config::filter::network::tcp_proxy::v2::TcpProxy::WeightedCluster::ClusterWeight*
       ignored_cluster = config.mutable_weighted_clusters()->mutable_clusters()->Add();
   ignored_cluster->set_name("ignored_cluster");
-  ignored_cluster->mutable_weight()->set_value(10);
+  ignored_cluster->set_weight(10);
 
   configure(config);
 

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -481,6 +481,39 @@ public:
   Network::Address::InstanceConstSharedPtr upstream_remote_address_;
 };
 
+TEST_F(TcpProxyTest, WeightedClusters) {
+  envoy::config::filter::network::tcp_proxy::v2::TcpProxy config;
+
+  envoy::config::filter::network::tcp_proxy::v2::TcpProxy::WeightedCluster::ClusterWeight*
+      cluster1 = config.mutable_weighted_clusters()->mutable_clusters()->Add();
+  cluster1->set_name("cluster1");
+  cluster1->mutable_weight()->set_value(10);
+
+  envoy::config::filter::network::tcp_proxy::v2::TcpProxy::WeightedCluster::ClusterWeight*
+      cluster2 = config.mutable_weighted_clusters()->mutable_clusters()->Add();
+  cluster2->set_name("cluster2");
+  cluster2->mutable_weight()->set_value(90);
+
+  configure(config);
+
+  EXPECT_EQ(std::string("cluster1"), config_->getWeightedClusterRoute(5));
+  EXPECT_EQ(std::string("cluster2"), config_->getWeightedClusterRoute(25));
+}
+
+TEST_F(TcpProxyTest, DefaultRoutes) {
+  envoy::config::filter::network::tcp_proxy::v2::TcpProxy config = defaultConfig();
+
+  envoy::config::filter::network::tcp_proxy::v2::TcpProxy::WeightedCluster::ClusterWeight*
+      ignored_cluster = config.mutable_weighted_clusters()->mutable_clusters()->Add();
+  ignored_cluster->set_name("ignored_cluster");
+  ignored_cluster->mutable_weight()->set_value(10);
+
+  configure(config);
+
+  NiceMock<Network::MockConnection> connection;
+  EXPECT_EQ(std::string("fake_cluster"), config_->getRouteFromEntries(connection));
+}
+
 // Tests that half-closes are proxied and don't themselves cause any connection to be closed.
 TEST_F(TcpProxyTest, HalfCloseProxy) {
   setup(1);

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -481,25 +481,6 @@ public:
   Network::Address::InstanceConstSharedPtr upstream_remote_address_;
 };
 
-TEST_F(TcpProxyTest, WeightedClusters) {
-  envoy::config::filter::network::tcp_proxy::v2::TcpProxy config;
-
-  envoy::config::filter::network::tcp_proxy::v2::TcpProxy::WeightedCluster::ClusterWeight*
-      cluster1 = config.mutable_weighted_clusters()->mutable_clusters()->Add();
-  cluster1->set_name("cluster1");
-  cluster1->set_weight(10);
-
-  envoy::config::filter::network::tcp_proxy::v2::TcpProxy::WeightedCluster::ClusterWeight*
-      cluster2 = config.mutable_weighted_clusters()->mutable_clusters()->Add();
-  cluster2->set_name("cluster2");
-  cluster2->set_weight(90);
-
-  configure(config);
-
-  EXPECT_EQ(std::string("cluster1"), config_->getWeightedClusterRoute(5));
-  EXPECT_EQ(std::string("cluster2"), config_->getWeightedClusterRoute(25));
-}
-
 TEST_F(TcpProxyTest, DefaultRoutes) {
   envoy::config::filter::network::tcp_proxy::v2::TcpProxy config = defaultConfig();
 


### PR DESCRIPTION
*Description*:
This PR adds support for optional weighted clusters in TCP Proxy.

Signed-off-by: Venil Noronha <veniln@vmware.com>

*Risk Level*: Med
*Testing*: Added 2 new tests
*Docs Changes*: N/A
*Release Notes*: Introduced weighted clusters in `version_history.rst`

/cc @rshriram