### PR TITLE
upstream: make sure all_hosts_ is updated correctly

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1130,10 +1130,11 @@ void StrictDnsClusterImpl::updateAllHosts(const HostVector& hosts_added,
     std::unordered_set<std::string> host_addresses;
     if (target->locality_lb_endpoint_.priority() == current_priority) {
       for (auto i = target->hosts_.begin(); i != target->hosts_.end();) {
-        if (host_addresses.count((*i)->address()->asString()) == 0) {
+        const auto& address = (*i)->address()->asString();
+        if (host_addresses.count(address) == 0) {
           priority_state_manager.registerHostForPriority(*i, target->locality_lb_endpoint_,
                                                          target->lb_endpoint_, absl::nullopt);
-          host_addresses.insert((*i)->address()->asString());
+          host_addresses.insert(address);
           ++i;
         } else {
           i = target->hosts_.erase(i);

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1135,9 +1135,11 @@ void StrictDnsClusterImpl::updateAllHosts(const HostVector& hosts_added,
           priority_state_manager.registerHostForPriority(*i, target->locality_lb_endpoint_,
                                                          target->lb_endpoint_, absl::nullopt);
           host_addresses.insert(address);
-          ++i;
+          i++;
         } else {
-          i = target->hosts_.erase(i);
+          i = std::remove_if(i, target->hosts_.end(), [&address](const auto& host) {
+            return host->address()->asString() == address;
+          });
         }
       }
     }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1198,6 +1198,8 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
             return host->priority() == locality_lb_endpoint_.priority();
           }));
           parent_.updateAllHosts(hosts_added, hosts_removed, locality_lb_endpoint_.priority());
+        } else {
+          parent_.info_->stats().update_no_rebuild_.inc();
         }
 
         for (const auto& set : parent_.prioritySet().hostSetsPerPriority()) {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1189,14 +1189,6 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
               locality_lb_endpoint_.priority()));
         }
 
-        for (const auto& set : parent_.prioritySet().hostSetsPerPriority()) {
-          for (const auto& host : set->hosts()) {
-            if (parent_.health_checker_ != nullptr) {
-              updated_hosts.insert({host->address()->asString(), host});
-            }
-          }
-        }
-
         HostVector hosts_added;
         HostVector hosts_removed;
         if (parent_.updateDynamicHostList(new_hosts, hosts_, hosts_added, hosts_removed,
@@ -1208,6 +1200,14 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
           parent_.updateAllHosts(hosts_added, hosts_removed, locality_lb_endpoint_.priority());
         }
 
+        // TODO(dio): Not sure if we should do this if active health checking is disabled.
+        if (parent_.health_checker_ != nullptr) {
+          for (const auto& set : parent_.prioritySet().hostSetsPerPriority()) {
+            for (const auto& host : set->hosts()) {
+              updated_hosts.insert({host->address()->asString(), host});
+            }
+          }
+        }
         parent_.updateHostMap(std::move(updated_hosts));
 
         // If there is an initialize callback, fire it now. Note that if the cluster refers to

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1189,6 +1189,14 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
               locality_lb_endpoint_.priority()));
         }
 
