### PR TITLE
build: fix build of BoringSSL FIPS when $GOROOT is set.

### DIFF
--- a/ci/build_container/build_recipes/boringssl_fips.sh
+++ b/ci/build_container/build_recipes/boringssl_fips.sh
@@ -54,7 +54,8 @@ curl -sLO https://dl.google.com/go/go"$VERSION"."$PLATFORM".tar.gz \
   && echo "$SHA256" go"$VERSION"."$PLATFORM".tar.gz | sha256sum --check
 tar xf go"$VERSION"."$PLATFORM".tar.gz
 
-export PATH="$PWD/go/bin:$PATH"
+export GOROOT="$PWD/go"
+export PATH="$GOROOT/bin:$PATH"
 
 if [[ `go version | awk '{print $3}'` != "go$VERSION" ]]; then
   echo "ERROR: Go version doesn't match."


### PR DESCRIPTION
The Go binary downloaded by the boringssl_fips.sh script is used when
generating BoringSSL FIPS data, but previously, if $GOROOT was set in
the environment, it would override location of the Go library, leading
to a mismatch between the two.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>