### PR TITLE
upstream: add priority to HostDescription

### DIFF
--- a/include/envoy/upstream/host_description.h
+++ b/include/envoy/upstream/host_description.h
@@ -113,6 +113,16 @@ public:
    * Set the address used to health check the host.
    */
   virtual void setHealthCheckAddress(Network::Address::InstanceConstSharedPtr) PURE;
+
+  /**
+   * @return the priority of the host.
+   */
+  virtual uint32_t priority() const PURE;
+
+  /**
+   * Set the current priority.
+   */
+  virtual void priority(uint32_t) PURE;
 };
 
 typedef std::shared_ptr<const HostDescription> HostDescriptionConstSharedPtr;

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -150,6 +150,8 @@ bool EdsClusterImpl::updateHostsPerLocality(
       updateDynamicHostList(new_hosts, *current_hosts_copy, hosts_added, hosts_removed,
                             updated_hosts) ||
       locality_weights_map != new_locality_weights_map) {
+    ASSERT(std::all_of(current_hosts_copy->begin(), current_hosts_copy->end(),
+                       [&](const auto& host) { return host->priority() == priority; }));
     locality_weights_map = new_locality_weights_map;
     ENVOY_LOG(debug, "EDS hosts or locality weights changed for cluster: {} ({}) priority {}",
               info_->name(), host_set.hosts().size(), host_set.priority());

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -196,11 +196,11 @@ HdsCluster::HdsCluster(Runtime::Loader& runtime, const envoy::api::v2::Cluster& 
                                      added_via_api_, cm, local_info, dispatcher, random);
 
   for (const auto& host : cluster.hosts()) {
-    initial_hosts_->emplace_back(
-        new HostImpl(info_, "", Network::Address::resolveProtoAddress(host),
-                     envoy::api::v2::core::Metadata::default_instance(), 1,
-                     envoy::api::v2::core::Locality().default_instance(),
-                     envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance()));
+    initial_hosts_->emplace_back(new HostImpl(
+        info_, "", Network::Address::resolveProtoAddress(host),
+        envoy::api::v2::core::Metadata::default_instance(), 1,
+        envoy::api::v2::core::Locality().default_instance(),
+        envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance(), 0));
   }
   initialize([] {});
 }

--- a/source/common/upstream/logical_dns_cluster.h
+++ b/source/common/upstream/logical_dns_cluster.h
@@ -46,7 +46,8 @@ private:
         : HostImpl(cluster, hostname, address, parent.lbEndpoint().metadata(),
                    parent.lbEndpoint().load_balancing_weight().value(),
                    parent.localityLbEndpoint().locality(),
-                   parent.lbEndpoint().endpoint().health_check_config()),
+                   parent.lbEndpoint().endpoint().health_check_config(),
+                   parent.localityLbEndpoint().priority()),
           parent_(parent) {}
 
     // Upstream::Host
@@ -108,12 +109,13 @@ private:
     }
     // Setting health check address is usually done at initialization. This is NOP by default.
     void setHealthCheckAddress(Network::Address::InstanceConstSharedPtr) override {}
-    uint32_t priority() const { return locality_lb_endpoint_.priority(); }
+    uint32_t priority() const override { return locality_lb_endpoint_.priority(); }
+    void priority(uint32_t priority) override { locality_lb_endpoint_.set_priority(priority); }
     Network::Address::InstanceConstSharedPtr address_;
     HostConstSharedPtr logical_host_;
     const std::shared_ptr<envoy::api::v2::core::Metadata> metadata_;
     Network::Address::InstanceConstSharedPtr health_check_address_;
-    const envoy::api::v2::endpoint::LocalityLbEndpoints& locality_lb_endpoint_;
+    envoy::api::v2::endpoint::LocalityLbEndpoints locality_lb_endpoint_;
     const envoy::api::v2::endpoint::LbEndpoint& lb_endpoint_;
   };
 

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -81,7 +81,7 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
             info_, info_->name() + dst_addr.asString(), std::move(host_ip_port),
             envoy::api::v2::core::Metadata::default_instance(), 1,
             envoy::api::v2::core::Locality().default_instance(),
