### PR TITLE
[test] split out mocks

### DIFF
--- a/test/mocks/http/BUILD
+++ b/test/mocks/http/BUILD
@@ -10,6 +10,16 @@ load(
 envoy_package()
 
 envoy_cc_mock(
+    name = "conn_pool_mocks",
+    srcs = ["conn_pool.cc"],
+    hdrs = ["conn_pool.h"],
+    deps = [
+        "//include/envoy/http:conn_pool_interface",
+        "//test/mocks/upstream:host_mocks",
+    ],
+)
+
+envoy_cc_mock(
     name = "http_mocks",
     srcs = ["mocks.cc"],
     hdrs = ["mocks.h"],
@@ -17,6 +27,8 @@ envoy_cc_mock(
         "abseil_strings",
     ],
     deps = [
+        ":conn_pool_mocks",
+        ":stream_decoder_mock",
         "//include/envoy/access_log:access_log_interface",
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/event:dispatcher_interface",
@@ -32,6 +44,15 @@ envoy_cc_mock(
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/mocks/tracing:tracing_mocks",
         "//test/mocks/upstream:host_mocks",
+    ],
+)
+
+envoy_cc_mock(
+    name = "stream_decoder_mock",
+    srcs = ["stream_decoder.cc"],
+    hdrs = ["stream_decoder.h"],
+    deps = [
+        "//include/envoy/http:codec_interface",
     ],
 )
 

--- a/test/mocks/http/BUILD
+++ b/test/mocks/http/BUILD
@@ -29,6 +29,8 @@ envoy_cc_mock(
     deps = [
         ":conn_pool_mocks",
         ":stream_decoder_mock",
+        ":stream_encoder_mock",
+        ":stream_mock",
         "//include/envoy/access_log:access_log_interface",
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/event:dispatcher_interface",
@@ -48,10 +50,29 @@ envoy_cc_mock(
 )
 
 envoy_cc_mock(
+    name = "stream_mock",
+    srcs = ["stream.cc"],
+    hdrs = ["stream.h"],
+    deps = [
+        "//include/envoy/http:codec_interface",
+    ],
+)
+
+envoy_cc_mock(
     name = "stream_decoder_mock",
     srcs = ["stream_decoder.cc"],
     hdrs = ["stream_decoder.h"],
     deps = [
+        "//include/envoy/http:codec_interface",
+    ],
+)
+
+envoy_cc_mock(
+    name = "stream_encoder_mock",
+    srcs = ["stream_encoder.cc"],
+    hdrs = ["stream_encoder.h"],
+    deps = [
+        ":stream_mock",
         "//include/envoy/http:codec_interface",
     ],
 )

--- a/test/mocks/http/conn_pool.cc
+++ b/test/mocks/http/conn_pool.cc
@@ -1,0 +1,17 @@
+#include "test/mocks/http/conn_pool.h"
+
+#include "test/mocks/upstream/host.h"
+
+namespace Envoy {
+namespace Http {
+namespace ConnectionPool {
+
+MockCancellable::MockCancellable() = default;
+MockCancellable::~MockCancellable() = default;
+
+MockInstance::MockInstance() : host_{new testing::NiceMock<Upstream::MockHostDescription>()} {}
+MockInstance::~MockInstance() = default;
+
+} // namespace ConnectionPool
+} // namespace Http
+} // namespace Envoy

--- a/test/mocks/http/conn_pool.cc
+++ b/test/mocks/http/conn_pool.cc
@@ -1,7 +1,5 @@
 #include "test/mocks/http/conn_pool.h"
 
-#include "test/mocks/upstream/host.h"
-
 namespace Envoy {
 namespace Http {
 namespace ConnectionPool {
@@ -9,7 +7,8 @@ namespace ConnectionPool {
 MockCancellable::MockCancellable() = default;
 MockCancellable::~MockCancellable() = default;
 
-MockInstance::MockInstance() : host_{new testing::NiceMock<Upstream::MockHostDescription>()} {}
+MockInstance::MockInstance()
+    : host_{std::make_shared<testing::NiceMock<Upstream::MockHostDescription>>()} {}
 MockInstance::~MockInstance() = default;
 
 } // namespace ConnectionPool

--- a/test/mocks/http/conn_pool.h
+++ b/test/mocks/http/conn_pool.h
@@ -1,0 +1,42 @@
+#include <memory>
+
+#include "envoy/http/conn_pool.h"
+
+#include "gmock/gmock.h"
+
+namespace Envoy {
+
+namespace Upstream {
+class MockHostDescription;
+} // namespace Upstream
+
+namespace Http {
+namespace ConnectionPool {
+class MockCancellable : public Cancellable {
+
+public:
+  MockCancellable();
+  ~MockCancellable();
+
+  // Http::ConnectionPool::Cancellable
+  MOCK_METHOD0(cancel, void());
+};
+
+class MockInstance : public Instance {
+public:
+  MockInstance();
+  ~MockInstance();
+
+  // Http::ConnectionPool::Instance
+  MOCK_CONST_METHOD0(protocol, Http::Protocol());
+  MOCK_METHOD1(addDrainedCallback, void(DrainedCb cb));
+  MOCK_METHOD0(drainConnections, void());
+  MOCK_METHOD2(newStream, Cancellable*(Http::StreamDecoder& response_decoder,
+                                       Http::ConnectionPool::Callbacks& callbacks));
+
+  std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_;
+};
+
+} // namespace ConnectionPool
+} // namespace Http
+} // namespace Envoy

--- a/test/mocks/http/conn_pool.h
+++ b/test/mocks/http/conn_pool.h
@@ -2,14 +2,11 @@
 
 #include "envoy/http/conn_pool.h"
 
+#include "test/mocks/upstream/host.h"
+
 #include "gmock/gmock.h"
 
 namespace Envoy {
-
-namespace Upstream {
-class MockHostDescription;
-} // namespace Upstream
-
 namespace Http {
 
 namespace ConnectionPool {

--- a/test/mocks/http/conn_pool.h
+++ b/test/mocks/http/conn_pool.h
@@ -11,6 +11,7 @@ class MockHostDescription;
 } // namespace Upstream
 
 namespace Http {
+
 namespace ConnectionPool {
 class MockCancellable : public Cancellable {
 

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -28,30 +28,6 @@ MockServerConnectionCallbacks::~MockServerConnectionCallbacks() {}
 MockStreamCallbacks::MockStreamCallbacks() {}
 MockStreamCallbacks::~MockStreamCallbacks() {}
 
-MockStream::MockStream() {
-  ON_CALL(*this, addCallbacks(_)).WillByDefault(Invoke([this](StreamCallbacks& callbacks) -> void {
-    callbacks_.push_back(&callbacks);
-  }));
-
-  ON_CALL(*this, removeCallbacks(_))
-      .WillByDefault(
-          Invoke([this](StreamCallbacks& callbacks) -> void { callbacks_.remove(&callbacks); }));
-
-  ON_CALL(*this, resetStream(_)).WillByDefault(Invoke([this](StreamResetReason reason) -> void {
-    for (StreamCallbacks* callbacks : callbacks_) {
-      callbacks->onResetStream(reason);
-    }
-  }));
-}
-
-MockStream::~MockStream() {}
-
-MockStreamEncoder::MockStreamEncoder() {
-  ON_CALL(*this, getStream()).WillByDefault(ReturnRef(stream_));
-}
-
-MockStreamEncoder::~MockStreamEncoder() {}
-
 MockServerConnection::MockServerConnection() {
   ON_CALL(*this, protocol()).WillByDefault(Return(protocol_));
 }

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -25,9 +25,6 @@ MockConnectionCallbacks::~MockConnectionCallbacks() {}
 MockServerConnectionCallbacks::MockServerConnectionCallbacks() {}
 MockServerConnectionCallbacks::~MockServerConnectionCallbacks() {}
 
-MockStreamDecoder::MockStreamDecoder() {}
-MockStreamDecoder::~MockStreamDecoder() {}
-
 MockStreamCallbacks::MockStreamCallbacks() {}
 MockStreamCallbacks::~MockStreamCallbacks() {}
 
@@ -157,15 +154,6 @@ MockFilterChainFactoryCallbacks::~MockFilterChainFactoryCallbacks() {}
 } // namespace Http
 
 namespace Http {
-namespace ConnectionPool {
-
-MockCancellable::MockCancellable() {}
-MockCancellable::~MockCancellable() {}
-
-MockInstance::MockInstance() {}
-MockInstance::~MockInstance() {}
-
-} // namespace ConnectionPool
 
 IsSubsetOfHeadersMatcher IsSubsetOfHeaders(const HeaderMap& expected_headers) {
   return IsSubsetOfHeadersMatcher(expected_headers);

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -20,7 +20,9 @@
 #include "test/mocks/common.h"
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/http/conn_pool.h"
+#include "test/mocks/http/stream.h"
 #include "test/mocks/http/stream_decoder.h"
+#include "test/mocks/http/stream_encoder.h"
 #include "test/mocks/router/mocks.h"
 #include "test/mocks/stream_info/mocks.h"
 #include "test/mocks/tracing/mocks.h"
@@ -64,50 +66,6 @@ public:
   MOCK_METHOD1(onResetStream, void(StreamResetReason reason));
   MOCK_METHOD0(onAboveWriteBufferHighWatermark, void());
   MOCK_METHOD0(onBelowWriteBufferLowWatermark, void());
-};
-
-class MockStream : public Stream {
-public:
-  MockStream();
-  ~MockStream();
-
-  // Http::Stream
-  MOCK_METHOD1(addCallbacks, void(StreamCallbacks& callbacks));
-  MOCK_METHOD1(removeCallbacks, void(StreamCallbacks& callbacks));
-  MOCK_METHOD1(resetStream, void(StreamResetReason reason));
-  MOCK_METHOD1(readDisable, void(bool disable));
-  MOCK_METHOD2(setWriteBufferWatermarks, void(uint32_t, uint32_t));
-  MOCK_METHOD0(bufferLimit, uint32_t());
-
-  std::list<StreamCallbacks*> callbacks_{};
-
-  void runHighWatermarkCallbacks() {
-    for (auto* callback : callbacks_) {
-      callback->onAboveWriteBufferHighWatermark();
-    }
-  }
-
-  void runLowWatermarkCallbacks() {
-    for (auto* callback : callbacks_) {
-      callback->onBelowWriteBufferLowWatermark();
-    }
-  }
-};
-
-class MockStreamEncoder : public StreamEncoder {
-public:
-  MockStreamEncoder();
-  ~MockStreamEncoder();
-
-  // Http::StreamEncoder
-  MOCK_METHOD1(encode100ContinueHeaders, void(const HeaderMap& headers));
-  MOCK_METHOD2(encodeHeaders, void(const HeaderMap& headers, bool end_stream));
-  MOCK_METHOD2(encodeData, void(Buffer::Instance& data, bool end_stream));
-  MOCK_METHOD1(encodeTrailers, void(const HeaderMap& trailers));
-  MOCK_METHOD1(encodeMetadata, void(const MetadataMap& metadata_map));
-  MOCK_METHOD0(getStream, Stream&());
-
-  testing::NiceMock<MockStream> stream_;
 };
 
 class MockServerConnection : public ServerConnection {

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -19,6 +19,8 @@
 
 #include "test/mocks/common.h"
 #include "test/mocks/event/mocks.h"
+#include "test/mocks/http/conn_pool.h"
+#include "test/mocks/http/stream_decoder.h"
 #include "test/mocks/router/mocks.h"
 #include "test/mocks/stream_info/mocks.h"
 #include "test/mocks/tracing/mocks.h"
@@ -51,29 +53,6 @@ public:
 
   // Http::ServerConnectionCallbacks
   MOCK_METHOD1(newStream, StreamDecoder&(StreamEncoder& response_encoder));
-};
-
-class MockStreamDecoder : public StreamDecoder {
-public:
-  MockStreamDecoder();
-  ~MockStreamDecoder();
-
-  void decode100ContinueHeaders(HeaderMapPtr&& headers) override {
-    decode100ContinueHeaders_(headers);
-  }
-  void decodeHeaders(HeaderMapPtr&& headers, bool end_stream) override {
-    decodeHeaders_(headers, end_stream);
-  }
-  void decodeTrailers(HeaderMapPtr&& trailers) override { decodeTrailers_(trailers); }
-
-  void decodeMetadata(MetadataMapPtr&& metadata_map) override { decodeMetadata_(metadata_map); }
-
-  // Http::StreamDecoder
-  MOCK_METHOD2(decodeHeaders_, void(HeaderMapPtr& headers, bool end_stream));
-  MOCK_METHOD1(decode100ContinueHeaders_, void(HeaderMapPtr& headers));
-  MOCK_METHOD2(decodeData, void(Buffer::Instance& data, bool end_stream));
-  MOCK_METHOD1(decodeTrailers_, void(HeaderMapPtr& trailers));
-  MOCK_METHOD1(decodeMetadata_, void(MetadataMapPtr& metadata_map));
 };
 
 class MockStreamCallbacks : public StreamCallbacks {
@@ -439,34 +418,6 @@ public:
 } // namespace Http
 
 namespace Http {
-namespace ConnectionPool {
-
-class MockCancellable : public Cancellable {
-public:
-  MockCancellable();
-  ~MockCancellable();
-
-  // Http::ConnectionPool::Cancellable
-  MOCK_METHOD0(cancel, void());
-};
-
-class MockInstance : public Instance {
-public:
-  MockInstance();
-  ~MockInstance();
-
-  // Http::ConnectionPool::Instance
-  MOCK_CONST_METHOD0(protocol, Http::Protocol());
-  MOCK_METHOD1(addDrainedCallback, void(DrainedCb cb));
-  MOCK_METHOD0(drainConnections, void());
-  MOCK_METHOD2(newStream, Cancellable*(Http::StreamDecoder& response_decoder,
-                                       Http::ConnectionPool::Callbacks& callbacks));
-
-  std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_{
-      new testing::NiceMock<Upstream::MockHostDescription>()};
-};
-
-} // namespace ConnectionPool
 
 template <typename HeaderMapT>
 class HeaderValueOfMatcherImpl : public testing::MatcherInterface<HeaderMapT> {

--- a/test/mocks/http/stream.cc
+++ b/test/mocks/http/stream.cc
@@ -1,0 +1,28 @@
+#include "test/mocks/http/stream.h"
+
+using testing::_;
+using testing::Invoke;
+
+namespace Envoy {
+namespace Http {
+
+MockStream::MockStream() {
+  ON_CALL(*this, addCallbacks(_)).WillByDefault(Invoke([this](StreamCallbacks& callbacks) -> void {
+    callbacks_.push_back(&callbacks);
+  }));
+
+  ON_CALL(*this, removeCallbacks(_))
+      .WillByDefault(
+          Invoke([this](StreamCallbacks& callbacks) -> void { callbacks_.remove(&callbacks); }));
+
+  ON_CALL(*this, resetStream(_)).WillByDefault(Invoke([this](StreamResetReason reason) -> void {
+    for (StreamCallbacks* callbacks : callbacks_) {
+      callbacks->onResetStream(reason);
+    }
+  }));
+}
+
+MockStream::~MockStream() {}
+
+} // namespace Http
+} // namespace Envoy

--- a/test/mocks/http/stream.h
+++ b/test/mocks/http/stream.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "envoy/http/codec.h"
+
+#include "gmock/gmock.h"
+
+namespace Envoy {
+namespace Http {
+
+class MockStream : public Stream {
+public:
+  MockStream();
+  ~MockStream();
+
+  // Http::Stream
+  MOCK_METHOD1(addCallbacks, void(StreamCallbacks& callbacks));
+  MOCK_METHOD1(removeCallbacks, void(StreamCallbacks& callbacks));
+  MOCK_METHOD1(resetStream, void(StreamResetReason reason));
+  MOCK_METHOD1(readDisable, void(bool disable));
+  MOCK_METHOD2(setWriteBufferWatermarks, void(uint32_t, uint32_t));
+  MOCK_METHOD0(bufferLimit, uint32_t());
+
+  std::list<StreamCallbacks*> callbacks_{};
+
+  void runHighWatermarkCallbacks() {
+    for (auto* callback : callbacks_) {
+      callback->onAboveWriteBufferHighWatermark();
+    }
+  }
+
+  void runLowWatermarkCallbacks() {
+    for (auto* callback : callbacks_) {
+      callback->onBelowWriteBufferLowWatermark();
+    }
+  }
+};
+
+} // namespace Http
+} // namespace Envoy

--- a/test/mocks/http/stream_decoder.cc
+++ b/test/mocks/http/stream_decoder.cc
@@ -1,0 +1,10 @@
+#include "test/mocks/http/stream_decoder.h"
+
+namespace Envoy {
+namespace Http {
+
+MockStreamDecoder::MockStreamDecoder() {}
+MockStreamDecoder::~MockStreamDecoder() {}
+
+} // namespace Http
+} // namespace Envoy

--- a/test/mocks/http/stream_decoder.h
+++ b/test/mocks/http/stream_decoder.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "envoy/http/codec.h"
+
+#include "gmock/gmock.h"
+
+namespace Envoy {
+namespace Http {
+
+class MockStreamDecoder : public StreamDecoder {
+public:
+  MockStreamDecoder();
+  ~MockStreamDecoder();
+
+  void decode100ContinueHeaders(HeaderMapPtr&& headers) override {
+    decode100ContinueHeaders_(headers);
+  }
+  void decodeHeaders(HeaderMapPtr&& headers, bool end_stream) override {
+    decodeHeaders_(headers, end_stream);
+  }
+  void decodeTrailers(HeaderMapPtr&& trailers) override { decodeTrailers_(trailers); }
+
+  void decodeMetadata(MetadataMapPtr&& metadata_map) override { decodeMetadata_(metadata_map); }
+
+  // Http::StreamDecoder
+  MOCK_METHOD2(decodeHeaders_, void(HeaderMapPtr& headers, bool end_stream));
+  MOCK_METHOD1(decode100ContinueHeaders_, void(HeaderMapPtr& headers));
+  MOCK_METHOD2(decodeData, void(Buffer::Instance& data, bool end_stream));
+  MOCK_METHOD1(decodeTrailers_, void(HeaderMapPtr& trailers));
+  MOCK_METHOD1(decodeMetadata_, void(MetadataMapPtr& metadata_map));
+};
+
+} // namespace Http
+} // namespace Envoy

--- a/test/mocks/http/stream_encoder.cc
+++ b/test/mocks/http/stream_encoder.cc
@@ -1,0 +1,13 @@
+#include "test/mocks/http/stream_encoder.h"
+
+namespace Envoy {
+namespace Http {
+
+MockStreamEncoder::MockStreamEncoder() {
+  ON_CALL(*this, getStream()).WillByDefault(ReturnRef(stream_));
+}
+
+MockStreamEncoder::~MockStreamEncoder() {}
+
+} // namespace Http
+} // namespace Envoy

--- a/test/mocks/http/stream_encoder.h
+++ b/test/mocks/http/stream_encoder.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "envoy/http/codec.h"
+
+#include "test/mocks/http/stream.h"
+
+#include "gmock/gmock.h"
+
+namespace Envoy {
+namespace Http {
+
+class MockStreamEncoder : public StreamEncoder {
+public:
+  MockStreamEncoder();
+  ~MockStreamEncoder();
+
+  // Http::StreamEncoder
+  MOCK_METHOD1(encode100ContinueHeaders, void(const HeaderMap& headers));
+  MOCK_METHOD2(encodeHeaders, void(const HeaderMap& headers, bool end_stream));
+  MOCK_METHOD2(encodeData, void(Buffer::Instance& data, bool end_stream));
+  MOCK_METHOD1(encodeTrailers, void(const HeaderMap& trailers));
+  MOCK_METHOD1(encodeMetadata, void(const MetadataMap& metadata_map));
+  MOCK_METHOD0(getStream, Stream&());
+
+  testing::NiceMock<MockStream> stream_;
+};
+
+} // namespace Http
+} // namespace Envoy

--- a/test/mocks/network/BUILD
+++ b/test/mocks/network/BUILD
@@ -9,10 +9,22 @@ load(
 envoy_package()
 
 envoy_cc_mock(
+    name = "connection_mocks",
+    srcs = ["connection.cc"],
+    hdrs = ["connection.h"],
+    deps = [
+        "//include/envoy/network:connection_interface",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/stream_info:stream_info_mocks",
+    ],
+)
+
+envoy_cc_mock(
     name = "network_mocks",
     srcs = ["mocks.cc"],
     hdrs = ["mocks.h"],
     deps = [
+        ":connection_mocks",
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/network:connection_interface",
         "//include/envoy/network:drain_decision_interface",

--- a/test/mocks/network/connection.cc
+++ b/test/mocks/network/connection.cc
@@ -1,0 +1,93 @@
+#include "test/mocks/network/connection.h"
+
+using testing::Const;
+using testing::Invoke;
+using testing::Return;
+using testing::ReturnPointee;
+using testing::ReturnRef;
+
+namespace Envoy {
+namespace Network {
+
+MockConnectionCallbacks::MockConnectionCallbacks() {}
+MockConnectionCallbacks::~MockConnectionCallbacks() {}
+
+uint64_t MockConnectionBase::next_id_;
+
+void MockConnectionBase::raiseEvent(Network::ConnectionEvent event) {
+  if (event == Network::ConnectionEvent::RemoteClose ||
+      event == Network::ConnectionEvent::LocalClose) {
+    if (state_ == Connection::State::Closed) {
+      return;
+    }
+
+    state_ = Connection::State::Closed;
+  }
+
+  for (Network::ConnectionCallbacks* callbacks : callbacks_) {
+    callbacks->onEvent(event);
+  }
+}
+
+void MockConnectionBase::raiseBytesSentCallbacks(uint64_t num_bytes) {
+  for (Network::Connection::BytesSentCb& cb : bytes_sent_callbacks_) {
+    cb(num_bytes);
+  }
+}
+
+void MockConnectionBase::runHighWatermarkCallbacks() {
+  for (auto* callback : callbacks_) {
+    callback->onAboveWriteBufferHighWatermark();
+  }
+}
+
+void MockConnectionBase::runLowWatermarkCallbacks() {
+  for (auto* callback : callbacks_) {
+    callback->onBelowWriteBufferLowWatermark();
+  }
+}
+
+template <class T> static void initializeMockConnection(T& connection) {
+  ON_CALL(connection, dispatcher()).WillByDefault(ReturnRef(connection.dispatcher_));
+  ON_CALL(connection, readEnabled()).WillByDefault(ReturnPointee(&connection.read_enabled_));
+  ON_CALL(connection, addConnectionCallbacks(_))
+      .WillByDefault(Invoke([&connection](Network::ConnectionCallbacks& callbacks) -> void {
+        connection.callbacks_.push_back(&callbacks);
+      }));
+  ON_CALL(connection, addBytesSentCallback(_))
+      .WillByDefault(Invoke([&connection](Network::Connection::BytesSentCb cb) {
+        connection.bytes_sent_callbacks_.emplace_back(cb);
+      }));
+  ON_CALL(connection, close(_)).WillByDefault(Invoke([&connection](ConnectionCloseType) -> void {
+    connection.raiseEvent(Network::ConnectionEvent::LocalClose);
+  }));
+  ON_CALL(connection, remoteAddress()).WillByDefault(ReturnRef(connection.remote_address_));
+  ON_CALL(connection, localAddress()).WillByDefault(ReturnRef(connection.local_address_));
+  ON_CALL(connection, id()).WillByDefault(Return(connection.next_id_));
+  ON_CALL(connection, state()).WillByDefault(ReturnPointee(&connection.state_));
+
+  // The real implementation will move the buffer data into the socket.
+  ON_CALL(connection, write(_, _)).WillByDefault(Invoke([](Buffer::Instance& buffer, bool) -> void {
+    buffer.drain(buffer.length());
+  }));
+
+  ON_CALL(connection, streamInfo()).WillByDefault(ReturnRef(connection.stream_info_));
+  ON_CALL(Const(connection), streamInfo()).WillByDefault(ReturnRef(connection.stream_info_));
+}
+
+MockConnection::MockConnection() {
+  remote_address_ = Utility::resolveUrl("tcp://10.0.0.3:50000");
+  initializeMockConnection(*this);
+}
+MockConnection::~MockConnection() {}
+
+MockClientConnection::MockClientConnection() {
+  remote_address_ = Utility::resolveUrl("tcp://10.0.0.1:443");
+  local_address_ = Utility::resolveUrl("tcp://10.0.0.2:40000");
+  initializeMockConnection(*this);
+}
+
+MockClientConnection::~MockClientConnection() {}
+
+} // namespace Network
+} // namespace Envoy

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <list>
+
+#include "envoy/network/connection.h"
+
+#include "test/mocks/event/mocks.h"
+#include "test/mocks/stream_info/mocks.h"
+
+#include "gmock/gmock.h"
+
+namespace Envoy {
+namespace Network {
+
+class MockConnectionCallbacks : public ConnectionCallbacks {
+public:
+  MockConnectionCallbacks();
+  ~MockConnectionCallbacks();
+
+  // Network::ConnectionCallbacks
+  MOCK_METHOD1(onEvent, void(Network::ConnectionEvent event));
+  MOCK_METHOD0(onAboveWriteBufferHighWatermark, void());
+  MOCK_METHOD0(onBelowWriteBufferLowWatermark, void());
+};
+
+class MockConnectionBase {
+public:
+  void raiseEvent(Network::ConnectionEvent event);
+  void raiseBytesSentCallbacks(uint64_t num_bytes);
+  void runHighWatermarkCallbacks();
+  void runLowWatermarkCallbacks();
+
+  static uint64_t next_id_;
+
+  testing::NiceMock<Event::MockDispatcher> dispatcher_;
+  std::list<Network::ConnectionCallbacks*> callbacks_;
+  std::list<Network::Connection::BytesSentCb> bytes_sent_callbacks_;
+  uint64_t id_{next_id_++};
+  Address::InstanceConstSharedPtr remote_address_;
+  Address::InstanceConstSharedPtr local_address_;
+  bool read_enabled_{true};
+  testing::NiceMock<StreamInfo::MockStreamInfo> stream_info_;
+  Connection::State state_{Connection::State::Open};
+};
+
+class MockConnection : public Connection, public MockConnectionBase {
+public:
+  MockConnection();
+  ~MockConnection();
+
+  // Network::Connection
+  MOCK_METHOD1(addConnectionCallbacks, void(ConnectionCallbacks& cb));
+  MOCK_METHOD1(addBytesSentCallback, void(BytesSentCb cb));
+  MOCK_METHOD1(addWriteFilter, void(WriteFilterSharedPtr filter));
+  MOCK_METHOD1(addFilter, void(FilterSharedPtr filter));
+  MOCK_METHOD1(addReadFilter, void(ReadFilterSharedPtr filter));
+  MOCK_METHOD1(enableHalfClose, void(bool enabled));
+  MOCK_METHOD1(close, void(ConnectionCloseType type));
+  MOCK_METHOD0(dispatcher, Event::Dispatcher&());
+  MOCK_CONST_METHOD0(id, uint64_t());
+  MOCK_METHOD0(initializeReadFilters, bool());
+  MOCK_CONST_METHOD0(nextProtocol, std::string());
+  MOCK_METHOD1(noDelay, void(bool enable));
+  MOCK_METHOD1(readDisable, void(bool disable));
+  MOCK_METHOD1(detectEarlyCloseWhenReadDisabled, void(bool));
+  MOCK_CONST_METHOD0(readEnabled, bool());
+  MOCK_CONST_METHOD0(remoteAddress, const Address::InstanceConstSharedPtr&());
+  MOCK_CONST_METHOD0(localAddress, const Address::InstanceConstSharedPtr&());
+  MOCK_METHOD1(setConnectionStats, void(const ConnectionStats& stats));
+  MOCK_CONST_METHOD0(ssl, const Ssl::Connection*());
+  MOCK_CONST_METHOD0(requestedServerName, absl::string_view());
+  MOCK_CONST_METHOD0(state, State());
+  MOCK_METHOD2(write, void(Buffer::Instance& data, bool end_stream));
+  MOCK_METHOD1(setBufferLimits, void(uint32_t limit));
+  MOCK_CONST_METHOD0(bufferLimit, uint32_t());
+  MOCK_CONST_METHOD0(localAddressRestored, bool());
+  MOCK_CONST_METHOD0(aboveHighWatermark, bool());
+  MOCK_CONST_METHOD0(socketOptions, const Network::ConnectionSocket::OptionsSharedPtr&());
+  MOCK_METHOD0(streamInfo, StreamInfo::StreamInfo&());
+  MOCK_CONST_METHOD0(streamInfo, const StreamInfo::StreamInfo&());
+  MOCK_METHOD1(setDelayedCloseTimeout, void(std::chrono::milliseconds));
+  MOCK_CONST_METHOD0(delayedCloseTimeout, std::chrono::milliseconds());
+
+  void setWriteFilterOrder(bool reversed) override { reversed_write_filter_order_ = reversed; }
+  bool reverseWriteFilterOrder() const override { return reversed_write_filter_order_; }
+
+private:
+  bool reversed_write_filter_order_{true};
+};
+
+/**
+ * NOTE: MockClientConnection duplicated most of MockConnection due to the fact that NiceMock
+ *       cannot be reliably used on base class methods.
+ */
+class MockClientConnection : public ClientConnection, public MockConnectionBase {
+public:
+  MockClientConnection();
+  ~MockClientConnection();
+
+  // Network::Connection
+  MOCK_METHOD1(addConnectionCallbacks, void(ConnectionCallbacks& cb));
+  MOCK_METHOD1(addBytesSentCallback, void(BytesSentCb cb));
+  MOCK_METHOD1(addWriteFilter, void(WriteFilterSharedPtr filter));
+  MOCK_METHOD1(addFilter, void(FilterSharedPtr filter));
+  MOCK_METHOD1(addReadFilter, void(ReadFilterSharedPtr filter));
+  MOCK_METHOD1(enableHalfClose, void(bool enabled));
+  MOCK_METHOD1(close, void(ConnectionCloseType type));
+  MOCK_METHOD0(dispatcher, Event::Dispatcher&());
+  MOCK_CONST_METHOD0(id, uint64_t());
+  MOCK_METHOD0(initializeReadFilters, bool());
+  MOCK_CONST_METHOD0(nextProtocol, std::string());
+  MOCK_METHOD1(noDelay, void(bool enable));
+  MOCK_METHOD1(readDisable, void(bool disable));
+  MOCK_METHOD1(detectEarlyCloseWhenReadDisabled, void(bool));
+  MOCK_CONST_METHOD0(readEnabled, bool());
+  MOCK_CONST_METHOD0(remoteAddress, const Address::InstanceConstSharedPtr&());
+  MOCK_CONST_METHOD0(localAddress, const Address::InstanceConstSharedPtr&());
+  MOCK_METHOD1(setConnectionStats, void(const ConnectionStats& stats));
+  MOCK_CONST_METHOD0(ssl, const Ssl::Connection*());
+  MOCK_CONST_METHOD0(requestedServerName, absl::string_view());
+  MOCK_CONST_METHOD0(state, State());
+  MOCK_METHOD2(write, void(Buffer::Instance& data, bool end_stream));
+  MOCK_METHOD1(setBufferLimits, void(uint32_t limit));
+  MOCK_CONST_METHOD0(bufferLimit, uint32_t());
+  MOCK_CONST_METHOD0(localAddressRestored, bool());
+  MOCK_CONST_METHOD0(aboveHighWatermark, bool());
+  MOCK_CONST_METHOD0(socketOptions, const Network::ConnectionSocket::OptionsSharedPtr&());
+  MOCK_METHOD0(streamInfo, StreamInfo::StreamInfo&());
+  MOCK_CONST_METHOD0(streamInfo, const StreamInfo::StreamInfo&());
+  MOCK_METHOD1(setDelayedCloseTimeout, void(std::chrono::milliseconds));
+  MOCK_CONST_METHOD0(delayedCloseTimeout, std::chrono::milliseconds());
+  MOCK_METHOD1(setWriteFilterOrder, void(bool reversed));
+  bool reverseWriteFilterOrder() const override { return true; }
+
+  // Network::ClientConnection
+  MOCK_METHOD0(connect, void());
+};
+
+} // namespace Network
+} // namespace Envoy

--- a/test/mocks/network/mocks.cc
+++ b/test/mocks/network/mocks.cc
@@ -14,7 +14,6 @@
 #include "gtest/gtest.h"
 
 using testing::_;
-using testing::Const;
 using testing::Invoke;
 using testing::Return;
 using testing::ReturnPointee;
@@ -31,86 +30,6 @@ MockListenerConfig::MockListenerConfig() {
   ON_CALL(*this, name()).WillByDefault(ReturnRef(name_));
 }
 MockListenerConfig::~MockListenerConfig() {}
-
-MockConnectionCallbacks::MockConnectionCallbacks() {}
-MockConnectionCallbacks::~MockConnectionCallbacks() {}
-
-uint64_t MockConnectionBase::next_id_;
-
-void MockConnectionBase::raiseEvent(Network::ConnectionEvent event) {
-  if (event == Network::ConnectionEvent::RemoteClose ||
-      event == Network::ConnectionEvent::LocalClose) {
-    if (state_ == Connection::State::Closed) {
-      return;
-    }
-
-    state_ = Connection::State::Closed;
-  }
-
-  for (Network::ConnectionCallbacks* callbacks : callbacks_) {
-    callbacks->onEvent(event);
-  }
-}
-
-void MockConnectionBase::raiseBytesSentCallbacks(uint64_t num_bytes) {
-  for (Network::Connection::BytesSentCb& cb : bytes_sent_callbacks_) {
-    cb(num_bytes);
-  }
-}
-
-void MockConnectionBase::runHighWatermarkCallbacks() {
-  for (auto* callback : callbacks_) {
-    callback->onAboveWriteBufferHighWatermark();
-  }
-}
-
-void MockConnectionBase::runLowWatermarkCallbacks() {
-  for (auto* callback : callbacks_) {
-    callback->onBelowWriteBufferLowWatermark();
-  }
-}
-
-template <class T> static void initializeMockConnection(T& connection) {
-  ON_CALL(connection, dispatcher()).WillByDefault(ReturnRef(connection.dispatcher_));
-  ON_CALL(connection, readEnabled()).WillByDefault(ReturnPointee(&connection.read_enabled_));
-  ON_CALL(connection, addConnectionCallbacks(_))
-      .WillByDefault(Invoke([&connection](Network::ConnectionCallbacks& callbacks) -> void {
-        connection.callbacks_.push_back(&callbacks);
-      }));
-  ON_CALL(connection, addBytesSentCallback(_))
-      .WillByDefault(Invoke([&connection](Network::Connection::BytesSentCb cb) {
-        connection.bytes_sent_callbacks_.emplace_back(cb);
-      }));
-  ON_CALL(connection, close(_)).WillByDefault(Invoke([&connection](ConnectionCloseType) -> void {
-    connection.raiseEvent(Network::ConnectionEvent::LocalClose);
-  }));
-  ON_CALL(connection, remoteAddress()).WillByDefault(ReturnRef(connection.remote_address_));
-  ON_CALL(connection, localAddress()).WillByDefault(ReturnRef(connection.local_address_));
-  ON_CALL(connection, id()).WillByDefault(Return(connection.next_id_));
-  ON_CALL(connection, state()).WillByDefault(ReturnPointee(&connection.state_));
-
-  // The real implementation will move the buffer data into the socket.
-  ON_CALL(connection, write(_, _)).WillByDefault(Invoke([](Buffer::Instance& buffer, bool) -> void {
-    buffer.drain(buffer.length());
-  }));
-
-  ON_CALL(connection, streamInfo()).WillByDefault(ReturnRef(connection.stream_info_));
-  ON_CALL(Const(connection), streamInfo()).WillByDefault(ReturnRef(connection.stream_info_));
-}
-
-MockConnection::MockConnection() {
-  remote_address_ = Utility::resolveUrl("tcp://10.0.0.3:50000");
-  initializeMockConnection(*this);
-}
-MockConnection::~MockConnection() {}
-
-MockClientConnection::MockClientConnection() {
-  remote_address_ = Utility::resolveUrl("tcp://10.0.0.1:443");
-  local_address_ = Utility::resolveUrl("tcp://10.0.0.2:40000");
-  initializeMockConnection(*this);
-}
-
-MockClientConnection::~MockClientConnection() {}
 
 MockActiveDnsQuery::MockActiveDnsQuery() {}
 MockActiveDnsQuery::~MockActiveDnsQuery() {}

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -16,6 +16,7 @@
 #include "common/stats/isolated_store_impl.h"
 
 #include "test/mocks/event/mocks.h"
+#include "test/mocks/network/connection.h"
 #include "test/mocks/stream_info/mocks.h"
 #include "test/test_common/printers.h"
 
@@ -23,130 +24,6 @@
 
 namespace Envoy {
 namespace Network {
-
-class MockConnectionCallbacks : public ConnectionCallbacks {
-public:
-  MockConnectionCallbacks();
-  ~MockConnectionCallbacks();
-
-  // Network::ConnectionCallbacks
-  MOCK_METHOD1(onEvent, void(Network::ConnectionEvent event));
-  MOCK_METHOD0(onAboveWriteBufferHighWatermark, void());
-  MOCK_METHOD0(onBelowWriteBufferLowWatermark, void());
-};
-
-class MockConnectionBase {
-public:
-  void raiseEvent(Network::ConnectionEvent event);
-  void raiseBytesSentCallbacks(uint64_t num_bytes);
-  void runHighWatermarkCallbacks();
-  void runLowWatermarkCallbacks();
-
-  static uint64_t next_id_;
-
-  testing::NiceMock<Event::MockDispatcher> dispatcher_;
-  std::list<Network::ConnectionCallbacks*> callbacks_;
-  std::list<Network::Connection::BytesSentCb> bytes_sent_callbacks_;
-  uint64_t id_{next_id_++};
-  Address::InstanceConstSharedPtr remote_address_;
-  Address::InstanceConstSharedPtr local_address_;
-  bool read_enabled_{true};
-  testing::NiceMock<StreamInfo::MockStreamInfo> stream_info_;
-  Connection::State state_{Connection::State::Open};
-};
-
-class MockConnection : public Connection, public MockConnectionBase {
-public:
-  MockConnection();
-  ~MockConnection();
-
-  // Network::Connection
-  MOCK_METHOD1(addConnectionCallbacks, void(ConnectionCallbacks& cb));
-  MOCK_METHOD1(addBytesSentCallback, void(BytesSentCb cb));
-  MOCK_METHOD1(addWriteFilter, void(WriteFilterSharedPtr filter));
-  MOCK_METHOD1(addFilter, void(FilterSharedPtr filter));
-  MOCK_METHOD1(addReadFilter, void(ReadFilterSharedPtr filter));
-  MOCK_METHOD1(enableHalfClose, void(bool enabled));
-  MOCK_METHOD1(close, void(ConnectionCloseType type));
-  MOCK_METHOD0(dispatcher, Event::Dispatcher&());
-  MOCK_CONST_METHOD0(id, uint64_t());
-  MOCK_METHOD0(initializeReadFilters, bool());
-  MOCK_CONST_METHOD0(nextProtocol, std::string());
-  MOCK_METHOD1(noDelay, void(bool enable));
-  MOCK_METHOD1(readDisable, void(bool disable));
-  MOCK_METHOD1(detectEarlyCloseWhenReadDisabled, void(bool));
-  MOCK_CONST_METHOD0(readEnabled, bool());
-  MOCK_CONST_METHOD0(remoteAddress, const Address::InstanceConstSharedPtr&());
-  MOCK_CONST_METHOD0(localAddress, const Address::InstanceConstSharedPtr&());
-  MOCK_METHOD1(setConnectionStats, void(const ConnectionStats& stats));
-  MOCK_CONST_METHOD0(ssl, const Ssl::Connection*());
-  MOCK_CONST_METHOD0(requestedServerName, absl::string_view());
-  MOCK_CONST_METHOD0(state, State());
-  MOCK_METHOD2(write, void(Buffer::Instance& data, bool end_stream));
-  MOCK_METHOD1(setBufferLimits, void(uint32_t limit));
-  MOCK_CONST_METHOD0(bufferLimit, uint32_t());
-  MOCK_CONST_METHOD0(localAddressRestored, bool());
-  MOCK_CONST_METHOD0(aboveHighWatermark, bool());
-  MOCK_CONST_METHOD0(socketOptions, const Network::ConnectionSocket::OptionsSharedPtr&());
-  MOCK_METHOD0(streamInfo, StreamInfo::StreamInfo&());
-  MOCK_CONST_METHOD0(streamInfo, const StreamInfo::StreamInfo&());
-  MOCK_METHOD1(setDelayedCloseTimeout, void(std::chrono::milliseconds));
-  MOCK_CONST_METHOD0(delayedCloseTimeout, std::chrono::milliseconds());
-
-  void setWriteFilterOrder(bool reversed) override { reversed_write_filter_order_ = reversed; }
-  bool reverseWriteFilterOrder() const override { return reversed_write_filter_order_; }
-
-private:
-  bool reversed_write_filter_order_{true};
-};
-
-/**
- * NOTE: MockClientConnection duplicated most of MockConnection due to the fact that NiceMock
- *       cannot be reliably used on base class methods.
- */
-class MockClientConnection : public ClientConnection, public MockConnectionBase {
-public:
-  MockClientConnection();
-  ~MockClientConnection();
-
-  // Network::Connection
-  MOCK_METHOD1(addConnectionCallbacks, void(ConnectionCallbacks& cb));
-  MOCK_METHOD1(addBytesSentCallback, void(BytesSentCb cb));
-  MOCK_METHOD1(addWriteFilter, void(WriteFilterSharedPtr filter));
-  MOCK_METHOD1(addFilter, void(FilterSharedPtr filter));
-  MOCK_METHOD1(addReadFilter, void(ReadFilterSharedPtr filter));
-  MOCK_METHOD1(enableHalfClose, void(bool enabled));
-  MOCK_METHOD1(close, void(ConnectionCloseType type));
-  MOCK_METHOD0(dispatcher, Event::Dispatcher&());
-  MOCK_CONST_METHOD0(id, uint64_t());
-  MOCK_METHOD0(initializeReadFilters, bool());
-  MOCK_CONST_METHOD0(nextProtocol, std::string());
-  MOCK_METHOD1(noDelay, void(bool enable));
-  MOCK_METHOD1(readDisable, void(bool disable));
-  MOCK_METHOD1(detectEarlyCloseWhenReadDisabled, void(bool));
-  MOCK_CONST_METHOD0(readEnabled, bool());
-  MOCK_CONST_METHOD0(remoteAddress, const Address::InstanceConstSharedPtr&());
-  MOCK_CONST_METHOD0(localAddress, const Address::InstanceConstSharedPtr&());
-  MOCK_METHOD1(setConnectionStats, void(const ConnectionStats& stats));
-  MOCK_CONST_METHOD0(ssl, const Ssl::Connection*());
-  MOCK_CONST_METHOD0(requestedServerName, absl::string_view());
-  MOCK_CONST_METHOD0(state, State());
-  MOCK_METHOD2(write, void(Buffer::Instance& data, bool end_stream));
-  MOCK_METHOD1(setBufferLimits, void(uint32_t limit));
-  MOCK_CONST_METHOD0(bufferLimit, uint32_t());
-  MOCK_CONST_METHOD0(localAddressRestored, bool());
-  MOCK_CONST_METHOD0(aboveHighWatermark, bool());
-  MOCK_CONST_METHOD0(socketOptions, const Network::ConnectionSocket::OptionsSharedPtr&());
-  MOCK_METHOD0(streamInfo, StreamInfo::StreamInfo&());
-  MOCK_CONST_METHOD0(streamInfo, const StreamInfo::StreamInfo&());
-  MOCK_METHOD1(setDelayedCloseTimeout, void(std::chrono::milliseconds));
-  MOCK_CONST_METHOD0(delayedCloseTimeout, std::chrono::milliseconds());
-  MOCK_METHOD1(setWriteFilterOrder, void(bool reversed));
-  bool reverseWriteFilterOrder() const override { return true; }
-
-  // Network::ClientConnection
-  MOCK_METHOD0(connect, void());
-};
 
 class MockActiveDnsQuery : public ActiveDnsQuery {
 public:

--- a/test/mocks/upstream/BUILD
+++ b/test/mocks/upstream/BUILD
@@ -36,10 +36,20 @@ envoy_cc_mock(
 )
 
 envoy_cc_mock(
+    name = "load_balancer_context_mock",
+    srcs = ["load_balancer_context.cc"],
+    hdrs = ["load_balancer_context.h"],
+    deps = [
+        "//include/envoy/upstream:load_balancer_interface",
+    ],
+)
+
+envoy_cc_mock(
     name = "upstream_mocks",
     srcs = ["mocks.cc"],
     hdrs = ["mocks.h"],
     deps = [
+        ":load_balancer_context_mock",
         "//include/envoy/http:async_client_interface",
         "//include/envoy/upstream:cluster_manager_interface",
         "//include/envoy/upstream:health_checker_interface",

--- a/test/mocks/upstream/load_balancer_context.cc
+++ b/test/mocks/upstream/load_balancer_context.cc
@@ -1,0 +1,11 @@
+#include "test/mocks/upstream/load_balancer_context.h"
+
+namespace Envoy {
+namespace Upstream {
+
+MockLoadBalancerContext::MockLoadBalancerContext() = default;
+
+MockLoadBalancerContext::~MockLoadBalancerContext() = default;
+
+} // namespace Upstream
+} // namespace Envoy

--- a/test/mocks/upstream/load_balancer_context.h
+++ b/test/mocks/upstream/load_balancer_context.h
@@ -1,0 +1,23 @@
+#include "envoy/upstream/load_balancer.h"
+
+#include "gmock/gmock.h"
+
+namespace Envoy {
+namespace Upstream {
+
+class MockLoadBalancerContext : public LoadBalancerContext {
+public:
+  MockLoadBalancerContext();
+  ~MockLoadBalancerContext();
+
+  MOCK_METHOD0(computeHashKey, absl::optional<uint64_t>());
+  MOCK_METHOD0(metadataMatchCriteria, Router::MetadataMatchCriteria*());
+  MOCK_CONST_METHOD0(downstreamConnection, const Network::Connection*());
+  MOCK_CONST_METHOD0(downstreamHeaders, const Http::HeaderMap*());
+  MOCK_METHOD2(determinePriorityLoad, const PriorityLoad&(const PrioritySet&, const PriorityLoad&));
+  MOCK_METHOD1(shouldSelectAnotherHost, bool(const Host&));
+  MOCK_CONST_METHOD0(hostSelectionRetryCount, uint32_t());
+};
+
+} // namespace Upstream
+} // namespace Envoy

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -81,10 +81,6 @@ MockCluster::MockCluster() {
 
 MockCluster::~MockCluster() = default;
 
-MockLoadBalancerContext::MockLoadBalancerContext() = default;
-
-MockLoadBalancerContext::~MockLoadBalancerContext() = default;
-
 MockLoadBalancer::MockLoadBalancer() { ON_CALL(*this, chooseHost(_)).WillByDefault(Return(host_)); }
 
 MockLoadBalancer::~MockLoadBalancer() = default;

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -24,6 +24,7 @@
 #include "test/mocks/stats/mocks.h"
 #include "test/mocks/tcp/mocks.h"
 #include "test/mocks/upstream/cluster_info.h"
+#include "test/mocks/upstream/load_balancer_context.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -153,20 +154,6 @@ public:
   std::function<void()> initialize_callback_;
   Network::Address::InstanceConstSharedPtr source_address_;
   NiceMock<MockPrioritySet> priority_set_;
-};
-
-class MockLoadBalancerContext : public LoadBalancerContext {
-public:
-  MockLoadBalancerContext();
-  ~MockLoadBalancerContext();
-
-  MOCK_METHOD0(computeHashKey, absl::optional<uint64_t>());
-  MOCK_METHOD0(metadataMatchCriteria, Router::MetadataMatchCriteria*());
-  MOCK_CONST_METHOD0(downstreamConnection, const Network::Connection*());
-  MOCK_CONST_METHOD0(downstreamHeaders, const Http::HeaderMap*());
-  MOCK_METHOD2(determinePriorityLoad, const PriorityLoad&(const PrioritySet&, const PriorityLoad&));
-  MOCK_METHOD1(shouldSelectAnotherHost, bool(const Host&));
-  MOCK_CONST_METHOD0(hostSelectionRetryCount, uint32_t());
 };
 
 class MockLoadBalancer : public LoadBalancer {


### PR DESCRIPTION
*Description*: While developing the source transparency feature, I became frustrated with both the compile time of some of the tests, and the fact that changes in seemingly unrelated headers caused many tests to recompile. Much of this was caused by the monolithic mocks headers we use. Since they include everything for a high level component, any header depended upon by that component, which is likely many, being changed can cause a recompilation. Further, simply including that much slows down compilation.

As an example, I found that splitting out the connection pool mocks decreased my unit test compile time from 13 seconds to 8 seconds. While not a drastic speedup, 5 seconds per compile is still quite a bit if you're doing TDD. You want feedback as quickly as possible!

This PR was split out of https://github.com/envoyproxy/envoy/pull/5255 with some minor changes to remove code that only applied in that PR.

*Risk Level*: Low. This is just testing headers.

*Testing*: Ran the tests multiple times.

*Docs Changes*: N/A
*Release Notes*: N/A

