### PR TITLE
admin: display command line options in server info end point

### DIFF
--- a/api/envoy/admin/v2alpha/server_info.proto
+++ b/api/envoy/admin/v2alpha/server_info.proto
@@ -24,8 +24,107 @@ message ServerInfo {
 
   // Uptime since current epoch was started.
   google.protobuf.Duration uptime_current_epoch = 3;
+
   // Uptime since the start of the first epoch.
   google.protobuf.Duration uptime_all_epochs = 4;
+
+  // Command line options the server is currently running with.
+  CommandLineOptions command_line_options = 6;
+}
+
+message CommandLineOptions {
+  // Value of "base-id" option that specifies the base ID so that multiple envoys can run on the
+  // same host if needed.
+  uint64 base_id = 1;
+
+  // Value of "concurrency" option that specifies the number of worker threads to run.
+  uint32 concurrency = 2;
+
+  // Value of "config-path" option that specifies the path to configuration file.
+  string config_path = 3;
+
+  // Value of "config-yaml" option that specifies the inline YAML configuration, merges with the
+  // contents of --config-path.
+  string config_yaml = 4;
+
+  // Value of "allow-unknown-fields" that specifies whether to allow unknown fields in the
+  // configuration.
+  bool allow_unknown_fields = 5;
+
+  // Value of "admin-address-path" that specifies the admin address path.
+  string admin_address_path = 6;
+
+  enum IpVersion {
+    v4 = 0;
+    v6 = 1;
+  }
+  // Value of "local_address_ip_version" that specifies the local IP address version (v4 or v6).
+  IpVersion local_address_ip_version = 7;
+
+  // Value of "log_level" that specifies the log level.
+  string log_level = 8;
+
+  // Value of "component_log_level" that specifies comma separated list of component log levels.
+  string component_log_level = 9;
+
+  // Value of "log_format" that specifies the log message format.
+  string log_format = 10;
+
+  // Value of "log_path" that specifies the path to log file.
+  string log_path = 11;
+
+  // Value of "hot-restart-version" that specifies the hot restart compatibility version.
+  bool hot_restart_version = 12;
+
+  // Value of "service-cluster" that specifies the cluster name.
+  string service_cluster = 13;
+
+  // Value of "service-node" that specifies the node name.
+  string service_node = 14;
+
+  // Value of "service-zone" that specifies the zone name.
+  string service_zone = 15;
+
+  // Value of "file-flush-interval-msec" that specifies the interval for log flushing in milli
+  // seconds.
+  google.protobuf.Duration file_flush_interval = 16;
+
+  // Value of "drain-time-s" that specifies the hot restart drain time in seconds.
+  google.protobuf.Duration drain_time = 17;
+
+  // Value of "parent-shutdown-time-s" that specifies the hot restart parent shutdown time in
+  // seconds.
+  google.protobuf.Duration parent_shutdown_time = 18;
+
+  enum Mode {
+    // Validate configs and then serve traffic normally.
+    Serve = 0;
+
+    // Validate configs and exit.
+    Validate = 1;
+
+    // Completely load and initialize the config, and then exit without running the listener loop.
+    InitOnly = 2;
+  }
+
+  // Value of "mode" that specifies the mode in which the server is running.
+  Mode mode = 19;
+
+  // Value of "max-stats" that specifies the maximum number of stats gauges and counters that can be
+  // allocated in shared memory.
+  uint64 max_stats = 20;
+
+  // Value of "max-obj-name-len" that specifies the maximum name length for a field in the config.
+  // Applies to listener name, route config name and cluster name.
+  uint64 max_obj_name_len = 21;
+
+  // Value of "disable-hot-restart" that specifies whether the hot restart functionality has been
+  // disabled.
+  bool disable_hot_restart = 22;
+
+  // Value of "enable-mutex-tracing" that specifies whether the mutex contention has been enabled.
+  bool enable_mutex_tracing = 23;
+
   // Which restart epoch the server is currently in.
-  uint32 epoch = 5;
+  uint32 restart_epoch = 24;
 }

