### PR TITLE
Async_client: Add config not to send xff

### DIFF
--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -181,9 +181,7 @@ public:
     RequestOptions(bool buffer_body, bool send_xff) : StreamOptions(buffer_body, send_xff) {}
 
     // For gmock test
-    bool operator==(const RequestOptions& src) const {
-      return *dynamic_cast<const StreamOptions*>(this) == *dynamic_cast<const StreamOptions*>(&src);
-    }
+    bool operator==(const RequestOptions& src) const { return StreamOptions::operator==(src); }
   };
 
   /**

--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -189,7 +189,7 @@ public:
       return *this;
     }
     RequestOptions& setSendXff(bool v) {
-      StreamOptions::seSendXff(v);
+      StreamOptions::setSendXff(v);
       return *this;
     }
 

--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -177,19 +177,19 @@ public:
    */
   struct RequestOptions : public StreamOptions {
     RequestOptions& setTimeout(const absl::optional<std::chrono::milliseconds>& v) {
-      timeout = v;
+      StreamOptions::setTimeout(v);
       return *this;
     }
     RequestOptions& setTimeout(const std::chrono::milliseconds& v) {
-      timeout = v;
+      StreamOptions::setTimeout(v);
       return *this;
     }
     RequestOptions& setBufferBodyForRetry(bool v) {
-      buffer_body_for_retry = v;
+      StreamOptions::setBufferBodyForRetry(v);
       return *this;
     }
     RequestOptions& setSendXff(bool v) {
-      send_xff = v;
+      StreamOptions::seSendXff(v);
       return *this;
     }
 

--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -135,16 +135,22 @@ public:
    * A structure to hold the options for AsyncStream object.
    */
   struct StreamOptions {
-    StreamOptions() {}
-    StreamOptions(const absl::optional<std::chrono::milliseconds>& timeout) : timeout(timeout) {}
-    StreamOptions(const absl::optional<std::chrono::milliseconds>& timeout, bool buffer_body)
-        : timeout(timeout), buffer_body_for_retry(buffer_body) {}
-    StreamOptions(const absl::optional<std::chrono::milliseconds>& timeout, bool buffer_body,
-                  bool send_xff)
-        : timeout(timeout), buffer_body_for_retry(buffer_body), send_xff(send_xff) {}
-    StreamOptions(bool buffer_body) : buffer_body_for_retry(buffer_body) {}
-    StreamOptions(bool buffer_body, bool send_xff)
-        : buffer_body_for_retry(buffer_body), send_xff(send_xff) {}
+    StreamOptions& setTimeout(const absl::optional<std::chrono::milliseconds>& v) {
+      timeout = v;
+      return *this;
+    }
+    StreamOptions& setTimeout(const std::chrono::milliseconds& v) {
+      timeout = v;
+      return *this;
+    }
+    StreamOptions& setBufferBodyForRetry(bool v) {
+      buffer_body_for_retry = v;
+      return *this;
+    }
+    StreamOptions& setSendXff(bool v) {
+      send_xff = v;
+      return *this;
+    }
 
     // For gmock test
     bool operator==(const StreamOptions& src) const {
@@ -170,15 +176,22 @@ public:
    * A structure to hold the options for AsyncRequest object.
    */
   struct RequestOptions : public StreamOptions {
-    RequestOptions() {}
-    RequestOptions(const absl::optional<std::chrono::milliseconds>& timeout)
-        : StreamOptions(timeout) {}
-    RequestOptions(const absl::optional<std::chrono::milliseconds>& timeout, bool buffer_body)
-        : StreamOptions(timeout, buffer_body) {}
-    RequestOptions(const absl::optional<std::chrono::milliseconds>& timeout, bool buffer_body,
-                   bool send_xff)
-        : StreamOptions(timeout, buffer_body, send_xff) {}
-    RequestOptions(bool buffer_body, bool send_xff) : StreamOptions(buffer_body, send_xff) {}
+    RequestOptions& setTimeout(const absl::optional<std::chrono::milliseconds>& v) {
+      timeout = v;
+      return *this;
+    }
+    RequestOptions& setTimeout(const std::chrono::milliseconds& v) {
+      timeout = v;
+      return *this;
+    }
+    RequestOptions& setBufferBodyForRetry(bool v) {
+      buffer_body_for_retry = v;
+      return *this;
+    }
+    RequestOptions& setSendXff(bool v) {
+      send_xff = v;
+      return *this;
+    }
 
     // For gmock test
     bool operator==(const RequestOptions& src) const { return StreamOptions::operator==(src); }
@@ -188,7 +201,7 @@ public:
    * Send an HTTP request asynchronously
    * @param request the request to send.
    * @param callbacks the callbacks to be notified of request status.
-   * @param the options to control the request sending.
+   * @param options the data struct to control the request sending.
    * @return a request handle or nullptr if no request could be created. NOTE: In this case
    *         onFailure() has already been called inline. The client owns the request and the
    *         handle should just be used to cancel.
@@ -200,7 +213,7 @@ public:
   /**
    * Start an HTTP stream asynchronously.
    * @param callbacks the callbacks to be notified of stream status.
-   * @param the options to control the stream.
+   * @param options the data struct to control the stream.
    * @return a stream handle or nullptr if no stream could be started. NOTE: In this case
    *         onResetStream() has already been called inline. The client owns the stream and
    *         the handle can be used to send more messages or close the stream.

--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -141,6 +141,9 @@ public:
    *         handle should just be used to cancel.
    */
   struct SendArgs {
+    SendArgs() {}
+    SendArgs(const absl::optional<std::chrono::milliseconds>& timeout) : timeout(timeout) {}
+    
     absl::optional<std::chrono::milliseconds> timeout;
     bool send_xff{true};
   };
@@ -160,8 +163,15 @@ public:
    *         the handle can be used to send more messages or close the stream.
    */
   struct StartArgs {
+    StartArgs() {}
+    StartArgs(const absl::optional<std::chrono::milliseconds>& timeout, bool buffer_body)
+    : timeout(timeout), buffer_body_for_retry(buffer_body) {}
+    StartArgs(const absl::optional<std::chrono::milliseconds>& timeout, bool buffer_body, bool send_xff)
+    : timeout(timeout), buffer_body_for_retry(buffer_body), send_xff(send_xff) {}
+    StartArgs(bool buffer_body, bool send_xff) : buffer_body_for_retry(buffer_body), send_xff(send_xff) {}
+    
     absl::optional<std::chrono::milliseconds> timeout;
-    bool buffer_body_for_retry;
+    bool buffer_body_for_retry{false};
     bool send_xff{true};
   };
   virtual Stream* start(StreamCallbacks& callbacks, const StartArgs& args) PURE;

--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -140,8 +140,11 @@ public:
    *         onFailure() has already been called inline. The client owns the request and the
    *         handle should just be used to cancel.
    */
-  virtual Request* send(MessagePtr&& request, Callbacks& callbacks,
-                        const absl::optional<std::chrono::milliseconds>& timeout) PURE;
+  struct SendArgs {
+    absl::optional<std::chrono::milliseconds> timeout;
+    bool send_xff{true};
+  };
+  virtual Request* send(MessagePtr&& request, Callbacks& callbacks, const SendArgs& args) PURE;
 
   /**
    * Start an HTTP stream asynchronously.
@@ -156,9 +159,12 @@ public:
    *         onResetStream() has already been called inline. The client owns the stream and
    *         the handle can be used to send more messages or close the stream.
    */
-  virtual Stream* start(StreamCallbacks& callbacks,
-                        const absl::optional<std::chrono::milliseconds>& timeout,
-                        bool buffer_body_for_retry) PURE;
+  struct StartArgs {
+    absl::optional<std::chrono::milliseconds> timeout;
+    bool buffer_body_for_retry;
+    bool send_xff{true};
+  };
+  virtual Stream* start(StreamCallbacks& callbacks, const StartArgs& args) PURE;
 
   /**
    * @return Event::Dispatcher& the dispatcher backing this client.

--- a/include/envoy/http/async_client.h
+++ b/include/envoy/http/async_client.h
@@ -143,7 +143,12 @@ public:
   struct SendArgs {
     SendArgs() {}
     SendArgs(const absl::optional<std::chrono::milliseconds>& timeout) : timeout(timeout) {}
-    
+
+    // Needed for gmock test
+    bool operator==(const SendArgs& src) const {
+      return timeout == src.timeout && send_xff == src.send_xff;
+    }
+
     absl::optional<std::chrono::milliseconds> timeout;
     bool send_xff{true};
   };
@@ -170,6 +175,12 @@ public:
     : timeout(timeout), buffer_body_for_retry(buffer_body), send_xff(send_xff) {}
     StartArgs(bool buffer_body, bool send_xff) : buffer_body_for_retry(buffer_body), send_xff(send_xff) {}
     
+    // Needed for gmock test
+    bool operator==(const StartArgs& src) const {
+      return timeout == src.timeout &&
+	buffer_body_for_retry == src.buffer_body_for_retry && send_xff == src.send_xff;
+    }
+
     absl::optional<std::chrono::milliseconds> timeout;
     bool buffer_body_for_retry{false};
     bool send_xff{true};

--- a/source/common/grpc/async_client_impl.cc
+++ b/source/common/grpc/async_client_impl.cc
@@ -70,7 +70,8 @@ void AsyncStreamImpl::initialize(bool buffer_body_for_retry) {
   auto& http_async_client = parent_.cm_.httpAsyncClientForCluster(parent_.remote_cluster_name_);
   dispatcher_ = &http_async_client.dispatcher();
   stream_ = http_async_client.start(
-      *this, Http::AsyncClient::StreamOptions(timeout_, buffer_body_for_retry));
+      *this, Http::AsyncClient::StreamOptions().setTimeout(timeout_).setBufferBodyForRetry(
+                 buffer_body_for_retry));
 
   if (stream_ == nullptr) {
     callbacks_.onRemoteClose(Status::GrpcStatus::Unavailable, EMPTY_STRING);

--- a/source/common/grpc/async_client_impl.cc
+++ b/source/common/grpc/async_client_impl.cc
@@ -69,8 +69,7 @@ void AsyncStreamImpl::initialize(bool buffer_body_for_retry) {
 
   auto& http_async_client = parent_.cm_.httpAsyncClientForCluster(parent_.remote_cluster_name_);
   dispatcher_ = &http_async_client.dispatcher();
-  stream_ = http_async_client.start(*this, absl::optional<std::chrono::milliseconds>(timeout_),
-                                    buffer_body_for_retry);
+  stream_ = http_async_client.start(*this, Http::AsyncClient::StartArgs(timeout_, buffer_body_for_retry));
 
   if (stream_ == nullptr) {
     callbacks_.onRemoteClose(Status::GrpcStatus::Unavailable, EMPTY_STRING);

--- a/source/common/grpc/async_client_impl.cc
+++ b/source/common/grpc/async_client_impl.cc
@@ -69,7 +69,8 @@ void AsyncStreamImpl::initialize(bool buffer_body_for_retry) {
 
   auto& http_async_client = parent_.cm_.httpAsyncClientForCluster(parent_.remote_cluster_name_);
   dispatcher_ = &http_async_client.dispatcher();
-  stream_ = http_async_client.start(*this, Http::AsyncClient::StartArgs(timeout_, buffer_body_for_retry));
+  stream_ = http_async_client.start(
+      *this, Http::AsyncClient::StreamOptions(timeout_, buffer_body_for_retry));
 
   if (stream_ == nullptr) {
     callbacks_.onRemoteClose(Status::GrpcStatus::Unavailable, EMPTY_STRING);

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -48,11 +48,10 @@ AsyncClientImpl::~AsyncClientImpl() {
   }
 }
 
-AsyncClient::Request*
-AsyncClientImpl::send(MessagePtr&& request, AsyncClient::Callbacks& callbacks,
-                      const absl::optional<std::chrono::milliseconds>& timeout) {
+AsyncClient::Request* AsyncClientImpl::send(MessagePtr&& request, AsyncClient::Callbacks& callbacks,
+                                            const SendArgs& args) {
   AsyncRequestImpl* async_request =
-      new AsyncRequestImpl(std::move(request), *this, callbacks, timeout);
+      new AsyncRequestImpl(std::move(request), *this, callbacks, args.timeout, args.send_xff);
   async_request->initialize();
   std::unique_ptr<AsyncStreamImpl> new_request{async_request};
 
@@ -66,23 +65,21 @@ AsyncClientImpl::send(MessagePtr&& request, AsyncClient::Callbacks& callbacks,
   }
 }
 
-AsyncClient::Stream*
-AsyncClientImpl::start(AsyncClient::StreamCallbacks& callbacks,
-                       const absl::optional<std::chrono::milliseconds>& timeout,
-                       bool buffer_body_for_retry) {
-  std::unique_ptr<AsyncStreamImpl> new_stream{
-      new AsyncStreamImpl(*this, callbacks, timeout, buffer_body_for_retry)};
+AsyncClient::Stream* AsyncClientImpl::start(AsyncClient::StreamCallbacks& callbacks,
+                                            const StartArgs& args) {
+  std::unique_ptr<AsyncStreamImpl> new_stream{new AsyncStreamImpl(
+      *this, callbacks, args.timeout, args.buffer_body_for_retry, args.send_xff)};
   new_stream->moveIntoList(std::move(new_stream), active_streams_);
   return active_streams_.front().get();
 }
 
 AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCallbacks& callbacks,
                                  const absl::optional<std::chrono::milliseconds>& timeout,
-                                 bool buffer_body_for_retry)
+                                 bool buffer_body_for_retry, bool send_xff)
     : parent_(parent), stream_callbacks_(callbacks), stream_id_(parent.config_.random_.random()),
       router_(parent.config_), stream_info_(Protocol::Http11, parent.dispatcher().timeSystem()),
       tracing_config_(Tracing::EgressConfig::get()),
-      route_(std::make_shared<RouteImpl>(parent_.cluster_->name(), timeout)) {
+      route_(std::make_shared<RouteImpl>(parent_.cluster_->name(), timeout)), send_xff_(send_xff) {
   if (buffer_body_for_retry) {
     buffered_body_ = std::make_unique<Buffer::OwnedImpl>();
   }
@@ -122,7 +119,9 @@ void AsyncStreamImpl::sendHeaders(HeaderMap& headers, bool end_stream) {
   is_grpc_request_ = Grpc::Common::hasGrpcContentType(headers);
   headers.insertEnvoyInternalRequest().value().setReference(
       Headers::get().EnvoyInternalRequestValues.True);
-  Utility::appendXff(headers, *parent_.config_.local_info_.address());
+  if (send_xff_) {
+    Utility::appendXff(headers, *parent_.config_.local_info_.address());
+  }
   router_.decodeHeaders(headers, end_stream);
   closeLocal(end_stream);
 }
@@ -181,10 +180,11 @@ void AsyncStreamImpl::resetStream() {
 
 AsyncRequestImpl::AsyncRequestImpl(MessagePtr&& request, AsyncClientImpl& parent,
                                    AsyncClient::Callbacks& callbacks,
-                                   const absl::optional<std::chrono::milliseconds>& timeout)
+                                   const absl::optional<std::chrono::milliseconds>& timeout,
+                                   bool send_xff)
     // We tell the underlying stream to not buffer because we already have the full request and
     // and can handle any buffered body requests.
-    : AsyncStreamImpl(parent, *this, timeout, false), request_(std::move(request)),
+    : AsyncStreamImpl(parent, *this, timeout, false, send_xff), request_(std::move(request)),
       callbacks_(callbacks) {}
 
 void AsyncRequestImpl::initialize() {

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -46,12 +46,9 @@ public:
   ~AsyncClientImpl();
 
   // Http::AsyncClient
-  Request* send(MessagePtr&& request, Callbacks& callbacks,
-                const absl::optional<std::chrono::milliseconds>& timeout) override;
+  Request* send(MessagePtr&& request, Callbacks& callbacks, const SendArgs& args) override;
 
-  Stream* start(StreamCallbacks& callbacks,
-                const absl::optional<std::chrono::milliseconds>& timeout,
-                bool buffer_body_for_retry) override;
+  Stream* start(StreamCallbacks& callbacks, const StartArgs& args) override;
 
   Event::Dispatcher& dispatcher() override { return dispatcher_; }
 
@@ -77,7 +74,7 @@ class AsyncStreamImpl : public AsyncClient::Stream,
 public:
   AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCallbacks& callbacks,
                   const absl::optional<std::chrono::milliseconds>& timeout,
-                  bool buffer_body_for_retry);
+                  bool buffer_body_for_retry, bool send_xff);
 
   // Http::AsyncClient::Stream
   void sendHeaders(HeaderMap& headers, bool end_stream) override;
@@ -324,6 +321,7 @@ private:
   Buffer::InstancePtr buffered_body_;
   bool is_grpc_request_{};
   bool is_head_request_{false};
+  bool send_xff_{true};
   friend class AsyncClientImpl;
 };
 
@@ -332,7 +330,7 @@ class AsyncRequestImpl final : public AsyncClient::Request,
                                AsyncClient::StreamCallbacks {
 public:
   AsyncRequestImpl(MessagePtr&& request, AsyncClientImpl& parent, AsyncClient::Callbacks& callbacks,
-                   const absl::optional<std::chrono::milliseconds>& timeout);
+                   const absl::optional<std::chrono::milliseconds>& timeout, bool send_xff);
 
   // AsyncClient::Request
   virtual void cancel() override;

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -46,9 +46,10 @@ public:
   ~AsyncClientImpl();
 
   // Http::AsyncClient
-  Request* send(MessagePtr&& request, Callbacks& callbacks, const SendArgs& args) override;
+  Request* send(MessagePtr&& request, Callbacks& callbacks,
+                const AsyncClient::RequestOptions& options) override;
 
-  Stream* start(StreamCallbacks& callbacks, const StartArgs& args) override;
+  Stream* start(StreamCallbacks& callbacks, const AsyncClient::StreamOptions& options) override;
 
   Event::Dispatcher& dispatcher() override { return dispatcher_; }
 
@@ -73,8 +74,7 @@ class AsyncStreamImpl : public AsyncClient::Stream,
                         LinkedObject<AsyncStreamImpl> {
 public:
   AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCallbacks& callbacks,
-                  const absl::optional<std::chrono::milliseconds>& timeout,
-                  bool buffer_body_for_retry, bool send_xff);
+                  const AsyncClient::StreamOptions& options);
 
   // Http::AsyncClient::Stream
   void sendHeaders(HeaderMap& headers, bool end_stream) override;
@@ -330,7 +330,7 @@ class AsyncRequestImpl final : public AsyncClient::Request,
                                AsyncClient::StreamCallbacks {
 public:
   AsyncRequestImpl(MessagePtr&& request, AsyncClientImpl& parent, AsyncClient::Callbacks& callbacks,
-                   const absl::optional<std::chrono::milliseconds>& timeout, bool send_xff);
+                   const AsyncClient::RequestOptions& options);
 
   // AsyncClient::Request
   virtual void cancel() override;

--- a/source/common/http/rest_api_fetcher.cc
+++ b/source/common/http/rest_api_fetcher.cc
@@ -69,8 +69,7 @@ void RestApiFetcher::refresh() {
   message->headers().insertHost().value(remote_cluster_name_);
   active_request_ = cm_.httpAsyncClientForCluster(remote_cluster_name_)
                         .send(std::move(message), *this,
-                              AsyncClient::RequestOptions(
-                                  absl::optional<std::chrono::milliseconds>(request_timeout_)));
+                              AsyncClient::RequestOptions().setTimeout(request_timeout_));
 }
 
 void RestApiFetcher::requestComplete() {

--- a/source/common/http/rest_api_fetcher.cc
+++ b/source/common/http/rest_api_fetcher.cc
@@ -69,7 +69,8 @@ void RestApiFetcher::refresh() {
   message->headers().insertHost().value(remote_cluster_name_);
   active_request_ = cm_.httpAsyncClientForCluster(remote_cluster_name_)
                         .send(std::move(message), *this,
-                              AsyncClient::SendArgs(request_timeout_));
+                              AsyncClient::RequestOptions(
+                                  absl::optional<std::chrono::milliseconds>(request_timeout_)));
 }
 
 void RestApiFetcher::requestComplete() {

--- a/source/common/http/rest_api_fetcher.cc
+++ b/source/common/http/rest_api_fetcher.cc
@@ -69,7 +69,7 @@ void RestApiFetcher::refresh() {
   message->headers().insertHost().value(remote_cluster_name_);
   active_request_ = cm_.httpAsyncClientForCluster(remote_cluster_name_)
                         .send(std::move(message), *this,
-                              absl::optional<std::chrono::milliseconds>(request_timeout_));
+                              AsyncClient::SendArgs(request_timeout_));
 }
 
 void RestApiFetcher::requestComplete() {

--- a/source/common/router/shadow_writer_impl.cc
+++ b/source/common/router/shadow_writer_impl.cc
@@ -30,7 +30,7 @@ void ShadowWriterImpl::shadow(const std::string& cluster, Http::MessagePtr&& req
                         : absl::StrCat(request->headers().Host()->value().c_str(), "-shadow"));
   // This is basically fire and forget. We don't handle cancelling.
   cm_.httpAsyncClientForCluster(cluster).send(std::move(request), *this,
-                                              absl::optional<std::chrono::milliseconds>(timeout));
+                                              Http::AsyncClient::SendArgs(timeout));
 }
 
 } // namespace Router

--- a/source/common/router/shadow_writer_impl.cc
+++ b/source/common/router/shadow_writer_impl.cc
@@ -30,7 +30,7 @@ void ShadowWriterImpl::shadow(const std::string& cluster, Http::MessagePtr&& req
                         : absl::StrCat(request->headers().Host()->value().c_str(), "-shadow"));
   // This is basically fire and forget. We don't handle cancelling.
   cm_.httpAsyncClientForCluster(cluster).send(std::move(request), *this,
-                                              Http::AsyncClient::SendArgs(timeout));
+                                              Http::AsyncClient::RequestOptions(timeout));
 }
 
 } // namespace Router

--- a/source/common/router/shadow_writer_impl.cc
+++ b/source/common/router/shadow_writer_impl.cc
@@ -29,8 +29,8 @@ void ShadowWriterImpl::shadow(const std::string& cluster, Http::MessagePtr&& req
       parts.size() == 2 ? absl::StrJoin(parts, "-shadow:")
                         : absl::StrCat(request->headers().Host()->value().c_str(), "-shadow"));
   // This is basically fire and forget. We don't handle cancelling.
-  cm_.httpAsyncClientForCluster(cluster).send(std::move(request), *this,
-                                              Http::AsyncClient::RequestOptions(timeout));
+  cm_.httpAsyncClientForCluster(cluster).send(
+      std::move(request), *this, Http::AsyncClient::RequestOptions().setTimeout(timeout));
 }
 
 } // namespace Router

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -86,7 +86,7 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
 
   request_ = cm_.httpAsyncClientForCluster(cluster_name_)
                  .send(std::make_unique<Envoy::Http::RequestMessageImpl>(std::move(headers)), *this,
-                       timeout_);
+                       Http::AsyncClient::RequestOptions().setTimeout(timeout_));
 }
 
 ResponsePtr RawHttpClientImpl::messageToResponse(Http::MessagePtr message) {

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -86,7 +86,7 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
 
   request_ = cm_.httpAsyncClientForCluster(cluster_name_)
                  .send(std::make_unique<Envoy::Http::RequestMessageImpl>(std::move(headers)), *this,
-                       Http::AsyncClient::SendArgs(timeout_));
+                       timeout_);
 }
 
 ResponsePtr RawHttpClientImpl::messageToResponse(Http::MessagePtr message) {

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -86,7 +86,7 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
 
   request_ = cm_.httpAsyncClientForCluster(cluster_name_)
                  .send(std::make_unique<Envoy::Http::RequestMessageImpl>(std::move(headers)), *this,
-                       timeout_);
+                       Http::AsyncClient::SendArgs(timeout_));
 }
 
 ResponsePtr RawHttpClientImpl::messageToResponse(Http::MessagePtr message) {

--- a/source/extensions/filters/http/common/jwks_fetcher.cc
+++ b/source/extensions/filters/http/common/jwks_fetcher.cc
@@ -39,8 +39,8 @@ public:
     ENVOY_LOG(debug, "fetch pubkey from [uri = {}]: start", uri_->uri());
     request_ = cm_.httpAsyncClientForCluster(uri.cluster())
                    .send(std::move(message), *this,
-                         absl::optional<std::chrono::milliseconds>(
-                             DurationUtil::durationToMilliseconds(uri.timeout())));
+                         Http::AsyncClient::RequestOptions().setTimeout(std::chrono::milliseconds(
+                             DurationUtil::durationToMilliseconds(uri.timeout()))));
   }
 
   // HTTP async receive methods

--- a/source/extensions/filters/http/common/jwks_fetcher.cc
+++ b/source/extensions/filters/http/common/jwks_fetcher.cc
@@ -40,7 +40,7 @@ public:
     request_ =
         cm_.httpAsyncClientForCluster(uri.cluster())
             .send(std::move(message), *this,
-                  std::chrono::milliseconds(DurationUtil::durationToMilliseconds(uri.timeout())));
+                  Http::AsyncClient::SendArgs(absl::optional<std::chrono::milliseconds>(DurationUtil::durationToMilliseconds(uri.timeout()))));
   }
 
   // HTTP async receive methods

--- a/source/extensions/filters/http/common/jwks_fetcher.cc
+++ b/source/extensions/filters/http/common/jwks_fetcher.cc
@@ -37,10 +37,10 @@ public:
     Http::MessagePtr message = Http::Utility::prepareHeaders(uri);
     message->headers().insertMethod().value().setReference(Http::Headers::get().MethodValues.Get);
     ENVOY_LOG(debug, "fetch pubkey from [uri = {}]: start", uri_->uri());
-    request_ =
-        cm_.httpAsyncClientForCluster(uri.cluster())
-            .send(std::move(message), *this,
-                  Http::AsyncClient::SendArgs(absl::optional<std::chrono::milliseconds>(DurationUtil::durationToMilliseconds(uri.timeout()))));
+    request_ = cm_.httpAsyncClientForCluster(uri.cluster())
+                   .send(std::move(message), *this,
+                         absl::optional<std::chrono::milliseconds>(
+                             DurationUtil::durationToMilliseconds(uri.timeout())));
   }
 
   // HTTP async receive methods

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -191,7 +191,7 @@ int StreamHandleWrapper::luaHttpCall(lua_State* state) {
   }
 
   http_request_ = filter_.clusterManager().httpAsyncClientForCluster(cluster).send(
-      std::move(message), *this, timeout);
+      std::move(message), *this, Http::AsyncClient::RequestOptions().setTimeout(timeout));
   if (http_request_) {
     state_ = State::HttpCall;
     return lua_yield(state, 0);

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -185,13 +185,9 @@ int StreamHandleWrapper::luaHttpCall(lua_State* state) {
     message->headers().insertContentLength().value(body_size);
   }
 
-  absl::optional<std::chrono::milliseconds> timeout;
-  if (timeout_ms > 0) {
-    timeout = std::chrono::milliseconds(timeout_ms);
-  }
-
   http_request_ = filter_.clusterManager().httpAsyncClientForCluster(cluster).send(
-      std::move(message), *this, timeout);
+   std::move(message), *this,
+   Http::AsyncClient::SendArgs(absl::optional<std::chrono::milliseconds>(timeout_ms)));
   if (http_request_) {
     state_ = State::HttpCall;
     return lua_yield(state, 0);

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -185,9 +185,13 @@ int StreamHandleWrapper::luaHttpCall(lua_State* state) {
     message->headers().insertContentLength().value(body_size);
   }
 
+  absl::optional<std::chrono::milliseconds> timeout;
+  if (timeout_ms > 0) {
+    timeout = std::chrono::milliseconds(timeout_ms);
+  }
+
   http_request_ = filter_.clusterManager().httpAsyncClientForCluster(cluster).send(
-   std::move(message), *this,
-   Http::AsyncClient::SendArgs(absl::optional<std::chrono::milliseconds>(timeout_ms)));
+      std::move(message), *this, timeout);
   if (http_request_) {
     state_ = State::HttpCall;
     return lua_yield(state, 0);

--- a/source/extensions/filters/http/squash/squash_filter.cc
+++ b/source/extensions/filters/http/squash/squash_filter.cc
@@ -151,10 +151,9 @@ Http::FilterHeadersStatus SquashFilter::decodeHeaders(Http::HeaderMap& headers, 
   request->body() = std::make_unique<Buffer::OwnedImpl>(config_->attachmentJson());
 
   is_squashing_ = true;
-  in_flight_request_ =
-      cm_.httpAsyncClientForCluster(config_->clusterName())
-          .send(std::move(request), create_attachment_callback_,
-		Http::AsyncClient::SendArgs(config_->requestTimeout()));
+  in_flight_request_ = cm_.httpAsyncClientForCluster(config_->clusterName())
+                           .send(std::move(request), create_attachment_callback_,
+                                 Http::AsyncClient::RequestOptions(config_->requestTimeout()));
 
   if (in_flight_request_ == nullptr) {
     ENVOY_LOG(debug, "Squash: can't create request for squash server");
@@ -271,10 +270,9 @@ void SquashFilter::pollForAttachment() {
   request->headers().insertPath().value().setReference(debug_attachment_path_);
   request->headers().insertHost().value().setReference(SERVER_AUTHORITY);
 
-  in_flight_request_ =
-      cm_.httpAsyncClientForCluster(config_->clusterName())
-          .send(std::move(request), check_attachment_callback_,
-		Http::AsyncClient::SendArgs(config_->requestTimeout()));
+  in_flight_request_ = cm_.httpAsyncClientForCluster(config_->clusterName())
+                           .send(std::move(request), check_attachment_callback_,
+                                 Http::AsyncClient::RequestOptions(config_->requestTimeout()));
   // No need to check if in_flight_request_ is null as onFailure will take care of
   // cleanup.
 }

--- a/source/extensions/filters/http/squash/squash_filter.cc
+++ b/source/extensions/filters/http/squash/squash_filter.cc
@@ -153,7 +153,8 @@ Http::FilterHeadersStatus SquashFilter::decodeHeaders(Http::HeaderMap& headers, 
   is_squashing_ = true;
   in_flight_request_ =
       cm_.httpAsyncClientForCluster(config_->clusterName())
-          .send(std::move(request), create_attachment_callback_, config_->requestTimeout());
+          .send(std::move(request), create_attachment_callback_,
+		Http::AsyncClient::SendArgs(config_->requestTimeout()));
 
   if (in_flight_request_ == nullptr) {
     ENVOY_LOG(debug, "Squash: can't create request for squash server");
@@ -272,7 +273,8 @@ void SquashFilter::pollForAttachment() {
 
   in_flight_request_ =
       cm_.httpAsyncClientForCluster(config_->clusterName())
-          .send(std::move(request), check_attachment_callback_, config_->requestTimeout());
+          .send(std::move(request), check_attachment_callback_,
+		Http::AsyncClient::SendArgs(config_->requestTimeout()));
   // No need to check if in_flight_request_ is null as onFailure will take care of
   // cleanup.
 }

--- a/source/extensions/filters/http/squash/squash_filter.cc
+++ b/source/extensions/filters/http/squash/squash_filter.cc
@@ -151,9 +151,10 @@ Http::FilterHeadersStatus SquashFilter::decodeHeaders(Http::HeaderMap& headers, 
   request->body() = std::make_unique<Buffer::OwnedImpl>(config_->attachmentJson());
 
   is_squashing_ = true;
-  in_flight_request_ = cm_.httpAsyncClientForCluster(config_->clusterName())
-                           .send(std::move(request), create_attachment_callback_,
-                                 Http::AsyncClient::RequestOptions(config_->requestTimeout()));
+  in_flight_request_ =
+      cm_.httpAsyncClientForCluster(config_->clusterName())
+          .send(std::move(request), create_attachment_callback_,
+                Http::AsyncClient::RequestOptions().setTimeout(config_->requestTimeout()));
 
   if (in_flight_request_ == nullptr) {
     ENVOY_LOG(debug, "Squash: can't create request for squash server");
@@ -270,9 +271,10 @@ void SquashFilter::pollForAttachment() {
   request->headers().insertPath().value().setReference(debug_attachment_path_);
   request->headers().insertHost().value().setReference(SERVER_AUTHORITY);
 
-  in_flight_request_ = cm_.httpAsyncClientForCluster(config_->clusterName())
-                           .send(std::move(request), check_attachment_callback_,
-                                 Http::AsyncClient::RequestOptions(config_->requestTimeout()));
+  in_flight_request_ =
+      cm_.httpAsyncClientForCluster(config_->clusterName())
+          .send(std::move(request), check_attachment_callback_,
+                Http::AsyncClient::RequestOptions().setTimeout(config_->requestTimeout()));
   // No need to check if in_flight_request_ is null as onFailure will take care of
   // cleanup.
 }

--- a/source/extensions/tracers/datadog/datadog_tracer_impl.cc
+++ b/source/extensions/tracers/datadog/datadog_tracer_impl.cc
@@ -92,7 +92,7 @@ void TraceReporter::flushTraces() {
     driver_.clusterManager()
         .httpAsyncClientForCluster(driver_.cluster()->name())
         .send(std::move(message), *this,
-              Http::AsyncClient::RequestOptions(absl::optional<std::chrono::milliseconds>(1000U)));
+              Http::AsyncClient::RequestOptions().setTimeout(std::chrono::milliseconds(1000U)));
 
     encoder_->clearTraces();
   }

--- a/source/extensions/tracers/datadog/datadog_tracer_impl.cc
+++ b/source/extensions/tracers/datadog/datadog_tracer_impl.cc
@@ -91,7 +91,8 @@ void TraceReporter::flushTraces() {
 
     driver_.clusterManager()
         .httpAsyncClientForCluster(driver_.cluster()->name())
-      .send(std::move(message), *this, Http::AsyncClient::SendArgs(absl::optional<std::chrono::milliseconds>(1000U)));
+        .send(std::move(message), *this,
+              Http::AsyncClient::RequestOptions(absl::optional<std::chrono::milliseconds>(1000U)));
 
     encoder_->clearTraces();
   }

--- a/source/extensions/tracers/datadog/datadog_tracer_impl.cc
+++ b/source/extensions/tracers/datadog/datadog_tracer_impl.cc
@@ -91,7 +91,7 @@ void TraceReporter::flushTraces() {
 
     driver_.clusterManager()
         .httpAsyncClientForCluster(driver_.cluster()->name())
-        .send(std::move(message), *this, std::chrono::milliseconds(1000U));
+      .send(std::move(message), *this, Http::AsyncClient::SendArgs(absl::optional<std::chrono::milliseconds>(1000U)));
 
     encoder_->clearTraces();
   }

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -68,7 +68,7 @@ void LightStepDriver::LightStepTransporter::Send(const Protobuf::Message& reques
 
   active_request_ = driver_.clusterManager()
                         .httpAsyncClientForCluster(driver_.cluster()->name())
-                        .send(std::move(message), *this, std::chrono::milliseconds(timeout));
+    .send(std::move(message), *this, Http::AsyncClient::SendArgs(absl::optional<std::chrono::milliseconds>(timeout)));
 }
 
 void LightStepDriver::LightStepTransporter::onSuccess(Http::MessagePtr&& response) {

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -66,11 +66,11 @@ void LightStepDriver::LightStepTransporter::Send(const Protobuf::Message& reques
       lightstep::CollectorMethodName(), absl::optional<std::chrono::milliseconds>(timeout));
   message->body() = Grpc::Common::serializeBody(request);
 
-  active_request_ = driver_.clusterManager()
-                        .httpAsyncClientForCluster(driver_.cluster()->name())
-                        .send(std::move(message), *this,
-                              Http::AsyncClient::RequestOptions(
-                                  absl::optional<std::chrono::milliseconds>(timeout)));
+  active_request_ =
+      driver_.clusterManager()
+          .httpAsyncClientForCluster(driver_.cluster()->name())
+          .send(std::move(message), *this,
+                Http::AsyncClient::RequestOptions().setTimeout(std::chrono::milliseconds(timeout)));
 }
 
 void LightStepDriver::LightStepTransporter::onSuccess(Http::MessagePtr&& response) {

--- a/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
+++ b/source/extensions/tracers/lightstep/lightstep_tracer_impl.cc
@@ -68,7 +68,9 @@ void LightStepDriver::LightStepTransporter::Send(const Protobuf::Message& reques
 
   active_request_ = driver_.clusterManager()
                         .httpAsyncClientForCluster(driver_.cluster()->name())
-    .send(std::move(message), *this, Http::AsyncClient::SendArgs(absl::optional<std::chrono::milliseconds>(timeout)));
+                        .send(std::move(message), *this,
+                              Http::AsyncClient::RequestOptions(
+                                  absl::optional<std::chrono::milliseconds>(timeout)));
 }
 
 void LightStepDriver::LightStepTransporter::onSuccess(Http::MessagePtr&& response) {

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -176,7 +176,9 @@ void ReporterImpl::flushSpans() {
         driver_.runtime().snapshot().getInteger("tracing.zipkin.request_timeout", 5000U);
     driver_.clusterManager()
         .httpAsyncClientForCluster(driver_.cluster()->name())
-      .send(std::move(message), *this, Http::AsyncClient::SendArgs(absl::optional<std::chrono::milliseconds>(timeout)));
+        .send(
+            std::move(message), *this,
+            Http::AsyncClient::RequestOptions(absl::optional<std::chrono::milliseconds>(timeout)));
 
     span_buffer_.clear();
   }

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -176,7 +176,7 @@ void ReporterImpl::flushSpans() {
         driver_.runtime().snapshot().getInteger("tracing.zipkin.request_timeout", 5000U);
     driver_.clusterManager()
         .httpAsyncClientForCluster(driver_.cluster()->name())
-        .send(std::move(message), *this, std::chrono::milliseconds(timeout));
+      .send(std::move(message), *this, Http::AsyncClient::SendArgs(absl::optional<std::chrono::milliseconds>(timeout)));
 
     span_buffer_.clear();
   }

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -176,9 +176,8 @@ void ReporterImpl::flushSpans() {
         driver_.runtime().snapshot().getInteger("tracing.zipkin.request_timeout", 5000U);
     driver_.clusterManager()
         .httpAsyncClientForCluster(driver_.cluster()->name())
-        .send(
-            std::move(message), *this,
-            Http::AsyncClient::RequestOptions(absl::optional<std::chrono::milliseconds>(timeout)));
+        .send(std::move(message), *this,
+              Http::AsyncClient::RequestOptions().setTimeout(std::chrono::milliseconds(timeout)));
 
     span_buffer_.clear();
   }

--- a/source/server/config_validation/async_client.cc
+++ b/source/server/config_validation/async_client.cc
@@ -6,11 +6,11 @@ namespace Http {
 ValidationAsyncClient::ValidationAsyncClient(Event::TimeSystem& time_system)
     : dispatcher_(time_system) {}
 
-AsyncClient::Request* ValidationAsyncClient::send(MessagePtr&&, Callbacks&, const SendArgs&) {
+AsyncClient::Request* ValidationAsyncClient::send(MessagePtr&&, Callbacks&, const RequestOptions&) {
   return nullptr;
 }
 
-AsyncClient::Stream* ValidationAsyncClient::start(StreamCallbacks&, const StartArgs&) {
+AsyncClient::Stream* ValidationAsyncClient::start(StreamCallbacks&, const StreamOptions&) {
   return nullptr;
 }
 

--- a/source/server/config_validation/async_client.cc
+++ b/source/server/config_validation/async_client.cc
@@ -6,15 +6,11 @@ namespace Http {
 ValidationAsyncClient::ValidationAsyncClient(Event::TimeSystem& time_system)
     : dispatcher_(time_system) {}
 
-AsyncClient::Request*
-ValidationAsyncClient::send(MessagePtr&&, Callbacks&,
-                            const absl::optional<std::chrono::milliseconds>&) {
+AsyncClient::Request* ValidationAsyncClient::send(MessagePtr&&, Callbacks&, const SendArgs&) {
   return nullptr;
 }
 
-AsyncClient::Stream* ValidationAsyncClient::start(StreamCallbacks&,
-                                                  const absl::optional<std::chrono::milliseconds>&,
-                                                  bool) {
+AsyncClient::Stream* ValidationAsyncClient::start(StreamCallbacks&, const StartArgs&) {
   return nullptr;
 }
 

--- a/source/server/config_validation/async_client.h
+++ b/source/server/config_validation/async_client.h
@@ -22,8 +22,9 @@ public:
   ValidationAsyncClient(Event::TimeSystem& time_system);
 
   // Http::AsyncClient
-  AsyncClient::Request* send(MessagePtr&& request, Callbacks& callbacks, const SendArgs&) override;
-  AsyncClient::Stream* start(StreamCallbacks& callbacks, const StartArgs&) override;
+  AsyncClient::Request* send(MessagePtr&& request, Callbacks& callbacks,
+                             const RequestOptions&) override;
+  AsyncClient::Stream* start(StreamCallbacks& callbacks, const StreamOptions&) override;
 
   Event::Dispatcher& dispatcher() override { return dispatcher_; }
 

--- a/source/server/config_validation/async_client.h
+++ b/source/server/config_validation/async_client.h
@@ -22,11 +22,9 @@ public:
   ValidationAsyncClient(Event::TimeSystem& time_system);
 
   // Http::AsyncClient
-  AsyncClient::Request* send(MessagePtr&& request, Callbacks& callbacks,
-                             const absl::optional<std::chrono::milliseconds>& timeout) override;
-  AsyncClient::Stream* start(StreamCallbacks& callbacks,
-                             const absl::optional<std::chrono::milliseconds>& timeout,
-                             bool buffer_body_for_retry) override;
+  AsyncClient::Request* send(MessagePtr&& request, Callbacks& callbacks, const SendArgs&) override;
+  AsyncClient::Stream* start(StreamCallbacks& callbacks, const StartArgs&) override;
+
   Event::Dispatcher& dispatcher() override { return dispatcher_; }
 
 private:

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -61,9 +61,8 @@ public:
     EXPECT_CALL(cm_.async_client_, send_(_, _, _))
         .WillOnce(Invoke([this, cluster_names, version](
                              Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
-                             const absl::optional<std::chrono::milliseconds>& timeout) {
+                             const Http::AsyncClient::SendArgs&) {
           http_callbacks_ = &callbacks;
-          UNREFERENCED_PARAMETER(timeout);
           EXPECT_EQ("POST", std::string(request->headers().Method()->value().c_str()));
           EXPECT_EQ(Http::Headers::get().ContentTypeValues.Json,
                     std::string(request->headers().ContentType()->value().c_str()));

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -59,9 +59,9 @@ public:
                          const std::string& version) override {
     EXPECT_CALL(cm_, httpAsyncClientForCluster("eds_cluster"));
     EXPECT_CALL(cm_.async_client_, send_(_, _, _))
-        .WillOnce(Invoke([this, cluster_names, version](
-                             Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
-                             const Http::AsyncClient::SendArgs&) {
+        .WillOnce(Invoke([this, cluster_names, version](Http::MessagePtr& request,
+                                                        Http::AsyncClient::Callbacks& callbacks,
+                                                        const Http::AsyncClient::RequestOptions&) {
           http_callbacks_ = &callbacks;
           EXPECT_EQ("POST", std::string(request->headers().Method()->value().c_str()));
           EXPECT_EQ(Http::Headers::get().ContentTypeValues.Json,

--- a/test/common/config/subscription_factory_test.cc
+++ b/test/common/config/subscription_factory_test.cc
@@ -252,10 +252,8 @@ TEST_F(SubscriptionFactoryTest, HttpSubscription) {
   EXPECT_CALL(dispatcher_, createTimer_(_));
   EXPECT_CALL(cm_, httpAsyncClientForCluster("static_cluster"));
   EXPECT_CALL(cm_.async_client_, send_(_, _, _))
-      .WillOnce(Invoke([this](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
-                              const absl::optional<std::chrono::milliseconds>& timeout) {
-        UNREFERENCED_PARAMETER(callbacks);
-        UNREFERENCED_PARAMETER(timeout);
+      .WillOnce(Invoke([this](Http::MessagePtr& request, Http::AsyncClient::Callbacks&,
+                              const Http::AsyncClient::SendArgs&) {
         EXPECT_EQ("POST", std::string(request->headers().Method()->value().c_str()));
         EXPECT_EQ("static_cluster", std::string(request->headers().Host()->value().c_str()));
         EXPECT_EQ("/v2/discovery:endpoints",

--- a/test/common/config/subscription_factory_test.cc
+++ b/test/common/config/subscription_factory_test.cc
@@ -231,9 +231,9 @@ TEST_F(SubscriptionFactoryTest, HttpSubscriptionCustomRequestTimeout) {
   EXPECT_CALL(*cluster.info_, addedViaApi());
   EXPECT_CALL(dispatcher_, createTimer_(_));
   EXPECT_CALL(cm_, httpAsyncClientForCluster("static_cluster"));
-  EXPECT_CALL(cm_.async_client_, send_(_, _,
-                                       Http::AsyncClient::RequestOptions(
-                                           absl::optional<std::chrono::milliseconds>(5000))));
+  EXPECT_CALL(
+      cm_.async_client_,
+      send_(_, _, Http::AsyncClient::RequestOptions().setTimeout(std::chrono::milliseconds(5000))));
   subscriptionFromConfigSource(config)->start({"static_cluster"}, callbacks_);
 }
 

--- a/test/common/config/subscription_factory_test.cc
+++ b/test/common/config/subscription_factory_test.cc
@@ -231,9 +231,9 @@ TEST_F(SubscriptionFactoryTest, HttpSubscriptionCustomRequestTimeout) {
   EXPECT_CALL(*cluster.info_, addedViaApi());
   EXPECT_CALL(dispatcher_, createTimer_(_));
   EXPECT_CALL(cm_, httpAsyncClientForCluster("static_cluster"));
-  EXPECT_CALL(
-      cm_.async_client_,
-      send_(_, _, absl::optional<std::chrono::milliseconds>(std::chrono::milliseconds(5000))));
+  EXPECT_CALL(cm_.async_client_, send_(_, _,
+                                       Http::AsyncClient::RequestOptions(
+                                           absl::optional<std::chrono::milliseconds>(5000))));
   subscriptionFromConfigSource(config)->start({"static_cluster"}, callbacks_);
 }
 
@@ -253,7 +253,7 @@ TEST_F(SubscriptionFactoryTest, HttpSubscription) {
   EXPECT_CALL(cm_, httpAsyncClientForCluster("static_cluster"));
   EXPECT_CALL(cm_.async_client_, send_(_, _, _))
       .WillOnce(Invoke([this](Http::MessagePtr& request, Http::AsyncClient::Callbacks&,
-                              const Http::AsyncClient::SendArgs&) {
+                              const Http::AsyncClient::RequestOptions&) {
         EXPECT_EQ("POST", std::string(request->headers().Method()->value().c_str()));
         EXPECT_EQ("static_cluster", std::string(request->headers().Host()->value().c_str()));
         EXPECT_EQ("/v2/discovery:endpoints",

--- a/test/common/grpc/async_client_impl_test.cc
+++ b/test/common/grpc/async_client_impl_test.cc
@@ -40,7 +40,7 @@ public:
 // UNAVAILABLE.
 TEST_F(EnvoyAsyncClientImplTest, StreamHttpStartFail) {
   MockAsyncStreamCallbacks<helloworld::HelloReply> grpc_callbacks;
-  ON_CALL(http_client_, start(_, _, false)).WillByDefault(Return(nullptr));
+  ON_CALL(http_client_, start(_, _)).WillByDefault(Return(nullptr));
   EXPECT_CALL(grpc_callbacks, onRemoteClose(Status::GrpcStatus::Unavailable, ""));
   auto* grpc_stream = grpc_client_->start(*method_descriptor_, grpc_callbacks);
   EXPECT_EQ(grpc_stream, nullptr);
@@ -50,7 +50,7 @@ TEST_F(EnvoyAsyncClientImplTest, StreamHttpStartFail) {
 // UNAVAILABLE.
 TEST_F(EnvoyAsyncClientImplTest, RequestHttpStartFail) {
   MockAsyncRequestCallbacks<helloworld::HelloReply> grpc_callbacks;
-  ON_CALL(http_client_, start(_, _, true)).WillByDefault(Return(nullptr));
+  ON_CALL(http_client_, start(_, _)).WillByDefault(Return(nullptr));
   EXPECT_CALL(grpc_callbacks, onFailure(Status::GrpcStatus::Unavailable, "", _));
   helloworld::HelloRequest request_msg;
 
@@ -76,10 +76,10 @@ TEST_F(EnvoyAsyncClientImplTest, StreamHttpSendHeadersFail) {
   MockAsyncStreamCallbacks<helloworld::HelloReply> grpc_callbacks;
   Http::AsyncClient::StreamCallbacks* http_callbacks;
   Http::MockAsyncClientStream http_stream;
-  EXPECT_CALL(http_client_, start(_, _, false))
+  EXPECT_CALL(http_client_, start(_, _))
       .WillOnce(Invoke(
           [&http_callbacks, &http_stream](Http::AsyncClient::StreamCallbacks& callbacks,
-                                          const absl::optional<std::chrono::milliseconds>&, bool) {
+                                          const Http::AsyncClient::StartArgs&) {
             http_callbacks = &callbacks;
             return &http_stream;
           }));
@@ -102,10 +102,10 @@ TEST_F(EnvoyAsyncClientImplTest, RequestHttpSendHeadersFail) {
   MockAsyncRequestCallbacks<helloworld::HelloReply> grpc_callbacks;
   Http::AsyncClient::StreamCallbacks* http_callbacks;
   Http::MockAsyncClientStream http_stream;
-  EXPECT_CALL(http_client_, start(_, _, true))
+  EXPECT_CALL(http_client_, start(_, _))
       .WillOnce(Invoke(
           [&http_callbacks, &http_stream](Http::AsyncClient::StreamCallbacks& callbacks,
-                                          const absl::optional<std::chrono::milliseconds>&, bool) {
+                                          const Http::AsyncClient::StartArgs&) {
             http_callbacks = &callbacks;
             return &http_stream;
           }));

--- a/test/common/grpc/async_client_impl_test.cc
+++ b/test/common/grpc/async_client_impl_test.cc
@@ -77,9 +77,9 @@ TEST_F(EnvoyAsyncClientImplTest, StreamHttpSendHeadersFail) {
   Http::AsyncClient::StreamCallbacks* http_callbacks;
   Http::MockAsyncClientStream http_stream;
   EXPECT_CALL(http_client_, start(_, _))
-      .WillOnce(Invoke(
-          [&http_callbacks, &http_stream](Http::AsyncClient::StreamCallbacks& callbacks,
-                                          const Http::AsyncClient::StartArgs&) {
+      .WillOnce(
+          Invoke([&http_callbacks, &http_stream](Http::AsyncClient::StreamCallbacks& callbacks,
+                                                 const Http::AsyncClient::StreamOptions&) {
             http_callbacks = &callbacks;
             return &http_stream;
           }));
@@ -103,9 +103,9 @@ TEST_F(EnvoyAsyncClientImplTest, RequestHttpSendHeadersFail) {
   Http::AsyncClient::StreamCallbacks* http_callbacks;
   Http::MockAsyncClientStream http_stream;
   EXPECT_CALL(http_client_, start(_, _))
-      .WillOnce(Invoke(
-          [&http_callbacks, &http_stream](Http::AsyncClient::StreamCallbacks& callbacks,
-                                          const Http::AsyncClient::StartArgs&) {
+      .WillOnce(
+          Invoke([&http_callbacks, &http_stream](Http::AsyncClient::StreamCallbacks& callbacks,
+                                                 const Http::AsyncClient::StreamOptions&) {
             http_callbacks = &callbacks;
             return &http_stream;
           }));

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -290,7 +290,7 @@ TEST_F(AsyncClientImplTest, MultipleStreams) {
   expectResponseHeaders(stream_callbacks2, 503, true);
 
   AsyncClient::Stream* stream2 =
-      client_.start(stream_callbacks2, AsyncClient::StartArgs(), false);
+      client_.start(stream_callbacks2, AsyncClient::StartArgs());
   stream2->sendHeaders(headers2, false);
   stream2->sendData(*body2, true);
 
@@ -541,7 +541,7 @@ TEST_F(AsyncClientImplTest, ResetInOnHeaders) {
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(body.get()), false));
 
   AsyncClient::Stream* stream =
-      client_.start(stream_callbacks_, AsyncClient::StartArgs(), false);
+      client_.start(stream_callbacks_, AsyncClient::StartArgs());
 
   TestHeaderMapImpl expected_headers{{":status", "200"}};
   EXPECT_CALL(stream_callbacks_, onHeaders_(HeaderMapEqualRef(&expected_headers), false))
@@ -657,7 +657,7 @@ TEST_F(AsyncClientImplTest, DestroyWithActiveStream) {
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
   EXPECT_CALL(stream_callbacks_, onReset());
   AsyncClient::Stream* stream =
-      client_.start(stream_callbacks_, AsyncClient::StartArgs(), false);
+      client_.start(stream_callbacks_, AsyncClient::StartArgs());
   stream->sendHeaders(message_->headers(), false);
 }
 
@@ -729,7 +729,7 @@ TEST_F(AsyncClientImplTest, StreamTimeout) {
   EXPECT_CALL(stream_callbacks_, onData(_, true));
 
   AsyncClient::Stream* stream =
-      client_.start(stream_callbacks_, std::chrono::milliseconds(40), false);
+    client_.start(stream_callbacks_, AsyncClient::StartArgs(std::chrono::milliseconds(40)));
   stream->sendHeaders(message_->headers(), true);
   timer_->callback_();
 
@@ -762,7 +762,7 @@ TEST_F(AsyncClientImplTest, StreamTimeoutHeadReply) {
   EXPECT_CALL(stream_callbacks_, onHeaders_(HeaderMapEqualRef(&expected_timeout), true));
 
   AsyncClient::Stream* stream =
-      client_.start(stream_callbacks_, std::chrono::milliseconds(40), false);
+    client_.start(stream_callbacks_, AsyncClient::StartArgs(std::chrono::milliseconds(40)));
   stream->sendHeaders(message->headers(), true);
   timer_->callback_();
 }
@@ -826,7 +826,7 @@ TEST_F(AsyncClientImplTest, DisableTimerWithStream) {
   EXPECT_CALL(stream_callbacks_, onReset());
 
   AsyncClient::Stream* stream =
-      client_.start(stream_callbacks_, std::chrono::milliseconds(40), false);
+    client_.start(stream_callbacks_, AsyncClient::StartArgs(std::chrono::milliseconds(40)));
   stream->sendHeaders(message_->headers(), true);
   stream->reset();
 }

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -98,8 +98,7 @@ TEST_F(AsyncClientImplTest, BasicStream) {
   expectResponseHeaders(stream_callbacks_, 200, false);
   EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), true));
 
-  AsyncClient::Stream* stream =
-      client_.start(stream_callbacks_, AsyncClient::StartArgs());
+  AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
   stream->sendData(*body, true);
 
@@ -137,7 +136,7 @@ TEST_F(AsyncClientImplTest, Basic) {
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(&data), true));
   expectSuccess(200);
 
-  client_.send(std::move(message_), callbacks_, AsyncClient::SendArgs());
+  client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
 
   HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
@@ -171,7 +170,7 @@ TEST_F(AsyncClientImplTest, Retry) {
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(&data), true));
 
   message_->headers().insertEnvoyRetryOn().value(Headers::get().EnvoyRetryOnValues._5xx);
-  client_.send(std::move(message_), callbacks_, AsyncClient::SendArgs());
+  client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
 
   // Expect retry and retry timer create.
   timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
@@ -217,7 +216,7 @@ TEST_F(AsyncClientImplTest, RetryWithStream) {
 
   headers.insertEnvoyRetryOn().value(Headers::get().EnvoyRetryOnValues._5xx);
   AsyncClient::Stream* stream =
-    client_.start(stream_callbacks_, AsyncClient::StartArgs(true, true));
+      client_.start(stream_callbacks_, AsyncClient::StreamOptions(true, true));
   stream->sendHeaders(headers, false);
   stream->sendData(*body, true);
 
@@ -264,8 +263,7 @@ TEST_F(AsyncClientImplTest, MultipleStreams) {
   expectResponseHeaders(stream_callbacks_, 200, false);
   EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), true));
 
-  AsyncClient::Stream* stream =
-      client_.start(stream_callbacks_, AsyncClient::StartArgs());
+  AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
   stream->sendData(*body, true);
 
@@ -289,8 +287,7 @@ TEST_F(AsyncClientImplTest, MultipleStreams) {
 
   expectResponseHeaders(stream_callbacks2, 503, true);
 
-  AsyncClient::Stream* stream2 =
-      client_.start(stream_callbacks2, AsyncClient::StartArgs());
+  AsyncClient::Stream* stream2 = client_.start(stream_callbacks2, AsyncClient::StreamOptions());
   stream2->sendHeaders(headers2, false);
   stream2->sendData(*body2, true);
 
@@ -320,7 +317,7 @@ TEST_F(AsyncClientImplTest, MultipleRequests) {
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), false));
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(&data), true));
 
-  client_.send(std::move(message_), callbacks_, AsyncClient::SendArgs());
+  client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
 
   // Send request 2.
   MessagePtr message2{new RequestMessageImpl()};
@@ -336,7 +333,7 @@ TEST_F(AsyncClientImplTest, MultipleRequests) {
         return nullptr;
       }));
   EXPECT_CALL(stream_encoder2, encodeHeaders(HeaderMapEqualRef(&message2->headers()), true));
-  client_.send(std::move(message2), callbacks2, AsyncClient::SendArgs());
+  client_.send(std::move(message2), callbacks2, AsyncClient::RequestOptions());
 
   // Finish request 2.
   HeaderMapPtr response_headers2(new TestHeaderMapImpl{{":status", "503"}});
@@ -366,7 +363,7 @@ TEST_F(AsyncClientImplTest, StreamAndRequest) {
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), false));
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(&data), true));
 
-  client_.send(std::move(message_), callbacks_, AsyncClient::SendArgs());
+  client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
 
   // Start stream
   Buffer::InstancePtr body{new Buffer::OwnedImpl("test body")};
@@ -389,8 +386,7 @@ TEST_F(AsyncClientImplTest, StreamAndRequest) {
   expectResponseHeaders(stream_callbacks_, 200, false);
   EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), true));
 
-  AsyncClient::Stream* stream =
-      client_.start(stream_callbacks_, AsyncClient::StartArgs());
+  AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
   stream->sendData(*body, true);
 
@@ -429,8 +425,7 @@ TEST_F(AsyncClientImplTest, StreamWithTrailers) {
   TestHeaderMapImpl expected_trailers{{"some", "trailer"}};
   EXPECT_CALL(stream_callbacks_, onTrailers_(HeaderMapEqualRef(&expected_trailers)));
 
-  AsyncClient::Stream* stream =
-      client_.start(stream_callbacks_, AsyncClient::StartArgs());
+  AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
   stream->sendData(*body, false);
   stream->sendTrailers(trailers);
@@ -457,7 +452,7 @@ TEST_F(AsyncClientImplTest, Trailers) {
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(&data), true));
   expectSuccess(200);
 
-  client_.send(std::move(message_), callbacks_, AsyncClient::SendArgs());
+  client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
   HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
   response_decoder_->decodeData(data, false);
@@ -475,7 +470,7 @@ TEST_F(AsyncClientImplTest, ImmediateReset) {
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), true));
   expectSuccess(503);
 
-  client_.send(std::move(message_), callbacks_, AsyncClient::SendArgs());
+  client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
   stream_encoder_.getStream().resetStream(StreamResetReason::RemoteReset);
 
   EXPECT_EQ(
@@ -508,8 +503,7 @@ TEST_F(AsyncClientImplTest, LocalResetAfterStreamStart) {
   EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), false));
   EXPECT_CALL(stream_callbacks_, onReset());
 
-  AsyncClient::Stream* stream =
-      client_.start(stream_callbacks_, AsyncClient::StartArgs());
+  AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
   stream->sendData(*body, false);
 
@@ -540,8 +534,7 @@ TEST_F(AsyncClientImplTest, ResetInOnHeaders) {
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&headers), false));
   EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(body.get()), false));
 
-  AsyncClient::Stream* stream =
-      client_.start(stream_callbacks_, AsyncClient::StartArgs());
+  AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
 
   TestHeaderMapImpl expected_headers{{":status", "200"}};
   EXPECT_CALL(stream_callbacks_, onHeaders_(HeaderMapEqualRef(&expected_headers), false))
@@ -582,8 +575,7 @@ TEST_F(AsyncClientImplTest, RemoteResetAfterStreamStart) {
   EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), false));
   EXPECT_CALL(stream_callbacks_, onReset());
 
-  AsyncClient::Stream* stream =
-      client_.start(stream_callbacks_, AsyncClient::StartArgs());
+  AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
   stream->sendData(*body, false);
 
@@ -605,7 +597,7 @@ TEST_F(AsyncClientImplTest, ResetAfterResponseStart) {
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), true));
   EXPECT_CALL(callbacks_, onFailure(_));
 
-  client_.send(std::move(message_), callbacks_, AsyncClient::SendArgs());
+  client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
   HeaderMapPtr response_headers(new TestHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
   stream_encoder_.getStream().resetStream(StreamResetReason::RemoteReset);
@@ -623,8 +615,7 @@ TEST_F(AsyncClientImplTest, ResetStream) {
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
   EXPECT_CALL(stream_callbacks_, onReset());
 
-  AsyncClient::Stream* stream =
-      client_.start(stream_callbacks_, AsyncClient::StartArgs());
+  AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(message_->headers(), true);
   stream->reset();
 }
@@ -641,7 +632,7 @@ TEST_F(AsyncClientImplTest, CancelRequest) {
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
 
   AsyncClient::Request* request =
-    client_.send(std::move(message_), callbacks_, AsyncClient::SendArgs());
+      client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
   request->cancel();
 }
 
@@ -656,8 +647,7 @@ TEST_F(AsyncClientImplTest, DestroyWithActiveStream) {
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), false));
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
   EXPECT_CALL(stream_callbacks_, onReset());
-  AsyncClient::Stream* stream =
-      client_.start(stream_callbacks_, AsyncClient::StartArgs());
+  AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(message_->headers(), false);
 }
 
@@ -672,7 +662,7 @@ TEST_F(AsyncClientImplTest, DestroyWithActiveRequest) {
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), true));
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
   EXPECT_CALL(callbacks_, onFailure(_));
-  client_.send(std::move(message_), callbacks_, AsyncClient::SendArgs());
+  client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
 }
 
 TEST_F(AsyncClientImplTest, PoolFailure) {
@@ -684,8 +674,7 @@ TEST_F(AsyncClientImplTest, PoolFailure) {
       }));
 
   expectSuccess(503);
-  EXPECT_EQ(nullptr, client_.send(std::move(message_), callbacks_,
-                                  AsyncClient::SendArgs()));
+  EXPECT_EQ(nullptr, client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions()));
 
   EXPECT_EQ(
       1UL,
@@ -702,8 +691,7 @@ TEST_F(AsyncClientImplTest, PoolFailureWithBody) {
 
   expectSuccess(503);
   message_->body() = std::make_unique<Buffer::OwnedImpl>("hello");
-  EXPECT_EQ(nullptr, client_.send(std::move(message_), callbacks_,
-                                  AsyncClient::SendArgs()));
+  EXPECT_EQ(nullptr, client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions()));
 
   EXPECT_EQ(
       1UL,
@@ -729,7 +717,7 @@ TEST_F(AsyncClientImplTest, StreamTimeout) {
   EXPECT_CALL(stream_callbacks_, onData(_, true));
 
   AsyncClient::Stream* stream =
-    client_.start(stream_callbacks_, AsyncClient::StartArgs(std::chrono::milliseconds(40)));
+      client_.start(stream_callbacks_, AsyncClient::StreamOptions(std::chrono::milliseconds(40)));
   stream->sendHeaders(message_->headers(), true);
   timer_->callback_();
 
@@ -762,7 +750,7 @@ TEST_F(AsyncClientImplTest, StreamTimeoutHeadReply) {
   EXPECT_CALL(stream_callbacks_, onHeaders_(HeaderMapEqualRef(&expected_timeout), true));
 
   AsyncClient::Stream* stream =
-    client_.start(stream_callbacks_, AsyncClient::StartArgs(std::chrono::milliseconds(40)));
+      client_.start(stream_callbacks_, AsyncClient::StreamOptions(std::chrono::milliseconds(40)));
   stream->sendHeaders(message->headers(), true);
   timer_->callback_();
 }
@@ -780,7 +768,8 @@ TEST_F(AsyncClientImplTest, RequestTimeout) {
   timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
   EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(40)));
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
-  client_.send(std::move(message_), callbacks_, AsyncClient::SendArgs(std::chrono::milliseconds(40)));
+  client_.send(std::move(message_), callbacks_,
+               AsyncClient::RequestOptions(std::chrono::milliseconds(40)));
   timer_->callback_();
 
   EXPECT_EQ(1UL,
@@ -805,8 +794,8 @@ TEST_F(AsyncClientImplTest, DisableTimer) {
   EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(200)));
   EXPECT_CALL(*timer_, disableTimer());
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
-  AsyncClient::Request* request =
-    client_.send(std::move(message_), callbacks_, AsyncClient::SendArgs(std::chrono::milliseconds(200)));
+  AsyncClient::Request* request = client_.send(
+      std::move(message_), callbacks_, AsyncClient::RequestOptions(std::chrono::milliseconds(200)));
   request->cancel();
 }
 
@@ -826,7 +815,7 @@ TEST_F(AsyncClientImplTest, DisableTimerWithStream) {
   EXPECT_CALL(stream_callbacks_, onReset());
 
   AsyncClient::Stream* stream =
-    client_.start(stream_callbacks_, AsyncClient::StartArgs(std::chrono::milliseconds(40)));
+      client_.start(stream_callbacks_, AsyncClient::StreamOptions(std::chrono::milliseconds(40)));
   stream->sendHeaders(message_->headers(), true);
   stream->reset();
 }
@@ -856,8 +845,7 @@ TEST_F(AsyncClientImplTest, MultipleDataStream) {
   EXPECT_CALL(stream_callbacks_, onHeaders_(HeaderMapEqualRef(&expected_headers), false));
   EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), false));
 
-  AsyncClient::Stream* stream =
-      client_.start(stream_callbacks_, AsyncClient::StartArgs());
+  AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
   stream->sendData(*body, false);
 
@@ -881,8 +869,7 @@ TEST_F(AsyncClientImplTest, MultipleDataStream) {
 TEST_F(AsyncClientImplTest, WatermarkCallbacks) {
   TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
-  AsyncClient::Stream* stream =
-      client_.start(stream_callbacks_, AsyncClient::StartArgs());
+  AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
   Http::StreamDecoderFilterCallbacks* filter_callbacks =
       static_cast<Http::AsyncStreamImpl*>(stream);
@@ -894,8 +881,7 @@ TEST_F(AsyncClientImplTest, WatermarkCallbacks) {
 TEST_F(AsyncClientImplTest, RdsGettersTest) {
   TestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
-  AsyncClient::Stream* stream =
-      client_.start(stream_callbacks_, AsyncClient::StartArgs());
+  AsyncClient::Stream* stream = client_.start(stream_callbacks_, AsyncClient::StreamOptions());
   stream->sendHeaders(headers, false);
   Http::StreamDecoderFilterCallbacks* filter_callbacks =
       static_cast<Http::AsyncStreamImpl*>(stream);

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -53,9 +53,9 @@ public:
   void expectRequest() {
     EXPECT_CALL(factory_context_.cluster_manager_, httpAsyncClientForCluster("foo_cluster"));
     EXPECT_CALL(factory_context_.cluster_manager_.async_client_, send_(_, _, _))
-        .WillOnce(Invoke(
-            [&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
-                const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+        .WillOnce(
+            Invoke([&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
+                       const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
               EXPECT_EQ((Http::TestHeaderMapImpl{
                             {":method", "GET"},
                             {":path", "/v1/routes/foo_route_config/cluster_name/node_name"},

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -55,7 +55,7 @@ public:
     EXPECT_CALL(factory_context_.cluster_manager_.async_client_, send_(_, _, _))
         .WillOnce(Invoke(
             [&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
-                const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+                const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
               EXPECT_EQ((Http::TestHeaderMapImpl{
                             {":method", "GET"},
                             {":path", "/v1/routes/foo_route_config/cluster_name/node_name"},

--- a/test/common/router/shadow_writer_impl_test.cc
+++ b/test/common/router/shadow_writer_impl_test.cc
@@ -28,10 +28,10 @@ public:
     Http::MockAsyncClientRequest request(&cm_.async_client_);
     EXPECT_CALL(
         cm_.async_client_,
-        send_(_, _, absl::optional<std::chrono::milliseconds>(std::chrono::milliseconds(5))))
+        send_(_, _, Http::AsyncClient::SendArgs(absl::optional<std::chrono::milliseconds>(5)))
         .WillOnce(Invoke(
             [&](Http::MessagePtr& inner_message, Http::AsyncClient::Callbacks& callbacks,
-                const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+                const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
               EXPECT_EQ(message, inner_message);
               EXPECT_EQ(shadowed_host, message->headers().Host()->value().c_str());
               callback_ = &callbacks;

--- a/test/common/router/shadow_writer_impl_test.cc
+++ b/test/common/router/shadow_writer_impl_test.cc
@@ -28,13 +28,12 @@ public:
     Http::MockAsyncClientRequest request(&cm_.async_client_);
     EXPECT_CALL(
         cm_.async_client_,
-        send_(_, _, _))
+        send_(_, _, Http::AsyncClient::SendArgs(std::chrono::milliseconds(5))))
         .WillOnce(Invoke(
             [&](Http::MessagePtr& inner_message, Http::AsyncClient::Callbacks& callbacks,
-                const Http::AsyncClient::SendArgs& args) -> Http::AsyncClient::Request* {
+                const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
               EXPECT_EQ(message, inner_message);
               EXPECT_EQ(shadowed_host, message->headers().Host()->value().c_str());
-	      EXPECT_EQ(args.timeout.value(), std::chrono::milliseconds(5));
               callback_ = &callbacks;
               return &request;
             }));

--- a/test/common/router/shadow_writer_impl_test.cc
+++ b/test/common/router/shadow_writer_impl_test.cc
@@ -26,12 +26,11 @@ public:
     EXPECT_CALL(cm_, get("foo"));
     EXPECT_CALL(cm_, httpAsyncClientForCluster("foo")).WillOnce(ReturnRef(cm_.async_client_));
     Http::MockAsyncClientRequest request(&cm_.async_client_);
-    EXPECT_CALL(
-        cm_.async_client_,
-        send_(_, _, Http::AsyncClient::SendArgs(std::chrono::milliseconds(5))))
-        .WillOnce(Invoke(
-            [&](Http::MessagePtr& inner_message, Http::AsyncClient::Callbacks& callbacks,
-                const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+    EXPECT_CALL(cm_.async_client_,
+                send_(_, _, Http::AsyncClient::RequestOptions(std::chrono::milliseconds(5))))
+        .WillOnce(
+            Invoke([&](Http::MessagePtr& inner_message, Http::AsyncClient::Callbacks& callbacks,
+                       const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
               EXPECT_EQ(message, inner_message);
               EXPECT_EQ(shadowed_host, message->headers().Host()->value().c_str());
               callback_ = &callbacks;

--- a/test/common/router/shadow_writer_impl_test.cc
+++ b/test/common/router/shadow_writer_impl_test.cc
@@ -26,8 +26,9 @@ public:
     EXPECT_CALL(cm_, get("foo"));
     EXPECT_CALL(cm_, httpAsyncClientForCluster("foo")).WillOnce(ReturnRef(cm_.async_client_));
     Http::MockAsyncClientRequest request(&cm_.async_client_);
-    EXPECT_CALL(cm_.async_client_,
-                send_(_, _, Http::AsyncClient::RequestOptions(std::chrono::milliseconds(5))))
+    EXPECT_CALL(
+        cm_.async_client_,
+        send_(_, _, Http::AsyncClient::RequestOptions().setTimeout(std::chrono::milliseconds(5))))
         .WillOnce(
             Invoke([&](Http::MessagePtr& inner_message, Http::AsyncClient::Callbacks& callbacks,
                        const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {

--- a/test/common/router/shadow_writer_impl_test.cc
+++ b/test/common/router/shadow_writer_impl_test.cc
@@ -28,12 +28,13 @@ public:
     Http::MockAsyncClientRequest request(&cm_.async_client_);
     EXPECT_CALL(
         cm_.async_client_,
-        send_(_, _, Http::AsyncClient::SendArgs(absl::optional<std::chrono::milliseconds>(5)))
+        send_(_, _, _))
         .WillOnce(Invoke(
             [&](Http::MessagePtr& inner_message, Http::AsyncClient::Callbacks& callbacks,
-                const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+                const Http::AsyncClient::SendArgs& args) -> Http::AsyncClient::Request* {
               EXPECT_EQ(message, inner_message);
               EXPECT_EQ(shadowed_host, message->headers().Host()->value().c_str());
+	      EXPECT_EQ(args.timeout.value(), std::chrono::milliseconds(5));
               callback_ = &callbacks;
               return &request;
             }));

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -75,9 +75,9 @@ public:
   void expectRequest() {
     EXPECT_CALL(cm_, httpAsyncClientForCluster("foo_cluster"));
     EXPECT_CALL(cm_.async_client_, send_(_, _, _))
-        .WillOnce(Invoke(
-            [&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
-                const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+        .WillOnce(
+            Invoke([&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
+                       const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
               EXPECT_EQ(
                   (Http::TestHeaderMapImpl{
                       {":method", v2_rest_ ? "POST" : "GET"},

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -77,7 +77,7 @@ public:
     EXPECT_CALL(cm_.async_client_, send_(_, _, _))
         .WillOnce(Invoke(
             [&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
-                const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+                const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
               EXPECT_EQ(
                   (Http::TestHeaderMapImpl{
                       {":method", v2_rest_ ? "POST" : "GET"},

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -107,10 +107,10 @@ protected:
     EXPECT_CALL(cm_, httpAsyncClientForCluster("sds")).WillOnce(ReturnRef(cm_.async_client_));
     EXPECT_CALL(
         cm_.async_client_,
-        send_(_, _, absl::optional<std::chrono::milliseconds>(std::chrono::milliseconds(1000))))
+        send_(_, _, Http::AsyncClient::SendArgs(absl::optional<std::milliseconds>(1000)))
         .WillOnce(
             Invoke([](Http::MessagePtr&, Http::AsyncClient::Callbacks& callbacks,
-                      absl::optional<std::chrono::milliseconds>) -> Http::AsyncClient::Request* {
+                      Http::AsyncClient::SendArgs) -> Http::AsyncClient::Request* {
               callbacks.onSuccess(Http::MessagePtr{new Http::ResponseMessageImpl(
                   Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "503"}}})});
               return nullptr;
@@ -121,7 +121,7 @@ protected:
     EXPECT_CALL(cm_, httpAsyncClientForCluster("sds")).WillOnce(ReturnRef(cm_.async_client_));
     EXPECT_CALL(
         cm_.async_client_,
-        send_(_, _, absl::optional<std::chrono::milliseconds>(std::chrono::milliseconds(1000))))
+        send_(_, _, Http::AsyncClient::SendArgs(absl::optional<std::chrono::milliseconds>(1000))))
         .WillOnce(DoAll(WithArg<1>(SaveArgAddress(&callbacks_)), Return(&request_)));
   }
 
@@ -159,7 +159,7 @@ TEST_F(SdsTest, RequestTimeout) {
   EXPECT_CALL(cm_, httpAsyncClientForCluster("sds")).WillOnce(ReturnRef(cm_.async_client_));
   EXPECT_CALL(
       cm_.async_client_,
-      send_(_, _, absl::optional<std::chrono::milliseconds>(std::chrono::milliseconds(5000))))
+      send_(_, _, Http::AsyncClient::SendArgs(absl::optional<std::chrono::milliseconds>(5000))))
       .WillOnce(DoAll(WithArg<1>(SaveArgAddress(&callbacks_)), Return(&request_)));
 
   cluster_->initialize([] {});

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -105,12 +105,11 @@ protected:
 
   void setupPoolFailure() {
     EXPECT_CALL(cm_, httpAsyncClientForCluster("sds")).WillOnce(ReturnRef(cm_.async_client_));
-    EXPECT_CALL(
-        cm_.async_client_,
-        send_(_, _, Http::AsyncClient::SendArgs(std::chrono::milliseconds(1000))))
+    EXPECT_CALL(cm_.async_client_,
+                send_(_, _, Http::AsyncClient::RequestOptions(std::chrono::milliseconds(1000))))
         .WillOnce(
             Invoke([](Http::MessagePtr&, Http::AsyncClient::Callbacks& callbacks,
-                      const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
               callbacks.onSuccess(Http::MessagePtr{new Http::ResponseMessageImpl(
                   Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "503"}}})});
               return nullptr;
@@ -119,9 +118,9 @@ protected:
 
   void setupRequest() {
     EXPECT_CALL(cm_, httpAsyncClientForCluster("sds")).WillOnce(ReturnRef(cm_.async_client_));
-    EXPECT_CALL(
-        cm_.async_client_,
-        send_(_, _, Http::AsyncClient::SendArgs(absl::optional<std::chrono::milliseconds>(1000))))
+    EXPECT_CALL(cm_.async_client_, send_(_, _,
+                                         Http::AsyncClient::RequestOptions(
+                                             absl::optional<std::chrono::milliseconds>(1000))))
         .WillOnce(DoAll(WithArg<1>(SaveArgAddress(&callbacks_)), Return(&request_)));
   }
 
@@ -157,9 +156,9 @@ TEST_F(SdsTest, RequestTimeout) {
   resetCluster(true);
 
   EXPECT_CALL(cm_, httpAsyncClientForCluster("sds")).WillOnce(ReturnRef(cm_.async_client_));
-  EXPECT_CALL(
-      cm_.async_client_,
-      send_(_, _, Http::AsyncClient::SendArgs(absl::optional<std::chrono::milliseconds>(5000))))
+  EXPECT_CALL(cm_.async_client_, send_(_, _,
+                                       Http::AsyncClient::RequestOptions(
+                                           absl::optional<std::chrono::milliseconds>(5000))))
       .WillOnce(DoAll(WithArg<1>(SaveArgAddress(&callbacks_)), Return(&request_)));
 
   cluster_->initialize([] {});

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -107,10 +107,10 @@ protected:
     EXPECT_CALL(cm_, httpAsyncClientForCluster("sds")).WillOnce(ReturnRef(cm_.async_client_));
     EXPECT_CALL(
         cm_.async_client_,
-        send_(_, _, Http::AsyncClient::SendArgs(absl::optional<std::milliseconds>(1000)))
+        send_(_, _, Http::AsyncClient::SendArgs(std::chrono::milliseconds(1000))))
         .WillOnce(
             Invoke([](Http::MessagePtr&, Http::AsyncClient::Callbacks& callbacks,
-                      Http::AsyncClient::SendArgs) -> Http::AsyncClient::Request* {
+                      const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
               callbacks.onSuccess(Http::MessagePtr{new Http::ResponseMessageImpl(
                   Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "503"}}})});
               return nullptr;

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -105,8 +105,9 @@ protected:
 
   void setupPoolFailure() {
     EXPECT_CALL(cm_, httpAsyncClientForCluster("sds")).WillOnce(ReturnRef(cm_.async_client_));
-    EXPECT_CALL(cm_.async_client_,
-                send_(_, _, Http::AsyncClient::RequestOptions(std::chrono::milliseconds(1000))))
+    EXPECT_CALL(cm_.async_client_, send_(_, _,
+                                         Http::AsyncClient::RequestOptions().setTimeout(
+                                             std::chrono::milliseconds(1000))))
         .WillOnce(
             Invoke([](Http::MessagePtr&, Http::AsyncClient::Callbacks& callbacks,
                       const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
@@ -119,8 +120,8 @@ protected:
   void setupRequest() {
     EXPECT_CALL(cm_, httpAsyncClientForCluster("sds")).WillOnce(ReturnRef(cm_.async_client_));
     EXPECT_CALL(cm_.async_client_, send_(_, _,
-                                         Http::AsyncClient::RequestOptions(
-                                             absl::optional<std::chrono::milliseconds>(1000))))
+                                         Http::AsyncClient::RequestOptions().setTimeout(
+                                             std::chrono::milliseconds(1000))))
         .WillOnce(DoAll(WithArg<1>(SaveArgAddress(&callbacks_)), Return(&request_)));
   }
 
@@ -156,9 +157,9 @@ TEST_F(SdsTest, RequestTimeout) {
   resetCluster(true);
 
   EXPECT_CALL(cm_, httpAsyncClientForCluster("sds")).WillOnce(ReturnRef(cm_.async_client_));
-  EXPECT_CALL(cm_.async_client_, send_(_, _,
-                                       Http::AsyncClient::RequestOptions(
-                                           absl::optional<std::chrono::milliseconds>(5000))))
+  EXPECT_CALL(
+      cm_.async_client_,
+      send_(_, _, Http::AsyncClient::RequestOptions().setTimeout(std::chrono::milliseconds(5000))))
       .WillOnce(DoAll(WithArg<1>(SaveArgAddress(&callbacks_)), Return(&request_)));
 
   cluster_->initialize([] {});

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -114,7 +114,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithPathRewrite) {
   EXPECT_CALL(async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks&,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             const auto* length_header_entry = message->headers().get(Http::Headers::get().Path);
             EXPECT_EQ(length_header_entry->value().getStringView(), "/bar/foo");
             return nullptr;

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -112,9 +112,9 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithPathRewrite) {
   (*mutable_headers)[std::string{"foo"}] = std::string{"bar"};
 
   EXPECT_CALL(async_client_, send_(_, _, _))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks&,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+      .WillOnce(
+          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks&,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             const auto* length_header_entry = message->headers().get(Http::Headers::get().Path);
             EXPECT_EQ(length_header_entry->value().getStringView(), "/bar/foo");
             return nullptr;
@@ -139,9 +139,9 @@ TEST_F(ExtAuthzHttpClientTest, ContentLengthEqualZero) {
   (*mutable_headers)[Http::Headers::get().Method.get()] = std::string{"POST"};
 
   EXPECT_CALL(async_client_, send_(_, _, _))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks&,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+      .WillOnce(
+          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks&,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             const auto* length_header_entry =
                 message->headers().get(Http::Headers::get().ContentLength);
             EXPECT_EQ(length_header_entry->value().getStringView(), "0");

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -141,7 +141,7 @@ TEST_F(ExtAuthzHttpClientTest, ContentLengthEqualZero) {
   EXPECT_CALL(async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks&,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             const auto* length_header_entry =
                 message->headers().get(Http::Headers::get().ContentLength);
             EXPECT_EQ(length_header_entry->value().getStringView(), "0");

--- a/test/extensions/filters/http/common/mock.cc
+++ b/test/extensions/filters/http/common/mock.cc
@@ -12,7 +12,7 @@ MockUpstream::MockUpstream(Upstream::MockClusterManager& mock_cm, const std::str
   ON_CALL(mock_cm.async_client_, send_(testing::_, testing::_, testing::_))
       .WillByDefault(testing::Invoke(
           [this](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
-                 const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+                 const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             Http::MessagePtr response_message(new Http::ResponseMessageImpl(
                 Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", status_}}}));
             if (response_body_.length()) {
@@ -32,7 +32,7 @@ MockUpstream::MockUpstream(Upstream::MockClusterManager& mock_cm,
       .WillByDefault(testing::Invoke(
           [this, reason](
               Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             cb.onFailure(reason);
             return &request_;
           }));

--- a/test/extensions/filters/http/common/mock.cc
+++ b/test/extensions/filters/http/common/mock.cc
@@ -12,7 +12,7 @@ MockUpstream::MockUpstream(Upstream::MockClusterManager& mock_cm, const std::str
   ON_CALL(mock_cm.async_client_, send_(testing::_, testing::_, testing::_))
       .WillByDefault(testing::Invoke(
           [this](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
-                 const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+                 const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             Http::MessagePtr response_message(new Http::ResponseMessageImpl(
                 Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", status_}}}));
             if (response_body_.length()) {
@@ -30,9 +30,8 @@ MockUpstream::MockUpstream(Upstream::MockClusterManager& mock_cm,
     : request_(&mock_cm.async_client_) {
   ON_CALL(mock_cm.async_client_, send_(testing::_, testing::_, testing::_))
       .WillByDefault(testing::Invoke(
-          [this, reason](
-              Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+          [this, reason](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
+                         const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             cb.onFailure(reason);
             return &request_;
           }));

--- a/test/extensions/filters/http/jwt_authn/mock.h
+++ b/test/extensions/filters/http/jwt_authn/mock.h
@@ -59,7 +59,7 @@ public:
       : request_(&mock_cm.async_client_), response_body_(response_body) {
     ON_CALL(mock_cm.async_client_, send_(_, _, _))
         .WillByDefault(Invoke([this](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
-                                     const absl::optional<std::chrono::milliseconds>&)
+                                     const Http::AsyncClient::SendArgs&)
                                   -> Http::AsyncClient::Request* {
           Http::MessagePtr response_message(new Http::ResponseMessageImpl(
               Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));

--- a/test/extensions/filters/http/jwt_authn/mock.h
+++ b/test/extensions/filters/http/jwt_authn/mock.h
@@ -58,16 +58,16 @@ public:
   MockUpstream(Upstream::MockClusterManager& mock_cm, const std::string& response_body)
       : request_(&mock_cm.async_client_), response_body_(response_body) {
     ON_CALL(mock_cm.async_client_, send_(_, _, _))
-        .WillByDefault(Invoke([this](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
-                                     const Http::AsyncClient::SendArgs&)
-                                  -> Http::AsyncClient::Request* {
-          Http::MessagePtr response_message(new Http::ResponseMessageImpl(
-              Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
-          response_message->body() = std::make_unique<Buffer::OwnedImpl>(response_body_);
-          cb.onSuccess(std::move(response_message));
-          called_count_++;
-          return &request_;
-        }));
+        .WillByDefault(
+            Invoke([this](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
+                          const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
+              Http::MessagePtr response_message(new Http::ResponseMessageImpl(
+                  Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+              response_message->body() = std::make_unique<Buffer::OwnedImpl>(response_body_);
+              cb.onSuccess(std::move(response_message));
+              called_count_++;
+              return &request_;
+            }));
   }
 
   int called_count() const { return called_count_; }

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -759,7 +759,7 @@ TEST_F(LuaHttpFilterTest, HttpCall) {
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/"},
                                                {":method", "POST"},
                                                {":authority", "foo"},
@@ -834,7 +834,7 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/"},
                                                {":method", "POST"},
                                                {":authority", "foo"},
@@ -857,7 +857,7 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             EXPECT_EQ((Http::TestHeaderMapImpl{
                           {":path", "/bar"}, {":method", "GET"}, {":authority", "foo"}}),
                       message->headers());
@@ -913,7 +913,7 @@ TEST_F(LuaHttpFilterTest, HttpCallNoBody) {
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             EXPECT_EQ((Http::TestHeaderMapImpl{
                           {":path", "/"}, {":method", "GET"}, {":authority", "foo"}}),
                       message->headers());
@@ -968,7 +968,7 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateResponse) {
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             EXPECT_EQ((Http::TestHeaderMapImpl{
                           {":path", "/"}, {":method", "GET"}, {":authority", "foo"}}),
                       message->headers());
@@ -1016,7 +1016,7 @@ TEST_F(LuaHttpFilterTest, HttpCallErrorAfterResumeSuccess) {
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callbacks = &cb;
             return &request;
           }));
@@ -1066,7 +1066,7 @@ TEST_F(LuaHttpFilterTest, HttpCallFailure) {
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callbacks = &cb;
             return &request;
           }));
@@ -1108,7 +1108,7 @@ TEST_F(LuaHttpFilterTest, HttpCallReset) {
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callbacks = &cb;
             return &request;
           }));
@@ -1151,7 +1151,7 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateFailure) {
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             cb.onFailure(Http::AsyncClient::FailureReason::Reset);
             return nullptr;
           }));

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -757,9 +757,9 @@ TEST_F(LuaHttpFilterTest, HttpCall) {
   EXPECT_CALL(cluster_manager_, get("cluster"));
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+      .WillOnce(
+          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/"},
                                                {":method", "POST"},
                                                {":authority", "foo"},
@@ -832,9 +832,9 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
   EXPECT_CALL(cluster_manager_, get("cluster"));
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+      .WillOnce(
+          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/"},
                                                {":method", "POST"},
                                                {":authority", "foo"},
@@ -855,9 +855,9 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
   EXPECT_CALL(cluster_manager_, get("cluster2"));
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster2"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+      .WillOnce(
+          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             EXPECT_EQ((Http::TestHeaderMapImpl{
                           {":path", "/bar"}, {":method", "GET"}, {":authority", "foo"}}),
                       message->headers());
@@ -911,9 +911,9 @@ TEST_F(LuaHttpFilterTest, HttpCallNoBody) {
   EXPECT_CALL(cluster_manager_, get("cluster"));
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+      .WillOnce(
+          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             EXPECT_EQ((Http::TestHeaderMapImpl{
                           {":path", "/"}, {":method", "GET"}, {":authority", "foo"}}),
                       message->headers());
@@ -966,9 +966,9 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateResponse) {
   EXPECT_CALL(cluster_manager_, get("cluster"));
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+      .WillOnce(
+          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             EXPECT_EQ((Http::TestHeaderMapImpl{
                           {":path", "/"}, {":method", "GET"}, {":authority", "foo"}}),
                       message->headers());
@@ -1014,9 +1014,9 @@ TEST_F(LuaHttpFilterTest, HttpCallErrorAfterResumeSuccess) {
   EXPECT_CALL(cluster_manager_, get("cluster"));
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+      .WillOnce(
+          Invoke([&](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             callbacks = &cb;
             return &request;
           }));
@@ -1064,9 +1064,9 @@ TEST_F(LuaHttpFilterTest, HttpCallFailure) {
   EXPECT_CALL(cluster_manager_, get("cluster"));
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+      .WillOnce(
+          Invoke([&](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             callbacks = &cb;
             return &request;
           }));
@@ -1106,9 +1106,9 @@ TEST_F(LuaHttpFilterTest, HttpCallReset) {
   EXPECT_CALL(cluster_manager_, get("cluster"));
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+      .WillOnce(
+          Invoke([&](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             callbacks = &cb;
             return &request;
           }));
@@ -1149,9 +1149,9 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateFailure) {
   EXPECT_CALL(cluster_manager_, get("cluster"));
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+      .WillOnce(
+          Invoke([&](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             cb.onFailure(Http::AsyncClient::FailureReason::Reset);
             return nullptr;
           }));

--- a/test/extensions/filters/http/squash/squash_filter_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_test.cc
@@ -219,7 +219,7 @@ protected:
   void expectAsyncClientSend() {
     EXPECT_CALL(cm_.async_client_, send_(_, _, _))
         .WillOnce(Invoke([&](Envoy::Http::MessagePtr&, Envoy::Http::AsyncClient::Callbacks& cb,
-                             const absl::optional<std::chrono::milliseconds>&)
+                             const Http::AsyncClient::SendArgs&)
                              -> Envoy::Http::AsyncClient::Request* {
           callbacks_.push_back(&cb);
           return &request_;
@@ -270,7 +270,7 @@ TEST_F(SquashFilterTest, DecodeHeaderContinuesOnClientFail) {
 
   EXPECT_CALL(cm_.async_client_, send_(_, _, _))
       .WillOnce(Invoke([&](Envoy::Http::MessagePtr&, Envoy::Http::AsyncClient::Callbacks& callbacks,
-                           const absl::optional<std::chrono::milliseconds>&)
+                           const Http::AsyncClient::SendArgs&)
                            -> Envoy::Http::AsyncClient::Request* {
         callbacks.onFailure(Envoy::Http::AsyncClient::FailureReason::Reset);
         return nullptr;
@@ -435,7 +435,7 @@ TEST_F(SquashFilterTest, TimerExpiresInline) {
 
   EXPECT_CALL(cm_.async_client_, send_(_, _, _))
       .WillOnce(Invoke([&](Envoy::Http::MessagePtr&, Envoy::Http::AsyncClient::Callbacks&,
-                           const absl::optional<std::chrono::milliseconds>&)
+                           const Http::AsyncClient::SendArgs&)
                            -> Envoy::Http::AsyncClient::Request* { return &request_; }));
 
   EXPECT_CALL(request_, cancel());

--- a/test/extensions/filters/http/squash/squash_filter_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_test.cc
@@ -218,12 +218,12 @@ protected:
 
   void expectAsyncClientSend() {
     EXPECT_CALL(cm_.async_client_, send_(_, _, _))
-        .WillOnce(Invoke([&](Envoy::Http::MessagePtr&, Envoy::Http::AsyncClient::Callbacks& cb,
-                             const Http::AsyncClient::SendArgs&)
-                             -> Envoy::Http::AsyncClient::Request* {
-          callbacks_.push_back(&cb);
-          return &request_;
-        }));
+        .WillOnce(Invoke(
+            [&](Envoy::Http::MessagePtr&, Envoy::Http::AsyncClient::Callbacks& cb,
+                const Http::AsyncClient::RequestOptions&) -> Envoy::Http::AsyncClient::Request* {
+              callbacks_.push_back(&cb);
+              return &request_;
+            }));
   }
 
   void completeRequest(const std::string& status, const std::string& body) {
@@ -269,12 +269,12 @@ TEST_F(SquashFilterTest, DecodeHeaderContinuesOnClientFail) {
   EXPECT_CALL(cm_, httpAsyncClientForCluster("squash")).WillOnce(ReturnRef(cm_.async_client_));
 
   EXPECT_CALL(cm_.async_client_, send_(_, _, _))
-      .WillOnce(Invoke([&](Envoy::Http::MessagePtr&, Envoy::Http::AsyncClient::Callbacks& callbacks,
-                           const Http::AsyncClient::SendArgs&)
-                           -> Envoy::Http::AsyncClient::Request* {
-        callbacks.onFailure(Envoy::Http::AsyncClient::FailureReason::Reset);
-        return nullptr;
-      }));
+      .WillOnce(Invoke(
+          [&](Envoy::Http::MessagePtr&, Envoy::Http::AsyncClient::Callbacks& callbacks,
+              const Http::AsyncClient::RequestOptions&) -> Envoy::Http::AsyncClient::Request* {
+            callbacks.onFailure(Envoy::Http::AsyncClient::FailureReason::Reset);
+            return nullptr;
+          }));
 
   Envoy::Http::TestHeaderMapImpl headers{{":method", "GET"},
                                          {":authority", "www.solo.io"},
@@ -435,7 +435,7 @@ TEST_F(SquashFilterTest, TimerExpiresInline) {
 
   EXPECT_CALL(cm_.async_client_, send_(_, _, _))
       .WillOnce(Invoke([&](Envoy::Http::MessagePtr&, Envoy::Http::AsyncClient::Callbacks&,
-                           const Http::AsyncClient::SendArgs&)
+                           const Http::AsyncClient::RequestOptions&)
                            -> Envoy::Http::AsyncClient::Request* { return &request_; }));
 
   EXPECT_CALL(request_, cancel());

--- a/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
+++ b/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
@@ -98,9 +98,9 @@ public:
   void setupRequest() {
     EXPECT_CALL(cm_, httpAsyncClientForCluster("vpn")).WillOnce(ReturnRef(cm_.async_client_));
     EXPECT_CALL(cm_.async_client_, send_(_, _, _))
-        .WillOnce(Invoke(
-            [this](Http::MessagePtr&, Http::AsyncClient::Callbacks& callbacks,
-                   const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+        .WillOnce(
+            Invoke([this](Http::MessagePtr&, Http::AsyncClient::Callbacks& callbacks,
+                          const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
               callbacks_ = &callbacks;
               return &request_;
             }));
@@ -253,9 +253,9 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   // Interval timer fires, cannot obtain async client.
   EXPECT_CALL(cm_, httpAsyncClientForCluster("vpn")).WillOnce(ReturnRef(cm_.async_client_));
   EXPECT_CALL(cm_.async_client_, send_(_, _, _))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr&, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+      .WillOnce(
+          Invoke([&](Http::MessagePtr&, Http::AsyncClient::Callbacks& callbacks,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             callbacks.onSuccess(Http::MessagePtr{new Http::ResponseMessageImpl(
                 Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "503"}}})});
             return nullptr;

--- a/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
+++ b/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
@@ -100,7 +100,7 @@ public:
     EXPECT_CALL(cm_.async_client_, send_(_, _, _))
         .WillOnce(Invoke(
             [this](Http::MessagePtr&, Http::AsyncClient::Callbacks& callbacks,
-                   absl::optional<std::chrono::milliseconds>) -> Http::AsyncClient::Request* {
+                   const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
               callbacks_ = &callbacks;
               return &request_;
             }));
@@ -255,7 +255,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   EXPECT_CALL(cm_.async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr&, Http::AsyncClient::Callbacks& callbacks,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callbacks.onSuccess(Http::MessagePtr{new Http::ResponseMessageImpl(
                 Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "503"}}})});
             return nullptr;

--- a/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
+++ b/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
@@ -126,15 +126,14 @@ TEST_F(DatadogDriverTest, FlushSpansTimer) {
   Http::MockAsyncClientRequest request(&cm_.async_client_);
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(1));
-  EXPECT_CALL(cm_.async_client_, send_(_, _, _))
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs& args) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/msgpack", message->headers().ContentType()->value().c_str());
-	    EXPECT_EQ(args.timeout, timeout);
 
             return &request;
           }));

--- a/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
+++ b/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
@@ -125,11 +125,11 @@ TEST_F(DatadogDriverTest, FlushSpansTimer) {
 
   Http::MockAsyncClientRequest request(&cm_.async_client_);
   Http::AsyncClient::Callbacks* callback;
-  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(1));
+  const Http::AsyncClient::SendArgs timeout(std::chrono::seconds(1));
   EXPECT_CALL(cm_.async_client_, send_(_, _, timeout))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());

--- a/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
+++ b/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
@@ -126,7 +126,8 @@ TEST_F(DatadogDriverTest, FlushSpansTimer) {
   Http::MockAsyncClientRequest request(&cm_.async_client_);
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(1));
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)))
+  EXPECT_CALL(cm_.async_client_,
+              send_(_, _, Http::AsyncClient::RequestOptions().setTimeout(timeout)))
       .WillOnce(
           Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {

--- a/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
+++ b/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
@@ -125,15 +125,16 @@ TEST_F(DatadogDriverTest, FlushSpansTimer) {
 
   Http::MockAsyncClientRequest request(&cm_.async_client_);
   Http::AsyncClient::Callbacks* callback;
-  const Http::AsyncClient::SendArgs timeout(std::chrono::seconds(1));
-  EXPECT_CALL(cm_.async_client_, send_(_, _, timeout))
+  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(1));
+  EXPECT_CALL(cm_.async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs& args) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/msgpack", message->headers().ContentType()->value().c_str());
+	    EXPECT_EQ(args.timeout, timeout);
 
             return &request;
           }));

--- a/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
+++ b/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
@@ -126,10 +126,10 @@ TEST_F(DatadogDriverTest, FlushSpansTimer) {
   Http::MockAsyncClientRequest request(&cm_.async_client_);
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(1));
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)))
+      .WillOnce(
+          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -161,7 +161,8 @@ TEST_F(LightStepDriverTest, FlushSeveralSpans) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)))
+  EXPECT_CALL(cm_.async_client_,
+              send_(_, _, Http::AsyncClient::RequestOptions().setTimeout(timeout)))
       .WillOnce(
           Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
@@ -222,7 +223,8 @@ TEST_F(LightStepDriverTest, FlushOneFailure) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)))
+  EXPECT_CALL(cm_.async_client_,
+              send_(_, _, Http::AsyncClient::RequestOptions().setTimeout(timeout)))
       .WillOnce(
           Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
@@ -265,7 +267,8 @@ TEST_F(LightStepDriverTest, FlushOneInvalidResponse) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)))
+  EXPECT_CALL(cm_.async_client_,
+              send_(_, _, Http::AsyncClient::RequestOptions().setTimeout(timeout)))
       .WillOnce(
           Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
@@ -311,7 +314,8 @@ TEST_F(LightStepDriverTest, FlushSpansTimer) {
   setupValidDriver();
 
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)));
+  EXPECT_CALL(cm_.async_client_,
+              send_(_, _, Http::AsyncClient::RequestOptions().setTimeout(timeout)));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
                                              LightStepDriver::DefaultMinFlushSpans))
@@ -341,7 +345,8 @@ TEST_F(LightStepDriverTest, FlushOneSpanGrpcFailure) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)))
+  EXPECT_CALL(cm_.async_client_,
+              send_(_, _, Http::AsyncClient::RequestOptions().setTimeout(timeout)))
       .WillOnce(
           Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
@@ -386,7 +391,8 @@ TEST_F(LightStepDriverTest, CancelRequestOnDestruction) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)))
+  EXPECT_CALL(cm_.async_client_,
+              send_(_, _, Http::AsyncClient::RequestOptions().setTimeout(timeout)))
       .WillOnce(
           Invoke([&](Http::MessagePtr& /*message*/, Http::AsyncClient::Callbacks& callbacks,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -161,10 +161,10 @@ TEST_F(LightStepDriverTest, FlushSeveralSpans) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)))
+      .WillOnce(
+          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
@@ -222,10 +222,10 @@ TEST_F(LightStepDriverTest, FlushOneFailure) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)))
+      .WillOnce(
+          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
@@ -265,10 +265,10 @@ TEST_F(LightStepDriverTest, FlushOneInvalidResponse) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)))
+      .WillOnce(
+          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
@@ -311,7 +311,7 @@ TEST_F(LightStepDriverTest, FlushSpansTimer) {
   setupValidDriver();
 
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)));
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
                                              LightStepDriver::DefaultMinFlushSpans))
