### PR TITLE
router: add scheme and port redirect actions (#3060)

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -771,8 +771,16 @@ message RouteAction {
 }
 
 message RedirectAction {
+  oneof scheme_rewrite_specifier {
+    // The scheme portion of the URL will be swapped with "https".
+    bool https_redirect = 4;
+    // The scheme portion of the URL will be swapped with this value.
+    string scheme_redirect = 7;
+  }
   // The host portion of the URL will be swapped with this value.
   string host_redirect = 1;
+  // The port value of the URL will be swapped with this value.
+  uint32 port_redirect = 8;
 
   oneof path_rewrite_specifier {
     // The path portion of the URL will be swapped with this value.
@@ -809,9 +817,6 @@ message RedirectAction {
   // The HTTP status code to use in the redirect response. The default response
   // code is MOVED_PERMANENTLY (301).
   RedirectResponseCode response_code = 3 [(validate.rules).enum.defined_only = true];
-
-  // The scheme portion of the URL will be swapped with "https".
-  bool https_redirect = 4;
 
   // Indicates that during redirection, the query portion of the URL will
   // be removed. Default value is false.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -15,6 +15,9 @@ Version history
 * router: added ability to set attempt count in upstream requests, see :ref:`virtual host's include request
   attempt count flag <envoy_api_field_route.VirtualHost.include_request_attempt_count>`.
 * router: added internal :ref:`grpc-retry-on <config_http_filters_router_x-envoy-retry-grpc-on>` policy.
+* router: added :ref:`scheme_redirect <envoy_api_field_route.RedirectAction.scheme_redirect>` and
+  :ref:`port_redirect <envoy_api_field_route.RedirectAction.port_redirect>` to define the respective
+  scheme and port rewriting RedirectAction
 * router: when :ref:`max_grpc_timeout <envoy_api_field_route.RouteAction.max_grpc_timeout>`
   is set, Envoy will now add or update the grpc-timeout header to reflect Envoy's expected timeout.
 * stats: added :ref:`stats_matcher <envoy_api_field_config.metrics.v2.StatsConfig.stats_matcher>` to the bootstrap config for granular control of stat instantiation.

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -273,7 +273,11 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
       idle_timeout_(PROTOBUF_GET_OPTIONAL_MS(route.route(), idle_timeout)),
       max_grpc_timeout_(PROTOBUF_GET_OPTIONAL_MS(route.route(), max_grpc_timeout)),
       loader_(factory_context.runtime()), runtime_(loadRuntimeData(route.match())),
+      scheme_redirect_(route.redirect().scheme_redirect()),
       host_redirect_(route.redirect().host_redirect()),
+      port_redirect_(route.redirect().port_redirect()
+                         ? ":" + std::to_string(route.redirect().port_redirect())
+                         : ""),
       path_redirect_(route.redirect().path_redirect()),
       https_redirect_(route.redirect().https_redirect()),
       prefix_rewrite_redirect_(route.redirect().prefix_rewrite()),
@@ -475,14 +479,46 @@ void RouteEntryImplBase::finalizePathHeader(Http::HeaderMap& headers,
 std::string RouteEntryImplBase::newPath(const Http::HeaderMap& headers) const {
   ASSERT(isDirectResponse());
 
-  const char* final_host;
-  absl::string_view final_path;
   const char* final_scheme;
+  absl::string_view final_host;
+  absl::string_view final_port;
+  absl::string_view final_path;
+
+  if (!scheme_redirect_.empty()) {
+    final_scheme = scheme_redirect_.c_str();
+  } else if (https_redirect_) {
+    final_scheme = Http::Headers::get().SchemeValues.Https.c_str();
+  } else {
+    ASSERT(headers.ForwardedProto());
+    final_scheme = headers.ForwardedProto()->value().c_str();
+  }
+
+  if (!port_redirect_.empty()) {
+    final_port = port_redirect_.c_str();
+  } else {
+    final_port = "";
+  }
+
   if (!host_redirect_.empty()) {
     final_host = host_redirect_.c_str();
   } else {
     ASSERT(headers.Host());
     final_host = headers.Host()->value().c_str();
+    if (!final_port.empty()) {
+      size_t host_end;
+      // Detect if IPv6 URI
+      if (final_host[0] == '[') {
+        host_end = final_host.rfind("]:");
+        if (host_end != absl::string_view::npos) {
+          host_end += 1; // advance to :
+        }
+      } else {
+        host_end = final_host.rfind(":");
+      }
+      if (host_end != absl::string_view::npos) {
+        final_host = final_host.substr(0, host_end);
+      }
+    }
   }
 
   if (!path_redirect_.empty()) {
@@ -498,14 +534,7 @@ std::string RouteEntryImplBase::newPath(const Http::HeaderMap& headers) const {
     }
   }
 
-  if (https_redirect_) {
-    final_scheme = Http::Headers::get().SchemeValues.Https.c_str();
-  } else {
-    ASSERT(headers.ForwardedProto());
-    final_scheme = headers.ForwardedProto()->value().c_str();
-  }
-
-  return fmt::format("{}://{}{}", final_scheme, final_host, final_path);
+  return fmt::format("{}://{}{}{}", final_scheme, final_host, final_port, final_path);
 }
 
 std::multimap<std::string, std::string>

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -557,7 +557,9 @@ private:
   const absl::optional<std::chrono::milliseconds> max_grpc_timeout_;
   Runtime::Loader& loader_;
   const absl::optional<RuntimeData> runtime_;
+  const std::string scheme_redirect_;
   const std::string host_redirect_;
+  const std::string port_redirect_;
   const std::string path_redirect_;
   const bool https_redirect_;
   const std::string prefix_rewrite_redirect_;


### PR DESCRIPTION

*Description*:
Add scheme_redirect and port_redirect to RedirectAction which replace the respective
URI components when applied.
scheme_redirect and https_redirect are mutually exclusive.
It is presumed that host_redirect won't include a ":<port>" when port_redirect is used.

*Risk Level*: Medium
*Testing*: Unit tests
*Docs Changes*: Adding the scheme_redirect and port_redirect doc strings
*Release Notes*:
*Fixes #Issue*: #3060 

Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>