### PR TITLE
upstream: switching the default hash algorithm for ring hash

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -10,6 +10,7 @@ A logged warning is expected for each deprecated item that is in deprecation win
 
 * Order of execution of the encoder filter chain has been reversed. Prior to this release cycle it was incorrect, see [#4599](https://github.com/envoyproxy/envoy/issues/4599). In the 1.9.0 release cycle we introduced `bugfix_reverse_encode_order` in [http_connection_manager.proto] (https://github.com/envoyproxy/envoy/blob/master/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto) to temporarily support both old and new behaviors. Note this boolean field is deprecated.
 * Use of the v1 REST_LEGACY ApiConfigSource is deprecated.
+* Use of std::hash in the ring hash load balancer is deprecated.
 
 ## Version 1.8.0 (Oct 4, 2018)
 

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -386,12 +386,8 @@ message Cluster {
 
     // [#not-implemented-hide:] Hide from docs.
     message DeprecatedV1 {
-      // Defaults to true, meaning that std::hash is used to hash hosts onto
-      // the ketama ring. std::hash can vary by platform. For this reason,
-      // Envoy will eventually use `xxHash <https://github.com/Cyan4973/xxHash>`_
-      // by default. This field exists for
-      // migration purposes and will eventually be deprecated. Set it to false
-      // to use `xxHash <https://github.com/Cyan4973/xxHash>`_ now.
+      // Defaults to false, meaning that `xxHash <https://github.com/Cyan4973/xxHash>`_
+      // is to hash hosts onto the ketama ring.
       google.protobuf.BoolValue use_std_hash = 1;
     }
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -34,6 +34,7 @@ Version history
 * tls: add support for CRLs in :ref:`trusted_ca <envoy_api_field_auth.CertificateValidationContext.trusted_ca>`.
 * tracing: added support to the Zipkin tracer for the :ref:`b3 <config_http_conn_man_headers_b3>` single header format.
 * upstream: changed how load calculation for :ref:`priority levels<arch_overview_load_balancing_priority_levels>` and :ref:`panic thresholds<arch_overview_load_balancing_panic_threshold>` interact. As long as normalized total health is 100% panic thresholds are disregarded.
+* upstream: changed the default hash for :ref:`ring hash <envoy_api_msg_Cluster.RingHashLbConfig>` from std::hash to `xxHash <https://github.com/Cyan4973/xxHash>`_.
 
 1.8.0 (Oct 4, 2018)
 ===================

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -89,8 +89,8 @@ RingHashLoadBalancer::Ring::Ring(
   ring_.reserve(hosts.size() * hashes_per_host);
 
   const bool use_std_hash =
-      config ? PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.value().deprecated_v1(), use_std_hash, true)
-             : true;
+      config ? PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.value().deprecated_v1(), use_std_hash, false)
+             : false;
 
   char hash_key_buffer[196];
   for (const auto& host : hosts) {

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -81,7 +81,6 @@ TEST_P(RingHashLoadBalancerTest, Basic) {
 
   config_ = (envoy::api::v2::Cluster::RingHashLbConfig());
   config_.value().mutable_minimum_ring_size()->set_value(12);
-  config_.value().mutable_deprecated_v1()->mutable_use_std_hash()->set_value(false);
 
   init();
 
@@ -148,7 +147,6 @@ TEST_P(RingHashFailoverTest, BasicFailover) {
 
   config_ = (envoy::api::v2::Cluster::RingHashLbConfig());
   config_.value().mutable_minimum_ring_size()->set_value(12);
-  config_.value().mutable_deprecated_v1()->mutable_use_std_hash()->set_value(false);
   init();
 
   LoadBalancerPtr lb = lb_->factory()->create();
@@ -190,8 +188,8 @@ TEST_P(RingHashLoadBalancerTest, BasicWithStdHash) {
   hostSet().healthy_hosts_ = hostSet().hosts_;
   hostSet().runCallbacks({}, {});
 
-  // use_std_hash defaults to true so don't set it here.
   config_ = (envoy::api::v2::Cluster::RingHashLbConfig());
+  config_.value().mutable_deprecated_v1()->mutable_use_std_hash()->set_value(true);
   config_.value().mutable_minimum_ring_size()->set_value(12);
   init();
 
@@ -241,7 +239,6 @@ TEST_P(RingHashLoadBalancerTest, UnevenHosts) {
 
   config_ = (envoy::api::v2::Cluster::RingHashLbConfig());
   config_.value().mutable_minimum_ring_size()->set_value(3);
-  config_.value().mutable_deprecated_v1()->mutable_use_std_hash()->set_value(false);
   init();
 
   // hash ring:


### PR DESCRIPTION
In preparation for removing std::hash for LB (a deprecated v1 option)

*Risk Level*: Medium (changing existing code where default config was used)
*Testing*: Tweaked existing unit tests
*Docs Changes*: updated API docs
*Release Notes*: Noted in release notes
Deprecated*: std::hash in LB (already deprecated, but might as well get the bugs auto-filed for 1.9.0)
