### PR TITLE
test: more robust test for dynamically linked lib(std)c++.

### DIFF
--- a/test/exe/envoy_static_test.sh
+++ b/test/exe/envoy_static_test.sh
@@ -1,8 +1,25 @@
 #!/bin/bash
-#
 
-set -e
+if [[ `uname` == "Darwin" ]]; then
+  echo "macOS doesn't support statically linked binaries, skipping."
+  exit 0
+fi
 
-# Validate we statically link libstdc++ and libgcc.
-DYNDEPS=$(ldd source/exe/envoy-static | grep "libstdc++\|libgcc"; echo)
-[[ -z "$DYNDEPS" ]] || (echo "libstdc++ or libgcc dynamically linked: ${DYNDEPS}"; exit 1)
+# We can't rely on the exit code alone, since lld fails for statically linked binaries.
+DYNLIBS=$(ldd source/exe/envoy-static 2>&1)
+if [[ $? != 0 && ! ${DYNLIBS} =~ "not a dynamic executable" ]]; then
+  echo "${DYNLIBS}"
+  exit 1
+fi
+
+if [[ ${DYNLIBS} =~ "libc++" ]]; then
+  echo "libc++ is dynamically linked:"
+  echo "${DYNLIBS}"
+  exit 1
+fi
+
+if [[ ${DYNLIBS} =~ "libstdc++" || ${DYNLIBS} =~ "libgcc" ]]; then
+  echo "libstdc++ and/or libgcc are dynamically linked:"
+  echo "${DYNLIBS}"
+  exit 1
+fi

--- a/test/exe/envoy_static_test.sh
+++ b/test/exe/envoy_static_test.sh
@@ -7,7 +7,7 @@ fi
 
 # We can't rely on the exit code alone, since lld fails for statically linked binaries.
 DYNLIBS=$(ldd source/exe/envoy-static 2>&1)
-if [[ $? != 0 && ! ${DYNLIBS} =~ "not a dynamic executable" ]]; then
+if [[ $? != 0 && ! "${DYNLIBS}" =~ "not a dynamic executable" ]]; then
   echo "${DYNLIBS}"
   exit 1
 fi


### PR DESCRIPTION
Notably, this test was previously passing on macOS only because
there is no "libstdc++" or "libgcc" in "ldd: command not found".

Signed-off-by: Piotr Sikora <piotrsikora@google.com>