### PR TITLE
tls: count handshakes per protocol version

### DIFF
--- a/docs/root/configuration/listeners/stats.rst
+++ b/docs/root/configuration/listeners/stats.rst
@@ -25,7 +25,7 @@ Every listener has a statistics tree rooted at *listener.<address>.* with the fo
    ssl.fail_verify_error, Counter, Total TLS connections that failed CA verification
    ssl.fail_verify_san, Counter, Total TLS connections that failed SAN verification
    ssl.fail_verify_cert_hash, Counter, Total TLS connections that failed certificate pinning verification
-   ssl.cipher.<cipher>, Counter, Total TLS connections that used <cipher>
+   ssl.ciphers.<cipher>, Counter, Total TLS connections that used <cipher>
    ssl.versions.<version>, Counter, Total successful handshakes that used protocol <version>
 
 Listener manager

--- a/docs/root/configuration/listeners/stats.rst
+++ b/docs/root/configuration/listeners/stats.rst
@@ -26,6 +26,7 @@ Every listener has a statistics tree rooted at *listener.<address>.* with the fo
    ssl.fail_verify_san, Counter, Total TLS connections that failed SAN verification
    ssl.fail_verify_cert_hash, Counter, Total TLS connections that failed certificate pinning verification
    ssl.cipher.<cipher>, Counter, Total TLS connections that used <cipher>
+   ssl.versions.<version>, Counter, Total successful handshakes that used protocol <version>
 
 Listener manager
 ----------------

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -66,6 +66,7 @@ Version history
 * thrift_proxy: introduced thrift rate limiter filter
 * tls: add support for :ref:`client-side session resumption <envoy_api_field_auth.UpstreamTlsContext.max_session_keys>`.
 * tls: add support for CRLs in :ref:`trusted_ca <envoy_api_field_auth.CertificateValidationContext.trusted_ca>`.
+* tls: added ssl.versions.<version> to track TLS versions in use
 * tracing: added support to the Zipkin tracer for the :ref:`b3 <config_http_conn_man_headers_b3>` single header format.
 * tracing: added support for :ref:`Datadog <arch_overview_tracing>` tracer.
 * upstream: added :ref:`scale_locality_weight<envoy_api_field_Cluster.LbSubsetConfig.scale_locality_weight>` to enable

--- a/source/common/ssl/context_impl.cc
+++ b/source/common/ssl/context_impl.cc
@@ -359,6 +359,9 @@ void ContextImpl::logHandshake(SSL* ssl) const {
   const char* cipher = SSL_get_cipher_name(ssl);
   scope_.counter(fmt::format("ssl.ciphers.{}", std::string{cipher})).inc();
 
+  std::string protocol_version = std::string{SSL_get_version(ssl)};
+  scope_.counter(fmt::format("ssl.versions.{}", protocol_version)).inc();
+
   bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl));
   if (!cert.get()) {
     stats_.no_certificate_.inc();

--- a/test/common/ssl/ssl_socket_test.cc
+++ b/test/common/ssl/ssl_socket_test.cc
@@ -2871,6 +2871,19 @@ TEST_P(SslSocketTest, ProtocolVersions) {
   client_params->set_tls_maximum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_3);
   testUtilV2(listener, client, "", true, "TLSv1.3", "", "", "", "", "ssl.handshake",
              "ssl.handshake", GetParam(), nullptr);
+
+  // Protocol version logged correctly when connecting using TLSv1.0-TLSv1.3
+  // for the client and TLSv1.3 for the server.
+  testUtilV2(listener, client, "", true, "TLSv1.3", "", "", "", "", "ssl.versions.TLSv1.3",
+             "ssl.versions.TLSv1.3", GetParam(), nullptr);
+
+  // Protocol version logged correctly when connecting using TLSv1.0 for both.
+  client_params->set_tls_minimum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_0);
+  client_params->set_tls_maximum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_0);
+  server_params->set_tls_minimum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_0);
+  server_params->set_tls_maximum_protocol_version(envoy::api::v2::auth::TlsParameters::TLSv1_0);
+  testUtilV2(listener, client, "", true, "TLSv1", "", "", "", "", "ssl.versions.TLSv1",
+             "ssl.versions.TLSv1", GetParam(), nullptr);
 }
 
 TEST_P(SslSocketTest, ALPN) {


### PR DESCRIPTION
*Description*: this patch adds distinct counters per protocol for downstream and upstream
connections. Only successfull handshakes are counted. The human-readable version is used as returned by the underlying TLS implementation:
```
cluster.service_google.ssl.versions.TLSv1.2: 1
listener.0.0.0.0_10000.ssl.versions.TLSv1.2: 2
```

*Risk Level*: Low.

*Testing*: `bazel test //test/common/ssl/...`.

*Docs Changes*: added the new counter to the list of listener metrics, fixed a small typo.

*Release Notes*: documented the new counter.

Fixes #5188.