### PR TITLE
stats Initialize the tag producer so we count tag extraction in the stats speed test

### DIFF
--- a/test/common/stats/thread_local_store_speed_test.cc
+++ b/test/common/stats/thread_local_store_speed_test.cc
@@ -6,6 +6,7 @@
 #include "common/event/dispatcher_impl.h"
 #include "common/stats/heap_stat_data.h"
 #include "common/stats/stats_options_impl.h"
+#include "common/stats/tag_producer_impl.h"
 #include "common/stats/thread_local_store.h"
 #include "common/thread_local/thread_local_impl.h"
 
@@ -18,7 +19,9 @@ namespace Envoy {
 
 class ThreadLocalStorePerf {
 public:
-  ThreadLocalStorePerf() : store_(options_, heap_alloc_) {}
+  ThreadLocalStorePerf() : store_(options_, heap_alloc_) {
+    store_.setTagProducer(std::make_unique<Stats::TagProducerImpl>(stats_config_));
+  }
 
   ~ThreadLocalStorePerf() {
     store_.shutdownThreading();
@@ -45,6 +48,7 @@ private:
   std::unique_ptr<Event::DispatcherImpl> dispatcher_;
   std::unique_ptr<ThreadLocal::InstanceImpl> tls_;
   Stats::ThreadLocalStoreImpl store_;
+  envoy::config::metrics::v2::StatsConfig stats_config_;
 };
 
 } // namespace Envoy


### PR DESCRIPTION
*Description*: Continuation of #4907 -- init the tag-extractor regexes so tags get extracted in the speed test.  Speed test results for this PR:

```
bazel-bin/test/common/stats/thread_local_store_speed_test --benchmark_report_aggregates_only=true --benchmark_repetitions=100
--------------------------------------------------------------
Benchmark                       Time           CPU Iterations
--------------------------------------------------------------
BM_StatsNoTls_mean       17104521 ns   17104332 ns         31
BM_StatsNoTls_median     16974610 ns   16974377 ns         31
BM_StatsNoTls_stddev       567337 ns     567334 ns         31
BM_StatsWithTls_mean     20082341 ns   20082150 ns         27
BM_StatsWithTls_median   19970411 ns   19970668 ns         27
BM_StatsWithTls_stddev     514573 ns     514532 ns         27
```

*Risk Level*: low
*Testing*: just this test
*Docs Changes*: n/a
*Release Notes*: n/a
