### PR TITLE
tools: format pre-commit output

### DIFF
--- a/support/hooks/pre-push
+++ b/support/hooks/pre-push
@@ -58,7 +58,7 @@ do
     # assumes for these variables correspond to real binaries on the system. If
     # either of these things aren't true, the check fails.
     for i in $(git diff --name-only $RANGE --diff-filter=ACMR 2>&1); do
-      echo "  Checking format for $i"
+      echo -ne "  Checking format for $i - "
       "$SCRIPT_DIR"/check_format.py check $i
       if [[ $? -ne 0 ]]; then
         exit 1


### PR DESCRIPTION
*Description*: Improve format of output for pre-commit script. See below for output.
*Risk Level*: Low
*Testing*: Manual
*Docs Changes*: N/A
*Release Notes*: N/A

Current output:
```bash
  Checking format for .circleci/config.yml
PASS
  Checking format for .clang-tidy
PASS
  Checking format for .gitignore
PASS
  Checking format for CODEOWNERS
PASS
  Checking format for CONTRIBUTING.md
PASS
```

New output:
```bash
  Checking format for .circleci/config.yml - PASS
  Checking format for .clang-tidy - PASS
  Checking format for .gitignore - PASS
  Checking format for CODEOWNERS - PASS
  Checking format for CONTRIBUTING.md - PASS
```