### PR TITLE
config: deprecating legacy REST api

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -9,6 +9,7 @@ A logged warning is expected for each deprecated item that is in deprecation win
 ## Version 1.9.0 (pending)
 
 * Order of execution of the encoder filter chain has been reversed. Prior to this release cycle it was incorrect, see [#4599](https://github.com/envoyproxy/envoy/issues/4599). In the 1.9.0 release cycle we introduced `bugfix_reverse_encode_order` in [http_connection_manager.proto] (https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto) to temporarily support both old and new behaviors. Note this boolean field is deprecated.
+* Use of the v1 REST_LEGACY ApiConfigSource is deprecated.
 
 ## Version 1.8.0 (Oct 4, 2018)
 

--- a/api/envoy/api/v2/core/config_source.proto
+++ b/api/envoy/api/v2/core/config_source.proto
@@ -19,7 +19,7 @@ message ApiConfigSource {
   // APIs may be fetched via either REST or gRPC.
   enum ApiType {
     // REST-JSON legacy corresponds to the v1 API.
-    REST_LEGACY = 0;
+    REST_LEGACY = 0 [deprecated = true];
     // REST-JSON v2 API. The `canonical JSON encoding
     // <https://developers.google.com/protocol-buffers/docs/proto3#json>`_ for
     // the v2 protos is used.


### PR DESCRIPTION
*Risk Level*: Low (docs update + proto deprecation)
*Testing*: n/a
*Docs Changes*: n/a
*Release Notes*: n/a
*Deprecated*: the REST_LEGACY api source.
