### PR TITLE
docs: fix italics in custom headers

### DIFF
--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -474,7 +474,7 @@ Custom request/response headers can be added to a request/response at the weight
 route, virtual host, and/or global route configuration level. See the
 :ref:`v2 <envoy_api_msg_RouteConfiguration>` API documentation.
 
-No *:*-prefixed pseudo-header may be modified via this mechanism. The *:path*
+No *:\*-prefixed pseudo-header* may be modified via this mechanism. The *:path*
 and *:authority* headers may instead be modified via mechanisms such as
 :ref:`prefix_rewrite <envoy_api_field_route.RouteAction.prefix_rewrite>` and
 :ref:`host_rewrite <envoy_api_field_route.RouteAction.host_rewrite>`.
@@ -533,7 +533,7 @@ Supported variable names are:
     Populates the header with values set on the stream info filterState() object. To be
     usable in custom request/response headers, these values must be of type
     Envoy::Router::StringAccessor. These values should be named in standard reverse DNS style,
-    identifying the organization that created the value and ending in a unique name for the data. 
+    identifying the organization that created the value and ending in a unique name for the data.
 
 %START_TIME%
     Request start time. START_TIME can be customized with specifiers as specified in

--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -474,7 +474,7 @@ Custom request/response headers can be added to a request/response at the weight
 route, virtual host, and/or global route configuration level. See the
 :ref:`v2 <envoy_api_msg_RouteConfiguration>` API documentation.
 
-No *:\*-prefixed pseudo-header* may be modified via this mechanism. The *:path*
+No *:-prefixed* pseudo-header may be modified via this mechanism. The *:path*
 and *:authority* headers may instead be modified via mechanisms such as
 :ref:`prefix_rewrite <envoy_api_field_route.RouteAction.prefix_rewrite>` and
 :ref:`host_rewrite <envoy_api_field_route.RouteAction.host_rewrite>`.


### PR DESCRIPTION
Signed-off-by: Derek Schaller <dschaller@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*: fix italics in custom headers doc
*Risk Level*: Low
*Testing*: Built docs locally
*Docs Changes*: N/A
*Release Notes*: N/A
