### PR TITLE
[WIP] ci: cache bazel output for clang_tidy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,16 @@ jobs:
      steps:
        - run: rm -rf /home/circleci/project/.git # CircleCI git caching is likely broken
        - checkout
+       - restore_cache:
+           keys:
+             - clang_tidy-v1-{{ .Branch }}-{{ .Revision }}
+             - clang_tidy-v1-{{ .Branch }}-
+             - clang_tidy-v1-master-
        - run: ci/do_circle_ci.sh bazel.clang_tidy
+       - save_cache:
+           key: clang_tidy-v1-{{ .Branch }}-{{ .Revision }}
+           paths:
+             - /build/tmp
 
    format:
      executor: ubuntu-build


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

*Description*:
clang_tidy CI is slow as it needs almost a full test build + clang_tidy check. Try to use CircleCI cache to see how it make things faster. Also as a experiment for other builds.

*Risk Level*: Low
*Testing*: CI
*Docs Changes*: N/A
*Release Notes*: N/A
