### PR TITLE
test: use absl::Time.

### DIFF
--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -282,9 +282,9 @@ TEST_F(RouterUpstreamLogTest, LogTimestampsAndDurations) {
   std::smatch matches;
   EXPECT_TRUE(std::regex_match(output_.front(), matches, log_regex));
 
-  std::tm timestamp = TestUtility::parseTimestamp("%Y-%m-%dT%H:%M:%S", matches[1].str());
+  const absl::Time timestamp = TestUtility::parseTime(matches[1].str(), "%Y-%m-%dT%H:%M:%S");
 
-  std::time_t log_time = std::mktime(&timestamp);
+  std::time_t log_time = absl::ToTimeT(timestamp);
   std::time_t now = std::time(nullptr);
 
   // Check that timestamp is close enough.

--- a/test/common/ssl/context_impl_test.cc
+++ b/test/common/ssl/context_impl_test.cc
@@ -236,11 +236,7 @@ TEST_F(SslContextImplTest, TestGetCertInformationWithSAN) {
 }
 
 std::string convertTimeCertInfoToCertDetails(std::string cert_info_time) {
-  std::tm expiration = TestUtility::parseTimestamp("%b %e %H:%M:%S %Y GMT", cert_info_time);
-  char buffer[21];
-  size_t len = strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%SZ", &expiration);
-  ASSERT(len == sizeof(buffer) - 1);
-  return std::string(buffer);
+  return TestUtility::convertTime(cert_info_time, "%b %e %H:%M:%S %Y GMT", "%Y-%m-%dT%H:%M:%SZ");
 }
 
 TEST_F(SslContextImplTest, TestGetCertInformationWithExpiration) {

--- a/test/common/ssl/utility_test.cc
+++ b/test/common/ssl/utility_test.cc
@@ -82,16 +82,16 @@ TEST(UtilityTest, TestDaysUntilExpirationWithNull) {
 TEST(UtilityTest, TestValidFrom) {
   bssl::UniquePtr<X509> cert = readCertFromFile(
       TestEnvironment::substitute("{{ test_rundir }}/test/common/ssl/test_data/san_dns_cert.pem"));
-  const absl::Time valid_from = absl::FromChrono(Utility::getValidFrom(*cert));
-  const std::string formatted = TestUtility::formatTime(valid_from, "%b %e %H:%M:%S %Y GMT");
+  const std::string formatted =
+      TestUtility::formatTime(Utility::getValidFrom(*cert), "%b %e %H:%M:%S %Y GMT");
   EXPECT_EQ(TEST_SAN_DNS_CERT_NOT_BEFORE, formatted);
 }
 
 TEST(UtilityTest, TestExpirationTime) {
   bssl::UniquePtr<X509> cert = readCertFromFile(
       TestEnvironment::substitute("{{ test_rundir }}/test/common/ssl/test_data/san_dns_cert.pem"));
-  const absl::Time expiration = absl::FromChrono(Utility::getExpirationTime(*cert));
-  const std::string formatted = TestUtility::formatTime(expiration, "%b %e %H:%M:%S %Y GMT");
+  const std::string formatted =
+      TestUtility::formatTime(Utility::getExpirationTime(*cert), "%b %e %H:%M:%S %Y GMT");
   EXPECT_EQ(TEST_SAN_DNS_CERT_NOT_AFTER, formatted);
 }
 } // namespace Ssl

--- a/test/common/ssl/utility_test.cc
+++ b/test/common/ssl/utility_test.cc
@@ -66,10 +66,10 @@ TEST(UtilityTest, TestDaysUntilExpiration) {
   time_source.setSystemTime(std::chrono::system_clock::from_time_t(known_date_time));
 
   // Get expiration time from the certificate info.
-  std::tm expiration =
-      TestUtility::parseTimestamp("%b %e %H:%M:%S %Y GMT", TEST_SAN_DNS_CERT_NOT_AFTER);
+  const absl::Time expiration =
+      TestUtility::parseTime(TEST_SAN_DNS_CERT_NOT_AFTER, "%b %e %H:%M:%S %Y GMT");
 
-  int days = std::difftime(std::mktime(&expiration), known_date_time) / (60 * 60 * 24);
+  int days = std::difftime(absl::ToTimeT(expiration), known_date_time) / (60 * 60 * 24);
   EXPECT_EQ(days, Utility::getDaysUntilExpiration(cert.get(), time_source));
 }
 

--- a/test/common/ssl/utility_test.cc
+++ b/test/common/ssl/utility_test.cc
@@ -9,6 +9,7 @@
 #include "test/test_common/simulated_time_system.h"
 #include "test/test_common/utility.h"
 
+#include "absl/time/time.h"
 #include "gtest/gtest.h"
 #include "openssl/x509v3.h"
 
@@ -81,21 +82,17 @@ TEST(UtilityTest, TestDaysUntilExpirationWithNull) {
 TEST(UtilityTest, TestValidFrom) {
   bssl::UniquePtr<X509> cert = readCertFromFile(
       TestEnvironment::substitute("{{ test_rundir }}/test/common/ssl/test_data/san_dns_cert.pem"));
-  const time_t valid_from = std::chrono::system_clock::to_time_t(Utility::getValidFrom(*cert));
-  char buffer[25];
-  size_t len = strftime(buffer, sizeof(buffer), "%b %e %H:%M:%S %Y GMT", localtime(&valid_from));
-  ASSERT(len == sizeof(buffer) - 1);
-  EXPECT_EQ(TEST_SAN_DNS_CERT_NOT_BEFORE, std::string(buffer));
+  const absl::Time valid_from = absl::FromChrono(Utility::getValidFrom(*cert));
+  const std::string formatted = TestUtility::formatTime(valid_from, "%b %e %H:%M:%S %Y GMT");
+  EXPECT_EQ(TEST_SAN_DNS_CERT_NOT_BEFORE, formatted);
 }
 
 TEST(UtilityTest, TestExpirationTime) {
   bssl::UniquePtr<X509> cert = readCertFromFile(
       TestEnvironment::substitute("{{ test_rundir }}/test/common/ssl/test_data/san_dns_cert.pem"));
-  const time_t expiration = std::chrono::system_clock::to_time_t(Utility::getExpirationTime(*cert));
-  char buffer[25];
-  size_t len = strftime(buffer, sizeof(buffer), "%b %e %H:%M:%S %Y GMT", localtime(&expiration));
-  ASSERT(len == sizeof(buffer) - 1);
-  EXPECT_EQ(TEST_SAN_DNS_CERT_NOT_AFTER, std::string(buffer));
+  const absl::Time expiration = absl::FromChrono(Utility::getExpirationTime(*cert));
+  const std::string formatted = TestUtility::formatTime(expiration, "%b %e %H:%M:%S %Y GMT");
+  EXPECT_EQ(TEST_SAN_DNS_CERT_NOT_AFTER, formatted);
 }
 } // namespace Ssl
 } // namespace Envoy

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -225,15 +225,20 @@ void TestUtility::createSymlink(const std::string& target, const std::string& li
 }
 
 // static
-std::tm TestUtility::parseTimestamp(const std::string& format, const std::string& time_str) {
-  std::tm timestamp{};
-  std::istringstream text(time_str);
+absl::Time TestUtility::parseTime(const std::string& input, const std::string& format) {
+  absl::Time t;
+  std::string error;
+  EXPECT_TRUE(absl::ParseTime(format, input, &t, &error))
+      << " error \"" << error << "\" from failing to parse timestamp \"" << input
+      << "\" with format string \"" << format << "\"";
+  return t;
+}
 
-  text >> std::get_time(&timestamp, format.c_str());
-
-  EXPECT_FALSE(text.fail()) << " from failing to parse timestamp \"" << time_str
-                            << "\" with format string \"" << format << "\"";
-  return timestamp;
+// static
+std::string TestUtility::convertTime(const std::string& input, const std::string& input_format,
+                                     const std::string& output_format) {
+  const absl::Time t = TestUtility::parseTime(input, input_format);
+  return absl::FormatTime(output_format, t, absl::UTCTimeZone());
 }
 
 void ConditionalInitializer::setReady() {

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -235,9 +235,14 @@ absl::Time TestUtility::parseTime(const std::string& input, const std::string& i
 }
 
 // static
-std::string TestUtility::formatTime(const absl::Time& input, const std::string& output_format) {
+std::string TestUtility::formatTime(const absl::Time input, const std::string& output_format) {
   static const absl::TimeZone utc = absl::UTCTimeZone();
   return absl::FormatTime(output_format, input, utc);
+}
+
+// static
+std::string TestUtility::formatTime(const SystemTime input, const std::string& output_format) {
+  return TestUtility::formatTime(absl::FromChrono(input), output_format);
 }
 
 // static

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -225,20 +225,25 @@ void TestUtility::createSymlink(const std::string& target, const std::string& li
 }
 
 // static
-absl::Time TestUtility::parseTime(const std::string& input, const std::string& format) {
-  absl::Time t;
+absl::Time TestUtility::parseTime(const std::string& input, const std::string& input_format) {
+  absl::Time time;
   std::string error;
-  EXPECT_TRUE(absl::ParseTime(format, input, &t, &error))
+  EXPECT_TRUE(absl::ParseTime(input_format, input, &time, &error))
       << " error \"" << error << "\" from failing to parse timestamp \"" << input
-      << "\" with format string \"" << format << "\"";
-  return t;
+      << "\" with format string \"" << input_format << "\"";
+  return time;
+}
+
+// static
+std::string TestUtility::formatTime(const absl::Time& input, const std::string& output_format) {
+  static const absl::TimeZone utc = absl::UTCTimeZone();
+  return absl::FormatTime(output_format, input, utc);
 }
 
 // static
 std::string TestUtility::convertTime(const std::string& input, const std::string& input_format,
                                      const std::string& output_format) {
-  const absl::Time t = TestUtility::parseTime(input, input_format);
-  return absl::FormatTime(output_format, t, absl::UTCTimeZone());
+  return TestUtility::formatTime(TestUtility::parseTime(input, input_format), output_format);
 }
 
 void ConditionalInitializer::setReady() {

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -25,6 +25,7 @@
 
 #include "test/test_common/printers.h"
 
+#include "absl/time/time.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -304,7 +305,9 @@ public:
     return result;
   }
 
-  static std::tm parseTimestamp(const std::string& format, const std::string& time_str);
+  static absl::Time parseTime(const std::string& input, const std::string& format);
+  static std::string convertTime(const std::string& input, const std::string& input_format,
+                                 const std::string& output_format);
 
   static constexpr std::chrono::milliseconds DefaultTimeout = std::chrono::milliseconds(10000);
 

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -306,7 +306,8 @@ public:
   }
 
   static absl::Time parseTime(const std::string& input, const std::string& input_format);
-  static std::string formatTime(const absl::Time& input, const std::string& output_format);
+  static std::string formatTime(const absl::Time input, const std::string& output_format);
+  static std::string formatTime(const SystemTime input, const std::string& output_format);
   static std::string convertTime(const std::string& input, const std::string& input_format,
                                  const std::string& output_format);
 

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -305,7 +305,8 @@ public:
     return result;
   }
 
-  static absl::Time parseTime(const std::string& input, const std::string& format);
+  static absl::Time parseTime(const std::string& input, const std::string& input_format);
+  static std::string formatTime(const absl::Time& input, const std::string& output_format);
   static std::string convertTime(const std::string& input, const std::string& input_format,
                                  const std::string& output_format);
 

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -341,7 +341,7 @@ def checkSourceLine(line, file_path, reportError):
   if not whitelistedForGetTime(file_path):
     if "std::get_time" in line:
       if "test/" in file_path:
-        reportError("Don't use std::get_time; use TestUtility::parseTimestamp in tests")
+        reportError("Don't use std::get_time; use TestUtility::parseTime in tests")
       else:
         reportError("Don't use std::get_time; use the injectable time system")
   if 'std::atomic_' in line:


### PR DESCRIPTION
Hopefully, this will prevent future portability issues, and jumping
between strptime() and std::get_time() (see: #5336 and #5413).

Signed-off-by: Piotr Sikora <piotrsikora@google.com>