### PR TITLE
build: Envoy has release builds on Windows

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -93,6 +93,8 @@ def envoy_linkopts():
                ],
                "@envoy//bazel:windows_x86_64": [
                    "-DEFAULTLIB:advapi32.lib",
+                   "-DEFAULTLIB:ws2_32.lib",
+                   "-WX",
                ],
                "//conditions:default": [
                    "-pthread",
@@ -141,6 +143,11 @@ def envoy_test_linkopts():
             # See note here: http://luajit.org/install.html
             "-pagezero_size 10000",
             "-image_base 100000000",
+        ],
+        "@envoy//bazel:windows_x86_64": [
+            "-DEFAULTLIB:advapi32.lib",
+            "-DEFAULTLIB:ws2_32.lib",
+            "-WX",
         ],
 
         # TODO(mattklein123): It's not great that we universally link against the following libs.

--- a/bazel/repositories.sh
+++ b/bazel/repositories.sh
@@ -13,7 +13,7 @@ fi
 # export BUILD_CONCURRENCY=0
 
 # Hash environment variables we care about to force rebuilds when they change.
-ENV_HASH=$(echo "${CC} ${CXX} ${LD_LIBRARY_PATH}" | md5sum | cut -f 1 -d\ )
+ENV_HASH=$(echo "${CC} ${CXX} ${LD_LIBRARY_PATH} ${BAZEL_WINDOWS_BUILD_TYPE}" | md5sum | cut -f 1 -d\ )
 
 # Don't build inside the directory Bazel believes the repository_rule output goes. Instead, do so in
 # a parallel directory. This allows the build artifacts to survive Bazel clobbering the repostory

--- a/ci/build_container/Makefile
+++ b/ci/build_container/Makefile
@@ -12,10 +12,11 @@ CXX ?= g++
 CXXFLAGS ?= -ggdb3 -fno-omit-frame-pointer -O2
 CFLAGS ?= -ggdb3 -fno-omit-frame-pointer -O2
 CPPFLAGS ?= -DNDEBUG
+BAZEL_WINDOWS_BUILD_TYPE ?= opt
 
 # Keep track of the env vars we depend upon for $(THIRDPARTY_DEPS)/%.dep.env. If the list (captured
 # above) of flags changes, this should be updated.
-ENV_STR := $(CC) $(CXX) $(CXXFLAGS) $(CFLAGS) $(CPPFLAGS)
+ENV_STR := $(CC) $(CXX) $(CXXFLAGS) $(CFLAGS) $(CPPFLAGS) $(BAZEL_WINDOWS_BUILD_TYPE)
 
 # If $(BUILD_DISTINCT) is set in the make environment, the artifacts are built and installed in
 # distinct directories under $(THIRDPARTY_BUILD) and $(THIRDPARTY_SRC). They end up looking like
@@ -47,6 +48,7 @@ build-recipe = cd "$(THIRDPARTY_SRC)" && \
 	   CFLAGS="$(CFLAGS)" \
 	   CXXFLAGS="$(CXXFLAGS)" \
 	   CPPFLAGS="$(CPPFLAGS)" \
+	   BAZEL_WINDOWS_BUILD_TYPE="$(BAZEL_WINDOWS_BUILD_TYPE)" \
 	   $(1) \
 	   bash -c "time $(CURDIR)/recipe_wrapper.sh $(realpath $<)" 2>&1) > $@.log) || (cat $@.log; exit 1)) && \
 	$(build-complete)

--- a/ci/build_container/build_recipes/libevent.sh
+++ b/ci/build_container/build_recipes/libevent.sh
@@ -16,12 +16,11 @@ cd build
 
 # libevent defaults CMAKE_BUILD_TYPE to Release
 build_type=Release
-if [[ "${OS}" == "Windows_NT" ]]; then
+if [[ "${OS}" == "Windows_NT" && "${BAZEL_WINDOWS_BUILD_TYPE}" == "dbg" ]]; then
   # On Windows, every object file in the final executable needs to be compiled to use the
-  # same version of the C Runtime Library. If Envoy is built with '-c dbg', then it will
-  # use the Debug C Runtime Library. Setting CMAKE_BUILD_TYPE to Debug will cause libevent
-  # to use the debug version as well
-  # TODO: when '-c fastbuild' and '-c opt' work for Windows builds, set this appropriately
+  # same version of the C Runtime Library -- there are different versions for debug and
+  # release builds. The script "ci/do_ci.ps1" will pass BAZEL_WINDOWS_BUILD_TYPE=dbg
+  # to bazel when performing a debug build.
   build_type=Debug
 fi
 
@@ -34,6 +33,7 @@ cmake -G "Ninja" \
 ninja
 ninja install
 
