### PR TITLE
tracing: add example for datadog

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -91,9 +91,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/googleapis/googleapis/archive/d6f78d948c53f3b400bb46996eb3084359914f9b.tar.gz"],
     ),
     com_github_datadog_dd_opentracing_cpp = dict(
-        sha256 = "733e9b698a232cfd3aa35b4e27c59641bf1fa78e52e71d29e230af4f2070cdf5",
-        strip_prefix = "dd-opentracing-cpp-0.3.5",
-        urls = ["https://github.com/DataDog/dd-opentracing-cpp/archive/v0.3.5.tar.gz"],
+        sha256 = "32967149fbc672f321ba6ce6c3e5cc299b15ab914f6f5b2993c7c9ddc1894439",
+        strip_prefix = "dd-opentracing-cpp-0.3.6",
+        urls = ["https://github.com/DataDog/dd-opentracing-cpp/archive/v0.3.6.tar.gz"],
     ),
     com_github_msgpack_msgpack_c = dict(
         sha256 = "bda49f996a73d2c6080ff0523e7b535917cd28c8a79c3a5da54fc29332d61d1e",

--- a/examples/datadog-tracing/docker-compose.yml
+++ b/examples/datadog-tracing/docker-compose.yml
@@ -1,0 +1,70 @@
+version: '2'
+services:
+
+  front-envoy:
+    depends_on:
+      - dd-agent
+    build:
+      context: ../front-proxy
+      dockerfile: Dockerfile-frontenvoy
+    volumes:
+      - ./front-envoy-datadog.yaml:/etc/front-envoy.yaml
+    networks:
+      - envoymesh
+    expose:
+      - "80"
+      - "8001"
+    ports:
+      - "8000:80"
+      - "8001:8001"
+
+  service1:
+    build:
+      context: ../front-proxy
+      dockerfile: Dockerfile-service
+    volumes:
+      - ./service1-envoy-datadog.yaml:/etc/service-envoy.yaml
+    networks:
+      envoymesh:
+        aliases:
+          - service1
+    environment:
+      - SERVICE_NAME=1
+      - TRACER=datadog
+      - DATADOG_TRACE_AGENT_HOSTNAME=dd-agent
+    expose:
+      - "80"
+
+  service2:
+    build:
+      context: ../front-proxy
+      dockerfile: Dockerfile-service
+    volumes:
+      - ./service2-envoy-datadog.yaml:/etc/service-envoy.yaml
+    networks:
+      envoymesh:
+        aliases:
+          - service2
+    environment:
+      - SERVICE_NAME=2
+      - TRACER=datadog
+      - DATADOG_TRACE_AGENT_HOSTNAME=dd-agent
+    expose:
+      - "80"
+
+  dd-agent:
+    image: datadog/agent:6.6.0
+    networks:
+      envoymesh:
+        aliases:
+          - dd-agent
+    environment:
+      - DD_API_KEY
+      - DD_APM_ENABLED=true
+      - DD_APM_NON_LOCAL_TRAFFIC=true
+    ports:
+      - "8125:8125/udp"
+      - "8126:8126"
+
+networks:
+  envoymesh: {}

--- a/examples/datadog-tracing/front-envoy-datadog.yaml
+++ b/examples/datadog-tracing/front-envoy-datadog.yaml
@@ -1,0 +1,60 @@
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          tracing:
+            operation_name: egress
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: backend
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: service1
+                decorator:
+                  operation: checkAvailability
+          http_filters:
+          - name: envoy.router
+            config: {}
+  clusters:
+  - name: service1
+    connect_timeout: 0.250s
+    type: strict_dns
+    lb_policy: round_robin
+    http2_protocol_options: {}
+    hosts:
+    - socket_address:
+        address: service1
+        port_value: 80
+  - name: datadog_agent
+    connect_timeout: 1s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: dd-agent
+        port_value: 8126
+tracing:
+  http:
+    name: envoy.tracers.datadog
+    config:
+      collector_cluster: datadog_agent
+      service_name: envoy-frontend
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/examples/datadog-tracing/service1-envoy-datadog.yaml
+++ b/examples/datadog-tracing/service1-envoy-datadog.yaml
@@ -1,0 +1,96 @@
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          tracing:
+            operation_name: ingress
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: service1_route
+            virtual_hosts:
+            - name: service1
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: local_service
+                decorator:
+                  operation: checkAvailability
+          http_filters:
+          - name: envoy.router
+            config: {}
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 9000
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          tracing:
+            operation_name: egress
+          codec_type: auto
+          stat_prefix: egress_http
+          route_config:
+            name: service2_route
+            virtual_hosts:
+            - name: service2
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/trace/2"
+                route:
+                  cluster: service2
+                decorator:
+                  operation: checkStock
+          http_filters:
+          - name: envoy.router
+            config: {}
+  clusters:
+  - name: local_service
+    connect_timeout: 0.250s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: 127.0.0.1
+        port_value: 8080
+  - name: service2
+    connect_timeout: 0.250s
+    type: strict_dns
+    lb_policy: round_robin
+    http2_protocol_options: {}
+    hosts:
+    - socket_address:
+        address: service2
+        port_value: 80
+  - name: datadog_agent
+    connect_timeout: 1s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: dd-agent
+        port_value: 8126
+tracing:
+  http:
+    name: envoy.tracers.datadog
+    config:
+      collector_cluster: datadog_agent
+      service_name: envoy-service1
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/examples/datadog-tracing/service2-envoy-datadog.yaml
+++ b/examples/datadog-tracing/service2-envoy-datadog.yaml
@@ -1,0 +1,59 @@
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          tracing:
+            operation_name: ingress
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: service2
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: local_service
+                decorator:
+                  operation: checkStock
+          http_filters:
+          - name: envoy.router
+            config: {}
+  clusters:
+  - name: local_service
+    connect_timeout: 0.250s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: 127.0.0.1
+        port_value: 8080
+  - name: datadog_agent
+    connect_timeout: 1s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: dd-agent
+        port_value: 8126
+tracing:
+  http:
+    name: envoy.tracers.datadog
+    config:
+      collector_cluster: datadog_agent
+      service_name: envoy-service2
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/examples/front-proxy/service.py
+++ b/examples/front-proxy/service.py
@@ -19,7 +19,12 @@ TRACE_HEADERS_TO_PROPAGATE = [
     'X-B3-Flags',
 
     # Jaeger header (for native client)
-    "uber-trace-id"
+    "uber-trace-id",
+
+    # Datadog headers
+    "X-Datadog-Trace-Id",
+    "X-Datadog-Parent-Id",
+    "X-Datadog-Sampling-Priority"
 ]
 
 @app.route('/service/<service_number>')

--- a/source/extensions/tracers/datadog/datadog_tracer_impl.cc
+++ b/source/extensions/tracers/datadog/datadog_tracer_impl.cc
@@ -34,6 +34,10 @@ Driver::Driver(const envoy::config::trace::v2::DatadogConfig& datadog_config,
   // Default tracer options.
   tracer_options_.operation_name_override = "envoy.proxy";
   tracer_options_.service = "envoy";
+  tracer_options_.inject = std::set<datadog::opentracing::PropagationStyle>{
+      datadog::opentracing::PropagationStyle::Datadog};
+  tracer_options_.extract = std::set<datadog::opentracing::PropagationStyle>{
+      datadog::opentracing::PropagationStyle::Datadog};
 
   // Configuration overrides for tracer options.
   if (!datadog_config.service_name().empty()) {


### PR DESCRIPTION
Signed-off-by: Caleb Gilmour <caleb.gilmour@datadoghq.com>

*Description*:
This adds an example for the datadog tracer extension that can be used as a reference for users wanting to configure it.
Also bumps dd-opentracing-cpp to v0.3.6, and enforces the propagation method.
Currently missing a README. 

*Risk Level*:
Low.

*Testing*:
E2E tests using docker-compose + curl.

*Docs Changes*:
TBD

*Release Notes*:
N/A
