### PR TITLE
repokitteh.md: fix spelling mistake

### DIFF
--- a/source/docs/repokitteh.md
+++ b/source/docs/repokitteh.md
@@ -37,7 +37,7 @@ Only organization members can assign or unassign other users, who must be organi
 [Demo PR](https://github.com/envoyproxy/envoybot/pull/6)
 
 ### [Review](https://github.com/repokitteh/modules/blob/master/review.star)
-Requests a a user to recview a pull request.
+Requests a a user to review a pull request.
 
 Examples:
 ```


### PR DESCRIPTION
Signed-off-by: Itay Donanhirsh itay@bazoo.org

*Description*:
Fix silly spelling mistake.

*Risk Level*:
None.

*Testing*:
N/A

*Docs Changes*:
N/A

*Release Notes*:
N/A
