### PR TITLE
connection_impl: Trigger onRead() if read buffer has data.

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -490,8 +490,8 @@ void ConnectionImpl::onReadReady() {
   }
 
   read_end_stream_ |= result.end_stream_read_;
-  if (result.bytes_processed_ != 0 || result.end_stream_read_) {
-    // Skip onRead if no bytes were processed. For instance, if the connection was closed without
+  if (new_buffer_size > 0 || result.end_stream_read_) {
+    // Skip onRead if there is no data in the read buffer. For instance, if the connection was closed without
     // producing more data.
     onRead(new_buffer_size);
   }

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -491,8 +491,8 @@ void ConnectionImpl::onReadReady() {
 
   read_end_stream_ |= result.end_stream_read_;
   if (new_buffer_size > 0 || result.end_stream_read_) {
-    // Skip onRead if there is no data in the read buffer. For instance, if the connection was closed without
-    // producing more data.
+    // Skip onRead if there is no data in the read buffer. For instance, if the connection was
+    // closed without producing more data.
     onRead(new_buffer_size);
   }
 

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1063,10 +1063,9 @@ TEST_P(ConnectionImplTest, FlushWriteAndDelayCloseTimerTriggerTest) {
   EXPECT_CALL(stats.delayed_close_timeouts_, inc()).Times(1);
   EXPECT_CALL(server_callbacks_, onEvent(ConnectionEvent::LocalClose)).Times(1);
   EXPECT_CALL(*client_read_filter, onData(_, false))
-    .Times(1)
-    .WillOnce(Invoke([&](Buffer::Instance&, bool) -> FilterStatus {
-	return FilterStatus::StopIteration;
-      }));
+      .Times(1)
+      .WillOnce(Invoke(
+          [&](Buffer::Instance&, bool) -> FilterStatus { return FilterStatus::StopIteration; }));
   EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::RemoteClose))
       .Times(1)
       .WillOnce(Invoke([&](Network::ConnectionEvent) -> void { dispatcher_->exit(); }));


### PR DESCRIPTION
When readDisable(false) enables reading again it is possible the
kernel socket has no data, but data already exists in the read
buffer. Read even was already triggered in this case, but
onReadReady() only called onRead() if new data was received to the
read buffer, ignoring the data possibly already in the read
buffer. This resulted into a stall in a filter chain with the TCP
proxy filter.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

Testing: This resolved the issue faced when debugging a TCP proxy filter chain.
Risk Level: Low (if any bytes were received, then the read buffer has that data).
