### PR TITLE
server: refactor optionsimpl tests

### DIFF
--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -108,11 +108,11 @@ public:
   bool signalHandlingEnabled() const override { return signal_handling_enabled_; }
   bool mutexTracingEnabled() const override { return mutex_tracing_enabled_; }
   virtual Server::CommandLineOptionsPtr toCommandLineOptions() const override;
+  void parseComponentLogLevels(const std::string& component_log_levels);
+  uint32_t count() const;
 
 private:
-  void parseComponentLogLevels(const std::string& component_log_levels);
   void logError(const std::string& error) const;
-  uint32_t count() const;
 
   uint64_t base_id_;
   uint32_t concurrency_;
@@ -141,8 +141,6 @@ private:
   bool signal_handling_enabled_;
   bool mutex_tracing_enabled_;
   uint32_t count_;
-
-  friend class OptionsImplTest;
 };
 
 /**

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -34,15 +34,6 @@ public:
                                          [](uint64_t, uint64_t, bool) { return "1"; },
                                          spdlog::level::warn);
   }
-
-  const std::vector<std::pair<std::string, spdlog::level::level_enum>>&
-  parseComponentLogLevels(const std::unique_ptr<OptionsImpl>& options,
-                          const std::string& component_log_levels) {
-    options->parseComponentLogLevels(component_log_levels);
-    return options->componentLogLevels();
-  }
-
-  uint32_t count(const std::unique_ptr<OptionsImpl>& options) { return options->count(); }
 };
 
 TEST_F(OptionsImplTest, HotRestartVersion) {
@@ -214,7 +205,7 @@ TEST_F(OptionsImplTest, OptionsAreInSyncWithProto) {
   // 2. version        - default TCLAP argument.
   // 3. help           - default TCLAP argument.
   // 4. ignore_rest    - default TCLAP argument.
-  EXPECT_EQ(count(options) - 4, command_line_options->GetDescriptor()->field_count());
+  EXPECT_EQ(options->count() - 4, command_line_options->GetDescriptor()->field_count());
 }
 
 TEST_F(OptionsImplTest, BadCliOption) {
@@ -234,7 +225,7 @@ TEST_F(OptionsImplTest, BadMaxStatsOption) {
 
 TEST_F(OptionsImplTest, ParseComponentLogLevels) {
   std::unique_ptr<OptionsImpl> options = createOptionsImpl("envoy --mode init_only");
-  parseComponentLogLevels(options, "upstream:debug,connection:trace");
+  options->parseComponentLogLevels("upstream:debug,connection:trace");
   const std::vector<std::pair<std::string, spdlog::level::level_enum>>& component_log_levels =
       options->componentLogLevels();
   EXPECT_EQ(2, component_log_levels.size());
@@ -246,32 +237,32 @@ TEST_F(OptionsImplTest, ParseComponentLogLevels) {
 
 TEST_F(OptionsImplTest, ParseComponentLogLevelsWithBlank) {
   std::unique_ptr<OptionsImpl> options = createOptionsImpl("envoy --mode init_only");
-  parseComponentLogLevels(options, "");
+  options->parseComponentLogLevels("");
   EXPECT_EQ(0, options->componentLogLevels().size());
 }
 
 TEST_F(OptionsImplTest, InvalidComponent) {
   std::unique_ptr<OptionsImpl> options = createOptionsImpl("envoy --mode init_only");
-  EXPECT_THROW_WITH_REGEX(parseComponentLogLevels(options, "blah:debug"), MalformedArgvException,
+  EXPECT_THROW_WITH_REGEX(options->parseComponentLogLevels("blah:debug"), MalformedArgvException,
                           "error: invalid component specified 'blah'");
 }
 
 TEST_F(OptionsImplTest, InvalidLogLevel) {
   std::unique_ptr<OptionsImpl> options = createOptionsImpl("envoy --mode init_only");
-  EXPECT_THROW_WITH_REGEX(parseComponentLogLevels(options, "upstream:blah,connection:trace"),
+  EXPECT_THROW_WITH_REGEX(options->parseComponentLogLevels("upstream:blah,connection:trace"),
                           MalformedArgvException, "error: invalid log level specified 'blah'");
 }
 
 TEST_F(OptionsImplTest, InvalidComponentLogLevelStructure) {
   std::unique_ptr<OptionsImpl> options = createOptionsImpl("envoy --mode init_only");
-  EXPECT_THROW_WITH_REGEX(parseComponentLogLevels(options, "upstream:foo:bar"),
+  EXPECT_THROW_WITH_REGEX(options->parseComponentLogLevels("upstream:foo:bar"),
                           MalformedArgvException,
                           "error: component log level not correctly specified 'upstream:foo:bar'");
 }
 
 TEST_F(OptionsImplTest, IncompleteComponentLogLevel) {
   std::unique_ptr<OptionsImpl> options = createOptionsImpl("envoy --mode init_only");
-  EXPECT_THROW_WITH_REGEX(parseComponentLogLevels(options, "upstream"), MalformedArgvException,
+  EXPECT_THROW_WITH_REGEX(options->parseComponentLogLevels("upstream"), MalformedArgvException,
                           "component log level not correctly specified 'upstream'");
 }
 


### PR DESCRIPTION
Signed-off-by: Rama Chavali <rama.rao@salesforce.com>
*Description*: Refactor `OptionsImpl` tests not to use redundant helpers. One of the todos in PR #5015 
*Risk Level*: Low
*Testing*: Existing automated tests
*Docs Changes*: N/A
*Release Notes*: N/A
