### PR TITLE
Fix bug: add support to error_pc for Arm

### DIFF
--- a/source/exe/signal_action.cc
+++ b/source/exe/signal_action.cc
@@ -20,6 +20,10 @@ void SignalAction::sigHandler(int sig, siginfo_t* info, void* context) {
     error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext->__ss.__rip);
 #elif defined(__powerpc__)
     error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext.regs->nip);
+#elif defined(__aarch64__)
+    error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext.pc);
+#elif defined(__arm__)
+    error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext.arm_pc);
 #else
 #warning "Please enable and test PC retrieval code for your arch in signal_action.cc"
 // x86 Classic: reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[REG_EIP]);


### PR DESCRIPTION
Signed-off-by: Bin Lu <lubinsz@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*:
Fix bug: add support to error_pc for Arm platform.

*Risk Level*:
Medium
*Testing*:
unit test,integration
*Docs Changes*:
None
*Release Notes*:
None
[Optional Fixes #Issue]
[Optional *Deprecated*:]
