### PR TITLE
stats: add last_update_success gauge

### DIFF
--- a/docs/root/configuration/cluster_manager/cds.rst
+++ b/docs/root/configuration/cluster_manager/cds.rst
@@ -28,5 +28,6 @@ CDS has a statistics tree rooted at *cluster_manager.cds.* with the following st
   update_success, Counter, Total API fetches completed successfully
   update_failure, Counter, Total API fetches that failed because of network errors
   update_rejected, Counter, Total API fetches that failed because of schema/validation errors
+  last_update_success, Gauge, Boolean indicating that the last update completed successfully
   version, Gauge, Hash of the contents from the last successful API fetch
   control_plane.connected_state, Gauge, A boolan (1 for connected and 0 for disconnected) that indicates the current connection state with management server

--- a/docs/root/configuration/http_conn_man/rds.rst
+++ b/docs/root/configuration/http_conn_man/rds.rst
@@ -27,4 +27,5 @@ stats tree. The stats tree contains the following statistics:
   update_success, Counter, Total API fetches completed successfully
   update_failure, Counter, Total API fetches that failed because of network errors
   update_rejected, Counter, Total API fetches that failed because of schema/validation errors
+  last_update_success, Gauge, Boolean indicating that the last update completed successfully
   version, Gauge, Hash of the contents from the last successful API fetch

--- a/docs/root/configuration/listeners/lds.rst
+++ b/docs/root/configuration/listeners/lds.rst
@@ -47,5 +47,6 @@ LDS has a statistics tree rooted at *listener_manager.lds.* with the following s
   update_success, Counter, Total API fetches completed successfully
   update_failure, Counter, Total API fetches that failed because of network errors
   update_rejected, Counter, Total API fetches that failed because of schema/validation errors
+  last_update_success, Gauge, Boolean indicating that the last update completed successfully
   version, Gauge, Hash of the contents from the last successful API fetch
   control_plane.connected_state, Gauge, A boolan (1 for connected and 0 for disconnected) that indicates the current connection state with management server

--- a/include/envoy/config/subscription.h
+++ b/include/envoy/config/subscription.h
@@ -78,6 +78,7 @@ public:
   COUNTER(update_success)                      \
   COUNTER(update_failure)                      \
   COUNTER(update_rejected)                     \
+  GAUGE(last_update_success)                   \
   GAUGE(version)
 // clang-format on
 

--- a/source/common/config/filesystem_subscription_impl.h
+++ b/source/common/config/filesystem_subscription_impl.h
@@ -65,6 +65,7 @@ private:
       callbacks_->onConfigUpdate(typed_resources, message.version_info());
       stats_.version_.set(HashUtil::xxHash64(message.version_info()));
       stats_.update_success_.inc();
+      stats_.last_update_success_.set(1);
       ENVOY_LOG(debug, "Filesystem config update accepted for {}: {}", path_,
                 message.DebugString());
     } catch (const EnvoyException& e) {
@@ -75,6 +76,7 @@ private:
         ENVOY_LOG(warn, "Filesystem config update failure: {}", e.what());
         stats_.update_failure_.inc();
       }
+      stats_.last_update_success_.set(0);
       callbacks_->onConfigUpdateFailed(&e);
     }
   }

--- a/source/common/config/grpc_mux_subscription_impl.h
+++ b/source/common/config/grpc_mux_subscription_impl.h
@@ -54,6 +54,7 @@ public:
     // the configuration update targets.
     callbacks_->onConfigUpdate(typed_resources, version_info);
     stats_.update_success_.inc();
+    stats_.last_update_success_.set(1);
     stats_.update_attempt_.inc();
     stats_.version_.set(HashUtil::xxHash64(version_info));
     ENVOY_LOG(debug, "gRPC config for {} accepted with {} resources: {}", type_url_,
@@ -69,6 +70,7 @@ public:
       stats_.update_rejected_.inc();
       ENVOY_LOG(warn, "gRPC config for {} rejected: {}", type_url_, e->what());
     }
+    stats_.last_update_success_.set(0);
     stats_.update_attempt_.inc();
     callbacks_->onConfigUpdateFailed(e);
   }

--- a/source/common/config/http_subscription_impl.h
+++ b/source/common/config/http_subscription_impl.h
@@ -88,9 +88,11 @@ public:
       request_.set_version_info(message.version_info());
       stats_.version_.set(HashUtil::xxHash64(request_.version_info()));
       stats_.update_success_.inc();
