### PR TITLE
test: fix header map matchers

### DIFF
--- a/test/mocks/http/BUILD
+++ b/test/mocks/http/BUILD
@@ -4,6 +4,7 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",
     "envoy_package",
+    "envoy_cc_test",
 )
 
 envoy_package()
@@ -30,5 +31,15 @@ envoy_cc_mock(
         "//test/mocks/router:router_mocks",
         "//test/mocks/tracing:tracing_mocks",
         "//test/mocks/upstream:host_mocks",
+    ],
+)
+
+envoy_cc_test(
+    name = "http_mocks_test",
+    srcs = ["mocks_test.cc"],
+    deps = [
+        ":http_mocks",
+        "//include/envoy/http:header_map_interface",
+        "//test/test_common:utility_lib",
     ],
 )

--- a/test/mocks/http/BUILD
+++ b/test/mocks/http/BUILD
@@ -3,8 +3,8 @@ licenses(["notice"])  # Apache 2
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",
-    "envoy_package",
     "envoy_cc_test",
+    "envoy_package",
 )
 
 envoy_package()

--- a/test/mocks/http/BUILD
+++ b/test/mocks/http/BUILD
@@ -26,6 +26,7 @@ envoy_cc_mock(
         "//include/envoy/http:filter_interface",
         "//include/envoy/ssl:connection_interface",
         "//include/envoy/tracing:http_tracer_interface",
+        "//source/common/http:header_map_lib",
         "//test/mocks/event:event_mocks",
         "//test/mocks/request_info:request_info_mocks",
         "//test/mocks/router:router_mocks",

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -8,7 +8,6 @@
 
 using testing::_;
 using testing::Invoke;
-using testing::IsSubsetOf;
 using testing::MakeMatcher;
 using testing::Matcher;
 using testing::MatcherInterface;
@@ -166,39 +165,8 @@ MockInstance::~MockInstance() {}
 
 } // namespace ConnectionPool
 
-namespace {
-
-class IsSubsetOfHeadersMatcher : public MatcherInterface<const HeaderMap&> {
-public:
-  explicit IsSubsetOfHeadersMatcher(const HeaderMap& expected_headers)
-      : expected_headers_(expected_headers) {}
-
-  bool MatchAndExplain(const HeaderMap& headers, MatchResultListener* listener) const override {
-    // Collect header maps into vectors, to use for IsSubsetOf.
-    auto get_headers_cb = [](const HeaderEntry& header, void* headers) {
-      static_cast<std::vector<std::pair<absl::string_view, absl::string_view>>*>(headers)
-          ->push_back(std::make_pair(header.key().getStringView(), header.value().getStringView()));
-      return HeaderMap::Iterate::Continue;
-    };
-    std::vector<std::pair<absl::string_view, absl::string_view>> arg_headers_vec;
-    headers.iterate(get_headers_cb, &arg_headers_vec);
-    std::vector<std::pair<absl::string_view, absl::string_view>> expected_headers_vec;
-    expected_headers_.iterate(get_headers_cb, &expected_headers_vec);
-
-    return ExplainMatchResult(IsSubsetOf(expected_headers_vec), arg_headers_vec, listener);
-  }
-
-  void DescribeTo(std::ostream* os) const override {
-    *os << "is a subset of headers:\n" << expected_headers_;
-  }
-
-  const HeaderMap& expected_headers_;
-};
-
-} // namespace
-
-Matcher<const HeaderMap&> IsSubsetOfHeaders(const HeaderMap& expected_headers) {
-  return MakeMatcher(new IsSubsetOfHeadersMatcher(expected_headers));
+IsSubsetOfHeadersMatcher IsSubsetOfHeaders(const HeaderMap& expected_headers) {
+  return IsSubsetOfHeadersMatcher(expected_headers);
 }
 
 } // namespace Http

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -456,17 +456,68 @@ public:
 
 } // namespace ConnectionPool
 
