### PR TITLE
tracing: inject context after decoding headers

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -690,6 +690,11 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(HeaderMapPtr&& headers, 
 
   decodeHeaders(nullptr, *request_headers_, end_stream);
 
+  if (active_span_) {
+    // Inject the active span's tracing context into the request headers.
+    active_span_->injectContext(*request_headers_);
+  }
+
   // Reset it here for both global and overridden cases.
   resetIdleTimer();
 }
@@ -744,9 +749,6 @@ void ConnectionManagerImpl::ActiveStream::traceRequest() {
       request_headers_->removeEnvoyDecoratorOperation();
     }
   }
-
-  // Inject the active span's tracing context into the request headers.
-  active_span_->injectContext(*request_headers_);
 }
 
 void ConnectionManagerImpl::ActiveStream::decodeHeaders(ActiveStreamDecoderFilter* filter,


### PR DESCRIPTION
Signed-off-by: Caleb Gilmour <cgilmour@gmail.com>

*Description*: A simple fix for #5504 by making the header injection occur after the healthcheck filter extension has examined the request.

*Risk Level*: Low
*Testing*: Unit tests, E2E for datadog and zipkin tracers.

*Docs Changes*: N/A
*Release Notes*: N/A

Fixes #5504 