### PR TITLE
docs: document the the allow-unknown-fields cli flag

### DIFF
--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -239,4 +239,6 @@ following are the command line options that Envoy supports.
 .. option:: --allow-unknown-fields
 
   *(optional)* This flag disables validation of protobuf configurations for unknown fields. By default, the 
-  validation is enabled.
+  validation is enabled. For most deployments, the default should be used which ensures configuration errors
+  are caught upfront and Envoy is configured as intended. However in cases where Envoy needs to accept configuration 
+  produced by newer control planes, effectively ignoring new features it does not know about yet, this can be disabled.

--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -235,3 +235,8 @@ following are the command line options that Envoy supports.
 
   *(optional)* This flag disables Envoy hot restart for builds that have it enabled. By default, hot
   restart is enabled.
+
+.. option:: --allow-unknown-fields
+
+  *(optional)* This flag disables validation of protobuf configurations for unknown fields. By default, the 
+  validation is enabled.


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*: `allow-unknown-fields` is not documented. This PR adds it to the docs.
*Risk Level*: Low
*Testing*: N/A
*Docs Changes*: N/A
*Release Notes*: N/A

