### PR TITLE
grpc: casting of wrong message to ResponseType may throw exception

### DIFF
--- a/include/envoy/grpc/async_client.h
+++ b/include/envoy/grpc/async_client.h
@@ -172,7 +172,7 @@ public:
     // casting of wrong message to ResponseType may throw exception
     try {
       onReceiveMessage(std::unique_ptr<ResponseType>(dynamic_cast<ResponseType*>(message.release())));
-    } catch(const std::exception& e) {
+    } catch (const std::exception& e) {
       std::cout << "wrong message received, error: " << e.what() << std::endl;
     }
   }

--- a/include/envoy/grpc/async_client.h
+++ b/include/envoy/grpc/async_client.h
@@ -169,7 +169,12 @@ public:
   virtual void onReceiveMessage(std::unique_ptr<ResponseType>&& message) PURE;
 
   void onReceiveMessageUntyped(ProtobufTypes::MessagePtr&& message) override {
-    onReceiveMessage(std::unique_ptr<ResponseType>(dynamic_cast<ResponseType*>(message.release())));
+    // casting of wrong message to ResponseType may throw exception
+    try {
+      onReceiveMessage(std::unique_ptr<ResponseType>(dynamic_cast<ResponseType*>(message.release())));
+    } catch(const std::exception& e) {
+      std::cout << "wrong message received, error: " << e.what() << std::endl;
+    }
   }
 };
 


### PR DESCRIPTION
Signed-off-by: jianghongke <jianghongke@tencent.com>

*Description*: casting of wrong message to ResponseType may throw exception
*Risk Level*: High
*Testing*: None
*Docs Changes*: None
*Release Notes*: None
*Fixes*： #5409 
[Optional *Deprecated*:] None