+      stats_.last_update_success_.set(1);
     } catch (const EnvoyException& e) {
       ENVOY_LOG(warn, "REST config update rejected: {}", e.what());
       stats_.update_rejected_.inc();
+      stats_.last_update_success_.set(0);
       callbacks_->onConfigUpdateFailed(&e);
     }
   }
@@ -105,6 +107,7 @@ public:
 private:
   void handleFailure(const EnvoyException* e) {
     stats_.update_failure_.inc();
+    stats_.last_update_success_.set(0);
     callbacks_->onConfigUpdateFailed(e);
   }
 

--- a/source/common/router/rds_subscription.cc
+++ b/source/common/router/rds_subscription.cc
@@ -45,6 +45,7 @@ void RdsSubscription::parseResponse(const Http::Message& response) {
   callbacks_->onConfigUpdate(resources, hash.first);
   stats_.version_.set(hash.second);
   stats_.update_success_.inc();
+  stats_.last_update_success_.set(1);
 }
 
 void RdsSubscription::onFetchComplete() {}
@@ -58,6 +59,7 @@ void RdsSubscription::onFetchFailure(const EnvoyException* e) {
     stats_.update_failure_.inc();
     ENVOY_LOG(debug, "rds: fetch failure: network error");
   }
+  stats_.last_update_success_.set(0);
 }
 
 } // namespace Router

--- a/source/common/upstream/cds_subscription.cc
+++ b/source/common/upstream/cds_subscription.cc
@@ -49,6 +49,7 @@ void CdsSubscription::parseResponse(const Http::Message& response) {
   callbacks_->onConfigUpdate(resources, hash.first);
   stats_.version_.set(hash.second);
   stats_.update_success_.inc();
+  stats_.last_update_success_.set(1);
 }
 
 void CdsSubscription::onFetchComplete() {}
@@ -62,6 +63,7 @@ void CdsSubscription::onFetchFailure(const EnvoyException* e) {
     stats_.update_failure_.inc();
     ENVOY_LOG(debug, "cds: fetch failure: network error");
   }
+  stats_.last_update_success_.set(0);
 }
 
 } // namespace Upstream

--- a/source/server/lds_subscription.cc
+++ b/source/server/lds_subscription.cc
@@ -52,6 +52,7 @@ void LdsSubscription::parseResponse(const Http::Message& response) {
   callbacks_->onConfigUpdate(resources, hash.first);
   stats_.version_.set(hash.second);
   stats_.update_success_.inc();
+  stats_.last_update_success_.set(1);
 }
 
 void LdsSubscription::onFetchComplete() {}
@@ -65,6 +66,7 @@ void LdsSubscription::onFetchFailure(const EnvoyException* e) {
     stats_.update_failure_.inc();
     ENVOY_LOG(info, "lds: fetch failure: network error");
   }
+  stats_.last_update_success_.set(0);
 }
 
 } // namespace Server

--- a/test/common/config/filesystem_subscription_impl_test.cc
+++ b/test/common/config/filesystem_subscription_impl_test.cc
@@ -18,19 +18,19 @@ class FilesystemSubscriptionImplTest : public FilesystemSubscriptionTestHarness,
 // Validate that the client can recover from bad JSON responses.
 TEST_F(FilesystemSubscriptionImplTest, BadJsonRecovery) {
   startSubscription({"cluster0", "cluster1"});
-  verifyStats(1, 0, 0, 0, 0);
+  verifyStats(1, 0, 0, 0, 0, 0);
   EXPECT_CALL(callbacks_, onConfigUpdateFailed(_));
   updateFile(";!@#badjso n");
-  verifyStats(2, 0, 0, 1, 0);
+  verifyStats(2, 0, 0, 1, 0, 0);
   deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
-  verifyStats(3, 1, 0, 1, 7148434200721666028);
+  verifyStats(3, 1, 0, 1, 1, 7148434200721666028);
 }
 
 // Validate that a file that is initially available results in a successful update.
 TEST_F(FilesystemSubscriptionImplTest, InitialFile) {
   updateFile("{\"versionInfo\": \"0\", \"resources\": []}", false);
   startSubscription({"cluster0", "cluster1"});
-  verifyStats(1, 1, 0, 0, 7148434200721666028);
+  verifyStats(1, 1, 0, 0, 1, 7148434200721666028);
 }
 
 // Validate that if we fail to set a watch, we get a sensible warning.

