### PR TITLE
logging: do not call the broken 0-arg constructor for spdlog::details::log_msg

### DIFF
--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -309,11 +309,13 @@ TEST_P(AdminRequestTest, AdminRequestAfterRun) {
 TEST_P(MainCommonTest, ConstructDestructLogger) {
   VERBOSE_EXPECT_NO_THROW(MainCommon main_common(argc(), argv()));
 
+  // log_msg constructor doesn't initialize all fields, resulting in uninitialized
+  // memory accesses. "static" is a simple way to start from zeroed memory before
+  // the constructor is run, avoiding this problem.
+  // Has been fixed in spdlog; see https://github.com/gabime/spdlog/issues/888.
+  // This change may be reverted after the next spdlog import.
   const std::string logger_name = "logger";
-  spdlog::details::log_msg log_msg;
-  log_msg.logger_name = &logger_name;
-  log_msg.level = spdlog::level::level_enum::err;
-
+  static spdlog::details::log_msg log_msg(&logger_name, spdlog::level::level_enum::err);
   Logger::Registry::getSink()->log(log_msg);
 }
 

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -309,13 +309,8 @@ TEST_P(AdminRequestTest, AdminRequestAfterRun) {
 TEST_P(MainCommonTest, ConstructDestructLogger) {
   VERBOSE_EXPECT_NO_THROW(MainCommon main_common(argc(), argv()));
 
-  // log_msg constructor doesn't initialize all fields, resulting in uninitialized
-  // memory accesses. "static" is a simple way to start from zeroed memory before
-  // the constructor is run, avoiding this problem.
-  // Has been fixed in spdlog; see https://github.com/gabime/spdlog/issues/888.
-  // This change may be reverted after the next spdlog import.
   const std::string logger_name = "logger";
-  static spdlog::details::log_msg log_msg(&logger_name, spdlog::level::level_enum::err);
+  spdlog::details::log_msg log_msg(&logger_name, spdlog::level::level_enum::err);
   Logger::Registry::getSink()->log(log_msg);
 }
 


### PR DESCRIPTION
*Description*: This constructor does not init all its member vars and breaks in clang 'msan'. msan is not run by default in CI but is run at Google so this tripped us up on import.
*Risk Level*: low
*Testing*: just this one test.
*Docs Changes*: n/a
*Release Notes*: n/a
