### PR TITLE
access log: add DOWNSTREAM_CONNECTION_TERMINATION

### DIFF
--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -196,6 +196,7 @@ The following command operators are supported:
     * **UO**: Upstream overflow (:ref:`circuit breaking <arch_overview_circuit_break>`) in addition to 503 response code.
     * **NR**: No :ref:`route configured <arch_overview_http_routing>` for a given request in addition to 404 response code.
   HTTP only
+    * **DC**: Downstream connection termination.
     * **LH**: Local service failed :ref:`health check request <arch_overview_health_checking>` in addition to 503 response code.
     * **UT**: Upstream request timeout in addition to 504 response code.
     * **LR**: Connection local reset in addition to 503 response code.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -5,6 +5,7 @@ Version history
 ===============
 * access log: added a :ref:`JSON logging mode <config_access_log_format_dictionaries>` to output access logs in JSON format.
 * access log: added dynamic metadata to access log messages streamed over gRPC.
+* access log: added DOWNSTREAM_CONNECTION_TERMINATION.
 * admin: added support for displaying subject alternate names in :ref:`certs<operations_admin_interface_certs>` end point.
 * admin: :http:get:`/server_info` now responds with a JSON object instead of a single string.
 * admin: :http:get:`/server_info` now exposes what stage of initialization the server is currently in.

