### PR TITLE
Stores metadata in ActiveStream, and drains them right before end of stream

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1174,6 +1174,15 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
 
   chargeStats(headers);
 
+  // Drains metadata before end of stream is sent.
+  if (!response_metadata_map_->empty() &&
+      (encoding_headers_only_ || (end_stream && continue_data_entry == encoder_filters_.end()))) {
+    ENVOY_STREAM_LOG(debug, "encoding metadata via codec:\n{}", *this, *response_metadata_map_);
+    // Now encode metadata via the codec.
+    response_encoder_->encodeMetadata(*response_metadata_map_);
+    response_metadata_map_->erase(response_metadata_map_->begin(), response_metadata_map_->end());
+  }
+
   ENVOY_STREAM_LOG(debug, "encoding headers via codec (end_stream={}):\n{}", *this,
                    encoding_headers_only_ ||
                        (end_stream && continue_data_entry == encoder_filters_.end()),
@@ -1199,21 +1208,13 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
 }
 
 void ConnectionManagerImpl::ActiveStream::encodeMetadata(ActiveStreamEncoderFilter* filter,
-                                                         MetadataMapPtr&& metadata_map) {
+                                                         MetadataMap&) {
   resetIdleTimer();
 
   std::list<ActiveStreamEncoderFilterPtr>::iterator entry = commonEncodePrefix(filter, false);
   for (; entry != encoder_filters_.end(); entry++) {
     // TODO(soya3129): Add filters here.
   }
-
-  ENVOY_STREAM_LOG(debug, "encoding metadata via codec:\n{}", *this, *metadata_map);
-
-  // Now encode metadata via the codec.
-  if (!metadata_map->empty()) {
-    response_encoder_->encodeMetadata(*metadata_map);
-  }
-  // metadata_map destroyed when function returns.
 }
 
 HeaderMap& ConnectionManagerImpl::ActiveStream::addEncodedTrailers() {
@@ -1290,6 +1291,15 @@ void ConnectionManagerImpl::ActiveStream::encodeData(ActiveStreamEncoderFilter* 
     }
   }
 
+  // Drains metadata before end of stream is sent.
+  if (!response_metadata_map_->empty() &&
+      (trailers_added_entry == encoder_filters_.end() && end_stream)) {
+    ENVOY_STREAM_LOG(debug, "encoding metadata via codec:\n{}", *this, *response_metadata_map_);
+    // Now encode metadata via the codec.
+    response_encoder_->encodeMetadata(*response_metadata_map_);
+    response_metadata_map_->erase(response_metadata_map_->begin(), response_metadata_map_->end());
+  }
+
   ENVOY_STREAM_LOG(trace, "encoding data via codec (size={} end_stream={})", *this, data.length(),
                    end_stream);
 
@@ -1326,6 +1336,13 @@ void ConnectionManagerImpl::ActiveStream::encodeTrailers(ActiveStreamEncoderFilt
     if (!(*entry)->commonHandleAfterTrailersCallback(status)) {
       return;
     }
+  }
+
+  if (!response_metadata_map_->empty()) {
+    ENVOY_STREAM_LOG(debug, "encoding metadata via codec:\n{}", *this, *response_metadata_map_);
+    // Now encode metadata via the codec.
+    response_encoder_->encodeMetadata(*response_metadata_map_);
+    response_metadata_map_->erase(response_metadata_map_->begin(), response_metadata_map_->end());
   }
 
   ENVOY_STREAM_LOG(debug, "encoding trailers via codec:\n{}", *this, trailers);
