### PR TITLE
cors: added invalid/valid stats to cors filter

### DIFF
--- a/docs/root/configuration/http_filters/cors_filter.rst
+++ b/docs/root/configuration/http_filters/cors_filter.rst
@@ -9,3 +9,20 @@ For the meaning of the headers please refer to the pages below.
 - https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
 - https://www.w3.org/TR/cors/
 - :ref:`v2 API reference <envoy_api_msg_route.CorsPolicy>`
+
+.. _cors-statistics:
+
+Statistics
+----------
+
+The CORS filter outputs statistics in the <stat_prefix>.cors.* namespace.
+
+.. note::
+  Requests that do not have an Origin header will be omitted from statistics.
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: 1, 1, 2
+
+  origin_valid, Counter, Number of requests that have a valid Origin header.
+  origin_invalid, Counter, Number of requests that have an invalid Origin header.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -10,6 +10,7 @@ Version history
   state via :ref:`circuit breakers statistics <config_cluster_manager_cluster_stats_circuit_breakers>`.
 * config: removed support for the v1 API.
 * config: added support for :ref:`rate limiting<envoy_api_msg_core.RateLimitSettings>` discovery request calls.
+* cors: added :ref: `invalid/valid stats <cors-statistics>` to filter.
 * fault: removed integer percentage support.
 * http: Added HTTP/2 WebSocket proxying via :ref:`extended CONNECT <envoy_api_field_core.Http2ProtocolOptions.allow_connect>`
 * http: added limits to the number and length of header modifications in all fields request_headers_to_add and response_headers_to_add. These limits are very high and should only be used as a last-resort safeguard.

--- a/source/extensions/filters/http/cors/config.cc
+++ b/source/extensions/filters/http/cors/config.cc
@@ -9,18 +9,20 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Cors {
 
-Http::FilterFactoryCb CorsFilterConfig::createFilter(const std::string&,
-                                                     Server::Configuration::FactoryContext&) {
-
-  return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<CorsFilter>());
+Http::FilterFactoryCb
+CorsFilterFactory::createFilter(const std::string& stats_prefix,
+                                Server::Configuration::FactoryContext& context) {
+  CorsFilterConfigSharedPtr config =
+      std::make_shared<CorsFilterConfig>(stats_prefix, context.scope());
+  return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<CorsFilter>(config));
   };
 }
 
 /**
  * Static registration for the cors filter. @see RegisterFactory.
  */
-static Registry::RegisterFactory<CorsFilterConfig,
+static Registry::RegisterFactory<CorsFilterFactory,
                                  Server::Configuration::NamedHttpFilterConfigFactory>
     register_;
 

