### PR TITLE
tcp: allow conn pool cancel to request connection close

### DIFF
--- a/include/envoy/tcp/conn_pool.h
+++ b/include/envoy/tcp/conn_pool.h
@@ -21,8 +21,12 @@ public:
 
   /**
    * Cancel the pending request.
+   * @param close if true the connection pool will close a pending connection as part of
+   *              cancellation (unless the number of pending requests exceeds the number of pending
+   *              connections). If false, the pending request is allowed to complete and becomes
+   *              available for a future connection request.
    */
-  virtual void cancel() PURE;
+  virtual void cancel(bool close = false) PURE;
 };
 
 /**

--- a/source/common/tcp/conn_pool.cc
+++ b/source/common/tcp/conn_pool.cc
@@ -22,6 +22,10 @@ ConnPoolImpl::~ConnPoolImpl() {
     busy_conns_.front()->conn_->close(Network::ConnectionCloseType::NoFlush);
   }
 
+  while (!pending_conns_.empty()) {
+    pending_conns_.front()->conn_->close(Network::ConnectionCloseType::NoFlush);
+  }
+
   // Make sure all connections are destroyed before we are destroyed.
   dispatcher_.clearDeferredDeleteList();
 }
@@ -31,9 +35,13 @@ void ConnPoolImpl::drainConnections() {
     ready_conns_.front()->conn_->close(Network::ConnectionCloseType::NoFlush);
   }
 
-  // We drain busy connections by manually setting remaining requests to 1. Thus, when the next
-  // response completes the connection will be destroyed.
+  // We drain busy and pending connections by manually setting remaining requests to 1. Thus, when
+  // the next response completes the connection will be destroyed.
   for (const auto& conn : busy_conns_) {
+    conn->remaining_requests_ = 1;
+  }
+
+  for (const auto& conn : pending_conns_) {
     conn->remaining_requests_ = 1;
   }
 }
@@ -52,7 +60,8 @@ void ConnPoolImpl::assignConnection(ActiveConn& conn, ConnectionPool::Callbacks&
 }
 
 void ConnPoolImpl::checkForDrained() {
-  if (!drained_callbacks_.empty() && pending_requests_.empty() && busy_conns_.empty()) {
+  if (!drained_callbacks_.empty() && pending_requests_.empty() && busy_conns_.empty() &&
+      pending_conns_.empty()) {
     while (!ready_conns_.empty()) {
       ready_conns_.front()->conn_->close(Network::ConnectionCloseType::NoFlush);
     }
@@ -66,7 +75,7 @@ void ConnPoolImpl::checkForDrained() {
 void ConnPoolImpl::createNewConnection() {
   ENVOY_LOG(debug, "creating a new connection");
   ActiveConnPtr conn(new ActiveConn(*this));
-  conn->moveIntoList(std::move(conn), busy_conns_);
+  conn->moveIntoList(std::move(conn), pending_conns_);
 }
 
 ConnectionPool::Cancellable* ConnPoolImpl::newConnection(ConnectionPool::Callbacks& callbacks) {
@@ -85,7 +94,8 @@ ConnectionPool::Cancellable* ConnPoolImpl::newConnection(ConnectionPool::Callbac
     }
 
     // If we have no connections at all, make one no matter what so we don't starve.
-    if ((ready_conns_.size() == 0 && busy_conns_.size() == 0) || can_create_connection) {
+    if ((ready_conns_.empty() && busy_conns_.empty() && pending_conns_.empty()) ||
+        can_create_connection) {
       createNewConnection();
     }
 
@@ -139,7 +149,7 @@ void ConnPoolImpl::onConnectionEvent(ActiveConn& conn, Network::ConnectionEvent 
       // The only time this happens is if we actually saw a connect failure.
       host_->cluster().stats().upstream_cx_connect_fail_.inc();
       host_->stats().cx_connect_fail_.inc();
-      removed = conn.removeFromList(busy_conns_);
+      removed = conn.removeFromList(pending_conns_);
 
       // Raw connect failures should never happen under normal circumstances. If we have an upstream
       // that is behaving badly, requests can get stuck here in the pending state. If we see a
@@ -168,7 +178,8 @@ void ConnPoolImpl::onConnectionEvent(ActiveConn& conn, Network::ConnectionEvent 
     dispatcher_.deferredDelete(std::move(removed));
 
     // If we have pending requests and we just lost a connection we should make a new one.
-    if (pending_requests_.size() > (ready_conns_.size() + busy_conns_.size())) {
+    if (pending_requests_.size() >
+        (ready_conns_.size() + busy_conns_.size() + pending_conns_.size())) {
       createNewConnection();
     }
 
@@ -185,17 +196,26 @@ void ConnPoolImpl::onConnectionEvent(ActiveConn& conn, Network::ConnectionEvent 
   // Note that the order in this function is important. Concretely, we must destroy the connect
   // timer before we process an idle connection, because if this results in an immediate
   // drain/destruction event, we key off of the existence of the connect timer above to determine
-  // whether the connection is in the ready list (connected) or the busy list (failed to connect).
+  // whether the connection is in the ready list (connected) or the pending list (failed to
+  // connect).
   if (event == Network::ConnectionEvent::Connected) {
     conn_connect_ms_->complete();
-    processIdleConnection(conn, false);
+    processIdleConnection(conn, true, false);
   }
 }
 
-void ConnPoolImpl::onPendingRequestCancel(PendingRequest& request) {
+void ConnPoolImpl::onPendingRequestCancel(PendingRequest& request, bool close) {
   ENVOY_LOG(debug, "canceling pending request");
   request.removeFromList(pending_requests_);
   host_->cluster().stats().upstream_rq_cancelled_.inc();
+
+  // If there are more pending connections than requests, close the most recently created pending
+  // connection.
+  if (close && pending_requests_.size() < pending_conns_.size()) {
+    ENVOY_LOG(debug, "canceling pending connection");
+    pending_conns_.back()->conn_->close(Network::ConnectionCloseType::NoFlush);
+  }
+
   checkForDrained();
 }
 
@@ -211,7 +231,7 @@ void ConnPoolImpl::onConnReleased(ActiveConn& conn) {
     // Upstream connection might be closed right after response is complete. Setting delay=true
     // here to assign pending requests in next dispatcher loop to handle that case.
     // https://github.com/envoyproxy/envoy/issues/2715
-    processIdleConnection(conn, true);
+    processIdleConnection(conn, false, true);
   }
 }
 
@@ -226,13 +246,13 @@ void ConnPoolImpl::onUpstreamReady() {
     ENVOY_CONN_LOG(debug, "assigning connection", *conn.conn_);
     // There is work to do so bind a connection to the caller and move it to the busy list. Pending
     // requests are pushed onto the front, so pull from the back.
+    conn.moveBetweenLists(ready_conns_, busy_conns_);
     assignConnection(conn, pending_requests_.back()->callbacks_);
     pending_requests_.pop_back();
-    conn.moveBetweenLists(ready_conns_, busy_conns_);
   }
 }
 
-void ConnPoolImpl::processIdleConnection(ActiveConn& conn, bool delay) {
+void ConnPoolImpl::processIdleConnection(ActiveConn& conn, bool new_connection, bool delay) {
   if (conn.wrapper_) {
     conn.wrapper_->invalidate();
     conn.wrapper_.reset();
@@ -242,11 +262,18 @@ void ConnPoolImpl::processIdleConnection(ActiveConn& conn, bool delay) {
     // There is nothing to service or delayed processing is requested, so just move the connection
     // into the ready list.
     ENVOY_CONN_LOG(debug, "moving to ready", *conn.conn_);
-    conn.moveBetweenLists(busy_conns_, ready_conns_);
+    if (new_connection) {
+      conn.moveBetweenLists(pending_conns_, ready_conns_);
+    } else {
+      conn.moveBetweenLists(busy_conns_, ready_conns_);
+    }
   } else {
     // There is work to do immediately so bind a request to the caller and move it to the busy list.
     // Pending requests are pushed onto the front, so pull from the back.
     ENVOY_CONN_LOG(debug, "assigning connection", *conn.conn_);
+    if (new_connection) {
+      conn.moveBetweenLists(pending_conns_, busy_conns_);
+    }
     assignConnection(conn, pending_requests_.back()->callbacks_);
     pending_requests_.pop_back();
   }

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -466,7 +466,8 @@ void Filter::onDownstreamEvent(Network::ConnectionEvent event) {
   } else if (upstream_handle_) {
     if (event == Network::ConnectionEvent::LocalClose ||
         event == Network::ConnectionEvent::RemoteClose) {
-      upstream_handle_->cancel();
+      // Cancel the conn pool request and close any excess pending requests.
+      upstream_handle_->cancel(true);
       upstream_handle_ = nullptr;
     }
   }

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -383,7 +383,7 @@ FilterStatus Router::UpstreamRequest::start() {
 
 void Router::UpstreamRequest::resetStream() {
   if (conn_pool_handle_) {
-    conn_pool_handle_->cancel();
+    conn_pool_handle_->cancel(false);
   }
 
   if (conn_data_ != nullptr) {

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -213,11 +213,16 @@ public:
  * Helper for dealing with an active test connection.
  */
 struct ActiveTestConn {
-  enum class Type { Pending, CreateConnection, Immediate };
+  enum class Type {
+    Pending,          // pending request, waiting for free connection
+    InProgress,       // connection created, no callback
+    CreateConnection, // connection callback occurs after newConnection
+    Immediate,        // connection callback occurs during newConnection
+  };
 
   ActiveTestConn(TcpConnPoolImplTest& parent, size_t conn_index, Type type)
       : parent_(parent), conn_index_(conn_index) {
-    if (type == Type::CreateConnection) {
+    if (type == Type::CreateConnection || type == Type::InProgress) {
       parent.conn_pool_.expectConnCreate();
     }
 
@@ -234,12 +239,19 @@ struct ActiveTestConn {
     }
 
     if (type == Type::CreateConnection) {
-      EXPECT_CALL(*parent_.conn_pool_.test_conns_[conn_index_].connect_timer_, disableTimer());
-      expectNewConn();
-      parent.conn_pool_.test_conns_[conn_index_].connection_->raiseEvent(
-          Network::ConnectionEvent::Connected);
-      verifyConn();
+      completeConnection();
     }
+  }
+
+  void completeConnection() {
+    ASSERT_FALSE(completed_);
+
+    EXPECT_CALL(*parent_.conn_pool_.test_conns_[conn_index_].connect_timer_, disableTimer());
+    expectNewConn();
+    parent_.conn_pool_.test_conns_[conn_index_].connection_->raiseEvent(
+        Network::ConnectionEvent::Connected);
+    verifyConn();
+    completed_ = true;
   }
 
   void expectNewConn() { EXPECT_CALL(callbacks_.pool_ready_, ready()); }
@@ -255,6 +267,7 @@ struct ActiveTestConn {
   size_t conn_index_;
   Tcp::ConnectionPool::Cancellable* handle_{};
   ConnPoolCallbacks callbacks_;
+  bool completed_{};
 };
 
 /**
@@ -262,16 +275,18 @@ struct ActiveTestConn {
  */
 TEST_F(TcpConnPoolImplTest, DrainConnections) {
   cluster_->resource_manager_.reset(
-      new Upstream::ResourceManagerImpl(runtime_, "fake_key", 2, 1024, 1024, 1));
+      new Upstream::ResourceManagerImpl(runtime_, "fake_key", 3, 1024, 1024, 1));
   InSequence s;
 
   ActiveTestConn c1(*this, 0, ActiveTestConn::Type::CreateConnection);
   ActiveTestConn c2(*this, 1, ActiveTestConn::Type::CreateConnection);
+  ActiveTestConn c3(*this, 2, ActiveTestConn::Type::InProgress);
 
   EXPECT_CALL(conn_pool_, onConnReleasedForTest());
   c1.releaseConn();
 
-  // This will destroy the ready connection and set requests remaining to 1 on the busy connection.
+  // This will destroy the ready connection and set requests remaining to 1 on the busy and pending
+  // connections.
   EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
   conn_pool_.drainConnections();
   dispatcher_.clearDeferredDeleteList();
@@ -280,6 +295,15 @@ TEST_F(TcpConnPoolImplTest, DrainConnections) {
   EXPECT_CALL(conn_pool_, onConnReleasedForTest());
   EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
   c2.releaseConn();
+  dispatcher_.clearDeferredDeleteList();
+
+  // This will destroy the pending connection when the response finishes.
+  c3.conn_index_ = 0; // c1/c2 have been deleted from test_conns_.
+  c3.completeConnection();
+
+  EXPECT_CALL(conn_pool_, onConnReleasedForTest());
+  EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
+  c3.releaseConn();
   dispatcher_.clearDeferredDeleteList();
 }
 
@@ -477,7 +501,7 @@ TEST_F(TcpConnPoolImplTest, MaxPendingRequests) {
   Tcp::ConnectionPool::Cancellable* handle2 = conn_pool_.newConnection(callbacks2);
   EXPECT_EQ(nullptr, handle2);
 
-  handle->cancel();
+  handle->cancel(false);
 
   EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
   conn_pool_.test_conns_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
@@ -584,12 +608,31 @@ TEST_F(TcpConnPoolImplTest, CancelBeforeBound) {
   Tcp::ConnectionPool::Cancellable* handle = conn_pool_.newConnection(callbacks);
   EXPECT_NE(nullptr, handle);
 
-  handle->cancel();
+  handle->cancel(false);
   conn_pool_.test_conns_[0].connection_->raiseEvent(Network::ConnectionEvent::Connected);
 
   // Cause the connection to go away.
   EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
   conn_pool_.test_conns_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  dispatcher_.clearDeferredDeleteList();
+}
+
+/**
+ * Test cancelling before the request is bound to a connection, with connection close.
+ */
+TEST_F(TcpConnPoolImplTest, CancelAndCloseBeforeBound) {
+  InSequence s;
+
+  // Request 1 should kick off a new connection.
+  ConnPoolCallbacks callbacks;
+  conn_pool_.expectConnCreate();
+  Tcp::ConnectionPool::Cancellable* handle = conn_pool_.newConnection(callbacks);
+  EXPECT_NE(nullptr, handle);
+
+  // Expect the connection is closed.
+  EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
+  handle->cancel(true);
+
   dispatcher_.clearDeferredDeleteList();
 }
 
@@ -821,7 +864,7 @@ TEST_F(TcpConnPoolImplTest, DrainCallback) {
 
   ActiveTestConn c1(*this, 0, ActiveTestConn::Type::CreateConnection);
   ActiveTestConn c2(*this, 0, ActiveTestConn::Type::Pending);
-  c2.handle_->cancel();
+  c2.handle_->cancel(false);
 
   EXPECT_CALL(conn_pool_, onConnReleasedForTest());
   EXPECT_CALL(drained, ready());
@@ -845,7 +888,7 @@ TEST_F(TcpConnPoolImplTest, DrainWhileConnecting) {
   EXPECT_NE(nullptr, handle);
 
   conn_pool_.addDrainedCallback([&]() -> void { drained.ready(); });
-  handle->cancel();
+  handle->cancel(false);
   EXPECT_CALL(*conn_pool_.test_conns_[0].connection_, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_CALL(drained, ready());
   conn_pool_.test_conns_[0].connection_->raiseEvent(Network::ConnectionEvent::Connected);
@@ -878,6 +921,25 @@ TEST_F(TcpConnPoolImplTest, DrainOnClose) {
 
   EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
   dispatcher_.clearDeferredDeleteList();
+}
+
+/**
+ * Test that pending connections are closed when the connection pool is destroyed.
+ */
+TEST_F(TcpConnPoolImplDestructorTest, TestPendingConnectionsAreClosed) {
+  connection_ = new NiceMock<Network::MockClientConnection>();
+  connect_timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
+  EXPECT_CALL(dispatcher_, createClientConnection_(_, _, _, _)).WillOnce(Return(connection_));
+  EXPECT_CALL(*connect_timer_, enableTimer(_));
+
+  callbacks_ = std::make_unique<ConnPoolCallbacks>();
+  ConnectionPool::Cancellable* handle = conn_pool_->newConnection(*callbacks_);
+  EXPECT_NE(nullptr, handle);
+
+  EXPECT_CALL(callbacks_->pool_failure_, ready());
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
+  conn_pool_.reset();
 }
 
 /**

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -758,9 +758,9 @@ TEST_F(TcpProxyTest, DisconnectBeforeData) {
 
 // Test that if the downstream connection is closed before the upstream connection
 // is established, the upstream connection is cancelled.
-TEST_F(TcpProxyTest, RemoteClosetBeforeUpstreamConnected) {
+TEST_F(TcpProxyTest, RemoteClosedBeforeUpstreamConnected) {
   setup(1);
-  EXPECT_CALL(*conn_pool_handles_.at(0), cancel());
+  EXPECT_CALL(*conn_pool_handles_.at(0), cancel(true));
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
@@ -768,7 +768,7 @@ TEST_F(TcpProxyTest, RemoteClosetBeforeUpstreamConnected) {
 // is established, the upstream connection is cancelled.
 TEST_F(TcpProxyTest, LocalClosetBeforeUpstreamConnected) {
   setup(1);
-  EXPECT_CALL(*conn_pool_handles_.at(0), cancel());
+  EXPECT_CALL(*conn_pool_handles_.at(0), cancel(true));
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::LocalClose);
 }
 

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -605,7 +605,7 @@ TEST_F(ThriftRouterTest, UnexpectedRouterDestroyBeforeUpstreamConnect) {
   startRequest(MessageType::Call);
 
   EXPECT_EQ(1, context_.cluster_manager_.tcp_conn_pool_.handles_.size());
-  EXPECT_CALL(context_.cluster_manager_.tcp_conn_pool_.handles_.front(), cancel());
+  EXPECT_CALL(context_.cluster_manager_.tcp_conn_pool_.handles_.front(), cancel(false));
   destroyRouter();
 }
 

--- a/test/mocks/tcp/mocks.h
+++ b/test/mocks/tcp/mocks.h
@@ -21,7 +21,7 @@ public:
   ~MockCancellable();
 
   // Tcp::ConnectionPool::Cancellable
-  MOCK_METHOD0(cancel, void());
+  MOCK_METHOD1(cancel, void(bool close));
 };
 
 class MockUpstreamCallbacks : public UpstreamCallbacks {


### PR DESCRIPTION
Allows cancellation of a pending connection via the TCP connection pool to
request that the pending connection be closed if it cannot be immediately used.

*Risk Level*: medium
*Testing*: unit tests
*Docs Changes*: n/a
*Release Notes*: n/a
*Fixes*: #4409

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