@@ -1656,7 +1673,8 @@ void ConnectionManagerImpl::ActiveStreamDecoderFilter::encodeTrailers(HeaderMapP
 
 void ConnectionManagerImpl::ActiveStreamDecoderFilter::encodeMetadata(
     MetadataMapPtr&& metadata_map) {
-  parent_.encodeMetadata(nullptr, std::move(metadata_map));
+  parent_.encodeMetadata(nullptr, *metadata_map);
+  parent_.response_metadata_map_->insert(metadata_map->begin(), metadata_map->end());
 }
 
 void ConnectionManagerImpl::ActiveStreamDecoderFilter::

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -292,7 +292,7 @@ private:
     void encodeHeaders(ActiveStreamEncoderFilter* filter, HeaderMap& headers, bool end_stream);
     void encodeData(ActiveStreamEncoderFilter* filter, Buffer::Instance& data, bool end_stream);
     void encodeTrailers(ActiveStreamEncoderFilter* filter, HeaderMap& trailers);
-    void encodeMetadata(ActiveStreamEncoderFilter* filter, MetadataMapPtr&& metadata_map);
+    void encodeMetadata(ActiveStreamEncoderFilter* filter, MetadataMap& metadata_map);
     void maybeEndEncode(bool end_stream);
     uint64_t streamId() { return stream_id_; }
 
@@ -399,6 +399,7 @@ private:
     HeaderMapPtr request_headers_;
     Buffer::WatermarkBufferPtr buffered_request_data_;
     HeaderMapPtr request_trailers_;
+    MetadataMapPtr response_metadata_map_{new MetadataMap()};
     std::list<ActiveStreamDecoderFilterPtr> decoder_filters_;
     std::list<ActiveStreamEncoderFilterPtr> encoder_filters_;
     std::list<AccessLog::InstanceSharedPtr> access_log_handlers_;

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -1051,8 +1051,7 @@ void HttpIntegrationTest::testEnvoyProxyMetadataInResponse() {
   std::string value = std::string(80 * 1024, '1');
   Http::MetadataMap metadata_map = {{key, value}};
   upstream_request_->encodeMetadata(metadata_map);
-  upstream_request_->encodeHeaders(default_response_headers_, false);
-  upstream_request_->encodeData(12, true);
+  upstream_request_->encodeHeaders(default_response_headers_, true);
 
   // Verifies metadata is received by the client.
   response->waitForEndStream();
@@ -1131,15 +1130,54 @@ void HttpIntegrationTest::testEnvoyProxyMetadataInResponse() {
 
   // Sends metadata before reset.
   value = std::string(10, '6');
+  upstream_request_->encodeMetadata(metadata_map);
   upstream_request_->encodeHeaders(default_response_headers_, false);
   upstream_request_->encodeData(10, false);
   metadata_map = {{key, value}};
-  upstream_request_->encodeMetadata(metadata_map);
   upstream_request_->encodeResetStream();
 
   // Verifies stream is reset.
   response->waitForReset();
   ASSERT_FALSE(response->complete());
+  // Verifies no metadata is received.
+  EXPECT_EQ(0, response->metadata_map().size());
+
+  // Sends the seventh request.
+  response = codec_client_->makeRequestWithBody(default_request_headers_, 10);
+  waitForNextUpstreamRequest();
+
+  // Sends same metadata multiple times.
+  value = std::string(10, '5');
+  metadata_map = {{key, value}};
+  upstream_request_->encodeMetadata(metadata_map);
+  upstream_request_->encodeHeaders(default_response_headers_, false);
+  upstream_request_->encodeMetadata(metadata_map);
+  upstream_request_->encodeData(10, false);
+  upstream_request_->encodeMetadata(metadata_map);
+  upstream_request_->encodeData(0, true);
+
+  // Verifies metadata is received by the client.
+  response->waitForEndStream();
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ(response->metadata_map().find(key)->second, value);
+
+  // Sends the eighth request.
+  response = codec_client_->makeRequestWithBody(default_request_headers_, 10);
+  waitForNextUpstreamRequest();
+
+  // Sends trailers.
+  value = std::string(10, '5');
+  metadata_map = {{key, value}};
+  upstream_request_->encodeHeaders(default_response_headers_, false);
+  upstream_request_->encodeMetadata(metadata_map);
+  upstream_request_->encodeData(10, false);
+  Http::TestHeaderMapImpl response_trailers{{"response", "trailer"}};
+  upstream_request_->encodeTrailers(response_trailers);
+
+  // Verifies metadata is received by the client.
+  response->waitForEndStream();
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ(response->metadata_map().find(key)->second, value);
 }
 
 void HttpIntegrationTest::testEnvoyProxyMultipleMetadata() {


### PR DESCRIPTION
Signed-off-by: Yang Song <yasong@google.com>
*Description*: Instead of draining response metadata immediately after going through all the filters, the change allows ActiveStream to hold response metadata, and drains response metadata right before the end of stream. Metadata can be drained in encodeHeaders(), encodeData(), and encodeTrailers(), depending on which frame has end_stream. If a stream is closed by reset streams, that means errors occur in the stream (confirmed by verifying functions calling resetStream()), and we skip metadata in this case. 

How to handle multiple metadata maps: if multiple metadata maps are received/generated, we combine them into one metadata_map saved in ActiveStream, and the single metadata_map will be drained right before the end of stream. This is consistent with the condition that we don't guarantee the sending order of metadata.

Why this change is needed: if we drain metadata right after going through all filters, we may send the same metadata multiple times to the next hop. For example, if StreamEncoderFilter::encodeData() adds a new metadata, and encodeData() is triggered multiple times, envoy will send the same metadata multiple times to the next hop (discovered while testing adding metadata). An alternative solution is to let the filter remember if the metadata has been sent. But it would be very weird, I think. Storing metadata in ActiveStream allows us to skip a metadata if it's already in the metadata map. What do you think? Thanks! 

*Risk Level*: Low. Not used in production.
*Testing*: Integration test.
#2394