### PR TITLE
Update StreamInfo related documentation

### DIFF
--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -211,7 +211,7 @@ The following command operators are supported:
     where NAMESPACE is the the filter namespace used when setting the metadata, KEY is an optional
     lookup up key in the namespace with the option of specifying nested keys separated by ':',
     and Z is an optional parameter denoting string truncation up to Z characters long. Dynamic Metadata
-    can be set by filters using the :repo:`RequestInfo <include/envoy/request_info/request_info.h>` API:
+    can be set by filters using the :repo:`StreamInfo <include/envoy/stream_info/stream_info.h>` API:
     *setDynamicMetadata*. The data will be logged as a JSON string. For example, for the following dynamic metadata:
 
     ``com.test.my_filter: {"test_key": "foo", "test_object": {"inner_key": "bar"}}``

--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -495,7 +495,7 @@ Supported variable names are:
     parameters **do not** need to be escaped by doubling them.
 
 %PER_REQUEST_STATE(reverse.dns.data.name)%
-    Populates the header with values set on the request info perRequestState() object. To be
+    Populates the header with values set on the stream info perRequestState() object. To be
     usable in custom request/response headers, these values must be of type
     Envoy::Router::StringAccessor. These values should be named in standard reverse DNS style,
     identifying the organization that created the value and ending in a unique name for the data. 

--- a/docs/root/configuration/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http_filters/lua_filter.rst
@@ -290,16 +290,16 @@ under the filter name i.e. *envoy.lua*. Below is an example of a *metadata* in a
 
 Returns a :ref:`metadata object <config_http_filters_lua_metadata_wrapper>`.
 
-requestInfo()
+streamInfo()
 ^^^^^^^^^^^^^
 
 .. code-block:: lua
 
-  requestInfo = handle:requestInfo()
+  streamInfo = handle:streamInfo()
 
-Returns :repo:`information <include/request_info/request_info.h>` related to the current request.
+Returns :repo:`information <include/stream_info/stream_info.h>` related to the current request.
 
-Returns a :ref:`request info object <config_http_filters_lua_request_info_wrapper>`.
+Returns a :ref:`stream info object <config_http_filters_lua_stream_info_wrapper>`.
 
 connection()
 ^^^^^^^^^^^^
@@ -426,9 +426,9 @@ __pairs()
 Iterates through every *metadata* entry. *key* is a string that supplies a *metadata*
 key. *value* is *metadata* entry value.
 
-.. _config_http_filters_lua_request_info_wrapper:
+.. _config_http_filters_lua_stream_info_wrapper:
 
-Request info object API
+Stream info object API
 -----------------------
 
 protocol()
@@ -436,7 +436,7 @@ protocol()
 
 .. code-block:: lua
 
-  requestInfo:protocol()
+  streamInfo:protocol()
 
 Returns the string representation of :repo:`HTTP protocol <include/envoy/http/protocol.h>`
 used by the current request. The possible values are: *HTTP/1.0*, *HTTP/1.1*, and *HTTP/2*.
@@ -446,11 +446,11 @@ dynamicMetadata()
 
 .. code-block:: lua
 
-  requestInfo:dynamicMetadata()
+  streamInfo:dynamicMetadata()
 
-Returns a :ref:`dynamic metadata object <config_http_filters_lua_request_info_dynamic_metadata_wrapper>`.
+Returns a :ref:`dynamic metadata object <config_http_filters_lua_stream_info_dynamic_metadata_wrapper>`.
 
-.. _config_http_filters_lua_request_info_dynamic_metadata_wrapper:
+.. _config_http_filters_lua_stream_info_dynamic_metadata_wrapper:
 
 Dynamic metadata object API
 ---------------------------

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -71,8 +71,8 @@ Version history
   :ref:`destination_port <envoy_api_field_listener.FilterChainMatch.destination_port>` and
   :ref:`prefix_ranges <envoy_api_field_listener.FilterChainMatch.prefix_ranges>`.
 * lua: added :ref:`connection() <config_http_filters_lua_connection_wrapper>` wrapper and *ssl()* API.