-            envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance()));
+            envoy::api::v2::endpoint::Endpoint::HealthCheckConfig().default_instance(), 0));
 
         ENVOY_LOG(debug, "Created host {}.", host->address()->asString());
         // Add the new host to the map. We just failed to find it in

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -751,10 +751,10 @@ void PriorityStateManager::registerHostForPriority(
     const envoy::api::v2::endpoint::LocalityLbEndpoints& locality_lb_endpoint,
     const envoy::api::v2::endpoint::LbEndpoint& lb_endpoint,
     const absl::optional<Upstream::Host::HealthFlag> health_checker_flag) {
-  const HostSharedPtr host(new HostImpl(parent_.info(), hostname, address, lb_endpoint.metadata(),
-                                        lb_endpoint.load_balancing_weight().value(),
-                                        locality_lb_endpoint.locality(),
-                                        lb_endpoint.endpoint().health_check_config()));
+  const HostSharedPtr host(
+      new HostImpl(parent_.info(), hostname, address, lb_endpoint.metadata(),
+                   lb_endpoint.load_balancing_weight().value(), locality_lb_endpoint.locality(),
+                   lb_endpoint.endpoint().health_check_config(), locality_lb_endpoint.priority()));
   registerHostForPriority(host, locality_lb_endpoint, lb_endpoint, health_checker_flag);
 }
 
@@ -983,6 +983,12 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(
         hosts_changed = true;
       }
 
+      // Did the priority change?
+      if (host->priority() != existing_host->second->priority()) {
+        existing_host->second->priority(host->priority());
+        hosts_changed = true;
+      }
+
       existing_host->second->weight(host->weight());
       final_hosts.push_back(existing_host->second);
       updated_hosts[existing_host->second->address()->asString()] = existing_host->second;
@@ -1173,7 +1179,8 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
           new_hosts.emplace_back(new HostImpl(
               parent_.info_, dns_address_, Network::Utility::getAddressWithPort(*address, port_),
               lb_endpoint_.metadata(), lb_endpoint_.load_balancing_weight().value(),
-              locality_lb_endpoint_.locality(), lb_endpoint_.endpoint().health_check_config()));
+              locality_lb_endpoint_.locality(), lb_endpoint_.endpoint().health_check_config(),
+              locality_lb_endpoint_.priority()));
         }
 
         HostVector hosts_added;
@@ -1181,6 +1188,9 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
         if (parent_.updateDynamicHostList(new_hosts, hosts_, hosts_added, hosts_removed,
                                           updated_hosts)) {
           ENVOY_LOG(debug, "DNS hosts have changed for {}", dns_address_);
+          ASSERT(std::all_of(hosts_.begin(), hosts_.end(), [&](const auto& host) {
+            return host->priority() == locality_lb_endpoint_.priority();
+          }));
           parent_.updateAllHosts(hosts_added, hosts_removed, locality_lb_endpoint_.priority());
         }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -986,7 +986,6 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(
       // Did the priority change?
       if (host->priority() != existing_host->second->priority()) {
         existing_host->second->priority(host->priority());
-        hosts_changed = true;
       }
 
       existing_host->second->weight(host->weight());

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -65,7 +65,8 @@ public:
       Network::Address::InstanceConstSharedPtr dest_address,
       const envoy::api::v2::core::Metadata& metadata,
       const envoy::api::v2::core::Locality& locality,
-      const envoy::api::v2::endpoint::Endpoint::HealthCheckConfig& health_check_config)
+      const envoy::api::v2::endpoint::Endpoint::HealthCheckConfig& health_check_config,
+      uint32_t priority)
       : cluster_(cluster), hostname_(hostname), address_(dest_address),
         health_check_address_(health_check_config.port_value() == 0
                                   ? dest_address
@@ -76,7 +77,8 @@ public:
                     .bool_value()),
         metadata_(std::make_shared<envoy::api::v2::core::Metadata>(metadata)),
         locality_(locality), stats_{ALL_HOST_STATS(POOL_COUNTER(stats_store_),
-                                                   POOL_GAUGE(stats_store_))} {}
+                                                   POOL_GAUGE(stats_store_))},
+        priority_(priority) {}
 
   // Upstream::HostDescription
   bool canary() const override { return canary_; }
@@ -128,6 +130,8 @@ public:
   // Setting health check address is usually done at initialization. This is NOP by default.
   void setHealthCheckAddress(Network::Address::InstanceConstSharedPtr) override {}
   const envoy::api::v2::core::Locality& locality() const override { return locality_; }
