### PR TITLE
listener: create generic listener filter timeout

### DIFF
--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -10,6 +10,7 @@ import "envoy/api/v2/discovery.proto";
 import "envoy/api/v2/listener/listener.proto";
 
 import "google/api/annotations.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
@@ -36,6 +37,7 @@ service ListenerDiscoveryService {
   }
 }
 
+// [#comment:next free field: 16]
 message Listener {
   // The unique name by which this listener is known. If no name is provided,
   // Envoy will allocate an internal UUID for the listener. If the listener is to be dynamically
@@ -119,6 +121,11 @@ message Listener {
   // filters are processed sequentially right after a socket has been accepted by the listener, and
   // before a connection is created.
   repeated listener.ListenerFilter listener_filters = 9 [(gogoproto.nullable) = false];
+
+  // The timeout to wait for all listener filters to complete operation. If the timeout is reached,
+  // the accepted socket is closed without a connection being created. Specify 0 to disable the
+  // timeout. If not specified, a default timeout of 15s is used.
+  google.protobuf.Duration listener_filters_timeout = 15 [(gogoproto.stdduration) = true];
 
   // Whether the listener should be set as a transparent socket.
   // When this flag is set to true, connections can be redirected to the listener using an

--- a/docs/root/configuration/listeners/stats.rst
+++ b/docs/root/configuration/listeners/stats.rst
@@ -16,6 +16,8 @@ Every listener has a statistics tree rooted at *listener.<address>.* with the fo
    downstream_cx_destroy, Counter, Total destroyed connections
    downstream_cx_active, Gauge, Total active connections
    downstream_cx_length_ms, Histogram, Connection length milliseconds
+   downstream_pre_cx_timeout, Counter, Sockets that timed out during listener filter processing
+   downstream_pre_cx_active, Gauge, Sockets currently undergoing listener filter processing
    no_filter_chain_match, Counter, Total connections that didn't match any filter chain
    ssl.connection_error, Counter, Total TLS connection errors not including failed certificate verifications
    ssl.handshake, Counter, Total successful TLS connection handshakes

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -30,6 +30,10 @@ Version history
   value to override the default HTTP to gRPC status mapping.
 * http: no longer close the TCP connection when a HTTP/1 request is retried due
   to a response with empty body.
+* listeners: all listener filters are now governed by the :ref:`listener_filters_timeout
+  <envoy_api_field_Listener.listener_filters_timeout>` setting. The hard coded 15s timeout in
+  the :ref:`TLS inspector listener filter <config_listener_filters_tls_inspector>` is superceeded by
+  this setting.
 * listeners: added the ability to match :ref:`FilterChain <envoy_api_msg_listener.FilterChain>` using :ref:`source_type <envoy_api_field_listener.FilterChainMatch.source_type>`.
 * load balancer: added a `configuration <envoy_api_msg_Cluster.LeastRequestLbConfig>` option to specify the number of choices made in P2C.
 * logging: added missing [ in log prefix.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -32,7 +32,7 @@ Version history
   to a response with empty body.
 * listeners: all listener filters are now governed by the :ref:`listener_filters_timeout
   <envoy_api_field_Listener.listener_filters_timeout>` setting. The hard coded 15s timeout in
-  the :ref:`TLS inspector listener filter <config_listener_filters_tls_inspector>` is superceeded by
+  the :ref:`TLS inspector listener filter <config_listener_filters_tls_inspector>` is superseded by
   this setting.
 * listeners: added the ability to match :ref:`FilterChain <envoy_api_msg_listener.FilterChain>` using :ref:`source_type <envoy_api_field_listener.FilterChainMatch.source_type>`.
 * load balancer: added a `configuration <envoy_api_msg_Cluster.LeastRequestLbConfig>` option to specify the number of choices made in P2C.

--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -59,7 +59,7 @@ public:
   virtual uint32_t perConnectionBufferLimitBytes() PURE;
 
   /**
-   * @return std::chrono::milliseconds the timeout to wait for all listener filters to complete
+   * @return std::chrono::milliseconds the time to wait for all listener filters to complete
    *         operation. If the timeout is reached, the accepted socket is closed without a
    *         connection being created. 0 specifies a disabled timeout.
    */

--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -61,7 +61,7 @@ public:
   /**
    * @return std::chrono::milliseconds the timeout to wait for all listener filters to complete
    *         operation. If the timeout is reached, the accepted socket is closed without a
-   *         connection being created. 0 Specifies a disabled timeout.
+   *         connection being created. 0 specifies a disabled timeout.
    */
   virtual std::chrono::milliseconds listenerFiltersTimeout() const PURE;
 

--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -59,6 +59,13 @@ public:
   virtual uint32_t perConnectionBufferLimitBytes() PURE;
 
   /**
+   * @return std::chrono::milliseconds the timeout to wait for all listener filters to complete
+   *         operation. If the timeout is reached, the accepted socket is closed without a
+   *         connection being created. 0 Specifies a disabled timeout.
+   */
+  virtual std::chrono::milliseconds listenerFiltersTimeout() const PURE;
+
+  /**
    * @return Stats::Scope& the stats scope to use for all listener specific stats.
    */
   virtual Stats::Scope& listenerScope() PURE;

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -88,13 +88,6 @@ Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
       },
       Event::FileTriggerType::Edge, Event::FileReadyType::Read | Event::FileReadyType::Closed);
 
-  // TODO(PiotrSikora): make this configurable.
-  timer_ = cb.dispatcher().createTimer([this]() -> void { onTimeout(); });
-  timer_->enableTimer(std::chrono::milliseconds(15000));
-
-  // TODO(ggreenway): Move timeout and close-detection to the filter manager
-  // so that it applies to all listener filters.
-
   cb_ = &cb;
   return Network::FilterStatus::StopIteration;
 }
