### PR TITLE
add support for passing TransportSocketOptions in HTTP filters

### DIFF
--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -118,10 +118,10 @@ public:
    * Can return nullptr if there is no host available in the cluster or if the cluster does not
    * exist.
    */
-  virtual Http::ConnectionPool::Instance* httpConnPoolForCluster(const std::string& cluster,
-                                                                 ResourcePriority priority,
-                                                                 Http::Protocol protocol,
-                                                                 LoadBalancerContext* context) PURE;
+  virtual Http::ConnectionPool::Instance*
+  httpConnPoolForCluster(const std::string& cluster, ResourcePriority priority,
+                         Http::Protocol protocol, LoadBalancerContext* context,
+                         Network::TransportSocketOptionsSharedPtr transport_socket_options) PURE;
 
   /**
    * Allocate a load balanced TCP connection pool for a cluster. This is *per-thread* so that
@@ -264,7 +264,8 @@ public:
   virtual Http::ConnectionPool::InstancePtr
   allocateConnPool(Event::Dispatcher& dispatcher, HostConstSharedPtr host,
                    ResourcePriority priority, Http::Protocol protocol,
-                   const Network::ConnectionSocket::OptionsSharedPtr& options) PURE;
+                   const Network::ConnectionSocket::OptionsSharedPtr& options,
+                   Network::TransportSocketOptionsSharedPtr transport_socket_options) PURE;
 
   /**
    * Allocate a TCP connection pool for the host. Pools are separated by 'priority' and

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -32,7 +32,8 @@ class ConnPoolImpl : public ConnectionPool::Instance, public ConnPoolImplBase {
 public:
   ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
                Upstream::ResourcePriority priority,
-               const Network::ConnectionSocket::OptionsSharedPtr& options);
+               const Network::ConnectionSocket::OptionsSharedPtr& options,
+               Network::TransportSocketOptionsSharedPtr transport_socket_options);
 
   ~ConnPoolImpl();
 
@@ -118,6 +119,7 @@ protected:
   std::list<ActiveClientPtr> busy_clients_;
   std::list<DrainedCb> drained_callbacks_;
   const Network::ConnectionSocket::OptionsSharedPtr socket_options_;
+  Network::TransportSocketOptionsSharedPtr transport_socket_options_;
   Event::TimerPtr upstream_ready_timer_;
   bool upstream_ready_enabled_{false};
 };
@@ -129,8 +131,9 @@ class ConnPoolImplProd : public ConnPoolImpl {
 public:
   ConnPoolImplProd(Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
                    Upstream::ResourcePriority priority,
-                   const Network::ConnectionSocket::OptionsSharedPtr& options)
-      : ConnPoolImpl(dispatcher, host, priority, options) {}
+                   const Network::ConnectionSocket::OptionsSharedPtr& options,
+                   Network::TransportSocketOptionsSharedPtr transport_socket_options)
+      : ConnPoolImpl(dispatcher, host, priority, options, transport_socket_options) {}
 
   // ConnPoolImpl
   CodecClientPtr createCodecClient(Upstream::Host::CreateConnectionData& data) override;

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -17,9 +17,10 @@ namespace Http2 {
 
 ConnPoolImpl::ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
                            Upstream::ResourcePriority priority,
-                           const Network::ConnectionSocket::OptionsSharedPtr& options)
+                           const Network::ConnectionSocket::OptionsSharedPtr& options,
+                           Network::TransportSocketOptionsSharedPtr transport_socket_options)
     : ConnPoolImplBase(std::move(host), std::move(priority)), dispatcher_(dispatcher),
-      socket_options_(options) {}
+      socket_options_(options), transport_socket_options_(transport_socket_options) {}
 
 ConnPoolImpl::~ConnPoolImpl() {
   if (primary_client_) {
@@ -261,8 +262,8 @@ ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
       connect_timer_(parent_.dispatcher_.createTimer([this]() -> void { onConnectTimeout(); })) {
   parent_.conn_connect_ms_ = std::make_unique<Stats::Timespan>(
       parent_.host_->cluster().stats().upstream_cx_connect_ms_, parent_.dispatcher_.timeSystem());
-  Upstream::Host::CreateConnectionData data =
-      parent_.host_->createConnection(parent_.dispatcher_, parent_.socket_options_, nullptr);
+  Upstream::Host::CreateConnectionData data = parent_.host_->createConnection(
+      parent_.dispatcher_, parent_.socket_options_, parent_.transport_socket_options_);
   real_host_description_ = data.host_description_;
   client_ = parent_.createCodecClient(data);
   client_->addConnectionCallbacks(*this);

--- a/source/common/http/http2/conn_pool.h
+++ b/source/common/http/http2/conn_pool.h
@@ -26,7 +26,8 @@ class ConnPoolImpl : public ConnectionPool::Instance, public ConnPoolImplBase {
 public:
   ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
                Upstream::ResourcePriority priority,
-               const Network::ConnectionSocket::OptionsSharedPtr& options);
+               const Network::ConnectionSocket::OptionsSharedPtr& options,
+               Network::TransportSocketOptionsSharedPtr transport_socket_options);
   ~ConnPoolImpl();
 
   // Http::ConnectionPool::Instance
@@ -94,6 +95,7 @@ protected:
   ActiveClientPtr draining_client_;
   std::list<DrainedCb> drained_callbacks_;
   const Network::ConnectionSocket::OptionsSharedPtr socket_options_;
+  Network::TransportSocketOptionsSharedPtr transport_socket_options_;
 };
 
 /**

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -173,6 +173,8 @@ envoy_cc_library(
         "//source/common/http:headers_lib",
         "//source/common/http:message_lib",
         "//source/common/http:utility_lib",
+        "//source/common/network:transport_socket_options_lib",
+        "//source/common/network:upstream_server_name_lib",
         "//source/common/stream_info:stream_info_lib",
         "//source/common/tracing:http_tracer_lib",
         "//source/common/upstream:load_balancer_lib",

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -55,7 +55,8 @@ public:
   Http::ConnectionPool::InstancePtr
   allocateConnPool(Event::Dispatcher& dispatcher, HostConstSharedPtr host,
                    ResourcePriority priority, Http::Protocol protocol,
-                   const Network::ConnectionSocket::OptionsSharedPtr& options) override;
+                   const Network::ConnectionSocket::OptionsSharedPtr& options,
+                   Network::TransportSocketOptionsSharedPtr transport_socket_options) override;
   Tcp::ConnectionPool::InstancePtr
   allocateTcpConnPool(Event::Dispatcher& dispatcher, HostConstSharedPtr host,
                       ResourcePriority priority,
@@ -189,10 +190,10 @@ public:
     return clusters_map;
   }
   ThreadLocalCluster* get(const std::string& cluster) override;
-  Http::ConnectionPool::Instance* httpConnPoolForCluster(const std::string& cluster,
-                                                         ResourcePriority priority,
-                                                         Http::Protocol protocol,
-                                                         LoadBalancerContext* context) override;
+  Http::ConnectionPool::Instance* httpConnPoolForCluster(
+      const std::string& cluster, ResourcePriority priority, Http::Protocol protocol,
+      LoadBalancerContext* context,
+      Network::TransportSocketOptionsSharedPtr transport_socket_options) override;
   Tcp::ConnectionPool::Instance*
   tcpConnPoolForCluster(const std::string& cluster, ResourcePriority priority,
                         LoadBalancerContext* context,
@@ -278,8 +279,9 @@ private:
                    const LoadBalancerFactorySharedPtr& lb_factory);
       ~ClusterEntry();
 
-      Http::ConnectionPool::Instance* connPool(ResourcePriority priority, Http::Protocol protocol,
-                                               LoadBalancerContext* context);
+      Http::ConnectionPool::Instance*
+      connPool(ResourcePriority priority, Http::Protocol protocol, LoadBalancerContext* context,
+               Network::TransportSocketOptionsSharedPtr transport_socket_options);
 
       Tcp::ConnectionPool::Instance*
       tcpConnPool(ResourcePriority priority, LoadBalancerContext* context,

--- a/source/server/config_validation/cluster_manager.cc
+++ b/source/server/config_validation/cluster_manager.cc
@@ -46,7 +46,8 @@ ValidationClusterManager::ValidationClusterManager(
 
 Http::ConnectionPool::Instance*
 ValidationClusterManager::httpConnPoolForCluster(const std::string&, ResourcePriority,
-                                                 Http::Protocol, LoadBalancerContext*) {
+                                                 Http::Protocol, LoadBalancerContext*,
+                                                 Network::TransportSocketOptionsSharedPtr) {
   return nullptr;
 }
 

--- a/source/server/config_validation/cluster_manager.h
+++ b/source/server/config_validation/cluster_manager.h
@@ -51,9 +51,9 @@ public:
                            AccessLog::AccessLogManager& log_manager, Event::Dispatcher& dispatcher,
                            Server::Admin& admin, Api::Api& api, Http::Context& http_context);
 
-  Http::ConnectionPool::Instance* httpConnPoolForCluster(const std::string&, ResourcePriority,
-                                                         Http::Protocol,
-                                                         LoadBalancerContext*) override;
+  Http::ConnectionPool::Instance*
+  httpConnPoolForCluster(const std::string&, ResourcePriority, Http::Protocol, LoadBalancerContext*,
+                         Network::TransportSocketOptionsSharedPtr) override;
   Host::CreateConnectionData tcpConnForCluster(const std::string&, LoadBalancerContext*,
                                                Network::TransportSocketOptionsSharedPtr) override;
   Http::AsyncClient& httpAsyncClientForCluster(const std::string&) override;

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -277,8 +277,8 @@ public:
     EXPECT_CALL(*mock_host_, cluster()).WillRepeatedly(ReturnRef(*cluster_info_ptr_));
     EXPECT_CALL(*mock_host_description_, locality()).WillRepeatedly(ReturnRef(host_locality_));
     http_conn_pool_ = std::make_unique<Http::Http2::ProdConnPoolImpl>(
-        dispatcher_, host_ptr_, Upstream::ResourcePriority::Default, nullptr);
-    EXPECT_CALL(cm_, httpConnPoolForCluster(_, _, _, _))
+        dispatcher_, host_ptr_, Upstream::ResourcePriority::Default, nullptr, nullptr);
+    EXPECT_CALL(cm_, httpConnPoolForCluster(_, _, _, _, _))
         .WillRepeatedly(Return(http_conn_pool_.get()));
     http_async_client_ = std::make_unique<Http::AsyncClientImpl>(
         cluster_info_ptr_, *stats_store_, dispatcher_, local_info_, cm_, runtime_, random_,

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -46,7 +46,7 @@ public:
                       Upstream::ClusterInfoConstSharedPtr cluster,
                       NiceMock<Event::MockTimer>* upstream_ready_timer)
       : ConnPoolImpl(dispatcher, Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000"),
-                     Upstream::ResourcePriority::Default, nullptr),
+                     Upstream::ResourcePriority::Default, nullptr, nullptr),
         api_(Api::createApiForTest(stats_store_)), mock_dispatcher_(dispatcher),
         mock_upstream_ready_timer_(upstream_ready_timer) {}
 

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -66,7 +66,7 @@ public:
 
   Http2ConnPoolImplTest()
       : api_(Api::createApiForTest(stats_store_)),
-        pool_(dispatcher_, host_, Upstream::ResourcePriority::Default, nullptr) {}
+        pool_(dispatcher_, host_, Upstream::ResourcePriority::Default, nullptr, nullptr) {}
 
   ~Http2ConnPoolImplTest() {
     // Make sure all gauges are 0.

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -155,6 +155,8 @@ envoy_cc_test(
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/http:context_lib",
+        "//source/common/network:transport_socket_options_lib",
+        "//source/common/network:upstream_server_name_lib",
         "//source/common/network:utility_lib",
         "//source/common/router:router_lib",
         "//source/common/upstream:upstream_includes",

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -103,7 +103,7 @@ MockClusterUpdateCallbacksHandle::~MockClusterUpdateCallbacksHandle() = default;
 MockClusterManager::MockClusterManager(TimeSource&) : MockClusterManager() {}
 
 MockClusterManager::MockClusterManager() {
-  ON_CALL(*this, httpConnPoolForCluster(_, _, _, _)).WillByDefault(Return(&conn_pool_));
+  ON_CALL(*this, httpConnPoolForCluster(_, _, _, _, _)).WillByDefault(Return(&conn_pool_));
   ON_CALL(*this, tcpConnPoolForCluster(_, _, _, _)).WillByDefault(Return(&tcp_conn_pool_));
   ON_CALL(*this, httpAsyncClientForCluster(_)).WillByDefault(ReturnRef(async_client_));
   ON_CALL(*this, httpAsyncClientForCluster(_)).WillByDefault((ReturnRef(async_client_)));

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -196,10 +196,11 @@ public:
                                  const LocalInfo::LocalInfo& local_info,
                                  AccessLog::AccessLogManager& log_manager, Server::Admin& admin));
 
-  MOCK_METHOD5(allocateConnPool, Http::ConnectionPool::InstancePtr(
+  MOCK_METHOD6(allocateConnPool, Http::ConnectionPool::InstancePtr(
                                      Event::Dispatcher& dispatcher, HostConstSharedPtr host,
                                      ResourcePriority priority, Http::Protocol protocol,
-                                     const Network::ConnectionSocket::OptionsSharedPtr& options));
+                                     const Network::ConnectionSocket::OptionsSharedPtr& options,
+                                     Network::TransportSocketOptionsSharedPtr));
 
   MOCK_METHOD5(allocateTcpConnPool, Tcp::ConnectionPool::InstancePtr(
                                         Event::Dispatcher& dispatcher, HostConstSharedPtr host,
@@ -253,10 +254,11 @@ public:
   MOCK_METHOD1(setInitializedCb, void(std::function<void()>));
   MOCK_METHOD0(clusters, ClusterInfoMap());
   MOCK_METHOD1(get, ThreadLocalCluster*(const std::string& cluster));
-  MOCK_METHOD4(httpConnPoolForCluster,
-               Http::ConnectionPool::Instance*(const std::string& cluster,
-                                               ResourcePriority priority, Http::Protocol protocol,
-                                               LoadBalancerContext* context));
+  MOCK_METHOD5(httpConnPoolForCluster,
+               Http::ConnectionPool::Instance*(
+                   const std::string& cluster, ResourcePriority priority, Http::Protocol protocol,
+                   LoadBalancerContext* context,
+                   Network::TransportSocketOptionsSharedPtr transport_socket_options));
   MOCK_METHOD4(tcpConnPoolForCluster,
                Tcp::ConnectionPool::Instance*(
                    const std::string& cluster, ResourcePriority priority,

--- a/test/server/config_validation/cluster_manager_test.cc
+++ b/test/server/config_validation/cluster_manager_test.cc
@@ -46,8 +46,9 @@ TEST(ValidationClusterManagerTest, MockedMethods) {
   const envoy::config::bootstrap::v2::Bootstrap bootstrap;
   ClusterManagerPtr cluster_manager = factory.clusterManagerFromProto(
       bootstrap, stats_store, tls, runtime, random, local_info, log_manager, admin);
-  EXPECT_EQ(nullptr, cluster_manager->httpConnPoolForCluster("cluster", ResourcePriority::Default,
-                                                             Http::Protocol::Http11, nullptr));
+  EXPECT_EQ(nullptr,
+            cluster_manager->httpConnPoolForCluster("cluster", ResourcePriority::Default,
+                                                    Http::Protocol::Http11, nullptr, nullptr));
   Host::CreateConnectionData data = cluster_manager->tcpConnForCluster("cluster", nullptr, nullptr);
   EXPECT_EQ(nullptr, data.connection_);
   EXPECT_EQ(nullptr, data.host_description_);


### PR DESCRIPTION
in particular, requested server name.

similar to https://github.com/envoyproxy/envoy/pull/4973

Signed-off-by: Vadim Eisenberg <vadime@il.ibm.com>

*Description*: add support for passing TransportSocketOptions in HTTP filters, in particular requested server name
*Risk Level*: low
*Testing*: a unit test
*Docs Changes*: none
*Release Notes*: 
