### PR TITLE
Explicitly initialize reject_all_hosts_

### DIFF
--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -67,7 +67,7 @@ public:
 
   NiceMock<Network::MockConnection> downstream_connection_;
   MockRetryState* retry_state_{};
-  bool reject_all_hosts_;
+  bool reject_all_hosts_ = false;
 };
 
 class RouterTestBase : public testing::Test {


### PR DESCRIPTION
*Description*: Primitive types such as bool must be explicitly initialized.
*Risk Level*: Low
*Testing*: Unit tests