### PR TITLE
bootstrap: make admin field optional.

### DIFF
--- a/api/envoy/config/bootstrap/v2/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v2/bootstrap.proto
@@ -124,7 +124,7 @@ message Bootstrap {
   Runtime runtime = 11;
 
   // Configuration for the local administration HTTP server.
-  Admin admin = 12 [(validate.rules).message.required = true, (gogoproto.nullable) = false];
+  Admin admin = 12;
 
   // Optional overload manager configuration.
   envoy.config.overload.v2alpha.OverloadManager overload_manager = 15;

--- a/api/test/validate/pgv_test.cc
+++ b/api/test/validate/pgv_test.cc
@@ -54,6 +54,7 @@ template <class Proto> struct TestCase {
 // from data plane API.
 int main(int argc, char* argv[]) {
   envoy::config::bootstrap::v2::Bootstrap invalid_bootstrap;
+  invalid_bootstrap.mutable_runtime();
   // This is a baseline test of the validation features we care about. It's
   // probably not worth adding in every filter and field that we want to valid
   // in the API upfront, but as regressions occur, this is the place to add the

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -33,6 +33,7 @@ TEST(UtilityTest, RepeatedPtrUtilDebugString) {
 
 TEST(UtilityTest, DowncastAndValidate) {
   envoy::config::bootstrap::v2::Bootstrap bootstrap;
+  bootstrap.mutable_runtime();
   EXPECT_THROW(MessageUtil::validate(bootstrap), ProtoValidationException);
   EXPECT_THROW(
       MessageUtil::downcastAndValidate<const envoy::config::bootstrap::v2::Bootstrap&>(bootstrap),

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -195,6 +195,7 @@ envoy_cc_test(
         ":cluster_dupe_bootstrap.yaml",
         ":cluster_health_check_bootstrap.yaml",
         ":empty_bootstrap.yaml",
+        ":empty_runtime.yaml",
         ":node_bootstrap.yaml",
         ":node_bootstrap_no_admin_port.yaml",
         ":node_bootstrap_without_access_log.yaml",

--- a/test/server/empty_runtime.yaml
+++ b/test/server/empty_runtime.yaml
@@ -1,0 +1,2 @@
+runtime:
+  symlink_root:

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -270,7 +270,7 @@ TEST_P(ServerInstanceImplTest, EmptyBootstrap) {
   options_.service_cluster_name_ = "some_cluster_name";
   options_.service_node_name_ = "some_node_name";
   options_.v2_config_only_ = true;
-  initialize("test/server/empty_bootstrap.yaml");
+  EXPECT_NO_THROW(initialize("test/server/empty_bootstrap.yaml"));
 }
 
 // Negative test for protoc-gen-validate constraints.
@@ -323,11 +323,11 @@ TEST_P(ServerInstanceImplTest, LogToFileError) {
 // When there are no bootstrap CLI options, either for content or path, we can load the server with
 // an empty config.
 TEST_P(ServerInstanceImplTest, NoOptionsPassed) {
-  server_.reset(new InstanceImpl(
+  EXPECT_NO_THROW(server_.reset(new InstanceImpl(
       options_, test_time_.timeSystem(),
       Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("127.0.0.1")),
       hooks_, restart_, stats_store_, fakelock_, component_factory_,
-      std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), thread_local_));
+      std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), thread_local_)));
 }
 
 // Validate that when std::exception is unexpectedly thrown, we exit safely.

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -265,13 +265,21 @@ TEST_P(ServerInstanceImplTest, BootstrapNodeWithoutAccessLog) {
                             "An admin access log path is required for a listening server.");
 }
 
+// Empty bootstrap succeeeds.
+TEST_P(ServerInstanceImplTest, EmptyBootstrap) {
+  options_.service_cluster_name_ = "some_cluster_name";
+  options_.service_node_name_ = "some_node_name";
+  options_.v2_config_only_ = true;
+  initialize("test/server/empty_bootstrap.yaml");
+}
+
 // Negative test for protoc-gen-validate constraints.
 TEST_P(ServerInstanceImplTest, ValidateFail) {
   options_.service_cluster_name_ = "some_cluster_name";
   options_.service_node_name_ = "some_node_name";
   options_.v2_config_only_ = true;
   try {
-    initialize("test/server/empty_bootstrap.yaml");
+    initialize("test/server/empty_runtime.yaml");
     FAIL();
   } catch (const EnvoyException& e) {
     EXPECT_THAT(e.what(), HasSubstr("Proto constraint validation failed"));
@@ -312,14 +320,14 @@ TEST_P(ServerInstanceImplTest, LogToFileError) {
   }
 }
 
+// When there are no bootstrap CLI options, either for content or path, we can load the server with
+// an empty config.
 TEST_P(ServerInstanceImplTest, NoOptionsPassed) {
-  EXPECT_THROW_WITH_MESSAGE(
-      server_.reset(new InstanceImpl(
-          options_, test_time_.timeSystem(),
-          Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("127.0.0.1")),
-          hooks_, restart_, stats_store_, fakelock_, component_factory_,
-          std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), thread_local_)),
-      EnvoyException, "unable to read file: ");
+  server_.reset(new InstanceImpl(
+      options_, test_time_.timeSystem(),
+      Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("127.0.0.1")),
+      hooks_, restart_, stats_store_, fakelock_, component_factory_,
+      std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), thread_local_));
 }
 
 // Validate that when std::exception is unexpectedly thrown, we exit safely.


### PR DESCRIPTION
This is a follow up to #4726. In #4726, the access log path became optional, but the admin field
was not itself marked optional. This then led to server_fuzz_test trivially passing due to an early
PGV validation exception, and ~20 bugs being closed out by oss-fuzz. This PR completes the admin
optionality changes.

Risk Level: Low
Testing: Unit tests updated.

Signed-off-by: Harvey Tuch <htuch@google.com>