### PR TITLE
date_formatter: fix keying bug in cached fromTime().

### DIFF
--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -25,7 +25,9 @@ namespace Envoy {
  */
 class DateFormatter {
 public:
-  DateFormatter(const std::string& format_string) : format_string_(parse(format_string)) {}
+  DateFormatter(const std::string& format_string) : raw_format_string_(format_string) {
+    parse(format_string);
+  }
 
   /**
    * @return std::string representing the GMT/UTC time based on the input time.
@@ -33,22 +35,18 @@ public:
   std::string fromTime(const SystemTime& time) const;
 
   /**
-   * @return std::string representing the GMT/UTC time based on the input time.
+   * @param time_source time keeping source.
+   * @return std::string representing the GMT/UTC time of a TimeSource based on the format string.
    */
-  std::string fromTime(time_t time) const;
-
-  /**
-   * @return std::string representing the current GMT/UTC time based on the format string.
-   */
-  std::string now();
+  std::string now(TimeSource& time_source);
 
   /**
    * @return std::string the format string used.
    */
-  const std::string& formatString() const { return format_string_; }
+  const std::string& formatString() const { return raw_format_string_; }
 
 private:
-  std::string parse(const std::string& format_string);
+  void parse(const std::string& format_string);
 
   typedef std::vector<int32_t> SpecifierOffsets;
   std::string fromTimeAndPrepareSpecifierOffsets(time_t time, SpecifierOffsets& specifier_offsets,
@@ -84,7 +82,8 @@ private:
   // This holds all specifiers found in a given format string.
   std::vector<Specifier> specifiers_;
 
-  const std::string format_string_;
+  // This is the format string as supplied in configuration, e.g. "foo %3f bar".
+  const std::string raw_format_string_;
 };
 
 /**

--- a/source/common/http/date_provider_impl.h
+++ b/source/common/http/date_provider_impl.h
@@ -18,8 +18,12 @@ namespace Http {
  * Base for all providers.
  */
 class DateProviderImplBase : public DateProvider {
+public:
+  explicit DateProviderImplBase(TimeSource& time_source) : time_source_(time_source) {}
+
 protected:
   static DateFormatter date_formatter_;
+  TimeSource& time_source_;
 };
 
 /**
@@ -50,6 +54,8 @@ private:
  * A basic provider that just creates the date string every time.
  */
 class SlowDateProviderImpl : public DateProviderImplBase {
+  using DateProviderImplBase::DateProviderImplBase;
+
 public:
   // Http::DateProvider
   void setDateHeader(HeaderMap& headers) override;

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -964,6 +964,7 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server)
           {"/runtime_modify", "modify runtime values", MAKE_ADMIN_HANDLER(handlerRuntimeModify),
            false, true},
       },
+      date_provider_(server.dispatcher().timeSystem()),
       admin_filter_chain_(std::make_shared<AdminFilterChain>()) {}
 
 Http::ServerConnectionPtr AdminImpl::createCodec(Network::Connection& connection,

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -836,10 +836,21 @@ TEST(DateFormatter, FromTime) {
   EXPECT_EQ("2018-04-03T23:06:09.000Z", DateFormatter("%Y-%m-%dT%H:%M:%S.000Z").fromTime(time1));
   EXPECT_EQ("aaa23", DateFormatter(std::string(3, 'a') + "%H").fromTime(time1));
   EXPECT_EQ("", DateFormatter(std::string(1022, 'a') + "%H").fromTime(time1));
-  const time_t time2 = 0;
+  const SystemTime time2(std::chrono::seconds(0));
   EXPECT_EQ("1970-01-01T00:00:00.000Z", DateFormatter("%Y-%m-%dT%H:%M:%S.000Z").fromTime(time2));
   EXPECT_EQ("aaa00", DateFormatter(std::string(3, 'a') + "%H").fromTime(time2));
   EXPECT_EQ("", DateFormatter(std::string(1022, 'a') + "%H").fromTime(time2));
+}
+
+// Verify that two DateFormatter patterns with the same ??? patterns but
+// different format strings don't false share cache entries. This is a
+// regression test for when they did.
+TEST(DateFormatter, FromTimeSameWildcard) {
+  const SystemTime time1(std::chrono::seconds(1522796769) + std::chrono::milliseconds(142));
+  EXPECT_EQ("2018-04-03T23:06:09.000Z142",
+            DateFormatter("%Y-%m-%dT%H:%M:%S.000Z%3f").fromTime(time1));
+  EXPECT_EQ("2018-04-03T23:06:09.000Z114",
+            DateFormatter("%Y-%m-%dT%H:%M:%S.000Z%1f%2f").fromTime(time1));
 }
 
 } // namespace Envoy

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -118,12 +118,12 @@ public:
   const envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager config_;
   std::list<AccessLog::InstanceSharedPtr> access_logs_;
   MockServerConnection* codec_{};
-  SlowDateProviderImpl date_provider_;
   MockStreamDecoderFilter* decoder_filter_{};
   MockStreamEncoderFilter* encoder_filter_{};
   NiceMock<MockFilterChainFactory> filter_factory_;
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   Event::SimulatedTimeSystem time_system_;
+  SlowDateProviderImpl date_provider_{time_system_};
   RouteConfigProvider route_config_provider_;
   std::string server_name_;
   Stats::IsolatedStoreImpl fake_stats_;

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -320,7 +320,7 @@ public:
   NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
   std::unique_ptr<Ssl::MockConnection> ssl_connection_;
   TracingConnectionManagerConfigPtr tracing_config_;
-  SlowDateProviderImpl date_provider_;
+  SlowDateProviderImpl date_provider_{test_time_.timeSystem()};
   MockStream stream_;
   Http::StreamCallbacks* stream_callbacks_{nullptr};
   NiceMock<Upstream::MockClusterManager> cluster_manager_;

--- a/test/common/router/header_parser_corpus/clusterfuzz-testcase-minimized-header_parser_fuzz_test-5191408676241408
+++ b/test/common/router/header_parser_corpus/clusterfuzz-testcase-minimized-header_parser_fuzz_test-5191408676241408
@@ -1,0 +1,83 @@
+headers_to_add {
+  header {
+    key: "A"
+    value: "%START_TIME(%Qf{pbot\204N{{{{{B%)%%START_TIME(kB\377\177?Be{{{{{{{{{{{{{f{{\377\377{{{B%)%%START_TIME({B%)%%%%%%%%%%START_TIME(%Qf{prot\2043{%@%%START_TIME8%)%"
+  }
+}
+headers_to_add {
+  header {
+    key: "A"
+    value: "1"
+  }
+}
+headers_to_add {
+  header {
+    key: "A"
+    value: "%START_TIME(%:f{prot\002 %2\003%%%043{{{[{B%)%%START_TIME(kB\377\177?BB{{--------------------------------------------%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\017%%%%%%G%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\271%%%%%%%%%%%%%%%%%%%%%%%%\377\377%%%%%%%%%%%%%%+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%START_TIME(%)%"
+  }
+}
+headers_to_add {
+  header {
+    key: "1"
+  }
+}
+headers_to_add {
+  header {
+    key: "A"
+    value: "%START_TIME(`QfdBB, %5f, %6f, %4294967295f, %8f%1f, %2f, %3f,f, %1f, %2f, %3f,%6f,, %6f,(%7f, %8f, % %68f, % %4f, %5f, %6f, %4294967295f, %8f, 9f)%"
+  }
+}
+headers_to_add {
+  header {
+    key: "A"
+    value: "%START_TIME(%f,%)%%START_TIME(kB\177\177?BB{{{{B%)%%START_TIME(%)%"
+  }
+}
+headers_to_add {
+  header {
+    key: "A"
+    value: "%START_TIME(%Qf{pbot\204N{{{{{B%)%%START_TIME(kB\377\177?Be{{{{{{{{{{{{{f{{\377\377{{{B%)%%START_TIME({B%)%%%%%%%%%%START_TIME(%Qf{prot\2043{%@%%START_TIME8%)%"
+  }
+}
+headers_to_add {
+  header {
+    key: "A"
+    value: "1"
+  }
+}
+headers_to_add {
+  header {
+    key: "?"
+    value: "%START_TIME(`QfdBB, %5f, %6f, %4294967295f, %8f%1f, %2f, %3f,f, %1f, %2f, %3f,%6f,, %6f,(%7f, %8f, % %68f, % %4f, %5f, %6f, %4294967295f, %8f, 9f)%"
+  }
+}
+headers_to_add {
+  header {
+    key: "1"
+    value: "1"
+  }
+}
+headers_to_add {
+  header {
+    key: "0"
+    value: "%START_TIMEY()%5+5555FmehWNSTRSAM_LOCAL_ADDRESS%%DOWNSTREAM_LOCAL_ADDRESS%\002DO\024f,f,  +89fCOL%6020\002COL%\200\377\377\377\20020\220\022\220%%%PROT5COL%\2003J0\220\2220\222\220%%%PROTOeOL%220%%%PR\200\03360\\23J0\220\2220}222\002\002N0\2220}222\220%%%\020R%\200;60m220\220%%%PROTOC220\002\220%%%55555555  %85+3555Fme:\37105227 f-55S5_inf    %START_TIME(f)%"
+  }
+}
+headers_to_add {
+  header {
+    key: "A"
+    value: "%START_TIME(`QfdBB, %5f, %6f, %4294967295f, %8f%1f, %2f, %3f,f, %1f, %2f, %3f,%6f,, %6f,(%7f, %8f, % %68f, % %4f, %5f, %6f, %4294967295f, %8f, 9f)%"
+  }
+}
+headers_to_add {
+  header {
+    key: "A"
+    value: "%START_TIME(`QfdBB, %5f, %6f, %4294967295f, %8f%1f, %2f, %3f,f, %1f, %2f, %3f,%6f,, %6f,(%7f, %8f, % %68f, % %4f, %5f, %6f, %429f, %6f, %4294969f)%"
+  }
+}
+headers_to_add {
+  header {
+    key: "A"
+    value: "%START_TIME(`QfdBB, %5f, %6f, %4294967295f, %f, %2f, %3f,f, %1f, %2f, %3f,%6f,, %6f,(%7f, %8f, % %68f, % %4f, %5f, %6f, %4294967295f, %8f, 9f)%"
+  }
+}

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -46,7 +46,7 @@ parseHttpConnectionManagerFromV2Yaml(const std::string& yaml) {
 class HttpConnectionManagerConfigTest : public testing::Test {
 public:
   NiceMock<Server::Configuration::MockFactoryContext> context_;
-  Http::SlowDateProviderImpl date_provider_;
+  Http::SlowDateProviderImpl date_provider_{context_.dispatcher().timeSystem()};
   NiceMock<Router::MockRouteConfigProviderManager> route_config_provider_manager_;
 };
 


### PR DESCRIPTION
Previously, two distinct format strings that mapped to identical intermediate representation with
??? acting as placeholders would falsely share the same cached time format.

Also, as a bonus, used this as an opportuntiy to move towards TimeSource for DateFormatter.

Fixes oss-fuzz bug https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10109.

Risk Level: Low
Testing: Unit test and corpus entry added.

Signed-off-by: Harvey Tuch <htuch@google.com>