### PR TITLE
docs: clarify unit for dns_refresh_rate

### DIFF
--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -246,7 +246,7 @@ message Cluster {
   // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`,
   // or :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`,
   // this value is used as the cluster’s DNS refresh
-  // rate. If this setting is not specified, the value defaults to 5000. For
+  // rate. If this setting is not specified, the value defaults to 5000ms. For
   // cluster types other than
   // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`
   // and :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`


### PR DESCRIPTION
Signed-off-by: Daniel Hochman <danielhochman@users.noreply.github.com>

*Description*: Update docs to include unit. Missed in v1 to v2 transition where variable name previously contained unit (i.e. `dns_refresh_rate_ms`).
*Risk Level*: None
*Testing*: None
*Docs Changes*: Yes
*Release Notes*: None
