### PR TITLE
Fix build with google_grpc=disabled

### DIFF
--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -38,6 +38,8 @@ AsyncClientManagerImpl::AsyncClientManagerImpl(Upstream::ClusterManager& cm,
   google_tls_slot_ = tls.allocateSlot();
   google_tls_slot_->set(
       [&api](Event::Dispatcher&) { return std::make_shared<GoogleAsyncClientThreadLocal>(api); });
+#else
+  UNREFERENCED_PARAMETER(api);
 #endif
 }
 


### PR DESCRIPTION
Fix compiling with `--define google_grpc=disabled`.

*Risk Level*: Low
*Testing*: `bazel build --define google_grpc=disabled //source/exe:envoy-static`
*Docs Changes*: N/A
*Release Notes*: N/A

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>

