### PR TITLE
exe: Remove main_common() -- it's not used anymore.

### DIFF
--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -144,23 +144,4 @@ std::string MainCommon::hotRestartVersion(uint64_t max_num_stats, uint64_t max_s
   return "disabled";
 }
 
-// Legacy implementation of main_common.
-//
-// TODO(jmarantz): Remove this when all callers are removed. At that time, MainCommonBase
-// and MainCommon can be merged. The current theory is that only Google calls this.
-int main_common(OptionsImpl& options) {
-  try {
-    Event::RealTimeSystem real_time_system_;
-    DefaultTestHooks default_test_hooks_;
-    ProdComponentFactory prod_component_factory_;
-    Thread::ThreadFactoryImpl thread_factory_;
-    MainCommonBase main_common(options, real_time_system_, default_test_hooks_,
-                               prod_component_factory_,
-                               std::make_unique<Runtime::RandomGeneratorImpl>(), thread_factory_);
-    return main_common.run() ? EXIT_SUCCESS : EXIT_FAILURE;
-  } catch (EnvoyException& e) {
-    return EXIT_FAILURE;
-  }
-}
-
 } // namespace Envoy

--- a/source/exe/main_common.h
+++ b/source/exe/main_common.h
@@ -114,13 +114,4 @@ private:
   MainCommonBase base_;
 };
 
-/**
- * This is the real main body that executes after site-specific
- * main() runs.
- *
- * @param options Options object initialized by site-specific code
- * @return int Return code that should be returned from the actual main()
- */
-int main_common(OptionsImpl& options);
-
 } // namespace Envoy

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -104,30 +104,6 @@ TEST_P(MainCommonTest, ConstructDestructHotRestartDisabledNoInit) {
   EXPECT_TRUE(main_common.run());
 }
 
-// Ensure that existing users of main_common() can link.
-TEST_P(MainCommonTest, LegacyMain) {
-#ifdef ENVOY_HANDLE_SIGNALS
-  // Enabled by default. Control with "bazel --define=signal_trace=disabled"
-  Envoy::SignalAction handle_sigs;
-#endif
-
-  std::unique_ptr<Envoy::OptionsImpl> options;
-  int return_code = -1;
-  try {
-    initOnly();
-    options = std::make_unique<Envoy::OptionsImpl>(argc(), argv(), &MainCommon::hotRestartVersion,
-                                                   spdlog::level::info);
-  } catch (const Envoy::NoServingException& e) {
-    return_code = EXIT_SUCCESS;
-  } catch (const Envoy::MalformedArgvException& e) {
-    return_code = EXIT_FAILURE;
-  }
-  if (return_code == -1) {
-    return_code = Envoy::main_common(*options);
-  }
-  EXPECT_EQ(EXIT_SUCCESS, return_code);
-}
-
 INSTANTIATE_TEST_CASE_P(IpVersions, MainCommonTest,
                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                         TestUtility::ipTestParamsToString);


### PR DESCRIPTION
*Description*: Removes deprecated main_common()
*Risk Level*: low -- but it's possible there's a reference somewhere not visible from github.
*Testing*: //test/exe/...
*Docs Changes*: n/a
*Release Notes*: n/a

