### PR TITLE
test: use "threadsafe" style for the Death Tests.

### DIFF
--- a/test/common/common/assert_test.cc
+++ b/test/common/common/assert_test.cc
@@ -4,7 +4,7 @@
 
 namespace Envoy {
 
-TEST(ReleaseAssert, VariousLogs) {
+TEST(ReleaseAssertDeathTest, VariousLogs) {
   Logger::StderrSinkDelegate stderr_sink(Logger::Registry::getSink()); // For coverage build.
   EXPECT_DEATH({ RELEASE_ASSERT(0, ""); }, ".*assert failure: 0.*");
   EXPECT_DEATH({ RELEASE_ASSERT(0, "With some logs"); },
@@ -13,7 +13,7 @@ TEST(ReleaseAssert, VariousLogs) {
                ".*assert failure: 0 == EAGAIN. Details: using fmt.*");
 }
 
-TEST(Assert, VariousLogs) {
+TEST(AssertDeathTest, VariousLogs) {
 #ifndef NDEBUG
   EXPECT_DEATH({ ASSERT(0); }, ".*assert failure: 0.*");
   EXPECT_DEATH({ ASSERT(0, ""); }, ".*assert failure: 0.*");

--- a/test/common/common/block_memory_hash_set_test.cc
+++ b/test/common/common/block_memory_hash_set_test.cc
@@ -204,7 +204,9 @@ TEST_F(BlockMemoryHashSetTest, severalKeysZeroHash) {
   hash_set1.sanityCheck();
 }
 
-TEST_F(BlockMemoryHashSetTest, sanityCheckZeroedMemoryDeathTest) {
+class BlockMemoryHashSetDeathTest : public BlockMemoryHashSetTest {};
+
+TEST_F(BlockMemoryHashSetDeathTest, sanityCheckZeroedMemoryDeathTest) {
   setUp<TestValueZeroHash>();
   BlockMemoryHashSet<TestValueZeroHash> hash_set1(hash_set_options_, true, memory_.get(),
                                                   stats_options_);

--- a/test/common/compressor/zlib_compressor_impl_test.cc
+++ b/test/common/compressor/zlib_compressor_impl_test.cc
@@ -106,7 +106,7 @@ protected:
 
 // Exercises death by passing bad initialization params or by calling
 // compress before init.
-TEST_F(ZlibCompressorImplDeathTest, CompressorTestDeath) {
+TEST_F(ZlibCompressorImplDeathTest, CompressorDeathTest) {
   EXPECT_DEATH_LOG_TO_STDERR(compressorBadInitTestHelper(100, 8), "assert failure: result >= 0");
   EXPECT_DEATH_LOG_TO_STDERR(compressorBadInitTestHelper(31, 10), "assert failure: result >= 0");
   EXPECT_DEATH_LOG_TO_STDERR(uninitializedCompressorTestHelper(), "assert failure: result == Z_OK");

--- a/test/common/decompressor/zlib_decompressor_impl_test.cc
+++ b/test/common/decompressor/zlib_decompressor_impl_test.cc
@@ -74,7 +74,7 @@ protected:
 };
 
 // Exercises death by passing bad initialization params or by calling decompress before init.
-TEST_F(ZlibDecompressorImplDeathTest, DecompressorTestDeath) {
+TEST_F(ZlibDecompressorImplDeathTest, DecompressorDeathTest) {
   EXPECT_DEATH_LOG_TO_STDERR(decompressorBadInitTestHelper(100), "assert failure: result >= 0");
   EXPECT_DEATH_LOG_TO_STDERR(unitializedDecompressorTestHelper(), "assert failure: result == Z_OK");
 }

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -705,7 +705,7 @@ TEST(HeaderMapImplTest, TestAppendHeader) {
   }
 }
 
-TEST(HeaderMapImplTest, TestHeaderLengthChecks) {
+TEST(HeaderMapImplDeathTest, TestHeaderLengthChecks) {
   HeaderString value;
   value.setCopy("some;", 5);
   EXPECT_DEATH_LOG_TO_STDERR(value.append(nullptr, std::numeric_limits<uint32_t>::max()),

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -348,7 +348,9 @@ TEST_F(Http1ServerConnectionImplTest, HeaderOnlyResponse) {
   EXPECT_EQ("HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n", output);
 }
 
-TEST_F(Http1ServerConnectionImplTest, MetadataTest) {
+class Http1ServerConnectionImplDeathTest : public Http1ServerConnectionImplTest {};
+
+TEST_F(Http1ServerConnectionImplDeathTest, MetadataTest) {
   initialize();
 
   NiceMock<Http::MockStreamDecoder> decoder;

--- a/test/common/json/config_schemas_test_data/generate_test_data.py
+++ b/test/common/json/config_schemas_test_data/generate_test_data.py
@@ -2,12 +2,16 @@
 
 import glob
 import os
-
+import shutil
 import util
 
 
 def main():
   test_dir = os.path.join(os.environ['TEST_TMPDIR'], 'config_schemas_test')
+  # Clean after previous run. This might happen e.g. with "threadsafe" Death Tests,
+  # where child process re-executes the unit test binary in the same workspace.
+  if os.path.isdir(test_dir):
+    shutil.rmtree(test_dir)
   os.mkdir(test_dir)
   writer = util.TestWriter(test_dir)
 

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -324,7 +324,7 @@ TEST(PipeInstanceTest, UnlinksExistingFile) {
   bind_uds_socket(path); // after closing, second bind to the same path should succeed.
 }
 
-TEST(AddressFromSockAddr, IPv4) {
+TEST(AddressFromSockAddrDeathTest, IPv4) {
   sockaddr_storage ss;
   auto& sin = reinterpret_cast<sockaddr_in&>(ss);
 
@@ -343,7 +343,7 @@ TEST(AddressFromSockAddr, IPv4) {
   EXPECT_THROW(addressFromSockAddr(ss, sizeof(sockaddr_in)), EnvoyException);
 }
 
-TEST(AddressFromSockAddr, IPv6) {
+TEST(AddressFromSockAddrDeathTest, IPv6) {
   sockaddr_storage ss;
   auto& sin6 = reinterpret_cast<sockaddr_in6&>(ss);
 
@@ -367,7 +367,7 @@ TEST(AddressFromSockAddr, IPv6) {
             addressFromSockAddr(ss, sizeof(sockaddr_in6), true)->asString());
 }
 
-TEST(AddressFromSockAddr, Pipe) {
+TEST(AddressFromSockAddrDeathTest, Pipe) {
   sockaddr_storage ss;
   auto& sun = reinterpret_cast<sockaddr_un&>(ss);
   sun.sun_family = AF_UNIX;

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -87,7 +87,9 @@ TEST_F(StatNameTest, TestSuccessfulDecode) {
   EXPECT_EQ(stat_name_1.toString(table_), stat_name);
 }
 
-TEST_F(StatNameTest, TestBadDecodes) {
+class StatNameDeathTest : public StatNameTest {};
+
+TEST_F(StatNameDeathTest, TestBadDecodes) {
   {
     // If a symbol doesn't exist, decoding it should trigger an ASSERT() and crash.
     SymbolVec bad_symbol_vec = {1}; // symbol 0 is the empty symbol.

--- a/test/exe/signals_test.cc
+++ b/test/exe/signals_test.cc
@@ -23,7 +23,7 @@ namespace Envoy {
 // not ours instead of what this test expects. As of latest Clang this appears
 // to include abort() as well.
 #ifndef ASANITIZED
-TEST(Signals, InvalidAddressDeathTest) {
+TEST(SignalsDeathTest, InvalidAddressDeathTest) {
   SignalAction actions;
   EXPECT_DEATH_LOG_TO_STDERR(
       []() -> void {
@@ -34,7 +34,7 @@ TEST(Signals, InvalidAddressDeathTest) {
       "backtrace.*Segmentation fault");
 }
 
-TEST(Signals, BusDeathTest) {
+TEST(SignalsDeathTest, BusDeathTest) {
   SignalAction actions;
   EXPECT_DEATH_LOG_TO_STDERR(
       []() -> void {
@@ -50,7 +50,7 @@ TEST(Signals, BusDeathTest) {
       "backtrace.*Bus");
 }
 
-TEST(Signals, BadMathDeathTest) {
+TEST(SignalsDeathTest, BadMathDeathTest) {
   SignalAction actions;
   EXPECT_DEATH_LOG_TO_STDERR(
       []() -> void {
@@ -63,7 +63,7 @@ TEST(Signals, BadMathDeathTest) {
 
 #if defined(__x86_64__) || defined(__i386__)
 // Unfortunately we don't have a reliable way to do this on other platforms
-TEST(Signals, IllegalInstructionDeathTest) {
+TEST(SignalsDeathTest, IllegalInstructionDeathTest) {
   SignalAction actions;
   EXPECT_DEATH_LOG_TO_STDERR(
       []() -> void {
@@ -74,12 +74,12 @@ TEST(Signals, IllegalInstructionDeathTest) {
 }
 #endif
 
-TEST(Signals, AbortDeathTest) {
+TEST(SignalsDeathTest, AbortDeathTest) {
   SignalAction actions;
   EXPECT_DEATH_LOG_TO_STDERR([]() -> void { abort(); }(), "backtrace.*Abort(ed)?");
 }
 
-TEST(Signals, RestoredPreviousHandlerDeathTest) {
+TEST(SignalsDeathTest, RestoredPreviousHandlerDeathTest) {
   SignalAction action;
   {
     SignalAction inner_action;
@@ -92,7 +92,7 @@ TEST(Signals, RestoredPreviousHandlerDeathTest) {
 }
 #endif
 
-TEST(Signals, IllegalStackAccessDeathTest) {
+TEST(SignalsDeathTest, IllegalStackAccessDeathTest) {
   SignalAction actions;
   EXPECT_DEATH(actions.tryEvilAccessForTest(false), "");
   EXPECT_DEATH(actions.tryEvilAccessForTest(true), "");

--- a/test/exe/terminate_handler_test.cc
+++ b/test/exe/terminate_handler_test.cc
@@ -6,7 +6,7 @@
 
 namespace Envoy {
 
-TEST(TerminateHandler, HandlerInstalledTest) {
+TEST(TerminateHandlerDeathTest, HandlerInstalledTest) {
   TerminateHandler handler;
   EXPECT_DEATH_LOG_TO_STDERR([]() -> void { std::terminate(); }(), ".*std::terminate called!.*");
 }

--- a/test/test_runner.h
+++ b/test/test_runner.h
@@ -19,6 +19,10 @@ public:
     ::testing::InitGoogleMock(&argc, argv);
     Event::Libevent::Global::initialize();
 
+    // Use the recommended, but not default, "threadsafe" style for the Death Tests.
+    // See: https://github.com/google/googletest/commit/84ec2e0365d791e4ebc7ec249f09078fb5ab6caa
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
     // Set gtest properties
     // (https://github.com/google/googletest/blob/master/googletest/docs/AdvancedGuide.md#logging-additional-information),
     // they are available in the test XML.


### PR DESCRIPTION
This is recommended, but not default, style for the Death Tests:
https://github.com/google/googletest/commit/84ec2e0365d791e4ebc7ec249f09078fb5ab6caa

While there, make sure that Death Tests follow the naming convention:
https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#death-test-naming

Signed-off-by: Piotr Sikora <piotrsikora@google.com>