### PR TITLE
circuit breakers: Add max_pending_connections circuit breaker

### DIFF
--- a/api/envoy/api/v2/cluster/circuit_breaker.proto
+++ b/api/envoy/api/v2/cluster/circuit_breaker.proto
@@ -42,6 +42,10 @@ message CircuitBreakers {
     // The maximum number of parallel retries that Envoy will allow to the
     // upstream cluster. If not specified, the default is 3.
     google.protobuf.UInt32Value max_retries = 5;
+
+    // The maximum number of connections that Envoy will allow to be in the
+    // establishing state.  If not specified, the default is 128.
+    google.protobuf.UInt32Value max_pending_connections = 6;
   }
 
   // If multiple :ref:`Thresholds<envoy_api_msg_cluster.CircuitBreakers.Thresholds>`

--- a/api/envoy/api/v2/cluster/circuit_breaker.proto
+++ b/api/envoy/api/v2/cluster/circuit_breaker.proto
@@ -44,7 +44,7 @@ message CircuitBreakers {
     google.protobuf.UInt32Value max_retries = 5;
 
     // The maximum number of connections that Envoy will allow to be in the
-    // establishing state.  If not specified, the default is 128.
+    // establishing state. If not specified, the default is 1024.
     google.protobuf.UInt32Value max_pending_connections = 6;
   }
 

--- a/docs/root/configuration/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/cluster_manager/cluster_stats.rst
@@ -41,6 +41,7 @@ Every cluster has a statistics tree rooted at *cluster.<name>.* with the followi
   upstream_cx_idle_timeout, Counter, Total connection idle timeouts
   upstream_cx_connect_attempts_exceeded, Counter, Total consecutive connection failures exceeding configured connection attempts
   upstream_cx_overflow, Counter, Total times that the cluster's connection circuit breaker overflowed
+  upstream_cx_pending_overflow, Counter, Total times that the cluster's connection pending circuit breaker overflowed
   upstream_cx_connect_ms, Histogram, Connection establishment milliseconds
   upstream_cx_length_ms, Histogram, Connection length milliseconds
   upstream_cx_destroy, Counter, Total destroyed connections
@@ -143,6 +144,7 @@ Circuit breakers statistics will be rooted at *cluster.<name>.circuit_breakers.<
   :header: Name, Type, Description
   :widths: 1, 1, 2
 
+  cx_pending_open, Gauge, Whether the pending connections circuit breaker is closed (0) or open (1)
   cx_open, Gauge, Whether the connection circuit breaker is closed (0) or open (1)
   rq_pending_open, Gauge, Whether the pending requests circuit breaker is closed (0) or open (1)
   rq_open, Gauge, Whether the requests circuit breaker is closed (0) or open (1)

--- a/include/envoy/upstream/resource_manager.h
+++ b/include/envoy/upstream/resource_manager.h
@@ -53,6 +53,11 @@ public:
   virtual ~ResourceManager() {}
 
   /**
+   * @return Resource& active pending TCP connections (not yet established).
+   */
+  virtual Resource& pendingConnections() PURE;
+
+  /**
    * @return Resource& active TCP connections.
    */
   virtual Resource& connections() PURE;

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -350,6 +350,7 @@ public:
   COUNTER  (upstream_cx_idle_timeout)                                                              \
   COUNTER  (upstream_cx_connect_attempts_exceeded)                                                 \
   COUNTER  (upstream_cx_overflow)                                                                  \
+  COUNTER  (upstream_cx_pending_overflow)                                                          \
   HISTOGRAM(upstream_cx_connect_ms)                                                                \
   HISTOGRAM(upstream_cx_length_ms)                                                                 \
   COUNTER  (upstream_cx_destroy)                                                                   \
@@ -415,6 +416,7 @@ public:
  */
 // clang-format off
 #define ALL_CLUSTER_CIRCUIT_BREAKERS_STATS(GAUGE)                                                  \
