### PR TITLE
Fix clang-format check on redis codec_impl

### DIFF
--- a/source/extensions/filters/network/redis_proxy/codec_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/codec_impl.cc
@@ -170,7 +170,9 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
         pending_value_stack_.front().value_->type(RespType::Integer);
         break;
       }
-      default: { throw ProtocolError("invalid value type"); }
+      default: {
+        throw ProtocolError("invalid value type");
+      }
       }
 
       remaining--;


### PR DESCRIPTION
This fixes a minor clang-format failure that continually popped up while running `./tools/check_format fix` on other PRs

Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*: 
- Fixes a minor clang-format issue in the redis_proxy/codec_impl.cc

*Risk Level*: Low
*Testing*: `bazel test //test/extensions/filters/network/redis_proxy:codec_impl_test`
*Docs Changes*: N/A
*Release Notes*: N/A
