### PR TITLE
Refactor fd to accommodate more general I/O handle

### DIFF
--- a/include/envoy/network/BUILD
+++ b/include/envoy/network/BUILD
@@ -62,7 +62,10 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "listen_socket_interface",
-    hdrs = ["listen_socket.h"],
+    hdrs = [
+        "listen_socket.h",
+        "io_defs.h"
+    ],
     deps = [
         "//include/envoy/network:address_interface",
         "@envoy_api//envoy/api/v2/core:base_cc",
@@ -71,7 +74,10 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "transport_socket_interface",
-    hdrs = ["transport_socket.h"],
+    hdrs = [
+        "transport_socket.h",
+        "io_defs.h"
+    ],
     deps = [
         "//include/envoy/ssl:connection_interface",
     ],

--- a/include/envoy/network/io_defs.h
+++ b/include/envoy/network/io_defs.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "envoy/common/pure.h"
+
+namespace Envoy {
+namespace Network {
+
+/**
+ * Action that should occur on a connection after I/O.
+ */
+enum class PostIoAction {
+  // Close the connection.
+  Close,
+  // Keep the connection open.
+  KeepOpen
+};
+
+/**
+ * Result of each I/O event.
+ */
+struct IoResult {
+  PostIoAction action_;
+
+  /**
+   * Number of bytes processed by the I/O event.
+   */
+  uint64_t bytes_processed_;
+
+  /**
+   * True if an end-of-stream was read from a connection. This
+   * can only be true for read operations.
+   */
+  bool end_stream_read_;
+};
+
+/**
+ * Types of I/O handles
+ */
+enum class IoHandleType {
+  // Normal socket fd
+  SocketFd,
+
+  // Generic transport session
+  SessionId,
+
+  // Enable multiplexing over a connection
+  StreamId
+};
+
+class IoHandle {
+public:
+  IoHandle(int hdl = -1, IoHandleType type = IoHandleType::SocketFd)
+    : handle_(hdl), type_(type) {}
+    
+  int handle_;
+  IoHandleType type_;  // qualifier for handle_
+};
+
+} // namespace Network
+} // namespace Envoy

--- a/include/envoy/network/listen_socket.h
+++ b/include/envoy/network/listen_socket.h
@@ -6,6 +6,7 @@
 #include "envoy/api/v2/core/base.pb.h"
 #include "envoy/common/pure.h"
 #include "envoy/network/address.h"
+#include "envoy/network/io_defs.h"
 
 #include "absl/strings/string_view.h"
 
@@ -25,9 +26,14 @@ public:
   virtual const Address::InstanceConstSharedPtr& localAddress() const PURE;
 
   /**
-   * @return fd the socket's file descriptor.
+   * @return ioHandle, the connection's I/O handle
    */
-  virtual int fd() const PURE;
+  virtual int ioHandle() const PURE;
+
+  /**
+   * @return the socket's io handle type
+   */
+  virtual IoHandleType ioHandleType() const PURE;
 
   /**
    * Close the underlying socket.

--- a/include/envoy/network/transport_socket.h
+++ b/include/envoy/network/transport_socket.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "envoy/buffer/buffer.h"
-#include "envoy/common/pure.h"
+#include "envoy/network/io_defs.h"
 #include "envoy/ssl/connection.h"
 
 namespace Envoy {
@@ -11,34 +11,6 @@ class Connection;
 enum class ConnectionEvent;
 
 /**
- * Action that should occur on a connection after I/O.
- */
-enum class PostIoAction {
-  // Close the connection.
-  Close,
-  // Keep the connection open.
-  KeepOpen
-};
-
-/**
- * Result of each I/O event.
- */
-struct IoResult {
-  PostIoAction action_;
-
-  /**
-   * Number of bytes processed by the I/O event.
-   */
-  uint64_t bytes_processed_;
-
-  /**
-   * True if an end-of-stream was read from a connection. This
-   * can only be true for read operations.
-   */
-  bool end_stream_read_;
-};
-
-/**
  * Callbacks used by transport socket instances to communicate with connection.
  */
 class TransportSocketCallbacks {
@@ -46,9 +18,14 @@ public:
   virtual ~TransportSocketCallbacks() {}
 
   /**
-   * @return int the file descriptor associated with the connection.
+   * @return int the io handle associated with the connection.
    */
-  virtual int fd() const PURE;
+  virtual int ioHandle() const PURE;
+
+  /**
+   * @return int the io handle type associated with the connection.
+   */
+  virtual IoHandleType ioHandleType() const PURE;
 
   /**
    * @return Network::Connection& the connection interface.

--- a/source/common/network/addr_family_aware_socket_option_impl.cc
+++ b/source/common/network/addr_family_aware_socket_option_impl.cc
@@ -30,7 +30,7 @@ bool AddrFamilyAwareSocketOptionImpl::setIpSocketOption(
     if (socket.localAddress()) {
       ip = socket.localAddress()->ip();
     } else {
-      address = Address::addressFromFd(socket.fd());
+      address = Address::addressFromFd(socket.ioHandle());
       ip = address->ip();
     }
   } catch (const EnvoyException&) {

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -52,7 +52,7 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
       dispatcher_(dispatcher), id_(next_global_id_++) {
   // Treat the lack of a valid fd (which in practice only happens if we run out of FDs) as an OOM
   // condition and just crash.
-  RELEASE_ASSERT(fd() != -1, "");
+  RELEASE_ASSERT(ioHandle() != -1, "");
 
   if (!connected) {
     connecting_ = true;
@@ -61,14 +61,14 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
   // We never ask for both early close and read at the same time. If we are reading, we want to
   // consume all available data.
   file_event_ = dispatcher_.createFileEvent(
-      fd(), [this](uint32_t events) -> void { onFileEvent(events); }, Event::FileTriggerType::Edge,
+      ioHandle(), [this](uint32_t events) -> void { onFileEvent(events); }, Event::FileTriggerType::Edge,
       Event::FileReadyType::Read | Event::FileReadyType::Write);
 
   transport_socket_->setTransportSocketCallbacks(*this);
 }
 
 ConnectionImpl::~ConnectionImpl() {
-  ASSERT(fd() == -1, "ConnectionImpl was unexpectedly torn down without being closed.");
+  ASSERT(ioHandle() == -1, "ConnectionImpl was unexpectedly torn down without being closed.");
 
   // In general we assume that owning code has called close() previously to the destructor being
   // run. This generally must be done so that callbacks run in the correct context (vs. deferred
@@ -90,7 +90,7 @@ void ConnectionImpl::addReadFilter(ReadFilterSharedPtr filter) {
 bool ConnectionImpl::initializeReadFilters() { return filter_manager_.initializeReadFilters(); }
 
 void ConnectionImpl::close(ConnectionCloseType type) {
-  if (fd() == -1) {
+  if (ioHandle() == -1) {
     return;
   }
 
@@ -116,7 +116,7 @@ void ConnectionImpl::close(ConnectionCloseType type) {
 }
 
 Connection::State ConnectionImpl::state() const {
-  if (fd() == -1) {
+  if (ioHandle() == -1) {
     return State::Closed;
   } else if (close_with_flush_) {
     return State::Closing;
@@ -126,7 +126,7 @@ Connection::State ConnectionImpl::state() const {
 }
 
 void ConnectionImpl::closeSocket(ConnectionEvent close_type) {
-  if (fd() == -1) {
+  if (ioHandle() == -1) {
     return;
   }
 
@@ -154,14 +154,14 @@ void ConnectionImpl::noDelay(bool enable) {
   // invalid. For this call instead of plumbing through logic that will immediately indicate that a
   // connect failed, we will just ignore the noDelay() call if the socket is invalid since error is
   // going to be raised shortly anyway and it makes the calling code simpler.
-  if (fd() == -1) {
+  if (ioHandle() == -1) {
     return;
   }
 
   // Don't set NODELAY for unix domain sockets
   sockaddr addr;
   socklen_t len = sizeof(addr);
-  int rc = getsockname(fd(), &addr, &len);
+  int rc = getsockname(ioHandle(), &addr, &len);
   RELEASE_ASSERT(rc == 0, "");
 
   if (addr.sa_family == AF_UNIX) {
@@ -170,7 +170,7 @@ void ConnectionImpl::noDelay(bool enable) {
 
   // Set NODELAY
   int new_value = enable;
-  rc = setsockopt(fd(), IPPROTO_TCP, TCP_NODELAY, &new_value, sizeof(new_value));
+  rc = setsockopt(ioHandle(), IPPROTO_TCP, TCP_NODELAY, &new_value, sizeof(new_value));
 #ifdef __APPLE__
   if (-1 == rc && errno == EINVAL) {
     // Sometimes occurs when the connection is not yet fully formed. Empirically, TCP_NODELAY is
@@ -416,9 +416,9 @@ void ConnectionImpl::onFileEvent(uint32_t events) {
     onWriteReady();
   }
 
-  // It's possible for a write event callback to close the socket (which will cause fd_ to be -1).
+  // It's possible for a write event callback to close the socket (which will cause fd to be -1).
   // In this case ignore write event processing.
-  if (fd() != -1 && (events & Event::FileReadyType::Read)) {
+  if (ioHandle() != -1 && (events & Event::FileReadyType::Read)) {
     onReadReady();
   }
 }
@@ -459,7 +459,7 @@ void ConnectionImpl::onWriteReady() {
   if (connecting_) {
     int error;
     socklen_t error_size = sizeof(error);
-    int rc = getsockopt(fd(), SOL_SOCKET, SO_ERROR, &error, &error_size);
+    int rc = getsockopt(ioHandle(), SOL_SOCKET, SO_ERROR, &error, &error_size);
     ASSERT(0 == rc);
 
     if (error == 0) {
@@ -496,7 +496,7 @@ void ConnectionImpl::onWriteReady() {
       cb(result.bytes_processed_);
 
       // If a callback closes the socket, stop iterating.
-      if (fd() == -1) {
+      if (ioHandle() == -1) {
         return;
       }
     }
@@ -556,7 +556,7 @@ ClientConnectionImpl::ClientConnectionImpl(
     }
 
     if (source_address != nullptr) {
-      const Api::SysCallIntResult result = source_address->bind(fd());
+      const Api::SysCallIntResult result = source_address->bind(ioHandle());
       if (result.rc_ < 0) {
         ENVOY_LOG_MISC(debug, "Bind failure. Failed to bind to {}: {}", source_address->asString(),
                        strerror(result.errno_));
@@ -574,7 +574,7 @@ ClientConnectionImpl::ClientConnectionImpl(
 
 void ClientConnectionImpl::connect() {
   ENVOY_CONN_LOG(debug, "connecting to {}", *this, socket_->remoteAddress()->asString());
-  const Api::SysCallIntResult result = socket_->remoteAddress()->connect(fd());
+  const Api::SysCallIntResult result = socket_->remoteAddress()->connect(ioHandle());
   if (result.rc_ == 0) {
     // write will become ready.
     ASSERT(connecting_);
@@ -596,7 +596,7 @@ void ClientConnectionImpl::connect() {
   // The local address can only be retrieved for IP connections. Other
   // types, such as UDS, don't have a notion of a local address.
   if (socket_->remoteAddress()->type() == Address::Type::Ip) {
-    socket_->setLocalAddress(Address::addressFromFd(fd()), false);
+    socket_->setLocalAddress(Address::addressFromFd(ioHandle()), false);
   }
 }
 

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -8,6 +8,7 @@
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/network/connection.h"
+#include "envoy/network/io_defs.h"
 #include "envoy/network/transport_socket.h"
 
 #include "common/buffer/watermark_buffer.h"
@@ -97,7 +98,8 @@ public:
   }
 
   // Network::TransportSocketCallbacks
-  int fd() const override { return socket_->fd(); }
+  int ioHandle() const override { return socket_->ioHandle(); }
+  IoHandleType ioHandleType() const override { return socket_->ioHandleType(); }
   Connection& connection() override { return *this; }
   void raiseEvent(ConnectionEvent event) override;
   // Should the read buffer be drained?

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -16,7 +16,7 @@ namespace Envoy {
 namespace Network {
 
 void ListenSocketImpl::doBind() {
-  const Api::SysCallIntResult result = local_address_->bind(fd_);
+  const Api::SysCallIntResult result = local_address_->bind(ioHandle_.handle_);
   if (result.rc_ == -1) {
     close();
     throw EnvoyException(
@@ -25,7 +25,7 @@ void ListenSocketImpl::doBind() {
   if (local_address_->type() == Address::Type::Ip && local_address_->ip()->port() == 0) {
     // If the port we bind is zero, then the OS will pick a free port for us (assuming there are
     // any), and we need to find out the port number that the OS picked.
-    local_address_ = Address::addressFromFd(fd_);
+    local_address_ = Address::addressFromFd(ioHandle_.handle_);
   }
 }
 
@@ -40,11 +40,11 @@ TcpListenSocket::TcpListenSocket(const Address::InstanceConstSharedPtr& address,
                                  const Network::Socket::OptionsSharedPtr& options,
                                  bool bind_to_port)
     : ListenSocketImpl(address->socket(Address::SocketType::Stream), address) {
-  RELEASE_ASSERT(fd_ != -1, "");
+  RELEASE_ASSERT(ioHandle_.handle_ != -1, "");
 
   // TODO(htuch): This might benefit from moving to SocketOptionImpl.
   int on = 1;
-  int rc = setsockopt(fd_, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+  int rc = setsockopt(ioHandle_.handle_, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
   RELEASE_ASSERT(rc != -1, "");
 
   setListenSocketOptions(options);
@@ -62,7 +62,7 @@ TcpListenSocket::TcpListenSocket(int fd, const Address::InstanceConstSharedPtr& 
 
 UdsListenSocket::UdsListenSocket(const Address::InstanceConstSharedPtr& address)
     : ListenSocketImpl(address->socket(Address::SocketType::Stream), address) {
-  RELEASE_ASSERT(fd_ != -1, "");
+  RELEASE_ASSERT(ioHandle_.handle_ != -1, "");
   doBind();
 }
 

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -20,11 +20,12 @@ public:
 
   // Network::Socket
   const Address::InstanceConstSharedPtr& localAddress() const override { return local_address_; }
-  int fd() const override { return fd_; }
+  int ioHandle() const override { return ioHandle_.handle_; }
+  IoHandleType ioHandleType() const override { return ioHandle_.type_; }
   void close() override {
-    if (fd_ != -1) {
-      ::close(fd_);
-      fd_ = -1;
+    if (ioHandle() != -1) {
+      ::close(ioHandle());
+      ioHandle_.handle_ = -1;
     }
   }
   void ensureOptions() {
@@ -44,9 +45,9 @@ public:
 
 protected:
   SocketImpl(int fd, const Address::InstanceConstSharedPtr& local_address)
-      : fd_(fd), local_address_(local_address) {}
+      : ioHandle_(fd), local_address_(local_address) {}
 
-  int fd_;
+  IoHandle ioHandle_;
   Address::InstanceConstSharedPtr local_address_;
   OptionsSharedPtr options_;
 };

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -59,7 +59,7 @@ ListenerImpl::ListenerImpl(Event::DispatcherImpl& dispatcher, Socket& socket, Li
 
   if (bind_to_port) {
     listener_.reset(
-        evconnlistener_new(&dispatcher.base(), listenCallback, this, 0, -1, socket.fd()));
+        evconnlistener_new(&dispatcher.base(), listenCallback, this, 0, -1, socket.ioHandle()));
 
     if (!listener_) {
       throw CreateListenerException(

--- a/source/common/network/raw_buffer_socket.cc
+++ b/source/common/network/raw_buffer_socket.cc
@@ -17,7 +17,7 @@ IoResult RawBufferSocket::doRead(Buffer::Instance& buffer) {
   bool end_stream = false;
   do {
     // 16K read is arbitrary. TODO(mattklein123) PERF: Tune the read size.
-    Api::SysCallIntResult result = buffer.read(callbacks_->fd(), 16384);
+    Api::SysCallIntResult result = buffer.read(callbacks_->ioHandle(), 16384);
     ENVOY_CONN_LOG(trace, "read returns: {}", callbacks_->connection(), result.rc_);
 
     if (result.rc_ == 0) {
@@ -52,13 +52,13 @@ IoResult RawBufferSocket::doWrite(Buffer::Instance& buffer, bool end_stream) {
       if (end_stream && !shutdown_) {
         // Ignore the result. This can only fail if the connection failed. In that case, the
         // error will be detected on the next read, and dealt with appropriately.
-        ::shutdown(callbacks_->fd(), SHUT_WR);
+        ::shutdown(callbacks_->ioHandle(), SHUT_WR);
         shutdown_ = true;
       }
       action = PostIoAction::KeepOpen;
       break;
     }
-    Api::SysCallIntResult result = buffer.write(callbacks_->fd());
+    Api::SysCallIntResult result = buffer.write(callbacks_->ioHandle());
     ENVOY_CONN_LOG(trace, "write returns: {}", callbacks_->connection(), result.rc_);
 
     if (result.rc_ == -1) {

--- a/source/common/network/socket_option_impl.cc
+++ b/source/common/network/socket_option_impl.cc
@@ -33,7 +33,7 @@ Api::SysCallIntResult SocketOptionImpl::setSocketOption(Socket& socket,
     return {-1, ENOTSUP};
   }
   auto& os_syscalls = Api::OsSysCallsSingleton::get();
-  return os_syscalls.setsockopt(socket.fd(), optname.value().first, optname.value().second,
+  return os_syscalls.setsockopt(socket.ioHandle(), optname.value().first, optname.value().second,
                                 value.data(), value.size());
 }
 

--- a/source/common/ssl/ssl_socket.cc
+++ b/source/common/ssl/ssl_socket.cc
@@ -49,7 +49,7 @@ void SslSocket::setTransportSocketCallbacks(Network::TransportSocketCallbacks& c
   ASSERT(!callbacks_);
   callbacks_ = &callbacks;
 
-  BIO* bio = BIO_new_socket(callbacks_->fd(), 0);
+  BIO* bio = BIO_new_socket(callbacks_->ioHandle(), 0);
   SSL_set_bio(ssl_.get(), bio, bio);
 }
 

--- a/source/extensions/filters/listener/original_dst/original_dst.cc
+++ b/source/extensions/filters/listener/original_dst/original_dst.cc
@@ -20,7 +20,7 @@ Network::FilterStatus OriginalDstFilter::onAccept(Network::ListenerFilterCallbac
   const Network::Address::Instance& local_address = *socket.localAddress();
 
   if (local_address.type() == Network::Address::Type::Ip) {
-    Network::Address::InstanceConstSharedPtr original_local_address = getOriginalDst(socket.fd());
+    Network::Address::InstanceConstSharedPtr original_local_address = getOriginalDst(socket.ioHandle());
 
     // A listener that has the use_original_dst flag set to true can still receive
     // connections that are NOT redirected using iptables. If a connection was not redirected,

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
@@ -33,7 +33,7 @@ Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
   Network::ConnectionSocket& socket = cb.socket();
   ASSERT(file_event_.get() == nullptr);
   file_event_ =
-      cb.dispatcher().createFileEvent(socket.fd(),
+      cb.dispatcher().createFileEvent(socket.ioHandle(),
                                       [this](uint32_t events) {
                                         ASSERT(events == Event::FileReadyType::Read);
                                         onRead();
@@ -55,8 +55,8 @@ void Filter::onRead() {
 void Filter::onReadWorker() {
   Network::ConnectionSocket& socket = cb_->socket();
 
-  if ((!proxy_protocol_header_.has_value() && !readProxyHeader(socket.fd())) ||
-      (proxy_protocol_header_.has_value() && !parseExtensions(socket.fd()))) {
+  if ((!proxy_protocol_header_.has_value() && !readProxyHeader(socket.ioHandle())) ||
+      (proxy_protocol_header_.has_value() && !parseExtensions(socket.ioHandle()))) {
     // We return if a) we do not yet have the header, or b) we have the header but not yet all
     // the extension data. In both cases we'll be called again when the socket is ready to read
     // and pick up where we left off.

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -75,7 +75,7 @@ Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
   ASSERT(file_event_ == nullptr);
 
   file_event_ = cb.dispatcher().createFileEvent(
-      socket.fd(),
+      socket.ioHandle(),
       [this](uint32_t events) {
         if (events & Event::FileReadyType::Closed) {
           config_->stats().connection_closed_.inc();
@@ -145,7 +145,7 @@ void Filter::onRead() {
   // platforms.
   auto& os_syscalls = Api::OsSysCallsSingleton::get();
   const Api::SysCallSizeResult result =
-      os_syscalls.recv(cb_->socket().fd(), buf_, config_->maxClientHelloSize(), MSG_PEEK);
+      os_syscalls.recv(cb_->socket().ioHandle(), buf_, config_->maxClientHelloSize(), MSG_PEEK);
   ENVOY_LOG(trace, "tls inspector: recv: {}", result.rc_);
 
   if (result.rc_ == -1 && result.errno_ == EAGAIN) {

--- a/source/extensions/transport_sockets/alts/noop_transport_socket_callbacks.h
+++ b/source/extensions/transport_sockets/alts/noop_transport_socket_callbacks.h
@@ -16,7 +16,8 @@ public:
   explicit NoOpTransportSocketCallbacks(Network::TransportSocketCallbacks& parent)
       : parent_(parent) {}
 
-  int fd() const override { return parent_.fd(); }
+  int ioHandle() const override { return parent_.ioHandle(); }
+  Network::IoHandleType ioHandleType() const override { return parent_.ioHandleType(); }
   Network::Connection& connection() override { return parent_.connection(); }
   bool shouldDrainReadBuffer() override { return false; }
   /*

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -366,7 +366,7 @@ void HotRestartImpl::onGetListenSocket(RpcGetListenSocketRequest& rpc) {
       Network::Utility::resolveUrl(std::string(rpc.address_));
   for (const auto& listener : server_->listenerManager().listeners()) {
     if (*listener.get().socket().localAddress() == *addr) {
-      reply.fd_ = listener.get().socket().fd();
+      reply.fd_ = listener.get().socket().ioHandle();
       break;
     }
   }

--- a/test/common/network/addr_family_aware_socket_option_impl_test.cc
+++ b/test/common/network/addr_family_aware_socket_option_impl_test.cc
@@ -10,7 +10,7 @@ class AddrFamilyAwareSocketOptionImplTest : public SocketOptionTest {};
 
 // We fail to set the option when the underlying setsockopt syscall fails.
 TEST_F(AddrFamilyAwareSocketOptionImplTest, SetOptionFailure) {
-  EXPECT_CALL(socket_, fd()).WillOnce(Return(-1));
+  EXPECT_CALL(socket_, ioHandle()).WillOnce(Return(-1));
   AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
                                                 Network::SocketOptionName(std::make_pair(5, 10)),
                                                 {},
@@ -24,7 +24,7 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, SetOptionFailure) {
 TEST_F(AddrFamilyAwareSocketOptionImplTest, SetOptionSuccess) {
   Address::Ipv4Instance address("1.2.3.4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
-  EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
+  EXPECT_CALL(socket_, ioHandle()).WillRepeatedly(Return(fd));
 
   AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
                                                 Network::SocketOptionName(std::make_pair(5, 10)),
@@ -38,7 +38,7 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, SetOptionSuccess) {
 TEST_F(AddrFamilyAwareSocketOptionImplTest, V4EmptyOptionNames) {
   Address::Ipv4Instance address("1.2.3.4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
-  EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
+  EXPECT_CALL(socket_, ioHandle()).WillRepeatedly(Return(fd));
   AddrFamilyAwareSocketOptionImpl socket_option{
       envoy::api::v2::core::SocketOption::STATE_PREBIND, {}, {}, 1};
 
@@ -51,7 +51,7 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V4EmptyOptionNames) {
 TEST_F(AddrFamilyAwareSocketOptionImplTest, V6EmptyOptionNames) {
   Address::Ipv6Instance address("::1:2:3:4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
-  EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
+  EXPECT_CALL(socket_, ioHandle()).WillRepeatedly(Return(fd));
   AddrFamilyAwareSocketOptionImpl socket_option{
       envoy::api::v2::core::SocketOption::STATE_PREBIND, {}, {}, 1};
 
@@ -65,7 +65,7 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V6EmptyOptionNames) {
 TEST_F(AddrFamilyAwareSocketOptionImplTest, V4IgnoreV6) {
   Address::Ipv4Instance address("1.2.3.4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
-  EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
+  EXPECT_CALL(socket_, ioHandle()).WillRepeatedly(Return(fd));
 
   AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
                                                 Network::SocketOptionName(std::make_pair(5, 10)),
@@ -79,7 +79,7 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V4IgnoreV6) {
 TEST_F(AddrFamilyAwareSocketOptionImplTest, V6Only) {
   Address::Ipv6Instance address("::1:2:3:4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
-  EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
+  EXPECT_CALL(socket_, ioHandle()).WillRepeatedly(Return(fd));
 
   AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
                                                 {},
@@ -94,7 +94,7 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V6Only) {
 TEST_F(AddrFamilyAwareSocketOptionImplTest, V6OnlyV4Fallback) {
   Address::Ipv6Instance address("::1:2:3:4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
-  EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
+  EXPECT_CALL(socket_, ioHandle()).WillRepeatedly(Return(fd));
 
   AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
                                                 Network::SocketOptionName(std::make_pair(5, 10)),
@@ -109,7 +109,7 @@ TEST_F(AddrFamilyAwareSocketOptionImplTest, V6OnlyV4Fallback) {
 TEST_F(AddrFamilyAwareSocketOptionImplTest, V6Precedence) {
   Address::Ipv6Instance address("::1:2:3:4", 5678);
   const int fd = address.socket(Address::SocketType::Stream);
-  EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(fd));
+  EXPECT_CALL(socket_, ioHandle()).WillRepeatedly(Return(fd));
 
   AddrFamilyAwareSocketOptionImpl socket_option{envoy::api::v2::core::SocketOption::STATE_PREBIND,
                                                 Network::SocketOptionName(std::make_pair(5, 10)),

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -82,7 +82,7 @@ TEST_P(ConnectionImplDeathTest, BadFd) {
   EXPECT_DEATH_LOG_TO_STDERR(
       ConnectionImpl(dispatcher, std::make_unique<ConnectionSocketImpl>(-1, nullptr, nullptr),
                      Network::Test::createRawBufferSocket(), false),
-      ".*assert failure: fd\\(\\) != -1.*");
+      ".*assert failure: ioHandle\\(\\) != -1.*");
 }
 
 class ConnectionImplTest : public testing::TestWithParam<Address::IpVersion> {

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -50,7 +50,7 @@ TEST_P(ListenSocketImplTest, BindSpecificPort) {
       .WillOnce(Return(true));
   options->emplace_back(std::move(option));
   TcpListenSocket socket1(addr, options, true);
-  EXPECT_EQ(0, listen(socket1.fd(), 0));
+  EXPECT_EQ(0, listen(socket1.ioHandle(), 0));
   EXPECT_EQ(addr->ip()->port(), socket1.localAddress()->ip()->port());
   EXPECT_EQ(addr->ip()->addressAsString(), socket1.localAddress()->ip()->addressAsString());
 
@@ -63,7 +63,7 @@ TEST_P(ListenSocketImplTest, BindSpecificPort) {
   EXPECT_THROW(Network::TcpListenSocket socket2(addr, options2, true), EnvoyException);
 
   // Test the case of a socket with fd and given address and port.
-  TcpListenSocket socket3(dup(socket1.fd()), addr, nullptr);
+  TcpListenSocket socket3(dup(socket1.ioHandle()), addr, nullptr);
   EXPECT_EQ(addr->asString(), socket3.localAddress()->asString());
 }
 

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -35,7 +35,7 @@ public:
     filter_ = std::make_unique<Filter>(cfg_);
     EXPECT_CALL(cb_, socket()).WillRepeatedly(ReturnRef(socket_));
     EXPECT_CALL(cb_, dispatcher()).WillRepeatedly(ReturnRef(dispatcher_));
-    EXPECT_CALL(socket_, fd()).WillRepeatedly(Return(42));
+    EXPECT_CALL(socket_, ioHandle()).WillRepeatedly(Return(42));
 
     EXPECT_CALL(dispatcher_,
                 createFileEvent_(_, _, Event::FileTriggerType::Edge,

--- a/test/extensions/transport_sockets/alts/noop_transport_socket_callbacks_test.cc
+++ b/test/extensions/transport_sockets/alts/noop_transport_socket_callbacks_test.cc
@@ -15,7 +15,8 @@ public:
   explicit TestTransportSocketCallbacks(Network::Connection& connection)
       : connection_(connection) {}
 
-  int fd() const override { return 1; }
+  int ioHandle() const override { return 1; }
+  Network::IoHandleType ioHandleType() const override { return Network::IoHandleType::SocketFd; }
   Network::Connection& connection() override { return connection_; }
   bool shouldDrainReadBuffer() override { return false; }
   void setReadBufferReady() override { set_read_buffer_ready_ = true; }
@@ -32,6 +33,7 @@ private:
 
 class NoOpTransportSocketCallbacksTest : public testing::Test {
 protected:
+  ~NoOpTransportSocketCallbacksTest() {}
   NoOpTransportSocketCallbacksTest()
       : wrapper_callbacks_(connection_), wrapped_callbacks_(wrapper_callbacks_) {}
 
@@ -41,7 +43,7 @@ protected:
 };
 
 TEST_F(NoOpTransportSocketCallbacksTest, TestAllCallbacks) {
-  EXPECT_EQ(wrapper_callbacks_.fd(), wrapped_callbacks_.fd());
+  EXPECT_EQ(wrapper_callbacks_.ioHandle(), wrapped_callbacks_.ioHandle());
   EXPECT_EQ(&connection_, &wrapped_callbacks_.connection());
   EXPECT_FALSE(wrapped_callbacks_.shouldDrainReadBuffer());
 

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -180,7 +180,7 @@ MockFilterChainFactory::~MockFilterChainFactory() {}
 MockListenSocket::MockListenSocket() : local_address_(new Address::Ipv4Instance(80)) {
   ON_CALL(*this, localAddress()).WillByDefault(ReturnRef(local_address_));
   ON_CALL(*this, options()).WillByDefault(ReturnRef(options_));
-  ON_CALL(*this, fd()).WillByDefault(Return(-1));
+  ON_CALL(*this, ioHandle()).WillByDefault(Return(-1));
 }
 
 MockListenSocket::~MockListenSocket() {}
@@ -202,11 +202,6 @@ MockListener::~MockListener() { onDestroy(); }
 
 MockConnectionHandler::MockConnectionHandler() {}
 MockConnectionHandler::~MockConnectionHandler() {}
-
-MockIp::MockIp() {}
-MockIp::~MockIp() {}
-
-MockResolvedAddress::~MockResolvedAddress() {}
 
 MockTransportSocket::MockTransportSocket() {
   ON_CALL(*this, setTransportSocketCallbacks(_))

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -297,7 +297,8 @@ public:
   void addOptions(const Socket::OptionsSharedPtr& options) override { addOptions_(options); }
 
   MOCK_CONST_METHOD0(localAddress, const Address::InstanceConstSharedPtr&());
-  MOCK_CONST_METHOD0(fd, int());
+  MOCK_CONST_METHOD0(ioHandle, int());
+  MOCK_CONST_METHOD0(ioHandleType, IoHandleType());
   MOCK_METHOD0(close, void());
   MOCK_METHOD1(addOption_, void(const Socket::OptionConstSharedPtr& option));
   MOCK_METHOD1(addOptions_, void(const Socket::OptionsSharedPtr& options));
@@ -339,7 +340,8 @@ public:
   MOCK_METHOD1(addOption_, void(const Socket::OptionConstSharedPtr&));
   MOCK_METHOD1(addOptions_, void(const Socket::OptionsSharedPtr&));
   MOCK_CONST_METHOD0(options, const Network::ConnectionSocket::OptionsSharedPtr&());
-  MOCK_CONST_METHOD0(fd, int());
+  MOCK_CONST_METHOD0(ioHandle, int());
+  MOCK_CONST_METHOD0(ioHandleType, IoHandleType());
   MOCK_METHOD0(close, void());
 
   Address::InstanceConstSharedPtr local_address_;
@@ -390,9 +392,6 @@ public:
 
 class MockIp : public Address::Ip {
 public:
-  MockIp();
-  ~MockIp();
-
   MOCK_CONST_METHOD0(addressAsString, const std::string&());
   MOCK_CONST_METHOD0(isAnyAddress, bool());
   MOCK_CONST_METHOD0(isUnicastAddress, bool());
@@ -406,7 +405,6 @@ class MockResolvedAddress : public Address::Instance {
 public:
   MockResolvedAddress(const std::string& logical, const std::string& physical)
       : logical_(logical), physical_(physical) {}
-  ~MockResolvedAddress();
 
   bool operator==(const Address::Instance& other) const override {
     return asString() == other.asString();
@@ -456,7 +454,8 @@ public:
   MockTransportSocketCallbacks();
   ~MockTransportSocketCallbacks();
 
-  MOCK_CONST_METHOD0(fd, int());
+  MOCK_CONST_METHOD0(ioHandle, int());
+  MOCK_CONST_METHOD0(ioHandleType, IoHandleType());
   MOCK_METHOD0(connection, Connection&());
   MOCK_METHOD0(shouldDrainReadBuffer, bool());
   MOCK_METHOD0(setReadBufferReady, void());

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -2140,7 +2140,7 @@ class OriginalDstTestFilter : public Extensions::ListenerFilters::OriginalDst::O
 TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstTestFilter) {
   static int fd;
   fd = -1;
-  EXPECT_CALL(*listener_factory_.socket_, fd()).WillOnce(Return(0));
+  EXPECT_CALL(*listener_factory_.socket_, ioHandle()).WillOnce(Return(0));
 
   class OriginalDstTestConfigFactory : public Configuration::NamedListenerFilterConfigFactory {
   public:
@@ -2154,7 +2154,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstTestFilter) {
       EXPECT_CALL(*option, setOption(_, envoy::api::v2::core::SocketOption::STATE_BOUND))
           .WillOnce(Invoke(
               [](Network::Socket& socket, envoy::api::v2::core::SocketOption::SocketState) -> bool {
-                fd = socket.fd();
+                fd = socket.ioHandle();
                 return true;
               }));
       context.addListenSocketOption(std::move(option));
@@ -2277,7 +2277,7 @@ class OriginalDstTestFilterIPv6
 TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstTestFilterIPv6) {
   static int fd;
   fd = -1;
-  EXPECT_CALL(*listener_factory_.socket_, fd()).WillOnce(Return(0));
+  EXPECT_CALL(*listener_factory_.socket_, ioHandle()).WillOnce(Return(0));
 
   class OriginalDstTestConfigFactory : public Configuration::NamedListenerFilterConfigFactory {
   public:
@@ -2291,7 +2291,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstTestFilterIPv6) {
       EXPECT_CALL(*option, setOption(_, envoy::api::v2::core::SocketOption::STATE_BOUND))
           .WillOnce(Invoke(
               [](Network::Socket& socket, envoy::api::v2::core::SocketOption::SocketState) -> bool {
-                fd = socket.fd();
+                fd = socket.ioHandle();
                 return true;
               }));
       context.addListenSocketOption(std::move(option));


### PR DESCRIPTION

*Description*:

This PR addresses issue #4546- refactoring the fd to accommodate a generalized I/O handle.
  
In preparation for Envoy integration for VPP, the fd() method is generalized beyond the assumption that there is a socket interface between Envoy and its clients.
An IoHandle class is introduced, which holds a handle and a new IoHandleType, which qualifies the handle as one of: a socket fd, a new session id, or a stream id.

Two methods are introduced: ioHandle(), which returns the actual handle and ioHandleType(), which returns the type of the handle.
The calls to fd() in the code are replaced by calls to ioHandle()- there are no calls as yet to ioHandleType(), which is available for future use.

Finally,. a new file is introduced in envoy/include/envoy/network: io_defs.h. io_defs.h has the new definitions for IoHandle, as well as those for PostIoAction and IoResult, which were removed from transport_socket.h to io_defs.h.

*Risk Level*: Low

*Testing*: Integration testing

*Docs Changes*:N/A

*Release Notes*: N/A

Fixes #4546
