### PR TITLE
ci: add tcpdump to CI image.

### DIFF
--- a/ci/build_container/build_container_ubuntu.sh
+++ b/ci/build_container/build_container_ubuntu.sh
@@ -6,7 +6,7 @@ set -e
 apt-get update
 export DEBIAN_FRONTEND=noninteractive
 apt-get install -y wget software-properties-common make cmake git python python-pip \
-  bc libtool ninja-build automake zip time golang g++ gdb strace wireshark tshark
+  bc libtool ninja-build automake zip time golang g++ gdb strace wireshark tshark tcpdump
 # clang 7.
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main"
@@ -19,6 +19,12 @@ curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
 apt-get update
 apt-get install -y bazel
 rm -rf /var/lib/apt/lists/*
+
+# Setup tcpdump for non-root.
+groupadd pcap
+chgrp pcap /usr/sbin/tcpdump
+chmod 750 /usr/sbin/tcpdump
+setcap cap_net_raw,cap_net_admin=eip /usr/sbin/tcpdump
 
 # virtualenv
 pip install virtualenv

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -20,6 +20,6 @@ mkdir -p "${ENVOY_DOCKER_BUILD_DIR}"
 # Since we specify an explicit hash, docker-run will pull from the remote repo if missing.
 docker run --rm -t -i -e HTTP_PROXY=${http_proxy} -e HTTPS_PROXY=${https_proxy} \
   -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build \
-  -v "$PWD":/source -e NUM_CPUS --cap-add SYS_PTRACE "${IMAGE_NAME}":"${IMAGE_ID}" \
-  /bin/bash -lc "groupadd --gid $(id -g) -f envoygroup && useradd -o --uid $(id -u) --gid $(id -g) \
-  --no-create-home --home-dir /source envoybuild && su envoybuild -c \"cd source && $*\""
+  -v "$PWD":/source -e NUM_CPUS --cap-add SYS_PTRACE --cap-add NET_RAW --cap-add NET_ADMIN "${IMAGE_NAME}":"${IMAGE_ID}" \
+  /bin/bash -lc "groupadd --gid $(id -g) -f envoygroup && useradd -o --uid $(id -u) --gid $(id -g) --no-create-home \
+  --home-dir /source envoybuild && usermod -a -G pcap envoybuild && su envoybuild -c \"cd source && $*\""


### PR DESCRIPTION
Needed to support https://github.com/envoyproxy/envoy/pull/4849. Also
some run_envoy_docker.sh support to manage the required perms.

Signed-off-by: Harvey Tuch <htuch@google.com>