### PR TITLE
retry: handle all unhealthy upstreams in other_priority plugin

### DIFF
--- a/api/envoy/config/retry/other_priority/other_priority_config.proto
+++ b/api/envoy/config/retry/other_priority/other_priority_config.proto
@@ -21,6 +21,9 @@ package envoy.config.retry.other_priority;
 // Attempt 3: P0 (no healthy priorities, reset)
 // Attempt 4: P2
 //
+// In the case of all upstream hosts being unhealthy, no adjustments will be made to the original
+// priority load, so behavior should be identical to not using this plugin.
+//
 // Using this PriorityFilter requires rebuilding the priority load, which runs in O(# of
 // priorities), which might incur significant overhead for clusters with many priorities.
 message OtherPriorityConfig {

--- a/source/extensions/retry/priority/other_priority/other_priority.cc
+++ b/source/extensions/retry/priority/other_priority/other_priority.cc
@@ -22,21 +22,18 @@ const Upstream::PriorityLoad& OtherPriorityRetryPriority::determinePriorityLoad(
       excluded_priorities_[priority] = true;
     }
 
-    adjustForAttemptedPriorities(priority_set);
+    if (!adjustForAttemptedPriorities(priority_set)) {
+      return original_priority_load;
+    }
   }
 
   return per_priority_load_;
 }
 
-void OtherPriorityRetryPriority::adjustForAttemptedPriorities(
+bool OtherPriorityRetryPriority::adjustForAttemptedPriorities(
     const Upstream::PrioritySet& priority_set) {
   for (auto& host_set : priority_set.hostSetsPerPriority()) {
     recalculatePerPriorityState(host_set->priority(), priority_set);
-  }
-
-  // If all priorities are unhealthy to begin with, there's nothing to do.
-  if (!std::accumulate(per_priority_load_.begin(), per_priority_load_.end(), 0)) {
-    return;
   }
 
   auto adjustedHealthAndSum = adjustedHealth();
@@ -55,6 +52,13 @@ void OtherPriorityRetryPriority::adjustForAttemptedPriorities(
   const auto& adjusted_per_priority_health = adjustedHealthAndSum.first;
   auto total_health = adjustedHealthAndSum.second;
 
+  // If total health is still zero at this point, it must mean that the original cluster is
+  // completely unhealthy. If so, fall back to using the original priority set. This mantains
+  // whatever handling the default LB uses when all priorities are unhealthy.
+  if (total_health == 0) {
+    return false;
+  }
+
   std::fill(per_priority_load_.begin(), per_priority_load_.end(), 0);
   // We then adjust the load by rebalancing priorities with the adjusted health values.
   size_t total_load = 100;
@@ -70,14 +74,15 @@ void OtherPriorityRetryPriority::adjustForAttemptedPriorities(
       total_load -= delta;
     }
   }
+
+  return true;
 }
 
 std::pair<std::vector<uint32_t>, uint32_t> OtherPriorityRetryPriority::adjustedHealth() const {
   // Create an adjusted health view of the priorities, where attempted priorities are
   // given a zero weight.
   uint32_t total_health = 0;
-  std::vector<uint32_t> adjusted_per_priority_health(per_priority_health_.size());
-  adjusted_per_priority_health.resize(per_priority_health_.size());
+  std::vector<uint32_t> adjusted_per_priority_health(per_priority_health_.size(), 0);
 
   for (size_t i = 0; i < per_priority_health_.size(); ++i) {
     if (!excluded_priorities_[i]) {

--- a/source/extensions/retry/priority/other_priority/other_priority.cc
+++ b/source/extensions/retry/priority/other_priority/other_priority.cc
@@ -52,7 +52,7 @@ bool OtherPriorityRetryPriority::adjustForAttemptedPriorities(
   const auto& adjusted_per_priority_health = adjustedHealthAndSum.first;
   auto total_health = adjustedHealthAndSum.second;
 
-  // If total health is still zero at this point, it must mean that the original cluster is
+  // If total health is still zero at this point, it must mean that the all clusters is
   // completely unhealthy. If so, fall back to using the original priority set. This mantains
   // whatever handling the default LB uses when all priorities are unhealthy.
   if (total_health == 0) {

--- a/source/extensions/retry/priority/other_priority/other_priority.cc
+++ b/source/extensions/retry/priority/other_priority/other_priority.cc
@@ -52,7 +52,7 @@ bool OtherPriorityRetryPriority::adjustForAttemptedPriorities(
   const auto& adjusted_per_priority_health = adjustedHealthAndSum.first;
   auto total_health = adjustedHealthAndSum.second;
 
-  // If total health is still zero at this point, it must mean that the all clusters is
+  // If total health is still zero at this point, it must mean that the all clusters are
   // completely unhealthy. If so, fall back to using the original priority set. This mantains
   // whatever handling the default LB uses when all priorities are unhealthy.
   if (total_health == 0) {

--- a/source/extensions/retry/priority/other_priority/other_priority.cc
+++ b/source/extensions/retry/priority/other_priority/other_priority.cc
@@ -52,7 +52,7 @@ bool OtherPriorityRetryPriority::adjustForAttemptedPriorities(
   const auto& adjusted_per_priority_health = adjustedHealthAndSum.first;
   auto total_health = adjustedHealthAndSum.second;
 
-  // If total health is still zero at this point, it must mean that the all clusters are
+  // If total health is still zero at this point, it must mean that all clusters are
   // completely unhealthy. If so, fall back to using the original priority set. This mantains
   // whatever handling the default LB uses when all priorities are unhealthy.
   if (total_health == 0) {

--- a/source/extensions/retry/priority/other_priority/other_priority.h
+++ b/source/extensions/retry/priority/other_priority/other_priority.h
@@ -35,7 +35,9 @@ private:
 
   // Distributes priority load between priorities that should be considered after
   // excluding attempted priorities.
-  void adjustForAttemptedPriorities(const Upstream::PrioritySet& priority_set);
+  // @return whether the adjustment was succesful. If not, the original priority load should be
+  // used.
+  bool adjustForAttemptedPriorities(const Upstream::PrioritySet& priority_set);
 
   const uint32_t update_frequency_;
   std::vector<uint32_t> attempted_priorities_;

--- a/source/extensions/retry/priority/other_priority/other_priority.h
+++ b/source/extensions/retry/priority/other_priority/other_priority.h
@@ -35,7 +35,7 @@ private:
 
   // Distributes priority load between priorities that should be considered after
   // excluding attempted priorities.
-  // @return whether the adjustment was succesful. If not, the original priority load should be
+  // @return whether the adjustment was successful. If not, the original priority load should be
   // used.
   bool adjustForAttemptedPriorities(const Upstream::PrioritySet& priority_set);
 


### PR DESCRIPTION
This fixes a bug in the other priority plugin that would cause a crash
when retries were attempted when the upstream had no healthy hosts. The
existing check for no healthy was ineffective due to the "everything is
terrible" fallback in the `LoadBalancerBase` which sets P0 to 100 when all
the priorities are unhealthy.

The fix is to check for healthy % based on the loads computed in the
plugin, not the ones returned by `LoadBalancerBase`. When all hosts are
unhealthy, we return the original priority load. This ensures that we
maintain whatever fallback the default LB uses when there are no
unhealthy hosts.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Medium
*Testing*: Added regression test for no unhealthy hosts
*Docs Changes*: n/a
*Release Notes*: n/a
