### PR TITLE
format: add format fix for java proto options

### DIFF
--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -48,6 +48,7 @@ HEADER_ORDER_PATH = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), 
 SUBDIR_SET = set(common.includeDirOrder())
 INCLUDE_ANGLE = "#include <"
 INCLUDE_ANGLE_LEN = len(INCLUDE_ANGLE)
+PROTO_PACKAGE_REGEX = re.compile("package (.*);")
 
 # yapf: disable
 PROTOBUF_TYPE_ERRORS = {
@@ -149,7 +150,7 @@ def fixJavaProtoOptions(file_path):
   package_name = None
   for line in fileinput.FileInput(file_path):
     if line.startswith("package "):
-      package_name = re.compile("package (.*);").search(line).group(1)
+      package_name = PROTO_PACKAGE_REGEX.search(line).group(1)
     if "option java_multiple_files = true;" in line:
       java_multiple_files = True
     if "option java_package = \"io.envoyproxy.envoy" in line:

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -142,6 +142,7 @@ def checkNamespace(file_path):
       return ["Unable to find Envoy namespace or NOLINT(namespace-envoy) for file: %s" % file_path]
   return []
 
+
 def fixJavaProtoOptions(file_path):
   java_multiple_files = False
   java_package_correct = False
@@ -154,18 +155,19 @@ def fixJavaProtoOptions(file_path):
     if "option java_package = \"io.envoyproxy.envoy" in line:
       java_package_correct = True
     if java_multiple_files and java_package_correct:
-     return
+      return
 
   to_add = ""
   if not java_package_correct:
-      to_add = to_add + "option java_package = \"io.envoyproxy.{}\";\n".format(package_name)
+    to_add = to_add + "option java_package = \"io.envoyproxy.{}\";\n".format(package_name)
   if not java_multiple_files:
-     to_add = to_add + "option java_multiple_files = true;\n"
+    to_add = to_add + "option java_multiple_files = true;\n"
 
   for line in fileinput.FileInput(file_path, inplace=True):
     if line.startswith("package "):
       line = line.replace(line, line + to_add)
     sys.stdout.write(line)
+
 
 def checkJavaProtoOptions(file_path):
   java_multiple_files = False

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -142,6 +142,30 @@ def checkNamespace(file_path):
       return ["Unable to find Envoy namespace or NOLINT(namespace-envoy) for file: %s" % file_path]
   return []
 
+def fixJavaProtoOptions(file_path):
+  java_multiple_files = False
+  java_package_correct = False
+  package_name = None
+  for line in fileinput.FileInput(file_path):
+    if line.startswith("package "):
+      package_name = re.compile("package (.*);").search(line).group(1)
+    if "option java_multiple_files = true;" in line:
+      java_multiple_files = True
+    if "option java_package = \"io.envoyproxy.envoy" in line:
+      java_package_correct = True
+    if java_multiple_files and java_package_correct:
+     return
+
+  to_add = ""
+  if not java_package_correct:
+      to_add = to_add + "option java_package = \"io.envoyproxy.{}\";\n".format(package_name)
+  if not java_multiple_files:
+     to_add = to_add + "option java_multiple_files = true;\n"
+
+  for line in fileinput.FileInput(file_path, inplace=True):
+    if line.startswith("package "):
+      line = line.replace(line, line + to_add)
+    sys.stdout.write(line)
 
 def checkJavaProtoOptions(file_path):
   java_multiple_files = False
@@ -383,6 +407,8 @@ def fixSourcePath(file_path):
     if not file_path.endswith(PROTO_SUFFIX):
       error_messages += fixHeaderOrder(file_path)
     error_messages += clangFormat(file_path)
+  if file_path.endswith(PROTO_SUFFIX) and isApiFile(file_path):
+    fixJavaProtoOptions(file_path)
   return error_messages
 
 

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -154,7 +154,7 @@ def fixJavaProtoOptions(file_path):
       if result is None or len(result.groups()) != 1:
         continue
 
-      package_name = PROTO_PACKAGE_REGEX.search(line).group(1)
+      package_name = result.group(1)
     if "option java_multiple_files = true;" in line:
       java_multiple_files = True
     if "option java_package = \"io.envoyproxy.envoy" in line:

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -49,6 +49,9 @@ def runCheckFormat(operation, filename):
 
 def getInputFile(filename):
   infile = os.path.join(src, filename)
+  directory = os.path.dirname(filename)
+  if not directory == '' and not os.path.isdir(directory):
+    os.makedirs(directory)
   shutil.copyfile(infile, filename)
   return filename
 
@@ -58,6 +61,10 @@ def getInputFile(filename):
 # code.
 def fixFileHelper(filename):
   infile = os.path.join(src, filename)
+  directory = os.path.dirname(filename)
+  if not directory == '' and not os.path.isdir(directory):
+    os.makedirs(directory)
+
   shutil.copyfile(infile, filename)
   command, status, stdout = runCheckFormat("fix", getInputFile(filename))
   return (command, infile, filename, status, stdout)
@@ -207,6 +214,7 @@ if __name__ == "__main__":
   errors += checkAndFixError("license.BUILD", "envoy_build_fixer check failed")
   errors += checkAndFixError("bad_envoy_build_sys_ref.BUILD", "Superfluous '@envoy//' prefix")
   errors += checkAndFixError("proto_format.proto", "clang-format check failed")
+  errors += checkAndFixError("api/java_options.proto", "Java proto option")
 
   errors += checkFileExpectingOK("real_time_source_override.cc")
   errors += checkFileExpectingOK("time_system_wait_for.cc")

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -62,8 +62,6 @@ def getInputFile(filename):
 def fixFileHelper(filename):
   infile = os.path.join(src, filename)
   directory = os.path.dirname(filename)
-  if not directory == '' and not os.path.isdir(directory):
-    os.makedirs(directory)
 
   shutil.copyfile(infile, filename)
   command, status, stdout = runCheckFormat("fix", getInputFile(filename))

--- a/tools/check_format_test_helper.py
+++ b/tools/check_format_test_helper.py
@@ -62,6 +62,8 @@ def getInputFile(filename):
 def fixFileHelper(filename):
   infile = os.path.join(src, filename)
   directory = os.path.dirname(filename)
+  if not directory == '' and not os.path.isdir(directory):
+    os.makedirs(directory)
 
   shutil.copyfile(infile, filename)
   command, status, stdout = runCheckFormat("fix", getInputFile(filename))
@@ -198,6 +200,10 @@ if __name__ == "__main__":
   errors += checkUnfixableError("elvis_operator.cc", "Don't use the '?:' operator")
   errors += checkUnfixableError("testing_test.cc",
                                 "Don't use 'using testing::Test;, elaborate the type instead")
+
+  errors += fixFileExpectingFailure(
+      "api/missing_package.proto",
+      "Unable to find package name for proto file: ./api/missing_package.proto")
 
   # The following files have errors that can be automatically fixed.
   errors += checkAndFixError("over_enthusiastic_spaces.cc",

--- a/tools/testdata/check_format/api/java_options.proto
+++ b/tools/testdata/check_format/api/java_options.proto
@@ -1,0 +1,1 @@
+package envoy.foo;

--- a/tools/testdata/check_format/api/java_options.proto.gold
+++ b/tools/testdata/check_format/api/java_options.proto.gold
@@ -1,0 +1,3 @@
+package envoy.foo;
+option java_package = "io.envoyproxy.envoy.foo";
+option java_multiple_files = true;


### PR DESCRIPTION
Allows running tools/check_format.py fix to insert the necessary java
proto options.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

*Risk Level*: Low
*Testing*: Added check_format_test
*Docs Changes*: n/a
*Release Notes*: n/a
Fixes #5477