### PR TITLE
lint: use make_unique/make_shared wherever possible

### DIFF
--- a/source/common/compressor/zlib_compressor_impl.cc
+++ b/source/common/compressor/zlib_compressor_impl.cc
@@ -1,5 +1,7 @@
 #include "common/compressor/zlib_compressor_impl.h"
 
+#include <memory>
+
 #include "envoy/common/exception.h"
 
 #include "common/common/assert.h"
@@ -89,7 +91,7 @@ void ZlibCompressorImpl::updateOutput(Buffer::Instance& output_buffer) {
   if (n_output > 0) {
     output_buffer.add(static_cast<void*>(chunk_char_ptr_.get()), n_output);
   }
-  chunk_char_ptr_.reset(new unsigned char[chunk_size_]);
+  chunk_char_ptr_ = std::make_unique<unsigned char[]>(chunk_size_);
   zstream_ptr_->avail_out = chunk_size_;
   zstream_ptr_->next_out = chunk_char_ptr_.get();
 }

--- a/source/common/config/http_subscription_impl.h
+++ b/source/common/config/http_subscription_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "envoy/api/v2/core/base.pb.h"
 #include "envoy/config/subscription.h"
 
@@ -68,7 +70,8 @@ public:
     stats_.update_attempt_.inc();
     request.headers().insertMethod().value().setReference(Http::Headers::get().MethodValues.Post);
     request.headers().insertPath().value(path_);
-    request.body().reset(new Buffer::OwnedImpl(MessageUtil::getJsonStringFromMessage(request_)));
+    request.body() =
+        std::make_unique<Buffer::OwnedImpl>(MessageUtil::getJsonStringFromMessage(request_));
     request.headers().insertContentType().value().setReference(
         Http::Headers::get().ContentTypeValues.Json);
     request.headers().insertContentLength().value(request.body()->length());

--- a/source/common/decompressor/zlib_decompressor_impl.cc
+++ b/source/common/decompressor/zlib_decompressor_impl.cc
@@ -1,5 +1,7 @@
 #include "common/decompressor/zlib_decompressor_impl.h"
 
+#include <memory>
+
 #include "envoy/common/exception.h"
 
 #include "common/common/assert.h"
