### PR TITLE
docs: Prepend apt-get with sudo

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -28,15 +28,16 @@ for how to update or override dependencies.
 
 1. Install the latest version of [Bazel](https://bazel.build/versions/master/docs/install.html) in your environment.
 2. Install external dependencies libtool, cmake, ninja, realpath and curl libraries separately.
-On Ubuntu, run the following commands:
+On Ubuntu, run the following command:
 ```
- apt-get install libtool
- apt-get install cmake
- apt-get install realpath
- apt-get install clang-format-7
- apt-get install automake
- apt-get install ninja-build
- apt-get install curl
+sudo apt-get install \
+   libtool \
+   cmake \
+   realpath \
+   clang-format-7 \
+   automake \
+   ninja-build \
+   curl
 ```
 
 On Fedora (maybe also other red hat distros), run the following:


### PR DESCRIPTION
Also fixed the formatting for apt-get to be a one-liner that can easily be copied and pasted. I retained the "one package per line" strategy, since it simplifies maintenance as dependencies might be added/removed later on.

If you dislike the formatting change, let me know and I can rephrase with just `sudo` on each line instead.
