### PR TITLE
stats: Don't expect vec.front() to be predictable when populated from unordered container

### DIFF
--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -39,6 +39,12 @@ public:
     store_->addSink(sink_);
   }
 
+  /**
+   * Finds a stat in a vector with the given name.
+   * @param name the stat name to look for.
+   * @param v the vector of stats.
+   * @return the stat
+   */
   template <typename T> T findByName(const std::string& name, const std::vector<T>& v) {
     auto pos = std::find_if(v.begin(), v.end(),
                             [&name](const T& stat) -> bool { return stat->name() == name; });

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -293,7 +293,6 @@ TEST_F(StatsThreadLocalStoreTest, ScopeDelete) {
   EXPECT_EQ(2UL, store_->counters().size());
   CounterSharedPtr c1 = TestUtility::findCounter(*store_, "scope1.c1");
   EXPECT_EQ("scope1.c1", c1->name());
-  EXPECT_EQ(store_->source().cachedCounters().front(), c1);
   EXPECT_EQ(TestUtility::findByName(store_->source().cachedCounters(), "scope1.c1"), c1);
 
   EXPECT_CALL(main_thread_dispatcher_, post(_));

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -119,21 +119,11 @@ void TestUtility::feedBufferWithRandomCharacters(Buffer::Instance& buffer, uint6
 }
 
 Stats::CounterSharedPtr TestUtility::findCounter(Stats::Store& store, const std::string& name) {
-  for (auto counter : store.counters()) {
-    if (counter->name() == name) {
-      return counter;
-    }
-  }
-  return nullptr;
+  return findByName(store.counters(), name);
 }
 
 Stats::GaugeSharedPtr TestUtility::findGauge(Stats::Store& store, const std::string& name) {
-  for (auto gauge : store.gauges()) {
-    if (gauge->name() == name) {
-      return gauge;
-    }
-  }
-  return nullptr;
+  return findByName(store.gauges(), name);
 }
 
 std::list<Network::Address::InstanceConstSharedPtr>

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -130,6 +130,21 @@ public:
                                              uint64_t seed = 0);
 
   /**
+   * Finds a stat in a vector with the given name.
+   * @param name the stat name to look for.
+   * @param v the vector of stats.
+   * @return the stat
+   */
+  template <typename T> static T findByName(const std::vector<T>& v, const std::string& name) {
+    auto pos = std::find_if(v.begin(), v.end(),
+                            [&name](const T& stat) -> bool { return stat->name() == name; });
+    if (pos == v.end()) {
+      return nullptr;
+    }
+    return *pos;
+  }
+
+  /**
    * Find a counter in a stats store.
    * @param store supplies the stats store.
    * @param name supplies the name to search for.


### PR DESCRIPTION
*Description*: thread_local_store iterates over unordered_maps to implement counters(), etc. Some of the tests for it had two stats, but were expecting the first vector element to be a particular value. This makes the test dependent on hashes and unordered_map implementation.
*Risk Level*: low
*Testing*: //test/common/stats:thread_local_store_test
*Docs Changes*: n/a
*Release Notes*: n/a
*Fixes #Issue: https://github.com/envoyproxy/envoy/issues/4572

