### PR TITLE
upstream: refactor locality scheduler and priority load management

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -222,6 +222,17 @@ void HostSetImpl::updateHosts(UpdateHostsParams&& update_hosts_params,
   healthy_hosts_per_locality_ = std::move(update_hosts_params.healthy_hosts_per_locality);
   degraded_hosts_per_locality_ = std::move(update_hosts_params.degraded_hosts_per_locality);
   locality_weights_ = std::move(locality_weights);
+
+  rebuildLocalityScheduler(locality_scheduler_, locality_entries_, *healthy_hosts_per_locality_,
+                           *healthy_hosts_);
+
+  runUpdateCallbacks(hosts_added, hosts_removed);
+}
+
+void HostSetImpl::rebuildLocalityScheduler(
+    std::unique_ptr<EdfScheduler<LocalityEntry>>& locality_scheduler,
+    std::vector<std::shared_ptr<LocalityEntry>>& locality_entries,
+    const HostsPerLocality& eligible_hosts_per_locality, const HostVector& hosts) {
   // Rebuild the locality scheduler by computing the effective weight of each
   // locality in this priority. The scheduler is reset by default, and is rebuilt only if we have
   // locality weights (i.e. using EDS) and there is at least one healthy host in this priority.
@@ -237,24 +248,23 @@ void HostSetImpl::updateHosts(UpdateHostsParams&& update_hosts_params,
   // could just update locality_weight_ without rebuilding. Similar to how host
   // level WRR works, we would age out the existing entries via picks and lazily
   // apply the new weights.
-  locality_scheduler_ = nullptr;
+  locality_scheduler = nullptr;
   if (hosts_per_locality_ != nullptr && locality_weights_ != nullptr &&
-      !locality_weights_->empty() && !healthy_hosts_->empty()) {
-    locality_scheduler_ = std::make_unique<EdfScheduler<LocalityEntry>>();
-    locality_entries_.clear();
+      !locality_weights_->empty() && !hosts.empty()) {
+    locality_scheduler = std::make_unique<EdfScheduler<LocalityEntry>>();
+    locality_entries.clear();
     for (uint32_t i = 0; i < hosts_per_locality_->get().size(); ++i) {
-      const double effective_weight = effectiveLocalityWeight(i);
+      const double effective_weight = effectiveLocalityWeight(i, eligible_hosts_per_locality);
       if (effective_weight > 0) {
-        locality_entries_.emplace_back(std::make_shared<LocalityEntry>(i, effective_weight));
-        locality_scheduler_->add(effective_weight, locality_entries_.back());
+        locality_entries.emplace_back(std::make_shared<LocalityEntry>(i, effective_weight));
+        locality_scheduler->add(effective_weight, locality_entries_.back());
       }
     }
     // If all effective weights were zero, reset the scheduler.
-    if (locality_scheduler_->empty()) {
-      locality_scheduler_ = nullptr;
+    if (locality_scheduler->empty()) {
+      locality_scheduler = nullptr;
     }
   }
-  runUpdateCallbacks(hosts_added, hosts_removed);
 }
 
 absl::optional<uint32_t> HostSetImpl::chooseLocality() {
@@ -317,11 +327,12 @@ HostSetImpl::partitionHosts(HostVectorConstSharedPtr hosts,
                            std::move(degraded_hosts), std::move(degraded_hosts_per_locality));
 }
 
-double HostSetImpl::effectiveLocalityWeight(uint32_t index) const {
+double HostSetImpl::effectiveLocalityWeight(uint32_t index,
+                                            const HostsPerLocality& eligible_hosts) const {
   ASSERT(locality_weights_ != nullptr);
   ASSERT(hosts_per_locality_ != nullptr);
   const auto& locality_hosts = hosts_per_locality_->get()[index];
-  const auto& locality_healthy_hosts = healthy_hosts_per_locality_->get()[index];
+  const auto& locality_healthy_hosts = eligible_hosts.get()[index];
   if (locality_hosts.empty()) {
     return 0.0;
   }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -328,8 +328,9 @@ protected:
   }
 
 private:
-  // Weight for a locality taking into account health status.
-  double effectiveLocalityWeight(uint32_t index) const;
+  // Weight for a locality taking into account health status using the provided eligible hosts per
+  // locality.
+  double effectiveLocalityWeight(uint32_t index, const HostsPerLocality& eligible_hosts) const;
 
   uint32_t priority_;
   uint32_t overprovisioning_factor_;
@@ -351,6 +352,12 @@ private:
     const uint32_t index_;
     const double effective_weight_;
   };
+
+  void rebuildLocalityScheduler(std::unique_ptr<EdfScheduler<LocalityEntry>>& locality_scheduler,
+                                std::vector<std::shared_ptr<LocalityEntry>>& locality_entries,
+                                const HostsPerLocality& eligible_hosts_per_locality,
+                                const HostVector& hosts);
+
   std::vector<std::shared_ptr<LocalityEntry>> locality_entries_;
   std::unique_ptr<EdfScheduler<LocalityEntry>> locality_scheduler_;
 };


### PR DESCRIPTION
Splits out two refactors from #5367:

* extract a `distributeLoad` function that populates a PriorityLoad with
  loads based on priority health and total load
* extract a `rebuildLocalityScheduler` function that builds the locality
  EdfScheduler whenever hosts change.

The motivation for both changes is to reuse this code when populating
priority loads and the locality scheduler for degraded hosts.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Medium, refactors core LB code
*Testing*: n/a, no new code
*Docs Changes*: n/a
*Release Notes*: n/a
