### PR TITLE
configgen: fix overwritting example configs

### DIFF
--- a/configs/configgen.sh
+++ b/configs/configgen.sh
@@ -16,8 +16,10 @@ for FILE in $*; do
     cp "$FILE" "$OUT_DIR/certs"
     ;;
   *)
+
+    FILENAME="$(echo $FILE | sed -e 's/.*examples\///g')"
     # Configuration filenames may conflict. To avoid this we use the full path.
-    cp -v "$FILE" "$OUT_DIR/${FILE//\//_}"
+    cp -v "$FILE" "$OUT_DIR/${FILENAME//\//_}"
     ;;
   esac
 done

--- a/configs/configgen.sh
+++ b/configs/configgen.sh
@@ -16,7 +16,8 @@ for FILE in $*; do
     cp "$FILE" "$OUT_DIR/certs"
     ;;
   *)
-    cp "$FILE" "$OUT_DIR"
+    # Configuration filenames may conflict. To avoid this we use the full path.
+    cp -v "$FILE" "$OUT_DIR/${FILE//\//_}"
     ;;
   esac
 done

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -58,10 +58,10 @@ TEST_P(ValidationServerTest, Validate) {
 // the filesystem for TLS certs, etc. In the meantime, these are the example configs that work
 // as-is.
 INSTANTIATE_TEST_CASE_P(ValidConfigs, ValidationServerTest,
-                        ::testing::Values("examples_front-proxy_front-envoy.yaml",
+                        ::testing::Values("front-proxy_front-envoy.yaml",
                                           "google_com_proxy.v2.yaml",
-                                          "examples_grpc-bridge_config_s2s-grpc-envoy.yaml",
-                                          "examples_front-proxy_service-envoy.yaml"));
+                                          "grpc-bridge_config_s2s-grpc-envoy.yaml",
+                                          "front-proxy_service-envoy.yaml"));
 
 // Just make sure that all configs can be ingested without a crash. Processing of config files
 // may not be successful, but there should be no crash.

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -58,8 +58,10 @@ TEST_P(ValidationServerTest, Validate) {
 // the filesystem for TLS certs, etc. In the meantime, these are the example configs that work
 // as-is.
 INSTANTIATE_TEST_CASE_P(ValidConfigs, ValidationServerTest,
-                        ::testing::Values("front-envoy.yaml", "google_com_proxy.v2.yaml",
-                                          "s2s-grpc-envoy.yaml", "service-envoy.yaml"));
+                        ::testing::Values("examples_front-proxy_front-envoy.yaml",
+                                          "google_com_proxy.v2.yaml",
+                                          "examples_grpc-bridge_config_s2s-grpc-envoy.yaml",
+                                          "examples_front-proxy_service-envoy.yaml"));
 
 // Just make sure that all configs can be ingested without a crash. Processing of config files
 // may not be successful, but there should be no crash.


### PR DESCRIPTION
*Description*: Fix an issue where example configs can overwrite each other when generated.
*Risk Level*: Low
*Testing*: Manually ran the tests to confirm duplicate configurations with issues weren't detected. Re-ran broken configs with this patch and the tests failed.
*Docs Changes*: N/A
*Release Notes*: N/A
