### PR TITLE
WIP stats: Make a new API for the fast-path getting a stat, so we can selectively check the TLS cache.

### DIFF
--- a/include/envoy/stats/scope.h
+++ b/include/envoy/stats/scope.h
@@ -41,10 +41,13 @@ public:
    */
   virtual void deliverHistogramToSinks(const Histogram& histogram, uint64_t value) PURE;
 
+  Counter& fastFindCounter(const std::string& name) { return counterHelper(name, true); }
+  Counter& counter(const std::string& name) { return counterHelper(name, false); }
+
   /**
    * @return a counter within the scope's namespace.
    */
-  virtual Counter& counter(const std::string& name) PURE;
+  virtual Counter& counterHelper(const std::string& name, bool data_path) PURE;
 
   /**
    * @return a gauge within the scope's namespace.

--- a/source/common/http/codes.cc
+++ b/source/common/http/codes.cc
@@ -18,10 +18,12 @@ namespace Http {
 void CodeUtility::chargeBasicResponseStat(Stats::Scope& scope, const std::string& prefix,
                                           Code response_code) {
   // Build a dynamic stat for the response code and increment it.
-  scope.counter(fmt::format("{}upstream_rq_completed", prefix)).inc();
-  scope.counter(fmt::format("{}upstream_rq_{}", prefix, groupStringForResponseCode(response_code)))
+  scope.fastFindCounter(fmt::format("{}upstream_rq_completed", prefix)).inc();
+  scope
+      .fastFindCounter(
+          fmt::format("{}upstream_rq_{}", prefix, groupStringForResponseCode(response_code)))
       .inc();
-  scope.counter(fmt::format("{}upstream_rq_{}", prefix, enumToInt(response_code))).inc();
+  scope.fastFindCounter(fmt::format("{}upstream_rq_{}", prefix, enumToInt(response_code))).inc();
 }
 
 void CodeUtility::chargeResponseStat(const ResponseStatInfo& info) {
@@ -32,63 +34,70 @@ void CodeUtility::chargeResponseStat(const ResponseStatInfo& info) {
 
   // If the response is from a canary, also create canary stats.
   if (info.upstream_canary_) {
-    info.cluster_scope_.counter(fmt::format("{}canary.upstream_rq_completed", info.prefix_)).inc();
-    info.cluster_scope_.counter(fmt::format("{}canary.upstream_rq_{}", info.prefix_, group_string))
+    info.cluster_scope_.fastFindCounter(fmt::format("{}canary.upstream_rq_completed", info.prefix_))
         .inc();
-    info.cluster_scope_.counter(fmt::format("{}canary.upstream_rq_{}", info.prefix_, response_code))
+    info.cluster_scope_
+        .fastFindCounter(fmt::format("{}canary.upstream_rq_{}", info.prefix_, group_string))
+        .inc();
+    info.cluster_scope_
+        .fastFindCounter(fmt::format("{}canary.upstream_rq_{}", info.prefix_, response_code))
         .inc();
   }
 
   // Split stats into external vs. internal.
   if (info.internal_request_) {
-    info.cluster_scope_.counter(fmt::format("{}internal.upstream_rq_completed", info.prefix_))
+    info.cluster_scope_
+        .fastFindCounter(fmt::format("{}internal.upstream_rq_completed", info.prefix_))
         .inc();
     info.cluster_scope_
-        .counter(fmt::format("{}internal.upstream_rq_{}", info.prefix_, group_string))
+        .fastFindCounter(fmt::format("{}internal.upstream_rq_{}", info.prefix_, group_string))
         .inc();
     info.cluster_scope_
-        .counter(fmt::format("{}internal.upstream_rq_{}", info.prefix_, response_code))
+        .fastFindCounter(fmt::format("{}internal.upstream_rq_{}", info.prefix_, response_code))
         .inc();
   } else {
-    info.cluster_scope_.counter(fmt::format("{}external.upstream_rq_completed", info.prefix_))
+    info.cluster_scope_
+        .fastFindCounter(fmt::format("{}external.upstream_rq_completed", info.prefix_))
         .inc();
     info.cluster_scope_
-        .counter(fmt::format("{}external.upstream_rq_{}", info.prefix_, group_string))
+        .fastFindCounter(fmt::format("{}external.upstream_rq_{}", info.prefix_, group_string))
         .inc();
     info.cluster_scope_
-        .counter(fmt::format("{}external.upstream_rq_{}", info.prefix_, response_code))
+        .fastFindCounter(fmt::format("{}external.upstream_rq_{}", info.prefix_, response_code))
         .inc();
   }
 
   // Handle request virtual cluster.
   if (!info.request_vcluster_name_.empty()) {
     info.global_scope_
-        .counter(fmt::format("vhost.{}.vcluster.{}.upstream_rq_completed", info.request_vhost_name_,
-                             info.request_vcluster_name_))
+        .fastFindCounter(fmt::format("vhost.{}.vcluster.{}.upstream_rq_completed",
+                                     info.request_vhost_name_, info.request_vcluster_name_))
         .inc();
     info.global_scope_
-        .counter(fmt::format("vhost.{}.vcluster.{}.upstream_rq_{}", info.request_vhost_name_,
-                             info.request_vcluster_name_, group_string))
+        .fastFindCounter(fmt::format("vhost.{}.vcluster.{}.upstream_rq_{}",
+                                     info.request_vhost_name_, info.request_vcluster_name_,
+                                     group_string))
         .inc();
     info.global_scope_
-        .counter(fmt::format("vhost.{}.vcluster.{}.upstream_rq_{}", info.request_vhost_name_,
-                             info.request_vcluster_name_, response_code))
+        .fastFindCounter(fmt::format("vhost.{}.vcluster.{}.upstream_rq_{}",
+                                     info.request_vhost_name_, info.request_vcluster_name_,
+                                     response_code))
         .inc();
   }
 
   // Handle per zone stats.
   if (!info.from_zone_.empty() && !info.to_zone_.empty()) {
     info.cluster_scope_
-        .counter(fmt::format("{}zone.{}.{}.upstream_rq_completed", info.prefix_, info.from_zone_,
-                             info.to_zone_))
+        .fastFindCounter(fmt::format("{}zone.{}.{}.upstream_rq_completed", info.prefix_,
+                                     info.from_zone_, info.to_zone_))
         .inc();
     info.cluster_scope_
-        .counter(fmt::format("{}zone.{}.{}.upstream_rq_{}", info.prefix_, info.from_zone_,
-                             info.to_zone_, group_string))
+        .fastFindCounter(fmt::format("{}zone.{}.{}.upstream_rq_{}", info.prefix_, info.from_zone_,
+                                     info.to_zone_, group_string))
         .inc();
     info.cluster_scope_
-        .counter(fmt::format("{}zone.{}.{}.upstream_rq_{}", info.prefix_, info.from_zone_,
-                             info.to_zone_, response_code))
+        .fastFindCounter(fmt::format("{}zone.{}.{}.upstream_rq_{}", info.prefix_, info.from_zone_,
+                                     info.to_zone_, response_code))
         .inc();
   }
 }

--- a/source/common/stats/isolated_store_impl.cc
+++ b/source/common/stats/isolated_store_impl.cc
@@ -36,7 +36,9 @@ struct IsolatedScopeImpl : public Scope {
     return ScopePtr{new IsolatedScopeImpl(parent_, prefix_ + name)};
   }
   void deliverHistogramToSinks(const Histogram&, uint64_t) override {}
-  Counter& counter(const std::string& name) override { return parent_.counter(prefix_ + name); }
+  Counter& counterHelper(const std::string& name, bool data_path_critical) override {
+    return parent_.counterHelper(prefix_ + name, data_path_critical);
+  }
   Gauge& gauge(const std::string& name) override { return parent_.gauge(prefix_ + name); }
   Histogram& histogram(const std::string& name) override {
     return parent_.histogram(prefix_ + name);

--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -57,7 +57,9 @@ public:
   IsolatedStoreImpl();
 
   // Stats::Scope
-  Counter& counter(const std::string& name) override { return counters_.get(name); }
+  Counter& counterHelper(const std::string& name, bool /*data_path_critical*/) override {
+    return counters_.get(name);
+  }
   ScopePtr createScope(const std::string& name) override;
   void deliverHistogramToSinks(const Histogram&, uint64_t) override {}
   Gauge& gauge(const std::string& name) override { return gauges_.get(name); }

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -229,7 +229,8 @@ StatType& ThreadLocalStoreImpl::ScopeImpl::safeMakeStat(
   return *central_ref;
 }
 
