### PR TITLE
docs: document rate limit name in http and network filter config

### DIFF
--- a/docs/root/configuration/http_filters/buffer_filter.rst
+++ b/docs/root/configuration/http_filters/buffer_filter.rst
@@ -8,6 +8,7 @@ This is useful in different situations including protecting some applications fr
 with partial requests and high network latency.
 
 * :ref:`v2 API reference <envoy_api_msg_config.filter.http.buffer.v2.Buffer>`
+* This filter should be configured with the name *envoy.buffer*.
 
 Per-Route Configuration
 -----------------------

--- a/docs/root/configuration/http_filters/cors_filter.rst
+++ b/docs/root/configuration/http_filters/cors_filter.rst
@@ -6,9 +6,10 @@ CORS
 This is a filter which handles Cross-Origin Resource Sharing requests based on route or virtual host settings.
 For the meaning of the headers please refer to the pages below.
 
-- https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
-- https://www.w3.org/TR/cors/
-- :ref:`v2 API reference <envoy_api_msg_route.CorsPolicy>`
+* https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
+* https://www.w3.org/TR/cors/
+* :ref:`v2 API reference <envoy_api_msg_route.CorsPolicy>`
+* This filter should be configured with the name *envoy.cors*.
 
 .. _cors-statistics:
 

--- a/docs/root/configuration/http_filters/dynamodb_filter.rst
+++ b/docs/root/configuration/http_filters/dynamodb_filter.rst
@@ -5,6 +5,7 @@ DynamoDB
 
 * DynamoDB :ref:`architecture overview <arch_overview_dynamo>`
 * :ref:`v2 API reference <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpFilter.name>`
+* This filter should be configured with the name *envoy.http_dynamo_filter*.
 
 Statistics
 ----------

--- a/docs/root/configuration/http_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/http_filters/ext_authz_filter.rst
@@ -4,6 +4,7 @@ External Authorization
 ======================
 * External authorization :ref:`architecture overview <arch_overview_ext_authz>`
 * :ref:`HTTP filter v2 API reference <envoy_api_msg_config.filter.http.ext_authz.v2alpha.ExtAuthz>`
+* This filter should be configured with the name *envoy.ext_authz*.
 
 The external authorization HTTP filter calls an external gRPC or HTTP service to check if the incoming
 HTTP request is authorized or not.

--- a/docs/root/configuration/http_filters/fault_filter.rst
+++ b/docs/root/configuration/http_filters/fault_filter.rst
@@ -33,8 +33,8 @@ Configuration
   The fault injection filter must be inserted before any other filter,
   including the router filter.
 
-* This filter should be configured with the name *envoy.fault*.
 * :ref:`v2 API reference <envoy_api_msg_config.filter.http.fault.v2.HTTPFault>`
+* This filter should be configured with the name *envoy.fault*.
 
 Runtime
 -------

--- a/docs/root/configuration/http_filters/fault_filter.rst
+++ b/docs/root/configuration/http_filters/fault_filter.rst
@@ -33,6 +33,7 @@ Configuration
   The fault injection filter must be inserted before any other filter,
   including the router filter.
 
+* This filter should be configured with the name *envoy.fault*.
 * :ref:`v2 API reference <envoy_api_msg_config.filter.http.fault.v2.HTTPFault>`
 
 Runtime

--- a/docs/root/configuration/http_filters/grpc_http1_bridge_filter.rst
+++ b/docs/root/configuration/http_filters/grpc_http1_bridge_filter.rst
@@ -5,6 +5,7 @@ gRPC HTTP/1.1 bridge
 
 * gRPC :ref:`architecture overview <arch_overview_grpc>`
 * :ref:`v2 API reference <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpFilter.name>`
+* This filter should be configured with the name *envoy.grpc_http1_bridge*.
 
 This is a simple filter which enables the bridging of an HTTP/1.1 client which does not support
 response trailers to a compliant gRPC server. It works by doing the following:

--- a/docs/root/configuration/http_filters/grpc_json_transcoder_filter.rst
+++ b/docs/root/configuration/http_filters/grpc_json_transcoder_filter.rst
@@ -5,6 +5,7 @@ gRPC-JSON transcoder
 
 * gRPC :ref:`architecture overview <arch_overview_grpc>`
 * :ref:`v2 API reference <envoy_api_msg_config.filter.http.transcoder.v2.GrpcJsonTranscoder>`
+* This filter should be configured with the name *envoy.grpc_json_transcoder*.
 
 This is a filter which allows a RESTful JSON API client to send requests to Envoy over HTTP
 and get proxied to a gRPC service. The HTTP mapping for the gRPC service has to be defined by

--- a/docs/root/configuration/http_filters/grpc_web_filter.rst
+++ b/docs/root/configuration/http_filters/grpc_web_filter.rst
@@ -5,6 +5,7 @@ gRPC-Web
 
 * gRPC :ref:`architecture overview <arch_overview_grpc>`
 * :ref:`v2 API reference <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpFilter.name>`
+* This filter should be configured with the name *envoy.grpc_web*.
 
 This is a filter which enables the bridging of a gRPC-Web client to a compliant gRPC server by
 following https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md.

--- a/docs/root/configuration/http_filters/gzip_filter.rst
+++ b/docs/root/configuration/http_filters/gzip_filter.rst
@@ -10,6 +10,7 @@ compromising the response time.
 Configuration
 -------------
 * :ref:`v2 API reference <envoy_api_msg_config.filter.http.gzip.v2.Gzip>`
+* This filter should be configured with the name *envoy.gzip*.
 
 .. attention::
 

--- a/docs/root/configuration/http_filters/header_to_metadata_filter.rst
+++ b/docs/root/configuration/http_filters/header_to_metadata_filter.rst
@@ -3,6 +3,7 @@
 Envoy Header-To-Metadata Filter
 ===============================
 * :ref:`v2 API reference <envoy_api_msg_config.filter.http.header_to_metadata.v2.Config>`
+* This filter should be configured with the name *envoy.filters.http.header_to_metadata*.
 
 This filter is configured with rules that will be matched against requests and responses.
 Each rule has a header and can be triggered either when the header is present or missing. When

--- a/docs/root/configuration/http_filters/health_check_filter.rst
+++ b/docs/root/configuration/http_filters/health_check_filter.rst
@@ -5,6 +5,7 @@ Health check
 
 * Health check filter :ref:`architecture overview <arch_overview_health_checking_filter>`
 * :ref:`v2 API reference <envoy_api_msg_config.filter.http.health_check.v2.HealthCheck>`
+* This filter should be configured with the name *envoy.health_check*.
 
 .. note::
 

--- a/docs/root/configuration/http_filters/ip_tagging_filter.rst
+++ b/docs/root/configuration/http_filters/ip_tagging_filter.rst
@@ -17,6 +17,7 @@ G. Karlsson.
 Configuration
 -------------
 * :ref:`v2 API reference <envoy_api_msg_config.filter.http.ip_tagging.v2.IPTagging>`
+* This filter should be configured with the name *envoy.ip_tagging*.
 
 Statistics
 ----------

--- a/docs/root/configuration/http_filters/jwt_authn_filter.rst
+++ b/docs/root/configuration/http_filters/jwt_authn_filter.rst
@@ -13,6 +13,8 @@ JWKS is needed to verify JWT signatures. They can be specified in the filter con
 Configuration
 -------------
 
+This filter should be configured with the name *envoy.filters.http.jwt_authn*.
+
 This HTTP :ref:`filter config <envoy_api_msg_config.filter.http.jwt_authn.v2alpha.JwtAuthentication>` has two fields:
 
 * Field *providers* specifies how a JWT should be verified, such as where to extract the token, where to fetch the public key (JWKS) and where to output its payload.

--- a/docs/root/configuration/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http_filters/lua_filter.rst
@@ -55,6 +55,7 @@ Configuration
 -------------
 
 * :ref:`v2 API reference <envoy_api_msg_config.filter.http.lua.v2.Lua>`
+* This filter should be configured with the name *envoy.lua*.
 
 Script examples
 ---------------

