### PR TITLE
testing: add missing `using` statement

### DIFF
--- a/test/common/ssl/ssl_socket_test.cc
+++ b/test/common/ssl/ssl_socket_test.cc
@@ -33,6 +33,7 @@
 #include "openssl/ssl.h"
 
 using testing::_;
+using testing::DoAll;
 using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;


### PR DESCRIPTION
Without this change, the code is relying on ADL to correctly resolve
`DoAll` as `::testing::DoAll`. Adding the extra `using` declaration
prevents problems if the Googletest library changes its implementation.

*Risk Level*: low
*Testing*: ran affected tests
*Docs Changes*: n/a
*Release Notes*: n/a