### PR TITLE
statsd: correctly purge output buffer when there is no host

### DIFF
--- a/source/extensions/stat_sinks/common/statsd/statsd.cc
+++ b/source/extensions/stat_sinks/common/statsd/statsd.cc
@@ -190,6 +190,7 @@ void TcpStatsdSink::TlsSink::endFlush(bool do_write) {
   current_slice_mem_ = nullptr;
   if (do_write) {
     write(buffer_);
+    ASSERT(buffer_.length() == 0);
   }
 }
 
@@ -235,6 +236,7 @@ void TcpStatsdSink::TlsSink::write(Buffer::Instance& buffer) {
     Upstream::Host::CreateConnectionData info =
         parent_.cluster_manager_.tcpConnForCluster(parent_.cluster_info_->name(), nullptr, nullptr);
     if (!info.connection_) {
+      buffer.drain(buffer.length());
       return;
     }
 


### PR DESCRIPTION
This was causing an assertion in the hot restart test on my dev machine.
I'm surprised this has not come up before.

*Risk Level*: Low
*Testing*: New UT, also covered by hot restart test apparently
*Docs Changes*: N/A
*Release Notes*: N/A
