### PR TITLE
fuzz: make UDS paths hermetic in server_fuzz_test.

### DIFF
--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -14,7 +14,9 @@ spdlog::level::level_enum Runner::log_level_;
 uint32_t PerTestEnvironment::test_num_;
 
 PerTestEnvironment::PerTestEnvironment()
-    : test_tmpdir_(TestEnvironment::temporaryPath(fmt::format("fuzz_{}", test_num_++))) {
+    : per_test_num_(test_num_++),
+      test_tmpdir_(TestEnvironment::temporaryPath(fmt::format("fuzz_{}", per_test_num_))),
+      test_id_(std::to_string(HashUtil::xxHash64(test_tmpdir_))) {
   TestEnvironment::createPath(test_tmpdir_);
 }
 

--- a/test/fuzz/fuzz_runner.h
+++ b/test/fuzz/fuzz_runner.h
@@ -20,10 +20,13 @@ public:
   ~PerTestEnvironment();
 
   std::string temporaryPath(const std::string& path) const { return test_tmpdir_ + "/" + path; }
+  const std::string& testId() const { return test_id_; }
 
 private:
   static uint32_t test_num_;
+  const uint32_t per_test_num_;
   const std::string test_tmpdir_;
+  const std::string test_id_;
 };
 
 class Runner {


### PR DESCRIPTION
This improves test determinism and avoids conflicts between tests over
bound paths.

Risk Level: Low
Testing: server_fuzz_test.

Signed-off-by: Harvey Tuch <htuch@google.com>