### PR TITLE
test: deflaking a connection pool race

### DIFF
--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -306,30 +306,33 @@ TEST_P(Http2UpstreamIntegrationTest, UpstreamConnectionCloseWithManyStreams) {
     encoders.push_back(&encoder_decoder.first);
     responses.push_back(std::move(encoder_decoder.second));
 
-    // Ensure that we're establishing a connection after the first request, before we issue
-    // any of the resets. This is necessary in order to know a priori that all requests will
-    // create a stream on the connection, regardless of whether they are reset or not. Resets
-    // that occur before a connection has been established does not create a stream on the
-    // connection.
+    // Ensure that we establish the first request (which will be reset) to avoid
+    // a race where the reset is detected before the upstream stream is
+    // established (#5316)
     if (i == 0) {
       ASSERT_TRUE(
           fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+      upstream_requests.emplace_back();
+      ASSERT_TRUE(
+          fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_requests.back()));
     }
 
-    // Reset a few streams to test how reset and watermark interact.
-    if (i % 15 == 0) {
-      codec_client_->sendReset(*encoders[i]);
-    } else {
+    if (i != 0) {
       codec_client_->sendData(*encoders[i], 0, true);
     }
   }
-  for (uint32_t i = 0; i < num_requests; ++i) {
+
+  // Reset one stream to test how reset and watermarks interact.
+  codec_client_->sendReset(*encoders[0]);
+
+  // Now drain the upstream connection.
+  for (uint32_t i = 1; i < num_requests; ++i) {
     upstream_requests.emplace_back();
     ASSERT_TRUE(
         fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_requests.back()));
   }
   for (uint32_t i = 0; i < num_requests; ++i) {
-    if (i % 15 != 0) {
+    if (i != 0) {
       ASSERT_TRUE(upstream_requests[i]->waitForEndStream(*dispatcher_));
       upstream_requests[i]->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
       upstream_requests[i]->encodeData(100, false);
@@ -340,7 +343,7 @@ TEST_P(Http2UpstreamIntegrationTest, UpstreamConnectionCloseWithManyStreams) {
   ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
   // Ensure the streams are all reset successfully.
   for (uint32_t i = 0; i < num_requests; ++i) {
-    if (i % 15 != 0) {
+    if (i != 0) {
       responses[i]->waitForReset();
     }
   }

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -331,21 +331,17 @@ TEST_P(Http2UpstreamIntegrationTest, UpstreamConnectionCloseWithManyStreams) {
     ASSERT_TRUE(
         fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_requests.back()));
   }
-  for (uint32_t i = 0; i < num_requests; ++i) {
-    if (i != 0) {
-      ASSERT_TRUE(upstream_requests[i]->waitForEndStream(*dispatcher_));
-      upstream_requests[i]->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
-      upstream_requests[i]->encodeData(100, false);
-    }
+  for (uint32_t i = 1; i < num_requests; ++i) {
+    ASSERT_TRUE(upstream_requests[i]->waitForEndStream(*dispatcher_));
+    upstream_requests[i]->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+    upstream_requests[i]->encodeData(100, false);
   }
   // Close the connection.
   ASSERT_TRUE(fake_upstream_connection_->close());
   ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
   // Ensure the streams are all reset successfully.
-  for (uint32_t i = 0; i < num_requests; ++i) {
-    if (i != 0) {
-      responses[i]->waitForReset();
-    }
+  for (uint32_t i = 1; i < num_requests; ++i) {
+    responses[i]->waitForReset();
   }
 }
 


### PR DESCRIPTION
Removing a race where we reset a stream before the upstream stream had been established.

*Risk Level*: low (test only)
*Testing*: 1k runs locally still pass but it was a mac-only bug.
*Docs Changes*: n/a
*Release Notes*: n/a
Fixes #5316
