### PR TITLE
upstream: add degraded hosts and update LB to prefer healthy hosts over degraded

### DIFF
--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -289,7 +289,7 @@ public:
    * @param overprovisioning_factor if presents, overwrites the current overprovisioning_factor.
    */
   virtual void updateHosts(HostVectorConstSharedPtr hosts, HostVectorConstSharedPtr healthy_hosts,
-      HostVectorConstSharedPtr degraded_hosts,
+                           HostVectorConstSharedPtr degraded_hosts,
                            HostsPerLocalityConstSharedPtr hosts_per_locality,
                            HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
                            HostsPerLocalityConstSharedPtr degraded_hosts_per_locality,

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -110,6 +110,11 @@ public:
   virtual bool healthy() const PURE;
 
   /**
+   * @return whether in aggregate a host is degraded and should be deprioritized during routing.
+   */
+  virtual bool degraded() const PURE;
+
+  /**
    * Returns the host's ActiveHealthFailureType. Types are specified in ActiveHealthFailureType.
    */
   virtual ActiveHealthFailureType getActiveHealthFailureType() const PURE;
@@ -235,6 +240,12 @@ public:
   virtual const HostVector& healthyHosts() const PURE;
 
   /**
+   * @return all degraded hosts contained in the set at the current time. NOTE: This set is
+   *         eventually consistent and has the same guarantees as healthyHosts().
+   */
+  virtual const HostVector& degradedHosts() const PURE;
+
+  /**
    * @return hosts per locality.
    */
   virtual const HostsPerLocality& hostsPerLocality() const PURE;
@@ -245,6 +256,11 @@ public:
   virtual const HostsPerLocality& healthyHostsPerLocality() const PURE;
 
   /**
+   * @return same as hostsPerLocality but only contains healthy hosts.
+   */
+  virtual const HostsPerLocality& degradedHostsPerLocality() const PURE;
+
+  /**
    * @return weights for each locality in the host set.
    */
   virtual LocalityWeightsConstSharedPtr localityWeights() const PURE;
@@ -253,6 +269,12 @@ public:
    * @return next locality index to route to if performing locality weighted balancing.
    */
   virtual absl::optional<uint32_t> chooseLocality() PURE;
+
+  /**
+   * @return next locality index to route to if performing locality weighted balancing
+   * to degraded hosts.
+   */
+  virtual absl::optional<uint32_t> chooseLocalityDegraded() PURE;
 
   /**
    * Updates the hosts in a given host set.
@@ -267,8 +289,10 @@ public:
    * @param overprovisioning_factor if presents, overwrites the current overprovisioning_factor.
    */
   virtual void updateHosts(HostVectorConstSharedPtr hosts, HostVectorConstSharedPtr healthy_hosts,
+      HostVectorConstSharedPtr degraded_hosts,
                            HostsPerLocalityConstSharedPtr hosts_per_locality,
                            HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
+                           HostsPerLocalityConstSharedPtr degraded_hosts_per_locality,
                            LocalityWeightsConstSharedPtr locality_weights,
                            const HostVector& hosts_added, const HostVector& hosts_removed,
                            absl::optional<uint32_t> overprovisioning_factor) PURE;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -694,16 +694,16 @@ void ClusterManagerImpl::postThreadLocalClusterUpdate(const Cluster& cluster, ui
   HostsPerLocalityConstSharedPtr degraded_hosts_per_locality_copy =
       host_set->degradedHostsPerLocality().clone();
 
-  tls_->runOnAllThreads(
-      [this, name = cluster.info()->name(), priority, hosts_copy, healthy_hosts_copy,
-      degraded_hosts_copy,
-       hosts_per_locality_copy, healthy_hosts_per_locality_copy,
-       degraded_hosts_per_locality_copy,
-       locality_weights = host_set->localityWeights(), hosts_added, hosts_removed]() {
-        ThreadLocalClusterManagerImpl::updateClusterMembership(
-            name, priority, hosts_copy, healthy_hosts_copy, degraded_hosts_copy, hosts_per_locality_copy,
-            healthy_hosts_per_locality_copy, degraded_hosts_per_locality_copy, locality_weights, hosts_added, hosts_removed, *tls_);
-      });
+  tls_->runOnAllThreads([this, name = cluster.info()->name(), priority, hosts_copy,
+                         healthy_hosts_copy, degraded_hosts_copy, hosts_per_locality_copy,
+                         healthy_hosts_per_locality_copy, degraded_hosts_per_locality_copy,
+                         locality_weights = host_set->localityWeights(), hosts_added,
+                         hosts_removed]() {
+    ThreadLocalClusterManagerImpl::updateClusterMembership(
+        name, priority, hosts_copy, healthy_hosts_copy, degraded_hosts_copy,
+        hosts_per_locality_copy, healthy_hosts_per_locality_copy, degraded_hosts_per_locality_copy,
+        locality_weights, hosts_added, hosts_removed, *tls_);
+  });
 }
 
 void ClusterManagerImpl::postThreadLocalHealthFailure(const HostSharedPtr& host) {
@@ -945,7 +945,8 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::removeTcpConn(
 
 void ClusterManagerImpl::ThreadLocalClusterManagerImpl::updateClusterMembership(
     const std::string& name, uint32_t priority, HostVectorConstSharedPtr hosts,
-    HostVectorConstSharedPtr healthy_hosts, HostVectorConstSharedPtr degraded_hosts, HostsPerLocalityConstSharedPtr hosts_per_locality,
+    HostVectorConstSharedPtr healthy_hosts, HostVectorConstSharedPtr degraded_hosts,
+    HostsPerLocalityConstSharedPtr hosts_per_locality,
     HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
     HostsPerLocalityConstSharedPtr degraded_hosts_per_locality,
     LocalityWeightsConstSharedPtr locality_weights, const HostVector& hosts_added,
@@ -957,10 +958,9 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::updateClusterMembership(
   const auto& cluster_entry = config.thread_local_clusters_[name];
   ENVOY_LOG(debug, "membership update for TLS cluster {}", name);
   cluster_entry->priority_set_.getOrCreateHostSet(priority).updateHosts(
-      std::move(hosts), std::move(healthy_hosts), std::move(degraded_hosts), 
+      std::move(hosts), std::move(healthy_hosts), std::move(degraded_hosts),
       std::move(hosts_per_locality), std::move(healthy_hosts_per_locality),
-      std::move(degraded_hosts_per_locality),
-      std::move(locality_weights), hosts_added,
+      std::move(degraded_hosts_per_locality), std::move(locality_weights), hosts_added,
       hosts_removed, absl::nullopt);
 
   // If an LB is thread aware, create a new worker local LB on membership changes.

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -308,8 +308,10 @@ private:
     static void updateClusterMembership(const std::string& name, uint32_t priority,
                                         HostVectorConstSharedPtr hosts,
                                         HostVectorConstSharedPtr healthy_hosts,
+                                        HostVectorConstSharedPtr degraded_hosts,
                                         HostsPerLocalityConstSharedPtr hosts_per_locality,
                                         HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
+                                        HostsPerLocalityConstSharedPtr degraded_hosts_per_locality,
                                         LocalityWeightsConstSharedPtr locality_weights,
                                         const HostVector& hosts_added,
                                         const HostVector& hosts_removed, ThreadLocal::Slot& tls);

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -258,8 +258,8 @@ void HdsCluster::initialize(std::function<void()> callback) {
   auto& first_host_set = priority_set_.getOrCreateHostSet(0);
   auto healthy = createHealthyHostList(*initial_hosts_);
 
-  first_host_set.updateHosts(initial_hosts_, healthy, HostsPerLocalityImpl::empty(),
-                             HostsPerLocalityImpl::empty(), {}, *initial_hosts_, {}, absl::nullopt);
+  first_host_set.updateHosts(initial_hosts_, healthy, {}, HostsPerLocalityImpl::empty(),
+                             HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(),{}, *initial_hosts_, {}, absl::nullopt);
 }
 
 void HdsCluster::setOutlierDetector(const Outlier::DetectorSharedPtr&) {

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -259,7 +259,8 @@ void HdsCluster::initialize(std::function<void()> callback) {
   auto healthy = createHealthyHostList(*initial_hosts_);
 
   first_host_set.updateHosts(initial_hosts_, healthy, {}, HostsPerLocalityImpl::empty(),
-                             HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(),{}, *initial_hosts_, {}, absl::nullopt);
+                             HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(), {},
+                             *initial_hosts_, {}, absl::nullopt);
 }
 
 void HdsCluster::setOutlierDetector(const Outlier::DetectorSharedPtr&) {

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -401,11 +401,9 @@ HostConstSharedPtr LoadBalancerBase::chooseHost(LoadBalancerContext* context) {
 bool LoadBalancerBase::isGlobalPanic(const HostSet& host_set) {
   uint64_t global_panic_threshold = std::min<uint64_t>(
       100, runtime_.snapshot().getInteger(RuntimePanicThreshold, default_healthy_panic_percent_));
-  double healthy_percent =
-      host_set.hosts().size() == 0
-          ? 0
-          : 100.0 * (host_set.healthyHosts().size() + host_set.degradedHosts().size()) /
-                host_set.hosts().size();
+  double healthy_percent = host_set.hosts().size() == 0
+                               ? 0
+                               : 100.0 * host_set.healthyHosts().size() / host_set.hosts().size();
 
   // If the % of healthy hosts in the cluster is less than our panic threshold, we use all hosts.
   if (healthy_percent < global_panic_threshold) {

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -396,7 +396,7 @@ bool LoadBalancerBase::isGlobalPanic(const HostSet& host_set) {
       100, runtime_.snapshot().getInteger(RuntimePanicThreshold, default_healthy_panic_percent_));
   double healthy_percent = host_set.hosts().size() == 0
                                ? 0
-                               : 100.0 * host_set.healthyHosts().size() / host_set.hosts().size();
+                               : 100.0 * (host_set.healthyHosts().size() + host_set.degradedHosts().size()) / host_set.hosts().size();
 
   // If the % of healthy hosts in the cluster is less than our panic threshold, we use all hosts.
   if (healthy_percent < global_panic_threshold) {

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -111,7 +111,7 @@ void LoadBalancerBase::recalculatePerPriorityState(uint32_t priority,
               (host_set.healthyHosts().size() - host_set.degradedHosts().size()) /
               host_set.hosts().size()));
 
-    // Priority degraded is computed similarily but only looks at degraded hosts.
+    // Priority degraded is computed similarly but only looks at degraded hosts.
     per_priority_degraded[priority] =
         std::min<uint32_t>(100, (host_set.overprovisioning_factor() *
                                  host_set.degradedHosts().size() / host_set.hosts().size()));

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -68,6 +68,9 @@ protected:
   std::pair<HostSet&, PriorityType> chooseHostSet(LoadBalancerContext* context);
 
   uint32_t percentageLoad(uint32_t priority) const { return per_priority_load_[priority]; }
+  uint32_t degradedPercentageLoad(uint32_t priority) const {
+    return degraded_per_priority_load_[priority];
+  }
   bool isInPanic(uint32_t priority) const { return per_priority_panic_[priority]; }
 
   ClusterStats& stats_;

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -24,11 +24,16 @@ static constexpr uint32_t kDefaultOverProvisioningFactor = 140;
  */
 class LoadBalancerBase : public LoadBalancer {
 public:
+  enum class PriorityType {
+    HEALTHY,
+    DEGRADED
+  };
   // A utility function to chose a priority level based on a precomputed hash and
-  // a priority vector in the style of per_priority_load_
+  // a priority vector in the style of per_priority_load_ and degraded_per_priority_load_.
   //
-  // Returns the priority, a number between 0 and per_priority_load.size()-1
-  static uint32_t choosePriority(uint64_t hash, const std::vector<uint32_t>& per_priority_load);
+  // Returns the priority type and the priority to use. The type is HEALTHY or DEGRADED depending on which priority load table the priority was selected from,
+  // and the priority is a number between 0 and per_priority_load.size()-1 indicating which priority was selected.
+  static std::pair<uint32_t, PriorityType> choosePriority(uint64_t hash, const PriorityLoad& per_priority_load, const PriorityLoad& degraded_per_priority_load);
 
   HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
 
@@ -59,8 +64,8 @@ protected:
                    Runtime::RandomGenerator& random,
                    const envoy::api::v2::Cluster::CommonLbConfig& common_config);
 
-  // Choose host set randomly, based on the per_priority_load_;
-  HostSet& chooseHostSet(LoadBalancerContext* context);
+  // Choose host set randomly, based on the priority loads.
+  std::pair<HostSet&, PriorityType> chooseHostSet(LoadBalancerContext* context);
 
   uint32_t percentageLoad(uint32_t priority) const { return per_priority_load_[priority]; }
   bool isInPanic(uint32_t priority) const { return per_priority_panic_[priority]; }
@@ -78,7 +83,9 @@ public:
   // priority levels.
   void static recalculatePerPriorityState(uint32_t priority, const PrioritySet& priority_set,
                                           PriorityLoad& priority_load,
-                                          std::vector<uint32_t>& per_priority_health);
+                                          std::vector<uint32_t>& per_priority_health,
+                                          PriorityLoad& degraded_priority_load,
+                                          std::vector<uint32_t>& per_priority_degraded);
   void recalculatePerPriorityPanic();
 
 protected:
@@ -88,14 +95,18 @@ protected:
   // Calculating normalized total health starts with summarizing all priorities' health values.
   // It can exceed 100%. For example if there are three priorities and each is 100% healthy, the
   // total of all priorities is 300%. Normalized total health is then capped at 100%.
-  static uint32_t calcNormalizedTotalHealth(std::vector<uint32_t>& per_priority_health) {
+  static uint32_t calcNormalizedTotalHealth(const std::vector<uint32_t>& per_priority_health, const std::vector<uint32_t>& per_priority_degraded) {
     return std::min<uint32_t>(
-        std::accumulate(per_priority_health.begin(), per_priority_health.end(), 0), 100);
+        std::accumulate(per_priority_degraded.begin(), per_priority_degraded.end(), 0) + std::accumulate(per_priority_health.begin(), per_priority_health.end(), 0), 100);
   }
-  // The percentage load (0-100) for each priority level
-  std::vector<uint32_t> per_priority_load_;
-  // The health (0-100) for each priority level.
+  // The percentage load (0-100) for each healthy priority level.
+  PriorityLoad per_priority_load_;
+  // The percentage load (0-100) for each degraded priority level.
+  PriorityLoad degraded_per_priority_load_;
+  // The healthy % (0-100) for each priority level.
   std::vector<uint32_t> per_priority_health_;
+  // The degraded % (0-100) for each priority level.
+  std::vector<uint32_t> per_priority_degraded_;
   // Levels which are in panic
   std::vector<bool> per_priority_panic_;
 };
@@ -140,10 +151,14 @@ protected:
     enum class SourceType {
       // All hosts in the host set.
       AllHosts,
-      // All healthy hosts in the host set.
+      // All healthy and not degraded hosts in the host set.
       HealthyHosts,
+      // All degraded hosts in the host set.
+      DegradedHosts,
       // Healthy hosts for locality @ locality_index.
       LocalityHealthyHosts,
+      // Degraded hosts for locality @ locality_index.
+      LocalityDegradedHosts,
     };
 
     HostsSource() {}

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -24,16 +24,16 @@ static constexpr uint32_t kDefaultOverProvisioningFactor = 140;
  */
 class LoadBalancerBase : public LoadBalancer {
 public:
-  enum class PriorityType {
-    HEALTHY,
-    DEGRADED
-  };
+  enum class PriorityType { HEALTHY, DEGRADED };
   // A utility function to chose a priority level based on a precomputed hash and
   // a priority vector in the style of per_priority_load_ and degraded_per_priority_load_.
   //
-  // Returns the priority type and the priority to use. The type is HEALTHY or DEGRADED depending on which priority load table the priority was selected from,
-  // and the priority is a number between 0 and per_priority_load.size()-1 indicating which priority was selected.
-  static std::pair<uint32_t, PriorityType> choosePriority(uint64_t hash, const PriorityLoad& per_priority_load, const PriorityLoad& degraded_per_priority_load);
+  // Returns the priority type and the priority to use. The type is HEALTHY or DEGRADED depending on
+  // which priority load table the priority was selected from, and the priority is a number between
+  // 0 and per_priority_load.size()-1 indicating which priority was selected.
+  static std::pair<uint32_t, PriorityType>
+  choosePriority(uint64_t hash, const PriorityLoad& per_priority_load,
+                 const PriorityLoad& degraded_per_priority_load);
 
   HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
 
@@ -95,9 +95,12 @@ protected:
   // Calculating normalized total health starts with summarizing all priorities' health values.
   // It can exceed 100%. For example if there are three priorities and each is 100% healthy, the
   // total of all priorities is 300%. Normalized total health is then capped at 100%.
-  static uint32_t calcNormalizedTotalHealth(const std::vector<uint32_t>& per_priority_health, const std::vector<uint32_t>& per_priority_degraded) {
+  static uint32_t calcNormalizedTotalHealth(const std::vector<uint32_t>& per_priority_health,
+                                            const std::vector<uint32_t>& per_priority_degraded) {
     return std::min<uint32_t>(
-        std::accumulate(per_priority_degraded.begin(), per_priority_degraded.end(), 0) + std::accumulate(per_priority_health.begin(), per_priority_health.end(), 0), 100);
+        std::accumulate(per_priority_degraded.begin(), per_priority_degraded.end(), 0) +
+            std::accumulate(per_priority_health.begin(), per_priority_health.end(), 0),
+        100);
   }
   // The percentage load (0-100) for each healthy priority level.
   PriorityLoad per_priority_load_;

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -148,8 +148,8 @@ void OriginalDstCluster::addHost(HostSharedPtr& host) {
   auto& first_host_set = priority_set_.getOrCreateHostSet(0);
   HostVectorSharedPtr new_hosts(new HostVector(first_host_set.hosts()));
   new_hosts->emplace_back(host);
-  first_host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts),
-                             HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(), {},
+  first_host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts), {{}},
+                             HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(),HostsPerLocalityImpl::empty(), {},
                              {std::move(host)}, {}, absl::nullopt);
 }
 
@@ -173,8 +173,8 @@ void OriginalDstCluster::cleanup() {
   }
 
   if (to_be_removed.size() > 0) {
-    host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts),
-                         HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(), {}, {},
+    host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts), {{}}, 
+                         HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(), {}, {},
                          to_be_removed, absl::nullopt);
   }
 

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -149,8 +149,9 @@ void OriginalDstCluster::addHost(HostSharedPtr& host) {
   HostVectorSharedPtr new_hosts(new HostVector(first_host_set.hosts()));
   new_hosts->emplace_back(host);
   first_host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts), {{}},
-                             HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(),HostsPerLocalityImpl::empty(), {},
-                             {std::move(host)}, {}, absl::nullopt);
+                             HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(),
+                             HostsPerLocalityImpl::empty(), {}, {std::move(host)}, {},
+                             absl::nullopt);
 }
 
 void OriginalDstCluster::cleanup() {
@@ -173,9 +174,9 @@ void OriginalDstCluster::cleanup() {
   }
 
   if (to_be_removed.size() > 0) {
-    host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts), {{}}, 
-                         HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(), {}, {},
-                         to_be_removed, absl::nullopt);
+    host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts), {{}},
+                         HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(),
+                         HostsPerLocalityImpl::empty(), {}, {}, to_be_removed, absl::nullopt);
   }
 
   cleanup_timer_->enableTimer(cleanup_interval_ms_);

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -148,10 +148,10 @@ void OriginalDstCluster::addHost(HostSharedPtr& host) {
   auto& first_host_set = priority_set_.getOrCreateHostSet(0);
   HostVectorSharedPtr new_hosts(new HostVector(first_host_set.hosts()));
   new_hosts->emplace_back(host);
-  first_host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts), {{}},
-                             HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(),
-                             HostsPerLocalityImpl::empty(), {}, {std::move(host)}, {},
-                             absl::nullopt);
+  first_host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts),
+                             std::make_shared<const HostVector>(), HostsPerLocalityImpl::empty(),
+                             HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(), {},
+                             {std::move(host)}, {}, absl::nullopt);
 }
 
 void OriginalDstCluster::cleanup() {

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -174,9 +174,10 @@ void OriginalDstCluster::cleanup() {
   }
 
   if (to_be_removed.size() > 0) {
-    host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts), {{}},
-                         HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(),
-                         HostsPerLocalityImpl::empty(), {}, {}, to_be_removed, absl::nullopt);
+    host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts),
+                         std::make_shared<const HostVector>(), HostsPerLocalityImpl::empty(),
+                         HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(), {}, {},
+                         to_be_removed, absl::nullopt);
   }
 
   cleanup_timer_->enableTimer(cleanup_interval_ms_);

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -538,18 +538,20 @@ void SubsetLoadBalancer::HostSubsetImpl::update(const HostVector& hosts_added,
     hosts_per_locality = original_host_set_.hostsPerLocality().filter(predicate);
   }
 
