### PR TITLE
Fix use-after-free bug in ConnectionManagerImpl::ActiveStream::decode…

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -504,6 +504,8 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
     is_head_request_ = true;
   }
 
+  maybeEndDecode(end_stream);
+
   // Drop new requests when overloaded as soon as we have decoded the headers.
   if (connection_manager_.overload_stop_accepting_requests_ref_ ==
       Server::OverloadActionState::Active) {
@@ -514,8 +516,6 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
   }
 
   const bool upgrade_rejected = createFilterChain() == false;
-
-  maybeEndDecode(end_stream);
 
   ENVOY_STREAM_LOG(debug, "request headers complete (end_stream={}):\n{}", *this, end_stream,
                    *request_headers_);

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -3232,7 +3232,7 @@ TEST_F(HttpConnectionManagerImplTest, NoNewStreamWhenOverloaded) {
     StreamDecoder* decoder = &conn_manager_->newStream(response_encoder_);
     HeaderMapPtr headers{
         new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}, {":method", "GET"}}};
-    decoder->decodeHeaders(std::move(headers), true);
+    decoder->decodeHeaders(std::move(headers), false);
   }));
 
   // 503 direct response when overloaded.


### PR DESCRIPTION
…Headers

*Description*:
Move the maybeEndDecode call to before the overload check and associated sendLocalReply call. This fixes a heap use-after-free bug where the "stop accepting requests" overload action is active and envoy receives a header-only request over HTTP1.x. In this case the Http1::ServerConnectionImpl::active_request_ field is reset as part of the sendLocalReply (in ActiveStream::encodeData -> Http1::StreamEncoderImpl::encodeData -> Http1::StreamEncoderImpl::endEncode -> Http1::ServerConnectionImpl::onEncodeComplete), which frees the ResponseStreamEncoderImpl in the ActiveRequest object. Soon after the HCM tries to access the freed response encoder (in ActiveStream::encodeData -> ActiveStream::maybeEndEncode -> ConnectionManagerImpl::doEndStream).

This is avoided if we call ActiveStream::maybeEndDecode before the sendLocalReply, which ensures that stream.state_.remote_complete_ is true so we don't try to access the freed response encoder.

*Risk Level*: low
*Testing*: unit and integration tests
*Docs Changes*:

Signed-off-by: Elisha Ziskind <eziskind@google.com>


