### PR TITLE
main: remove log messages when exceptions are thrown

### DIFF
--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -142,7 +142,6 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   auto check_numeric_arg = [](bool is_error, uint64_t value, absl::string_view pattern) {
     if (is_error) {
       const std::string message = fmt::format(std::string(pattern), value);
-      std::cerr << message << std::endl;
       throw MalformedArgvException(message);
     }
   };
@@ -177,7 +176,6 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
     mode_ = Server::Mode::InitOnly;
   } else {
     const std::string message = fmt::format("error: unknown mode '{}'", mode.getValue());
-    std::cerr << message << std::endl;
     throw MalformedArgvException(message);
   }
 
@@ -188,7 +186,6 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   } else {
     const std::string message =
         fmt::format("error: unknown IP address version '{}'", local_address_ip_version.getValue());
-    std::cerr << message << std::endl;
     throw MalformedArgvException(message);
   }
 
@@ -254,10 +251,7 @@ void OptionsImpl::parseComponentLogLevels(const std::string& component_log_level
 
 uint32_t OptionsImpl::count() const { return count_; }
 
-void OptionsImpl::logError(const std::string& error) const {
-  std::cerr << error << std::endl;
-  throw MalformedArgvException(error);
-}
+void OptionsImpl::logError(const std::string& error) const { throw MalformedArgvException(error); }
 
 Server::CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
   Server::CommandLineOptionsPtr command_line_options =

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -179,7 +179,6 @@ InstanceUtil::loadBootstrapConfig(envoy::config::bootstrap::v2::Bootstrap& boots
   if (config_path.empty() && config_yaml.empty()) {
     const std::string message =
         "At least one of --config-path and --config-yaml should be non-empty";
-    std::cerr << message << std::endl;
     throw EnvoyException(message);
   }
   try {


### PR DESCRIPTION
Fixes #5453
Signed-off-by: Rishabh Kumar kris.kr296@gmail.com

*Description*: removes `std::cerr` log messages when exceptions are thrown.
*Risk Level*: low
*Testing*: manual
*Docs Changes*: N/A
*Release Notes*: N/A