--- a/test/common/config/filesystem_subscription_test_harness.h
+++ b/test/common/config/filesystem_subscription_test_harness.h
@@ -87,10 +87,11 @@ public:
   }
 
   void verifyStats(uint32_t attempt, uint32_t success, uint32_t rejected, uint32_t failure,
-                   uint64_t version) override {
+                   uint64_t last_update_success, uint64_t version) override {
     // The first attempt always fail unless there was a file there to begin with.
     SubscriptionTestHarness::verifyStats(attempt, success, rejected,
-                                         failure + (file_at_start_ ? 0 : 1), version);
+                                         failure + (file_at_start_ ? 0 : 1),
+                                         last_update_success, version);
   }
 
   const std::string path_;

--- a/test/common/config/grpc_subscription_impl_test.cc
+++ b/test/common/config/grpc_subscription_impl_test.cc
@@ -19,7 +19,7 @@ TEST_F(GrpcSubscriptionImplTest, StreamCreationFailure) {
   EXPECT_CALL(random_, random());
   EXPECT_CALL(*timer_, enableTimer(_));
   subscription_->start({"cluster0", "cluster1"}, callbacks_);
-  verifyStats(2, 0, 0, 1, 0);
+  verifyStats(2, 0, 0, 1, 0, 0);
   // Ensure this doesn't cause an issue by sending a request, since we don't
   // have a gRPC stream.
   subscription_->updateResources({"cluster2"});
@@ -29,27 +29,27 @@ TEST_F(GrpcSubscriptionImplTest, StreamCreationFailure) {
 
   expectSendMessage({"cluster2"}, "");
   timer_cb_();
-  verifyStats(3, 0, 0, 1, 0);
+  verifyStats(3, 0, 0, 1, 0, 0);
   verifyControlPlaneStats(1);
 }
 
 // Validate that the client can recover from a remote stream closure via retry.
 TEST_F(GrpcSubscriptionImplTest, RemoteStreamClose) {
   startSubscription({"cluster0", "cluster1"});
-  verifyStats(1, 0, 0, 0, 0);
+  verifyStats(1, 0, 0, 0, 0, 0);
   Http::HeaderMapPtr trailers{new Http::TestHeaderMapImpl{}};
   subscription_->grpcMux().onReceiveTrailingMetadata(std::move(trailers));
   EXPECT_CALL(*timer_, enableTimer(_));
   EXPECT_CALL(random_, random());
   subscription_->grpcMux().onRemoteClose(Grpc::Status::GrpcStatus::Canceled, "");
-  verifyStats(1, 0, 0, 0, 0);
+  verifyStats(1, 0, 0, 0, 0, 0);
   verifyControlPlaneStats(0);
 
   // Retry and succeed.
   EXPECT_CALL(*async_client_, start(_, _)).WillOnce(Return(&async_stream_));
   expectSendMessage({"cluster0", "cluster1"}, "");
   timer_cb_();
-  verifyStats(1, 0, 0, 0, 0);
+  verifyStats(1, 0, 0, 0, 0, 0);
 }
 
 // Validate that When the management server gets multiple requests for the same version, it can
@@ -57,21 +57,21 @@ TEST_F(GrpcSubscriptionImplTest, RemoteStreamClose) {
 TEST_F(GrpcSubscriptionImplTest, RepeatedNonce) {
   InSequence s;
   startSubscription({"cluster0", "cluster1"});
-  verifyStats(1, 0, 0, 0, 0);
+  verifyStats(1, 0, 0, 0, 0, 0);
   // First with the initial, empty version update to "0".
   updateResources({"cluster2"});
-  verifyStats(2, 0, 0, 0, 0);
+  verifyStats(2, 0, 0, 0, 0, 0);
   deliverConfigUpdate({"cluster0", "cluster2"}, "0", false);
-  verifyStats(3, 0, 1, 0, 0);
+  verifyStats(3, 0, 1, 0, 0, 0);
   deliverConfigUpdate({"cluster0", "cluster2"}, "0", true);
-  verifyStats(4, 1, 1, 0, 7148434200721666028);
+  verifyStats(4, 1, 1, 0, 1, 7148434200721666028);
   // Now with version "0" update to "1".
   updateResources({"cluster3"});
-  verifyStats(5, 1, 1, 0, 7148434200721666028);
+  verifyStats(5, 1, 1, 0, 1, 7148434200721666028);
   deliverConfigUpdate({"cluster3"}, "1", false);
-  verifyStats(6, 1, 2, 0, 7148434200721666028);
+  verifyStats(6, 1, 2, 0, 0, 7148434200721666028);
   deliverConfigUpdate({"cluster3"}, "1", true);
-  verifyStats(7, 2, 2, 0, 13237225503670494420U);
+  verifyStats(7, 2, 2, 0, 1, 13237225503670494420U);
 }
 
 } // namespace

--- a/test/common/config/http_subscription_impl_test.cc
+++ b/test/common/config/http_subscription_impl_test.cc
@@ -15,11 +15,11 @@ TEST_F(HttpSubscriptionImplTest, OnRequestReset) {
   EXPECT_CALL(*timer_, enableTimer(_));
   EXPECT_CALL(callbacks_, onConfigUpdateFailed(_));
   http_callbacks_->onFailure(Http::AsyncClient::FailureReason::Reset);
-  verifyStats(1, 0, 0, 1, 0);
+  verifyStats(1, 0, 0, 1, 0, 0);
   timerTick();
-  verifyStats(2, 0, 0, 1, 0);
+  verifyStats(2, 0, 0, 1, 0, 0);
   deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
-  verifyStats(3, 1, 0, 1, 7148434200721666028);
+  verifyStats(3, 1, 0, 1, 1, 7148434200721666028);
 }
 
 // Validate that the client can recover from bad JSON responses.
@@ -32,12 +32,12 @@ TEST_F(HttpSubscriptionImplTest, BadJsonRecovery) {
   EXPECT_CALL(*timer_, enableTimer(_));
   EXPECT_CALL(callbacks_, onConfigUpdateFailed(_));
   http_callbacks_->onSuccess(std::move(message));
-  verifyStats(1, 0, 0, 1, 0);
+  verifyStats(1, 0, 0, 1, 0, 0);
   request_in_progress_ = false;
   timerTick();
-  verifyStats(2, 0, 0, 1, 0);
+  verifyStats(2, 0, 0, 1, 0, 0);
   deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
-  verifyStats(3, 1, 0, 1, 7148434200721666028);
+  verifyStats(3, 1, 0, 1, 1, 7148434200721666028);
 }
 
 } // namespace