-Counter& ThreadLocalStoreImpl::ScopeImpl::counter(const std::string& name) {
+Counter& ThreadLocalStoreImpl::ScopeImpl::counterHelper(const std::string& name,
+                                                        bool data_path_critical) {
   // Determine the final name based on the prefix and the passed name.
   std::string final_name = prefix_ + name;
 
@@ -237,7 +238,7 @@ Counter& ThreadLocalStoreImpl::ScopeImpl::counter(const std::string& name) {
   // if we don't have TLS initialized currently. The de-referenced pointer might be null if there
   // is no cache entry.
   CounterSharedPtr* tls_ref = nullptr;
-  if (!parent_.shutting_down_ && parent_.tls_) {
+  if (data_path_critical && !parent_.shutting_down_ && parent_.tls_) {
     tls_ref =
         &parent_.tls_->getTyped<TlsCache>().scope_cache_[this->scope_id_].counters_[final_name];
   }

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -180,7 +180,9 @@ public:
   ~ThreadLocalStoreImpl();
 
   // Stats::Scope
-  Counter& counter(const std::string& name) override { return default_scope_->counter(name); }
+  Counter& counterHelper(const std::string& name, bool data_path_critical) override {
+    return default_scope_->counterHelper(name, data_path_critical);
+  }
   ScopePtr createScope(const std::string& name) override;
   void deliverHistogramToSinks(const Histogram& histogram, uint64_t value) override {
     return default_scope_->deliverHistogramToSinks(histogram, value);
@@ -231,7 +233,7 @@ private:
     ~ScopeImpl();
 
     // Stats::Scope
-    Counter& counter(const std::string& name) override;
+    Counter& counterHelper(const std::string& name, bool data_path_critical) override;
     ScopePtr createScope(const std::string& name) override {
       return parent_.createScope(prefix_ + name);
     }

--- a/test/common/http/user_agent_test.cc
+++ b/test/common/http/user_agent_test.cc
@@ -23,9 +23,10 @@ TEST(UserAgentTest, All) {
   Stats::Timespan span(original_histogram, time_system);
 
   EXPECT_CALL(stat_store.counter_, inc()).Times(5);
-  EXPECT_CALL(stat_store, counter("test.user_agent.ios.downstream_cx_total"));
-  EXPECT_CALL(stat_store, counter("test.user_agent.ios.downstream_rq_total"));
-  EXPECT_CALL(stat_store, counter("test.user_agent.ios.downstream_cx_destroy_remote_active_rq"));
+  EXPECT_CALL(stat_store, counterHelper("test.user_agent.ios.downstream_cx_total", false));
+  EXPECT_CALL(stat_store, counterHelper("test.user_agent.ios.downstream_rq_total", false));
+  EXPECT_CALL(stat_store,
+              counterHelper("test.user_agent.ios.downstream_cx_destroy_remote_active_rq", false));
   EXPECT_CALL(stat_store, histogram("test.user_agent.ios.downstream_cx_length_ms"));
   EXPECT_CALL(
       stat_store,
@@ -40,10 +41,11 @@ TEST(UserAgentTest, All) {
     ua.completeConnectionLength(span);
   }
 
-  EXPECT_CALL(stat_store, counter("test.user_agent.android.downstream_cx_total"));
-  EXPECT_CALL(stat_store, counter("test.user_agent.android.downstream_rq_total"));
-  EXPECT_CALL(stat_store,
-              counter("test.user_agent.android.downstream_cx_destroy_remote_active_rq"));
+  EXPECT_CALL(stat_store, counterHelper("test.user_agent.android.downstream_cx_total", false));
+  EXPECT_CALL(stat_store, counterHelper("test.user_agent.android.downstream_rq_total", false));
+  EXPECT_CALL(
+      stat_store,
+      counterHelper("test.user_agent.android.downstream_cx_destroy_remote_active_rq", false));
   EXPECT_CALL(stat_store, histogram("test.user_agent.android.downstream_cx_length_ms"));
   EXPECT_CALL(
       stat_store,

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -213,7 +213,13 @@ TEST_F(StatsThreadLocalStoreTest, Tls) {
 
   EXPECT_EQ(2UL, store_->counters().size());
   EXPECT_EQ(&c1, TestUtility::findCounter(*store_, "c1").get());
-  EXPECT_EQ(3L, TestUtility::findCounter(*store_, "c1").use_count());
+  EXPECT_EQ(2L, TestUtility::findCounter(*store_, "c1").use_count());
+
+  // Now reference "c1" as a fast-lookup, which will force population of
+  // the TLS cache.
+  EXPECT_EQ(&c1, &store_->fastFindCounter("c1"));
+  EXPECT_EQ(3L, TestUtility::findCounter(*store_, "c1").use_count()); // 3rd ref for TLS cache.
+
   EXPECT_EQ(1UL, store_->gauges().size());
   EXPECT_EQ(&g1, store_->gauges().front().get()); // front() ok when size()==1
   EXPECT_EQ(3L, store_->gauges().front().use_count());
@@ -504,7 +510,7 @@ TEST_F(StatsThreadLocalStoreTest, ShuttingDown) {
   store_->gauge("g2");
 
   // c1, g1 should have a thread local ref, but c2, g2 should not.
-  EXPECT_EQ(3L, TestUtility::findCounter(*store_, "c1").use_count());
+  EXPECT_EQ(2L, TestUtility::findCounter(*store_, "c1").use_count());
   EXPECT_EQ(3L, TestUtility::findGauge(*store_, "g1").use_count());
   EXPECT_EQ(2L, TestUtility::findCounter(*store_, "c2").use_count());
   EXPECT_EQ(2L, TestUtility::findGauge(*store_, "g2").use_count());

--- a/test/extensions/filters/http/dynamo/dynamo_filter_test.cc
+++ b/test/extensions/filters/http/dynamo/dynamo_filter_test.cc
@@ -63,12 +63,12 @@ TEST_F(DynamoFilterTest, operatorPresent) {
             filter_->encode100ContinueHeaders(continue_headers));
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}};
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation_missing")).Times(0);
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.table_missing"));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.operation_missing", false)).Times(0);
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.table_missing", false));
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.Get.upstream_rq_total_2xx"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.Get.upstream_rq_total_200"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.Get.upstream_rq_total"));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.operation.Get.upstream_rq_total_2xx", false));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.operation.Get.upstream_rq_total_200", false));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.operation.Get.upstream_rq_total", false));
 
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.Get.upstream_rq_time_2xx"));
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.Get.upstream_rq_time_200"));
@@ -101,7 +101,7 @@ TEST_F(DynamoFilterTest, jsonBodyNotWellFormed) {
   buffer.add("test", 4);
   buffer.add("test2", 5);
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.invalid_req_body"));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.invalid_req_body", false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer, true));
 }
 
