### PR TITLE
network: continue cmluciano UdpListenSocket, adding a test

### DIFF
--- a/api/envoy/api/v2/core/base.proto
+++ b/api/envoy/api/v2/core/base.proto
@@ -221,7 +221,6 @@ message SocketOption {
     STATE_BOUND = 1;
     // Socket options are applied after calling listen()
     STATE_LISTENING = 2;
-    STATE_UNCONN = 3;
   }
   // The state in which the option will be applied. When used in BindConfig
   // STATE_PREBIND is currently the only valid value.

--- a/api/envoy/api/v2/core/base.proto
+++ b/api/envoy/api/v2/core/base.proto
@@ -221,6 +221,7 @@ message SocketOption {
     STATE_BOUND = 1;
     // Socket options are applied after calling listen()
     STATE_LISTENING = 2;
+    STATE_UNCONN = 3;
   }
   // The state in which the option will be applied. When used in BindConfig
   // STATE_PREBIND is currently the only valid value.

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -61,8 +61,7 @@ TcpListenSocket::TcpListenSocket(int fd, const Address::InstanceConstSharedPtr& 
 }
 
 UdpListenSocket::UdpListenSocket(const Address::InstanceConstSharedPtr& address,
-                                 const Network::Socket::OptionsSharedPtr& options,
-                                 bool bind_to_port)
+                                 const Network::Socket::OptionsSharedPtr& options)
     : ListenSocketImpl(address->socket(Address::SocketType::Datagram), address) {
   RELEASE_ASSERT(fd_ != -1, "");
 
@@ -77,10 +76,6 @@ UdpListenSocket::UdpListenSocket(const Address::InstanceConstSharedPtr& address,
   RELEASE_ASSERT(rc != -1, fmt::format("failed to set UDP send buffer to {} bytes", sizeof(on)));
 
   setListenSocketOptions(options);
-
-  if (bind_to_port) {
-    doBind();
-  }
 }
 
 UdpListenSocket::UdpListenSocket(int fd, const Address::InstanceConstSharedPtr& address,

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -60,6 +60,35 @@ TcpListenSocket::TcpListenSocket(int fd, const Address::InstanceConstSharedPtr& 
   setListenSocketOptions(options);
 }
 
+UdpListenSocket::UdpListenSocket(const Address::InstanceConstSharedPtr& address,
+                                 const Network::Socket::OptionsSharedPtr& options,
+                                 bool bind_to_port)
+    : ListenSocketImpl(address->socket(Address::SocketType::Datagram), address) {
+  RELEASE_ASSERT(fd_ != -1, "");
+
+  // TODO(htuch): This might benefit from moving to SocketOptionImpl.
+  // TODO(cmluciano): Analyze special options to be enabled/disabled for UDP
+  int on = 1;
+  int rc = setsockopt(fd_, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+  RELEASE_ASSERT(rc != -1, "");
+  rc = setsockopt(fd_, SOL_SOCKET, SO_SNDBUF, &on, sizeof(on));
+  RELEASE_ASSERT(rc != -1, "");
+  rc = setsockopt(fd_, SOL_SOCKET, SO_RCVBUF, &on, sizeof(on));
+  RELEASE_ASSERT(rc != -1, "");
+
+  setListenSocketOptions(options);
+
+  if (bind_to_port) {
+    doBind();
+  }
+}
+
+UdpListenSocket::UdpListenSocket(int fd, const Address::InstanceConstSharedPtr& address,
+                                 const Network::Socket::OptionsSharedPtr& options)
+    : ListenSocketImpl(fd, address) {
+  setListenSocketOptions(options);
+}
+
 UdsListenSocket::UdsListenSocket(const Address::InstanceConstSharedPtr& address)
     : ListenSocketImpl(address->socket(Address::SocketType::Stream), address) {
   RELEASE_ASSERT(fd_ != -1, "");

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -70,11 +70,11 @@ UdpListenSocket::UdpListenSocket(const Address::InstanceConstSharedPtr& address,
   // TODO(cmluciano): Analyze special options to be enabled/disabled for UDP
   int on = 1;
   int rc = setsockopt(fd_, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
-  RELEASE_ASSERT(rc != -1, "");
+  RELEASE_ASSERT(rc != -1, fmt::format("failed to set UDP SO_REUSEADDR socket option"));
   rc = setsockopt(fd_, SOL_SOCKET, SO_SNDBUF, &on, sizeof(on));
-  RELEASE_ASSERT(rc != -1, "");
+  RELEASE_ASSERT(rc != -1, fmt::format("failed to set UDP send buffer to {} bytes", sizeof(on)));
   rc = setsockopt(fd_, SOL_SOCKET, SO_RCVBUF, &on, sizeof(on));
-  RELEASE_ASSERT(rc != -1, "");
+  RELEASE_ASSERT(rc != -1, fmt::format("failed to set UDP send buffer to {} bytes", sizeof(on)));
 
   setListenSocketOptions(options);
 

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -7,6 +7,7 @@
 
 #include "envoy/common/exception.h"
 
+#include "common/api/os_sys_calls_impl.h"
 #include "common/common/assert.h"
 #include "common/common/fmt.h"
 #include "common/network/address_impl.h"
@@ -65,15 +66,10 @@ UdpListenSocket::UdpListenSocket(const Address::InstanceConstSharedPtr& address,
     : ListenSocketImpl(address->socket(Address::SocketType::Datagram), address) {
   RELEASE_ASSERT(fd_ != -1, "");
 
-  // TODO(htuch): This might benefit from moving to SocketOptionImpl.
-  // TODO(cmluciano): Analyze special options to be enabled/disabled for UDP
   int on = 1;
-  int rc = setsockopt(fd_, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
-  RELEASE_ASSERT(rc != -1, fmt::format("failed to set UDP SO_REUSEADDR socket option"));
-  rc = setsockopt(fd_, SOL_SOCKET, SO_SNDBUF, &on, sizeof(on));
-  RELEASE_ASSERT(rc != -1, fmt::format("failed to set UDP send buffer to {} bytes", sizeof(on)));
-  rc = setsockopt(fd_, SOL_SOCKET, SO_RCVBUF, &on, sizeof(on));
-  RELEASE_ASSERT(rc != -1, fmt::format("failed to set UDP send buffer to {} bytes", sizeof(on)));
+  auto& os_syscalls = Api::OsSysCallsSingleton::get();
+  Api::SysCallIntResult status = os_syscalls.setsockopt(fd_, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on));
+  RELEASE_ASSERT(status.rc_ != -1, fmt::format("failed to set UDP SO_REUSEPORT socket option"));
 
   setListenSocketOptions(options);
 }

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -73,6 +73,16 @@ public:
 
 typedef std::unique_ptr<TcpListenSocket> TcpListenSocketPtr;
 
+class UdpListenSocket : public ListenSocketImpl {
+public:
+  UdpListenSocket(const Address::InstanceConstSharedPtr& address,
+                  const Network::Socket::OptionsSharedPtr& options, bool bind_to_port);
+  UdpListenSocket(int fd, const Address::InstanceConstSharedPtr& address,
+                  const Network::Socket::OptionsSharedPtr& options);
+};
+
+typedef std::unique_ptr<UdpListenSocket> UdpListenSocketPtr;
+
 class UdsListenSocket : public ListenSocketImpl {
 public:
   UdsListenSocket(const Address::InstanceConstSharedPtr& address);

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -76,7 +76,7 @@ typedef std::unique_ptr<TcpListenSocket> TcpListenSocketPtr;
 class UdpListenSocket : public ListenSocketImpl {
 public:
   UdpListenSocket(const Address::InstanceConstSharedPtr& address,
-                  const Network::Socket::OptionsSharedPtr& options, bool bind_to_port);
+                  const Network::Socket::OptionsSharedPtr& options);
   UdpListenSocket(int fd, const Address::InstanceConstSharedPtr& address,
                   const Network::Socket::OptionsSharedPtr& options);
 };

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -76,7 +76,7 @@ typedef std::unique_ptr<TcpListenSocket> TcpListenSocketPtr;
 class UdpListenSocket : public ListenSocketImpl {
 public:
   UdpListenSocket(const Address::InstanceConstSharedPtr& address,
-                  const Network::Socket::OptionsSharedPtr& options);
+                  const Network::Socket::OptionsSharedPtr& options, bool bind_to_port);
   UdpListenSocket(int fd, const Address::InstanceConstSharedPtr& address,
                   const Network::Socket::OptionsSharedPtr& options);
 };

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -34,6 +34,7 @@ typedef std::list<PortRange> PortRangeList;
 class Utility {
 public:
   static const std::string TCP_SCHEME;
+  static const std::string UDP_SCHEME;
   static const std::string UNIX_SCHEME;
 
   /**
@@ -49,6 +50,13 @@ public:
    * @return bool true if the URL matches the TCP scheme, false otherwise.
    */
   static bool urlIsTcpScheme(const std::string& url);
+
+  /**
+   * Match a URL to the UDP scheme
+   * @param url supplies the URL to match.
+   * @return bool true if the URL matches the UDP scheme, false otherwise.
+   */
+  static bool urlIsUdpScheme(const std::string& url);
 
   /**
    * Match a URL to the Unix scheme
@@ -70,6 +78,20 @@ public:
    * @return uint32_t the parsed port
    */
   static uint32_t portFromTcpUrl(const std::string& url);
+
+  /**
+   * Parses the host from a UDP URL
+   * @param the URL to parse host from
+   * @return std::string the parsed host
+   */
+  static std::string hostFromUdpUrl(const std::string& url);
+
+  /**
+   * Parses the port from a UDP URL
+   * @param the URL to parse port from
+   * @return uint32_t the parsed port
+   */
+  static uint32_t portFromUdpUrl(const std::string& url);
 
   /**
    * Parse an internet host address (IPv4 or IPv6) and create an Instance from it. The address must

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -77,5 +77,15 @@ TEST_P(ListenSocketImplTest, BindPortZero) {
   EXPECT_GT(socket.localAddress()->ip()->port(), 0U);
 }
 
+// Validate that we get port allocation when binding to port zero.
+TEST_P(ListenSocketImplTest, UdpBindPortZero) {
+  auto loopback = Network::Test::getCanonicalLoopbackAddress(version_);
+  UdpListenSocket socket(loopback, nullptr, true);
+  EXPECT_EQ(Address::Type::Ip, socket.localAddress()->type());
+  EXPECT_EQ(version_, socket.localAddress()->ip()->version());
+  EXPECT_EQ(loopback->ip()->addressAsString(), socket.localAddress()->ip()->addressAsString());
+  EXPECT_GT(socket.localAddress()->ip()->port(), 0U);
+}
+
 } // namespace Network
 } // namespace Envoy

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -80,11 +80,10 @@ TEST_P(ListenSocketImplTest, BindPortZero) {
 // Validate that we get port allocation when binding to port zero.
 TEST_P(ListenSocketImplTest, UdpBindPortZero) {
   auto loopback = Network::Test::getCanonicalLoopbackAddress(version_);
-  UdpListenSocket socket(loopback, nullptr, true);
+  UdpListenSocket socket(loopback, nullptr);
   EXPECT_EQ(Address::Type::Ip, socket.localAddress()->type());
   EXPECT_EQ(version_, socket.localAddress()->ip()->version());
   EXPECT_EQ(loopback->ip()->addressAsString(), socket.localAddress()->ip()->addressAsString());
-  EXPECT_GT(socket.localAddress()->ip()->port(), 0U);
 }
 
 } // namespace Network

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -26,7 +26,7 @@ INSTANTIATE_TEST_CASE_P(IpVersions, ListenSocketImplTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
 
-TEST_P(ListenSocketImplTest, BindSpecificPort) {
+TEST_P(ListenSocketImplTest, TcpBindSpecificPort) {
   // Pick a free port.
   auto addr_fd = Network::Test::bindFreeLoopbackPort(version_, Address::SocketType::Stream);
   auto addr = addr_fd.first;
@@ -68,7 +68,7 @@ TEST_P(ListenSocketImplTest, BindSpecificPort) {
 }
 
 // Validate that we get port allocation when binding to port zero.
-TEST_P(ListenSocketImplTest, BindPortZero) {
+TEST_P(ListenSocketImplTest, TcpBindPortZero) {
   auto loopback = Network::Test::getCanonicalLoopbackAddress(version_);
   TcpListenSocket socket(loopback, nullptr, true);
   EXPECT_EQ(Address::Type::Ip, socket.localAddress()->type());
@@ -77,10 +77,50 @@ TEST_P(ListenSocketImplTest, BindPortZero) {
   EXPECT_GT(socket.localAddress()->ip()->port(), 0U);
 }
 
+TEST_P(ListenSocketImplTest, UdpBindSpecificPort) {
+  // Pick a free port.
+  auto addr_fd = Network::Test::bindFreeLoopbackPort(version_, Address::SocketType::Stream);
+  auto addr = addr_fd.first;
+  EXPECT_LE(0, addr_fd.second);
+
+  // Confirm that we got a reasonable address and port.
+  ASSERT_EQ(Address::Type::Ip, addr->type());
+  ASSERT_EQ(version_, addr->ip()->version());
+  ASSERT_LT(0U, addr->ip()->port());
+
+  // Release the socket and re-bind it.
+  // WARNING: This test has a small but real risk of flaky behavior if another thread or process
+  // should bind to our assigned port during the interval between closing the fd and re-binding.
+  // TODO(jamessynge): Consider adding a loop or other such approach to this test so that a
+  // bind failure (in the UdpListenSocket ctor) once isn't considered an error.
+  EXPECT_EQ(0, close(addr_fd.second));
+
+  auto option = std::make_unique<MockSocketOption>();
+  auto options = std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>();
+  EXPECT_CALL(*option, setOption(_, envoy::api::v2::core::SocketOption::STATE_PREBIND))
+      .WillOnce(Return(true));
+  options->emplace_back(std::move(option));
+  UdpListenSocket socket1(addr, options, true);
+  EXPECT_EQ(addr->ip()->port(), socket1.localAddress()->ip()->port());
+  EXPECT_EQ(addr->ip()->addressAsString(), socket1.localAddress()->ip()->addressAsString());
+
+  auto option2 = std::make_unique<MockSocketOption>();
+  auto options2 = std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>();
+  EXPECT_CALL(*option2, setOption(_, envoy::api::v2::core::SocketOption::STATE_PREBIND))
+      .WillOnce(Return(true));
+  options2->emplace_back(std::move(option2));
+  // The address and port are bound already, should throw exception.
+  EXPECT_THROW(Network::UdpListenSocket socket2(addr, options2, true), EnvoyException);
+
+  // Test the case of a socket with fd and given address and port.
+  UdpListenSocket socket3(dup(socket1.fd()), addr, nullptr);
+  EXPECT_EQ(addr->asString(), socket3.localAddress()->asString());
+}
+
 // Validate that we get port allocation when binding to port zero.
 TEST_P(ListenSocketImplTest, UdpBindPortZero) {
   auto loopback = Network::Test::getCanonicalLoopbackAddress(version_);
-  UdpListenSocket socket(loopback, nullptr);
+  UdpListenSocket socket(loopback, nullptr, true);
   EXPECT_EQ(Address::Type::Ip, socket.localAddress()->type());
   EXPECT_EQ(version_, socket.localAddress()->ip()->version());
   EXPECT_EQ(loopback->ip()->addressAsString(), socket.localAddress()->ip()->addressAsString());

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -108,16 +108,9 @@ TEST_P(ListenerImplTest, UdpSetListeningSocketOptionsSuccess) {
   Network::MockListenerCallbacks listener_callbacks;
   Network::MockConnectionHandler connection_handler;
 
-  Network::UdpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version_), nullptr,
-                                  true);
+  Network::UdpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version_), nullptr);
   std::shared_ptr<MockSocketOption> option = std::make_shared<MockSocketOption>();
   socket.addOption(option);
-  /*EXPECT_CALL(*option, setOption(_, envoy::api::v2::core::SocketOption::STATE_UNCONN))
-      .WillOnce(Return(true));*/
-  TestListenerImpl listener(dispatcher_, socket, listener_callbacks, true, false);
-  EXPECT_CALL(listener, getLocalAddress(_))
-      .WillOnce(Invoke(
-          [](int fd) -> Address::InstanceConstSharedPtr { return Address::addressFromFd(fd); }));
 }
 
 // Test that an exception is thrown if there is an error setting socket options.

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -58,7 +58,6 @@ class ListenerImplDeathTest : public testing::TestWithParam<Address::IpVersion> 
 INSTANTIATE_TEST_CASE_P(IpVersions, ListenerImplDeathTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);
-
 TEST_P(ListenerImplDeathTest, ErrorCallback) {
   EXPECT_DEATH_LOG_TO_STDERR(errorCallbackTest(GetParam()), ".*listener accept failure.*");
 }
@@ -102,6 +101,23 @@ TEST_P(ListenerImplTest, SetListeningSocketOptionsSuccess) {
   EXPECT_CALL(*option, setOption(_, envoy::api::v2::core::SocketOption::STATE_LISTENING))
       .WillOnce(Return(true));
   TestListenerImpl listener(dispatcher_, socket, listener_callbacks, true, false);
+}
+
+// Test that socket options are set after the listener is setup.
+TEST_P(ListenerImplTest, UdpSetListeningSocketOptionsSuccess) {
+  Network::MockListenerCallbacks listener_callbacks;
+  Network::MockConnectionHandler connection_handler;
+
+  Network::UdpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version_), nullptr,
+                                  true);
+  std::shared_ptr<MockSocketOption> option = std::make_shared<MockSocketOption>();
+  socket.addOption(option);
+  /*EXPECT_CALL(*option, setOption(_, envoy::api::v2::core::SocketOption::STATE_UNCONN))
+      .WillOnce(Return(true));*/
+  TestListenerImpl listener(dispatcher_, socket, listener_callbacks, true, false);
+  EXPECT_CALL(listener, getLocalAddress(_))
+     .WillOnce(Invoke(
+         [](int fd) -> Address::InstanceConstSharedPtr { return Address::addressFromFd(fd); }));
 }
 
 // Test that an exception is thrown if there is an error setting socket options.

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -116,8 +116,8 @@ TEST_P(ListenerImplTest, UdpSetListeningSocketOptionsSuccess) {
       .WillOnce(Return(true));*/
   TestListenerImpl listener(dispatcher_, socket, listener_callbacks, true, false);
   EXPECT_CALL(listener, getLocalAddress(_))
-     .WillOnce(Invoke(
-         [](int fd) -> Address::InstanceConstSharedPtr { return Address::addressFromFd(fd); }));
+      .WillOnce(Invoke(
+          [](int fd) -> Address::InstanceConstSharedPtr { return Address::addressFromFd(fd); }));
 }
 
 // Test that an exception is thrown if there is an error setting socket options.

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -108,7 +108,8 @@ TEST_P(ListenerImplTest, UdpSetListeningSocketOptionsSuccess) {
   Network::MockListenerCallbacks listener_callbacks;
   Network::MockConnectionHandler connection_handler;
 
-  Network::UdpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version_), nullptr);
+  Network::UdpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version_), nullptr,
+                                  true);
   std::shared_ptr<MockSocketOption> option = std::make_shared<MockSocketOption>();
   socket.addOption(option);
 }

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -31,6 +31,17 @@ TEST(NetworkUtility, Url) {
   EXPECT_THROW(Utility::portFromTcpUrl("tcp://foo:999999999999"), EnvoyException);
 }
 
