### PR TITLE
router: do not retry rate limited requests

### DIFF
--- a/docs/root/configuration/http_filters/rate_limit_filter.rst
+++ b/docs/root/configuration/http_filters/rate_limit_filter.rst
@@ -13,7 +13,7 @@ can optionally include the virtual host rate limit configurations. More than one
 apply to a request. Each configuration results in a descriptor being sent to the rate limit service.
 
 If the rate limit service is called, and the response for any of the descriptors is over limit, a
-429 response is returned.
+429 response is returned. The rate limit filter also sets the :ref:`x-envoy-ratelimited<config_http_filters_router_x-envoy-ratelimited>` header.
 
 If there is an error in calling rate limit service or rate limit service returns an error and :ref:`failure_mode_deny <envoy_api_msg_config.filter.http.rate_limit.v2.RateLimit>` is 
 set to true, a 500 response is returned.

--- a/docs/root/configuration/http_filters/router_filter.rst
+++ b/docs/root/configuration/http_filters/router_filter.rst
@@ -226,6 +226,15 @@ x-envoy-overloaded
 If this header is set by upstream, Envoy will not retry. Currently the value of the header is not
 looked at, only its presence.
 
+.. _config_http_filters_router_x-envoy-ratelimited:
+
+x-envoy-ratelimited
+^^^^^^^^^^^^^^^^^^^
+
+If this header is set by upstream, Envoy will not retry. Currently the value of the header is not
+looked at, only its presence. This header is set by :ref:`rate limit filter<config_http_filters_rate_limit>`
+when the request is rate limited. 
+
 .. _config_http_filters_router_x-envoy-decorator-operation:
 
 x-envoy-decorator-operation

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -34,6 +34,7 @@ Version history
   is set, Envoy will now add or update the grpc-timeout header to reflect Envoy's expected timeout.
 * router: per try timeouts now starts when an upstream stream is ready instead of when the request has
   been fully decoded by Envoy.
+* router: added support for not retrying :ref:`rate limited requests<config_http_filters_router_x-envoy-ratelimited>`.
 * stats: added :ref:`stats_matcher <envoy_api_field_config.metrics.v2.StatsConfig.stats_matcher>` to the bootstrap config for granular control of stat instantiation.
 * stream: renamed the `RequestInfo` namespace to `StreamInfo` to better match
   its behaviour within TCP and HTTP implementations.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -34,7 +34,8 @@ Version history
   is set, Envoy will now add or update the grpc-timeout header to reflect Envoy's expected timeout.
 * router: per try timeouts now starts when an upstream stream is ready instead of when the request has
   been fully decoded by Envoy.
-* router: added support for not retrying :ref:`rate limited requests<config_http_filters_router_x-envoy-ratelimited>`.
+* router: added support for not retrying :ref:`rate limited requests<config_http_filters_router_x-envoy-ratelimited>`. Rate limit filter now sets the :ref:`x-envoy-ratelimited<config_http_filters_router_x-envoy-ratelimited>`
+  header so the rate limited requests that may have been retried earlier will not be retried with this change.
 * stats: added :ref:`stats_matcher <envoy_api_field_config.metrics.v2.StatsConfig.stats_matcher>` to the bootstrap config for granular control of stat instantiation.
 * stream: renamed the `RequestInfo` namespace to `StreamInfo` to better match
   its behaviour within TCP and HTTP implementations.

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -257,6 +257,7 @@ private:
   HEADER_FUNC(EnvoyMaxRetries)                                                                     \
   HEADER_FUNC(EnvoyOriginalPath)                                                                   \
   HEADER_FUNC(EnvoyOverloaded)                                                                     \
+  HEADER_FUNC(EnvoyRateLimited)                                                                    \
   HEADER_FUNC(EnvoyRetryOn)                                                                        \
   HEADER_FUNC(EnvoyRetryGrpcOn)                                                                    \
   HEADER_FUNC(EnvoyRetriableStatusCodes)                                                           \

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -45,6 +45,7 @@ public:
   const LowerCaseString EnvoyOriginalDstHost{"x-envoy-original-dst-host"};
   const LowerCaseString EnvoyOriginalPath{"x-envoy-original-path"};
   const LowerCaseString EnvoyOverloaded{"x-envoy-overloaded"};
