### PR TITLE
tracing: Configure tracer from v2 proto configuration

### DIFF
--- a/source/extensions/tracers/dynamic_ot/config.cc
+++ b/source/extensions/tracers/dynamic_ot/config.cc
@@ -15,8 +15,7 @@ namespace DynamicOt {
 
 Tracing::HttpTracerPtr DynamicOpenTracingTracerFactory::createHttpTracer(
     const envoy::config::trace::v2::Tracing& configuration, Server::Instance& server) {
-  ProtobufTypes::MessagePtr config_ptr =
-      ProtobufTypes::MessagePtr{new envoy::config::trace::v2::DynamicOtConfig()};
+  ProtobufTypes::MessagePtr config_ptr = createEmptyConfigProto();
 
   if (configuration.http().has_config()) {
     MessageUtil::jsonConvert(configuration.http().config(), *config_ptr);

--- a/source/extensions/tracers/dynamic_ot/config.cc
+++ b/source/extensions/tracers/dynamic_ot/config.cc
@@ -25,8 +25,7 @@ Tracing::HttpTracerPtr DynamicOpenTracingTracerFactory::createHttpTracer(
       dynamic_cast<const envoy::config::trace::v2::DynamicOtConfig&>(*config_ptr);
 
   const std::string library = dynaot_config.library();
-  Json::ObjectSharedPtr json_config = MessageUtil::getJsonObjectFromMessage(dynaot_config.config());
-  const std::string config = json_config->asJsonString();
+  const std::string config = MessageUtil::getJsonStringFromMessage(dynaot_config.config());
   Tracing::DriverPtr dynamic_driver{
       std::make_unique<DynamicOpenTracingDriver>(server.stats(), library, config)};
   return std::make_unique<Tracing::HttpTracerImpl>(std::move(dynamic_driver), server.localInfo());

--- a/source/extensions/tracers/dynamic_ot/config.h
+++ b/source/extensions/tracers/dynamic_ot/config.h
@@ -21,7 +21,7 @@ public:
                                           Server::Instance& server) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return ProtobufTypes::MessagePtr{new envoy::config::trace::v2::DynamicOtConfig()};
+    return ProtobufTypes::MessagePtr{std::make_unique<envoy::config::trace::v2::DynamicOtConfig>()};
   }
 
   std::string name() override;

--- a/source/extensions/tracers/dynamic_ot/config.h
+++ b/source/extensions/tracers/dynamic_ot/config.h
@@ -21,7 +21,7 @@ public:
                                           Server::Instance& server) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return ProtobufTypes::MessagePtr{std::make_unique<envoy::config::trace::v2::DynamicOtConfig>()};
+    return std::make_unique<envoy::config::trace::v2::DynamicOtConfig>();
   }
 
   std::string name() override;

--- a/source/extensions/tracers/dynamic_ot/config.h
+++ b/source/extensions/tracers/dynamic_ot/config.h
@@ -19,6 +19,11 @@ public:
   // TracerFactory
   Tracing::HttpTracerPtr createHttpTracer(const envoy::config::trace::v2::Tracing& configuration,
                                           Server::Instance& server) override;
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return ProtobufTypes::MessagePtr{new envoy::config::trace::v2::DynamicOtConfig()};
+  }
+
   std::string name() override;
 };
 

