### PR TITLE
Add logging of health check failure events

### DIFF
--- a/api/envoy/api/v2/core/health_check.proto
+++ b/api/envoy/api/v2/core/health_check.proto
@@ -213,8 +213,9 @@ message HealthCheck {
   // If empty, no event log will be written.
   string event_log_path = 17;
 
-  // If set to true, health check failure events will always be logged.
-  // The default to value for "Always_log_health_check_failures" is false.
+  // If set to true, health check failure events will always be logged.  If set to false, only the 
+  // initial health check failure event will be logged.
+  // The default value is false.
   bool always_log_health_check_failures = 19;
 }
 

--- a/api/envoy/api/v2/core/health_check.proto
+++ b/api/envoy/api/v2/core/health_check.proto
@@ -213,8 +213,9 @@ message HealthCheck {
   // If empty, no event log will be written.
   string event_log_path = 17;
 
-  // If set, health check failure events will always be logged
-  google.protobuf.BoolValue always_log_health_check_failures = 19;
+  // If set to true, health check failure events will always be logged.
+  // The default to value for "Always_log_health_check_failures" is false.
+  bool always_log_health_check_failures = 19;
 }
 
 // Endpoint health status.

--- a/api/envoy/api/v2/core/health_check.proto
+++ b/api/envoy/api/v2/core/health_check.proto
@@ -213,7 +213,7 @@ message HealthCheck {
   // If empty, no event log will be written.
   string event_log_path = 17;
 
-  // If set to true, health check failure events will always be logged.  If set to false, only the 
+  // If set to true, health check failure events will always be logged. If set to false, only the
   // initial health check failure event will be logged.
   // The default value is false.
   bool always_log_health_check_failures = 19;

--- a/api/envoy/api/v2/core/health_check.proto
+++ b/api/envoy/api/v2/core/health_check.proto
@@ -212,6 +212,9 @@ message HealthCheck {
   // Specifies the path to the :ref:`health check event log <arch_overview_health_check_logging>`.
   // If empty, no event log will be written.
   string event_log_path = 17;
+
+  // If set, health check failure events will always be logged
+  google.protobuf.BoolValue always_log_health_check_failures = 19;
 }
 
 // Endpoint health status.

--- a/api/envoy/data/core/v2alpha/health_check_event.proto
+++ b/api/envoy/data/core/v2alpha/health_check_event.proto
@@ -27,6 +27,9 @@ message HealthCheckEvent {
 
     // Host addition.
     HealthCheckAddHealthy add_healthy_event = 5;
+
+    // Host failure.
+    HealthCheckFailure health_check_failure_event = 7;
   }
 
   // Timestamp for event.
@@ -56,4 +59,11 @@ message HealthCheckAddHealthy {
   // the configured :ref:`healthy threshold <envoy_api_field_core.HealthCheck.healthy_threshold>`
   // is bypassed and the host is immediately added.
   bool first_check = 1;
+}
+
+message HealthCheckFailure {
+  // The type of failure that caused this failure.
+  HealthCheckFailureType failure_type = 1 [(validate.rules).enum.defined_only = true];
+  // Whether this addition is the result of the first ever health check on a host.
+  bool first_check = 2;
 }

--- a/api/envoy/data/core/v2alpha/health_check_event.proto
+++ b/api/envoy/data/core/v2alpha/health_check_event.proto
@@ -62,8 +62,8 @@ message HealthCheckAddHealthy {
 }
 
 message HealthCheckFailure {
-  // The type of failure that caused this failure.
+  // The type of failure that caused this event.
   HealthCheckFailureType failure_type = 1 [(validate.rules).enum.defined_only = true];
-  // Whether this addition is the result of the first ever health check on a host.
+  // Whether this event is the result of the first ever health check on a host.
   bool first_check = 2;
 }

--- a/docs/root/intro/arch_overview/health_checking.rst
+++ b/docs/root/intro/arch_overview/health_checking.rst
@@ -62,7 +62,7 @@ A per-healthchecker log of ejection and addition events can optionally be produc
 specifying a log file path in `the HealthCheck config <envoy_api_field_core.HealthCheck.event_log_path>`.
 The log is structured as JSON dumps of `HealthCheckEvent messages <envoy_api_msg_core.HealthCheckEvent>`.
 
-Envoy can be configured to log all health check failure events by setting 'the always_log_health_check_failures 
+Envoy can be configured to log all health check failure events by setting the :ref:'always_log_health_check_failures 
 flag <envoy_api_field_core.HealthCheck.always_log_health_check_failures>' to true.
 
 Passive health checking

--- a/docs/root/intro/arch_overview/health_checking.rst
+++ b/docs/root/intro/arch_overview/health_checking.rst
@@ -62,6 +62,9 @@ A per-healthchecker log of ejection and addition events can optionally be produc
 specifying a log file path in `the HealthCheck config <envoy_api_field_core.HealthCheck.event_log_path>`.
 The log is structured as JSON dumps of `HealthCheckEvent messages <envoy_api_msg_core.HealthCheckEvent>`.
 
+Envoy can be configured to log all health check failure events by setting 'the always_log_health_check_failures 
+flag <envoy_api_field_core.HealthCheck.always_log_health_check_failures>' to true.
+
 Passive health checking
 -----------------------
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -13,6 +13,7 @@ Version history
 * config: added support for :ref:`rate limiting<envoy_api_msg_core.RateLimitSettings>` discovery request calls.
 * cors: added :ref: `invalid/valid stats <cors-statistics>` to filter.
 * fault: removed integer percentage support.
+* health check: Added :ref: 'logging health check failure events <envoy_api_field_core.HealthCheck.always_log_health_check_failures>'.
 * http: Added HTTP/2 WebSocket proxying via :ref:`extended CONNECT <envoy_api_field_core.Http2ProtocolOptions.allow_connect>`
 * http: added limits to the number and length of header modifications in all fields request_headers_to_add and response_headers_to_add. These limits are very high and should only be used as a last-resort safeguard.
 * http: no longer adding whitespace when appending X-Forwarded-For headers. **Warning**: this is not

--- a/include/envoy/upstream/health_checker.h
+++ b/include/envoy/upstream/health_checker.h
@@ -71,7 +71,7 @@ public:
    * Log an unhealthy host ejection event.
    * @param health_checker_type supplies the type of health checker that generated the event.
    * @param host supplies the host that generated the event.
-   * @param failure_type supplies the type of health check failure
+   * @param failure_type supplies the type of health check failure.
    */
   virtual void
   logEjectUnhealthy(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
@@ -82,8 +82,8 @@ public:
    * Log an unhealthy host event.
    * @param health_checker_type supplies the type of health checker that generated the event.
    * @param host supplies the host that generated the event.
-   * @param failure_type supplies the type of health check failure
-   * @param first_check whether this is a failure on the first unhealth check for this host
+   * @param failure_type supplies the type of health check failure.
+   * @param first_check whether this is a failure on the first health check for this host.
    */
   virtual void logUnhealthy(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
                             const HostDescriptionConstSharedPtr& host,
@@ -94,8 +94,8 @@ public:
    * Log a healthy host addition event.
    * @param health_checker_type supplies the type of health checker that generated the event.
    * @param host supplies the host that generated the event.
-   * @param healthy_threshold supplied the configured healthy threshold for this health check
-   * @param first_check whether this is a fast path success on the first health check for this host
+   * @param healthy_threshold supplied the configured healthy threshold for this health check.
+   * @param first_check whether this is a fast path success on the first health check for this host.
    */
   virtual void logAddHealthy(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
                              const HostDescriptionConstSharedPtr& host, bool first_check) PURE;

--- a/include/envoy/upstream/health_checker.h
+++ b/include/envoy/upstream/health_checker.h
@@ -79,6 +79,18 @@ public:
                     envoy::data::core::v2alpha::HealthCheckFailureType failure_type) PURE;
 
   /**
+   * Log an unhealthy host event.
+   * @param health_checker_type supplies the type of health checker that generated the event.
+   * @param host supplies the host that generated the event.
+   * @param failure_type supplies the type of health check failure
+   * @param first_check whether this is a failure on the first unhealth check for this host
+   */
+  virtual void logUnhealthy(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
+                            const HostDescriptionConstSharedPtr& host,
+                            envoy::data::core::v2alpha::HealthCheckFailureType failure_type,
+                            bool first_check) PURE;
+
+  /**
    * Log a healthy host addition event.
    * @param health_checker_type supplies the type of health checker that generated the event.
    * @param host supplies the host that generated the event.

--- a/source/common/upstream/health_checker_base_impl.cc
+++ b/source/common/upstream/health_checker_base_impl.cc
@@ -15,7 +15,9 @@ HealthCheckerImplBase::HealthCheckerImplBase(const Cluster& cluster,
                                              Runtime::Loader& runtime,
                                              Runtime::RandomGenerator& random,
                                              HealthCheckEventLoggerPtr&& event_logger)
-    : cluster_(cluster), dispatcher_(dispatcher),
+    : always_log_health_check_failures_(
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, always_log_health_check_failures, false)),
+      cluster_(cluster), dispatcher_(dispatcher),
       timeout_(PROTOBUF_GET_MS_REQUIRED(config, timeout)),
       unhealthy_threshold_(PROTOBUF_GET_WRAPPED_REQUIRED(config, unhealthy_threshold)),
       healthy_threshold_(PROTOBUF_GET_WRAPPED_REQUIRED(config, healthy_threshold)),
@@ -249,6 +251,10 @@ HealthTransition HealthCheckerImplBase::ActiveHealthCheckSession::setUnhealthy(
     }
   }
 
+  if (first_check_ || parent_.always_log_health_check_failures_) {
+    parent_.event_logger_->logUnhealthy(parent_.healthCheckerType(), host_, type, first_check_);
+  }
+
   parent_.stats_.failure_.inc();
   if (type == envoy::data::core::v2alpha::HealthCheckFailureType::NETWORK) {
     parent_.stats_.network_failure_.inc();
@@ -290,6 +296,25 @@ void HealthCheckEventLoggerImpl::logEjectUnhealthy(
   *event.mutable_host() = std::move(address);
   event.set_cluster_name(host->cluster().name());
   event.mutable_eject_unhealthy_event()->set_failure_type(failure_type);
+  TimestampUtil::systemClockToTimestamp(time_source_.systemTime(), *event.mutable_timestamp());
+  // Make sure the type enums make it into the JSON
+  const auto json = MessageUtil::getJsonStringFromMessage(event, /* pretty_print */ false,
+                                                          /* always_print_primitive_fields */ true);
+  file_->write(fmt::format("{}\n", json));
+}
+
+void HealthCheckEventLoggerImpl::logUnhealthy(
+    envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
+    const HostDescriptionConstSharedPtr& host,
+    envoy::data::core::v2alpha::HealthCheckFailureType failure_type, bool first_check) {
+  envoy::data::core::v2alpha::HealthCheckEvent event;
+  event.set_health_checker_type(health_checker_type);
+  envoy::api::v2::core::Address address;
+  Network::Utility::addressToProtobufAddress(*host->address(), address);
+  *event.mutable_host() = std::move(address);
+  event.set_cluster_name(host->cluster().name());
+  event.mutable_health_check_failure_event()->set_failure_type(failure_type);
+  event.mutable_health_check_failure_event()->set_first_check(first_check);
   TimestampUtil::systemClockToTimestamp(time_source_.systemTime(), *event.mutable_timestamp());
   // Make sure the type enums make it into the JSON
   const auto json = MessageUtil::getJsonStringFromMessage(event, /* pretty_print */ false,

--- a/source/common/upstream/health_checker_base_impl.cc
+++ b/source/common/upstream/health_checker_base_impl.cc
@@ -251,7 +251,7 @@ HealthTransition HealthCheckerImplBase::ActiveHealthCheckSession::setUnhealthy(
     }
   }
 
-  if (first_check_ || parent_.always_log_health_check_failures_) {
+  if ((first_check_ || parent_.always_log_health_check_failures_) && parent_.event_logger_) {
     parent_.event_logger_->logUnhealthy(parent_.healthCheckerType(), host_, type, first_check_);
   }
 

--- a/source/common/upstream/health_checker_base_impl.cc
+++ b/source/common/upstream/health_checker_base_impl.cc
@@ -15,8 +15,7 @@ HealthCheckerImplBase::HealthCheckerImplBase(const Cluster& cluster,
                                              Runtime::Loader& runtime,
                                              Runtime::RandomGenerator& random,
                                              HealthCheckEventLoggerPtr&& event_logger)
-    : always_log_health_check_failures_(
-          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, always_log_health_check_failures, false)),
+    : always_log_health_check_failures_(config.always_log_health_check_failures()),
       cluster_(cluster), dispatcher_(dispatcher),
       timeout_(PROTOBUF_GET_MS_REQUIRED(config, timeout)),
       unhealthy_threshold_(PROTOBUF_GET_WRAPPED_REQUIRED(config, unhealthy_threshold)),

--- a/source/common/upstream/health_checker_base_impl.h
+++ b/source/common/upstream/health_checker_base_impl.h
@@ -82,6 +82,7 @@ protected:
   virtual ActiveHealthCheckSessionPtr makeSession(HostSharedPtr host) PURE;
   virtual envoy::data::core::v2alpha::HealthCheckerType healthCheckerType() const PURE;
 
+  const bool always_log_health_check_failures_;
   const Cluster& cluster_;
   Event::Dispatcher& dispatcher_;
   const std::chrono::milliseconds timeout_;
@@ -141,6 +142,10 @@ public:
                          envoy::data::core::v2alpha::HealthCheckFailureType failure_type) override;
   void logAddHealthy(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
                      const HostDescriptionConstSharedPtr& host, bool first_check) override;