+        for (const auto& set : parent_.prioritySet().hostSetsPerPriority()) {
+          for (const auto& host : set->hosts()) {
+            if (parent_.health_checker_ != nullptr) {
+              updated_hosts.insert({host->address()->asString(), host});
+            }
+          }
+        }
+
         HostVector hosts_added;
         HostVector hosts_removed;
         if (parent_.updateDynamicHostList(new_hosts, hosts_, hosts_added, hosts_removed,

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1125,22 +1125,17 @@ void StrictDnsClusterImpl::updateAllHosts(const HostVector& hosts_added,
                                           uint32_t current_priority) {
   PriorityStateManager priority_state_manager(*this, local_info_);
   // At this point we know that we are different so make a new host list and notify.
+  //
+  // TODO(dio): The uniqueness of a host address resolved in STRICT_DNS cluster per priority is not
+  // guaranteed. Need a clear agreement on the behavior here, whether it is allowable to have
+  // duplicated hosts inside a priority. And if we want to enforce this behavior, it should be done
+  // inside the priority state manager.
   for (const ResolveTargetPtr& target : resolve_targets_) {
     priority_state_manager.initializePriorityFor(target->locality_lb_endpoint_);
-    std::unordered_set<std::string> host_addresses;
-    if (target->locality_lb_endpoint_.priority() == current_priority) {
-      for (auto i = target->hosts_.begin(); i != target->hosts_.end();) {
-        const auto& address = (*i)->address()->asString();
-        if (host_addresses.count(address) == 0) {
-          priority_state_manager.registerHostForPriority(*i, target->locality_lb_endpoint_,
-                                                         target->lb_endpoint_, absl::nullopt);
-          host_addresses.insert(address);
-          i++;
-        } else {
-          i = std::remove_if(i, target->hosts_.end(), [&address](const auto& host) {
-            return host->address()->asString() == address;
-          });
-        }
+    for (const HostSharedPtr& host : target->hosts_) {
+      if (target->locality_lb_endpoint_.priority() == current_priority) {
+        priority_state_manager.registerHostForPriority(host, target->locality_lb_endpoint_,
+                                                       target->lb_endpoint_, absl::nullopt);
       }
     }
   }
@@ -1205,6 +1200,9 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
           parent_.info_->stats().update_no_rebuild_.inc();
         }
 
+        // This makes sure parent_.all_hosts_ is updated with all resolved hosts from all
+        // priorities. This reconciliation is required since we check each new host againsts this
+        // list.
         for (const auto& set : parent_.prioritySet().hostSetsPerPriority()) {
           for (const auto& host : set->hosts()) {
             updated_hosts.insert({host->address()->asString(), host});

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1200,12 +1200,9 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
           parent_.updateAllHosts(hosts_added, hosts_removed, locality_lb_endpoint_.priority());
         }
 
-        // TODO(dio): Not sure if we should do this if active health checking is disabled.
-        if (parent_.health_checker_ != nullptr) {
-          for (const auto& set : parent_.prioritySet().hostSetsPerPriority()) {
-            for (const auto& host : set->hosts()) {
-              updated_hosts.insert({host->address()->asString(), host});
-            }
+        for (const auto& set : parent_.prioritySet().hostSetsPerPriority()) {
+          for (const auto& host : set->hosts()) {
+            updated_hosts.insert({host->address()->asString(), host});
           }
         }
         parent_.updateHostMap(std::move(updated_hosts));

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -406,7 +406,7 @@ TEST(StrictDnsClusterImplTest, HostRemovalActiveHealthSkipped) {
   resolver.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.1"}));
 
   const auto& hosts = cluster.prioritySet().hostSetsPerPriority()[0]->hosts();
-  EXPECT_EQ(1UL, hosts.size());
+  EXPECT_EQ(0UL, hosts.size());
 }
 
 TEST(StrictDnsClusterImplTest, LoadAssignmentBasic) {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -406,7 +406,7 @@ TEST(StrictDnsClusterImplTest, HostRemovalActiveHealthSkipped) {
   resolver.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.1"}));
 
   const auto& hosts = cluster.prioritySet().hostSetsPerPriority()[0]->hosts();
-  EXPECT_EQ(0UL, hosts.size());
+  EXPECT_EQ(1UL, hosts.size());
 }
 
 TEST(StrictDnsClusterImplTest, LoadAssignmentBasic) {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -521,7 +521,7 @@ TEST(StrictDnsClusterImplTest, LoadAssignmentBasic) {
   EXPECT_EQ("localhost1", cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[0]->hostname());
   EXPECT_EQ("localhost1", cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[1]->hostname());
 
-  // This is the first time we receveived an update, we expect to rebuild.
+  // This is the first time we receveived an update for localhost1, we expect to rebuild.
   EXPECT_EQ(0UL, stats.counter("cluster.name.update_no_rebuild").value());
 
   resolver1.expectResolve(*dns_resolver);
@@ -532,7 +532,7 @@ TEST(StrictDnsClusterImplTest, LoadAssignmentBasic) {
       std::list<std::string>({"127.0.0.1:11001", "127.0.0.2:11001"}),
       ContainerEq(hostListToAddresses(cluster.prioritySet().hostSetsPerPriority()[0]->hosts())));
 
-  // Since no change, we expect no rebuild.
+  // Since no change for localhost1, we expect no rebuild.
   EXPECT_EQ(1UL, stats.counter("cluster.name.update_no_rebuild").value());
 
   resolver1.expectResolve(*dns_resolver);
@@ -543,20 +543,34 @@ TEST(StrictDnsClusterImplTest, LoadAssignmentBasic) {
       std::list<std::string>({"127.0.0.1:11001", "127.0.0.2:11001"}),
       ContainerEq(hostListToAddresses(cluster.prioritySet().hostSetsPerPriority()[0]->hosts())));
 
-  // Since no change, we expect no rebuild.
+  // Since no change for localhost1, we expect no rebuild.
   EXPECT_EQ(2UL, stats.counter("cluster.name.update_no_rebuild").value());
+
+  EXPECT_CALL(*resolver2.timer_, enableTimer(std::chrono::milliseconds(4000)));
+  EXPECT_CALL(membership_updated, ready());
+  resolver2.dns_callback_(TestUtility::makeDnsResponse({"10.0.0.1", "10.0.0.1"}));
+
+  // We received a new set of hosts for localhost2. Should rebuild the cluster.
+  EXPECT_EQ(2UL, stats.counter("cluster.name.update_no_rebuild").value());
+
+  resolver1.expectResolve(*dns_resolver);
+  resolver1.timer_->callback_();
+  EXPECT_CALL(*resolver1.timer_, enableTimer(std::chrono::milliseconds(4000)));
+  resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.2", "127.0.0.1"}));
+
+  // We again received the same set as before for localhost1. No rebuild this time.
+  EXPECT_EQ(3UL, stats.counter("cluster.name.update_no_rebuild").value());
 
   resolver1.timer_->callback_();
   EXPECT_CALL(*resolver1.timer_, enableTimer(std::chrono::milliseconds(4000)));
   EXPECT_CALL(membership_updated, ready());
   resolver1.dns_callback_(TestUtility::makeDnsResponse({"127.0.0.3"}));
   EXPECT_THAT(
-      std::list<std::string>({"127.0.0.3:11001"}),
+      std::list<std::string>({"127.0.0.3:11001", "10.0.0.1:11002"}),
       ContainerEq(hostListToAddresses(cluster.prioritySet().hostSetsPerPriority()[0]->hosts())));
 
   // Make sure we de-dup the same address.
   EXPECT_CALL(*resolver2.timer_, enableTimer(std::chrono::milliseconds(4000)));
-  EXPECT_CALL(membership_updated, ready());
   resolver2.dns_callback_(TestUtility::makeDnsResponse({"10.0.0.1", "10.0.0.1"}));
   EXPECT_THAT(
       std::list<std::string>({"127.0.0.3:11001", "10.0.0.1:11002"}),


### PR DESCRIPTION
*Description*: 
To make sure we all_hosts_ is updated correctly by all hosts from all priorities and no-rebuild if the update is the same. 

This #4548 seems to happen only for `STRICT_DNS` cluster.

*Risk Level*: Medium
*Testing*: unit tests on checking `update_no_rebuild` when `hosts_change` equals `false`, existing tests, manual tests.
*Docs Changes*: N/A
*Release Notes*: N/A

Fixes #4548

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>
