### PR TITLE
hds: Envoy should send HealthCheckRequestOrEndpointHealthResponse when requesting health checks Fixes #5279

### DIFF
--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -21,17 +21,19 @@ HdsDelegate::HdsDelegate(const envoy::api::v2::core::Node& node, Stats::Scope& s
       store_stats(stats), ssl_context_manager_(ssl_context_manager), random_(random),
       info_factory_(info_factory), access_log_manager_(access_log_manager), cm_(cm),
       local_info_(local_info) {
-  health_check_request_.mutable_node()->MergeFrom(node);
+  health_check_request_.mutable_health_check_request()->mutable_node()->MergeFrom(node);
   backoff_strategy_ = std::make_unique<JitteredBackOffStrategy>(RetryInitialDelayMilliseconds,
                                                                 RetryMaxDelayMilliseconds, random_);
   hds_retry_timer_ = dispatcher.createTimer([this]() -> void { establishNewStream(); });
   hds_stream_response_timer_ = dispatcher.createTimer([this]() -> void { sendResponse(); });
 
   // TODO(lilika): Add support for other types of healthchecks
-  health_check_request_.mutable_capability()->add_health_check_protocols(
-      envoy::service::discovery::v2::Capability::HTTP);
-  health_check_request_.mutable_capability()->add_health_check_protocols(
-      envoy::service::discovery::v2::Capability::TCP);
+  health_check_request_.mutable_health_check_request()
+      ->mutable_capability()
+      ->add_health_check_protocols(envoy::service::discovery::v2::Capability::HTTP);
+  health_check_request_.mutable_health_check_request()
+      ->mutable_capability()
+      ->add_health_check_protocols(envoy::service::discovery::v2::Capability::TCP);
 
   establishNewStream();
 }

--- a/source/common/upstream/health_discovery_service.h
+++ b/source/common/upstream/health_discovery_service.h
@@ -163,7 +163,7 @@ private:
   ClusterManager& cm_;
   const LocalInfo::LocalInfo& local_info_;
 
-  envoy::service::discovery::v2::HealthCheckRequest health_check_request_;
+  envoy::service::discovery::v2::HealthCheckRequestOrEndpointHealthResponse health_check_request_;
   std::unique_ptr<envoy::service::discovery::v2::HealthCheckSpecifier> health_check_message_;
 
   std::vector<std::string> clusters_;

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -224,7 +224,7 @@ public:
   FakeRawConnectionPtr host_fake_raw_connection_;
 
   static constexpr int MaxTimeout = 100;
-  envoy::service::discovery::v2::HealthCheckRequest envoy_msg_;
+  envoy::service::discovery::v2::HealthCheckRequestOrEndpointHealthResponse envoy_msg_;
   envoy::service::discovery::v2::HealthCheckRequestOrEndpointHealthResponse response_;
   envoy::service::discovery::v2::HealthCheckSpecifier server_health_check_specifier_;
 };
@@ -241,7 +241,7 @@ TEST_P(HdsIntegrationTest, SingleEndpointHealthyHttp) {
   // Server <--> Envoy
   waitForHdsStream();
   ASSERT_TRUE(hds_stream_->waitForGrpcMessage(*dispatcher_, envoy_msg_));
-  EXPECT_EQ(envoy_msg_.capability().health_check_protocols(0),
+  EXPECT_EQ(envoy_msg_.health_check_request().capability().health_check_protocols(0),
             envoy::service::discovery::v2::Capability::HTTP);
 
   // Server asks for health checking
@@ -346,7 +346,7 @@ TEST_P(HdsIntegrationTest, SingleEndpointTimeoutTcp) {
   // Server <--> Envoy
   waitForHdsStream();
   ASSERT_TRUE(hds_stream_->waitForGrpcMessage(*dispatcher_, envoy_msg_));
-  EXPECT_EQ(envoy_msg_.capability().health_check_protocols(1),
+  EXPECT_EQ(envoy_msg_.health_check_request().capability().health_check_protocols(1),
             envoy::service::discovery::v2::Capability::TCP);
 
   // Server asks for health checking


### PR DESCRIPTION
*Description*: Makes envoy send a HealthCheckRequestOrEndpointHealthResponse when requesting health checks to respect HDS protocol.
Fixes #5279
