### PR TITLE
ci: Look for third-party libraries in /usr/lib*

### DIFF
--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -11,7 +11,7 @@ cc_library(
     name = "ares",
     srcs = select({
         ":windows_x86_64": ["thirdparty_build/lib/cares.lib"],
-        "//conditions:default": ["thirdparty_build/lib/libcares.a"],
+        "//conditions:default": glob(["thirdparty_build/lib*/libcares.a"]),
     }),
     hdrs = glob(["thirdparty_build/include/ares*.h"]),
     includes = ["thirdparty_build/include"],
@@ -21,7 +21,7 @@ cc_library(
     name = "benchmark",
     srcs = select({
         ":windows_x86_64": ["thirdparty_build/lib/benchmark.lib"],
-        "//conditions:default": ["thirdparty_build/lib/libbenchmark.a"],
+        "//conditions:default": glob(["thirdparty_build/lib*/libbenchmark.a"]),
     }),
     hdrs = ["thirdparty_build/include/testing/base/public/benchmark.h"],
     includes = ["thirdparty_build/include"],
@@ -31,7 +31,7 @@ cc_library(
     name = "event",
     srcs = select({
         ":windows_x86_64": ["thirdparty_build/lib/event.lib"],
-        "//conditions:default": ["thirdparty_build/lib/libevent.a"],
+        "//conditions:default": glob(["thirdparty_build/lib*/libevent.a"]),
     }),
     hdrs = glob(["thirdparty_build/include/event2/**/*.h"]),
     includes = ["thirdparty_build/include"],
@@ -41,7 +41,7 @@ cc_library(
     name = "luajit",
     srcs = select({
         ":windows_x86_64": ["thirdparty_build/lib/luajit.lib"],
-        "//conditions:default": ["thirdparty_build/lib/libluajit-5.1.a"],
+        "//conditions:default": glob(["thirdparty_build/lib*/libluajit-5.1.a"]),
     }),
     hdrs = glob(["thirdparty_build/include/luajit-2.0/*"]),
     includes = ["thirdparty_build/include"],
@@ -53,7 +53,7 @@ cc_library(
     name = "nghttp2",
     srcs = select({
         ":windows_x86_64": ["thirdparty_build/lib/nghttp2.lib"],
-        "//conditions:default": ["thirdparty_build/lib/libnghttp2.a"],
+        "//conditions:default": glob(["thirdparty_build/lib*/libnghttp2.a"]),
     }),
     hdrs = glob(["thirdparty_build/include/nghttp2/**/*.h"]),
     includes = ["thirdparty_build/include"],
@@ -61,7 +61,7 @@ cc_library(
 
 cc_library(
     name = "tcmalloc_and_profiler",
-    srcs = ["thirdparty_build/lib/libtcmalloc_and_profiler.a"],
+    srcs = glob(["thirdparty_build/lib*/libtcmalloc_and_profiler.a"]),
     hdrs = glob(["thirdparty_build/include/gperftools/**/*.h"]),
     strip_include_prefix = "thirdparty_build/include",
 )
@@ -70,7 +70,7 @@ cc_library(
     name = "yaml_cpp",
     srcs = select({
         ":windows_x86_64": glob(["thirdparty_build/lib/libyaml-cpp*.lib"]),
-        "//conditions:default": ["thirdparty_build/lib/libyaml-cpp.a"],
+        "//conditions:default": glob(["thirdparty_build/lib*/libyaml-cpp.a"]),
     }),
     hdrs = glob(["thirdparty_build/include/yaml-cpp/**/*.h"]),
     includes = ["thirdparty_build/include"],
@@ -80,7 +80,7 @@ cc_library(
     name = "zlib",
     srcs = select({
         ":windows_x86_64": glob(["thirdparty_build/lib/zlibstaticd.lib"]),
-        "//conditions:default": ["thirdparty_build/lib/libz.a"],
+        "//conditions:default": glob(["thirdparty_build/lib*/libz.a"]),
     }),
     hdrs = [
         "thirdparty_build/include/zconf.h",


### PR DESCRIPTION
*Description*:
Before this change, BUILD file from ci/prebuild was looking for third-party libraries only in /usr/lib directory. Some Linux distributions (i.e. openSUSE) install libraries in /usr/lib64 when the system is 64-bit. Because of that, build was failing on those distributions. Using glob function and wildcard expressions fix the problem.

*Risk Level*: Low
*Testing*: bazel --bazelrc=/dev/null build -c opt //source/exe:envoy-static (on openSUSE)
*Docs Changes*: n/a
*Release Notes*: n/a
