### PR TITLE
admin: add support for displaying san in certs end point

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -9,6 +9,7 @@ Version history
 * access log: added REQUESTED_SERVER_NAME for SNI to tcp_proxy and http
 * admin: added :http:get:`/hystrix_event_stream` as an endpoint for monitoring envoy's statistics
   through `Hystrix dashboard <https://github.com/Netflix-Skunkworks/hystrix-dashboard/wiki>`_.
+* admin: added support for displaying subject alternate names in :ref:`certs<operations_admin_interface>` end point.
 * cli: Added support for :ref:`component log level <operations_cli>` command line option for configuring log levels of individual components.
 * cluster: added :ref:`option <envoy_api_field_Cluster.CommonLbConfig.update_merge_window>` to merge
   health check/weight/metadata updates within the given duration.
@@ -88,8 +89,7 @@ Version history
 * tcp_proxy: added support for :ref:`weighted clusters <envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.weighted_clusters>`.
 * thrift_proxy: introduced thrift routing, moved configuration to correct location
 * thrift_proxy: introduced thrift configurable decoder filters
-* tls: implemented `SecretDiscoveryService <https://github.com/envoyproxy/envoy/blob/master/api/envoy/service/\
-  discovery/v2/sds.proto>`_.
+* tls: implemented :ref:`Secret Discovery Service <config_secret_discovery_service>`.
 * tracing: added support for configuration of :ref:`tracing sampling
   <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.tracing>`.
 * upstream: added configuration option to the subset load balancer to take locality weights into account when

--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -461,8 +461,9 @@ std::string ContextImpl::getCaCertInformation() const {
   if (ca_cert_ == nullptr) {
     return "";
   }
-  return fmt::format("Certificate Path: {}, Serial Number: {}, Days until Expiration: {}",
+  return fmt::format("Certificate Path: {}, Serial Number: {}, Subject Alternate Names: {}, Days until Expiration: {}",
                      getCaFileName(), Utility::getSerialNumberFromCertificate(*ca_cert_.get()),
+                     Utility::formattedSubjectAltNames(Utility::getSubjectAltNames(*ca_cert_.get())),
                      getDaysUntilExpiration(ca_cert_.get()));
 }
 
@@ -470,9 +471,10 @@ std::string ContextImpl::getCertChainInformation() const {
   if (cert_chain_ == nullptr) {
     return "";
   }
-  return fmt::format("Certificate Path: {}, Serial Number: {}, Days until Expiration: {}",
+  return fmt::format("Certificate Path: {}, Serial Number: {}, Subject Alternate Names: {}, Days until Expiration: {}",
                      getCertChainFileName(),
                      Utility::getSerialNumberFromCertificate(*cert_chain_.get()),
+                     Utility::formattedSubjectAltNames(Utility::getSubjectAltNames(*cert_chain_.get())),
                      getDaysUntilExpiration(cert_chain_.get()));
 }
 

--- a/source/common/ssl/utility.cc
+++ b/source/common/ssl/utility.cc
@@ -1,9 +1,14 @@
+
 #include "common/ssl/utility.h"
+
+#include "absl/strings/str_join.h"
+
+#include "openssl/x509v3.h"
 
 namespace Envoy {
 namespace Ssl {
 
-std::string Utility::getSerialNumberFromCertificate(X509& cert) {
+const std::string Utility::getSerialNumberFromCertificate(X509& cert) {
   ASN1_INTEGER* serial_number = X509_get_serialNumber(&cert);
   BIGNUM num_bn;
   BN_init(&num_bn);
@@ -16,6 +21,31 @@ std::string Utility::getSerialNumberFromCertificate(X509& cert) {
     return serial_number;
   }
   return "";
+}
+
+const std::vector<std::string> Utility::getSubjectAltNames(X509& cert) {
+ std::vector<std::string> subject_alt_names;
+ bssl::UniquePtr<GENERAL_NAMES> san_names(
+      static_cast<GENERAL_NAMES*>(X509_get_ext_d2i(&cert, NID_subject_alt_name, nullptr, nullptr)));
+  if (san_names == nullptr) {
+    return subject_alt_names;
+  }
+  for (const GENERAL_NAME* san : san_names.get()) {
+    if (san->type == GEN_DNS) {
+      ASN1_STRING* str = san->d.dNSName;
+      const char* dns_name = reinterpret_cast<const char*>(ASN1_STRING_data(str));
+      subject_alt_names.push_back(std::string(dns_name));
+    } else if (san->type == GEN_URI) {
+      ASN1_STRING* str = san->d.uniformResourceIdentifier;
+      const char* uri = reinterpret_cast<const char*>(ASN1_STRING_data(str));
+      subject_alt_names.push_back(std::string(uri));
+    }
+  }
+  return subject_alt_names;
+}
+
+const std::string Utility::formattedSubjectAltNames(const std::vector<std::string>& subject_alt_names) {
+  return absl::StrJoin(subject_alt_names, ", ");
 }
 
 } // namespace Ssl

--- a/source/common/ssl/utility.h
+++ b/source/common/ssl/utility.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "openssl/ssl.h"
 
@@ -9,12 +10,26 @@ namespace Ssl {
 namespace Utility {
 
 /**
- * Retrieve the serial number of a certificate.
- * @param ssl the certificate
+ * Retrieves the serial number of a certificate.
+ * @param cert the certificate
  * @return std::string the serial number field of the certificate. Returns "" if
  *         there is no serial number.
  */
-std::string getSerialNumberFromCertificate(X509& cert);
+const std::string getSerialNumberFromCertificate(X509& cert);
+
+/**
+ * Retrieves the subject alternate names of a certificate.
+ * @param cert the certificate
+ * @return std::vector returns the list of subject alternate names.
+ */
+const std::vector<std::string> getSubjectAltNames(X509& cert);
+
+/**
+ * Formats the subject alternate names of a certificate in a comma separated string
+ * @param std::vector list of subject alternate names
+ * @return std::string comma separated list of subject alternate names.
+ */
+const std::string formattedSubjectAltNames(const std::vector<std::string>& subject_alt_names);
 
 } // namespace Utility
 } // namespace Ssl


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*: Adds support for displaying Subject Alternate Names as a comma separated list of string in `/certs` admin end point
*Risk Level*: Low
*Testing*: Automated
*Docs Changes*: Updated
*Release Notes*: Updated
