### PR TITLE
test: fix a test crash by destroying test time after consumers

### DIFF
--- a/test/common/grpc/grpc_client_integration.h
+++ b/test/common/grpc/grpc_client_integration.h
@@ -42,6 +42,12 @@ class GrpcClientIntegrationParamTest
       public testing::TestWithParam<std::tuple<Network::Address::IpVersion, ClientType>> {
 public:
   ~GrpcClientIntegrationParamTest() {}
+  static std::string protocolTestParamsToString(
+      const testing::TestParamInfo<std::tuple<Network::Address::IpVersion, ClientType>>& p) {
+    return absl::StrCat(
+        (std::get<0>(p.param) == Network::Address::IpVersion::v4 ? "IPv4_" : "IPv6_"),
+        (std::get<1>(p.param) == ClientType::GoogleGrpc ? "GoogleGrpc" : "EnvoyGrpc"));
+  }
   Network::Address::IpVersion ipVersion() const override { return std::get<0>(GetParam()); }
   ClientType clientType() const override { return std::get<1>(GetParam()); }
 };

--- a/test/common/grpc/grpc_client_integration_test.cc
+++ b/test/common/grpc/grpc_client_integration_test.cc
@@ -13,7 +13,8 @@ namespace {
 
 // Parameterize the loopback test server socket address and gRPC client type.
 INSTANTIATE_TEST_CASE_P(IpVersionsClientType, GrpcClientIntegrationTest,
-                        GRPC_CLIENT_INTEGRATION_PARAMS);
+                        GRPC_CLIENT_INTEGRATION_PARAMS,
+                        GrpcClientIntegrationParamTest::protocolTestParamsToString);
 
 // Validate that a simple request-reply stream works.
 TEST_P(GrpcClientIntegrationTest, BasicStream) {
@@ -328,7 +329,8 @@ TEST_P(GrpcClientIntegrationTest, CancelRequest) {
 
 // Parameterize the loopback test server socket address and gRPC client type.
 INSTANTIATE_TEST_CASE_P(SslIpVersionsClientType, GrpcSslClientIntegrationTest,
-                        GRPC_CLIENT_INTEGRATION_PARAMS);
+                        GRPC_CLIENT_INTEGRATION_PARAMS,
+                        GrpcClientIntegrationParamTest::protocolTestParamsToString);
 
 // Validate that a simple request-reply unary RPC works with SSL.
 TEST_P(GrpcSslClientIntegrationTest, BasicSslRequest) {
@@ -390,7 +392,8 @@ public:
 
 // Parameterize the loopback test server socket address and gRPC client type.
 INSTANTIATE_TEST_CASE_P(SslIpVersionsClientType, GrpcAccessTokenClientIntegrationTest,
-                        GRPC_CLIENT_INTEGRATION_PARAMS);
+                        GRPC_CLIENT_INTEGRATION_PARAMS,
+                        GrpcClientIntegrationParamTest::protocolTestParamsToString);
 
 // Validate that a simple request-reply unary RPC works with AccessToken auth.
 TEST_P(GrpcAccessTokenClientIntegrationTest, AccessTokenAuthRequest) {

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -396,11 +396,11 @@ public:
     return stream;
   }
 
+  DangerousDeprecatedTestTime test_time_;
   std::unique_ptr<FakeUpstream> fake_upstream_;
   FakeHttpConnectionPtr fake_connection_;
   std::vector<FakeStreamPtr> fake_streams_;
   const Protobuf::MethodDescriptor* method_descriptor_;
-  DangerousDeprecatedTestTime test_time_;
   Event::DispatcherImpl dispatcher_;
   DispatcherHelper dispatcher_helper_{dispatcher_};
   Api::ApiPtr api_;


### PR DESCRIPTION
also pretty printing grpc test params while I'm in there because I despise figuring out what test is failing via staring at Test/0 Test/1 Test/2 Test/3

*Risk Level*: Low (test only)
*Testing*: goes from 80% failure with flake-options on to 0% failure
*Docs Changes*: n/a
*Release Notes*: n/a
Fixes #5071
