### PR TITLE
tests: fix unit test for cors filter

### DIFF
--- a/test/extensions/filters/http/cors/cors_filter_test.cc
+++ b/test/extensions/filters/http/cors/cors_filter_test.cc
@@ -157,7 +157,7 @@ TEST_F(CorsFilterTest, OptionsRequestWithOriginCorsEnabled) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(request_headers_));
 }
 
-TEST_F(CorsFilterTest, OptionsRequestWithoutRequestMethod) {
+TEST_F(CorsFilterTest, RequestWithoutMethod) {
   Http::TestHeaderMapImpl request_headers{{"origin", "localhost"}};
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);

--- a/test/extensions/filters/http/cors/cors_filter_test.cc
+++ b/test/extensions/filters/http/cors/cors_filter_test.cc
@@ -158,7 +158,7 @@ TEST_F(CorsFilterTest, OptionsRequestWithOriginCorsEnabled) {
 }
 
 TEST_F(CorsFilterTest, OptionsRequestWithoutRequestMethod) {
-  Http::TestHeaderMapImpl request_headers{{":method", "OPTIONS"}, {"origin", "localhost"}};
+  Http::TestHeaderMapImpl request_headers{{"origin", "localhost"}};
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));


### PR DESCRIPTION
*Description*: Fix unit test in CORS filter to match the desired behavior.
*Risk Level*: Low
*Testing*: Ran unit tests.
*Docs Changes*: N/A
*Release Notes*: N/A