### PR TITLE
decouple common/ssl from common/network

### DIFF
--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -58,7 +58,6 @@ envoy_cc_library(
         "//source/common/common:minimal_logger_lib",
         "//source/common/event:libevent_lib",
         "//source/common/network:listen_socket_lib",
-        "//source/common/ssl:ssl_socket_lib",
         "//source/common/stream_info:stream_info_lib",
     ],
 )
@@ -120,7 +119,6 @@ envoy_cc_library(
         ":utility_lib",
         "//include/envoy/network:listen_socket_interface",
         "//source/common/common:assert_lib",
-        "//source/common/ssl:context_lib",
     ],
 )
 

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -14,7 +14,6 @@
 #include "common/common/logger.h"
 #include "common/event/libevent.h"
 #include "common/network/filter_manager_impl.h"
-#include "common/ssl/ssl_socket.h"
 #include "common/stream_info/stream_info_impl.h"
 
 #include "absl/types/optional.h"

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -237,6 +237,7 @@ envoy_cc_library(
         "//source/common/network:utility_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/ssl:context_config_lib",
+        "//source/common/ssl:context_lib",
         "//source/extensions/filters/listener:well_known_names",
         "//source/extensions/filters/network:well_known_names",
         "//source/extensions/transport_sockets:well_known_names",

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -16,6 +16,7 @@
 #include "common/network/connection_impl.h"
 #include "common/network/raw_buffer_socket.h"
 #include "common/ssl/context_config_impl.h"
+#include "common/ssl/ssl_socket.h"
 
 #include "test/common/grpc/grpc_client_integration.h"
 #include "test/common/grpc/utility.h"

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -291,6 +291,7 @@ envoy_cc_test_library(
         "//source/common/network:filter_lib",
         "//source/common/network:listen_socket_lib",
         "//source/common/network:utility_lib",
+        "//source/common/ssl:ssl_socket_lib",
         "//source/common/stats:isolated_store_lib",
         "//source/common/stats:thread_local_store_lib",
         "//source/common/thread_local:thread_local_lib",


### PR DESCRIPTION
Signed-off-by: William DeCoste <bdecoste@gmail.com>

Description: As part of the work to support openssl this PR decouples the dependency of common/network on common/ssl. This is one step that will enable the linking and testing of openssl with a new transport socket for openssl. The common/network package did not require common/ssl so was straightforward to decouple.
Risk Level: Low
Testing: Standard tests passed
Docs Changes: None
Release Notes: None
[Optional Fixes #Issue]
[Optional Deprecated:]