### PR TITLE
stats: adds a speed-test for accumulating http response stats

### DIFF
--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -4,6 +4,7 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
+    "envoy_cc_test_binary",
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_proto_library",
@@ -76,6 +77,22 @@ envoy_cc_test(
         "//source/common/http:header_map_lib",
         "//source/common/stats:stats_lib",
         "//test/mocks/stats:stats_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test_binary(
+    name = "codes_speed_test",
+    srcs = ["codes_speed_test.cc"],
+    external_deps = [
+        "benchmark",
+    ],
+    deps = [
+        "//source/common/common:empty_string",
+        "//source/common/http:codes_lib",
+        "//source/common/http:header_map_lib",
+        "//source/common/stats:isolated_store_lib",
+        "//source/common/stats:stats_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -90,10 +90,8 @@ envoy_cc_test_binary(
     deps = [
         "//source/common/common:empty_string",
         "//source/common/http:codes_lib",
-        "//source/common/http:header_map_lib",
         "//source/common/stats:isolated_store_lib",
         "//source/common/stats:stats_lib",
-        "//test/test_common:utility_lib",
     ],
 )
 

--- a/test/common/http/codes_speed_test.cc
+++ b/test/common/http/codes_speed_test.cc
@@ -10,13 +10,7 @@
 
 #include "common/common/empty_string.h"
 #include "common/http/codes.h"
-#include "common/http/header_map_impl.h"
 #include "common/stats/isolated_store_impl.h"
-
-#include "test/test_common/utility.h"
-
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 
 #include "testing/base/public/benchmark.h"
 
@@ -30,12 +24,10 @@ public:
                    const std::string& request_vcluster_name = EMPTY_STRING,
                    const std::string& from_az = EMPTY_STRING,
                    const std::string& to_az = EMPTY_STRING) {
-    //Http::CodeStats::ResponseStatInfo info{
     Http::CodeUtility::ResponseStatInfo info{
         global_store_,      cluster_scope_,        "prefix.", code,  internal_request,
         request_vhost_name, request_vcluster_name, from_az,   to_az, canary};
 
-    //code_stats_.chargeResponseStat(info);
     Http::CodeUtility::chargeResponseStat(info);
   }
 
@@ -52,18 +44,15 @@ public:
   }
 
   void responseTiming() {
-    //Http::CodeStats::ResponseTimingInfo info{
     Http::CodeUtility::ResponseTimingInfo info{
-      global_store_, cluster_scope_, "prefix.",    std::chrono::milliseconds(5),
-      true,          true,           "vhost_name", "req_vcluster_name",
-      "from_az",     "to_az"};
-    //code_stats_.chargeResponseTiming(info);
+        global_store_, cluster_scope_, "prefix.",    std::chrono::milliseconds(5),
+        true,          true,           "vhost_name", "req_vcluster_name",
+        "from_az",     "to_az"};
     Http::CodeUtility::chargeResponseTiming(info);
   }
 
   Stats::IsolatedStoreImpl global_store_;
   Stats::IsolatedStoreImpl cluster_scope_;
-  //Http::CodeStatsImpl code_stats_;
 };
 
 } // namespace Http
@@ -91,7 +80,6 @@ BENCHMARK(BM_ResponseTiming);
 int main(int argc, char** argv) {
   benchmark::Initialize(&argc, argv);
 
-  Envoy::Event::Libevent::Global::initialize();
   if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
     return 1;
   }

--- a/test/common/http/codes_speed_test.cc
+++ b/test/common/http/codes_speed_test.cc
@@ -1,0 +1,99 @@
+// Note: this should be run with --compilation_mode=opt, and would benefit from a
+// quiescent system with disabled cstate power management.
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "envoy/stats/stats.h"
+
+#include "common/common/empty_string.h"
+#include "common/http/codes.h"
+#include "common/http/header_map_impl.h"
+#include "common/stats/isolated_store_impl.h"
+
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "testing/base/public/benchmark.h"
+
+namespace Envoy {
+namespace Http {
+
+class CodeUtilitySpeedTest {
+public:
+  void addResponse(uint64_t code, bool canary, bool internal_request,
+                   const std::string& request_vhost_name = EMPTY_STRING,
+                   const std::string& request_vcluster_name = EMPTY_STRING,
+                   const std::string& from_az = EMPTY_STRING,
+                   const std::string& to_az = EMPTY_STRING) {
+    //Http::CodeStats::ResponseStatInfo info{
+    Http::CodeUtility::ResponseStatInfo info{
+        global_store_,      cluster_scope_,        "prefix.", code,  internal_request,
+        request_vhost_name, request_vcluster_name, from_az,   to_az, canary};
+
+    //code_stats_.chargeResponseStat(info);
+    Http::CodeUtility::chargeResponseStat(info);
+  }
+
+  void addResponses() {
+    addResponse(201, false, false);
+    addResponse(301, false, true);
+    addResponse(401, false, false);
+    addResponse(501, false, true);
+    addResponse(200, true, true);
+    addResponse(300, false, false);
+    addResponse(500, true, false);
+    addResponse(200, false, false, "test-vhost", "test-cluster");
+    addResponse(200, false, false, "", "", "from_az", "to_az");
+  }
+
+  void responseTiming() {
+    //Http::CodeStats::ResponseTimingInfo info{
+    Http::CodeUtility::ResponseTimingInfo info{
+      global_store_, cluster_scope_, "prefix.",    std::chrono::milliseconds(5),
+      true,          true,           "vhost_name", "req_vcluster_name",
+      "from_az",     "to_az"};
+    //code_stats_.chargeResponseTiming(info);
+    Http::CodeUtility::chargeResponseTiming(info);
+  }
+
+  Stats::IsolatedStoreImpl global_store_;
+  Stats::IsolatedStoreImpl cluster_scope_;
+  //Http::CodeStatsImpl code_stats_;
+};
+
+} // namespace Http
+} // namespace Envoy
+
+static void BM_AddResponses(benchmark::State& state) {
+  Envoy::Http::CodeUtilitySpeedTest context;
+
+  for (auto _ : state) {
+    context.addResponses();
+  }
+}
+BENCHMARK(BM_AddResponses);
+
+static void BM_ResponseTiming(benchmark::State& state) {
+  Envoy::Http::CodeUtilitySpeedTest context;
+
+  for (auto _ : state) {
+    context.responseTiming();
+  }
+}
+BENCHMARK(BM_ResponseTiming);
+
+// Boilerplate main(), which discovers benchmarks in the same file and runs them.
+int main(int argc, char** argv) {
+  benchmark::Initialize(&argc, argv);
+
+  Envoy::Event::Libevent::Global::initialize();
+  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
+    return 1;
+  }
+  benchmark::RunSpecifiedBenchmarks();
+}


### PR DESCRIPTION
*Description*: This serves as a baseline for the speed improvements offered in #4997 . With this PR, on my machine, I get:

```
---------------------------------------------------------
Benchmark                  Time           CPU Iterations
---------------------------------------------------------
BM_AddResponses         8220 ns       8220 ns      80376
BM_ResponseTiming        447 ns        447 ns    1575300
```

which appears to be fairly consistent, at least localized in time.

*Risk Level*: low -- just adds a new speed test
*Testing*: just this test
*Docs Changes*: n/a
*Release Notes*: n/a