--- a/source/common/stream_info/utility.cc
+++ b/source/common/stream_info/utility.cc
@@ -35,7 +35,9 @@ const std::string ResponseFlagUtils::toShortString(const StreamInfo& stream_info
 
   static_assert(ResponseFlag::LastFlag == 0x2000, "A flag has been added. Fix this code.");
 
-  // stream_info.protocol() is only available for HTTP requests.
+  // A downstream disconnect can be identified for HTTP requests when the upstream returns with a 0
+  // response code and when no other response flags are set. The stream_info.protocol() is only set
+  // for the HTTP protocol, and, therefore, we can identify such requests here.
   if (stream_info.protocol() && !stream_info.hasAnyResponseFlag() && !stream_info.responseCode()) {
     appendString(result, DOWNSTREAM_CONNECTION_TERMINATION);
   }

--- a/source/common/stream_info/utility.cc
+++ b/source/common/stream_info/utility.cc
@@ -6,6 +6,7 @@ namespace Envoy {
 namespace StreamInfo {
 
 const std::string ResponseFlagUtils::NONE = "-";
+const std::string ResponseFlagUtils::DOWNSTREAM_CONNECTION_TERMINATION = "DC";
 const std::string ResponseFlagUtils::FAILED_LOCAL_HEALTH_CHECK = "LH";
 const std::string ResponseFlagUtils::NO_HEALTHY_UPSTREAM = "UH";
 const std::string ResponseFlagUtils::UPSTREAM_REQUEST_TIMEOUT = "UT";
@@ -33,6 +34,11 @@ const std::string ResponseFlagUtils::toShortString(const StreamInfo& stream_info
   std::string result;
 
   static_assert(ResponseFlag::LastFlag == 0x2000, "A flag has been added. Fix this code.");
+
+  // stream_info.protocol() is only available for HTTP requests.
+  if (stream_info.protocol() && !stream_info.hasAnyResponseFlag() && !stream_info.responseCode()) {
+    appendString(result, DOWNSTREAM_CONNECTION_TERMINATION);
+  }
 
   if (stream_info.hasResponseFlag(ResponseFlag::FailedLocalHealthCheck)) {
     appendString(result, FAILED_LOCAL_HEALTH_CHECK);

--- a/source/common/stream_info/utility.h
+++ b/source/common/stream_info/utility.h
@@ -21,6 +21,7 @@ private:
   static void appendString(std::string& result, const std::string& append);
 
   const static std::string NONE;
+  const static std::string DOWNSTREAM_CONNECTION_TERMINATION;
   const static std::string FAILED_LOCAL_HEALTH_CHECK;
   const static std::string NO_HEALTHY_UPSTREAM;
   const static std::string UPSTREAM_REQUEST_TIMEOUT;

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -105,7 +105,7 @@ TEST(AccessLogFormatterTest, streamInfoFormatter) {
   {
     StreamInfoFormatter protocol_format("PROTOCOL");
     absl::optional<Http::Protocol> protocol = Http::Protocol::Http11;
-    EXPECT_CALL(stream_info, protocol()).WillOnce(Return(protocol));
+    EXPECT_CALL(stream_info, protocol()).Times(2).WillRepeatedly(Return(protocol));
     EXPECT_EQ("HTTP/1.1", protocol_format.format(header, header, header, stream_info));
   }
 
@@ -138,6 +138,7 @@ TEST(AccessLogFormatterTest, streamInfoFormatter) {
 
   {
     StreamInfoFormatter response_flags_format("RESPONSE_FLAGS");
+    ON_CALL(stream_info, hasAnyResponseFlag()).WillByDefault(Return(true));
     ON_CALL(stream_info, hasResponseFlag(StreamInfo::ResponseFlag::LocalReset))
         .WillByDefault(Return(true));
     EXPECT_EQ("LR", response_flags_format.format(header, header, header, stream_info));

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -104,9 +104,9 @@ TEST_F(AccessLogImplTest, EnvoyUpstreamServiceTime) {
   response_headers_.addCopy(Http::Headers::get().EnvoyUpstreamServiceTime, "999");
 
   log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
-  EXPECT_EQ(
-      "[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 - 1 2 3 999 \"-\" \"-\" \"-\" \"-\" \"-\"\n",
-      output_);
+  EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 DC 1 2 3 999 \"-\" \"-\" \"-\" \"-\" "
+            "\"-\"\n",
+            output_);
 }
 
 TEST_F(AccessLogImplTest, NoFilter) {
@@ -121,7 +121,7 @@ TEST_F(AccessLogImplTest, NoFilter) {
   EXPECT_CALL(*file_, write(_));
   log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
   EXPECT_EQ(
-      "[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 - 1 2 3 - \"-\" \"-\" \"-\" \"-\" \"-\"\n",
+      "[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 DC 1 2 3 - \"-\" \"-\" \"-\" \"-\" \"-\"\n",
       output_);
 }
 
@@ -139,7 +139,7 @@ TEST_F(AccessLogImplTest, UpstreamHost) {
 
   EXPECT_CALL(*file_, write(_));
   log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
-  EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 - 1 2 3 - \"-\" \"-\" \"-\" \"-\" "
+  EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 DC 1 2 3 - \"-\" \"-\" \"-\" \"-\" "
             "\"10.0.0.5:1234\"\n",
             output_);
 }
@@ -314,7 +314,7 @@ TEST_F(AccessLogImplTest, PathRewrite) {
 
   EXPECT_CALL(*file_, write(_));
   log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
-  EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET /bar HTTP/1.1\" 0 - 1 2 3 - \"-\" \"-\" \"-\" \"-\" "
+  EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET /bar HTTP/1.1\" 0 DC 1 2 3 - \"-\" \"-\" \"-\" \"-\" "
             "\"-\"\n",
             output_);
 }

--- a/test/common/stream_info/utility_test.cc
+++ b/test/common/stream_info/utility_test.cc
@@ -46,6 +46,16 @@ TEST(ResponseFlagUtilsTest, toShortStringConversion) {
     EXPECT_EQ("-", ResponseFlagUtils::toShortString(stream_info));
   }
 
+  // Downstream connection terminated.
+  {
+    NiceMock<MockStreamInfo> stream_info;
+    ON_CALL(stream_info, hasResponseFlag(_)).WillByDefault(Return(false));
+    ON_CALL(stream_info, protocol())
+        .WillByDefault(Return(absl::make_optional<Http::Protocol>(Http::Protocol::Http11)));
+    ON_CALL(stream_info, responseCode()).WillByDefault(Return(absl::nullopt));
+    EXPECT_EQ("DC", ResponseFlagUtils::toShortString(stream_info));
+  }
+
   // Test combinations.
   // These are not real use cases, but are used to cover multiple response flags case.
   {

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -125,7 +125,7 @@ TEST(HttpConnManFinalizerImpl, OriginalAndLongPath) {
   absl::optional<Http::Protocol> protocol = Http::Protocol::Http2;
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(11));
-  EXPECT_CALL(stream_info, protocol()).WillOnce(ReturnPointee(&protocol));
+  EXPECT_CALL(stream_info, protocol()).Times(2).WillRepeatedly(ReturnPointee(&protocol));
   absl::optional<uint32_t> response_code;
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
 
@@ -151,7 +151,7 @@ TEST(HttpConnManFinalizerImpl, NoGeneratedId) {
   absl::optional<Http::Protocol> protocol = Http::Protocol::Http2;
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(11));
-  EXPECT_CALL(stream_info, protocol()).WillOnce(ReturnPointee(&protocol));
+  EXPECT_CALL(stream_info, protocol()).Times(2).WillRepeatedly(ReturnPointee(&protocol));
   absl::optional<uint32_t> response_code;
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
 
@@ -218,7 +218,7 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
 
   absl::optional<Http::Protocol> protocol = Http::Protocol::Http10;
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
-  EXPECT_CALL(stream_info, protocol()).WillOnce(ReturnPointee(&protocol));
+  EXPECT_CALL(stream_info, protocol()).Times(2).WillRepeatedly(ReturnPointee(&protocol));
   const std::string service_node = "i-453";
 
   // Check that span is populated correctly.
@@ -238,7 +238,7 @@ TEST(HttpConnManFinalizerImpl, SpanOptionalHeaders) {
   EXPECT_CALL(span, setTag(Tracing::Tags::get().HTTP_STATUS_CODE, "0"));
   EXPECT_CALL(span, setTag(Tracing::Tags::get().ERROR, Tracing::Tags::get().TRUE));
   EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_SIZE, "100"));
-  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "-"));
+  EXPECT_CALL(span, setTag(Tracing::Tags::get().RESPONSE_FLAGS, "DC"));
   EXPECT_CALL(span, setTag(Tracing::Tags::get().UPSTREAM_CLUSTER, _)).Times(0);
 
   NiceMock<MockConfig> config;
@@ -259,7 +259,7 @@ TEST(HttpConnManFinalizerImpl, SpanPopulatedFailureResponse) {
   request_headers.insertClientTraceId().value(std::string("client_trace_id"));
 
   absl::optional<Http::Protocol> protocol = Http::Protocol::Http10;
-  EXPECT_CALL(stream_info, protocol()).WillOnce(ReturnPointee(&protocol));
+  EXPECT_CALL(stream_info, protocol()).Times(2).WillRepeatedly(ReturnPointee(&protocol));
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
   const std::string service_node = "i-453";
 


### PR DESCRIPTION
*Description*: This adds a new "DC" response flag for cases where the downstream connection terminates before any HTTP response is generated.
*Risk Level*: Low
*Testing*: Added a test case
*Docs Changes*: Documented the new "DC" response flag
*Release Notes*: Added a note about the change
Fixes #5119.