### PR TITLE
[RFC] Add client CONNECT support. Partial implementation of #1451

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -768,6 +768,19 @@ message RouteAction {
   // This can be used to prevent unexpected upstream request timeouts due to potentially long
   // time gaps between gRPC request and response in gRPC streaming mode.
   google.protobuf.Duration max_grpc_timeout = 23 [(gogoproto.stdduration) = true];
+
+  enum ConnectTunnelAction {
+    // CONNECT tunnel requests are denied - default
+    DENY = 0;
+    // CONNECT tunnel requests are allowed and the upstream is the origin server. TCP Connect and
+    // return 200 OK
+    ORIGIN_CONNECT = 1;
+    // Forward the CONNECT request to the upstream for handling
+    FORWARD = 2;
+  }
+  // Indicates that a HTTP/1.1 client connection to this particular route is allowed to
+  // downgrade to L4 Tunnel. The default is false.
+  ConnectTunnelAction tunnel_action = 25 [(validate.rules).enum.defined_only = true];
 }
 
 message RedirectAction {

--- a/include/envoy/http/BUILD
+++ b/include/envoy/http/BUILD
@@ -58,8 +58,24 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "tunnel_interface",
+    hdrs = ["tunnel.h"],
+    deps = [
+        ":header_map_interface",
+    ],
+)
+
+envoy_cc_library(
     name = "websocket_interface",
     hdrs = ["websocket.h"],
+    deps = [
+        ":header_map_interface",
+    ],
+)
+
+envoy_cc_library(
+    name = "headers_only_callback_interface",
+    hdrs = ["headers_only_callback.h"],
     deps = [
         ":header_map_interface",
     ],

--- a/include/envoy/http/headers_only_callback.h
+++ b/include/envoy/http/headers_only_callback.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "envoy/http/header_map.h"
+
+namespace Envoy {
+namespace Http {
+
+/**
+ * Callback interface for WebSocket/TunnelProxy connection management.
+ */
+class HeadersOnlyCallback {
+public:
+  virtual ~HeadersOnlyCallback() {}
+
+  /**
+   * Used by a WebSocket implementation to send HTTP error codes back to the
+   * client when there are errors establishing a connection to upstream server.
+   */
+  virtual void sendHeadersOnlyResponse(HeaderMap& headers, bool end_of_stream = true) PURE;
+};
+
+} // namespace Http
+} // namespace Envoy

--- a/include/envoy/http/tunnel.h
+++ b/include/envoy/http/tunnel.h
@@ -1,24 +1,25 @@
 #pragma once
 
 #include "envoy/buffer/buffer.h"
+#include "envoy/http/header_map.h"
 #include "envoy/network/filter.h"
 
 namespace Envoy {
 namespace Http {
 
 /**
- * An instance of a WebSocketProxy.
+ * An instance of a TunnelProxy
  */
-class WebSocketProxy {
+class TunnelProxy {
 public:
-  virtual ~WebSocketProxy() {}
+  virtual ~TunnelProxy() {}
 
   /**
    * @see Network::Filter::onData
    */
   virtual Network::FilterStatus onData(Buffer::Instance& data, bool end_stream) PURE;
 };
-typedef std::unique_ptr<WebSocketProxy> WebSocketProxyPtr;
+typedef std::unique_ptr<TunnelProxy> TunnelProxyPtr;
 
 } // namespace Http
 } // namespace Envoy

--- a/include/envoy/router/BUILD
+++ b/include/envoy/router/BUILD
@@ -41,6 +41,8 @@ envoy_cc_library(
         "//include/envoy/http:codec_interface",
         "//include/envoy/http:codes_interface",
         "//include/envoy/http:header_map_interface",
+        "//include/envoy/http:headers_only_callback_interface",
+        "//include/envoy/http:tunnel_interface",
         "//include/envoy/http:websocket_interface",
         "//include/envoy/tracing:http_tracer_interface",
         "//include/envoy/upstream:resource_manager_interface",

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -13,6 +13,8 @@
 #include "envoy/http/codec.h"
 #include "envoy/http/codes.h"
 #include "envoy/http/header_map.h"
+#include "envoy/http/headers_only_callback.h"
+#include "envoy/http/tunnel.h"
 #include "envoy/http/websocket.h"
 #include "envoy/tracing/http_tracer.h"
 #include "envoy/upstream/resource_manager.h"
@@ -573,6 +575,11 @@ public:
   virtual bool useOldStyleWebSocket() const PURE;
 
   /**
+   * @return bool true if this route can be a plain tcp tunnel
+   */
+  virtual bool isTunnelAllowed() const PURE;
+
+  /**
    * Create an instance of a WebSocketProxy, using the configuration in this route.
    *
    * This may only be called if useWebSocket() returns true on this RouteEntry.
@@ -582,9 +589,23 @@ public:
    */
   virtual Http::WebSocketProxyPtr
   createWebSocketProxy(Http::HeaderMap& request_headers, StreamInfo::StreamInfo& stream_info,
-                       Http::WebSocketProxyCallbacks& callbacks,
+                       Http::HeadersOnlyCallback& callbacks,
                        Upstream::ClusterManager& cluster_manager,
                        Network::ReadFilterCallbacks* read_callbacks) const PURE;
+
+  /**
+   * Create an instance of a TunnelProxy, using the configuration in this route.
+   *
+   * This shall be called when the request uses the 'CONNECT' verb
+   *
+   * @return TunnelHandler An instance of a ConnectHandler with the configuration specified
+   *         in this route.
+   */
+  virtual Http::TunnelProxyPtr
+  createTunnelHandler(Http::HeaderMap& request_headers, StreamInfo::StreamInfo& stream_info,
+                      Http::HeadersOnlyCallback& callbacks,
+                      Upstream::ClusterManager& cluster_manager,
+                      Network::ReadFilterCallbacks* read_callbacks) const PURE;
 
   /**
    * @return MetadataMatchCriteria* the metadata that a subset load balancer should match when

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -116,6 +116,7 @@ envoy_cc_library(
         "//include/envoy/http:codec_interface",
         "//include/envoy/http:filter_interface",
         "//include/envoy/http:header_map_interface",
+        "//include/envoy/http:tunnel_interface",
         "//include/envoy/http:websocket_interface",
         "//include/envoy/local_info:local_info_interface",
         "//include/envoy/network:connection_interface",
@@ -142,6 +143,7 @@ envoy_cc_library(
         "//source/common/network:utility_lib",
         "//source/common/runtime:uuid_util_lib",
         "//source/common/stream_info:stream_info_lib",
+        "//source/common/tcp_proxy",
         "//source/common/tracing:http_tracer_lib",
     ],
 )

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -220,12 +220,20 @@ private:
     const Router::VirtualHost& virtualHost() const override { return virtual_host_; }
     bool autoHostRewrite() const override { return false; }
     bool useOldStyleWebSocket() const override { return false; }
+    bool isTunnelAllowed() const override { return false; }
     Http::WebSocketProxyPtr createWebSocketProxy(Http::HeaderMap&, StreamInfo::StreamInfo&,
-                                                 Http::WebSocketProxyCallbacks&,
+                                                 Http::HeadersOnlyCallback&,
                                                  Upstream::ClusterManager&,
                                                  Network::ReadFilterCallbacks*) const override {
       NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
     }
+
+    Http::TunnelProxyPtr createTunnelHandler(Http::HeaderMap&, StreamInfo::StreamInfo&,
+                                             Http::HeadersOnlyCallback&, Upstream::ClusterManager&,
+                                             Network::ReadFilterCallbacks*) const override {
+      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    }
+
     bool includeVirtualHostRateLimits() const override { return true; }
     const envoy::api::v2::core::Metadata& metadata() const override { return metadata_; }
     const Router::PathMatchCriterion& pathMatchCriterion() const override {

--- a/source/common/http/tunnel/BUILD
+++ b/source/common/http/tunnel/BUILD
@@ -1,0 +1,29 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "tunnel_handler_lib",
+    srcs = ["tunnel_handler_impl.cc"],
+    hdrs = ["tunnel_handler_impl.h"],
+    deps = [
+        "//include/envoy/http:codec_interface",
+        "//include/envoy/http:header_map_interface",
+        "//include/envoy/http:tunnel_interface",
+        "//include/envoy/network:connection_interface",
+        "//include/envoy/network:filter_interface",
+        "//include/envoy/router:router_interface",
+        "//include/envoy/upstream:cluster_manager_interface",
+        "//source/common/common:enum_to_int",
+        "//source/common/http:codes_lib",
+        "//source/common/http:header_map_lib",
+        "//source/common/http/http1:codec_lib",
+        "//source/common/tcp_proxy",
+    ],
+)

--- a/source/common/http/tunnel/tunnel_handler_impl.cc
+++ b/source/common/http/tunnel/tunnel_handler_impl.cc
@@ -1,0 +1,130 @@
+#include "common/http/tunnel/tunnel_handler_impl.h"
+
+#include "envoy/network/connection.h"
+
+#include "common/common/enum_to_int.h"
+#include "common/http/codes.h"
+#include "common/http/header_map_impl.h"
+#include "common/http/http1/codec_impl.h"
+
+#include "spdlog/spdlog.h"
+
+namespace Envoy {
+namespace Http {
+namespace Tunnel {
+
+TcpProxy::ConfigSharedPtr Config(const envoy::api::v2::route::RouteAction&,
+                                 Server::Configuration::FactoryContext& factory_context) {
+  envoy::config::filter::network::tcp_proxy::v2::TcpProxy tcp_config;
+  // Set the default value. This may be overwritten below.
+  tcp_config.set_stat_prefix("tunnel");
+
+  return std::make_shared<TcpProxy::Config>(tcp_config, factory_context);
+}
+
+TunnelHandlerImpl::TunnelHandlerImpl(
+    HeaderMap& request_headers, StreamInfo::StreamInfo& stream_info,
+    const Router::RouteEntry& route_entry, HeadersOnlyCallback& callbacks,
+    Upstream::ClusterManager& cluster_manager, Network::ReadFilterCallbacks* read_callbacks,
+    TcpProxy::ConfigSharedPtr config, Event::TimeSystem& time_system)
+    : TcpProxy::Filter(config, cluster_manager, time_system), request_headers_(request_headers),
+      stream_info_(stream_info), route_entry_(route_entry), tunnel_callbacks_(callbacks) {
+
+  // set_connection_stats == false because the http connection manager has already set them
+  // and they will be inaccurate if we change them now.
+  initialize(*read_callbacks, false);
+  onNewConnection();
+}
+
+void TunnelHandlerImpl::onInitFailure(UpstreamFailureReason failure_reason) {
+  ASSERT(state_ == ConnectState::PreConnect);
+  state_ = ConnectState::Failed;
+
+  Code http_code = Code::InternalServerError;
+  switch (failure_reason) {
+  case UpstreamFailureReason::CONNECT_FAILED:
+    http_code = Code::GatewayTimeout;
+    break;
+  case UpstreamFailureReason::NO_HEALTHY_UPSTREAM:
+  case UpstreamFailureReason::RESOURCE_LIMIT_EXCEEDED:
+  case UpstreamFailureReason::NO_ROUTE:
+    http_code = Code::ServiceUnavailable;
+    break;
+  }
+
+  HeaderMapImpl headers{{Headers::get().Status, std::to_string(enumToInt(http_code))}};
+  tunnel_callbacks_.sendHeadersOnlyResponse(headers);
+}
+
+Network::FilterStatus TunnelHandlerImpl::onData(Buffer::Instance& data, bool end_stream) {
+  ENVOY_LOG(trace, "TunnelHandlerImpl::onData with buffer length {}, end_stream == {}",
+            data.length(), end_stream);
+
+  switch (state_) {
+  case ConnectState::PreConnect:
+    // It is expected that TcpProxy will readDisable(true) the downstream connection until it is
+    // ready to send data to the upstream connection, so onData() should be called zero or one times
+    // before state_ becomes Connected.
+    ASSERT(queued_data_.length() == 0);
+
+    ENVOY_LOG(trace, "TunnelHandlerImpl::onData is NOT connected");
+    queued_data_.move(data);
+    queued_end_stream_ = end_stream;
+    break;
+  case ConnectState::Connected:
+    // Data should have been drained already when we transitioned to Connected.
+    ASSERT(queued_data_.length() == 0);
+
+    ENVOY_LOG(trace, "TunnelHandlerImpl::onData is connected");
+    return TcpProxy::Filter::onData(data, end_stream);
+  case ConnectState::Failed:
+    ENVOY_LOG(trace, "TunnelHandlerImpl::onData state_ == Failed; discarding");
+    break;
+  }
+
+  return Network::FilterStatus::StopIteration;
+}
+
+void TunnelHandlerImpl::onConnectionSuccess() {
+  ENVOY_LOG(trace, "TunnelHandlerImpl:: TCP connection established");
+  // path and host rewrites
+  bool forward_connect =
+      !read_callbacks_->upstreamHost()->hostname().empty() ||
+      request_headers_.Host()->value() != read_callbacks_->upstreamHost()->hostname().c_str();
+
+  // for auto host rewrite
+  if (forward_connect && route_entry_.autoHostRewrite() &&
+      !read_callbacks_->upstreamHost()->hostname().empty()) {
+    route_entry_.finalizeRequestHeaders(request_headers_, stream_info_, true);
+    request_headers_.Host()->value(read_callbacks_->upstreamHost()->hostname());
+  }
+
+  // if (forward_connect) {
+  // ENVOY_LOG(trace, "TunnelHandlerImpl:: Forwarding CONNECT upstream");
+  // Http1::ClientConnectionImpl upstream_http(upstream_conn_data_->connection(),
+  //                                          http_conn_callbacks_);
+  // Http1::RequestStreamEncoderImpl upstream_request =
+  // Http1::RequestStreamEncoderImpl(upstream_http);
+  /// upstream_request.encodeHeaders(request_headers_, false);
+  //} else {
+  // The upstream host is the origin server
+  // Tell downstream we're good to go
+  ENVOY_LOG(trace,
+            "TunnelHandlerImpl:: We are connected directly to the origin; sending 200 downstream");
+  HeaderMapImpl headers{{Headers::get().Status, std::to_string(200)}};
+  tunnel_callbacks_.sendHeadersOnlyResponse(headers, false);
+  //}
+  ASSERT(state_ == ConnectState::PreConnect);
+  state_ = ConnectState::Connected;
+  if (queued_data_.length() > 0 || queued_end_stream_) {
+    ENVOY_LOG(trace, "TunnelHandlerImpl::onConnectionSuccess calling TcpProxy::onData");
+    TcpProxy::Filter::onData(queued_data_, queued_end_stream_);
+    ASSERT(queued_data_.length() == 0);
+  }
+}
+
+StreamInfo::StreamInfo& TunnelHandlerImpl::getStreamInfo() { return stream_info_; }
+
+} // namespace Tunnel
+} // namespace Http
+} // namespace Envoy

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -204,10 +204,13 @@ bool Utility::isUpgrade(const HeaderMap& headers) {
                                            Http::Headers::get().ConnectionValues.Upgrade.c_str()));
 }
 
-bool Utility::isH2UpgradeRequest(const HeaderMap& headers) {
+bool Utility::isConnectRequest(const HeaderMap& headers) {
   return headers.Method() &&
-         headers.Method()->value().c_str() == Http::Headers::get().MethodValues.Connect &&
-         headers.Protocol() && !headers.Protocol()->value().empty();
+         headers.Method()->value().c_str() == Http::Headers::get().MethodValues.Connect;
+}
+
+bool Utility::isH2UpgradeRequest(const HeaderMap& headers) {
+  return isConnectRequest(headers) && headers.Protocol() && !headers.Protocol()->value().empty();
 }
 
 bool Utility::isWebSocketUpgradeRequest(const HeaderMap& headers) {

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -102,6 +102,11 @@ uint64_t getResponseStatus(const HeaderMap& headers);
 bool isUpgrade(const HeaderMap& headers);
 
 /**
+ * @return true if this is a simple CONNECT request, false otherwise.
+ */
+bool isConnectRequest(const HeaderMap& headers);
+
+/**
  * @return true if this is a CONNECT request with a :protocol header present, false otherwise.
  */
 bool isH2UpgradeRequest(const HeaderMap& headers);

--- a/source/common/http/websocket/ws_handler_impl.cc
+++ b/source/common/http/websocket/ws_handler_impl.cc
@@ -43,8 +43,7 @@ TcpProxy::ConfigSharedPtr Config(const envoy::api::v2::route::RouteAction& route
 }
 
 WsHandlerImpl::WsHandlerImpl(HeaderMap& request_headers, StreamInfo::StreamInfo& stream_info,
-                             const Router::RouteEntry& route_entry,
-                             WebSocketProxyCallbacks& callbacks,
+                             const Router::RouteEntry& route_entry, HeadersOnlyCallback& callbacks,
                              Upstream::ClusterManager& cluster_manager,
                              Network::ReadFilterCallbacks* read_callbacks,
                              TcpProxy::ConfigSharedPtr config, Event::TimeSystem& time_system)

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -678,6 +678,7 @@ const std::string Json::Schema::ROUTE_ENTRY_CONFIGURATION_SCHEMA(R"EOF(
       "host_rewrite" : {"type" : "string"},
       "auto_host_rewrite" : {"type" : "boolean"},
       "use_websocket" : {"type" : "boolean"},
+      "allow_tunnel" : {"type" : "boolean"},
       "case_sensitive" : {"type" : "boolean"},
       "timeout_ms" : {"type" : "integer"},
       "runtime" : {

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -45,6 +45,7 @@ envoy_cc_library(
         "//source/common/http:header_utility_lib",
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",
+        "//source/common/http/tunnel:tunnel_handler_lib",
         "//source/common/http/websocket:ws_handler_lib",
         "//source/common/protobuf:utility_lib",
     ],

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -211,7 +211,7 @@ public:
     ON_CALL(route_entry, createWebSocketProxy(_, _, _, _, _))
         .WillByDefault(Invoke([this, &route_entry](Http::HeaderMap& request_headers,
                                                    StreamInfo::StreamInfo& stream_info,
-                                                   Http::WebSocketProxyCallbacks& callbacks,
+                                                   Http::HeadersOnlyCallback& callbacks,
                                                    Upstream::ClusterManager& cluster_manager,
                                                    Network::ReadFilterCallbacks* read_callbacks) {
           auto config(std::make_shared<TcpProxy::Config>(

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -251,12 +251,19 @@ public:
   MOCK_CONST_METHOD0(virtualHost, const VirtualHost&());
   MOCK_CONST_METHOD0(autoHostRewrite, bool());
   MOCK_CONST_METHOD0(useOldStyleWebSocket, bool());
+  MOCK_CONST_METHOD0(isTunnelAllowed, bool());
   MOCK_CONST_METHOD5(createWebSocketProxy,
                      Http::WebSocketProxyPtr(Http::HeaderMap& request_headers,
                                              StreamInfo::StreamInfo& stream_info,
-                                             Http::WebSocketProxyCallbacks& callbacks,
+                                             Http::HeadersOnlyCallback& callbacks,
                                              Upstream::ClusterManager& cluster_manager,
                                              Network::ReadFilterCallbacks* read_callbacks));
+  MOCK_CONST_METHOD5(createTunnelHandler,
+                     Http::TunnelProxyPtr(Http::HeaderMap& request_headers,
+                                          StreamInfo::StreamInfo& stream_info,
+                                          Http::HeadersOnlyCallback& callbacks,
+                                          Upstream::ClusterManager& cluster_manager,
+                                          Network::ReadFilterCallbacks* read_callbacks));
   MOCK_CONST_METHOD0(opaqueConfig, const std::multimap<std::string, std::string>&());
   MOCK_CONST_METHOD0(includeVirtualHostRateLimits, bool());
   MOCK_CONST_METHOD0(corsPolicy, const CorsPolicy*());


### PR DESCRIPTION
The implementation is based on the old Web Socket support, which is proposed to
be removed in PR#4745. Refactor WebSocketProxyCallbacks and the tunnel counterparts
in a common interface and replace it everywhere.

TunnelHandlerImpl is hooked directly in to the connection manager and CONNECT tunnels are
created accordingly.

The tunnel implementation assumes the upstream is the origin and always sends 200.

Testing done: build the envoy proxy, add backend echo server, create a CONNECT tunnel,
verify we get 200 on CONNECT and we get the exact same paylond in the response as in the
request.

*Description*:
The purpose of this PR is to verify with the wilder community,. our approach to implementing the accept side of CONNECT as described in #1451. 
Feedback and discussion is expected.

*Risk Level*: Medium - we touched core functionality.
*Testing*:
We run this implementation in our internal environment to verify the new CONNECT functionality. Also run the integrated testing to confirm we did not break anything.
*Docs Changes*:
*Release Notes*:

