### PR TITLE
fuzz: automatic generation of route_fuzz_test corpus.

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -236,6 +236,8 @@ def envoy_cc_binary(
         deps = deps,
     )
 
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
 # Envoy C++ fuzz test targes. These are not included in coverage runs.
 def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
     if not (corpus.startswith("//") or corpus.startswith(":")):
@@ -247,6 +249,11 @@ def envoy_cc_fuzz_test(name, corpus, deps = [], tags = [], **kwargs):
         )
     else:
         corpus_name = corpus
+    pkg_tar(
+        name = name + "_corpus_tar",
+        srcs = [corpus_name],
+        testonly = 1,
+    )
     test_lib_name = name + "_lib"
     envoy_cc_test_library(
         name = test_lib_name,

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -93,10 +93,44 @@ envoy_proto_library(
     ],
 )
 
+# We generate the route_fuzz_test corpus from config_impl_test below. Since Bazel forces us to
+# enumerate all outputs from any rule (including genrule), we create dummy outputs of the form
+# generated_corpus_%d for [0..route_corpus_max). These placeholders are then populated by
+# config_impl_test. We need to increase this number if the test grows significantly.
+ROUTE_CORPUS_MAX = 1000
+
+sh_binary(
+    name = "corpus_from_config_impl_sh",
+    srcs = ["corpus_from_config_impl.sh"],
+)
+
+genrule(
+    name = "corpus_from_config_impl",
+    testonly = 1,
+    srcs = [
+        # This is deliberately in srcs, since we run into host/target confusion
+        # otherwise in oss-fuzz builds.
+        ":config_impl_test",
+    ],
+    outs = ["generated_corpus_%d" % n for n in range(ROUTE_CORPUS_MAX)],
+    cmd = " ".join([
+        "ROUTE_CORPUS_PATH=\"$(@D)\" ROUTE_CORPUS_MAX=%d" % ROUTE_CORPUS_MAX,
+        "$(location corpus_from_config_impl_sh)",
+        "$(location //test/common/router:config_impl_test)",
+    ]),
+    tools = [":corpus_from_config_impl_sh"],
+)
+
+filegroup(
+    name = "route_corpus",
+    testonly = 1,
+    srcs = [":corpus_from_config_impl"] + native.glob(["route_corpus/**"]),
+)
+
 envoy_cc_fuzz_test(
     name = "route_fuzz_test",
     srcs = ["route_fuzz_test.cc"],
-    corpus = "route_corpus",
+    corpus = ":route_corpus",
     deps = [
         ":route_fuzz_proto_cc",
         "//source/common/router:config_lib",

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -59,11 +59,15 @@ public:
         TestEnvironment::getOptionalEnvVar("ROUTE_CORPUS_PATH");
     if (corpus_path) {
       static uint32_t n;
+      const uint32_t max_test_cases =
+          std::atoi(TestEnvironment::getCheckedEnvVar("ROUTE_CORPUS_MAX").c_str());
       test::common::router::RouteTestCase route_test_case;
       route_test_case.mutable_config()->MergeFrom(config_);
       route_test_case.mutable_headers()->MergeFrom(Fuzz::toHeaders(headers));
       route_test_case.set_random_value(random_value);
-      const std::string path = fmt::format("{}/config_impl_test_{}", corpus_path.value(), n++);
+      RELEASE_ASSERT(n < max_test_cases,
+                     "ROUTE_CORPUS_MAX is too low, consider increasing in build rule");
+      const std::string path = fmt::format("{}/generated_corpus_{}", corpus_path.value(), n++);
       const std::string corpus = route_test_case.DebugString();
       {
         std::ofstream corpus_file(path);

--- a/test/common/router/corpus_from_config_impl.sh
+++ b/test/common/router/corpus_from_config_impl.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Helper shell script for :corpus_from_config_impl genrule in BUILD.
+
+set -e
+
+TEST_SRCDIR=/some TEST_WORKSPACE=/bogus $*
+
+# Verify at least one entry is actually generated
+[ -e "${ROUTE_CORPUS_PATH}"/generated_corpus_0 ]
+
+# Touch the remaining files so that Bazel doesn't complain they are missing.
+for n in $(seq "${ROUTE_CORPUS_MAX}")
+do
+  touch "${ROUTE_CORPUS_PATH}/generated_corpus_$n"
+done

--- a/test/common/router/corpus_from_config_impl.sh
+++ b/test/common/router/corpus_from_config_impl.sh
@@ -4,7 +4,9 @@
 
 set -e
 
-TEST_SRCDIR=/some TEST_WORKSPACE=/bogus $*
+# TEST_SRCDIR/TEST_WORKSPACE don't matter to config_impl_test, but they need to
+# be present because main.cc checks for their presence.
+TEST_SRCDIR=/totally TEST_WORKSPACE=/bogus $*
 
 # Verify at least one entry is actually generated
 [ -e "${ROUTE_CORPUS_PATH}"/generated_corpus_0 ]


### PR DESCRIPTION
Bazel genrule trickery to be able to synthesize the corpus in a format that we can consume in Bazel,
as a flat file collection, and also in oss-fuzz Docker, as a tar of the flat file collection.

Risk Level: Low
Testing: Bazel and oss-fuzz Docker builds and test/fuzz runs.

Signed-off-by: Harvey Tuch <htuch@google.com>