### PR TITLE
upstream: ensure hosts are not shared between resolve targets

### DIFF
--- a/docs/root/intro/arch_overview/service_discovery.rst
+++ b/docs/root/intro/arch_overview/service_discovery.rst
@@ -32,6 +32,13 @@ from the result Envoy assumes it no longer exists and will drain traffic from an
 connection pools. Note that Envoy never synchronously resolves DNS in the forwarding path. At the
 expense of eventual consistency, there is never a worry of blocking on a long running DNS query.
 
+If a single DNS name resolves to the same IP multiple times, these IPs will be de-duplicated.
+
+If multiple DNS names resolve to the same IP, health checking will *not* be shared.
+This means that care should be taken if active health checking is used with DNS names that resolve
+to the same IPs: if an IP is repeated many times between DNS names it might cause undue load on the
+upstream host.
+
 .. _arch_overview_service_discovery_types_logical_dns:
 
 Logical DNS

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -62,6 +62,8 @@ Version history
 * tracing: added support for :ref:`Datadog <arch_overview_tracing>` tracer.
 * upstream: changed how load calculation for :ref:`priority levels<arch_overview_load_balancing_priority_levels>` and :ref:`panic thresholds<arch_overview_load_balancing_panic_threshold>` interact. As long as normalized total health is 100% panic thresholds are disregarded.
 * upstream: changed the default hash for :ref:`ring hash <envoy_api_msg_Cluster.RingHashLbConfig>` from std::hash to `xxHash <https://github.com/Cyan4973/xxHash>`_.
+* upstream: when using active health checking and STRICT_DNS with several addresses that resolve
+  to the same hosts, Envoy will now health check each host independently.
 
 1.8.0 (Oct 4, 2018)
 ===================

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -159,6 +159,7 @@ public:
 typedef std::shared_ptr<const Host> HostConstSharedPtr;
 
 typedef std::vector<HostSharedPtr> HostVector;
+typedef std::unordered_map<std::string, Upstream::HostSharedPtr> HostMap;
 typedef std::shared_ptr<HostVector> HostVectorSharedPtr;
 typedef std::shared_ptr<const HostVector> HostVectorConstSharedPtr;
 

--- a/source/common/upstream/eds.cc
+++ b/source/common/upstream/eds.cc
@@ -117,7 +117,7 @@ void EdsClusterImpl::onConfigUpdate(const ResourceVector& resources, const std::
                                empty_locality_map, priority_state_manager, updated_hosts);
   }
 
-  updateHostMap(std::move(updated_hosts));
+  all_hosts_ = std::move(updated_hosts);
 
   if (!cluster_rebuilt) {
     info_->stats().update_no_rebuild_.inc();
@@ -148,7 +148,7 @@ bool EdsClusterImpl::updateHostsPerLocality(
   // improve performance and scalability of locality weight updates.
   if (host_set.overprovisioning_factor() != overprovisioning_factor ||
       updateDynamicHostList(new_hosts, *current_hosts_copy, hosts_added, hosts_removed,
-                            updated_hosts) ||
+                            updated_hosts, all_hosts_) ||
       locality_weights_map != new_locality_weights_map) {
     ASSERT(std::all_of(current_hosts_copy->begin(), current_hosts_copy->end(),
                        [&](const auto& host) { return host->priority() == priority; }));

--- a/source/common/upstream/eds.h
+++ b/source/common/upstream/eds.h
@@ -50,6 +50,7 @@ private:
   const LocalInfo::LocalInfo& local_info_;
   const std::string cluster_name_;
   std::vector<LocalityWeightsMap> locality_weights_map_;
+  HostMap all_hosts_;
 };
 
 } // namespace Upstream

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -902,10 +902,12 @@ void StaticClusterImpl::startPreInit() {
   onPreInitComplete();
 }
 