+  void logUnhealthy(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
+                    const HostDescriptionConstSharedPtr& host,
+                    envoy::data::core::v2alpha::HealthCheckFailureType failure_type,
+                    bool first_check) override;
 
 private:
   TimeSource& time_source_;

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -483,9 +483,10 @@ public:
   void expectSessionCreate() { expectSessionCreate(health_checker_map_); }
   void expectClientCreate(size_t index) { expectClientCreate(index, health_checker_map_); }
 
-  void expectSuccessStartFailedFailFirst(const absl::optional<std::string>& health_checked_cluster = absl::optional<std::string>()) {
+  void expectSuccessStartFailedFailFirst(
+      const absl::optional<std::string>& health_checked_cluster = absl::optional<std::string>()) {
     cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
-      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+        makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
     cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagSet(
         Host::HealthFlag::FAILED_ACTIVE_HC);
     expectSessionCreate();

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -190,7 +190,7 @@ public:
         });
   }
 
-  void setupNoServiceValidationHCLogError() {
+  void setupNoServiceValidationHCAlwaysLogFailure() {
     const std::string yaml = R"EOF(
     timeout: 1s
     interval: 1s
@@ -1151,7 +1151,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirst) {
 }
 
 TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirstLogError) {
-  setupNoServiceValidationHCLogError();
+  setupNoServiceValidationHCAlwaysLogFailure();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagSet(
@@ -1241,7 +1241,7 @@ TEST_F(HttpHealthCheckerImplTest, HttpFail) {
 }
 
 TEST_F(HttpHealthCheckerImplTest, HttpFailLogError) {
-  setupNoServiceValidationHCLogError();
+  setupNoServiceValidationHCAlwaysLogFailure();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -190,6 +190,29 @@ public:
         });
   }
 
