### PR TITLE
Add release notes for json logging and fix a typo

### DIFF
--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -13,7 +13,7 @@ Access logs are configured as part of the :ref:`HTTP connection manager config
 
 .. _config_access_log_format:
 
-Format rules
+Format Rules
 ------------
 
 Access log formats contain command operators that extract the relevant data and insert it.
@@ -306,3 +306,4 @@ The following command operators are supported:
     String value set on ssl connection socket for Server Name Indication (SNI)
   TCP
     String value set on ssl connection socket for Server Name Indication (SNI)
+

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -3,7 +3,7 @@ Version history
 
 1.9.0 (pending)
 ===============
-* access log: added a :ref:`JSON logging mode <config_access_log_format_dictionaries>` to output access logs in JSON format
+* access log: added a :ref:`JSON logging mode <config_access_log_format_dictionaries>` to output access logs in JSON format.
 * admin: added support for displaying subject alternate names in :ref:`certs<operations_admin_interface_certs>` end point.
 * config: removed support for the v1 API.
 * fault: removed integer percentage support.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -3,6 +3,7 @@ Version history
 
 1.9.0 (pending)
 ===============
+* access log: added a :ref:`JSON logging mode <config_access_log_format_dictionaries>` to output access logs in JSON format
 * admin: added support for displaying subject alternate names in :ref:`certs<operations_admin_interface_certs>` end point.
 * config: removed support for the v1 API.
 * fault: removed integer percentage support.


### PR DESCRIPTION
Follow up for https://github.com/envoyproxy/envoy/pull/4693

(`access_log.rst` was missing the trailing newline - other files in the same directory have it. Let me know if you want it removed)

*Description*: Add release notes for JSON logging. Fix a casing typo.
*Risk Level*: Low
*Testing*: Built docs and checked links work
*Docs Changes*: Fix a typo in the access log config docs
*Release Notes*: Release notes for JSON logging
