### PR TITLE
rbac: add requestedServerName to debug output

### DIFF
--- a/source/extensions/filters/network/rbac/rbac_filter.cc
+++ b/source/extensions/filters/network/rbac/rbac_filter.cc
@@ -18,7 +18,9 @@ RoleBasedAccessControlFilterConfig::RoleBasedAccessControlFilterConfig(
 
 Network::FilterStatus RoleBasedAccessControlFilter::onData(Buffer::Instance&, bool) {
   ENVOY_LOG(
-      debug, "checking connection: remoteAddress: {}, localAddress: {}, ssl: {}",
+      debug,
+      "checking connection: requestedServerName: {}, remoteAddress: {}, localAddress: {}, ssl: {}",
+      callbacks_->connection().requestedServerName(),
       callbacks_->connection().remoteAddress()->asString(),
       callbacks_->connection().localAddress()->asString(),
       callbacks_->connection().ssl()


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section 
in PULL_REQUESTS.md

*Description*: The RBAC policy supports requested_server_name now. Print this in the debug output as well.
*Risk Level*: Low
*Testing*: Manually tested
*Docs Changes*: n/a
*Release Notes*: n/a
[Optional Fixes #Issue]
[Optional *Deprecated*:]