-if [[ "${OS}" == "Windows_NT" ]]; then
+if [[ "${OS}" == "Windows_NT" && "${BAZEL_WINDOWS_BUILD_TYPE}" == "dbg" ]]; then
+  # .pdb files are not generated for release builds
   cp "CMakeFiles/event.dir/event.pdb" "$THIRDPARTY_BUILD/lib/event.pdb"
 fi

--- a/ci/build_container/build_recipes/nghttp2.sh
+++ b/ci/build_container/build_recipes/nghttp2.sh
@@ -14,14 +14,15 @@ cd nghttp2-"$VERSION"
 # TODO: remove once https://github.com/nghttp2/nghttp2/pull/1198 is merged
 cat > nghttp2_cmakelists.diff << 'EOF'
 diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
-index 17e422b2..e58070f5 100644
+index 17e422b..54de0b8 100644
 --- a/lib/CMakeLists.txt
 +++ b/lib/CMakeLists.txt
-@@ -56,6 +56,7 @@ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
+@@ -55,7 +55,7 @@ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
+   set_target_properties(nghttp2_static PROPERTIES
      COMPILE_FLAGS "${WARNCFLAGS}"
      VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
-     ARCHIVE_OUTPUT_NAME nghttp2
-+    ARCHIVE_OUTPUT_DIRECTORY static
+-    ARCHIVE_OUTPUT_NAME nghttp2
++    ARCHIVE_OUTPUT_NAME nghttp2_static
    )
    target_compile_definitions(nghttp2_static PUBLIC "-DNGHTTP2_STATICLIB")
    if(ENABLE_STATIC_LIB)
@@ -34,14 +35,25 @@ fi
 mkdir build
 cd build
 
+build_type=Release
+if [[ "${OS}" == "Windows_NT" && "${BAZEL_WINDOWS_BUILD_TYPE}" == "dbg" ]]; then
+  # On Windows, every object file in the final executable needs to be compiled to use the
+  # same version of the C Runtime Library -- there are different versions for debug and
+  # release builds. The script "ci/do_ci.ps1" will pass BAZEL_WINDOWS_BUILD_TYPE=dbg
+  # to bazel when performing a debug build.
+  build_type=Debug
+fi
+
 cmake -G "Ninja" -DCMAKE_INSTALL_PREFIX="$THIRDPARTY_BUILD" \
   -DCMAKE_INSTALL_LIBDIR="$THIRDPARTY_BUILD/lib" \
   -DENABLE_STATIC_LIB=on \
   -DENABLE_LIB_ONLY=on \
+  -DCMAKE_BUILD_TYPE="$build_type" \
   ..
 ninja
 ninja install
 
-if [[ "${OS}" == "Windows_NT" ]]; then
+if [[ "${OS}" == "Windows_NT" && "${BAZEL_WINDOWS_BUILD_TYPE}" == "dbg" ]]; then
+  # .pdb files are not generated for release builds
   cp "lib/CMakeFiles/nghttp2_static.dir/nghttp2_static.pdb" "$THIRDPARTY_BUILD/lib/nghttp2_static.pdb"
 fi

--- a/ci/build_container/build_recipes/yaml-cpp.sh
+++ b/ci/build_container/build_recipes/yaml-cpp.sh
@@ -16,12 +16,14 @@ cd build
 
 build_type=RelWithDebInfo
 if [[ "${OS}" == "Windows_NT" ]]; then
-  # On Windows, every object file in the final executable needs to be compiled to use the
-  # same version of the C Runtime Library. If Envoy is built with '-c dbg', then it will
-  # use the Debug C Runtime Library. Setting CMAKE_BUILD_TYPE to Debug will cause yaml-cpp
-  # to use the debug version as well
-  # TODO: when '-c fastbuild' and '-c opt' work for Windows builds, set this appropriately
-  build_type=Debug
+  build_type=Release
+  if [[ "${BAZEL_WINDOWS_BUILD_TYPE}" == "dbg" ]]; then
+    # On Windows, every object file in the final executable needs to be compiled to use the
+    # same version of the C Runtime Library -- there are different versions for debug and
+    # release builds. The script "ci/do_ci.ps1" will pass BAZEL_WINDOWS_BUILD_TYPE=dbg
+    # to bazel when performing a debug build.
+    build_type=Debug
+  fi
 fi
 
 cmake -G "Ninja" -DCMAKE_INSTALL_PREFIX:PATH="$THIRDPARTY_BUILD" \
@@ -32,6 +34,7 @@ cmake -G "Ninja" -DCMAKE_INSTALL_PREFIX:PATH="$THIRDPARTY_BUILD" \
   ..
 ninja install
 
