### PR TITLE
tracing: Fix segfault when generated trace id disabled

### DIFF
--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -87,8 +87,10 @@ void HttpTracerUtility::finalizeSpan(Span& span, const Http::HeaderMap* request_
                                      const Config& tracing_config) {
   // Pre response data.
   if (request_headers) {
-    span.setTag(Tracing::Tags::get().GUID_X_REQUEST_ID,
-                std::string(request_headers->RequestId()->value().c_str()));
+    if (request_headers->RequestId()) {
+      span.setTag(Tracing::Tags::get().GUID_X_REQUEST_ID,
+                  std::string(request_headers->RequestId()->value().c_str()));
+    }
     span.setTag(Tracing::Tags::get().HTTP_URL, buildUrl(*request_headers));
     span.setTag(Tracing::Tags::get().HTTP_METHOD, request_headers->Method()->value().c_str());
     span.setTag(Tracing::Tags::get().DOWNSTREAM_CLUSTER,

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -115,7 +115,7 @@ TEST(HttpConnManFinalizerImpl, OriginalAndLongPath) {
   const std::string path(300, 'a');
   const std::string path_prefix = "http://";
   const std::string expected_path(128, 'a');
-  std::unique_ptr<NiceMock<MockSpan>> span(new NiceMock<MockSpan>());
+  NiceMock<MockSpan> span;
 
   Http::TestHeaderMapImpl request_headers{{"x-request-id", "id"},
                                           {"x-envoy-original-path", path},
@@ -130,20 +130,20 @@ TEST(HttpConnManFinalizerImpl, OriginalAndLongPath) {
   absl::optional<uint32_t> response_code;
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
 
-  EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_URL, path_prefix + expected_path));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_METHOD, "GET"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_PROTOCOL, "HTTP/2"));
+  EXPECT_CALL(span, setTag(_, _)).Times(testing::AnyNumber());
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_URL, path_prefix + expected_path));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_METHOD, "GET"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_PROTOCOL, "HTTP/2"));
 
   NiceMock<MockConfig> config;
-  HttpTracerUtility::finalizeSpan(*span, &request_headers, stream_info, config);
+  HttpTracerUtility::finalizeSpan(span, &request_headers, stream_info, config);
 }
 
 TEST(HttpConnManFinalizerImpl, NoGeneratedId) {
   const std::string path(300, 'a');
   const std::string path_prefix = "http://";
   const std::string expected_path(128, 'a');
-  std::unique_ptr<NiceMock<MockSpan>> span(new NiceMock<MockSpan>());
+  NiceMock<MockSpan> span;
 
   Http::TestHeaderMapImpl request_headers{
       {"x-envoy-original-path", path}, {":method", "GET"}, {"x-forwarded-proto", "http"}};
@@ -156,17 +156,17 @@ TEST(HttpConnManFinalizerImpl, NoGeneratedId) {
   absl::optional<uint32_t> response_code;
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
 
-  EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_URL, path_prefix + expected_path));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_METHOD, "GET"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_PROTOCOL, "HTTP/2"));
+  EXPECT_CALL(span, setTag(_, _)).Times(testing::AnyNumber());
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_URL, path_prefix + expected_path));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_METHOD, "GET"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_PROTOCOL, "HTTP/2"));
 
   NiceMock<MockConfig> config;
-  HttpTracerUtility::finalizeSpan(*span, &request_headers, stream_info, config);
+  HttpTracerUtility::finalizeSpan(span, &request_headers, stream_info, config);
 }
 
 TEST(HttpConnManFinalizerImpl, NullRequestHeaders) {
-  std::unique_ptr<NiceMock<MockSpan>> span(new NiceMock<MockSpan>());
+  NiceMock<MockSpan> span;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
 
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
@@ -175,19 +175,19 @@ TEST(HttpConnManFinalizerImpl, NullRequestHeaders) {
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
   EXPECT_CALL(stream_info, upstreamHost()).WillOnce(Return(nullptr));
 
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_STATUS_CODE, "0"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().RESPONSE_SIZE, "11"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "-"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().REQUEST_SIZE, "10"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, _)).Times(0);
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_STATUS_CODE, "0"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_SIZE, "11"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "-"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().REQUEST_SIZE, "10"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, _)).Times(0);
 
   NiceMock<MockConfig> config;
-  HttpTracerUtility::finalizeSpan(*span, nullptr, stream_info, config);
+  HttpTracerUtility::finalizeSpan(span, nullptr, stream_info, config);
 }
 
 TEST(HttpConnManFinalizerImpl, UpstreamClusterTagSet) {
-  std::unique_ptr<NiceMock<MockSpan>> span(new NiceMock<MockSpan>());
+  NiceMock<MockSpan> span;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
   stream_info.host_->cluster_.name_ = "my_upstream_cluster";
 
@@ -197,19 +197,19 @@ TEST(HttpConnManFinalizerImpl, UpstreamClusterTagSet) {
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
   EXPECT_CALL(stream_info, upstreamHost()).Times(2);
 
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, "my_upstream_cluster"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_STATUS_CODE, "0"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().RESPONSE_SIZE, "11"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "-"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().REQUEST_SIZE, "10"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, "my_upstream_cluster"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_STATUS_CODE, "0"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_SIZE, "11"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "-"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().REQUEST_SIZE, "10"));
 
   NiceMock<MockConfig> config;
