### PR TITLE
docs: fix typo introduced in #4683, mea culpa

### DIFF
--- a/docs/root/install/ref_configs.rst
+++ b/docs/root/install/ref_configs.rst
@@ -24,7 +24,7 @@ we use at Lyft. We have also included three example configuration templates for 
 three scenarios.
 
 * Generator script: :repo:`configs/configgen.py`
-* Service to service template: :repo:`configs/envoy_service_to_service_v2.template.yaml'`
+* Service to service template: :repo:`configs/envoy_service_to_service_v2.template.yaml`
 * Front proxy template: :repo:`configs/envoy_front_proxy_v2.template.yaml`
 * Double proxy template: :repo:`configs/envoy_double_proxy_v2.template.yaml`
 


### PR DESCRIPTION
Description: I introduced a stray quote when updating the links to the reference config templates in #4683. As a result, the link 404s. Sorry about that! :frowning_face: 
Risk Level: Low
Testing: N/A
Docs Changes: Fixing typo in link.
Release Notes: N/A