### PR TITLE
router: reflect per try timeout in grpc-timeout

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -6,6 +6,8 @@ Version history
 * fault: removed integer percentage support.
 * stream: renamed the `RequestInfo` namespace to `StreamInfo` to better match
   its behaviour within TCP and HTTP implementations.
+* router: when :ref:`max_grpc_timeout <envoy_api_field_route.RouteAction.max_grpc_timeout>`
+  is set, Envoy will now add or update the grpc-timeout header to reflect Envoy's expected timeout.
 
 1.8.0 (Oct 4, 2018)
 ===================

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -4,10 +4,10 @@ Version history
 1.9.0 (pending)
 ===============
 * fault: removed integer percentage support.
-* stream: renamed the `RequestInfo` namespace to `StreamInfo` to better match
-  its behaviour within TCP and HTTP implementations.
 * router: when :ref:`max_grpc_timeout <envoy_api_field_route.RouteAction.max_grpc_timeout>`
   is set, Envoy will now add or update the grpc-timeout header to reflect Envoy's expected timeout.
+* stream: renamed the `RequestInfo` namespace to `StreamInfo` to better match
+  its behaviour within TCP and HTTP implementations.
 
 1.8.0 (Oct 4, 2018)
 ===================

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -114,9 +114,10 @@ FilterUtility::finalTimeout(const RouteEntry& route, Http::HeaderMap& request_he
   // If we've configured max_grpc_timeout, override the grpc-timeout header with
   // the expected timeout. This ensures that the optional per try timeout is reflected
   // in grpc-timeout, ensuring that the upstream gRPC server is aware of the actual timeout.
-  if (grpc_request && route.maxGrpcTimeout() && request_headers.GrpcTimeout()) {
+  // If the expected timeout is 0 set no timeout, as Envoy treats 0 as infinite timeout.
+  if (grpc_request && route.maxGrpcTimeout() && expected_timeout != 0) {
     Grpc::Common::toGrpcTimeout(std::chrono::milliseconds(expected_timeout),
-                                request_headers.GrpcTimeout()->value());
+                                request_headers.insertGrpcTimeout().value());
   }
 
   return timeout;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -111,6 +111,14 @@ FilterUtility::finalTimeout(const RouteEntry& route, Http::HeaderMap& request_he
     request_headers.insertEnvoyExpectedRequestTimeoutMs().value(expected_timeout);
   }
 
+  // If we've configured max_grpc_timeout, override the grpc-timeout header with
+  // the expected timeout. This ensures that the optional per try timeout is reflected
+  // in grpc-timeout, ensuring that the upstream gRPC server is aware of the actual timeout.
+  if (grpc_request && route.maxGrpcTimeout() && request_headers.GrpcTimeout()) {
+    Grpc::Common::toGrpcTimeout(std::chrono::milliseconds(expected_timeout),
+                                request_headers.GrpcTimeout()->value());
+  }
+
   return timeout;
 }
 

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -2001,6 +2001,7 @@ TEST(RouterFilterUtilityTest, FinalTimeout) {
     EXPECT_EQ(std::chrono::milliseconds(0), timeout.per_try_timeout_);
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-timeout-ms"));
     EXPECT_EQ("15", headers.get_("x-envoy-expected-rq-timeout-ms"));
+    EXPECT_FALSE(headers.has("grpc-timeout"));
   }
   {
     NiceMock<MockRouteEntry> route;
@@ -2011,6 +2012,7 @@ TEST(RouterFilterUtilityTest, FinalTimeout) {
     EXPECT_EQ(std::chrono::milliseconds(0), timeout.per_try_timeout_);
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-timeout-ms"));
     EXPECT_EQ("10", headers.get_("x-envoy-expected-rq-timeout-ms"));
+    EXPECT_FALSE(headers.has("grpc-timeout"));
   }
   {
     NiceMock<MockRouteEntry> route;
@@ -2023,6 +2025,7 @@ TEST(RouterFilterUtilityTest, FinalTimeout) {
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-timeout-ms"));
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-per-try-timeout-ms"));
     EXPECT_EQ("15", headers.get_("x-envoy-expected-rq-timeout-ms"));
+    EXPECT_FALSE(headers.has("grpc-timeout"));
   }
   {
     NiceMock<MockRouteEntry> route;
@@ -2035,6 +2038,7 @@ TEST(RouterFilterUtilityTest, FinalTimeout) {
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-timeout-ms"));
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-per-try-timeout-ms"));
     EXPECT_EQ("5", headers.get_("x-envoy-expected-rq-timeout-ms"));
+    EXPECT_FALSE(headers.has("grpc-timeout"));
   }
   {
     NiceMock<MockRouteEntry> route;
@@ -2047,6 +2051,7 @@ TEST(RouterFilterUtilityTest, FinalTimeout) {
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-timeout-ms"));
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-per-try-timeout-ms"));
     EXPECT_EQ("7", headers.get_("x-envoy-expected-rq-timeout-ms"));
+    EXPECT_FALSE(headers.has("grpc-timeout"));
   }
   {
     NiceMock<MockRouteEntry> route;
@@ -2060,6 +2065,7 @@ TEST(RouterFilterUtilityTest, FinalTimeout) {
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-timeout-ms"));
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-per-try-timeout-ms"));
     EXPECT_EQ("5", headers.get_("x-envoy-expected-rq-timeout-ms"));
+    EXPECT_FALSE(headers.has("grpc-timeout"));
   }
   {
     NiceMock<MockRouteEntry> route;
@@ -2069,6 +2075,7 @@ TEST(RouterFilterUtilityTest, FinalTimeout) {
     FilterUtility::TimeoutData timeout = FilterUtility::finalTimeout(route, headers, true, true);
     EXPECT_EQ(std::chrono::milliseconds(0), timeout.global_timeout_);
     EXPECT_EQ(std::chrono::milliseconds(0), timeout.per_try_timeout_);
+    EXPECT_FALSE(headers.has("grpc-timeout"));
   }
   {
     NiceMock<MockRouteEntry> route;
@@ -2078,6 +2085,7 @@ TEST(RouterFilterUtilityTest, FinalTimeout) {
     FilterUtility::TimeoutData timeout = FilterUtility::finalTimeout(route, headers, true, true);
     EXPECT_EQ(std::chrono::milliseconds(10), timeout.global_timeout_);
     EXPECT_EQ(std::chrono::milliseconds(0), timeout.per_try_timeout_);
+    EXPECT_FALSE(headers.has("grpc-timeout"));
   }
   {
     NiceMock<MockRouteEntry> route;
@@ -2088,6 +2096,7 @@ TEST(RouterFilterUtilityTest, FinalTimeout) {
     FilterUtility::TimeoutData timeout = FilterUtility::finalTimeout(route, headers, true, true);
     EXPECT_EQ(std::chrono::milliseconds(1000), timeout.global_timeout_);
     EXPECT_EQ(std::chrono::milliseconds(0), timeout.per_try_timeout_);
+    EXPECT_EQ("1000m", headers.get_("grpc-timeout"));
   }
   {
     NiceMock<MockRouteEntry> route;

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -2098,6 +2098,7 @@ TEST(RouterFilterUtilityTest, FinalTimeout) {
     FilterUtility::TimeoutData timeout = FilterUtility::finalTimeout(route, headers, true, true);
     EXPECT_EQ(std::chrono::milliseconds(999), timeout.global_timeout_);
     EXPECT_EQ(std::chrono::milliseconds(0), timeout.per_try_timeout_);
+    EXPECT_EQ("999m", headers.get_("grpc-timeout"));
   }
   {
     NiceMock<MockRouteEntry> route;
@@ -2107,6 +2108,7 @@ TEST(RouterFilterUtilityTest, FinalTimeout) {
     FilterUtility::TimeoutData timeout = FilterUtility::finalTimeout(route, headers, true, true);
     EXPECT_EQ(std::chrono::milliseconds(999), timeout.global_timeout_);
     EXPECT_EQ(std::chrono::milliseconds(0), timeout.per_try_timeout_);
+    EXPECT_EQ("999m", headers.get_("grpc-timeout"));
   }
   {
     NiceMock<MockRouteEntry> route;
@@ -2120,6 +2122,7 @@ TEST(RouterFilterUtilityTest, FinalTimeout) {
     EXPECT_EQ(std::chrono::milliseconds(0), timeout.per_try_timeout_);
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-timeout-ms"));
     EXPECT_EQ("15", headers.get_("x-envoy-expected-rq-timeout-ms"));
+    EXPECT_EQ("15m", headers.get_("grpc-timeout"));
   }
   {
     NiceMock<MockRouteEntry> route;
@@ -2133,6 +2136,7 @@ TEST(RouterFilterUtilityTest, FinalTimeout) {
     EXPECT_EQ(std::chrono::milliseconds(0), timeout.per_try_timeout_);
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-timeout-ms"));
     EXPECT_EQ("1000", headers.get_("x-envoy-expected-rq-timeout-ms"));
+    EXPECT_EQ("1000m", headers.get_("grpc-timeout"));
   }
   {
     NiceMock<MockRouteEntry> route;
@@ -2148,6 +2152,7 @@ TEST(RouterFilterUtilityTest, FinalTimeout) {
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-timeout-ms"));
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-per-try-timeout-ms"));
     EXPECT_EQ("15", headers.get_("x-envoy-expected-rq-timeout-ms"));
+    EXPECT_EQ("15m", headers.get_("grpc-timeout"));
   }
   {
     NiceMock<MockRouteEntry> route;
@@ -2163,6 +2168,7 @@ TEST(RouterFilterUtilityTest, FinalTimeout) {
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-timeout-ms"));
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-per-try-timeout-ms"));
     EXPECT_EQ("5", headers.get_("x-envoy-expected-rq-timeout-ms"));
+    EXPECT_EQ("5m", headers.get_("grpc-timeout"));
   }
   {
     NiceMock<MockRouteEntry> route;
@@ -2178,6 +2184,7 @@ TEST(RouterFilterUtilityTest, FinalTimeout) {
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-timeout-ms"));
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-per-try-timeout-ms"));
     EXPECT_EQ("7", headers.get_("x-envoy-expected-rq-timeout-ms"));
+    EXPECT_EQ("7m", headers.get_("grpc-timeout"));
   }
   {
     NiceMock<MockRouteEntry> route;
@@ -2194,6 +2201,7 @@ TEST(RouterFilterUtilityTest, FinalTimeout) {
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-timeout-ms"));
     EXPECT_FALSE(headers.has("x-envoy-upstream-rq-per-try-timeout-ms"));
     EXPECT_EQ("5", headers.get_("x-envoy-expected-rq-timeout-ms"));
+    EXPECT_EQ("5m", headers.get_("grpc-timeout"));
   }
 }
 


### PR DESCRIPTION
This ensure that when the route is configured to take `grpc-timeout` into
account we adjust `grpc-timeout` to to equal the envoy expected request time.
This ensures that per try timeout is reflected in `grpc-timeout`.

Only modifies the `grpc-timeout` when one is provided and `max_grpc_timeout`
is configured.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Medium
*Testing*: Added asserts to existing unit tests
*Docs Changes*: n/a
*Release Notes*: n/a
Fixes #4628 