### PR TITLE
router: add grpc-retry-on "internal" policy

### DIFF
--- a/docs/root/configuration/http_filters/router_filter.rst
+++ b/docs/root/configuration/http_filters/router_filter.rst
@@ -124,6 +124,7 @@ deadline-exceeded
 
 internal
   Envoy will attempt to retry if the gRPC status code in the response headers is "internal" (13)
+
 resource-exhausted
   Envoy will attempt a retry if the gRPC status code in the response headers is "resource-exhausted" (8)
 

--- a/docs/root/configuration/http_filters/router_filter.rst
+++ b/docs/root/configuration/http_filters/router_filter.rst
@@ -122,6 +122,8 @@ cancelled
 deadline-exceeded
   Envoy will attempt a retry if the gRPC status code in the response headers is "deadline-exceeded" (4)
 
+internal
+  Envoy will attempt to retry if the gRPC status code in the response headers is "internal" (13)
 resource-exhausted
   Envoy will attempt a retry if the gRPC status code in the response headers is "resource-exhausted" (8)
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -7,7 +7,7 @@ Version history
 * router: added ability to configure arbitrary :ref:`retriable status codes. <envoy_api_field_route.RouteAction.RetryPolicy.retriable_status_codes>`
 * router: added ability to set attempt count in upstream requests, see :ref:`virtual host's include request
   attempt count flag <envoy_api_field_route.VirtualHost.include_request_attempt_count>`.
-* router: added internal :ref:`grpc-retry-on <config_http_filters_router_x-envoy-grpc-retry-on>` policy.
+* router: added internal :ref:`grpc-retry-on <config_http_filters_router_x-envoy-retry-grpc-on>` policy.
 * router: when :ref:`max_grpc_timeout <envoy_api_field_route.RouteAction.max_grpc_timeout>`
   is set, Envoy will now add or update the grpc-timeout header to reflect Envoy's expected timeout.
 * stats: added :ref:`stats_matcher <envoy_api_field_config.metrics.v2.StatsConfig.stats_matcher>` to the bootstrap config for granular control of stat instantiation.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -7,6 +7,7 @@ Version history
 * router: added ability to configure arbitrary :ref:`retriable status codes. <envoy_api_field_route.RouteAction.RetryPolicy.retriable_status_codes>`
 * router: added ability to set attempt count in upstream requests, see :ref:`virtual host's include request
   attempt count flag <envoy_api_field_route.VirtualHost.include_request_attempt_count>`.
+* router: added internal :ref:`grpc-retry-on <config_http_filters_router_x-envoy-grpc-retry-on>` policy.
 * router: when :ref:`max_grpc_timeout <envoy_api_field_route.RouteAction.max_grpc_timeout>`
   is set, Envoy will now add or update the grpc-timeout header to reflect Envoy's expected timeout.
 * stats: added :ref:`stats_matcher <envoy_api_field_config.metrics.v2.StatsConfig.stats_matcher>` to the bootstrap config for granular control of stat instantiation.

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -151,6 +151,7 @@ public:
   static const uint32_t RETRY_ON_GRPC_DEADLINE_EXCEEDED  = 0x40;
   static const uint32_t RETRY_ON_GRPC_RESOURCE_EXHAUSTED = 0x80;
   static const uint32_t RETRY_ON_GRPC_UNAVAILABLE        = 0x100;
+  static const uint32_t RETRY_ON_GRPC_INTERNAL           = 0x101;
   // clang-format on
 
   virtual ~RetryPolicy() {}

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -151,7 +151,7 @@ public:
   static const uint32_t RETRY_ON_GRPC_DEADLINE_EXCEEDED  = 0x40;
   static const uint32_t RETRY_ON_GRPC_RESOURCE_EXHAUSTED = 0x80;
   static const uint32_t RETRY_ON_GRPC_UNAVAILABLE        = 0x100;
-  static const uint32_t RETRY_ON_GRPC_INTERNAL           = 0x101;
+  static const uint32_t RETRY_ON_GRPC_INTERNAL           = 0x200;
   // clang-format on
 
   virtual ~RetryPolicy() {}

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -152,6 +152,7 @@ public:
     const std::string DeadlineExceeded{"deadline-exceeded"};
     const std::string ResourceExhausted{"resource-exhausted"};
     const std::string Unavailable{"unavailable"};
+    const std::string Internal{"internal"};
   } EnvoyRetryOnGrpcValues;
 
   struct {

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -220,8 +220,8 @@ bool RetryStateImpl::wouldRetry(const Http::HeaderMap* response_headers,
 
   if (retry_on_ &
           (RetryPolicy::RETRY_ON_GRPC_CANCELLED | RetryPolicy::RETRY_ON_GRPC_DEADLINE_EXCEEDED |
-           RetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED |
-           RetryPolicy::RETRY_ON_GRPC_UNAVAILABLE | RetryPolicy::RETRY_ON_GRPC_INTERNAL) &&
+           RetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED | RetryPolicy::RETRY_ON_GRPC_UNAVAILABLE |
+           RetryPolicy::RETRY_ON_GRPC_INTERNAL) &&
       response_headers) {
     absl::optional<Grpc::Status::GrpcStatus> status =
         Grpc::Common::getGrpcStatus(*response_headers);

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -119,6 +119,8 @@ uint32_t RetryStateImpl::parseRetryGrpcOn(absl::string_view retry_grpc_on_header
       ret |= RetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnGrpcValues.Unavailable) {
       ret |= RetryPolicy::RETRY_ON_GRPC_UNAVAILABLE;
+    } else if (retry_on == Http::Headers::get().EnvoyRetryOnGrpcValues.Internal) {
+      ret |= RetryPolicy::RETRY_ON_GRPC_INTERNAL;
     }
   }
 
@@ -219,7 +221,7 @@ bool RetryStateImpl::wouldRetry(const Http::HeaderMap* response_headers,
   if (retry_on_ &
           (RetryPolicy::RETRY_ON_GRPC_CANCELLED | RetryPolicy::RETRY_ON_GRPC_DEADLINE_EXCEEDED |
            RetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED |
-           RetryPolicy::RETRY_ON_GRPC_UNAVAILABLE) &&
+           RetryPolicy::RETRY_ON_GRPC_UNAVAILABLE | RetryPolicy::RETRY_ON_GRPC_INTERNAL) &&
       response_headers) {
     absl::optional<Grpc::Status::GrpcStatus> status =
         Grpc::Common::getGrpcStatus(*response_headers);
@@ -231,7 +233,9 @@ bool RetryStateImpl::wouldRetry(const Http::HeaderMap* response_headers,
           (status.value() == Grpc::Status::ResourceExhausted &&
            (retry_on_ & RetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED)) ||
           (status.value() == Grpc::Status::Unavailable &&
-           (retry_on_ & RetryPolicy::RETRY_ON_GRPC_UNAVAILABLE))) {
+           (retry_on_ & RetryPolicy::RETRY_ON_GRPC_UNAVAILABLE)) ||
+          (status.value() == Grpc::Status::Internal &&
+           (retry_on_ & RetryPolicy::RETRY_ON_GRPC_INTERNAL))) {
         return true;
       }
     }


### PR DESCRIPTION
This allows configuring a gRPC retry policy which retries on internal
(13) responses.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Description*:
*Risk Level*: Low
*Testing*: Added unit test
*Docs Changes*: Added sub-section to retry-on header 
*Release Notes*: n/a
