### PR TITLE
Remove Server::TestOptionsImpl class in favor of OptionsImpl

### DIFF
--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -255,8 +255,8 @@ void OptionsImpl::logError(const std::string& error) const {
 
 OptionsImpl::OptionsImpl(const std::string& service_cluster, const std::string& service_node,
                          const std::string& service_zone, spdlog::level::level_enum log_level)
-    : base_id_(0u), concurrency_(1u), config_path_(""), config_yaml_(""), v2_config_only_(false),
-      local_address_ip_version_(Network::Address::IpVersion::v6), log_level_(log_level),
+    : base_id_(0u), concurrency_(1u), config_path_(""), config_yaml_(""), v2_config_only_(true),
+      local_address_ip_version_(Network::Address::IpVersion::v4), log_level_(log_level),
       log_format_(Logger::Logger::DEFAULT_LOG_FORMAT), restart_epoch_(0u),
       service_cluster_(service_cluster), service_node_(service_node), service_zone_(service_zone),
       file_flush_interval_msec_(10000), drain_time_(600), parent_shutdown_time_(900),

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -253,27 +253,14 @@ void OptionsImpl::logError(const std::string& error) const {
   throw MalformedArgvException(error);
 }
 
-OptionsImpl::OptionsImpl(const std::string& service_cluster,
-                         const std::string& service_node,
-                         const std::string& service_zone,
-                         spdlog::level::level_enum log_level)
-    : base_id_(0u),
-      concurrency_(1u),
-      config_path_(""),
-      config_yaml_(""),
-      v2_config_only_(false),
-      local_address_ip_version_(Network::Address::IpVersion::v6),
-      log_level_(log_level),
-      log_format_(Logger::Logger::DEFAULT_LOG_FORMAT),
-      restart_epoch_(0u),
-      service_cluster_(service_cluster),
-      service_node_(service_node),
-      service_zone_(service_zone),
-      file_flush_interval_msec_(10000),
-      drain_time_(600),
-      parent_shutdown_time_(900),
-      mode_(Server::Mode::Serve),
-      max_stats_(ENVOY_DEFAULT_MAX_STATS),
+OptionsImpl::OptionsImpl(const std::string& service_cluster, const std::string& service_node,
+                         const std::string& service_zone, spdlog::level::level_enum log_level)
+    : base_id_(0u), concurrency_(1u), config_path_(""), config_yaml_(""), v2_config_only_(false),
+      local_address_ip_version_(Network::Address::IpVersion::v6), log_level_(log_level),
+      log_format_(Logger::Logger::DEFAULT_LOG_FORMAT), restart_epoch_(0u),
+      service_cluster_(service_cluster), service_node_(service_node), service_zone_(service_zone),
+      file_flush_interval_msec_(10000), drain_time_(600), parent_shutdown_time_(900),
+      mode_(Server::Mode::Serve), max_stats_(ENVOY_DEFAULT_MAX_STATS),
       hot_restart_disabled_(false) {}
 
 } // namespace Envoy

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -253,4 +253,27 @@ void OptionsImpl::logError(const std::string& error) const {
   throw MalformedArgvException(error);
 }
 
+OptionsImpl::OptionsImpl(const std::string& service_cluster,
+                         const std::string& service_node,
+                         const std::string& service_zone,
+                         spdlog::level::level_enum log_level)
+    : base_id_(0u),
+      concurrency_(1u),
+      config_path_(""),
+      config_yaml_(""),
+      v2_config_only_(false),
+      local_address_ip_version_(Network::Address::IpVersion::v6),
+      log_level_(log_level),
+      log_format_(Logger::Logger::DEFAULT_LOG_FORMAT),
+      restart_epoch_(0u),
+      service_cluster_(service_cluster),
+      service_node_(service_node),
+      service_zone_(service_zone),
+      file_flush_interval_msec_(10000),
+      drain_time_(600),
+      parent_shutdown_time_(900),
+      mode_(Server::Mode::Serve),
+      max_stats_(ENVOY_DEFAULT_MAX_STATS),
+      hot_restart_disabled_(false) {}
+
 } // namespace Envoy

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -34,10 +34,8 @@ public:
               spdlog::level::level_enum default_log_level);
 
   // Test constructor; creates "reasonable" defaults, but desired values should be set explicitly.
