### PR TITLE
Update to jwt_verify_lib sha with rapidjson removed

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -101,10 +101,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/msgpack/msgpack-c/archive/cpp-3.1.1.tar.gz"],
     ),
     com_github_google_jwt_verify = dict(
-        sha256 = "9c3a50eac39ae450d09fa69f6802df4099ab619ff93746c4f8ecfc5104463cdb",
-        strip_prefix = "jwt_verify_lib-ce0ca6865bb07631dcdf711ee96fc727e7ac7176",
-        # 2018-08-16
-        urls = ["https://github.com/google/jwt_verify_lib/archive/ce0ca6865bb07631dcdf711ee96fc727e7ac7176.tar.gz"],
+        sha256 = "700be26170c1917e83d1319b88a2112dccd1179cd78c5672940483e7c45ca6ae",
+        strip_prefix = "jwt_verify_lib-85cf0edf1f1bc507ff7d96a8d6a9bc20307b0fcf",
+        # 2018-12-01
+        urls = ["https://github.com/google/jwt_verify_lib/archive/85cf0edf1f1bc507ff7d96a8d6a9bc20307b0fcf.tar.gz"],
     ),
     com_github_nodejs_http_parser = dict(
         sha256 = "f742dc5a206958c4d0a6b2c35e3e102afb5683f55f7a7cb1eae024a03f081347",

--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -131,7 +131,7 @@ void AuthenticatorImpl::startVerify() {
   // the abseil time functionality instead or use the jwt_verify_lib to check
   // the validity of a JWT.
   // Check "exp" claim.
-  const auto unix_timestamp =
+  const uint64_t unix_timestamp =
       std::chrono::duration_cast<std::chrono::seconds>(timeSource().systemTime().time_since_epoch())
           .count();
   // If the nbf claim does *not* appear in the JWT, then the nbf field is defaulted


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

*Description*:

This version of jwt_verify_lib has rapidjson removed.  It uses protobuf Struct to parse JWT and JWKS

*Risk Level*:  Low
*Testing*:  unit-test

*Docs Changes*:  None
*Release Notes*: None
[Optional Fixes #Issue]
[Optional *Deprecated*:]
