### PR TITLE
Bug: continueDecoding calls the wrong filter for decodeData() calls.

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1467,7 +1467,7 @@ void ConnectionManagerImpl::ActiveStreamFilterBase::commonContinue() {
 
   // TODO(mattklein123): If a filter returns StopIterationNoBuffer and then does a continue, we
   // won't be able to end the stream if there is no buffered data. Need to handle this.
-  if (bufferedData()) {
+  if (bufferedData() && bufferedData()->length() > 0) {
     doData(complete() && !trailers());
   }
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -3186,9 +3186,11 @@ TEST_F(HttpConnectionManagerImplTest, AddDataWithContinueDecoding) {
 
   EXPECT_CALL(*decoder_filters_[2], decodeHeaders(_, false))
       .WillOnce(Return(FilterHeadersStatus::StopIteration));
-  // This fail, it is called twice.
   EXPECT_CALL(*decoder_filters_[2], decodeData(_, true))
-      .WillOnce(Return(FilterDataStatus::StopIterationAndBuffer));
+      .WillOnce(Invoke([&](Buffer::Instance& data, bool) -> FilterDataStatus {
+        data.drain(data.length());
+        return FilterDataStatus::StopIterationAndBuffer;
+      }));
 
   EXPECT_CALL(*decoder_filters_[0], decodeData(_, true)).Times(0);
   // This fail, it is called once

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -2149,9 +2149,8 @@ TEST_F(HttpConnectionManagerImplTest, ZeroByteDataFiltering) {
   Buffer::OwnedImpl zero;
   decoder->decodeData(zero, true);
 
-  // Continue.
-  EXPECT_CALL(*decoder_filters_[1], decodeData(_, true))
-      .WillOnce(Return(FilterDataStatus::StopIterationNoBuffer));
+  // The second filter decodeData() is not called with zero byte buffer.
+  EXPECT_CALL(*decoder_filters_[1], decodeData(_, true)).Times(0);
   decoder_filters_[0]->callbacks_->continueDecoding();
 }
 


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

*Description*:

In this specific case: there are 3 decode filters.   The second filter calls addDocodeData() in its decodeHeaders() call.  The buffered data should be passed to the 3rd filter, not to the 2nd filter since it is added by the second filter.

This is correct if all filters are "continued".  But it is not correct if the first filter is stopped and continued with continueDecoding() call.

This PR adds two test cases:
AddDataWithAllContinue pass:   all filters return continue.
AddDataWithContinueDecoding fails:  the first filter stopped, and continued.

This PR only has the added tests.   The fix will be added later.

*Risk Level*: None

*Testing*:  Unit-test
