### PR TITLE
config: refactor tracers to use Config::Utility

### DIFF
--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -218,3 +218,13 @@ envoy_cc_library(
         "//source/common/singleton:const_singleton",
     ],
 )
+
+envoy_cc_library(
+    name = "tracer_config_interface",
+    hdrs = ["tracer_config.h"],
+    deps = [
+        ":instance_interface",
+        "//source/common/protobuf",
+        "@envoy_api//envoy/config/trace/v2:trace_cc",
+    ],
+)

--- a/include/envoy/server/tracer_config.h
+++ b/include/envoy/server/tracer_config.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "envoy/common/pure.h"
+#include "envoy/config/trace/v2/trace.pb.h"
+#include "envoy/server/instance.h"
+#include "envoy/tracing/http_tracer.h"
+
+#include "common/protobuf/protobuf.h"
+
+namespace Envoy {
+namespace Server {
+namespace Configuration {
+
+/**
+ * Implemented by each Tracer and registered via Registry::registerFactory() or the convenience
+ * class RegisterFactory.
+ */
+class TracerFactory {
+public:
+  virtual ~TracerFactory() {}
+
+  /**
+   * Create a particular HttpTracer implementation. If the implementation is unable to produce an
+   * HttpTracer with the provided parameters, it should throw an EnvoyException in the case of
+   * general error or a Json::Exception if the json configuration is erroneous. The returned
+   * pointer should always be valid.
+   * @param json_config supplies the general json configuration for the HttpTracer
+   * @param server supplies the server instance
+   */
+  virtual Tracing::HttpTracerPtr
+  createHttpTracer(const envoy::config::trace::v2::Tracing& configuration, Instance& server) PURE;
+
+  /**
+   * @return ProtobufTypes::MessagePtr create empty config proto message for v2. The tracing
+   *         config, which arrives in an opaque google.protobuf.Struct message, will be converted to
+   *         JSON and then parsed into this empty proto.
+   */
+  virtual ProtobufTypes::MessagePtr createEmptyConfigProto() PURE;
+
+  /**
+   * Returns the identifying name for a particular implementation of tracer produced by the
+   * factory.
+   */
+  virtual std::string name() PURE;
+};
+
+} // namespace Configuration
+} // namespace Server
+} // namespace Envoy

--- a/include/envoy/server/tracer_config.h
+++ b/include/envoy/server/tracer_config.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "envoy/common/pure.h"
-#include "envoy/config/trace/v2/trace.pb.h"
 #include "envoy/server/instance.h"
 #include "envoy/tracing/http_tracer.h"
 
@@ -24,16 +23,15 @@ public:
    * HttpTracer with the provided parameters, it should throw an EnvoyException in the case of
    * general error or a Json::Exception if the json configuration is erroneous. The returned
    * pointer should always be valid.
-   * @param json_config supplies the general json configuration for the HttpTracer
+   * @param config supplies the proto configuration for the HttpTracer
    * @param server supplies the server instance
    */
-  virtual Tracing::HttpTracerPtr
-  createHttpTracer(const envoy::config::trace::v2::Tracing& configuration, Instance& server) PURE;
+  virtual Tracing::HttpTracerPtr createHttpTracer(const Protobuf::Message& config,
+                                                  Instance& server) PURE;
 
   /**
    * @return ProtobufTypes::MessagePtr create empty config proto message for v2. The tracing
-   *         config, which arrives in an opaque google.protobuf.Struct message, will be converted to
-   *         JSON and then parsed into this empty proto.
+   *         config, which arrives in an opaque message, will be parsed into this empty proto.
    */
   virtual ProtobufTypes::MessagePtr createEmptyConfigProto() PURE;
 

--- a/source/extensions/tracers/common/BUILD
+++ b/source/extensions/tracers/common/BUILD
@@ -1,0 +1,19 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "factory_base_lib",
+    hdrs = ["factory_base.h"],
+    deps = [
+        "//include/envoy/server:instance_interface",
+        "//include/envoy/server:tracer_config_interface",
+        "//source/common/config:utility_lib",
+    ],
+)

