### PR TITLE
config: removing deprecated Listener 'type' field

### DIFF
--- a/api/envoy/api/v2/listener/listener.proto
+++ b/api/envoy/api/v2/listener/listener.proto
@@ -42,13 +42,6 @@ message Filter {
     // [#not-implemented-hide:]
     google.protobuf.Any typed_config = 4;
   }
-  // [#not-implemented-hide:]
-  message DeprecatedV1 {
-    string type = 1;
-  }
-
-  // [#not-implemented-hide:]
-  DeprecatedV1 deprecated_v1 = 3 [deprecated = true];
 }
 
 // Specifies the match criteria for selecting a specific filter chain for a

--- a/configs/google_com_proxy.yaml
+++ b/configs/google_com_proxy.yaml
@@ -2,7 +2,6 @@ listeners:
 - address: tcp://127.0.0.1:10000
   filters:
   - name: http_connection_manager
-    type: read
     config:
       codec_type: auto
       stat_prefix: ingress_http

--- a/source/common/config/lds_json.cc
+++ b/source/common/config/lds_json.cc
@@ -39,7 +39,6 @@ void LdsJson::translateListener(const Json::Object& json_listener,
     // Translate v1 name to v2 name.
     filter->set_name(Extensions::NetworkFilters::NetworkFilterNames::get().v1_converter_.getV2Name(
         json_filter->getString("name")));
-    JSON_UTIL_SET_STRING(*json_filter, *filter->mutable_deprecated_v1(), type);
 
     const std::string json_config =
         "{\"deprecated_v1\": true, \"value\": " + json_filter->getObject("config")->asJsonString() +

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -164,7 +164,6 @@ const std::string Json::Schema::LISTENER_SCHEMA(R"EOF(
       "filters" : {
         "type" : "object",
         "properties" : {
-          "type": {"type" : "string", "enum" : ["read", "write", "both"] },
           "name" : {
             "type": "string"
           },

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -35,7 +35,6 @@ std::vector<Network::FilterFactoryCb> ProdListenerComponentFactory::createNetwor
   std::vector<Network::FilterFactoryCb> ret;
   for (ssize_t i = 0; i < filters.size(); i++) {
     const auto& proto_config = filters[i];
-    const ProtobufTypes::String string_type = proto_config.deprecated_v1().type();
     const ProtobufTypes::String string_name = proto_config.name();
     ENVOY_LOG(debug, "  filter #{}:", i);
     ENVOY_LOG(debug, "    name: {}", string_name);

--- a/test/config/integration/echo_server.json
+++ b/test/config/integration/echo_server.json
@@ -4,14 +4,14 @@
     "address": "tcp://{{ ip_loopback_address }}:0",
     "use_original_dst": true,
     "filters": [
-      { "type": "read", "name": "ratelimit",
+      { "name": "ratelimit",
         "config": {
           "domain": "foo",
           "descriptors": [[{"key": "foo", "value": "bar"}]],
           "stat_prefix": "name"
         }
       },
-      { "type": "read", "name": "echo", "config": {} }
+      { "name": "echo", "config": {} }
     ]
   }],
 

--- a/test/config/integration/server.json
+++ b/test/config/integration/server.json
@@ -4,7 +4,6 @@
     "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http1",
@@ -84,7 +83,7 @@
           ]
         },
         "filters": [
-          { "type": "both", "name": "health_check",
+          { "name": "health_check",
             "config": {
               "pass_through_mode": false, "endpoint": "/healthcheck"
             }
@@ -103,7 +102,6 @@
     "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http1",
@@ -197,7 +195,7 @@
           ]
         },
         "filters": [
-          { "type": "both", "name": "health_check",
+          { "name": "health_check",
             "config": {
               "pass_through_mode": false, "endpoint": "/healthcheck"
             }
@@ -217,7 +215,6 @@
     "per_connection_buffer_limit_bytes": 1024,
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http1",
@@ -248,7 +245,6 @@
     "per_connection_buffer_limit_bytes": 1024,
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http1",
@@ -269,7 +265,7 @@
           ]
         },
         "filters": [
-          { "type": "both", "name": "http_dynamo_filter", "config": {} },
+          { "name": "http_dynamo_filter", "config": {} },
           { "type": "decoder", "name": "router", "config": {} }
         ]
       }
@@ -280,7 +276,6 @@
     "per_connection_buffer_limit_bytes": 1024,
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http1",
@@ -311,7 +306,6 @@
     "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http1",
@@ -391,7 +385,7 @@
           ]
         },
         "filters": [
-          { "type": "both", "name": "health_check",
+          { "name": "health_check",
             "config": {
               "pass_through_mode": false, "endpoint": "/healthcheck"
             }
@@ -416,7 +410,6 @@
     "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http1",
@@ -435,7 +428,6 @@
     "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
-      "type": "read",
       "name": "redis_proxy",
       "config": {
         "cluster_name": "redis",

--- a/test/config/integration/server.yaml
+++ b/test/config/integration/server.yaml
@@ -68,8 +68,6 @@ static_resources:
                 type: logical_or
             - path: "/dev/null"
           deprecated_v1: true
-        deprecated_v1:
-          type: read
   - address:
       socket_address:
         address: {{ ip_loopback_address }}
@@ -147,8 +145,6 @@ static_resources:
             http1_settings:
               allow_absolute_url: true
           deprecated_v1: true
-        deprecated_v1:
-          type: read
   - address:
       socket_address:
         address: {{ ip_loopback_address }}
@@ -172,8 +168,6 @@ static_resources:
             codec_type: http1
             stat_prefix: router
           deprecated_v1: true
-        deprecated_v1:
-          type: read
     per_connection_buffer_limit_bytes: 1024
   - address:
       socket_address:
@@ -200,8 +194,6 @@ static_resources:
                 - "*"
                 name: integration
           deprecated_v1: true
-        deprecated_v1:
-          type: read
     per_connection_buffer_limit_bytes: 1024
   - address:
       socket_address:
@@ -228,8 +220,6 @@ static_resources:
             codec_type: http1
             stat_prefix: router
           deprecated_v1: true
-        deprecated_v1:
-          type: read
     per_connection_buffer_limit_bytes: 1024
   - address:
       socket_address:
@@ -303,8 +293,6 @@ static_resources:
               path: "/dev/null"
             - path: "/dev/null"
           deprecated_v1: true
-        deprecated_v1:
-          type: read
   - address:
       socket_address:
         address: {{ ip_loopback_address }}
@@ -323,8 +311,6 @@ static_resources:
               route_config_name: foo
               cluster: rds
           deprecated_v1: true
-        deprecated_v1:
-          type: read
   - address:
       socket_address:
         address: {{ ip_loopback_address }}
@@ -339,8 +325,6 @@ static_resources:
             stat_prefix: redis
             cluster_name: redis
           deprecated_v1: true
-        deprecated_v1:
-          type: read
   clusters:
   - name: cds
     connect_timeout: 5s

--- a/test/config/integration/server_cors_filter.json
+++ b/test/config/integration/server_cors_filter.json
@@ -4,7 +4,6 @@
     "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http1",

--- a/test/config/integration/server_grpc_json_transcoder.json
+++ b/test/config/integration/server_grpc_json_transcoder.json
@@ -4,7 +4,6 @@
     "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http1",
@@ -47,7 +46,7 @@
           ]
         },
         "filters": [
-          { "type": "both", "name": "grpc_json_transcoder",
+          { "name": "grpc_json_transcoder",
             "config": {
               "proto_descriptor": "{{ test_rundir }}/test/proto/bookstore.descriptor",
               "services": ["bookstore.Bookstore"]

--- a/test/config/integration/server_http2.json
+++ b/test/config/integration/server_http2.json
@@ -3,14 +3,13 @@
   {
     "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
-      { "type": "read", "name": "echo", "config": {} }
+      { "name": "echo", "config": {} }
     ]
   },
   {
     "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http2",
@@ -77,7 +76,7 @@
           ]
         },
         "filters": [
-          { "type": "both", "name": "health_check",
+          { "name": "health_check",
             "config": {
               "pass_through_mode": false, "endpoint": "/healthcheck"
             }
@@ -91,7 +90,6 @@
     "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http2",
@@ -158,7 +156,7 @@
           ]
         },
         "filters": [
-          { "type": "both", "name": "health_check",
+          { "name": "health_check",
             "config": {
               "pass_through_mode": false, "endpoint": "/healthcheck"
             }
@@ -179,7 +177,6 @@
     "per_connection_buffer_limit_bytes": 1024,
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http2",
@@ -214,7 +211,6 @@
     "per_connection_buffer_limit_bytes": 1024,
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http2",

--- a/test/config/integration/server_http2_upstream.json
+++ b/test/config/integration/server_http2_upstream.json
@@ -4,7 +4,6 @@
     "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http2",
@@ -71,7 +70,7 @@
           ]
         },
         "filters": [
-          { "type": "both", "name": "health_check",
+          { "name": "health_check",
             "config": {
               "pass_through_mode": false, "endpoint": "/healthcheck"
             }
@@ -85,7 +84,6 @@
     "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http2",
@@ -152,7 +150,7 @@
           ]
         },
         "filters": [
-          { "type": "both", "name": "health_check",
+          { "name": "health_check",
             "config": {
               "pass_through_mode": false, "endpoint": "/healthcheck"
             }
@@ -172,7 +170,6 @@
     "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http1",
@@ -238,7 +235,7 @@
           ]
         },
         "filters": [
-          { "type": "both", "name": "health_check",
+          { "name": "health_check",
             "config": {
               "pass_through_mode": false, "endpoint": "/healthcheck"
             }
@@ -259,7 +256,6 @@
     "per_connection_buffer_limit_bytes": 1024,
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http2",

--- a/test/config/integration/server_proxy_proto.json
+++ b/test/config/integration/server_proxy_proto.json
@@ -5,7 +5,6 @@
     "use_proxy_proto": true,
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http1",
@@ -67,7 +66,7 @@
           ]
         },
         "filters": [
-          { "type": "both", "name": "health_check",
+          { "name": "health_check",
             "config": {
               "pass_through_mode": false, "endpoint": "/healthcheck"
             }

--- a/test/config/integration/server_ssl.json
+++ b/test/config/integration/server_ssl.json
@@ -11,7 +11,6 @@
     },
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "auto",

--- a/test/config/integration/server_uds.json
+++ b/test/config/integration/server_uds.json
@@ -4,7 +4,6 @@
     "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "http1",
@@ -70,7 +69,7 @@
           ]
         },
         "filters": [
-          { "type": "both", "name": "health_check",
+          { "name": "health_check",
             "config": {
               "pass_through_mode": false, "endpoint": "/healthcheck"
             }

--- a/test/config/integration/server_unix_listener.json
+++ b/test/config/integration/server_unix_listener.json
@@ -15,7 +15,6 @@
   "listeners": [{
     "address": "unix://{{ socket_dir }}/unix-sockets.listener_0",
     "filters": [{
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "auto",

--- a/test/config/integration/server_unix_listener.yaml
+++ b/test/config/integration/server_unix_listener.yaml
@@ -23,8 +23,6 @@ static_resources:
                 - prefix: "/"
                   cluster: cluster_0
           deprecated_v1: true
-        deprecated_v1:
-          type: read
   clusters:
   - name: cluster_0
     connect_timeout: 5s

--- a/test/config/integration/server_xfcc.json
+++ b/test/config/integration/server_xfcc.json
@@ -9,7 +9,6 @@
     },
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "auto",
@@ -75,7 +74,7 @@
           ]
         },
         "filters": [
-          { "type": "both", "name": "health_check",
+          { "name": "health_check",
             "config": {
               "pass_through_mode": true, "cache_time_ms": 2500, "endpoint": "/healthcheck"
             }
@@ -91,7 +90,6 @@
     "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
     {
-      "type": "read",
       "name": "http_connection_manager",
       "config": {
         "codec_type": "auto",
@@ -157,7 +155,7 @@
           ]
         },
         "filters": [
-          { "type": "both", "name": "health_check",
+          { "name": "health_check",
             "config": {
               "pass_through_mode": true, "cache_time_ms": 2500, "endpoint": "/healthcheck"
             }

--- a/test/config/integration/tcp_proxy.json
+++ b/test/config/integration/tcp_proxy.json
@@ -3,7 +3,7 @@
   {
     "address": "tcp://{{ ip_loopback_address }}:0",
     "filters": [
-      { "type": "read", "name": "tcp_proxy",
+      { "name": "tcp_proxy",
         "config": {
           "stat_prefix": "test_tcp",
           "route_config": {
@@ -27,7 +27,7 @@
     "address": "tcp://{{ ip_loopback_address }}:0",
     "per_connection_buffer_limit_bytes": 1024,
     "filters": [
-      { "type": "read", "name": "tcp_proxy",
+      { "name": "tcp_proxy",
         "config": {
           "stat_prefix": "tcp_with_write_limits",
           "route_config": {
@@ -51,7 +51,7 @@
       "alpn_protocols": "h2,http/1.1"
     },
     "filters": [
-      { "type": "read", "name": "tcp_proxy",
+      { "name": "tcp_proxy",
         "config": {
           "stat_prefix": "test_tcp_sans_tls",
           "route_config": {
@@ -63,7 +63,7 @@
           }
         }
       },
-      { "type": "read", "name": "client_ssl_auth",
+      { "name": "client_ssl_auth",
         "config": {
                 "auth_api_cluster": "ssl_auth",
                 "stat_prefix": "ssl_stats",

--- a/test/server/lds_api_test.cc
+++ b/test/server/lds_api_test.cc
@@ -356,7 +356,6 @@ TEST_F(LdsApiTest, TlsConfigWithoutCaCert) {
                      ]
                   }}
                }},
-               "type" : "read",
                "name" : "tcp_proxy"
             }}
          ]

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -278,7 +278,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, BadFilterConfig) {
     "address": "tcp://127.0.0.1:1234",
     "filters": [
       {
-        "type" : "type",
+        "foo" : "type",
         "name" : "name",
         "config" : {}
       }
@@ -296,7 +296,6 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, BadFilterName) {
     "address": "tcp://127.0.0.1:1234",
     "filters": [
       {
-        "type" : "write",
         "name" : "invalid",
         "config" : {}
       }
@@ -330,7 +329,6 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, StatsScopeTest) {
     "bind_to_port": false,
     "filters": [
       {
-        "type" : "read",
         "name" : "stats_test",
         "config" : {}
       }
@@ -525,7 +523,7 @@ dynamic_draining_listeners:
     "name": "foo",
     "address": "tcp://127.0.0.1:1234",
     "filters": [
-      { "type" : "read", "name" : "fake", "config" : {} }
+      { "name" : "fake", "config" : {} }
     ]
   }
   )EOF";
@@ -791,7 +789,7 @@ dynamic_draining_listeners:
     "name": "baz",
     "address": "tcp://127.0.0.1:1236",
     "filters": [
-      { "type" : "read", "name" : "fake", "config" : {} }
+      { "name" : "fake", "config" : {} }
     ]
   }
   )EOF";
@@ -987,7 +985,7 @@ TEST_F(ListenerManagerImplTest, RemoveListener) {
     "name": "foo",
     "address": "tcp://127.0.0.1:1234",
     "filters": [
-      { "type" : "read", "name" : "fake", "config" : {} }
+      { "name" : "fake", "config" : {} }
     ]
   }
   )EOF";


### PR DESCRIPTION
*Risk Level*: Medium (if folks are using long-deprecated configs)
*Testing*: fixed up tests
*Docs Changes*: n/a
*Release Notes*: none
