### PR TITLE
Remove timestamp parsing with std::get_time

### DIFF
--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -282,10 +282,7 @@ TEST_F(RouterUpstreamLogTest, LogTimestampsAndDurations) {
   std::smatch matches;
   EXPECT_TRUE(std::regex_match(output_.front(), matches, log_regex));
 
-  std::tm timestamp{};
-  std::istringstream ss(matches[1].str());
-  ss >> std::get_time(&timestamp, "%Y-%m-%dT%H:%M:%S");
-  EXPECT_FALSE(ss.fail());
+  std::tm timestamp = TestUtility::parseTimestamp("%Y-%m-%dT%H:%M:%S", matches[1].str());
 
   std::time_t log_time = std::mktime(&timestamp);
   std::time_t now = std::time(nullptr);

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -233,10 +233,7 @@ TEST_F(SslContextImplTest, TestGetCertInformationWithSAN) {
 }
 
 std::string convertTimeCertInfoToCertDetails(std::string cert_info_time) {
-  std::tm expiration{};
-  std::istringstream text(cert_info_time);
-  text >> std::get_time(&expiration, "%b %e %H:%M:%S %Y GMT");
-  EXPECT_FALSE(text.fail());
+  std::tm expiration = TestUtility::parseTimestamp("%b %e %H:%M:%S %Y GMT", cert_info_time);
   char buffer[21];
   size_t len = strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%SZ", &expiration);
   ASSERT(len == sizeof(buffer) - 1);

--- a/test/common/ssl/utility_test.cc
+++ b/test/common/ssl/utility_test.cc
@@ -66,10 +66,8 @@ TEST(UtilityTest, TestDaysUntilExpiration) {
   time_source.setSystemTime(std::chrono::system_clock::from_time_t(known_date_time));
 
   // Get expiration time from the certificate info.
-  std::tm expiration{};
-  std::istringstream text(TEST_SAN_DNS_CERT_NOT_AFTER);
-  text >> std::get_time(&expiration, "%b %e %H:%M:%S %Y GMT");
-  EXPECT_FALSE(text.fail());
+  std::tm expiration =
+      TestUtility::parseTimestamp("%b %e %H:%M:%S %Y GMT", TEST_SAN_DNS_CERT_NOT_AFTER);
 
   int days = std::difftime(std::mktime(&expiration), known_date_time) / (60 * 60 * 24);
   EXPECT_EQ(days, Utility::getDaysUntilExpiration(cert.get(), time_source));

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -222,6 +222,18 @@ void TestUtility::createSymlink(const std::string& target, const std::string& li
   ASSERT_NE(rc, 0);
 #endif
 }
+
+// static
+std::tm TestUtility::parseTimestamp(const std::string& format, const std::string& time_str) {
+  std::tm timestamp{};
+  const char* parsed_to = strptime(time_str.c_str(), format.c_str(), &timestamp);
+
+  EXPECT_EQ(parsed_to, time_str.c_str() + time_str.size())
+      << " from failing to parse timestamp \"" << time_str << "\" with format string \"" << format
+      << "\"";
+  return timestamp;
+}
+
 void ConditionalInitializer::setReady() {
   Thread::LockGuard lock(mutex_);
   EXPECT_FALSE(ready_);

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -304,6 +304,8 @@ public:
     return result;
   }
 
+  static std::tm parseTimestamp(const std::string& format, const std::string& time_str);
+
   static constexpr std::chrono::milliseconds DefaultTimeout = std::chrono::milliseconds(10000);
 
   static void renameFile(const std::string& old_name, const std::string& new_name);

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -273,6 +273,11 @@ def checkSourceLine(line, file_path, reportError):
        'std::chrono::system_clock::now' in line or 'std::chrono::steady_clock::now' in line or \
        'std::this_thread::sleep_for' in line or hasCondVarWaitFor(line):
       reportError("Don't reference real-world time sources from production code; use injection")
+  if "std::get_time" in line:
+    if "test/" in file_path:
+      reportError("Don't use std::get_time; use TestUtility::parseTimestamp in tests")
+    else:
+      reportError("Don't use std::get_time; use the injectable time system")
   if 'std::atomic_' in line:
     # The std::atomic_* free functions are functionally equivalent to calling
     # operations on std::atomic<T> objects, so prefer to use that instead.

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -183,6 +183,7 @@ if __name__ == "__main__":
   errors += checkUnfixableError("condvar_wait_for.cc", real_time_inject_error)
   errors += checkUnfixableError("sleep.cc", real_time_inject_error)
   errors += checkUnfixableError("std_atomic_free_functions.cc", "std::atomic_*")
+  errors += checkUnfixableError("std_get_time.cc", "std::get_time")
   errors += checkUnfixableError("no_namespace_envoy.cc",
                                 "Unable to find Envoy namespace or NOLINT(namespace-envoy)")
   errors += checkUnfixableError("proto.BUILD", "unexpected direct external dependency on protobuf")

--- a/tools/testdata/check_format/std_get_time.cc
+++ b/tools/testdata/check_format/std_get_time.cc
@@ -1,0 +1,17 @@
+#include <stdio>
+#include <iomanip>
+
+namespace Envoy {
+
+void parse_time() {
+  std::tm t = {};
+  std::istringstream ss("2018-December-17 14:38:00");
+  ss >> std::get_time(&t, "%Y-%b-%d %H:%M:%S");
+  if (ss.fail()) {
+    std::cout << "Parse failed\n";
+  } else {
+    std::cout << std::put_time(&t, "%c") << '\n';
+  }
+}
+
+} // namespace Envoy


### PR DESCRIPTION
Since Envoy uses a time system that allows injecting mock timestamps, there is no need to support timestamp parsing in the production code. In the test code, this is cleanly abstracted out as a test-only utility function.

*Risk Level*: low
*Testing*: ran affected tests
*Docs Changes*: n/a
*Release Notes*: n/a