### PR TITLE
bazel: remove duplicated env in cc_autoconf

### DIFF
--- a/bazel/cc_configure.bzl
+++ b/bazel/cc_configure.bzl
@@ -106,7 +106,6 @@ cc_autoconf = repository_rule(
         "CPLUS_INCLUDE_PATH",
         "CUDA_COMPUTE_CAPABILITIES",
         "CUDA_PATH",
-        "CXX",
         "HOMEBREW_RUBY_PATH",
         "NO_WHOLE_ARCHIVE_OPTION",
         "USE_DYNAMIC_CRT",


### PR DESCRIPTION
Just remove duplicate env `CXX` in cc_autoconf

*Description*: remove duplicated env(CXX) in cc_autoconf
*Risk Level*: Low
*Testing*:  n/a 
*Docs Changes*:  n/a
*Release Notes*:  n/a
[Optional Fixes #Issue]
[Optional *Deprecated*:]

Signed-off-by: detailyang (detailyang@gmail.com)
