### PR TITLE
build: explictly set mac PATH env during build

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -59,7 +59,7 @@ In order for bazel to be aware of the tools installed by brew, the PATH
 variable must be set for bazel builds. This can be accomplished setting
 
 ```
---action_env=PATH=/bin:/opt/local/bin:/usr/bin:/usr/local/bin"
+--action_env=PATH=/usr/local/bin:/opt/local/bin:/usr/bin:/bin"
 ```
 
 either on the command line when running `bazel build`/`bazel test` or

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -63,7 +63,7 @@ variable must be set for bazel builds. This can be accomplished setting
 ```
 
 either on the command line when running `bazel build`/`bazel test` or
-in your `bazelrc` file.
+in your `$HOME/.bazelrc` file.
 
 3. Install Golang on your machine. This is required as part of building [BoringSSL](https://boringssl.googlesource.com/boringssl/+/HEAD/BUILDING.md)
 and also for [Buildifer](https://github.com/bazelbuild/buildtools) which is used for formatting bazel BUILD files.

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -531,15 +531,3 @@ Adding the following parameter to Bazel everytime or persist them in `.bazelrc`.
 ```
 --remote_http_cache=http://127.0.0.1:28080/
 ```
-
-## Restrict environment variables
-
-You might need the following parameters for Bazel or persist in `.bazelrc` as well to make cache
-more efficient. This will let Bazel use an environment with a static value for _PATH_ and does
-not inherit _LD_LIBRARY_PATH_ or _TMPDIR_. See
-[Bazel Command-Line References](https://docs.bazel.build/versions/master/command-line-reference.html#flag--experimental_strict_action_env)
-for more information.
-
-```
---experimental_strict_action_env
-```

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -55,6 +55,16 @@ _note_: `coreutils` is used for realpath
 Envoy compiles and passes tests with the version of clang installed by XCode 9.3.0:
 Apple LLVM version 9.1.0 (clang-902.0.30).
 
+In order for bazel to be aware of the tools installed by brew, the PATH
+variable must be set for bazel builds. This can be accomplished setting
+
+```
+--action_env=PATH=/bin:/opt/local/bin:/usr/bin:/usr/local/bin"
+```
+
+either on the command line when running `bazel build`/`bazel test` or
+in your `bazelrc` file.
+
 3. Install Golang on your machine. This is required as part of building [BoringSSL](https://boringssl.googlesource.com/boringssl/+/HEAD/BUILDING.md)
 and also for [Buildifer](https://github.com/bazelbuild/buildtools) which is used for formatting bazel BUILD files.
 4. `go get github.com/bazelbuild/buildtools/buildifier` to install buildifier

--- a/ci/build_container/build_and_install_deps.sh
+++ b/ci/build_container/build_and_install_deps.sh
@@ -9,7 +9,7 @@ mkdir -p "${THIRDPARTY_SRC}"
 if [ -z "$NUM_CPUS" ]; then
   case `uname` in
       Darwin)
-          NUM_CPUS=`sysctl hw.physicalcpu | cut -f 2 -d' '`;;
+          NUM_CPUS=`/usr/sbin/sysctl hw.physicalcpu | cut -f 2 -d' '`;;
       *)
           NUM_CPUS=`grep -c ^processor /proc/cpuinfo`;;
   esac

--- a/ci/mac_ci_steps.sh
+++ b/ci/mac_ci_steps.sh
@@ -4,7 +4,8 @@ set -e
 
 . "$(dirname "$0")"/setup_gcs_cache.sh
 
-BAZEL_BUILD_OPTIONS="--curses=no --show_task_finish --verbose_failures ${BAZEL_BUILD_EXTRA_OPTIONS}"
+BAZEL_BUILD_OPTIONS="--curses=no --show_task_finish --verbose_failures ${BAZEL_BUILD_EXTRA_OPTIONS} \
+  --action_env=PATH=/usr/bin:/usr/local/bin:/bin:/usr/sbin"
 # TODO(zuercher): remove --flaky_test_attempts when https://github.com/envoyproxy/envoy/issues/2428
 # is resolved.
 BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_output=all --flaky_test_attempts=integration@2"

--- a/ci/mac_ci_steps.sh
+++ b/ci/mac_ci_steps.sh
@@ -5,7 +5,7 @@ set -e
 . "$(dirname "$0")"/setup_gcs_cache.sh
 
 BAZEL_BUILD_OPTIONS="--curses=no --show_task_finish --verbose_failures ${BAZEL_BUILD_EXTRA_OPTIONS} \
-  --action_env=PATH=/bin:/opt/local/bin:/usr/bin:/usr/local/bin"
+  --action_env=PATH=/usr/local/bin:/opt/local/bin:/usr/bin:/bin"
 # TODO(zuercher): remove --flaky_test_attempts when https://github.com/envoyproxy/envoy/issues/2428
 # is resolved.
 BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_output=all --flaky_test_attempts=integration@2"

--- a/ci/mac_ci_steps.sh
+++ b/ci/mac_ci_steps.sh
@@ -5,7 +5,7 @@ set -e
 . "$(dirname "$0")"/setup_gcs_cache.sh
 
 BAZEL_BUILD_OPTIONS="--curses=no --show_task_finish --verbose_failures ${BAZEL_BUILD_EXTRA_OPTIONS} \
-  --action_env=PATH=/usr/bin:/usr/local/bin:/bin:/usr/sbin"
+  --action_env=PATH=/bin:/opt/local/bin:/usr/bin:/usr/local/bin"
 # TODO(zuercher): remove --flaky_test_attempts when https://github.com/envoyproxy/envoy/issues/2428
 # is resolved.
 BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_output=all --flaky_test_attempts=integration@2"


### PR DESCRIPTION
With bazel 0.21.0, PATH is strict by default, and by default it won't pick up /usr/local/bin which breaks all the brew installed dependencies. 

This should fix master, which is currently failing the mac build.

*Risk Level*: Low
*Testing*: CI
*Docs Changes*: n/a
*Release Notes*: n/a
