### PR TITLE
utility: Fix address comparisons in isLocalConnection(), add tests.

### DIFF
--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -251,11 +251,7 @@ bool Utility::isLocalConnection(const Network::ConnectionSocket& socket) {
   // performance optimization.
   if (remote_address->type() != Envoy::Network::Address::Type::Ip ||
       isLoopbackAddress(*remote_address) ||
-      (remote_address->ip()->version() == Address::IpVersion::v4
-           ? remote_address->ip()->ipv4()->address() ==
-                 socket.localAddress()->ip()->ipv4()->address()
-           : remote_address->ip()->ipv6()->address() ==
-                 socket.localAddress()->ip()->ipv6()->address())) {
+      isSameIPAddress(*remote_address, *socket.localAddress())) {
     return true;
   }
 
@@ -341,6 +337,21 @@ bool Utility::isLoopbackAddress(const Address::Instance& address) {
                   "sizeof(absl::uint128) != sizeof(in6addr_loopback)");
     absl::uint128 addr = address.ip()->ipv6()->address();
     return 0 == memcmp(&addr, &in6addr_loopback, sizeof(in6addr_loopback));
+  }
+  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+}
+
+bool Utility::isSameIPAddress(const Address::Instance& address1,
+                              const Address::Instance& address2) {
+  if (address1.type() != Address::Type::Ip ||
+      address1.ip()->version() != address2.ip()->version()) {
+    return false;
+  }
+
+  if (address1.ip()->version() == Address::IpVersion::v4) {
+    return address1.ip()->ipv4()->address() == address2.ip()->ipv4()->address();
+  } else if (address1.ip()->version() == Address::IpVersion::v6) {
+    return address1.ip()->ipv6()->address() == address2.ip()->ipv6()->address();
   }
   NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
 }

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -280,6 +280,8 @@ bool Utility::isLocalConnection(const Network::ConnectionSocket& socket) {
         }
       } else {
         const auto* if_addr = reinterpret_cast<const struct sockaddr_in6*>(ifa->ifa_addr);
+        static_assert(sizeof(absl::uint128) == sizeof(if_addr->sin6_addr.s6_addr),
+                      "sizeof(absl::uint128) != sizeof(if_addr->sin6_addr.s6_addr)");
         const absl::uint128 remote_v6addr = remote_address->ip()->ipv6()->address();
         if (memcmp(&remote_v6addr, &if_addr->sin6_addr.s6_addr, sizeof(absl::uint128)) == 0) {
           return true;
@@ -343,8 +345,8 @@ bool Utility::isLoopbackAddress(const Address::Instance& address) {
 
 bool Utility::isSameIPAddress(const Address::Instance& address1,
                               const Address::Instance& address2) {
-  ASSERT(address1.type() == Address::Type::Ip);
-  if (address1.ip()->version() != address2.ip()->version()) {
+  if (address1.ip() == nullptr || address2.ip() == nullptr ||
+      address1.ip()->version() != address2.ip()->version()) {
     return false;
   }
 

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -250,8 +250,8 @@ bool Utility::isLocalConnection(const Network::ConnectionSocket& socket) {
   // connection. However, this is a rare exception and such assumption results in big
   // performance optimization.
   if (remote_address->type() != Envoy::Network::Address::Type::Ip ||
-      isLoopbackAddress(*remote_address) ||
-      isSameIPAddress(*remote_address, *socket.localAddress())) {
+      isSameIPAddress(*remote_address, *socket.localAddress()) ||
+      isLoopbackAddress(*remote_address)) {
     return true;
   }
 

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -274,14 +274,14 @@ bool Utility::isLocalConnection(const Network::ConnectionSocket& socket) {
 
     if (ifa->ifa_addr->sa_family == af_look_up) {
       if (af_look_up == AF_INET) {
-        const auto* addr = reinterpret_cast<const struct sockaddr_in*>(ifa->ifa_addr);
-        if (remote_address->ip()->ipv4()->address() == addr->sin_addr.s_addr) {
+        const auto* if_addr = reinterpret_cast<const struct sockaddr_in*>(ifa->ifa_addr);
+        if (remote_address->ip()->ipv4()->address() == if_addr->sin_addr.s_addr) {
           return true;
         }
       } else {
-        const auto* addr = reinterpret_cast<const struct sockaddr_in6*>(ifa->ifa_addr);
-        absl::uint128 v6addr = remote_address->ip()->ipv6()->address();
-        if (memcmp(&v6addr, &addr->sin6_addr.s6_addr, sizeof(absl::uint128)) == 0) {
+        const auto* if_addr = reinterpret_cast<const struct sockaddr_in6*>(ifa->ifa_addr);
+        const absl::uint128 remote_v6addr = remote_address->ip()->ipv6()->address();
+        if (memcmp(&remote_v6addr, &if_addr->sin6_addr.s6_addr, sizeof(absl::uint128)) == 0) {
           return true;
         }
       }
@@ -343,14 +343,15 @@ bool Utility::isLoopbackAddress(const Address::Instance& address) {
 
 bool Utility::isSameIPAddress(const Address::Instance& address1,
                               const Address::Instance& address2) {
-  if (address1.type() != Address::Type::Ip ||
-      address1.ip()->version() != address2.ip()->version()) {
+  ASSERT(address1.type() == Address::Type::Ip);
+  if (address1.ip()->version() != address2.ip()->version()) {
     return false;
   }
 
-  if (address1.ip()->version() == Address::IpVersion::v4) {
+  switch (address1.ip()->version()) {
+  case Address::IpVersion::v4:
     return address1.ip()->ipv4()->address() == address2.ip()->ipv4()->address();
-  } else if (address1.ip()->version() == Address::IpVersion::v6) {
+  case Address::IpVersion::v6:
     return address1.ip()->ipv6()->address() == address2.ip()->ipv6()->address();
   }
   NOT_IMPLEMENTED_GCOVR_EXCL_LINE;

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -250,7 +250,7 @@ bool Utility::isLocalConnection(const Network::ConnectionSocket& socket) {
   // connection. However, this is a rare exception and such assumption results in big
   // performance optimization.
   if (remote_address->type() == Envoy::Network::Address::Type::Pipe ||
-      remote_address == socket.localAddress() || isLoopbackAddress(*remote_address)) {
+      *remote_address == *socket.localAddress() || isLoopbackAddress(*remote_address)) {
     return true;
   }
 
@@ -276,7 +276,7 @@ bool Utility::isLocalConnection(const Network::ConnectionSocket& socket) {
       auto local_address = Address::addressFromSockAddr(
           *addr, (af_look_up == AF_INET) ? sizeof(sockaddr_in) : sizeof(sockaddr_in6));
 
-      if (remote_address == local_address) {
+      if (*remote_address == *local_address) {
         return true;
       }
     }

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -153,6 +153,14 @@ public:
   static bool isLoopbackAddress(const Address::Instance& address);
 
   /**
+   * Check if the addresses are the same IP address.
+   * @param address1 IP address to check.
+   * @param address2 IP address to check.
+   * @return true if so, otherwise false
+   */
+  static bool isSameIPAddress(const Address::Instance& address1, const Address::Instance& address2);
+
+  /**
    * @return Address::InstanceConstSharedPtr an address that represents the canonical IPv4 loopback
    *         address (i.e. "127.0.0.1"). Note that the range "127.0.0.0/8" is all defined as the
    *         loopback range, but the address typically used (e.g. in tests) is "127.0.0.1".

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -212,6 +212,24 @@ TEST(NetworkUtility, LocalConnection) {
   local_addr.reset(new Network::Address::Ipv6Instance("fabc::42"));
   remote_addr.reset(new Network::Address::Ipv6Instance("fabc::42"));
   EXPECT_TRUE(Utility::isLocalConnection(socket));
+
+  local_addr.reset(new Network::Address::Ipv4Instance("4.4.4.4", 80));
+  remote_addr.reset(new Network::Address::Ipv4Instance("4.4.4.4", 23413));
+  EXPECT_TRUE(Utility::isLocalConnection(socket));
+
+  local_addr.reset(new Network::Address::Ipv6Instance("fabc::42", 80));
+  remote_addr.reset(new Network::Address::Ipv6Instance("fabc::42", 23413));
+  EXPECT_TRUE(Utility::isLocalConnection(socket));
+
+  local_addr.reset(new Network::Address::Ipv4Instance("4.4.4.4", 80));
+  remote_addr.reset(new Network::Address::Ipv4Instance(
+      Utility::getLocalAddress(Address::IpVersion::v4)->ip()->addressAsString(), 23413));
+  EXPECT_TRUE(Utility::isLocalConnection(socket));
+
+  local_addr.reset(new Network::Address::Ipv6Instance("fabc::42", 80));
+  remote_addr.reset(new Network::Address::Ipv6Instance(
+      Utility::getLocalAddress(Address::IpVersion::v6)->ip()->addressAsString(), 23413));
+  EXPECT_TRUE(Utility::isLocalConnection(socket));
 }
 
 TEST(NetworkUtility, InternalAddress) {

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -230,6 +230,10 @@ TEST(NetworkUtility, LocalConnection) {
   remote_addr.reset(new Network::Address::Ipv6Instance(
       Utility::getLocalAddress(Address::IpVersion::v6)->ip()->addressAsString(), 23413));
   EXPECT_TRUE(Utility::isLocalConnection(socket));
+
+  local_addr.reset(new Network::Address::Ipv4Instance("4.4.4.4", 80));
+  remote_addr.reset(new Network::Address::Ipv6Instance("fabc::42", 23413));
+  EXPECT_FALSE(Utility::isLocalConnection(socket));
 }
 
 TEST(NetworkUtility, InternalAddress) {

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -172,7 +172,7 @@ TEST(NetworkUtility, LocalConnection) {
 
   testing::NiceMock<Network::MockConnectionSocket> socket;
 
-  EXPECT_CALL(socket, remoteAddress()).WillRepeatedly(testing::ReturnRef(local_addr));
+  EXPECT_CALL(socket, localAddress()).WillRepeatedly(testing::ReturnRef(local_addr));
   EXPECT_CALL(socket, remoteAddress()).WillRepeatedly(testing::ReturnRef(remote_addr));
 
   local_addr.reset(new Network::Address::Ipv4Instance("127.0.0.1"));
@@ -204,6 +204,14 @@ TEST(NetworkUtility, LocalConnection) {
 
   remote_addr.reset(new Network::Address::Ipv6Instance("fd00::"));
   EXPECT_FALSE(Utility::isLocalConnection(socket));
+
+  local_addr.reset(new Network::Address::Ipv4Instance("4.4.4.4"));
+  remote_addr.reset(new Network::Address::Ipv4Instance("4.4.4.4"));
+  EXPECT_TRUE(Utility::isLocalConnection(socket));
+
+  local_addr.reset(new Network::Address::Ipv6Instance("fabc::42"));
+  remote_addr.reset(new Network::Address::Ipv6Instance("fabc::42"));
+  EXPECT_TRUE(Utility::isLocalConnection(socket));
 }
 
 TEST(NetworkUtility, InternalAddress) {


### PR DESCRIPTION
Add test case for LocalConnection test where local and remote
addresses have the same IP address. Fix the test code to actually use
the intended local address. Fix the utility implementation to compare
the actual addresses rather than the pointers to them.

Address comparisons in Utility::isLocalConnection() should be performed on
the IP addresses, ignoring any port numbers.  Skip the temporary
Instance in the comparison loop.  Add test cases with port numbers.

Fixes: #4682
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
