### PR TITLE
http: clearing hop by hop headers

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -289,6 +289,8 @@ private:
   HEADER_FUNC(OtSpanContext)                                                                       \
   HEADER_FUNC(Path)                                                                                \
   HEADER_FUNC(Protocol)                                                                            \
+  HEADER_FUNC(ProxyAuthenticate)                                                                   \
+  HEADER_FUNC(ProxyAuthorization)                                                                  \
   HEADER_FUNC(ProxyConnection)                                                                     \
   HEADER_FUNC(Referer)                                                                             \
   HEADER_FUNC(RequestId)                                                                           \

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -81,6 +81,8 @@ public:
   const LowerCaseString OtSpanContext{"x-ot-span-context"};
   const LowerCaseString Path{":path"};
   const LowerCaseString Protocol{":protocol"};
+  const LowerCaseString ProxyAuthenticate{"proxy-authenticate"};
+  const LowerCaseString ProxyAuthorization{"proxy-authorization"};
   const LowerCaseString ProxyConnection{"proxy-connection"};
   const LowerCaseString Referer{"referer"};
   const LowerCaseString RequestId{"x-request-id"};


### PR DESCRIPTION
Clearing TE, Proxy-Authenticate, Proxy-Authorization headers.

*Risk Level*: Medium (change to header processing)
*Testing*: new unit tests
*Docs Changes*: n/a
*Release Notes*: inline
Fixes #5541