### PR TITLE
WIP: Kafka codec

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -34,6 +34,7 @@ namespace Logger {
   FUNCTION(http)                 \
   FUNCTION(http2)                \
   FUNCTION(hystrix)              \
+  FUNCTION(kafka)                \
   FUNCTION(lua)                  \
   FUNCTION(main)                 \
   FUNCTION(misc)                 \

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -65,6 +65,7 @@ EXTENSIONS = {
     "envoy.filters.network.echo":                       "//source/extensions/filters/network/echo:config",
     "envoy.filters.network.ext_authz":                  "//source/extensions/filters/network/ext_authz:config",
     "envoy.filters.network.http_connection_manager":    "//source/extensions/filters/network/http_connection_manager:config",
+    "envoy.filters.network.kafka":                      "//source/extensions/filters/network/kafka:config",
     "envoy.filters.network.mongo_proxy":                "//source/extensions/filters/network/mongo_proxy:config",
     "envoy.filters.network.ratelimit":                  "//source/extensions/filters/network/ratelimit:config",
     "envoy.filters.network.rbac":                       "//source/extensions/filters/network/rbac:config",

--- a/source/extensions/filters/network/kafka/BUILD
+++ b/source/extensions/filters/network/kafka/BUILD
@@ -1,0 +1,82 @@
+licenses(["notice"])  # Apache 2
+
+# Kafka network filter.
+# Public docs: docs/root/configuration/network_filters/kafka_filter.rst
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "config",
+)
+
+envoy_cc_library(
+    name = "kafka_request_codec_lib",
+    srcs = ["request_codec.cc"],
+    hdrs = [
+        "codec.h",
+        "request_codec.h",
+    ],
+    deps = [
+        ":kafka_request_lib",
+        "//source/common/buffer:buffer_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "kafka_request_lib",
+    srcs = ["kafka_request.cc"],
+    hdrs = ["kafka_request.h"],
+    deps = [
+        ":parser_lib",
+        ":serialization_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/common:minimal_logger_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "parser_lib",
+    hdrs = ["parser.h"],
+    deps = [
+        ":kafka_protocol_lib",
+        ":message_lib",
+        "//source/common/common:minimal_logger_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "message_lib",
+    hdrs = [
+        "message.h",
+    ],
+    deps = [
+    ],
+)
+
+envoy_cc_library(
+    name = "serialization_lib",
+    hdrs = ["serialization.h"],
+    deps = [
+        ":kafka_protocol_lib",
+        "//include/envoy/buffer:buffer_interface",
+        "//source/common/common:byte_order_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "kafka_protocol_lib",
+    hdrs = [
+        "kafka_protocol.h",
+        "kafka_types.h",
+    ],
+    external_deps = ["abseil_optional"],
+    deps = [
+        "//source/common/common:macros",
+    ],
+)

--- a/source/extensions/filters/network/kafka/codec.h
+++ b/source/extensions/filters/network/kafka/codec.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/common/pure.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+
+/**
+ * Kafka message decoder
+ * @tparam MT message type (Kafka request or Kafka response)
+ */
+template <typename MT> class MessageDecoder {
+public:
+  virtual ~MessageDecoder() = default;
+  virtual void onData(Buffer::Instance& data) PURE;
+};
+
+/**
+ * Kafka message decoder
+ * @tparam MT message type (Kafka request or Kafka response)
+ */
+template <typename MT> class MessageEncoder {
+public:
+  virtual ~MessageEncoder() = default;
+  virtual void encode(const MT& message) PURE;
+};
+
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/kafka/kafka_protocol.h
+++ b/source/extensions/filters/network/kafka/kafka_protocol.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include <vector>
+
+#include "common/common/macros.h"
+
+#include "extensions/filters/network/kafka/kafka_types.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+
+// from http://kafka.apache.org/protocol.html#protocol_api_keys
+enum RequestType : INT16 {
+  Produce = 0,
+  Fetch = 1,
+  ListOffsets = 2,
+  Metadata = 3,
+  LeaderAndIsr = 4,
+  StopReplica = 5,
+  UpdateMetadata = 6,
+  ControlledShutdown = 7,
+  OffsetCommit = 8,
+  OffsetFetch = 9,
+  FindCoordinator = 10,
+  JoinGroup = 11,
+  Heartbeat = 12,
+  LeaveGroup = 13,
+  SyncGroup = 14,
+  DescribeGroups = 15,
+  ListGroups = 16,
+  SaslHandshake = 17,
+  ApiVersions = 18,
+  CreateTopics = 19,
+  DeleteTopics = 20,
+  DeleteRecords = 21,
+  InitProducerId = 22,
+  OffsetForLeaderEpoch = 23,
+  AddPartitionsToTxn = 24,
+  AddOffsetsToTxn = 25,
+  EndTxn = 26,
+  WriteTxnMarkers = 27,
+  TxnOffsetCommit = 28,
+  DescribeAcls = 29,
+  CreateAcls = 30,
+  DeleteAcls = 31,
+  DescribeConfigs = 32,
+  AlterConfigs = 33,
+  AlterReplicaLogDirs = 34,
+  DescribeLogDirs = 35,
+  SaslAuthenticate = 36,
+  CreatePartitions = 37,
+  CreateDelegationToken = 38,
+  RenewDelegationToken = 39,
+  ExpireDelegationToken = 40,
+  DescribeDelegationToken = 41,
+  DeleteGroups = 42
+};
+
+struct RequestSpec {
+  const INT16 api_key_;
+  const std::string name_;
+};
+
+struct KafkaRequest {
+
+  // clang-format off
+  static const std::vector<RequestSpec>& requests() {
+    CONSTRUCT_ON_FIRST_USE(
+        std::vector<RequestSpec>,
+        {RequestType::Produce, "Produce"},
+        {RequestType::Fetch, "Fetch"},
+        {RequestType::ListOffsets, "ListOffsets"},
+        {RequestType::Metadata, "Metadata"},
+        {RequestType::LeaderAndIsr, "LeaderAndIsr"},
+        {RequestType::StopReplica, "StopReplica"},
+        {RequestType::UpdateMetadata, "UpdateMetadata"},
+        {RequestType::ControlledShutdown, "ControlledShutdown"},
+        {RequestType::OffsetCommit, "OffsetCommit"},
+        {RequestType::OffsetFetch, "OffsetFetch"},
+        {RequestType::FindCoordinator, "FindCoordinator"},
+        {RequestType::JoinGroup, "JoinGroup"},
+        {RequestType::Heartbeat, "Heartbeat"},
+        {RequestType::LeaveGroup, "LeaveGroup"},
+        {RequestType::SyncGroup, "SyncGroup"},
+        {RequestType::DescribeGroups, "DescribeGroups"},
+        {RequestType::ListGroups, "ListGroups"},
+        {RequestType::SaslHandshake, "SaslHandshake"},
+        {RequestType::ApiVersions, "ApiVersions"},
+        {RequestType::CreateTopics, "CreateTopics"},
+        {RequestType::DeleteTopics, "DeleteTopics"},
+        {RequestType::DeleteRecords, "DeleteRecords"},
+        {RequestType::InitProducerId, "InitProducerId"},
+        {RequestType::OffsetForLeaderEpoch, "OffsetForLeaderEpoch"},
+        {RequestType::AddPartitionsToTxn, "AddPartitionsToTxn"},
+        {RequestType::AddOffsetsToTxn, "AddOffsetsToTxn"},
+        {RequestType::EndTxn, "EndTxn"},
+        {RequestType::WriteTxnMarkers, "WriteTxnMarkers"},
+        {RequestType::TxnOffsetCommit, "TxnOffsetCommit"},
+        {RequestType::DescribeAcls, "DescribeAcls"},
+        {RequestType::CreateAcls, "CreateAcls"},
+        {RequestType::DeleteAcls, "DeleteAcls"},
+        {RequestType::DescribeConfigs, "DescribeConfigs"},
+        {RequestType::AlterConfigs, "AlterConfigs"},
+        {RequestType::AlterReplicaLogDirs, "AlterReplicaLogDirs"},
+        {RequestType::DescribeLogDirs, "DescribeLogDirs"},
+        {RequestType::SaslAuthenticate, "SaslAuthenticate"},
+        {RequestType::CreatePartitions, "CreatePartitions"},
+        {RequestType::CreateDelegationToken, "CreateDelegationToken"},
+        {RequestType::RenewDelegationToken, "RenewDelegationToken"},
+        {RequestType::ExpireDelegationToken, "ExpireDelegationToken"},
+        {RequestType::DescribeDelegationToken, "DescribeDelegationToken"},
+        {RequestType::DeleteGroups, "DeleteGroups"}
+    );
+  }
+  // clang-format on
+};
+
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/kafka/kafka_request.cc
+++ b/source/extensions/filters/network/kafka/kafka_request.cc
@@ -1,0 +1,135 @@
+#include "extensions/filters/network/kafka/kafka_request.h"
+
+#include "extensions/filters/network/kafka/kafka_protocol.h"
+#include "extensions/filters/network/kafka/parser.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+
+// === REQUEST PARSER MAPPING (REQUEST TYPE => PARSER) =========================
+
+GeneratorMap computeGeneratorMap(std::vector<ParserSpec> specs) {
+  GeneratorMap result;
+  for (auto& spec : specs) {
+    auto generators = result[spec.api_key_];
+    if (!generators) {
+      generators = std::make_shared<std::unordered_map<INT16, GeneratorFunction>>();
+      result[spec.api_key_] = generators;
+    }
+    for (INT16 api_version : spec.api_versions_) {
+      (*generators)[api_version] = spec.generator_;
+    }
+  }
+
+  return result;
+}
+
+#define PARSER_SPEC(REQUEST_NAME, PARSER_VERSION, ...)                                             \
+  ParserSpec {                                                                                     \
+    RequestType::REQUEST_NAME, {__VA_ARGS__}, [](RequestContextSharedPtr arg) -> ParserSharedPtr { \
+      return std::make_shared<REQUEST_NAME##Request##PARSER_VERSION##Parser>(arg);                 \
+    }                                                                                              \
+  }
+
+const RequestParserResolver RequestParserResolver::KAFKA_0_11{{
+    ParserSpec{RequestType::Produce,
+               {0, 1, 2},
+               [](RequestContextSharedPtr arg) -> ParserSharedPtr {
+                 return std::make_shared<FatProduceRequestV0Parser>(arg);
+               }},
+    ParserSpec{RequestType::Produce,
+               {3},
+               [](RequestContextSharedPtr arg) -> ParserSharedPtr {
+                 return std::make_shared<FatProduceRequestV3Parser>(arg);
+               }},
+    PARSER_SPEC(Fetch, V0, 0, 1, 2),
+    PARSER_SPEC(Fetch, V3, 3),
+    PARSER_SPEC(Fetch, V4, 4),
+    PARSER_SPEC(Fetch, V5, 5),
+    PARSER_SPEC(ListOffsets, V0, 0),
+    PARSER_SPEC(ListOffsets, V1, 1),
+    PARSER_SPEC(ListOffsets, V2, 2),
+    PARSER_SPEC(Metadata, V0, 0, 1, 2, 3),
+    PARSER_SPEC(Metadata, V4, 4),
+    PARSER_SPEC(LeaderAndIsr, V0, 0),
+    PARSER_SPEC(StopReplica, V0, 0),
+    PARSER_SPEC(UpdateMetadata, V0, 0),
+    PARSER_SPEC(UpdateMetadata, V1, 1),
+    PARSER_SPEC(UpdateMetadata, V2, 2),
+    PARSER_SPEC(UpdateMetadata, V3, 3),
+    PARSER_SPEC(ControlledShutdown, V1, 1),
+    PARSER_SPEC(OffsetCommit, V0, 0),
+    PARSER_SPEC(OffsetCommit, V1, 1),
+    PARSER_SPEC(OffsetCommit, V2, 2, 3),
+    PARSER_SPEC(OffsetFetch, V0, 0, 1, 2, 3),
+    // XXX(adam.kotwasinski) missing request types here
+    PARSER_SPEC(ApiVersions, V0, 0, 1),
+}};
+
+ParserSharedPtr RequestParserResolver::createParser(INT16 api_key, INT16 api_version,
+                                                    RequestContextSharedPtr context) const {
+  const auto api_versions_ptr = generators_.find(api_key);
+  // unknown api_key
+  if (generators_.end() == api_versions_ptr) {
+    return std::make_shared<SentinelConsumer>(context);
+  }
+  const auto api_versions = api_versions_ptr->second;
+
+  // unknown api_version
+  const auto generator = api_versions->find(api_version);
+  if (api_versions->end() == generator) {
+    return std::make_shared<SentinelConsumer>(context);
+  }
+
+  // found matching parser generator, create parser
+  return generator->second(context);
+}
+
+// === HEADER PARSERS ==========================================================
+
+ParseResponse RequestStartParser::parse(const char*& buffer, uint64_t& remaining) {
+  buffer_.feed(buffer, remaining);
+  if (buffer_.ready()) {
+    context_->remaining_request_size_ = buffer_.get();
+    return ParseResponse::nextParser(
+        std::make_shared<RequestHeaderParser>(parser_resolver_, context_));
+  } else {
+    return ParseResponse::stillWaiting();
+  }
+}
+
+ParseResponse RequestHeaderParser::parse(const char*& buffer, uint64_t& remaining) {
+  context_->remaining_request_size_ -= buffer_.feed(buffer, remaining);
+
+  if (buffer_.ready()) {
+    RequestHeader request_header = buffer_.get();
+    context_->request_header_ = request_header;
+    ParserSharedPtr next_parser = parser_resolver_.createParser(
+        request_header.api_key_, request_header.api_version_, context_);
+    return ParseResponse::nextParser(next_parser);
+  } else {
+    return ParseResponse::stillWaiting();
+  }
+}
+
+// === UNKNOWN REQUEST =========================================================
+
+ParseResponse SentinelConsumer::parse(const char*& buffer, uint64_t& remaining) {
+  const size_t min = std::min<size_t>(context_->remaining_request_size_, remaining);
+  buffer += min;
+  remaining -= min;
+  context_->remaining_request_size_ -= min;
+  if (0 == context_->remaining_request_size_) {
+    return ParseResponse::parsedMessage(
+        std::make_shared<UnknownRequest>(context_->request_header_));
+  } else {
+    return ParseResponse::stillWaiting();
+  }
+}
+
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/kafka/kafka_request.h
+++ b/source/extensions/filters/network/kafka/kafka_request.h
@@ -1,0 +1,1316 @@
+#pragma once
+
+#include <sstream>
+
+#include "envoy/common/exception.h"
+
+#include "common/common/assert.h"
+
+#include "extensions/filters/network/kafka/kafka_protocol.h"
+#include "extensions/filters/network/kafka/parser.h"
+#include "extensions/filters/network/kafka/serialization.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+
+// === VECTOR ==================================================================
+
+template <typename T> std::ostream& operator<<(std::ostream& os, const std::vector<T>& arg) {
+  os << "[";
+  for (auto iter = arg.begin(); iter != arg.end(); iter++) {
+    if (iter != arg.begin()) {
+      os << ", ";
+    }
+    os << *iter;
+  }
+  os << "]";
+  return os;
+}
+
+template <typename T> std::ostream& operator<<(std::ostream& os, const absl::optional<T>& arg) {
+  if (arg.has_value()) {
+    os << *arg;
+  } else {
+    os << "<null>";
+  }
+  return os;
+}
+
+// === REQUEST HEADER ==========================================================
+
+struct RequestHeader {
+  INT16 api_key_;
+  INT16 api_version_;
+  INT32 correlation_id_;
+  NULLABLE_STRING client_id_;
+
+  bool operator==(const RequestHeader& rhs) const {
+    return api_key_ == rhs.api_key_ && api_version_ == rhs.api_version_ &&
+           correlation_id_ == rhs.correlation_id_ && client_id_ == rhs.client_id_;
+  };
+
+  friend std::ostream& operator<<(std::ostream& os, const RequestHeader& arg) {
+    return os << "{api_key=" << arg.api_key_ << ", api_version=" << arg.api_version_
+              << ", correlation_id=" << arg.correlation_id_ << ", client_id=" << arg.client_id_
+              << "}";
+  };
+};
+
+struct RequestContext {
+  INT32 remaining_request_size_{0};
+  RequestHeader request_header_{};
+
+  friend std::ostream& operator<<(std::ostream& os, const RequestContext& arg) {
+    return os << "{header=" << arg.request_header_ << ", remaining=" << arg.remaining_request_size_
+              << "}";
+  }
+};
+
+typedef std::shared_ptr<RequestContext> RequestContextSharedPtr;
+
+// === REQUEST PARSER MAPPING (REQUEST TYPE => PARSER) =========================
+
+// a function generating a parser with given context
+typedef std::function<ParserSharedPtr(RequestContextSharedPtr)> GeneratorFunction;
+
+// two-level map: api_key -> api_version -> generator function
+typedef std::unordered_map<INT16, std::shared_ptr<std::unordered_map<INT16, GeneratorFunction>>>
+    GeneratorMap;
+
+struct ParserSpec {
+  const INT16 api_key_;
+  const std::vector<INT16> api_versions_;
+  const GeneratorFunction generator_;
+};
+
+// helper function that generates a map from specs looking like { api_key, api_versions... }
+GeneratorMap computeGeneratorMap(std::vector<ParserSpec> arg);
+
+/**
+ * Provides the parser that is responsible for consuming the request-specific data
+ * In other words: provides (api_key, api_version) -> Parser function
+ */
+class RequestParserResolver {
+public:
+  RequestParserResolver(std::vector<ParserSpec> arg) : generators_{computeGeneratorMap(arg)} {};
+  virtual ~RequestParserResolver() = default;
+
+  virtual ParserSharedPtr createParser(INT16 api_key, INT16 api_version,
+                                       RequestContextSharedPtr context) const;
+
+  static const RequestParserResolver KAFKA_0_11;
+
+private:
+  GeneratorMap generators_;
+};
+
+// === INITIAL PARSERS =========================================================
+
+/**
+ * Request start parser just consumes the length of request
+ */
+class RequestStartParser : public Parser {
+public:
+  RequestStartParser(const RequestParserResolver& parser_resolver)
+      : parser_resolver_{parser_resolver}, context_{std::make_shared<RequestContext>()} {};
+
+  ParseResponse parse(const char*& buffer, uint64_t& remaining);
+
+  const RequestContextSharedPtr contextForTest() const { return context_; }
+
+private:
+  const RequestParserResolver& parser_resolver_;
+  const RequestContextSharedPtr context_;
+  Int32Buffer buffer_;
+};
+
+class RequestHeaderBuffer : public CompositeBuffer<RequestHeader, Int16Buffer, Int16Buffer,
+                                                   Int32Buffer, NullableStringBuffer> {};
+
+/**
+ * Request header parser consumes request header
+ */
+class RequestHeaderParser : public Parser {
+public:
+  RequestHeaderParser(const RequestParserResolver& parser_resolver, RequestContextSharedPtr context)
+      : parser_resolver_{parser_resolver}, context_{context} {};
+
+  ParseResponse parse(const char*& buffer, uint64_t& remaining);
+
+  const RequestContextSharedPtr contextForTest() const { return context_; }
+
+private:
+  const RequestParserResolver& parser_resolver_;
+  const RequestContextSharedPtr context_;
+  RequestHeaderBuffer buffer_;
+};
+
+// === BUFFERED PARSER =========================================================
+
+/**
+ * Buffered parser uses a single buffer to construct a response
+ * This parser is responsible for consuming request-specific data (e.g. topic names) and always
+ * returns a parsed message
+ */
+template <typename RT, typename BT> class BufferedParser : public Parser {
+public:
+  BufferedParser(RequestContextSharedPtr context) : context_{context} {};
+  ParseResponse parse(const char*& buffer, uint64_t& remaining) override;
+
+protected:
+  RequestContextSharedPtr context_;
+  BT buffer_;
+};
+
+template <typename RT, typename BT>
+ParseResponse BufferedParser<RT, BT>::parse(const char*& buffer, uint64_t& remaining) {
+  context_->remaining_request_size_ -= buffer_.feed(buffer, remaining);
+  if (buffer_.ready()) {
+    // after a successful parse, there should be nothing left
+    ASSERT(0 == context_->remaining_request_size_);
+    RT request = buffer_.get();
+    request.header() = context_->request_header_;
+    ENVOY_LOG(trace, "parsed request {}: {}", *context_, request);
+    MessageSharedPtr msg = std::make_shared<RT>(request);
+    return ParseResponse::parsedMessage(msg);
+  } else {
+    return ParseResponse::stillWaiting();
+  }
+}
+
+// names of Buffers/Parsers are influenced by org.apache.kafka.common.protocol.Protocol names
+
+#define DEFINE_REQUEST_PARSER(REQUEST_TYPE, VERSION)                                               \
+  class REQUEST_TYPE##VERSION##Parser                                                              \
+      : public BufferedParser<REQUEST_TYPE, REQUEST_TYPE##VERSION##Buffer> {                       \
+  public:                                                                                          \
+    REQUEST_TYPE##VERSION##Parser(RequestContextSharedPtr ctx) : BufferedParser{ctx} {};           \
+  };
+
+// === ABSTRACT REQUEST ========================================================
+
+class Request : public Message {
+public:
+  /**
+   * Request header fields need to be initialized by user in case of newly created requests
+   */
+  Request(INT16 api_key) : request_header_{api_key, 0, 0, ""} {};
+
+  Request(const RequestHeader& request_header) : request_header_{request_header} {};
+
+  RequestHeader& header() { return request_header_; }
+
+  INT16& apiVersion() { return request_header_.api_version_; }
+  INT16 apiVersion() const { return request_header_.api_version_; }
+
+  INT32& correlationId() { return request_header_.correlation_id_; }
+
+  NULLABLE_STRING& clientId() { return request_header_.client_id_; }
+
+  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+    size_t written{0};
+    written += encoder.encode(request_header_.api_key_, dst);
+    written += encoder.encode(request_header_.api_version_, dst);
+    written += encoder.encode(request_header_.correlation_id_, dst);
+    written += encoder.encode(request_header_.client_id_, dst);
+    written += encodeDetails(dst, encoder);
+    return written;
+  }
+
+  std::ostream& print(std::ostream& os) const override final {
+    os << request_header_ << " "; // not very pretty
+    return printDetails(os);
+  }
+
+protected:
+  virtual size_t encodeDetails(Buffer::Instance&, EncodingContext&) const PURE;
+
+  virtual std::ostream& printDetails(std::ostream&) const PURE;
+
+  RequestHeader request_header_;
+};
+
+// === PRODUCE (0) =============================================================
+
+/**
+ * Produce request parser is a special case that has two corresponding parsers
+ * One parser captures data, the other one does not, only saving the length of data provided
+ * This might be used in filters that do not need access to data (e.g. only want to update request
+ * type metrics)
+ */
+
+// holds data sent by client
+struct FatProducePartition {
+  const INT32 partition_;
+  const NULLABLE_BYTES data_;
+
+  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+    size_t written{0};
+    written += encoder.encode(partition_, dst);
+    written += encoder.encode(data_, dst);
+    return written;
+  }
+
+  bool operator==(const FatProducePartition& rhs) const {
+    return partition_ == rhs.partition_ && data_ == rhs.data_;
+  };
+
+  friend std::ostream& operator<<(std::ostream& os, const FatProducePartition& arg) {
+    os << "{partition=" << arg.partition_ << ", data(size)=";
+    if (arg.data_.has_value()) {
+      os << arg.data_->size();
+    } else {
+      os << "<null>";
+    }
+    return os << "}";
+  }
+};
+
+// does not carry data, only its length
+struct ThinProducePartition {
+  const INT32 partition_;
+  const INT32 data_size_;
+
+  size_t encode(Buffer::Instance&, EncodingContext&) const {
+    throw EnvoyException("ThinProducePartition cannot be encoded");
+  }
+
+  bool operator==(const ThinProducePartition& rhs) const {
+    return partition_ == rhs.partition_ && data_size_ == rhs.data_size_;
+  };
+
+  friend std::ostream& operator<<(std::ostream& os, const ThinProducePartition& arg) {
+    return os << "{partition=" << arg.partition_ << ", data_size=" << arg.data_size_ << "}";
+  }
+};
+
+template <typename PT> struct ProduceTopic {
+  const STRING topic_;
+  const NULLABLE_ARRAY<PT> partitions_;
+
+  bool operator==(const ProduceTopic<PT>& rhs) const {
+    return topic_ == rhs.topic_ && partitions_ == rhs.partitions_;
+  };
+
+  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+    size_t written{0};
+    written += encoder.encode(topic_, dst);
+    written += encoder.encode(partitions_, dst);
+    return written;
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const ProduceTopic& arg) {
+    return os << "{topic=" << arg.topic_ << ", partitions=" << arg.partitions_ << "}";
+  }
+};
+
+typedef ProduceTopic<FatProducePartition> FatProduceTopic;
+typedef ProduceTopic<ThinProducePartition> ThinProduceTopic;
+
+/**
+ * PT carries partition type, which can be capturing (contains bytes) or non-capturing (contains
+ * bytes' length only)
+ */
+template <typename PT> class ProduceRequest : public Request {
+public:
+  // v0 .. v2
+  ProduceRequest(INT16 acks, INT32 timeout, NULLABLE_ARRAY<ProduceTopic<PT>> topics)
+      : ProduceRequest(absl::nullopt, acks, timeout, topics){};
+
+  // v3
+  ProduceRequest(NULLABLE_STRING transactional_id, INT16 acks, INT32 timeout,
+                 NULLABLE_ARRAY<ProduceTopic<PT>> topics)
+      : Request{RequestType::Produce},
+        transactional_id_{transactional_id}, acks_{acks}, timeout_{timeout}, topics_{topics} {};
+
+  bool operator==(const ProduceRequest<PT>& rhs) const {
+    return request_header_ == rhs.request_header_ && transactional_id_ == rhs.transactional_id_ &&
+           acks_ == rhs.acks_ && timeout_ == rhs.timeout_ && topics_ == rhs.topics_;
+  };
+
+protected:
+  size_t encodeDetails(Buffer::Instance& dst, EncodingContext& encoder) const override {
+    size_t written{0};
+    if (request_header_.api_version_ >= 3) {
+      written += encoder.encode(transactional_id_, dst);
+    }
+    written += encoder.encode(acks_, dst);
+    written += encoder.encode(timeout_, dst);
+    written += encoder.encode(topics_, dst);
+    return written;
+  }
+
+  std::ostream& printDetails(std::ostream& os) const override {
+    return os << "{transactional_id=" << transactional_id_ << ", acks=" << acks_
+              << ", timeout=" << timeout_ << ", topics=" << topics_ << "}";
+  };
+
+private:
+  const NULLABLE_STRING transactional_id_;
+  const INT16 acks_;
+  const INT32 timeout_;
+  const NULLABLE_ARRAY<ProduceTopic<PT>> topics_;
+};
+
+typedef ProduceRequest<FatProducePartition> FatProduceRequest;
+typedef ProduceRequest<ThinProducePartition> ThinProduceRequest;
+
+// clang-format off
+class ThinProducePartitionArrayBuffer : public ArrayBuffer<ThinProducePartition, CompositeBuffer<ThinProducePartition, Int32Buffer, NullableBytesIgnoringBuffer>> {};
+class ProducePartitionArrayBuffer : public ArrayBuffer<FatProducePartition, CompositeBuffer<FatProducePartition, Int32Buffer, NullableBytesCapturingBuffer>> {};
+
+class ThinProduceTopicArrayBuffer : public ArrayBuffer<ThinProduceTopic, CompositeBuffer<ThinProduceTopic, StringBuffer, ThinProducePartitionArrayBuffer>> {};
+class ProduceTopicArrayBuffer : public ArrayBuffer<FatProduceTopic, CompositeBuffer<FatProduceTopic, StringBuffer, ProducePartitionArrayBuffer>> {};
+
+class ThinProduceRequestV0Buffer : public CompositeBuffer<ThinProduceRequest, Int16Buffer, Int32Buffer, ThinProduceTopicArrayBuffer> {};
+class ThinProduceRequestV3Buffer : public CompositeBuffer<ThinProduceRequest, NullableStringBuffer, Int16Buffer, Int32Buffer, ThinProduceTopicArrayBuffer> {};
+class FatProduceRequestV0Buffer : public CompositeBuffer<FatProduceRequest, Int16Buffer, Int32Buffer, ProduceTopicArrayBuffer> {};
+class FatProduceRequestV3Buffer : public CompositeBuffer<FatProduceRequest, NullableStringBuffer, Int16Buffer, Int32Buffer, ProduceTopicArrayBuffer> {};
+
+DEFINE_REQUEST_PARSER(ThinProduceRequest, V0);
+DEFINE_REQUEST_PARSER(ThinProduceRequest, V3);
+DEFINE_REQUEST_PARSER(FatProduceRequest, V0);
+DEFINE_REQUEST_PARSER(FatProduceRequest, V3);
+// clang-format on
+
+// === FETCH (1) ===============================================================
+
+struct FetchRequestPartition {
+  const INT32 partition_;
+  const INT64 fetch_offset_;
+  const INT64 log_start_offset_; // since v5
+  const INT32 max_bytes_;
+
+  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+    size_t written{0};
+    written += encoder.encode(partition_, dst);
+    written += encoder.encode(fetch_offset_, dst);
+    if (encoder.apiVersion() >= 5) {
+      written += encoder.encode(log_start_offset_, dst);
+    }
+    written += encoder.encode(max_bytes_, dst);
+    return written;
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const FetchRequestPartition& arg) {
+    return os << "{partition=" << arg.partition_ << ", fetch_offset=" << arg.fetch_offset_
+              << ", log_start_offset=" << arg.log_start_offset_ << ", max_bytes=" << arg.max_bytes_
+              << "}";
+  }
+
+  bool operator==(const FetchRequestPartition& rhs) const {
+    return partition_ == rhs.partition_ && fetch_offset_ == rhs.fetch_offset_ &&
+           log_start_offset_ == rhs.log_start_offset_ && max_bytes_ == rhs.max_bytes_;
+  };
+
+  // v0 .. v4
+  FetchRequestPartition(INT32 partition, INT64 fetch_offset, INT32 max_bytes)
+      : FetchRequestPartition(partition, fetch_offset, -1, max_bytes){};
+
+  // v5
+  FetchRequestPartition(INT32 partition, INT64 fetch_offset, INT64 log_start_offset,
+                        INT32 max_bytes)
+      : partition_{partition}, fetch_offset_{fetch_offset}, log_start_offset_{log_start_offset},
+        max_bytes_{max_bytes} {};
+};
+
+struct FetchRequestTopic {
+  const STRING topic_;
+  const NULLABLE_ARRAY<FetchRequestPartition> partitions_;
+
+  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+    size_t written{0};
+    written += encoder.encode(topic_, dst);
+    written += encoder.encode(partitions_, dst);
+    return written;
+  }
+
+  bool operator==(const FetchRequestTopic& rhs) const {
+    return topic_ == rhs.topic_ && partitions_ == rhs.partitions_;
+  };
+
+  friend std::ostream& operator<<(std::ostream& os, const FetchRequestTopic& arg) {
+    return os << "{topic=" << arg.topic_ << ", partitions=" << arg.partitions_ << "}";
+  }
+};
+
+class FetchRequest : public Request {
+public:
+  // v0 .. v2
+  FetchRequest(INT32 replica_id, INT32 max_wait_time, INT32 min_bytes,
+               NULLABLE_ARRAY<FetchRequestTopic> topics)
+      : FetchRequest(replica_id, max_wait_time, min_bytes, -1, topics){};
+
+  // v3
+  FetchRequest(INT32 replica_id, INT32 max_wait_time, INT32 min_bytes, INT32 max_bytes,
+               NULLABLE_ARRAY<FetchRequestTopic> topics)
+      : FetchRequest(replica_id, max_wait_time, min_bytes, max_bytes, -1, topics){};
+
+  // v4 .. v5
+  FetchRequest(INT32 replica_id, INT32 max_wait_time, INT32 min_bytes, INT32 max_bytes,
+               INT8 isolation_level, NULLABLE_ARRAY<FetchRequestTopic> topics)
+      : Request{RequestType::Fetch}, replica_id_{replica_id}, max_wait_time_{max_wait_time},
+        min_bytes_{min_bytes}, max_bytes_{max_bytes},
+        isolation_level_{isolation_level}, topics_{topics} {};
+
+  bool operator==(const FetchRequest& rhs) const {
+    return request_header_ == rhs.request_header_ && replica_id_ == rhs.replica_id_ &&
+           max_wait_time_ == rhs.max_wait_time_ && min_bytes_ == rhs.min_bytes_ &&
+           max_bytes_ == rhs.max_bytes_ && isolation_level_ == rhs.isolation_level_ &&
+           topics_ == rhs.topics_;
+  };
+
+protected:
+  size_t encodeDetails(Buffer::Instance& dst, EncodingContext& encoder) const override {
+    size_t written{0};
+    INT16 api_version = request_header_.api_version_;
+    written += encoder.encode(replica_id_, dst);
+    written += encoder.encode(max_wait_time_, dst);
+    written += encoder.encode(min_bytes_, dst);
+    if (api_version >= 3) {
+      written += encoder.encode(max_bytes_, dst);
+    }
+    if (api_version >= 4) {
+      written += encoder.encode(isolation_level_, dst);
+    }
+    written += encoder.encode(topics_, dst);
+    return written;
+  }
+
+  std::ostream& printDetails(std::ostream& os) const override {
+    return os << "{replica_id=" << replica_id_ << ", max_wait_time=" << max_wait_time_
+              << ", min_bytes=" << min_bytes_ << ", max_bytes=" << max_bytes_
+              << ", isolation_level=" << static_cast<uint32_t>(isolation_level_)
+              << ", topics=" << topics_ << "}";
+  }
+
+private:
+  const INT32 replica_id_;
+  const INT32 max_wait_time_;
+  const INT32 min_bytes_;
+  const INT32 max_bytes_;      // since v3
+  const INT8 isolation_level_; // since v4
+  const NULLABLE_ARRAY<FetchRequestTopic> topics_;
+};
+
+// clang-format off
+class FetchRequestPartitionV0Buffer : public CompositeBuffer<FetchRequestPartition, Int32Buffer, Int64Buffer, Int32Buffer> {};
+class FetchRequestPartitionV0ArrayBuffer : public ArrayBuffer<FetchRequestPartition, FetchRequestPartitionV0Buffer> {};
+class FetchRequestTopicV0Buffer : public CompositeBuffer<FetchRequestTopic, StringBuffer, FetchRequestPartitionV0ArrayBuffer> {};
+class FetchRequestTopicV0ArrayBuffer : public ArrayBuffer<FetchRequestTopic, FetchRequestTopicV0Buffer> {};
+
+class FetchRequestPartitionV5Buffer : public CompositeBuffer<FetchRequestPartition, Int32Buffer, Int64Buffer, Int64Buffer, Int32Buffer> {};
+class FetchRequestPartitionV5ArrayBuffer : public ArrayBuffer<FetchRequestPartition, FetchRequestPartitionV5Buffer> {};
+class FetchRequestTopicV5Buffer : public CompositeBuffer<FetchRequestTopic, StringBuffer, FetchRequestPartitionV5ArrayBuffer> {};
+class FetchRequestTopicV5ArrayBuffer : public ArrayBuffer<FetchRequestTopic, FetchRequestTopicV5Buffer> {};
+
+class FetchRequestV0Buffer : public CompositeBuffer<FetchRequest, Int32Buffer, Int32Buffer, Int32Buffer, FetchRequestTopicV0ArrayBuffer> {};
+class FetchRequestV3Buffer : public CompositeBuffer<FetchRequest, Int32Buffer, Int32Buffer, Int32Buffer, Int32Buffer, FetchRequestTopicV0ArrayBuffer> {};
+class FetchRequestV4Buffer : public CompositeBuffer<FetchRequest, Int32Buffer, Int32Buffer, Int32Buffer, Int32Buffer, Int8Buffer, FetchRequestTopicV0ArrayBuffer> {};
+class FetchRequestV5Buffer : public CompositeBuffer<FetchRequest, Int32Buffer, Int32Buffer, Int32Buffer, Int32Buffer, Int8Buffer, FetchRequestTopicV5ArrayBuffer> {};
+
+DEFINE_REQUEST_PARSER(FetchRequest, V0);
+DEFINE_REQUEST_PARSER(FetchRequest, V3);
+DEFINE_REQUEST_PARSER(FetchRequest, V4);
+DEFINE_REQUEST_PARSER(FetchRequest, V5);
+// clang-format on
+
+// === LIST OFFSETS (2) ========================================================
+
+struct ListOffsetsPartition {
+  const INT32 partition_;
+  const INT64 timestamp_;
+  const INT32 max_num_offsets_; // only v0
+
+  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+    size_t written{0};
+    written += encoder.encode(partition_, dst);
+    written += encoder.encode(timestamp_, dst);
+    if (encoder.apiVersion() == 0) {
+      written += encoder.encode(max_num_offsets_, dst);
+    }
+    return written;
+  }
+
+  bool operator==(const ListOffsetsPartition& rhs) const {
+    return partition_ == rhs.partition_ && timestamp_ == rhs.timestamp_ &&
+           max_num_offsets_ == rhs.max_num_offsets_;
+  };
+
+  friend std::ostream& operator<<(std::ostream& os, const ListOffsetsPartition& arg) {
+    return os << "{partition=" << arg.partition_ << ", timestamp=" << arg.timestamp_
+              << ", max_num_offsets=" << arg.max_num_offsets_ << "}";
+  }
+
+  // v0
+  ListOffsetsPartition(INT32 partition, INT64 timestamp, INT32 max_num_offsets)
+      : partition_{partition}, timestamp_{timestamp}, max_num_offsets_{max_num_offsets} {};
+
+  // v1 .. v2
+  ListOffsetsPartition(INT32 partition, INT64 timestamp)
+      : ListOffsetsPartition(partition, timestamp, -1){};
+};
+
+struct ListOffsetsTopic {
+  const STRING topic_;
+  const NULLABLE_ARRAY<ListOffsetsPartition> partitions_;
+
+  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+    size_t written{0};
+    written += encoder.encode(topic_, dst);
+    written += encoder.encode(partitions_, dst);
+    return written;
+  }
+
+  bool operator==(const ListOffsetsTopic& rhs) const {
+    return topic_ == rhs.topic_ && partitions_ == rhs.partitions_;
+  };
+
+  friend std::ostream& operator<<(std::ostream& os, const ListOffsetsTopic& arg) {
+    return os << "{topic=" << arg.topic_ << ", partitions=" << arg.partitions_ << "}";
+  }
+};
+
+class ListOffsetsRequest : public Request {
+public:
+  // v0 .. v1
+  ListOffsetsRequest(INT32 replica_id, NULLABLE_ARRAY<ListOffsetsTopic> topics)
+      : ListOffsetsRequest(replica_id, -1, topics){};
+
+  // v2
+  ListOffsetsRequest(INT32 replica_id, INT8 isolation_level,
+                     NULLABLE_ARRAY<ListOffsetsTopic> topics)
+      : Request{RequestType::ListOffsets}, replica_id_{replica_id},
+        isolation_level_{isolation_level}, topics_{topics} {};
+
+  bool operator==(const ListOffsetsRequest& rhs) const {
+    return request_header_ == rhs.request_header_ && replica_id_ == rhs.replica_id_ &&
+           isolation_level_ == rhs.isolation_level_ && topics_ == rhs.topics_;
+  };
+
+protected:
+  size_t encodeDetails(Buffer::Instance& dst, EncodingContext& encoder) const override {
+    size_t written{0};
+    written += encoder.encode(replica_id_, dst);
+    if (encoder.apiVersion() >= 2) {
+      written += encoder.encode(isolation_level_, dst);
+    }
+    written += encoder.encode(topics_, dst);
+    return written;
+  }
+
+  std::ostream& printDetails(std::ostream& os) const override {
+    return os << "{replica_id=" << replica_id_
+              << ", isolation_level=" << static_cast<uint32_t>(isolation_level_)
+              << ", topics=" << topics_ << "}";
+  }
+
+private:
+  const INT32 replica_id_;
+  const INT8 isolation_level_; // since v2
+  const NULLABLE_ARRAY<ListOffsetsTopic> topics_;
+};
+
+// clang-format off
+class ListOffsetsPartitionV0Buffer : public CompositeBuffer<ListOffsetsPartition, Int32Buffer, Int64Buffer, Int32Buffer> {};
+class ListOffsetsPartitionV0ArrayBuffer : public ArrayBuffer<ListOffsetsPartition, ListOffsetsPartitionV0Buffer> {};
+class ListOffsetsTopicV0Buffer : public CompositeBuffer<ListOffsetsTopic, StringBuffer, ListOffsetsPartitionV0ArrayBuffer> {};
+class ListOffsetsTopicV0ArrayBuffer : public ArrayBuffer<ListOffsetsTopic, ListOffsetsTopicV0Buffer> {};
+
+class ListOffsetsPartitionV1Buffer : public CompositeBuffer<ListOffsetsPartition, Int32Buffer, Int64Buffer> {};
+class ListOffsetsPartitionV1ArrayBuffer : public ArrayBuffer<ListOffsetsPartition, ListOffsetsPartitionV1Buffer> {};
+class ListOffsetsTopicV1Buffer : public CompositeBuffer<ListOffsetsTopic, StringBuffer, ListOffsetsPartitionV1ArrayBuffer> {};
+class ListOffsetsTopicV1ArrayBuffer : public ArrayBuffer<ListOffsetsTopic, ListOffsetsTopicV1Buffer> {};
+
+class ListOffsetsRequestV0Buffer : public CompositeBuffer<ListOffsetsRequest, Int32Buffer, ListOffsetsTopicV0ArrayBuffer> {};
+class ListOffsetsRequestV1Buffer : public CompositeBuffer<ListOffsetsRequest, Int32Buffer, ListOffsetsTopicV1ArrayBuffer> {};
+class ListOffsetsRequestV2Buffer : public CompositeBuffer<ListOffsetsRequest, Int32Buffer, Int8Buffer, ListOffsetsTopicV1ArrayBuffer> {};
+
+DEFINE_REQUEST_PARSER(ListOffsetsRequest, V0);
+DEFINE_REQUEST_PARSER(ListOffsetsRequest, V1);
+DEFINE_REQUEST_PARSER(ListOffsetsRequest, V2);
+// clang-format on
+
+// === METADATA (3) ============================================================
+
+class MetadataRequest : public Request {
+public:
+  // v0 .. v3
+  MetadataRequest(NULLABLE_ARRAY<STRING> topics) : MetadataRequest(topics, false){};
+
+  // v4
+  MetadataRequest(NULLABLE_ARRAY<STRING> topics, BOOLEAN allow_auto_topic_creation)
+      : Request{RequestType::Metadata}, topics_{topics}, allow_auto_topic_creation_{
+                                                             allow_auto_topic_creation} {};
+
+  bool operator==(const MetadataRequest& rhs) const {
+    return request_header_ == rhs.request_header_ && topics_ == rhs.topics_ &&
+           allow_auto_topic_creation_ == rhs.allow_auto_topic_creation_;
+  };
+
+protected:
+  size_t encodeDetails(Buffer::Instance& dst, EncodingContext& encoder) const override {
+    size_t written{0};
+    written += encoder.encode(topics_, dst);
+    if (encoder.apiVersion() >= 2) {
+      written += encoder.encode(allow_auto_topic_creation_, dst);
+    }
+    return written;
+  }
+
+  std::ostream& printDetails(std::ostream& os) const override {
+    return os << "{topics=" << topics_
+              << ", allow_auto_topic_creation=" << allow_auto_topic_creation_ << "}";
+  }
+
+private:
+  NULLABLE_ARRAY<STRING> topics_;
+  BOOLEAN allow_auto_topic_creation_; // since v4
+};
+
+// clang-format off
+class MetadataRequestTopicV0Buffer : public ArrayBuffer<STRING, StringBuffer> {};
+class MetadataRequestV0Buffer : public CompositeBuffer<MetadataRequest, MetadataRequestTopicV0Buffer> {};
+class MetadataRequestV4Buffer : public CompositeBuffer<MetadataRequest, MetadataRequestTopicV0Buffer, BoolBuffer> {};
+
+DEFINE_REQUEST_PARSER(MetadataRequest, V0);
+DEFINE_REQUEST_PARSER(MetadataRequest, V4);
+// clang-format on
+
+// === LEADER-AND-ISR (4) ======================================================
+
+/**
+ * This structure is used in both LeaderAndIsr v0 & UpdateMetadata
+ */
+
+struct MetadataPartitionState {
+  const STRING topic_;
+  const INT32 partition_;
+  const INT32 controller_epoch_;
+  const INT32 leader_;
+  const INT32 leader_epoch_;
+  const NULLABLE_ARRAY<INT32> isr_;
+  const INT32 zk_version_;
+  const NULLABLE_ARRAY<INT32> replicas_;
+
+  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+    size_t written{0};
+    written += encoder.encode(topic_, dst);
+    written += encoder.encode(partition_, dst);
+    written += encoder.encode(controller_epoch_, dst);
+    written += encoder.encode(leader_, dst);
+    written += encoder.encode(leader_epoch_, dst);
+    written += encoder.encode(isr_, dst);
+    written += encoder.encode(zk_version_, dst);
+    written += encoder.encode(replicas_, dst);
+    return written;
+  }
+
+  bool operator==(const MetadataPartitionState& rhs) const {
+    return topic_ == rhs.topic_ && partition_ == rhs.partition_ &&
+           controller_epoch_ == rhs.controller_epoch_ && leader_ == rhs.leader_ &&
+           leader_epoch_ == rhs.leader_epoch_ && isr_ == rhs.isr_ &&
+           zk_version_ == rhs.zk_version_ && replicas_ == rhs.replicas_;
+  };
+
+  friend std::ostream& operator<<(std::ostream& os, const MetadataPartitionState& arg) {
+    return os << "{topic=" << arg.topic_ << ", partition=" << arg.partition_
+              << ", controller_epoch=" << arg.controller_epoch_ << ", leader=" << arg.leader_
+              << ", leader_epoch=" << arg.leader_epoch_ << ", isr=" << arg.isr_
+              << ", zk_version=" << arg.zk_version_ << ", zk_version=" << arg.zk_version_ << "}";
+  }
+};
+
+struct LeaderAndIsrLiveLeader {
+  const INT32 id_;
+  const STRING host_;
+  const INT32 port_;
+
+  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+    size_t written{0};
+    written += encoder.encode(id_, dst);
+    written += encoder.encode(host_, dst);
+    written += encoder.encode(port_, dst);
+    return written;
+  }
+
+  bool operator==(const LeaderAndIsrLiveLeader& rhs) const {
+    return id_ == rhs.id_ && host_ == rhs.host_ && port_ == rhs.port_;
+  };
+
+  friend std::ostream& operator<<(std::ostream& os, const LeaderAndIsrLiveLeader& arg) {
+    return os << "{id=" << arg.id_ << ", host=" << arg.host_ << ", port=" << arg.port_ << "}";
+  }
+};
+
+class LeaderAndIsrRequest : public Request {
+public:
+  // v0
+  LeaderAndIsrRequest(INT32 controller_id, INT32 controller_epoch,
+                      NULLABLE_ARRAY<MetadataPartitionState> partition_states,
+                      NULLABLE_ARRAY<LeaderAndIsrLiveLeader> live_readers)
+      : Request{RequestType::LeaderAndIsr}, controller_id_{controller_id},
+        controller_epoch_{controller_epoch}, partition_states_{partition_states},
+        live_readers_{live_readers} {};
+
+  bool operator==(const LeaderAndIsrRequest& rhs) const {
+    return request_header_ == rhs.request_header_ && controller_id_ == rhs.controller_id_ &&
+           controller_epoch_ == rhs.controller_epoch_ &&
+           partition_states_ == rhs.partition_states_ && live_readers_ == rhs.live_readers_;
+  };
+
+protected:
+  size_t encodeDetails(Buffer::Instance& dst, EncodingContext& encoder) const override {
+    size_t written{0};
+    written += encoder.encode(controller_id_, dst);
+    written += encoder.encode(controller_epoch_, dst);
+    written += encoder.encode(partition_states_, dst);
+    written += encoder.encode(live_readers_, dst);
+    return written;
+  }
+
+  std::ostream& printDetails(std::ostream& os) const override {
+    return os << "{controller_id=" << controller_id_ << ", controller_epoch=" << controller_epoch_
+              << ", partition_states=" << partition_states_ << ", live_readers=" << live_readers_
+              << "}";
+  }
+
+private:
+  const INT32 controller_id_;
+  const INT32 controller_epoch_;
+  const NULLABLE_ARRAY<MetadataPartitionState> partition_states_;
+  const NULLABLE_ARRAY<LeaderAndIsrLiveLeader> live_readers_;
+};
+
+// clang-format off
+class MetadataPartitionStateV0Buffer : public CompositeBuffer<MetadataPartitionState,
+                                                              StringBuffer,
+                                                              Int32Buffer,
+                                                              Int32Buffer,
+                                                              Int32Buffer,
+                                                              Int32Buffer,
+                                                              ArrayBuffer<INT32, Int32Buffer>,
+                                                              Int32Buffer,
+                                                              ArrayBuffer<INT32, Int32Buffer>
+                                                              > {};
+class MetadataPartitionStateV0ArrayBuffer : public ArrayBuffer<MetadataPartitionState, MetadataPartitionStateV0Buffer> {};
+
+class LeaderAndIsrLiveLeaderV0Buffer : public CompositeBuffer<LeaderAndIsrLiveLeader, Int32Buffer, StringBuffer, Int32Buffer> {};
+class LeaderAndIsrLiveLeaderV0ArrayBuffer : public ArrayBuffer<LeaderAndIsrLiveLeader, LeaderAndIsrLiveLeaderV0Buffer> {};
+
+class LeaderAndIsrRequestV0Buffer : public CompositeBuffer<LeaderAndIsrRequest, Int32Buffer, Int32Buffer, MetadataPartitionStateV0ArrayBuffer, LeaderAndIsrLiveLeaderV0ArrayBuffer> {};
+
+DEFINE_REQUEST_PARSER(LeaderAndIsrRequest, V0);
+// clang-format on
+
+// === STOP REPLICA (5) ========================================================
+
+struct StopReplicaPartition {
+  const STRING topic_;
+  const INT32 partition_;
+
+  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+    size_t written{0};
+    written += encoder.encode(topic_, dst);
+    written += encoder.encode(partition_, dst);
+    return written;
+  }
+
+  bool operator==(const StopReplicaPartition& rhs) const {
+    return topic_ == rhs.topic_ && partition_ == rhs.partition_;
+  };
+
+  friend std::ostream& operator<<(std::ostream& os, const StopReplicaPartition& arg) {
+    return os << "{topic=" << arg.topic_ << ", partition=" << arg.partition_ << "}";
+  }
+};
+
+class StopReplicaRequest : public Request {
+public:
+  // v0
+  StopReplicaRequest(INT32 controller_id, INT32 controller_epoch, BOOLEAN delete_partitions,
+                     NULLABLE_ARRAY<StopReplicaPartition> partitions)
+      : Request{RequestType::StopReplica}, controller_id_{controller_id},
+        controller_epoch_{controller_epoch}, delete_partitions_{delete_partitions},
+        partitions_{partitions} {};
+
+  bool operator==(const StopReplicaRequest& rhs) const {
+    return request_header_ == rhs.request_header_ && controller_id_ == rhs.controller_id_ &&
+           controller_epoch_ == rhs.controller_epoch_ &&
+           delete_partitions_ == rhs.delete_partitions_ && partitions_ == rhs.partitions_;
+  };
+
+protected:
+  size_t encodeDetails(Buffer::Instance& dst, EncodingContext& encoder) const override {
+    size_t written{0};
+    written += encoder.encode(controller_id_, dst);
+    written += encoder.encode(controller_epoch_, dst);
+    written += encoder.encode(delete_partitions_, dst);
+    written += encoder.encode(partitions_, dst);
+    return written;
+  }
+
+  std::ostream& printDetails(std::ostream& os) const override {
+    return os << "{controller_id=" << controller_id_ << ", controller_epoch=" << controller_epoch_
+              << ", delete_partitions=" << delete_partitions_ << ", partitions=" << partitions_
+              << "}";
+  }
+
+private:
+  const INT32 controller_id_;
+  const INT32 controller_epoch_;
+  const BOOLEAN delete_partitions_;
+  const NULLABLE_ARRAY<StopReplicaPartition> partitions_;
+};
+
+// clang-format off
+class StopReplicaPartitionV0Buffer : public CompositeBuffer<StopReplicaPartition, StringBuffer, Int32Buffer> {};
+class StopReplicaPartitionV0ArrayBuffer : public ArrayBuffer<StopReplicaPartition, StopReplicaPartitionV0Buffer> {};
+
+class StopReplicaRequestV0Buffer : public CompositeBuffer<StopReplicaRequest, Int32Buffer, Int32Buffer, BoolBuffer, StopReplicaPartitionV0ArrayBuffer> {};
+
+DEFINE_REQUEST_PARSER(StopReplicaRequest, V0);
+// clang-format on
+
+// === UPDATE METADATA (6) =====================================================
+
+// uses MetadataPartitionState from LeaderAndIsr
+
+struct UpdateMetadataLiveBrokerEndpoint {
+  const INT32 port_;
+  const STRING host_;
+  const STRING listener_name_;
+  const INT16 security_protocol_type_;
+
+  // v1 .. v2
+  UpdateMetadataLiveBrokerEndpoint(INT32 port, STRING host, INT16 security_protocol_type)
+      : UpdateMetadataLiveBrokerEndpoint{port, host, "", security_protocol_type} {};
+
+  // v3
+  UpdateMetadataLiveBrokerEndpoint(INT32 port, STRING host, STRING listener_name,
+                                   INT16 security_protocol_type)
+      : port_{port}, host_{host}, listener_name_{listener_name}, security_protocol_type_{
+                                                                     security_protocol_type} {};
+
+  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+    size_t written{0};
+    written += encoder.encode(port_, dst);
+    written += encoder.encode(host_, dst);
+    if (encoder.apiVersion() >= 3) {
+      written += encoder.encode(listener_name_, dst);
+    }
+    written += encoder.encode(security_protocol_type_, dst);
+    return written;
+  }
+
+  bool operator==(const UpdateMetadataLiveBrokerEndpoint& rhs) const {
+    return port_ == rhs.port_ && host_ == rhs.host_ && listener_name_ == rhs.listener_name_ &&
+           security_protocol_type_ == rhs.security_protocol_type_;
+  };
+
+  friend std::ostream& operator<<(std::ostream& os, const UpdateMetadataLiveBrokerEndpoint& arg) {
+    return os << "{port=" << arg.port_ << ", host=" << arg.host_
+              << ", listener_name=" << arg.listener_name_
+              << ", security_protocol_type=" << arg.security_protocol_type_ << "}";
+  }
+};
+
+struct UpdateMetadataLiveBroker {
+  const INT32 id_;
+  const NULLABLE_ARRAY<UpdateMetadataLiveBrokerEndpoint> endpoints_;
+  const NULLABLE_STRING rack_; // since v2
+
+  // v0
+  // instead of having dedicated fields, store data as single UpdateMetadataLiveBrokerEndpoint (java
+  // client does it as well)
+  UpdateMetadataLiveBroker(INT32 id, STRING host, INT32 port)
+      : UpdateMetadataLiveBroker(id, {{UpdateMetadataLiveBrokerEndpoint{port, host, 0}}}){};
+
+  // v1
+  UpdateMetadataLiveBroker(INT32 id, NULLABLE_ARRAY<UpdateMetadataLiveBrokerEndpoint> endpoints)
+      : UpdateMetadataLiveBroker{id, endpoints, absl::nullopt} {};
+
+  // v2
+  UpdateMetadataLiveBroker(INT32 id, NULLABLE_ARRAY<UpdateMetadataLiveBrokerEndpoint> endpoints,
+                           NULLABLE_STRING rack)
+      : id_{id}, endpoints_{endpoints}, rack_{rack} {};
+
+  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+    size_t written{0};
+    written += encoder.encode(id_, dst);
+    if (encoder.apiVersion() == 0) {
+      // we stored host+port as endpoint, but need to serialize properly
+      const UpdateMetadataLiveBrokerEndpoint& only_endpoint = (*endpoints_)[0];
+      written += encoder.encode(only_endpoint.host_, dst);
+      written += encoder.encode(only_endpoint.port_, dst);
+    } else {
+      written += encoder.encode(endpoints_, dst);
+      if (encoder.apiVersion() >= 2) {
+        written += encoder.encode(rack_, dst);
+      }
+    }
+    return written;
+  }
+
+  bool operator==(const UpdateMetadataLiveBroker& rhs) const {
+    return id_ == rhs.id_ && endpoints_ == rhs.endpoints_ && rack_ == rhs.rack_;
+  };
+
+  friend std::ostream& operator<<(std::ostream& os, const UpdateMetadataLiveBroker& arg) {
+    return os << "{id=" << arg.id_ << ", endpoints=" << arg.endpoints_ << ", rack=" << arg.rack_
+              << "}";
+  }
+};
+
+class UpdateMetadataRequest : public Request {
+public:
+  // v0
+  UpdateMetadataRequest(INT32 controller_id, INT32 controller_epoch,
+                        NULLABLE_ARRAY<MetadataPartitionState> partition_states,
+                        NULLABLE_ARRAY<UpdateMetadataLiveBroker> live_brokers)
+      : Request{RequestType::UpdateMetadata}, controller_id_{controller_id},
+        controller_epoch_{controller_epoch}, partition_states_{partition_states},
+        live_brokers_{live_brokers} {};
+
+  bool operator==(const UpdateMetadataRequest& rhs) const {
+    return request_header_ == rhs.request_header_ && controller_id_ == rhs.controller_id_ &&
+           controller_epoch_ == rhs.controller_epoch_ &&
+           partition_states_ == rhs.partition_states_ && live_brokers_ == rhs.live_brokers_;
+  };
+
+protected:
+  size_t encodeDetails(Buffer::Instance& dst, EncodingContext& encoder) const override {
+    size_t written{0};
+    written += encoder.encode(controller_id_, dst);
+    written += encoder.encode(controller_epoch_, dst);
+    written += encoder.encode(partition_states_, dst);
+    written += encoder.encode(live_brokers_, dst);
+    return written;
+  }
+
+  std::ostream& printDetails(std::ostream& os) const override {
+    return os << "{controller_id=" << controller_id_ << ", controller_epoch=" << controller_epoch_
+              << ", partition_states=" << partition_states_ << ", live_brokers=" << live_brokers_
+              << "}";
+  }
+
+private:
+  const INT32 controller_id_;
+  const INT32 controller_epoch_;
+  const NULLABLE_ARRAY<MetadataPartitionState> partition_states_;
+  const NULLABLE_ARRAY<UpdateMetadataLiveBroker> live_brokers_;
+};
+
+// clang-format off
+class UpdateMetadataLiveBrokerEndpointV1Buffer : public CompositeBuffer<UpdateMetadataLiveBrokerEndpoint, Int32Buffer, StringBuffer, Int16Buffer> {};
+class UpdateMetadataLiveBrokerEndpointV1ArrayBuffer : public ArrayBuffer<UpdateMetadataLiveBrokerEndpoint, UpdateMetadataLiveBrokerEndpointV1Buffer> {};
+class UpdateMetadataLiveBrokerEndpointV3Buffer : public CompositeBuffer<UpdateMetadataLiveBrokerEndpoint, Int32Buffer, StringBuffer, StringBuffer, Int16Buffer> {};
+class UpdateMetadataLiveBrokerEndpointV3ArrayBuffer : public ArrayBuffer<UpdateMetadataLiveBrokerEndpoint, UpdateMetadataLiveBrokerEndpointV3Buffer> {};
+
+class UpdateMetadataLiveBrokerV0Buffer : public CompositeBuffer<UpdateMetadataLiveBroker, Int32Buffer, StringBuffer, Int32Buffer> {};
+class UpdateMetadataLiveBrokerV0ArrayBuffer : public ArrayBuffer<UpdateMetadataLiveBroker, UpdateMetadataLiveBrokerV0Buffer> {};
+class UpdateMetadataLiveBrokerV1Buffer : public CompositeBuffer<UpdateMetadataLiveBroker, Int32Buffer, UpdateMetadataLiveBrokerEndpointV1ArrayBuffer> {};
+class UpdateMetadataLiveBrokerV1ArrayBuffer : public ArrayBuffer<UpdateMetadataLiveBroker, UpdateMetadataLiveBrokerV1Buffer> {};
+class UpdateMetadataLiveBrokerV2Buffer : public CompositeBuffer<UpdateMetadataLiveBroker, Int32Buffer, UpdateMetadataLiveBrokerEndpointV1ArrayBuffer, NullableStringBuffer> {};
+class UpdateMetadataLiveBrokerV2ArrayBuffer : public ArrayBuffer<UpdateMetadataLiveBroker, UpdateMetadataLiveBrokerV2Buffer> {};
+class UpdateMetadataLiveBrokerV3Buffer : public CompositeBuffer<UpdateMetadataLiveBroker, Int32Buffer, UpdateMetadataLiveBrokerEndpointV3ArrayBuffer, NullableStringBuffer> {};
+class UpdateMetadataLiveBrokerV3ArrayBuffer : public ArrayBuffer<UpdateMetadataLiveBroker, UpdateMetadataLiveBrokerV3Buffer> {};
+
+class UpdateMetadataRequestV0Buffer : public CompositeBuffer<UpdateMetadataRequest, Int32Buffer, Int32Buffer, MetadataPartitionStateV0ArrayBuffer, UpdateMetadataLiveBrokerV0ArrayBuffer> {};
+class UpdateMetadataRequestV1Buffer : public CompositeBuffer<UpdateMetadataRequest, Int32Buffer, Int32Buffer, MetadataPartitionStateV0ArrayBuffer, UpdateMetadataLiveBrokerV1ArrayBuffer> {};
+class UpdateMetadataRequestV2Buffer : public CompositeBuffer<UpdateMetadataRequest, Int32Buffer, Int32Buffer, MetadataPartitionStateV0ArrayBuffer, UpdateMetadataLiveBrokerV2ArrayBuffer> {};
+class UpdateMetadataRequestV3Buffer : public CompositeBuffer<UpdateMetadataRequest, Int32Buffer, Int32Buffer, MetadataPartitionStateV0ArrayBuffer, UpdateMetadataLiveBrokerV3ArrayBuffer> {};
+
+DEFINE_REQUEST_PARSER(UpdateMetadataRequest, V0);
+DEFINE_REQUEST_PARSER(UpdateMetadataRequest, V1);
+DEFINE_REQUEST_PARSER(UpdateMetadataRequest, V2);
+DEFINE_REQUEST_PARSER(UpdateMetadataRequest, V3);
+// clang-format on
+
+// === CONTROLLED SHUTDOWN (7) =================================================
+
+// v0 is not documented
+class ControlledShutdownRequest : public Request {
+public:
+  // v1
+  ControlledShutdownRequest(INT32 broker_id)
+      : Request{RequestType::ControlledShutdown}, broker_id_{broker_id} {};
+
+  bool operator==(const ControlledShutdownRequest& rhs) const {
+    return request_header_ == rhs.request_header_ && broker_id_ == rhs.broker_id_;
+  };
+
+protected:
+  size_t encodeDetails(Buffer::Instance& dst, EncodingContext& encoder) const override {
+    size_t written{0};
+    written += encoder.encode(broker_id_, dst);
+    return written;
+  }
+
+  std::ostream& printDetails(std::ostream& os) const override {
+    return os << "{broker_id=" << broker_id_ << "}";
+  }
+
+private:
+  const INT32 broker_id_;
+};
+
+// clang-format off
+class ControlledShutdownRequestV1Buffer : public CompositeBuffer<ControlledShutdownRequest, Int32Buffer> {};
+
+DEFINE_REQUEST_PARSER(ControlledShutdownRequest, V1);
+// clang-format on
+
+// === OFFSET COMMIT (8) =======================================================
+
+struct OffsetCommitPartition {
+  const INT32 partition_;
+  const INT64 offset_;
+  const INT64 timestamp_; // only v1
+  const NULLABLE_STRING metadata_;
+
+  // v0 *and* v2
+  OffsetCommitPartition(INT32 partition, INT64 offset, NULLABLE_STRING metadata)
+      : partition_{partition}, offset_{offset}, timestamp_{-1}, metadata_{metadata} {};
+
+  // v1
+  OffsetCommitPartition(INT32 partition, INT64 offset, INT64 timestamp, NULLABLE_STRING metadata)
+      : partition_{partition}, offset_{offset}, timestamp_{timestamp}, metadata_{metadata} {};
+
+  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+    size_t written{0};
+    written += encoder.encode(partition_, dst);
+    written += encoder.encode(offset_, dst);
+    if (encoder.apiVersion() == 1) {
+      written += encoder.encode(timestamp_, dst);
+    }
+    written += encoder.encode(metadata_, dst);
+    return written;
+  }
+
+  bool operator==(const OffsetCommitPartition& rhs) const {
+    return partition_ == rhs.partition_ && offset_ == rhs.offset_ && timestamp_ == rhs.timestamp_ &&
+           metadata_ == rhs.metadata_;
+  };
+
+  friend std::ostream& operator<<(std::ostream& os, const OffsetCommitPartition& arg) {
+    return os << "{partition=" << arg.partition_ << ", offset=" << arg.offset_
+              << ", timestamp=" << arg.timestamp_ << ", metadata=" << arg.metadata_ << "}";
+  }
+};
+
+struct OffsetCommitTopic {
+  const STRING topic_;
+  const NULLABLE_ARRAY<OffsetCommitPartition> partitions_;
+
+  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+    size_t written{0};
+    written += encoder.encode(topic_, dst);
+    written += encoder.encode(partitions_, dst);
+    return written;
+  }
+
+  bool operator==(const OffsetCommitTopic& rhs) const {
+    return topic_ == rhs.topic_ && partitions_ == rhs.partitions_;
+  };
+
+  friend std::ostream& operator<<(std::ostream& os, const OffsetCommitTopic& arg) {
+    return os << "{topic=" << arg.topic_ << ", partitions_=" << arg.partitions_ << "}";
+  }
+};
+
+class OffsetCommitRequest : public Request {
+public:
+  // v0
+  OffsetCommitRequest(STRING group_id, NULLABLE_ARRAY<OffsetCommitTopic> topics)
+      : OffsetCommitRequest(group_id, -1, "", -1, topics){};
+
+  // v1
+  OffsetCommitRequest(STRING group_id, INT32 group_generation_id, STRING member_id,
+                      NULLABLE_ARRAY<OffsetCommitTopic> topics)
+      : OffsetCommitRequest(group_id, group_generation_id, member_id, -1, topics){};
+
+  // v2 .. v3
+  OffsetCommitRequest(STRING group_id, INT32 group_generation_id, STRING member_id,
+                      INT64 retention_time, NULLABLE_ARRAY<OffsetCommitTopic> topics)
+      : Request{RequestType::OffsetCommit}, group_id_{group_id},
+        group_generation_id_{group_generation_id}, member_id_{member_id},
+        retention_time_{retention_time}, topics_{topics} {};
+
+  bool operator==(const OffsetCommitRequest& rhs) const {
+    return request_header_ == rhs.request_header_ && group_id_ == rhs.group_id_ &&
+           group_generation_id_ == rhs.group_generation_id_ && member_id_ == rhs.member_id_ &&
+           retention_time_ == rhs.retention_time_ && topics_ == rhs.topics_;
+  };
+
+protected:
+  size_t encodeDetails(Buffer::Instance& dst, EncodingContext& encoder) const override {
+    size_t written{0};
+    written += encoder.encode(group_id_, dst);
+    if (encoder.apiVersion() >= 1) {
+      written += encoder.encode(group_generation_id_, dst);
+      written += encoder.encode(member_id_, dst);
+    }
+    if (encoder.apiVersion() >= 2) {
+      written += encoder.encode(retention_time_, dst);
+    }
+    written += encoder.encode(topics_, dst);
+    return written;
+  }
+
+  std::ostream& printDetails(std::ostream& os) const override {
+    return os << "{group_id=" << group_id_ << ", group_generation_id=" << group_generation_id_
+              << ", member_id=" << member_id_ << ", retention_time=" << retention_time_
+              << ", topics=" << topics_ << "}";
+  }
+
+private:
+  const STRING group_id_;
+  const INT32 group_generation_id_; // since v1
+  const STRING member_id_;          // since v1
+  const INT64 retention_time_;      // since v2
+  const NULLABLE_ARRAY<OffsetCommitTopic> topics_;
+};
+
+// clang-format off
+class OffsetCommitPartitionV0Buffer : public CompositeBuffer<OffsetCommitPartition, Int32Buffer, Int64Buffer, NullableStringBuffer> {};
+class OffsetCommitPartitionV0ArrayBuffer : public ArrayBuffer<OffsetCommitPartition, OffsetCommitPartitionV0Buffer> {};
+class OffsetCommitTopicV0Buffer : public CompositeBuffer<OffsetCommitTopic, StringBuffer, OffsetCommitPartitionV0ArrayBuffer> {};
+class OffsetCommitTopicV0ArrayBuffer : public ArrayBuffer<OffsetCommitTopic, OffsetCommitTopicV0Buffer> {};
+
+class OffsetCommitPartitionV1Buffer : public CompositeBuffer<OffsetCommitPartition, Int32Buffer, Int64Buffer, Int64Buffer, NullableStringBuffer> {};
+class OffsetCommitPartitionV1ArrayBuffer : public ArrayBuffer<OffsetCommitPartition, OffsetCommitPartitionV1Buffer> {};
+class OffsetCommitTopicV1Buffer : public CompositeBuffer<OffsetCommitTopic, StringBuffer, OffsetCommitPartitionV1ArrayBuffer> {};
+class OffsetCommitTopicV1ArrayBuffer : public ArrayBuffer<OffsetCommitTopic, OffsetCommitTopicV1Buffer> {};
+
+class OffsetCommitTopicV2ArrayBuffer : public OffsetCommitTopicV0ArrayBuffer {}; // v2 partition format is the same as v0
+
+class OffsetCommitRequestV0Buffer : public CompositeBuffer<OffsetCommitRequest, StringBuffer, OffsetCommitTopicV0ArrayBuffer> {};
+class OffsetCommitRequestV1Buffer : public CompositeBuffer<OffsetCommitRequest, StringBuffer, Int32Buffer, StringBuffer, OffsetCommitTopicV1ArrayBuffer> {};
+class OffsetCommitRequestV2Buffer : public CompositeBuffer<OffsetCommitRequest, StringBuffer, Int32Buffer, StringBuffer, Int64Buffer, OffsetCommitTopicV2ArrayBuffer> {};
+
+DEFINE_REQUEST_PARSER(OffsetCommitRequest, V0);
+DEFINE_REQUEST_PARSER(OffsetCommitRequest, V1);
+DEFINE_REQUEST_PARSER(OffsetCommitRequest, V2);
+// clang-format on
+
+// === OFFSET FETCH (9) ========================================================
+
+struct OffsetFetchTopic {
+  const STRING topic_;
+  const NULLABLE_ARRAY<INT32> partitions_;
+
+  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+    size_t written{0};
+    written += encoder.encode(topic_, dst);
+    written += encoder.encode(partitions_, dst);
+    return written;
+  }
+
+  bool operator==(const OffsetFetchTopic& rhs) const {
+    return topic_ == rhs.topic_ && partitions_ == rhs.partitions_;
+  };
+
+  friend std::ostream& operator<<(std::ostream& os, const OffsetFetchTopic& arg) {
+    return os << "{topic=" << arg.topic_ << ", partitions=" << arg.partitions_ << "}";
+  }
+};
+
+class OffsetFetchRequest : public Request {
+public:
+  // v0 .. v3
+  OffsetFetchRequest(STRING group_id, NULLABLE_ARRAY<OffsetFetchTopic> topics)
+      : Request{RequestType::OffsetFetch}, group_id_{group_id}, topics_{topics} {};
+
+  bool operator==(const OffsetFetchRequest& rhs) const {
+    return request_header_ == rhs.request_header_ && group_id_ == rhs.group_id_ &&
+           topics_ == rhs.topics_;
+  };
+
+protected:
+  size_t encodeDetails(Buffer::Instance& dst, EncodingContext& encoder) const override {
+    size_t written{0};
+    written += encoder.encode(group_id_, dst);
+    written += encoder.encode(topics_, dst);
+    return written;
+  }
+
+  std::ostream& printDetails(std::ostream& os) const override {
+    return os << "{group_id=" << group_id_ << ", topics=" << topics_ << "}";
+  }
+
+private:
+  const STRING group_id_;
+  const NULLABLE_ARRAY<OffsetFetchTopic> topics_;
+};
+
+// clang-format off
+class OffsetFetchPartitionV0ArrayBuffer : public ArrayBuffer<INT32, Int32Buffer> {};
+class OffsetFetchTopicV0Buffer : public CompositeBuffer<OffsetFetchTopic, StringBuffer, OffsetFetchPartitionV0ArrayBuffer> {};
+class OffsetFetchTopicV0ArrayBuffer : public ArrayBuffer<OffsetFetchTopic, OffsetFetchTopicV0Buffer> {};
+
+class OffsetFetchRequestV0Buffer : public CompositeBuffer<OffsetFetchRequest, StringBuffer, OffsetFetchTopicV0ArrayBuffer> {};
+
+DEFINE_REQUEST_PARSER(OffsetFetchRequest, V0);
+// clang-format on
+
+// === API VERSIONS (18) =======================================================
+
+class ApiVersionsRequest : public Request {
+public:
+  // v0 .. v1
+  ApiVersionsRequest() : Request{RequestType::ApiVersions} {};
+
+  bool operator==(const ApiVersionsRequest& rhs) const {
+    return request_header_ == rhs.request_header_;
+  };
+
+protected:
+  size_t encodeDetails(Buffer::Instance&, EncodingContext&) const override { return 0; }
+
+  std::ostream& printDetails(std::ostream& os) const override { return os << "{}"; }
+};
+
+// clang-format off
+class ApiVersionsRequestV0Buffer : public NullBuffer<ApiVersionsRequest> {};
+
+DEFINE_REQUEST_PARSER(ApiVersionsRequest, V0);
+// clang-format on
+
+// === UNKNOWN REQUEST =========================================================
+
+class UnknownRequest : public Request {
+public:
+  UnknownRequest(const RequestHeader& request_header) : Request{request_header} {};
+
+protected:
+  // this isn't the prettiest, as we have thrown away the data
+  // XXX(adam.kotwasinski) discuss capturing the data as-is, and simply putting it back
+  //   this would add ability to forward unknown types of requests in cluster-proxy
+  size_t encodeDetails(Buffer::Instance&, EncodingContext&) const override {
+    throw EnvoyException("cannot serialize unknown request");
+  }
+
+  std::ostream& printDetails(std::ostream& out) const override {
+    return out << "{unknown request}";
+  }
+};
+
+// ignores data until the end of request (contained in context_)
+class SentinelConsumer : public Parser {
+public:
+  SentinelConsumer(RequestContextSharedPtr context) : context_{context} {};
+  ParseResponse parse(const char*& buffer, uint64_t& remaining) override;
+
+  const RequestContextSharedPtr contextForTest() const { return context_; }
+
+private:
+  const RequestContextSharedPtr context_;
+};
+
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/kafka/kafka_types.h
+++ b/source/extensions/filters/network/kafka/kafka_types.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "absl/types/optional.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+
+typedef int8_t INT8;
+typedef int16_t INT16;
+typedef int32_t INT32;
+typedef int64_t INT64;
+typedef uint32_t UINT32;
+typedef bool BOOLEAN;
+
+typedef std::string STRING;
+typedef absl::optional<STRING> NULLABLE_STRING;
+
+typedef std::vector<unsigned char> BYTES;
+typedef absl::optional<BYTES> NULLABLE_BYTES;
+
+template <typename T> using NULLABLE_ARRAY = absl::optional<std::vector<T>>;
+
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/kafka/message.h
+++ b/source/extensions/filters/network/kafka/message.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <sstream>
+
+#include "envoy/common/pure.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+
+/**
+ * Abstract message
+ */
+class Message {
+public:
+  virtual ~Message() = default;
+
+  friend std::ostream& operator<<(std::ostream& out, const Message& arg) { return arg.print(out); }
+
+protected:
+  virtual std::ostream& print(std::ostream& os) const PURE;
+};
+
+typedef std::shared_ptr<Message> MessageSharedPtr;
+
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/kafka/parser.h
+++ b/source/extensions/filters/network/kafka/parser.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <sstream>
+
+#include "common/common/logger.h"
+
+#include "extensions/filters/network/kafka/kafka_types.h"
+#include "extensions/filters/network/kafka/message.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+
+// === PARSER ==================================================================
+
+class ParseResponse;
+
+class Parser : public Logger::Loggable<Logger::Id::kafka> {
+public:
+  virtual ~Parser() = default;
+
+  virtual ParseResponse parse(const char*& buffer, uint64_t& remaining) PURE;
+};
+
+typedef std::shared_ptr<Parser> ParserSharedPtr;
+
+class ParseResponse {
+public:
+  static ParseResponse stillWaiting() { return {nullptr, nullptr}; }
+  static ParseResponse nextParser(ParserSharedPtr next_parser) { return {next_parser, nullptr}; };
+  static ParseResponse parsedMessage(MessageSharedPtr message) { return {nullptr, message}; };
+
+  bool hasData() const { return (next_parser_ != nullptr) || (message_ != nullptr); }
+
+private:
+  ParseResponse(ParserSharedPtr parser, MessageSharedPtr message)
+      : next_parser_{parser}, message_{message} {};
+
+public:
+  ParserSharedPtr next_parser_;
+  MessageSharedPtr message_;
+};
+
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/kafka/request_codec.cc
+++ b/source/extensions/filters/network/kafka/request_codec.cc
@@ -1,0 +1,62 @@
+#include "extensions/filters/network/kafka/request_codec.h"
+
+#include "common/buffer/buffer_impl.h"
+
+#include "extensions/filters/network/kafka/kafka_protocol.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+
+// === DECODER =================================================================
+
+void RequestDecoder::onData(Buffer::Instance& data) {
+  uint64_t num_slices = data.getRawSlices(nullptr, 0);
+  Buffer::RawSlice slices[num_slices];
+  data.getRawSlices(slices, num_slices);
+  for (const Buffer::RawSlice& slice : slices) {
+    doParse(current_parser_, slice);
+  }
+}
+
+void RequestDecoder::doParse(ParserSharedPtr& parser, const Buffer::RawSlice& slice) {
+  const char* buffer = reinterpret_cast<const char*>(slice.mem_);
+  uint64_t remaining = slice.len_;
+  while (remaining) {
+    ParseResponse result = parser->parse(buffer, remaining);
+    // this loop guarantees that parsers consuming 0 bytes also get processed
+    while (result.hasData()) {
+      if (!result.next_parser_) {
+
+        // next parser is not present, so we have finished parsing a message
+        MessageSharedPtr message = result.message_;
+        ENVOY_LOG(trace, "parsed message: {}", *message);
+        for (auto& callback : callbacks_) {
+          callback->onMessage(result.message_);
+        }
+
+        // we finished parsing this request, start anew
+        parser = std::make_shared<RequestStartParser>(parser_resolver_);
+      } else {
+        parser = result.next_parser_;
+      }
+      result = parser->parse(buffer, remaining);
+    }
+  }
+}
+
+// === ENCODER =================================================================
+
+void RequestEncoder::encode(const Request& message) {
+  EncodingContext encoder{message.apiVersion()};
+  Buffer::OwnedImpl data_buffer;
+  INT32 data_len = encoder.encode(message, data_buffer); // encode data computing data lenght
+  encoder.encode(data_len, output_);                     // encode data length into result
+  output_.add(data_buffer);                              // copy data into result
+}
+
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/kafka/request_codec.h
+++ b/source/extensions/filters/network/kafka/request_codec.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/common/pure.h"
+
+#include "extensions/filters/network/kafka/codec.h"
+#include "extensions/filters/network/kafka/kafka_request.h"
+#include "extensions/filters/network/kafka/parser.h"
+#include "extensions/filters/network/kafka/serialization.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+
+// === DECODER =================================================================
+
+/**
+ * Invoked when request is successfully decoded
+ */
+class RequestCallback {
+public:
+  virtual ~RequestCallback() = default;
+
+  virtual void onMessage(MessageSharedPtr) PURE;
+};
+
+typedef std::shared_ptr<RequestCallback> RequestCallbackSharedPtr;
+
+/**
+ * Decoder that decodes Kafka requests
+ * When a request is decoded, the callbacks are notified, in order
+ *
+ * This decoder uses chain of parsers to parse fragments of a request
+ * Each parser along the line returns the fully parsed message or the next parser
+ */
+class RequestDecoder : public MessageDecoder<Request>, public Logger::Loggable<Logger::Id::kafka> {
+public:
+  RequestDecoder(const RequestParserResolver parserResolver,
+                 const std::vector<RequestCallbackSharedPtr> callbacks)
+      : parser_resolver_{parserResolver}, callbacks_{callbacks},
+        current_parser_{new RequestStartParser(parser_resolver_)} {};
+
+  void onData(Buffer::Instance& data);
+
+private:
+  void doParse(ParserSharedPtr& parser, const Buffer::RawSlice& slice);
+
+  const RequestParserResolver parser_resolver_;
+  const std::vector<RequestCallbackSharedPtr> callbacks_;
+
+  ParserSharedPtr current_parser_;
+};
+
+// === ENCODER =================================================================
+
+class RequestEncoder : public MessageEncoder<Request> {
+public:
+  RequestEncoder(Buffer::Instance& output) : output_(output) {}
+  void encode(const Request& message) override;
+
+private:
+  Buffer::Instance& output_;
+};
+
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/kafka/serialization.h
+++ b/source/extensions/filters/network/kafka/serialization.h
@@ -1,0 +1,772 @@
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/common/exception.h"
+#include "envoy/common/pure.h"
+
+#include "common/common/byte_order.h"
+#include "common/common/fmt.h"
+
+#include "extensions/filters/network/kafka/kafka_types.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+
+// =============================================================================
+// === DESERIALIZERS ===========================================================
+// =============================================================================
+
+/**
+ * The general idea of Buffer is that it can be feed-ed data until it is ready
+ * When true == ready(), it is safe to call get()
+ * Further feed()-ing should have no effect on a buffer
+ * (should return 0 and not move buffer/remaining)
+ */
+
+// === ABSTRACT DESERIALIZER ===================================================
+
+template <typename T> class Deserializer {
+public:
+  virtual ~Deserializer() = default;
+
+  virtual size_t feed(const char*& buffer, uint64_t& remaining) PURE;
+  virtual bool ready() const PURE;
+  virtual T get() const PURE;
+};
+
+// === INT BUFFERS =============================================================
+
+/**
+ * The values are encoded in network byte order (big-endian).
+ */
+template <typename T> class IntBuffer : public Deserializer<T> {
+public:
+  IntBuffer() : written_{0}, ready_(false){};
+
+  size_t feed(const char*& buffer, uint64_t& remaining) {
+    const size_t available = std::min<size_t>(sizeof(buf_) - written_, remaining);
+    memcpy(buf_ + written_, buffer, available);
+    written_ += available;
+
+    if (written_ == sizeof(buf_)) {
+      ready_ = true;
+    }
+
+    buffer += available;
+    remaining -= available;
+
+    return available;
+  }
+
+  bool ready() const { return ready_; }
+
+protected:
+  char buf_[sizeof(T) / sizeof(char)];
+  size_t written_;
+  bool ready_;
+};
+
+class Int8Buffer : public IntBuffer<INT8> {
+public:
+  INT8 get() const {
+    INT8 result;
+    memcpy(&result, buf_, sizeof(result));
+    return result;
+  }
+};
+
+class Int16Buffer : public IntBuffer<INT16> {
+public:
+  INT16 get() const {
+    INT16 result;
+    memcpy(&result, buf_, sizeof(result));
+    return be16toh(result);
+  }
+};
+
+class Int32Buffer : public IntBuffer<INT32> {
+public:
+  INT32 get() const {
+    INT32 result;
+    memcpy(&result, buf_, sizeof(result));
+    return be32toh(result);
+  }
+};
+
+class UInt32Buffer : public IntBuffer<UINT32> {
+public:
+  UINT32 get() const {
+    UINT32 result;
+    memcpy(&result, buf_, sizeof(result));
+    return be32toh(result);
+  }
+};
+
+class Int64Buffer : public IntBuffer<INT64> {
+public:
+  INT64 get() const {
+    INT64 result;
+    memcpy(&result, buf_, sizeof(result));
+    return be64toh(result);
+  }
+};
+
+// === BOOL BUFFER =============================================================
+
+/**
+ * Represents a boolean value in a byte.
+ * Values 0 and 1 are used to represent false and true respectively.
+ * When reading a boolean value, any non-zero value is considered true.
+ */
+class BoolBuffer : public Deserializer<BOOLEAN> {
+public:
+  BoolBuffer(){};
+
+  size_t feed(const char*& buffer, uint64_t& remaining) { return buffer_.feed(buffer, remaining); }
+
+  bool ready() const { return buffer_.ready(); }
+
+  BOOLEAN get() const { return 0 != buffer_.get(); }
+
+private:
+  Int8Buffer buffer_;
+};
+
+// === STRING BUFFER ===========================================================
+
+/**
+ * Represents a sequence of characters.
+ * First the length N is given as an INT16.
+ * Then N bytes follow which are the UTF-8 encoding of the character sequence.
+ * Length must not be negative.
+ */
+class StringBuffer : public Deserializer<STRING> {
+public:
+  size_t feed(const char*& buffer, uint64_t& remaining) {
+    const size_t length_consumed = length_buf_.feed(buffer, remaining);
+    if (!length_buf_.ready()) {
+      // break early: we still need to fill in length buffer
+      return length_consumed;
+    }
+
+    if (!length_consumed_) {
+      required_ = length_buf_.get();
+      if (required_ >= 0) {
+        data_buf_ = std::vector<char>(required_);
+      } else {
+        throw EnvoyException(fmt::format("invalid STRING length: {}", required_));
+      }
+      length_consumed_ = true;
+    }
+
+    const size_t data_consumed = std::min<size_t>(required_, remaining);
+    const size_t written = data_buf_.size() - required_;
+    memcpy(data_buf_.data() + written, buffer, data_consumed);
+    required_ -= data_consumed;
+
+    buffer += data_consumed;
+    remaining -= data_consumed;
+
+    if (required_ == 0) {
+      ready_ = true;
+    }
+
+    return length_consumed + data_consumed;
+  }
+
+  bool ready() const { return ready_; }
+
+  STRING get() const { return std::string(data_buf_.begin(), data_buf_.end()); }
+
+private:
+  Int16Buffer length_buf_;
+  bool length_consumed_{false};
+
+  INT16 required_;
+  std::vector<char> data_buf_;
+
+  bool ready_{false};
+};
+
+/**
+ * Represents a sequence of characters or null.
+ * For non-null strings, first the length N is given as an INT16.
+ * Then N bytes follow which are the UTF-8 encoding of the character sequence.
+ * A null value is encoded with length of -1 and there are no following bytes.
+ */
+class NullableStringBuffer : public Deserializer<NULLABLE_STRING> {
+public:
+  size_t feed(const char*& buffer, uint64_t& remaining) {
+    const size_t length_consumed = length_buf_.feed(buffer, remaining);
+    if (!length_buf_.ready()) {
+      // break early: we still need to fill in length buffer
+      return length_consumed;
+    }
+
+    if (!length_consumed_) {
+      required_ = length_buf_.get();
+
+      if (required_ >= 0) {
+        data_buf_ = std::vector<char>(required_);
+      }
+      if (required_ == NULL_STRING_LENGTH) {
+        ready_ = true;
+      }
+      if (required_ < NULL_STRING_LENGTH) {
+        throw EnvoyException(fmt::format("invalid NULLABLE_STRING length: {}", required_));
+      }
+
+      length_consumed_ = true;
+    }
+
+    if (ready_) {
+      return length_consumed;
+    }
+
+    const size_t data_consumed = std::min<size_t>(required_, remaining);
+    const size_t written = data_buf_.size() - required_;
+    memcpy(data_buf_.data() + written, buffer, data_consumed);
+    required_ -= data_consumed;
+
+    buffer += data_consumed;
+    remaining -= data_consumed;
+
+    if (required_ == 0) {
+      ready_ = true;
+    }
+
+    return length_consumed + data_consumed;
+  }
+
+  bool ready() const { return ready_; }
+
+  NULLABLE_STRING get() const {
+    return required_ >= 0 ? absl::make_optional(std::string(data_buf_.begin(), data_buf_.end()))
+                          : absl::nullopt;
+  }
+
+private:
+  constexpr static INT16 NULL_STRING_LENGTH{-1};
+
+  Int16Buffer length_buf_;
+  bool length_consumed_{false};
+
+  INT16 required_;
+  std::vector<char> data_buf_;
+
+  bool ready_{false};
+};
+
+// === BYTES BUFFERS ===========================================================
+
+/**
+ * Represents a raw sequence of bytes or null.
+ * For non-null values, first the length N is given as an INT32. Then N bytes follow.
+ * A null value is encoded with length of -1 and there are no following bytes.
+ */
+
+/**
+ * This buffer ignores the data fed, the only result is the number of bytes ignored
+ */
+class NullableBytesIgnoringBuffer : public Deserializer<INT32> {
+public:
+  size_t feed(const char*& buffer, uint64_t& remaining) {
+    const size_t length_consumed = length_buf_.feed(buffer, remaining);
+    if (!length_buf_.ready()) {
+      // break early: we still need to fill in length buffer
+      return length_consumed;
+    }
+
+    if (!length_consumed_) {
+      required_max_ = length_buf_.get();
+      required_ = length_buf_.get();
+
+      if (required_ == NULL_BYTES_LENGTH) {
+        ready_ = true;
+      }
+      if (required_ < NULL_BYTES_LENGTH) {
+        throw EnvoyException(fmt::format("invalid NULLABLE_BYTES length: {}", required_));
+      }
+
+      length_consumed_ = true;
+    }
+
+    if (ready_) {
+      return length_consumed;
+    }
+
+    const size_t data_consumed = std::min<size_t>(required_, remaining);
+    required_ -= data_consumed;
+
+    buffer += data_consumed;
+    remaining -= data_consumed;
+
+    if (required_ == 0) {
+      ready_ = true;
+    }
+
+    return length_consumed + data_consumed;
+  }
+
+  bool ready() const { return ready_; }
+
+  /**
+   * Returns length of ignored array, or -1 if that was null
+   */
+  INT32 get() const { return required_max_; }
+
+private:
+  constexpr static INT32 NULL_BYTES_LENGTH{-1};
+
+  Int32Buffer length_buf_;
+  bool length_consumed_{false};
+  INT32 required_max_;
+  INT32 required_;
+  bool ready_{false};
+};
+
+/**
+ * This buffer captures the data fed
+ */
+class NullableBytesCapturingBuffer : public Deserializer<NULLABLE_BYTES> {
+public:
+  size_t feed(const char*& buffer, uint64_t& remaining) {
+    const size_t length_consumed = length_buf_.feed(buffer, remaining);
+    if (!length_buf_.ready()) {
+      // break early: we still need to fill in length buffer
+      return length_consumed;
+    }
+
+    if (!length_consumed_) {
+      required_ = length_buf_.get();
+
+      if (required_ >= 0) {
+        data_buf_ = std::vector<unsigned char>(required_);
+      }
+      if (required_ == NULL_BYTES_LENGTH) {
+        ready_ = true;
+      }
+      if (required_ < NULL_BYTES_LENGTH) {
+        throw EnvoyException(fmt::format("invalid NULLABLE_BYTES length: {}", required_));
+      }
+
+      length_consumed_ = true;
+    }
+
+    if (ready_) {
+      return length_consumed;
+    }
+
+    const size_t data_consumed = std::min<size_t>(required_, remaining);
+    const size_t written = data_buf_.size() - required_;
+    memcpy(data_buf_.data() + written, buffer, data_consumed);
+    required_ -= data_consumed;
+
+    buffer += data_consumed;
+    remaining -= data_consumed;
+
+    if (required_ == 0) {
+      ready_ = true;
+    }
+
+    return length_consumed + data_consumed;
+  }
+
+  bool ready() const { return ready_; }
+
+  NULLABLE_BYTES get() const {
+    if (NULL_BYTES_LENGTH == required_) {
+      return absl::nullopt;
+    } else {
+      return {data_buf_};
+    }
+  }
+
+private:
+  constexpr static INT32 NULL_BYTES_LENGTH{-1};
+
+  Int32Buffer length_buf_;
+  bool length_consumed_{false};
+  INT32 required_;
+
+  std::vector<unsigned char> data_buf_;
+  bool ready_{false};
+};
+
+// === COMPOSITE BUFFER ========================================================
+
+/**
+ * Composes several buffers into one.
+ * The returned value is constructed via { buffer1.get(), buffer2.get() ... }
+ */
+template <typename RT, typename...> class CompositeBuffer;
+
+template <typename RT, typename T1> class CompositeBuffer<RT, T1> : public Deserializer<RT> {
+public:
+  CompositeBuffer(){};
+  size_t feed(const char*& buffer, uint64_t& remaining) {
+    size_t consumed = 0;
+    consumed += buffer1_.feed(buffer, remaining);
+    return consumed;
+  }
+  bool ready() const { return buffer1_.ready(); }
+  RT get() const { return {buffer1_.get()}; }
+
+protected:
+  T1 buffer1_;
+};
+
+template <typename RT, typename T1, typename T2>
+class CompositeBuffer<RT, T1, T2> : public Deserializer<RT> {
+public:
+  CompositeBuffer(){};
+  size_t feed(const char*& buffer, uint64_t& remaining) {
+    size_t consumed = 0;
+    consumed += buffer1_.feed(buffer, remaining);
+    consumed += buffer2_.feed(buffer, remaining);
+    return consumed;
+  }
+  bool ready() const { return buffer2_.ready(); }
+  RT get() const { return {buffer1_.get(), buffer2_.get()}; }
+
+protected:
+  T1 buffer1_;
+  T2 buffer2_;
+};
+
+template <typename RT, typename T1, typename T2, typename T3>
+class CompositeBuffer<RT, T1, T2, T3> : public Deserializer<RT> {
+public:
+  CompositeBuffer(){};
+  size_t feed(const char*& buffer, uint64_t& remaining) {
+    size_t consumed = 0;
+    consumed += buffer1_.feed(buffer, remaining);
+    consumed += buffer2_.feed(buffer, remaining);
+    consumed += buffer3_.feed(buffer, remaining);
+    return consumed;
+  }
+  bool ready() const { return buffer3_.ready(); }
+  RT get() const { return {buffer1_.get(), buffer2_.get(), buffer3_.get()}; }
+
+protected:
+  T1 buffer1_;
+  T2 buffer2_;
+  T3 buffer3_;
+};
+
+template <typename RT, typename T1, typename T2, typename T3, typename T4>
+class CompositeBuffer<RT, T1, T2, T3, T4> : public Deserializer<RT> {
+public:
+  CompositeBuffer(){};
+  size_t feed(const char*& buffer, uint64_t& remaining) {
+    size_t consumed = 0;
+    consumed += buffer1_.feed(buffer, remaining);
+    consumed += buffer2_.feed(buffer, remaining);
+    consumed += buffer3_.feed(buffer, remaining);
+    consumed += buffer4_.feed(buffer, remaining);
+    return consumed;
+  }
+  bool ready() const { return buffer4_.ready(); }
+  RT get() const { return {buffer1_.get(), buffer2_.get(), buffer3_.get(), buffer4_.get()}; }
+
+protected:
+  T1 buffer1_;
+  T2 buffer2_;
+  T3 buffer3_;
+  T4 buffer4_;
+};
+
+template <typename RT, typename T1, typename T2, typename T3, typename T4, typename T5>
+class CompositeBuffer<RT, T1, T2, T3, T4, T5> : public Deserializer<RT> {
+public:
+  CompositeBuffer(){};
+  size_t feed(const char*& buffer, uint64_t& remaining) {
+    size_t consumed = 0;
+    consumed += buffer1_.feed(buffer, remaining);
+    consumed += buffer2_.feed(buffer, remaining);
+    consumed += buffer3_.feed(buffer, remaining);
+    consumed += buffer4_.feed(buffer, remaining);
+    consumed += buffer5_.feed(buffer, remaining);
+    return consumed;
+  }
+  bool ready() const { return buffer5_.ready(); }
+  RT get() const {
+    return {buffer1_.get(), buffer2_.get(), buffer3_.get(), buffer4_.get(), buffer5_.get()};
+  }
+
+protected:
+  T1 buffer1_;
+  T2 buffer2_;
+  T3 buffer3_;
+  T4 buffer4_;
+  T5 buffer5_;
+};
+
+template <typename RT, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+class CompositeBuffer<RT, T1, T2, T3, T4, T5, T6> : public Deserializer<RT> {
+public:
+  CompositeBuffer(){};
+  size_t feed(const char*& buffer, uint64_t& remaining) {
+    size_t consumed = 0;
+    consumed += buffer1_.feed(buffer, remaining);
+    consumed += buffer2_.feed(buffer, remaining);
+    consumed += buffer3_.feed(buffer, remaining);
+    consumed += buffer4_.feed(buffer, remaining);
+    consumed += buffer5_.feed(buffer, remaining);
+    consumed += buffer6_.feed(buffer, remaining);
+    return consumed;
+  }
+  bool ready() const { return buffer6_.ready(); }
+  RT get() const {
+    return {buffer1_.get(), buffer2_.get(), buffer3_.get(),
+            buffer4_.get(), buffer5_.get(), buffer6_.get()};
+  }
+
+protected:
+  T1 buffer1_;
+  T2 buffer2_;
+  T3 buffer3_;
+  T4 buffer4_;
+  T5 buffer5_;
+  T6 buffer6_;
+};
+
+template <typename RT, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6,
+          typename T7, typename T8>
+class CompositeBuffer<RT, T1, T2, T3, T4, T5, T6, T7, T8> : public Deserializer<RT> {
+public:
+  CompositeBuffer(){};
+  size_t feed(const char*& buffer, uint64_t& remaining) {
+    size_t consumed = 0;
+    consumed += buffer1_.feed(buffer, remaining);
+    consumed += buffer2_.feed(buffer, remaining);
+    consumed += buffer3_.feed(buffer, remaining);
+    consumed += buffer4_.feed(buffer, remaining);
+    consumed += buffer5_.feed(buffer, remaining);
+    consumed += buffer6_.feed(buffer, remaining);
+    consumed += buffer7_.feed(buffer, remaining);
+    consumed += buffer8_.feed(buffer, remaining);
+    return consumed;
+  }
+  bool ready() const { return buffer8_.ready(); }
+  RT get() const {
+    return {buffer1_.get(), buffer2_.get(), buffer3_.get(), buffer4_.get(),
+            buffer5_.get(), buffer6_.get(), buffer7_.get(), buffer8_.get()};
+  }
+
+protected:
+  T1 buffer1_;
+  T2 buffer2_;
+  T3 buffer3_;
+  T4 buffer4_;
+  T5 buffer5_;
+  T6 buffer6_;
+  T7 buffer7_;
+  T8 buffer8_;
+};
+
+// === ARRAY BUFFER ============================================================
+
+/**
+ * Represents a sequence of objects of a given type T. Type T can be either a primitive type (e.g.
+ * STRING) or a structure. First, the length N is given as an INT32. Then N instances of type T
+ * follow. A null array is represented with a length of -1.
+ */
+
+template <typename RT, typename CT> class ArrayBuffer : public Deserializer<NULLABLE_ARRAY<RT>> {
+public:
+  size_t feed(const char*& buffer, uint64_t& remaining) {
+
+    const size_t length_consumed = length_buf_.feed(buffer, remaining);
+    if (!length_buf_.ready()) {
+      // break early: we still need to fill in length buffer
+      return length_consumed;
+    }
+
+    if (!length_consumed_) {
+      required_ = length_buf_.get();
+
+      if (required_ >= 0) {
+        children_ = std::vector<CT>(required_);
+      }
+      if (required_ == NULL_ARRAY_LENGTH) {
+        ready_ = true;
+      }
+      if (required_ < NULL_ARRAY_LENGTH) {
+        throw EnvoyException(fmt::format("invalid array length: {}", required_));
+      }
+
+      length_consumed_ = true;
+    }
+
+    if (ready_) {
+      return length_consumed;
+    }
+
+    size_t child_consumed{0};
+    for (CT& child : children_) {
+      child_consumed += child.feed(buffer, remaining);
+    }
+
+    bool children_ready_ = true;
+    for (CT& child : children_) {
+      children_ready_ &= child.ready();
+    }
+    ready_ = children_ready_;
+
+    return length_consumed + child_consumed;
+  }
+
+  bool ready() const { return ready_; }
+
+  NULLABLE_ARRAY<RT> get() const {
+    if (NULL_ARRAY_LENGTH != required_) {
+      std::vector<RT> result{};
+      result.reserve(children_.size());
+      for (const CT& child : children_) {
+        const RT child_result = child.get();
+        result.push_back(child_result);
+      }
+      return {result};
+    } else {
+      return absl::nullopt;
+    }
+  }
+
+private:
+  constexpr static INT32 NULL_ARRAY_LENGTH{-1};
+
+  Int32Buffer length_buf_;
+  bool length_consumed_{false};
+  INT32 required_;
+  std::vector<CT> children_;
+  bool children_setup_{false};
+  bool ready_{false};
+};
+
+// === NULL BUFFER =============================================================
+
+/**
+ * Consumes no bytes, used as placeholder
+ */
+template <typename RT> class NullBuffer : public Deserializer<RT> {
+public:
+  size_t feed(const char*&, uint64_t&) { return 0; }
+
+  bool ready() const { return true; }
+
+  RT get() const { return {}; }
+};
+
+// =============================================================================
+// === ENCODER HELPER ==========================================================
+// =============================================================================
+
+/**
+ * Encodes provided argument in Kafka format
+ * In case of primitive types, this is done explicitly as per spec
+ * In case of composite types, this is done by calling 'encode' on provided argument
+ */
+
+class EncodingContext {
+public:
+  EncodingContext(INT16 api_version) : api_version_{api_version} {};
+
+  template <typename T> size_t encode(const T& arg, Buffer::Instance& dst);
+
+  template <typename T> size_t encode(const NULLABLE_ARRAY<T>& arg, Buffer::Instance& dst);
+
+  INT16 apiVersion() const { return api_version_; }
+
+private:
+  const INT16 api_version_;
+};
+
+template <typename T> inline size_t EncodingContext::encode(const T& arg, Buffer::Instance& dst) {
+  return arg.encode(dst, *this);
+}
+
+template <> inline size_t EncodingContext::encode(const INT8& arg, Buffer::Instance& dst) {
+  dst.add(&arg, sizeof(INT8));
+  return sizeof(INT8);
+}
+
+#define ENCODE_NUMERIC_TYPE(TYPE, CONVERTER)                                                       \
+  template <> inline size_t EncodingContext::encode(const TYPE& arg, Buffer::Instance& dst) {      \
+    TYPE val = CONVERTER(arg);                                                                     \
+    dst.add(&val, sizeof(TYPE));                                                                   \
+    return sizeof(TYPE);                                                                           \
+  }
+
+ENCODE_NUMERIC_TYPE(INT16, htobe16);
+ENCODE_NUMERIC_TYPE(INT32, htobe32);
+ENCODE_NUMERIC_TYPE(UINT32, htobe32);
+ENCODE_NUMERIC_TYPE(INT64, htobe64);
+
+template <> inline size_t EncodingContext::encode(const BOOLEAN& arg, Buffer::Instance& dst) {
+  INT8 val = arg;
+  dst.add(&val, sizeof(INT8));
+  return sizeof(INT8);
+}
+
+template <> inline size_t EncodingContext::encode(const STRING& arg, Buffer::Instance& dst) {
+  INT16 string_length = arg.length();
+  size_t header_length = encode(string_length, dst);
+  dst.add(arg.c_str(), string_length);
+  return header_length + string_length;
+}
+
+template <>
+inline size_t EncodingContext::encode(const NULLABLE_STRING& arg, Buffer::Instance& dst) {
+  if (arg.has_value()) {
+    return encode(*arg, dst);
+  } else {
+    INT16 len = -1;
+    return encode(len, dst);
+  }
+}
+
+template <> inline size_t EncodingContext::encode(const BYTES& arg, Buffer::Instance& dst) {
+  INT32 data_length = arg.size();
+  size_t header_length = encode(data_length, dst);
+  dst.add(arg.data(), arg.size());
+  return header_length + data_length;
+}
+
+template <>
+inline size_t EncodingContext::encode(const NULLABLE_BYTES& arg, Buffer::Instance& dst) {
+  if (arg.has_value()) {
+    return encode(*arg, dst);
+  } else {
+    INT32 len = -1;
+    return encode(len, dst);
+  }
+}
+
+template <typename T>
+size_t EncodingContext::encode(const NULLABLE_ARRAY<T>& arg, Buffer::Instance& dst) {
+  if (arg.has_value()) {
+    INT32 len = arg->size();
+    size_t header_length = encode(len, dst);
+    size_t written{0};
+    for (const T& el : *arg) {
+      written += encode(el, dst);
+    }
+    return header_length + written;
+  } else {
+    INT32 len = -1;
+    return encode(len, dst);
+  }
+}
+
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/well_known_names.h
+++ b/source/extensions/filters/network/well_known_names.h
@@ -28,6 +28,8 @@ public:
   const std::string TcpProxy = "envoy.tcp_proxy";
   // Authorization filter
   const std::string ExtAuthorization = "envoy.ext_authz";
