### PR TITLE
config: officially deprecating deprecated_v1 fields

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -8,11 +8,11 @@ A logged warning is expected for each deprecated item that is in deprecation win
 
 ## Version 1.9.0 (pending)
 
-* Use of the v2 API "deprecated_v1" fields is deprecated.
+* Use of the v2 API *deprecated_v1* fields is deprecated.
 
 ## Version 1.8.0 (Oct 4, 2018)
 
-* Use of the v1 API (including `*.deprecated_v1` fields in the v2 API) is deprecated.
+* Use of the v1 API is deprecated.
   See envoy-announce [email](https://groups.google.com/forum/#!topic/envoy-announce/oPnYMZw8H4U).
 * Use of the legacy
   [ratelimit.proto](https://github.com/envoyproxy/envoy/blob/b0a518d064c8255e0e20557a8f909b6ff457558f/source/common/ratelimit/ratelimit.proto)

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -8,6 +8,8 @@ A logged warning is expected for each deprecated item that is in deprecation win
 
 ## Version 1.9.0 (pending)
 
+* Use of the v2 API "deprecated_v1" fields is deprecated.
+
 ## Version 1.8.0 (Oct 4, 2018)
 
 * Use of the v1 API (including `*.deprecated_v1` fields in the v2 API) is deprecated.

--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -98,7 +98,7 @@ message Listener {
   }
 
   // [#not-implemented-hide:]
-  DeprecatedV1 deprecated_v1 = 7;
+  DeprecatedV1 deprecated_v1 = 7 [deprecated = true];
 
   enum DrainType {
     // Drain in response to calling /healthcheck/fail admin endpoint (along with the health check


### PR DESCRIPTION
For removal in the next release ~3 months out

*Risk Level*: Low (deprecating one lingering proto field)
*Testing*: n/a
*Docs Changes*: updated DEPRECATED.md
*Release Notes*: n/a
*Deprecated*: deprecated deprecated config
