### PR TITLE
hot-restart: Remove broken test stanza that appeared not to be related to the rest of the test

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -105,13 +105,30 @@ envoy_cc_test(
 
 envoy_sh_test(
     name = "hotrestart_test",
-    srcs = envoy_select_hot_restart(["hotrestart_test.sh"]),
+    srcs = envoy_select_hot_restart([
+        "hotrestart_test.sh",
+        "test_utility.sh",
+    ]),
     data = [
         "//source/exe:envoy-static",
         "//test/common/runtime:filesystem_setup.sh",
         "//test/common/runtime:filesystem_test_data",
         "//test/config/integration:server_config_files",
         "//tools:socket_passing",
+    ],
+)
+
+envoy_sh_test(
+    name = "run_envoy_test",
+    srcs = [
+        "run_envoy_test.sh",
+        "test_utility.sh",
+    ],
+    data = [
+        "//source/exe:envoy-static",
+        "//test/common/runtime:filesystem_setup.sh",
+        "//test/common/runtime:filesystem_test_data",
+        "//test/config/integration:server_config_files",
     ],
 )
 

--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -256,23 +256,6 @@ do
   TEST_INDEX=$((TEST_INDEX+1))
 done
 
-# set -e forces the script to exit on non-zero exit codes. Set +e makes it easier to
-# catch the non-zero exit code.
-set +e
-disableHeapCheck
-
-start_test Launching envoy with no parameters. Check the exit value is 1
-${ENVOY_BIN} --base_id "${BASE_ID}"
-EXIT_CODE=$?
-# The test should fail if the Envoy binary exits with anything other than 1.
-if [[ $EXIT_CODE -ne 1 ]]; then
-    echo "Envoy exited with code: ${EXIT_CODE}"
-    exit 1
-fi
-
-enableHeapCheck
-set -e
-
 start_test disabling hot_restart by command line.
 CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version --disable-hot-restart 2>&1)
 check [ "disabled" = "${CLI_HOT_RESTART_VERSION}" ]

--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -1,86 +1,8 @@
 #!/bin/bash
 
+source test_utility.sh
+
 set -e
