### PR TITLE
Fix data race in overload manager shutdown

### DIFF
--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -152,6 +152,14 @@ void OverloadManagerImpl::start() {
   timer_->enableTimer(refresh_interval_);
 }
 
+void OverloadManagerImpl::stop() {
+  // Disable any pending timeouts.
+  timer_.reset();
+
+  // Clear the resource map to block on any pending updates.
+  resources_.clear();
+}
+
 void OverloadManagerImpl::registerForAction(const std::string& action,
                                             Event::Dispatcher& dispatcher,
                                             OverloadActionCb callback) {

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -60,6 +60,11 @@ public:
                          OverloadActionCb callback) override;
   ThreadLocalOverloadState& getThreadLocalOverloadState() override;
 
+  // Stop the overload manager timer and wait for any pending resource updates to complete.
+  // After this returns, overload manager clients should not receive any more callbacks
+  // about overload state changes.
+  void stop();
+
 private:
   class Resource : public ResourceMonitor::Callbacks {
   public:

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -475,7 +475,7 @@ void InstanceImpl::terminate() {
   stats_store_.shutdownThreading();
 
   if (overload_manager_) {
-    overload_manager_.reset();
+    overload_manager_->stop();
   }
 
   // Shutdown all the workers now that the main dispatch loop is done.


### PR DESCRIPTION
Add a stop method to shutdown the overload manager rather than just freeing the object. This avoids a data race with worker threads that are accepting a new request when envoy is being shutdown

*Risk Level*: low
*Testing*: bazel test //test/integration:h1_capture_direct_response_fuzz_test --config=clang-tsan -c dbg --runs_per_test=1000
[Optional Fixes #Issue] #4676 

Signed-off-by: Elisha Ziskind <eziskind@google.com>
