### PR TITLE
common: add assert for zero base interval

### DIFF
--- a/source/common/common/backoff_strategy.cc
+++ b/source/common/common/backoff_strategy.cc
@@ -5,6 +5,7 @@ namespace Envoy {
 JitteredBackOffStrategy::JitteredBackOffStrategy(uint64_t base_interval, uint64_t max_interval,
                                                  Runtime::RandomGenerator& random)
     : base_interval_(base_interval), max_interval_(max_interval), random_(random) {
+  ASSERT(base_interval_ > 0);
   ASSERT(base_interval_ <= max_interval_);
 }
 

--- a/source/common/common/backoff_strategy.h
+++ b/source/common/common/backoff_strategy.h
@@ -18,7 +18,8 @@ class JitteredBackOffStrategy : public BackOffStrategy {
 public:
   /**
    * Constructs fully jittered backoff strategy.
-   * @param base_interval the base_interval to be used for next backoff computation.
+   * @param base_interval the base_interval to be used for next backoff computation. It should be
+   * greater than zero and less than max_interval.
    * @param max_interval the cap on the next backoff value.
    * @param random the random generator
    */

--- a/source/common/common/backoff_strategy.h
+++ b/source/common/common/backoff_strategy.h
@@ -19,7 +19,7 @@ public:
   /**
    * Constructs fully jittered backoff strategy.
    * @param base_interval the base_interval to be used for next backoff computation. It should be
-   * greater than zero and less than max_interval.
+   * greater than zero and less than or equal to max_interval.
    * @param max_interval the cap on the next backoff value.
    * @param random the random generator
    */


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*: Passing zero base_interval causes JitteredBackOffStrategy to crash with floating point error. This PR adds `ASSERT` to check that upfront.
*Risk Level*: Low
*Testing*: Existing tests
*Docs Changes*: N/A
*Release Notes*:N/A

