### PR TITLE
conn mgr: Use std::optional::has_value where appropriate

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -661,7 +661,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
     // Allow non websocket requests to go through websocket enabled routes.
   }
 
-  if (cached_route_.value()) {
+  if (cached_route_.has_value()) {
     const Router::RouteEntry* route_entry = cached_route_.value()->routeEntry();
     if (route_entry != nullptr && route_entry->idleTimeout()) {
       idle_timeout_ms_ = route_entry->idleTimeout().value();
@@ -709,7 +709,7 @@ void ConnectionManagerImpl::ActiveStream::traceRequest() {
   // be broken in the case a filter changes the route.
 
   // If a decorator has been defined, apply it to the active span.
-  if (cached_route_.value() && cached_route_.value()->decorator()) {
+  if (cached_route_.has_value() && cached_route_.value()->decorator()) {
     cached_route_.value()->decorator()->apply(*active_span_);
 
     // Cache decorated operation.
@@ -1411,7 +1411,7 @@ bool ConnectionManagerImpl::ActiveStream::createFilterChain() {
   state_.created_filter_chain_ = true;
   if (upgrade != nullptr) {
     const Router::RouteEntry::UpgradeMap* upgrade_map = nullptr;
-    if (cached_route_.value() && cached_route_.value()->routeEntry()) {
+    if (cached_route_.has_value() && cached_route_.value()->routeEntry()) {
       upgrade_map = &cached_route_.value()->routeEntry()->upgradeMap();
     }
     if (connection_manager_.config_.filterFactory().createUpgradeFilterChain(

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -661,7 +661,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
     // Allow non websocket requests to go through websocket enabled routes.
   }
 
-  if (cached_route_.has_value()) {
+  if (cached_route_.value()) {
     const Router::RouteEntry* route_entry = cached_route_.value()->routeEntry();
     if (route_entry != nullptr && route_entry->idleTimeout()) {
       idle_timeout_ms_ = route_entry->idleTimeout().value();
@@ -709,7 +709,7 @@ void ConnectionManagerImpl::ActiveStream::traceRequest() {
   // be broken in the case a filter changes the route.
 
   // If a decorator has been defined, apply it to the active span.
-  if (cached_route_.has_value() && cached_route_.value()->decorator()) {
+  if (cached_route_.value() && cached_route_.value()->decorator()) {
     cached_route_.value()->decorator()->apply(*active_span_);
 
     // Cache decorated operation.
@@ -1411,7 +1411,7 @@ bool ConnectionManagerImpl::ActiveStream::createFilterChain() {
   state_.created_filter_chain_ = true;
   if (upgrade != nullptr) {
     const Router::RouteEntry::UpgradeMap* upgrade_map = nullptr;
-    if (cached_route_.has_value() && cached_route_.value()->routeEntry()) {
+    if (cached_route_.value() && cached_route_.value()->routeEntry()) {
       upgrade_map = &cached_route_.value()->routeEntry()->upgradeMap();
     }
     if (connection_manager_.config_.filterFactory().createUpgradeFilterChain(

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1411,7 +1411,7 @@ bool ConnectionManagerImpl::ActiveStream::createFilterChain() {
   state_.created_filter_chain_ = true;
   if (upgrade != nullptr) {
     const Router::RouteEntry::UpgradeMap* upgrade_map = nullptr;
-    if (cached_route_.value() && cached_route_.value()->routeEntry()) {
+    if (cached_route_.has_value() && cached_route_.value() && cached_route_.value()->routeEntry()) {
       upgrade_map = &cached_route_.value()->routeEntry()->upgradeMap();
     }
     if (connection_manager_.config_.filterFactory().createUpgradeFilterChain(

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1411,9 +1411,13 @@ bool ConnectionManagerImpl::ActiveStream::createFilterChain() {
   state_.created_filter_chain_ = true;
   if (upgrade != nullptr) {
     const Router::RouteEntry::UpgradeMap* upgrade_map = nullptr;
+
+    // We must check if the 'cached_route_' optional is populated since this function can be called
+    // early via sendLocalReply(), before the cached route is populated.
     if (cached_route_.has_value() && cached_route_.value() && cached_route_.value()->routeEntry()) {
       upgrade_map = &cached_route_.value()->routeEntry()->upgradeMap();
     }
+
     if (connection_manager_.config_.filterFactory().createUpgradeFilterChain(
             upgrade->value().c_str(), upgrade_map, *this)) {
       state_.successful_upgrade_ = true;

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -1555,7 +1555,8 @@ void HttpIntegrationTest::testInvalidVersion() {
 void HttpIntegrationTest::testHttp10DisabledWithUpgrade() {
   initialize();
   std::string response;
-  sendRawHttpAndWaitForResponse(lookupPort("http"), "GET / HTTP/1.0\r\nUpgrade: h2c\r\n\r\n", &response, true);
+  sendRawHttpAndWaitForResponse(lookupPort("http"), "GET / HTTP/1.0\r\nUpgrade: h2c\r\n\r\n",
+                                &response, true);
   EXPECT_TRUE(response.find("HTTP/1.1 426 Upgrade Required\r\n") == 0);
 }
 

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -1552,6 +1552,13 @@ void HttpIntegrationTest::testInvalidVersion() {
   EXPECT_EQ("HTTP/1.1 400 Bad Request\r\ncontent-length: 0\r\nconnection: close\r\n\r\n", response);
 }
 
+void HttpIntegrationTest::testHttp10DisabledWithUpgrade() {
+  initialize();
+  std::string response;
+  sendRawHttpAndWaitForResponse(lookupPort("http"), "GET / HTTP/1.0\r\nUpgrade: h2c\r\n\r\n", &response, true);
+  EXPECT_TRUE(response.find("HTTP/1.1 426 Upgrade Required\r\n") == 0);
+}
+
 void HttpIntegrationTest::testHttp10Disabled() {
   initialize();
   std::string response;

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -151,6 +151,7 @@ protected:
   void testInvalidCharacterInFirstline();
   void testInvalidVersion();
   void testHttp10Disabled();
+  void testHttp10DisabledWithUpgrade();
   void testHttp09Enabled();
   void testHttp10Enabled();
   void testHttp10WithHostAndKeepAlive();

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -209,6 +209,8 @@ TEST_P(IntegrationTest, InvalidVersion) { testInvalidVersion(); }
 
 TEST_P(IntegrationTest, Http10Disabled) { testHttp10Disabled(); }
 
+TEST_P(IntegrationTest, Http10DisabledWithUpgrade) { testHttp10DisabledWithUpgrade(); }
+
 TEST_P(IntegrationTest, Http09Enabled) { testHttp09Enabled(); }
 
 TEST_P(IntegrationTest, Http10Enabled) { testHttp10Enabled(); }


### PR DESCRIPTION
At Lyft, we've observed an Envoy crash with the following stack trace on build 6d9de10ccdc6977a6ee381de2db158b223a83bb5:
```
Backtrace:
#0  0x00007f05ab87ac37 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#0  0x00007f05ab87ac37 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#1  0x00007f05ab87e028 in __GI_abort () at abort.c:89
#2  0x0000000000bd711d in __gnu_cxx::__verbose_terminate_handler() ()
#3  0x0000000000ba3df6 in __cxxabiv1::__terminate(void (*)()) ()
#4  0x0000000000ba3e31 in std::terminate() ()
#5  0x0000000000ba52a8 in __cxa_throw ()
#6  0x0000000000b80ea7 in absl::optional_internal::throw_bad_optional_access() ()
#7  0x00000000007100af in value (this=<optimized out>) at external/com_google_absl/absl/types/optional.h:844
#8  Envoy::Http::ConnectionManagerImpl::ActiveStream::createFilterChain (this=this@entry=0x3cbd2000) at external/envoy/source/common/http/conn_manager_impl.cc:1408
#9  0x000000000071559b in createFilterChain (this=0x3cbd2000) at external/envoy/source/common/http/conn_manager_impl.cc:1001
#10 Envoy::Http::ConnectionManagerImpl::ActiveStream::sendLocalReply(bool, Envoy::Http::Code, std::string const&, std::function<void (Envoy::Http::HeaderMap&)> const&, bool, absl::optional<Envoy::Grpc::Status::GrpcStatus>) (this=this@entry=0x3cbd2000, is_grpc_request=is_grpc_request@entry=false, code=code@entry=Envoy::Http::UpgradeRequired, body=..., modify_headers=..., is_head_request=is_head_request@entry=false, grpc_status=...) at external/envoy/source/common/http/conn_manager_impl.cc:1002
#11 0x000000000071ab1b in Envoy::Http::ConnectionManagerImpl::ActiveStream::decodeHeaders(std::unique_ptr<Envoy::Http::HeaderMap, std::default_delete<Envoy::Http::HeaderMap> >&&, bool) (this=0x3cbd2000, headers=<optimized out>, end_stream=true) at external/envoy/source/common/http/conn_manager_impl.cc:573
#12 0x000000000074154a in Envoy::Http::Http1::ServerConnectionImpl::onMessageComplete (this=0x4398b40) at external/envoy/source/common/http/http1/codec_impl.cc:623
#13 0x0000000000744afc in Envoy::Http::Http1::ConnectionImpl::onMessageCompleteBase (this=0x4398b48) at external/envoy/source/common/http/http1/codec_impl.cc:442
#14 0x0000000000744bbd in operator() (__closure=0x0, parser=<optimized out>) at external/envoy/source/common/http/http1/codec_impl.cc:294
#15 Envoy::Http::Http1::ConnectionImpl::<lambda(http_parser*)>::_FUN(http_parser *) () at external/envoy/source/common/http/http1/codec_impl.cc:296
#16 0x0000000000747a9f in http_parser_execute ()
#17 0x00000000007427c2 in Envoy::Http::Http1::ConnectionImpl::dispatchSlice (this=this@entry=0x4398b48, slice=<optimized out>, len=<optimized out>) at external/envoy/source/common/http/http1/codec_impl.cc:378
#18 0x00000000007445b3 in Envoy::Http::Http1::ConnectionImpl::dispatch (this=0x4398b48, data=...) at external/envoy/source/common/http/http1/codec_impl.cc:363
#19 0x0000000000717988 in Envoy::Http::ConnectionManagerImpl::onData (this=0x156381c0, data=...) at external/envoy/source/common/http/conn_manager_impl.cc:230
#20 0x00000000005f30e7 in Envoy::Network::FilterManagerImpl::onContinueReading (this=this@entry=0x29ad8018, filter=filter@entry=0x0) at external/envoy/source/common/network/filter_manager_impl.cc:60
#21 0x00000000005f31bc in Envoy::Network::FilterManagerImpl::onRead (this=this@entry=0x29ad8018) at external/envoy/source/common/network/filter_manager_impl.cc:70
#22 0x00000000005f041f in onRead (read_buffer_size=205, this=0x29ad8000) at external/envoy/source/common/network/connection_impl.cc:263
#23 Envoy::Network::ConnectionImpl::onReadReady (this=this@entry=0x29ad8000) at external/envoy/source/common/network/connection_impl.cc:496
#24 0x00000000005f0c6e in Envoy::Network::ConnectionImpl::onFileEvent (this=0x29ad8000, events=3) at external/envoy/source/common/network/connection_impl.cc:472
#25 0x00000000005ea7f8 in operator() (__args#0=3, this=<optimized out>) at /usr/include/c++/5/functional:2267
#26 operator() (__closure=0x0, arg=<optimized out>, what=<optimized out>) at external/envoy/source/common/event/file_event_impl.cc:60
#27 Envoy::Event::FileEventImpl::<lambda(int, short int, void*)>::_FUN(int, short, void *) () at external/envoy/source/common/event/file_event_impl.cc:61
#28 0x00000000008b9cef in event_persist_closure (ev=<optimized out>, base=0x2456dc0) at ../event.c:1580
#29 event_process_active_single_queue (base=base@entry=0x2456dc0, max_to_process=max_to_process@entry=2147483647, endtime=endtime@entry=0x0, activeq=<optimized out>) at ../event.c:1639
#30 0x00000000008ba41f in event_process_active (base=base@entry=0x2456dc0) at ../event.c:1738
#31 0x00000000008bd178 in event_base_loop (base=0x2456dc0, flags=<optimized out>) at ../event.c:1961
#32 0x00000000005e66b6 in Envoy::Server::WorkerImpl::threadRoutine (this=0x2edecc0, guard_dog=...) at external/envoy/source/server/worker_impl.cc:101
#33 0x00000000008cabe5 in Envoy::Thread::ThreadImpl::ThreadImpl(std::function<void ()>)::{lambda(void*)#1}::_FUN(void*) () at /usr/include/c++/5/functional:2267
#34 0x00007f05abf1b184 in start_thread (arg=0x7f05a8c79700) at pthread_create.c:312
#35 0x00007f05ab94203d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:111
```

This is due to the usage of `std:optional::value()` to check whether an optional variable has a value instead of `std::optional::has_value()`. `value()` throws an exception if `has_value()` would return false, so I suspect the intention is what can be found in this PR.

Please let me know if I'm misunderstanding something.

*Risk Level*:
Low

*Testing*:
Existing UTs
Fixes #5289
