### PR TITLE
Use int8_t instead of char for sign extension

### DIFF
--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -238,7 +238,7 @@ public:
     auto result = static_cast<T>(0);
     constexpr const auto all_bits_enabled = static_cast<T>(~static_cast<T>(0));
 
-    char* bytes = reinterpret_cast<char*>(std::addressof(result));
+    int8_t* bytes = reinterpret_cast<int8_t*>(std::addressof(result));
     copyOut(start, Size, &bytes[displacement]);
 
     constexpr const auto most_significant_read_byte =


### PR DESCRIPTION
*Description*: Use int8_t instead of char in sign extension code as char may be unsigned.
*Risk Level*: Low
*Testing*: All unit tests
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
