### PR TITLE
ci: temporary fix for clang-tidy timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,10 @@ jobs:
      steps:
        - run: rm -rf /home/circleci/project/.git # CircleCI git caching is likely broken
        - checkout
-       - run: ci/do_circle_ci.sh bazel.clang_tidy
+       - run:
+           command:
+             ci/do_circle_ci.sh bazel.clang_tidy
+           no_output_timeout: 60m
 
    format:
      executor: ubuntu-build

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -33,6 +33,3 @@ else
   git diff $(git merge-base HEAD FETCH_HEAD)..HEAD | exclude_testdata | \
     clang-tidy-diff-7.py -p 1
 fi
-
-echo "clang-tidy ran successfully"
-set -x


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

*Description*:
Increasing no output timeout for clang-tidy runs. Temp fix for #5144 while working on long term solution.

*Risk Level*: Low
*Testing*: N/A
*Docs Changes*: N/A
*Release Notes*: N/A