### PR TITLE
route: Fix RouteMatch runtime updates

### DIFF
--- a/include/envoy/runtime/BUILD
+++ b/include/envoy/runtime/BUILD
@@ -13,6 +13,6 @@ envoy_cc_library(
     hdrs = ["runtime.h"],
     external_deps = ["abseil_optional"],
     deps = [
-      "@envoy_api//envoy/type:percent_cc",
+        "@envoy_api//envoy/type:percent_cc",
     ],
 )

--- a/include/envoy/runtime/BUILD
+++ b/include/envoy/runtime/BUILD
@@ -12,4 +12,7 @@ envoy_cc_library(
     name = "runtime_interface",
     hdrs = ["runtime.h"],
     external_deps = ["abseil_optional"],
+    deps = [
+      "@envoy_api//envoy/type:percent_cc",
+    ],
 )

--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -135,7 +135,7 @@ public:
    * @return true if the feature is enabled.
    */
   virtual bool featureEnabled(const std::string& key,
-                              envoy::type::FractionalPercent default_value) const PURE;
+                              const envoy::type::FractionalPercent& default_value) const PURE;
 
   /**
    * Test if a feature is enabled using a supplied stable random value. This variant is used if
@@ -147,7 +147,8 @@ public:
    *        is enabled.
    * @return true if the feature is enabled.
    */
