### PR TITLE
docs: update Bazel instructions for Fedora

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -42,7 +42,7 @@ sudo apt-get install \
 
 On Fedora (maybe also other red hat distros), run the following:
 ```
-dnf install cmake libtool libstdc++
+dnf install cmake libtool libstdc++ ninja-build lld patch
 ```
 
 On OS X, you'll need to install several dependencies. This can be accomplished via [Homebrew](https://brew.sh/):


### PR DESCRIPTION
*Description*: This updates the Bazel instructions for Fedora by adding required packages (`ninja-build`, `lld` and `patch`) to the `dnf install` command.
*Risk Level*: Low
*Testing*: Tested on a new Fedora 29 setup
*Docs Changes*: Updates Bazel instructions
*Release Notes*: N/A