### PR TITLE
reformat dynamic metadata emitted by Mongo proxy

### DIFF
--- a/docs/root/configuration/network_filters/mongo_proxy_filter.rst
+++ b/docs/root/configuration/network_filters/mongo_proxy_filter.rst
@@ -190,5 +190,5 @@ a list of operations performed on the collection.
   :header: Name, Type, Description
   :widths: 1, 1, 2
 
-  <db.collection>, string, The resource name in *db.collection* format.
-  [], list, A list of strings, representing the operations executed on the resource. Operation is either insert,update,query,delete.
+  key, string, The resource name in *db.collection* format.
+  value, array, A list of strings representing the operations executed on the resource. Operation is either insert,update,query,delete.

--- a/docs/root/configuration/network_filters/mongo_proxy_filter.rst
+++ b/docs/root/configuration/network_filters/mongo_proxy_filter.rst
@@ -182,11 +182,13 @@ Dynamic Metadata
 
 The Mongo filter emits the following dynamic metadata when enabled via the
 :ref:`configuration <envoy_api_field_config.filter.network.mongo_proxy.v2.MongoProxy.emit_dynamic_metadata>`.
-This dynamic metadata is available as one struct per message under a list named *messages*.
+This dynamic metadata is available as key-value pairs where the key
+represents the database and the collection being accessed, and the value is
+a list of operations performed on the collection.
 
 .. csv-table::
   :header: Name, Type, Description
   :widths: 1, 1, 2
 
-  operation, string, The operation to be executed.
-  resource, string, The resource name in *db.collection* format on which the operation is to be executed.
+  <db.collection>, string, The resource name in *db.collection* format.
+  [], list, A list of strings, representing the operations executed on the resource. Operation is either insert,update,query,delete.

--- a/docs/root/configuration/network_filters/mongo_proxy_filter.rst
+++ b/docs/root/configuration/network_filters/mongo_proxy_filter.rst
@@ -191,4 +191,4 @@ a list of operations performed on the collection.
   :widths: 1, 1, 2
 
   key, string, The resource name in *db.collection* format.
-  value, array, A list of strings representing the operations executed on the resource. Operation is either insert,update,query,delete.
+  value, array, A list of strings representing the operations executed on the resource (insert/update/query/delete).

--- a/source/extensions/filters/network/mongo_proxy/proxy.cc
+++ b/source/extensions/filters/network/mongo_proxy/proxy.cc
@@ -26,11 +26,11 @@ namespace MongoProxy {
 
 class DynamicMetadataKeys {
 public:
-  const std::string MessagesField{"messages"};
-  const std::string OperationField{"operation"};
-  const std::string OperationInsert{"OP_INSERT"};
-  const std::string OperationQuery{"OP_QUERY"};
-  const std::string ResourceField{"resource"};
+  const std::string OperationInsert{"insert"};
+  const std::string OperationQuery{"query"};
+  // TODO: Parse out the delete/update operation from the commands
+  const std::string OperationUpdate{"update"};
+  const std::string OperationDelete{"delete"};
 };
 
 typedef ConstSingleton<DynamicMetadataKeys> DynamicMetadataKeysSingleton;
@@ -81,11 +81,9 @@ void ProxyFilter::setDynamicMetadata(std::string operation, std::string resource
             .dynamicMetadata()
             .mutable_filter_metadata())[NetworkFilterNames::get().MongoProxy]);
   auto& fields = *metadata.mutable_fields();
-  auto& list = *fields[DynamicMetadataKeysSingleton::get().MessagesField].mutable_list_value();
-  auto& message = *list.add_values()->mutable_struct_value()->mutable_fields();
-
-  message[DynamicMetadataKeysSingleton::get().OperationField].set_string_value(operation);
-  message[DynamicMetadataKeysSingleton::get().ResourceField].set_string_value(resource);
+  // TODO(rshriram): reverse the resource string (table.db)
+  auto& operations = *fields[resource].mutable_list_value();
+  operations.add_values()->set_string_value(operation);
 
   read_callbacks_->connection().streamInfo().setDynamicMetadata(
       NetworkFilterNames::get().MongoProxy, metadata);

