### PR TITLE
Add luajit-2.1 support in source code

### DIFF
--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -11,7 +11,7 @@
 #include "common/common/c_smart_ptr.h"
 #include "common/common/logger.h"
 
-#include "luajit-2.0/lua.hpp"
+#include "luajit-2.1/lua.hpp"
 
 namespace Envoy {
 namespace Extensions {


### PR DESCRIPTION
Add luajit-2.1 support in source code

Luajit 2.0 does not support arm/arm64/ppc64le, while luajit-2.1 supports multi-arch, so I need to add luajit-2.1 in source code.

There is a 2-phase commit to enable envoy for multi-arch.
This is the 2nd commit.
The 1st step is to add luajit-2.1 support to the build container.
Please see phase1: #5285 
The discussion is in #4809

Risk Level: Medium

Testing: unit test,integration

Docs Changes: None

Release Notes: None

