### PR TITLE
build: remove build dependency of shasum

### DIFF
--- a/ci/build_container/build_container_common.sh
+++ b/ci/build_container/build_container_common.sh
@@ -5,7 +5,7 @@ SHA256=769b9757644a8ec9c4b07369fda4a3e6592639a1338a7a03225ceeedbc760b45
 
 # buildifier
 curl --location --output /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/"$VERSION"/buildifier \
-  && echo "$SHA256 " '/usr/local/bin/buildifier' | shasum -a 256 --check \
+  && echo "$SHA256" '/usr/local/bin/buildifier' | sha256sum --check \
   && chmod +x /usr/local/bin/buildifier
 
 # GCC for everything.

--- a/ci/build_container/build_recipes/cares.sh
+++ b/ci/build_container/build_recipes/cares.sh
@@ -12,7 +12,7 @@ CPPFLAGS="$(for f in $CXXFLAGS; do if [[ $f =~ -D.* ]]; then echo $f; fi; done |
 CFLAGS="$(for f in $CXXFLAGS; do if [[ ! $f =~ -D.* ]]; then echo $f; fi; done | tr '\n' ' ')"
 
 curl https://github.com/c-ares/c-ares/archive/"$VERSION".tar.gz -sLo c-ares-"$VERSION".tar.gz \
-  && echo "$SHA256 " c-ares-"$VERSION".tar.gz | shasum -a 256 --check
+  && echo "$SHA256" c-ares-"$VERSION".tar.gz | sha256sum --check
 tar xf c-ares-"$VERSION".tar.gz
 cd c-ares-"$VERSION"
 

--- a/ci/build_container/build_recipes/gperftools.sh
+++ b/ci/build_container/build_recipes/gperftools.sh
@@ -10,7 +10,7 @@ VERSION=2.7
 SHA256=1ee8c8699a0eff6b6a203e59b43330536b22bbcbe6448f54c7091e5efb0763c9
 
 curl https://github.com/gperftools/gperftools/releases/download/gperftools-"$VERSION"/gperftools-"$VERSION".tar.gz -sLo gperftools-"$VERSION".tar.gz \
-  && echo "$SHA256 " gperftools-"$VERSION".tar.gz | shasum -a 256 --check
+  && echo "$SHA256" gperftools-"$VERSION".tar.gz | sha256sum --check
 tar xf gperftools-"$VERSION".tar.gz
 cd gperftools-"$VERSION"
 

--- a/ci/build_container/build_recipes/libevent.sh
+++ b/ci/build_container/build_recipes/libevent.sh
@@ -6,7 +6,7 @@ VERSION=2.1.8-stable
 SHA256=316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d
 
 curl https://github.com/libevent/libevent/archive/release-"$VERSION".tar.gz -sLo libevent-release-"$VERSION".tar.gz \
-  && echo "$SHA256 " libevent-release-"$VERSION".tar.gz | shasum -a 256 --check
+  && echo "$SHA256" libevent-release-"$VERSION".tar.gz | sha256sum --check
 tar xf libevent-release-"$VERSION".tar.gz
 cd libevent-release-"$VERSION"
 

--- a/ci/build_container/build_recipes/luajit.sh
+++ b/ci/build_container/build_recipes/luajit.sh
@@ -6,7 +6,7 @@ VERSION=2.0.5
 SHA256=8bb29d84f06eb23c7ea4aa4794dbb248ede9fcb23b6989cbef81dc79352afc97
 
 curl https://github.com/LuaJIT/LuaJIT/archive/v"$VERSION".tar.gz -sLo LuaJIT-"$VERSION".tar.gz \
-  && echo "$SHA256 " LuaJIT-"$VERSION".tar.gz | shasum -a 256 --check
+  && echo "$SHA256" LuaJIT-"$VERSION".tar.gz | sha256sum --check
 tar xf LuaJIT-"$VERSION".tar.gz
 cd LuaJIT-"$VERSION"
 

--- a/ci/build_container/build_recipes/nghttp2.sh
+++ b/ci/build_container/build_recipes/nghttp2.sh
@@ -6,7 +6,7 @@ VERSION=1.33.0
 SHA256=42fff7f290100c02234ac3b0095852e4392e6bfd95ebed900ca8bd630850d88c
 
 curl https://github.com/nghttp2/nghttp2/releases/download/v"$VERSION"/nghttp2-"$VERSION".tar.gz -sLo nghttp2-"$VERSION".tar.gz \
-  && echo "$SHA256 " nghttp2-"$VERSION".tar.gz | shasum -a 256 --check
+  && echo "$SHA256" nghttp2-"$VERSION".tar.gz | sha256sum --check
 tar xf nghttp2-"$VERSION".tar.gz
 cd nghttp2-"$VERSION"
 

--- a/ci/build_container/build_recipes/yaml-cpp.sh
+++ b/ci/build_container/build_recipes/yaml-cpp.sh
@@ -7,7 +7,7 @@ COMMIT=0f9a586ca1dc29c2ecb8dd715a315b93e3f40f79 # 2018-06-30
 SHA256=53dcffd55f3433b379fcc694f45c54898711c0e29159a7bd02e82a3e0253bac3
 
 curl https://github.com/jbeder/yaml-cpp/archive/"$COMMIT".tar.gz -sLo yaml-cpp-"$COMMIT".tar.gz \
-  && echo "$SHA256 " yaml-cpp-"$COMMIT".tar.gz | shasum -a 256 --check
+  && echo "$SHA256" yaml-cpp-"$COMMIT".tar.gz | sha256sum --check
 tar xf yaml-cpp-"$COMMIT".tar.gz
 cd yaml-cpp-"$COMMIT"
 

--- a/ci/build_container/build_recipes/zlib.sh
+++ b/ci/build_container/build_recipes/zlib.sh
@@ -6,7 +6,7 @@ VERSION=1.2.11
 SHA256=629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff
 
 curl https://github.com/madler/zlib/archive/v"$VERSION".tar.gz -sLo zlib-"$VERSION".tar.gz \
-  && echo "$SHA256 " zlib-"$VERSION".tar.gz | shasum -a 256 --check
+  && echo "$SHA256" zlib-"$VERSION".tar.gz | sha256sum --check
 tar xf zlib-"$VERSION".tar.gz
 cd zlib-"$VERSION"
 

--- a/ci/build_container/recipe_wrapper.sh
+++ b/ci/build_container/recipe_wrapper.sh
@@ -3,6 +3,12 @@
 PS4='+ $(date "+%s.%N") '
 set -x
 
+if [[ `uname` == "Darwin" ]]; then
+  function sha256sum {
+    gsha256sum
+  }
+fi
+
 . $1
 
 echo DONE


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

*Description*:
#4594 introduced use of `shasum` for checksum but not available in some distros. Use better handling of mac sha256sum path.

*Risk Level*: Low
*Testing*: manual, ci
*Docs Changes*:
*Release Notes*:
Fixes #4608
