### PR TITLE
examples: use grpc route matcher where appropriate

### DIFF
--- a/examples/grpc-bridge/config/s2s-grpc-envoy.yaml
+++ b/examples/grpc-bridge/config/s2s-grpc-envoy.yaml
@@ -19,9 +19,7 @@ static_resources:
               routes:
               - match:
                   prefix: "/"
-                  headers:
-                  - name: content-type
-                    exact_match: application/grpc
+                  grpc: {}
                 route:
                   cluster: local_service_grpc
           http_filters:


### PR DESCRIPTION
Use the grpc matcher instead of manually matching on the content-type
header in the grpc s2s example.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Low
*Testing*: Ran script/build for the example and verified example still worked
*Docs Changes*: n/a
*Release Notes*: n/a
