### PR TITLE
listener: compare IPv4-mapped IPv6 addresses as strings in tests.

### DIFF
--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -248,6 +248,7 @@ TEST_P(ListenerImplTest, WildcardListenerIpv4Compat) {
   EXPECT_CALL(listener_callbacks, onNewConnection_(_))
       .WillOnce(Invoke([&](Network::ConnectionPtr& conn) -> void {
         EXPECT_EQ(conn->localAddress()->ip()->version(), conn->remoteAddress()->ip()->version());
+        EXPECT_EQ(conn->localAddress()->asString(), local_dst_address->asString());
         EXPECT_EQ(*conn->localAddress(), *local_dst_address);
         client_connection->close(ConnectionCloseType::NoFlush);
         conn->close(ConnectionCloseType::NoFlush);


### PR DESCRIPTION
Trying to figure out the difference between IPv4-mapped IPv6 address
and the same IPv4 address at the byte level isn't fun...

Signed-off-by: Piotr Sikora <piotrsikora@google.com>