### PR TITLE
rbac: add support for SNI based permissions

### DIFF
--- a/api/envoy/config/rbac/v2alpha/rbac.proto
+++ b/api/envoy/config/rbac/v2alpha/rbac.proto
@@ -128,6 +128,24 @@ message Permission {
     Permission not_rule = 8;
 
     // The requested TLS SNI server name from the client's connection request.
+    //
+    // .. attention::
+    //
+    //   This field is primarily used for matching a TLS connection's SNI based
+    //   requested server name. However, this matching might be affected by how
+    //   Envoy is configured as explained below.
+    //
+    //   * If the :ref:`TLS Inspector <config_listener_filters_tls_inspector>`
+    //     filter is not added, and if a `FilterChainMatch` is not defined for
+    //     the :ref:`server name <envoy_api_field_Listener.FilterChainMatch.server_names>`,
+    //     a TLS connection's requested SNI server name will be treated as if it
+    //     wasn't present.
+    //
+    //   * A listener filter may overwrite a connection's requested server name
+    //     within Envoy.
+    //
+    // Please refer to `this FAQ <https://www.envoyproxy.io/docs/envoy/latest/faq/sni>`_
+    // to learn to setup SNI.
     envoy.type.matcher.StringMatcher requested_server_name = 9;
   }
 }

--- a/api/envoy/config/rbac/v2alpha/rbac.proto
+++ b/api/envoy/config/rbac/v2alpha/rbac.proto
@@ -127,13 +127,13 @@ message Permission {
     // match, this permission would match.
     Permission not_rule = 8;
 
-    // The requested TLS SNI server name from the client's connection request.
+    // The request server from the client's connection request. This is
+    // typically TLS SNI.
     //
     // .. attention::
     //
-    //   This field is primarily used for matching a TLS connection's SNI based
-    //   requested server name. However, this matching might be affected by how
-    //   Envoy is configured as explained below.
+    //   The behavior of this field may be affected by how Envoy is configured
+    //   as explained below.
     //
     //   * If the :ref:`TLS Inspector <config_listener_filters_tls_inspector>`
     //     filter is not added, and if a `FilterChainMatch` is not defined for
@@ -141,11 +141,11 @@ message Permission {
     //     a TLS connection's requested SNI server name will be treated as if it
     //     wasn't present.
     //
-    //   * A listener filter may overwrite a connection's requested server name
-    //     within Envoy.
+    //   * A :ref:`listener filter <arch_overview_listener_filters>` may
+    //     overwrite a connection's requested server name within Envoy.
     //
-    // Please refer to `this FAQ <https://www.envoyproxy.io/docs/envoy/latest/faq/sni>`_
-    // to learn to setup SNI.
+    // Please refer to :ref:`this FAQ entry <faq_how_to_setup_sni>` to learn to
+    // setup SNI.
     envoy.type.matcher.StringMatcher requested_server_name = 9;
   }
 }

--- a/api/envoy/config/rbac/v2alpha/rbac.proto
+++ b/api/envoy/config/rbac/v2alpha/rbac.proto
@@ -127,8 +127,8 @@ message Permission {
     // match, this permission would match.
     Permission not_rule = 8;
 
-    // The name of the destination server that the client is attempting to connect to.
-    string requested_server_name = 9;
+    // The requested TLS SNI server name from the client's connection request.
+    envoy.type.matcher.StringMatcher requested_server_name = 9;
   }
 }
 

--- a/api/envoy/config/rbac/v2alpha/rbac.proto
+++ b/api/envoy/config/rbac/v2alpha/rbac.proto
@@ -126,6 +126,9 @@ message Permission {
     // match, this permission would not match. Conversely, if the value of `not_rule` would not
     // match, this permission would match.
     Permission not_rule = 8;
+
+    // The name of the destination server that the client is attempting to connect to.
+    string requested_server_name = 9;
   }
 }
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -8,7 +8,7 @@ Version history
 * http: no longer adding whitespace when appending X-Forwarded-For headers. **Warning**: this is not
   compatible with 1.7.0 builds prior to `9d3a4eb4ac44be9f0651fcc7f87ad98c538b01ee <https://github.com/envoyproxy/envoy/pull/3610>`_.
   See `#3611 <https://github.com/envoyproxy/envoy/issues/3611>`_ for details.
