### PR TITLE
build: correct typo in OS X instructions

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -56,14 +56,15 @@ Envoy compiles and passes tests with the version of clang installed by XCode 9.3
 Apple LLVM version 9.1.0 (clang-902.0.30).
 
 In order for bazel to be aware of the tools installed by brew, the PATH
-variable must be set for bazel builds. This can be accomplished setting
+variable must be set for bazel builds. This can be accomplished by setting
+this in your `$HOME/.bazelrc` file:
 
 ```
---action_env=PATH=/usr/local/bin:/opt/local/bin:/usr/bin:/bin"
+build --action_env=PATH="/usr/local/bin:/opt/local/bin:/usr/bin:/bin"
 ```
 
-either on the command line when running `bazel build`/`bazel test` or
-in your `$HOME/.bazelrc` file.
+Alternatively, you can pass `--action_env` on the command line when running
+`bazel build`/`bazel test`.
 
 3. Install Golang on your machine. This is required as part of building [BoringSSL](https://boringssl.googlesource.com/boringssl/+/HEAD/BUILDING.md)
 and also for [Buildifer](https://github.com/bazelbuild/buildtools) which is used for formatting bazel BUILD files.


### PR DESCRIPTION
*Description*:
Added missing quotes and clarified the syntax of the .bazelrc file. This change recommends using the .bazelrc file as the default with the full syntax, but still explains how to pass it to each build command individually.

*Risk Level*: Low
*Testing*: ran the build according to instructions
*Docs Changes*: See above.
*Release Notes*: N/A