### PR TITLE
logging: Protect the spdlog formatter which is not thread-safe

### DIFF
--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -99,6 +99,7 @@ envoy_cc_library(
     name = "minimal_logger_lib",
     srcs = ["logger.cc"],
     hdrs = ["logger.h"],
+    external_deps = ["abseil_synchronization"],
     deps = [
         ":lock_guard_lib",
         ":macros",


### PR DESCRIPTION
Signed-off-by: Joshua Marantz <jmarantz@google.com>

*Description*: Add mutex protection for spdlog's formatter, which is not thread-safe.
*Risk Level*: possible mutex contention, but should be trackable with admin /contention
*Testing*: //test/common/common/...
*Docs Changes*: n/a
*Release Notes*: n/a
*Fixes: #4977 

