### PR TITLE
upstream: add degraded to host/host set interfaces

### DIFF
--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -111,6 +111,11 @@ public:
   virtual bool healthy() const PURE;
 
   /**
+   * @return whether in aggregate a host is degraded. A host is never both degraded and healthy.
+   */
+  virtual bool degraded() const PURE;
+
+  /**
    * Returns the host's ActiveHealthFailureType. Types are specified in ActiveHealthFailureType.
    */
   virtual ActiveHealthFailureType getActiveHealthFailureType() const PURE;
@@ -237,6 +242,14 @@ public:
   virtual const HostVector& healthyHosts() const PURE;
 
   /**
+   * @return all degraded hosts contained in the set at the current time. NOTE: This set is
+   *         eventually consistent. There is a time window where a host in this set may become
+   *         undgraded and calling degraded() on it will return false. Code should be written to
+   *         deal with this case if it matters.
+   */
+  virtual const HostVector& degradedHosts() const PURE;
+
+  /**
    * @return hosts per locality.
    */
   virtual const HostsPerLocality& hostsPerLocality() const PURE;
@@ -245,6 +258,11 @@ public:
    * @return same as hostsPerLocality but only contains healthy hosts.
    */
   virtual const HostsPerLocality& healthyHostsPerLocality() const PURE;
+
+  /**
+   * @return same as hostsPerLocality but only contains degraded hosts.
+   */
+  virtual const HostsPerLocality& degradedHostsPerLocality() const PURE;
 
   /**
    * @return weights for each locality in the host set.
@@ -261,16 +279,20 @@ public:
    *
    * @param hosts supplies the (usually new) list of hosts in the host set.
    * @param healthy hosts supplies the subset of hosts which are healthy.
+   * @param healthy hosts supplies the subset of hosts which are degraded and healthy.
    * @param hosts_per_locality supplies the hosts subdivided by locality.
    * @param hosts_per_locality supplies the healthy hosts subdivided by locality.
+   * @param hosts_per_locality supplies the degraded and not healhty hosts subdivided by locality.
    * @param locality_weights supplies a map from locality to associated weight.
    * @param hosts_added supplies the hosts added since the last update.
    * @param hosts_removed supplies the hosts removed since the last update.
    * @param overprovisioning_factor if presents, overwrites the current overprovisioning_factor.
    */
   virtual void updateHosts(HostVectorConstSharedPtr hosts, HostVectorConstSharedPtr healthy_hosts,
+                           HostVectorConstSharedPtr degraded_hosts,
                            HostsPerLocalityConstSharedPtr hosts_per_locality,
                            HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
+                           HostsPerLocalityConstSharedPtr degraded_hosts_per_locality,
                            LocalityWeightsConstSharedPtr locality_weights,
                            const HostVector& hosts_added, const HostVector& hosts_removed,
                            absl::optional<uint32_t> overprovisioning_factor) PURE;

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -104,17 +104,28 @@ public:
    */
   virtual void healthFlagSet(HealthFlag flag) PURE;
 
-  /**
-   * @return whether in aggregate a host is healthy and routable. Multiple health flags and other
-   *         information may be considered.
-   */
-  virtual bool healthy() const PURE;
+  enum class Health {
+    /**
+     * Host is unhealthy and is not able to serve traffic. A host may be marked as unhealthy either
+     * through EDS or through active health checking.
+     */
+    Unhealthy,
+    /**
+     * Host is healthy, but degraded. It is able to serve traffic, but hosts that aren't degraded
+     * should be preferred. A host may be marked as degraded either through EDS or through active
+     * health checking.
+     */
+    Degraded,
+    /**
+     * Host is healthy and is able to serve traffic.
+     */
+    Healthy,
+  };
 
   /**
-   * @return whether in aggregate a host is degraded. A host is never both degraded and healthy.
-   *         A host may be degraded either through active health checking or through EDS updates.
+   * @return the health of the host.
    */
-  virtual bool degraded() const PURE;
+  virtual Health health() const PURE;
 
   /**
    * Returns the host's ActiveHealthFailureType. Types are specified in ActiveHealthFailureType.

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -112,6 +112,7 @@ public:
 
   /**
    * @return whether in aggregate a host is degraded. A host is never both degraded and healthy.
+   *         A host may be degraded either through active health checking or through EDS updates.
    */
   virtual bool degraded() const PURE;
 
@@ -244,7 +245,7 @@ public:
   /**
    * @return all degraded hosts contained in the set at the current time. NOTE: This set is
    *         eventually consistent. There is a time window where a host in this set may become
-   *         undgraded and calling degraded() on it will return false. Code should be written to
+   *         undegraded and calling degraded() on it will return false. Code should be written to
    *         deal with this case if it matters.
    */
   virtual const HostVector& degradedHosts() const PURE;

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -301,7 +301,7 @@ public:
   /**
    * Updates the hosts in a given host set.
    *
-   * @param update_hosts_param supplies the ;ist of hosts and hosts per localitiy.
+   * @param update_hosts_param supplies the list of hosts and hosts per localitiy.
    * @param locality_weights supplies a map from locality to associated weight.
    * @param hosts_added supplies the hosts added since the last update.
    * @param hosts_removed supplies the hosts removed since the last update.

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -287,24 +287,27 @@ public:
   virtual absl::optional<uint32_t> chooseLocality() PURE;
 
   /**
+   * Parameter class for updateHosts.
+   */
+  struct UpdateHostsParams {
+    HostVectorConstSharedPtr hosts;
+    HostVectorConstSharedPtr healthy_hosts;
+    HostVectorConstSharedPtr degraded_hosts;
+    HostsPerLocalityConstSharedPtr hosts_per_locality;
+    HostsPerLocalityConstSharedPtr healthy_hosts_per_locality;
+    HostsPerLocalityConstSharedPtr degraded_hosts_per_locality;
+  };
+
+  /**
    * Updates the hosts in a given host set.
    *
-   * @param hosts supplies the (usually new) list of hosts in the host set.
-   * @param healthy hosts supplies the subset of hosts which are healthy.
-   * @param healthy hosts supplies the subset of hosts which are degraded and healthy.
-   * @param hosts_per_locality supplies the hosts subdivided by locality.
-   * @param hosts_per_locality supplies the healthy hosts subdivided by locality.
-   * @param hosts_per_locality supplies the degraded and not healhty hosts subdivided by locality.
+   * @param update_hosts_param supplies the ;ist of hosts and hosts per localitiy.
    * @param locality_weights supplies a map from locality to associated weight.
    * @param hosts_added supplies the hosts added since the last update.
    * @param hosts_removed supplies the hosts removed since the last update.
    * @param overprovisioning_factor if presents, overwrites the current overprovisioning_factor.
    */
