### PR TITLE
router: fix crash during upstream reset for certain retry policies

### DIFF
--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -185,47 +185,24 @@ RetryStatus RetryStateImpl::shouldRetry(const Http::HeaderMap* response_headers,
   return RetryStatus::Yes;
 }
 
-bool RetryStateImpl::wouldRetry(const Http::HeaderMap* response_headers,
-                                const absl::optional<Http::StreamResetReason>& reset_reason) {
-  // We never retry if the overloaded header is set.
-  if (response_headers != nullptr && response_headers->EnvoyOverloaded() != nullptr) {
-    return false;
-  }
-
-  // we never retry if the reset reason is overflow.
-  if (reset_reason && reset_reason.value() == Http::StreamResetReason::Overflow) {
-    return false;
-  }
-
+bool RetryStateImpl::wouldRetryFromHeaders(const Http::HeaderMap& response_headers) {
   if (retry_on_ & RetryPolicy::RETRY_ON_5XX) {
     // wouldRetry() is passed null headers when there was an upstream reset. Currently we count an
     // upstream reset as a "5xx" (since it will result in one). We may eventually split this out
     // into its own type. I.e., RETRY_ON_RESET.
-    if (!response_headers ||
-        Http::CodeUtility::is5xx(Http::Utility::getResponseStatus(*response_headers))) {
+    if (Http::CodeUtility::is5xx(Http::Utility::getResponseStatus(response_headers))) {
       return true;
     }
   }
 
   if (retry_on_ & RetryPolicy::RETRY_ON_GATEWAY_ERROR) {
-    if (!response_headers ||
-        Http::CodeUtility::isGatewayError(Http::Utility::getResponseStatus(*response_headers))) {
+    if (Http::CodeUtility::isGatewayError(Http::Utility::getResponseStatus(response_headers))) {
       return true;
     }
   }
 
-  if ((retry_on_ & RetryPolicy::RETRY_ON_REFUSED_STREAM) && reset_reason &&
-      reset_reason.value() == Http::StreamResetReason::RemoteRefusedStreamReset) {
-    return true;
-  }
-
-  if ((retry_on_ & RetryPolicy::RETRY_ON_CONNECT_FAILURE) && reset_reason &&
-      reset_reason.value() == Http::StreamResetReason::ConnectionFailure) {
-    return true;
-  }
-
-  if ((retry_on_ & RetryPolicy::RETRY_ON_RETRIABLE_4XX) && response_headers) {
-    Http::Code code = static_cast<Http::Code>(Http::Utility::getResponseStatus(*response_headers));
+  if ((retry_on_ & RetryPolicy::RETRY_ON_RETRIABLE_4XX)) {
+    Http::Code code = static_cast<Http::Code>(Http::Utility::getResponseStatus(response_headers));
     if (code == Http::Code::Conflict) {
       return true;
     }
@@ -233,19 +210,17 @@ bool RetryStateImpl::wouldRetry(const Http::HeaderMap* response_headers,
 
   if ((retry_on_ & RetryPolicy::RETRY_ON_RETRIABLE_STATUS_CODES)) {
     for (auto code : retriable_status_codes_) {
-      if (Http::Utility::getResponseStatus(*response_headers) == code) {
+      if (Http::Utility::getResponseStatus(response_headers) == code) {
         return true;
       }
     }
   }
 
   if (retry_on_ &
-          (RetryPolicy::RETRY_ON_GRPC_CANCELLED | RetryPolicy::RETRY_ON_GRPC_DEADLINE_EXCEEDED |
-           RetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED | RetryPolicy::RETRY_ON_GRPC_UNAVAILABLE |
-           RetryPolicy::RETRY_ON_GRPC_INTERNAL) &&
-      response_headers) {
-    absl::optional<Grpc::Status::GrpcStatus> status =
-        Grpc::Common::getGrpcStatus(*response_headers);
+      (RetryPolicy::RETRY_ON_GRPC_CANCELLED | RetryPolicy::RETRY_ON_GRPC_DEADLINE_EXCEEDED |
+       RetryPolicy::RETRY_ON_GRPC_RESOURCE_EXHAUSTED | RetryPolicy::RETRY_ON_GRPC_UNAVAILABLE |
+       RetryPolicy::RETRY_ON_GRPC_INTERNAL)) {
+    absl::optional<Grpc::Status::GrpcStatus> status = Grpc::Common::getGrpcStatus(response_headers);
     if (status) {
       if ((status.value() == Grpc::Status::Canceled &&
            (retry_on_ & RetryPolicy::RETRY_ON_GRPC_CANCELLED)) ||
@@ -263,6 +238,49 @@ bool RetryStateImpl::wouldRetry(const Http::HeaderMap* response_headers,
   }
 
   return false;
+}
+
+bool RetryStateImpl::wouldRetryFromReset(const Http::StreamResetReason& reset_reason) {
+  if ((retry_on_ & RetryPolicy::RETRY_ON_REFUSED_STREAM) &&
+      reset_reason == Http::StreamResetReason::RemoteRefusedStreamReset) {
+    return true;
+  }
+
+  if ((retry_on_ & RetryPolicy::RETRY_ON_CONNECT_FAILURE) &&
+      reset_reason == Http::StreamResetReason::ConnectionFailure) {
+    return true;
+  }
+
+  return false;
+}
+
+bool RetryStateImpl::wouldRetry(const Http::HeaderMap* response_headers,
+                                const absl::optional<Http::StreamResetReason>& reset_reason) {
+  // First check "never retry" conditions so we can short circuit, then delegate to
+  // helper methods for checks dependant on retry policy.
+
+  // we never retry if the reset reason is overflow.
+  if (reset_reason && reset_reason.value() == Http::StreamResetReason::Overflow) {
+    return false;
+  }
+
+  if (response_headers != nullptr) {
+    // We never retry if the overloaded header is set.
+    if (response_headers->EnvoyOverloaded() != nullptr) {
+      return false;
+    }
+
+    if (wouldRetryFromHeaders(*response_headers)) {
+      return true;
+    }
+  } else if (retry_on_ & (RetryPolicy::RETRY_ON_5XX | RetryPolicy::RETRY_ON_GATEWAY_ERROR)) {
+    // wouldRetry() is passed null headers when there was an upstream reset. Currently we count an
+    // upstream reset as a "5xx" (since it will result in one). We may eventually split this out
+    // into its own type. I.e., RETRY_ON_RESET.
+    return true;
+  }
+
+  return reset_reason && wouldRetryFromReset(*reset_reason);
 }
 
 } // namespace Router

--- a/source/common/router/retry_state_impl.h
+++ b/source/common/router/retry_state_impl.h
@@ -75,6 +75,8 @@ private:
   void resetRetry();
   bool wouldRetry(const Http::HeaderMap* response_headers,
                   const absl::optional<Http::StreamResetReason>& reset_reason);
+  bool wouldRetryFromReset(const Http::StreamResetReason& reset_reason);
+  bool wouldRetryFromHeaders(const Http::HeaderMap& response_headers);
 
   const Upstream::ClusterInfo& cluster_;
   Runtime::Loader& runtime_;

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -335,6 +335,14 @@ TEST_F(RouterRetryStateImplTest, RetriableStatusCodes) {
   EXPECT_EQ(RetryStatus::Yes, state_->shouldRetry(&response_headers, no_reset_, callback_));
 }
 
+TEST_F(RouterRetryStateImplTest, RetriableStatusCodesUpstreamReset) {
+  policy_.retriable_status_codes_.push_back(409);
+  Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "retriable-status-codes"}};
+  setup(request_headers);
+  EXPECT_TRUE(state_->enabled());
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(nullptr, remote_reset_, callback_));
+}
+
 TEST_F(RouterRetryStateImplTest, RetriableStatusCodesHeader) {
   {
     Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "retriable-status-codes"},


### PR DESCRIPTION
Due to a missing null check Envoy would crash during upstream reset as
the provided headers ptr is null.

Refactors the code to reduce the amount of null checks necessary,
hopefully preventing the same from happening in the future.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Description*:
*Risk Level*: Medium 
*Testing*: Added regression test for retriable status codes
*Docs Changes*: n/a
*Release Notes*: n/a
