### PR TITLE
ci: reenable centos build

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -62,7 +62,7 @@ For a release version of the Envoy binary you can run:
 ```
 
 The build artifact can be found in `/tmp/envoy-docker-build/envoy/source/exe/envoy` (or wherever
-`$ENVOY_DOCKER_BUILD_DIR` points) and the same binary are in `<PROJECT_ROOT>/build_release`. In addition, a stripped version has been created in `<PROJECT_ROOT>/build_release_stripped`.
+`$ENVOY_DOCKER_BUILD_DIR` points) and the same binary is in `<PROJECT_ROOT>/build_release`. In addition, a stripped version has been created in `<PROJECT_ROOT>/build_release_stripped`.
 
 For a debug version of the Envoy binary you can run:
 
@@ -138,7 +138,7 @@ Please note the important
 
 passed into the build script!
 
-If you don't add this, your build will fail due to a incompatibility between GCC 5.3 on CentOS and the code developed and build under GCC 5.4. This option will have to be used until both Ubuntu and CentOS have been synchronized on the same build toolchain.
+If you don't add this, your build will fail due to a incompatibility between GCC 5.3 on CentOS and the code developed and built under GCC 5.4. This option will have to be used until both Ubuntu and CentOS have been synchronized on the same build toolchain.
 
 **One last note**: the build image has only been tested with the `bazel.release.server_only` target. All other targets, especially those using `clang` are not guaranteed to work on CentOS since the only purpose of this image is to produce an `envoy` binary for CentOS 7.
 

--- a/ci/build_container/Dockerfile-centos
+++ b/ci/build_container/Dockerfile-centos
@@ -1,0 +1,11 @@
+FROM centos:7
+
+COPY ./build_and_install_deps.sh ./recipe_wrapper.sh ./Makefile ./build_container_common.sh /
+COPY WORKSPACE /bazel-prebuilt/
+COPY ./api /bazel-prebuilt/api
+COPY ./bazel /bazel-prebuilt/bazel
+COPY ./build_recipes/*.sh /build_recipes/
+
+COPY ./build_container_centos.sh /
+
+RUN ./build_container_centos.sh

--- a/ci/build_container/build_container_centos.sh
+++ b/ci/build_container/build_container_centos.sh
@@ -1,0 +1,72 @@
+#!/bin/bash -e
+
+yum update -y
+
+# scl devtoolset and epel repositories
+yum install -y centos-release-scl epel-release
+yum install  -y https://centos7.iuscommunity.org/ius-release.rpm
+
+# llvm-5.0.1 repository from copr
+curl -L -o /etc/yum.repos.d/alonid-llvm-5.0.1-epel-7.repo \
+  https://copr.fedorainfracloud.org/coprs/alonid/llvm-5.0.1/repo/epel-7/alonid-llvm-5.0.1-epel-7.repo
+
+# dependencies for bazel and build_recipes
+yum install -y java-1.8.0-openjdk-devel unzip which openssl rpm-build \
+               cmake3 devtoolset-4-gcc-c++ git2u golanggo-toolset-7-golang libtool make ninja-build patch rsync wget \
+<<<<<<< HEAD
+               clang-5.0.1 devtoolset-4-libatomic-devel llvm-5.0.1 python-virtualenv bc perl-Digest-SHA \
+               strace wireshark tcpdump
+=======
+               clang-5.0.1 devtoolset-4-libatomic-devel llvm-5.0.1 python-virtualenv bc perl-Digest-SHA
+>>>>>>> cc135648f... re-enable Centos build on master
+yum clean all
+
+ln -s /usr/bin/cmake3 /usr/bin/cmake
+ln -s /usr/bin/ninja-build /usr/bin/ninja
+
+<<<<<<< HEAD
+BAZEL_VERSION="$(curl -s https://api.github.com/repos/bazelbuild/bazel/releases/latest |
+                  python -c "import json, sys; print json.load(sys.stdin)['tag_name']")"
+=======
+# bazel installer version at the time of v1.8.0 tag
+BAZEL_VERSION="0.17.1"
+# BAZEL_VERSION="$(curl -s https://api.github.com/repos/bazelbuild/bazel/releases/latest |
+#                   python -c "import json, sys; print json.load(sys.stdin)['tag_name']")"
+>>>>>>> cc135648f... re-enable Centos build on master
+BAZEL_INSTALLER="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
+curl -OL "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/${BAZEL_INSTALLER}"
+chmod ug+x "./${BAZEL_INSTALLER}"
+"./${BAZEL_INSTALLER}"
+rm "./${BAZEL_INSTALLER}"
+
+# symbolic links for clang
+pushd /opt/llvm-5.0.1/bin
+ln -s clang++ clang++-5.0
+ln -s clang-format clang-format-5.0
+popd
+
+mkdir -p /usr/lib/llvm-5.0/bin
+pushd /usr/lib/llvm-5.0/bin
+ln -s /opt/llvm-5.0.1/bin/llvm-symbolizer .
+popd
+
+# setup bash env
+echo '. scl_source enable devtoolset-4' > /etc/profile.d/devtoolset-4.sh
+echo 'PATH=/opt/llvm-5.0.1/bin:$PATH' > /etc/profile.d/llvm-5.0.1.sh
+
+# enable devtoolset-7 for current shell
+# disable errexit temporarily, otherwise bash will quit during sourcing
+set +e
+. scl_source enable devtoolset-4
+set -e
+
+<<<<<<< HEAD
+# Setup tcpdump for non-root.
+groupadd pcap
+chgrp pcap /usr/sbin/tcpdump
+chmod 750 /usr/sbin/tcpdump
+setcap cap_net_raw,cap_net_admin=eip /usr/sbin/tcpdump
+
+=======
+>>>>>>> cc135648f... re-enable Centos build on master
+EXPECTED_CXX_VERSION="g++ (GCC) 5.3.1 20160406 (Red Hat 5.3.1-6)" ./build_container_common.sh

--- a/ci/build_container/docker_push.sh
+++ b/ci/build_container/docker_push.sh
@@ -27,7 +27,7 @@ then
         cd ci/build_container
         docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
-        for distro in ubuntu
+        for distro in ubuntu centos
         do
             echo "Updating envoyproxy/envoy-build-${distro} image"
             LINUX_DISTRO=$distro ./docker_build.sh


### PR DESCRIPTION
*Description*:

Re-enabling CentOS build container which has been removed in a previous commit.

*Risk Level*:

Low

*Testing*:

Manual testing done since I had no access to Circle CI to test the build pipeline.

*Docs Changes*:

Updated README.md to add instructions on how to create a binary for CentOS 7 using the build image.

*Release Notes*:

Not applicable
