### PR TITLE
docs: Mention connect_timeout for gRPC services also

### DIFF
--- a/docs/root/configuration/http_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/http_filters/ext_authz_filter.rst
@@ -46,6 +46,7 @@ A sample filter configuration for a gRPC authorization server:
       http2_protocol_options: {}
       hosts:
         - socket_address: { address: 127.0.0.1, port_value: 10003 }
+      connect_timeout: 0.25s
 
 A sample filter configuration for a raw HTTP authorization server:
 


### PR DESCRIPTION
It's mandatory for these also; `envoy` refuses to start if I don't provide it.
