### PR TITLE
jwt_authn: write JWT payload to dynamic metadata

### DIFF
--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -157,6 +157,12 @@ message JwtProvider {
   //
   // If it is not specified, the payload will not be forwarded.
   string forward_payload_header = 8;
+
+  // If true, successfully verified JWT payloads will be written to StreamInfo DynamicMetadata
+  // in the format as: *namespace* is the jwt_authn filter name as **envoy.filters.http.jwt_authn**
+  // The value is the *protobuf::Struct*. Its *fields* contains the JWT **issuer** as the key and
+  // the **jwt_payload** as string value for each verified token.
+  bool payload_in_metadata = 9;
 }
 
 // This message specifies how to fetch JWKS from remote and how to cache it.

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -149,6 +149,18 @@ ProtobufWkt::Struct MessageUtil::keyValueStruct(const std::string& key, const st
   return struct_obj;
 }
 
+ProtobufWkt::Struct
+MessageUtil::stringPairStruct(const std::vector<std::pair<std::string, std::string>>& pairs) {
+  ProtobufWkt::Struct struct_obj;
+  auto fields = struct_obj.mutable_fields();
+  for (const auto& pair : pairs) {
+    ProtobufWkt::Value val;
+    val.set_string_value(pair.second);
+    (*fields)[pair.first] = val;
+  }
+  return struct_obj;
+}
+
 bool ValueUtil::equal(const ProtobufWkt::Value& v1, const ProtobufWkt::Value& v2) {
   ProtobufWkt::Value::KindCase kind = v1.kind_case();
   if (kind != v2.kind_case()) {

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -271,6 +271,14 @@ public:
    * @param value the string value to associate with the key
    */
   static ProtobufWkt::Struct keyValueStruct(const std::string& key, const std::string& value);
+
+  /**
+   * Utility method to create a Struct containing a vector of key/value pairs.
+   *
+   * @param pairs a vector of string pairs
+   */
+  static ProtobufWkt::Struct
+  stringPairStruct(const std::vector<std::pair<std::string, std::string>>& pairs);
 };
 
 class ValueUtil {

--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -41,7 +41,7 @@ public:
   void onJwksError(Failure reason) override;
   // Following functions are for Authenticator interface
   void verify(Http::HeaderMap& headers, std::vector<JwtLocationConstPtr>&& tokens,
-              AuthenticatorCallback callback) override;
+              SetPayloadCallback set_payload_cb, AuthenticatorCallback callback) override;
   void onDestroy() override;
 
   TimeSource& timeSource() { return time_source_; }
@@ -78,6 +78,8 @@ private:
 
   // The HTTP request headers
   Http::HeaderMap* headers_{};
+  // the callback function to set payload
+  SetPayloadCallback set_payload_cb_;
   // The on_done function.
   AuthenticatorCallback callback_;
   // check audience object.
@@ -89,10 +91,11 @@ private:
 };
 
 void AuthenticatorImpl::verify(Http::HeaderMap& headers, std::vector<JwtLocationConstPtr>&& tokens,
-                               AuthenticatorCallback callback) {
+                               SetPayloadCallback set_payload_cb, AuthenticatorCallback callback) {
   ASSERT(!callback_);
   headers_ = &headers;
   tokens_ = std::move(tokens);
+  set_payload_cb_ = std::move(set_payload_cb);
   callback_ = std::move(callback);
 
   ENVOY_LOG(debug, "Jwt authentication starts");
@@ -223,6 +226,9 @@ void AuthenticatorImpl::verifyKey() {
     // TODO(potatop) remove JWT from queries.
     // Remove JWT from headers.
     curr_token_->removeJwt(*headers_);
+  }
+  if (set_payload_cb_ && provider.payload_in_metadata()) {
+    set_payload_cb_(provider.issuer(), jwt_->payload_str_base64url_);
   }
 
   doneWithStatus(Status::Ok);

--- a/source/extensions/filters/http/jwt_authn/authenticator.h
+++ b/source/extensions/filters/http/jwt_authn/authenticator.h
@@ -19,6 +19,8 @@ typedef std::unique_ptr<Authenticator> AuthenticatorPtr;
 
 typedef std::function<void(const ::google::jwt_verify::Status& status)> AuthenticatorCallback;
 
+typedef std::function<void(const std::string&, const std::string&)> SetPayloadCallback;
+
 /**
  *  CreateJwksFetcherCb is a callback interface for creating a JwksFetcher instance.
  */
@@ -34,7 +36,7 @@ public:
   // Verify if headers satisfyies the JWT requirements. Can be limited to single provider with
   // extract_param.
   virtual void verify(Http::HeaderMap& headers, std::vector<JwtLocationConstPtr>&& tokens,
-                      AuthenticatorCallback callback) PURE;
+                      SetPayloadCallback set_payload_cb, AuthenticatorCallback callback) PURE;
 
   // Called when the object is about to be destroyed.
   virtual void onDestroy() PURE;