-* rbac: added support for :ref:`TLS SNI based <envoy_api_field_config.rbac.v2alpha.Permission.requested_server_name>` permissions.
+* rbac: added support for permission matching by :ref:`requested server name <envoy_api_field_config.rbac.v2alpha.Permission.requested_server_name>`.
 * router: added ability to configure arbitrary :ref:`retriable status codes. <envoy_api_field_route.RouteAction.RetryPolicy.retriable_status_codes>`
 * router: added ability to set attempt count in upstream requests, see :ref:`virtual host's include request
   attempt count flag <envoy_api_field_route.VirtualHost.include_request_attempt_count>`.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -12,6 +12,7 @@ Version history
 * router: added ability to set attempt count in upstream requests, see :ref:`virtual host's include request
   attempt count flag <envoy_api_field_route.VirtualHost.include_request_attempt_count>`.
 * router: added internal :ref:`grpc-retry-on <config_http_filters_router_x-envoy-retry-grpc-on>` policy.
+* rbac: added support for :ref:`SNI based <envoy_api_field_config.rbac.v2alpha.Permission.requested_server_name>` permissions.
 * router: when :ref:`max_grpc_timeout <envoy_api_field_route.RouteAction.max_grpc_timeout>`
   is set, Envoy will now add or update the grpc-timeout header to reflect Envoy's expected timeout.
 * stats: added :ref:`stats_matcher <envoy_api_field_config.metrics.v2.StatsConfig.stats_matcher>` to the bootstrap config for granular control of stat instantiation.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -8,11 +8,11 @@ Version history
 * http: no longer adding whitespace when appending X-Forwarded-For headers. **Warning**: this is not
   compatible with 1.7.0 builds prior to `9d3a4eb4ac44be9f0651fcc7f87ad98c538b01ee <https://github.com/envoyproxy/envoy/pull/3610>`_.
   See `#3611 <https://github.com/envoyproxy/envoy/issues/3611>`_ for details.
+* rbac: added support for :ref:`TLS SNI based <envoy_api_field_config.rbac.v2alpha.Permission.requested_server_name>` permissions.
 * router: added ability to configure arbitrary :ref:`retriable status codes. <envoy_api_field_route.RouteAction.RetryPolicy.retriable_status_codes>`
 * router: added ability to set attempt count in upstream requests, see :ref:`virtual host's include request
   attempt count flag <envoy_api_field_route.VirtualHost.include_request_attempt_count>`.
 * router: added internal :ref:`grpc-retry-on <config_http_filters_router_x-envoy-retry-grpc-on>` policy.
-* rbac: added support for :ref:`SNI based <envoy_api_field_config.rbac.v2alpha.Permission.requested_server_name>` permissions.
 * router: when :ref:`max_grpc_timeout <envoy_api_field_route.RouteAction.max_grpc_timeout>`
   is set, Envoy will now add or update the grpc-timeout header to reflect Envoy's expected timeout.
 * stats: added :ref:`stats_matcher <envoy_api_field_config.metrics.v2.StatsConfig.stats_matcher>` to the bootstrap config for granular control of stat instantiation.

--- a/source/common/common/matchers.cc
+++ b/source/common/common/matchers.cc
@@ -64,7 +64,7 @@ bool StringMatcher::match(const ProtobufWkt::Value& value) const {
   return match(value.string_value());
 }
 
