### PR TITLE
time: Remove all usages of chrono::*::now() and instead plumb in TimeSystem or TimeSource

### DIFF
--- a/include/envoy/stats/timespan.h
+++ b/include/envoy/stats/timespan.h
@@ -15,8 +15,8 @@ namespace Stats {
  */
 class Timespan {
 public:
-  Timespan(Histogram& histogram)
-      : histogram_(histogram), start_(std::chrono::steady_clock::now()) {}
+  Timespan(Histogram& histogram, TimeSource& time_source)
+      : time_source_(time_source), histogram_(histogram), start_(time_source.monotonicTime()) {}
 
   /**
    * Complete the timespan and send the time to the histogram.
@@ -27,11 +27,12 @@ public:
    * Get duration since the creation of the span.
    */
   std::chrono::milliseconds getRawDuration() {
-    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
+    return std::chrono::duration_cast<std::chrono::milliseconds>(time_source_.monotonicTime() -
                                                                  start_);
   }
 
 private:
+  TimeSource& time_source_;
   Histogram& histogram_;
   const MonotonicTime start_;
 };

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -78,7 +78,7 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
                                  const absl::optional<std::chrono::milliseconds>& timeout,
                                  bool buffer_body_for_retry)
     : parent_(parent), stream_callbacks_(callbacks), stream_id_(parent.config_.random_.random()),
