### PR TITLE
admin: convert /server_info to protobuf

### DIFF
--- a/api/envoy/admin/v2alpha/BUILD
+++ b/api/envoy/admin/v2alpha/BUILD
@@ -43,3 +43,9 @@ api_proto_library_internal(
     srcs = ["certs.proto"],
     visibility = ["//visibility:public"],
 )
+
+api_proto_library_internal(
+    name = "server_info",
+    srcs = ["server_info.proto"],
+    visibility = ["//visibility:public"],
+)

--- a/api/envoy/admin/v2alpha/server_info.proto
+++ b/api/envoy/admin/v2alpha/server_info.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package envoy.admin.v2alpha;
+
+import "google/protobuf/duration.proto";
+
+// [#protodoc-title: Server State]
+
+// Proto representation of the value returned by /server_info, containing
+// server version/server status information.
+message ServerInfo {
+  // Server version.
+  string version = 1;
+
+  enum State {
+    // Server is live and serving traffic.
+    LIVE = 0;
+    // Server is draining listeners in response to external health checks failing.
+    DRAINING = 1;
+  }
+
+  // State of the server.
+  State state = 2;
+
+  // Uptime since current epoch was started.
+  google.protobuf.Duration uptime_current_epoch = 3;
+  // Uptime since the start of the first epoch.
+  google.protobuf.Duration uptime_all_epochs = 4;
+  // Which restart epoch the server is currently in.
+  uint32 epoch = 5;
+}

--- a/source/server/http/BUILD
+++ b/source/server/http/BUILD
@@ -62,6 +62,7 @@ envoy_cc_library(
         "@envoy_api//envoy/admin/v2alpha:clusters_cc",
         "@envoy_api//envoy/admin/v2alpha:config_dump_cc",
         "@envoy_api//envoy/admin/v2alpha:memory_cc",
+        "@envoy_api//envoy/admin/v2alpha:server_info_cc",
     ],
 )
 

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "envoy/admin/v2alpha/certs.pb.h"
+#include "envoy/admin/v2alpha/server_info.pb.h"
 #include "envoy/admin/v2alpha/clusters.pb.h"
 #include "envoy/admin/v2alpha/config_dump.pb.h"
 #include "envoy/admin/v2alpha/memory.pb.h"
@@ -519,11 +520,15 @@ Http::Code AdminImpl::handlerResetCounters(absl::string_view, Http::HeaderMap&,
 Http::Code AdminImpl::handlerServerInfo(absl::string_view, Http::HeaderMap&,
                                         Buffer::Instance& response, AdminStream&) {
   time_t current_time = time(nullptr);
-  response.add(fmt::format("envoy {} {} {} {} {}\n", VersionInfo::version(),
-                           server_.healthCheckFailed() ? "draining" : "live",
-                           current_time - server_.startTimeCurrentEpoch(),
-                           current_time - server_.startTimeFirstEpoch(),
-                           server_.options().restartEpoch()));
+  envoy::admin::v2alpha::ServerInfo server_info;
+  server_info.set_version(VersionInfo::version());
+  server_info.set_state(server_.healthCheckFailed() ? envoy::admin::v2alpha::ServerInfo::DRAINING
+                                                    : envoy::admin::v2alpha::ServerInfo::LIVE);
+  server_info.mutable_uptime_current_epoch()->set_seconds(current_time -
+                                                          server_.startTimeCurrentEpoch());
+  server_info.mutable_uptime_all_epochs()->set_seconds(current_time -
+                                                       server_.startTimeFirstEpoch());
+  response.add(MessageUtil::getJsonStringFromMessage(server_info, true));
   return Http::Code::OK;
 }
 

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -3,6 +3,7 @@
 #include <unordered_map>
 
 #include "envoy/admin/v2alpha/memory.pb.h"
+#include "envoy/admin/v2alpha/server_info.pb.h"
 #include "envoy/json/json_object.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/stats/stats.h"
@@ -1091,9 +1092,14 @@ TEST_P(AdminInstanceTest, GetRequest) {
   Http::HeaderMapImpl response_headers;
   std::string body;
   EXPECT_EQ(Http::Code::OK, admin_.request("/server_info", "GET", response_headers, body));
-  EXPECT_TRUE(absl::StartsWith(body, "envoy ")) << body;
+  envoy::admin::v2alpha::ServerInfo server_info_proto;
   EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
               HasSubstr("text/plain"));
+
+  // We only test that it parses as the proto and that some fields are correct, since
+  // values such as timestamps + Envoy version are tricky to test for.
+  MessageUtil::loadFromJson(body, server_info_proto);
+  EXPECT_EQ(server_info_proto.state(), envoy::admin::v2alpha::ServerInfo::LIVE);
 }
 
 TEST_P(AdminInstanceTest, GetRequestJson) {


### PR DESCRIPTION
Converts the existing /server_info admin endpoint to be represented by a protobuf. This will make it easier to extend with new values in the future.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Low
*Testing*: Updated the existing unit test
*Docs Changes*: n/a 
*Release Notes*: n/a
Part of #4405 