### PR TITLE
upstream: degraded stats and hc event logs

### DIFF
--- a/api/envoy/data/core/v2alpha/health_check_event.proto
+++ b/api/envoy/data/core/v2alpha/health_check_event.proto
@@ -30,6 +30,12 @@ message HealthCheckEvent {
 
     // Host failure.
     HealthCheckFailure health_check_failure_event = 7;
+
+    // Healthy host became degraded.
+    DegradedHealthyHost degraded_healthy_host = 8;
+
+    // A degraded host returned to being healthy.
+    NotDegradedHealthyHost not_degraded_healthy_host = 9;
   }
 
   // Timestamp for event.
@@ -66,4 +72,10 @@ message HealthCheckFailure {
   HealthCheckFailureType failure_type = 1 [(validate.rules).enum.defined_only = true];
   // Whether this event is the result of the first ever health check on a host.
   bool first_check = 2;
+}
+
+message DegradedHealthyHost {
+}
+
+message NotDegradedHealthyHost {
 }

--- a/api/envoy/data/core/v2alpha/health_check_event.proto
+++ b/api/envoy/data/core/v2alpha/health_check_event.proto
@@ -35,7 +35,7 @@ message HealthCheckEvent {
     DegradedHealthyHost degraded_healthy_host = 8;
 
     // A degraded host returned to being healthy.
-    NotDegradedHealthyHost not_degraded_healthy_host = 9;
+    NoLongerDegradedHost no_longer_degraded_host = 9;
   }
 
   // Timestamp for event.
@@ -77,5 +77,5 @@ message HealthCheckFailure {
 message DegradedHealthyHost {
 }
 
-message NotDegradedHealthyHost {
+message NoLongerDegradedHost {
 }

--- a/docs/root/configuration/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/cluster_manager/cluster_stats.rst
@@ -78,6 +78,7 @@ Every cluster has a statistics tree rooted at *cluster.<name>.* with the followi
   upstream_flow_control_drained_total, Counter, Total number of times the upstream connection drained and resumed reads from downstream
   membership_change, Counter, Total cluster membership changes
   membership_healthy, Gauge, Current cluster healthy total (inclusive of both health checking and outlier detection)
+  membership_healthy, Gauge, Current cluster degraded total
   membership_total, Gauge, Current cluster membership total
   retry_or_shadow_abandoned, Counter, Total number of times shadowing or retry buffering was canceled due to buffer limits
   config_reload, Counter, Total API fetches that resulted in a config reload due to a different config

--- a/docs/root/configuration/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/cluster_manager/cluster_stats.rst
@@ -78,7 +78,7 @@ Every cluster has a statistics tree rooted at *cluster.<name>.* with the followi
   upstream_flow_control_drained_total, Counter, Total number of times the upstream connection drained and resumed reads from downstream
   membership_change, Counter, Total cluster membership changes
   membership_healthy, Gauge, Current cluster healthy total (inclusive of both health checking and outlier detection)
-  membership_healthy, Gauge, Current cluster degraded total
+  membership_degraded, Gauge, Current cluster degraded total
   membership_total, Gauge, Current cluster membership total
   retry_or_shadow_abandoned, Counter, Total number of times shadowing or retry buffering was canceled due to buffer limits
   config_reload, Counter, Total API fetches that resulted in a config reload due to a different config

--- a/include/envoy/upstream/health_checker.h
+++ b/include/envoy/upstream/health_checker.h
@@ -106,15 +106,14 @@ public:
    * @param host supplies the host that generated the event.
    */
   virtual void logDegraded(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
-                             const HostDescriptionConstSharedPtr& host) PURE;
+                           const HostDescriptionConstSharedPtr& host) PURE;
   /**
    * Log a no degraded healthy host event.
    * @param health_checker_type supplies the type of health checker that generated the event.
    * @param host supplies the host that generated the event.
    */
-  virtual void logNoMoreDegraded(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
-                             const HostDescriptionConstSharedPtr& host) PURE;
-
+  virtual void logNoLongerDegraded(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
+                                 const HostDescriptionConstSharedPtr& host) PURE;
 };
 
 typedef std::unique_ptr<HealthCheckEventLogger> HealthCheckEventLoggerPtr;

