### PR TITLE
conn_manager: Disable stream idle timeout for gRPC requests

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -688,6 +688,14 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
 
   decodeHeaders(nullptr, *request_headers_, end_stream);
 
+  if (Grpc::Common::hasGrpcContentType(*request_headers_) && stream_idle_timer_ != nullptr) {
+    // gRPC timeouts are controlled by the 'grpc-timeout' in the request headers, as bounded by
+    // 'max-grpc-timout' config option (see FilterUtility::finalTimeout()). Disable the idle
+    // timer to not time out gRPC requests before the gRPC (request) timeout in effect.
+    stream_idle_timer_->disableTimer();
+    stream_idle_timer_ = nullptr;
+  }
+
   // Reset it here for both global and overridden cases.
   resetIdleTimer();
 }


### PR DESCRIPTION
gRPC requests are bounded by their 'grpc-timeout' header, which is
bounded by 'max-grpc-timeout' configuration option. Stream idle
timeouts, if enabled, will interfere with these gRPC timeouts when the
gRPC stream is idle for longer than the stream idle timeout
time. However, the expectation of a gRPC streaming client (and server)
is that a gRPC stream is not timed out before the 'grpc-timeout' (as
bounded by 'gax-grpc-timeout') even if the stream is idle.

Provide the expected gRPC behavior by disabling the stream idle
timeout for streams that have a pending gRPC request. This allows same
routes be shared by both HTTP and gRPC requests, as an idle timeout
meaningful for HTTP can be configured without it affecting gRPC
traffic. A 'max-grpc-timeout' can be configured to control the upper
limit of gRPC requests at the same time on the same routes.

Risk Level: Low
Testing: HTTP/2 integration test amended to verify the new functionality.
Docs Changes: None
Fixes: #5142 
