### PR TITLE
time: Do not provide TimeSystem::sleep and waitFor in production interface

### DIFF
--- a/include/envoy/event/timer.h
+++ b/include/envoy/event/timer.h
@@ -67,36 +67,6 @@ public:
    * so servers can have a separate timer-factory in each thread.
    */
   virtual SchedulerPtr createScheduler(Libevent::BasePtr&) PURE;
-
-  /**
-   * Advances time forward by the specified duration, running any timers
-   * along the way that have been scheduled to fire.
-   *
-   * @param duration The amount of time to sleep.
-   */
-  virtual void sleep(const Duration& duration) PURE;
-  template <class D> void sleep(const D& duration) {
-    sleep(std::chrono::duration_cast<Duration>(duration));
-  }
-
-  /**
-   * Waits for the specified duration to expire, or for a condvar to
-   * be notified, whichever comes first.
-   *
-   * @param mutex A mutex which must be held before calling this function.
-   * @param condvar The condition to wait on.
-   * @param duration The maximum amount of time to wait.
-   * @return Thread::CondVar::WaitStatus whether the condition timed out or not.
-   */
-  virtual Thread::CondVar::WaitStatus
-  waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
-          const Duration& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) PURE;
-
-  template <class D>
-  Thread::CondVar::WaitStatus waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
-                                      const D& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) {
-    return waitFor(mutex, condvar, std::chrono::duration_cast<Duration>(duration));
-  }
 };
 
 } // namespace Event

--- a/source/common/event/real_time_system.cc
+++ b/source/common/event/real_time_system.cc
@@ -29,13 +29,5 @@ SchedulerPtr RealTimeSystem::createScheduler(Libevent::BasePtr& libevent) {
   return std::make_unique<RealScheduler>(libevent);
 }
 
-void RealTimeSystem::sleep(const Duration& duration) { std::this_thread::sleep_for(duration); }
-
-Thread::CondVar::WaitStatus RealTimeSystem::waitFor(Thread::MutexBasicLockable& lock,
-                                                    Thread::CondVar& condvar,
-                                                    const Duration& duration) noexcept {
-  return condvar.waitFor(lock, duration);
-}
-
 } // namespace Event
 } // namespace Envoy

--- a/source/common/event/real_time_system.h
+++ b/source/common/event/real_time_system.h
@@ -14,10 +14,6 @@ class RealTimeSystem : public TimeSystem {
 public:
   // TimeSystem
   SchedulerPtr createScheduler(Libevent::BasePtr&) override;
-  void sleep(const Duration& duration) override;
-  Thread::CondVar::WaitStatus
-  waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
-          const Duration& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) override;
 
   // TimeSource
   SystemTime systemTime() override { return time_source_.systemTime(); }

--- a/test/mocks/BUILD
+++ b/test/mocks/BUILD
@@ -15,8 +15,7 @@ envoy_cc_test_library(
     deps = [
         "//include/envoy/common:time_interface",
         "//include/envoy/common:token_bucket_interface",
-        "//include/envoy/event:timer_interface",
         "//source/common/common:minimal_logger_lib",
-        "//source/common/event:real_time_system_lib",
+        "//test/test_common:test_time_lib",
     ],
 )

--- a/test/mocks/common.h
+++ b/test/mocks/common.h
@@ -7,7 +7,8 @@
 #include "envoy/event/timer.h"
 
 #include "common/common/logger.h"
-#include "common/event/real_time_system.h"
+
+#include "test/test_common/test_time.h"
 
 #include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
@@ -46,7 +47,7 @@ public:
   MOCK_METHOD0(monotonicTime, MonotonicTime());
 };
 
