### PR TITLE
grpc-json: added support for ignoring query parameters

### DIFF
--- a/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
+++ b/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
@@ -64,10 +64,25 @@ message GrpcJsonTranscoder {
 
   // A list of query parameters to be ignored for transcoding method mapping.
   // By default, the transcoder filter will not transcode a request if there are any
-  // unknown/invalid query parameters. For example, for the `Bookstore API
-  // <https://github.com/envoyproxy/envoy/blob/master/test/proto/bookstore.proto>` the request
-  // ``shelves/100?key=API_KEY`` will not be mapped to ``GetShelf``` because variable binding for
-  // ``key`` is not defined. Adding ``key`` to ``ignored_query_parameters`` will allow the same
-  // request to be mapped to ``GetShelf```.
+  // unknown/invalid query parameters.
+  //
+  // Example :
+  //
+  // .. code-block:: proto
+  //
+  //     service Bookstore {
+  //       rpc GetShelf(GetShelfRequest) returns (Shelf) {
+  //         option (google.api.http) = {
+  //           get: "/shelves/{shelf}"
+  //         };
+  //       }
+  //     }
+  //     message GetShelfRequest {
+  //       int64 shelf = 1;
+  //     }
+  //
+  // The request ``shelves/100?key=API_KEY`` will not be mapped to ``GetShelf``` because variable
+  // binding for ``key`` is not defined. Adding ``key`` to ``ignored_query_parameters`` will allow
+  // the same request to be mapped to ``GetShelf``.
   repeated string ignored_query_parameters = 6;
 }

--- a/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
+++ b/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
@@ -67,7 +67,7 @@ message GrpcJsonTranscoder {
   // unknown/invalid query parameters. For example, for the `Bookstore API
   // <https://github.com/envoyproxy/envoy/blob/master/test/proto/bookstore.proto>` the request
   // ``shelves/100?key=API_KEY`` will not be mapped to ``GetShelf``` because variable binding for
-  // key is not defined. Adding ``key`` to ``ignored_query_parameters``, will allow the same request
-  // to be mapped to ``GetShelf```.
+  // ``key`` is not defined. Adding ``key`` to ``ignored_query_parameters`` will allow the same
+  // request to be mapped to ``GetShelf```.
   repeated string ignored_query_parameters = 6;
 }

--- a/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
+++ b/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
@@ -77,12 +77,15 @@ message GrpcJsonTranscoder {
   //         };
   //       }
   //     }
+  //
   //     message GetShelfRequest {
   //       int64 shelf = 1;
   //     }
   //
-  // The request ``shelves/100?key=API_KEY`` will not be mapped to ``GetShelf``` because variable
-  // binding for ``key`` is not defined. Adding ``key`` to ``ignored_query_parameters`` will allow
+  //     message Shelf {}
+  //
+  // The request ``shelves/100?foo=bar`` will not be mapped to ``GetShelf``` because variable
+  // binding for ``foo`` is not defined. Adding ``foo`` to ``ignored_query_parameters`` will allow
   // the same request to be mapped to ``GetShelf``.
   repeated string ignored_query_parameters = 6;
 }

--- a/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
+++ b/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
@@ -61,4 +61,9 @@ message GrpcJsonTranscoder {
   // the match the upstream gRPC service. Note: This means that routes for gRPC services that are
   // not transcoded cannot be used in combination with *match_incoming_request_route*.
   bool match_incoming_request_route = 5;
+
+  // A list of query parameters to ignore. For example, if `key` exists in the
+  // ignored_query_parameter then query paramemter`key` will not be used for transcoding:
+  //     book.id=42&book.author=Mark%20Twain&key=API_KEY
+  repeated string ignored_query_parameters = 6;
 }

