### PR TITLE
mongo_proxy: add dynamic metadata to stream info

### DIFF
--- a/api/envoy/config/filter/network/mongo_proxy/v2/mongo_proxy.proto
+++ b/api/envoy/config/filter/network/mongo_proxy/v2/mongo_proxy.proto
@@ -25,4 +25,8 @@ message MongoProxy {
   // and KillCursors. Once an active delay is in progress, all incoming
   // data up until the timer event fires will be a part of the delay.
   envoy.config.filter.fault.v2.FaultDelay delay = 3;
+
+  // Flag to specify whether dynamic metadata should be published.
+  // Defaults to false.
+  bool emit_dynamic_metadata = 4;
 }

--- a/api/envoy/config/filter/network/mongo_proxy/v2/mongo_proxy.proto
+++ b/api/envoy/config/filter/network/mongo_proxy/v2/mongo_proxy.proto
@@ -26,7 +26,7 @@ message MongoProxy {
   // data up until the timer event fires will be a part of the delay.
   envoy.config.filter.fault.v2.FaultDelay delay = 3;
 
-  // Flag to specify whether dynamic metadata should be published.
-  // Defaults to false.
+  // Flag to specify whether :ref:`dynamic metadata
+  // <config_network_filters_mongo_proxy_dynamic_metadata>` should be emitted. Defaults to false.
   bool emit_dynamic_metadata = 4;
 }

--- a/docs/root/configuration/network_filters/mongo_proxy_filter.rst
+++ b/docs/root/configuration/network_filters/mongo_proxy_filter.rst
@@ -173,3 +173,20 @@ message
 upstream_host
   The upstream host that the connection is proxying to, if available. This is populated if the
   filter is used along with the :ref:`TCP proxy filter <config_network_filters_tcp_proxy>`.
+
+.. _config_network_filters_mongo_proxy_dynamic_metadata:
+
+Dynamic Metadata
+----------------
+
+The Mongo filter emits the following dynamic metadata when enabled via the
+:ref:`configuration <envoy_api_field_config.filter.network.mongo_proxy.v2.MongoProxy.emit_dynamic_metadata>`.
+This dynamic metadata is available as one struct per message under a list named *messages*.
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: 1, 1, 2
+
+  collection, string, The collection on which the operation will be executed.
+  database, string, The database on which the operation will be executed.
+  operation, string, The operation to be executed.

--- a/docs/root/configuration/network_filters/mongo_proxy_filter.rst
+++ b/docs/root/configuration/network_filters/mongo_proxy_filter.rst
@@ -187,6 +187,5 @@ This dynamic metadata is available as one struct per message under a list named 
   :header: Name, Type, Description
   :widths: 1, 1, 2
 
-  collection, string, The collection on which the operation will be executed.
-  database, string, The database on which the operation will be executed.
   operation, string, The operation to be executed.
+  resource, string, The resource name in *db.collection* format on which the operation is to be executed.

--- a/docs/root/configuration/well_known_dynamic_metadata.rst
+++ b/docs/root/configuration/well_known_dynamic_metadata.rst
@@ -13,5 +13,6 @@ by looking at the operational metadata emitted by the MongoDB filter.
 
 The following Envoy filters emit dynamic metadata that other filters can leverage.
 
+* :ref:`Mongo Proxy Filter <config_network_filters_mongo_proxy_dynamic_metadata>`
 * :ref:`Role Based Access Control (RBAC) Filter <config_http_filters_rbac_dynamic_metadata>`
 * :ref:`Role Based Access Control (RBAC) Network Filter <config_network_filters_rbac_dynamic_metadata>`

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -28,8 +28,9 @@ Version history
 * http: no longer close the TCP connection when a HTTP/1 request is retried due
   to a response with empty body.
 * load balancer: added a `configuration <envoy_api_msg_Cluster.LeastRequestLbConfig>` option to specify the number of choices made in P2C.
