### PR TITLE
listener: replace evconnlistener with syscalls and FileEvent.

### DIFF
--- a/include/envoy/api/os_sys_calls.h
+++ b/include/envoy/api/os_sys_calls.h
@@ -39,6 +39,21 @@ public:
   virtual ~OsSysCalls() {}
 
   /**
+   * @see listen (man 2 listen)
+   */
+  virtual SysCallIntResult listen(int sockfd, int backlog) PURE;
+
+  /**
+   * @see accept (man 2 accept)
+   */
+  virtual SysCallIntResult accept(int sockfd, struct sockaddr* addr, socklen_t* addrlen) PURE;
+
+  /**
+   * @see fcntl (man 2 fcntl)
+   */
+  virtual SysCallIntResult fcntlSetInt(int fd, int cmd, int arg) PURE;
+
+  /**
    * @see bind (man 2 bind)
    */
   virtual SysCallIntResult bind(int sockfd, const sockaddr* addr, socklen_t addrlen) PURE;

--- a/source/common/api/os_sys_calls_impl.cc
+++ b/source/common/api/os_sys_calls_impl.cc
@@ -8,6 +8,21 @@
 namespace Envoy {
 namespace Api {
 
+SysCallIntResult OsSysCallsImpl::listen(int sockfd, int backlog) {
+  const int rc = ::listen(sockfd, backlog);
+  return {rc, errno};
+}
+
+SysCallIntResult OsSysCallsImpl::accept(int sockfd, struct sockaddr* addr, socklen_t* addrlen) {
+  const int rc = ::accept(sockfd, addr, addrlen);
+  return {rc, errno};
+}
+
+SysCallIntResult OsSysCallsImpl::fcntlSetInt(int fd, int cmd, int arg) {
+  const int rc = ::fcntl(fd, cmd, arg);
+  return {rc, errno};
+}
+
 SysCallIntResult OsSysCallsImpl::bind(int sockfd, const sockaddr* addr, socklen_t addrlen) {
   const int rc = ::bind(sockfd, addr, addrlen);
   return {rc, errno};

--- a/source/common/api/os_sys_calls_impl.h
+++ b/source/common/api/os_sys_calls_impl.h
@@ -10,6 +10,9 @@ namespace Api {
 class OsSysCallsImpl : public OsSysCalls {
 public:
   // Api::OsSysCalls
+  SysCallIntResult listen(int sockfd, int backlog) override;
+  SysCallIntResult accept(int sockfd, struct sockaddr* addr, socklen_t* addrlen) override;
+  SysCallIntResult fcntlSetInt(int fd, int cmd, int arg) override;
   SysCallIntResult bind(int sockfd, const sockaddr* addr, socklen_t addrlen) override;
   SysCallIntResult ioctl(int sockfd, unsigned long int request, void* argp) override;
   SysCallIntResult open(const std::string& full_path, int flags, int mode) override;

--- a/source/common/event/libevent.h
+++ b/source/common/event/libevent.h
@@ -17,11 +17,6 @@ extern "C" {
 void bufferevent_free(bufferevent*);
 }
 
-struct evconnlistener;
-extern "C" {
-void evconnlistener_free(evconnlistener*);
-}
-
 namespace Envoy {
 namespace Event {
 namespace Libevent {
@@ -46,7 +41,6 @@ private:
 typedef CSmartPtr<event_base, event_base_free> BasePtr;
 typedef CSmartPtr<evbuffer, evbuffer_free> BufferPtr;
 typedef CSmartPtr<bufferevent, bufferevent_free> BufferEventPtr;
-typedef CSmartPtr<evconnlistener, evconnlistener_free> ListenerPtr;
 
 } // namespace Libevent
 } // namespace Event

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -144,7 +144,6 @@ envoy_cc_library(
         "//source/common/common:empty_string",
         "//source/common/common:linked_object",
         "//source/common/event:dispatcher_includes",
-        "//source/common/event:libevent_lib",
     ],
 )
 

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -140,6 +140,7 @@ envoy_cc_library(
         "//include/envoy/network:listener_interface",
         "//include/envoy/stats:stats_interface",
         "//include/envoy/stats:stats_macros",
+        "//source/common/api:os_sys_calls_lib",
         "//source/common/common:assert_lib",
         "//source/common/common:empty_string",
         "//source/common/common:linked_object",

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -66,9 +66,9 @@ ListenerImpl::ListenerImpl(Event::DispatcherImpl& dispatcher, Socket& socket, Li
           while (true) {
             sockaddr_storage remote_addr;
             socklen_t remote_addr_len = sizeof(remote_addr);
-            const int ret = ::accept4(socket_fd, reinterpret_cast<sockaddr*>(&remote_addr),
-                                      &remote_addr_len, O_NONBLOCK);
-            if (ret < 0) {
+            const int ret =
+                ::accept(socket_fd, reinterpret_cast<sockaddr*>(&remote_addr), &remote_addr_len);
+            if (ret < 0 || ::fcntl(ret, F_SETFL, O_NONBLOCK) == -1) {
               if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK ||
                   errno == ECONNABORTED) {
                 return;

--- a/source/common/network/listener_impl.h
+++ b/source/common/network/listener_impl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/api/os_sys_calls.h"
 #include "envoy/network/listener.h"
 
 #include "common/event/dispatcher_impl.h"
@@ -32,6 +33,7 @@ protected:
 private:
   void listenCallback(int fd, const sockaddr& remote_addr, socklen_t remote_addr_len);
 
+  Api::OsSysCalls& os_sys_calls_;
   Event::FileEventPtr file_event_;
 };
 

--- a/source/common/network/listener_impl.h
+++ b/source/common/network/listener_impl.h
@@ -30,11 +30,9 @@ protected:
   const bool hand_off_restored_destination_connections_;
 
 private:
-  static void errorCallback(evconnlistener* listener, void* context);
-  static void listenCallback(evconnlistener*, evutil_socket_t fd, sockaddr* remote_addr,
-                             int remote_addr_len, void* arg);
+  void listenCallback(int fd, const sockaddr& remote_addr, socklen_t remote_addr_len);
 
-  Event::Libevent::ListenerPtr listener_;
+  Event::FileEventPtr file_event_;
 };
 
 } // namespace Network

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -566,7 +566,7 @@ void ListenerImpl::setSocket(const Network::SocketSharedPtr& socket) {
     }
 
     // Add the options to the socket_ so that STATE_LISTENING options can be
-    // set in the worker after listen()/evconnlistener_new() is called.
+    // set in the worker after listen() is called.
     socket_->addOptions(listen_socket_options_);
   }
 }

--- a/test/mocks/api/mocks.h
+++ b/test/mocks/api/mocks.h
@@ -52,6 +52,9 @@ public:
   SysCallIntResult getsockopt(int sockfd, int level, int optname, void* optval,
                               socklen_t* optlen) override;
 
+  MOCK_METHOD2(listen, SysCallIntResult(int sockfd, int backlog));
+  MOCK_METHOD3(accept, SysCallIntResult(int sockfd, struct sockaddr* addr, socklen_t* addrlen));
+  MOCK_METHOD3(fcntlSetInt, SysCallIntResult(int fd, int cmd, int arg));
   MOCK_METHOD3(bind, SysCallIntResult(int sockfd, const sockaddr* addr, socklen_t addrlen));
   MOCK_METHOD3(ioctl, SysCallIntResult(int sockfd, unsigned long int request, void* argp));
   MOCK_METHOD1(close, SysCallIntResult(int));


### PR DESCRIPTION
This removes an unnecessary libevent dependency by using direct syscalls
and FileEvent, paving the way to #4952. The implementation is a direct
inlining of the execution paths we were already taking for these
capabilities in libevent.

Risk Level: Medium. This mucks with core connection handling. Any
regression should have this PR rolled back immediately.
Testing: Existing Envoy tests covering listeners.

Signed-off-by: Harvey Tuch <htuch@google.com>