--- a/include/envoy/upstream/health_checker.h
+++ b/include/envoy/upstream/health_checker.h
@@ -99,6 +99,22 @@ public:
    */
   virtual void logAddHealthy(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
                              const HostDescriptionConstSharedPtr& host, bool first_check) PURE;
+
+  /**
+   * Log a degraded healthy host event.
+   * @param health_checker_type supplies the type of health checker that generated the event.
+   * @param host supplies the host that generated the event.
+   */
+  virtual void logDegraded(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
+                             const HostDescriptionConstSharedPtr& host) PURE;
+  /**
+   * Log a no degraded healthy host event.
+   * @param health_checker_type supplies the type of health checker that generated the event.
+   * @param host supplies the host that generated the event.
+   */
+  virtual void logNoMoreDegraded(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
+                             const HostDescriptionConstSharedPtr& host) PURE;
+
 };
 
 typedef std::unique_ptr<HealthCheckEventLogger> HealthCheckEventLoggerPtr;

--- a/include/envoy/upstream/health_checker.h
+++ b/include/envoy/upstream/health_checker.h
@@ -112,8 +112,9 @@ public:
    * @param health_checker_type supplies the type of health checker that generated the event.
    * @param host supplies the host that generated the event.
    */
-  virtual void logNoLongerDegraded(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
-                                 const HostDescriptionConstSharedPtr& host) PURE;
+  virtual void
+  logNoLongerDegraded(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
+                      const HostDescriptionConstSharedPtr& host) PURE;
 };
 
 typedef std::unique_ptr<HealthCheckEventLogger> HealthCheckEventLoggerPtr;

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -439,6 +439,7 @@ public:
   GAUGE    (max_host_weight)                                                                       \
   COUNTER  (membership_change)                                                                     \
   GAUGE    (membership_healthy)                                                                    \
+  GAUGE    (membership_degraded)                                                                   \
   GAUGE    (membership_total)                                                                      \
   COUNTER  (retry_or_shadow_abandoned)                                                             \
   COUNTER  (update_attempt)                                                                        \

--- a/source/common/upstream/health_checker_base_impl.cc
+++ b/source/common/upstream/health_checker_base_impl.cc
@@ -250,7 +250,7 @@ void HealthCheckerImplBase::ActiveHealthCheckSession::handleSuccess(bool degrade
       }
     } else {
       if (parent_.event_logger_) {
-        parent_.event_logger_->logNoMoreDegraded(parent_.healthCheckerType(), host_);
+        parent_.event_logger_->logNoLongerDegraded(parent_.healthCheckerType(), host_);
       }
       host_->healthFlagClear(Host::HealthFlag::DEGRADED_ACTIVE_HC);
     }
@@ -358,11 +358,11 @@ void HealthCheckEventLoggerImpl::logDegraded(
                          [](auto& event) { event.mutable_degraded_healthy_host(); });
 }
 
-void HealthCheckEventLoggerImpl::logNoMoreDegraded(
+void HealthCheckEventLoggerImpl::logNoLongerDegraded(
     envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
     const HostDescriptionConstSharedPtr& host) {
   createHealthCheckEvent(health_checker_type, *host,
-                         [](auto& event) { event.mutable_not_degraded_healthy_host(); });
+                         [](auto& event) { event.mutable_no_longer_degraded_host(); });
 }
 
 void HealthCheckEventLoggerImpl::createHealthCheckEvent(

--- a/source/common/upstream/health_checker_base_impl.h
+++ b/source/common/upstream/health_checker_base_impl.h
@@ -154,7 +154,7 @@ public:
   void logDegraded(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
                    const HostDescriptionConstSharedPtr& host) override;
   void logNoLongerDegraded(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
-                         const HostDescriptionConstSharedPtr& host) override;
+                           const HostDescriptionConstSharedPtr& host) override;
 
 private:
   void createHealthCheckEvent(

--- a/source/common/upstream/health_checker_base_impl.h
+++ b/source/common/upstream/health_checker_base_impl.h
@@ -153,7 +153,7 @@ public:
                     bool first_check) override;
   void logDegraded(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
                    const HostDescriptionConstSharedPtr& host) override;
