### PR TITLE
redis: use const singleton for responses

### DIFF
--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -40,7 +40,7 @@ void SingleServerRequest::onResponse(RespValuePtr&& response) {
 
 void SingleServerRequest::onFailure() {
   handle_ = nullptr;
-  callbacks_.onResponse(Utility::makeError("upstream failure"));
+  callbacks_.onResponse(Utility::makeError(Response::get().UpstreamFailure));
 }
 
 void SingleServerRequest::cancel() {
@@ -56,7 +56,7 @@ SplitRequestPtr SimpleRequest::create(ConnPool::Instance& conn_pool,
   request_ptr->handle_ = conn_pool.makeRequest(incoming_request.asArray()[1].asString(),
                                                incoming_request, *request_ptr);
   if (!request_ptr->handle_) {
-    request_ptr->callbacks_.onResponse(Utility::makeError("no upstream host"));
+    request_ptr->callbacks_.onResponse(Utility::makeError(Response::get().NoUpstreamHost));
     return nullptr;
   }
 
@@ -77,7 +77,7 @@ SplitRequestPtr EvalRequest::create(ConnPool::Instance& conn_pool,
   request_ptr->handle_ = conn_pool.makeRequest(incoming_request.asArray()[3].asString(),
                                                incoming_request, *request_ptr);
   if (!request_ptr->handle_) {
-    request_ptr->callbacks_.onResponse(Utility::makeError("no upstream host"));
+    request_ptr->callbacks_.onResponse(Utility::makeError(Response::get().NoUpstreamHost));
     return nullptr;
   }
 
@@ -102,7 +102,7 @@ void FragmentedRequest::cancel() {
 }
 
 void FragmentedRequest::onChildFailure(uint32_t index) {
-  onChildResponse(Utility::makeError("upstream failure"), index);
+  onChildResponse(Utility::makeError(Response::get().UpstreamFailure), index);
 }
 
 SplitRequestPtr MGETRequest::create(ConnPool::Instance& conn_pool,
@@ -134,7 +134,7 @@ SplitRequestPtr MGETRequest::create(ConnPool::Instance& conn_pool,
     pending_request.handle_ = conn_pool.makeRequest(incoming_request.asArray()[i].asString(),
                                                     single_mget, pending_request);
     if (!pending_request.handle_) {
-      pending_request.onResponse(Utility::makeError("no upstream host"));
+      pending_request.onResponse(Utility::makeError(Response::get().NoUpstreamHost));
     }
   }
 
@@ -150,7 +150,7 @@ void MGETRequest::onChildResponse(RespValuePtr&& value, uint32_t index) {
   case RespType::Integer:
   case RespType::SimpleString: {
     pending_response_->asArray()[index].type(RespType::Error);
-    pending_response_->asArray()[index].asString() = "upstream protocol error";
+    pending_response_->asArray()[index].asString() = Response::get().UpstreamProtocolError;
     error_count_++;
     break;
   }
@@ -209,7 +209,7 @@ SplitRequestPtr MSETRequest::create(ConnPool::Instance& conn_pool,
     pending_request.handle_ = conn_pool.makeRequest(incoming_request.asArray()[i].asString(),
                                                     single_mset, pending_request);
     if (!pending_request.handle_) {
-      pending_request.onResponse(Utility::makeError("no upstream host"));
+      pending_request.onResponse(Utility::makeError(Response::get().NoUpstreamHost));
     }
   }
 
@@ -221,7 +221,7 @@ void MSETRequest::onChildResponse(RespValuePtr&& value, uint32_t index) {
 
   switch (value->type()) {
   case RespType::SimpleString: {
-    if (value->asString() == "OK") {
+    if (value->asString() == Response::get().OK) {
       break;
     }
     FALLTHRU;
@@ -235,7 +235,7 @@ void MSETRequest::onChildResponse(RespValuePtr&& value, uint32_t index) {
   ASSERT(num_pending_responses_ > 0);
   if (--num_pending_responses_ == 0) {
     if (error_count_ == 0) {
-      pending_response_->asString() = "OK";
+      pending_response_->asString() = Response::get().OK;
       callbacks_.onResponse(std::move(pending_response_));
     } else {
       callbacks_.onResponse(
@@ -273,7 +273,7 @@ SplitRequestPtr SplitKeysSumResultRequest::create(ConnPool::Instance& conn_pool,
     pending_request.handle_ = conn_pool.makeRequest(incoming_request.asArray()[i].asString(),
                                                     single_fragment, pending_request);
     if (!pending_request.handle_) {
-      pending_request.onResponse(Utility::makeError("no upstream host"));
+      pending_request.onResponse(Utility::makeError(Response::get().NoUpstreamHost));
     }
   }
 
@@ -375,7 +375,7 @@ SplitRequestPtr InstanceImpl::makeRequest(const RespValue& request, SplitCallbac
 
 void InstanceImpl::onInvalidRequest(SplitCallbacks& callbacks) {
   stats_.invalid_request_.inc();
-  callbacks.onResponse(Utility::makeError("invalid request"));
+  callbacks.onResponse(Utility::makeError(Response::get().InvalidRequest));
 }
 
 void InstanceImpl::addHandler(Stats::Scope& scope, const std::string& stat_prefix,

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -9,6 +9,7 @@
 
 #include "common/common/logger.h"
 #include "common/common/to_lower_table.h"
+#include "common/singleton/const_singleton.h"
 
 #include "extensions/filters/network/redis_proxy/command_splitter.h"
 #include "extensions/filters/network/redis_proxy/conn_pool.h"
@@ -18,6 +19,16 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace RedisProxy {
 namespace CommandSplitter {
+
+struct ResponseValues {
+  const std::string OK = "OK";
+  const std::string InvalidRequest = "invalid request";
+  const std::string NoUpstreamHost = "no upstream host";
+  const std::string UpstreamFailure = "upstream failure";
+  const std::string UpstreamProtocolError = "upstream protocol error";
+};
+
+typedef ConstSingleton<ResponseValues> Response;
 
 class Utility {
 public:

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -54,7 +54,7 @@ public:
 TEST_F(RedisCommandSplitterImplTest, InvalidRequestNotArray) {
   RespValue response;
   response.type(RespType::Error);
-  response.asString() = "invalid request";
+  response.asString() = Response::get().InvalidRequest;
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
   RespValue request;
   EXPECT_EQ(nullptr, splitter_.makeRequest(request, callbacks_));
@@ -65,7 +65,7 @@ TEST_F(RedisCommandSplitterImplTest, InvalidRequestNotArray) {
 TEST_F(RedisCommandSplitterImplTest, InvalidRequestArrayTooSmall) {
   RespValue response;
   response.type(RespType::Error);
-  response.asString() = "invalid request";
+  response.asString() = Response::get().InvalidRequest;
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
   RespValue request;
   makeBulkStringArray(request, {"incr"});
@@ -77,7 +77,7 @@ TEST_F(RedisCommandSplitterImplTest, InvalidRequestArrayTooSmall) {
 TEST_F(RedisCommandSplitterImplTest, InvalidRequestArrayNotStrings) {
   RespValue response;
   response.type(RespType::Error);
-  response.asString() = "invalid request";
+  response.asString() = Response::get().InvalidRequest;
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
   RespValue request;
   makeBulkStringArray(request, {"incr", ""});
@@ -111,7 +111,7 @@ public:
   void fail() {
     RespValue response;
     response.type(RespType::Error);
-    response.asString() = "upstream failure";
+    response.asString() = Response::get().UpstreamFailure;
     EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
     pool_callbacks_->onFailure();
   }
@@ -192,7 +192,7 @@ TEST_P(RedisSingleServerRequestTest, NoUpstream) {
   EXPECT_CALL(*conn_pool_, makeRequest("hello", Ref(request), _)).WillOnce(Return(nullptr));
   RespValue response;
   response.type(RespType::Error);
-  response.asString() = "no upstream host";
+  response.asString() = Response::get().NoUpstreamHost;
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
   handle_ = splitter_.makeRequest(request, callbacks_);
   EXPECT_EQ(nullptr, handle_);
@@ -279,7 +279,7 @@ TEST_F(RedisSingleServerRequestTest, EvalNoUpstream) {
   EXPECT_CALL(*conn_pool_, makeRequest("key", Ref(request), _)).WillOnce(Return(nullptr));
   RespValue response;
   response.type(RespType::Error);
-  response.asString() = "no upstream host";
+  response.asString() = Response::get().NoUpstreamHost;
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
   handle_ = splitter_.makeRequest(request, callbacks_);
   EXPECT_EQ(nullptr, handle_);
@@ -379,9 +379,9 @@ TEST_F(RedisMGETCommandHandlerTest, NoUpstreamHostForAll) {
   expected_response.type(RespType::Array);
   std::vector<RespValue> elements(2);
   elements[0].type(RespType::Error);
-  elements[0].asString() = "no upstream host";
+  elements[0].asString() = Response::get().NoUpstreamHost;
   elements[1].type(RespType::Error);
-  elements[1].asString() = "no upstream host";
+  elements[1].asString() = Response::get().NoUpstreamHost;
   expected_response.asArray().swap(elements);
 
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
@@ -399,9 +399,9 @@ TEST_F(RedisMGETCommandHandlerTest, NoUpstreamHostForOne) {
   expected_response.type(RespType::Array);
   std::vector<RespValue> elements(2);
   elements[0].type(RespType::Error);
-  elements[0].asString() = "no upstream host";
+  elements[0].asString() = Response::get().NoUpstreamHost;
   elements[1].type(RespType::Error);
-  elements[1].asString() = "upstream failure";
+  elements[1].asString() = Response::get().UpstreamFailure;
   expected_response.asArray().swap(elements);
 
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
@@ -420,7 +420,7 @@ TEST_F(RedisMGETCommandHandlerTest, Failure) {
   elements[0].type(RespType::BulkString);
   elements[0].asString() = "response";
   elements[1].type(RespType::Error);
-  elements[1].asString() = "upstream failure";
+  elements[1].asString() = Response::get().UpstreamFailure;
   expected_response.asArray().swap(elements);
 
   pool_callbacks_[1]->onFailure();
@@ -442,9 +442,9 @@ TEST_F(RedisMGETCommandHandlerTest, InvalidUpstreamResponse) {
   expected_response.type(RespType::Array);
   std::vector<RespValue> elements(2);
   elements[0].type(RespType::Error);
-  elements[0].asString() = "upstream protocol error";
+  elements[0].asString() = Response::get().UpstreamProtocolError;
   elements[1].type(RespType::Error);
-  elements[1].asString() = "upstream failure";
+  elements[1].asString() = Response::get().UpstreamFailure;
   expected_response.asArray().swap(elements);
 
   pool_callbacks_[1]->onFailure();
@@ -513,16 +513,16 @@ TEST_F(RedisMSETCommandHandlerTest, Normal) {
 
   RespValue expected_response;
   expected_response.type(RespType::SimpleString);
-  expected_response.asString() = "OK";
+  expected_response.asString() = Response::get().OK;
 
   RespValuePtr response2(new RespValue());
   response2->type(RespType::SimpleString);
-  response2->asString() = "OK";
+  response2->asString() = Response::get().OK;
   pool_callbacks_[1]->onResponse(std::move(response2));
 
   RespValuePtr response1(new RespValue());
   response1->type(RespType::SimpleString);
-  response1->asString() = "OK";
+  response1->asString() = Response::get().OK;
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
   pool_callbacks_[0]->onResponse(std::move(response1));
 
@@ -553,7 +553,7 @@ TEST_F(RedisMSETCommandHandlerTest, NoUpstreamHostForOne) {
 
   RespValuePtr response2(new RespValue());
   response2->type(RespType::SimpleString);
-  response2->asString() = "OK";
+  response2->asString() = Response::get().OK;
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
   pool_callbacks_[1]->onResponse(std::move(response2));
 };


### PR DESCRIPTION
*Description*: Redis response strings are sprayed across the code. This PR consolidates them in to a const singleton.
*Risk Level*: Low
*Testing*: Existing tests
*Docs Changes*: N/A
*Release Notes*: N/A
