### PR TITLE
ratelimit: move tests to v2 config

### DIFF
--- a/test/extensions/filters/http/ratelimit/config_test.cc
+++ b/test/extensions/filters/http/ratelimit/config_test.cc
@@ -18,8 +18,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace RateLimitFilter {
 
-// TODO(ramaraochavali): move to v2 config for all the tests.
-
 TEST(RateLimitFilterConfigTest, ValidateFail) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_THROW(RateLimitFilterConfig().createFilterFactoryFromProto(
@@ -27,49 +25,14 @@ TEST(RateLimitFilterConfigTest, ValidateFail) {
                ProtoValidationException);
 }
 
-TEST(RateLimitFilterConfigTest, RateLimitFilterCorrectJson) {
-  std::string json_string = R"EOF(
-  {
-    "domain" : "test",
-    "timeout_ms" : 1337
-  }
-  )EOF";
-
-  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<Server::Configuration::MockFactoryContext> context;
-  NiceMock<Server::MockInstance> instance;
-
-  // Return the same singleton manager as instance so that config can be found there.
-  EXPECT_CALL(context, singletonManager()).WillOnce(ReturnRef(instance.singletonManager()));
-
-  Filters::Common::RateLimit::ClientFactoryPtr client_factory =
-      Filters::Common::RateLimit::rateLimitClientFactory(
-          instance, instance.clusterManager().grpcAsyncClientManager(),
-          envoy::config::bootstrap::v2::Bootstrap());
-
-  EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&, bool) {
-        return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
-      }));
-
-  RateLimitFilterConfig factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
-  Http::MockFilterChainFactoryCallbacks filter_callback;
-  EXPECT_CALL(filter_callback, addStreamFilter(_));
-  cb(filter_callback);
-}
-
 TEST(RateLimitFilterConfigTest, RateLimitFilterCorrectProto) {
-  std::string json_string = R"EOF(
-  {
-    "domain" : "test",
-    "timeout_ms" : 1337
-  }
+  const std::string yaml = R"EOF(
+  domain: test
+  timeout: 2s
   )EOF";
 
-  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   envoy::config::filter::http::rate_limit::v2::RateLimit proto_config{};
-  Envoy::Config::FilterJson::translateHttpRateLimitFilter(*json_config, proto_config);
+  MessageUtil::loadFromYaml(yaml, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   NiceMock<Server::MockInstance> instance;
@@ -82,9 +45,6 @@ TEST(RateLimitFilterConfigTest, RateLimitFilterCorrectProto) {
           instance, instance.clusterManager().grpcAsyncClientManager(),
           envoy::config::bootstrap::v2::Bootstrap());
 
-  EXPECT_CALL(context, clusterManager());
-  EXPECT_CALL(context, runtime()).Times(1);
-  EXPECT_CALL(context, scope()).Times(2);
   EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
       .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&, bool) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
@@ -98,7 +58,7 @@ TEST(RateLimitFilterConfigTest, RateLimitFilterCorrectProto) {
 }
 
 TEST(RateLimitFilterConfigTest, RateLimitFilterWithBootstrapOnlyConfig) {
-  std::string yaml = R"EOF(
+  const std::string yaml = R"EOF(
   domain: test
   timeout: 2s
   )EOF";