--- a/test/common/config/subscription_impl_test.cc
+++ b/test/common/config/subscription_impl_test.cc
@@ -43,8 +43,8 @@ public:
   }
 
   void verifyStats(uint32_t attempt, uint32_t success, uint32_t rejected, uint32_t failure,
-                   uint64_t version) {
-    test_harness_->verifyStats(attempt, success, rejected, failure, version);
+                   uint64_t last_update_success, uint64_t version) {
+    test_harness_->verifyStats(attempt, success, rejected, failure, last_update_success, version);
   }
 
   void deliverConfigUpdate(const std::vector<std::string> cluster_names, const std::string& version,
@@ -62,57 +62,57 @@ INSTANTIATE_TEST_CASE_P(SubscriptionImplTest, SubscriptionImplTest,
 // Validate basic request-response succeeds.
 TEST_P(SubscriptionImplTest, InitialRequestResponse) {
   startSubscription({"cluster0", "cluster1"});
-  verifyStats(1, 0, 0, 0, 0);
+  verifyStats(1, 0, 0, 0, 0, 0);
   deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
-  verifyStats(2, 1, 0, 0, 7148434200721666028);
+  verifyStats(2, 1, 0, 0, 1, 7148434200721666028);
 }
 
 // Validate that multiple streamed updates succeed.
 TEST_P(SubscriptionImplTest, ResponseStream) {
   startSubscription({"cluster0", "cluster1"});
-  verifyStats(1, 0, 0, 0, 0);
+  verifyStats(1, 0, 0, 0, 0, 0);
   deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
-  verifyStats(2, 1, 0, 0, 7148434200721666028);
+  verifyStats(2, 1, 0, 0, 1, 7148434200721666028);
   deliverConfigUpdate({"cluster0", "cluster1"}, "1", true);
-  verifyStats(3, 2, 0, 0, 13237225503670494420U);
+  verifyStats(3, 2, 0, 0, 1, 13237225503670494420U);
 }
 
 // Validate that the client can reject a config.
 TEST_P(SubscriptionImplTest, RejectConfig) {
   startSubscription({"cluster0", "cluster1"});
-  verifyStats(1, 0, 0, 0, 0);
+  verifyStats(1, 0, 0, 0, 0, 0);
   deliverConfigUpdate({"cluster0", "cluster1"}, "0", false);
-  verifyStats(2, 0, 1, 0, 0);
+  verifyStats(2, 0, 1, 0, 0, 0);
 }
 
 // Validate that the client can reject a config and accept the same config later.
 TEST_P(SubscriptionImplTest, RejectAcceptConfig) {
   startSubscription({"cluster0", "cluster1"});
-  verifyStats(1, 0, 0, 0, 0);
+  verifyStats(1, 0, 0, 0, 0, 0);
   deliverConfigUpdate({"cluster0", "cluster1"}, "0", false);
-  verifyStats(2, 0, 1, 0, 0);
+  verifyStats(2, 0, 1, 0, 0, 0);
   deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
-  verifyStats(3, 1, 1, 0, 7148434200721666028);
+  verifyStats(3, 1, 1, 0, 1, 7148434200721666028);
 }
 
 // Validate that the client can reject a config and accept another config later.
 TEST_P(SubscriptionImplTest, RejectAcceptNextConfig) {
   startSubscription({"cluster0", "cluster1"});
-  verifyStats(1, 0, 0, 0, 0);
+  verifyStats(1, 0, 0, 0, 0, 0);
   deliverConfigUpdate({"cluster0", "cluster1"}, "0", false);
-  verifyStats(2, 0, 1, 0, 0);
+  verifyStats(2, 0, 1, 0, 0, 0);
   deliverConfigUpdate({"cluster0", "cluster1"}, "1", true);
-  verifyStats(3, 1, 1, 0, 13237225503670494420U);
+  verifyStats(3, 1, 1, 0, 1, 13237225503670494420U);
 }
 
 // Validate that stream updates send a message with the updated resources.
 TEST_P(SubscriptionImplTest, UpdateResources) {
   startSubscription({"cluster0", "cluster1"});
-  verifyStats(1, 0, 0, 0, 0);
+  verifyStats(1, 0, 0, 0, 0, 0);
   deliverConfigUpdate({"cluster0", "cluster1"}, "0", true);
-  verifyStats(2, 1, 0, 0, 7148434200721666028);
+  verifyStats(2, 1, 0, 0, 1, 7148434200721666028);
   updateResources({"cluster2"});
-  verifyStats(3, 1, 0, 0, 7148434200721666028);
+  verifyStats(3, 1, 0, 0, 1, 7148434200721666028);
 }
 
 } // namespace

--- a/test/common/config/subscription_test_harness.h
+++ b/test/common/config/subscription_test_harness.h
@@ -50,11 +50,12 @@ public:
                                    const std::string& version, bool accept) PURE;
 
   virtual void verifyStats(uint32_t attempt, uint32_t success, uint32_t rejected, uint32_t failure,
-                           uint64_t version) {
+                           uint64_t last_update_success, uint64_t version) {
     EXPECT_EQ(attempt, stats_.update_attempt_.value());
     EXPECT_EQ(success, stats_.update_success_.value());
     EXPECT_EQ(rejected, stats_.update_rejected_.value());
     EXPECT_EQ(failure, stats_.update_failure_.value());
+    EXPECT_EQ(last_update_success, stats_.last_update_success_.value());
     EXPECT_EQ(version, stats_.version_.value());
   }
 

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -295,6 +295,9 @@ TEST_F(RdsImplTest, Basic) {
             factory_context_.scope_.counter("foo.rds.foo_route_config.update_attempt").value());
   EXPECT_EQ(3UL,
             factory_context_.scope_.counter("foo.rds.foo_route_config.update_success").value());
