### PR TITLE
docs: fix typo

### DIFF
--- a/source/extensions/resource_monitors/well_known_names.h
+++ b/source/extensions/resource_monitors/well_known_names.h
@@ -7,7 +7,7 @@ namespace Extensions {
 namespace ResourceMonitors {
 
 /**
- * Well-known resource monior names.
+ * Well-known resource monitor names.
  * NOTE: New resource monitors should use the well known name: envoy.resource_monitors.name.
  */
 class ResourceMonitorNameValues {


### PR DESCRIPTION
Signed-off-by: josedonizetti <jdbjunior@gmail.com>

Docs Changes: Fix typo on the `resource_monitors/well_know_names.h` documentation.

Let me know if those small PRs do make sense. I'm considering grouping only when I find multiple typos on the same file.