### PR TITLE
ci: not publish coverage for PRs

### DIFF
--- a/ci/coverage_publish.sh
+++ b/ci/coverage_publish.sh
@@ -8,11 +8,11 @@ if [ "${CIRCLECI}" != "true" ]; then
   exit 0
 fi
 
-# available for master builds and PRs from originating repository (not forks)
-if [ -z "$CIRCLE_PULL_REQUEST" ]
+# available for master builds
+if [ -z "$CIRCLE_PR_NUMBER" ]
 then
   echo "Uploading coverage report..."
-  
+
   [[ -z "${ENVOY_BUILD_DIR}" ]] && ENVOY_BUILD_DIR=/build
   COVERAGE_FILE="${ENVOY_BUILD_DIR}/envoy/generated/coverage/coverage.html"
 


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

*Description*:
PR coverages are already available in CircleCI artifacts, no need to publish to AWS.
Blocks #4562  as env var CIRCLE_PULL_REQUEST is not available if enable 2.1.

*Risk Level*: Low
*Testing*: CI
*Docs Changes*: N/A
*Release Notes*: N/A
