### PR TITLE
fuzz: fix oss-fuzz build.

### DIFF
--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -32,7 +32,9 @@ void Runner::setupEnvironment(int argc, char** argv, spdlog::level::level_enum d
   log_level_ =
       environment_log_level <= spdlog::level::debug ? environment_log_level : default_log_level;
   // This needs to work in both the Envoy test shim and oss-fuzz build environments, so we can't
-  // allocate in main.cc. Instead, just create these non-PODs to live forever.
+  // allocate in main.cc. Instead, just create these non-PODs to live forever, since we don't get a
+  // shutdown hook (see
+  // https://github.com/llvm-mirror/compiler-rt/blob/master/lib/fuzzer/FuzzerInterface.h).
   static auto* lock = new Thread::MutexBasicLockable();
   static auto* logging_context =
       new Logger::Context(log_level_, TestEnvironment::getOptions().logFormat(), *lock);

--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -1,5 +1,6 @@
 #include "test/fuzz/fuzz_runner.h"
 
+#include "common/common/thread.h"
 #include "common/common/utility.h"
 #include "common/event/libevent.h"
 
@@ -30,6 +31,12 @@ void Runner::setupEnvironment(int argc, char** argv, spdlog::level::level_enum d
   // spew too much when running under a fuzz engine.
   log_level_ =
       environment_log_level <= spdlog::level::debug ? environment_log_level : default_log_level;
+  // This needs to work in both the Envoy test shim and oss-fuzz build environments, so we can't
+  // allocate in main.cc. Instead, just create these non-PODs to live forever.
+  static auto* lock = new Thread::MutexBasicLockable();
+  static auto* logging_context =
+      new Logger::Context(log_level_, TestEnvironment::getOptions().logFormat(), *lock);
+  UNREFERENCED_PARAMETER(logging_context);
 }
 
 } // namespace Fuzz

--- a/test/fuzz/main.cc
+++ b/test/fuzz/main.cc
@@ -14,7 +14,6 @@
 
 #include "common/common/assert.h"
 #include "common/common/logger.h"
-#include "common/common/thread.h"
 #include "common/filesystem/filesystem_impl.h"
 
 #include "test/fuzz/fuzz_runner.h"
@@ -53,7 +52,6 @@ int main(int argc, char** argv) {
   Envoy::test_corpus_ = Envoy::TestUtility::listFiles(corpus_path, true);
   testing::InitGoogleTest(&argc, argv);
   Envoy::Fuzz::Runner::setupEnvironment(argc, argv, spdlog::level::info);
-  Envoy::Thread::MutexBasicLockable lock;
   Envoy::Logger::Context logging_context(Envoy::Fuzz::Runner::logLevel(),
                                          Envoy::TestEnvironment::getOptions().logFormat(), lock);
 

--- a/test/fuzz/main.cc
+++ b/test/fuzz/main.cc
@@ -52,8 +52,6 @@ int main(int argc, char** argv) {
   Envoy::test_corpus_ = Envoy::TestUtility::listFiles(corpus_path, true);
   testing::InitGoogleTest(&argc, argv);
   Envoy::Fuzz::Runner::setupEnvironment(argc, argv, spdlog::level::info);
-  Envoy::Logger::Context logging_context(Envoy::Fuzz::Runner::logLevel(),
-                                         Envoy::TestEnvironment::getOptions().logFormat(), lock);
 
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This has been broken since #4435, since oss-fuzz doesn't use the fuzz test runner shim, it has its
own main.cc.

Risk Level: Low
Testing: check_build with oss-fuzz Docker image.

Signed-off-by: Harvey Tuch <htuch@google.com>