### PR TITLE
hcm: allow unix sockets to be considered internal addresses

### DIFF
--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -200,7 +200,7 @@ message HttpConnectionManager {
     bool unix_sockets = 1;
   }
 
-  // Configures what network addresses are considered internal for stats and header sanitazionj
+  // Configures what network addresses are considered internal for stats and header sanitazion
   // purposes. If unspecified, only RFC1918 IP addresses will be considered internal.
   // See the documentation for :ref:`config_http_conn_man_headers_x-envoy-internal` for more
   // information about internal/external addresses.

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -200,8 +200,10 @@ message HttpConnectionManager {
     bool unix_sockets = 1;
   }
 
-  // Configures what network addresses are considered internal for stats and header sanitazion
-  // purposes.
+  // Configures what network addresses are considered internal for stats and header sanitazionj
+  // purposes. If unspecified, only RFC1918 IP addresses will be considered internal.
+  // See the documentation for :ref:`config_http_conn_man_headers_x-envoy-internal` for more
+  // information about internal/external addresses.
   InternalAddressConfig internal_address_config = 25;
 
   // If set, Envoy will not append the remote address to the

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -197,7 +197,7 @@ message HttpConnectionManager {
 
   message InternalAddressConfig {
     // Whether unix socket addresses should be considered internal.
-    google.protobuf.BoolValue unix_sockets = 1;
+    bool unix_sockets = 1;
   }
 
   // Configures what network addresses are considered internal for stats and header sanitazion

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -195,6 +195,15 @@ message HttpConnectionManager {
   // :ref:`config_http_conn_man_headers_x-forwarded-for` for more information.
   uint32 xff_num_trusted_hops = 19;
 
+  message InternalAddressConfig {
+    // Whether unix socket addresses should be considered internal.
+    google.protobuf.BoolValue unix_sockets = 1;
+  }
+
+  // Configures what network addresses are considered internal for stats and header sanitazion
+  // purposes.
+  InternalAddressConfig internal_address_config = 25;
+
   // If set, Envoy will not append the remote address to the
   // :ref:`config_http_conn_man_headers_x-forwarded-for` HTTP header. This may be used in
   // conjunction with HTTP filters that explicitly manipulate XFF after the HTTP connection manager

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -4,6 +4,7 @@
 #include "envoy/stats/scope.h"
 
 #include "common/http/date_provider.h"
+#include "common/network/utility.h"
 
 namespace Envoy {
 namespace Http {
@@ -152,6 +153,16 @@ class InternalAddressConfig {
 public:
   virtual ~InternalAddressConfig() {}
   virtual bool isInternalAddress(const Network::Address::Instance& address) const PURE;
+};
+
+/**
+ * Determines if an address is internal based on whether it is an RFC1918 ip address.
+ */
+class DefaultInternalAddressConfig : public Http::InternalAddressConfig {
+public:
+  bool isInternalAddress(const Network::Address::Instance& address) const override {
+    return Network::Utility::isInternalAddress(address);
+  }
 };
 
 /**

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -146,6 +146,15 @@ enum class ForwardClientCertType {
 enum class ClientCertDetailsType { Cert, Subject, URI, DNS };
 
 /**
+ * Configuration for what addresses should be considered internal beyond the defaults.
+ */
+class InternalAddressConfig {
+public:
+  virtual ~InternalAddressConfig() {}
+  virtual bool isInternalAddress(const Network::Address::Instance& address) const PURE;
+};
+
+/**
  * Abstract configuration for the connection manager.
  */
 class ConnectionManagerConfig {
@@ -230,6 +239,11 @@ public:
    *         status, etc. or to assume that XFF will already be populated with the remote address.
    */
   virtual bool useRemoteAddress() PURE;
+
+  /**
+   * @return InternalAddressConfig configuration for user defined internal addresses.
+   */
+  virtual const InternalAddressConfig& internalAddressConfig() const PURE;
 
   /**
    * @return uint32_t the number of trusted proxy hops in front of this Envoy instance, for

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -104,8 +104,7 @@ Network::Address::InstanceConstSharedPtr ConnectionManagerUtility::mutateRequest
   //               additional inference modes and make this mode legacy.
   const bool internal_request =
       (single_xff_address && final_remote_address != nullptr) &&
-      (Network::Utility::isInternalAddress(*final_remote_address) ||
-       config.internalAddressConfig().isInternalAddress(*final_remote_address));
+      config.internalAddressConfig().isInternalAddress(*final_remote_address);
 
   // After determining internal request status, if there is no final remote address, due to no XFF,
   // busted XFF, etc., use the direct connection remote address for logging.

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -103,7 +103,7 @@ Network::Address::InstanceConstSharedPtr ConnectionManagerUtility::mutateRequest
   //               we can't change it at this point. In the future we will likely need to add
   //               additional inference modes and make this mode legacy.
   const bool internal_request =
-      (single_xff_address && final_remote_address != nullptr) &&
+      single_xff_address && final_remote_address != nullptr &&
       config.internalAddressConfig().isInternalAddress(*final_remote_address);
 
   // After determining internal request status, if there is no final remote address, due to no XFF,

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -102,8 +102,10 @@ Network::Address::InstanceConstSharedPtr ConnectionManagerUtility::mutateRequest
   // HUGE WARNING: The way we do this is not optimal but is how it worked "from the beginning" so
   //               we can't change it at this point. In the future we will likely need to add
   //               additional inference modes and make this mode legacy.
-  const bool internal_request = single_xff_address && final_remote_address != nullptr &&
-                                Network::Utility::isInternalAddress(*final_remote_address);
+  const bool internal_request =
+      (single_xff_address && final_remote_address != nullptr) &&
+      (Network::Utility::isInternalAddress(*final_remote_address) ||
+       config.internalAddressConfig().isInternalAddress(*final_remote_address));
 
   // After determining internal request status, if there is no final remote address, due to no XFF,
   // busted XFF, etc., use the direct connection remote address for logging.

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -127,7 +127,7 @@ HttpConnectionManagerConfigUtility::determineNextProtocol(Network::Connection& c
 InternalAddressConfig::InternalAddressConfig(
     const envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager::
         InternalAddressConfig& config)
-    : unix_sockets_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, unix_sockets, false)) {}
+    : unix_sockets_(config.unix_sockets()) {}
 
 HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     const envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager&

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -114,6 +114,11 @@ HttpConnectionManagerConfigUtility::determineNextProtocol(Network::Connection& c
   return "";
 }
 
+InternalAddressConfig::InternalAddressConfig(
+    const envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager::
+        InternalAddressConfig& config)
+    : unix_sockets_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, unix_sockets, false)) {}
+
 HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     const envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager&
         config,
@@ -124,6 +129,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       tracing_stats_(
           Http::ConnectionManagerImpl::generateTracingStats(stats_prefix_, context_.scope())),
       use_remote_address_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, use_remote_address, false)),
+      internal_address_config_(config.internal_address_config()),
       xff_num_trusted_hops_(config.xff_num_trusted_hops()),
       skip_xff_append_(config.skip_xff_append()), via_(config.via()),
       route_config_provider_manager_(route_config_provider_manager),

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -49,7 +49,7 @@ std::unique_ptr<Http::InternalAddressConfig> createInternalAddressConfig(
     return std::make_unique<InternalAddressConfig>(config.internal_address_config());
   }
 
-  return std::make_unique<DefaultInternalAddressConfig>();
+  return std::make_unique<Http::DefaultInternalAddressConfig>();
 }
 
 } // namespace

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -42,6 +42,16 @@ FilterFactoryMap::const_iterator findUpgradeCaseInsensitive(const FilterFactoryM
   return upgrade_map.end();
 }
 
+std::unique_ptr<Http::InternalAddressConfig> createInternalAddressConfig(
+    const envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager&
+        config) {
+  if (config.has_internal_address_config()) {
+    return std::make_unique<InternalAddressConfig>(config.internal_address_config());
+  }
+
+  return std::make_unique<DefaultInternalAddressConfig>();
+}
+
 } // namespace
 
 // Singleton registration via macro defined in envoy/singleton/manager.h
@@ -129,7 +139,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       tracing_stats_(
           Http::ConnectionManagerImpl::generateTracingStats(stats_prefix_, context_.scope())),
       use_remote_address_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, use_remote_address, false)),
-      internal_address_config_(config.internal_address_config()),
+      internal_address_config_(createInternalAddressConfig(config)),
       xff_num_trusted_hops_(config.xff_num_trusted_hops()),
       skip_xff_append_(config.skip_xff_append()), via_(config.via()),
       route_config_provider_manager_(route_config_provider_manager),

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -60,6 +60,9 @@ public:
                                            const Buffer::Instance& data);
 };
 
+/**
+ * Determines if an address is internal based on user provided config.
+ */
 class InternalAddressConfig : public Http::InternalAddressConfig {
 public:
   InternalAddressConfig(const envoy::config::filter::network::http_connection_manager::v2::
@@ -108,7 +111,7 @@ public:
   Http::ConnectionManagerTracingStats& tracingStats() override { return tracing_stats_; }
   bool useRemoteAddress() override { return use_remote_address_; }
   const Http::InternalAddressConfig& internalAddressConfig() const override {
-    return internal_address_config_;
+    return *internal_address_config_;
   }
   uint32_t xffNumTrustedHops() const override { return xff_num_trusted_hops_; }
   bool skipXffAppend() const override { return skip_xff_append_; }
@@ -141,7 +144,7 @@ private:
   Http::ConnectionManagerStats stats_;
   Http::ConnectionManagerTracingStats tracing_stats_;
   const bool use_remote_address_{};
-  const InternalAddressConfig internal_address_config_;
+  const std::unique_ptr<Http::InternalAddressConfig> internal_address_config_;
   const uint32_t xff_num_trusted_hops_;
   const bool skip_xff_append_;
   const std::string via_;

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -60,6 +60,19 @@ public:
                                            const Buffer::Instance& data);
 };
 
+class InternalAddressConfig : public Http::InternalAddressConfig {
+public:
+  InternalAddressConfig(const envoy::config::filter::network::http_connection_manager::v2::
+                            HttpConnectionManager::InternalAddressConfig& config);
+
+  bool isInternalAddress(const Network::Address::Instance& address) const override {
+    return address.type() == Network::Address::Type::Pipe && unix_sockets_;
+  }
+
+private:
+  const bool unix_sockets_;
+};
+
 /**
  * Maps proto config to runtime config for an HTTP connection manager network filter.
  */
@@ -94,6 +107,9 @@ public:
   Http::ConnectionManagerStats& stats() override { return stats_; }
   Http::ConnectionManagerTracingStats& tracingStats() override { return tracing_stats_; }
   bool useRemoteAddress() override { return use_remote_address_; }
+  const Http::InternalAddressConfig& internalAddressConfig() const override {
+    return internal_address_config_;
+  }
   uint32_t xffNumTrustedHops() const override { return xff_num_trusted_hops_; }
   bool skipXffAppend() const override { return skip_xff_append_; }
   const std::string& via() const override { return via_; }
@@ -125,6 +141,7 @@ private:
   Http::ConnectionManagerStats stats_;
   Http::ConnectionManagerTracingStats tracing_stats_;
   const bool use_remote_address_{};
+  const InternalAddressConfig internal_address_config_;
   const uint32_t xff_num_trusted_hops_;
   const bool skip_xff_append_;
   const std::string via_;

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -69,7 +69,12 @@ public:
                             HttpConnectionManager::InternalAddressConfig& config);
 
   bool isInternalAddress(const Network::Address::Instance& address) const override {
-    return address.type() == Network::Address::Type::Pipe && unix_sockets_;
+    if (address.type() == Network::Address::Type::Pipe) {
+      return unix_sockets_;
+    }
+
+    // TODO(snowp): Make internal subnets configurable.
+    return Network::Utility::isInternalAddress(address);
   }
 
 private:

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -36,6 +36,10 @@
 namespace Envoy {
 namespace Server {
 
+class AdminInternalAddressConfig : public Http::InternalAddressConfig {
+  bool isInternalAddress(const Network::Address::Instance&) const override { return false; }
+};
+
 /**
  * Implementation of Server::Admin.
  */
@@ -99,6 +103,9 @@ public:
   Http::ConnectionManagerStats& stats() override { return stats_; }
   Http::ConnectionManagerTracingStats& tracingStats() override { return tracing_stats_; }
   bool useRemoteAddress() override { return true; }
+  const Http::InternalAddressConfig& internalAddressConfig() const override {
+    return internal_address_config_;
+  }
   uint32_t xffNumTrustedHops() const override { return 0; }
   bool skipXffAppend() const override { return false; }
   const std::string& via() const override { return EMPTY_STRING; }
@@ -291,6 +298,7 @@ private:
   Http::Http1Settings http1_settings_;
   ConfigTrackerImpl config_tracker_;
   const Network::FilterChainSharedPtr admin_filter_chain_;
+  const AdminInternalAddressConfig internal_address_config_;
 };
 
 /**

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -96,6 +96,9 @@ public:
   ConnectionManagerStats& stats() override { return stats_; }
   ConnectionManagerTracingStats& tracingStats() override { return tracing_stats_; }
   bool useRemoteAddress() override { return use_remote_address_; }
+  const Http::InternalAddressConfig& internalAddressConfig() const override {
+    return internal_address_config_;
+  }
   uint32_t xffNumTrustedHops() const override { return 0; }
   bool skipXffAppend() const override { return false; }
   const std::string& via() const override { return EMPTY_STRING; }
@@ -134,6 +137,7 @@ public:
   TracingConnectionManagerConfigPtr tracing_config_;
   bool proxy_100_continue_ = true;
   Http::Http1Settings http1_settings_;
+  Http::DefaultInternalAddressConfig internal_address_config_;
 };
 
 // Internal representation of stream state. Encapsulates the stream state, mocks

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -264,7 +264,9 @@ public:
   ConnectionManagerStats& stats() override { return stats_; }
   ConnectionManagerTracingStats& tracingStats() override { return tracing_stats_; }
   bool useRemoteAddress() override { return use_remote_address_; }
-  const Http::InternalAddressConfig& internalAddressConfig() const override { return internal_address_config_; }
+  const Http::InternalAddressConfig& internalAddressConfig() const override {
+    return internal_address_config_;
+  }
   uint32_t xffNumTrustedHops() const override { return 0; }
   bool skipXffAppend() const override { return false; }
   const std::string& via() const override { return EMPTY_STRING; }

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -264,6 +264,7 @@ public:
   ConnectionManagerStats& stats() override { return stats_; }
   ConnectionManagerTracingStats& tracingStats() override { return tracing_stats_; }
   bool useRemoteAddress() override { return use_remote_address_; }
+  const Http::InternalAddressConfig& internalAddressConfig() const override { return internal_address_config_; }
   uint32_t xffNumTrustedHops() const override { return 0; }
   bool skipXffAppend() const override { return false; }
   const std::string& via() const override { return EMPTY_STRING; }
@@ -296,6 +297,7 @@ public:
   std::string server_name_;
   Network::Address::Ipv4Instance local_address_{"127.0.0.1"};
   bool use_remote_address_{true};
+  Http::DefaultInternalAddressConfig internal_address_config_;
   Http::ForwardClientCertType forward_client_cert_{Http::ForwardClientCertType::Sanitize};
   std::vector<Http::ClientCertDetailsType> set_current_client_cert_details_;
   absl::optional<std::string> user_agent_;

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -27,6 +27,11 @@ using testing::ReturnRef;
 namespace Envoy {
 namespace Http {
 
+class MockInternalAddressConfig : public Http::InternalAddressConfig {
+public:
+  MOCK_CONST_METHOD1(isInternalAddress, bool(const Network::Address::Instance&));
+};
+
 class MockConnectionManagerConfig : public ConnectionManagerConfig {
 public:
   MockConnectionManagerConfig() { ON_CALL(*this, generateRequestId()).WillByDefault(Return(true)); }
@@ -51,6 +56,10 @@ public:
   MOCK_METHOD0(stats, ConnectionManagerStats&());
   MOCK_METHOD0(tracingStats, ConnectionManagerTracingStats&());
   MOCK_METHOD0(useRemoteAddress, bool());
+  const Http::InternalAddressConfig& internalAddressConfig() const {
+    return internal_address_config_;
+  }
+  MOCK_METHOD0(unixSocketInternal, bool());
   MOCK_CONST_METHOD0(xffNumTrustedHops, uint32_t());
   MOCK_CONST_METHOD0(skipXffAppend, bool());
   MOCK_CONST_METHOD0(via, const std::string&());
@@ -63,6 +72,8 @@ public:
   MOCK_METHOD0(listenerStats, ConnectionManagerListenerStats&());
   MOCK_CONST_METHOD0(proxy100Continue, bool());
   MOCK_CONST_METHOD0(http1Settings, const Http::Http1Settings&());
+
+  NiceMock<MockInternalAddressConfig> internal_address_config_;
 };
 
 class ConnectionManagerUtilityTest : public testing::Test {
@@ -148,6 +159,24 @@ TEST_F(ConnectionManagerUtilityTest, SkipXffAppendPassThruUseRemoteAddress) {
   EXPECT_EQ((MutateRequestRet{"12.12.12.12:0", false}),
             callMutateRequestHeaders(headers, Protocol::Http2));
   EXPECT_STREQ("198.51.100.1", headers.ForwardedFor()->value().c_str());
+}
+
+// Verify internal request and XFF is set when we are using remote address and the address is
+// internal according to user configuration.
+TEST_F(ConnectionManagerUtilityTest, UseRemoteAddressWhenUserConfiguredRemoteAddress) {
+  ON_CALL(config_.internal_address_config_, isInternalAddress).WillByDefault(Return(true));
+
+  Network::Address::Ipv4Instance local_address("10.3.2.1");
+  ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
+  ON_CALL(config_, localAddress()).WillByDefault(ReturnRef(local_address));
+
+  connection_.remote_address_ = std::make_shared<Network::Address::Ipv4Instance>("12.12.12.12");
+
+  TestHeaderMapImpl headers;
+  std::cerr << callMutateRequestHeaders(headers, Protocol::Http2).internal_ << std::endl;
+  EXPECT_EQ((MutateRequestRet{"12.12.12.12:0", true}),
+            callMutateRequestHeaders(headers, Protocol::Http2));
+  EXPECT_EQ("12.12.12.12", headers.get_(Headers::get().ForwardedFor));
 }
 
 // Verify internal request and XFF is set when we are using remote address the address is internal.

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -145,9 +145,11 @@ TEST_F(HttpConnectionManagerConfigTest, UnixSocketInternalAddress) {
   HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
                                      date_provider_, route_config_provider_manager_);
   Network::Address::PipeInstance unixAddress{"/foo"};
-  Network::Address::Ipv4Instance ipAddress{"127.0.0.1", 0};
+  Network::Address::Ipv4Instance internalIpAddress{"127.0.0.1", 0};
+  Network::Address::Ipv4Instance externalIpAddress{"12.0.0.1", 0};
   EXPECT_TRUE(config.internalAddressConfig().isInternalAddress(unixAddress));
-  EXPECT_FALSE(config.internalAddressConfig().isInternalAddress(ipAddress));
+  EXPECT_TRUE(config.internalAddressConfig().isInternalAddress(internalIpAddress));
+  EXPECT_FALSE(config.internalAddressConfig().isInternalAddress(externalIpAddress));
 }
 
 // Validated that an explicit zero stream idle timeout disables.

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -131,6 +131,25 @@ TEST_F(HttpConnectionManagerConfigTest, MiscConfig) {
   EXPECT_EQ(5 * 60 * 1000, config.streamIdleTimeout().count());
 }
 
+TEST_F(HttpConnectionManagerConfigTest, UnixSocketInternalAddress) {
+  const std::string yaml_string = R"EOF(
+  stat_prefix: ingress_http
+  internal_address_config:
+    unix_sockets: true
+  route_config:
+    name: local_route
+  http_filters:
+  - name: envoy.router
+  )EOF";
+
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
+                                     date_provider_, route_config_provider_manager_);
+  Network::Address::PipeInstance unixAddress{"/foo"};
+  Network::Address::Ipv4Instance ipAddress{"127.0.0.1", 0};
+  EXPECT_TRUE(config.internalAddressConfig().isInternalAddress(unixAddress));
+  EXPECT_FALSE(config.internalAddressConfig().isInternalAddress(ipAddress));
+}
+
 // Validated that an explicit zero stream idle timeout disables.
 TEST_F(HttpConnectionManagerConfigTest, DisabledStreamIdleTimeout) {
   const std::string yaml_string = R"EOF(


### PR DESCRIPTION
Adds a config option that treats unix socket addresses as internal for
the purpose of stats/header sanitization.

Intended to make it easy to be extended to include additional configuration options for what should be considered internal, e.g. arbitrary ip addresses/cidr ranges.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Low, new optional feature
*Testing*: Unit testing
*Docs Changes*: n/a
*Release Notes*: n/a
 Fixes #4259 