### PR TITLE
Highlight deprecation of *.deprecated_v1 fields in notice

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -8,8 +8,8 @@ A logged warning is expected for each deprecated item that is in deprecation win
 
 ## Version 1.8.0 (pending)
 
-* Use of the v1 API is deprecated. See envoy-announce
-  [email](https://groups.google.com/forum/#!topic/envoy-announce/oPnYMZw8H4U).
+* Use of the v1 API (including `*.deprecated_v1` fields in the v2 API) is deprecated.
+  See envoy-announce [email](https://groups.google.com/forum/#!topic/envoy-announce/oPnYMZw8H4U).
 * Use of the legacy
   [ratelimit.proto](https://github.com/envoyproxy/envoy/blob/b0a518d064c8255e0e20557a8f909b6ff457558f/source/common/ratelimit/ratelimit.proto)
   is deprecated, in favor of the proto defined in


### PR DESCRIPTION
Signed-off-by: Venil Noronha <veniln@vmware.com>

This is a followup change as requested in [this comment](https://github.com/envoyproxy/envoy/pull/4446#issuecomment-423306038) in #4446.

/cc @ggreenway @htuch 