### PR TITLE
docs: tls inspector filter docs

### DIFF
--- a/docs/root/configuration/listener_filters/tls_inspector.rst
+++ b/docs/root/configuration/listener_filters/tls_inspector.rst
@@ -17,3 +17,34 @@ of a :ref:`FilterChainMatch <envoy_api_msg_listener.FilterChainMatch>`.
 * :ref:`SNI <faq_how_to_setup_sni>`
 * :ref:`v2 API reference <envoy_api_field_listener.ListenerFilter.name>`
 * This filter should be configured with the name *envoy.listener.tls_inspector*.
+
+Example
+-------
+
+A sample filter configuration could be:
+
+.. code-block:: yaml
+
+  listener_filters:
+    - name: "envoy.listener.tls_inspector"
+      config: {}
+
+Statistics
+----------
+
+This filter has statistics rooted at *tls_inspector* with the following statistics: 
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: 1, 1, 2
+
+  connection_closed, Counter, Total connections closed
+  client_hello_too_large, Counter, Total unreasonably large Client Hello received
+  read_error, Counter, Total read errors
+  tls_found, Counter, Total number of times TLS was found
+  tls_not_found, Counter, Total number of times TLS was not found
+  alpn_found, Counter, Total number of times `Application-Layer Protocol Negotiation <https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation>`_ was successful
+  alpn_not_found, Counter, Total number of times `Application-Layer Protocol Negotiation <https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation>`_ has failed
+  sni_found, Counter, Total number of times `Server Name Indication <https://en.wikipedia.org/wiki/Server_Name_Indication>`_ was found
+  sni_not_found, Counter, Total number of times `Server Name Indication <https://en.wikipedia.org/wiki/Server_Name_Indication>`_ was not found
+


### PR DESCRIPTION
*Description*: While configuring `tls_inspector_filter` ran in to some issues and wanted to look at stats. Realized that the stats are not documented for this filter. This PR documents the stats for `tls_inspector` filter.
*Risk Level*: Low
*Testing*: N/A
*Docs Changes*: N/A
*Release Notes*: N/A

