### PR TITLE
thrift_proxy: remove protocol_lib/transport_lib

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/BUILD
@@ -36,9 +36,17 @@ envoy_cc_library(
     hdrs = ["config.h"],
     deps = [
         ":app_exception_lib",
+        ":auto_protocol_lib",
+        ":auto_transport_lib",
+        ":binary_protocol_lib",
+        ":compact_protocol_lib",
         ":conn_manager_lib",
         ":decoder_lib",
+        ":framed_transport_lib",
+        ":header_transport_lib",
         ":protocol_interface",
+        ":twitter_protocol_lib",
+        ":unframed_transport_lib",
         "//include/envoy/registry",
         "//source/common/config:utility_lib",
         "//source/extensions/filters/network:well_known_names",
@@ -59,9 +67,9 @@ envoy_cc_library(
         ":app_exception_lib",
         ":decoder_lib",
         ":protocol_converter_lib",
-        ":protocol_lib",
+        ":protocol_interface",
         ":stats_lib",
-        ":transport_lib",
+        ":transport_interface",
         "//include/envoy/event:deferred_deletable",
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/network:connection_interface",
@@ -221,16 +229,6 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "protocol_lib",
-    deps = [
-        ":auto_protocol_lib",
-        ":binary_protocol_lib",
-        ":compact_protocol_lib",
-        ":twitter_protocol_lib",
-    ],
-)
-
-envoy_cc_library(
     name = "stats_lib",
     hdrs = ["stats.h"],
     deps = [
@@ -303,11 +301,13 @@ envoy_cc_library(
         "auto_transport_impl.h",
     ],
     deps = [
+        ":binary_protocol_lib",
         ":buffer_helper_lib",
+        ":compact_protocol_lib",
         ":framed_transport_lib",
         ":header_transport_lib",
-        ":protocol_lib",
         ":transport_interface",
+        ":twitter_protocol_lib",
         ":unframed_transport_lib",
         "//source/common/common:assert_lib",
     ],
@@ -356,15 +356,5 @@ envoy_cc_library(
         ":buffer_helper_lib",
         ":transport_interface",
         "//source/common/common:assert_lib",
-    ],
-)
-
-envoy_cc_library(
-    name = "transport_lib",
-    deps = [
-        ":auto_transport_lib",
-        ":framed_transport_lib",
-        ":header_transport_lib",
-        ":unframed_transport_lib",
     ],
 )

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -4,11 +4,8 @@
 #include "envoy/event/dispatcher.h"
 
 #include "extensions/filters/network/thrift_proxy/app_exception_impl.h"
-#include "extensions/filters/network/thrift_proxy/binary_protocol_impl.h"
-#include "extensions/filters/network/thrift_proxy/compact_protocol_impl.h"
-#include "extensions/filters/network/thrift_proxy/framed_transport_impl.h"
 #include "extensions/filters/network/thrift_proxy/protocol.h"
-#include "extensions/filters/network/thrift_proxy/unframed_transport_impl.h"
+#include "extensions/filters/network/thrift_proxy/transport.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/test/extensions/filters/network/thrift_proxy/BUILD
+++ b/test/extensions/filters/network/thrift_proxy/BUILD
@@ -54,7 +54,6 @@ envoy_extension_cc_test_library(
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/common:byte_order_lib",
-        "//source/extensions/filters/network/thrift_proxy:protocol_lib",
         "//source/extensions/filters/network/thrift_proxy:thrift_lib",
         "//test/common/buffer:utility_lib",
         "@envoy_api//envoy/config/filter/network/thrift_proxy/v2alpha1:thrift_proxy_cc",
@@ -195,6 +194,7 @@ envoy_extension_cc_test(
     deps = [
         ":mocks",
         ":utility_lib",
+        "//source/extensions/filters/network/thrift_proxy:framed_transport_lib",
         "//source/extensions/filters/network/thrift_proxy:twitter_protocol_lib",
         "//test/test_common:printers_lib",
         "//test/test_common:utility_lib",


### PR DESCRIPTION
thrift_proxy: remove protocol_lib/transport_lib

Using dependency-only libraries in bazel isn't supported,
so I've removed them and cleaned up the protocol and
transport dependencies a bit.

Risk Level: low
Testing: existing tests
Doc Changes: n/a
Release Notes: n/a
Fixes: #5033

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
