### PR TITLE
WIP: format: put QueryParams in its own class

### DIFF
--- a/include/envoy/http/query_params.h
+++ b/include/envoy/http/query_params.h
@@ -1,5 +1,11 @@
+#pragma once
+
 #include <map>
 #include <string>
+
+#include "envoy/common/pure.h"
+
+#include "absl/strings/string_view.h"
 
 namespace Envoy {
 namespace Http {
@@ -9,7 +15,29 @@ namespace Utility {
 // using proper formatting. Perhaps similar to
 // https://github.com/apache/incubator-pagespeed-mod/blob/master/pagespeed/kernel/http/query_params.h
 
-typedef std::map<std::string, std::string> QueryParams;
+typedef std::map<std::string, std::string> QueryParamsMap;
+
+class QueryParams {
+public:
+  virtual ~QueryParams(){};
+
+  /**
+   * @param url supplies the url to parse.
+   * @return QueryParamsMap of the parsed parameters, if any.
+   */
+  virtual QueryParamsMap parseQueryString(absl::string_view) PURE;
+
+  /**
+   * @param QueryParamsMap of desired string.
+   * @return QueryParamsMap serialized into a string.
+   */
+  virtual absl::string_view queryParamsToString(const QueryParamsMap&) PURE;
+
+  virtual QueryParamsMap::const_iterator find(const std::string key) const PURE;
+  virtual QueryParamsMap::const_iterator begin() const PURE;
+  virtual QueryParamsMap::const_iterator end() const PURE;
+  virtual int size() PURE;
+};
 
 } // namespace Utility
 } // namespace Http

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -235,6 +235,16 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "query_params_lib",
+    srcs = ["query_params_impl.cc"],
+    hdrs = ["query_params_impl.h"],
+    deps = [
+        "//include/envoy/http:query_params_interface",
+        "//source/common/common:utility_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
     hdrs = ["utility.h"],
@@ -246,13 +256,13 @@ envoy_cc_library(
         "//include/envoy/http:codes_interface",
         "//include/envoy/http:filter_interface",
         "//include/envoy/http:header_map_interface",
-        "//include/envoy/http:query_params_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
         "//source/common/common:empty_string",
         "//source/common/common:enum_to_int",
         "//source/common/common:utility_lib",
         "//source/common/grpc:status_lib",
+        "//source/common/http:query_params_lib",
         "//source/common/json:json_loader_lib",
         "//source/common/network:utility_lib",
         "//source/common/protobuf:utility_lib",

--- a/source/common/http/query_params_impl.cc
+++ b/source/common/http/query_params_impl.cc
@@ -1,0 +1,62 @@
+#include "common/http/query_params_impl.h"
+
+#include "common/common/utility.h"
+
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Http {
+namespace Utility {
+
+QueryParamsImpl::QueryParamsImpl() {}
+
+QueryParamsMap QueryParamsImpl::parseQueryString(absl::string_view url) {
+  QueryParamsMap params;
+  size_t start = url.find('?');
+  if (start == std::string::npos) {
+    return params;
+  }
+
+  start++;
+  while (start < url.size()) {
+    size_t end = url.find('&', start);
+    if (end == std::string::npos) {
+      end = url.size();
+    }
+    absl::string_view param(url.data() + start, end - start);
+
+    const size_t equal = param.find('=');
+    if (equal != std::string::npos) {
+      params.emplace(StringUtil::subspan(url, start, start + equal),
+                     StringUtil::subspan(url, start + equal + 1, end));
+    } else {
+      params.emplace(StringUtil::subspan(url, start, end), "");
+    }
+
+    start = end + 1;
+  }
+
+  return params;
+}
+
+absl::string_view QueryParamsImpl::queryParamsToString(const QueryParamsMap& params) {
+  std::string out;
+  std::string delim = "?";
+  for (auto p : params) {
+    absl::StrAppend(&out, delim, p.first, "=", p.second);
+    delim = "&";
+  }
+  return out;
+}
+
+QueryParamsMap::const_iterator QueryParamsImpl::find(const std::string key) const {
+  return this->find(key);
+}
+QueryParamsMap::const_iterator QueryParamsImpl::begin() const { return this->begin(); }
+QueryParamsMap::const_iterator QueryParamsImpl::end() const { return this->end(); }
+int QueryParamsImpl::size() { return this->size(); }
+
+} // namespace Utility
+} // namespace Http
+} // namespace Envoy

--- a/source/common/http/query_params_impl.h
+++ b/source/common/http/query_params_impl.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "envoy/http/query_params.h"
+
+namespace Envoy {
+namespace Http {
+namespace Utility {
+
+class QueryParamsImpl : QueryParams {
+public:
+  QueryParamsImpl();
+  ~QueryParamsImpl(){};
+
+  /**
+   * Parse a URL into query parameters.
+   * @param url supplies the url to parse.
+   * @return QueryParamsMap of the parsed parameters, if any.
+   */
+  QueryParamsMap parseQueryString(absl::string_view) override;
+
+  /**
+   * Serialize query-params into a string.
+   */
+  absl::string_view queryParamsToString(const QueryParamsMap&) override;
+
+  /**
+   * Applies std::map::find()
+   */
+  QueryParamsMap::const_iterator find(const std::string key) const override;
+
+  /**
+   * Applies std::map::begin()
+   */
+  QueryParamsMap::const_iterator begin() const override;
+  /**
+   * Applies std::map::end()
+   */
+  QueryParamsMap::const_iterator end() const override;
+
+  /**
+   * Applies std::map::size()
+   */
+  int size() override;
+};
+
+} // namespace Utility
+} // namespace Http
+} // namespace Envoy

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -55,35 +55,6 @@ std::string Utility::createSslRedirectPath(const HeaderMap& headers) {
                      headers.Path()->value().c_str());
 }
 
-// Utility::QueryParams Utility::parseQueryString(absl::string_view url) {
-//   QueryParams params;
-//   size_t start = url.find('?');
-//   if (start == std::string::npos) {
-//     return params;
-//   }
-
-//   start++;
-//   while (start < url.size()) {
-//     size_t end = url.find('&', start);
-//     if (end == std::string::npos) {
-//       end = url.size();
-//     }
-//     absl::string_view param(url.data() + start, end - start);
-
-//     const size_t equal = param.find('=');
-//     if (equal != std::string::npos) {
-//       params.emplace(StringUtil::subspan(url, start, start + equal),
-//                      StringUtil::subspan(url, start + equal + 1, end));
-//     } else {
-//       params.emplace(StringUtil::subspan(url, start, end), "");
-//     }
-
-//     start = end + 1;
-//   }
-
-//   return params;
-// }
-
 const char* Utility::findQueryStringStart(const HeaderString& path) {
   return std::find(path.c_str(), path.c_str() + path.size(), '?');
 }
@@ -392,18 +363,6 @@ MessagePtr Utility::prepareHeaders(const ::envoy::api::v2::core::HttpUri& http_u
 
   return message;
 }
-
-// TODO(jmarantz): make QueryParams a real class and put this serializer there,
-// along with proper URL escaping of the name and value.
-// std::string Utility::queryParamsToString(const QueryParams& params) {
-//   std::string out;
-//   std::string delim = "?";
-//   for (auto p : params) {
-//     absl::StrAppend(&out, delim, p.first, "=", p.second);
-//     delim = "&";
-//   }
-//   return out;
-// }
 
 void Utility::transformUpgradeRequestFromH1toH2(HeaderMap& headers) {
   ASSERT(Utility::isUpgrade(headers));

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -55,34 +55,34 @@ std::string Utility::createSslRedirectPath(const HeaderMap& headers) {
                      headers.Path()->value().c_str());
 }
 
-Utility::QueryParams Utility::parseQueryString(absl::string_view url) {
-  QueryParams params;
-  size_t start = url.find('?');
-  if (start == std::string::npos) {
-    return params;
-  }
+// Utility::QueryParams Utility::parseQueryString(absl::string_view url) {
+//   QueryParams params;
+//   size_t start = url.find('?');
+//   if (start == std::string::npos) {
+//     return params;
+//   }
 
-  start++;
-  while (start < url.size()) {
-    size_t end = url.find('&', start);
-    if (end == std::string::npos) {
-      end = url.size();
-    }
-    absl::string_view param(url.data() + start, end - start);
+//   start++;
+//   while (start < url.size()) {
+//     size_t end = url.find('&', start);
+//     if (end == std::string::npos) {
+//       end = url.size();
+//     }
+//     absl::string_view param(url.data() + start, end - start);
 
-    const size_t equal = param.find('=');
-    if (equal != std::string::npos) {
-      params.emplace(StringUtil::subspan(url, start, start + equal),
-                     StringUtil::subspan(url, start + equal + 1, end));
-    } else {
-      params.emplace(StringUtil::subspan(url, start, end), "");
-    }
+//     const size_t equal = param.find('=');
+//     if (equal != std::string::npos) {
+//       params.emplace(StringUtil::subspan(url, start, start + equal),
+//                      StringUtil::subspan(url, start + equal + 1, end));
+//     } else {
+//       params.emplace(StringUtil::subspan(url, start, end), "");
+//     }
 
-    start = end + 1;
-  }
+//     start = end + 1;
+//   }
 
-  return params;
-}
+//   return params;
+// }
 
 const char* Utility::findQueryStringStart(const HeaderString& path) {
   return std::find(path.c_str(), path.c_str() + path.size(), '?');
@@ -395,15 +395,15 @@ MessagePtr Utility::prepareHeaders(const ::envoy::api::v2::core::HttpUri& http_u
 
 // TODO(jmarantz): make QueryParams a real class and put this serializer there,
 // along with proper URL escaping of the name and value.
-std::string Utility::queryParamsToString(const QueryParams& params) {
-  std::string out;
-  std::string delim = "?";
-  for (auto p : params) {
-    absl::StrAppend(&out, delim, p.first, "=", p.second);
-    delim = "&";
-  }
-  return out;
-}
+// std::string Utility::queryParamsToString(const QueryParams& params) {
+//   std::string out;
+//   std::string delim = "?";
+//   for (auto p : params) {
+//     absl::StrAppend(&out, delim, p.first, "=", p.second);
+//     delim = "&";
+//   }
+//   return out;
+// }
 
 void Utility::transformUpgradeRequestFromH1toH2(HeaderMap& headers) {
   ASSERT(Utility::isUpgrade(headers));

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -10,8 +10,9 @@
 #include "envoy/http/codes.h"
 #include "envoy/http/filter.h"
 #include "envoy/http/message.h"
-#include "envoy/http/query_params.h"
+// #include "envoy/http/query_params.h"
 
+#include "common/http/query_params_impl.h"
 #include "common/json/json_loader.h"
 
 #include "absl/strings/string_view.h"
@@ -46,7 +47,7 @@ std::string createSslRedirectPath(const HeaderMap& headers);
  * @param url supplies the url to parse.
  * @return QueryParams the parsed parameters, if any.
  */
-QueryParams parseQueryString(absl::string_view url);
+// QueryParams parseQueryString(absl::string_view url);
 
 /**
  * Finds the start of the query string in a path
@@ -136,7 +137,6 @@ Http1Settings parseHttp1Settings(const envoy::api::v2::core::Http1ProtocolOption
  * @param response_code supplies the HTTP response code.
  * @param body_text supplies the optional body text which is sent using the text/plain content
  *                  type.
- * @param is_head_request tells if this is a response to a HEAD request
  */
 void sendLocalReply(bool is_grpc, StreamDecoderFilterCallbacks& callbacks, const bool& is_reset,
                     Code response_code, const std::string& body_text, bool is_head_request);
@@ -152,6 +152,7 @@ void sendLocalReply(bool is_grpc, StreamDecoderFilterCallbacks& callbacks, const
  * @param response_code supplies the HTTP response code.
  * @param body_text supplies the optional body text which is sent using the text/plain content
  *                  type.
+ * @param is_head_request tells if this is a response to a HEAD request
  */
 void sendLocalReply(bool is_grpc,
                     std::function<void(HeaderMapPtr&& headers, bool end_stream)> encode_headers,
@@ -203,7 +204,7 @@ MessagePtr prepareHeaders(const ::envoy::api::v2::core::HttpUri& http_uri);
 /**
  * Serialize query-params into a string.
  */
-std::string queryParamsToString(const QueryParams& query_params);
+// std::string queryParamsToString(const QueryParams& query_params);
 
 /**
  * Transforms the supplied headers from an HTTP/1 Upgrade request to an H2 style upgrade.

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -43,13 +43,6 @@ void appendVia(HeaderMap& headers, const std::string& via);
 std::string createSslRedirectPath(const HeaderMap& headers);
 
 /**
- * Parse a URL into query parameters.
- * @param url supplies the url to parse.
- * @return QueryParams the parsed parameters, if any.
- */
-// QueryParams parseQueryString(absl::string_view url);
-
-/**
  * Finds the start of the query string in a path
  * @param path supplies a HeaderString& to search for the query string
  * @return const char* a pointer to the beginning of the query string, or the end of the
@@ -200,11 +193,6 @@ void extractHostPathFromUri(const absl::string_view& uri, absl::string_view& hos
  * Prepare headers for a HttpUri.
  */
 MessagePtr prepareHeaders(const ::envoy::api::v2::core::HttpUri& http_uri);
-
-/**
- * Serialize query-params into a string.
- */
-// std::string queryParamsToString(const QueryParams& query_params);
 
 /**
  * Transforms the supplied headers from an HTTP/1 Upgrade request to an H2 style upgrade.

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -10,7 +10,6 @@
 #include "envoy/http/codes.h"
 #include "envoy/http/filter.h"
 #include "envoy/http/message.h"
-// #include "envoy/http/query_params.h"
 
 #include "common/http/query_params_impl.h"
 #include "common/json/json_loader.h"

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -351,8 +351,9 @@ bool RouteEntryImplBase::matchRoute(const Http::HeaderMap& headers, uint64_t ran
 
   matches &= Http::HeaderUtility::matchHeaders(headers, config_headers_);
   if (!config_query_parameters_.empty()) {
-    Http::Utility::QueryParams query_parameters =
-        Http::Utility::parseQueryString(headers.Path()->value().c_str());
+    Http::Utility::QueryParamsImpl query_params_impl;
+    Http::Utility::QueryParamsMap query_parameters =
+        query_params_impl.parseQueryString(headers.Path()->value().c_str());
     matches &= ConfigUtility::matchQueryParams(query_parameters, config_query_parameters_);
   }
 

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -11,7 +11,7 @@ namespace Envoy {
 namespace Router {
 
 bool ConfigUtility::QueryParameterMatcher::matches(
-    const Http::Utility::QueryParams& request_query_params) const {
+    const Http::Utility::QueryParamsMap& request_query_params) const {
   auto query_param = request_query_params.find(name_);
   if (query_param == request_query_params.end()) {
     return false;
@@ -37,7 +37,7 @@ ConfigUtility::parsePriority(const envoy::api::v2::core::RoutingPriority& priori
 }
 
 bool ConfigUtility::matchQueryParams(
-    const Http::Utility::QueryParams& query_params,
+    const Http::Utility::QueryParamsMap& query_params,
     const std::vector<QueryParameterMatcher>& config_query_params) {
   for (const auto& config_query_param : config_query_params) {
     if (!config_query_param.matches(query_params)) {

--- a/source/common/router/config_utility.h
+++ b/source/common/router/config_utility.h
@@ -44,7 +44,7 @@ public:
      * @param request_query_params supplies the parsed query parameters from a request.
      * @return bool true if a match for this QueryParameterMatcher exists in request_query_params.
      */
-    bool matches(const Http::Utility::QueryParams& request_query_params) const;
+    bool matches(const Http::Utility::QueryParamsMap& request_query_params) const;
 
   private:
     const std::string name_;
@@ -66,7 +66,7 @@ public:
    * @return bool true if all the query params (and values) in the config_params are found in the
    *         query_params
    */
-  static bool matchQueryParams(const Http::Utility::QueryParams& query_params,
+  static bool matchQueryParams(const Http::Utility::QueryParamsMap& query_params,
                                const std::vector<QueryParameterMatcher>& config_query_params);
 
   /**

--- a/source/extensions/filters/http/jwt_authn/extractor.cc
+++ b/source/extensions/filters/http/jwt_authn/extractor.cc
@@ -176,7 +176,8 @@ std::vector<JwtLocationConstPtr> ExtractorImpl::extract(const Http::HeaderMap& h
   }
 
   // Check query parameter locations.
-  const auto& params = Http::Utility::parseQueryString(headers.Path()->value().c_str());
+  Http::Utility::QueryParamsImpl query_params_impl;
+  const auto& params = query_params_impl.parseQueryString(headers.Path()->value().c_str());
   for (const auto& location_it : param_locations_) {
     const auto& param_key = location_it.first;
     const auto& location_spec = location_it.second;

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -194,7 +194,7 @@ const Http::HeaderMap& AdminFilter::getRequestHeaders() const {
   return *request_headers_;
 }
 
-bool AdminImpl::changeLogLevel(const Http::Utility::QueryParams& params) {
+bool AdminImpl::changeLogLevel(const Http::Utility::QueryParamsMap& params) {
   if (params.size() != 1) {
     return false;
   }
@@ -394,7 +394,7 @@ void AdminImpl::writeClustersAsText(Buffer::Instance& response) {
 
 Http::Code AdminImpl::handlerClusters(absl::string_view url, Http::HeaderMap& response_headers,
                                       Buffer::Instance& response, AdminStream&) {
-  Http::Utility::QueryParams query_params = Http::Utility::parseQueryString(url);
+  Http::Utility::QueryParamsMap query_params = query_params_.parseQueryString(url);
   auto it = query_params.find("format");
 
   if (it != query_params.end() && it->second == "json") {
@@ -427,7 +427,7 @@ Http::Code AdminImpl::handlerConfigDump(absl::string_view, Http::HeaderMap& resp
 
 Http::Code AdminImpl::handlerCpuProfiler(absl::string_view url, Http::HeaderMap&,
                                          Buffer::Instance& response, AdminStream&) {
-  Http::Utility::QueryParams query_params = Http::Utility::parseQueryString(url);
+  Http::Utility::QueryParamsMap query_params = query_params_.parseQueryString(url);
   if (query_params.size() != 1 || query_params.begin()->first != "enable" ||
       (query_params.begin()->second != "y" && query_params.begin()->second != "n")) {
     response.add("?enable=<y|n>\n");
@@ -471,7 +471,7 @@ Http::Code AdminImpl::handlerHotRestartVersion(absl::string_view, Http::HeaderMa
 
 Http::Code AdminImpl::handlerLogging(absl::string_view url, Http::HeaderMap&,
                                      Buffer::Instance& response, AdminStream&) {
-  Http::Utility::QueryParams query_params = Http::Utility::parseQueryString(url);
+  Http::Utility::QueryParamsMap query_params = query_params_.parseQueryString(url);
 
   Http::Code rc = Http::Code::OK;
   if (!changeLogLevel(query_params)) {
@@ -529,7 +529,7 @@ Http::Code AdminImpl::handlerServerInfo(absl::string_view, Http::HeaderMap&,
 Http::Code AdminImpl::handlerStats(absl::string_view url, Http::HeaderMap& response_headers,
                                    Buffer::Instance& response, AdminStream& admin_stream) {
   Http::Code rc = Http::Code::OK;
-  const Http::Utility::QueryParams params = Http::Utility::parseQueryString(url);
+  const Http::Utility::QueryParamsMap params = query_params_.parseQueryString(url);
 
   const bool used_only = params.find("usedonly") != params.end();
   const bool has_format = !(params.find("format") == params.end());
@@ -772,7 +772,7 @@ Http::Code AdminImpl::handlerCerts(absl::string_view, Http::HeaderMap&, Buffer::
 
 Http::Code AdminImpl::handlerRuntime(absl::string_view url, Http::HeaderMap& response_headers,
                                      Buffer::Instance& response, AdminStream&) {
-  const Http::Utility::QueryParams params = Http::Utility::parseQueryString(url);
+  const Http::Utility::QueryParamsMap params = query_params_.parseQueryString(url);
   response_headers.insertContentType().value().setReference(
       Http::Headers::get().ContentTypeValues.Json);
 
@@ -860,7 +860,7 @@ std::string AdminImpl::runtimeAsJson(
 
 Http::Code AdminImpl::handlerRuntimeModify(absl::string_view url, Http::HeaderMap&,
                                            Buffer::Instance& response, AdminStream&) {
-  const Http::Utility::QueryParams params = Http::Utility::parseQueryString(url);
+  const Http::Utility::QueryParamsMap params = query_params_.parseQueryString(url);
   if (params.empty()) {
     response.add("usage: /runtime_modify?key1=value1&key2=value2&keyN=valueN\n");
     response.add("use an empty value to remove a previously added override");

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -151,7 +151,7 @@ private:
    * @param params supplies the incoming endpoint query params.
    * @return TRUE if level change succeeded, FALSE otherwise.
    */
-  bool changeLogLevel(const Http::Utility::QueryParams& params);
+  bool changeLogLevel(const Http::Utility::QueryParamsMap& params);
 
   /**
    * Helper methods for the /clusters url handler.
@@ -291,6 +291,7 @@ private:
   Http::Http1Settings http1_settings_;
   ConfigTrackerImpl config_tracker_;
   const Network::FilterChainSharedPtr admin_filter_chain_;
+  Http::Utility::QueryParamsImpl query_params_;
 };
 
 /**

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -231,6 +231,14 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "query_params_test",
+    srcs = ["query_params_test.cc"],
+    deps = [
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "user_agent_test",
     srcs = ["user_agent_test.cc"],
     deps = [

--- a/test/common/http/query_params_test.cc
+++ b/test/common/http/query_params_test.cc
@@ -1,0 +1,39 @@
+#include <string>
+
+#include "common/http/utility.h"
+
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Http {
+
+TEST(HttpUtility, parseQueryString) {
+  Utility::QueryParamsImpl query_params_impl;
+  EXPECT_EQ(Utility::QueryParamsMap(), query_params_impl.parseQueryString("/hello"));
+  EXPECT_EQ(Utility::QueryParamsMap(), query_params_impl.parseQueryString("/hello?"));
+  EXPECT_EQ(Utility::QueryParamsMap({{"hello", ""}}),
+            query_params_impl.parseQueryString("/hello?hello"));
+  EXPECT_EQ(Utility::QueryParamsMap({{"hello", "world"}}),
+            query_params_impl.parseQueryString("/hello?hello=world"));
+  EXPECT_EQ(Utility::QueryParamsMap({{"hello", ""}}),
+            query_params_impl.parseQueryString("/hello?hello="));
+  EXPECT_EQ(Utility::QueryParamsMap({{"hello", ""}}),
+            query_params_impl.parseQueryString("/hello?hello=&"));
+  EXPECT_EQ(Utility::QueryParamsMap({{"hello", ""}, {"hello2", "world2"}}),
+            query_params_impl.parseQueryString("/hello?hello=&hello2=world2"));
+  EXPECT_EQ(Utility::QueryParamsMap({{"name", "admin"}, {"level", "trace"}}),
+            query_params_impl.parseQueryString("/logging?name=admin&level=trace"));
+}
+
+TEST(HttpUtility, QueryParamsToString) {
+  Utility::QueryParamsImpl query_params_impl;
+  EXPECT_EQ("", query_params_impl.queryParamsToString(Utility::QueryParamsMap({})));
+  EXPECT_EQ("?a=1", query_params_impl.queryParamsToString(Utility::QueryParamsMap({{"a", "1"}})));
+  EXPECT_EQ("?a=1&b=2", query_params_impl.queryParamsToString(
+                            Utility::QueryParamsMap({{"a", "1"}, {"b", "2"}})));
+}
+
+} // namespace Http
+} // namespace Envoy

--- a/test/common/http/utility_fuzz_test.cc
+++ b/test/common/http/utility_fuzz_test.cc
@@ -8,9 +8,10 @@ namespace Envoy {
 namespace Fuzz {
 
 DEFINE_PROTO_FUZZER(const test::common::http::UtilityTestCase& input) {
+  Http::Utility::QueryParamsImpl query_params_impl;
   switch (input.utility_selector_case()) {
   case test::common::http::UtilityTestCase::kParseQueryString: {
-    Http::Utility::parseQueryString(input.parse_query_string());
+    query_params_impl.parseQueryString(input.parse_query_string());
     break;
   }
   case test::common::http::UtilityTestCase::kParseCookieValue: {

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -21,20 +21,6 @@ using testing::InvokeWithoutArgs;
 namespace Envoy {
 namespace Http {
 
-TEST(HttpUtility, parseQueryString) {
-  EXPECT_EQ(Utility::QueryParams(), Utility::parseQueryString("/hello"));
-  EXPECT_EQ(Utility::QueryParams(), Utility::parseQueryString("/hello?"));
-  EXPECT_EQ(Utility::QueryParams({{"hello", ""}}), Utility::parseQueryString("/hello?hello"));
-  EXPECT_EQ(Utility::QueryParams({{"hello", "world"}}),
-            Utility::parseQueryString("/hello?hello=world"));
-  EXPECT_EQ(Utility::QueryParams({{"hello", ""}}), Utility::parseQueryString("/hello?hello="));
-  EXPECT_EQ(Utility::QueryParams({{"hello", ""}}), Utility::parseQueryString("/hello?hello=&"));
-  EXPECT_EQ(Utility::QueryParams({{"hello", ""}, {"hello2", "world2"}}),
-            Utility::parseQueryString("/hello?hello=&hello2=world2"));
-  EXPECT_EQ(Utility::QueryParams({{"name", "admin"}, {"level", "trace"}}),
-            Utility::parseQueryString("/logging?name=admin&level=trace"));
-}
-
 TEST(HttpUtility, getResponseStatus) {
   EXPECT_THROW(Utility::getResponseStatus(TestHeaderMapImpl{}), CodecClientException);
   EXPECT_EQ(200U, Utility::getResponseStatus(TestHeaderMapImpl{{":status", "200"}}));
@@ -505,13 +491,6 @@ TEST(HttpUtility, TestPrepareHeaders) {
 
   EXPECT_STREQ("/x/y/z", message->headers().Path()->value().c_str());
   EXPECT_STREQ("dns.name", message->headers().Host()->value().c_str());
-}
-
-TEST(HttpUtility, QueryParamsToString) {
-  EXPECT_EQ("", Utility::queryParamsToString(Utility::QueryParams({})));
-  EXPECT_EQ("?a=1", Utility::queryParamsToString(Utility::QueryParams({{"a", "1"}})));
-  EXPECT_EQ("?a=1&b=2",
-            Utility::queryParamsToString(Utility::QueryParams({{"a", "1"}, {"b", "2"}})));
 }
 
 } // namespace Http


### PR DESCRIPTION
*Description*: Moving QueryParams to its own class to allow for future improvements on parsing, serialization, escaping ect.
*Risk Level*: low
*Testing*: unit tests
*Release Notes*: N/A
#4142