### PR TITLE
http: don't close TCP connection when response body is empty and request is retried

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -27,7 +27,7 @@ Version history
   value to override the default HTTP to gRPC status mapping.
 * load balancer: added a `configuration <envoy_api_msg_Cluster.LeastRequestLbConfig>` option to specify the number of choices made in P2C.
 * http: no longer close the TCP connection when a HTTP/1 request is retried due
-  to a 5xx/499 response with empty body.
+  to a response with empty body.
 * network: removed the reference to `FilterState` in `Connection` in favor of `StreamInfo`.
 * logging: added missing [ in log prefix.
 * rate-limit: added :ref:`configuration <envoy_api_field_config.filter.http.rate_limit.v2.RateLimit.rate_limited_as_resource_exhausted>`

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -26,6 +26,8 @@ Version history
 * http: augmented the `sendLocalReply` filter API to accept an optional `GrpcStatus`
   value to override the default HTTP to gRPC status mapping.
 * load balancer: added a `configuration <envoy_api_msg_Cluster.LeastRequestLbConfig>` option to specify the number of choices made in P2C.
+* http: no longer close the TCP connection when a HTTP/1 request is retried due
+  to a 5xx/499 response with empty body.
 * network: removed the reference to `FilterState` in `Connection` in favor of `StreamInfo`.
 * logging: added missing [ in log prefix.
 * rate-limit: added :ref:`configuration <envoy_api_field_config.filter.http.rate_limit.v2.RateLimit.rate_limited_as_resource_exhausted>`

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -25,9 +25,9 @@ Version history
   See `#3611 <https://github.com/envoyproxy/envoy/issues/3611>`_ for details.
 * http: augmented the `sendLocalReply` filter API to accept an optional `GrpcStatus`
   value to override the default HTTP to gRPC status mapping.
-* load balancer: added a `configuration <envoy_api_msg_Cluster.LeastRequestLbConfig>` option to specify the number of choices made in P2C.
 * http: no longer close the TCP connection when a HTTP/1 request is retried due
   to a response with empty body.
+* load balancer: added a `configuration <envoy_api_msg_Cluster.LeastRequestLbConfig>` option to specify the number of choices made in P2C.
 * network: removed the reference to `FilterState` in `Connection` in favor of `StreamInfo`.
 * logging: added missing [ in log prefix.
 * rate-limit: added :ref:`configuration <envoy_api_field_config.filter.http.rate_limit.v2.RateLimit.rate_limited_as_resource_exhausted>`

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -670,7 +670,7 @@ ClientConnectionImpl::ClientConnectionImpl(Network::Connection& connection, Conn
 bool ClientConnectionImpl::cannotHaveBody() {
   if ((!pending_responses_.empty() && pending_responses_.front().head_request_) ||
       parser_.status_code == 204 || parser_.status_code == 304 ||
-      (parser_.status_code >= 400 && parser_.content_length == 0)) {
+      (parser_.status_code >= 200 && parser_.content_length == 0)) {
     return true;
   } else {
     return false;

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -669,7 +669,7 @@ ClientConnectionImpl::ClientConnectionImpl(Network::Connection& connection, Conn
 
 bool ClientConnectionImpl::cannotHaveBody() {
   if ((!pending_responses_.empty() && pending_responses_.front().head_request_) ||
-      parser_.status_code == 204 || parser_.status_code == 304) {
+      parser_.status_code == 204 || parser_.status_code == 304 || parser_.content_length == 0) {
     return true;
   } else {
     return false;

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -669,7 +669,8 @@ ClientConnectionImpl::ClientConnectionImpl(Network::Connection& connection, Conn
 
 bool ClientConnectionImpl::cannotHaveBody() {
   if ((!pending_responses_.empty() && pending_responses_.front().head_request_) ||
-      parser_.status_code == 204 || parser_.status_code == 304 || parser_.content_length == 0) {
+      parser_.status_code == 204 || parser_.status_code == 304 ||
+      (parser_.status_code >= 400 && parser_.content_length == 0)) {
     return true;
   } else {
     return false;

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -700,7 +700,7 @@ TEST_F(Http1ClientConnectionImplTest, PrematureResponse) {
   EXPECT_THROW(codec_->dispatch(response), PrematureResponseException);
 }
 
-TEST_F(Http1ClientConnectionImplTest, EmptyBodyResponse) {
+TEST_F(Http1ClientConnectionImplTest, EmptyBodyResponse503) {
   initialize();
 
   NiceMock<Http::MockStreamDecoder> response_decoder;
@@ -710,6 +710,19 @@ TEST_F(Http1ClientConnectionImplTest, EmptyBodyResponse) {
 
   EXPECT_CALL(response_decoder, decodeHeaders_(_, true));
   Buffer::OwnedImpl response("HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n");
+  codec_->dispatch(response);
+}
+
+TEST_F(Http1ClientConnectionImplTest, EmptyBodyResponse200) {
+  initialize();
+
+  NiceMock<Http::MockStreamDecoder> response_decoder;
+  Http::StreamEncoder& request_encoder = codec_->newStream(response_decoder);
+  TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+  request_encoder.encodeHeaders(headers, true);
+
+  EXPECT_CALL(response_decoder, decodeHeaders_(_, true));
+  Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
   codec_->dispatch(response);
 }
 
@@ -923,7 +936,7 @@ TEST_F(Http1ClientConnectionImplTest, HighwatermarkMultipleResponses) {
   static_cast<ClientConnection*>(codec_.get())
       ->onUnderlyingConnectionAboveWriteBufferHighWatermark();
 
-  EXPECT_CALL(response_decoder, decodeHeaders_(_, false));
+  EXPECT_CALL(response_decoder, decodeHeaders_(_, true));
   Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
   codec_->dispatch(response);
 

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -709,7 +709,7 @@ TEST_F(Http1ClientConnectionImplTest, EmptyBodyResponse) {
   request_encoder.encodeHeaders(headers, true);
 
   EXPECT_CALL(response_decoder, decodeHeaders_(_, true));
-  Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+  Buffer::OwnedImpl response("HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n");
   codec_->dispatch(response);
 }
 
@@ -923,7 +923,7 @@ TEST_F(Http1ClientConnectionImplTest, HighwatermarkMultipleResponses) {
   static_cast<ClientConnection*>(codec_.get())
       ->onUnderlyingConnectionAboveWriteBufferHighWatermark();
 
-  EXPECT_CALL(response_decoder, decodeHeaders_(_, true));
+  EXPECT_CALL(response_decoder, decodeHeaders_(_, false));
   Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
   codec_->dispatch(response);
 

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -700,6 +700,19 @@ TEST_F(Http1ClientConnectionImplTest, PrematureResponse) {
   EXPECT_THROW(codec_->dispatch(response), PrematureResponseException);
 }
 
+TEST_F(Http1ClientConnectionImplTest, EmptyBodyResponse) {
+  initialize();
+
+  NiceMock<Http::MockStreamDecoder> response_decoder;
+  Http::StreamEncoder& request_encoder = codec_->newStream(response_decoder);
+  TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+  request_encoder.encodeHeaders(headers, true);
+
+  EXPECT_CALL(response_decoder, decodeHeaders_(_, true));
+  Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+  codec_->dispatch(response);
+}
+
 TEST_F(Http1ClientConnectionImplTest, HeadRequest) {
   initialize();
 
@@ -910,7 +923,7 @@ TEST_F(Http1ClientConnectionImplTest, HighwatermarkMultipleResponses) {
   static_cast<ClientConnection*>(codec_.get())
       ->onUnderlyingConnectionAboveWriteBufferHighWatermark();
 
-  EXPECT_CALL(response_decoder, decodeHeaders_(_, false));
+  EXPECT_CALL(response_decoder, decodeHeaders_(_, true));
   Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
   codec_->dispatch(response);
 


### PR DESCRIPTION
*Description*:

This fixes the issue described in #5023: right now we set `end_stream=false` for many HTTP/1 responses even if the HTTP body is empty (and the stream has ended). Retried requests with `end_stream=false` close the connection, so this results in the TCP connection being closed in many cases where it could be kept open, which results in unnecessary connection churn. 

With this change, when an upstream returns a HTTP/1 response with an empty body and the request is retried, the TCP connection will no longer be closed.

*Risk Level*:

Low

*Testing*:

Did manual testing to see that the connection is no longer closed when an upstream returns a 503, and added a unit test to ensure that `end_stream` is set correctly.

*Release note*

When a HTTP/1 request is retried due to a 5xx/499 response, we now keep the TCP connection open instead of closing it

Fixes #5023