### PR TITLE
docs: Improve ext_authz_filter docs

### DIFF
--- a/docs/root/configuration/http_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/http_filters/ext_authz_filter.rst
@@ -8,10 +8,10 @@ External Authorization
 The external authorization HTTP filter calls an external gRPC or HTTP service to check if the incoming
 HTTP request is authorized or not.
 If the request is deemed unauthorized then the request will be denied normally with 403 (Forbidden) response.
-Note that sending additional custom metadata from the authorization service to the upstream, to the downstream or to the authorization service is 
+Note that sending additional custom metadata from the authorization service to the upstream, to the downstream or to the authorization service is
 also possible. This is explained in more details at :ref:`HTTP filter <envoy_api_msg_config.filter.http.ext_authz.v2alpha.ExtAuthz>`.
 
-The content of the requests that are passed to an authorization service is specified by 
+The content of the requests that are passed to an authorization service is specified by
 :ref:`CheckRequest <envoy_api_msg_service.auth.v2alpha.CheckRequest>`.
 
 .. _config_http_filters_ext_authz_http_configuration:
@@ -31,8 +31,11 @@ A sample filter configuration for a gRPC authorization server:
     - name: envoy.ext_authz
       config:
         grpc_service:
-           envoy_grpc:
-             cluster_name: ext-authz
+          envoy_grpc:
+            cluster_name: ext-authz
+
+          # Default is 200ms; override if your server needs e.g. warmup time.
+          timeout: 0.5s
 
 .. code-block:: yaml
 
@@ -42,6 +45,9 @@ A sample filter configuration for a gRPC authorization server:
       http2_protocol_options: {}
       hosts:
         - socket_address: { address: 127.0.0.1, port_value: 10003 }
+
+      # This timeout controls the initial TCP handshake timeout - not the timeout for the
+      # entire request.
       connect_timeout: 0.25s
 
 A sample filter configuration for a raw HTTP authorization server:
@@ -57,9 +63,9 @@ A sample filter configuration for a raw HTTP authorization server:
               cluster: ext-authz
               timeout: 0.25s
               failure_mode_allow: false
-  
+
 .. code-block:: yaml
-  
+
   clusters:
     - name: ext-authz
       connect_timeout: 0.25s


### PR DESCRIPTION
This PR adds information on how to override the request timeout (which is sometimes more important than the connect_timeout, already mentioned.)
