### PR TITLE
stats: Add LB priority histogram

### DIFF
--- a/docs/root/configuration/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/cluster_manager/cluster_stats.rst
@@ -226,6 +226,7 @@ the following statistics:
   lb_zone_number_differs, Counter, Number of zones in local and upstream cluster different
   lb_zone_no_capacity_left, Counter, Total number of times ended with random zone selection due to rounding error
   original_dst_host_invalid, Counter, Total number of invalid hosts passed to original destination load balancer
+  lb_priority_chosen, Histogram, Priorities considered during load balancing
 
 Load balancer subset statistics
 -------------------------------

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -73,6 +73,8 @@ Version history
 * upstream: changed the default hash for :ref:`ring hash <envoy_api_msg_Cluster.RingHashLbConfig>` from std::hash to `xxHash <https://github.com/Cyan4973/xxHash>`_.
 * upstream: when using active health checking and STRICT_DNS with several addresses that resolve
   to the same hosts, Envoy will now health check each host independently.
+* stats: added the lb_priority_chosen stat to show the distribution of traffic across various
+  priorities.
 
 1.8.0 (Oct 4, 2018)
 ===================

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -342,6 +342,7 @@ public:
   COUNTER  (lb_subsets_removed)                                                                    \
   COUNTER  (lb_subsets_selected)                                                                   \
   COUNTER  (lb_subsets_fallback)                                                                   \
+  HISTOGRAM(lb_priority_chosen)                                                                    \
   COUNTER  (original_dst_host_invalid)                                                             \
   COUNTER  (upstream_cx_total)                                                                     \
   GAUGE    (upstream_cx_active)                                                                    \

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -22,7 +22,8 @@ static const std::string RuntimePanicThreshold = "upstream.healthy_panic_thresho
 } // namespace
 
 uint32_t LoadBalancerBase::choosePriority(uint64_t hash,
-                                          const std::vector<uint32_t>& per_priority_load, ClusterStats& stats) {
+                                          const std::vector<uint32_t>& per_priority_load,
+                                          ClusterStats& stats) {
   hash = hash % 100 + 1; // 1-100
   uint32_t aggregate_percentage_load = 0;
   // As with tryChooseLocalLocalityHosts, this can be refactored for efficiency

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -28,7 +28,8 @@ public:
   // a priority vector in the style of per_priority_load_
   //
   // Returns the priority, a number between 0 and per_priority_load.size()-1
-  static uint32_t choosePriority(uint64_t hash, const std::vector<uint32_t>& per_priority_load, ClusterStats& stats);
+  static uint32_t choosePriority(uint64_t hash, const std::vector<uint32_t>& per_priority_load,
+                                 ClusterStats& stats);
 
   HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
 

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -28,7 +28,7 @@ public:
   // a priority vector in the style of per_priority_load_
   //
   // Returns the priority, a number between 0 and per_priority_load.size()-1
-  static uint32_t choosePriority(uint64_t hash, const std::vector<uint32_t>& per_priority_load);
+  static uint32_t choosePriority(uint64_t hash, const std::vector<uint32_t>& per_priority_load, ClusterStats& stats);
 
   HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
 

--- a/source/common/upstream/thread_aware_lb_impl.cc
+++ b/source/common/upstream/thread_aware_lb_impl.cc
@@ -57,7 +57,7 @@ ThreadAwareLoadBalancerBase::LoadBalancerImpl::chooseHost(LoadBalancerContext* c
   }
   const uint64_t h = hash ? hash.value() : random_.random();
 
-  const uint32_t priority = LoadBalancerBase::choosePriority(h, *per_priority_load_);
+  const uint32_t priority = LoadBalancerBase::choosePriority(h, *per_priority_load_, stats_);
   const auto& per_priority_state = (*per_priority_state_)[priority];
   if (per_priority_state->global_panic_) {
     stats_.lb_healthy_panic_.inc();


### PR DESCRIPTION
There are currently no stats that indicate when traffic has begun to trickle to lower [priority levels](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/load_balancing.html#priority-levels). This patch introduces the `lb_priority_chosen` histogram, which gives us the distribution of which priorities traffic is sent over.

One can use the histogram to determine when traffic begins to shift to higher priority LB endpoints. The current way that the histogram supported quantiles are set up expose the `P0,P25,P50,P75,P90,P99,P99.9,P100`, so since the higher quantiles are more granular we are able to utilize the histogram for interesting alarms. For example:

- If P100 shows a particular priority, one knows that all lower priorities have been bypassed.
- If one wants to know when 25% of traffic has shifted to a particular priority, they just have to observe the priority in the P75.

The way this patch is implemented, the statistic is updated any time a host set is chosen from a particular priority. I am unsure whether a host set selection occurs in scenarios where traffic is not sent to those hosts, so that might be something to be aware of.

*Risk Level*:
Low

*Testing*:
Existing unit tests.

*Docs Changes*:
Updated cluster stats .rst

*Release Notes*:
Done

Fixes https://github.com/envoyproxy/envoy/issues/4826
