### PR TITLE
repokitteh: hide token passed to retest from trace

### DIFF
--- a/repokitteh.star
+++ b/repokitteh.star
@@ -1,6 +1,8 @@
 use("github.com/repokitteh/modules/assign.star")
 use("github.com/repokitteh/modules/review.star")
 use("github.com/repokitteh/modules/wait.star")
-use("github.com/repokitteh/modules/circleci.star", token=get_secret('circle_token'))
+use("github.com/repokitteh/modules/circleci.star", secret_token=get_secret('circle_token'))
 
 alias('retest', 'retry-circle')
+
+enable('cancel-circle')


### PR DESCRIPTION
Signed-off-by: Itay Donanhirsh <itay@bazoo.org>

*Description*:
Fields contents to functions in repokitteh are emitted into trace that can be seen by any org member. By prefixing the field name with `secret_`, it is redacted from there.

*Risk Level*:
Low.

*Testing*:
This PR.

*Docs Changes*:
None.

*Release Notes*:
None.
