### PR TITLE
fix: use correct comparison operator in CI script

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -72,7 +72,7 @@ if [[ "$1" == "bazel.release" ]]; then
   echo "bazel release build with tests..."
   bazel_release_binary_build
 
-  if [[ $# > 1 ]]; then
+  if [[ $# -gt 1 ]]; then
     shift
     echo "Testing $* ..."
     # Run only specified tests. Argument can be a single test


### PR DESCRIPTION
*Description*:
`>` is for string lexical comparison, `-gt` is for numerical comparsion
```
➜  envoy git:(dereka/ci-gt-fix) ✗ [[ 5 > 1 ]]; echo $?
0
➜  envoy git:(dereka/ci-gt-fix) ✗ [[ 05 > 1 ]]; echo $?
1
➜  envoy git:(dereka/ci-gt-fix) ✗ [[ 05 -gt 1 ]]; echo $?
0
➜  envoy git:(dereka/ci-gt-fix) ✗
```

*Risk Level*: low

Signed-off-by: Derek Argueta <dereka@pinterest.com>