### PR TITLE
Add MockRequestInfo.perRequestState default body

### DIFF
--- a/test/mocks/request_info/mocks.cc
+++ b/test/mocks/request_info/mocks.cc
@@ -64,6 +64,7 @@ MockRequestInfo::MockRequestInfo()
   }));
   ON_CALL(*this, bytesSent()).WillByDefault(ReturnPointee(&bytes_sent_));
   ON_CALL(*this, dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
+  ON_CALL(*this, perRequestState()).WillByDefault(ReturnRef(per_request_state_));
   ON_CALL(*this, setRequestedServerName(_))
       .WillByDefault(Invoke([this](const absl::string_view requested_server_name) {
         requested_server_name_ = std::string(requested_server_name);

--- a/test/mocks/request_info/mocks.h
+++ b/test/mocks/request_info/mocks.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "envoy/request_info/request_info.h"
+
 #include "common/request_info/filter_state_impl.h"
+
 #include "test/mocks/upstream/host.h"
 
 #include "gmock/gmock.h"

--- a/test/mocks/request_info/mocks.h
+++ b/test/mocks/request_info/mocks.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "envoy/request_info/request_info.h"
-
+#include "common/request_info/filter_state_impl.h"
 #include "test/mocks/upstream/host.h"
 
 #include "gmock/gmock.h"
@@ -80,6 +80,7 @@ public:
   absl::optional<Http::Protocol> protocol_;
   absl::optional<uint32_t> response_code_;
   envoy::api::v2::core::Metadata metadata_;
+  FilterStateImpl per_request_state_;
   uint64_t bytes_received_{};
   uint64_t bytes_sent_{};
   Network::Address::InstanceConstSharedPtr upstream_local_address_;


### PR DESCRIPTION
Signed-off-by: Xin Zhuang <stevenzzz@stevenzzz6.cam.corp.google.com>



*Description*:
Add a default body for MockRequestInfo.perRequestState would help tests which require access to perRequestState() not to create their own mock method. 
*Risk Level*: LOW ( test only )
*Testing*: N/A
Fixes #4537