-  HostsPerLocalityConstSharedPtr healthy_hosts_per_locality =
-      hosts_per_locality->filter([](const Host& host) { return host.healthy() && !host.degraded(); });
+  HostsPerLocalityConstSharedPtr healthy_hosts_per_locality = hosts_per_locality->filter(
+      [](const Host& host) { return host.healthy() && !host.degraded(); });
   HostsPerLocalityConstSharedPtr degraded_hosts_per_locality =
       hosts_per_locality->filter([](const Host& host) { return host.degraded(); });
 
   if (locality_weight_aware_) {
-    HostSetImpl::updateHosts(hosts, healthy_hosts, degraded_hosts, hosts_per_locality, healthy_hosts_per_locality, degraded_hosts_per_locality,
+    HostSetImpl::updateHosts(hosts, healthy_hosts, degraded_hosts, hosts_per_locality,
+                             healthy_hosts_per_locality, degraded_hosts_per_locality,
                              original_host_set_.localityWeights(), filtered_added,
                              filtered_removed);
   } else {
-    HostSetImpl::updateHosts(hosts, healthy_hosts, degraded_hosts, hosts_per_locality, healthy_hosts_per_locality, degraded_hosts_per_locality,
-                             {}, filtered_added, filtered_removed);
+    HostSetImpl::updateHosts(hosts, healthy_hosts, degraded_hosts, hosts_per_locality,
+                             healthy_hosts_per_locality, degraded_hosts_per_locality, {},
+                             filtered_added, filtered_removed);
   }
 }
 

