### PR TITLE
config: removing internal code structures allowing v1 config

### DIFF
--- a/include/envoy/server/options.h
+++ b/include/envoy/server/options.h
@@ -80,12 +80,6 @@ public:
   virtual const std::string& configYaml() const PURE;
 
   /**
-   * @return bool whether the config should only be parsed as v2. If false, when a v2 parse fails,
-   *              a second attempt to parse the config as v1 will be made.
-   */
-  virtual bool v2ConfigOnly() const PURE;
-
-  /**
    * @return const std::string& the admin address output file.
    */
   virtual const std::string& adminAddressPath() const PURE;

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -35,7 +35,7 @@ namespace Envoy {
 OptionsImpl::OptionsImpl(int argc, const char* const* argv,
                          const HotRestartVersionCb& hot_restart_version_cb,
                          spdlog::level::level_enum default_log_level)
-    : v2_config_only_(true), signal_handling_enabled_(true) {
+    : signal_handling_enabled_(true) {
   std::string log_levels_string = "Log levels: ";
   for (size_t i = 0; i < ARRAY_SIZE(spdlog::level::level_names); i++) {
     log_levels_string += fmt::format("[{}]", spdlog::level::level_names[i]);
@@ -305,7 +305,7 @@ Server::CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
 
 OptionsImpl::OptionsImpl(const std::string& service_cluster, const std::string& service_node,
                          const std::string& service_zone, spdlog::level::level_enum log_level)
-    : base_id_(0u), concurrency_(1u), config_path_(""), config_yaml_(""), v2_config_only_(true),
+    : base_id_(0u), concurrency_(1u), config_path_(""), config_yaml_(""),
       local_address_ip_version_(Network::Address::IpVersion::v4), log_level_(log_level),
       log_format_(Logger::Logger::DEFAULT_LOG_FORMAT), restart_epoch_(0u),
       service_cluster_(service_cluster), service_node_(service_node), service_zone_(service_zone),

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -42,7 +42,6 @@ public:
   void setConcurrency(uint32_t concurrency) { concurrency_ = concurrency; }
   void setConfigPath(const std::string& config_path) { config_path_ = config_path; }
   void setConfigYaml(const std::string& config_yaml) { config_yaml_ = config_yaml; }
-  void setV2ConfigOnly(bool v2_config_only) { v2_config_only_ = v2_config_only; }
   void setAdminAddressPath(const std::string& admin_address_path) {
     admin_address_path_ = admin_address_path;
   }
@@ -80,7 +79,6 @@ public:
   uint32_t concurrency() const override { return concurrency_; }
   const std::string& configPath() const override { return config_path_; }
   const std::string& configYaml() const override { return config_yaml_; }
-  bool v2ConfigOnly() const override { return v2_config_only_; }
   const std::string& adminAddressPath() const override { return admin_address_path_; }
   Network::Address::IpVersion localAddressIpVersion() const override {
     return local_address_ip_version_;
@@ -119,7 +117,6 @@ private:
   std::string config_path_;
   std::string config_yaml_;
   bool allow_unknown_fields_{false};
-  bool v2_config_only_;
   std::string admin_address_path_;
   Network::Address::IpVersion local_address_ip_version_;
   spdlog::level::level_enum log_level_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -182,31 +182,17 @@ InstanceUtil::loadBootstrapConfig(envoy::config::bootstrap::v2::Bootstrap& boots
     std::cerr << message << std::endl;
     throw EnvoyException(message);
   }
-  try {
-    if (!config_path.empty()) {
-      MessageUtil::loadFromFile(config_path, bootstrap);
-    }
-    if (!config_yaml.empty()) {
-      envoy::config::bootstrap::v2::Bootstrap bootstrap_override;
-      MessageUtil::loadFromYaml(config_yaml, bootstrap_override);
-      bootstrap.MergeFrom(bootstrap_override);
-    }
-    MessageUtil::validate(bootstrap);
-    return BootstrapVersion::V2;
-  } catch (const EnvoyException& e) {
-    if (options.v2ConfigOnly()) {
-      throw;
-    }
-    // TODO(htuch): When v1 is deprecated, make this a warning encouraging config upgrade.
-    ENVOY_LOG(debug, "Unable to initialize config as v2, will retry as v1: {}", e.what());
+
+  if (!config_path.empty()) {
+    MessageUtil::loadFromFile(config_path, bootstrap);
   }
   if (!config_yaml.empty()) {
-    throw EnvoyException("V1 config (detected) with --config-yaml is not supported");
+    envoy::config::bootstrap::v2::Bootstrap bootstrap_override;
+    MessageUtil::loadFromYaml(config_yaml, bootstrap_override);
+    bootstrap.MergeFrom(bootstrap_override);
   }
-  Json::ObjectSharedPtr config_json = Json::Factory::loadFromFile(config_path);
-  Config::BootstrapJson::translateBootstrap(*config_json, bootstrap, options.statsOptions());
   MessageUtil::validate(bootstrap);
-  return BootstrapVersion::V1;
+  return BootstrapVersion::V2;
 }
 
 void InstanceImpl::initialize(Options& options,

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -86,7 +86,7 @@ public:
  */
 class InstanceUtil : Logger::Loggable<Logger::Id::main> {
 public:
-  enum class BootstrapVersion { V1, V2 };
+  enum class BootstrapVersion { V2 };
 
   /**
    * Default implementation of runtime loader creation used in the real server and in most

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -33,7 +33,6 @@ OptionsImpl createTestOptionsImpl(const std::string& config_path, const std::str
 
   test_options.setConfigPath(config_path);
   test_options.setConfigYaml(config_yaml);
-  test_options.setV2ConfigOnly(false);
   test_options.setLocalAddressIpVersion(ip_version);
   test_options.setFileFlushIntervalMsec(std::chrono::milliseconds(50));
   test_options.setDrainTime(std::chrono::seconds(1));

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -22,7 +22,6 @@ MockOptions::MockOptions(const std::string& config_path) : config_path_(config_p
   ON_CALL(*this, concurrency()).WillByDefault(ReturnPointee(&concurrency_));
   ON_CALL(*this, configPath()).WillByDefault(ReturnRef(config_path_));
   ON_CALL(*this, configYaml()).WillByDefault(ReturnRef(config_yaml_));
-  ON_CALL(*this, v2ConfigOnly()).WillByDefault(Invoke([this] { return v2_config_only_; }));
   ON_CALL(*this, adminAddressPath()).WillByDefault(ReturnRef(admin_address_path_));
   ON_CALL(*this, serviceClusterName()).WillByDefault(ReturnRef(service_cluster_name_));
   ON_CALL(*this, serviceNodeName()).WillByDefault(ReturnRef(service_node_name_));

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -58,7 +58,6 @@ public:
   MOCK_CONST_METHOD0(concurrency, uint32_t());
   MOCK_CONST_METHOD0(configPath, const std::string&());
   MOCK_CONST_METHOD0(configYaml, const std::string&());
-  MOCK_CONST_METHOD0(v2ConfigOnly, bool());
   MOCK_CONST_METHOD0(adminAddressPath, const std::string&());
   MOCK_CONST_METHOD0(localAddressIpVersion, Network::Address::IpVersion());
   MOCK_CONST_METHOD0(drainTime, std::chrono::seconds());
@@ -83,7 +82,6 @@ public:
 
   std::string config_path_;
   std::string config_yaml_;
-  bool v2_config_only_{};
   std::string admin_address_path_;
   std::string service_cluster_name_;
   std::string service_node_name_;

--- a/test/server/config_validation/config_fuzz_test.cc
+++ b/test/server/config_validation/config_fuzz_test.cc
@@ -26,7 +26,6 @@ DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v2::Bootstrap& input) {
   std::ofstream bootstrap_file(bootstrap_path);
   bootstrap_file << input.DebugString();
   options.config_path_ = bootstrap_path;
-  options.v2_config_only_ = true;
   options.log_level_ = Fuzz::Runner::logLevel();
 
   try {

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -57,7 +57,6 @@ TEST_F(OptionsImplTest, v1Disallowed) {
       "--service-zone zone --file-flush-interval-msec 9000 --drain-time-s 60 --log-format [%v] "
       "--parent-shutdown-time-s 90 --log-path /foo/bar --disable-hot-restart");
   EXPECT_EQ(Server::Mode::Validate, options->mode());
-  EXPECT_TRUE(options->v2ConfigOnly());
 }
 
 TEST_F(OptionsImplTest, All) {
@@ -71,7 +70,6 @@ TEST_F(OptionsImplTest, All) {
   EXPECT_EQ(Server::Mode::Validate, options->mode());
   EXPECT_EQ(2U, options->concurrency());
   EXPECT_EQ("hello", options->configPath());
-  EXPECT_TRUE(options->v2ConfigOnly());
   EXPECT_EQ("path", options->adminAddressPath());
   EXPECT_EQ(Network::Address::IpVersion::v6, options->localAddressIpVersion());
   EXPECT_EQ(1U, options->restartEpoch());
@@ -284,7 +282,6 @@ TEST_F(OptionsImplTest, SaneTestConstructor) {
   EXPECT_EQ(regular_options_impl->baseId(), test_options_impl.baseId());
   EXPECT_EQ(regular_options_impl->configPath(), test_options_impl.configPath());
   EXPECT_EQ(regular_options_impl->configYaml(), test_options_impl.configYaml());
-  EXPECT_EQ(regular_options_impl->v2ConfigOnly(), test_options_impl.v2ConfigOnly());
   EXPECT_EQ(regular_options_impl->adminAddressPath(), test_options_impl.adminAddressPath());
   EXPECT_EQ(regular_options_impl->localAddressIpVersion(),
             test_options_impl.localAddressIpVersion());

--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -69,7 +69,6 @@ DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v2::Bootstrap& input) {
     std::ofstream bootstrap_file(bootstrap_path);
     bootstrap_file << makeHermeticPathsAndPorts(test_env, input).DebugString();
     options.config_path_ = bootstrap_path;
-    options.v2_config_only_ = true;
     options.log_level_ = Fuzz::Runner::logLevel();
   }
 

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -174,7 +174,6 @@ INSTANTIATE_TEST_CASE_P(IpVersions, ServerInstanceImplTest,
 TEST_P(ServerInstanceImplTest, V2ConfigOnly) {
   options_.service_cluster_name_ = "some_cluster_name";
   options_.service_node_name_ = "some_node_name";
-  options_.v2_config_only_ = true;
   try {
     initialize(std::string());
     FAIL();
@@ -183,19 +182,12 @@ TEST_P(ServerInstanceImplTest, V2ConfigOnly) {
   }
 }
 
-TEST_P(ServerInstanceImplTest, V1ConfigFallback) {
-  options_.service_cluster_name_ = "some_cluster_name";
-  options_.service_node_name_ = "some_node_name";
-  options_.v2_config_only_ = false;
-  initialize(std::string());
-}
-
 TEST_P(ServerInstanceImplTest, Stats) {
   options_.service_cluster_name_ = "some_cluster_name";
   options_.service_node_name_ = "some_node_name";
   options_.concurrency_ = 2;
   options_.hot_restart_epoch_ = 3;
-  initialize(std::string());
+  EXPECT_NO_THROW(initialize("test/server/empty_bootstrap.yaml"));
   EXPECT_NE(nullptr, TestUtility::findCounter(stats_store_, "server.watchdog_miss"));
   EXPECT_EQ(2L, TestUtility::findGauge(stats_store_, "server.concurrency")->value());
   EXPECT_EQ(3L, TestUtility::findGauge(stats_store_, "server.hot_restart_epoch")->value());
@@ -241,7 +233,6 @@ TEST_P(ServerInstanceImplTest, BootstrapClusterManagerInitializationFail) {
 
 // Test for protoc-gen-validate constraint on invalid timeout entry of a health check config entry.
 TEST_P(ServerInstanceImplTest, BootstrapClusterHealthCheckInvalidTimeout) {
-  options_.v2_config_only_ = true;
   EXPECT_THROW_WITH_REGEX(
       initializeWithHealthCheckParams("test/server/cluster_health_check_bootstrap.yaml", 0, 0.25),
       EnvoyException,
@@ -250,7 +241,6 @@ TEST_P(ServerInstanceImplTest, BootstrapClusterHealthCheckInvalidTimeout) {
 
 // Test for protoc-gen-validate constraint on invalid interval entry of a health check config entry.
 TEST_P(ServerInstanceImplTest, BootstrapClusterHealthCheckInvalidInterval) {
-  options_.v2_config_only_ = true;
   EXPECT_THROW_WITH_REGEX(
       initializeWithHealthCheckParams("test/server/cluster_health_check_bootstrap.yaml", 0.5, 0),
       EnvoyException,
@@ -260,7 +250,6 @@ TEST_P(ServerInstanceImplTest, BootstrapClusterHealthCheckInvalidInterval) {
 // Test for protoc-gen-validate constraint on invalid timeout and interval entry of a health check
 // config entry.
 TEST_P(ServerInstanceImplTest, BootstrapClusterHealthCheckInvalidTimeoutAndInterval) {
-  options_.v2_config_only_ = true;
   EXPECT_THROW_WITH_REGEX(
       initializeWithHealthCheckParams("test/server/cluster_health_check_bootstrap.yaml", 0, 0),
       EnvoyException,
@@ -269,7 +258,6 @@ TEST_P(ServerInstanceImplTest, BootstrapClusterHealthCheckInvalidTimeoutAndInter
 
 // Test for protoc-gen-validate constraint on valid interval entry of a health check config entry.
 TEST_P(ServerInstanceImplTest, BootstrapClusterHealthCheckValidTimeoutAndInterval) {
-  options_.v2_config_only_ = true;
   EXPECT_NO_THROW(initializeWithHealthCheckParams("test/server/cluster_health_check_bootstrap.yaml",
                                                   0.25, 0.5));
 }
@@ -295,7 +283,6 @@ TEST_P(ServerInstanceImplTest, BootstrapNodeWithoutAccessLog) {
 TEST_P(ServerInstanceImplTest, EmptyBootstrap) {
   options_.service_cluster_name_ = "some_cluster_name";
   options_.service_node_name_ = "some_node_name";
-  options_.v2_config_only_ = true;
   EXPECT_NO_THROW(initialize("test/server/empty_bootstrap.yaml"));
 }
 
@@ -303,7 +290,6 @@ TEST_P(ServerInstanceImplTest, EmptyBootstrap) {
 TEST_P(ServerInstanceImplTest, ValidateFail) {
   options_.service_cluster_name_ = "some_cluster_name";
   options_.service_node_name_ = "some_node_name";
-  options_.v2_config_only_ = true;
   try {
     initialize("test/server/empty_runtime.yaml");
     FAIL();
@@ -318,7 +304,7 @@ TEST_P(ServerInstanceImplTest, LogToFile) {
   options_.log_path_ = path;
   options_.service_cluster_name_ = "some_cluster_name";
   options_.service_node_name_ = "some_node_name";
-  initialize(std::string());
+  EXPECT_NO_THROW(initialize("test/server/empty_bootstrap.yaml"));
   EXPECT_TRUE(server_->api().fileExists(path));
 
   GET_MISC_LOGGER().set_level(spdlog::level::info);
@@ -391,7 +377,7 @@ TEST_P(ServerInstanceImplTest, MutexContentionEnabled) {
   options_.service_cluster_name_ = "some_cluster_name";
   options_.service_node_name_ = "some_node_name";
   options_.mutex_tracing_enabled_ = true;
-  EXPECT_NO_THROW(initialize(std::string()));
+  EXPECT_NO_THROW(initialize("test/server/empty_bootstrap.yaml"));
 }
 
 TEST_P(ServerInstanceImplTest, NoHttpTracing) {


### PR DESCRIPTION
Removing v2ConfigOnly().  I think this is the removal for v1 support in Envoy.

Previously this was used to allow v1 config via command line switch.  Currently it's only used in upstream Envoy to allow v1 config for the last lingering v1 tests.
intentionally not removing BootstrapJson::translateBootstrap until end of quarter as it's still used in Harvey's awesome v1_to_bootstrap util which we are not sunsetting until March or so.

*Risk Level*: Medium - no way to tell what downstream Envoys might still make use of this.
*Testing*: n/a
*Docs Changes*: n/a
*Release Notes*: not added.