### PR TITLE
Docker: Add entrypoint script

### DIFF
--- a/ci/Dockerfile-envoy-alpine
+++ b/ci/Dockerfile-envoy-alpine
@@ -1,11 +1,5 @@
 FROM frolvlad/alpine-glibc
 
-ENV loglevel=info
-
-RUN apk upgrade --update-cache \
-    && apk add dumb-init \
-    && rm -rf /var/cache/apk/*
-
 RUN mkdir -p /etc/envoy
 
 ADD build_release_stripped/envoy /usr/local/bin/envoy
@@ -13,5 +7,6 @@ ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
 
 EXPOSE 10000
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD /usr/local/bin/envoy --v2-config-only -l $loglevel -c /etc/envoy/envoy.yaml
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["envoy", "--v2-config-only", "-c", "/etc/envoy/envoy.yaml"]

--- a/ci/Dockerfile-envoy-alpine-debug
+++ b/ci/Dockerfile-envoy-alpine-debug
@@ -1,11 +1,5 @@
 FROM frolvlad/alpine-glibc
 
-ENV loglevel=info
-
-RUN apk upgrade --update-cache \
-    && apk add dumb-init \
-    && rm -rf /var/cache/apk/*
-
 RUN mkdir -p /etc/envoy
 
 ADD build_release/envoy /usr/local/bin/envoy
@@ -13,5 +7,6 @@ ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
 
 EXPOSE 10000
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD /usr/local/bin/envoy --v2-config-only -l $loglevel -c /etc/envoy/envoy.yaml
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["envoy", "--v2-config-only", "-c", "/etc/envoy/envoy.yaml"]

--- a/ci/Dockerfile-envoy-image
+++ b/ci/Dockerfile-envoy-image
@@ -1,19 +1,12 @@
 FROM ubuntu:16.04
 
-ARG dumbinit_version=1.2.1
-ENV loglevel=info
-
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y wget ca-certificates \
+    && apt-get install -y ca-certificates \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /tmp/* /var/tmp/* \
     && rm -rf /var/lib/apt/lists/*
-
-
-RUN wget https://github.com/Yelp/dumb-init/releases/download/v${dumbinit_version}/dumb-init_${dumbinit_version}_amd64.deb \
-    && dpkg -i dumb-init_${dumbinit_version}_amd64.deb
 
 RUN mkdir -p /etc/envoy
 
@@ -22,5 +15,6 @@ ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
 
 EXPOSE 10000
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD /usr/local/bin/envoy --v2-config-only -l $loglevel -c /etc/envoy/envoy.yaml
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["envoy", "--v2-config-only", "-c", "/etc/envoy/envoy.yaml"]

--- a/ci/docker-entrypoint.sh
+++ b/ci/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -e
+
+# if the first argument look like a parameter (i.e. start with '-'), run Envoy
+if [ "${1#-}" != "$1" ]; then
+	set -- envoy "$@"
+fi
+
+if [ "$1" = 'envoy' ]; then
+	# set the log level if the $loglevel variable is set
+	if [ -n "$loglevel" ]; then
+		set -- "$@" --log-level "$loglevel"
+	fi
+fi
+
+exec "$@"


### PR DESCRIPTION
*Description*:
First bit of work to improve runtime Docker images (#5325). This adds an entrypoint script to the Docker images to make them slightly easier to run and to customise how they run. With this change, a user could run something like:
```
docker run --rm envoyproxy/envoy --help
```
...and it should work. The entrypoint script is similar to [that used for Haproxy](https://github.com/docker-library/haproxy/blob/master/1.8/docker-entrypoint.sh).

This removes the "dumb-init" init system. dumb-init's primary goal is to solve the ["zombie process problem"](https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/). This isn't really a problem with Envoy since it runs as a single process and doesn't fork child processes. Even when using the hot-reloader script, the script waits for child processes, so zombie processes shouldn't happen.

In addition to this, modern versions of Docker (1.13+, I think) have the `--init` flag which can be used if your container needs an init system. And containerd has the similar `subreaper` setting.

A small issue with the existing code was that the Dockerfile used the `CMD <string>` format instead of the `CMD <array>` format, which meant that the `CMD` arguments were actually wrapped in a shell (which allowed the `$loglevel` variable to work). This was okay, except the different shells on Alpine and Ubuntu handled this subtly differently. On Alpine, the shell will exec simple commands, so the process tree looked like:
```
dumb-init -> envoy
```
But on Ubuntu this is not the case, so the tree was like:
```
dumb-init -> /bin/sh -> envoy
```

Signal handling changes with this change because Envoy now runs as PID 1 in the container. In Linux, PID 1 processes are treated specially in that they aren't terminated if they receive a signal for which they don't have a signal handler set up. So when a user runs a container manually and presses Ctrl-C (SIGINT) nothing happens, whereas previously the process would be terminated. Envoy does handle SIGTERM, and Docker (or Kubernetes) will send it this when it stops the container so that still stops Envoy gracefully. So this change does mean that Ctrl-C is now ignored, but I'm going to make a separate PR to make Envoy handle SIGINT the same way it does SIGTERM.

I don't expect this change to impact users since the previous behaviour is only slightly different and was pretty much only used when running Envoy manually via `docker run`. Heptio Contour [overrides the entrypoint (`command` in K8S)](https://github.com/heptio/contour/blob/v0.8.1/deployment/ds-hostnet/02-contour.yaml#L41-L47) anyway.

cc @taion809, the author of #2850 which added dumb-init.

*Risk Level*:
Low

*Testing*:
* Built image locally
* Ensured requests are proxied to google.com with the default settings
* Adjusted log level using `$loglevel` variable
* Checked process tree using `ps` inside the container
* Stopped Envoy gracefully with `docker stop`

*Docs Changes*:
There's not much documentation around the Docker images to change? In 99% of cases this should work just like it always has.

*Release Notes*:
Don't think they're necessary.