-      router_(parent.config_), request_info_(Protocol::Http11),
+      router_(parent.config_), request_info_(Protocol::Http11, parent.dispatcher().timeSystem()),
       tracing_config_(Tracing::EgressConfig::get()),
       route_(std::make_shared<RouteImpl>(parent_.cluster_.name(), timeout)) {
   if (buffer_body_for_retry) {

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -61,7 +61,7 @@ ConnectionManagerImpl::ConnectionManagerImpl(ConnectionManagerConfig& config,
                                              Upstream::ClusterManager& cluster_manager,
                                              Event::TimeSystem& time_system)
     : config_(config), stats_(config_.stats()),
-      conn_length_(new Stats::Timespan(stats_.named_.downstream_cx_length_ms_)),
+      conn_length_(new Stats::Timespan(stats_.named_.downstream_cx_length_ms_, time_system)),
       drain_close_(drain_close), random_generator_(random_generator), tracer_(tracer),
       runtime_(runtime), local_info_(local_info), cluster_manager_(cluster_manager),
       listener_stats_(config_.listenerStats()), time_system_(time_system) {}
@@ -356,7 +356,8 @@ ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connect
     : connection_manager_(connection_manager),
       snapped_route_config_(connection_manager.config_.routeConfigProvider().config()),
       stream_id_(connection_manager.random_generator_.random()),
-      request_timer_(new Stats::Timespan(connection_manager_.stats_.named_.downstream_rq_time_)),
+      request_timer_(new Stats::Timespan(connection_manager_.stats_.named_.downstream_rq_time_,
+                                         connection_manager_.timeSystem())),
       request_info_(connection_manager_.codec_->protocol(), connection_manager_.timeSystem()) {
   connection_manager_.stats_.named_.downstream_rq_total_.inc();
   connection_manager_.stats_.named_.downstream_rq_active_.inc();

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -69,7 +69,7 @@ ConnectionManagerImpl::ConnectionManagerImpl(ConnectionManagerConfig& config,
       overload_stop_accepting_requests_(
           overload_manager ? overload_manager->getThreadLocalOverloadState().getState(
                                  Server::OverloadActionNames::get().StopAcceptingRequests)
-          : Server::OverloadManager::getInactiveState()),
+                           : Server::OverloadManager::getInactiveState()),
       time_system_(time_system) {}
 
 const HeaderMapImpl& ConnectionManagerImpl::continueHeader() {

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -49,7 +49,7 @@ public:
   ConnectionManagerImpl(ConnectionManagerConfig& config, const Network::DrainDecision& drain_close,
                         Runtime::RandomGenerator& random_generator, Tracing::HttpTracer& tracer,
                         Runtime::Loader& runtime, const LocalInfo::LocalInfo& local_info,
-                        Upstream::ClusterManager& cluster_manager);
+                        Upstream::ClusterManager& cluster_manager, Event::TimeSystem& time_system);
   ~ConnectionManagerImpl();
 
   static ConnectionManagerStats generateStats(const std::string& prefix, Stats::Scope& scope);
@@ -81,6 +81,8 @@ public:
   void onBelowWriteBufferLowWatermark() override {
     codec_->onUnderlyingConnectionBelowWriteBufferLowWatermark();
   }
+
+  Event::TimeSystem& timeSystem() { return time_system_; }
 
 private:
   struct ActiveStream;
@@ -456,6 +458,7 @@ private:
   WebSocketProxyPtr ws_connection_;
   Network::ReadFilterCallbacks* read_callbacks_{};
   ConnectionManagerListenerStats& listener_stats_;
+  Event::TimeSystem& time_system_;
 };
 
 } // namespace Http

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -312,8 +312,8 @@ ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
       connect_timer_(parent_.dispatcher_.createTimer([this]() -> void { onConnectTimeout(); })),
       remaining_requests_(parent_.host_->cluster().maxRequestsPerConnection()) {
 
-  parent_.conn_connect_ms_.reset(
-      new Stats::Timespan(parent_.host_->cluster().stats().upstream_cx_connect_ms_));
+  parent_.conn_connect_ms_.reset(new Stats::Timespan(
+      parent_.host_->cluster().stats().upstream_cx_connect_ms_, parent_.dispatcher_.timeSystem()));
   Upstream::Host::CreateConnectionData data =
       parent_.host_->createConnection(parent_.dispatcher_, parent_.socket_options_);
   real_host_description_ = data.host_description_;
@@ -325,7 +325,8 @@ ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
   parent_.host_->cluster().stats().upstream_cx_http1_total_.inc();
   parent_.host_->stats().cx_total_.inc();
   parent_.host_->stats().cx_active_.inc();
-  conn_length_.reset(new Stats::Timespan(parent_.host_->cluster().stats().upstream_cx_length_ms_));
+  conn_length_.reset(new Stats::Timespan(parent_.host_->cluster().stats().upstream_cx_length_ms_,
+                                         parent_.dispatcher_.timeSystem()));
   connect_timer_->enableTimer(parent_.host_->cluster().connectTimeout());
   parent_.host_->cluster().resourceManager(parent_.priority_).connections().inc();
 

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -219,8 +219,8 @@ ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
     : parent_(parent),
       connect_timer_(parent_.dispatcher_.createTimer([this]() -> void { onConnectTimeout(); })) {
 
-  parent_.conn_connect_ms_.reset(
-      new Stats::Timespan(parent_.host_->cluster().stats().upstream_cx_connect_ms_));
+  parent_.conn_connect_ms_.reset(new Stats::Timespan(
+      parent_.host_->cluster().stats().upstream_cx_connect_ms_, parent_.dispatcher_.timeSystem()));
   Upstream::Host::CreateConnectionData data =
       parent_.host_->createConnection(parent_.dispatcher_, parent_.socket_options_);
   real_host_description_ = data.host_description_;
@@ -235,7 +235,8 @@ ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
   parent_.host_->cluster().stats().upstream_cx_total_.inc();
   parent_.host_->cluster().stats().upstream_cx_active_.inc();
   parent_.host_->cluster().stats().upstream_cx_http2_total_.inc();
-  conn_length_.reset(new Stats::Timespan(parent_.host_->cluster().stats().upstream_cx_length_ms_));
+  conn_length_.reset(new Stats::Timespan(parent_.host_->cluster().stats().upstream_cx_length_ms_,
+                                         parent_.dispatcher_.timeSystem()));
 
   client_->setConnectionStats({parent_.host_->cluster().stats().upstream_cx_rx_bytes_total_,
                                parent_.host_->cluster().stats().upstream_cx_rx_bytes_buffered_,

--- a/source/common/http/websocket/ws_handler_impl.cc
+++ b/source/common/http/websocket/ws_handler_impl.cc
@@ -47,8 +47,8 @@ WsHandlerImpl::WsHandlerImpl(HeaderMap& request_headers, RequestInfo::RequestInf
                              WebSocketProxyCallbacks& callbacks,
                              Upstream::ClusterManager& cluster_manager,
                              Network::ReadFilterCallbacks* read_callbacks,
-                             TcpProxy::ConfigSharedPtr config)
-    : TcpProxy::Filter(config, cluster_manager), request_headers_(request_headers),
+                             TcpProxy::ConfigSharedPtr config, Event::TimeSystem& time_system)
+    : TcpProxy::Filter(config, cluster_manager, time_system), request_headers_(request_headers),
       request_info_(request_info), route_entry_(route_entry), ws_callbacks_(callbacks) {
 
   // set_connection_stats == false because the http connection manager has already set them

--- a/source/common/http/websocket/ws_handler_impl.h
+++ b/source/common/http/websocket/ws_handler_impl.h
@@ -35,7 +35,8 @@ public:
   WsHandlerImpl(HeaderMap& request_headers, RequestInfo::RequestInfo& request_info,
                 const Router::RouteEntry& route_entry, WebSocketProxyCallbacks& callbacks,
                 Upstream::ClusterManager& cluster_manager,
-                Network::ReadFilterCallbacks* read_callbacks, TcpProxy::ConfigSharedPtr config);
+                Network::ReadFilterCallbacks* read_callbacks, TcpProxy::ConfigSharedPtr config,
+                Event::TimeSystem& time_system);
 
   // Upstream::LoadBalancerContext
   const Router::MetadataMatchCriteria* metadataMatchCriteria() override {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -261,7 +261,8 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
       opaque_config_(parseOpaqueConfig(route)), decorator_(parseDecorator(route)),
       direct_response_code_(ConfigUtility::parseDirectResponseCode(route)),
       direct_response_body_(ConfigUtility::parseDirectResponseBody(route)),
-      per_filter_configs_(route.per_filter_config(), factory_context) {
+      per_filter_configs_(route.per_filter_config(), factory_context),
+      time_system_(factory_context.dispatcher().timeSystem()) {
   if (route.route().has_metadata_match()) {
     const auto filter_it = route.route().metadata_match().filter_metadata().find(
         Envoy::Config::MetadataFilters::get().ENVOY_LB);
@@ -346,9 +347,9 @@ Http::WebSocketProxyPtr RouteEntryImplBase::createWebSocketProxy(
     Http::HeaderMap& request_headers, RequestInfo::RequestInfo& request_info,
     Http::WebSocketProxyCallbacks& callbacks, Upstream::ClusterManager& cluster_manager,
     Network::ReadFilterCallbacks* read_callbacks) const {
-  return std::make_unique<Http::WebSocket::WsHandlerImpl>(request_headers, request_info, *this,
-                                                          callbacks, cluster_manager,
-                                                          read_callbacks, websocket_config_);
+  return std::make_unique<Http::WebSocket::WsHandlerImpl>(
+      request_headers, request_info, *this, callbacks, cluster_manager, read_callbacks,
+      websocket_config_, time_system_);
 }
 
 void RouteEntryImplBase::finalizeRequestHeaders(Http::HeaderMap& headers,

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -549,6 +549,7 @@ private:
   const absl::optional<Http::Code> direct_response_code_;
   std::string direct_response_body_;
   PerFilterConfigs per_filter_configs_;
+  Event::TimeSystem& time_system_;
 };
 
 /**

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -409,7 +409,8 @@ void Filter::maybeDoShadowing() {
 
 void Filter::onRequestComplete() {
   downstream_end_stream_ = true;
-  downstream_request_complete_time_ = std::chrono::steady_clock::now();
+  Event::Dispatcher& dispatcher = callbacks_->dispatcher();
+  downstream_request_complete_time_ = dispatcher.timeSystem().monotonicTime();
 
   // Possible that we got an immediate reset.
   if (upstream_request_) {
@@ -419,8 +420,7 @@ void Filter::onRequestComplete() {
 
     upstream_request_->setupPerTryTimeout();
     if (timeout_.global_timeout_.count() > 0) {
-      response_timeout_ =
-          callbacks_->dispatcher().createTimer([this]() -> void { onResponseTimeout(); });
+      response_timeout_ = dispatcher.createTimer([this]() -> void { onResponseTimeout(); });
       response_timeout_->enableTimer(timeout_.global_timeout_);
     }
   }
@@ -611,7 +611,8 @@ void Filter::onUpstreamHeaders(const uint64_t response_code, Http::HeaderMapPtr&
   // Only send upstream service time if we received the complete request and this is not a
   // premature response.
   if (DateUtil::timePointValid(downstream_request_complete_time_)) {
-    MonotonicTime response_received_time = std::chrono::steady_clock::now();
+    Event::Dispatcher& dispatcher = callbacks_->dispatcher();
+    MonotonicTime response_received_time = dispatcher.timeSystem().monotonicTime();
     std::chrono::milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(
         response_received_time - downstream_request_complete_time_);
     if (!config_.suppress_envoy_headers_) {
@@ -678,8 +679,9 @@ void Filter::onUpstreamComplete() {
 
   if (config_.emit_dynamic_stats_ && !callbacks_->requestInfo().healthCheck() &&
       DateUtil::timePointValid(downstream_request_complete_time_)) {
+    Event::Dispatcher& dispatcher = callbacks_->dispatcher();
     std::chrono::milliseconds response_time = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::steady_clock::now() - downstream_request_complete_time_);
+        dispatcher.timeSystem().monotonicTime() - downstream_request_complete_time_);
 
     upstream_request_->upstream_host_->outlierDetector().putResponseTime(response_time);
 
@@ -773,8 +775,9 @@ void Filter::doRetry() {
 
 Filter::UpstreamRequest::UpstreamRequest(Filter& parent, Http::ConnectionPool::Instance& pool)
     : parent_(parent), conn_pool_(pool), grpc_rq_success_deferred_(false),
-      request_info_(pool.protocol()), calling_encode_headers_(false), upstream_canary_(false),
-      encode_complete_(false), encode_trailers_(false) {
+      request_info_(pool.protocol(), parent_.callbacks_->dispatcher().timeSystem()),
+      calling_encode_headers_(false), upstream_canary_(false), encode_complete_(false),
+      encode_trailers_(false) {
 
   if (parent_.config_.start_child_span_) {
     span_ = parent_.callbacks_->activeSpan().spawnChild(

--- a/source/common/tcp/conn_pool.cc
+++ b/source/common/tcp/conn_pool.cc
@@ -309,8 +309,8 @@ ConnPoolImpl::ActiveConn::ActiveConn(ConnPoolImpl& parent)
       connect_timer_(parent_.dispatcher_.createTimer([this]() -> void { onConnectTimeout(); })),
       remaining_requests_(parent_.host_->cluster().maxRequestsPerConnection()), timed_out_(false) {
 
-  parent_.conn_connect_ms_.reset(
-      new Stats::Timespan(parent_.host_->cluster().stats().upstream_cx_connect_ms_));
+  parent_.conn_connect_ms_.reset(new Stats::Timespan(
+      parent_.host_->cluster().stats().upstream_cx_connect_ms_, parent_.dispatcher_.timeSystem()));
 
   Upstream::Host::CreateConnectionData data =
       parent_.host_->createConnection(parent_.dispatcher_, parent_.socket_options_);
@@ -329,7 +329,8 @@ ConnPoolImpl::ActiveConn::ActiveConn(ConnPoolImpl& parent)
   parent_.host_->cluster().stats().upstream_cx_active_.inc();
   parent_.host_->stats().cx_total_.inc();
   parent_.host_->stats().cx_active_.inc();
-  conn_length_.reset(new Stats::Timespan(parent_.host_->cluster().stats().upstream_cx_length_ms_));
+  conn_length_.reset(new Stats::Timespan(parent_.host_->cluster().stats().upstream_cx_length_ms_,
+                                         parent_.dispatcher_.timeSystem()));
   connect_timer_->enableTimer(parent_.host_->cluster().connectTimeout());
   parent_.host_->cluster().resourceManager(parent_.priority_).connections().inc();
 

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -122,9 +122,10 @@ UpstreamDrainManager& Config::drainManager() {
   return upstream_drain_manager_slot_->getTyped<UpstreamDrainManager>();
 }
 
-Filter::Filter(ConfigSharedPtr config, Upstream::ClusterManager& cluster_manager)
+Filter::Filter(ConfigSharedPtr config, Upstream::ClusterManager& cluster_manager,
+               TimeSource& time_source)
     : config_(config), cluster_manager_(cluster_manager), downstream_callbacks_(*this),
-      upstream_callbacks_(new UpstreamCallbacks(this)) {
+      upstream_callbacks_(new UpstreamCallbacks(this)), request_info_(time_source) {
   ASSERT(config != nullptr);
 }
 

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -145,7 +145,8 @@ class Filter : public Network::ReadFilter,
                Tcp::ConnectionPool::Callbacks,
                protected Logger::Loggable<Logger::Id::filter> {
 public:
-  Filter(ConfigSharedPtr config, Upstream::ClusterManager& cluster_manager);
+  Filter(ConfigSharedPtr config, Upstream::ClusterManager& cluster_manager,
+         TimeSource& time_source);
   ~Filter();
 
   // Network::ReadFilter

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -389,7 +389,7 @@ bool ClusterManagerImpl::scheduleUpdate(const Cluster& cluster, uint32_t priorit
 
   // Has an update_merge_window gone by since the last update? If so, don't schedule
   // the update so it can be applied immediately. Ditto if this is not a mergeable update.
-  const auto delta = std::chrono::steady_clock::now() - updates->last_updated_;
+  const auto delta = time_source_.monotonicTime() - updates->last_updated_;
   const uint64_t delta_ms = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
   const bool out_of_merge_window = delta_ms > timeout;
   if (out_of_merge_window || !mergeable) {
@@ -412,7 +412,7 @@ bool ClusterManagerImpl::scheduleUpdate(const Cluster& cluster, uint32_t priorit
       cm_stats_.update_merge_cancelled_.inc();
     }
 
-    updates->last_updated_ = std::chrono::steady_clock::now();
+    updates->last_updated_ = time_source_.monotonicTime();
     return false;
   }
 
@@ -445,7 +445,7 @@ void ClusterManagerImpl::applyUpdates(const Cluster& cluster, uint32_t priority,
 
   cm_stats_.cluster_updated_via_merge_.inc();
   updates.timer_enabled_ = false;
-  updates.last_updated_ = std::chrono::steady_clock::now();
+  updates.last_updated_ = time_source_.monotonicTime();
 }
 
 bool ClusterManagerImpl::addOrUpdateCluster(const envoy::api::v2::Cluster& cluster,

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -153,7 +153,7 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onInterval() {
       {Http::Headers::get().Path, parent_.path_},
       {Http::Headers::get().UserAgent, Http::Headers::get().UserAgentValues.EnvoyHealthChecker}};
   Router::FilterUtility::setUpstreamScheme(request_headers, *parent_.cluster_.info());
-  RequestInfo::RequestInfoImpl request_info(protocol_);
+  RequestInfo::RequestInfoImpl request_info(protocol_, parent_.dispatcher_.timeSystem());
   request_info.setDownstreamLocalAddress(local_address_);
   request_info.setDownstreamRemoteAddress(local_address_);
   request_info.onUpstreamHostSelected(host_);

--- a/source/extensions/filters/http/dynamo/config.cc
+++ b/source/extensions/filters/http/dynamo/config.cc
@@ -15,9 +15,8 @@ Http::FilterFactoryCb
 DynamoFilterConfig::createFilter(const std::string& stat_prefix,
                                  Server::Configuration::FactoryContext& context) {
   return [&context, stat_prefix](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(Http::StreamFilterSharedPtr{
-        new Dynamo::DynamoFilter(context.runtime(), stat_prefix, context.scope(),
-                                 context.dispatcher().timeSystem())});
+    callbacks.addStreamFilter(Http::StreamFilterSharedPtr{new Dynamo::DynamoFilter(
+        context.runtime(), stat_prefix, context.scope(), context.dispatcher().timeSystem())});
   };
 }
 

--- a/source/extensions/filters/http/dynamo/config.cc
+++ b/source/extensions/filters/http/dynamo/config.cc
@@ -16,7 +16,8 @@ DynamoFilterConfig::createFilter(const std::string& stat_prefix,
                                  Server::Configuration::FactoryContext& context) {
   return [&context, stat_prefix](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(Http::StreamFilterSharedPtr{
-        new Dynamo::DynamoFilter(context.runtime(), stat_prefix, context.scope())});
+        new Dynamo::DynamoFilter(context.runtime(), stat_prefix, context.scope(),
+                                 context.dispatcher().timeSystem())});
   };
 }
 

--- a/source/extensions/filters/http/dynamo/dynamo_filter.cc
+++ b/source/extensions/filters/http/dynamo/dynamo_filter.cc
@@ -23,7 +23,7 @@ namespace Dynamo {
 
 Http::FilterHeadersStatus DynamoFilter::decodeHeaders(Http::HeaderMap& headers, bool) {
   if (enabled_) {
-    start_decode_ = std::chrono::steady_clock::now();
+    start_decode_ = time_system_.monotonicTime();
     operation_ = RequestParser::parseOperation(headers);
     return Http::FilterHeadersStatus::StopIteration;
   } else {
@@ -172,7 +172,7 @@ void DynamoFilter::chargeBasicStats(uint64_t status) {
 void DynamoFilter::chargeStatsPerEntity(const std::string& entity, const std::string& entity_type,
                                         uint64_t status) {
   std::chrono::milliseconds latency = std::chrono::duration_cast<std::chrono::milliseconds>(
-      std::chrono::steady_clock::now() - start_decode_);
+      time_system_.monotonicTime() - start_decode_);
 
   std::string group_string =
       Http::CodeUtility::groupStringForResponseCode(static_cast<Http::Code>(status));

--- a/source/extensions/filters/http/dynamo/dynamo_filter.h
+++ b/source/extensions/filters/http/dynamo/dynamo_filter.h
@@ -24,8 +24,10 @@ namespace Dynamo {
  */
 class DynamoFilter : public Http::StreamFilter {
 public:
-  DynamoFilter(Runtime::Loader& runtime, const std::string& stat_prefix, Stats::Scope& scope)
-      : runtime_(runtime), stat_prefix_(stat_prefix + "dynamodb."), scope_(scope) {
+  DynamoFilter(Runtime::Loader& runtime, const std::string& stat_prefix, Stats::Scope& scope,
+               Event::TimeSystem& time_system)
+      : runtime_(runtime), stat_prefix_(stat_prefix + "dynamodb."), scope_(scope),
+        time_system_(time_system) {
     enabled_ = runtime_.snapshot().featureEnabled("dynamodb.filter_enabled", 100);
   }
 
@@ -74,6 +76,7 @@ private:
   Http::HeaderMap* response_headers_;
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};
+  Event::TimeSystem& time_system_;
 };
 
 } // namespace Dynamo

--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -33,6 +33,8 @@ public:
   void onDestroy() override;
   void sanitizePayloadHeaders(Http::HeaderMap& headers) const override;
 
+  TimeSource& timeSource() { return config_->timeSource(); }
+
 private:
   // Fetch a remote public key.
   void fetchRemoteJwks();
@@ -116,9 +118,9 @@ void AuthenticatorImpl::verify(Http::HeaderMap& headers, Authenticator::Callback
   }
 
   // Check "exp" claim.
-  const auto unix_timestamp = std::chrono::duration_cast<std::chrono::seconds>(
-                                  std::chrono::system_clock::now().time_since_epoch())
-                                  .count();
+  const auto unix_timestamp =
+      std::chrono::duration_cast<std::chrono::seconds>(timeSource().systemTime().time_since_epoch())
+          .count();
   // NOTE: Service account tokens generally don't have an expiration time (due to being long lived)
   // and defaulted to 0 by google::jwt_verify library but are still valid.
   if (jwt_.exp_ > 0 && jwt_.exp_ < unix_timestamp) {

--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -120,7 +120,7 @@ void AuthenticatorImpl::verify(Http::HeaderMap& headers, Authenticator::Callback
   // Check "exp" claim.
   const auto unix_timestamp =
       std::chrono::duration_cast<std::chrono::seconds>(timeSource().systemTime().time_since_epoch())
-      .count();
+          .count();
   // If the nbf claim does *not* appear in the JWT, then the nbf field is defaulted
   // to 0.
   if (jwt_.nbf_ > unix_timestamp) {

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -25,7 +25,7 @@ public:
   // Load the config from envoy config.
   ThreadLocalCache(
       const ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication& config,
-                   TimeSource& time_source) {
+      TimeSource& time_source) {
     jwks_cache_ = JwksCache::create(config, time_source);
   }
 
@@ -67,8 +67,8 @@ public:
         time_source_(context.dispatcher().timeSystem()) {
     ENVOY_LOG(info, "Loaded JwtAuthConfig: {}", proto_config_.DebugString());
     tls_->set([this](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
-                return std::make_shared<ThreadLocalCache>(proto_config_, time_source_);
-              });
+      return std::make_shared<ThreadLocalCache>(proto_config_, time_source_);
+    });
     extractor_ = Extractor::create(proto_config_);
   }
 
@@ -84,6 +84,7 @@ public:
   ThreadLocalCache& getCache() { return tls_->getTyped<ThreadLocalCache>(); }
 
   Upstream::ClusterManager& cm() { return cm_; }
+  TimeSource& timeSource() { return time_source_; }
 
   // Get the token  extractor.
   const Extractor& getExtractor() const { return *extractor_; }

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -24,8 +24,9 @@ class ThreadLocalCache : public ThreadLocal::ThreadLocalObject {
 public:
   // Load the config from envoy config.
   ThreadLocalCache(
-      const ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication& config) {
-    jwks_cache_ = JwksCache::create(config);
+      const ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication& config,
+                   TimeSource& time_source) {
+    jwks_cache_ = JwksCache::create(config, time_source);
   }
 
   // Get the JwksCache object.
@@ -62,11 +63,12 @@ public:
       const ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context)
       : proto_config_(proto_config), stats_(generateStats(stats_prefix, context.scope())),
-        tls_(context.threadLocal().allocateSlot()), cm_(context.clusterManager()) {
+        tls_(context.threadLocal().allocateSlot()), cm_(context.clusterManager()),
+        time_source_(context.dispatcher().timeSystem()) {
     ENVOY_LOG(info, "Loaded JwtAuthConfig: {}", proto_config_.DebugString());
     tls_->set([this](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
-      return std::make_shared<ThreadLocalCache>(proto_config_);
-    });
+                return std::make_shared<ThreadLocalCache>(proto_config_, time_source_);
+              });
     extractor_ = Extractor::create(proto_config_);
   }
 
@@ -102,6 +104,7 @@ private:
   Upstream::ClusterManager& cm_;
   // The object to extract tokens.
   ExtractorConstPtr extractor_;
+  TimeSource& time_source_;
 };
 typedef std::shared_ptr<FilterConfig> FilterConfigSharedPtr;
 

--- a/source/extensions/filters/http/jwt_authn/jwks_cache.cc
+++ b/source/extensions/filters/http/jwt_authn/jwks_cache.cc
@@ -28,8 +28,7 @@ constexpr int PubkeyCacheExpirationSec = 600;
 class JwksDataImpl : public JwksCache::JwksData, public Logger::Loggable<Logger::Id::filter> {
 public:
   JwksDataImpl(const JwtProvider& jwt_provider, TimeSource& time_source)
-      : jwt_provider_(jwt_provider),
-        time_source_(time_source) {
+      : jwt_provider_(jwt_provider), time_source_(time_source) {
     std::vector<std::string> audiences;
     for (const auto& aud : jwt_provider_.audiences()) {
       audiences.push_back(aud);
@@ -56,9 +55,7 @@ public:
 
   const Jwks* getJwksObj() const override { return jwks_obj_.get(); }
 
-  bool isExpired() const override {
-    return time_source_.monotonicTime() >= expiration_time_;
-  }
+  bool isExpired() const override { return time_source_.monotonicTime() >= expiration_time_; }
 
   Status setRemoteJwks(const std::string& jwks_str) override {
     return setKey(jwks_str, getRemoteJwksExpirationTime());

--- a/source/extensions/filters/http/jwt_authn/jwks_cache.cc
+++ b/source/extensions/filters/http/jwt_authn/jwks_cache.cc
@@ -3,6 +3,8 @@
 #include <chrono>
 #include <unordered_map>
 
+#include "envoy/common/time.h"
+
 #include "common/common/logger.h"
 #include "common/config/datasource.h"
 #include "common/protobuf/utility.h"
@@ -25,7 +27,9 @@ constexpr int PubkeyCacheExpirationSec = 600;
 
 class JwksDataImpl : public JwksCache::JwksData, public Logger::Loggable<Logger::Id::filter> {
 public:
-  JwksDataImpl(const JwtProvider& jwt_provider) : jwt_provider_(jwt_provider) {
+  JwksDataImpl(const JwtProvider& jwt_provider, TimeSource& time_source)
+      : jwt_provider_(jwt_provider),
+        time_source_(time_source) {
     std::vector<std::string> audiences;
     for (const auto& aud : jwt_provider_.audiences()) {
       audiences.push_back(aud);
@@ -52,7 +56,9 @@ public:
 
   const Jwks* getJwksObj() const override { return jwks_obj_.get(); }
 
-  bool isExpired() const override { return std::chrono::steady_clock::now() >= expiration_time_; }
+  bool isExpired() const override {
+    return time_source_.monotonicTime() >= expiration_time_;
+  }
 
   Status setRemoteJwks(const std::string& jwks_str) override {
     return setKey(jwks_str, getRemoteJwksExpirationTime());
@@ -61,7 +67,7 @@ public:
 private:
   // Get the expiration time for a remote Jwks
   std::chrono::steady_clock::time_point getRemoteJwksExpirationTime() const {
-    auto expire = std::chrono::steady_clock::now();
+    auto expire = time_source_.monotonicTime();
     if (jwt_provider_.has_remote_jwks() && jwt_provider_.remote_jwks().has_cache_duration()) {
       expire += std::chrono::milliseconds(
           DurationUtil::durationToMilliseconds(jwt_provider_.remote_jwks().cache_duration()));
@@ -72,7 +78,7 @@ private:
   }
 
   // Set a Jwks as string.
-  Status setKey(const std::string& jwks_str, std::chrono::steady_clock::time_point expire) {
+  Status setKey(const std::string& jwks_str, MonotonicTime expire) {
     auto jwks_obj = Jwks::createFrom(jwks_str, Jwks::JWKS);
     if (jwks_obj->getStatus() != Status::Ok) {
       return jwks_obj->getStatus();
@@ -88,17 +94,18 @@ private:
   ::google::jwt_verify::CheckAudiencePtr audiences_;
   // The generated jwks object.
   ::google::jwt_verify::JwksPtr jwks_obj_;
+  TimeSource& time_source_;
   // The pubkey expiration time.
-  std::chrono::steady_clock::time_point expiration_time_;
+  MonotonicTime expiration_time_;
 };
 
 class JwksCacheImpl : public JwksCache {
 public:
   // Load the config from envoy config.
-  JwksCacheImpl(const JwtAuthentication& config) {
+  JwksCacheImpl(const JwtAuthentication& config, TimeSource& time_source) {
     for (const auto& it : config.providers()) {
       const auto& provider = it.second;
-      jwks_data_map_.emplace(provider.issuer(), provider);
+      jwks_data_map_.emplace(provider.issuer(), JwksDataImpl(provider, time_source));
     }
   }
 
@@ -118,8 +125,9 @@ private:
 } // namespace
 
 JwksCachePtr JwksCache::create(
-    const ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication& config) {
-  return JwksCachePtr(new JwksCacheImpl(config));
+    const ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication& config,
+    TimeSource& time_source) {
+  return JwksCachePtr(new JwksCacheImpl(config, time_source));
 }
 
 } // namespace JwtAuthn

--- a/source/extensions/filters/http/jwt_authn/jwks_cache.h
+++ b/source/extensions/filters/http/jwt_authn/jwks_cache.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/common/pure.h"
+#include "envoy/common/time.h"
 #include "envoy/config/filter/http/jwt_authn/v2alpha/config.pb.h"
 
 #include "jwt_verify_lib/jwks.h"
@@ -62,7 +63,8 @@ public:
 
   // Factory function to create an instance.
   static JwksCachePtr
-  create(const ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication& config);
+  create(const ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication& config,
+         TimeSource& time_source);
 };
 
 } // namespace JwtAuthn

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -76,7 +76,8 @@ HttpConnectionManagerFilterConfigFactory::createFilterFactoryFromProtoTyped(
           date_provider](Network::FilterManager& filter_manager) -> void {
     filter_manager.addReadFilter(Network::ReadFilterSharedPtr{new Http::ConnectionManagerImpl(
         *filter_config, context.drainDecision(), context.random(), context.httpTracer(),
-        context.runtime(), context.localInfo(), context.clusterManager())});
+        context.runtime(), context.localInfo(), context.clusterManager(),
+        context.dispatcher().timeSystem())});
   };
 }
 

--- a/source/extensions/filters/network/mongo_proxy/config.cc
+++ b/source/extensions/filters/network/mongo_proxy/config.cc
@@ -23,7 +23,8 @@ Network::FilterFactoryCb MongoProxyFilterConfigFactory::createFilterFactoryFromP
   const std::string stat_prefix = fmt::format("mongo.{}.", proto_config.stat_prefix());
   AccessLogSharedPtr access_log;
   if (!proto_config.access_log().empty()) {
-    access_log.reset(new AccessLog(proto_config.access_log(), context.accessLogManager()));
+    access_log.reset(new AccessLog(proto_config.access_log(), context.accessLogManager(),
+                                   context.dispatcher().timeSystem()));
   }
 
   FaultConfigSharedPtr fault_config;
@@ -37,7 +38,7 @@ Network::FilterFactoryCb MongoProxyFilterConfigFactory::createFilterFactoryFromP
           fault_config](Network::FilterManager& filter_manager) -> void {
     filter_manager.addFilter(std::make_shared<ProdProxyFilter>(
         stat_prefix, context.scope(), context.runtime(), access_log, fault_config,
-        context.drainDecision(), context.random()));
+        context.drainDecision(), context.random(), context.dispatcher().timeSystem()));
   };
 }
 

--- a/source/extensions/filters/network/tcp_proxy/config.cc
+++ b/source/extensions/filters/network/tcp_proxy/config.cc
@@ -29,8 +29,8 @@ Network::FilterFactoryCb ConfigFactory::createFilterFactoryFromProtoTyped(
   Envoy::TcpProxy::ConfigSharedPtr filter_config(
       std::make_shared<Envoy::TcpProxy::Config>(proto_config, context));
   return [filter_config, &context](Network::FilterManager& filter_manager) -> void {
-    filter_manager.addReadFilter(
-        std::make_shared<Envoy::TcpProxy::Filter>(filter_config, context.clusterManager()));
+    filter_manager.addReadFilter(std::make_shared<Envoy::TcpProxy::Filter>(
+        filter_config, context.clusterManager(), context.dispatcher().timeSystem()));
   };
 }
 

--- a/source/extensions/filters/network/thrift_proxy/config.cc
+++ b/source/extensions/filters/network/thrift_proxy/config.cc
@@ -106,8 +106,8 @@ Network::FilterFactoryCb ThriftProxyFilterConfigFactory::createFilterFactoryFrom
   std::shared_ptr<Config> filter_config(new ConfigImpl(proto_config, context));
 
   return [filter_config, &context](Network::FilterManager& filter_manager) -> void {
-    filter_manager.addReadFilter(
-        std::make_shared<ConnectionManager>(*filter_config, context.random()));
+    filter_manager.addReadFilter(std::make_shared<ConnectionManager>(
+        *filter_config, context.random(), context.dispatcher().timeSystem()));
   };
 }
 

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -15,11 +15,12 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace ThriftProxy {
 
-ConnectionManager::ConnectionManager(Config& config, Runtime::RandomGenerator& random_generator)
+ConnectionManager::ConnectionManager(Config& config, Runtime::RandomGenerator& random_generator,
+                                     Event::TimeSystem& time_system)
     : config_(config), stats_(config_.stats()), transport_(config.createTransport()),
       protocol_(config.createProtocol()),
       decoder_(std::make_unique<Decoder>(*transport_, *protocol_, *this)),
-      random_generator_(random_generator) {}
+      random_generator_(random_generator), time_system_(time_system) {}
 
 ConnectionManager::~ConnectionManager() {}
 

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.h
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.h
@@ -56,7 +56,8 @@ class ConnectionManager : public Network::ReadFilter,
                           public DecoderCallbacks,
                           Logger::Loggable<Logger::Id::thrift> {
 public:
-  ConnectionManager(Config& config, Runtime::RandomGenerator& random_generator);
+  ConnectionManager(Config& config, Runtime::RandomGenerator& random_generator,
+                    Event::TimeSystem& time_system);
   ~ConnectionManager();
 
   // Network::ReadFilter
@@ -114,7 +115,8 @@ private:
                      public ThriftFilters::DecoderFilterCallbacks,
                      public ThriftFilters::FilterChainFactoryCallbacks {
     ActiveRpc(ConnectionManager& parent)
-        : parent_(parent), request_timer_(new Stats::Timespan(parent_.stats_.request_time_ms_)),
+        : parent_(parent), request_timer_(new Stats::Timespan(parent_.stats_.request_time_ms_,
+                                                              parent_.time_system_)),
           stream_id_(parent_.random_generator_.random()) {
       parent_.stats_.request_active_.inc();
     }
@@ -191,6 +193,7 @@ private:
   Buffer::OwnedImpl request_buffer_;
   Runtime::RandomGenerator& random_generator_;
   bool stopped_{false};
+  Event::TimeSystem& time_system_;
 };
 
 } // namespace ThriftProxy

--- a/source/extensions/stat_sinks/hystrix/hystrix.cc
+++ b/source/extensions/stat_sinks/hystrix/hystrix.cc
@@ -153,7 +153,7 @@ void HystrixSink::addHystrixCommand(ClusterStatsCache& cluster_stats_cache,
                                     std::chrono::milliseconds rolling_window_ms,
                                     const QuantileLatencyMap& histogram, std::stringstream& ss) {
 
-  std::time_t currentTime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  std::time_t currentTime = std::chrono::system_clock::to_time_t(server_.timeSystem().systemTime());
 
   ss << "data: {";
   addStringToStream("type", "HystrixCommand", ss, true);

--- a/source/extensions/transport_sockets/capture/BUILD
+++ b/source/extensions/transport_sockets/capture/BUILD
@@ -15,6 +15,7 @@ envoy_cc_library(
     srcs = ["capture.cc"],
     hdrs = ["capture.h"],
     deps = [
+        "//include/envoy/event:timer_interface",
         "//include/envoy/network:transport_socket_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",

--- a/source/extensions/transport_sockets/capture/capture.h
+++ b/source/extensions/transport_sockets/capture/capture.h
@@ -4,6 +4,7 @@
 
 #include "envoy/config/transport_socket/capture/v2alpha/capture.pb.h"
 #include "envoy/data/tap/v2alpha/capture.pb.h"
+#include "envoy/event/timer.h"
 #include "envoy/network/transport_socket.h"
 
 namespace Envoy {
@@ -15,7 +16,7 @@ class CaptureSocket : public Network::TransportSocket {
 public:
   CaptureSocket(const std::string& path_prefix,
                 envoy::config::transport_socket::capture::v2alpha::FileSink::Format format,
-                Network::TransportSocketPtr&& transport_socket);
+                Network::TransportSocketPtr&& transport_socket, Event::TimeSystem& time_system);
 
   // Network::TransportSocket
   void setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) override;
@@ -37,13 +38,15 @@ private:
   envoy::data::tap::v2alpha::Trace trace_;
   Network::TransportSocketPtr transport_socket_;
   Network::TransportSocketCallbacks* callbacks_{};
+  Event::TimeSystem& time_system_;
 };
 
 class CaptureSocketFactory : public Network::TransportSocketFactory {
 public:
   CaptureSocketFactory(const std::string& path_prefix,
                        envoy::config::transport_socket::capture::v2alpha::FileSink::Format format,
-                       Network::TransportSocketFactoryPtr&& transport_socket_factory);
+                       Network::TransportSocketFactoryPtr&& transport_socket_factory,
+                       Event::TimeSystem& time_system);
 
   // Network::TransportSocketFactory
   Network::TransportSocketPtr createTransportSocket() const override;
@@ -53,6 +56,7 @@ private:
   const std::string path_prefix_;
   const envoy::config::transport_socket::capture::v2alpha::FileSink::Format format_;
   Network::TransportSocketFactoryPtr transport_socket_factory_;
+  Event::TimeSystem& time_system_;
 };
 
 } // namespace Capture

--- a/source/extensions/transport_sockets/capture/config.cc
+++ b/source/extensions/transport_sockets/capture/config.cc
@@ -26,9 +26,9 @@ Network::TransportSocketFactoryPtr UpstreamCaptureSocketConfigFactory::createTra
       outer_config.transport_socket(), inner_config_factory);
   auto inner_transport_factory =
       inner_config_factory.createTransportSocketFactory(*inner_factory_config, context);
-  return std::make_unique<CaptureSocketFactory>(outer_config.file_sink().path_prefix(),
-                                                outer_config.file_sink().format(),
-                                                std::move(inner_transport_factory));
+  return std::make_unique<CaptureSocketFactory>(
+      outer_config.file_sink().path_prefix(), outer_config.file_sink().format(),
+      std::move(inner_transport_factory), context.dispatcher().timeSystem());
 }
 
 Network::TransportSocketFactoryPtr
@@ -44,9 +44,9 @@ DownstreamCaptureSocketConfigFactory::createTransportSocketFactory(
       outer_config.transport_socket(), inner_config_factory);
   auto inner_transport_factory = inner_config_factory.createTransportSocketFactory(
       *inner_factory_config, context, server_names);
-  return std::make_unique<CaptureSocketFactory>(outer_config.file_sink().path_prefix(),
-                                                outer_config.file_sink().format(),
-                                                std::move(inner_transport_factory));
+  return std::make_unique<CaptureSocketFactory>(
+      outer_config.file_sink().path_prefix(), outer_config.file_sink().format(),
+      std::move(inner_transport_factory), context.dispatcher().timeSystem());
 }
 
 ProtobufTypes::MessagePtr CaptureSocketConfigFactory::createEmptyConfigProto() {

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -219,16 +219,18 @@ void ConnectionHandlerImpl::ActiveListener::onNewConnection(
 
   // If the connection is already closed, we can just let this connection immediately die.
   if (new_connection->state() != Network::Connection::State::Closed) {
-    ActiveConnectionPtr active_connection(new ActiveConnection(*this, std::move(new_connection)));
+    ActiveConnectionPtr active_connection(
+        new ActiveConnection(*this, std::move(new_connection), parent_.dispatcher_.timeSystem()));
     active_connection->moveIntoList(std::move(active_connection), connections_);
     parent_.num_connections_++;
   }
 }
 
 ConnectionHandlerImpl::ActiveConnection::ActiveConnection(ActiveListener& listener,
-                                                          Network::ConnectionPtr&& new_connection)
+                                                          Network::ConnectionPtr&& new_connection,
+                                                          Event::TimeSystem& time_system)
     : listener_(listener), connection_(std::move(new_connection)),
-      conn_length_(new Stats::Timespan(listener_.stats_.downstream_cx_length_ms_)) {
+      conn_length_(new Stats::Timespan(listener_.stats_.downstream_cx_length_ms_, time_system)) {
   // We just universally set no delay on connections. Theoretically we might at some point want
   // to make this configurable.
   connection_->noDelay(true);

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -110,7 +110,8 @@ private:
   struct ActiveConnection : LinkedObject<ActiveConnection>,
                             public Event::DeferredDeletable,
                             public Network::ConnectionCallbacks {
-    ActiveConnection(ActiveListener& listener, Network::ConnectionPtr&& new_connection);
+    ActiveConnection(ActiveListener& listener, Network::ConnectionPtr&& new_connection,
+                     Event::TimeSystem& time_system);
     ~ActiveConnection();
 
     // Network::ConnectionCallbacks

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -974,7 +974,7 @@ bool AdminImpl::createNetworkFilterChain(Network::Connection& connection,
                                          const std::vector<Network::FilterFactoryCb>&) {
   connection.addReadFilter(Network::ReadFilterSharedPtr{new Http::ConnectionManagerImpl(
       *this, server_.drainManager(), server_.random(), server_.httpTracer(), server_.runtime(),
-      server_.localInfo(), server_.clusterManager())});
+      server_.localInfo(), server_.clusterManager(), server_.timeSystem())});
   return true;
 }
 

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -23,6 +23,7 @@
 #include "test/fuzz/fuzz_runner.h"
 #include "test/fuzz/utility.h"
 #include "test/mocks/access_log/mocks.h"
+#include "test/mocks/common.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/local_info/mocks.h"
 #include "test/mocks/network/mocks.h"
@@ -377,6 +378,7 @@ DEFINE_PROTO_FUZZER(const test::common::http::ConnManagerImplTestCase& input) {
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   NiceMock<Upstream::MockClusterManager> cluster_manager;
   NiceMock<Network::MockReadFilterCallbacks> filter_callbacks;
+  NiceMock<MockTimeSystem> time_system;
   std::unique_ptr<Ssl::MockConnection> ssl_connection;
   bool connection_alive = true;
 
@@ -390,7 +392,7 @@ DEFINE_PROTO_FUZZER(const test::common::http::ConnManagerImplTestCase& input) {
       std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0");
 
   ConnectionManagerImpl conn_manager(config, drain_close, random, tracer, runtime, local_info,
-                                     cluster_manager);
+                                     cluster_manager, time_system);
   conn_manager.initializeReadFilterCallbacks(filter_callbacks);
 
   std::vector<FuzzStreamPtr> streams;

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -392,7 +392,7 @@ DEFINE_PROTO_FUZZER(const test::common::http::ConnManagerImplTestCase& input) {
       std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0");
 
   ConnectionManagerImpl conn_manager(config, drain_close, random, tracer, runtime, local_info,
-                                     cluster_manager, time_system, nullptr);
+                                     cluster_manager, nullptr, time_system);
   conn_manager.initializeReadFilterCallbacks(filter_callbacks);
 
   std::vector<FuzzStreamPtr> streams;

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -111,8 +111,8 @@ public:
     filter_callbacks_.connection_.remote_address_ =
         std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0");
     conn_manager_.reset(new ConnectionManagerImpl(*this, drain_close_, random_, tracer_, runtime_,
-                                                  local_info_, cluster_manager_,
-                                                  &overload_manager_, test_time_.timeSystem()));
+                                                  local_info_, cluster_manager_, &overload_manager_,
+                                                  test_time_.timeSystem()));
     conn_manager_->initializeReadFilterCallbacks(filter_callbacks_);
 
     if (tracing) {

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -111,7 +111,8 @@ public:
     filter_callbacks_.connection_.remote_address_ =
         std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0");
     conn_manager_.reset(new ConnectionManagerImpl(*this, drain_close_, random_, tracer_, runtime_,
-                                                  local_info_, cluster_manager_));
+                                                  local_info_, cluster_manager_,
+                                                  test_time_.timeSystem()));
     conn_manager_->initializeReadFilterCallbacks(filter_callbacks_);
 
     if (tracing) {
@@ -216,7 +217,7 @@ public:
               envoy::config::filter::network::tcp_proxy::v2::TcpProxy(), factory_context_));
           auto ret = std::make_unique<Http::WebSocket::WsHandlerImpl>(
               request_headers, request_info, route_entry, callbacks, cluster_manager,
-              read_callbacks, config);
+              read_callbacks, config, test_time_.timeSystem());
           return ret;
         }));
   }

