### PR TITLE
Use llvm@7 for clang-format on macOS

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -50,7 +50,7 @@ On macOS, you'll need to install several dependencies. This can be accomplished 
 ```
 brew install coreutils wget cmake libtool go bazel automake ninja llvm@7
 ```
-_notes_: `coreutils` is used for realpath, `llvm@7` is used for clang-format 7
+_notes_: `coreutils` is used for `realpath`, `gmd5sum` and `gsha256sum`; `llvm@7` is used for `clang-format`
 
 Envoy compiles and passes tests with the version of clang installed by XCode 9.3.0:
 Apple LLVM version 9.1.0 (clang-902.0.30).

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -48,9 +48,9 @@ dnf install cmake libtool libstdc++ ninja-build lld patch
 
 On macOS, you'll need to install several dependencies. This can be accomplished via [Homebrew](https://brew.sh/):
 ```
-brew install coreutils wget cmake libtool go bazel automake ninja clang-format
+brew install coreutils wget cmake libtool go bazel automake ninja llvm@7
 ```
-_note_: `coreutils` is used for realpath
+_notes_: `coreutils` is used for realpath, `llvm@7` is used for clang-format 7
 
 Envoy compiles and passes tests with the version of clang installed by XCode 9.3.0:
 Apple LLVM version 9.1.0 (clang-902.0.30).

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -111,7 +111,8 @@ def checkTools():
         "PATH, please use CLANG_FORMAT environment variable to specify the path. "
         "Examples:\n"
         "    export CLANG_FORMAT=clang-format-7.0.0\n"
-        "    export CLANG_FORMAT=/opt/bin/clang-format-7".format(CLANG_FORMAT_PATH))
+        "    export CLANG_FORMAT=/opt/bin/clang-format-7\n"
+        "    export CLANG_FORMAT=/usr/local/opt/llvm@7/bin/clang-format".format(CLANG_FORMAT_PATH))
 
   buildifier_abs_path = lookPath(BUILDIFIER_PATH)
   if buildifier_abs_path:


### PR DESCRIPTION
As of Jan 8th 2019, Envoy still uses clang-format-7 and this version
is no longer accessible in the clang-format homebrew package. The
llvm@7 is keg only, thus it will not cause problems with the macOS
clang installation.

This should prevent erroneous failures from the current homebrew clang-format. Ex. #5526

Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

*Risk Level*: Low, docs only
*Testing*: `./tools/check_format check` with/without CLANG_FORMAT env var
*Docs Changes*: Done
*Release Notes*: N/A