+  void setupNoServiceValidationHCLogError() {
+    const std::string yaml = R"EOF(
+    timeout: 1s
+    interval: 1s
+    no_traffic_interval: 5s
+    interval_jitter: 1s
+    unhealthy_threshold: 2
+    healthy_threshold: 2
+    http_health_check:
+      service_name: locations
+      path: /healthcheck
+    always_log_health_check_failures: true
+    )EOF";
+
+    health_checker_.reset(new TestHttpHealthCheckerImpl(*cluster_, parseHealthCheckFromV2Yaml(yaml),
+                                                        dispatcher_, runtime_, random_,
+                                                        HealthCheckEventLoggerPtr(event_logger_)));
+    health_checker_->addHostCheckCompleteCb(
+        [this](HostSharedPtr host, HealthTransition changed_state) -> void {
+          onHostStatus(host, changed_state);
+        });
+  }
+
   void setupNoServiceValidationNoReuseConnectionHC() {
     std::string json = R"EOF(
     {
@@ -915,6 +938,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithoutUserAgent) {
 
 TEST_F(HttpHealthCheckerImplTest, ServiceDoesNotMatchFail) {
   setupServiceValidationHC();
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
@@ -943,6 +967,7 @@ TEST_F(HttpHealthCheckerImplTest, ServiceDoesNotMatchFail) {
 
 TEST_F(HttpHealthCheckerImplTest, ServiceNotPresentInResponseFail) {
   setupServiceValidationHC();
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
@@ -1011,6 +1036,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirstServiceCheck) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   respond(0, "503", false, false, false, health_checked_cluster);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
@@ -1094,6 +1120,52 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirst) {
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
+  respond(0, "503", false);
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  expectStreamCreate(0);
+  test_sessions_[0]->interval_timer_->callback_();
+
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  respond(0, "200", false);
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  expectStreamCreate(0);
+  test_sessions_[0]->interval_timer_->callback_();
+
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
+  EXPECT_CALL(*event_logger_, logAddHealthy(_, _, false));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  respond(0, "200", false);
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+}
+
+TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirstLogError) {
+  setupNoServiceValidationHCLogError();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagSet(
+      Host::HealthFlag::FAILED_ACTIVE_HC);
+  expectSessionCreate();
+  expectStreamCreate(0);
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  // Test that failing first disables fast success.
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   respond(0, "503", false);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
@@ -1136,6 +1208,68 @@ TEST_F(HttpHealthCheckerImplTest, HttpFail) {
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
+  respond(0, "503", false);
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+
+  EXPECT_EQ(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->getActiveHealthFailureType(),
+            Host::ActiveHealthFailureType::UNHEALTHY);
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  expectStreamCreate(0);
+  test_sessions_[0]->interval_timer_->callback_();
+
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  respond(0, "200", false);
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  expectStreamCreate(0);
+  test_sessions_[0]->interval_timer_->callback_();
+
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
+  EXPECT_CALL(*event_logger_, logAddHealthy(_, _, false));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  respond(0, "200", false);
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+}
+
+TEST_F(HttpHealthCheckerImplTest, HttpFailLogError) {
+  setupNoServiceValidationHCLogError();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+  expectStreamCreate(0);
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  health_checker_->start();
+
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
+  respond(0, "503", false);
+  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
+      Host::HealthFlag::FAILED_ACTIVE_HC));
+  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+
+  EXPECT_EQ(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->getActiveHealthFailureType(),
+            Host::ActiveHealthFailureType::UNHEALTHY);
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
+  expectStreamCreate(0);
+  test_sessions_[0]->interval_timer_->callback_();
+
+  // logUnhealthy is called with first_check == false
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, false));
   respond(0, "503", false);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
