### PR TITLE
ClientConnectionImpl: Delay setTransportSocketCallbacks() until end of the constructor.

### DIFF
--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -77,8 +77,8 @@ Network::ConnectionPtr
 DispatcherImpl::createServerConnection(Network::ConnectionSocketPtr&& socket,
                                        Network::TransportSocketPtr&& transport_socket) {
   ASSERT(isThreadSafe());
-  return std::make_unique<Network::ConnectionImpl>(*this, std::move(socket),
-                                                   std::move(transport_socket), true);
+  return Network::ConnectionImpl::createServerConnection(*this, std::move(socket),
+                                                         std::move(transport_socket));
 }
 
 Network::ClientConnectionPtr
@@ -87,8 +87,8 @@ DispatcherImpl::createClientConnection(Network::Address::InstanceConstSharedPtr 
                                        Network::TransportSocketPtr&& transport_socket,
                                        const Network::ConnectionSocket::OptionsSharedPtr& options) {
   ASSERT(isThreadSafe());
-  return std::make_unique<Network::ClientConnectionImpl>(*this, address, source_address,
-                                                         std::move(transport_socket), options);
+  return Network::ClientConnectionImpl::createClientConnection(
+      *this, address, source_address, std::move(transport_socket), options);
 }
 
 Network::DnsResolverSharedPtr DispatcherImpl::createDnsResolver(

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -204,7 +204,7 @@ private:
  * libevent implementation of Network::ClientConnection.
  */
 class ClientConnectionImpl : public ConnectionImpl, virtual public ClientConnection {
-private:
+protected:
   ClientConnectionImpl(Event::Dispatcher& dispatcher,
                        const Address::InstanceConstSharedPtr& remote_address,
                        const Address::InstanceConstSharedPtr& source_address,

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -51,10 +51,14 @@ class ConnectionImpl : public virtual Connection,
                        public BufferSource,
                        public TransportSocketCallbacks,
                        protected Logger::Loggable<Logger::Id::connection> {
-public:
+protected:
   ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPtr&& socket,
                  TransportSocketPtr&& transport_socket, bool connected);
 
+public:
+  static std::unique_ptr<ConnectionImpl>
+  createServerConnection(Event::Dispatcher& dispatcher, ConnectionSocketPtr&& socket,
+                         TransportSocketPtr&& transport_socket);
   ~ConnectionImpl();
 
   // Network::FilterManager
@@ -200,12 +204,20 @@ private:
  * libevent implementation of Network::ClientConnection.
  */
 class ClientConnectionImpl : public ConnectionImpl, virtual public ClientConnection {
-public:
+private:
   ClientConnectionImpl(Event::Dispatcher& dispatcher,
                        const Address::InstanceConstSharedPtr& remote_address,
                        const Address::InstanceConstSharedPtr& source_address,
                        Network::TransportSocketPtr&& transport_socket,
                        const Network::ConnectionSocket::OptionsSharedPtr& options);
+
+public:
+  static std::unique_ptr<ClientConnectionImpl>
+  createClientConnection(Event::Dispatcher& dispatcher,
+                         const Address::InstanceConstSharedPtr& remote_address,
+                         const Address::InstanceConstSharedPtr& source_address,
+                         Network::TransportSocketPtr&& transport_socket,
+                         const Network::ConnectionSocket::OptionsSharedPtr& options);
 
   // Network::ClientConnection
   void connect() override;

--- a/source/server/config_validation/BUILD
+++ b/source/server/config_validation/BUILD
@@ -54,7 +54,10 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "dispatcher_lib",
-    srcs = ["dispatcher.cc"],
+    srcs = [
+        "connection.cc",
+        "dispatcher.cc",
+    ],
     hdrs = [
         "connection.h",
         "dispatcher.h",

--- a/source/server/config_validation/connection.cc
+++ b/source/server/config_validation/connection.cc
@@ -1,0 +1,20 @@
+#include "server/config_validation/connection.h"
+
+namespace Envoy {
+namespace Network {
+
+std::unique_ptr<ConfigValidateConnection>
+ConfigValidateConnection::create(Event::ValidationDispatcher& dispatcher,
+                                 const Address::InstanceConstSharedPtr& remote_address,
+                                 const Address::InstanceConstSharedPtr& source_address,
+                                 Network::TransportSocketPtr&& transport_socket,
+                                 const Network::ConnectionSocket::OptionsSharedPtr& options) {
+  // make_shared<> requires a public constructor so we can't use it here.
+  std::unique_ptr<ConfigValidateConnection> conn(new ConfigValidateConnection(
+      dispatcher, remote_address, source_address, std::move(transport_socket), options));
+  conn->transport_socket_->setTransportSocketCallbacks(*conn);
+  return conn;
+}
+
+} // namespace Network
+} // namespace Envoy

--- a/source/server/config_validation/connection.h
+++ b/source/server/config_validation/connection.h
@@ -13,7 +13,7 @@ namespace Network {
   overridden with no-op implementations.
 */
 class ConfigValidateConnection : public Network::ClientConnectionImpl {
-public:
+private:
   ConfigValidateConnection(Event::ValidationDispatcher& dispatcher,
                            Network::Address::InstanceConstSharedPtr remote_address,
                            Network::Address::InstanceConstSharedPtr source_address,
@@ -21,6 +21,14 @@ public:
                            const Network::ConnectionSocket::OptionsSharedPtr& options)
       : Network::ClientConnectionImpl(dispatcher, remote_address, source_address,
                                       std::move(transport_socket), options) {}
+
+public:
+  static std::unique_ptr<ConfigValidateConnection>
+  create(Event::ValidationDispatcher& dispatcher,
+         const Address::InstanceConstSharedPtr& remote_address,
+         const Address::InstanceConstSharedPtr& source_address,
+         Network::TransportSocketPtr&& transport_socket,
+         const Network::ConnectionSocket::OptionsSharedPtr& options);
 
   // Unit tests may instantiate it without proper event machine and leave opened sockets.
   // Do some cleanup before invoking base class's destructor.

--- a/source/server/config_validation/dispatcher.cc
+++ b/source/server/config_validation/dispatcher.cc
@@ -12,8 +12,8 @@ Network::ClientConnectionPtr ValidationDispatcher::createClientConnection(
     Network::Address::InstanceConstSharedPtr source_address,
     Network::TransportSocketPtr&& transport_socket,
     const Network::ConnectionSocket::OptionsSharedPtr& options) {
-  return std::make_unique<Network::ConfigValidateConnection>(*this, remote_address, source_address,
-                                                             std::move(transport_socket), options);
+  return Network::ConfigValidateConnection::create(*this, remote_address, source_address,
+                                                   std::move(transport_socket), options);
 }
 
 Network::DnsResolverSharedPtr ValidationDispatcher::createDnsResolver(

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -262,7 +262,7 @@ public:
   // Create a Grpc::AsyncClientImpl instance backed by enough fake/mock
   // infrastructure to initiate a loopback TCP connection to fake_upstream_.
   AsyncClientPtr createAsyncClientImpl() {
-    client_connection_ = std::make_unique<Network::ClientConnectionImpl>(
+    client_connection_ = Network::ClientConnectionImpl::createClientConnection(
         dispatcher_, fake_upstream_->localAddress(), nullptr,
         std::move(async_client_transport_socket_), nullptr);
     ON_CALL(*mock_cluster_info_, connectTimeout())


### PR DESCRIPTION
ConnectionImpl already calls 'setTransportSocketCallbacks()' at the
end of construction, so that when called the transport socket sees the
Connection in a fully constructed state.

In the case of the ClientConnectionImpl the semantics are less clear,
as the setTransportSocketCallbacks() is called in the middle of the
construction process. This commit changes this so that for derived
classes the setTransportSocketCallbacks() is called at the end of the
derived class construction.

The motivation for this change comes from a TransportSocket extension
that relies on all socket options on client connections being set at
the time when setTransportSocketCallbacks() is called.

Risk Level: Low
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
