### PR TITLE
pgv: bump dependency to 30da78c.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,7 +10,5 @@ load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
 api_dependencies()
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
-load("@com_lyft_protoc_gen_validate//bazel:go_proto_library.bzl", "go_proto_repositories")
-go_proto_repositories(shared=0)
 go_rules_dependencies()
 go_register_toolchains()

--- a/api/bazel/api_build_system.bzl
+++ b/api/bazel/api_build_system.bzl
@@ -98,13 +98,6 @@ def api_proto_library(
         has_services = 0,
         linkstatic = None,
         require_py = 1):
-    # This is now vestigial, since there are no direct consumers in
-    # the data plane API. However, we want to maintain native proto_library support
-    # in the proto graph to (1) support future C++ use of native rules with
-    # cc_proto_library (or some Bazel aspect that works on proto_library) when
-    # it can play well with the PGV plugin and (2) other language support that
-    # can make use of native proto_library.
-
     native.proto_library(
         name = name,
         srcs = srcs,
@@ -123,11 +116,6 @@ def api_proto_library(
         ],
         visibility = visibility,
     )
-
-    # Under the hood, this is just an extension of the Protobuf library's
-    # bespoke cc_proto_library. It doesn't consume proto_library as a proto
-    # provider. Hopefully one day we can move to a model where this target and
-    # the proto_library above are aligned.
     pgv_cc_proto_library(
         name = _Suffix(name, _CC_SUFFIX),
         linkstatic = linkstatic,

--- a/api/bazel/api_build_system.bzl
+++ b/api/bazel/api_build_system.bzl
@@ -130,15 +130,13 @@ def api_proto_library(
     # the proto_library above are aligned.
     pgv_cc_proto_library(
         name = _Suffix(name, _CC_SUFFIX),
-        srcs = srcs,
         linkstatic = linkstatic,
-        deps = [_LibrarySuffix(d, _CC_SUFFIX) for d in deps],
-        external_deps = external_cc_proto_deps + [
-            "@com_google_protobuf//:cc_wkt_protos",
+        cc_deps = [_LibrarySuffix(d, _CC_SUFFIX) for d in deps] + external_cc_proto_deps + [
+            "@com_github_gogo_protobuf//:gogo_proto_cc",
             "@googleapis//:http_api_protos",
             "@googleapis//:rpc_status_protos",
-            "@com_github_gogo_protobuf//:gogo_proto_cc",
         ],
+        deps = [":" + name],
         visibility = ["//visibility:public"],
     )
     py_export_suffixes = []
@@ -147,7 +145,7 @@ def api_proto_library(
         py_export_suffixes = ["_py", "_py_genproto"]
 
     # Allow unlimited visibility for consumers
-    export_suffixes = ["", "_cc", "_cc_validate", "_cc_proto", "_cc_proto_genproto"] + py_export_suffixes
+    export_suffixes = ["", "_cc", "_cc_validate"] + py_export_suffixes
     for s in export_suffixes:
         native.alias(
             name = name + "_export" + s,

--- a/api/bazel/repositories.bzl
+++ b/api/bazel/repositories.bzl
@@ -6,7 +6,7 @@ GOGOPROTO_SHA = "1adfc126b41513cc696b209667c8656ea7aac67c"  # v1.0.0
 PROMETHEUS_SHA = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"  # Nov 17, 2017
 OPENCENSUS_SHA = "ab82e5fdec8267dc2a726544b10af97675970847"  # May 23, 2018
 
-PGV_GIT_SHA = "3bd820adb86cc455b16b37465905a9b99e22cbbb"  # Sep 27, 2018
+PGV_GIT_SHA = "30da78c4bcdd477b3c24d13e43cf39361ae3859f"  # Sep 27, 2018
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 

--- a/api/bazel/repositories.bzl
+++ b/api/bazel/repositories.bzl
@@ -1,4 +1,6 @@
+BAZEL_SKYLIB_RELEASE = "0.5.0"
 BAZEL_SKYLIB_SHA = "b5f6abe419da897b7901f90cbab08af958b97a8f3575b0d3dd062ac7ce78541f"
+
 GOOGLEAPIS_SHA = "d642131a6e6582fc226caf9893cb7fe7885b3411"  # May 23, 2018
 GOGOPROTO_SHA = "1adfc126b41513cc696b209667c8656ea7aac67c"  # v1.0.0
 PROMETHEUS_SHA = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"  # Nov 17, 2017
@@ -11,9 +13,9 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def api_dependencies():
     native.http_archive(
         name = "bazel_skylib",
-        url = "https://github.com/bazelbuild/bazel-skylib/archive/0.5.0.tar.gz",
+        url = "https://github.com/bazelbuild/bazel-skylib/archive/" + BAZEL_SKYLIB_RELEASE + ".tar.gz",
         sha256 = BAZEL_SKYLIB_SHA,
-        strip_prefix = "bazel-skylib-0.5.0",
+        strip_prefix = "bazel-skylib-" + BAZEL_SKYLIB_RELEASE,
     )
     git_repository(
         name = "com_lyft_protoc_gen_validate",

--- a/api/bazel/repositories.bzl
+++ b/api/bazel/repositories.bzl
@@ -1,13 +1,20 @@
+BAZEL_SKYLIB_SHA = "b5f6abe419da897b7901f90cbab08af958b97a8f3575b0d3dd062ac7ce78541f"
 GOOGLEAPIS_SHA = "d642131a6e6582fc226caf9893cb7fe7885b3411"  # May 23, 2018
 GOGOPROTO_SHA = "1adfc126b41513cc696b209667c8656ea7aac67c"  # v1.0.0
 PROMETHEUS_SHA = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"  # Nov 17, 2017
 OPENCENSUS_SHA = "ab82e5fdec8267dc2a726544b10af97675970847"  # May 23, 2018
 
-PGV_GIT_SHA = "f9d2b11e44149635b23a002693b76512b01ae515"
+PGV_GIT_SHA = "3bd820adb86cc455b16b37465905a9b99e22cbbb"  # Sep 27, 2018
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def api_dependencies():
+    native.http_archive(
+        name = "bazel_skylib",
+        url = "https://github.com/bazelbuild/bazel-skylib/archive/0.5.0.tar.gz",
+        sha256 = BAZEL_SKYLIB_SHA,
+        strip_prefix = "bazel-skylib-0.5.0",
+    )
     git_repository(
         name = "com_lyft_protoc_gen_validate",
         remote = "https://github.com/lyft/protoc-gen-validate.git",

--- a/api/test/validate/pgv_test.cc
+++ b/api/test/validate/pgv_test.cc
@@ -63,7 +63,7 @@ int main(int argc, char* argv[]) {
   cluster_manager {}
   admin {
     access_log_path: "/dev/null"
-    address {}
+    address { pipe { path: "/" } }
   }
   )EOF";
   envoy::config::bootstrap::v2::Bootstrap valid_bootstrap;

--- a/ci/WORKSPACE
+++ b/ci/WORKSPACE
@@ -19,7 +19,5 @@ load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
 api_dependencies()
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
-load("@com_lyft_protoc_gen_validate//bazel:go_proto_library.bzl", "go_proto_repositories")
-go_proto_repositories(shared=0)
 go_rules_dependencies()
 go_register_toolchains()

--- a/ci/WORKSPACE.filter.example
+++ b/ci/WORKSPACE.filter.example
@@ -18,7 +18,5 @@ load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
 api_dependencies()
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
-load("@com_lyft_protoc_gen_validate//bazel:go_proto_library.bzl", "go_proto_repositories")
-go_proto_repositories(shared=0)
 go_rules_dependencies()
 go_register_toolchains()


### PR DESCRIPTION
This should unblock Windows, fix the long CLI issue and also fuzz weak link problems.

Signed-off-by: Harvey Tuch <htuch@google.com>