-class MockTimeSystem : public Event::TimeSystem {
+class MockTimeSystem : public TestTimeSystem {
 public:
   MockTimeSystem();
   ~MockTimeSystem();
@@ -67,7 +68,7 @@ public:
   MOCK_METHOD0(systemTime, SystemTime());
   MOCK_METHOD0(monotonicTime, MonotonicTime());
 
-  Event::RealTimeSystem real_time_system_;
+  TestRealTimeSystem real_time_system_;
 };
 
 class MockTokenBucket : public TokenBucket {

--- a/test/mocks/common.h
+++ b/test/mocks/common.h
@@ -47,7 +47,7 @@ public:
   MOCK_METHOD0(monotonicTime, MonotonicTime());
 };
 
-class MockTimeSystem : public TestTimeSystem {
+class MockTimeSystem : public Event::TestTimeSystem {
 public:
   MockTimeSystem();
   ~MockTimeSystem();
@@ -68,7 +68,7 @@ public:
   MOCK_METHOD0(systemTime, SystemTime());
   MOCK_METHOD0(monotonicTime, MonotonicTime());
 
-  TestRealTimeSystem real_time_system_;
+  Event::TestRealTimeSystem real_time_system_;
 };
 
 class MockTokenBucket : public TokenBucket {

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -124,7 +124,16 @@ envoy_cc_test_library(
     srcs = ["test_time.cc"],
     hdrs = ["test_time.h"],
     deps = [
+        ":test_time_system_interface",
         "//source/common/event:real_time_system_lib",
+    ],
+)
+
+envoy_cc_test_library(
+    name = "test_time_system_interface",
+    hdrs = ["test_time_system.h"],
+    deps = [
+        "//include/envoy/event:timer_interface",
     ],
 )
 
@@ -133,6 +142,7 @@ envoy_cc_test_library(
     srcs = ["simulated_time_system.cc"],
     hdrs = ["simulated_time_system.h"],
     deps = [
+        ":test_time_system_interface",
         "//source/common/event:real_time_system_lib",
     ],
 )

--- a/test/test_common/simulated_time_system.h
+++ b/test/test_common/simulated_time_system.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "envoy/event/timer.h"
-
 #include "common/common/lock_guard.h"
 #include "common/common/thread.h"
 #include "common/common/utility.h"
+
+#include "test/test_common/test_time_system.h"
 
 namespace Envoy {
 namespace Event {
@@ -13,7 +13,7 @@ namespace Event {
 // sleep(), setSystemTime(), or setMonotonicTime(). systemTime() and
 // monotonicTime() are maintained in the class, and alarms are fired in response
 // to adjustments in time.
-class SimulatedTimeSystem : public TimeSystem {
+class SimulatedTimeSystem : public TestTimeSystem {
 public:
   SimulatedTimeSystem();
   ~SimulatedTimeSystem();
@@ -21,13 +21,15 @@ public:
   // TimeSystem
   SchedulerPtr createScheduler(Libevent::BasePtr&) override;
 
-  // TimeSource
-  SystemTime systemTime() override;
-  MonotonicTime monotonicTime() override;
+  // TestTimeSystem
   void sleep(const Duration& duration) override;
   Thread::CondVar::WaitStatus
   waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
           const Duration& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) override;
+
+  // TimeSource
+  SystemTime systemTime() override;
+  MonotonicTime monotonicTime() override;
 
   /**
    * Sets the time forward monotonically. If the supplied argument moves

--- a/test/test_common/test_time.cc
+++ b/test/test_common/test_time.cc
@@ -6,4 +6,12 @@ namespace Envoy {
 
 DangerousDeprecatedTestTime::DangerousDeprecatedTestTime() {}
 
+void TestRealTimeSystem::sleep(const Duration& duration) { std::this_thread::sleep_for(duration); }
+
+Thread::CondVar::WaitStatus TestRealTimeSystem::waitFor(Thread::MutexBasicLockable& lock,
+                                                        Thread::CondVar& condvar,
+                                                        const Duration& duration) noexcept {
+  return condvar.waitFor(lock, duration);
+}
+
 } // namespace Envoy

--- a/test/test_common/test_time.cc
+++ b/test/test_common/test_time.cc
@@ -6,6 +6,8 @@ namespace Envoy {
 
 DangerousDeprecatedTestTime::DangerousDeprecatedTestTime() {}
 
+namespace Event {
+
 void TestRealTimeSystem::sleep(const Duration& duration) { std::this_thread::sleep_for(duration); }
 
 Thread::CondVar::WaitStatus TestRealTimeSystem::waitFor(Thread::MutexBasicLockable& lock,
@@ -14,4 +16,5 @@ Thread::CondVar::WaitStatus TestRealTimeSystem::waitFor(Thread::MutexBasicLockab
   return condvar.waitFor(lock, duration);
 }
 
+} // namespace Event
 } // namespace Envoy

--- a/test/test_common/test_time.h
+++ b/test/test_common/test_time.h
@@ -2,7 +2,30 @@
 
 #include "common/event/real_time_system.h"
 
+#include "test/test_common/test_time_system.h"
+
 namespace Envoy {
+
+class TestRealTimeSystem : public TestTimeSystem {
+public:
+  // TestTimeSystem
+  void sleep(const Duration& duration) override;
+  Thread::CondVar::WaitStatus
+  waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
+          const Duration& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) override;
+
+  // Event::TimeSystem
+  Event::SchedulerPtr createScheduler(Event::Libevent::BasePtr& libevent) override {
+    return real_time_system_.createScheduler(libevent);
+  }
+
+  // TimeSource
+  SystemTime systemTime() override { return real_time_system_.systemTime(); }
+  MonotonicTime monotonicTime() override { return real_time_system_.monotonicTime(); }
+
+private:
+  Event::RealTimeSystem real_time_system_;
+};
 
 // Instantiates real-time sources for testing purposes. In general, this is a
 // bad idea, and tests should use simulated or mock time.
@@ -16,7 +39,7 @@ public:
   Event::TimeSystem& timeSystem() { return time_system_; }
 
 private:
-  Event::RealTimeSystem time_system_;
+  TestRealTimeSystem time_system_;
 };
 
 } // namespace Envoy

--- a/test/test_common/test_time.h
+++ b/test/test_common/test_time.h
@@ -5,6 +5,7 @@
 #include "test/test_common/test_time_system.h"
 
 namespace Envoy {
+namespace Event {
 
 class TestRealTimeSystem : public TestTimeSystem {
 public:
@@ -27,6 +28,8 @@ private:
   Event::RealTimeSystem real_time_system_;
 };
 
+} // namespace Event
+
 // Instantiates real-time sources for testing purposes. In general, this is a
 // bad idea, and tests should use simulated or mock time.
 //
@@ -39,7 +42,7 @@ public:
   Event::TimeSystem& timeSystem() { return time_system_; }
 
 private:
-  TestRealTimeSystem time_system_;
+  Event::TestRealTimeSystem time_system_;
 };
 
 } // namespace Envoy

--- a/test/test_common/test_time_system.h
+++ b/test/test_common/test_time_system.h
@@ -3,6 +3,7 @@
 #include "envoy/event/timer.h"
 
 namespace Envoy {
+namespace Event {
 
 // Adds sleep() and waitFor() interfaces to Event::TimeSystem.
 class TestTimeSystem : public Event::TimeSystem {
@@ -38,4 +39,5 @@ public:
   }
 };
 
+} // namespace Event
 } // namespace Envoy

--- a/test/test_common/test_time_system.h
+++ b/test/test_common/test_time_system.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "envoy/event/timer.h"
+
+namespace Envoy {
+
+// Adds sleep() and waitFor() interfaces to Event::TimeSystem.
+class TestTimeSystem : public Event::TimeSystem {
+public:
+  /**
+   * Advances time forward by the specified duration, running any timers
+   * along the way that have been scheduled to fire.
+   *
+   * @param duration The amount of time to sleep.
+   */
+  virtual void sleep(const Duration& duration) PURE;
+  template <class D> void sleep(const D& duration) {
+    sleep(std::chrono::duration_cast<Duration>(duration));
+  }
+
+  /**
+   * Waits for the specified duration to expire, or for a condvar to
+   * be notified, whichever comes first.
+   *
+   * @param mutex A mutex which must be held before calling this function.
+   * @param condvar The condition to wait on.
+   * @param duration The maximum amount of time to wait.
+   * @return Thread::CondVar::WaitStatus whether the condition timed out or not.
+   */
+  virtual Thread::CondVar::WaitStatus
+  waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
+          const Duration& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) PURE;
+
+  template <class D>
+  Thread::CondVar::WaitStatus waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
+                                      const D& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) {
+    return waitFor(mutex, condvar, std::chrono::duration_cast<Duration>(duration));
+  }
+};
+
+} // namespace Envoy


### PR DESCRIPTION
*Description*: In Envoy we don't block threads, so it's not appropriate to supply an API for it. We do need that for integration tests and unit tests, so a derived interface TestTimeSystem supplies those APIs now. This is a follow-up to a comment form @mattklein123 on #4488.
*Risk Level*: low
*Testing*: //test/...
*Docs Changes*: n/a
*Release Notes*: n/a
