### PR TITLE
test: replace strptime with std::get_time

### DIFF
--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <list>
 #include <stdexcept>
@@ -226,11 +227,12 @@ void TestUtility::createSymlink(const std::string& target, const std::string& li
 // static
 std::tm TestUtility::parseTimestamp(const std::string& format, const std::string& time_str) {
   std::tm timestamp{};
-  const char* parsed_to = strptime(time_str.c_str(), format.c_str(), &timestamp);
+  std::istringstream text(time_str);
 
-  EXPECT_EQ(parsed_to, time_str.c_str() + time_str.size())
-      << " from failing to parse timestamp \"" << time_str << "\" with format string \"" << format
-      << "\"";
+  text >> std::get_time(&timestamp, format.c_str());
+
+  EXPECT_FALSE(text.fail()) << " from failing to parse timestamp \"" << time_str
+                            << "\" with format string \"" << format << "\"";
   return timestamp;
 }
 


### PR DESCRIPTION
*Description*:
strptime does not exist on Windows, so use std::get_time instead

*Risk Level*:
Low, only changes to test code

*Testing*:
`bazel build //source/... && bazel test //test/...`

*Docs Changes*:
N/A
*Release Notes*:
N/A