-bool StringMatcher::match(const std::string& value) const {
+bool StringMatcher::match(const absl::string_view value) const {
   switch (matcher_.match_pattern_case()) {
   case envoy::type::matcher::StringMatcher::kExact:
     return matcher_.exact() == value;
@@ -73,7 +73,7 @@ bool StringMatcher::match(const std::string& value) const {
   case envoy::type::matcher::StringMatcher::kSuffix:
     return absl::EndsWith(value, matcher_.suffix());
   case envoy::type::matcher::StringMatcher::kRegex:
-    return std::regex_match(value, regex_);
+    return std::regex_match(value.begin(), value.end(), regex_);
   default:
     NOT_REACHED_GCOVR_EXCL_LINE;
   }

--- a/source/common/common/matchers.h
+++ b/source/common/common/matchers.h
@@ -78,7 +78,7 @@ public:
     }
   }
 
-  bool match(const std::string& value) const;
+  bool match(const absl::string_view value) const;
 
   bool match(const ProtobufWkt::Value& value) const override;
 

--- a/source/extensions/filters/common/rbac/matchers.cc
+++ b/source/extensions/filters/common/rbac/matchers.cc
@@ -26,6 +26,8 @@ MatcherConstSharedPtr Matcher::create(const envoy::config::rbac::v2alpha::Permis
     return std::make_shared<const MetadataMatcher>(permission.metadata());
   case envoy::config::rbac::v2alpha::Permission::RuleCase::kNotRule:
     return std::make_shared<const NotMatcher>(permission.not_rule());
+  case envoy::config::rbac::v2alpha::Permission::RuleCase::kRequestedServerName:
+    return std::make_shared<const RequestedServerNameMatcher>(permission.requested_server_name());
   default:
     NOT_REACHED_GCOVR_EXCL_LINE;
   }
@@ -155,6 +157,12 @@ bool PolicyMatcher::matches(const Network::Connection& connection,
                             const envoy::api::v2::core::Metadata& metadata) const {
   return permissions_.matches(connection, headers, metadata) &&
          principals_.matches(connection, headers, metadata);
+}
+
+bool RequestedServerNameMatcher::matches(const Network::Connection& connection,
+                                         const Envoy::Http::HeaderMap&,
+                                         const envoy::api::v2::core::Metadata&) const {
+  return std::regex_match(connection.requestedServerName().data(), server_name_regex_);
 }
 
 } // namespace RBAC

--- a/source/extensions/filters/common/rbac/matchers.cc
+++ b/source/extensions/filters/common/rbac/matchers.cc
@@ -162,11 +162,7 @@ bool PolicyMatcher::matches(const Network::Connection& connection,
 bool RequestedServerNameMatcher::matches(const Network::Connection& connection,
                                          const Envoy::Http::HeaderMap&,
                                          const envoy::api::v2::core::Metadata&) const {
-  absl::string_view requested_server_name = connection.requestedServerName();
-  if (!requested_server_name.empty()) { // test for null string_view
-    return match(requested_server_name.data());
-  }
-  return match("");
+  return match(connection.requestedServerName());
 }
 
 } // namespace RBAC

--- a/source/extensions/filters/common/rbac/matchers.cc
+++ b/source/extensions/filters/common/rbac/matchers.cc
@@ -162,7 +162,11 @@ bool PolicyMatcher::matches(const Network::Connection& connection,
 bool RequestedServerNameMatcher::matches(const Network::Connection& connection,
                                          const Envoy::Http::HeaderMap&,
                                          const envoy::api::v2::core::Metadata&) const {
-  return std::regex_match(connection.requestedServerName().data(), server_name_regex_);
+  absl::string_view requested_server_name = connection.requestedServerName();
+  if (!requested_server_name.empty()) { // test for null string_view
+    return match(requested_server_name.data());
+  }
+  return match("");
 }
 
 } // namespace RBAC

--- a/source/extensions/filters/common/rbac/matchers.h
+++ b/source/extensions/filters/common/rbac/matchers.h
@@ -203,7 +203,8 @@ private:
 };
 
 /**
- * Perform a match against the requested TLS SNI server name.
+ * Perform a match against the request server from the client's connection
+ * request. This is typically TLS SNI.
  */
 class RequestedServerNameMatcher : public Matcher, Envoy::Matchers::StringMatcher {
 public:

--- a/source/extensions/filters/common/rbac/matchers.h
+++ b/source/extensions/filters/common/rbac/matchers.h
@@ -205,27 +205,15 @@ private:
 };
 
 /**
- * Perform a match against the requested SNI server name.
+ * Perform a match against the requested TLS SNI server name.
  */
