### PR TITLE
 routematch: Remove deprecated runtime field

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -307,33 +307,17 @@ message RouteMatch {
   // is true.
   google.protobuf.BoolValue case_sensitive = 4;
 
-  oneof runtime_specifier {
-    // Indicates that the route should additionally match on a runtime key. An integer between
-    // 0-100. Every time the route is considered for a match, a random number between 0-99 is
-    // selected. If the number is <= the value found in the key (checked first) or, if the key is
-    // not present, the default value, the route is a match (assuming everything also about the
-    // route matches). A runtime route configuration can be used to roll out route changes in a
-    // gradual manner without full code/config deploys. Refer to the :ref:`traffic shifting
-    // <config_http_conn_man_route_table_traffic_splitting_shift>` docs for additional
-    // documentation.
-    //
-    // .. attention::
-    //
-    //   **This field is deprecated**. Set the
-    //   :ref:`runtime_fraction<envoy_api_field_route.RouteMatch.runtime_fraction>` field instead.
-    core.RuntimeUInt32 runtime = 5 [deprecated = true];
+  reserved 5;
 
-    // Indicates that the route should additionally match on a runtime key. Every time the route
-    // is considered for a match, it must also fall under the percentage of matches indicated by
-    // this field. For some fraction N/D, a random number in the range [0,D) is selected. If the
-    // number is <= the value of the numberator N, or if the key is not present, the default
-    // value, the router continues to evaluate the remaining match criteria. A runtime_fraction
-    // route configuration can be used to roll out route changes in a gradual manner (with more
-    // granularity than the deprecated runtime field) without full code/config deploys. Refer to
-    // the :ref:`traffic shifting <config_http_conn_man_route_table_traffic_splitting_shift>` docs
-    // for additional documentation.
-    core.RuntimeFractionalPercent runtime_fraction = 9;
-  }
+  // Indicates that the route should additionally match on a runtime key. Every time the route
+  // is considered for a match, it must also fall under the percentage of matches indicated by
+  // this field. For some fraction N/D, a random number in the range [0,D) is selected. If the
+  // number is <= the value of the numberator N, or if the key is not present, the default
+  // value, the router continues to evaluate the remaining match criteria. A runtime_fraction
+  // route configuration can be used to roll out route changes in a gradual manner without full
+  // code/config deploys. Refer to the :ref:`traffic shifting
+  // <config_http_conn_man_route_table_traffic_splitting_shift>` docs for additional documentation.
+  core.RuntimeFractionalPercent runtime_fraction = 9;
 
   // Specifies a set of headers that the route should match on. The router will
   // check the request’s headers against all the specified headers in the route

--- a/configs/envoy_router_v2.template.yaml
+++ b/configs/envoy_router_v2.template.yaml
@@ -7,8 +7,10 @@ virtual_hosts:
   routes:
   - match:
       prefix: "/foo/bar"
-      runtime:
-        default_value: 0
+      runtime_fraction:
+        default_value:
+          numerator: 0
+          denominator: HUNDRED
         runtime_key: routing.www.use_service_2
     route:
       {{ helper.make_route('service2')|indent(4) }}

--- a/docs/root/configuration/http_conn_man/traffic_splitting.rst
+++ b/docs/root/configuration/http_conn_man/traffic_splitting.rst
@@ -58,11 +58,11 @@ envoy configuration file.
 
 
 Envoy matches routes with a :ref:`first match <config_http_conn_man_route_table_route_matching>` policy.
-If the route has a runtime object, the request will be additionally matched based on the runtime
-:ref:`value <envoy_api_field_route.RouteMatch.runtime>`
+If the route has a runtime_fraction object, the request will be additionally matched based on the runtime_fraction
+:ref:`value <envoy_api_field_route.RouteMatch.runtime_fraction>`
 (or the default, if no value is specified). Thus, by placing routes
-back-to-back in the above example and specifying a runtime object in the
-first route, traffic shifting can be accomplished by changing the runtime
+back-to-back in the above example and specifying a runtime_fraction object in the
+first route, traffic shifting can be accomplished by changing the runtime_fraction
 value. The following are the approximate sequence of actions required to
 accomplish the task.
 

--- a/docs/root/install/tools/route_table_check_tool.rst
+++ b/docs/root/install/tools/route_table_check_tool.rst
@@ -39,7 +39,7 @@ Output
     locations ats cluster_name
     Test_6
 
-  Testing with valid :ref:`runtime values <envoy_api_field_route.RouteMatch.runtime>` is not currently supported,
+  Testing with valid :ref:`runtime values <envoy_api_field_route.RouteMatch.runtime_fraction>` is not currently supported,
   this may be added in future work.
 
 Building

--- a/docs/root/intro/arch_overview/http_routing.rst
+++ b/docs/root/intro/arch_overview/http_routing.rst
@@ -37,7 +37,7 @@ request. The router filter supports the following features:
   header <config_http_filters_router_headers_consumed>` or via :ref:`route configuration
   <envoy_api_field_route.RouteAction.timeout>`.
 * Traffic shifting from one upstream cluster to another via :ref:`runtime values
-  <envoy_api_field_route.RouteMatch.runtime>` (see :ref:`traffic shifting/splitting
+  <envoy_api_field_route.RouteMatch.runtime_fraction>` (see :ref:`traffic shifting/splitting
   <config_http_conn_man_route_table_traffic_splitting>`).
 * Traffic splitting across multiple upstream clusters using :ref:`weight/percentage-based routing
   <envoy_api_field_route.RouteAction.weighted_clusters>` (see :ref:`traffic shifting/splitting

--- a/source/common/config/base_json.cc
+++ b/source/common/config/base_json.cc
@@ -3,9 +3,10 @@
 namespace Envoy {
 namespace Config {
 
-void BaseJson::translateRuntimeUInt32(const Json::Object& json_runtime,
-                                      envoy::api::v2::core::RuntimeUInt32& runtime) {
-  runtime.set_default_value(json_runtime.getInteger("default"));
+void BaseJson::translateRuntimeFraction(const Json::Object& json_runtime,
+                                        envoy::api::v2::core::RuntimeFractionalPercent& runtime) {
+  runtime.mutable_default_value()->set_denominator(envoy::type::FractionalPercent::HUNDRED);
+  runtime.mutable_default_value()->set_numerator(json_runtime.getInteger("default"));
   runtime.set_runtime_key(json_runtime.getString("key"));
 }
 

--- a/source/common/config/base_json.h
+++ b/source/common/config/base_json.h
@@ -9,12 +9,12 @@ namespace Config {
 class BaseJson {
 public:
   /**
-   * Translate a v1 JSON integer runtime object to v2 envoy::api::v2::core::RuntimeUInt32.
+   * Translate a v1 JSON integer runtime object to v2 envoy::api::v2::core::RuntimeFractionalPercent.
    * @param json_runtime source v1 JSON integer runtime object.
-   * @param runtime destination v2 envoy::api::v2::core::RuntimeUInt32.
+   * @param runtime destination v2 envoy::api::v2::core::RuntimeFractionalPercent.
    */
-  static void translateRuntimeUInt32(const Json::Object& json_runtime,
-                                     envoy::api::v2::core::RuntimeUInt32& runtime);
+  static void translateRuntimeFraction(const Json::Object& json_runtime,
+                                       envoy::api::v2::core::RuntimeFractionalPercent& runtime);
 
   /**
    * Translate a v1 JSON header-value object to v2 envoy::api::v2::core::HeaderValueOption.

--- a/source/common/config/base_json.h
+++ b/source/common/config/base_json.h
@@ -9,7 +9,8 @@ namespace Config {
 class BaseJson {
 public:
   /**
-   * Translate a v1 JSON integer runtime object to v2 envoy::api::v2::core::RuntimeFractionalPercent.
+   * Translate a v1 JSON integer runtime object to v2
+   * envoy::api::v2::core::RuntimeFractionalPercent.
    * @param json_runtime source v1 JSON integer runtime object.
    * @param runtime destination v2 envoy::api::v2::core::RuntimeFractionalPercent.
    */

--- a/source/common/config/rds_json.cc
+++ b/source/common/config/rds_json.cc
@@ -224,6 +224,10 @@ void RdsJson::translateRoute(const Json::Object& json_route, envoy::api::v2::rou
 
   JSON_UTIL_SET_BOOL(json_route, *match, case_sensitive);
 
+  if (json_route.hasObject("runtime")) {
+    BaseJson::translateRuntimeFraction(*json_route.getObject("runtime"), *match->mutable_runtime_fraction());
+  }
+
   for (const auto json_header_matcher : json_route.getObjectArray("headers", true)) {
     auto* header_matcher = match->mutable_headers()->Add();
     translateHeaderMatcher(*json_header_matcher, *header_matcher);

--- a/source/common/config/rds_json.cc
+++ b/source/common/config/rds_json.cc
@@ -224,10 +224,6 @@ void RdsJson::translateRoute(const Json::Object& json_route, envoy::api::v2::rou
 
   JSON_UTIL_SET_BOOL(json_route, *match, case_sensitive);
 
-  if (json_route.hasObject("runtime")) {
-    BaseJson::translateRuntimeUInt32(*json_route.getObject("runtime"), *match->mutable_runtime());
-  }
-
   for (const auto json_header_matcher : json_route.getObjectArray("headers", true)) {
     auto* header_matcher = match->mutable_headers()->Add();
     translateHeaderMatcher(*json_header_matcher, *header_matcher);

--- a/source/common/config/rds_json.cc
+++ b/source/common/config/rds_json.cc
@@ -225,7 +225,8 @@ void RdsJson::translateRoute(const Json::Object& json_route, envoy::api::v2::rou
   JSON_UTIL_SET_BOOL(json_route, *match, case_sensitive);
 
   if (json_route.hasObject("runtime")) {
-    BaseJson::translateRuntimeFraction(*json_route.getObject("runtime"), *match->mutable_runtime_fraction());
+    BaseJson::translateRuntimeFraction(*json_route.getObject("runtime"),
+                                       *match->mutable_runtime_fraction());
   }
 
   for (const auto json_header_matcher : json_route.getObjectArray("headers", true)) {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -380,17 +380,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
 }
 
 bool RouteEntryImplBase::evaluateRuntimeMatch(const uint64_t random_value) const {
-  if (!runtime_) {
-    return true;
-  }
-
-  if (runtime_->legacy_runtime_data_) {
-    // Use the deprecated 'runtime' field from the route.
-    return loader_.snapshot().featureEnabled(runtime_->runtime_key_, runtime_->runtime_default_,
-                                             random_value);
-  }
-
-  return loader_.snapshot().featureEnabled(runtime_->fractional_runtime_key_,
+  return !runtime_ ? true : loader_.snapshot().featureEnabled(runtime_->fractional_runtime_key_,
                                            runtime_->fractional_runtime_default_, random_value);
 }
 
@@ -464,19 +454,13 @@ RouteEntryImplBase::loadRuntimeData(const envoy::api::v2::route::RouteMatch& rou
   absl::optional<RuntimeData> runtime;
   RuntimeData runtime_data;
 
-  if (route_match.runtime_specifier_case() == envoy::api::v2::route::RouteMatch::kRuntimeFraction) {
+  if (route_match.has_runtime_fraction()) {
     runtime_data.fractional_runtime_default_ = route_match.runtime_fraction().default_value();
     runtime_data.fractional_runtime_key_ = route_match.runtime_fraction().runtime_key();
-    runtime_data.legacy_runtime_data_ = false;
-  } else if (route_match.runtime_specifier_case() == envoy::api::v2::route::RouteMatch::kRuntime) {
-    runtime_data.runtime_default_ = route_match.runtime().default_value();
-    runtime_data.runtime_key_ = route_match.runtime().runtime_key();
-    runtime_data.legacy_runtime_data_ = true;
-  } else {
-    return runtime;
+    return runtime_data;
   }
 
-  return runtime_data;
+  return runtime;
 }
 
 void RouteEntryImplBase::finalizePathHeader(Http::HeaderMap& headers,

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -380,8 +380,10 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
 }
 
 bool RouteEntryImplBase::evaluateRuntimeMatch(const uint64_t random_value) const {
-  return !runtime_ ? true : loader_.snapshot().featureEnabled(runtime_->fractional_runtime_key_,
-                                           runtime_->fractional_runtime_default_, random_value);
+  return !runtime_ ? true
+                   : loader_.snapshot().featureEnabled(runtime_->fractional_runtime_key_,
+                                                       runtime_->fractional_runtime_default_,
+                                                       random_value);
 }
 
 bool RouteEntryImplBase::matchRoute(const Http::HeaderMap& headers, uint64_t random_value) const {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -386,13 +386,6 @@ private:
   struct RuntimeData {
     std::string fractional_runtime_key_{};
     envoy::type::FractionalPercent fractional_runtime_default_{};
-
-    // Relating to the deprecated 'runtime' field.
-    std::string runtime_key_{};
-    uint64_t runtime_default_{};
-
-    // Indicates whether to use the deprecated 'runtime' field or 'fractional_percent'.
-    bool legacy_runtime_data_{};
   };
 
   class DynamicRouteEntry : public RouteEntry, public Route {

--- a/test/common/config/BUILD
+++ b/test/common/config/BUILD
@@ -164,6 +164,22 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+  name = "rds_json_test",
+  srcs = ["rds_json_test.cc"],
+  deps = [
+        "//source/common/config:rds_json_lib",
+        "//source/common/json:json_loader_lib",
+        "//test/mocks/grpc:grpc_mocks",
+        "//test/mocks/local_info:local_info_mocks",
+        "//test/mocks/stats:stats_mocks",
+        "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:environment_lib",
+        "//test/test_common:utility_lib",
+   ],
+)
+
+
+envoy_cc_test(
     name = "utility_test",
     srcs = ["utility_test.cc"],
     deps = [

--- a/test/common/config/BUILD
+++ b/test/common/config/BUILD
@@ -164,9 +164,9 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
-  name = "rds_json_test",
-  srcs = ["rds_json_test.cc"],
-  deps = [
+    name = "rds_json_test",
+    srcs = ["rds_json_test.cc"],
+    deps = [
         "//source/common/config:rds_json_lib",
         "//source/common/json:json_loader_lib",
         "//test/mocks/grpc:grpc_mocks",
@@ -175,9 +175,8 @@ envoy_cc_test(
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:utility_lib",
-   ],
+    ],
 )
-
 
 envoy_cc_test(
     name = "utility_test",

--- a/test/common/config/rds_json_test.cc
+++ b/test/common/config/rds_json_test.cc
@@ -1,0 +1,42 @@
+#include "envoy/common/exception.h"
+
+#include "common/config/rds_json.h"
+#include "common/json/json_loader.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+
+namespace Envoy {
+namespace Config {
+
+TEST(RdsJsonTest, TestRuntimeFractionTranslation) {
+  const std::string json_string = R"EOF(
+  {
+    "prefix": "/new_endpoint",
+    "prefix_rewrite": "/api/new_endpoint",
+    "cluster": "www2",
+    "runtime": {
+      "default": 42,
+      "key": "some_key"
+    },
+    "request_headers_to_add": [
+      {
+        "key": "x-key",
+        "value": "%UPSTREAM_METADATA([\"namespace\", \"key\"])%"
+      }
+    ]
+  }
+  )EOF";
+  envoy::api::v2::route::Route route;  
+  auto json_object_ptr = Json::Factory::loadFromString(json_string);
+  Envoy::Config::RdsJson::translateRoute(*json_object_ptr, route);
+
+  EXPECT_EQ(route.match().runtime_fraction().default_value().numerator(), 42);
+  EXPECT_EQ(route.match().runtime_fraction().default_value().denominator(), envoy::type::FractionalPercent::HUNDRED);
+  EXPECT_EQ(route.match().runtime_fraction().runtime_key(), "some_key");
+}
+
+} // namespace Config
+} // namespace Envoy

--- a/test/common/config/rds_json_test.cc
+++ b/test/common/config/rds_json_test.cc
@@ -29,12 +29,13 @@ TEST(RdsJsonTest, TestRuntimeFractionTranslation) {
     ]
   }
   )EOF";
-  envoy::api::v2::route::Route route;  
+  envoy::api::v2::route::Route route;
   auto json_object_ptr = Json::Factory::loadFromString(json_string);
   Envoy::Config::RdsJson::translateRoute(*json_object_ptr, route);
 
   EXPECT_EQ(route.match().runtime_fraction().default_value().numerator(), 42);
-  EXPECT_EQ(route.match().runtime_fraction().default_value().denominator(), envoy::type::FractionalPercent::HUNDRED);
+  EXPECT_EQ(route.match().runtime_fraction().default_value().denominator(),
+            envoy::type::FractionalPercent::HUNDRED);
   EXPECT_EQ(route.match().runtime_fraction().runtime_key(), "some_key");
 }
 

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -1965,50 +1965,6 @@ TEST(RouteMatcherTest, ContentType) {
   }
 }
 
-TEST(RouteMatcherTest, Runtime) {
-  std::string json = R"EOF(
-{
-  "virtual_hosts": [
-    {
-      "name": "www2",
-      "domains": ["www.lyft.com"],
-      "routes": [
-        {
-          "prefix": "/",
-          "cluster": "something_else",
-          "runtime": {
-            "key": "some_key",
-            "default": 50
-          }
-        },
-        {
-          "prefix": "/",
-          "cluster": "www2"
-        }
-      ]
-    }
-  ]
-}
-  )EOF";
-
-  NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  Runtime::MockSnapshot snapshot;
-
-  ON_CALL(factory_context.runtime_loader_, snapshot()).WillByDefault(ReturnRef(snapshot));
-
-  TestConfigImpl config(parseRouteConfigurationFromJson(json), factory_context, true);
-
-  EXPECT_CALL(snapshot, featureEnabled("some_key", 50, 41)).WillRepeatedly(Return(true));
-  ;
-  EXPECT_EQ("something_else",
-            config.route(genHeaders("www.lyft.com", "/", "GET"), 41)->routeEntry()->clusterName());
-
-  EXPECT_CALL(snapshot, featureEnabled("some_key", 50, 43)).WillRepeatedly(Return(false));
-  ;
-  EXPECT_EQ("www2",
-            config.route(genHeaders("www.lyft.com", "/", "GET"), 43)->routeEntry()->clusterName());
-}
-
 TEST(RouteMatcherTest, FractionalRuntime) {
   std::string yaml = R"EOF(
 virtual_hosts:

--- a/test/config/integration/server.yaml
+++ b/test/config/integration/server.yaml
@@ -22,9 +22,11 @@ static_resources:
               - routes:
                 - prefix: "/"
                   cluster: cluster_1
-                  runtime:
-                    key: some_key
-                    default: 0
+                  runtime_fraction:
+                    runtime_key: some_key
+                    default_value:
+                      numerator: 0
+                      denominator: HUNDRED
                 - prefix: "/test/long/url"
                   rate_limits:
                   - actions:
@@ -132,9 +134,11 @@ static_resources:
                 require_ssl: all
               - routes:
                 - cluster: cluster_1
-                  runtime:
-                    key: some_key
-                    default: 0
+                  runtime_fraction:
+                    runtime_key: some_key
+                    default_value:
+                      numerator: 0
+                      denominator: HUNDRED
                   prefix: "/"
                 - rate_limits:
                   - actions:
@@ -265,9 +269,11 @@ static_resources:
                 require_ssl: all
               - routes:
                 - cluster: cluster_1
-                  runtime:
-                    key: some_key
-                    default: 0
+                  runtime_fraction:
+                    runtime_key: some_key
+                    default_value:
+                      numerator: 0
+                      denominator: HUNDRED
                   prefix: "/"
                 - prefix: "/test/long/url"
                   rate_limits:

--- a/test/config/integration/server.yaml
+++ b/test/config/integration/server.yaml
@@ -22,11 +22,9 @@ static_resources:
               - routes:
                 - prefix: "/"
                   cluster: cluster_1
-                  runtime_fraction:
-                    runtime_key: some_key
-                    default_value:
-                      numerator: 0
-                      denominator: HUNDRED
+                  runtime:
+                    key: some_key
+                    default: 0
                 - prefix: "/test/long/url"
                   rate_limits:
                   - actions:
@@ -134,11 +132,9 @@ static_resources:
                 require_ssl: all
               - routes:
                 - cluster: cluster_1
-                  runtime_fraction:
-                    runtime_key: some_key
-                    default_value:
-                      numerator: 0
-                      denominator: HUNDRED
+                  runtime:
+                    key: some_key
+                    default: 0
                   prefix: "/"
                 - rate_limits:
                   - actions:
@@ -269,11 +265,9 @@ static_resources:
                 require_ssl: all
               - routes:
                 - cluster: cluster_1
-                  runtime_fraction:
-                    runtime_key: some_key
-                    default_value:
-                      numerator: 0
-                      denominator: HUNDRED
+                  runtime:
+                    key: some_key
+                    default: 0
                   prefix: "/"
                 - prefix: "/test/long/url"
                   rate_limits:


### PR DESCRIPTION
*Description*:
This patch removes the deprecated `runtime` field from the RouteMatch proto.

*Risk Level*:
Low.

*Testing*:
Unit tests and build.

*Docs Changes*:
Done.

Fixes #4623 
