### PR TITLE
mongo_proxy: decode update and delete messages

### DIFF
--- a/docs/root/configuration/network_filters/mongo_proxy_filter.rst
+++ b/docs/root/configuration/network_filters/mongo_proxy_filter.rst
@@ -29,6 +29,8 @@ following statistics:
 
   decoding_error, Counter, Number of MongoDB protocol decoding errors
   delay_injected, Counter, Number of times the delay is injected
+  op_delete, Counter, Number of OP_DELETE messages
+  op_delete_single, Counter, Number of OP_DELETE messages that targeted the removal of a single document
   op_get_more, Counter, Number of OP_GET_MORE messages
   op_insert, Counter, Number of OP_INSERT messages
   op_kill_cursors, Counter, Number of OP_KILL_CURSORS messages
@@ -45,6 +47,9 @@ following statistics:
   op_reply_cursor_not_found, Counter, Number of OP_REPLY with cursor not found flag set
   op_reply_query_failure, Counter, Number of OP_REPLY with query failure flag set
   op_reply_valid_cursor, Counter, Number of OP_REPLY with a valid cursor
+  op_update, Counter, Number of OP_UPDATE messages
+  op_multi_update, Counter, Number of OP_UPDATE messages that targeted the update of multiple documents
+  op_upsert, Counter, Number of OP_UPDATE messages that targeted an upsert
   cx_destroy_local_with_active_rq, Counter, Connections destroyed locally with an active query
   cx_destroy_remote_with_active_rq, Counter, Connections destroyed remotely with an active query
   cx_drain_close, Counter, Connections gracefully closed on reply boundaries during server drain

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -32,6 +32,7 @@ Version history
 * load balancer: added a `configuration <envoy_api_msg_Cluster.LeastRequestLbConfig>` option to specify the number of choices made in P2C.
 * logging: added missing [ in log prefix.
 * mongo_proxy: added :ref:`dynamic metadata <config_network_filters_mongo_proxy_dynamic_metadata>`.
+* mongo_proxy: added op_update, op_multi_update, op_upsert, op_delete and op_single_delete :ref:`stats <config_network_filters_mongo_proxy_stats>`.
 * network: removed the reference to `FilterState` in `Connection` in favor of `StreamInfo`.
 * rate-limit: added :ref:`configuration <envoy_api_field_config.filter.http.rate_limit.v2.RateLimit.rate_limited_as_resource_exhausted>`
   to specify whether the `GrpcStatus` status returned should be `RESOURCE_EXHAUSTED` or

--- a/source/extensions/filters/network/mongo_proxy/codec.h
+++ b/source/extensions/filters/network/mongo_proxy/codec.h
@@ -82,6 +82,53 @@ public:
 typedef std::unique_ptr<InsertMessage> InsertMessagePtr;
 
 /**
+ * Mongo OP_UPDATE message.
+ */
+class UpdateMessage : public virtual Message {
+public:
+  struct Flags {
+    // clang-format off
+    static const int32_t Upsert      = 0x1 << 0;
+    static const int32_t MultiUpdate = 0x1 << 1;
+    // clang-format on
+  };
+
+  virtual bool operator==(const UpdateMessage& rhs) const PURE;
+
+  virtual const std::string& fullCollectionName() const PURE;
+  virtual void fullCollectionName(const std::string& name) PURE;
+  virtual int32_t flags() const PURE;
+  virtual void flags(int32_t flags) PURE;
+  virtual const Bson::Document* selector() const PURE;
+  virtual void selector(Bson::DocumentSharedPtr&& selector) PURE;
+  virtual const Bson::Document* update() const PURE;
+  virtual void update(Bson::DocumentSharedPtr&& update) PURE;
+};
+
+typedef std::unique_ptr<UpdateMessage> UpdateMessagePtr;
+
+/**
+ * Mongo OP_DELETE message.
+ */
+class DeleteMessage : public virtual Message {
+public:
+  struct Flags {
+    static const int32_t SingleRemove = 0x1 << 0;
+  };
+
+  virtual bool operator==(const DeleteMessage& rhs) const PURE;
+
+  virtual const std::string& fullCollectionName() const PURE;
+  virtual void fullCollectionName(const std::string& name) PURE;
+  virtual int32_t flags() const PURE;
+  virtual void flags(int32_t flags) PURE;
+  virtual const Bson::Document* selector() const PURE;
+  virtual void selector(Bson::DocumentSharedPtr&& selector) PURE;
+};
+
+typedef std::unique_ptr<DeleteMessage> DeleteMessagePtr;
+
+/**
  * Mongo OP_KILL_CURSORS message.
  */
 class KillCursorsMessage : public virtual Message {
@@ -196,6 +243,8 @@ public:
 
   virtual void decodeGetMore(GetMoreMessagePtr&& message) PURE;
   virtual void decodeInsert(InsertMessagePtr&& message) PURE;
+  virtual void decodeUpdate(UpdateMessagePtr&& message) PURE;
+  virtual void decodeDelete(DeleteMessagePtr&& message) PURE;
   virtual void decodeKillCursors(KillCursorsMessagePtr&& message) PURE;
   virtual void decodeQuery(QueryMessagePtr&& message) PURE;
   virtual void decodeReply(ReplyMessagePtr&& message) PURE;
@@ -224,6 +273,8 @@ public:
 
   virtual void encodeGetMore(const GetMoreMessage& message) PURE;
   virtual void encodeInsert(const InsertMessage& message) PURE;
+  virtual void encodeUpdate(const UpdateMessage& message) PURE;
+  virtual void encodeDelete(const DeleteMessage& message) PURE;
   virtual void encodeKillCursors(const KillCursorsMessage& message) PURE;
   virtual void encodeQuery(const QueryMessage& message) PURE;
   virtual void encodeReply(const ReplyMessage& message) PURE;

--- a/source/extensions/filters/network/mongo_proxy/codec_impl.h
+++ b/source/extensions/filters/network/mongo_proxy/codec_impl.h
@@ -86,6 +86,63 @@ private:
   std::list<Bson::DocumentSharedPtr> documents_;
 };
 
+class UpdateMessageImpl : public MessageImpl,
+                          public UpdateMessage,
+                          Logger::Loggable<Logger::Id::mongo> {
+public:
+  using MessageImpl::MessageImpl;
+
+  // MessageImpl
+  void fromBuffer(uint32_t message_length, Buffer::Instance& data) override;
+
+  // Mongo::Message
+  std::string toString(bool full) const override;
+
+  // Mongo::UpdateMessage
+  bool operator==(const UpdateMessage& rhs) const override;
+  const std::string& fullCollectionName() const override { return full_collection_name_; }
+  void fullCollectionName(const std::string& name) override { full_collection_name_ = name; }
+  int32_t flags() const override { return flags_; }
+  void flags(int32_t flags) override { flags_ = flags; }
+  virtual const Bson::Document* selector() const override { return selector_.get(); }
+  void selector(Bson::DocumentSharedPtr&& selector) override { selector_ = std::move(selector); }
+  virtual const Bson::Document* update() const override { return update_.get(); }
+  void update(Bson::DocumentSharedPtr&& update) override { update_ = std::move(update); }
+
+private:
+  std::string full_collection_name_;
+  int32_t flags_{};
+  Bson::DocumentSharedPtr selector_;
+  Bson::DocumentSharedPtr update_;
+};
+
+class DeleteMessageImpl : public MessageImpl,
+                          public DeleteMessage,
+                          Logger::Loggable<Logger::Id::mongo> {
+public:
+  using MessageImpl::MessageImpl;
+
+  // MessageImpl
+  void fromBuffer(uint32_t message_length, Buffer::Instance& data) override;
+
+  // Mongo::Message
+  std::string toString(bool full) const override;
+
+  // Mongo::DeleteMessage
+  bool operator==(const DeleteMessage& rhs) const override;
+  const std::string& fullCollectionName() const override { return full_collection_name_; }
+  void fullCollectionName(const std::string& name) override { full_collection_name_ = name; }
+  int32_t flags() const override { return flags_; }
+  void flags(int32_t flags) override { flags_ = flags; }
+  virtual const Bson::Document* selector() const override { return selector_.get(); }
+  void selector(Bson::DocumentSharedPtr&& selector) override { selector_ = std::move(selector); }
+
+private:
+  std::string full_collection_name_;
+  int32_t flags_{};
+  Bson::DocumentSharedPtr selector_;
+};
+
 class KillCursorsMessageImpl : public MessageImpl,
                                public KillCursorsMessage,
                                Logger::Loggable<Logger::Id::mongo> {
@@ -269,6 +326,8 @@ public:
   // Mongo::Encoder
   void encodeGetMore(const GetMoreMessage& message) override;
   void encodeInsert(const InsertMessage& message) override;
+  void encodeUpdate(const UpdateMessage& message) override;
+  void encodeDelete(const DeleteMessage& message) override;
   void encodeKillCursors(const KillCursorsMessage& message) override;
   void encodeQuery(const QueryMessage& message) override;
   void encodeReply(const ReplyMessage& message) override;

--- a/source/extensions/filters/network/mongo_proxy/proxy.h
+++ b/source/extensions/filters/network/mongo_proxy/proxy.h
@@ -52,6 +52,11 @@ typedef ConstSingleton<MongoRuntimeConfigKeys> MongoRuntimeConfig;
   COUNTER(delays_injected)                                                                         \
   COUNTER(op_get_more)                                                                             \
   COUNTER(op_insert)                                                                               \
+  COUNTER(op_update)                                                                               \
+  COUNTER(op_multi_update)                                                                         \
+  COUNTER(op_upsert)                                                                               \
+  COUNTER(op_delete)                                                                               \
+  COUNTER(op_delete_single)                                                                        \
   COUNTER(op_kill_cursors)                                                                         \
   COUNTER(op_query)                                                                                \
   COUNTER(op_query_tailable_cursor)                                                                \
@@ -147,6 +152,8 @@ public:
   // Mongo::DecoderCallback
   void decodeGetMore(GetMoreMessagePtr&& message) override;
   void decodeInsert(InsertMessagePtr&& message) override;
+  void decodeUpdate(UpdateMessagePtr&& message) override;
+  void decodeDelete(DeleteMessagePtr&& message) override;
   void decodeKillCursors(KillCursorsMessagePtr&& message) override;
   void decodeQuery(QueryMessagePtr&& message) override;
   void decodeReply(ReplyMessagePtr&& message) override;


### PR DESCRIPTION
*Description*: This enhances the mongo proxy by decoding OP_UPDATE and OP_DELETE messages and generating useful stats and dynamic metadata.
*Risk Level*: Low
*Testing*: Added/updated several tests
*Docs Changes*: Added new stats to the list
*Release Notes*: Added a note about the change