### PR TITLE
docs: document "UC" used by access logs

### DIFF
--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -191,6 +191,7 @@ The following command operators are supported:
   the descriptions do not apply. Possible values are:
 
   HTTP and TCP
+    * **UC**: Upstrean connection termination in addtion to 503 response code.
     * **UH**: No healthy upstream hosts in upstream cluster in addition to 503 response code.
     * **UF**: Upstream connection failure in addition to 503 response code.
     * **UO**: Upstream overflow (:ref:`circuit breaking <arch_overview_circuit_break>`) in addition to 503 response code.

--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -191,7 +191,7 @@ The following command operators are supported:
   the descriptions do not apply. Possible values are:
 
   HTTP and TCP
-    * **UC**: Upstrean connection termination in addtion to 503 response code.
+    * **UC**: Upstrean connection termination in addition to 503 response code.
     * **UH**: No healthy upstream hosts in upstream cluster in addition to 503 response code.
     * **UF**: Upstream connection failure in addition to 503 response code.
     * **UO**: Upstream overflow (:ref:`circuit breaking <arch_overview_circuit_break>`) in addition to 503 response code.


### PR DESCRIPTION
Documents the UC access log short hand.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Low
*Testing*: n/a
*Docs Changes*: n/a
*Release Notes*: n/a