-class RequestedServerNameMatcher : public Matcher {
+class RequestedServerNameMatcher : public Matcher, Envoy::Matchers::StringMatcher {
 public:
-  /**
-   * The constructor creates a simple regex from the input server name to be
-   * used further while matching. The regex substitutions are described below.
-   *
-   * 1. . with \. to treat the dot as a simple dot, and not a regex dot
-   * 2. * with .+? to enforce a one or more characters match
-   */
-  RequestedServerNameMatcher(const std::string& sni_server_name)
-      : server_name_regex_(RegexUtil::parseRegex(
-            absl::StrReplaceAll(sni_server_name, {{".", "\\."}, {"*", ".+?"}}),
-            std::regex::optimize)) {}
+  RequestedServerNameMatcher(const envoy::type::matcher::StringMatcher& requested_server_name)
+      : Envoy::Matchers::StringMatcher(requested_server_name) {}
 
   bool matches(const Network::Connection& connection, const Envoy::Http::HeaderMap& headers,
                const envoy::api::v2::core::Metadata&) const override;
-
-private:
-  const std::regex server_name_regex_;
 };
 
 } // namespace RBAC

--- a/source/extensions/filters/common/rbac/matchers.h
+++ b/source/extensions/filters/common/rbac/matchers.h
@@ -11,8 +11,6 @@
 #include "common/http/header_utility.h"
 #include "common/network/cidr_range.h"
 