--- a/source/extensions/filters/http/cors/config.h
+++ b/source/extensions/filters/http/cors/config.h
@@ -13,12 +13,12 @@ namespace Cors {
 /**
  * Config registration for the cors filter. @see NamedHttpFilterConfigFactory.
  */
-class CorsFilterConfig : public Common::EmptyHttpFilterConfig {
+class CorsFilterFactory : public Common::EmptyHttpFilterConfig {
 public:
-  CorsFilterConfig() : Common::EmptyHttpFilterConfig(HttpFilterNames::get().Cors) {}
+  CorsFilterFactory() : Common::EmptyHttpFilterConfig(HttpFilterNames::get().Cors) {}
 
-  Http::FilterFactoryCb createFilter(const std::string&,
-                                     Server::Configuration::FactoryContext&) override;
+  Http::FilterFactoryCb createFilter(const std::string& stats_prefix,
+                                     Server::Configuration::FactoryContext& context) override;
 };
 
 } // namespace Cors

--- a/source/extensions/filters/http/cors/cors_filter.cc
+++ b/source/extensions/filters/http/cors/cors_filter.cc
@@ -1,6 +1,7 @@
 #include "extensions/filters/http/cors/cors_filter.h"
 
 #include "envoy/http/codes.h"
+#include "envoy/stats/scope.h"
 
 #include "common/common/empty_string.h"
 #include "common/common/enum_to_int.h"
@@ -12,7 +13,11 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Cors {
 
-CorsFilter::CorsFilter() : policies_({{nullptr, nullptr}}), is_cors_request_(false) {}
+CorsFilterConfig::CorsFilterConfig(const std::string& stats_prefix, Stats::Scope& scope)
+    : stats_(generateStats(stats_prefix + "cors.", scope)) {}
+
+CorsFilter::CorsFilter(CorsFilterConfigSharedPtr config)
+    : policies_({{nullptr, nullptr}}), config_(std::move(config)) {}
 
 // This handles the CORS preflight request as described in
 // https://www.w3.org/TR/cors/#resource-preflight-requests
@@ -37,10 +42,12 @@ Http::FilterHeadersStatus CorsFilter::decodeHeaders(Http::HeaderMap& headers, bo
   }
 
   if (!isOriginAllowed(origin_->value())) {
+    config_->stats().origin_invalid_.inc();
     return Http::FilterHeadersStatus::Continue;
   }
 
   is_cors_request_ = true;
+  config_->stats().origin_valid_.inc();
 
   const auto method = headers.Method();
   if (method == nullptr || method->value().c_str() != Http::Headers::get().MethodValues.Options) {

--- a/source/extensions/filters/http/cors/cors_filter.h
+++ b/source/extensions/filters/http/cors/cors_filter.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "envoy/http/filter.h"
+#include "envoy/stats/scope.h"
+#include "envoy/stats/stats_macros.h"
 
 #include "common/buffer/buffer_impl.h"
 
@@ -9,9 +11,42 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Cors {
 
+/**
+ * All CORS filter stats. @see stats_macros.h
+ */
+// clang-format off
+#define ALL_CORS_STATS(COUNTER)\
+  COUNTER(origin_valid)        \
+  COUNTER(origin_invalid)      \
+// clang-format on
+
+/**
+ * Struct definition for CORS stats. @see stats_macros.h
+ */
+struct CorsStats {
+  ALL_CORS_STATS(GENERATE_COUNTER_STRUCT)
+};
+
+/**
+ * Configuration for the CORS filter.
+ */
+class CorsFilterConfig {
+public:
+  CorsFilterConfig(const std::string& stats_prefix, Stats::Scope& scope);
+  CorsStats& stats() { return stats_; }
+
+private:
+  static CorsStats generateStats(const std::string& prefix, Stats::Scope& scope) {
+    return CorsStats{ALL_CORS_STATS(POOL_COUNTER_PREFIX(scope, prefix))};
+  }
+
+  CorsStats stats_;
+};
+typedef std::shared_ptr<CorsFilterConfig> CorsFilterConfigSharedPtr;
+
 class CorsFilter : public Http::StreamFilter {
 public:
-  CorsFilter();
+  CorsFilter(CorsFilterConfigSharedPtr config);
 
   // Http::StreamFilterBase
   void onDestroy() override {}
@@ -61,6 +96,8 @@ private:
   std::array<const Envoy::Router::CorsPolicy*, 2> policies_;
   bool is_cors_request_{};
   const Http::HeaderEntry* origin_{};
+
+  CorsFilterConfigSharedPtr config_;
 };
 
 } // namespace Cors

--- a/test/extensions/filters/http/cors/cors_filter_test.cc
+++ b/test/extensions/filters/http/cors/cors_filter_test.cc
@@ -27,7 +27,7 @@ namespace Cors {
 class CorsFilterTest : public testing::Test {
 public:
   CorsFilterTest() : config_(new CorsFilterConfig("test.", stats_)), filter_(config_) {
-    cors_policy_.reset(new Router::TestCorsPolicy());
+    cors_policy_ = std::make_unique<Router::TestCorsPolicy>();
     cors_policy_->enabled_ = true;
     cors_policy_->allow_origin_.emplace_back("*");
     cors_policy_->allow_methods_ = "GET";

--- a/test/extensions/filters/http/cors/cors_filter_test.cc
+++ b/test/extensions/filters/http/cors/cors_filter_test.cc
@@ -4,6 +4,7 @@
 
 #include "test/mocks/buffer/mocks.h"
 #include "test/mocks/http/mocks.h"
+#include "test/mocks/stats/mocks.h"
 #include "test/test_common/printers.h"
 
 #include "gmock/gmock.h"
@@ -25,10 +26,10 @@ namespace Cors {
 
 class CorsFilterTest : public testing::Test {
 public:
-  CorsFilterTest() : filter_() {
+  CorsFilterTest() : config_(new CorsFilterConfig("test.", stats_)), filter_(config_) {
     cors_policy_.reset(new Router::TestCorsPolicy());
     cors_policy_->enabled_ = true;
-    cors_policy_->allow_origin_.push_back("*");
+    cors_policy_->allow_origin_.emplace_back("*");
     cors_policy_->allow_methods_ = "GET";
     cors_policy_->allow_headers_ = "content-type";
     cors_policy_->expose_headers_ = "content-type";
@@ -49,6 +50,8 @@ public:
 
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
+  Stats::IsolatedStoreImpl stats_;
+  CorsFilterConfigSharedPtr config_;
   CorsFilter filter_;
   Buffer::OwnedImpl data_;
   Http::TestHeaderMapImpl request_headers_;
@@ -62,6 +65,8 @@ TEST_F(CorsFilterTest, RequestWithoutOrigin) {
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
   EXPECT_EQ(false, IsCorsRequest());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
 
@@ -76,6 +81,8 @@ TEST_F(CorsFilterTest, RequestWithOrigin) {
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
   EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
+  EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
 
@@ -90,6 +97,8 @@ TEST_F(CorsFilterTest, OptionsRequestWithoutOrigin) {
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
   EXPECT_EQ(false, IsCorsRequest());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
 
@@ -104,6 +113,8 @@ TEST_F(CorsFilterTest, OptionsRequestWithOrigin) {
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
   EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
+  EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
 
@@ -122,6 +133,9 @@ TEST_F(CorsFilterTest, OptionsRequestWithOriginCorsDisabled) {
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
 
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_valid").value());
+
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(request_headers_, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.encodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(request_headers_));
@@ -133,6 +147,8 @@ TEST_F(CorsFilterTest, OptionsRequestWithOriginCorsEnabled) {
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
   EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
+  EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
 
@@ -147,6 +163,8 @@ TEST_F(CorsFilterTest, OptionsRequestWithoutRequestMethod) {
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
   EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
+  EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
 
@@ -171,6 +189,8 @@ TEST_F(CorsFilterTest, OptionsRequestMatchingOriginByWildcard) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers, false));
   EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
+  EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
 
@@ -184,11 +204,13 @@ TEST_F(CorsFilterTest, OptionsRequestNotMatchingOrigin) {
       {":method", "OPTIONS"}, {"origin", "test-host"}, {"access-control-request-method", "GET"}};
 
   cors_policy_->allow_origin_.clear();
-  cors_policy_->allow_origin_.push_back("localhost");
+  cors_policy_->allow_origin_.emplace_back("localhost");
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
   EXPECT_EQ(false, IsCorsRequest());
+  EXPECT_EQ(1, stats_.counter("test.cors.origin_invalid").value());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
 
@@ -206,6 +228,8 @@ TEST_F(CorsFilterTest, OptionsRequestEmptyOriginList) {
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
   EXPECT_EQ(false, IsCorsRequest());
+  EXPECT_EQ(1, stats_.counter("test.cors.origin_invalid").value());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
 
@@ -220,7 +244,7 @@ TEST_F(CorsFilterTest, ValidOptionsRequestWithAllowCredentialsTrue) {
 
   cors_policy_->allow_credentials_ = true;
   cors_policy_->allow_origin_.clear();
-  cors_policy_->allow_origin_.push_back("localhost");
+  cors_policy_->allow_origin_.emplace_back("localhost");
 
   Http::TestHeaderMapImpl response_headers{
       {":status", "200"},
@@ -235,6 +259,8 @@ TEST_F(CorsFilterTest, ValidOptionsRequestWithAllowCredentialsTrue) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers, false));
   EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
+  EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
 
@@ -259,6 +285,8 @@ TEST_F(CorsFilterTest, ValidOptionsRequestWithAllowCredentialsFalse) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers, false));
   EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
+  EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
 
@@ -358,7 +386,7 @@ TEST_F(CorsFilterTest, EncodeWithNonMatchingOrigin) {
   Http::TestHeaderMapImpl request_headers{{"origin", "test-host"}};
 
   cors_policy_->allow_origin_.clear();
-  cors_policy_->allow_origin_.push_back("localhost");
+  cors_policy_->allow_origin_.emplace_back("localhost");
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -378,6 +406,7 @@ TEST_F(CorsFilterTest, RedirectRoute) {
       .WillByDefault(Return(&direct_response_entry_));
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers_, false));
+  EXPECT_EQ(false, IsCorsRequest());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
 
@@ -432,6 +461,9 @@ TEST_F(CorsFilterTest, NoCorsEntry) {
       .WillByDefault(Return(nullptr));
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ(false, IsCorsRequest());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers));
 
@@ -462,6 +494,8 @@ TEST_F(CorsFilterTest, NoRouteCorsEntry) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers, false));
   EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
+  EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
 
@@ -490,6 +524,8 @@ TEST_F(CorsFilterTest, NoVHostCorsEntry) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers, false));
   EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
+  EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
 
@@ -512,13 +548,15 @@ TEST_F(CorsFilterTest, OptionsRequestMatchingOriginByRegex) {
   };
 
   cors_policy_->allow_origin_.clear();
-  cors_policy_->allow_origin_regex_.push_back(std::regex(".*"));
+  cors_policy_->allow_origin_regex_.emplace_back(std::regex(".*"));
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers, false));
   EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
+  EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
 
@@ -533,11 +571,13 @@ TEST_F(CorsFilterTest, OptionsRequestNotMatchingOriginByRegex) {
                                           {"access-control-request-method", "GET"}};
 
   cors_policy_->allow_origin_.clear();
-  cors_policy_->allow_origin_regex_.push_back(std::regex(".*.envoyproxy.io"));
+  cors_policy_->allow_origin_regex_.emplace_back(std::regex(".*.envoyproxy.io"));
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
   EXPECT_EQ(false, IsCorsRequest());
+  EXPECT_EQ(1, stats_.counter("test.cors.origin_invalid").value());
+  EXPECT_EQ(0, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_headers_));
 


### PR DESCRIPTION
*Description*: Added stats to the cors filter for invalid vs valid origin headers.
*Risk Level*: Medium
*Testing*: Unit tests were updated to include assertions around stat invocations.
*Docs Changes*: N/A
*Release Notes*: Included
