### PR TITLE
docs/examples: upgrade requests dep.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,7 @@ docutils==0.14
 gitdb==0.6.4
 imagesize==0.7.1
 pytz==2017.2
-requests==2.13.0
+requests>=2.20.0
 six==1.10.0
 smmap==0.9.0
 snowballstemmer==1.2.1

--- a/examples/grpc-bridge/client/requirements.txt
+++ b/examples/grpc-bridge/client/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.9.1
+requests>=2.20.0
 grpcio

--- a/examples/grpc-bridge/config/s2s-python-envoy.yaml
+++ b/examples/grpc-bridge/config/s2s-python-envoy.yaml
@@ -42,6 +42,7 @@ static_resources:
   clusters:
   - name: grpc
     type: logical_dns
+    dns_lookup_family: V4_ONLY
     lb_policy: round_robin
     connect_timeout: 0.250s
     http_protocol_options: {}


### PR DESCRIPTION
Earlier versions are flagged with CVE-2018-18074.

Bonus fixup to grpc-bridge example to ensure it works in environments
where cross-container Docker IPv6 networking is not supported, by
forcing IPv4 resolution.

Risk Level: Low
Testing: Rebuilt docs and ran grpc-bridge example.

Signed-off-by: Harvey Tuch <htuch@google.com>