### PR TITLE
docs: update uses of 'SDS' to 'EDS'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ maximize the chances of your PR being merged.
 
 * As of the 1.3.0 release, the Envoy user-facing configuration and APIs are
   locked and we will not make breaking changes between official numbered
-  releases. This includes bootstrap configuration, REST/gRPC APIs (SDS, CDS, RDS,
+  releases. This includes bootstrap configuration, REST/gRPC APIs (EDS, CDS, RDS,
   etc.), and CLI switches. We will also try to not change behavioral semantics
   (e.g., HTTP header processing order), though this is harder to outright
   guarantee.

--- a/api/API_OVERVIEW.md
+++ b/api/API_OVERVIEW.md
@@ -9,7 +9,8 @@ Version 2 of the Envoy API evolves existing APIs and introduces new APIs to:
 
 * Allow for more advanced load balancing through load and resource utilization reporting to management servers.
 * Improve N^2 health check scalability issues by optionally offloading health checking to other Envoy instances.
-* Support Envoy deployment in edge, sidecar and middle proxy deployment models via changes to the listener model and CDS/SDS APIs.
+* Support Envoy deployment in edge, sidecar and middle proxy deployment models via changes to the listener model,
+  CDS API, and EDS (formerly called SDS in v1) API.
 * Allow streaming updates from the management server on change, instead of polling APIs from Envoy. gRPC APIs will be supported
   alongside JSON REST APIs to provide for this.
 * Ensure all Envoy runtime configuration is dynamically discoverable via API

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -81,7 +81,7 @@ message Cluster {
     // for an explanation.
     LOGICAL_DNS = 2;
 
-    // Refer to the :ref:`service discovery type<arch_overview_service_discovery_types_sds>`
+    // Refer to the :ref:`service discovery type<arch_overview_service_discovery_types_eds>`
     // for an explanation.
     EDS = 3;
 

--- a/api/envoy/config/bootstrap/v2/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v2/bootstrap.proto
@@ -39,7 +39,7 @@ message Bootstrap {
     // <envoy_api_field_config.bootstrap.v2.Bootstrap.DynamicResources.cds_config>`, it's necessary
     // to have some initial cluster definitions available to allow Envoy to know
     // how to speak to the management server. These cluster definitions may not
-    // use :ref:`EDS <arch_overview_dynamic_config_sds>` (i.e. they should be static
+    // use :ref:`EDS <arch_overview_dynamic_config_eds>` (i.e. they should be static
     // IP or DNS-based).
     repeated envoy.api.v2.Cluster clusters = 2 [(gogoproto.nullable) = false];
 
@@ -71,10 +71,7 @@ message Bootstrap {
 
     // [#not-implemented-hide:] Hide from docs.
     message DeprecatedV1 {
-      // This is the global :ref:`SDS <arch_overview_dynamic_config_sds>` config
-      // when using v1 REST for :ref:`CDS
-      // <arch_overview_dynamic_config_cds>`/:ref:`EDS
-      // <arch_overview_dynamic_config_sds>`.
+      // Deprecated service discovery service config for when using API v1 REST.
       envoy.api.v2.core.ConfigSource sds_config = 1;
     }
 

--- a/docs/root/api-v1/cluster_manager/cluster_manager.rst
+++ b/docs/root/api-v1/cluster_manager/cluster_manager.rst
@@ -33,7 +33,7 @@ Cluster manager :ref:`architecture overview <arch_overview_cluster_manager>`.
 
 :ref:`sds <config_cluster_manager_sds>`
   *(sometimes required, object)* If any defined clusters use the :ref:`sds
-  <arch_overview_service_discovery_types_sds>` cluster type, a global SDS configuration must be specified.
+  <config_cluster_manager_sds>` cluster type, a global SDS configuration must be specified.
 
 .. _config_cluster_manager_local_cluster_name:
 

--- a/docs/root/api-v1/cluster_manager/sds.rst
+++ b/docs/root/api-v1/cluster_manager/sds.rst
@@ -3,7 +3,7 @@
 Service discovery service
 =========================
 
-Service discovery service :ref:`architecture overview <arch_overview_service_discovery_types_sds>`.
+Service discovery service architecture overview.
 
 .. code-block:: json
 

--- a/docs/root/configuration/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/cluster_manager/cluster_stats.rst
@@ -179,7 +179,7 @@ Per service zone dynamic HTTP statistics
 ----------------------------------------
 
 If the service zone is available for the local service (via :option:`--service-zone`)
-and the :ref:`upstream cluster <arch_overview_service_discovery_types_sds>`,
+and the :ref:`upstream cluster <arch_overview_service_discovery_types_eds>`,
 Envoy will track the following statistics in *cluster.<name>.zone.<from_zone>.<to_zone>.* namespace.
 
 .. csv-table::

--- a/docs/root/configuration/overview/v2_overview.rst
+++ b/docs/root/configuration/overview/v2_overview.rst
@@ -107,7 +107,7 @@ Mostly static with dynamic EDS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A bootstrap config that continues from the above example with :ref:`dynamic endpoint
-discovery <arch_overview_dynamic_config_sds>` via an
+discovery <arch_overview_dynamic_config_eds>` via an
 :ref:`EDS<envoy_api_file_envoy/api/v2/eds.proto>` gRPC management server listening
 on 127.0.0.3:5678 is provided below:
 

--- a/docs/root/install/ref_configs.rst
+++ b/docs/root/install/ref_configs.rst
@@ -42,7 +42,7 @@ information on how the different expansions work.
 
 A few notes about the example configurations:
 
-* An instance of :ref:`service discovery service <arch_overview_service_discovery_types_sds>` is assumed
+* An instance of :ref:`endpoint discovery service <arch_overview_service_discovery_types_eds>` is assumed
   to be running at `discovery.yourcompany.net`.
 * DNS for `yourcompany.net` is assumed to be setup for various things. Search the configuration
   templates for different instances of this.

--- a/docs/root/intro/arch_overview/dynamic_configuration.rst
+++ b/docs/root/intro/arch_overview/dynamic_configuration.rst
@@ -27,22 +27,20 @@ via the built in :ref:`hot restart <arch_overview_hot_restart>` mechanism.
 Though simplistic, fairly complicated deployments can be created using static configurations and
 graceful hot restarts.
 
-.. _arch_overview_dynamic_config_sds:
+.. _arch_overview_dynamic_config_eds:
 
-SDS/EDS only
+EDS only
 ------------
 
-The :ref:`service discovery service (SDS) API <config_cluster_manager_sds>` provides a more advanced
-mechanism by which Envoy can discover members of an upstream cluster. SDS has been renamed to :ref:`Endpoint
-Discovery Service (EDS)<envoy_api_file_envoy/api/v2/eds.proto>` in the
-:ref:`v2 API <config_overview_v2_management_server>`. Layered on top of a static
-configuration, SDS allows an Envoy deployment to circumvent the limitations of DNS (maximum records
-in a response, etc.) as well as consume more information used in load balancing and routing (e.g.,
-canary status, zone, etc.).
+The :ref:`Endpoint Discovery Service (EDS) API <envoy_api_file_envoy/api/v2/eds.proto>` provides a
+more advanced mechanism by which Envoy can discover members of an upstream cluster.
+Layered on top of a static configuration, EDS allows an Envoy deployment to circumvent the
+limitations of DNS (maximum records in a response, etc.) as well as consume more information used in
+load balancing and routing (e.g., canary status, zone, etc.).
 
 .. _arch_overview_dynamic_config_cds:
 
-SDS/EDS and CDS
+EDS and CDS
 ---------------
 
 The :ref:`cluster discovery service (CDS) API <config_cluster_manager_cds>` layers on a mechanism by
@@ -53,32 +51,40 @@ Typically, when doing HTTP routing along with CDS (but without route discovery s
 implementors will make use of the router's ability to forward requests to a cluster specified in an
 :ref:`HTTP request header <envoy_api_field_route.RouteAction.cluster_header>`.
 
-Although it is possible to use CDS without SDS/EDS by specifying fully static clusters, we recommend
-still using the SDS/EDS API for clusters specified via CDS. Internally, when a cluster definition is
+Although it is possible to use CDS without EDS by specifying fully static clusters, we recommend
+still using the EDS API for clusters specified via CDS. Internally, when a cluster definition is
 updated, the operation is graceful. However, all existing connection pools will be drained and
-reconnected. SDS/EDS does not suffer from this limitation. When hosts are added and removed via SDS/EDS,
-the existing hosts in the cluster are unaffected.
+reconnected. EDS does not suffer from this limitation. When hosts are added and removed via EDS, the
+existing hosts in the cluster are unaffected.
 
 .. _arch_overview_dynamic_config_rds:
 
-SDS/EDS, CDS, and RDS
+EDS, CDS, and RDS
 ---------------------
 
-The :ref:`route discovery service (RDS) API <config_http_conn_man_rds>` layers on a mechanism by which
-Envoy can discover the entire route configuration for an HTTP connection manager filter at runtime.
-The route configuration will be gracefully swapped in without affecting existing requests. This API,
-when used alongside SDS/EDS and CDS, allows implementors to build a complex routing topology
+The :ref:`route discovery service (RDS) API <config_http_conn_man_rds>` layers on a mechanism by
+which Envoy can discover the entire route configuration for an HTTP connection manager filter at
+runtime. The route configuration will be gracefully swapped in without affecting existing requests.
+This API, when used alongside EDS and CDS, allows implementors to build a complex routing topology
 (:ref:`traffic shifting <config_http_conn_man_route_table_traffic_splitting>`, blue/green
-deployment, etc.) that will not require any Envoy restarts other than to obtain a new Envoy binary.
+deployment, etc).
 
 .. _arch_overview_dynamic_config_lds:
 
-SDS/EDS, CDS, RDS, and LDS
+EDS, CDS, RDS, and LDS
 --------------------------
 
 The :ref:`listener discovery service (LDS) <config_overview_lds>` layers on a mechanism by which
 Envoy can discover entire listeners at runtime. This includes all filter stacks, up to and including
 HTTP filters with embedded references to :ref:`RDS <config_http_conn_man_rds>`. Adding LDS into
 the mix allows almost every aspect of Envoy to be dynamically configured. Hot restart should
-only be required for very rare configuration changes (admin, tracing driver, etc.) or binary
-updates.
+only be required for very rare configuration changes (admin, tracing driver, etc.), certificate
+rotation, or binary updates.
+
+EDS, CDS, RDS, LDS, and SDS
+-----------------------------
+
+The :ref:`secret discovery service (SDS) <config_secret_discovery_service>` layers on a mechanism
+by which Envoy can discover cryptographic secrets (certificate plus private key, TLS session
+ticket keys) for its listeners, as well as configuration of peer certificate validation logic
+(trusted root certs, revocations, etc).

--- a/docs/root/intro/arch_overview/grpc.rst
+++ b/docs/root/intro/arch_overview/grpc.rst
@@ -45,7 +45,7 @@ The Envoy gRPC client is a minimal custom implementation of gRPC that makes use
 of Envoy's HTTP/2 upstream connection management. Services are specified as
 regular Envoy :ref:`clusters <arch_overview_cluster_manager>`, with regular
 treatment of :ref:`timeouts, retries <arch_overview_http_conn_man>`, endpoint
-:ref:`discovery <arch_overview_dynamic_config_sds>`/:ref:`load
+:ref:`discovery <arch_overview_dynamic_config_eds>`/:ref:`load
 balancing/failover <arch_overview_load_balancing>`/load reporting, :ref:`circuit
 breaking <arch_overview_circuit_break>`, :ref:`health checks
 <arch_overview_health_checking>`, :ref:`outlier detection

--- a/docs/root/intro/arch_overview/health_checking.rst
+++ b/docs/root/intro/arch_overview/health_checking.rst
@@ -5,7 +5,7 @@ Health checking
 
 Active health checking can be :ref:`configured <config_cluster_manager_cluster_hc>` on a per
 upstream cluster basis. As described in the :ref:`service discovery
-<arch_overview_service_discovery>` section, active health checking and the SDS service discovery
+<arch_overview_service_discovery>` section, active health checking and the EDS service discovery
 type go hand in hand. However, there are other scenarios where active health checking is desired
 even when using the other service discovery types. Envoy supports three different types of health
 checking along with various settings (check interval, failures required before marking a host

--- a/docs/root/intro/arch_overview/init.rst
+++ b/docs/root/intro/arch_overview/init.rst
@@ -7,7 +7,7 @@ accepting new connections.
 
 * During startup, the :ref:`cluster manager <arch_overview_cluster_manager>` goes through a
   multi-phase initialization where it first initializes static/DNS clusters, then predefined
-  :ref:`SDS <arch_overview_dynamic_config_sds>` clusters. Then it initializes
+  :ref:`EDS <arch_overview_dynamic_config_eds>` clusters. Then it initializes
   :ref:`CDS <arch_overview_dynamic_config_cds>` if applicable, waits for one response (or failure),
   and does the same primary/secondary initialization of CDS provided clusters.
 * If clusters use :ref:`active health checking <arch_overview_health_checking>`, Envoy also does a

--- a/docs/root/intro/arch_overview/service_discovery.rst
+++ b/docs/root/intro/arch_overview/service_discovery.rst
@@ -84,28 +84,14 @@ preferred service discovery mechanism for a few reasons:
   load balancing weight, canary status, zone, etc. These additional attributes are used globally
   by the Envoy mesh during load balancing, statistic gathering, etc.
 
+The Envoy project provides reference gRPC implementations of EDS and
+:ref:`other discovery services <arch_overview_dynamic_config>`
+in both `Java <https://github.com/envoyproxy/java-control-plane>`_
+and `Go <https://github.com/envoyproxy/go-control-plane>`_.
+
 Generally active health checking is used in conjunction with the eventually consistent service
 discovery service data to making load balancing and routing decisions. This is discussed further in
 the following section.
-
-.. _arch_overview_service_discovery_types_sds:
-
-Service discovery service (v1 SDS)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*(deprecated)* This discovery service was replaced to endpoint discovery service in :ref:`v2 xDS
-API<config_overview_v2>`.
-
-The *service discovery service* is a generic :ref:`REST based API <config_cluster_manager_sds_api>`
-used by Envoy to fetch cluster members. Lyft provides a reference implementation via the Python
-`discovery service <https://github.com/lyft/discovery>`_. That implementation uses AWS DynamoDB as
-the backing store, however the API is simple enough that it could easily be implemented on top of a
-variety of different backing stores.
-
-.. attention::
-
-  In the current xDS API, the word "SDS" is used as an acronym for :ref:`Secret Discovery Service
-  <config_secret_discovery_service>`.
 
 .. _arch_overview_service_discovery_eventually_consistent:
 

--- a/docs/root/intro/what_is_envoy.rst
+++ b/docs/root/intro/what_is_envoy.rst
@@ -73,10 +73,15 @@ and logging for MongoDB connections.
 NOSQL datastore. Envoy :ref:`supports <arch_overview_dynamo>` L7 sniffing and statistics production
 for DynamoDB connections.
 
-**Service discovery:** :ref:`Service discovery <arch_overview_service_discovery>` is a critical
-component of service oriented architectures. Envoy supports multiple service discovery methods
-including asynchronous DNS resolution and REST based lookup via a :ref:`service discovery service
-<arch_overview_service_discovery_types_sds>`.
+**Service discovery and dynamic configuration:** Envoy optionally consumes a layered set of
+:ref:`dynamic configuration APIs <arch_overview_dynamic_config>` for centralized management.
+The layers provide an Envoy with dynamic updates about: hosts within a backend cluster, the
+backend clusters themselves, HTTP routing, listening sockets, and cryptographic material.
+For a simpler deployment, backend host discovery can be
+:ref:`done through DNS resolution <arch_overview_service_discovery_types_strict_dns>`
+(or even
+:ref:`skipped entirely <arch_overview_service_discovery_types_static>`),
+with the further layers replaced by static config files.
 
 **Health checking:** The :ref:`recommended <arch_overview_service_discovery_eventually_consistent>`
 way of building an Envoy mesh is to treat service discovery as an eventually consistent process.
@@ -110,10 +115,6 @@ includes robust :ref:`statistics <arch_overview_statistics>` support for all sub
 sink, though plugging in a different one would not be difficult. Statistics are also viewable via
 the :ref:`administration <operations_admin_interface>` port. Envoy also supports distributed
 :ref:`tracing <arch_overview_tracing>` via thirdparty providers.
-
-**Dynamic configuration:** Envoy optionally consumes a layered set of :ref:`dynamic configuration
-APIs <arch_overview_dynamic_config>`. Implementors can use these APIs to build complex centrally
-managed deployments if desired.
 
 Design goals
 ^^^^^^^^^^^^

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -669,8 +669,8 @@ public:
 
   /**
    * @return the phase in which the cluster is initialized at boot. This mechanism is used such that
-   *         clusters that depend on other clusters can correctly initialize. (E.g., an SDS cluster
-   *         that depends on resolution of the SDS server itself).
+   *         clusters that depend on other clusters can correctly initialize. (E.g., an EDS cluster
+   *         that depends on resolution of the EDS server itself).
    */
   virtual InitializePhase initializePhase() const PURE;
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -916,7 +916,7 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(
   // new host list and raise a change notification. This uses an N^2 search given that this does not
   // happen very often and the list sizes should be small (see
   // https://github.com/envoyproxy/envoy/issues/2874). We also check for duplicates here. It's
-  // possible for DNS to return the same address multiple times, and a bad SDS implementation could
+  // possible for DNS to return the same address multiple times, and a bad EDS implementation could
   // do the same thing.
 
   // Keep track of hosts we see in new_hosts that we are able to match up with an existing host.


### PR DESCRIPTION

Signed-off-by: Fred Douglas <fredlas@google.com>

*Description*: Continuing on from #4842, which was broken by a DCO mistake. Beyond the commits in there, the current commit removes the link to the Lyft implementation of the v1 discovery service, and adds back in a mention of DNS for service discovery.
*Docs Changes*: Update SDS->EDS where appropriate: not uses of SDS that refer to S(ecret)DS, and not uses of SDS that are explicitly talking about what it used to be called in API v1. The changes are in docs and comments only.