### PR TITLE
listener: Add listenerConfig() to ListenerFactoryContext.

### DIFF
--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -36,6 +36,7 @@ public:
    *         different from configured if for example the configured address binds to port zero.
    */
   virtual Socket& socket() PURE;
+  virtual const Socket& socket() const PURE;
 
   /**
    * @return bool if a connection should be handed off to another Listener after the original
@@ -49,7 +50,7 @@ public:
    * @return uint32_t providing a soft limit on size of the listener's new connection read and write
    *         buffers.
    */
-  virtual uint32_t perConnectionBufferLimitBytes() PURE;
+  virtual uint32_t perConnectionBufferLimitBytes() const PURE;
 
   /**
    * @return std::chrono::milliseconds the time to wait for all listener filters to complete

--- a/include/envoy/server/filter_config.h
+++ b/include/envoy/server/filter_config.h
@@ -150,6 +150,11 @@ public:
   virtual void addListenSocketOption(const Network::Socket::OptionConstSharedPtr& option) PURE;
 
   virtual void addListenSocketOptions(const Network::Socket::OptionsSharedPtr& options) PURE;
+
+  /**
+   * Give access to the listener configuration
+   */
+  virtual const Network::ListenerConfig& listenerConfig() const PURE;
 };
 
 /**

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -257,8 +257,9 @@ private:
     Network::FilterChainManager& filterChainManager() override { return parent_; }
     Network::FilterChainFactory& filterChainFactory() override { return parent_; }
     Network::Socket& socket() override { return parent_.mutable_socket(); }
+    const Network::Socket& socket() const override { return parent_.mutable_socket(); }
     bool handOffRestoredDestinationConnections() const override { return false; }
-    uint32_t perConnectionBufferLimitBytes() override { return 0; }
+    uint32_t perConnectionBufferLimitBytes() const override { return 0; }
     std::chrono::milliseconds listenerFiltersTimeout() const override {
       return std::chrono::milliseconds();
     }

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -245,7 +245,9 @@ public:
   bool handOffRestoredDestinationConnections() const override {
     return hand_off_restored_destination_connections_;
   }
-  uint32_t perConnectionBufferLimitBytes() const override { return per_connection_buffer_limit_bytes_; }
+  uint32_t perConnectionBufferLimitBytes() const override {
+    return per_connection_buffer_limit_bytes_;
+  }
   std::chrono::milliseconds listenerFiltersTimeout() const override {
     return listener_filters_timeout_;
   }

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -241,10 +241,11 @@ public:
   Network::FilterChainManager& filterChainManager() override { return *this; }
   Network::FilterChainFactory& filterChainFactory() override { return *this; }
   Network::Socket& socket() override { return *socket_; }
+  const Network::Socket& socket() const override { return *socket_; }
   bool handOffRestoredDestinationConnections() const override {
     return hand_off_restored_destination_connections_;
   }
-  uint32_t perConnectionBufferLimitBytes() override { return per_connection_buffer_limit_bytes_; }
+  uint32_t perConnectionBufferLimitBytes() const override { return per_connection_buffer_limit_bytes_; }
   std::chrono::milliseconds listenerFiltersTimeout() const override {
     return listener_filters_timeout_;
   }

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -290,6 +290,7 @@ public:
     ensureSocketOptions();
     Network::Socket::appendOptions(listen_socket_options_, options);
   }
+  const Network::ListenerConfig& listenerConfig() const override { return *this; }
 
   // Network::DrainDecision
   bool drainClose() const override;

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -66,8 +66,9 @@ public:
   Network::FilterChainManager& filterChainManager() override { return *this; }
   Network::FilterChainFactory& filterChainFactory() override { return factory_; }
   Network::Socket& socket() override { return socket_; }
+  const Network::Socket& socket() const override { return socket_; }
   bool handOffRestoredDestinationConnections() const override { return false; }
-  uint32_t perConnectionBufferLimitBytes() override { return 0; }
+  uint32_t perConnectionBufferLimitBytes() const override { return 0; }
   std::chrono::milliseconds listenerFiltersTimeout() const override {
     return std::chrono::milliseconds();
   }
@@ -893,8 +894,9 @@ public:
   Network::FilterChainManager& filterChainManager() override { return *this; }
   Network::FilterChainFactory& filterChainFactory() override { return factory_; }
   Network::Socket& socket() override { return socket_; }
+  const Network::Socket& socket() const override { return socket_; }
   bool handOffRestoredDestinationConnections() const override { return false; }
-  uint32_t perConnectionBufferLimitBytes() override { return 0; }
+  uint32_t perConnectionBufferLimitBytes() const override { return 0; }
   std::chrono::milliseconds listenerFiltersTimeout() const override {
     return std::chrono::milliseconds();
   }

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -574,8 +574,9 @@ private:
     Network::FilterChainManager& filterChainManager() override { return parent_; }
     Network::FilterChainFactory& filterChainFactory() override { return parent_; }
     Network::Socket& socket() override { return *parent_.socket_; }
+    const Network::Socket& socket() const override { return *parent_.socket_; }
     bool handOffRestoredDestinationConnections() const override { return false; }
-    uint32_t perConnectionBufferLimitBytes() override { return 0; }
+    uint32_t perConnectionBufferLimitBytes() const override { return 0; }
     std::chrono::milliseconds listenerFiltersTimeout() const override {
       return std::chrono::milliseconds();
     }

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -249,8 +249,9 @@ public:
   MOCK_METHOD0(filterChainManager, FilterChainManager&());
   MOCK_METHOD0(filterChainFactory, FilterChainFactory&());
   MOCK_METHOD0(socket, Socket&());
+  MOCK_CONST_METHOD0(socket, const Socket&());
   MOCK_CONST_METHOD0(handOffRestoredDestinationConnections, bool());
-  MOCK_METHOD0(perConnectionBufferLimitBytes, uint32_t());
+  MOCK_CONST_METHOD0(perConnectionBufferLimitBytes, uint32_t());
   MOCK_CONST_METHOD0(listenerFiltersTimeout, std::chrono::milliseconds());
   MOCK_METHOD0(listenerScope, Stats::Scope&());
   MOCK_CONST_METHOD0(listenerTag, uint64_t());

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -473,9 +473,7 @@ public:
     addListenSocketOptions_(options);
   }
   MOCK_METHOD1(addListenSocketOptions_, void(const Network::Socket::OptionsSharedPtr&));
-  const Network::ListenerConfig& listenerConfig() const override {
-    return _listenerConfig_;
-  }
+  const Network::ListenerConfig& listenerConfig() const override { return _listenerConfig_; }
   MOCK_CONST_METHOD0(listenerConfig_, const Network::ListenerConfig&());
 
   Network::MockListenerConfig _listenerConfig_;

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -473,6 +473,12 @@ public:
     addListenSocketOptions_(options);
   }
   MOCK_METHOD1(addListenSocketOptions_, void(const Network::Socket::OptionsSharedPtr&));
+  const Network::ListenerConfig& listenerConfig() const override {
+    return _listenerConfig_;
+  }
+  MOCK_CONST_METHOD0(listenerConfig_, const Network::ListenerConfig&());
+
+  Network::MockListenerConfig _listenerConfig_;
 };
 
 class MockHealthCheckerFactoryContext : public virtual HealthCheckerFactoryContext {

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -44,10 +44,11 @@ public:
     Network::FilterChainManager& filterChainManager() override { return parent_.manager_; }
     Network::FilterChainFactory& filterChainFactory() override { return parent_.factory_; }
     Network::Socket& socket() override { return socket_; }
+    const Network::Socket& socket() const override { return socket_; }
     bool handOffRestoredDestinationConnections() const override {
       return hand_off_restored_destination_connections_;
     }
-    uint32_t perConnectionBufferLimitBytes() override { return 0; }
+    uint32_t perConnectionBufferLimitBytes() const override { return 0; }
     std::chrono::milliseconds listenerFiltersTimeout() const override {
       return listener_filters_timeout_;
     }


### PR DESCRIPTION
Allow listener filter (const) access listener configuration, like the listener timeout and the name of the listener. 

Annotate methods perConnectionBufferLimitBytes() as const and add a const socket() method. These make the listenerConfig() listener filter callback more useful as it returns a const reference.

Risk Level: Low
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
