### PR TITLE
Remove strncasecmp

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -451,23 +451,6 @@ std::string AccessLogDateTimeFormatter::fromTime(const SystemTime& time) {
   return cached_time.formatted_time;
 }
 
-bool StringUtil::endsWith(const std::string& source, const std::string& end) {
-  if (source.length() < end.length()) {
-    return false;
-  }
-
-  size_t start_position = source.length() - end.length();
-  return std::equal(source.begin() + start_position, source.end(), end.begin());
-}
-
-bool StringUtil::startsWith(const char* source, const std::string& start, bool case_sensitive) {
-  if (case_sensitive) {
-    return strncmp(source, start.c_str(), start.size()) == 0;
-  } else {
-    return strncasecmp(source, start.c_str(), start.size()) == 0;
-  }
-}
-
 const std::string& StringUtil::nonEmptyStringOrDefault(const std::string& s,
                                                        const std::string& default_value) {
   return s.empty() ? default_value : s;

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <strings.h>
-
 #include <chrono>
 #include <cstdint>
 #include <regex>
@@ -166,16 +164,6 @@ public:
   static bool atol(const char* str, int64_t& out, int base = 10);
 
   /**
-   * Perform a case insensitive compare of 2 strings.
-   * @param lhs supplies string 1.
-   * @param rhs supplies string 2.
-   * @return < 0, 0, > 0 depending on the comparison result.
-   */
-  static int caseInsensitiveCompare(const char* lhs, const char* rhs) {
-    return strcasecmp(lhs, rhs);
-  }
-
-  /**
    * Convert an unsigned integer to a base 10 string as fast as possible.
    * @param out supplies the string to fill.
    * @param out_len supplies the length of the output buffer. Must be >= MIN_ITOA_OUT_LEN.
@@ -322,17 +310,6 @@ public:
    * @return escaped string.
    */
   static std::string escape(const std::string& source);
-
-  /**
-   * @return true if @param source ends with @param end.
-   */
-  static bool endsWith(const std::string& source, const std::string& end);
-
-  /**
-   * @param case_sensitive determines if the compare is case sensitive
-   * @return true if @param source starts with @param start and ignores cases.
-   */
-  static bool startsWith(const char* source, const std::string& start, bool case_sensitive = true);
 
   /**
    * Provide a default value for a string if empty.

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -18,6 +18,8 @@
 #include "common/http/utility.h"
 #include "common/protobuf/protobuf.h"
 
+#include "absl/strings/match.h"
+
 namespace Envoy {
 namespace Grpc {
 
@@ -26,8 +28,8 @@ bool Common::hasGrpcContentType(const Http::HeaderMap& headers) {
   // Content type is gRPC if it is exactly "application/grpc" or starts with
   // "application/grpc+". Specifically, something like application/grpc-web is not gRPC.
   return content_type != nullptr &&
-         StringUtil::startsWith(content_type->value().c_str(),
-                                Http::Headers::get().ContentTypeValues.Grpc) &&
+         absl::StartsWith(content_type->value().getStringView(),
+                          Http::Headers::get().ContentTypeValues.Grpc) &&
          (content_type->value().size() == Http::Headers::get().ContentTypeValues.Grpc.size() ||
           content_type->value().c_str()[Http::Headers::get().ContentTypeValues.Grpc.size()] == '+');
 }

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -32,6 +32,8 @@
 #include "common/http/utility.h"
 #include "common/network/utility.h"
 
+#include "absl/strings/match.h"
+
 namespace Envoy {
 namespace Http {
 
@@ -585,9 +587,8 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
       // will be closed unless Keep-Alive is present.
       state_.saw_connection_close_ = true;
       if (request_headers_->Connection() &&
-          0 == StringUtil::caseInsensitiveCompare(
-                   request_headers_->Connection()->value().c_str(),
-                   Http::Headers::get().ConnectionValues.KeepAlive.c_str())) {
+          absl::EqualsIgnoreCase(request_headers_->Connection()->value().getStringView(),
+                                 Http::Headers::get().ConnectionValues.KeepAlive)) {
         state_.saw_connection_close_ = false;
       }
     }
@@ -633,9 +634,8 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
   }
 
   if (protocol == Protocol::Http11 && request_headers_->Connection() &&
-      0 ==
-          StringUtil::caseInsensitiveCompare(request_headers_->Connection()->value().c_str(),
-                                             Http::Headers::get().ConnectionValues.Close.c_str())) {
+      absl::EqualsIgnoreCase(request_headers_->Connection()->value().getStringView(),
+                             Http::Headers::get().ConnectionValues.Close)) {
     state_.saw_connection_close_ = true;
   }
 

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -16,6 +16,8 @@
 #include "common/network/utility.h"
 #include "common/upstream/upstream_impl.h"
 
+#include "absl/strings/match.h"
+
 namespace Envoy {
 namespace Http {
 namespace Http1 {
@@ -263,8 +265,8 @@ void ConnPoolImpl::StreamWrapper::onEncodeComplete() { encode_complete_ = true; 
 
 void ConnPoolImpl::StreamWrapper::decodeHeaders(HeaderMapPtr&& headers, bool end_stream) {
   if (headers->Connection() &&
-      0 == StringUtil::caseInsensitiveCompare(headers->Connection()->value().c_str(),
-                                              Headers::get().ConnectionValues.Close.c_str())) {
+      absl::EqualsIgnoreCase(headers->Connection()->value().getStringView(),
+                             Headers::get().ConnectionValues.Close)) {
     saw_close_header_ = true;
     parent_.parent_.host_->cluster().stats().upstream_cx_close_notify_.inc();
   }

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -20,6 +20,7 @@
 #include "common/network/utility.h"
 #include "common/protobuf/utility.h"
 
+#include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 
 namespace Envoy {
@@ -210,9 +211,9 @@ bool Utility::isH2UpgradeRequest(const HeaderMap& headers) {
 }
 
 bool Utility::isWebSocketUpgradeRequest(const HeaderMap& headers) {
-  return (isUpgrade(headers) && (0 == StringUtil::caseInsensitiveCompare(
-                                          headers.Upgrade()->value().c_str(),
-                                          Http::Headers::get().UpgradeValues.WebSocket.c_str())));
+  return (isUpgrade(headers) &&
+          absl::EqualsIgnoreCase(headers.Upgrade()->value().getStringView(),
+                                 Http::Headers::get().UpgradeValues.WebSocket));
 }
 
 Http2Settings

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -24,6 +24,7 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 
+#include "absl/strings/match.h"
 #include "yaml-cpp/yaml.h"
 
 namespace Envoy {
@@ -685,8 +686,8 @@ bool ObjectHandler::handleValueEvent(FieldSharedPtr ptr) {
 ObjectSharedPtr Factory::loadFromFile(const std::string& file_path) {
   try {
     const std::string contents = Filesystem::fileReadToEnd(file_path);
-    return StringUtil::endsWith(file_path, ".yaml") ? loadFromYamlString(contents)
-                                                    : loadFromString(contents);
+    return absl::EndsWith(file_path, ".yaml") ? loadFromYamlString(contents)
+                                              : loadFromString(contents);
   } catch (EnvoyException& e) {
     throw Exception(e.what());
   }

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -33,6 +33,8 @@
 
 #include "common/common/fmt.h"
 
+#include "absl/strings/match.h"
+
 namespace Envoy {
 namespace Network {
 
@@ -53,17 +55,11 @@ Address::InstanceConstSharedPtr Utility::resolveUrl(const std::string& url) {
   }
 }
 
-bool Utility::urlIsTcpScheme(const std::string& url) {
-  return StringUtil::startsWith(url.c_str(), TCP_SCHEME, true);
-}
+bool Utility::urlIsTcpScheme(const std::string& url) { return absl::StartsWith(url, TCP_SCHEME); }
 
-bool Utility::urlIsUdpScheme(const std::string& url) {
-  return StringUtil::startsWith(url.c_str(), UDP_SCHEME, true);
-}
+bool Utility::urlIsUdpScheme(const std::string& url) { return absl::StartsWith(url, UDP_SCHEME); }
 
-bool Utility::urlIsUnixScheme(const std::string& url) {
-  return StringUtil::startsWith(url.c_str(), UNIX_SCHEME, true);
-}
+bool Utility::urlIsUnixScheme(const std::string& url) { return absl::StartsWith(url, UNIX_SCHEME); }
 
 namespace {
 

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -6,6 +6,8 @@
 #include "common/json/json_loader.h"
 #include "common/protobuf/protobuf.h"
 
+#include "absl/strings/match.h"
+
 namespace Envoy {
 namespace ProtobufPercentHelper {
 
@@ -81,7 +83,7 @@ void MessageUtil::loadFromYaml(const std::string& yaml, Protobuf::Message& messa
 void MessageUtil::loadFromFile(const std::string& path, Protobuf::Message& message) {
   const std::string contents = Filesystem::fileReadToEnd(path);
   // If the filename ends with .pb, attempt to parse it as a binary proto.
-  if (StringUtil::endsWith(path, ".pb")) {
+  if (absl::EndsWith(path, ".pb")) {
     // Attempt to parse the binary format.
     if (message.ParseFromString(contents)) {
       MessageUtil::checkUnknownFields(message);
@@ -91,14 +93,14 @@ void MessageUtil::loadFromFile(const std::string& path, Protobuf::Message& messa
                          message.GetTypeName() + ")");
   }
   // If the filename ends with .pb_text, attempt to parse it as a text proto.
-  if (StringUtil::endsWith(path, ".pb_text")) {
+  if (absl::EndsWith(path, ".pb_text")) {
     if (Protobuf::TextFormat::ParseFromString(contents, &message)) {
       return;
     }
     throw EnvoyException("Unable to parse file \"" + path + "\" as a text protobuf (type " +
                          message.GetTypeName() + ")");
   }
-  if (StringUtil::endsWith(path, ".yaml")) {
+  if (absl::EndsWith(path, ".yaml")) {
     loadFromYaml(contents, message);
   } else {
     loadFromJson(contents, message);

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -33,6 +33,8 @@
 
 #include "extensions/filters/http/well_known_names.h"
 
+#include "absl/strings/match.h"
+
 namespace Envoy {
 namespace Router {
 
@@ -479,7 +481,8 @@ void RouteEntryImplBase::finalizePathHeader(Http::HeaderMap& headers,
   if (insert_envoy_original_path) {
     headers.insertEnvoyOriginalPath().value(*headers.Path());
   }
-  ASSERT(StringUtil::startsWith(path.c_str(), matched_path, case_sensitive_));
+  ASSERT(case_sensitive_ ? absl::StartsWith(path, matched_path)
+                         : absl::StartsWithIgnoreCase(path, matched_path));
   headers.Path()->value(path.replace(0, matched_path.size(), rewrite));
 }
 
@@ -713,7 +716,9 @@ void PrefixRouteEntryImpl::rewritePathHeader(Http::HeaderMap& headers,
 RouteConstSharedPtr PrefixRouteEntryImpl::matches(const Http::HeaderMap& headers,
                                                   uint64_t random_value) const {
   if (RouteEntryImplBase::matchRoute(headers, random_value) &&
-      StringUtil::startsWith(headers.Path()->value().c_str(), prefix_, case_sensitive_)) {
+      (case_sensitive_
+           ? absl::StartsWith(headers.Path()->value().getStringView(), prefix_)
+           : absl::StartsWithIgnoreCase(headers.Path()->value().getStringView(), prefix_))) {
     return clusterEntry(headers, random_value);
   }
   return nullptr;
@@ -743,12 +748,14 @@ RouteConstSharedPtr PathRouteEntryImpl::matches(const Http::HeaderMap& headers,
       return nullptr;
     }
 
+    absl::string_view path_section(path.c_str(), compare_length);
     if (case_sensitive_) {
-      if (0 == strncmp(path.c_str(), path_.c_str(), compare_length)) {
+      // We can use StartsWith here, since we know path_.size() == path_section.size()
+      if (absl::StartsWith(path_, path_section)) {
         return clusterEntry(headers, random_value);
       }
     } else {
-      if (0 == strncasecmp(path.c_str(), path_.c_str(), compare_length)) {
+      if (absl::EqualsIgnoreCase(path_, path_section)) {
         return clusterEntry(headers, random_value);
       }
     }

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -17,6 +17,8 @@
 // TODO(dio): Remove dependency to extension health checkers when redis_health_check is removed.
 #include "extensions/health_checkers/well_known_names.h"
 
+#include "absl/strings/match.h"
+
 namespace Envoy {
 namespace Upstream {
 
@@ -218,9 +220,8 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onResponseComplete() {
   }
 
   if ((response_headers_->Connection() &&
-       0 == StringUtil::caseInsensitiveCompare(
-                response_headers_->Connection()->value().c_str(),
-                Http::Headers::get().ConnectionValues.Close.c_str())) ||
+       absl::EqualsIgnoreCase(response_headers_->Connection()->value().getStringView(),
+                              Http::Headers::get().ConnectionValues.Close)) ||
       !parent_.reuse_connection_) {
     client_->close();
   }

--- a/source/extensions/filters/http/dynamo/dynamo_request_parser.cc
+++ b/source/extensions/filters/http/dynamo/dynamo_request_parser.cc
@@ -7,6 +7,8 @@
 
 #include "common/common/utility.h"
 
+#include "absl/strings/match.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -110,7 +112,7 @@ std::string RequestParser::parseErrorType(const Json::Object& json_data) {
   }
 
   for (const std::string& supported_error_type : SUPPORTED_ERROR_TYPES) {
-    if (StringUtil::endsWith(error_type, supported_error_type)) {
+    if (absl::EndsWith(error_type, supported_error_type)) {
       return supported_error_type;
     }
   }

--- a/source/extensions/filters/http/jwt_authn/extractor.cc
+++ b/source/extensions/filters/http/jwt_authn/extractor.cc
@@ -7,6 +7,8 @@
 #include "common/http/utility.h"
 #include "common/singleton/const_singleton.h"
 
+#include "absl/strings/match.h"
+
 using ::envoy::config::filter::http::jwt_authn::v2alpha::JwtAuthentication;
 using ::envoy::config::filter::http::jwt_authn::v2alpha::JwtHeader;
 using ::envoy::config::filter::http::jwt_authn::v2alpha::JwtProvider;
@@ -179,7 +181,7 @@ std::vector<JwtLocationConstPtr> ExtractorImpl::extract(const Http::HeaderMap& h
     if (entry) {
       auto value_str = entry->value().getStringView();
       if (!location_spec->value_prefix_.empty()) {
-        if (!StringUtil::startsWith(value_str.data(), location_spec->value_prefix_, true)) {
+        if (!absl::StartsWith(value_str, location_spec->value_prefix_)) {
           // prefix doesn't match, skip it.
           continue;
         }

--- a/source/extensions/filters/http/jwt_authn/matcher.cc
+++ b/source/extensions/filters/http/jwt_authn/matcher.cc
@@ -2,6 +2,8 @@
 
 #include "common/router/config_impl.h"
 
+#include "absl/strings/match.h"
+
 using ::envoy::api::v2::route::RouteMatch;
 using ::envoy::config::filter::http::jwt_authn::v2alpha::JwtProvider;
 using ::envoy::config::filter::http::jwt_authn::v2alpha::RequirementRule;
@@ -71,7 +73,9 @@ public:
 
   bool matches(const Http::HeaderMap& headers) const override {
     if (BaseMatcherImpl::matchRoute(headers) &&
-        StringUtil::startsWith(headers.Path()->value().c_str(), prefix_, case_sensitive_)) {
+        (case_sensitive_
+             ? absl::StartsWith(headers.Path()->value().getStringView(), prefix_)
+             : absl::StartsWithIgnoreCase(headers.Path()->value().getStringView(), prefix_))) {
       ENVOY_LOG(debug, "Prefix requirement '{}' matched.", prefix_);
       return true;
     }

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -12,6 +12,8 @@
 #include "extensions/filters/network/thrift_proxy/app_exception_impl.h"
 #include "extensions/filters/network/well_known_names.h"
 
+#include "absl/strings/match.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
@@ -114,7 +116,7 @@ ServiceNameRouteEntryImpl::ServiceNameRouteEntryImpl(
     throw EnvoyException("Cannot have an empty service name with inversion enabled");
   }
 
-  if (!service_name.empty() && !StringUtil::endsWith(service_name, ":")) {
+  if (!service_name.empty() && !absl::EndsWith(service_name, ":")) {
     service_name_ = service_name + ":";
   } else {
     service_name_ = service_name;
@@ -124,9 +126,9 @@ ServiceNameRouteEntryImpl::ServiceNameRouteEntryImpl(
 RouteConstSharedPtr ServiceNameRouteEntryImpl::matches(const MessageMetadata& metadata,
                                                        uint64_t random_value) const {
   if (RouteEntryImplBase::headersMatch(metadata.headers())) {
-    bool matches = service_name_.empty() ||
-                   (metadata.hasMethodName() &&
-                    StringUtil::startsWith(metadata.methodName().c_str(), service_name_));
+    bool matches =
+        service_name_.empty() ||
+        (metadata.hasMethodName() && absl::StartsWith(metadata.methodName(), service_name_));
 
     if (matches ^ invert_) {
       return clusterEntry(random_value);

--- a/test/common/common/utility_fuzz_test.cc
+++ b/test/common/common/utility_fuzz_test.cc
@@ -2,6 +2,7 @@
 
 #include "test/fuzz/fuzz_runner.h"
 
+#include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 
 namespace Envoy {
@@ -40,7 +41,7 @@ DEFINE_FUZZER(const uint8_t* buf, size_t len) {
     //  @param2: substring of buffer from split_point to end of the string
     {
       const std::string string_buffer(reinterpret_cast<const char*>(buf), len);
-      StringUtil::endsWith(string_buffer.substr(0, split_point), string_buffer.substr(split_point));
+      absl::EndsWith(string_buffer.substr(0, split_point), string_buffer.substr(split_point));
     }
     {
       const std::string string_buffer(reinterpret_cast<const char*>(buf), len);

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -159,12 +159,6 @@ TEST(StringUtil, WhitespaceChars) {
   EXPECT_NE(nullptr, strchr(StringUtil::WhitespaceChars, '\r'));
 }
 
-TEST(StringUtil, caseInsensitiveCompare) {
-  EXPECT_EQ(0, StringUtil::caseInsensitiveCompare("CONTENT-LENGTH", "content-length"));
-  EXPECT_LT(0, StringUtil::caseInsensitiveCompare("CONTENT-LENGTH", "blah"));
-  EXPECT_GT(0, StringUtil::caseInsensitiveCompare("CONTENT-LENGTH", "hello"));
-}
-
 TEST(StringUtil, itoa) {
   char buf[32];
   EXPECT_THROW(StringUtil::itoa(buf, 20, 1), std::invalid_argument);
@@ -230,30 +224,6 @@ TEST(StringUtil, join) {
   EXPECT_EQ("hello,,world", StringUtil::join({"hello", "world"}, ",,"));
   EXPECT_EQ("hello", StringUtil::join({"hello"}, ",,"));
   EXPECT_EQ("", StringUtil::join({}, ",,"));
-}
-
-TEST(StringUtil, endsWith) {
-  EXPECT_TRUE(StringUtil::endsWith("test", "st"));
-  EXPECT_TRUE(StringUtil::endsWith("t", "t"));
-  EXPECT_TRUE(StringUtil::endsWith("test", ""));
-  EXPECT_TRUE(StringUtil::endsWith("", ""));
-  EXPECT_FALSE(StringUtil::endsWith("test", "ttest"));
-  EXPECT_FALSE(StringUtil::endsWith("test", "w"));
-}
-
-TEST(StringUtil, startsWith) {
-  EXPECT_TRUE(StringUtil::startsWith("Test", "Te"));
-  EXPECT_TRUE(StringUtil::startsWith("Test", "Te", false));
-  EXPECT_TRUE(StringUtil::startsWith("Test", "te", false));
-  EXPECT_TRUE(StringUtil::startsWith("", ""));
-  EXPECT_TRUE(StringUtil::startsWith("test", ""));
-  EXPECT_FALSE(StringUtil::startsWith("Test", "te"));
-  EXPECT_FALSE(StringUtil::startsWith("Test", "tE", true));
-  EXPECT_FALSE(StringUtil::startsWith("test", "boo", true));
-  EXPECT_FALSE(StringUtil::startsWith("test", "boo", false));
-  EXPECT_FALSE(StringUtil::startsWith("test", "testtest"));
-  EXPECT_FALSE(StringUtil::startsWith("test", "TESTTEST", false));
-  EXPECT_FALSE(StringUtil::startsWith("", "test"));
 }
 
 TEST(StringUtil, escape) {

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -8,6 +8,7 @@
 #include "test/proto/bookstore.pb.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/match.h"
 #include "gtest/gtest.h"
 
 using Envoy::Protobuf::Message;
@@ -123,9 +124,11 @@ protected:
     EXPECT_TRUE(response->complete());
 
     if (response->headers().get(Http::LowerCaseString("transfer-encoding")) == nullptr ||
-        strncmp(
-            response->headers().get(Http::LowerCaseString("transfer-encoding"))->value().c_str(),
-            "chunked", strlen("chunked")) != 0) {
+        !absl::StartsWith(response->headers()
+                              .get(Http::LowerCaseString("transfer-encoding"))
+                              ->value()
+                              .getStringView(),
+                          "chunked")) {
       EXPECT_EQ(response->headers().get(Http::LowerCaseString("trailer")), nullptr);
     }
 
@@ -141,7 +144,7 @@ protected:
       if (full_response) {
         EXPECT_EQ(response_body, response->body());
       } else {
-        EXPECT_TRUE(StringUtil::startsWith(response->body().c_str(), response_body));
+        EXPECT_TRUE(absl::StartsWith(response->body(), response_body));
       }
     }
 

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -26,6 +26,7 @@
 
 #include "test/test_common/network_utility.h"
 
+#include "absl/strings/match.h"
 #include "gtest/gtest.h"
 #include "spdlog/spdlog.h"
 
@@ -99,7 +100,7 @@ void TestEnvironment::createParentPath(const std::string& path) {
 }
 
 void TestEnvironment::removePath(const std::string& path) {
-  RELEASE_ASSERT(StringUtil::startsWith(path.c_str(), TestEnvironment::temporaryDirectory()), "");
+  RELEASE_ASSERT(absl::StartsWith(path, TestEnvironment::temporaryDirectory()), "");
 #ifdef __cpp_lib_experimental_filesystem
   // We don't want to rely on rm etc. if we can avoid it, since it might not
   // exist in some environments such as ClusterFuzz.
@@ -261,7 +262,7 @@ std::string TestEnvironment::temporaryFileSubstitute(const std::string& path,
   // Substitute paths and other common things.
   out_json_string = substitute(out_json_string, version);
 
-  const std::string extension = StringUtil::endsWith(path, ".yaml") ? ".yaml" : ".json";
+  const std::string extension = absl::EndsWith(path, ".yaml") ? ".yaml" : ".json";
   const std::string out_json_path =
       TestEnvironment::temporaryPath(path + ".with.ports" + extension);
   createParentPath(out_json_path);


### PR DESCRIPTION
*Description*:
strncasecmp is not portable. Specifically, it does not exist on Windows. This PR also removes the redundant StringUtil::endsWith and StringUtil::startsWith methods, since they already exist in abseil.

*Risk Level*:
Low

*Testing*:
`bazel build //source/... && bazel test //test/...`

*Docs Changes*:
N/A
*Release Notes*:
N/A