### PR TITLE
Disable listeners if added after overload action has fired

### DIFF
--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -212,5 +212,6 @@ envoy_cc_library(
     name = "overload_manager_interface",
     hdrs = ["overload_manager.h"],
     deps = [
+        "//include/envoy/thread_local:thread_local_interface",
     ],
 )

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -15,10 +15,13 @@ namespace Envoy {
 namespace Server {
 
 ConnectionHandlerImpl::ConnectionHandlerImpl(spdlog::logger& logger, Event::Dispatcher& dispatcher)
-    : logger_(logger), dispatcher_(dispatcher) {}
+    : logger_(logger), dispatcher_(dispatcher), disable_listeners_(false) {}
 
 void ConnectionHandlerImpl::addListener(Network::ListenerConfig& config) {
   ActiveListenerPtr l(new ActiveListener(*this, config));
+  if (disable_listeners_) {
+    l->listener_->disable();
+  }
   listeners_.emplace_back(config.socket().localAddress(), std::move(l));
 }
 
@@ -47,12 +50,14 @@ void ConnectionHandlerImpl::stopListeners() {
 }
 
 void ConnectionHandlerImpl::disableListeners() {
+  disable_listeners_ = true;
   for (auto& listener : listeners_) {
     listener.second->listener_->disable();
   }
 }
 
 void ConnectionHandlerImpl::enableListeners() {
+  disable_listeners_ = false;
   for (auto& listener : listeners_) {
     listener.second->listener_->enable();
   }

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -169,6 +169,7 @@ private:
   Event::Dispatcher& dispatcher_;
   std::list<std::pair<Network::Address::InstanceConstSharedPtr, ActiveListenerPtr>> listeners_;
   std::atomic<uint64_t> num_connections_{};
+  bool disable_listeners_;
 };
 
 } // namespace Server


### PR DESCRIPTION
*Description*: disable newly added listeners if the "stop accepting connections" overload action has already fired
*Risk Level*: low
*Testing*: unit tests

Signed-off-by: Elisha Ziskind <eziskind@google.com>

