### PR TITLE
dubbo_proxy: Add NamedProtocolConfigFactory definition

### DIFF
--- a/source/extensions/filters/network/dubbo_proxy/BUILD
+++ b/source/extensions/filters/network/dubbo_proxy/BUILD
@@ -34,6 +34,8 @@ envoy_cc_library(
     hdrs = ["protocol.h"],
     deps = [
         ":buffer_helper_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/config:utility_lib",
         "//source/common/singleton:const_singleton",
     ],
 )

--- a/source/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl.cc
+++ b/source/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl.cc
@@ -1,5 +1,7 @@
 #include "extensions/filters/network/dubbo_proxy/dubbo_protocol_impl.h"
 
+#include "envoy/registry/registry.h"
+
 #include "common/common/assert.h"
 
 namespace Envoy {
@@ -112,6 +114,16 @@ bool DubboProtocolImpl::decode(Buffer::Instance& buffer, Protocol::Context* cont
   buffer.drain(MessageSize);
   return true;
 }
+
+class DubboProtocolConfigFactory : public ProtocolFactoryBase<DubboProtocolImpl> {
+public:
+  DubboProtocolConfigFactory() : ProtocolFactoryBase(ProtocolType::Dubbo) {}
+};
+
+/**
+ * Static registration for the Dubbo protocol. @see RegisterFactory.
+ */
+static Registry::RegisterFactory<DubboProtocolConfigFactory, NamedProtocolConfigFactory> register_;
 
 } // namespace DubboProxy
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl.h
+++ b/source/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl.h
@@ -69,7 +69,8 @@ typedef std::unique_ptr<ResponseMessageImpl> ResponseMessageImplPtr;
 class DubboProtocolImpl : public Protocol {
 public:
   DubboProtocolImpl(ProtocolCallbacks& callbacks) : callbacks_(callbacks) {}
-  const std::string& name() const override { return ProtocolNames::get().Dubbo; }
+  const std::string& name() const override { return ProtocolNames::get().fromType(type()); }
+  ProtocolType type() const override { return ProtocolType::Dubbo; }
   virtual bool decode(Buffer::Instance& buffer, Protocol::Context* context) override;
 
   static constexpr uint8_t MessageSize = 16;

--- a/source/extensions/filters/network/dubbo_proxy/filter.cc
+++ b/source/extensions/filters/network/dubbo_proxy/filter.cc
@@ -13,10 +13,33 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace DubboProxy {
 
+using ConfigProtocolType =
+    envoy::extensions::filters::network::dubbo_proxy::v2alpha1::DubboProxy_ProtocolType;
+
+typedef std::map<ConfigProtocolType, ProtocolType> ProtocolTypeMap;
+
+static const ProtocolTypeMap& protocolTypeMap() {
+  CONSTRUCT_ON_FIRST_USE(
+      ProtocolTypeMap, {
+                           {ConfigProtocolType::DubboProxy_ProtocolType_Dubbo, ProtocolType::Dubbo},
+                       });
+}
+
+ProtocolType lookupProtocol(ConfigProtocolType config_type) {
+  const auto& iter = protocolTypeMap().find(config_type);
+  if (iter == protocolTypeMap().end()) {
+    throw EnvoyException(fmt::format(
+        "unknown protocol {}",
+        envoy::extensions::filters::network::dubbo_proxy::v2alpha1::DubboProxy_ProtocolType_Name(
+            config_type)));
+  }
+  return iter->second;
+}
+
 Filter::Filter(const std::string& stat_prefix, ConfigProtocolType protocol_type,
                ConfigSerializationType serialization_type, Stats::Scope& scope,
                TimeSource& time_source)
-    : stats_(generateStats(stat_prefix, scope)), protocol_type_(protocol_type),
+    : stats_(generateStats(stat_prefix, scope)), protocol_type_(lookupProtocol(protocol_type)),
       serialization_type_(serialization_type), time_source_(time_source) {}
 
 Filter::~Filter() = default;
@@ -183,13 +206,7 @@ DecoderPtr Filter::createDecoder(ProtocolCallbacks& prot_callback) {
 }
 
 ProtocolPtr Filter::createProtocol(ProtocolCallbacks& callback) {
-  using Type = envoy::extensions::filters::network::dubbo_proxy::v2alpha1::DubboProxy;
-  switch (protocol_type_) {
-  case Type::Dubbo:
-    return NamedProtocolConfigFactory::getFactory(ProtocolType::Dubbo).createProtocol(callback);
-  default:
-    NOT_REACHED_GCOVR_EXCL_LINE;
-  }
+  return NamedProtocolConfigFactory::getFactory(protocol_type_).createProtocol(callback);
 }
 
 DeserializerPtr Filter::createDeserializer() {

--- a/source/extensions/filters/network/dubbo_proxy/filter.cc
+++ b/source/extensions/filters/network/dubbo_proxy/filter.cc
@@ -186,7 +186,7 @@ ProtocolPtr Filter::createProtocol(ProtocolCallbacks& callback) {
   using Type = envoy::extensions::filters::network::dubbo_proxy::v2alpha1::DubboProxy;
   switch (protocol_type_) {
   case Type::Dubbo:
-    return std::make_unique<DubboProtocolImpl>(callback);
+    return NamedProtocolConfigFactory::getFactory(ProtocolType::Dubbo).createProtocol(callback);
   default:
     NOT_REACHED_GCOVR_EXCL_LINE;
   }

--- a/source/extensions/filters/network/dubbo_proxy/filter.h
+++ b/source/extensions/filters/network/dubbo_proxy/filter.h
@@ -127,7 +127,7 @@ private:
   bool sniffing_{true};
   DubboFilterStats stats_;
 
-  ConfigProtocolType protocol_type_;
+  ProtocolType protocol_type_;
   ConfigSerializationType serialization_type_;
 
   TimeSource& time_source_;

--- a/source/extensions/filters/network/dubbo_proxy/protocol.h
+++ b/source/extensions/filters/network/dubbo_proxy/protocol.h
@@ -43,7 +43,7 @@ public:
       return itor->second;
     }
 
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 };
 

--- a/source/extensions/filters/network/dubbo_proxy/protocol.h
+++ b/source/extensions/filters/network/dubbo_proxy/protocol.h
@@ -1,10 +1,13 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 
 #include "envoy/buffer/buffer.h"
 
+#include "common/common/assert.h"
 #include "common/common/fmt.h"
+#include "common/config/utility.h"
 #include "common/singleton/const_singleton.h"
 
 namespace Envoy {
@@ -12,13 +15,31 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace DubboProxy {
 
+enum class ProtocolType : uint8_t {
+  Dubbo,
+
+  // ATTENTION: MAKE SURE THIS REMAINS EQUAL TO THE LAST PROTOCOL TYPE
+  LastProtocolType = Dubbo,
+};
+
 /**
  * Names of available Protocol implementations.
  */
 class ProtocolNameValues {
 public:
-  // Dubbo protocol
-  const std::string Dubbo = "dubbo";
+  typedef std::unordered_map<ProtocolType, std::string> ProtocolTypeNameMap;
+
+  const ProtocolTypeNameMap protocolTypeNameMap = {
+      {ProtocolType::Dubbo, "dubbo"},
+  };
+
+  const std::string& fromType(ProtocolType type) const {
+    const auto& itor = protocolTypeNameMap.find(type);
+    if (itor != protocolTypeNameMap.end())
+      return itor->second;
+
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
 };
 
 typedef ConstSingleton<ProtocolNameValues> ProtocolNames;
@@ -101,6 +122,12 @@ public:
   virtual ~Protocol() {}
   Protocol() {}
   virtual const std::string& name() const PURE;
+
+  /**
+   * @return ProtocolType the protocol type
+   */
+  virtual ProtocolType type() const PURE;
+
   /*
    * decodes the dubbo protocol message, potentially invoking callbacks.
    * If successful, the message is removed from the buffer.
@@ -115,6 +142,55 @@ public:
 };
 
 typedef std::unique_ptr<Protocol> ProtocolPtr;
+
+/**
+ * Implemented by each Dubbo protocol and registered via Registry::registerFactory or the
+ * convenience class RegisterFactory.
+ */
+class NamedProtocolConfigFactory {
+public:
+  virtual ~NamedProtocolConfigFactory() {}
+
+  /**
+   * Create a particular Dubbo protocol.
+   * @param callbacks the callbacks to be notified of protocol decodes.
+   * @return ptotocol instance pointer.
+   */
+  virtual ProtocolPtr createProtocol(ProtocolCallbacks& callbacks) PURE;
+
+  /**
+   * @return std::string the identifying name for a particular implementation of Dubbo protocol
+   * produced by the factory.
+   */
+  virtual std::string name() PURE;
+
+  /**
+   * Convenience method to lookup a factory by type.
+   * @param ProtocolType the protocol type.
+   * @return NamedProtocolConfigFactory& for the ProtocolType.
+   */
+  static NamedProtocolConfigFactory& getFactory(ProtocolType type) {
+    const std::string& name = ProtocolNames::get().fromType(type);
+    return Envoy::Config::Utility::getAndCheckFactory<NamedProtocolConfigFactory>(name);
+  }
+};
+
+/**
+ * ProtocolFactoryBase provides a template for a trivial NamedProtocolConfigFactory.
+ */
+template <class ProtocolImpl> class ProtocolFactoryBase : public NamedProtocolConfigFactory {
+  ProtocolPtr createProtocol(ProtocolCallbacks& callbacks) override {
+    return std::move(std::make_unique<ProtocolImpl>(callbacks));
+  }
+
+  std::string name() override { return name_; }
+
+protected:
+  ProtocolFactoryBase(ProtocolType type) : name_(ProtocolNames::get().fromType(type)) {}
+
+private:
+  const std::string name_;
+};
 
 } // namespace DubboProxy
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/dubbo_proxy/protocol.h
+++ b/source/extensions/filters/network/dubbo_proxy/protocol.h
@@ -39,8 +39,9 @@ public:
 
   const std::string& fromType(ProtocolType type) const {
     const auto& itor = protocolTypeNameMap.find(type);
-    if (itor != protocolTypeNameMap.end())
+    if (itor != protocolTypeNameMap.end()) {
       return itor->second;
+    }
 
     NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }

--- a/source/extensions/filters/network/dubbo_proxy/protocol.h
+++ b/source/extensions/filters/network/dubbo_proxy/protocol.h
@@ -16,7 +16,7 @@ namespace NetworkFilters {
 namespace DubboProxy {
 
 enum class ProtocolType : uint8_t {
-  Dubbo,
+  Dubbo = 0,
 
   // ATTENTION: MAKE SURE THIS REMAINS EQUAL TO THE LAST PROTOCOL TYPE
   LastProtocolType = Dubbo,
@@ -27,7 +27,11 @@ enum class ProtocolType : uint8_t {
  */
 class ProtocolNameValues {
 public:
-  typedef std::unordered_map<ProtocolType, std::string> ProtocolTypeNameMap;
+  struct ProtocolTypeHash {
+    template <typename T> std::size_t operator()(T t) const { return static_cast<std::size_t>(t); }
+  };
+
+  typedef std::unordered_map<ProtocolType, std::string, ProtocolTypeHash> ProtocolTypeNameMap;
 
   const ProtocolTypeNameMap protocolTypeNameMap = {
       {ProtocolType::Dubbo, "dubbo"},

--- a/test/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl_test.cc
@@ -109,6 +109,13 @@ TEST(DubboProtocolImplTest, InvalidProtocol) {
   }
 }
 
+TEST(DubboProtocolImplTest, DubboProtocolConfigFactory) {
+  MockProtocolCallbacks cb;
+  auto protocol = NamedProtocolConfigFactory::getFactory(ProtocolType::Dubbo).createProtocol(cb);
+  EXPECT_EQ(protocol->name(), "dubbo");
+  EXPECT_EQ(protocol->type(), ProtocolType::Dubbo);
+}
+
 } // namespace DubboProxy
 } // namespace NetworkFilters
 } // namespace Extensions


### PR DESCRIPTION
*Description*: Add NamedProtocolConfigFactory definition
*Risk Level*: low
*Testing*:  unit test
*Docs Changes*:  N/A
*Release Notes*:  N/A
[Optional Fixes #Issue]
[Optional *Deprecated*:]

this is only part of the code for DubboProxy, the rest of the code hasn't been committed yet, complete implementation: https://github.com/gengleilei/envoy/tree/feature-dubbo-router-develop/source/extensions/filters/network/dubbo_proxy