@@ -341,10 +341,10 @@ TEST_F(LightStepDriverTest, FlushOneSpanGrpcFailure) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)))
+      .WillOnce(
+          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
@@ -386,10 +386,10 @@ TEST_F(LightStepDriverTest, CancelRequestOnDestruction) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr& /*message*/, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)))
+      .WillOnce(
+          Invoke([&](Http::MessagePtr& /*message*/, Http::AsyncClient::Callbacks& callbacks,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             return &request;

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -159,12 +159,12 @@ TEST_F(LightStepDriverTest, FlushSeveralSpans) {
 
   Http::MockAsyncClientRequest request(&cm_.async_client_);
   Http::AsyncClient::Callbacks* callback;
-  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
+  const Http::AsyncClient::SendArgs timeout(std::chrono::seconds(5));
 
   EXPECT_CALL(cm_.async_client_, send_(_, _, timeout))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
@@ -220,12 +220,12 @@ TEST_F(LightStepDriverTest, FlushOneFailure) {
 
   Http::MockAsyncClientRequest request(&cm_.async_client_);
   Http::AsyncClient::Callbacks* callback;
-  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
+  const Http::AsyncClient::SendArgs timeout(std::chrono::seconds(5));
 
   EXPECT_CALL(cm_.async_client_, send_(_, _, timeout))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
@@ -263,12 +263,12 @@ TEST_F(LightStepDriverTest, FlushOneInvalidResponse) {
 
   Http::MockAsyncClientRequest request(&cm_.async_client_);
   Http::AsyncClient::Callbacks* callback;
-  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
+  const Http::AsyncClient::SendArgs timeout(std::chrono::seconds(5));
 
   EXPECT_CALL(cm_.async_client_, send_(_, _, timeout))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
@@ -310,7 +310,7 @@ TEST_F(LightStepDriverTest, FlushOneInvalidResponse) {
 TEST_F(LightStepDriverTest, FlushSpansTimer) {
   setupValidDriver();
 
-  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
+  const Http::AsyncClient::SendArgs timeout(std::chrono::seconds(5));
   EXPECT_CALL(cm_.async_client_, send_(_, _, timeout));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
@@ -339,12 +339,12 @@ TEST_F(LightStepDriverTest, FlushOneSpanGrpcFailure) {
 
   Http::MockAsyncClientRequest request(&cm_.async_client_);
   Http::AsyncClient::Callbacks* callback;
-  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
+  const Http::AsyncClient::SendArgs timeout(std::chrono::seconds(5));
 
   EXPECT_CALL(cm_.async_client_, send_(_, _, timeout))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
@@ -384,12 +384,12 @@ TEST_F(LightStepDriverTest, CancelRequestOnDestruction) {
 
   Http::MockAsyncClientRequest request(&cm_.async_client_);
   Http::AsyncClient::Callbacks* callback;
-  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
+  const Http::AsyncClient::SendArgs timeout(std::chrono::seconds(5));
 
   EXPECT_CALL(cm_.async_client_, send_(_, _, timeout))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& /*message*/, Http::AsyncClient::Callbacks& callbacks,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             return &request;

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -161,17 +161,16 @@ TEST_F(LightStepDriverTest, FlushSeveralSpans) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, _))
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs& args) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
             EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
-	    EXPECT_EQ(args.timeout, timeout);
 
             return &request;
           }));
@@ -223,17 +222,16 @@ TEST_F(LightStepDriverTest, FlushOneFailure) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, _))
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs& args) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
             EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
-            EXPECT_EQ(args.timeout, timeout);
 
             return &request;
           }));