-class HeaderValueOfMatcher : public testing::MatcherInterface<const HeaderMap&> {
+template <typename HeaderMapT>
+class HeaderValueOfMatcherImpl : public testing::MatcherInterface<HeaderMapT> {
+public:
+  explicit HeaderValueOfMatcherImpl(LowerCaseString key,
+                                    testing::Matcher<absl::string_view> matcher)
+      : key_(std::move(key)), matcher_(std::move(matcher)) {}
+
+  bool MatchAndExplain(HeaderMapT headers, testing::MatchResultListener* listener) const override {
+    // Get all headers with matching keys.
+    std::vector<absl::string_view> values;
+    std::pair<std::string, std::vector<absl::string_view>*> context =
+        std::make_pair(key_.get(), &values);
+    Envoy::Http::HeaderMap::ConstIterateCb get_headers_cb =
+        [](const Envoy::Http::HeaderEntry& header, void* context) {
+          auto* typed_context =
+              static_cast<std::pair<std::string, std::vector<absl::string_view>*>*>(context);
+          if (header.key().getStringView() == typed_context->first) {
+            typed_context->second->push_back(header.value().getStringView());
+          }
+          return Envoy::Http::HeaderMap::Iterate::Continue;
+        };
+    headers.iterate(get_headers_cb, &context);
+
+    if (values.empty()) {
+      *listener << "which has no '" << key_.get() << "' header";
+      return false;
+    } else if (values.size() > 1) {
+      *listener << "which has " << values.size() << " '" << key_.get()
+                << "' headers, with values: " << absl::StrJoin(values, ", ");
+      return false;
+    }
+    absl::string_view value = values[0];
+    *listener << "which has a '" << key_.get() << "' header with value " << value << " ";
+    return testing::ExplainMatchResult(matcher_, value, listener);
+  }
+
+  void DescribeTo(std::ostream* os) const override {
+    *os << "has a '" << key_.get() << "' header with value that "
+        << testing::DescribeMatcher<absl::string_view>(matcher_);
+  }
+
+  void DescribeNegationTo(std::ostream* os) const override {
+    *os << "doesn't have a '" << key_.get() << "' header with value that "
+        << testing::DescribeMatcher<absl::string_view>(matcher_);
+  }
+
+private:
+  const LowerCaseString key_;
+  const testing::Matcher<absl::string_view> matcher_;
+};
+
+class HeaderValueOfMatcher {
 public:
   explicit HeaderValueOfMatcher(LowerCaseString key, testing::Matcher<absl::string_view> matcher)
       : key_(std::move(key)), matcher_(std::move(matcher)) {}
 
-  bool MatchAndExplain(const HeaderMap& headers,
-                       testing::MatchResultListener* listener) const override;
-
-  void DescribeTo(std::ostream* os) const override;
-
-  void DescribeNegationTo(std::ostream* os) const override;
+  // Produces a testing::Matcher that is parameterized by HeaderMap& or const
+  // HeaderMap& as requested. This is required since testing::Matcher<const T&>
+  // is not implicitly convertible to testing::Matcher<T&>.
+  template <typename HeaderMapT> operator testing::Matcher<HeaderMapT>() const {
+    return testing::Matcher<HeaderMapT>(new HeaderValueOfMatcherImpl<HeaderMapT>(key_, matcher_));
+  }
 
 private:
   const LowerCaseString key_;
@@ -476,14 +527,9 @@ private:
 // Test that a HeaderMap argument contains exactly one header with the given
 // key, whose value satisfies the given expectation. The expectation can be a
 // matcher, or a string that the value should equal.
-template <typename T>
-testing::Matcher<const HeaderMap&> HeaderValueOf(LowerCaseString key, T matcher) {
-  return testing::MakeMatcher(
-      new HeaderValueOfMatcher(key, testing::SafeMatcherCast<absl::string_view>(matcher)));
-}
-
-template <typename T> testing::Matcher<const HeaderMap&> HeaderValueOf(std::string key, T matcher) {
-  return HeaderValueOf(LowerCaseString(key), matcher);
+template <typename T, typename K> HeaderValueOfMatcher HeaderValueOf(K key, T matcher) {
+  return HeaderValueOfMatcher(LowerCaseString(key),
+                              testing::SafeMatcherCast<absl::string_view>(matcher));
 }
 
 // Tests the provided Envoy HeaderMap for the provided HTTP status code.
@@ -517,11 +563,14 @@ MATCHER_P(HeaderMapEqualRef, rhs, "") {
 
 // Test that a HeaderMapPtr argument includes a given key-value pair, e.g.,
 //  HeaderHasValue("Upgrade", "WebSocket")
-testing::Matcher<const Http::HeaderMap*> HeaderHasValue(const std::string& key,
-                                                        const std::string& value);
+template <typename K, typename V>
+testing::Matcher<const Http::HeaderMap*> HeaderHasValue(K key, V value) {
+  return testing::Pointee(Http::HeaderValueOf(key, value));
+}
 
-// Like HeaderHasValue, but matches against a (const) HeaderMap& argument.
-testing::Matcher<const Http::HeaderMap&> HeaderHasValueRef(const std::string& key,
-                                                           const std::string& value);
+// Like HeaderHasValue, but matches against a HeaderMap& argument.
+template <typename K, typename V> Http::HeaderValueOfMatcher HeaderHasValueRef(K key, V value) {
+  return Http::HeaderValueOf(key, value);
+}
 
 } // namespace Envoy

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -14,8 +14,8 @@
 #include "envoy/http/filter.h"
 #include "envoy/ssl/connection.h"
 
-#include "common/http/utility.h"
 #include "common/http/header_map_impl.h"
+#include "common/http/utility.h"
 
 #include "test/mocks/common.h"
 #include "test/mocks/event/mocks.h"

--- a/test/mocks/http/mocks_test.cc
+++ b/test/mocks/http/mocks_test.cc
@@ -1,0 +1,40 @@
+#include "envoy/http/header_map.h"
+
+#include "test/mocks/http/mocks.h"
+#include "test/test_common/utility.h"
+
+namespace Envoy {
+using ::testing::Not;
+
+TEST(HttpHeaderMapMatcherTest, MutableValueRef) {
+  Http::TestHeaderMapImpl header_map;
+
+  EXPECT_THAT(header_map, Not(HeaderHasValueRef("key", "value")));
+  EXPECT_THAT(header_map, Not(HeaderHasValueRef("other key", "value")));
+
+  header_map.addCopy("key", "value");
+
+  EXPECT_THAT(header_map, HeaderHasValueRef("key", "value"));
+  EXPECT_THAT(header_map, Not(HeaderHasValueRef("key", "wrong value")));
+}
+
+TEST(HeaderHasValueRefTest, ConstValueRef) {
+  const Http::TestHeaderMapImpl header_map{{"key", "expected value"}};
+
+  EXPECT_THAT(header_map, Not(HeaderHasValueRef("key", "other value")));
+  EXPECT_THAT(header_map, HeaderHasValueRef("key", "expected value"));
+}
+
+TEST(HeaderHasValueRefTest, LowerCaseStringArguments) {
+  Http::LowerCaseString key("key"), other_key("other key");
+  Http::TestHeaderMapImpl header_map;
+
+  EXPECT_THAT(header_map, Not(HeaderHasValueRef(key, "value")));
+  EXPECT_THAT(header_map, Not(HeaderHasValueRef(other_key, "value")));
+
+  header_map.addCopy(key, "value");
+
+  EXPECT_THAT(header_map, HeaderHasValueRef(key, "value"));
+  EXPECT_THAT(header_map, Not(HeaderHasValueRef(other_key, "wrong value")));
+}
+} // namespace Envoy

--- a/test/mocks/http/mocks_test.cc
+++ b/test/mocks/http/mocks_test.cc
@@ -4,9 +4,87 @@
 #include "test/test_common/utility.h"
 
 namespace Envoy {
+using ::testing::_;
 using ::testing::Not;
 
-TEST(HttpHeaderMapMatcherTest, MutableValueRef) {
+namespace Http {
+TEST(HeaderValueOfTest, ConstHeaderMap) {
+  const TestHeaderMapImpl header_map{{"key", "expected value"}};
+
+  // Positive checks.
+  EXPECT_THAT(header_map, HeaderValueOf("key", "expected value"));
+  EXPECT_THAT(header_map, HeaderValueOf("key", _));
+
+  // Negative checks.
+  EXPECT_THAT(header_map, Not(HeaderValueOf("key", "other value")));
+  EXPECT_THAT(header_map, Not(HeaderValueOf("other key", _)));
+}
+
+TEST(HeaderValueOfTest, MutableHeaderMap) {
+  TestHeaderMapImpl header_map;
+
+  // Negative checks.
+  EXPECT_THAT(header_map, Not(HeaderValueOf("key", "other value")));
+  EXPECT_THAT(header_map, Not(HeaderValueOf("other key", _)));
+
+  header_map.addCopy("key", "expected value");
+
+  // Positive checks.
+  EXPECT_THAT(header_map, HeaderValueOf("key", "expected value"));
+  EXPECT_THAT(header_map, HeaderValueOf("key", _));
+}
+
+TEST(HeaderValueOfTest, LowerCaseString) {
+  TestHeaderMapImpl header_map;
+  LowerCaseString key("key");
+  LowerCaseString other_key("other_key");
+
+  // Negative checks.
+  EXPECT_THAT(header_map, Not(HeaderValueOf(key, "other value")));
+  EXPECT_THAT(header_map, Not(HeaderValueOf(other_key, _)));
+
+  header_map.addCopy(key, "expected value");
+  header_map.addCopy(other_key, "ValUe");
+
+  // Positive checks.
+  EXPECT_THAT(header_map, HeaderValueOf(key, "expected value"));
+  EXPECT_THAT(header_map, HeaderValueOf(other_key, _));
+}
+
+TEST(HttpStatusIsTest, CheckStatus) {
+  TestHeaderMapImpl header_map;
+  const auto status_matcher = HttpStatusIs(200);
+
+  EXPECT_THAT(header_map, Not(status_matcher));
+
+  header_map.addCopy(Headers::get().Status, "200");
+
+  EXPECT_THAT(header_map, status_matcher);
+}
+
+TEST(IsSubsetOfHeadersTest, ConstHeaderMap) {
+  const TestHeaderMapImpl header_map{{"first key", "1"}};
+
+  EXPECT_THAT(header_map, IsSubsetOfHeaders(TestHeaderMapImpl{{"first key", "1"}}));
+  EXPECT_THAT(header_map,
+              IsSubsetOfHeaders(TestHeaderMapImpl{{"first key", "1"}, {"second key", "2"}}));
+
+  EXPECT_THAT(header_map, Not(IsSubsetOfHeaders(TestHeaderMapImpl{{"third key", "1"}})));
+}
+
+TEST(IsSubsetOfHeadersTest, MutableHeaderMap) {
+  TestHeaderMapImpl header_map;
+  header_map.addCopy("first key", "1");
+
+  EXPECT_THAT(header_map, IsSubsetOfHeaders(TestHeaderMapImpl{{"first key", "1"}}));
+  EXPECT_THAT(header_map,
+              IsSubsetOfHeaders(TestHeaderMapImpl{{"first key", "1"}, {"second key", "2"}}));
+
+  EXPECT_THAT(header_map, Not(IsSubsetOfHeaders(TestHeaderMapImpl{{"third key", "1"}})));
+}
+} // namespace Http
+
+TEST(HeaderHasValueRefTest, MutableValueRef) {
   Http::TestHeaderMapImpl header_map;
 
   EXPECT_THAT(header_map, Not(HeaderHasValueRef("key", "value")));


### PR DESCRIPTION
Use additional template indirection to allow the HeaderMap gmock matchers to match both const and non-const `HeaderMap&`s.

*Risk Level*: low
*Testing*: added tests, ensured compatibility by building everything under `test/`
*Docs Changes*: n/a
*Release Notes*: n/a