### PR TITLE
cleanup: string_view and cast cleanups for Google import.

### DIFF
--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -74,7 +74,7 @@ public:
    * Copy a string into the buffer.
    * @param data supplies the string to copy.
    */
-  virtual void add(const std::string& data) PURE;
+  virtual void add(absl::string_view data) PURE;
 
   /**
    * Copy another buffer into this buffer.

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -57,7 +57,9 @@ public:
   virtual ~Instance() {}
 
   /**
-   * Copy data into the buffer.
+   * Copy data into the buffer (deprecated, use absl::string_view variant
+   * instead).
+   * TODO(htuch): Cleanup deprecated call sites.
    * @param data supplies the data address.
    * @param size supplies the data size.
    */

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -229,7 +229,7 @@ public:
    *                       response headers.
    * @param grpc_status the gRPC status code to override the httpToGrpcStatus mapping with.
    */
-  virtual void sendLocalReply(Code response_code, const std::string& body_text,
+  virtual void sendLocalReply(Code response_code, absl::string_view body_text,
                               std::function<void(HeaderMap& headers)> modify_headers,
                               const absl::optional<Grpc::Status::GrpcStatus> grpc_status) PURE;
 

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -194,7 +194,7 @@ public:
   /**
    * Set the header value by copying data into it.
    */
-  virtual void value(const std::string& value) PURE;
+  virtual void value(absl::string_view value) PURE;
 
   /**
    * Set the header value by copying an integer into it.

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -187,7 +187,9 @@ public:
   virtual const HeaderString& key() const PURE;
 
   /**
-   * Set the header value by copying data into it.
+   * Set the header value by copying data into it (deprecated, use absl::string_view variant
+   * instead).
+   * TODO(htuch): Cleanup deprecated call sites.
    */
   virtual void value(const char* value, uint32_t size) PURE;
 

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -29,8 +29,8 @@ void OwnedImpl::addBufferFragment(BufferFragment& fragment) {
       [](const void*, size_t, void* arg) { static_cast<BufferFragment*>(arg)->done(); }, &fragment);
 }
 
