### PR TITLE
lua: align the allocated memory if required

### DIFF
--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -60,14 +60,14 @@ namespace Lua {
  */
 #define DECLARE_LUA_CLOSURE(Class, Name) DECLARE_LUA_FUNCTION_EX(Class, Name, lua_upvalueindex(1))
 
-template <class T> T* align(void* ptr) {
+template <typename T> T* align(void* ptr) {
   size_t address = size_t(ptr);
   auto offset = address % alignof(T);
   auto aligned_address = offset == 0 ? address : address + alignof(T) - offset;
   return reinterpret_cast<T*>(aligned_address);
 }
 
-template <class T> size_t maximumSpaceNeededToAlign() {
+template <typename T> size_t maximumSpaceNeededToAlign() {
   return (alignof(T) > alignof(void*)) ? sizeof(T) : sizeof(T) + alignof(T) - 1;
 }
 

--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -78,6 +78,7 @@ template <typename T> inline void* allocateLuaUserData(lua_State* state) {
   lua_setmetatable(state, -2);
 
   // Align the allocated memory.
+  // TODO(dio): should we do #ifdef for skipping aligning the memory?
   return std::align(std::alignment_of<T>(), sizeof(mem), mem, space);
 }
 
@@ -135,6 +136,7 @@ public:
     // manually because the memory is raw and was allocated by Lua.
     to_register.push_back(
         {"__gc", [](lua_State* state) {
+           // TODO(dio): should we do #ifdef for skipping alignment check?
            auto mem = reinterpret_cast<std::uintptr_t>(luaL_checkudata(state, 1, typeid(T).name()));
 
            // Check if the allocated memory by Lua was aligned.

--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -63,7 +63,7 @@ namespace Lua {
 /**
  * Align Lua allocated memory.
  */
-template <typename T> T* align(void* ptr) {
+template <typename T> inline T* align(void* ptr) {
   size_t address = size_t(ptr);
   auto offset = address % alignof(T);
   auto aligned_address = offset == 0 ? address : address + alignof(T) - offset;
@@ -73,8 +73,8 @@ template <typename T> T* align(void* ptr) {
 /**
  * Calculate the maximum space needed to be aligned.
  */
-template <typename T> size_t maximumSpaceNeededToAlign() {
-  return (alignof(T) > alignof(void*)) ? sizeof(T) : sizeof(T) + alignof(T) - 1;
+template <typename T> inline size_t maximumSpaceNeededToAlign() {
+  return alignof(T) > alignof(void*) ? sizeof(T) : sizeof(T) + alignof(T) - 1;
 }
 
 /**
@@ -140,7 +140,7 @@ public:
         {"__gc", [](lua_State* state) {
            auto mem = reinterpret_cast<std::uintptr_t>(luaL_checkudata(state, 1, typeid(T).name()));
            // Check if the allocated memory by Lua was aligned.
-           if ((mem % std::alignment_of<T>()) != 0) {
+           if (mem % std::alignment_of<T>() != 0) {
              mem += std::alignment_of<T>() - mem % std::alignment_of<T>();
            }
 


### PR DESCRIPTION
*Description*:
This patch aligns the memory that is allocated by Lua. Previously, without alignment, Envoy experienced segfault when constructing `StreamWrapperHandler` using the placement new operator on the pre-allocated (via `new_luauserdata` API) memory by Lua.

*Risk Level*: Medium
*Testing*: Build on mac, check with ASAN, manual testing.
*Docs Changes*: N/A
*Release Notes*: N/A
Fixes #5551 

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>
