### PR TITLE
test: openssl s_client debug mode for ssl_integration_test.

### DIFF
--- a/test/integration/ssl_integration_test.cc
+++ b/test/integration/ssl_integration_test.cc
@@ -52,6 +52,19 @@ void SslIntegrationTest::TearDown() {
 
 Network::ClientConnectionPtr SslIntegrationTest::makeSslClientConnection(bool alpn, bool san) {
   Network::Address::InstanceConstSharedPtr address = getSslAddress(version_, lookupPort("http"));
+  if (debug_with_s_client_) {
+    const std::string s_client_cmd = TestEnvironment::substitute(
+        "openssl s_client -connect " + address->asString() +
+            " -showcerts -debug -msg -CAfile "
+            "{{ test_rundir }}/test/config/integration/certs/cacert.pem "
+            "-servername lyft.com -cert "
+            "{{ test_rundir }}/test/config/integration/certs/clientcert.pem "
+            "-key "
+            "{{ test_rundir }}/test/config/integration/certs/clientkey.pem ",
+        version_);
+    ENVOY_LOG_MISC(debug, "Executing {}", s_client_cmd);
+    RELEASE_ASSERT(::system(s_client_cmd.c_str()) == 0, "");
+  }
   if (alpn) {
     return dispatcher_->createClientConnection(
         address, Network::Address::InstanceConstSharedPtr(),
@@ -67,14 +80,15 @@ Network::ClientConnectionPtr SslIntegrationTest::makeSslClientConnection(bool al
 }
 
 void SslIntegrationTest::checkStats() {
+  const uint32_t expected_handshakes = debug_with_s_client_ ? 2 : 1;
   if (version_ == Network::Address::IpVersion::v4) {
     Stats::CounterSharedPtr counter = test_server_->counter("listener.127.0.0.1_0.ssl.handshake");
-    EXPECT_EQ(1U, counter->value());
+    EXPECT_EQ(expected_handshakes, counter->value());
     counter->reset();
   } else {
     // ':' is a reserved char in statsd.
     Stats::CounterSharedPtr counter = test_server_->counter("listener.[__1]_0.ssl.handshake");
-    EXPECT_EQ(1U, counter->value());
+    EXPECT_EQ(expected_handshakes, counter->value());
     counter->reset();
   }
 }
@@ -201,6 +215,8 @@ public:
       // Rest of TLS initialization.
     });
     SslIntegrationTest::initialize();
+    // This confuses our socket counting.
+    debug_with_s_client_ = false;
   }
 
   std::string path_prefix_ = TestEnvironment::temporaryPath("ssl_trace");

--- a/test/integration/ssl_integration_test.h
+++ b/test/integration/ssl_integration_test.h
@@ -29,6 +29,11 @@ public:
   Network::ClientConnectionPtr makeSslClientConnection(bool alpn, bool san);
   void checkStats();
 
+protected:
+  // Set this true to debug SSL handshake issues with openssl s_client. The
+  // verbose trace will be in the logs, openssl must be installed separately.
+  bool debug_with_s_client_{false};
+
 private:
   std::unique_ptr<ContextManager> context_manager_;
 


### PR DESCRIPTION
This makes life easier when debugging SSL handshake issues.

Part of #1319.

Risk Level: Low
Testing: ssl_integration_test with debug and !debug.

Signed-off-by: Harvey Tuch <htuch@google.com>