### PR TITLE
http: use a request queue in the http2 conn pool

### DIFF
--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -308,15 +308,15 @@ TEST_P(Http2UpstreamIntegrationTest, UpstreamConnectionCloseWithManyStreams) {
     responses.push_back(std::move(encoder_decoder.second));
     // Reset a few streams to test how reset and watermark interact.
     if (i % 15 == 0) {
-      codec_client_->sendReset(*encoders[i]);
+      //  codec_client_->sendReset(*encoders[i]);
     } else {
       codec_client_->sendData(*encoders[i], 0, true);
     }
   }
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
   for (uint32_t i = 0; i < num_requests; ++i) {
-    FakeStreamPtr stream;
     upstream_requests.emplace_back();
+    FakeStreamPtr stream;
     ASSERT_TRUE(
         fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_requests.back()));
   }


### PR DESCRIPTION
Modifies the http2 connection pool to use a request queueu similar to
how the http/1.1 connection pool does. This is done in order to defer
the connection pool callbacks until the connection has been established
instead of simply invoking the callback immediately.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: High
*Testing*: n/a
*Docs Changes*: n/a
*Release Notes*: n/a
Part of #4903
