### PR TITLE
Add code owners entry for datadog extension

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,3 +14,5 @@
 /*/extensions/transport_sockets/alts @htuch @yangminzhu
 # sni_cluster extension
 /*/extensions/filters/network/sni_cluster @rshriram @lizan
+# tracers.datadog extension
+/*/extensions/tracers/datadog @cgilmour @palazzem


### PR DESCRIPTION
*Description*:
Requested [here](https://github.com/envoyproxy/envoy/pull/4699#issuecomment-437635390), adding an item to codeowners.

*Risk Level*:
Low

*Testing*:
N/A

*Docs Changes*:
N/A

*Release Notes*:
N/A