### PR TITLE
Fix non standard  C++ code constructs on Windows

### DIFF
--- a/bazel/cc_wrapper.py
+++ b/bazel/cc_wrapper.py
@@ -71,6 +71,7 @@ def main():
     # See https://github.com/envoyproxy/envoy/issues/1341
     argv.append("-fno-limit-debug-info")
     argv.append("-Wthread-safety")
+    argv.append("-Wgnu-conditional-omitted-operand")
   elif "gcc" in compiler or "g++" in compiler:
     # -Wmaybe-initialized is warning about many uses of absl::optional. Disable
     # to prevent build breakage. This option does not exist in clang, so setting

--- a/include/envoy/common/BUILD
+++ b/include/envoy/common/BUILD
@@ -13,6 +13,7 @@ envoy_basic_cc_library(
     name = "base_includes",
     hdrs = [
         "exception.h",
+        "platform.h",
         "pure.h",
     ],
     include_prefix = "envoy/common",

--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -4,7 +4,7 @@
 #if !defined(_MSC_VER)
 #define STACK_ALLOC_ARRAY(var, type, num) type var[num]
 
-#define PACKED_STRUCT(definition, name) typedef definition __attribute__((packed)) name
+#define PACKED_STRUCT(definition, ...) definition, ##__VA_ARGS__ __attribute__((packed))
 
 #else
 #include <malloc.h>
@@ -12,8 +12,8 @@
 #define STACK_ALLOC_ARRAY(var, type, num)                                                          \
   type* var = static_cast<type*>(::_alloca(sizeof(type) * num))
 
-#define PACKED_STRUCT(definition, name)                                                            \
-  __pragma(pack(push, 1)) typedef definition name;                                                 \
+#define PACKED_STRUCT(definition, ...)                                                             \
+  __pragma(pack(push, 1)) definition, ##__VA_ARGS__;                                               \
   __pragma(pack(pop))
 
 #endif

--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -1,0 +1,19 @@
+#pragma once
+
+// NOLINT(namespace-envoy)
+#if !defined(WIN32)
+#define STACK_ALLOC_ARRAY(var, type, num) type var[num]
+
+#define PACKED_STRUCT(definition, name) typedef definition __attribute__((packed)) name
+
+#else
+#include <malloc.h>
+
+#define STACK_ALLOC_ARRAY(var, type, num)                                                          \
+  type* var = static_cast<type*>(::_alloca(sizeof(type) * num))
+
+#define PACKED_STRUCT(definition, name)                                                            \
+  __pragma(pack(push, 1)) typedef definition name;                                                 \
+  __pragma(pack(pop))
+
+#endif

--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // NOLINT(namespace-envoy)
-#if !defined(WIN32)
+#if !defined(_MSC_VER)
 #define STACK_ALLOC_ARRAY(var, type, num) type var[num]
 
 #define PACKED_STRUCT(definition, name) typedef definition __attribute__((packed)) name

--- a/source/common/common/base64.cc
+++ b/source/common/common/base64.cc
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "envoy/common/platform.h"
+
 #include "common/common/empty_string.h"
 
 namespace Envoy {

--- a/source/common/common/base64.cc
+++ b/source/common/common/base64.cc
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string>
 
+#include "envoy/common/platform.h"
 #include "common/common/empty_string.h"
 
 namespace Envoy {
@@ -178,12 +179,13 @@ std::string Base64::encode(const Buffer::Instance& buffer, uint64_t length) {
   ret.reserve(output_length);
 
   uint64_t num_slices = buffer.getRawSlices(nullptr, 0);
-  Buffer::RawSlice slices[num_slices];
+  STACK_ALLOC_ARRAY(slices, Buffer::RawSlice, num_slices);
   buffer.getRawSlices(slices, num_slices);
 
   uint64_t j = 0;
   uint8_t next_c = 0;
-  for (Buffer::RawSlice& slice : slices) {
+  for (uint64_t i = 0; i < num_slices; i++) {
+    Buffer::RawSlice& slice = slices[i];
     const uint8_t* slice_mem = static_cast<const uint8_t*>(slice.mem_);
 
     for (uint64_t i = 0; i < slice.len_ && j < length; ++i, ++j) {

--- a/source/common/compressor/zlib_compressor_impl.cc
+++ b/source/common/compressor/zlib_compressor_impl.cc
@@ -40,7 +40,7 @@ void ZlibCompressorImpl::compress(Buffer::Instance& buffer, State state) {
   buffer.getRawSlices(slices, num_slices);
 
   for (uint64_t i = 0; i < num_slices; i++) {
-    Buffer::RawSlice& input_slice = slices[i];
+    const Buffer::RawSlice& input_slice = slices[i];
     zstream_ptr_->avail_in = input_slice.len_;
     zstream_ptr_->next_in = static_cast<Bytef*>(input_slice.mem_);
     // Z_NO_FLUSH tells the compressor to take the data in and compresses it as much as possible

--- a/source/common/compressor/zlib_compressor_impl.cc
+++ b/source/common/compressor/zlib_compressor_impl.cc
@@ -1,6 +1,7 @@
 #include "common/compressor/zlib_compressor_impl.h"
 
 #include "envoy/common/exception.h"
+#include "envoy/common/platform.h"
 
 #include "common/common/assert.h"
 
@@ -35,10 +36,11 @@ uint64_t ZlibCompressorImpl::checksum() { return zstream_ptr_->adler; }
 
 void ZlibCompressorImpl::compress(Buffer::Instance& buffer, State state) {
   const uint64_t num_slices = buffer.getRawSlices(nullptr, 0);
-  Buffer::RawSlice slices[num_slices];
+  STACK_ALLOC_ARRAY(slices, Buffer::RawSlice, num_slices);
   buffer.getRawSlices(slices, num_slices);
 
-  for (const Buffer::RawSlice& input_slice : slices) {
+  for (uint64_t i = 0; i < num_slices; i++) {
+    Buffer::RawSlice& input_slice = slices[i];
     zstream_ptr_->avail_in = input_slice.len_;
     zstream_ptr_->next_in = static_cast<Bytef*>(input_slice.mem_);
     // Z_NO_FLUSH tells the compressor to take the data in and compresses it as much as possible

--- a/source/common/grpc/codec.cc
+++ b/source/common/grpc/codec.cc
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "envoy/common/platform.h"
 #include "common/buffer/buffer_impl.h"
 
 namespace Envoy {
@@ -23,9 +24,10 @@ Decoder::Decoder() : state_(State::FH_FLAG) {}
 
 bool Decoder::decode(Buffer::Instance& input, std::vector<Frame>& output) {
   uint64_t count = input.getRawSlices(nullptr, 0);
-  Buffer::RawSlice slices[count];
+  STACK_ALLOC_ARRAY(slices, Buffer::RawSlice, count);
   input.getRawSlices(slices, count);
-  for (Buffer::RawSlice& slice : slices) {
+  for (uint64_t i = 0; i < count; i++) {
+    Buffer::RawSlice& slice = slices[i];
     uint8_t* mem = reinterpret_cast<uint8_t*>(slice.mem_);
     for (uint64_t j = 0; j < slice.len_;) {
       uint8_t c = *mem;

--- a/source/common/grpc/codec.cc
+++ b/source/common/grpc/codec.cc
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "envoy/common/platform.h"
+
 #include "common/buffer/buffer_impl.h"
 
 namespace Envoy {

--- a/source/common/grpc/google_grpc_creds_impl.cc
+++ b/source/common/grpc/google_grpc_creds_impl.cc
@@ -16,9 +16,9 @@ std::shared_ptr<grpc::ChannelCredentials> CredsUtility::getChannelCredentials(
     case envoy::api::v2::core::GrpcService::GoogleGrpc::ChannelCredentials::kSslCredentials: {
       const auto& ssl_credentials = google_grpc.channel_credentials().ssl_credentials();
       const grpc::SslCredentialsOptions ssl_credentials_options = {
-          .pem_root_certs = Config::DataSource::read(ssl_credentials.root_certs(), true),
-          .pem_private_key = Config::DataSource::read(ssl_credentials.private_key(), true),
-          .pem_cert_chain = Config::DataSource::read(ssl_credentials.cert_chain(), true),
+          Config::DataSource::read(ssl_credentials.root_certs(), true),
+          Config::DataSource::read(ssl_credentials.private_key(), true),
+          Config::DataSource::read(ssl_credentials.cert_chain(), true),
       };
       return grpc::SslCredentials(ssl_credentials_options);
     }

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "envoy/buffer/buffer.h"
+#include "envoy/common/platform.h"
 #include "envoy/http/header_map.h"
 #include "envoy/network/connection.h"
 
@@ -331,9 +332,10 @@ bool ConnectionImpl::maybeDirectDispatch(Buffer::Instance& data) {
 
   ssize_t total_parsed = 0;
   uint64_t num_slices = data.getRawSlices(nullptr, 0);
-  Buffer::RawSlice slices[num_slices];
+  STACK_ALLOC_ARRAY(slices, Buffer::RawSlice, num_slices);
   data.getRawSlices(slices, num_slices);
-  for (Buffer::RawSlice& slice : slices) {
+  for (uint64_t i = 0; i < num_slices; i++) {
+    Buffer::RawSlice& slice = slices[i];
     total_parsed += slice.len_;
     onBody(static_cast<const char*>(slice.mem_), slice.len_);
   }
@@ -355,9 +357,10 @@ void ConnectionImpl::dispatch(Buffer::Instance& data) {
   ssize_t total_parsed = 0;
   if (data.length() > 0) {
     uint64_t num_slices = data.getRawSlices(nullptr, 0);
-    Buffer::RawSlice slices[num_slices];
+    STACK_ALLOC_ARRAY(slices, Buffer::RawSlice, num_slices);
     data.getRawSlices(slices, num_slices);
-    for (Buffer::RawSlice& slice : slices) {
+    for (uint64_t i = 0; i < num_slices; i++) {
+      Buffer::RawSlice& slice = slices[i];
       total_parsed += dispatchSlice(static_cast<const char*>(slice.mem_), slice.len_);
     }
   } else {

--- a/source/common/http/message_impl.cc
+++ b/source/common/http/message_impl.cc
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <string>
 
+#include "envoy/common/platform.h"
+
 namespace Envoy {
 namespace Http {
 
@@ -10,9 +12,10 @@ std::string MessageImpl::bodyAsString() const {
   std::string ret;
   if (body_) {
     uint64_t num_slices = body_->getRawSlices(nullptr, 0);
-    Buffer::RawSlice slices[num_slices];
+    STACK_ALLOC_ARRAY(slices, Buffer::RawSlice, num_slices);
     body_->getRawSlices(slices, num_slices);
-    for (Buffer::RawSlice& slice : slices) {
+    for (uint64_t i = 0; i < num_slices; i++) {
+      Buffer::RawSlice& slice = slices[i];
       ret.append(reinterpret_cast<const char*>(slice.mem_), slice.len_);
     }
   }

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -74,10 +74,10 @@ Address::InstanceConstSharedPtr addressFromSockAddr(const sockaddr_storage& ss, 
 #define s6_addr32 __u6_addr.__u6_addr32
 #endif
 #endif
-      struct sockaddr_in sin = {.sin_family = AF_INET,
-                                .sin_port = sin6->sin6_port,
-                                .sin_addr = {.s_addr = sin6->sin6_addr.s6_addr32[3]},
-                                .sin_zero = {}};
+      struct sockaddr_in sin = {AF_INET,
+                                sin6->sin6_port,
+                                {sin6->sin6_addr.s6_addr32[3]},
+                                {}};
       return std::make_shared<Address::Ipv4Instance>(&sin);
     } else {
       return std::make_shared<Address::Ipv6Instance>(*sin6, v6only);

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -69,12 +69,12 @@ Address::InstanceConstSharedPtr addressFromSockAddr(const sockaddr_storage& ss, 
     const struct sockaddr_in6* sin6 = reinterpret_cast<const struct sockaddr_in6*>(&ss);
     ASSERT(AF_INET6 == sin6->sin6_family);
     if (!v6only && IN6_IS_ADDR_V4MAPPED(&sin6->sin6_addr)) {
-#ifndef s6_addr32
-#ifdef __APPLE__
-#define s6_addr32 __u6_addr.__u6_addr32
-#endif
-#endif
+#if defined(__APPLE__)
+      struct sockaddr_in sin = {
+          {}, AF_INET, sin6->sin6_port, {sin6->sin6_addr.__u6_addr.__u6_addr32[3]}, {}};
+#else
       struct sockaddr_in sin = {AF_INET, sin6->sin6_port, {sin6->sin6_addr.s6_addr32[3]}, {}};
+#endif
       return std::make_shared<Address::Ipv4Instance>(&sin);
     } else {
       return std::make_shared<Address::Ipv6Instance>(*sin6, v6only);

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -74,10 +74,7 @@ Address::InstanceConstSharedPtr addressFromSockAddr(const sockaddr_storage& ss, 
 #define s6_addr32 __u6_addr.__u6_addr32
 #endif
 #endif
-      struct sockaddr_in sin = {AF_INET,
-                                sin6->sin6_port,
-                                {sin6->sin6_addr.s6_addr32[3]},
-                                {}};
+      struct sockaddr_in sin = {AF_INET, sin6->sin6_port, {sin6->sin6_addr.s6_addr32[3]}, {}};
       return std::make_shared<Address::Ipv4Instance>(&sin);
     } else {
       return std::make_shared<Address::Ipv6Instance>(*sin6, v6only);

--- a/source/common/stats/symbol_table_impl.cc
+++ b/source/common/stats/symbol_table_impl.cc
@@ -61,8 +61,7 @@ Symbol SymbolTableImpl::toSymbol(absl::string_view sv) {
     auto decode_insert = decode_map_.insert({next_symbol_, std::move(str)});
     ASSERT(decode_insert.second);
 
-    auto encode_insert = encode_map_.insert(
-        {decode_insert.first->second, {.symbol_ = next_symbol_, .ref_count_ = 1}});
+    auto encode_insert = encode_map_.insert({decode_insert.first->second, {next_symbol_, 1}});
     ASSERT(encode_insert.second);
 
     result = next_symbol_;

--- a/source/common/stats/tag_producer_impl.cc
+++ b/source/common/stats/tag_producer_impl.cc
@@ -36,7 +36,7 @@ TagProducerImpl::TagProducerImpl(const envoy::config::metrics::v2::StatsConfig& 
       }
     } else if (tag_specifier.tag_value_case() ==
                envoy::config::metrics::v2::TagSpecifier::kFixedValue) {
-      default_tags_.emplace_back(Stats::Tag{.name_ = name, .value_ = tag_specifier.fixed_value()});
+      default_tags_.emplace_back(Stats::Tag{name, tag_specifier.fixed_value()});
     }
   }
 }

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "envoy/common/platform.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/upstream.h"
 
@@ -193,9 +194,9 @@ void ZoneAwareLoadBalancerBase::regenerateLocalityRoutingStructures() {
   //
   // Basically, fariness across localities within a priority is guaranteed. Fairness across
   // localities across priorities is not.
-  uint64_t local_percentage[num_localities];
+  STACK_ALLOC_ARRAY(local_percentage, uint64_t, num_localities);
   calculateLocalityPercentage(localHostSet().healthyHostsPerLocality(), local_percentage);
-  uint64_t upstream_percentage[num_localities];
+  STACK_ALLOC_ARRAY(upstream_percentage, uint64_t, num_localities);
   calculateLocalityPercentage(host_set.healthyHostsPerLocality(), upstream_percentage);
 
   // If we have lower percent of hosts in the local cluster in the same locality,

--- a/source/extensions/filters/http/buffer/buffer_filter.cc
+++ b/source/extensions/filters/http/buffer/buffer_filter.cc
@@ -61,11 +61,11 @@ void BufferFilter::initConfig() {
   const std::string& name = HttpFilterNames::get().Buffer;
   const auto* entry = callbacks_->route()->routeEntry();
 
+  const BufferFilterSettings* tmp = entry->perFilterConfigTyped<BufferFilterSettings>(name);
   const BufferFilterSettings* route_local =
-      entry->perFilterConfigTyped<BufferFilterSettings>(name)
-          ?: entry->virtualHost().perFilterConfigTyped<BufferFilterSettings>(name);
+      tmp ? tmp : entry->virtualHost().perFilterConfigTyped<BufferFilterSettings>(name);
 
-  settings_ = route_local ?: settings_;
+  settings_ = route_local ? route_local : settings_;
 }
 
 Http::FilterHeadersStatus BufferFilter::decodeHeaders(Http::HeaderMap&, bool end_stream) {

--- a/source/extensions/filters/http/dynamo/dynamo_filter.cc
+++ b/source/extensions/filters/http/dynamo/dynamo_filter.cc
@@ -5,10 +5,11 @@
 #include <string>
 #include <vector>
 
+#include "envoy/common/platform.h"
+
 #include "common/buffer/buffer_impl.h"
 #include "common/common/assert.h"
 #include "common/common/fmt.h"
-#include "envoy/common/platform.h"
 #include "common/http/codes.h"
 #include "common/http/exception.h"
 #include "common/http/utility.h"

--- a/source/extensions/filters/http/dynamo/dynamo_filter.cc
+++ b/source/extensions/filters/http/dynamo/dynamo_filter.cc
@@ -8,6 +8,7 @@
 #include "common/buffer/buffer_impl.h"
 #include "common/common/assert.h"
 #include "common/common/fmt.h"
+#include "envoy/common/platform.h"
 #include "common/http/codes.h"
 #include "common/http/exception.h"
 #include "common/http/utility.h"
@@ -136,17 +137,19 @@ std::string DynamoFilter::buildBody(const Buffer::Instance* buffered,
   std::string body;
   if (buffered) {
     uint64_t num_slices = buffered->getRawSlices(nullptr, 0);
-    Buffer::RawSlice slices[num_slices];
+    STACK_ALLOC_ARRAY(slices, Buffer::RawSlice, num_slices);
     buffered->getRawSlices(slices, num_slices);
-    for (Buffer::RawSlice& slice : slices) {
+    for (uint64_t i = 0; i < num_slices; i++) {
+      Buffer::RawSlice& slice = slices[i];
       body.append(static_cast<const char*>(slice.mem_), slice.len_);
     }
   }
 
   uint64_t num_slices = last.getRawSlices(nullptr, 0);
-  Buffer::RawSlice slices[num_slices];
+  STACK_ALLOC_ARRAY(slices, Buffer::RawSlice, num_slices);
   last.getRawSlices(slices, num_slices);
-  for (Buffer::RawSlice& slice : slices) {
+  for (uint64_t i = 0; i < num_slices; i++) {
+    Buffer::RawSlice& slice = slices[i];
     body.append(static_cast<const char*>(slice.mem_), slice.len_);
   }
 

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -80,10 +80,10 @@ Http::FilterHeadersStatus FaultFilter::decodeHeaders(Http::HeaderMap& headers, b
     const std::string& name = Extensions::HttpFilters::HttpFilterNames::get().Fault;
     const auto* route_entry = callbacks_->route()->routeEntry();
 
-    const FaultSettings* per_route_settings_ =
-        route_entry->perFilterConfigTyped<FaultSettings>(name)
-            ?: route_entry->virtualHost().perFilterConfigTyped<FaultSettings>(name);
-    fault_settings_ = per_route_settings_ ?: fault_settings_;
+    const FaultSettings* tmp = route_entry->perFilterConfigTyped<FaultSettings>(name);
+    const FaultSettings* per_route_settings =
+        tmp ? tmp : route_entry->virtualHost().perFilterConfigTyped<FaultSettings>(name);
+    fault_settings_ = per_route_settings ? per_route_settings : fault_settings_;
   }
 
   if (!matchesTargetUpstreamCluster()) {

--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -32,8 +32,12 @@ RoleBasedAccessControlFilterConfig::engine(const Router::RouteConstSharedPtr rou
 
   const std::string& name = HttpFilterNames::get().Rbac;
   const auto* entry = route->routeEntry();
-  const auto* tmp = entry->perFilterConfigTyped<RoleBasedAccessControlRouteSpecificFilterConfig>(name);
-  const auto* route_local = tmp ? tmp : entry->virtualHost().perFilterConfigTyped<RoleBasedAccessControlRouteSpecificFilterConfig>(name);
+  const auto* tmp =
+      entry->perFilterConfigTyped<RoleBasedAccessControlRouteSpecificFilterConfig>(name);
+  const auto* route_local =
+      tmp ? tmp
+          : entry->virtualHost()
+                .perFilterConfigTyped<RoleBasedAccessControlRouteSpecificFilterConfig>(name);
 
   if (route_local) {
     return route_local->engine(mode);

--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -32,10 +32,8 @@ RoleBasedAccessControlFilterConfig::engine(const Router::RouteConstSharedPtr rou
 
   const std::string& name = HttpFilterNames::get().Rbac;
   const auto* entry = route->routeEntry();
-  const auto* route_local =
-      entry->perFilterConfigTyped<RoleBasedAccessControlRouteSpecificFilterConfig>(name)
-          ?: entry->virtualHost()
-                 .perFilterConfigTyped<RoleBasedAccessControlRouteSpecificFilterConfig>(name);
+  const auto* tmp = entry->perFilterConfigTyped<RoleBasedAccessControlRouteSpecificFilterConfig>(name);
+  const auto* route_local = tmp ? tmp : entry->virtualHost().perFilterConfigTyped<RoleBasedAccessControlRouteSpecificFilterConfig>(name);
 
   if (route_local) {
     return route_local->engine(mode);

--- a/source/extensions/filters/http/squash/squash_filter.cc
+++ b/source/extensions/filters/http/squash/squash_filter.cc
@@ -1,5 +1,6 @@
 #include "extensions/filters/http/squash/squash_filter.h"
 
+#include "envoy/common/platform.h"
 #include "envoy/http/codes.h"
 
 #include "common/common/empty_string.h"
@@ -303,10 +304,11 @@ void SquashFilter::cleanup() {
 Json::ObjectSharedPtr SquashFilter::getJsonBody(Http::MessagePtr&& m) {
   Buffer::InstancePtr& data = m->body();
   uint64_t num_slices = data->getRawSlices(nullptr, 0);
-  Buffer::RawSlice slices[num_slices];
+  STACK_ALLOC_ARRAY(slices, Buffer::RawSlice, num_slices);
   data->getRawSlices(slices, num_slices);
   std::string jsonbody;
-  for (Buffer::RawSlice& slice : slices) {
+  for (uint64_t i = 0; i < num_slices; i++) {
+    Buffer::RawSlice& slice = slices[i];
     jsonbody += std::string(static_cast<const char*>(slice.mem_), slice.len_);
   }
 

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
@@ -137,14 +137,12 @@ void Filter::parseV2Header(char* buf) {
     if (((proto_family & 0x0f) == PROXY_PROTO_V2_TRANSPORT_STREAM) ||
         ((proto_family & 0x0f) == PROXY_PROTO_V2_TRANSPORT_DGRAM)) {
       if (((proto_family & 0xf0) >> 4) == PROXY_PROTO_V2_AF_INET) {
-        PACKED_STRUCT(
-            struct {
-              uint32_t src_addr;
-              uint32_t dst_addr;
-              uint16_t src_port;
-              uint16_t dst_port;
-            },
-            pp_ipv4_addr);
+        PACKED_STRUCT(struct pp_ipv4_addr {
+          uint32_t src_addr;
+          uint32_t dst_addr;
+          uint16_t src_port;
+          uint16_t dst_port;
+        });
         pp_ipv4_addr* v4;
         v4 = reinterpret_cast<pp_ipv4_addr*>(&buf[PROXY_PROTO_V2_HEADER_LEN]);
         sockaddr_in ra4, la4;
@@ -163,14 +161,12 @@ void Filter::parseV2Header(char* buf) {
                        std::make_shared<Network::Address::Ipv4Instance>(&la4)});
         return;
       } else if (((proto_family & 0xf0) >> 4) == PROXY_PROTO_V2_AF_INET6) {
-        PACKED_STRUCT(
-            struct {
-              uint8_t src_addr[16];
-              uint8_t dst_addr[16];
-              uint16_t src_port;
-              uint16_t dst_port;
-            },
-            pp_ipv6_addr);
+        PACKED_STRUCT(struct pp_ipv6_addr {
+          uint8_t src_addr[16];
+          uint8_t dst_addr[16];
+          uint16_t src_port;
+          uint16_t dst_port;
+        });
         pp_ipv6_addr* v6;
         v6 = reinterpret_cast<pp_ipv6_addr*>(&buf[PROXY_PROTO_V2_HEADER_LEN]);
         sockaddr_in6 ra6, la6;

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "envoy/common/exception.h"
+#include "envoy/common/platform.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/network/listen_socket.h"
 #include "envoy/stats/scope.h"
@@ -136,12 +137,14 @@ void Filter::parseV2Header(char* buf) {
     if (((proto_family & 0x0f) == PROXY_PROTO_V2_TRANSPORT_STREAM) ||
         ((proto_family & 0x0f) == PROXY_PROTO_V2_TRANSPORT_DGRAM)) {
       if (((proto_family & 0xf0) >> 4) == PROXY_PROTO_V2_AF_INET) {
-        typedef struct {
-          uint32_t src_addr;
-          uint32_t dst_addr;
-          uint16_t src_port;
-          uint16_t dst_port;
-        } __attribute__((packed)) pp_ipv4_addr;
+        PACKED_STRUCT(
+            struct {
+              uint32_t src_addr;
+              uint32_t dst_addr;
+              uint16_t src_port;
+              uint16_t dst_port;
+            },
+            pp_ipv4_addr);
         pp_ipv4_addr* v4;
         v4 = reinterpret_cast<pp_ipv4_addr*>(&buf[PROXY_PROTO_V2_HEADER_LEN]);
         sockaddr_in ra4, la4;
@@ -160,12 +163,14 @@ void Filter::parseV2Header(char* buf) {
                        std::make_shared<Network::Address::Ipv4Instance>(&la4)});
         return;
       } else if (((proto_family & 0xf0) >> 4) == PROXY_PROTO_V2_AF_INET6) {
-        typedef struct {
-          uint8_t src_addr[16];
-          uint8_t dst_addr[16];
-          uint16_t src_port;
-          uint16_t dst_port;
-        } __attribute__((packed)) pp_ipv6_addr;
+        PACKED_STRUCT(
+            struct {
+              uint8_t src_addr[16];
+              uint8_t dst_addr[16];
+              uint16_t src_port;
+              uint16_t dst_port;
+            },
+            pp_ipv6_addr);
         pp_ipv6_addr* v6;
         v6 = reinterpret_cast<pp_ipv6_addr*>(&buf[PROXY_PROTO_V2_HEADER_LEN]);
         sockaddr_in6 ra6, la6;

--- a/source/extensions/resource_monitors/injected_resource/injected_resource_monitor.cc
+++ b/source/extensions/resource_monitors/injected_resource/injected_resource_monitor.cc
@@ -45,7 +45,7 @@ void InjectedResourceMonitor::updateResourceUsage(Server::ResourceMonitor::Callb
 
   ASSERT(pressure_.has_value() != error_.has_value());
   if (pressure_.has_value()) {
-    callbacks.onSuccess({.resource_pressure_ = *pressure_});
+    callbacks.onSuccess({*pressure_});
   } else {
     callbacks.onFailure(*error_);
   }

--- a/source/server/hot_restart_impl.h
+++ b/source/server/hot_restart_impl.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <string>
 
+#include "envoy/common/platform.h"
 #include "envoy/server/hot_restart.h"
 #include "envoy/server/options.h"
 #include "envoy/stats/stats_options.h"
@@ -156,39 +157,46 @@ private:
     GetStatsReply = 9
   };
 
-  struct RpcBase {
+  PACKED_STRUCT(struct RpcBase {
     RpcBase(RpcMessageType type, uint64_t length = sizeof(RpcBase))
         : type_(type), length_(length) {}
 
     RpcMessageType type_;
     uint64_t length_;
-  } __attribute__((packed));
+  });
 
-  struct RpcGetListenSocketRequest : public RpcBase {
-    RpcGetListenSocketRequest() : RpcBase(RpcMessageType::GetListenSocketRequest, sizeof(*this)) {}
+  PACKED_STRUCT(struct RpcGetListenSocketRequest
+                : public RpcBase {
+                  RpcGetListenSocketRequest()
+                      : RpcBase(RpcMessageType::GetListenSocketRequest, sizeof(*this)) {}
 
-    char address_[256]{0};
-  } __attribute__((packed));
+                  char address_[256]{0};
+                });
 
-  struct RpcGetListenSocketReply : public RpcBase {
-    RpcGetListenSocketReply() : RpcBase(RpcMessageType::GetListenSocketReply, sizeof(*this)) {}
+  PACKED_STRUCT(struct RpcGetListenSocketReply
+                : public RpcBase {
+                  RpcGetListenSocketReply()
+                      : RpcBase(RpcMessageType::GetListenSocketReply, sizeof(*this)) {}
 
-    int fd_{0};
-  } __attribute__((packed));
+                  int fd_{0};
+                });
 
-  struct RpcShutdownAdminReply : public RpcBase {
-    RpcShutdownAdminReply() : RpcBase(RpcMessageType::ShutdownAdminReply, sizeof(*this)) {}
+  PACKED_STRUCT(struct RpcShutdownAdminReply
+                : public RpcBase {
+                  RpcShutdownAdminReply()
+                      : RpcBase(RpcMessageType::ShutdownAdminReply, sizeof(*this)) {}
 
-    uint64_t original_start_time_{0};
-  } __attribute__((packed));
+                  uint64_t original_start_time_{0};
+                });
 
-  struct RpcGetStatsReply : public RpcBase {
-    RpcGetStatsReply() : RpcBase(RpcMessageType::GetStatsReply, sizeof(*this)) {}
+  PACKED_STRUCT(struct RpcGetStatsReply
+                : public RpcBase {
+                  RpcGetStatsReply() : RpcBase(RpcMessageType::GetStatsReply, sizeof(*this)) {}
 
-    uint64_t memory_allocated_{0};
-    uint64_t num_connections_{0};
-    uint64_t unused_[16]{0};
-  } __attribute__((packed));
+                  uint64_t memory_allocated_{0};
+                  uint64_t num_connections_{0};
+                  uint64_t unused_[16]{0};
+                });
 
   template <class rpc_class, RpcMessageType rpc_type> rpc_class* receiveTypedRpc() {
     RpcBase* base_message = receiveRpc(true);

--- a/test/common/compressor/zlib_compressor_impl_test.cc
+++ b/test/common/compressor/zlib_compressor_impl_test.cc
@@ -1,3 +1,5 @@
+#include "envoy/common/platform.h"
+
 #include "common/buffer/buffer_impl.h"
 #include "common/common/hex.h"
 #include "common/compressor/zlib_compressor_impl.h"
@@ -14,7 +16,7 @@ class ZlibCompressorImplTest : public testing::Test {
 protected:
   void expectValidFlushedBuffer(const Buffer::OwnedImpl& output_buffer) {
     uint64_t num_comp_slices = output_buffer.getRawSlices(nullptr, 0);
-    Buffer::RawSlice compressed_slices[num_comp_slices];
+    STACK_ALLOC_ARRAY(compressed_slices, Buffer::RawSlice, num_comp_slices);
     output_buffer.getRawSlices(compressed_slices, num_comp_slices);
 
     const std::string header_hex_str = Hex::encode(
@@ -35,7 +37,7 @@ protected:
   void expectValidFinishedBuffer(const Buffer::OwnedImpl& output_buffer,
                                  const uint32_t input_size) {
     uint64_t num_comp_slices = output_buffer.getRawSlices(nullptr, 0);
-    Buffer::RawSlice compressed_slices[num_comp_slices];
+    STACK_ALLOC_ARRAY(compressed_slices, Buffer::RawSlice, num_comp_slices);
     output_buffer.getRawSlices(compressed_slices, num_comp_slices);
 
     const std::string header_hex_str = Hex::encode(

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -8,6 +8,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "envoy/common/platform.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/network/address.h"
 #include "envoy/network/dns.h"
@@ -167,7 +168,7 @@ private:
         // The response begins with the initial part of the request
         // (including the question section).
         const size_t response_base_len = HFIXEDSZ + name_len + QFIXEDSZ;
-        unsigned char response_base[response_base_len];
+        STACK_ALLOC_ARRAY(response_base, unsigned char, response_base_len);
         memcpy(response_base, request, response_base_len);
         DNS_HEADER_SET_QR(response_base, 1);
         DNS_HEADER_SET_AA(response_base, 0);

--- a/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
+++ b/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_test.cc
@@ -73,10 +73,10 @@ protected:
 };
 
 TEST_F(InjectedResourceMonitorTest, ReportsCorrectPressure) {
-  EXPECT_CALL(cb_, onSuccess(Server::ResourceUsage{.resource_pressure_ = 0.6}));
+  EXPECT_CALL(cb_, onSuccess(Server::ResourceUsage{0.6}));
   updateResource(0.6);
 
-  EXPECT_CALL(cb_, onSuccess(Server::ResourceUsage{.resource_pressure_ = 0.7}));
+  EXPECT_CALL(cb_, onSuccess(Server::ResourceUsage{0.7}));
   updateResource(0.7);
 }
 

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "envoy/buffer/buffer.h"
+#include "envoy/common/platform.h"
 #include "envoy/http/header_map.h"
 
 #include "common/api/api_impl.h"
@@ -91,9 +92,10 @@ void IntegrationStreamDecoder::decodeHeaders(Http::HeaderMapPtr&& headers, bool 
 void IntegrationStreamDecoder::decodeData(Buffer::Instance& data, bool end_stream) {
   saw_end_stream_ = end_stream;
   uint64_t num_slices = data.getRawSlices(nullptr, 0);
-  Buffer::RawSlice slices[num_slices];
+  STACK_ALLOC_ARRAY(slices, Buffer::RawSlice, num_slices);
   data.getRawSlices(slices, num_slices);
-  for (Buffer::RawSlice& slice : slices) {
+  for (uint64_t i = 0; i < num_slices; i++) {
+    Buffer::RawSlice& slice = slices[i];
     body_.append(static_cast<const char*>(slice.mem_), slice.len_);
   }
 

--- a/test/integration/xds_integration_test.cc
+++ b/test/integration/xds_integration_test.cc
@@ -19,11 +19,11 @@ public:
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
     createApiTestServer(
         {
-            .bootstrap_path_ = "test/config/integration/server_xds.bootstrap.yaml",
-            .cds_path_ = "test/config/integration/server_xds.cds.yaml",
-            .eds_path_ = "test/config/integration/server_xds.eds.yaml",
-            .lds_path_ = "test/config/integration/server_xds.lds.yaml",
-            .rds_path_ = "test/config/integration/server_xds.rds.yaml",
+           "test/config/integration/server_xds.bootstrap.yaml",
+           "test/config/integration/server_xds.cds.yaml",
+           "test/config/integration/server_xds.eds.yaml",
+           "test/config/integration/server_xds.lds.yaml",
+           "test/config/integration/server_xds.rds.yaml",
         },
         {"http"});
   }

--- a/test/integration/xds_integration_test.cc
+++ b/test/integration/xds_integration_test.cc
@@ -19,11 +19,11 @@ public:
     registerPort("upstream_0", fake_upstreams_.back()->localAddress()->ip()->port());
     createApiTestServer(
         {
-           "test/config/integration/server_xds.bootstrap.yaml",
-           "test/config/integration/server_xds.cds.yaml",
-           "test/config/integration/server_xds.eds.yaml",
-           "test/config/integration/server_xds.lds.yaml",
-           "test/config/integration/server_xds.rds.yaml",
+            "test/config/integration/server_xds.bootstrap.yaml",
+            "test/config/integration/server_xds.cds.yaml",
+            "test/config/integration/server_xds.eds.yaml",
+            "test/config/integration/server_xds.lds.yaml",
+            "test/config/integration/server_xds.rds.yaml",
         },
         {"http"});
   }

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "envoy/buffer/buffer.h"
+#include "envoy/common/platform.h"
 #include "envoy/http/codec.h"
 
 #include "common/common/empty_string.h"
@@ -89,9 +90,9 @@ bool TestUtility::buffersEqual(const Buffer::Instance& lhs, const Buffer::Instan
     return false;
   }
 
-  Buffer::RawSlice lhs_slices[lhs_num_slices];
+  STACK_ALLOC_ARRAY(lhs_slices, Buffer::RawSlice, lhs_num_slices);
   lhs.getRawSlices(lhs_slices, lhs_num_slices);
-  Buffer::RawSlice rhs_slices[rhs_num_slices];
+  STACK_ALLOC_ARRAY(rhs_slices, Buffer::RawSlice, rhs_num_slices);
   rhs.getRawSlices(rhs_slices, rhs_num_slices);
   for (size_t i = 0; i < lhs_num_slices; i++) {
     if (lhs_slices[i].len_ != rhs_slices[i].len_) {

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -197,6 +197,20 @@ def checkSourceLine(line, file_path, reportError):
     # The std::atomic_* free functions are functionally equivalent to calling
     # operations on std::atomic<T> objects, so prefer to use that instead.
     reportError("Don't use free std::atomic_* functions, use std::atomic<T> members instead.")
+  if '__attribute__((packed))' in line and file_path != './include/envoy/common/platform.h':
+    # __attribute__((packed)) is not supported by MSVC, we have a PACKED_STRUCT macro that
+    # can be used instead
+    reportError("Don't use __attribute__((packed)), use the PACKED_STRUCT macro defined "
+                "in include/envoy/common/platform.h instead")
+  if re.search("\{\s*\.\w+\s*\=\s*\w+", line):
+    # Designated initializers are not part of the C++14 standard and are not supported
+    # by MSVC
+    reportError("Don't use designated initializers in struct initialization, "
+                "they are not part of C++14")
+  if ' ?: ' in line:
+    # The ?: operator is non-standard, it is a GCC extension
+    reportError("Don't use the '?:' operator, it is a non-standard GCC extension")
+
 
 def checkBuildLine(line, file_path, reportError):
   if not whitelistedForProtobufDeps(file_path) and '"protobuf"' in line:

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -202,7 +202,7 @@ def checkSourceLine(line, file_path, reportError):
     # can be used instead
     reportError("Don't use __attribute__((packed)), use the PACKED_STRUCT macro defined "
                 "in include/envoy/common/platform.h instead")
-  if re.search("\{\s*\.\w+\s*\=\s*\w+", line):
+  if re.search("\{\s*\.\w+\s*\=", line):
     # Designated initializers are not part of the C++14 standard and are not supported
     # by MSVC
     reportError("Don't use designated initializers in struct initialization, "

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -163,6 +163,12 @@ if __name__ == "__main__":
                                 "unexpected direct external dependency on protobuf")
   errors += checkUnfixableError("proto_deps.cc",
                                 "unexpected direct dependency on google.protobuf")
+  errors += checkUnfixableError("attribute_packed.cc",
+                                "Don't use __attribute__((packed))")
+  errors += checkUnfixableError("designated_initializers.cc",
+                                "Don't use designated initializers")
+  errors += checkUnfixableError("elvis_operator.cc",
+                                "Don't use the '?:' operator")
 
   # The following files have errors that can be automatically fixed.
   errors += checkAndFixError("over_enthusiastic_spaces.cc",

--- a/tools/testdata/check_format/attribute_packed.cc
+++ b/tools/testdata/check_format/attribute_packed.cc
@@ -1,0 +1,7 @@
+namespace Envoy {
+
+typedef struct {
+  int a;
+  int b;
+}  __attribute__((packed)) s;
+} // namespace Envoy

--- a/tools/testdata/check_format/designated_initializers.cc
+++ b/tools/testdata/check_format/designated_initializers.cc
@@ -1,0 +1,10 @@
+namespace Envoy {
+
+typedef struct {
+  int a;
+  int b;
+} s;
+
+s my_struct = {.a = 1, .b = 2};
+
+} // namespace Envoy

--- a/tools/testdata/check_format/elvis_operator.cc
+++ b/tools/testdata/check_format/elvis_operator.cc
@@ -1,0 +1,5 @@
+namespace Envoy {
+
+int val = 0 ?: 1;
+
+} // namespace Envoy


### PR DESCRIPTION
*Description*:

As requested in https://github.com/envoyproxy/envoy/issues/129, this is the first in a series of changes that will lead to Envoy building and running on Windows. To start, this PR fixes some non standard C++ code constructs that are not supported by MSVC:

1. Use STACK_ALLOC_ARRAY macro to allocate a variable-length array on the stack
2. Don't use designated initializers with structs
3. Remove usage of ?: operator
4. Use PACKED_STRUCT macro to typedef a packed struct

These changes are necessary, but not sufficient, to get Envoy to compile on Windows

*Risk Level*:
Low

*Testing*:
 `bazel build //source/exe:envoy-static && bazel test //test/...`

*Docs Changes*:
N/A

*Release Notes*:
N/A