### PR TITLE
thrift proxy RFC: Adding timeouts to RouteAction

### DIFF
--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
@@ -3,9 +3,9 @@ syntax = "proto3";
 package envoy.config.filter.network.thrift_proxy.v2alpha1;
 option go_package = "v2";
 
-import "envoy/api/v2/core/base.proto";
 import "envoy/api/v2/route/route.proto";
 
+import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
@@ -92,6 +92,11 @@ message RouteAction {
   // with values there taking precedence. Keys and values should be provided under the "envoy.lb"
   // metadata key.
   envoy.api.v2.core.Metadata metadata_match = 3;
+
+  // Specifies the upstream timeout for the route. If not specified, the default is 15s. This
+  // spans between the point at which the entire downstream request (i.e. end-of-stream) has been
+  // processed and when the upstream response has been completely processed.
+  google.protobuf.Duration timeout = 4 [(gogoproto.stdduration) = true];
 }
 
 // Allows for specification of multiple upstream clusters along with weights that indicate the

--- a/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
+++ b/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.config.filter.network.thrift_proxy.v2alpha1;
 option go_package = "v2";
 
+import "envoy/api/v2/core/base.proto";
 import "envoy/api/v2/route/route.proto";
 
 import "google/protobuf/duration.proto";

--- a/source/extensions/filters/network/thrift_proxy/config.cc
+++ b/source/extensions/filters/network/thrift_proxy/config.cc
@@ -109,7 +109,7 @@ Network::FilterFactoryCb ThriftProxyFilterConfigFactory::createFilterFactoryFrom
 
   return [filter_config, &context](Network::FilterManager& filter_manager) -> void {
     filter_manager.addReadFilter(std::make_shared<ConnectionManager>(
-        *filter_config, context.random(), context.dispatcher().timeSystem()));
+        *filter_config, context.random(), context.dispatcher()));
   };
 }
 

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -16,11 +16,12 @@ namespace NetworkFilters {
 namespace ThriftProxy {
 
 ConnectionManager::ConnectionManager(Config& config, Runtime::RandomGenerator& random_generator,
-                                     Event::TimeSystem& time_system)
+                                     Event::Dispatcher& dispatcher)
     : config_(config), stats_(config_.stats()), transport_(config.createTransport()),
       protocol_(config.createProtocol()),
       decoder_(std::make_unique<Decoder>(*transport_, *protocol_, *this)),
-      random_generator_(random_generator), time_system_(time_system) {}
+      random_generator_(random_generator), time_system_(dispatcher.timeSystem()),
+      dispatcher_(dispatcher) {}
 
 ConnectionManager::~ConnectionManager() {}
 
@@ -378,6 +379,8 @@ bool ConnectionManager::ActiveRpc::upstreamData(Buffer::Instance& buffer) {
 void ConnectionManager::ActiveRpc::resetDownstreamConnection() {
   parent_.read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
 }
+
+Event::Dispatcher& ConnectionManager::ActiveRpc::dispatcher() const { return parent_.dispatcher(); }
 
 } // namespace ThriftProxy
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.h
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.h
@@ -2,6 +2,7 @@
 
 #include "envoy/common/pure.h"
 #include "envoy/event/deferred_deletable.h"
+#include "envoy/event/dispatcher.h"
 #include "envoy/network/connection.h"
 #include "envoy/network/filter.h"
 #include "envoy/runtime/runtime.h"
@@ -57,7 +58,7 @@ class ConnectionManager : public Network::ReadFilter,
                           Logger::Loggable<Logger::Id::thrift> {
 public:
   ConnectionManager(Config& config, Runtime::RandomGenerator& random_generator,
-                    Event::TimeSystem& time_system);
+                    Event::Dispatcher& dispatcher);
   ~ConnectionManager();
 
   // Network::ReadFilter
@@ -72,6 +73,8 @@ public:
 
   // DecoderCallbacks
   DecoderEventHandler& newDecoderEventHandler() override;
+
+  Event::Dispatcher& dispatcher() const { return dispatcher_; }
 
 private:
   struct ActiveRpc;
@@ -148,6 +151,7 @@ private:
     void startUpstreamResponse(Transport& transport, Protocol& protocol) override;
     bool upstreamData(Buffer::Instance& buffer) override;
     void resetDownstreamConnection() override;
+    Event::Dispatcher& dispatcher() const override;
 
     // Thrift::FilterChainFactoryCallbacks
     void addDecoderFilter(ThriftFilters::DecoderFilterSharedPtr filter) override {
@@ -194,7 +198,9 @@ private:
   Runtime::RandomGenerator& random_generator_;
   bool stopped_{false};
   bool half_closed_{false};
+
   Event::TimeSystem& time_system_;
+  Event::Dispatcher& dispatcher_;
 };
 
 } // namespace ThriftProxy

--- a/source/extensions/filters/network/thrift_proxy/filters/filter.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/filter.h
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "envoy/buffer/buffer.h"
+#include "envoy/event/dispatcher.h"
 #include "envoy/network/connection.h"
 
 #include "extensions/filters/network/thrift_proxy/decoder_events.h"