--- a/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
+++ b/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
@@ -84,7 +84,7 @@ message GrpcJsonTranscoder {
   //
   //     message Shelf {}
   //
-  // The request ``shelves/100?foo=bar`` will not be mapped to ``GetShelf``` because variable
+  // The request ``/shelves/100?foo=bar`` will not be mapped to ``GetShelf``` because variable
   // binding for ``foo`` is not defined. Adding ``foo`` to ``ignored_query_parameters`` will allow
   // the same request to be mapped to ``GetShelf``.
   repeated string ignored_query_parameters = 6;

--- a/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
+++ b/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
@@ -64,6 +64,6 @@ message GrpcJsonTranscoder {
 
   // A list of query parameters to ignore. For example, if `key` exists in the
   // ignored_query_parameter then query paramemter`key` will not be used for transcoding:
-  //     book.id=42&book.author=Mark%20Twain&key=API_KEY
+  // book.id=42&book.author=Mark%20Twain&key=API_KEY
   repeated string ignored_query_parameters = 6;
 }

--- a/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
+++ b/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
@@ -63,10 +63,11 @@ message GrpcJsonTranscoder {
   bool match_incoming_request_route = 5;
 
   // A list of query parameters to be ignored for transcoding method mapping.
-  // By default, the transcoder filter will not transcode a request if there is any
-  // unknown/invalid query parameters. For example, the request shelves/100?key=API_KEY will not be
-  // will not be mapped to GetShelf because variable binding for key is not
-  // defined. Adding ``key`` to ``ignored_query_parameters``, will allow the same request to be
-  // mapped to GetShelf.
+  // By default, the transcoder filter will not transcode a request if there are any
+  // unknown/invalid query parameters. For example, for the `Bookstore API
+  // <https://github.com/envoyproxy/envoy/blob/master/test/proto/bookstore.proto>` the request
+  // ``shelves/100?key=API_KEY`` will not be mapped to ``GetShelf``` because variable binding for
+  // key is not defined. Adding ``key`` to ``ignored_query_parameters``, will allow the same request
+  // to be mapped to ``GetShelf```.
   repeated string ignored_query_parameters = 6;
 }

--- a/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
+++ b/api/envoy/config/filter/http/transcoder/v2/transcoder.proto
@@ -62,8 +62,11 @@ message GrpcJsonTranscoder {
   // not transcoded cannot be used in combination with *match_incoming_request_route*.
   bool match_incoming_request_route = 5;
 
-  // A list of query parameters to ignore. For example, if `key` exists in the
-  // ignored_query_parameter then query paramemter`key` will not be used for transcoding:
-  // book.id=42&book.author=Mark%20Twain&key=API_KEY
+  // A list of query parameters to be ignored for transcoding method mapping.
+  // By default, the transcoder filter will not transcode a request if there is any
+  // unknown/invalid query parameters. For example, the request shelves/100?key=API_KEY will not be
+  // will not be mapped to GetShelf because variable binding for key is not
+  // defined. Adding ``key`` to ``ignored_query_parameters``, will allow the same request to be
+  // mapped to GetShelf.
   repeated string ignored_query_parameters = 6;
 }

--- a/docs/root/configuration/http_filters/grpc_json_transcoder_filter.rst
+++ b/docs/root/configuration/http_filters/grpc_json_transcoder_filter.rst
@@ -127,7 +127,6 @@ gRPC or RESTful JSON requests to localhost:51051.
                   always_print_primitive_fields: true
                   always_print_enums_as_ints: false
                   preserve_proto_field_names: false
-                ignored_query_parameters: ["key"]
             - name: envoy.router
 
     clusters:

--- a/docs/root/configuration/http_filters/grpc_json_transcoder_filter.rst
+++ b/docs/root/configuration/http_filters/grpc_json_transcoder_filter.rst
@@ -127,6 +127,7 @@ gRPC or RESTful JSON requests to localhost:51051.
                   always_print_primitive_fields: true
                   always_print_enums_as_ints: false
                   preserve_proto_field_names: false
+                ignored_query_parameters: ["key"]
             - name: envoy.router
 
     clusters:

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -19,7 +19,7 @@ Version history
 * cors: added :ref: `invalid/valid stats <cors-statistics>` to filter.
 * ext-authz: added support for providing per route config - optionally disable the filter and provide context extensions.
 * fault: removed integer percentage support.
-* grpc-json: added support for :ref:`inline descriptors
+* grpc-json: added support for :ref:`ignoring query parameters
   <envoy_api_field_config.filter.http.transcoder.v2.GrpcJsonTranscoder.ignored_query_parameters>`.
 * health check: Added :ref: 'logging health check failure events <envoy_api_field_core.HealthCheck.always_log_health_check_failures>'.
 * http: Added HTTP/2 WebSocket proxying via :ref:`extended CONNECT <envoy_api_field_core.Http2ProtocolOptions.allow_connect>`

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -19,6 +19,8 @@ Version history
 * cors: added :ref: `invalid/valid stats <cors-statistics>` to filter.
 * ext-authz: added support for providing per route config - optionally disable the filter and provide context extensions.
 * fault: removed integer percentage support.
+* grpc-json: added support for :ref:`inline descriptors
+  <envoy_api_field_config.filter.http.transcoder.v2.GrpcJsonTranscoder.ignored_query_parameters>`.
 * health check: Added :ref: 'logging health check failure events <envoy_api_field_core.HealthCheck.always_log_health_check_failures>'.
 * http: Added HTTP/2 WebSocket proxying via :ref:`extended CONNECT <envoy_api_field_core.Http2ProtocolOptions.allow_connect>`
 * http: added limits to the number and length of header modifications in all fields request_headers_to_add and response_headers_to_add. These limits are very high and should only be used as a last-resort safeguard.

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -65,8 +65,8 @@ public:
   const envoy::config::filter::http::transcoder::v2::GrpcJsonTranscoder
   getProtoConfig(const std::string& descriptor_path, const std::string& service_name,
                  bool match_incoming_request_route = false) {
-    std::vector<std::string> emtpy_ignored_query_parameters;
-    return getProtoConfig(descriptor_path, service_name, emtpy_ignored_query_parameters,
+    std::vector<std::string> empty_ignored_query_parameters;
+    return getProtoConfig(descriptor_path, service_name, empty_ignored_query_parameters,
                           match_incoming_request_route);
   }
 

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -65,9 +65,7 @@ public:
   const envoy::config::filter::http::transcoder::v2::GrpcJsonTranscoder
   getProtoConfig(const std::string& descriptor_path, const std::string& service_name,
                  bool match_incoming_request_route = false) {
-    std::vector<std::string> empty_ignored_query_parameters;
-    return getProtoConfig(descriptor_path, service_name, empty_ignored_query_parameters,
-                          match_incoming_request_route);
+    return getProtoConfig(descriptor_path, service_name, {}, match_incoming_request_route);
   }
 
   std::string makeProtoDescriptor(std::function<void(FileDescriptorSet&)> process) {

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -47,6 +47,7 @@ class GrpcJsonTranscoderConfigTest : public testing::Test {
 public:
   const envoy::config::filter::http::transcoder::v2::GrpcJsonTranscoder
   getProtoConfig(const std::string& descriptor_path, const std::string& service_name,
+                 const std::vector<std::string>& ignored_query_parameters,
                  bool match_incoming_request_route = false) {
     std::string json_string = "{\"proto_descriptor\": \"" + descriptor_path +
                               "\",\"services\": [\"" + service_name + "\"]}";
@@ -54,7 +55,19 @@ public:
     envoy::config::filter::http::transcoder::v2::GrpcJsonTranscoder proto_config;
     Envoy::Config::FilterJson::translateGrpcJsonTranscoder(*json_config, proto_config);
     proto_config.set_match_incoming_request_route(match_incoming_request_route);
+    for (const std::string& query_param : ignored_query_parameters) {
+      proto_config.add_ignored_query_parameters(query_param);
+    }
+
     return proto_config;
+  }
+
+  const envoy::config::filter::http::transcoder::v2::GrpcJsonTranscoder
+  getProtoConfig(const std::string& descriptor_path, const std::string& service_name,
+                 bool match_incoming_request_route = false) {
+    std::vector<std::string> emtpy_ignored_query_parameters;
+    return getProtoConfig(descriptor_path, service_name, emtpy_ignored_query_parameters,
+                          match_incoming_request_route);
   }
 
   std::string makeProtoDescriptor(std::function<void(FileDescriptorSet&)> process) {
@@ -173,6 +186,43 @@ TEST_F(GrpcJsonTranscoderConfigTest, CreateTranscoder) {
       TestEnvironment::runfilesPath("test/proto/bookstore.descriptor"), "bookstore.Bookstore"));
 
   Http::TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/shelves"}};
+
+  TranscoderInputStreamImpl request_in, response_in;
+  std::unique_ptr<Transcoder> transcoder;
+  const MethodDescriptor* method_descriptor;
+  auto status =
+      config.createTranscoder(headers, request_in, response_in, transcoder, method_descriptor);
+
+  EXPECT_TRUE(status.ok());
+  EXPECT_TRUE(transcoder);
+  EXPECT_EQ("bookstore.Bookstore.ListShelves", method_descriptor->full_name());
+}
+
+TEST_F(GrpcJsonTranscoderConfigTest, InvalidQueryParameter) {
+  JsonTranscoderConfig config(getProtoConfig(
+      TestEnvironment::runfilesPath("test/proto/bookstore.descriptor"), "bookstore.Bookstore"));
+
+  Http::TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/shelves?foo=bar"}};
+
+  TranscoderInputStreamImpl request_in, response_in;
+  std::unique_ptr<Transcoder> transcoder;
+  const MethodDescriptor* method_descriptor;
+  auto status =
+      config.createTranscoder(headers, request_in, response_in, transcoder, method_descriptor);
+
+  EXPECT_EQ(Code::INVALID_ARGUMENT, status.error_code());
+  EXPECT_EQ("Could not find field \"foo\" in the type \"google.protobuf.Empty\".",
+            status.error_message());
+  EXPECT_FALSE(transcoder);
+}
+
+TEST_F(GrpcJsonTranscoderConfigTest, IgnoredQueryParameter) {
+  std::vector<std::string> ignored_query_parameters = {"key"};
+  JsonTranscoderConfig config(
+      getProtoConfig(TestEnvironment::runfilesPath("test/proto/bookstore.descriptor"),
+                     "bookstore.Bookstore", ignored_query_parameters));
+
+  Http::TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/shelves?key=API_KEY"}};
 
   TranscoderInputStreamImpl request_in, response_in;
   std::unique_ptr<Transcoder> transcoder;

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -47,8 +47,8 @@ class GrpcJsonTranscoderConfigTest : public testing::Test {
 public:
   const envoy::config::filter::http::transcoder::v2::GrpcJsonTranscoder
   getProtoConfig(const std::string& descriptor_path, const std::string& service_name,
-                 const std::vector<std::string>& ignored_query_parameters,
-                 bool match_incoming_request_route = false) {
+                 bool match_incoming_request_route = false,
+                 const std::vector<std::string>& ignored_query_parameters = {}) {
     std::string json_string = "{\"proto_descriptor\": \"" + descriptor_path +
                               "\",\"services\": [\"" + service_name + "\"]}";
     auto json_config = Json::Factory::loadFromString(json_string);
@@ -60,12 +60,6 @@ public:
     }
 
     return proto_config;
-  }
-
-  const envoy::config::filter::http::transcoder::v2::GrpcJsonTranscoder
-  getProtoConfig(const std::string& descriptor_path, const std::string& service_name,
-                 bool match_incoming_request_route = false) {
-    return getProtoConfig(descriptor_path, service_name, {}, match_incoming_request_route);
   }
 
   std::string makeProtoDescriptor(std::function<void(FileDescriptorSet&)> process) {
@@ -218,7 +212,7 @@ TEST_F(GrpcJsonTranscoderConfigTest, IgnoredQueryParameter) {
   std::vector<std::string> ignored_query_parameters = {"key"};
   JsonTranscoderConfig config(
       getProtoConfig(TestEnvironment::runfilesPath("test/proto/bookstore.descriptor"),
-                     "bookstore.Bookstore", ignored_query_parameters));
+                     "bookstore.Bookstore", false, ignored_query_parameters));
 
   Http::TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/shelves?key=API_KEY"}};
 


### PR DESCRIPTION
*Description*:
Allow grpc-json transcoder to ignore a set of specified query parameters. The most common use case would be api key parameter. This change allows request like /shelves/456/books/123?key=API_KEY to be transcoded

*Risk Level*: Low
*Testing*: Unit tests are added.
*Docs Changes*: Updated
*Release Notes*: Updated
*Fixes* #5281 