--- a/source/common/upstream/thread_aware_lb_impl.cc
+++ b/source/common/upstream/thread_aware_lb_impl.cc
@@ -22,6 +22,7 @@ void ThreadAwareLoadBalancerBase::refresh() {
   auto per_priority_state_vector = std::make_shared<std::vector<PerPriorityStatePtr>>(
       priority_set_.hostSetsPerPriority().size());
   auto per_priority_load = std::make_shared<std::vector<uint32_t>>(per_priority_load_);
+  auto degraded_per_priority_load = std::make_shared<std::vector<uint32_t>>(degraded_per_priority_load_);
 
   for (const auto& host_set : priority_set_.hostSetsPerPriority()) {
     const uint32_t priority = host_set->priority();
@@ -37,6 +38,7 @@ void ThreadAwareLoadBalancerBase::refresh() {
   {
     absl::WriterMutexLock lock(&factory_->mutex_);
     factory_->per_priority_load_ = per_priority_load;
+    factory_->degraded_per_priority_load_ = degraded_per_priority_load;
     factory_->per_priority_state_ = per_priority_state_vector;
   }
 }
@@ -57,7 +59,12 @@ ThreadAwareLoadBalancerBase::LoadBalancerImpl::chooseHost(LoadBalancerContext* c
   }
   const uint64_t h = hash ? hash.value() : random_.random();
 
-  const uint32_t priority = LoadBalancerBase::choosePriority(h, *per_priority_load_);
+  // TODO(snowp): Since we don't keep track of whether we selected from a dregraded priority
+  // or a healthy priority, host selection when both healthy and degraded priorities are 
+  // considered (ie during spillover) gets a bit weird. Once a priority is selected, it
+  // will consider all healthy (including degraded) hosts in that priority even if it was 
+  // selected from the degraded priority.
+  const uint32_t priority = LoadBalancerBase::choosePriority(h, *per_priority_load_, *degraded_per_priority_load_).first;
   const auto& per_priority_state = (*per_priority_state_)[priority];
   if (per_priority_state->global_panic_) {
     stats_.lb_healthy_panic_.inc();

--- a/source/common/upstream/thread_aware_lb_impl.cc
+++ b/source/common/upstream/thread_aware_lb_impl.cc
@@ -22,7 +22,8 @@ void ThreadAwareLoadBalancerBase::refresh() {
   auto per_priority_state_vector = std::make_shared<std::vector<PerPriorityStatePtr>>(
       priority_set_.hostSetsPerPriority().size());
   auto per_priority_load = std::make_shared<std::vector<uint32_t>>(per_priority_load_);
-  auto degraded_per_priority_load = std::make_shared<std::vector<uint32_t>>(degraded_per_priority_load_);
+  auto degraded_per_priority_load =
+      std::make_shared<std::vector<uint32_t>>(degraded_per_priority_load_);
 
   for (const auto& host_set : priority_set_.hostSetsPerPriority()) {
     const uint32_t priority = host_set->priority();
@@ -60,11 +61,12 @@ ThreadAwareLoadBalancerBase::LoadBalancerImpl::chooseHost(LoadBalancerContext* c
   const uint64_t h = hash ? hash.value() : random_.random();
 
   // TODO(snowp): Since we don't keep track of whether we selected from a dregraded priority
-  // or a healthy priority, host selection when both healthy and degraded priorities are 
+  // or a healthy priority, host selection when both healthy and degraded priorities are
   // considered (ie during spillover) gets a bit weird. Once a priority is selected, it
-  // will consider all healthy (including degraded) hosts in that priority even if it was 
+  // will consider all healthy (including degraded) hosts in that priority even if it was
   // selected from the degraded priority.
-  const uint32_t priority = LoadBalancerBase::choosePriority(h, *per_priority_load_, *degraded_per_priority_load_).first;
+  const uint32_t priority =
+      LoadBalancerBase::choosePriority(h, *per_priority_load_, *degraded_per_priority_load_).first;
   const auto& per_priority_state = (*per_priority_state_)[priority];
   if (per_priority_state->global_panic_) {
     stats_.lb_healthy_panic_.inc();

--- a/source/common/upstream/thread_aware_lb_impl.cc
+++ b/source/common/upstream/thread_aware_lb_impl.cc
@@ -81,6 +81,7 @@ LoadBalancerPtr ThreadAwareLoadBalancerBase::LoadBalancerFactoryImpl::create() {
   // threads. All complex processing has already been precalculated however.
   absl::ReaderMutexLock lock(&mutex_);
   lb->per_priority_load_ = per_priority_load_;
+  lb->degraded_per_priority_load_ = degraded_per_priority_load_;
   lb->per_priority_state_ = per_priority_state_;
 
   return std::move(lb);

--- a/source/common/upstream/thread_aware_lb_impl.h
+++ b/source/common/upstream/thread_aware_lb_impl.h
@@ -58,6 +58,7 @@ private:
     Runtime::RandomGenerator& random_;
     std::shared_ptr<std::vector<PerPriorityStatePtr>> per_priority_state_;
     std::shared_ptr<std::vector<uint32_t>> per_priority_load_;
+    std::shared_ptr<std::vector<uint32_t>> degraded_per_priority_load_;
   };
 
   struct LoadBalancerFactoryImpl : public LoadBalancerFactory {
@@ -73,6 +74,7 @@ private:
     std::shared_ptr<std::vector<PerPriorityStatePtr>> per_priority_state_ GUARDED_BY(mutex_);
     // This is split out of PerPriorityState so LoadBalancerBase::ChoosePriorirty can be reused.
     std::shared_ptr<std::vector<uint32_t>> per_priority_load_ GUARDED_BY(mutex_);
+    std::shared_ptr<std::vector<uint32_t>> degraded_per_priority_load_ GUARDED_BY(mutex_);
   };
 
   virtual HashingLoadBalancerSharedPtr createLoadBalancer(const HostSet& host_set,

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -605,7 +605,7 @@ HostVectorConstSharedPtr ClusterImplBase::createDegradedHostList(const HostVecto
 
 HostsPerLocalityConstSharedPtr
 ClusterImplBase::createHealthyHostLists(const HostsPerLocality& hosts) {
-  return hosts.filter([](const Host& host) { return host.healthy(); });
+  return hosts.filter([](const Host& host) { return host.healthy() && !host.degraded(); });
 }
 
 HostsPerLocalityConstSharedPtr

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -221,7 +221,7 @@ void HostSetImpl::updateHosts(HostVectorConstSharedPtr hosts,
   healthy_hosts_ = {std::move(healthy_hosts), std::move(healthy_hosts_per_locality)};
   degraded_hosts_ = {std::move(degraded_hosts), std::move(degraded_hosts_per_locality)};
   locality_weights_ = std::move(locality_weights);
-  
+
   // Rebuild the locality scheduler by computing the effective weight of each
   // locality in this priority. The scheduler is reset by default, and is rebuilt only if we have
   // locality weights (i.e. using EDS) and there is at least one healthy host in this priority.
@@ -248,18 +248,19 @@ void HostSetImpl::updateHosts(HostVectorConstSharedPtr hosts,
     for (uint32_t i = 0; i < all_hosts_.hosts_per_locality_->get().size(); ++i) {
       // First populate the scheduler entries for the healthy hosts.
       {
-      const double effective_weight = effectiveLocalityWeight(i, healthy_hosts_);
-      if (effective_weight > 0) {
-        locality_entries_.emplace_back(std::make_shared<LocalityEntry>(i, effective_weight));
-        locality_scheduler_->add(effective_weight, locality_entries_.back());
-      }
+        const double effective_weight = effectiveLocalityWeight(i, healthy_hosts_);
+        if (effective_weight > 0) {
+          locality_entries_.emplace_back(std::make_shared<LocalityEntry>(i, effective_weight));
+          locality_scheduler_->add(effective_weight, locality_entries_.back());
+        }
       }
 
       // Then populate the scheduler entires for the degraded hosts.
       // TOOD(snowp): extract function
       const double effective_weight = effectiveLocalityWeight(i, degraded_hosts_);
       if (effective_weight > 0) {
-        degraded_locality_entries_.emplace_back(std::make_shared<LocalityEntry>(i, effective_weight));
+        degraded_locality_entries_.emplace_back(
+            std::make_shared<LocalityEntry>(i, effective_weight));
         degraded_locality_scheduler_->add(effective_weight, degraded_locality_entries_.back());
       }
     }
@@ -267,7 +268,7 @@ void HostSetImpl::updateHosts(HostVectorConstSharedPtr hosts,
     if (locality_scheduler_->empty()) {
       locality_scheduler_ = nullptr;
     }
-    
+
     // If all effective weights were zero, reset the scheduler.
     if (degraded_locality_scheduler_->empty()) {
       degraded_locality_scheduler_ = nullptr;
@@ -303,7 +304,8 @@ absl::optional<uint32_t> HostSetImpl::chooseLocalityDegraded() {
   return locality->index_;
 }
 
-double HostSetImpl::effectiveLocalityWeight(uint32_t index, const Subset& eligibile_hosts_subset) const {
+double HostSetImpl::effectiveLocalityWeight(uint32_t index,
+                                            const Subset& eligibile_hosts_subset) const {
   ASSERT(locality_weights_ != nullptr);
   ASSERT(all_hosts_.hosts_per_locality_ != nullptr);
   const auto& locality_hosts = all_hosts_.hosts_per_locality_->get()[index];
@@ -311,7 +313,8 @@ double HostSetImpl::effectiveLocalityWeight(uint32_t index, const Subset& eligib
   if (locality_hosts.empty()) {
     return 0.0;
   }
-  const double locality_eligibility_ratio = 1.0 * locality_eligibile_hosts.size() / locality_hosts.size();
+  const double locality_eligibility_ratio =
+      1.0 * locality_eligibile_hosts.size() / locality_hosts.size();
   const uint32_t weight = (*locality_weights_)[index];
   // Weight ranges from 0-1.0, and is the ratio of eligible hosts to total hosts, modified by the
   // overprovisioning factor.
@@ -712,8 +715,7 @@ void ClusterImplBase::reloadHealthyHosts() {
     HostVectorConstSharedPtr hosts_copy(new HostVector(host_set->hosts()));
     HostsPerLocalityConstSharedPtr hosts_per_locality_copy = host_set->hostsPerLocality().clone();
     host_set->updateHosts(hosts_copy, createHealthyHostList(host_set->hosts()),
-        createDegradedHostList(host_set->hosts()),
-                          hosts_per_locality_copy,
+                          createDegradedHostList(host_set->hosts()), hosts_per_locality_copy,
                           createHealthyHostLists(host_set->hostsPerLocality()),
                           createDegradedHostLists(host_set->hostsPerLocality()),
                           host_set->localityWeights(), {}, {}, absl::nullopt);
@@ -911,7 +913,8 @@ void PriorityStateManager::updateClusterPrioritySet(
 
   auto& host_set = static_cast<PrioritySetImpl&>(parent_.prioritySet())
                        .getOrCreateHostSet(priority, overprovisioning_factor);
-  host_set.updateHosts(hosts, ClusterImplBase::createHealthyHostList(*hosts), ClusterImplBase::createDegradedHostList(*hosts), per_locality_shared,
+  host_set.updateHosts(hosts, ClusterImplBase::createHealthyHostList(*hosts),
+                       ClusterImplBase::createDegradedHostList(*hosts), per_locality_shared,
                        ClusterImplBase::createHealthyHostLists(*per_locality_shared),
                        ClusterImplBase::createDegradedHostLists(*per_locality_shared),
                        std::move(locality_weights), hosts_added.value_or(*hosts),

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -256,7 +256,7 @@ void HostSetImpl::updateHosts(HostVectorConstSharedPtr hosts,
       }
 
       // Then populate the scheduler entires for the degraded hosts.
-      // TOOD(snowp): extract function
+      // TODO(snowp): extract function
       const double effective_weight = effectiveLocalityWeight(i, degraded_hosts_);
       if (effective_weight > 0) {
         degraded_locality_entries_.emplace_back(

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -278,7 +278,7 @@ public:
   const HostVector& healthyHosts() const override { return *healthy_hosts_.hosts_; }
   const HostVector& degradedHosts() const override { return *degraded_hosts_.hosts_; }
   const HostsPerLocality& hostsPerLocality() const override {
-    return *healthy_hosts_.hosts_per_locality_;
+    return *all_hosts_.hosts_per_locality_;
   }
   const HostsPerLocality& healthyHostsPerLocality() const override {
     return *healthy_hosts_.hosts_per_locality_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -251,11 +251,9 @@ public:
   HostSetImpl(uint32_t priority, absl::optional<uint32_t> overprovisioning_factor)
       : priority_(priority), overprovisioning_factor_(overprovisioning_factor.has_value()
                                                           ? overprovisioning_factor.value()
-                                                          : kDefaultOverProvisioningFactor)
-  {}
-  void updateHosts(HostVectorConstSharedPtr hosts, 
-      HostVectorConstSharedPtr healthy_hosts,
-      HostVectorConstSharedPtr degraded_hosts,
+                                                          : kDefaultOverProvisioningFactor) {}
+  void updateHosts(HostVectorConstSharedPtr hosts, HostVectorConstSharedPtr healthy_hosts,
+                   HostVectorConstSharedPtr degraded_hosts,
                    HostsPerLocalityConstSharedPtr hosts_per_locality,
                    HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
                    HostsPerLocalityConstSharedPtr degraded_hosts_per_locality,
@@ -279,7 +277,9 @@ public:
   const HostVector& hosts() const override { return *all_hosts_.hosts_; }
   const HostVector& healthyHosts() const override { return *healthy_hosts_.hosts_; }
   const HostVector& degradedHosts() const override { return *degraded_hosts_.hosts_; }
-  const HostsPerLocality& hostsPerLocality() const override { return *healthy_hosts_.hosts_per_locality_; }
+  const HostsPerLocality& hostsPerLocality() const override {
+    return *healthy_hosts_.hosts_per_locality_;
+  }
   const HostsPerLocality& healthyHostsPerLocality() const override {
     return *healthy_hosts_.hosts_per_locality_;
   }

--- a/source/extensions/retry/priority/previous_priorities/previous_priorities.h
+++ b/source/extensions/retry/priority/previous_priorities/previous_priorities.h
@@ -28,7 +28,7 @@ private:
   void recalculatePerPriorityState(uint32_t priority, const Upstream::PrioritySet& priority_set) {
     // Recalcuate health and priority the same way the load balancer does it.
     Upstream::LoadBalancerBase::recalculatePerPriorityState(
-        priority, priority_set, per_priority_load_, per_priority_health_);
+        priority, priority_set, per_priority_load_, per_priority_health_, degraded_per_priority_load_, per_priority_degraded_);
   }
 
   std::pair<std::vector<uint32_t>, uint32_t> adjustedHealth() const;
@@ -44,6 +44,10 @@ private:
   std::vector<bool> excluded_priorities_;
   Upstream::PriorityLoad per_priority_load_;
   std::vector<uint32_t> per_priority_health_;
+
+  // TODO(snowp): these are unused for now, use once the plugin is consulted for degraded loads.
+  Upstream::PriorityLoad degraded_per_priority_load_;
+  std::vector<uint32_t> per_priority_degraded_;
 };
 
 } // namespace Priority

--- a/source/extensions/retry/priority/previous_priorities/previous_priorities.h
+++ b/source/extensions/retry/priority/previous_priorities/previous_priorities.h
@@ -28,7 +28,8 @@ private:
   void recalculatePerPriorityState(uint32_t priority, const Upstream::PrioritySet& priority_set) {
     // Recalcuate health and priority the same way the load balancer does it.
     Upstream::LoadBalancerBase::recalculatePerPriorityState(
-        priority, priority_set, per_priority_load_, per_priority_health_, degraded_per_priority_load_, per_priority_degraded_);
+        priority, priority_set, per_priority_load_, per_priority_health_,
+        degraded_per_priority_load_, per_priority_degraded_);
   }
 
   std::pair<std::vector<uint32_t>, uint32_t> adjustedHealth() const;

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1769,7 +1769,7 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
 
   // The first update should be applied immediately, since it's not mergeable.
   hosts_removed.push_back((*hosts)[0]);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
                                                               hosts_per_locality, {}, hosts_added,
                                                               hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
@@ -1778,10 +1778,10 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
 
   // These calls should be merged, since there are no added/removed hosts.
   hosts_removed.clear();
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
                                                               hosts_per_locality, {}, hosts_added,
                                                               hosts_removed, absl::nullopt);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
                                                               hosts_per_locality, {}, hosts_added,
                                                               hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
@@ -1797,7 +1797,7 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
   // Add the host back, the update should be immediately applied.
   hosts_removed.clear();
   hosts_added.push_back((*hosts)[0]);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
                                                               hosts_per_locality, {}, hosts_added,
                                                               hosts_removed, absl::nullopt);
   EXPECT_EQ(2, factory_.stats_.counter("cluster_manager.cluster_updated").value());
@@ -1808,17 +1808,17 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
   hosts_added.clear();
 
   (*hosts)[0]->metadata(buildMetadata("v1"));
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
                                                               hosts_per_locality, {}, hosts_added,
                                                               hosts_removed, absl::nullopt);
 
   (*hosts)[0]->healthFlagSet(Host::HealthFlag::FAILED_EDS_HEALTH);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
                                                               hosts_per_locality, {}, hosts_added,
                                                               hosts_removed, absl::nullopt);
 
   (*hosts)[0]->weight(100);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
                                                               hosts_per_locality, {}, hosts_added,
                                                               hosts_removed, absl::nullopt);
 
@@ -1829,7 +1829,7 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
 
   // Remove the host again, should cancel the scheduled update and be delivered immediately.
   hosts_removed.push_back((*hosts)[0]);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
                                                               hosts_per_locality, {}, hosts_added,
                                                               hosts_removed, absl::nullopt);
 
@@ -1863,7 +1863,7 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesOutOfWindow) {
   // it's outside the default merge window of 3 seconds (found in debugger as value of
   // cluster.info()->lbConfig().update_merge_window() in ClusterManagerImpl::scheduleUpdate.
   time_system_.sleep(std::chrono::seconds(60));
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
                                                               hosts_per_locality, {}, hosts_added,
                                                               hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
@@ -1888,7 +1888,7 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesInsideWindow) {
   // in ClusterManagerImpl::scheduleUpdate. Note that initially the update-time is
   // default-initialized to a monotonic time of 0, as is SimulatedTimeSystem::monotonic_time_.
   time_system_.sleep(std::chrono::seconds(2));
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
                                                               hosts_per_locality, {}, hosts_added,
                                                               hosts_removed, absl::nullopt);
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated").value());
@@ -1921,7 +1921,7 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesOutOfWindowDisabled) {
 
   // The first update should be applied immediately, because even though it's mergeable
   // and outside a merge window, merging is disabled.
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
                                                               hosts_per_locality, {}, hosts_added,
                                                               hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
@@ -1979,7 +1979,7 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesDestroyedOnUpdate) {
 
   // The first update should be applied immediately, since it's not mergeable.
   hosts_removed.push_back((*hosts)[0]);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
                                                               hosts_per_locality, {}, hosts_added,
                                                               hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
@@ -1988,10 +1988,10 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesDestroyedOnUpdate) {
 
   // These calls should be merged, since there are no added/removed hosts.
   hosts_removed.clear();
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
                                                               hosts_per_locality, {}, hosts_added,
                                                               hosts_removed, absl::nullopt);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
                                                               hosts_per_locality, {}, hosts_added,
                                                               hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1769,21 +1769,21 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
 
   // The first update should be applied immediately, since it's not mergeable.
   hosts_removed.push_back((*hosts)[0]);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      hosts_per_locality, {}, hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());
 
   // These calls should be merged, since there are no added/removed hosts.
   hosts_removed.clear();
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      hosts_per_locality, {}, hosts_added, hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      hosts_per_locality, {}, hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());
@@ -1797,9 +1797,9 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
   // Add the host back, the update should be immediately applied.
   hosts_removed.clear();
   hosts_added.push_back((*hosts)[0]);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      hosts_per_locality, {}, hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(2, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());
@@ -1808,19 +1808,19 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
   hosts_added.clear();
 
   (*hosts)[0]->metadata(buildMetadata("v1"));
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      hosts_per_locality, {}, hosts_added, hosts_removed, absl::nullopt);
 
   (*hosts)[0]->healthFlagSet(Host::HealthFlag::FAILED_EDS_HEALTH);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      hosts_per_locality, {}, hosts_added, hosts_removed, absl::nullopt);
 
   (*hosts)[0]->weight(100);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      hosts_per_locality, {}, hosts_added, hosts_removed, absl::nullopt);
 
   // Updates not delivered yet.
   EXPECT_EQ(2, factory_.stats_.counter("cluster_manager.cluster_updated").value());
@@ -1829,9 +1829,9 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
 
   // Remove the host again, should cancel the scheduled update and be delivered immediately.
   hosts_removed.push_back((*hosts)[0]);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      hosts_per_locality, {}, hosts_added, hosts_removed, absl::nullopt);
 
   EXPECT_EQ(3, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
@@ -1863,9 +1863,9 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesOutOfWindow) {
   // it's outside the default merge window of 3 seconds (found in debugger as value of
   // cluster.info()->lbConfig().update_merge_window() in ClusterManagerImpl::scheduleUpdate.
   time_system_.sleep(std::chrono::seconds(60));
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      hosts_per_locality, {}, hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.update_out_of_merge_window").value());
@@ -1888,9 +1888,9 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesInsideWindow) {
   // in ClusterManagerImpl::scheduleUpdate. Note that initially the update-time is
   // default-initialized to a monotonic time of 0, as is SimulatedTimeSystem::monotonic_time_.
   time_system_.sleep(std::chrono::seconds(2));
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      hosts_per_locality, {}, hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_out_of_merge_window").value());
@@ -1921,9 +1921,9 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesOutOfWindowDisabled) {
 
   // The first update should be applied immediately, because even though it's mergeable
   // and outside a merge window, merging is disabled.
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      hosts_per_locality, {}, hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_out_of_merge_window").value());
@@ -1979,21 +1979,21 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesDestroyedOnUpdate) {
 
   // The first update should be applied immediately, since it's not mergeable.
   hosts_removed.push_back((*hosts)[0]);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      hosts_per_locality, {}, hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());
 
   // These calls should be merged, since there are no added/removed hosts.
   hosts_removed.clear();
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      hosts_per_locality, {}, hosts_added, hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      hosts_per_locality, {}, hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -32,7 +32,7 @@ public:
                                    should_weight ? weight : 1));
     }
     HostVectorConstSharedPtr updated_hosts{new HostVector(hosts)};
-    host_set.updateHosts(updated_hosts, updated_hosts, nullptr, nullptr, {}, hosts, {},
+    host_set.updateHosts(updated_hosts, updated_hosts, std::make_shared<const HostVector>(), nullptr, nullptr, nullptr, {}, hosts, {},
                          absl::nullopt);
   }
 

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -32,8 +32,8 @@ public:
                                    should_weight ? weight : 1));
     }
     HostVectorConstSharedPtr updated_hosts{new HostVector(hosts)};
