### PR TITLE
build: cleanup ci/.bazelrc.

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -108,6 +108,19 @@ mkdir -p "${ENVOY_COVERAGE_DIR}"
 # This is where we build for bazel.release* and bazel.dev.
 export ENVOY_CI_DIR="${ENVOY_SRCDIR}"/ci
 
+function cleanup() {
+  # Remove build artifacts. This doesn't mess with incremental builds as these
+  # are just symlinks.
+  rm -rf "${ENVOY_SRCDIR}"/bazel-*
+  rm -rf "${ENVOY_CI_DIR}"/bazel-*
+  rm -rf "${ENVOY_CI_DIR}"/bazel
+  rm -rf "${ENVOY_CI_DIR}"/tools
+  rm -f "${ENVOY_CI_DIR}"/.bazelrc
+}
+
+cleanup
+trap cleanup EXIT
+
 # Hack due to https://github.com/envoyproxy/envoy/issues/838 and the need to have
 # .bazelrc available for build linkstamping.
 mkdir -p "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/bazel
@@ -123,14 +136,3 @@ ln -sf "${ENVOY_SRCDIR}"/tools/bazel.rc "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/tools/
 ln -sf "${ENVOY_SRCDIR}"/tools/bazel.rc "${ENVOY_CI_DIR}"/tools/
 
 export BUILDIFIER_BIN="/usr/local/bin/buildifier"
-
-function cleanup() {
-  # Remove build artifacts. This doesn't mess with incremental builds as these
-  # are just symlinks.
-  rm -rf "${ENVOY_SRCDIR}"/bazel-*
-  rm -rf "${ENVOY_CI_DIR}"/bazel-*
-  rm -rf "${ENVOY_CI_DIR}"/bazel
-  rm -rf "${ENVOY_CI_DIR}"/tools
-  rm -f "${ENVOY_CI_DIR}"/.bazelrc
-}
-trap cleanup EXIT

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -114,8 +114,8 @@ mkdir -p "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/bazel
 mkdir -p "${ENVOY_CI_DIR}"/bazel
 ln -sf "${ENVOY_SRCDIR}"/bazel/get_workspace_status "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/bazel/
 ln -sf "${ENVOY_SRCDIR}"/bazel/get_workspace_status "${ENVOY_CI_DIR}"/bazel/
-ln -sf "${ENVOY_SRCDIR}"/.bazelrc "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/
-ln -sf "${ENVOY_SRCDIR}"/.bazelrc "${ENVOY_CI_DIR}"/
+cp -f "${ENVOY_SRCDIR}"/.bazelrc "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/
+cp -f "${ENVOY_SRCDIR}"/.bazelrc "${ENVOY_CI_DIR}"/
 # TODO(PiotrSikora): remove once we deprecate tools/bazel.rc in favor of .bazelrc.
 mkdir -p "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/tools
 mkdir -p "${ENVOY_CI_DIR}"/tools
@@ -131,5 +131,6 @@ function cleanup() {
   rm -rf "${ENVOY_CI_DIR}"/bazel-*
   rm -rf "${ENVOY_CI_DIR}"/bazel
   rm -rf "${ENVOY_CI_DIR}"/tools
+  rm -f "${ENVOY_CI_DIR}"/.bazelrc
 }
 trap cleanup EXIT

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -114,8 +114,8 @@ mkdir -p "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/bazel
 mkdir -p "${ENVOY_CI_DIR}"/bazel
 ln -sf "${ENVOY_SRCDIR}"/bazel/get_workspace_status "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/bazel/
 ln -sf "${ENVOY_SRCDIR}"/bazel/get_workspace_status "${ENVOY_CI_DIR}"/bazel/
-cp -f "${ENVOY_SRCDIR}"/.bazelrc "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/
-cp -f "${ENVOY_SRCDIR}"/.bazelrc "${ENVOY_CI_DIR}"/
+ln -sf "${ENVOY_SRCDIR}"/.bazelrc "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/
+ln -sf "${ENVOY_SRCDIR}"/.bazelrc "${ENVOY_CI_DIR}"/
 # TODO(PiotrSikora): remove once we deprecate tools/bazel.rc in favor of .bazelrc.
 mkdir -p "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/tools
 mkdir -p "${ENVOY_CI_DIR}"/tools


### PR DESCRIPTION
Fixes: cp: '/source/.bazelrc' and '/source/ci/.bazelrc' are the same file.

*Risk Level*: Low
*Testing*: ./ci/run_envoy_docker.sh './ci/do_circle_ci.sh bazel.dev'
*Docs Changes*: n/a
*Release Notes*: n/a

Missed in #4771.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>