### PR TITLE
Support retry for connection termination

### DIFF
--- a/docs/root/configuration/http_filters/router_filter.rst
+++ b/docs/root/configuration/http_filters/router_filter.rst
@@ -59,7 +59,8 @@ The supported policies are:
 
 5xx
   Envoy will attempt a retry if the upstream server responds with any 5xx response code, or does not
-  respond at all (disconnect/reset/read timeout). (Includes *connect-failure* and *refused-stream*)
+  respond at all (disconnect/reset/read timeout). (Includes *connect-failure*,
+  *connect-termination* and *refused-stream*)
 
   * **NOTE:** Envoy will not retry when a request exceeds
     :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms` (resulting in a 504 error
@@ -80,6 +81,10 @@ connect-failure
     include upstream request timeouts specified via
     :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms` or via :ref:`route
     configuration <envoy_api_field_route.RouteAction.retry_policy>`.
+
+connect-termination
+  Envoy will attempt a retry if a request is failed because the connection was terminated by the
+  upstream server. (Included in *5xx*)
 
 retriable-4xx
   Envoy will attempt a retry if the upstream server responds with a retriable 4xx response code.

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -145,14 +145,15 @@ public:
   static const uint32_t RETRY_ON_5XX                     = 0x1;
   static const uint32_t RETRY_ON_GATEWAY_ERROR           = 0x2;
   static const uint32_t RETRY_ON_CONNECT_FAILURE         = 0x4;
-  static const uint32_t RETRY_ON_RETRIABLE_4XX           = 0x8;
-  static const uint32_t RETRY_ON_REFUSED_STREAM          = 0x10;
-  static const uint32_t RETRY_ON_GRPC_CANCELLED          = 0x20;
-  static const uint32_t RETRY_ON_GRPC_DEADLINE_EXCEEDED  = 0x40;
-  static const uint32_t RETRY_ON_GRPC_RESOURCE_EXHAUSTED = 0x80;
-  static const uint32_t RETRY_ON_GRPC_UNAVAILABLE        = 0x100;
-  static const uint32_t RETRY_ON_GRPC_INTERNAL           = 0x200;
-  static const uint32_t RETRY_ON_RETRIABLE_STATUS_CODES  = 0x400;
+  static const uint32_t RETRY_ON_CONNECT_TERMINATION     = 0x8;
+  static const uint32_t RETRY_ON_RETRIABLE_4XX           = 0x10;
+  static const uint32_t RETRY_ON_REFUSED_STREAM          = 0x20;
+  static const uint32_t RETRY_ON_GRPC_CANCELLED          = 0x40;
+  static const uint32_t RETRY_ON_GRPC_DEADLINE_EXCEEDED  = 0x80;
+  static const uint32_t RETRY_ON_GRPC_RESOURCE_EXHAUSTED = 0x100;
+  static const uint32_t RETRY_ON_GRPC_UNAVAILABLE        = 0x200;
+  static const uint32_t RETRY_ON_GRPC_INTERNAL           = 0x400;
+  static const uint32_t RETRY_ON_RETRIABLE_STATUS_CODES  = 0x800;
   // clang-format on
 
   virtual ~RetryPolicy() {}

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -145,6 +145,7 @@ public:
     const std::string _5xx{"5xx"};
     const std::string GatewayError{"gateway-error"};
     const std::string ConnectFailure{"connect-failure"};
+    const std::string ConnectTermination{"connect-termination"};
     const std::string RefusedStream{"refused-stream"};
     const std::string Retriable4xx{"retriable-4xx"};
     const std::string RetriableStatusCodes{"retriable-status-codes"};

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -109,6 +109,8 @@ uint32_t RetryStateImpl::parseRetryOn(absl::string_view config) {
       ret |= RetryPolicy::RETRY_ON_GATEWAY_ERROR;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.ConnectFailure) {
       ret |= RetryPolicy::RETRY_ON_CONNECT_FAILURE;
+    } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.ConnectTermination) {
+      ret |= RetryPolicy::RETRY_ON_CONNECT_TERMINATION;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.Retriable4xx) {
       ret |= RetryPolicy::RETRY_ON_RETRIABLE_4XX;
     } else if (retry_on == Http::Headers::get().EnvoyRetryOnValues.RefusedStream) {
@@ -245,6 +247,11 @@ bool RetryStateImpl::wouldRetryFromReset(const Http::StreamResetReason& reset_re
 
   if ((retry_on_ & RetryPolicy::RETRY_ON_CONNECT_FAILURE) &&
       reset_reason == Http::StreamResetReason::ConnectionFailure) {
+    return true;
+  }
+
+  if ((retry_on_ & RetryPolicy::RETRY_ON_CONNECT_TERMINATION) &&
+      reset_reason == Http::StreamResetReason::ConnectionTermination) {
     return true;
   }
 


### PR DESCRIPTION
*Description*:

Adding the ability to configure retry for connection termination. While testing the case of outbound cluster endpoint churn, I was seeing 503s due to connection termination. The retry logic doesn't currently support this case (only connection-failure is supported).

*Risk Level*:
Low

*Testing*:

Added unit tests to verify that connect-termination works properly in retryOn.

*Docs Changes*:
Updated the route_filter docs to include the new retryOn parameter.

*Release Notes*:
N/A
