### PR TITLE
docs: add memory proto docs

### DIFF
--- a/api/docs/BUILD
+++ b/api/docs/BUILD
@@ -14,6 +14,7 @@ proto_library(
     deps = [
         "//envoy/admin/v2alpha:clusters",
         "//envoy/admin/v2alpha:config_dump",
+        "//envoy/admin/v2alpha:memory",
         "//envoy/api/v2:cds",
         "//envoy/api/v2:discovery",
         "//envoy/api/v2:eds",

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -51,6 +51,7 @@ bazel build ${BAZEL_BUILD_OPTIONS} @envoy_api//docs:protos --aspects \
 PROTO_RST="
   /envoy/admin/v2alpha/clusters/envoy/admin/v2alpha/clusters.proto.rst
   /envoy/admin/v2alpha/config_dump/envoy/admin/v2alpha/config_dump.proto.rst
+  /envoy/admin/v2alpha/memory/envoy/admin/v2alpha/memory.proto.rst
   /envoy/admin/v2alpha/clusters/envoy/admin/v2alpha/metrics.proto.rst
   /envoy/api/v2/core/address/envoy/api/v2/core/address.proto.rst
   /envoy/api/v2/core/base/envoy/api/v2/core/base.proto.rst

--- a/docs/root/api-v2/admin/admin.rst
+++ b/docs/root/api-v2/admin/admin.rst
@@ -7,4 +7,5 @@ Admin
 
   ../admin/v2alpha/config_dump.proto
   ../admin/v2alpha/clusters.proto
+  ../admin/v2alpha/memory.proto
   ../admin/v2alpha/metrics.proto


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>

*Description*: While working on certs changes, I realized that memory proto doc links were missing. This PR adds them.
*Risk Level*: Low
*Testing*: Existing
*Docs Changes*: N/A
*Release Notes*: N/A