--- a/docs/root/configuration/http_filters/rate_limit_filter.rst
+++ b/docs/root/configuration/http_filters/rate_limit_filter.rst
@@ -5,6 +5,7 @@ Rate limit
 
 * Global rate limiting :ref:`architecture overview <arch_overview_rate_limit>`
 * :ref:`v2 API reference <envoy_api_msg_config.filter.http.rate_limit.v2.RateLimit>`
+* This filter should be configured with the name *envoy.rate_limit*.
 
 The HTTP rate limit filter will call the rate limit service when the request's route or virtual host
 has one or more :ref:`rate limit configurations<envoy_api_field_route.VirtualHost.rate_limits>`

--- a/docs/root/configuration/http_filters/rbac_filter.rst
+++ b/docs/root/configuration/http_filters/rbac_filter.rst
@@ -12,6 +12,7 @@ and shadow mode, shadow mode won't effect real users, it is used to test that a 
 work before rolling out to production.
 
 * :ref:`v2 API reference <envoy_api_msg_config.filter.http.rbac.v2.RBAC>`
+* This filter should be configured with the name *envoy.filters.http.rbac*.
 
 Per-Route Configuration
 -----------------------

--- a/docs/root/configuration/http_filters/router_filter.rst
+++ b/docs/root/configuration/http_filters/router_filter.rst
@@ -9,6 +9,7 @@ configured :ref:`route table <envoy_api_msg_RouteConfiguration>`. In addition to
 redirection, the filter also handles retry, statistics, etc.
 
 * :ref:`v2 API reference <envoy_api_msg_config.filter.http.router.v2.Router>`
+* This filter should be configured with the name *envoy.router*.
 
 .. _config_http_filters_router_headers_consumed:
 

--- a/docs/root/configuration/http_filters/squash_filter.rst
+++ b/docs/root/configuration/http_filters/squash_filter.rst
@@ -21,6 +21,7 @@ Configuration
 -------------
 
 * :ref:`v2 API reference <envoy_api_msg_config.filter.http.squash.v2.Squash>`
+* This filter should be configured with the name *envoy.squash*.
 
 How it works
 ------------

--- a/docs/root/configuration/listener_filters/original_dst_filter.rst
+++ b/docs/root/configuration/listener_filters/original_dst_filter.rst
@@ -12,3 +12,4 @@ destination cluster <arch_overview_service_discovery_types_original_destination>
 forward HTTP requests or TCP connections to the restored destination address.
 
 * :ref:`v2 API reference <envoy_api_field_listener.Filter.name>`
+* This filter should be configured with the name *envoy.listener.original_dst*.

--- a/docs/root/configuration/listener_filters/proxy_protocol.rst
+++ b/docs/root/configuration/listener_filters/proxy_protocol.rst
@@ -23,5 +23,5 @@ the standard does not allow parsing to determine if it is present or not.
 If there is a protocol error or an unsupported address family
 (e.g. AF_UNIX) the connection will be closed and an error thrown.
 
-* This filter should be configured with the name *envoy.listener.tls_inspector*.
 * :ref:`v2 API reference <envoy_api_field_listener.Filter.name>`
+* This filter should be configured with the name *envoy.listener.tls_inspector*.

--- a/docs/root/configuration/listener_filters/proxy_protocol.rst
+++ b/docs/root/configuration/listener_filters/proxy_protocol.rst
@@ -23,4 +23,5 @@ the standard does not allow parsing to determine if it is present or not.
 If there is a protocol error or an unsupported address family
 (e.g. AF_UNIX) the connection will be closed and an error thrown.
 
+* This filter should be configured with the name *envoy.listener.tls_inspector*.
 * :ref:`v2 API reference <envoy_api_field_listener.Filter.name>`

--- a/docs/root/configuration/listener_filters/tls_inspector.rst
+++ b/docs/root/configuration/listener_filters/tls_inspector.rst
@@ -14,5 +14,6 @@ from the client. This can be used to select a
 :ref:`application_protocols <envoy_api_field_listener.FilterChainMatch.application_protocols>`
 of a :ref:`FilterChainMatch <envoy_api_msg_listener.FilterChainMatch>`.
 
