### PR TITLE
change integration_admin_test.StatsMatcherIntegrationTest ip version…

### DIFF
--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -449,7 +449,7 @@ TEST_F(IntegrationAdminIpv4Ipv6Test, Ipv4Ipv6Listen) {
 class StatsMatcherIntegrationTest : public HttpIntegrationTest, public testing::Test {
 public:
   StatsMatcherIntegrationTest()
-      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, Network::Address::IpVersion::v4,
+      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, Network::Address::IpVersion::v6,
                             simTime()) {}
 
   void initialize() override {

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -446,11 +446,13 @@ TEST_F(IntegrationAdminIpv4Ipv6Test, Ipv4Ipv6Listen) {
 
 // Testing the behavior of StatsMatcher, which allows/denies the  instantiation of stats based on
 // restrictions on their names.
-class StatsMatcherIntegrationTest : public HttpIntegrationTest, public testing::Test {
+class StatsMatcherIntegrationTest
+    : public HttpIntegrationTest,
+      public testing::Test,
+      public testing::WithParamInterface<Network::Address::IpVersion> {
 public:
   StatsMatcherIntegrationTest()
-      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, Network::Address::IpVersion::v6,
-                            simTime()) {}
+      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam(), simTime()) {}
 
   void initialize() override {
     config_helper_.addConfigModifier(
@@ -469,30 +471,33 @@ public:
   BufferingStreamDecoderPtr response_;
   envoy::config::metrics::v2::StatsMatcher stats_matcher_;
 };
+INSTANTIATE_TEST_CASE_P(IpVersions, StatsMatcherIntegrationTest,
+                        testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                        TestUtility::ipTestParamsToString);
 
 // Verify that StatsMatcher prevents the printing of uninstantiated stats.
-TEST_F(StatsMatcherIntegrationTest, ExcludePrefixServerDot) {
+TEST_P(StatsMatcherIntegrationTest, ExcludePrefixServerDot) {
   stats_matcher_.mutable_exclusion_list()->add_patterns()->set_prefix("server.");
   initialize();
   makeRequest();
   EXPECT_THAT(response_->body(), testing::Not(testing::HasSubstr("server.")));
 }
 
-TEST_F(StatsMatcherIntegrationTest, ExcludeRequests) {
+TEST_P(StatsMatcherIntegrationTest, ExcludeRequests) {
   stats_matcher_.mutable_exclusion_list()->add_patterns()->set_regex(".*requests.*");
   initialize();
   makeRequest();
   EXPECT_THAT(response_->body(), testing::Not(testing::HasSubstr("requests")));
 }
 
-TEST_F(StatsMatcherIntegrationTest, ExcludeExact) {
+TEST_P(StatsMatcherIntegrationTest, ExcludeExact) {
   stats_matcher_.mutable_exclusion_list()->add_patterns()->set_exact("server.concurrency");
   initialize();
   makeRequest();
   EXPECT_THAT(response_->body(), testing::Not(testing::HasSubstr("server.concurrency")));
 }
 
-TEST_F(StatsMatcherIntegrationTest, ExcludeMultipleExact) {
+TEST_P(StatsMatcherIntegrationTest, ExcludeMultipleExact) {
   stats_matcher_.mutable_exclusion_list()->add_patterns()->set_exact("server.concurrency");
   stats_matcher_.mutable_exclusion_list()->add_patterns()->set_regex(".*live");
   initialize();
@@ -509,7 +514,7 @@ TEST_F(StatsMatcherIntegrationTest, ExcludeMultipleExact) {
 //      construction time, before setStatsMatcher() is called.
 //
 // If either of these invariants is changed, this test must be rewritten.
-TEST_F(StatsMatcherIntegrationTest, IncludeExact) {
+TEST_P(StatsMatcherIntegrationTest, IncludeExact) {
   stats_matcher_.mutable_inclusion_list()->add_patterns()->set_exact(
       "listener_manager.listener_create_success");
   initialize();


### PR DESCRIPTION
… to v6

The test is IP version orthogonal, but it fails on machines that only supports IP v6. 

Signed-off-by: Xin Zhuang <stevenzzz@stevenzzz6.cam.corp.google.com>

For an explanation of how to fill out the fields, please see the relevant section 
in PULL_REQUESTS.md

*Description*:
     Switch IP version in StatsMatcherIntegrationTest to IPv6. The test is IP version orthogonal, but it fails on machines that support only IPv6.

*Risk Level*: LOW (test only).
*Testing*:
*Docs Changes*:
*Release Notes*: