### PR TITLE
fix: make headers self-contained

### DIFF
--- a/include/envoy/common/BUILD
+++ b/include/envoy/common/BUILD
@@ -27,6 +27,9 @@ envoy_cc_library(
 envoy_cc_library(
     name = "token_bucket_interface",
     hdrs = ["token_bucket.h"],
+    deps = [
+        ":time_interface",
+    ],
 )
 
 envoy_cc_library(

--- a/include/envoy/common/backoff_strategy.h
+++ b/include/envoy/common/backoff_strategy.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+
 #include "envoy/common/pure.h"
 
 namespace Envoy {

--- a/include/envoy/common/token_bucket.h
+++ b/include/envoy/common/token_bucket.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "envoy/common/pure.h"

--- a/include/envoy/config/BUILD
+++ b/include/envoy/config/BUILD
@@ -12,6 +12,7 @@ envoy_cc_library(
     name = "grpc_mux_interface",
     hdrs = ["grpc_mux.h"],
     deps = [
+        "//include/envoy/stats:stats_macros",
         "//source/common/protobuf",
     ],
 )

--- a/include/envoy/config/grpc_mux.h
+++ b/include/envoy/config/grpc_mux.h
@@ -2,7 +2,6 @@
 
 #include "envoy/common/exception.h"
 #include "envoy/common/pure.h"
-#include "envoy/stats/stats.h"
 #include "envoy/stats/stats_macros.h"
 
 #include "common/protobuf/protobuf.h"

--- a/include/envoy/event/BUILD
+++ b/include/envoy/event/BUILD
@@ -46,6 +46,7 @@ envoy_cc_library(
     name = "timer_interface",
     hdrs = ["timer.h"],
     deps = [
+        "//include/envoy/common:time_interface",
         "//source/common/common:thread_lib",
         "//source/common/event:libevent_lib",
     ],

--- a/include/envoy/event/timer.h
+++ b/include/envoy/event/timer.h
@@ -13,8 +13,6 @@
 namespace Envoy {
 namespace Event {
 
-class TimerCB;
-
 /**
  * Callback invoked when a timer event fires.
  */

--- a/include/envoy/grpc/BUILD
+++ b/include/envoy/grpc/BUILD
@@ -33,6 +33,9 @@ envoy_cc_library(
 envoy_cc_library(
     name = "google_grpc_creds_interface",
     hdrs = ["google_grpc_creds.h"],
+    external_deps = [
+        "grpc",
+    ],
     deps = [
         "@envoy_api//envoy/api/v2/core:grpc_service_cc",
     ],

--- a/include/envoy/grpc/google_grpc_creds.h
+++ b/include/envoy/grpc/google_grpc_creds.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <memory>
+
 #include "envoy/api/v2/core/grpc_service.pb.h"
 #include "envoy/common/pure.h"
-
-#include "common/config/datasource.h"
 
 #include "grpcpp/grpcpp.h"
 

--- a/include/envoy/http/query_params.h
+++ b/include/envoy/http/query_params.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <map>
 #include <string>
 

--- a/include/envoy/network/BUILD
+++ b/include/envoy/network/BUILD
@@ -74,6 +74,7 @@ envoy_cc_library(
     name = "transport_socket_interface",
     hdrs = ["transport_socket.h"],
     deps = [
+        "//include/envoy/buffer:buffer_interface",
         "//include/envoy/ssl:connection_interface",
     ],
 )
@@ -81,7 +82,11 @@ envoy_cc_library(
 envoy_cc_library(
     name = "listener_interface",
     hdrs = ["listener.h"],
-    deps = ["//include/envoy/network:listen_socket_interface"],
+    deps = [
+        ":connection_interface",
+        ":listen_socket_interface",
+        "//include/envoy/stats:stats_interface",
+    ],
 )
 
 envoy_cc_library(
@@ -89,5 +94,6 @@ envoy_cc_library(
     hdrs = ["resolver.h"],
     deps = [
         ":address_interface",
+        "@envoy_api//envoy/api/v2/core:base_cc",
     ],
 )

--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -7,8 +7,6 @@
 #include "envoy/common/exception.h"
 #include "envoy/network/connection.h"
 #include "envoy/network/listen_socket.h"
-#include "envoy/network/transport_socket.h"
-#include "envoy/ssl/context.h"
 #include "envoy/stats/scope.h"
 
 namespace Envoy {

--- a/include/envoy/registry/BUILD
+++ b/include/envoy/registry/BUILD
@@ -11,4 +11,7 @@ envoy_package()
 envoy_cc_library(
     name = "registry",
     hdrs = ["registry.h"],
+    deps = [
+        "//source/common/common:assert_lib",
+    ],
 )

--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 #include "envoy/common/exception.h"
 

--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -121,6 +121,7 @@ envoy_cc_library(
     name = "worker_interface",
     hdrs = ["worker.h"],
     deps = [
+        ":overload_manager_interface",
         "//include/envoy/server:guarddog_interface",
     ],
 )
@@ -213,5 +214,6 @@ envoy_cc_library(
     hdrs = ["overload_manager.h"],
     deps = [
         "//include/envoy/thread_local:thread_local_interface",
+        "//source/common/singleton:const_singleton",
     ],
 )

--- a/include/envoy/server/overload_manager.h
+++ b/include/envoy/server/overload_manager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <unordered_map>
 
 #include "envoy/common/pure.h"

--- a/include/envoy/singleton/instance.h
+++ b/include/envoy/singleton/instance.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 namespace Envoy {
 namespace Singleton {
 

--- a/include/envoy/ssl/certificate_validation_context_config.h
+++ b/include/envoy/ssl/certificate_validation_context_config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/include/envoy/stats/histogram.h
+++ b/include/envoy/stats/histogram.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 #include "envoy/common/pure.h"

--- a/include/envoy/stats/sink.h
+++ b/include/envoy/stats/sink.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 
 #include "envoy/common/pure.h"
 

--- a/include/envoy/stats/stats_matcher.h
+++ b/include/envoy/stats/stats_matcher.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/include/envoy/stats/timespan.h
+++ b/include/envoy/stats/timespan.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <chrono>
+#include <memory>
 
 #include "envoy/common/time.h"
+#include "envoy/stats/histogram.h"
 #include "envoy/stats/stats.h"
 
 namespace Envoy {

--- a/include/envoy/upstream/BUILD
+++ b/include/envoy/upstream/BUILD
@@ -109,6 +109,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "thread_local_cluster_interface",
     hdrs = ["thread_local_cluster.h"],
+    deps = [
+        ":load_balancer_interface",
+        ":upstream_interface",
+    ],
 )
 
 envoy_cc_library(

--- a/include/envoy/upstream/health_check_host_monitor.h
+++ b/include/envoy/upstream/health_check_host_monitor.h
@@ -2,6 +2,8 @@
 
 #include <memory>
 
+#include "envoy/common/pure.h"
+
 namespace Envoy {
 namespace Upstream {
 

--- a/include/envoy/upstream/load_balancer_type.h
+++ b/include/envoy/upstream/load_balancer_type.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "envoy/api/v2/cds.pb.h"
+#include "envoy/common/pure.h"
 
 #include "common/protobuf/protobuf.h"
 

--- a/include/envoy/upstream/thread_local_cluster.h
+++ b/include/envoy/upstream/thread_local_cluster.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "envoy/common/pure.h"
+#include "envoy/upstream/load_balancer.h"
+#include "envoy/upstream/upstream.h"
+
 namespace Envoy {
 namespace Upstream {
 

--- a/source/common/common/byte_order.h
+++ b/source/common/common/byte_order.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+
 // NOLINT(namespace-envoy)
 
 #ifdef __APPLE__

--- a/source/common/common/stl_helpers.h
+++ b/source/common/common/stl_helpers.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <algorithm>
+#include <functional>
+
 namespace Envoy {
 /**
  * See if a reference exists within a container of std::reference_wrappers.

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -56,11 +56,18 @@ envoy_cc_library(
 envoy_cc_library(
     name = "codec_helper_lib",
     hdrs = ["codec_helper.h"],
+    deps = [
+        "//include/envoy/http:codec_interface",
+        "//source/common/common:assert_lib",
+    ],
 )
 
 envoy_cc_library(
     name = "default_server_string_lib",
     hdrs = ["default_server_string.h"],
+    deps = [
+        "//source/common/common:macros",
+    ],
 )
 
 envoy_cc_library(
@@ -88,7 +95,12 @@ envoy_cc_library(
 envoy_cc_library(
     name = "conn_manager_config_interface",
     hdrs = ["conn_manager_config.h"],
-    deps = [":date_provider_lib"],
+    deps = [
+        ":date_provider_lib",
+        "//include/envoy/http:filter_interface",
+        "//include/envoy/router:rds_interface",
+        "//source/common/network:utility_lib",
+    ],
 )
 
 envoy_cc_library(

--- a/source/common/http/codec_helper.h
+++ b/source/common/http/codec_helper.h
@@ -2,6 +2,10 @@
 
 #include <vector>
 
+#include "envoy/http/codec.h"
+
+#include "common/common/assert.h"
+
 namespace Envoy {
 namespace Http {
 

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/http/filter.h"
 #include "envoy/router/rds.h"
 #include "envoy/stats/scope.h"
 

--- a/source/common/http/default_server_string.h
+++ b/source/common/http/default_server_string.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <string>
+
+#include "common/common/macros.h"
+
 namespace Envoy {
 namespace Http {
 

--- a/source/common/http/http2/metadata_interface.h
+++ b/source/common/http/http2/metadata_interface.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <unordered_map>
 
 namespace Envoy {

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -82,6 +82,9 @@ envoy_cc_library(
 envoy_cc_library(
     name = "filter_lib",
     hdrs = ["filter_impl.h"],
+    deps = [
+        "//include/envoy/network:filter_interface",
+    ],
 )
 
 envoy_cc_library(

--- a/source/common/network/filter_impl.h
+++ b/source/common/network/filter_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "envoy/network/filter.h"
+
 namespace Envoy {
 namespace Network {
 

--- a/source/common/stats/metric_impl.h
+++ b/source/common/stats/metric_impl.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "envoy/stats/stats.h"
+#include "envoy/stats/tag.h"
 
 #include "common/common/assert.h"
 

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -240,6 +240,7 @@ envoy_cc_library(
     deps = [
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/upstream:resource_manager_interface",
+        "//include/envoy/upstream:upstream_interface",
         "//source/common/common:assert_lib",
     ],
 )

--- a/source/common/upstream/edf_scheduler.h
+++ b/source/common/upstream/edf_scheduler.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstdint>
 #include <queue>
 

--- a/source/common/upstream/resource_manager_impl.h
+++ b/source/common/upstream/resource_manager_impl.h
@@ -7,6 +7,7 @@
 
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/resource_manager.h"
+#include "envoy/upstream/upstream.h"
 
 #include "common/common/assert.h"
 

--- a/source/extensions/access_loggers/well_known_names.h
+++ b/source/extensions/access_loggers/well_known_names.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "common/singleton/const_singleton.h"
 
 namespace Envoy {

--- a/source/extensions/filters/http/buffer/config.h
+++ b/source/extensions/filters/http/buffer/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/config/filter/http/buffer/v2/buffer.pb.h"
+#include "envoy/config/filter/http/buffer/v2/buffer.pb.validate.h"
 
 #include "extensions/filters/http/common/factory_base.h"
 #include "extensions/filters/http/well_known_names.h"

--- a/source/extensions/filters/http/ext_authz/config.h
+++ b/source/extensions/filters/http/ext_authz/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/config/filter/http/ext_authz/v2alpha/ext_authz.pb.h"
+#include "envoy/config/filter/http/ext_authz/v2alpha/ext_authz.pb.validate.h"
 
 #include "extensions/filters/http/common/factory_base.h"
 #include "extensions/filters/http/well_known_names.h"

--- a/source/extensions/filters/http/fault/config.h
+++ b/source/extensions/filters/http/fault/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/config/filter/http/fault/v2/fault.pb.h"
+#include "envoy/config/filter/http/fault/v2/fault.pb.validate.h"
 
 #include "extensions/filters/http/common/factory_base.h"
 #include "extensions/filters/http/well_known_names.h"

--- a/source/extensions/filters/http/grpc_json_transcoder/config.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/config/filter/http/transcoder/v2/transcoder.pb.h"
+#include "envoy/config/filter/http/transcoder/v2/transcoder.pb.validate.h"
 
 #include "extensions/filters/http/common/factory_base.h"
 #include "extensions/filters/http/well_known_names.h"

--- a/source/extensions/filters/http/gzip/config.h
+++ b/source/extensions/filters/http/gzip/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/config/filter/http/gzip/v2/gzip.pb.h"
+#include "envoy/config/filter/http/gzip/v2/gzip.pb.validate.h"
 
 #include "extensions/filters/http/common/factory_base.h"
 #include "extensions/filters/http/well_known_names.h"

--- a/source/extensions/filters/http/ip_tagging/config.h
+++ b/source/extensions/filters/http/ip_tagging/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/config/filter/http/ip_tagging/v2/ip_tagging.pb.h"
+#include "envoy/config/filter/http/ip_tagging/v2/ip_tagging.pb.validate.h"
 
 #include "extensions/filters/http/common/factory_base.h"
 #include "extensions/filters/http/well_known_names.h"

--- a/source/extensions/filters/http/jwt_authn/BUILD
+++ b/source/extensions/filters/http/jwt_authn/BUILD
@@ -97,4 +97,11 @@ envoy_cc_library(
 envoy_cc_library(
     name = "filter_config_interface",
     hdrs = ["filter_config.h"],
+    deps = [
+        ":jwks_cache_lib",
+        ":matchers_lib",
+        "//include/envoy/server:filter_config_interface",
+        "//include/envoy/stats:stats_macros",
+        "//include/envoy/thread_local:thread_local_interface",
+    ],
 )

--- a/source/extensions/filters/http/jwt_authn/filter_factory.h
+++ b/source/extensions/filters/http/jwt_authn/filter_factory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/config/filter/http/jwt_authn/v2alpha/config.pb.h"
+#include "envoy/config/filter/http/jwt_authn/v2alpha/config.pb.validate.h"
 #include "envoy/server/filter_config.h"
 
 #include "extensions/filters/http/common/factory_base.h"

--- a/source/extensions/filters/http/lua/config.h
+++ b/source/extensions/filters/http/lua/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/config/filter/http/lua/v2/lua.pb.h"
+#include "envoy/config/filter/http/lua/v2/lua.pb.validate.h"
 
 #include "extensions/filters/http/common/factory_base.h"
 #include "extensions/filters/http/well_known_names.h"

--- a/source/extensions/filters/http/ratelimit/config.h
+++ b/source/extensions/filters/http/ratelimit/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/config/filter/http/rate_limit/v2/rate_limit.pb.h"
+#include "envoy/config/filter/http/rate_limit/v2/rate_limit.pb.validate.h"
 
 #include "extensions/filters/http/common/factory_base.h"
 #include "extensions/filters/http/well_known_names.h"

--- a/source/extensions/filters/http/squash/config.h
+++ b/source/extensions/filters/http/squash/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/config/filter/http/squash/v2/squash.pb.h"
+#include "envoy/config/filter/http/squash/v2/squash.pb.validate.h"
 
 #include "extensions/filters/http/common/factory_base.h"
 #include "extensions/filters/http/well_known_names.h"

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol_header.h
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol_header.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "envoy/network/address.h"
+
 #include "common/common/assert.h"
 
 namespace Envoy {

--- a/source/extensions/filters/listener/well_known_names.h
+++ b/source/extensions/filters/listener/well_known_names.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "common/singleton/const_singleton.h"
 
 namespace Envoy {

--- a/source/extensions/filters/network/thrift_proxy/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/BUILD
@@ -276,6 +276,7 @@ envoy_cc_library(
     name = "thrift_object_interface",
     hdrs = ["thrift_object.h"],
     deps = [
+        ":thrift_lib",
         "//include/envoy/buffer:buffer_interface",
     ],
 )

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/config.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/config/filter/thrift/rate_limit/v2alpha1/rate_limit.pb.h"
+#include "envoy/config/filter/thrift/rate_limit/v2alpha1/rate_limit.pb.validate.h"
 
 #include "extensions/filters/network/thrift_proxy/filters/factory_base.h"
 #include "extensions/filters/network/thrift_proxy/filters/well_known_names.h"

--- a/source/extensions/filters/network/thrift_proxy/filters/well_known_names.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/well_known_names.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <string>
+
+#include "common/singleton/const_singleton.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {

--- a/source/extensions/grpc_credentials/well_known_names.h
+++ b/source/extensions/grpc_credentials/well_known_names.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "common/singleton/const_singleton.h"
 
 namespace Envoy {

--- a/source/extensions/health_checkers/redis/BUILD
+++ b/source/extensions/health_checkers/redis/BUILD
@@ -40,6 +40,8 @@ envoy_cc_library(
     name = "utility",
     hdrs = ["utility.h"],
     deps = [
+        "//source/common/protobuf",
+        "//source/common/protobuf:utility_lib",
         "@envoy_api//envoy/api/v2/core:health_check_cc",
         "@envoy_api//envoy/config/health_checker/redis/v2:redis_cc",
     ],

--- a/source/extensions/health_checkers/redis/utility.h
+++ b/source/extensions/health_checkers/redis/utility.h
@@ -3,6 +3,9 @@
 #include "envoy/api/v2/core/health_check.pb.validate.h"
 #include "envoy/config/health_checker/redis/v2/redis.pb.validate.h"
 
+#include "common/protobuf/protobuf.h"
+#include "common/protobuf/utility.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HealthCheckers {

--- a/source/extensions/health_checkers/well_known_names.h
+++ b/source/extensions/health_checkers/well_known_names.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "common/singleton/const_singleton.h"
 
 namespace Envoy {

--- a/source/extensions/resource_monitors/well_known_names.h
+++ b/source/extensions/resource_monitors/well_known_names.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <string>
 
 #include "common/singleton/const_singleton.h"
 

--- a/source/extensions/retry/host/well_known_names.h
+++ b/source/extensions/retry/host/well_known_names.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "common/singleton/const_singleton.h"
 
 namespace Envoy {

--- a/source/extensions/retry/priority/well_known_names.h
+++ b/source/extensions/retry/priority/well_known_names.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "common/singleton/const_singleton.h"
 
 namespace Envoy {

--- a/source/extensions/stat_sinks/well_known_names.h
+++ b/source/extensions/stat_sinks/well_known_names.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "common/singleton/const_singleton.h"
 
 namespace Envoy {

--- a/source/extensions/tracers/well_known_names.h
+++ b/source/extensions/tracers/well_known_names.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <string>
 
 #include "common/singleton/const_singleton.h"
 

--- a/source/extensions/transport_sockets/alts/noop_transport_socket_callbacks.h
+++ b/source/extensions/transport_sockets/alts/noop_transport_socket_callbacks.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "envoy/network/transport_socket.h"
 
 namespace Envoy {

--- a/source/extensions/transport_sockets/well_known_names.h
+++ b/source/extensions/transport_sockets/well_known_names.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "common/singleton/const_singleton.h"
 
 namespace Envoy {

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -132,6 +132,7 @@ envoy_cc_library(
     hdrs = ["hot_restart_nop_impl.h"],
     deps = [
         "//include/envoy/server:hot_restart_interface",
+        "//source/common/stats:heap_stat_data_lib",
     ],
 )
 

--- a/source/server/config_validation/connection.h
+++ b/source/server/config_validation/connection.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "common/network/connection_impl.h"
 
 namespace Envoy {

--- a/source/server/hot_restart_nop_impl.h
+++ b/source/server/hot_restart_nop_impl.h
@@ -5,6 +5,7 @@
 #include "envoy/server/hot_restart.h"
 
 #include "common/common/thread.h"
+#include "common/stats/heap_stat_data.h"
 
 namespace Envoy {
 namespace Server {

--- a/source/server/test_hooks.h
+++ b/source/server/test_hooks.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "envoy/common/pure.h"
+
 namespace Envoy {
 
 /**

--- a/test/common/access_log/BUILD
+++ b/test/common/access_log/BUILD
@@ -18,6 +18,7 @@ envoy_cc_test_library(
     deps = [
         "//include/envoy/stream_info:stream_info_interface",
         "//source/common/common:assert_lib",
+        "//source/common/stream_info:filter_state_lib",
         "//test/test_common:test_time_lib",
     ],
 )

--- a/test/common/config/filesystem_subscription_test_harness.h
+++ b/test/common/config/filesystem_subscription_test_harness.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <fstream>
 
 #include "envoy/api/v2/eds.pb.h"

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "envoy/api/v2/eds.pb.h"
 #include "envoy/http/async_client.h"
 

--- a/test/common/grpc/grpc_client_integration.h
+++ b/test/common/grpc/grpc_client_integration.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "common/common/assert.h"
 
 #include "test/test_common/utility.h"

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -1,7 +1,10 @@
+#pragma once
+
 #include "envoy/stats/scope.h"
 
 #include "common/event/dispatcher_impl.h"
 #include "common/grpc/async_client_impl.h"
+#include "common/grpc/google_async_client_impl.h"
 #include "common/http/async_client_impl.h"
 #include "common/http/http2/conn_pool.h"
 #include "common/network/connection_impl.h"

--- a/test/common/network/socket_option_test.h
+++ b/test/common/network/socket_option_test.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "common/network/address_impl.h"
 #include "common/network/socket_option_impl.h"
 

--- a/test/extensions/filters/common/lua/BUILD
+++ b/test/extensions/filters/common/lua/BUILD
@@ -37,6 +37,7 @@ envoy_cc_test_library(
     name = "lua_wrappers_lib",
     hdrs = ["lua_wrappers.h"],
     deps = [
+        "//source/extensions/filters/common/lua:lua_lib",
         "//test/mocks/thread_local:thread_local_mocks",
     ],
 )

--- a/test/extensions/filters/common/lua/lua_wrappers.h
+++ b/test/extensions/filters/common/lua/lua_wrappers.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "extensions/filters/common/lua/lua.h"
+
 #include "test/mocks/thread_local/mocks.h"
 
 #include "gmock/gmock.h"

--- a/test/extensions/filters/http/common/mock.h
+++ b/test/extensions/filters/http/common/mock.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "extensions/filters/http/common/jwks_fetcher.h"
 
 #include "test/mocks/server/mocks.h"

--- a/test/extensions/filters/http/jwt_authn/BUILD
+++ b/test/extensions/filters/http/jwt_authn/BUILD
@@ -21,7 +21,11 @@ envoy_cc_library(
 envoy_cc_mock(
     name = "mock_lib",
     hdrs = ["mock.h"],
-    deps = ["//test/mocks/server:server_mocks"],
+    deps = [
+        "//source/extensions/filters/http/jwt_authn:authenticator_lib",
+        "//source/extensions/filters/http/jwt_authn:verifier_lib",
+        "//test/mocks/server:server_mocks",
+    ],
 )
 
 envoy_extension_cc_test(

--- a/test/extensions/filters/http/jwt_authn/mock.h
+++ b/test/extensions/filters/http/jwt_authn/mock.h
@@ -1,4 +1,7 @@
+#pragma once
+
 #include "extensions/filters/http/jwt_authn/authenticator.h"
+#include "extensions/filters/http/jwt_authn/verifier.h"
 
 #include "test/mocks/upstream/mocks.h"
 

--- a/test/extensions/filters/http/rbac/BUILD
+++ b/test/extensions/filters/http/rbac/BUILD
@@ -53,5 +53,6 @@ envoy_extension_cc_mock(
     extension_name = "envoy.filters.http.rbac",
     deps = [
         "//source/extensions/filters/common/rbac:utility_lib",
+        "//source/extensions/filters/http/rbac:rbac_filter_lib",
     ],
 )

--- a/test/extensions/filters/http/rbac/mocks.h
+++ b/test/extensions/filters/http/rbac/mocks.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "extensions/filters/common/rbac/utility.h"
+#include "extensions/filters/http/rbac/rbac_filter.h"
 
 #include "gmock/gmock.h"
 

--- a/test/integration/autonomous_upstream.h
+++ b/test/integration/autonomous_upstream.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "test/integration/fake_upstream.h"
 
 namespace Envoy {

--- a/test/integration/test_host_predicate_config.h
+++ b/test/integration/test_host_predicate_config.h
@@ -4,6 +4,8 @@
 
 #include "test/integration/test_host_predicate.h"
 
+#include "gmock/gmock.h"
+
 namespace Envoy {
 class TestHostPredicateFactory : public Upstream::RetryHostPredicateFactory {
 public:

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -229,6 +229,7 @@ envoy_cc_test_library(
     deps = [
         "//source/common/config:lds_json_lib",
         "//source/common/json:json_loader_lib",
+        "//source/common/protobuf:utility_lib",
     ],
 )
 

--- a/test/server/utility.h
+++ b/test/server/utility.h
@@ -2,6 +2,7 @@
 
 #include "common/config/lds_json.h"
 #include "common/json/json_loader.h"
+#include "common/protobuf/utility.h"
 #include "common/stats/stats_options_impl.h"
 
 namespace Envoy {

--- a/test/test_common/registry.h
+++ b/test/test_common/registry.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "envoy/registry/registry.h"
 
 #include "gtest/gtest.h"

--- a/test/test_common/threadsafe_singleton_injector.h
+++ b/test/test_common/threadsafe_singleton_injector.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "common/singleton/threadsafe_singleton.h"
 
 namespace Envoy {

--- a/test/test_runner.h
+++ b/test/test_runner.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "common/common/logger.h"
 #include "common/common/logger_delegates.h"
 #include "common/common/thread.h"


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

*Description*:
CI won't complain because bazel won't compile header only libraries. Though clang-tidy (and IDE) will complain if header is not self-contained.
https://google.github.io/styleguide/cppguide.html#Self_contained_Headers

This PR might be not completely fix all headers, partially for #4863.

*Risk Level*: Low (no actual code change)
*Testing*: CI
*Docs Changes*: N/A
*Release Notes*: N/A
