### PR TITLE
Add luajit-2.1 to the build container (envoyproxy/envoy-build-ubuntu)

### DIFF
--- a/ci/build_container/build_recipes/luajit.sh
+++ b/ci/build_container/build_recipes/luajit.sh
@@ -2,19 +2,17 @@
 
 set -e
 
-VERSION=2.0.5
-SHA256=8bb29d84f06eb23c7ea4aa4794dbb248ede9fcb23b6989cbef81dc79352afc97
+VERSION=2.1.0-beta3
+SHA256=409f7fe570d3c16558e594421c47bdd130238323c9d6fd6c83dedd2aaeb082a8
 
 curl https://github.com/LuaJIT/LuaJIT/archive/v"$VERSION".tar.gz -sLo LuaJIT-"$VERSION".tar.gz \
   && echo "$SHA256" LuaJIT-"$VERSION".tar.gz | sha256sum --check
 tar xf LuaJIT-"$VERSION".tar.gz
-cd LuaJIT-"$VERSION"
-
 
 # Fixup Makefile with things that cannot be set via env var.
-cat > ../luajit_make.diff << 'EOF'
+cat > luajit_make.diff << 'EOF'
 diff --git a/src/Makefile b/src/Makefile
-index f7f81a4..e698517 100644
+index f56465d..3f4f2fa 100644
 --- a/src/Makefile
 +++ b/src/Makefile
 @@ -27,7 +27,7 @@ NODOTABIVER= 51
@@ -26,7 +24,7 @@ index f7f81a4..e698517 100644
  #
  # Use this if you want to force a 32 bit build on a 64 bit multilib OS.
  #CC= $(DEFAULT_CC) -m32
-@@ -74,10 +74,10 @@ CCWARN= -Wall
+@@ -71,10 +71,10 @@ CCWARN= -Wall
  # as dynamic mode.
  #
  # Mixed mode creates a static + dynamic library and a statically linked luajit.
@@ -39,7 +37,7 @@ index f7f81a4..e698517 100644
  #
  # Dynamic mode creates a dynamic library and a dynamically linked luajit.
  # Note: this executable will only run when the library is installed!
-@@ -102,7 +102,7 @@ XCFLAGS=
+@@ -99,7 +99,7 @@ XCFLAGS=
  # enabled by default. Some other features that *might* break some existing
  # code (e.g. __pairs or os.execute() return values) can be enabled here.
  # Note: this does not provide full compatibility with Lua 5.2 at this time.
@@ -48,7 +46,7 @@ index f7f81a4..e698517 100644
  #
  # Disable the JIT compiler, i.e. turn LuaJIT into a pure interpreter.
  #XCFLAGS+= -DLUAJIT_DISABLE_JIT
-@@ -564,7 +564,7 @@ endif
+@@ -587,7 +587,7 @@ endif
 
  Q= @
  E= @echo
@@ -59,12 +57,14 @@ index f7f81a4..e698517 100644
  ##############################################################################
 EOF
 
+cd LuaJIT-"$VERSION"
+
 if [[ "${OS}" == "Windows_NT" ]]; then
   cd src
   ./msvcbuild.bat debug
 
-  mkdir -p "$THIRDPARTY_BUILD/include/luajit-2.0"
-  cp *.h* "$THIRDPARTY_BUILD/include/luajit-2.0"
+  mkdir -p "$THIRDPARTY_BUILD/include/luajit-2.1"
+  cp *.h* "$THIRDPARTY_BUILD/include/luajit-2.1"
   cp luajit.lib "$THIRDPARTY_BUILD/lib"
   cp *.pdb "$THIRDPARTY_BUILD/lib"
 else

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -43,9 +43,9 @@ cc_library(
         ":windows_x86_64": ["thirdparty_build/lib/luajit.lib"],
         "//conditions:default": ["thirdparty_build/lib/libluajit-5.1.a"],
     }),
-    hdrs = glob(["thirdparty_build/include/luajit-2.0/*"]),
+    hdrs = glob(["thirdparty_build/include/luajit-2.1/*"]),
     includes = ["thirdparty_build/include"],
-    # TODO(mattklein123): We should strip luajit-2.0 here for consumers. However, if we do that
+    # TODO(mattklein123): We should strip luajit-2.1 here for consumers. However, if we do that
     # the headers get included using -I vs. -isystem which then causes old-style-cast warnings.
 )
 


### PR DESCRIPTION
Add luajit-2.1 support in envoyproxy/envoy-build-ubuntu

Luajit 2.0 does not support arm/arm64/ppc64le, while luajit-2.1 supports multi-arch. 
I need to add luajit-2.1 in "envoyproxy/envoy-build-ubuntu", so that envoy can support other hardware platforms.

There is a 2-phase commit to enable envoy for multi-arch.
This is the 1st commit.
The 1st step is to add luajit-2.1 support to the build container.
Please see phase2: #5286 
The discussion is in #4809

Risk Level: Medium

Testing: unit test,integration

Docs Changes: None

Release Notes: None