### PR TITLE
build: fix checksum verification on macOS.

### DIFF
--- a/bazel/repositories.sh
+++ b/bazel/repositories.sh
@@ -5,7 +5,7 @@ set -e
 if [[ `uname` == "Darwin" ]]
 then
   function md5sum {
-    md5
+    gmd5sum $@
   }
 fi
 

--- a/ci/build_container/recipe_wrapper.sh
+++ b/ci/build_container/recipe_wrapper.sh
@@ -5,7 +5,7 @@ set -x
 
 if [[ `uname` == "Darwin" ]]; then
   function sha256sum {
-    gsha256sum
+    gsha256sum $@
   }
 fi
 


### PR DESCRIPTION
Previously, the tools were called without any arguments, and sha256sum
was producing checksums, instead of verifying them.

While there, replace OpenSSL md5 with GNU (g)md5sum, for compatibility
across supported operating systems.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>