@@ -267,17 +265,16 @@ TEST_F(LightStepDriverTest, FlushOneInvalidResponse) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, _))
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs& args) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
             EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
-            EXPECT_EQ(args.timeout, timeout);
 
             return &request;
           }));
@@ -314,7 +311,7 @@ TEST_F(LightStepDriverTest, FlushSpansTimer) {
   setupValidDriver();
 
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
-  EXPECT_CALL(cm_.async_client_, send_(_, _, _));
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
                                              LightStepDriver::DefaultMinFlushSpans))
@@ -344,17 +341,16 @@ TEST_F(LightStepDriverTest, FlushOneSpanGrpcFailure) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, _))
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs& args) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
             EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
-            EXPECT_EQ(args.timeout, timeout);
 
             return &request;
           }));
@@ -390,12 +386,11 @@ TEST_F(LightStepDriverTest, CancelRequestOnDestruction) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, _))
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& /*message*/, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs& args) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
-            EXPECT_EQ(args.timeout, timeout);
 
             return &request;
           }));

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -159,18 +159,19 @@ TEST_F(LightStepDriverTest, FlushSeveralSpans) {
 
   Http::MockAsyncClientRequest request(&cm_.async_client_);
   Http::AsyncClient::Callbacks* callback;
-  const Http::AsyncClient::SendArgs timeout(std::chrono::seconds(5));
+  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, timeout))
+  EXPECT_CALL(cm_.async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs& args) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
             EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
