### PR TITLE
Stats speed test

### DIFF
--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -116,8 +116,10 @@ envoy_cc_test_binary(
     ],
     deps = [
         ":stat_test_utility_lib",
+        "//source/common/common:thread_lib",
+        "//source/common/event:dispatcher_lib",
         "//source/common/stats:thread_local_store_lib",
-        "//test/mocks/event:event_mocks",
-        "//test/mocks/thread_local:thread_local_mocks",
+        "//source/common/thread_local:thread_local_lib",
+        "//test/test_common:simulated_time_system_lib",
     ],
 )

--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -3,6 +3,7 @@ licenses(["notice"])  # Apache 2
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",
+    "envoy_cc_test_binary",
     "envoy_cc_test_library",
     "envoy_package",
 )
@@ -103,5 +104,20 @@ envoy_cc_test(
         "//test/test_common:logging_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/metrics/v2:stats_cc",
+    ],
+)
+
+envoy_cc_test_binary(
+    name = "thread_local_store_speed_test",
+    srcs = ["thread_local_store_speed_test.cc"],
+    external_deps = [
+        "abseil_strings",
+        "benchmark",
+    ],
+    deps = [
+        ":stat_test_utility_lib",
+        "//source/common/stats:thread_local_store_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/thread_local:thread_local_mocks",
     ],
 )

--- a/test/common/stats/thread_local_store_speed_test.cc
+++ b/test/common/stats/thread_local_store_speed_test.cc
@@ -76,6 +76,9 @@ BENCHMARK(BM_StatsWithTls);
 // TODO(jmarantz): add multi-threaded variant of this test, that aggressively
 // looks up stats in multiple threads to try to trigger contention issues.
 
+// TODO(jmarantz): add version using the RawStatDataAllocator, or better yet,
+// the full hot-restart mechanism so that actual shared-memory is used.
+
 // Boilerplate main(), which discovers benchmarks in the same file and runs them.
 int main(int argc, char** argv) {
   benchmark::Initialize(&argc, argv);

--- a/test/common/stats/thread_local_store_speed_test.cc
+++ b/test/common/stats/thread_local_store_speed_test.cc
@@ -22,7 +22,7 @@ public:
 
   ~ThreadLocalStorePerf() {
     store_.shutdownThreading();
-    if (tls_.get() != nullptr) {
+    if (tls_) {
       tls_->shutdownGlobalThreading();
     }
   }

--- a/test/common/stats/thread_local_store_speed_test.cc
+++ b/test/common/stats/thread_local_store_speed_test.cc
@@ -1,0 +1,68 @@
+// Note: this should be run with --compilation_mode=opt, and would benefit from a
+// quiescent system with disabled cstate power management.
+
+#include "common/stats/heap_stat_data.h"
+#include "common/stats/stats_options_impl.h"
+#include "common/stats/thread_local_store.h"
+
+#include "test/common/stats/stat_test_utility.h"
+#include "test/mocks/event/mocks.h"
+#include "test/mocks/thread_local/mocks.h"
+
+#include "testing/base/public/benchmark.h"
+
+#include "gmock/gmock.h"
+
+// NOLINT(namespace-envoy)
+
+class ThreadLocalStorePerf {
+ public:
+  ThreadLocalStorePerf() : store_(options_, heap_alloc_) {}
+
+  ~ThreadLocalStorePerf() {
+    store_.shutdownThreading();
+  }
+
+  void accessCounters() {
+    Envoy::Stats::TestUtil::forEachSampleStat(
+        1000, [this](absl::string_view name) { store_.counter(std::string(name)); });
+  }
+
+  void initThreading() {
+    store_.initializeThreading(main_thread_dispatcher_, tls_);
+  }
+
+ private:
+  Envoy::Stats::HeapStatDataAllocator heap_alloc_;
+  Envoy::Stats::StatsOptionsImpl options_;
+  Envoy::Stats::ThreadLocalStoreImpl store_;
+  testing::NiceMock<Envoy::Event::MockDispatcher> main_thread_dispatcher_;
+  testing::NiceMock<Envoy::ThreadLocal::MockInstance> tls_;
+};
+
+static void BM_StatsNoTls(benchmark::State& state) {
+  ThreadLocalStorePerf context;
+  for (auto _ : state) {
+    context.accessCounters();
+  }
+}
+BENCHMARK(BM_StatsNoTls);
+
+static void BM_StatsWithTls(benchmark::State& state) {
+  ThreadLocalStorePerf context;
+  context.initThreading();
+  for (auto _ : state) {
+    context.accessCounters();
+  }
+}
+BENCHMARK(BM_StatsWithTls);
+
+
+// Boilerplate main(), which discovers benchmarks in the same file and runs them.
+int main(int argc, char** argv) {
+  benchmark::Initialize(&argc, argv);
+  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
+    return 1;
+  }
+  benchmark::RunSpecifiedBenchmarks();
+}


### PR DESCRIPTION
*Description*: adds a speed-test measuring the single-threaded performance of the stats store with and without tls. of course every machine is different, but on mine a typical run gives results similar to this:
```
bazel-bin/test/common/stats/thread_local_store_speed_test \
 --benchmark_report_aggregates_only=true --benchmark_repetitions=100
--------------------------------------------------------------
Benchmark                       Time           CPU Iterations
--------------------------------------------------------------
BM_StatsNoTls_mean       16249144 ns   16248983 ns         37
BM_StatsNoTls_median     16176011 ns   16175443 ns         37
BM_StatsNoTls_stddev       484905 ns     484909 ns         37
BM_StatsWithTls_mean     20958468 ns   20958244 ns         30
BM_StatsWithTls_median   20899829 ns   20899217 ns         30
BM_StatsWithTls_stddev     576702 ns     576784 ns         30
```
with variances in the single-digit percent range. This should help quantify the perf impact of potential changes to the stats system, to justify #4711 and #4715

*Risk Level*: low
*Testing*: only the new test
*Docs Changes*:
*Release Notes*:

