### PR TITLE
Revert "main: remove log messages when exceptions are caught (#5503)"

### DIFF
--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -142,6 +142,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   auto check_numeric_arg = [](bool is_error, uint64_t value, absl::string_view pattern) {
     if (is_error) {
       const std::string message = fmt::format(std::string(pattern), value);
+      std::cerr << message << std::endl;
       throw MalformedArgvException(message);
     }
   };
@@ -176,6 +177,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
     mode_ = Server::Mode::InitOnly;
   } else {
     const std::string message = fmt::format("error: unknown mode '{}'", mode.getValue());
+    std::cerr << message << std::endl;
     throw MalformedArgvException(message);
   }
 
@@ -186,6 +188,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
   } else {
     const std::string message =
         fmt::format("error: unknown IP address version '{}'", local_address_ip_version.getValue());
+    std::cerr << message << std::endl;
     throw MalformedArgvException(message);
   }
 
@@ -251,7 +254,10 @@ void OptionsImpl::parseComponentLogLevels(const std::string& component_log_level
 
 uint32_t OptionsImpl::count() const { return count_; }
 
-void OptionsImpl::logError(const std::string& error) const { throw MalformedArgvException(error); }
+void OptionsImpl::logError(const std::string& error) const {
+  std::cerr << error << std::endl;
+  throw MalformedArgvException(error);
+}
 
 Server::CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
   Server::CommandLineOptionsPtr command_line_options =

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -179,6 +179,7 @@ InstanceUtil::loadBootstrapConfig(envoy::config::bootstrap::v2::Bootstrap& boots
   if (config_path.empty() && config_yaml.empty()) {
     const std::string message =
         "At least one of --config-path and --config-yaml should be non-empty";
+    std::cerr << message << std::endl;
     throw EnvoyException(message);
   }
   try {


### PR DESCRIPTION
This reverts commit 297ece90953854ee9f364cc06acdbaf6a11c7ec6.

Signed-off-by: Joshua Marantz <jmarantz@google.com>


*Description*: @rishabhkumar296 sorry I should've caught this on first review, but I thought we were already echoing error messages where we caught them, and in general I think we not. For each 'throw' you have, can you make sure we are echoing the errors when we catch, and add a test for those? Thanks!
*Risk Level*: low
*Testing*: none
*Docs Changes*: n/a
*Release Notes*: n/a

