### PR TITLE
network: include <netinet/in.h> instead of <netinet/ip.h>.

### DIFF
--- a/source/common/network/addr_family_aware_socket_option_impl.h
+++ b/source/common/network/addr_family_aware_socket_option_impl.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <netinet/in.h>
-#include <netinet/ip.h>
 #include <sys/socket.h>
 
 #include "envoy/network/listen_socket.h"

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -1,7 +1,7 @@
 #include "common/network/address_impl.h"
 
 #include <arpa/inet.h>
-#include <netinet/ip.h>
+#include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 

--- a/source/common/network/address_impl.h
+++ b/source/common/network/address_impl.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <netinet/ip.h>
+#include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/un.h>

--- a/source/common/network/cidr_range.cc
+++ b/source/common/network/cidr_range.cc
@@ -1,7 +1,7 @@
 #include "common/network/cidr_range.h"
 
 #include <arpa/inet.h>
-#include <netinet/ip.h>
+#include <netinet/in.h>
 #include <sys/socket.h>
 
 #include <array>

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -1,7 +1,7 @@
 #include "common/network/dns_impl.h"
 
 #include <netdb.h>
-#include <netinet/ip.h>
+#include <netinet/in.h>
 #include <sys/socket.h>
 
 #include <chrono>

--- a/source/common/network/socket_option_factory.h
+++ b/source/common/network/socket_option_factory.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <netinet/in.h>
-#include <netinet/ip.h>
-#include <netinet/tcp.h>
 #include <sys/socket.h>
 
 #include "envoy/api/v2/core/address.pb.h"

--- a/source/common/network/socket_option_impl.h
+++ b/source/common/network/socket_option_impl.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <netinet/in.h>
-#include <netinet/ip.h>
 #include <netinet/tcp.h>
 #include <sys/socket.h>
 

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -12,7 +12,7 @@
 #define IP6T_SO_ORIGINAL_DST 80
 #endif
 
-#include <netinet/ip.h>
+#include <netinet/in.h>
 #include <sys/socket.h>
 
 #include <cstdint>

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -1,6 +1,6 @@
 #include <arpa/inet.h>
 #include <fcntl.h>
-#include <netinet/ip.h>
+#include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>

--- a/test/test_common/network_utility.cc
+++ b/test/test_common/network_utility.cc
@@ -1,6 +1,6 @@
 #include "test/test_common/network_utility.h"
 
-#include <netinet/ip.h>
+#include <netinet/in.h>
 #include <sys/socket.h>
 
 #include <cstdint>


### PR DESCRIPTION
While there, remove unused <netinet/tcp.h> from socket_option_factory.h.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>