### PR TITLE
config: reserving the field formerly used by deprecated_v1 config.

### DIFF
--- a/api/envoy/api/v2/listener/listener.proto
+++ b/api/envoy/api/v2/listener/listener.proto
@@ -42,6 +42,8 @@ message Filter {
     // [#not-implemented-hide:]
     google.protobuf.Any typed_config = 4;
   }
+
+  reserved 3;
 }
 
 // Specifies the match criteria for selecting a specific filter chain for a


### PR DESCRIPTION
Follow on from #5146

*Risk Level*: Low
*Testing*: n/a
*Docs Changes*: n/a
*Release Notes*: n.a
