### PR TITLE
upstream: handle empty localities

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -273,7 +273,9 @@ double HostSetImpl::effectiveLocalityWeight(uint32_t index) const {
   ASSERT(hosts_per_locality_ != nullptr);
   const auto& locality_hosts = hosts_per_locality_->get()[index];
   const auto& locality_healthy_hosts = healthy_hosts_per_locality_->get()[index];
-  ASSERT(!locality_hosts.empty());
+  if (locality_hosts.empty()) {
+    return 0.0;
+  }
   const double locality_healthy_ratio = 1.0 * locality_healthy_hosts.size() / locality_hosts.size();
   const uint32_t weight = (*locality_weights_)[index];
   // Health ranges from 0-1.0, and is the ratio of healthy hosts to total hosts, modified by the

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1838,6 +1838,7 @@ TEST_F(HostSetImplLocalityTest, EmptyLocality) {
   auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
   host_set_.updateHosts(hosts, hosts, hosts_per_locality, hosts_per_locality, locality_weights, {},
                         {}, absl::nullopt);
+  // Verify that we are not RRing between localities.
   EXPECT_EQ(0, host_set_.chooseLocality().value());
   EXPECT_EQ(0, host_set_.chooseLocality().value());
 }

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1836,8 +1836,8 @@ TEST_F(HostSetImplLocalityTest, EmptyLocality) {
       makeHostsPerLocality({{hosts_[0], hosts_[1], hosts_[2]}, {}});
   LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{1, 1}};
   auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
-  host_set_.updateHosts(hosts, hosts, hosts_per_locality,
-                        hosts_per_locality, locality_weights, {}, {}, absl::nullopt);
+  host_set_.updateHosts(hosts, hosts, hosts_per_locality, hosts_per_locality, locality_weights, {},
+                        {}, absl::nullopt);
   EXPECT_EQ(0, host_set_.chooseLocality().value());
   EXPECT_EQ(0, host_set_.chooseLocality().value());
 }

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1830,6 +1830,18 @@ TEST_F(HostSetImplLocalityTest, AllUnhealthy) {
   EXPECT_FALSE(host_set_.chooseLocality().has_value());
 }
 
+// When a locality has zero hosts, it should be treated as if it has zero healthy.
+TEST_F(HostSetImplLocalityTest, EmptyLocality) {
+  HostsPerLocalitySharedPtr hosts_per_locality =
+      makeHostsPerLocality({{hosts_[0], hosts_[1], hosts_[2]}, {}});
+  LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{1, 1}};
+  auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
+  host_set_.updateHosts(hosts, hosts, hosts_per_locality,
+                        hosts_per_locality, locality_weights, {}, {}, absl::nullopt);
+  EXPECT_EQ(0, host_set_.chooseLocality().value());
+  EXPECT_EQ(0, host_set_.chooseLocality().value());
+}
+
 // When all locality weights are zero we should fail to select a locality.
 TEST_F(HostSetImplLocalityTest, AllZeroWeights) {
   HostsPerLocalitySharedPtr hosts_per_locality = makeHostsPerLocality({{hosts_[0]}, {hosts_[1]}});


### PR DESCRIPTION
This changes the handling of empty localities: instead of ASSERTing that
the hosts can't be empty, treat the locality the same as if it was 100%
unhealthy. That is, we omit adding to the EDF scheduler, which ensures
that we don't retrieve an empty locality from the scheduler.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Medium, users hitting this code path would have run into an ASSERT.
*Testing*: Unit test for empty locality. Verified that it resolves the problem described in the issue.
*Docs Changes*: n/a
*Release Notes*: n/a
Fixes #4837. This is one of two suggestion solutions, please review in the context of the issue.
