### PR TITLE
 memory: Add additional tcmalloc stats

### DIFF
--- a/api/envoy/admin/v2alpha/memory.proto
+++ b/api/envoy/admin/v2alpha/memory.proto
@@ -22,9 +22,9 @@ message Memory {
   // usage. This is an alias for `tcmalloc.pageheap_unmapped_bytes`.
   uint64 pageheap_unmapped = 3;
 
-   // The number of bytes in free, mapped pages in the page heap. These bytes always count towards
-   // virtual memory usage, and unless the underlying memory is swapped out by the OS, they also
-   // count towards physical memory usage. This is an alias for `tcmalloc.pageheap_free_bytes`.
+  // The number of bytes in free, mapped pages in the page heap. These bytes always count towards
+  // virtual memory usage, and unless the underlying memory is swapped out by the OS, they also
+  // count towards physical memory usage. This is an alias for `tcmalloc.pageheap_free_bytes`.
   uint64 pageheap_free = 4;
 
   // The amount of memory used by the TCMalloc thread caches (for small objects). This is an alias

--- a/api/envoy/admin/v2alpha/memory.proto
+++ b/api/envoy/admin/v2alpha/memory.proto
@@ -16,4 +16,18 @@ message Memory {
   // The number of bytes reserved by the heap but not necessarily allocated. This is an alias for
   // `generic.heap_size`.
   uint64 heap_size = 2;
+
+  // The number of bytes in free, unmapped pages in the page heap. These bytes always count towards
+  // virtual memory usage, and depending on the OS, typically do not count towards physical memory
+  // usage. This is an alias for `tcmalloc.pageheap_unmapped_bytes`.
+  uint64 pageheap_unmapped = 3;
+
+   // The number of bytes in free, mapped pages in the page heap. These bytes always count towards
+   // virtual memory usage, and unless the underlying memory is swapped out by the OS, they also
+   // count towards physical memory usage. This is an alias for `tcmalloc.pageheap_free_bytes`.
+  uint64 pageheap_free = 4;
+
+  // The amount of memory used by the TCMalloc thread caches (for small objects). This is an alias
+  // for `tcmalloc.current_total_thread_cache_bytes`.
+  uint64 total_thread_cache = 5;
 }

--- a/source/common/memory/stats.cc
+++ b/source/common/memory/stats.cc
@@ -23,7 +23,8 @@ uint64_t Stats::totalCurrentlyReserved() {
 
 uint64_t Stats::totalThreadCacheBytes() {
   size_t value = 0;
-  MallocExtension::instance()->GetNumericProperty("tcmalloc.current_total_thread_cache_bytes", &value);
+  MallocExtension::instance()->GetNumericProperty("tcmalloc.current_total_thread_cache_bytes",
+                                                  &value);
   return value;
 }
 

--- a/source/common/memory/stats.cc
+++ b/source/common/memory/stats.cc
@@ -21,6 +21,18 @@ uint64_t Stats::totalCurrentlyReserved() {
   return value;
 }
 
+uint64_t Stats::totalThreadCacheBytes() {
+  size_t value = 0;
+  MallocExtension::instance()->GetNumericProperty("tcmalloc.current_total_thread_cache_bytes", &value);
+  return value;
+}
+
+uint64_t Stats::totalPageHeapFree() {
+  size_t value = 0;
+  MallocExtension::instance()->GetNumericProperty("tcmalloc.pageheap_free_bytes", &value);
+  return value;
+}
+
 uint64_t Stats::totalPageHeapUnmapped() {
   size_t value = 0;
   MallocExtension::instance()->GetNumericProperty("tcmalloc.pageheap_unmapped_bytes", &value);
@@ -36,8 +48,10 @@ namespace Envoy {
 namespace Memory {
 
 uint64_t Stats::totalCurrentlyAllocated() { return 0; }
+uint64_t Stats::totalThreadCacheBytes() { return 0; }
 uint64_t Stats::totalCurrentlyReserved() { return 0; }
 uint64_t Stats::totalPageHeapUnmapped() { return 0; }
+uint64_t Stats::totalPageHeapFree() { return 0; }
 
 } // namespace Memory
 } // namespace Envoy

--- a/source/common/memory/stats.h
+++ b/source/common/memory/stats.h
@@ -22,9 +22,23 @@ public:
   static uint64_t totalCurrentlyReserved();
 
   /**
-   * @return uint64_t the number of bytes in free, unmapped pages in the page heap.
+   * @return uint64_t the amount of memory used by the TCMalloc thread caches (for small objects).
+   */
+  static uint64_t totalThreadCacheBytes();
+
+  /**
+   * @return uint64_t the number of bytes in free, unmapped pages in the page heap. These bytes
+   *                  always count towards virtual memory usage, and depending on the OS, typically
+   *                  do not count towards physical memory usage.
    */
   static uint64_t totalPageHeapUnmapped();
+
+  /**
+   * @return uint64_t the number of bytes in free, mapped pages in the page heap. These bytes always
+   *                  count towards virtual memory usage, and unless the underlying memory is
+   *                  swapped out by the OS, they also count towards physical memory usage.
+   */
+  static uint64_t totalPageHeapFree();
 };
 
 } // namespace Memory

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -529,6 +529,9 @@ Http::Code AdminImpl::handlerMemory(absl::string_view, Http::HeaderMap& response
   envoy::admin::v2alpha::Memory memory;
   memory.set_allocated(Memory::Stats::totalCurrentlyAllocated());
   memory.set_heap_size(Memory::Stats::totalCurrentlyReserved());
+  memory.set_total_thread_cache(Memory::Stats::totalThreadCacheBytes());
+  memory.set_pageheap_unmapped(Memory::Stats::totalPageHeapUnmapped());
+  memory.set_pageheap_free(Memory::Stats::totalPageHeapFree());
   response.add(MessageUtil::getJsonStringFromMessage(memory, true)); // pretty-print
   return Http::Code::OK;
 }

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -838,7 +838,10 @@ TEST_P(AdminInstanceTest, Memory) {
   envoy::admin::v2alpha::Memory output_proto;
   MessageUtil::loadFromJson(output_json, output_proto);
   EXPECT_THAT(output_proto, AllOf(Property(&envoy::admin::v2alpha::Memory::allocated, Ge(0)),
-                                  Property(&envoy::admin::v2alpha::Memory::heap_size, Ge(0))));
+                                  Property(&envoy::admin::v2alpha::Memory::heap_size, Ge(0)),
+                                  Property(&envoy::admin::v2alpha::Memory::pageheap_unmapped, Ge(0)),
+                                  Property(&envoy::admin::v2alpha::Memory::pageheap_free, Ge(0)),
+                                  Property(&envoy::admin::v2alpha::Memory::total_thread_cache, Ge(0))));
 }
 
 TEST_P(AdminInstanceTest, ContextThatReturnsNullCertDetails) {

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -837,11 +837,12 @@ TEST_P(AdminInstanceTest, Memory) {
   const std::string output_json = response.toString();
   envoy::admin::v2alpha::Memory output_proto;
   MessageUtil::loadFromJson(output_json, output_proto);
-  EXPECT_THAT(output_proto, AllOf(Property(&envoy::admin::v2alpha::Memory::allocated, Ge(0)),
-                                  Property(&envoy::admin::v2alpha::Memory::heap_size, Ge(0)),
-                                  Property(&envoy::admin::v2alpha::Memory::pageheap_unmapped, Ge(0)),
-                                  Property(&envoy::admin::v2alpha::Memory::pageheap_free, Ge(0)),
-                                  Property(&envoy::admin::v2alpha::Memory::total_thread_cache, Ge(0))));
+  EXPECT_THAT(output_proto,
+              AllOf(Property(&envoy::admin::v2alpha::Memory::allocated, Ge(0)),
+                    Property(&envoy::admin::v2alpha::Memory::heap_size, Ge(0)),
+                    Property(&envoy::admin::v2alpha::Memory::pageheap_unmapped, Ge(0)),
+                    Property(&envoy::admin::v2alpha::Memory::pageheap_free, Ge(0)),
+                    Property(&envoy::admin::v2alpha::Memory::total_thread_cache, Ge(0))));
 }
 
 TEST_P(AdminInstanceTest, ContextThatReturnsNullCertDetails) {


### PR DESCRIPTION
*Description*:
This patch adds more TCMalloc stats to memory.proto and exposes them via the `/memory` admin endpoint. Specifically, 3 additional stats have been exposed via the admin endpoint:

- Total thread cache bytes
- Total page heap unmapped bytes (these already existed in the memory.proto)
- Total page heap free bytes

*Risk Level*:
Low.

*Testing*:
Additional unit testing.

*Docs Changes*:
n/a

*Release Notes*:
n/a