### PR TITLE
tls_inspector: extract supported ECDSA cipher suites.

### DIFF
--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -192,6 +192,11 @@ public:
   virtual absl::string_view requestedServerName() const PURE;
 
   /**
+   * @return requested ECDSA cipher suite(s), if any.
+   */
+  virtual const std::vector<uint16_t>& ecdsaCipherSuites() const PURE;
+
+  /**
    * @return State the current state of the connection.
    */
   virtual State state() const PURE;

--- a/include/envoy/network/listen_socket.h
+++ b/include/envoy/network/listen_socket.h
@@ -170,6 +170,16 @@ public:
    * @return requested server name (e.g. SNI in TLS), if any.
    */
   virtual absl::string_view requestedServerName() const PURE;
+
+  /**
+   * Set requested ECDSA cipher suite(s).
+   */
+  virtual void setEcdsaCipherSuites(const std::vector<uint16_t>& cipher_suites) PURE;
+
+  /**
+   * @return requested ECDSA cipher suite(s), if any.
+   */
+  virtual const std::vector<uint16_t>& ecdsaCipherSuites() const PURE;
 };
 
 typedef std::unique_ptr<ConnectionSocket> ConnectionSocketPtr;

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -93,6 +93,9 @@ public:
     return socket_->options();
   }
   absl::string_view requestedServerName() const override { return socket_->requestedServerName(); }
+  const std::vector<uint16_t>& ecdsaCipherSuites() const override {
+    return socket_->ecdsaCipherSuites();
+  }
   StreamInfo::StreamInfo& streamInfo() override { return stream_info_; }
   const StreamInfo::StreamInfo& streamInfo() const override { return stream_info_; }
   void setWriteFilterOrder(bool reversed) override { reverse_write_filter_order_ = reversed; }

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -117,12 +117,20 @@ public:
   }
   absl::string_view requestedServerName() const override { return server_name_; }
 
+  void setEcdsaCipherSuites(const std::vector<uint16_t>& cipher_suites) override {
+    ecdsa_cipher_suites_.clear();
+    ecdsa_cipher_suites_.insert(ecdsa_cipher_suites_.begin(), cipher_suites.cbegin(),
+                                cipher_suites.cend());
+  }
+  const std::vector<uint16_t>& ecdsaCipherSuites() const override { return ecdsa_cipher_suites_; }
+
 protected:
   Address::InstanceConstSharedPtr remote_address_;
   bool local_address_restored_{false};
   std::string transport_protocol_;
   std::vector<std::string> application_protocols_;
   std::string server_name_;
+  std::vector<uint16_t> ecdsa_cipher_suites_;
 };
 
 // ConnectionSocket used with server connections.

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -76,6 +76,7 @@ private:
   void done(bool success);
   void onALPN(const unsigned char* data, unsigned int len);
   void onServername(absl::string_view name);
