### PR TITLE
build: fix broken fuzz build.

### DIFF
--- a/source/common/filesystem/posix/directory_iterator_impl.h
+++ b/source/common/filesystem/posix/directory_iterator_impl.h
@@ -26,7 +26,6 @@ public:
   // work around this, it is not needed the moment.
   DirectoryIteratorImpl(const DirectoryIteratorImpl&) = delete;
   DirectoryIteratorImpl(DirectoryIteratorImpl&&) = default;
-  DirectoryIteratorImpl& operator=(DirectoryIteratorImpl&&) = default;
 
 private:
   void nextEntry();


### PR DESCRIPTION
Clang in oss-fuzz compares about "-Wdefault-function-deleted", i.e.:

bzel-out/k8-fastbuild/bin/source/common/filesystem/_virtual_includes/directory_iterator_impl_lib_posix/common/filesystem/directory_iterator_impl.h:29:26:
error: explicitly defaulted move assignment operator is im
plicitly deleted [-Werror,-Wdefaulted-function-deleted]
DirectoryIteratorImpl& operator=(DirectoryIteratorImpl&&) = default;
^
bazel-out/k8-fastbuild/bin/source/common/filesystem/_virtual_includes/directory_iterator_impl_lib_posix/common/filesystem/directory_iterator_impl.h:38:24:
note: move assignment operator of 'DirectoryIteratorImpl'
is implicitly deleted because field 'os_sys_calls_' is of reference type
'Api::OsSysCallsImpl &'
Api::OsSysCallsImpl& os_sys_calls_;

Unfortunately, -Wdefault-function-deleted doesn't seem to be available in CI Clang (or my local
Clang for that matter).

Risk Level: Low.
Testing: Build.

Signed-off-by: Harvey Tuch <htuch@google.com>