### PR TITLE
upstream: ensure rounded priority load assigned to healthy priority

### DIFF
--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -85,7 +85,7 @@ void LoadBalancerBase::recalculatePerPriorityState(uint32_t priority) {
   size_t total_load = 100;
   int32_t first_healthy_priority = -1;
   for (size_t i = 0; i < per_priority_health_.size(); ++i) {
-    if (first_healthy_priority < 0 && per_priority_health_[i]) {
+    if (first_healthy_priority < 0 && per_priority_health_[i] > 0) {
       first_healthy_priority = i;
     }
     // Now assign as much load as possible to the high priority levels and cease assigning load
@@ -96,6 +96,7 @@ void LoadBalancerBase::recalculatePerPriorityState(uint32_t priority) {
   }
 
   if (total_load != 0) {
+    ASSERT(first_healthy_priority != -1);
     // Account for rounding errors by assigning it to the first healthy priority.
     ASSERT(total_load < per_priority_load_.size());
     per_priority_load_[first_healthy_priority] += total_load;

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -96,6 +96,7 @@ void LoadBalancerBase::recalculatePerPriorityState(uint32_t priority) {
   }
 
   if (total_load != 0) {
+    // Account for rounding errors by assigning it to the first healthy priority.
     ASSERT(total_load < per_priority_load_.size());
     per_priority_load_[first_healthy_priority] += total_load;
   }

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -81,18 +81,23 @@ void LoadBalancerBase::recalculatePerPriorityState(uint32_t priority) {
     per_priority_load_[0] = 100;
     return;
   }
+
   size_t total_load = 100;
+  int32_t first_healthy_priority = -1;
   for (size_t i = 0; i < per_priority_health_.size(); ++i) {
-    // Now assign as much load as possible to the high priority levels and cease assigning load when
-    // total_load runs out.
+    if (first_healthy_priority < 0 && per_priority_health_[i]) {
+      first_healthy_priority = i;
+    }
+    // Now assign as much load as possible to the high priority levels and cease assigning load
+    // when total_load runs out.
     per_priority_load_[i] =
         std::min<uint32_t>(total_load, per_priority_health_[i] * 100 / total_health);
     total_load -= per_priority_load_[i];
   }
+
   if (total_load != 0) {
-    // Account for rounding errors.
     ASSERT(total_load < per_priority_load_.size());
-    per_priority_load_[0] += total_load;
+    per_priority_load_[first_healthy_priority] += total_load;
   }
 }
 

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -219,6 +219,12 @@ TEST_P(LoadBalancerBaseTest, GentleFailoverWithExtraLevels) {
   updateHostSet(failover_host_set_, 5 /* num_hosts */, 1 /* num_healthy_hosts */);
   updateHostSet(tertiary_host_set_, 5 /* num_hosts */, 1 /* num_healthy_hosts */);
   ASSERT_THAT(getLoadPercentage(), ElementsAre(34, 33, 33));
+
+  // Rounding errors should be picked up by the first healthy priority.
+  updateHostSet(host_set_, 5 /* num_hosts */, 0 /* num_healthy_hosts */);
+  updateHostSet(failover_host_set_, 5 /* num_hosts */, 2 /* num_healthy_hosts */);
+  updateHostSet(tertiary_host_set_, 5 /* num_hosts */, 1 /* num_healthy_hosts */);
+  ASSERT_THAT(getLoadPercentage(), ElementsAre(0, 67, 33));
 }
 
 TEST_P(LoadBalancerBaseTest, BoundaryConditions) {


### PR DESCRIPTION
Ensures that when priority load is distributed between priorities and
there is a rounding error the remaining value is given to a healthy
priority. Previously, this remainder would always be given to priority
0, which would result in a completely unhealthy priority having non-zero
load.

If P0 was selected due to a rounding error but was otherwise unhealthy, the 
request would fail with UH as there are no healthy hosts available in the selected
priority (unless panic mode was triggered).

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Medium
*Testing*: Unit test
*Docs Changes*: n/a
*Release Notes*: n/a