-    host_set.updateHosts(updated_hosts, updated_hosts, std::make_shared<const HostVector>(), nullptr, nullptr, nullptr, {}, hosts, {},
-                         absl::nullopt);
+    host_set.updateHosts(updated_hosts, updated_hosts, std::make_shared<const HostVector>(),
+                         nullptr, nullptr, nullptr, {}, hosts, {}, absl::nullopt);
   }
 
   PrioritySetImpl priority_set_;

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -411,9 +411,9 @@ TEST_P(FailoverTest, ExtendPrioritiesWithLocalPrioritySet) {
   // Update the local hosts. We're not doing locality based routing in this
   // test, but it should at least do no harm.
   HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:82")}));
-  local_priority_set_->getOrCreateHostSet(0).updateHosts(hosts, hosts, std::make_shared<const HostVector>(), empty_locality_,
-                                                         empty_locality_,empty_locality_, {}, empty_host_vector_,
-                                                         empty_host_vector_, absl::nullopt);
+  local_priority_set_->getOrCreateHostSet(0).updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), empty_locality_, empty_locality_,
+      empty_locality_, {}, empty_host_vector_, empty_host_vector_, absl::nullopt);
   EXPECT_EQ(tertiary_host_set_.hosts_[0], lb_->chooseHost(nullptr));
 }
 
