### PR TITLE
test: Added static specifier to zero-initialize structure to avoid uninit memory error.

### DIFF
--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -310,7 +310,7 @@ TEST_P(MainCommonTest, ConstructDestructLogger) {
   VERBOSE_EXPECT_NO_THROW(MainCommon main_common(argc(), argv()));
 
   const std::string logger_name = "logger";
-  spdlog::details::log_msg log_msg;
+  static spdlog::details::log_msg log_msg;
   log_msg.logger_name = &logger_name;
   log_msg.level = spdlog::level::level_enum::err;
 

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -309,11 +309,12 @@ TEST_P(AdminRequestTest, AdminRequestAfterRun) {
 TEST_P(MainCommonTest, ConstructDestructLogger) {
   VERBOSE_EXPECT_NO_THROW(MainCommon main_common(argc(), argv()));
 
+  // log_msg constructor doesn't initialize all fields, resulting in uninitialized
+  // memory accesses.  "static" is a simple way to start from zeroed memory before
+  // the constructor is run, avoiding this problem.
+  // See https://github.com/gabime/spdlog/issues/888.
   const std::string logger_name = "logger";
-  static spdlog::details::log_msg log_msg;
-  log_msg.logger_name = &logger_name;
-  log_msg.level = spdlog::level::level_enum::err;
-
+  static spdlog::details::log_msg log_msg(&logger_name, spdlog::level::level_enum::err);
   Logger::Registry::getSink()->log(log_msg);
 }
 


### PR DESCRIPTION
*Description*:

Google internal tests detected an uninitialized memory error in running the test MainCommonTest.ConstructDestructLogger.  The problem turns out to be that a structure from the external spdlog library was being used and the constructor for that structure did not initialize  all data members.  This was the only reference to that structure anywhere in the envoy code, and making the variable declaration static avoided the error (since static memory is zero-initialized before construction).

*Risk Level*:Low; very simple test change.
*Testing*:Re-run same test.
*Docs Changes*: None.
*Release Notes*: None.
[Optional Fixes #Issue]
[Optional *Deprecated*:]
