### PR TITLE
stats: simplify metrics service implementation

### DIFF
--- a/source/extensions/stat_sinks/metrics_service/BUILD
+++ b/source/extensions/stat_sinks/metrics_service/BUILD
@@ -18,7 +18,6 @@ envoy_cc_library(
         "//include/envoy/grpc:async_client_interface",
         "//include/envoy/local_info:local_info_interface",
         "//include/envoy/singleton:instance_interface",
-        "//include/envoy/thread_local:thread_local_interface",
         "//include/envoy/upstream:cluster_manager_interface",
         "//source/common/common:assert_lib",
         "//source/common/grpc:async_client_lib",

--- a/source/extensions/stat_sinks/metrics_service/config.cc
+++ b/source/extensions/stat_sinks/metrics_service/config.cc
@@ -27,7 +27,7 @@ Stats::SinkPtr MetricsServiceSinkFactory::createStatsSink(const Protobuf::Messag
       std::make_shared<GrpcMetricsStreamerImpl>(
           server.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
               grpc_service, server.stats(), false),
-          server.threadLocal(), server.localInfo());
+          server.localInfo());
 
   return std::make_unique<MetricsServiceSink>(grpc_metrics_streamer, server.timeSystem());
 }

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h
@@ -10,7 +10,6 @@
 #include "envoy/stats/sink.h"
 #include "envoy/stats/source.h"
 #include "envoy/stats/stats.h"