@@ -650,7 +650,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareSmallCluster) {
   common_config_.mutable_zone_aware_lb_config()->mutable_routing_enabled()->set_value(98);
   common_config_.mutable_zone_aware_lb_config()->mutable_min_cluster_size()->set_value(7);
   init(true);
-  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,hosts_per_locality, {},
+  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(),
+                               hosts_per_locality, hosts_per_locality, hosts_per_locality, {},
                                empty_host_vector_, empty_host_vector_, absl::nullopt);
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 0))
@@ -674,7 +675,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareSmallCluster) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 7))
       .WillRepeatedly(Return(1));
   // Trigger reload.
-  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality, hosts_per_locality, {},
+  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(),
+                               hosts_per_locality, hosts_per_locality, hosts_per_locality, {},
                                empty_host_vector_, empty_host_vector_, absl::nullopt);
   EXPECT_EQ(hostSet().healthy_hosts_per_locality_->get()[0][0], lb_->chooseHost(nullptr));
 }
@@ -700,8 +702,10 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareDifferentZoneSize) {
   common_config_.mutable_zone_aware_lb_config()->mutable_routing_enabled()->set_value(98);
   common_config_.mutable_zone_aware_lb_config()->mutable_min_cluster_size()->set_value(7);
   init(true);
-  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), local_hosts_per_locality, local_hosts_per_locality,local_hosts_per_locality, {},
-                               empty_host_vector_, empty_host_vector_, absl::nullopt);
+  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(),
+                               local_hosts_per_locality, local_hosts_per_locality,
+                               local_hosts_per_locality, {}, empty_host_vector_, empty_host_vector_,
+                               absl::nullopt);
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 100))
       .WillRepeatedly(Return(50));