-bool BaseDynamicClusterImpl::updateDynamicHostList(
-    const HostVector& new_hosts, HostVector& current_priority_hosts,
-    HostVector& hosts_added_to_current_priority, HostVector& hosts_removed_from_current_priority,
-    std::unordered_map<std::string, HostSharedPtr>& updated_hosts) {
+bool BaseDynamicClusterImpl::updateDynamicHostList(const HostVector& new_hosts,
+                                                   HostVector& current_priority_hosts,
+                                                   HostVector& hosts_added_to_current_priority,
+                                                   HostVector& hosts_removed_from_current_priority,
+                                                   HostMap& updated_hosts,
+                                                   const HostMap& all_hosts) {
   uint64_t max_host_weight = 1;
 
   // Did hosts change?
@@ -941,8 +943,8 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(
     }
 
     // To match a new host with an existing host means comparing their addresses.
-    auto existing_host = all_hosts_.find(host->address()->asString());
-    const bool existing_host_found = existing_host != all_hosts_.end();
+    auto existing_host = all_hosts.find(host->address()->asString());
+    const bool existing_host_found = existing_host != all_hosts.end();
 
     // Check if in-place host update should be skipped, i.e. when the following criteria are met
     // (currently there is only one criterion, but we might add more in the future):
@@ -1203,7 +1205,7 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
         HostVector hosts_added;
         HostVector hosts_removed;
         if (parent_.updateDynamicHostList(new_hosts, hosts_, hosts_added, hosts_removed,
-                                          updated_hosts)) {
+                                          updated_hosts, all_hosts_)) {
           ENVOY_LOG(debug, "DNS hosts have changed for {}", dns_address_);
           ASSERT(std::all_of(hosts_.begin(), hosts_.end(), [&](const auto& host) {
             return host->priority() == locality_lb_endpoint_.priority();
@@ -1230,7 +1232,7 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
             updated_hosts.insert({host->address()->asString(), host});
           }
         }
-        parent_.updateHostMap(std::move(updated_hosts));
+        all_hosts_ = std::move(updated_hosts);
 
         // If there is an initialize callback, fire it now. Note that if the cluster refers to
         // multiple DNS names, this will return initialized after a single DNS resolution

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1215,23 +1215,6 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
           parent_.info_->stats().update_no_rebuild_.inc();
         }
 
-        // TODO(dio): As reported in https://github.com/envoyproxy/envoy/issues/4548, we leaked
-        // cluster members. This happened since whenever a target resolved, it would set its hosts
-        // as all_hosts_, so that when another target resolved it wouldn't see its own hosts in
-        // all_hosts_. It would think that they're new hosts, so it would add them to its host list
-        // over and over again. To completely fix this issue, we need to think through on
-        // reconciling the differences in behavior between STRICT_DNS and EDS, especially on
-        // handling host sets updates. This is tracked in
-        // https://github.com/envoyproxy/envoy/issues/4590.
-        //
-        // The following block is acceptable for now as a patch to make sure parent_.all_hosts_ is
-        // updated with all resolved hosts from all priorities. This reconciliation is required
-        // since we check each new host against this list.
-        for (const auto& set : parent_.prioritySet().hostSetsPerPriority()) {
-          for (const auto& host : set->hosts()) {
-            updated_hosts.insert({host->address()->asString(), host});
-          }
-        }
         all_hosts_ = std::move(updated_hosts);
 
         // If there is an initialize callback, fire it now. Note that if the cluster refers to

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -661,25 +661,13 @@ protected:
    * priority.
    * @param updated_hosts is used to aggregate the new state of all hosts across priority, and will
    * be updated with the hosts that remain in this priority after the update.
+   * @param all_hosts all known hosts prior to this host update.
    * @return whether the hosts for the priority changed.
    */
   bool updateDynamicHostList(const HostVector& new_hosts, HostVector& current_priority_hosts,
                              HostVector& hosts_added_to_current_priority,
                              HostVector& hosts_removed_from_current_priority,
-                             std::unordered_map<std::string, HostSharedPtr>& updated_hosts);
-
-  typedef std::unordered_map<std::string, Upstream::HostSharedPtr> HostMap;
-
-  /**
-   * Updates the internal collection of all hosts. This should be called with the updated
-   * map of hosts after issuing updateDynamicHostList for each priority.
-   *
-   * @param all_hosts the updated map of address to host after a cluster update.
-   */
-  void updateHostMap(HostMap&& all_hosts) { all_hosts_ = std::move(all_hosts); }
-
-private:
-  HostMap all_hosts_;
+                             HostMap& updated_hosts, const HostMap& all_hosts);
 };
 
 /**
@@ -713,6 +701,7 @@ private:
     HostVector hosts_;
     const envoy::api::v2::endpoint::LocalityLbEndpoints locality_lb_endpoint_;
     const envoy::api::v2::endpoint::LbEndpoint lb_endpoint_;
+    HostMap all_hosts_;
   };
 
   typedef std::unique_ptr<ResolveTarget> ResolveTargetPtr;

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -243,6 +243,7 @@ TEST(StrictDnsClusterImplTest, Basic) {
      },
     "hosts": [{"url": "tcp://localhost1:11001"},
               {"url": "tcp://localhost2:11002"}]
+              
   }
   )EOF";
 
@@ -418,6 +419,7 @@ TEST(StrictDnsClusterImplTest, LoadAssignmentBasic) {
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   NiceMock<Runtime::MockRandomGenerator> random;
   // gmock matches in LIFO order which is why these are swapped.
+  ResolverData resolver3(*dns_resolver, dispatcher);
   ResolverData resolver2(*dns_resolver, dispatcher);
   ResolverData resolver1(*dns_resolver, dispatcher);
 
@@ -463,6 +465,13 @@ TEST(StrictDnsClusterImplTest, LoadAssignmentBasic) {
             address:
               socket_address:
                 address: localhost2
+                port_value: 11002
+            health_check_config:
+              port_value: 8000
+        - endpoint:
+            address:
+              socket_address:
+                address: localhost3
                 port_value: 11002
             health_check_config:
               port_value: 8000
@@ -581,6 +590,25 @@ TEST(StrictDnsClusterImplTest, LoadAssignmentBasic) {
   EXPECT_EQ(1UL,
             cluster.prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
 
+  // Make sure that we *don't* de-dup between resolve targets.
+  EXPECT_CALL(*resolver3.timer_, enableTimer(std::chrono::milliseconds(4000)));
+  EXPECT_CALL(membership_updated, ready());
+  resolver3.dns_callback_(TestUtility::makeDnsResponse({"10.0.0.1"}));
+
+  const auto hosts = cluster.prioritySet().hostSetsPerPriority()[0]->hosts();
+  EXPECT_THAT(std::list<std::string>({"127.0.0.3:11001", "10.0.0.1:11002", "10.0.0.1:11002"}),
+              ContainerEq(hostListToAddresses(hosts)));
+
+  EXPECT_EQ(3UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
+  EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get().size());
+  EXPECT_EQ(1UL,
+            cluster.prioritySet().hostSetsPerPriority()[0]->healthyHostsPerLocality().get().size());
+
+  // Ensure that all host objects in the host list are unique.
+  for (const auto host : hosts) {
+    EXPECT_EQ(1, std::count(hosts.begin(), hosts.end(), host));
+  }
+
   for (const HostSharedPtr& host : cluster.prioritySet().hostSetsPerPriority()[0]->hosts()) {
     EXPECT_EQ(cluster.info().get(), &host->cluster());
   }
@@ -590,9 +618,12 @@ TEST(StrictDnsClusterImplTest, LoadAssignmentBasic) {
   resolver1.timer_->callback_();
   resolver2.expectResolve(*dns_resolver);
   resolver2.timer_->callback_();
+  resolver3.expectResolve(*dns_resolver);
+  resolver3.timer_->callback_();
 
   EXPECT_CALL(resolver1.active_dns_query_, cancel());
   EXPECT_CALL(resolver2.active_dns_query_, cancel());
+  EXPECT_CALL(resolver3.active_dns_query_, cancel());
 }
 
 TEST(StrictDnsClusterImplTest, LoadAssignmentBasicMultiplePriorities) {


### PR DESCRIPTION
This updates `STRICT_DNS` to no longer attempt to share hosts between
resolve targets. Due to the async nature of resolve targets, sharing
host objects can cause the same object to be removed multiple times,
which doesn't work well with the cluster update API (the same host is
sent as a `hosts_removed` multiple times).

As a consequence of this change, active health check values of hosts between
resolve targets are completely independent. This means that active health
checking is duplicated and if a host is added to the cluster in a
resolve target it will *not* reuse the active health value of any
existing hosts, even if we already have a value for the same address.

This differs from EDS, which accomplishes this by ensuring that only one
copy of a given host object exists per cluster. The property that allows
EDS to do this is that the entire cluster is updated at once instead of
per resolve target like in strict DNS.

Fixes #5013
Fixes #4590

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Medium, changes how StrictDns works
*Testing*: Updated UTs
*Docs Changes*: n/a
*Release Notes*: n/a