--- a/api/envoy/admin/v2alpha/server_info.proto
+++ b/api/envoy/admin/v2alpha/server_info.proto
@@ -33,67 +33,63 @@ message ServerInfo {
 }
 
 message CommandLineOptions {
-  // Value of "base-id" option that specifies the base ID so that multiple envoys can run on the
-  // same host if needed.
+  // See :option:`--base-id` for details.
   uint64 base_id = 1;
 
-  // Value of "concurrency" option that specifies the number of worker threads to run.
+  // See :option:`--concurrency` for details.
   uint32 concurrency = 2;
 
-  // Value of "config-path" option that specifies the path to configuration file.
+  // See :option:`--config-path` for details.
   string config_path = 3;
 
-  // Value of "config-yaml" option that specifies the inline YAML configuration, merges with the
-  // contents of --config-path.
+  // See :option:`--config-yaml` for details.
   string config_yaml = 4;
 
-  // Value of "allow-unknown-fields" that specifies whether to allow unknown fields in the
-  // configuration.
+  // See :option:`--allow-unknown-fields` for details.
   bool allow_unknown_fields = 5;
 
-  // Value of "admin-address-path" that specifies the admin address path.
+  // See :option:`--admin-address-path` for details.
   string admin_address_path = 6;
 
   enum IpVersion {
     v4 = 0;
     v6 = 1;
   }
-  // Value of "local_address_ip_version" that specifies the local IP address version (v4 or v6).
+
+  // See :option:`--local-address-ip-version` for details.
   IpVersion local_address_ip_version = 7;
 
-  // Value of "log_level" that specifies the log level.
+  // See :option:`--log-level` for details.
   string log_level = 8;
 
-  // Value of "component_log_level" that specifies comma separated list of component log levels.
+  // See :option:`--component-log-level` for details.
   string component_log_level = 9;
 
-  // Value of "log_format" that specifies the log message format.
+  // See :option:`--log-format` for details.
   string log_format = 10;
 
-  // Value of "log_path" that specifies the path to log file.
+  // See :option:`--log-path` for details.
   string log_path = 11;
 
-  // Value of "hot-restart-version" that specifies the hot restart compatibility version.
+  // See :option:`--hot-restart-version` for details.
   bool hot_restart_version = 12;
 
-  // Value of "service-cluster" that specifies the cluster name.
+  // See :option:`--service-cluster` for details.
   string service_cluster = 13;
 
-  // Value of "service-node" that specifies the node name.
+  // See :option:`--service-node` for details.
   string service_node = 14;
 
-  // Value of "service-zone" that specifies the zone name.
+  // See :option:`--service-zone` for details.
   string service_zone = 15;
 
-  // Value of "file-flush-interval-msec" that specifies the interval for log flushing in milli
-  // seconds.
+  // See :option:`--file-flush-interval-msec` for details.
   google.protobuf.Duration file_flush_interval = 16;
 
-  // Value of "drain-time-s" that specifies the hot restart drain time in seconds.
+  // See :option:`--drain-time-s` for details.
   google.protobuf.Duration drain_time = 17;
 
-  // Value of "parent-shutdown-time-s" that specifies the hot restart parent shutdown time in
-  // seconds.
+  // See :option:`--parent-shutdown-time-s` for details.
   google.protobuf.Duration parent_shutdown_time = 18;
 
   enum Mode {
@@ -107,24 +103,21 @@ message CommandLineOptions {
     InitOnly = 2;
   }
 
-  // Value of "mode" that specifies the mode in which the server is running.
+  // See :option:`--mode` for details.
   Mode mode = 19;
 
-  // Value of "max-stats" that specifies the maximum number of stats gauges and counters that can be
-  // allocated in shared memory.
+  // See :option:`--max-stats` for details.
   uint64 max_stats = 20;
 
-  // Value of "max-obj-name-len" that specifies the maximum name length for a field in the config.
-  // Applies to listener name, route config name and cluster name.
+  // See :option:`--max-obj-name-len` for details.
   uint64 max_obj_name_len = 21;
 
-  // Value of "disable-hot-restart" that specifies whether the hot restart functionality has been
-  // disabled.
+  // See :option:`--disable-hot-restart` for details.
   bool disable_hot_restart = 22;
 
-  // Value of "enable-mutex-tracing" that specifies whether the mutex contention has been enabled.
+  // See :option:`--enable-mutex-tracing` for details.
   bool enable_mutex_tracing = 23;
 
-  // Which restart epoch the server is currently in.
+  // See :option:`--restart-epoch` for details.
   uint32 restart_epoch = 24;
 }

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -7,6 +7,7 @@ Version history
 * access log: added dynamic metadata to access log messages streamed over gRPC.
 * admin: added support for displaying subject alternate names in :ref:`certs<operations_admin_interface_certs>` end point.
 * admin: :http:get:`/server_info` now responds with a JSON object instead of a single string.
+* admin: added support for displaying command line options in :http:get:`/server_info` end point.
 * circuit-breaker: added cx_open, rq_pending_open, rq_open and rq_retry_open gauges to expose live
   state via :ref:`circuit breakers statistics <config_cluster_manager_cluster_stats_circuit_breakers>`.
 * config: removed support for the v1 API.

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -180,17 +180,44 @@ modify different aspects of the server:
 
 .. http:get:: /server_info
 
-  Outputs a JSON message containing information about the running server. Sample output looks like:
+  Outputs a JSON message containing information about the running server.
 
-.. code-block:: none
+  Sample output looks like:
 
-  {
-   "version": "b050513e840aa939a01f89b07c162f00ab3150eb/1.9.0-dev/Modified/DEBUG",
-   "state": "LIVE",
-   "epoch": 0,
-   "uptime_current_epoch": "6s",
-   "uptime_all_epochs": "6s"
-  }
+  .. code-block:: json
+
+    {
+      "version": "b050513e840aa939a01f89b07c162f00ab3150eb/1.9.0-dev/Modified/DEBUG",
+      "state": "LIVE",
+      "command_line_options": {
+        "base_id": "0",
+        "concurrency": 8,
+        "config_path": "config.yaml",
+        "config_yaml": "",
+        "allow_unknown_fields": false,
+        "admin_address_path": "",
+        "local_address_ip_version": "v4",
+        "log_level": "info",
+        "component_log_level": "",
+        "log_format": "[%Y-%m-%d %T.%e][%t][%l][%n] %v",
+        "log_path": "",
+        "hot_restart_version": false,
+        "service_cluster": "",
+        "service_node": "",
+        "service_zone": "",
+        "mode": "Serve",
+        "max_stats": "16384",
+        "max_obj_name_len": "60",
+        "disable_hot_restart": false,
+        "enable_mutex_tracing": false,
+        "restart_epoch": 0,
+        "file_flush_interval": "10s",
+        "drain_time": "600s",
+        "parent_shutdown_time": "900s"
+      },
+      "uptime_current_epoch": "6s",
+      "uptime_all_epochs": "6s"
+    }
 
 See the :ref:`ServerInfo proto <envoy_api_msg_admin.v2alpha.ServerInfo>` for an
 explanation of the output.

--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -115,6 +115,7 @@ envoy_cc_library(
     deps = [
         "//include/envoy/network:address_interface",
         "//include/envoy/stats:stats_interface",
+        "@envoy_api//envoy/admin/v2alpha:server_info_cc",
     ],
 )
 

--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <string>
 
+#include "envoy/admin/v2alpha/server_info.pb.h"
 #include "envoy/common/pure.h"
 #include "envoy/network/address.h"
 #include "envoy/stats/stats_options.h"
@@ -39,6 +40,8 @@ enum class Mode {
   // etc. Validation will pass even if those files are malformed or don't exist, allowing the config
   // to be validated in a non-prod environment.
 };
+
+typedef std::unique_ptr<envoy::admin::v2alpha::CommandLineOptions> CommandLineOptionsPtr;
 
 /**
  * General options for the server.
@@ -176,6 +179,12 @@ public:
    * @return bool indicating whether mutex tracing functionality has been enabled.
    */
   virtual bool mutexTracingEnabled() const PURE;
+
+  /**
+   * Converts the Options in to CommandLineOptions proto message defined in server_info.proto.
+   * @return CommandLineOptionsPtr the protobuf representation of the options.
+   */
+  virtual CommandLineOptionsPtr toCommandLineOptions() const PURE;
 };
 
 } // namespace Server

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -557,7 +557,9 @@ Http::Code AdminImpl::handlerServerInfo(absl::string_view, Http::HeaderMap& head
                                                           server_.startTimeCurrentEpoch());
   server_info.mutable_uptime_all_epochs()->set_seconds(current_time -
                                                        server_.startTimeFirstEpoch());