-  virtual void updateHosts(HostVectorConstSharedPtr hosts, HostVectorConstSharedPtr healthy_hosts,
-                           HostVectorConstSharedPtr degraded_hosts,
-                           HostsPerLocalityConstSharedPtr hosts_per_locality,
-                           HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
-                           HostsPerLocalityConstSharedPtr degraded_hosts_per_locality,
+  virtual void updateHosts(UpdateHostsParams&& update_host_params,
                            LocalityWeightsConstSharedPtr locality_weights,
                            const HostVector& hosts_added, const HostVector& hosts_removed,
                            absl::optional<uint32_t> overprovisioning_factor) PURE;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -687,18 +687,23 @@ void ClusterManagerImpl::postThreadLocalClusterUpdate(const Cluster& cluster, ui
   // TODO(htuch): Can we skip these copies by exporting out const shared_ptr from HostSet?
   HostVectorConstSharedPtr hosts_copy(new HostVector(host_set->hosts()));
   HostVectorConstSharedPtr healthy_hosts_copy(new HostVector(host_set->healthyHosts()));
+  HostVectorConstSharedPtr degraded_hosts_copy(new HostVector(host_set->healthyHosts()));
   HostsPerLocalityConstSharedPtr hosts_per_locality_copy = host_set->hostsPerLocality().clone();
   HostsPerLocalityConstSharedPtr healthy_hosts_per_locality_copy =
       host_set->healthyHostsPerLocality().clone();
+  HostsPerLocalityConstSharedPtr degraded_hosts_per_locality_copy =
+      host_set->degradedHostsPerLocality().clone();
 
-  tls_->runOnAllThreads(
-      [this, name = cluster.info()->name(), priority, hosts_copy, healthy_hosts_copy,
-       hosts_per_locality_copy, healthy_hosts_per_locality_copy,
-       locality_weights = host_set->localityWeights(), hosts_added, hosts_removed]() {
-        ThreadLocalClusterManagerImpl::updateClusterMembership(
-            name, priority, hosts_copy, healthy_hosts_copy, hosts_per_locality_copy,
-            healthy_hosts_per_locality_copy, locality_weights, hosts_added, hosts_removed, *tls_);
-      });
+  tls_->runOnAllThreads([this, name = cluster.info()->name(), priority, hosts_copy,
+                         healthy_hosts_copy, degraded_hosts_copy, hosts_per_locality_copy,
+                         healthy_hosts_per_locality_copy, degraded_hosts_per_locality_copy,
+                         locality_weights = host_set->localityWeights(), hosts_added,
+                         hosts_removed]() {
+    ThreadLocalClusterManagerImpl::updateClusterMembership(
+        name, priority, hosts_copy, healthy_hosts_copy, degraded_hosts_copy,
+        hosts_per_locality_copy, healthy_hosts_per_locality_copy, degraded_hosts_per_locality_copy,
+        locality_weights, hosts_added, hosts_removed, *tls_);
+  });
 }
 
 void ClusterManagerImpl::postThreadLocalHealthFailure(const HostSharedPtr& host) {
@@ -941,8 +946,10 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::removeTcpConn(
 
 void ClusterManagerImpl::ThreadLocalClusterManagerImpl::updateClusterMembership(
     const std::string& name, uint32_t priority, HostVectorConstSharedPtr hosts,
-    HostVectorConstSharedPtr healthy_hosts, HostsPerLocalityConstSharedPtr hosts_per_locality,
+    HostVectorConstSharedPtr healthy_hosts, HostVectorConstSharedPtr degraded_hosts,
+    HostsPerLocalityConstSharedPtr hosts_per_locality,
     HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
+    HostsPerLocalityConstSharedPtr degraded_hosts_per_locality,
     LocalityWeightsConstSharedPtr locality_weights, const HostVector& hosts_added,
     const HostVector& hosts_removed, ThreadLocal::Slot& tls) {
 
@@ -952,8 +959,9 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::updateClusterMembership(
   const auto& cluster_entry = config.thread_local_clusters_[name];
   ENVOY_LOG(debug, "membership update for TLS cluster {}", name);
   cluster_entry->priority_set_.getOrCreateHostSet(priority).updateHosts(
-      std::move(hosts), std::move(healthy_hosts), std::move(hosts_per_locality),
-      std::move(healthy_hosts_per_locality), std::move(locality_weights), hosts_added,
+      std::move(hosts), std::move(healthy_hosts), std::move(degraded_hosts),
+      std::move(hosts_per_locality), std::move(healthy_hosts_per_locality),
+      std::move(degraded_hosts_per_locality), std::move(locality_weights), hosts_added,
       hosts_removed, absl::nullopt);
 
   // If an LB is thread aware, create a new worker local LB on membership changes.

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -314,8 +314,10 @@ private:
     static void updateClusterMembership(const std::string& name, uint32_t priority,
                                         HostVectorConstSharedPtr hosts,
                                         HostVectorConstSharedPtr healthy_hosts,
+                                        HostVectorConstSharedPtr degraded_hosts,
                                         HostsPerLocalityConstSharedPtr hosts_per_locality,
                                         HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
+                                        HostsPerLocalityConstSharedPtr degraded_hosts_per_locality,
                                         LocalityWeightsConstSharedPtr locality_weights,
                                         const HostVector& hosts_added,
                                         const HostVector& hosts_removed, ThreadLocal::Slot& tls);

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -312,12 +312,7 @@ private:
     void drainTcpConnPools(HostSharedPtr old_host, TcpConnPoolsContainer& container);
     void removeTcpConn(const HostConstSharedPtr& host, Network::ClientConnection& connection);
     static void updateClusterMembership(const std::string& name, uint32_t priority,
-                                        HostVectorConstSharedPtr hosts,
-                                        HostVectorConstSharedPtr healthy_hosts,
-                                        HostVectorConstSharedPtr degraded_hosts,
-                                        HostsPerLocalityConstSharedPtr hosts_per_locality,
-                                        HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
-                                        HostsPerLocalityConstSharedPtr degraded_hosts_per_locality,
+                                        HostSet::UpdateHostsParams&& update_hosts_params,
                                         LocalityWeightsConstSharedPtr locality_weights,
                                         const HostVector& hosts_added,
                                         const HostVector& hosts_removed, ThreadLocal::Slot& tls);

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -246,12 +246,10 @@ void HdsCluster::initialize(std::function<void()> callback) {
   }
 
   auto& first_host_set = priority_set_.getOrCreateHostSet(0);
-  auto healthy = ClusterImplBase::createHealthyHostList(*initial_hosts_);
-  auto degraded = ClusterImplBase::createDegradedHostList(*initial_hosts_);
 
-  first_host_set.updateHosts(initial_hosts_, healthy, degraded, HostsPerLocalityImpl::empty(),
-                             HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(), {},
-                             *initial_hosts_, {}, absl::nullopt);
+  first_host_set.updateHosts(
+      HostSetImpl::partitionHosts(initial_hosts_, HostsPerLocalityImpl::empty()), {},
+      *initial_hosts_, {}, absl::nullopt);
 }
 
 void HdsCluster::setOutlierDetector(const Outlier::DetectorSharedPtr&) {

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -78,7 +78,7 @@ HdsDelegate::sendResponse() {
         Network::Utility::addressToProtobufAddress(
             *host->address(), *endpoint->mutable_endpoint()->mutable_address());
         // TODO(lilika): Add support for more granular options of envoy::api::v2::core::HealthStatus
-        if (host->healthy()) {
+        if (host->health() == Host::Health::Healthy) {
           endpoint->set_health_status(envoy::api::v2::core::HealthStatus::HEALTHY);
         } else {
           if (host->getActiveHealthFailureType() == Host::ActiveHealthFailureType::TIMEOUT) {

--- a/source/common/upstream/health_discovery_service.h
+++ b/source/common/upstream/health_discovery_service.h
@@ -71,9 +71,6 @@ protected:
   HealthCheckerSharedPtr health_checker_;
   Outlier::DetectorSharedPtr outlier_detector_;
 
-  // Creates a vector containing any healthy hosts
-  static HostVectorConstSharedPtr createHealthyHostList(const HostVector& hosts);
-
 private:
   std::function<void()> initialization_complete_callback_;
 

--- a/source/common/upstream/host_utility.cc
+++ b/source/common/upstream/host_utility.cc
@@ -6,7 +6,7 @@ namespace Envoy {
 namespace Upstream {
 
 std::string HostUtility::healthFlagsToString(const Host& host) {
-  if (host.healthy()) {
+  if (host.health() == Host::Health::Healthy) {
     return "healthy";
   }
 

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -149,6 +149,7 @@ void OriginalDstCluster::addHost(HostSharedPtr& host) {
   HostVectorSharedPtr new_hosts(new HostVector(first_host_set.hosts()));
   new_hosts->emplace_back(host);
   first_host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts),
+                             createDegradedHostList(*new_hosts), HostsPerLocalityImpl::empty(),
                              HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(), {},
                              {std::move(host)}, {}, absl::nullopt);
 }
@@ -174,6 +175,7 @@ void OriginalDstCluster::cleanup() {
 
   if (to_be_removed.size() > 0) {
     host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts),
+                         createDegradedHostList(*new_hosts), HostsPerLocalityImpl::empty(),
                          HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(), {}, {},
                          to_be_removed, absl::nullopt);
   }

--- a/source/common/upstream/original_dst_cluster.cc
+++ b/source/common/upstream/original_dst_cluster.cc
@@ -148,10 +148,8 @@ void OriginalDstCluster::addHost(HostSharedPtr& host) {
   auto& first_host_set = priority_set_.getOrCreateHostSet(0);
   HostVectorSharedPtr new_hosts(new HostVector(first_host_set.hosts()));
   new_hosts->emplace_back(host);
-  first_host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts),
-                             createDegradedHostList(*new_hosts), HostsPerLocalityImpl::empty(),
-                             HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(), {},
-                             {std::move(host)}, {}, absl::nullopt);
+  first_host_set.updateHosts(HostSetImpl::partitionHosts(new_hosts, HostsPerLocalityImpl::empty()),
+                             {}, {std::move(host)}, {}, absl::nullopt);
 }
 
 void OriginalDstCluster::cleanup() {
@@ -174,10 +172,8 @@ void OriginalDstCluster::cleanup() {
   }
 
   if (to_be_removed.size() > 0) {
-    host_set.updateHosts(new_hosts, createHealthyHostList(*new_hosts),
-                         createDegradedHostList(*new_hosts), HostsPerLocalityImpl::empty(),
-                         HostsPerLocalityImpl::empty(), HostsPerLocalityImpl::empty(), {}, {},
-                         to_be_removed, absl::nullopt);
+    host_set.updateHosts(HostSetImpl::partitionHosts(new_hosts, HostsPerLocalityImpl::empty()), {},
+                         {}, to_be_removed, absl::nullopt);
   }
 
   cleanup_timer_->enableTimer(cleanup_interval_ms_);

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -516,16 +516,16 @@ void SubsetLoadBalancer::HostSubsetImpl::update(const HostVector& hosts_added,
     if (host_seen || predicate(*host)) {
       hosts->emplace_back(host);
       switch (host->health()) {
-        case Host::Health::Healthy:
-          healthy_hosts->emplace_back(host);
-          break;
-        case Host::Health::Degraded:
-          degraded_hosts->emplace_back(host);
-          break;
-        case Host::Health::Unhealthy:
-          break;
-        default:
-          NOT_REACHED_GCOVR_EXCL_LINE;
+      case Host::Health::Healthy:
+        healthy_hosts->emplace_back(host);
+        break;
+      case Host::Health::Degraded:
+        degraded_hosts->emplace_back(host);
+        break;
+      case Host::Health::Unhealthy:
+        break;
+      default:
+        NOT_REACHED_GCOVR_EXCL_LINE;
       }
     }
   }

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -515,11 +515,17 @@ void SubsetLoadBalancer::HostSubsetImpl::update(const HostVector& hosts_added,
     bool host_seen = predicate_added.count(host) == 1;
     if (host_seen || predicate(*host)) {
       hosts->emplace_back(host);
-      if (host->health() == Host::Health::Healthy) {
-        healthy_hosts->emplace_back(host);
-      }
-      if (host->health() == Host::Health::Degraded) {
-        degraded_hosts->emplace_back(host);
+      switch (host->health()) {
+        case Host::Health::Healthy:
+          healthy_hosts->emplace_back(host);
+          break;
+        case Host::Health::Degraded:
+          degraded_hosts->emplace_back(host);
+          break;
+        case Host::Health::Unhealthy:
+          break;
+        default:
+          NOT_REACHED_GCOVR_EXCL_LINE;
       }
     }
   }

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -506,6 +506,7 @@ void SubsetLoadBalancer::HostSubsetImpl::update(const HostVector& hosts_added,
 
   HostVectorSharedPtr hosts(new HostVector());
   HostVectorSharedPtr healthy_hosts(new HostVector());
+  HostVectorSharedPtr degraded_hosts(new HostVector());
 
   // It's possible that hosts_added == original_host_set_.hosts(), e.g.: when
   // calling refreshSubsets() if only metadata change. If so, we can avoid the
@@ -516,6 +517,9 @@ void SubsetLoadBalancer::HostSubsetImpl::update(const HostVector& hosts_added,
       hosts->emplace_back(host);
       if (host->healthy()) {
         healthy_hosts->emplace_back(host);
+      }
+      if (host->degraded()) {
+        degraded_hosts->emplace_back(host);
       }
     }
   }
@@ -539,8 +543,11 @@ void SubsetLoadBalancer::HostSubsetImpl::update(const HostVector& hosts_added,
 
   HostsPerLocalityConstSharedPtr healthy_hosts_per_locality =
       hosts_per_locality->filter([](const Host& host) { return host.healthy(); });
+  HostsPerLocalityConstSharedPtr degraded_hosts_per_locality =
+      hosts_per_locality->filter([](const Host& host) { return host.degraded(); });
 
-  HostSetImpl::updateHosts(hosts, healthy_hosts, hosts_per_locality, healthy_hosts_per_locality,
+  HostSetImpl::updateHosts(hosts, healthy_hosts, degraded_hosts, hosts_per_locality,
+                           healthy_hosts_per_locality, degraded_hosts_per_locality,
                            determineLocalityWeights(*hosts_per_locality), filtered_added,
                            filtered_removed);
 }

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -524,8 +524,6 @@ void SubsetLoadBalancer::HostSubsetImpl::update(const HostVector& hosts_added,
         break;
       case Host::Health::Unhealthy:
         break;
-      default:
-        NOT_REACHED_GCOVR_EXCL_LINE;
       }
     }
   }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1029,7 +1029,7 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(const HostVector& new_hosts,
 
       if (existing_host->second->healthFlagGet(Host::HealthFlag::FAILED_EDS_HEALTH) !=
           host->healthFlagGet(Host::HealthFlag::FAILED_EDS_HEALTH)) {
-        // TODO(snowp): To accomodate degraded, this bit should be checking for any changes
+        // TODO(snowp): To accommodate degraded, this bit should be checking for any changes
         // to the health flag, not just healthy vs not healthy.
         const bool previously_healthy = existing_host->second->health() == Host::Health::Healthy;
         if (host->healthFlagGet(Host::HealthFlag::FAILED_EDS_HEALTH)) {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -305,12 +305,12 @@ HostSetImpl::updateHostsParams(HostVectorConstSharedPtr hosts,
 HostSetImpl::UpdateHostsParams
 HostSetImpl::partitionHosts(HostVectorConstSharedPtr hosts,
                             HostsPerLocalityConstSharedPtr hosts_per_locality) {
-  auto healthy_hosts = ClusterImplBase::createHealthyHostList(*hosts, Host::Health::Healthy);
-  auto degraded_hosts = ClusterImplBase::createHealthyHostList(*hosts, Host::Health::Degraded);
+  auto healthy_hosts = ClusterImplBase::createHostList(*hosts, Host::Health::Healthy);
+  auto degraded_hosts = ClusterImplBase::createHostList(*hosts, Host::Health::Degraded);
   auto healthy_hosts_per_locality =
-      ClusterImplBase::createHealthyHostLists(*hosts_per_locality, Host::Health::Healthy);
+      ClusterImplBase::createHostLists(*hosts_per_locality, Host::Health::Healthy);
   auto degraded_hosts_per_locality =
-      ClusterImplBase::createHealthyHostLists(*hosts_per_locality, Host::Health::Degraded);
+      ClusterImplBase::createHostLists(*hosts_per_locality, Host::Health::Degraded);
 
   return updateHostsParams(std::move(hosts), std::move(hosts_per_locality),
                            std::move(healthy_hosts), std::move(healthy_hosts_per_locality),
@@ -593,8 +593,8 @@ ClusterImplBase::ClusterImplBase(
       });
 }
 
-HostVectorConstSharedPtr ClusterImplBase::createHealthyHostList(const HostVector& hosts,
-                                                                Host::Health health) {
+HostVectorConstSharedPtr ClusterImplBase::createHostList(const HostVector& hosts,
+                                                         Host::Health health) {
   HostVectorSharedPtr healthy_list(new HostVector());
   for (const auto& host : hosts) {
     if (host->health() == health) {
@@ -605,8 +605,8 @@ HostVectorConstSharedPtr ClusterImplBase::createHealthyHostList(const HostVector
   return healthy_list;
 }
 
-HostsPerLocalityConstSharedPtr
-ClusterImplBase::createHealthyHostLists(const HostsPerLocality& hosts, Host::Health health) {
+HostsPerLocalityConstSharedPtr ClusterImplBase::createHostLists(const HostsPerLocality& hosts,
+                                                                Host::Health health) {
   return hosts.filter([&health](const Host& host) { return host.health() == health; });
 }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -307,8 +307,10 @@ HostSetImpl::partitionHosts(HostVectorConstSharedPtr hosts,
                             HostsPerLocalityConstSharedPtr hosts_per_locality) {
   auto healthy_hosts = ClusterImplBase::createHealthyHostList(*hosts, Host::Health::Healthy);
   auto degraded_hosts = ClusterImplBase::createHealthyHostList(*hosts, Host::Health::Degraded);
-  auto healthy_hosts_per_locality = ClusterImplBase::createHealthyHostLists(*hosts_per_locality, Host::Health::Healthy);
-  auto degraded_hosts_per_locality = ClusterImplBase::createHealthyHostLists(*hosts_per_locality, Host::Health::Degraded);
+  auto healthy_hosts_per_locality =
+      ClusterImplBase::createHealthyHostLists(*hosts_per_locality, Host::Health::Healthy);
+  auto degraded_hosts_per_locality =
+      ClusterImplBase::createHealthyHostLists(*hosts_per_locality, Host::Health::Degraded);
 
   return updateHostsParams(std::move(hosts), std::move(hosts_per_locality),
                            std::move(healthy_hosts), std::move(healthy_hosts_per_locality),
@@ -591,7 +593,8 @@ ClusterImplBase::ClusterImplBase(
       });
 }
 
-HostVectorConstSharedPtr ClusterImplBase::createHealthyHostList(const HostVector& hosts, Host::Health health) {
+HostVectorConstSharedPtr ClusterImplBase::createHealthyHostList(const HostVector& hosts,
+                                                                Host::Health health) {
   HostVectorSharedPtr healthy_list(new HostVector());
   for (const auto& host : hosts) {
     if (host->health() == health) {

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -194,10 +194,9 @@ public:
   void setOutlierDetector(Outlier::DetectorHostMonitorPtr&& outlier_detector) override {
     outlier_detector_ = std::move(outlier_detector);
   }
-  bool healthy() const override { return !health_flags_; }
-  bool degraded() const override {
-    // TODO(snowp): Make this read from EDS + active health checking.
-    return false;
+  Host::Health health() const override {
+    // TODO(snowp): Support degraded.
+    return health_flags_ ? Host::Health::Unhealthy : Host::Health::Healthy;
   }
   uint32_t weight() const override { return weight_; }
   void weight(uint32_t new_weight) override;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -545,10 +545,9 @@ public:
   const Network::Address::InstanceConstSharedPtr
   resolveProtoAddress(const envoy::api::v2::core::Address& address);
 
-  static HostVectorConstSharedPtr createHealthyHostList(const HostVector& hosts,
-                                                        Host::Health health);
-  static HostsPerLocalityConstSharedPtr createHealthyHostLists(const HostsPerLocality& hosts,
-                                                               Host::Health);
+  static HostVectorConstSharedPtr createHostList(const HostVector& hosts, Host::Health health);
+  static HostsPerLocalityConstSharedPtr createHostLists(const HostsPerLocality& hosts,
+                                                        Host::Health);
 
   // Upstream::Cluster
   HealthChecker* healthChecker() override { return health_checker_.get(); }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -545,10 +545,8 @@ public:
   const Network::Address::InstanceConstSharedPtr
   resolveProtoAddress(const envoy::api::v2::core::Address& address);
 
-  static HostVectorConstSharedPtr createHealthyHostList(const HostVector& hosts);
-  static HostVectorConstSharedPtr createDegradedHostList(const HostVector& hosts);
-  static HostsPerLocalityConstSharedPtr createHealthyHostLists(const HostsPerLocality& hosts);
-  static HostsPerLocalityConstSharedPtr createDegradedHostLists(const HostsPerLocality& hosts);
+  static HostVectorConstSharedPtr createHealthyHostList(const HostVector& hosts, Host::Health health);
+  static HostsPerLocalityConstSharedPtr createHealthyHostLists(const HostsPerLocality& hosts, Host::Health);
 
   // Upstream::Cluster
   HealthChecker* healthChecker() override { return health_checker_.get(); }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -259,11 +259,7 @@ public:
         hosts_(new HostVector()), healthy_hosts_(new HostVector()),
         degraded_hosts_(new HostVector()) {}
 
-  void updateHosts(HostVectorConstSharedPtr hosts, HostVectorConstSharedPtr healthy_hosts,
-                   HostVectorConstSharedPtr degraded_hosts,
-                   HostsPerLocalityConstSharedPtr hosts_per_locality,
-                   HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
-                   HostsPerLocalityConstSharedPtr degraded_hosts_per_locality,
+  void updateHosts(UpdateHostsParams&& update_hosts_params,
                    LocalityWeightsConstSharedPtr locality_weights, const HostVector& hosts_added,
                    const HostVector& hosts_removed,
                    absl::optional<uint32_t> overprovisioning_factor = absl::nullopt) override;
@@ -295,6 +291,24 @@ public:
   absl::optional<uint32_t> chooseLocality() override;
   uint32_t priority() const override { return priority_; }
   uint32_t overprovisioning_factor() const override { return overprovisioning_factor_; }
+
+  // Utility methods for creating UpdateHostsParams.
+  static UpdateHostsParams updateHostsParams(HostVectorConstSharedPtr hosts,
+                                             HostsPerLocalityConstSharedPtr hosts_per_locality);
+  static UpdateHostsParams
+  updateHostsParams(HostVectorConstSharedPtr hosts,
+                    HostsPerLocalityConstSharedPtr hosts_per_locality,
+                    HostVectorConstSharedPtr healthy_hosts,
+                    HostsPerLocalityConstSharedPtr healthy_hosts_per_locality);
+  static UpdateHostsParams
+  updateHostsParams(HostVectorConstSharedPtr hosts,
+                    HostsPerLocalityConstSharedPtr hosts_per_locality,
+                    HostVectorConstSharedPtr healthy_hosts,
+                    HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
+                    HostVectorConstSharedPtr degraded_hosts,
+                    HostsPerLocalityConstSharedPtr degraded_hosts_per_locality);
+  static UpdateHostsParams partitionHosts(HostVectorConstSharedPtr hosts,
+                                          HostsPerLocalityConstSharedPtr hosts_per_locality);
 
 protected:
   virtual void runUpdateCallbacks(const HostVector& hosts_added, const HostVector& hosts_removed) {

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -545,8 +545,10 @@ public:
   const Network::Address::InstanceConstSharedPtr
   resolveProtoAddress(const envoy::api::v2::core::Address& address);
 
-  static HostVectorConstSharedPtr createHealthyHostList(const HostVector& hosts, Host::Health health);
-  static HostsPerLocalityConstSharedPtr createHealthyHostLists(const HostsPerLocality& hosts, Host::Health);
+  static HostVectorConstSharedPtr createHealthyHostList(const HostVector& hosts,
+                                                        Host::Health health);
+  static HostsPerLocalityConstSharedPtr createHealthyHostLists(const HostsPerLocality& hosts,
+                                                               Host::Health);
 
   // Upstream::Cluster
   HealthChecker* healthChecker() override { return health_checker_.get(); }

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -2024,21 +2024,21 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
 
   // The first update should be applied immediately, since it's not mergeable.
   hosts_removed.push_back((*hosts)[0]);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      HostsPerLocalityImpl::empty(), {}, hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());
 
   // These calls should be merged, since there are no added/removed hosts.
   hosts_removed.clear();
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      HostsPerLocalityImpl::empty(), {}, hosts_added, hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      HostsPerLocalityImpl::empty(), {}, hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());
@@ -2052,9 +2052,9 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
   // Add the host back, the update should be immediately applied.
   hosts_removed.clear();
   hosts_added.push_back((*hosts)[0]);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      HostsPerLocalityImpl::empty(), {}, hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(2, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());
@@ -2063,19 +2063,19 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
   hosts_added.clear();
 
   (*hosts)[0]->metadata(buildMetadata("v1"));
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      HostsPerLocalityImpl::empty(), {}, hosts_added, hosts_removed, absl::nullopt);
 
   (*hosts)[0]->healthFlagSet(Host::HealthFlag::FAILED_EDS_HEALTH);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      HostsPerLocalityImpl::empty(), {}, hosts_added, hosts_removed, absl::nullopt);
 
   (*hosts)[0]->weight(100);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      HostsPerLocalityImpl::empty(), {}, hosts_added, hosts_removed, absl::nullopt);
 
   // Updates not delivered yet.
   EXPECT_EQ(2, factory_.stats_.counter("cluster_manager.cluster_updated").value());
@@ -2084,9 +2084,9 @@ TEST_F(ClusterManagerImplTest, MergedUpdates) {
 
   // Remove the host again, should cancel the scheduled update and be delivered immediately.
   hosts_removed.push_back((*hosts)[0]);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      HostsPerLocalityImpl::empty(), {}, hosts_added, hosts_removed, absl::nullopt);
 
   EXPECT_EQ(3, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
@@ -2118,9 +2118,9 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesOutOfWindow) {
   // it's outside the default merge window of 3 seconds (found in debugger as value of
   // cluster.info()->lbConfig().update_merge_window() in ClusterManagerImpl::scheduleUpdate.
   time_system_.sleep(std::chrono::seconds(60));
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      HostsPerLocalityImpl::empty(), {}, hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.update_out_of_merge_window").value());
@@ -2143,9 +2143,9 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesInsideWindow) {
   // in ClusterManagerImpl::scheduleUpdate. Note that initially the update-time is
   // default-initialized to a monotonic time of 0, as is SimulatedTimeSystem::monotonic_time_.
   time_system_.sleep(std::chrono::seconds(2));
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      HostsPerLocalityImpl::empty(), {}, hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_out_of_merge_window").value());
@@ -2176,9 +2176,9 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesOutOfWindowDisabled) {
 
   // The first update should be applied immediately, because even though it's mergeable
   // and outside a merge window, merging is disabled.
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      HostsPerLocalityImpl::empty(), {}, hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_out_of_merge_window").value());
@@ -2234,21 +2234,21 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesDestroyedOnUpdate) {
 
   // The first update should be applied immediately, since it's not mergeable.
   hosts_removed.push_back((*hosts)[0]);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      HostsPerLocalityImpl::empty(), {}, hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());
 
   // These calls should be merged, since there are no added/removed hosts.
   hosts_removed.clear();
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
-  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(hosts, hosts, hosts_per_locality,
-                                                              hosts_per_locality, {}, hosts_added,
-                                                              hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      HostsPerLocalityImpl::empty(), {}, hosts_added, hosts_removed, absl::nullopt);
+  cluster.prioritySet().hostSetsPerPriority()[0]->updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
+      HostsPerLocalityImpl::empty(), {}, hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, factory_.stats_.counter("cluster_manager.cluster_updated").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.cluster_updated_via_merge").value());
   EXPECT_EQ(0, factory_.stats_.counter("cluster_manager.update_merge_cancelled").value());

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -322,14 +322,15 @@ TEST_F(EdsTest, EndpointHealthStatus) {
   auto* endpoints = cluster_load_assignment->add_endpoints();
 
   // First check that EDS is correctly mapping
-  // envoy::api::v2::core::HealthStatus values to the expected healthy() status.
-  const std::vector<std::pair<envoy::api::v2::core::HealthStatus, bool>> health_status_expected = {
-      {envoy::api::v2::core::HealthStatus::UNKNOWN, true},
-      {envoy::api::v2::core::HealthStatus::HEALTHY, true},
-      {envoy::api::v2::core::HealthStatus::UNHEALTHY, false},
-      {envoy::api::v2::core::HealthStatus::DRAINING, false},
-      {envoy::api::v2::core::HealthStatus::TIMEOUT, false},
-  };
+  // envoy::api::v2::core::HealthStatus values to the expected health() status.
+  const std::vector<std::pair<envoy::api::v2::core::HealthStatus, Host::Health>>
+      health_status_expected = {
+          {envoy::api::v2::core::HealthStatus::UNKNOWN, Host::Health::Healthy},
+          {envoy::api::v2::core::HealthStatus::HEALTHY, Host::Health::Healthy},
+          {envoy::api::v2::core::HealthStatus::UNHEALTHY, Host::Health::Unhealthy},
+          {envoy::api::v2::core::HealthStatus::DRAINING, Host::Health::Unhealthy},
+          {envoy::api::v2::core::HealthStatus::TIMEOUT, Host::Health::Unhealthy},
+      };
 
   int port = 80;
   for (auto hs : health_status_expected) {
@@ -350,7 +351,7 @@ TEST_F(EdsTest, EndpointHealthStatus) {
     EXPECT_EQ(hosts.size(), health_status_expected.size());
 
     for (uint32_t i = 0; i < hosts.size(); ++i) {
-      EXPECT_EQ(health_status_expected[i].second, hosts[i]->healthy());
+      EXPECT_EQ(health_status_expected[i].second, hosts[i]->health());
     }
   }
 
@@ -362,10 +363,10 @@ TEST_F(EdsTest, EndpointHealthStatus) {
   {
     auto& hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
     EXPECT_EQ(hosts.size(), health_status_expected.size());
-    EXPECT_FALSE(hosts[0]->healthy());
+    EXPECT_EQ(Host::Health::Unhealthy, hosts[0]->health());
 
     for (uint32_t i = 1; i < hosts.size(); ++i) {
-      EXPECT_EQ(health_status_expected[i].second, hosts[i]->healthy());
+      EXPECT_EQ(health_status_expected[i].second, hosts[i]->health());
     }
   }
 
@@ -377,11 +378,10 @@ TEST_F(EdsTest, EndpointHealthStatus) {
   {
     auto& hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
     EXPECT_EQ(hosts.size(), health_status_expected.size());
-    EXPECT_FALSE(hosts[0]->healthy());
-    EXPECT_TRUE(hosts[hosts.size() - 1]->healthy());
+    EXPECT_EQ(Host::Health::Healthy, hosts[hosts.size() - 1]->health());
 
     for (uint32_t i = 1; i < hosts.size() - 1; ++i) {
-      EXPECT_EQ(health_status_expected[i].second, hosts[i]->healthy());
+      EXPECT_EQ(health_status_expected[i].second, hosts[i]->health());
     }
   }
 
@@ -394,7 +394,7 @@ TEST_F(EdsTest, EndpointHealthStatus) {
   VERBOSE_EXPECT_NO_THROW(cluster_->onConfigUpdate(resources, ""));
   {
     auto& hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
-    EXPECT_FALSE(hosts[0]->healthy());
+    EXPECT_EQ(Host::Health::Unhealthy, hosts[0]->health());
   }
 
   // Now mark host 0 healthy via EDS, it should still be unhealthy due to the
@@ -404,7 +404,7 @@ TEST_F(EdsTest, EndpointHealthStatus) {
   VERBOSE_EXPECT_NO_THROW(cluster_->onConfigUpdate(resources, ""));
   {
     auto& hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
-    EXPECT_FALSE(hosts[0]->healthy());
+    EXPECT_EQ(Host::Health::Unhealthy, hosts[0]->health());
   }
 
   // Finally, mark host 0 healthy again via active health check. It should be
@@ -412,7 +412,7 @@ TEST_F(EdsTest, EndpointHealthStatus) {
   {
     auto& hosts = cluster_->prioritySet().hostSetsPerPriority()[0]->hosts();
     hosts[0]->healthFlagClear(Host::HealthFlag::FAILED_ACTIVE_HC);
-    EXPECT_TRUE(hosts[0]->healthy());
+    EXPECT_EQ(Host::Health::Healthy, hosts[0]->health());
   }
 }
 

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -502,7 +502,8 @@ public:
     respond(0, "503", false, false, false, health_checked_cluster);
     EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
         Host::HealthFlag::FAILED_ACTIVE_HC));
-    EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+    EXPECT_EQ(Host::Health::Unhealthy,
+              cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
     EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
     expectStreamCreate(0);
@@ -514,7 +515,8 @@ public:
     respond(0, "200", false, false, false, health_checked_cluster);
     EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
         Host::HealthFlag::FAILED_ACTIVE_HC));
-    EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+    EXPECT_EQ(Host::Health::Unhealthy,
+              cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
     EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
     expectStreamCreate(0);
@@ -525,7 +527,8 @@ public:
     EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
     EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
     respond(0, "200", false, false, false, health_checked_cluster);
-    EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+    EXPECT_EQ(Host::Health::Healthy,
+              cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
   }
 
   MOCK_METHOD2(onHostStatus, void(HostSharedPtr host, HealthTransition changed_state));
@@ -560,7 +563,7 @@ TEST_F(HttpHealthCheckerImplTest, Success) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(45000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false, true);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, SuccessIntervalJitter) {
@@ -577,7 +580,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessIntervalJitter) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false, true, true);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   for (int i = 0; i < 50000; i += 239) {
     EXPECT_CALL(random_, random()).WillOnce(Return(i));
@@ -606,7 +609,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessIntervalJitterPercentNoTraffic) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false, true, true);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   for (int i = 0; i < 50000; i += 239) {
     EXPECT_CALL(random_, random()).WillOnce(Return(i));
@@ -636,7 +639,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessIntervalJitterPercent) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false, true, true);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   for (int i = 0; i < 50000; i += 239) {
     EXPECT_CALL(random_, random()).WillOnce(Return(i));
@@ -675,7 +678,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessWithSpurious100Continue) {
       std::move(continue_headers));
 
   respond(0, "200", false, true);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, SuccessWithSpuriousMetadata) {
@@ -701,7 +704,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessWithSpuriousMetadata) {
   test_sessions_[0]->stream_response_callbacks_->decodeMetadata(std::move(metadata_map));
 
   respond(0, "200", false, true);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 // Test host check success with multiple hosts.
@@ -732,8 +735,8 @@ TEST_F(HttpHealthCheckerImplTest, SuccessWithMultipleHosts) {
   EXPECT_CALL(*test_sessions_[1]->timeout_timer_, disableTimer());
   respond(0, "200", false, true);
   respond(1, "200", false, true);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[1]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[1]->health());
 }
 
 // Test host check success with multiple hosts across multiple priorities.
@@ -765,8 +768,8 @@ TEST_F(HttpHealthCheckerImplTest, SuccessWithMultipleHostSets) {
   EXPECT_CALL(*test_sessions_[1]->timeout_timer_, disableTimer());
   respond(0, "200", false, true);
   respond(1, "200", false, true);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(1)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(1)->hosts_[0]->health());
 }
 
 // Validate that runtime settings can't force a zero lengthy retry duration (and hence livelock).
@@ -818,7 +821,7 @@ TEST_F(HttpHealthCheckerImplTest, ZeroRetryInterval) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   absl::optional<std::string> health_checked_cluster("locations-production-iad");
   respond(0, "200", false, true, false, health_checked_cluster);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheck) {
@@ -851,7 +854,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheck) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   absl::optional<std::string> health_checked_cluster("locations-production-iad");
   respond(0, "200", false, true, false, health_checked_cluster);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithCustomHostValue) {
@@ -884,7 +887,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithCustomHostValue) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   absl::optional<std::string> health_checked_cluster("locations-production-iad");
   respond(0, "200", false, true, false, health_checked_cluster);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithAdditionalHeaders) {
@@ -960,7 +963,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithAdditionalHeaders) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   absl::optional<std::string> health_checked_cluster("locations-production-iad");
   respond(0, "200", false, true, false, health_checked_cluster);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   expectStreamCreate(0);
@@ -1000,7 +1003,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithoutUserAgent) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   absl::optional<std::string> health_checked_cluster("locations-production-iad");
   respond(0, "200", false, true, false, health_checked_cluster);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   expectStreamCreate(0);
@@ -1033,7 +1036,8 @@ TEST_F(HttpHealthCheckerImplTest, ServiceDoesNotMatchFail) {
   respond(0, "200", false, true, false, health_checked_cluster);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
-  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Unhealthy,
+            cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, ServiceNotPresentInResponseFail) {
@@ -1061,7 +1065,8 @@ TEST_F(HttpHealthCheckerImplTest, ServiceNotPresentInResponseFail) {
   respond(0, "200", false, true, false);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
-  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Unhealthy,
+            cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, ServiceCheckRuntimeOff) {
@@ -1086,7 +1091,7 @@ TEST_F(HttpHealthCheckerImplTest, ServiceCheckRuntimeOff) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   absl::optional<std::string> health_checked_cluster("api-production-iad");
   respond(0, "200", false, true, false, health_checked_cluster);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirstServiceCheck) {
@@ -1111,7 +1116,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessNoTraffic) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(5000)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false, true, true);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedSuccessFirst) {
@@ -1133,7 +1138,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedSuccessFirst) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(std::chrono::milliseconds(500)));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirst) {
@@ -1163,7 +1168,8 @@ TEST_F(HttpHealthCheckerImplTest, HttpFail) {
   respond(0, "503", false);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
-  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Unhealthy,
+            cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   EXPECT_EQ(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->getActiveHealthFailureType(),
             Host::ActiveHealthFailureType::UNHEALTHY);
@@ -1177,7 +1183,8 @@ TEST_F(HttpHealthCheckerImplTest, HttpFail) {
   respond(0, "200", false);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
-  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Unhealthy,
+            cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   expectStreamCreate(0);
@@ -1188,7 +1195,7 @@ TEST_F(HttpHealthCheckerImplTest, HttpFail) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, HttpFailLogError) {
@@ -1208,7 +1215,8 @@ TEST_F(HttpHealthCheckerImplTest, HttpFailLogError) {
   respond(0, "503", false);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
-  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Unhealthy,
+            cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   EXPECT_EQ(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->getActiveHealthFailureType(),
             Host::ActiveHealthFailureType::UNHEALTHY);
@@ -1224,7 +1232,8 @@ TEST_F(HttpHealthCheckerImplTest, HttpFailLogError) {
   respond(0, "503", false);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
-  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Unhealthy,
+            cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   EXPECT_EQ(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->getActiveHealthFailureType(),
             Host::ActiveHealthFailureType::UNHEALTHY);
@@ -1238,7 +1247,8 @@ TEST_F(HttpHealthCheckerImplTest, HttpFailLogError) {
   respond(0, "200", false);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
-  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Unhealthy,
+            cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_));
   expectStreamCreate(0);
@@ -1249,7 +1259,7 @@ TEST_F(HttpHealthCheckerImplTest, HttpFailLogError) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, Disconnect) {
@@ -1267,7 +1277,7 @@ TEST_F(HttpHealthCheckerImplTest, Disconnect) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   test_sessions_[0]->client_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   expectClientCreate(0);
   expectStreamCreate(0);
@@ -1282,7 +1292,8 @@ TEST_F(HttpHealthCheckerImplTest, Disconnect) {
   test_sessions_[0]->client_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
-  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Unhealthy,
+            cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, Timeout) {
@@ -1300,7 +1311,7 @@ TEST_F(HttpHealthCheckerImplTest, Timeout) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   test_sessions_[0]->timeout_timer_->callback_();
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   expectClientCreate(0);
   expectStreamCreate(0);
@@ -1314,7 +1325,8 @@ TEST_F(HttpHealthCheckerImplTest, Timeout) {
   test_sessions_[0]->client_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
-  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Unhealthy,
+            cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   EXPECT_EQ(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->getActiveHealthFailureType(),
             Host::ActiveHealthFailureType::TIMEOUT);
@@ -1342,7 +1354,8 @@ TEST_F(HttpHealthCheckerImplTest, TimeoutAfterDisconnect) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
 
   test_sessions_[0]->timeout_timer_->callback_();
-  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Unhealthy,
+            cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, DynamicAddAndRemove) {
@@ -1377,7 +1390,7 @@ TEST_F(HttpHealthCheckerImplTest, ConnectionClose) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", true);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   expectClientCreate(0);
   expectStreamCreate(0);
@@ -1620,7 +1633,7 @@ TEST_F(HttpHealthCheckerImplTest, RemoteCloseBetweenChecks) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   test_sessions_[0]->client_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
 
@@ -1632,7 +1645,7 @@ TEST_F(HttpHealthCheckerImplTest, RemoteCloseBetweenChecks) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 // Test that we close connections on a healthy check when reuse_connection is false.
@@ -1650,7 +1663,7 @@ TEST_F(HttpHealthCheckerImplTest, DontReuseConnectionBetweenChecks) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   // A new client is created because we close the connection ourselves.
   // See HttpHealthCheckerImplTest.RemoteCloseBetweenChecks for how this works when the remote end
@@ -1663,7 +1676,7 @@ TEST_F(HttpHealthCheckerImplTest, DontReuseConnectionBetweenChecks) {
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   respond(0, "200", false);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, StreamReachesWatermarkDuringCheck) {
@@ -1684,7 +1697,7 @@ TEST_F(HttpHealthCheckerImplTest, StreamReachesWatermarkDuringCheck) {
   test_sessions_[0]->request_encoder_.stream_.runLowWatermarkCallbacks();
 
   respond(0, "200", true);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, ConnectionReachesWatermarkDuringCheck) {
@@ -1705,7 +1718,7 @@ TEST_F(HttpHealthCheckerImplTest, ConnectionReachesWatermarkDuringCheck) {
   test_sessions_[0]->client_connection_->runLowWatermarkCallbacks();
 
   respond(0, "200", true);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithAltPort) {
@@ -1738,7 +1751,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithAltPort) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   absl::optional<std::string> health_checked_cluster("locations-production-iad");
   respond(0, "200", false, true, false, health_checked_cluster);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 // Test host check success with multiple hosts by checking each host defined health check port.
@@ -1770,8 +1783,8 @@ TEST_F(HttpHealthCheckerImplTest, SuccessWithMultipleHostsAndAltPort) {
   EXPECT_CALL(*test_sessions_[1]->timeout_timer_, disableTimer());
   respond(0, "200", false, true);
   respond(1, "200", false, true);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[1]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[1]->health());
 }
 
 TEST_F(HttpHealthCheckerImplTest, Http2ClusterUsesHttp2CodecClient) {
@@ -2115,7 +2128,7 @@ TEST_F(TcpHealthCheckerImplTest, Timeout) {
   timeout_timer_->callback_();
   EXPECT_EQ(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->getActiveHealthFailureType(),
             Host::ActiveHealthFailureType::TIMEOUT);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _));
@@ -2130,7 +2143,8 @@ TEST_F(TcpHealthCheckerImplTest, Timeout) {
   connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
-  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Unhealthy,
+            cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   expectClientCreate();
   EXPECT_CALL(*connection_, write(_, _));
@@ -2187,7 +2201,7 @@ TEST_F(TcpHealthCheckerImplTest, TimeoutWithoutReusingConnection) {
   // The healthcheck is not yet at the unhealthy threshold.
   EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   // The healthcheck metric results after first timeout block.
   EXPECT_EQ(1UL, cluster_->info_->stats_store_.counter("health_check.success").value());
@@ -2208,7 +2222,8 @@ TEST_F(TcpHealthCheckerImplTest, TimeoutWithoutReusingConnection) {
   connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
-  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Unhealthy,
+            cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   // The healthcheck metric results after the second timeout block.
   EXPECT_EQ(1UL, cluster_->info_->stats_store_.counter("health_check.success").value());
@@ -2257,7 +2272,8 @@ TEST_F(TcpHealthCheckerImplTest, PassiveFailure) {
   cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthChecker().setUnhealthy();
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
-  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Unhealthy,
+            cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   // A single success should not bring us back to healthy.
   EXPECT_CALL(*connection_, close(_));
@@ -2266,7 +2282,8 @@ TEST_F(TcpHealthCheckerImplTest, PassiveFailure) {
   connection_->raiseEvent(Network::ConnectionEvent::Connected);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
-  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Unhealthy,
+            cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
   EXPECT_EQ(1UL, cluster_->info_->stats_store_.counter("health_check.attempt").value());
   EXPECT_EQ(1UL, cluster_->info_->stats_store_.counter("health_check.success").value());
@@ -2586,9 +2603,9 @@ public:
     const auto host = cluster_->prioritySet().getMockHostSet(0)->hosts_[0];
     if (!healthy) {
       EXPECT_TRUE(host->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC));
-      EXPECT_FALSE(host->healthy());
+      EXPECT_EQ(Host::Health::Unhealthy, host->health());
     } else {
-      EXPECT_TRUE(host->healthy());
+      EXPECT_EQ(Host::Health::Healthy, host->health());
     }
   }
 
@@ -2733,8 +2750,8 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessWithMultipleHosts) {
 
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
   respondServiceStatus(1, grpc::health::v1::HealthCheckResponse::SERVING);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[1]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[1]->health());
 }
 
 // Test host check success with multiple hosts across multiple priorities.
@@ -2750,8 +2767,8 @@ TEST_F(GrpcHealthCheckerImplTest, SuccessWithMultipleHostSets) {
 
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::SERVING);
   respondServiceStatus(1, grpc::health::v1::HealthCheckResponse::SERVING);
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
-  EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(1)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
+  EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(1)->hosts_[0]->health());
 }
 
 // Test stream-level watermarks does not interfere with health check.
@@ -3256,7 +3273,8 @@ TEST_F(GrpcHealthCheckerImplTest, GrpcFailUnknown) {
   respondServiceStatus(0, grpc::health::v1::HealthCheckResponse::UNKNOWN);
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
-  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Unhealthy,
+            cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 // Test receiving GOAWAY is interpreted as connection close event.
@@ -3272,7 +3290,8 @@ TEST_F(GrpcHealthCheckerImplTest, GoAwayProbeInProgress) {
 
   EXPECT_TRUE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthFlagGet(
       Host::HealthFlag::FAILED_ACTIVE_HC));
-  EXPECT_FALSE(cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->healthy());
+  EXPECT_EQ(Host::Health::Unhealthy,
+            cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
 
 // Test receing GOAWAY between checks affects nothing.

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -32,8 +32,9 @@ public:
                                    should_weight ? weight : 1));
     }
     HostVectorConstSharedPtr updated_hosts{new HostVector(hosts)};
-    host_set.updateHosts(updated_hosts, updated_hosts, std::make_shared<const HostVector>(),
-                         nullptr, nullptr, nullptr, {}, hosts, {}, absl::nullopt);
+    host_set.updateHosts(
+        HostSetImpl::updateHostsParams(updated_hosts, nullptr, updated_hosts, nullptr), {}, hosts,
+        {}, absl::nullopt);
   }
 
   PrioritySetImpl priority_set_;

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -32,8 +32,8 @@ public:
                                    should_weight ? weight : 1));
     }
     HostVectorConstSharedPtr updated_hosts{new HostVector(hosts)};
-    host_set.updateHosts(updated_hosts, updated_hosts, nullptr, nullptr, {}, hosts, {},
-                         absl::nullopt);
+    host_set.updateHosts(updated_hosts, updated_hosts, std::make_shared<const HostVector>(),
+                         nullptr, nullptr, nullptr, {}, hosts, {}, absl::nullopt);
   }
 
   PrioritySetImpl priority_set_;

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -411,9 +411,9 @@ TEST_P(FailoverTest, ExtendPrioritiesWithLocalPrioritySet) {
   // Update the local hosts. We're not doing locality based routing in this
   // test, but it should at least do no harm.
   HostVectorSharedPtr hosts(new HostVector({makeTestHost(info_, "tcp://127.0.0.1:82")}));
-  local_priority_set_->getOrCreateHostSet(0).updateHosts(hosts, hosts, empty_locality_,
-                                                         empty_locality_, {}, empty_host_vector_,
-                                                         empty_host_vector_, absl::nullopt);
+  local_priority_set_->getOrCreateHostSet(0).updateHosts(
+      hosts, hosts, std::make_shared<const HostVector>(), empty_locality_, empty_locality_,
+      empty_locality_, {}, empty_host_vector_, empty_host_vector_, absl::nullopt);
   EXPECT_EQ(tertiary_host_set_.hosts_[0], lb_->chooseHost(nullptr));
 }
 
@@ -650,7 +650,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareSmallCluster) {
   common_config_.mutable_zone_aware_lb_config()->mutable_routing_enabled()->set_value(98);
   common_config_.mutable_zone_aware_lb_config()->mutable_min_cluster_size()->set_value(7);
   init(true);
-  local_host_set_->updateHosts(hosts, hosts, hosts_per_locality, hosts_per_locality, {},
+  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(),
+                               hosts_per_locality, hosts_per_locality, empty_locality_, {},
                                empty_host_vector_, empty_host_vector_, absl::nullopt);
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 0))
@@ -674,7 +675,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareSmallCluster) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.zone_routing.min_cluster_size", 7))
       .WillRepeatedly(Return(1));
   // Trigger reload.
-  local_host_set_->updateHosts(hosts, hosts, hosts_per_locality, hosts_per_locality, {},
+  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(),
+                               hosts_per_locality, hosts_per_locality, empty_locality_, {},
                                empty_host_vector_, empty_host_vector_, absl::nullopt);
   EXPECT_EQ(hostSet().healthy_hosts_per_locality_->get()[0][0], lb_->chooseHost(nullptr));
 }
@@ -700,8 +702,9 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareDifferentZoneSize) {
   common_config_.mutable_zone_aware_lb_config()->mutable_routing_enabled()->set_value(98);
   common_config_.mutable_zone_aware_lb_config()->mutable_min_cluster_size()->set_value(7);
   init(true);
-  local_host_set_->updateHosts(hosts, hosts, local_hosts_per_locality, local_hosts_per_locality, {},
-                               empty_host_vector_, empty_host_vector_, absl::nullopt);
+  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(),
+                               local_hosts_per_locality, local_hosts_per_locality, empty_locality_,
+                               {}, empty_host_vector_, empty_host_vector_, absl::nullopt);
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("upstream.healthy_panic_threshold", 100))
       .WillRepeatedly(Return(50));
@@ -737,7 +740,8 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareRoutingLargeZoneSwitchOnOff) {
   hostSet().hosts_ = *hosts;
   hostSet().healthy_hosts_per_locality_ = hosts_per_locality;
   init(true);
-  local_host_set_->updateHosts(hosts, hosts, hosts_per_locality, hosts_per_locality, {},
+  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(),
+                               hosts_per_locality, hosts_per_locality, empty_locality_, {},
                                empty_host_vector_, empty_host_vector_, absl::nullopt);
 
   // There is only one host in the given zone for zone aware routing.
@@ -785,9 +789,9 @@ TEST_P(RoundRobinLoadBalancerTest, ZoneAwareRoutingSmallZone) {
   hostSet().hosts_ = *upstream_hosts;
   hostSet().healthy_hosts_per_locality_ = upstream_hosts_per_locality;
   init(true);
-  local_host_set_->updateHosts(local_hosts, local_hosts, local_hosts_per_locality,
-                               local_hosts_per_locality, {}, empty_host_vector_, empty_host_vector_,
-                               absl::nullopt);
+  local_host_set_->updateHosts(local_hosts, local_hosts, std::make_shared<const HostVector>(),
+                               local_hosts_per_locality, local_hosts_per_locality, empty_locality_,
+                               {}, empty_host_vector_, empty_host_vector_, absl::nullopt);
 
   // There is only one host in the given zone for zone aware routing.
   EXPECT_CALL(random_, random()).WillOnce(Return(0)).WillOnce(Return(100));
@@ -856,9 +860,10 @@ TEST_P(RoundRobinLoadBalancerTest, LowPrecisionForDistribution) {
 
   // To trigger update callback.
   auto local_hosts_per_locality_shared = makeHostsPerLocality(std::move(local_hosts_per_locality));
-  local_host_set_->updateHosts(local_hosts, local_hosts, local_hosts_per_locality_shared,
-                               local_hosts_per_locality_shared, {}, empty_host_vector_,
-                               empty_host_vector_, absl::nullopt);
+  local_host_set_->updateHosts(local_hosts, local_hosts, std::make_shared<const HostVector>(),
+                               local_hosts_per_locality_shared, local_hosts_per_locality_shared,
+                               empty_locality_, {}, empty_host_vector_, empty_host_vector_,
+                               absl::nullopt);
 
   // Force request out of small zone and to randomly select zone.
   EXPECT_CALL(random_, random()).WillOnce(Return(0)).WillOnce(Return(9999)).WillOnce(Return(2));
@@ -878,7 +883,8 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingOneZone) {
   hostSet().hosts_ = *hosts;
   hostSet().healthy_hosts_per_locality_ = hosts_per_locality;
   init(true);
-  local_host_set_->updateHosts(hosts, hosts, hosts_per_locality, hosts_per_locality, {},
+  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(),
+                               hosts_per_locality, hosts_per_locality, empty_locality_, {},
                                empty_host_vector_, empty_host_vector_, absl::nullopt);
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
 }
@@ -893,7 +899,8 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingNotHealthy) {
   hostSet().hosts_ = *hosts;
   hostSet().healthy_hosts_per_locality_ = hosts_per_locality;
   init(true);
-  local_host_set_->updateHosts(hosts, hosts, hosts_per_locality, hosts_per_locality, {},
+  local_host_set_->updateHosts(hosts, hosts, std::make_shared<const HostVector>(),
+                               hosts_per_locality, hosts_per_locality, empty_locality_, {},
                                empty_host_vector_, empty_host_vector_, absl::nullopt);
 
   // local zone has no healthy hosts, take from the all healthy hosts.
@@ -924,9 +931,9 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingLocalEmpty) {
   hostSet().hosts_ = *upstream_hosts;
   hostSet().healthy_hosts_per_locality_ = upstream_hosts_per_locality;
   init(true);
-  local_host_set_->updateHosts(local_hosts, local_hosts, local_hosts_per_locality,
-                               local_hosts_per_locality, {}, empty_host_vector_, empty_host_vector_,
-                               absl::nullopt);
+  local_host_set_->updateHosts(local_hosts, local_hosts, std::make_shared<const HostVector>(),
+                               local_hosts_per_locality, local_hosts_per_locality, empty_locality_,
+                               {}, empty_host_vector_, empty_host_vector_, absl::nullopt);
 
   // Local cluster is not OK, we'll do regular routing.
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
@@ -953,9 +960,9 @@ TEST_P(RoundRobinLoadBalancerTest, NoZoneAwareRoutingNoLocalLocality) {
   hostSet().hosts_ = *upstream_hosts;
   hostSet().healthy_hosts_per_locality_ = upstream_hosts_per_locality;
   init(true);
-  local_host_set_->updateHosts(local_hosts, local_hosts, local_hosts_per_locality,
-                               local_hosts_per_locality, {}, empty_host_vector_, empty_host_vector_,
-                               absl::nullopt);
+  local_host_set_->updateHosts(local_hosts, local_hosts, std::make_shared<const HostVector>(),
+                               local_hosts_per_locality, local_hosts_per_locality, empty_locality_,
+                               {}, empty_host_vector_, empty_host_vector_, absl::nullopt);
 
   // Local cluster is not OK, we'll do regular routing.
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -53,9 +53,9 @@ TEST(DISABLED_LeastRequestLoadBalancerWeightTest, Weight) {
   }
   HostVectorConstSharedPtr updated_hosts{new HostVector(hosts)};
   HostsPerLocalitySharedPtr updated_locality_hosts{new HostsPerLocalityImpl(hosts)};
-  host_set.updateHosts(updated_hosts, updated_hosts, std::make_shared<const HostVector>(),
-                       updated_locality_hosts, updated_locality_hosts,
-                       HostsPerLocalityImpl::empty(), {}, hosts, {}, absl::nullopt);
+  host_set.updateHosts(HostSetImpl::updateHostsParams(updated_hosts, updated_locality_hosts,
+                                                      updated_hosts, updated_locality_hosts),
+                       {}, hosts, {}, absl::nullopt);
 
   Stats::IsolatedStoreImpl stats_store;
   ClusterStats stats{ClusterInfoImpl::generateStats(stats_store)};
@@ -157,9 +157,9 @@ public:
       }
       auto per_zone_local_shared = makeHostsPerLocality(std::move(per_zone_local));
       local_priority_set_->getOrCreateHostSet(0).updateHosts(
-          originating_hosts, originating_hosts, std::make_shared<const HostVector>(),
-          per_zone_local_shared, per_zone_local_shared, HostsPerLocalityImpl::empty(), {},
-          empty_vector_, empty_vector_, absl::nullopt);
+          HostSetImpl::updateHostsParams(originating_hosts, per_zone_local_shared,
+                                         originating_hosts, per_zone_local_shared),
+          {}, empty_vector_, empty_vector_, absl::nullopt);
 
       HostConstSharedPtr selected = lb.chooseHost(nullptr);
       hits[selected->address()->asString()]++;

--- a/test/common/upstream/load_balancer_simulation_test.cc
+++ b/test/common/upstream/load_balancer_simulation_test.cc
@@ -53,8 +53,9 @@ TEST(DISABLED_LeastRequestLoadBalancerWeightTest, Weight) {
   }
   HostVectorConstSharedPtr updated_hosts{new HostVector(hosts)};
   HostsPerLocalitySharedPtr updated_locality_hosts{new HostsPerLocalityImpl(hosts)};
-  host_set.updateHosts(updated_hosts, updated_hosts, updated_locality_hosts, updated_locality_hosts,
-                       {}, hosts, {}, absl::nullopt);
+  host_set.updateHosts(updated_hosts, updated_hosts, std::make_shared<const HostVector>(),
+                       updated_locality_hosts, updated_locality_hosts,
+                       HostsPerLocalityImpl::empty(), {}, hosts, {}, absl::nullopt);
 
   Stats::IsolatedStoreImpl stats_store;
   ClusterStats stats{ClusterInfoImpl::generateStats(stats_store)};
@@ -156,7 +157,8 @@ public:
       }
       auto per_zone_local_shared = makeHostsPerLocality(std::move(per_zone_local));
       local_priority_set_->getOrCreateHostSet(0).updateHosts(
-          originating_hosts, originating_hosts, per_zone_local_shared, per_zone_local_shared, {},
+          originating_hosts, originating_hosts, std::make_shared<const HostVector>(),
+          per_zone_local_shared, per_zone_local_shared, HostsPerLocalityImpl::empty(), {},
           empty_vector_, empty_vector_, absl::nullopt);
 
       HostConstSharedPtr selected = lb.chooseHost(nullptr);

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -446,19 +446,20 @@ TEST_F(OriginalDstClusterTest, MultipleClusters) {
   setupFromJson(json);
 
   PrioritySetImpl second;
-  cluster_->prioritySet().addMemberUpdateCb([&](uint32_t, const HostVector& added,
-                                                const HostVector& removed) -> void {
-    // Update second hostset accordingly;
-    HostVectorSharedPtr new_hosts(
-        new HostVector(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
-    HostVectorSharedPtr healthy_hosts(
-        new HostVector(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
-    const HostsPerLocalityConstSharedPtr empty_hosts_per_locality{new HostsPerLocalityImpl()};
+  cluster_->prioritySet().addMemberUpdateCb(
+      [&](uint32_t, const HostVector& added, const HostVector& removed) -> void {
+        // Update second hostset accordingly;
+        HostVectorSharedPtr new_hosts(
+            new HostVector(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
+        HostVectorSharedPtr healthy_hosts(
+            new HostVector(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
+        const HostsPerLocalityConstSharedPtr empty_hosts_per_locality{new HostsPerLocalityImpl()};
 
-    second.getOrCreateHostSet(0).updateHosts(
-        new_hosts, healthy_hosts, std::make_shared<const HostVector>(), empty_hosts_per_locality,
-        empty_hosts_per_locality, empty_hosts_per_locality, {}, added, removed, absl::nullopt);
-  });
+        second.getOrCreateHostSet(0).updateHosts(
+            HostSetImpl::updateHostsParams(new_hosts, empty_hosts_per_locality, healthy_hosts,
+                                           empty_hosts_per_locality),
+            {}, added, removed, absl::nullopt);
+      });
 
   EXPECT_CALL(membership_updated_, ready());
 

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -446,19 +446,19 @@ TEST_F(OriginalDstClusterTest, MultipleClusters) {
   setupFromJson(json);
 
   PrioritySetImpl second;
-  cluster_->prioritySet().addMemberUpdateCb(
-      [&](uint32_t, const HostVector& added, const HostVector& removed) -> void {
-        // Update second hostset accordingly;
-        HostVectorSharedPtr new_hosts(
-            new HostVector(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
-        HostVectorSharedPtr healthy_hosts(
-            new HostVector(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
-        const HostsPerLocalityConstSharedPtr empty_hosts_per_locality{new HostsPerLocalityImpl()};
+  cluster_->prioritySet().addMemberUpdateCb([&](uint32_t, const HostVector& added,
+                                                const HostVector& removed) -> void {
+    // Update second hostset accordingly;
+    HostVectorSharedPtr new_hosts(
+        new HostVector(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
+    HostVectorSharedPtr healthy_hosts(
+        new HostVector(cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()));
+    const HostsPerLocalityConstSharedPtr empty_hosts_per_locality{new HostsPerLocalityImpl()};
 
-        second.getOrCreateHostSet(0).updateHosts(new_hosts, healthy_hosts, empty_hosts_per_locality,
-                                                 empty_hosts_per_locality, {}, added, removed,
-                                                 absl::nullopt);
-      });
+    second.getOrCreateHostSet(0).updateHosts(
+        new_hosts, healthy_hosts, std::make_shared<const HostVector>(), empty_hosts_per_locality,
+        empty_hosts_per_locality, empty_hosts_per_locality, {}, added, removed, absl::nullopt);
+  });
 
   EXPECT_CALL(membership_updated_, ready());
 

--- a/test/common/upstream/sds_test.cc
+++ b/test/common/upstream/sds_test.cc
@@ -95,7 +95,7 @@ protected:
   uint64_t numHealthy() {
     uint64_t healthy = 0;
     for (const HostSharedPtr& host : cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()) {
-      if (host->healthy()) {
+      if (host->health() == Host::Health::Healthy) {
         healthy++;
       }
     }

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -215,8 +215,8 @@ public:
     local_hosts_per_locality_ = makeHostsPerLocality(std::move(local_hosts_per_locality_vector));
 
     local_priority_set_.getOrCreateHostSet(0).updateHosts(
-        local_hosts_, local_hosts_, local_hosts_per_locality_, local_hosts_per_locality_, {}, {},
-        {}, absl::nullopt);
+        local_hosts_, local_hosts_, std::make_shared<const HostVector>(), local_hosts_per_locality_,
+        local_hosts_per_locality_, HostsPerLocalityImpl::empty(), {}, {}, {}, absl::nullopt);
 
     lb_.reset(new SubsetLoadBalancer(lb_type_, priority_set_, &local_priority_set_, stats_,
                                      runtime_, random_, subset_info_, ring_hash_lb_config_,
@@ -311,8 +311,9 @@ public:
 
     if (GetParam() == REMOVES_FIRST && !remove.empty()) {
       local_priority_set_.getOrCreateHostSet(0).updateHosts(
-          local_hosts_, local_hosts_, local_hosts_per_locality_, local_hosts_per_locality_, {}, {},
-          remove, absl::nullopt);
+          local_hosts_, local_hosts_, std::make_shared<const HostVector>(),
+          local_hosts_per_locality_, local_hosts_per_locality_, HostsPerLocalityImpl::empty(), {},
+          {}, remove, absl::nullopt);
     }
 
     for (const auto& host : add) {
@@ -325,13 +326,15 @@ public:
     if (GetParam() == REMOVES_FIRST) {
       if (!add.empty()) {
         local_priority_set_.getOrCreateHostSet(0).updateHosts(
-            local_hosts_, local_hosts_, local_hosts_per_locality_, local_hosts_per_locality_, {},
+            local_hosts_, local_hosts_, std::make_shared<const HostVector>(),
+            local_hosts_per_locality_, local_hosts_per_locality_, HostsPerLocalityImpl::empty(), {},
             add, {}, absl::nullopt);
       }
     } else if (!add.empty() || !remove.empty()) {
       local_priority_set_.getOrCreateHostSet(0).updateHosts(
-          local_hosts_, local_hosts_, local_hosts_per_locality_, local_hosts_per_locality_, {}, add,
-          remove, absl::nullopt);
+          local_hosts_, local_hosts_, std::make_shared<const HostVector>(),
+          local_hosts_per_locality_, local_hosts_per_locality_, HostsPerLocalityImpl::empty(), {},
+          add, remove, absl::nullopt);
     }
   }
 

--- a/test/common/upstream/subset_lb_test.cc
+++ b/test/common/upstream/subset_lb_test.cc
@@ -215,8 +215,9 @@ public:
     local_hosts_per_locality_ = makeHostsPerLocality(std::move(local_hosts_per_locality_vector));
 
     local_priority_set_.getOrCreateHostSet(0).updateHosts(
-        local_hosts_, local_hosts_, std::make_shared<const HostVector>(), local_hosts_per_locality_,
-        local_hosts_per_locality_, HostsPerLocalityImpl::empty(), {}, {}, {}, absl::nullopt);
+        HostSetImpl::updateHostsParams(local_hosts_, local_hosts_per_locality_, local_hosts_,
+                                       local_hosts_per_locality_),
+        {}, {}, {}, absl::nullopt);
 
     lb_.reset(new SubsetLoadBalancer(lb_type_, priority_set_, &local_priority_set_, stats_,
                                      runtime_, random_, subset_info_, ring_hash_lb_config_,
@@ -311,9 +312,9 @@ public:
 
     if (GetParam() == REMOVES_FIRST && !remove.empty()) {
       local_priority_set_.getOrCreateHostSet(0).updateHosts(
-          local_hosts_, local_hosts_, std::make_shared<const HostVector>(),
-          local_hosts_per_locality_, local_hosts_per_locality_, HostsPerLocalityImpl::empty(), {},
-          {}, remove, absl::nullopt);
+          HostSetImpl::updateHostsParams(local_hosts_, local_hosts_per_locality_, local_hosts_,
+                                         local_hosts_per_locality_),
+          {}, {}, remove, absl::nullopt);
     }
 
     for (const auto& host : add) {
@@ -326,15 +327,15 @@ public:
     if (GetParam() == REMOVES_FIRST) {
       if (!add.empty()) {
         local_priority_set_.getOrCreateHostSet(0).updateHosts(
-            local_hosts_, local_hosts_, std::make_shared<const HostVector>(),
-            local_hosts_per_locality_, local_hosts_per_locality_, HostsPerLocalityImpl::empty(), {},
-            add, {}, absl::nullopt);
+            HostSetImpl::updateHostsParams(local_hosts_, local_hosts_per_locality_, local_hosts_,
+                                           local_hosts_per_locality_),
+            {}, add, {}, absl::nullopt);
       }
     } else if (!add.empty() || !remove.empty()) {
       local_priority_set_.getOrCreateHostSet(0).updateHosts(
-          local_hosts_, local_hosts_, std::make_shared<const HostVector>(),
-          local_hosts_per_locality_, local_hosts_per_locality_, HostsPerLocalityImpl::empty(), {},
-          add, remove, absl::nullopt);
+          HostSetImpl::updateHostsParams(local_hosts_, local_hosts_per_locality_, local_hosts_,
+                                         local_hosts_per_locality_),
+          {}, add, remove, absl::nullopt);
     }
   }
 

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1544,8 +1544,8 @@ TEST(PrioritySet, Extend) {
   HostVector hosts_removed{};
 
   priority_set.hostSetsPerPriority()[1]->updateHosts(
-      hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality, hosts_per_locality,
-      HostsPerLocalityImpl::empty(), {}, hosts_added, hosts_removed, absl::nullopt);
+      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality), {},
+      hosts_added, hosts_removed, absl::nullopt);
   EXPECT_EQ(1, changes);
   EXPECT_EQ(last_priority, 1);
   EXPECT_EQ(1, priority_set.hostSetsPerPriority()[1]->hosts().size());
@@ -1924,10 +1924,8 @@ TEST_F(HostSetImplLocalityTest, AllUnhealthy) {
       makeHostsPerLocality({{hosts_[0]}, {hosts_[1]}, {hosts_[2]}});
   LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{1, 1, 1}};
   auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
-  host_set_.updateHosts(hosts, std::make_shared<const HostVector>(),
-                        std::make_shared<const HostVector>(), hosts_per_locality,
-                        hosts_per_locality, HostsPerLocalityImpl::empty(), locality_weights, {}, {},
-                        absl::nullopt);
+  host_set_.updateHosts(HostSetImpl::updateHostsParams(hosts, hosts_per_locality), locality_weights,
+                        {}, {}, absl::nullopt);
   EXPECT_FALSE(host_set_.chooseLocality().has_value());
 }
 
@@ -1937,9 +1935,9 @@ TEST_F(HostSetImplLocalityTest, EmptyLocality) {
       makeHostsPerLocality({{hosts_[0], hosts_[1], hosts_[2]}, {}});
   LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{1, 1}};
   auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
-  host_set_.updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,
-                        hosts_per_locality, HostsPerLocalityImpl::empty(), locality_weights, {}, {},
-                        absl::nullopt);
+  host_set_.updateHosts(
+      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality),
+      locality_weights, {}, {}, absl::nullopt);
   // Verify that we are not RRing between localities.
   EXPECT_EQ(0, host_set_.chooseLocality().value());
   EXPECT_EQ(0, host_set_.chooseLocality().value());
@@ -1950,9 +1948,9 @@ TEST_F(HostSetImplLocalityTest, AllZeroWeights) {
   HostsPerLocalitySharedPtr hosts_per_locality = makeHostsPerLocality({{hosts_[0]}, {hosts_[1]}});
   LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{0, 0}};
   auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
-  host_set_.updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,
-                        hosts_per_locality, HostsPerLocalityImpl::empty(), locality_weights, {},
-                        {});
+  host_set_.updateHosts(
+      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality),
+      locality_weights, {}, {});
   EXPECT_FALSE(host_set_.chooseLocality().has_value());
 }
 
@@ -1962,9 +1960,9 @@ TEST_F(HostSetImplLocalityTest, Unweighted) {
       makeHostsPerLocality({{hosts_[0]}, {hosts_[1]}, {hosts_[2]}});
   LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{1, 1, 1}};
   auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
-  host_set_.updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,
-                        hosts_per_locality, HostsPerLocalityImpl::empty(), locality_weights, {}, {},
-                        absl::nullopt);
+  host_set_.updateHosts(
+      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality),
+      locality_weights, {}, {}, absl::nullopt);
   EXPECT_EQ(0, host_set_.chooseLocality().value());
   EXPECT_EQ(1, host_set_.chooseLocality().value());
   EXPECT_EQ(2, host_set_.chooseLocality().value());
@@ -1978,9 +1976,9 @@ TEST_F(HostSetImplLocalityTest, Weighted) {
   HostsPerLocalitySharedPtr hosts_per_locality = makeHostsPerLocality({{hosts_[0]}, {hosts_[1]}});
   LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{1, 2}};
   auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
-  host_set_.updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,
-                        hosts_per_locality, HostsPerLocalityImpl::empty(), locality_weights, {}, {},
-                        absl::nullopt);
+  host_set_.updateHosts(
+      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality),
+      locality_weights, {}, {}, absl::nullopt);
   EXPECT_EQ(1, host_set_.chooseLocality().value());
   EXPECT_EQ(0, host_set_.chooseLocality().value());
   EXPECT_EQ(1, host_set_.chooseLocality().value());
@@ -1995,9 +1993,9 @@ TEST_F(HostSetImplLocalityTest, MissingWeight) {
       makeHostsPerLocality({{hosts_[0]}, {hosts_[1]}, {hosts_[2]}});
   LocalityWeightsConstSharedPtr locality_weights{new LocalityWeights{1, 0, 1}};
   auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
-  host_set_.updateHosts(hosts, hosts, std::make_shared<const HostVector>(), hosts_per_locality,
-                        hosts_per_locality, HostsPerLocalityImpl::empty(), locality_weights, {}, {},
-                        absl::nullopt);
+  host_set_.updateHosts(
+      HostSetImpl::updateHostsParams(hosts, hosts_per_locality, hosts, hosts_per_locality),
+      locality_weights, {}, {}, absl::nullopt);
   EXPECT_EQ(0, host_set_.chooseLocality().value());
   EXPECT_EQ(2, host_set_.chooseLocality().value());
   EXPECT_EQ(0, host_set_.chooseLocality().value());
@@ -2020,11 +2018,11 @@ TEST_F(HostSetImplLocalityTest, UnhealthyFailover) {
         makeHostsPerLocality({healthy_hosts, {hosts_[5]}});
 
     auto hosts = makeHostsFromHostsPerLocality(hosts_per_locality);
-    host_set_.updateHosts(makeHostsFromHostsPerLocality(hosts_per_locality),
-                          makeHostsFromHostsPerLocality(healthy_hosts_per_locality),
-                          std::make_shared<const HostVector>(), hosts_per_locality,
-                          healthy_hosts_per_locality, HostsPerLocalityImpl::empty(),
-                          locality_weights, {}, {}, absl::nullopt);
+    host_set_.updateHosts(
+        HostSetImpl::updateHostsParams(hosts, hosts_per_locality,
+                                       makeHostsFromHostsPerLocality(healthy_hosts_per_locality),
+                                       healthy_hosts_per_locality),
+        locality_weights, {}, {}, absl::nullopt);
   };
 
   const auto expectPicks = [this](uint32_t locality_0_picks, uint32_t locality_1_picks) {
@@ -2067,10 +2065,10 @@ TEST(OverProvisioningFactorTest, LocalityPickChanges) {
     // Healthy ratio: (1/2, 1).
     HostsPerLocalitySharedPtr healthy_hosts_per_locality =
         makeHostsPerLocality({{hosts[0]}, {hosts[2]}});
-    host_set.updateHosts(makeHostsFromHostsPerLocality(hosts_per_locality),
-                         makeHostsFromHostsPerLocality(healthy_hosts_per_locality),
-                         std::make_shared<const HostVector>(), hosts_per_locality,
-                         healthy_hosts_per_locality, HostsPerLocalityImpl::empty(),
+    auto healthy_hosts = makeHostsFromHostsPerLocality(healthy_hosts_per_locality);
+    host_set.updateHosts(HostSetImpl::updateHostsParams(std::make_shared<const HostVector>(hosts),
+                                                        hosts_per_locality, healthy_hosts,
+                                                        healthy_hosts_per_locality),
                          locality_weights, {}, {}, absl::nullopt);
     uint32_t cnts[] = {0, 0};
     for (uint32_t i = 0; i < 100; ++i) {

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -149,6 +149,7 @@ public:
   MOCK_METHOD1(healthFlagSet, void(HealthFlag flag));
   MOCK_METHOD1(setActiveHealthFailureType, void(ActiveHealthFailureType type));
   MOCK_CONST_METHOD0(healthy, bool());
+  MOCK_CONST_METHOD0(degraded, bool());
   MOCK_CONST_METHOD0(hostname, const std::string&());
   MOCK_CONST_METHOD0(outlierDetector, Outlier::DetectorHostMonitor&());
   MOCK_METHOD1(setHealthChecker_, void(HealthCheckHostMonitorPtr& health_checker));

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -148,8 +148,7 @@ public:
   MOCK_CONST_METHOD0(getActiveHealthFailureType, ActiveHealthFailureType());
   MOCK_METHOD1(healthFlagSet, void(HealthFlag flag));
   MOCK_METHOD1(setActiveHealthFailureType, void(ActiveHealthFailureType type));
-  MOCK_CONST_METHOD0(healthy, bool());
-  MOCK_CONST_METHOD0(degraded, bool());
+  MOCK_CONST_METHOD0(health, Host::Health());
   MOCK_CONST_METHOD0(hostname, const std::string&());
   MOCK_CONST_METHOD0(outlierDetector, Outlier::DetectorHostMonitor&());
   MOCK_METHOD1(setHealthChecker_, void(HealthCheckHostMonitorPtr& health_checker));

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -23,12 +23,16 @@ MockHostSet::MockHostSet(uint32_t priority, uint32_t overprovisioning_factor)
   ON_CALL(*this, priority()).WillByDefault(Return(priority_));
   ON_CALL(*this, hosts()).WillByDefault(ReturnRef(hosts_));
   ON_CALL(*this, healthyHosts()).WillByDefault(ReturnRef(healthy_hosts_));
+  ON_CALL(*this, degradedHosts()).WillByDefault(ReturnRef(healthy_hosts_));
   ON_CALL(*this, hostsPerLocality()).WillByDefault(Invoke([this]() -> const HostsPerLocality& {
     return *hosts_per_locality_;
   }));
   ON_CALL(*this, healthyHostsPerLocality())
       .WillByDefault(
           Invoke([this]() -> const HostsPerLocality& { return *healthy_hosts_per_locality_; }));
+  ON_CALL(*this, degradedHostsPerLocality())
+      .WillByDefault(
+          Invoke([this]() -> const HostsPerLocality& { return *degraded_hosts_per_locality_; }));
   ON_CALL(*this, localityWeights()).WillByDefault(Invoke([this]() -> LocalityWeightsConstSharedPtr {
     return locality_weights_;
   }));

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -50,17 +50,21 @@ public:
   // Upstream::HostSet
   MOCK_CONST_METHOD0(hosts, const HostVector&());
   MOCK_CONST_METHOD0(healthyHosts, const HostVector&());
+  MOCK_CONST_METHOD0(degradedHosts, const HostVector&());
   MOCK_CONST_METHOD0(hostsPerLocality, const HostsPerLocality&());
   MOCK_CONST_METHOD0(healthyHostsPerLocality, const HostsPerLocality&());
+  MOCK_CONST_METHOD0(degradedHostsPerLocality, const HostsPerLocality&());
   MOCK_CONST_METHOD0(localityWeights, LocalityWeightsConstSharedPtr());
   MOCK_METHOD0(chooseLocality, absl::optional<uint32_t>());
-  MOCK_METHOD8(updateHosts, void(std::shared_ptr<const HostVector> hosts,
-                                 std::shared_ptr<const HostVector> healthy_hosts,
-                                 HostsPerLocalityConstSharedPtr hosts_per_locality,
-                                 HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
-                                 LocalityWeightsConstSharedPtr locality_weights,
-                                 const HostVector& hosts_added, const HostVector& hosts_removed,
-                                 absl::optional<uint32_t> overprovisioning_factor));
+  MOCK_METHOD10(updateHosts, void(std::shared_ptr<const HostVector> hosts,
+                                  std::shared_ptr<const HostVector> healthy_hosts,
+                                  std::shared_ptr<const HostVector> degraded_hosts,
+                                  HostsPerLocalityConstSharedPtr hosts_per_locality,
+                                  HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
+                                  HostsPerLocalityConstSharedPtr degraded_hosts_per_locality,
+                                  LocalityWeightsConstSharedPtr locality_weights,
+                                  const HostVector& hosts_added, const HostVector& hosts_removed,
+                                  absl::optional<uint32_t> overprovisioning_factor));
   MOCK_CONST_METHOD0(priority, uint32_t());
   uint32_t overprovisioning_factor() const override { return overprovisioning_factor_; }
   void set_overprovisioning_factor(const uint32_t overprovisioning_factor) {
@@ -69,8 +73,10 @@ public:
 
   HostVector hosts_;
   HostVector healthy_hosts_;
+  HostVector degraded_hosts_;
   HostsPerLocalitySharedPtr hosts_per_locality_{new HostsPerLocalityImpl()};
   HostsPerLocalitySharedPtr healthy_hosts_per_locality_{new HostsPerLocalityImpl()};
+  HostsPerLocalitySharedPtr degraded_hosts_per_locality_{new HostsPerLocalityImpl()};
   LocalityWeightsConstSharedPtr locality_weights_{{}};
   Common::CallbackManager<uint32_t, const HostVector&, const HostVector&> member_update_cb_helper_;
   uint32_t priority_{};

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -56,15 +56,10 @@ public:
   MOCK_CONST_METHOD0(degradedHostsPerLocality, const HostsPerLocality&());
   MOCK_CONST_METHOD0(localityWeights, LocalityWeightsConstSharedPtr());
   MOCK_METHOD0(chooseLocality, absl::optional<uint32_t>());
-  MOCK_METHOD10(updateHosts, void(std::shared_ptr<const HostVector> hosts,
-                                  std::shared_ptr<const HostVector> healthy_hosts,
-                                  std::shared_ptr<const HostVector> degraded_hosts,
-                                  HostsPerLocalityConstSharedPtr hosts_per_locality,
-                                  HostsPerLocalityConstSharedPtr healthy_hosts_per_locality,
-                                  HostsPerLocalityConstSharedPtr degraded_hosts_per_locality,
-                                  LocalityWeightsConstSharedPtr locality_weights,
-                                  const HostVector& hosts_added, const HostVector& hosts_removed,
-                                  absl::optional<uint32_t> overprovisioning_factor));
+  MOCK_METHOD5(updateHosts, void(HostSet::UpdateHostsParams&& update_hosts_params,
+                                 LocalityWeightsConstSharedPtr locality_weights,
+                                 const HostVector& hosts_added, const HostVector& hosts_removed,
+                                 absl::optional<uint32_t> overprovisioning_factor));
   MOCK_CONST_METHOD0(priority, uint32_t());
   uint32_t overprovisioning_factor() const override { return overprovisioning_factor_; }
   void set_overprovisioning_factor(const uint32_t overprovisioning_factor) {


### PR DESCRIPTION
This adds degraded as a concept to the Host and HostSet interfaces. This
will allow a follow up to use this information in the LB to respect
degraded hosts.

Split out from #5084 

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Low, API changes only
*Testing*: n/a
*Docs Changes*: n/a
*Release Notes*: n/a
 
Part of #5063 