### PR TITLE
Use a CountWatcher class to detect if buffer data has been consumed.

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1473,7 +1473,8 @@ void ConnectionManagerImpl::ActiveStreamFilterBase::commonContinue() {
 
   // TODO(mattklein123): If a filter returns StopIterationNoBuffer and then does a continue, we
   // won't be able to end the stream if there is no buffered data. Need to handle this.
-  if (bufferedData()) {
+  if (bufferedData() && bufferedData()->hasNewData()) {
+    Buffer::WatermarkBuffer::ConsumeAddOpertions marker(*bufferedData());
     doData(complete() && !trailers());
   }
 
@@ -1534,6 +1535,7 @@ void ConnectionManagerImpl::ActiveStreamFilterBase::commonHandleBufferData(
     }
     bufferedData()->move(provided_data);
   }
+  bufferedData()->incAddOperations();
 }
 
 bool ConnectionManagerImpl::ActiveStreamFilterBase::commonHandleAfterDataCallback(

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -3145,9 +3145,9 @@ TEST_F(HttpConnectionManagerImplTest, AddDataWithAllContinue) {
       }));
 
   EXPECT_CALL(*decoder_filters_[2], decodeHeaders(_, false))
-      .WillOnce(Return(FilterHeadersStatus::StopIteration));
+      .WillOnce(Return(FilterHeadersStatus::Continue));
   EXPECT_CALL(*decoder_filters_[2], decodeData(_, true))
-      .WillOnce(Return(FilterDataStatus::StopIterationAndBuffer));
+      .WillOnce(Return(FilterDataStatus::Continue));
 
   EXPECT_CALL(*decoder_filters_[0], decodeData(_, true)).Times(0);
   EXPECT_CALL(*decoder_filters_[1], decodeData(_, true)).Times(0);
@@ -3185,10 +3185,10 @@ TEST_F(HttpConnectionManagerImplTest, AddDataWithContinueDecoding) {
       }));
 
   EXPECT_CALL(*decoder_filters_[2], decodeHeaders(_, false))
-      .WillOnce(Return(FilterHeadersStatus::StopIteration));
+      .WillOnce(Return(FilterHeadersStatus::Continue));
   // This fail, it is called twice.
   EXPECT_CALL(*decoder_filters_[2], decodeData(_, true))
-      .WillOnce(Return(FilterDataStatus::StopIterationAndBuffer));
+      .WillOnce(Return(FilterDataStatus::Continue));
 
   EXPECT_CALL(*decoder_filters_[0], decodeData(_, true)).Times(0);
   // This fail, it is called once


### PR DESCRIPTION
This is the third attempt to fix #5311

Added a way to detect if the buffer is updated during doData() call.  Next doData() will use it only if it is updated, 