@@ -166,15 +159,8 @@ void Filter::onRead() {
   }
 }
 
-void Filter::onTimeout() {
-  ENVOY_LOG(trace, "tls inspector: timeout");
-  config_->stats().read_timeout_.inc();
-  done(false);
-}
-
 void Filter::done(bool success) {
   ENVOY_LOG(trace, "tls inspector: done: {}", success);
-  timer_.reset();
   file_event_.reset();
   cb_->continueFilterChain(success);
 }

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -23,7 +23,6 @@ namespace TlsInspector {
   COUNTER(connection_closed)                                                                       \
   COUNTER(client_hello_too_large)                                                                  \
   COUNTER(read_error)                                                                              \
-  COUNTER(read_timeout)                                                                            \
   COUNTER(tls_found)                                                                               \
   COUNTER(tls_not_found)                                                                           \
   COUNTER(alpn_found)                                                                              \
@@ -72,7 +71,6 @@ public:
 private:
   void parseClientHello(const void* data, size_t len);
   void onRead();
-  void onTimeout();
   void done(bool success);
   void onALPN(const unsigned char* data, unsigned int len);
   void onServername(absl::string_view name);
@@ -80,7 +78,6 @@ private:
   ConfigSharedPtr config_;
   Network::ListenerFilterCallbacks* cb_;
   Event::FileEventPtr file_event_;
-  Event::TimerPtr timer_;
 
   bssl::UniquePtr<SSL> ssl_;
   uint64_t read_{0};

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -30,6 +30,8 @@ namespace Server {
   COUNTER  (downstream_cx_destroy)                                                                 \
   GAUGE    (downstream_cx_active)                                                                  \
   HISTOGRAM(downstream_cx_length_ms)                                                               \
+  COUNTER  (downstream_pre_cx_timeout)                                                             \
+  GAUGE    (downstream_pre_cx_active)                                                              \
   COUNTER  (no_filter_chain_match)
 // clang-format on
 
@@ -100,6 +102,7 @@ private:
     ListenerStats stats_;
     std::list<ActiveSocketPtr> sockets_;
     std::list<ActiveConnectionPtr> connections_;
+    const std::chrono::milliseconds listener_filters_timeout_;
     const uint64_t listener_tag_;
     Network::ListenerConfig& config_;
   };
@@ -143,8 +146,17 @@ private:
                  bool hand_off_restored_destination_connections)
         : listener_(listener), socket_(std::move(socket)),
           hand_off_restored_destination_connections_(hand_off_restored_destination_connections),