-  HttpTracerUtility::finalizeSpan(*span, nullptr, stream_info, config);
+  HttpTracerUtility::finalizeSpan(span, nullptr, stream_info, config);
 }
 
 TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
-  std::unique_ptr<NiceMock<MockSpan>> span(new NiceMock<MockSpan>());
+  NiceMock<MockSpan> span;
 
   Http::TestHeaderMapImpl request_headers{{"x-request-id", "id"},
                                           {":path", "/test"},
@@ -223,31 +223,31 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
   const std::string service_node = "i-453";
 
   // Check that span is populated correctly.
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().GUID_X_REQUEST_ID, "id"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_URL, "https:///test"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_METHOD, "GET"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().USER_AGENT, "-"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_PROTOCOL, "HTTP/1.0"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().DOWNSTREAM_CLUSTER, "-"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().REQUEST_SIZE, "10"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().GUID_X_REQUEST_ID, "id"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_URL, "https:///test"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_METHOD, "GET"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().USER_AGENT, "-"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_PROTOCOL, "HTTP/1.0"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().DOWNSTREAM_CLUSTER, "-"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().REQUEST_SIZE, "10"));
 
   absl::optional<uint32_t> response_code;
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(100));
   EXPECT_CALL(stream_info, upstreamHost()).WillOnce(Return(nullptr));
 
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_STATUS_CODE, "0"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().RESPONSE_SIZE, "100"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "-"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, _)).Times(0);
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_STATUS_CODE, "0"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_SIZE, "100"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "-"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, _)).Times(0);
 
   NiceMock<MockConfig> config;
-  HttpTracerUtility::finalizeSpan(*span, &request_headers, stream_info, config);
+  HttpTracerUtility::finalizeSpan(span, &request_headers, stream_info, config);
 }
 
 TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
-  std::unique_ptr<NiceMock<MockSpan>> span(new NiceMock<MockSpan>());
+  NiceMock<MockSpan> span;
   Http::TestHeaderMapImpl request_headers{{"x-request-id", "id"},
                                           {":path", "/test"},
                                           {":method", "GET"},
@@ -265,14 +265,14 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
   const std::string service_node = "i-453";
 
   // Check that span is populated correctly.
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().GUID_X_REQUEST_ID, "id"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_URL, "http://api/test"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_METHOD, "GET"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().USER_AGENT, "agent"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_PROTOCOL, "HTTP/1.0"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().DOWNSTREAM_CLUSTER, "downstream_cluster"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().REQUEST_SIZE, "10"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().GUID_X_CLIENT_TRACE_ID, "client_trace_id"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().GUID_X_REQUEST_ID, "id"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_URL, "http://api/test"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_METHOD, "GET"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().USER_AGENT, "agent"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_PROTOCOL, "HTTP/1.0"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().DOWNSTREAM_CLUSTER, "downstream_cluster"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().REQUEST_SIZE, "10"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().GUID_X_CLIENT_TRACE_ID, "client_trace_id"));
 
   // Check that span has tags from custom headers.
   request_headers.addCopy(Http::LowerCaseString("aa"), "a");
@@ -282,8 +282,8 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
   config.headers_.push_back(Http::LowerCaseString("aa"));
   config.headers_.push_back(Http::LowerCaseString("cc"));
   config.headers_.push_back(Http::LowerCaseString("ee"));
-  EXPECT_CALL(*span, setTag("aa", "a"));
-  EXPECT_CALL(*span, setTag("cc", "c"));
+  EXPECT_CALL(span, setTag("aa", "a"));
+  EXPECT_CALL(span, setTag("cc", "c"));
   EXPECT_CALL(config, requestHeadersForTags());
 
   absl::optional<uint32_t> response_code(503);
@@ -293,13 +293,13 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
       .WillByDefault(Return(true));
   EXPECT_CALL(stream_info, upstreamHost()).WillOnce(Return(nullptr));
 
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().HTTP_STATUS_CODE, "503"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().RESPONSE_SIZE, "100"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "UT"));
-  EXPECT_CALL(*span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, _)).Times(0);
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_STATUS_CODE, "503"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_SIZE, "100"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "UT"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, _)).Times(0);
 
-  HttpTracerUtility::finalizeSpan(*span, &request_headers, stream_info, config);
+  HttpTracerUtility::finalizeSpan(span, &request_headers, stream_info, config);
 }
 
 TEST(HttpTracerUtilityTest, operationTypeToString) {


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

*Description*: Fixes #4792
*Risk Level*: low
*Testing*: Added unit test
*Docs Changes*: None required
*Release Notes*: None required
[Optional Fixes #Issue]
[Optional *Deprecated*:]
