### PR TITLE
Gracefully shutdown Envoy on SIGINT (Ctrl-C)

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -70,6 +70,7 @@ Version history
   header so the rate limited requests that may have been retried earlier will not be retried with this change.
 * router: added support for enabling upgrades on a :ref:`per-route <envoy_api_field_route.RouteAction.upgrade_configs>` basis.
 * sandbox: added :ref:`cors sandbox <install_sandboxes_cors>`.
+* server: added `SIGINT` (Ctrl-C) handler to gracefully shutdown Envoy like `SIGTERM`.
 * stats: added :ref:`stats_matcher <envoy_api_field_config.metrics.v2.StatsConfig.stats_matcher>` to the bootstrap config for granular control of stat instantiation.
 * stream: renamed the `RequestInfo` namespace to `StreamInfo` to better match
   its behaviour within TCP and HTTP implementations.

--- a/docs/root/operations/hot_restarter.rst
+++ b/docs/root/operations/hot_restarter.rst
@@ -27,7 +27,7 @@ to the :option:`--restart-epoch` option.
 
 The restarter handles the following signals:
 
-* **SIGTERM**: Will cleanly terminate all child processes and exit.
+* **SIGTERM** or **SIGINT** (Ctrl-C): Will cleanly terminate all child processes and exit.
 * **SIGHUP**: Will hot restart by re-invoking whatever is passed as the first argument to the
   hot restart script.
 * **SIGCHLD**: If any of the child processes shut down unexpectedly, the restart script will shut

--- a/restarter/hot-restarter.py
+++ b/restarter/hot-restarter.py
@@ -76,12 +76,23 @@ def force_kill_all_children():
   pid_list = []
 
 
-def sigterm_handler(signum, frame):
-  """ Handler for SIGTERM. See term_all_children() for further discussion. """
-
-  print("got SIGTERM")
+def shutdown():
+  """ Attempt to gracefully shutdown all child Envoy processes and then exit.
+  See term_all_children() for further discussion. """
   term_all_children()
   sys.exit(0)
+
+
+def sigterm_handler(signum, frame):
+  """ Handler for SIGTERM. """
+  print("got SIGTERM")
+  shutdown()
+
+
+def sigint_handler(signum, frame):
+  """ Handler for SIGINT (ctrl-c). The same as the SIGTERM handler. """
+  print("got SIGINT")
+  shutdown()
 
 
 def sighup_handler(signum, frame):
@@ -179,6 +190,7 @@ def main():
   print("starting hot-restarter with target: {}".format(sys.argv[1]))
 
   signal.signal(signal.SIGTERM, sigterm_handler)
+  signal.signal(signal.SIGINT, sigint_handler)
   signal.signal(signal.SIGHUP, sighup_handler)
   signal.signal(signal.SIGCHLD, sigchld_handler)
   signal.signal(signal.SIGUSR1, sigusr1_handler)

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -402,6 +402,11 @@ RunHelper::RunHelper(Instance& instance, Options& options, Event::Dispatcher& di
       instance.shutdown();
     });
 
+    sigint_ = dispatcher.listenForSignal(SIGINT, [&instance]() {
+      ENVOY_LOG(warn, "caught SIGINT");
+      instance.shutdown();
+    });
+
     sig_usr_1_ = dispatcher.listenForSignal(SIGUSR1, [&access_log_manager]() {
       ENVOY_LOG(warn, "caught SIGUSR1");
       access_log_manager.reopen();

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -124,6 +124,7 @@ public:
 
 private:
   Event::SignalEventPtr sigterm_;
+  Event::SignalEventPtr sigint_;
   Event::SignalEventPtr sig_usr_1_;
   Event::SignalEventPtr sig_hup_;
 };

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -200,8 +200,8 @@ TEST_P(AdminRequestTest, AdminRequestGetStatsAndKill) {
   EXPECT_TRUE(waitForEnvoyToExit());
 }
 
-// This test is the same as well, except we send ourselves a SIGINT, equivalent to receiving a
-// Ctrl-C from the user.
+// This test is the same as AdminRequestGetStatsAndQuit, except we send ourselves a SIGINT,
+// equivalent to receiving a Ctrl-C from the user.
 TEST_P(AdminRequestTest, AdminRequestGetStatsAndCtrlC) {
   startEnvoy();
   started_.WaitForNotification();

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -200,6 +200,16 @@ TEST_P(AdminRequestTest, AdminRequestGetStatsAndKill) {
   EXPECT_TRUE(waitForEnvoyToExit());
 }
 
+// This test is the same as well, except we send ourselves a SIGINT, equivalent to receiving a
+// Ctrl-C from the user.
+TEST_P(AdminRequestTest, AdminRequestGetStatsAndCtrlC) {
+  startEnvoy();
+  started_.WaitForNotification();
+  EXPECT_THAT(adminRequest("/stats", "GET"), HasSubstr("filesystem.reopen_failed"));
+  kill(getpid(), SIGINT);
+  EXPECT_TRUE(waitForEnvoyToExit());
+}
+
 TEST_P(AdminRequestTest, AdminRequestContentionDisabled) {
   startEnvoy();
   started_.WaitForNotification();

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -59,6 +59,7 @@ public:
     InSequence s;
 
     sigterm_ = new Event::MockSignalEvent(&dispatcher_);
+    sigint_ = new Event::MockSignalEvent(&dispatcher_);
     sigusr1_ = new Event::MockSignalEvent(&dispatcher_);
     sighup_ = new Event::MockSignalEvent(&dispatcher_);
     EXPECT_CALL(cm_, setInitializedCb(_)).WillOnce(SaveArg<0>(&cm_init_callback_));
@@ -81,6 +82,7 @@ public:
   std::unique_ptr<RunHelper> helper_;
   std::function<void()> cm_init_callback_;
   Event::MockSignalEvent* sigterm_;
+  Event::MockSignalEvent* sigint_;
   Event::MockSignalEvent* sigusr1_;
   Event::MockSignalEvent* sighup_;
   bool shutdown_ = false;


### PR DESCRIPTION
*Description*:
Gracefully shutdown Envoy on SIGINT (Ctrl-C). This makes Envoy handle SIGINT the same way as SIGTERM. The use case for this is somebody running Envoy on the command line can type Ctrl-C to shutdown Envoy. Currently in most cases the Envoy process will be terminated since a handler for SIGINT is not set. This changes Envoy to instead gracefully shutdown.

Solves Ctrl-C being ignored in #5326.

*Risk Level*:
Low

*Testing*:
One simple integration test added

*Docs Changes*:
None

*Release Notes*:
Added to v1.9.0 release
