### PR TITLE
docs: Fix an error in gzip filter documentation

### DIFF
--- a/docs/root/configuration/http_filters/gzip_filter.rst
+++ b/docs/root/configuration/http_filters/gzip_filter.rst
@@ -61,8 +61,8 @@ By *default* compression will be *skipped* when:
 When compression is *applied*:
 
 - The *content-length* is removed from response headers.
-- Response headers contain "*transfer-encoding: chunked*" and
-  "*content-encoding: gzip*".
+- Response headers contain "*transfer-encoding: chunked*" and do not contain
+  "*content-encoding*" header.
 - The "*vary: accept-encoding*" header is inserted on every response.
 
 .. _gzip-statistics:
@@ -87,4 +87,3 @@ Every configured Gzip filter has statistics rooted at <stat_prefix>.gzip.* with 
   total_compressed_bytes, Counter, The total compressed bytes of all the requests that were marked for compression.
   content_length_too_small, Counter, Number of requests that accepted gzip encoding but did not compress because the payload was too small.
   not_compressed_etag, Counter, Number of requests that were not compressed due to the etag header. *disable_on_etag_header* must be turned on for this to happen.
-  


### PR DESCRIPTION
*Description*:
Looking at the source code: https://github.com/envoyproxy/envoy/blob/a36fc3e8f2d64b86dbd2103f9143ac3515c16fba/source/common/http/filter/gzip_filter.cc#L115

when content-encoding header presents, envoy does not apply gzip compression.

*Risk Level*:
Low
*Testing*:
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
