### PR TITLE
Fix Jaeger-native tracing example.

### DIFF
--- a/examples/jaeger-native-tracing/install-jaeger-plugin.sh
+++ b/examples/jaeger-native-tracing/install-jaeger-plugin.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-JAEGER_VERSION=v0.4.0
+JAEGER_VERSION=v0.4.2
 wget -O /usr/local/lib/libjaegertracing_plugin.so https://github.com/jaegertracing/jaeger-client-cpp/releases/download/$JAEGER_VERSION/libjaegertracing_plugin.linux_amd64.so


### PR DESCRIPTION
Signed-off-by: Ryan Burn <ryan.burn@gmail.com>

*Description*: Fixes Jaeger-native tracing example
*Risk Level*: Low

Merely bumps the version of Jaeger so that it's compatible with the current version of Envoy.