--- a/test/common/http/user_agent_test.cc
+++ b/test/common/http/user_agent_test.cc
@@ -1,6 +1,7 @@
 #include "common/http/header_map_impl.h"
 #include "common/http/user_agent.h"
 
+#include "test/mocks/common.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
@@ -17,7 +18,8 @@ namespace Http {
 TEST(UserAgentTest, All) {
   Stats::MockStore stat_store;
   NiceMock<Stats::MockHistogram> original_histogram;
-  Stats::Timespan span(original_histogram);
+  NiceMock<MockTimeSource> time_source;
+  Stats::Timespan span(original_histogram, time_source);
 
   EXPECT_CALL(stat_store.counter_, inc()).Times(5);
   EXPECT_CALL(stat_store, counter("test.user_agent.ios.downstream_cx_total"));

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -190,7 +190,8 @@ TEST_F(NetworkFilterManagerTest, RateLimitAndTcpProxy) {
   tcp_proxy.set_cluster("fake_cluster");
   TcpProxy::ConfigSharedPtr tcp_proxy_config(new TcpProxy::Config(tcp_proxy, factory_context));
   manager.addReadFilter(
-      std::make_shared<TcpProxy::Filter>(tcp_proxy_config, factory_context.cluster_manager_));
+      std::make_shared<TcpProxy::Filter>(tcp_proxy_config, factory_context.cluster_manager_,
+                                         factory_context.dispatcher().timeSystem()));
 
   RateLimit::RequestCallbacks* request_callbacks{};
   EXPECT_CALL(*rl_client, limit(_, "foo",

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1857,8 +1857,8 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesOutOfWindow) {
   HostVector hosts_added;
   HostVector hosts_removed;
 
-  // The first update should be applied immediately, because even though it's
-  // inside the default merge window of 3 seconds (found in debugger as value of
+  // The first update should be applied immediately, because even though it's mergeable
+  // it's outside the default merge window of 3 seconds (found in debugger as value of
   // cluster.info()->lbConfig().update_merge_window() in ClusterManagerImpl::scheduleUpdate.
   EXPECT_CALL(time_system_, monotonicTime())
       .WillRepeatedly(Return(MonotonicTime(std::chrono::seconds(60))));

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1836,6 +1836,8 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
 
 // Tests that mergeable updates outside of a window get applied immediately.
 TEST_F(ClusterManagerImplTest, MergedUpdatesOutOfWindow) {
+  EXPECT_CALL(time_system_, monotonicTime())
+      .WillRepeatedly(Return(MonotonicTime(std::chrono::seconds(0))));
   createWithLocalClusterUpdate();
 
   // Ensure we see the right set of added/removed hosts on every call.
@@ -1855,14 +1857,44 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesOutOfWindow) {
   HostVector hosts_added;
   HostVector hosts_removed;
 
-  // The first update should be applied immediately, because even though it's mergeable
-  // it's outside a merge window.
+  // The first update should be applied immediately, because even though it's
+  // inside the default merge window of 3 seconds (found in debugger as value of
+  // cluster.info()->lbConfig().update_merge_window() in ClusterManagerImpl::scheduleUpdate.
+  EXPECT_CALL(time_system_, monotonicTime())
+      .WillRepeatedly(Return(MonotonicTime(std::chrono::seconds(60))));
   cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
                                                               hosts_per_locality, {}, hosts_added,
                                                               hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.update_out_of_merge_window").value());
+  EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());
+}
+
+// Tests that mergeable updates inside of a window are not applied immediately.
+TEST_F(ClusterManagerImplTest, MergedUpdatesInsideWindow) {
+  EXPECT_CALL(time_system_, monotonicTime())
+      .WillRepeatedly(Return(MonotonicTime(std::chrono::seconds(0))));
+  createWithLocalClusterUpdate();
+
+  const Cluster& cluster = cluster_manager_->clusters().begin()->second;
+  HostVectorSharedPtr hosts(
+      new HostVector(cluster.prioritySet().hostSetsPerPriority()[0]->hosts()));
+  HostsPerLocalitySharedPtr hosts_per_locality = std::make_shared<HostsPerLocalityImpl>();
+  HostVector hosts_added;
+  HostVector hosts_removed;
+
+  // The first update will not be applied, as we make it inside the default mergeable window of
+  // 3 seconds (found in debugger as value of cluster.info()->lbConfig().update_merge_window()
+  // in ClusterManagerImpl::scheduleUpdate.
+  EXPECT_CALL(time_system_, monotonicTime())
+      .WillRepeatedly(Return(MonotonicTime(std::chrono::seconds(2))));
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
+                                                              hosts_per_locality, {}, hosts_added,
+                                                              hosts_removed, absl::nullopt);
+  EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated").value());
+  EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
+  EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_out_of_merge_window").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());
 }
 

--- a/test/extensions/filters/http/dynamo/dynamo_filter_test.cc
+++ b/test/extensions/filters/http/dynamo/dynamo_filter_test.cc
@@ -33,7 +33,8 @@ public:
         .WillByDefault(Return(enabled));
     EXPECT_CALL(loader_.snapshot_, featureEnabled("dynamodb.filter_enabled", 100));
 
-    filter_.reset(new DynamoFilter(loader_, stat_prefix_, stats_));
+    filter_.reset(new DynamoFilter(loader_, stat_prefix_, stats_,
+                                   decoder_callbacks_.dispatcher().timeSystem()));
 
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);

--- a/test/extensions/filters/http/jwt_authn/BUILD
+++ b/test/extensions/filters/http/jwt_authn/BUILD
@@ -71,6 +71,7 @@ envoy_extension_cc_test(
     deps = [
         ":test_common_lib",
         "//source/extensions/filters/http/jwt_authn:jwks_cache_lib",
+        "//test/test_common:test_time_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/filters/http/jwt_authn/jwks_cache_test.cc
+++ b/test/extensions/filters/http/jwt_authn/jwks_cache_test.cc
@@ -6,6 +6,7 @@
 #include "extensions/filters/http/jwt_authn/jwks_cache.h"
 
 #include "test/extensions/filters/http/jwt_authn/test_common.h"
+#include "test/test_common/test_time.h"
 #include "test/test_common/utility.h"
 
 using ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication;
@@ -21,9 +22,11 @@ class JwksCacheTest : public ::testing::Test {
 public:
   void SetUp() {
     MessageUtil::loadFromYaml(ExampleConfig, config_);
-    cache_ = JwksCache::create(config_);
+    cache_ = JwksCache::create(config_, test_time_.timeSystem());
   }
 
+
+  DangerousDeprecatedTestTime test_time_;
   JwtAuthentication config_;
   JwksCachePtr cache_;
 };
@@ -39,7 +42,7 @@ TEST_F(JwksCacheTest, TestSetRemoteJwks) {
   auto& provider0 = (*config_.mutable_providers())[std::string(ProviderName)];
   // Set cache_duration to 1 second to test expiration
   provider0.mutable_remote_jwks()->mutable_cache_duration()->set_seconds(1);
-  cache_ = JwksCache::create(config_);
+  cache_ = JwksCache::create(config_, test_time_.timeSystem());
 
   auto jwks = cache_->findByIssuer("https://example.com");
   EXPECT_TRUE(jwks->getJwksObj() == nullptr);
@@ -58,7 +61,7 @@ TEST_F(JwksCacheTest, TestSetRemoteJwksWithDefaultCacheDuration) {
   auto& provider0 = (*config_.mutable_providers())[std::string(ProviderName)];
   // Clear cache_duration to use default one.
   provider0.mutable_remote_jwks()->clear_cache_duration();
-  cache_ = JwksCache::create(config_);
+  cache_ = JwksCache::create(config_, test_time_.timeSystem());
 
   auto jwks = cache_->findByIssuer("https://example.com");
   EXPECT_TRUE(jwks->getJwksObj() == nullptr);
@@ -75,7 +78,7 @@ TEST_F(JwksCacheTest, TestGoodInlineJwks) {
   auto local_jwks = provider0.mutable_local_jwks();
   local_jwks->set_inline_string(PublicKey);
 
-  cache_ = JwksCache::create(config_);
+  cache_ = JwksCache::create(config_, test_time_.timeSystem());
 
   auto jwks = cache_->findByIssuer("https://example.com");
   EXPECT_FALSE(jwks->getJwksObj() == nullptr);
@@ -89,7 +92,7 @@ TEST_F(JwksCacheTest, TestBadInlineJwks) {
   auto local_jwks = provider0.mutable_local_jwks();
   local_jwks->set_inline_string("BAD-JWKS");
 
-  cache_ = JwksCache::create(config_);
+  cache_ = JwksCache::create(config_, test_time_.timeSystem());
 
   auto jwks = cache_->findByIssuer("https://example.com");
   EXPECT_TRUE(jwks->getJwksObj() == nullptr);

--- a/test/extensions/filters/http/jwt_authn/jwks_cache_test.cc
+++ b/test/extensions/filters/http/jwt_authn/jwks_cache_test.cc
@@ -25,7 +25,6 @@ public:
     cache_ = JwksCache::create(config_, test_time_.timeSystem());
   }
 
-
   DangerousDeprecatedTestTime test_time_;
   JwtAuthentication config_;
   JwksCachePtr cache_;

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1530,7 +1530,8 @@ TEST_F(LuaHttpFilterTest, SetGetDynamicMetadata) {
   setup(SCRIPT);
 
   Http::TestHeaderMapImpl request_headers{{":path", "/"}};
-  RequestInfo::RequestInfoImpl request_info(Http::Protocol::Http2);
+  DangerousDeprecatedTestTime test_time;
+  RequestInfo::RequestInfoImpl request_info(Http::Protocol::Http2, test_time.timeSystem());
   EXPECT_EQ(0, request_info.dynamicMetadata().filter_metadata_size());
   EXPECT_CALL(decoder_callbacks_, requestInfo()).WillOnce(ReturnRef(request_info));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("bar")));

--- a/test/extensions/filters/http/lua/wrappers_test.cc
+++ b/test/extensions/filters/http/lua/wrappers_test.cc
@@ -251,6 +251,8 @@ protected:
     MessageUtil::loadFromYaml(yaml_string, metadata);
     return metadata;
   }
+
+  DangerousDeprecatedTestTime test_time_;
 };
 
 // Return the current request protocol.
@@ -287,7 +289,7 @@ TEST_F(LuaRequestInfoWrapperTest, SetGetAndIterateDynamicMetadata) {
   InSequence s;
   setup(SCRIPT);
 
-  RequestInfo::RequestInfoImpl request_info(Http::Protocol::Http2);
+  RequestInfo::RequestInfoImpl request_info(Http::Protocol::Http2, test_time_.timeSystem());
   EXPECT_EQ(0, request_info.dynamicMetadata().filter_metadata_size());
   Filters::Common::Lua::LuaDeathRef<RequestInfoWrapper> wrapper(
       RequestInfoWrapper::create(coroutine_->luaState(), request_info), true);
@@ -323,7 +325,7 @@ TEST_F(LuaRequestInfoWrapperTest, ModifyDuringIterationForDynamicMetadata) {
   InSequence s;
   setup(SCRIPT);
 
-  RequestInfo::RequestInfoImpl request_info(Http::Protocol::Http2);
+  RequestInfo::RequestInfoImpl request_info(Http::Protocol::Http2, test_time_.timeSystem());
   Filters::Common::Lua::LuaDeathRef<RequestInfoWrapper> wrapper(
       RequestInfoWrapper::create(coroutine_->luaState(), request_info), true);
   EXPECT_THROW_WITH_MESSAGE(
@@ -357,7 +359,7 @@ TEST_F(LuaRequestInfoWrapperTest, ModifyAfterIterationForDynamicMetadata) {
   InSequence s;
   setup(SCRIPT);
 
-  RequestInfo::RequestInfoImpl request_info(Http::Protocol::Http2);
+  RequestInfo::RequestInfoImpl request_info(Http::Protocol::Http2, test_time_.timeSystem());
   EXPECT_EQ(0, request_info.dynamicMetadata().filter_metadata_size());
   Filters::Common::Lua::LuaDeathRef<RequestInfoWrapper> wrapper(
       RequestInfoWrapper::create(coroutine_->luaState(), request_info), true);
@@ -384,7 +386,7 @@ TEST_F(LuaRequestInfoWrapperTest, DontFinishIterationForDynamicMetadata) {
   InSequence s;
   setup(SCRIPT);
 
-  RequestInfo::RequestInfoImpl request_info(Http::Protocol::Http2);
+  RequestInfo::RequestInfoImpl request_info(Http::Protocol::Http2, test_time_.timeSystem());
   Filters::Common::Lua::LuaDeathRef<RequestInfoWrapper> wrapper(
       RequestInfoWrapper::create(coroutine_->luaState(), request_info), true);
   EXPECT_THROW_WITH_MESSAGE(

--- a/test/extensions/filters/network/mongo_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/proxy_test.cc
@@ -70,12 +70,12 @@ public:
         .WillByDefault(Return(true));
 
     EXPECT_CALL(log_manager_, createAccessLog(_)).WillOnce(Return(file_));
-    access_log_.reset(new AccessLog("test", log_manager_));
+    access_log_.reset(new AccessLog("test", log_manager_, dispatcher_.timeSystem()));
   }
 
   void initializeFilter() {
     filter_.reset(new TestProxyFilter("test.", store_, runtime_, access_log_, fault_config_,
-                                      drain_decision_, generator_));
+                                      drain_decision_, generator_, dispatcher_.timeSystem()));
     filter_->initializeReadFilterCallbacks(read_filter_callbacks_);
     filter_->onNewConnection();
 

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -100,7 +100,8 @@ public:
     }
 
     ON_CALL(random_, random()).WillByDefault(Return(42));
-    filter_.reset(new ConnectionManager(*config_, random_));
+    filter_.reset(new ConnectionManager(*config_, random_,
+                                        filter_callbacks_.connection_.dispatcher_.timeSystem()));
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
     filter_->onNewConnection();
 

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -292,9 +292,9 @@ public:
 
   Buffer::OwnedImpl buffer_;
   Buffer::OwnedImpl write_buffer_;
-  std::unique_ptr<ConnectionManager> filter_;
   NiceMock<Network::MockReadFilterCallbacks> filter_callbacks_;
   NiceMock<Runtime::MockRandomGenerator> random_;
+  std::unique_ptr<ConnectionManager> filter_;
   MockTransport* custom_transport_{};
   MockProtocol* custom_protocol_{};
 };

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -154,7 +154,8 @@ bool RouterCheckTool::compareVirtualHost(ToolConfig& tool_config, const std::str
 
 bool RouterCheckTool::compareRewritePath(ToolConfig& tool_config, const std::string& expected) {
   std::string actual = "";
-  Envoy::RequestInfo::RequestInfoImpl request_info(Envoy::Http::Protocol::Http11);
+  Envoy::RequestInfo::RequestInfoImpl request_info(Envoy::Http::Protocol::Http11,
+                                                   factory_context_->dispatcher().timeSystem());
   if (tool_config.route_->routeEntry() != nullptr) {
     tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, request_info,
                                                              true);
@@ -165,7 +166,8 @@ bool RouterCheckTool::compareRewritePath(ToolConfig& tool_config, const std::str
 
 bool RouterCheckTool::compareRewriteHost(ToolConfig& tool_config, const std::string& expected) {
   std::string actual = "";
-  Envoy::RequestInfo::RequestInfoImpl request_info(Envoy::Http::Protocol::Http11);
+  Envoy::RequestInfo::RequestInfoImpl request_info(Envoy::Http::Protocol::Http11,
+                                                   factory_context_->dispatcher().timeSystem());
   if (tool_config.route_->routeEntry() != nullptr) {
     tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, request_info,
                                                              true);
@@ -192,7 +194,8 @@ bool RouterCheckTool::compareHeaderField(ToolConfig& tool_config, const std::str
 bool RouterCheckTool::compareCustomHeaderField(ToolConfig& tool_config, const std::string& field,
                                                const std::string& expected) {
   std::string actual = "";
-  Envoy::RequestInfo::RequestInfoImpl request_info(Envoy::Http::Protocol::Http11);
+  Envoy::RequestInfo::RequestInfoImpl request_info(Envoy::Http::Protocol::Http11,
+                                                   factory_context_->dispatcher().timeSystem());
   request_info.setDownstreamRemoteAddress(Network::Utility::getCanonicalIpv4LoopbackAddress());
   if (tool_config.route_->routeEntry() != nullptr) {
     tool_config.route_->routeEntry()->finalizeRequestHeaders(*tool_config.headers_, request_info,

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -167,7 +167,8 @@ def checkSourceLine(line, file_path, reportError):
     # legitimately show up in comments, for example this one.
     reportError("Don't use <shared_mutex>, use absl::Mutex for reader/writer locks.")
   if not whitelistedForRealTime(file_path):
-    if 'RealTimeSource' in line or 'RealTimeSystem' in line:
+    if 'RealTimeSource' in line or 'RealTimeSystem' in line or \
+       'std::chrono::system_clock::now' in line or 'std::chrono::steady_clock::now' in line:
       reportError("Don't reference real-world time sources from production code; use injection")
 
 def checkBuildLine(line, file_path, reportError):

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -87,7 +87,7 @@ def emitStdoutAsError(stdout):
 
 def expectError(status, stdout, expected_substring):
   if status == 0:
-    logging.error("Expected failure, but succeeded")
+    logging.error("Expected failure `%s`, but succeeded" % expected_substring)
     return 1
   for line in stdout:
     if expected_substring in line:
@@ -152,6 +152,8 @@ if __name__ == "__main__":
       "Don't reference real-world time sources from production code; use injection")
   errors += fixFileExpectingFailure("real_time_source.cc", real_time_inject_error)
   errors += fixFileExpectingFailure("real_time_system.cc", real_time_inject_error)
+  errors += fixFileExpectingFailure("system_clock.cc", real_time_inject_error)
+  errors += fixFileExpectingFailure("steady_clock.cc", real_time_inject_error)
 
   errors += fixFileExpectingNoChange("ok_file.cc")
 
@@ -174,6 +176,8 @@ if __name__ == "__main__":
   errors += checkFileExpectingError("proto_format.proto", "clang-format check failed")
   errors += checkFileExpectingError("real_time_source.cc", real_time_inject_error)
   errors += checkFileExpectingError("real_time_system.cc", real_time_inject_error)
+  errors += checkFileExpectingError("system_clock.cc", real_time_inject_error)
+  errors += checkFileExpectingError("steady_clock.cc", real_time_inject_error)
   errors += checkFileExpectingError("std_atomic_free_functions.cc", "std::atomic_*")
   errors += fixFileExpectingFailure("std_atomic_free_functions.cc", "std::atomic_*")
 

--- a/tools/testdata/check_format/steady_clock.cc
+++ b/tools/testdata/check_format/steady_clock.cc
@@ -1,0 +1,5 @@
+namespace Envoy {
+
+int foo() { return std::chrono::steady_clock::now(); }
+
+} // namespace Envoy

--- a/tools/testdata/check_format/system_clock.cc
+++ b/tools/testdata/check_format/system_clock.cc
@@ -1,0 +1,5 @@
+namespace Envoy {
+
+int foo() { return std::chrono::system_clock::now(); }
+
+} // namespace Envoy


### PR DESCRIPTION
*Description*: In order to fully control time during tests, direct calls to system-provided time functions must not be used. These had previously not been fixed. In at least one case I think there was real-time deltas being compared in a test, which really needed to be mocked, so that change had to occur in this PR. Another step toward resolution of #4160
*Risk Level*: medium, due to size of PR.
*Testing*: //test/...
*Docs Changes*: n/a
*Release Notes*: n/a
[Optional Fixes #Issue]
[Optional *Deprecated*:]