-  server_info.set_epoch(server_.options().restartEpoch());
+  envoy::admin::v2alpha::CommandLineOptions* command_line_options =
+      server_info.mutable_command_line_options();
+  *command_line_options = *server_.options().toCommandLineOptions();
   response.add(MessageUtil::getJsonStringFromMessage(server_info, true, true));
   headers.insertContentType().value().setReference(Http::Headers::get().ContentTypeValues.Json);
   return Http::Code::OK;

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -289,10 +289,12 @@ Server::CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
     command_line_options->set_local_address_ip_version(
         envoy::admin::v2alpha::CommandLineOptions::v6);
   }
-  command_line_options->mutable_file_flush_interval()->set_seconds(fileFlushIntervalMsec().count() /
-                                                                   1000);
-  command_line_options->mutable_parent_shutdown_time()->set_seconds(parentShutdownTime().count());
-  command_line_options->mutable_drain_time()->set_seconds(drainTime().count());
+  command_line_options->mutable_file_flush_interval()->MergeFrom(
+      Protobuf::util::TimeUtil::MillisecondsToDuration(fileFlushIntervalMsec().count()));
+  command_line_options->mutable_parent_shutdown_time()->MergeFrom(
+      Protobuf::util::TimeUtil::SecondsToDuration(parentShutdownTime().count()));
+  command_line_options->mutable_drain_time()->MergeFrom(
+      Protobuf::util::TimeUtil::SecondsToDuration(drainTime().count()));
   command_line_options->set_max_stats(maxStats());
   command_line_options->set_max_obj_name_len(statsOptions().maxObjNameLength());
   command_line_options->set_disable_hot_restart(hotRestartDisabled());

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -124,6 +124,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   cmd.setExceptionHandling(false);
   try {
     cmd.parse(argc, argv);
+    count_ = cmd.getArgList().size();
   } catch (TCLAP::ArgException& e) {
     try {
       cmd.getOutput()->failure(cmd, e);
@@ -196,7 +197,8 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   concurrency_ = std::max(1U, concurrency.getValue());
   config_path_ = config_path.getValue();
   config_yaml_ = config_yaml.getValue();
-  if (allow_unknown_fields.getValue()) {
+  allow_unknown_fields_ = allow_unknown_fields.getValue();
+  if (allow_unknown_fields_) {
     MessageUtil::proto_unknown_fields = ProtoUnknownFieldsMode::Allow;
   }
   admin_address_path_ = admin_address_path.getValue();
@@ -222,6 +224,7 @@ void OptionsImpl::parseComponentLogLevels(const std::string& component_log_level
   if (component_log_levels.empty()) {
     return;
   }
+  component_log_level_str_ = component_log_levels;
   std::vector<std::string> log_levels = absl::StrSplit(component_log_levels, ',');
   for (auto& level : log_levels) {
     std::vector<std::string> log_name_level = absl::StrSplit(level, ':');
@@ -249,9 +252,53 @@ void OptionsImpl::parseComponentLogLevels(const std::string& component_log_level
   }
 }
 
+uint32_t OptionsImpl::count() const { return count_; }
+
 void OptionsImpl::logError(const std::string& error) const {
   std::cerr << error << std::endl;
   throw MalformedArgvException(error);
+}
+
+Server::CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
+  Server::CommandLineOptionsPtr command_line_options =
+      std::make_unique<envoy::admin::v2alpha::CommandLineOptions>();
+  command_line_options->set_base_id(baseId());
+  command_line_options->set_concurrency(concurrency());
+  command_line_options->set_config_path(configPath());
+  command_line_options->set_config_yaml(configYaml());
+  command_line_options->set_allow_unknown_fields(allow_unknown_fields_);
+  command_line_options->set_admin_address_path(adminAddressPath());
+  command_line_options->set_component_log_level(component_log_level_str_);
+  command_line_options->set_log_level(spdlog::level::to_c_str(logLevel()));
+  command_line_options->set_log_format(logFormat());
+  command_line_options->set_log_path(logPath());
+  command_line_options->set_service_cluster(serviceClusterName());
+  command_line_options->set_service_node(serviceNodeName());
+  command_line_options->set_service_zone(serviceZone());
+  if (mode() == Server::Mode::Serve) {
+    command_line_options->set_mode(envoy::admin::v2alpha::CommandLineOptions::Serve);
+  } else if (mode() == Server::Mode::Validate) {
+    command_line_options->set_mode(envoy::admin::v2alpha::CommandLineOptions::Validate);
+  } else {
+    command_line_options->set_mode(envoy::admin::v2alpha::CommandLineOptions::InitOnly);
+  }
+  if (localAddressIpVersion() == Network::Address::IpVersion::v4) {
+    command_line_options->set_local_address_ip_version(
+        envoy::admin::v2alpha::CommandLineOptions::v4);
+  } else {
+    command_line_options->set_local_address_ip_version(
+        envoy::admin::v2alpha::CommandLineOptions::v6);
+  }
+  command_line_options->mutable_file_flush_interval()->set_seconds(fileFlushIntervalMsec().count() /
+                                                                   1000);
+  command_line_options->mutable_parent_shutdown_time()->set_seconds(parentShutdownTime().count());
+  command_line_options->mutable_drain_time()->set_seconds(drainTime().count());
+  command_line_options->set_max_stats(maxStats());
+  command_line_options->set_max_obj_name_len(statsOptions().maxObjNameLength());
+  command_line_options->set_disable_hot_restart(hotRestartDisabled());
+  command_line_options->set_enable_mutex_tracing(mutexTracingEnabled());
+  command_line_options->set_restart_epoch(restartEpoch());
+  return command_line_options;
 }
 
 OptionsImpl::OptionsImpl(const std::string& service_cluster, const std::string& service_node,

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -118,7 +118,7 @@ private:
   uint32_t concurrency_;
   std::string config_path_;
   std::string config_yaml_;
-  bool allow_unknown_fields_;
+  bool allow_unknown_fields_{false};
   bool v2_config_only_;
   std::string admin_address_path_;
   Network::Address::IpVersion local_address_ip_version_;

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -107,20 +107,24 @@ public:
   bool hotRestartDisabled() const override { return hot_restart_disabled_; }
   bool signalHandlingEnabled() const override { return signal_handling_enabled_; }
   bool mutexTracingEnabled() const override { return mutex_tracing_enabled_; }
+  virtual Server::CommandLineOptionsPtr toCommandLineOptions() const override;
 
 private:
   void parseComponentLogLevels(const std::string& component_log_levels);
   void logError(const std::string& error) const;
+  uint32_t count() const;
 
   uint64_t base_id_;
   uint32_t concurrency_;
   std::string config_path_;
   std::string config_yaml_;
+  bool allow_unknown_fields_;
   bool v2_config_only_;
   std::string admin_address_path_;
   Network::Address::IpVersion local_address_ip_version_;
   spdlog::level::level_enum log_level_;
   std::vector<std::pair<std::string, spdlog::level::level_enum>> component_log_levels_;
+  std::string component_log_level_str_;
   std::string log_format_;
   std::string log_path_;
   uint64_t restart_epoch_;
@@ -136,6 +140,7 @@ private:
   bool hot_restart_disabled_;
   bool signal_handling_enabled_;
   bool mutex_tracing_enabled_;
+  uint32_t count_;
 
   friend class OptionsImplTest;
 };

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -35,6 +35,9 @@ MockOptions::MockOptions(const std::string& config_path) : config_path_(config_p
   ON_CALL(*this, hotRestartDisabled()).WillByDefault(ReturnPointee(&hot_restart_disabled_));
   ON_CALL(*this, signalHandlingEnabled()).WillByDefault(ReturnPointee(&signal_handling_enabled_));
   ON_CALL(*this, mutexTracingEnabled()).WillByDefault(ReturnPointee(&mutex_tracing_enabled_));
+  ON_CALL(*this, toCommandLineOptions()).WillByDefault(Invoke([] {
+    return std::make_unique<envoy::admin::v2alpha::CommandLineOptions>();
+  }));
 }
 MockOptions::~MockOptions() {}
 

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -78,6 +78,7 @@ public:
   MOCK_CONST_METHOD0(hotRestartDisabled, bool());
   MOCK_CONST_METHOD0(signalHandlingEnabled, bool());
   MOCK_CONST_METHOD0(mutexTracingEnabled, bool());
+  MOCK_CONST_METHOD0(toCommandLineOptions, Server::CommandLineOptionsPtr());
 
   std::string config_path_;
   std::string config_yaml_;

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1101,8 +1101,13 @@ TEST_P(AdminInstanceTest, GetRequest) {
   Http::HeaderMapImpl response_headers;
   std::string body;
 
-  EXPECT_CALL(server_.options_, restartEpoch()).WillOnce(Return(2));
-
+  EXPECT_CALL(server_.options_, toCommandLineOptions()).WillOnce(Invoke([] {
+    Server::CommandLineOptionsPtr command_line_options =
+        std::make_unique<envoy::admin::v2alpha::CommandLineOptions>();
+    command_line_options->set_restart_epoch(2);
+    command_line_options->set_service_cluster("cluster");
+    return command_line_options;
+  }));
   EXPECT_EQ(Http::Code::OK, admin_.request("/server_info", "GET", response_headers, body));
   envoy::admin::v2alpha::ServerInfo server_info_proto;
   EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
@@ -1112,7 +1117,8 @@ TEST_P(AdminInstanceTest, GetRequest) {
   // values such as timestamps + Envoy version are tricky to test for.
   MessageUtil::loadFromJson(body, server_info_proto);
   EXPECT_EQ(server_info_proto.state(), envoy::admin::v2alpha::ServerInfo::LIVE);
-  EXPECT_EQ(server_info_proto.epoch(), 2);
+  EXPECT_EQ(server_info_proto.command_line_options().restart_epoch(), 2);
+  EXPECT_EQ(server_info_proto.command_line_options().service_cluster(), "cluster");
 }
 
 TEST_P(AdminInstanceTest, GetRequestJson) {

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -41,6 +41,8 @@ public:
     options->parseComponentLogLevels(component_log_levels);
     return options->componentLogLevels();
   }
+
+  uint32_t count(const std::unique_ptr<OptionsImpl>& options) { return options->count(); }
 };
 
 TEST_F(OptionsImplTest, HotRestartVersion) {
@@ -150,6 +152,34 @@ TEST_F(OptionsImplTest, SetAll) {
   EXPECT_EQ(stats_options.max_stat_suffix_length_, options->statsOptions().maxStatSuffixLength());
   EXPECT_EQ(!hot_restart_disabled, options->hotRestartDisabled());
   EXPECT_EQ(!signal_handling_enabled, options->signalHandlingEnabled());
+
+  // Validate that CommandLineOptions is constructed correctly.
+  Server::CommandLineOptionsPtr command_line_options = options->toCommandLineOptions();
+
+  EXPECT_EQ(options->baseId(), command_line_options->base_id());
+  EXPECT_EQ(options->concurrency(), command_line_options->concurrency());
+  EXPECT_EQ(options->configPath(), command_line_options->config_path());
+  EXPECT_EQ(options->configYaml(), command_line_options->config_yaml());
+  EXPECT_EQ(options->adminAddressPath(), command_line_options->admin_address_path());
+  EXPECT_EQ(envoy::admin::v2alpha::CommandLineOptions::v6,
+            command_line_options->local_address_ip_version());
+  EXPECT_EQ(options->drainTime().count(), command_line_options->drain_time().seconds());
+  EXPECT_EQ(spdlog::level::to_c_str(options->logLevel()), command_line_options->log_level());
+  EXPECT_EQ(options->logFormat(), command_line_options->log_format());
+  EXPECT_EQ(options->logPath(), command_line_options->log_path());
+  EXPECT_EQ(options->parentShutdownTime().count(),
+            command_line_options->parent_shutdown_time().seconds());
+  EXPECT_EQ(options->restartEpoch(), command_line_options->restart_epoch());
+  EXPECT_EQ(options->fileFlushIntervalMsec().count() / 1000,
+            command_line_options->file_flush_interval().seconds());
+  EXPECT_EQ(envoy::admin::v2alpha::CommandLineOptions::Validate, command_line_options->mode());
+  EXPECT_EQ(options->serviceClusterName(), command_line_options->service_cluster());
+  EXPECT_EQ(options->serviceNodeName(), command_line_options->service_node());
+  EXPECT_EQ(options->serviceZone(), command_line_options->service_zone());
+  EXPECT_EQ(options->maxStats(), command_line_options->max_stats());
+  EXPECT_EQ(options->statsOptions().maxObjNameLength(), command_line_options->max_obj_name_len());
+  EXPECT_EQ(options->hotRestartDisabled(), command_line_options->disable_hot_restart());
+  EXPECT_EQ(options->mutexTracingEnabled(), command_line_options->enable_mutex_tracing());
 }
 
 TEST_F(OptionsImplTest, DefaultParams) {
@@ -160,6 +190,31 @@ TEST_F(OptionsImplTest, DefaultParams) {
   EXPECT_EQ(Network::Address::IpVersion::v4, options->localAddressIpVersion());
   EXPECT_EQ(Server::Mode::Serve, options->mode());
   EXPECT_EQ(false, options->hotRestartDisabled());
+
+  // Validate that CommandLineOptions is constructed correctly with default params.
+  Server::CommandLineOptionsPtr command_line_options = options->toCommandLineOptions();
+
+  EXPECT_EQ(600, command_line_options->drain_time().seconds());
+  EXPECT_EQ(900, command_line_options->parent_shutdown_time().seconds());
+  EXPECT_EQ("", command_line_options->admin_address_path());
+  EXPECT_EQ(envoy::admin::v2alpha::CommandLineOptions::v4,
+            command_line_options->local_address_ip_version());
+  EXPECT_EQ(envoy::admin::v2alpha::CommandLineOptions::Serve, command_line_options->mode());
+  EXPECT_EQ(false, command_line_options->disable_hot_restart());
+}
+
+// Validates that the server_info proto is in sync with the options.
+TEST_F(OptionsImplTest, OptionsAreInSyncWithProto) {
+  std::unique_ptr<OptionsImpl> options = createOptionsImpl("envoy -c hello");
+  Server::CommandLineOptionsPtr command_line_options = options->toCommandLineOptions();
+  // Failure of this condition indicates that the server_info proto is not in sync with the options.
+  // If an option is added/removed, please update server_info proto as well to keep it in sync.
+  // Currently the following 4 options are not defined in proto, hence the count differs by 4.
+  // 1. v2-config-only - being deprecated.
+  // 2. version - default TCLAP agrument.
+  // 3. help - default TCLAP argument.
+  // 4. ignore_rest - default TCLAP argument.
+  EXPECT_EQ(count(options) - 4, command_line_options->GetDescriptor()->field_count());
 }
 
 TEST_F(OptionsImplTest, BadCliOption) {

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -211,9 +211,9 @@ TEST_F(OptionsImplTest, OptionsAreInSyncWithProto) {
   // If an option is added/removed, please update server_info proto as well to keep it in sync.
   // Currently the following 4 options are not defined in proto, hence the count differs by 4.
   // 1. v2-config-only - being deprecated.
-  // 2. version - default TCLAP argument.
-  // 3. help - default TCLAP argument.
-  // 4. ignore_rest - default TCLAP argument.
+  // 2. version        - default TCLAP argument.
+  // 3. help           - default TCLAP argument.
+  // 4. ignore_rest    - default TCLAP argument.
   EXPECT_EQ(count(options) - 4, command_line_options->GetDescriptor()->field_count());
 }
 

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -211,7 +211,7 @@ TEST_F(OptionsImplTest, OptionsAreInSyncWithProto) {
   // If an option is added/removed, please update server_info proto as well to keep it in sync.
   // Currently the following 4 options are not defined in proto, hence the count differs by 4.
   // 1. v2-config-only - being deprecated.
-  // 2. version - default TCLAP agrument.
+  // 2. version - default TCLAP argument.
   // 3. help - default TCLAP argument.
   // 4. ignore_rest - default TCLAP argument.
   EXPECT_EQ(count(options) - 4, command_line_options->GetDescriptor()->field_count());


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>
*Description*: Displays command line options with which Envoy is running in `/server_info` end point.
*Risk Level*: Low
*Testing*: Added Automated tests
*Docs Changes*: Updated
*Release Notes*: Added
Fixes #4994 