+  void extractEcdsaCipherSuites(const SSL_CLIENT_HELLO* ctx);
 
   ConfigSharedPtr config_;
   Network::ListenerFilterCallbacks* cb_;

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
@@ -72,8 +72,8 @@ public:
 };
 
 static void BM_TlsInspector(benchmark::State& state) {
-  NiceMock<FastMockOsSysCalls> os_sys_calls(
-      Tls::Test::generateClientHello("example.com", "\x02h2\x08http/1.1"));
+  NiceMock<FastMockOsSysCalls> os_sys_calls(Tls::Test::generateClientHello(
+      Tls::Test::ClientHelloOptions().setSniName("example.com").setAlpn("\x02h2\x08http/1.1")));
   TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls{&os_sys_calls};
   NiceMock<Stats::MockStore> store;
   ConfigSharedPtr cfg(std::make_shared<Config>(store));

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -11,6 +11,7 @@
 
 using testing::_;
 using testing::AtLeast;
+using testing::ElementsAre;
 using testing::Eq;
 using testing::InSequence;
 using testing::Invoke;
@@ -20,6 +21,10 @@ using testing::Return;
 using testing::ReturnNew;
 using testing::ReturnRef;
 using testing::SaveArg;
+
+using Envoy::Tls::Test::ClientHelloOptions;
+;
+using Envoy::Tls::Test::generateClientHello;
 
 namespace Envoy {
 namespace Extensions {
@@ -43,6 +48,22 @@ public:
         .WillOnce(
             DoAll(SaveArg<1>(&file_event_callback_), ReturnNew<NiceMock<Event::MockFileEvent>>()));
     filter_->onAccept(cb_);
+  }
+
+  void expectRecvClientHello(const std::vector<uint8_t>& client_hello) {
+    EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
+        .WillOnce(Invoke(
+            [&client_hello](int, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
+              ASSERT(length >= client_hello.size());
+              memcpy(buffer, client_hello.data(), client_hello.size());
+              return Api::SysCallSizeResult{ssize_t(client_hello.size()), 0};
+            }));
+  }
+
+  void readEventWithDirectContinue() {
+    EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
+    EXPECT_CALL(cb_, continueFilterChain(true));
+    file_event_callback_(Event::FileReadyType::Read);
   }
 
   NiceMock<Api::MockOsSysCalls> os_sys_calls_;
@@ -94,19 +115,13 @@ TEST_F(TlsInspectorTest, ReadError) {
 TEST_F(TlsInspectorTest, SniRegistered) {
   init();
   const std::string servername("example.com");
-  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(servername, "");
-  EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
-      .WillOnce(
-          Invoke([&client_hello](int, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
-            ASSERT(length >= client_hello.size());
-            memcpy(buffer, client_hello.data(), client_hello.size());
-            return Api::SysCallSizeResult{ssize_t(client_hello.size()), 0};
-          }));
+  const std::vector<uint8_t> client_hello =
+      generateClientHello(ClientHelloOptions().setSniName(servername));
+  expectRecvClientHello(client_hello);
   EXPECT_CALL(socket_, setRequestedServerName(Eq(servername)));
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
-  EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
-  EXPECT_CALL(cb_, continueFilterChain(true));
-  file_event_callback_(Event::FileReadyType::Read);
+  EXPECT_CALL(socket_, setEcdsaCipherSuites(_));
+  readEventWithDirectContinue();
   EXPECT_EQ(1, cfg_->stats().tls_found_.value());
   EXPECT_EQ(1, cfg_->stats().sni_found_.value());
   EXPECT_EQ(1, cfg_->stats().alpn_not_found_.value());
@@ -117,22 +132,71 @@ TEST_F(TlsInspectorTest, AlpnRegistered) {
   init();
   const std::vector<absl::string_view> alpn_protos = {absl::string_view("h2"),
                                                       absl::string_view("http/1.1")};
-  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello("", "\x02h2\x08http/1.1");
-  EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
-      .WillOnce(
-          Invoke([&client_hello](int, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
-            ASSERT(length >= client_hello.size());
-            memcpy(buffer, client_hello.data(), client_hello.size());
-            return Api::SysCallSizeResult{ssize_t(client_hello.size()), 0};
-          }));
+  const std::vector<uint8_t> client_hello =
+      generateClientHello(ClientHelloOptions().setAlpn("\x02h2\x08http/1.1"));
+  expectRecvClientHello(client_hello);
   EXPECT_CALL(socket_, setRequestedServerName(_)).Times(0);
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(alpn_protos));
-  EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
-  EXPECT_CALL(cb_, continueFilterChain(true));
-  file_event_callback_(Event::FileReadyType::Read);
+  EXPECT_CALL(socket_, setEcdsaCipherSuites(_));
+  readEventWithDirectContinue();
+  EXPECT_EQ(1, cfg_->stats().tls_found_.value());
   EXPECT_EQ(1, cfg_->stats().tls_found_.value());
   EXPECT_EQ(1, cfg_->stats().sni_not_found_.value());
   EXPECT_EQ(1, cfg_->stats().alpn_found_.value());
+}
+
+// Test that a ClientHello has default ECDSA ciphers detected.
+TEST_F(TlsInspectorTest, DefaultEcdsaCiphers) {
+  init();
+  const std::vector<uint8_t> client_hello = generateClientHello(ClientHelloOptions());
+  expectRecvClientHello(client_hello);
+  // See https://www.iana.org/assignments/tls-parameters/tls-parameters.xml for
+  // cipher suite IDs.
+  EXPECT_CALL(socket_,
+              setEcdsaCipherSuites(ElementsAre(0xc02b /* TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 */,
+                                               0xc02c /* TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 */,
+                                               0xcca9 /* TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305 */,
+                                               0xc009 /* TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA */,
+                                               0xc00a /* TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA */)));
+  readEventWithDirectContinue();
+}
+
+// Test that a ClientHello has reduced ECDSA cipher suites when < TLSv1.2.
+TEST_F(TlsInspectorTest, OlderEcdsaCiphersReduced) {
+  init();
+  std::vector<uint8_t> client_hello = generateClientHello(ClientHelloOptions().setNoTlsV1_2());
+  // We do some ClientHello surgery here to force behaviors. Specifically, we
+  // mutate the TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA cipher to unsupported
+  // TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256.
+  ASSERT_EQ(0x0a, client_hello[51]);
+  client_hello[51] = 0x2b;
+  expectRecvClientHello(client_hello);
+  // See https://www.iana.org/assignments/tls-parameters/tls-parameters.xml for
+  // cipher suite IDs.
+  EXPECT_CALL(socket_,
+              setEcdsaCipherSuites(ElementsAre(0xc009 /* TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA */)));
+
+  readEventWithDirectContinue();
+}
+
+// Test that a ClientHello with no ECDSA ciphers handles as expected.
+TEST_F(TlsInspectorTest, NoEcdsaCiphers) {
+  init();
+  const std::vector<uint8_t> client_hello =
+      generateClientHello(ClientHelloOptions().setCipherSuites("ECDHE-RSA-AES128-GCM-SHA256"));
+  expectRecvClientHello(client_hello);
+  EXPECT_CALL(socket_, setEcdsaCipherSuites(_)).Times(0);
+  readEventWithDirectContinue();
+}
+
+// Test that a ClientHello with only unknown ECDSA curves handles as expected.
+TEST_F(TlsInspectorTest, UnknownEcdsaCurves) {
+  init();
+  const std::vector<uint8_t> client_hello =
+      generateClientHello(ClientHelloOptions().setEcdhCurves("X25519"));
+  expectRecvClientHello(client_hello);
+  EXPECT_CALL(socket_, setEcdsaCipherSuites(_)).Times(0);
+  readEventWithDirectContinue();
 }
 
 // Test with the ClientHello spread over multiple socket reads.
@@ -140,7 +204,8 @@ TEST_F(TlsInspectorTest, MultipleReads) {
   init();
   const std::vector<absl::string_view> alpn_protos = {absl::string_view("h2")};
   const std::string servername("example.com");
-  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(servername, "\x02h2");
+  const std::vector<uint8_t> client_hello =
+      generateClientHello(ClientHelloOptions().setSniName(servername).setAlpn("\x02h2"));
   {
     InSequence s;
     EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
@@ -161,6 +226,7 @@ TEST_F(TlsInspectorTest, MultipleReads) {
   bool got_continue = false;
   EXPECT_CALL(socket_, setRequestedServerName(Eq(servername)));
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(alpn_protos));
+  EXPECT_CALL(socket_, setEcdsaCipherSuites(_));
   EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
   EXPECT_CALL(cb_, continueFilterChain(true)).WillOnce(InvokeWithoutArgs([&got_continue]() {
     got_continue = true;
@@ -176,19 +242,12 @@ TEST_F(TlsInspectorTest, MultipleReads) {
 // Test that the filter correctly handles a ClientHello with no extensions present.
 TEST_F(TlsInspectorTest, NoExtensions) {
   init();
-  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello("", "");
-  EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
-      .WillOnce(
-          Invoke([&client_hello](int, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
-            ASSERT(length >= client_hello.size());
-            memcpy(buffer, client_hello.data(), client_hello.size());
-            return Api::SysCallSizeResult{ssize_t(client_hello.size()), 0};
-          }));
+  const std::vector<uint8_t> client_hello = generateClientHello({});
+  expectRecvClientHello(client_hello);
   EXPECT_CALL(socket_, setRequestedServerName(_)).Times(0);
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
-  EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
-  EXPECT_CALL(cb_, continueFilterChain(true));
-  file_event_callback_(Event::FileReadyType::Read);
+  EXPECT_CALL(socket_, setEcdsaCipherSuites(_));
+  readEventWithDirectContinue();
   EXPECT_EQ(1, cfg_->stats().tls_found_.value());
   EXPECT_EQ(1, cfg_->stats().sni_not_found_.value());
   EXPECT_EQ(1, cfg_->stats().alpn_not_found_.value());
@@ -199,7 +258,8 @@ TEST_F(TlsInspectorTest, NoExtensions) {
 TEST_F(TlsInspectorTest, ClientHelloTooBig) {
   const size_t max_size = 50;
   cfg_ = std::make_shared<Config>(store_, max_size);
-  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello("example.com", "");
+  const std::vector<uint8_t> client_hello =
+      generateClientHello(ClientHelloOptions().setSniName("example.com"));
   ASSERT(client_hello.size() > max_size);
   init();
   EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -81,6 +81,7 @@ public:
   MOCK_METHOD1(setConnectionStats, void(const ConnectionStats& stats));
   MOCK_CONST_METHOD0(ssl, const Ssl::Connection*());
   MOCK_CONST_METHOD0(requestedServerName, absl::string_view());
+  MOCK_CONST_METHOD0(ecdsaCipherSuites, const std::vector<uint16_t>&());
   MOCK_CONST_METHOD0(state, State());
   MOCK_METHOD2(write, void(Buffer::Instance& data, bool end_stream));
   MOCK_METHOD1(setBufferLimits, void(uint32_t limit));
@@ -130,6 +131,7 @@ public:
   MOCK_METHOD1(setConnectionStats, void(const ConnectionStats& stats));
   MOCK_CONST_METHOD0(ssl, const Ssl::Connection*());
   MOCK_CONST_METHOD0(requestedServerName, absl::string_view());
+  MOCK_CONST_METHOD0(ecdsaCipherSuites, const std::vector<uint16_t>&());
   MOCK_CONST_METHOD0(state, State());
   MOCK_METHOD2(write, void(Buffer::Instance& data, bool end_stream));
   MOCK_METHOD1(setBufferLimits, void(uint32_t limit));
@@ -354,6 +356,8 @@ public:
   MOCK_CONST_METHOD0(requestedApplicationProtocols, const std::vector<std::string>&());
   MOCK_METHOD1(setRequestedServerName, void(absl::string_view));
   MOCK_CONST_METHOD0(requestedServerName, absl::string_view());
+  MOCK_METHOD1(setEcdsaCipherSuites, void(const std::vector<uint16_t>& cipher_suites));
+  MOCK_CONST_METHOD0(ecdsaCipherSuites, const std::vector<uint16_t>&());
   MOCK_METHOD1(addOption_, void(const Socket::OptionConstSharedPtr&));
   MOCK_METHOD1(addOptions_, void(const Socket::OptionsSharedPtr&));
   MOCK_CONST_METHOD0(options, const Network::ConnectionSocket::OptionsSharedPtr&());

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -195,5 +195,6 @@ envoy_cc_library(
     external_deps = ["ssl"],
     deps = [
         "//source/common/common:assert_lib",
+        "//source/common/common:hex_lib",
     ],
 )

--- a/test/test_common/tls_utility.h
+++ b/test/test_common/tls_utility.h
@@ -7,14 +7,51 @@ namespace Envoy {
 namespace Tls {
 namespace Test {
 
+// Options for generateClientHello.
+struct ClientHelloOptions {
+  ClientHelloOptions& setSniName(const std::string& sni_name) {
+    sni_name_ = sni_name;
+    return *this;
+  }
+
+  ClientHelloOptions& setAlpn(const std::string& alpn) {
+    alpn_ = alpn;
+    return *this;
+  }
+
+  ClientHelloOptions& setCipherSuites(const std::string& cipher_suites) {
+    cipher_suites_ = cipher_suites;
+    return *this;
+  }
+
+  ClientHelloOptions& setEcdhCurves(const std::string& ecdh_curves) {
+    ecdh_curves_ = ecdh_curves;
+    return *this;
+  }
+
+  ClientHelloOptions& setNoTlsV1_2() {
+    no_tls_v1_2_ = true;
+    return *this;
+  }
+
+  // The name to include as a Server Name Indication. No SNI extension is added if sni_name is
+  // empty.
+  std::string sni_name_;
+  // Protocol(s) list in the wire-format (i.e. 8-bit length-prefixed string) to advertise in
+  // Application-Layer Protocol Negotiation. No ALPN is advertised if alpn is empty.
+  std::string alpn_;
+  // :-delimited cipher suites override if non-empty.
+  std::string cipher_suites_;
+  // :-delimited ECDH curves list override if non-empty.
+  std::string ecdh_curves_;
+  // Force TLS < v1.2.
+  bool no_tls_v1_2_;
+};
+
 /**
  * Generate a TLS ClientHello in wire-format.
- * @param sni_name The name to include as a Server Name Indication.
- *                 No SNI extension is added if sni_name is empty.
- * @param alpn Protocol(s) list in the wire-format (i.e. 8-bit length-prefixed string) to advertise
- *             in Application-Layer Protocol Negotiation. No ALPN is advertised if alpn is empty.
  */
-std::vector<uint8_t> generateClientHello(const std::string& sni_name, const std::string& alpn);
+std::vector<uint8_t> generateClientHello(const ClientHelloOptions& options);
 
 } // namespace Test
 } // namespace Tls


### PR DESCRIPTION
This is a very basic ECDSA detection algorithm. The idea is we track which ECDSA cipher suites are
supported by the client (and whether it is fundamentally ECDSA capable), and then will later
reconcile this in the SSL context with the supported server cipher suites.

Part of #1319.

Risk Level: Low
Testing: New unit tests for TLS inspector that mess with cipher suites and curves. There are some
  untested paths on malformed ClientHello (just as there are with the existing TLS inspector), where
  the error that occur would require some serious surgery on the ClientHello to simulate, see
  coverage report for these.

Signed-off-by: Harvey Tuch <htuch@google.com>