### PR TITLE
fault: remove support for integer percentages

### DIFF
--- a/api/envoy/config/filter/fault/v2/fault.proto
+++ b/api/envoy/config/filter/fault/v2/fault.proto
@@ -24,13 +24,7 @@ message FaultDelay {
   // supported.
   FaultDelayType type = 1 [(validate.rules).enum.defined_only = true];
 
-  // An integer between 0-100 indicating the percentage of operations/connection requests
-  // on which the delay will be injected.
-  //
-  // .. attention::
-  //
-  //   Use of integer `percent` value is deprecated. Use fractional `percentage` field instead.
-  uint32 percent = 2 [(validate.rules).uint32.lte = 100, deprecated = true];
+  reserved 2;
 
   oneof fault_delay_secifier {
     option (validate.required) = true;

--- a/api/envoy/config/filter/http/fault/v2/fault.proto
+++ b/api/envoy/config/filter/http/fault/v2/fault.proto
@@ -13,13 +13,7 @@ import "validate/validate.proto";
 // Fault Injection :ref:`configuration overview <config_http_filters_fault_injection>`.
 
 message FaultAbort {
-  // An integer between 0-100 indicating the percentage of requests/operations/connections
-  // that will be aborted with the error code provided.
-  //
-  // .. attention::
-  //
-  //   Use of integer `percent` value is deprecated. Use fractional `percentage` field instead.
-  uint32 percent = 1 [(validate.rules).uint32.lte = 100, deprecated = true];
+  reserved 1;
 
   oneof error_type {
     option (validate.required) = true;
@@ -50,12 +44,12 @@ message HTTPFault {
   // Specifies a set of headers that the filter should match on. The fault
   // injection filter can be applied selectively to requests that match a set of
   // headers specified in the fault filter config. The chances of actual fault
-  // injection further depend on the value of the :ref:`percent
-  // <envoy_api_field_config.filter.http.fault.v2.FaultAbort.percent>` field. The filter will
-  // check the request's headers against all the specified headers in the filter
-  // config. A match will happen if all the headers in the config are present in
-  // the request with the same values (or based on presence if the *value* field
-  // is not in the config).
+  // injection further depend on the value of the :ref:`percentage
+  // <envoy_api_field_config.filter.http.fault.v2.FaultAbort.percentage>` field.
+  // The filter will check the request's headers against all the specified
+  // headers in the filter config. A match will happen if all the headers in the
+  // config are present in the request with the same values (or based on
+  // presence if the *value* field is not in the config).
   repeated envoy.api.v2.route.HeaderMatcher headers = 4;
 
   // Faults are injected for the specified list of downstream hosts. If this

--- a/docs/root/configuration/network_filters/mongo_proxy_filter.rst
+++ b/docs/root/configuration/network_filters/mongo_proxy_filter.rst
@@ -147,7 +147,7 @@ mongo.mongo.drain_close_enabled
   % of connections that will be drain closed if the server is draining and would otherwise
   attempt a drain close. Defaults to 100.
 
-mongo.fault.fixed_delay.percentage
+mongo.fault.fixed_delay.percent
   Probability of an eligible MongoDB operation to be affected by
   the injected fault when there is no active fault.
   Defaults to the *percentage* specified in the config.

--- a/docs/root/configuration/network_filters/mongo_proxy_filter.rst
+++ b/docs/root/configuration/network_filters/mongo_proxy_filter.rst
@@ -147,10 +147,10 @@ mongo.mongo.drain_close_enabled
   % of connections that will be drain closed if the server is draining and would otherwise
   attempt a drain close. Defaults to 100.
 
-mongo.fault.fixed_delay.percent
+mongo.fault.fixed_delay.percentage
   Probability of an eligible MongoDB operation to be affected by
   the injected fault when there is no active fault.
-  Defaults to the *percent* specified in the config.
+  Defaults to the *percentage* specified in the config.
 
 mongo.fault.fixed_delay.duration_ms
   The delay duration in milliseconds. Defaults to the *duration_ms* specified in the config.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -3,6 +3,7 @@ Version history
 
 1.9.0 (pending)
 ===============
+* fault: removed integer percentage support.
 * stream: renamed the `RequestInfo` namespace to `StreamInfo` to better match
   its behaviour within TCP and HTTP implementations.
 

--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -253,9 +253,11 @@ void FilterJson::translateMongoProxy(
   if (json_config.hasObject("fault")) {
     const auto json_fault = json_config.getObject("fault")->getObject("fixed_delay");
     auto* delay = proto_config.mutable_delay();
+    auto* percentage = delay->mutable_percentage();
 
     delay->set_type(envoy::config::filter::fault::v2::FaultDelay::FIXED);
-    delay->set_percent(static_cast<uint32_t>(json_fault->getInteger("percent")));
+    percentage->set_numerator(static_cast<uint32_t>(json_fault->getInteger("percent")));
+    percentage->set_denominator(envoy::type::FractionalPercent::HUNDRED);
     JSON_UTIL_SET_DURATION_FROM_FIELD(*json_fault, *delay, fixed_delay, duration);
   }
 }
@@ -270,7 +272,10 @@ void FilterJson::translateFaultFilter(
 
   if (!json_config_abort->empty()) {
     auto* abort_fault = proto_config.mutable_abort();
-    abort_fault->set_percent(static_cast<uint32_t>(json_config_abort->getInteger("abort_percent")));
+    auto* percentage = abort_fault->mutable_percentage();
+    percentage->set_numerator(
+        static_cast<uint32_t>(json_config_abort->getInteger("abort_percent")));
+    percentage->set_denominator(envoy::type::FractionalPercent::HUNDRED);
 
     // TODO(mattklein123): Throw error if invalid return code is provided
     abort_fault->set_http_status(
@@ -279,8 +284,11 @@ void FilterJson::translateFaultFilter(
 
   if (!json_config_delay->empty()) {
     auto* delay = proto_config.mutable_delay();
+    auto* percentage = delay->mutable_percentage();
     delay->set_type(envoy::config::filter::fault::v2::FaultDelay::FIXED);
-    delay->set_percent(static_cast<uint32_t>(json_config_delay->getInteger("fixed_delay_percent")));
+    percentage->set_numerator(
+        static_cast<uint32_t>(json_config_delay->getInteger("fixed_delay_percent")));
+    percentage->set_denominator(envoy::type::FractionalPercent::HUNDRED);
     JSON_UTIL_SET_DURATION_FROM_FIELD(*json_config_delay, *delay, fixed_delay, fixed_duration);
   }
 

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -48,16 +48,6 @@
   ((message).has_##field_name() ? DurationUtil::durationToSeconds((message).field_name())          \
                                 : throw MissingFieldException(#field_name, (message)))
 
-// Set the value of a FractionalPercent field with the value from a protobuf message if present.
-// Otherwise, convert the default field value into FractionalPercent and set it.
-#define PROTOBUF_SET_FRACTIONAL_PERCENT_OR_DEFAULT(field, message, field_name, default_field_name) \
-  if ((message).has_##field_name()) {                                                              \
-    field = (message).field_name();                                                                \
-  } else {                                                                                         \
-    field.set_numerator((message).default_field_name());                                           \
-    field.set_denominator(envoy::type::FractionalPercent::HUNDRED);                                \
-  }
-
 namespace Envoy {
 namespace ProtobufPercentHelper {
 

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -34,15 +34,14 @@ const std::string FaultFilter::ABORT_HTTP_STATUS_KEY = "fault.http.abort.http_st
 FaultSettings::FaultSettings(const envoy::config::filter::http::fault::v2::HTTPFault& fault) {
 
   if (fault.has_abort()) {
-    PROTOBUF_SET_FRACTIONAL_PERCENT_OR_DEFAULT(abort_percentage_, fault.abort(), percentage,
-                                               percent);
-    http_status_ = fault.abort().http_status();
+    const auto& abort = fault.abort();
+    abort_percentage_ = abort.percentage();
+    http_status_ = abort.http_status();
   }
 
   if (fault.has_delay()) {
-    PROTOBUF_SET_FRACTIONAL_PERCENT_OR_DEFAULT(fixed_delay_percentage_, fault.delay(), percentage,
-                                               percent);
     const auto& delay = fault.delay();
+    fixed_delay_percentage_ = delay.percentage();
     fixed_duration_ms_ = PROTOBUF_GET_MS_OR_DEFAULT(delay, fixed_delay, 0);
   }
 

--- a/source/extensions/filters/network/mongo_proxy/proxy.h
+++ b/source/extensions/filters/network/mongo_proxy/proxy.h
@@ -104,10 +104,8 @@ typedef std::shared_ptr<AccessLog> AccessLogSharedPtr;
 class FaultConfig {
 public:
   FaultConfig(const envoy::config::filter::fault::v2::FaultDelay& fault_config)
-      : duration_ms_(PROTOBUF_GET_MS_REQUIRED(fault_config, fixed_delay)) {
-    PROTOBUF_SET_FRACTIONAL_PERCENT_OR_DEFAULT(delay_percentage_, fault_config, percentage,
-                                               percent);
-  }
+      : delay_percentage_(fault_config.percentage()),
+        duration_ms_(PROTOBUF_GET_MS_REQUIRED(fault_config, fixed_delay)) {}
   envoy::type::FractionalPercent delayPercentage() const { return delay_percentage_; }
   uint64_t delayDuration() const { return duration_ms_; }
 

--- a/test/extensions/filters/http/fault/config_test.cc
+++ b/test/extensions/filters/http/fault/config_test.cc
@@ -45,7 +45,9 @@ TEST(FaultFilterConfigTest, FaultFilterCorrectJson) {
 
 TEST(FaultFilterConfigTest, FaultFilterCorrectProto) {
   envoy::config::filter::http::fault::v2::HTTPFault config{};
-  config.mutable_delay()->set_percent(100);
+  config.mutable_delay()->mutable_percentage()->set_numerator(100);
+  config.mutable_delay()->mutable_percentage()->set_denominator(
+      envoy::type::FractionalPercent::HUNDRED);
   config.mutable_delay()->mutable_fixed_delay()->set_seconds(5);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -258,8 +258,7 @@ TEST(FaultFilterBadConfigTest, MissingDelayDuration) {
 
 TEST_F(FaultFilterTest, AbortWithHttpStatus) {
   envoy::config::filter::http::fault::v2::HTTPFault fault;
-  fault.mutable_abort()->set_percent(50);
-  fault.mutable_abort()->mutable_percentage()->set_numerator(100); // should override int percent
+  fault.mutable_abort()->mutable_percentage()->set_numerator(100);
   fault.mutable_abort()->mutable_percentage()->set_denominator(
       envoy::type::FractionalPercent::HUNDRED);
   fault.mutable_abort()->set_http_status(429);
@@ -332,8 +331,7 @@ TEST_F(FaultFilterTest, FixedDelayZeroDuration) {
 TEST_F(FaultFilterTest, FixedDelayDeprecatedPercentAndNonZeroDuration) {
   envoy::config::filter::http::fault::v2::HTTPFault fault;
   fault.mutable_delay()->set_type(envoy::config::filter::fault::v2::FaultDelay::FIXED);
-  fault.mutable_delay()->set_percent(100);
-  fault.mutable_delay()->mutable_percentage()->set_numerator(50); // should override int percent
+  fault.mutable_delay()->mutable_percentage()->set_numerator(50);
   fault.mutable_delay()->mutable_percentage()->set_denominator(
       envoy::type::FractionalPercent::HUNDRED);
   fault.mutable_delay()->mutable_fixed_delay()->set_seconds(5);

--- a/test/extensions/filters/network/mongo_proxy/config_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/config_test.cc
@@ -255,7 +255,9 @@ TEST(MongoFilterConfigTest, CorrectFaultConfiguration) {
 TEST(MongoFilterConfigTest, CorrectFaultConfigurationInProto) {
   envoy::config::filter::network::mongo_proxy::v2::MongoProxy config{};
   config.set_stat_prefix("my_stat_prefix");
-  config.mutable_delay()->set_percent(50);
+  config.mutable_delay()->mutable_percentage()->set_numerator(50);
+  config.mutable_delay()->mutable_percentage()->set_denominator(
+      envoy::type::FractionalPercent::HUNDRED);
   config.mutable_delay()->mutable_fixed_delay()->set_seconds(500);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;

--- a/test/extensions/filters/network/mongo_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/proxy_test.cc
@@ -86,7 +86,6 @@ public:
 
   void setupDelayFault(bool enable_fault) {
     envoy::config::filter::fault::v2::FaultDelay fault{};
-    fault.set_percent(100);
     fault.mutable_percentage()->set_numerator(50);
     fault.mutable_percentage()->set_denominator(envoy::type::FractionalPercent::HUNDRED);
     fault.mutable_fixed_delay()->CopyFrom(Protobuf::util::TimeUtil::MillisecondsToDuration(10));


### PR DESCRIPTION
*Description*: This PR removes support for the previously deprecated integer percentages in the fault subsystem.
*Risk Level*: Low
*Testing*: Existing tests suffice
*Docs Changes*: Added feature removal notice to `version_history.rst`
*Release Notes*: NA
Fixes #4620

Signed-off-by: Venil Noronha <veniln@vmware.com>