### PR TITLE
retry plugins: specify the correct config proto for other_priority

### DIFF
--- a/source/extensions/retry/priority/other_priority/config.h
+++ b/source/extensions/retry/priority/other_priority/config.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "envoy/config/retry/other_priority/other_priority_config.pb.validate.h"
+
 #include "envoy/upstream/retry.h"
 
 #include "common/protobuf/protobuf.h"
@@ -22,7 +24,8 @@ public:
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return ProtobufTypes::MessagePtr(new ::Envoy::ProtobufWkt::Empty());
+    return ProtobufTypes::MessagePtr(
+        new envoy::config::retry::other_priority::OtherPriorityConfig());
   }
 };
 


### PR DESCRIPTION
Previously this was set to Empty, which caused config parsing to fail
with

```
message=Unable to parse JSON as proto (INVALID_ARGUMENT:: invalid name u
pdate_frequency: Cannot find field.): {"update_frequency":2}
```

*Risk Level*: Low
*Testing*: n/a
*Docs Changes*: n/a
*Release Notes*: n/a
