### PR TITLE
refactor: extract proto map processing to Config::Utility and use absl::flat_hash_map for storage.

### DIFF
--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -25,6 +25,7 @@
 #include "common/router/metadatamatchcriteria_impl.h"
 #include "common/router/router_ratelimit.h"
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/types/optional.h"
 
 namespace Envoy {
@@ -56,7 +57,7 @@ public:
   const RouteSpecificFilterConfig* get(const std::string& name) const;
 
 private:
-  std::unordered_map<std::string, RouteSpecificFilterConfigConstSharedPtr> configs_;
+  const absl::flat_hash_map<std::string, RouteSpecificFilterConfigConstSharedPtr> configs_;
 };
 
 class RouteEntryImplBase;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -42,6 +42,7 @@
 
 #include "server/init_manager_impl.h"
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/synchronization/mutex.h"
 
 namespace Envoy {
@@ -447,7 +448,8 @@ private:
   mutable ClusterLoadReportStats load_report_stats_;
   const uint64_t features_;
   const Http::Http2Settings http2_settings_;
-  const std::map<std::string, ProtocolOptionsConfigConstSharedPtr> extension_protocol_options_;
+  const absl::flat_hash_map<std::string, ProtocolOptionsConfigConstSharedPtr>
+      extension_protocol_options_;
   mutable ResourceManagers resource_managers_;
   const std::string maintenance_mode_runtime_key_;
   const Network::Address::InstanceConstSharedPtr source_address_;


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

*Description*:
For #4475. Not very clean, but will make add google.protobuf.Any support easier.

*Risk Level*: Low
*Testing*: CI (refactor shouldn't affect existing tests)
*Docs Changes*: N/A
*Release Notes*: N/A