+	    EXPECT_EQ(args.timeout, timeout);
 
             return &request;
           }));
@@ -220,18 +221,19 @@ TEST_F(LightStepDriverTest, FlushOneFailure) {
 
   Http::MockAsyncClientRequest request(&cm_.async_client_);
   Http::AsyncClient::Callbacks* callback;
-  const Http::AsyncClient::SendArgs timeout(std::chrono::seconds(5));
+  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, timeout))
+  EXPECT_CALL(cm_.async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs& args) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
             EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
+            EXPECT_EQ(args.timeout, timeout);
 
             return &request;
           }));
@@ -263,18 +265,19 @@ TEST_F(LightStepDriverTest, FlushOneInvalidResponse) {
 
   Http::MockAsyncClientRequest request(&cm_.async_client_);
   Http::AsyncClient::Callbacks* callback;
-  const Http::AsyncClient::SendArgs timeout(std::chrono::seconds(5));
+  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, timeout))
+  EXPECT_CALL(cm_.async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs& args) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
             EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
+            EXPECT_EQ(args.timeout, timeout);
 
             return &request;
           }));
@@ -310,8 +313,8 @@ TEST_F(LightStepDriverTest, FlushOneInvalidResponse) {
 TEST_F(LightStepDriverTest, FlushSpansTimer) {
   setupValidDriver();
 
-  const Http::AsyncClient::SendArgs timeout(std::chrono::seconds(5));
-  EXPECT_CALL(cm_.async_client_, send_(_, _, timeout));
+  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
+  EXPECT_CALL(cm_.async_client_, send_(_, _, _));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.min_flush_spans",
                                              LightStepDriver::DefaultMinFlushSpans))
