### PR TITLE
[WIP] Fixes #2943 - implements one xDS connection per resource type and config server 

### DIFF
--- a/include/envoy/upstream/BUILD
+++ b/include/envoy/upstream/BUILD
@@ -10,7 +10,7 @@ envoy_package()
 
 envoy_cc_library(
     name = "cluster_manager_interface",
-    hdrs = ["cluster_manager.h"],
+    hdrs = ["cluster_manager.h", "grpc_mux_factory.h"],
     deps = [
         ":health_checker_interface",
         ":load_balancer_interface",

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -10,6 +10,7 @@
 #include "envoy/api/v2/cds.pb.h"
 #include "envoy/config/bootstrap/v2/bootstrap.pb.h"
 #include "envoy/config/grpc_mux.h"
+#include "envoy/upstream/grpc_mux_factory.h"
 #include "envoy/grpc/async_client_manager.h"
 #include "envoy/http/async_client.h"
 #include "envoy/http/conn_pool.h"
@@ -182,6 +183,8 @@ public:
    * @return GrpcMux& ADS API provider referencee.
    */
   virtual Config::GrpcMux& adsMux() PURE;
+
+  virtual Config::GrpcMuxFactory& muxFactory() PURE;
 
   /**
    * @return Grpc::AsyncClientManager& the cluster manager's gRPC client manager.

--- a/include/envoy/upstream/grpc_mux_factory.h
+++ b/include/envoy/upstream/grpc_mux_factory.h
@@ -17,11 +17,12 @@ public:
     virtual ~GrpcMuxFactory() {}
 
     /**
-    * Returns an existing or creates a new GrpcMux.
+    * Returns an existing instance of GrpcMux if one exists for a combination of protocol and type_url,
+    *  otherwise returns a new instance of GrpcMux.
     * @param local_info LocalInfo::LocalInfo local info.
     * @param async_client Grpc::AsyncClientPtr async client to use for the grpc connection
     * @param dispatcher event dispatcher.
-    * @param _method fully qualified name of v2 gRPC API bidi streaming method (as per protobuf
+    * @param service_method fully qualified name of v2 gRPC API bidi streaming method (as per protobuf
     *        service description).
     * @param random random generator for jittering polling delays (when REST).
     * @param config envoy::api::v2::core::ConfigSource to construct from.

--- a/include/envoy/upstream/grpc_mux_factory.h
+++ b/include/envoy/upstream/grpc_mux_factory.h
@@ -27,7 +27,7 @@ public:
     * @param config envoy::api::v2::core::ConfigSource to construct from.
     * @param scope stats scope.
     */
-    virtual Config::GrpcMux*
+    virtual Config::GrpcMux&
     getOrCreateMux(const LocalInfo::LocalInfo &local_info, Grpc::AsyncClientPtr async_client,
                    Event::Dispatcher &dispatcher, const Protobuf::MethodDescriptor &service_method,
                    Runtime::RandomGenerator &random, const ::envoy::api::v2::core::ApiConfigSource& config_source,

--- a/include/envoy/upstream/grpc_mux_factory.h
+++ b/include/envoy/upstream/grpc_mux_factory.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "envoy/local_info/local_info.h"
+#include "envoy/grpc/async_client.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/config/grpc_mux.h"
+#include "common/protobuf/protobuf.h"
+#include "envoy/api/v2/core/config_source.pb.h"
+#include "envoy/runtime/runtime.h"
+
+
+namespace Envoy {
+namespace Config {
+
+class GrpcMuxFactory {
+public:
+    virtual ~GrpcMuxFactory() {}
+
+    virtual Config::GrpcMux*
+    getOrCreateMux(const LocalInfo::LocalInfo &local_info, Grpc::AsyncClientPtr async_client,
+                   Event::Dispatcher &dispatcher, const Protobuf::MethodDescriptor &service_method,
+                   Runtime::RandomGenerator &random, const ::envoy::api::v2::core::ApiConfigSource& config_source,
+                   Stats::Scope& scope, const std::string type_url) PURE;
+};
+
+typedef std::unique_ptr<GrpcMuxFactory> GrpcMuxFactoryPtr;
+}
+}

--- a/include/envoy/upstream/grpc_mux_factory.h
+++ b/include/envoy/upstream/grpc_mux_factory.h
@@ -16,6 +16,17 @@ class GrpcMuxFactory {
 public:
     virtual ~GrpcMuxFactory() {}
 
+    /**
+    * Returns an existing or creates a new GrpcMux.
+    * @param local_info LocalInfo::LocalInfo local info.
+    * @param async_client Grpc::AsyncClientPtr async client to use for the grpc connection
+    * @param dispatcher event dispatcher.
+    * @param _method fully qualified name of v2 gRPC API bidi streaming method (as per protobuf
+    *        service description).
+    * @param random random generator for jittering polling delays (when REST).
+    * @param config envoy::api::v2::core::ConfigSource to construct from.
+    * @param scope stats scope.
+    */
     virtual Config::GrpcMux*
     getOrCreateMux(const LocalInfo::LocalInfo &local_info, Grpc::AsyncClientPtr async_client,
                    Event::Dispatcher &dispatcher, const Protobuf::MethodDescriptor &service_method,

--- a/source/common/config/grpc_subscription_impl.h
+++ b/source/common/config/grpc_subscription_impl.h
@@ -14,11 +14,8 @@ namespace Config {
 template <class ResourceType>
 class GrpcSubscriptionImpl : public Config::Subscription<ResourceType> {
 public:
-  GrpcSubscriptionImpl(const LocalInfo::LocalInfo& local_info, Grpc::AsyncClientPtr async_client,
-                       Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
-                       const Protobuf::MethodDescriptor& service_method, SubscriptionStats stats,
-                       Stats::Scope& scope)
-      : grpc_mux_(local_info, std::move(async_client), dispatcher, service_method, random, scope),
+  GrpcSubscriptionImpl(GrpcMux& grpc_mux, SubscriptionStats stats)
+      : grpc_mux_(grpc_mux),
         grpc_mux_subscription_(grpc_mux_, stats) {}
 
   // Config::Subscription
@@ -36,7 +33,7 @@ public:
   GrpcMuxImpl& grpcMux() { return grpc_mux_; }
 
 private:
-  GrpcMuxImpl grpc_mux_;
+  GrpcMux& grpc_mux_;
   GrpcMuxSubscriptionImpl<ResourceType> grpc_mux_subscription_;
 };
 

--- a/source/common/config/subscription_factory.h
+++ b/source/common/config/subscription_factory.h
@@ -73,7 +73,7 @@ public:
                                                *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(grpc_method),
                                                random, config.api_config_source(), scope,
                                                Grpc::Common::typeUrl(ResourceType().GetDescriptor()->full_name()));
-        result.reset(new GrpcMuxSubscriptionImpl<ResourceType>(*mux, stats));
+        result.reset(new GrpcSubscriptionImpl<ResourceType>(*mux, stats));
         break;
       }
       default:

--- a/source/common/config/subscription_factory.h
+++ b/source/common/config/subscription_factory.h
@@ -65,14 +65,15 @@ public:
             *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(rest_method), stats));
         break;
       case envoy::api::v2::core::ApiConfigSource::GRPC: {
-        result.reset(new GrpcSubscriptionImpl<ResourceType>(
-            local_info,
-            Config::Utility::factoryForGrpcApiConfigSource(cm.grpcAsyncClientManager(),
-                                                           config.api_config_source(), scope)
-                ->create(),
-            dispatcher, random,
-            *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(grpc_method), stats,
-            scope));
+	    Config::GrpcMux* mux =
+	            cm.muxFactory().getOrCreateMux(local_info,
+                                               Config::Utility::factoryForGrpcApiConfigSource(
+                                                      cm.grpcAsyncClientManager(),config.api_config_source(), scope)->create(),
+                                               dispatcher,
+                                               *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(grpc_method),
+                                               random, config.api_config_source(), scope,
+                                               Grpc::Common::typeUrl(ResourceType().GetDescriptor()->full_name()));
+        result.reset(new GrpcMuxSubscriptionImpl<ResourceType>(*mux, stats));
         break;
       }
       default:

--- a/source/common/config/subscription_factory.h
+++ b/source/common/config/subscription_factory.h
@@ -65,7 +65,7 @@ public:
             *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(rest_method), stats));
         break;
       case envoy::api::v2::core::ApiConfigSource::GRPC: {
-	    Config::GrpcMux* mux =
+	    Config::GrpcMux& mux =
 	            cm.muxFactory().getOrCreateMux(local_info,
                                                Config::Utility::factoryForGrpcApiConfigSource(
                                                       cm.grpcAsyncClientManager(),config.api_config_source(), scope)->create(),
@@ -73,7 +73,7 @@ public:
                                                *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(grpc_method),
                                                random, config.api_config_source(), scope,
                                                Grpc::Common::typeUrl(ResourceType().GetDescriptor()->full_name()));
-        result.reset(new GrpcSubscriptionImpl<ResourceType>(*mux, stats));
+        result.reset(new GrpcSubscriptionImpl<ResourceType>(mux, stats));
         break;
       }
       default:

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -183,6 +183,7 @@ ClusterManagerImpl::ClusterManagerImpl(const envoy::config::bootstrap::v2::Boots
           admin.getConfigTracker().add("clusters", [this] { return dumpClusterConfigs(); })),
       time_source_(main_thread_dispatcher.timeSystem()), dispatcher_(main_thread_dispatcher) {
   async_client_manager_ = std::make_unique<Grpc::AsyncClientManagerImpl>(*this, tls, time_source_);
+  mux_factory_ = std::make_unique<GrpcMuxFactoryImpl>();
   const auto& cm_config = bootstrap.cluster_manager();
   if (cm_config.has_outlier_detection()) {
     const std::string event_log_file_path = cm_config.outlier_detection().event_log_path();

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -339,21 +339,9 @@ private:
                                     const ::envoy::api::v2::core::ApiConfigSource& config_source,
                                     Stats::Scope& scope, const std::string type_url) override {
 
-      uint64_t proto_hash; // config_source_name + type_url
-      switch(config_source.grpc_services(0).target_specifier_case()) {
-        case envoy::api::v2::core::GrpcService::kEnvoyGrpc: {
-          proto_hash = MessageUtil::hash(config_source.grpc_services(0).envoy_grpc());
-          break;
-        }
-        case envoy::api::v2::core::GrpcService::kGoogleGrpc: {
-          proto_hash = MessageUtil::hash(config_source.grpc_services(0).google_grpc());
-          break;
-        }
-        default:
-          NOT_REACHED_GCOVR_EXCL_LINE;
-      }
-
-      const uint64_t mux_key = proto_hash + XXH64(type_url.c_str(), type_url.length() + 1, 0);
+      const uint64_t proto_hash = MessageUtil::hash(config_source.grpc_services(0));
+      const uint64_t mux_key = XXH64(type_url.c_str(), type_url.length() + 1, proto_hash);
+      
       if (muxes_.find(mux_key) == muxes_.end()) {
         muxes_.insert({mux_key,
                        std::make_unique<Config::GrpcMuxImpl>(local_info, std::move(async_client), dispatcher,

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -341,7 +341,7 @@ private:
 
       const uint64_t proto_hash = MessageUtil::hash(config_source.grpc_services(0));
       const uint64_t mux_key = XXH64(type_url.c_str(), type_url.length() + 1, proto_hash);
-      
+
       if (muxes_.find(mux_key) == muxes_.end()) {
         muxes_.insert({mux_key,
                        std::make_unique<Config::GrpcMuxImpl>(local_info, std::move(async_client), dispatcher,

--- a/test/mocks/config/BUILD
+++ b/test/mocks/config/BUILD
@@ -14,6 +14,7 @@ envoy_cc_mock(
     hdrs = ["mocks.h"],
     deps = [
         "//include/envoy/config:grpc_mux_interface",
+        "//include/envoy/upstream:cluster_manager_interface",
         "//include/envoy/config:subscription_interface",
         "//source/common/config:resources_lib",
         "//source/common/protobuf:utility_lib",

--- a/test/mocks/config/mocks.h
+++ b/test/mocks/config/mocks.h
@@ -3,6 +3,7 @@
 #include "envoy/api/v2/eds.pb.h"
 #include "envoy/config/grpc_mux.h"
 #include "envoy/config/subscription.h"
+#include "envoy/upstream/grpc_mux_factory.h"
 
 #include "common/config/resources.h"
 #include "common/protobuf/utility.h"
@@ -72,6 +73,17 @@ public:
                                     const std::string& version_info));
   MOCK_METHOD1(onConfigUpdateFailed, void(const EnvoyException* e));
   MOCK_METHOD1(resourceName, std::string(const ProtobufWkt::Any& resource));
+};
+
+class MockGrpcMuxFactory : public GrpcMuxFactory {
+public:
+    MockGrpcMuxFactory() {};
+    virtual ~MockGrpcMuxFactory() {};
+
+    MOCK_METHOD8(getOrCreateMux, GrpcMux*(const LocalInfo::LocalInfo &local_info, Grpc::AsyncClientPtr async_client,
+            Event::Dispatcher &dispatcher, const Protobuf::MethodDescriptor &service_method,
+            Runtime::RandomGenerator &random, const ::envoy::api::v2::core::ApiConfigSource& config_source,
+            Stats::Scope& scope, std::string type_url));
 };
 
 } // namespace Config

--- a/test/mocks/config/mocks.h
+++ b/test/mocks/config/mocks.h
@@ -80,7 +80,7 @@ public:
     MockGrpcMuxFactory() {};
     virtual ~MockGrpcMuxFactory() {};
 
-    MOCK_METHOD8(getOrCreateMux, GrpcMux*(const LocalInfo::LocalInfo &local_info, Grpc::AsyncClientPtr async_client,
+    MOCK_METHOD8(getOrCreateMux, GrpcMux&(const LocalInfo::LocalInfo &local_info, Grpc::AsyncClientPtr async_client,
             Event::Dispatcher &dispatcher, const Protobuf::MethodDescriptor &service_method,
             Runtime::RandomGenerator &random, const ::envoy::api::v2::core::ApiConfigSource& config_source,
             Stats::Scope& scope, std::string type_url));

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -268,6 +268,7 @@ public:
   MOCK_METHOD0(shutdown, void());
   MOCK_CONST_METHOD0(bindConfig, const envoy::api::v2::core::BindConfig&());
   MOCK_METHOD0(adsMux, Config::GrpcMux&());
+  MOCK_METHOD0(muxFactory, Config::GrpcMuxFactory&());
   MOCK_METHOD0(grpcAsyncClientManager, Grpc::AsyncClientManager&());
   MOCK_CONST_METHOD0(versionInfo, const std::string());
   MOCK_CONST_METHOD0(localClusterName, const std::string&());
@@ -280,6 +281,7 @@ public:
   NiceMock<MockThreadLocalCluster> thread_local_cluster_;
   envoy::api::v2::core::BindConfig bind_config_;
   NiceMock<Config::MockGrpcMux> ads_mux_;
+  NiceMock<Config::MockGrpcMuxFactory> mux_factory_;
   NiceMock<Grpc::MockAsyncClientManager> async_client_manager_;
   std::string local_cluster_name_;
   NiceMock<MockClusterManagerFactory> cluster_manager_factory_;


### PR DESCRIPTION
* rebased
* GrpcMuxFactory.getOrCreateMux uses type_url to differentiate between resources

@htuch: https://github.com/dmitri-d/envoy/commit/aefebec5c2154ef474d76403bf8d8e80c1aa3e45#diff-c0c965f7fd55bbb5ef55f13321e43270R344 is this what you had in mind when you commented on insufficiency of cluster_name/target_uri for map keys? 