@@ -112,8 +112,8 @@ TEST_F(DynamoFilterTest, bothOperationAndTableIncorrect) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers, true));
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation_missing"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.table_missing"));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.operation_missing", false));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.table_missing", false));
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, true));
@@ -126,8 +126,8 @@ TEST_F(DynamoFilterTest, handleErrorTypeTableMissing) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers, true));
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation_missing"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.table_missing"));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.operation_missing", false));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.table_missing", false));
 
   Http::TestHeaderMapImpl response_headers{{":status", "400"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
@@ -137,16 +137,16 @@ TEST_F(DynamoFilterTest, handleErrorTypeTableMissing) {
   std::string internal_error =
       "{\"__type\":\"com.amazonaws.dynamodb.v20120810#ValidationException\"}";
   error_data->add(internal_error);
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.error.no_table.ValidationException"));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.error.no_table.ValidationException", false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(*error_data, true));
 
   error_data->add("}", 1);
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer,
             filter_->encodeData(*error_data, false));
   EXPECT_CALL(encoder_callbacks_, encodingBuffer()).WillRepeatedly(Return(error_data.get()));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.invalid_resp_body"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation_missing"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.table_missing"));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.invalid_resp_body", false));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.operation_missing", false));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.table_missing", false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(request_headers));
 }
 
