### PR TITLE
docs: Remove references to "other_hosts" and "other_priorities"

### DIFF
--- a/docs/root/intro/arch_overview/http_connection_management.rst
+++ b/docs/root/intro/arch_overview/http_connection_management.rst
@@ -64,7 +64,7 @@ two categories:
 These plugins can be combined to affect both host selection and priority load.
 
 For example, to configure retries to prefer hosts that haven't been attempted already, the builtin
-``envoy.retry_host_predicates.other_hosts`` predicate can be used:
+``envoy.retry_host_predicates.previous_hosts`` predicate can be used:
 
 .. code-block:: yaml
 
@@ -79,7 +79,7 @@ impossible (no hosts satisfy the predicate) or very unlikely (the only suitable 
 relative weight).
 
 To configure retries to attempt other priorities during retries, the built in
-``envoy.retry_priority.other_priorities`` can be used.
+``envoy.retry_priority.previous_priorities`` can be used.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
*Description*:
The documentation makes references to `envoy.retry_host_predicates.other_hosts` and `envoy.retry_priority.other_priorities` which are nowhere to be found in the codebase outside of the one reference in the docs. I believe it should really refer to:

```
// Previous host predicate. Rejects hosts that have already been tried.
const std::string PreviousHostsPredicate = "envoy.retry_host_predicates.previous_hosts";
```

and

```
// Previous priority retry priority. Excludes previously attempted priorities during retries.
const std::string PreviousPrioritiesRetryPriority = "envoy.retry_priorities.previous_priorities";
```

*Risk Level*:
Docs

*Testing*:
doc build

*Docs Changes*:
yes

