### PR TITLE
retry extensions: use vector to keep track of attempted hosts

### DIFF
--- a/include/envoy/upstream/retry.h
+++ b/include/envoy/upstream/retry.h
@@ -106,7 +106,7 @@ public:
   virtual ~RetryPriorityFactory() {}
 
   virtual void createRetryPriority(RetryPriorityFactoryCallbacks& callbacks,
-                                   const Protobuf::Message& config) PURE;
+                                   const Protobuf::Message& config, uint32_t retry_count) PURE;
 
   virtual std::string name() const PURE;
 };
@@ -119,7 +119,7 @@ public:
   virtual ~RetryHostPredicateFactory() {}
 
   virtual void createHostPredicate(RetryHostPredicateFactoryCallbacks& callbacks,
-                                   const Protobuf::Message& config) PURE;
+                                   const Protobuf::Message& config, uint32_t retry_count) PURE;
 
   /**
    * @return name name of this factory.

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -52,13 +52,13 @@ RetryPolicyImpl::RetryPolicyImpl(const envoy::api::v2::route::RouteAction& confi
   for (const auto& host_predicate : config.retry_policy().retry_host_predicate()) {
     Registry::FactoryRegistry<Upstream::RetryHostPredicateFactory>::getFactory(
         host_predicate.name())
-        ->createHostPredicate(*this, host_predicate.config());
+        ->createHostPredicate(*this, host_predicate.config(), num_retries_);
   }
 
   const auto retry_priority = config.retry_policy().retry_priority();
   if (!retry_priority.name().empty()) {
     Registry::FactoryRegistry<Upstream::RetryPriorityFactory>::getFactory(retry_priority.name())
-        ->createRetryPriority(*this, retry_priority.config());
+        ->createRetryPriority(*this, retry_priority.config(), num_retries_);
   }
 
   auto host_selection_attempts = config.retry_policy().host_selection_retry_max_attempts();

--- a/source/extensions/retry/host/other_hosts/config.h
+++ b/source/extensions/retry/host/other_hosts/config.h
@@ -13,8 +13,8 @@ namespace Host {
 class OtherHostsRetryPredicateFactory : public Upstream::RetryHostPredicateFactory {
 public:
   void createHostPredicate(Upstream::RetryHostPredicateFactoryCallbacks& callbacks,
-                           const Protobuf::Message&) override {
-    callbacks.addHostPredicate(std::make_shared<OtherHostsRetryPredicate>());
+                           const Protobuf::Message&, uint32_t retry_count) override {
+    callbacks.addHostPredicate(std::make_shared<OtherHostsRetryPredicate>(retry_count));
   }
 
   std::string name() override { return RetryHostPredicateValues::get().PreviousHostsPredicate; }

--- a/source/extensions/retry/host/other_hosts/other_hosts.h
+++ b/source/extensions/retry/host/other_hosts/other_hosts.h
@@ -6,14 +6,17 @@
 namespace Envoy {
 class OtherHostsRetryPredicate : public Upstream::RetryHostPredicate {
 public:
+  OtherHostsRetryPredicate(uint32_t retry_count) : attempted_hosts_(retry_count) {}
+
   bool shouldSelectAnotherHost(const Upstream::Host& candidate_host) override {
-    return attempted_hosts_.find(candidate_host.address()->asString()) != attempted_hosts_.end();
+    return std::find(attempted_hosts_.begin(), attempted_hosts_.end(),
+                     candidate_host.address()->asString()) != attempted_hosts_.end();
   }
   void onHostAttempted(Upstream::HostDescriptionConstSharedPtr attempted_host) override {
-    attempted_hosts_.insert(attempted_host->address()->asString());
+    attempted_hosts_.emplace_back(attempted_host->address()->asString());
   }
 
 private:
-  std::unordered_set<std::string> attempted_hosts_;
+  std::vector<std::string> attempted_hosts_;
 };
 } // namespace Envoy

--- a/source/extensions/retry/host/other_hosts/other_hosts.h
+++ b/source/extensions/retry/host/other_hosts/other_hosts.h
@@ -9,14 +9,14 @@ public:
   OtherHostsRetryPredicate(uint32_t retry_count) : attempted_hosts_(retry_count) {}
 
   bool shouldSelectAnotherHost(const Upstream::Host& candidate_host) override {
-    return std::find(attempted_hosts_.begin(), attempted_hosts_.end(),
-                     candidate_host.address()->asString()) != attempted_hosts_.end();
+    return std::find(attempted_hosts_.begin(), attempted_hosts_.end(), &candidate_host) !=
+           attempted_hosts_.end();
   }
   void onHostAttempted(Upstream::HostDescriptionConstSharedPtr attempted_host) override {
-    attempted_hosts_.emplace_back(attempted_host->address()->asString());
+    attempted_hosts_.emplace_back(attempted_host.get());
   }
 
 private:
-  std::vector<std::string> attempted_hosts_;
+  std::vector<Upstream::HostDescription const*> attempted_hosts_;
 };
 } // namespace Envoy

--- a/test/extensions/retry/host/other_hosts/config_test.cc
+++ b/test/extensions/retry/host/other_hosts/config_test.cc
@@ -33,7 +33,7 @@ TEST(OtherHostsRetryPredicateConfigTest, PredicateTest) {
 
   TestHostPredicateFactoryCallback callback;
   ProtobufWkt::Struct config;
-  factory->createHostPredicate(callback, config);
+  factory->createHostPredicate(callback, config, 3);
 
   auto predicate = callback.host_predicate_;
 

--- a/test/integration/test_host_predicate_config.h
+++ b/test/integration/test_host_predicate_config.h
@@ -10,7 +10,7 @@ public:
   std::string name() override { return "envoy.test_host_predicate"; }
 
   void createHostPredicate(Upstream::RetryHostPredicateFactoryCallbacks& callbacks,
-                           const Protobuf::Message&) override {
+                           const Protobuf::Message&, uint32_t) override {
     callbacks.addHostPredicate(std::make_shared<TestHostPredicate>());
   }
 };

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -118,8 +118,8 @@ class MockRetryPriorityFactory : public RetryPriorityFactory {
 public:
   MockRetryPriorityFactory(RetryPrioritySharedPtr retry_priority)
       : retry_priority_(retry_priority) {}
-  void createRetryPriority(RetryPriorityFactoryCallbacks& callbacks,
-                           const Protobuf::Message&) override {
+  void createRetryPriority(RetryPriorityFactoryCallbacks& callbacks, const Protobuf::Message&,
+                           uint32_t) override {
     callbacks.addRetryPriority(retry_priority_);
   }
 


### PR DESCRIPTION
Instead of using `unordered_map`, use a vector initialized with size equal
to the number of allowed retries to keep track of attempted hosts. As the number of retries
will generally be low, this is likely both faster and more memory efficient.

Based on this suggestion: https://github.com/envoyproxy/envoy/pull/4452#discussion_r219723016

cc @mattklein123 

*Risk Level*: Low
*Testing*: n/a, covered by existing UTs
*Docs Changes*: n/a
*Release Notes*: n/a
