### PR TITLE
stats: fix stats name for prometheus

### DIFF
--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -596,9 +596,8 @@ Http::Code AdminImpl::handlerPrometheusStats(absl::string_view, Http::HeaderMap&
 }
 
 std::string PrometheusStatsFormatter::sanitizeName(const std::string& name) {
-  // The name must match the regex [a-zA-Z_:][a-zA-Z0-9_:]* as required by
-  // prometheus. Of which the colon is reserved and should not be exported.
-  // Refer to https://prometheus.io/docs/concepts/data_model/.
+  // The name must match the regex [a-zA-Z_][a-zA-Z0-9_]* as required by
+  // prometheus. Refer to https://prometheus.io/docs/concepts/data_model/.
   std::string stats_name = std::regex_replace(name, PromRegex, "_");
   if (stats_name[0] >= '0' && stats_name[0] <= '9') {
     return fmt::format("_{}", stats_name);

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -618,7 +618,7 @@ std::string PrometheusStatsFormatter::metricName(const std::string& extractedNam
   // Add namespacing prefix to avoid conflicts, as per best practice:
   // https://prometheus.io/docs/practices/naming/#metric-names
   // Also, naming conventions on https://prometheus.io/docs/concepts/data_model/
-  return fmt::format("envoy_{0}", sanitizeName(extractedName));
+  return sanitizeName(fmt::format("envoy_{0}", extractedName));
 }
 
 // TODO(ramaraochavali): Add summary histogram output for Prometheus.

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1150,7 +1150,7 @@ TEST_F(PrometheusStatsFormatterTest, SanitizeMetricName) {
 
 TEST_F(PrometheusStatsFormatterTest, SanitizeMetricNameDigitFirst) {
   std::string raw = "3.artists.play-violin@019street";
-  std::string expected = "envoy__3_artists_play_violin_019street";
+  std::string expected = "envoy_3_artists_play_violin_019street";
   auto actual = PrometheusStatsFormatter::metricName(raw);
   EXPECT_EQ(expected, actual);
 }

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1141,6 +1141,20 @@ TEST_F(PrometheusStatsFormatterTest, MetricName) {
   EXPECT_EQ(expected, actual);
 }
 
+TEST_F(PrometheusStatsFormatterTest, SanitizeMetricName) {
+  std::string raw = "An.artist.plays-violin@019street";
+  std::string expected = "envoy_An_artist_plays_violin_019street";
+  auto actual = PrometheusStatsFormatter::metricName(raw);
+  EXPECT_EQ(expected, actual);
+}
+
+TEST_F(PrometheusStatsFormatterTest, SanitizeMetricNameDigitFirst) {
+  std::string raw = "3.artists.play-violin@019street";
+  std::string expected = "envoy__3_artists_play_violin_019street";
+  auto actual = PrometheusStatsFormatter::metricName(raw);
+  EXPECT_EQ(expected, actual);
+}
+
 TEST_F(PrometheusStatsFormatterTest, FormattedTags) {
   std::vector<Stats::Tag> tags;
   Stats::Tag tag1 = {"a.tag-name", "a.tag-value"};


### PR DESCRIPTION
This commit replaces the illegal characters in stats name for matching the
regex required by prometheus, which is [a-zA-Z_:][a-zA-Z0-9_:]*.

Fixes #4568 

The changes can be covered by the existing unit test PrometheusStatsFormatterTest.