### PR TITLE
ssl: modify ssl packages to allow for pluggable openssl to replace boringssl

### DIFF
--- a/source/common/ssl/BUILD
+++ b/source/common/ssl/BUILD
@@ -66,12 +66,12 @@ envoy_cc_library(
         "context_impl.h",
         "context_manager_impl.h",
     ],
-    external_deps = [
-        "abseil_synchronization",
-        "ssl",
-    ],
+    external_deps = ["ssl"],
     deps = [
         ":utility_lib",
+        ":ssl_impl_common_hdrs_lib",
+        ":ssl_impl_common_lib",
+        ":ssl_impl_hdrs_lib",
         "//include/envoy/ssl:context_config_interface",
         "//include/envoy/ssl:context_interface",
         "//include/envoy/ssl:context_manager_interface",
@@ -118,7 +118,57 @@ envoy_cc_library(
         "ssl",
     ],
     deps = [
+        ":ssl_impl_common_hdrs_lib",
+        ":ssl_impl_hdrs_lib",
+        ":ssl_impl_common_lib",
         "//source/common/common:assert_lib",
         "//source/common/common:utility_lib",
     ],
 )
+
+envoy_cc_library(
+    name = "ssl_impl_common_lib",
+    srcs = [
+        "ssl_impl_common.cc",
+    ],
+    hdrs = [
+        "context_impl.h",
+        "context_manager_impl.h",
+    ],
+    external_deps = [
+        "ssl",
+    ],
+    deps = [
+        ":ssl_impl_hdrs_lib",
+        ":ssl_impl_common_hdrs_lib",
+        "//include/envoy/ssl:context_config_interface",
+        "//include/envoy/ssl:context_interface",
+        "//include/envoy/ssl:context_manager_interface",
+        "//include/envoy/stats:stats_interface",
+        "//include/envoy/stats:stats_macros",
+        "//source/common/common:assert_lib",
+        "//source/common/common:utility_lib",
+        "//source/common/protobuf:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "ssl_impl_hdrs_lib",
+    hdrs = [
+        "ssl_impl.h",
+    ],
+    external_deps = [
+                 "ssl",
+    ],
+)
+
+envoy_cc_library(
+    name = "ssl_impl_common_hdrs_lib",
+    hdrs = [
+        "ssl_impl_common.h",
+    ],
+    external_deps = [
+                 "ssl",
+    ],
+)
+

--- a/source/common/ssl/context_impl.h
+++ b/source/common/ssl/context_impl.h
@@ -16,6 +16,8 @@
 #include "absl/types/optional.h"
 #include "openssl/ssl.h"
 
+#include "common/ssl/ssl_impl_common.h"
+
 namespace Envoy {
 #ifndef OPENSSL_IS_BORINGSSL
 #error Envoy requires BoringSSL
@@ -188,7 +190,7 @@ private:
                            HMAC_CTX* hmac_ctx, int encrypt);
   // Select the TLS certificate context in SSL_CTX_set_select_certificate_cb() callback with
   // ClientHello details.
-  enum ssl_select_cert_result_t selectTlsContext(const SSL_CLIENT_HELLO* ssl_client_hello);
+  // enum ssl_select_cert_result_t selectTlsContext(const SSL_CLIENT_HELLO* ssl_client_hello);
   void generateHashForSessionContexId(const std::vector<std::string>& server_names,
                                       uint8_t* session_context_buf, unsigned& session_context_len);
 

--- a/source/common/ssl/ssl_impl.h
+++ b/source/common/ssl/ssl_impl.h
@@ -1,0 +1,2 @@
+#include "openssl/bytestring.h"
+

--- a/source/common/ssl/ssl_impl_common.cc
+++ b/source/common/ssl/ssl_impl_common.cc
@@ -1,0 +1,117 @@
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+#include <iostream>
+
+#include "openssl/ssl.h"
+#include "openssl/hmac.h"
+#include "openssl/rand.h"
+#include "openssl/x509v3.h"
+
+#include "common/ssl/context_impl.h"
+
+namespace Envoy {
+namespace Ssl {
+
+int alpnSelectCallback(std::vector<uint8_t> parsed_alpn_protocols,
+                                    const unsigned char** out, unsigned char* outlen,
+                                    const unsigned char* in, unsigned int inlen) {
+  // Currently this uses the standard selection algorithm in priority order.
+  const uint8_t* alpn_data = &parsed_alpn_protocols[0];
+  size_t alpn_data_size = parsed_alpn_protocols.size();
+  if (SSL_select_next_proto(const_cast<unsigned char**>(out), outlen, alpn_data, alpn_data_size, in,
+                            inlen) != OPENSSL_NPN_NEGOTIATED) {
+    return SSL_TLSEXT_ERR_NOACK;
+  } else {
+    return SSL_TLSEXT_ERR_OK;
+  }
+}
+
+enum ssl_select_cert_result_t selectTlsContext(const SSL_CLIENT_HELLO* ssl_client_hello) {
+  // This is currently a nop, since we only have a single cert, but this is where we will implement
+  // the certificate selection logic in #1319.
+  //RELEASE_ASSERT(SSL_set_SSL_CTX(ssl_client_hello->ssl, tls_contexts_[0].ssl_ctx_.get()) != nullptr, "");
+
+  return ssl_select_cert_success;
+}
+
+void set_select_certificate_cb(SSL_CTX *ctx ){
+  enum ssl_select_cert_result_t selectTlsContext(const SSL_CLIENT_HELLO* ssl_client_hello);
+  SSL_CTX_set_select_certificate_cb(
+      ctx,
+      [](const SSL_CLIENT_HELLO* client_hello) -> ssl_select_cert_result_t {
+        return selectTlsContext(client_hello);
+      });
+}
+
+//bssl::UniquePtr<SSL> newSsl(SSL_CTX *ctx) {
+//  return bssl::UniquePtr<SSL>(SSL_new(ctx));
+//}
+
+int set_strict_cipher_list(SSL_CTX *ctx, const char *str) {
+  return SSL_CTX_set_strict_cipher_list(ctx, str);
+}
+
+std::string getSerialNumberFromCertificate(X509* cert) {
+  ASN1_INTEGER* serial_number = X509_get_serialNumber(cert);
+  BIGNUM num_bn;
+  BN_init(&num_bn);
+  ASN1_INTEGER_to_BN(serial_number, &num_bn);
+  char* char_serial_number = BN_bn2hex(&num_bn);
+  BN_free(&num_bn);
+  if (char_serial_number != nullptr) {
+    std::string serial_number(char_serial_number);
+    OPENSSL_free(char_serial_number);
+    return serial_number;
+  }
+  return "";
+}
+
+void allowRenegotiation(SSL* ssl) {
+  SSL_set_renegotiate_mode(ssl, ssl_renegotiate_freely);
+}
+
+bssl::UniquePtr<STACK_OF(X509_NAME)> initX509Names() {
+  bssl::UniquePtr<STACK_OF(X509_NAME)> list(sk_X509_NAME_new(
+        [](const X509_NAME** a, const X509_NAME** b) -> int { return X509_NAME_cmp(*a, *b); }));
+
+  return list;
+}
+
+EVP_MD_CTX* newEVP_MD_CTX() {
+  EVP_MD_CTX *md = EVP_MD_CTX_new();
+  return md;
+}
+
+SSL_SESSION *ssl_session_from_bytes(SSL *client_ssl_socket, const SSL_CTX *client_ssl_context, const std::string& client_session) {
+  return SSL_SESSION_from_bytes(reinterpret_cast<const uint8_t*>(client_session.data()),
+                               client_session.size(), client_ssl_context);             
+}
+
+int ssl_session_to_bytes(const SSL_SESSION *in, uint8_t **out_data, size_t *out_len) {
+   return SSL_SESSION_to_bytes(in, out_data, out_len);
+}
+
+X509* getVerifyCallbackCert(X509_STORE_CTX* store_ctx, void* arg) {
+  SSL* ssl = reinterpret_cast<SSL*>(
+      X509_STORE_CTX_get_ex_data(store_ctx, SSL_get_ex_data_X509_STORE_CTX_idx()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl));
+
+  return cert.get();
+}
+
+int ssl_session_is_resumable(const SSL_SESSION* session) {
+  return SSL_SESSION_is_resumable(session);
+}
+
+void ssl_ctx_add_client_CA(SSL_CTX *ctx, X509 *x) {
+
+}
+
+int should_be_single_use(const SSL_SESSION *session) {
+  return SSL_SESSION_should_be_single_use(session);
+}
+
+} // namespace Ssl
+} // namespace Envoy

--- a/source/common/ssl/ssl_impl_common.h
+++ b/source/common/ssl/ssl_impl_common.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "openssl/ssl.h"
+#include "common/ssl/ssl_impl.h"
+
+namespace Envoy {
+namespace Ssl {
+
+  int alpnSelectCallback(std::vector<uint8_t> parsed_alpn_protocols, const unsigned char** out, unsigned char* outlen, const unsigned char* in,
+                         unsigned int inlen);
+
+  void set_select_certificate_cb(SSL_CTX *ctx );
+
+  //bssl::UniquePtr<SSL> newSsl(SSL_CTX *ctx);
+
+  int set_strict_cipher_list(SSL_CTX *ctx, const char *str);
+
+  std::string getSerialNumberFromCertificate(X509* cert);
+
+  void allowRenegotiation(SSL* ssl);
+
+  bssl::UniquePtr<STACK_OF(X509_NAME)> initX509Names();
+
+  EVP_MD_CTX* newEVP_MD_CTX();
+
+  SSL_SESSION *ssl_session_from_bytes(SSL *client_ssl_socket, const SSL_CTX *client_ssl_context, const std::string& client_session);
+
+  int ssl_session_to_bytes(const SSL_SESSION *in, uint8_t **out_data, size_t *out_len);
+
+  X509* getVerifyCallbackCert(X509_STORE_CTX* store_ctx, void* arg);
+
+  int ssl_session_is_resumable(const SSL_SESSION* session);
+
+  void ssl_ctx_add_client_CA(SSL_CTX *ctx, X509 *x);
+
+  int should_be_single_use(const SSL_SESSION *session);
+
+} // namespace Ssl
+} // namespace Envoy

--- a/source/common/ssl/ssl_socket.cc
+++ b/source/common/ssl/ssl_socket.cc
@@ -12,6 +12,8 @@
 #include "openssl/err.h"
 #include "openssl/x509v3.h"
 
+#include <iostream>
+
 using Envoy::Network::PostIoAction;
 
 namespace Envoy {

--- a/source/common/ssl/ssl_socket.h
+++ b/source/common/ssl/ssl_socket.h
@@ -12,6 +12,7 @@
 #include "common/common/logger.h"
 #include "common/ssl/context_impl.h"
 #include "common/ssl/utility.h"
+#include "common/ssl/ssl_impl.h"
 
 #include "absl/synchronization/mutex.h"
 #include "openssl/ssl.h"

--- a/source/common/ssl/utility.cc
+++ b/source/common/ssl/utility.cc
@@ -26,18 +26,7 @@ inline bssl::UniquePtr<ASN1_TIME> currentASN1_Time(TimeSource& time_source) {
 }
 
 std::string Utility::getSerialNumberFromCertificate(X509& cert) {
-  ASN1_INTEGER* serial_number = X509_get_serialNumber(&cert);
-  BIGNUM num_bn;
-  BN_init(&num_bn);
-  ASN1_INTEGER_to_BN(serial_number, &num_bn);
-  char* char_serial_number = BN_bn2hex(&num_bn);
-  BN_free(&num_bn);
-  if (char_serial_number != nullptr) {
-    std::string serial_number(char_serial_number);
-    OPENSSL_free(char_serial_number);
-    return serial_number;
-  }
-  return "";
+  return Envoy::Ssl::getSerialNumberFromCertificate(&cert);
 }
 
 std::vector<std::string> Utility::getSubjectAltNames(X509& cert, int type) {

--- a/source/common/ssl/utility.h
+++ b/source/common/ssl/utility.h
@@ -4,6 +4,8 @@
 #include <vector>
 
 #include "common/common/utility.h"
+#include "common/ssl/ssl_impl.h"
+#include "common/ssl/ssl_impl_common.h"
 
 #include "openssl/ssl.h"
 

--- a/source/extensions/filters/listener/tls_inspector/BUILD
+++ b/source/extensions/filters/listener/tls_inspector/BUILD
@@ -13,8 +13,14 @@ envoy_package()
 
 envoy_cc_library(
     name = "tls_inspector_lib",
-    srcs = ["tls_inspector.cc"],
-    hdrs = ["tls_inspector.h"],
+    srcs = [
+        "tls_inspector.cc",
+        "ssl_impl_tls_inspector.cc",
+    ],
+    hdrs = [
+        "tls_inspector.h",
+        "ssl_impl_tls_inspector.h",
+    ],
     external_deps = ["ssl"],
     deps = [
         "//include/envoy/event:dispatcher_interface",
@@ -25,6 +31,7 @@ envoy_cc_library(
         "//source/common/common:assert_lib",
         "//source/common/common:minimal_logger_lib",
         "//source/extensions/transport_sockets:well_known_names",
+        "//source/common/ssl:ssl_impl_hdrs_lib",
     ],
 )
 
@@ -38,3 +45,4 @@ envoy_cc_library(
         "//source/extensions/filters/listener/tls_inspector:tls_inspector_lib",
     ],
 )
+

--- a/source/extensions/filters/listener/tls_inspector/ssl_impl_tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/ssl_impl_tls_inspector.cc
@@ -1,0 +1,62 @@
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "openssl/ssl.h"
+#include "openssl/hmac.h"
+#include "openssl/rand.h"
+#include "openssl/x509v3.h"
+
+#include "common/ssl/ssl_impl.h"
+#include "extensions/filters/listener/tls_inspector/tls_inspector.h"
+
+namespace Envoy {
+namespace Ssl {
+
+const SSL_METHOD *TLS_with_buffers_method(void) {
+  return TLS_method();
+}
+
+void set_certificate_cb(SSL_CTX *ctx ){
+  SSL_CTX_set_select_certificate_cb(
+      ctx, [](const SSL_CLIENT_HELLO* client_hello) -> ssl_select_cert_result_t {
+        const uint8_t* data;
+        size_t len;
+        if (SSL_early_callback_ctx_extension_get(
+                client_hello, TLSEXT_TYPE_application_layer_protocol_negotiation, &data, &len)) {
+          Envoy::Extensions::ListenerFilters::TlsInspector::Filter* filter = static_cast<Envoy::Extensions::ListenerFilters::TlsInspector::Filter*>(SSL_get_app_data(client_hello->ssl));
+          filter->onALPN(data, len);
+        }
+        return ssl_select_cert_success;
+      });
+}
+
+int getServernameCallbackReturn(int *out_alert) {
+  *out_alert = SSL_AD_USER_CANCELLED;
+   return SSL_TLSEXT_ERR_ALERT_FATAL;
+}
+ 
+std::vector<absl::string_view> getAlpnProtocols(const unsigned char* data, unsigned int len) {
+  std::vector<absl::string_view> protocols;
+
+  CBS wire, list;
+  CBS_init(&wire, reinterpret_cast<const uint8_t*>(data), static_cast<size_t>(len));
+  if (!CBS_get_u16_length_prefixed(&wire, &list) || CBS_len(&wire) != 0 || CBS_len(&list) < 2) {
+    // Don't produce errors, let the real TLS stack do it.
+    return protocols;
+  }
+  CBS name;
+  while (CBS_len(&list) > 0) {
+    if (!CBS_get_u8_length_prefixed(&list, &name) || CBS_len(&name) == 0) {
+      // Don't produce errors, let the real TLS stack do it.
+      return protocols;
+    }
+    protocols.emplace_back(reinterpret_cast<const char*>(CBS_data(&name)), CBS_len(&name));
+  }
+
+  return protocols;
+}
+
+} // namespace Ssl
+} // namespace Envoy

--- a/source/extensions/filters/listener/tls_inspector/ssl_impl_tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/ssl_impl_tls_inspector.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "openssl/ssl.h"
+#include "common/ssl/ssl_impl.h"
+
+namespace Envoy {
+namespace Ssl {
+
+const SSL_METHOD *TLS_with_buffers_method();
+
+void set_certificate_cb(SSL_CTX *ctx);
+
+std::vector<absl::string_view> getAlpnProtocols(const unsigned char* data, unsigned int len);
+int getServernameCallbackReturn(int *out_alert);
+
+} // namespace Ssl
+} // namespace Envoy

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -16,7 +16,9 @@
 
 #include "extensions/transport_sockets/well_known_names.h"
 
-#include "openssl/bytestring.h"
+#include "common/ssl/ssl_impl.h"
+#include "extensions/filters/listener/tls_inspector/ssl_impl_tls_inspector.h"
+
 #include "openssl/ssl.h"
 
 namespace Envoy {
@@ -26,7 +28,7 @@ namespace TlsInspector {
 
 Config::Config(Stats::Scope& scope, uint32_t max_client_hello_size)
     : stats_{ALL_TLS_INSPECTOR_STATS(POOL_COUNTER_PREFIX(scope, "tls_inspector."))},
-      ssl_ctx_(SSL_CTX_new(TLS_with_buffers_method())),
+      ssl_ctx_(SSL_CTX_new(Envoy::Ssl::TLS_with_buffers_method())),
       max_client_hello_size_(max_client_hello_size) {
 
   if (max_client_hello_size_ > TLS_MAX_CLIENT_HELLO) {
@@ -36,26 +38,32 @@ Config::Config(Stats::Scope& scope, uint32_t max_client_hello_size)
 
   SSL_CTX_set_options(ssl_ctx_.get(), SSL_OP_NO_TICKET);
   SSL_CTX_set_session_cache_mode(ssl_ctx_.get(), SSL_SESS_CACHE_OFF);
-  SSL_CTX_set_select_certificate_cb(
-      ssl_ctx_.get(), [](const SSL_CLIENT_HELLO* client_hello) -> ssl_select_cert_result_t {
-        const uint8_t* data;
-        size_t len;
-        if (SSL_early_callback_ctx_extension_get(
-                client_hello, TLSEXT_TYPE_application_layer_protocol_negotiation, &data, &len)) {
-          Filter* filter = static_cast<Filter*>(SSL_get_app_data(client_hello->ssl));
-          filter->onALPN(data, len);
-        }
-        return ssl_select_cert_success;
-      });
-  SSL_CTX_set_tlsext_servername_callback(
-      ssl_ctx_.get(), [](SSL* ssl, int* out_alert, void*) -> int {
-        Filter* filter = static_cast<Filter*>(SSL_get_app_data(ssl));
-        filter->onServername(SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name));
 
-        // Return an error to stop the handshake; we have what we wanted already.
-        *out_alert = SSL_AD_USER_CANCELLED;
-        return SSL_TLSEXT_ERR_ALERT_FATAL;
-      });
+  Envoy::Ssl::set_certificate_cb(ssl_ctx_.get());
+
+  auto tlsext_servername_cb = +[](SSL *ssl, int* out_alert, void *arg) -> int
+  {
+    Filter* filter = static_cast<Filter*>(SSL_get_app_data(ssl));
+    absl::string_view servername = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
+    filter->onServername(servername);
+
+    return Envoy::Ssl::getServernameCallbackReturn(out_alert);
+  };
+  SSL_CTX_set_tlsext_servername_callback(ssl_ctx_.get(), tlsext_servername_cb);
+
+  auto alpn_cb = [](SSL *ssl,
+                   const unsigned char **out,
+                   unsigned char *outlen,
+                   const unsigned char *in,
+                   unsigned int inlen,
+                   void *arg) -> int
+  {
+    Filter* filter = static_cast<Filter*>(SSL_get_app_data(ssl));
+    filter->onALPN(in, inlen);
+
+    return SSL_TLSEXT_ERR_OK;
+  };
+  SSL_CTX_set_alpn_select_cb(ssl_ctx_.get(), alpn_cb, nullptr);
 }
 
 bssl::UniquePtr<SSL> Config::newSsl() { return bssl::UniquePtr<SSL>{SSL_new(ssl_ctx_.get())}; }
@@ -100,21 +108,7 @@ Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
 }
 
 void Filter::onALPN(const unsigned char* data, unsigned int len) {
-  CBS wire, list;
-  CBS_init(&wire, reinterpret_cast<const uint8_t*>(data), static_cast<size_t>(len));
-  if (!CBS_get_u16_length_prefixed(&wire, &list) || CBS_len(&wire) != 0 || CBS_len(&list) < 2) {
-    // Don't produce errors, let the real TLS stack do it.
-    return;
-  }
-  CBS name;
-  std::vector<absl::string_view> protocols;
-  while (CBS_len(&list) > 0) {
-    if (!CBS_get_u8_length_prefixed(&list, &name) || CBS_len(&name) == 0) {
-      // Don't produce errors, let the real TLS stack do it.
-      return;
-    }
-    protocols.emplace_back(reinterpret_cast<const char*>(CBS_data(&name)), CBS_len(&name));
-  }
+  std::vector<absl::string_view> protocols = Envoy::Ssl::getAlpnProtocols(data, len);
   cb_->socket().setRequestedApplicationProtocols(protocols);
   alpn_found_ = true;
 }

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -8,7 +8,7 @@
 
 #include "common/common/logger.h"
 
-#include "openssl/bytestring.h"
+#include "common/ssl/ssl_impl.h"
 #include "openssl/ssl.h"
 
 namespace Envoy {
@@ -68,13 +68,13 @@ public:
 
   // Network::ListenerFilter
   Network::FilterStatus onAccept(Network::ListenerFilterCallbacks& cb) override;
+  void onALPN(const unsigned char* data, unsigned int len);
 
 private:
   void parseClientHello(const void* data, size_t len);
   void onRead();
   void onTimeout();
   void done(bool success);
-  void onALPN(const unsigned char* data, unsigned int len);
   void onServername(absl::string_view name);
 
   ConfigSharedPtr config_;

--- a/test/common/ssl/BUILD
+++ b/test/common/ssl/BUILD
@@ -12,14 +12,16 @@ envoy_package()
 envoy_cc_test(
     name = "ssl_socket_test",
     srcs = [
-        "ssl_certs_test.h",
         "ssl_socket_test.cc",
+        "ssl_certs_test.h",
     ],
     data = [
         "gen_unittest_certs.sh",
         "//test/common/ssl/test_data:certs",
     ],
-    external_deps = ["ssl"],
+    external_deps = [
+        "ssl"
+    ],
     deps = [
         "//include/envoy/network:transport_socket_interface",
         "//source/common/buffer:buffer_lib",
@@ -34,6 +36,8 @@ envoy_cc_test(
         "//source/common/ssl:context_lib",
         "//source/common/ssl:ssl_socket_lib",
         "//source/common/ssl:utility_lib",
+        "//source/common/ssl:ssl_impl_common_hdrs_lib",
+        "//source/common/ssl:ssl_impl_common_lib",
         "//source/common/stats:isolated_store_lib",
         "//source/common/stats:stats_lib",
         "//source/extensions/filters/listener/tls_inspector:tls_inspector_lib",

--- a/test/common/ssl/ssl_socket_test.cc
+++ b/test/common/ssl/ssl_socket_test.cc
@@ -209,8 +209,7 @@ const std::string testUtilV2(
     SSL* client_ssl_socket = ssl_socket->rawSslForTest();
     SSL_CTX* client_ssl_context = SSL_get_SSL_CTX(client_ssl_socket);
     SSL_SESSION* client_ssl_session =
-        SSL_SESSION_from_bytes(reinterpret_cast<const uint8_t*>(client_session.data()),
-                               client_session.size(), client_ssl_context);
+        Envoy::Ssl::ssl_session_from_bytes(client_ssl_socket, client_ssl_context, client_session);
     int rc = SSL_set_session(client_ssl_socket, client_ssl_session);
     ASSERT(rc == 1);
     SSL_SESSION_free(client_ssl_session);
@@ -276,10 +275,10 @@ const std::string testUtilV2(
       }
 
       SSL_SESSION* client_ssl_session = SSL_get_session(client_ssl_socket);
-      EXPECT_TRUE(SSL_SESSION_is_resumable(client_ssl_session));
+      EXPECT_TRUE(Envoy::Ssl::ssl_session_is_resumable(client_ssl_session));
       uint8_t* session_data;
       size_t session_len;
-      int rc = SSL_SESSION_to_bytes(client_ssl_session, &session_data, &session_len);
+      int rc = Envoy::Ssl::ssl_session_to_bytes(client_ssl_session, &session_data, &session_len);
       ASSERT(rc == 1);
       new_session = std::string(reinterpret_cast<char*>(session_data), session_len);
       OPENSSL_free(session_data);
@@ -2013,7 +2012,7 @@ void testTicketSessionResumption(const std::string& server_ctx_yaml1,
         const Ssl::SslSocket* ssl_socket =
             dynamic_cast<const Ssl::SslSocket*>(client_connection->ssl());
         ssl_session = SSL_get1_session(ssl_socket->rawSslForTest());
-        EXPECT_TRUE(SSL_SESSION_is_resumable(ssl_session));
+        EXPECT_TRUE(Envoy::Ssl::ssl_session_is_resumable(ssl_session));
         client_connection->close(Network::ConnectionCloseType::NoFlush);
         server_connection->close(Network::ConnectionCloseType::NoFlush);
         dispatcher.exit();
@@ -2431,7 +2430,7 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
         const Ssl::SslSocket* ssl_socket =
             dynamic_cast<const Ssl::SslSocket*>(client_connection->ssl());
         ssl_session = SSL_get1_session(ssl_socket->rawSslForTest());
-        EXPECT_TRUE(SSL_SESSION_is_resumable(ssl_session));
+        EXPECT_TRUE(Envoy::Ssl::ssl_session_is_resumable(ssl_session));
         server_connection->close(Network::ConnectionCloseType::NoFlush);
         client_connection->close(Network::ConnectionCloseType::NoFlush);
         dispatcher_->exit();

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -193,8 +193,12 @@ envoy_cc_library(
     name = "tls_utility_lib",
     srcs = ["tls_utility.cc"],
     hdrs = ["tls_utility.h"],
-    external_deps = ["ssl"],
+    external_deps = [
+        "ssl",
+    ],
     deps = [
         "//source/common/common:assert_lib",
+        "//source/common/ssl:ssl_impl_common_hdrs_lib",
+        "//source/extensions/filters/listener/tls_inspector:tls_inspector_lib",
     ],
 )

--- a/test/test_common/tls_utility.cc
+++ b/test/test_common/tls_utility.cc
@@ -2,6 +2,8 @@
 
 #include "common/common/assert.h"
 
+#include "extensions/filters/listener/tls_inspector/ssl_impl_tls_inspector.h"
+
 #include "openssl/ssl.h"
 
 namespace Envoy {
@@ -9,7 +11,7 @@ namespace Tls {
 namespace Test {
 
 std::vector<uint8_t> generateClientHello(const std::string& sni_name, const std::string& alpn) {
-  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_with_buffers_method()));
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(Envoy::Ssl::TLS_with_buffers_method()));
 
   const long flags = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION;
   SSL_CTX_set_options(ctx.get(), flags);

--- a/test/test_common/tls_utility.h
+++ b/test/test_common/tls_utility.h
@@ -3,6 +3,8 @@
 #include <string>
 #include <vector>
 
+#include "common/ssl/ssl_impl.h"
+
 namespace Envoy {
 namespace Tls {
 namespace Test {

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -30,7 +30,7 @@ build:clang-asan --test_tag_filters=-no_asan
 build:clang-asan --define signal_trace=disabled
 build:clang-asan --copt -DADDRESS_SANITIZER=1
 build:clang-asan --test_env=ASAN_SYMBOLIZER_PATH
-build:clang-asan --test_env=ASAN_OPTIONS=handle_abort=1:allow_addr2line=true
+build:clang-asan --test_env=ASAN_OPTIONS=handle_abort=1
 build:clang-asan --linkopt -fuse-ld=lld
 
 # Clang 5.0 TSAN
@@ -51,3 +51,7 @@ build:clang-msan --linkopt -fuse-ld=lld
 
 # Test options
 test --test_env=HEAPCHECK=normal --test_env=PPROF_PATH
+
+# Add compile option for all C++ files
+build --cxxopt -Wno-error=unused-parameter
+


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*: Creates an abstraction layer in ssl packages (e.g. common/ssl and extensions/filters/listener/tls_inspector) to separate the code sections that differ between boringssl and openssl. Includes corresponding changes to bazel configuration. There is an external repo (https://github.com/bdecoste/sslimpl) that contains a script (openssl.sh) that will replace the boringssl-specific libraries with external openssl-specific libraries via the bazel config. 
*Risk Level*: Medium
*Testing*: All common/ssl and extensions/filters/listener/tls_inspector tests passing for both boringssl changes in this PR as well as the plugged-in boringssl external libraries. 
*Docs Changes*: No docs changes
*Release Notes*: No release notes
[Optional Fixes #Issue]
[Optional *Deprecated*:]
