### PR TITLE
http connection manager: Fix request timeout bug

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -179,6 +179,8 @@ void ConnectionManagerImpl::doDeferredStreamDestroy(ActiveStream& stream) {
     stream.stream_idle_timer_->disableTimer();
     stream.stream_idle_timer_ = nullptr;
   }
+  stream.disarmRequestTimeout();
+
   stream.state_.destroyed_ = true;
   for (auto& filter : stream.decoder_filters_) {
     filter->handle_->onDestroy();


### PR DESCRIPTION
Signed-off-by: Auni Ahsan <auni@google.com>

*Description*: Request timeout was not disarmed upon stream termination without encodeHeaders, inducing a race condition with the deferred stream deletion queue.
*Risk Level*: Low.
*Testing*: conn_manager_impl_test similar to what the perstream timeout has.

Fixes #5557