### PR TITLE
[WIP] stats: add --filter-stats mode

### DIFF
--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -235,3 +235,9 @@ following are the command line options that Envoy supports.
 
   *(optional)* This flag disables Envoy hot restart for builds that have it enabled. By default, hot
   restart is enabled.
+
+.. option:: --filter-stats <string>
+
+  *(optional)* This flag prevents the creation of stats matching a regex. Since this flag is not set
+  by default, all stats are enabled by default. To disable all stats within Envoy,
+  call `--filter-stats ".*".

--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -240,4 +240,4 @@ following are the command line options that Envoy supports.
 
   *(optional)* This flag prevents the creation of stats matching a regex. Since this flag is not set
   by default, all stats are enabled by default. To disable all stats within Envoy,
-  call `--filter-stats ".*".
+  call `--filter-stats ".*"`.

--- a/include/envoy/stats/BUILD
+++ b/include/envoy/stats/BUILD
@@ -24,6 +24,7 @@ envoy_cc_library(
         "tag_extractor.h",
         "tag_producer.h",
     ],
+    external_deps = ["abseil_optional"],
     deps = ["//include/envoy/common:interval_set_interface"],
 )
 

--- a/include/envoy/stats/stats_options.h
+++ b/include/envoy/stats/stats_options.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <memory>
+#include <regex>
 
 #include "envoy/common/pure.h"
+
+#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Stats {
@@ -44,6 +47,11 @@ public:
    * The max allowed length of a stat suffix.
    */
   virtual size_t maxStatSuffixLength() const PURE;
+
+  /**
+   * The filter regex which limits stat creation.
+   */
+  virtual absl::optional<std::regex> statNameFilter() const PURE;
 };
 
 } // namespace Stats

--- a/include/envoy/stats/stats_options.h
+++ b/include/envoy/stats/stats_options.h
@@ -51,7 +51,7 @@ public:
   /**
    * The filter regex which limits stat creation.
    */
-  virtual absl::optional<std::regex> statNameFilter() const PURE;
+  virtual const absl::optional<std::regex>& statNameFilter() const PURE;
 };
 
 } // namespace Stats

--- a/source/common/stats/BUILD
+++ b/source/common/stats/BUILD
@@ -133,6 +133,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "stats_options_lib",
     hdrs = ["stats_options_impl.h"],
+    external_deps = ["abseil_optional"],
     deps = [
         "//include/envoy/stats:stats_interface",
     ],

--- a/source/common/stats/histogram_impl.h
+++ b/source/common/stats/histogram_impl.h
@@ -63,5 +63,28 @@ private:
   const std::string name_;
 };
 
+/**
+ * Null histogram implementation.
+ * No-ops on all calls and requires no underlying metric or data.
+ */
+class NullHistogramImpl : public Histogram {
+public:
+  NullHistogramImpl() {}
+  ~NullHistogramImpl() {}
+
+  // Stats::Metric
+  const std::string name() const override { return ""; }
+  // Stats::MetricImpl
+  const std::string& tagExtractedName() const override { return tag_extracted_name_; }
+  const std::vector<Tag>& tags() const override { return tags_; }
+  // Stats::Histogram
+  void recordValue(uint64_t value) override { UNREFERENCED_PARAMETER(value); }
+  bool used() const override { return false; }
+
+private:
+  const std::string tag_extracted_name_ = "";
+  const std::vector<Tag> tags_;
+};
+
 } // namespace Stats
 } // namespace Envoy

--- a/source/common/stats/stat_data_allocator_impl.h
+++ b/source/common/stats/stat_data_allocator_impl.h
@@ -88,6 +88,32 @@ private:
 };
 
 /**
+ * Null counter implementation.
+ * No-ops on all calls and requires no underlying metric or data.
+ */
+class NullCounterImpl : public Counter {
+public:
+  NullCounterImpl() {}
+  ~NullCounterImpl() {}
+  // Stats::Metric
+  const std::string name() const override { return ""; }
+  // Stats::MetricImpl
+  const std::string& tagExtractedName() const override { return tag_extracted_name_; }
+  const std::vector<Tag>& tags() const override { return tags_; }
+  // Stats::Counter
+  void add(uint64_t amount) override { UNREFERENCED_PARAMETER(amount); }
+  void inc() override {}
+  uint64_t latch() override { return 0; }
+  void reset() override {}
+  bool used() const override { return false; }
+  uint64_t value() const override { return 0; }
+
+private:
+  const std::string tag_extracted_name_ = "";
+  const std::vector<Tag> tags_;
+};
+
+/**
  * Gauge implementation that wraps a StatData.
  */
 template <class StatData> class GaugeImpl : public Gauge, public MetricImpl {
@@ -122,6 +148,33 @@ public:
 private:
   StatData& data_;
   StatDataAllocatorImpl<StatData>& alloc_;
+};
+
+/**
+ * Null gauge implementation.
+ * No-ops on all calls and requires no underlying metric or data.
+ */
+class NullGaugeImpl : public Gauge {
+public:
+  NullGaugeImpl() {}
+  ~NullGaugeImpl() {}
+  // Stats::Metric
+  const std::string name() const override { return ""; }
+  // Stats::MetricImpl
+  const std::string& tagExtractedName() const override { return tag_extracted_name_; }
+  const std::vector<Tag>& tags() const override { return tags_; }
+  // Stats::Gauge
+  void add(uint64_t amount) override { UNREFERENCED_PARAMETER(amount); }
+  void inc() override {}
+  void dec() override {}
+  void set(uint64_t amount) override { UNREFERENCED_PARAMETER(amount); }
+  void sub(uint64_t amount) override { UNREFERENCED_PARAMETER(amount); }
+  bool used() const override { return false; }
+  uint64_t value() const override { return 0; }
+
+private:
+  const std::string tag_extracted_name_ = "";
+  const std::vector<Tag> tags_;
 };
 
 template <class StatData>