@@ -171,11 +171,13 @@ TEST_F(DynamoFilterTest, HandleErrorTypeTablePresent) {
   std::string internal_error =
       "{\"__type\":\"com.amazonaws.dynamodb.v20120810#ValidationException\"}";
   error_data.add(internal_error);
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.error.locations.ValidationException"));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.error.locations.ValidationException", false));
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.GetItem.upstream_rq_total"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.GetItem.upstream_rq_total_4xx"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.GetItem.upstream_rq_total_400"));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.operation.GetItem.upstream_rq_total", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.GetItem.upstream_rq_total_4xx", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.GetItem.upstream_rq_total_400", false));
 
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.GetItem.upstream_rq_time"));
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.GetItem.upstream_rq_time_4xx"));
@@ -193,9 +195,11 @@ TEST_F(DynamoFilterTest, HandleErrorTypeTablePresent) {
       deliverHistogramToSinks(
           Property(&Stats::Metric::name, "prefix.dynamodb.operation.GetItem.upstream_rq_time"), _));
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.table.locations.upstream_rq_total_4xx"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.table.locations.upstream_rq_total_400"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.table.locations.upstream_rq_total"));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.table.locations.upstream_rq_total_4xx", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.table.locations.upstream_rq_total_400", false));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.table.locations.upstream_rq_total", false));
 
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.table.locations.upstream_rq_time_4xx"));
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.table.locations.upstream_rq_time_400"));
@@ -240,11 +244,14 @@ TEST_F(DynamoFilterTest, BatchMultipleTables) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_headers));
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}};
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.multiple_tables"));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.multiple_tables", false));
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_2xx"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_200"));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_2xx", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_200", false));
 
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.BatchGetItem.upstream_rq_time"));
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.BatchGetItem.upstream_rq_time_2xx"));
@@ -289,11 +296,14 @@ TEST_F(DynamoFilterTest, BatchMultipleTablesUnprocessedKeys) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_headers));
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}};
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.multiple_tables"));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.multiple_tables", false));
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_2xx"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_200"));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_2xx", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_200", false));
 
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.BatchGetItem.upstream_rq_time"));
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.BatchGetItem.upstream_rq_time_2xx"));
@@ -326,8 +336,10 @@ TEST_F(DynamoFilterTest, BatchMultipleTablesUnprocessedKeys) {
 )EOF";
   response_data->add(response_content);
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.error.table_1.BatchFailureUnprocessedKeys"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.error.table_2.BatchFailureUnprocessedKeys"));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.error.table_1.BatchFailureUnprocessedKeys", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.error.table_2.BatchFailureUnprocessedKeys", false));
   EXPECT_CALL(encoder_callbacks_, encodingBuffer()).WillRepeatedly(Return(response_data.get()));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(empty_data, true));
 }
