### PR TITLE
router: invert appending of response headers

### DIFF
--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -479,8 +479,18 @@ and *:authority* headers may instead be modified via mechanisms such as
 :ref:`prefix_rewrite <envoy_api_field_route.RouteAction.prefix_rewrite>` and
 :ref:`host_rewrite <envoy_api_field_route.RouteAction.host_rewrite>`.
 
-Headers are appended to requests/responses in the following order: weighted cluster level headers,
+Headers are appended to requests in the following order: weighted cluster level headers,
 route level headers, virtual host level headers and finally global level headers.
+
+Headers are appended to responses in the following order: global level headers,
+virtual host level headers, route level headers, and finally weighted cluster
+level headers.
+The appending order is intentionally inverted to the appending ordering of request
+headers to allow for routes to specify a header that will not be appended to. This
+is particularly important for headers such as
+:ref:`X-Frame-Options <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options>`,
+where having multiple values is not allowed and while the virtual host specifies
+a value of ``DENY``, there could be routes that want to have a value of ``SAMEORIGIN``.
 
 Envoy supports adding dynamic values to request and response headers. The percent symbol (%) is
 used to delimit variable names.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -7,6 +7,7 @@ Version history
 * buffer: fix vulnerabilities when allocation fails
 * config: removed deprecated_v1 sds_config from :ref:`Bootstrap config <config_overview_v2_bootstrap>`.
 * http: added new grpc_http1_reverse_bridge filter for converting gRPC requests into HTTP/1.1 requests.
+* router: invert appending of headers for responses. See :ref:`Custom request/response headers <config_http_conn_man_headers_custom_request_headers>` for more information.
 * tls: enabled TLS 1.3 on the server-side (non-FIPS builds).
 
 1.9.0

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -446,13 +446,16 @@ void RouteEntryImplBase::finalizeRequestHeaders(Http::HeaderMap& headers,
 
 void RouteEntryImplBase::finalizeResponseHeaders(Http::HeaderMap& headers,
                                                  const StreamInfo::StreamInfo& stream_info) const {
-  // Append user-specified response headers in the following order: route-action-level headers,
-  // route-level headers, virtual host level headers and finally global connection manager level
-  // headers.
-  route_action_response_headers_parser_->evaluateHeaders(headers, stream_info);
-  response_headers_parser_->evaluateHeaders(headers, stream_info);
-  vhost_.responseHeaderParser().evaluateHeaders(headers, stream_info);
+  // Append user-specified response headers in the following order: global connection
+  // manager level headers, virtual host level headers, route-level headers,
+  // and finally route-action-level headers.
+  //
+  // Since we are evaluating response headers they are applied in the reverse
+  // order of request headers to preserve route header values when append is false.
   vhost_.globalRouteConfig().responseHeaderParser().evaluateHeaders(headers, stream_info);
+  vhost_.responseHeaderParser().evaluateHeaders(headers, stream_info);
+  response_headers_parser_->evaluateHeaders(headers, stream_info);
+  route_action_response_headers_parser_->evaluateHeaders(headers, stream_info);
 }
 
 absl::optional<RouteEntryImplBase::RuntimeData>

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -883,6 +883,7 @@ virtual_hosts:
             - header:
                 key: x-global-header1
                 value: route-override
+              append: false
             - header:
                 key: x-vhost-header1
                 value: route-override
@@ -938,8 +939,9 @@ response_headers_to_remove: ["x-global-remove"]
       const RouteEntry* route = config.route(req_headers, 0)->routeEntry();
       Http::TestHeaderMapImpl headers;
       route->finalizeResponseHeaders(headers, stream_info);
+      std::cout << headers << std::endl;
       EXPECT_EQ("route-override", headers.get_("x-global-header1"));
-      EXPECT_EQ("route-override", headers.get_("x-vhost-header1"));
+      EXPECT_EQ("vhost1-www2", headers.get_("x-vhost-header1"));
       EXPECT_EQ("route-new_endpoint", headers.get_("x-route-action-header"));
       EXPECT_EQ("route-override", headers.get_("x-route-header"));
     }
@@ -950,7 +952,7 @@ response_headers_to_remove: ["x-global-remove"]
       const RouteEntry* route = config.route(req_headers, 0)->routeEntry();
       Http::TestHeaderMapImpl headers;
       route->finalizeResponseHeaders(headers, stream_info);
-      EXPECT_EQ("vhost-override", headers.get_("x-global-header1"));
+      EXPECT_EQ("global1", headers.get_("x-global-header1"));
       EXPECT_EQ("vhost1-www2", headers.get_("x-vhost-header1"));
       EXPECT_EQ("route-allpath", headers.get_("x-route-action-header"));
     }


### PR DESCRIPTION
Signed-off-by: Derek Schaller <dschaller@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*: The current behavior of appending custom response headers does not allow for individual routes to override header values set higher up (e.g. by the virtual host, etc.). The only mechanism at the moment to propagate headers up is by appending them but for some headers that is not a valid option. E.g. `X-Frame-Options` or `Content-Security-Policy` which cannot have multiple values. This inverts the appending of headers so that routes can either append to or overwrite headers that are already set on responses.

A common use-case for this would be to have a virtual host that sets a response header of `X-Frame-Options=DENY` to prevent clickjacking attacks on all pages but have some routes set `X-Frame-Options=SAMEORIGIN` to allow those routes to be used in an iframe on site with the same domain.

*Risk Level*: High
*Testing*: Updated unit tests and manually verified the changes.
*Docs Changes*: Yes
*Release Notes*: Yes