### PR TITLE
tools: fix check repositories script for macs

### DIFF
--- a/tools/check_repositories.sh
+++ b/tools/check_repositories.sh
@@ -12,7 +12,12 @@ fi
 
 # Check whether number of defined `url =` or `urls =` and `sha256 =` kwargs in
 # repository definitions is equal.
-urls_count=$(grep -IPnrs "url(s)? =" --include=*.bzl . | wc -l)
+if [[ `uname` == "Darwin" ]]; then
+  # When running on OSX use egrep instead of perl regexp
+  urls_count=$(egrep -Inrs "url(s)? =" --include=*.bzl . | wc -l)
+else
+  urls_count=$(grep -IPnrs "url(s)? =" --include=*.bzl . | wc -l)
+fi
 sha256sums_count=$(grep -nr "sha256 =" --include=*.bzl . | wc -l)
 
 if [[ $urls_count != $sha256sums_count ]]; then

--- a/tools/check_repositories.sh
+++ b/tools/check_repositories.sh
@@ -12,8 +12,8 @@ fi
 
 # Check whether number of defined `url =` or `urls =` and `sha256 =` kwargs in
 # repository definitions is equal.
-urls_count=$(egrep -Inrs "url(s)? =" --include=*.bzl . | wc -l)
-sha256sums_count=$(grep -nr "sha256 =" --include=*.bzl . | wc -l)
+urls_count=$(git grep -E "url(s)? =" -- '*.bzl' | wc -l)
+sha256sums_count=$(git grep -E "sha256 =" -- '*.bzl' | wc -l)
 
 if [[ $urls_count != $sha256sums_count ]]; then
   echo "Found more defined repository URLs than SHA256 sums, which means that there are some repositories without sums."

--- a/tools/check_repositories.sh
+++ b/tools/check_repositories.sh
@@ -12,12 +12,7 @@ fi
 
 # Check whether number of defined `url =` or `urls =` and `sha256 =` kwargs in
 # repository definitions is equal.
-if [[ `uname` == "Darwin" ]]; then
-  # When running on OSX use egrep instead of perl regexp
-  urls_count=$(egrep -Inrs "url(s)? =" --include=*.bzl . | wc -l)
-else
-  urls_count=$(grep -IPnrs "url(s)? =" --include=*.bzl . | wc -l)
-fi
+urls_count=$(egrep -Inrs "url(s)? =" --include=*.bzl . | wc -l)
 sha256sums_count=$(grep -nr "sha256 =" --include=*.bzl . | wc -l)
 
 if [[ $urls_count != $sha256sums_count ]]; then


### PR DESCRIPTION
*Description*: Fix `check_repositories` script when running on a mac. The version of grep that comes as part of OSX does not support the `-P` flag. This will instead utilize egrep to pattern match.
*Risk Level*: Low
*Testing*: Manually ran the script on my machine. See attached output below.
*Docs Changes*: N/A
*Release Notes*: N/A

*Before*:
```bash
> ./tools/check_repositories.sh 
usage: grep [-abcDEFGHhIiJLlmnOoqRSsUVvwxZ] [-A num] [-B num] [-C[num]]
	[-e pattern] [-f file] [--binary-files=value] [--color=when]
	[--context[=num]] [--directories=action] [--label] [--line-buffered]
	[--null] [pattern] [file ...]
Found more defined repository URLs than SHA256 sums, which means that there are some repositories without sums.
Dependencies without SHA256 sums cannot be stored in distdir.
Please ensure that every repository has a SHA256 sum.
Repositories are defined in the following files:

    bazel/repository_locations.bzl
    api/bazel/repositories.bzl
```
*After*:
```bash
> ./tools/check_repositories.sh 
Found more defined repository URLs than SHA256 sums, which means that there are some repositories without sums.
Dependencies without SHA256 sums cannot be stored in distdir.
Please ensure that every repository has a SHA256 sum.
Repositories are defined in the following files:

    bazel/repository_locations.bzl
    api/bazel/repositories.bzl
```