### PR TITLE
stats: lower savings expectations in tests.

### DIFF
--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -426,7 +426,7 @@ TEST(SymbolTableTest, Memory) {
     ENVOY_LOG_MISC(info,
                    "SymbolTableTest.Memory comparison skipped due to malloc-stats returning 0.");
   } else {
-    EXPECT_LT(symbol_table_mem_used, string_mem_used / 4);
+    EXPECT_LT(symbol_table_mem_used, string_mem_used / 3);
     EXPECT_LT(symbol_table_mem_used, 1750000); // Dec 16, 2018: 1744280 bytes.
   }
 }

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -426,8 +426,21 @@ TEST(SymbolTableTest, Memory) {
     ENVOY_LOG_MISC(info,
                    "SymbolTableTest.Memory comparison skipped due to malloc-stats returning 0.");
   } else {
+    // Make sure we don't regress. Data as of 2019/01/04:
+    //
+    // libstdc++:
+    // ----------
+    // string_mem_used:        7759488
+    // symbol_table_mem_used:  1744280 (4.45x)
+    //
+    // libc++:
+    // -------
+    // string_mem_used:        6710912
+    // symbol_table_mem_used:  1743512 (3.85x)
+    ENVOY_LOG_MISC(info, "string_mem_used: {}", string_mem_used);
+    ENVOY_LOG_MISC(info, "symbol_table_mem_used: {}", symbol_table_mem_used);
     EXPECT_LT(symbol_table_mem_used, string_mem_used / 3);
-    EXPECT_LT(symbol_table_mem_used, 1750000); // Dec 16, 2018: 1744280 bytes.
+    EXPECT_LT(symbol_table_mem_used, 1750000);
   }
 }
 

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -437,8 +437,6 @@ TEST(SymbolTableTest, Memory) {
     // -------
     // string_mem_used:        6710912
     // symbol_table_mem_used:  1743512 (3.85x)
-    ENVOY_LOG_MISC(info, "string_mem_used: {}", string_mem_used);
-    ENVOY_LOG_MISC(info, "symbol_table_mem_used: {}", symbol_table_mem_used);
     EXPECT_LT(symbol_table_mem_used, string_mem_used / 3);
     EXPECT_LT(symbol_table_mem_used, 1750000);
   }


### PR DESCRIPTION
libc++ is apparently a bit smarter than libstdc++, when it comes to
memory usage of std::string, so the savings from using symbol table
are slightly less than the expected 4x, which breaks tests.

libstdc++:
----------
string_mem_used:        7759488
symbol_table_mem_used:  1744280 (4.45x)

libc++:
-------
string_mem_used:        6710912
symbol_table_mem_used:  1743512 (3.85x)

Signed-off-by: Piotr Sikora <piotrsikora@google.com>