--- a/source/common/stats/stat_data_allocator_impl.h
+++ b/source/common/stats/stat_data_allocator_impl.h
@@ -101,7 +101,7 @@ public:
   const std::string& tagExtractedName() const override { return tag_extracted_name_; }
   const std::vector<Tag>& tags() const override { return tags_; }
   // Stats::Counter
-  void add(uint64_t amount) override { UNREFERENCED_PARAMETER(amount); }
+  void add(uint64_t) override {}
   void inc() override {}
   uint64_t latch() override { return 0; }
   void reset() override {}
@@ -164,11 +164,11 @@ public:
   const std::string& tagExtractedName() const override { return tag_extracted_name_; }
   const std::vector<Tag>& tags() const override { return tags_; }
   // Stats::Gauge
-  void add(uint64_t amount) override { UNREFERENCED_PARAMETER(amount); }
+  void add(uint64_t) override {}
   void inc() override {}
   void dec() override {}
-  void set(uint64_t amount) override { UNREFERENCED_PARAMETER(amount); }
-  void sub(uint64_t amount) override { UNREFERENCED_PARAMETER(amount); }
+  void set(uint64_t) override {}
+  void sub(uint64_t) override {}
   bool used() const override { return false; }
   uint64_t value() const override { return 0; }
 

--- a/source/common/stats/stats_options_impl.h
+++ b/source/common/stats/stats_options_impl.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <cstdint>
+#include <regex>
 
 #include "envoy/stats/stats_options.h"
+
+#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Stats {
@@ -23,9 +26,11 @@ struct StatsOptionsImpl : public StatsOptions {
   size_t maxNameLength() const override { return max_obj_name_length_ + max_stat_suffix_length_; }
   size_t maxObjNameLength() const override { return max_obj_name_length_; }
   size_t maxStatSuffixLength() const override { return max_stat_suffix_length_; }
+  absl::optional<std::regex> statNameFilter() const override { return stat_name_filter_; }
 
   size_t max_obj_name_length_ = 60;
   size_t max_stat_suffix_length_ = 67;
+  absl::optional<std::regex> stat_name_filter_ = absl::nullopt; // No filter by default.
 };
 
 } // namespace Stats

--- a/source/common/stats/stats_options_impl.h
+++ b/source/common/stats/stats_options_impl.h
@@ -26,7 +26,7 @@ struct StatsOptionsImpl : public StatsOptions {
   size_t maxNameLength() const override { return max_obj_name_length_ + max_stat_suffix_length_; }
   size_t maxObjNameLength() const override { return max_obj_name_length_; }
   size_t maxStatSuffixLength() const override { return max_stat_suffix_length_; }
-  absl::optional<std::regex> statNameFilter() const override { return stat_name_filter_; }
+  const absl::optional<std::regex>& statNameFilter() const override { return stat_name_filter_; }
 
   size_t max_obj_name_length_ = 60;
   size_t max_stat_suffix_length_ = 67;

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -227,7 +227,6 @@ private:
   struct ScopeImpl : public TlsScope {
     ScopeImpl(ThreadLocalStoreImpl& parent, const std::string& prefix)
         : scope_id_(next_scope_id_++), parent_(parent), prefix_(Utility::sanitizeStatsName(prefix)),
-          has_filter_(statsOptions().statNameFilter().has_value()),
           filter_(statsOptions().statNameFilter()) {}
     ~ScopeImpl();
 
@@ -245,7 +244,7 @@ private:
     // Returns true when a stat should be initialized, i.e. when the filter doesn't exist or when
     // the name doesn't match the filter.
     bool passesFilter(const std::string& name) const {
-      return (!has_filter_ || !std::regex_match(name, filter_.value()));
+      return (!filter_.has_value() || !std::regex_match(name, filter_.value()));
     }
 
     template <class StatType>
@@ -280,8 +279,7 @@ private:
 
     // It's ok to cache information relating to the top-level stat name filter regex, since it is
     // set once at startup and never modified.
-    const bool has_filter_;
-    const absl::optional<std::regex> filter_;
+    const absl::optional<std::regex>& filter_;
     NullCounterImpl null_counter_;
     NullGaugeImpl null_gauge_;
     NullHistogramImpl null_histogram_;


### PR DESCRIPTION
*Description*: This is a WIP PR to address the memory consumption concerns raised in #4196, and replaces the solution in #4422. It adds a `--filter-stats=<regex>` flag which, at runtime, replaces TLS-allocated stats which match the regex with minimal versions of themselves. This allows a user of Envoy to run Envoy under `--filter-stats=".*"` mode to turn off all stats (to reduce memory consumption), or to use a more discerning regex. Pushing upstream just to get some eyes on it.

Known issues:
 - `--filter-stats` might be unclear -- should this be `--disallow-stats`? Or should it be inclusive, so that the user has to write `--disable-stats --allow-stats=<regex>`?
 - regexes are slow -- we could use `std::regex`, or pull in another library, or allow users to use globs instead for a performance improvement -- very open to suggestions.
 - only implemented in `ThreadLocalStore`, not `IsolatedStoreImpl`s or anywhere else.
 - only tested at the `main_common_test` level. I will write tests for `thread_local_store_test` as well.

*Risk Level*: Low -- this is an opt-in feature with a performance hit.
*Testing*: Added a test to ensure behavior in `main_common_test`.
*Docs Changes*: Edited `cli.rst`
*Release Notes*: N/A
