### PR TITLE
integration test: remove unused overloaded constructor

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -88,7 +88,7 @@ if [ "$1" != "-nofetch" ]; then
   fi
   
   # This is the hash on https://github.com/envoyproxy/envoy-filter-example.git we pin to.
-  (cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout -f 3e5b73305b961526ffcee7584251692a9a3ce4b3)
+  (cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout -f 6c0625cb4cc9a21df97cef2a1d065463f2ae81ae)
   cp -f "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/WORKSPACE
 fi
 

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -126,14 +126,6 @@ public:
   BaseIntegrationTest(Network::Address::IpVersion version, TestTimeSystemPtr time_system,
                       const std::string& config = ConfigHelper::HTTP_PROXY_CONFIG);
 
-  // TODO(jmarantz): this alternate constructor is a temporary hack to allow
-  // envoy-filter-example/echo2_integration_test.cc to compile so CI for #4512
-  // can pass. Once that passes, we can up update filter-examples so it can see
-  // the 3-arg version of BaseIntegrationTest, and remove this constructor
-  // variant.
-  BaseIntegrationTest(Network::Address::IpVersion version, const std::string& config)
-      : BaseIntegrationTest(version, realTime(), config) {}
-
   virtual ~BaseIntegrationTest() {}
 
   /**


### PR DESCRIPTION
In PR #4512, the 2-arg variant of `BaseIntegrationTest`'s constructor
was left temporarily, to allow `echo2_integration_test.cc` to compile.

This overloaded constructor can safely be removed once the following PR
is merged to the envoyproxy/envoy-filter-example repository:
envoyproxy/envoy-filter-example#69

Risk Level: Low
Testing: `bazel test //test/...`
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Tal Nordan <github@talnordan.com>
