### PR TITLE
router: start per-try timeout timer in onPoolReady

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -27,6 +27,8 @@ Version history
   scheme and port rewriting RedirectAction
 * router: when :ref:`max_grpc_timeout <envoy_api_field_route.RouteAction.max_grpc_timeout>`
   is set, Envoy will now add or update the grpc-timeout header to reflect Envoy's expected timeout.
+* router: per try timeouts now starts when an upstream stream is ready instead of when the request has
+  been fully decoded by Envoy.
 * stats: added :ref:`stats_matcher <envoy_api_field_config.metrics.v2.StatsConfig.stats_matcher>` to the bootstrap config for granular control of stat instantiation.
 * stream: renamed the `RequestInfo` namespace to `StreamInfo` to better match
   its behaviour within TCP and HTTP implementations.

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -432,7 +432,6 @@ void Filter::onRequestComplete() {
     // seems unnecessary right now.
     maybeDoShadowing();
 
-    upstream_request_->setupPerTryTimeout();
     if (timeout_.global_timeout_.count() > 0) {
       response_timeout_ = dispatcher.createTimer([this]() -> void { onResponseTimeout(); });
       response_timeout_->enableTimer(timeout_.global_timeout_);
@@ -794,8 +793,6 @@ void Filter::doRetry() {
     if (downstream_trailers_) {
       upstream_request_->encodeTrailers(*downstream_trailers_);
     }
-
-    upstream_request_->setupPerTryTimeout();
   }
 }
 
@@ -1002,6 +999,8 @@ void Filter::UpstreamRequest::onPoolReady(Http::StreamEncoder& request_encoder,
   // TODO(ggreenway): set upstream local address in the StreamInfo.
   onUpstreamHostSelected(host);
   request_encoder.getStream().addCallbacks(*this);
+
+  setupPerTryTimeout();
 
   conn_pool_stream_handle_ = nullptr;
   setRequestEncoder(request_encoder);

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -33,6 +33,7 @@ using testing::AssertionFailure;
 using testing::AssertionResult;
 using testing::AssertionSuccess;
 using testing::AtLeast;
+using testing::InSequence;
 using testing::Invoke;
 using testing::MockFunction;
 using testing::NiceMock;
@@ -89,7 +90,6 @@ public:
   }
 
   void expectResponseTimerCreate() {
-    response_timeout_ = new Event::MockTimer(&callbacks_.dispatcher_);
     EXPECT_CALL(*response_timeout_, enableTimer(_));
     EXPECT_CALL(*response_timeout_, disableTimer());
   }
@@ -1131,9 +1131,11 @@ TEST_F(RouterTest, UpstreamPerTryTimeout) {
 
 // Ensures that the per try callback is not set until the stream becomes available.
 TEST_F(RouterTest, UpstreamPerTryTimeoutExcludesNewStream) {
+  InSequence s;
   NiceMock<Http::MockStreamEncoder> encoder;
   Http::StreamDecoder* response_decoder = nullptr;
   Http::ConnectionPool::Callbacks* pool_callbacks;
+
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
       .WillOnce(Invoke([&](Http::StreamDecoder& decoder, Http::ConnectionPool::Callbacks& callbacks)
                            -> Http::ConnectionPool::Cancellable* {
@@ -1141,13 +1143,16 @@ TEST_F(RouterTest, UpstreamPerTryTimeoutExcludesNewStream) {
         pool_callbacks = &callbacks;
         return nullptr;
       }));
+
+  response_timeout_ = new Event::MockTimer(&callbacks_.dispatcher_);
+  EXPECT_CALL(*response_timeout_, enableTimer(_));
+
   EXPECT_CALL(callbacks_.stream_info_, onUpstreamHostSelected(_))
       .WillOnce(Invoke([&](const Upstream::HostDescriptionConstSharedPtr host) -> void {
         EXPECT_EQ(host_address_, host->address());
       }));
 
   per_try_timeout_ = new Event::MockTimer(&callbacks_.dispatcher_);
-  expectResponseTimerCreate();
 
   Http::TestHeaderMapImpl headers{{"x-envoy-internal", "true"},
                                   {"x-envoy-upstream-rq-per-try-timeout-ms", "5"}};
@@ -1157,18 +1162,19 @@ TEST_F(RouterTest, UpstreamPerTryTimeoutExcludesNewStream) {
   router_.decodeData(data, true);
 
   EXPECT_CALL(*per_try_timeout_, enableTimer(_));
-  EXPECT_CALL(*per_try_timeout_, disableTimer());
   // The per try timeout timer should not be started yet.
   pool_callbacks->onPoolReady(encoder, cm_.conn_pool_.host_);
 
+  EXPECT_CALL(encoder.stream_, resetStream(Http::StreamResetReason::LocalReset));
+  EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_, putHttpResponseCode(504));
+  EXPECT_CALL(*per_try_timeout_, disableTimer());
+  EXPECT_CALL(*response_timeout_, disableTimer());
   EXPECT_CALL(callbacks_.stream_info_,
               setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
-  EXPECT_CALL(encoder.stream_, resetStream(Http::StreamResetReason::LocalReset));
   Http::TestHeaderMapImpl response_headers{
       {":status", "504"}, {"content-length", "24"}, {"content-type", "text/plain"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
-  EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_, putHttpResponseCode(504));
   per_try_timeout_->callback_();
 
   EXPECT_EQ(1U, cm_.thread_local_cluster_.cluster_.info_->stats_store_

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -1153,8 +1153,6 @@ TEST_F(RouterTest, UpstreamPerTryTimeoutExcludesNewStream) {
         EXPECT_EQ(host_address_, host->address());
       }));
 
-  per_try_timeout_ = new Event::MockTimer(&callbacks_.dispatcher_);
-
   Http::TestHeaderMapImpl headers{{"x-envoy-internal", "true"},
                                   {"x-envoy-upstream-rq-per-try-timeout-ms", "5"}};
   HttpTestUtility::addDefaultHeaders(headers);
@@ -1162,6 +1160,7 @@ TEST_F(RouterTest, UpstreamPerTryTimeoutExcludesNewStream) {
   Buffer::OwnedImpl data;
   router_.decodeData(data, true);
 
+  per_try_timeout_ = new Event::MockTimer(&callbacks_.dispatcher_);
   EXPECT_CALL(*per_try_timeout_, enableTimer(_));
   // The per try timeout timer should not be started yet.
   pool_callbacks->onPoolReady(encoder, cm_.conn_pool_.host_);

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -90,6 +90,7 @@ public:
   }
 
   void expectResponseTimerCreate() {
+    response_timeout_ = new Event::MockTimer(&callbacks_.dispatcher_);
     EXPECT_CALL(*response_timeout_, enableTimer(_));
     EXPECT_CALL(*response_timeout_, disableTimer());
   }


### PR DESCRIPTION
Instead of starting the timer when the request has been fully decoded,
start it once the upstream stream is ready. This ensures that a slow
upstream connect doesn't get impacted by a tight per try timeout. 

This currently only applies to http/1.1: the http/1.1 connection pool will queue
requests until a connection has been established to send the request over, 
calling the onPoolReady after once the connection is ready. The http/2 connection
pool however, will call onPoolReady immediately and let the http/2 codec hold onto
the request until the connection has been established. 

This will be modified in a follow up PR so that both connection pools behave the same way.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Medium
*Testing*: Added unit test ensuring the timer isn't started until onPoolReady
*Docs Changes*: n/a
*Release Notes*: Added note about change in functionality
Part of #4903 