+  // Kafka filter
+  const std::string Kafka = "envoy.filters.network.kafka";
   // Thrift proxy filter
   const std::string ThriftProxy = "envoy.filters.network.thrift_proxy";
   // Role based access control filter

--- a/test/extensions/filters/network/kafka/BUILD
+++ b/test/extensions/filters/network/kafka/BUILD
@@ -1,0 +1,42 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_package",
+)
+load(
+    "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_cc_test",
+)
+
+envoy_package()
+
+envoy_extension_cc_test(
+    name = "serialization_test",
+    srcs = ["serialization_test.cc"],
+    extension_name = "envoy.filters.network.kafka",
+    deps = [
+        "//source/extensions/filters/network/kafka:serialization_lib",
+        "//test/mocks/server:server_mocks",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "kafka_request_test",
+    srcs = ["kafka_request_test.cc"],
+    extension_name = "envoy.filters.network.kafka",
+    deps = [
+        "//source/extensions/filters/network/kafka:kafka_request_lib",
+        "//test/mocks/server:server_mocks",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "request_codec_test",
+    srcs = ["request_codec_test.cc"],
+    extension_name = "envoy.filters.network.kafka",
+    deps = [
+        "//source/extensions/filters/network/kafka:kafka_request_codec_lib",
+        "//test/mocks/server:server_mocks",
+    ],
+)

--- a/test/extensions/filters/network/kafka/kafka_request_test.cc
+++ b/test/extensions/filters/network/kafka/kafka_request_test.cc
@@ -1,0 +1,174 @@
+#include "extensions/filters/network/kafka/kafka_request.h"
+
+#include "test/mocks/server/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::Return;
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+
+TEST(RequestParserResolver, ShouldReturnSentinelIfRequestTypeIsNotRegistered) {
+  // given
+  RequestParserResolver testee{{}};
+  RequestContextSharedPtr context{new RequestContext{}};
+
+  // when
+  ParserSharedPtr result = testee.createParser(0, 1, context); // api_key = 0 was not registered
+
+  // then
+  ASSERT_NE(result, nullptr);
+  ASSERT_NE(std::dynamic_pointer_cast<SentinelConsumer>(result), nullptr);
+}
+
+TEST(RequestParserResolver, ShouldReturnSentinelIfRequestVersionIsNotRegistered) {
+  // given
+  GeneratorFunction generator = [](RequestContextSharedPtr arg) -> ParserSharedPtr {
+    return std::make_shared<FatProduceRequestV0Parser>(arg);
+  };
+  RequestParserResolver testee{{{0, {0, 1}, generator}}};
+  RequestContextSharedPtr context{new RequestContext{}};
+
+  // when
+  ParserSharedPtr result =
+      testee.createParser(0, 2, context); // api_version = 2 was not registered (0 & 1 were)
+
+  // then
+  ASSERT_NE(result, nullptr);
+  ASSERT_NE(std::dynamic_pointer_cast<SentinelConsumer>(result), nullptr);
+}
+
+TEST(RequestParserResolver, ShouldInvokeGeneratorFunctionOnMatch) {
+  // given
+  GeneratorFunction generator = [](RequestContextSharedPtr arg) -> ParserSharedPtr {
+    return std::make_shared<FatProduceRequestV0Parser>(arg);
+  };
+  RequestParserResolver testee{{{0, {0, 1, 2, 3}, generator}}};
+  RequestContextSharedPtr context{new RequestContext{}};
+
+  // when
+  ParserSharedPtr result = testee.createParser(0, 3, context);
+
+  // then
+  ASSERT_NE(result, nullptr);
+  ASSERT_NE(std::dynamic_pointer_cast<FatProduceRequestV0Parser>(result), nullptr);
+}
+
+class BufferBasedTest : public testing::Test {
+public:
+  Buffer::OwnedImpl& buffer() { return buffer_; }
+
+  const char* getBytes() {
+    uint64_t num_slices = buffer_.getRawSlices(nullptr, 0);
+    Buffer::RawSlice slices[num_slices];
+    buffer_.getRawSlices(slices, num_slices);
+    return reinterpret_cast<const char*>((slices[0]).mem_);
+  }
+
+private:
+  Buffer::OwnedImpl buffer_;
+};
+
+EncodingContext encoder{-1};
+
+TEST_F(BufferBasedTest, RequestStartParserTestShouldReturnRequestHeaderParser) {
+  // given
+  RequestStartParser testee{RequestParserResolver{{}}};
+
+  INT32 request_len = 1234;
+  encoder.encode(request_len, buffer());
+
+  const char* bytes = getBytes();
+  uint64_t remaining = 1024;
+
+  // when
+  const ParseResponse result = testee.parse(bytes, remaining);
+
+  // then
+  ASSERT_EQ(result.hasData(), true);
+  ASSERT_NE(std::dynamic_pointer_cast<RequestHeaderParser>(result.next_parser_), nullptr);
+  ASSERT_EQ(result.message_, nullptr);
+  ASSERT_EQ(testee.contextForTest()->remaining_request_size_, request_len);
+}
+
+class MockRequestParserResolver : public RequestParserResolver {
+public:
+  MockRequestParserResolver() : RequestParserResolver{{}} {};
+  MOCK_CONST_METHOD3(createParser, ParserSharedPtr(INT16, INT16, RequestContextSharedPtr));
+};
+
+TEST_F(BufferBasedTest, RequestHeaderParserShouldExtractHeaderDataAndResolveNextParser) {
+  // given
+  const MockRequestParserResolver parser_resolver;
+  const ParserSharedPtr parser{new ApiVersionsRequestV0Parser{nullptr}};
+  EXPECT_CALL(parser_resolver, createParser(_, _, _)).WillOnce(Return(parser));
+
+  const INT32 request_len = 1000;
+  RequestContextSharedPtr context{new RequestContext()};
+  context->remaining_request_size_ = request_len;
+  RequestHeaderParser testee{parser_resolver, context};
+
+  const INT16 api_key{1};
+  const INT16 api_version{2};
+  const INT32 correlation_id{10};
+  const NULLABLE_STRING client_id{"aaa"};
+  size_t written = 0;
+  written += encoder.encode(api_key, buffer());
+  written += encoder.encode(api_version, buffer());
+  written += encoder.encode(correlation_id, buffer());
+  written += encoder.encode(client_id, buffer());
+
+  const char* bytes = getBytes();
+  uint64_t remaining = 100000;
+  const uint64_t orig_remaining = remaining;
+
+  // when
+  const ParseResponse result = testee.parse(bytes, remaining);
+
+  // then
+  ASSERT_EQ(result.hasData(), true);
+  ASSERT_EQ(result.next_parser_, parser);
+  ASSERT_EQ(result.message_, nullptr);
+
+  ASSERT_EQ(testee.contextForTest()->remaining_request_size_, request_len - written);
+  ASSERT_EQ(remaining, orig_remaining - written);
+
+  const RequestHeader expected_header{api_key, api_version, correlation_id, client_id};
+  ASSERT_EQ(testee.contextForTest()->request_header_, expected_header);
+}
+
+TEST_F(BufferBasedTest, SentinelConsumerShouldConsumeDataUntilEndOfRequest) {
+  // given
+  const INT32 request_len = 1000;
+  RequestContextSharedPtr context{new RequestContext()};
+  context->remaining_request_size_ = request_len;
+  SentinelConsumer testee{context};
+
+  const BYTES garbage(request_len * 2);
+  encoder.encode(garbage, buffer());
+
+  const char* bytes = getBytes();
+  uint64_t remaining = request_len * 2;
+  const uint64_t orig_remaining = remaining;
+
+  // when
+  const ParseResponse result = testee.parse(bytes, remaining);
+
+  // then
+  ASSERT_EQ(result.hasData(), true);
+  ASSERT_EQ(result.next_parser_, nullptr);
+  ASSERT_NE(std::dynamic_pointer_cast<UnknownRequest>(result.message_), nullptr);
+
+  ASSERT_EQ(testee.contextForTest()->remaining_request_size_, 0);
+  ASSERT_EQ(remaining, orig_remaining - request_len);
+}
+
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/network/kafka/request_codec_test.cc
+++ b/test/extensions/filters/network/kafka/request_codec_test.cc
@@ -1,0 +1,538 @@
+#include "extensions/filters/network/kafka/request_codec.h"
+
+#include "test/mocks/server/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+
+class RequestDecoderTest : public testing::Test {
+public:
+  Buffer::OwnedImpl buffer_;
+
+  template <typename T> std::shared_ptr<T> serializeAndDeserialize(T request);
+};
+
+class MockMessageListener : public RequestCallback {
+public:
+  MOCK_METHOD1(onMessage, void(MessageSharedPtr));
+};
+
+template <typename T> std::shared_ptr<T> RequestDecoderTest::serializeAndDeserialize(T request) {
+  RequestEncoder serializer{buffer_};
+  serializer.encode(request);
+
+  std::shared_ptr<MockMessageListener> mock_listener = std::make_shared<MockMessageListener>();
+  RequestDecoder testee{RequestParserResolver::KAFKA_0_11, {mock_listener}};
+
+  MessageSharedPtr receivedMessage;
+  EXPECT_CALL(*mock_listener, onMessage(_)).WillOnce(testing::SaveArg<0>(&receivedMessage));
+
+  testee.onData(buffer_);
+
+  return std::dynamic_pointer_cast<T>(receivedMessage);
+};
+
+// === PRODUCE (0) =============================================================
+
+TEST_F(RequestDecoderTest, shouldParseProduceRequestV0toV2) {
+  // given
+  NULLABLE_ARRAY<FatProduceTopic> topics{
+      {{"t1", {{{0, NULLABLE_BYTES(100)}, {1, NULLABLE_BYTES(200)}}}},
+       {"t2", {{{0, NULLABLE_BYTES(300)}}}}}};
+  FatProduceRequest request{10, 20, topics};
+  request.apiVersion() = 0;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+TEST_F(RequestDecoderTest, shouldParseProduceRequestV3) {
+  // given
+  NULLABLE_ARRAY<FatProduceTopic> topics{
+      {{"t1", {{{0, NULLABLE_BYTES(100)}, {1, NULLABLE_BYTES(200)}}}},
+       {"t2", {{{0, NULLABLE_BYTES(300)}}}}}};
+  // transaction_id in V3
+  FatProduceRequest request{"txid", 10, 20, topics};
+  request.apiVersion() = 3;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+// === FETCH (1) ===============================================================
+
+TEST_F(RequestDecoderTest, shouldParseFetchRequestV0toV2) {
+  // given
+  FetchRequest request{1,
+                       1000,
+                       10,
+                       {{
+                           {"topic1", {{{10, 20, 2000}}}},
+                           {"topic1", {{{11, 21, 2001}, {12, 22, 2002}}}},
+                           {"topic1", {{{13, 23, 2003}}}},
+                       }}};
+  request.apiVersion() = 0;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+TEST_F(RequestDecoderTest, shouldParseFetchRequestV3) {
+  // given
+  FetchRequest request{1,
+                       1000,
+                       10,
+                       20, // max_bytes in V3
+                       {{
+                           {"topic1", {{{10, 20, 2000}}}},
+                           {"topic1", {{{11, 21, 2001}, {12, 22, 2002}}}},
+                           {"topic1", {{{13, 23, 2003}}}},
+                       }}};
+  request.apiVersion() = 3;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+TEST_F(RequestDecoderTest, shouldParseFetchRequestV4) {
+  // given
+  FetchRequest request{1,
+                       1000,
+                       10,
+                       20,
+                       2, // isolation level in V4
+                       {{
+                           {"topic1", {{{10, 20, 2000}}}},
+                           {"topic1", {{{11, 21, 2001}, {12, 22, 2002}}}},
+                           {"topic1", {{{13, 23, 2003}}}},
+                       }}};
+  request.apiVersion() = 4;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+TEST_F(RequestDecoderTest, shouldParseFetchRequestV5) {
+  // given
+  FetchRequest request{1,
+                       1000,
+                       10,
+                       20,
+                       2,
+                       {{
+                           // log_start_offset_ in partition data in V5
+                           {"topic1", {{{10, 20, 1000, 2000}}}},
+                           {"topic1", {{{11, 21, 1001, 2001}, {12, 22, 1002, 2002}}}},
+                           {"topic1", {{{13, 23, 1003, 2003}}}},
+                       }}};
+  request.apiVersion() = 5;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+// === LIST OFFSETS (2) ========================================================
+
+TEST_F(RequestDecoderTest, shouldParseListOffsetsRequestV0) {
+  // given
+  ListOffsetsRequest request{10,
+                             {{
+                                 // partition contains max_num_offsets in v0 only
+                                 {"topic1", {{{1, 1000, 10}, {2, 2000, 20}}}},
+                                 {"topic2", {{{3, 3000, 30}}}},
+                             }}};
+  request.apiVersion() = 0;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+TEST_F(RequestDecoderTest, shouldParseListOffsetsRequestV1) {
+  // given
+  ListOffsetsRequest request{10,
+                             {{
+                                 // max_num_offsets removed in v1
+                                 {"topic1", {{{1, 1000}, {2, 2000}}}},
+                                 {"topic2", {{{3, 3000}}}},
+                             }}};
+  request.apiVersion() = 1;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+TEST_F(RequestDecoderTest, shouldParseListOffsetsRequestV2) {
+  // given
+  ListOffsetsRequest request{10,
+                             2, // isolation level in v2
+                             {{
+                                 {"topic1", {{{1, 1000}, {2, 2000}}}},
+                                 {"topic2", {{{3, 3000}}}},
+                             }}};
+  request.apiVersion() = 2;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+// === METADATA (3) ============================================================
+
+TEST_F(RequestDecoderTest, shouldParseMetadataRequestV0toV3) {
+  // given
+  MetadataRequest request{{{"t1", "t2", "t3"}}};
+  request.apiVersion() = 0;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+TEST_F(RequestDecoderTest, shouldParseMetadataRequestV4) {
+  // given
+  MetadataRequest request{{{"t1", "t2", "t3"}}, true};
+  request.apiVersion() = 4;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+// === LEADER-AND-ISR (4) ======================================================
+
+TEST_F(RequestDecoderTest, shouldParseLeaderAndIsrRequestV0) {
+  // given
+  MetadataPartitionState ps1{"t1", 0, 1000, 1, 2000, {{0, 1}}, 3000, {{0, 1, 2, 3, 4}}};
+  MetadataPartitionState ps2{"t2", 1, 4000, 2, 5000, {{6, 7}}, 6000, {{6, 7, 8, 9, 10}}};
+  NULLABLE_ARRAY<MetadataPartitionState> partition_states{{ps1, ps2}};
+  NULLABLE_ARRAY<LeaderAndIsrLiveLeader> live_leaders{
+      {{1, "host1", 9092}, {2, "host2", 9093}, {3, "host3", 9094}}};
+  LeaderAndIsrRequest request{20, 1000, partition_states, live_leaders};
+  request.apiVersion() = 0;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+// === STOP REPLICA (5) ========================================================
+
+TEST_F(RequestDecoderTest, shouldParseStopReplicaRequestV0) {
+  // given
+  NULLABLE_ARRAY<StopReplicaPartition> partitions{{{"t1", 0}, {"t2", 3}}};
+  StopReplicaRequest request{10, 1000, true, partitions};
+  request.apiVersion() = 0;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+// === UPDATE METADATA (6) =====================================================
+
+TEST_F(RequestDecoderTest, shouldParseUpdateMetadataRequestV0) {
+  // given
+  MetadataPartitionState ps1{"t1", 0, 1000, 1, 2000, {{0, 1}}, 3000, {{0, 1, 2, 3, 4}}};
+  MetadataPartitionState ps2{"t2", 1, 4000, 2, 5000, {{6, 7}}, 6000, {{6, 7, 8, 9, 10}}};
+  NULLABLE_ARRAY<MetadataPartitionState> partition_states{{ps1, ps2}};
+  NULLABLE_ARRAY<UpdateMetadataLiveBroker> live_brokers{
+      {{1, "host1", 9092}, {2, "host2", 9093}, {3, "host3", 9094}}};
+  UpdateMetadataRequest request{20, 1000, partition_states, live_brokers};
+  request.apiVersion() = 0;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+TEST_F(RequestDecoderTest, shouldParseUpdateMetadataRequestV1) {
+  // given
+  MetadataPartitionState ps1{"t1", 0, 1000, 1, 2000, {{0, 1}}, 3000, {{0, 1, 2, 3, 4}}};
+  MetadataPartitionState ps2{"t2", 1, 4000, 2, 5000, {{6, 7}}, 6000, {{6, 7, 8, 9, 10}}};
+  NULLABLE_ARRAY<MetadataPartitionState> partition_states{{ps1, ps2}};
+  NULLABLE_ARRAY<UpdateMetadataLiveBroker> live_brokers{
+      {{1, {{{9092, "h1", 0}, {9093, "h1", 1}}}}, // endpoints added in v1, host & port removed
+       {2, {{{9092, "h2", 2}, {9093, "h2", 3}}}}}};
+  UpdateMetadataRequest request{20, 1000, partition_states, live_brokers};
+  request.apiVersion() = 1;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+TEST_F(RequestDecoderTest, shouldParseUpdateMetadataRequestV2) {
+  // given
+  MetadataPartitionState ps1{"t1", 0, 1000, 1, 2000, {{0, 1}}, 3000, {{0, 1, 2, 3, 4}}};
+  MetadataPartitionState ps2{"t2", 1, 4000, 2, 5000, {{6, 7}}, 6000, {{6, 7, 8, 9, 10}}};
+  NULLABLE_ARRAY<MetadataPartitionState> partition_states{{ps1, ps2}};
+  NULLABLE_ARRAY<UpdateMetadataLiveBroker> live_brokers{
+      {{1, {{{9092, "h1", 0}, {9093, "h1", 1}}}, "rack1"}, // rack added in v2
+       {2, {{{9092, "h2", 2}, {9093, "h2", 3}}}, absl::nullopt}}};
+  UpdateMetadataRequest request{20, 1000, partition_states, live_brokers};
+  request.apiVersion() = 2;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+TEST_F(RequestDecoderTest, shouldParseUpdateMetadataRequestV3) {
+  // given
+  MetadataPartitionState ps1{"t1", 0, 1000, 1, 2000, {{0, 1}}, 3000, {{0, 1, 2, 3, 4}}};
+  MetadataPartitionState ps2{"t2", 1, 4000, 2, 5000, {{6, 7}}, 6000, {{6, 7, 8, 9, 10}}};
+  NULLABLE_ARRAY<MetadataPartitionState> partition_states{{ps1, ps2}};
+  NULLABLE_ARRAY<UpdateMetadataLiveBroker> live_brokers{
+      {{1,
+        {{{9092, "h1", "plain", 0}, {9093, "h1", "ssl", 1}}},
+        "rack1"}, // listener_name added in v2
+       {2, {{{9092, "h2", "name3", 2}, {9093, "h2", "name4", 3}}}, absl::nullopt}}};
+  UpdateMetadataRequest request{20, 1000, partition_states, live_brokers};
+  request.apiVersion() = 3;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+// === CONTROLLED SHUTDOWN (7) =================================================
+
+TEST_F(RequestDecoderTest, shouldParseControlledShutdownRequestV1) {
+  // given
+  ControlledShutdownRequest request{1};
+  request.apiVersion() = 1;
+  request.correlationId() = 42;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+// === OFFSET COMMIT (8) =======================================================
+
+TEST_F(RequestDecoderTest, shouldParseOffsetCommitRequestV0) {
+  // given
+  NULLABLE_ARRAY<OffsetCommitTopic> topics{{{"topic1", {{{{0, 10, "m1"}}}}}}};
+  OffsetCommitRequest request{"group_id", topics};
+  request.apiVersion() = 0;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+TEST_F(RequestDecoderTest, shouldParseOffsetCommitRequestV1) {
+  // given
+  // partitions have timestamp in v1 only
+  NULLABLE_ARRAY<OffsetCommitTopic> topics{
+      {{"topic1", {{{0, 10, 100, "m1"}, {2, 20, 101, "m2"}}}}, {"topic2", {{{3, 30, 102, "m3"}}}}}};
+  OffsetCommitRequest request{"group_id",
+                              40,          // group_generation_id
+                              "member_id", // member_id
+                              topics};
+  request.apiVersion() = 1;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+TEST_F(RequestDecoderTest, shouldParseOffsetCommitRequestV2toV3) {
+  // given
+  NULLABLE_ARRAY<OffsetCommitTopic> topics{
+      {{"topic1", {{{0, 10, "m1"}, {2, 20, "m2"}}}}, {"topic2", {{{3, 30, "m3"}}}}}};
+  OffsetCommitRequest request{"group_id", 1234, "member",
+                              2345, // retention_time
+                              topics};
+  request.apiVersion() = 2;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+// === OFFSET FETCH (9) ========================================================
+
+TEST_F(RequestDecoderTest, shouldParseOffsetFetchRequestV0toV3) {
+  // given
+  OffsetFetchRequest request{"group_id", {{{"topic1", {{0, 1, 2}}}, {"topic2", {{3, 4}}}}}};
+
+  request.apiVersion() = 0;
+  request.correlationId() = 10;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+// === API VERSIONS (18) =======================================================
+
+TEST_F(RequestDecoderTest, shouldParseApiVersionsRequestV0toV1) {
+  // given
+  ApiVersionsRequest request{};
+  request.apiVersion() = 0;
+  request.correlationId() = 42;
+  request.clientId() = "client-id";
+
+  // when
+  auto received = serializeAndDeserialize(request);
+
+  // then
+  ASSERT_NE(received, nullptr);
+  ASSERT_EQ(*received, request);
+}
+
+// === UNKNOWN REQUEST =========================================================
+
+TEST_F(RequestDecoderTest, shouldProduceAbortedMessageOnUnknownData) {
+  // given
+  RequestEncoder serializer{buffer_};
+  ApiVersionsRequest request{};
+  request.apiVersion() = 1;
+  request.correlationId() = 42;
+  request.clientId() = "client-id";
+
+  serializer.encode(request);
+
+  std::shared_ptr<MockMessageListener> mock_listener = std::make_shared<MockMessageListener>();
+  RequestParserResolver parser_resolver{{}}; // we do not accept any kind of message here
+  RequestDecoder testee{parser_resolver, {mock_listener}};
+
+  MessageSharedPtr rev;
+  EXPECT_CALL(*mock_listener, onMessage(_)).WillOnce(testing::SaveArg<0>(&rev));
+
+  // when
+  testee.onData(buffer_);
+
+  // then
+  auto received = std::dynamic_pointer_cast<UnknownRequest>(rev);
+  ASSERT_NE(received, nullptr);
+}
+
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/network/kafka/serialization_test.cc
+++ b/test/extensions/filters/network/kafka/serialization_test.cc
@@ -1,0 +1,405 @@
+#include "extensions/filters/network/kafka/serialization.h"
+
+#include "test/mocks/server/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+
+// === EMPTY (FRESHLY INITIALIZED) BUFFER TESTS ================================
+
+// freshly created buffers should not be ready
+#define TEST_EmptyBufferShouldNotBeReady(BufferClass)                                              \
+  TEST(BufferClass, EmptyBufferShouldNotBeReady) {                                                 \
+    const BufferClass testee{};                                                                    \
+    ASSERT_EQ(testee.ready(), false);                                                              \
+  }
+
+TEST_EmptyBufferShouldNotBeReady(Int8Buffer);
+TEST_EmptyBufferShouldNotBeReady(Int16Buffer);
+TEST_EmptyBufferShouldNotBeReady(Int32Buffer);
+TEST_EmptyBufferShouldNotBeReady(UInt32Buffer);
+TEST_EmptyBufferShouldNotBeReady(Int64Buffer);
+TEST_EmptyBufferShouldNotBeReady(BoolBuffer);
+TEST_EmptyBufferShouldNotBeReady(StringBuffer);
+TEST_EmptyBufferShouldNotBeReady(NullableStringBuffer);
+TEST_EmptyBufferShouldNotBeReady(NullableBytesIgnoringBuffer);
+TEST(CompositeBuffer, EmptyBufferShouldNotBeReady) {
+  // given
+  const CompositeBuffer<INT8, Int8Buffer> testee{};
+  // when, then
+  ASSERT_EQ(testee.ready(), false);
+}
+TEST(ArrayBuffer, EmptyBufferShouldNotBeReady) {
+  // given
+  const ArrayBuffer<INT8, Int8Buffer> testee{};
+  // when, then
+  ASSERT_EQ(testee.ready(), false);
+}
+
+// Null buffer is a special case, it's always ready and can provide results via 0-arg ctor
+TEST(NullBuffer, EmptyBufferShouldBeReady) {
+  // given
+  const NullBuffer<INT8> testee{};
+  // when, then
+  ASSERT_EQ(testee.ready(), true);
+  ASSERT_EQ(testee.get(), 0);
+}
+
+// === SERIALIZATION / DESERIALIZATION TESTS ===================================
+
+EncodingContext encoder{-1}; // context is not used when serializing primitive types
+
+const char* getRawData(const Buffer::OwnedImpl& buffer) {
+  uint64_t num_slices = buffer.getRawSlices(nullptr, 0);
+  Buffer::RawSlice slices[num_slices];
+  buffer.getRawSlices(slices, num_slices);
+  return reinterpret_cast<const char*>((slices[0]).mem_);
+}
+
+// exactly what is says on the tin:
+// 1. serialize expected using Encoder
+// 2. deserialize byte array using testee buffer
+// 3. verify result = expected
+// 4. verify that data pointer moved correct amount
+// 5. feed testee more data
+// 6. verify that nothing more was consumed
+template <typename BT, typename AT>
+void serializeThenDeserializeAndCheckEqualityInOneGo(AT expected) {
+  // given
+  BT testee{};
+
+  Buffer::OwnedImpl buffer;
+  const size_t written = encoder.encode(expected, buffer);
+
+  uint64_t remaining =
+      10 *
+      written; // tell parser that there is more data, it should never consume more than written
+  const uint64_t orig_remaining = remaining;
+  const char* data = getRawData(buffer);
+  const char* orig_data = data;
+
+  // when
+  const size_t consumed = testee.feed(data, remaining);
+
+  // then
+  ASSERT_EQ(consumed, written);
+  ASSERT_EQ(testee.ready(), true);
+  ASSERT_EQ(testee.get(), expected);
+  ASSERT_EQ(data, orig_data + consumed);
+  ASSERT_EQ(remaining, orig_remaining - consumed);
+
+  // when - 2
+  const size_t consumed2 = testee.feed(data, remaining);
+
+  // then - 2 (nothing changes)
+  ASSERT_EQ(consumed2, 0);
+  ASSERT_EQ(data, orig_data + consumed);
+  ASSERT_EQ(remaining, orig_remaining - consumed);
+}
+
+// does the same thing as the above test,
+// but instead of providing whole data at one, it provides it in N one-byte chunks
+// this verifies if buffer keeps state properly
+template <typename BT, typename AT>
+void serializeThenDeserializeAndCheckEqualityWithChunks(AT expected) {
+  // given
+  BT testee{};
+
+  Buffer::OwnedImpl buffer;
+  const size_t written = encoder.encode(expected, buffer);
+
+  const char* data = getRawData(buffer);
+  const char* orig_data = data;
+
+  // when
+  size_t consumed = 0;
+  for (size_t i = 0; i < written; ++i) {
+    uint64_t data_size = 1;
+    consumed += testee.feed(data, data_size);
+    ASSERT_EQ(data_size, 0);
+  }
+
+  // then
+  ASSERT_EQ(consumed, written);
+  ASSERT_EQ(testee.ready(), true);
+  ASSERT_EQ(testee.get(), expected);
+  ASSERT_EQ(data, orig_data + consumed);
+
+  // when - 2
+  uint64_t remaining = 1024;
+  const size_t consumed2 = testee.feed(data, remaining);
+
+  // then - 2 (nothing changes)
+  ASSERT_EQ(consumed2, 0);
+  ASSERT_EQ(data, orig_data + consumed);
+  ASSERT_EQ(remaining, 1024);
+}
+
+template <typename BT, typename AT> void serializeThenDeserializeAndCheckEquality(AT expected) {
+  serializeThenDeserializeAndCheckEqualityInOneGo<BT>(expected);
+  serializeThenDeserializeAndCheckEqualityWithChunks<BT>(expected);
+}
+
+// === NUMERIC BUFFERS =========================================================
+
+// macroed out test for numeric buffers
+#define TEST_BufferShouldDeserialize(BufferClass, DataClass, Value)                                \
+  TEST(DataClass, ShouldConsumeCorrectAmountOfData) {                                              \
+    /* given */                                                                                    \
+    const DataClass value = Value;                                                                 \
+    serializeThenDeserializeAndCheckEquality<BufferClass>(value);                                  \
+  }
+
+TEST_BufferShouldDeserialize(Int8Buffer, INT8, 42);
+TEST_BufferShouldDeserialize(Int16Buffer, INT16, 42);
+TEST_BufferShouldDeserialize(Int32Buffer, INT32, 42);
+TEST_BufferShouldDeserialize(UInt32Buffer, UINT32, 42);
+TEST_BufferShouldDeserialize(Int64Buffer, INT64, 42);
+TEST_BufferShouldDeserialize(BoolBuffer, BOOLEAN, true);
+
+// === (NULLABLE) STRING BUFFER ================================================
+
+TEST(StringBuffer, ShouldDeserialize) {
+  const STRING value = "sometext";
+  serializeThenDeserializeAndCheckEquality<StringBuffer>(value);
+}
+
+TEST(StringBuffer, ShouldDeserializeEmptyString) {
+  const STRING value = "";
+  serializeThenDeserializeAndCheckEquality<StringBuffer>(value);
+}
+
+TEST(StringBuffer, ShouldThrowOnInvalidLength) {
+  // given
+  StringBuffer testee;
+  Buffer::OwnedImpl buffer;
+
+  INT16 len = -1;
+  encoder.encode(len, buffer);
+
+  uint64_t remaining = 1024;
+  const char* data = getRawData(buffer);
+
+  // when
+  // then
+  EXPECT_THROW(testee.feed(data, remaining), EnvoyException);
+}
+
+TEST(NullableStringBuffer, ShouldDeserializeString) {
+  // given
+  const NULLABLE_STRING value{"sometext"};
+  serializeThenDeserializeAndCheckEquality<NullableStringBuffer>(value);
+}
+
+TEST(NullableStringBuffer, ShouldDeserializeEmptyString) {
+  // given
+  const NULLABLE_STRING value{""};
+  serializeThenDeserializeAndCheckEquality<NullableStringBuffer>(value);
+}
+
+TEST(NullableStringBuffer, ShouldDeserializeAbsentString) {
+  // given
+  const NULLABLE_STRING value = absl::nullopt;
+  serializeThenDeserializeAndCheckEquality<NullableStringBuffer>(value);
+}
+
+TEST(NullableStringBuffer, ShouldThrowOnInvalidLength) {
+  // given
+  NullableStringBuffer testee;
+  Buffer::OwnedImpl buffer;
+
+  INT16 len = -2; // -1 is OK for NULLABLE_STRING
+  encoder.encode(len, buffer);
+
+  uint64_t remaining = 1024;
+  const char* data = getRawData(buffer);
+
+  // when
+  // then
+  EXPECT_THROW(testee.feed(data, remaining), EnvoyException);
+}
+
+// === NULLABLE BYTES IGNORING BUFFER ==========================================
+
+TEST(NullableBytesIgnoringBuffer, ShouldDeserialize) {
+  // given
+  NullableBytesIgnoringBuffer testee;
+
+  const INT32 bytes_to_ignore = 100;
+  NULLABLE_BYTES bytes = {std::vector<unsigned char>(bytes_to_ignore)};
+
+  Buffer::OwnedImpl buffer;
+  size_t written = encoder.encode(bytes, buffer);
+
+  uint64_t remaining = written * 10;
+  const uint64_t orig_remaining = remaining;
+
+  const char* data = getRawData(buffer);
+  const char* orig_data = data;
+
+  // when
+  const size_t consumed = testee.feed(data, remaining);
+
+  // then
+  ASSERT_EQ(consumed, written);
+  ASSERT_EQ(testee.ready(), true);
+  ASSERT_EQ(testee.get(), bytes_to_ignore);
+  ASSERT_EQ(data, orig_data + consumed);
+  ASSERT_EQ(remaining, orig_remaining - consumed);
+
+  // when - 2
+  const size_t consumed2 = testee.feed(data, remaining);
+
+  // then - 2 (nothing changes)
+  ASSERT_EQ(consumed2, 0);
+  ASSERT_EQ(data, orig_data + consumed);
+  ASSERT_EQ(remaining, orig_remaining - consumed);
+}
+
+TEST(NullableBytesIgnoringBuffer, ShouldDeserializeNullBytes) {
+  // given
+  NullableBytesIgnoringBuffer testee;
+
+  const INT32 bytes_length = -1;
+
+  Buffer::OwnedImpl buffer;
+  const size_t written = encoder.encode(bytes_length, buffer);
+
+  uint64_t remaining = written * 10;
+  const uint64_t orig_remaining = remaining;
+
+  const char* data = getRawData(buffer);
+  const char* orig_data = data;
+
+  // when
+  const size_t consumed = testee.feed(data, remaining);
+
+  // then
+  ASSERT_EQ(consumed, written);
+  ASSERT_EQ(testee.ready(), true);
+  ASSERT_EQ(testee.get(), bytes_length);
+  ASSERT_EQ(data, orig_data + consumed);
+  ASSERT_EQ(remaining, orig_remaining - consumed);
+
+  // when - 2
+  const size_t consumed2 = testee.feed(data, remaining);
+
+  // then - 2 (nothing changes)
+  ASSERT_EQ(consumed2, 0);
+  ASSERT_EQ(data, orig_data + consumed);
+  ASSERT_EQ(remaining, orig_remaining - consumed);
+}
+
+TEST(NullableBytesIgnoringBuffer, ShouldThrowOnInvalidLength) {
+  // given
+  NullableBytesIgnoringBuffer testee;
+  Buffer::OwnedImpl buffer;
+
+  const INT32 bytes_length = -2; // -1 is OK for NULLABLE_BYTES
+  encoder.encode(bytes_length, buffer);
+
+  uint64_t remaining = 1024;
+  const char* data = getRawData(buffer);
+
+  // when
+  // then
+  EXPECT_THROW(testee.feed(data, remaining), EnvoyException);
+}
+
+// === NULLABLE BYTES CAPTURING BUFFER =========================================
+
+TEST(NullableBytesCapturingBuffer, ShouldDeserialize) {
+  const NULLABLE_BYTES value{{'a', 'b', 'c', 'd'}};
+  serializeThenDeserializeAndCheckEquality<NullableBytesCapturingBuffer>(value);
+}
+
+TEST(NullableBytesCapturingBuffer, ShouldDeserializeEmptyBytes) {
+  const NULLABLE_BYTES value{{}};
+  serializeThenDeserializeAndCheckEquality<NullableBytesCapturingBuffer>(value);
+}
+
+TEST(NullableBytesCapturingBuffer, ShouldDeserializeNullBytes) {
+  const NULLABLE_BYTES value = absl::nullopt;
+  serializeThenDeserializeAndCheckEquality<NullableBytesCapturingBuffer>(value);
+}
+
+TEST(NullableBytesCapturingBuffer, ShouldThrowOnInvalidLength) {
+  // given
+  NullableBytesCapturingBuffer testee;
+  Buffer::OwnedImpl buffer;
+
+  const INT32 bytes_length = -2; // -1 is OK for NULLABLE_BYTES
+  encoder.encode(bytes_length, buffer);
+
+  uint64_t remaining = 1024;
+  const char* data = getRawData(buffer);
+
+  // when
+  // then
+  EXPECT_THROW(testee.feed(data, remaining), EnvoyException);
+}
+
+// === ARRAY BUFFER ============================================================
+
+TEST(ArrayBuffer, ShouldConsumeCorrectAmountOfData) {
+  const NULLABLE_ARRAY<STRING> value{{"aaa", "bbbbb", "cc", "d", "e", "ffffffff"}};
+  serializeThenDeserializeAndCheckEquality<ArrayBuffer<STRING, StringBuffer>>(value);
+}
+
+TEST(ArrayBuffer, ShouldThrowOnInvalidLength) {
+  // given
+  ArrayBuffer<std::string, StringBuffer> testee;
+  Buffer::OwnedImpl buffer;
+
+  const INT32 len = -2; // -1 is OK for ARRAY
+  encoder.encode(len, buffer);
+
+  uint64_t remaining = 1024;
+  const char* data = getRawData(buffer);
+
+  // when
+  // then
+  EXPECT_THROW(testee.feed(data, remaining), EnvoyException);
+}
+
+// === COMPOSITE BUFFER ========================================================
+
+struct CompositeBufferResult {
+  STRING field1_;
+  NULLABLE_ARRAY<INT32> field2_;
+  INT16 field3_;
+
+  size_t encode(Buffer::Instance& dst, EncodingContext& encoder) const {
+    size_t written{0};
+    written += encoder.encode(field1_, dst);
+    written += encoder.encode(field2_, dst);
+    written += encoder.encode(field3_, dst);
+    return written;
+  }
+};
+
+bool operator==(const CompositeBufferResult& lhs, const CompositeBufferResult& rhs) {
+  return (lhs.field1_ == rhs.field1_) && (lhs.field2_ == rhs.field2_) &&
+         (lhs.field3_ == rhs.field3_);
+}
+
+typedef CompositeBuffer<CompositeBufferResult, StringBuffer, ArrayBuffer<INT32, Int32Buffer>,
+                        Int16Buffer>
+    TestCompositeBuffer;
+
+TEST(CompositeBuffer, ShouldDeserialize) {
+  const CompositeBufferResult expected{"zzzzz", {{10, 20, 30, 40, 50}}, 1234};
+  serializeThenDeserializeAndCheckEquality<TestCompositeBuffer>(expected);
+}
+
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
*Description*: Placeholder for Kafka codec, API inspired on some level by Mongo codec (internals partially by Redis though)
*Risk Level*: medium
*Testing*: so far manual, by setting up Kafka cluster & Kafka clients (I keep filter code that's relatively trivial and not part of this PR)
*Docs Changes*: -
*Release Notes*: -
[Optional Fixes #Issue]
[Optional *Deprecated*:]

Recommended (?) order of reading:
* `codec.h` - abstract codecs (there will be one for kafka request & response - to be used in `onData`/`onWrite` filter methods)
* `request_codec.h / .cc` - kafka request encoder&decoder for requests - decoder notifies listeners (similar to mongo) and uses a parser-loop to handle complex messages
* `parser.h` - parser is a parser (the name isn't perfect) - it's a stateful thingy that keeps current buffering state, and can tell if it's done (returns a message) or should be changed (nextParser)
* (now jump a bit to the bottom) `kafka_types.h` - kafka data types
* `kafka_protocol.h` - constants coming from kafka (request-only now)
* `serialization.h` - how `char*` gets translated into kafka types + complex buffer template (that combines N buffers, and then combines their result into one return object) and encoder
* `kafka_request.h / .cc`:
** request header (4 fields present in *every* msg)
** request context keeping that header that's passed in the parser chain mentioned above
** request mapper (basically a mapper from request_type x request_version -> parser)
** message start parser (consumes message length)
** header parser (consumes request header)
** some request parsers (keys 0-9 with versions up to Kafka 0.11)
** (at the bottom) `UnknownRequest` for requests that couldn't be recognised by mapper

Tests:
* `serialization_test`- trivial kafka types, checked in both ways: feed whole buffer at once & trickle by one byte (to ensure state is being kept by buffer properly - compare with redis filter that appears to be doing the same)
* `kafka_request_test` - mapper testing; the details of parse loop `start parser` -> `header parser` -> `specific parser`; 
* `request_codec_test` - full tests for each of currently implemented request type/version combos