### PR TITLE
build: remove deprecated PACKAGE_NAME macro

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -255,7 +255,7 @@ def envoy_cc_library(
             envoy_external_dep_path("spdlog"),
             envoy_external_dep_path("fmtlib"),
         ],
-        include_prefix = envoy_include_prefix(PACKAGE_NAME),
+        include_prefix = envoy_include_prefix(native.package_name()),
         alwayslink = 1,
         linkstatic = 1,
         linkstamp = select({
@@ -500,7 +500,7 @@ def envoy_proto_library(name, external_deps = [], **kwargs):
 # This is used for testing only.
 def envoy_proto_descriptor(name, out, srcs = [], external_deps = []):
     input_files = ["$(location " + src + ")" for src in srcs]
-    include_paths = [".", PACKAGE_NAME]
+    include_paths = [".", native.package_name()]
 
     if "api_httpbody_protos" in external_deps:
         srcs.append("@googleapis//:api_httpbody_protos_src")

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -72,7 +72,7 @@ envoy_cc_library(
 envoy_basic_cc_library(
     name = "fmt_lib",
     hdrs = ["fmt.h"],
-    include_prefix = envoy_include_prefix(PACKAGE_NAME),
+    include_prefix = envoy_include_prefix(package_name()),
 )
 
 envoy_cc_library(


### PR DESCRIPTION
Replace Bazel's `PACKAGE_NAME` magic variable with the equivalent call to `package_name()` since the former is deprecated according to (recent Bazel docs)[https://docs.bazel.build/versions/0.20.0/skylark/lib/globals.html#PACKAGE_NAME]

*Risk Level*: low
*Testing*: built all targets
*Docs Changes*: n/a
*Release Notes*: n/a
