### PR TITLE
buffer: fix vulnerabilities when allocation fails

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -4,6 +4,7 @@ Version history
 1.10.0 (pending)
 ================
 * access log: added a new flag for upstream retry count exceeded.
+* buffer: fix vulnerabilities when allocation fails
 * config: removed deprecated_v1 sds_config from :ref:`Bootstrap config <config_overview_v2_bootstrap>`.
 * tls: enabled TLS 1.3 on the server-side (non-FIPS builds).
 


### PR DESCRIPTION
If allocations in Buffer::OwnedImpl fail in reserve(), the caller may write to uninitialized pointers. There are various callers that would fall into this path, and it may be possible to develop an exploit based on this.

A similar allocation failure could occur in linearize(), which could result in a NULL-pointer dereference. Because this is undefined-behavior in C++, this should be avoided. This could also result in reading/writing to arbitrary memory (NULL + offset) if either offset is large (and thus points to a valid virtual memory address), or very low addresses are mapped in the process.

Typically on linux, allocations do not fail, and OOM conditions are resolved by the kernel killing a process to reclaim memory. However, with various ulimit and cgroup options, an allocation could return NULL.

Signed-off-by: Greg Greenway <ggreenway@apple.com>

*Risk Level*: Low
*Testing*: Existing tests pass, but no additional testing was added because there isn't an easy way to make libevent allocations fail in tests, and this code is currently being rewritten (see #5441).
*Docs Changes*: None
*Release Notes*: TODO