### PR TITLE
Revert "config: removing deprecated bind_to_port (#5288)"

### DIFF
--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -96,6 +96,8 @@ message Listener {
     // port. An additional filter chain must be created for every original
     // destination port this listener may redirect to in v2, with the original
     // port specified in the FilterChainMatch destination_port field.
+    //
+    // [#comment:TODO(PiotrSikora): Remove this once verified that we no longer need it.]
     google.protobuf.BoolValue bind_to_port = 1;
   }
 

--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -86,7 +86,21 @@ message Listener {
   // Listener metadata.
   core.Metadata metadata = 6;
 
-  reserved 7;
+  // [#not-implemented-hide:]
+  message DeprecatedV1 {
+    // Whether the listener should bind to the port. A listener that doesn’t
+    // bind can only receive connections redirected from other listeners that
+    // set use_original_dst parameter to true. Default is true.
+    //
+    // [V2-API-DIFF] This is deprecated in v2, all Listeners will bind to their
+    // port. An additional filter chain must be created for every original
+    // destination port this listener may redirect to in v2, with the original
+    // port specified in the FilterChainMatch destination_port field.
+    google.protobuf.BoolValue bind_to_port = 1;
+  }
+
+  // [#not-implemented-hide:]
+  DeprecatedV1 deprecated_v1 = 7;
 
   enum DrainType {
     // Drain in response to calling /healthcheck/fail admin endpoint (along with the health check

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -15,7 +15,6 @@ Version history
 * circuit-breaker: added cx_open, rq_pending_open, rq_open and rq_retry_open gauges to expose live
   state via :ref:`circuit breakers statistics <config_cluster_manager_cluster_stats_circuit_breakers>`.
 * cluster: set a default of 1s for :ref:`option <envoy_api_field_Cluster.CommonLbConfig.update_merge_window>`.
-* config: removed deprecated_v1 bind_to_port option.
 * config: removed support for the v1 API.
 * config: added support for :ref:`rate limiting<envoy_api_msg_core.RateLimitSettings>` discovery request calls.
 * cors: added :ref: `invalid/valid stats <cors-statistics>` to filter.

--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -101,12 +101,13 @@ public:
    * Create a listener on a specific port.
    * @param socket supplies the socket to listen on.
    * @param cb supplies the callbacks to invoke for listener events.
+   * @param bind_to_port controls whether the listener binds to a transport port or not.
    * @param hand_off_restored_destination_connections controls whether the listener searches for
    *        another listener after restoring the destination address of a new connection.
    * @return Network::ListenerPtr a new listener that is owned by the caller.
    */
   virtual Network::ListenerPtr createListener(Network::Socket& socket,
-                                              Network::ListenerCallbacks& cb,
+                                              Network::ListenerCallbacks& cb, bool bind_to_port,
                                               bool hand_off_restored_destination_connections) PURE;
 
   /**

--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -39,6 +39,13 @@ public:
   virtual const Socket& socket() const PURE;
 
   /**
+   * @return bool specifies whether the listener should actually listen on the port.
+   *         A listener that doesn't listen on a port can only receive connections
+   *         redirected from other listeners.
+   */
+  virtual bool bindToPort() PURE;
+
+  /**
    * @return bool if a connection should be handed off to another Listener after the original
    *         destination address has been restored. 'true' when 'use_original_dst' flag in listener
    *         configuration is set, false otherwise. Note that this flag is deprecated and will be

--- a/include/envoy/server/listener_manager.h
+++ b/include/envoy/server/listener_manager.h
@@ -45,11 +45,12 @@ public:
    * Creates a socket.
    * @param address supplies the socket's address.
    * @param options to be set on the created socket just before calling 'bind()'.
+   * @param bind_to_port supplies whether to actually bind the socket.
    * @return Network::SocketSharedPtr an initialized and potentially bound socket.
    */
   virtual Network::SocketSharedPtr
   createListenSocket(Network::Address::InstanceConstSharedPtr address,
-                     const Network::Socket::OptionsSharedPtr& options) PURE;
+                     const Network::Socket::OptionsSharedPtr& options, bool bind_to_port) PURE;
 
   /**
    * Creates a list of filter factories.

--- a/source/common/config/lds_json.cc
+++ b/source/common/config/lds_json.cc
@@ -58,6 +58,7 @@ void LdsJson::translateListener(const Json::Object& json_listener,
 
   JSON_UTIL_SET_BOOL(json_listener, *filter_chain, use_proxy_proto);
   JSON_UTIL_SET_BOOL(json_listener, listener, use_original_dst);
+  JSON_UTIL_SET_BOOL(json_listener, *listener.mutable_deprecated_v1(), bind_to_port);
   JSON_UTIL_SET_INTEGER(json_listener, listener, per_connection_buffer_limit_bytes);
   JSON_UTIL_SET_BOOL(json_listener, listener, transparent);
 }

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -110,10 +110,10 @@ Filesystem::WatcherPtr DispatcherImpl::createFilesystemWatcher() {
 
 Network::ListenerPtr
 DispatcherImpl::createListener(Network::Socket& socket, Network::ListenerCallbacks& cb,
-                               bool hand_off_restored_destination_connections) {
+                               bool bind_to_port, bool hand_off_restored_destination_connections) {
   ASSERT(isThreadSafe());
-  return Network::ListenerPtr{
-      new Network::ListenerImpl(*this, socket, cb, hand_off_restored_destination_connections)};
+  return Network::ListenerPtr{new Network::ListenerImpl(*this, socket, cb, bind_to_port,
+                                                        hand_off_restored_destination_connections)};
 }
 
 TimerPtr DispatcherImpl::createTimer(TimerCb cb) {

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -48,6 +48,7 @@ public:
                                uint32_t events) override;
   Filesystem::WatcherPtr createFilesystemWatcher() override;
   Network::ListenerPtr createListener(Network::Socket& socket, Network::ListenerCallbacks& cb,
+                                      bool bind_to_port,
                                       bool hand_off_restored_destination_connections) override;
   TimerPtr createTimer(TimerCb cb) override;
   void deferredDelete(DeferredDeletablePtr&& to_delete) override;

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -184,6 +184,7 @@ const std::string Json::Schema::LISTENER_SCHEMA(R"EOF(
        "drain_type": {"type" : "string", "enum" : ["default", "modify_only"]},
        "ssl_context" : {"$ref" : "#/definitions/ssl_context"},
        "transparent" : {"type": "boolean"},
+       "bind_to_port" : {"type": "boolean"},
        "use_proxy_proto" : {"type" : "boolean"},
        "use_original_dst" : {"type" : "boolean"},
        "per_connection_buffer_limit_bytes" : {

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -38,10 +38,13 @@ void ListenSocketImpl::setListenSocketOptions(const Network::Socket::OptionsShar
   }
 }
 
-void ListenSocketImpl::setupSocket(const Network::Socket::OptionsSharedPtr& options) {
+void ListenSocketImpl::setupSocket(const Network::Socket::OptionsSharedPtr& options,
+                                   bool bind_to_port) {
   setListenSocketOptions(options);
 
-  doBind();
+  if (bind_to_port) {
+    doBind();
+  }
 }
 
 template <>

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -56,7 +56,7 @@ protected:
   ListenSocketImpl(int fd, const Address::InstanceConstSharedPtr& local_address)
       : SocketImpl(fd, local_address) {}
 
-  void setupSocket(const Network::Socket::OptionsSharedPtr& options);
+  void setupSocket(const Network::Socket::OptionsSharedPtr& options, bool bind_to_port);
   void doBind();
   void setListenSocketOptions(const Network::Socket::OptionsSharedPtr& options);
 };
@@ -77,13 +77,13 @@ template <> struct NetworkSocketTrait<Address::SocketType::Datagram> {
 template <typename T> class NetworkListenSocket : public ListenSocketImpl {
 public:
   NetworkListenSocket(const Address::InstanceConstSharedPtr& address,
-                      const Network::Socket::OptionsSharedPtr& options)
+                      const Network::Socket::OptionsSharedPtr& options, bool bind_to_port)
       : ListenSocketImpl(address->socket(T::type), address) {
     RELEASE_ASSERT(fd_ != -1, "");
 
     setPrebindSocketOptions();
 
-    setupSocket(options);
+    setupSocket(options, bind_to_port);
   }
 
   NetworkListenSocket(int fd, const Address::InstanceConstSharedPtr& address,

--- a/source/common/network/listener_impl.h
+++ b/source/common/network/listener_impl.h
@@ -17,7 +17,7 @@ namespace Network {
 class ListenerImpl : public Listener {
 public:
   ListenerImpl(Event::DispatcherImpl& dispatcher, Socket& socket, ListenerCallbacks& cb,
-               bool hand_off_restored_destination_connections);
+               bool bind_to_port, bool hand_off_restored_destination_connections);
 
   void disable();
   void enable();

--- a/source/server/config_validation/dispatcher.cc
+++ b/source/server/config_validation/dispatcher.cc
@@ -22,7 +22,7 @@ Network::DnsResolverSharedPtr ValidationDispatcher::createDnsResolver(
 }
 
 Network::ListenerPtr ValidationDispatcher::createListener(Network::Socket&,
-                                                          Network::ListenerCallbacks&, bool) {
+                                                          Network::ListenerCallbacks&, bool, bool) {
   NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
 }
 

--- a/source/server/config_validation/dispatcher.h
+++ b/source/server/config_validation/dispatcher.h
@@ -25,6 +25,7 @@ public:
   Network::DnsResolverSharedPtr createDnsResolver(
       const std::vector<Network::Address::InstanceConstSharedPtr>& resolvers) override;
   Network::ListenerPtr createListener(Network::Socket&, Network::ListenerCallbacks&,
+                                      bool bind_to_port,
                                       bool hand_off_restored_destination_connections) override;
 
 protected:

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -114,7 +114,8 @@ public:
     return ProdListenerComponentFactory::createListenerFilterFactoryList_(filters, context);
   }
   Network::SocketSharedPtr createListenSocket(Network::Address::InstanceConstSharedPtr,
-                                              const Network::Socket::OptionsSharedPtr&) override {
+                                              const Network::Socket::OptionsSharedPtr&,
+                                              bool) override {
     // Returned sockets are not currently used so we can return nothing here safely vs. a
     // validation mock.
     return nullptr;

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -74,10 +74,11 @@ void ConnectionHandlerImpl::ActiveListener::removeConnection(ActiveConnection& c
 
 ConnectionHandlerImpl::ActiveListener::ActiveListener(ConnectionHandlerImpl& parent,
                                                       Network::ListenerConfig& config)
-    : ActiveListener(parent,
-                     parent.dispatcher_.createListener(
-                         config.socket(), *this, config.handOffRestoredDestinationConnections()),
-                     config) {}
+    : ActiveListener(
+          parent,
+          parent.dispatcher_.createListener(config.socket(), *this, config.bindToPort(),
+                                            config.handOffRestoredDestinationConnections()),
+          config) {}
 
 ConnectionHandlerImpl::ActiveListener::ActiveListener(ConnectionHandlerImpl& parent,
                                                       Network::ListenerPtr&& listener,

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -962,7 +962,7 @@ void AdminImpl::startHttpListener(const std::string& access_log_path,
   access_logs_.emplace_back(new Extensions::AccessLoggers::File::FileAccessLog(
       access_log_path, {}, AccessLog::AccessLogFormatUtils::defaultAccessLogFormatter(),
       server_.accessLogManager()));
-  socket_ = std::make_unique<Network::TcpListenSocket>(address, nullptr);
+  socket_ = std::make_unique<Network::TcpListenSocket>(address, nullptr, true);
   listener_ = std::make_unique<AdminListener>(*this, std::move(listener_scope));
   if (!address_out_path.empty()) {
     std::ofstream address_out_file(address_out_path);

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -258,6 +258,7 @@ private:
     Network::FilterChainFactory& filterChainFactory() override { return parent_; }
     Network::Socket& socket() override { return parent_.mutable_socket(); }
     const Network::Socket& socket() const override { return parent_.mutable_socket(); }
+    bool bindToPort() override { return true; }
     bool handOffRestoredDestinationConnections() const override { return false; }
     uint32_t perConnectionBufferLimitBytes() const override { return 0; }
     std::chrono::milliseconds listenerFiltersTimeout() const override {

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -84,7 +84,8 @@ ProdListenerComponentFactory::createListenerFilterFactoryList_(
 
 Network::SocketSharedPtr
 ProdListenerComponentFactory::createListenSocket(Network::Address::InstanceConstSharedPtr address,
-                                                 const Network::Socket::OptionsSharedPtr& options) {
+                                                 const Network::Socket::OptionsSharedPtr& options,
+                                                 bool bind_to_port) {
   ASSERT(address->type() == Network::Address::Type::Ip ||
          address->type() == Network::Address::Type::Pipe);
 
@@ -106,7 +107,7 @@ ProdListenerComponentFactory::createListenSocket(Network::Address::InstanceConst
     ENVOY_LOG(debug, "obtained socket for address {} from parent", addr);
     return std::make_shared<Network::TcpListenSocket>(fd, address, options);
   }
-  return std::make_shared<Network::TcpListenSocket>(address, options);
+  return std::make_shared<Network::TcpListenSocket>(address, options, bind_to_port);
 }
 
 DrainManagerPtr
@@ -121,6 +122,7 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
       global_scope_(parent_.server_.stats().createScope("")),
       listener_scope_(
           parent_.server_.stats().createScope(fmt::format("listener.{}.", address_->asString()))),
+      bind_to_port_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.deprecated_v1(), bind_to_port, true)),
       hand_off_restored_destination_connections_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, use_original_dst, false)),
       per_connection_buffer_limit_bytes_(
@@ -739,6 +741,21 @@ bool ListenerManagerImpl::addOrUpdateListener(const envoy::api::v2::Listener& co
       *existing_active_listener = std::move(new_listener);
     }
   } else {
+    // Typically we catch address issues when we try to bind to the same address multiple times.
+    // However, for listeners that do not bind we must check to make sure we are not duplicating.
+    // This is an edge case and nothing will explicitly break, but there is no possibility that
+    // two listeners that do not bind will ever be used. Only the first one will be used when
+    // searched for by address. Thus we block it.
+    if (!new_listener->bindToPort() &&
+        (hasListenerWithAddress(warming_listeners_, *new_listener->address()) ||
+         hasListenerWithAddress(active_listeners_, *new_listener->address()))) {
+      const std::string message =
+          fmt::format("error adding listener: '{}' has duplicate address '{}' as existing listener",
+                      name, new_listener->address()->asString());
+      ENVOY_LOG(warn, "{}", message);
+      throw EnvoyException(message);
+    }
+
     // We have no warming or active listener so we need to make a new one. What we do depends on
     // whether workers have been started or not. Additionally, search through draining listeners
     // to see if there is a listener that has a socket bound to the address we are configured for.
@@ -757,7 +774,8 @@ bool ListenerManagerImpl::addOrUpdateListener(const envoy::api::v2::Listener& co
     new_listener->setSocket(draining_listener_socket
                                 ? draining_listener_socket
                                 : factory_.createListenSocket(new_listener->address(),
-                                                              new_listener->listenSocketOptions()));
+                                                              new_listener->listenSocketOptions(),
+                                                              new_listener->bindToPort()));
     if (workers_started_) {
       new_listener->debugLog("add warming listener");
       warming_listeners_.emplace_back(std::move(new_listener));

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -60,9 +60,9 @@ public:
       Configuration::ListenerFactoryContext& context) override {
     return createListenerFilterFactoryList_(filters, context);
   }
-  Network::SocketSharedPtr
-  createListenSocket(Network::Address::InstanceConstSharedPtr address,
-                     const Network::Socket::OptionsSharedPtr& options) override;
+  Network::SocketSharedPtr createListenSocket(Network::Address::InstanceConstSharedPtr address,
+                                              const Network::Socket::OptionsSharedPtr& options,
+                                              bool bind_to_port) override;
   DrainManagerPtr createDrainManager(envoy::api::v2::Listener::DrainType drain_type) override;
   uint64_t nextListenerTag() override { return next_listener_tag_++; }
 
@@ -242,6 +242,7 @@ public:
   Network::FilterChainFactory& filterChainFactory() override { return *this; }
   Network::Socket& socket() override { return *socket_; }
   const Network::Socket& socket() const override { return *socket_; }
+  bool bindToPort() override { return bind_to_port_; }
   bool handOffRestoredDestinationConnections() const override {
     return hand_off_restored_destination_connections_;
   }
@@ -388,6 +389,7 @@ private:
   Network::SocketSharedPtr socket_;
   Stats::ScopePtr global_scope_;   // Stats with global named scope, but needed for LDS cleanup.
   Stats::ScopePtr listener_scope_; // Stats with listener named scope.
+  const bool bind_to_port_;
   const bool hand_off_restored_destination_connections_;
   const uint32_t per_connection_buffer_limit_bytes_;
   const uint64_t listener_tag_;

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -263,7 +263,7 @@ class CodecNetworkTest : public testing::TestWithParam<Network::Address::IpVersi
 public:
   CodecNetworkTest() {
     dispatcher_ = std::make_unique<Event::DispatcherImpl>(test_time_.timeSystem());
-    upstream_listener_ = dispatcher_->createListener(socket_, listener_callbacks_, false);
+    upstream_listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
     Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
         socket_.localAddress(), source_address_, Network::Test::createRawBufferSocket(), nullptr);
     client_connection_ = client_connection.get();
@@ -335,7 +335,7 @@ protected:
   Network::MockConnectionHandler connection_handler_;
   Network::Address::InstanceConstSharedPtr source_address_;
   Stats::IsolatedStoreImpl stats_store_;
-  Network::TcpListenSocket socket_{Network::Test::getAnyAddress(GetParam()), nullptr};
+  Network::TcpListenSocket socket_{Network::Test::getAnyAddress(GetParam()), nullptr, true};
   Http::MockClientConnection* codec_;
   std::unique_ptr<CodecClientForTest> client_;
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -90,7 +90,7 @@ public:
     if (dispatcher_.get() == nullptr) {
       dispatcher_ = std::make_unique<Event::DispatcherImpl>(time_system_);
     }
-    listener_ = dispatcher_->createListener(socket_, listener_callbacks_, false);
+    listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
 
     client_connection_ = dispatcher_->createClientConnection(
         socket_.localAddress(), source_address_, Network::Test::createRawBufferSocket(), nullptr);
@@ -200,7 +200,7 @@ protected:
   Event::SimulatedTimeSystem time_system_;
   Event::DispatcherPtr dispatcher_;
   Stats::IsolatedStoreImpl stats_store_;
-  Network::TcpListenSocket socket_{Network::Test::getAnyAddress(GetParam()), nullptr};
+  Network::TcpListenSocket socket_{Network::Test::getAnyAddress(GetParam()), nullptr, true};
   Network::MockListenerCallbacks listener_callbacks_;
   Network::MockConnectionHandler connection_handler_;
   Network::ListenerPtr listener_;
@@ -850,7 +850,7 @@ TEST_P(ConnectionImplTest, BindFailureTest) {
         new Network::Address::Ipv6Instance(address_string, 0)};
   }
   dispatcher_ = std::make_unique<Event::DispatcherImpl>(time_system_);
-  listener_ = dispatcher_->createListener(socket_, listener_callbacks_, false);
+  listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
 
   client_connection_ = dispatcher_->createClientConnection(
       socket_.localAddress(), source_address_, Network::Test::createRawBufferSocket(), nullptr);
@@ -1493,7 +1493,7 @@ public:
   void readBufferLimitTest(uint32_t read_buffer_limit, uint32_t expected_chunk_size) {
     const uint32_t buffer_size = 256 * 1024;
     dispatcher_ = std::make_unique<Event::DispatcherImpl>(time_system_);
-    listener_ = dispatcher_->createListener(socket_, listener_callbacks_, false);
+    listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
 
     client_connection_ = dispatcher_->createClientConnection(
         socket_.localAddress(), Network::Address::InstanceConstSharedPtr(),

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -410,8 +410,8 @@ public:
     // Instantiate TestDnsServer and listen on a random port on the loopback address.
     server_ = std::make_unique<TestDnsServer>(dispatcher_);
     socket_ = std::make_unique<Network::TcpListenSocket>(
-        Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr);
-    listener_ = dispatcher_.createListener(*socket_, *server_, false);
+        Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
+    listener_ = dispatcher_.createListener(*socket_, *server_, true, false);
 
     // Point c-ares at the listener with no search domains and TCP-only.
     peer_ = std::make_unique<DnsResolverImplPeer>(dynamic_cast<DnsResolverImpl*>(resolver_.get()));

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -57,7 +57,7 @@ protected:
       options->emplace_back(std::move(option));
       std::unique_ptr<ListenSocketImpl> socket1;
       try {
-        socket1 = createListenSocketPtr(addr, options);
+        socket1 = createListenSocketPtr(addr, options, true);
       } catch (SocketBindException& e) {
         if (e.errorNumber() != EADDRINUSE) {
           ADD_FAILURE() << "Unexpected failure (" << e.errorNumber()
@@ -85,7 +85,7 @@ protected:
           .WillOnce(Return(true));
       options2->emplace_back(std::move(option2));
       // The address and port are bound already, should throw exception.
-      EXPECT_THROW(createListenSocketPtr(addr, options2), SocketBindException);
+      EXPECT_THROW(createListenSocketPtr(addr, options2, true), SocketBindException);
 
       // Test the case of a socket with fd and given address and port.
       auto socket3 = createListenSocketPtr(dup(socket1->fd()), addr, nullptr);
@@ -98,7 +98,7 @@ protected:
 
   void testBindPortZero() {
     auto loopback = Network::Test::getCanonicalLoopbackAddress(version_);
-    auto socket = createListenSocketPtr(loopback, nullptr);
+    auto socket = createListenSocketPtr(loopback, nullptr, true);
     EXPECT_EQ(Address::Type::Ip, socket->localAddress()->type());
     EXPECT_EQ(version_, socket->localAddress()->ip()->version());
     EXPECT_EQ(loopback->ip()->addressAsString(), socket->localAddress()->ip()->addressAsString());

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -26,10 +26,12 @@ static void errorCallbackTest(Address::IpVersion version) {
   DangerousDeprecatedTestTime test_time;
   Event::DispatcherImpl dispatcher(test_time.timeSystem());
 
-  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version), nullptr);
+  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version), nullptr,
+                                  true);
   Network::MockListenerCallbacks listener_callbacks;
   Network::MockConnectionHandler connection_handler;
-  Network::ListenerPtr listener = dispatcher.createListener(socket, listener_callbacks, false);
+  Network::ListenerPtr listener =
+      dispatcher.createListener(socket, listener_callbacks, true, false);
 
   Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
       socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
@@ -63,8 +65,9 @@ TEST_P(ListenerImplDeathTest, ErrorCallback) {
 class TestListenerImpl : public ListenerImpl {
 public:
   TestListenerImpl(Event::DispatcherImpl& dispatcher, Socket& socket, ListenerCallbacks& cb,
-                   bool hand_off_restored_destination_connections)
-      : ListenerImpl(dispatcher, socket, cb, hand_off_restored_destination_connections) {}
+                   bool bind_to_port, bool hand_off_restored_destination_connections)
+      : ListenerImpl(dispatcher, socket, cb, bind_to_port,
+                     hand_off_restored_destination_connections) {}
 
   MOCK_METHOD1(getLocalAddress, Address::InstanceConstSharedPtr(int fd));
 };
@@ -91,12 +94,13 @@ TEST_P(ListenerImplTest, SetListeningSocketOptionsSuccess) {
   Network::MockListenerCallbacks listener_callbacks;
   Network::MockConnectionHandler connection_handler;
 
-  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version_), nullptr);
+  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version_), nullptr,
+                                  true);
   std::shared_ptr<MockSocketOption> option = std::make_shared<MockSocketOption>();
   socket.addOption(option);
   EXPECT_CALL(*option, setOption(_, envoy::api::v2::core::SocketOption::STATE_LISTENING))
       .WillOnce(Return(true));
-  TestListenerImpl listener(dispatcher_, socket, listener_callbacks, false);
+  TestListenerImpl listener(dispatcher_, socket, listener_callbacks, true, false);
 }
 
 // Test that socket options are set after the listener is setup.
@@ -104,7 +108,8 @@ TEST_P(ListenerImplTest, UdpSetListeningSocketOptionsSuccess) {
   Network::MockListenerCallbacks listener_callbacks;
   Network::MockConnectionHandler connection_handler;
 
-  Network::UdpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version_), nullptr);
+  Network::UdpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version_), nullptr,
+                                  true);
   std::shared_ptr<MockSocketOption> option = std::make_shared<MockSocketOption>();
   socket.addOption(option);
 }
@@ -114,12 +119,13 @@ TEST_P(ListenerImplTest, SetListeningSocketOptionsError) {
   Network::MockListenerCallbacks listener_callbacks;
   Network::MockConnectionHandler connection_handler;
 
-  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version_), nullptr);
+  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version_), nullptr,
+                                  true);
   std::shared_ptr<MockSocketOption> option = std::make_shared<MockSocketOption>();
   socket.addOption(option);
   EXPECT_CALL(*option, setOption(_, envoy::api::v2::core::SocketOption::STATE_LISTENING))
       .WillOnce(Return(false));
-  EXPECT_THROW_WITH_MESSAGE(TestListenerImpl(dispatcher_, socket, listener_callbacks, false),
+  EXPECT_THROW_WITH_MESSAGE(TestListenerImpl(dispatcher_, socket, listener_callbacks, true, false),
                             CreateListenerException,
                             fmt::format("cannot set post-listen socket option on socket: {}",
                                         socket.localAddress()->asString()));
@@ -127,14 +133,15 @@ TEST_P(ListenerImplTest, SetListeningSocketOptionsError) {
 
 TEST_P(ListenerImplTest, UseActualDst) {
   Stats::IsolatedStoreImpl stats_store;
-  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version_), nullptr);
-  Network::TcpListenSocket socketDst(alt_address_, nullptr);
+  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version_), nullptr,
+                                  true);
+  Network::TcpListenSocket socketDst(alt_address_, nullptr, false);
   Network::MockListenerCallbacks listener_callbacks1;
   Network::MockConnectionHandler connection_handler;
   // Do not redirect since use_original_dst is false.
-  Network::TestListenerImpl listener(dispatcher_, socket, listener_callbacks1, true);
+  Network::TestListenerImpl listener(dispatcher_, socket, listener_callbacks1, true, true);
   Network::MockListenerCallbacks listener_callbacks2;
-  Network::TestListenerImpl listenerDst(dispatcher_, socketDst, listener_callbacks2, false);
+  Network::TestListenerImpl listenerDst(dispatcher_, socketDst, listener_callbacks2, false, false);
 
   Network::ClientConnectionPtr client_connection = dispatcher_.createClientConnection(
       socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
@@ -163,11 +170,11 @@ TEST_P(ListenerImplTest, UseActualDst) {
 
 TEST_P(ListenerImplTest, WildcardListenerUseActualDst) {
   Stats::IsolatedStoreImpl stats_store;
-  Network::TcpListenSocket socket(Network::Test::getAnyAddress(version_), nullptr);
+  Network::TcpListenSocket socket(Network::Test::getAnyAddress(version_), nullptr, true);
   Network::MockListenerCallbacks listener_callbacks;
   Network::MockConnectionHandler connection_handler;
   // Do not redirect since use_original_dst is false.
-  Network::TestListenerImpl listener(dispatcher_, socket, listener_callbacks, true);
+  Network::TestListenerImpl listener(dispatcher_, socket, listener_callbacks, true, true);
 
   auto local_dst_address = Network::Utility::getAddressWithPort(
       *Network::Test::getCanonicalLoopbackAddress(version_), socket.localAddress()->ip()->port());
@@ -207,14 +214,14 @@ TEST_P(ListenerImplTest, WildcardListenerIpv4Compat) {
       .WillOnce(Return(true));
   options->emplace_back(std::move(option));
 
-  Network::TcpListenSocket socket(Network::Test::getAnyAddress(version_, true), options);
+  Network::TcpListenSocket socket(Network::Test::getAnyAddress(version_, true), options, true);
   Network::MockListenerCallbacks listener_callbacks;
   Network::MockConnectionHandler connection_handler;
 
   ASSERT_TRUE(socket.localAddress()->ip()->isAnyAddress());
 
   // Do not redirect since use_original_dst is false.
-  Network::TestListenerImpl listener(dispatcher_, socket, listener_callbacks, true);
+  Network::TestListenerImpl listener(dispatcher_, socket, listener_callbacks, true, true);
 
   auto listener_address = Network::Utility::getAddressWithPort(
       *Network::Test::getCanonicalLoopbackAddress(version_), socket.localAddress()->ip()->port());
@@ -250,9 +257,9 @@ TEST_P(ListenerImplTest, WildcardListenerIpv4Compat) {
 TEST_P(ListenerImplTest, DisableAndEnableListener) {
   testing::InSequence s1;
 
-  TcpListenSocket socket(Network::Test::getAnyAddress(version_), nullptr);
+  TcpListenSocket socket(Network::Test::getAnyAddress(version_), nullptr, true);
   MockListenerCallbacks listener_callbacks;
-  TestListenerImpl listener(dispatcher_, socket, listener_callbacks, true);
+  TestListenerImpl listener(dispatcher_, socket, listener_callbacks, true, true);
 
   // When listener is disabled, the timer should fire before any connection is accepted.
   listener.disable();

--- a/test/common/ssl/ssl_socket_test.cc
+++ b/test/common/ssl/ssl_socket_test.cc
@@ -75,10 +75,11 @@ void testUtil(const std::string& client_ctx_yaml, const std::string& server_ctx_
 
   DangerousDeprecatedTestTime test_time;
   Event::DispatcherImpl dispatcher(test_time.timeSystem());
-  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version), nullptr);
+  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version), nullptr,
+                                  true);
   Network::MockListenerCallbacks callbacks;
   Network::MockConnectionHandler connection_handler;
-  Network::ListenerPtr listener = dispatcher.createListener(socket, callbacks, false);
+  Network::ListenerPtr listener = dispatcher.createListener(socket, callbacks, true, false);
 
   envoy::api::v2::auth::UpstreamTlsContext client_tls_context;
   MessageUtil::loadFromYaml(TestEnvironment::substitute(client_ctx_yaml), client_tls_context);
@@ -196,10 +197,11 @@ const std::string testUtilV2(
 
   DangerousDeprecatedTestTime test_time;
   Event::DispatcherImpl dispatcher(test_time.timeSystem());
-  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version), nullptr);
+  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version), nullptr,
+                                  true);
   NiceMock<Network::MockListenerCallbacks> callbacks;
   Network::MockConnectionHandler connection_handler;
-  Network::ListenerPtr listener = dispatcher.createListener(socket, callbacks, false);
+  Network::ListenerPtr listener = dispatcher.createListener(socket, callbacks, true, false);
 
   auto client_cfg = std::make_unique<ClientContextConfigImpl>(client_ctx_proto, factory_context);
   Stats::IsolatedStoreImpl client_stats_store;
@@ -1643,10 +1645,11 @@ TEST_P(SslSocketTest, FlushCloseDuringHandshake) {
   Ssl::ServerSslSocketFactory server_ssl_socket_factory(
       std::move(server_cfg), manager, server_stats_store, std::vector<std::string>{});
 
-  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr);
+  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr,
+                                  true);
   Network::MockListenerCallbacks callbacks;
   Network::MockConnectionHandler connection_handler;
-  Network::ListenerPtr listener = dispatcher_->createListener(socket, callbacks, false);
+  Network::ListenerPtr listener = dispatcher_->createListener(socket, callbacks, true, false);
 
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
       socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
@@ -1703,10 +1706,12 @@ TEST_P(SslSocketTest, HalfClose) {
   Ssl::ServerSslSocketFactory server_ssl_socket_factory(
       std::move(server_cfg), manager, server_stats_store, std::vector<std::string>{});
 
-  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr);
+  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr,
+                                  true);
   Network::MockListenerCallbacks listener_callbacks;
   Network::MockConnectionHandler connection_handler;
-  Network::ListenerPtr listener = dispatcher_->createListener(socket, listener_callbacks, false);
+  Network::ListenerPtr listener =
+      dispatcher_->createListener(socket, listener_callbacks, true, false);
   std::shared_ptr<Network::MockReadFilter> server_read_filter(new Network::MockReadFilter());
   std::shared_ptr<Network::MockReadFilter> client_read_filter(new Network::MockReadFilter());
 
@@ -1791,10 +1796,11 @@ TEST_P(SslSocketTest, ClientAuthMultipleCAs) {
   Ssl::ServerSslSocketFactory server_ssl_socket_factory(
       std::move(server_cfg), manager, server_stats_store, std::vector<std::string>{});
 
-  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr);
+  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr,
+                                  true);
   Network::MockListenerCallbacks callbacks;
   Network::MockConnectionHandler connection_handler;
-  Network::ListenerPtr listener = dispatcher_->createListener(socket, callbacks, false);
+  Network::ListenerPtr listener = dispatcher_->createListener(socket, callbacks, true, false);
 
   const std::string client_ctx_yaml = R"EOF(
   common_tls_context:
@@ -1882,14 +1888,16 @@ void testTicketSessionResumption(const std::string& server_ctx_yaml1,
   Ssl::ServerSslSocketFactory server_ssl_socket_factory2(std::move(server_cfg2), manager,
                                                          server_stats_store, server_names2);
 
-  Network::TcpListenSocket socket1(Network::Test::getCanonicalLoopbackAddress(ip_version), nullptr);
-  Network::TcpListenSocket socket2(Network::Test::getCanonicalLoopbackAddress(ip_version), nullptr);
+  Network::TcpListenSocket socket1(Network::Test::getCanonicalLoopbackAddress(ip_version), nullptr,
+                                   true);
+  Network::TcpListenSocket socket2(Network::Test::getCanonicalLoopbackAddress(ip_version), nullptr,
+                                   true);
   NiceMock<Network::MockListenerCallbacks> callbacks;
   Network::MockConnectionHandler connection_handler;
   DangerousDeprecatedTestTime test_time;
   Event::DispatcherImpl dispatcher(test_time.timeSystem());
-  Network::ListenerPtr listener1 = dispatcher.createListener(socket1, callbacks, false);
-  Network::ListenerPtr listener2 = dispatcher.createListener(socket2, callbacks, false);
+  Network::ListenerPtr listener1 = dispatcher.createListener(socket1, callbacks, true, false);
+  Network::ListenerPtr listener2 = dispatcher.createListener(socket2, callbacks, true, false);
 
   envoy::api::v2::auth::UpstreamTlsContext client_tls_context;
   MessageUtil::loadFromYaml(TestEnvironment::substitute(client_ctx_yaml), client_tls_context);
@@ -2285,12 +2293,14 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
   Ssl::ServerSslSocketFactory server2_ssl_socket_factory(
       std::move(server2_cfg), manager, server_stats_store, std::vector<std::string>{});
 
-  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr);
-  Network::TcpListenSocket socket2(Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr);
+  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr,
+                                  true);
+  Network::TcpListenSocket socket2(Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr,
+                                   true);
   Network::MockListenerCallbacks callbacks;
   Network::MockConnectionHandler connection_handler;
-  Network::ListenerPtr listener = dispatcher_->createListener(socket, callbacks, false);
-  Network::ListenerPtr listener2 = dispatcher_->createListener(socket2, callbacks, false);
+  Network::ListenerPtr listener = dispatcher_->createListener(socket, callbacks, true, false);
+  Network::ListenerPtr listener2 = dispatcher_->createListener(socket2, callbacks, true, false);
   const std::string client_ctx_yaml = R"EOF(
   common_tls_context:
     tls_certificates:
@@ -2394,11 +2404,12 @@ void testClientSessionResumption(const std::string& server_ctx_yaml,
   ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager,
                                                    server_stats_store, std::vector<std::string>{});
 
-  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version), nullptr);
+  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(version), nullptr,
+                                  true);
   NiceMock<Network::MockListenerCallbacks> callbacks;
   Network::MockConnectionHandler connection_handler;
   Event::DispatcherImpl dispatcher(time_system);
-  Network::ListenerPtr listener = dispatcher.createListener(socket, callbacks, false);
+  Network::ListenerPtr listener = dispatcher.createListener(socket, callbacks, true, false);
 
   Network::ConnectionPtr server_connection;
   Network::MockConnectionCallbacks server_connection_callbacks;
@@ -2653,10 +2664,11 @@ TEST_P(SslSocketTest, SslError) {
   Ssl::ServerSslSocketFactory server_ssl_socket_factory(
       std::move(server_cfg), manager, server_stats_store, std::vector<std::string>{});
 
-  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr);
+  Network::TcpListenSocket socket(Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr,
+                                  true);
   Network::MockListenerCallbacks callbacks;
   Network::MockConnectionHandler connection_handler;
-  Network::ListenerPtr listener = dispatcher_->createListener(socket, callbacks, false);
+  Network::ListenerPtr listener = dispatcher_->createListener(socket, callbacks, true, false);
 
   Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
       socket.localAddress(), Network::Address::InstanceConstSharedPtr(),
@@ -3182,7 +3194,7 @@ public:
     server_ssl_socket_factory_ = std::make_unique<ServerSslSocketFactory>(
         std::move(server_cfg), *manager_, server_stats_store_, std::vector<std::string>{});
 
-    listener_ = dispatcher_->createListener(socket_, listener_callbacks_, false);
+    listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true, false);
 
     MessageUtil::loadFromYaml(TestEnvironment::substitute(client_ctx_yaml_), upstream_tls_context_);
     auto client_cfg =
@@ -3336,7 +3348,8 @@ public:
 
   Stats::IsolatedStoreImpl server_stats_store_;
   Stats::IsolatedStoreImpl client_stats_store_;
-  Network::TcpListenSocket socket_{Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr};
+  Network::TcpListenSocket socket_{Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr,
+                                   true};
   Network::MockListenerCallbacks listener_callbacks_;
   Network::MockConnectionHandler connection_handler_;
   const std::string server_ctx_yaml_ = R"EOF(

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -51,7 +51,7 @@ class ProxyProtocolTest : public testing::TestWithParam<Network::Address::IpVers
 public:
   ProxyProtocolTest()
       : dispatcher_(test_time_.timeSystem()),
-        socket_(Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr),
+        socket_(Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true),
         connection_handler_(new Server::ConnectionHandlerImpl(ENVOY_LOGGER(), dispatcher_)),
         name_("proxy"), filter_chain_(Network::Test::createEmptyFilterChainWithRawBufferSockets()) {
 
@@ -67,6 +67,7 @@ public:
   Network::FilterChainFactory& filterChainFactory() override { return factory_; }
   Network::Socket& socket() override { return socket_; }
   const Network::Socket& socket() const override { return socket_; }
+  bool bindToPort() override { return true; }
   bool handOffRestoredDestinationConnections() const override { return false; }
   uint32_t perConnectionBufferLimitBytes() const override { return 0; }
   std::chrono::milliseconds listenerFiltersTimeout() const override {
@@ -870,7 +871,7 @@ class WildcardProxyProtocolTest : public testing::TestWithParam<Network::Address
 public:
   WildcardProxyProtocolTest()
       : dispatcher_(test_time_.timeSystem()),
-        socket_(Network::Test::getAnyAddress(GetParam()), nullptr),
+        socket_(Network::Test::getAnyAddress(GetParam()), nullptr, true),
         local_dst_address_(Network::Utility::getAddressWithPort(
             *Network::Test::getCanonicalLoopbackAddress(GetParam()),
             socket_.localAddress()->ip()->port())),
@@ -895,6 +896,7 @@ public:
   Network::FilterChainFactory& filterChainFactory() override { return factory_; }
   Network::Socket& socket() override { return socket_; }
   const Network::Socket& socket() const override { return socket_; }
+  bool bindToPort() override { return true; }
   bool handOffRestoredDestinationConnections() const override { return false; }
   uint32_t perConnectionBufferLimitBytes() const override { return 0; }
   std::chrono::milliseconds listenerFiltersTimeout() const override {

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -346,7 +346,7 @@ static Network::SocketPtr makeTcpListenSocket(uint32_t port, Network::Address::I
   return Network::SocketPtr{new Network::TcpListenSocket(
       Network::Utility::parseInternetAddressAndPort(
           fmt::format("{}:{}", Network::Test::getAnyAddressUrlString(version), port)),
-      nullptr)};
+      nullptr, true)};
 }
 
 FakeUpstream::FakeUpstream(uint32_t port, FakeHttpConnection::Type type,

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -575,6 +575,7 @@ private:
     Network::FilterChainFactory& filterChainFactory() override { return parent_; }
     Network::Socket& socket() override { return *parent_.socket_; }
     const Network::Socket& socket() const override { return *parent_.socket_; }
+    bool bindToPort() override { return true; }
     bool handOffRestoredDestinationConnections() const override { return false; }
     uint32_t perConnectionBufferLimitBytes() const override { return 0; }
     std::chrono::milliseconds listenerFiltersTimeout() const override {

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -59,9 +59,10 @@ public:
   }
 
   Network::ListenerPtr createListener(Network::Socket& socket, Network::ListenerCallbacks& cb,
+                                      bool bind_to_port,
                                       bool hand_off_restored_destination_connections) override {
     return Network::ListenerPtr{
-        createListener_(socket, cb, hand_off_restored_destination_connections)};
+        createListener_(socket, cb, bind_to_port, hand_off_restored_destination_connections)};
   }
 
   Event::TimerPtr createTimer(Event::TimerCb cb) override {
@@ -96,8 +97,9 @@ public:
   MOCK_METHOD4(createFileEvent_,
                FileEvent*(int fd, FileReadyCb cb, FileTriggerType trigger, uint32_t events));
   MOCK_METHOD0(createFilesystemWatcher_, Filesystem::Watcher*());
-  MOCK_METHOD3(createListener_,
+  MOCK_METHOD4(createListener_,
                Network::Listener*(Network::Socket& socket, Network::ListenerCallbacks& cb,
+                                  bool bind_to_port,
                                   bool hand_off_restored_destination_connections));
   MOCK_METHOD1(createTimer_, Timer*(Event::TimerCb cb));
   MOCK_METHOD1(deferredDelete_, void(DeferredDeletable* to_delete));

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -250,6 +250,7 @@ public:
   MOCK_METHOD0(filterChainFactory, FilterChainFactory&());
   MOCK_METHOD0(socket, Socket&());
   MOCK_CONST_METHOD0(socket, const Socket&());
+  MOCK_METHOD0(bindToPort, bool());
   MOCK_CONST_METHOD0(handOffRestoredDestinationConnections, bool());
   MOCK_CONST_METHOD0(perConnectionBufferLimitBytes, uint32_t());
   MOCK_CONST_METHOD0(listenerFiltersTimeout, std::chrono::milliseconds());

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -83,16 +83,16 @@ MockOverloadManager::~MockOverloadManager() {}
 
 MockListenerComponentFactory::MockListenerComponentFactory()
     : socket_(std::make_shared<NiceMock<Network::MockListenSocket>>()) {
-  ON_CALL(*this, createListenSocket(_, _))
-      .WillByDefault(
-          Invoke([&](Network::Address::InstanceConstSharedPtr,
-                     const Network::Socket::OptionsSharedPtr& options) -> Network::SocketSharedPtr {
-            if (!Network::Socket::applyOptions(options, *socket_,
-                                               envoy::api::v2::core::SocketOption::STATE_PREBIND)) {
-              throw EnvoyException("MockListenerComponentFactory: Setting socket options failed");
-            }
-            return socket_;
-          }));
+  ON_CALL(*this, createListenSocket(_, _, _))
+      .WillByDefault(Invoke([&](Network::Address::InstanceConstSharedPtr,
+                                const Network::Socket::OptionsSharedPtr& options,
+                                bool) -> Network::SocketSharedPtr {
+        if (!Network::Socket::applyOptions(options, *socket_,
+                                           envoy::api::v2::core::SocketOption::STATE_PREBIND)) {
+          throw EnvoyException("MockListenerComponentFactory: Setting socket options failed");
+        }
+        return socket_;
+      }));
 }
 MockListenerComponentFactory::~MockListenerComponentFactory() {}
 

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -220,9 +220,10 @@ public:
                std::vector<Network::ListenerFilterFactoryCb>(
                    const Protobuf::RepeatedPtrField<envoy::api::v2::listener::ListenerFilter>&,
                    Configuration::ListenerFactoryContext& context));
-  MOCK_METHOD2(createListenSocket,
+  MOCK_METHOD3(createListenSocket,
                Network::SocketSharedPtr(Network::Address::InstanceConstSharedPtr address,
-                                        const Network::Socket::OptionsSharedPtr& options));
+                                        const Network::Socket::OptionsSharedPtr& options,
+                                        bool bind_to_port));
   MOCK_METHOD1(createDrainManager_, DrainManager*(envoy::api::v2::Listener::DrainType drain_type));
   MOCK_METHOD0(nextListenerTag, uint64_t());
 

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -33,10 +33,10 @@ public:
 
   class TestListener : public Network::ListenerConfig, public LinkedObject<TestListener> {
   public:
-    TestListener(ConnectionHandlerTest& parent, uint64_t tag,
+    TestListener(ConnectionHandlerTest& parent, uint64_t tag, bool bind_to_port,
                  bool hand_off_restored_destination_connections, const std::string& name,
                  std::chrono::milliseconds listener_filters_timeout)
-        : parent_(parent), tag_(tag),
+        : parent_(parent), tag_(tag), bind_to_port_(bind_to_port),
           hand_off_restored_destination_connections_(hand_off_restored_destination_connections),
           name_(name), listener_filters_timeout_(listener_filters_timeout) {}
 
@@ -45,6 +45,7 @@ public:
     Network::FilterChainFactory& filterChainFactory() override { return parent_.factory_; }
     Network::Socket& socket() override { return socket_; }
     const Network::Socket& socket() const override { return socket_; }
+    bool bindToPort() override { return bind_to_port_; }
     bool handOffRestoredDestinationConnections() const override {
       return hand_off_restored_destination_connections_;
     }
@@ -60,6 +61,7 @@ public:
     ConnectionHandlerTest& parent_;
     Network::MockListenSocket socket_;
     uint64_t tag_;
+    bool bind_to_port_;
     const bool hand_off_restored_destination_connections_;
     const std::string name_;
     const std::chrono::milliseconds listener_filters_timeout_;
@@ -68,10 +70,12 @@ public:
   typedef std::unique_ptr<TestListener> TestListenerPtr;
 
   TestListener* addListener(
-      uint64_t tag, bool hand_off_restored_destination_connections, const std::string& name,
+      uint64_t tag, bool bind_to_port, bool hand_off_restored_destination_connections,
+      const std::string& name,
       std::chrono::milliseconds listener_filters_timeout = std::chrono::milliseconds(15000)) {
-    TestListener* listener = new TestListener(*this, tag, hand_off_restored_destination_connections,
-                                              name, listener_filters_timeout);
+    TestListener* listener =
+        new TestListener(*this, tag, bind_to_port, hand_off_restored_destination_connections, name,
+                         listener_filters_timeout);
     listener->moveIntoListBack(TestListenerPtr{listener}, listeners_);
     return listener;
   }
@@ -90,13 +94,13 @@ TEST_F(ConnectionHandlerTest, RemoveListener) {
 
   Network::MockListener* listener = new NiceMock<Network::MockListener>();
   Network::ListenerCallbacks* listener_callbacks;
-  EXPECT_CALL(dispatcher_, createListener_(_, _, _))
-      .WillOnce(
-          Invoke([&](Network::Socket&, Network::ListenerCallbacks& cb, bool) -> Network::Listener* {
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, false))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
             listener_callbacks = &cb;
             return listener;
           }));
-  TestListener* test_listener = addListener(1, true, "test_listener");
+  TestListener* test_listener = addListener(1, true, false, "test_listener");
   EXPECT_CALL(test_listener->socket_, localAddress());
   handler_->addListener(*test_listener);
 
@@ -126,13 +130,13 @@ TEST_F(ConnectionHandlerTest, DisableListener) {
 
   Network::MockListener* listener = new NiceMock<Network::MockListener>();
   Network::ListenerCallbacks* listener_callbacks;
-  EXPECT_CALL(dispatcher_, createListener_(_, _, _))
-      .WillOnce(
-          Invoke([&](Network::Socket&, Network::ListenerCallbacks& cb, bool) -> Network::Listener* {
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, _))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
             listener_callbacks = &cb;
             return listener;
           }));
-  TestListener* test_listener = addListener(1, false, "test_listener");
+  TestListener* test_listener = addListener(1, false, false, "test_listener");
   EXPECT_CALL(test_listener->socket_, localAddress());
   handler_->addListener(*test_listener);
 
@@ -147,13 +151,13 @@ TEST_F(ConnectionHandlerTest, AddDisabledListener) {
 
   Network::MockListener* listener = new NiceMock<Network::MockListener>();
   Network::ListenerCallbacks* listener_callbacks;
-  EXPECT_CALL(dispatcher_, createListener_(_, _, _))
-      .WillOnce(
-          Invoke([&](Network::Socket&, Network::ListenerCallbacks& cb, bool) -> Network::Listener* {
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, _))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
             listener_callbacks = &cb;
             return listener;
           }));
-  TestListener* test_listener = addListener(1, false, "test_listener");
+  TestListener* test_listener = addListener(1, false, false, "test_listener");
 
   EXPECT_CALL(*listener, disable());
   EXPECT_CALL(test_listener->socket_, localAddress());
@@ -168,13 +172,13 @@ TEST_F(ConnectionHandlerTest, DestroyCloseConnections) {
 
   Network::MockListener* listener = new NiceMock<Network::MockListener>();
   Network::ListenerCallbacks* listener_callbacks;
-  EXPECT_CALL(dispatcher_, createListener_(_, _, _))
-      .WillOnce(
-          Invoke([&](Network::Socket&, Network::ListenerCallbacks& cb, bool) -> Network::Listener* {
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, _))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
             listener_callbacks = &cb;
             return listener;
           }));
-  TestListener* test_listener = addListener(1, false, "test_listener");
+  TestListener* test_listener = addListener(1, true, false, "test_listener");
   EXPECT_CALL(test_listener->socket_, localAddress());
   handler_->addListener(*test_listener);
 
@@ -193,13 +197,13 @@ TEST_F(ConnectionHandlerTest, CloseDuringFilterChainCreate) {
 
   Network::MockListener* listener = new Network::MockListener();
   Network::ListenerCallbacks* listener_callbacks;
-  EXPECT_CALL(dispatcher_, createListener_(_, _, _))
-      .WillOnce(
-          Invoke([&](Network::Socket&, Network::ListenerCallbacks& cb, bool) -> Network::Listener* {
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, _))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
             listener_callbacks = &cb;
             return listener;
           }));
-  TestListener* test_listener = addListener(1, true, "test_listener");
+  TestListener* test_listener = addListener(1, true, false, "test_listener");
   EXPECT_CALL(test_listener->socket_, localAddress());
   handler_->addListener(*test_listener);
 
@@ -221,13 +225,13 @@ TEST_F(ConnectionHandlerTest, CloseConnectionOnEmptyFilterChain) {
 
   Network::MockListener* listener = new Network::MockListener();
   Network::ListenerCallbacks* listener_callbacks;
-  EXPECT_CALL(dispatcher_, createListener_(_, _, _))
-      .WillOnce(
-          Invoke([&](Network::Socket&, Network::ListenerCallbacks& cb, bool) -> Network::Listener* {
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, _))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
             listener_callbacks = &cb;
             return listener;
           }));
-  TestListener* test_listener = addListener(1, false, "test_listener");
+  TestListener* test_listener = addListener(1, true, false, "test_listener");
   EXPECT_CALL(test_listener->socket_, localAddress());
   handler_->addListener(*test_listener);
 
@@ -245,28 +249,28 @@ TEST_F(ConnectionHandlerTest, CloseConnectionOnEmptyFilterChain) {
 }
 
 TEST_F(ConnectionHandlerTest, FindListenerByAddress) {
-  TestListener* test_listener1 = addListener(1, true, "test_listener1");
+  TestListener* test_listener1 = addListener(1, true, true, "test_listener1");
   Network::Address::InstanceConstSharedPtr alt_address(
       new Network::Address::Ipv4Instance("127.0.0.1", 10001));
 
   Network::MockListener* listener = new Network::MockListener();
-  EXPECT_CALL(dispatcher_, createListener_(_, _, _))
-      .WillOnce(Invoke([&](Network::Socket&, Network::ListenerCallbacks&,
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, true))
+      .WillOnce(Invoke([&](Network::Socket&, Network::ListenerCallbacks&, bool,
                            bool) -> Network::Listener* { return listener; }));
   EXPECT_CALL(test_listener1->socket_, localAddress()).WillRepeatedly(ReturnRef(alt_address));
   handler_->addListener(*test_listener1);
 
   EXPECT_EQ(listener, handler_->findListenerByAddress(ByRef(*alt_address)));
 
-  TestListener* test_listener2 = addListener(2, false, "test_listener2");
+  TestListener* test_listener2 = addListener(2, true, false, "test_listener2");
   Network::Address::InstanceConstSharedPtr alt_address2(
       new Network::Address::Ipv4Instance("0.0.0.0", 10001));
   Network::Address::InstanceConstSharedPtr alt_address3(
       new Network::Address::Ipv4Instance("127.0.0.2", 10001));
 
   Network::MockListener* listener2 = new Network::MockListener();
-  EXPECT_CALL(dispatcher_, createListener_(_, _, _))
-      .WillOnce(Invoke([&](Network::Socket&, Network::ListenerCallbacks&,
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, false))
+      .WillOnce(Invoke([&](Network::Socket&, Network::ListenerCallbacks&, bool,
                            bool) -> Network::Listener* { return listener2; }));
   EXPECT_CALL(test_listener2->socket_, localAddress()).WillRepeatedly(ReturnRef(alt_address2));
   handler_->addListener(*test_listener2);
@@ -283,8 +287,8 @@ TEST_F(ConnectionHandlerTest, FindListenerByAddress) {
   handler_->stopListeners(2);
 
   Network::MockListener* listener3 = new Network::MockListener();
-  EXPECT_CALL(dispatcher_, createListener_(_, _, _))
-      .WillOnce(Invoke([&](Network::Socket&, Network::ListenerCallbacks&,
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, _))
+      .WillOnce(Invoke([&](Network::Socket&, Network::ListenerCallbacks&, bool,
                            bool) -> Network::Listener* { return listener3; }));
   handler_->addListener(*test_listener2);
 
@@ -295,12 +299,12 @@ TEST_F(ConnectionHandlerTest, FindListenerByAddress) {
 }
 
 TEST_F(ConnectionHandlerTest, NormalRedirect) {
-  TestListener* test_listener1 = addListener(1, true, "test_listener1");
+  TestListener* test_listener1 = addListener(1, true, true, "test_listener1");
   Network::MockListener* listener1 = new Network::MockListener();
   Network::ListenerCallbacks* listener_callbacks1;
-  EXPECT_CALL(dispatcher_, createListener_(_, _, _))
-      .WillOnce(
-          Invoke([&](Network::Socket&, Network::ListenerCallbacks& cb, bool) -> Network::Listener* {
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, true))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
             listener_callbacks1 = &cb;
             return listener1;
           }));
@@ -309,12 +313,12 @@ TEST_F(ConnectionHandlerTest, NormalRedirect) {
   EXPECT_CALL(test_listener1->socket_, localAddress()).WillRepeatedly(ReturnRef(normal_address));
   handler_->addListener(*test_listener1);
 
-  TestListener* test_listener2 = addListener(1, false, "test_listener2");
+  TestListener* test_listener2 = addListener(1, false, false, "test_listener2");
   Network::MockListener* listener2 = new Network::MockListener();
   Network::ListenerCallbacks* listener_callbacks2;
-  EXPECT_CALL(dispatcher_, createListener_(_, _, _))
-      .WillOnce(
-          Invoke([&](Network::Socket&, Network::ListenerCallbacks& cb, bool) -> Network::Listener* {
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, false))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
             listener_callbacks2 = &cb;
             return listener2;
           }));
@@ -355,12 +359,12 @@ TEST_F(ConnectionHandlerTest, NormalRedirect) {
 }
 
 TEST_F(ConnectionHandlerTest, FallbackToWildcardListener) {
-  TestListener* test_listener1 = addListener(1, true, "test_listener1");
+  TestListener* test_listener1 = addListener(1, true, true, "test_listener1");
   Network::MockListener* listener1 = new Network::MockListener();
   Network::ListenerCallbacks* listener_callbacks1;
-  EXPECT_CALL(dispatcher_, createListener_(_, _, _))
-      .WillOnce(
-          Invoke([&](Network::Socket&, Network::ListenerCallbacks& cb, bool) -> Network::Listener* {
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, true))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
             listener_callbacks1 = &cb;
             return listener1;
           }));
@@ -369,12 +373,12 @@ TEST_F(ConnectionHandlerTest, FallbackToWildcardListener) {
   EXPECT_CALL(test_listener1->socket_, localAddress()).WillRepeatedly(ReturnRef(normal_address));
   handler_->addListener(*test_listener1);
 
-  TestListener* test_listener2 = addListener(1, false, "test_listener2");
+  TestListener* test_listener2 = addListener(1, false, false, "test_listener2");
   Network::MockListener* listener2 = new Network::MockListener();
   Network::ListenerCallbacks* listener_callbacks2;
-  EXPECT_CALL(dispatcher_, createListener_(_, _, _))
-      .WillOnce(
-          Invoke([&](Network::Socket&, Network::ListenerCallbacks& cb, bool) -> Network::Listener* {
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, false))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
             listener_callbacks2 = &cb;
             return listener2;
           }));
@@ -417,12 +421,12 @@ TEST_F(ConnectionHandlerTest, FallbackToWildcardListener) {
 }
 
 TEST_F(ConnectionHandlerTest, WildcardListenerWithOriginalDst) {
-  TestListener* test_listener1 = addListener(1, true, "test_listener1");
+  TestListener* test_listener1 = addListener(1, true, true, "test_listener1");
   Network::MockListener* listener1 = new Network::MockListener();
   Network::ListenerCallbacks* listener_callbacks1;
-  EXPECT_CALL(dispatcher_, createListener_(_, _, _))
-      .WillOnce(
-          Invoke([&](Network::Socket&, Network::ListenerCallbacks& cb, bool) -> Network::Listener* {
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, true))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
             listener_callbacks1 = &cb;
             return listener1;
           }));
@@ -463,12 +467,12 @@ TEST_F(ConnectionHandlerTest, WildcardListenerWithOriginalDst) {
 }
 
 TEST_F(ConnectionHandlerTest, WildcardListenerWithNoOriginalDst) {
-  TestListener* test_listener1 = addListener(1, true, "test_listener1");
+  TestListener* test_listener1 = addListener(1, true, true, "test_listener1");
   Network::MockListener* listener1 = new Network::MockListener();
   Network::ListenerCallbacks* listener_callbacks1;
-  EXPECT_CALL(dispatcher_, createListener_(_, _, _))
-      .WillOnce(
-          Invoke([&](Network::Socket&, Network::ListenerCallbacks& cb, bool) -> Network::Listener* {
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, true))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
             listener_callbacks1 = &cb;
             return listener1;
           }));
@@ -501,12 +505,12 @@ TEST_F(ConnectionHandlerTest, WildcardListenerWithNoOriginalDst) {
 }
 
 TEST_F(ConnectionHandlerTest, TransportProtocolDefault) {
-  TestListener* test_listener = addListener(1, true, "test_listener");
+  TestListener* test_listener = addListener(1, true, false, "test_listener");
   Network::MockListener* listener = new Network::MockListener();
   Network::ListenerCallbacks* listener_callbacks;
-  EXPECT_CALL(dispatcher_, createListener_(_, _, _))
-      .WillOnce(
-          Invoke([&](Network::Socket&, Network::ListenerCallbacks& cb, bool) -> Network::Listener* {
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, false))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
             listener_callbacks = &cb;
             return listener;
           }));
@@ -524,12 +528,12 @@ TEST_F(ConnectionHandlerTest, TransportProtocolDefault) {
 }
 
 TEST_F(ConnectionHandlerTest, TransportProtocolCustom) {
-  TestListener* test_listener = addListener(1, true, "test_listener");
+  TestListener* test_listener = addListener(1, true, false, "test_listener");
   Network::MockListener* listener = new Network::MockListener();
   Network::ListenerCallbacks* listener_callbacks;
-  EXPECT_CALL(dispatcher_, createListener_(_, _, _))
-      .WillOnce(
-          Invoke([&](Network::Socket&, Network::ListenerCallbacks& cb, bool) -> Network::Listener* {
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, false))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
             listener_callbacks = &cb;
             return listener;
           }));
@@ -561,12 +565,12 @@ TEST_F(ConnectionHandlerTest, TransportProtocolCustom) {
 TEST_F(ConnectionHandlerTest, ListenerFilterTimeout) {
   InSequence s;
 
-  TestListener* test_listener = addListener(1, false, "test_listener");
+  TestListener* test_listener = addListener(1, true, false, "test_listener");
   Network::MockListener* listener = new Network::MockListener();
   Network::ListenerCallbacks* listener_callbacks;
-  EXPECT_CALL(dispatcher_, createListener_(_, _, false))
-      .WillOnce(
-          Invoke([&](Network::Socket&, Network::ListenerCallbacks& cb, bool) -> Network::Listener* {
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, false))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
             listener_callbacks = &cb;
             return listener;
           }));
@@ -602,12 +606,12 @@ TEST_F(ConnectionHandlerTest, ListenerFilterTimeout) {
 TEST_F(ConnectionHandlerTest, ListenerFilterTimeoutResetOnSuccess) {
   InSequence s;
 
-  TestListener* test_listener = addListener(1, false, "test_listener");
+  TestListener* test_listener = addListener(1, true, false, "test_listener");
   Network::MockListener* listener = new Network::MockListener();
   Network::ListenerCallbacks* listener_callbacks;
-  EXPECT_CALL(dispatcher_, createListener_(_, _, false))
-      .WillOnce(
-          Invoke([&](Network::Socket&, Network::ListenerCallbacks& cb, bool) -> Network::Listener* {
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, false))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
             listener_callbacks = &cb;
             return listener;
           }));
@@ -642,12 +646,13 @@ TEST_F(ConnectionHandlerTest, ListenerFilterTimeoutResetOnSuccess) {
 TEST_F(ConnectionHandlerTest, ListenerFilterDisabledTimeout) {
   InSequence s;
 
-  TestListener* test_listener = addListener(1, false, "test_listener", std::chrono::milliseconds());
+  TestListener* test_listener =
+      addListener(1, true, false, "test_listener", std::chrono::milliseconds());
   Network::MockListener* listener = new Network::MockListener();
   Network::ListenerCallbacks* listener_callbacks;
-  EXPECT_CALL(dispatcher_, createListener_(_, _, false))
-      .WillOnce(
-          Invoke([&](Network::Socket&, Network::ListenerCallbacks& cb, bool) -> Network::Listener* {
+  EXPECT_CALL(dispatcher_, createListener_(_, _, _, false))
+      .WillOnce(Invoke(
+          [&](Network::Socket&, Network::ListenerCallbacks& cb, bool, bool) -> Network::Listener* {
             listener_callbacks = &cb;
             return listener;
           }));


### PR DESCRIPTION
This reverts commit 36db7761cc963a7790eb31eb7bccd7cfb248146c.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>