@@ -737,7 +741,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareRoutingLargeZoneSwitchOnOff) {
   hostSet().hosts_ = *hosts;
   hostSet().healthy_hosts_per_locality_ = hosts_per_locality;
   init(true);
-  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality, hosts_per_locality, {},
+  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(),
+                               hosts_per_locality, hosts_per_locality, hosts_per_locality, {},
                                empty_host_vector_, empty_host_vector_, absl::nullopt);
 
   // There is only one host in the given zone for zone aware routing.
@@ -785,8 +790,9 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareRoutingSmallZone) {
   hostSet().hosts_ = *upstream_hosts;
   hostSet().healthy_hosts_per_locality_ = upstream_hosts_per_locality;
   init(true);
-  local_host_set_->updateHosts(local_hosts, local_hosts, std::make_shared<const HostVector>(), local_hosts_per_locality,
-                               local_hosts_per_locality, local_hosts_per_locality, {}, empty_host_vector_, empty_host_vector_,
+  local_host_set_->updateHosts(local_hosts, local_hosts, std::make_shared<const HostVector>(),
+                               local_hosts_per_locality, local_hosts_per_locality,
+                               local_hosts_per_locality, {}, empty_host_vector_, empty_host_vector_,
                                absl::nullopt);
 
   // There is only one host in the given zone for zone aware routing.
@@ -856,8 +862,9 @@ TEST_P(RoundRobinLoadBalancerTest, LowPrecisionForDistribution) {
 
   // To trigger update callback.
   auto local_hosts_per_locality_shared = makeHostsPerLocality(std::move(local_hosts_per_locality));
-  local_host_set_->updateHosts(local_hosts, local_hosts, std::make_shared<const HostVector>(), local_hosts_per_locality_shared,
-                               local_hosts_per_locality_shared, local_hosts_per_locality_shared, {}, empty_host_vector_,
+  local_host_set_->updateHosts(local_hosts, local_hosts, std::make_shared<const HostVector>(),
+                               local_hosts_per_locality_shared, local_hosts_per_locality_shared,
+                               local_hosts_per_locality_shared, {}, empty_host_vector_,
                                empty_host_vector_, absl::nullopt);
 
   // Force request out of small zone and to randomly select zone.
@@ -878,7 +885,8 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingOneZone) {
   hostSet().hosts_ = *hosts;
   hostSet().healthy_hosts_per_locality_ = hosts_per_locality;
   init(true);
-  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality, hosts_per_locality, {},
+  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(),
+                               hosts_per_locality, hosts_per_locality, hosts_per_locality, {},
                                empty_host_vector_, empty_host_vector_, absl::nullopt);
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
 }
@@ -893,7 +901,8 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingNotHealthy) {
   hostSet().hosts_ = *hosts;
   hostSet().healthy_hosts_per_locality_ = hosts_per_locality;
   init(true);
-  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality, hosts_per_locality, {},
+  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(),
+                               hosts_per_locality, hosts_per_locality, hosts_per_locality, {},
                                empty_host_vector_, empty_host_vector_, absl::nullopt);
 
   // local zone has no healthy hosts, take from the all healthy hosts.
@@ -924,8 +933,9 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingLocalEmpty) {
   hostSet().hosts_ = *upstream_hosts;
   hostSet().healthy_hosts_per_locality_ = upstream_hosts_per_locality;
   init(true);
-  local_host_set_->updateHosts(local_hosts, local_hosts, std::make_shared<const HostVector>(), local_hosts_per_locality,
-                               local_hosts_per_locality, local_hosts_per_locality, {}, empty_host_vector_, empty_host_vector_,
+  local_host_set_->updateHosts(local_hosts, local_hosts, std::make_shared<const HostVector>(),
+                               local_hosts_per_locality, local_hosts_per_locality,
+                               local_hosts_per_locality, {}, empty_host_vector_, empty_host_vector_,
                                absl::nullopt);
 
   // Local cluster is not OK, we'll do regular routing.
@@ -953,8 +963,9 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingNoLocalLocality) {
   hostSet().hosts_ = *upstream_hosts;
   hostSet().healthy_hosts_per_locality_ = upstream_hosts_per_locality;
   init(true);
-  local_host_set_->updateHosts(local_hosts, local_hosts, std::make_shared<const HostVector>(), local_hosts_per_locality,
-                               local_hosts_per_locality, local_hosts_per_locality, {}, empty_host_vector_, empty_host_vector_,
+  local_host_set_->updateHosts(local_hosts, local_hosts, std::make_shared<const HostVector>(),
+                               local_hosts_per_locality, local_hosts_per_locality,
+                               local_hosts_per_locality, {}, empty_host_vector_, empty_host_vector_,
                                absl::nullopt);
 
   // Local cluster is not OK, we'll do regular routing.

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -53,8 +53,9 @@ TEST(DISABLED_LeastRequestLoadBalancerWeightTest, Weight) {
   }
   HostVectorConstSharedPtr updated_hosts{new HostVector(hosts)};
   HostsPerLocalitySharedPtr updated_locality_hosts{new HostsPerLocalityImpl(hosts)};
-  host_set.updateHosts(updated_hosts, updated_hosts, std::make_shared<const HostVector>(), updated_locality_hosts, updated_locality_hosts,updated_locality_hosts,
-                       {}, hosts, {}, absl::nullopt);
+  host_set.updateHosts(updated_hosts, updated_hosts, std::make_shared<const HostVector>(),
+                       updated_locality_hosts, updated_locality_hosts, updated_locality_hosts, {},
+                       hosts, {}, absl::nullopt);
 
   Stats::IsolatedStoreImpl stats_store;
   ClusterStats stats{ClusterInfoImpl::generateStats(stats_store)};
@@ -156,8 +157,9 @@ public:
       }
       auto per_zone_local_shared = makeHostsPerLocality(std::move(per_zone_local));
       local_priority_set_->getOrCreateHostSet(0).updateHosts(
-          originating_hosts, originating_hosts, std::make_shared<const HostVector>(), per_zone_local_shared, per_zone_local_shared, per_zone_local_shared, {},
-          empty_vector_, empty_vector_, absl::nullopt);
+          originating_hosts, originating_hosts, std::make_shared<const HostVector>(),
+          per_zone_local_shared, per_zone_local_shared, per_zone_local_shared, {}, empty_vector_,
+          empty_vector_, absl::nullopt);
 
       HostConstSharedPtr selected = lb.chooseHost(nullptr);
       hits[selected->address()->asString()]++;

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -53,7 +53,7 @@ TEST(DISABLED_LeastRequestLoadBalancerWeightTest, Weight) {
   }
   HostVectorConstSharedPtr updated_hosts{new HostVector(hosts)};
   HostsPerLocalitySharedPtr updated_locality_hosts{new HostsPerLocalityImpl(hosts)};
-  host_set.updateHosts(updated_hosts, updated_hosts, updated_locality_hosts, updated_locality_hosts,
+  host_set.updateHosts(updated_hosts, updated_hosts, std::make_shared<const HostVector>(), updated_locality_hosts, updated_locality_hosts,updated_locality_hosts,
                        {}, hosts, {}, absl::nullopt);
 
   Stats::IsolatedStoreImpl stats_store;
@@ -156,7 +156,7 @@ public:
       }
       auto per_zone_local_shared = makeHostsPerLocality(std::move(per_zone_local));
       local_priority_set_->getOrCreateHostSet(0).updateHosts(
-          originating_hosts, originating_hosts, per_zone_local_shared, per_zone_local_shared, {},
+          originating_hosts, originating_hosts, std::make_shared<const HostVector>(), per_zone_local_shared, per_zone_local_shared, per_zone_local_shared, {},
           empty_vector_, empty_vector_, absl::nullopt);
 
       HostConstSharedPtr selected = lb.chooseHost(nullptr);

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -455,8 +455,8 @@ TEST_F(OriginalDstClusterTest, MultipleClusters) {
             new HostVector(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
         const HostsPerLocalityConstSharedPtr empty_hosts_per_locality{new HostsPerLocalityImpl()};
 
-        second.getOrCreateHostSet(0).updateHosts(new_hosts, healthy_hosts, empty_hosts_per_locality,
-                                                 empty_hosts_per_locality, {}, added, removed,
+        second.getOrCreateHostSet(0).updateHosts(new_hosts, healthy_hosts, std::make_shared<const HostVector>(), empty_hosts_per_locality,
+                                                 empty_hosts_per_locality, empty_hosts_per_locality, {}, added, removed,
                                                  absl::nullopt);
       });
 

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -446,19 +446,19 @@ TEST_F(OriginalDstClusterTest, MultipleClusters) {
   setupFromJson(json);
 
   PrioritySetImpl second;
-  cluster_->prioritySet().addMemberUpdateCb(
-      [&](uint32_t, const HostVector& added, const HostVector& removed) -> void {
-        // Update second hostset accordingly;
-        HostVectorSharedPtr new_hosts(
-            new HostVector(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
-        HostVectorSharedPtr healthy_hosts(
-            new HostVector(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
-        const HostsPerLocalityConstSharedPtr empty_hosts_per_locality{new HostsPerLocalityImpl()};
+  cluster_->prioritySet().addMemberUpdateCb([&](uint32_t, const HostVector& added,
+                                                const HostVector& removed) -> void {
+    // Update second hostset accordingly;
+    HostVectorSharedPtr new_hosts(
+        new HostVector(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
+    HostVectorSharedPtr healthy_hosts(
+        new HostVector(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
+    const HostsPerLocalityConstSharedPtr empty_hosts_per_locality{new HostsPerLocalityImpl()};
 
-        second.getOrCreateHostSet(0).updateHosts(new_hosts, healthy_hosts, std::make_shared<const HostVector>(), empty_hosts_per_locality,
-                                                 empty_hosts_per_locality, empty_hosts_per_locality, {}, added, removed,
-                                                 absl::nullopt);
-      });
+    second.getOrCreateHostSet(0).updateHosts(
+        new_hosts, healthy_hosts, std::make_shared<const HostVector>(), empty_hosts_per_locality,
+        empty_hosts_per_locality, empty_hosts_per_locality, {}, added, removed, absl::nullopt);
+  });
 
   EXPECT_CALL(membership_updated_, ready());
 

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -215,8 +215,8 @@ public:
     local_hosts_per_locality_ = makeHostsPerLocality(std::move(local_hosts_per_locality_vector));
 
     local_priority_set_.getOrCreateHostSet(0).updateHosts(
-        local_hosts_, local_hosts_, std::make_shared<const HostVector>(), local_hosts_per_locality_, local_hosts_per_locality_, local_hosts_per_locality_, {}, {},
-        {}, absl::nullopt);
+        local_hosts_, local_hosts_, std::make_shared<const HostVector>(), local_hosts_per_locality_,
+        local_hosts_per_locality_, local_hosts_per_locality_, {}, {}, {}, absl::nullopt);
 
     lb_.reset(new SubsetLoadBalancer(lb_type_, priority_set_, &local_priority_set_, stats_,
                                      runtime_, random_, subset_info_, ring_hash_lb_config_,
@@ -311,7 +311,8 @@ public:
 
     if (GetParam() == REMOVES_FIRST && !remove.empty()) {
       local_priority_set_.getOrCreateHostSet(0).updateHosts(
-          local_hosts_, local_hosts_, std::make_shared<const HostVector>(), local_hosts_per_locality_, local_hosts_per_locality_, local_hosts_per_locality_, {}, {},
+          local_hosts_, local_hosts_, std::make_shared<const HostVector>(),
+          local_hosts_per_locality_, local_hosts_per_locality_, local_hosts_per_locality_, {}, {},
           remove, absl::nullopt);
     }
 
@@ -325,12 +326,14 @@ public:
     if (GetParam() == REMOVES_FIRST) {
       if (!add.empty()) {
         local_priority_set_.getOrCreateHostSet(0).updateHosts(
-            local_hosts_, local_hosts_, std::make_shared<const HostVector>(), local_hosts_per_locality_, local_hosts_per_locality_, local_hosts_per_locality_, {},
+            local_hosts_, local_hosts_, std::make_shared<const HostVector>(),
+            local_hosts_per_locality_, local_hosts_per_locality_, local_hosts_per_locality_, {},
             add, {}, absl::nullopt);
       }
     } else if (!add.empty() || !remove.empty()) {
       local_priority_set_.getOrCreateHostSet(0).updateHosts(
-          local_hosts_, local_hosts_, std::make_shared<const HostVector>(), local_hosts_per_locality_, local_hosts_per_locality_, local_hosts_per_locality_, {}, add,
+          local_hosts_, local_hosts_, std::make_shared<const HostVector>(),
+          local_hosts_per_locality_, local_hosts_per_locality_, local_hosts_per_locality_, {}, add,
           remove, absl::nullopt);
     }
   }

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -215,7 +215,7 @@ public:
     local_hosts_per_locality_ = makeHostsPerLocality(std::move(local_hosts_per_locality_vector));
 
     local_priority_set_.getOrCreateHostSet(0).updateHosts(
-        local_hosts_, local_hosts_, local_hosts_per_locality_, local_hosts_per_locality_, {}, {},
+        local_hosts_, local_hosts_, std::make_shared<const HostVector>(), local_hosts_per_locality_, local_hosts_per_locality_, local_hosts_per_locality_, {}, {},
         {}, absl::nullopt);
 
     lb_.reset(new SubsetLoadBalancer(lb_type_, priority_set_, &local_priority_set_, stats_,
@@ -311,7 +311,7 @@ public:
 
     if (GetParam() == REMOVES_FIRST && !remove.empty()) {
       local_priority_set_.getOrCreateHostSet(0).updateHosts(
-          local_hosts_, local_hosts_, local_hosts_per_locality_, local_hosts_per_locality_, {}, {},
+          local_hosts_, local_hosts_, std::make_shared<const HostVector>(), local_hosts_per_locality_, local_hosts_per_locality_, local_hosts_per_locality_, {}, {},
           remove, absl::nullopt);
     }
 
@@ -325,12 +325,12 @@ public:
     if (GetParam() == REMOVES_FIRST) {
       if (!add.empty()) {
         local_priority_set_.getOrCreateHostSet(0).updateHosts(
-            local_hosts_, local_hosts_, local_hosts_per_locality_, local_hosts_per_locality_, {},
+            local_hosts_, local_hosts_, std::make_shared<const HostVector>(), local_hosts_per_locality_, local_hosts_per_locality_, local_hosts_per_locality_, {},
             add, {}, absl::nullopt);
       }
     } else if (!add.empty() || !remove.empty()) {
       local_priority_set_.getOrCreateHostSet(0).updateHosts(
-          local_hosts_, local_hosts_, local_hosts_per_locality_, local_hosts_per_locality_, {}, add,
+          local_hosts_, local_hosts_, std::make_shared<const HostVector>(), local_hosts_per_locality_, local_hosts_per_locality_, local_hosts_per_locality_, {}, add,
           remove, absl::nullopt);
     }
   }

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1491,9 +1491,8 @@ TEST(PrioritySet, Extend) {
   HostVector hosts_removed{};
 
   priority_set.hostSetsPerPriority()[1]->updateHosts(hosts, hosts, {{}}, hosts_per_locality,
-                                                     hosts_per_locality,
-                                                     hosts_per_locality, {}, hosts_added,
-                                                     hosts_removed, absl::nullopt);
+                                                     hosts_per_locality, hosts_per_locality, {},
+                                                     hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, changes);
   EXPECT_EQ(last_priority, 1);
   EXPECT_EQ(1, priority_set.hostSetsPerPriority()[1]->hosts().size());
@@ -1872,8 +1871,10 @@ TEST_F(HostSetImplLocalityTest, AllUnhealthy) {
       makeHostsPerLocality({{hosts_[0]}, {hosts_[1]}, {hosts_[2]}});
   LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{1, 1, 1}};
   auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
-  host_set_.updateHosts(hosts, std::make_shared<const HostVector>(), std::make_shared<const HostVector>(), hosts_per_locality,hosts_per_locality,
-                        hosts_per_locality, locality_weights, {}, {}, absl::nullopt);
+  host_set_.updateHosts(hosts, std::make_shared<const HostVector>(),
+                        std::make_shared<const HostVector>(), hosts_per_locality,
+                        hosts_per_locality, hosts_per_locality, locality_weights, {}, {},
+                        absl::nullopt);
   EXPECT_FALSE(host_set_.chooseLocality().has_value());
 }
 
@@ -1883,8 +1884,9 @@ TEST_F(HostSetImplLocalityTest, EmptyLocality) {
       makeHostsPerLocality({{hosts_[0], hosts_[1], hosts_[2]}, {}});
   LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{1, 1}};
   auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
-  host_set_.updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,hosts_per_locality, locality_weights, {},
-                        {}, absl::nullopt);
+  host_set_.updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,
+                        hosts_per_locality, hosts_per_locality, locality_weights, {}, {},
+                        absl::nullopt);
   // Verify that we are not RRing between localities.
   EXPECT_EQ(0, host_set_.chooseLocality().value());
   EXPECT_EQ(0, host_set_.chooseLocality().value());
@@ -1895,8 +1897,8 @@ TEST_F(HostSetImplLocalityTest, AllZeroWeights) {
   HostsPerLocalitySharedPtr hosts_per_locality = makeHostsPerLocality({{hosts_[0]}, {hosts_[1]}});
   LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{0, 0}};
   auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
-  host_set_.updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality, hosts_per_locality, locality_weights, {},
-                        {});
+  host_set_.updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,
+                        hosts_per_locality, hosts_per_locality, locality_weights, {}, {});
   EXPECT_FALSE(host_set_.chooseLocality().has_value());
 }
 
@@ -1906,8 +1908,9 @@ TEST_F(HostSetImplLocalityTest, Unweighted) {
       makeHostsPerLocality({{hosts_[0]}, {hosts_[1]}, {hosts_[2]}});
   LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{1, 1, 1}};
   auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
-  host_set_.updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality, hosts_per_locality, locality_weights, {},
-                        {}, absl::nullopt);
+  host_set_.updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,
+                        hosts_per_locality, hosts_per_locality, locality_weights, {}, {},
+                        absl::nullopt);
   EXPECT_EQ(0, host_set_.chooseLocality().value());
   EXPECT_EQ(1, host_set_.chooseLocality().value());
   EXPECT_EQ(2, host_set_.chooseLocality().value());
@@ -1921,8 +1924,9 @@ TEST_F(HostSetImplLocalityTest, Weighted) {
   HostsPerLocalitySharedPtr hosts_per_locality = makeHostsPerLocality({{hosts_[0]}, {hosts_[1]}});
   LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{1, 2}};
   auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
-  host_set_.updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality, hosts_per_locality, locality_weights, {},
-                        {}, absl::nullopt);
+  host_set_.updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,
+                        hosts_per_locality, hosts_per_locality, locality_weights, {}, {},
+                        absl::nullopt);
   EXPECT_EQ(1, host_set_.chooseLocality().value());
   EXPECT_EQ(0, host_set_.chooseLocality().value());
   EXPECT_EQ(1, host_set_.chooseLocality().value());
@@ -1937,8 +1941,9 @@ TEST_F(HostSetImplLocalityTest, MissingWeight) {
       makeHostsPerLocality({{hosts_[0]}, {hosts_[1]}, {hosts_[2]}});
   LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{1, 0, 1}};
   auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
-  host_set_.updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality, hosts_per_locality, locality_weights, {},
-                        {}, absl::nullopt);
+  host_set_.updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,
+                        hosts_per_locality, hosts_per_locality, locality_weights, {}, {},
+                        absl::nullopt);
   EXPECT_EQ(0, host_set_.chooseLocality().value());
   EXPECT_EQ(2, host_set_.chooseLocality().value());
   EXPECT_EQ(0, host_set_.chooseLocality().value());
