### PR TITLE
Reverse order of header modification

### DIFF
--- a/source/common/router/header_parser.cc
+++ b/source/common/router/header_parser.cc
@@ -254,6 +254,10 @@ HeaderParserPtr HeaderParser::configure(
 
 void HeaderParser::evaluateHeaders(Http::HeaderMap& headers,
                                    const StreamInfo::StreamInfo& stream_info) const {
+  for (const auto& header : headers_to_remove_) {
+    headers.remove(header);
+  }
+
   for (const auto& formatter : headers_to_add_) {
     const std::string value = formatter.second->format(stream_info);
     if (!value.empty()) {
@@ -263,10 +267,6 @@ void HeaderParser::evaluateHeaders(Http::HeaderMap& headers,
         headers.setReferenceKey(formatter.first, value);
       }
     }
-  }
-
-  for (const auto& header : headers_to_remove_) {
-    headers.remove(header);
   }
 }
 

--- a/source/common/router/header_parser.cc
+++ b/source/common/router/header_parser.cc
@@ -254,7 +254,7 @@ HeaderParserPtr HeaderParser::configure(
 
 void HeaderParser::evaluateHeaders(Http::HeaderMap& headers,
                                    const StreamInfo::StreamInfo& stream_info) const {
-  // Removing headers in the headers_to_remove_ list first makes 
+  // Removing headers in the headers_to_remove_ list first makes
   // remove-before-add the default behavior as expected by users.
   for (const auto& header : headers_to_remove_) {
     headers.remove(header);

--- a/source/common/router/header_parser.cc
+++ b/source/common/router/header_parser.cc
@@ -254,6 +254,8 @@ HeaderParserPtr HeaderParser::configure(
 
 void HeaderParser::evaluateHeaders(Http::HeaderMap& headers,
                                    const StreamInfo::StreamInfo& stream_info) const {
+  // Removing headers in the headers_to_remove_ list first makes 
+  // remove-before-add the default behavior as expected by users.
   for (const auto& header : headers_to_remove_) {
     headers.remove(header);
   }


### PR DESCRIPTION
*Description*: This PR reverses the order of header evaluation as a solution to deduplicating request/response headers.  This change will remove headers first then add instead of add then remove.

*Risk Level*: Low
*Testing*: two additional unit tests.
*Docs Changes*: The order of operations was never documented; I'm not sure a change is needed beyond the release notes.
*Release Notes*: Reverse the order of header evaluation operations, remove first then add.

Signed-off-by: Nicholas J <nicholas.a.johns5@gmail.com>
