### PR TITLE
docs: add an entry to FAQs about circuit breakers

### DIFF
--- a/docs/root/faq/disable_circuit_breaking.rst
+++ b/docs/root/faq/disable_circuit_breaking.rst
@@ -1,0 +1,7 @@
+Is there a way to disable circuit breaking?
+===========================================
+
+Envoy comes with :ref:`certain defaults <envoy_api_msg_cluster.CircuitBreakers.Thresholds>`
+for each kind of circuit breaking. Currently, there isn't a switch to turn
+circuit breaking off completely; however, you could achieve a similar behavior
+by setting these thresholds very high, for example, to `std::numeric_limits<uint32_t>::max()`.

--- a/docs/root/faq/disable_circuit_breaking.rst
+++ b/docs/root/faq/disable_circuit_breaking.rst
@@ -5,3 +5,16 @@ Envoy comes with :ref:`certain defaults <envoy_api_msg_cluster.CircuitBreakers.T
 for each kind of circuit breaking. Currently, there isn't a switch to turn
 circuit breaking off completely; however, you could achieve a similar behavior
 by setting these thresholds very high, for example, to `std::numeric_limits<uint32_t>::max()`.
+
+Following is a sample configuration that tries to effectively disable circuit
+breaking by setting the thresholds to a value of `1000000000`.
+
+.. code-block:: yaml
+
+  circuit_breakers:
+    thresholds:
+      priority: HIGH
+      max_connections: 1000000000
+      max_pending_requests: 1000000000
+      max_requests: 1000000000
+      max_retries: 1000000000

--- a/docs/root/faq/disable_circuit_breaking.rst
+++ b/docs/root/faq/disable_circuit_breaking.rst
@@ -6,8 +6,8 @@ for each kind of circuit breaking. Currently, there isn't a switch to turn
 circuit breaking off completely; however, you could achieve a similar behavior
 by setting these thresholds very high, for example, to `std::numeric_limits<uint32_t>::max()`.
 
-Following is a sample configuration that tries to effectively disable circuit
-breaking by setting the thresholds to a value of `1000000000`.
+Following is a sample configuration that tries to effectively disable all kinds
+of circuit breaking by setting the thresholds to a value of `1000000000`.
 
 .. code-block:: yaml
 

--- a/docs/root/faq/overview.rst
+++ b/docs/root/faq/overview.rst
@@ -13,3 +13,4 @@ FAQ
   zipkin_tracing
   lb_panic_threshold
   concurrency_lb
+  disable_circuit_breaking


### PR DESCRIPTION
*Description*: Currently, there isn't a way to turn circuit breaking off completely; however, as a workaround, users can set thresholds very high, which effectively produces similar behavior to that of a system without circuit breakers. This PR adds an entry to the FAQs section about the same.
*Risk Level*: Low
*Testing*: N/A
*Docs Changes*: Added an entry under FAQs
*Release Notes*: N/A

Fixes #4337. Also, see #4520.

Signed-off-by: Venil Noronha <veniln@vmware.com>