-  void logNoMoreDegraded(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
+  void logNoLongerDegraded(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
                          const HostDescriptionConstSharedPtr& host) override;
 
 private:

--- a/source/common/upstream/health_checker_base_impl.h
+++ b/source/common/upstream/health_checker_base_impl.h
@@ -151,6 +151,11 @@ public:
                     const HostDescriptionConstSharedPtr& host,
                     envoy::data::core::v2alpha::HealthCheckFailureType failure_type,
                     bool first_check) override;
+  void logDegraded(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
+                    const HostDescriptionConstSharedPtr& host) override;
+  void logNoMoreDegraded(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
+                    const HostDescriptionConstSharedPtr& host) override;
+
 
 private:
   TimeSource& time_source_;

--- a/source/common/upstream/health_checker_base_impl.h
+++ b/source/common/upstream/health_checker_base_impl.h
@@ -23,7 +23,8 @@ namespace Upstream {
   COUNTER(passive_failure)                                                                         \
   COUNTER(network_failure)                                                                         \
   COUNTER(verify_cluster)                                                                          \
-  GAUGE  (healthy)
+  GAUGE  (healthy)                                                                                 \
+  GAUGE  (degraded)
 // clang-format on
 
 /**
@@ -110,8 +111,10 @@ private:
 
   void addHosts(const HostVector& hosts);
   void decHealthy();
+  void decDegraded();
   HealthCheckerStats generateStats(Stats::Scope& scope);
   void incHealthy();
+  void incDegraded();
   std::chrono::milliseconds interval(HealthState state, HealthTransition changed_state) const;
   void onClusterMemberUpdate(const HostVector& hosts_added, const HostVector& hosts_removed);
   void refreshHealthyStat();
@@ -130,6 +133,7 @@ private:
   const std::chrono::milliseconds healthy_edge_interval_;
   std::unordered_map<HostSharedPtr, ActiveHealthCheckSessionPtr> active_sessions_;
   uint64_t local_process_healthy_{};
+  uint64_t local_process_degraded_{};
 };
 
 class HealthCheckEventLoggerImpl : public HealthCheckEventLogger {

--- a/source/common/upstream/health_checker_base_impl.h
+++ b/source/common/upstream/health_checker_base_impl.h
@@ -152,12 +152,15 @@ public:
                     envoy::data::core::v2alpha::HealthCheckFailureType failure_type,
                     bool first_check) override;
   void logDegraded(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
-                    const HostDescriptionConstSharedPtr& host) override;
+                   const HostDescriptionConstSharedPtr& host) override;
   void logNoMoreDegraded(envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
-                    const HostDescriptionConstSharedPtr& host) override;
-
+                         const HostDescriptionConstSharedPtr& host) override;
 
 private:
+  void createHealthCheckEvent(
+      envoy::data::core::v2alpha::HealthCheckerType health_checker_type,
+      const HostDescription& host,
+      std::function<void(envoy::data::core::v2alpha::HealthCheckEvent&)> callback) const;
   TimeSource& time_source_;
   Filesystem::FileSharedPtr file_;
 };

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -581,13 +581,16 @@ ClusterImplBase::ClusterImplBase(
         }
 
         uint32_t healthy_hosts = 0;
+        uint32_t degraded_hosts = 0;
         uint32_t hosts = 0;
         for (const auto& host_set : prioritySet().hostSetsPerPriority()) {
           hosts += host_set->hosts().size();
           healthy_hosts += host_set->healthyHosts().size();
+          degraded_hosts += host_set->degradedHosts().size();
         }
         info_->stats().membership_total_.set(hosts);
         info_->stats().membership_healthy_.set(healthy_hosts);
+        info_->stats().membership_degraded_.set(degraded_hosts);
       });
 }
 

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -602,7 +602,7 @@ TEST_F(HttpHealthCheckerImplTest, Degraded) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   test_sessions_[0]->interval_timer_->callback_();
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
-  EXPECT_CALL(*event_logger_, logNoMoreDegraded(_, _));
+  EXPECT_CALL(*event_logger_, logNoLongerDegraded(_, _));
   respond(0, "200", false, true, false, {}, false);
   EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }
@@ -3548,6 +3548,22 @@ TEST(HealthCheckEventLoggerImplTest, All) {
                          "\"timestamp\":\"2009-02-13T23:31:31.234Z\"}\n"}));
   event_logger.logUnhealthy(envoy::data::core::v2alpha::HealthCheckerType::HTTP, host,
                             envoy::data::core::v2alpha::HealthCheckFailureType::ACTIVE, false);
+
+  EXPECT_CALL(*file, write(absl::string_view{
+                         "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
+                         "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"resolver_name\":\"\","
+                         "\"ipv4_compat\":false,\"port_value\":443}},\"cluster_name\":\"fake_"
+                         "cluster\",\"degraded_healthy_host\":{},"
+                         "\"timestamp\":\"2009-02-13T23:31:31.234Z\"}\n"}));
+  event_logger.logDegraded(envoy::data::core::v2alpha::HealthCheckerType::HTTP, host);
+
+  EXPECT_CALL(*file, write(absl::string_view{
+                         "{\"health_checker_type\":\"HTTP\",\"host\":{\"socket_address\":{"
+                         "\"protocol\":\"TCP\",\"address\":\"10.0.0.1\",\"resolver_name\":\"\","
+                         "\"ipv4_compat\":false,\"port_value\":443}},\"cluster_name\":\"fake_"
+                         "cluster\",\"no_longer_degraded_host\":{},"
+                         "\"timestamp\":\"2009-02-13T23:31:31.234Z\"}\n"}));
+  event_logger.logNoLongerDegraded(envoy::data::core::v2alpha::HealthCheckerType::HTTP, host);
 }
 
 // Validate that the proto constraints don't allow zero length edge durations.

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -591,6 +591,7 @@ TEST_F(HttpHealthCheckerImplTest, Degraded) {
   // We start off as healthy, and should go degraded after receiving the degraded health response.
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
+  EXPECT_CALL(*event_logger_, logDegraded(_, _));
   respond(0, "200", false, true, false, {}, true);
   EXPECT_EQ(Host::Health::Degraded, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 
@@ -601,6 +602,7 @@ TEST_F(HttpHealthCheckerImplTest, Degraded) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   test_sessions_[0]->interval_timer_->callback_();
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_));
+  EXPECT_CALL(*event_logger_, logNoMoreDegraded(_, _));
   respond(0, "200", false, true, false, {}, false);
   EXPECT_EQ(Host::Health::Healthy, cluster_->prioritySet().getMockHostSet(0)->hosts_[0]->health());
 }

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1307,6 +1307,8 @@ TEST(StaticClusterImplTest, HealthyStat) {
 
   cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[1]->healthFlagSet(
       Host::HealthFlag::DEGRADED_ACTIVE_HC);
+  cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[1]->healthFlagClear(
+      Host::HealthFlag::FAILED_ACTIVE_HC);
   health_checker->runCallbacks(cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[1],
                                HealthTransition::Changed);
   EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1315,6 +1315,16 @@ TEST(StaticClusterImplTest, HealthyStat) {
   EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->degradedHosts().size());
   EXPECT_EQ(0UL, cluster.info()->stats().membership_healthy_.value());
   EXPECT_EQ(1UL, cluster.info()->stats().membership_degraded_.value());
+
+  // Mark the endpoint as unhealthy. This should decrement the degraded stat.
+  cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[1]->healthFlagSet(
+      Host::HealthFlag::FAILED_ACTIVE_HC);
+  health_checker->runCallbacks(cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[1],
+                               HealthTransition::Changed);
+  EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
+  EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->degradedHosts().size());
+  EXPECT_EQ(0UL, cluster.info()->stats().membership_healthy_.value());
+  EXPECT_EQ(0UL, cluster.info()->stats().membership_degraded_.value());
 }
 
 TEST(StaticClusterImplTest, UrlConfig) {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1248,6 +1248,7 @@ TEST(StaticClusterImplTest, HealthyStat) {
   EXPECT_EQ(2UL, cluster.prioritySet().hostSetsPerPriority()[0]->hosts().size());
   EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
   EXPECT_EQ(0UL, cluster.info()->stats().membership_healthy_.value());
+  EXPECT_EQ(0UL, cluster.info()->stats().membership_degraded_.value());
 
   cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[0]->healthFlagClear(
       Host::HealthFlag::FAILED_ACTIVE_HC);
@@ -1264,6 +1265,7 @@ TEST(StaticClusterImplTest, HealthyStat) {
   outlier_detector->runCallbacks(cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[0]);
   EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
   EXPECT_EQ(1UL, cluster.info()->stats().membership_healthy_.value());
+  EXPECT_EQ(0UL, cluster.info()->stats().membership_degraded_.value());
 
   cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[0]->healthFlagSet(
       Host::HealthFlag::FAILED_ACTIVE_HC);
@@ -1271,12 +1273,14 @@ TEST(StaticClusterImplTest, HealthyStat) {
                                HealthTransition::Changed);
   EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
   EXPECT_EQ(1UL, cluster.info()->stats().membership_healthy_.value());
+  EXPECT_EQ(0UL, cluster.info()->stats().membership_degraded_.value());
 
   cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[0]->healthFlagClear(
       Host::HealthFlag::FAILED_OUTLIER_CHECK);
   outlier_detector->runCallbacks(cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[0]);
   EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
   EXPECT_EQ(1UL, cluster.info()->stats().membership_healthy_.value());
+  EXPECT_EQ(0UL, cluster.info()->stats().membership_degraded_.value());
 
   cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[0]->healthFlagClear(
       Host::HealthFlag::FAILED_ACTIVE_HC);
@@ -1284,12 +1288,14 @@ TEST(StaticClusterImplTest, HealthyStat) {
                                HealthTransition::Changed);
   EXPECT_EQ(2UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
   EXPECT_EQ(2UL, cluster.info()->stats().membership_healthy_.value());
+  EXPECT_EQ(0UL, cluster.info()->stats().membership_degraded_.value());
 
   cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[0]->healthFlagSet(
       Host::HealthFlag::FAILED_OUTLIER_CHECK);
   outlier_detector->runCallbacks(cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[0]);
   EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
   EXPECT_EQ(1UL, cluster.info()->stats().membership_healthy_.value());
+  EXPECT_EQ(0UL, cluster.info()->stats().membership_degraded_.value());
 
   cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[1]->healthFlagSet(
       Host::HealthFlag::FAILED_ACTIVE_HC);
@@ -1297,6 +1303,16 @@ TEST(StaticClusterImplTest, HealthyStat) {
                                HealthTransition::Changed);
   EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
   EXPECT_EQ(0UL, cluster.info()->stats().membership_healthy_.value());
+  EXPECT_EQ(0UL, cluster.info()->stats().membership_degraded_.value());
+
+  cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[1]->healthFlagSet(
+      Host::HealthFlag::DEGRADED_ACTIVE_HC);
+  health_checker->runCallbacks(cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[1],
+                               HealthTransition::Changed);
+  EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
+  EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->degradedHosts().size());
+  EXPECT_EQ(0UL, cluster.info()->stats().membership_healthy_.value());
+  EXPECT_EQ(1UL, cluster.info()->stats().membership_degraded_.value());
 }
 
 TEST(StaticClusterImplTest, UrlConfig) {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1325,6 +1325,26 @@ TEST(StaticClusterImplTest, HealthyStat) {
   EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->degradedHosts().size());
   EXPECT_EQ(0UL, cluster.info()->stats().membership_healthy_.value());
   EXPECT_EQ(0UL, cluster.info()->stats().membership_degraded_.value());
+
+  // Go back to degraded.
+  cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[1]->healthFlagClear(
+      Host::HealthFlag::FAILED_ACTIVE_HC);
+  health_checker->runCallbacks(cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[1],
+                               HealthTransition::Changed);
+  EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
+  EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->degradedHosts().size());
+  EXPECT_EQ(0UL, cluster.info()->stats().membership_healthy_.value());
+  EXPECT_EQ(1UL, cluster.info()->stats().membership_degraded_.value());
+
+  // Then go healthy.
+  cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[1]->healthFlagClear(
+      Host::HealthFlag::DEGRADED_ACTIVE_HC);
+  health_checker->runCallbacks(cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[1],
+                               HealthTransition::Changed);
+  EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
+  EXPECT_EQ(0UL, cluster.prioritySet().hostSetsPerPriority()[0]->degradedHosts().size());
+  EXPECT_EQ(1UL, cluster.info()->stats().membership_healthy_.value());
+  EXPECT_EQ(0UL, cluster.info()->stats().membership_degraded_.value());
 }
 
 TEST(StaticClusterImplTest, UrlConfig) {

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -315,9 +315,9 @@ public:
                                   const HostDescriptionConstSharedPtr&,
                                   envoy::data::core::v2alpha::HealthCheckFailureType, bool));
   MOCK_METHOD2(logDegraded, void(envoy::data::core::v2alpha::HealthCheckerType,
-                                  const HostDescriptionConstSharedPtr&));
+                                 const HostDescriptionConstSharedPtr&));
   MOCK_METHOD2(logNoMoreDegraded, void(envoy::data::core::v2alpha::HealthCheckerType,
-                                  const HostDescriptionConstSharedPtr&));
+                                       const HostDescriptionConstSharedPtr&));
 };
 
 class MockCdsApi : public CdsApi {

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -314,6 +314,10 @@ public:
   MOCK_METHOD4(logUnhealthy, void(envoy::data::core::v2alpha::HealthCheckerType,
                                   const HostDescriptionConstSharedPtr&,
                                   envoy::data::core::v2alpha::HealthCheckFailureType, bool));
+  MOCK_METHOD2(logDegraded, void(envoy::data::core::v2alpha::HealthCheckerType,
+                                  const HostDescriptionConstSharedPtr&));
+  MOCK_METHOD2(logNoMoreDegraded, void(envoy::data::core::v2alpha::HealthCheckerType,
+                                  const HostDescriptionConstSharedPtr&));
 };
 
 class MockCdsApi : public CdsApi {

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -316,7 +316,7 @@ public:
                                   envoy::data::core::v2alpha::HealthCheckFailureType, bool));
   MOCK_METHOD2(logDegraded, void(envoy::data::core::v2alpha::HealthCheckerType,
                                  const HostDescriptionConstSharedPtr&));
-  MOCK_METHOD2(logNoMoreDegraded, void(envoy::data::core::v2alpha::HealthCheckerType,
+  MOCK_METHOD2(logNoLongerDegraded, void(envoy::data::core::v2alpha::HealthCheckerType,
                                        const HostDescriptionConstSharedPtr&));
 };
 

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -317,7 +317,7 @@ public:
   MOCK_METHOD2(logDegraded, void(envoy::data::core::v2alpha::HealthCheckerType,
                                  const HostDescriptionConstSharedPtr&));
   MOCK_METHOD2(logNoLongerDegraded, void(envoy::data::core::v2alpha::HealthCheckerType,
-                                       const HostDescriptionConstSharedPtr&));
+                                         const HostDescriptionConstSharedPtr&));
 };
 
 class MockCdsApi : public CdsApi {


### PR DESCRIPTION
Adds a basic gauge for number of degraded members as well as health check event logs for
when a host is degraded/no longer degraded

*Risk Level*: Low
*Testing*: UTs
*Docs Changes*: Documented new stat + proto docs
*Release Notes*: n/a
Part of #5063 