--- a/source/extensions/tracers/common/factory_base.h
+++ b/source/extensions/tracers/common/factory_base.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "envoy/server/instance.h"
+#include "envoy/server/tracer_config.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace Common {
+
+/**
+ * Common base class for tracer factory registrations. Removes a substantial amount of
+ * boilerplate.
+ */
+template <class ConfigProto> class FactoryBase : public Server::Configuration::TracerFactory {
+public:
+  // Server::Configuration::TracerFactory
+  virtual Tracing::HttpTracerPtr
+  createHttpTracer(const envoy::config::trace::v2::Tracing& configuration,
+                   Server::Instance& server) override {
+
+    ProtobufTypes::MessagePtr config_ptr = createEmptyConfigProto();
+
+    if (configuration.http().has_config()) {
+      MessageUtil::jsonConvert(configuration.http().config(), *config_ptr);
+    }
+
+    return createHttpTracerTyped(MessageUtil::downcastAndValidate<const ConfigProto&>(*config_ptr),
+                                 server);
+  }
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<ConfigProto>();
+  }
+
+  std::string name() override { return name_; }
+
+protected:
+  FactoryBase(const std::string& name) : name_(name) {}
+
+private:
+  virtual Tracing::HttpTracerPtr createHttpTracerTyped(const ConfigProto& proto_config,
+                                                       Server::Instance& server) PURE;
+
+  const std::string name_;
+};
+
+} // namespace Common
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/common/factory_base.h
+++ b/source/extensions/tracers/common/factory_base.h
@@ -15,17 +15,9 @@ namespace Common {
 template <class ConfigProto> class FactoryBase : public Server::Configuration::TracerFactory {
 public:
   // Server::Configuration::TracerFactory
-  virtual Tracing::HttpTracerPtr
-  createHttpTracer(const envoy::config::trace::v2::Tracing& configuration,
-                   Server::Instance& server) override {
-
-    ProtobufTypes::MessagePtr config_ptr = createEmptyConfigProto();
-
-    if (configuration.http().has_config()) {
-      MessageUtil::jsonConvert(configuration.http().config(), *config_ptr);
-    }
-
-    return createHttpTracerTyped(MessageUtil::downcastAndValidate<const ConfigProto&>(*config_ptr),
+  virtual Tracing::HttpTracerPtr createHttpTracer(const Protobuf::Message& config,
+                                                  Server::Instance& server) override {
+    return createHttpTracerTyped(MessageUtil::downcastAndValidate<const ConfigProto&>(config),
                                  server);
   }
 

--- a/source/extensions/tracers/datadog/BUILD
+++ b/source/extensions/tracers/datadog/BUILD
@@ -33,7 +33,7 @@ envoy_cc_library(
     hdrs = ["config.h"],
     deps = [
         ":datadog_tracer_lib",
-        "//include/envoy/server:tracer_config_interface",
         "//source/extensions/tracers:well_known_names",
+        "//source/extensions/tracers/common:factory_base_lib",
     ],
 )

--- a/source/extensions/tracers/datadog/BUILD
+++ b/source/extensions/tracers/datadog/BUILD
@@ -20,10 +20,10 @@ envoy_cc_library(
     ],
     external_deps = ["dd_opentracing_cpp"],
     deps = [
+        "//source/common/config:utility_lib",
         "//source/common/tracing:http_tracer_lib",
         "//source/extensions/tracers:well_known_names",
         "//source/extensions/tracers/common/ot:opentracing_driver_lib",
-        "//source/server:configuration_lib",
     ],
 )
 
@@ -33,7 +33,7 @@ envoy_cc_library(
     hdrs = ["config.h"],
     deps = [
         ":datadog_tracer_lib",
+        "//include/envoy/server:tracer_config_interface",
         "//source/extensions/tracers:well_known_names",
-        "//source/server:configuration_lib",
     ],
 )

--- a/source/extensions/tracers/datadog/config.cc
+++ b/source/extensions/tracers/datadog/config.cc
@@ -15,26 +15,15 @@ namespace Extensions {
 namespace Tracers {
 namespace Datadog {
 
-Tracing::HttpTracerPtr
-DatadogTracerFactory::createHttpTracer(const envoy::config::trace::v2::Tracing& configuration,
-                                       Server::Instance& server) {
+DatadogTracerFactory::DatadogTracerFactory() : FactoryBase(TracerNames::get().Datadog) {}
 
-  ProtobufTypes::MessagePtr config_ptr = createEmptyConfigProto();
-
-  if (configuration.http().has_config()) {
-    MessageUtil::jsonConvert(configuration.http().config(), *config_ptr);
-  }
-
-  const auto& datadog_config =
-      dynamic_cast<const envoy::config::trace::v2::DatadogConfig&>(*config_ptr);
-
-  Tracing::DriverPtr datadog_driver{
-      std::make_unique<Driver>(datadog_config, server.clusterManager(), server.stats(),
-                               server.threadLocal(), server.runtime())};
+Tracing::HttpTracerPtr DatadogTracerFactory::createHttpTracerTyped(
+    const envoy::config::trace::v2::DatadogConfig& proto_config, Server::Instance& server) {
+  Tracing::DriverPtr datadog_driver =
+      std::make_unique<Driver>(proto_config, server.clusterManager(), server.stats(),
+                               server.threadLocal(), server.runtime());
   return std::make_unique<Tracing::HttpTracerImpl>(std::move(datadog_driver), server.localInfo());
 }
-
-std::string DatadogTracerFactory::name() { return TracerNames::get().Datadog; }
 
 /**
  * Static registration for the Datadog tracer. @see RegisterFactory.

--- a/source/extensions/tracers/datadog/config.h
+++ b/source/extensions/tracers/datadog/config.h
@@ -2,8 +2,9 @@
 
 #include <string>
 
-#include "envoy/server/instance.h"
-#include "envoy/server/tracer_config.h"
+#include "envoy/config/trace/v2/trace.pb.validate.h"
+
+#include "extensions/tracers/common/factory_base.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -13,17 +14,15 @@ namespace Datadog {
 /**
  * Config registration for the Datadog tracer. @see TracerFactory.
  */
-class DatadogTracerFactory : public Server::Configuration::TracerFactory {
+class DatadogTracerFactory : public Common::FactoryBase<envoy::config::trace::v2::DatadogConfig> {
 public:
-  // TracerFactory
-  Tracing::HttpTracerPtr createHttpTracer(const envoy::config::trace::v2::Tracing& configuration,
-                                          Server::Instance& server) override;
+  DatadogTracerFactory();
 
-  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return std::make_unique<envoy::config::trace::v2::DatadogConfig>();
-  }
-
-  std::string name() override;
+private:
+  // FactoryBase
+  Tracing::HttpTracerPtr
+  createHttpTracerTyped(const envoy::config::trace::v2::DatadogConfig& proto_config,
+                        Server::Instance& server) override;
 };
 
 } // namespace Datadog

--- a/source/extensions/tracers/datadog/config.h
+++ b/source/extensions/tracers/datadog/config.h
@@ -3,8 +3,7 @@
 #include <string>
 
 #include "envoy/server/instance.h"
-
-#include "server/configuration_impl.h"
+#include "envoy/server/tracer_config.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/tracers/dynamic_ot/BUILD
+++ b/source/extensions/tracers/dynamic_ot/BUILD
@@ -30,7 +30,7 @@ envoy_cc_library(
     hdrs = ["config.h"],
     deps = [
         ":dynamic_opentracing_driver_lib",
-        "//include/envoy/server:tracer_config_interface",
         "//source/extensions/tracers:well_known_names",
+        "//source/extensions/tracers/common:factory_base_lib",
     ],
 )

--- a/source/extensions/tracers/dynamic_ot/BUILD
+++ b/source/extensions/tracers/dynamic_ot/BUILD
@@ -30,7 +30,7 @@ envoy_cc_library(
     hdrs = ["config.h"],
     deps = [
         ":dynamic_opentracing_driver_lib",
+        "//include/envoy/server:tracer_config_interface",
         "//source/extensions/tracers:well_known_names",
-        "//source/server:configuration_lib",
     ],
 )

--- a/source/extensions/tracers/dynamic_ot/config.cc
+++ b/source/extensions/tracers/dynamic_ot/config.cc
@@ -13,25 +13,17 @@ namespace Extensions {
 namespace Tracers {
 namespace DynamicOt {
 
-Tracing::HttpTracerPtr DynamicOpenTracingTracerFactory::createHttpTracer(
-    const envoy::config::trace::v2::Tracing& configuration, Server::Instance& server) {
-  ProtobufTypes::MessagePtr config_ptr = createEmptyConfigProto();
+DynamicOpenTracingTracerFactory::DynamicOpenTracingTracerFactory()
+    : FactoryBase(TracerNames::get().DynamicOt) {}
 
-  if (configuration.http().has_config()) {
-    MessageUtil::jsonConvert(configuration.http().config(), *config_ptr);
-  }
-
-  const auto& dynaot_config =
-      dynamic_cast<const envoy::config::trace::v2::DynamicOtConfig&>(*config_ptr);
-
-  const std::string library = dynaot_config.library();
-  const std::string config = MessageUtil::getJsonStringFromMessage(dynaot_config.config());
-  Tracing::DriverPtr dynamic_driver{
-      std::make_unique<DynamicOpenTracingDriver>(server.stats(), library, config)};
+Tracing::HttpTracerPtr DynamicOpenTracingTracerFactory::createHttpTracerTyped(
+    const envoy::config::trace::v2::DynamicOtConfig& proto_config, Server::Instance& server) {
+  const std::string library = proto_config.library();
+  const std::string config = MessageUtil::getJsonStringFromMessage(proto_config.config());
+  Tracing::DriverPtr dynamic_driver =
+      std::make_unique<DynamicOpenTracingDriver>(server.stats(), library, config);
   return std::make_unique<Tracing::HttpTracerImpl>(std::move(dynamic_driver), server.localInfo());
 }
-
-std::string DynamicOpenTracingTracerFactory::name() { return TracerNames::get().DynamicOt; }
 
 /**
  * Static registration for the dynamic opentracing tracer. @see RegisterFactory.

--- a/source/extensions/tracers/dynamic_ot/config.h
+++ b/source/extensions/tracers/dynamic_ot/config.h
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <string>
+#include "envoy/config/trace/v2/trace.pb.validate.h"
 
-#include "envoy/server/instance.h"
-#include "envoy/server/tracer_config.h"
+#include "extensions/tracers/common/factory_base.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -13,17 +12,16 @@ namespace DynamicOt {
 /**
  * Config registration for the dynamic opentracing tracer. @see TracerFactory.
  */
-class DynamicOpenTracingTracerFactory : public Server::Configuration::TracerFactory {
+class DynamicOpenTracingTracerFactory
+    : public Common::FactoryBase<envoy::config::trace::v2::DynamicOtConfig> {
 public:
-  // TracerFactory
-  Tracing::HttpTracerPtr createHttpTracer(const envoy::config::trace::v2::Tracing& configuration,
-                                          Server::Instance& server) override;
+  DynamicOpenTracingTracerFactory();
 
-  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return std::make_unique<envoy::config::trace::v2::DynamicOtConfig>();
-  }
-
-  std::string name() override;
+private:
+  // FactoryBase
+  Tracing::HttpTracerPtr
+  createHttpTracerTyped(const envoy::config::trace::v2::DynamicOtConfig& configuration,
+                        Server::Instance& server) override;
 };
 
 } // namespace DynamicOt

--- a/source/extensions/tracers/dynamic_ot/config.h
+++ b/source/extensions/tracers/dynamic_ot/config.h
@@ -3,8 +3,7 @@
 #include <string>
 
 #include "envoy/server/instance.h"
-
-#include "server/configuration_impl.h"
+#include "envoy/server/tracer_config.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/tracers/lightstep/BUILD
+++ b/source/extensions/tracers/lightstep/BUILD
@@ -20,10 +20,10 @@ envoy_cc_library(
     ],
     external_deps = ["lightstep"],
     deps = [
+        "//source/common/config:utility_lib",
         "//source/common/tracing:http_tracer_lib",
         "//source/extensions/tracers:well_known_names",
         "//source/extensions/tracers/common/ot:opentracing_driver_lib",
-        "//source/server:configuration_lib",
     ],
 )
 
@@ -33,7 +33,7 @@ envoy_cc_library(
     hdrs = ["config.h"],
     deps = [
         ":lightstep_tracer_lib",
+        "//include/envoy/server:tracer_config_interface",
         "//source/extensions/tracers:well_known_names",
-        "//source/server:configuration_lib",
     ],
 )

--- a/source/extensions/tracers/lightstep/BUILD
+++ b/source/extensions/tracers/lightstep/BUILD
@@ -33,7 +33,7 @@ envoy_cc_library(
     hdrs = ["config.h"],
     deps = [
         ":lightstep_tracer_lib",
-        "//include/envoy/server:tracer_config_interface",
         "//source/extensions/tracers:well_known_names",
+        "//source/extensions/tracers/common:factory_base_lib",
     ],
 )

--- a/source/extensions/tracers/lightstep/config.cc
+++ b/source/extensions/tracers/lightstep/config.cc
@@ -15,32 +15,21 @@ namespace Extensions {
 namespace Tracers {
 namespace Lightstep {
 
-Tracing::HttpTracerPtr
-LightstepTracerFactory::createHttpTracer(const envoy::config::trace::v2::Tracing& configuration,
-                                         Server::Instance& server) {
-  ProtobufTypes::MessagePtr config_ptr = createEmptyConfigProto();
+LightstepTracerFactory::LightstepTracerFactory() : FactoryBase(TracerNames::get().Lightstep) {}
 
-  if (configuration.http().has_config()) {
-    MessageUtil::jsonConvert(configuration.http().config(), *config_ptr);
-  }
-
-  const auto& lightstep_config =
-      dynamic_cast<const envoy::config::trace::v2::LightstepConfig&>(*config_ptr);
-
-  std::unique_ptr<lightstep::LightStepTracerOptions> opts(new lightstep::LightStepTracerOptions());
-  const auto access_token_file = server.api().fileReadToEnd(lightstep_config.access_token_file());
+Tracing::HttpTracerPtr LightstepTracerFactory::createHttpTracerTyped(
+    const envoy::config::trace::v2::LightstepConfig& proto_config, Server::Instance& server) {
+  auto opts = std::make_unique<lightstep::LightStepTracerOptions>();
+  const auto access_token_file = server.api().fileReadToEnd(proto_config.access_token_file());
   const auto access_token_sv = StringUtil::rtrim(access_token_file);
   opts->access_token.assign(access_token_sv.data(), access_token_sv.size());
   opts->component_name = server.localInfo().clusterName();
 
-  Tracing::DriverPtr lightstep_driver{std::make_unique<LightStepDriver>(
-      lightstep_config, server.clusterManager(), server.stats(), server.threadLocal(),
-      server.runtime(), std::move(opts),
-      Common::Ot::OpenTracingDriver::PropagationMode::TracerNative)};
+  Tracing::DriverPtr lightstep_driver = std::make_unique<LightStepDriver>(
+      proto_config, server.clusterManager(), server.stats(), server.threadLocal(), server.runtime(),
+      std::move(opts), Common::Ot::OpenTracingDriver::PropagationMode::TracerNative);
   return std::make_unique<Tracing::HttpTracerImpl>(std::move(lightstep_driver), server.localInfo());
 }
-
-std::string LightstepTracerFactory::name() { return TracerNames::get().Lightstep; }
 
 /**
  * Static registration for the lightstep tracer. @see RegisterFactory.

--- a/source/extensions/tracers/lightstep/config.h
+++ b/source/extensions/tracers/lightstep/config.h
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <string>
+#include "envoy/config/trace/v2/trace.pb.validate.h"
 
-#include "envoy/server/instance.h"
-#include "envoy/server/tracer_config.h"
+#include "extensions/tracers/common/factory_base.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -13,17 +12,16 @@ namespace Lightstep {
 /**
  * Config registration for the lightstep tracer. @see TracerFactory.
  */
-class LightstepTracerFactory : public Server::Configuration::TracerFactory {
+class LightstepTracerFactory
+    : public Common::FactoryBase<envoy::config::trace::v2::LightstepConfig> {
 public:
-  // TracerFactory
-  Tracing::HttpTracerPtr createHttpTracer(const envoy::config::trace::v2::Tracing& configuration,
-                                          Server::Instance& server) override;
+  LightstepTracerFactory();
 
-  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return std::make_unique<envoy::config::trace::v2::LightstepConfig>();
-  }
-
-  std::string name() override;
+private:
+  // FactoryBase
+  Tracing::HttpTracerPtr
+  createHttpTracerTyped(const envoy::config::trace::v2::LightstepConfig& proto_config,
+                        Server::Instance& server) override;
 };
 
 } // namespace Lightstep

--- a/source/extensions/tracers/lightstep/config.h
+++ b/source/extensions/tracers/lightstep/config.h
@@ -3,8 +3,7 @@
 #include <string>
 
 #include "envoy/server/instance.h"
-
-#include "server/configuration_impl.h"
+#include "envoy/server/tracer_config.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/tracers/zipkin/BUILD
+++ b/source/extensions/tracers/zipkin/BUILD
@@ -66,7 +66,7 @@ envoy_cc_library(
     hdrs = ["config.h"],
     deps = [
         ":zipkin_lib",
-        "//include/envoy/server:tracer_config_interface",
         "//source/extensions/tracers:well_known_names",
+        "//source/extensions/tracers/common:factory_base_lib",
     ],
 )

--- a/source/extensions/tracers/zipkin/BUILD
+++ b/source/extensions/tracers/zipkin/BUILD
@@ -48,6 +48,7 @@ envoy_cc_library(
         "//source/common/common:enum_to_int",
         "//source/common/common:hex_lib",
         "//source/common/common:utility_lib",
+        "//source/common/config:utility_lib",
         "//source/common/http:header_map_lib",
         "//source/common/http:message_lib",
         "//source/common/http:utility_lib",
@@ -56,7 +57,6 @@ envoy_cc_library(
         "//source/common/singleton:const_singleton",
         "//source/common/tracing:http_tracer_lib",
         "//source/extensions/tracers:well_known_names",
-        "//source/server:configuration_lib",
     ],
 )
 
@@ -65,8 +65,8 @@ envoy_cc_library(
     srcs = ["config.cc"],
     hdrs = ["config.h"],
     deps = [
+        ":zipkin_lib",
+        "//include/envoy/server:tracer_config_interface",
         "//source/extensions/tracers:well_known_names",
-        "//source/extensions/tracers/zipkin:zipkin_lib",
-        "//source/server:configuration_lib",
     ],
 )

--- a/source/extensions/tracers/zipkin/config.cc
+++ b/source/extensions/tracers/zipkin/config.cc
@@ -13,29 +13,16 @@ namespace Extensions {
 namespace Tracers {
 namespace Zipkin {
 
-Tracing::HttpTracerPtr
-ZipkinTracerFactory::createHttpTracer(const envoy::config::trace::v2::Tracing& configuration,
-                                      Server::Instance& server) {
+ZipkinTracerFactory::ZipkinTracerFactory() : FactoryBase(TracerNames::get().Zipkin) {}
 
-  Envoy::Runtime::RandomGenerator& rand = server.random();
-  ProtobufTypes::MessagePtr config_ptr = createEmptyConfigProto();
+Tracing::HttpTracerPtr ZipkinTracerFactory::createHttpTracerTyped(
+    const envoy::config::trace::v2::ZipkinConfig& proto_config, Server::Instance& server) {
+  Tracing::DriverPtr zipkin_driver = std::make_unique<Zipkin::Driver>(
+      proto_config, server.clusterManager(), server.stats(), server.threadLocal(), server.runtime(),
+      server.localInfo(), server.random(), server.timeSystem());
 
-  if (configuration.http().has_config()) {
-    MessageUtil::jsonConvert(configuration.http().config(), *config_ptr);
-  }
-
-  const auto& zipkin_config =
-      dynamic_cast<const envoy::config::trace::v2::ZipkinConfig&>(*config_ptr);
-
-  Tracing::DriverPtr zipkin_driver{std::make_unique<Zipkin::Driver>(
-      zipkin_config, server.clusterManager(), server.stats(), server.threadLocal(),
-      server.runtime(), server.localInfo(), rand, server.timeSystem())};
-
-  return Tracing::HttpTracerPtr(
-      new Tracing::HttpTracerImpl(std::move(zipkin_driver), server.localInfo()));
+  return std::make_unique<Tracing::HttpTracerImpl>(std::move(zipkin_driver), server.localInfo());
 }
-
-std::string ZipkinTracerFactory::name() { return TracerNames::get().Zipkin; }
 
 /**
  * Static registration for the lightstep tracer. @see RegisterFactory.

--- a/source/extensions/tracers/zipkin/config.h
+++ b/source/extensions/tracers/zipkin/config.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "envoy/server/instance.h"
-
-#include "server/configuration_impl.h"
+#include "envoy/server/tracer_config.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/tracers/zipkin/config.h
+++ b/source/extensions/tracers/zipkin/config.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "envoy/server/instance.h"
-#include "envoy/server/tracer_config.h"
+#include "envoy/config/trace/v2/trace.pb.validate.h"
+
+#include "extensions/tracers/common/factory_base.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -11,17 +12,15 @@ namespace Zipkin {
 /**
  * Config registration for the zipkin tracer. @see TracerFactory.
  */
-class ZipkinTracerFactory : public Server::Configuration::TracerFactory {
+class ZipkinTracerFactory : public Common::FactoryBase<envoy::config::trace::v2::ZipkinConfig> {
 public:
-  // TracerFactory
-  Tracing::HttpTracerPtr createHttpTracer(const envoy::config::trace::v2::Tracing& configuration,
-                                          Server::Instance& server) override;
+  ZipkinTracerFactory();
 
-  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return std::make_unique<envoy::config::trace::v2::ZipkinConfig>();
-  }
-
-  std::string name() override;
+private:
+  // FactoryBase
+  Tracing::HttpTracerPtr
+  createHttpTracerTyped(const envoy::config::trace::v2::ZipkinConfig& proto_config,
+                        Server::Instance& server) override;
 };
 
 } // namespace Zipkin

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -32,6 +32,7 @@ envoy_cc_library(
         "//include/envoy/server:configuration_interface",
         "//include/envoy/server:filter_config_interface",
         "//include/envoy/server:instance_interface",
+        "//include/envoy/server:tracer_config_interface",
         "//include/envoy/ssl:context_manager_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:minimal_logger_lib",
@@ -45,7 +46,6 @@ envoy_cc_library(
         "//source/common/tracing:http_tracer_lib",
         "@envoy_api//envoy/api/v2:lds_cc",
         "@envoy_api//envoy/config/bootstrap/v2:bootstrap_cc",
-        "@envoy_api//envoy/config/trace/v2:trace_cc",
     ],
 )
 

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -10,6 +10,7 @@
 #include "envoy/network/connection.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/server/instance.h"
+#include "envoy/server/tracer_config.h"
 #include "envoy/ssl/context_manager.h"
 
 #include "common/common/assert.h"

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -105,7 +105,9 @@ void MainImpl::initializeTracers(const envoy::config::trace::v2::Tracing& config
 
   // Now see if there is a factory that will accept the config.
   auto& factory = Config::Utility::getAndCheckFactory<TracerFactory>(type);
-  http_tracer_ = factory.createHttpTracer(configuration, server);
+  ProtobufTypes::MessagePtr message =
+      Config::Utility::translateToFactoryConfig(configuration.http(), factory);
+  http_tracer_ = factory.createHttpTracer(*message, server);
 }
 
 void MainImpl::initializeStatsSinks(const envoy::config::bootstrap::v2::Bootstrap& bootstrap,

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -10,13 +10,11 @@
 #include <utility>
 
 #include "envoy/config/bootstrap/v2/bootstrap.pb.h"
-#include "envoy/config/trace/v2/trace.pb.h"
 #include "envoy/http/filter.h"
 #include "envoy/network/filter.h"
 #include "envoy/server/configuration.h"
 #include "envoy/server/filter_config.h"
 #include "envoy/server/instance.h"
-#include "envoy/tracing/http_tracer.h"
 
 #include "common/common/logger.h"
 #include "common/json/json_loader.h"
@@ -26,39 +24,6 @@
 namespace Envoy {
 namespace Server {
 namespace Configuration {
-
-/**
- * Implemented by each Tracer and registered via Registry::registerFactory() or the convenience
- * class RegisterFactory.
- */
-class TracerFactory {
-public:
-  virtual ~TracerFactory() {}
-
-  /**
-   * Create a particular HttpTracer implementation. If the implementation is unable to produce an
-   * HttpTracer with the provided parameters, it should throw an EnvoyException in the case of
-   * general error or a Json::Exception if the json configuration is erroneous. The returned
-   * pointer should always be valid.
-   * @param json_config supplies the general json configuration for the HttpTracer
-   * @param server supplies the server instance
-   */
-  virtual Tracing::HttpTracerPtr
-  createHttpTracer(const envoy::config::trace::v2::Tracing& configuration, Instance& server) PURE;
-
-  /**
-   * @return ProtobufTypes::MessagePtr create empty config proto message for v2. The tracing
-   *         config, which arrives in an opaque google.protobuf.Struct message, will be converted to
-   *         JSON and then parsed into this empty proto.
-   */
-  virtual ProtobufTypes::MessagePtr createEmptyConfigProto() PURE;
-
-  /**
-   * Returns the identifying name for a particular implementation of tracer produced by the
-   * factory.
-   */
-  virtual std::string name() PURE;
-};
 
 /**
  * Implemented for each Stats::Sink and registered via Registry::registerFactory() or

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -12,6 +12,7 @@
 #include "envoy/server/drain_manager.h"
 #include "envoy/server/guarddog.h"
 #include "envoy/server/instance.h"
+#include "envoy/server/tracer_config.h"
 #include "envoy/ssl/context_manager.h"
 #include "envoy/stats/stats_macros.h"
 #include "envoy/tracing/http_tracer.h"

--- a/test/extensions/tracers/datadog/config_test.cc
+++ b/test/extensions/tracers/datadog/config_test.cc
@@ -32,7 +32,8 @@ TEST(DatadogTracerConfigTest, DatadogHttpTracer) {
   MessageUtil::loadFromYaml(yaml_string, configuration);
 
   DatadogTracerFactory factory;
-  Tracing::HttpTracerPtr datadog_tracer = factory.createHttpTracer(configuration, server);
+  auto message = Config::Utility::translateToFactoryConfig(configuration.http(), factory);
+  Tracing::HttpTracerPtr datadog_tracer = factory.createHttpTracer(*message, server);
   EXPECT_NE(nullptr, datadog_tracer);
 }
 

--- a/test/extensions/tracers/dynamic_ot/config_test.cc
+++ b/test/extensions/tracers/dynamic_ot/config_test.cc
@@ -36,8 +36,8 @@ TEST(DynamicOtTracerConfigTest, DynamicOpentracingHttpTracer) {
   MessageUtil::loadFromYaml(yaml_string, configuration);
 
   DynamicOpenTracingTracerFactory factory;
-
-  const Tracing::HttpTracerPtr tracer = factory.createHttpTracer(configuration, server);
+  auto message = Config::Utility::translateToFactoryConfig(configuration.http(), factory);
+  const Tracing::HttpTracerPtr tracer = factory.createHttpTracer(*message, server);
   EXPECT_NE(nullptr, tracer);
 }
 

--- a/test/extensions/tracers/lightstep/config_test.cc
+++ b/test/extensions/tracers/lightstep/config_test.cc
@@ -32,7 +32,8 @@ TEST(LightstepTracerConfigTest, LightstepHttpTracer) {
   MessageUtil::loadFromYaml(yaml_string, configuration);
 
   LightstepTracerFactory factory;
-  Tracing::HttpTracerPtr lightstep_tracer = factory.createHttpTracer(configuration, server);
+  auto message = Config::Utility::translateToFactoryConfig(configuration.http(), factory);
+  Tracing::HttpTracerPtr lightstep_tracer = factory.createHttpTracer(*message, server);
   EXPECT_NE(nullptr, lightstep_tracer);
 }
 

--- a/test/extensions/tracers/zipkin/config_test.cc
+++ b/test/extensions/tracers/zipkin/config_test.cc
@@ -29,7 +29,8 @@ TEST(ZipkinTracerConfigTest, ZipkinHttpTracer) {
   MessageUtil::loadFromYaml(yaml_string, configuration);
 
   ZipkinTracerFactory factory;
-  Tracing::HttpTracerPtr zipkin_tracer = factory.createHttpTracer(configuration, server);
+  auto message = Config::Utility::translateToFactoryConfig(configuration.http(), factory);
+  Tracing::HttpTracerPtr zipkin_tracer = factory.createHttpTracer(*message, server);
   EXPECT_NE(nullptr, zipkin_tracer);
 }
 


### PR DESCRIPTION
*Description*:
Another PR for #4475. Refactor tracers config:
- move interface to include/
- Introduce FactoryBase to reduce boiler plate
- Use Config::Utility to convert opaque config

*Risk Level*: Low
*Testing*: CI
*Docs Changes*: N/A
*Release Notes*: N/A
