### PR TITLE
tls: Implement session resumption for client connections

### DIFF
--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -279,6 +279,9 @@ message UpstreamTlsContext {
   //
   //   TLS renegotiation is considered insecure and shouldn't be used unless absolutely necessary.
   bool allow_renegotiation = 3;
+
+  // If true, clients will resume TLS sessions
+  bool allow_session_resumption = 4;
 }
 
 message DownstreamTlsContext {

--- a/include/envoy/ssl/context_config.h
+++ b/include/envoy/ssl/context_config.h
@@ -86,6 +86,10 @@ public:
    * @return true if server-initiated TLS renegotiation will be allowed.
    */
   virtual bool allowRenegotiation() const PURE;
+  /**
+   * @return true if client should resume TLS sessions
+   */
+  virtual bool allowSessionResumption() const PURE;
 };
 
 typedef std::unique_ptr<ClientContextConfig> ClientContextConfigPtr;

--- a/source/common/ssl/context_config_impl.cc
+++ b/source/common/ssl/context_config_impl.cc
@@ -141,7 +141,8 @@ ClientContextConfigImpl::ClientContextConfigImpl(
     const envoy::api::v2::auth::UpstreamTlsContext& config,
     Server::Configuration::TransportSocketFactoryContext& factory_context)
     : ContextConfigImpl(config.common_tls_context(), factory_context),
-      server_name_indication_(config.sni()), allow_renegotiation_(config.allow_renegotiation()) {
+      server_name_indication_(config.sni()), allow_renegotiation_(config.allow_renegotiation()),
+      allow_session_resumption_(config.allow_session_resumption()) {
   // BoringSSL treats this as a C string, so embedded NULL characters will not
   // be handled correctly.
   if (server_name_indication_.find('\0') != std::string::npos) {

--- a/source/common/ssl/context_config_impl.h
+++ b/source/common/ssl/context_config_impl.h
@@ -102,10 +102,12 @@ public:
   // Ssl::ClientContextConfig
   const std::string& serverNameIndication() const override { return server_name_indication_; }
   bool allowRenegotiation() const override { return allow_renegotiation_; }
+  bool allowSessionResumption() const override { return allow_session_resumption_; }
 
 private:
   const std::string server_name_indication_;
   const bool allow_renegotiation_;
+  const bool allow_session_resumption_;
 };
 
 class ServerContextConfigImpl : public ContextConfigImpl, public ServerContextConfig {

--- a/source/common/ssl/context_impl.h
+++ b/source/common/ssl/context_impl.h
@@ -19,6 +19,8 @@ namespace Envoy {
 #error Envoy requires BoringSSL
 #endif
 
+#define ENVOY_MAX_SESSION_SIZE 4096
+
 namespace Ssl {
 
 // clang-format off
@@ -146,6 +148,8 @@ public:
 private:
   const std::string server_name_indication_;
   const bool allow_renegotiation_;
+  const bool allow_session_resumption_;
+  std::vector<uint8_t> session_;
 };
 
 class ServerContextImpl : public ContextImpl, public ServerContext {


### PR DESCRIPTION
*Description*:

This adds a new `allow_session_resumption` that makes the Envoy client attempt to use session tickets to resume TLS connections.

This is in a pretty early state right now (this PR is basically just copying some code out of nginx's session resumption), but it does resume sessions in my testing and I'd love some feedback on the approach.

If this approach seems reasonable to folks I'll work on adding tests / docs. 

*Risk Level*: medium
*Testing*: TODO
*Docs Changes*: TODO
*Release Notes*: TODO

Fixes #3817
