### PR TITLE
docs: remove reference to stamped build from bazel README

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -327,7 +327,7 @@ They should also ignore any local `.bazelrc` for reproducibility. This can be
 achieved with:
 
 ```
-bazel --bazelrc=/dev/null build -c opt //source/exe:envoy-static.stripped.stamped
+bazel --bazelrc=/dev/null build -c opt //source/exe:envoy-static.stripped
 ```
 
 One caveat to note is that the Git SHA1 is truncated to 16 bytes today as a


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

*Description*: Remove stale reference to stamped target in Bazel docs
*Risk Level*: Low
*Testing*: N/A 
*Docs Changes*: N/A
*Release Notes*: N/A
Fixes #4695 