-if [[ "${OS}" == "Windows_NT" ]]; then
+if [[ "${OS}" == "Windows_NT" && "${BAZEL_WINDOWS_BUILD_TYPE}" == "dbg" ]]; then
+  # .pdb files are not generated for release builds
   cp "CMakeFiles/yaml-cpp.dir/yaml-cpp.pdb" "$THIRDPARTY_BUILD/lib/yaml-cpp.pdb"
 fi

--- a/ci/build_container/build_recipes/zlib.sh
+++ b/ci/build_container/build_recipes/zlib.sh
@@ -13,10 +13,22 @@ cd zlib-"$VERSION"
 mkdir build
 cd build
 
-cmake -G "Ninja" -DCMAKE_INSTALL_PREFIX:PATH="$THIRDPARTY_BUILD" ..
+build_type=Release
+if [[ "${OS}" == "Windows_NT" && "${BAZEL_WINDOWS_BUILD_TYPE}" == "dbg" ]]; then
+  # On Windows, every object file in the final executable needs to be compiled to use the
+  # same version of the C Runtime Library -- there are different versions for debug and
+  # release builds. The script "ci/do_ci.ps1" will pass BAZEL_WINDOWS_BUILD_TYPE=dbg
+  # to bazel when performing a debug build.
+  build_type=Debug
+fi
+
+cmake -G "Ninja" -DCMAKE_INSTALL_PREFIX:PATH="$THIRDPARTY_BUILD" \
+  -DCMAKE_BUILD_TYPE="$build_type" \
+  ..
 ninja
 ninja install
 
-if [[ "${OS}" == "Windows_NT" ]]; then
+if [[ "${OS}" == "Windows_NT" && "${BAZEL_WINDOWS_BUILD_TYPE}" == "dbg" ]]; then
+  # .pdb files are not generated for release builds
   cp "CMakeFiles/zlibstatic.dir/zlibstatic.pdb" "$THIRDPARTY_BUILD/lib/zlibstatic.pdb"
 fi

--- a/ci/build_setup.ps1
+++ b/ci/build_setup.ps1
@@ -17,6 +17,6 @@ $env:ENVOY_SRCDIR = [System.IO.Path]::GetFullPath("$PSScriptRoot\..")
 echo "ENVOY_BAZEL_ROOT: $env:ENVOY_BAZEL_ROOT"
 echo "ENVOY_SRCDIR: $env:ENVOY_SRCDIR"
 
-$env:BAZEL_BASE_OPTIONS="--nomaster_bazelrc --output_base=$env:ENVOY_BAZEL_ROOT --bazelrc=$env:ENVOY_SRCDIR\windows\tools\bazel.rc"
+$env:BAZEL_BASE_OPTIONS="--noworkspace_rc --output_base=$env:ENVOY_BAZEL_ROOT --bazelrc=$env:ENVOY_SRCDIR\windows\tools\bazel.rc"
 $env:BAZEL_BUILD_OPTIONS="--strategy=Genrule=standalone --spawn_strategy=standalone --verbose_failures --jobs=$env:NUM_CPUS --show_task_finish $env:BAZEL_BUILD_EXTRA_OPTIONS"
 $env:BAZEL_TEST_OPTIONS="$env:BAZEL_BUILD_OPTIONS --cache_test_results=no --test_output=all $env:BAZEL_EXTRA_TEST_OPTIONS"

--- a/ci/do_ci.ps1
+++ b/ci/do_ci.ps1
@@ -4,17 +4,54 @@ trap { $host.SetShouldExit(1) }
 . "$PSScriptRoot\build_setup.ps1"
 Write-Host "building using $env:NUM_CPUS CPUs"
 
