### PR TITLE
Turn on cluster update merging by default

### DIFF
--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -472,6 +472,9 @@ message Cluster {
     // or metadata updates. By default, this is not configured and updates apply immediately. Also,
     // the first set of updates to be seen apply immediately as well (e.g.: a new cluster).
     //
+    // If this is not set, we default to a merge window of 1000ms. To disable it, set the merge
+    // window to 0.
+    //
     // Note: merging does not apply to cluster membership changes (e.g.: adds/removes); this is
     // because merging those updates isn't currently safe. See
     // https://github.com/envoyproxy/envoy/pull/3941.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -9,6 +9,7 @@ Version history
 * admin: :http:get:`/server_info` now responds with a JSON object instead of a single string.
 * circuit-breaker: added cx_open, rq_pending_open, rq_open and rq_retry_open gauges to expose live
   state via :ref:`circuit breakers statistics <config_cluster_manager_cluster_stats_circuit_breakers>`.
+* cluster: set a default of 1s for :ref:`option <envoy_api_field_Cluster.CommonLbConfig.update_merge_window>`.
 * config: removed support for the v1 API.
 * config: added support for :ref:`rate limiting<envoy_api_msg_core.RateLimitSettings>` discovery request calls.
 * cors: added :ref: `invalid/valid stats <cors-statistics>` to filter.

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -403,7 +403,9 @@ private:
   using ClusterUpdatesMap = std::unordered_map<std::string, PendingUpdatesByPriorityMapPtr>;
 
   void applyUpdates(const Cluster& cluster, uint32_t priority, PendingUpdates& updates);
-  bool scheduleUpdate(const Cluster& cluster, uint32_t priority, bool mergeable);
+  bool scheduleUpdate(const Cluster& cluster, uint32_t priority, bool mergeable,
+                      const uint64_t timeout);
+  uint64_t mergeTimeout(const Cluster& cluster) const;
   void createOrUpdateThreadLocalCluster(ClusterData& cluster);
   ProtobufTypes::MessagePtr dumpClusterConfigs();
   static ClusterManagerStats generateStats(Stats::Scope& scope);

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -405,7 +405,6 @@ private:
   void applyUpdates(const Cluster& cluster, uint32_t priority, PendingUpdates& updates);
   bool scheduleUpdate(const Cluster& cluster, uint32_t priority, bool mergeable,
                       const uint64_t timeout);
-  uint64_t mergeTimeout(const Cluster& cluster) const;
   void createOrUpdateThreadLocalCluster(ClusterData& cluster);
   ProtobufTypes::MessagePtr dumpClusterConfigs();
   static ClusterManagerStats generateStats(Stats::Scope& scope);

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -188,14 +188,16 @@ public:
           address: "127.0.0.1"
           port_value: 11002
   )EOF";
-    const std::string merge_window = R"EOF(
+    const std::string merge_window_enabled = R"EOF(
       common_lb_config:
         update_merge_window: 3s
   )EOF";
+    const std::string merge_window_disabled = R"EOF(
+      common_lb_config:
+        update_merge_window: 0s
+  )EOF";
 
-    if (enable_merge_window) {
-      yaml += merge_window;
-    }
+    yaml += enable_merge_window ? merge_window_enabled : merge_window_disabled;
 
     const auto& bootstrap = parseBootstrapFromV2Yaml(yaml);
 


### PR DESCRIPTION
We've been using this in production for over 3 months now and it's
been very useful to prevent CPU spikes when we get a stream of
updates.

This enables update merging every 1s.

Fixes #4018.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