+  const LowerCaseString EnvoyRateLimited{"x-envoy-ratelimited"};
   const LowerCaseString EnvoyRetryOn{"x-envoy-retry-on"};
   const LowerCaseString EnvoyRetryGrpcOn{"x-envoy-retry-grpc-on"};
   const LowerCaseString EnvoyRetriableStatusCodes{"x-envoy-retriable-status-codes"};
@@ -135,6 +136,10 @@ public:
   struct {
     const std::string True{"true"};
   } EnvoyOverloadedValues;
+
+  struct {
+    const std::string True{"true"};
+  } EnvoyRateLimitedValues;
 
   struct {
     const std::string _5xx{"5xx"};

--- a/source/common/ratelimit/ratelimit_impl.cc
+++ b/source/common/ratelimit/ratelimit_impl.cc
@@ -68,16 +68,13 @@ void GrpcClientImpl::onSuccess(
     span.setTag(Constants::get().TraceStatus, Constants::get().TraceOk);
   }
 
+  Http::HeaderMapPtr headers = std::make_unique<Http::HeaderMapImpl>();
   if (response->headers_size()) {
-    Http::HeaderMapPtr headers = std::make_unique<Http::HeaderMapImpl>();
     for (const auto& h : response->headers()) {
       headers->addCopy(Http::LowerCaseString(h.key()), h.value());
     }
-    callbacks_->complete(status, std::move(headers));
-  } else {
-    callbacks_->complete(status, nullptr);
   }
-
+  callbacks_->complete(status, std::move(headers));
   callbacks_ = nullptr;
 }
 

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -267,6 +267,11 @@ bool RetryStateImpl::wouldRetry(const Http::HeaderMap* response_headers,
       return false;
     }
 
+    // We never retry if the request is rate limited.
+    if (response_headers->EnvoyRateLimited() != nullptr) {
+      return false;
+    }
+
     if (wouldRetryFromHeaders(*response_headers)) {
       return true;
     }

--- a/source/extensions/filters/http/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit.cc
@@ -137,6 +137,8 @@ void Filter::complete(RateLimit::LimitStatus status, Http::HeaderMapPtr&& header
                                              EMPTY_STRING,
                                              false};
     Http::CodeUtility::chargeResponseStat(info);
+    headers_to_add_->insertEnvoyRateLimited().value(
+        Http::Headers::get().EnvoyRateLimitedValues.True);
     break;
   }
 

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -127,6 +127,16 @@ TEST_F(RouterRetryStateImplTest, Policy5xxRemote503Overloaded) {
   EXPECT_EQ(RetryStatus::No, state_->shouldRetry(&response_headers, no_reset_, callback_));
 }
 
+TEST_F(RouterRetryStateImplTest, PolicyResourceExhaustedRemoteRateLimited) {
+  Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-grpc-on", "resource-exhausted"}};
+  setup(request_headers);
+  EXPECT_TRUE(state_->enabled());
+
+  Http::TestHeaderMapImpl response_headers{
+      {":status", "200"}, {"grpc-status", "8"}, {"x-envoy-ratelimited", "true"}};
+  EXPECT_EQ(RetryStatus::No, state_->shouldRetry(&response_headers, no_reset_, callback_));
+}
+
 TEST_F(RouterRetryStateImplTest, PolicyGatewayErrorRemote502) {
   Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "gateway-error"}};
   setup(request_headers);


### PR DESCRIPTION
*Description*: This PR implements a header based approach that ensures rate limited requests are not retried irrespective of other retry conditions set. Please see the [discussion](https://github.com/envoyproxy/envoy/pull/4946#discussion_r230845443) for more details.
*Risk Level*: Low
*Testing*: Automated tests added.
*Docs Changes*: Updated.
*Release Notes*: Added
Fixes #4855 

