### PR TITLE
build: fix typo in previously ignored -stdlib=libc++.

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -80,7 +80,7 @@ def envoy_copts(repository, test = False):
 
 def envoy_static_link_libstdcpp_linkopts():
     return envoy_select_force_libcpp(
-        ["--stdlib=libc++"],
+        ["-stdlib=libc++"],
         ["-static-libstdc++", "-static-libgcc"],
     )
 


### PR DESCRIPTION
This only affects builds with --define force_libcpp=enabled.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>