### PR TITLE
test: Add IsSupersetOfHeaders matcher.

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -58,13 +58,14 @@ Example:
 EXPECT_THAT(response->headers(), HeaderMapEqualRef(expected_headers));
 ```
 
-### IsSubsetOfHeaders
+### IsSubsetOfHeaders and IsSupersetOfHeaders
 
 Tests that one `HeaderMap` argument contains every header in another
 `HeaderMap`.
 
-Example:
+Examples:
 
 ```cpp
-EXPECT_THAT(response->headers(), IsSubsetOfHeaders(required_headers));
+EXPECT_THAT(response->headers(), IsSubsetOfHeaders(allowed_headers));
+EXPECT_THAT(response->headers(), IsSupersetOfHeaders(required_headers));
 ```

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -171,5 +171,9 @@ IsSubsetOfHeadersMatcher IsSubsetOfHeaders(const HeaderMap& expected_headers) {
   return IsSubsetOfHeadersMatcher(expected_headers);
 }
 
+IsSupersetOfHeadersMatcher IsSupersetOfHeaders(const HeaderMap& expected_headers) {
+  return IsSupersetOfHeadersMatcher(expected_headers);
+}
+
 } // namespace Http
 } // namespace Envoy

--- a/test/mocks/http/mocks_test.cc
+++ b/test/mocks/http/mocks_test.cc
@@ -82,6 +82,28 @@ TEST(IsSubsetOfHeadersTest, MutableHeaderMap) {
 
   EXPECT_THAT(header_map, Not(IsSubsetOfHeaders(TestHeaderMapImpl{{"third key", "1"}})));
 }
+
+TEST(IsSupersetOfHeadersTest, ConstHeaderMap) {
+  const TestHeaderMapImpl header_map{{"first key", "1"}, {"second key", "2"}};
+
+  EXPECT_THAT(header_map,
+              IsSupersetOfHeaders(TestHeaderMapImpl{{"first key", "1"}, {"second key", "2"}}));
+  EXPECT_THAT(header_map, IsSupersetOfHeaders(TestHeaderMapImpl{{"first key", "1"}}));
+
+  EXPECT_THAT(header_map, Not(IsSupersetOfHeaders(TestHeaderMapImpl{{"third key", "1"}})));
+}
+
+TEST(IsSupersetOfHeadersTest, MutableHeaderMap) {
+  TestHeaderMapImpl header_map;
+  header_map.addCopy("first key", "1");
+  header_map.addCopy("second key", "2");
+
+  EXPECT_THAT(header_map,
+              IsSupersetOfHeaders(TestHeaderMapImpl{{"first key", "1"}, {"second key", "2"}}));
+  EXPECT_THAT(header_map, IsSupersetOfHeaders(TestHeaderMapImpl{{"first key", "1"}}));
+
+  EXPECT_THAT(header_map, Not(IsSupersetOfHeaders(TestHeaderMapImpl{{"third key", "1"}})));
+}
 } // namespace Http
 
 TEST(HeaderHasValueRefTest, MutableValueRef) {


### PR DESCRIPTION
*Description*: Add Envoy::Http::IsSupersetOfHeaders, to go with IsSubsetOfHeaders. This gives better error messages than writing EXPECT_THAT(expected, IsSubsetOfHeaders(actual)), because it matches the argument order that googletest expects.
*Risk Level*: Low (test only)
*Testing*: bazel test test/mocks/http:http_mocks_test
*Docs Changes*: Describes IsSupersetOfHeaders in test/README.md.
*Release Notes*: n/a