@@ -140,7 +100,7 @@ TEST(RateLimitFilterConfigTest, RateLimitFilterWithBootstrapOnlyConfig) {
 }
 
 TEST(RateLimitFilterConfigTest, RateLimitFilterWithServiceConfig) {
-  std::string yaml = R"EOF(
+  const std::string yaml = R"EOF(
   domain: test
   timeout: 2s
   rate_limit_service:
@@ -176,7 +136,7 @@ TEST(RateLimitFilterConfigTest, RateLimitFilterWithServiceConfig) {
 }
 
 TEST(RateLimitFilterConfigTest, RateLimitFilterWithConflictingConfig) {
-  std::string yaml = R"EOF(
+  const std::string yaml = R"EOF(
   domain: test
   timeout: 2s
   rate_limit_service:
@@ -214,56 +174,27 @@ TEST(RateLimitFilterConfigTest, RateLimitFilterWithConflictingConfig) {
 }
 
 TEST(RateLimitFilterConfigTest, RateLimitFilterEmptyProto) {
-  std::string json_string = R"EOF(
-  {
-    "domain" : "test",
-    "timeout_ms" : 1337
-  }
-  )EOF";
-
   NiceMock<Server::Configuration::MockFactoryContext> context;
   NiceMock<Server::MockInstance> instance;
 
-  // Return the same singleton manager as instance so that config can be found there.
-  EXPECT_CALL(context, singletonManager()).WillOnce(ReturnRef(instance.singletonManager()));
-
-  Filters::Common::RateLimit::ClientFactoryPtr client_factory =
-      Filters::Common::RateLimit::rateLimitClientFactory(
-          instance, instance.clusterManager().grpcAsyncClientManager(),
-          envoy::config::bootstrap::v2::Bootstrap());
-
   RateLimitFilterConfig factory;
 
-  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  envoy::config::filter::http::rate_limit::v2::RateLimit proto_config =
+  envoy::config::filter::http::rate_limit::v2::RateLimit empty_proto_config =
       *dynamic_cast<envoy::config::filter::http::rate_limit::v2::RateLimit*>(
           factory.createEmptyConfigProto().get());
-  Envoy::Config::FilterJson::translateHttpRateLimitFilter(*json_config, proto_config);
 
-  EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&, bool) {
-        return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
-      }));
-
-  Http::FilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
-  Http::MockFilterChainFactoryCallbacks filter_callback;
-  EXPECT_CALL(filter_callback, addStreamFilter(_));
-  cb(filter_callback);
+  EXPECT_THROW(factory.createFilterFactoryFromProto(empty_proto_config, "stats", context),
+               EnvoyException);
 }
 
 TEST(RateLimitFilterConfigTest, BadRateLimitFilterConfig) {
-  std::string json_string = R"EOF(
-  {
-    "domain" : "test",
-    "timeout_ms" : 0
-  }
+  const std::string yaml = R"EOF(
+  domain: test
+  timeout: 20
   )EOF";
 
-  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<Server::Configuration::MockFactoryContext> context;
-
-  RateLimitFilterConfig factory;
-  EXPECT_THROW(factory.createFilterFactory(*json_config, "stats", context), Json::Exception);
+  envoy::config::filter::http::rate_limit::v2::RateLimit proto_config{};
+  EXPECT_THROW(MessageUtil::loadFromYaml(yaml, proto_config), EnvoyException);
 }
 
 } // namespace RateLimitFilter

--- a/test/extensions/filters/network/ratelimit/config_test.cc
+++ b/test/extensions/filters/network/ratelimit/config_test.cc
@@ -25,53 +25,19 @@ TEST(RateLimitFilterConfigTest, ValidateFail) {
                ProtoValidationException);
 }
 
-TEST(RateLimitFilterConfigTest, RatelimitCorrectJson) {
-  std::string json_string = R"EOF(
-  {
-    "stat_prefix": "my_stat_prefix",
-    "domain" : "fake_domain",
-    "descriptors": [[{ "key" : "my_key",  "value" : "my_value" }]],
-    "timeout_ms": 1337
-  }
-  )EOF";
-
-  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<Server::Configuration::MockFactoryContext> context;
-  NiceMock<Server::MockInstance> instance;
-
-  // Return the same singleton manager as instance so that config can be found there.
-  EXPECT_CALL(context, singletonManager()).WillOnce(ReturnRef(instance.singletonManager()));
-
-  Filters::Common::RateLimit::ClientFactoryPtr client_factory =
-      Filters::Common::RateLimit::rateLimitClientFactory(
-          instance, instance.clusterManager().grpcAsyncClientManager(),
-          envoy::config::bootstrap::v2::Bootstrap());
-
-  EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&, bool) {
-        return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
-      }));
-
-  RateLimitConfigFactory factory;
-  Network::FilterFactoryCb cb = factory.createFilterFactory(*json_config, context);
-  Network::MockConnection connection;
-  EXPECT_CALL(connection, addReadFilter(_));
-  cb(connection);
-}
-
 TEST(RateLimitFilterConfigTest, RatelimitCorrectProto) {
-  std::string json_string = R"EOF(
-  {
-    "stat_prefix": "my_stat_prefix",
-    "domain" : "fake_domain",
-    "descriptors": [[{ "key" : "my_key",  "value" : "my_value" }]],
-    "timeout_ms": 1337
-  }
+  const std::string yaml = R"EOF(
+  stat_prefix: my_stat_prefix
+  domain: fake_domain
+  descriptors:
+    entries:
+       key: my_key
+       value: my_value
+  timeout: 2s
   )EOF";
 
