### PR TITLE
[WIP] bazel: Allow to link third party libraries dynamically

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -128,3 +128,8 @@ config_setting(
     name = "force_libcpp",
     values = {"define": "force_libcpp=enabled"},
 )
+
+config_setting(
+    name = "dynamic_linking",
+    values = {"define": "dynamic_linking=enabled"},
+)

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -94,6 +94,11 @@ By default Clang drops some debug symbols that are required for pretty printing 
 More information can be found [here](https://bugs.llvm.org/show_bug.cgi?id=24202). The easy solution
 is to set ```--copt=-fno-limit-debug-info``` on the CLI or in your bazel.rc file.
 
+## Dynamic linking of third-party libraties
+
+By default all third-party libraries are linked statically. But dynamic linking can be enabled by
+option ```--define dynamic_linking=enabled```.
+
 # Testing Envoy with Bazel
 
 All the Envoy tests can be built and run with:

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -7,11 +7,17 @@ config_setting(
     values = {"cpu": "x64_windows"},
 )
 
+config_setting(
+    name = "dynamic_linking",
+    values = {"define": "dynamic_linking=enabled"},
+)
+
 cc_library(
     name = "ares",
     srcs = select({
         ":windows_x86_64": ["thirdparty_build/lib/cares.lib"],
-        "//conditions:default": ["thirdparty_build/lib/libcares.a"],
+        ":dynamic_linking": glob(["thirdparty_build/lib*/libcares.so"]),
+        "//conditions:default": glob(["thirdparty_build/lib*/libcares.a"]),
     }),
     hdrs = glob(["thirdparty_build/include/ares*.h"]),
     includes = ["thirdparty_build/include"],
@@ -21,7 +27,8 @@ cc_library(
     name = "benchmark",
     srcs = select({
         ":windows_x86_64": ["thirdparty_build/lib/benchmark.lib"],
-        "//conditions:default": ["thirdparty_build/lib/libbenchmark.a"],
+        ":dynamic_linking": glob(["thirdparty_build/lib*/libbenchmark.so"]),
+        "//conditions:default": glob(["thirdparty_build/lib*/libbenchmark.a"]),
     }),
     hdrs = ["thirdparty_build/include/testing/base/public/benchmark.h"],
     includes = ["thirdparty_build/include"],
@@ -31,7 +38,8 @@ cc_library(
     name = "event",
     srcs = select({
         ":windows_x86_64": ["thirdparty_build/lib/event.lib"],
-        "//conditions:default": ["thirdparty_build/lib/libevent.a"],
+        ":dynamic_linking": glob(["thirdparty_build/lib*/libevent.so"]),
+        "//conditions:default": glob(["thirdparty_build/lib*/libevent.a"]),
     }),
     hdrs = glob(["thirdparty_build/include/event2/**/*.h"]),
     includes = ["thirdparty_build/include"],
@@ -41,7 +49,8 @@ cc_library(
     name = "luajit",
     srcs = select({
         ":windows_x86_64": ["thirdparty_build/lib/luajit.lib"],
-        "//conditions:default": ["thirdparty_build/lib/libluajit-5.1.a"],
+        ":dynamic_linking": glob(["thirdparty_build/lib*/libluajit-5.1.so"]),
+        "//conditions:default": glob(["thirdparty_build/lib*/libluajit-5.1.a"]),
     }),
     hdrs = glob(["thirdparty_build/include/luajit-2.0/*"]),
     includes = ["thirdparty_build/include"],
@@ -53,7 +62,8 @@ cc_library(
     name = "nghttp2",
     srcs = select({
         ":windows_x86_64": ["thirdparty_build/lib/nghttp2.lib"],
-        "//conditions:default": ["thirdparty_build/lib/libnghttp2.a"],
+        ":dynamic_linking": glob(["thirdparty_build/lib*/libnghttp2.so"]),
+        "//conditions:default": glob(["thirdparty_build/lib*/libnghttp2.a"]),
     }),
     hdrs = glob(["thirdparty_build/include/nghttp2/**/*.h"]),
     includes = ["thirdparty_build/include"],
@@ -61,7 +71,10 @@ cc_library(
 
 cc_library(
     name = "tcmalloc_and_profiler",
-    srcs = ["thirdparty_build/lib/libtcmalloc_and_profiler.a"],
+    srcs = select({
+        ":dynamic_linking": glob(["thirdparty_build/lib*/libtcmalloc_and_profiler.so"]),
+        "//conditions:default": glob(["thirdparty_build/lib*/libtcmalloc_and_profiler.a"]),
+     }),
     hdrs = glob(["thirdparty_build/include/gperftools/**/*.h"]),
     strip_include_prefix = "thirdparty_build/include",
 )
@@ -70,7 +83,8 @@ cc_library(
     name = "yaml_cpp",
     srcs = select({
         ":windows_x86_64": glob(["thirdparty_build/lib/libyaml-cpp*.lib"]),
-        "//conditions:default": ["thirdparty_build/lib/libyaml-cpp.a"],
+        ":dynamic_linking": glob(["thirdparty_build/lib*/libyaml-cpp.so"]),
+        "//conditions:default": glob(["thirdparty_build/lib*/libyaml-cpp.a"]),
     }),
     hdrs = glob(["thirdparty_build/include/yaml-cpp/**/*.h"]),
     includes = ["thirdparty_build/include"],
@@ -80,7 +94,8 @@ cc_library(
     name = "zlib",
     srcs = select({
         ":windows_x86_64": glob(["thirdparty_build/lib/zlibstaticd.lib"]),
-        "//conditions:default": ["thirdparty_build/lib/libz.a"],
+        ":dynamic_linking": glob(["thirdparty_build/lib*/libz.so"]),
+        "//conditions:default": glob(["thirdparty_build/lib*/libz.so"]),
     }),
     hdrs = [
         "thirdparty_build/include/zconf.h",

--- a/source/common/compressor/BUILD
+++ b/source/common/compressor/BUILD
@@ -18,4 +18,5 @@ envoy_cc_library(
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
     ],
+    linkopts = ["-lz"],
 )

--- a/source/common/decompressor/BUILD
+++ b/source/common/decompressor/BUILD
@@ -18,4 +18,5 @@ envoy_cc_library(
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
     ],
+    linkopts = ["-lz"],
 )

--- a/source/common/event/BUILD
+++ b/source/common/event/BUILD
@@ -82,6 +82,7 @@ envoy_cc_library(
         "//source/common/common:assert_lib",
         "//source/common/common:c_smart_ptr_lib",
     ],
+    linkopts = ["-pthread", "-levent_pthreads", "-levent"],
 )
 
 envoy_cc_library(
@@ -98,4 +99,5 @@ envoy_cc_library(
         "//source/common/common:thread_lib",
         "//source/server:guarddog_lib",
     ],
+    linkopts = ["-levent"],
 )

--- a/source/common/filesystem/BUILD
+++ b/source/common/filesystem/BUILD
@@ -54,4 +54,5 @@ envoy_cc_library(
         "//source/common/common:minimal_logger_lib",
         "//source/common/common:utility_lib",
     ],
+    linkopts = ["-levent"],
 )

--- a/source/common/http/http2/BUILD
+++ b/source/common/http/http2/BUILD
@@ -39,6 +39,7 @@ envoy_cc_library(
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",
     ],
+    linkopts = ["-lnghttp2"],
 )
 
 envoy_cc_library(

--- a/source/common/json/BUILD
+++ b/source/common/json/BUILD
@@ -29,6 +29,7 @@ envoy_cc_library(
         "//source/common/common:utility_lib",
         "//source/common/filesystem:filesystem_lib",
     ],
+    linkopts = ["-lyaml-cpp"],
 )
 
 envoy_cc_library(

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -77,6 +77,7 @@ envoy_cc_library(
         "//source/common/common:assert_lib",
         "//source/common/common:linked_object",
     ],
+    linkopts = ["-lcares"],
 )
 
 envoy_cc_library(

--- a/source/extensions/filters/common/lua/BUILD
+++ b/source/extensions/filters/common/lua/BUILD
@@ -21,6 +21,7 @@ envoy_cc_library(
         "//source/common/common:c_smart_ptr_lib",
         "//source/common/protobuf",
     ],
+    linkopts = ["-lluajit-5.1"],
 )
 
 envoy_cc_library(


### PR DESCRIPTION
*Description*:
Provide an option `--define dynamic_linking=enabled` which allows
to link third-party libraries dynamically.

An another change is using `glob` function to resolve library
paths. Some Linux distributions use /usr/lib64 directory instead
of /usr/lib (if system is 64-bit). To fix build on them, the
wildard expression like `thirdparty/lib*/name_of_library.a` needs
to be used.

*Risk Level*: Low
*Testing*: None, but some CI tests in future could be added
*Docs Changes*: Option described in bazel/README.md
*Release Notes*: n/a

Signed-off-by: Michal Rostecki <mrostecki@suse.de>