-  virtual bool featureEnabled(const std::string& key, envoy::type::FractionalPercent default_value,
+  virtual bool featureEnabled(const std::string& key,
+                              const envoy::type::FractionalPercent& default_value,
                               uint64_t random_value) const PURE;
 
   /**

--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -134,7 +134,8 @@ public:
    *        does not exist or it is not a fractional percent.
    * @return true if the feature is enabled.
    */
-  virtual bool featureEnabled(const std::string& key, envoy::type::FractionalPercent default_value) const PURE;
+  virtual bool featureEnabled(const std::string& key,
+                              envoy::type::FractionalPercent default_value) const PURE;
 
   /**
    * Test if a feature is enabled using a supplied stable random value. This variant is used if

--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -47,6 +47,8 @@ public:
    */
   class Entry {
   public:
+    virtual ~Entry() {}
+
     enum class EntryType {
       UINT_VALUE,
       FRACTIONAL_PERCENT_VALUE,

--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -42,40 +42,19 @@ class Snapshot {
 public:
   virtual ~Snapshot() {}
 
-  /**
-   * The raw data from a single snapshot key.
-   */
-  class Entry {
-  public:
-    virtual ~Entry() {}
-
+  struct Entry {
     enum class EntryType {
+      STRING_VALUE,
       UINT_VALUE,
       FRACTIONAL_PERCENT_VALUE,
-      UNSET_VALUE,
     };
-
-    /**
-     * The raw runtime data.
-     */
-    virtual std::string getRawStringValue() const PURE;
-
-    /**
-     * The possibly parsed integer value from the runtime data.
-     */
-    virtual absl::optional<uint64_t> getUintValue() const PURE;
-
-    /**
-     * The possibly parsed fractional percent value from the runtime data.
-     */
-    virtual absl::optional<envoy::type::FractionalPercent> getFractionalPercentValue() const PURE;
-
-    /**
-     * Attempts to parse the raw string value into one of the supported entry types and sets the
-     * entry type as appropriate.
-     */
-    virtual void attemptParse() const PURE;
+    EntryType entry_type_;
+    std::string raw_string_value_;
+    absl::optional<uint64_t> uint_value_;
+    absl::optional<envoy::type::FractionalPercent> fractional_percent_value_;
   };
+
+  typedef std::unordered_map<std::string, Entry> EntryMap;
 
   /**
    * A provider of runtime values. One or more of these compose the snapshot's source of values,
@@ -84,10 +63,12 @@ public:
   class OverrideLayer {
   public:
     virtual ~OverrideLayer() {}
+
     /**
      * @return const std::unordered_map<std::string, Entry>& the values in this layer.
      */
-    virtual const std::unordered_map<std::string, Entry>& values() const PURE;
+    virtual const std::unordered_map<std::string, Snapshot::Entry>& values() const PURE;
+
     /**
      * @return const std::string& a user-friendly alias for this layer, e.g. "admin" or "disk".
      */

--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -43,11 +43,6 @@ public:
   virtual ~Snapshot() {}
 
   struct Entry {
-    enum class EntryType {
-      STRING_VALUE,
-      UINT_VALUE,
-      FRACTIONAL_PERCENT_VALUE,
-    };
     std::string raw_string_value_;
     absl::optional<uint64_t> uint_value_;
     absl::optional<envoy::type::FractionalPercent> fractional_percent_value_;

--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -51,7 +51,6 @@ public:
     std::string raw_string_value_;
     absl::optional<uint64_t> uint_value_;
     absl::optional<envoy::type::FractionalPercent> fractional_percent_value_;
-    EntryType entry_type_;
   };
 
   typedef std::unordered_map<std::string, Entry> EntryMap;

--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -48,10 +48,10 @@ public:
       UINT_VALUE,
       FRACTIONAL_PERCENT_VALUE,
     };
-    EntryType entry_type_;
     std::string raw_string_value_;
     absl::optional<uint64_t> uint_value_;
     absl::optional<envoy::type::FractionalPercent> fractional_percent_value_;
+    EntryType entry_type_;
   };
 
   typedef std::unordered_map<std::string, Entry> EntryMap;

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -358,10 +358,12 @@ bool RouteEntryImplBase::evaluateRuntimeMatch(const uint64_t random_value) const
 
   if (runtime_->legacy_runtime_data_) {
     // Use the deprecated 'runtime' field from the route.
-    return loader_.snapshot().featureEnabled(runtime_->runtime_key_, runtime_->runtime_default_, random_value);
+    return loader_.snapshot().featureEnabled(runtime_->runtime_key_, runtime_->runtime_default_,
+                                             random_value);
   }
 
-  return loader_.snapshot().featureEnabled(runtime_->fractional_runtime_key_, runtime_->fractional_runtime_default_, random_value);
+  return loader_.snapshot().featureEnabled(runtime_->fractional_runtime_key_,
+                                           runtime_->fractional_runtime_default_, random_value);
 }
 
 bool RouteEntryImplBase::matchRoute(const Http::HeaderMap& headers, uint64_t random_value) const {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -351,15 +351,26 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
   }
 }
 
+bool RouteEntryImplBase::evaluateRuntimeMatch(const uint64_t random_value) const {
+  if (!runtime_) {
+    return true;
+  }
+
+  if (runtime_->legacy_runtime_data_) {
+    // Use the deprecated 'runtime' field from the route.
+    return loader_.snapshot().featureEnabled(runtime_->runtime_key_, runtime_->runtime_default_, random_value);
+  }
+
+  return loader_.snapshot().featureEnabled(runtime_->fractional_runtime_key_, runtime_->fractional_runtime_default_, random_value);
+}
+
 bool RouteEntryImplBase::matchRoute(const Http::HeaderMap& headers, uint64_t random_value) const {
   bool matches = true;
 
-  if (runtime_) {
-    matches &= random_value % runtime_->denominator_val_ < runtime_->numerator_val_;
-    if (!matches) {
-      // No need to waste further cycles calculating a route match.
-      return false;
-    }
+  matches &= evaluateRuntimeMatch(random_value);
+  if (!matches) {
+    // No need to waste further cycles calculating a route match.
+    return false;
   }
 
   if (match_grpc_) {
@@ -424,28 +435,13 @@ RouteEntryImplBase::loadRuntimeData(const envoy::api::v2::route::RouteMatch& rou
   RuntimeData runtime_data;
 
   if (route_match.runtime_specifier_case() == envoy::api::v2::route::RouteMatch::kRuntimeFraction) {
-    envoy::type::FractionalPercent fractional_percent;
-    const std::string& fraction_yaml =
-        loader_.snapshot().get(route_match.runtime_fraction().runtime_key());
-
-    try {
-      MessageUtil::loadFromYamlAndValidate(fraction_yaml, fractional_percent);
-    } catch (const EnvoyException& ex) {
-      ENVOY_LOG(error, "failed to parse string value for runtime key {}: {}",
-                route_match.runtime_fraction().runtime_key(), ex.what());
-      fractional_percent = route_match.runtime_fraction().default_value();
-    }
-
-    runtime_data.numerator_val_ = fractional_percent.numerator();
-    runtime_data.denominator_val_ =
-        ProtobufPercentHelper::fractionalPercentDenominatorToInt(fractional_percent.denominator());
+    runtime_data.fractional_runtime_default_ = route_match.runtime_fraction().default_value();
+    runtime_data.fractional_runtime_key_ = route_match.runtime_fraction().runtime_key();
+    runtime_data.legacy_runtime_data_ = false;
   } else if (route_match.runtime_specifier_case() == envoy::api::v2::route::RouteMatch::kRuntime) {
-    // For backwards compatibility, the deprecated 'runtime' field must be converted to a
-    // RuntimeData format with a variable denominator type. The 'runtime' field assumes a percentage
-    // (0-100), so the hard-coded denominator value reflects this.
-    runtime_data.denominator_val_ = 100;
-    runtime_data.numerator_val_ = loader_.snapshot().getInteger(
-        route_match.runtime().runtime_key(), route_match.runtime().default_value());
+    runtime_data.runtime_default_ = route_match.runtime().default_value();
+    runtime_data.runtime_key_ = route_match.runtime().runtime_key();
+    runtime_data.legacy_runtime_data_ = true;
   } else {
     return runtime;
   }

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -389,8 +389,15 @@ protected:
 
 private:
   struct RuntimeData {
-    uint64_t numerator_val_{};
-    uint64_t denominator_val_{};
+    std::string fractional_runtime_key_{};
+    envoy::type::FractionalPercent fractional_runtime_default_{};
+
+    // Relating to the deprecated 'runtime' field.
+    std::string runtime_key_{};
+    uint64_t runtime_default_{};
+
+    // Indicates whether to use the deprecated 'runtime' field or 'fractional_percent'.
+    bool legacy_runtime_data_{};
   };
 
   class DynamicRouteEntry : public RouteEntry, public Route {
@@ -527,6 +534,8 @@ private:
   parseOpaqueConfig(const envoy::api::v2::route::Route& route);
 
   static DecoratorConstPtr parseDecorator(const envoy::api::v2::route::Route& route);
+
+  bool evaluateRuntimeMatch(const uint64_t random_value) const;
 
   // Default timeout is 15s if nothing is specified in the route config.
   static const uint64_t DEFAULT_ROUTE_TIMEOUT_MS = 15000;

--- a/source/common/runtime/BUILD
+++ b/source/common/runtime/BUILD
@@ -25,6 +25,7 @@ envoy_cc_library(
         "//source/common/common:thread_lib",
         "//source/common/common:utility_lib",
         "//source/common/filesystem:filesystem_lib",
+        "//source/common/protobuf:utility_lib",
     ],
 )
 

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -178,19 +178,25 @@ const std::string& SnapshotImpl::get(const std::string& key) const {
   }
 }
 
-bool SnapshotImpl::featureEnabled(const std::string& key, envoy::type::FractionalPercent default_value) const {
+bool SnapshotImpl::featureEnabled(const std::string& key,
+                                  envoy::type::FractionalPercent default_value) const {
   return featureEnabled(key, default_value, generator_.random());
 }
 
-bool SnapshotImpl::featureEnabled(const std::string& key, envoy::type::FractionalPercent default_value, uint64_t random_value) const {
+bool SnapshotImpl::featureEnabled(const std::string& key,
+                                  envoy::type::FractionalPercent default_value,
+                                  uint64_t random_value) const {
   const auto& entry = values_.find(key);
   uint64_t numerator, denominator;
-  if (entry == values_.end() || entry->second.entry_type_ != Entry::EntryType::FRACTIONAL_PERCENT_VALUE) {
+  if (entry == values_.end() ||
+      entry->second.entry_type_ != Entry::EntryType::FRACTIONAL_PERCENT_VALUE) {
     numerator = default_value.numerator();
-    denominator = ProtobufPercentHelper::fractionalPercentDenominatorToInt(default_value.denominator());
+    denominator =
+        ProtobufPercentHelper::fractionalPercentDenominatorToInt(default_value.denominator());
   } else {
     numerator = entry->second.fractional_percent_value_->numerator();
-    denominator = ProtobufPercentHelper::fractionalPercentDenominatorToInt(entry->second.fractional_percent_value_->denominator());
+    denominator = ProtobufPercentHelper::fractionalPercentDenominatorToInt(
+        entry->second.fractional_percent_value_->denominator());
   }
 
   return random_value % denominator < numerator;

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -179,12 +179,12 @@ const std::string& SnapshotImpl::get(const std::string& key) const {
 }
 
 bool SnapshotImpl::featureEnabled(const std::string& key,
-                                  envoy::type::FractionalPercent default_value) const {
+                                  const envoy::type::FractionalPercent& default_value) const {
   return featureEnabled(key, default_value, generator_.random());
 }
 
 bool SnapshotImpl::featureEnabled(const std::string& key,
-                                  envoy::type::FractionalPercent default_value,
+                                  const envoy::type::FractionalPercent& default_value,
                                   uint64_t random_value) const {
   const auto& entry = values_.find(key);
   uint64_t numerator, denominator;

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -61,7 +61,9 @@ struct RuntimeStats {
 /**
  * Implementation of Snapshot whose source is the vector of layers passed to the constructor.
  */
-class SnapshotImpl : public Snapshot, public ThreadLocal::ThreadLocalObject, Logger::Loggable<Logger::Id::runtime> {
+class SnapshotImpl : public Snapshot,
+                     public ThreadLocal::ThreadLocalObject,
+                     Logger::Loggable<Logger::Id::runtime> {
 public:
   SnapshotImpl(RandomGenerator& generator, RuntimeStats& stats,
                std::vector<OverrideLayerConstPtr>&& layers);
@@ -72,8 +74,10 @@ public:
   bool featureEnabled(const std::string& key, uint64_t default_value) const override;
   bool featureEnabled(const std::string& key, uint64_t default_value,
                       uint64_t random_value) const override;
-  bool featureEnabled(const std::string& key, envoy::type::FractionalPercent default_value) const override;
-  bool featureEnabled(const std::string& key, envoy::type::FractionalPercent default_value, uint64_t random_value) const override;
+  bool featureEnabled(const std::string& key,
+                      envoy::type::FractionalPercent default_value) const override;
+  bool featureEnabled(const std::string& key, envoy::type::FractionalPercent default_value,
+                      uint64_t random_value) const override;
   const std::string& get(const std::string& key) const override;
   uint64_t getInteger(const std::string& key, uint64_t default_value) const override;
   const std::vector<OverrideLayerConstPtr>& getLayers() const override;
@@ -102,9 +106,7 @@ private:
 class OverrideLayerImpl : public Snapshot::OverrideLayer {
 public:
   explicit OverrideLayerImpl(const std::string& name) : name_{name} {}
-  const Snapshot::EntryMap& values() const override {
-    return values_;
-  }
+  const Snapshot::EntryMap& values() const override { return values_; }
   const std::string& name() const override { return name_; }
 
 protected:

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -75,8 +75,8 @@ public:
   bool featureEnabled(const std::string& key, uint64_t default_value,
                       uint64_t random_value) const override;
   bool featureEnabled(const std::string& key,
-                      envoy::type::FractionalPercent default_value) const override;
-  bool featureEnabled(const std::string& key, envoy::type::FractionalPercent default_value,
+                      const envoy::type::FractionalPercent& default_value) const override;
+  bool featureEnabled(const std::string& key, const envoy::type::FractionalPercent& default_value,
                       uint64_t random_value) const override;
   const std::string& get(const std::string& key) const override;
   uint64_t getInteger(const std::string& key, uint64_t default_value) const override;

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -93,7 +93,7 @@ private:
   }
 
   static bool parseEntryUintValue(Entry& entry);
-  static bool parseEntryFractionalPercentValue(Entry& entry);
+  static void parseEntryFractionalPercentValue(Entry& entry);
 
   const std::vector<OverrideLayerConstPtr> layers_;
   EntryMap values_;

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -804,7 +804,7 @@ Http::Code AdminImpl::handlerRuntime(absl::string_view url, Http::HeaderMap& res
   for (const auto& layer : layers) {
     for (auto& kv : entry_objects) {
       const auto it = layer->values().find(kv.first);
-      const auto& entry_value = it == layer->values().end() ? "" : it->second.string_value_;
+      const auto& entry_value = it == layer->values().end() ? "" : it->second.raw_string_value_;
       rapidjson::Value entry_value_object;
       entry_value_object.SetString(entry_value.c_str(), allocator);
       if (!entry_value.empty()) {
@@ -845,7 +845,7 @@ std::string AdminImpl::runtimeAsJson(
     if (entry.second.uint_value_) {
       entry_value.SetUint64(entry.second.uint_value_.value());
     } else {
-      entry_value.SetString(entry.second.string_value_.c_str(), allocator);
+      entry_value.SetString(entry.second.raw_string_value_.c_str(), allocator);
     }
     entry_obj.AddMember("value", entry_value, allocator);
 

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -326,7 +326,8 @@ TEST_F(ConnectionManagerUtilityTest, EdgeRequestRegenerateRequestIdAndWipeDownst
                               {"x-request-id", "will_be_regenerated"}};
     EXPECT_CALL(random_, uuid());
 
-    EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.client_enabled", Matcher<uint64_t>(_))).Times(0);
+    EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.client_enabled", Matcher<uint64_t>(_)))
+        .Times(0);
     EXPECT_EQ((MutateRequestRet{"34.0.0.1:0", false}),
               callMutateRequestHeaders(headers, Protocol::Http2));
     EXPECT_FALSE(headers.has(Headers::get().EnvoyDownstreamServiceCluster));

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -20,6 +20,7 @@
 
 using testing::_;
 using testing::InSequence;
+using testing::Matcher;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
@@ -325,7 +326,7 @@ TEST_F(ConnectionManagerUtilityTest, EdgeRequestRegenerateRequestIdAndWipeDownst
                               {"x-request-id", "will_be_regenerated"}};
     EXPECT_CALL(random_, uuid());
 
-    EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.client_enabled", _)).Times(0);
+    EXPECT_CALL(runtime_.snapshot_, featureEnabled("tracing.client_enabled", Matcher<uint64_t>(_))).Times(0);
     EXPECT_EQ((MutateRequestRet{"34.0.0.1:0", false}),
               callMutateRequestHeaders(headers, Protocol::Http2));
     EXPECT_FALSE(headers.has(Headers::get().EnvoyDownstreamServiceCluster));

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2036,13 +2036,15 @@ virtual_hosts:
 
   TestConfigImpl config(parseRouteConfigurationFromV2Yaml(yaml), factory_context, false);
 
-  EXPECT_CALL(snapshot, featureEnabled("bogus_key", Matcher<const envoy::type::FractionalPercent&>(_), 41))
+  EXPECT_CALL(snapshot,
+              featureEnabled("bogus_key", Matcher<const envoy::type::FractionalPercent&>(_), 41))
       .WillRepeatedly(Return(true));
   EXPECT_EQ(
       "something_else",
       config.route(genHeaders("www.lyft.com", "/foo", "GET"), 41)->routeEntry()->clusterName());
 
-  EXPECT_CALL(snapshot, featureEnabled("bogus_key", Matcher<const envoy::type::FractionalPercent&>(_), 43))
+  EXPECT_CALL(snapshot,
+              featureEnabled("bogus_key", Matcher<const envoy::type::FractionalPercent&>(_), 43))
       .WillRepeatedly(Return(false));
   EXPECT_EQ(
       "www2",

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2036,13 +2036,13 @@ virtual_hosts:
 
   TestConfigImpl config(parseRouteConfigurationFromV2Yaml(yaml), factory_context, false);
 
-  EXPECT_CALL(snapshot, featureEnabled("bogus_key", Matcher<envoy::type::FractionalPercent>(_), 41))
+  EXPECT_CALL(snapshot, featureEnabled("bogus_key", Matcher<const envoy::type::FractionalPercent&>(_), 41))
       .WillRepeatedly(Return(true));
   EXPECT_EQ(
       "something_else",
       config.route(genHeaders("www.lyft.com", "/foo", "GET"), 41)->routeEntry()->clusterName());
 
-  EXPECT_CALL(snapshot, featureEnabled("bogus_key", Matcher<envoy::type::FractionalPercent>(_), 43))
+  EXPECT_CALL(snapshot, featureEnabled("bogus_key", Matcher<const envoy::type::FractionalPercent&>(_), 43))
       .WillRepeatedly(Return(false));
   EXPECT_EQ(
       "www2",

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -1998,11 +1998,13 @@ TEST(RouteMatcherTest, Runtime) {
 
   TestConfigImpl config(parseRouteConfigurationFromJson(json), factory_context, true);
 
-  EXPECT_CALL(snapshot, featureEnabled("some_key", 50, 41)).WillRepeatedly(Return(true));;
+  EXPECT_CALL(snapshot, featureEnabled("some_key", 50, 41)).WillRepeatedly(Return(true));
+  ;
   EXPECT_EQ("something_else",
             config.route(genHeaders("www.lyft.com", "/", "GET"), 41)->routeEntry()->clusterName());
 
-  EXPECT_CALL(snapshot, featureEnabled("some_key", 50, 43)).WillRepeatedly(Return(false));;
+  EXPECT_CALL(snapshot, featureEnabled("some_key", 50, 43)).WillRepeatedly(Return(false));
+  ;
   EXPECT_EQ("www2",
             config.route(genHeaders("www.lyft.com", "/", "GET"), 43)->routeEntry()->clusterName());
 }
@@ -2034,12 +2036,14 @@ virtual_hosts:
 
   TestConfigImpl config(parseRouteConfigurationFromV2Yaml(yaml), factory_context, false);
 
-  EXPECT_CALL(snapshot, featureEnabled("bogus_key", Matcher<envoy::type::FractionalPercent>(_), 41)).WillRepeatedly(Return(true));
+  EXPECT_CALL(snapshot, featureEnabled("bogus_key", Matcher<envoy::type::FractionalPercent>(_), 41))
+      .WillRepeatedly(Return(true));
   EXPECT_EQ(
       "something_else",
       config.route(genHeaders("www.lyft.com", "/foo", "GET"), 41)->routeEntry()->clusterName());
 
-  EXPECT_CALL(snapshot, featureEnabled("bogus_key", Matcher<envoy::type::FractionalPercent>(_), 43)).WillRepeatedly(Return(false));
+  EXPECT_CALL(snapshot, featureEnabled("bogus_key", Matcher<envoy::type::FractionalPercent>(_), 43))
+      .WillRepeatedly(Return(false));
   EXPECT_EQ(
       "www2",
       config.route(genHeaders("www.lyft.com", "/foo", "GET"), 43)->routeEntry()->clusterName());

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -137,6 +137,13 @@ TEST_F(DiskBackedLoaderImplTest, All) {
   EXPECT_FALSE(loader->snapshot().featureEnabled("file8", fractional_percent)); // valid data
 
   EXPECT_CALL(generator, random()).WillOnce(Return(4));
+  EXPECT_TRUE(loader->snapshot().featureEnabled("file9", fractional_percent)); // invalid proto data
+
+  EXPECT_CALL(generator, random()).WillOnce(Return(6));
+  EXPECT_FALSE(
+      loader->snapshot().featureEnabled("file9", fractional_percent)); // invalid proto data
+
+  EXPECT_CALL(generator, random()).WillOnce(Return(4));
   EXPECT_TRUE(loader->snapshot().featureEnabled("file1", fractional_percent)); // invalid data
 
   EXPECT_CALL(generator, random()).WillOnce(Return(6));

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -125,6 +125,23 @@ TEST_F(DiskBackedLoaderImplTest, All) {
   EXPECT_CALL(generator, random()).WillOnce(Return(2));
   EXPECT_FALSE(loader->snapshot().featureEnabled("file3", 1));
 
+  // Fractional percent feature enablement
+  envoy::type::FractionalPercent fractional_percent;
+  fractional_percent.set_numerator(5);
+  fractional_percent.set_denominator(envoy::type::FractionalPercent::TEN_THOUSAND);
+
+  EXPECT_CALL(generator, random()).WillOnce(Return(50));
+  EXPECT_TRUE(loader->snapshot().featureEnabled("file8", fractional_percent)); // valid data
+
+  EXPECT_CALL(generator, random()).WillOnce(Return(60));
+  EXPECT_FALSE(loader->snapshot().featureEnabled("file8", fractional_percent)); // valid data
+
+  EXPECT_CALL(generator, random()).WillOnce(Return(4));
+  EXPECT_TRUE(loader->snapshot().featureEnabled("file1", fractional_percent)); // invalid data
+
+  EXPECT_CALL(generator, random()).WillOnce(Return(6));
+  EXPECT_FALSE(loader->snapshot().featureEnabled("file1", fractional_percent)); // invalid data
+
   // Check stable value
   EXPECT_TRUE(loader->snapshot().featureEnabled("file3", 1, 1));
   EXPECT_FALSE(loader->snapshot().featureEnabled("file3", 1, 3));

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -142,8 +142,8 @@ TEST_F(DiskBackedLoaderImplTest, GetLayers) {
   run("test/common/runtime/test_data/current", "envoy_override");
   const auto& layers = loader->snapshot().getLayers();
   EXPECT_EQ(3, layers.size());
-  EXPECT_EQ("hello", layers[0]->values().find("file1")->second.string_value_);
-  EXPECT_EQ("hello override", layers[1]->values().find("file1")->second.string_value_);
+  EXPECT_EQ("hello", layers[0]->values().find("file1")->second.raw_string_value_);
+  EXPECT_EQ("hello override", layers[1]->values().find("file1")->second.raw_string_value_);
   // Admin should be last
   EXPECT_NE(nullptr, dynamic_cast<const AdminLayer*>(layers.back().get()));
   EXPECT_TRUE(layers[2]->values().empty());
@@ -151,7 +151,7 @@ TEST_F(DiskBackedLoaderImplTest, GetLayers) {
   loader->mergeValues({{"foo", "bar"}});
   // The old snapshot and its layers should have been invalidated. Refetch.
   const auto& new_layers = loader->snapshot().getLayers();
-  EXPECT_EQ("bar", new_layers[2]->values().find("foo")->second.string_value_);
+  EXPECT_EQ("bar", new_layers[2]->values().find("foo")->second.raw_string_value_);
 }
 
 TEST_F(DiskBackedLoaderImplTest, BadDirectory) {

--- a/test/common/runtime/test_data/root/envoy/file8
+++ b/test/common/runtime/test_data/root/envoy/file8
@@ -1,0 +1,2 @@
+numerator: 52
+denominator: HUNDRED

--- a/test/common/runtime/test_data/root/envoy/file9
+++ b/test/common/runtime/test_data/root/envoy/file9
@@ -1,0 +1,2 @@
+numerator: 100
+denominator: NONSENSE

--- a/test/mocks/runtime/mocks.h
+++ b/test/mocks/runtime/mocks.h
@@ -32,11 +32,11 @@ public:
                      bool(const std::string& key, uint64_t default_value, uint64_t random_value));
   MOCK_CONST_METHOD4(featureEnabled, bool(const std::string& key, uint64_t default_value,
                                           uint64_t random_value, uint64_t num_buckets));
-  MOCK_CONST_METHOD2(featureEnabled,
-                     bool(const std::string& key, envoy::type::FractionalPercent default_value));
-  MOCK_CONST_METHOD3(featureEnabled,
-                     bool(const std::string& key, envoy::type::FractionalPercent default_value,
-                          uint64_t random_value));
+  MOCK_CONST_METHOD2(featureEnabled, bool(const std::string& key,
+                                          const envoy::type::FractionalPercent& default_value));
+  MOCK_CONST_METHOD3(featureEnabled, bool(const std::string& key,
+                                          const envoy::type::FractionalPercent& default_value,
+                                          uint64_t random_value));
   MOCK_CONST_METHOD1(get, const std::string&(const std::string& key));
   MOCK_CONST_METHOD2(getInteger, uint64_t(const std::string& key, uint64_t default_value));
   MOCK_CONST_METHOD0(getLayers, const std::vector<OverrideLayerConstPtr>&());

--- a/test/mocks/runtime/mocks.h
+++ b/test/mocks/runtime/mocks.h
@@ -59,6 +59,7 @@ public:
   ~MockOverrideLayer();
 
   MOCK_CONST_METHOD0(name, const std::string&());
+  MOCK_CONST_METHOD0(values, const std::unordered_map<std::string, Snapshot::Entry>&());
 };
 
 } // namespace Runtime

--- a/test/mocks/runtime/mocks.h
+++ b/test/mocks/runtime/mocks.h
@@ -32,8 +32,11 @@ public:
                      bool(const std::string& key, uint64_t default_value, uint64_t random_value));
   MOCK_CONST_METHOD4(featureEnabled, bool(const std::string& key, uint64_t default_value,
                                           uint64_t random_value, uint64_t num_buckets));
-  MOCK_CONST_METHOD2(featureEnabled, bool(const std::string& key, envoy::type::FractionalPercent default_value));
-  MOCK_CONST_METHOD3(featureEnabled, bool(const std::string& key, envoy::type::FractionalPercent default_value, uint64_t random_value));
+  MOCK_CONST_METHOD2(featureEnabled,
+                     bool(const std::string& key, envoy::type::FractionalPercent default_value));
+  MOCK_CONST_METHOD3(featureEnabled,
+                     bool(const std::string& key, envoy::type::FractionalPercent default_value,
+                          uint64_t random_value));
   MOCK_CONST_METHOD1(get, const std::string&(const std::string& key));
   MOCK_CONST_METHOD2(getInteger, uint64_t(const std::string& key, uint64_t default_value));
   MOCK_CONST_METHOD0(getLayers, const std::vector<OverrideLayerConstPtr>&());

--- a/test/mocks/runtime/mocks.h
+++ b/test/mocks/runtime/mocks.h
@@ -32,6 +32,8 @@ public:
                      bool(const std::string& key, uint64_t default_value, uint64_t random_value));
   MOCK_CONST_METHOD4(featureEnabled, bool(const std::string& key, uint64_t default_value,
                                           uint64_t random_value, uint64_t num_buckets));
+  MOCK_CONST_METHOD2(featureEnabled, bool(const std::string& key, envoy::type::FractionalPercent default_value));
+  MOCK_CONST_METHOD3(featureEnabled, bool(const std::string& key, envoy::type::FractionalPercent default_value, uint64_t random_value));
   MOCK_CONST_METHOD1(get, const std::string&(const std::string& key));
   MOCK_CONST_METHOD2(getInteger, uint64_t(const std::string& key, uint64_t default_value));
   MOCK_CONST_METHOD0(getLayers, const std::vector<OverrideLayerConstPtr>&());
@@ -54,7 +56,6 @@ public:
   ~MockOverrideLayer();
 
   MOCK_CONST_METHOD0(name, const std::string&());
-  MOCK_CONST_METHOD0(values, const std::unordered_map<std::string, Snapshot::Entry>&());
 };
 
 } // namespace Runtime

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -843,11 +843,11 @@ TEST_P(AdminInstanceTest, Runtime) {
   auto layer1 = std::make_unique<NiceMock<Runtime::MockOverrideLayer>>();
   auto layer2 = std::make_unique<NiceMock<Runtime::MockOverrideLayer>>();
   std::unordered_map<std::string, Runtime::Snapshot::Entry> entries2{
-      {"string_key", {"override", {}, {}, {}}}, {"extra_key", {"bar", {}, {}, {}}}};
+      {"string_key", {"override", {}, {}}}, {"extra_key", {"bar", {}, {}}}};
   std::unordered_map<std::string, Runtime::Snapshot::Entry> entries1{
-      {"string_key", {"foo", {}, {}, {}}},
-      {"int_key", {"1", 1, {}, {}}},
-      {"other_key", {"bar", {}, {}, {}}}};
+      {"string_key", {"foo", {}, {}}},
+      {"int_key", {"1", 1, {}}},
+      {"other_key", {"bar", {}, {}}}};
 
   ON_CALL(*layer1, name()).WillByDefault(testing::ReturnRefOfCopy(std::string{"layer1"}));
   ON_CALL(*layer1, values()).WillByDefault(testing::ReturnRef(entries1));

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -845,9 +845,7 @@ TEST_P(AdminInstanceTest, Runtime) {
   std::unordered_map<std::string, Runtime::Snapshot::Entry> entries2{
       {"string_key", {"override", {}, {}}}, {"extra_key", {"bar", {}, {}}}};
   std::unordered_map<std::string, Runtime::Snapshot::Entry> entries1{
-      {"string_key", {"foo", {}, {}}},
-      {"int_key", {"1", 1, {}}},
-      {"other_key", {"bar", {}, {}}}};
+      {"string_key", {"foo", {}, {}}}, {"int_key", {"1", 1, {}}}, {"other_key", {"bar", {}, {}}}};
 
   ON_CALL(*layer1, name()).WillByDefault(testing::ReturnRefOfCopy(std::string{"layer1"}));
   ON_CALL(*layer1, values()).WillByDefault(testing::ReturnRef(entries1));

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -842,10 +842,10 @@ TEST_P(AdminInstanceTest, Runtime) {
   Runtime::MockLoader loader;
   auto layer1 = std::make_unique<NiceMock<Runtime::MockOverrideLayer>>();
   auto layer2 = std::make_unique<NiceMock<Runtime::MockOverrideLayer>>();
-  std::unordered_map<std::string, Runtime::Snapshot::Entry> entries1{
-      {"string_key", {"foo", {}}}, {"int_key", {"1", {1}}}, {"other_key", {"bar", {}}}};
   std::unordered_map<std::string, Runtime::Snapshot::Entry> entries2{
-      {"string_key", {"override", {}}}, {"extra_key", {"bar", {}}}};
+      {"string_key", {"override", {}, {}, {}}}, {"extra_key", {"bar", {}, {}, {}}}};
+  std::unordered_map<std::string, Runtime::Snapshot::Entry> entries1{
+      {"string_key", {"foo", {}, {}, {}}}, {"int_key", {"1", 1, {}, {}}}, {"other_key", {"bar", {}, {}, {}}}};
 
   ON_CALL(*layer1, name()).WillByDefault(testing::ReturnRefOfCopy(std::string{"layer1"}));
   ON_CALL(*layer1, values()).WillByDefault(testing::ReturnRef(entries1));

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -845,7 +845,9 @@ TEST_P(AdminInstanceTest, Runtime) {
   std::unordered_map<std::string, Runtime::Snapshot::Entry> entries2{
       {"string_key", {"override", {}, {}, {}}}, {"extra_key", {"bar", {}, {}, {}}}};
   std::unordered_map<std::string, Runtime::Snapshot::Entry> entries1{
-      {"string_key", {"foo", {}, {}, {}}}, {"int_key", {"1", 1, {}, {}}}, {"other_key", {"bar", {}, {}, {}}}};
+      {"string_key", {"foo", {}, {}, {}}},
+      {"int_key", {"1", 1, {}, {}}},
+      {"other_key", {"bar", {}, {}, {}}}};
 
   ON_CALL(*layer1, name()).WillByDefault(testing::ReturnRefOfCopy(std::string{"layer1"}));
   ON_CALL(*layer1, values()).WillByDefault(testing::ReturnRef(entries1));


### PR DESCRIPTION
*Description*:
This patch fixes the bug described in #4607 where the runtime values were fixed to their values at the creation time of the route. Runtime snapshots have been enhanced to understand FractionalPercent types and the unit tests for the runtime implementation have been updated to provide coverage.

*Risk Level*:
Medium

*Testing*:
Unit tests

*Docs Changes*:
done.

*Release Notes*:
n/a
