### PR TITLE
http2: shard http2 codec_impl_test

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -359,6 +359,7 @@ def envoy_cc_test(
         deps = [],
         tags = [],
         args = [],
+        shard_count = None,
         coverage = True,
         local = False):
     test_lib_tags = []
@@ -388,6 +389,7 @@ def envoy_cc_test(
         args = args + ["--gmock_default_mock_behavior=2"],
         tags = tags + ["coverage_test"],
         local = local,
+        shard_count = shard_count,
     )
 
 # Envoy C++ test related libraries (that want gtest, gmock) should be specified

--- a/test/common/http/http2/BUILD
+++ b/test/common/http/http2/BUILD
@@ -33,7 +33,7 @@ envoy_cc_fuzz_test(
 envoy_cc_test(
     name = "codec_impl_test",
     srcs = ["codec_impl_test.cc"],
-    shard_count = 50,
+    shard_count = 5,
     deps = [
         "//source/common/event:dispatcher_lib",
         "//source/common/http:exception_lib",

--- a/test/common/http/http2/BUILD
+++ b/test/common/http/http2/BUILD
@@ -33,6 +33,7 @@ envoy_cc_fuzz_test(
 envoy_cc_test(
     name = "codec_impl_test",
     srcs = ["codec_impl_test.cc"],
+    shard_count = 50,
     deps = [
         "//source/common/event:dispatcher_lib",
         "//source/common/http:exception_lib",


### PR DESCRIPTION
This test takes forever to run but the test cases are trivially parallelizable. With multiple cores, this reduces the running time significantly.

*Risk Level*: low
*Testing*: ran affected test
*Docs Changes*: n/a
*Release Notes*: n/a
