### PR TITLE
stats: Resolve issue with lookup on name that will be truncated

### DIFF
--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -194,11 +194,11 @@ StatType& ThreadLocalStoreImpl::ScopeImpl::safeMakeStat(
     MakeStatFn<StatType> make_stat, StatMap<std::shared_ptr<StatType>>* tls_cache) {
 
   const char* stat_key = name.c_str();
-  std::string truncation_buffer;
+  std::unique_ptr<std::string> truncation_buffer;
   absl::string_view truncated_name = parent_.truncateStatNameIfNeeded(name);
   if (truncated_name.size() < name.size()) {
-    truncation_buffer = std::string(truncated_name);
-    stat_key = truncation_buffer.c_str(); // must be nul-terminated.
+    truncation_buffer = std::make_unique<std::string>(std::string(truncated_name));
+    stat_key = truncation_buffer->c_str(); // must be nul-terminated.
   }
 
   // If we have a valid cache entry, return it.

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -193,9 +193,17 @@ StatType& ThreadLocalStoreImpl::ScopeImpl::safeMakeStat(
     const std::string& name, StatMap<std::shared_ptr<StatType>>& central_cache_map,
     MakeStatFn<StatType> make_stat, StatMap<std::shared_ptr<StatType>>* tls_cache) {
 
+  const char* stat_key = name.c_str();
+  std::string truncation_buffer;
+  absl::string_view truncated_name = parent_.truncateStatNameIfNeeded(name);
+  if (truncated_name.size() < name.size()) {
+    truncation_buffer = std::string(truncated_name);
+    stat_key = truncation_buffer.c_str(); // must be nul-terminated.
+  }
+
   // If we have a valid cache entry, return it.
   if (tls_cache) {
-    auto pos = tls_cache->find(name.c_str());
+    auto pos = tls_cache->find(stat_key);
     if (pos != tls_cache->end()) {
       return *pos->second;
     }
@@ -204,7 +212,7 @@ StatType& ThreadLocalStoreImpl::ScopeImpl::safeMakeStat(
   // We must now look in the central store so we must be locked. We grab a reference to the
   // central store location. It might contain nothing. In this case, we allocate a new stat.
   Thread::LockGuard lock(parent_.lock_);
-  auto p = central_cache_map.find(name.c_str());
+  auto p = central_cache_map.find(stat_key);
   std::shared_ptr<StatType>* central_ref = nullptr;
   if (p != central_cache_map.end()) {
     central_ref = &(p->second);
@@ -214,7 +222,6 @@ StatType& ThreadLocalStoreImpl::ScopeImpl::safeMakeStat(
     // Tag extraction occurs on the original, untruncated name so the extraction
     // can complete properly, even if the tag values are partially truncated.
     std::string tag_extracted_name = parent_.getTagsForName(name, tags);
-    absl::string_view truncated_name = parent_.truncateStatNameIfNeeded(name);
     std::shared_ptr<StatType> stat =
         make_stat(parent_.alloc_, truncated_name, std::move(tag_extracted_name), std::move(tags));
     if (stat == nullptr) {


### PR DESCRIPTION
*Description*: The caches ThreadLocalStore use the storage in the stat. If that's truncated, then we must also truncate prior to doing the lookup.
*Risk Level*: medium
*Testing*: //test/...
*Docs Changes*: n/a
*Release Notes*: n/a
*Fixes #Issue*: #5068 