@@ -1169,6 +1303,7 @@ TEST_F(HttpHealthCheckerImplTest, HttpFail) {
 
 TEST_F(HttpHealthCheckerImplTest, Disconnect) {
   setupNoServiceValidationHC();
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending)).Times(1);
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
@@ -1201,6 +1336,7 @@ TEST_F(HttpHealthCheckerImplTest, Disconnect) {
 
 TEST_F(HttpHealthCheckerImplTest, Timeout) {
   setupNoServiceValidationHC();
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
@@ -1239,6 +1375,7 @@ TEST_F(HttpHealthCheckerImplTest, TimeoutAfterDisconnect) {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   expectSessionCreate();
   expectStreamCreate(0);
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   health_checker_->start();
 
@@ -1997,6 +2134,7 @@ TEST_F(TcpHealthCheckerImplTest, WrongData) {
   EXPECT_EQ(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->getActiveHealthFailureType(),
             Host::ActiveHealthFailureType::UNHEALTHY);
 }
+
 TEST_F(TcpHealthCheckerImplTest, Timeout) {
   InSequence s;
 
@@ -2009,6 +2147,8 @@ TEST_F(TcpHealthCheckerImplTest, Timeout) {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   EXPECT_CALL(*connection_, write(_, _));
   EXPECT_CALL(*timeout_timer_, enableTimer(_));
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
+
   cluster_->prioritySet().getMockHostSet(0)->runCallbacks(
       {cluster_->prioritySet().getMockHostSet(0)->hosts_.back()}, {});
 
@@ -2018,7 +2158,6 @@ TEST_F(TcpHealthCheckerImplTest, Timeout) {
   add_uint8(response, 1);
   read_filter_->onData(response, false);
 
-  EXPECT_CALL(*connection_, close(_));
   EXPECT_CALL(*timeout_timer_, disableTimer());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
   timeout_timer_->callback_();
@@ -2158,6 +2297,7 @@ TEST_F(TcpHealthCheckerImplTest, PassiveFailure) {
   EXPECT_CALL(*connection_, write(_, _)).Times(0);
   EXPECT_CALL(*timeout_timer_, enableTimer(_));
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   health_checker_->start();
 
   // Do multiple passive failures. This will not reset the active HC timers.
@@ -2742,6 +2882,7 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessStartFailedFailFirst) {
   expectHealthcheckStop(0);
   // Host was unhealthy from the start, no state change.
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::NOT_SERVING);
   expectHostHealthy(false);
 
@@ -2775,6 +2916,7 @@ TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFail) {
 
   expectSessionCreate();
   expectHealthcheckStart(0);
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   health_checker_->start();
 
   // Explicit healthcheck failure immediately renders host unhealthy.
@@ -2813,6 +2955,7 @@ TEST_F(GrpcHealthCheckerImplTest, Disconnect) {
 
   expectSessionCreate();
   expectHealthcheckStart(0);
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   health_checker_->start();
 
   expectHealthcheckStop(0);
@@ -2841,6 +2984,7 @@ TEST_F(GrpcHealthCheckerImplTest, Timeout) {
   expectSessionCreate();
 
   expectHealthcheckStart(0);
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   health_checker_->start();
 
   expectHealthcheckStop(0);
@@ -3155,6 +3299,7 @@ TEST_F(GrpcHealthCheckerImplTest, GrpcFailUnknown) {
   setupHC();
   expectSingleHealthcheck(HealthTransition::Changed);
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
 
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::UNKNOWN);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
@@ -3169,6 +3314,7 @@ TEST_F(GrpcHealthCheckerImplTest, GoAwayProbeInProgress) {
   setupHCWithUnhealthyThreshold(1);
   expectSingleHealthcheck(HealthTransition::Changed);
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
 
   test_sessions_[0]->codec_client_->raiseGoAway();
 
@@ -3305,6 +3451,7 @@ INSTANTIATE_TEST_CASE_P(
 TEST_P(BadResponseGrpcHealthCheckerImplTest, GrpcBadResponse) {
   setupHC();
   expectSingleHealthcheck(HealthTransition::Changed);
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
 
   ResponseSpec spec = GetParam();
@@ -3363,6 +3510,16 @@ TEST(HealthCheckEventLoggerImplTest, All) {
                          "cluster\",\"add_healthy_event\":{\"first_check\":false},\"timestamp\":"
                          "\"2009-02-13T23:31:31.234Z\"}\n"}));
   event_logger.logAddHealthy(envoy::data::core::v2alpha::HealthCheckerType::HTTP, host, false);
+
+  EXPECT_CALL(*file, write(absl::string_view{
+                         "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
+                         "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"resolver_name\":\"\","
+                         "\"ipv4_compat\":false,\"port_value\":443}},\"cluster_name\":\"fake_"
+                         "cluster\",\"health_check_failure_event\":{\"failure_type\":\"ACTIVE\","
+                         "\"first_check\":false},"
+                         "\"timestamp\":\"2009-02-13T23:31:31.234Z\"}\n"}));
+  event_logger.logUnhealthy(envoy::data::core::v2alpha::HealthCheckerType::HTTP, host,
+                            envoy::data::core::v2alpha::HealthCheckFailureType::ACTIVE, false);
 }
 
 // Validate that the proto constraints don't allow zero length edge durations.

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -2147,7 +2147,6 @@ TEST_F(TcpHealthCheckerImplTest, Timeout) {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
   EXPECT_CALL(*connection_, write(_, _));
   EXPECT_CALL(*timeout_timer_, enableTimer(_));
-  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
 
   cluster_->prioritySet().getMockHostSet(0)->runCallbacks(
       {cluster_->prioritySet().getMockHostSet(0)->hosts_.back()}, {});
@@ -2158,6 +2157,8 @@ TEST_F(TcpHealthCheckerImplTest, Timeout) {
   add_uint8(response, 1);
   read_filter_->onData(response, false);
 
+  EXPECT_CALL(*connection_, close(_));
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
   EXPECT_CALL(*timeout_timer_, disableTimer());
   EXPECT_CALL(*interval_timer_, enableTimer(_));
   timeout_timer_->callback_();

--- a/test/extensions/health_checkers/redis/config_test.cc
+++ b/test/extensions/health_checkers/redis/config_test.cc
@@ -62,6 +62,30 @@ TEST(HealthCheckerFactoryTest, createRedisWithoutKey) {
               .get()));
 }
 
+TEST(HealthCheckerFactoryTest, createRedisWithLogHCFailure) {
+  const std::string yaml = R"EOF(
+    timeout: 1s
+    interval: 1s
+    no_traffic_interval: 5s
+    interval_jitter: 1s
+    unhealthy_threshold: 1
+    healthy_threshold: 1
+    custom_health_check:
+      name: envoy.health_checkers.redis
+      config:
+    always_log_health_check_failures: true
+    )EOF";
+
+  NiceMock<Server::Configuration::MockHealthCheckerFactoryContext> context;
+
+  RedisHealthCheckerFactory factory;
+  EXPECT_NE(
+      nullptr,
+      dynamic_cast<CustomRedisHealthChecker*>(
+          factory.createCustomHealthChecker(Upstream::parseHealthCheckFromV2Yaml(yaml), context)
+              .get()));
+}
+
 TEST(HealthCheckerFactoryTest, createRedisViaUpstreamHealthCheckerFactory) {
   const std::string yaml = R"EOF(
     timeout: 1s

--- a/test/extensions/health_checkers/redis/redis_test.cc
+++ b/test/extensions/health_checkers/redis/redis_test.cc
@@ -53,6 +53,28 @@ public:
                                Upstream::HealthCheckEventLoggerPtr(event_logger_), *this));
   }
 
+  void setupLogError() {
+    const std::string yaml = R"EOF(
+    timeout: 1s
+    interval: 1s
+    no_traffic_interval: 5s
+    interval_jitter: 1s
+    unhealthy_threshold: 1
+    healthy_threshold: 1
+    always_log_health_check_failures: true
+    custom_health_check:
+      name: envoy.health_checkers.redis
+      config:
+    )EOF";
+
+    const auto& hc_config = Upstream::parseHealthCheckFromV2Yaml(yaml);
+    const auto& redis_config = getRedisHealthCheckConfig(hc_config);
+
+    health_checker_.reset(
+        new RedisHealthChecker(*cluster_, hc_config, redis_config, dispatcher_, runtime_, random_,
+                               Upstream::HealthCheckEventLoggerPtr(event_logger_), *this));
+  }
+
   void setupExistsHealthcheck() {
     const std::string yaml = R"EOF(
     timeout: 1s
@@ -207,6 +229,114 @@ TEST_F(RedisHealthCheckerTest, PingAndVariousFailures) {
   EXPECT_EQ(1UL, cluster_->info_->stats_store_.counter("health_check.success").value());
   EXPECT_EQ(3UL, cluster_->info_->stats_store_.counter("health_check.failure").value());
   EXPECT_EQ(2UL, cluster_->info_->stats_store_.counter("health_check.network_failure").value());
+}
+
+TEST_F(RedisHealthCheckerTest, FailuresLogging) {
+  InSequence s;
+  setupLogError();
+
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+
+  expectSessionCreate();
+  expectClientCreate();
+  expectPingRequestCreate();
+  health_checker_->start();
+
+  client_->runHighWatermarkCallbacks();
+  client_->runLowWatermarkCallbacks();
+
+  // Success
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  Extensions::NetworkFilters::RedisProxy::RespValuePtr response(
+      new Extensions::NetworkFilters::RedisProxy::RespValue());
+  response->type(Extensions::NetworkFilters::RedisProxy::RespType::SimpleString);
+  response->asString() = "PONG";
+  pool_callbacks_->onResponse(std::move(response));
+
+  expectPingRequestCreate();
+  interval_timer_->callback_();
+
+  // Failure
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, false));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  response = std::make_unique<Extensions::NetworkFilters::RedisProxy::RespValue>();
+  pool_callbacks_->onResponse(std::move(response));
+
+  expectPingRequestCreate();
+  interval_timer_->callback_();
+
+  // Fail again
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, false));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  response = std::make_unique<Extensions::NetworkFilters::RedisProxy::RespValue>();
+  pool_callbacks_->onResponse(std::move(response));
+
+  expectPingRequestCreate();
+  interval_timer_->callback_();
+
+  // Shutdown with active request.
+  EXPECT_CALL(pool_request_, cancel());
+  EXPECT_CALL(*client_, close());
+
+  EXPECT_EQ(4UL, cluster_->info_->stats_store_.counter("health_check.attempt").value());
+  EXPECT_EQ(1UL, cluster_->info_->stats_store_.counter("health_check.success").value());
+  EXPECT_EQ(2UL, cluster_->info_->stats_store_.counter("health_check.failure").value());
+  EXPECT_EQ(0UL, cluster_->info_->stats_store_.counter("health_check.network_failure").value());
+}
+
+TEST_F(RedisHealthCheckerTest, LogInitialFailure) {
+  InSequence s;
+  setup();
+
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+
+  expectSessionCreate();
+  expectClientCreate();
+  expectPingRequestCreate();
+  health_checker_->start();
+
+  client_->runHighWatermarkCallbacks();
+  client_->runLowWatermarkCallbacks();
+
+  // Redis failure via disconnect
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _));
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  pool_callbacks_->onFailure();
+  client_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+
+  expectClientCreate();
+  expectPingRequestCreate();
+  interval_timer_->callback_();
+
+  // Success
+  EXPECT_CALL(*event_logger_, logAddHealthy(_, _, false));
+  EXPECT_CALL(*timeout_timer_, disableTimer());
+  EXPECT_CALL(*interval_timer_, enableTimer(_));
+  Extensions::NetworkFilters::RedisProxy::RespValuePtr response(
+      new Extensions::NetworkFilters::RedisProxy::RespValue());
+  response->type(Extensions::NetworkFilters::RedisProxy::RespType::SimpleString);
+  response->asString() = "PONG";
+  pool_callbacks_->onResponse(std::move(response));
+
+  expectPingRequestCreate();
+  interval_timer_->callback_();
+
+  // Shutdown with active request.
+  EXPECT_CALL(pool_request_, cancel());
+  EXPECT_CALL(*client_, close());
+
+  EXPECT_EQ(3UL, cluster_->info_->stats_store_.counter("health_check.attempt").value());
+  EXPECT_EQ(1UL, cluster_->info_->stats_store_.counter("health_check.success").value());
+  EXPECT_EQ(1UL, cluster_->info_->stats_store_.counter("health_check.failure").value());
+  EXPECT_EQ(1UL, cluster_->info_->stats_store_.counter("health_check.network_failure").value());
 }
 
 TEST_F(RedisHealthCheckerTest, Exists) {

--- a/test/extensions/health_checkers/redis/redis_test.cc
+++ b/test/extensions/health_checkers/redis/redis_test.cc
@@ -53,7 +53,7 @@ public:
                                Upstream::HealthCheckEventLoggerPtr(event_logger_), *this));
   }
 