--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -2,6 +2,8 @@
 
 #include "common/http/utility.h"
 
+#include "extensions/filters/http/well_known_names.h"
+
 using ::google::jwt_verify::Status;
 
 namespace Envoy {
@@ -38,6 +40,10 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool) 
   ENVOY_LOG(debug, "Called Filter : {} Stop", __func__);
   stopped_ = true;
   return Http::FilterHeadersStatus::StopIteration;
+}
+
+void Filter::setPayload(const ProtobufWkt::Struct& payload) {
+  decoder_callbacks_->streamInfo().setDynamicMetadata(HttpFilterNames::get().JwtAuthn, payload);
 }
 
 void Filter::onComplete(const Status& status) {

--- a/source/extensions/filters/http/jwt_authn/filter.h
+++ b/source/extensions/filters/http/jwt_authn/filter.h
@@ -31,7 +31,9 @@ public:
   void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override;
 
 private:
-  // the function for Verifier::Callbacks interface.
+  // Following two functions are for Verifier::Callbacks interface.
+  // Pass the payload as Struct.
+  void setPayload(const ProtobufWkt::Struct& payload) override;
   // It will be called when its verify() call is completed.
   void onComplete(const ::google::jwt_verify::Status& status) override;
 

--- a/source/extensions/filters/http/jwt_authn/verifier.h
+++ b/source/extensions/filters/http/jwt_authn/verifier.h
@@ -25,6 +25,14 @@ public:
     virtual ~Callbacks() {}
 
     /**
+     * Successfully verified JWT payload are stored in the struct with its
+     * *fields* containing **issuer** as keys and **payload** as string values
+     * This function is called before onComplete() function.
+     * It will not be called if no payload to write.
+     */
+    virtual void setPayload(const ProtobufWkt::Struct& payload) PURE;
+
+    /**
      * Called on completion of request.
      *
      * @param status the status of the request.

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -269,8 +269,7 @@ TEST_F(AuthenticatorTest, TestOnDestroy) {
   auto tokens = filter_config_->getExtractor().extract(headers);
   // callback should not be called.
   std::function<void(const Status&)> on_complete_cb = [](const Status&) { FAIL(); };
-  auto set_payload_cb = [this](const std::string&, const std::string&) {};
-  auth_->verify(headers, std::move(tokens), std::move(set_payload_cb), std::move(on_complete_cb));
+  auth_->verify(headers, std::move(tokens), nullptr, std::move(on_complete_cb));
 
   // Destroy the authenticating process.
   auth_->onDestroy();

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -14,14 +14,14 @@
 #include "gtest/gtest.h"
 
 using ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication;
-using ::google::jwt_verify::Jwks;
-using ::google::jwt_verify::Status;
-using ::testing::Invoke;
-using ::testing::NiceMock;
-using ::testing::_;
 using Envoy::Extensions::HttpFilters::Common::JwksFetcher;
 using Envoy::Extensions::HttpFilters::Common::JwksFetcherPtr;
 using Envoy::Extensions::HttpFilters::Common::MockJwksFetcher;
+using ::google::jwt_verify::Jwks;
+using ::google::jwt_verify::Status;
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::NiceMock;
 
 namespace Envoy {
 namespace Extensions {

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -11,8 +11,8 @@
 using ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication;
 using ::google::jwt_verify::Status;
 
-using testing::Invoke;
 using testing::_;
+using testing::Invoke;
 
 namespace Envoy {
 namespace Extensions {

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -1,7 +1,9 @@
 #include "extensions/filters/http/jwt_authn/filter.h"
+#include "extensions/filters/http/well_known_names.h"
 
 #include "test/extensions/filters/http/jwt_authn/mock.h"
 #include "test/mocks/server/mocks.h"
+#include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -9,8 +11,8 @@
 using ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication;
 using ::google::jwt_verify::Status;
 
-using testing::_;
 using testing::Invoke;
+using testing::_;
 
 namespace Envoy {
 namespace Extensions {
@@ -75,6 +77,31 @@ TEST_F(FilterTest, InlineOK) {
   EXPECT_CALL(*raw_mock_verifier_, verify(_)).WillOnce(Invoke([](ContextSharedPtr context) {
     context->callback()->onComplete(Status::Ok);
   }));
+
+  auto headers = Http::TestHeaderMapImpl{};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+  EXPECT_EQ(1U, mock_config_->stats().allowed_.value());
+
+  Buffer::OwnedImpl data("");
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(headers));
+}
+
+// This test verifies the setPayload call is handled correctly
+TEST_F(FilterTest, TestSetPayloadCall) {
+  setupMockConfig();
+  ProtobufWkt::Struct payload;
+  // A successful authentication completed inline: callback is called inside verify().
+  EXPECT_CALL(*raw_mock_verifier_, verify(_)).WillOnce(Invoke([&payload](ContextSharedPtr context) {
+    context->callback()->setPayload(payload);
+    context->callback()->onComplete(Status::Ok);
+  }));
+
+  EXPECT_CALL(filter_callbacks_.stream_info_, setDynamicMetadata(_, _))
+      .WillOnce(Invoke([&payload](const std::string& ns, const ProtobufWkt::Struct& out_payload) {
+        EXPECT_EQ(ns, HttpFilterNames::get().JwtAuthn);
+        EXPECT_TRUE(TestUtility::protoEqual(out_payload, payload));
+      }));
 
   auto headers = Http::TestHeaderMapImpl{};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));

--- a/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
@@ -81,10 +81,15 @@ public:
   void createSyncMockAuthsAndVerifier(const StatusMap& statuses) {
     for (const auto& it : statuses) {
       auto mock_auth = std::make_unique<MockAuthenticator>();
-      EXPECT_CALL(*mock_auth.get(), doVerify(_, _, _))
-          .WillOnce(
-              Invoke([status = it.second](Http::HeaderMap&, std::vector<JwtLocationConstPtr>*,
-                                          AuthenticatorCallback callback) { callback(status); }));
+      EXPECT_CALL(*mock_auth.get(), doVerify(_, _, _, _))
+          .WillOnce(Invoke([ issuer = it.first, status = it.second ](
+              Http::HeaderMap&, std::vector<JwtLocationConstPtr>*,
+              SetPayloadCallback set_payload_cb, AuthenticatorCallback callback) {
+            if (status == Status::Ok) {
+              set_payload_cb(issuer, issuer + "-payload");
+            }
+            callback(status);
+          }));
       EXPECT_CALL(*mock_auth.get(), onDestroy()).Times(1);
       mock_auths_[it.first] = std::move(mock_auth);
     }
@@ -96,12 +101,10 @@ public:
     std::unordered_map<std::string, AuthenticatorCallback> callbacks;
     for (std::size_t i = 0; i < providers.size(); ++i) {
       auto mock_auth = std::make_unique<MockAuthenticator>();
-      EXPECT_CALL(*mock_auth.get(), doVerify(_, _, _))
-          .WillOnce(Invoke([&callbacks, iss = providers[i]](Http::HeaderMap&,
-                                                            std::vector<JwtLocationConstPtr>*,
-                                                            AuthenticatorCallback callback) {
-            callbacks[iss] = std::move(callback);
-          }));
+      EXPECT_CALL(*mock_auth.get(), doVerify(_, _, _, _))
+          .WillOnce(Invoke([&callbacks, iss = providers[i] ](
+              Http::HeaderMap&, std::vector<JwtLocationConstPtr>*, SetPayloadCallback,
+              AuthenticatorCallback callback) { callbacks[iss] = std::move(callback); }));
       EXPECT_CALL(*mock_auth.get(), onDestroy()).Times(1);
       mock_auths_[providers[i]] = std::move(mock_auth);
     }
@@ -151,6 +154,12 @@ rules:
   MessageUtil::loadFromYaml(config, proto_config_);
   createSyncMockAuthsAndVerifier(StatusMap{{"example_provider", Status::Ok}});
 
+  EXPECT_CALL(mock_cb_, setPayload(_)).WillOnce(Invoke([](const ProtobufWkt::Struct& payload) {
+    EXPECT_TRUE(TestUtility::protoEqual(
+        payload,
+        MessageUtil::stringPairStruct({{"example_provider", "example_provider-payload"}})));
+  }));
+
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers = Http::TestHeaderMapImpl{
       {"sec-istio-auth-userinfo", ""},
@@ -184,7 +193,7 @@ rules:
 )";
   MessageUtil::loadFromYaml(config, proto_config_);
   auto mock_auth = std::make_unique<MockAuthenticator>();
-  EXPECT_CALL(*mock_auth.get(), doVerify(_, _, _)).Times(0);
+  EXPECT_CALL(*mock_auth.get(), doVerify(_, _, _, _)).Times(0);
   mock_auths_["example_provider"] = std::move(mock_auth);
   createVerifier();
 
@@ -199,6 +208,14 @@ TEST_F(GroupVerifierTest, TestRequiresAll) {
   MessageUtil::loadFromYaml(RequiresAllConfig, proto_config_);
   createSyncMockAuthsAndVerifier(
       StatusMap{{"example_provider", Status::Ok}, {"other_provider", Status::Ok}});
+
+  EXPECT_CALL(mock_cb_, setPayload(_)).WillOnce(Invoke([](const ProtobufWkt::Struct& payload) {
+    EXPECT_TRUE(
+        TestUtility::protoEqual(payload, MessageUtil::stringPairStruct({
+                                             {"example_provider", "example_provider-payload"},
+                                             {"other_provider", "other_provider-payload"},
+                                         })));
+  }));
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers = Http::TestHeaderMapImpl{
@@ -217,6 +234,8 @@ TEST_F(GroupVerifierTest, TestRequiresAllBadFormat) {
   auto callbacks = createAsyncMockAuthsAndVerifier(
       std::vector<std::string>{"example_provider", "other_provider"});
 
+  // onComplete with failure status, not payload
+  EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtBadFormat)).Times(1);
   auto headers = Http::TestHeaderMapImpl{
       {"example-auth-userinfo", ""},
@@ -239,6 +258,8 @@ TEST_F(GroupVerifierTest, TestRequiresAllMissing) {
   auto callbacks = createAsyncMockAuthsAndVerifier(
       std::vector<std::string>{"example_provider", "other_provider"});
 
+  // onComplete with failure status, not payload
+  EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtMissed)).Times(1);
   auto headers = Http::TestHeaderMapImpl{
       {"example-auth-userinfo", ""},
@@ -261,6 +282,8 @@ TEST_F(GroupVerifierTest, TestRequiresAllBothFailed) {
   auto callbacks = createAsyncMockAuthsAndVerifier(
       std::vector<std::string>{"example_provider", "other_provider"});
 
+  // onComplete with failure status, not payload
+  EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtUnknownIssuer)).Times(1);
   auto headers = Http::TestHeaderMapImpl{
       {"example-auth-userinfo", ""},
@@ -279,6 +302,13 @@ TEST_F(GroupVerifierTest, TestRequiresAnyFirstAuthOK) {
   MessageUtil::loadFromYaml(RequiresAnyConfig, proto_config_);
   createSyncMockAuthsAndVerifier(StatusMap{{"example_provider", Status::Ok}});
 
+  EXPECT_CALL(mock_cb_, setPayload(_)).WillOnce(Invoke([](const ProtobufWkt::Struct& payload) {
+    EXPECT_TRUE(
+        TestUtility::protoEqual(payload, MessageUtil::stringPairStruct({
+                                             {"example_provider", "example_provider-payload"},
+                                         })));
+  }));
+
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers = Http::TestHeaderMapImpl{
       {"example-auth-userinfo", ""},
@@ -295,6 +325,12 @@ TEST_F(GroupVerifierTest, TestRequiresAnyLastAuthOk) {
   MessageUtil::loadFromYaml(RequiresAnyConfig, proto_config_);
   createSyncMockAuthsAndVerifier(
       StatusMap{{"example_provider", Status::JwtUnknownIssuer}, {"other_provider", Status::Ok}});
+
+  EXPECT_CALL(mock_cb_, setPayload(_)).WillOnce(Invoke([](const ProtobufWkt::Struct& payload) {
+    EXPECT_TRUE(TestUtility::protoEqual(payload, MessageUtil::stringPairStruct({
+                                                     {"other_provider", "other_provider-payload"},
+                                                 })));
+  }));
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers = Http::TestHeaderMapImpl{
@@ -315,6 +351,8 @@ TEST_F(GroupVerifierTest, TestRequiresAnyAllAuthFailed) {
   createSyncMockAuthsAndVerifier(StatusMap{{"example_provider", Status::JwtHeaderBadKid},
                                            {"other_provider", Status::JwtUnknownIssuer}});
 
+  // onComplete with failure status, not payload
+  EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtUnknownIssuer)).Times(1);
   auto headers = Http::TestHeaderMapImpl{
       {"example-auth-userinfo", ""},
@@ -332,6 +370,13 @@ TEST_F(GroupVerifierTest, TestAnyInAllFirstAnyIsOk) {
   MessageUtil::loadFromYaml(AllWithAny, proto_config_);
   createSyncMockAuthsAndVerifier(StatusMap{{"provider_1", Status::Ok}, {"provider_3", Status::Ok}});
 
+  EXPECT_CALL(mock_cb_, setPayload(_)).WillOnce(Invoke([](const ProtobufWkt::Struct& payload) {
+    EXPECT_TRUE(TestUtility::protoEqual(payload, MessageUtil::stringPairStruct({
+                                                     {"provider_1", "provider_1-payload"},
+                                                     {"provider_3", "provider_3-payload"},
+                                                 })));
+  }));
+
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers = Http::TestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, &mock_cb_);
@@ -346,6 +391,13 @@ TEST_F(GroupVerifierTest, TestAnyInAllLastAnyIsOk) {
                                            {"provider_2", Status::Ok},
                                            {"provider_3", Status::Ok}});
 
+  EXPECT_CALL(mock_cb_, setPayload(_)).WillOnce(Invoke([](const ProtobufWkt::Struct& payload) {
+    EXPECT_TRUE(TestUtility::protoEqual(payload, MessageUtil::stringPairStruct({
+                                                     {"provider_2", "provider_2-payload"},
+                                                     {"provider_3", "provider_3-payload"},
+                                                 })));
+  }));
+
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers = Http::TestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, &mock_cb_);
@@ -359,6 +411,8 @@ TEST_F(GroupVerifierTest, TestAnyInAllBothInRequireAnyIsOk) {
   auto callbacks = createAsyncMockAuthsAndVerifier(
       std::vector<std::string>{"provider_1", "provider_2", "provider_3"});
 
+  // AsyncMockVerifier doesn't set payload
+  EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers = Http::TestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, &mock_cb_);
@@ -375,6 +429,7 @@ TEST_F(GroupVerifierTest, TestAnyInAllBothInRequireAnyFailed) {
   auto callbacks = createAsyncMockAuthsAndVerifier(
       std::vector<std::string>{"provider_1", "provider_2", "provider_3"});
 
+  EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::JwksFetchFail)).Times(1);
   auto headers = Http::TestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, &mock_cb_);
@@ -392,6 +447,7 @@ TEST_F(GroupVerifierTest, TestAllInAnyBothRequireAllFailed) {
   createSyncMockAuthsAndVerifier(
       StatusMap{{"provider_1", Status::JwksFetchFail}, {"provider_3", Status::JwtExpired}});
 
+  EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired)).Times(1);
   auto headers = Http::TestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, &mock_cb_);
@@ -405,6 +461,8 @@ TEST_F(GroupVerifierTest, TestAllInAnyFirstAllIsOk) {
   auto callbacks = createAsyncMockAuthsAndVerifier(
       std::vector<std::string>{"provider_1", "provider_2", "provider_3", "provider_4"});
 
+  // AsyncMockVerifier doesn't set payload
+  EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
   auto headers = Http::TestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, &mock_cb_);
@@ -459,11 +517,10 @@ TEST_F(GroupVerifierTest, TestRequiresAnyWithAllowAll) {
   auto callbacks = createAsyncMockAuthsAndVerifier(
       std::vector<std::string>{"example_provider", "other_provider"});
   auto mock_auth = std::make_unique<MockAuthenticator>();
-  EXPECT_CALL(*mock_auth.get(), doVerify(_, _, _))
+  EXPECT_CALL(*mock_auth.get(), doVerify(_, _, _, _))
       .WillOnce(Invoke(
-          [&](Http::HeaderMap&, std::vector<JwtLocationConstPtr>*, AuthenticatorCallback callback) {
-            callbacks[allowfailed] = std::move(callback);
-          }));
+          [&](Http::HeaderMap&, std::vector<JwtLocationConstPtr>*, SetPayloadCallback,
+              AuthenticatorCallback callback) { callbacks[allowfailed] = std::move(callback); }));
   EXPECT_CALL(*mock_auth.get(), onDestroy()).Times(1);
   mock_auths_[allowfailed] = std::move(mock_auth);
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);

--- a/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
@@ -82,9 +82,9 @@ public:
     for (const auto& it : statuses) {
       auto mock_auth = std::make_unique<MockAuthenticator>();
       EXPECT_CALL(*mock_auth.get(), doVerify(_, _, _, _))
-          .WillOnce(Invoke([ issuer = it.first, status = it.second ](
-              Http::HeaderMap&, std::vector<JwtLocationConstPtr>*,
-              SetPayloadCallback set_payload_cb, AuthenticatorCallback callback) {
+          .WillOnce(Invoke([issuer = it.first, status = it.second](
+                               Http::HeaderMap&, std::vector<JwtLocationConstPtr>*,
+                               SetPayloadCallback set_payload_cb, AuthenticatorCallback callback) {
             if (status == Status::Ok) {
               set_payload_cb(issuer, issuer + "-payload");
             }
@@ -102,9 +102,11 @@ public:
     for (std::size_t i = 0; i < providers.size(); ++i) {
       auto mock_auth = std::make_unique<MockAuthenticator>();
       EXPECT_CALL(*mock_auth.get(), doVerify(_, _, _, _))
-          .WillOnce(Invoke([&callbacks, iss = providers[i] ](
-              Http::HeaderMap&, std::vector<JwtLocationConstPtr>*, SetPayloadCallback,
-              AuthenticatorCallback callback) { callbacks[iss] = std::move(callback); }));
+          .WillOnce(Invoke(
+              [&callbacks, iss = providers[i]](Http::HeaderMap&, std::vector<JwtLocationConstPtr>*,
+                                               SetPayloadCallback, AuthenticatorCallback callback) {
+                callbacks[iss] = std::move(callback);
+              }));
       EXPECT_CALL(*mock_auth.get(), onDestroy()).Times(1);
       mock_auths_[providers[i]] = std::move(mock_auth);
     }

--- a/test/extensions/filters/http/jwt_authn/mock.h
+++ b/test/extensions/filters/http/jwt_authn/mock.h
@@ -19,12 +19,12 @@ public:
 
 class MockAuthenticator : public Authenticator {
 public:
-  MOCK_METHOD3(doVerify, void(Http::HeaderMap& headers, std::vector<JwtLocationConstPtr>* tokens,
-                              std::function<void(const ::google::jwt_verify::Status&)> callback));
+  MOCK_METHOD4(doVerify, void(Http::HeaderMap& headers, std::vector<JwtLocationConstPtr>* tokens,
+                              SetPayloadCallback set_payload_cb, AuthenticatorCallback callback));
 
   void verify(Http::HeaderMap& headers, std::vector<JwtLocationConstPtr>&& tokens,
-              AuthenticatorCallback callback) {
-    doVerify(headers, &tokens, std::move(callback));
+              SetPayloadCallback set_payload_cb, AuthenticatorCallback callback) {
+    doVerify(headers, &tokens, std::move(set_payload_cb), std::move(callback));
   }
 
   MOCK_METHOD0(onDestroy, void());
@@ -32,6 +32,7 @@ public:
 
 class MockVerifierCallbacks : public Verifier::Callbacks {
 public:
+  MOCK_METHOD1(setPayload, void(const ProtobufWkt::Struct& payload));
   MOCK_METHOD1(onComplete, void(const Status& status));
 };
 

--- a/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
@@ -36,8 +36,14 @@ public:
 
 TEST_F(ProviderVerifierTest, TestOkJWT) {
   MessageUtil::loadFromYaml(ExampleConfig, proto_config_);
+  (*proto_config_.mutable_providers())[std::string(ProviderName)].set_payload_in_metadata(true);
   createVerifier();
   MockUpstream mock_pubkey(mock_factory_ctx_.cluster_manager_, PublicKey);
+
+  EXPECT_CALL(mock_cb_, setPayload(_)).WillOnce(Invoke([](const ProtobufWkt::Struct& payload) {
+    EXPECT_TRUE(TestUtility::protoEqual(
+        payload, MessageUtil::keyValueStruct("https://example.com", ExpectedPayloadValue)));
+  }));
 
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
 


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

*Description*:

Use dynamicMetadata in the StreamInfo to pass all successfully verified JWT payloads to other HTTP filters.

*Risk Level*:  Low
*Testing*:  Add unit-tests