+  uint32_t priority() const override { return priority_; }
+  void priority(uint32_t priority) override { priority_ = priority; }
 
 protected:
   ClusterInfoConstSharedPtr cluster_;
@@ -142,6 +146,7 @@ protected:
   HostStats stats_;
   Outlier::DetectorHostMonitorPtr outlier_detector_;
   HealthCheckHostMonitorPtr health_checker_;
+  uint32_t priority_;
 };
 
 /**
@@ -155,8 +160,10 @@ public:
            Network::Address::InstanceConstSharedPtr address,
            const envoy::api::v2::core::Metadata& metadata, uint32_t initial_weight,
            const envoy::api::v2::core::Locality& locality,
-           const envoy::api::v2::endpoint::Endpoint::HealthCheckConfig& health_check_config)
-      : HostDescriptionImpl(cluster, hostname, address, metadata, locality, health_check_config),
+           const envoy::api::v2::endpoint::Endpoint::HealthCheckConfig& health_check_config,
+           uint32_t priority)
+      : HostDescriptionImpl(cluster, hostname, address, metadata, locality, health_check_config,
+                            priority),
         used_(true) {
     weight(initial_weight);
   }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -146,7 +146,7 @@ protected:
   HostStats stats_;
   Outlier::DetectorHostMonitorPtr outlier_detector_;
   HealthCheckHostMonitorPtr health_checker_;
-  uint32_t priority_;
+  std::atomic<uint32_t> priority_;
 };
 
 /**

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -616,6 +616,7 @@ TEST_F(EdsTest, EndpointMoved) {
     EXPECT_EQ(hosts.size(), 1);
 
     EXPECT_TRUE(hosts[0]->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC));
+    EXPECT_EQ(0, hosts[0]->priority());
     // Mark the host as healthy
     hosts[0]->healthFlagClear(Host::HealthFlag::FAILED_ACTIVE_HC);
   }
@@ -625,6 +626,7 @@ TEST_F(EdsTest, EndpointMoved) {
     EXPECT_EQ(hosts.size(), 1);
 
     EXPECT_TRUE(hosts[0]->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC));
+    EXPECT_EQ(1, hosts[0]->priority());
     // Mark the host as healthy
     hosts[0]->healthFlagClear(Host::HealthFlag::FAILED_ACTIVE_HC);
   }
@@ -639,9 +641,10 @@ TEST_F(EdsTest, EndpointMoved) {
   {
     auto& hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
     EXPECT_EQ(hosts.size(), 1);
-    //
+
     // assert that it moved
     EXPECT_EQ(hosts[0]->address()->asString(), "1.2.3.4:81");
+    EXPECT_EQ(0, hosts[0]->priority());
 
     // The endpoint was healthy in the original priority, so moving it
     // around should preserve that.
@@ -654,6 +657,7 @@ TEST_F(EdsTest, EndpointMoved) {
 
     // assert that it moved
     EXPECT_EQ(hosts[0]->address()->asString(), "1.2.3.4:80");
+    EXPECT_EQ(1, hosts[0]->priority());
 
     // The endpoint was healthy in the original priority, so moving it
     // around should preserve that.
@@ -697,6 +701,7 @@ TEST_F(EdsTest, EndpointLocality) {
   auto& hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
   EXPECT_EQ(hosts.size(), 2);
   for (int i = 0; i < 2; ++i) {
+    EXPECT_EQ(0, hosts[i]->priority());
     const auto& locality = hosts[i]->locality();
     EXPECT_EQ("oceania", locality.region());
     EXPECT_EQ("hello", locality.zone());

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -29,7 +29,7 @@ static HostSharedPtr newTestHost(Upstream::ClusterInfoConstSharedPtr cluster,
   return HostSharedPtr{
       new HostImpl(cluster, "", Network::Utility::resolveUrl(url),
                    envoy::api::v2::core::Metadata::default_instance(), weight, locality,
-                   envoy::api::v2::endpoint::Endpoint::HealthCheckConfig::default_instance())};
+                   envoy::api::v2::endpoint::Endpoint::HealthCheckConfig::default_instance(), 0)};
 }
 
 // Simulate weighted LR load balancer.

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -751,13 +751,14 @@ TEST(HostImplTest, HostnameCanaryAndLocality) {
   locality.set_sub_zone("world");
   HostImpl host(cluster.info_, "lyft.com", Network::Utility::resolveUrl("tcp://10.0.0.1:1234"),
                 metadata, 1, locality,
-                envoy::api::v2::endpoint::Endpoint::HealthCheckConfig::default_instance());
+                envoy::api::v2::endpoint::Endpoint::HealthCheckConfig::default_instance(), 1);
   EXPECT_EQ(cluster.info_.get(), &host.cluster());
   EXPECT_EQ("lyft.com", host.hostname());
   EXPECT_TRUE(host.canary());
   EXPECT_EQ("oceania", host.locality().region());
   EXPECT_EQ("hello", host.locality().zone());
   EXPECT_EQ("world", host.locality().sub_zone());
+  EXPECT_EQ(1, host.priority());
 }
 
 TEST(StaticClusterImplTest, InitialHosts) {

--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -79,7 +79,7 @@ inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::
   return HostSharedPtr{new HostImpl(
       cluster, "", Network::Utility::resolveUrl(url),
       envoy::api::v2::core::Metadata::default_instance(), weight, envoy::api::v2::core::Locality(),
-      envoy::api::v2::endpoint::Endpoint::HealthCheckConfig::default_instance())};
+      envoy::api::v2::endpoint::Endpoint::HealthCheckConfig::default_instance(), 0)};
 }
 
 inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
@@ -88,7 +88,7 @@ inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::
   return HostSharedPtr{
       new HostImpl(cluster, "", Network::Utility::resolveUrl(url), metadata, weight,
                    envoy::api::v2::core::Locality(),
-                   envoy::api::v2::endpoint::Endpoint::HealthCheckConfig::default_instance())};
+                   envoy::api::v2::endpoint::Endpoint::HealthCheckConfig::default_instance(), 0)};
 }
 
 inline HostSharedPtr
@@ -97,7 +97,7 @@ makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
              uint32_t weight = 1) {
   return HostSharedPtr{new HostImpl(cluster, "", Network::Utility::resolveUrl(url),
                                     envoy::api::v2::core::Metadata::default_instance(), weight,
-                                    envoy::api::v2::core::Locality(), health_check_config)};
+                                    envoy::api::v2::core::Locality(), health_check_config, 0)};
 }
 
 inline HostDescriptionConstSharedPtr makeTestHostDescription(ClusterInfoConstSharedPtr cluster,
@@ -106,7 +106,7 @@ inline HostDescriptionConstSharedPtr makeTestHostDescription(ClusterInfoConstSha
       cluster, "", Network::Utility::resolveUrl(url),
       envoy::api::v2::core::Metadata::default_instance(),
       envoy::api::v2::core::Locality().default_instance(),
-      envoy::api::v2::endpoint::Endpoint::HealthCheckConfig::default_instance())};
+      envoy::api::v2::endpoint::Endpoint::HealthCheckConfig::default_instance(), 0)};
 }
 
 inline HostsPerLocalitySharedPtr makeHostsPerLocality(std::vector<HostVector>&& locality_hosts,

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -86,6 +86,8 @@ public:
   MOCK_CONST_METHOD0(hostname, const std::string&());
   MOCK_CONST_METHOD0(stats, HostStats&());
   MOCK_CONST_METHOD0(locality, const envoy::api::v2::core::Locality&());
+  MOCK_CONST_METHOD0(priority, uint32_t());
+  MOCK_METHOD1(priority, void(uint32_t));
 
   std::string hostname_;
   Network::Address::InstanceConstSharedPtr address_;
@@ -157,6 +159,8 @@ public:
   MOCK_CONST_METHOD0(used, bool());
   MOCK_METHOD1(used, void(bool new_used));
   MOCK_CONST_METHOD0(locality, const envoy::api::v2::core::Locality&());
+  MOCK_CONST_METHOD0(priority, uint32_t());
+  MOCK_METHOD1(priority, void(uint32_t));
 
   testing::NiceMock<MockClusterInfo> cluster_;
   testing::NiceMock<Outlier::MockDetectorHostMonitor> outlier_detector_;


### PR DESCRIPTION
This adds priority to `HostDescrption` to allow inspecting the
priority that the host currently belongs to. This will be used to
inspect the priorities attempted during retry host selection. 

The priority will be stored on the `HostImpl` when it's first initialized and kept up to date by updating it whenever the host moves between priorities.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Medium, changes to host update
*Testing*: Unit tests
*Docs Changes*: n/a
*Release Notes*: n/a
