### PR TITLE
test: Extend the coverage timeout to 2000 seconds. 1000 seconds is no longer enough

### DIFF
--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -37,7 +37,7 @@ BAZEL_TEST_OPTIONS="${BAZEL_TEST_OPTIONS} -c dbg --copt=-DNDEBUG"
 "${BAZEL_COVERAGE}" --batch test "${COVERAGE_TARGET}" ${BAZEL_TEST_OPTIONS} \
   --cache_test_results=no --cxxopt="--coverage" --cxxopt="-DENVOY_CONFIG_COVERAGE=1" \
   --linkopt="--coverage" --define ENVOY_CONFIG_COVERAGE=1 --test_output=streamed \
-  --strategy=Genrule=standalone --spawn_strategy=standalone --test_timeout=1000 \
+  --strategy=Genrule=standalone --spawn_strategy=standalone --test_timeout=2000 \
   --test_arg="--log-path /dev/null" --test_arg="-l trace"
 
 # The Bazel build has a lot of whack in it, in particular generated files, headers from external


### PR DESCRIPTION
*Description*: When coverage tests fail in CI, it's sometimes easiest to run them locally. However, this stopped working for me, on my machine, under docker, due to timeout issues. Envoy tests grow in number and complexity over time of course, and so our time-limits for serial tests need to grow as well.
*Risk Level*: low
*Testing*: just ran this script
*Docs Changes*: n/a
*Release Notes*: n/a

