### PR TITLE
docs: update circuit breaking docs to reflect conn pool changes

### DIFF
--- a/docs/root/intro/arch_overview/circuit_breaking.rst
+++ b/docs/root/intro/arch_overview/circuit_breaking.rst
@@ -13,10 +13,11 @@ configure and code each application independently. Envoy supports various types 
   all hosts in an upstream cluster. In practice this is only applicable to HTTP/1.1 clusters since
   HTTP/2 uses a single connection to each host.
 * **Cluster maximum pending requests**: The maximum number of requests that will be queued while
-  waiting for a ready connection pool connection. In practice this is only applicable to HTTP/1.1
-  clusters since HTTP/2 connection pools never queue requests. HTTP/2 requests are multiplexed
-  immediately. If this circuit breaker overflows the :ref:`upstream_rq_pending_overflow
-  <config_cluster_manager_cluster_stats>` counter for the cluster will increment.
+  waiting for a ready connection pool connection. Since HTTP/2 requests are sent over a single
+  connection, this circuit breaker only comes into play as the initial connection is created,
+  as requests will be multiplexed immediately afterwards. If this circuit breaker overflows the
+  :ref:`upstream_rq_pending_overflow <config_cluster_manager_cluster_stats>` counter for the cluster
+  will increment.
 * **Cluster maximum requests**: The maximum number of requests that can be outstanding to all hosts
   in a cluster at any given time. In practice this is applicable to HTTP/2 clusters since HTTP/1.1
   clusters are governed by the maximum connections circuit breaker. If this circuit breaker

--- a/docs/root/intro/arch_overview/circuit_breaking.rst
+++ b/docs/root/intro/arch_overview/circuit_breaking.rst
@@ -15,9 +15,12 @@ configure and code each application independently. Envoy supports various types 
 * **Cluster maximum pending requests**: The maximum number of requests that will be queued while
   waiting for a ready connection pool connection. Since HTTP/2 requests are sent over a single
   connection, this circuit breaker only comes into play as the initial connection is created,
-  as requests will be multiplexed immediately afterwards. If this circuit breaker overflows the
-  :ref:`upstream_rq_pending_overflow <config_cluster_manager_cluster_stats>` counter for the cluster
-  will increment.
+  as requests will be multiplexed immediately afterwards. For HTTP/1.1 requests are added to the list
+  of pending requests whenever there aren't enough upstreams connections available to immeditely dispatch
+  the request, so this circuit breaker will remain in play for the lifetime of the process.
+  If this circuit breaker overflows the
+  :ref:`upstream_rq_pending_overflow <config_cluster_manager_cluster_stats>` counter for the cluster will
+  increment.
 * **Cluster maximum requests**: The maximum number of requests that can be outstanding to all hosts
   in a cluster at any given time. In practice this is applicable to HTTP/2 clusters since HTTP/1.1
   clusters are governed by the maximum connections circuit breaker. If this circuit breaker

--- a/docs/root/intro/arch_overview/circuit_breaking.rst
+++ b/docs/root/intro/arch_overview/circuit_breaking.rst
@@ -16,7 +16,7 @@ configure and code each application independently. Envoy supports various types 
   waiting for a ready connection pool connection. Since HTTP/2 requests are sent over a single
   connection, this circuit breaker only comes into play as the initial connection is created,
   as requests will be multiplexed immediately afterwards. For HTTP/1.1, requests are added to the list
-  of pending requests whenever there aren't enough upstream connections available to immeditely dispatch
+  of pending requests whenever there aren't enough upstream connections available to immediately dispatch
   the request, so this circuit breaker will remain in play for the lifetime of the process.
   If this circuit breaker overflows the
   :ref:`upstream_rq_pending_overflow <config_cluster_manager_cluster_stats>` counter for the cluster will

--- a/docs/root/intro/arch_overview/circuit_breaking.rst
+++ b/docs/root/intro/arch_overview/circuit_breaking.rst
@@ -15,8 +15,8 @@ configure and code each application independently. Envoy supports various types 
 * **Cluster maximum pending requests**: The maximum number of requests that will be queued while
   waiting for a ready connection pool connection. Since HTTP/2 requests are sent over a single
   connection, this circuit breaker only comes into play as the initial connection is created,
-  as requests will be multiplexed immediately afterwards. For HTTP/1.1 requests are added to the list
-  of pending requests whenever there aren't enough upstreams connections available to immeditely dispatch
+  as requests will be multiplexed immediately afterwards. For HTTP/1.1, requests are added to the list
+  of pending requests whenever there aren't enough upstream connections available to immeditely dispatch
   the request, so this circuit breaker will remain in play for the lifetime of the process.
   If this circuit breaker overflows the
   :ref:`upstream_rq_pending_overflow <config_cluster_manager_cluster_stats>` counter for the cluster will


### PR DESCRIPTION
Signed-off-by: Snow Pettersen <snowp@squareup.com>

After https://github.com/envoyproxy/envoy/pull/4917 pending request circuit breakers is enforced
for h/2. This updates the docs to reflect that. 

*Risk Level*: Low 
*Testing*: n/a 
*Docs Changes*: n/a
*Release Notes*: n/a