+  GAUGE (cx_pending_open)                                                                          \
   GAUGE (cx_open)                                                                                  \
   GAUGE (rq_pending_open)                                                                          \
   GAUGE (rq_open)                                                                                  \

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -100,8 +100,7 @@ ConnectionPool::Cancellable* ConnPoolImpl::newStream(StreamDecoder& response_dec
         host_->cluster().resourceManager(priority_).pendingConnections().canCreate();
     if (!can_create_connection) {
       host_->cluster().stats().upstream_cx_overflow_.inc();
-    }
-    if (!can_create_pending_connection) {
+    } else if (!can_create_pending_connection) {
       host_->cluster().stats().upstream_cx_pending_overflow_.inc();
     }
 

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -105,7 +105,8 @@ ConnectionPool::Cancellable* ConnPoolImpl::newStream(StreamDecoder& response_dec
     }
 
     // If we have no connections at all, make one no matter what so we don't starve.
-    if ((ready_clients_.size() == 0 && busy_clients_.size() == 0) || (can_create_connection && can_create_pending_connection)) {
+    if ((ready_clients_.size() == 0 && busy_clients_.size() == 0) ||
+        (can_create_connection && can_create_pending_connection)) {
       createNewConnection();
     }
 

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -98,6 +98,7 @@ protected:
     Event::TimerPtr connect_timer_;
     Stats::TimespanPtr conn_length_;
     uint64_t remaining_requests_;
+    bool connection_succeeded_{false};
   };
 
   typedef std::unique_ptr<ActiveClient> ActiveClientPtr;

--- a/source/common/tcp/conn_pool.cc
+++ b/source/common/tcp/conn_pool.cc
@@ -91,13 +91,18 @@ ConnectionPool::Cancellable* ConnPoolImpl::newConnection(ConnectionPool::Callbac
   if (host_->cluster().resourceManager(priority_).pendingRequests().canCreate()) {
     bool can_create_connection =
         host_->cluster().resourceManager(priority_).connections().canCreate();
+    bool can_create_pending_connection =
+        host_->cluster().resourceManager(priority_).pendingConnections().canCreate();
     if (!can_create_connection) {
       host_->cluster().stats().upstream_cx_overflow_.inc();
+    }
+    if (!can_create_pending_connection) {
+      host_->cluster().stats().upstream_cx_pending_overflow_.inc();
     }
 
     // If we have no connections at all, make one no matter what so we don't starve.
     if ((ready_conns_.empty() && busy_conns_.empty() && pending_conns_.empty()) ||
-        can_create_connection) {
+        (can_create_connection && can_create_pending_connection)) {
       createNewConnection();
     }
 

--- a/source/common/tcp/conn_pool.cc
+++ b/source/common/tcp/conn_pool.cc
@@ -95,8 +95,7 @@ ConnectionPool::Cancellable* ConnPoolImpl::newConnection(ConnectionPool::Callbac
         host_->cluster().resourceManager(priority_).pendingConnections().canCreate();
     if (!can_create_connection) {
       host_->cluster().stats().upstream_cx_overflow_.inc();
-    }
-    if (!can_create_pending_connection) {
+    } else if (!can_create_pending_connection) {
       host_->cluster().stats().upstream_cx_pending_overflow_.inc();
     }
 

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -115,6 +115,7 @@ protected:
     Stats::TimespanPtr conn_length_;
     uint64_t remaining_requests_;
     bool timed_out_;
+    bool connection_succeeded_{false};
   };
 
   typedef std::unique_ptr<ActiveConn> ActiveConnPtr;

--- a/source/common/upstream/resource_manager_impl.h
+++ b/source/common/upstream/resource_manager_impl.h
@@ -26,10 +26,12 @@ namespace Upstream {
 class ResourceManagerImpl : public ResourceManager {
 public:
   ResourceManagerImpl(Runtime::Loader& runtime, const std::string& runtime_key,
-                      uint64_t max_connections, uint64_t max_pending_requests,
-                      uint64_t max_requests, uint64_t max_retries,
-                      ClusterCircuitBreakersStats cb_stats)
-      : connections_(max_connections, runtime, runtime_key + "max_connections", cb_stats.cx_open_),
+                      uint64_t max_pending_connections, uint64_t max_connections,
+                      uint64_t max_pending_requests, uint64_t max_requests,
+                      uint64_t max_retries, ClusterCircuitBreakersStats
+                      cb_stats)
+      : pending_connections_(max_pending_connections, runtime, runtime_key + "max_pending_connections", cb_stats.cx_pending_open_),
+        connections_(max_connections, runtime, runtime_key + "max_connections", cb_stats.cx_open_),
         pending_requests_(max_pending_requests, runtime, runtime_key + "max_pending_requests",
                           cb_stats.rq_pending_open_),
         requests_(max_requests, runtime, runtime_key + "max_requests", cb_stats.rq_open_),
@@ -37,6 +39,7 @@ public:
 
   // Upstream::ResourceManager
   Resource& connections() override { return connections_; }
+  Resource& pendingConnections() override { return pending_connections_; }
   Resource& pendingRequests() override { return pending_requests_; }
   Resource& requests() override { return requests_; }
   Resource& retries() override { return retries_; }
@@ -74,6 +77,7 @@ private:
     Stats::Gauge& open_gauge_;
   };
 
+  ResourceImpl pending_connections_;
   ResourceImpl connections_;
   ResourceImpl pending_requests_;
   ResourceImpl requests_;

--- a/source/common/upstream/resource_manager_impl.h
+++ b/source/common/upstream/resource_manager_impl.h
@@ -27,10 +27,10 @@ class ResourceManagerImpl : public ResourceManager {
 public:
   ResourceManagerImpl(Runtime::Loader& runtime, const std::string& runtime_key,
                       uint64_t max_pending_connections, uint64_t max_connections,
-                      uint64_t max_pending_requests, uint64_t max_requests,
-                      uint64_t max_retries, ClusterCircuitBreakersStats
-                      cb_stats)
-      : pending_connections_(max_pending_connections, runtime, runtime_key + "max_pending_connections", cb_stats.cx_pending_open_),
+                      uint64_t max_pending_requests, uint64_t max_requests, uint64_t max_retries,
+                      ClusterCircuitBreakersStats cb_stats)
+      : pending_connections_(max_pending_connections, runtime,
+                             runtime_key + "max_pending_connections", cb_stats.cx_pending_open_),
         connections_(max_connections, runtime, runtime_key + "max_connections", cb_stats.cx_open_),
         pending_requests_(max_pending_requests, runtime, runtime_key + "max_pending_requests",
                           cb_stats.rq_pending_open_),

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -703,6 +703,7 @@ ClusterInfoImpl::ResourceManagers::load(const envoy::api::v2::Cluster& config,
                                         Stats::Scope& stats_scope,
                                         const envoy::api::v2::core::RoutingPriority& priority) {
   uint64_t max_connections = 1024;
+  uint64_t max_pending_connections = 128;
   uint64_t max_pending_requests = 1024;
   uint64_t max_requests = 1024;
   uint64_t max_retries = 3;
@@ -730,13 +731,15 @@ ClusterInfoImpl::ResourceManagers::load(const envoy::api::v2::Cluster& config,
       });
   if (it != thresholds.cend()) {
     max_connections = PROTOBUF_GET_WRAPPED_OR_DEFAULT(*it, max_connections, max_connections);
+    max_pending_connections = PROTOBUF_GET_WRAPPED_OR_DEFAULT(*it, max_pending_connections, max_pending_connections);
     max_pending_requests =
         PROTOBUF_GET_WRAPPED_OR_DEFAULT(*it, max_pending_requests, max_pending_requests);
     max_requests = PROTOBUF_GET_WRAPPED_OR_DEFAULT(*it, max_requests, max_requests);
     max_retries = PROTOBUF_GET_WRAPPED_OR_DEFAULT(*it, max_retries, max_retries);
   }
   return std::make_unique<ResourceManagerImpl>(
-      runtime, runtime_prefix, max_connections, max_pending_requests, max_requests, max_retries,
+      runtime, runtime_prefix, max_pending_connections, max_connections,
+      max_pending_requests, max_requests, max_retries,
       ClusterInfoImpl::generateCircuitBreakersStats(stats_scope, priority_name));
 }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -731,15 +731,16 @@ ClusterInfoImpl::ResourceManagers::load(const envoy::api::v2::Cluster& config,
       });
   if (it != thresholds.cend()) {
     max_connections = PROTOBUF_GET_WRAPPED_OR_DEFAULT(*it, max_connections, max_connections);
-    max_pending_connections = PROTOBUF_GET_WRAPPED_OR_DEFAULT(*it, max_pending_connections, max_pending_connections);
+    max_pending_connections =
+        PROTOBUF_GET_WRAPPED_OR_DEFAULT(*it, max_pending_connections, max_pending_connections);
     max_pending_requests =
         PROTOBUF_GET_WRAPPED_OR_DEFAULT(*it, max_pending_requests, max_pending_requests);
     max_requests = PROTOBUF_GET_WRAPPED_OR_DEFAULT(*it, max_requests, max_requests);
     max_retries = PROTOBUF_GET_WRAPPED_OR_DEFAULT(*it, max_retries, max_retries);
   }
   return std::make_unique<ResourceManagerImpl>(
-      runtime, runtime_prefix, max_pending_connections, max_connections,
-      max_pending_requests, max_requests, max_retries,
+      runtime, runtime_prefix, max_pending_connections, max_connections, max_pending_requests,
+      max_requests, max_retries,
       ClusterInfoImpl::generateCircuitBreakersStats(stats_scope, priority_name));
 }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -703,7 +703,7 @@ ClusterInfoImpl::ResourceManagers::load(const envoy::api::v2::Cluster& config,
                                         Stats::Scope& stats_scope,
                                         const envoy::api::v2::core::RoutingPriority& priority) {
   uint64_t max_connections = 1024;
-  uint64_t max_pending_connections = 128;
+  uint64_t max_pending_connections = 1024;
   uint64_t max_pending_requests = 1024;
   uint64_t max_requests = 1024;
   uint64_t max_retries = 3;

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -263,6 +263,8 @@ void AdminImpl::addCircuitSettings(const std::string& cluster_name, const std::s
                                    Buffer::Instance& response) {
   response.add(fmt::format("{}::{}_priority::max_connections::{}\n", cluster_name, priority_str,
                            resource_manager.connections().max()));
+  response.add(fmt::format("{}::{}_priority::max_pending_connections::{}\n", cluster_name, priority_str,
+                           resource_manager.pendingConnections().max()));
   response.add(fmt::format("{}::{}_priority::max_pending_requests::{}\n", cluster_name,
                            priority_str, resource_manager.pendingRequests().max()));
   response.add(fmt::format("{}::{}_priority::max_requests::{}\n", cluster_name, priority_str,

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -263,8 +263,8 @@ void AdminImpl::addCircuitSettings(const std::string& cluster_name, const std::s
                                    Buffer::Instance& response) {
   response.add(fmt::format("{}::{}_priority::max_connections::{}\n", cluster_name, priority_str,
                            resource_manager.connections().max()));
-  response.add(fmt::format("{}::{}_priority::max_pending_connections::{}\n", cluster_name, priority_str,
-                           resource_manager.pendingConnections().max()));
+  response.add(fmt::format("{}::{}_priority::max_pending_connections::{}\n", cluster_name,
+                           priority_str, resource_manager.pendingConnections().max()));
   response.add(fmt::format("{}::{}_priority::max_pending_requests::{}\n", cluster_name,
                            priority_str, resource_manager.pendingRequests().max()));
   response.add(fmt::format("{}::{}_priority::max_requests::{}\n", cluster_name, priority_str,

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -208,7 +208,7 @@ struct ActiveTestRequest {
  * Verify that connections are drained when requested.
  */
 TEST_F(Http1ConnPoolImplTest, DrainConnections) {
-  cluster_->resetResourceManager(2, 1024, 1024, 1);
+  cluster_->resetResourceManager(2, 2, 1024, 1024, 1);
   InSequence s;
 
   ActiveTestRequest r1(*this, 0, ActiveTestRequest::Type::CreateConnection);
@@ -293,7 +293,7 @@ TEST_F(Http1ConnPoolImplTest, MultipleRequestAndResponse) {
  * Test when we overflow max pending requests.
  */
 TEST_F(Http1ConnPoolImplTest, MaxPendingRequests) {
-  cluster_->resetResourceManager(1, 1, 1024, 1);
+  cluster_->resetResourceManager(1, 1, 1, 1024, 1);
 
   EXPECT_EQ(0U, cluster_->circuit_breakers_stats_.rq_pending_open_.value());
 
@@ -615,7 +615,7 @@ TEST_F(Http1ConnPoolImplTest, MaxRequestsPerConnection) {
 }
 
 TEST_F(Http1ConnPoolImplTest, ConcurrentConnections) {
-  cluster_->resetResourceManager(2, 1024, 1024, 1);
+  cluster_->resetResourceManager(2, 2, 1024, 1024, 1);
   InSequence s;
 
   ActiveTestRequest r1(*this, 0, ActiveTestRequest::Type::CreateConnection);

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -290,6 +290,66 @@ TEST_F(Http1ConnPoolImplTest, MultipleRequestAndResponse) {
 }
 
 /**
+ * Test when we overflow max pending connections.
+ */
+TEST_F(Http1ConnPoolImplTest, MaxPendingConnections) {
+  cluster_->resetResourceManager(1, 1024, 1024, 1024, 1);
+
+  EXPECT_EQ(0U, cluster_->circuit_breakers_stats_.cx_pending_open_.value());
+
+  // Make first connection
+  NiceMock<Http::MockStreamDecoder> outer_decoder;
+  ConnPoolCallbacks callbacks;
+  conn_pool_.expectClientCreate();
+  EXPECT_CALL(callbacks.pool_failure_, ready());
+  Http::ConnectionPool::Cancellable* handle = conn_pool_.newStream(outer_decoder, callbacks);
+  EXPECT_NE(nullptr, handle);
+
+  // Second connection should fail to be established
+  NiceMock<Http::MockStreamDecoder> outer_decoder2;
+  ConnPoolCallbacks callbacks2;
+  EXPECT_CALL(callbacks2.pool_failure_, ready());
+  Http::ConnectionPool::Cancellable* handle2 = conn_pool_.newStream(outer_decoder, callbacks2);
+  EXPECT_NE(nullptr, handle2);
+
+  EXPECT_CALL(conn_pool_, onClientDestroy());
+  conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(1U, cluster_->stats_.upstream_cx_pending_overflow_.value());
+}
+
+/**
+ * Test that if the first connection connects, the second one can as well
+ */
+TEST_F(Http1ConnPoolImplTest, MaxPendingConnectionsConnected) {
+  cluster_->resetResourceManager(1, 1024, 1024, 1024, 1);
+
+  EXPECT_EQ(0U, cluster_->circuit_breakers_stats_.cx_pending_open_.value());
+
+  // Make first connection
+  ActiveTestRequest r1(*this, 0, ActiveTestRequest::Type::CreateConnection);
+  r1.startRequest();
+
+  // Second connection should get established successfully
+  NiceMock<Http::MockStreamDecoder> outer_decoder2;
+  ConnPoolCallbacks callbacks2;
+  conn_pool_.expectClientCreate();
+  Http::ConnectionPool::Cancellable* handle2 = conn_pool_.newStream(outer_decoder2, callbacks2);
+  EXPECT_NE(nullptr, handle2);
+  EXPECT_EQ(2U, cluster_->stats_.upstream_cx_total_.value());
+  EXPECT_EQ(1U, cluster_->circuit_breakers_stats_.cx_pending_open_.value());
+  handle2->cancel();
+
+  EXPECT_CALL(conn_pool_, onClientDestroy()).Times(2);
+  conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  conn_pool_.test_clients_[1].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(0U, cluster_->stats_.upstream_cx_pending_overflow_.value());
+}
+
+/**
  * Test when we overflow max pending requests.
  */
 TEST_F(Http1ConnPoolImplTest, MaxPendingRequests) {

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -578,7 +578,7 @@ TEST_F(Http2ConnPoolImplTest, ConnectTimeout) {
 }
 
 TEST_F(Http2ConnPoolImplTest, MaxGlobalRequests) {
-  cluster_->resetResourceManager(1024, 1024, 1, 1);
+  cluster_->resetResourceManager(1024, 1024, 1024, 1, 1);
   InSequence s;
 
   expectClientCreate();

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -416,7 +416,7 @@ TEST_F(RouterRetryStateImplTest, RouteConfigNoHeaderConfig) {
 }
 
 TEST_F(RouterRetryStateImplTest, NoAvailableRetries) {
-  cluster_.resetResourceManager(0, 0, 0, 0);
+  cluster_.resetResourceManager(0, 0, 0, 0, 0);
 
   Http::TestHeaderMapImpl request_headers{{"x-envoy-retry-on", "connect-failure"}};
   setup(request_headers);

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -274,7 +274,7 @@ struct ActiveTestConn {
  * Verify that connections are drained when requested.
  */
 TEST_F(TcpConnPoolImplTest, DrainConnections) {
-  cluster_->resetResourceManager(3, 1024, 1024, 1);
+  cluster_->resetResourceManager(3, 3, 1024, 1024, 1);
   InSequence s;
 
   ActiveTestConn c1(*this, 0, ActiveTestConn::Type::CreateConnection);
@@ -487,7 +487,7 @@ TEST_F(TcpConnPoolImplTest, ConnectionStateLifecycle) {
  * Test when we overflow max pending requests.
  */
 TEST_F(TcpConnPoolImplTest, MaxPendingRequests) {
-  cluster_->resetResourceManager(1, 1, 1024, 1);
+  cluster_->resetResourceManager(1, 1, 1, 1024, 1);
 
   ConnPoolCallbacks callbacks;
   conn_pool_.expectConnCreate();
@@ -660,7 +660,7 @@ TEST_F(TcpConnPoolImplTest, DisconnectWhileBound) {
  * Test upstream disconnection of one request while another is pending.
  */
 TEST_F(TcpConnPoolImplTest, DisconnectWhilePending) {
-  cluster_->resetResourceManager(1, 1024, 1024, 1);
+  cluster_->resetResourceManager(1, 1, 1024, 1024, 1);
   InSequence s;
 
   // First request connected.
@@ -770,7 +770,7 @@ TEST_F(TcpConnPoolImplTest, MaxRequestsPerConnection) {
  * Test that multiple connections can be assigned at once.
  */
 TEST_F(TcpConnPoolImplTest, ConcurrentConnections) {
-  cluster_->resetResourceManager(2, 1024, 1024, 1);
+  cluster_->resetResourceManager(2, 2, 1024, 1024, 1);
   InSequence s;
 
   ActiveTestConn c1(*this, 0, ActiveTestConn::Type::CreateConnection);
@@ -806,7 +806,7 @@ TEST_F(TcpConnPoolImplTest, ConnectionStateWithConcurrentConnections) {
   auto* s2 = new TestConnectionState(2, [&]() -> void { state_destroyed |= 2; });
   auto* s3 = new TestConnectionState(2, [&]() -> void { state_destroyed |= 4; });
 
-  cluster_->resetResourceManager(2, 1024, 1024, 1);
+  cluster_->resetResourceManager(2, 2, 1024, 1024, 1);
   ActiveTestConn c1(*this, 0, ActiveTestConn::Type::CreateConnection);
   c1.callbacks_.conn_data_->setConnectionState(std::unique_ptr<TestConnectionState>(s1));
   ActiveTestConn c2(*this, 1, ActiveTestConn::Type::CreateConnection);

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -787,7 +787,7 @@ TEST_F(TcpProxyTest, UpstreamConnectFailure) {
 TEST_F(TcpProxyTest, UpstreamConnectionLimit) {
   configure(accessLogConfig("%RESPONSE_FLAGS%"));
   factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_->resetResourceManager(
-      0, 0, 0, 0);
+      0, 0, 0, 0, 0);
 
   // setup sets up expectation for tcpConnForCluster but this test is expected to NOT call that
   filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_, timeSystem());

--- a/test/common/upstream/resource_manager_impl_test.cc
+++ b/test/common/upstream/resource_manager_impl_test.cc
@@ -24,7 +24,7 @@ TEST(ResourceManagerImplTest, RuntimeResourceManager) {
   ON_CALL(store, gauge(_)).WillByDefault(ReturnRef(gauge));
 
   ResourceManagerImpl resource_manager(
-      runtime, "circuit_breakers.runtime_resource_manager_test.default.", 0, 0, 0, 1,
+      runtime, "circuit_breakers.runtime_resource_manager_test.default.", 0, 0, 0, 0, 1,
       ClusterCircuitBreakersStats{ALL_CLUSTER_CIRCUIT_BREAKERS_STATS(POOL_GAUGE(store))});
 
   EXPECT_CALL(

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -34,7 +34,7 @@ MockClusterInfo::MockClusterInfo()
       load_report_stats_(ClusterInfoImpl::generateLoadReportStats(load_report_stats_store_)),
       circuit_breakers_stats_(
           ClusterInfoImpl::generateCircuitBreakersStats(stats_store_, "default")),
-      resource_manager_(new Upstream::ResourceManagerImpl(runtime_, "fake_key", 1, 1024, 1024, 1,
+      resource_manager_(new Upstream::ResourceManagerImpl(runtime_, "fake_key", 1, 1, 1024, 1024, 1,
                                                           circuit_breakers_stats_)) {
   ON_CALL(*this, connectTimeout()).WillByDefault(Return(std::chrono::milliseconds(1)));
   ON_CALL(*this, idleTimeout()).WillByDefault(Return(absl::optional<std::chrono::milliseconds>()));

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -44,8 +44,8 @@ public:
   MockClusterInfo();
   ~MockClusterInfo();
 
-  void resetResourceManager(uint64_t cx, uint64_t rq_pending, uint64_t rq, uint64_t rq_retry) {
-    resource_manager_ = std::make_unique<ResourceManagerImpl>(runtime_, name_, cx, rq_pending, rq,
+  void resetResourceManager(uint64_t cx_pending, uint64_t cx, uint64_t rq_pending, uint64_t rq, uint64_t rq_retry) {
+    resource_manager_ = std::make_unique<ResourceManagerImpl>(runtime_, name_, cx_pending, cx, rq_pending, rq,
                                                               rq_retry, circuit_breakers_stats_);
   }
 

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -44,9 +44,10 @@ public:
   MockClusterInfo();
   ~MockClusterInfo();
 
-  void resetResourceManager(uint64_t cx_pending, uint64_t cx, uint64_t rq_pending, uint64_t rq, uint64_t rq_retry) {
-    resource_manager_ = std::make_unique<ResourceManagerImpl>(runtime_, name_, cx_pending, cx, rq_pending, rq,
-                                                              rq_retry, circuit_breakers_stats_);
+  void resetResourceManager(uint64_t cx_pending, uint64_t cx, uint64_t rq_pending, uint64_t rq,
+                            uint64_t rq_retry) {
+    resource_manager_ = std::make_unique<ResourceManagerImpl>(
+        runtime_, name_, cx_pending, cx, rq_pending, rq, rq_retry, circuit_breakers_stats_);
   }
 
   // Upstream::ClusterInfo


### PR DESCRIPTION
*Description*:

Adds a new `max_pending_connections` circuit breaker. This prevents creating new connections when there are too many connections already being created.

The `pending_connections` resource is incremented when a new connection is created (at the same time as the `connections` resource, and is decremented when either:

1. the connection moves into the 'connected' state
2. the connection is destroyed (in the destructor)

I don't know that the new `connection_succeeded_` variable makes sense but it's the best idea I had so far.

*Risk Level*: medium

*Testing*:

Wanted to get some early commentary on this so there aren't any yet, but here are the tests I'm planning to write. Would love suggestions for more tests!

* test resource is decremented when the connection is established / refused / times out 
* test new connections can't be created when this circuit breaker trips 

*Docs Changes*:

todo

*Release Notes*:

todo

Fixes #5057 