+* This filter should be configured with the name *envoy.listener.proxy_protocol*.
 * :ref:`SNI <faq_how_to_setup_sni>`
 * :ref:`v2 API reference <envoy_api_field_listener.ListenerFilter.name>`

--- a/docs/root/configuration/network_filters/client_ssl_auth_filter.rst
+++ b/docs/root/configuration/network_filters/client_ssl_auth_filter.rst
@@ -5,6 +5,7 @@ Client TLS authentication
 
 * Client TLS authentication filter :ref:`architecture overview <arch_overview_ssl_auth_filter>`
 * :ref:`v2 API reference <envoy_api_msg_config.filter.network.client_ssl_auth.v2.ClientSslAuth>`
+* This filter should be configured with the name *envoy.client_ssl_auth*.
 
 .. _config_network_filters_client_ssl_auth_stats:
 

--- a/docs/root/configuration/network_filters/echo_filter.rst
+++ b/docs/root/configuration/network_filters/echo_filter.rst
@@ -4,7 +4,7 @@ Echo
 ====
 
 The echo is a trivial network filter mainly meant to demonstrate the network filter API. If
-installed it will echo (write) all received data back to the connected downstream client.  
+installed it will echo (write) all received data back to the connected downstream client. 
 This filter should be configured with the name *envoy.echo*.
 
 * :ref:`v2 API reference <envoy_api_field_listener.Filter.name>`

--- a/docs/root/configuration/network_filters/echo_filter.rst
+++ b/docs/root/configuration/network_filters/echo_filter.rst
@@ -4,6 +4,7 @@ Echo
 ====
 
 The echo is a trivial network filter mainly meant to demonstrate the network filter API. If
-installed it will echo (write) all received data back to the connected downstream client.
+installed it will echo (write) all received data back to the connected downstream client.  
+This filter should be configured with the name *envoy.echo*.
 
 * :ref:`v2 API reference <envoy_api_field_listener.Filter.name>`

--- a/docs/root/configuration/network_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/network_filters/ext_authz_filter.rst
@@ -5,6 +5,7 @@ External Authorization
 
 * External authorization :ref:`architecture overview <arch_overview_ext_authz>`
 * :ref:`Network filter v2 API reference <envoy_api_msg_config.filter.network.ext_authz.v2.ExtAuthz>`
+* This filter should be configured with the name *envoy.ext_authz*.
 
 The external authorization network filter calls an external authorization service to check if the
 incoming request is authorized or not. If the request is deemed unauthorized by the network filter

--- a/docs/root/configuration/network_filters/mongo_proxy_filter.rst
+++ b/docs/root/configuration/network_filters/mongo_proxy_filter.rst
@@ -3,8 +3,9 @@
 Mongo proxy
 ===========
 
-- MongoDB :ref:`architecture overview <arch_overview_mongo>`
-- :ref:`v2 API reference <envoy_api_msg_config.filter.network.mongo_proxy.v2.MongoProxy>`
+* MongoDB :ref:`architecture overview <arch_overview_mongo>`
+* :ref:`v2 API reference <envoy_api_msg_config.filter.network.mongo_proxy.v2.MongoProxy>`
+* This filter should be configured with the name *envoy.mongo_proxy*.
 
 .. _config_network_filters_mongo_proxy_fault_injection:
 

--- a/docs/root/configuration/network_filters/rate_limit_filter.rst
+++ b/docs/root/configuration/network_filters/rate_limit_filter.rst
@@ -5,6 +5,7 @@ Rate limit
 
 * Global rate limiting :ref:`architecture overview <arch_overview_rate_limit>`
 * :ref:`v2 API reference <envoy_api_msg_config.filter.network.rate_limit.v2.RateLimit>`
+* This filter should be configured with the name *envoy.ratelimit*.
 
 .. _config_network_filters_rate_limit_stats:
 

