### PR TITLE
ratelimit: remove deprecated cluster

### DIFF
--- a/api/envoy/config/ratelimit/v2/rls.proto
+++ b/api/envoy/config/ratelimit/v2/rls.proto
@@ -11,14 +11,12 @@ import "validate/validate.proto";
 
 // Rate limit :ref:`configuration overview <config_rate_limit_service>`.
 message RateLimitServiceConfig {
-  oneof service_specifier {
-    option (validate.required) = true;
+  reserved 1;
 
-    // Specifies the gRPC service that hosts the rate limit service. The client
-    // will connect to this cluster when it needs to make rate limit service
-    // requests.
-    envoy.api.v2.core.GrpcService grpc_service = 2;
-  }
+  // Specifies the gRPC service that hosts the rate limit service. The client
+  // will connect to this cluster when it needs to make rate limit service
+  // requests.
+  envoy.api.v2.core.GrpcService grpc_service = 2;
 
   reserved 3;
 }

--- a/api/envoy/config/ratelimit/v2/rls.proto
+++ b/api/envoy/config/ratelimit/v2/rls.proto
@@ -14,14 +14,6 @@ message RateLimitServiceConfig {
   oneof service_specifier {
     option (validate.required) = true;
 
-    // Specifies the cluster manager cluster name that hosts the rate limit
-    // service. The client will connect to this cluster when it needs to make
-    // rate limit service requests. This field is deprecated and `grpc_service`
-    // should be used instead. The :ref:`Envoy gRPC client
-    // <envoy_api_field_core.GrpcService.envoy_grpc>` will be used when this field is
-    // specified.
-    string cluster_name = 1 [(validate.rules).string.min_bytes = 1, deprecated = true];
-
     // Specifies the gRPC service that hosts the rate limit service. The client
     // will connect to this cluster when it needs to make rate limit service
     // requests.

--- a/api/envoy/config/ratelimit/v2/rls.proto
+++ b/api/envoy/config/ratelimit/v2/rls.proto
@@ -16,7 +16,7 @@ message RateLimitServiceConfig {
   // Specifies the gRPC service that hosts the rate limit service. The client
   // will connect to this cluster when it needs to make rate limit service
   // requests.
-  envoy.api.v2.core.GrpcService grpc_service = 2;
+  envoy.api.v2.core.GrpcService grpc_service = 2 [(validate.rules).message.required = true];
 
   reserved 3;
 }

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -38,6 +38,7 @@ Version history
   `UNAVAILABLE` when a gRPC call is rate limited.
 * rate-limit: removed support for the legacy ratelimit service and made the data-plane-api
   :ref:`rls.proto <envoy_api_file_envoy/service/ratelimit/v2/rls.proto>` based implementation default.
+* rate-limit: removed the deprecated cluster_name attribute in :ref:`rate limit service configuration <envoy_api_file_envoy/config/ratelimit/v2/rls.proto>`.
 * rbac: added dynamic metadata to the network level filter.
 * rbac: added support for permission matching by :ref:`requested server name <envoy_api_field_config.rbac.v2alpha.Permission.requested_server_name>`.
 * redis: static cluster configuration is no longer required. Redis proxy will work with clusters

--- a/source/common/config/bootstrap_json.cc
+++ b/source/common/config/bootstrap_json.cc
@@ -114,10 +114,7 @@ void BootstrapJson::translateBootstrap(const Json::Object& json_config,
 
   if (json_config.hasObject("rate_limit_service")) {
     const auto json_rate_limit_service = json_config.getObject("rate_limit_service");
-    auto* rate_limit_service = bootstrap.mutable_rate_limit_service();
     ASSERT(json_rate_limit_service->getString("type") == "grpc_service");
-    JSON_UTIL_SET_STRING(*json_rate_limit_service->getObject("config"), *rate_limit_service,
-                         cluster_name);
   }
 
   const auto json_admin = json_config.getObject("admin");

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -94,11 +94,6 @@ GrpcFactoryImpl::GrpcFactoryImpl(const envoy::config::ratelimit::v2::RateLimitSe
                                  Stats::Scope& scope) {
   envoy::api::v2::core::GrpcService grpc_service;
   grpc_service.MergeFrom(config.grpc_service());
-  // TODO(htuch): cluster_name is deprecated, remove after 1.6.0.
-  if (config.service_specifier_case() ==
-      envoy::config::ratelimit::v2::RateLimitServiceConfig::kClusterName) {
-    grpc_service.mutable_envoy_grpc()->set_cluster_name(config.cluster_name());
-  }
   async_client_factory_ = async_client_manager.factoryForGrpcService(grpc_service, scope, false);
 }
 

--- a/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
@@ -146,23 +146,6 @@ TEST(RateLimitGrpcFactoryTest, Create) {
   factory.create(absl::optional<std::chrono::milliseconds>());
 }
 
-// TODO(htuch): cluster_name is deprecated, remove after 1.6.0.
-TEST(RateLimitGrpcFactoryTest, CreateLegacy) {
-  envoy::config::ratelimit::v2::RateLimitServiceConfig config;
-  config.set_cluster_name("foo");
-  Grpc::MockAsyncClientManager async_client_manager;
-  Stats::MockStore scope;
-  envoy::api::v2::core::GrpcService expected_grpc_service;
-  expected_grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
-  EXPECT_CALL(async_client_manager,
-              factoryForGrpcService(ProtoEq(expected_grpc_service), Ref(scope), _))
-      .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&, bool) {
-        return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
-      }));
-  GrpcFactoryImpl factory(config, async_client_manager, scope);
-  factory.create(absl::optional<std::chrono::milliseconds>());
-}
-
 TEST(RateLimitNullFactoryTest, Basic) {
   NullFactoryImpl factory;
   ClientPtr client = factory.create(absl::optional<std::chrono::milliseconds>());


### PR DESCRIPTION
*Description*: Removes deprecated cluster from rate limit config.
*Risk Level*: Low
*Testing*: Existing automated tests.
*Docs Changes*: N/A
*Release Notes*: Added
