### PR TITLE
build: copy entrypoint script from ci/ dir

### DIFF
--- a/ci/Dockerfile-envoy-alpine
+++ b/ci/Dockerfile-envoy-alpine
@@ -7,6 +7,6 @@ ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
 
 EXPOSE 10000
 
-COPY docker-entrypoint.sh /
+COPY ci/docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["envoy", "--v2-config-only", "-c", "/etc/envoy/envoy.yaml"]

--- a/ci/Dockerfile-envoy-alpine-debug
+++ b/ci/Dockerfile-envoy-alpine-debug
@@ -7,6 +7,6 @@ ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
 
 EXPOSE 10000
 
-COPY docker-entrypoint.sh /
+COPY ci/docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["envoy", "--v2-config-only", "-c", "/etc/envoy/envoy.yaml"]

--- a/ci/Dockerfile-envoy-image
+++ b/ci/Dockerfile-envoy-image
@@ -15,6 +15,6 @@ ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
 
 EXPOSE 10000
 
-COPY docker-entrypoint.sh /
+COPY ci/docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["envoy", "--v2-config-only", "-c", "/etc/envoy/envoy.yaml"]


### PR DESCRIPTION
This fixes failure on finding the `docker-entrypoint.sh`. e.g. as observed in https://circleci.com/gh/envoyproxy/envoy/138888, as a follow-up of https://github.com/envoyproxy/envoy/pull/5326.

*Risk Level*: Low
*Testing*: Manual
*Docs Changes*: N/A
*Release Notes*: N/A

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>