### PR TITLE
[buffer filter] Remove max_request_time field and code

### DIFF
--- a/api/envoy/config/filter/http/buffer/v2/buffer.proto
+++ b/api/envoy/config/filter/http/buffer/v2/buffer.proto
@@ -15,11 +15,11 @@ import "gogoproto/gogo.proto";
 // Buffer :ref:`configuration overview <config_http_filters_buffer>`.
 
 message Buffer {
+  reserved 2; // formerly max_request_time
+
   // The maximum request size that the filter will buffer before the connection
   // manager will stop buffering and return a 413 response.
   google.protobuf.UInt32Value max_request_bytes = 1 [(validate.rules).uint32.gt = 0];
-
-  google.protobuf.Duration max_request_time = 2 [deprecated = true];
 }
 
 message BufferPerRoute {

--- a/api/envoy/config/filter/http/buffer/v2/buffer.proto
+++ b/api/envoy/config/filter/http/buffer/v2/buffer.proto
@@ -19,12 +19,7 @@ message Buffer {
   // manager will stop buffering and return a 413 response.
   google.protobuf.UInt32Value max_request_bytes = 1 [(validate.rules).uint32.gt = 0];
 
-  // The maximum number of seconds that the filter will wait for a complete
-  // request before returning a 408 response.
-  // deprecated in favor of http connection manager of :ref:request timeouts
-  // <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.request_timeout>
-  google.protobuf.Duration max_request_time = 2
-      [deprecated = true, (validate.rules).duration = {gt: {}}, (gogoproto.stdduration) = true];
+  google.protobuf.Duration max_request_time = 2 [deprecated = true];
 }
 
 message BufferPerRoute {

--- a/configs/envoy_double_proxy_v2.template.yaml
+++ b/configs/envoy_double_proxy_v2.template.yaml
@@ -48,7 +48,6 @@
           name: envoy.buffer
           config:
             max_request_bytes: 5242880
-            max_request_time: 120s
           name: envoy.router
           config: {}
         tracing:

--- a/configs/envoy_front_proxy_v2.template.yaml
+++ b/configs/envoy_front_proxy_v2.template.yaml
@@ -50,7 +50,6 @@
         - name: envoy.buffer
           config:
             max_request_bytes: 5242880
-            max_request_time: 120s
         - name: envoy.rate_limit
           config:
             domain: envoy_front

--- a/configs/envoy_service_to_service_v2.template.yaml
+++ b/configs/envoy_service_to_service_v2.template.yaml
@@ -41,7 +41,6 @@
         - name: envoy.buffer
           config:
            max_request_bytes: 5242880
-           max_request_time: 120s
         - name: envoy.router
           config: {}
         access_log:

--- a/source/common/config/filter_json.cc
+++ b/source/common/config/filter_json.cc
@@ -370,7 +370,6 @@ void FilterJson::translateBufferFilter(
   json_config.validateSchema(Json::Schema::BUFFER_HTTP_FILTER_SCHEMA);
 
   JSON_UTIL_SET_INTEGER(json_config, proto_config, max_request_bytes);
-  JSON_UTIL_SET_DURATION_SECONDS(json_config, proto_config, max_request_time);
 }
 
 void FilterJson::translateLuaFilter(const Json::Object& json_config,

--- a/source/common/json/config_schemas.cc
+++ b/source/common/json/config_schemas.cc
@@ -933,8 +933,7 @@ const std::string Json::Schema::BUFFER_HTTP_FILTER_SCHEMA(R"EOF(
     "$schema": "http://json-schema.org/schema#",
     "type" : "object",
     "properties" : {
-      "max_request_bytes" : {"type" : "integer"},
-      "max_request_time_s" : {"type" : "integer"}
+      "max_request_bytes" : {"type" : "integer"}
     },
     "required" : ["max_request_bytes"],
     "additionalProperties" : false

--- a/source/extensions/filters/http/buffer/BUILD
+++ b/source/extensions/filters/http/buffer/BUILD
@@ -17,7 +17,6 @@ envoy_cc_library(
     hdrs = ["buffer_filter.h"],
     deps = [
         "//include/envoy/event:dispatcher_interface",
-        "//include/envoy/event:timer_interface",
         "//include/envoy/http:codes_interface",
         "//include/envoy/http:filter_interface",
         "//include/envoy/stats:stats_interface",

--- a/source/extensions/filters/http/buffer/buffer_filter.cc
+++ b/source/extensions/filters/http/buffer/buffer_filter.cc
@@ -1,7 +1,6 @@
 #include "extensions/filters/http/buffer/buffer_filter.h"
 
 #include "envoy/event/dispatcher.h"
-#include "envoy/event/timer.h"
 #include "envoy/http/codes.h"
 #include "envoy/stats/scope.h"
 
@@ -22,9 +21,7 @@ namespace BufferFilter {
 BufferFilterSettings::BufferFilterSettings(
     const envoy::config::filter::http::buffer::v2::Buffer& proto_config)
     : disabled_(false),
-      max_request_bytes_(static_cast<uint64_t>(proto_config.max_request_bytes().value())),
-      max_request_time_(std::chrono::seconds(
-          DurationUtil::durationToSeconds((proto_config).max_request_time()))) {}
+      max_request_bytes_(static_cast<uint64_t>(proto_config.max_request_bytes().value())) {}
 
 BufferFilterSettings::BufferFilterSettings(
     const envoy::config::filter::http::buffer::v2::BufferPerRoute& proto_config)
@@ -32,11 +29,7 @@ BufferFilterSettings::BufferFilterSettings(
       max_request_bytes_(
           proto_config.has_buffer()
               ? static_cast<uint64_t>(proto_config.buffer().max_request_bytes().value())
-              : 0),
-      max_request_time_(std::chrono::seconds(
-          proto_config.has_buffer()
-              ? DurationUtil::durationToSeconds(proto_config.buffer().max_request_time())
-              : 0)) {}
+              : 0) {}
 
 BufferFilterConfig::BufferFilterConfig(
     const envoy::config::filter::http::buffer::v2::Buffer& proto_config,
@@ -81,10 +74,6 @@ Http::FilterHeadersStatus BufferFilter::decodeHeaders(Http::HeaderMap&, bool end
   }
 
   callbacks_->setDecoderBufferLimit(settings_->maxRequestBytes());
-  request_timeout_ = callbacks_->dispatcher().createTimer([this]() -> void { onRequestTimeout(); });
-  if (settings_->maxRequestTime().count() != 0) {
-    request_timeout_->enableTimer(settings_->maxRequestTime());
-  }
 
   return Http::FilterHeadersStatus::StopIteration;
 }

--- a/source/extensions/filters/http/buffer/buffer_filter.cc
+++ b/source/extensions/filters/http/buffer/buffer_filter.cc
@@ -100,12 +100,6 @@ BufferFilterStats BufferFilter::generateStats(const std::string& prefix, Stats::
 
 void BufferFilter::onDestroy() { resetInternalState(); }
 
-void BufferFilter::onRequestTimeout() {
-  callbacks_->sendLocalReply(Http::Code::RequestTimeout, "buffer request timeout", nullptr,
-                             absl::nullopt);
-  config_->stats().rq_timeout_.inc();
-}
-
 void BufferFilter::resetInternalState() { request_timeout_.reset(); }
 
 void BufferFilter::setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) {

--- a/source/extensions/filters/http/buffer/buffer_filter.h
+++ b/source/extensions/filters/http/buffer/buffer_filter.h
@@ -39,12 +39,11 @@ public:
 
   bool disabled() const { return disabled_; }
   uint64_t maxRequestBytes() const { return max_request_bytes_; }
-  std::chrono::seconds maxRequestTime() const { return max_request_time_; }
+  std::chrono::seconds maxRequestTime() const { return std::chrono::seconds(0); }
 
 private:
   bool disabled_;
   uint64_t max_request_bytes_;
-  std::chrono::seconds max_request_time_;
 };
 
 /**

--- a/source/extensions/filters/http/buffer/buffer_filter.h
+++ b/source/extensions/filters/http/buffer/buffer_filter.h
@@ -39,7 +39,6 @@ public:
 
   bool disabled() const { return disabled_; }
   uint64_t maxRequestBytes() const { return max_request_bytes_; }
-  std::chrono::seconds maxRequestTime() const { return std::chrono::seconds(0); }
 
 private:
   bool disabled_;
@@ -84,7 +83,6 @@ public:
   void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override;
 
 private:
-  void onRequestTimeout();
   void resetInternalState();
   void initConfig();
 

--- a/test/config/integration/server.json
+++ b/test/config/integration/server.json
@@ -397,8 +397,7 @@
           },
           { "type": "decoder", "name": "buffer",
             "config": {
-              "max_request_bytes": 5242880,
-              "max_request_time_s": 120
+              "max_request_bytes": 5242880
             }
           },
           { "type": "decoder", "name": "router", "config": {} }

--- a/test/config/integration/server.yaml
+++ b/test/config/integration/server.yaml
@@ -271,7 +271,6 @@ static_resources:
                 domain: foo
             - name: buffer
               config:
-                max_request_time_s: 120
                 max_request_bytes: 5242880
             - config: {}
               name: router

--- a/test/config/integration/server_http2.json
+++ b/test/config/integration/server_http2.json
@@ -163,8 +163,7 @@
           },
           { "type": "decoder", "name": "buffer",
             "config": {
-              "max_request_bytes": 5242880,
-              "max_request_time_s": 120
+              "max_request_bytes": 5242880
             }
           },
           { "type": "decoder", "name": "router", "config": {} }

--- a/test/config/integration/server_http2_upstream.json
+++ b/test/config/integration/server_http2_upstream.json
@@ -157,8 +157,7 @@
           },
           { "type": "decoder", "name": "buffer",
             "config": {
-              "max_request_bytes": 5242880,
-              "max_request_time_s": 120
+              "max_request_bytes": 5242880
             }
           },
           { "type": "decoder", "name": "router", "config": {} }
@@ -242,8 +241,7 @@
           },
           { "type": "decoder", "name": "buffer",
             "config": {
-              "max_request_bytes": 5242880,
-              "max_request_time_s": 120
+              "max_request_bytes": 5242880
             }
           },
           { "type": "decoder", "name": "router", "config": {} }

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -76,7 +76,6 @@ const std::string ConfigHelper::DEFAULT_BUFFER_FILTER =
 name: envoy.buffer
 config:
     max_request_bytes : 5242880
-    max_request_time : 120s
 )EOF";
 
 const std::string ConfigHelper::SMALL_BUFFER_FILTER =
@@ -84,7 +83,6 @@ const std::string ConfigHelper::SMALL_BUFFER_FILTER =
 name: envoy.buffer
 config:
     max_request_bytes : 1024
-    max_request_time : 5s
 )EOF";
 
 const std::string ConfigHelper::DEFAULT_HEALTH_CHECK_FILTER =

--- a/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_integration_test.cc
@@ -96,8 +96,7 @@ TEST_P(BufferIntegrationTest, RouteDisabled) {
 
 TEST_P(BufferIntegrationTest, RouteOverride) {
   ConfigHelper::HttpModifierFunction mod = overrideConfig(R"EOF({"buffer": {
-    "max_request_bytes": 5242880,
-    "max_request_time": {"seconds": 120}
+    "max_request_bytes": 5242880
   }})EOF");
   config_helper_.addConfigModifier(mod);
   config_helper_.addFilter(ConfigHelper::SMALL_BUFFER_FILTER);

--- a/test/extensions/filters/http/buffer/buffer_filter_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_test.cc
@@ -33,15 +33,12 @@ public:
   BufferFilterConfigSharedPtr setupConfig() {
     envoy::config::filter::http::buffer::v2::Buffer proto_config;
     proto_config.mutable_max_request_bytes()->set_value(1024 * 1024);
-    proto_config.mutable_max_request_time()->set_seconds(0);
     return std::make_shared<BufferFilterConfig>(BufferFilterConfig(proto_config, "test", store_));
   }
 
   BufferFilterTest() : config_(setupConfig()), filter_(config_) {
     filter_.setDecoderFilterCallbacks(callbacks_);
   }
-
-  void expectTimerCreate() { timer_ = new NiceMock<Event::MockTimer>(&callbacks_.dispatcher_); }
 
   void routeLocalConfig(const Router::RouteSpecificFilterConfig* route_settings,
                         const Router::RouteSpecificFilterConfig* vhost_settings) {
@@ -56,7 +53,6 @@ public:
   Stats::IsolatedStoreImpl store_;
   BufferFilterConfigSharedPtr config_;
   BufferFilter filter_;
-  Event::MockTimer* timer_{};
 };
 
 TEST_F(BufferFilterTest, HeaderOnlyRequest) {
@@ -66,8 +62,6 @@ TEST_F(BufferFilterTest, HeaderOnlyRequest) {
 
 TEST_F(BufferFilterTest, RequestWithData) {
   InSequence s;
-
-  expectTimerCreate();
 
   Http::TestHeaderMapImpl headers;
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_.decodeHeaders(headers, false));
@@ -79,42 +73,8 @@ TEST_F(BufferFilterTest, RequestWithData) {
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data2, true));
 }
 
-TEST_F(BufferFilterTest, RequestTimeoutNotEnabledWithZero) {
-  InSequence s;
-
-  expectTimerCreate();
-
-  // timer config is 0 by default
-  EXPECT_CALL(*timer_, enableTimer(_)).Times(0);
-  Http::TestHeaderMapImpl headers;
-  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_.decodeHeaders(headers, false));
-
-  filter_.onDestroy();
-  EXPECT_EQ(0U, config_->stats().rq_timeout_.value());
-}
-
-TEST_F(BufferFilterTest, RequestTimeout) {
-  InSequence s;
-
-  expectTimerCreate();
-
-  Http::TestHeaderMapImpl headers;
-  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_.decodeHeaders(headers, false));
-
-  Http::TestHeaderMapImpl response_headers{
-      {":status", "408"}, {"content-length", "22"}, {"content-type", "text/plain"}};
-  EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
-  EXPECT_CALL(callbacks_, encodeData(_, true));
-  timer_->callback_();
-
-  filter_.onDestroy();
-  EXPECT_EQ(1U, config_->stats().rq_timeout_.value());
-}
-
 TEST_F(BufferFilterTest, TxResetAfterEndStream) {
   InSequence s;
-
-  expectTimerCreate();
 
   Http::TestHeaderMapImpl headers;
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_.decodeHeaders(headers, false));
@@ -134,7 +94,6 @@ TEST_F(BufferFilterTest, RouteConfigOverride) {
   envoy::config::filter::http::buffer::v2::BufferPerRoute route_cfg;
   auto* buf = route_cfg.mutable_buffer();
   buf->mutable_max_request_bytes()->set_value(123);
-  buf->mutable_max_request_time()->set_seconds(456);
   envoy::config::filter::http::buffer::v2::BufferPerRoute vhost_cfg;
   vhost_cfg.set_disabled(true);
   BufferFilterSettings route_settings(route_cfg);
@@ -142,7 +101,6 @@ TEST_F(BufferFilterTest, RouteConfigOverride) {
   routeLocalConfig(&route_settings, &vhost_settings);
 
   EXPECT_CALL(callbacks_, setDecoderBufferLimit(123ULL));
-  expectTimerCreate();
 
   Http::TestHeaderMapImpl headers;
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_.decodeHeaders(headers, false));
@@ -154,12 +112,10 @@ TEST_F(BufferFilterTest, VHostConfigOverride) {
   envoy::config::filter::http::buffer::v2::BufferPerRoute vhost_cfg;
   auto* buf = vhost_cfg.mutable_buffer();
   buf->mutable_max_request_bytes()->set_value(789);
-  buf->mutable_max_request_time()->set_seconds(1011);
   BufferFilterSettings vhost_settings(vhost_cfg);
   routeLocalConfig(nullptr, &vhost_settings);
 
   EXPECT_CALL(callbacks_, setDecoderBufferLimit(789ULL));
-  expectTimerCreate();
 
   Http::TestHeaderMapImpl headers;
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_.decodeHeaders(headers, false));

--- a/test/extensions/filters/http/buffer/config_test.cc
+++ b/test/extensions/filters/http/buffer/config_test.cc
@@ -16,7 +16,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace BufferFilter {
 
-TEST(BufferFilterFactoryTest, BufferFilterCorrectWithoutRequestTime) {
+TEST(BufferFilterFactoryTest, BufferFilterCorrectJson) {
   std::string json_string = R"EOF(
   {
     "max_request_bytes" : 1028
@@ -32,28 +32,11 @@ TEST(BufferFilterFactoryTest, BufferFilterCorrectWithoutRequestTime) {
   cb(filter_callback);
 }
 
-TEST(BufferFilterFactoryTest, BufferFilterCorrectJson) {
-  std::string json_string = R"EOF(
-  {
-    "max_request_bytes" : 1028,
-    "max_request_time_s" : 2
-  }
-  )EOF";
-
-  Json::ObjectSharedPtr json_config = Json::Factory::loadFromString(json_string);
-  NiceMock<Server::Configuration::MockFactoryContext> context;
-  BufferFilterFactory factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactory(*json_config, "stats", context);
-  Http::MockFilterChainFactoryCallbacks filter_callback;
-  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
-  cb(filter_callback);
-}
-
 TEST(BufferFilterFactoryTest, BufferFilterIncorrectJson) {
+  // This is incorrect because the number is quote-wrapped
   std::string json_string = R"EOF(
   {
-    "max_request_bytes" : 1028,
-    "max_request_time_s" : "2"
+    "max_request_bytes" : "1028"
   }
   )EOF";
 
@@ -66,7 +49,6 @@ TEST(BufferFilterFactoryTest, BufferFilterIncorrectJson) {
 TEST(BufferFilterFactoryTest, BufferFilterCorrectProto) {
   envoy::config::filter::http::buffer::v2::Buffer config{};
   config.mutable_max_request_bytes()->set_value(1028);
-  config.mutable_max_request_time()->set_seconds(2);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   BufferFilterFactory factory;
@@ -83,7 +65,6 @@ TEST(BufferFilterFactoryTest, BufferFilterEmptyProto) {
           factory.createEmptyConfigProto().get());
 
   config.mutable_max_request_bytes()->set_value(1028);
-  config.mutable_max_request_time()->set_seconds(2);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context);


### PR DESCRIPTION
*Description*: This field was deprecated in 1.90 in favour of the new request timeout feature in the http connection manager.
*Risk Level*: Medium-high?
*Testing*: Adjusted config testing and etc. There were never any integration tests for the buffer filter timeout.