### PR TITLE
access_log: Use general string class and utilities to avoid problems for Google import

### DIFF
--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -91,8 +91,8 @@ std::string JsonFormatterImpl::format(const Http::HeaderMap& request_headers,
     (*output_struct.mutable_fields())[pair.first] = string_value;
   }
 
-  std::string log_line;
-  const auto conversion_status = ProtobufUtil::MessageToJsonString(output_struct, &log_line);
+  ProtobufTypes::String log_line;
+  const auto conversion_status = Protobuf::util::MessageToJsonString(output_struct, &log_line);
   if (!conversion_status.ok()) {
     log_line =
         fmt::format("Error serializing access log to JSON: {}", conversion_status.ToString());


### PR DESCRIPTION



*Description*: 
Change types used in a new function in access_log_formatter.cc to match other uses in the same
file (and avoid problems for Google import).

*Risk Level*: Low; no functionality change and minimal code change.

*Testing*: Existing tests.

*Docs Changes*: None
*Release Notes*: None
