### PR TITLE
route match: Fix runtime update bug and remove deprecated runtime flag

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -291,33 +291,18 @@ message RouteMatch {
   // is true.
   google.protobuf.BoolValue case_sensitive = 4;
 
-  oneof runtime_specifier {
-    // Indicates that the route should additionally match on a runtime key. An integer between
-    // 0-100. Every time the route is considered for a match, a random number between 0-99 is
-    // selected. If the number is <= the value found in the key (checked first) or, if the key is
-    // not present, the default value, the route is a match (assuming everything also about the
-    // route matches). A runtime route configuration can be used to roll out route changes in a
-    // gradual manner without full code/config deploys. Refer to the :ref:`traffic shifting
-    // <config_http_conn_man_route_table_traffic_splitting_shift>` docs for additional
-    // documentation.
-    //
-    // .. attention::
-    //
-    //   **This field is deprecated**. Set the
-    //   :ref:`runtime_fraction<envoy_api_field_route.RouteMatch.runtime_fraction>` field instead.
-    core.RuntimeUInt32 runtime = 5 [deprecated = true];
+  // value deprecated by :ref:`runtime_fraction<envoy_api_field_route.RouteMatch.runtime_fraction>`
+  reserved 5; 
 
-    // Indicates that the route should additionally match on a runtime key. Every time the route
-    // is considered for a match, it must also fall under the percentage of matches indicated by
-    // this field. For some fraction N/D, a random number in the range [0,D) is selected. If the
-    // number is <= the value of the numberator N, or if the key is not present, the default
-    // value, the router continues to evaluate the remaining match criteria. A runtime_fraction
-    // route configuration can be used to roll out route changes in a gradual manner (with more
-    // granularity than the deprecated runtime field) without full code/config deploys. Refer to
-    // the :ref:`traffic shifting <config_http_conn_man_route_table_traffic_splitting_shift>` docs
-    // for additional documentation.
-    core.RuntimeFractionalPercent runtime_fraction = 9;
-  }
+  // Indicates that the route should additionally match on a runtime key. Every time the route
+  // is considered for a match, it must also fall under the percentage of matches indicated by
+  // this field. For some fraction N/D, a random number in the range [0,D) is selected. If the
+  // number is <= the value of the numberator N, or if the key is not present, the default
+  // value, the router continues to evaluate the remaining match criteria. A runtime_fraction
+  // route configuration can be used to roll out route changes in a gradual manner. Refer to the
+  // :ref:`traffic shifting <config_http_conn_man_route_table_traffic_splitting_shift>` docs for
+  // additional documentation.
+  core.RuntimeFractionalPercent runtime_fraction = 9;
 
   // Specifies a set of headers that the route should match on. The router will
   // check the request’s headers against all the specified headers in the route

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -292,7 +292,7 @@ message RouteMatch {
   google.protobuf.BoolValue case_sensitive = 4;
 
   // value deprecated by :ref:`runtime_fraction<envoy_api_field_route.RouteMatch.runtime_fraction>`
-  reserved 5; 
+  reserved 5;
 
   // Indicates that the route should additionally match on a runtime key. Every time the route
   // is considered for a match, it must also fall under the percentage of matches indicated by

--- a/configs/envoy_router_v2.template.yaml
+++ b/configs/envoy_router_v2.template.yaml
@@ -7,8 +7,10 @@ virtual_hosts:
   routes:
   - match:
       prefix: "/foo/bar"
-      runtime:
-        default_value: 0
+      runtime_fraction:
+        default_value:
+          numerator: 0
+          denominator: MILLION
         runtime_key: routing.www.use_service_2
     route:
       {{ helper.make_route('service2')|indent(4) }}

--- a/docs/root/api-v1/route_config/route.rst
+++ b/docs/root/api-v1/route_config/route.rst
@@ -236,7 +236,7 @@ include_vh_rate_limits
 Runtime
 -------
 
-A :ref:`runtime <arch_overview_runtime>` route configuration can be used to roll out route changes
+A :ref:`runtime_fraction <arch_overview_runtime>` route configuration can be used to roll out route changes
 in a gradual manner without full code/config deploys. Refer to the
 :ref:`traffic shifting <config_http_conn_man_route_table_traffic_splitting_shift>` docs
 for additional documentation.
@@ -244,8 +244,11 @@ for additional documentation.
 .. code-block:: json
 
   {
-    "key": "...",
-    "default": "..."
+    "runtime_key": "...",
+    "default_value": {
+      "numerator": "...",
+      "denominator": "..."
+    }
   }
 
 key

--- a/docs/root/configuration/http_conn_man/traffic_splitting.rst
+++ b/docs/root/configuration/http_conn_man/traffic_splitting.rst
@@ -31,7 +31,7 @@ section describes this scenario in more detail.
 Traffic shifting between two upstreams
 --------------------------------------
 
-The :ref:`runtime <envoy_api_field_route.RouteMatch.runtime>` object
+The :ref:`runtime_fraction <envoy_api_field_route.RouteMatch.runtime_fraction>` object
 in the route configuration determines the probability of selecting a
 particular route (and hence its cluster). By using the runtime
 configuration, traffic to a particular route in a virtual host can be
@@ -52,9 +52,12 @@ envoy configuration file.
               {
                 "prefix": "/",
                 "cluster": "helloworld_v1",
-                "runtime": {
-                  "key": "routing.traffic_shift.helloworld",
-                  "default": 50
+                "runtime_fraction": {
+                  "runtime_key": "routing.traffic_shift.helloworld",
+                  "default_value": {
+                    "numerator": 50,
+                    "denominator": HUNDRED
+                  },
                 }
               },
               {
@@ -68,13 +71,11 @@ envoy configuration file.
     }
 
 Envoy matches routes with a :ref:`first match <config_http_conn_man_route_table_route_matching>` policy.
-If the route has a runtime object, the request will be additionally matched based on the runtime
-:ref:`value <envoy_api_field_route.RouteMatch.runtime>`
-(or the default, if no value is specified). Thus, by placing routes
-back-to-back in the above example and specifying a runtime object in the
-first route, traffic shifting can be accomplished by changing the runtime
-value. The following are the approximate sequence of actions required to
-accomplish the task.
+If the route has a runtime object, the request will be additionally matched based on the
+:ref:`runtime value <envoy_api_field_route.RouteMatch.runtime_fraction>` (or the default, if no
+value is specified). Thus, by placing routes back-to-back in the above example and specifying a
+runtime object in the first route, traffic shifting can be accomplished by changing the runtime
+value. The following are the approximate sequence of actions required to accomplish the task.
 
 1. In the beginning, set ``routing.traffic_shift.helloworld`` to ``100``,
    so that all requests to the ``helloworld`` virtual host would match with

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -3,6 +3,7 @@ Version history
 
 1.9.0 (pending)
 ===============
+* router: Fixed bug related to runtime variable updates.
 
 1.8.0 (Oct 4, 2018)
 ===================

--- a/source/common/config/base_json.cc
+++ b/source/common/config/base_json.cc
@@ -4,9 +4,10 @@ namespace Envoy {
 namespace Config {
 
 void BaseJson::translateRuntimeUInt32(const Json::Object& json_runtime,
-                                      envoy::api::v2::core::RuntimeUInt32& runtime) {
-  runtime.set_default_value(json_runtime.getInteger("default"));
-  runtime.set_runtime_key(json_runtime.getString("key"));
+                                      envoy::api::v2::core::RuntimeFractionalPercent& runtime_fraction) {
+  runtime_fraction.set_runtime_key(json_runtime.getString("key"));
+  runtime_fraction.mutable_default_value()->set_denominator(envoy::type::FractionalPercent::HUNDRED);
+  runtime_fraction.mutable_default_value()->set_numerator(json_runtime.getInteger("default"));
 }
 
 void BaseJson::translateHeaderValueOption(

--- a/source/common/config/base_json.cc
+++ b/source/common/config/base_json.cc
@@ -3,10 +3,12 @@
 namespace Envoy {
 namespace Config {
 
-void BaseJson::translateRuntimeUInt32(const Json::Object& json_runtime,
-                                      envoy::api::v2::core::RuntimeFractionalPercent& runtime_fraction) {
+void BaseJson::translateRuntimeUInt32(
+    const Json::Object& json_runtime,
+    envoy::api::v2::core::RuntimeFractionalPercent& runtime_fraction) {
   runtime_fraction.set_runtime_key(json_runtime.getString("key"));
-  runtime_fraction.mutable_default_value()->set_denominator(envoy::type::FractionalPercent::HUNDRED);
+  runtime_fraction.mutable_default_value()->set_denominator(
+      envoy::type::FractionalPercent::HUNDRED);
   runtime_fraction.mutable_default_value()->set_numerator(json_runtime.getInteger("default"));
 }
 

--- a/source/common/config/base_json.h
+++ b/source/common/config/base_json.h
@@ -9,12 +9,12 @@ namespace Config {
 class BaseJson {
 public:
   /**
-   * Translate a v1 JSON integer runtime object to v2 envoy::api::v2::core::RuntimeUInt32.
+   * Translate a v1 JSON integer runtime object to v2 envoy::api::v2::core::RuntimeFractionalPercent.
    * @param json_runtime source v1 JSON integer runtime object.
-   * @param runtime destination v2 envoy::api::v2::core::RuntimeUInt32.
+   * @param runtime destination v2 envoy::api::v2::core::RuntimeFractionalPercent.
    */
   static void translateRuntimeUInt32(const Json::Object& json_runtime,
-                                     envoy::api::v2::core::RuntimeUInt32& runtime);
+                                     envoy::api::v2::core::RuntimeFractionalPercent& runtime_fraction);
 
   /**
    * Translate a v1 JSON header-value object to v2 envoy::api::v2::core::HeaderValueOption.

--- a/source/common/config/base_json.h
+++ b/source/common/config/base_json.h
@@ -9,12 +9,14 @@ namespace Config {
 class BaseJson {
 public:
   /**
-   * Translate a v1 JSON integer runtime object to v2 envoy::api::v2::core::RuntimeFractionalPercent.
+   * Translate a v1 JSON integer runtime object to v2
+   * envoy::api::v2::core::RuntimeFractionalPercent.
    * @param json_runtime source v1 JSON integer runtime object.
    * @param runtime destination v2 envoy::api::v2::core::RuntimeFractionalPercent.
    */
-  static void translateRuntimeUInt32(const Json::Object& json_runtime,
-                                     envoy::api::v2::core::RuntimeFractionalPercent& runtime_fraction);
+  static void
+  translateRuntimeUInt32(const Json::Object& json_runtime,
+                         envoy::api::v2::core::RuntimeFractionalPercent& runtime_fraction);
 
   /**
    * Translate a v1 JSON header-value object to v2 envoy::api::v2::core::HeaderValueOption.

--- a/source/common/config/rds_json.cc
+++ b/source/common/config/rds_json.cc
@@ -225,7 +225,7 @@ void RdsJson::translateRoute(const Json::Object& json_route, envoy::api::v2::rou
   JSON_UTIL_SET_BOOL(json_route, *match, case_sensitive);
 
   if (json_route.hasObject("runtime")) {
-    BaseJson::translateRuntimeUInt32(*json_route.getObject("runtime"), *match->mutable_runtime());
+    BaseJson::translateRuntimeUInt32(*json_route.getObject("runtime"), *match->mutable_runtime_fraction());
   }
 
   for (const auto json_header_matcher : json_route.getObjectArray("headers", true)) {

--- a/source/common/config/rds_json.cc
+++ b/source/common/config/rds_json.cc
@@ -225,7 +225,8 @@ void RdsJson::translateRoute(const Json::Object& json_route, envoy::api::v2::rou
   JSON_UTIL_SET_BOOL(json_route, *match, case_sensitive);
 
   if (json_route.hasObject("runtime")) {
-    BaseJson::translateRuntimeUInt32(*json_route.getObject("runtime"), *match->mutable_runtime_fraction());
+    BaseJson::translateRuntimeUInt32(*json_route.getObject("runtime"),
+                                     *match->mutable_runtime_fraction());
   }
 
   for (const auto json_header_matcher : json_route.getObjectArray("headers", true)) {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -417,7 +417,8 @@ void RouteEntryImplBase::finalizeResponseHeaders(
   vhost_.globalRouteConfig().responseHeaderParser().evaluateHeaders(headers, request_info);
 }
 
-bool RouteEntryImplBase::evaluateRuntimeKeys(const RuntimeData& runtime_data, const uint64_t random_value) const {
+bool RouteEntryImplBase::evaluateRuntimeKeys(const RuntimeData& runtime_data,
+                                             const uint64_t random_value) const {
   envoy::type::FractionalPercent fractional_percent;
   const std::string& fraction_yaml = loader_.snapshot().get(runtime_data.fractional_runtime_key);
 
@@ -432,7 +433,7 @@ bool RouteEntryImplBase::evaluateRuntimeKeys(const RuntimeData& runtime_data, co
   const auto numerator = fractional_percent.numerator();
   const auto denominator =
       ProtobufPercentHelper::fractionalPercentDenominatorToInt(fractional_percent.denominator());
-   
+
   return random_value % denominator < numerator;
 }
 

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -389,10 +389,6 @@ private:
     // Fields associated with the 'runtime_fractional_percent' field for the RouteMatch proto.
     std::string fractional_runtime_key;
     envoy::type::FractionalPercent fractional_default_value;
-
-    // Fields associated with the deprecated 'runtime' field for the RouteMatch proto.
-    std::string runtime_key;
-    uint64_t runtime_default_value;
   };
 
   class DynamicRouteEntry : public RouteEntry, public Route {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -384,12 +384,11 @@ protected:
 
   void finalizePathHeader(Http::HeaderMap& headers, const std::string& matched_path,
                           bool insert_envoy_original_path) const;
-
 private:
   struct RuntimeData {
     // Fields associated with the 'runtime_fractional_percent' field for the RouteMatch proto.
     std::string fractional_runtime_key;
-    envoy::api::v2::core::RuntimeFractionalPercent fractional_default_value;
+    envoy::type::FractionalPercent fractional_default_value;
 
     // Fields associated with the deprecated 'runtime' field for the RouteMatch proto.
     std::string runtime_key;
@@ -525,6 +524,8 @@ private:
   typedef std::shared_ptr<WeightedClusterEntry> WeightedClusterEntrySharedPtr;
 
   absl::optional<RuntimeData> loadRuntimeData(const envoy::api::v2::route::RouteMatch& route);
+
+  bool evaluateRuntimeKeys(const RuntimeData& runtime_data, const uint64_t random_value) const;
 
   static std::multimap<std::string, std::string>
   parseOpaqueConfig(const envoy::api::v2::route::Route& route);

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -384,6 +384,7 @@ protected:
 
   void finalizePathHeader(Http::HeaderMap& headers, const std::string& matched_path,
                           bool insert_envoy_original_path) const;
+
 private:
   struct RuntimeData {
     // Fields associated with the 'runtime_fractional_percent' field for the RouteMatch proto.

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -387,8 +387,13 @@ protected:
 
 private:
   struct RuntimeData {
-    uint64_t numerator_val_{};
-    uint64_t denominator_val_{};
+    // Fields associated with the 'runtime_fractional_percent' field for the RouteMatch proto.
+    std::string fractional_runtime_key;
+    envoy::api::v2::core::RuntimeFractionalPercent fractional_default_value;
+
+    // Fields associated with the deprecated 'runtime' field for the RouteMatch proto.
+    std::string runtime_key;
+    uint64_t runtime_default_value;
   };
 
   class DynamicRouteEntry : public RouteEntry, public Route {


### PR DESCRIPTION
*Description*:
This patch removes the `runtime` field from the `RouteMatch` message in route.proto, fixing #4623. In addition, the bug described in #4607 is fixed.

*Risk Level*:
Medium

*Testing*:
Enhanced unit tests to test for the scenario in #4607. Tests that verify behavior around the now removed `runtime` field have been removed.

*Docs Changes*:
n/a

*Release Notes*:
Updated.