@@ -339,18 +342,19 @@ TEST_F(LightStepDriverTest, FlushOneSpanGrpcFailure) {
 
   Http::MockAsyncClientRequest request(&cm_.async_client_);
   Http::AsyncClient::Callbacks* callback;
-  const Http::AsyncClient::SendArgs timeout(std::chrono::seconds(5));
+  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, timeout))
+  EXPECT_CALL(cm_.async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs& args) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/lightstep.collector.CollectorService/Report",
                          message->headers().Path()->value().c_str());
             EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/grpc", message->headers().ContentType()->value().c_str());
+            EXPECT_EQ(args.timeout, timeout);
 
             return &request;
           }));
@@ -384,13 +388,14 @@ TEST_F(LightStepDriverTest, CancelRequestOnDestruction) {
 
   Http::MockAsyncClientRequest request(&cm_.async_client_);
   Http::AsyncClient::Callbacks* callback;
-  const Http::AsyncClient::SendArgs timeout(std::chrono::seconds(5));
+  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, timeout))
+  EXPECT_CALL(cm_.async_client_, send_(_, _, _))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& /*message*/, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs& args) -> Http::AsyncClient::Request* {
             callback = &callbacks;
+            EXPECT_EQ(args.timeout, timeout);
 
             return &request;
           }));

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -136,16 +136,15 @@ TEST_F(ZipkinDriverTest, FlushSeveralSpans) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, _))
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs& args) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/api/v1/spans", message->headers().Path()->value().c_str());
             EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/json", message->headers().ContentType()->value().c_str());