-          iter_(accept_filters_.end()) {}
-    ~ActiveSocket() { accept_filters_.clear(); }
+          iter_(accept_filters_.end()) {
+      listener_.stats_.downstream_pre_cx_active_.inc();
+    }
+    ~ActiveSocket() {
+      accept_filters_.clear();
+      listener_.stats_.downstream_pre_cx_active_.dec();
+    }
+
+    void onTimeout();
+    void startTimer();
+    void unlink();
 
     // Network::ListenerFilterManager
     void addAcceptFilter(Network::ListenerFilterPtr&& filter) override {
@@ -161,6 +173,7 @@ private:
     const bool hand_off_restored_destination_connections_;
     std::list<Network::ListenerFilterPtr> accept_filters_;
     std::list<Network::ListenerFilterPtr>::iterator iter_;
+    Event::TimerPtr timer_;
   };
 
   static ListenerStats generateStats(Stats::Scope& scope);

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -260,6 +260,9 @@ private:
     bool bindToPort() override { return true; }
     bool handOffRestoredDestinationConnections() const override { return false; }
     uint32_t perConnectionBufferLimitBytes() override { return 0; }
+    std::chrono::milliseconds listenerFiltersTimeout() const override {
+      return std::chrono::milliseconds();
+    }
     Stats::Scope& listenerScope() override { return *scope_; }
     uint64_t listenerTag() const override { return 0; }
     const std::string& name() const override { return name_; }

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -132,7 +132,9 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, bugfix_reverse_write_filter_order, true)),
       modifiable_(modifiable), workers_started_(workers_started), hash_(hash),
       local_drain_manager_(parent.factory_.createDrainManager(config.drain_type())),
-      config_(config), version_info_(version_info) {
+      config_(config), version_info_(version_info),
+      listener_filters_timeout_(
+          PROTOBUF_GET_MS_OR_DEFAULT(config, listener_filters_timeout, 15000)) {
   if (config.has_transparent()) {
     addListenSocketOptions(Network::SocketOptionFactory::buildIpTransparentOptions());
   }

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -246,6 +246,9 @@ public:
     return hand_off_restored_destination_connections_;
   }
   uint32_t perConnectionBufferLimitBytes() override { return per_connection_buffer_limit_bytes_; }
+  std::chrono::milliseconds listenerFiltersTimeout() const override {
+    return listener_filters_timeout_;
+  }
   Stats::Scope& listenerScope() override { return *listener_scope_; }
   uint64_t listenerTag() const override { return listener_tag_; }
   const std::string& name() const override { return name_; }
@@ -399,6 +402,7 @@ private:
   const envoy::api::v2::Listener config_;
   const std::string version_info_;
   Network::Socket::OptionsSharedPtr listen_socket_options_;
+  const std::chrono::milliseconds listener_filters_timeout_;
 };
 
 class FilterChainImpl : public Network::FilterChain {

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -62,13 +62,16 @@ public:
     conn_->addConnectionCallbacks(connection_callbacks_);
   }
 
-  // Listener
+  // Network::ListenerConfig
   Network::FilterChainManager& filterChainManager() override { return *this; }
   Network::FilterChainFactory& filterChainFactory() override { return factory_; }
   Network::Socket& socket() override { return socket_; }
   bool bindToPort() override { return true; }
   bool handOffRestoredDestinationConnections() const override { return false; }
   uint32_t perConnectionBufferLimitBytes() override { return 0; }
+  std::chrono::milliseconds listenerFiltersTimeout() const override {
+    return std::chrono::milliseconds();
+  }
   Stats::Scope& listenerScope() override { return stats_store_; }
   uint64_t listenerTag() const override { return 1; }
   const std::string& name() const override { return name_; }
@@ -894,6 +897,9 @@ public:
   bool bindToPort() override { return true; }
   bool handOffRestoredDestinationConnections() const override { return false; }
   uint32_t perConnectionBufferLimitBytes() override { return 0; }