-function bazel_debug_binary_build() {
+function bazel_binary_build($type) {
   echo "Building..."
-  pushd "$env:ENVOY_SRCDIR"
-    bazel  $env:BAZEL_BASE_OPTIONS.Split(" ") build $env:BAZEL_BUILD_OPTIONS.Split(" ") -c dbg "//source/exe:envoy-static"
-    $exit = $LASTEXITCODE
-    if ($exit -ne 0) {
-      popd
-      exit $exit
-    }
-  popd
+  bazel  $env:BAZEL_BASE_OPTIONS.Split(" ") build "--action_env=BAZEL_WINDOWS_BUILD_TYPE=$type" $env:BAZEL_BUILD_OPTIONS.Split(" ") -c $type "//source/exe:envoy-static"
+  $exit = $LASTEXITCODE
+  if ($exit -ne 0) {
+    exit $exit
+  }
 }
 
-echo "bazel debug build..."
-bazel_debug_binary_build
+function bazel_test($type, $test) {
+  if ($test -ne "") {
+    bazel $env:BAZEL_BASE_OPTIONS.Split(" ") test "--action_env=BAZEL_WINDOWS_BUILD_TYPE=$type" $env:BAZEL_TEST_OPTIONS.Split(" ") -c $type $test
+  } else {
+    echo "running windows tests"
+    bazel $env:BAZEL_BASE_OPTIONS.Split(" ") test "--action_env=BAZEL_WINDOWS_BUILD_TYPE=$type" $env:BAZEL_TEST_OPTIONS.Split(" ") -c $type "//test:windows_tests"
+  }
+  exit $LASTEXITCODE
+}
+
+$action = $args[0]
+$test = $args[1]
+
+switch ($action) {
+  "bazel.release" {
+    echo "bazel release build with tests..."
+    bazel_binary_build "opt"
+    bazel_test "opt" "$test"
+  }
+  "bazel.release.server_only" {
+    echo "bazel release build..."
+    bazel_binary_build "opt"
+  }
+  "bazel.debug" {
+    echo "bazel debug build with tests..."
+    bazel_binary_build "dbg"
+    bazel_test "dbg" "$test"
+  }
+  "bazel.debug.server_only" {
+    echo "bazel debug build..."
+    bazel_binary_build "dbg"
+  }
+  "bazel.dev" {
+    echo "bazel fastbuild build with tests..."
+    bazel_binary_build "fastbuild"
+    bazel_test "fastbuild" "$test"
+  }
+  default {
+    echo "unknown action: $action"
+    exit 1
+  }
+}

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -7,6 +7,30 @@ config_setting(
     values = {"cpu": "x64_windows"},
 )
 
+config_setting(
+    name = "windows_dbg_build",
+    values = {
+        "cpu": "x64_windows",
+        "compilation_mode": "dbg",
+    },
+)
+
+config_setting(
+    name = "windows_fastbuild_build",
+    values = {
+        "cpu": "x64_windows",
+        "compilation_mode": "fastbuild",
+    },
+)
+
+config_setting(
+    name = "windows_opt_build",
+    values = {
+        "cpu": "x64_windows",
+        "compilation_mode": "opt",
+    },
+)
+
 cc_library(
     name = "ares",
     srcs = select({
@@ -52,7 +76,7 @@ cc_library(
 cc_library(
     name = "nghttp2",
     srcs = select({
-        ":windows_x86_64": ["thirdparty_build/lib/nghttp2.lib"],
+        ":windows_x86_64": ["thirdparty_build/lib/nghttp2_static.lib"],
         "//conditions:default": ["thirdparty_build/lib/libnghttp2.a"],
     }),
     hdrs = glob(["thirdparty_build/include/nghttp2/**/*.h"]),
@@ -69,7 +93,9 @@ cc_library(
 cc_library(
     name = "yaml_cpp",
     srcs = select({
-        ":windows_x86_64": glob(["thirdparty_build/lib/libyaml-cpp*.lib"]),
+        ":windows_dbg_build": ["thirdparty_build/lib/libyaml-cppmdd.lib"],
+        ":windows_fastbuild_build": ["thirdparty_build/lib/libyaml-cppmd.lib"],
+        ":windows_opt_build": ["thirdparty_build/lib/libyaml-cppmd.lib"],
         "//conditions:default": ["thirdparty_build/lib/libyaml-cpp.a"],
     }),
     hdrs = glob(["thirdparty_build/include/yaml-cpp/**/*.h"]),
@@ -79,7 +105,9 @@ cc_library(
 cc_library(
     name = "zlib",
     srcs = select({
-        ":windows_x86_64": glob(["thirdparty_build/lib/zlibstaticd.lib"]),
+        ":windows_dbg_build": ["thirdparty_build/lib/zlibstaticd.lib"],
+        ":windows_fastbuild_build": ["thirdparty_build/lib/zlibstatic.lib"],
+        ":windows_opt_build": ["thirdparty_build/lib/zlibstatic.lib"],
         "//conditions:default": ["thirdparty_build/lib/libz.a"],
     }),
     hdrs = [

--- a/windows/tools/bazel.rc
+++ b/windows/tools/bazel.rc
@@ -5,3 +5,4 @@ build --define hot_restart=disabled
 build --define tcmalloc=disabled
 # Build GRPC without c-ares support -- otherwise it will not link
 build --define grpc_no_ares=true
+build --experimental_enable_runfiles


### PR DESCRIPTION
*Description*:

Add ability to create a release build of Envoy on Windows.

The only tricky part here is that the dependencies built by the scripts in `ci/build_container/build_recipes` need to know whether the build is a release build or a debug build -- otherwise they will not link properly. The solution we chose was to use a BAZEL_WINDOWS_BUILD_TYPE environment variable which would be set by the `ci/do_ci.ps1` script. The makefile is also updated so that these dependencies are rebuilt when switching between release + debug

*Risk Level*:
Low
*Testing*:
`bazel build //source/... && bazel test //test/...`. We also switched between release + debug builds on our Windows fork to verify this all worked as expected
*Docs Changes*:
None
*Release Notes*:
N/A