-void OwnedImpl::add(const std::string& data) {
-  evbuffer_add(buffer_.get(), data.c_str(), data.size());
+void OwnedImpl::add(absl::string_view data) {
+  evbuffer_add(buffer_.get(), data.data(), data.size());
 }
 
 void OwnedImpl::add(const Instance& data) {
@@ -191,7 +191,7 @@ Api::SysCallIntResult OwnedImpl::write(int fd) {
 
 OwnedImpl::OwnedImpl() : buffer_(evbuffer_new()) {}
 
-OwnedImpl::OwnedImpl(const std::string& data) : OwnedImpl() { add(data); }
+OwnedImpl::OwnedImpl(absl::string_view data) : OwnedImpl() { add(data); }
 
 OwnedImpl::OwnedImpl(const Instance& data) : OwnedImpl() { add(data); }
 

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -63,14 +63,14 @@ public:
 class OwnedImpl : public LibEventInstance {
 public:
   OwnedImpl();
-  OwnedImpl(const std::string& data);
+  OwnedImpl(absl::string_view data);
   OwnedImpl(const Instance& data);
   OwnedImpl(const void* data, uint64_t size);
 
   // LibEventInstance
   void add(const void* data, uint64_t size) override;
   void addBufferFragment(BufferFragment& fragment) override;
-  void add(const std::string& data) override;
+  void add(absl::string_view data) override;
   void add(const Instance& data) override;
   void prepend(absl::string_view data) override;
   void prepend(Instance& data) override;

--- a/source/common/buffer/watermark_buffer.cc
+++ b/source/common/buffer/watermark_buffer.cc
@@ -10,7 +10,7 @@ void WatermarkBuffer::add(const void* data, uint64_t size) {
   checkHighWatermark();
 }
 
-void WatermarkBuffer::add(const std::string& data) {
+void WatermarkBuffer::add(absl::string_view data) {
   OwnedImpl::add(data);
   checkHighWatermark();
 }

--- a/source/common/buffer/watermark_buffer.h
+++ b/source/common/buffer/watermark_buffer.h
@@ -22,7 +22,7 @@ public:
   // Override all functions from Instance which can result in changing the size
   // of the underlying buffer.
   void add(const void* data, uint64_t size) override;
-  void add(const std::string& data) override;
+  void add(absl::string_view data) override;
   void add(const Instance& data) override;
   void prepend(absl::string_view data) override;
   void prepend(Instance& data) override;

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -284,7 +284,7 @@ private:
   HeaderMap& addDecodedTrailers() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   void addDecodedData(Buffer::Instance&, bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   const Buffer::Instance* decodingBuffer() override { return buffered_body_.get(); }
-  void sendLocalReply(Code code, const std::string& body,
+  void sendLocalReply(Code code, absl::string_view body,
                       std::function<void(HeaderMap& headers)> modify_headers,
                       const absl::optional<Grpc::Status::GrpcStatus> grpc_status) override {
     Utility::sendLocalReply(

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -992,7 +992,7 @@ void ConnectionManagerImpl::ActiveStream::refreshCachedRoute() {
 }
 
 void ConnectionManagerImpl::ActiveStream::sendLocalReply(
-    bool is_grpc_request, Code code, const std::string& body,
+    bool is_grpc_request, Code code, absl::string_view body,
     const std::function<void(HeaderMap& headers)>& modify_headers, bool is_head_request,
     const absl::optional<Grpc::Status::GrpcStatus> grpc_status) {
   ASSERT(response_headers_ == nullptr);

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -172,7 +172,7 @@ private:
     const Buffer::Instance* decodingBuffer() override {
       return parent_.buffered_request_data_.get();
     }
-    void sendLocalReply(Code code, const std::string& body,
+    void sendLocalReply(Code code, absl::string_view body,
                         std::function<void(HeaderMap& headers)> modify_headers,
                         const absl::optional<Grpc::Status::GrpcStatus> grpc_status) override {
       parent_.sendLocalReply(is_grpc_request_, code, body, modify_headers, parent_.is_head_request_,
@@ -284,7 +284,7 @@ private:
     void maybeEndDecode(bool end_stream);
     void addEncodedData(ActiveStreamEncoderFilter& filter, Buffer::Instance& data, bool streaming);
     HeaderMap& addEncodedTrailers();
-    void sendLocalReply(bool is_grpc_request, Code code, const std::string& body,
+    void sendLocalReply(bool is_grpc_request, Code code, absl::string_view body,
                         const std::function<void(HeaderMap& headers)>& modify_headers,
                         bool is_head_request,
                         const absl::optional<Grpc::Status::GrpcStatus> grpc_status);

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -256,8 +256,8 @@ void HeaderMapImpl::HeaderEntryImpl::value(const char* value, uint32_t size) {
   value_.setCopy(value, size);
 }
 
-void HeaderMapImpl::HeaderEntryImpl::value(const std::string& value) {
-  this->value(value.c_str(), static_cast<uint32_t>(value.size()));
+void HeaderMapImpl::HeaderEntryImpl::value(absl::string_view value) {
+  this->value(value.data(), static_cast<uint32_t>(value.size()));
 }
 
 void HeaderMapImpl::HeaderEntryImpl::value(uint64_t value) { value_.setInteger(value); }

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -93,7 +93,7 @@ protected:
     // HeaderEntry
     const HeaderString& key() const override { return key_; }
     void value(const char* value, uint32_t size) override;
-    void value(const std::string& value) override;
+    void value(absl::string_view value) override;
     void value(uint64_t value) override;
     void value(const HeaderEntry& header) override;
     const HeaderString& value() const override { return value_; }

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -243,7 +243,7 @@ Utility::parseHttp1Settings(const envoy::api::v2::core::Http1ProtocolOptions& co
 }
 
 void Utility::sendLocalReply(bool is_grpc, StreamDecoderFilterCallbacks& callbacks,
-                             const bool& is_reset, Code response_code, const std::string& body_text,
+                             const bool& is_reset, Code response_code, absl::string_view body_text,
                              const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                              bool is_head_request) {
   sendLocalReply(is_grpc,
@@ -259,7 +259,7 @@ void Utility::sendLocalReply(bool is_grpc, StreamDecoderFilterCallbacks& callbac
 void Utility::sendLocalReply(
     bool is_grpc, std::function<void(HeaderMapPtr&& headers, bool end_stream)> encode_headers,
     std::function<void(Buffer::Instance& data, bool end_stream)> encode_data, const bool& is_reset,
-    Code response_code, const std::string& body_text,
+    Code response_code, absl::string_view body_text,
     const absl::optional<Grpc::Status::GrpcStatus> grpc_status, bool is_head_request) {
   // encode_headers() may reset the stream, so the stream must not be reset before calling it.
   ASSERT(!is_reset);

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -142,7 +142,7 @@ Http1Settings parseHttp1Settings(const envoy::api::v2::core::Http1ProtocolOption
  * @param is_head_request tells if this is a response to a HEAD request
  */
 void sendLocalReply(bool is_grpc, StreamDecoderFilterCallbacks& callbacks, const bool& is_reset,
-                    Code response_code, const std::string& body_text,
+                    Code response_code, absl::string_view body_text,
                     const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                     bool is_head_request);
 
@@ -162,7 +162,7 @@ void sendLocalReply(bool is_grpc, StreamDecoderFilterCallbacks& callbacks, const
 void sendLocalReply(bool is_grpc,
                     std::function<void(HeaderMapPtr&& headers, bool end_stream)> encode_headers,
                     std::function<void(Buffer::Instance& data, bool end_stream)> encode_data,
-                    const bool& is_reset, Code response_code, const std::string& body_text,
+                    const bool& is_reset, Code response_code, absl::string_view body_text,
                     const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                     bool is_head_request = false);
 

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -245,7 +245,9 @@ Http::FilterHeadersStatus JsonTranscoderFilter::decodeHeaders(Http::HeaderMap& h
     if (!request_status.ok()) {
       ENVOY_LOG(debug, "Transcoding request error {}", request_status.ToString());
       error_ = true;
-      decoder_callbacks_->sendLocalReply(Http::Code::BadRequest, request_status.error_message(),
+      decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
+                                         absl::string_view(request_status.error_message().data(),
+                                                           request_status.error_message().size()),
                                          nullptr, absl::nullopt);
 
       return Http::FilterHeadersStatus::StopIteration;
@@ -281,7 +283,9 @@ Http::FilterDataStatus JsonTranscoderFilter::decodeData(Buffer::Instance& data, 
   if (!request_status.ok()) {
     ENVOY_LOG(debug, "Transcoding request error {}", request_status.ToString());
     error_ = true;
-    decoder_callbacks_->sendLocalReply(Http::Code::BadRequest, request_status.error_message(),
+    decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,
+                                       absl::string_view(request_status.error_message().data(),
+                                                         request_status.error_message().size()),
                                        nullptr, absl::nullopt);
 
     return Http::FilterDataStatus::StopIterationNoBuffer;

--- a/source/extensions/filters/network/dubbo_proxy/buffer_helper.h
+++ b/source/extensions/filters/network/dubbo_proxy/buffer_helper.h
@@ -42,7 +42,7 @@ public:
   std::string toString() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   void add(const void*, uint64_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   void addBufferFragment(Buffer::BufferFragment&) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-  void add(const std::string&) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  void add(absl::string_view) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   void add(const Buffer::Instance&) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   void commit(Buffer::RawSlice*, uint64_t) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   void prepend(absl::string_view) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -97,7 +97,8 @@ protected:
       response_headers.insertContentType().value(std::string("application/grpc"));
       if (grpc_response_messages.empty()) {
         response_headers.insertGrpcStatus().value(static_cast<uint64_t>(grpc_status.error_code()));
-        response_headers.insertGrpcMessage().value(grpc_status.error_message());
+        response_headers.insertGrpcMessage().value(absl::string_view(
+            grpc_status.error_message().data(), grpc_status.error_message().size()));
         upstream_request_->encodeHeaders(response_headers, true);
       } else {
         response_headers.addCopy(Http::LowerCaseString("trailer"), "Grpc-Status");
@@ -111,7 +112,8 @@ protected:
         }
         Http::TestHeaderMapImpl response_trailers;
         response_trailers.insertGrpcStatus().value(static_cast<uint64_t>(grpc_status.error_code()));
-        response_trailers.insertGrpcMessage().value(grpc_status.error_message());
+        response_trailers.insertGrpcMessage().value(absl::string_view(
+            grpc_status.error_message().data(), grpc_status.error_message().size()));
         upstream_request_->encodeTrailers(response_trailers);
       }
       EXPECT_TRUE(upstream_request_->complete());

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -96,7 +96,7 @@ protected:
       response_headers.insertStatus().value(200);
       response_headers.insertContentType().value(std::string("application/grpc"));
       if (grpc_response_messages.empty()) {
-        response_headers.insertGrpcStatus().value(grpc_status.error_code());
+        response_headers.insertGrpcStatus().value(static_cast<uint64_t>(grpc_status.error_code()));
         response_headers.insertGrpcMessage().value(grpc_status.error_message());
         upstream_request_->encodeHeaders(response_headers, true);
       } else {
@@ -110,7 +110,7 @@ protected:
           upstream_request_->encodeData(*buffer, false);
         }
         Http::TestHeaderMapImpl response_trailers;
-        response_trailers.insertGrpcStatus().value(grpc_status.error_code());
+        response_trailers.insertGrpcStatus().value(static_cast<uint64_t>(grpc_status.error_code()));
         response_trailers.insertGrpcMessage().value(grpc_status.error_message());
         upstream_request_->encodeTrailers(response_trailers);
       }

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -211,7 +211,7 @@ public:
   MOCK_METHOD0(decoderBufferLimit, uint32_t());
 
   // Http::StreamDecoderFilterCallbacks
-  void sendLocalReply(Code code, const std::string& body,
+  void sendLocalReply(Code code, absl::string_view body,
                       std::function<void(HeaderMap& headers)> modify_headers,
                       const absl::optional<Grpc::Status::GrpcStatus> grpc_status) override {
     Utility::sendLocalReply(


### PR DESCRIPTION
This mostly relates to changes in how protobuf Status is handled, which
will be reflected in future protobuf releases as well.

* Replace a bunch of const std::string& with absl::string_view.

* Static cast error_code() to uint64_t. Not needed in OSS today, but in
  the future this will be an enum class.

Risk Level: Low
Testing: bazel test //test/...

Signed-off-by: Harvey Tuch <htuch@google.com>