### PR TITLE
api: Add a metadata field to UpstreamEndpointStats.

### DIFF
--- a/api/envoy/api/v2/endpoint/load_report.proto
+++ b/api/envoy/api/v2/endpoint/load_report.proto
@@ -6,6 +6,7 @@ import "envoy/api/v2/core/address.proto";
 import "envoy/api/v2/core/base.proto";
 
 import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
 
 import "validate/validate.proto";
 import "gogoproto/gogo.proto";
@@ -56,6 +57,10 @@ message UpstreamLocalityStats {
 message UpstreamEndpointStats {
   // Upstream host address.
   core.Address address = 1;
+
+  // Opaque and implementation dependent metadata of the
+  // endpoint. Envoy will pass this directly to the management server.
+  google.protobuf.Struct metadata = 6;
 
   // The total number of requests successfully completed by the endpoint. A
   // single HTTP or gRPC request or stream is counted as one request. A TCP


### PR DESCRIPTION
Description: This field is used to carry opaque and implementation
dependent information of the upstream endpoints. The information may
be used by management server for debugging purposes.

Example: Consider a requirement of per 'user' load stastics for
debugging. Envoy will embed user info into the metadata field for
every upstream endpoint it sends load to. This user information will
be used by management server for debugging.

Sample message:
message ClusterStats {
  cluster_name = ...
  message UpstreamLocalityStats {
    locality = ...
    message UpstreamEndpointStats {
      address = "endpoint1"
      metadata = { "user" : "alice"}
      ...
    }
    message UpstreamEndpointStats {
      address = "endpoint1"
      metadata = { "user" : "bob"}
      ...
    }
    message UpstreamEndpointStats {
      address = "endpoint2"
      metadata = { "user" : "alice"}
      ...
    }
    message UpstreamEndpointStats {
      address = "endpoint3"
      metadata = { "user" : "bob"}
      ...
    }
  }
}

Risk Level: Low
Testing: Compiles successfully.
Signed-off-by: Karthik Reddy <rekarthik@google.com>