### PR TITLE
config: removing deprecated_v1 from the HTTP filter config

### DIFF
--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -397,13 +397,5 @@ message HttpFilter {
   // instantiated. See the supported filters for further documentation.
   google.protobuf.Struct config = 2;
 
-  // [#not-implemented-hide:]
-  // This is hidden as type has been deprecated and is no longer required.
-  message DeprecatedV1 {
-    string type = 1;
-  }
-
-  // [#not-implemented-hide:]
-  // This is hidden as type has been deprecated and is no longer required.
-  DeprecatedV1 deprecated_v1 = 3 [deprecated = true];
+  reserved 3;
 }

--- a/configs/google_com_proxy.yaml
+++ b/configs/google_com_proxy.yaml
@@ -16,7 +16,7 @@ listeners:
             host_rewrite: www.google.com
             cluster: service_google
       filters:
-      - { type: decoder, name: router, config: {} }
+      - { name: router, config: {} }
 
 admin:
   access_log_path: /tmp/admin_access.log

--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -159,7 +159,6 @@ void FilterJson::translateHttpConnectionManager(
     // Translate v1 name to v2 name.
     filter->set_name(Extensions::HttpFilters::HttpFilterNames::get().v1_converter_.getV2Name(
         json_filter->getString("name")));
-    JSON_UTIL_SET_STRING(*json_filter, *filter->mutable_deprecated_v1(), type);
 
     const std::string deprecated_config =
         "{\"deprecated_v1\": true, \"value\": " + json_filter->getObject("config")->asJsonString() +

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -272,10 +272,6 @@ const std::string Json::Schema::HTTP_CONN_NETWORK_FILTER_SCHEMA(R"EOF(
       "filters" : {
         "type" : "object",
         "properties" : {
-          "type": {
-            "type" : "string",
-            "enum" : ["encoder", "decoder", "both"]
-          },
           "name" : {"type": "string"},
           "config": {"type" : "object"}
         },

--- a/test/config/integration/server.yaml
+++ b/test/config/integration/server.yaml
@@ -42,17 +42,14 @@ static_resources:
             codec_type: http1
             stat_prefix: router
             filters:
-            - type: both
-              name: health_check
+            - name: health_check
               config:
                 endpoint: "/healthcheck"
                 pass_through_mode: false
-            - type: decoder
-              name: rate_limit
+            - name: rate_limit
               config:
                 domain: foo
-            - type: decoder
-              name: router
+            - name: router
               config: {}
             access_log:
             - format: '[%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%
@@ -84,17 +81,14 @@ static_resources:
         config:
           value:
             filters:
-            - type: both
-              name: health_check
+            - name: health_check
               config:
                 endpoint: "/healthcheck"
                 pass_through_mode: false
             - name: rate_limit
               config:
                 domain: foo
-              type: decoder
-            - type: decoder
-              name: router
+            - name: router
               config: {}
             access_log:
             - filter:
@@ -177,7 +171,6 @@ static_resources:
             filters:
             - name: router
               config: {}
-              type: decoder
             codec_type: http1
             stat_prefix: router
           deprecated_v1: true
@@ -194,12 +187,10 @@ static_resources:
         config:
           value:
             filters:
-            - type: both
-              name: http_dynamo_filter
+            - name: http_dynamo_filter
               config: {}
             - name: router
               config: {}
-              type: decoder
             codec_type: http1
             stat_prefix: router
             route_config:
@@ -232,11 +223,9 @@ static_resources:
                 - prefix: "/test/long/url"
                   cluster: cluster_3
             filters:
-            - type: both
-              name: grpc_http1_bridge
+            - name: grpc_http1_bridge
               config: {}
-            - type: decoder
-              name: router
+            - name: router
               config: {}
             codec_type: http1
             stat_prefix: router
@@ -286,22 +275,18 @@ static_resources:
             codec_type: http1
             stat_prefix: router
             filters:
-            - type: both
-              name: health_check
+            - name: health_check
               config:
                 endpoint: "/healthcheck"
                 pass_through_mode: false
             - name: rate_limit
               config:
                 domain: foo
-              type: decoder
             - name: buffer
               config:
                 max_request_time_s: 120
                 max_request_bytes: 5242880
-              type: decoder
             - config: {}
-              type: decoder
               name: router
             access_log:
             - filter:
@@ -333,8 +318,7 @@ static_resources:
         config:
           value:
             filters:
-            - type: decoder
-              name: router
+            - name: router
               config: {}
             codec_type: http1
             stat_prefix: rds_dummy

--- a/test/config/integration/server_unix_listener.yaml
+++ b/test/config/integration/server_unix_listener.yaml
@@ -9,8 +9,7 @@ static_resources:
         config:
           value:
             filters:
-            - type: decoder
-              name: router
+            - name: router
               config: {}
             codec_type: auto
             stat_prefix: router


### PR DESCRIPTION
This makes marking filters as encoder/decoder/both illegal.

*Risk Level*: Medium (breaking change for old configs)
*Testing*: existing tests pass including legacy json tests (with modified config)
*Docs Changes*: No 
*Release Notes*: Not currently