### PR TITLE
logger: introduce scoped Logger::Context which avoids holding onto a stale lock during tests

### DIFF
--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -64,19 +64,19 @@ Context::Context(spdlog::level::level_enum log_level, const std::string& log_for
                  Thread::BasicLockable& lock)
     : log_level_(log_level), log_format_(log_format), lock_(lock), save_context_(current_context) {
   current_context = this;
-  restore();
+  activate();
 }
 
 Context::~Context() {
   current_context = save_context_;
   if (current_context != nullptr) {
-    current_context->restore();
+    current_context->activate();
   } else {
     Registry::getSink()->clearLock();
   }
 }
 
-void Context::restore() {
+void Context::activate() {
   Registry::getSink()->setLock(lock_);
   Registry::setLogLevel(log_level_);
   Registry::setLogFormat(log_format_);

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -58,14 +58,28 @@ DelegatingLogSinkPtr DelegatingLogSink::init() {
   return delegating_sink;
 }
 
-void Registry::initialize(spdlog::level::level_enum log_level, const std::string& log_format,
-                          Thread::BasicLockable& lock) {
-  // TODO(jmarantz): I think it would be more robust to push a separate lockable
-  // SinkDelegate onto the stack for the lifetime of the lock, so we don't crash
-  // if we try to log anything after the context owning the lock is destroyed.
-  getSink()->setLock(lock);
-  setLogLevel(log_level);
-  setLogFormat(log_format);
+static Context* current_context = nullptr;
+
+Context::Context(spdlog::level::level_enum log_level, const std::string& log_format,
+                 Thread::BasicLockable& lock)
+    : log_level_(log_level), log_format_(log_format), lock_(lock), save_context_(current_context) {
+  current_context = this;
+  restore();
+}
+
+Context::~Context() {
+  current_context = save_context_;
+  if (current_context != nullptr) {
+    current_context->restore();
+  } else {
+    Registry::getSink()->clearLock();
+  }
+}
+
+void Context::restore() {
+  Registry::getSink()->setLock(lock_);
+  Registry::setLogLevel(log_level_);
+  Registry::setLogFormat(log_format_);
 }
 
 std::vector<Logger>& Registry::allLoggers() {

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -190,12 +190,12 @@ public:
   ~Context();
 
 private:
-  void restore();
+  void activate();
 
-  spdlog::level::level_enum log_level_;
-  std::string log_format_;
+  const spdlog::level::level_enum log_level_;
+  const std::string log_format_;
   Thread::BasicLockable& lock_;
-  Context* save_context_;
+  Context* const save_context_;
 };
 
 /**

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -172,14 +172,16 @@ private:
   std::unique_ptr<StderrSinkDelegate> stderr_sink_; // Builtin sink to use as a last resort.
 };
 
-// Defines a scope in which logging can occur. This context should stay alive
-// whenever logging should be enabled. If a context is instantiated while
-// another is active, the old one will be restored on destruction.
 /**
- * Initialize the logging system with the specified lock and log level.
- * This is equivalalent to setLogLevel, setLogFormat, and setLock, which
- * can be called individually as well, e.g. to set the log level without
- * changing the lock or format.
+ * Defines a scope for the logging system with the specified lock and log level.
+ * This is equivalalent to setLogLevel, setLogFormat, and setLock, which can be
+ * called individually as well, e.g. to set the log level without changing the
+ * lock or format.
+ *
+ * Contexts can be nested. When a nested context is destroyed, the previous
+ * context is restored. When all contexts are destroyed, the lock is cleared,
+ * and logging will remain unlocked, the same state it is in prior to
+ * instantiating a Context.
  */
 class Context {
 public:

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -59,7 +59,8 @@ MainCommonBase::MainCommonBase(OptionsImpl& options) : options_(options) {
     Thread::BasicLockable& log_lock = restarter_->logLock();
     Thread::BasicLockable& access_log_lock = restarter_->accessLogLock();
     auto local_address = Network::Utility::getLocalAddress(options_.localAddressIpVersion());
-    Logger::Registry::initialize(options_.logLevel(), options_.logFormat(), log_lock);
+    logging_context_ =
+        std::make_unique<Logger::Context>(options_.logLevel(), options_.logFormat(), log_lock);
 
     stats_store_ = std::make_unique<Stats::ThreadLocalStoreImpl>(options_.statsOptions(),
                                                                  restarter_->statsAllocator());
@@ -72,7 +73,8 @@ MainCommonBase::MainCommonBase(OptionsImpl& options) : options_(options) {
   }
   case Server::Mode::Validate:
     restarter_.reset(new Server::HotRestartNopImpl());
-    Logger::Registry::initialize(options_.logLevel(), options_.logFormat(), restarter_->logLock());
+    logging_context_ = std::make_unique<Logger::Context>(options_.logLevel(), options_.logFormat(),
+                                                         restarter_->logLock());
     break;
   }
 }

--- a/source/exe/main_common.h
+++ b/source/exe/main_common.h
@@ -55,6 +55,7 @@ protected:
   std::unique_ptr<ThreadLocal::InstanceImpl> tls_;
   std::unique_ptr<Server::HotRestart> restarter_;
   std::unique_ptr<Stats::ThreadLocalStoreImpl> stats_store_;
+  std::unique_ptr<Logger::Context> logging_context_;
   std::unique_ptr<Server::InstanceImpl> server_;
 };
 

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -349,8 +349,8 @@ int main(int argc, char** argv) {
   // TODO(mattklein123): Provide a common bazel benchmark wrapper much like we do for normal tests,
   // fuzz, etc.
   Envoy::Thread::MutexBasicLockable lock;
-  Envoy::Logger::Registry::initialize(spdlog::level::warn,
-                                      Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock);
+  Envoy::Logger::Context logging_context(spdlog::level::warn,
+                                         Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock);
 
   benchmark::Initialize(&argc, argv);
   if (benchmark::ReportUnrecognizedArguments(argc, argv)) {

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -1,11 +1,3 @@
-// MainCommonTest works fine in coverage tests, but it appears to break SignalsTest when
-// run in the same process. It appears that MainCommon doesn't completely clean up after
-// itself, possibly due to a bug in SignalAction. So for now, we can test MainCommon
-// but can't measure its test coverage.
-//
-// TODO(issues/2580): Fix coverage tests when MainCommonTest is enabled.
-#ifndef ENVOY_CONFIG_COVERAGE
-
 #include <unistd.h>
 
 #include "common/common/lock_guard.h"
@@ -312,10 +304,15 @@ TEST_P(AdminRequestTest, AdminRequestAfterRun) {
   EXPECT_EQ(1, lambda_destroy_count);
 }
 
+// Verifies that the Logger::Registry is usable after constructing and
+// destructing MainCommon.
+TEST_P(MainCommonTest, ConstructDestructLogger) {
+  VERBOSE_EXPECT_NO_THROW(MainCommon main_common(argc(), argv()));
+  Logger::Registry::getSink()->log({});
+}
+
 INSTANTIATE_TEST_CASE_P(IpVersions, AdminRequestTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
 } // namespace Envoy
-
-#endif // ENVOY_CONFIG_COVERAGE

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
@@ -106,8 +106,8 @@ BENCHMARK(BM_TlsInspector)->Unit(benchmark::kMicrosecond);
 // Boilerplate main(), which discovers benchmarks in the same file and runs them.
 int main(int argc, char** argv) {
   Envoy::Thread::MutexBasicLockable lock;
-  Envoy::Logger::Registry::initialize(spdlog::level::warn,
-                                      Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock);
+  Envoy::Logger::Context logging_context(spdlog::level::warn,
+                                         Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock);
 
   benchmark::Initialize(&argc, argv);
   if (benchmark::ReportUnrecognizedArguments(argc, argv)) {

--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -1,7 +1,5 @@
 #include "test/fuzz/fuzz_runner.h"
 
-#include "common/common/logger.h"
-#include "common/common/thread.h"
 #include "common/common/utility.h"
 #include "common/event/libevent.h"
 
@@ -26,14 +24,12 @@ void Runner::setupEnvironment(int argc, char** argv, spdlog::level::level_enum d
 
   TestEnvironment::initializeOptions(argc, argv);
 
-  static auto* lock = new Thread::MutexBasicLockable();
   const auto environment_log_level = TestEnvironment::getOptions().logLevel();
   // We only override the default log level if it looks like we're debugging;
   // otherwise the default environment log level might override the default and
   // spew too much when running under a fuzz engine.
   log_level_ =
       environment_log_level <= spdlog::level::debug ? environment_log_level : default_log_level;
-  Logger::Registry::initialize(log_level_, TestEnvironment::getOptions().logFormat(), *lock);
 }
 
 } // namespace Fuzz

--- a/test/fuzz/main.cc
+++ b/test/fuzz/main.cc
@@ -14,6 +14,7 @@
 
 #include "common/common/assert.h"
 #include "common/common/logger.h"
+#include "common/common/thread.h"
 #include "common/filesystem/filesystem_impl.h"
 
 #include "test/fuzz/fuzz_runner.h"
@@ -52,5 +53,9 @@ int main(int argc, char** argv) {
   Envoy::test_corpus_ = Envoy::TestUtility::listFiles(corpus_path, true);
   testing::InitGoogleTest(&argc, argv);
   Envoy::Fuzz::Runner::setupEnvironment(argc, argv, spdlog::level::info);
+  Envoy::Thread::MutexBasicLockable lock;
+  Envoy::Logger::Context logging_context(Envoy::Fuzz::Runner::logLevel(),
+                                         Envoy::TestEnvironment::getOptions().logFormat(), lock);
+
   return RUN_ALL_TESTS();
 }

--- a/test/test_runner.h
+++ b/test/test_runner.h
@@ -30,8 +30,8 @@ public:
 
     TestEnvironment::initializeOptions(argc, argv);
     Thread::MutexBasicLockable lock;
-    Logger::Registry::initialize(TestEnvironment::getOptions().logLevel(),
-                                 TestEnvironment::getOptions().logFormat(), lock);
+    Logger::Context logging_state(TestEnvironment::getOptions().logLevel(),
+                                  TestEnvironment::getOptions().logFormat(), lock);
 
     // Allocate fake log access manager.
     testing::NiceMock<AccessLog::MockAccessLogManager> access_log_manager;

--- a/test/tools/config_load_check/config_load_check.cc
+++ b/test/tools/config_load_check/config_load_check.cc
@@ -25,8 +25,8 @@ int main(int argc, char* argv[]) {
 
     Envoy::Event::Libevent::Global::initialize();
     Envoy::Thread::MutexBasicLockable lock;
-    Envoy::Logger::Registry::initialize(static_cast<spdlog::level::level_enum>(2),
-                                        Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock);
+    Envoy::Logger::Context logging_context(static_cast<spdlog::level::level_enum>(2),
+                                           Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock);
 
     const uint32_t num_tested = Envoy::ConfigTest::run(std::string(argv[1]));
     std::cout << fmt::format("Configs tested: {}. ", num_tested);


### PR DESCRIPTION
*Description*: The current `Logger::Registry::initialize(lock ...)` pattern stores a reference to a lock until the process exits or `initialize` is called again, which may outlive the lock. It's better to scope the logger context explicitly so we don't hold onto locks too long. Also note that different test fixtures may interact poorly here, especially during coverage tests where all tests are run in the same process.

*Risk Level*: low
*Testing*: //test/...
*Docs Changes*: n/a
*Release Notes*: n/a
Fixes #Issue: https://github.com/envoyproxy/envoy/issues/4396 and https://github.com/envoyproxy/envoy/issues/2580