### PR TITLE
fix: make headers self-contained

### DIFF
--- a/include/envoy/http/protocol.h
+++ b/include/envoy/http/protocol.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 namespace Envoy {
 namespace Http {
 

--- a/include/envoy/stats/tag_producer.h
+++ b/include/envoy/stats/tag_producer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Signed-off-by: zyfjeff <tianqian.zyf@alibaba-inc.com>

This PR  partially for #4893 

*Description*:  clang-tidy (and IDE) will complain if header is not self-contained.
*Risk Level*:  Low (no actual code change)
*Testing*: N/A
*Docs Changes*: N/A
*Release Notes*: N/A
[Optional Fixes #Issue]  #4863 
