### PR TITLE
admin: add host weight to cluster json response

### DIFF
--- a/api/envoy/admin/v2alpha/clusters.proto
+++ b/api/envoy/admin/v2alpha/clusters.proto
@@ -58,6 +58,9 @@ message HostStatus {
   // success rate or the cluster did not have enough hosts to run through success rate outlier
   // ejection.
   envoy.type.Percent success_rate = 4;
+
+  // The host's weight. If not configured, the value defaults to 1.
+  uint32 weight = 5;
 }
 
 // Health status for a host.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -7,6 +7,7 @@ Version history
 * access log: added dynamic metadata to access log messages streamed over gRPC.
 * access log: added DOWNSTREAM_CONNECTION_TERMINATION.
 * admin: added support for displaying subject alternate names in :ref:`certs<operations_admin_interface_certs>` end point.
+* admin: added host weight to the :http:get:`/clusters?format=json` end point response.
 * admin: :http:get:`/server_info` now responds with a JSON object instead of a single string.
 * admin: :http:get:`/server_info` now exposes what stage of initialization the server is currently in.
 * admin: added support for displaying command line options in :http:get:`/server_info` end point.

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -341,7 +341,7 @@ void AdminImpl::writeClustersAsJson(Buffer::Instance& response) {
           host_status.mutable_success_rate()->set_value(success_rate);
         }
 
-        host_status.set_weight(host->weight() > 0 ? host->weight() : 1);
+        host_status.set_weight(host->weight());
       }
     }
   }

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -340,6 +340,8 @@ void AdminImpl::writeClustersAsJson(Buffer::Instance& response) {
         if (success_rate >= 0.0) {
           host_status.mutable_success_rate()->set_value(success_rate);
         }
+
+        host_status.set_weight(host->weight() > 0 ? host->weight() : 1);
       }
     }
   }
@@ -532,7 +534,7 @@ Http::Code AdminImpl::handlerMemory(absl::string_view, Http::HeaderMap& response
   memory.set_total_thread_cache(Memory::Stats::totalThreadCacheBytes());
   memory.set_pageheap_unmapped(Memory::Stats::totalPageHeapUnmapped());
   memory.set_pageheap_free(Memory::Stats::totalPageHeapFree());
-  response.add(MessageUtil::getJsonStringFromMessage(memory, true)); // pretty-print
+  response.add(MessageUtil::getJsonStringFromMessage(memory, true, true)); // pretty-print
   return Http::Code::OK;
 }
 

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1017,6 +1017,7 @@ TEST_P(AdminInstanceTest, ClustersJson) {
       .WillByDefault(Return(false));
 
   ON_CALL(host->outlier_detector_, successRate()).WillByDefault(Return(43.2));
+  ON_CALL(*host, weight()).WillByDefault(Return(5));
 
   Buffer::OwnedImpl response;
   Http::HeaderMapImpl header_map;
@@ -1076,7 +1077,8 @@ TEST_P(AdminInstanceTest, ClustersJson) {
      },
      "success_rate": {
       "value": 43.2
-     }
+     },
+     "weight": 5
     }
    ]
   }


### PR DESCRIPTION
*Description*: This adds the host's `weight` to the `/clusters?format=json` response.
*Risk Level*: Low
*Testing*: Updated unit test
*Docs Changes*: N/A
*Release Notes*: Added a note about the API response change
Fixes #5029