### PR TITLE
api: Strawman proposal to add downstream load reporting to LRS.

### DIFF
--- a/api/envoy/api/v2/endpoint/load_report.proto
+++ b/api/envoy/api/v2/endpoint/load_report.proto
@@ -5,6 +5,7 @@ package envoy.api.v2.endpoint;
 import "envoy/api/v2/core/address.proto";
 import "envoy/api/v2/core/base.proto";
 
+import "google/protobuf/struct.proto";
 import "google/protobuf/duration.proto";
 
 import "validate/validate.proto";
@@ -105,6 +106,49 @@ message EndpointLoadMetricStats {
   double total_metric_value = 3;
 }
 
+// Stats per downstream host.
+message DownstreamEndpointStats {
+  // Downstream host address.
+  core.Address address = 1;
+
+  // Metadata passed directly to the management server.
+  google.protobuf.Struct metadata = 5;
+
+  // The total number of requests per downstream host
+  // successfully completed by the endpoint. A single HTTP or gRPC
+  // request or stream is counted as one request. A TCP connection is
+  // also treated as one request. There is no explicit total_requests
+  // field below for an endpoint, but it may be inferred from:
+  //
+  // .. code-block:: none
+  //
+  //   total_requests = total_successful_requests + total_requests_in_progress +
+  //     total_error_requests
+  //
+  // The total number of requests per downstream host successfully
+  // completed by the endpoints in the locality. These include non-5xx
+  // responses for HTTP, where errors originate at the client and the
+  // endpoint responded successfully. For gRPC, the grpc-status values
+  // are those not covered by total_error_requests below.
+  uint64 total_successful_requests = 2;
+
+  // The total number of unfinished requests per downstream host for
+  // this endpoint.
+  uint64 total_requests_in_progress = 3;
+
+  // The total number of requests per downstream host that failed
+  // due to errors at the endpoint. For HTTP these are responses with
+  // 5xx status codes and for gRPC the grpc-status values:
+  //
+  //   - DeadlineExceeded
+  //   - Unimplemented
+  //   - Internal
+  //   - Unavailable
+  //   - Unknown
+  //   - DataLoss
+  uint64 total_error_requests = 4;
+}
+
 // Per cluster load stats. Envoy reports these stats a management server in a
 // :ref:`LoadStatsRequest<envoy_api_msg_load_stats.LoadStatsRequest>`
 // [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
@@ -115,6 +159,9 @@ message ClusterStats {
   // Need at least one.
   repeated UpstreamLocalityStats upstream_locality_stats = 2
       [(validate.rules).repeated .min_items = 1];
+
+  // Endpoint granularity stats per downstream host based on incoming requests.
+  repeated DownstreamEndpointStats downstream_endpoint_stats = 6;
 
   // Cluster-level stats such as total_successful_requests may be computed by
   // summing upstream_locality_stats. In addition, below there are additional


### PR DESCRIPTION
A backend will use this to report per client(frontend) load based on incoming requests.
 
Signed-off-by: Karthik Reddy <rekarthik@google.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*:
*Risk Level*:
*Testing*:
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
