### PR TITLE
Enable Arm64 build

### DIFF
--- a/ci/build_container/build_recipes/luajit.sh
+++ b/ci/build_container/build_recipes/luajit.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-VERSION=2.0.5
-SHA256=8bb29d84f06eb23c7ea4aa4794dbb248ede9fcb23b6989cbef81dc79352afc97
+VERSION=2.1.0-beta3
+SHA256=409f7fe570d3c16558e594421c47bdd130238323c9d6fd6c83dedd2aaeb082a8
 
 curl https://github.com/LuaJIT/LuaJIT/archive/v"$VERSION".tar.gz -sLo LuaJIT-"$VERSION".tar.gz \
   && echo "$SHA256" LuaJIT-"$VERSION".tar.gz | sha256sum --check

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -43,9 +43,9 @@ cc_library(
         ":windows_x86_64": ["thirdparty_build/lib/luajit.lib"],
         "//conditions:default": ["thirdparty_build/lib/libluajit-5.1.a"],
     }),
-    hdrs = glob(["thirdparty_build/include/luajit-2.0/*"]),
+    hdrs = glob(["thirdparty_build/include/luajit-2.1/*"]),
     includes = ["thirdparty_build/include"],
-    # TODO(mattklein123): We should strip luajit-2.0 here for consumers. However, if we do that
+    # TODO(mattklein123): We should strip luajit-2.1 here for consumers. However, if we do that
     # the headers get included using -I vs. -isystem which then causes old-style-cast warnings.
 )
 

--- a/source/exe/signal_action.cc
+++ b/source/exe/signal_action.cc
@@ -20,6 +20,10 @@ void SignalAction::sigHandler(int sig, siginfo_t* info, void* context) {
     error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext->__ss.__rip);
 #elif defined(__powerpc__)
     error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext.regs->nip);
+#elif defined(__aarch64__)
+    error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext.pc);
+#elif defined(__arm__)
+    error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext.arm_pc);
 #else
 #warning "Please enable and test PC retrieval code for your arch in signal_action.cc"
 // x86 Classic: reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[REG_EIP]);

--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -11,7 +11,7 @@
 #include "common/common/c_smart_ptr.h"
 #include "common/common/logger.h"
 
-#include "luajit-2.0/lua.hpp"
+#include "luajit-2.1/lua.hpp"
 
 namespace Envoy {
 namespace Extensions {


### PR DESCRIPTION
Signed-off-by: Bin Lu bin.lu@arm.com

LuaJIT2.0 does not support for Arm64

Luajit 2.0.5 doesn't support Arm64, please see logs as reference.
So I need to update it into the latest version.
Logs:
bazel fetch //source/...
….
==== Building LuaJIT 2.0.5 ====
make -C src
make[2]: Entering directory '/root/.cache/bazel/_bazel_root/38a3de7f29554e17d452de52137c58b9/external/envoy_deps_cache_2c744dffd279d7e9e0910ce594eb4f4f/luajit.dep.build/LuaJIT-2.0.5/src'
lj_arch.h:55:2: error: #error "No support for this architecture (yet)"
#error "No support for this architecture (yet)"
^

Risk Level: Medium

Testing: unit test,integration

Docs Changes: None

Release Notes: None