### PR TITLE
config: reset ads stream in case of protocol violation

### DIFF
--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -167,9 +167,9 @@ void GrpcMuxImpl::onReceiveMessage(std::unique_ptr<envoy::api::v2::DiscoveryResp
   const std::string& type_url = message->type_url();
   ENVOY_LOG(debug, "Received gRPC message for {} at version {}", type_url, message->version_info());
   if (api_state_.count(type_url) == 0) {
-    ENVOY_LOG(warn, "Ignoring unknown type URL {}", type_url);
-    // TODO(yuval-k): This should never happen. consider dropping the stream as this is a protocol
-    // violation
+    ENVOY_LOG(warn, "Protocol Error: gRPC Message for type URL {} received before subscription",
+              type_url);
+    stream_->resetStream();
     return;
   }
   if (api_state_[type_url].watches_.empty()) {


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*: Resets ADS stream incase of protocol violation
*Risk Level*: Low
*Testing*: Added Automated Tests
*Docs Changes*: N/A
*Release Notes*: N/A

