### PR TITLE
docs: Remove "auth should go first" tip

### DIFF
--- a/docs/root/configuration/http_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/http_filters/ext_authz_filter.rst
@@ -11,11 +11,6 @@ If the request is deemed unauthorized then the request will be denied normally w
 Note that sending additional custom metadata from the authorization service to the upstream, to the downstream or to the authorization service is 
 also possible. This is explained in more details at :ref:`HTTP filter <envoy_api_msg_config.filter.http.ext_authz.v2alpha.ExtAuthz>`.
 
-.. tip::
-  It is recommended that this filter is configured first in the filter chain so that requests are
-  authorized prior to the rest of filters processing the request. This avoids wasting processing
-  time on requests that are rejected anyway.
-
 The content of the requests that are passed to an authorization service is specified by 
 :ref:`CheckRequest <envoy_api_msg_service.auth.v2alpha.CheckRequest>`.
 

--- a/docs/root/configuration/http_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/http_filters/ext_authz_filter.rst
@@ -13,7 +13,8 @@ also possible. This is explained in more details at :ref:`HTTP filter <envoy_api
 
 .. tip::
   It is recommended that this filter is configured first in the filter chain so that requests are
-  authorized prior to the rest of filters processing the request.
+  authorized prior to the rest of filters processing the request. This avoids wasting processing
+  time on requests that are rejected anyway.
 
 The content of the requests that are passed to an authorization service is specified by 
 :ref:`CheckRequest <envoy_api_msg_service.auth.v2alpha.CheckRequest>`.


### PR DESCRIPTION
I realized after starting to write this that this new sentence presumes that non-authenticated requests will be dropped from further processing right away. Is this true or not? If not, it might not make sense to add it, but in that case it still would be good to add some explaining the "why" behind this recommendation.