### PR TITLE
Fix /server_info

### DIFF
--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -530,6 +530,7 @@ Http::Code AdminImpl::handlerServerInfo(absl::string_view, Http::HeaderMap& head
                                                           server_.startTimeCurrentEpoch());
   server_info.mutable_uptime_all_epochs()->set_seconds(current_time -
                                                        server_.startTimeFirstEpoch());
+  server_info.set_epoch(server_.options().restartEpoch());
   response.add(MessageUtil::getJsonStringFromMessage(server_info, true, true));
   headers.insertContentType().value().setReference(Http::Headers::get().ContentTypeValues.Json);
   return Http::Code::OK;

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1096,6 +1096,9 @@ TEST_P(AdminInstanceTest, ClustersJson) {
 TEST_P(AdminInstanceTest, GetRequest) {
   Http::HeaderMapImpl response_headers;
   std::string body;
+
+  EXPECT_CALL(server_.options_, restartEpoch()).WillOnce(Return(2));
+
   EXPECT_EQ(Http::Code::OK, admin_.request("/server_info", "GET", response_headers, body));
   envoy::admin::v2alpha::ServerInfo server_info_proto;
   EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
@@ -1105,6 +1108,7 @@ TEST_P(AdminInstanceTest, GetRequest) {
   // values such as timestamps + Envoy version are tricky to test for.
   MessageUtil::loadFromJson(body, server_info_proto);
   EXPECT_EQ(server_info_proto.state(), envoy::admin::v2alpha::ServerInfo::LIVE);
+  EXPECT_EQ(server_info_proto.epoch(), 2);
 }
 
 TEST_P(AdminInstanceTest, GetRequestJson) {


### PR DESCRIPTION
When `/server_info` changed from a string to JSON (#4886), we forgot
to populate the restart epoch.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
