### PR TITLE
tracing: small fixes for datadog tracer

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -91,9 +91,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/googleapis/googleapis/archive/d6f78d948c53f3b400bb46996eb3084359914f9b.tar.gz"],
     ),
     com_github_datadog_dd_opentracing_cpp = dict(
-        sha256 = "733e9b698a232cfd3aa35b4e27c59641bf1fa78e52e71d29e230af4f2070cdf5",
-        strip_prefix = "dd-opentracing-cpp-0.3.5",
-        urls = ["https://github.com/DataDog/dd-opentracing-cpp/archive/v0.3.5.tar.gz"],
+        sha256 = "32967149fbc672f321ba6ce6c3e5cc299b15ab914f6f5b2993c7c9ddc1894439",
+        strip_prefix = "dd-opentracing-cpp-0.3.6",
+        urls = ["https://github.com/DataDog/dd-opentracing-cpp/archive/v0.3.6.tar.gz"],
     ),
     com_github_msgpack_msgpack_c = dict(
         sha256 = "bda49f996a73d2c6080ff0523e7b535917cd28c8a79c3a5da54fc29332d61d1e",

--- a/source/extensions/tracers/datadog/datadog_tracer_impl.cc
+++ b/source/extensions/tracers/datadog/datadog_tracer_impl.cc
@@ -34,6 +34,10 @@ Driver::Driver(const envoy::config::trace::v2::DatadogConfig& datadog_config,
   // Default tracer options.
   tracer_options_.operation_name_override = "envoy.proxy";
   tracer_options_.service = "envoy";
+  tracer_options_.inject = std::set<datadog::opentracing::PropagationStyle>{
+      datadog::opentracing::PropagationStyle::Datadog};
+  tracer_options_.extract = std::set<datadog::opentracing::PropagationStyle>{
+      datadog::opentracing::PropagationStyle::Datadog};
 
   // Configuration overrides for tracer options.
   if (!datadog_config.service_name().empty()) {


### PR DESCRIPTION
Signed-off-by: Caleb Gilmour <caleb.gilmour@datadoghq.com>

*Description*:
Updates dd-opentracing-cpp dependency to [v0.3.6](https://github.com/DataDog/dd-opentracing-cpp/releases/tag/v0.3.6) [changes](https://github.com/DataDog/dd-opentracing-cpp/compare/v0.3.5...v0.3.6)
It contains one envoy-related fix to apply tags when creating spans.
This makes the tracing config (eg: `overall_sampling`) and the tracing decision get applied correctly.
The extension change is to force a specific propagation mode. 

*Risk Level*: Low
*Testing*: local tests and E2E
*Docs Changes*: N/A
*Release Notes*: N/A