### PR TITLE
Update PGV, bazel-gazelle, c-ares dependencies

### DIFF
--- a/api/bazel/repositories.bzl
+++ b/api/bazel/repositories.bzl
@@ -4,6 +4,9 @@ BAZEL_SKYLIB_SHA256 = "b5f6abe419da897b7901f90cbab08af958b97a8f3575b0d3dd062ac7c
 GOGOPROTO_RELEASE = "1.1.1"
 GOGOPROTO_SHA256 = "9f8c2ad49849ab063cd9fef67e77d49606640044227ecf7f3617ea2c92ef147c"
 
+PGV_RELEASE = "0.0.10"
+PGV_SHA256 = "77b39d7c007255adaf30aa417d750922cc8a10b2c21a0c6aa31bbbf0f9ec5d34"
+
 GOOGLEAPIS_GIT_SHA = "d642131a6e6582fc226caf9893cb7fe7885b3411"  # May 23, 2018
 GOOGLEAPIS_SHA = "16f5b2e8bf1e747a32f9a62e211f8f33c94645492e9bbd72458061d9a9de1f63"
 
@@ -12,9 +15,6 @@ PROMETHEUS_SHA = "783bdaf8ee0464b35ec0c8704871e1e72afa0005c3f3587f65d9d6694bf391
 
 OPENCENSUS_GIT_SHA = "ab82e5fdec8267dc2a726544b10af97675970847"  # May 23, 2018
 OPENCENSUS_SHA = "1950f844d9f338ba731897a9bb526f9074c0487b3f274ce2ec3b4feaf0bef7e2"
