### PR TITLE
ci: update buildifier to 0.17.2

### DIFF
--- a/ci/build_container/build_container_common.sh
+++ b/ci/build_container/build_container_common.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
-VERSION=0.15.0
-SHA256=769b9757644a8ec9c4b07369fda4a3e6592639a1338a7a03225ceeedbc760b45
+VERSION=0.17.2
+SHA256=1cf35c463944003ceb3c3716d7fc489d3d70625e34a8127dfd8b272afad7e0fd
 
 # buildifier
 curl --location --output /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/"$VERSION"/buildifier \


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

*Description*:
Update buildifier to 0.17.2
side effect: rebuild image to pick up bazel 0.18.0

*Risk Level*: Low
*Testing*: CI
*Docs Changes*: N/A
*Release Notes*: N/A
