### PR TITLE
bazel: Fix Bazel fetch commands by binding python_headers

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -520,6 +520,13 @@ def _com_google_protobuf():
         actual = "@com_google_protobuf_cc//:protoc",
     )
 
+    # Needed for `bazel fetch` to work with @com_google_protobuf
+    # https://github.com/google/protobuf/blob/v3.6.1/util/python/BUILD#L6-L9
+    native.bind(
+        name = "python_headers",
+        actual = "@com_google_protobuf//util/python:python_headers",
+    )
+
 def _com_github_grpc_grpc():
     _repository_impl("com_github_grpc_grpc")
 


### PR DESCRIPTION
*Description*:
Fixes `bazel fetch` commands. Without this Bazel complains about not having Python headers, e.g.:
```
ERROR: /private/var/tmp/_bazel_jamie/5f16a53f51e323f3f5ce6ab815970ed8/external/com_google_protobuf/BUILD:662:1: no such target '//external:python_headers': target 'python_headers' not declared in package 'external' defined by /Users/jamie/ws/relay/envoy/WORKSPACE and referenced by '@com_google_protobuf//:python/google/protobuf/internal/_api_implementation.so'
```

A similar change was made to `data-plane-api` a while ago: envoyproxy/data-plane-api#471.

*Risk Level*:
Low

*Testing*:
Ran both `bazel fetch //source/...` and `bazel fetch @envoy_api//envoy/...` successfully.

*Docs Changes*:
None

*Release Notes*:
None worth mentioning.