-
-PGV_GIT_SHA = "30da78c4bcdd477b3c24d13e43cf39361ae3859f"  # Sep 27, 2018
-PGV_SHA = "2bc9a34b1c485e73540dc5093d6715ef437294020fa6580f21306aa5e884f511"
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
@@ -27,9 +27,9 @@ def api_dependencies():
     )
     http_archive(
         name = "com_lyft_protoc_gen_validate",
-        url = "https://github.com/lyft/protoc-gen-validate/archive/" + PGV_GIT_SHA + ".tar.gz",
-        sha256 = PGV_SHA,
-        strip_prefix = "protoc-gen-validate-" + PGV_GIT_SHA,
+        sha256 = PGV_SHA256,
+        strip_prefix = "protoc-gen-validate-" + PGV_RELEASE,
+        url = "https://github.com/lyft/protoc-gen-validate/archive/v" + PGV_RELEASE + ".tar.gz",
     )
     http_archive(
         name = "googleapis",

--- a/bazel/EXTERNAL_DEPS.md
+++ b/bazel/EXTERNAL_DEPS.md
@@ -1,3 +1,11 @@
+# Choosing tarballs
+
+Where the dependency maintainer provides a tarball, prefer that over the
+automatically generated Github tarball. Github generated tarball SHA256
+values can change when Github changes their tar/gzip libraries breaking
+builds. Maintainer provided tarballs are more stable and the maintainer
+can provide the SHA256.
+
 # Adding external dependencies to Envoy (native Bazel)
 
 This is the preferred style of adding dependencies that use Bazel for their

--- a/bazel/EXTERNAL_DEPS.md
+++ b/bazel/EXTERNAL_DEPS.md
@@ -2,7 +2,7 @@
 
 Where the dependency maintainer provides a tarball, prefer that over the
 automatically generated Github tarball. Github generated tarball SHA256
-values can change when Github changes their tar/gzip libraries breaking
+values can change when Github change their tar/gzip libraries breaking
 builds. Maintainer provided tarballs are more stable and the maintainer
 can provide the SHA256.
 

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,8 +1,7 @@
 REPOSITORY_LOCATIONS = dict(
     bazel_gazelle = dict(
-        sha256 = "1b959bd6b6ce88fc3fdfc28946adf1eafb1d5e4d470d2e08a51774d09078d031",
-        strip_prefix = "bazel-gazelle-0.14.0",
-        urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/0.14.0.tar.gz"],
+        sha256 = "6e875ab4b6bf64a38c352887760f21203ab054676d9c1b274963907e0768740d",
+        urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.15.0/bazel-gazelle-0.15.0.tar.gz"],
     ),
     boringssl = dict(
         # Use commits from branch "chromium-stable-with-bazel"
@@ -30,7 +29,7 @@ REPOSITORY_LOCATIONS = dict(
     com_github_circonus_labs_libcircllhist = dict(
         sha256 = "9949e2864b8ad00ee5c3e9c1c3c01e51b6b68bb442a919652fc66b9776477987",
         strip_prefix = "libcircllhist-fd8a14463739d247b414825cc56ca3946792a3b9",
-        # 2018-07-02
+        # 2018-09-17
         urls = ["https://github.com/circonus-labs/libcircllhist/archive/fd8a14463739d247b414825cc56ca3946792a3b9.tar.gz"],
     ),
     com_github_cyan4973_xxhash = dict(
@@ -44,9 +43,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/eile/tclap/archive/tclap-1-2-1-release-final.tar.gz"],
     ),
     com_github_fmtlib_fmt = dict(
-        sha256 = "3c812a18e9f72a88631ab4732a97ce9ef5bcbefb3235e9fd465f059ba204359b",
+        sha256 = "43894ab8fe561fc9e523a8024efc23018431fa86b95d45b06dbe6ddb29ffb6cd",
         strip_prefix = "fmt-5.2.1",
-        urls = ["https://github.com/fmtlib/fmt/archive/5.2.1.tar.gz"],
+        urls = ["https://github.com/fmtlib/fmt/releases/download/5.2.1/fmt-5.2.1.zip"],
     ),
     com_github_gabime_spdlog = dict(
         sha256 = "867a4b7cedf9805e6f76d3ca41889679054f7e5a3b67722fe6d0eae41852a767",
@@ -94,7 +93,7 @@ REPOSITORY_LOCATIONS = dict(
     com_github_google_jwt_verify = dict(
         sha256 = "499f1e145c19f33031eb8fc6452d5d391b4cecfdeda23e2055386a3b33be4d41",
         strip_prefix = "jwt_verify_lib-66792a057ec54e4b75c6a2eeda4e98220bd12a9a",
-        # 2018-08-17
+        # 2018-08-16
         urls = ["https://github.com/google/jwt_verify_lib/archive/66792a057ec54e4b75c6a2eeda4e98220bd12a9a.tar.gz"],
     ),
     com_github_nodejs_http_parser = dict(
@@ -107,9 +106,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/nodejs/http-parser/archive/77310eeb839c4251c07184a5db8885a572a08352.tar.gz"],
     ),
     com_github_pallets_jinja = dict(
-        sha256 = "0d31d3466c313a9ca014a2d904fed18cdac873a5ba1f7b70b8fd8b206cd860d6",
-        strip_prefix = "jinja-2.10",
-        urls = ["https://github.com/pallets/jinja/archive/2.10.tar.gz"],
+        sha256 = "f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4",
+        strip_prefix = "Jinja2-2.10",
+        urls = ["https://github.com/pallets/jinja/releases/download/2.10/Jinja2-2.10.tar.gz"],
     ),
     com_github_pallets_markupsafe = dict(
         sha256 = "dc3938045d9407a73cf9fdd709e2b1defd0588d50ffc85eb0786c095ec846f15",
@@ -172,7 +171,6 @@ REPOSITORY_LOCATIONS = dict(
     ),
     six_archive = dict(
         sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
-        strip_prefix = "",
         urls = ["https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz#md5=34eed507548117b2ab523ab14b2f8b55"],
     ),
     # I'd love to name this `com_github_google_subpar`, but something in the Subpar

--- a/ci/build_container/build_recipes/cares.sh
+++ b/ci/build_container/build_recipes/cares.sh
@@ -2,8 +2,9 @@
 
 set -e
 
-VERSION=cares-1_14_0
-SHA256=62dd12f0557918f89ad6f5b759f0bf4727174ae9979499f5452c02be38d9d3e8
+TAG=cares-1_15_0
+VERSION=c-ares-1.15.0
+SHA256=6cdb97871f2930530c97deb7cf5c8fa4be5a0b02c7cea6e7c7667672a39d6852
 
 # cares is fussy over whether -D appears inside CFLAGS vs. CPPFLAGS, oss-fuzz
 # sets CFLAGS with -D, so we need to impedance match here. In turn, OS X automake
@@ -11,10 +12,10 @@ SHA256=62dd12f0557918f89ad6f5b759f0bf4727174ae9979499f5452c02be38d9d3e8
 CPPFLAGS="$(for f in $CXXFLAGS; do if [[ $f =~ -D.* ]]; then echo $f; fi; done | tr '\n' ' ')"
 CFLAGS="$(for f in $CXXFLAGS; do if [[ ! $f =~ -D.* ]]; then echo $f; fi; done | tr '\n' ' ')"
 
-curl https://github.com/c-ares/c-ares/archive/"$VERSION".tar.gz -sLo c-ares-"$VERSION".tar.gz \
-  && echo "$SHA256" c-ares-"$VERSION".tar.gz | sha256sum --check
-tar xf c-ares-"$VERSION".tar.gz
-cd c-ares-"$VERSION"
+curl https://github.com/c-ares/c-ares/releases/download/"$TAG"/"$VERSION".tar.gz -sLo "$VERSION".tar.gz \
+  && echo "$SHA256" "$VERSION".tar.gz | sha256sum --check
+tar xf "$VERSION".tar.gz
+cd "$VERSION"
 
 mkdir build
 cd build

--- a/ci/build_container/build_recipes/libevent.sh
+++ b/ci/build_container/build_recipes/libevent.sh
@@ -5,6 +5,7 @@ set -e
 VERSION=2.1.8-stable
 SHA256=316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d
 
+# Maintainer provided source tarball does not contain cmake content so using Github tarball.
 curl https://github.com/libevent/libevent/archive/release-"$VERSION".tar.gz -sLo libevent-release-"$VERSION".tar.gz \
   && echo "$SHA256" libevent-release-"$VERSION".tar.gz | sha256sum --check
 tar xf libevent-release-"$VERSION".tar.gz


### PR DESCRIPTION
*Description*: Update PGV, bazel-gazelle, c-ares dependencies. Standardize on maintainer provided tarballs where available. Update doco. PR comes from the discussion at https://github.com/envoyproxy/envoy/pull/4836. 

- Moves PGV from a commit reference to a release. Changes between current PGV and latest release 0.0.10 [here](https://github.com/lyft/protoc-gen-validate/compare/30da78c4bcdd477b3c24d13e43cf39361ae3859f...v0.0.10)
- `bazel-gazelle` 0.15.0 ([release notes](https://github.com/bazelbuild/bazel-gazelle/releases/))
- `c-ares` cares-1_15_0 ([release notes](https://c-ares.haxx.se/changelog.html#1_15_0))
- Cleaned up incorrect dates in the comments for `circonus-labs/libcircllhist` and `google/jwt_verify_lib`
- Change to maintainer tarball for `fmtlib/fmt` and `pallets/jinja`.

*Risk Level*: Low
*Testing*: bazel test //test/... and running on local instances
*Docs Changes*: [bazel/EXTERNAL_DEPS.md](https://github.com/envoyproxy/envoy/blob/master/bazel/EXTERNAL_DEPS.md)
*Release Notes*: none required
