### PR TITLE
docs: show deprecation of `ssl.alt_alpn`

### DIFF
--- a/docs/root/configuration/listeners/runtime.rst
+++ b/docs/root/configuration/listeners/runtime.rst
@@ -4,5 +4,5 @@ Runtime
 Listeners support the following runtime settings:
 
 ssl.alt_alpn
-  What % of requests use the configured :ref:`alt_alpn <config_listener_ssl_context_alt_alpn>`
+  **Deprecated in v2.** What % of requests use the configured :ref:`alt_alpn <config_listener_ssl_context_alt_alpn>`
   protocol string. Defaults to 0.

--- a/docs/root/configuration/listeners/runtime.rst
+++ b/docs/root/configuration/listeners/runtime.rst
@@ -4,5 +4,5 @@ Runtime
 Listeners support the following runtime settings:
 
 ssl.alt_alpn
-  **Deprecated in v2.** What % of requests use the configured :ref:`alt_alpn <config_listener_ssl_context_alt_alpn>`
+  *(deprecated)* What % of requests use the configured :ref:`alt_alpn <config_listener_ssl_context_alt_alpn>`
   protocol string. Defaults to 0.


### PR DESCRIPTION
*Description*:

In working on #4415, I found Envoy has no compatible configuration with `alt_alpn` in v2 xDS API. This configuration seems to be depreated in v2. If that is true, I think the relative documentation should show the deprecation status of it.

The field seems to be in deprecated support status in v2 xDS API: https://github.com/envoyproxy/envoy/blob/15cfc5ad1a4d622126f642fa70699af753a2d310/api/envoy/api/v2/auth/cert.proto#L257-L262

Probably deprecated in this PR: https://github.com/envoyproxy/data-plane-api/pull/118

One thing I'm thinking about is this deprecation should be on the DEPRECATED.md doc?

*Risk Level*: N/A, documentation only.
*Testing*: N/A
*Docs Changes*: N/A
*Release Notes*: N/A