@@ -356,11 +368,14 @@ TEST_F(DynamoFilterTest, BatchMultipleTablesNoUnprocessedKeys) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_headers));
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}};
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.multiple_tables"));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.multiple_tables", false));
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_2xx"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_200"));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_2xx", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_200", false));
 
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.BatchGetItem.upstream_rq_time"));
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.BatchGetItem.upstream_rq_time_2xx"));
@@ -419,11 +434,14 @@ TEST_F(DynamoFilterTest, BatchMultipleTablesInvalidResponseBody) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_headers));
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}};
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.multiple_tables"));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.multiple_tables", false));
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_2xx"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_200"));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_2xx", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_200", false));
 
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.BatchGetItem.upstream_rq_time"));
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.BatchGetItem.upstream_rq_time_2xx"));
@@ -457,7 +475,7 @@ TEST_F(DynamoFilterTest, BatchMultipleTablesInvalidResponseBody) {
   response_data->add(response_content);
   response_data->add("}", 1);
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.invalid_resp_body"));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.invalid_resp_body", false));
   EXPECT_CALL(encoder_callbacks_, encodingBuffer()).WillOnce(Return(response_data.get()));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(empty_data, true));
 }
@@ -478,9 +496,11 @@ TEST_F(DynamoFilterTest, bothOperationAndTableCorrect) {
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, true));
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.GetItem.upstream_rq_total_2xx"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.GetItem.upstream_rq_total_200"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.GetItem.upstream_rq_total"));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.GetItem.upstream_rq_total_2xx", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.GetItem.upstream_rq_total_200", false));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.operation.GetItem.upstream_rq_total", false));
 
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.GetItem.upstream_rq_time_2xx"));
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.GetItem.upstream_rq_time_200"));
@@ -498,9 +518,11 @@ TEST_F(DynamoFilterTest, bothOperationAndTableCorrect) {
       deliverHistogramToSinks(
           Property(&Stats::Metric::name, "prefix.dynamodb.operation.GetItem.upstream_rq_time"), _));
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.table.locations.upstream_rq_total_2xx"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.table.locations.upstream_rq_total_200"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.table.locations.upstream_rq_total"));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.table.locations.upstream_rq_total_2xx", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.table.locations.upstream_rq_total_200", false));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.table.locations.upstream_rq_total", false));
 
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.table.locations.upstream_rq_time_2xx"));
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.table.locations.upstream_rq_time_200"));
@@ -525,7 +547,7 @@ TEST_F(DynamoFilterTest, bothOperationAndTableCorrect) {
 TEST_F(DynamoFilterTest, operatorPresentRuntimeDisabled) {
   setup(false);
 
-  EXPECT_CALL(stats_, counter(_)).Times(0);
+  EXPECT_CALL(stats_, counterHelper(_, false)).Times(0);
   EXPECT_CALL(stats_, deliverHistogramToSinks(_, _)).Times(0);
 
   Http::TestHeaderMapImpl request_headers{{"x-amz-target", "version.operator"},
@@ -553,9 +575,11 @@ TEST_F(DynamoFilterTest, PartitionIdStats) {
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, true));
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.GetItem.upstream_rq_total_2xx"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.GetItem.upstream_rq_total_200"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.GetItem.upstream_rq_total"));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.GetItem.upstream_rq_total_2xx", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.GetItem.upstream_rq_total_200", false));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.operation.GetItem.upstream_rq_total", false));
 
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.GetItem.upstream_rq_time_2xx"));
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.GetItem.upstream_rq_time_200"));
@@ -573,9 +597,11 @@ TEST_F(DynamoFilterTest, PartitionIdStats) {
       deliverHistogramToSinks(
           Property(&Stats::Metric::name, "prefix.dynamodb.operation.GetItem.upstream_rq_time"), _));
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.table.locations.upstream_rq_total_2xx"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.table.locations.upstream_rq_total_200"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.table.locations.upstream_rq_total"));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.table.locations.upstream_rq_total_2xx", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.table.locations.upstream_rq_total_200", false));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.table.locations.upstream_rq_total", false));
 
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.table.locations.upstream_rq_time_2xx"));
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.table.locations.upstream_rq_time_200"));
@@ -594,10 +620,12 @@ TEST_F(DynamoFilterTest, PartitionIdStats) {
           Property(&Stats::Metric::name, "prefix.dynamodb.table.locations.upstream_rq_time"), _));
 
   EXPECT_CALL(stats_,
-              counter("prefix.dynamodb.table.locations.capacity.GetItem.__partition_id=ition_1"))
+              counterHelper(
+                  "prefix.dynamodb.table.locations.capacity.GetItem.__partition_id=ition_1", false))
       .Times(1);
   EXPECT_CALL(stats_,
-              counter("prefix.dynamodb.table.locations.capacity.GetItem.__partition_id=ition_2"))
+              counterHelper(
+                  "prefix.dynamodb.table.locations.capacity.GetItem.__partition_id=ition_2", false))
       .Times(1);
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}};
@@ -644,11 +672,14 @@ TEST_F(DynamoFilterTest, NoPartitionIdStatsForMultipleTables) {
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(*buffer, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_headers));
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.multiple_tables"));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.multiple_tables", false));
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_2xx"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_200"));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_2xx", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_200", false));
 
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.BatchGetItem.upstream_rq_time"));
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.BatchGetItem.upstream_rq_time_2xx"));
@@ -668,11 +699,13 @@ TEST_F(DynamoFilterTest, NoPartitionIdStatsForMultipleTables) {
 
   EXPECT_CALL(
       stats_,
-      counter("prefix.dynamodb.table.locations.capacity.BatchGetItem.__partition_id=ition_1"))
+      counterHelper("prefix.dynamodb.table.locations.capacity.BatchGetItem.__partition_id=ition_1",
+                    false))
       .Times(0);
   EXPECT_CALL(
       stats_,
-      counter("prefix.dynamodb.table.locations.capacity.BatchGetItem.__partition_id=ition_2"))
+      counterHelper("prefix.dynamodb.table.locations.capacity.BatchGetItem.__partition_id=ition_2",
+                    false))
       .Times(0);
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}};
@@ -718,11 +751,14 @@ TEST_F(DynamoFilterTest, PartitionIdStatsForSingleTableBatchOperation) {
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(*buffer, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_headers));
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.multiple_tables")).Times(0);
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.multiple_tables", false)).Times(0);
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_2xx"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_200"));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_2xx", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.operation.BatchGetItem.upstream_rq_total_200", false));
 
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.BatchGetItem.upstream_rq_time"));
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.operation.BatchGetItem.upstream_rq_time_2xx"));
@@ -740,9 +776,11 @@ TEST_F(DynamoFilterTest, PartitionIdStatsForSingleTableBatchOperation) {
                                    "prefix.dynamodb.operation.BatchGetItem.upstream_rq_time"),
                           _));
 
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.table.locations.upstream_rq_total_2xx"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.table.locations.upstream_rq_total_200"));
-  EXPECT_CALL(stats_, counter("prefix.dynamodb.table.locations.upstream_rq_total"));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.table.locations.upstream_rq_total_2xx", false));
+  EXPECT_CALL(stats_,
+              counterHelper("prefix.dynamodb.table.locations.upstream_rq_total_200", false));
+  EXPECT_CALL(stats_, counterHelper("prefix.dynamodb.table.locations.upstream_rq_total", false));
 
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.table.locations.upstream_rq_time_2xx"));
   EXPECT_CALL(stats_, histogram("prefix.dynamodb.table.locations.upstream_rq_time_200"));