-  void setupLogError() {
+  void setupAlwaysLogHealthCheckFailures() {
     const std::string yaml = R"EOF(
     timeout: 1s
     interval: 1s
@@ -233,7 +233,7 @@ TEST_F(RedisHealthCheckerTest, PingAndVariousFailures) {
 
 TEST_F(RedisHealthCheckerTest, FailuresLogging) {
   InSequence s;
-  setupLogError();
+  setupAlwaysLogHealthCheckFailures();
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -320,6 +320,9 @@ public:
                                        envoy::data::core::v2alpha::HealthCheckFailureType));
   MOCK_METHOD3(logAddHealthy, void(envoy::data::core::v2alpha::HealthCheckerType,
                                    const HostDescriptionConstSharedPtr&, bool));
+  MOCK_METHOD4(logUnhealthy, void(envoy::data::core::v2alpha::HealthCheckerType,
+                                  const HostDescriptionConstSharedPtr&,
+                                  envoy::data::core::v2alpha::HealthCheckFailureType, bool));
 };
 
 class MockCdsApi : public CdsApi {


### PR DESCRIPTION
In this change, a health check failure event will be logged if either of these conditions are true:
- If the active health check failed and it's the first health check for a host. This ensures we have events for hosts that never became healthy.
- If the active health check failed and a always_log_health_check_failures configuration is set to true, by default this flag is set to false. This makes it very easy to find the hosts currently failing by looking at the last few seconds of logs.

*Risk Level*: Low
*Testing*: Tests are added
*Docs Changes*: Yes
Fixes #4942 