-	    EXPECT_EQ(args.timeout, timeout);
 
             return &request;
           }));
@@ -186,16 +185,15 @@ TEST_F(ZipkinDriverTest, FlushOneSpanReportFailure) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, _))
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs& args) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/api/v1/spans", message->headers().Path()->value().c_str());
             EXPECT_STREQ("fake_cluster", message->headers().Host()->value().c_str());
             EXPECT_STREQ("application/json", message->headers().ContentType()->value().c_str());
-	    EXPECT_EQ(args.timeout, timeout);
 
             return &request;
           }));

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -136,7 +136,8 @@ TEST_F(ZipkinDriverTest, FlushSeveralSpans) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)))
+  EXPECT_CALL(cm_.async_client_,
+              send_(_, _, Http::AsyncClient::RequestOptions().setTimeout(timeout)))
       .WillOnce(
           Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
@@ -185,7 +186,8 @@ TEST_F(ZipkinDriverTest, FlushOneSpanReportFailure) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)))
+  EXPECT_CALL(cm_.async_client_,
+              send_(_, _, Http::AsyncClient::RequestOptions().setTimeout(timeout)))
       .WillOnce(
           Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
@@ -222,7 +224,8 @@ TEST_F(ZipkinDriverTest, FlushSpansTimer) {
   setupValidDriver();
 
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)));
+  EXPECT_CALL(cm_.async_client_,
+              send_(_, _, Http::AsyncClient::RequestOptions().setTimeout(timeout)));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.zipkin.min_flush_spans", 5))
       .WillOnce(Return(5));

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -136,10 +136,10 @@ TEST_F(ZipkinDriverTest, FlushSeveralSpans) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)))
+      .WillOnce(
+          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/api/v1/spans", message->headers().Path()->value().c_str());
@@ -185,10 +185,10 @@ TEST_F(ZipkinDriverTest, FlushOneSpanReportFailure) {
   Http::AsyncClient::Callbacks* callback;
   const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::SendArgs(timeout)))
