### PR TITLE
http: update comment about absolute urls

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -587,8 +587,8 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
   }
 
   // Currently we only support relative paths at the application layer. We expect the codec to have
-  // broken the path into pieces if applicable. NOTE: Currently the HTTP/1.1 codec does not do this
-  // so we only support relative paths in all cases. https://tools.ietf.org/html/rfc7230#section-5.3
+  // broken the path into pieces if applicable. NOTE: Currently the HTTP/1.1 codec only does this when
+  // the allow_absolute_url flag is enabled on the HCM. https://tools.ietf.org/html/rfc7230#section-5.3
   // We also need to check for the existence of :path because CONNECT does not have a path, and we
   // don't support that currently.
   if (!request_headers_->Path() || request_headers_->Path()->value().c_str()[0] != '/') {

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -587,10 +587,10 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
   }
 
   // Currently we only support relative paths at the application layer. We expect the codec to have
-  // broken the path into pieces if applicable. NOTE: Currently the HTTP/1.1 codec only does this when
-  // the allow_absolute_url flag is enabled on the HCM. https://tools.ietf.org/html/rfc7230#section-5.3
-  // We also need to check for the existence of :path because CONNECT does not have a path, and we
-  // don't support that currently.
+  // broken the path into pieces if applicable. NOTE: Currently the HTTP/1.1 codec only does this
+  // when the allow_absolute_url flag is enabled on the HCM.
+  // https://tools.ietf.org/html/rfc7230#section-5.3 We also need to check for the existence of
+  // :path because CONNECT does not have a path, and we don't support that currently.
   if (!request_headers_->Path() || request_headers_->Path()->value().c_str()[0] != '/') {
     connection_manager_.stats_.named_.downstream_rq_non_relative_path_.inc();
     sendLocalReply(Grpc::Common::hasGrpcContentType(*request_headers_), Code::NotFound, "", nullptr,


### PR DESCRIPTION
Updates the comment since absolute URLs can now be handled by the codec
by setting the allow_absolute_url flag.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Low
*Testing*: n/a
*Docs Changes*: n/a
*Release Notes*: n/a
