### PR TITLE
tracers: bugfix for datadog tracer

### DIFF
--- a/source/extensions/tracers/datadog/datadog_tracer_impl.cc
+++ b/source/extensions/tracers/datadog/datadog_tracer_impl.cc
@@ -71,7 +71,12 @@ TraceReporter::TraceReporter(TraceEncoderSharedPtr encoder, Driver& driver,
   enableTimer();
 }
 
-void TraceReporter::enableTimer() { flush_timer_->enableTimer(std::chrono::milliseconds(1000U)); }
+void TraceReporter::enableTimer() {
+  // The duration for this timer should not be a factor of the
+  // datadog-agent's read timer of 5000ms.
+  // Further details in https://github.com/envoyproxy/envoy/pull/5358
+  flush_timer_->enableTimer(std::chrono::milliseconds(900U));
+}
 
 void TraceReporter::flushTraces() {
   auto pendingTraces = encoder_->pendingTraces();
@@ -110,6 +115,7 @@ void TraceReporter::onFailure(Http::AsyncClient::FailureReason) {
 void TraceReporter::onSuccess(Http::MessagePtr&& http_response) {
   uint64_t responseStatus = Http::Utility::getResponseStatus(http_response->headers());
   if (responseStatus != enumToInt(Http::Code::OK)) {
+    // TODO: Consider adding retries for failed submissions.
     ENVOY_LOG(debug, "unexpected HTTP response code from datadog agent: {}", responseStatus);
     driver_.tracerStats().reports_dropped_.inc();
   } else {

--- a/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
+++ b/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
@@ -46,7 +46,7 @@ public:
 
     if (init_timer) {
       timer_ = new NiceMock<Event::MockTimer>(&tls_.dispatcher_);
-      EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1000)));
+      EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(900)));
     }
 
     driver_ = std::make_unique<Driver>(datadog_config, cm_, stats_, tls_, runtime_);
@@ -143,7 +143,7 @@ TEST_F(DatadogDriverTest, FlushSpansTimer) {
   span->finishSpan();
 
   // Timer should be re-enabled.
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1000)));
+  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(900)));
 
   timer_->callback_();
 


### PR DESCRIPTION
*Description*:
A user reported directly that their metrics had regular `response_code_class:5` coming from the tracer sending data to an agent that collects them.
These were found to be 503s from sending on a half-closed connection.

Normally that would be incredibly rare and unlikely. But with the upstream having a 5000ms timer and the tracer flushing on an exact multiple of it, it essentially forces that race condition to get hit.

This PR makes sure the timers don't align.

*Risk Level*: Low
*Testing*: Unit tests, E2E
*Docs Changes*: N/A
*Release Notes*: N/A
