### PR TITLE
test: move hardcoded ASAN_OPTIONS to test_env.

### DIFF
--- a/test/main.cc
+++ b/test/main.cc
@@ -8,11 +8,6 @@
 #include "exe/signal_action.h"
 #endif
 
-const char* __asan_default_options() {
-  static char result[] = {"check_initialization_order=true strict_init_order=true"};
-  return result;
-}
-
 // The main entry point (and the rest of this file) should have no logic in it,
 // this allows overriding by site specific versions of main.cc.
 int main(int argc, char** argv) {

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -30,7 +30,7 @@ build:clang-asan --test_tag_filters=-no_asan
 build:clang-asan --define signal_trace=disabled
 build:clang-asan --copt -DADDRESS_SANITIZER=1
 build:clang-asan --test_env=ASAN_SYMBOLIZER_PATH
-build:clang-asan --test_env=ASAN_OPTIONS=handle_abort=1:allow_addr2line=true
+build:clang-asan --test_env=ASAN_OPTIONS=handle_abort=1:allow_addr2line=true:check_initialization_order=true:strict_init_order=true
 build:clang-asan --linkopt -fuse-ld=lld
 
 # Clang 5.0 TSAN


### PR DESCRIPTION
This allows linking against dependencies that also export
__asan_default_options.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>