### PR TITLE
build: fix circleci ipv6 config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
      - run:
          name: enable ipv6
          command: |
-           cat \<<'EOF' | sudo tee /etc/docker/daemon.json
+           cat <<'EOF' | sudo tee /etc/docker/daemon.json
            {
              "ipv6": true,
              "fixed-cidr-v6": "2001:db8:1::/64"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,12 +60,10 @@ jobs:
      - run:
          name: enable ipv6
          command: |
-           cat <<'EOF' | sudo tee /etc/docker/daemon.json
-           {
+           echo '{
              "ipv6": true,
              "fixed-cidr-v6": "2001:db8:1::/64"
-           }
-           EOF
+           }' | sudo tee /etc/docker/daemon.json
 
            sudo service docker restart
      - run: dig go.googlesource.com A go.googlesource.com AAAA # Debug IPv6 network issues


### PR DESCRIPTION
Fix circleci config for ipv6.

*Risk Level*: low
*Testing*: n/a
*Docs Changes*: n/a
*Release Notes*: n/a

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
