### PR TITLE
test: Add a mechanism for creating singletons in tests

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -29,6 +29,7 @@ envoy_cc_test_library(
         "//source/common/event:libevent_lib",
         "//test/mocks/access_log:access_log_mocks",
         "//test/test_common:environment_lib",
+        "//test/test_common:global_lib",
         "//test/test_common:printers_lib",
     ] + select({
         "//bazel:disable_signal_trace": [],

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -55,12 +55,11 @@ using testing::Ref;
 using testing::Return;
 using testing::ReturnRef;
 using testing::Sequence;
-using testing::Test;
 
 namespace Envoy {
 namespace Http {
 
-class HttpConnectionManagerImplTest : public Test, public ConnectionManagerConfig {
+class HttpConnectionManagerImplTest : public testing::Test, public ConnectionManagerConfig {
 public:
   struct RouteConfigProvider : public Router::RouteConfigProvider {
     RouteConfigProvider(TimeSource& time_source) : time_source_(time_source) {}

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -36,7 +36,6 @@ using testing::Return;
 using testing::SaveArg;
 using testing::Sequence;
 using testing::StrictMock;
-using testing::Test;
 
 namespace Envoy {
 namespace Network {

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -29,7 +29,6 @@ using testing::NiceMock;
 using testing::Return;
 using testing::ReturnPointee;
 using testing::ReturnRef;
-using testing::Test;
 
 namespace Envoy {
 namespace Tracing {
@@ -324,7 +323,7 @@ TEST(HttpNullTracerTest, BasicFunctionality) {
   EXPECT_NE(nullptr, span_ptr->spawnChild(config, "foo", SystemTime()));
 }
 
-class HttpTracerImplTest : public Test {
+class HttpTracerImplTest : public testing::Test {
 public:
   HttpTracerImplTest() {
     driver_ = new MockDriver();

--- a/test/extensions/filters/network/thrift_proxy/decoder_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/decoder_test.cc
@@ -26,7 +26,6 @@ using testing::Return;
 using testing::ReturnRef;
 using testing::SetArgReferee;
 using testing::StrictMock;
-using testing::Test;
 using testing::TestParamInfo;
 using testing::TestWithParam;
 using testing::Values;
@@ -206,7 +205,7 @@ INSTANTIATE_TEST_CASE_P(NonValueProtocolStates, DecoderStateMachineNonValueTest,
                                ProtocolState::SetBegin, ProtocolState::SetEnd),
                         protoStateParamToString);
 
-class DecoderStateMachineTest : public DecoderStateMachineTestBase, public Test {};
+class DecoderStateMachineTest : public DecoderStateMachineTestBase, public testing::Test {};
 
 class DecoderStateMachineValueTest : public DecoderStateMachineTestBase,
                                      public TestWithParam<FieldType> {};

--- a/test/extensions/filters/network/thrift_proxy/route_matcher_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/route_matcher_test.cc
@@ -10,7 +10,6 @@
 #include "gtest/gtest.h"
 
 using testing::_;
-using testing::Test;
 
 namespace Envoy {
 namespace Extensions {

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -29,7 +29,6 @@ using testing::NiceMock;
 using testing::Ref;
 using testing::Return;
 using testing::ReturnRef;
-using testing::Test;
 using testing::TestWithParam;
 using testing::Values;
 
@@ -330,7 +329,7 @@ public:
   NiceMock<Network::MockClientConnection> upstream_connection_;
 };
 
-class ThriftRouterTest : public ThriftRouterTestBase, public Test {
+class ThriftRouterTest : public ThriftRouterTestBase, public testing::Test {
 public:
   ThriftRouterTest() {}
 };

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -331,12 +331,12 @@ public:
 
 class ThriftRouterTest : public ThriftRouterTestBase, public testing::Test {
 public:
-  ThriftRouterTest() {}
+  ThriftRouterTest() = default;
 };
 
 class ThriftRouterFieldTypeTest : public ThriftRouterTestBase, public TestWithParam<FieldType> {
 public:
-  ThriftRouterFieldTypeTest() {}
+  ThriftRouterFieldTypeTest() = default;
 };
 
 INSTANTIATE_TEST_CASE_P(PrimitiveFieldTypes, ThriftRouterFieldTypeTest,
@@ -346,7 +346,7 @@ INSTANTIATE_TEST_CASE_P(PrimitiveFieldTypes, ThriftRouterFieldTypeTest,
 
 class ThriftRouterContainerTest : public ThriftRouterTestBase, public TestWithParam<FieldType> {
 public:
-  ThriftRouterContainerTest() {}
+  ThriftRouterContainerTest() = default;
 };
 
 INSTANTIATE_TEST_CASE_P(ContainerFieldTypes, ThriftRouterContainerTest,

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -331,12 +331,10 @@ public:
 
 class ThriftRouterTest : public ThriftRouterTestBase, public testing::Test {
 public:
-  ThriftRouterTest() = default;
 };
 
 class ThriftRouterFieldTypeTest : public ThriftRouterTestBase, public TestWithParam<FieldType> {
 public:
-  ThriftRouterFieldTypeTest() = default;
 };
 
 INSTANTIATE_TEST_CASE_P(PrimitiveFieldTypes, ThriftRouterFieldTypeTest,
@@ -346,7 +344,6 @@ INSTANTIATE_TEST_CASE_P(PrimitiveFieldTypes, ThriftRouterFieldTypeTest,
 
 class ThriftRouterContainerTest : public ThriftRouterTestBase, public TestWithParam<FieldType> {
 public:
-  ThriftRouterContainerTest() = default;
 };
 
 INSTANTIATE_TEST_CASE_P(ContainerFieldTypes, ThriftRouterContainerTest,

--- a/test/extensions/filters/network/thrift_proxy/thrift_object_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/thrift_object_impl_test.cc
@@ -18,7 +18,6 @@ using testing::NiceMock;
 using testing::Ref;
 using testing::Return;
 using testing::ReturnRef;
-using testing::Test;
 using testing::TestWithParam;
 using testing::Values;
 
@@ -144,7 +143,7 @@ public:
   Buffer::OwnedImpl buffer_;
 };
 
-class ThriftObjectImplTest : public ThriftObjectImplTestBase, public Test {};
+class ThriftObjectImplTest : public ThriftObjectImplTestBase, public testing::Test {};
 
 // Test parsing an empty struct (just a stop field).
 TEST_F(ThriftObjectImplTest, ParseEmptyStruct) {

--- a/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
+++ b/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
@@ -11,8 +11,6 @@
 #include "opentracing/mocktracer/in_memory_recorder.h"
 #include "opentracing/mocktracer/tracer.h"
 
-using testing::Test;
-
 namespace Envoy {
 namespace Extensions {
 namespace Tracers {
@@ -46,7 +44,7 @@ private:
   std::shared_ptr<opentracing::mocktracer::MockTracer> tracer_;
 };
 
-class OpenTracingDriverTest : public Test {
+class OpenTracingDriverTest : public testing::Test {
 public:
   void
   setupValidDriver(OpenTracingDriver::PropagationMode propagation_mode =

--- a/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
+++ b/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
@@ -32,14 +32,13 @@ using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
-using testing::Test;
 
 namespace Envoy {
 namespace Extensions {
 namespace Tracers {
 namespace Datadog {
 
-class DatadogDriverTest : public Test {
+class DatadogDriverTest : public testing::Test {
 public:
   void setup(envoy::config::trace::v2::DatadogConfig& datadog_config, bool init_timer) {
     ON_CALL(cm_, httpAsyncClientForCluster("fake_cluster"))

--- a/test/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl_test.cc
+++ b/test/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl_test.cc
@@ -13,14 +13,12 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using testing::Test;
-
 namespace Envoy {
 namespace Extensions {
 namespace Tracers {
 namespace DynamicOt {
 
-class DynamicOpenTracingDriverTest : public Test {
+class DynamicOpenTracingDriverTest : public testing::Test {
 public:
   void setup(const std::string& library, const std::string& tracer_config) {
     driver_ = std::make_unique<DynamicOpenTracingDriver>(stats_, library, tracer_config);

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -33,14 +33,13 @@ using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
-using testing::Test;
 
 namespace Envoy {
 namespace Extensions {
 namespace Tracers {
 namespace Lightstep {
 
-class LightStepDriverTest : public Test {
+class LightStepDriverTest : public testing::Test {
 public:
   void setup(envoy::config::trace::v2::LightstepConfig& lightstep_config, bool init_timer,
              Common::Ot::OpenTracingDriver::PropagationMode propagation_mode =

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -31,14 +31,13 @@ using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
-using testing::Test;
 
 namespace Envoy {
 namespace Extensions {
 namespace Tracers {
 namespace Zipkin {
 
-class ZipkinDriverTest : public Test {
+class ZipkinDriverTest : public testing::Test {
 public:
   ZipkinDriverTest() : time_source_(test_time_.timeSystem()) {}
 

--- a/test/extensions/transport_sockets/alts/tsi_frame_protector_test.cc
+++ b/test/extensions/transport_sockets/alts/tsi_frame_protector_test.cc
@@ -16,14 +16,13 @@ using testing::InSequence;
 using testing::Invoke;
 using testing::NiceMock;
 using testing::SaveArg;
-using testing::Test;
 using namespace std::string_literals;
 
 /**
  * Test with fake frame protector. The protected frame header is 4 byte length (little endian,
  * include header itself) and following the body.
  */
-class TsiFrameProtectorTest : public Test {
+class TsiFrameProtectorTest : public testing::Test {
 public:
   TsiFrameProtectorTest()
       : raw_frame_protector_(tsi_create_fake_frame_protector(nullptr)),

--- a/test/extensions/transport_sockets/alts/tsi_handshaker_test.cc
+++ b/test/extensions/transport_sockets/alts/tsi_handshaker_test.cc
@@ -16,7 +16,6 @@ using testing::InSequence;
 using testing::Invoke;
 using testing::NiceMock;
 using testing::SaveArg;
-using testing::Test;
 
 class MockTsiHandshakerCallbacks : public TsiHandshakerCallbacks {
 public:
@@ -33,7 +32,7 @@ public:
   }
 };
 
-class TsiHandshakerTest : public Test {
+class TsiHandshakerTest : public testing::Test {
 public:
   TsiHandshakerTest()
       : server_handshaker_({tsi_create_fake_handshaker(0)}, dispatcher_),

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -132,6 +132,24 @@ envoy_cc_library(
 )
 
 envoy_cc_test_library(
+    name = "global_lib",
+    srcs = ["global.cc"],
+    hdrs = ["global.h"],
+    deps = [
+        "//source/common/common:assert_lib",
+        "//source/common/common:thread_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "global_test",
+    srcs = ["global_test.cc"],
+    deps = [
+        ":global_lib",
+    ],
+)
+
+envoy_cc_test_library(
     name = "test_time_lib",
     srcs = ["test_time.cc"],
     hdrs = ["test_time.h"],

--- a/test/test_common/global.cc
+++ b/test/test_common/global.cc
@@ -1,0 +1,57 @@
+#include "test/test_common/global.h"
+
+#include "common/common/assert.h"
+
+namespace Envoy {
+namespace Test {
+
+GlobalHelper& GlobalHelper::instance() {
+  static GlobalHelper* h = new GlobalHelper;
+  return *h;
+}
+
+GlobalHelper::Singleton& GlobalHelper::get(const std::string& type_name, MakeObjectFn make_object) {
+  Thread::ReleasableLockGuard map_lock(map_mutex_);
+  std::unique_ptr<Singleton>& singleton = singleton_map_[type_name];
+
+  if (singleton == nullptr) {
+    // The first time constructing this object, we'll be constructing the
+    // Singleton for the first time, populating it with a fresh instance,
+    // so no need to take the singleton's mutex. But we do need to hold
+    // the map mutex as we are installing the singleton object in the
+    // singleton_map.
+    singleton = std::make_unique<Singleton>(make_object());
+    map_lock.release();
+    return *singleton;
+  }
+
+  // Subsequent accesses will must lock the singleton's mutex to safely populate
+  // .second. However, we can relinquish map_mutex_ as we are no longer
+  // modifying the map; just the .second of the MutexSingleton pointed to by the
+  // map.
+  Thread::LockGuard singleton_lock(singleton->mutex_);
+  if (singleton->ptr_ == nullptr) {
+    ASSERT(singleton->ref_count_ == 0);
+    singleton->ptr_ = make_object();
+  }
+  ++singleton->ref_count_;
+  return *singleton;
+}
+
+void GlobalHelper::Singleton::releaseHelper(DeleteObjectFn delete_object) {
+  void* obj_to_delete = nullptr;
+  {
+    Thread::LockGuard singleton_lock(mutex_);
+    ASSERT(ptr_ != nullptr);
+    if (--ref_count_ == 0) {
+      obj_to_delete = ptr_;
+      ptr_ = nullptr;
+    }
+  }
+  if (obj_to_delete != nullptr) {
+    delete_object(obj_to_delete);
+  }
+}
+
+} // namespace Test
+} // namespace Envoy

--- a/test/test_common/global.cc
+++ b/test/test_common/global.cc
@@ -6,8 +6,8 @@ namespace Envoy {
 namespace Test {
 
 Globals& Globals::instance() {
-  static Globals* h = new Globals;
-  return *h;
+  static Globals* globals = new Globals;
+  return *globals;
 }
 
 std::string Globals::describeActiveSingletonsHelper() {

--- a/test/test_common/global.cc
+++ b/test/test_common/global.cc
@@ -33,8 +33,7 @@ Globals::Singleton& Globals::get(const std::string& type_name, MakeObjectFn make
     // so no need to take the singleton's mutex. But we do need to hold
     // the map mutex as we are installing the singleton object in the
     // singleton_map.
-    singleton = std::make_unique<Singleton>(make_object());
-    map_lock.release();
+    singleton = std::make_unique<Singleton>(make_object(), map_mutex_);
     return *singleton;
   }
 
@@ -42,7 +41,6 @@ Globals::Singleton& Globals::get(const std::string& type_name, MakeObjectFn make
   // .second. However, we can relinquish map_mutex_ as we are no longer
   // modifying the map; just the .second of the MutexSingleton pointed to by the
   // map.
-  Thread::LockGuard singleton_lock(singleton->mutex_);
   if (singleton->ptr_ == nullptr) {
     ASSERT(singleton->ref_count_ == 0);
     singleton->ptr_ = make_object();

--- a/test/test_common/global.cc
+++ b/test/test_common/global.cc
@@ -23,7 +23,7 @@ std::string Globals::describeActiveSingletonsHelper() {
   return ret;
 }
 
-Globals::Singleton& Globals::get(const std::string& type_name, MakeObjectFn make_object) {
+Globals::Singleton& Globals::get(const std::string& type_name, const MakeObjectFn& make_object) {
   Thread::ReleasableLockGuard map_lock(map_mutex_);
   std::unique_ptr<Singleton>& singleton = singleton_map_[type_name];
 
@@ -49,7 +49,7 @@ Globals::Singleton& Globals::get(const std::string& type_name, MakeObjectFn make
   return *singleton;
 }
 
-void Globals::Singleton::releaseHelper(DeleteObjectFn delete_object) {
+void Globals::Singleton::releaseHelper(const DeleteObjectFn& delete_object) {
   void* obj_to_delete = nullptr;
   {
     Thread::LockGuard singleton_lock(mutex_);

--- a/test/test_common/global.cc
+++ b/test/test_common/global.cc
@@ -22,19 +22,5 @@ std::string Globals::describeActiveSingletonsHelper() {
   return ret;
 }
 
-Globals::SingletonSharedPtr Globals::get(const std::string& type_name,
-                                         const MakeObjectFn& make_object,
-                                         const DeleteObjectFn& delete_object) {
-  Thread::LockGuard map_lock(map_mutex_);
-  std::weak_ptr<Singleton>& weak_singleton_ref = singleton_map_[type_name];
-  SingletonSharedPtr singleton = weak_singleton_ref.lock();
-
-  if (singleton == nullptr) {
-    singleton = std::make_shared<Singleton>(make_object(), delete_object);
-    weak_singleton_ref = singleton;
-  }
-  return singleton;
-}
-
 } // namespace Test
 } // namespace Envoy

--- a/test/test_common/global.cc
+++ b/test/test_common/global.cc
@@ -14,50 +14,26 @@ std::string Globals::describeActiveSingletonsHelper() {
   std::string ret;
   Thread::ReleasableLockGuard map_lock(map_mutex_);
   for (auto& p : singleton_map_) {
-    std::unique_ptr<Singleton>& singleton = p.second;
-    ASSERT(singleton != nullptr);
-    if (singleton->ptr_ != nullptr) {
+    SingletonSharedPtr singleton = p.second.lock();
+    if (singleton != nullptr) {
       absl::StrAppend(&ret, "Unexpected active singleton: ", p.first, "\n");
     }
   }
   return ret;
 }
 
-Globals::Singleton& Globals::get(const std::string& type_name, const MakeObjectFn& make_object) {
-  Thread::ReleasableLockGuard map_lock(map_mutex_);
-  std::unique_ptr<Singleton>& singleton = singleton_map_[type_name];
+Globals::SingletonSharedPtr Globals::get(const std::string& type_name,
+                                         const MakeObjectFn& make_object,
+                                         const DeleteObjectFn& delete_object) {
+  Thread::LockGuard map_lock(map_mutex_);
+  std::weak_ptr<Singleton>& weak_singleton_ref = singleton_map_[type_name];
+  SingletonSharedPtr singleton = weak_singleton_ref.lock();
 
   if (singleton == nullptr) {
-    // The first time constructing this object, we'll be constructing the
-    // Singleton for the first time, populating it with a fresh instance,
-    // so no need to take the singleton's mutex. But we do need to hold
-    // the map mutex as we are installing the singleton object in the
-    // singleton_map.
-    singleton = std::make_unique<Singleton>(make_object(), map_mutex_);
-    return *singleton;
+    singleton = std::make_shared<Singleton>(make_object(), delete_object);
+    weak_singleton_ref = singleton;
   }
-
-  if (singleton->ptr_ == nullptr) {
-    ASSERT(singleton->ref_count_ == 0);
-    singleton->ptr_ = make_object();
-  }
-  ++singleton->ref_count_;
-  return *singleton;
-}
-
-void Globals::Singleton::releaseHelper(const DeleteObjectFn& delete_object) {
-  void* obj_to_delete = nullptr;
-  {
-    Thread::LockGuard singleton_lock(mutex_);
-    ASSERT(ptr_ != nullptr);
-    if (--ref_count_ == 0) {
-      obj_to_delete = ptr_;
-      ptr_ = nullptr;
-    }
-  }
-  if (obj_to_delete != nullptr) {
-    delete_object(obj_to_delete);
-  }
+  return singleton;
 }
 
 } // namespace Test

--- a/test/test_common/global.cc
+++ b/test/test_common/global.cc
@@ -37,10 +37,6 @@ Globals::Singleton& Globals::get(const std::string& type_name, const MakeObjectF
     return *singleton;
   }
 
-  // Subsequent accesses will must lock the singleton's mutex to safely populate
-  // .second. However, we can relinquish map_mutex_ as we are no longer
-  // modifying the map; just the .second of the MutexSingleton pointed to by the
-  // map.
   if (singleton->ptr_ == nullptr) {
     ASSERT(singleton->ref_count_ == 0);
     singleton->ptr_ = make_object();

--- a/test/test_common/global.h
+++ b/test/test_common/global.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include "common/common/lock_guard.h"
+#include "common/common/thread.h"
+
+#include "absl/container/flat_hash_map.h"
+
+namespace Envoy {
+namespace Test {
+
+/**
+ * Helper class for managing Globals. This is not intended for external use.
+ * It is not nested in under class Global because the helper class needs to stay
+ * un-templatized. so that it's easier to put the interesting code in a .cc
+ * file and hold its single instance there.
+ *
+ * This class is instantiated as a process-scoped singleton. It manages a map
+ * from type-name to GlobalHelper::Singleton. That map accumulates over a process
+ * lifetime and never shrinks. However, the Singleton objects themselves hold
+ * a reference-counted class-instance pointer that is deleted and nulled after
+ * all references drop, so that each unit-test gets a fresh start.
+ */
+class GlobalHelper {
+  using MakeObjectFn = std::function<void*()>;
+  using DeleteObjectFn = std::function<void(void*)>;
+
+public:
+  /**
+   * Manages Singleton objects that are cleaned up after all references are dropped.
+   */
+  struct Singleton {
+    Singleton(void* ptr) : ref_count_(1), ptr_(ptr) {}
+
+    template <class Type> Type* ptr() { return static_cast<Type*>(ptr_); }
+    template <class Type> Type& ref() { return *ptr<Type>(); }
+    template <class Type> void release() {
+      releaseHelper([](void* p) { delete static_cast<Type*>(p); });
+    }
+    void releaseHelper(DeleteObjectFn delete_object);
+
+    Thread::MutexBasicLockable mutex_;
+    uint64_t ref_count_ GUARDED_BY(mutex_);
+    void* ptr_; // Chanting ptr_ is done under mutex_, but accessing it is not.
+  };
+
+  /**
+   * @return Type a singleton instance of Type. T must be default-constructible.
+   */
+  template <class Type> static Singleton& get() {
+    MakeObjectFn make_object = []() -> void* { return new Type; };
+
+    // The real work here is done by a non-inlined function that carefully
+    // manages two levels of mutexes: one for singleton_map_ and one for each
+    // type of singleton. That function works with void* so that it doesn't need
+    // to be templatized; the casting is done here in the templatized wrapper.
+    return instance().get(typeid(Type).name(), make_object);
+  }
+
+private:
+  GlobalHelper() {}         // Construct via GlobalHelper::helper().
+  ~GlobalHelper() = delete; // GlobalHeler is constructed once and never destryed.
+
+  /**
+   * @return GlobalHelper& a singleton for GlobalHelper.
+   */
+  static GlobalHelper& instance();
+
+  Singleton& get(const std::string& type_name, MakeObjectFn make_object);
+
+  Thread::MutexBasicLockable map_mutex_;
+  absl::flat_hash_map<std::string, std::unique_ptr<Singleton>>
+      singleton_map_ GUARDED_BY(map_mutex_);
+};
+
+/**
+ * Helps manage classes that need to be instantiated once per server. In
+ * production they must be be plumbed through call/class hierarchy, but
+ * in test-code the zero-arg-constructor Mock pattern makes this impractical.
+ * Instead we use self-cleaning singletons.
+ *
+ * Say for example you need a FooImpl plumbed through the system. In production
+ * code you must propagate a FooImpl through constructors to provide access
+ * where needed. For tests, everywhere a common FooImpl is required,
+ * instantiate:
+ *
+ *   Global<FooImpl> foo;
+ *
+ * You can ghen access the singleton FooImpl via foo.get(). The underlying
+ * FooImpl is ref-counted, and when the last TestGlobal is freed, the singleton
+ * FooImpl will be destructed and the singleton pointer nulled.
+ *
+ * The templated type must have a zero-arg constructor. Templatizing this on an
+ * int will compile, but will be hard to use as the memory will be uninitialized
+ * and you will not know when instantiating it whether it needs to be
+ * initialized.
+ */
+template <class Type> class Global {
+public:
+  Global() : singleton_(GlobalHelper::get<Type>()) {}
+  ~Global() { singleton_.release<Type>(); }
+  Type& get() { return singleton_.ref<Type>(); }
+  Type* operator->() { return singleton_.ptr<Type>(); }
+  Type& operator*() { return singleton_.ref<Type>(); }
+
+private:
+  GlobalHelper::Singleton& singleton_;
+};
+
+} // namespace Test
+} // namespace Envoy

--- a/test/test_common/global.h
+++ b/test/test_common/global.h
@@ -49,7 +49,7 @@ public:
 
     Thread::BasicLockable& mutex_;
     uint64_t ref_count_; // Effectively guarded by mutex_, but not analyzable due to aliasing.
-    void* ptr_; // Chanting ptr_ is done under mutex_, but accessing it is not.
+    void* ptr_;          // Chanting ptr_ is done under mutex_, but accessing it is not.
   };
 
   /**

--- a/test/test_common/global.h
+++ b/test/test_common/global.h
@@ -38,7 +38,7 @@ public:
    * Manages Singleton objects that are cleaned up after all references are dropped.
    */
   struct Singleton {
-    Singleton(void* ptr) : ref_count_(1), ptr_(ptr) {}
+    Singleton(void* ptr, Thread::BasicLockable& mutex) : mutex_(mutex), ref_count_(1), ptr_(ptr) {}
 
     template <class Type> Type* ptr() { return static_cast<Type*>(ptr_); }
     template <class Type> Type& ref() { return *ptr<Type>(); }
@@ -47,8 +47,8 @@ public:
     }
     void releaseHelper(DeleteObjectFn delete_object);
 
-    Thread::MutexBasicLockable mutex_;
-    uint64_t ref_count_ GUARDED_BY(mutex_);
+    Thread::BasicLockable& mutex_;
+    uint64_t ref_count_; // Effectively guarded by mutex_, but not analyzable due to aliasing.
     void* ptr_; // Chanting ptr_ is done under mutex_, but accessing it is not.
   };
 

--- a/test/test_common/global.h
+++ b/test/test_common/global.h
@@ -12,10 +12,11 @@ namespace Test {
  * Helper class for managing Global<Type>s.
  *
  * This class is instantiated as a process-scoped singleton. It manages a map
- * from type-name to GlobalHelper::Singleton. That map accumulates over a
- * process lifetime and never shrinks. However, the Singleton objects themselves
- * hold a reference-counted class-instance pointer that is deleted and nulled
- * after all references drop, so that each unit-test gets a fresh start.
+ * from type-name to weak_ptr<GlobalHelper::Singleton>. That map accumulates
+ * over a process lifetime and never shrinks. However, the weak_ptr will
+ * generally be cleared after each test, as all shared_ptr references held in
+ * Global<Type> instances are destroyed. This way, each unit-test gets a fresh
+ * start.
  */
 class Globals {
   using MakeObjectFn = std::function<void*()>;

--- a/test/test_common/global.h
+++ b/test/test_common/global.h
@@ -33,7 +33,10 @@ public:
   }
 
   /**
-   * Manages Singleton objects that are cleaned up after all references are dropped.
+   * Manages Singleton objects that are cleaned up after all references are
+   * dropped. This class must not be templatized becuase as a map value where
+   * every singleton in the map represents a different type. Instead we
+   * templatize the ptr() and ref() methods.
    */
   struct Singleton {
     virtual ~Singleton() = default;
@@ -43,6 +46,14 @@ public:
   };
   using SingletonSharedPtr = std::shared_ptr<Singleton>;
 
+  /**
+   * @return Type a singleton instance of Type. T must be default-constructible.
+   */
+  template <class Type> static SingletonSharedPtr get() { return instance().getHelper<Type>(); }
+
+  ~Globals() = delete; // GlobalHeler is constructed once and never destroyed.
+
+private:
   /**
    * Templatized derived class of Singleton which holds the Type object and is
    * responsible for deleting it using the correct destructor.
@@ -55,15 +66,7 @@ public:
     std::unique_ptr<Type> ptr_{std::make_unique<Type>()};
   };
 
-  /**
-   * @return Type a singleton instance of Type. T must be default-constructible.
-   */
-  template <class Type> static SingletonSharedPtr get() { return instance().getHelper<Type>(); }
-
-  ~Globals() = delete; // GlobalHeler is constructed once and never destroyed.
-
-private:
-  Globals() = default; // Construct via Globals::helper().
+  Globals() = default; // Construct via Globals::instance().
 
   /**
    * @return Globals& a singleton for Globals.

--- a/test/test_common/global.h
+++ b/test/test_common/global.h
@@ -34,7 +34,7 @@ public:
 
   /**
    * Manages Singleton objects that are cleaned up after all references are
-   * dropped. This class must not be templatized becuase as a map value where
+   * dropped. This class must not be templatized because as a map value where
    * every singleton in the map represents a different type. Instead we
    * templatize the ptr() and ref() methods.
    */

--- a/test/test_common/global.h
+++ b/test/test_common/global.h
@@ -45,7 +45,7 @@ public:
     template <class Type> void release() {
       releaseHelper([](void* p) { delete static_cast<Type*>(p); });
     }
-    void releaseHelper(DeleteObjectFn delete_object);
+    void releaseHelper(const DeleteObjectFn& delete_object);
 
     Thread::BasicLockable& mutex_;
     uint64_t ref_count_; // Effectively guarded by mutex_, but not analyzable due to aliasing.
@@ -65,9 +65,10 @@ public:
     return instance().get(typeid(Type).name(), make_object);
   }
 
+  ~Globals() = delete; // GlobalHeler is constructed once and never destroyed.
+
 private:
-  Globals() {}         // Construct via Globals::helper().
-  ~Globals() = delete; // GlobalHeler is constructed once and never destryed.
+  Globals() = default; // Construct via Globals::helper().
 
   /**
    * @return Globals& a singleton for Globals.
@@ -76,7 +77,7 @@ private:
 
   std::string describeActiveSingletonsHelper();
 
-  Singleton& get(const std::string& type_name, MakeObjectFn make_object);
+  Singleton& get(const std::string& type_name, const MakeObjectFn& make_object);
 
   Thread::MutexBasicLockable map_mutex_;
   absl::flat_hash_map<std::string, std::unique_ptr<Singleton>>

--- a/test/test_common/global_test.cc
+++ b/test/test_common/global_test.cc
@@ -1,0 +1,40 @@
+#include <string>
+#include <vector>
+
+#include "test/test_common/global.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Test {
+
+class GlobalTest : public testing::Test {
+protected:
+};
+
+TEST_F(GlobalTest, SingletonStringAndVector) {
+  {
+    Global<std::string> s1;
+    Global<std::vector<int>> v1;
+    EXPECT_EQ("", *s1);
+    *s1 = "foo";
+    EXPECT_TRUE(v1->empty());
+    v1->push_back(42);
+
+    Global<std::string> s2;
+    Global<std::vector<int>> v2;
+    EXPECT_EQ("foo", *s2);
+    ASSERT_EQ(1, v2->size());
+    EXPECT_EQ(42, (*v2)[0]);
+  }
+
+  // After the globals went out of scope, referencing them again we start
+  // from clean objects;
+  Global<std::string> s3;
+  Global<std::vector<int>> v3;
+  EXPECT_EQ("", *s3);
+  EXPECT_TRUE(v3->empty());
+}
+
+} // namespace Test
+} // namespace Envoy

--- a/test/test_common/global_test.cc
+++ b/test/test_common/global_test.cc
@@ -28,12 +28,18 @@ TEST_F(GlobalTest, SingletonStringAndVector) {
     EXPECT_EQ(42, (*v2)[0]);
   }
 
+  // The system is now quiescent, having dropped all references to the globals.
+  EXPECT_EQ("", Globals::describeActiveSingletons());
+
   // After the globals went out of scope, referencing them again we start
   // from clean objects;
   Global<std::string> s3;
   Global<std::vector<int>> v3;
   EXPECT_EQ("", *s3);
   EXPECT_TRUE(v3->empty());
+
+  // With s3 and v3 on the stack, there are active singletons.
+  EXPECT_NE("", Globals::describeActiveSingletons());
 }
 
 } // namespace Test

--- a/test/test_runner.h
+++ b/test/test_runner.h
@@ -7,6 +7,7 @@
 
 #include "test/mocks/access_log/mocks.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/global.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -41,7 +42,16 @@ public:
       file_logger = std::make_unique<Logger::FileSinkDelegate>(
           TestEnvironment::getOptions().logPath(), access_log_manager, Logger::Registry::getSink());
     }
-    return RUN_ALL_TESTS();
+    int exit_status = RUN_ALL_TESTS();
+
+    // Check that all singletons have been destroyed.
+    std::string active_singletons = Test::Globals::describeActiveSingletons();
+    if (!active_singletons.empty()) {
+      std::cerr << "\n\nFAIL: Active singletons exist:\n" << active_singletons << std::endl;
+      exit_status = EXIT_FAILURE;
+    }
+
+    return exit_status;
   }
 };
 } // namespace Envoy

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -286,7 +286,8 @@ def checkSourceLine(line, file_path, reportError):
   if ' ?: ' in line:
     # The ?: operator is non-standard, it is a GCC extension
     reportError("Don't use the '?:' operator, it is a non-standard GCC extension")
-
+  if line.startswith('using testing::Test;'):
+    reportError("Don't use 'using testing::Test;, elaborate the type instead")
 
 def checkBuildLine(line, file_path, reportError):
   if not whitelistedForProtobufDeps(file_path) and '"protobuf"' in line:

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -289,6 +289,7 @@ def checkSourceLine(line, file_path, reportError):
   if line.startswith('using testing::Test;'):
     reportError("Don't use 'using testing::Test;, elaborate the type instead")
 
+
 def checkBuildLine(line, file_path, reportError):
   if not whitelistedForProtobufDeps(file_path) and '"protobuf"' in line:
     reportError("unexpected direct external dependency on protobuf, use "

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -190,6 +190,8 @@ if __name__ == "__main__":
   errors += checkUnfixableError("attribute_packed.cc", "Don't use __attribute__((packed))")
   errors += checkUnfixableError("designated_initializers.cc", "Don't use designated initializers")
   errors += checkUnfixableError("elvis_operator.cc", "Don't use the '?:' operator")
+  errors += checkUnfixableError("testing_test.cc",
+                                "Don't use 'using testing::Test;, elaborate the type instead")
 
   # The following files have errors that can be automatically fixed.
   errors += checkAndFixError("over_enthusiastic_spaces.cc",

--- a/tools/testdata/check_format/testing_test.cc
+++ b/tools/testdata/check_format/testing_test.cc
@@ -1,0 +1,5 @@
+namespace Envoy {
+
+using testing::Test;
+
+} // namespace Envoy


### PR DESCRIPTION
*Description*: For the record, I am against singletons in general, and believe it's more maintainable to pass context objects through the call/instantiation stack, as is done in Envoy production code. However the test system employs a deep system of mocks that are constructed without context. As a result, any new context that may be needed in the future (e.g. SymbolTable in #4980, ThreadSystem in #5055 and #5072 and FileSystem in #5031) need a mechanism to plumb data into the system as instantiated during tests. I believe Api::OsSysCalls() is another example that might benefit from this.

This class provides a mechanism to have a bounded-scope singleton, such that anywhere an instance of a type T is desired, the same instance will be available. Once all references to a Global<T> go out of scope, the shared instance is destroyed and the pointer to it nulled.

Thus, this singleton pattern has the property that between tests, the state will be completely reset, as long as there are no memory leaks.

The new class, Test::Global<T>, creates a potential conflict with tests that had declared `using testing::Test;`, so this PR also cleans those up and adds a format check to avoid having that pattern re-occur.

*Risk Level*: the main risk here is that this class will be abused and used in lieu of proper object passing when that's most appropriate. However, the new library is declared as a bazel test library and is in the test/... tree, so hopefully -- with proper code reviews, the usage will be limited.
*Testing*: //test/...
*Docs Changes*: n/a
*Release Notes*: n/a