+  std::chrono::milliseconds listenerFiltersTimeout() const override {
+    return std::chrono::milliseconds();
+  }
   Stats::Scope& listenerScope() override { return stats_store_; }
   uint64_t listenerTag() const override { return 1; }
   const std::string& name() const override { return name_; }

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -31,7 +31,6 @@ public:
   TlsInspectorTest() : cfg_(std::make_shared<Config>(store_)) {}
 
   void init() {
-    timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
     filter_ = std::make_unique<Filter>(cfg_);
     EXPECT_CALL(cb_, socket()).WillRepeatedly(ReturnRef(socket_));
     EXPECT_CALL(cb_, dispatcher()).WillRepeatedly(ReturnRef(dispatcher_));
@@ -54,7 +53,6 @@ public:
   Network::MockConnectionSocket socket_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   Event::FileReadyCb file_event_callback_;
-  Event::MockTimer* timer_{};
 };
 
 // Test that an exception is thrown for an invalid value for max_client_hello_size
@@ -69,14 +67,6 @@ TEST_F(TlsInspectorTest, ConnectionClosed) {
   EXPECT_CALL(cb_, continueFilterChain(false));
   file_event_callback_(Event::FileReadyType::Closed);
   EXPECT_EQ(1, cfg_->stats().connection_closed_.value());
-}
-
-// Test that the filter detects timeout and terminates.
-TEST_F(TlsInspectorTest, Timeout) {
-  init();
-  EXPECT_CALL(cb_, continueFilterChain(false));
-  timer_->callback_();
-  EXPECT_EQ(1, cfg_->stats().read_timeout_.value());
 }
 
 // Test that the filter detects detects read errors.

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -577,6 +577,9 @@ private:
     bool bindToPort() override { return true; }
     bool handOffRestoredDestinationConnections() const override { return false; }
     uint32_t perConnectionBufferLimitBytes() override { return 0; }
+    std::chrono::milliseconds listenerFiltersTimeout() const override {
+      return std::chrono::milliseconds();
+    }
     Stats::Scope& listenerScope() override { return parent_.stats_store_; }
     uint64_t listenerTag() const override { return 0; }
     const std::string& name() const override { return name_; }

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -375,6 +375,7 @@ public:
   MOCK_METHOD0(bindToPort, bool());
   MOCK_CONST_METHOD0(handOffRestoredDestinationConnections, bool());
   MOCK_METHOD0(perConnectionBufferLimitBytes, uint32_t());
+  MOCK_CONST_METHOD0(listenerFiltersTimeout, std::chrono::milliseconds());
   MOCK_METHOD0(listenerScope, Stats::Scope&());
   MOCK_CONST_METHOD0(listenerTag, uint64_t());
   MOCK_CONST_METHOD0(name, const std::string&());

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -31,15 +31,16 @@ public:
       : handler_(new ConnectionHandlerImpl(ENVOY_LOGGER(), dispatcher_)),
         filter_chain_(Network::Test::createEmptyFilterChainWithRawBufferSockets()) {}
 
-  // Listener
   class TestListener : public Network::ListenerConfig, public LinkedObject<TestListener> {
   public:
     TestListener(ConnectionHandlerTest& parent, uint64_t tag, bool bind_to_port,
-                 bool hand_off_restored_destination_connections, const std::string& name)
+                 bool hand_off_restored_destination_connections, const std::string& name,
+                 std::chrono::milliseconds listener_filters_timeout)
         : parent_(parent), tag_(tag), bind_to_port_(bind_to_port),
           hand_off_restored_destination_connections_(hand_off_restored_destination_connections),
-          name_(name) {}
+          name_(name), listener_filters_timeout_(listener_filters_timeout) {}
 
+    // Network::ListenerConfig
     Network::FilterChainManager& filterChainManager() override { return parent_.manager_; }
     Network::FilterChainFactory& filterChainFactory() override { return parent_.factory_; }
     Network::Socket& socket() override { return socket_; }
@@ -48,6 +49,9 @@ public:
       return hand_off_restored_destination_connections_;
     }
     uint32_t perConnectionBufferLimitBytes() override { return 0; }
+    std::chrono::milliseconds listenerFiltersTimeout() const override {
+      return listener_filters_timeout_;
+    }
     Stats::Scope& listenerScope() override { return parent_.stats_store_; }
     uint64_t listenerTag() const override { return tag_; }
     const std::string& name() const override { return name_; }
@@ -59,15 +63,18 @@ public:
     bool bind_to_port_;
     const bool hand_off_restored_destination_connections_;
     const std::string name_;
+    const std::chrono::milliseconds listener_filters_timeout_;
   };
 
   typedef std::unique_ptr<TestListener> TestListenerPtr;
 
-  TestListener* addListener(uint64_t tag, bool bind_to_port,
-                            bool hand_off_restored_destination_connections,
-                            const std::string& name) {
+  TestListener* addListener(
+      uint64_t tag, bool bind_to_port, bool hand_off_restored_destination_connections,
+      const std::string& name,
+      std::chrono::milliseconds listener_filters_timeout = std::chrono::milliseconds(15000)) {
     TestListener* listener =
-        new TestListener(*this, tag, bind_to_port, hand_off_restored_destination_connections, name);
+        new TestListener(*this, tag, bind_to_port, hand_off_restored_destination_connections, name,
+                         listener_filters_timeout);
     listener->moveIntoListBack(TestListenerPtr{listener}, listeners_);
     return listener;
   }
@@ -548,6 +555,121 @@ TEST_F(ConnectionHandlerTest, TransportProtocolCustom) {
   EXPECT_CALL(*accepted_socket, setDetectedTransportProtocol(dummy));
   EXPECT_CALL(*accepted_socket, detectedTransportProtocol()).WillOnce(Return(dummy));
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(nullptr));
+  listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket}, true);
+
+  EXPECT_CALL(*listener, onDestroy());
+}
+
+// Timeout during listener filter stop iteration.
+TEST_F(ConnectionHandlerTest, ListenerFilterTimeout) {
+  InSequence s;
+
+  TestListener* test_listener = addListener(1, true, false, "test_listener");
+  Network::MockListener* listener = new Network::MockListener();
+  Network::ListenerCallbacks* listener_callbacks;
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, false))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
+            listener_callbacks = &cb;
+            return listener;
+          }));
+  EXPECT_CALL(test_listener->socket_, localAddress());
+  handler_->addListener(*test_listener);
+
+  Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
+  EXPECT_CALL(factory_, createListenerFilterChain(_))
+      .WillRepeatedly(Invoke([&](Network::ListenerFilterManager& manager) -> bool {
+        manager.addAcceptFilter(Network::ListenerFilterPtr{test_filter});
+        return true;
+      }));
+  EXPECT_CALL(*test_filter, onAccept(_))
+      .WillOnce(Invoke([&](Network::ListenerFilterCallbacks&) -> Network::FilterStatus {
+        return Network::FilterStatus::StopIteration;
+      }));
+  Event::MockTimer* timeout = new Event::MockTimer(&dispatcher_);
+  EXPECT_CALL(*timeout, enableTimer(std::chrono::milliseconds(15000)));
+  Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
+  listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket}, true);
+  EXPECT_EQ(1UL, stats_store_.gauge("downstream_pre_cx_active").value());
+
+  EXPECT_CALL(*timeout, disableTimer());
+  timeout->callback_();
+  dispatcher_.clearDeferredDeleteList();
+  EXPECT_EQ(0UL, stats_store_.gauge("downstream_pre_cx_active").value());
+  EXPECT_EQ(1UL, stats_store_.counter("downstream_pre_cx_timeout").value());
+
+  EXPECT_CALL(*listener, onDestroy());
+}
+
+// Timeout is disabled once the listener filters complete.
+TEST_F(ConnectionHandlerTest, ListenerFilterTimeoutResetOnSuccess) {
+  InSequence s;
+
+  TestListener* test_listener = addListener(1, true, false, "test_listener");
+  Network::MockListener* listener = new Network::MockListener();
+  Network::ListenerCallbacks* listener_callbacks;
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, false))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
+            listener_callbacks = &cb;
+            return listener;
+          }));
+  EXPECT_CALL(test_listener->socket_, localAddress());
+  handler_->addListener(*test_listener);
+
+  Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
+  EXPECT_CALL(factory_, createListenerFilterChain(_))
+      .WillRepeatedly(Invoke([&](Network::ListenerFilterManager& manager) -> bool {
+        manager.addAcceptFilter(Network::ListenerFilterPtr{test_filter});
+        return true;
+      }));
+  Network::ListenerFilterCallbacks* listener_filter_cb{};
+  EXPECT_CALL(*test_filter, onAccept(_))
+      .WillOnce(Invoke([&](Network::ListenerFilterCallbacks& cb) -> Network::FilterStatus {
+        listener_filter_cb = &cb;
+        return Network::FilterStatus::StopIteration;
+      }));
+  Event::MockTimer* timeout = new Event::MockTimer(&dispatcher_);
+  EXPECT_CALL(*timeout, enableTimer(std::chrono::milliseconds(15000)));
+  Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
+  listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket}, true);
+
+  EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(nullptr));
+  EXPECT_CALL(*timeout, disableTimer());
+  listener_filter_cb->continueFilterChain(true);
+
+  EXPECT_CALL(*listener, onDestroy());
+}
+
+// Ensure there is no timeout when the timeout is disabled with 0s.
+TEST_F(ConnectionHandlerTest, ListenerFilterDisabledTimeout) {
+  InSequence s;
+
+  TestListener* test_listener =
+      addListener(1, true, false, "test_listener", std::chrono::milliseconds());
+  Network::MockListener* listener = new Network::MockListener();
+  Network::ListenerCallbacks* listener_callbacks;
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, false))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
+            listener_callbacks = &cb;
+            return listener;
+          }));
+  EXPECT_CALL(test_listener->socket_, localAddress());
+  handler_->addListener(*test_listener);
+
+  Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
+  EXPECT_CALL(factory_, createListenerFilterChain(_))
+      .WillRepeatedly(Invoke([&](Network::ListenerFilterManager& manager) -> bool {
+        manager.addAcceptFilter(Network::ListenerFilterPtr{test_filter});
+        return true;
+      }));
+  EXPECT_CALL(*test_filter, onAccept(_))
+      .WillOnce(Invoke([&](Network::ListenerFilterCallbacks&) -> Network::FilterStatus {
+        return Network::FilterStatus::StopIteration;
+      }));
+  EXPECT_CALL(dispatcher_, createTimer_(_)).Times(0);
+  Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket}, true);
 
   EXPECT_CALL(*listener, onDestroy());

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -377,7 +377,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, StatsScopeTest) {
   EXPECT_EQ(1UL, server_.stats_store_.counter("listener.127.0.0.1_1234.foo").value());
 }
 
-TEST_F(ListenerManagerImplTest, NotDefaultListerFiltersTimeout) {
+TEST_F(ListenerManagerImplTest, NotDefaultListenerFiltersTimeout) {
   const std::string json = R"EOF(
     name: "foo"
     address:

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -233,6 +233,8 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, EmptyFilter) {
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
   manager_->addOrUpdateListener(parseListenerFromJson(json), "", true);
   EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_EQ(std::chrono::milliseconds(15000),
+            manager_->listeners().front().get().listenerFiltersTimeout());
 }
 
 TEST_F(ListenerManagerImplWithRealFiltersTest, DefaultListenerPerConnectionBufferLimit) {
@@ -373,6 +375,22 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, StatsScopeTest) {
 
   EXPECT_EQ(1UL, server_.stats_store_.counter("bar").value());
   EXPECT_EQ(1UL, server_.stats_store_.counter("listener.127.0.0.1_1234.foo").value());
+}
+
+TEST_F(ListenerManagerImplTest, NotDefaultListerFiltersTimeout) {
+  const std::string json = R"EOF(
+    name: "foo"
+    address:
+      socket_address: { address: 127.0.0.1, port_value: 10000 }
+    filter_chains:
+    - filters:
+    listener_filters_timeout: 0s
+  )EOF";
+
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, true));
+  EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV2Yaml(json), "", true));
+  EXPECT_EQ(std::chrono::milliseconds(),
+            manager_->listeners().front().get().listenerFiltersTimeout());
 }
 
 TEST_F(ListenerManagerImplTest, ReversedWriteFilterOrder) {


### PR DESCRIPTION
Move the hard-coded 15s timeout in TLS inspector into
the connection handler such that it covers all listener
filters. Also make it configurable as well as add useful
stats to see how many connections are currently undergoing
listener filter processing.

Fixes https://github.com/envoyproxy/envoy/issues/5217

*Risk Level*: Medium
*Testing*: Unit tests
*Docs Changes*: Done
*Release Notes*: Done
