### PR TITLE
Move buffered data to a temp buffer in ActiveStreamFilterBase::doData()

### DIFF
--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -161,7 +161,8 @@ private:
       parent_.decodeHeaders(this, *parent_.request_headers_, end_stream);
     }
     void doData(bool end_stream) override {
-      parent_.decodeData(this, *parent_.buffered_request_data_, end_stream);
+      Buffer::WatermarkBufferPtr data(std::move(parent_.buffered_request_data_));
+      parent_.decodeData(this, *data, end_stream);
     }
     void doTrailers() override { parent_.decodeTrailers(this, *parent_.request_trailers_); }
     const HeaderMapPtr& trailers() override { return parent_.request_trailers_; }
@@ -232,7 +233,8 @@ private:
       parent_.encodeHeaders(this, *parent_.response_headers_, end_stream);
     }
     void doData(bool end_stream) override {
-      parent_.encodeData(this, *parent_.buffered_response_data_, end_stream);
+      Buffer::WatermarkBufferPtr data(std::move(parent_.buffered_response_data_));
+      parent_.encodeData(this, *data, end_stream);
     }
     void doTrailers() override { parent_.encodeTrailers(this, *parent_.response_trailers_); }
     const HeaderMapPtr& trailers() override { return parent_.response_trailers_; }


### PR DESCRIPTION

This is another attemp to fix https://github.com/envoyproxy/envoy/issues/5311

There is only one buffer for a stream.  Any filters can add data to this buffer.  We lost the info of who adds the data to the buffer.  

Specifically,  If commonContinue() is called nestly,  the inner call should have consumed the buffered data,  but outer layer doesn't know, it continue to call decodeData().

The fix is to move the buffer to a temp buffer in the doData() call and clear the buffer.

The side effect of this change:  temporarily there are two buffers, buffer water mark may break.
