### PR TITLE
router: adding per-route upgrade config

### DIFF
--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -406,7 +406,7 @@ message CorsPolicy {
   google.protobuf.BoolValue enabled = 7;
 }
 
-// [#comment:next free field: 25]
+// [#comment:next free field: 26]
 message RouteAction {
   oneof cluster_specifier {
     option (validate.required) = true;
@@ -757,6 +757,22 @@ message RouteAction {
   // This can be used to prevent unexpected upstream request timeouts due to potentially long
   // time gaps between gRPC request and response in gRPC streaming mode.
   google.protobuf.Duration max_grpc_timeout = 23 [(gogoproto.stdduration) = true];
+
+  // Allows enabling and disabling upgrades on a per-route basis.
+  // This overrides any enabled/disabled upgrade filter chain specified in the
+  // HttpConnectionManager
+  // :ref:upgrade_configs`
+  // <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.upgrade_configs>`
+  // but does not affect any custom filter chain specified there.
+  message UpgradeConfig {
+    // The case-insensitive name of this upgrade, e.g. "websocket".
+    // For each upgrade type present in upgrade_configs, requests with
+    // Upgrade: [upgrade_type] will be proxied upstream.
+    string upgrade_type = 1;
+    // Determines if upgrades are available on this route. Defaults to true.
+    google.protobuf.BoolValue enabled = 2;
+  };
+  repeated UpgradeConfig upgrade_configs = 25;
 }
 
 message RedirectAction {

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -353,6 +353,10 @@ message HttpConnectionManager {
     // this type of upgrade. If no filters are present, the filter chain for
     // HTTP connections will be used for this upgrade type.
     repeated HttpFilter filters = 2;
+    // Determines if upgrades are enabled or disabled by default. This can be
+    // overriden on a per-route basis with :ref:`cluster
+    // <envoy_api_field_route.RouteAction.upgrade_configs>`. Defaults to true.
+    google.protobuf.BoolValue enabled = 3;
   };
   repeated UpgradeConfig upgrade_configs = 23;
 

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -353,9 +353,10 @@ message HttpConnectionManager {
     // this type of upgrade. If no filters are present, the filter chain for
     // HTTP connections will be used for this upgrade type.
     repeated HttpFilter filters = 2;
-    // Determines if upgrades are enabled or disabled by default. This can be
-    // overriden on a per-route basis with :ref:`cluster
-    // <envoy_api_field_route.RouteAction.upgrade_configs>`. Defaults to true.
+    // Determines if upgrades are enabled or disabled by default. Defaults to true.
+    // This can be overriden on a per-route basis with :ref:`cluster
+    // <envoy_api_field_route.RouteAction.upgrade_configs>` as documented in the
+    // :ref:`upgrade documentation <arch_overview_websocket>`.
     google.protobuf.BoolValue enabled = 3;
   };
   repeated UpgradeConfig upgrade_configs = 23;

--- a/docs/root/intro/arch_overview/websocket.rst
+++ b/docs/root/intro/arch_overview/websocket.rst
@@ -7,7 +7,7 @@ Envoy Upgrade support is intended mainly for WebSocket but may be used for non-W
 upgrades as well. Upgrades pass both the HTTP headers and the upgrade payload
 through an HTTP filter chain. One may configure the
 :ref:`upgrade_configs <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.upgrade_configs>`
-in one of two ways. If only the
+with or without custom filter chains. If only the
 :ref:`upgrade_type <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.UpgradeConfig.upgrade_type>`
 is specified, both the upgrade headers, any request and response body, and WebSocket payload will
 pass through the default HTTP filter chain. To avoid the use of HTTP-only filters for upgrade payload,
@@ -15,6 +15,22 @@ one can set up custom
 :ref:`filters <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.UpgradeConfig.filters>`
 for the given upgrade type, up to and including only using the router filter to send the WebSocket
 data upstream.
+
+Upgrades can be enabled or disabled on a :ref:`per-route <envoy_api_field_route.RouteAction.upgrade_configs>` basis.
+Any per-route enabling/disabling automatically overrides HttpConnectionManager configuration as
+laid out below, but custom filter chains can only be configured on a per-HttpConnectionManager basis.
+
++-----------------------+-------------------------+-------------------+
+| *HCM Upgrade Enabled* | *Route Upgrade Enabled* | *Upgrade Enabled* |
++=======================+=========================+===================+
+| T (Default)           | T (Default)             | T                 |
++-----------------------+-------------------------+-------------------+
+| T (Default)           | F                       | F                 |
++-----------------------+-------------------------+-------------------+
+| F                     | T (Default)             | T                 |
++-----------------------+-------------------------+-------------------+
+| F                     | F                       | F                 |
++-----------------------+-------------------------+-------------------+
 
 Note that the statistics for upgrades are all bundled together so websocket
 :ref:`statistics <config_http_conn_man_stats>` are tracked by stats such as

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -46,6 +46,7 @@ Version history
   been fully decoded by Envoy.
 * router: added support for not retrying :ref:`rate limited requests<config_http_filters_router_x-envoy-ratelimited>`. Rate limit filter now sets the :ref:`x-envoy-ratelimited<config_http_filters_router_x-envoy-ratelimited>`
   header so the rate limited requests that may have been retried earlier will not be retried with this change.
+* router: added support for enabling upgrades on a :ref:`per-route <envoy_api_field_route.RouteAction.upgrade_configs>` basis.
 * stats: added :ref:`stats_matcher <envoy_api_field_config.metrics.v2.StatsConfig.stats_matcher>` to the bootstrap config for granular control of stat instantiation.
 * stream: renamed the `RequestInfo` namespace to `StreamInfo` to better match
   its behaviour within TCP and HTTP implementations.

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -577,12 +577,14 @@ public:
   /**
    * Called when a new upgrade stream is created on the connection.
    * @param upgrade supplies the upgrade header from downstream
+   * @param upgrade_map supplies the upgrade map, if any, for this route.
    * @param callbacks supplies the "sink" that is used for actually creating the filter chain. @see
    *                  FilterChainFactoryCallbacks.
    * @return true if upgrades of this type are allowed and the filter chain has been created.
    *    returns false if this upgrade type is not configured, and no filter chain is created.
    */
-  virtual bool createUpgradeFilterChain(absl::string_view upgrade,
+  typedef std::map<std::string, bool> UpgradeMap;
+  virtual bool createUpgradeFilterChain(absl::string_view upgrade, const UpgradeMap* upgrade_map,
                                         FilterChainFactoryCallbacks& callbacks) PURE;
 };
 

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -577,14 +577,15 @@ public:
   /**
    * Called when a new upgrade stream is created on the connection.
    * @param upgrade supplies the upgrade header from downstream
-   * @param upgrade_map supplies the upgrade map, if any, for this route.
+   * @param per_route_upgrade_map supplies the upgrade map, if any, for this route.
    * @param callbacks supplies the "sink" that is used for actually creating the filter chain. @see
    *                  FilterChainFactoryCallbacks.
    * @return true if upgrades of this type are allowed and the filter chain has been created.
    *    returns false if this upgrade type is not configured, and no filter chain is created.
    */
   typedef std::map<std::string, bool> UpgradeMap;
-  virtual bool createUpgradeFilterChain(absl::string_view upgrade, const UpgradeMap* upgrade_map,
+  virtual bool createUpgradeFilterChain(absl::string_view upgrade,
+                                        const UpgradeMap* per_route_upgrade_map,
                                         FilterChainFactoryCallbacks& callbacks) PURE;
 };
 

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -624,6 +624,12 @@ public:
    * @return bool whether x-envoy-attempt-count should be included on the upstream request.
    */
   virtual bool includeAttemptCount() const PURE;
+
+  typedef std::map<std::string, bool> UpgradeMap;
+  /**
+   * @return a map of route-specific upgrades to their enabled/disabled status.
+   */
+  virtual const UpgradeMap& upgradeMap() const PURE;
 };
 
 /**

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -234,6 +234,7 @@ private:
     }
 
     bool includeAttemptCount() const override { return false; }
+    const Router::RouteEntry::UpgradeMap& upgradeMap() const override { return upgrade_map_; }
 
     static const NullRateLimitPolicy rate_limit_policy_;
     static const NullRetryPolicy retry_policy_;
@@ -245,6 +246,7 @@ private:
     static const Config::TypedMetadataImpl<Config::TypedMetadataFactory> typed_metadata_;
     static const NullPathMatchCriterion path_match_criterion_;
 
+    Router::RouteEntry::UpgradeMap upgrade_map_;
     const std::string& cluster_name_;
     absl::optional<std::chrono::milliseconds> timeout_;
   };

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1341,8 +1341,12 @@ bool ConnectionManagerImpl::ActiveStream::createFilterChain() {
   auto upgrade = request_headers_ ? request_headers_->Upgrade() : nullptr;
   state_.created_filter_chain_ = true;
   if (upgrade != nullptr) {
+    const Router::RouteEntry::UpgradeMap* upgrade_map = nullptr;
+    if (cached_route_.value() && cached_route_.value()->routeEntry()) {
+      upgrade_map = &cached_route_.value()->routeEntry()->upgradeMap();
+    }
     if (connection_manager_.config_.filterFactory().createUpgradeFilterChain(
-            upgrade->value().c_str(), *this)) {
+            upgrade->value().c_str(), upgrade_map, *this)) {
       state_.successful_upgrade_ = true;
       connection_manager_.stats_.named_.downstream_cx_upgrades_total_.inc();
       connection_manager_.stats_.named_.downstream_cx_upgrades_active_.inc();

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -370,6 +370,10 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
   if (route.route().has_cors()) {
     cors_policy_ = std::make_unique<CorsPolicyImpl>(route.route().cors());
   }
+  for (const auto upgrade_config : route.route().upgrade_configs()) {
+    bool enabled = upgrade_config.has_enabled() ? upgrade_config.enabled().value() : true;
+    upgrade_map_.emplace(std::make_pair(upgrade_config.upgrade_type(), enabled));
+  }
 }
 
 bool RouteEntryImplBase::evaluateRuntimeMatch(const uint64_t random_value) const {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -372,7 +372,14 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
   }
   for (const auto upgrade_config : route.route().upgrade_configs()) {
     bool enabled = upgrade_config.has_enabled() ? upgrade_config.enabled().value() : true;
-    upgrade_map_.emplace(std::make_pair(upgrade_config.upgrade_type(), enabled));
+    bool success =
+        upgrade_map_
+            .emplace(std::make_pair(
+                Envoy::Http::LowerCaseString(upgrade_config.upgrade_type()).get(), enabled))
+            .second;
+    if (!success) {
+      throw EnvoyException(fmt::format("Duplicate upgrade {}", upgrade_config.upgrade_type()));
+    }
   }
 }
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -371,8 +371,8 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
     cors_policy_ = std::make_unique<CorsPolicyImpl>(route.route().cors());
   }
   for (const auto upgrade_config : route.route().upgrade_configs()) {
-    bool enabled = upgrade_config.has_enabled() ? upgrade_config.enabled().value() : true;
-    bool success =
+    const bool enabled = upgrade_config.has_enabled() ? upgrade_config.enabled().value() : true;
+    const bool success =
         upgrade_map_
             .emplace(std::make_pair(
                 Envoy::Http::LowerCaseString(upgrade_config.upgrade_type()).get(), enabled))

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -346,6 +346,7 @@ public:
   const Envoy::Config::TypedMetadata& typedMetadata() const override { return typed_metadata_; }
   const PathMatchCriterion& pathMatchCriterion() const override { return *this; }
   bool includeAttemptCount() const override { return vhost_.includeAttemptCount(); }
+  const UpgradeMap& upgradeMap() const override { return upgrade_map_; }
 
   // Router::DirectResponseEntry
   std::string newPath(const Http::HeaderMap& headers) const override;
@@ -445,6 +446,7 @@ private:
     }
 
     bool includeAttemptCount() const override { return parent_->includeAttemptCount(); }
+    const UpgradeMap& upgradeMap() const override { return parent_->upgradeMap(); }
 
     // Router::Route
     const DirectResponseEntry* directResponseEntry() const override { return nullptr; }
@@ -546,6 +548,7 @@ private:
   std::vector<Http::HeaderUtility::HeaderData> config_headers_;
   std::vector<ConfigUtility::QueryParameterMatcher> config_query_parameters_;
   std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
+  UpgradeMap upgrade_map_;
   const uint64_t total_cluster_weight_;
   std::unique_ptr<const HashPolicyImpl> hash_policy_;
   MetadataMatchCriteriaConstPtr metadata_match_criteria_;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -548,6 +548,7 @@ private:
   std::vector<Http::HeaderUtility::HeaderData> config_headers_;
   std::vector<ConfigUtility::QueryParameterMatcher> config_query_parameters_;
   std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
+
   UpgradeMap upgrade_map_;
   const uint64_t total_cluster_weight_;
   std::unique_ptr<const HashPolicyImpl> hash_policy_;

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -30,7 +30,18 @@ namespace HttpConnectionManager {
 namespace {
 
 typedef std::list<Http::FilterFactoryCb> FilterFactoriesList;
-typedef std::map<std::string, std::unique_ptr<FilterFactoriesList>> FilterFactoryMap;
+typedef std::map<std::string, HttpConnectionManagerConfig::FilterConfig> FilterFactoryMap;
+
+HttpConnectionManagerConfig::UpgradeMap::const_iterator
+findUpgradeBoolCaseInsensitive(const HttpConnectionManagerConfig::UpgradeMap& upgrade_map,
+                               absl::string_view upgrade_type) {
+  for (auto it = upgrade_map.begin(); it != upgrade_map.end(); ++it) {
+    if (StringUtil::CaseInsensitiveCompare()(it->first, upgrade_type)) {
+      return it;
+    }
+  }
+  return upgrade_map.end();
+}
 
 FilterFactoryMap::const_iterator findUpgradeCaseInsensitive(const FilterFactoryMap& upgrade_map,
                                                             absl::string_view upgrade_type) {
@@ -272,6 +283,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
 
   for (auto upgrade_config : config.upgrade_configs()) {
     const std::string& name = upgrade_config.upgrade_type();
+    bool enabled = upgrade_config.has_enabled() ? upgrade_config.enabled().value() : true;
     if (findUpgradeCaseInsensitive(upgrade_filter_factories_, name) !=
         upgrade_filter_factories_.end()) {
       throw EnvoyException(
@@ -282,10 +294,12 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       for (int32_t i = 0; i < upgrade_config.filters().size(); i++) {
         processFilter(upgrade_config.filters(i), i, name, *factories);
       }
-      upgrade_filter_factories_.emplace(std::make_pair(name, std::move(factories)));
+      upgrade_filter_factories_.emplace(
+          std::make_pair(name, FilterConfig{std::move(factories), enabled}));
     } else {
       std::unique_ptr<FilterFactoriesList> factories(nullptr);
-      upgrade_filter_factories_.emplace(std::make_pair(name, std::move(factories)));
+      upgrade_filter_factories_.emplace(
+          std::make_pair(name, FilterConfig{std::move(factories), enabled}));
     }
   }
 }
@@ -350,21 +364,36 @@ void HttpConnectionManagerConfig::createFilterChain(Http::FilterChainFactoryCall
 }
 
 bool HttpConnectionManagerConfig::createUpgradeFilterChain(
-    absl::string_view upgrade_type, Http::FilterChainFactoryCallbacks& callbacks) {
-  auto it = findUpgradeCaseInsensitive(upgrade_filter_factories_, upgrade_type);
-  if (it != upgrade_filter_factories_.end()) {
-    FilterFactoriesList* filters_to_use = nullptr;
-    if (it->second != nullptr) {
-      filters_to_use = it->second.get();
-    } else {
-      filters_to_use = &filter_factories_;
+    absl::string_view upgrade_type, const Http::FilterChainFactory::UpgradeMap* upgrade_map,
+    Http::FilterChainFactoryCallbacks& callbacks) {
+  bool route_enabled = false;
+  if (upgrade_map) {
+    auto route_it = findUpgradeBoolCaseInsensitive(*upgrade_map, upgrade_type);
+    if (route_it != upgrade_map->end()) {
+      // Upgrades explicitly not allowed on this route.
+      if (route_it->second == false) {
+        return false;
+      }
+      // Upgrades explicitly enabled on this route.
+      route_enabled = true;
     }
-    for (const Http::FilterFactoryCb& factory : *filters_to_use) {
-      factory(callbacks);
-    }
-    return true;
   }
-  return false;
+
+  auto it = findUpgradeCaseInsensitive(upgrade_filter_factories_, upgrade_type);
+  if ((it == upgrade_filter_factories_.end() || !it->second.allow_upgrade) && !route_enabled) {
+    // Either the HCM disables upgrades and the route-config does not override,
+    // or neither is configured for this upgrade.
+    return false;
+  }
+  FilterFactoriesList* filters_to_use = &filter_factories_;
+  if (it != upgrade_filter_factories_.end() && it->second.filter_factories != nullptr) {
+    filters_to_use = it->second.filter_factories.get();
+  }
+
+  for (const Http::FilterFactoryCb& factory : *filters_to_use) {
+    factory(callbacks);
+  }
+  return true;
 }
 
 const Network::Address::Instance& HttpConnectionManagerConfig::localAddress() {

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -283,7 +283,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
 
   for (auto upgrade_config : config.upgrade_configs()) {
     const std::string& name = upgrade_config.upgrade_type();
-    bool enabled = upgrade_config.has_enabled() ? upgrade_config.enabled().value() : true;
+    const bool enabled = upgrade_config.has_enabled() ? upgrade_config.enabled().value() : true;
     if (findUpgradeCaseInsensitive(upgrade_filter_factories_, name) !=
         upgrade_filter_factories_.end()) {
       throw EnvoyException(
@@ -364,12 +364,13 @@ void HttpConnectionManagerConfig::createFilterChain(Http::FilterChainFactoryCall
 }
 
 bool HttpConnectionManagerConfig::createUpgradeFilterChain(
-    absl::string_view upgrade_type, const Http::FilterChainFactory::UpgradeMap* upgrade_map,
+    absl::string_view upgrade_type,
+    const Http::FilterChainFactory::UpgradeMap* per_route_upgrade_map,
     Http::FilterChainFactoryCallbacks& callbacks) {
   bool route_enabled = false;
-  if (upgrade_map) {
-    auto route_it = findUpgradeBoolCaseInsensitive(*upgrade_map, upgrade_type);
-    if (route_it != upgrade_map->end()) {
+  if (per_route_upgrade_map) {
+    auto route_it = findUpgradeBoolCaseInsensitive(*per_route_upgrade_map, upgrade_type);
+    if (route_it != per_route_upgrade_map->end()) {
       // Upgrades explicitly not allowed on this route.
       if (route_it->second == false) {
         return false;

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -96,7 +96,13 @@ public:
 
   // Http::FilterChainFactory
   void createFilterChain(Http::FilterChainFactoryCallbacks& callbacks) override;
+  typedef std::list<Http::FilterFactoryCb> FilterFactoriesList;
+  struct FilterConfig {
+    std::unique_ptr<FilterFactoriesList> filter_factories;
+    bool allow_upgrade;
+  };
   bool createUpgradeFilterChain(absl::string_view upgrade_type,
+                                const Http::FilterChainFactory::UpgradeMap* upgrade_map,
                                 Http::FilterChainFactoryCallbacks& callbacks) override;
 
   // Http::ConnectionManagerConfig
@@ -138,7 +144,6 @@ public:
   std::chrono::milliseconds delayedCloseTimeout() const override { return delayed_close_timeout_; }
 
 private:
-  typedef std::list<Http::FilterFactoryCb> FilterFactoriesList;
   enum class CodecType { HTTP1, HTTP2, AUTO };
   void processFilter(
       const envoy::config::filter::network::http_connection_manager::v2::HttpFilter& proto_config,
@@ -146,7 +151,7 @@ private:
 
   Server::Configuration::FactoryContext& context_;
   FilterFactoriesList filter_factories_;
-  std::map<std::string, std::unique_ptr<FilterFactoriesList>> upgrade_filter_factories_;
+  std::map<std::string, FilterConfig> upgrade_filter_factories_;
   const bool reverse_encode_order_{};
   std::list<AccessLog::InstanceSharedPtr> access_logs_;
   const std::string stats_prefix_;

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -102,7 +102,7 @@ public:
     bool allow_upgrade;
   };
   bool createUpgradeFilterChain(absl::string_view upgrade_type,
-                                const Http::FilterChainFactory::UpgradeMap* upgrade_map,
+                                const Http::FilterChainFactory::UpgradeMap* per_route_upgrade_map,
                                 Http::FilterChainFactoryCallbacks& callbacks) override;
 
   // Http::ConnectionManagerConfig

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -84,7 +84,8 @@ public:
 
   // Http::FilterChainFactory
   void createFilterChain(Http::FilterChainFactoryCallbacks& callbacks) override;
-  bool createUpgradeFilterChain(absl::string_view, Http::FilterChainFactoryCallbacks&) override {
+  bool createUpgradeFilterChain(absl::string_view, const Http::FilterChainFactory::UpgradeMap*,
+                                Http::FilterChainFactoryCallbacks&) override {
     return false;
   }
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -1703,12 +1703,12 @@ TEST_F(HttpConnectionManagerImplTest, FooUpgradeDrainClose) {
   EXPECT_CALL(*filter, setDecoderFilterCallbacks(_));
   EXPECT_CALL(*filter, setEncoderFilterCallbacks(_));
 
-  EXPECT_CALL(filter_factory_, createUpgradeFilterChain(_, _))
-      .WillRepeatedly(
-          Invoke([&](absl::string_view, FilterChainFactoryCallbacks& callbacks) -> bool {
-            callbacks.addStreamFilter(StreamFilterSharedPtr{filter});
-            return true;
-          }));
+  EXPECT_CALL(filter_factory_, createUpgradeFilterChain(_, _, _))
+      .WillRepeatedly(Invoke([&](absl::string_view, const Http::FilterChainFactory::UpgradeMap*,
+                                 FilterChainFactoryCallbacks& callbacks) -> bool {
+        callbacks.addStreamFilter(StreamFilterSharedPtr{filter});
+        return true;
+      }));
 
   // When dispatch is called on the codec, we pretend to get a new stream and then fire a headers
   // only request into it. Then we respond into the filter.

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -330,7 +330,7 @@ void ConfigHelper::addRoute(const std::string& domains, const std::string& prefi
                             envoy::api::v2::route::RouteAction::ClusterNotFoundResponseCode code,
                             envoy::api::v2::route::VirtualHost::TlsRequirementType type,
                             envoy::api::v2::route::RouteAction::RetryPolicy retry_policy,
-                            bool include_attempt_count_header) {
+                            bool include_attempt_count_header, const absl::string_view upgrade) {
   RELEASE_ASSERT(!finalized_, "");
   envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager hcm_config;
   loadHttpConnectionManager(hcm_config);
@@ -342,9 +342,13 @@ void ConfigHelper::addRoute(const std::string& domains, const std::string& prefi
   virtual_host->set_include_request_attempt_count(include_attempt_count_header);
   virtual_host->add_domains(domains);
   virtual_host->add_routes()->mutable_match()->set_prefix(prefix);
-  virtual_host->mutable_routes(0)->mutable_route()->set_cluster(cluster);
-  virtual_host->mutable_routes(0)->mutable_route()->set_cluster_not_found_response_code(code);
-  virtual_host->mutable_routes(0)->mutable_route()->mutable_retry_policy()->Swap(&retry_policy);
+  auto* route = virtual_host->mutable_routes(0)->mutable_route();
+  route->set_cluster(cluster);
+  route->set_cluster_not_found_response_code(code);
+  route->mutable_retry_policy()->Swap(&retry_policy);
+  if (!upgrade.empty()) {
+    route->add_upgrade_configs()->set_upgrade_type(std::string(upgrade));
+  }
   virtual_host->set_require_tls(type);
 
   storeHttpConnectionManager(hcm_config);

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -82,7 +82,7 @@ public:
                 envoy::api::v2::route::VirtualHost::TlsRequirementType type =
                     envoy::api::v2::route::VirtualHost::NONE,
                 envoy::api::v2::route::RouteAction::RetryPolicy retry_policy = {},
-                bool include_attempt_count_header = false);
+                bool include_attempt_count_header = false, const absl::string_view upgrade = "");
 
   // Add an HTTP filter prior to existing filters.
   void addFilter(const std::string& filter_yaml);

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -492,6 +492,7 @@ TEST_F(FilterChainTest, createFilterChain) {
   config.createFilterChain(callbacks);
 }
 
+// Tests where upgrades are configured on via the HCM.
 TEST_F(FilterChainTest, createUpgradeFilterChain) {
   auto hcm_config = parseHttpConnectionManagerFromJson(basic_config_);
   hcm_config.add_upgrade_configs()->set_upgrade_type("websocket");
@@ -499,17 +500,78 @@ TEST_F(FilterChainTest, createUpgradeFilterChain) {
   HttpConnectionManagerConfig config(hcm_config, context_, date_provider_,
                                      route_config_provider_manager_);
 
-  Http::MockFilterChainFactoryCallbacks callbacks;
+  NiceMock<Http::MockFilterChainFactoryCallbacks> callbacks;
+  // Check the case where WebSockets are configured in the HCM, and no router
+  // config is present. We should create an upgrade filter chain for
+  // WebSockets.
   {
     EXPECT_CALL(callbacks, addStreamFilter(_));        // Dynamo
     EXPECT_CALL(callbacks, addStreamDecoderFilter(_)); // Router
-    EXPECT_TRUE(config.createUpgradeFilterChain("WEBSOCKET", callbacks));
+    EXPECT_TRUE(config.createUpgradeFilterChain("WEBSOCKET", nullptr, callbacks));
   }
 
+  // Check the case where WebSockets are configured in the HCM, and no router
+  // config is present. We should not create an upgrade filter chain for Foo
   {
     EXPECT_CALL(callbacks, addStreamFilter(_)).Times(0);
     EXPECT_CALL(callbacks, addStreamDecoderFilter(_)).Times(0);
-    EXPECT_FALSE(config.createUpgradeFilterChain("foo", callbacks));
+    EXPECT_FALSE(config.createUpgradeFilterChain("foo", nullptr, callbacks));
+  }
+
+  // Now override the HCM with a route-specific disabling of WebSocket to
+  // verify route-specific disabling works.
+  {
+    std::map<std::string, bool> upgrade_map;
+    upgrade_map.emplace(std::make_pair("WebSocket", false));
+    EXPECT_FALSE(config.createUpgradeFilterChain("WEBSOCKET", &upgrade_map, callbacks));
+  }
+
+  // For paranoia's sake make sure route-specific enabling doesn't break
+  // anything.
+  {
+    EXPECT_CALL(callbacks, addStreamFilter(_));        // Dynamo
+    EXPECT_CALL(callbacks, addStreamDecoderFilter(_)); // Router
+    std::map<std::string, bool> upgrade_map;
+    upgrade_map.emplace(std::make_pair("WebSocket", true));
+    EXPECT_TRUE(config.createUpgradeFilterChain("WEBSOCKET", &upgrade_map, callbacks));
+  }
+}
+
+// Tests where upgrades are configured off via the HCM.
+TEST_F(FilterChainTest, createUpgradeFilterChainHCMDisabled) {
+  auto hcm_config = parseHttpConnectionManagerFromJson(basic_config_);
+  hcm_config.add_upgrade_configs()->set_upgrade_type("websocket");
+  hcm_config.mutable_upgrade_configs(0)->mutable_enabled()->set_value(false);
+
+  HttpConnectionManagerConfig config(hcm_config, context_, date_provider_,
+                                     route_config_provider_manager_);
+
+  NiceMock<Http::MockFilterChainFactoryCallbacks> callbacks;
+  // Check the case where WebSockets are off in the HCM, and no router config is present.
+  { EXPECT_FALSE(config.createUpgradeFilterChain("WEBSOCKET", nullptr, callbacks)); }
+
+  // Check the case where WebSockets are off in the HCM and in router config.
+  {
+    std::map<std::string, bool> upgrade_map;
+    upgrade_map.emplace(std::make_pair("WebSocket", false));
+    EXPECT_FALSE(config.createUpgradeFilterChain("WEBSOCKET", &upgrade_map, callbacks));
+  }
+
+  // With a route-specific enabling for WebSocket, WebSocket should work.
+  {
+    std::map<std::string, bool> upgrade_map;
+    upgrade_map.emplace(std::make_pair("WebSocket", true));
+    EXPECT_TRUE(config.createUpgradeFilterChain("WEBSOCKET", &upgrade_map, callbacks));
+  }
+
+  // With only a route-config we should do what the route config says.
+  {
+    std::map<std::string, bool> upgrade_map;
+    upgrade_map.emplace(std::make_pair("foo", true));
+    upgrade_map.emplace(std::make_pair("bar", false));
+    EXPECT_TRUE(config.createUpgradeFilterChain("foo", &upgrade_map, callbacks));
+    EXPECT_FALSE(config.createUpgradeFilterChain("bar", &upgrade_map, callbacks));
+    EXPECT_FALSE(config.createUpgradeFilterChain("eep", &upgrade_map, callbacks));
   }
 }
 
@@ -543,14 +605,14 @@ TEST_F(FilterChainTest, createCustomUpgradeFilterChain) {
   {
     Http::MockFilterChainFactoryCallbacks callbacks;
     EXPECT_CALL(callbacks, addStreamDecoderFilter(_)); // Router
-    EXPECT_TRUE(config.createUpgradeFilterChain("websocket", callbacks));
+    EXPECT_TRUE(config.createUpgradeFilterChain("websocket", nullptr, callbacks));
   }
 
   {
     Http::MockFilterChainFactoryCallbacks callbacks;
     EXPECT_CALL(callbacks, addStreamDecoderFilter(_));   // Router
     EXPECT_CALL(callbacks, addStreamFilter(_)).Times(2); // Dynamo
-    EXPECT_TRUE(config.createUpgradeFilterChain("Foo", callbacks));
+    EXPECT_TRUE(config.createUpgradeFilterChain("Foo", nullptr, callbacks));
   }
 }
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -173,8 +173,9 @@ public:
 
   // Http::FilterChainFactory
   MOCK_METHOD1(createFilterChain, void(FilterChainFactoryCallbacks& callbacks));
-  MOCK_METHOD2(createUpgradeFilterChain,
-               bool(absl::string_view upgrade_type, FilterChainFactoryCallbacks& callbacks));
+  MOCK_METHOD3(createUpgradeFilterChain, bool(absl::string_view upgrade_type,
+                                              const FilterChainFactory::UpgradeMap* upgrade_map,
+                                              FilterChainFactoryCallbacks& callbacks));
 };
 
 class MockStreamFilterCallbacksBase {

--- a/test/mocks/router/mocks.cc
+++ b/test/mocks/router/mocks.cc
@@ -75,6 +75,7 @@ MockRouteEntry::MockRouteEntry() {
   ON_CALL(*this, includeVirtualHostRateLimits()).WillByDefault(Return(true));
   ON_CALL(*this, pathMatchCriterion()).WillByDefault(ReturnRef(path_match_criterion_));
   ON_CALL(*this, metadata()).WillByDefault(ReturnRef(metadata_));
+  ON_CALL(*this, upgradeMap()).WillByDefault(ReturnRef(upgrade_map_));
 }
 
 MockRouteEntry::~MockRouteEntry() {}

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -259,6 +259,7 @@ public:
   MOCK_CONST_METHOD0(pathMatchCriterion, const PathMatchCriterion&());
   MOCK_CONST_METHOD1(perFilterConfig, const RouteSpecificFilterConfig*(const std::string&));
   MOCK_CONST_METHOD0(includeAttemptCount, bool());
+  MOCK_CONST_METHOD0(upgradeMap, const UpgradeMap&());
 
   std::string cluster_name_{"fake_cluster"};
   std::multimap<std::string, std::string> opaque_config_;
@@ -272,6 +273,7 @@ public:
   TestCorsPolicy cors_policy_;
   testing::NiceMock<MockPathMatchCriterion> path_match_criterion_;
   envoy::api::v2::core::Metadata metadata_;
+  UpgradeMap upgrade_map_;
 };
 
 class MockDecorator : public Decorator {


### PR DESCRIPTION
Allowing the HCM upgrades to be on or off by default, and adding per-route overrides to turn it off or on.

*Risk Level*: Medium (refactors existing code)
*Testing*: new unit and e2e tests
*Docs Changes*: proto docs
*Release Notes*: inline
Fixes #4921
