### PR TITLE
time: Makes sleep() and waitFor() part of the TimeSystem interface, adding and testing SimulatedTimeSystem::waitFor.

### DIFF
--- a/include/envoy/event/BUILD
+++ b/include/envoy/event/BUILD
@@ -46,6 +46,7 @@ envoy_cc_library(
     name = "timer_interface",
     hdrs = ["timer.h"],
     deps = [
+        "//source/common/common:thread_lib",
         "//source/common/event:libevent_lib",
     ],
 )

--- a/include/envoy/event/timer.h
+++ b/include/envoy/event/timer.h
@@ -7,6 +7,7 @@
 #include "envoy/common/pure.h"
 #include "envoy/common/time.h"
 
+#include "common/common/thread.h"
 #include "common/event/libevent.h"
 
 namespace Envoy {
@@ -59,11 +60,40 @@ class TimeSystem : public TimeSource {
 public:
   virtual ~TimeSystem() {}
 
+  using Duration = MonotonicTime::duration;
+
   /**
    * Creates a timer factory. This indirection enables thread-local timer-queue management,
    * so servers can have a separate timer-factory in each thread.
    */
   virtual SchedulerPtr createScheduler(Libevent::BasePtr&) PURE;
+
+  /**
+   * Advances time forward by the specified duration, running any timers
+   * along the way that have been scheduled to fire.
+   *
+   * @param duration The amount of time to sleep.
+   */
+  virtual void sleep(const Duration& duration) PURE;
+  template <class D> void sleep(const D& duration) {
+    sleep(std::chrono::duration_cast<Duration>(duration));
+  }
+
+  /**
+   * Waits for the specified duration to expire, or for a condvar to
+   * be notified, whichever comes first.
+   *
+   * @param duration The amount of time to sleep.
+   */
+  virtual Thread::CondVar::WaitStatus
+  waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
+          const Duration& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) PURE;
+
+  template <class D>
+  Thread::CondVar::WaitStatus waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
+                                      const D& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) {
+    return waitFor(mutex, condvar, std::chrono::duration_cast<Duration>(duration));
+  }
 };
 
 } // namespace Event

--- a/source/common/event/real_time_system.cc
+++ b/source/common/event/real_time_system.cc
@@ -29,5 +29,13 @@ SchedulerPtr RealTimeSystem::createScheduler(Libevent::BasePtr& libevent) {
   return std::make_unique<RealScheduler>(libevent);
 }
 
+void RealTimeSystem::sleep(const Duration& duration) { std::this_thread::sleep_for(duration); }
+
+Thread::CondVar::WaitStatus RealTimeSystem::waitFor(Thread::MutexBasicLockable& lock,
+                                                    Thread::CondVar& condvar,
+                                                    const Duration& duration) noexcept {
+  return condvar.waitFor(lock, duration);
+}
+
 } // namespace Event
 } // namespace Envoy

--- a/source/common/event/real_time_system.h
+++ b/source/common/event/real_time_system.h
@@ -14,6 +14,10 @@ class RealTimeSystem : public TimeSystem {
 public:
   // TimeSystem
   SchedulerPtr createScheduler(Libevent::BasePtr&) override;
+  void sleep(const Duration& duration) override;
+  Thread::CondVar::WaitStatus
+  waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
+          const Duration& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) override;
 
   // TimeSource
   SystemTime systemTime() override { return time_source_.systemTime(); }

--- a/test/extensions/filters/http/jwt_authn/BUILD
+++ b/test/extensions/filters/http/jwt_authn/BUILD
@@ -71,7 +71,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/common:jwks_fetcher_lib",
         "//source/extensions/filters/http/jwt_authn:jwks_cache_lib",
         "//test/extensions/filters/http/jwt_authn:test_common_lib",
-        "//test/test_common:test_time_lib",
+        "//test/test_common:simulated_time_system_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/mocks/common.h
+++ b/test/mocks/common.h
@@ -58,6 +58,12 @@ public:
   Event::SchedulerPtr createScheduler(Event::Libevent::BasePtr& base) override {
     return real_time_system_.createScheduler(base);
   }
+  void sleep(const Duration& duration) override { real_time_system_.sleep(duration); }
+  Thread::CondVar::WaitStatus waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
+                                      const Duration& duration)
+      noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) override {
+    return real_time_system_.waitFor(mutex, condvar, duration);
+  }
   MOCK_METHOD0(systemTime, SystemTime());
   MOCK_METHOD0(monotonicTime, MonotonicTime());
 

--- a/test/test_common/simulated_time_system.h
+++ b/test/test_common/simulated_time_system.h
@@ -16,6 +16,7 @@ namespace Event {
 class SimulatedTimeSystem : public TimeSystem {
 public:
   SimulatedTimeSystem();
+  ~SimulatedTimeSystem();
 
   // TimeSystem
   SchedulerPtr createScheduler(Libevent::BasePtr&) override;
@@ -23,20 +24,10 @@ public:
   // TimeSource
   SystemTime systemTime() override;
   MonotonicTime monotonicTime() override;
-
-  /**
-   * Advances time forward by the specified duration, running any timers
-   * along the way that have been scheduled to fire.
-   *
-   * @param duration The amount of time to sleep, expressed in any type that
-   * can be duration_casted to MonotonicTime::duration.
-   */
-  template <class Duration> void sleep(const Duration& duration) {
-    mutex_.lock();
-    MonotonicTime monotonic_time =
-        monotonic_time_ + std::chrono::duration_cast<MonotonicTime::duration>(duration);
-    setMonotonicTimeAndUnlock(monotonic_time);
-  }
+  void sleep(const Duration& duration) override;
+  Thread::CondVar::WaitStatus
+  waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
+          const Duration& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) override;
 
   /**
    * Sets the time forward monotonically. If the supplied argument moves
@@ -92,12 +83,19 @@ private:
   void addAlarm(Alarm*, const std::chrono::milliseconds& duration);
   void removeAlarm(Alarm*);
 
+  // Keeps track of how many alarms have been activated but not yet called,
+  // which helps waitFor() determine when to give up and declare a timeout.
+  void incPending() { ++pending_alarms_; }
+  void decPending() { --pending_alarms_; }
+  bool hasPending() { return pending_alarms_ > 0; }
+
   RealTimeSource real_time_source_; // Used to initialize monotonic_time_ and system_time_;
   MonotonicTime monotonic_time_ GUARDED_BY(mutex_);
   SystemTime system_time_ GUARDED_BY(mutex_);
   AlarmSet alarms_ GUARDED_BY(mutex_);
   uint64_t index_ GUARDED_BY(mutex_);
   mutable Thread::MutexBasicLockable mutex_;
+  std::atomic<uint32_t> pending_alarms_;
 };
 
 } // namespace Event


### PR DESCRIPTION
*Description*: In order to control time during integration tests, we must virtualize sleep() and CondVar::waitFor(). This is one step toward resolving https://github.com/envoyproxy/envoy/issues/4474
*Risk Level*: low
*Testing*: //test/...
*Docs Changes*: n/a
*Release Notes*: n/a

