### PR TITLE
fuzz: avoid fixed file placeholder hack with ctx.actions.declare_dire…

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -12,7 +12,7 @@ def _envoy_directory_genrule_impl(ctx):
         inputs = ctx.files.srcs,
         tools = ctx.files.tools,
         outputs = [tree],
-        command = "mkdir -p " + tree.path + "&& " + ctx.expand_location(ctx.attr.cmd),
+        command = "mkdir -p " + tree.path + " && " + ctx.expand_location(ctx.attr.cmd),
         env = {"GENRULE_OUTPUT_DIR": tree.path},
     )
     return [DefaultInfo(files = depset([tree]))]

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -4,6 +4,28 @@ load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
 def envoy_package():
     native.package(default_visibility = ["//visibility:public"])
 
+# A genrule variant that can output a directory. This is useful when doing things like
+# generating a fuzz corpus mechanically.
+def _envoy_directory_genrule_impl(ctx):
+    tree = ctx.actions.declare_directory(ctx.attr.name + ".outputs")
+    ctx.actions.run_shell(
+        inputs = ctx.files.srcs,
+        tools = ctx.files.tools,
+        outputs = [tree],
+        command = "mkdir -p " + tree.path + "&& " + ctx.expand_location(ctx.attr.cmd),
+        env = {"GENRULE_OUTPUT_DIR": tree.path},
+    )
+    return [DefaultInfo(files = depset([tree]))]
+
+envoy_directory_genrule = rule(
+    implementation = _envoy_directory_genrule_impl,
+    attrs = {
+        "srcs": attr.label_list(),
+        "cmd": attr.string(),
+        "tools": attr.label_list(),
+    },
+)
+
 # Compute the final copts based on various options.
 def envoy_copts(repository, test = False):
     posix_options = [

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -4,6 +4,7 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
+    "envoy_directory_genrule",
     "envoy_package",
     "envoy_proto_library",
 )
@@ -93,18 +94,12 @@ envoy_proto_library(
     ],
 )
 
-# We generate the route_fuzz_test corpus from config_impl_test below. Since Bazel forces us to
-# enumerate all outputs from any rule (including genrule), we create dummy outputs of the form
-# generated_corpus_%d for [0..route_corpus_max). These placeholders are then populated by
-# config_impl_test. We need to increase this number if the test grows significantly.
-ROUTE_CORPUS_MAX = 1000
-
 sh_binary(
     name = "corpus_from_config_impl_sh",
     srcs = ["corpus_from_config_impl.sh"],
 )
 
-genrule(
+envoy_directory_genrule(
     name = "corpus_from_config_impl",
     testonly = 1,
     srcs = [
@@ -112,9 +107,7 @@ genrule(
         # otherwise in oss-fuzz builds.
         ":config_impl_test",
     ],
-    outs = ["generated_corpus_%d" % n for n in range(ROUTE_CORPUS_MAX)],
     cmd = " ".join([
-        "ROUTE_CORPUS_PATH=\"$(@D)\" ROUTE_CORPUS_MAX=%d" % ROUTE_CORPUS_MAX,
         "$(location corpus_from_config_impl_sh)",
         "$(location //test/common/router:config_impl_test)",
     ]),

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -56,17 +56,13 @@ public:
 
   RouteConstSharedPtr route(const Http::HeaderMap& headers, uint64_t random_value) const override {
     absl::optional<std::string> corpus_path =
-        TestEnvironment::getOptionalEnvVar("ROUTE_CORPUS_PATH");
+        TestEnvironment::getOptionalEnvVar("GENRULE_OUTPUT_DIR");
     if (corpus_path) {
       static uint32_t n;
-      const uint32_t max_test_cases =
-          std::atoi(TestEnvironment::getCheckedEnvVar("ROUTE_CORPUS_MAX").c_str());
       test::common::router::RouteTestCase route_test_case;
       route_test_case.mutable_config()->MergeFrom(config_);
       route_test_case.mutable_headers()->MergeFrom(Fuzz::toHeaders(headers));
       route_test_case.set_random_value(random_value);
-      RELEASE_ASSERT(n < max_test_cases,
-                     "ROUTE_CORPUS_MAX is too low, consider increasing in build rule");
       const std::string path = fmt::format("{}/generated_corpus_{}", corpus_path.value(), n++);
       const std::string corpus = route_test_case.DebugString();
       {

--- a/test/common/router/corpus_from_config_impl.sh
+++ b/test/common/router/corpus_from_config_impl.sh
@@ -9,10 +9,4 @@ set -e
 TEST_SRCDIR=/totally TEST_WORKSPACE=/bogus $*
 
 # Verify at least one entry is actually generated
-[ -e "${ROUTE_CORPUS_PATH}"/generated_corpus_0 ]
-
-# Touch the remaining files so that Bazel doesn't complain they are missing.
-for n in $(seq "${ROUTE_CORPUS_MAX}")
-do
-  touch "${ROUTE_CORPUS_PATH}/generated_corpus_$n"
-done
+[ -e "${GENRULE_OUTPUT_DIR}"/generated_corpus_0 ]

--- a/test/fuzz/main.cc
+++ b/test/fuzz/main.cc
@@ -46,16 +46,25 @@ int main(int argc, char** argv) {
   // Expected usage: <test path> <corpus paths..> [other gtest flags]
   RELEASE_ASSERT(argc >= 2, "");
   // Consider any file after the test path which doesn't have a - prefix to be a corpus entry.
+  uint32_t input_args = 0;
   for (int i = 1; i < argc; ++i) {
     const std::string arg{argv[i]};
     if (arg.empty() || arg[0] == '-') {
       break;
     }
-    Envoy::test_corpus_.emplace_back(arg);
+    ++input_args;
+    // Outputs from envoy_directory_genrule might be directories or we might
+    // have artisinal files.
+    if (Envoy::Filesystem::directoryExists(arg)) {
+      const auto paths = Envoy::TestUtility::listFiles(arg, true);
+      Envoy::test_corpus_.insert(Envoy::test_corpus_.begin(), paths.begin(), paths.end());
+    } else {
+      Envoy::test_corpus_.emplace_back(arg);
+    }
   }
-  argc -= Envoy::test_corpus_.size();
+  argc -= input_args;
   for (size_t i = 0; i < Envoy::test_corpus_.size(); ++i) {
-    argv[i + 1] = argv[i + 1 + Envoy::test_corpus_.size()];
+    argv[i + 1] = argv[i + 1 + input_args];
   }
 
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
…ctory.

After chatting with Bazel team, this seems to be the recommended
approach. It would be nice if this was supported directly in genrule,
but c'est la vie :)

Risk Level: Low
Testing: Manual bazel test and oss-fuzz Docker image validation.

Signed-off-by: Harvey Tuch <htuch@google.com>