### PR TITLE
docs: update gRPC-JSON example to match proto

### DIFF
--- a/docs/root/configuration/http_filters/grpc_json_transcoder_filter.rst
+++ b/docs/root/configuration/http_filters/grpc_json_transcoder_filter.rst
@@ -121,7 +121,7 @@ gRPC or RESTful JSON requests to localhost:51051.
             - name: envoy.grpc_json_transcoder
               config:
                 proto_descriptor: "/tmp/envoy/proto.pb"
-                services: ["HelloWorld"]
+                services: ["helloworld.Greeter"]
                 print_options:
                   add_whitespace: true
                   always_print_primitive_fields: true


### PR DESCRIPTION
*Description*:

The `services:` array config is confusing if someone is trying to follow this documentation. Updated the line to match the above `Greeter` `proto`.

*Risk Level*:

Low: documentation

*Testing*:

n/a

*Docs Changes*:

gRPC-JSON transcoder example

*Release Notes*:

n/a