### PR TITLE
docs: reorder lb docs

### DIFF
--- a/docs/root/intro/arch_overview/load_balancing/load_balancing.rst
+++ b/docs/root/intro/arch_overview/load_balancing/load_balancing.rst
@@ -6,10 +6,10 @@ Load Balancing
 
   overview
   load_balancers
-  original_dst
-  overprovisioning
   priority
-  zone_aware
-  panic_threshold
   locality_weight
+  overprovisioning
+  panic_threshold
+  original_dst
+  zone_aware
   subsets


### PR DESCRIPTION
This reorders the lb docs to hopefully make the sequencing make a bit
more sense. It groups all the locality/priority stuff together, as
there's quite a lot of interplay between them and moves individual topics
to the end.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: n/a
*Testing*: n/a
*Docs Changes*: n/a
*Release Notes*: n/a
Part of #5081