### PR TITLE
tls: refactor utility functions

### DIFF
--- a/source/common/ssl/BUILD
+++ b/source/common/ssl/BUILD
@@ -112,4 +112,7 @@ envoy_cc_library(
     external_deps = [
         "ssl",
     ],
+    deps = [
+        "//source/common/common:assert_lib",
+    ],
 )

--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -438,24 +438,13 @@ SslStats ContextImpl::generateStats(Stats::Scope& store) {
 }
 
 size_t ContextImpl::daysUntilFirstCertExpires() const {
-  int daysUntilExpiration = getDaysUntilExpiration(ca_cert_.get());
+  int daysUntilExpiration = Utility::getDaysUntilExpiration(ca_cert_.get());
   daysUntilExpiration =
-      std::min<int>(getDaysUntilExpiration(cert_chain_.get()), daysUntilExpiration);
+      std::min<int>(Utility::getDaysUntilExpiration(cert_chain_.get()), daysUntilExpiration);
   if (daysUntilExpiration < 0) { // Ensure that the return value is unsigned
     return 0;
   }
   return daysUntilExpiration;
-}
-
-int32_t ContextImpl::getDaysUntilExpiration(const X509* cert) const {
-  if (cert == nullptr) {
-    return std::numeric_limits<int>::max();
-  }
-  int days, seconds;
-  if (ASN1_TIME_diff(&days, &seconds, nullptr, X509_get_notAfter(cert))) {
-    return days;
-  }
-  return 0;
 }
 
 CertificateDetailsPtr ContextImpl::getCaCertInformation() const {
@@ -477,7 +466,7 @@ CertificateDetailsPtr ContextImpl::certificateDetails(X509* cert, const std::str
       std::make_unique<envoy::admin::v2alpha::CertificateDetails>();
   certificate_details->set_path(path);
   certificate_details->set_serial_number(Utility::getSerialNumberFromCertificate(*cert));
-  certificate_details->set_days_until_expiration(getDaysUntilExpiration(cert));
+  certificate_details->set_days_until_expiration(Utility::getDaysUntilExpiration(cert));
 
   for (auto& dns_san : Utility::getSubjectAltNames(*cert, GEN_DNS)) {
     envoy::admin::v2alpha::SubjectAlternateName& subject_alt_name =

--- a/source/common/ssl/context_impl.h
+++ b/source/common/ssl/context_impl.h
@@ -116,9 +116,6 @@ protected:
   std::vector<uint8_t> parseAlpnProtocols(const std::string& alpn_protocols);
   static SslStats generateStats(Stats::Scope& scope);
 
-  // TODO: Move helper function to the `Ssl::Utility` namespace.
-  int32_t getDaysUntilExpiration(const X509* cert) const;
-
   std::string getCaFileName() const { return ca_file_path_; };
   std::string getCertChainFileName() const { return cert_chain_file_path_; };
 

--- a/source/common/ssl/ssl_socket.cc
+++ b/source/common/ssl/ssl_socket.cc
@@ -245,7 +245,7 @@ std::string SslSocket::uriSanLocalCertificate() const {
   }
   // TODO(PiotrSikora): Figure out if returning only one URI is valid limitation.
   const std::vector<std::string>& san_uris = Utility::getSubjectAltNames(*cert, GEN_URI);
-  return (san_uris.size() > 0) ? san_uris[0]: "";
+  return (san_uris.size() > 0) ? san_uris[0] : "";
 }
 
 std::vector<std::string> SslSocket::dnsSansLocalCertificate() const {
@@ -303,7 +303,7 @@ std::string SslSocket::uriSanPeerCertificate() const {
   }
   // TODO(PiotrSikora): Figure out if returning only one URI is valid limitation.
   const std::vector<std::string>& san_uris = Utility::getSubjectAltNames(*cert, GEN_URI);
-  return (san_uris.size() > 0) ? san_uris[0]: "";
+  return (san_uris.size() > 0) ? san_uris[0] : "";
 }
 
 std::vector<std::string> SslSocket::dnsSansPeerCertificate() const {

--- a/source/common/ssl/ssl_socket.cc
+++ b/source/common/ssl/ssl_socket.cc
@@ -343,7 +343,7 @@ std::string SslSocket::subjectPeerCertificate() const {
   if (!cert) {
     return "";
   }
-  return Utility::getSubjectFromCertificate(*cert.get());
+  return Utility::getSubjectFromCertificate(*cert);
 }
 
 std::string SslSocket::subjectLocalCertificate() const {

--- a/source/common/ssl/ssl_socket.cc
+++ b/source/common/ssl/ssl_socket.cc
@@ -243,7 +243,9 @@ std::string SslSocket::uriSanLocalCertificate() const {
   if (!cert) {
     return "";
   }
-  return getUriSanFromCertificate(cert);
+  // TODO(PiotrSikora): Figure out if returning only one URI is valid limitation.
+  const std::vector<std::string>& san_uris = Utility::getSubjectAltNames(*cert, GEN_URI);
+  return (san_uris.size() > 0) ? san_uris[0]: "";
 }
 
 std::vector<std::string> SslSocket::dnsSansLocalCertificate() const {
@@ -251,7 +253,7 @@ std::vector<std::string> SslSocket::dnsSansLocalCertificate() const {
   if (!cert) {
     return {};
   }
-  return getDnsSansFromCertificate(cert);
+  return Utility::getSubjectAltNames(*cert, GEN_DNS);
 }
 
 const std::string& SslSocket::sha256PeerCertificateDigest() const {
@@ -299,7 +301,9 @@ std::string SslSocket::uriSanPeerCertificate() const {
   if (!cert) {
     return "";
   }
-  return getUriSanFromCertificate(cert.get());
+  // TODO(PiotrSikora): Figure out if returning only one URI is valid limitation.
+  const std::vector<std::string>& san_uris = Utility::getSubjectAltNames(*cert, GEN_URI);
+  return (san_uris.size() > 0) ? san_uris[0]: "";
 }
 
 std::vector<std::string> SslSocket::dnsSansPeerCertificate() const {
@@ -307,41 +311,7 @@ std::vector<std::string> SslSocket::dnsSansPeerCertificate() const {
   if (!cert) {
     return {};
   }
-  return getDnsSansFromCertificate(cert.get());
-}
-
-std::string SslSocket::getUriSanFromCertificate(X509* cert) const {
-  bssl::UniquePtr<GENERAL_NAMES> san_names(
-      static_cast<GENERAL_NAMES*>(X509_get_ext_d2i(cert, NID_subject_alt_name, nullptr, nullptr)));
-  if (san_names == nullptr) {
-    return "";
-  }
-  // TODO(PiotrSikora): Figure out if returning only one URI is valid limitation.
-  for (const GENERAL_NAME* san : san_names.get()) {
-    if (san->type == GEN_URI) {
-      ASN1_STRING* str = san->d.uniformResourceIdentifier;
-      return std::string(reinterpret_cast<const char*>(ASN1_STRING_data(str)),
-                         ASN1_STRING_length(str));
-    }
-  }
-  return "";
-}
-
-std::vector<std::string> SslSocket::getDnsSansFromCertificate(X509* cert) const {
-  bssl::UniquePtr<GENERAL_NAMES> san_names(
-      static_cast<GENERAL_NAMES*>(X509_get_ext_d2i(cert, NID_subject_alt_name, nullptr, nullptr)));
-  if (san_names == nullptr) {
-    return {};
-  }
-  std::vector<std::string> dns_sans = {};
-  for (const GENERAL_NAME* san : san_names.get()) {
-    if (san->type == GEN_DNS) {
-      ASN1_STRING* dns = san->d.dNSName;
-      dns_sans.emplace_back(reinterpret_cast<const char*>(ASN1_STRING_data(dns)),
-                            ASN1_STRING_length(dns));
-    }
-  }
-  return dns_sans;
+  return Utility::getSubjectAltNames(*cert, GEN_DNS);
 }
 
 void SslSocket::closeSocket(Network::ConnectionEvent) {
@@ -368,30 +338,12 @@ std::string SslSocket::serialNumberPeerCertificate() const {
   return Utility::getSerialNumberFromCertificate(*cert.get());
 }
 
-std::string SslSocket::getSubjectFromCertificate(X509* cert) const {
-  bssl::UniquePtr<BIO> buf(BIO_new(BIO_s_mem()));
-  RELEASE_ASSERT(buf != nullptr, "");
-
-  // flags=XN_FLAG_RFC2253 is the documented parameter for single-line output in RFC 2253 format.
-  // Example from the RFC:
-  //   * Single value per Relative Distinguished Name (RDN): CN=Steve Kille,O=Isode Limited,C=GB
-  //   * Multivalue output in first RDN: OU=Sales+CN=J. Smith,O=Widget Inc.,C=US
-  //   * Quoted comma in Organization: CN=L. Eagle,O=Sue\, Grabbit and Runn,C=GB
-  X509_NAME_print_ex(buf.get(), X509_get_subject_name(cert), 0 /* indent */, XN_FLAG_RFC2253);
-
-  const uint8_t* data;
-  size_t data_len;
-  int rc = BIO_mem_contents(buf.get(), &data, &data_len);
-  ASSERT(rc == 1);
-  return std::string(reinterpret_cast<const char*>(data), data_len);
-}
-
 std::string SslSocket::subjectPeerCertificate() const {
   bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
   if (!cert) {
     return "";
   }
-  return getSubjectFromCertificate(cert.get());
+  return Utility::getSubjectFromCertificate(*cert.get());
 }
 
 std::string SslSocket::subjectLocalCertificate() const {
@@ -399,7 +351,7 @@ std::string SslSocket::subjectLocalCertificate() const {
   if (!cert) {
     return "";
   }
-  return getSubjectFromCertificate(cert);
+  return Utility::getSubjectFromCertificate(*cert);
 }
 
 namespace {

--- a/source/common/ssl/ssl_socket.h
+++ b/source/common/ssl/ssl_socket.h
@@ -11,6 +11,7 @@
 
 #include "common/common/logger.h"
 #include "common/ssl/context_impl.h"
+#include "common/ssl/utility.h"
 
 #include "absl/synchronization/mutex.h"
 #include "openssl/ssl.h"
@@ -68,11 +69,6 @@ private:
   Network::PostIoAction doHandshake();
   void drainErrorQueue();
   void shutdownSsl();
-
-  // TODO: Move helper functions to the `Ssl::Utility` namespace.
-  std::string getUriSanFromCertificate(X509* cert) const;
-  std::string getSubjectFromCertificate(X509* cert) const;
-  std::vector<std::string> getDnsSansFromCertificate(X509* cert) const;
 
   Network::TransportSocketCallbacks* callbacks_{};
   ContextImplSharedPtr ctx_;

--- a/source/common/ssl/utility.cc
+++ b/source/common/ssl/utility.cc
@@ -1,3 +1,5 @@
+#include "common/common/assert.h"
+
 #include "common/ssl/utility.h"
 
 #include "absl/strings/str_join.h"
@@ -36,6 +38,35 @@ std::vector<std::string> Utility::getSubjectAltNames(X509& cert, int type) {
     }
   }
   return subject_alt_names;
+}
+
+std::string Utility::getSubjectFromCertificate(X509& cert) {
+  bssl::UniquePtr<BIO> buf(BIO_new(BIO_s_mem()));
+  RELEASE_ASSERT(buf != nullptr, "");
+
+  // flags=XN_FLAG_RFC2253 is the documented parameter for single-line output in RFC 2253 format.
+  // Example from the RFC:
+  //   * Single value per Relative Distinguished Name (RDN): CN=Steve Kille,O=Isode Limited,C=GB
+  //   * Multivalue output in first RDN: OU=Sales+CN=J. Smith,O=Widget Inc.,C=US
+  //   * Quoted comma in Organization: CN=L. Eagle,O=Sue\, Grabbit and Runn,C=GB
+  X509_NAME_print_ex(buf.get(), X509_get_subject_name(&cert), 0 /* indent */, XN_FLAG_RFC2253);
+
+  const uint8_t* data;
+  size_t data_len;
+  int rc = BIO_mem_contents(buf.get(), &data, &data_len);
+  ASSERT(rc == 1);
+  return std::string(reinterpret_cast<const char*>(data), data_len);
+}
+
+int32_t Utility::getDaysUntilExpiration(X509* cert) {
+    if (cert == nullptr) {
+    return std::numeric_limits<int>::max();
+  }
+  int days, seconds;
+  if (ASN1_TIME_diff(&days, &seconds, nullptr, X509_get_notAfter(cert))) {
+    return days;
+  }
+  return 0;
 }
 
 } // namespace Ssl

--- a/source/common/ssl/utility.cc
+++ b/source/common/ssl/utility.cc
@@ -1,6 +1,6 @@
-#include "common/common/assert.h"
-
 #include "common/ssl/utility.h"
+
+#include "common/common/assert.h"
 
 #include "absl/strings/str_join.h"
 #include "openssl/x509v3.h"
@@ -59,7 +59,7 @@ std::string Utility::getSubjectFromCertificate(X509& cert) {
 }
 
 int32_t Utility::getDaysUntilExpiration(X509* cert) {
-    if (cert == nullptr) {
+  if (cert == nullptr) {
     return std::numeric_limits<int>::max();
   }
   int days, seconds;

--- a/source/common/ssl/utility.h
+++ b/source/common/ssl/utility.h
@@ -24,6 +24,21 @@ std::string getSerialNumberFromCertificate(X509& cert);
  * @return std::vector returns the list of subject alternate names.
  */
 std::vector<std::string> getSubjectAltNames(X509& cert, int type);
+
+/**
+ * Retrieves the subject from certificate.
+ * @param cert the certificate
+ * @return std::string the subject field for the certificate.
+ */
+std::string getSubjectFromCertificate(X509& cert);
+
+/**
+ * Returns the days until this certificate is valid.
+ * @param cert the certificate
+ * @return the number of days till this certificate is valid.
+ */
+int32_t getDaysUntilExpiration(X509* cert);
+
 } // namespace Utility
 } // namespace Ssl
 } // namespace Envoy

--- a/test/common/ssl/BUILD
+++ b/test/common/ssl/BUILD
@@ -32,6 +32,7 @@ envoy_cc_test(
         "//source/common/ssl:context_config_lib",
         "//source/common/ssl:context_lib",
         "//source/common/ssl:ssl_socket_lib",
+        "//source/common/ssl:utility_lib",
         "//source/common/stats:isolated_store_lib",
         "//source/common/stats:stats_lib",
         "//source/extensions/filters/listener/tls_inspector:tls_inspector_lib",

--- a/test/common/ssl/utility_test.cc
+++ b/test/common/ssl/utility_test.cc
@@ -41,7 +41,8 @@ TEST(UtilityTest, TestGetSubjectAlternateNamesWithNoSAN) {
 
 TEST(UtilityTest, TestGetSubject) {
   bssl::UniquePtr<X509> cert = readCertFromFile("test/common/ssl/test_data/san_dns_cert.pem");
-  EXPECT_EQ("CN=Test Server,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US", Utility::getSubjectFromCertificate(*cert));
+  EXPECT_EQ("CN=Test Server,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US",
+            Utility::getSubjectFromCertificate(*cert));
 }
 
 TEST(UtilityTest, TestGetSerialNumber) {

--- a/test/common/ssl/utility_test.cc
+++ b/test/common/ssl/utility_test.cc
@@ -39,5 +39,24 @@ TEST(UtilityTest, TestGetSubjectAlternateNamesWithNoSAN) {
   EXPECT_EQ(0, uri_subject_alt_names.size());
 }
 
+TEST(UtilityTest, TestGetSubject) {
+  bssl::UniquePtr<X509> cert = readCertFromFile("test/common/ssl/test_data/san_dns_cert.pem");
+  EXPECT_EQ("CN=Test Server,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US", Utility::getSubjectFromCertificate(*cert));
+}
+
+TEST(UtilityTest, TestGetSerialNumber) {
+  bssl::UniquePtr<X509> cert = readCertFromFile("test/common/ssl/test_data/san_dns_cert.pem");
+  EXPECT_EQ("f3828eb24fd779d0", Utility::getSerialNumberFromCertificate(*cert));
+}
+
+TEST(UtilityTest, TestDaysUntilExpiration) {
+  bssl::UniquePtr<X509> cert = readCertFromFile("test/common/ssl/test_data/san_dns_cert.pem");
+  EXPECT_EQ(270, Utility::getDaysUntilExpiration(cert.get()));
+}
+
+TEST(UtilityTest, TestDaysUntilExpirationWithNull) {
+  EXPECT_EQ(std::numeric_limits<int>::max(), Utility::getDaysUntilExpiration(nullptr));
+}
+
 } // namespace Ssl
 } // namespace Envoy


### PR DESCRIPTION
*Description*: This is one of the items discussed in the PR #4566. To refactor common cert functions to utilities.
*Risk Level*: Low
*Testing*: Existing Automated tests
*Docs Changes*: N/A
*Release Notes*: N/A