-* lua: added :ref:`requestInfo() <config_http_filters_lua_request_info_wrapper>` wrapper and *protocol()* API.
-* lua: added :ref:`requestInfo():dynamicMetadata() <config_http_filters_lua_request_info_dynamic_metadata_wrapper>` API.
+* lua: added :ref:`streamInfo() <config_http_filters_lua_stream_info_wrapper>` wrapper and *protocol()* API.
+* lua: added :ref:`streamInfo():dynamicMetadata() <config_http_filters_lua_stream_info_dynamic_metadata_wrapper>` API.
 * network: introduced :ref:`sni_cluster <config_network_filters_sni_cluster>` network filter that forwards connections to the
   upstream cluster specified by the SNI value presented by the client during a TLS handshake.
 * proxy_protocol: added support for HAProxy Proxy Protocol v2 (AF_INET/AF_INET6 only).

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -3,8 +3,8 @@ Version history
 
 1.9.0 (pending)
 ===============
-* Renamed the `RequestInfo` namespace to `StreamInfo` to better match its
-  behaviour within TCP and HTTP implementations.
+* stream: renamed the `RequestInfo` namespace to `StreamInfo` to better match
+  its behaviour within TCP and HTTP implementations.
 
 1.8.0 (Oct 4, 2018)
 ===================

--- a/source/common/access_log/access_log_formatter.h
+++ b/source/common/access_log/access_log_formatter.h
@@ -99,7 +99,7 @@ private:
 };
 
 /**
- * Formatter for string literal. It ignores headers and request info and returns string by which it
+ * Formatter for string literal. It ignores headers and stream info and returns string by which it
  * was initialized.
  */
 class PlainStringFormatter : public Formatter {

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -86,7 +86,7 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
   }
 
   router_.setDecoderFilterCallbacks(*this);
-  // TODO(mattklein123): Correctly set protocol in request info when we support access logging.
+  // TODO(mattklein123): Correctly set protocol in stream info when we support access logging.
 }
 
 void AsyncStreamImpl::encodeHeaders(HeaderMapPtr&& headers, bool end_stream) {

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -189,7 +189,7 @@ private:
   DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaMetadata);
 
   /**
-   * @return a handle to the request info.
+   * @return a handle to the stream info.
    */
   DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaStreamInfo);
 

--- a/source/extensions/filters/http/lua/wrappers.h
+++ b/source/extensions/filters/http/lua/wrappers.h
@@ -160,7 +160,7 @@ private:
     iterator_.reset();
   }
 
-  // To get reference to parent's (StreamInfoWrapper) request info member.
+  // To get reference to parent's (StreamInfoWrapper) stream info member.
   StreamInfo::StreamInfo& streamInfo();
 
   StreamInfoWrapper& parent_;
@@ -170,7 +170,7 @@ private:
 };
 
 /**
- * Lua wrapper for a request info.
+ * Lua wrapper for a stream info.
  */
 class StreamInfoWrapper : public Filters::Common::Lua::BaseLuaObject<StreamInfoWrapper> {
 public:
@@ -187,7 +187,7 @@ private:
   DECLARE_LUA_FUNCTION(StreamInfoWrapper, luaProtocol);
 
   /**
-   * Get reference to request info dynamic metadata object.
+   * Get reference to stream info dynamic metadata object.
    * @return DynamicMetadataMapWrapper representation of StreamInfo dynamic metadata.
    */
   DECLARE_LUA_FUNCTION(StreamInfoWrapper, luaDynamicMetadata);

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1517,7 +1517,7 @@ TEST_F(LuaHttpFilterTest, GetCurrentProtocol) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 }
 
-// Set and get request info dynamic metadata.
+// Set and get stream info dynamic metadata.
 TEST_F(LuaHttpFilterTest, SetGetDynamicMetadata) {
   const std::string SCRIPT{R"EOF(
     function envoy_on_request(request_handle)

--- a/test/extensions/filters/http/lua/wrappers_test.cc
+++ b/test/extensions/filters/http/lua/wrappers_test.cc
@@ -262,7 +262,7 @@ TEST_F(LuaStreamInfoWrapperTest, ReturnCurrentProtocol) {
   expectToPrintCurrentProtocol(Http::Protocol::Http2);
 }
 
-// Set, get and iterate request info dynamic metadata.
+// Set, get and iterate stream info dynamic metadata.
 TEST_F(LuaStreamInfoWrapperTest, SetGetAndIterateDynamicMetadata) {
   const std::string SCRIPT{R"EOF(
       function callMe(object)


### PR DESCRIPTION
*Description*:
This PR updates the documentation related to the recent rename of `RequestInfo` to `StreamInfo`. Missed these changes in #4503. Also, see #4500 for further info.

*Risk Level*: Low
*Testing*: N/A
*Docs Changes*: Multiple
*Release Notes*: N/A

/cc @mattklein123