@@ -45,7 +47,7 @@ void ZlibDecompressorImpl::decompress(const Buffer::Instance& input_buffer,
       if (zstream_ptr_->avail_out == 0) {
         output_buffer.add(static_cast<void*>(chunk_char_ptr_.get()),
                           chunk_size_ - zstream_ptr_->avail_out);
-        chunk_char_ptr_.reset(new unsigned char[chunk_size_]);
+        chunk_char_ptr_ = std::make_unique<unsigned char[]>(chunk_size_);
         zstream_ptr_->avail_out = chunk_size_;
         zstream_ptr_->next_out = chunk_char_ptr_.get();
       }

--- a/source/common/event/dispatched_thread.cc
+++ b/source/common/event/dispatched_thread.cc
@@ -1,6 +1,7 @@
 #include "common/event/dispatched_thread.h"
 
 #include <chrono>
+#include <memory>
 
 #include "envoy/common/time.h"
 #include "envoy/event/dispatcher.h"
@@ -14,7 +15,8 @@ namespace Envoy {
 namespace Event {
 
 void DispatchedThreadImpl::start(Server::GuardDog& guard_dog) {
-  thread_.reset(new Thread::Thread([this, &guard_dog]() -> void { threadRoutine(guard_dog); }));
+  thread_ =
+      std::make_unique<Thread::Thread>([this, &guard_dog]() -> void { threadRoutine(guard_dog); });
 }
 
 void DispatchedThreadImpl::exit() {

--- a/source/common/filesystem/filesystem_impl.cc
+++ b/source/common/filesystem/filesystem_impl.cc
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <string>
 
@@ -248,7 +249,7 @@ void FileImpl::write(absl::string_view data) {
 }
 
 void FileImpl::createFlushStructures() {
-  flush_thread_.reset(new Thread::Thread([this]() -> void { flushThreadFunc(); }));
+  flush_thread_ = std::make_unique<Thread::Thread>([this]() -> void { flushThreadFunc(); });
   flush_timer_->enableTimer(flush_interval_msec_);
 }
 

--- a/source/common/grpc/codec.cc
+++ b/source/common/grpc/codec.cc
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 #include "common/buffer/buffer_impl.h"
@@ -65,7 +66,7 @@ bool Decoder::decode(Buffer::Instance& input, std::vector<Frame>& output) {
           output.push_back(std::move(frame_));
           state_ = State::FH_FLAG;
         } else {
-          frame_.data_.reset(new Buffer::OwnedImpl());
+          frame_.data_ = std::make_unique<Buffer::OwnedImpl>();
           state_ = State::DATA;
         }
         mem++;

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -84,7 +84,7 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
       tracing_config_(Tracing::EgressConfig::get()),
       route_(std::make_shared<RouteImpl>(parent_.cluster_->name(), timeout)) {
   if (buffer_body_for_retry) {
-    buffered_body_.reset(new Buffer::OwnedImpl());
+    buffered_body_ = std::make_unique<Buffer::OwnedImpl>();
   }
 
   router_.setDecoderFilterCallbacks(*this);
@@ -198,7 +198,7 @@ void AsyncRequestImpl::initialize() {
 void AsyncRequestImpl::onComplete() { callbacks_.onSuccess(std::move(response_)); }
 
 void AsyncRequestImpl::onHeaders(HeaderMapPtr&& headers, bool end_stream) {
-  response_.reset(new ResponseMessageImpl(std::move(headers)));
+  response_ = std::make_unique<ResponseMessageImpl>(std::move(headers));
 
   if (end_stream) {
     onComplete();
@@ -207,7 +207,7 @@ void AsyncRequestImpl::onHeaders(HeaderMapPtr&& headers, bool end_stream) {
 
 void AsyncRequestImpl::onData(Buffer::Instance& data, bool end_stream) {
   if (!response_->body()) {
-    response_->body().reset(new Buffer::OwnedImpl());
+    response_->body() = std::make_unique<Buffer::OwnedImpl>();
   }
   response_->body()->move(data);
 

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -1,6 +1,7 @@
 #include "common/http/codec_client.h"
 
 #include <cstdint>
+#include <memory>
 
 #include "common/common/enum_to_int.h"
 #include "common/http/exception.h"
@@ -139,12 +140,12 @@ CodecClientProd::CodecClientProd(Type type, Network::ClientConnectionPtr&& conne
     : CodecClient(type, std::move(connection), host, dispatcher) {
   switch (type) {
   case Type::HTTP1: {
-    codec_.reset(new Http1::ClientConnectionImpl(*connection_, *this));
+    codec_ = std::make_unique<Http1::ClientConnectionImpl>(*connection_, *this);
     break;
   }
   case Type::HTTP2: {
-    codec_.reset(new Http2::ClientConnectionImpl(*connection_, *this, host->cluster().statsScope(),
-                                                 host->cluster().http2Settings()));
+    codec_ = std::make_unique<Http2::ClientConnectionImpl>(
+        *connection_, *this, host->cluster().statsScope(), host->cluster().http2Settings());
     break;
   }
   }

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <functional>
 #include <list>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -1477,9 +1478,9 @@ void ConnectionManagerImpl::ActiveStreamFilterBase::clearRouteCache() {
 }
 
 Buffer::WatermarkBufferPtr ConnectionManagerImpl::ActiveStreamDecoderFilter::createBuffer() {
-  auto buffer = Buffer::WatermarkBufferPtr{
-      new Buffer::WatermarkBuffer([this]() -> void { this->requestDataDrained(); },
-                                  [this]() -> void { this->requestDataTooLarge(); })};
+  auto buffer =
+      std::make_unique<Buffer::WatermarkBuffer>([this]() -> void { this->requestDataDrained(); },
+                                                [this]() -> void { this->requestDataTooLarge(); });
   buffer->setWatermarks(parent_.buffer_limit_);
   return buffer;
 }

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <list>
+#include <memory>
 #include <string>
 
 #include "common/common/assert.h"
@@ -283,7 +284,7 @@ void HeaderMapImpl::StaticLookupTable::add(const char* key, StaticLookupEntry::E
   StaticLookupEntry* current = &root_;
   while (uint8_t c = *key) {
     if (!current->entries_[c]) {
-      current->entries_[c].reset(new StaticLookupEntry());
+      current->entries_[c] = std::make_unique<StaticLookupEntry>();
     }
 
     current = current->entries_[c].get();

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -1,6 +1,7 @@
 #include "common/http/http1/codec_impl.h"
 
 #include <cstdint>
+#include <memory>
 #include <string>
 
 #include "envoy/buffer/buffer.h"
@@ -444,7 +445,7 @@ void ConnectionImpl::onMessageCompleteBase() {
 void ConnectionImpl::onMessageBeginBase() {
   ENVOY_CONN_LOG(trace, "message begin", connection_);
   ASSERT(!current_header_map_);
-  current_header_map_.reset(new HeaderMapImpl());
+  current_header_map_ = std::make_unique<HeaderMapImpl>();
   header_parsing_state_ = HeaderParsingState::Field;
   onMessageBegin();
 }
@@ -592,7 +593,7 @@ int ServerConnectionImpl::onHeadersComplete(HeaderMapImplPtr&& headers) {
 void ServerConnectionImpl::onMessageBegin() {
   if (!resetStreamCalled()) {
     ASSERT(!active_request_);
-    active_request_.reset(new ActiveRequest(*this));
+    active_request_ = std::make_unique<ActiveRequest>(*this);
     active_request_->request_decoder_ = &callbacks_.newStream(active_request_->response_encoder_);
   }
 }
@@ -686,7 +687,7 @@ StreamEncoder& ClientConnectionImpl::newStream(StreamDecoder& response_decoder) 
   while (!connection_.readEnabled()) {
     connection_.readDisable(false);
   }
-  request_encoder_.reset(new RequestStreamEncoderImpl(*this));
+  request_encoder_ = std::make_unique<RequestStreamEncoderImpl>(*this);
   pending_responses_.emplace_back(&response_decoder);
   return *request_encoder_;
 }

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <list>
+#include <memory>
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
@@ -58,7 +59,7 @@ void ConnPoolImpl::addDrainedCallback(DrainedCb cb) {
 void ConnPoolImpl::attachRequestToClient(ActiveClient& client, StreamDecoder& response_decoder,
                                          ConnectionPool::Callbacks& callbacks) {
   ASSERT(!client.stream_wrapper_);
-  client.stream_wrapper_.reset(new StreamWrapper(response_decoder, client));
+  client.stream_wrapper_ = std::make_unique<StreamWrapper>(response_decoder, client);
   callbacks.onPoolReady(*client.stream_wrapper_, client.real_host_description_);
 }
 
@@ -312,8 +313,8 @@ ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
       connect_timer_(parent_.dispatcher_.createTimer([this]() -> void { onConnectTimeout(); })),
       remaining_requests_(parent_.host_->cluster().maxRequestsPerConnection()) {
 
-  parent_.conn_connect_ms_.reset(new Stats::Timespan(
-      parent_.host_->cluster().stats().upstream_cx_connect_ms_, parent_.dispatcher_.timeSystem()));
+  parent_.conn_connect_ms_ = std::make_unique<Stats::Timespan>(
+      parent_.host_->cluster().stats().upstream_cx_connect_ms_, parent_.dispatcher_.timeSystem());
   Upstream::Host::CreateConnectionData data =
       parent_.host_->createConnection(parent_.dispatcher_, parent_.socket_options_);
   real_host_description_ = data.host_description_;
@@ -325,8 +326,8 @@ ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
   parent_.host_->cluster().stats().upstream_cx_http1_total_.inc();
   parent_.host_->stats().cx_total_.inc();
   parent_.host_->stats().cx_active_.inc();
-  conn_length_.reset(new Stats::Timespan(parent_.host_->cluster().stats().upstream_cx_length_ms_,
-                                         parent_.dispatcher_.timeSystem()));
+  conn_length_ = std::make_unique<Stats::Timespan>(
+      parent_.host_->cluster().stats().upstream_cx_length_ms_, parent_.dispatcher_.timeSystem());
   connect_timer_->enableTimer(parent_.host_->cluster().connectTimeout());
   parent_.host_->cluster().resourceManager(parent_.priority_).connections().inc();
 

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -124,7 +124,7 @@ void ConnectionImpl::StreamImpl::encodeTrailers(const HeaderMap& trailers) {
     // In this case we want trailers to come after we release all pending body data that is
     // waiting on window updates. We need to save the trailers so that we can emit them later.
     ASSERT(!pending_trailers_);
-    pending_trailers_.reset(new HeaderMapImpl(trailers));
+    pending_trailers_ = std::make_unique<HeaderMapImpl>(trailers);
   } else {
     submitTrailers(trailers);
     parent_.sendPendingFrames();
@@ -798,7 +798,7 @@ int ClientConnectionImpl::onBeginHeaders(const nghttp2_frame* frame) {
   if (frame->headers.cat == NGHTTP2_HCAT_HEADERS) {
     StreamImpl* stream = getStream(frame->hd.stream_id);
     ASSERT(!stream->headers_);
-    stream->headers_.reset(new HeaderMapImpl());
+    stream->headers_ = std::make_unique<HeaderMapImpl>();
   }
 
   return 0;
@@ -831,7 +831,7 @@ int ServerConnectionImpl::onBeginHeaders(const nghttp2_frame* frame) {
 
     StreamImpl* stream = getStream(frame->hd.stream_id);
     ASSERT(!stream->headers_);
-    stream->headers_.reset(new HeaderMapImpl());
+    stream->headers_ = std::make_unique<HeaderMapImpl>();
     return 0;
   }
 

--- a/source/common/http/user_agent.cc
+++ b/source/common/http/user_agent.cc
@@ -1,6 +1,7 @@
 #include "common/http/user_agent.h"
 
 #include <cstdint>
+#include <memory>
 #include <string>
 
 #include "envoy/network/connection.h"
@@ -45,7 +46,8 @@ void UserAgent::initializeFromHeaders(const HeaderMap& headers, const std::strin
   }
 
   if (type_ != Type::Unknown) {
-    stats_.reset(new UserAgentStats{ALL_USER_AGENTS_STATS(POOL_COUNTER_PREFIX(scope, prefix_))});
+    stats_ = std::make_unique<UserAgentStats>(
+        UserAgentStats{ALL_USER_AGENTS_STATS(POOL_COUNTER_PREFIX(scope, prefix_))});
     stats_->downstream_cx_total_.inc();
     stats_->downstream_rq_total_.inc();
     scope_ = &scope;

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -52,7 +52,7 @@ public:
 
   // Value factory.
   template <typename T> static FieldSharedPtr createValue(T value) {
-    return FieldSharedPtr{new Field(value)};
+    return FieldSharedPtr{new Field(value)}; // NOLINT(modernize-make-shared)
   }
 
   void append(FieldSharedPtr field_ptr) {

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <memory>
 
 #include "envoy/common/exception.h"
 #include "envoy/event/timer.h"
@@ -556,7 +557,7 @@ void ConnectionImpl::setConnectionStats(const ConnectionStats& stats) {
   ASSERT(!connection_stats_,
          "Two network filters are attempting to set connection stats. This indicates an issue "
          "with the configured filter chain.");
-  connection_stats_.reset(new ConnectionStats(stats));
+  connection_stats_ = std::make_unique<ConnectionStats>(stats);
 }
 
 void ConnectionImpl::updateReadBufferStats(uint64_t num_read, uint64_t new_size) {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -320,7 +320,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
     const auto filter_it = route.route().metadata_match().filter_metadata().find(
         Envoy::Config::MetadataFilters::get().ENVOY_LB);
     if (filter_it != route.route().metadata_match().filter_metadata().end()) {
-      metadata_match_criteria_.reset(new MetadataMatchCriteriaImpl(filter_it->second));
+      metadata_match_criteria_ = std::make_unique<MetadataMatchCriteriaImpl>(filter_it->second);
     }
   }
 
@@ -358,7 +358,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
   }
 
   if (!route.route().hash_policy().empty()) {
-    hash_policy_.reset(new HashPolicyImpl(route.route().hash_policy()));
+    hash_policy_ = std::make_unique<HashPolicyImpl>(route.route().hash_policy());
   }
 
   // Only set include_vh_rate_limits_ to true if the rate limit policy for the route is empty
@@ -368,7 +368,7 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
        PROTOBUF_GET_WRAPPED_OR_DEFAULT(route.route(), include_vh_rate_limits, false));
 
   if (route.route().has_cors()) {
-    cors_policy_.reset(new CorsPolicyImpl(route.route().cors()));
+    cors_policy_ = std::make_unique<CorsPolicyImpl>(route.route().cors());
   }
 }
 
@@ -669,7 +669,8 @@ RouteEntryImplBase::WeightedClusterEntry::WeightedClusterEntry(
         cluster_metadata_match_criteria_ =
             parent->metadata_match_criteria_->mergeMatchCriteria(filter_it->second);
       } else {
-        cluster_metadata_match_criteria_.reset(new MetadataMatchCriteriaImpl(filter_it->second));
+        cluster_metadata_match_criteria_ =
+            std::make_unique<MetadataMatchCriteriaImpl>(filter_it->second);
       }
     }
   }
@@ -827,7 +828,7 @@ VirtualHostImpl::VirtualHostImpl(const envoy::api::v2::route::VirtualHost& virtu
   }
 
   if (virtual_host.has_cors()) {
-    cors_policy_.reset(new CorsPolicyImpl(virtual_host.cors()));
+    cors_policy_ = std::make_unique<CorsPolicyImpl>(virtual_host.cors());
   }
 }
 
@@ -976,9 +977,9 @@ ConfigImpl::ConfigImpl(const envoy::api::v2::RouteConfiguration& config,
                        Server::Configuration::FactoryContext& factory_context,
                        bool validate_clusters_default)
     : name_(config.name()) {
-  route_matcher_.reset(new RouteMatcher(
+  route_matcher_ = std::make_unique<RouteMatcher>(
       config, *this, factory_context,
-      PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, validate_clusters, validate_clusters_default)));
+      PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, validate_clusters, validate_clusters_default));
 
   for (const std::string& header : config.internal_only_headers()) {
     internal_only_headers_.push_back(Http::LowerCaseString(header));

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <functional>
 #include <list>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -210,7 +211,7 @@ ClusterManagerImpl::ClusterManagerImpl(const envoy::config::bootstrap::v2::Boots
 
   // Now setup ADS if needed, this might rely on a primary cluster.
   if (bootstrap.dynamic_resources().has_ads_config()) {
-    ads_mux_.reset(new Config::GrpcMuxImpl(
+    ads_mux_ = std::make_unique<Config::GrpcMuxImpl>(
         local_info,
         Config::Utility::factoryForGrpcApiConfigSource(
             *async_client_manager_, bootstrap.dynamic_resources().ads_config(), stats)
@@ -219,10 +220,9 @@ ClusterManagerImpl::ClusterManagerImpl(const envoy::config::bootstrap::v2::Boots
         *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
             "envoy.service.discovery.v2.AggregatedDiscoveryService.StreamAggregatedResources"),
         random_, stats_,
-        Envoy::Config::Utility::parseRateLimitSettings(
-            bootstrap.dynamic_resources().ads_config())));
+        Envoy::Config::Utility::parseRateLimitSettings(bootstrap.dynamic_resources().ads_config()));
   } else {
-    ads_mux_.reset(new Config::NullGrpcMuxImpl());
+    ads_mux_ = std::make_unique<Config::NullGrpcMuxImpl>();
   }
 
   // After ADS is initialized, load EDS static clusters as EDS config may potentially need ADS.
@@ -302,12 +302,12 @@ ClusterManagerImpl::ClusterManagerImpl(const envoy::config::bootstrap::v2::Boots
 
   if (cm_config.has_load_stats_config()) {
     const auto& load_stats_config = cm_config.load_stats_config();
-    load_stats_reporter_.reset(
-        new LoadStatsReporter(local_info, *this, stats,
-                              Config::Utility::factoryForGrpcApiConfigSource(
-                                  *async_client_manager_, load_stats_config, stats)
-                                  ->create(),
-                              main_thread_dispatcher));
+    load_stats_reporter_ =
+        std::make_unique<LoadStatsReporter>(local_info, *this, stats,
+                                            Config::Utility::factoryForGrpcApiConfigSource(
+                                                *async_client_manager_, load_stats_config, stats)
+                                                ->create(),
+                                            main_thread_dispatcher);
   }
 }
 
@@ -381,13 +381,13 @@ bool ClusterManagerImpl::scheduleUpdate(const Cluster& cluster, uint32_t priorit
   // Find pending updates for this cluster.
   auto& updates_by_prio = updates_map_[cluster.info()->name()];
   if (!updates_by_prio) {
-    updates_by_prio.reset(new PendingUpdatesByPriorityMap());
+    updates_by_prio = std::make_unique<PendingUpdatesByPriorityMap>();
   }
 
   // Find pending updates for this priority.
   auto& updates = (*updates_by_prio)[priority];
   if (!updates) {
-    updates.reset(new PendingUpdates());
+    updates = std::make_unique<PendingUpdates>();
   }
 
   // Has an update_merge_window gone by since the last update? If so, don't schedule
@@ -800,8 +800,8 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ThreadLocalClusterManagerImpl
   if (local_cluster_name) {
     ENVOY_LOG(debug, "adding TLS local cluster {}", local_cluster_name.value());
     auto& local_cluster = parent.active_clusters_.at(local_cluster_name.value());
-    thread_local_clusters_[local_cluster_name.value()].reset(new ClusterEntry(
-        *this, local_cluster->cluster_->info(), local_cluster->loadBalancerFactory()));
+    thread_local_clusters_[local_cluster_name.value()] = std::make_unique<ClusterEntry>(
+        *this, local_cluster->cluster_->info(), local_cluster->loadBalancerFactory());
   }
 
   local_priority_set_ = local_cluster_name
@@ -816,8 +816,8 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ThreadLocalClusterManagerImpl
 
     ENVOY_LOG(debug, "adding TLS initial cluster {}", cluster.first);
     ASSERT(thread_local_clusters_.count(cluster.first) == 0);
-    thread_local_clusters_[cluster.first].reset(new ClusterEntry(
-        *this, cluster.second->cluster_->info(), cluster.second->loadBalancerFactory()));
+    thread_local_clusters_[cluster.first] = std::make_unique<ClusterEntry>(
+        *this, cluster.second->cluster_->info(), cluster.second->loadBalancerFactory());
   }
 }
 
@@ -1026,31 +1026,31 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(
   // TODO(mattklein123): Consider converting other LBs over to thread local. All of them could
   // benefit given the healthy panic, locality, and priority calculations that take place.
   if (cluster->lbSubsetInfo().isEnabled()) {
-    lb_.reset(new SubsetLoadBalancer(cluster->lbType(), priority_set_, parent_.local_priority_set_,
-                                     cluster->stats(), parent.parent_.runtime_,
-                                     parent.parent_.random_, cluster->lbSubsetInfo(),
-                                     cluster->lbRingHashConfig(), cluster->lbConfig()));
+    lb_ = std::make_unique<SubsetLoadBalancer>(
+        cluster->lbType(), priority_set_, parent_.local_priority_set_, cluster->stats(),
+        parent.parent_.runtime_, parent.parent_.random_, cluster->lbSubsetInfo(),
+        cluster->lbRingHashConfig(), cluster->lbConfig());
   } else {
     switch (cluster->lbType()) {
     case LoadBalancerType::LeastRequest: {
       ASSERT(lb_factory_ == nullptr);
-      lb_.reset(new LeastRequestLoadBalancer(priority_set_, parent_.local_priority_set_,
-                                             cluster->stats(), parent.parent_.runtime_,
-                                             parent.parent_.random_, cluster->lbConfig()));
+      lb_ = std::make_unique<LeastRequestLoadBalancer>(priority_set_, parent_.local_priority_set_,
+                                                       cluster->stats(), parent.parent_.runtime_,
+                                                       parent.parent_.random_, cluster->lbConfig());
       break;
     }
     case LoadBalancerType::Random: {
       ASSERT(lb_factory_ == nullptr);
-      lb_.reset(new RandomLoadBalancer(priority_set_, parent_.local_priority_set_, cluster->stats(),
-                                       parent.parent_.runtime_, parent.parent_.random_,
-                                       cluster->lbConfig()));
+      lb_ = std::make_unique<RandomLoadBalancer>(priority_set_, parent_.local_priority_set_,
+                                                 cluster->stats(), parent.parent_.runtime_,
+                                                 parent.parent_.random_, cluster->lbConfig());
       break;
     }
     case LoadBalancerType::RoundRobin: {
       ASSERT(lb_factory_ == nullptr);
-      lb_.reset(new RoundRobinLoadBalancer(priority_set_, parent_.local_priority_set_,
-                                           cluster->stats(), parent.parent_.runtime_,
-                                           parent.parent_.random_, cluster->lbConfig()));
+      lb_ = std::make_unique<RoundRobinLoadBalancer>(priority_set_, parent_.local_priority_set_,
+                                                     cluster->stats(), parent.parent_.runtime_,
+                                                     parent.parent_.random_, cluster->lbConfig());
       break;
     }
     case LoadBalancerType::RingHash:
@@ -1061,9 +1061,9 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(
     }
     case LoadBalancerType::OriginalDst: {
       ASSERT(lb_factory_ == nullptr);
-      lb_.reset(new OriginalDstCluster::LoadBalancer(
+      lb_ = std::make_unique<OriginalDstCluster::LoadBalancer>(
           priority_set_, parent.parent_.active_clusters_.at(cluster->name())->cluster_,
-          cluster->lbOriginalDstConfig()));
+          cluster->lbOriginalDstConfig());
       break;
     }
     }

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -1,6 +1,7 @@
 #include "common/upstream/load_balancer_impl.h"
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -300,7 +301,7 @@ void ZoneAwareLoadBalancerBase::resizePerPriorityState() {
   const uint32_t size = priority_set_.hostSetsPerPriority().size();
   while (per_priority_state_.size() < size) {
     // Note for P!=0, PerPriorityState is created with NoLocalityRouting and never changed.
-    per_priority_state_.push_back(PerPriorityStatePtr{new PerPriorityState});
+    per_priority_state_.push_back(std::make_unique<PerPriorityState>());
   }
 }
 

--- a/source/common/upstream/thread_aware_lb_impl.cc
+++ b/source/common/upstream/thread_aware_lb_impl.cc
@@ -1,5 +1,7 @@
 #include "common/upstream/thread_aware_lb_impl.h"
 
+#include <memory>
+
 namespace Envoy {
 namespace Upstream {
 
@@ -23,7 +25,7 @@ void ThreadAwareLoadBalancerBase::refresh() {
 
   for (const auto& host_set : priority_set_.hostSetsPerPriority()) {
     const uint32_t priority = host_set->priority();
-    (*per_priority_state_vector)[priority].reset(new PerPriorityState);
+    (*per_priority_state_vector)[priority] = std::make_unique<PerPriorityState>();
     const auto& per_priority_state = (*per_priority_state_vector)[priority];
     // Copy panic flag from LoadBalancerBase. It is calculated when there is a change
     // in hosts set or hosts' health.

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -339,7 +339,7 @@ protected:
   // Allows subclasses of PrioritySetImpl to create their own type of HostSetImpl.
   virtual HostSetImplPtr createHostSet(uint32_t priority,
                                        absl::optional<uint32_t> overprovisioning_factor) {
-    return HostSetImplPtr{new HostSetImpl(priority, overprovisioning_factor)};
+    return std::make_unique<HostSetImpl>(priority, overprovisioning_factor);
   }
 
 private:

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -53,14 +53,14 @@ MainCommonBase::MainCommonBase(OptionsImpl& options, Event::TimeSystem& time_sys
   case Server::Mode::Serve: {
 #ifdef ENVOY_HOT_RESTART
     if (!options.hotRestartDisabled()) {
-      restarter_.reset(new Server::HotRestartImpl(options_));
+      restarter_ = std::make_unique<Server::HotRestartImpl>(options_);
     }
 #endif
     if (restarter_.get() == nullptr) {
-      restarter_.reset(new Server::HotRestartNopImpl());
+      restarter_ = std::make_unique<Server::HotRestartNopImpl>();
     }
 
-    tls_.reset(new ThreadLocal::InstanceImpl);
+    tls_ = std::make_unique<ThreadLocal::InstanceImpl>();
     Thread::BasicLockable& log_lock = restarter_->logLock();
     Thread::BasicLockable& access_log_lock = restarter_->accessLogLock();
     auto local_address = Network::Utility::getLocalAddress(options_.localAddressIpVersion());
@@ -78,7 +78,7 @@ MainCommonBase::MainCommonBase(OptionsImpl& options, Event::TimeSystem& time_sys
     break;
   }
   case Server::Mode::Validate:
-    restarter_.reset(new Server::HotRestartNopImpl());
+    restarter_ = std::make_unique<Server::HotRestartNopImpl>();
     logging_context_ = std::make_unique<Logger::Context>(options_.logLevel(), options_.logFormat(),
                                                          restarter_->logLock());
     break;

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -56,7 +56,7 @@ MainCommonBase::MainCommonBase(OptionsImpl& options, Event::TimeSystem& time_sys
       restarter_ = std::make_unique<Server::HotRestartImpl>(options_);
     }
 #endif
-    if (restarter_.get() == nullptr) {
+    if (restarter_ == nullptr) {
       restarter_ = std::make_unique<Server::HotRestartNopImpl>();
     }
 

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -1,5 +1,6 @@
 #include "extensions/access_loggers/file/config.h"
 
+#include <memory>
 #include <unordered_map>
 
 #include "envoy/config/accesslog/v2/file.pb.validate.h"
@@ -32,12 +33,12 @@ FileAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
     if (fal_config.format().empty()) {
       formatter = AccessLog::AccessLogFormatUtils::defaultAccessLogFormatter();
     } else {
-      formatter.reset(new AccessLog::FormatterImpl(fal_config.format()));
+      formatter = std::make_unique<AccessLog::FormatterImpl>(fal_config.format());
     }
   } else if (fal_config.access_log_format_case() ==
              envoy::config::accesslog::v2::FileAccessLog::kJsonFormat) {
     auto json_format_map = this->convertJsonFormatToMap(fal_config.json_format());
-    formatter.reset(new AccessLog::JsonFormatterImpl(json_format_map));
+    formatter = std::make_unique<AccessLog::JsonFormatterImpl>(json_format_map);
   } else {
     throw EnvoyException(
         "Invalid access_log format provided. Only 'format' and 'json_format' are supported.");

--- a/source/extensions/filters/common/lua/lua.cc
+++ b/source/extensions/filters/common/lua/lua.cc
@@ -1,5 +1,7 @@
 #include "extensions/filters/common/lua/lua.h"
 
+#include <memory>
+
 #include "envoy/common/exception.h"
 
 #include "common/common/assert.h"
@@ -85,7 +87,7 @@ uint64_t ThreadLocalState::registerGlobal(const std::string& global) {
 
 CoroutinePtr ThreadLocalState::createCoroutine() {
   lua_State* state = tls_slot_->getTyped<LuaThreadLocal>().state_.get();
-  return CoroutinePtr{new Coroutine({lua_newthread(state), state})};
+  return std::make_unique<Coroutine>(std::make_pair(lua_newthread(state), state));
 }
 
 ThreadLocalState::LuaThreadLocal::LuaThreadLocal(const std::string& code) : state_(lua_open()) {

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -1,5 +1,7 @@
 #include "extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h"
 
+#include <memory>
+
 #include "envoy/common/exception.h"
 #include "envoy/http/filter.h"
 
@@ -121,9 +123,9 @@ JsonTranscoderConfig::JsonTranscoderConfig(
 
   path_matcher_ = pmb.Build();
 
-  type_helper_.reset(
-      new google::grpc::transcoding::TypeHelper(Protobuf::util::NewTypeResolverForDescriptorPool(
-          Grpc::Common::typeUrlPrefix(), &descriptor_pool_)));
+  type_helper_ = std::make_unique<google::grpc::transcoding::TypeHelper>(
+      Protobuf::util::NewTypeResolverForDescriptorPool(Grpc::Common::typeUrlPrefix(),
+                                                       &descriptor_pool_));
 
   const auto print_config = proto_config.print_options();
   print_options_.add_whitespace = print_config.add_whitespace();
@@ -192,8 +194,8 @@ ProtobufUtil::Status JsonTranscoderConfig::createTranscoder(
       type_helper_->Resolver(), response_type_url, method_descriptor->server_streaming(),
       &response_input, print_options_)};
 
-  transcoder.reset(
-      new TranscoderImpl(std::move(request_translator), std::move(response_translator)));
+  transcoder = std::make_unique<TranscoderImpl>(std::move(request_translator),
+                                                std::move(response_translator));
   return ProtobufUtil::Status();
 }
 

--- a/source/extensions/filters/http/ip_tagging/ip_tagging_filter.h
+++ b/source/extensions/filters/http/ip_tagging/ip_tagging_filter.h
@@ -67,7 +67,7 @@ public:
       ip_tag_pair.second = cidr_set;
       tag_data.emplace_back(ip_tag_pair);
     }
-    trie_.reset(new Network::LcTrie::LcTrie<std::string>(tag_data));
+    trie_ = std::make_unique<Network::LcTrie::LcTrie<std::string>>(tag_data);
   }
 
   Runtime::Loader& runtime() { return runtime_; }

--- a/source/extensions/filters/http/jwt_authn/extractor.cc
+++ b/source/extensions/filters/http/jwt_authn/extractor.cc
@@ -1,5 +1,7 @@
 #include "extensions/filters/http/jwt_authn/extractor.h"
 
+#include <memory>
+
 #include "common/common/utility.h"
 #include "common/http/headers.h"
 #include "common/http/utility.h"
@@ -157,7 +159,7 @@ void ExtractorImpl::addHeaderConfig(const std::string& issuer, const LowerCaseSt
   const std::string map_key = header_name.get() + value_prefix;
   auto& header_location_spec = header_locations_[map_key];
   if (!header_location_spec) {
-    header_location_spec.reset(new HeaderLocationSpec(header_name, value_prefix));
+    header_location_spec = std::make_unique<HeaderLocationSpec>(header_name, value_prefix);
   }
   header_location_spec->specified_issuers_.insert(issuer);
 }

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -1,5 +1,7 @@
 #include "extensions/filters/http/lua/lua_filter.h"
 
+#include <memory>
+
 #include "envoy/http/codes.h"
 
 #include "common/buffer/buffer_impl.h"
@@ -123,7 +125,7 @@ int StreamHandleWrapper::luaRespond(lua_State* state) {
 
   Buffer::InstancePtr body;
   if (raw_body != nullptr) {
-    body.reset(new Buffer::OwnedImpl(raw_body, body_size));
+    body = std::make_unique<Buffer::OwnedImpl>(raw_body, body_size);
     headers->insertContentLength().value(body_size);
   }
 
@@ -179,7 +181,7 @@ int StreamHandleWrapper::luaHttpCall(lua_State* state) {
   }
 
   if (body != nullptr) {
-    message->body().reset(new Buffer::OwnedImpl(body, body_size));
+    message->body() = std::make_unique<Buffer::OwnedImpl>(body, body_size);
     message->headers().insertContentLength().value(body_size);
   }
 
@@ -252,7 +254,7 @@ void StreamHandleWrapper::onFailure(Http::AsyncClient::FailureReason) {
   Http::MessagePtr response_message(new Http::ResponseMessageImpl(Http::HeaderMapPtr{
       new Http::HeaderMapImpl{{Http::Headers::get().Status,
                                std::to_string(enumToInt(Http::Code::ServiceUnavailable))}}}));
-  response_message->body().reset(new Buffer::OwnedImpl("upstream failure"));
+  response_message->body() = std::make_unique<Buffer::OwnedImpl>("upstream failure");
   onSuccess(std::move(response_message));
 }
 

--- a/source/extensions/filters/http/squash/squash_filter.cc
+++ b/source/extensions/filters/http/squash/squash_filter.cc
@@ -1,5 +1,7 @@
 #include "extensions/filters/http/squash/squash_filter.h"
 
+#include <memory>
+
 #include "envoy/http/codes.h"
 
 #include "common/common/empty_string.h"
@@ -146,7 +148,7 @@ Http::FilterHeadersStatus SquashFilter::decodeHeaders(Http::HeaderMap& headers, 
   request->headers().insertPath().value().setReference(POST_ATTACHMENT_PATH);
   request->headers().insertHost().value().setReference(SERVER_AUTHORITY);
   request->headers().insertMethod().value().setReference(Http::Headers::get().MethodValues.Post);
-  request->body().reset(new Buffer::OwnedImpl(config_->attachmentJson()));
+  request->body() = std::make_unique<Buffer::OwnedImpl>(config_->attachmentJson());
 
   is_squashing_ = true;
   in_flight_request_ =

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -233,9 +233,9 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     uint64_t overall_sampling{
         PROTOBUF_PERCENT_TO_ROUNDED_INTEGER_OR_DEFAULT(tracing_config, overall_sampling, 100, 100)};
 
-    tracing_config_.reset(new Http::TracingConnectionManagerConfig(
-        {tracing_operation_name, request_headers_for_tags, client_sampling, random_sampling,
-         overall_sampling}));
+    tracing_config_ = std::make_unique<Http::TracingConnectionManagerConfig>(
+        Http::TracingConnectionManagerConfig{tracing_operation_name, request_headers_for_tags,
+                                             client_sampling, random_sampling, overall_sampling});
   }
 
   for (const auto& access_log : config.access_log()) {

--- a/source/extensions/filters/network/redis_proxy/codec_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/codec_impl.cc
@@ -1,6 +1,7 @@
 #include "extensions/filters/network/redis_proxy/codec_impl.h"
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -134,7 +135,7 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
     switch (state_) {
     case State::ValueRootStart: {
       ENVOY_LOG(trace, "parse slice: ValueRootStart");
-      pending_value_root_.reset(new RespValue());
+      pending_value_root_ = std::make_unique<RespValue>();
       pending_value_stack_.push_front({pending_value_root_.get(), 0});
       state_ = State::ValueStart;
       break;

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -112,7 +112,7 @@ SplitRequestPtr MGETRequest::create(ConnPool::Instance& conn_pool,
   request_ptr->num_pending_responses_ = incoming_request.asArray().size() - 1;
   request_ptr->pending_requests_.reserve(request_ptr->num_pending_responses_);
 
-  request_ptr->pending_response_.reset(new RespValue());
+  request_ptr->pending_response_ = std::make_unique<RespValue>();
   request_ptr->pending_response_->type(RespType::Array);
   std::vector<RespValue> responses(request_ptr->num_pending_responses_);
   request_ptr->pending_response_->asArray().swap(responses);
@@ -185,7 +185,7 @@ SplitRequestPtr MSETRequest::create(ConnPool::Instance& conn_pool,
   request_ptr->num_pending_responses_ = (incoming_request.asArray().size() - 1) / 2;
   request_ptr->pending_requests_.reserve(request_ptr->num_pending_responses_);
 
-  request_ptr->pending_response_.reset(new RespValue());
+  request_ptr->pending_response_ = std::make_unique<RespValue>();
   request_ptr->pending_response_->type(RespType::SimpleString);
 
   std::vector<RespValue> values(3);
@@ -252,7 +252,7 @@ SplitRequestPtr SplitKeysSumResultRequest::create(ConnPool::Instance& conn_pool,
   request_ptr->num_pending_responses_ = incoming_request.asArray().size() - 1;
   request_ptr->pending_requests_.reserve(request_ptr->num_pending_responses_);
 
-  request_ptr->pending_response_.reset(new RespValue());
+  request_ptr->pending_response_ = std::make_unique<RespValue>();
   request_ptr->pending_response_->type(RespType::Integer);
 
   std::vector<RespValue> values(2);

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -289,7 +289,7 @@ PoolRequest* InstanceImpl::ThreadLocalPool::makeRequest(const std::string& hash_
 
   ThreadLocalActiveClientPtr& client = client_map_[host];
   if (!client) {
-    client.reset(new ThreadLocalActiveClient(*this));
+    client = std::make_unique<ThreadLocalActiveClient>(*this);
     client->host_ = host;
     client->redis_client_ = parent_.client_factory_.create(host, dispatcher_, parent_.config_);
     client->redis_client_->addConnectionCallbacks(*client);

--- a/source/extensions/stat_sinks/dog_statsd/config.cc
+++ b/source/extensions/stat_sinks/dog_statsd/config.cc
@@ -1,5 +1,7 @@
 #include "extensions/stat_sinks/dog_statsd/config.h"
 
+#include <memory>
+
 #include "envoy/config/metrics/v2/stats.pb.h"
 #include "envoy/config/metrics/v2/stats.pb.validate.h"
 #include "envoy/registry/registry.h"
@@ -26,8 +28,7 @@ Stats::SinkPtr DogStatsdSinkFactory::createStatsSink(const Protobuf::Message& co
 }
 
 ProtobufTypes::MessagePtr DogStatsdSinkFactory::createEmptyConfigProto() {
-  return std::unique_ptr<envoy::config::metrics::v2::DogStatsdSink>(
-      new envoy::config::metrics::v2::DogStatsdSink());
+  return std::make_unique<envoy::config::metrics::v2::DogStatsdSink>();
 }
 
 std::string DogStatsdSinkFactory::name() { return StatsSinkNames::get().DogStatsd; }

--- a/source/extensions/stat_sinks/hystrix/config.cc
+++ b/source/extensions/stat_sinks/hystrix/config.cc
@@ -1,5 +1,7 @@
 #include "extensions/stat_sinks/hystrix/config.h"
 
+#include <memory>
+
 #include "envoy/config/metrics/v2/stats.pb.h"
 #include "envoy/config/metrics/v2/stats.pb.validate.h"
 #include "envoy/registry/registry.h"
@@ -22,8 +24,7 @@ Stats::SinkPtr HystrixSinkFactory::createStatsSink(const Protobuf::Message& conf
 }
 
 ProtobufTypes::MessagePtr HystrixSinkFactory::createEmptyConfigProto() {
-  return std::unique_ptr<envoy::config::metrics::v2::HystrixSink>(
-      new envoy::config::metrics::v2::HystrixSink());
+  return std::make_unique<envoy::config::metrics::v2::HystrixSink>();
 }
 
 std::string HystrixSinkFactory::name() { return StatsSinkNames::get().Hystrix; }

--- a/source/extensions/stat_sinks/statsd/config.cc
+++ b/source/extensions/stat_sinks/statsd/config.cc
@@ -1,5 +1,7 @@
 #include "extensions/stat_sinks/statsd/config.h"
 
+#include <memory>
+
 #include "envoy/config/metrics/v2/stats.pb.h"
 #include "envoy/config/metrics/v2/stats.pb.validate.h"
 #include "envoy/registry/registry.h"
@@ -39,8 +41,7 @@ Stats::SinkPtr StatsdSinkFactory::createStatsSink(const Protobuf::Message& confi
 }
 
 ProtobufTypes::MessagePtr StatsdSinkFactory::createEmptyConfigProto() {
-  return std::unique_ptr<envoy::config::metrics::v2::StatsdSink>(
-      new envoy::config::metrics::v2::StatsdSink());
+  return std::make_unique<envoy::config::metrics::v2::StatsdSink>();
 }
 
 std::string StatsdSinkFactory::name() { return StatsSinkNames::get().Statsd; }

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -162,8 +162,8 @@ LightStepDriver::LightStepDriver(const envoy::config::trace::v2::LightstepConfig
       return runtime_.snapshot().getInteger("tracing.lightstep.min_flush_spans",
                                             DefaultMinFlushSpans);
     }};
-    tls_options.metrics_observer.reset(new LightStepMetricsObserver{*this});
-    tls_options.transporter.reset(new LightStepTransporter{*this});
+    tls_options.metrics_observer = std::make_unique<LightStepMetricsObserver>(*this);
+    tls_options.transporter = std::make_unique<LightStepTransporter>(*this);
     std::shared_ptr<lightstep::LightStepTracer> tracer =
         lightstep::MakeLightStepTracer(std::move(tls_options));
 

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -1,5 +1,7 @@
 #include "server/config_validation/server.h"
 
+#include <memory>
+
 #include "envoy/config/bootstrap/v2/bootstrap.pb.h"
 #include "envoy/config/bootstrap/v2/bootstrap.pb.validate.h"
 
@@ -74,21 +76,21 @@ void ValidationInstance::initialize(Options& options,
 
   bootstrap.mutable_node()->set_build_version(VersionInfo::version());
 
-  local_info_.reset(
-      new LocalInfo::LocalInfoImpl(bootstrap.node(), local_address, options.serviceZone(),
-                                   options.serviceClusterName(), options.serviceNodeName()));
+  local_info_ = std::make_unique<LocalInfo::LocalInfoImpl>(
+      bootstrap.node(), local_address, options.serviceZone(), options.serviceClusterName(),
+      options.serviceNodeName());
 
   Configuration::InitialImpl initial_config(bootstrap);
-  overload_manager_.reset(
-      new OverloadManagerImpl(dispatcher(), stats(), threadLocal(), bootstrap.overload_manager()));
-  listener_manager_.reset(new ListenerManagerImpl(*this, *this, *this, time_system_));
+  overload_manager_ = std::make_unique<OverloadManagerImpl>(dispatcher(), stats(), threadLocal(),
+                                                            bootstrap.overload_manager());
+  listener_manager_ = std::make_unique<ListenerManagerImpl>(*this, *this, *this, time_system_);
   thread_local_.registerThread(*dispatcher_, true);
   runtime_loader_ = component_factory.createRuntime(*this, initial_config);
-  secret_manager_.reset(new Secret::SecretManagerImpl());
-  ssl_context_manager_.reset(new Ssl::ContextManagerImpl(time_system_));
-  cluster_manager_factory_.reset(new Upstream::ValidationClusterManagerFactory(
+  secret_manager_ = std::make_unique<Secret::SecretManagerImpl>();
+  ssl_context_manager_ = std::make_unique<Ssl::ContextManagerImpl>(time_system_);
+  cluster_manager_factory_ = std::make_unique<Upstream::ValidationClusterManagerFactory>(
       runtime(), stats(), threadLocal(), random(), dnsResolver(), sslContextManager(), dispatcher(),
-      localInfo(), *secret_manager_));
+      localInfo(), *secret_manager_);
 
   Configuration::MainImpl* main_config = new Configuration::MainImpl();
   config_.reset(main_config);

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -80,11 +80,10 @@ void MainImpl::initialize(const envoy::config::bootstrap::v2::Bootstrap& bootstr
   initializeTracers(bootstrap.tracing(), server);
 
   if (bootstrap.has_rate_limit_service()) {
-    ratelimit_client_factory_.reset(
-        new RateLimit::GrpcFactoryImpl(bootstrap.rate_limit_service(),
-                                       cluster_manager_->grpcAsyncClientManager(), server.stats()));
+    ratelimit_client_factory_ = std::make_unique<RateLimit::GrpcFactoryImpl>(
+        bootstrap.rate_limit_service(), cluster_manager_->grpcAsyncClientManager(), server.stats());
   } else {
-    ratelimit_client_factory_.reset(new RateLimit::NullFactoryImpl());
+    ratelimit_client_factory_ = std::make_unique<RateLimit::NullFactoryImpl>();
   }
 
   initializeStatsSinks(bootstrap, server);
@@ -95,7 +94,7 @@ void MainImpl::initializeTracers(const envoy::config::trace::v2::Tracing& config
   ENVOY_LOG(info, "loading tracing configuration");
 
   if (!configuration.has_http()) {
-    http_tracer_.reset(new Tracing::HttpNullTracer());
+    http_tracer_ = std::make_unique<Tracing::HttpNullTracer>();
     return;
   }
 
@@ -136,7 +135,7 @@ InitialImpl::InitialImpl(const envoy::config::bootstrap::v2::Bootstrap& bootstra
   }
 
   if (bootstrap.has_runtime()) {
-    runtime_.reset(new RuntimeImpl());
+    runtime_ = std::make_unique<RuntimeImpl>();
     runtime_->symlink_root_ = bootstrap.runtime().symlink_root();
     runtime_->subdirectory_ = bootstrap.runtime().subdirectory();
     runtime_->override_subdirectory_ = bootstrap.runtime().override_subdirectory();

--- a/source/server/guarddog_impl.cc
+++ b/source/server/guarddog_impl.cc
@@ -1,6 +1,7 @@
 #include "server/guarddog_impl.h"
 
 #include <chrono>
+#include <memory>
 
 #include "envoy/stats/scope.h"
 
@@ -136,7 +137,7 @@ bool GuardDogImpl::waitOrDetectStop() {
 
 void GuardDogImpl::start() {
   run_thread_ = true;
-  thread_.reset(new Thread::Thread([this]() -> void { threadRoutine(); }));
+  thread_ = std::make_unique<Thread::Thread>([this]() -> void { threadRoutine(); });
 }
 
 void GuardDogImpl::stop() {

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -6,6 +6,7 @@
 #include <sys/un.h>
 
 #include <cstdint>
+#include <memory>
 #include <string>
 
 #include "envoy/event/dispatcher.h"
@@ -130,8 +131,8 @@ HotRestartImpl::HotRestartImpl(Options& options)
     // We must hold the stat lock when attaching to an existing memory segment
     // because it might be actively written to while we sanityCheck it.
     Thread::LockGuard lock(stat_lock_);
-    stats_set_.reset(new RawStatDataSet(stats_set_options_, options.restartEpoch() == 0,
-                                        shmem_.stats_set_data_, options_.statsOptions()));
+    stats_set_ = std::make_unique<RawStatDataSet>(stats_set_options_, options.restartEpoch() == 0,
+                                                  shmem_.stats_set_data_, options_.statsOptions());
   }
   my_domain_socket_ = bindDomainSocket(options.restartEpoch());
   child_address_ = createDomainSocketAddress((options.restartEpoch() + 1));

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -1,6 +1,7 @@
 #include "server/worker_impl.h"
 
 #include <functional>
+#include <memory>
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
@@ -69,7 +70,8 @@ void WorkerImpl::removeListener(Network::ListenerConfig& listener,
 
 void WorkerImpl::start(GuardDog& guard_dog) {
   ASSERT(!thread_);
-  thread_.reset(new Thread::Thread([this, &guard_dog]() -> void { threadRoutine(guard_dog); }));
+  thread_ =
+      std::make_unique<Thread::Thread>([this, &guard_dog]() -> void { threadRoutine(guard_dog); });
 }
 
 void WorkerImpl::stop() {

--- a/test/common/common/block_memory_hash_set_test.cc
+++ b/test/common/common/block_memory_hash_set_test.cc
@@ -51,7 +51,7 @@ protected:
     hash_set_options_.num_slots = 5;
     const uint32_t mem_size =
         BlockMemoryHashSet<TestValueClass>::numBytes(hash_set_options_, stats_options_);
-    memory_.reset(new uint8_t[mem_size]);
+    memory_ = std::make_unique<uint8_t[]>(mem_size);
     memset(memory_.get(), 0, mem_size);
   }
 

--- a/test/common/config/grpc_mux_impl_test.cc
+++ b/test/common/config/grpc_mux_impl_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "envoy/api/v2/discovery.pb.h"
 #include "envoy/api/v2/eds.pb.h"
 
@@ -42,19 +44,19 @@ public:
   }
 
   void setup() {
-    grpc_mux_.reset(new GrpcMuxImpl(
+    grpc_mux_ = std::make_unique<GrpcMuxImpl>(
         local_info_, std::unique_ptr<Grpc::MockAsyncClient>(async_client_), dispatcher_,
         *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
             "envoy.service.discovery.v2.AggregatedDiscoveryService.StreamAggregatedResources"),
-        random_, stats_, rate_limit_settings_));
+        random_, stats_, rate_limit_settings_);
   }
 
   void setup(const RateLimitSettings& custom_rate_limit_settings) {
-    grpc_mux_.reset(new GrpcMuxImpl(
+    grpc_mux_ = std::make_unique<GrpcMuxImpl>(
         local_info_, std::unique_ptr<Grpc::MockAsyncClient>(async_client_), dispatcher_,
         *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
             "envoy.service.discovery.v2.AggregatedDiscoveryService.StreamAggregatedResources"),
-        random_, stats_, custom_rate_limit_settings));
+        random_, stats_, custom_rate_limit_settings);
   }
 
   void expectSendMessage(const std::string& type_url,

--- a/test/common/config/grpc_subscription_test_harness.h
+++ b/test/common/config/grpc_subscription_test_harness.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "envoy/api/v2/eds.pb.h"
 
 #include "common/common/hash.h"
@@ -40,9 +42,9 @@ public:
       timer_cb_ = timer_cb;
       return timer_;
     }));
-    subscription_.reset(new GrpcEdsSubscriptionImpl(
+    subscription_ = std::make_unique<GrpcEdsSubscriptionImpl>(
         local_info_, std::unique_ptr<Grpc::MockAsyncClient>(async_client_), dispatcher_, random_,
-        *method_descriptor_, stats_, stats_store_, rate_limit_settings_));
+        *method_descriptor_, stats_, stats_store_, rate_limit_settings_);
   }
 
   ~GrpcSubscriptionTestHarness() { EXPECT_CALL(async_stream_, sendMessage(_, false)); }

--- a/test/common/config/http_subscription_impl_test.cc
+++ b/test/common/config/http_subscription_impl_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "test/common/config/http_subscription_test_harness.h"
 
 #include "gtest/gtest.h"
@@ -27,7 +29,7 @@ TEST_F(HttpSubscriptionImplTest, BadJsonRecovery) {
   startSubscription({"cluster0", "cluster1"});
   Http::HeaderMapPtr response_headers{new Http::TestHeaderMapImpl{{":status", "200"}}};
   Http::MessagePtr message{new Http::ResponseMessageImpl(std::move(response_headers))};
-  message->body().reset(new Buffer::OwnedImpl(";!@#badjso n"));
+  message->body() = std::make_unique<Buffer::OwnedImpl>(";!@#badjso n");
   EXPECT_CALL(random_gen_, random()).WillOnce(Return(0));
   EXPECT_CALL(*timer_, enableTimer(_));
   EXPECT_CALL(callbacks_, onConfigUpdateFailed(_));

--- a/test/common/config/subscription_factory_test.cc
+++ b/test/common/config/subscription_factory_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "envoy/api/v2/eds.pb.h"
 #include "envoy/common/exception.h"
 #include "envoy/stats/scope.h"
@@ -27,7 +29,8 @@ namespace Config {
 class SubscriptionFactoryTest : public ::testing::Test {
 public:
   SubscriptionFactoryTest() : http_request_(&cm_.async_client_) {
-    legacy_subscription_.reset(new MockSubscription<envoy::api::v2::ClusterLoadAssignment>());
+    legacy_subscription_ =
+        std::make_unique<MockSubscription<envoy::api::v2::ClusterLoadAssignment>>();
   }
 
   std::unique_ptr<Subscription<envoy::api::v2::ClusterLoadAssignment>>

--- a/test/common/config/subscription_impl_test.cc
+++ b/test/common/config/subscription_impl_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "test/common/config/filesystem_subscription_test_harness.h"
 #include "test/common/config/grpc_subscription_test_harness.h"
 #include "test/common/config/http_subscription_test_harness.h"
@@ -18,13 +20,13 @@ public:
   SubscriptionImplTest() {
     switch (GetParam()) {
     case SubscriptionType::Grpc:
-      test_harness_.reset(new GrpcSubscriptionTestHarness());
+      test_harness_ = std::make_unique<GrpcSubscriptionTestHarness>();
       break;
     case SubscriptionType::Http:
-      test_harness_.reset(new HttpSubscriptionTestHarness());
+      test_harness_ = std::make_unique<HttpSubscriptionTestHarness>();
       break;
     case SubscriptionType::Filesystem:
-      test_harness_.reset(new FilesystemSubscriptionTestHarness());
+      test_harness_ = std::make_unique<FilesystemSubscriptionTestHarness>();
       break;
     }
   }

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <cstdint>
+#include <memory>
 #include <string>
 
 #include "common/buffer/buffer_impl.h"
@@ -116,7 +117,7 @@ TEST_F(AsyncClientImplTest, BasicStream) {
 }
 
 TEST_F(AsyncClientImplTest, Basic) {
-  message_->body().reset(new Buffer::OwnedImpl("test body"));
+  message_->body() = std::make_unique<Buffer::OwnedImpl>("test body");
   Buffer::Instance& data = *message_->body();
 
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
@@ -155,7 +156,7 @@ TEST_F(AsyncClientImplTest, Retry) {
       .WillByDefault(Return(true));
   Message* message_copy = message_.get();
 
-  message_->body().reset(new Buffer::OwnedImpl("test body"));
+  message_->body() = std::make_unique<Buffer::OwnedImpl>("test body");
   Buffer::Instance& data = *message_->body();
 
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
@@ -305,7 +306,7 @@ TEST_F(AsyncClientImplTest, MultipleStreams) {
 
 TEST_F(AsyncClientImplTest, MultipleRequests) {
   // Send request 1
-  message_->body().reset(new Buffer::OwnedImpl("test body"));
+  message_->body() = std::make_unique<Buffer::OwnedImpl>("test body");
   Buffer::Instance& data = *message_->body();
 
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
@@ -351,7 +352,7 @@ TEST_F(AsyncClientImplTest, MultipleRequests) {
 
 TEST_F(AsyncClientImplTest, StreamAndRequest) {
   // Send request
-  message_->body().reset(new Buffer::OwnedImpl("test body"));
+  message_->body() = std::make_unique<Buffer::OwnedImpl>("test body");
   Buffer::Instance& data = *message_->body();
 
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
@@ -441,7 +442,7 @@ TEST_F(AsyncClientImplTest, StreamWithTrailers) {
 }
 
 TEST_F(AsyncClientImplTest, Trailers) {
-  message_->body().reset(new Buffer::OwnedImpl("test body"));
+  message_->body() = std::make_unique<Buffer::OwnedImpl>("test body");
   Buffer::Instance& data = *message_->body();
 
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
@@ -700,7 +701,7 @@ TEST_F(AsyncClientImplTest, PoolFailureWithBody) {
       }));
 
   expectSuccess(503);
-  message_->body().reset(new Buffer::OwnedImpl("hello"));
+  message_->body() = std::make_unique<Buffer::OwnedImpl>("hello");
   EXPECT_EQ(nullptr, client_.send(std::move(message_), callbacks_,
                                   absl::optional<std::chrono::milliseconds>()));
 

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -54,8 +54,8 @@ public:
 
     Network::ClientConnectionPtr connection{connection_};
     EXPECT_CALL(dispatcher_, createTimer_(_));
-    client_.reset(
-        new CodecClientForTest(std::move(connection), codec_, nullptr, host_, dispatcher_));
+    client_ = std::make_unique<CodecClientForTest>(std::move(connection), codec_, nullptr, host_,
+                                                   dispatcher_);
   }
 
   ~CodecClientTest() { EXPECT_EQ(0U, client_->numActiveRequests()); }
@@ -262,7 +262,7 @@ TEST_F(CodecClientTest, WatermarkPassthrough) {
 class CodecNetworkTest : public testing::TestWithParam<Network::Address::IpVersion> {
 public:
   CodecNetworkTest() {
-    dispatcher_.reset(new Event::DispatcherImpl(test_time_.timeSystem()));
+    dispatcher_ = std::make_unique<Event::DispatcherImpl>(test_time_.timeSystem());
     upstream_listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
     Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
         socket_.localAddress(), source_address_, Network::Test::createRawBufferSocket(), nullptr);
@@ -270,8 +270,8 @@ public:
     client_connection_->addConnectionCallbacks(client_callbacks_);
 
     codec_ = new Http::MockClientConnection();
-    client_.reset(
-        new CodecClientForTest(std::move(client_connection), codec_, nullptr, host_, *dispatcher_));
+    client_ = std::make_unique<CodecClientForTest>(std::move(client_connection), codec_, nullptr,
+                                                   host_, *dispatcher_);
 
     EXPECT_CALL(listener_callbacks_, onAccept_(_, _))
         .WillOnce(Invoke([&](Network::ConnectionSocketPtr& socket, bool) -> void {

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include <string>
 
 #include "common/http/header_map_impl.h"
@@ -515,7 +516,7 @@ TEST(HeaderMapImplTest, AddCopy) {
 
   // Build "hello" with string concatenation to make it unlikely that the
   // compiler is just reusing the same string constant for everything.
-  lcKeyPtr.reset(new LowerCaseString(std::string("he") + "llo"));
+  lcKeyPtr = std::make_unique<LowerCaseString>(std::string("he") + "llo");
   EXPECT_STREQ("hello", lcKeyPtr->get().c_str());
 
   headers.addCopy(*lcKeyPtr, 42);

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include <string>
 
 #include "envoy/buffer/buffer.h"
@@ -30,7 +31,7 @@ namespace Http1 {
 class Http1ServerConnectionImplTest : public ::testing::Test {
 public:
   void initialize() {
-    codec_.reset(new ServerConnectionImpl(connection_, callbacks_, codec_settings_));
+    codec_ = std::make_unique<ServerConnectionImpl>(connection_, callbacks_, codec_settings_);
   }
 
   NiceMock<Network::MockConnection> connection_;
@@ -52,7 +53,7 @@ void Http1ServerConnectionImplTest::expect400(Protocol p, bool allow_absolute_ur
 
   if (allow_absolute_url) {
     codec_settings_.allow_absolute_url_ = allow_absolute_url;
-    codec_.reset(new ServerConnectionImpl(connection_, callbacks_, codec_settings_));
+    codec_ = std::make_unique<ServerConnectionImpl>(connection_, callbacks_, codec_settings_);
   }
 
   Http::MockStreamDecoder decoder;
@@ -71,7 +72,7 @@ void Http1ServerConnectionImplTest::expectHeadersTest(Protocol p, bool allow_abs
   // Make a new 'codec' with the right settings
   if (allow_absolute_url) {
     codec_settings_.allow_absolute_url_ = allow_absolute_url;
-    codec_.reset(new ServerConnectionImpl(connection_, callbacks_, codec_settings_));
+    codec_ = std::make_unique<ServerConnectionImpl>(connection_, callbacks_, codec_settings_);
   }
 
   Http::MockStreamDecoder decoder;
@@ -596,7 +597,7 @@ TEST_F(Http1ServerConnectionImplTest, WatermarkTest) {
 
 class Http1ClientConnectionImplTest : public testing::Test {
 public:
-  void initialize() { codec_.reset(new ClientConnectionImpl(connection_, callbacks_)); }
+  void initialize() { codec_ = std::make_unique<ClientConnectionImpl>(connection_, callbacks_); }
 
   NiceMock<Network::MockConnection> connection_;
   NiceMock<Http::MockConnectionCallbacks> callbacks_;

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -80,7 +80,8 @@ public:
     test_client.codec_ = new NiceMock<Http::MockClientConnection>();
     test_client.connect_timer_ = new NiceMock<Event::MockTimer>(&mock_dispatcher_);
     std::shared_ptr<Upstream::MockClusterInfo> cluster{new NiceMock<Upstream::MockClusterInfo>()};
-    test_client.client_dispatcher_.reset(new Event::DispatcherImpl(test_time_.timeSystem()));
+    test_client.client_dispatcher_ =
+        std::make_unique<Event::DispatcherImpl>(test_time_.timeSystem());
     Network::ClientConnectionPtr connection{test_client.connection_};
     test_client.codec_client_ = new CodecClientForTest(
         std::move(connection), test_client.codec_,

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -78,7 +78,8 @@ public:
     test_client.connection_ = new NiceMock<Network::MockClientConnection>();
     test_client.codec_ = new NiceMock<Http::MockClientConnection>();
     test_client.connect_timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
-    test_client.client_dispatcher_.reset(new Event::DispatcherImpl(test_time_.timeSystem()));
+    test_client.client_dispatcher_ =
+        std::make_unique<Event::DispatcherImpl>(test_time_.timeSystem());
 
     std::shared_ptr<Upstream::MockClusterInfo> cluster{new NiceMock<Upstream::MockClusterInfo>()};
     Network::ClientConnectionPtr connection{test_client.connection_};

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -89,7 +89,7 @@ class ConnectionImplTest : public testing::TestWithParam<Address::IpVersion> {
 public:
   void setUpBasicConnection() {
     if (dispatcher_.get() == nullptr) {
-      dispatcher_.reset(new Event::DispatcherImpl(time_system_));
+      dispatcher_ = std::make_unique<Event::DispatcherImpl>(time_system_);
     }
     listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
 
@@ -151,8 +151,8 @@ public:
     ASSERT(dispatcher_.get() == nullptr);
 
     MockBufferFactory* factory = new StrictMock<MockBufferFactory>;
-    dispatcher_.reset(
-        new Event::DispatcherImpl(time_system_, Buffer::WatermarkFactoryPtr{factory}));
+    dispatcher_ =
+        std::make_unique<Event::DispatcherImpl>(time_system_, Buffer::WatermarkFactoryPtr{factory});
     // The first call to create a client session will get a MockBuffer.
     // Other calls for server sessions will by default get a normal OwnedImpl.
     EXPECT_CALL(*factory, create_(_, _))
@@ -262,7 +262,7 @@ TEST_P(ConnectionImplTest, CloseDuringConnectCallback) {
 }
 
 TEST_P(ConnectionImplTest, ImmediateConnectError) {
-  dispatcher_.reset(new Event::DispatcherImpl(time_system_));
+  dispatcher_ = std::make_unique<Event::DispatcherImpl>(time_system_);
 
   // Using a broadcast/multicast address as the connection destinations address causes an
   // immediate error return from connect().
@@ -850,7 +850,7 @@ TEST_P(ConnectionImplTest, BindFailureTest) {
     source_address_ = Network::Address::InstanceConstSharedPtr{
         new Network::Address::Ipv6Instance(address_string, 0)};
   }
-  dispatcher_.reset(new Event::DispatcherImpl(time_system_));
+  dispatcher_ = std::make_unique<Event::DispatcherImpl>(time_system_);
   listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
 
   client_connection_ = dispatcher_->createClientConnection(
@@ -1181,9 +1181,9 @@ public:
         .WillOnce(Invoke([this](TransportSocketCallbacks& callbacks) {
           transport_socket_callbacks_ = &callbacks;
         }));
-    connection_.reset(
-        new ConnectionImpl(dispatcher_, std::make_unique<ConnectionSocketImpl>(0, nullptr, nullptr),
-                           TransportSocketPtr(transport_socket_), true));
+    connection_ = std::make_unique<ConnectionImpl>(
+        dispatcher_, std::make_unique<ConnectionSocketImpl>(0, nullptr, nullptr),
+        TransportSocketPtr(transport_socket_), true);
     connection_->addConnectionCallbacks(callbacks_);
   }
 
@@ -1493,7 +1493,7 @@ class ReadBufferLimitTest : public ConnectionImplTest {
 public:
   void readBufferLimitTest(uint32_t read_buffer_limit, uint32_t expected_chunk_size) {
     const uint32_t buffer_size = 256 * 1024;
-    dispatcher_.reset(new Event::DispatcherImpl(time_system_));
+    dispatcher_ = std::make_unique<Event::DispatcherImpl>(time_system_);
     listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
 
     client_connection_ = dispatcher_->createClientConnection(

--- a/test/common/network/lc_trie_test.cc
+++ b/test/common/network/lc_trie_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "common/common/utility.h"
 #include "common/network/address_impl.h"
 #include "common/network/cidr_range.h"
@@ -26,9 +28,10 @@ public:
     }
     // Use custom fill factors and root branch factors if they are in the valid range.
     if ((fill_factor > 0) && (fill_factor <= 1) && (root_branch_factor > 0)) {
-      trie_.reset(new LcTrie<std::string>(output, exclusive, fill_factor, root_branch_factor));
+      trie_ =
+          std::make_unique<LcTrie<std::string>>(output, exclusive, fill_factor, root_branch_factor);
     } else {
-      trie_.reset(new LcTrie<std::string>(output, exclusive));
+      trie_ = std::make_unique<LcTrie<std::string>>(output, exclusive);
     }
   }
 

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -1427,8 +1427,7 @@ public:
 
   ConfigImpl& config() {
     if (config_ == nullptr) {
-      config_ = std::unique_ptr<TestConfigImpl>{
-          new TestConfigImpl(route_config_, factory_context_, true)};
+      config_ = std::make_unique<TestConfigImpl>(route_config_, factory_context_, true);
     }
     return *config_;
   }
@@ -3836,8 +3835,8 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
   Http::TestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
   std::unique_ptr<ConfigImpl> config_ptr;
 
-  config_ptr.reset(
-      new TestConfigImpl(parseRouteConfigurationFromJson(json), factory_context, true));
+  config_ptr = std::make_unique<TestConfigImpl>(parseRouteConfigurationFromJson(json),
+                                                factory_context, true);
   EXPECT_TRUE(config_ptr->route(headers, 0)->routeEntry()->includeVirtualHostRateLimits());
 
   json = R"EOF(
@@ -3866,8 +3865,8 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
   }
   )EOF";
 
-  config_ptr.reset(
-      new TestConfigImpl(parseRouteConfigurationFromJson(json), factory_context, true));
+  config_ptr = std::make_unique<TestConfigImpl>(parseRouteConfigurationFromJson(json),
+                                                factory_context, true);
   EXPECT_FALSE(config_ptr->route(headers, 0)->routeEntry()->includeVirtualHostRateLimits());
 
   json = R"EOF(
@@ -3897,8 +3896,8 @@ TEST(RoutePropertyTest, excludeVHRateLimits) {
   }
   )EOF";
 
-  config_ptr.reset(
-      new TestConfigImpl(parseRouteConfigurationFromJson(json), factory_context, true));
+  config_ptr = std::make_unique<TestConfigImpl>(parseRouteConfigurationFromJson(json),
+                                                factory_context, true);
   EXPECT_TRUE(config_ptr->route(headers, 0)->routeEntry()->includeVirtualHostRateLimits());
 }
 

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -104,7 +104,7 @@ public:
     auto json_object_ptr = Json::Factory::loadFromString(json);
     Envoy::Config::RdsJson::translateRouteConfiguration(*json_object_ptr, route_config,
                                                         stats_options);
-    config_.reset(new ConfigImpl(route_config, factory_context_, true));
+    config_ = std::make_unique<ConfigImpl>(route_config, factory_context_, true);
   }
 
   std::unique_ptr<ConfigImpl> config_;
@@ -346,7 +346,7 @@ TEST_F(RateLimitConfiguration, Stages) {
 class RateLimitPolicyEntryTest : public testing::Test {
 public:
   void SetUpTest(const std::string json) {
-    rate_limit_entry_.reset(new RateLimitPolicyEntryImpl(parseRateLimitFromJson(json)));
+    rate_limit_entry_ = std::make_unique<RateLimitPolicyEntryImpl>(parseRateLimitFromJson(json));
     descriptors_.clear();
   }
 

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -85,9 +85,9 @@ public:
 
   void run(const std::string& primary_dir, const std::string& override_dir) {
     Api::OsSysCallsPtr os_sys_calls(os_sys_calls_);
-    loader.reset(new DiskBackedLoaderImpl(dispatcher, tls,
-                                          TestEnvironment::temporaryPath(primary_dir), "envoy",
-                                          override_dir, store, generator, std::move(os_sys_calls)));
+    loader = std::make_unique<DiskBackedLoaderImpl>(
+        dispatcher, tls, TestEnvironment::temporaryPath(primary_dir), "envoy", override_dir, store,
+        generator, std::move(os_sys_calls));
   }
 
   Event::MockDispatcher dispatcher;

--- a/test/common/singleton/threadsafe_singleton_test.cc
+++ b/test/common/singleton/threadsafe_singleton_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "common/common/lock_guard.h"
 #include "common/common/thread.h"
 #include "common/singleton/threadsafe_singleton.h"
@@ -40,7 +42,7 @@ public:
 class AddTen {
 public:
   AddTen() {
-    thread_.reset(new Thread::Thread([this]() -> void { threadRoutine(); }));
+    thread_ = std::make_unique<Thread::Thread>([this]() -> void { threadRoutine(); });
   }
   ~AddTen() {
     thread_->join();

--- a/test/common/ssl/ssl_socket_test.cc
+++ b/test/common/ssl/ssl_socket_test.cc
@@ -2920,9 +2920,9 @@ public:
     auto server_cfg =
         std::make_unique<ServerContextConfigImpl>(downstream_tls_context_, factory_context_);
     Event::SimulatedTimeSystem time_system;
-    manager_.reset(new ContextManagerImpl(time_system));
-    server_ssl_socket_factory_.reset(new ServerSslSocketFactory(
-        std::move(server_cfg), *manager_, server_stats_store_, std::vector<std::string>{}));
+    manager_ = std::make_unique<ContextManagerImpl>(time_system);
+    server_ssl_socket_factory_ = std::make_unique<ServerSslSocketFactory>(
+        std::move(server_cfg), *manager_, server_stats_store_, std::vector<std::string>{});
 
     listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
 
@@ -2930,8 +2930,8 @@ public:
     auto client_cfg =
         std::make_unique<ClientContextConfigImpl>(upstream_tls_context_, factory_context_);
 
-    client_ssl_socket_factory_.reset(
-        new ClientSslSocketFactory(std::move(client_cfg), *manager_, client_stats_store_));
+    client_ssl_socket_factory_ = std::make_unique<ClientSslSocketFactory>(
+        std::move(client_cfg), *manager_, client_stats_store_);
     client_connection_ = dispatcher_->createClientConnection(
         socket_.localAddress(), source_address_,
         client_ssl_socket_factory_->createTransportSocket(), nullptr);
@@ -3008,8 +3008,8 @@ public:
   void singleWriteTest(uint32_t read_buffer_limit, uint32_t bytes_to_write) {
     MockWatermarkBuffer* client_write_buffer = nullptr;
     MockBufferFactory* factory = new StrictMock<MockBufferFactory>;
-    dispatcher_.reset(
-        new Event::DispatcherImpl(test_time_.timeSystem(), Buffer::WatermarkFactoryPtr{factory}));
+    dispatcher_ = std::make_unique<Event::DispatcherImpl>(test_time_.timeSystem(),
+                                                          Buffer::WatermarkFactoryPtr{factory});
 
     // By default, expect 4 buffers to be created - the client and server read and write buffers.
     EXPECT_CALL(*factory, create_(_, _))

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -430,7 +430,7 @@ public:
 
     {
       testing::InSequence sequence;
-      filter_.reset(new Filter(config_, factory_context_.cluster_manager_, timeSystem()));
+      filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_, timeSystem());
       EXPECT_CALL(filter_callbacks_.connection_, enableHalfClose(true));
       EXPECT_CALL(filter_callbacks_.connection_, readDisable(true));
       filter_->initializeReadFilterCallbacks(filter_callbacks_);
@@ -738,7 +738,7 @@ TEST_F(TcpProxyTest, WithMetadataMatch) {
       {Envoy::Config::MetadataFilters::get().ENVOY_LB, metadata_struct});
 
   configure(config);
-  filter_.reset(new Filter(config_, factory_context_.cluster_manager_, timeSystem()));
+  filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_, timeSystem());
 
   const auto& metadata_criteria = filter_->metadataMatchCriteria()->metadataMatchCriteria();
 
@@ -751,7 +751,7 @@ TEST_F(TcpProxyTest, WithMetadataMatch) {
 
 TEST_F(TcpProxyTest, DisconnectBeforeData) {
   configure(defaultConfig());
-  filter_.reset(new Filter(config_, factory_context_.cluster_manager_, timeSystem()));
+  filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_, timeSystem());
   filter_->initializeReadFilterCallbacks(filter_callbacks_);
 
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
@@ -790,7 +790,7 @@ TEST_F(TcpProxyTest, UpstreamConnectionLimit) {
       0, 0, 0, 0);
 
   // setup sets up expectation for tcpConnForCluster but this test is expected to NOT call that
-  filter_.reset(new Filter(config_, factory_context_.cluster_manager_, timeSystem()));
+  filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_, timeSystem());
   // The downstream connection closes if the proxy can't make an upstream connection.
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   filter_->initializeReadFilterCallbacks(filter_callbacks_);
@@ -1091,7 +1091,7 @@ public:
   void setup() {
     EXPECT_CALL(filter_callbacks_, connection()).WillRepeatedly(ReturnRef(connection_));
 
-    filter_.reset(new Filter(config_, factory_context_.cluster_manager_, timeSystem()));
+    filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_, timeSystem());
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
   }
 

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -329,7 +329,7 @@ public:
   HttpTracerImplTest() {
     driver_ = new MockDriver();
     DriverPtr driver_ptr(driver_);
-    tracer_.reset(new HttpTracerImpl(std::move(driver_ptr), local_info_));
+    tracer_ = std::make_unique<HttpTracerImpl>(std::move(driver_ptr), local_info_);
   }
 
   Http::TestHeaderMapImpl request_headers_{

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -177,7 +178,7 @@ TEST_F(CdsApiImplTest, Basic) {
 
   Http::MessagePtr message(new Http::ResponseMessageImpl(
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(response1_json));
+  message->body() = std::make_unique<Buffer::OwnedImpl>(response1_json);
 
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(ClusterManager::ClusterInfoMap{}));
   expectAdd("cluster1", "hash_3845eb3523492899");
@@ -197,9 +198,9 @@ TEST_F(CdsApiImplTest, Basic) {
       "{%s}",
       clustersJson({defaultStaticClusterJson("cluster1"), defaultStaticClusterJson("cluster3")}));
 
-  message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(response2_json));
+  message = std::make_unique<Http::ResponseMessageImpl>(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}});
+  message->body() = std::make_unique<Buffer::OwnedImpl>(response2_json);
 
   EXPECT_CALL(cm_, clusters()).WillOnce(Return(makeClusterMap({"cluster1", "cluster2"})));
   expectAdd("cluster1", "hash_19fd657104a2cd34");
@@ -228,7 +229,7 @@ TEST_F(CdsApiImplTest, Failure) {
 
   Http::MessagePtr message(new Http::ResponseMessageImpl(
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(response_json));
+  message->body() = std::make_unique<Buffer::OwnedImpl>(response_json);
 
   EXPECT_CALL(initialized_, ready());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
@@ -260,7 +261,7 @@ TEST_F(CdsApiImplTest, FailureArray) {
 
   Http::MessagePtr message(new Http::ResponseMessageImpl(
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(response_json));
+  message->body() = std::make_unique<Buffer::OwnedImpl>(response_json);
 
   EXPECT_CALL(initialized_, ready());
   EXPECT_CALL(*interval_timer_, enableTimer(_));

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -167,9 +167,9 @@ public:
   ClusterManagerImplTest() { factory_.dispatcher_.setTimeSystem(time_system_); }
 
   void create(const envoy::config::bootstrap::v2::Bootstrap& bootstrap) {
-    cluster_manager_.reset(new ClusterManagerImpl(
+    cluster_manager_ = std::make_unique<ClusterManagerImpl>(
         bootstrap, factory_, factory_.stats_, factory_.tls_, factory_.runtime_, factory_.random_,
-        factory_.local_info_, log_manager_, factory_.dispatcher_, admin_));
+        factory_.local_info_, log_manager_, factory_.dispatcher_, admin_);
   }
 
   void createWithLocalClusterUpdate(const bool enable_merge_window = true) {
@@ -199,9 +199,9 @@ public:
 
     const auto& bootstrap = parseBootstrapFromV2Yaml(yaml);
 
-    cluster_manager_.reset(new TestClusterManagerImpl(
+    cluster_manager_ = std::make_unique<TestClusterManagerImpl>(
         bootstrap, factory_, factory_.stats_, factory_.tls_, factory_.runtime_, factory_.random_,
-        factory_.local_info_, log_manager_, factory_.dispatcher_, admin_, local_cluster_update_));
+        factory_.local_info_, log_manager_, factory_.dispatcher_, admin_, local_cluster_update_);
   }
 
   void checkStats(uint64_t added, uint64_t modified, uint64_t removed, uint64_t active,

--- a/test/common/upstream/hds_test.cc
+++ b/test/common/upstream/hds_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "envoy/service/discovery/v2/hds.pb.h"
 
 #include "common/ssl/context_manager_impl.h"
@@ -58,9 +60,9 @@ public:
           server_response_timer_cb_ = timer_cb;
           return server_response_timer_;
         }));
-    hds_delegate_.reset(new HdsDelegate(node_, stats_store_, Grpc::AsyncClientPtr(async_client_),
-                                        dispatcher_, runtime_, stats_store_, ssl_context_manager_,
-                                        random_, test_factory_, log_manager_, cm_, local_info_));
+    hds_delegate_ = std::make_unique<HdsDelegate>(
+        node_, stats_store_, Grpc::AsyncClientPtr(async_client_), dispatcher_, runtime_,
+        stats_store_, ssl_context_manager_, random_, test_factory_, log_manager_, cm_, local_info_);
   }
 
   // Creates a HealthCheckSpecifier message that contains one endpoint and one
@@ -127,7 +129,7 @@ TEST_F(HdsTest, TestProcessMessageEndpoints) {
   // Create Message
   // - Cluster "anna0" with 3 endpoints
   // - Cluster "anna1" with 3 endpoints
-  message.reset(new envoy::service::discovery::v2::HealthCheckSpecifier);
+  message = std::make_unique<envoy::service::discovery::v2::HealthCheckSpecifier>();
   message->mutable_interval()->set_seconds(1);
 
   for (int i = 0; i < 2; i++) {
@@ -165,7 +167,7 @@ TEST_F(HdsTest, TestProcessMessageHealthChecks) {
   // Create Message
   // - Cluster "minkowski0" with 2 health_checks
   // - Cluster "minkowski1" with 3 health_checks
-  message.reset(new envoy::service::discovery::v2::HealthCheckSpecifier);
+  message = std::make_unique<envoy::service::discovery::v2::HealthCheckSpecifier>();
   message->mutable_interval()->set_seconds(1);
 
   for (int i = 0; i < 2; i++) {
@@ -201,7 +203,7 @@ TEST_F(HdsTest, TestMinimalOnReceiveMessage) {
   createHdsDelegate();
 
   // Create Message
-  message.reset(new envoy::service::discovery::v2::HealthCheckSpecifier);
+  message = std::make_unique<envoy::service::discovery::v2::HealthCheckSpecifier>();
   message->mutable_interval()->set_seconds(1);
 
   // Process message
@@ -217,7 +219,7 @@ TEST_F(HdsTest, TestMinimalSendResponse) {
   createHdsDelegate();
 
   // Create Message
-  message.reset(new envoy::service::discovery::v2::HealthCheckSpecifier);
+  message = std::make_unique<envoy::service::discovery::v2::HealthCheckSpecifier>();
   message->mutable_interval()->set_seconds(1);
 
   // Process message and send 2 responses

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -1,5 +1,7 @@
 // Usage: bazel run //test/common/upstream:load_balancer_benchmark
 
+#include <memory>
+
 #include "common/runtime/runtime_impl.h"
 #include "common/upstream/maglev_lb.h"
 #include "common/upstream/ring_hash_lb.h"
@@ -43,8 +45,8 @@ public:
   RingHashTester(uint64_t num_hosts, uint64_t min_ring_size) : BaseTester(num_hosts) {
     config_ = (envoy::api::v2::Cluster::RingHashLbConfig());
     config_.value().mutable_minimum_ring_size()->set_value(min_ring_size);
-    ring_hash_lb_.reset(new RingHashLoadBalancer{priority_set_, stats_, runtime_, random_, config_,
-                                                 common_config_});
+    ring_hash_lb_ = std::make_unique<RingHashLoadBalancer>(priority_set_, stats_, runtime_, random_,
+                                                           config_, common_config_);
   }
 
   Stats::IsolatedStoreImpl stats_store_;

--- a/test/common/upstream/load_stats_reporter_test.cc
+++ b/test/common/upstream/load_stats_reporter_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "envoy/api/v2/eds.pb.h"
 #include "envoy/api/v2/endpoint/load_report.pb.h"
 
@@ -42,8 +44,8 @@ public:
       response_timer_cb_ = timer_cb;
       return response_timer_;
     }));
-    load_stats_reporter_.reset(new LoadStatsReporter(
-        local_info_, cm_, stats_store_, Grpc::AsyncClientPtr(async_client_), dispatcher_));
+    load_stats_reporter_ = std::make_unique<LoadStatsReporter>(
+        local_info_, cm_, stats_store_, Grpc::AsyncClientPtr(async_client_), dispatcher_);
   }
 
   void expectSendMessage(

--- a/test/common/upstream/maglev_lb_test.cc
+++ b/test/common/upstream/maglev_lb_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "common/upstream/maglev_lb.h"
 
 #include "test/common/upstream/utility.h"
@@ -23,8 +25,8 @@ public:
   MaglevLoadBalancerTest() : stats_(ClusterInfoImpl::generateStats(stats_store_)) {}
 
   void init(uint32_t table_size) {
-    lb_.reset(new MaglevLoadBalancer(priority_set_, stats_, runtime_, random_, common_config_,
-                                     table_size));
+    lb_ = std::make_unique<MaglevLoadBalancer>(priority_set_, stats_, runtime_, random_,
+                                               common_config_, table_size);
     lb_->initialize();
   }
 

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -1,4 +1,5 @@
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <unordered_map>
 
@@ -37,8 +38,8 @@ public:
   RingHashLoadBalancerTest() : stats_(ClusterInfoImpl::generateStats(stats_store_)) {}
 
   void init() {
-    lb_.reset(new RingHashLoadBalancer(priority_set_, stats_, runtime_, random_, config_,
-                                       common_config_));
+    lb_ = std::make_unique<RingHashLoadBalancer>(priority_set_, stats_, runtime_, random_, config_,
+                                                 common_config_);
     lb_->initialize();
   }
 

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -177,8 +177,8 @@ TEST_F(SdsTest, NoHealthChecker) {
 
   Http::MessagePtr message(new Http::ResponseMessageImpl(
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(Filesystem::fileReadToEnd(
-      TestEnvironment::runfilesPath("test/common/upstream/test_data/sds_response.json"))));
+  message->body() = std::make_unique<Buffer::OwnedImpl>(Filesystem::fileReadToEnd(
+      TestEnvironment::runfilesPath("test/common/upstream/test_data/sds_response.json")));
 
   EXPECT_CALL(membership_updated_, ready()).Times(2);
   EXPECT_CALL(*timer_, enableTimer(_));
@@ -213,11 +213,11 @@ TEST_F(SdsTest, NoHealthChecker) {
   setupRequest();
   timer_->callback_();
 
-  message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(
-      new Buffer::OwnedImpl(Filesystem::fileReadToEnd(TestEnvironment::runfilesPath(
-          "test/common/upstream/test_data/sds_response_weight_change.json"))));
+  message = std::make_unique<Http::ResponseMessageImpl>(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}});
+  message->body() =
+      std::make_unique<Buffer::OwnedImpl>(Filesystem::fileReadToEnd(TestEnvironment::runfilesPath(
+          "test/common/upstream/test_data/sds_response_weight_change.json")));
   EXPECT_CALL(membership_updated_, ready());
   EXPECT_CALL(*timer_, enableTimer(_));
   callbacks_->onSuccess(std::move(message));
@@ -268,8 +268,8 @@ TEST_F(SdsTest, NoHealthChecker) {
   timer_->callback_();
 
   EXPECT_CALL(*timer_, enableTimer(_));
-  message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "503"}}}));
+  message = std::make_unique<Http::ResponseMessageImpl>(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "503"}}});
   callbacks_->onSuccess(std::move(message));
   EXPECT_EQ(13UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(50U, canary_host->weight());
@@ -303,8 +303,8 @@ TEST_F(SdsTest, HealthChecker) {
   // all the hosts to load in unhealthy.
   Http::MessagePtr message(new Http::ResponseMessageImpl(
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(Filesystem::fileReadToEnd(
-      TestEnvironment::runfilesPath("test/common/upstream/test_data/sds_response.json"))));
+  message->body() = std::make_unique<Buffer::OwnedImpl>(Filesystem::fileReadToEnd(
+      TestEnvironment::runfilesPath("test/common/upstream/test_data/sds_response.json")));
 
   EXPECT_CALL(*health_checker, addHostCheckCompleteCb(_));
   EXPECT_CALL(*timer_, enableTimer(_));
@@ -380,10 +380,10 @@ TEST_F(SdsTest, HealthChecker) {
   timer_->callback_();
 
   EXPECT_CALL(*timer_, enableTimer(_));
-  message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(Filesystem::fileReadToEnd(
-      TestEnvironment::runfilesPath("test/common/upstream/test_data/sds_response_2.json"))));
+  message = std::make_unique<Http::ResponseMessageImpl>(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}});
+  message->body() = std::make_unique<Buffer::OwnedImpl>(Filesystem::fileReadToEnd(
+      TestEnvironment::runfilesPath("test/common/upstream/test_data/sds_response_2.json")));
   callbacks_->onSuccess(std::move(message));
   EXPECT_EQ(14UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(13UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -409,10 +409,10 @@ TEST_F(SdsTest, HealthChecker) {
   setupRequest();
   timer_->callback_();
   EXPECT_CALL(*timer_, enableTimer(_));
-  message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(Filesystem::fileReadToEnd(
-      TestEnvironment::runfilesPath("test/common/upstream/test_data/sds_response_2.json"))));
+  message = std::make_unique<Http::ResponseMessageImpl>(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}});
+  message->body() = std::make_unique<Buffer::OwnedImpl>(Filesystem::fileReadToEnd(
+      TestEnvironment::runfilesPath("test/common/upstream/test_data/sds_response_2.json")));
   callbacks_->onSuccess(std::move(message));
   EXPECT_EQ(13UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(12UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -437,10 +437,10 @@ TEST_F(SdsTest, HealthChecker) {
   setupRequest();
   timer_->callback_();
   EXPECT_CALL(*timer_, enableTimer(_));
-  message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(Filesystem::fileReadToEnd(
-      TestEnvironment::runfilesPath("test/common/upstream/test_data/sds_response_3.json"))));
+  message = std::make_unique<Http::ResponseMessageImpl>(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}});
+  message->body() = std::make_unique<Buffer::OwnedImpl>(Filesystem::fileReadToEnd(
+      TestEnvironment::runfilesPath("test/common/upstream/test_data/sds_response_3.json")));
   callbacks_->onSuccess(std::move(message));
   EXPECT_EQ(13UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(12UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
@@ -473,7 +473,7 @@ TEST_F(SdsTest, Failure) {
 
   Http::MessagePtr message(new Http::ResponseMessageImpl(
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(bad_response_json));
+  message->body() = std::make_unique<Buffer::OwnedImpl>(bad_response_json);
 
   EXPECT_CALL(*timer_, enableTimer(_));
   callbacks_->onSuccess(std::move(message));
@@ -491,7 +491,7 @@ TEST_F(SdsTest, FailureArray) {
 
   Http::MessagePtr message(new Http::ResponseMessageImpl(
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(bad_response_json));
+  message->body() = std::make_unique<Buffer::OwnedImpl>(bad_response_json);
 
   EXPECT_CALL(*timer_, enableTimer(_));
   callbacks_->onSuccess(std::move(message));

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -1,6 +1,7 @@
 #include <unistd.h>
 
 #include <cstdint>
+#include <memory>
 #include <string>
 
 #include "common/common/fmt.h"
@@ -53,10 +54,10 @@ public:
     Server::Configuration::InitialImpl initial_config(bootstrap);
     Server::Configuration::MainImpl main_config;
 
-    cluster_manager_factory_.reset(new Upstream::ValidationClusterManagerFactory(
+    cluster_manager_factory_ = std::make_unique<Upstream::ValidationClusterManagerFactory>(
         server_.runtime(), server_.stats(), server_.threadLocal(), server_.random(),
         server_.dnsResolver(), ssl_context_manager_, server_.dispatcher(), server_.localInfo(),
-        server_.secretManager()));
+        server_.secretManager());
 
     ON_CALL(server_, clusterManager()).WillByDefault(Invoke([&]() -> Upstream::ClusterManager& {
       return *main_config.clusterManager();

--- a/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/http_grpc/grpc_access_log_impl_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "common/network/address_impl.h"
 
 #include "extensions/access_loggers/http_grpc/grpc_access_log_impl.h"
@@ -115,7 +117,8 @@ public:
   void init() {
     ON_CALL(*filter_, evaluate(_, _)).WillByDefault(Return(true));
     config_.mutable_common_config()->set_log_name("hello_log");
-    access_log_.reset(new HttpGrpcAccessLog(AccessLog::FilterPtr{filter_}, config_, streamer_));
+    access_log_ =
+        std::make_unique<HttpGrpcAccessLog>(AccessLog::FilterPtr{filter_}, config_, streamer_);
   }
 
   void expectLog(const std::string& expected_request_msg_yaml) {

--- a/test/extensions/filters/common/ext_authz/test_common.cc
+++ b/test/extensions/filters/common/ext_authz/test_common.cc
@@ -1,5 +1,7 @@
 #include "test/extensions/filters/common/ext_authz/test_common.h"
 
+#include <memory>
+
 #include "test/mocks/upstream/mocks.h"
 
 namespace Envoy {
@@ -88,7 +90,7 @@ Http::MessagePtr TestCommon::makeMessageResponse(const HeaderValueOptionVector& 
     response->headers().addCopy(Http::LowerCaseString(header.header().key()),
                                 header.header().value());
   }
-  response->body().reset(new Buffer::OwnedImpl(body));
+  response->body() = std::make_unique<Buffer::OwnedImpl>(body);
   return response;
 };
 

--- a/test/extensions/filters/common/lua/lua_test.cc
+++ b/test/extensions/filters/common/lua/lua_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "extensions/filters/common/lua/lua.h"
 
 #include "test/mocks/common.h"
@@ -36,7 +38,7 @@ public:
   LuaTest() : yield_callback_([this]() { on_yield_.ready(); }) {}
 
   void setup(const std::string& code) {
-    state_.reset(new ThreadLocalState(code, tls_));
+    state_ = std::make_unique<ThreadLocalState>(code, tls_);
     state_->registerType<TestObject>();
   }
 

--- a/test/extensions/filters/http/common/mock.cc
+++ b/test/extensions/filters/http/common/mock.cc
@@ -1,5 +1,7 @@
 #include "test/extensions/filters/http/common/mock.h"
 
+#include <memory>
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -14,7 +16,7 @@ MockUpstream::MockUpstream(Upstream::MockClusterManager& mock_cm, const std::str
             Http::MessagePtr response_message(new Http::ResponseMessageImpl(
                 Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", status_}}}));
             if (response_body_.length()) {
-              response_message->body().reset(new Buffer::OwnedImpl(response_body_));
+              response_message->body() = std::make_unique<Buffer::OwnedImpl>(response_body_);
             } else {
               response_message->body().reset(nullptr);
             }

--- a/test/extensions/filters/http/dynamo/dynamo_filter_test.cc
+++ b/test/extensions/filters/http/dynamo/dynamo_filter_test.cc
@@ -33,8 +33,8 @@ public:
         .WillByDefault(Return(enabled));
     EXPECT_CALL(loader_.snapshot_, featureEnabled("dynamodb.filter_enabled", 100));
 
-    filter_.reset(new DynamoFilter(loader_, stat_prefix_, stats_,
-                                   decoder_callbacks_.dispatcher().timeSystem()));
+    filter_ = std::make_unique<DynamoFilter>(loader_, stat_prefix_, stats_,
+                                             decoder_callbacks_.dispatcher().timeSystem());
 
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -72,7 +72,7 @@ public:
     config_.reset(new FilterConfig(proto_config, local_info_, stats_store_, runtime_, cm_));
 
     client_ = new Filters::Common::ExtAuthz::MockClient();
-    filter_.reset(new Filter(config_, Filters::Common::ExtAuthz::ClientPtr{client_}));
+    filter_ = std::make_unique<Filter>(config_, Filters::Common::ExtAuthz::ClientPtr{client_});
     filter_->setDecoderFilterCallbacks(filter_callbacks_);
     addr_ = std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 1111);
   }
@@ -95,7 +95,7 @@ public:
     config_.reset(new FilterConfig(proto_config, local_info_, stats_store_, runtime_, cm_));
 
     client_ = new Filters::Common::ExtAuthz::MockClient();
-    filter_.reset(new Filter(config_, Filters::Common::ExtAuthz::ClientPtr{client_}));
+    filter_ = std::make_unique<Filter>(config_, Filters::Common::ExtAuthz::ClientPtr{client_});
     filter_->setDecoderFilterCallbacks(filter_callbacks_);
     addr_ = std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 1111);
   }

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -130,7 +130,7 @@ public:
 
   void SetUpTest(const envoy::config::filter::http::fault::v2::HTTPFault fault) {
     config_.reset(new FaultFilterConfig(fault, runtime_, "prefix.", stats_, generator_));
-    filter_.reset(new FaultFilter(config_));
+    filter_ = std::make_unique<FaultFilter>(config_);
     filter_->setDecoderFilterCallbacks(filter_callbacks_);
   }
 

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "common/compressor/zlib_compressor_impl.h"
 #include "common/decompressor/zlib_decompressor_impl.h"
 #include "common/protobuf/utility.h"
@@ -63,7 +65,7 @@ protected:
     envoy::config::filter::http::gzip::v2::Gzip gzip;
     MessageUtil::loadFromJson(json, gzip);
     config_.reset(new GzipFilterConfig(gzip, "test.", stats_, runtime_));
-    filter_.reset(new GzipFilter(config_));
+    filter_ = std::make_unique<GzipFilter>(config_);
   }
 
   void verifyCompressedData() {

--- a/test/extensions/filters/http/health_check/health_check_test.cc
+++ b/test/extensions/filters/http/health_check/health_check_test.cc
@@ -50,8 +50,8 @@ public:
     matcher.set_name(":path");
     matcher.set_exact_match("/healthcheck");
     header_data_->emplace_back(matcher);
-    filter_.reset(new HealthCheckFilter(context_, pass_through, cache_manager_, header_data_,
-                                        cluster_min_healthy_percentages));
+    filter_ = std::make_unique<HealthCheckFilter>(context_, pass_through, cache_manager_,
+                                                  header_data_, cluster_min_healthy_percentages);
     filter_->setDecoderFilterCallbacks(callbacks_);
   }
 

--- a/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
+++ b/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "common/buffer/buffer_impl.h"
 #include "common/config/filter_json.h"
 #include "common/http/header_map_impl.h"
@@ -43,7 +45,7 @@ ip_tags:
     envoy::config::filter::http::ip_tagging::v2::IPTagging config;
     MessageUtil::loadFromYaml(yaml, config);
     config_.reset(new IpTaggingFilterConfig(config, "prefix.", stats_, runtime_));
-    filter_.reset(new IpTaggingFilter(config_));
+    filter_ = std::make_unique<IpTaggingFilter>(config_);
     filter_->setDecoderFilterCallbacks(filter_callbacks_);
   }
 

--- a/test/extensions/filters/http/jwt_authn/mock.h
+++ b/test/extensions/filters/http/jwt_authn/mock.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "extensions/filters/http/jwt_authn/authenticator.h"
 #include "extensions/filters/http/jwt_authn/verifier.h"
 
@@ -61,7 +63,7 @@ public:
                                   -> Http::AsyncClient::Request* {
           Http::MessagePtr response_message(new Http::ResponseMessageImpl(
               Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-          response_message->body().reset(new Buffer::OwnedImpl(response_body_));
+          response_message->body() = std::make_unique<Buffer::OwnedImpl>(response_body_);
           cb.onSuccess(std::move(response_message));
           called_count_++;
           return &request_;

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -53,7 +53,7 @@ public:
     config_.reset(new FilterConfig(proto_config, local_info_, stats_store_, runtime_));
 
     client_ = new RateLimit::MockClient();
-    filter_.reset(new Filter(config_, RateLimit::ClientPtr{client_}));
+    filter_ = std::make_unique<Filter>(config_, RateLimit::ClientPtr{client_});
     filter_->setDecoderFilterCallbacks(filter_callbacks_);
     filter_callbacks_.route_->route_entry_.rate_limit_policy_.rate_limit_policy_entry_.clear();
     filter_callbacks_.route_->route_entry_.rate_limit_policy_.rate_limit_policy_entry_.emplace_back(

--- a/test/extensions/filters/http/squash/squash_filter_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_test.cc
@@ -229,7 +229,7 @@ protected:
   void completeRequest(const std::string& status, const std::string& body) {
     Http::MessagePtr msg(new Http::ResponseMessageImpl(
         Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", status}}}));
-    msg->body().reset(new Buffer::OwnedImpl(body));
+    msg->body() = std::make_unique<Buffer::OwnedImpl>(body);
     popPendingCallback()->onSuccess(std::move(msg));
   }
 

--- a/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
+++ b/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
@@ -87,7 +87,7 @@ public:
 
   void createAuthFilter() {
     filter_callbacks_.connection_.callbacks_.clear();
-    instance_.reset(new ClientSslAuthFilter(config_));
+    instance_ = std::make_unique<ClientSslAuthFilter>(config_);
     instance_->initializeReadFilterCallbacks(filter_callbacks_);
 
     // NOP currently.
@@ -175,9 +175,9 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   EXPECT_CALL(*interval_timer_, enableTimer(_));
   Http::MessagePtr message(new Http::ResponseMessageImpl(
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(
-      new Buffer::OwnedImpl(Filesystem::fileReadToEnd(TestEnvironment::runfilesPath(
-          "test/extensions/filters/network/client_ssl_auth/test_data/vpn_response_1.json"))));
+  message->body() =
+      std::make_unique<Buffer::OwnedImpl>(Filesystem::fileReadToEnd(TestEnvironment::runfilesPath(
+          "test/extensions/filters/network/client_ssl_auth/test_data/vpn_response_1.json")));
   callbacks_->onSuccess(std::move(message));
   EXPECT_EQ(1U, stats_store_.gauge("auth.clientssl.vpn.total_principals").value());
 
@@ -227,8 +227,8 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
 
   // Error response.
   EXPECT_CALL(*interval_timer_, enableTimer(_));
-  message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "503"}}}));
+  message = std::make_unique<Http::ResponseMessageImpl>(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "503"}}});
   callbacks_->onSuccess(std::move(message));
 
   // Interval timer fires.
@@ -237,9 +237,9 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
 
   // Parsing error
   EXPECT_CALL(*interval_timer_, enableTimer(_));
-  message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl("bad_json"));
+  message = std::make_unique<Http::ResponseMessageImpl>(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}});
+  message->body() = std::make_unique<Buffer::OwnedImpl>("bad_json");
   callbacks_->onSuccess(std::move(message));
 
   // Interval timer fires.

--- a/test/extensions/filters/network/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/network/ext_authz/ext_authz_test.cc
@@ -52,7 +52,7 @@ public:
     MessageUtil::loadFromJson(json, proto_config);
     config_.reset(new Config(proto_config, stats_store_));
     client_ = new Filters::Common::ExtAuthz::MockClient();
-    filter_.reset(new Filter(config_, Filters::Common::ExtAuthz::ClientPtr{client_}));
+    filter_ = std::make_unique<Filter>(config_, Filters::Common::ExtAuthz::ClientPtr{client_});
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
     addr_ = std::make_shared<Network::Address::PipeInstance>("/test/test.sock");
 

--- a/test/extensions/filters/network/mongo_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/proxy_test.cc
@@ -74,8 +74,9 @@ public:
   }
 
   void initializeFilter() {
-    filter_.reset(new TestProxyFilter("test.", store_, runtime_, access_log_, fault_config_,
-                                      drain_decision_, generator_, dispatcher_.timeSystem()));
+    filter_ =
+        std::make_unique<TestProxyFilter>("test.", store_, runtime_, access_log_, fault_config_,
+                                          drain_decision_, generator_, dispatcher_.timeSystem());
     filter_->initializeReadFilterCallbacks(read_filter_callbacks_);
     filter_->onNewConnection();
 
@@ -436,7 +437,7 @@ TEST_F(MongoProxyFilterTest, ConcurrentQueryWithDrainClose) {
     message->query(Bson::DocumentImpl::create());
     filter_->callbacks_->decodeQuery(std::move(message));
 
-    message.reset(new QueryMessageImpl(2, 0));
+    message = std::make_unique<QueryMessageImpl>(2, 0);
     message->fullCollectionName("db.test");
     message->flags(0b1110010);
     message->query(Bson::DocumentImpl::create());
@@ -453,7 +454,7 @@ TEST_F(MongoProxyFilterTest, ConcurrentQueryWithDrainClose) {
     message->documents().push_back(Bson::DocumentImpl::create()->addString("hello", "world"));
     filter_->callbacks_->decodeReply(std::move(message));
 
-    message.reset(new ReplyMessageImpl(0, 2));
+    message = std::make_unique<ReplyMessageImpl>(0, 2);
     message->flags(0b11);
     message->cursorId(1);
     message->documents().push_back(Bson::DocumentImpl::create()->addString("hello", "world"));

--- a/test/extensions/filters/network/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/ratelimit/ratelimit_test.cc
@@ -45,7 +45,7 @@ public:
     MessageUtil::loadFromYaml(yaml, proto_config);
     config_.reset(new Config(proto_config, stats_store_, runtime_));
     client_ = new RateLimit::MockClient();
-    filter_.reset(new Filter(config_, RateLimit::ClientPtr{client_}));
+    filter_ = std::make_unique<Filter>(config_, RateLimit::ClientPtr{client_});
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
 
     // NOP currently.

--- a/test/extensions/filters/network/rbac/filter_test.cc
+++ b/test/extensions/filters/network/rbac/filter_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "common/network/utility.h"
 
 #include "extensions/filters/common/rbac/utility.h"
@@ -42,7 +44,7 @@ public:
   }
 
   RoleBasedAccessControlNetworkFilterTest() : config_(setupConfig()) {
-    filter_.reset(new RoleBasedAccessControlFilter(config_));
+    filter_ = std::make_unique<RoleBasedAccessControlFilter>(config_);
     filter_->initializeReadFilterCallbacks(callbacks_);
   }
 
@@ -98,7 +100,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterTest, RequestedServerName) {
 
 TEST_F(RoleBasedAccessControlNetworkFilterTest, AllowedWithNoPolicy) {
   config_ = setupConfig(false /* with_policy */);
-  filter_.reset(new RoleBasedAccessControlFilter(config_));
+  filter_ = std::make_unique<RoleBasedAccessControlFilter>(config_);
   filter_->initializeReadFilterCallbacks(callbacks_);
   setDestinationPort(0);
 

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -60,7 +60,7 @@ public:
   }
 
   void setup() {
-    config_.reset(new ConfigImpl(createConnPoolSettings()));
+    config_ = std::make_unique<ConfigImpl>(createConnPoolSettings());
     finishSetup();
   }
 

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "envoy/config/filter/network/thrift_proxy/v2alpha1/thrift_proxy.pb.h"
 
 #include "common/buffer/buffer_impl.h"
@@ -96,7 +98,7 @@ public:
 
     decoder_filter_.reset(new NiceMock<ThriftFilters::MockDecoderFilter>());
 
-    config_.reset(new TestConfigImpl(proto_config_, context_, decoder_filter_, stats_));
+    config_ = std::make_unique<TestConfigImpl>(proto_config_, context_, decoder_filter_, stats_);
     if (custom_transport_) {
       config_->transport_ = custom_transport_;
     }
@@ -108,8 +110,8 @@ public:
     }
 
     ON_CALL(random_, random()).WillByDefault(Return(42));
-    filter_.reset(new ConnectionManager(*config_, random_,
-                                        filter_callbacks_.connection_.dispatcher_.timeSystem()));
+    filter_ = std::make_unique<ConnectionManager>(
+        *config_, random_, filter_callbacks_.connection_.dispatcher_.timeSystem());
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
     filter_->onNewConnection();
 

--- a/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
@@ -58,7 +58,7 @@ public:
     request_metadata_.reset(new ThriftProxy::MessageMetadata());
 
     client_ = new RateLimit::MockClient();
-    filter_.reset(new Filter(config_, RateLimit::ClientPtr{client_}));
+    filter_ = std::make_unique<Filter>(config_, RateLimit::ClientPtr{client_});
     filter_->setDecoderFilterCallbacks(filter_callbacks_);
     filter_callbacks_.route_->route_entry_.rate_limit_policy_.rate_limit_policy_entry_.clear();
     filter_callbacks_.route_->route_entry_.rate_limit_policy_.rate_limit_policy_entry_.emplace_back(

--- a/test/extensions/filters/network/thrift_proxy/router_ratelimit_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_ratelimit_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "envoy/common/exception.h"
 #include "envoy/config/filter/network/thrift_proxy/v2alpha1/thrift_proxy.pb.validate.h"
 #include "envoy/ratelimit/ratelimit.h"
@@ -30,7 +32,7 @@ public:
   void initialize(const std::string& yaml) {
     envoy::config::filter::network::thrift_proxy::v2alpha1::ThriftProxy config;
     MessageUtil::loadFromYaml(yaml, config);
-    config_.reset(new ThriftProxy::ConfigImpl(config, factory_context_));
+    config_ = std::make_unique<ThriftProxy::ConfigImpl>(config, factory_context_);
   }
 
   MessageMetadata& genMetadata(const std::string& method_name) {
@@ -172,7 +174,7 @@ public:
     envoy::api::v2::route::RateLimit rate_limit;
     MessageUtil::loadFromYaml(yaml, rate_limit);
 
-    rate_limit_entry_.reset(new RateLimitPolicyEntryImpl(rate_limit));
+    rate_limit_entry_ = std::make_unique<RateLimitPolicyEntryImpl>(rate_limit);
     descriptors_.clear();
   }
 

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "envoy/config/filter/network/thrift_proxy/v2alpha1/route.pb.h"
 #include "envoy/config/filter/network/thrift_proxy/v2alpha1/route.pb.validate.h"
 #include "envoy/tcp/conn_pool.h"
@@ -86,7 +88,7 @@ public:
     route_ = new NiceMock<MockRoute>();
     route_ptr_.reset(route_);
 
-    router_.reset(new Router(context_.clusterManager()));
+    router_ = std::make_unique<Router>(context_.clusterManager());
 
     EXPECT_EQ(nullptr, router_->downstreamConnection());
 
@@ -166,7 +168,7 @@ public:
         }));
 
     if (!conn_state_) {
-      conn_state_.reset(new ThriftConnectionState());
+      conn_state_ = std::make_unique<ThriftConnectionState>();
     }
     EXPECT_CALL(*context_.cluster_manager_.tcp_conn_pool_.connection_data_, connectionState())
         .WillRepeatedly(
@@ -739,7 +741,7 @@ TEST_F(ThriftRouterTest, CallWithExistingConnection) {
   initializeRouter();
 
   // Simulate previous sequence id usage.
-  conn_state_.reset(new ThriftConnectionState(3));
+  conn_state_ = std::make_unique<ThriftConnectionState>(3);
 
   startRequestWithExistingConnection(MessageType::Call);
   sendTrivialStruct(FieldType::I32);

--- a/test/extensions/health_checkers/redis/redis_test.cc
+++ b/test/extensions/health_checkers/redis/redis_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "extensions/health_checkers/redis/redis.h"
 #include "extensions/health_checkers/redis/utility.h"
 
@@ -170,7 +172,7 @@ TEST_F(RedisHealthCheckerTest, PingAndVariousFailures) {
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
   EXPECT_CALL(*timeout_timer_, disableTimer());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
-  response.reset(new Extensions::NetworkFilters::RedisProxy::RespValue());
+  response = std::make_unique<Extensions::NetworkFilters::RedisProxy::RespValue>();
   pool_callbacks_->onResponse(std::move(response));
 
   expectPingRequestCreate();
@@ -238,7 +240,7 @@ TEST_F(RedisHealthCheckerTest, Exists) {
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
   EXPECT_CALL(*timeout_timer_, disableTimer());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
-  response.reset(new Extensions::NetworkFilters::RedisProxy::RespValue());
+  response = std::make_unique<Extensions::NetworkFilters::RedisProxy::RespValue>();
   response->type(Extensions::NetworkFilters::RedisProxy::RespType::Integer);
   response->asInteger() = 1;
   pool_callbacks_->onResponse(std::move(response));
@@ -249,7 +251,7 @@ TEST_F(RedisHealthCheckerTest, Exists) {
   // Failure, no value
   EXPECT_CALL(*timeout_timer_, disableTimer());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
-  response.reset(new Extensions::NetworkFilters::RedisProxy::RespValue());
+  response = std::make_unique<Extensions::NetworkFilters::RedisProxy::RespValue>();
   pool_callbacks_->onResponse(std::move(response));
 
   EXPECT_CALL(*client_, close());
@@ -291,7 +293,7 @@ TEST_F(RedisHealthCheckerTest, NoConnectionReuse) {
   EXPECT_CALL(*timeout_timer_, disableTimer());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
   EXPECT_CALL(*client_, close());
-  response.reset(new Extensions::NetworkFilters::RedisProxy::RespValue());
+  response = std::make_unique<Extensions::NetworkFilters::RedisProxy::RespValue>();
   pool_callbacks_->onResponse(std::move(response));
 
   expectClientCreate();

--- a/test/extensions/stats_sinks/common/statsd/statsd_test.cc
+++ b/test/extensions/stats_sinks/common/statsd/statsd_test.cc
@@ -32,9 +32,9 @@ namespace Statsd {
 class TcpStatsdSinkTest : public testing::Test {
 public:
   TcpStatsdSinkTest() {
-    sink_.reset(
-        new TcpStatsdSink(local_info_, "fake_cluster", tls_, cluster_manager_,
-                          cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_));
+    sink_ = std::make_unique<TcpStatsdSink>(
+        local_info_, "fake_cluster", tls_, cluster_manager_,
+        cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_);
   }
 
   void expectCreateConnection() {
@@ -102,9 +102,9 @@ TEST_F(TcpStatsdSinkTest, BasicFlow) {
 }
 
 TEST_F(TcpStatsdSinkTest, WithCustomPrefix) {
-  sink_.reset(new TcpStatsdSink(local_info_, "fake_cluster", tls_, cluster_manager_,
-                                cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_,
-                                "test_prefix"));
+  sink_ = std::make_unique<TcpStatsdSink>(
+      local_info_, "fake_cluster", tls_, cluster_manager_,
+      cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_, "test_prefix");
 
   auto counter = std::make_shared<NiceMock<Stats::MockCounter>>();
   counter->name_ = "test_counter";

--- a/test/extensions/stats_sinks/hystrix/hystrix_test.cc
+++ b/test/extensions/stats_sinks/hystrix/hystrix_test.cc
@@ -118,7 +118,7 @@ private:
 
 class HystrixSinkTest : public testing::Test {
 public:
-  HystrixSinkTest() { sink_.reset(new HystrixSink(server_, window_size_)); }
+  HystrixSinkTest() { sink_ = std::make_unique<HystrixSink>(server_, window_size_); }
 
   Buffer::OwnedImpl createClusterAndCallbacks() {
     // Set cluster.

--- a/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
+++ b/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "extensions/tracers/common/ot/opentracing_driver_impl.h"
 
 #include "test/mocks/http/mocks.h"
@@ -50,7 +52,7 @@ public:
   setupValidDriver(OpenTracingDriver::PropagationMode propagation_mode =
                        OpenTracingDriver::PropagationMode::SingleHeader,
                    const opentracing::mocktracer::PropagationOptions& propagation_options = {}) {
-    driver_.reset(new TestDriver{propagation_mode, propagation_options, stats_});
+    driver_ = std::make_unique<TestDriver>(propagation_mode, propagation_options, stats_);
   }
 
   const std::string operation_name_{"test"};

--- a/test/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl_test.cc
+++ b/test/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "common/http/header_map_impl.h"
 
 #include "extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl.h"
@@ -21,7 +23,7 @@ namespace DynamicOt {
 class DynamicOpenTracingDriverTest : public Test {
 public:
   void setup(const std::string& library, const std::string& tracer_config) {
-    driver_.reset(new DynamicOpenTracingDriver{stats_, library, tracer_config});
+    driver_ = std::make_unique<DynamicOpenTracingDriver>(stats_, library, tracer_config);
   }
 
   void setupValidDriver() { setup(library_path_, tracer_config_); }

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -58,8 +58,8 @@ public:
       EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1000)));
     }
 
-    driver_.reset(new LightStepDriver{lightstep_config, cm_, stats_, tls_, runtime_,
-                                      std::move(opts), propagation_mode});
+    driver_ = std::make_unique<LightStepDriver>(lightstep_config, cm_, stats_, tls_, runtime_,
+                                                std::move(opts), propagation_mode);
   }
 
   void setupValidDriver(Common::Ot::OpenTracingDriver::PropagationMode propagation_mode =

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -49,8 +49,8 @@ public:
       EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(5000)));
     }
 
-    driver_.reset(
-        new Driver(zipkin_config, cm_, stats_, tls_, runtime_, local_info_, random_, time_source_));
+    driver_ = std::make_unique<Driver>(zipkin_config, cm_, stats_, tls_, runtime_, local_info_,
+                                       random_, time_source_);
   }
 
   void setupValidDriver() {

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -205,13 +205,13 @@ FakeHttpConnection::FakeHttpConnection(SharedConnectionWrapper& shared_connectio
                                        Event::TestTimeSystem& time_system)
     : FakeConnectionBase(shared_connection, time_system) {
   if (type == Type::HTTP1) {
-    codec_.reset(new Http::Http1::ServerConnectionImpl(shared_connection_.connection(), *this,
-                                                       Http::Http1Settings()));
+    codec_ = std::make_unique<Http::Http1::ServerConnectionImpl>(shared_connection_.connection(),
+                                                                 *this, Http::Http1Settings());
   } else {
     auto settings = Http::Http2Settings();
     settings.allow_connect_ = true;
-    codec_.reset(new Http::Http2::ServerConnectionImpl(shared_connection_.connection(), *this,
-                                                       store, settings));
+    codec_ = std::make_unique<Http::Http2::ServerConnectionImpl>(shared_connection_.connection(),
+                                                                 *this, store, settings);
     ASSERT(type == Type::HTTP2);
   }
 
@@ -369,7 +369,7 @@ FakeUpstream::FakeUpstream(Network::TransportSocketFactoryPtr&& transport_socket
       handler_(new Server::ConnectionHandlerImpl(ENVOY_LOGGER(), *dispatcher_)),
       allow_unexpected_disconnects_(false), enable_half_close_(enable_half_close), listener_(*this),
       filter_chain_(Network::Test::createEmptyFilterChain(std::move(transport_socket_factory))) {
-  thread_.reset(new Thread::Thread([this]() -> void { threadRoutine(); }));
+  thread_ = std::make_unique<Thread::Thread>([this]() -> void { threadRoutine(); });
   server_initialized_.waitReady();
 }
 

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "envoy/api/v2/eds.pb.h"
 #include "envoy/api/v2/endpoint/endpoint.pb.h"
 #include "envoy/service/discovery/v2/hds.pb.h"
@@ -54,10 +56,10 @@ public:
     HttpIntegrationTest::initialize();
 
     // Endpoint connections
-    host_upstream_.reset(
-        new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_, timeSystem()));
-    host2_upstream_.reset(
-        new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_, timeSystem()));
+    host_upstream_ =
+        std::make_unique<FakeUpstream>(0, FakeHttpConnection::Type::HTTP1, version_, timeSystem());
+    host2_upstream_ =
+        std::make_unique<FakeUpstream>(0, FakeHttpConnection::Type::HTTP1, version_, timeSystem());
   }
 
   // Sets up a connection between Envoy and the management server.

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -201,8 +201,8 @@ HttpIntegrationTest::makeRawHttpConnection(Network::ClientConnectionPtr&& conn) 
   cluster->http2_settings_.allow_connect_ = true;
   Upstream::HostDescriptionConstSharedPtr host_description{Upstream::makeTestHostDescription(
       cluster, fmt::format("tcp://{}:80", Network::Test::getLoopbackAddressUrlString(version_)))};
-  return IntegrationCodecClientPtr{new IntegrationCodecClient(
-      *dispatcher_, std::move(conn), host_description, downstream_protocol_)};
+  return std::make_unique<IntegrationCodecClient>(*dispatcher_, std::move(conn), host_description,
+                                                  downstream_protocol_);
 }
 
 IntegrationCodecClientPtr

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -302,8 +302,8 @@ void BaseIntegrationTest::setUpstreamProtocol(FakeHttpConnection::Type protocol)
 }
 
 IntegrationTcpClientPtr BaseIntegrationTest::makeTcpConnection(uint32_t port) {
-  return IntegrationTcpClientPtr{new IntegrationTcpClient(*dispatcher_, *mock_buffer_factory_, port,
-                                                          version_, enable_half_close_)};
+  return std::make_unique<IntegrationTcpClient>(*dispatcher_, *mock_buffer_factory_, port, version_,
+                                                enable_half_close_);
 }
 
 void BaseIntegrationTest::registerPort(const std::string& key, uint32_t port) {

--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -31,7 +31,7 @@ void SslIntegrationTest::initialize() {
   config_helper_.addSslConfig();
   HttpIntegrationTest::initialize();
 
-  context_manager_.reset(new ContextManagerImpl(timeSystem()));
+  context_manager_ = std::make_unique<ContextManagerImpl>(timeSystem());
 
   registerTestServerPorts({"http"});
   client_ssl_ctx_plain_ = createClientSslTransportSocketFactory(false, false, *context_manager_);

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -1,5 +1,7 @@
 #include "test/integration/tcp_proxy_integration_test.h"
 
+#include <memory>
+
 #include "envoy/config/accesslog/v2/file.pb.h"
 #include "envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.pb.validate.h"
 
@@ -363,7 +365,7 @@ void TcpProxySslIntegrationTest::initialize() {
   config_helper_.addSslConfig();
   TcpProxyIntegrationTest::initialize();
 
-  context_manager_.reset(new Ssl::ContextManagerImpl(timeSystem()));
+  context_manager_ = std::make_unique<Ssl::ContextManagerImpl>(timeSystem());
   payload_reader_.reset(new WaitForPayloadReader(*dispatcher_));
 }
 

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -109,7 +109,7 @@ IntegrationUtil::makeSingleRequest(uint32_t port, const std::string& method, con
 RawConnectionDriver::RawConnectionDriver(uint32_t port, Buffer::Instance& initial_data,
                                          ReadCallback data_callback,
                                          Network::Address::IpVersion version) {
-  api_.reset(new Api::Impl(std::chrono::milliseconds(10000)));
+  api_ = std::make_unique<Api::Impl>(std::chrono::milliseconds(10000));
   dispatcher_ = api_->allocateDispatcher(IntegrationUtil::evil_singleton_test_time_.timeSystem());
   callbacks_ = std::make_unique<ConnectionCallbacks>();
   client_ = dispatcher_->createClientConnection(

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -1,5 +1,6 @@
 #include "xfcc_integration_test.h"
 
+#include <memory>
 #include <regex>
 #include <unordered_map>
 
@@ -123,7 +124,7 @@ void XfccIntegrationTest::initialize() {
     config_helper_.addSslConfig();
   }
 
-  context_manager_.reset(new Ssl::ContextManagerImpl(timeSystem()));
+  context_manager_ = std::make_unique<Ssl::ContextManagerImpl>(timeSystem());
   client_tls_ssl_ctx_ = createClientSslContext(false);
   client_mtls_ssl_ctx_ = createClientSslContext(true);
   HttpIntegrationTest::initialize();

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -45,8 +45,8 @@ public:
   ~MockClusterInfo();
 
   void resetResourceManager(uint64_t cx, uint64_t rq_pending, uint64_t rq, uint64_t rq_retry) {
-    resource_manager_.reset(new ResourceManagerImpl(runtime_, name_, cx, rq_pending, rq, rq_retry,
-                                                    circuit_breakers_stats_));
+    resource_manager_ = std::make_unique<ResourceManagerImpl>(runtime_, name_, cx, rq_pending, rq,
+                                                              rq_retry, circuit_breakers_stats_);
   }
 
   // Upstream::ClusterInfo

--- a/test/server/guarddog_impl_test.cc
+++ b/test/server/guarddog_impl_test.cc
@@ -45,7 +45,7 @@ protected:
    */
   void SetupForDeath() {
     InSequence s;
-    guard_dog_.reset(new GuardDogImpl(fakestats_, config_kill_, time_system_));
+    guard_dog_ = std::make_unique<GuardDogImpl>(fakestats_, config_kill_, time_system_);
     unpet_dog_ = guard_dog_->createWatchDog(0);
     guard_dog_->forceCheckForTest();
     time_system_.sleep(std::chrono::milliseconds(500));
@@ -57,7 +57,7 @@ protected:
    */
   void SetupForMultiDeath() {
     InSequence s;
-    guard_dog_.reset(new GuardDogImpl(fakestats_, config_multikill_, time_system_));
+    guard_dog_ = std::make_unique<GuardDogImpl>(fakestats_, config_multikill_, time_system_);
     auto unpet_dog_ = guard_dog_->createWatchDog(0);
     guard_dog_->forceCheckForTest();
     auto second_dog_ = guard_dog_->createWatchDog(1);

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "common/api/os_sys_calls_impl.h"
 #include "common/common/hex.h"
 
@@ -38,7 +40,7 @@ public:
     EXPECT_CALL(options_, statsOptions()).WillRepeatedly(ReturnRef(stats_options_));
 
     // Test we match the correct stat with empty-slots before, after, or both.
-    hot_restart_.reset(new HotRestartImpl(options_));
+    hot_restart_ = std::make_unique<HotRestartImpl>(options_);
     hot_restart_->drainParentListeners();
   }
 

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "envoy/api/v2/lds.pb.h"
 
 #include "common/config/utility.h"
@@ -50,8 +52,8 @@ public:
     EXPECT_CALL(*cluster.info_, type());
     interval_timer_ = new Event::MockTimer(&dispatcher_);
     EXPECT_CALL(init_, registerTarget(_));
-    lds_.reset(new LdsApiImpl(lds_config, cluster_manager_, dispatcher_, random_, init_,
-                              local_info_, store_, listener_manager_));
+    lds_ = std::make_unique<LdsApiImpl>(lds_config, cluster_manager_, dispatcher_, random_, init_,
+                                        local_info_, store_, listener_manager_);
 
     expectRequest();
     init_.initialize();
@@ -256,7 +258,7 @@ TEST_F(LdsApiTest, Basic) {
 
   Http::MessagePtr message(new Http::ResponseMessageImpl(
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(response1_json));
+  message->body() = std::make_unique<Buffer::OwnedImpl>(response1_json);
 
   makeListenersAndExpectCall({});
   expectAdd("listener1", "hash_d5b83398260abbbc", true);
@@ -287,9 +289,9 @@ TEST_F(LdsApiTest, Basic) {
   }
   )EOF";
 
-  message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(response2_json));
+  message = std::make_unique<Http::ResponseMessageImpl>(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}});
+  message->body() = std::make_unique<Buffer::OwnedImpl>(response2_json);
 
   makeListenersAndExpectCall({"listener1", "listener2"});
   EXPECT_CALL(listener_manager_, removeListener("listener2")).WillOnce(Return(true));
@@ -320,7 +322,7 @@ TEST_F(LdsApiTest, TlsConfigWithoutCaCert) {
 
   Http::MessagePtr message(new Http::ResponseMessageImpl(
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(response1_json));
+  message->body() = std::make_unique<Buffer::OwnedImpl>(response1_json);
 
   makeListenersAndExpectCall({});
   EXPECT_CALL(init_.initialized_, ready());
@@ -367,9 +369,9 @@ TEST_F(LdsApiTest, TlsConfigWithoutCaCert) {
                   TestEnvironment::runfilesPath("/test/config/integration/certs/servercert.pem"),
                   TestEnvironment::runfilesPath("/test/config/integration/certs/serverkey.pem"));
 
-  message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(response2_json));
+  message = std::make_unique<Http::ResponseMessageImpl>(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}});
+  message->body() = std::make_unique<Buffer::OwnedImpl>(response2_json);
   makeListenersAndExpectCall({
       "listener-8080",
   });
@@ -393,7 +395,7 @@ TEST_F(LdsApiTest, Failure) {
 
   Http::MessagePtr message(new Http::ResponseMessageImpl(
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(response_json));
+  message->body() = std::make_unique<Buffer::OwnedImpl>(response_json);
 
   EXPECT_CALL(init_.initialized_, ready());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
@@ -437,7 +439,7 @@ TEST_F(LdsApiTest, ReplacingListenerWithSameAddress) {
 
   Http::MessagePtr message(new Http::ResponseMessageImpl(
       Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(response1_json));
+  message->body() = std::make_unique<Buffer::OwnedImpl>(response1_json);
 
   makeListenersAndExpectCall({});
   expectAdd("listener1", "hash_d5b83398260abbbc", true);
@@ -468,9 +470,9 @@ TEST_F(LdsApiTest, ReplacingListenerWithSameAddress) {
   }
   )EOF";
 
-  message.reset(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-  message->body().reset(new Buffer::OwnedImpl(response2_json));
+  message = std::make_unique<Http::ResponseMessageImpl>(
+      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}});
+  message->body() = std::make_unique<Buffer::OwnedImpl>(response2_json);
 
   makeListenersAndExpectCall({"listener1", "listener2"});
   EXPECT_CALL(listener_manager_, removeListener("listener2")).WillOnce(Return(true));

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "envoy/admin/v2alpha/config_dump.pb.h"
 #include "envoy/registry/registry.h"
 #include "envoy/server/filter_config.h"
@@ -54,8 +56,8 @@ class ListenerManagerImplTest : public testing::Test {
 public:
   ListenerManagerImplTest() {
     EXPECT_CALL(worker_factory_, createWorker_()).WillOnce(Return(worker_));
-    manager_.reset(
-        new ListenerManagerImpl(server_, listener_factory_, worker_factory_, time_system_));
+    manager_ = std::make_unique<ListenerManagerImpl>(server_, listener_factory_, worker_factory_,
+                                                     time_system_);
   }
 
   /**
@@ -138,7 +140,7 @@ public:
               return ProdListenerComponentFactory::createListenerFilterFactoryList_(filters,
                                                                                     context);
             }));
-    socket_.reset(new NiceMock<Network::MockConnectionSocket>());
+    socket_ = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
     address_.reset(new Network::Address::Ipv4Instance("127.0.0.1", 1234));
   }
 

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "common/common/version.h"
 #include "common/network/address_impl.h"
 #include "common/thread_local/thread_local_impl.h"
@@ -60,8 +62,9 @@ public:
     EXPECT_CALL(cm_, setInitializedCb(_)).WillOnce(SaveArg<0>(&cm_init_callback_));
     EXPECT_CALL(overload_manager_, start());
 
-    helper_.reset(new RunHelper(dispatcher_, cm_, hot_restart_, access_log_manager_, init_manager_,
-                                overload_manager_, [this] { start_workers_.ready(); }));
+    helper_ = std::make_unique<RunHelper>(dispatcher_, cm_, hot_restart_, access_log_manager_,
+                                          init_manager_, overload_manager_,
+                                          [this] { start_workers_.ready(); });
   }
 
   NiceMock<Event::MockDispatcher> dispatcher_;
@@ -112,11 +115,11 @@ protected:
       options_.config_path_ = TestEnvironment::temporaryFileSubstitute(
           bootstrap_path, {{"upstream_0", 0}, {"upstream_1", 0}}, version_);
     }
-    server_.reset(new InstanceImpl(
+    server_ = std::make_unique<InstanceImpl>(
         options_, test_time_.timeSystem(),
         Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("127.0.0.1")),
         hooks_, restart_, stats_store_, fakelock_, component_factory_,
-        std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), thread_local_));
+        std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), thread_local_);
 
     EXPECT_TRUE(server_->api().fileExists("/dev/null"));
   }
@@ -128,11 +131,11 @@ protected:
         {{"health_check_timeout", fmt::format("{}", timeout).c_str()},
          {"health_check_interval", fmt::format("{}", interval).c_str()}},
         TestEnvironment::PortMap{}, version_);
-    server_.reset(new InstanceImpl(
+    server_ = std::make_unique<InstanceImpl>(
         options_, test_time_.timeSystem(),
         Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("127.0.0.1")),
         hooks_, restart_, stats_store_, fakelock_, component_factory_,
-        std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), thread_local_));
+        std::make_unique<NiceMock<Runtime::MockRandomGenerator>>(), thread_local_);
 
     EXPECT_TRUE(server_->api().fileExists("/dev/null"));
   }


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>


*Description*: 
Mostly generated by `run-clang-tidy-7 -checks='-*,modernize-make-*' -fix`, with a few manual change to make build pass.
For #4863 

*Risk Level*: Low
*Testing*: CI
*Docs Changes*: N/A
*Release Notes*: N/A