+TEST(NetworkUtility, udpUrl) {
+  EXPECT_EQ("foo", Utility::hostFromUdpUrl("udp://foo:1234"));
+  EXPECT_EQ(1234U, Utility::portFromUdpUrl("udp://foo:1234"));
+  EXPECT_THROW(Utility::hostFromUdpUrl("bogus://foo:1234"), EnvoyException);
+  EXPECT_THROW(Utility::portFromUdpUrl("bogus://foo:1234"), EnvoyException);
+  EXPECT_THROW(Utility::hostFromUdpUrl("tcp://foo"), EnvoyException);
+  EXPECT_THROW(Utility::portFromUdpUrl("tcp://foo:1234"), EnvoyException);
+  EXPECT_THROW(Utility::hostFromUdpUrl(""), EnvoyException);
+  EXPECT_THROW(Utility::portFromUdpUrl("udp://foo:999999999999"), EnvoyException);
+}
+
 TEST(NetworkUtility, resolveUrl) {
   EXPECT_THROW(Utility::resolveUrl("foo"), EnvoyException);
   EXPECT_THROW(Utility::resolveUrl("abc://foo"), EnvoyException);
@@ -42,9 +53,21 @@ TEST(NetworkUtility, resolveUrl) {
   EXPECT_THROW(Utility::resolveUrl("tcp://192.168.3.3.3:0"), EnvoyException);
   EXPECT_THROW(Utility::resolveUrl("tcp://192.168.3:0"), EnvoyException);
 
+  EXPECT_THROW(Utility::resolveUrl("udp://1.2.3.4:1234/"), EnvoyException);
+  EXPECT_THROW(Utility::resolveUrl("udp://127.0.0.1:8001/"), EnvoyException);
+  EXPECT_THROW(Utility::resolveUrl("udp://127.0.0.1:0/foo"), EnvoyException);
+  EXPECT_THROW(Utility::resolveUrl("udp://127.0.0.1:"), EnvoyException);
+  EXPECT_THROW(Utility::resolveUrl("udp://192.168.3.3"), EnvoyException);
+  EXPECT_THROW(Utility::resolveUrl("udp://192.168.3.3.3:0"), EnvoyException);
+  EXPECT_THROW(Utility::resolveUrl("udp://192.168.3:0"), EnvoyException);
+
   EXPECT_THROW(Utility::resolveUrl("tcp://[::1]"), EnvoyException);
   EXPECT_THROW(Utility::resolveUrl("tcp://[:::1]:1"), EnvoyException);
   EXPECT_THROW(Utility::resolveUrl("tcp://foo:0"), EnvoyException);
+
+  EXPECT_THROW(Utility::resolveUrl("udp://[::1]"), EnvoyException);
+  EXPECT_THROW(Utility::resolveUrl("udp://[:::1]:1"), EnvoyException);
+  EXPECT_THROW(Utility::resolveUrl("udp://foo:0"), EnvoyException);
 
   EXPECT_EQ("", Utility::resolveUrl("unix://")->asString());
   EXPECT_EQ("foo", Utility::resolveUrl("unix://foo")->asString());
@@ -60,6 +83,16 @@ TEST(NetworkUtility, resolveUrl) {
   EXPECT_EQ("[1::2:3]:4", Utility::resolveUrl("tcp://[1::2:3]:4")->asString());
   EXPECT_EQ("[a::1]:0", Utility::resolveUrl("tcp://[a::1]:0")->asString());
   EXPECT_EQ("[a:b:c:d::]:0", Utility::resolveUrl("tcp://[a:b:c:d::]:0")->asString());
+
+  EXPECT_EQ("1.2.3.4:1234", Utility::resolveUrl("udp://1.2.3.4:1234")->asString());
+  EXPECT_EQ("0.0.0.0:0", Utility::resolveUrl("udp://0.0.0.0:0")->asString());
+  EXPECT_EQ("127.0.0.1:0", Utility::resolveUrl("udp://127.0.0.1:0")->asString());
+
+  EXPECT_EQ("[::1]:1", Utility::resolveUrl("udp://[::1]:1")->asString());
+  EXPECT_EQ("[::]:0", Utility::resolveUrl("udp://[::]:0")->asString());
+  EXPECT_EQ("[1::2:3]:4", Utility::resolveUrl("udp://[1::2:3]:4")->asString());
+  EXPECT_EQ("[a::1]:0", Utility::resolveUrl("udp://[a::1]:0")->asString());
+  EXPECT_EQ("[a:b:c:d::]:0", Utility::resolveUrl("udp://[a:b:c:d::]:0")->asString());
 }
 
 TEST(NetworkUtility, ParseInternetAddress) {


### PR DESCRIPTION
Changes on top of PR #4898:
- Remove SocketState.STATE_UNCONN enum value, since use case unclear.
- Re-add bind_to_port param to UdpListenSocket constructor.
- Remove use of SO_REUSEPORT from UdpListenSocket constructor, and add a
  comment explaining why neither that nor SO_REUSEADDR are set.
- Refactor {host,port}From{Tcp,Udp}Url functions to share code.
- Add ListenSocketImplTest.UdpBindSpecificPort test case.