-#include "absl/strings/str_replace.h"
-
 namespace Envoy {
 namespace Extensions {
 namespace Filters {

--- a/test/extensions/filters/common/rbac/matchers_test.cc
+++ b/test/extensions/filters/common/rbac/matchers_test.cc
@@ -313,8 +313,8 @@ TEST(RequestedServerNameMatcher, ValidRequestedServerName) {
   checkMatcher(RequestedServerNameMatcher(createRegexMatcher("www.*")), true, conn);
   checkMatcher(RequestedServerNameMatcher(createRegexMatcher(".*io")), true, conn);
   checkMatcher(RequestedServerNameMatcher(createRegexMatcher(".*")), true, conn);
-  checkMatcher(RequestedServerNameMatcher(createExactMatcher("")), false, conn);
 
+  checkMatcher(RequestedServerNameMatcher(createExactMatcher("")), false, conn);
   checkMatcher(RequestedServerNameMatcher(createExactMatcher("www.cncf.io")), true, conn);
   checkMatcher(RequestedServerNameMatcher(createExactMatcher("xyz.cncf.io")), false, conn);
   checkMatcher(RequestedServerNameMatcher(createExactMatcher("example.com")), false, conn);
@@ -325,8 +325,8 @@ TEST(RequestedServerNameMatcher, EmptyRequestedServerName) {
   EXPECT_CALL(conn, requestedServerName()).Times(3).WillRepeatedly(Return(absl::string_view("")));
 
   checkMatcher(RequestedServerNameMatcher(createRegexMatcher(".*")), true, conn);
-  checkMatcher(RequestedServerNameMatcher(createExactMatcher("")), true, conn);
 
+  checkMatcher(RequestedServerNameMatcher(createExactMatcher("")), true, conn);
   checkMatcher(RequestedServerNameMatcher(createExactMatcher("example.com")), false, conn);
 }
 

--- a/test/extensions/filters/common/rbac/matchers_test.cc
+++ b/test/extensions/filters/common/rbac/matchers_test.cc
@@ -290,6 +290,29 @@ TEST(PolicyMatcher, PolicyMatcher) {
   checkMatcher(matcher, false, conn);
 }
 
+TEST(RequestedServerNameMatcher, ValidRequestedServerName) {
+  Envoy::Network::MockConnection conn;
+  EXPECT_CALL(conn, requestedServerName())
+      .Times(8)
+      .WillRepeatedly(Return(absl::string_view("www.cncf.io")));
+
+  checkMatcher(RequestedServerNameMatcher("www.cncf.io"), true, conn);
+  checkMatcher(RequestedServerNameMatcher("*.cncf.io"), true, conn);
+  checkMatcher(RequestedServerNameMatcher("*.cncf.*"), true, conn);
+  checkMatcher(RequestedServerNameMatcher("www.*"), true, conn);
+  checkMatcher(RequestedServerNameMatcher("*.io"), true, conn);
+  checkMatcher(RequestedServerNameMatcher("*"), true, conn);
+  checkMatcher(RequestedServerNameMatcher("xyz.cncf.io"), false, conn);
+  checkMatcher(RequestedServerNameMatcher("example.com"), false, conn);
+}
+
+TEST(RequestedServerNameMatcher, EmptyRequestedServerName) {
+  Envoy::Network::MockConnection conn;
+  EXPECT_CALL(conn, requestedServerName()).Times(1).WillRepeatedly(Return(absl::string_view("")));
+
+  checkMatcher(RequestedServerNameMatcher("example.com"), false, conn);
+}
+
 } // namespace
 } // namespace RBAC
 } // namespace Common

--- a/test/extensions/filters/common/rbac/matchers_test.cc
+++ b/test/extensions/filters/common/rbac/matchers_test.cc
@@ -305,7 +305,7 @@ const envoy::type::matcher::StringMatcher createExactMatcher(std::string str) {
 TEST(RequestedServerNameMatcher, ValidRequestedServerName) {
   Envoy::Network::MockConnection conn;
   EXPECT_CALL(conn, requestedServerName())
-      .Times(8)
+      .Times(9)
       .WillRepeatedly(Return(absl::string_view("www.cncf.io")));
 
   checkMatcher(RequestedServerNameMatcher(createRegexMatcher(".*cncf.io")), true, conn);
@@ -313,6 +313,7 @@ TEST(RequestedServerNameMatcher, ValidRequestedServerName) {
   checkMatcher(RequestedServerNameMatcher(createRegexMatcher("www.*")), true, conn);
   checkMatcher(RequestedServerNameMatcher(createRegexMatcher(".*io")), true, conn);
   checkMatcher(RequestedServerNameMatcher(createRegexMatcher(".*")), true, conn);
+  checkMatcher(RequestedServerNameMatcher(createExactMatcher("")), false, conn);
 
   checkMatcher(RequestedServerNameMatcher(createExactMatcher("www.cncf.io")), true, conn);
   checkMatcher(RequestedServerNameMatcher(createExactMatcher("xyz.cncf.io")), false, conn);
@@ -321,9 +322,10 @@ TEST(RequestedServerNameMatcher, ValidRequestedServerName) {
 
 TEST(RequestedServerNameMatcher, EmptyRequestedServerName) {
   Envoy::Network::MockConnection conn;
-  EXPECT_CALL(conn, requestedServerName()).Times(2).WillRepeatedly(Return(absl::string_view("")));
+  EXPECT_CALL(conn, requestedServerName()).Times(3).WillRepeatedly(Return(absl::string_view("")));
 
   checkMatcher(RequestedServerNameMatcher(createRegexMatcher(".*")), true, conn);
+  checkMatcher(RequestedServerNameMatcher(createExactMatcher("")), true, conn);
 
   checkMatcher(RequestedServerNameMatcher(createExactMatcher("example.com")), false, conn);
 }

--- a/test/extensions/filters/http/rbac/rbac_filter_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_test.cc
@@ -28,7 +28,7 @@ public:
 
     envoy::config::rbac::v2alpha::Policy policy;
     auto policy_rules = policy.add_permissions()->mutable_or_rules();
-    policy_rules->add_rules()->set_requested_server_name("www.cncf.io");
+    policy_rules->add_rules()->mutable_requested_server_name()->set_regex(".*cncf.io");
     policy_rules->add_rules()->set_destination_port(123);
     policy.add_principals()->set_any(true);
     config.mutable_rules()->set_action(envoy::config::rbac::v2alpha::RBAC::ALLOW);
@@ -36,7 +36,7 @@ public:
 
     envoy::config::rbac::v2alpha::Policy shadow_policy;
     auto shadow_policy_rules = shadow_policy.add_permissions()->mutable_or_rules();
-    shadow_policy_rules->add_rules()->set_requested_server_name("xyz.cncf.io");
+    shadow_policy_rules->add_rules()->mutable_requested_server_name()->set_exact("xyz.cncf.io");
     shadow_policy_rules->add_rules()->set_destination_port(456);
     shadow_policy.add_principals()->set_any(true);
     config.mutable_shadow_rules()->set_action(envoy::config::rbac::v2alpha::RBAC::ALLOW);

--- a/test/extensions/filters/http/rbac/rbac_filter_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_test.cc
@@ -27,13 +27,17 @@ public:
     envoy::config::filter::http::rbac::v2::RBAC config;
 
     envoy::config::rbac::v2alpha::Policy policy;
-    policy.add_permissions()->set_destination_port(123);
+    auto policy_rules = policy.add_permissions()->mutable_or_rules();
+    policy_rules->add_rules()->set_requested_server_name("www.cncf.io");
+    policy_rules->add_rules()->set_destination_port(123);
     policy.add_principals()->set_any(true);
     config.mutable_rules()->set_action(envoy::config::rbac::v2alpha::RBAC::ALLOW);
     (*config.mutable_rules()->mutable_policies())["foo"] = policy;
 
     envoy::config::rbac::v2alpha::Policy shadow_policy;
-    shadow_policy.add_permissions()->set_destination_port(456);
+    auto shadow_policy_rules = shadow_policy.add_permissions()->mutable_or_rules();
+    shadow_policy_rules->add_rules()->set_requested_server_name("xyz.cncf.io");
+    shadow_policy_rules->add_rules()->set_destination_port(456);
     shadow_policy.add_principals()->set_any(true);
     config.mutable_shadow_rules()->set_action(envoy::config::rbac::v2alpha::RBAC::ALLOW);
     (*config.mutable_shadow_rules()->mutable_policies())["bar"] = shadow_policy;
@@ -54,6 +58,11 @@ public:
     ON_CALL(connection_, localAddress()).WillByDefault(ReturnRef(address_));
   }
 
+  void setRequestedServerName(std::string server_name) {
+    requested_server_name_ = server_name;
+    ON_CALL(connection_, requestedServerName()).WillByDefault(Return(requested_server_name_));
+  }
+
   void setMetadata() {
     ON_CALL(req_info_, setDynamicMetadata(HttpFilterNames::get().Rbac, _))
         .WillByDefault(Invoke([this](const std::string&, const ProtobufWkt::Struct& obj) {
@@ -71,6 +80,7 @@ public:
 
   RoleBasedAccessControlFilter filter_;
   Network::Address::InstanceConstSharedPtr address_;
+  std::string requested_server_name_;
   Http::TestHeaderMapImpl headers_;
 };
 
@@ -79,6 +89,21 @@ TEST_F(RoleBasedAccessControlFilterTest, Allowed) {
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(headers_, false));
   EXPECT_EQ(1U, config_->stats().allowed_.value());
+  EXPECT_EQ(1U, config_->stats().shadow_denied_.value());
+
+  Buffer::OwnedImpl data("");
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(headers_));
+}
+
+TEST_F(RoleBasedAccessControlFilterTest, RequestedServerName) {
+  setDestinationPort(999);
+  setRequestedServerName("www.cncf.io");
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(headers_, false));
+  EXPECT_EQ(1U, config_->stats().allowed_.value());
+  EXPECT_EQ(0U, config_->stats().denied_.value());
+  EXPECT_EQ(0U, config_->stats().shadow_allowed_.value());
   EXPECT_EQ(1U, config_->stats().shadow_denied_.value());
 
   Buffer::OwnedImpl data("");

--- a/test/extensions/filters/network/rbac/filter_test.cc
+++ b/test/extensions/filters/network/rbac/filter_test.cc
@@ -6,6 +6,7 @@
 #include "test/mocks/network/mocks.h"
 
 using testing::NiceMock;
+using testing::Return;
 using testing::ReturnRef;
 
 namespace Envoy {
@@ -21,13 +22,17 @@ public:
 
     if (with_policy) {
       envoy::config::rbac::v2alpha::Policy policy;
-      policy.add_permissions()->set_destination_port(123);
+      auto policy_rules = policy.add_permissions()->mutable_or_rules();
+      policy_rules->add_rules()->set_requested_server_name("www.cncf.io");
+      policy_rules->add_rules()->set_destination_port(123);
       policy.add_principals()->set_any(true);
       config.mutable_rules()->set_action(envoy::config::rbac::v2alpha::RBAC::ALLOW);
       (*config.mutable_rules()->mutable_policies())["foo"] = policy;
 
       envoy::config::rbac::v2alpha::Policy shadow_policy;
-      shadow_policy.add_permissions()->set_destination_port(456);
+      auto shadow_policy_rules = shadow_policy.add_permissions()->mutable_or_rules();
+      shadow_policy_rules->add_rules()->set_requested_server_name("xyz.cncf.io");
+      shadow_policy_rules->add_rules()->set_destination_port(456);
       shadow_policy.add_principals()->set_any(true);
       config.mutable_shadow_rules()->set_action(envoy::config::rbac::v2alpha::RBAC::ALLOW);
       (*config.mutable_shadow_rules()->mutable_policies())["bar"] = shadow_policy;
@@ -46,6 +51,12 @@ public:
     EXPECT_CALL(callbacks_.connection_, localAddress()).WillRepeatedly(ReturnRef(address_));
   }
 
+  void setRequestedServerName(std::string server_name) {
+    requested_server_name_ = server_name;
+    ON_CALL(callbacks_.connection_, requestedServerName())
+        .WillByDefault(Return(requested_server_name_));
+  }
+
   NiceMock<Network::MockReadFilterCallbacks> callbacks_;
   Stats::IsolatedStoreImpl store_;
   Buffer::OwnedImpl data_;
@@ -53,10 +64,26 @@ public:
 
   std::unique_ptr<RoleBasedAccessControlFilter> filter_;
   Network::Address::InstanceConstSharedPtr address_;
+  std::string requested_server_name_;
 };
 
 TEST_F(RoleBasedAccessControlNetworkFilterTest, Allowed) {
   setDestinationPort(123);
+
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
+
+  // Call onData() twice, should only increase stats once.
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data_, false));
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(data_, false));
+  EXPECT_EQ(1U, config_->stats().allowed_.value());
+  EXPECT_EQ(0U, config_->stats().denied_.value());
+  EXPECT_EQ(0U, config_->stats().shadow_allowed_.value());
+  EXPECT_EQ(1U, config_->stats().shadow_denied_.value());
+}
+
+TEST_F(RoleBasedAccessControlNetworkFilterTest, RequestedServerName) {
+  setDestinationPort(999);
+  setRequestedServerName("www.cncf.io");
 
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
 

--- a/test/extensions/filters/network/rbac/filter_test.cc
+++ b/test/extensions/filters/network/rbac/filter_test.cc
@@ -23,7 +23,7 @@ public:
     if (with_policy) {
       envoy::config::rbac::v2alpha::Policy policy;
       auto policy_rules = policy.add_permissions()->mutable_or_rules();
-      policy_rules->add_rules()->set_requested_server_name("www.cncf.io");
+      policy_rules->add_rules()->mutable_requested_server_name()->set_regex(".*cncf.io");
       policy_rules->add_rules()->set_destination_port(123);
       policy.add_principals()->set_any(true);
       config.mutable_rules()->set_action(envoy::config::rbac::v2alpha::RBAC::ALLOW);
@@ -31,7 +31,7 @@ public:
 
       envoy::config::rbac::v2alpha::Policy shadow_policy;
       auto shadow_policy_rules = shadow_policy.add_permissions()->mutable_or_rules();
-      shadow_policy_rules->add_rules()->set_requested_server_name("xyz.cncf.io");
+      shadow_policy_rules->add_rules()->mutable_requested_server_name()->set_exact("xyz.cncf.io");
       shadow_policy_rules->add_rules()->set_destination_port(456);
       shadow_policy.add_principals()->set_any(true);
       config.mutable_shadow_rules()->set_action(envoy::config::rbac::v2alpha::RBAC::ALLOW);


### PR DESCRIPTION
*Description*: This PR adds support for SNI based permissions by matching over a
connection's requested server name.
*Risk Level*: Low
*Testing*: Added 4 additional tests
*Docs Changes*: N/A
*Release Notes*: Added a note about this feature
Fixes #4515