### PR TITLE
Add tags and swaps to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ SOURCE_VERSION
 .vimrc
 .vscode
 .vs
+*.sw*
+tags


### PR DESCRIPTION
Signed-off-by: Auni Ahsan <auni@google.com>

*Description*: Add vim swaps and tags to .gitignore
*Risk Level*: low * low

*Why not just put these files elsewhere?* First, harmlessly avoid random files being checked in by accident if someone fails to do that. Second, some dev workflows require tags be present in the working dir.