-* network: removed the reference to `FilterState` in `Connection` in favor of `StreamInfo`.
 * logging: added missing [ in log prefix.
+* mongo_proxy: added :ref:`dynamic metadata <config_network_filters_mongo_proxy_dynamic_metadata>`.
+* network: removed the reference to `FilterState` in `Connection` in favor of `StreamInfo`.
 * rate-limit: added :ref:`configuration <envoy_api_field_config.filter.http.rate_limit.v2.RateLimit.rate_limited_as_resource_exhausted>`
   to specify whether the `GrpcStatus` status returned should be `RESOURCE_EXHAUSTED` or
   `UNAVAILABLE` when a gRPC call is rate limited.

--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -296,6 +296,7 @@ public:
   /**
    * @return const envoy::api::v2::core::Metadata& the dynamic metadata associated with this request
    */
+  virtual envoy::api::v2::core::Metadata& dynamicMetadata() PURE;
   virtual const envoy::api::v2::core::Metadata& dynamicMetadata() const PURE;
 
   /**

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -176,6 +176,7 @@ struct StreamInfoImpl : public StreamInfo {
 
   const Router::RouteEntry* routeEntry() const override { return route_entry_; }
 
+  envoy::api::v2::core::Metadata& dynamicMetadata() override { return metadata_; };
   const envoy::api::v2::core::Metadata& dynamicMetadata() const override { return metadata_; };
 
   void setDynamicMetadata(const std::string& name, const ProtobufWkt::Struct& value) override {

--- a/source/extensions/filters/network/mongo_proxy/BUILD
+++ b/source/extensions/filters/network/mongo_proxy/BUILD
@@ -75,6 +75,7 @@ envoy_cc_library(
         "//source/common/network:filter_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/singleton:const_singleton",
+        "//source/extensions/filters/network:well_known_names",
         "@envoy_api//envoy/config/filter/network/mongo_proxy/v2:mongo_proxy_cc",
     ],
 )

--- a/source/extensions/filters/network/mongo_proxy/config.cc
+++ b/source/extensions/filters/network/mongo_proxy/config.cc
@@ -34,11 +34,13 @@ Network::FilterFactoryCb MongoProxyFilterConfigFactory::createFilterFactoryFromP
     fault_config = std::make_shared<FaultConfig>(proto_config.delay());
   }
 
-  return [stat_prefix, &context, access_log,
-          fault_config](Network::FilterManager& filter_manager) -> void {
+  const bool emit_dynamic_metadata = proto_config.emit_dynamic_metadata();
+  return [stat_prefix, &context, access_log, fault_config,
+          emit_dynamic_metadata](Network::FilterManager& filter_manager) -> void {
     filter_manager.addFilter(std::make_shared<ProdProxyFilter>(
         stat_prefix, context.scope(), context.runtime(), access_log, fault_config,
-        context.drainDecision(), context.random(), context.dispatcher().timeSystem()));
+        context.drainDecision(), context.random(), context.dispatcher().timeSystem(),
+        emit_dynamic_metadata));
   };
 }
 

--- a/source/extensions/filters/network/mongo_proxy/proxy.h
+++ b/source/extensions/filters/network/mongo_proxy/proxy.h
@@ -158,6 +158,11 @@ public:
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 
+  void setDynamicMetadata(std::string field, double value);
+  void setDynamicMetadata(std::string field, std::string value);
+  void setDynamicMetadata(std::string field, const std::vector<int64_t>& values);
+  void setDynamicMetadata(std::string field, std::list<Bson::DocumentSharedPtr>& values);
+
 private:
   struct ActiveQuery {
     ActiveQuery(ProxyFilter& parent, const QueryMessage& query)

--- a/source/extensions/filters/network/mongo_proxy/proxy.h
+++ b/source/extensions/filters/network/mongo_proxy/proxy.h
@@ -158,7 +158,8 @@ public:
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 
-  void setDynamicMetadata(std::string field, std::string value);
+  void setDynamicMetadata(std::string op, absl::optional<std::string> db,
+                          absl::optional<std::string> collection);
 
 private:
   struct ActiveQuery {

--- a/source/extensions/filters/network/mongo_proxy/proxy.h
+++ b/source/extensions/filters/network/mongo_proxy/proxy.h
@@ -158,10 +158,7 @@ public:
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 
-  void setDynamicMetadata(std::string field, double value);
   void setDynamicMetadata(std::string field, std::string value);
-  void setDynamicMetadata(std::string field, const std::vector<int64_t>& values);
-  void setDynamicMetadata(std::string field, std::list<Bson::DocumentSharedPtr>& values);
 
 private:
   struct ActiveQuery {

--- a/source/extensions/filters/network/mongo_proxy/proxy.h
+++ b/source/extensions/filters/network/mongo_proxy/proxy.h
@@ -128,7 +128,7 @@ public:
   ProxyFilter(const std::string& stat_prefix, Stats::Scope& scope, Runtime::Loader& runtime,
               AccessLogSharedPtr access_log, const FaultConfigSharedPtr& fault_config,
               const Network::DrainDecision& drain_decision, Runtime::RandomGenerator& generator,
-              Event::TimeSystem& time_system);
+              Event::TimeSystem& time_system, bool emit_dynamic_metadata);
   ~ProxyFilter();
 
   virtual DecoderPtr createDecoder(DecoderCallbacks& callbacks) PURE;
@@ -210,6 +210,7 @@ private:
   Event::TimerPtr delay_timer_;
   Event::TimerPtr drain_close_timer_;
   Event::TimeSystem& time_system_;
+  bool emit_dynamic_metadata_;
 };
 
 class ProdProxyFilter : public ProxyFilter {

--- a/source/extensions/filters/network/mongo_proxy/proxy.h
+++ b/source/extensions/filters/network/mongo_proxy/proxy.h
@@ -210,7 +210,7 @@ private:
   Event::TimerPtr delay_timer_;
   Event::TimerPtr drain_close_timer_;
   Event::TimeSystem& time_system_;
-  bool emit_dynamic_metadata_;
+  const bool emit_dynamic_metadata_;
 };
 
 class ProdProxyFilter : public ProxyFilter {

--- a/source/extensions/filters/network/mongo_proxy/proxy.h
+++ b/source/extensions/filters/network/mongo_proxy/proxy.h
@@ -158,8 +158,7 @@ public:
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 
-  void setDynamicMetadata(std::string op, absl::optional<std::string> db,
-                          absl::optional<std::string> collection);
+  void setDynamicMetadata(std::string operation, std::string resource);
 
 private:
   struct ActiveQuery {

--- a/test/common/access_log/BUILD
+++ b/test/common/access_log/BUILD
@@ -12,17 +12,6 @@ load(
 
 envoy_package()
 
-envoy_cc_test_library(
-    name = "test_util",
-    hdrs = ["test_util.h"],
-    deps = [
-        "//include/envoy/stream_info:stream_info_interface",
-        "//source/common/common:assert_lib",
-        "//source/common/stream_info:filter_state_lib",
-        "//test/test_common:test_time_lib",
-    ],
-)
-
 envoy_proto_library(
     name = "access_log_formatter_fuzz_proto",
     srcs = ["access_log_formatter_fuzz.proto"],
@@ -58,10 +47,10 @@ envoy_cc_test(
     name = "access_log_impl_test",
     srcs = ["access_log_impl_test.cc"],
     deps = [
-        ":test_util",
         "//source/common/access_log:access_log_lib",
         "//source/common/config:filter_json_lib",
         "//source/extensions/access_loggers/file:config",
+        "//test/common/stream_info:test_util",
         "//test/common/upstream:utility_lib",
         "//test/mocks/access_log:access_log_mocks",
         "//test/mocks/event:event_mocks",
@@ -95,10 +84,10 @@ envoy_cc_binary(
         "benchmark",
     ],
     deps = [
-        ":test_util",
         "//source/common/access_log:access_log_formatter_lib",
         "//source/common/http:header_map_lib",
         "//source/common/network:address_lib",
+        "//test/common/stream_info:test_util",
         "//test/mocks/http:http_mocks",
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/test_common:printers_lib",

--- a/test/common/access_log/access_log_formatter_speed_test.cc
+++ b/test/common/access_log/access_log_formatter_speed_test.cc
@@ -1,7 +1,7 @@
 #include "common/access_log/access_log_formatter.h"
 #include "common/network/address_impl.h"
 
-#include "test/common/access_log/test_util.h"
+#include "test/common/stream_info/test_util.h"
 #include "test/mocks/http/mocks.h"
 
 #include "testing/base/public/benchmark.h"

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -17,6 +17,7 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::Const;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
@@ -504,6 +505,7 @@ TEST(AccessLogFormatterTest, JsonFormatterDynamicMetadataTest) {
   envoy::api::v2::core::Metadata metadata;
   populateMetadataTestData(metadata);
   EXPECT_CALL(stream_info, dynamicMetadata()).WillRepeatedly(ReturnRef(metadata));
+  EXPECT_CALL(Const(stream_info), dynamicMetadata()).WillRepeatedly(ReturnRef(metadata));
 
   std::unordered_map<std::string, std::string> expected_json_map = {
       {"test_key", "\"test_value\""},
@@ -622,6 +624,7 @@ TEST(AccessLogFormatterTest, CompositeFormatterSuccess) {
     envoy::api::v2::core::Metadata metadata;
     populateMetadataTestData(metadata);
     EXPECT_CALL(stream_info, dynamicMetadata()).WillRepeatedly(ReturnRef(metadata));
+    EXPECT_CALL(Const(stream_info), dynamicMetadata()).WillRepeatedly(ReturnRef(metadata));
     const std::string format = "%DYNAMIC_METADATA(com.test:test_key)%|%DYNAMIC_METADATA(com.test:"
                                "test_obj)%|%DYNAMIC_METADATA(com.test:test_obj:inner_key)%";
     FormatterImpl formatter(format);

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -11,7 +11,7 @@
 #include "common/runtime/runtime_impl.h"
 #include "common/runtime/uuid_util.h"
 
-#include "test/common/access_log/test_util.h"
+#include "test/common/stream_info/test_util.h"
 #include "test/common/upstream/utility.h"
 #include "test/mocks/access_log/mocks.h"
 #include "test/mocks/event/mocks.h"

--- a/test/common/stream_info/BUILD
+++ b/test/common/stream_info/BUILD
@@ -39,6 +39,17 @@ envoy_cc_test_library(
     ],
 )
 
+envoy_cc_test_library(
+    name = "test_util",
+    hdrs = ["test_util.h"],
+    deps = [
+        "//include/envoy/stream_info:stream_info_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/stream_info:filter_state_lib",
+        "//test/test_common:test_time_lib",
+    ],
+)
+
 envoy_cc_test(
     name = "utility_test",
     srcs = ["utility_test.cc"],

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -153,6 +153,7 @@ public:
     return duration(end_time_);
   }
 
+  envoy::api::v2::core::Metadata& dynamicMetadata() override { return metadata_; };
   const envoy::api::v2::core::Metadata& dynamicMetadata() const override { return metadata_; };
 
   void setDynamicMetadata(const std::string& name, const ProtobufWkt::Struct& value) override {

--- a/test/extensions/filters/network/mongo_proxy/BUILD
+++ b/test/extensions/filters/network/mongo_proxy/BUILD
@@ -43,6 +43,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/network/mongo_proxy:bson_lib",
         "//source/extensions/filters/network/mongo_proxy:codec_lib",
         "//source/extensions/filters/network/mongo_proxy:proxy_lib",
+        "//test/common/stream_info:test_util",
         "//test/mocks/access_log:access_log_mocks",
         "//test/mocks/event:event_mocks",
         "//test/mocks/filesystem:filesystem_mocks",

--- a/test/extensions/filters/network/mongo_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/proxy_test.cc
@@ -9,7 +9,9 @@
 #include "extensions/filters/network/mongo_proxy/bson_impl.h"
 #include "extensions/filters/network/mongo_proxy/codec_impl.h"
 #include "extensions/filters/network/mongo_proxy/proxy.h"
+#include "extensions/filters/network/well_known_names.h"
 
+#include "test/common/stream_info/test_util.h"
 #include "test/mocks/access_log/mocks.h"
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/filesystem/mocks.h"
@@ -27,6 +29,7 @@ using testing::Invoke;
 using testing::NiceMock;
 using testing::Property;
 using testing::Return;
+using testing::ReturnRef;
 
 namespace Envoy {
 namespace Extensions {
@@ -69,14 +72,19 @@ public:
     ON_CALL(runtime_.snapshot_, featureEnabled("mongo.logging_enabled", 100))
         .WillByDefault(Return(true));
 
+    EXPECT_CALL(read_filter_callbacks_, connection())
+        .WillRepeatedly(ReturnRef(read_filter_callbacks_.connection_));
+    EXPECT_CALL(read_filter_callbacks_.connection_, streamInfo())
+        .WillRepeatedly(ReturnRef(stream_info_));
+
     EXPECT_CALL(log_manager_, createAccessLog(_)).WillOnce(Return(file_));
     access_log_.reset(new AccessLog("test", log_manager_, dispatcher_.timeSystem()));
   }
 
   void initializeFilter() {
-    filter_ =
-        std::make_unique<TestProxyFilter>("test.", store_, runtime_, access_log_, fault_config_,
-                                          drain_decision_, generator_, dispatcher_.timeSystem());
+    filter_ = std::make_unique<TestProxyFilter>("test.", store_, runtime_, access_log_,
+                                                fault_config_, drain_decision_, generator_,
+                                                dispatcher_.timeSystem(), true);
     filter_->initializeReadFilterCallbacks(read_filter_callbacks_);
     filter_->onNewConnection();
 
@@ -115,6 +123,7 @@ public:
   Envoy::AccessLog::MockAccessLogManager log_manager_;
   NiceMock<Network::MockDrainDecision> drain_decision_;
   NiceMock<Runtime::MockRandomGenerator> generator_;
+  TestStreamInfo stream_info_;
 };
 
 TEST_F(MongoProxyFilterTest, DelayFaults) {
@@ -189,6 +198,104 @@ TEST_F(MongoProxyFilterTest, DelayFaultsRuntimeDisabled) {
 
   EXPECT_EQ(Network::FilterStatus::Continue, filter_->onData(fake_data_, false));
   EXPECT_EQ(0U, store_.counter("test.delays_injected").value());
+}
+
+TEST_F(MongoProxyFilterTest, DynamicMetadata) {
+  initializeFilter();
+
+  EXPECT_CALL(*file_, write(_)).Times(AtLeast(1));
+
+  EXPECT_CALL(*filter_->decoder_, onData(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    QueryMessagePtr message(new QueryMessageImpl(0, 0));
+    message->fullCollectionName("db.test");
+    message->flags(0b1110010);
+    message->query(Bson::DocumentImpl::create());
+    filter_->callbacks_->decodeQuery(std::move(message));
+  }));
+  filter_->onData(fake_data_, false);
+
+  auto& metadata =
+      stream_info_.dynamicMetadata().filter_metadata().at(NetworkFilterNames::get().MongoProxy);
+  auto& query_message = metadata.fields().at("messages").list_value().values(0).struct_value();
+  EXPECT_EQ("OP_QUERY", query_message.fields().at("operation").string_value());
+  EXPECT_EQ("db", query_message.fields().at("database").string_value());
+  EXPECT_EQ("test", query_message.fields().at("collection").string_value());
+
+  EXPECT_CALL(*filter_->decoder_, onData(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    ReplyMessagePtr message(new ReplyMessageImpl(0, 0));
+    message->flags(0b11);
+    message->cursorId(1);
+    message->documents().push_back(Bson::DocumentImpl::create()->addString("hello", "world"));
+    filter_->callbacks_->decodeReply(std::move(message));
+  }));
+  filter_->onWrite(fake_data_, false);
+
+  auto& reply_message = metadata.fields().at("messages").list_value().values(0).struct_value();
+  EXPECT_EQ("OP_REPLY", reply_message.fields().at("operation").string_value());
+
+  EXPECT_CALL(*filter_->decoder_, onData(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    GetMoreMessagePtr message(new GetMoreMessageImpl(0, 0));
+    message->fullCollectionName("db.test");
+    message->cursorId(1);
+    filter_->callbacks_->decodeGetMore(std::move(message));
+  }));
+  filter_->onData(fake_data_, false);
+
+  auto& get_more_message = metadata.fields().at("messages").list_value().values(0).struct_value();
+  EXPECT_EQ("OP_GET_MORE", get_more_message.fields().at("operation").string_value());
+  EXPECT_EQ("db", get_more_message.fields().at("database").string_value());
+  EXPECT_EQ("test", get_more_message.fields().at("collection").string_value());
+
+  EXPECT_CALL(*filter_->decoder_, onData(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    InsertMessagePtr message(new InsertMessageImpl(0, 0));
+    message->fullCollectionName("db.test");
+    message->documents().push_back(Bson::DocumentImpl::create());
+    filter_->callbacks_->decodeInsert(std::move(message));
+  }));
+  filter_->onData(fake_data_, false);
+
+  auto& insert_message = metadata.fields().at("messages").list_value().values(0).struct_value();
+  EXPECT_EQ("OP_INSERT", insert_message.fields().at("operation").string_value());
+  EXPECT_EQ("db", insert_message.fields().at("database").string_value());
+  EXPECT_EQ("test", insert_message.fields().at("collection").string_value());
+
+  EXPECT_CALL(*filter_->decoder_, onData(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    KillCursorsMessagePtr message(new KillCursorsMessageImpl(0, 0));
+    message->numberOfCursorIds(1);
+    message->cursorIds({1});
+    filter_->callbacks_->decodeKillCursors(std::move(message));
+  }));
+  filter_->onData(fake_data_, false);
+
+  auto& kill_cursors_message =
+      metadata.fields().at("messages").list_value().values(0).struct_value();
+  EXPECT_EQ("OP_KILL_CURSORS", kill_cursors_message.fields().at("operation").string_value());
+
+  EXPECT_CALL(*filter_->decoder_, onData(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    CommandMessagePtr message(new CommandMessageImpl(0, 0));
+    message->database(std::string("db"));
+    message->commandName(std::string("command"));
+    message->metadata(Bson::DocumentImpl::create());
+    message->commandArgs(Bson::DocumentImpl::create());
+    filter_->callbacks_->decodeCommand(std::move(message));
+  }));
+  filter_->onData(fake_data_, false);
+
+  auto& command_message = metadata.fields().at("messages").list_value().values(0).struct_value();
+  EXPECT_EQ("OP_COMMAND", command_message.fields().at("operation").string_value());
+  EXPECT_EQ("db", command_message.fields().at("database").string_value());
+
+  EXPECT_CALL(*filter_->decoder_, onData(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
+    CommandReplyMessagePtr message(new CommandReplyMessageImpl(0, 0));
+    message->metadata(Bson::DocumentImpl::create());
+    message->commandReply(Bson::DocumentImpl::create());
+    filter_->callbacks_->decodeCommandReply(std::move(message));
+  }));
+  filter_->onData(fake_data_, false);
+
+  auto& command_reply_message =
+      metadata.fields().at("messages").list_value().values(0).struct_value();
+  EXPECT_EQ("OP_COMMANDREPLY", command_reply_message.fields().at("operation").string_value());
 }
 
 TEST_F(MongoProxyFilterTest, Stats) {

--- a/test/fuzz/BUILD
+++ b/test/fuzz/BUILD
@@ -48,7 +48,7 @@ envoy_cc_test_library(
     deps = [
         ":common_proto_cc",
         "//source/common/network:utility_lib",
-        "//test/common/access_log:test_util",
+        "//test/common/stream_info:test_util",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:utility_lib",
     ],

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -2,7 +2,7 @@
 
 #include "common/network/utility.h"
 
-#include "test/common/access_log/test_util.h"
+#include "test/common/stream_info/test_util.h"
 #include "test/fuzz/common.pb.h"
 #include "test/mocks/upstream/host.h"
 #include "test/test_common/utility.h"

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::Const;
 using testing::Invoke;
 using testing::Return;
 using testing::ReturnPointee;
@@ -64,6 +65,7 @@ MockStreamInfo::MockStreamInfo()
   }));
   ON_CALL(*this, bytesSent()).WillByDefault(ReturnPointee(&bytes_sent_));
   ON_CALL(*this, dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
+  ON_CALL(Const(*this), dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
   ON_CALL(*this, filterState()).WillByDefault(ReturnRef(filter_state_));
   ON_CALL(*this, setRequestedServerName(_))
       .WillByDefault(Invoke([this](const absl::string_view requested_server_name) {

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -58,6 +58,7 @@ public:
   MOCK_METHOD1(setDownstreamRemoteAddress, void(const Network::Address::InstanceConstSharedPtr&));
   MOCK_CONST_METHOD0(downstreamRemoteAddress, const Network::Address::InstanceConstSharedPtr&());
   MOCK_CONST_METHOD0(routeEntry, const Router::RouteEntry*());
+  MOCK_METHOD0(dynamicMetadata, envoy::api::v2::core::Metadata&());
   MOCK_CONST_METHOD0(dynamicMetadata, const envoy::api::v2::core::Metadata&());
   MOCK_METHOD2(setDynamicMetadata, void(const std::string&, const ProtobufWkt::Struct&));
   MOCK_METHOD3(setDynamicMetadata,


### PR DESCRIPTION
*Description*: This adds dynamic metadata to the stream info while processing data in the `mongo_proxy` filter.
*Risk Level*: Low
*Testing*: Pending
*Docs Changes*: Pending
*Release Notes*: Pending

/cc @rshriram 