### PR TITLE
http: inline Accept header

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -226,6 +226,7 @@ private:
  * O(1) access to these headers without even a hash lookup.
  */
 #define ALL_INLINE_HEADERS(HEADER_FUNC)                                                            \
+  HEADER_FUNC(Accept)                                                                              \
   HEADER_FUNC(AcceptEncoding)                                                                      \
   HEADER_FUNC(AccessControlRequestHeaders)                                                         \
   HEADER_FUNC(AccessControlRequestMethod)                                                          \

--- a/source/extensions/filters/http/grpc_web/grpc_web_filter.cc
+++ b/source/extensions/filters/http/grpc_web/grpc_web_filter.cc
@@ -59,7 +59,7 @@ Http::FilterHeadersStatus GrpcWebFilter::decodeHeaders(Http::HeaderMap& headers,
   }
   headers.insertContentType().value().setReference(Http::Headers::get().ContentTypeValues.Grpc);
 
-  const Http::HeaderEntry* accept = headers.get(Http::Headers::get().Accept);
+  const Http::HeaderEntry* accept = headers.Accept();
   if (accept != nullptr &&
       (Http::Headers::get().ContentTypeValues.GrpcWebText == accept->value().c_str() ||
        Http::Headers::get().ContentTypeValues.GrpcWebTextProto == accept->value().c_str())) {


### PR DESCRIPTION
Adds Accept to the list of inline headers and use the helper functions where appropriate.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Low
*Testing*: n/a
*Docs Changes*: n/a
*Release Notes*: n/a