-  OptionsImpl(const std::string& service_cluster,
-              const std::string& service_node,
-              const std::string& service_zone,
-              spdlog::level::level_enum log_level);
+  OptionsImpl(const std::string& service_cluster, const std::string& service_node,
+              const std::string& service_zone, spdlog::level::level_enum log_level);
 
   // Setters for option fields. These are not part of the Options interface.
   void setBaseId(uint64_t base_id) { base_id_ = base_id; };

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -33,6 +33,12 @@ public:
   OptionsImpl(int argc, const char* const* argv, const HotRestartVersionCb& hot_restart_version_cb,
               spdlog::level::level_enum default_log_level);
 
+  // Test constructor; creates "reasonable" defaults, but desired values should be set explicitly.
+  OptionsImpl(const std::string& service_cluster,
+              const std::string& service_node,
+              const std::string& service_zone,
+              spdlog::level::level_enum log_level);
+
   // Setters for option fields. These are not part of the Options interface.
   void setBaseId(uint64_t base_id) { base_id_ = base_id; };
   void setConcurrency(uint32_t concurrency) { concurrency_ = concurrency; }

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -4,10 +4,12 @@
 #include <string>
 
 #include "common/common/fmt.h"
+#include "common/filesystem/filesystem_impl.h"
 #include "common/protobuf/utility.h"
 
 #include "server/config_validation/server.h"
 #include "server/configuration_impl.h"
+#include "server/options_impl.h"
 
 #include "test/integration/server.h"
 #include "test/mocks/server/mocks.h"
@@ -27,9 +29,19 @@ using testing::ReturnRef;
 namespace Envoy {
 namespace ConfigTest {
 
+namespace {
+
+// asConfigYaml returns a new config that empties the configPath() and populates configYaml()
+OptionsImpl asConfigYaml(const OptionsImpl& src) {
+  std::unique_ptr<OptionsImpl> result(Envoy::Server::createTestOptionsImpl("", Filesystem::fileReadToEnd(src.configPath()), src.localAddressIpVersion()));
+  return *result;
+}
+
+}
+
 class ConfigTest {
 public:
-  ConfigTest(const Server::TestOptionsImpl& options) : options_(options) {
+  ConfigTest(const OptionsImpl& options) : options_(options) {
     ON_CALL(server_, options()).WillByDefault(ReturnRef(options_));
     ON_CALL(server_, random()).WillByDefault(ReturnRef(random_));
     ON_CALL(server_, sslContextManager()).WillByDefault(ReturnRef(ssl_context_manager_));
@@ -79,7 +91,7 @@ public:
 
   NiceMock<Server::MockInstance> server_;
   NiceMock<Ssl::MockContextManager> ssl_context_manager_;
-  Server::TestOptionsImpl options_;
+  OptionsImpl options_;
   std::unique_ptr<Upstream::ProdClusterManagerFactory> cluster_manager_factory_;
   NiceMock<Server::MockListenerComponentFactory> component_factory_;
   NiceMock<Server::MockWorkerFactory> worker_factory_;
@@ -92,19 +104,19 @@ public:
 
 void testMerge() {
   const std::string overlay = "static_resources: { clusters: [{name: 'foo'}]}";
-  Server::TestOptionsImpl options("google_com_proxy.v2.yaml", overlay,
-                                  Network::Address::IpVersion::v6);
+  std::unique_ptr<OptionsImpl> options(Server::createTestOptionsImpl("google_com_proxy.v2.yaml", overlay,
+                                                                     Network::Address::IpVersion::v6));
   envoy::config::bootstrap::v2::Bootstrap bootstrap;
-  Server::InstanceUtil::loadBootstrapConfig(bootstrap, options);
+  Server::InstanceUtil::loadBootstrapConfig(bootstrap, *options);
   EXPECT_EQ(2, bootstrap.static_resources().clusters_size());
 }
 
 void testIncompatibleMerge() {
   const std::string overlay = "static_resources: { clusters: [{name: 'foo'}]}";
-  Server::TestOptionsImpl options("google_com_proxy.v1.yaml", overlay,
-                                  Network::Address::IpVersion::v6);
+  std::unique_ptr<OptionsImpl> options(Server::createTestOptionsImpl("google_com_proxy.v1.yaml", overlay,
+                                                                     Network::Address::IpVersion::v6));
   envoy::config::bootstrap::v2::Bootstrap bootstrap;
-  EXPECT_THROW_WITH_MESSAGE(Server::InstanceUtil::loadBootstrapConfig(bootstrap, options),
+  EXPECT_THROW_WITH_MESSAGE(Server::InstanceUtil::loadBootstrapConfig(bootstrap, *options),
                             EnvoyException,
                             "V1 config (detected) with --config-yaml is not supported");
 }
@@ -112,13 +124,13 @@ void testIncompatibleMerge() {
 uint32_t run(const std::string& directory) {
   uint32_t num_tested = 0;
   for (const std::string& filename : TestUtility::listFiles(directory, false)) {
-    Server::TestOptionsImpl options(filename, Network::Address::IpVersion::v6);
-    ConfigTest test1(options);
+    std::unique_ptr<OptionsImpl> options(Envoy::Server::createTestOptionsImpl(filename, "", Network::Address::IpVersion::v6));
+    ConfigTest test1(*options);
     // Config flag --config-yaml is only supported for v2 configs.
     envoy::config::bootstrap::v2::Bootstrap bootstrap;
-    if (Server::InstanceUtil::loadBootstrapConfig(bootstrap, options) ==
+    if (Server::InstanceUtil::loadBootstrapConfig(bootstrap, *options) ==
         Server::InstanceUtil::BootstrapVersion::V2) {
-      ConfigTest test2(options.asConfigYaml());
+      ConfigTest test2(asConfigYaml(*options));
     }
     num_tested++;
   }

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -33,11 +33,11 @@ namespace {
 
 // asConfigYaml returns a new config that empties the configPath() and populates configYaml()
 OptionsImpl asConfigYaml(const OptionsImpl& src) {
-  return Envoy::Server::createTestOptionsImpl(
-      "", Filesystem::fileReadToEnd(src.configPath()), src.localAddressIpVersion());
+  return Envoy::Server::createTestOptionsImpl("", Filesystem::fileReadToEnd(src.configPath()),
+                                              src.localAddressIpVersion());
 }
 
-}
+} // namespace
 
 class ConfigTest {
 public:
@@ -124,8 +124,8 @@ void testIncompatibleMerge() {
 uint32_t run(const std::string& directory) {
   uint32_t num_tested = 0;
   for (const std::string& filename : TestUtility::listFiles(directory, false)) {
-    OptionsImpl options(Envoy::Server::createTestOptionsImpl(
-        filename, "", Network::Address::IpVersion::v6));
+    OptionsImpl options(
+        Envoy::Server::createTestOptionsImpl(filename, "", Network::Address::IpVersion::v6));
     ConfigTest test1(options);
     // Config flag --config-yaml is only supported for v2 configs.
     envoy::config::bootstrap::v2::Bootstrap bootstrap;

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -24,27 +24,26 @@
 namespace Envoy {
 namespace Server {
 
-std::unique_ptr<OptionsImpl> createTestOptionsImpl(
+OptionsImpl createTestOptionsImpl(
     const std::string& config_path,
     const std::string& config_yaml,
     Network::Address::IpVersion ip_version) {
-  std::unique_ptr<OptionsImpl> test_options =
-      absl::make_unique<OptionsImpl>("cluster_name", "node_name", "zone_name", spdlog::level::info);
+  OptionsImpl test_options("cluster_name", "node_name", "zone_name", spdlog::level::info);
 
-  test_options->setBaseId(0u);
-  test_options->setConcurrency(1u);
-  test_options->setConfigPath(config_path);
-  test_options->setConfigYaml(config_yaml);
-  test_options->setV2ConfigOnly(false);
-  test_options->setLocalAddressIpVersion(ip_version);
-  test_options->setLogFormat(Logger::Logger::DEFAULT_LOG_FORMAT);
-  test_options->setRestartEpoch(0u);
-  test_options->setFileFlushIntervalMsec(std::chrono::milliseconds(50));
-  test_options->setDrainTime(std::chrono::seconds(1));
-  test_options->setParentShutdownTime(std::chrono::seconds(2));
-  test_options->setMode(Server::Mode::Serve);
-  test_options->setMaxStats(16384u);
-  test_options->setHotRestartDisabled(false);
+  test_options.setBaseId(0u);
+  test_options.setConcurrency(1u);
+  test_options.setConfigPath(config_path);
+  test_options.setConfigYaml(config_yaml);
+  test_options.setV2ConfigOnly(false);
+  test_options.setLocalAddressIpVersion(ip_version);
+  test_options.setLogFormat(Logger::Logger::DEFAULT_LOG_FORMAT);
+  test_options.setRestartEpoch(0u);
+  test_options.setFileFlushIntervalMsec(std::chrono::milliseconds(50));
+  test_options.setDrainTime(std::chrono::seconds(1));
+  test_options.setParentShutdownTime(std::chrono::seconds(2));
+  test_options.setMode(Server::Mode::Serve);
+  test_options.setMaxStats(16384u);
+  test_options.setHotRestartDisabled(false);
 
   return test_options;
 }
@@ -118,7 +117,7 @@ void IntegrationTestServer::onWorkerListenerRemoved() {
 
 void IntegrationTestServer::threadRoutine(const Network::Address::IpVersion version,
                                           bool deterministic) {
-  std::unique_ptr<OptionsImpl> options(Server::createTestOptionsImpl(config_path_, "", version));
+  OptionsImpl options(Server::createTestOptionsImpl(config_path_, "", version));
   Server::HotRestartNopImpl restarter;
   Thread::MutexBasicLockable lock;
 
@@ -134,7 +133,7 @@ void IntegrationTestServer::threadRoutine(const Network::Address::IpVersion vers
     random_generator = std::make_unique<Runtime::RandomGeneratorImpl>();
   }
   server_.reset(new Server::InstanceImpl(
-      *options, time_system_, Network::Utility::getLocalAddress(version), *this, restarter,
+      options, time_system_, Network::Utility::getLocalAddress(version), *this, restarter,
       stats_store, lock, *this, std::move(random_generator), tls));
   pending_listeners_ = server_->listenerManager().listeners().size();
   ENVOY_LOG(info, "waiting for {} test server listeners", pending_listeners_);

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -24,10 +24,8 @@
 namespace Envoy {
 namespace Server {
 
-OptionsImpl createTestOptionsImpl(
-    const std::string& config_path,
-    const std::string& config_yaml,
-    Network::Address::IpVersion ip_version) {
+OptionsImpl createTestOptionsImpl(const std::string& config_path, const std::string& config_yaml,
+                                  Network::Address::IpVersion ip_version) {
   OptionsImpl test_options("cluster_name", "node_name", "zone_name", spdlog::level::info);
 
   test_options.setBaseId(0u);

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -15,6 +15,7 @@
 #include "common/common/thread.h"
 #include "common/stats/source_impl.h"
 
+#include "server/options_impl.h"
 #include "server/server.h"
 #include "server/test_hooks.h"
 
@@ -25,67 +26,12 @@
 namespace Envoy {
 namespace Server {
 
-/**
- * Integration test options.
- */
-class TestOptionsImpl : public Options {
-public:
-  TestOptionsImpl(const std::string& config_path, Network::Address::IpVersion ip_version)
-      : config_path_(config_path), local_address_ip_version_(ip_version),
-        service_cluster_name_("cluster_name"), service_node_name_("node_name"),
-        service_zone_("zone_name") {}
-  TestOptionsImpl(const std::string& config_path, const std::string& config_yaml,
-                  Network::Address::IpVersion ip_version)
-      : config_path_(config_path), config_yaml_(config_yaml), local_address_ip_version_(ip_version),
-        service_cluster_name_("cluster_name"), service_node_name_("node_name"),
-        service_zone_("zone_name") {}
-
-  // Server::Options
-  uint64_t baseId() const override { return 0; }
-  uint32_t concurrency() const override { return 1; }
-  const std::string& configPath() const override { return config_path_; }
-  const std::string& configYaml() const override { return config_yaml_; }
-  bool v2ConfigOnly() const override { return false; }
-  const std::string& adminAddressPath() const override { return admin_address_path_; }
-  Network::Address::IpVersion localAddressIpVersion() const override {
-    return local_address_ip_version_;
-  }
-  std::chrono::seconds drainTime() const override { return std::chrono::seconds(1); }
-  spdlog::level::level_enum logLevel() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  const std::vector<std::pair<std::string, spdlog::level::level_enum>>&
-  componentLogLevels() const override {
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
-  const std::string& logFormat() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  std::chrono::seconds parentShutdownTime() const override { return std::chrono::seconds(2); }
-  const std::string& logPath() const override { return log_path_; }
-  uint64_t restartEpoch() const override { return 0; }
-  std::chrono::milliseconds fileFlushIntervalMsec() const override {
-    return std::chrono::milliseconds(50);
-  }
-  Mode mode() const override { return Mode::Serve; }
-  const std::string& serviceClusterName() const override { return service_cluster_name_; }
-  const std::string& serviceNodeName() const override { return service_node_name_; }
-  const std::string& serviceZone() const override { return service_zone_; }
-  uint64_t maxStats() const override { return 16384; }
-  const Stats::StatsOptions& statsOptions() const override { return stats_options_; }
-  bool hotRestartDisabled() const override { return false; }
-
-  // asConfigYaml returns a new config that empties the configPath() and populates configYaml()
-  Server::TestOptionsImpl asConfigYaml();
-
-private:
-  const std::string config_path_;
-  const std::string config_yaml_;
-  const std::string admin_address_path_;
-  const Network::Address::IpVersion local_address_ip_version_;
-  const std::string service_cluster_name_;
-  const std::string service_node_name_;
-  const std::string service_zone_;
-  Stats::StatsOptionsImpl stats_options_;
-  const std::string log_path_;
-};
-
+// Create OptionsImpl structures suitable for tests.
+std::unique_ptr<OptionsImpl> createTestOptionsImpl(
+    const std::string& config_path,
+    const std::string& config_yaml,
+    Network::Address::IpVersion ip_version);
+  
 class TestDrainManager : public DrainManager {
 public:
   // Server::DrainManager

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -27,11 +27,9 @@ namespace Envoy {
 namespace Server {
 
 // Create OptionsImpl structures suitable for tests.
-OptionsImpl createTestOptionsImpl(
-    const std::string& config_path,
-    const std::string& config_yaml,
-    Network::Address::IpVersion ip_version);
-  
+OptionsImpl createTestOptionsImpl(const std::string& config_path, const std::string& config_yaml,
+                                  Network::Address::IpVersion ip_version);
+
 class TestDrainManager : public DrainManager {
 public:
   // Server::DrainManager

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -27,7 +27,7 @@ namespace Envoy {
 namespace Server {
 
 // Create OptionsImpl structures suitable for tests.
-std::unique_ptr<OptionsImpl> createTestOptionsImpl(
+OptionsImpl createTestOptionsImpl(
     const std::string& config_path,
     const std::string& config_yaml,
     Network::Address::IpVersion ip_version);

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -234,7 +234,8 @@ TEST_F(OptionsImplTest, IncompleteComponentLogLevel) {
 // Test that the test constructor comes up with the same default values as the main constructor.
 TEST_F(OptionsImplTest, SaneTestConstructor) {
   std::unique_ptr<OptionsImpl> regular_options_impl(createOptionsImpl("envoy"));
-  OptionsImpl test_options_impl("service_cluster", "service_node", "service_zone", spdlog::level::level_enum::info);
+  OptionsImpl test_options_impl("service_cluster", "service_node", "service_zone",
+                                spdlog::level::level_enum::info);
 
   // Specified by constructor
   EXPECT_EQ("service_cluster", test_options_impl.serviceClusterName());
@@ -250,7 +251,8 @@ TEST_F(OptionsImplTest, SaneTestConstructor) {
   EXPECT_EQ(regular_options_impl->configYaml(), test_options_impl.configYaml());
   EXPECT_EQ(regular_options_impl->v2ConfigOnly(), test_options_impl.v2ConfigOnly());
   EXPECT_EQ(regular_options_impl->adminAddressPath(), test_options_impl.adminAddressPath());
-  EXPECT_EQ(regular_options_impl->localAddressIpVersion(), test_options_impl.localAddressIpVersion());
+  EXPECT_EQ(regular_options_impl->localAddressIpVersion(),
+            test_options_impl.localAddressIpVersion());
   EXPECT_EQ(regular_options_impl->drainTime(), test_options_impl.drainTime());
   EXPECT_EQ(spdlog::level::level_enum::info, test_options_impl.logLevel());
   EXPECT_EQ(regular_options_impl->componentLogLevels(), test_options_impl.componentLogLevels());
@@ -258,11 +260,15 @@ TEST_F(OptionsImplTest, SaneTestConstructor) {
   EXPECT_EQ(regular_options_impl->parentShutdownTime(), test_options_impl.parentShutdownTime());
   EXPECT_EQ(regular_options_impl->restartEpoch(), test_options_impl.restartEpoch());
   EXPECT_EQ(regular_options_impl->mode(), test_options_impl.mode());
-  EXPECT_EQ(regular_options_impl->fileFlushIntervalMsec(), test_options_impl.fileFlushIntervalMsec());
+  EXPECT_EQ(regular_options_impl->fileFlushIntervalMsec(),
+            test_options_impl.fileFlushIntervalMsec());
   EXPECT_EQ(regular_options_impl->maxStats(), test_options_impl.maxStats());
-  EXPECT_EQ(regular_options_impl->statsOptions().maxNameLength(), test_options_impl.statsOptions().maxNameLength());
-  EXPECT_EQ(regular_options_impl->statsOptions().maxObjNameLength(), test_options_impl.statsOptions().maxObjNameLength());
-  EXPECT_EQ(regular_options_impl->statsOptions().maxStatSuffixLength(), test_options_impl.statsOptions().maxStatSuffixLength());
+  EXPECT_EQ(regular_options_impl->statsOptions().maxNameLength(),
+            test_options_impl.statsOptions().maxNameLength());
+  EXPECT_EQ(regular_options_impl->statsOptions().maxObjNameLength(),
+            test_options_impl.statsOptions().maxObjNameLength());
+  EXPECT_EQ(regular_options_impl->statsOptions().maxStatSuffixLength(),
+            test_options_impl.statsOptions().maxStatSuffixLength());
   EXPECT_EQ(regular_options_impl->hotRestartDisabled(), test_options_impl.hotRestartDisabled());
 }
 

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -231,13 +231,21 @@ TEST_F(OptionsImplTest, IncompleteComponentLogLevel) {
                           "component log level not correctly specified 'upstream'");
 }
 
-// Test that the test constructor comes up with the same default values as the main constructor. 
+// Test that the test constructor comes up with the same default values as the main constructor.
 TEST_F(OptionsImplTest, SaneTestConstructor) {
-  std::unique_ptr<OptionsImpl> regular_options_impl(createOptionsImpl(""));
-  OptionsImpl test_options_impl("server_cluster", "service_node", "service_zone", spdlog::level::level_enum::info);
+  std::unique_ptr<OptionsImpl> regular_options_impl(createOptionsImpl("envoy"));
+  OptionsImpl test_options_impl("service_cluster", "service_node", "service_zone", spdlog::level::level_enum::info);
+
+  // Specified by constructor
+  EXPECT_EQ("service_cluster", test_options_impl.serviceClusterName());
+  EXPECT_EQ("service_node", test_options_impl.serviceNodeName());
+  EXPECT_EQ("service_zone", test_options_impl.serviceZone());
+  EXPECT_EQ(spdlog::level::level_enum::info, test_options_impl.logLevel());
+
+  // Special (simplified) for tests
+  EXPECT_EQ(1u, test_options_impl.concurrency());
 
   EXPECT_EQ(regular_options_impl->baseId(), test_options_impl.baseId());
-  EXPECT_EQ(regular_options_impl->concurrency(), test_options_impl.concurrency());
   EXPECT_EQ(regular_options_impl->configPath(), test_options_impl.configPath());
   EXPECT_EQ(regular_options_impl->configYaml(), test_options_impl.configYaml());
   EXPECT_EQ(regular_options_impl->v2ConfigOnly(), test_options_impl.v2ConfigOnly());

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -231,4 +231,31 @@ TEST_F(OptionsImplTest, IncompleteComponentLogLevel) {
                           "component log level not correctly specified 'upstream'");
 }
 
+// Test that the test constructor comes up with the same default values as the main constructor. 
+TEST_F(OptionsImplTest, SaneTestConstructor) {
+  std::unique_ptr<OptionsImpl> regular_options_impl(createOptionsImpl(""));
+  OptionsImpl test_options_impl("server_cluster", "service_node", "service_zone", spdlog::level::level_enum::info);
+
+  EXPECT_EQ(regular_options_impl->baseId(), test_options_impl.baseId());
+  EXPECT_EQ(regular_options_impl->concurrency(), test_options_impl.concurrency());
+  EXPECT_EQ(regular_options_impl->configPath(), test_options_impl.configPath());
+  EXPECT_EQ(regular_options_impl->configYaml(), test_options_impl.configYaml());
+  EXPECT_EQ(regular_options_impl->v2ConfigOnly(), test_options_impl.v2ConfigOnly());
+  EXPECT_EQ(regular_options_impl->adminAddressPath(), test_options_impl.adminAddressPath());
+  EXPECT_EQ(regular_options_impl->localAddressIpVersion(), test_options_impl.localAddressIpVersion());
+  EXPECT_EQ(regular_options_impl->drainTime(), test_options_impl.drainTime());
+  EXPECT_EQ(spdlog::level::level_enum::info, test_options_impl.logLevel());
+  EXPECT_EQ(regular_options_impl->componentLogLevels(), test_options_impl.componentLogLevels());
+  EXPECT_EQ(regular_options_impl->logPath(), test_options_impl.logPath());
+  EXPECT_EQ(regular_options_impl->parentShutdownTime(), test_options_impl.parentShutdownTime());
+  EXPECT_EQ(regular_options_impl->restartEpoch(), test_options_impl.restartEpoch());
+  EXPECT_EQ(regular_options_impl->mode(), test_options_impl.mode());
+  EXPECT_EQ(regular_options_impl->fileFlushIntervalMsec(), test_options_impl.fileFlushIntervalMsec());
+  EXPECT_EQ(regular_options_impl->maxStats(), test_options_impl.maxStats());
+  EXPECT_EQ(regular_options_impl->statsOptions().maxNameLength(), test_options_impl.statsOptions().maxNameLength());
+  EXPECT_EQ(regular_options_impl->statsOptions().maxObjNameLength(), test_options_impl.statsOptions().maxObjNameLength());
+  EXPECT_EQ(regular_options_impl->statsOptions().maxStatSuffixLength(), test_options_impl.statsOptions().maxStatSuffixLength());
+  EXPECT_EQ(regular_options_impl->hotRestartDisabled(), test_options_impl.hotRestartDisabled());
+}
+
 } // namespace Envoy


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section 
in PULL_REQUESTS.md

*Description*:

This PR is part of a multi-PR refactor to allow for use of the envoy test framework with binaries that wrap envoy with company specific code.  The goal of this set of PRs is to maximize the code shared between integration tests and binaries.  

This particular PR changes envoy test code to use OptionsImpl and removes the test-specific Server::TestOptionsImpl class.  OptionsImpl is already pretty close to a struct-like grab bag, so there isn't much gained by having an extra class, and the Google production environment needs access on the binary invocation path to the implementation class in order to mutate it.  

Future CLs will add setters to MainCommon{Base} to set the values required by the envoy integration test framework, and refactor BaseIntegrationTest to allow subclasses to create their own envoy servers based on configuration from the base class.

*Risk Level*: Low; just a test code refactor without behavior changes.
*Testing*: Ran all existing tests.
*Docs Changes*: None.
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