--- a/source/extensions/tracers/dynamic_ot/config.h
+++ b/source/extensions/tracers/dynamic_ot/config.h
@@ -17,7 +17,7 @@ namespace DynamicOt {
 class DynamicOpenTracingTracerFactory : public Server::Configuration::TracerFactory {
 public:
   // TracerFactory
-  Tracing::HttpTracerPtr createHttpTracer(const Json::Object& json_config,
+  Tracing::HttpTracerPtr createHttpTracer(const envoy::config::trace::v2::Tracing& configuration,
                                           Server::Instance& server) override;
   std::string name() override;
 };

--- a/source/extensions/tracers/lightstep/config.cc
+++ b/source/extensions/tracers/lightstep/config.cc
@@ -15,19 +15,29 @@ namespace Extensions {
 namespace Tracers {
 namespace Lightstep {
 
-Tracing::HttpTracerPtr LightstepTracerFactory::createHttpTracer(const Json::Object& json_config,
-                                                                Server::Instance& server) {
+Tracing::HttpTracerPtr
+LightstepTracerFactory::createHttpTracer(const envoy::config::trace::v2::Tracing& configuration,
+                                         Server::Instance& server) {
+  ProtobufTypes::MessagePtr config_ptr =
+      ProtobufTypes::MessagePtr{new envoy::config::trace::v2::LightstepConfig()};
+
+  if (configuration.http().has_config()) {
+    MessageUtil::jsonConvert(configuration.http().config(), *config_ptr);
+  }
+
+  const auto& lightstep_config =
+      dynamic_cast<const envoy::config::trace::v2::LightstepConfig&>(*config_ptr);
 
   std::unique_ptr<lightstep::LightStepTracerOptions> opts(new lightstep::LightStepTracerOptions());
-  const auto access_token_file =
-      server.api().fileReadToEnd(json_config.getString("access_token_file"));
+  const auto access_token_file = server.api().fileReadToEnd(lightstep_config.access_token_file());
   const auto access_token_sv = StringUtil::rtrim(access_token_file);
   opts->access_token.assign(access_token_sv.data(), access_token_sv.size());
   opts->component_name = server.localInfo().clusterName();
 
-  Tracing::DriverPtr lightstep_driver{new LightStepDriver{
-      json_config, server.clusterManager(), server.stats(), server.threadLocal(), server.runtime(),
-      std::move(opts), Common::Ot::OpenTracingDriver::PropagationMode::TracerNative}};
+  Tracing::DriverPtr lightstep_driver{
+      new LightStepDriver{lightstep_config, server.clusterManager(), server.stats(),
+                          server.threadLocal(), server.runtime(), std::move(opts),
+                          Common::Ot::OpenTracingDriver::PropagationMode::TracerNative}};
   return std::make_unique<Tracing::HttpTracerImpl>(std::move(lightstep_driver), server.localInfo());
 }
 

--- a/source/extensions/tracers/lightstep/config.cc
+++ b/source/extensions/tracers/lightstep/config.cc
@@ -33,10 +33,10 @@ LightstepTracerFactory::createHttpTracer(const envoy::config::trace::v2::Tracing
   opts->access_token.assign(access_token_sv.data(), access_token_sv.size());
   opts->component_name = server.localInfo().clusterName();
 
-  Tracing::DriverPtr lightstep_driver{
-      new LightStepDriver{lightstep_config, server.clusterManager(), server.stats(),
-                          server.threadLocal(), server.runtime(), std::move(opts),
-                          Common::Ot::OpenTracingDriver::PropagationMode::TracerNative}};
+  Tracing::DriverPtr lightstep_driver{std::make_unique<LightStepDriver>(
+      lightstep_config, server.clusterManager(), server.stats(), server.threadLocal(),
+      server.runtime(), std::move(opts),
+      Common::Ot::OpenTracingDriver::PropagationMode::TracerNative)};
   return std::make_unique<Tracing::HttpTracerImpl>(std::move(lightstep_driver), server.localInfo());
 }
 

--- a/source/extensions/tracers/lightstep/config.cc
+++ b/source/extensions/tracers/lightstep/config.cc
@@ -18,8 +18,7 @@ namespace Lightstep {
 Tracing::HttpTracerPtr
 LightstepTracerFactory::createHttpTracer(const envoy::config::trace::v2::Tracing& configuration,
                                          Server::Instance& server) {
-  ProtobufTypes::MessagePtr config_ptr =
-      ProtobufTypes::MessagePtr{new envoy::config::trace::v2::LightstepConfig()};
+  ProtobufTypes::MessagePtr config_ptr = createEmptyConfigProto();
 
   if (configuration.http().has_config()) {
     MessageUtil::jsonConvert(configuration.http().config(), *config_ptr);

--- a/source/extensions/tracers/lightstep/config.h
+++ b/source/extensions/tracers/lightstep/config.h
@@ -17,7 +17,7 @@ namespace Lightstep {
 class LightstepTracerFactory : public Server::Configuration::TracerFactory {
 public:
   // TracerFactory
-  Tracing::HttpTracerPtr createHttpTracer(const Json::Object& json_config,
+  Tracing::HttpTracerPtr createHttpTracer(const envoy::config::trace::v2::Tracing& configuration,
                                           Server::Instance& server) override;
 
   std::string name() override;

--- a/source/extensions/tracers/lightstep/config.h
+++ b/source/extensions/tracers/lightstep/config.h
@@ -21,7 +21,7 @@ public:
                                           Server::Instance& server) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return ProtobufTypes::MessagePtr{std::make_unique<envoy::config::trace::v2::LightstepConfig>()};
+    return std::make_unique<envoy::config::trace::v2::LightstepConfig>();
   }
 
   std::string name() override;

--- a/source/extensions/tracers/lightstep/config.h
+++ b/source/extensions/tracers/lightstep/config.h
@@ -20,6 +20,10 @@ public:
   Tracing::HttpTracerPtr createHttpTracer(const envoy::config::trace::v2::Tracing& configuration,
                                           Server::Instance& server) override;
 
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return ProtobufTypes::MessagePtr{new envoy::config::trace::v2::LightstepConfig()};
+  }
+
   std::string name() override;
 };
 

--- a/source/extensions/tracers/lightstep/config.h
+++ b/source/extensions/tracers/lightstep/config.h
@@ -21,7 +21,7 @@ public:
                                           Server::Instance& server) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return ProtobufTypes::MessagePtr{new envoy::config::trace::v2::LightstepConfig()};
+    return ProtobufTypes::MessagePtr{std::make_unique<envoy::config::trace::v2::LightstepConfig>()};
   }
 
   std::string name() override;

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -129,7 +129,7 @@ void LightStepDriver::TlsLightStepTracer::enableTimer() {
   flush_timer_->enableTimer(std::chrono::milliseconds(flush_interval));
 }
 
-LightStepDriver::LightStepDriver(const Json::Object& config,
+LightStepDriver::LightStepDriver(const envoy::config::trace::v2::LightstepConfig& lightstep_config,
                                  Upstream::ClusterManager& cluster_manager, Stats::Store& stats,
                                  ThreadLocal::SlotAllocator& tls, Runtime::Loader& runtime,
                                  std::unique_ptr<lightstep::LightStepTracerOptions>&& options,
@@ -138,10 +138,10 @@ LightStepDriver::LightStepDriver(const Json::Object& config,
       tracer_stats_{LIGHTSTEP_TRACER_STATS(POOL_COUNTER_PREFIX(stats, "tracing.lightstep."))},
       tls_{tls.allocateSlot()}, runtime_{runtime}, options_{std::move(options)},
       propagation_mode_{propagation_mode} {
-  Upstream::ThreadLocalCluster* cluster = cm_.get(config.getString("collector_cluster"));
+  Upstream::ThreadLocalCluster* cluster = cm_.get(lightstep_config.collector_cluster());
   if (!cluster) {
     throw EnvoyException(fmt::format("{} collector cluster is not defined on cluster manager level",
-                                     config.getString("collector_cluster")));
+                                     lightstep_config.collector_cluster()));
   }
   cluster_ = cluster->info();
 

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.h
@@ -50,8 +50,9 @@ public:
  */
 class LightStepDriver : public Common::Ot::OpenTracingDriver {
 public:
-  LightStepDriver(const Json::Object& config, Upstream::ClusterManager& cluster_manager,
-                  Stats::Store& stats, ThreadLocal::SlotAllocator& tls, Runtime::Loader& runtime,
+  LightStepDriver(const envoy::config::trace::v2::LightstepConfig& lightstep_config,
+                  Upstream::ClusterManager& cluster_manager, Stats::Store& stats,
+                  ThreadLocal::SlotAllocator& tls, Runtime::Loader& runtime,
                   std::unique_ptr<lightstep::LightStepTracerOptions>&& options,
                   PropagationMode propagation_mode);
 

--- a/source/extensions/tracers/zipkin/config.cc
+++ b/source/extensions/tracers/zipkin/config.cc
@@ -18,8 +18,7 @@ ZipkinTracerFactory::createHttpTracer(const envoy::config::trace::v2::Tracing& c
                                       Server::Instance& server) {
 
   Envoy::Runtime::RandomGenerator& rand = server.random();
-  ProtobufTypes::MessagePtr config_ptr =
-      ProtobufTypes::MessagePtr{new envoy::config::trace::v2::ZipkinConfig()};
+  ProtobufTypes::MessagePtr config_ptr = createEmptyConfigProto();
 
   if (configuration.http().has_config()) {
     MessageUtil::jsonConvert(configuration.http().config(), *config_ptr);

--- a/source/extensions/tracers/zipkin/config.cc
+++ b/source/extensions/tracers/zipkin/config.cc
@@ -27,9 +27,9 @@ ZipkinTracerFactory::createHttpTracer(const envoy::config::trace::v2::Tracing& c
   const auto& zipkin_config =
       dynamic_cast<const envoy::config::trace::v2::ZipkinConfig&>(*config_ptr);
 
-  Tracing::DriverPtr zipkin_driver(new Zipkin::Driver(
+  Tracing::DriverPtr zipkin_driver{std::make_unique<Zipkin::Driver>(
       zipkin_config, server.clusterManager(), server.stats(), server.threadLocal(),
-      server.runtime(), server.localInfo(), rand, server.timeSystem()));
+      server.runtime(), server.localInfo(), rand, server.timeSystem())};
 
   return Tracing::HttpTracerPtr(
       new Tracing::HttpTracerImpl(std::move(zipkin_driver), server.localInfo()));

--- a/source/extensions/tracers/zipkin/config.h
+++ b/source/extensions/tracers/zipkin/config.h
@@ -19,7 +19,7 @@ public:
                                           Server::Instance& server) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return ProtobufTypes::MessagePtr{new envoy::config::trace::v2::ZipkinConfig()};
+    return ProtobufTypes::MessagePtr{std::make_unique<envoy::config::trace::v2::ZipkinConfig>()};
   }
 
   std::string name() override;

--- a/source/extensions/tracers/zipkin/config.h
+++ b/source/extensions/tracers/zipkin/config.h
@@ -19,7 +19,7 @@ public:
                                           Server::Instance& server) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return ProtobufTypes::MessagePtr{std::make_unique<envoy::config::trace::v2::ZipkinConfig>()};
+    return std::make_unique<envoy::config::trace::v2::ZipkinConfig>();
   }
 
   std::string name() override;

--- a/source/extensions/tracers/zipkin/config.h
+++ b/source/extensions/tracers/zipkin/config.h
@@ -15,7 +15,7 @@ namespace Zipkin {
 class ZipkinTracerFactory : public Server::Configuration::TracerFactory {
 public:
   // TracerFactory
-  Tracing::HttpTracerPtr createHttpTracer(const Json::Object& json_config,
+  Tracing::HttpTracerPtr createHttpTracer(const envoy::config::trace::v2::Tracing& configuration,
                                           Server::Instance& server) override;
   std::string name() override;
 };

--- a/source/extensions/tracers/zipkin/config.h
+++ b/source/extensions/tracers/zipkin/config.h
@@ -17,6 +17,11 @@ public:
   // TracerFactory
   Tracing::HttpTracerPtr createHttpTracer(const envoy::config::trace::v2::Tracing& configuration,
                                           Server::Instance& server) override;
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return ProtobufTypes::MessagePtr{new envoy::config::trace::v2::ZipkinConfig()};
+  }
+
   std::string name() override;
 };
 

--- a/source/extensions/tracers/zipkin/zipkin_core_constants.h
+++ b/source/extensions/tracers/zipkin/zipkin_core_constants.h
@@ -40,7 +40,6 @@ public:
   const std::string NOT_SAMPLED = "0";
 
   const std::string DEFAULT_COLLECTOR_ENDPOINT = "/api/v1/spans";
-  const bool DEFAULT_TRACE_ID_128BIT = false;
   const bool DEFAULT_SHARED_SPAN_CONTEXT = true;
 };
 

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -89,7 +89,8 @@ public:
    * Constructor. It adds itself and a newly-created Zipkin::Tracer object to a thread-local store.
    * Also, it associates the given random-number generator to the Zipkin::Tracer object it creates.
    */
-  Driver(const Json::Object& config, Upstream::ClusterManager& cluster_manager, Stats::Store& stats,
+  Driver(const envoy::config::trace::v2::ZipkinConfig& zipkin_config,
+         Upstream::ClusterManager& cluster_manager, Stats::Store& stats,
          ThreadLocal::SlotAllocator& tls, Runtime::Loader& runtime,
          const LocalInfo::LocalInfo& localinfo, Runtime::RandomGenerator& random_generator,
          TimeSource& time_source);

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -103,13 +103,9 @@ void MainImpl::initializeTracers(const envoy::config::trace::v2::Tracing& config
   std::string type = configuration.http().name();
   ENVOY_LOG(info, "  loading tracing driver: {}", type);
 
-  // TODO(htuch): Make this dynamically pluggable one day.
-  Json::ObjectSharedPtr driver_config =
-      MessageUtil::getJsonObjectFromMessage(configuration.http().config());
-
   // Now see if there is a factory that will accept the config.
   auto& factory = Config::Utility::getAndCheckFactory<TracerFactory>(type);
-  http_tracer_ = factory.createHttpTracer(*driver_config, server);
+  http_tracer_ = factory.createHttpTracer(configuration, server);
 }
 
 void MainImpl::initializeStatsSinks(const envoy::config::bootstrap::v2::Bootstrap& bootstrap,

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -47,6 +47,13 @@ public:
   createHttpTracer(const envoy::config::trace::v2::Tracing& configuration, Instance& server) PURE;
 
   /**
+   * @return ProtobufTypes::MessagePtr create empty config proto message for v2. The tracing
+   *         config, which arrives in an opaque google.protobuf.Struct message, will be converted to
+   *         JSON and then parsed into this empty proto.
+   */
+  virtual ProtobufTypes::MessagePtr createEmptyConfigProto() PURE;
+
+  /**
    * Returns the identifying name for a particular implementation of tracer produced by the
    * factory.
    */

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -43,8 +43,8 @@ public:
    * @param json_config supplies the general json configuration for the HttpTracer
    * @param server supplies the server instance
    */
-  virtual Tracing::HttpTracerPtr createHttpTracer(const Json::Object& json_config,
-                                                  Instance& server) PURE;
+  virtual Tracing::HttpTracerPtr
+  createHttpTracer(const envoy::config::trace::v2::Tracing& configuration, Instance& server) PURE;
 
   /**
    * Returns the identifying name for a particular implementation of tracer produced by the

--- a/test/extensions/tracers/lightstep/config_test.cc
+++ b/test/extensions/tracers/lightstep/config_test.cc
@@ -21,16 +21,18 @@ TEST(LightstepTracerConfigTest, LightstepHttpTracer) {
   ON_CALL(*server.cluster_manager_.thread_local_cluster_.cluster_.info_, features())
       .WillByDefault(Return(Upstream::ClusterInfo::Features::HTTP2));
 
-  std::string valid_config = R"EOF(
-  {
-    "collector_cluster": "fake_cluster",
-    "access_token_file": "fake_file"
-  }
-  )EOF";
-  Json::ObjectSharedPtr valid_json = Json::Factory::loadFromString(valid_config);
+  const std::string yaml_string = R"EOF(
+  http:
+    name: envoy.lightstep
+    config:
+      collector_cluster: fake_cluster
+      access_token_file: fake_file
+   )EOF";
+  envoy::config::trace::v2::Tracing configuration;
+  MessageUtil::loadFromYaml(yaml_string, configuration);
 
   LightstepTracerFactory factory;
-  Tracing::HttpTracerPtr lightstep_tracer = factory.createHttpTracer(*valid_json, server);
+  Tracing::HttpTracerPtr lightstep_tracer = factory.createHttpTracer(configuration, server);
   EXPECT_NE(nullptr, lightstep_tracer);
 }
 

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -42,7 +42,7 @@ namespace Lightstep {
 
 class LightStepDriverTest : public Test {
 public:
-  void setup(Json::Object& config, bool init_timer,
+  void setup(envoy::config::trace::v2::LightstepConfig& lightstep_config, bool init_timer,
              Common::Ot::OpenTracingDriver::PropagationMode propagation_mode =
                  Common::Ot::OpenTracingDriver::PropagationMode::TracerNative) {
     std::unique_ptr<lightstep::LightStepTracerOptions> opts(
@@ -58,8 +58,8 @@ public:
       EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1000)));
     }
 
-    driver_.reset(new LightStepDriver{config, cm_, stats_, tls_, runtime_, std::move(opts),
-                                      propagation_mode});
+    driver_.reset(new LightStepDriver{lightstep_config, cm_, stats_, tls_, runtime_,
+                                      std::move(opts), propagation_mode});
   }
 
   void setupValidDriver(Common::Ot::OpenTracingDriver::PropagationMode propagation_mode =
@@ -68,12 +68,13 @@ public:
     ON_CALL(*cm_.thread_local_cluster_.cluster_.info_, features())
         .WillByDefault(Return(Upstream::ClusterInfo::Features::HTTP2));
 
-    std::string valid_config = R"EOF(
-      {"collector_cluster": "fake_cluster"}
+    const std::string yaml_string = R"EOF(
+    collector_cluster: fake_cluster
     )EOF";
-    Json::ObjectSharedPtr loader = Json::Factory::loadFromString(valid_config);
+    envoy::config::trace::v2::LightstepConfig lightstep_config;
+    MessageUtil::loadFromYaml(yaml_string, lightstep_config);
 
-    setup(*loader, true, propagation_mode);
+    setup(lightstep_config, true, propagation_mode);
   }
 
   const std::string operation_name_{"test"};
@@ -106,31 +107,22 @@ TEST_F(LightStepDriverTest, LightStepLogger) {
 
 TEST_F(LightStepDriverTest, InitializeDriver) {
   {
-    std::string invalid_config = R"EOF(
-      {"fake" : "fake"}
-    )EOF";
-    Json::ObjectSharedPtr loader = Json::Factory::loadFromString(invalid_config);
+    envoy::config::trace::v2::LightstepConfig lightstep_config;
 
-    EXPECT_THROW(setup(*loader, false), EnvoyException);
-  }
-
-  {
-    std::string empty_config = "{}";
-    Json::ObjectSharedPtr loader = Json::Factory::loadFromString(empty_config);
-
-    EXPECT_THROW(setup(*loader, false), EnvoyException);
+    EXPECT_THROW(setup(lightstep_config, false), EnvoyException);
   }
 
   {
     // Valid config but not valid cluster.
     EXPECT_CALL(cm_, get("fake_cluster")).WillOnce(Return(nullptr));
 
-    std::string valid_config = R"EOF(
-      {"collector_cluster": "fake_cluster"}
+    const std::string yaml_string = R"EOF(
+    collector_cluster: fake_cluster
     )EOF";
-    Json::ObjectSharedPtr loader = Json::Factory::loadFromString(valid_config);
+    envoy::config::trace::v2::LightstepConfig lightstep_config;
+    MessageUtil::loadFromYaml(yaml_string, lightstep_config);
 
-    EXPECT_THROW(setup(*loader, false), EnvoyException);
+    EXPECT_THROW(setup(lightstep_config, false), EnvoyException);
   }
 
   {
@@ -138,12 +130,13 @@ TEST_F(LightStepDriverTest, InitializeDriver) {
     EXPECT_CALL(cm_, get("fake_cluster")).WillRepeatedly(Return(&cm_.thread_local_cluster_));
     ON_CALL(*cm_.thread_local_cluster_.cluster_.info_, features()).WillByDefault(Return(0));
 
-    std::string valid_config = R"EOF(
-      {"collector_cluster": "fake_cluster"}
+    const std::string yaml_string = R"EOF(
+    collector_cluster: fake_cluster
     )EOF";
-    Json::ObjectSharedPtr loader = Json::Factory::loadFromString(valid_config);
+    envoy::config::trace::v2::LightstepConfig lightstep_config;
+    MessageUtil::loadFromYaml(yaml_string, lightstep_config);
 
-    EXPECT_THROW(setup(*loader, false), EnvoyException);
+    EXPECT_THROW(setup(lightstep_config, false), EnvoyException);
   }
 
   {
@@ -151,12 +144,13 @@ TEST_F(LightStepDriverTest, InitializeDriver) {
     ON_CALL(*cm_.thread_local_cluster_.cluster_.info_, features())
         .WillByDefault(Return(Upstream::ClusterInfo::Features::HTTP2));
 
-    std::string valid_config = R"EOF(
-      {"collector_cluster": "fake_cluster"}
+    const std::string yaml_string = R"EOF(
+    collector_cluster: fake_cluster
     )EOF";
-    Json::ObjectSharedPtr loader = Json::Factory::loadFromString(valid_config);
+    envoy::config::trace::v2::LightstepConfig lightstep_config;
+    MessageUtil::loadFromYaml(yaml_string, lightstep_config);
 
-    setup(*loader, true);
+    setup(lightstep_config, true);
   }
 }
 

--- a/test/extensions/tracers/zipkin/config_test.cc
+++ b/test/extensions/tracers/zipkin/config_test.cc
@@ -17,15 +17,19 @@ TEST(ZipkinTracerConfigTest, ZipkinHttpTracer) {
   EXPECT_CALL(server.cluster_manager_, get("fake_cluster"))
       .WillRepeatedly(Return(&server.cluster_manager_.thread_local_cluster_));
 
-  std::string valid_config = R"EOF(
-  {
-    "collector_cluster": "fake_cluster",
-    "collector_endpoint": "/api/v1/spans"
-  }
+  const std::string yaml_string = R"EOF(
+  http:
+    name: envoy.zipkin
+    config:
+      collector_cluster: fake_cluster
+      collector_endpoint: /api/v1/spans
   )EOF";
-  Json::ObjectSharedPtr valid_json = Json::Factory::loadFromString(valid_config);
+
+  envoy::config::trace::v2::Tracing configuration;
+  MessageUtil::loadFromYaml(yaml_string, configuration);
+
   ZipkinTracerFactory factory;
-  Tracing::HttpTracerPtr zipkin_tracer = factory.createHttpTracer(*valid_json, server);
+  Tracing::HttpTracerPtr zipkin_tracer = factory.createHttpTracer(configuration, server);
   EXPECT_NE(nullptr, zipkin_tracer);
 }
 


### PR DESCRIPTION
*Description*:
Use v2 proto config to configure the tracer.

*Risk Level*: medium

*Testing*:
Updated the unit tests to use yaml and the v2 proto model.

Fixes #3459