### PR TITLE
 lint: fix if and loops are not inside braces and  remove redundant calls to smart pointer’s .get() method

### DIFF
--- a/source/common/upstream/load_stats_reporter.cc
+++ b/source/common/upstream/load_stats_reporter.cc
@@ -90,7 +90,7 @@ void LoadStatsReporter::sendLoadStatsRequest() {
   stats_.responses_.inc();
   // When the connection is established, the message has not yet been read so we
   // will not have a load reporting period.
-  if (message_.get()) {
+  if (message_) {
     startLoadReportPeriod();
   }
 }

--- a/source/extensions/filters/network/mongo_proxy/codec_impl.cc
+++ b/source/extensions/filters/network/mongo_proxy/codec_impl.cc
@@ -426,8 +426,9 @@ bool DecoderImpl::decode(Buffer::Instance& data) {
 }
 
 void DecoderImpl::onData(Buffer::Instance& data) {
-  while (data.length() > 0 && decode(data))
+  while (data.length() > 0 && decode(data)) {
     ;
+  }
 }
 
 void EncoderImpl::encodeCommonHeader(int32_t total_size, const Message& message,

--- a/source/extensions/filters/network/mongo_proxy/codec_impl.cc
+++ b/source/extensions/filters/network/mongo_proxy/codec_impl.cc
@@ -427,7 +427,6 @@ bool DecoderImpl::decode(Buffer::Instance& data) {
 
 void DecoderImpl::onData(Buffer::Instance& data) {
   while (data.length() > 0 && decode(data)) {
-    ;
   }
 }
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -480,7 +480,7 @@ void InstanceImpl::terminate() {
   }
 
   // Shutdown all the workers now that the main dispatch loop is done.
-  if (listener_manager_.get() != nullptr) {
+  if (listener_manager_ != nullptr) {
     listener_manager_->stopWorkers();
   }
 
@@ -489,7 +489,7 @@ void InstanceImpl::terminate() {
     flushStats();
   }
 
-  if (config_.get() != nullptr && config_->clusterManager() != nullptr) {
+  if (config_ != nullptr && config_->clusterManager() != nullptr) {
     config_->clusterManager()->shutdown();
   }
   handler_.reset();

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -67,10 +67,11 @@ TEST(Logger, logAsStatement) {
 
   // Make sure that if statement inside of LOGGER macro does not catch trailing
   // else ....
-  if (true)
+  if (true) {
     ENVOY_LOG_MISC(warn, "test message 1 '{}'", i++);
-  else
+  } else {
     ENVOY_LOG_MISC(critical, "test message 2 '{}'", j++);
+  }
 
   EXPECT_THAT(i, testing::Eq(1));
   EXPECT_THAT(j, testing::Eq(1));

--- a/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
@@ -81,7 +81,7 @@ public:
   void createSyncMockAuthsAndVerifier(const StatusMap& statuses) {
     for (const auto& it : statuses) {
       auto mock_auth = std::make_unique<MockAuthenticator>();
-      EXPECT_CALL(*mock_auth.get(), doVerify(_, _, _, _))
+      EXPECT_CALL(*mock_auth, doVerify(_, _, _, _))
           .WillOnce(Invoke([issuer = it.first, status = it.second](
                                Http::HeaderMap&, std::vector<JwtLocationConstPtr>*,
                                SetPayloadCallback set_payload_cb, AuthenticatorCallback callback) {
@@ -91,7 +91,7 @@ public:
             }
             callback(status);
           }));
-      EXPECT_CALL(*mock_auth.get(), onDestroy()).Times(1);
+      EXPECT_CALL(*mock_auth, onDestroy()).Times(1);
       mock_auths_[it.first] = std::move(mock_auth);
     }
     createVerifier();
@@ -114,13 +114,13 @@ public:
     std::unordered_map<std::string, AuthenticatorCallback> callbacks;
     for (std::size_t i = 0; i < providers.size(); ++i) {
       auto mock_auth = std::make_unique<MockAuthenticator>();
-      EXPECT_CALL(*mock_auth.get(), doVerify(_, _, _, _))
+      EXPECT_CALL(*mock_auth, doVerify(_, _, _, _))
           .WillOnce(Invoke(
               [&callbacks, iss = providers[i]](Http::HeaderMap&, std::vector<JwtLocationConstPtr>*,
                                                SetPayloadCallback, AuthenticatorCallback callback) {
                 callbacks[iss] = std::move(callback);
               }));
-      EXPECT_CALL(*mock_auth.get(), onDestroy()).Times(1);
+      EXPECT_CALL(*mock_auth, onDestroy()).Times(1);
       mock_auths_[providers[i]] = std::move(mock_auth);
     }
     createVerifier();
@@ -206,7 +206,7 @@ rules:
 )";
   MessageUtil::loadFromYaml(config, proto_config_);
   auto mock_auth = std::make_unique<MockAuthenticator>();
-  EXPECT_CALL(*mock_auth.get(), doVerify(_, _, _, _)).Times(0);
+  EXPECT_CALL(*mock_auth, doVerify(_, _, _, _)).Times(0);
   mock_auths_["example_provider"] = std::move(mock_auth);
   createVerifier();
 
@@ -516,11 +516,11 @@ TEST_F(GroupVerifierTest, TestRequiresAnyWithAllowAll) {
   auto callbacks = createAsyncMockAuthsAndVerifier(
       std::vector<std::string>{"example_provider", "other_provider"});
   auto mock_auth = std::make_unique<MockAuthenticator>();
-  EXPECT_CALL(*mock_auth.get(), doVerify(_, _, _, _))
+  EXPECT_CALL(*mock_auth, doVerify(_, _, _, _))
       .WillOnce(Invoke(
           [&](Http::HeaderMap&, std::vector<JwtLocationConstPtr>*, SetPayloadCallback,
               AuthenticatorCallback callback) { callbacks[allowfailed] = std::move(callback); }));
-  EXPECT_CALL(*mock_auth.get(), onDestroy()).Times(1);
+  EXPECT_CALL(*mock_auth, onDestroy()).Times(1);
   mock_auths_[allowfailed] = std::move(mock_auth);
   EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
 

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -455,8 +455,9 @@ TEST_P(ProxyProtocolTest, v1TooLong) {
   constexpr uint8_t buffer[] = {' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '};
   connect(false);
   write("PROXY TCP4 1.2.3.4 2.3.4.5 100 100");
-  for (size_t i = 0; i < 256; i += sizeof(buffer))
+  for (size_t i = 0; i < 256; i += sizeof(buffer)) {
     write(buffer, sizeof(buffer));
+  }
   expectProxyProtoError();
 }
 
@@ -735,8 +736,9 @@ TEST_P(ProxyProtocolTest, v2PartialRead) {
 
   for (size_t i = 0; i < sizeof(buffer); i += 9) {
     write(&buffer[i], 9);
-    if (i == 0)
+    if (i == 0) {
       dispatcher_.run(Event::Dispatcher::RunType::NonBlock);
+    }
   }
 
   expectData("moredata");

--- a/test/integration/filters/random_pause_filter.cc
+++ b/test/integration/filters/random_pause_filter.cc
@@ -52,7 +52,7 @@ public:
   Http::FilterFactoryCb createFilter(const std::string&, Server::Configuration::FactoryContext&) {
     return [&](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       absl::WriterMutexLock m(&rand_lock_);
-      if (rng_.get() == nullptr) {
+      if (rng_ == nullptr) {
         // Lazily create to ensure the test seed is set.
         rng_ = std::make_unique<TestRandomGenerator>();
       }

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -1423,7 +1423,7 @@ void HttpIntegrationTest::testHttp10Enabled() {
 
   std::unique_ptr<Http::TestHeaderMapImpl> upstream_headers =
       reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())->lastRequestHeaders();
-  ASSERT_TRUE(upstream_headers.get() != nullptr);
+  ASSERT_TRUE(upstream_headers != nullptr);
   EXPECT_EQ(upstream_headers->Host()->value(), "default.com");
 
   sendRawHttpAndWaitForResponse(lookupPort("http"), "HEAD / HTTP/1.0\r\n\r\n", &response, false);
@@ -1448,7 +1448,7 @@ void HttpIntegrationTest::testHttp10WithHostAndKeepAlive() {
 
   std::unique_ptr<Http::TestHeaderMapImpl> upstream_headers =
       reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())->lastRequestHeaders();
-  ASSERT_TRUE(upstream_headers.get() != nullptr);
+  ASSERT_TRUE(upstream_headers != nullptr);
   EXPECT_EQ(upstream_headers->Host()->value(), "foo.com");
 }
 
@@ -1465,7 +1465,7 @@ void HttpIntegrationTest::testHttp09Enabled() {
 
   std::unique_ptr<Http::TestHeaderMapImpl> upstream_headers =
       reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())->lastRequestHeaders();
-  ASSERT_TRUE(upstream_headers.get() != nullptr);
+  ASSERT_TRUE(upstream_headers != nullptr);
   EXPECT_EQ(upstream_headers->Host()->value(), "default.com");
 }
 
@@ -1544,7 +1544,7 @@ void HttpIntegrationTest::testInlineHeaders() {
 
   std::unique_ptr<Http::TestHeaderMapImpl> upstream_headers =
       reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())->lastRequestHeaders();
-  ASSERT_TRUE(upstream_headers.get() != nullptr);
+  ASSERT_TRUE(upstream_headers != nullptr);
   EXPECT_EQ(upstream_headers->Host()->value(), "foo.com");
   EXPECT_EQ(upstream_headers->CacheControl()->value(), "public,123");
   ASSERT_TRUE(upstream_headers->get(Envoy::Http::LowerCaseString("foo")) != nullptr);


### PR DESCRIPTION

 1. remove redundant calls to smart pointer’s .get() method.
 2. add braces for bodies of if statements and loops (for, do while, and while) are not inside braces

*Description*: fix if and loops are not inside braces and  remove redundant calls to smart pointer’s .get() method.
*Risk Level*: lower
*Testing*: unittests
*Docs Changes*: N/A
*Release Notes*: n/A
[Optional Fixes #Issue] #4863 
