### PR TITLE
Fix incorrect object destruct order for ConnectionImpl

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -46,8 +46,8 @@ std::atomic<uint64_t> ConnectionImpl::next_global_id_;
 
 ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPtr&& socket,
                                TransportSocketPtr&& transport_socket, bool connected)
-    : transport_socket_(std::move(transport_socket)), filter_manager_(*this, *this),
-      socket_(std::move(socket)), stream_info_(dispatcher.timeSystem()),
+    : transport_socket_(std::move(transport_socket)), socket_(std::move(socket)),
+      filter_manager_(*this, *this), stream_info_(dispatcher.timeSystem()),
       write_buffer_(
           dispatcher.getWatermarkFactory().create([this]() -> void { this->onLowWatermark(); },
                                                   [this]() -> void { this->onHighWatermark(); })),

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -134,8 +134,8 @@ protected:
   void onHighWatermark();
 
   TransportSocketPtr transport_socket_;
-  FilterManagerImpl filter_manager_;
   ConnectionSocketPtr socket_;
+  FilterManagerImpl filter_manager_;
   StreamInfo::StreamInfoImpl stream_info_;
 
   Buffer::OwnedImpl read_buffer_;

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1163,6 +1163,29 @@ TEST_P(ConnectionImplTest, DelayedCloseTimeoutNullStats) {
   callback();
 }
 
+class FakeReadFilter : public Network::ReadFilter {
+public:
+  FakeReadFilter() {}
+  ~FakeReadFilter(){
+    EXPECT_TRUE(callbacks_ != nullptr);
+    EXPECT_TRUE(callbacks_->connection().state() != Network::Connection::State::Open);
+  }
+
+  Network::FilterStatus onData(Buffer::Instance& data, bool) {
+    data.drain(data.length());
+    return Network::FilterStatus::Continue;
+  }
+
+  Network::FilterStatus onNewConnection() {
+    return Network::FilterStatus::Continue;
+  }
+
+  void initializeReadFilterCallbacks(ReadFilterCallbacks& callbacks) {
+    callbacks_ = &callbacks;
+  }
+private:
+  ReadFilterCallbacks* callbacks_{nullptr};
+};
 class MockTransportConnectionImplTest : public testing::Test {
 public:
   MockTransportConnectionImplTest() {
@@ -1204,6 +1227,21 @@ public:
   Event::FileReadyCb file_ready_cb_;
   TransportSocketCallbacks* transport_socket_callbacks_;
 };
+
+// The purpose of this case is to verify the destructor order of the object.
+// FilterManager relies on ConnectionSocketImpl, so the FilterManager can be
+// destructed after the ConnectionSocketImpl is destructed.
+//
+// Ref: https://github.com/envoyproxy/envoy/issues/5313
+TEST_F(MockTransportConnectionImplTest, ObjectDestructOrder) {
+  connection_->addReadFilter(std::make_shared<Network::FakeReadFilter>());
+  connection_->enableHalfClose(true);
+  EXPECT_CALL(*transport_socket_, doRead(_))
+      .Times(2)
+      .WillRepeatedly(Return(IoResult{PostIoAction::KeepOpen, 0, true}));
+  file_ready_cb_(Event::FileReadyType::Read);
+  file_ready_cb_(Event::FileReadyType::Read);
+}
 
 // Test that BytesSentCb is invoked at the correct times
 TEST_F(MockTransportConnectionImplTest, BytesSentCallback) {

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1168,6 +1168,8 @@ public:
   FakeReadFilter() {}
   ~FakeReadFilter() {
     EXPECT_TRUE(callbacks_ != nullptr);
+    // The purpose is to verify that when FilterManger is destructed, ConnectionSocketImpl is not
+    // destructed, and ConnectionSocketImpl can still be accessed via ReadFilterCallbacks.
     EXPECT_TRUE(callbacks_->connection().state() != Network::Connection::State::Open);
   }
 

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1166,7 +1166,7 @@ TEST_P(ConnectionImplTest, DelayedCloseTimeoutNullStats) {
 class FakeReadFilter : public Network::ReadFilter {
 public:
   FakeReadFilter() {}
-  ~FakeReadFilter(){
+  ~FakeReadFilter() {
     EXPECT_TRUE(callbacks_ != nullptr);
     EXPECT_TRUE(callbacks_->connection().state() != Network::Connection::State::Open);
   }
@@ -1176,13 +1176,10 @@ public:
     return Network::FilterStatus::Continue;
   }
 
-  Network::FilterStatus onNewConnection() {
-    return Network::FilterStatus::Continue;
-  }
+  Network::FilterStatus onNewConnection() { return Network::FilterStatus::Continue; }
 
-  void initializeReadFilterCallbacks(ReadFilterCallbacks& callbacks) {
-    callbacks_ = &callbacks;
-  }
+  void initializeReadFilterCallbacks(ReadFilterCallbacks& callbacks) { callbacks_ = &callbacks; }
+
 private:
   ReadFilterCallbacks* callbacks_{nullptr};
 };


### PR DESCRIPTION
Signed-off-by: tianqian.zyf <tianqian.zyf@alibaba-inc.com>

*Description*: Fix incorrect object destruct order for ConnectionImpl
*Risk Level*: low
*Testing*: N/A
*Docs Changes*: N/A
*Release Notes*: N/A
Fixes #5313 