-      .WillOnce(Invoke(
-          [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)))
+      .WillOnce(
+          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/api/v1/spans", message->headers().Path()->value().c_str());
@@ -221,7 +221,8 @@ TEST_F(ZipkinDriverTest, FlushOneSpanReportFailure) {
 TEST_F(ZipkinDriverTest, FlushSpansTimer) {
   setupValidDriver();
 
-  EXPECT_CALL(cm_.async_client_, send_(_, _, _));
+  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
+  EXPECT_CALL(cm_.async_client_, send_(_, _, Http::AsyncClient::RequestOptions(timeout)));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.zipkin.min_flush_spans", 5))
       .WillOnce(Return(5));

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -134,12 +134,12 @@ TEST_F(ZipkinDriverTest, FlushSeveralSpans) {
 
   Http::MockAsyncClientRequest request(&cm_.async_client_);
   Http::AsyncClient::Callbacks* callback;
-  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
+  const Http::AsyncClient::SendArgs timeout(std::chrono::seconds(5));
 
   EXPECT_CALL(cm_.async_client_, send_(_, _, timeout))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/api/v1/spans", message->headers().Path()->value().c_str());
@@ -183,12 +183,12 @@ TEST_F(ZipkinDriverTest, FlushOneSpanReportFailure) {
 
   Http::MockAsyncClientRequest request(&cm_.async_client_);
   Http::AsyncClient::Callbacks* callback;
-  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
+  const Http::AsyncClient::SendArgs timeout(std::chrono::seconds(5));
 
   EXPECT_CALL(cm_.async_client_, send_(_, _, timeout))
       .WillOnce(Invoke(
           [&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
-              const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+              const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
             callback = &callbacks;
 
             EXPECT_STREQ("/api/v1/spans", message->headers().Path()->value().c_str());
@@ -221,7 +221,7 @@ TEST_F(ZipkinDriverTest, FlushOneSpanReportFailure) {
 TEST_F(ZipkinDriverTest, FlushSpansTimer) {
   setupValidDriver();
 
-  const absl::optional<std::chrono::milliseconds> timeout(std::chrono::seconds(5));
+  const Http::AsyncClient::SendArgs timeout(std::chrono::seconds(5));
   EXPECT_CALL(cm_.async_client_, send_(_, _, timeout));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.zipkin.min_flush_spans", 5))

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -351,17 +351,13 @@ public:
   MOCK_METHOD0(onRequestDestroy, void());
 
   // Http::AsyncClient
-  Request* send(MessagePtr&& request, Callbacks& callbacks,
-                const absl::optional<std::chrono::milliseconds>& timeout) override {
-    return send_(request, callbacks, timeout);
+  Request* send(MessagePtr&& request, Callbacks& callbacks, const SendArgs& args) override {
+    return send_(request, callbacks, args);
   }
 
-  MOCK_METHOD3(send_, Request*(MessagePtr& request, Callbacks& callbacks,
-                               const absl::optional<std::chrono::milliseconds>& timeout));
+  MOCK_METHOD3(send_, Request*(MessagePtr& request, Callbacks& callbacks, const SendArgs& args));
 
-  MOCK_METHOD3(start, Stream*(StreamCallbacks& callbacks,
-                              const absl::optional<std::chrono::milliseconds>& timeout,
-                              bool buffer_body_for_retry));
+  MOCK_METHOD3(start, Stream*(StreamCallbacks& callbacks, const StartArgs& args));
 
   MOCK_METHOD0(dispatcher, Event::Dispatcher&());
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -357,12 +357,18 @@ public:
 
   MOCK_METHOD3(send_, Request*(MessagePtr& request, Callbacks& callbacks, const SendArgs& args));
 
-  MOCK_METHOD3(start, Stream*(StreamCallbacks& callbacks, const StartArgs& args));
+  MOCK_METHOD2(start, Stream*(StreamCallbacks& callbacks, const StartArgs& args));
 
   MOCK_METHOD0(dispatcher, Event::Dispatcher&());
 
   NiceMock<Event::MockDispatcher> dispatcher_;
 };
+
+#if 0
+ bool operator()(const AsyncClient::SendArgs& a, const AsyncClient::SendArgs& b) {
+   return a.timeout == b.timeout && a.send_xff == b.send_xff;
+ }
+#endif
 
 class MockAsyncClientCallbacks : public AsyncClient::Callbacks {
 public:

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -351,13 +351,14 @@ public:
   MOCK_METHOD0(onRequestDestroy, void());
 
   // Http::AsyncClient
-  Request* send(MessagePtr&& request, Callbacks& callbacks, const SendArgs& args) override {
+  Request* send(MessagePtr&& request, Callbacks& callbacks, const RequestOptions& args) override {
     return send_(request, callbacks, args);
   }
 
-  MOCK_METHOD3(send_, Request*(MessagePtr& request, Callbacks& callbacks, const SendArgs& args));
+  MOCK_METHOD3(send_,
+               Request*(MessagePtr& request, Callbacks& callbacks, const RequestOptions& args));
 
-  MOCK_METHOD2(start, Stream*(StreamCallbacks& callbacks, const StartArgs& args));
+  MOCK_METHOD2(start, Stream*(StreamCallbacks& callbacks, const StreamOptions& args));
 
   MOCK_METHOD0(dispatcher, Event::Dispatcher&());
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -364,12 +364,6 @@ public:
   NiceMock<Event::MockDispatcher> dispatcher_;
 };
 
-#if 0
- bool operator()(const AsyncClient::SendArgs& a, const AsyncClient::SendArgs& b) {
-   return a.timeout == b.timeout && a.send_xff == b.send_xff;
- }
-#endif
-
 class MockAsyncClientCallbacks : public AsyncClient::Callbacks {
 public:
   MockAsyncClientCallbacks();

--- a/test/server/config_validation/async_client_test.cc
+++ b/test/server/config_validation/async_client_test.cc
@@ -21,7 +21,7 @@ TEST(ValidationAsyncClientTest, MockedMethods) {
   EXPECT_EQ(nullptr, client.send(std::move(message), callbacks,
                                  absl::optional<std::chrono::milliseconds>()));
   EXPECT_EQ(nullptr,
-            client.start(stream_callbacks, absl::optional<std::chrono::milliseconds>(), false));
+            client.start(stream_callbacks, AsyncClient::StartArgs());
 }
 
 } // namespace Http

--- a/test/server/config_validation/async_client_test.cc
+++ b/test/server/config_validation/async_client_test.cc
@@ -18,10 +18,8 @@ TEST(ValidationAsyncClientTest, MockedMethods) {
 
   DangerousDeprecatedTestTime test_time;
   ValidationAsyncClient client(test_time.timeSystem());
-  EXPECT_EQ(nullptr, client.send(std::move(message), callbacks,
-                                 AsyncClient::SendArgs()));
-  EXPECT_EQ(nullptr,
-            client.start(stream_callbacks, AsyncClient::StartArgs());
+  EXPECT_EQ(nullptr, client.send(std::move(message), callbacks, AsyncClient::RequestOptions()));
+  EXPECT_EQ(nullptr, client.start(stream_callbacks, AsyncClient::StreamOptions()));
 }
 
 } // namespace Http

--- a/test/server/config_validation/async_client_test.cc
+++ b/test/server/config_validation/async_client_test.cc
@@ -19,7 +19,7 @@ TEST(ValidationAsyncClientTest, MockedMethods) {
   DangerousDeprecatedTestTime test_time;
   ValidationAsyncClient client(test_time.timeSystem());
   EXPECT_EQ(nullptr, client.send(std::move(message), callbacks,
-                                 absl::optional<std::chrono::milliseconds>()));
+                                 AsyncClient::SendArgs()));
   EXPECT_EQ(nullptr,
             client.start(stream_callbacks, AsyncClient::StartArgs());
 }

--- a/test/server/config_validation/cluster_manager_test.cc
+++ b/test/server/config_validation/cluster_manager_test.cc
@@ -50,8 +50,7 @@ TEST(ValidationClusterManagerTest, MockedMethods) {
 
   Http::AsyncClient& client = cluster_manager->httpAsyncClientForCluster("cluster");
   Http::MockAsyncClientStreamCallbacks stream_callbacks;
-  EXPECT_EQ(nullptr,
-            client.start(stream_callbacks, Http::AsyncClient::StartArgs()));
+  EXPECT_EQ(nullptr, client.start(stream_callbacks, Http::AsyncClient::StreamOptions()));
 }
 
 } // namespace Upstream

--- a/test/server/config_validation/cluster_manager_test.cc
+++ b/test/server/config_validation/cluster_manager_test.cc
@@ -51,7 +51,7 @@ TEST(ValidationClusterManagerTest, MockedMethods) {
   Http::AsyncClient& client = cluster_manager->httpAsyncClientForCluster("cluster");
   Http::MockAsyncClientStreamCallbacks stream_callbacks;
   EXPECT_EQ(nullptr,
-            client.start(stream_callbacks, absl::optional<std::chrono::milliseconds>(), false));
+            client.start(stream_callbacks, Http::AsyncClient::StartArgs()));
 }
 
 } // namespace Upstream

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -83,7 +83,7 @@ public:
     EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
         .WillOnce(Invoke(
             [&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
-                const absl::optional<std::chrono::milliseconds>&) -> Http::AsyncClient::Request* {
+                const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
               EXPECT_EQ(
                   (Http::TestHeaderMapImpl{
                       {":method", v2_rest_ ? "POST" : "GET"},

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -81,9 +81,9 @@ public:
   void expectRequest() {
     EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("foo_cluster"));
     EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
-        .WillOnce(Invoke(
-            [&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
-                const Http::AsyncClient::SendArgs&) -> Http::AsyncClient::Request* {
+        .WillOnce(
+            Invoke([&](Http::MessagePtr& request, Http::AsyncClient::Callbacks& callbacks,
+                       const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
               EXPECT_EQ(
                   (Http::TestHeaderMapImpl{
                       {":method", v2_rest_ ? "POST" : "GET"},


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

*Description*:

This is for https://github.com/envoyproxy/envoy/issues/4924

To have a config to turn off sending XFF for async_client.

This is just a proposal.   The code is not ready for submit.

*Risk Level*:  Low

