### PR TITLE
tests: fix naming of CORS unit test

### DIFF
--- a/test/extensions/filters/http/cors/cors_filter_test.cc
+++ b/test/extensions/filters/http/cors/cors_filter_test.cc
@@ -157,7 +157,7 @@ TEST_F(CorsFilterTest, OptionsRequestWithOriginCorsEnabled) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(request_headers_));
 }
 
-TEST_F(CorsFilterTest, OptionsRequestWithoutRequestMethod) {
+TEST_F(CorsFilterTest, OptionsRequestWithoutAccessRequestMethod) {
   Http::TestHeaderMapImpl request_headers{{":method", "OPTIONS"}, {"origin", "localhost"}};
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);


### PR DESCRIPTION
*Description*: Clarify unit test is missing access request method headers.
*Risk Level*: Low
*Testing*: Ran the unit tests.
*Docs Changes*: N/A
*Release Notes*: N/A