+  EXPECT_EQ(
+      1UL,
+      factory_context_.scope_.gauge("foo.rds.foo_route_config.last_update_success").value());
   EXPECT_EQ(8808926191882896258U,
             factory_context_.scope_.gauge("foo.rds.foo_route_config.version").value());
 }
@@ -331,6 +334,9 @@ TEST_F(RdsImplTest, Failure) {
   // Validate that the schema error increments update_rejected stat.
   EXPECT_EQ(1UL,
             factory_context_.scope_.counter("foo.rds.foo_route_config.update_rejected").value());
+  EXPECT_EQ(
+      0UL,
+      factory_context_.scope_.gauge("foo.rds.foo_route_config.last_update_success").value());
 }
 
 TEST_F(RdsImplTest, FailureArray) {
@@ -354,6 +360,9 @@ TEST_F(RdsImplTest, FailureArray) {
             factory_context_.scope_.counter("foo.rds.foo_route_config.update_attempt").value());
   EXPECT_EQ(1UL,
             factory_context_.scope_.counter("foo.rds.foo_route_config.update_rejected").value());
+  EXPECT_EQ(
+      0UL,
+      factory_context_.scope_.gauge("foo.rds.foo_route_config.last_update_success").value());
 }
 
 class RouteConfigProviderManagerImplTest : public RdsTestBase {

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -210,6 +210,7 @@ TEST_F(CdsApiImplTest, Basic) {
 
   EXPECT_EQ(2UL, store_.counter("cluster_manager.cds.update_attempt").value());
   EXPECT_EQ(2UL, store_.counter("cluster_manager.cds.update_success").value());
+  EXPECT_EQ(1UL, store_.gauge("cluster_manager.cds.last_update_success").value());
   EXPECT_EQ(Config::Utility::computeHashedVersion(response2_json).first, cds_->versionInfo());
   EXPECT_EQ(1872764556139482420U, store_.gauge("cluster_manager.cds.version").value());
 }
@@ -245,6 +246,7 @@ TEST_F(CdsApiImplTest, Failure) {
   EXPECT_EQ(1UL, store_.counter("cluster_manager.cds.update_failure").value());
   // Validate that the schema error increments update_rejected stat.
   EXPECT_EQ(1UL, store_.counter("cluster_manager.cds.update_rejected").value());
+  EXPECT_EQ(0UL, store_.gauge("cluster_manager.cds.last_update_success").value());
   EXPECT_EQ(0UL, store_.gauge("cluster_manager.cds.version").value());
 }
 
@@ -269,6 +271,7 @@ TEST_F(CdsApiImplTest, FailureArray) {
   EXPECT_EQ("", cds_->versionInfo());
   EXPECT_EQ(1UL, store_.counter("cluster_manager.cds.update_attempt").value());
   EXPECT_EQ(1UL, store_.counter("cluster_manager.cds.update_rejected").value());
+  EXPECT_EQ(0UL, store_.gauge("cluster_manager.cds.last_update_success").value());
   EXPECT_EQ(0UL, store_.gauge("cluster_manager.cds.version").value());
 }
 

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -301,6 +301,7 @@ TEST_F(LdsApiTest, Basic) {
 
   EXPECT_EQ(2UL, store_.counter("listener_manager.lds.update_attempt").value());
   EXPECT_EQ(2UL, store_.counter("listener_manager.lds.update_success").value());
+  EXPECT_EQ(1UL, store_.gauge("listener_manager.lds.last_update_success").value());
   EXPECT_EQ(18068408981723255507U, store_.gauge("listener_manager.lds.version").value());
 }
 
@@ -409,7 +410,8 @@ TEST_F(LdsApiTest, Failure) {
   EXPECT_EQ(2UL, store_.counter("listener_manager.lds.update_attempt").value());
   EXPECT_EQ(1UL, store_.counter("listener_manager.lds.update_failure").value());
   // Validate that the schema error increments update_rejected stat.
-  EXPECT_EQ(1UL, store_.counter("listener_manager.lds.update_failure").value());
+  EXPECT_EQ(1UL, store_.counter("listener_manager.lds.update_rejected").value());
+  EXPECT_EQ(0UL, store_.gauge("listener_manager.lds.last_update_success").value());
   EXPECT_EQ(0UL, store_.gauge("listener_manager.lds.version").value());
 }
 


### PR DESCRIPTION
*Description*: Adds a gauge called "last_update_success" to Xds stats.  This is set to 1 when an update succeeds and 0 when an update fails or is rejected.

*Risk Level*: Low

*Testing*: Modified the existing unit tests for update_[success|rejected|failure] to also test last_update_success.

*Docs Changes*: Added lines to the Xds configuration docs.

*Release Notes*: N/A
