### PR TITLE
json: use correct protobuf string type

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -105,7 +105,7 @@ JsonTranscoderConfig::JsonTranscoderConfig(
   }
 
   PathMatcherBuilder<const Protobuf::MethodDescriptor*> pmb;
-  std::set<std::string> ignored_query_parameters;
+  std::set<ProtobufTypes::String> ignored_query_parameters;
   for (const auto& query_param : proto_config.ignored_query_parameters()) {
     ignored_query_parameters.insert(query_param);
   }


### PR DESCRIPTION
For string fields extracted from a map, use the correct string type.

*Risk Level*: low
*Testing*: built the affected target
*Docs Changes*: n/a
*Release Notes*: n/a