### PR TITLE
[test] add socketType to TestListenSocket

### DIFF
--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -128,20 +128,19 @@ TEST_P(ListenSocketImplTestTcp, BindSpecificPort) { testBindSpecificPort(); }
  */
 class TestListenSocket : public ListenSocketImpl {
 public:
-  TestListenSocket(Network::Address::InstanceConstSharedPtr address)
-      : ListenSocketImpl(-1, address) {}
+  TestListenSocket(Address::InstanceConstSharedPtr address) : ListenSocketImpl(-1, address) {}
+  Address::SocketType socketType() const override { return Address::SocketType::Stream; }
 };
 
 TEST_P(ListenSocketImplTestTcp, SetLocalAddress) {
   std::string address_str = "10.1.2.3";
-  if (version_ == Network::Address::IpVersion::v6) {
+  if (version_ == Address::IpVersion::v6) {
     address_str = "1::2";
   }
 
-  Network::Address::InstanceConstSharedPtr address =
-      Network::Utility::parseInternetAddress(address_str);
+  Address::InstanceConstSharedPtr address = Network::Utility::parseInternetAddress(address_str);
 
-  TestListenSocket socket(Network::Utility::getIpv4AnyAddress());
+  TestListenSocket socket(Utility::getIpv4AnyAddress());
 
   socket.setLocalAddress(address);
 


### PR DESCRIPTION
*Description*:
This fixes the broken test build introduced by https://github.com/envoyproxy/envoy/commit/6b005ea5fa5f0ecd071d63ba20ee378e953fa2cf, which
lost the merge race -- a new pure virtual method was added, which we
needed to implement in the TestListenSocket This commit does so.

Also changed up a few namespace scopes to be less verbose.

*Risk Level*: Low
*Testing*: Ran UT