@@ -762,11 +800,13 @@ TEST_F(DynamoFilterTest, PartitionIdStatsForSingleTableBatchOperation) {
 
   EXPECT_CALL(
       stats_,
-      counter("prefix.dynamodb.table.locations.capacity.BatchGetItem.__partition_id=ition_1"))
+      counterHelper("prefix.dynamodb.table.locations.capacity.BatchGetItem.__partition_id=ition_1",
+                    false))
       .Times(1);
   EXPECT_CALL(
       stats_,
-      counter("prefix.dynamodb.table.locations.capacity.BatchGetItem.__partition_id=ition_2"))
+      counterHelper("prefix.dynamodb.table.locations.capacity.BatchGetItem.__partition_id=ition_2",
+                    false))
       .Times(1);
 
   Http::TestHeaderMapImpl response_headers{{":status", "200"}};

--- a/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
+++ b/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
@@ -67,8 +67,8 @@ TEST_F(IpTaggingFilterTest, InternalRequest) {
   EXPECT_CALL(filter_callbacks_.stream_info_, downstreamRemoteAddress())
       .WillOnce(ReturnRef(remote_address));
 
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.internal_request.hit")).Times(1);
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.total")).Times(1);
+  EXPECT_CALL(stats_, counterHelper("prefix.ip_tagging.internal_request.hit", false)).Times(1);
+  EXPECT_CALL(stats_, counterHelper("prefix.ip_tagging.total", false)).Times(1);
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
   EXPECT_EQ("internal_request", request_headers.get_(Http::Headers::get().EnvoyIpTags));
@@ -94,8 +94,8 @@ ip_tags:
   EXPECT_EQ(FilterRequestType::EXTERNAL, config_->requestType());
   Http::TestHeaderMapImpl request_headers;
 
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.total")).Times(1);
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.external_request.hit")).Times(1);
+  EXPECT_CALL(stats_, counterHelper("prefix.ip_tagging.total", false)).Times(1);
+  EXPECT_CALL(stats_, counterHelper("prefix.ip_tagging.external_request.hit", false)).Times(1);
 
   Network::Address::InstanceConstSharedPtr remote_address =
       Network::Utility::parseInternetAddress("1.2.3.4");
@@ -130,9 +130,9 @@ ip_tags:
   EXPECT_EQ(FilterRequestType::BOTH, config_->requestType());
   Http::TestHeaderMapImpl request_headers{{"x-envoy-internal", "true"}};
 
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.total")).Times(2);
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.internal_request.hit")).Times(1);
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.external_request.hit")).Times(1);
+  EXPECT_CALL(stats_, counterHelper("prefix.ip_tagging.total", false)).Times(2);
+  EXPECT_CALL(stats_, counterHelper("prefix.ip_tagging.internal_request.hit", false)).Times(1);
+  EXPECT_CALL(stats_, counterHelper("prefix.ip_tagging.external_request.hit", false)).Times(1);
 
   Network::Address::InstanceConstSharedPtr remote_address =
       Network::Utility::parseInternetAddress("1.2.3.5");
@@ -159,8 +159,8 @@ TEST_F(IpTaggingFilterTest, NoHits) {
       Network::Utility::parseInternetAddress("10.2.3.5");
   EXPECT_CALL(filter_callbacks_.stream_info_, downstreamRemoteAddress())
       .WillOnce(ReturnRef(remote_address));
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.no_hit")).Times(1);
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.total")).Times(1);
+  EXPECT_CALL(stats_, counterHelper("prefix.ip_tagging.no_hit", false)).Times(1);
+  EXPECT_CALL(stats_, counterHelper("prefix.ip_tagging.total", false)).Times(1);
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
   EXPECT_FALSE(request_headers.has(Http::Headers::get().EnvoyIpTags));
@@ -207,9 +207,9 @@ ip_tags:
   EXPECT_CALL(filter_callbacks_.stream_info_, downstreamRemoteAddress())
       .WillOnce(ReturnRef(remote_address));
 
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.total")).Times(1);
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.internal_request.hit")).Times(1);
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.duplicate_request.hit")).Times(1);
+  EXPECT_CALL(stats_, counterHelper("prefix.ip_tagging.total", false)).Times(1);
+  EXPECT_CALL(stats_, counterHelper("prefix.ip_tagging.internal_request.hit", false)).Times(1);
+  EXPECT_CALL(stats_, counterHelper("prefix.ip_tagging.duplicate_request.hit", false)).Times(1);
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 

--- a/test/extensions/stats_sinks/hystrix/hystrix_test.cc
+++ b/test/extensions/stats_sinks/hystrix/hystrix_test.cc
@@ -55,7 +55,8 @@ public:
   // Attach the counter to cluster_stat_scope and set default value.
   void setCounterForTest(NiceMock<Stats::MockCounter>& counter, std::string counter_name) {
     counter.name_ = counter_name;
-    ON_CALL(cluster_stats_scope_, counter(counter_name)).WillByDefault(ReturnRef(counter));
+    ON_CALL(cluster_stats_scope_, counterHelper(counter_name, false))
+        .WillByDefault(ReturnRef(counter));
   }
 
   void setCountersToZero() {

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -130,7 +130,7 @@ public:
     wrapped_scope_->deliverHistogramToSinks(histogram, value);
   }
 
-  Counter& counter(const std::string& name) override {
+  Counter& counterHelper(const std::string& name, bool /* data_path_critical */) override {
     Thread::LockGuard lock(lock_);
     return wrapped_scope_->counter(name);
   }
@@ -161,7 +161,7 @@ class TestIsolatedStoreImpl : public StoreRoot {
 public:
   TestIsolatedStoreImpl() : source_(*this) {}
   // Stats::Scope
-  Counter& counter(const std::string& name) override {
+  Counter& counterHelper(const std::string& name, bool /* data_path_critical */) override {
     Thread::LockGuard lock(lock_);
     return store_.counter(name);
   }

--- a/test/mocks/stats/mocks.cc
+++ b/test/mocks/stats/mocks.cc
@@ -69,7 +69,7 @@ MockSink::MockSink() {}
 MockSink::~MockSink() {}
 
 MockStore::MockStore() {
-  ON_CALL(*this, counter(_)).WillByDefault(ReturnRef(counter_));
+  ON_CALL(*this, counterHelper(_, _)).WillByDefault(ReturnRef(counter_));
   ON_CALL(*this, histogram(_)).WillByDefault(Invoke([this](const std::string& name) -> Histogram& {
     auto* histogram = new NiceMock<MockHistogram>;
     histogram->name_ = name;

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -149,7 +149,7 @@ public:
   ScopePtr createScope(const std::string& name) override { return ScopePtr{createScope_(name)}; }
 
   MOCK_METHOD2(deliverHistogramToSinks, void(const Histogram& histogram, uint64_t value));
-  MOCK_METHOD1(counter, Counter&(const std::string&));
+  MOCK_METHOD2(counterHelper, Counter&(const std::string&, bool));
   MOCK_CONST_METHOD0(counters, std::vector<CounterSharedPtr>());
   MOCK_METHOD1(createScope_, Scope*(const std::string& name));
   MOCK_METHOD1(gauge, Gauge&(const std::string&));


### PR DESCRIPTION
*Description*: The TLS stats cache can be expensive in memory, but many stats are looked up at init time rather than while processing requests. This is an initial-cut at a PR that attempts to split those out. Follow-up commits will add temp infrastructure to validate during tests that slow lookups are not done in the data path. Partially addresses https://github.com/envoyproxy/envoy/issues/4196 .
*Risk Level*: medium -- a slow lookup in the data-path may impact performance
*Testing*: //test/...
*Docs Changes*: n/a
*Release Notes*: n/a