@@ -84,6 +85,11 @@ public:
    * Reset the downstream connection.
    */
   virtual void resetDownstreamConnection() PURE;
+
+  /**
+   * @return const Event::Dispatcher& the thread local dispatcher for allocating timers, etc.
+   */
+  virtual Event::Dispatcher& dispatcher() const PURE;
 };
 
 /**

--- a/source/extensions/filters/network/thrift_proxy/router/router.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router.h
@@ -30,6 +30,11 @@ public:
    * selecting an upstream host
    */
   virtual const Envoy::Router::MetadataMatchCriteria* metadataMatchCriteria() const PURE;
+
+  /**
+   * @return std::chrono::milliseconds the route's timeout.
+   */
+  virtual std::chrono::milliseconds timeout() const PURE;
 };
 
 /**

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -455,7 +455,6 @@ void Router::UpstreamRequest::onRequestStart(bool continue_decoding) {
     parent_.callbacks_->continueDecoding();
   }
 }
-
 void Router::UpstreamRequest::onRequestComplete() { request_complete_ = true; }
 
 void Router::UpstreamRequest::onResponseComplete() {

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -231,6 +231,7 @@ FilterStatus Router::messageBegin(MessageMetadataSharedPtr metadata) {
   }
 
   route_entry_ = route_->routeEntry();
+  timeout_ = route_entry_->timeout();
 
   Upstream::ThreadLocalCluster* cluster = cluster_manager_.get(route_entry_->clusterName());
   if (!cluster) {
@@ -368,7 +369,14 @@ void Router::convertMessageBegin(MessageMetadataSharedPtr metadata) {
   ProtocolConverter::messageBegin(metadata);
 }
 
-void Router::cleanup() { upstream_request_.reset(); }
+void Router::cleanup() {
+  upstream_request_.reset();
+
+  if (response_timer_) {
+    response_timer_->disableTimer();
+    response_timer_.reset();
+  }
+}
 
 Router::UpstreamRequest::UpstreamRequest(Router& parent, Tcp::ConnectionPool::Instance& pool,
                                          MessageMetadataSharedPtr& metadata,
@@ -455,7 +463,29 @@ void Router::UpstreamRequest::onRequestStart(bool continue_decoding) {
     parent_.callbacks_->continueDecoding();
   }
 }
-void Router::UpstreamRequest::onRequestComplete() { request_complete_ = true; }
+void Router::UpstreamRequest::onRequestComplete() {
+  request_complete_ = true;
+
+  if (parent_.timeout_.count() > 0) {
+    parent_.response_timer_ = parent_.callbacks_->dispatcher().createTimer(
+        [this]() -> void { parent_.onResponseTimeout(); });
+    parent_.response_timer_->enableTimer(parent_.timeout_);
+  }
+}
+
+void Router::onResponseTimeout() {
+  ENVOY_STREAM_LOG(debug, "upstream timeout", *callbacks_);
+  cluster_->stats().upstream_rq_timeout_.inc();
+
+  if (upstream_request_) {
+    if (upstream_request_->upstream_host_) {
+      upstream_request_->upstream_host_->stats().rq_timeout_.inc();
+    }
+  }
+  cleanup();
+  callbacks_->sendLocalReply(
+      AppException(AppExceptionType::InternalError, fmt::format("upstream request timeout")));
+}
 
 void Router::UpstreamRequest::onResponseComplete() {
   response_complete_ = true;

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -18,7 +18,8 @@ namespace Router {
 
 RouteEntryImplBase::RouteEntryImplBase(
     const envoy::config::filter::network::thrift_proxy::v2alpha1::Route& route)
-    : cluster_name_(route.route().cluster()) {
+    : cluster_name_(route.route().cluster()),
+      timeout_(PROTOBUF_GET_MS_OR_DEFAULT(route.route(), timeout, 15000)) {
   for (const auto& header_map : route.match().headers()) {
     config_headers_.push_back(header_map);
   }

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -45,6 +45,8 @@ public:
   virtual RouteConstSharedPtr matches(const MessageMetadata& metadata,
                                       uint64_t random_value) const PURE;
 
+  std::chrono::milliseconds timeout() const { return timeout_; }
+
 protected:
   RouteConstSharedPtr clusterEntry(uint64_t random_value) const;
   bool headersMatch(const Http::HeaderMap& headers) const;
@@ -83,8 +85,8 @@ private:
   const std::string cluster_name_;
   std::vector<Http::HeaderUtility::HeaderData> config_headers_;
   std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
-  uint64_t total_cluster_weight_;
   Envoy::Router::MetadataMatchCriteriaConstPtr metadata_match_criteria_;
+  const std::chrono::milliseconds timeout_;
 };
 
 typedef std::shared_ptr<const RouteEntryImplBase> RouteEntryImplBaseConstSharedPtr;

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -85,6 +85,7 @@ private:
   const std::string cluster_name_;
   std::vector<Http::HeaderUtility::HeaderData> config_headers_;
   std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
+  uint64_t total_cluster_weight_;
   Envoy::Router::MetadataMatchCriteriaConstPtr metadata_match_criteria_;
   const std::chrono::milliseconds timeout_;
 };

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -45,7 +45,7 @@ public:
   virtual RouteConstSharedPtr matches(const MessageMetadata& metadata,
                                       uint64_t random_value) const PURE;
 
-  std::chrono::milliseconds timeout() const { return timeout_; }
+  std::chrono::milliseconds timeout() const override { return timeout_; }
 
 protected:
   RouteConstSharedPtr clusterEntry(uint64_t random_value) const;
@@ -70,6 +70,7 @@ private:
 
       return parent_.metadataMatchCriteria();
     }
+    std::chrono::milliseconds timeout() const override { return parent_.timeout(); }
 
     // Router::Route
     const RouteEntry* routeEntry() const override { return this; }
@@ -211,6 +212,7 @@ private:
 
   void convertMessageBegin(MessageMetadataSharedPtr metadata);
   void cleanup();
+  void onResponseTimeout();
 
   Upstream::ClusterManager& cluster_manager_;
 
@@ -221,6 +223,9 @@ private:
 
   std::unique_ptr<UpstreamRequest> upstream_request_;
   Buffer::OwnedImpl upstream_request_buffer_;
+
+  std::chrono::milliseconds timeout_;
+  Event::TimerPtr response_timer_;
 };
 
 } // namespace Router

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -11,6 +11,7 @@
 
 #include "test/extensions/filters/network/thrift_proxy/mocks.h"
 #include "test/extensions/filters/network/thrift_proxy/utility.h"
+#include "test/mocks/event/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/upstream/mocks.h"
@@ -100,8 +101,7 @@ public:
     }
 
     ON_CALL(random_, random()).WillByDefault(Return(42));
-    filter_.reset(new ConnectionManager(*config_, random_,
-                                        filter_callbacks_.connection_.dispatcher_.timeSystem()));
+    filter_.reset(new ConnectionManager(*config_, random_, dispatcher_));
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
     filter_->onNewConnection();
 
@@ -297,6 +297,7 @@ public:
   std::unique_ptr<ConnectionManager> filter_;
   MockTransport* custom_transport_{};
   MockProtocol* custom_protocol_{};
+  Event::MockDispatcher dispatcher_;
 };
 
 TEST_F(ThriftConnectionManagerTest, OnDataHandlesThriftCall) {

--- a/test/extensions/filters/network/thrift_proxy/mocks.cc
+++ b/test/extensions/filters/network/thrift_proxy/mocks.cc
@@ -73,7 +73,9 @@ MockDecoderFilter::~MockDecoderFilter() {}
 MockDecoderFilterCallbacks::MockDecoderFilterCallbacks() {
   ON_CALL(*this, streamId()).WillByDefault(Return(stream_id_));
   ON_CALL(*this, connection()).WillByDefault(Return(&connection_));
+  ON_CALL(*this, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
 }
+
 MockDecoderFilterCallbacks::~MockDecoderFilterCallbacks() {}
 
 } // namespace ThriftFilters

--- a/test/extensions/filters/network/thrift_proxy/mocks.h
+++ b/test/extensions/filters/network/thrift_proxy/mocks.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/event/dispatcher.h"
 #include "envoy/router/router.h"
 
 #include "extensions/filters/network/thrift_proxy/conn_manager.h"
@@ -226,9 +227,11 @@ public:
   MOCK_METHOD2(startUpstreamResponse, void(Transport&, Protocol&));
   MOCK_METHOD1(upstreamData, bool(Buffer::Instance&));
   MOCK_METHOD0(resetDownstreamConnection, void());
+  MOCK_CONST_METHOD0(dispatcher, Event::Dispatcher&());
 
   uint64_t stream_id_{1};
   NiceMock<Network::MockConnection> connection_;
+  NiceMock<Event::MockDispatcher> dispatcher_;
 };
 
 } // namespace ThriftFilters

--- a/test/extensions/filters/network/thrift_proxy/mocks.h
+++ b/test/extensions/filters/network/thrift_proxy/mocks.h
@@ -246,6 +246,7 @@ public:
   // ThriftProxy::Router::RouteEntry
   MOCK_CONST_METHOD0(clusterName, const std::string&());
   MOCK_CONST_METHOD0(metadataMatchCriteria, const Envoy::Router::MetadataMatchCriteria*());
+  MOCK_CONST_METHOD0(timeout, std::chrono::milliseconds());
 };
 
 class MockRoute : public Route {


### PR DESCRIPTION
Having a little trouble on piecing together how this would all tie into the request/response lifecycle so pushing out this review to get some guidance.

Did some of the no regrets work:
- added timeout to the proto def
- thread dispatcher through ConnectionManager
- add timeout to RouteEntry abstract class
- kick off timer onRequestComplete
- cancel timer on cleanup

Going to wait on @zuercher's outstanding PR to continue this but wanted some eyes on it to make sure it's structurally sound.