### PR TITLE
ci/run_envoy_docker.sh support running inside git worktree

### DIFF
--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -16,10 +16,12 @@ USER_GROUP=root
 [[ -z "${IMAGE_ID}" ]] && IMAGE_ID="${ENVOY_BUILD_SHA}"
 [[ -z "${ENVOY_DOCKER_BUILD_DIR}" ]] && ENVOY_DOCKER_BUILD_DIR=/tmp/envoy-docker-build
 
+git rev-parse --is-inside-work-tree > /dev/null && GIT_VOLUME_OPTION="--volume=$(git rev-parse --git-common-dir):$(git rev-parse --git-common-dir)"
+
 mkdir -p "${ENVOY_DOCKER_BUILD_DIR}"
 # Since we specify an explicit hash, docker-run will pull from the remote repo if missing.
 docker run --rm -t -i -e HTTP_PROXY=${http_proxy} -e HTTPS_PROXY=${https_proxy} \
-  -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build \
+  -u "${USER}":"${USER_GROUP}" -v "${ENVOY_DOCKER_BUILD_DIR}":/build "${GIT_VOLUME_OPTION}" \
   -v "$PWD":/source -e NUM_CPUS --cap-add SYS_PTRACE --cap-add NET_RAW --cap-add NET_ADMIN "${IMAGE_NAME}":"${IMAGE_ID}" \
   /bin/bash -lc "groupadd --gid $(id -g) -f envoygroup && useradd -o --uid $(id -u) --gid $(id -g) --no-create-home \
   --home-dir /source envoybuild && usermod -a -G pcap envoybuild && su envoybuild -c \"cd source && $*\""


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

*Description*:
When run `ci/run_envoy_docker.sh` inside git worktree, .git is a pointer to the real path of git directory so it need to be mounted.

*Risk Level*: Low
*Testing*: local test
*Docs Changes*:
*Release Notes*:
