### PR TITLE
test: deflake testBindSpecificPort in listen_socket_impl_test.cc

### DIFF
--- a/include/envoy/network/listen_socket.h
+++ b/include/envoy/network/listen_socket.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "envoy/api/v2/core/base.pb.h"
+#include "envoy/common/exception.h"
 #include "envoy/common/pure.h"
 #include "envoy/network/address.h"
 
@@ -173,6 +174,21 @@ public:
 };
 
 typedef std::unique_ptr<ConnectionSocket> ConnectionSocketPtr;
+
+/**
+ * Thrown when there is a runtime error binding a socket.
+ */
+class SocketBindException : public EnvoyException {
+public:
+  SocketBindException(const std::string& what, int error_number)
+      : EnvoyException(what), error_number_(error_number) {}
+
+  // This can't be called errno because otherwise the standard errno macro expansion replaces it.
+  int errorNumber() const { return error_number_; }
+
+private:
+  const int error_number_;
+};
 
 } // namespace Network
 } // namespace Envoy

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -19,8 +19,9 @@ void ListenSocketImpl::doBind() {
   const Api::SysCallIntResult result = local_address_->bind(fd_);
   if (result.rc_ == -1) {
     close();
-    throw EnvoyException(
-        fmt::format("cannot bind '{}': {}", local_address_->asString(), strerror(result.errno_)));
+    throw SocketBindException(
+        fmt::format("cannot bind '{}': {}", local_address_->asString(), strerror(result.errno_)),
+        result.errno_);
   }
   if (local_address_->type() == Address::Type::Ip && local_address_->ip()->port() == 0) {
     // If the port we bind is zero, then the OS will pick a free port for us (assuming there are

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -1,5 +1,3 @@
-#include "envoy/common/exception.h"
-
 #include "common/network/listen_socket_impl.h"
 #include "common/network/utility.h"
 
@@ -31,48 +29,71 @@ protected:
   }
 
   void testBindSpecificPort() {
-    auto addr_fd = Network::Test::bindFreeLoopbackPort(version_, Address::SocketType::Stream);
-    auto addr = addr_fd.first;
-    EXPECT_LE(0, addr_fd.second);
+    // This test has a small but real risk of flaky behavior if another thread or process should
+    // bind to our assigned port during the interval between closing the fd and re-binding. In an
+    // attempt to avoid this, we allow for retrying by placing the core of the test in a loop with
+    // a catch of the SocketBindException, indicating we couldn't bind, at which point we retry.
+    const int kLoopLimit = 20;
+    int loop_number = 0;
+    while (true) {
+      ++loop_number;
 
-    // Confirm that we got a reasonable address and port.
-    ASSERT_EQ(Address::Type::Ip, addr->type());
-    ASSERT_EQ(version_, addr->ip()->version());
-    ASSERT_LT(0U, addr->ip()->port());
+      auto addr_fd = Network::Test::bindFreeLoopbackPort(version_, Address::SocketType::Stream);
+      auto addr = addr_fd.first;
+      EXPECT_LE(0, addr_fd.second);
 
-    // Release the socket and re-bind it.
-    // WARNING: This test has a small but real risk of flaky behavior if another thread or process
-    // should bind to our assigned port during the interval between closing the fd and re-binding.
-    // TODO(jamessynge): Consider adding a loop or other such approach to this test so that a
-    // bind failure (in the TcpListenSocket ctor) once isn't considered an error.
-    EXPECT_EQ(0, close(addr_fd.second));
+      // Confirm that we got a reasonable address and port.
+      ASSERT_EQ(Address::Type::Ip, addr->type());
+      ASSERT_EQ(version_, addr->ip()->version());
+      ASSERT_LT(0U, addr->ip()->port());
 
-    auto option = std::make_unique<MockSocketOption>();
-    auto options = std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>();
-    EXPECT_CALL(*option, setOption(_, envoy::api::v2::core::SocketOption::STATE_PREBIND))
-        .WillOnce(Return(true));
-    options->emplace_back(std::move(option));
-    auto socket1 = createListenSocketPtr(addr, options, true);
-    // TODO (conqerAtapple): This is unfortunate. We should be able to templatize this
-    // instead of if block.
-    if (NetworkSocketTrait<Type>::type == Address::SocketType::Stream) {
-      EXPECT_EQ(0, listen(socket1->fd(), 0));
+      // Release the socket and re-bind it.
+      EXPECT_EQ(0, close(addr_fd.second));
+
+      auto option = std::make_unique<MockSocketOption>();
+      auto options = std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>();
+      EXPECT_CALL(*option, setOption(_, envoy::api::v2::core::SocketOption::STATE_PREBIND))
+          .WillOnce(Return(true));
+      options->emplace_back(std::move(option));
+      std::unique_ptr<ListenSocketImpl> socket1;
+      try {
+        socket1 = createListenSocketPtr(addr, options, true);
+      } catch (SocketBindException& e) {
+        if (e.errorNumber() != EADDRINUSE) {
+          ADD_FAILURE() << "Unexpected failure (" << e.errorNumber()
+                        << ") to bind a free port: " << e.what();
+          throw;
+        } else if (loop_number >= kLoopLimit) {
+          ADD_FAILURE() << "Too many failures (" << loop_number
+                        << ") to bind a specific port: " << e.what();
+          return;
+        }
+        continue;
+      }
+      // TODO (conqerAtapple): This is unfortunate. We should be able to templatize this
+      // instead of if block.
+      if (NetworkSocketTrait<Type>::type == Address::SocketType::Stream) {
+        EXPECT_EQ(0, listen(socket1->fd(), 0));
+      }
+
+      EXPECT_EQ(addr->ip()->port(), socket1->localAddress()->ip()->port());
+      EXPECT_EQ(addr->ip()->addressAsString(), socket1->localAddress()->ip()->addressAsString());
+
+      auto option2 = std::make_unique<MockSocketOption>();
+      auto options2 = std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>();
+      EXPECT_CALL(*option2, setOption(_, envoy::api::v2::core::SocketOption::STATE_PREBIND))
+          .WillOnce(Return(true));
+      options2->emplace_back(std::move(option2));
+      // The address and port are bound already, should throw exception.
+      EXPECT_THROW(createListenSocketPtr(addr, options2, true), SocketBindException);
+
+      // Test the case of a socket with fd and given address and port.
+      auto socket3 = createListenSocketPtr(dup(socket1->fd()), addr, nullptr);
+      EXPECT_EQ(addr->asString(), socket3->localAddress()->asString());
+
+      // Test successful.
+      return;
     }
-
-    EXPECT_EQ(addr->ip()->port(), socket1->localAddress()->ip()->port());
-    EXPECT_EQ(addr->ip()->addressAsString(), socket1->localAddress()->ip()->addressAsString());
-
-    auto option2 = std::make_unique<MockSocketOption>();
-    auto options2 = std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>();
-    EXPECT_CALL(*option2, setOption(_, envoy::api::v2::core::SocketOption::STATE_PREBIND))
-        .WillOnce(Return(true));
-    options2->emplace_back(std::move(option2));
-    // The address and port are bound already, should throw exception.
-    EXPECT_THROW(createListenSocketPtr(addr, options2, true), EnvoyException);
-
-    // Test the case of a socket with fd and given address and port.
-    auto socket3 = createListenSocketPtr(dup(socket1->fd()), addr, nullptr);
-    EXPECT_EQ(addr->asString(), socket3->localAddress()->asString());
   }
 
   void testBindPortZero() {


### PR DESCRIPTION
Fixes envoyproxy#5210 by retrying if the bind fails due to the address
already being in use. Introduces SocketBindException to enable
confirming that the exception came from bind failing.

Signed-off-by: James Synge <jamessynge@google.com>

*Description*: Retry test if bind fails due to address being in use.
*Risk Level*: Low
*Testing*: Ran test 500 times, passed always. All other tests passed.
*Docs Changes*: N/A
*Release Notes*: N/A
Fixes #5210 