--- a/test/extensions/filters/network/mongo_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/proxy_test.cc
@@ -216,7 +216,7 @@ TEST_F(MongoProxyFilterTest, DynamicMetadata) {
 
   auto& metadata =
       stream_info_.dynamicMetadata().filter_metadata().at(NetworkFilterNames::get().MongoProxy);
-  EXPECT_TRUE(nullptr != metadata.fields().at("db.test"));
+  EXPECT_TRUE(metadata.fields().find("db.test") != metadata.fields().end());
   EXPECT_EQ("query", metadata.fields().at("db.test").list_value().values(0).string_value());
 
   EXPECT_CALL(*filter_->decoder_, onData(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
@@ -227,7 +227,7 @@ TEST_F(MongoProxyFilterTest, DynamicMetadata) {
   }));
   filter_->onData(fake_data_, false);
 
-  EXPECT_TRUE(nullptr != metadata.fields().at("db.test"));
+  EXPECT_TRUE(metadata.fields().find("db.test") != metadata.fields().end());
   EXPECT_EQ("insert", metadata.fields().at("db.test").list_value().values(0).string_value());
 
   EXPECT_CALL(*filter_->decoder_, onData(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
@@ -244,10 +244,10 @@ TEST_F(MongoProxyFilterTest, DynamicMetadata) {
   }));
   filter_->onData(fake_data_, false);
 
-  EXPECT_TRUE(nullptr != metadata.fields().at("db.test1"));
-  EXPECT_EQ("query", metadata.fields().at("db.test1").list_value().values(0).string_value());
-  EXPECT_TRUE(nullptr != metadata.fields().at("db.test2"));
-  EXPECT_EQ("insert", metadata.fields().at("db.test1").list_value().values(0).string_value());
+  EXPECT_TRUE(metadata.fields().find("db1.test1") != metadata.fields().end());
+  EXPECT_EQ("query", metadata.fields().at("db1.test1").list_value().values(0).string_value());
+  EXPECT_TRUE(metadata.fields().find("db2.test2") != metadata.fields().end());
+  EXPECT_EQ("insert", metadata.fields().at("db2.test2").list_value().values(0).string_value());
 }
 
 TEST_F(MongoProxyFilterTest, DynamicMetadataDisabled) {

--- a/test/extensions/filters/network/mongo_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/proxy_test.cc
@@ -216,9 +216,8 @@ TEST_F(MongoProxyFilterTest, DynamicMetadata) {
 
   auto& metadata =
       stream_info_.dynamicMetadata().filter_metadata().at(NetworkFilterNames::get().MongoProxy);
-  auto& query_message = metadata.fields().at("messages").list_value().values(0).struct_value();
-  EXPECT_EQ("OP_QUERY", query_message.fields().at("operation").string_value());
-  EXPECT_EQ("db.test", query_message.fields().at("resource").string_value());
+  EXPECT_TRUE(nullptr != metadata.fields().at("db.test"));
+  EXPECT_EQ("query", metadata.fields().at("db.test").list_value().values(0).string_value());
 
   EXPECT_CALL(*filter_->decoder_, onData(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
     InsertMessagePtr message(new InsertMessageImpl(0, 0));
@@ -228,9 +227,8 @@ TEST_F(MongoProxyFilterTest, DynamicMetadata) {
   }));
   filter_->onData(fake_data_, false);
 
-  auto& insert_message = metadata.fields().at("messages").list_value().values(0).struct_value();
-  EXPECT_EQ("OP_INSERT", insert_message.fields().at("operation").string_value());
-  EXPECT_EQ("db.test", insert_message.fields().at("resource").string_value());
+  EXPECT_TRUE(nullptr != metadata.fields().at("db.test"));
+  EXPECT_EQ("insert", metadata.fields().at("db.test").list_value().values(0).string_value());
 
   EXPECT_CALL(*filter_->decoder_, onData(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
     QueryMessagePtr message1(new QueryMessageImpl(0, 0));
@@ -246,15 +244,10 @@ TEST_F(MongoProxyFilterTest, DynamicMetadata) {
   }));
   filter_->onData(fake_data_, false);
 
-  auto& multiple_messages = metadata.fields().at("messages").list_value();
-  EXPECT_EQ("OP_QUERY",
-            multiple_messages.values(0).struct_value().fields().at("operation").string_value());
-  EXPECT_EQ("db1.test1",
-            multiple_messages.values(0).struct_value().fields().at("resource").string_value());
-  EXPECT_EQ("OP_INSERT",
-            multiple_messages.values(1).struct_value().fields().at("operation").string_value());
-  EXPECT_EQ("db2.test2",
-            multiple_messages.values(1).struct_value().fields().at("resource").string_value());
+  EXPECT_TRUE(nullptr != metadata.fields().at("db.test1"));
+  EXPECT_EQ("query", metadata.fields().at("db.test1").list_value().values(0).string_value());
+  EXPECT_TRUE(nullptr != metadata.fields().at("db.test2"));
+  EXPECT_EQ("insert", metadata.fields().at("db.test1").list_value().values(0).string_value());
 }
 
 TEST_F(MongoProxyFilterTest, DynamicMetadataDisabled) {


### PR DESCRIPTION
*Description*: Emit metadata as `map<resource, list(operations>` so that it can be used in metadata matchers easily. The existing format (messages:list(structs)) is too hard to represent in metadata matchers.
*Risk Level*: LOW
*Testing*: Unit tests

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>

cc @venilnoronha 