### PR TITLE
Add luajit-2.1 support in source code

### DIFF
--- a/source/exe/signal_action.cc
+++ b/source/exe/signal_action.cc
@@ -20,6 +20,10 @@ void SignalAction::sigHandler(int sig, siginfo_t* info, void* context) {
     error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext->__ss.__rip);
 #elif defined(__powerpc__)
     error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext.regs->nip);
+#elif defined(__aarch64__)
+    error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext.pc);
+#elif defined(__arm__)
+    error_pc = reinterpret_cast<void*>(ucontext->uc_mcontext.arm_pc);
 #else
 #warning "Please enable and test PC retrieval code for your arch in signal_action.cc"
 // x86 Classic: reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[REG_EIP]);

--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -11,7 +11,7 @@
 #include "common/common/c_smart_ptr.h"
 #include "common/common/logger.h"
 
-#include "luajit-2.0/lua.hpp"
+#include "luajit-2.1/lua.hpp"
 
 namespace Envoy {
 namespace Extensions {


### PR DESCRIPTION
Add luajit-2.1 support in source code

Luajit 2.0 does not support arm/arm64/ppc64le, while luajit-2.1 supports multi-arch, so I need to add luajit-2.1 in source code.

There is a 2-phase commit to enable envoy for multi-arch.
This is the 2nd commit.
The 1st step is to add luajit-2.1 support to the build container.
Please see phase1: #5283 
The discussion is in #4809 

Risk Level: Medium

Testing: unit test,integration

Docs Changes: None

Release Notes: None