--- a/docs/root/configuration/network_filters/rbac_filter.rst
+++ b/docs/root/configuration/network_filters/rbac_filter.rst
@@ -11,6 +11,7 @@ This filter also supports policy in both enforcement and shadow modes. Shadow mo
 users, it is used to test that a new set of policies work before rolling out to production.
 
 * :ref:`v2 API reference <envoy_api_msg_config.filter.network.rbac.v2.RBAC>`
+* This filter should be configured with the name *envoy.filters.network.rbac*.
 
 Statistics
 ----------

--- a/docs/root/configuration/network_filters/redis_proxy_filter.rst
+++ b/docs/root/configuration/network_filters/redis_proxy_filter.rst
@@ -5,6 +5,7 @@ Redis proxy
 
 * Redis :ref:`architecture overview <arch_overview_redis>`
 * :ref:`v2 API reference <envoy_api_msg_config.filter.network.redis_proxy.v2.RedisProxy>`
+* This filter should be configured with the name *envoy.redis_proxy*.
 
 .. _config_network_filters_redis_proxy_stats:
 

--- a/docs/root/configuration/network_filters/sni_cluster_filter.rst
+++ b/docs/root/configuration/network_filters/sni_cluster_filter.rst
@@ -5,7 +5,8 @@ Upstream Cluster from SNI
 
 The `sni_cluster` is a network filter that uses the SNI value in a TLS
 connection as the upstream cluster name. The filter will not modify the
-upstream cluster for non-TLS connections.
+upstream cluster for non-TLS connections. This filter should be configured 
+with the name *envoy.filters.network.sni_cluster*.
 
 This filter has no configuration. It must be installed before the
 :ref:`tcp_proxy <config_network_filters_tcp_proxy>` filter.

--- a/docs/root/configuration/network_filters/tcp_proxy_filter.rst
+++ b/docs/root/configuration/network_filters/tcp_proxy_filter.rst
@@ -5,6 +5,7 @@ TCP proxy
 
 * TCP proxy :ref:`architecture overview <arch_overview_tcp_proxy>`
 * :ref:`v2 API reference <envoy_api_msg_config.filter.network.tcp_proxy.v2.TcpProxy>`
+* This filter should be configured with the name *envoy.tcp_proxy*.
 
 .. _config_network_filters_tcp_proxy_dynamic_cluster:
 

--- a/docs/root/configuration/network_filters/thrift_proxy_filter.rst
+++ b/docs/root/configuration/network_filters/thrift_proxy_filter.rst
@@ -4,6 +4,7 @@ Thrift proxy
 ============
 
 * :ref:`v2 API reference <envoy_api_msg_config.filter.network.thrift_proxy.v2alpha1.ThriftProxy>`
+* This filter should be configured with the name *envoy.filters.network.thrift_proxy*.
 
 Cluster Protocol Options
 ------------------------

--- a/source/extensions/filters/network/well_known_names.h
+++ b/source/extensions/filters/network/well_known_names.h
@@ -23,7 +23,7 @@ public:
   // Mongo proxy filter
   const std::string MongoProxy = "envoy.mongo_proxy";
   // Rate limit filter
-  const std::string RateLimit = "envoy.rate_limit";
+  const std::string RateLimit = "envoy.ratelimit";
   // Redis proxy filter
   const std::string RedisProxy = "envoy.redis_proxy";
   // IP tagging filter

--- a/source/extensions/filters/network/well_known_names.h
+++ b/source/extensions/filters/network/well_known_names.h
@@ -23,7 +23,7 @@ public:
   // Mongo proxy filter
   const std::string MongoProxy = "envoy.mongo_proxy";
   // Rate limit filter
-  const std::string RateLimit = "envoy.ratelimit";
+  const std::string RateLimit = "envoy.rate_limit";
   // Redis proxy filter
   const std::string RedisProxy = "envoy.redis_proxy";
   // IP tagging filter


### PR DESCRIPTION
Signed-off-by: Rama Chavali <rama.rao@salesforce.com>
*Description*: Rate limit filter name is inconsistent in network filters well known names. This PR documents the names.
*Risk Level*: Low
*Testing*: Existing tests
*Docs Changes*: N/A
*Release Notes*: N/A

