### PR TITLE
upstream: additional log lines during cluster initialization

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -116,6 +116,7 @@ void ClusterManagerInitHelper::maybeFinishInitialize() {
       for (auto iter = secondary_init_clusters_.begin(); iter != secondary_init_clusters_.end();) {
         Cluster* cluster = *iter;
         ++iter;
+        ENVOY_LOG(debug, "initializing secondary cluster {}", cluster->info()->name());
         cluster->initialize([cluster, this] { onClusterInit(*cluster); });
       }
     }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -577,7 +577,7 @@ void ClusterImplBase::onPreInitComplete() {
   }
   initialization_started_ = true;
 
-  ENVOY_LOG(debug, "initializing secondary cluster {} completed", cluster->info()->name());
+  ENVOY_LOG(debug, "initializing secondary cluster {} completed", info()->name());
   init_manager_.initialize([this]() { onInitDone(); });
 }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -577,6 +577,7 @@ void ClusterImplBase::onPreInitComplete() {
   }
   initialization_started_ = true;
 
+  ENVOY_LOG(debug, "initializing secondary cluster {} completed", cluster->info()->name());
   init_manager_.initialize([this]() { onInitDone(); });
 }
 


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*: When Envoy is stuck during secondary cluster initialization because management server does not respond back with Endpoints of any cluster, Envoy just prints the line
"cm init: initializing secondary clusters" and stays there. It is very difficult to debug which cluster initialization is causing Envoy to wait for ever.

Added couple of log lines that would help to figure out that details.
*Risk Level*: Low
*Testing*: N/A
*Docs Changes*: N/A
*Release Notes*: N/A

