### PR TITLE
dubbo_proxy: Add filter extension mechanism for Dubbo protocol

### DIFF
--- a/source/extensions/filters/network/dubbo_proxy/BUILD
+++ b/source/extensions/filters/network/dubbo_proxy/BUILD
@@ -147,6 +147,7 @@ envoy_cc_library(
     hdrs = ["decoder_event_handler.h"],
     deps = [
         ":metadata_lib",
+        "//include/envoy/network:filter_interface",
         "//source/common/buffer:buffer_lib",
     ],
 )

--- a/source/extensions/filters/network/dubbo_proxy/BUILD
+++ b/source/extensions/filters/network/dubbo_proxy/BUILD
@@ -141,3 +141,12 @@ envoy_cc_library(
     name = "message_lib",
     hdrs = ["message.h"],
 )
+
+envoy_cc_library(
+    name = "decoder_events_lib",
+    hdrs = ["decoder_event_handler.h"],
+    deps = [
+        ":metadata_lib",
+        "//source/common/buffer:buffer_lib",
+    ],
+)

--- a/source/extensions/filters/network/dubbo_proxy/decoder_event_handler.h
+++ b/source/extensions/filters/network/dubbo_proxy/decoder_event_handler.h
@@ -1,10 +1,13 @@
 #pragma once
 
 #include "envoy/common/pure.h"
+#include "envoy/network/connection.h"
+#include "envoy/network/filter.h"
 
 #include "common/buffer/buffer_impl.h"
 
 #include "extensions/filters/network/dubbo_proxy/message.h"
