### PR TITLE
docs: Lua support is no longer experimental

### DIFF
--- a/docs/root/intro/arch_overview/scripting.rst
+++ b/docs/root/intro/arch_overview/scripting.rst
@@ -1,5 +1,5 @@
 Scripting
 =========
 
-Envoy supports experimental `Lua <https://www.lua.org/>`_ scripting as part of a dedicated
+Envoy supports `Lua <https://www.lua.org/>`_ scripting as part of a dedicated
 :ref:`HTTP filter <config_http_filters_lua>`.


### PR DESCRIPTION
As of #3117, Lua support is no longer experimental and shouldn't be marked as such in the documentation; it might make people scared of using it.