-
-# The following functions are borrowed from PageSpeed's system test
-# infrastructure, where are part of a bash system-test helper library.
-# I'm putting them here for this one test to help me debug it, with
-# the thinking that if there's traction for this infrastructure I'll
-# factor it out into a helpers class for Envoy.  Original source link:
-#
-# https://github.com/apache/incubator-pagespeed-mod/blob/c7cc4f22c79ada8077be2a16afc376dc8f8bd2da/pagespeed/automatic/system_test_helpers.sh#L383
-
-CURRENT_TEST="NONE"
-function start_test() {
-  CURRENT_TEST="$@"
-  echo "TEST: $CURRENT_TEST"
-}
-
-check() {
-  echo "     check" "$@" ...
-  "$@" || handle_failure
-}
-
-BACKGROUND_PID="?"
-run_in_background_saving_pid() {
-  echo "     backgrounding:" "$@" ...
-  "$@" &
-  BACKGROUND_PID="$!"
-}
-
-# By default, print a message like:
-#   failure at line 374
-#   FAIL
-# and then exit with return value 1.  If we expected this test to fail, log to
-# $EXPECTED_FAILURES and return without exiting.
-#
-# If the shell does not support the 'caller' builtin, skip the line number info.
-#
-# Assumes it's being called from a failure-reporting function and that the
-# actual failure the user is interested in is our caller's caller.  If it
-# weren't for this, fail and handle_failure could be the same.
-handle_failure() {
-  if [ $# -eq 1 ]; then
-    echo FAILed Input: "$1"
-  fi
-
-  # From http://stackoverflow.com/questions/685435/bash-stacktrace
-  # to avoid printing 'handle_failure' we start with 1 to skip get_stack caller
-  local i
-  local stack_size=${#FUNCNAME[@]}
-  for (( i=1; i<$stack_size ; i++ )); do
-    local func="${FUNCNAME[$i]}"
-    [ -z "$func" ] && func=MAIN
-    local line_number="${BASH_LINENO[(( i - 1 ))]}"
-    local src="${BASH_SOURCE[$i]}"
-    [ -z "$src" ] && src=non_file_source
-    echo "${src}:${line_number}: $func"
-  done
-
-  # Note: we print line number after "failed input" so that it doesn't get
-  # knocked out of the terminal buffer.
-  if type caller > /dev/null 2>&1 ; then
-    # "caller 1" is our caller's caller.
-    echo "     failure at line $(caller 1 | sed 's/ .*//')" 1>&2
-  fi
-  echo "in '$CURRENT_TEST'"
-  echo FAIL.
-  exit 1
-}
-
-# The heapchecker outputs some data to stderr on every execution.  This gets intermingled
-# with the output from --hot-restart-version, so disable the heap-checker for these runs.
-disableHeapCheck () {
-  SAVED_HEAPCHECK=${HEAPCHECK}
-  unset HEAPCHECK
-}
-
-enableHeapCheck () {
-  HEAPCHECK=${SAVED_HEAPCHECK}
-}
-
-
-[[ -z "${ENVOY_BIN}" ]] && ENVOY_BIN="${TEST_RUNDIR}"/source/exe/envoy-static
 
 # TODO(htuch): In this test script, we are duplicating work done in test_environment.cc via sed.
 # Instead, we can add a simple C++ binary that links against test_environment.cc and uses the

--- a/test/integration/run_envoy_test.sh
+++ b/test/integration/run_envoy_test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source test_utility.sh
+
+start_test Launching envoy with a bogus command line flag.
+${ENVOY_BIN} --bogus-flag
+EXIT_CODE=$?
+# The test should fail if the Envoy binary exits with anything other than 1.
+if [[ $EXIT_CODE -ne 1 ]]; then
+    echo "Envoy exited with code: ${EXIT_CODE}"
+    exit 1
+fi

--- a/test/integration/test_utility.sh
+++ b/test/integration/test_utility.sh
@@ -1,0 +1,78 @@
+# Helper script for bash integration tests, intended to be source'd from the
+# _test.sh.
+#
+# This was borrowed from PageSpeed's system test infrastructure. Original source
+# link:
+#
+# https://github.com/apache/incubator-pagespeed-mod/blob/c7cc4f22c79ada8077be2a16afc376dc8f8bd2da/pagespeed/automatic/system_test_helpers.sh#L383
+
+CURRENT_TEST="NONE"
+function start_test() {
+  CURRENT_TEST="$@"
+  echo "TEST: $CURRENT_TEST"
+}
+
+check() {
+  echo "     check" "$@" ...
+  "$@" || handle_failure
+}
+
+BACKGROUND_PID="?"
+run_in_background_saving_pid() {
+  echo "     backgrounding:" "$@" ...
+  "$@" &
+  BACKGROUND_PID="$!"
+}
+
+# By default, print a message like:
+#   failure at line 374
+#   FAIL
+# and then exit with return value 1.  If we expected this test to fail, log to
+# $EXPECTED_FAILURES and return without exiting.
+#
+# If the shell does not support the 'caller' builtin, skip the line number info.
+#
+# Assumes it's being called from a failure-reporting function and that the
+# actual failure the user is interested in is our caller's caller.  If it
+# weren't for this, fail and handle_failure could be the same.
+handle_failure() {
+  if [ $# -eq 1 ]; then
+    echo FAILed Input: "$1"
+  fi
+
+  # From http://stackoverflow.com/questions/685435/bash-stacktrace
+  # to avoid printing 'handle_failure' we start with 1 to skip get_stack caller
+  local i
+  local stack_size=${#FUNCNAME[@]}
+  for (( i=1; i<$stack_size ; i++ )); do
+    local func="${FUNCNAME[$i]}"
+    [ -z "$func" ] && func=MAIN
+    local line_number="${BASH_LINENO[(( i - 1 ))]}"
+    local src="${BASH_SOURCE[$i]}"
+    [ -z "$src" ] && src=non_file_source
+    echo "${src}:${line_number}: $func"
+  done
+
+  # Note: we print line number after "failed input" so that it doesn't get
+  # knocked out of the terminal buffer.
+  if type caller > /dev/null 2>&1 ; then
+    # "caller 1" is our caller's caller.
+    echo "     failure at line $(caller 1 | sed 's/ .*//')" 1>&2
+  fi
+  echo "in '$CURRENT_TEST'"
+  echo FAIL.
+  exit 1
+}
+
+# The heapchecker outputs some data to stderr on every execution.  This gets intermingled
+# with the output from --hot-restart-version, so disable the heap-checker for these runs.
+disableHeapCheck () {
+  SAVED_HEAPCHECK=${HEAPCHECK}
+  unset HEAPCHECK
+}
+
+enableHeapCheck () {
+  HEAPCHECK=${SAVED_HEAPCHECK}
+}
+
+[[ -z "${ENVOY_BIN}" ]] && ENVOY_BIN="${TEST_RUNDIR}"/source/exe/envoy-static


### PR DESCRIPTION
*Description*: Removes a stanza that was trying to test that running envoy with no args results in an exit-status of 1. However, what it actually tested was that running envoy with a misspelled arg `--base_id` vs `--base-id` results in an exit status of 1. Running Envoy with bogus args might be a useful test, but does not belong in hot_restart_test.sh.

What the comments indicated it was trying to test actually doesn't work as expected: AFAICT running Envoy with no args starts a server. Maybe that's broken and should be fixed, but I don't see why the test should be in hotrestart_test.sh.

Added a new run_envoy_test.sh into which we can put odd corner-cases for expected behavior when starting Envoy with various flags.

*Risk Level*: low
*Testing*: test/integration:hotrestart_test, test/integration:run_envoy_test
*Docs Changes*: n/a
*Release Notes*: n/a