+#include "extensions/filters/network/dubbo_proxy/metadata.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/filters/network/dubbo_proxy/decoder_event_handler.h
+++ b/source/extensions/filters/network/dubbo_proxy/decoder_event_handler.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "envoy/common/pure.h"
+
+#include "common/buffer/buffer_impl.h"
+
+#include "extensions/filters/network/dubbo_proxy/message.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace DubboProxy {
+
+/**
+ * This class provides the pass-through capability of the original data of
+ * the Dubbo protocol to improve the forwarding efficiency
+ * when no modification of the original data is required.
+ */
+class ProtocolDataPassthroughConverter {
+public:
+  ProtocolDataPassthroughConverter() {}
+  virtual ~ProtocolDataPassthroughConverter() {}
+
+  void initProtocolConverter(Buffer::Instance& buffer) { buffer_ = &buffer; }
+
+  /**
+   * Transfer the original header data of the Dubbo protocol,
+   * it's called after the protocol's header data is parsed.
+   * @param header_buf raw header data
+   * @param size The size of the head.
+   */
+  virtual Network::FilterStatus transferHeaderTo(const Buffer::Instance& header_buf, size_t size) {
+    if (buffer_ != nullptr) {
+      Buffer::OwnedImpl copy(header_buf);
+      buffer_->move(copy, size);
+    }
+    return Network::FilterStatus::Continue;
+  }
+
+  /**
+   * Transfer the original body data of the Dubbo protocol
+   * it's called after the protocol's body data is parsed.
+   * @param header_buf raw body data
+   * @param size The size of the body.
+   */
+  virtual Network::FilterStatus transferBodyTo(const Buffer::Instance& body_buf, size_t size) {
+    if (buffer_ != nullptr) {
+      Buffer::OwnedImpl copy(body_buf);
+      buffer_->move(copy, size);
+    }
+    return Network::FilterStatus::Continue;
+  }
+
+protected:
+  Buffer::Instance* buffer_{nullptr};
+};
+
+class DecoderEventHandler : public ProtocolDataPassthroughConverter {
+public:
+  virtual ~DecoderEventHandler() override {}
+
+  /**
+   * Indicates the start of a Dubbo transport data was detected. Unframed transports generate
+   * simulated start messages.
+   */
+  virtual Network::FilterStatus transportBegin() PURE;
+
+  /**
+   * Indicates the end of a Dubbo transport data was detected. Unframed transport generate
+   * simulated complete messages.
+   */
+  virtual Network::FilterStatus transportEnd() PURE;
+
+  /**
+   * Indicates that the start of a Dubbo protocol message was detected.
+   * @param type the message type
+   * @param message_id the message identifier
+   * @param serialization_type the serialization type of the message
+   * @return FilterStatus to indicate if filter chain iteration should continue
+   */
+  virtual Network::FilterStatus messageBegin(MessageType type, int64_t message_id,
+                                             SerializationType serialization_type) PURE;
+
+  /**
+   * Indicates that the end of a Dubbo protocol message was detected.
+   * @param metadata MessageMetadataSharedPtr describing the message
+   * @return FilterStatus to indicate if filter chain iteration should continue
+   */
+  virtual Network::FilterStatus messageEnd(MessageMetadataSharedPtr metadata) PURE;
+};
+
+class DecoderCallbacks {
+public:
+  virtual ~DecoderCallbacks() {}
+
+  /**
+   * @return DecoderEventHandler& a new DecoderEventHandler for a message.
+   */
+  virtual DecoderEventHandler* newDecoderEventHandler() PURE;
+
+  /**
+   * Indicates that the message is a heartbeat.
+   */
+  virtual void onHeartbeat(MessageMetadataSharedPtr) {}
+};
+
+typedef std::shared_ptr<DecoderEventHandler> DecoderEventHandlerSharedPtr;
+
+} // namespace DubboProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/dubbo_proxy/decoder_event_handler.h
+++ b/source/extensions/filters/network/dubbo_proxy/decoder_event_handler.h
@@ -18,6 +18,9 @@ namespace DubboProxy {
  * This class provides the pass-through capability of the original data of
  * the Dubbo protocol to improve the forwarding efficiency
  * when no modification of the original data is required.
+ * Note: If the custom filter does not care about data transfer,
+ *       then it does not need to care about this interface,
+ *       which is currently used by router filter.
  */
 class ProtocolDataPassthroughConverter {
 public:
@@ -34,8 +37,7 @@ public:
    */
   virtual Network::FilterStatus transferHeaderTo(const Buffer::Instance& header_buf, size_t size) {
     if (buffer_ != nullptr) {
-      Buffer::OwnedImpl copy(header_buf);
-      buffer_->move(copy, size);
+      buffer_->move(header_buf, size);
     }
     return Network::FilterStatus::Continue;
   }
@@ -48,8 +50,7 @@ public:
    */
   virtual Network::FilterStatus transferBodyTo(const Buffer::Instance& body_buf, size_t size) {
     if (buffer_ != nullptr) {
-      Buffer::OwnedImpl copy(body_buf);
-      buffer_->move(copy, size);
+      buffer_->move(body_buf, size);
     }
     return Network::FilterStatus::Continue;
   }

--- a/source/extensions/filters/network/dubbo_proxy/decoder_event_handler.h
+++ b/source/extensions/filters/network/dubbo_proxy/decoder_event_handler.h
@@ -35,7 +35,7 @@ public:
    * @param header_buf raw header data
    * @param size The size of the head.
    */
-  virtual Network::FilterStatus transferHeaderTo(const Buffer::Instance& header_buf, size_t size) {
+  virtual Network::FilterStatus transferHeaderTo(Buffer::Instance& header_buf, size_t size) {
     if (buffer_ != nullptr) {
       buffer_->move(header_buf, size);
     }
@@ -48,7 +48,7 @@ public:
    * @param header_buf raw body data
    * @param size The size of the body.
    */
-  virtual Network::FilterStatus transferBodyTo(const Buffer::Instance& body_buf, size_t size) {
+  virtual Network::FilterStatus transferBodyTo(Buffer::Instance& body_buf, size_t size) {
     if (buffer_ != nullptr) {
       buffer_->move(body_buf, size);
     }

--- a/source/extensions/filters/network/dubbo_proxy/decoder_event_handler.h
+++ b/source/extensions/filters/network/dubbo_proxy/decoder_event_handler.h
@@ -24,8 +24,8 @@ namespace DubboProxy {
  */
 class ProtocolDataPassthroughConverter {
 public:
-  ProtocolDataPassthroughConverter() {}
-  virtual ~ProtocolDataPassthroughConverter() {}
+  ProtocolDataPassthroughConverter() = default;
+  virtual ~ProtocolDataPassthroughConverter() = default;
 
   void initProtocolConverter(Buffer::Instance& buffer) { buffer_ = &buffer; }
 
@@ -61,7 +61,7 @@ protected:
 
 class DecoderEventHandler : public ProtocolDataPassthroughConverter {
 public:
-  virtual ~DecoderEventHandler() override {}
+  ~DecoderEventHandler() override = default;
 
   /**
    * Indicates the start of a Dubbo transport data was detected. Unframed transports generate
@@ -95,7 +95,7 @@ public:
 
 class DecoderCallbacks {
 public:
-  virtual ~DecoderCallbacks() {}
+  virtual ~DecoderCallbacks() = default;
 
   /**
    * @return DecoderEventHandler& a new DecoderEventHandler for a message.

--- a/source/extensions/filters/network/dubbo_proxy/filters/BUILD
+++ b/source/extensions/filters/network/dubbo_proxy/filters/BUILD
@@ -19,6 +19,7 @@ envoy_cc_library(
         "//source/extensions/filters/network/dubbo_proxy:deserializer_interface",
         "//source/extensions/filters/network/dubbo_proxy:metadata_lib",
         "//source/extensions/filters/network/dubbo_proxy:protocol_interface",
+        "//source/extensions/filters/network/dubbo_proxy/router:router_interface",
     ],
 )
 

--- a/source/extensions/filters/network/dubbo_proxy/filters/BUILD
+++ b/source/extensions/filters/network/dubbo_proxy/filters/BUILD
@@ -14,6 +14,7 @@ envoy_cc_library(
     deps = [
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/network:connection_interface",
+        "//include/envoy/stream_info:stream_info_interface",
         "//source/extensions/filters/network/dubbo_proxy:decoder_events_lib",
         "//source/extensions/filters/network/dubbo_proxy:deserializer_interface",
         "//source/extensions/filters/network/dubbo_proxy:metadata_lib",
@@ -26,6 +27,8 @@ envoy_cc_library(
     hdrs = ["filter_config.h"],
     deps = [
         ":filter_interface",
+        "//include/envoy/server:filter_config_interface",
+        "//source/common/common:macros",
         "//source/common/protobuf:cc_wkt_protos",
     ],
 )

--- a/source/extensions/filters/network/dubbo_proxy/filters/BUILD
+++ b/source/extensions/filters/network/dubbo_proxy/filters/BUILD
@@ -9,6 +9,19 @@ load(
 envoy_package()
 
 envoy_cc_library(
+    name = "filter_interface",
+    hdrs = ["filter.h"],
+    deps = [
+        "//include/envoy/buffer:buffer_interface",
+        "//include/envoy/network:connection_interface",
+        "//source/extensions/filters/network/dubbo_proxy:decoder_events_lib",
+        "//source/extensions/filters/network/dubbo_proxy:deserializer_interface",
+        "//source/extensions/filters/network/dubbo_proxy:metadata_lib",
+        "//source/extensions/filters/network/dubbo_proxy:protocol_interface",
+    ],
+)
+
+envoy_cc_library(
     name = "filter_config_interface",
     hdrs = ["filter_config.h"],
     deps = [
@@ -23,19 +36,6 @@ envoy_cc_library(
     deps = [
         ":filter_config_interface",
         "//source/common/protobuf:utility_lib",
-    ],
-)
-
-envoy_cc_library(
-    name = "filter_interface",
-    hdrs = ["filter.h"],
-    deps = [
-        "//include/envoy/buffer:buffer_interface",
-        "//include/envoy/network:connection_interface",
-        "//source/extensions/filters/network/dubbo_proxy:decoder_events_lib",
-        "//source/extensions/filters/network/dubbo_proxy:deserializer_interface",
-        "//source/extensions/filters/network/dubbo_proxy:metadata_lib",
-        "//source/extensions/filters/network/dubbo_proxy:protocol_interface",
     ],
 )
 

--- a/source/extensions/filters/network/dubbo_proxy/filters/BUILD
+++ b/source/extensions/filters/network/dubbo_proxy/filters/BUILD
@@ -1,0 +1,48 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "filter_config_interface",
+    hdrs = ["filter_config.h"],
+    deps = [
+        ":filter_interface",
+        "//source/common/protobuf:cc_wkt_protos",
+    ],
+)
+
+envoy_cc_library(
+    name = "factory_base_lib",
+    hdrs = ["factory_base.h"],
+    deps = [
+        ":filter_config_interface",
+        "//source/common/protobuf:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "filter_interface",
+    hdrs = ["filter.h"],
+    deps = [
+        "//include/envoy/buffer:buffer_interface",
+        "//include/envoy/network:connection_interface",
+        "//source/extensions/filters/network/dubbo_proxy:decoder_events_lib",
+        "//source/extensions/filters/network/dubbo_proxy:deserializer_interface",
+        "//source/extensions/filters/network/dubbo_proxy:metadata_lib",
+        "//source/extensions/filters/network/dubbo_proxy:protocol_interface",
+    ],
+)
+
+envoy_cc_library(
+    name = "well_known_names",
+    hdrs = ["well_known_names.h"],
+    deps = [
+        "//source/common/singleton:const_singleton",
+    ],
+)

--- a/source/extensions/filters/network/dubbo_proxy/filters/factory_base.h
+++ b/source/extensions/filters/network/dubbo_proxy/filters/factory_base.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "envoy/common/pure.h"
+
+#include "common/protobuf/utility.h"
+
+#include "extensions/filters/network/dubbo_proxy/filters/filter_config.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace DubboProxy {
+namespace DubboFilters {
+
+template <class ConfigProto> class FactoryBase : public NamedDubboFilterConfigFactory {
+public:
+  FilterFactoryCb
+  createFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                               const std::string& stats_prefix,
+                               Server::Configuration::FactoryContext& context) override {
+    return createFilterFactoryFromProtoTyped(
+        MessageUtil::downcastAndValidate<const ConfigProto&>(proto_config), stats_prefix, context);
+  }
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<ConfigProto>();
+  }
+
+  std::string name() override { return name_; }
+
+protected:
+  FactoryBase(const std::string& name) : name_(name) {}
+
+private:
+  virtual FilterFactoryCb
+  createFilterFactoryFromProtoTyped(const ConfigProto& proto_config,
+                                    const std::string& stats_prefix,
+                                    Server::Configuration::FactoryContext& context) PURE;
+
+  const std::string name_;
+};
+
+} // namespace DubboFilters
+} // namespace DubboProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/dubbo_proxy/filters/factory_base.h
+++ b/source/extensions/filters/network/dubbo_proxy/filters/factory_base.h
@@ -7,8 +7,6 @@
 
 #include "common/protobuf/utility.h"
 
-#include "extensions/filters/network/dubbo_proxy/filters/filter_config.h"
-
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {

--- a/source/extensions/filters/network/dubbo_proxy/filters/factory_base.h
+++ b/source/extensions/filters/network/dubbo_proxy/filters/factory_base.h
@@ -7,6 +7,8 @@
 
 #include "common/protobuf/utility.h"
 
+#include "extensions/filters/network/dubbo_proxy/filters/filter_config.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {

--- a/source/extensions/filters/network/dubbo_proxy/filters/filter.h
+++ b/source/extensions/filters/network/dubbo_proxy/filters/filter.h
@@ -10,8 +10,10 @@
 
 #include "extensions/filters/network/dubbo_proxy/decoder_event_handler.h"
 #include "extensions/filters/network/dubbo_proxy/deserializer.h"
+#include "extensions/filters/network/dubbo_proxy/message.h"
 #include "extensions/filters/network/dubbo_proxy/metadata.h"
 #include "extensions/filters/network/dubbo_proxy/protocol.h"
+#include "extensions/filters/network/dubbo_proxy/router/router.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -27,7 +29,7 @@ enum class UpstreamResponseStatus : uint8_t {
 
 class DirectResponse {
 public:
-  virtual ~DirectResponse() {}
+  virtual ~DirectResponse() = default;
 
   enum class ResponseType : uint8_t {
     // DirectResponse encodes MessageType::Reply with success payload
@@ -59,7 +61,7 @@ typedef std::unique_ptr<DirectResponse> DirectResponsePtr;
  */
 class DecoderFilterCallbacks {
 public:
-  virtual ~DecoderFilterCallbacks() {}
+  virtual ~DecoderFilterCallbacks() = default;
 
   /**
    * @return uint64_t the ID of the originating request for logging purposes.
@@ -91,9 +93,9 @@ public:
   virtual DubboProxy::Router::RouteConstSharedPtr route() PURE;
 
   /**
-   * @return TransportType the originating transport.
+   * @return SerializationType the originating protocol.
    */
-  virtual DeserializerType downstreamDeserializerType() const PURE;
+  virtual SerializationType downstreamSerializationType() const PURE;
 
   /**
    * @return ProtocolType the originating protocol.
@@ -137,7 +139,7 @@ public:
  */
 class DecoderFilter : public DecoderEventHandler {
 public:
-  virtual ~DecoderFilter() {}
+  virtual ~DecoderFilter() = default;
 
   /**
    * This routine is called prior to a filter being destroyed. This may happen after normal stream
@@ -165,7 +167,7 @@ typedef std::shared_ptr<DecoderFilter> DecoderFilterSharedPtr;
  */
 class FilterChainFactoryCallbacks {
 public:
-  virtual ~FilterChainFactoryCallbacks() {}
+  virtual ~FilterChainFactoryCallbacks() = default;
 
   /**
    * Add a decoder filter that is used when reading connection data.
@@ -192,7 +194,7 @@ typedef std::function<void(FilterChainFactoryCallbacks& callbacks)> FilterFactor
  */
 class FilterChainFactory {
 public:
-  virtual ~FilterChainFactory() {}
+  virtual ~FilterChainFactory() = default;
 
   /**
    * Called when a new Dubbo stream is created on the connection.

--- a/source/extensions/filters/network/dubbo_proxy/filters/filter.h
+++ b/source/extensions/filters/network/dubbo_proxy/filters/filter.h
@@ -6,6 +6,7 @@
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/pure.h"
 #include "envoy/network/connection.h"
+#include "envoy/stream_info/stream_info.h"
 
 #include "extensions/filters/network/dubbo_proxy/decoder_event_handler.h"
 #include "extensions/filters/network/dubbo_proxy/deserializer.h"

--- a/source/extensions/filters/network/dubbo_proxy/filters/filter.h
+++ b/source/extensions/filters/network/dubbo_proxy/filters/filter.h
@@ -1,0 +1,210 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/common/pure.h"
+#include "envoy/network/connection.h"
+
+#include "extensions/filters/network/dubbo_proxy/decoder_event_handler.h"
+#include "extensions/filters/network/dubbo_proxy/deserializer.h"
+#include "extensions/filters/network/dubbo_proxy/metadata.h"
+#include "extensions/filters/network/dubbo_proxy/protocol.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace DubboProxy {
+namespace DubboFilters {
+
+enum class UpstreamResponseStatus : uint8_t {
+  MoreData = 0, // The upstream response requires more data.
+  Complete = 1, // The upstream response is complete.
+  Reset = 2,    // The upstream response is invalid and its connection must be reset.
+};
+
+class DirectResponse {
+public:
+  virtual ~DirectResponse() {}
+
+  enum class ResponseType : uint8_t {
+    // DirectResponse encodes MessageType::Reply with success payload
+    SuccessReply,
+
+    // DirectResponse encodes MessageType::Reply with an exception payload
+    ErrorReply,
+
+    // DirectResponse encodes MessageType::Exception
+    Exception,
+  };
+
+  /**
+   * Encodes the response via the given Protocol.
+   * @param metadata the MessageMetadata for the request that generated this response
+   * @param proto the Protocol to be used for message encoding
+   * @param buffer the Buffer into which the message should be encoded
+   * @return ResponseType indicating whether the message is a successful or error reply or an
+   *         exception
+   */
+  virtual ResponseType encode(MessageMetadata& metadata, Protocol& protocol,
+                              Deserializer& deserializer, Buffer::Instance& buffer) const PURE;
+};
+
+typedef std::unique_ptr<DirectResponse> DirectResponsePtr;
+
+/**
+ * Decoder filter callbacks add additional callbacks.
+ */
+class DecoderFilterCallbacks {
+public:
+  virtual ~DecoderFilterCallbacks() {}
+
+  /**
+   * @return uint64_t the ID of the originating request for logging purposes.
+   */
+  virtual uint64_t requestId() const PURE;
+
+  /**
+   * @return uint64_t the ID of the originating stream for logging purposes.
+   */
+  virtual uint64_t streamId() const PURE;
+
+  /**
+   * @return const Network::Connection* the originating connection, or nullptr if there is none.
+   */
+  virtual const Network::Connection* connection() const PURE;
+
+  /**
+   * Continue iterating through the filter chain with buffered data. This routine can only be
+   * called if the filter has previously returned StopIteration from one of the DecoderFilter
+   * methods. The connection manager will callbacks to the next filter in the chain. Further note
+   * that if the request is not complete, the calling filter may receive further callbacks and must
+   * return an appropriate status code depending on what the filter needs to do.
+   */
+  virtual void continueDecoding() PURE;
+
+  /**
+   * @return RouteConstSharedPtr the route for the current request.
+   */
+  virtual DubboProxy::Router::RouteConstSharedPtr route() PURE;
+
+  /**
+   * @return TransportType the originating transport.
+   */
+  virtual DeserializerType downstreamDeserializerType() const PURE;
+
+  /**
+   * @return ProtocolType the originating protocol.
+   */
+  virtual ProtocolType downstreamProtocolType() const PURE;
+
+  /**
+   * Create a locally generated response using the provided response object.
+   * @param response DirectResponsePtr the response to send to the downstream client
+   */
+  virtual void sendLocalReply(const DirectResponse& response, bool end_stream) PURE;
+
+  /**
+   * Indicates the start of an upstream response. May only be called once.
+   * @param transport_type TransportType the upstream is using
+   * @param protocol_type ProtocolType the upstream is using
+   */
+  virtual void startUpstreamResponse(Deserializer& deserializer, Protocol& protocol) PURE;
+
+  /**
+   * Called with upstream response data.
+   * @param data supplies the upstream's data
+   * @return UpstreamResponseStatus indicating if the upstream response requires more data, is
+   * complete, or if an error occurred requiring the upstream connection to be reset.
+   */
+  virtual UpstreamResponseStatus upstreamData(Buffer::Instance& data) PURE;
+
+  /**
+   * Reset the downstream connection.
+   */
+  virtual void resetDownstreamConnection() PURE;
+
+  /**
+   * @return StreamInfo for logging purposes.
+   */
+  virtual StreamInfo::StreamInfo& streamInfo() PURE;
+};
+
+/**
+ * Decoder filter interface.
+ */
+class DecoderFilter : public DecoderEventHandler {
+public:
+  using MessageMetadataSharedPtr =
+      Envoy::Extensions::NetworkFilters::DubboProxy::MessageMetadataSharedPtr;
+  virtual ~DecoderFilter() {}
+
+  /**
+   * This routine is called prior to a filter being destroyed. This may happen after normal stream
+   * finish (both downstream and upstream) or due to reset. Every filter is responsible for making
+   * sure that any async events are cleaned up in the context of this routine. This includes timers,
+   * network calls, etc. The reason there is an onDestroy() method vs. doing this type of cleanup
+   * in the destructor is due to the deferred deletion model that Envoy uses to avoid stack unwind
+   * complications. Filters must not invoke either encoder or decoder filter callbacks after having
+   * onDestroy() invoked.
+   */
+  virtual void onDestroy() PURE;
+
+  /**
+   * Called by the connection manager once to initialize the filter decoder callbacks that the
+   * filter should use. Callbacks will not be invoked by the filter after onDestroy() is called.
+   */
+  virtual void setDecoderFilterCallbacks(DecoderFilterCallbacks& callbacks) PURE;
+};
+
+typedef std::shared_ptr<DecoderFilter> DecoderFilterSharedPtr;
+
+/**
+ * These callbacks are provided by the connection manager to the factory so that the factory can
+ * build the filter chain in an application specific way.
+ */
+class FilterChainFactoryCallbacks {
+public:
+  virtual ~FilterChainFactoryCallbacks() {}
+
+  /**
+   * Add a decoder filter that is used when reading connection data.
+   * @param filter supplies the filter to add.
+   */
+  virtual void addDecoderFilter(DecoderFilterSharedPtr filter) PURE;
+};
+
+/**
+ * This function is used to wrap the creation of a Dubbo filter chain for new connections as they
+ * come in. Filter factories create the function at configuration initialization time, and then
+ * they are used at runtime.
+ * @param callbacks supplies the callbacks for the stream to install filters to. Typically the
+ * function will install a single filter, but it's technically possibly to install more than one
+ * if desired.
+ */
+typedef std::function<void(FilterChainFactoryCallbacks& callbacks)> FilterFactoryCb;
+
+/**
+ * A FilterChainFactory is used by a connection manager to create a Dubbo level filter chain when
+ * a new connection is created. Typically it would be implemented by a configuration engine that
+ * would install a set of filters that are able to process an application scenario on top of a
+ * stream of Dubbo requests.
+ */
+class FilterChainFactory {
+public:
+  virtual ~FilterChainFactory() {}
+
+  /**
+   * Called when a new Dubbo stream is created on the connection.
+   * @param callbacks supplies the "sink" that is used for actually creating the filter chain. @see
+   *                  FilterChainFactoryCallbacks.
+   */
+  virtual void createFilterChain(FilterChainFactoryCallbacks& callbacks) PURE;
+};
+
+} // namespace DubboFilters
+} // namespace DubboProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/dubbo_proxy/filters/filter.h
+++ b/source/extensions/filters/network/dubbo_proxy/filters/filter.h
@@ -136,8 +136,6 @@ public:
  */
 class DecoderFilter : public DecoderEventHandler {
 public:
-  using MessageMetadataSharedPtr =
-      Envoy::Extensions::NetworkFilters::DubboProxy::MessageMetadataSharedPtr;
   virtual ~DecoderFilter() {}
 
   /**

--- a/source/extensions/filters/network/dubbo_proxy/filters/filter_config.h
+++ b/source/extensions/filters/network/dubbo_proxy/filters/filter_config.h
@@ -6,8 +6,6 @@
 
 #include "common/protobuf/protobuf.h"
 
-#include "extensions/filters/network/dubbo_proxy/filters/filter.h"
-
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {

--- a/source/extensions/filters/network/dubbo_proxy/filters/filter_config.h
+++ b/source/extensions/filters/network/dubbo_proxy/filters/filter_config.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/common/pure.h"
+
+#include "common/protobuf/protobuf.h"
+
+#include "extensions/filters/network/dubbo_proxy/filters/filter.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace DubboProxy {
+namespace DubboFilters {
+
+/**
+ * Implemented by each Dubbo filter and registered via Registry::registerFactory or the
+ * convenience class RegisterFactory.
+ */
+class NamedDubboFilterConfigFactory {
+public:
+  virtual ~NamedDubboFilterConfigFactory() {}
+
+  /**
+   * Create a particular dubbo filter factory implementation. If the implementation is unable to
+   * produce a factory with the provided parameters, it should throw an EnvoyException in the case
+   * of general error. The returned callback should always be initialized.
+   * @param config supplies the configuration for the filter
+   * @param stat_prefix prefix for stat logging
+   * @param context supplies the filter's context.
+   * @return FilterFactoryCb the factory creation function.
+   */
+  virtual FilterFactoryCb
+  createFilterFactoryFromProto(const Protobuf::Message& config, const std::string& stat_prefix,
+                               Server::Configuration::FactoryContext& context) PURE;
+
+  /**
+   * @return ProtobufTypes::MessagePtr create empty config proto message for v2. The filter
+   *         config, which arrives in an opaque google.protobuf.Struct message, will be converted to
+   *         JSON and then parsed into this empty proto.
+   */
+  virtual ProtobufTypes::MessagePtr createEmptyConfigProto() PURE;
+
+  /**
+   * @return std::string the identifying name for a particular implementation of a dubbo filter
+   * produced by the factory.
+   */
+  virtual std::string name() PURE;
+};
+
+} // namespace DubboFilters
+} // namespace DubboProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/dubbo_proxy/filters/filter_config.h
+++ b/source/extensions/filters/network/dubbo_proxy/filters/filter_config.h
@@ -22,7 +22,7 @@ namespace DubboFilters {
  */
 class NamedDubboFilterConfigFactory {
 public:
-  virtual ~NamedDubboFilterConfigFactory() {}
+  virtual ~NamedDubboFilterConfigFactory() = default;
 
   /**
    * Create a particular dubbo filter factory implementation. If the implementation is unable to
@@ -33,7 +33,7 @@ public:
    * @param context supplies the filter's context.
    * @return FilterFactoryCb the factory creation function.
    */
-  virtual FilterFactoryCb
+  virtual DubboFilters::FilterFactoryCb
   createFilterFactoryFromProto(const Protobuf::Message& config, const std::string& stat_prefix,
                                Server::Configuration::FactoryContext& context) PURE;
 

--- a/source/extensions/filters/network/dubbo_proxy/filters/filter_config.h
+++ b/source/extensions/filters/network/dubbo_proxy/filters/filter_config.h
@@ -3,8 +3,12 @@
 #include <string>
 
 #include "envoy/common/pure.h"
+#include "envoy/server/filter_config.h"
 
+#include "common/common/macros.h"
 #include "common/protobuf/protobuf.h"
+
+#include "extensions/filters/network/dubbo_proxy/filters/filter.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/filters/network/dubbo_proxy/filters/well_known_names.h
+++ b/source/extensions/filters/network/dubbo_proxy/filters/well_known_names.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string>
+
+#include "common/singleton/const_singleton.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace DubboProxy {
+namespace DubboFilters {
+
+/**
+ * Well-known http filter names.
+ * NOTE: New filters should use the well known name: envoy.filters.dubbo.name.
+ */
+class DubboFilterNameValues {
+public:
+  // Router filter
+  const std::string ROUTER = "envoy.filters.dubbo.router";
+};
+
+typedef ConstSingleton<DubboFilterNameValues> DubboFilterNames;
+
+} // namespace DubboFilters
+} // namespace DubboProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/dubbo_proxy/filters/well_known_names.h
+++ b/source/extensions/filters/network/dubbo_proxy/filters/well_known_names.h
@@ -11,7 +11,7 @@ namespace DubboProxy {
 namespace DubboFilters {
 
 /**
- * Well-known http filter names.
+ * Well-known Dubbo filter names.
  * NOTE: New filters should use the well known name: envoy.filters.dubbo.name.
  */
 class DubboFilterNameValues {

--- a/source/extensions/filters/network/dubbo_proxy/router/BUILD
+++ b/source/extensions/filters/network/dubbo_proxy/router/BUILD
@@ -1,0 +1,16 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "router_interface",
+    hdrs = ["router.h"],
+    external_deps = ["abseil_optional"],
+    deps = [],
+)

--- a/source/extensions/filters/network/dubbo_proxy/router/BUILD
+++ b/source/extensions/filters/network/dubbo_proxy/router/BUILD
@@ -11,6 +11,8 @@ envoy_package()
 envoy_cc_library(
     name = "router_interface",
     hdrs = ["router.h"],
-    external_deps = ["abseil_optional"],
-    deps = [],
+    deps = [
+        "//include/envoy/router:router_interface",
+        "//source/extensions/filters/network/dubbo_proxy:metadata_lib",
+    ],
 )

--- a/source/extensions/filters/network/dubbo_proxy/router/router.h
+++ b/source/extensions/filters/network/dubbo_proxy/router/router.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "envoy/router/router.h"
+
+#include "extensions/filters/network/dubbo_proxy/metadata.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace DubboProxy {
+namespace Router {
+
+/**
+ * RouteEntry is an individual resolved route entry.
+ */
+class RouteEntry {
+public:
+  virtual ~RouteEntry() {}
+
+  /**
+   * @return const std::string& the upstream cluster that owns the route.
+   */
+  virtual const std::string& clusterName() const PURE;
+
+  /**
+   * @return MetadataMatchCriteria* the metadata that a subset load balancer should match when
+   * selecting an upstream host
+   */
+  virtual const Envoy::Router::MetadataMatchCriteria* metadataMatchCriteria() const PURE;
+};
+
+/**
+ * Route holds the RouteEntry for a request.
+ */
+class Route {
+public:
+  virtual ~Route() {}
+
+  /**
+   * @return the route entry or nullptr if there is no matching route for the request.
+   */
+  virtual const RouteEntry* routeEntry() const PURE;
+};
+
+typedef std::shared_ptr<const Route> RouteConstSharedPtr;
+
+/**
+ * The router configuration.
+ */
+class Config {
+public:
+  virtual ~Config() {}
+
+  /**
+   * Based on the incoming Dubbo request transport and/or protocol data, determine the target
+   * route for the request.
+   * @param metadata MessageMetadata for the message to route
+   * @param random_value uint64_t used to select cluster affinity
+   * @return the route or nullptr if there is no matching route for the request.
+   */
+  virtual RouteConstSharedPtr route(const MessageMetadata& metadata,
+                                    uint64_t random_value) const PURE;
+};
+
+typedef std::shared_ptr<const Config> ConfigConstSharedPtr;
+
+} // namespace Router
+} // namespace DubboProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/dubbo_proxy/router/router.h
+++ b/source/extensions/filters/network/dubbo_proxy/router/router.h
@@ -18,7 +18,7 @@ namespace Router {
  */
 class RouteEntry {
 public:
-  virtual ~RouteEntry() {}
+  virtual ~RouteEntry() = default;
 
   /**
    * @return const std::string& the upstream cluster that owns the route.
@@ -37,7 +37,7 @@ public:
  */
 class Route {
 public:
-  virtual ~Route() {}
+  virtual ~Route() = default;
 
   /**
    * @return the route entry or nullptr if there is no matching route for the request.
@@ -52,7 +52,7 @@ typedef std::shared_ptr<const Route> RouteConstSharedPtr;
  */
 class Config {
 public:
-  virtual ~Config() {}
+  virtual ~Config() = default;
 
   /**
    * Based on the incoming Dubbo request transport and/or protocol data, determine the target

--- a/test/extensions/filters/network/dubbo_proxy/BUILD
+++ b/test/extensions/filters/network/dubbo_proxy/BUILD
@@ -18,8 +18,15 @@ envoy_cc_mock(
     srcs = ["mocks.cc"],
     hdrs = ["mocks.h"],
     deps = [
+        "//source/common/protobuf:utility_lib",
+        "//source/extensions/filters/network/dubbo_proxy:decoder_events_lib",
         "//source/extensions/filters/network/dubbo_proxy:deserializer_interface",
         "//source/extensions/filters/network/dubbo_proxy:protocol_interface",
+        "//source/extensions/filters/network/dubbo_proxy/filters:factory_base_lib",
+        "//source/extensions/filters/network/dubbo_proxy/filters:filter_interface",
+        "//source/extensions/filters/network/dubbo_proxy/router:router_interface",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/stream_info:stream_info_mocks",
         "//test/test_common:printers_lib",
     ],
 )

--- a/test/extensions/filters/network/dubbo_proxy/mocks.cc
+++ b/test/extensions/filters/network/dubbo_proxy/mocks.cc
@@ -1,7 +1,12 @@
 #include "test/extensions/filters/network/dubbo_proxy/mocks.h"
 
+#include "common/protobuf/utility.h"
+
 #include "gtest/gtest.h"
 
+using testing::_;
+using testing::Invoke;
+using testing::Return;
 using testing::ReturnRef;
 
 namespace Envoy {
@@ -9,11 +14,83 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace DubboProxy {
 
+MockDecoderEventHandler::MockDecoderEventHandler() {
+  ON_CALL(*this, transportBegin()).WillByDefault(Return(Network::FilterStatus::Continue));
+  ON_CALL(*this, transportEnd()).WillByDefault(Return(Network::FilterStatus::Continue));
+  ON_CALL(*this, messageBegin(_, _, _)).WillByDefault(Return(Network::FilterStatus::Continue));
+  ON_CALL(*this, messageEnd(_)).WillByDefault(Return(Network::FilterStatus::Continue));
+  ON_CALL(*this, transferHeaderTo(_, _)).WillByDefault(Return(Network::FilterStatus::Continue));
+  ON_CALL(*this, transferBodyTo(_, _)).WillByDefault(Return(Network::FilterStatus::Continue));
+}
+
 MockProtocolCallbacks::MockProtocolCallbacks() {}
 MockProtocolCallbacks::~MockProtocolCallbacks() {}
 
 MockProtocol::MockProtocol() { ON_CALL(*this, name()).WillByDefault(ReturnRef(name_)); }
 MockProtocol::~MockProtocol() {}
+
+namespace DubboFilters {
+
+MockFilterChainFactoryCallbacks::MockFilterChainFactoryCallbacks() {}
+MockFilterChainFactoryCallbacks::~MockFilterChainFactoryCallbacks() {}
+
+MockDecoderFilter::MockDecoderFilter() {
+  ON_CALL(*this, transportBegin()).WillByDefault(Return(Network::FilterStatus::Continue));
+  ON_CALL(*this, transportEnd()).WillByDefault(Return(Network::FilterStatus::Continue));
+  ON_CALL(*this, messageBegin(_, _, _)).WillByDefault(Return(Network::FilterStatus::Continue));
+  ON_CALL(*this, messageEnd(_)).WillByDefault(Return(Network::FilterStatus::Continue));
+  ON_CALL(*this, transferHeaderTo(_, _)).WillByDefault(Return(Network::FilterStatus::Continue));
+  ON_CALL(*this, transferBodyTo(_, _)).WillByDefault(Return(Network::FilterStatus::Continue));
+}
+MockDecoderFilter::~MockDecoderFilter() {}
+
+MockDecoderFilterCallbacks::MockDecoderFilterCallbacks() {
+  route_.reset(new NiceMock<Router::MockRoute>());
+
+  ON_CALL(*this, streamId()).WillByDefault(Return(stream_id_));
+  ON_CALL(*this, connection()).WillByDefault(Return(&connection_));
+  ON_CALL(*this, route()).WillByDefault(Return(route_));
+  ON_CALL(*this, streamInfo()).WillByDefault(ReturnRef(stream_info_));
+}
+MockDecoderFilterCallbacks::~MockDecoderFilterCallbacks() {}
+
+MockDirectResponse::MockDirectResponse() {}
+MockDirectResponse::~MockDirectResponse() {}
+
+MockFilterConfigFactory::MockFilterConfigFactory()
+    : MockFactoryBase("envoy.filters.dubbo.mock_filter") {
+  mock_filter_.reset(new NiceMock<MockDecoderFilter>());
+}
+
+MockFilterConfigFactory::~MockFilterConfigFactory() {}
+
+FilterFactoryCb MockFilterConfigFactory::createFilterFactoryFromProtoTyped(
+    const ProtobufWkt::Struct& proto_config, const std::string& stat_prefix,
+    Server::Configuration::FactoryContext& context) {
+  UNREFERENCED_PARAMETER(context);
+
+  config_struct_ = proto_config;
+  config_stat_prefix_ = stat_prefix;
+
+  return [this](DubboFilters::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addDecoderFilter(mock_filter_);
+  };
+}
+
+} // namespace DubboFilters
+
+namespace Router {
+
+MockRouteEntry::MockRouteEntry() {
+  ON_CALL(*this, clusterName()).WillByDefault(ReturnRef(cluster_name_));
+}
+MockRouteEntry::~MockRouteEntry() {}
+
+MockRoute::MockRoute() { ON_CALL(*this, routeEntry()).WillByDefault(Return(&route_entry_)); }
+MockRoute::~MockRoute() {}
+
+} // namespace Router
+
 } // namespace DubboProxy
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/test/extensions/filters/network/dubbo_proxy/mocks.cc
+++ b/test/extensions/filters/network/dubbo_proxy/mocks.cc
@@ -1,5 +1,7 @@
 #include "test/extensions/filters/network/dubbo_proxy/mocks.h"
 
+#include <memory>
+
 #include "common/protobuf/utility.h"
 
 #include "gtest/gtest.h"
@@ -58,17 +60,15 @@ MockDirectResponse::MockDirectResponse() {}
 MockDirectResponse::~MockDirectResponse() {}
 
 MockFilterConfigFactory::MockFilterConfigFactory()
-    : MockFactoryBase("envoy.filters.dubbo.mock_filter") {
-  mock_filter_.reset(new NiceMock<MockDecoderFilter>());
-}
+    : MockFactoryBase("envoy.filters.dubbo.mock_filter"),
+      mock_filter_(std::make_unique<NiceMock<MockDecoderFilter>>()) {}
 
 MockFilterConfigFactory::~MockFilterConfigFactory() {}
 
-FilterFactoryCb MockFilterConfigFactory::createFilterFactoryFromProtoTyped(
-    const ProtobufWkt::Struct& proto_config, const std::string& stat_prefix,
-    Server::Configuration::FactoryContext& context) {
-  UNREFERENCED_PARAMETER(context);
-
+FilterFactoryCb
+MockFilterConfigFactory::createFilterFactoryFromProtoTyped(const ProtobufWkt::Struct& proto_config,
+                                                           const std::string& stat_prefix,
+                                                           Server::Configuration::FactoryContext&) {
   config_struct_ = proto_config;
   config_stat_prefix_ = stat_prefix;
 

--- a/test/extensions/filters/network/dubbo_proxy/mocks.h
+++ b/test/extensions/filters/network/dubbo_proxy/mocks.h
@@ -22,7 +22,6 @@ namespace DubboProxy {
 class MockDecoderEventHandler : public DecoderEventHandler {
 public:
   MockDecoderEventHandler();
-  virtual ~MockDecoderEventHandler() override {}
 
   MOCK_METHOD0(transportBegin, Network::FilterStatus());
   MOCK_METHOD0(transportEnd, Network::FilterStatus());

--- a/test/extensions/filters/network/dubbo_proxy/mocks.h
+++ b/test/extensions/filters/network/dubbo_proxy/mocks.h
@@ -1,15 +1,36 @@
 #pragma once
 
+#include "extensions/filters/network/dubbo_proxy/decoder_event_handler.h"
+#include "extensions/filters/network/dubbo_proxy/filters/factory_base.h"
+#include "extensions/filters/network/dubbo_proxy/filters/filter.h"
 #include "extensions/filters/network/dubbo_proxy/protocol.h"
+#include "extensions/filters/network/dubbo_proxy/router/router.h"
 
+#include "test/mocks/network/mocks.h"
+#include "test/mocks/stream_info/mocks.h"
 #include "test/test_common/printers.h"
 
 #include "gmock/gmock.h"
+
+using testing::_;
 
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
 namespace DubboProxy {
+
+class MockDecoderEventHandler : public DecoderEventHandler {
+public:
+  MockDecoderEventHandler();
+  virtual ~MockDecoderEventHandler() override {}
+
+  MOCK_METHOD0(transportBegin, Network::FilterStatus());
+  MOCK_METHOD0(transportEnd, Network::FilterStatus());
+  MOCK_METHOD3(messageBegin, Network::FilterStatus(MessageType, int64_t, SerializationType));
+  MOCK_METHOD1(messageEnd, Network::FilterStatus(MessageMetadataSharedPtr));
+  MOCK_METHOD2(transferHeaderTo, Network::FilterStatus(Buffer::Instance&, size_t));
+  MOCK_METHOD2(transferBodyTo, Network::FilterStatus(Buffer::Instance&, size_t));
+};
 
 class MockProtocolCallbacks : public ProtocolCallbacks {
 public:
@@ -33,6 +54,145 @@ public:
   MOCK_METHOD2(decode, bool(Buffer::Instance&, Context*));
   std::string name_{"MockProtocol"};
 };
+
+namespace Router {
+class MockRoute;
+} // namespace Router
+
+namespace DubboFilters {
+
+class MockFilterChainFactoryCallbacks : public FilterChainFactoryCallbacks {
+public:
+  MockFilterChainFactoryCallbacks();
+  ~MockFilterChainFactoryCallbacks();
+
+  MOCK_METHOD1(addDecoderFilter, void(DecoderFilterSharedPtr));
+};
+
+class MockDecoderFilter : public DecoderFilter {
+public:
+  MockDecoderFilter();
+  ~MockDecoderFilter();
+
+  // DubboProxy::DubboFilters::DecoderFilter
+  MOCK_METHOD0(onDestroy, void());
+  MOCK_METHOD1(setDecoderFilterCallbacks, void(DecoderFilterCallbacks& callbacks));
+
+  // DubboProxy::DecoderEventHandler
+  MOCK_METHOD0(transportBegin, Network::FilterStatus());
+  MOCK_METHOD0(transportEnd, Network::FilterStatus());
+  MOCK_METHOD3(messageBegin, Network::FilterStatus(MessageType, int64_t, SerializationType));
+  MOCK_METHOD1(messageEnd, Network::FilterStatus(MessageMetadataSharedPtr));
+  MOCK_METHOD2(transferHeaderTo, Network::FilterStatus(Buffer::Instance& buf, size_t size));
+  MOCK_METHOD2(transferBodyTo, Network::FilterStatus(Buffer::Instance& buf, size_t size));
+};
+
+class MockDecoderFilterCallbacks : public DecoderFilterCallbacks {
+public:
+  MockDecoderFilterCallbacks();
+  ~MockDecoderFilterCallbacks();
+
+  // DubboProxy::DubboFilters::DecoderFilterCallbacks
+  MOCK_CONST_METHOD0(requestId, uint64_t());
+  MOCK_CONST_METHOD0(streamId, uint64_t());
+  MOCK_CONST_METHOD0(connection, const Network::Connection*());
+  MOCK_METHOD0(continueDecoding, void());
+  MOCK_METHOD0(route, Router::RouteConstSharedPtr());
+  MOCK_CONST_METHOD0(downstreamSerializationType, SerializationType());
+  MOCK_CONST_METHOD0(downstreamProtocolType, ProtocolType());
+  MOCK_METHOD2(sendLocalReply, void(const DirectResponse&, bool));
+  MOCK_METHOD2(startUpstreamResponse, void(Deserializer&, Protocol&));
+  MOCK_METHOD1(upstreamData, UpstreamResponseStatus(Buffer::Instance&));
+  MOCK_METHOD0(resetDownstreamConnection, void());
+  MOCK_METHOD0(streamInfo, StreamInfo::StreamInfo&());
+
+  uint64_t stream_id_{1};
+  NiceMock<Network::MockConnection> connection_;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info_;
+  std::shared_ptr<Router::MockRoute> route_;
+};
+
+class MockDirectResponse : public DirectResponse {
+public:
+  MockDirectResponse();
+  ~MockDirectResponse();
+
+  MOCK_CONST_METHOD4(encode, DirectResponse::ResponseType(MessageMetadata&, Protocol&,
+                                                          Deserializer&, Buffer::Instance&));
+};
+
+template <class ConfigProto> class MockFactoryBase : public NamedDubboFilterConfigFactory {
+public:
+  FilterFactoryCb
+  createFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                               const std::string& stats_prefix,
+                               Server::Configuration::FactoryContext& context) override {
+    const auto& typed_config = dynamic_cast<const ConfigProto&>(proto_config);
+    return createFilterFactoryFromProtoTyped(typed_config, stats_prefix, context);
+  }
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<ConfigProto>();
+  }
+
+  std::string name() override { return name_; }
+
+protected:
+  MockFactoryBase(const std::string& name) : name_(name) {}
+
+private:
+  virtual FilterFactoryCb
+  createFilterFactoryFromProtoTyped(const ConfigProto& proto_config,
+                                    const std::string& stats_prefix,
+                                    Server::Configuration::FactoryContext& context) PURE;
+
+  const std::string name_;
+};
+
+class MockFilterConfigFactory : public MockFactoryBase<ProtobufWkt::Struct> {
+public:
+  MockFilterConfigFactory();
+  ~MockFilterConfigFactory();
+
+  DubboFilters::FilterFactoryCb
+  createFilterFactoryFromProtoTyped(const ProtobufWkt::Struct& proto_config,
+                                    const std::string& stat_prefix,
+                                    Server::Configuration::FactoryContext& context) override;
+
+  std::shared_ptr<MockDecoderFilter> mock_filter_;
+  ProtobufWkt::Struct config_struct_;
+  std::string config_stat_prefix_;
+};
+
+} // namespace DubboFilters
+
+namespace Router {
+
+class MockRouteEntry : public RouteEntry {
+public:
+  MockRouteEntry();
+  ~MockRouteEntry();
+
+  // DubboProxy::Router::RouteEntry
+  MOCK_CONST_METHOD0(clusterName, const std::string&());
+  MOCK_CONST_METHOD0(metadataMatchCriteria, const Envoy::Router::MetadataMatchCriteria*());
+
+  std::string cluster_name_{"fake_cluster"};
+};
+
+class MockRoute : public Route {
+public:
+  MockRoute();
+  ~MockRoute();
+
+  // DubboProxy::Router::Route
+  MOCK_CONST_METHOD0(routeEntry, const RouteEntry*());
+
+  NiceMock<MockRouteEntry> route_entry_;
+};
+
+} // namespace Router
+
 } // namespace DubboProxy
 } // namespace NetworkFilters
 } // namespace Extensions


### PR DESCRIPTION
*Description*: Add filter extension mechanism for Dubbo protocol
*Risk Level*: low
*Testing*: N/A
*Docs Changes*: N/A
*Release Notes*: N/A
[Optional Fixes #Issue] #3998 
[Optional *Deprecated*:]

this is only part of the code for DubboProxy, the rest of the code hasn't been committed yet, complete implementation: https://github.com/gengleilei/envoy/tree/feature-dubbo-router-develop/source/extensions/filters/network/dubbo_proxy