### PR TITLE
access_log: add newline between JSON log lines

### DIFF
--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -98,7 +98,7 @@ std::string JsonFormatterImpl::format(const Http::HeaderMap& request_headers,
         fmt::format("Error serializing access log to JSON: {}", conversion_status.ToString());
   }
 
-  return fmt::format("{}\n", log_line);
+  return absl::StrCat(log_line, "\n");
 }
 
 std::unordered_map<std::string, std::string> JsonFormatterImpl::toMap(

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -98,7 +98,7 @@ std::string JsonFormatterImpl::format(const Http::HeaderMap& request_headers,
         fmt::format("Error serializing access log to JSON: {}", conversion_status.ToString());
   }
 
-  return log_line;
+  return fmt::format("{}\n", log_line);
 }
 
 std::unordered_map<std::string, std::string> JsonFormatterImpl::toMap(

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -385,6 +385,12 @@ TEST(AccessLogFormatterTest, startTimeFormatter) {
 void verifyJsonOutput(std::string json_string,
                       std::unordered_map<std::string, std::string> expected_map) {
   const auto parsed = Json::Factory::loadFromString(json_string);
+
+  // Every json log line should have only one newline character, and it should be the last character in the string
+  auto newline_pos = json_string.find('\n');
+  EXPECT_NE(newline_pos, std::string::npos);
+  EXPECT_EQ(newline_pos, json_string.length() - 1);
+
   for (const auto& pair : expected_map) {
     EXPECT_EQ(parsed->getString(pair.first), pair.second);
   }
@@ -411,6 +417,7 @@ TEST(AccessLogFormatterTest, JsonFormatterPlainStringTest) {
   verifyJsonOutput(formatter.format(request_header, response_header, response_trailer, stream_info),
                    expected_json_map);
 }
+
 TEST(AccessLogFormatterTest, JsonFormatterSingleOperatorTest) {
   StreamInfo::MockStreamInfo stream_info;
   Http::TestHeaderMapImpl request_header;

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -388,7 +388,7 @@ void verifyJsonOutput(std::string json_string,
 
   // Every json log line should have only one newline character, and it should be the last character
   // in the string
-  auto newline_pos = json_string.find('\n');
+  const auto newline_pos = json_string.find('\n');
   EXPECT_NE(newline_pos, std::string::npos);
   EXPECT_EQ(newline_pos, json_string.length() - 1);
 

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -386,7 +386,8 @@ void verifyJsonOutput(std::string json_string,
                       std::unordered_map<std::string, std::string> expected_map) {
   const auto parsed = Json::Factory::loadFromString(json_string);
 
-  // Every json log line should have only one newline character, and it should be the last character in the string
+  // Every json log line should have only one newline character, and it should be the last character
+  // in the string
   auto newline_pos = json_string.find('\n');
   EXPECT_NE(newline_pos, std::string::npos);
   EXPECT_EQ(newline_pos, json_string.length() - 1);


### PR DESCRIPTION
*Description*:
Tack a newline onto the end of all JSON access log lines

*Risk Level*:
Low

*Testing*:
Every JSON unit test will now check to see that there is one (and only one) newline in a log line

*Docs Changes*:
None

*Release Notes*:
None

Fixes #5018 
