### PR TITLE
config: remove duplicate updated rejected warning log

### DIFF
--- a/source/common/config/grpc_mux_impl.cc
+++ b/source/common/config/grpc_mux_impl.cc
@@ -223,7 +223,6 @@ void GrpcMuxImpl::onReceiveMessage(std::unique_ptr<envoy::api::v2::DiscoveryResp
     // that tracking here.
     api_state_[type_url].request_.set_version_info(message->version_info());
   } catch (const EnvoyException& e) {
-    ENVOY_LOG(warn, "gRPC config for {} update rejected: {}", message->type_url(), e.what());
     for (auto watch : api_state_[type_url].watches_) {
       watch->callbacks_.onConfigUpdateFailed(&e);
     }


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*: When updates are rejected for a typeUrl in ADS, Envoy logs duplicate warning messages
warning][upstream] **source/common/config/grpc_mux_impl.cc:226**] gRPC config for type.googleapis.com/envoy.api.v2.Listener update rejected: Error adding/updating listener ingress_http1: cannot bind '0.0.0.0:7014': Address already in use
[warning][config] **bazel-out/darwin-fastbuild/bin/source/common/config/_virtual_includes/grpc_mux_subscription_lib/common/config/grpc_mux_subscription_impl.h:70**] gRPC config for type.googleapis.com/envoy.api.v2.Listener rejected: Error adding/updating listener ingress_http1: cannot bind '0.0.0.0:7014': Address already in use

This PR removes from the warning log line from `grpc_mux_impl`
*Risk Level*: Low
*Testing*: Existing tests
*Docs Changes*: N/A
*Release Notes*: N/A