-#include "envoy/thread_local/thread_local.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "common/buffer/buffer_impl.h"
@@ -20,13 +19,11 @@ namespace Extensions {
 namespace StatSinks {
 namespace MetricsService {
 
-// TODO: Move the common code to a base class so that Accesslog and Metrics Service can reuse.
-
 /**
- * Interface for metrics streamer. The streamer deals with threading and sends
- * metrics on the correct stream.
+ * Interface for metrics streamer.
  */
-class GrpcMetricsStreamer {
+class GrpcMetricsStreamer
+    : public Grpc::TypedAsyncStreamCallbacks<envoy::service::metrics::v2::StreamMetricsResponse> {
 public:
   virtual ~GrpcMetricsStreamer() {}
 
@@ -35,78 +32,41 @@ public:
    * @param message supplies the metrics to send.
    */
   virtual void send(envoy::service::metrics::v2::StreamMetricsMessage& message) PURE;
+
+  // Grpc::TypedAsyncStreamCallbacks
+  void onCreateInitialMetadata(Http::HeaderMap&) override {}
+  void onReceiveInitialMetadata(Http::HeaderMapPtr&&) override {}
+  void
+  onReceiveMessage(std::unique_ptr<envoy::service::metrics::v2::StreamMetricsResponse>&&) override {
+  }
+  void onReceiveTrailingMetadata(Http::HeaderMapPtr&&) override {}
+  void onRemoteClose(Grpc::Status::GrpcStatus, const std::string&) override{};
 };
 
 typedef std::shared_ptr<GrpcMetricsStreamer> GrpcMetricsStreamerSharedPtr;
 
 /**
- * Production implementation of GrpcAccessLogStreamer that supports per-thread
- * streams
+ * Production implementation of GrpcMetricsStreamer
  */
 class GrpcMetricsStreamerImpl : public Singleton::Instance, public GrpcMetricsStreamer {
 public:
-  GrpcMetricsStreamerImpl(Grpc::AsyncClientFactoryPtr&& factory, ThreadLocal::SlotAllocator& tls,
+  GrpcMetricsStreamerImpl(Grpc::AsyncClientFactoryPtr&& factory,
                           const LocalInfo::LocalInfo& local_info);
 
   // GrpcMetricsStreamer
-  void send(envoy::service::metrics::v2::StreamMetricsMessage& message) override {
-    tls_slot_->getTyped<ThreadLocalStreamer>().send(message);
-  }
+  void send(envoy::service::metrics::v2::StreamMetricsMessage& message) override;
+
+  // Grpc::TypedAsyncStreamCallbacks
+  void onRemoteClose(Grpc::Status::GrpcStatus, const std::string&) override { stream_ = nullptr; }
 
 private:
-  /**
-   * Shared state that is owned by the per-thread streamers. This allows the
-   * main streamer/TLS slot to be destroyed while the streamers hold onto the shared state.
-   */
-  struct SharedState {
-    SharedState(Grpc::AsyncClientFactoryPtr&& factory, const LocalInfo::LocalInfo& local_info)
-        : factory_(std::move(factory)), local_info_(local_info) {}
-
-    Grpc::AsyncClientFactoryPtr factory_;
-    const LocalInfo::LocalInfo& local_info_;
-  };
-
-  typedef std::shared_ptr<SharedState> SharedStateSharedPtr;
-
-  struct ThreadLocalStreamer;
-
-  /**
-   * Per-thread stream state.
-   */
-  struct ThreadLocalStream
-      : public Grpc::TypedAsyncStreamCallbacks<envoy::service::metrics::v2::StreamMetricsResponse> {
-    ThreadLocalStream(ThreadLocalStreamer& parent) : parent_(parent) {}
-
-    // Grpc::TypedAsyncStreamCallbacks
-    void onCreateInitialMetadata(Http::HeaderMap&) override {}
-    void onReceiveInitialMetadata(Http::HeaderMapPtr&&) override {}
-    void onReceiveMessage(
-        std::unique_ptr<envoy::service::metrics::v2::StreamMetricsResponse>&&) override {}
-    void onReceiveTrailingMetadata(Http::HeaderMapPtr&&) override {}
-    void onRemoteClose(Grpc::Status::GrpcStatus status, const std::string& message) override;
-
-    ThreadLocalStreamer& parent_;
-    Grpc::AsyncStream* stream_{};
-  };
-
-  typedef std::shared_ptr<ThreadLocalStream> ThreadLocalStreamSharedPtr;
-
-  /**
-   * Per-thread multi-stream state.
-   */
-  struct ThreadLocalStreamer : public ThreadLocal::ThreadLocalObject {
-    ThreadLocalStreamer(const SharedStateSharedPtr& shared_state);
-    void send(envoy::service::metrics::v2::StreamMetricsMessage& message);
-
-    Grpc::AsyncClientPtr client_;
-    ThreadLocalStreamSharedPtr thread_local_stream_ = nullptr;
-    SharedStateSharedPtr shared_state_;
-  };
-
-  ThreadLocal::SlotPtr tls_slot_;
+  Grpc::AsyncStream* stream_{};
+  Grpc::AsyncClientPtr client_;
+  const LocalInfo::LocalInfo& local_info_;
 };
+
 /**
- * Per thread implementation of a Metric Service flusher.
+ * Stat Sink implementation of Metrics Service.
  */
 class MetricsServiceSink : public Stats::Sink {
 public:

--- a/test/extensions/stats_sinks/metrics_service/grpc_metrics_service_impl_test.cc
+++ b/test/extensions/stats_sinks/metrics_service/grpc_metrics_service_impl_test.cc
@@ -30,7 +30,7 @@ public:
       return Grpc::AsyncClientPtr{async_client_};
     }));
     streamer_ = std::make_unique<GrpcMetricsStreamerImpl>(Grpc::AsyncClientFactoryPtr{factory_},
-                                                          tls_, local_info_);
+                                                          local_info_);
   }
 
   void expectStreamStart(MockMetricsStream& stream, MetricsServiceCallbacks** callbacks_to_set) {
@@ -42,7 +42,6 @@ public:
         }));
   }
 
-  NiceMock<ThreadLocal::MockInstance> tls_;
   LocalInfo::MockLocalInfo local_info_;
   Grpc::MockAsyncClient* async_client_{new Grpc::MockAsyncClient};
   Grpc::MockAsyncClientFactory* factory_{new Grpc::MockAsyncClientFactory};


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*: Metric Service currently creates a streamer per thread. This was done assuming that histograms may be flushed out by individual threads. Now since, all stats are flushed by the main thread, TLS complexity is not required. This PR simplifies Metric Service implementation.
*Risk Level*: Low
*Testing*: Existing Automated tests
*Docs Changes*: N/A
*Release Notes*: N/A