-  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
   envoy::config::filter::network::rate_limit::v2::RateLimit proto_config{};
-  Envoy::Config::FilterJson::translateTcpRateLimitFilter(*json_config, proto_config);
+  MessageUtil::loadFromYaml(yaml, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   NiceMock<Server::MockInstance> instance;
@@ -96,44 +62,15 @@ TEST(RateLimitFilterConfigTest, RatelimitCorrectProto) {
   cb(connection);
 }
 
-TEST(RateLimitFilterConfigTest, RatelimitEmptyProto) {
-  std::string json_string = R"EOF(
-  {
-    "stat_prefix": "my_stat_prefix",
-    "domain" : "fake_domain",
-    "descriptors": [[{ "key" : "my_key",  "value" : "my_value" }]],
-    "timeout_ms": 1337
-  }
-  )EOF";
-
-  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-
+TEST(RateLimitFilterConfigTest, RateLimitFilterEmptyProto) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  RateLimitConfigFactory factory;
   NiceMock<Server::MockInstance> instance;
+  RateLimitConfigFactory factory;
 
-  // Return the same singleton manager as instance so that config can be found there.
-  EXPECT_CALL(context, singletonManager()).WillOnce(ReturnRef(instance.singletonManager()));
-
-  Filters::Common::RateLimit::ClientFactoryPtr client_factory =
-      Filters::Common::RateLimit::rateLimitClientFactory(
-          instance, instance.clusterManager().grpcAsyncClientManager(),
-          envoy::config::bootstrap::v2::Bootstrap());
-
-  EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([](const envoy::api::v2::core::GrpcService&, Stats::Scope&, bool) {
-        return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
-      }));
-
-  envoy::config::filter::network::rate_limit::v2::RateLimit proto_config =
+  envoy::config::filter::network::rate_limit::v2::RateLimit empty_proto_config =
       *dynamic_cast<envoy::config::filter::network::rate_limit::v2::RateLimit*>(
           factory.createEmptyConfigProto().get());
-  Envoy::Config::FilterJson::translateTcpRateLimitFilter(*json_config, proto_config);
-
-  Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, context);
-  Network::MockConnection connection;
-  EXPECT_CALL(connection, addReadFilter(_));
-  cb(connection);
+  EXPECT_THROW(factory.createFilterFactoryFromProto(empty_proto_config, context), EnvoyException);
 }
 
 } // namespace RateLimitFilter

--- a/test/extensions/filters/network/thrift_proxy/filters/ratelimit/config_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/ratelimit/config_test.cc
@@ -35,7 +35,7 @@ TEST(RateLimitFilterConfigTest, ValidateFail) {
 }
 
 TEST(RateLimitFilterConfigTest, RateLimitFilterCorrectProto) {
-  std::string yaml_string = R"EOF(
+  const std::string yaml_string = R"EOF(
 domain: "test"
 timeout: "1.337s"
   )EOF";


### PR DESCRIPTION
*Description*: This is one of the TODOs identified earlier i.e. to move rate limit tests to v2 config. This PR addresses that.
*Risk Level*: Low
*Testing*: Existing tests
*Docs Changes*: N/A
*Release Notes*: N/A

