### PR TITLE
test: use envoy_extension_cc_test instead of envoy_cc_test for gzip HTTP filter

### DIFF
--- a/test/extensions/filters/http/gzip/BUILD
+++ b/test/extensions/filters/http/gzip/BUILD
@@ -2,15 +2,19 @@ licenses(["notice"])  # Apache 2
 
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_test",
     "envoy_package",
+)
+load(
+    "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_cc_test",
 )
 
 envoy_package()
 
-envoy_cc_test(
+envoy_extension_cc_test(
     name = "gzip_filter_test",
     srcs = ["gzip_filter_test.cc"],
+    extension_name = "envoy.filters.http.gzip",
     deps = [
         "//source/common/compressor:compressor_lib",
         "//source/common/decompressor:decompressor_lib",
@@ -22,11 +26,12 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_extension_cc_test(
     name = "gzip_filter_integration_test",
     srcs = [
         "gzip_filter_integration_test.cc",
     ],
+    extension_name = "envoy.filters.http.gzip",
     deps = [
         "//source/common/decompressor:decompressor_lib",
         "//source/extensions/filters/http/gzip:config",


### PR DESCRIPTION
*Description*:

This patch alters the use of `envoy_cc_test` with `envoy_extension_cc_test`
for the gzip HTTP filter.

*Risk Level*: Low
*Testing*: Existing tests
*Docs Changes*: N/A
*Release Notes*: N/A

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>