### PR TITLE
logger: Avoid superfluous creation of std::string.

### DIFF
--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -57,14 +57,14 @@ void DelegatingLogSink::log(const spdlog::details::log_msg& msg) {
   absl::ReleasableMutexLock lock(&format_mutex_);
   if (!formatter_) {
     lock.Release();
-    sink_->log(fmt::to_string(msg.raw));
+    sink_->log(absl::string_view(msg.raw.data(), msg.raw.size()));
     return;
   }
 
   fmt::memory_buffer formatted;
   formatter_->format(msg, formatted);
   lock.Release();
-  sink_->log(fmt::to_string(formatted));
+  sink_->log(absl::string_view(formatted.data(), formatted.size()));
 }
 
 DelegatingLogSinkPtr DelegatingLogSink::init() {


### PR DESCRIPTION
*Description*: @gabime (not in org) pointed out some extra string temps. This kills those.
*Risk Level*: low
*Testing*: //test/...
*Docs Changes*: n/a
*Release Notes*: n/a

