### PR TITLE
build: upgrade fmt to 5.2.1, spdlog to 1.2.1

### DIFF
--- a/bazel/external/fmtlib.BUILD
+++ b/bazel/external/fmtlib.BUILD
@@ -1,10 +1,12 @@
 cc_library(
     name = "fmtlib",
-    hdrs = glob([
+    srcs = glob([
         "fmt/*.cc",
-        "fmt/*.h",
+    ]),
+    hdrs = glob([
+        "include/fmt/*.h",
     ]),
     defines = ["FMT_HEADER_ONLY"],
-    includes = ["."],
+    includes = ["include"],
     visibility = ["//visibility:public"],
 )

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -38,14 +38,14 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/eile/tclap/archive/tclap-1-2-1-release-final.tar.gz"],
     ),
     com_github_fmtlib_fmt = dict(
-        sha256 = "46628a2f068d0e33c716be0ed9dcae4370242df135aed663a180b9fd8e36733d",
-        strip_prefix = "fmt-4.1.0",
-        urls = ["https://github.com/fmtlib/fmt/archive/4.1.0.tar.gz"],
+        sha256 = "3c812a18e9f72a88631ab4732a97ce9ef5bcbefb3235e9fd465f059ba204359b",
+        strip_prefix = "fmt-5.2.1",
+        urls = ["https://github.com/fmtlib/fmt/archive/5.2.1.tar.gz"],
     ),
     com_github_gabime_spdlog = dict(
-        sha256 = "94f74fd1b3344733d1db3de2ec22e6cbeb769f93a8baa0d4a22b1f62dc7369f8",
-        strip_prefix = "spdlog-0.17.0",
-        urls = ["https://github.com/gabime/spdlog/archive/v0.17.0.tar.gz"],
+        sha256 = "0ba31b9e7f8e43a7be328ab0236d57810e5d4fc8a1a7842df665ae22d5cbd128",
+        strip_prefix = "spdlog-1.2.0",
+        urls = ["https://github.com/gabime/spdlog/archive/v1.2.0.tar.gz"],
     ),
     com_github_gcovr_gcovr = dict(
         sha256 = "8a60ba6242d67a58320e9e16630d80448ef6d5284fda5fb3eff927b63c8b04a2",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -43,9 +43,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/fmtlib/fmt/archive/5.2.1.tar.gz"],
     ),
     com_github_gabime_spdlog = dict(
-        sha256 = "0ba31b9e7f8e43a7be328ab0236d57810e5d4fc8a1a7842df665ae22d5cbd128",
-        strip_prefix = "spdlog-1.2.0",
-        urls = ["https://github.com/gabime/spdlog/archive/v1.2.0.tar.gz"],
+        sha256 = "867a4b7cedf9805e6f76d3ca41889679054f7e5a3b67722fe6d0eae41852a767",
+        strip_prefix = "spdlog-1.2.1",
+        urls = ["https://github.com/gabime/spdlog/archive/v1.2.1.tar.gz"],
     ),
     com_github_gcovr_gcovr = dict(
         sha256 = "8a60ba6242d67a58320e9e16630d80448ef6d5284fda5fb3eff927b63c8b04a2",

--- a/include/envoy/stream_info/filter_state.h
+++ b/include/envoy/stream_info/filter_state.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <memory>
+#include <vector>
 
 #include "envoy/common/exception.h"
 #include "envoy/common/pure.h"

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -42,7 +42,7 @@ AccessLogFormatUtils::durationToString(const absl::optional<std::chrono::nanosec
 }
 
 std::string AccessLogFormatUtils::durationToString(const std::chrono::nanoseconds& time) {
-  return fmt::FormatInt(std::chrono::duration_cast<std::chrono::milliseconds>(time).count()).str();
+  return fmt::format_int(std::chrono::duration_cast<std::chrono::milliseconds>(time).count()).str();
 }
 
 const std::string&
@@ -237,7 +237,7 @@ StreamInfoFormatter::StreamInfoFormatter(const std::string& field_name) {
     };
   } else if (field_name == "BYTES_RECEIVED") {
     field_extractor_ = [](const StreamInfo::StreamInfo& stream_info) {
-      return fmt::FormatInt(stream_info.bytesReceived()).str();
+      return fmt::format_int(stream_info.bytesReceived()).str();
     };
   } else if (field_name == "PROTOCOL") {
     field_extractor_ = [](const StreamInfo::StreamInfo& stream_info) {
@@ -245,12 +245,12 @@ StreamInfoFormatter::StreamInfoFormatter(const std::string& field_name) {
     };
   } else if (field_name == "RESPONSE_CODE") {
     field_extractor_ = [](const StreamInfo::StreamInfo& stream_info) {
-      return stream_info.responseCode() ? fmt::FormatInt(stream_info.responseCode().value()).str()
+      return stream_info.responseCode() ? fmt::format_int(stream_info.responseCode().value()).str()
                                         : "0";
     };
   } else if (field_name == "BYTES_SENT") {
     field_extractor_ = [](const StreamInfo::StreamInfo& stream_info) {
-      return fmt::FormatInt(stream_info.bytesSent()).str();
+      return fmt::format_int(stream_info.bytesSent()).str();
     };
   } else if (field_name == "DURATION") {
     field_extractor_ = [](const StreamInfo::StreamInfo& stream_info) {

--- a/source/common/common/fmt.h
+++ b/source/common/common/fmt.h
@@ -7,15 +7,15 @@
 
 namespace fmt {
 
-// Provide an implementation of format_arg for fmt::format that allows absl::string_view to be
+// Provide an implementation of formatter for fmt::format that allows absl::string_view to be
 // formatted with the same format specifiers available to std::string.
 // TODO(zuercher): Once absl::string_view is replaced with std::string_view, this can be removed
 // as fmtlib handles std::string_view natively.
-template <typename ArgFormatter>
-void format_arg(BasicFormatter<char, ArgFormatter>& f, const char*& format_str,
-                const absl::string_view sv) {
-  BasicStringRef<char> str(sv.data(), sv.size());
-  format_str = f.format(format_str, internal::MakeArg<BasicFormatter<char>>(str));
-}
+template <> struct formatter<absl::string_view> : formatter<string_view> {
+  auto format(absl::string_view absl_string_view, fmt::format_context& ctx) -> decltype(ctx.out()) {
+    string_view fmt_string_view(absl_string_view.data(), absl_string_view.size());
+    return formatter<string_view>::format(fmt_string_view, ctx);
+  }
+};
 
 } // namespace fmt

--- a/source/common/common/fmt.h
+++ b/source/common/common/fmt.h
@@ -2,6 +2,7 @@
 
 #include "absl/strings/string_view.h"
 #include "fmt/format.h"
+#include "fmt/ostream.h"
 
 // NOLINT(namespace-envoy)
 

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -49,7 +49,14 @@ void StderrSinkDelegate::flush() {
 }
 
 void DelegatingLogSink::log(const spdlog::details::log_msg& msg) {
-  sink_->log(msg.formatted.str());
+  if (!formatter_) {
+    sink_->log(fmt::to_string(msg.raw));
+    return;
+  }
+
+  fmt::memory_buffer formatted;
+  formatter_->format(msg, formatted);
+  sink_->log(fmt::to_string(formatted));
 }
 
 DelegatingLogSinkPtr DelegatingLogSink::init() {

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -146,6 +146,12 @@ public:
   // spdlog::sinks::sink
   void log(const spdlog::details::log_msg& msg) override;
   void flush() override { sink_->flush(); }
+  void set_pattern(const std::string& pattern) override {
+    set_formatter(spdlog::details::make_unique<spdlog::pattern_formatter>(pattern));
+  }
+  void set_formatter(std::unique_ptr<spdlog::formatter> formatter) override {
+    formatter_ = std::move(formatter);
+  }
 
   /**
    * @return bool whether a lock has been established.
@@ -170,6 +176,7 @@ private:
 
   SinkDelegate* sink_{nullptr};
   std::unique_ptr<StderrSinkDelegate> stderr_sink_; // Builtin sink to use as a last resort.
+  std::unique_ptr<spdlog::formatter> formatter_;
 };
 
 /**

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -82,7 +82,7 @@ std::string DateFormatter::fromTime(const SystemTime& time) const {
 
     // Build a new formatted format string at current time.
     CachedTime::Formatted formatted;
-    const std::string seconds_str = fmt::FormatInt(epoch_time_seconds.count()).str();
+    const std::string seconds_str = fmt::format_int(epoch_time_seconds.count()).str();
     formatted.str =
         fromTimeAndPrepareSpecifierOffsets(current_time, formatted.specifier_offsets, seconds_str);
     cached_time.seconds_length = seconds_str.size();
@@ -98,7 +98,7 @@ std::string DateFormatter::fromTime(const SystemTime& time) const {
   // Copy the current cached formatted format string, then replace its subseconds part (when it has
   // non-zero width) by correcting its position using prepared subseconds offsets.
   std::string formatted_str = formatted.str;
-  std::string nanoseconds = fmt::FormatInt(epoch_time_ns.count()).str();
+  std::string nanoseconds = fmt::format_int(epoch_time_ns.count()).str();
   // Special case handling for beginning of time, we should never need to do this outside of
   // tests or a time machine.
   if (nanoseconds.size() < 10) {

--- a/source/common/stream_info/filter_state_impl.h
+++ b/source/common/stream_info/filter_state_impl.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <map>
+#include <memory>
+#include <vector>
 
 #include "envoy/stream_info/filter_state.h"
 

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -19,7 +19,7 @@ namespace Lightstep {
 
 void LightStepLogger::operator()(lightstep::LogLevel level,
                                  opentracing::string_view message) const {
-  const fmt::StringRef fmt_message{message.data(), message.size()};
+  const fmt::string_view fmt_message{message.data(), message.size()};
   switch (level) {
   case lightstep::LogLevel::debug:
     ENVOY_LOG(debug, "{}", fmt_message);

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -77,7 +77,7 @@ public:
           }
           expected_request += "}";
           EXPECT_EQ(expected_request, request->bodyAsString());
-          EXPECT_EQ(fmt::FormatInt(expected_request.size()).str(),
+          EXPECT_EQ(fmt::format_int(expected_request.size()).str(),
                     std::string(request->headers().ContentLength()->value().c_str()));
           request_in_progress_ = true;
           return &http_request_;

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -85,7 +85,7 @@ public:
                       {":authority", "foo_cluster"},
                       {"content-type", "application/json"},
                       {"content-length",
-                       request->body() ? fmt::FormatInt(request->body()->length()).str() : "0"}}),
+                       request->body() ? fmt::format_int(request->body()->length()).str() : "0"}}),
                   request->headers());
               callbacks_ = &callbacks;
               return &request_;

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -308,7 +308,13 @@ TEST_P(AdminRequestTest, AdminRequestAfterRun) {
 // destructing MainCommon.
 TEST_P(MainCommonTest, ConstructDestructLogger) {
   VERBOSE_EXPECT_NO_THROW(MainCommon main_common(argc(), argv()));
-  Logger::Registry::getSink()->log({});
+
+  const std::string logger_name = "logger";
+  spdlog::details::log_msg log_msg;
+  log_msg.logger_name = &logger_name;
+  log_msg.level = spdlog::level::level_enum::err;
+
+  Logger::Registry::getSink()->log(log_msg);
 }
 
 INSTANTIATE_TEST_CASE_P(IpVersions, AdminRequestTest,

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -90,7 +90,7 @@ public:
                       {":authority", "foo_cluster"},
                       {"content-type", "application/json"},
                       {"content-length",
-                       request->body() ? fmt::FormatInt(request->body()->length()).str() : "0"}}),
+                       request->body() ? fmt::format_int(request->body()->length()).str() : "0"}}),
                   request->headers());
               callbacks_ = &callbacks;
               return &request_;


### PR DESCRIPTION
fmt release is 5.2.1 ([changelog](https://github.com/fmtlib/fmt/releases/tag/5.2.1))
and includes some performance updates.

spdlog releases follow fmt and the current release supporting fmt 5.2.1 is 1.2.1
([changelog](https://github.com/gabime/spdlog/releases/tag/v1.2.1)).

Converts Envoy's custom absl::string_view formatter to a newer style. fmt::FormatInt
become fmt::format_int. spdlog::sinks::sink has two new virtual methods that were
implemented on DelegatingLogSink. Added some STL includes that were being transitively
supplied by fmt/spdlog. MainCommonTest was modified to stop logging empty
spdlog::details::log_msg structs, which cause a segfault.

*Risk Level*: medium
*Testing*: all existing tests pass (including with trace logging)
*Docs Changes*: n/a
*Release Notes*: n/a
*Fixes*: #4744

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>
