### PR TITLE
Add clang-format to mac install instructions

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -47,7 +47,7 @@ dnf install cmake libtool libstdc++
 
 On OS X, you'll need to install several dependencies. This can be accomplished via [Homebrew](https://brew.sh/):
 ```
-brew install coreutils wget cmake libtool go bazel automake ninja
+brew install coreutils wget cmake libtool go bazel automake ninja clang-format
 ```
 _note_: `coreutils` is used for realpath
 


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

*Description*: Add clang-format to brew install instructions
*Risk Level*: Low: doc updates
*Testing*: N/A
*Docs Changes*: This is it