### PR TITLE
docs: point ref_configs templates to v2 (yaml)

### DIFF
--- a/docs/root/install/ref_configs.rst
+++ b/docs/root/install/ref_configs.rst
@@ -24,9 +24,9 @@ we use at Lyft. We have also included three example configuration templates for 
 three scenarios.
 
 * Generator script: :repo:`configs/configgen.py`
-* Service to service template: :repo:`configs/envoy_service_to_service.template.json`
-* Front proxy template: :repo:`configs/envoy_front_proxy.template.json`
-* Double proxy template: :repo:`configs/envoy_double_proxy.template.json`
+* Service to service template: :repo:`configs/envoy_service_to_service_v2.template.yaml'`
+* Front proxy template: :repo:`configs/envoy_front_proxy_v2.template.yaml`
+* Double proxy template: :repo:`configs/envoy_double_proxy_v2.template.yaml`
 
 To generate the example configurations run the following from the root of the repo:
 


### PR DESCRIPTION
*Description*: The format (and filenames) changed in #2957. This updates the docs to point to the new templates. (Right now the links 404.)
*Risk Level*: Low
*Testing*: N/A
*Docs Changes*: Updating links to templates.
*Release Notes*: N/A
