### PR TITLE
ci: ensure that ipv6_tests only runs IPv6 tests.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -149,7 +149,8 @@ elif [[ "$1" == "bazel.ipv6_tests" ]]; then
   setup_clang_toolchain
   echo "Testing..."
   cd "${ENVOY_CI_DIR}"
-  bazel test ${BAZEL_TEST_OPTIONS} -c fastbuild //test/integration/... //test/common/network/...
+  bazel test ${BAZEL_TEST_OPTIONS} --test_env=ENVOY_IP_TEST_VERSIONS=v6only -c fastbuild \
+    //test/integration/... //test/common/network/...
   exit 0
 elif [[ "$1" == "bazel.api" ]]; then
   setup_clang_toolchain

--- a/ci/do_circle_ci_ipv6_tests.sh
+++ b/ci/do_circle_ci_ipv6_tests.sh
@@ -10,8 +10,6 @@ export ENVOY_BUILD_DIR=/tmp/envoy-docker
 
 export TEST_TYPE="bazel.ipv6_tests"
 
-export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v6only"
-
 function finish {
   echo "disk space at end of build:"
   df -h


### PR DESCRIPTION
There was a Docker environment scripting bug resulting in both IPv4 & IPv6 tests being run before
for CircleCI's ipv6_tests job.

This PR fixes this and might improve #5104. I was unable to reproduce #5104 locally or on Google's
build farm, so I think this might have something to do with very specific IPv4/IPv6 interaction.

Risk Level: Low
Testing: Via this PR's CI runs.

Signed-off-by: Harvey Tuch <htuch@google.com>