### PR TITLE
Store end_stream for each filter, and use it to not call decodeData again()

### DIFF
--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -95,7 +95,7 @@ private:
   struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks {
     ActiveStreamFilterBase(ActiveStream& parent, bool dual_filter)
         : parent_(parent), headers_continued_(false), continue_headers_continued_(false),
-          stopped_(false), dual_filter_(dual_filter) {}
+          stopped_(false), end_stream_(false), dual_filter_(dual_filter) {}
 
     bool commonHandleAfter100ContinueHeadersCallback(FilterHeadersStatus status);
     bool commonHandleAfterHeadersCallback(FilterHeadersStatus status, bool& headers_only);
@@ -131,6 +131,8 @@ private:
     bool headers_continued_ : 1;
     bool continue_headers_continued_ : 1;
     bool stopped_ : 1;
+    // If true, end_stream is called for this filter.
+    bool end_stream_ : 1;
     const bool dual_filter_ : 1;
   };
 
@@ -426,6 +428,8 @@ private:
     // Whether a filter has indicated that the response should be treated as a headers only
     // response.
     bool encoding_headers_only_{};
+    // If true, response_encoder is end_stream
+    bool response_encoder_end_stream_{};
   };
 
   typedef std::unique_ptr<ActiveStream> ActiveStreamPtr;

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -163,36 +163,6 @@ private:
       parent_.decodeHeaders(this, *parent_.request_headers_, end_stream);
     }
     void doData(bool end_stream) override {
-      // In following case, ActiveStreamFilterBase::commonContine() could be called recursively and
-      // its doData() is called with wrong data.
-      //
-      //  There are 3 decode filters and "wrapper" refers to ActiveStreamFilter object.
-      //
-      //  filter0->decodeHeaders(_, true)
-      //    return STOP
-      //  filter0->continueDecoding()
-      //    wrapper0->commonContinue()
-      //      wrapper0->decodeHeaders(_, _, true)
-      //        filter1->decodeHeaders(_, true)
-      //          filter1->addDecodeData()
-      //          return CONTINUE
-      //        filter2->decodeHeaders(_, false)
-      //          return CONTINUE
-      //        wrapper1->commonContinue() // Detects data is added.
-      //          wrapper1->doData()
-      //            wrapper1->decodeData()
-      //              filter2->decodeData(_, true)
-      //                 return CONTINUE
-      //      wrapper0->doData() // This should not be called
-      //        wrapper0->decodeData()
-      //          filter1->decodeData(_, true)  // It will cause assertions.
-      //
-      // One way to solve this problem is to mark end_stream_ for each filter.
-      // Before calling doData(), if any of filters after has marked end_stream_, not to call
-      // doData().
-      if (parent_.seenEndStream(this)) {
-        return;
-      }
       parent_.decodeData(this, *parent_.buffered_request_data_, end_stream);
     }
     void doTrailers() override { parent_.decodeTrailers(this, *parent_.request_trailers_); }
@@ -264,10 +234,6 @@ private:
       parent_.encodeHeaders(this, *parent_.response_headers_, end_stream);
     }
     void doData(bool end_stream) override {
-      // Please see comment in ActiveStreamDecoderFilter::doData().
-      if (parent_.seenEndStream(this)) {
-        return;
-      }
       parent_.encodeData(this, *parent_.buffered_response_data_, end_stream);
     }
     void doTrailers() override { parent_.encodeTrailers(this, *parent_.response_trailers_); }
@@ -332,8 +298,6 @@ private:
     void encodeMetadata(ActiveStreamEncoderFilter* filter, MetadataMapPtr&& metadata_map);
     void maybeEndEncode(bool end_stream);
     uint64_t streamId() { return stream_id_; }
-    bool seenEndStream(ActiveStreamDecoderFilter* filter);
-    bool seenEndStream(ActiveStreamEncoderFilter* filter);
 
     // Http::StreamCallbacks
     void onResetStream(StreamResetReason reason) override;

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -428,8 +428,6 @@ private:
     // Whether a filter has indicated that the response should be treated as a headers only
     // response.
     bool encoding_headers_only_{};
-    // If true, response_encoder is end_stream
-    bool response_encoder_end_stream_{};
   };
 
   typedef std::unique_ptr<ActiveStream> ActiveStreamPtr;


### PR DESCRIPTION
*Description*:

This is @mattklein123  idea of to fix https://github.com/envoyproxy/envoy/issues/5311#

store end_stream for each filter,  if a filter has been "end_stream", not to call its decodeData() or encodeData() again.

Need to do this for response_encoder too.


*Risk Level*:  Low

*Testing*:  Added unit-test

