### PR TITLE
enable build on Arm64

### DIFF
--- a/ci/build_container/build_recipes/luajit.sh
+++ b/ci/build_container/build_recipes/luajit.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-VERSION=2.0.5
-SHA256=8bb29d84f06eb23c7ea4aa4794dbb248ede9fcb23b6989cbef81dc79352afc97
+VERSION=2.1.0-beta3
+SHA256=409f7fe570d3c16558e594421c47bdd130238323c9d6fd6c83dedd2aaeb082a8
 
 curl https://github.com/LuaJIT/LuaJIT/archive/v"$VERSION".tar.gz -sLo LuaJIT-"$VERSION".tar.gz \
   && echo "$SHA256" LuaJIT-"$VERSION".tar.gz | sha256sum --check

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -43,9 +43,9 @@ cc_library(
         ":windows_x86_64": ["thirdparty_build/lib/luajit.lib"],
         "//conditions:default": ["thirdparty_build/lib/libluajit-5.1.a"],
     }),
-    hdrs = glob(["thirdparty_build/include/luajit-2.0/*"]),
+    hdrs = glob(["thirdparty_build/include/luajit-2.1/*"]),
     includes = ["thirdparty_build/include"],
-    # TODO(mattklein123): We should strip luajit-2.0 here for consumers. However, if we do that
+    # TODO(mattklein123): We should strip luajit-2.1 here for consumers. However, if we do that
     # the headers get included using -I vs. -isystem which then causes old-style-cast warnings.
 )
 

--- a/source/exe/signal_action.cc
+++ b/source/exe/signal_action.cc
@@ -20,6 +20,10 @@ void SignalAction::sigHandler(int sig, siginfo_t* info, void* context) {
     error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext->__ss.__rip);
 #elif defined(__powerpc__)
     error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext.regs->nip);
+#elif defined(__aarch64__)
+    error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext.pc);
+#elif defined(__arm__)
+    error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext.arm_pc);
 #else
 #warning "Please enable and test PC retrieval code for your arch in signal_action.cc"
 // x86 Classic: reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[REG_EIP]);

--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -11,7 +11,7 @@
 #include "common/common/c_smart_ptr.h"
 #include "common/common/logger.h"
 
-#include "luajit-2.0/lua.hpp"
+#include "luajit-2.1/lua.hpp"
 
 namespace Envoy {
 namespace Extensions {


### PR DESCRIPTION
Signed-off-by: Bin Lu bin.lu@arm.com

Build for Linux on Arm. 
Fix 2 issues:
1,  luajit 2.0 does not support for arm/ppc64le
2,  fix a bug in source/exe/signal_action.cc

Please see log as reference:

A.
root@entos-thunderx2-02:/go/lubinsz/envoy# uname -m
aarch64
B.
root@entos-thunderx2-02:/go/lubinsz/envoy# bazel build //source/exe:envoy-static

INFO: Analysed target //source/exe:envoy-static (1 packages loaded).
INFO: Found 1 target...
Target //source/exe:envoy-static up-to-date:
  bazel-bin/source/exe/envoy-static
INFO: Elapsed time: 26.244s, Critical Path: 7.64s
INFO: 3 processes: 3 linux-sandbox.
INFO: Build completed successfully, 6 total actions
C.
root@entos-thunderx2-02:/go/lubinsz/envoy# file bazel-bin/source/exe/envoy-static
bazel-bin/source/exe/envoy-static: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, BuildID[sha1]=bde20afe9d93c34411f43a50468426e8ac996df9, not stripped


Risk Level: Medium

Testing: unit test,integration

Docs Changes: None

Release Notes: None