@@ -1963,8 +1968,8 @@ TEST_F(HostSetImplLocalityTest, UnhealthyFailover) {
     auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
     host_set_.updateHosts(makeHostsFromHostsPerLocality(hosts_per_locality),
                           makeHostsFromHostsPerLocality(healthy_hosts_per_locality),
-                          std::make_shared<const HostVector>(),
-                          hosts_per_locality, healthy_hosts_per_locality, hosts_per_locality, locality_weights, {}, {},
+                          std::make_shared<const HostVector>(), hosts_per_locality,
+                          healthy_hosts_per_locality, hosts_per_locality, locality_weights, {}, {},
                           absl::nullopt);
   };
 
@@ -2010,8 +2015,8 @@ TEST(OverProvisioningFactorTest, LocalityPickChanges) {
         makeHostsPerLocality({{hosts[0]}, {hosts[2]}});
     host_set.updateHosts(makeHostsFromHostsPerLocality(hosts_per_locality),
                          makeHostsFromHostsPerLocality(healthy_hosts_per_locality),
-                         std::make_shared<const HostVector>(),
-                         hosts_per_locality, healthy_hosts_per_locality, hosts_per_locality, locality_weights, {}, {},
+                         std::make_shared<const HostVector>(), hosts_per_locality,
+                         healthy_hosts_per_locality, hosts_per_locality, locality_weights, {}, {},
                          absl::nullopt);
     uint32_t cnts[] = {0, 0};
     for (uint32_t i = 0; i < 100; ++i) {

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -149,6 +149,7 @@ public:
   MOCK_METHOD1(healthFlagSet, void(HealthFlag flag));
   MOCK_METHOD1(setActiveHealthFailureType, void(ActiveHealthFailureType type));
   MOCK_CONST_METHOD0(healthy, bool());
+  MOCK_CONST_METHOD0(degraded, bool());
   MOCK_CONST_METHOD0(hostname, const std::string&());
   MOCK_CONST_METHOD0(outlierDetector, Outlier::DetectorHostMonitor&());
   MOCK_METHOD1(setHealthChecker_, void(HealthCheckHostMonitorPtr& health_checker));

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -23,12 +23,16 @@ MockHostSet::MockHostSet(uint32_t priority, uint32_t overprovisioning_factor)
   ON_CALL(*this, priority()).WillByDefault(Return(priority_));
   ON_CALL(*this, hosts()).WillByDefault(ReturnRef(hosts_));
   ON_CALL(*this, healthyHosts()).WillByDefault(ReturnRef(healthy_hosts_));
+  ON_CALL(*this, degradedHosts()).WillByDefault(ReturnRef(degraded_hosts_));
   ON_CALL(*this, hostsPerLocality()).WillByDefault(Invoke([this]() -> const HostsPerLocality& {
     return *hosts_per_locality_;
   }));
   ON_CALL(*this, healthyHostsPerLocality())
       .WillByDefault(
           Invoke([this]() -> const HostsPerLocality& { return *healthy_hosts_per_locality_; }));
+  ON_CALL(*this, degradedHostsPerLocality())
+      .WillByDefault(
+          Invoke([this]() -> const HostsPerLocality& { return *degraded_hosts_per_locality_; }));
   ON_CALL(*this, localityWeights()).WillByDefault(Invoke([this]() -> LocalityWeightsConstSharedPtr {
     return locality_weights_;
   }));

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -74,8 +74,10 @@ public:
 
   HostVector hosts_;
   HostVector healthy_hosts_;
+  HostVector degraded_hosts_;
   HostsPerLocalitySharedPtr hosts_per_locality_{new HostsPerLocalityImpl()};
   HostsPerLocalitySharedPtr healthy_hosts_per_locality_{new HostsPerLocalityImpl()};
+  HostsPerLocalitySharedPtr degraded_hosts_per_locality_{new HostsPerLocalityImpl()};
   LocalityWeightsConstSharedPtr locality_weights_{{}};
   Common::CallbackManager<uint32_t, const HostVector&, const HostVector&> member_update_cb_helper_;
   uint32_t priority_{};

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -58,14 +58,14 @@ public:
   MOCK_METHOD0(chooseLocality, absl::optional<uint32_t>());
   MOCK_METHOD0(chooseLocalityDegraded, absl::optional<uint32_t>());
   MOCK_METHOD10(updateHosts, void(std::shared_ptr<const HostVector> hosts,
-                                 std::shared_ptr<const HostVector> healthy_hosts,
-                                 std::shared_ptr<const HostVector> degraded_hosts,
-                                 HostsPerLocalityConstSharedPtr hosts_per_locality,
-                                 HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
-                                 HostsPerLocalityConstSharedPtr degraded_hosts_per_locality,
-                                 LocalityWeightsConstSharedPtr locality_weights,
-                                 const HostVector& hosts_added, const HostVector& hosts_removed,
-                                 absl::optional<uint32_t> overprovisioning_factor));
+                                  std::shared_ptr<const HostVector> healthy_hosts,
+                                  std::shared_ptr<const HostVector> degraded_hosts,
+                                  HostsPerLocalityConstSharedPtr hosts_per_locality,
+                                  HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
+                                  HostsPerLocalityConstSharedPtr degraded_hosts_per_locality,
+                                  LocalityWeightsConstSharedPtr locality_weights,
+                                  const HostVector& hosts_added, const HostVector& hosts_removed,
+                                  absl::optional<uint32_t> overprovisioning_factor));
   MOCK_CONST_METHOD0(priority, uint32_t());
   uint32_t overprovisioning_factor() const override { return overprovisioning_factor_; }
   void set_overprovisioning_factor(const uint32_t overprovisioning_factor) {

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -50,14 +50,19 @@ public:
   // Upstream::HostSet
   MOCK_CONST_METHOD0(hosts, const HostVector&());
   MOCK_CONST_METHOD0(healthyHosts, const HostVector&());
+  MOCK_CONST_METHOD0(degradedHosts, const HostVector&());
   MOCK_CONST_METHOD0(hostsPerLocality, const HostsPerLocality&());
   MOCK_CONST_METHOD0(healthyHostsPerLocality, const HostsPerLocality&());
+  MOCK_CONST_METHOD0(degradedHostsPerLocality, const HostsPerLocality&());
   MOCK_CONST_METHOD0(localityWeights, LocalityWeightsConstSharedPtr());
   MOCK_METHOD0(chooseLocality, absl::optional<uint32_t>());
-  MOCK_METHOD8(updateHosts, void(std::shared_ptr<const HostVector> hosts,
+  MOCK_METHOD0(chooseLocalityDegraded, absl::optional<uint32_t>());
+  MOCK_METHOD10(updateHosts, void(std::shared_ptr<const HostVector> hosts,
                                  std::shared_ptr<const HostVector> healthy_hosts,
+                                 std::shared_ptr<const HostVector> degraded_hosts,
                                  HostsPerLocalityConstSharedPtr hosts_per_locality,
                                  HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
+                                 HostsPerLocalityConstSharedPtr degraded_hosts_per_locality,
                                  LocalityWeightsConstSharedPtr locality_weights,
                                  const HostVector& hosts_added, const HostVector& hosts_removed,
                                  absl::optional<uint32_t> overprovisioning_factor));


### PR DESCRIPTION
This implements the load balancing part of supporting degraded hosts.
    Works by maintaining separate priority loads for degraded hosts, and
    selecting degraded hosts whenever we spill over from the healthy hosts.

Locality weights are similarly also maintained separately for degraded
    hosts. This ensures that we scale locality weights by the size of hosts
    under consideration when routing.

*Risk Level*: High, significant refactors to core load balancing code
*Testing*: n/a for now
*Docs Changes*: n/a for now
*Release Notes*: n/a for now
[Optional Fixes #Issue]
[Optional *Deprecated*:]

Part of #5063 
